### PR TITLE
refactor: split CLI and server into separate binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dat9 cp :/data/a.bin :/shared/a.bin
 dat9 mv :/data/old.bin :/data/new.bin
 
 # Start the server
-dat9 serve
+dat9-server
 ```
 
 ### Go SDK
@@ -132,7 +132,8 @@ POST   /v1/fs/{path}?mkdir        Create directory
 ## Project Structure
 
 ```
-cmd/dat9/           CLI entrypoint and subcommands
+cmd/dat9/           CLI entrypoint and commands
+cmd/dat9-server/    Server entrypoint
 pkg/
   backend/          Dat9Backend — AGFS FileSystem implementation (inode model)
   client/           Go SDK HTTP client
@@ -176,6 +177,7 @@ Four tables, all in the tenant's database:
 
 ```bash
 go build -o dat9 ./cmd/dat9
+go build -o dat9-server ./cmd/dat9-server
 ```
 
 ## Running Tests

--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -1,4 +1,9 @@
-package cli
+// Command dat9-server starts the dat9 HTTP server.
+//
+// Usage:
+//
+//	dat9-server [listen-addr]
+package main
 
 import (
 	"fmt"
@@ -16,40 +21,38 @@ const (
 	defaultBlobDir    = "blobs"
 )
 
-// Serve starts the dat9 HTTP server backed by the local SQLite/blob stand-in
-// used in P0.
-func Serve(args []string) error {
-	if len(args) > 1 {
-		return fmt.Errorf("usage: dat9 serve [listen-addr]")
+func main() {
+	if len(os.Args) > 2 {
+		usage()
 	}
 
 	addr := envOr("DAT9_LISTEN_ADDR", defaultListenAddr)
-	if len(args) == 1 {
-		addr = args[0]
+	if len(os.Args) == 2 {
+		addr = os.Args[1]
 	}
 
 	dbPath := envOr("DAT9_DB_PATH", defaultDBPath)
 	blobDir := envOr("DAT9_BLOB_DIR", defaultBlobDir)
 
 	if err := ensureParentDir(dbPath); err != nil {
-		return err
+		die(err)
 	}
 	if err := os.MkdirAll(blobDir, 0o755); err != nil {
-		return fmt.Errorf("create blob dir: %w", err)
+		die(fmt.Errorf("create blob dir: %w", err))
 	}
 
 	store, err := meta.Open(dbPath)
 	if err != nil {
-		return fmt.Errorf("open meta store: %w", err)
+		die(fmt.Errorf("open meta store: %w", err))
 	}
 	defer store.Close()
 
 	b, err := backend.New(store, blobDir)
 	if err != nil {
-		return fmt.Errorf("create backend: %w", err)
+		die(fmt.Errorf("create backend: %w", err))
 	}
 
-	return server.New(b).ListenAndServe(addr)
+	die(server.New(b).ListenAndServe(addr))
 }
 
 func envOr(key, fallback string) string {
@@ -68,4 +71,23 @@ func ensureParentDir(path string) error {
 		return fmt.Errorf("create db dir: %w", err)
 	}
 	return nil
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `usage: dat9-server [listen-addr]
+
+environment:
+  DAT9_LISTEN_ADDR serve listen address (default: :9009)
+  DAT9_DB_PATH     sqlite path (default: ./dat9.db)
+  DAT9_BLOB_DIR    blob directory (default: ./blobs)
+`)
+	os.Exit(2)
+}
+
+func die(err error) {
+	if err == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "dat9-server: %v\n", err)
+	os.Exit(1)
 }

--- a/cmd/dat9/main.go
+++ b/cmd/dat9/main.go
@@ -13,7 +13,6 @@
 //	mv    rename/move a file or directory
 //	rm    remove a file or directory
 //	sh    interactive shell
-//	serve start the dat9 HTTP server
 package main
 
 import (
@@ -49,8 +48,6 @@ func main() {
 		err = cli.Rm(c, args)
 	case "sh":
 		err = cli.Sh(c, args)
-	case "serve":
-		err = cli.Serve(args)
 	case "-h", "-help", "help":
 		usage()
 	default:
@@ -75,14 +72,10 @@ commands:
   mv <old> <new>   rename/move
   rm <path>        remove
   sh               interactive shell
-  serve            start server
 
 environment:
   DAT9_SERVER      server URL (default: http://localhost:9009)
   DAT9_API_KEY     API key
-  DAT9_LISTEN_ADDR serve listen address (default: :9009)
-  DAT9_DB_PATH     serve sqlite path (default: ./dat9.db)
-  DAT9_BLOB_DIR    serve blob directory (default: ./blobs)
 `)
 	os.Exit(2)
 }


### PR DESCRIPTION
## Summary
- Split server startup out of `dat9` into a dedicated `dat9-server` binary under `cmd/dat9-server`.
- Keep `dat9` focused on filesystem CLI commands by removing the `serve` command path and server-only env vars from CLI usage.
- Update README examples, project structure, and build instructions to reflect the two-bin layout.

## Validation
- `go test ./...`