### PR TITLE
build: add Makefile workflow and resolve lint errors

### DIFF
--- a/.github/workflows/code-ci.yml
+++ b/.github/workflows/code-ci.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout agfs dependency
+        run: |
+          git clone --depth 1 https://github.com/c4pt0r/agfs ../agfs
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/code-ci.yml
+++ b/.github/workflows/code-ci.yml
@@ -1,0 +1,29 @@
+name: code-ci
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Lint
+        run: make lint
+
+      - name: Test
+        run: make test

--- a/.github/workflows/code-ci.yml
+++ b/.github/workflows/code-ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Test
         run: make test
+
+      - name: Build (server and cli)
+        run: make build

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -39,12 +39,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Lint
-        run: make lint
-
-      - name: Test
-        run: make test
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -12,6 +12,12 @@ on:
       - 'Makefile'
       - '.github/workflows/dev-cd.yml'
   workflow_dispatch:
+    inputs:
+      deploy_ref:
+        description: "Branch, tag, or SHA to deploy"
+        required: true
+        default: "main"
+        type: string
 
 env:
   AWS_REGION: ap-southeast-1
@@ -32,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.deploy_ref || github.ref }}
 
       - name: Checkout agfs dependency
         run: |
@@ -54,7 +62,7 @@ jobs:
 
       - name: Build and push image
         run: |
-          REF_NAME=${{ github.ref_name }}
+          REF_NAME=${{ github.event.inputs.deploy_ref || github.ref_name }}
           REF_NAME=${REF_NAME/\//-}
           TAG="${REF_NAME}-${GITHUB_SHA::7}"
           make docker-build IMAGE_REPO=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }} IMAGE_TAG=$TAG

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout agfs dependency
+        run: |
+          git clone --depth 1 https://github.com/c4pt0r/agfs ../agfs
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -14,10 +14,23 @@ on:
   workflow_dispatch:
     inputs:
       deploy_ref:
-        description: "Branch, tag, or SHA to deploy"
+        description: "Select ref to deploy"
         required: true
         default: "main"
-        type: string
+        type: choice
+        options:
+          - main
+          - feat/makefile-lint-ci-targets
+          - dat9-dev2/t19-integration
+          - dat9-dev3/p1-transfer-engine
+          - feat/p1-large-file-upload
+          - feat/p1-large-file-upload-final
+          - feat/split-cli-server-bin
+          - feat/tidb-mysql-migration
+          - docs/add-readme
+          - new_overview_design
+          - new_overview_design_main
+          - proposal/dat9-agent-native-data-infra
 
 env:
   AWS_REGION: ap-southeast-1

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -12,25 +12,6 @@ on:
       - 'Makefile'
       - '.github/workflows/dev-cd.yml'
   workflow_dispatch:
-    inputs:
-      deploy_ref:
-        description: "Select ref to deploy"
-        required: true
-        default: "main"
-        type: choice
-        options:
-          - main
-          - feat/makefile-lint-ci-targets
-          - dat9-dev2/t19-integration
-          - dat9-dev3/p1-transfer-engine
-          - feat/p1-large-file-upload
-          - feat/p1-large-file-upload-final
-          - feat/split-cli-server-bin
-          - feat/tidb-mysql-migration
-          - docs/add-readme
-          - new_overview_design
-          - new_overview_design_main
-          - proposal/dat9-agent-native-data-infra
 
 env:
   AWS_REGION: ap-southeast-1
@@ -51,8 +32,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.deploy_ref || github.ref }}
 
       - name: Checkout agfs dependency
         run: |
@@ -75,7 +54,7 @@ jobs:
 
       - name: Build and push image
         run: |
-          REF_NAME=${{ github.event.inputs.deploy_ref || github.ref_name }}
+          REF_NAME=${{ github.ref_name }}
           REF_NAME=${REF_NAME/\//-}
           TAG="${REF_NAME}-${GITHUB_SHA::7}"
           make docker-build IMAGE_REPO=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }} IMAGE_TAG=$TAG

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -14,8 +14,9 @@ on:
   workflow_dispatch:
 
 env:
-  AWS_REGION: ap-southeast-1
-  ECR_REGISTRY: 401696231252.dkr.ecr.ap-southeast-1.amazonaws.com
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+  AWS_ASSUME_ARN: ${{ secrets.AWS_ASSUME_ARN }}
   ECR_REPOSITORY: dat9-server
   EKS_CLUSTER: dev-dat9
   DEPLOY_NAMESPACE: dat9
@@ -46,7 +47,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::401696231252:role/dev-dat9-eks-ap-southeast-1-github-deploy
+          role-to-assume: ${{ env.AWS_ASSUME_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Log in to ECR

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -1,0 +1,85 @@
+name: Deploy server to dev
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/**'
+      - 'pkg/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - 'Makefile'
+      - '.github/workflows/dev-cd.yml'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ap-southeast-1
+  ECR_REGISTRY: 401696231252.dkr.ecr.ap-southeast-1.amazonaws.com
+  ECR_REPOSITORY: dat9-server
+  EKS_CLUSTER: dev-dat9
+  DEPLOY_NAMESPACE: dat9
+  K8S_DEPLOYMENT: dat9-server
+
+jobs:
+  deploy:
+    name: Build and deploy to dev
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Lint
+        run: make lint
+
+      - name: Test
+        run: make test
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::401696231252:role/dev-dat9-eks-ap-southeast-1-github-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Log in to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push image
+        run: |
+          REF_NAME=${{ github.ref_name }}
+          REF_NAME=${REF_NAME/\//-}
+          TAG="${REF_NAME}-${GITHUB_SHA::7}"
+          make docker-build IMAGE_REPO=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }} IMAGE_TAG=$TAG
+          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:$TAG
+          echo "IMAGE_TAG=$TAG" >> "$GITHUB_ENV"
+
+      - name: Update kubeconfig
+        run: |
+          aws eks update-kubeconfig \
+            --name ${{ env.EKS_CLUSTER }} \
+            --region ${{ env.AWS_REGION }}
+
+      - name: Deploy
+        run: |
+          kubectl set image deployment/${{ env.K8S_DEPLOYMENT }} \
+            ${{ env.K8S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }} \
+            -n ${{ env.DEPLOY_NAMESPACE }}
+          kubectl rollout status deployment/${{ env.K8S_DEPLOYMENT }} \
+            -n ${{ env.DEPLOY_NAMESPACE }} \
+            --timeout=180s
+
+      - name: Rollback on failed deploy
+        if: failure()
+        run: |
+          kubectl rollout undo deployment/${{ env.K8S_DEPLOYMENT }} \
+            -n ${{ env.DEPLOY_NAMESPACE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.19
+RUN apk add --no-cache ca-certificates
+
+COPY ./bin/dat9-server /dat9-server
+
+EXPOSE 9009
+
+ENTRYPOINT ["/dat9-server"]

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,9 @@ SHELL := /bin/bash
 
 GO ?= go
 DOCKER ?= docker
-AWS ?= aws
 
 APP_NAME ?= dat9-server
 CLI_NAME ?= dat9
-MAKEFILE_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 BIN_DIR ?= bin
 SERVER_BIN ?= $(BIN_DIR)/$(APP_NAME)
@@ -16,15 +14,12 @@ LOCAL_BIN ?= $(CURDIR)/bin
 GOLANGCI_LINT_VERSION ?= v2.5.0
 GOLANGCI_LINT_BIN ?= $(LOCAL_BIN)/golangci-lint
 
-IMAGE_REPO ?= 401696231252.dkr.ecr.ap-southeast-1.amazonaws.com/dat9-server
+IMAGE_REPO ?= dat9-server
 IMAGE_TAG ?= latest
 IMAGE ?= $(IMAGE_REPO):$(IMAGE_TAG)
-ECR_REGISTRY ?= 401696231252.dkr.ecr.ap-southeast-1.amazonaws.com
-
-AWS_REGION ?= ap-southeast-1
 LINT_TIMEOUT ?= 10m
 
-.PHONY: mod test fmt lint lint-fix install-lint build build-server build-cli docker-build docker-push
+.PHONY: mod test fmt lint install-lint build build-server build-cli docker-build
 
 mod:
 	$(GO) mod tidy
@@ -40,10 +35,6 @@ fmt:
 lint:
 	$(MAKE) install-lint
 	$(GOLANGCI_LINT_BIN) run --timeout $(LINT_TIMEOUT)
-
-lint-fix:
-	$(MAKE) install-lint
-	$(GOLANGCI_LINT_BIN) run --fix
 
 install-lint:
 	@echo "Checking for golangci-lint..."
@@ -67,7 +58,3 @@ build-cli:
 
 docker-build: build-server
 	DOCKER_BUILDKIT=0 $(DOCKER) build -t $(IMAGE) .
-
-docker-push:
-	$(AWS) ecr get-login-password --region $(AWS_REGION) | $(DOCKER) login --username AWS --password-stdin $(ECR_REGISTRY)
-	$(DOCKER) push $(IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,73 @@
+SHELL := /bin/bash
+
+GO ?= go
+DOCKER ?= docker
+AWS ?= aws
+
+APP_NAME ?= dat9-server
+CLI_NAME ?= dat9
+MAKEFILE_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+BIN_DIR ?= bin
+SERVER_BIN ?= $(BIN_DIR)/$(APP_NAME)
+CLI_BIN ?= $(BIN_DIR)/$(CLI_NAME)
+LOCAL_BIN ?= $(CURDIR)/bin
+
+GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_BIN ?= $(LOCAL_BIN)/golangci-lint
+
+IMAGE_REPO ?= 401696231252.dkr.ecr.ap-southeast-1.amazonaws.com/dat9-server
+IMAGE_TAG ?= latest
+IMAGE ?= $(IMAGE_REPO):$(IMAGE_TAG)
+ECR_REGISTRY ?= 401696231252.dkr.ecr.ap-southeast-1.amazonaws.com
+
+AWS_REGION ?= ap-southeast-1
+LINT_TIMEOUT ?= 10m
+
+.PHONY: mod test fmt lint lint-fix install-lint build build-server build-cli docker-build docker-push
+
+mod:
+	$(GO) mod tidy
+	$(GO) mod download
+
+test:
+	$(GO) test ./...
+
+fmt:
+	$(MAKE) install-lint
+	$(GOLANGCI_LINT_BIN) run --fix
+
+lint:
+	$(MAKE) install-lint
+	$(GOLANGCI_LINT_BIN) run --timeout $(LINT_TIMEOUT)
+
+lint-fix:
+	$(MAKE) install-lint
+	$(GOLANGCI_LINT_BIN) run --fix
+
+install-lint:
+	@echo "Checking for golangci-lint..."
+	@if [ ! -x "$(GOLANGCI_LINT_BIN)" ]; then \
+		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) to $(LOCAL_BIN)..."; \
+		mkdir -p "$(LOCAL_BIN)"; \
+		GOBIN="$(LOCAL_BIN)" $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
+	else \
+		echo "golangci-lint already installed at $(GOLANGCI_LINT_BIN)"; \
+	fi
+
+build: build-server build-cli
+
+build-server:
+	mkdir -p $(BIN_DIR)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -o $(SERVER_BIN) ./cmd/dat9-server
+
+build-cli:
+	mkdir -p $(BIN_DIR)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -o $(CLI_BIN) ./cmd/dat9
+
+docker-build: build-server
+	DOCKER_BUILDKIT=0 $(DOCKER) build -t $(IMAGE) .
+
+docker-push:
+	$(AWS) ecr get-login-password --region $(AWS_REGION) | $(DOCKER) login --username AWS --password-stdin $(ECR_REGISTRY)
+	$(DOCKER) push $(IMAGE)

--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -43,7 +43,7 @@ func main() {
 	if err != nil {
 		die(fmt.Errorf("open meta store: %w", err))
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	b, err := backend.New(store, blobDir)
 	if err != nil {

--- a/cmd/dat9/cli/cat.go
+++ b/cmd/dat9/cli/cat.go
@@ -21,7 +21,7 @@ func Cat(c *client.Client, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	_, err = io.Copy(os.Stdout, rc)
 	return err
 }

--- a/cmd/dat9/cli/cp.go
+++ b/cmd/dat9/cli/cp.go
@@ -88,7 +88,7 @@ func uploadFile(ctx context.Context, c *client.Client, localPath, remotePath str
 	if err != nil {
 		return fmt.Errorf("open %s: %w", localPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
 	if err != nil {
@@ -103,7 +103,7 @@ func resumeUpload(ctx context.Context, c *client.Client, localPath, remotePath s
 	if err != nil {
 		return fmt.Errorf("open %s: %w", localPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
 	if err != nil {
@@ -118,13 +118,13 @@ func downloadFile(ctx context.Context, c *client.Client, remotePath, localPath s
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	out, err := os.Create(localPath)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", localPath, err)
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
 	_, err = io.Copy(out, rc)
 	return err
@@ -135,7 +135,7 @@ func streamToStdout(ctx context.Context, c *client.Client, remotePath string) er
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	_, err = io.Copy(os.Stdout, rc)
 	return err

--- a/cmd/dat9/cli/ls.go
+++ b/cmd/dat9/cli/ls.go
@@ -38,7 +38,7 @@ func Ls(c *client.Client, args []string) error {
 			if e.IsDir {
 				kind = "d"
 			}
-			fmt.Fprintf(w, "%s\t%d\t%s\n", kind, e.Size, e.Name)
+			_, _ = fmt.Fprintf(w, "%s\t%d\t%s\n", kind, e.Size, e.Name)
 		}
 		return w.Flush()
 	}

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -418,7 +418,7 @@ func (b *Dat9Backend) readBlob(ref string) ([]byte, error) {
 }
 
 func (b *Dat9Backend) deleteBlob(ref string) {
-	os.Remove(b.blobPath(ref))
+	_ = os.Remove(b.blobPath(ref))
 }
 
 // --- writeCloser ---

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -17,14 +17,14 @@ func newTestBackend(t *testing.T) *Dat9Backend {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.RemoveAll(blobDir) })
+	t.Cleanup(func() { _ = os.RemoveAll(blobDir) })
 
 	store, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
 	testmysql.ResetDB(t, store.DB())
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	b, err := New(store, blobDir)
 	if err != nil {
@@ -69,8 +69,12 @@ func TestWriteAndRead(t *testing.T) {
 
 func TestWriteOverwrite(t *testing.T) {
 	b := newTestBackend(t)
-	b.Write("/f.txt", []byte("old"), 0, filesystem.WriteFlagCreate)
-	b.Write("/f.txt", []byte("new"), 0, filesystem.WriteFlagTruncate)
+	if _, err := b.Write("/f.txt", []byte("old"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/f.txt", []byte("new"), 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatal(err)
+	}
 	data, _ := b.Read("/f.txt", 0, -1)
 	if string(data) != "new" {
 		t.Errorf("got %q", data)
@@ -79,8 +83,12 @@ func TestWriteOverwrite(t *testing.T) {
 
 func TestWriteAppend(t *testing.T) {
 	b := newTestBackend(t)
-	b.Write("/f.txt", []byte("hello"), 0, filesystem.WriteFlagCreate)
-	b.Write("/f.txt", []byte(" world"), 0, filesystem.WriteFlagAppend)
+	if _, err := b.Write("/f.txt", []byte("hello"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/f.txt", []byte(" world"), 0, filesystem.WriteFlagAppend); err != nil {
+		t.Fatal(err)
+	}
 	data, _ := b.Read("/f.txt", 0, -1)
 	if string(data) != "hello world" {
 		t.Errorf("got %q", data)
@@ -89,7 +97,9 @@ func TestWriteAppend(t *testing.T) {
 
 func TestReadWithOffset(t *testing.T) {
 	b := newTestBackend(t)
-	b.Write("/f.txt", []byte("hello world"), 0, filesystem.WriteFlagCreate)
+	if _, err := b.Write("/f.txt", []byte("hello world"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 	data, _ := b.Read("/f.txt", 6, 5)
 	if string(data) != "world" {
 		t.Errorf("got %q", data)
@@ -98,9 +108,15 @@ func TestReadWithOffset(t *testing.T) {
 
 func TestMkdirAndReadDir(t *testing.T) {
 	b := newTestBackend(t)
-	b.Mkdir("/data", 0o755)
-	b.Write("/data/a.txt", []byte("a"), 0, filesystem.WriteFlagCreate)
-	b.Write("/data/b.txt", []byte("bb"), 0, filesystem.WriteFlagCreate)
+	if err := b.Mkdir("/data", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/data/a.txt", []byte("a"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/data/b.txt", []byte("bb"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 
 	entries, err := b.ReadDir("/data/")
 	if err != nil {
@@ -116,7 +132,9 @@ func TestMkdirAndReadDir(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	b := newTestBackend(t)
-	b.Write("/f.txt", []byte("data"), 0, filesystem.WriteFlagCreate)
+	if _, err := b.Write("/f.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 	if err := b.Remove("/f.txt"); err != nil {
 		t.Fatal(err)
 	}
@@ -128,9 +146,15 @@ func TestRemove(t *testing.T) {
 
 func TestRemoveAll(t *testing.T) {
 	b := newTestBackend(t)
-	b.Mkdir("/data", 0o755)
-	b.Write("/data/a.txt", []byte("a"), 0, filesystem.WriteFlagCreate)
-	b.Write("/data/b.txt", []byte("b"), 0, filesystem.WriteFlagCreate)
+	if err := b.Mkdir("/data", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/data/a.txt", []byte("a"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/data/b.txt", []byte("b"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 	if err := b.RemoveAll("/data/"); err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +166,9 @@ func TestRemoveAll(t *testing.T) {
 
 func TestRename(t *testing.T) {
 	b := newTestBackend(t)
-	b.Write("/old.txt", []byte("data"), 0, filesystem.WriteFlagCreate)
+	if _, err := b.Write("/old.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 	if err := b.Rename("/old.txt", "/new.txt"); err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +183,9 @@ func TestRename(t *testing.T) {
 
 func TestZeroCopyCp(t *testing.T) {
 	b := newTestBackend(t)
-	b.Write("/a.txt", []byte("shared"), 0, filesystem.WriteFlagCreate)
+	if _, err := b.Write("/a.txt", []byte("shared"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 	if err := b.CopyFile("/a.txt", "/b.txt"); err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +195,9 @@ func TestZeroCopyCp(t *testing.T) {
 		t.Error("content mismatch")
 	}
 	// Delete one, other survives
-	b.Remove("/a.txt")
+	if err := b.Remove("/a.txt"); err != nil {
+		t.Fatal(err)
+	}
 	dataB, err := b.Read("/b.txt", 0, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -179,7 +209,9 @@ func TestZeroCopyCp(t *testing.T) {
 
 func TestAutoCreateParentDirs(t *testing.T) {
 	b := newTestBackend(t)
-	b.Write("/a/b/c/file.txt", []byte("deep"), 0, filesystem.WriteFlagCreate)
+	if _, err := b.Write("/a/b/c/file.txt", []byte("deep"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 	for _, p := range []string{"/a/", "/a/b/", "/a/b/c/"} {
 		info, err := b.Stat(p)
 		if err != nil {
@@ -195,7 +227,9 @@ func TestAutoCreateParentDirs(t *testing.T) {
 func TestEnsureParentDirsNoRootSelfInsert(t *testing.T) {
 	b := newTestBackend(t)
 	// Creating a file at root level should not insert "/" as a child of itself
-	b.Write("/top.txt", []byte("x"), 0, filesystem.WriteFlagCreate)
+	if _, err := b.Write("/top.txt", []byte("x"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 	entries, err := b.ReadDir("/")
 	if err != nil {
 		t.Fatal(err)
@@ -209,9 +243,13 @@ func TestEnsureParentDirsNoRootSelfInsert(t *testing.T) {
 
 func TestOffsetWritePreservesTail(t *testing.T) {
 	b := newTestBackend(t)
-	b.Write("/f.txt", []byte("ABCDEFGH"), 0, filesystem.WriteFlagCreate)
+	if _, err := b.Write("/f.txt", []byte("ABCDEFGH"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 	// Overwrite bytes 2-4 with "XY", should preserve tail "EFGH"
-	b.Write("/f.txt", []byte("XY"), 2, 0)
+	if _, err := b.Write("/f.txt", []byte("XY"), 2, 0); err != nil {
+		t.Fatal(err)
+	}
 	data, err := b.Read("/f.txt", 0, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -223,8 +261,12 @@ func TestOffsetWritePreservesTail(t *testing.T) {
 
 func TestRenameDirUpdatesName(t *testing.T) {
 	b := newTestBackend(t)
-	b.Mkdir("/alpha", 0o755)
-	b.Write("/alpha/file.txt", []byte("data"), 0, filesystem.WriteFlagCreate)
+	if err := b.Mkdir("/alpha", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/alpha/file.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 	if err := b.Rename("/alpha/", "/beta/"); err != nil {
 		t.Fatal(err)
 	}
@@ -239,8 +281,12 @@ func TestRenameDirUpdatesName(t *testing.T) {
 
 func TestRenameDirEnsuresParentDirs(t *testing.T) {
 	b := newTestBackend(t)
-	b.Mkdir("/src", 0o755)
-	b.Write("/src/file.txt", []byte("data"), 0, filesystem.WriteFlagCreate)
+	if err := b.Mkdir("/src", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/src/file.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 	// Rename to a deeply nested path whose parents don't exist
 	if err := b.Rename("/src/", "/x/y/dst/"); err != nil {
 		t.Fatal(err)
@@ -268,18 +314,35 @@ func TestRenameDirEnsuresParentDirs(t *testing.T) {
 
 func TestOpenAndOpenWrite(t *testing.T) {
 	b := newTestBackend(t)
-	b.Write("/f.txt", []byte("content"), 0, filesystem.WriteFlagCreate)
+	if _, err := b.Write("/f.txt", []byte("content"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
 
-	rc, _ := b.Open("/f.txt")
-	data, _ := io.ReadAll(rc)
-	rc.Close()
+	rc, err := b.Open("/f.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatal(err)
+	}
 	if string(data) != "content" {
 		t.Errorf("got %q", data)
 	}
 
-	wc, _ := b.OpenWrite("/f.txt")
-	wc.Write([]byte("new content"))
-	wc.Close()
+	wc, err := b.OpenWrite("/f.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wc.Write([]byte("new content")); err != nil {
+		t.Fatal(err)
+	}
+	if err := wc.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	readData, _ := b.Read("/f.txt", 0, -1)
 	if string(readData) != "new content" {

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -63,7 +63,7 @@ func (b *Dat9Backend) InitiateUpload(ctx context.Context, path string, totalSize
 	for i, p := range parts {
 		u, err := b.s3.PresignUploadPart(ctx, s3Key, mpu.UploadID, p.Number, s3client.UploadTTL)
 		if err != nil {
-			b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
+			_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 			return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
 		}
 		u.Size = p.Size
@@ -83,7 +83,7 @@ func (b *Dat9Backend) InitiateUpload(ctx context.Context, path string, totalSize
 		Status:      meta.StatusPending,
 		CreatedAt:   now,
 	}); err != nil {
-		b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
+		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 		return nil, err
 	}
 
@@ -102,7 +102,7 @@ func (b *Dat9Backend) InitiateUpload(ctx context.Context, path string, totalSize
 		UpdatedAt:  now,
 		ExpiresAt:  now.Add(24 * time.Hour),
 	}); err != nil {
-		b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
+		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 		return nil, err
 	}
 
@@ -168,8 +168,9 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 			isOverwrite = true
 
 			var oldRef string
-			tx.QueryRow(`SELECT storage_ref FROM files WHERE file_id = ?`, existingFileID.String).Scan(&oldRef)
-			oldStorageRef = oldRef
+			if err := tx.QueryRow(`SELECT storage_ref FROM files WHERE file_id = ?`, existingFileID.String).Scan(&oldRef); err == nil {
+				oldStorageRef = oldRef
+			}
 
 			_, err := tx.Exec(`UPDATE files SET storage_type = ?, storage_ref = ?,
 				size_bytes = ?, content_text = NULL, revision = revision + 1,
@@ -229,7 +230,7 @@ func (b *Dat9Backend) ResumeUpload(ctx context.Context, uploadID string) (*Uploa
 		if err := b.s3.AbortMultipartUpload(ctx, upload.S3Key, upload.S3UploadID); err != nil {
 			log.Printf("WARNING: failed to abort expired multipart upload %s: %v", uploadID, err)
 		}
-		b.store.AbortUpload(uploadID)
+		_ = b.store.AbortUpload(uploadID)
 		return nil, meta.ErrUploadExpired
 	}
 
@@ -279,7 +280,7 @@ func (b *Dat9Backend) AbortUpload(ctx context.Context, uploadID string) error {
 		return meta.ErrUploadNotActive
 	}
 
-	b.s3.AbortMultipartUpload(ctx, upload.S3Key, upload.S3UploadID)
+	_ = b.s3.AbortMultipartUpload(ctx, upload.S3Key, upload.S3UploadID)
 	return b.store.AbortUpload(uploadID)
 }
 

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -7,36 +7,31 @@ import (
 	"testing"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 )
 
 func newTestBackendWithS3(t *testing.T) *Dat9Backend {
 	t.Helper()
-	dbFile, err := os.CreateTemp("", "dat9-*.db")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dbFile.Close()
-	t.Cleanup(func() { os.Remove(dbFile.Name()) })
-
 	blobDir, err := os.MkdirTemp("", "dat9-blobs-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.RemoveAll(blobDir) })
+	t.Cleanup(func() { _ = os.RemoveAll(blobDir) })
 
 	s3Dir, err := os.MkdirTemp("", "dat9-s3-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.RemoveAll(s3Dir) })
+	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
 
-	store, err := meta.Open(dbFile.Name())
+	store, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { store.Close() })
+	testmysql.ResetDB(t, store.DB())
+	t.Cleanup(func() { _ = store.Close() })
 
 	s3c, err := s3client.NewLocal(s3Dir, "http://localhost:9091/s3")
 	if err != nil {
@@ -177,7 +172,9 @@ func TestResumeUpload(t *testing.T) {
 
 	// Upload only part 1 (simulate partial upload)
 	data := make([]byte, s3client.PartSize)
-	b.S3().(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, 1, bytes.NewReader(data))
+	if _, err := b.S3().(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, 1, bytes.NewReader(data)); err != nil {
+		t.Fatal(err)
+	}
 
 	// Resume should return parts 2 and 3
 	resumed, err := b.ResumeUpload(ctx, plan.UploadID)
@@ -216,8 +213,12 @@ func TestListUploads(t *testing.T) {
 	ctx := context.Background()
 
 	// One upload per path — use different paths
-	b.InitiateUpload(ctx, "/list-a.bin", 2<<20)
-	b.InitiateUpload(ctx, "/list-b.bin", 3<<20)
+	if _, err := b.InitiateUpload(ctx, "/list-a.bin", 2<<20); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.InitiateUpload(ctx, "/list-b.bin", 3<<20); err != nil {
+		t.Fatal(err)
+	}
 
 	uploadsA, err := b.ListUploads("/list-a.bin", meta.UploadUploading)
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -67,7 +67,7 @@ func (c *Client) Write(path string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return readError(resp)
 	}
@@ -84,7 +84,7 @@ func (c *Client) Read(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return nil, readError(resp)
 	}
@@ -101,7 +101,7 @@ func (c *Client) List(path string) ([]FileInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return nil, readError(resp)
 	}
@@ -124,7 +124,7 @@ func (c *Client) Stat(path string) (*StatResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode == 404 {
 		return nil, fmt.Errorf("not found: %s", path)
 	}
@@ -153,7 +153,7 @@ func (c *Client) Delete(path string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return readError(resp)
 	}
@@ -171,7 +171,7 @@ func (c *Client) Copy(srcPath, dstPath string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return readError(resp)
 	}
@@ -189,7 +189,7 @@ func (c *Client) Rename(oldPath, newPath string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return readError(resp)
 	}
@@ -206,7 +206,7 @@ func (c *Client) Mkdir(path string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return readError(resp)
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -35,8 +35,8 @@ func newTestClient(t *testing.T) (*Client, func()) {
 
 	cleanup := func() {
 		ts.Close()
-		store.Close()
-		os.RemoveAll(blobDir)
+		_ = store.Close()
+		_ = os.RemoveAll(blobDir)
 	}
 
 	return New(ts.URL, ""), cleanup
@@ -61,8 +61,12 @@ func TestListDir(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	c.Write("/data/a.txt", []byte("a"))
-	c.Write("/data/b.txt", []byte("bb"))
+	if err := c.Write("/data/a.txt", []byte("a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Write("/data/b.txt", []byte("bb")); err != nil {
+		t.Fatal(err)
+	}
 
 	entries, err := c.List("/data/")
 	if err != nil {
@@ -77,7 +81,9 @@ func TestStat(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	c.Write("/test.txt", []byte("data"))
+	if err := c.Write("/test.txt", []byte("data")); err != nil {
+		t.Fatal(err)
+	}
 	info, err := c.Stat("/test.txt")
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +97,9 @@ func TestDelete(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	c.Write("/del.txt", []byte("x"))
+	if err := c.Write("/del.txt", []byte("x")); err != nil {
+		t.Fatal(err)
+	}
 	if err := c.Delete("/del.txt"); err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +113,9 @@ func TestCopy(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	c.Write("/src.txt", []byte("shared"))
+	if err := c.Write("/src.txt", []byte("shared")); err != nil {
+		t.Fatal(err)
+	}
 	if err := c.Copy("/src.txt", "/dst.txt"); err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +129,9 @@ func TestRename(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	c.Write("/old.txt", []byte("data"))
+	if err := c.Write("/old.txt", []byte("data")); err != nil {
+		t.Fatal(err)
+	}
 	if err := c.Rename("/old.txt", "/new.txt"); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -62,7 +62,7 @@ func (c *Client) WriteStream(ctx context.Context, path string, r io.Reader, size
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusAccepted {
 		return readError(resp)
@@ -154,7 +154,7 @@ func (c *Client) uploadOnePart(ctx context.Context, url string, data []byte) (st
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
@@ -177,7 +177,7 @@ func (c *Client) completeUpload(ctx context.Context, uploadID string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {
 		return readError(resp)
@@ -209,7 +209,7 @@ func (c *Client) ReadStream(ctx context.Context, path string) (io.ReadCloser, er
 	switch {
 	case resp.StatusCode == http.StatusFound || resp.StatusCode == http.StatusTemporaryRedirect:
 		// Large file: follow presigned URL
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		location := resp.Header.Get("Location")
 		if location == "" {
 			return nil, fmt.Errorf("302 without Location header")
@@ -223,13 +223,13 @@ func (c *Client) ReadStream(ctx context.Context, path string) (io.ReadCloser, er
 			return nil, err
 		}
 		if resp2.StatusCode >= 300 {
-			defer resp2.Body.Close()
+			defer func() { _ = resp2.Body.Close() }()
 			return nil, readError(resp2)
 		}
 		return resp2.Body, nil
 
 	case resp.StatusCode >= 300:
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		return nil, readError(resp)
 
 	default:
@@ -286,7 +286,7 @@ func (c *Client) queryUpload(ctx context.Context, path string) (*UploadMeta, err
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {
 		return nil, readError(resp)
@@ -315,7 +315,7 @@ func (c *Client) requestResume(ctx context.Context, uploadID string) (*UploadPla
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusGone {
 		return nil, fmt.Errorf("upload %s has expired", uploadID)

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/s3client"
@@ -72,7 +73,7 @@ func TestWriteStreamLargeFile(t *testing.T) {
 			plan.Parts[0].URL = fmt.Sprintf("http://%s/parts/1", r.Host)
 			plan.Parts[1].URL = fmt.Sprintf("http://%s/parts/2", r.Host)
 			w.WriteHeader(http.StatusAccepted)
-			json.NewEncoder(w).Encode(plan)
+			_ = json.NewEncoder(w).Encode(plan)
 
 		case r.Method == http.MethodPut && r.URL.Path == "/parts/1":
 			data, _ := io.ReadAll(r.Body)
@@ -130,7 +131,7 @@ func TestWriteStreamLargeFile(t *testing.T) {
 // TestReadStreamSmallFile verifies direct read for small files.
 func TestReadStreamSmallFile(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("small content"))
+		_, _ = w.Write([]byte("small content"))
 	}))
 	defer srv.Close()
 
@@ -139,7 +140,7 @@ func TestReadStreamSmallFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadStream: %v", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	data, _ := io.ReadAll(rc)
 	if string(data) != "small content" {
@@ -156,7 +157,7 @@ func TestReadStreamLargeFile(t *testing.T) {
 			w.Header().Set("Location", fmt.Sprintf("http://%s/s3/presigned", r.Host))
 			w.WriteHeader(http.StatusFound)
 		case "/s3/presigned":
-			w.Write([]byte("large content from S3"))
+			_, _ = w.Write([]byte("large content from S3"))
 		}
 	}))
 	defer srv.Close()
@@ -166,7 +167,7 @@ func TestReadStreamLargeFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadStream: %v", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	data, _ := io.ReadAll(rc)
 	if string(data) != "large content from S3" {
@@ -184,7 +185,7 @@ func TestResumeUpload(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/uploads":
-			json.NewEncoder(w).Encode(struct {
+			_ = json.NewEncoder(w).Encode(struct {
 				Uploads []UploadMeta `json:"uploads"`
 			}{
 				Uploads: []UploadMeta{{
@@ -203,7 +204,7 @@ func TestResumeUpload(t *testing.T) {
 					{Number: 2, URL: fmt.Sprintf("http://%s/parts/2", r.Host), Size: 4},
 				},
 			}
-			json.NewEncoder(w).Encode(plan)
+			_ = json.NewEncoder(w).Encode(plan)
 
 		case r.Method == http.MethodPut && r.URL.Path == "/parts/2":
 			data, _ := io.ReadAll(r.Body)
@@ -251,30 +252,24 @@ func TestResumeUpload(t *testing.T) {
 }
 
 func TestResumeUploadIntegrationProgressTotal(t *testing.T) {
-	dbFile, err := os.CreateTemp("", "dat9-client-*.db")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dbFile.Close()
-	defer os.Remove(dbFile.Name())
-
 	blobDir, err := os.MkdirTemp("", "dat9-client-blobs-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(blobDir)
+	defer func() { _ = os.RemoveAll(blobDir) }()
 
 	s3Dir, err := os.MkdirTemp("", "dat9-client-s3-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(s3Dir)
+	defer func() { _ = os.RemoveAll(s3Dir) }()
 
-	store, err := meta.Open(dbFile.Name())
+	store, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	testmysql.ResetDB(t, store.DB())
+	defer func() { _ = store.Close() }()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -284,18 +279,18 @@ func TestResumeUploadIntegrationProgressTotal(t *testing.T) {
 	baseURL := "http://" + ln.Addr().String()
 	s3c, err := s3client.NewLocal(s3Dir, baseURL+"/s3")
 	if err != nil {
-		ln.Close()
+		_ = ln.Close()
 		t.Fatal(err)
 	}
 
 	b, err := backend.NewWithS3(store, blobDir, s3c)
 	if err != nil {
-		ln.Close()
+		_ = ln.Close()
 		t.Fatal(err)
 	}
 
 	ts := httptest.NewUnstartedServer(srvpkg.New(b))
-	ts.Listener.Close()
+	_ = ts.Listener.Close()
 	ts.Listener = ln
 	ts.Start()
 	defer ts.Close()
@@ -314,7 +309,7 @@ func TestResumeUploadIntegrationProgressTotal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusAccepted {
 		t.Fatalf("initiate upload: expected 202, got %d", resp.StatusCode)
 	}
@@ -336,7 +331,7 @@ func TestResumeUploadIntegrationProgressTotal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("upload part 1: expected 200, got %d", resp.StatusCode)
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -132,7 +132,7 @@ func (s *Store) InTx(fn func(tx *sql.Tx) error) error {
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	if err := fn(tx); err != nil {
 		return err
 	}
@@ -744,7 +744,7 @@ func (s *Store) ListUploadsByPath(targetPath string, status UploadStatus) ([]*Up
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var uploads []*Upload
 	for rows.Next() {
 		u, err := scanUpload(rows)

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -105,12 +105,12 @@ func Open(dsn string) (*Store, error) {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
 	if err := db.Ping(); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("ping db: %w", err)
 	}
 	s := &Store{db: db}
 	if err := s.migrate(); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 	return s, nil
@@ -214,7 +214,7 @@ func (s *Store) ListNodes(parentPath string) ([]*FileNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var nodes []*FileNode
 	for rows.Next() {
 		n, err := scanNode(rows)
@@ -244,7 +244,7 @@ func (s *Store) DeleteEmptyDir(path string) error {
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	var count int64
 	if err := tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE parent_path = ?`, path).Scan(&count); err != nil {
@@ -291,7 +291,7 @@ func (s *Store) RenameDir(oldPrefix, newPrefix string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	rows, err := tx.Query(`SELECT node_id, path, parent_path, name FROM file_nodes
 		WHERE path = ? OR path LIKE ? ORDER BY path`, oldPrefix, oldPrefix+"%")
@@ -305,7 +305,7 @@ func (s *Store) RenameDir(oldPrefix, newPrefix string) (int64, error) {
 	for rows.Next() {
 		var nodeID, p, pp, name string
 		if err := rows.Scan(&nodeID, &p, &pp, &name); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return 0, err
 		}
 		newPath := newPrefix + strings.TrimPrefix(p, oldPrefix)
@@ -318,13 +318,13 @@ func (s *Store) RenameDir(oldPrefix, newPrefix string) (int64, error) {
 		}
 		updates = append(updates, update{nodeID, newPath, newParent, newName})
 	}
-	rows.Close()
+	_ = rows.Close()
 
 	stmt, err := tx.Prepare(`UPDATE file_nodes SET path = ?, parent_path = ?, name = ? WHERE node_id = ?`)
 	if err != nil {
 		return 0, err
 	}
-	defer stmt.Close()
+	defer func() { _ = stmt.Close() }()
 
 	for _, u := range updates {
 		if _, err := stmt.Exec(u.newPath, u.newParent, u.newName, u.nodeID); err != nil {
@@ -455,7 +455,7 @@ func (s *Store) ListDir(parentPath string) ([]*NodeWithFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var result []*NodeWithFile
 	for rows.Next() {
@@ -473,7 +473,7 @@ func (s *Store) DeleteFileWithRefCheck(path string) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	var fileID sql.NullString
 	var isDir bool
@@ -530,7 +530,7 @@ func (s *Store) DeleteDirRecursive(dirPath string) ([]*File, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	rows, err := tx.Query(`SELECT DISTINCT file_id FROM file_nodes
 		WHERE (path = ? OR path LIKE ?) AND file_id IS NOT NULL`, dirPath, dirPath+"%")
@@ -541,12 +541,12 @@ func (s *Store) DeleteDirRecursive(dirPath string) ([]*File, error) {
 	for rows.Next() {
 		var fid string
 		if err := rows.Scan(&fid); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return nil, err
 		}
 		fileIDs = append(fileIDs, fid)
 	}
-	rows.Close()
+	_ = rows.Close()
 
 	if _, err := tx.Exec(`DELETE FROM file_nodes WHERE path = ? OR path LIKE ?`,
 		dirPath, dirPath+"%"); err != nil {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -15,7 +15,7 @@ func newTestStore(t *testing.T) *Store {
 		t.Fatal(err)
 	}
 	testmysql.ResetDB(t, s.DB())
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() { _ = s.Close() })
 	return s
 }
 
@@ -77,9 +77,13 @@ func TestInsertAndGetFile(t *testing.T) {
 func TestStat(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
-		SizeBytes: 42, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now})
-	s.InsertNode(&FileNode{NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt", FileID: "f1", CreatedAt: now})
+	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		SizeBytes: 42, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
 
 	nf, err := s.Stat("/a.txt")
 	if err != nil {
@@ -93,11 +97,19 @@ func TestStat(t *testing.T) {
 func TestListDir(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	s.InsertNode(&FileNode{NodeID: "d1", Path: "/data/", ParentPath: "/", Name: "data", IsDirectory: true, CreatedAt: now})
-	s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
-		SizeBytes: 10, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now})
-	s.InsertNode(&FileNode{NodeID: "n1", Path: "/data/a.txt", ParentPath: "/data/", Name: "a.txt", FileID: "f1", CreatedAt: now})
-	s.InsertNode(&FileNode{NodeID: "d2", Path: "/data/sub/", ParentPath: "/data/", Name: "sub", IsDirectory: true, CreatedAt: now})
+	if err := s.InsertNode(&FileNode{NodeID: "d1", Path: "/data/", ParentPath: "/", Name: "data", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		SizeBytes: 10, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/data/a.txt", ParentPath: "/data/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "d2", Path: "/data/sub/", ParentPath: "/data/", Name: "sub", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
 
 	entries, err := s.ListDir("/data/")
 	if err != nil {
@@ -114,10 +126,16 @@ func TestListDir(t *testing.T) {
 func TestZeroCopyCp(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	s.InsertFile(&File{FileID: "f1", StorageType: StorageS3, StorageRef: "blobs/f1",
-		SizeBytes: 1000000, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now})
-	s.InsertNode(&FileNode{NodeID: "n1", Path: "/a.bin", ParentPath: "/", Name: "a.bin", FileID: "f1", CreatedAt: now})
-	s.InsertNode(&FileNode{NodeID: "n2", Path: "/b.bin", ParentPath: "/", Name: "b.bin", FileID: "f1", CreatedAt: now})
+	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageS3, StorageRef: "blobs/f1",
+		SizeBytes: 1000000, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/a.bin", ParentPath: "/", Name: "a.bin", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n2", Path: "/b.bin", ParentPath: "/", Name: "b.bin", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
 
 	count, err := s.RefCount("f1")
 	if err != nil {
@@ -131,10 +149,16 @@ func TestZeroCopyCp(t *testing.T) {
 func TestDeleteWithRefCount(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
-		SizeBytes: 50, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now})
-	s.InsertNode(&FileNode{NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt", FileID: "f1", CreatedAt: now})
-	s.InsertNode(&FileNode{NodeID: "n2", Path: "/b.txt", ParentPath: "/", Name: "b.txt", FileID: "f1", CreatedAt: now})
+	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		SizeBytes: 50, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n2", Path: "/b.txt", ParentPath: "/", Name: "b.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
 
 	deleted, err := s.DeleteFileWithRefCheck("/a.txt")
 	if err != nil {
@@ -156,14 +180,26 @@ func TestDeleteWithRefCount(t *testing.T) {
 func TestDeleteDirRecursive(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	s.InsertNode(&FileNode{NodeID: "d1", Path: "/data/", ParentPath: "/", Name: "data", IsDirectory: true, CreatedAt: now})
-	s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
-		SizeBytes: 10, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now})
-	s.InsertFile(&File{FileID: "f2", StorageType: StorageDB9, StorageRef: "/blobs/f2",
-		SizeBytes: 20, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now})
-	s.InsertNode(&FileNode{NodeID: "n1", Path: "/data/a.txt", ParentPath: "/data/", Name: "a.txt", FileID: "f1", CreatedAt: now})
-	s.InsertNode(&FileNode{NodeID: "n2", Path: "/data/b.txt", ParentPath: "/data/", Name: "b.txt", FileID: "f2", CreatedAt: now})
-	s.InsertNode(&FileNode{NodeID: "n3", Path: "/shared.txt", ParentPath: "/", Name: "shared.txt", FileID: "f1", CreatedAt: now})
+	if err := s.InsertNode(&FileNode{NodeID: "d1", Path: "/data/", ParentPath: "/", Name: "data", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		SizeBytes: 10, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertFile(&File{FileID: "f2", StorageType: StorageDB9, StorageRef: "/blobs/f2",
+		SizeBytes: 20, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/data/a.txt", ParentPath: "/data/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n2", Path: "/data/b.txt", ParentPath: "/data/", Name: "b.txt", FileID: "f2", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n3", Path: "/shared.txt", ParentPath: "/", Name: "shared.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
 
 	orphaned, err := s.DeleteDirRecursive("/data/")
 	if err != nil {
@@ -207,7 +243,9 @@ func TestEnsureParentDirs(t *testing.T) {
 func TestRenameFile(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	s.InsertNode(&FileNode{NodeID: "n1", Path: "/old.txt", ParentPath: "/", Name: "old.txt", FileID: "f1", CreatedAt: now})
+	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/old.txt", ParentPath: "/", Name: "old.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.UpdateNodePath("/old.txt", "/new.txt", "/", "new.txt"); err != nil {
 		t.Fatal(err)
@@ -224,10 +262,18 @@ func TestRenameFile(t *testing.T) {
 func TestRenameDir(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	s.InsertNode(&FileNode{NodeID: "d1", Path: "/old/", ParentPath: "/", Name: "old", IsDirectory: true, CreatedAt: now})
-	s.InsertNode(&FileNode{NodeID: "n1", Path: "/old/a.txt", ParentPath: "/old/", Name: "a.txt", FileID: "f1", CreatedAt: now})
-	s.InsertNode(&FileNode{NodeID: "d2", Path: "/old/sub/", ParentPath: "/old/", Name: "sub", IsDirectory: true, CreatedAt: now})
-	s.InsertNode(&FileNode{NodeID: "n2", Path: "/old/sub/b.txt", ParentPath: "/old/sub/", Name: "b.txt", FileID: "f2", CreatedAt: now})
+	if err := s.InsertNode(&FileNode{NodeID: "d1", Path: "/old/", ParentPath: "/", Name: "old", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/old/a.txt", ParentPath: "/old/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "d2", Path: "/old/sub/", ParentPath: "/old/", Name: "sub", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(&FileNode{NodeID: "n2", Path: "/old/sub/b.txt", ParentPath: "/old/sub/", Name: "b.txt", FileID: "f2", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
 
 	count, err := s.RenameDir("/old/", "/new/")
 	if err != nil {
@@ -249,8 +295,10 @@ func TestRenameDir(t *testing.T) {
 func TestUpdateFileContent(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
-		SizeBytes: 10, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now})
+	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		SizeBytes: 10, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.UpdateFileContent("f1", StorageDB9, "/blobs/f1-v2", "text/plain", "abc123", "new content", 42); err != nil {
 		t.Fatal(err)

--- a/pkg/s3client/handler.go
+++ b/pkg/s3client/handler.go
@@ -62,8 +62,8 @@ func (c *LocalS3Client) handleGetObject(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	w.Header().Set("Content-Type", "application/octet-stream")
-	io.Copy(w, rc)
+	_, _ = io.Copy(w, rc)
 }

--- a/pkg/s3client/local.go
+++ b/pkg/s3client/local.go
@@ -16,10 +16,10 @@ import (
 // LocalS3Client implements S3Client using the local filesystem.
 // Used for testing and development without real S3.
 type LocalS3Client struct {
-	rootDir  string
-	baseURL  string // base URL for presigned URLs (e.g. "http://localhost:9091/s3")
-	mu       sync.Mutex
-	uploads  map[string]*localUpload // uploadID → upload state
+	rootDir string
+	baseURL string // base URL for presigned URLs (e.g. "http://localhost:9091/s3")
+	mu      sync.Mutex
+	uploads map[string]*localUpload // uploadID → upload state
 }
 
 type localUpload struct {
@@ -133,7 +133,7 @@ func (c *LocalS3Client) CompleteMultipartUpload(ctx context.Context, key, upload
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	for _, p := range sorted {
 		partFile := c.partPath(upload.key, uploadID, p.Number)
@@ -148,7 +148,7 @@ func (c *LocalS3Client) CompleteMultipartUpload(ctx context.Context, key, upload
 
 	// Cleanup parts
 	partsDir := filepath.Join(c.rootDir, "parts", uploadID)
-	os.RemoveAll(partsDir)
+	_ = os.RemoveAll(partsDir)
 
 	c.mu.Lock()
 	delete(c.uploads, uploadID)
@@ -159,7 +159,7 @@ func (c *LocalS3Client) CompleteMultipartUpload(ctx context.Context, key, upload
 
 func (c *LocalS3Client) AbortMultipartUpload(ctx context.Context, key, uploadID string) error {
 	partsDir := filepath.Join(c.rootDir, "parts", uploadID)
-	os.RemoveAll(partsDir)
+	_ = os.RemoveAll(partsDir)
 
 	c.mu.Lock()
 	delete(c.uploads, uploadID)

--- a/pkg/s3client/s3client_test.go
+++ b/pkg/s3client/s3client_test.go
@@ -14,7 +14,7 @@ func newTestClient(t *testing.T) *LocalS3Client {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 
 	c, err := NewLocal(dir, "http://localhost:9091/s3")
 	if err != nil {
@@ -67,7 +67,7 @@ func TestPutAndGetObject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	got, _ := io.ReadAll(rc)
 	if string(got) != "hello world" {
 		t.Errorf("got %q", got)
@@ -78,7 +78,9 @@ func TestDeleteObject(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()
 
-	c.PutObject(ctx, "blobs/del", bytes.NewReader([]byte("x")), 1)
+	if err := c.PutObject(ctx, "blobs/del", bytes.NewReader([]byte("x")), 1); err != nil {
+		t.Fatal(err)
+	}
 	if err := c.DeleteObject(ctx, "blobs/del"); err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +133,7 @@ func TestMultipartUploadComplete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	got, _ := io.ReadAll(rc)
 	if string(got) != "AAAABBBBCC" {
 		t.Errorf("expected AAAABBBBCC, got %q", got)
@@ -146,7 +148,9 @@ func TestMultipartUploadAbort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.UploadPart(ctx, upload.UploadID, 1, bytes.NewReader([]byte("data")))
+	if _, err := c.UploadPart(ctx, upload.UploadID, 1, bytes.NewReader([]byte("data"))); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := c.AbortMultipartUpload(ctx, "blobs/aborted", upload.UploadID); err != nil {
 		t.Fatal(err)
@@ -189,8 +193,12 @@ func TestPartialUploadAndListParts(t *testing.T) {
 	upload, _ := c.CreateMultipartUpload(ctx, "blobs/partial")
 
 	// Upload only parts 1 and 3 (skip 2 — simulates interrupted upload)
-	c.UploadPart(ctx, upload.UploadID, 1, bytes.NewReader([]byte("PART1")))
-	c.UploadPart(ctx, upload.UploadID, 3, bytes.NewReader([]byte("PART3")))
+	if _, err := c.UploadPart(ctx, upload.UploadID, 1, bytes.NewReader([]byte("PART1"))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.UploadPart(ctx, upload.UploadID, 3, bytes.NewReader([]byte("PART3"))); err != nil {
+		t.Fatal(err)
+	}
 
 	listed, err := c.ListParts(ctx, "blobs/partial", upload.UploadID)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -151,7 +151,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		json.NewEncoder(w).Encode(plan)
+		_ = json.NewEncoder(w).Encode(plan)
 		return
 	}
 
@@ -316,7 +316,7 @@ func (s *Server) handleUploads(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{"uploads": result})
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"uploads": result})
 }
 
 // handleUploadAction handles /v1/uploads/{id}/complete, /v1/uploads/{id}/resume, DELETE /v1/uploads/{id}
@@ -365,7 +365,7 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uploadID string) {
@@ -387,7 +387,7 @@ func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uplo
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(plan)
+	_ = json.NewEncoder(w).Encode(plan)
 }
 
 func (s *Server) handleUploadAbort(w http.ResponseWriter, r *http.Request, uploadID string) {
@@ -400,7 +400,7 @@ func (s *Server) handleUploadAbort(w http.ResponseWriter, r *http.Request, uploa
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func errJSON(w http.ResponseWriter, code int, msg string) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -80,7 +80,7 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 	}
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
-	w.Write(data)
+	_, _ = w.Write(data)
 }
 
 func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string) {
@@ -110,7 +110,7 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string) {
@@ -128,7 +128,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string) {
@@ -176,7 +176,7 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path strin
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath string) {
@@ -196,7 +196,7 @@ func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath stri
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath string) {
@@ -216,7 +216,7 @@ func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath st
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string) {
@@ -225,13 +225,13 @@ func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func errJSON(w http.ResponseWriter, code int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
 // ListenAndServe starts the server on the given address.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -21,14 +21,14 @@ func newTestServer(t *testing.T) *Server {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.RemoveAll(blobDir) })
+	t.Cleanup(func() { _ = os.RemoveAll(blobDir) })
 
 	store, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
 	testmysql.ResetDB(t, store.DB())
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	b, err := backend.New(store, blobDir)
 	if err != nil {
@@ -47,7 +47,7 @@ func TestWriteAndRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("write: %d", resp.StatusCode)
 	}
@@ -57,7 +57,7 @@ func TestWriteAndRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		t.Fatalf("read: %d", resp.StatusCode)
 	}
@@ -76,7 +76,7 @@ func TestListDir(t *testing.T) {
 	for _, name := range []string{"a.txt", "b.txt"} {
 		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/data/"+name, strings.NewReader(name))
 		resp, _ := http.DefaultClient.Do(req)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 
 	// List
@@ -84,7 +84,7 @@ func TestListDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var result struct {
 		Entries []struct {
@@ -92,7 +92,9 @@ func TestListDir(t *testing.T) {
 			IsDir bool   `json:"isDir"`
 		} `json:"entries"`
 	}
-	json.NewDecoder(resp.Body).Decode(&result)
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
 	if len(result.Entries) != 2 {
 		t.Fatalf("expected 2 entries, got %d", len(result.Entries))
 	}
@@ -106,7 +108,7 @@ func TestStat(t *testing.T) {
 	// Write a file
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/test.txt", strings.NewReader("data"))
 	resp, _ := http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	// Stat
 	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/test.txt", nil)
@@ -114,7 +116,7 @@ func TestStat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("stat: %d", resp.StatusCode)
 	}
@@ -134,12 +136,12 @@ func TestDelete(t *testing.T) {
 	// Write
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/del.txt", strings.NewReader("data"))
 	resp, _ := http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	// Delete
 	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/v1/fs/del.txt", nil)
 	resp, _ = http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("delete: %d", resp.StatusCode)
 	}
@@ -147,7 +149,7 @@ func TestDelete(t *testing.T) {
 	// Verify gone
 	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/del.txt", nil)
 	resp, _ = http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != 404 {
 		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
@@ -161,13 +163,13 @@ func TestCopy(t *testing.T) {
 	// Write source
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/src.txt", strings.NewReader("shared"))
 	resp, _ := http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	// Copy (zero-copy)
 	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/dst.txt?copy", nil)
 	req.Header.Set("X-Dat9-Copy-Source", "/src.txt")
 	resp, _ = http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("copy: %d", resp.StatusCode)
 	}
@@ -175,7 +177,7 @@ func TestCopy(t *testing.T) {
 	// Read copy
 	resp, _ = http.Get(ts.URL + "/v1/fs/dst.txt")
 	body, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if string(body) != "shared" {
 		t.Errorf("got %q", body)
 	}
@@ -189,13 +191,13 @@ func TestRename(t *testing.T) {
 	// Write
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/old.txt", strings.NewReader("data"))
 	resp, _ := http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	// Rename
 	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/new.txt?rename", nil)
 	req.Header.Set("X-Dat9-Rename-Source", "/old.txt")
 	resp, _ = http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("rename: %d", resp.StatusCode)
 	}
@@ -203,7 +205,7 @@ func TestRename(t *testing.T) {
 	// Old gone
 	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/old.txt", nil)
 	resp, _ = http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != 404 {
 		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
@@ -211,7 +213,7 @@ func TestRename(t *testing.T) {
 	// New exists
 	resp, _ = http.Get(ts.URL + "/v1/fs/new.txt")
 	body, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if string(body) != "data" {
 		t.Errorf("got %q", body)
 	}
@@ -222,8 +224,11 @@ func TestNotFound(t *testing.T) {
 	ts := httptest.NewServer(s)
 	defer ts.Close()
 
-	resp, _ := http.Get(ts.URL + "/v1/fs/nonexistent.txt")
-	defer resp.Body.Close()
+	resp, err := http.Get(ts.URL + "/v1/fs/nonexistent.txt")
+	if err != nil {
+		t.Fatalf("GET nonexistent: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 404 {
 		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/s3client"
@@ -17,30 +18,24 @@ import (
 
 func newTestServerWithS3(t *testing.T) (*Server, *s3client.LocalS3Client) {
 	t.Helper()
-	dbFile, err := os.CreateTemp("", "dat9-srv-*.db")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dbFile.Close()
-	t.Cleanup(func() { os.Remove(dbFile.Name()) })
-
 	blobDir, err := os.MkdirTemp("", "dat9-srv-blobs-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.RemoveAll(blobDir) })
+	t.Cleanup(func() { _ = os.RemoveAll(blobDir) })
 
 	s3Dir, err := os.MkdirTemp("", "dat9-srv-s3-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.RemoveAll(s3Dir) })
+	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
 
-	store, err := meta.Open(dbFile.Name())
+	store, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { store.Close() })
+	testmysql.ResetDB(t, store.DB())
+	t.Cleanup(func() { _ = store.Close() })
 
 	s3c, err := s3client.NewLocal(s3Dir, "http://localhost:9091/s3")
 	if err != nil {
@@ -67,7 +62,7 @@ func TestLargeFilePut202(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusAccepted {
 		t.Fatalf("expected 202, got %d", resp.StatusCode)
@@ -97,7 +92,7 @@ func TestSmallFilePut200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
@@ -113,11 +108,16 @@ func TestUploadCompleteEndpoint(t *testing.T) {
 	body := make([]byte, 1<<20)
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/complete-test.bin", bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
-	resp, _ := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var plan backend.UploadPlan
-	json.NewDecoder(resp.Body).Decode(&plan)
-	resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
 
 	// Get the upload to find s3_upload_id
 	upload, _ := s.backend.GetUpload(plan.UploadID)
@@ -129,16 +129,18 @@ func TestUploadCompleteEndpoint(t *testing.T) {
 		if end > int64(len(body)) {
 			end = int64(len(body))
 		}
-		s3c.UploadPart(context.Background(), upload.S3UploadID, p.Number, bytes.NewReader(body[start:end]))
+		if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, p.Number, bytes.NewReader(body[start:end])); err != nil {
+			t.Fatalf("upload part %d: %v", p.Number, err)
+		}
 	}
 
 	// POST /v1/uploads/{id}/complete
 	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/uploads/"+plan.UploadID+"/complete", nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("complete: expected 200, got %d", resp.StatusCode)
@@ -155,24 +157,31 @@ func TestUploadResumeEndpoint(t *testing.T) {
 	body := make([]byte, totalSize)
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/resume-test.bin", bytes.NewReader(body))
 	req.ContentLength = totalSize
-	resp, _ := http.DefaultClient.Do(req)
-
-	var plan backend.UploadPlan
-	json.NewDecoder(resp.Body).Decode(&plan)
-	resp.Body.Close()
-
-	upload, _ := s.backend.GetUpload(plan.UploadID)
-
-	// Upload only part 1
-	s3c.UploadPart(context.Background(), upload.S3UploadID, 1, bytes.NewReader(make([]byte, s3client.PartSize)))
-
-	// POST /v1/uploads/{id}/resume
-	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/uploads/"+plan.UploadID+"/resume", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+
+	var plan backend.UploadPlan
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	upload, _ := s.backend.GetUpload(plan.UploadID)
+
+	// Upload only part 1
+	if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, 1, bytes.NewReader(make([]byte, s3client.PartSize))); err != nil {
+		t.Fatal(err)
+	}
+
+	// POST /v1/uploads/{id}/resume
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/uploads/"+plan.UploadID+"/resume", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -180,7 +189,9 @@ func TestUploadResumeEndpoint(t *testing.T) {
 	}
 
 	var resumed backend.UploadPlan
-	json.NewDecoder(resp.Body).Decode(&resumed)
+	if err := json.NewDecoder(resp.Body).Decode(&resumed); err != nil {
+		t.Fatal(err)
+	}
 	if len(resumed.Parts) != 2 {
 		t.Errorf("expected 2 missing parts, got %d", len(resumed.Parts))
 	}
@@ -198,7 +209,7 @@ func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("small seed: expected 200, got %d", resp.StatusCode)
 	}
@@ -215,7 +226,7 @@ func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
 		t.Fatalf("decode plan: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted {
 		t.Fatalf("initiate overwrite: expected 202, got %d", resp.StatusCode)
 	}
@@ -241,7 +252,7 @@ func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("complete overwrite: expected 200, got %d", resp.StatusCode)
 	}
@@ -268,14 +279,14 @@ func TestListUploadsEndpoint(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/list-test.bin", bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
 	resp, _ := http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	// GET /v1/uploads?path=/list-test.bin&status=UPLOADING
 	resp, err := http.Get(ts.URL + "/v1/uploads?path=/list-test.bin&status=UPLOADING")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
@@ -288,7 +299,9 @@ func TestListUploadsEndpoint(t *testing.T) {
 			Status     string `json:"status"`
 		} `json:"uploads"`
 	}
-	json.NewDecoder(resp.Body).Decode(&result)
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
 	if len(result.Uploads) != 1 {
 		t.Errorf("expected 1 upload, got %d", len(result.Uploads))
 	}
@@ -307,7 +320,7 @@ func TestOneUploadPerPath(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/dup-test.bin", bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
 	resp, _ := http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted {
 		t.Fatalf("first upload: expected 202, got %d", resp.StatusCode)
 	}
@@ -316,7 +329,7 @@ func TestOneUploadPerPath(t *testing.T) {
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/dup-test.bin", bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
 	resp, _ = http.DefaultClient.Do(req)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("second upload: expected 409 (conflict), got %d", resp.StatusCode)
 	}
@@ -334,8 +347,10 @@ func TestAbortUploadEndpoint(t *testing.T) {
 	resp, _ := http.DefaultClient.Do(req)
 
 	var plan backend.UploadPlan
-	json.NewDecoder(resp.Body).Decode(&plan)
-	resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
 
 	// DELETE /v1/uploads/{id}
 	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/v1/uploads/"+plan.UploadID, nil)
@@ -343,7 +358,7 @@ func TestAbortUploadEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("abort: expected 200, got %d", resp.StatusCode)


### PR DESCRIPTION
## Summary
- add a root `Makefile` with `mod`, `fmt`, `lint`, `test`, `build`, `build-server`, `build-cli`, `docker-build`, and `docker-push` targets for a consistent local workflow
- add a runtime-only `Dockerfile` that packages the prebuilt `bin/dat9-server` binary for ECR/EKS deployment
- fix `golangci-lint` `errcheck` violations across server, client, backend, and metadata code/tests so `make lint` passes cleanly

## Verification
- `make lint`
- `make test`
- `make build`