### PR TITLE
feat: multi-tenant auth with per-tenant API keys and cluster routing

### DIFF
--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
 	"log"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/server"
+	"github.com/mem9-ai/dat9/pkg/tenant"
 )
 
 const (
@@ -33,11 +35,6 @@ func main() {
 		addr = os.Args[1]
 	}
 
-	mysqlDSN := os.Getenv("DAT9_MYSQL_DSN")
-	if mysqlDSN == "" {
-		die(fmt.Errorf("DAT9_MYSQL_DSN is required"))
-	}
-
 	blobDir := envOr("DAT9_BLOB_DIR", defaultBlobDir)
 	s3Dir := envOr("DAT9_S3_DIR", defaultS3Dir)
 
@@ -48,24 +45,79 @@ func main() {
 		die(fmt.Errorf("create s3 dir: %w", err))
 	}
 
-	store, err := meta.Open(mysqlDSN)
-	if err != nil {
-		die(fmt.Errorf("open meta store: %w", err))
-	}
-	defer store.Close()
+	pubURL := publicBaseURL(addr)
+	s3BaseURL := pubURL + "/s3"
 
-	s3BaseURL := publicBaseURL(addr) + "/s3"
-	s3c, err := s3client.NewLocal(s3Dir, s3BaseURL)
-	if err != nil {
-		die(fmt.Errorf("create local s3 client: %w", err))
+	cfg := server.Config{}
+
+	// Multi-tenant mode: control plane DSN + master key + admin key
+	cpDSN := os.Getenv("DAT9_CONTROL_PLANE_DSN")
+	masterKeyHex := os.Getenv("DAT9_MASTER_KEY")
+	adminKey := os.Getenv("DAT9_ADMIN_KEY")
+
+	if cpDSN != "" && masterKeyHex != "" {
+		// Multi-tenant mode
+		masterKey, err := hex.DecodeString(masterKeyHex)
+		if err != nil {
+			die(fmt.Errorf("DAT9_MASTER_KEY must be 64 hex chars (32 bytes): %w", err))
+		}
+		enc, err := tenant.NewEncryptor(masterKey)
+		if err != nil {
+			die(fmt.Errorf("create encryptor: %w", err))
+		}
+		tenants, err := tenant.OpenStore(cpDSN, enc)
+		if err != nil {
+			die(fmt.Errorf("open control plane: %w", err))
+		}
+		defer tenants.Close()
+
+		pool := tenant.NewPool(tenant.PoolConfig{
+			MaxTenants: 128,
+			BlobDir:    blobDir,
+			S3Dir:      s3Dir,
+			PublicURL:  pubURL,
+		}, enc)
+		defer pool.Close()
+
+		cfg.Tenants = tenants
+		cfg.Pool = pool
+		cfg.AdminKey = adminKey
+
+		// Set up provisioner if TiDB Cloud credentials are available
+		provisioner, err := tenant.NewTiDBStarterFromEnv()
+		if err != nil {
+			log.Printf("tidb starter not configured: %v (provisioning disabled)", err)
+		} else {
+			cfg.Provisioner = provisioner
+		}
+
+		log.Printf("multi-tenant mode enabled (admin key: %v, provisioner: %v)",
+			adminKey != "", cfg.Provisioner != nil)
+	} else {
+		// Local dev mode: single backend
+		mysqlDSN := os.Getenv("DAT9_MYSQL_DSN")
+		if mysqlDSN == "" {
+			die(fmt.Errorf("DAT9_MYSQL_DSN is required in local dev mode (or set DAT9_CONTROL_PLANE_DSN + DAT9_MASTER_KEY for multi-tenant)"))
+		}
+		store, err := meta.Open(mysqlDSN)
+		if err != nil {
+			die(fmt.Errorf("open meta store: %w", err))
+		}
+		defer store.Close()
+
+		s3c, err := s3client.NewLocal(s3Dir, s3BaseURL)
+		if err != nil {
+			die(fmt.Errorf("create local s3 client: %w", err))
+		}
+
+		b, err := backend.NewWithS3(store, blobDir, s3c)
+		if err != nil {
+			die(fmt.Errorf("create backend: %w", err))
+		}
+		cfg.Backend = b
 	}
 
-	b, err := backend.NewWithS3(store, blobDir, s3c)
-	if err != nil {
-		die(fmt.Errorf("create backend: %w", err))
-	}
-
-	die(server.New(b).ListenAndServe(addr))
+	die(server.New(cfg).ListenAndServe(addr))
 }
 
 func envOr(key, fallback string) string {
@@ -78,10 +130,20 @@ func envOr(key, fallback string) string {
 func usage() {
 	fmt.Fprintf(os.Stderr, `usage: dat9-server [listen-addr]
 
-environment:
-  DAT9_LISTEN_ADDR serve listen address (default: :9009)
-  DAT9_PUBLIC_URL  externally reachable base URL for presigned URLs (required for remote clients)
+environment (local dev mode):
   DAT9_MYSQL_DSN   TiDB/MySQL DSN (required)
+
+environment (multi-tenant mode):
+  DAT9_CONTROL_PLANE_DSN  control plane MySQL DSN (required)
+  DAT9_MASTER_KEY         32-byte hex master key for password encryption (required)
+  DAT9_ADMIN_KEY          admin key for /v1/provision (required for provisioning)
+  DAT9_TIDBCLOUD_API_KEY     TiDB Cloud API public key
+  DAT9_TIDBCLOUD_API_SECRET  TiDB Cloud API private key
+  DAT9_TIDBCLOUD_POOL_ID     TiDB Cloud cluster pool ID
+
+environment (common):
+  DAT9_LISTEN_ADDR serve listen address (default: :9009)
+  DAT9_PUBLIC_URL  externally reachable base URL for presigned URLs
   DAT9_BLOB_DIR    blob directory (default: ./blobs)
   DAT9_S3_DIR      s3 directory (default: ./s3)
 `)
@@ -101,8 +163,6 @@ func publicBaseURL(listenAddr string) string {
 		return v
 	}
 
-	// Without DAT9_PUBLIC_URL, only allow explicit loopback addresses.
-	// Wildcard or non-loopback addresses would produce unreachable presigned URLs.
 	switch {
 	case strings.HasPrefix(listenAddr, "127.0.0.1:"),
 		strings.HasPrefix(listenAddr, "localhost:"),

--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -82,6 +82,7 @@ func main() {
 		cfg.Tenants = tenants
 		cfg.Pool = pool
 		cfg.AdminKey = adminKey
+		cfg.S3Dir = s3Dir
 
 		// Set up provisioner if TiDB Cloud credentials are available
 		provisioner, err := tenant.NewTiDBStarterFromEnv()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -30,7 +30,7 @@ func newTestClient(t *testing.T) (*Client, func()) {
 		t.Fatal(err)
 	}
 
-	srv := server.New(b)
+	srv := server.New(server.Config{Backend: b})
 	ts := httptest.NewServer(srv)
 
 	cleanup := func() {

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -294,7 +294,7 @@ func TestResumeUploadIntegrationProgressTotal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ts := httptest.NewUnstartedServer(srvpkg.New(b))
+	ts := httptest.NewUnstartedServer(srvpkg.New(srvpkg.Config{Backend: b}))
 	ts.Listener.Close()
 	ts.Listener = ln
 	ts.Start()

--- a/pkg/s3client/handler.go
+++ b/pkg/s3client/handler.go
@@ -10,6 +10,7 @@ import (
 )
 
 // Handler returns an http.Handler that serves the local S3 presigned URLs.
+// All requests must include valid sig and exp query parameters (HMAC-signed).
 // Mount this at the baseURL path prefix (e.g. "/s3").
 func (c *LocalS3Client) Handler() http.Handler {
 	mux := http.NewServeMux()
@@ -18,10 +19,24 @@ func (c *LocalS3Client) Handler() http.Handler {
 	return mux
 }
 
+// verifySig checks the HMAC signature and expiry on the request.
+func (c *LocalS3Client) verifySig(r *http.Request) bool {
+	sig := r.URL.Query().Get("sig")
+	exp := r.URL.Query().Get("exp")
+	if sig == "" || exp == "" {
+		return false
+	}
+	return c.VerifySignature(r.URL.Path, sig, exp)
+}
+
 // handleUploadPart handles PUT /upload/{uploadID}/{partNumber}
 func (c *LocalS3Client) handleUploadPart(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPut {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !c.verifySig(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
 
@@ -53,6 +68,10 @@ func (c *LocalS3Client) handleUploadPart(w http.ResponseWriter, r *http.Request)
 func (c *LocalS3Client) handleGetObject(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !c.verifySig(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
 

--- a/pkg/s3client/local.go
+++ b/pkg/s3client/local.go
@@ -2,6 +2,8 @@ package s3client
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -9,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -16,10 +19,11 @@ import (
 // LocalS3Client implements S3Client using the local filesystem.
 // Used for testing and development without real S3.
 type LocalS3Client struct {
-	rootDir  string
-	baseURL  string // base URL for presigned URLs (e.g. "http://localhost:9091/s3")
-	mu       sync.Mutex
-	uploads  map[string]*localUpload // uploadID → upload state
+	rootDir    string
+	baseURL    string // base URL for presigned URLs (e.g. "http://localhost:9091/s3")
+	signingKey []byte // HMAC-SHA256 key for presigned URL signatures
+	mu         sync.Mutex
+	uploads    map[string]*localUpload // uploadID → upload state
 }
 
 type localUpload struct {
@@ -38,10 +42,15 @@ func NewLocal(rootDir, baseURL string) (*LocalS3Client, error) {
 	if err := os.MkdirAll(rootDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create s3 root: %w", err)
 	}
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generate signing key: %w", err)
+	}
 	return &LocalS3Client{
-		rootDir: rootDir,
-		baseURL: baseURL,
-		uploads: make(map[string]*localUpload),
+		rootDir:    rootDir,
+		baseURL:    baseURL,
+		signingKey: key,
+		uploads:    make(map[string]*localUpload),
 	}, nil
 }
 
@@ -69,13 +78,13 @@ func (c *LocalS3Client) CreateMultipartUpload(ctx context.Context, key string) (
 }
 
 func (c *LocalS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, ttl time.Duration) (*UploadPartURL, error) {
-	// For local: presigned URL is just a direct path to the part file location.
-	// The local HTTP handler will resolve this.
-	url := fmt.Sprintf("%s/upload/%s/%d", c.baseURL, uploadID, partNumber)
+	exp := time.Now().Add(ttl)
+	path := fmt.Sprintf("/upload/%s/%d", uploadID, partNumber)
+	url := fmt.Sprintf("%s%s?exp=%d&sig=%s", c.baseURL, path, exp.Unix(), c.sign(path, exp))
 	return &UploadPartURL{
 		Number:    partNumber,
 		URL:       url,
-		ExpiresAt: time.Now().Add(ttl),
+		ExpiresAt: exp,
 	}, nil
 }
 
@@ -186,7 +195,9 @@ func (c *LocalS3Client) ListParts(ctx context.Context, key, uploadID string) ([]
 }
 
 func (c *LocalS3Client) PresignGetObject(ctx context.Context, key string, ttl time.Duration) (string, error) {
-	url := fmt.Sprintf("%s/objects/%s", c.baseURL, key)
+	exp := time.Now().Add(ttl)
+	path := fmt.Sprintf("/objects/%s", key)
+	url := fmt.Sprintf("%s%s?exp=%d&sig=%s", c.baseURL, path, exp.Unix(), c.sign(path, exp))
 	return url, nil
 }
 
@@ -208,6 +219,27 @@ func (c *LocalS3Client) GetObject(ctx context.Context, key string) (io.ReadClose
 
 func (c *LocalS3Client) DeleteObject(ctx context.Context, key string) error {
 	return os.Remove(c.objectPath(key))
+}
+
+// sign produces an HMAC-SHA256 signature for a path and expiry.
+func (c *LocalS3Client) sign(path string, exp time.Time) string {
+	mac := hmac.New(sha256.New, c.signingKey)
+	mac.Write([]byte(fmt.Sprintf("%s\n%d", path, exp.Unix())))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifySignature checks the sig and exp query params on an incoming request path.
+// Returns true if the signature is valid and not expired.
+func (c *LocalS3Client) VerifySignature(path, sig, expStr string) bool {
+	expUnix, err := strconv.ParseInt(expStr, 10, 64)
+	if err != nil {
+		return false
+	}
+	if time.Now().Unix() > expUnix {
+		return false
+	}
+	expected := c.sign(path, time.Unix(expUnix, 0))
+	return hmac.Equal([]byte(sig), []byte(expected))
 }
 
 // Verify interface compliance.

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/mem9-ai/dat9/pkg/backend"
+	"github.com/mem9-ai/dat9/pkg/tenant"
+)
+
+type contextKey int
+
+const backendKey contextKey = iota
+
+// BackendFromCtx extracts the tenant-scoped backend from the request context.
+// Returns nil if no backend is set (e.g. control plane routes).
+func BackendFromCtx(ctx context.Context) *backend.Dat9Backend {
+	b, _ := ctx.Value(backendKey).(*backend.Dat9Backend)
+	return b
+}
+
+func withBackend(ctx context.Context, b *backend.Dat9Backend) context.Context {
+	return context.WithValue(ctx, backendKey, b)
+}
+
+// tenantAuthMiddleware resolves a Bearer token to a tenant backend.
+// Flow: extract token → SHA-256 hash → lookup tenant → check status → pool.Get → inject into context.
+func tenantAuthMiddleware(tenants *tenant.Store, pool *tenant.Pool, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := bearerToken(r)
+		if token == "" {
+			errJSON(w, http.StatusUnauthorized, "missing or malformed Authorization header")
+			return
+		}
+
+		hash := tenant.HashAPIKey(token)
+		t, err := tenants.GetByAPIKeyHash(hash)
+		if err != nil {
+			// Don't leak whether tenant exists — same error for invalid and not-found
+			errJSON(w, http.StatusUnauthorized, "invalid API key")
+			return
+		}
+
+		switch t.Status {
+		case tenant.StatusActive:
+			// proceed
+		case tenant.StatusProvisioning:
+			errJSON(w, http.StatusServiceUnavailable, "tenant is provisioning")
+			return
+		case tenant.StatusSuspended, tenant.StatusDeleted:
+			pool.Invalidate(t.ID)
+			errJSON(w, http.StatusForbidden, "tenant is suspended")
+			return
+		default:
+			errJSON(w, http.StatusForbidden, "tenant status: "+string(t.Status))
+			return
+		}
+
+		b, err := pool.Get(t)
+		if err != nil {
+			errJSON(w, http.StatusInternalServerError, "backend unavailable")
+			return
+		}
+
+		next.ServeHTTP(w, r.WithContext(withBackend(r.Context(), b)))
+	})
+}
+
+func bearerToken(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	if h == "" {
+		return ""
+	}
+	const prefix = "Bearer "
+	if !strings.HasPrefix(h, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(h[len(prefix):])
+}

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -1,0 +1,324 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/dat9/internal/testmysql"
+	"github.com/mem9-ai/dat9/pkg/backend"
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/tenant"
+)
+
+// newMultiTenantTestServer creates a server in multi-tenant mode with a single active tenant.
+// Returns (server, rawAPIKey, cleanup).
+func newMultiTenantTestServer(t *testing.T) (*Server, string, func()) {
+	t.Helper()
+	if testDSN == "" {
+		t.Skip("no test database available")
+	}
+
+	masterKey := make([]byte, 32)
+	rand.Read(masterKey)
+	enc, err := tenant.NewEncryptor(masterKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Open control plane store (reuses the test DB)
+	tenantStore, err := tenant.OpenStore(testDSN, enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Clean tenant table
+	tenantStore.DB().Exec("DELETE FROM tenants")
+
+	// Create a tenant with its own meta store (reuses same DB for testing)
+	raw, prefix, hash, err := tenant.GenerateAPIKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pwEnc, err := tenantStore.EncryptPassword("unused")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Open tenant's meta store
+	tenantMetaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetDB(t, tenantMetaStore.DB())
+
+	blobDir, _ := os.MkdirTemp("", "dat9-auth-blobs-*")
+
+	tenantBackend, err := backend.New(tenantMetaStore, blobDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := mustNow()
+	tid := hash[:16]
+	tenantStore.Insert(&tenant.Tenant{
+		ID:            tid,
+		APIKeyPrefix:  prefix,
+		APIKeyHash:    hash,
+		Status:        tenant.StatusActive,
+		DBHost:        "127.0.0.1",
+		DBPort:        4000,
+		DBUser:        "root",
+		DBPasswordEnc: pwEnc,
+		DBName:        "test",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+
+	// Create pool that returns our pre-built backend
+	pool := tenant.NewPool(tenant.PoolConfig{
+		MaxTenants: 10,
+		BlobDir:    blobDir,
+	}, enc)
+
+	// We need to inject the backend into the pool. Since pool.Get creates new
+	// backends from DSN, and we're testing auth flow, use injectBackendMiddleware
+	// approach — but we actually want the real auth middleware. For a proper test,
+	// we'll set up so pool.Get works by having a valid DSN in the tenant record.
+	// Since we're reusing testDSN, extract its components.
+
+	// Actually, for auth tests, let's just use the server with fallback + tenant auth.
+	// The simplest approach: create server with both tenant store and pool.
+	srv := New(Config{
+		Tenants:  tenantStore,
+		Pool:     pool,
+		AdminKey: "test-admin-key",
+	})
+
+	cleanup := func() {
+		pool.Close()
+		tenantStore.DB().Exec("DELETE FROM tenants")
+		tenantStore.Close()
+		tenantMetaStore.Close()
+		os.RemoveAll(blobDir)
+	}
+
+	// Pre-warm the pool by injecting backend directly is not possible from outside,
+	// so we accept that pool.Get will try to connect using the tenant's DSN.
+	// In test, the tenant's DB creds won't work (encrypted "unused").
+	// For auth-level tests (401/403/503), we don't need the backend to succeed.
+	_ = tenantBackend
+
+	return srv, raw, cleanup
+}
+
+func mustNow() time.Time {
+	return time.Now().UTC().Truncate(time.Millisecond)
+}
+
+func TestAuthMissingKey(t *testing.T) {
+	srv, _, cleanup := newMultiTenantTestServer(t)
+	defer cleanup()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/fs/test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestAuthInvalidKey(t *testing.T) {
+	srv, _, cleanup := newMultiTenantTestServer(t)
+	defer cleanup()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/test.txt", nil)
+	req.Header.Set("Authorization", "Bearer invalid-key-here")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+
+	// Verify error message doesn't leak tenant existence
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/test.txt", nil)
+	req.Header.Set("Authorization", "Bearer invalid-key-here")
+	resp, _ = http.DefaultClient.Do(req)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	var errResp map[string]string
+	json.Unmarshal(body, &errResp)
+	if errResp["error"] != "invalid API key" {
+		t.Errorf("error message should be generic, got %q", errResp["error"])
+	}
+}
+
+func TestAuthSuspendedTenant(t *testing.T) {
+	if testDSN == "" {
+		t.Skip("no test database available")
+	}
+
+	masterKey := make([]byte, 32)
+	rand.Read(masterKey)
+	enc, _ := tenant.NewEncryptor(masterKey)
+	tenantStore, err := tenant.OpenStore(testDSN, enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tenantStore.Close()
+	tenantStore.DB().Exec("DELETE FROM tenants")
+
+	raw, prefix, hash, _ := tenant.GenerateAPIKey()
+	pwEnc, _ := tenantStore.EncryptPassword("unused")
+	now := mustNow()
+	tenantStore.Insert(&tenant.Tenant{
+		ID: hash[:16], APIKeyPrefix: prefix, APIKeyHash: hash,
+		Status: tenant.StatusSuspended, DBPasswordEnc: pwEnc,
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	pool := tenant.NewPool(tenant.PoolConfig{MaxTenants: 10, BlobDir: "/tmp"}, enc)
+	defer pool.Close()
+
+	srv := New(Config{Tenants: tenantStore, Pool: pool})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/test.txt", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for suspended tenant, got %d", resp.StatusCode)
+	}
+}
+
+func TestAuthProvisioningTenant(t *testing.T) {
+	if testDSN == "" {
+		t.Skip("no test database available")
+	}
+
+	masterKey := make([]byte, 32)
+	rand.Read(masterKey)
+	enc, _ := tenant.NewEncryptor(masterKey)
+	tenantStore, err := tenant.OpenStore(testDSN, enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tenantStore.Close()
+	tenantStore.DB().Exec("DELETE FROM tenants")
+
+	raw, prefix, hash, _ := tenant.GenerateAPIKey()
+	pwEnc, _ := tenantStore.EncryptPassword("unused")
+	now := mustNow()
+	tenantStore.Insert(&tenant.Tenant{
+		ID: hash[:16], APIKeyPrefix: prefix, APIKeyHash: hash,
+		Status: tenant.StatusProvisioning, DBPasswordEnc: pwEnc,
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	pool := tenant.NewPool(tenant.PoolConfig{MaxTenants: 10, BlobDir: "/tmp"}, enc)
+	defer pool.Close()
+
+	srv := New(Config{Tenants: tenantStore, Pool: pool})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/test.txt", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 for provisioning tenant, got %d", resp.StatusCode)
+	}
+}
+
+func TestProvisionEndpointAdminKeyRequired(t *testing.T) {
+	srv := New(Config{AdminKey: "secret-admin"})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// No auth
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", nil)
+	resp, _ := http.DefaultClient.Do(req)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 without admin key, got %d", resp.StatusCode)
+	}
+
+	// Wrong key
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", nil)
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	resp, _ = http.DefaultClient.Do(req)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 with wrong admin key, got %d", resp.StatusCode)
+	}
+}
+
+func TestLocalDevModeNoAuth(t *testing.T) {
+	if testDSN == "" {
+		t.Skip("no test database available")
+	}
+
+	blobDir, _ := os.MkdirTemp("", "dat9-noauth-*")
+	defer os.RemoveAll(blobDir)
+
+	store, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetDB(t, store.DB())
+	defer store.Close()
+
+	b, _ := backend.New(store, blobDir)
+
+	// Local dev mode: no tenants configured, backend as fallback
+	srv := New(Config{Backend: b})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Should work without any auth
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/noauth.txt", strings.NewReader("hello"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 in local dev mode, got %d", resp.StatusCode)
+	}
+
+	// Read back
+	resp, err = http.Get(ts.URL + "/v1/fs/noauth.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(body) != "hello" {
+		t.Errorf("got %q, want %q", body, "hello")
+	}
+}

--- a/pkg/server/integration_test.go
+++ b/pkg/server/integration_test.go
@@ -1,0 +1,247 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/tenant"
+)
+
+// mockProvisioner returns the test DSN as the cluster, simulating provision.
+type mockProvisioner struct {
+	dsn string
+}
+
+func (m *mockProvisioner) Provision(_ context.Context) (*tenant.ClusterInfo, error) {
+	// Parse the test DSN to extract host/port/user/password/dbname
+	// For testing, just return localhost defaults — InitSchema does the real work.
+	return &tenant.ClusterInfo{
+		ClusterID: "test-cluster",
+		Host:      "127.0.0.1",
+		Port:      3306,
+		Username:  "root",
+		Password:  "",
+		DBName:    "test",
+	}, nil
+}
+
+func (m *mockProvisioner) InitSchema(_ context.Context, dsn string) error {
+	store, err := meta.Open(dsn)
+	if err != nil {
+		return err
+	}
+	store.Close()
+	return nil
+}
+
+func (m *mockProvisioner) ProviderType() string { return "mock" }
+
+// newIntegrationServer creates a full multi-tenant server backed by the test database.
+// Provision endpoint uses a mock provisioner that targets testDSN.
+func newIntegrationServer(t *testing.T) (*httptest.Server, *tenant.Store, func()) {
+	t.Helper()
+	if testDSN == "" {
+		t.Skip("no test database available")
+	}
+
+	masterKey := make([]byte, 32)
+	rand.Read(masterKey)
+	enc, err := tenant.NewEncryptor(masterKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenantStore, err := tenant.OpenStore(testDSN, enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantStore.DB().Exec("DELETE FROM tenants")
+
+	blobDir, _ := os.MkdirTemp("", "dat9-integ-blobs-*")
+
+	pool := tenant.NewPool(tenant.PoolConfig{
+		MaxTenants: 10,
+		BlobDir:    blobDir,
+	}, enc)
+
+	srv := New(Config{
+		Tenants:     tenantStore,
+		Pool:        pool,
+		Provisioner: &mockProvisioner{dsn: testDSN},
+		AdminKey:    "test-admin-key",
+	})
+	ts := httptest.NewServer(srv)
+
+	cleanup := func() {
+		ts.Close()
+		pool.Close()
+		tenantStore.DB().Exec("DELETE FROM tenants")
+		tenantStore.Close()
+		os.RemoveAll(blobDir)
+	}
+
+	return ts, tenantStore, cleanup
+}
+
+// provisionTenant calls POST /v1/provision and returns the raw API key.
+func provisionTenant(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", nil)
+	req.Header.Set("Authorization", "Bearer test-admin-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("provision: expected 201, got %d: %s", resp.StatusCode, body)
+	}
+	var result struct {
+		APIKey   string `json:"api_key"`
+		TenantID string `json:"tenant_id"`
+		Status   string `json:"status"`
+	}
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result.APIKey == "" {
+		t.Fatal("provision returned empty API key")
+	}
+	if result.Status != "active" {
+		t.Fatalf("expected status active, got %q", result.Status)
+	}
+	return result.APIKey
+}
+
+func authedRequest(method, url, apiKey string, body io.Reader) *http.Request {
+	req, _ := http.NewRequest(method, url, body)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	return req
+}
+
+func TestProvisionAndAuth(t *testing.T) {
+	ts, _, cleanup := newIntegrationServer(t)
+	defer cleanup()
+
+	// Provision a tenant
+	apiKey := provisionTenant(t, ts)
+
+	// Use the key to write a file
+	req := authedRequest(http.MethodPut, ts.URL+"/v1/fs/hello.txt", apiKey, strings.NewReader("world"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write: expected 200, got %d", resp.StatusCode)
+	}
+
+	// Read it back
+	req = authedRequest(http.MethodGet, ts.URL+"/v1/fs/hello.txt", apiKey, nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("read: expected 200, got %d", resp.StatusCode)
+	}
+	if string(body) != "world" {
+		t.Errorf("read: got %q, want %q", body, "world")
+	}
+}
+
+func TestProvisionAdminKeyRequired(t *testing.T) {
+	ts, _, cleanup := newIntegrationServer(t)
+	defer cleanup()
+
+	// No key
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", nil)
+	resp, _ := http.DefaultClient.Do(req)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+
+	// Wrong key
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", nil)
+	req.Header.Set("Authorization", "Bearer wrong-admin-key")
+	resp, _ = http.DefaultClient.Do(req)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+
+	// Wrong method
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/v1/provision", nil)
+	req.Header.Set("Authorization", "Bearer test-admin-key")
+	resp, _ = http.DefaultClient.Do(req)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestRevokedKeyRejected(t *testing.T) {
+	ts, tenantStore, cleanup := newIntegrationServer(t)
+	defer cleanup()
+
+	apiKey := provisionTenant(t, ts)
+
+	// Verify it works first
+	req := authedRequest(http.MethodPut, ts.URL+"/v1/fs/test.txt", apiKey, strings.NewReader("data"))
+	resp, _ := http.DefaultClient.Do(req)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write before revoke: expected 200, got %d", resp.StatusCode)
+	}
+
+	// Revoke: find tenant ID from hash and suspend
+	hash := tenant.HashAPIKey(apiKey)
+	tnt, err := tenantStore.GetByAPIKeyHash(hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tenantStore.UpdateStatus(tnt.ID, tenant.StatusSuspended); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now the key should be rejected with 403
+	req = authedRequest(http.MethodGet, ts.URL+"/v1/fs/test.txt", apiKey, nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 after revoke, got %d", resp.StatusCode)
+	}
+}
+
+func TestWrongKeyRejected(t *testing.T) {
+	ts, _, cleanup := newIntegrationServer(t)
+	defer cleanup()
+
+	// Provision a tenant
+	_ = provisionTenant(t, ts)
+
+	// Try with a completely fabricated key
+	req := authedRequest(http.MethodGet, ts.URL+"/v1/fs/test.txt", "dat9_fakefakefakefake", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 for wrong key, got %d", resp.StatusCode)
+	}
+}

--- a/pkg/server/integration_test.go
+++ b/pkg/server/integration_test.go
@@ -3,7 +3,9 @@ package server
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,25 +13,70 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
 )
 
-// mockProvisioner returns the test DSN as the cluster, simulating provision.
+func openDB(dsn string) (*sql.DB, error) {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, err
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+// mockProvisioner creates a new database per tenant to simulate real isolation.
 type mockProvisioner struct {
-	dsn string
+	dsn    string
+	dbSeq  int
+	parsed *mysql.Config
+	dbs    []string // track created DBs for cleanup
+}
+
+func newMockProvisioner(dsn string) *mockProvisioner {
+	cfg, _ := mysql.ParseDSN(dsn)
+	return &mockProvisioner{dsn: dsn, parsed: cfg, dbs: make([]string, 0)}
 }
 
 func (m *mockProvisioner) Provision(_ context.Context) (*tenant.ClusterInfo, error) {
-	// Parse the test DSN to extract host/port/user/password/dbname
-	// For testing, just return localhost defaults — InitSchema does the real work.
+	m.dbSeq++
+	dbName := fmt.Sprintf("dat9_tenant_%d", m.dbSeq)
+
+	// Create a new database for this tenant
+	adminCfg := m.parsed.Clone()
+	adminCfg.DBName = ""
+	adminDB, err := openDB(adminCfg.FormatDSN())
+	if err != nil {
+		return nil, fmt.Errorf("open admin db: %w", err)
+	}
+	defer adminDB.Close()
+	if _, err := adminDB.Exec("CREATE DATABASE IF NOT EXISTS " + dbName); err != nil {
+		return nil, fmt.Errorf("create tenant db: %w", err)
+	}
+	m.dbs = append(m.dbs, dbName)
+
+	host, port := "127.0.0.1", 3306
+	if m.parsed.Addr != "" {
+		h, p, _ := strings.Cut(m.parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			fmt.Sscanf(p, "%d", &port)
+		}
+	}
 	return &tenant.ClusterInfo{
-		ClusterID: "test-cluster",
-		Host:      "127.0.0.1",
-		Port:      3306,
-		Username:  "root",
-		Password:  "",
-		DBName:    "test",
+		ClusterID: fmt.Sprintf("test-cluster-%d", m.dbSeq),
+		Host:      host,
+		Port:      port,
+		Username:  m.parsed.User,
+		Password:  m.parsed.Passwd,
+		DBName:    dbName,
 	}, nil
 }
 
@@ -43,6 +90,19 @@ func (m *mockProvisioner) InitSchema(_ context.Context, dsn string) error {
 }
 
 func (m *mockProvisioner) ProviderType() string { return "mock" }
+
+func (m *mockProvisioner) cleanup() {
+	adminCfg := m.parsed.Clone()
+	adminCfg.DBName = ""
+	adminDB, err := openDB(adminCfg.FormatDSN())
+	if err != nil {
+		return
+	}
+	defer adminDB.Close()
+	for _, db := range m.dbs {
+		adminDB.Exec("DROP DATABASE IF EXISTS " + db)
+	}
+}
 
 // newIntegrationServer creates a full multi-tenant server backed by the test database.
 // Provision endpoint uses a mock provisioner that targets testDSN.
@@ -72,10 +132,11 @@ func newIntegrationServer(t *testing.T) (*httptest.Server, *tenant.Store, func()
 		BlobDir:    blobDir,
 	}, enc)
 
+	prov := newMockProvisioner(testDSN)
 	srv := New(Config{
 		Tenants:     tenantStore,
 		Pool:        pool,
-		Provisioner: &mockProvisioner{dsn: testDSN},
+		Provisioner: prov,
 		AdminKey:    "test-admin-key",
 	})
 	ts := httptest.NewServer(srv)
@@ -83,6 +144,7 @@ func newIntegrationServer(t *testing.T) (*httptest.Server, *tenant.Store, func()
 	cleanup := func() {
 		ts.Close()
 		pool.Close()
+		prov.cleanup()
 		tenantStore.DB().Exec("DELETE FROM tenants")
 		tenantStore.Close()
 		os.RemoveAll(blobDir)
@@ -224,6 +286,67 @@ func TestRevokedKeyRejected(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("expected 403 after revoke, got %d", resp.StatusCode)
+	}
+}
+
+func TestTenantIsolation(t *testing.T) {
+	ts, _, cleanup := newIntegrationServer(t)
+	defer cleanup()
+
+	// Provision two tenants
+	key1 := provisionTenant(t, ts)
+	key2 := provisionTenant(t, ts)
+
+	// Tenant 1 writes a file
+	req := authedRequest(http.MethodPut, ts.URL+"/v1/fs/secret.txt", key1, strings.NewReader("tenant1-data"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tenant1 write: expected 200, got %d", resp.StatusCode)
+	}
+
+	// Tenant 2 writes a different file
+	req = authedRequest(http.MethodPut, ts.URL+"/v1/fs/secret.txt", key2, strings.NewReader("tenant2-data"))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tenant2 write: expected 200, got %d", resp.StatusCode)
+	}
+
+	// Tenant 1 reads back their file — should see their own data
+	req = authedRequest(http.MethodGet, ts.URL+"/v1/fs/secret.txt", key1, nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tenant1 read: expected 200, got %d", resp.StatusCode)
+	}
+	if string(body) != "tenant1-data" {
+		t.Errorf("tenant1 read: got %q, want %q", body, "tenant1-data")
+	}
+
+	// Tenant 2 reads back their file — should see their own data
+	req = authedRequest(http.MethodGet, ts.URL+"/v1/fs/secret.txt", key2, nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tenant2 read: expected 200, got %d", resp.StatusCode)
+	}
+	if string(body) != "tenant2-data" {
+		t.Errorf("tenant2 read: got %q, want %q", body, "tenant2-data")
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,7 @@
 package server
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -494,7 +495,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	token := bearerToken(r)
-	if token != s.adminKey {
+	if subtle.ConstantTimeCompare([]byte(token), []byte(s.adminKey)) != 1 {
 		errJSON(w, http.StatusUnauthorized, "invalid admin key")
 		return
 	}
@@ -543,7 +544,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusInternalServerError, "provisioning failed")
 		return
 	}
-	if err := s.tenants.UpdateClusterInfo(t.ID, info.Host, info.Port, info.Username, passwordEnc, info.DBName); err != nil {
+	if err := s.tenants.UpdateClusterInfo(t.ID, info.Host, info.Port, info.Username, passwordEnc, info.DBName, info.TLSMode); err != nil {
 		log.Printf("provision: update cluster info: %v", err)
 		s.tenants.UpdateStatus(t.ID, tenant.StatusDeleted)
 		errJSON(w, http.StatusInternalServerError, "provisioning failed")
@@ -551,7 +552,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Step 5: Init schema on the new cluster
-	dsn := tenant.DSN(info.Host, info.Port, info.Username, info.Password, info.DBName)
+	dsn := tenant.DSN(info.Host, info.Port, info.Username, info.Password, info.DBName, info.TLSMode)
 	if err := s.provisioner.InitSchema(ctx, dsn); err != nil {
 		log.Printf("provision: init schema: %v", err)
 		s.tenants.UpdateStatus(t.ID, tenant.StatusDeleted)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,8 +35,12 @@ type Config struct {
 	// AdminKey protects /v1/provision. Required when Tenants is set.
 	AdminKey string
 
-	// LocalS3 is set when using local S3 for presigned URL handling.
+	// LocalS3 is set when using local S3 for presigned URL handling (single-tenant).
 	LocalS3 *s3client.LocalS3Client
+
+	// S3Dir is the base S3 directory for multi-tenant local S3.
+	// Per-tenant S3 dirs are created as subdirs. Only used in multi-tenant mode.
+	S3Dir string
 }
 
 type Server struct {
@@ -82,6 +86,30 @@ func New(cfg Config) *Server {
 	}
 	if local != nil {
 		mux.Handle("/s3/", http.StripPrefix("/s3", local.Handler()))
+	} else if cfg.S3Dir != "" && cfg.Pool != nil {
+		// Multi-tenant local S3: presigned URLs use /s3/{tenantID}/...
+		mux.Handle("/s3/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Extract tenant ID from path: /s3/{tenantID}/upload/... or /s3/{tenantID}/objects/...
+			rest := strings.TrimPrefix(r.URL.Path, "/s3/")
+			tenantID, sub, ok := strings.Cut(rest, "/")
+			if !ok || tenantID == "" {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			b := cfg.Pool.S3Backend(tenantID)
+			if b == nil || b.S3() == nil {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			localS3, ok := b.S3().(*s3client.LocalS3Client)
+			if !ok {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			// Rewrite path to strip /s3/{tenantID} prefix
+			r.URL.Path = "/" + sub
+			localS3.Handler().ServeHTTP(w, r)
+		}))
 	}
 
 	s.mux = mux

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,32 +11,106 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/s3client"
+	"github.com/mem9-ai/dat9/pkg/tenant"
 )
 
-type Server struct {
-	backend *backend.Dat9Backend
-	mux     *http.ServeMux
+// Config configures the server.
+type Config struct {
+	// Backend is the fallback backend for local dev mode (no multi-tenant).
+	// When Tenants is set, business routes use the tenant backend from context.
+	Backend *backend.Dat9Backend
+
+	// Multi-tenant fields. When Tenants is non-nil, auth is enforced.
+	Tenants     *tenant.Store
+	Pool        *tenant.Pool
+	Provisioner tenant.Provisioner
+
+	// AdminKey protects /v1/provision. Required when Tenants is set.
+	AdminKey string
+
+	// LocalS3 is set when using local S3 for presigned URL handling.
+	LocalS3 *s3client.LocalS3Client
 }
 
-func New(b *backend.Dat9Backend) *Server {
-	s := &Server{backend: b}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/fs/", s.handleFS)
-	mux.HandleFunc("/v1/uploads", s.handleUploads)
-	mux.HandleFunc("/v1/uploads/", s.handleUploadAction)
+type Server struct {
+	fallback    *backend.Dat9Backend // nil in multi-tenant mode with no fallback
+	tenants     *tenant.Store
+	pool        *tenant.Pool
+	provisioner tenant.Provisioner
+	adminKey    string
+	mux         *http.ServeMux
+}
 
-	// Register local S3 handler for presigned URL support in dev/test mode
-	if local, ok := b.S3().(*s3client.LocalS3Client); ok {
+func New(cfg Config) *Server {
+	s := &Server{
+		fallback:    cfg.Backend,
+		tenants:     cfg.Tenants,
+		pool:        cfg.Pool,
+		provisioner: cfg.Provisioner,
+		adminKey:    cfg.AdminKey,
+	}
+	mux := http.NewServeMux()
+
+	// Business routes — require tenant backend
+	var businessHandler http.Handler = http.HandlerFunc(s.handleBusiness)
+	if cfg.Tenants != nil && cfg.Pool != nil {
+		businessHandler = tenantAuthMiddleware(cfg.Tenants, cfg.Pool, businessHandler)
+	} else if cfg.Backend != nil {
+		// Local dev mode: inject fallback backend for all requests
+		businessHandler = injectBackendMiddleware(cfg.Backend, businessHandler)
+	}
+	mux.Handle("/v1/fs/", businessHandler)
+	mux.Handle("/v1/uploads", businessHandler)
+	mux.Handle("/v1/uploads/", businessHandler)
+
+	// Control plane routes (no tenant auth, admin key protected)
+	mux.HandleFunc("/v1/provision", s.handleProvision)
+
+	// Local S3 presigned URL handler (no auth — URLs are HMAC-signed)
+	local := cfg.LocalS3
+	if local == nil && cfg.Backend != nil {
+		if l, ok := cfg.Backend.S3().(*s3client.LocalS3Client); ok {
+			local = l
+		}
+	}
+	if local != nil {
 		mux.Handle("/s3/", http.StripPrefix("/s3", local.Handler()))
 	}
 
 	s.mux = mux
 	return s
+}
+
+// injectBackendMiddleware injects a fixed backend into context (local dev mode).
+func injectBackendMiddleware(b *backend.Dat9Backend, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(withBackend(r.Context(), b)))
+	})
+}
+
+// handleBusiness dispatches to the appropriate handler based on path.
+func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasPrefix(r.URL.Path, "/v1/fs/"):
+		s.handleFS(w, r)
+	case r.URL.Path == "/v1/uploads":
+		s.handleUploads(w, r)
+	case strings.HasPrefix(r.URL.Path, "/v1/uploads/"):
+		s.handleUploadAction(w, r)
+	default:
+		errJSON(w, http.StatusNotFound, "not found")
+	}
+}
+
+// backendFromRequest extracts the tenant backend from context.
+func backendFromRequest(r *http.Request) *backend.Dat9Backend {
+	return BackendFromCtx(r.Context())
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -78,9 +152,10 @@ func (s *Server) handleFS(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string) {
+	b := backendFromRequest(r)
 	// Check if this is an S3-stored file — redirect to presigned URL
-	if s.backend.S3() != nil {
-		url, err := s.backend.PresignGetObject(r.Context(), path)
+	if b.S3() != nil {
+		url, err := b.PresignGetObject(r.Context(), path)
 		if err == nil {
 			http.Redirect(w, r, url, http.StatusFound)
 			return
@@ -88,7 +163,7 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 		// Not an S3 file or error — fall through to local read
 	}
 
-	data, err := s.backend.Read(path, 0, -1)
+	data, err := b.Read(path, 0, -1)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, err.Error())
@@ -103,7 +178,8 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 }
 
 func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string) {
-	entries, err := s.backend.ReadDir(path)
+	b := backendFromRequest(r)
+	entries, err := b.ReadDir(path)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, err.Error())
@@ -133,14 +209,15 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 }
 
 func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string) {
+	b := backendFromRequest(r)
 	// Bifurcate by size. Prefer X-Dat9-Content-Length because Go's net/http
 	// normalizes Content-Length to 0 when the request body is http.NoBody.
 	cl := r.ContentLength
 	if h := r.Header.Get("X-Dat9-Content-Length"); h != "" {
 		cl, _ = strconv.ParseInt(h, 10, 64)
 	}
-	if cl > 0 && s.backend.IsLargeFile(cl) {
-		plan, err := s.backend.InitiateUpload(r.Context(), path, cl)
+	if cl > 0 && b.IsLargeFile(cl) {
+		plan, err := b.InitiateUpload(r.Context(), path, cl)
 		if err != nil {
 			if errors.Is(err, meta.ErrUploadConflict) {
 				errJSON(w, http.StatusConflict, err.Error())
@@ -162,7 +239,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		return
 	}
 
-	_, err = s.backend.Write(path, data, 0,
+	_, err = b.Write(path, data, 0,
 		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate)
 	if err != nil {
 		errJSON(w, http.StatusInternalServerError, err.Error())
@@ -174,8 +251,9 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 }
 
 func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string) {
+	b := backendFromRequest(r)
 	// Single call to store.Stat to get both FileInfo and revision
-	nf, err := s.backend.Store().Stat(path)
+	nf, err := b.Store().Stat(path)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			w.WriteHeader(http.StatusNotFound)
@@ -200,13 +278,14 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 }
 
 func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path string) {
+	b := backendFromRequest(r)
 	recursive := r.URL.Query().Has("recursive")
 
 	var err error
 	if recursive {
-		err = s.backend.RemoveAll(path)
+		err = b.RemoveAll(path)
 	} else {
-		err = s.backend.Remove(path)
+		err = b.Remove(path)
 	}
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
@@ -228,7 +307,7 @@ func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath stri
 		return
 	}
 
-	if err := s.backend.CopyFile(srcPath, dstPath); err != nil {
+	if err := backendFromRequest(r).CopyFile(srcPath, dstPath); err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
@@ -248,7 +327,7 @@ func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath st
 		return
 	}
 
-	if err := s.backend.Rename(oldPath, newPath); err != nil {
+	if err := backendFromRequest(r).Rename(oldPath, newPath); err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
@@ -262,7 +341,7 @@ func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath st
 }
 
 func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string) {
-	if err := s.backend.Mkdir(path, 0o755); err != nil {
+	if err := backendFromRequest(r).Mkdir(path, 0o755); err != nil {
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -287,7 +366,7 @@ func (s *Server) handleUploads(w http.ResponseWriter, r *http.Request) {
 		status = "UPLOADING"
 	}
 
-	uploads, err := s.backend.ListUploads(path, meta.UploadStatus(status))
+	uploads, err := backendFromRequest(r).ListUploads(path, meta.UploadStatus(status))
 	if err != nil {
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
@@ -348,7 +427,7 @@ func (s *Server) handleUploadAction(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, uploadID string) {
-	if err := s.backend.ConfirmUpload(r.Context(), uploadID); err != nil {
+	if err := backendFromRequest(r).ConfirmUpload(r.Context(), uploadID); err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
@@ -369,7 +448,7 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 }
 
 func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uploadID string) {
-	plan, err := s.backend.ResumeUpload(r.Context(), uploadID)
+	plan, err := backendFromRequest(r).ResumeUpload(r.Context(), uploadID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, err.Error())
@@ -391,7 +470,7 @@ func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uplo
 }
 
 func (s *Server) handleUploadAbort(w http.ResponseWriter, r *http.Request, uploadID string) {
-	if err := s.backend.AbortUpload(r.Context(), uploadID); err != nil {
+	if err := backendFromRequest(r).AbortUpload(r.Context(), uploadID); err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
@@ -401,6 +480,100 @@ func (s *Server) handleUploadAbort(w http.ResponseWriter, r *http.Request, uploa
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// handleProvision handles POST /v1/provision (admin-key protected).
+// Flow: validate admin key → generate API key → provision cluster → init schema → persist tenant → return key.
+func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if s.adminKey == "" || s.provisioner == nil || s.tenants == nil {
+		errJSON(w, http.StatusNotFound, "provisioning not enabled")
+		return
+	}
+	token := bearerToken(r)
+	if token != s.adminKey {
+		errJSON(w, http.StatusUnauthorized, "invalid admin key")
+		return
+	}
+
+	ctx := r.Context()
+
+	// Step 1: Generate API key
+	rawKey, prefix, hash, err := tenant.GenerateAPIKey()
+	if err != nil {
+		log.Printf("provision: generate key: %v", err)
+		errJSON(w, http.StatusInternalServerError, "key generation failed")
+		return
+	}
+
+	// Step 2: Create tenant record in provisioning state
+	now := time.Now().UTC()
+	t := &tenant.Tenant{
+		ID:              hash[:16], // use first 16 chars of hash as tenant ID
+		APIKeyPrefix:    prefix,
+		APIKeyHash:      hash,
+		Status:          tenant.StatusProvisioning,
+		ProvisionerType: s.provisioner.ProviderType(),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := s.tenants.Insert(t); err != nil {
+		log.Printf("provision: insert tenant: %v", err)
+		errJSON(w, http.StatusInternalServerError, "provisioning failed")
+		return
+	}
+
+	// Step 3: Provision cluster
+	info, err := s.provisioner.Provision(ctx)
+	if err != nil {
+		log.Printf("provision: cluster: %v", err)
+		s.tenants.UpdateStatus(t.ID, tenant.StatusDeleted)
+		errJSON(w, http.StatusInternalServerError, "cluster provisioning failed")
+		return
+	}
+
+	// Step 4: Encrypt password and update tenant with cluster info
+	passwordEnc, err := s.tenants.EncryptPassword(info.Password)
+	if err != nil {
+		log.Printf("provision: encrypt password: %v", err)
+		s.tenants.UpdateStatus(t.ID, tenant.StatusDeleted)
+		errJSON(w, http.StatusInternalServerError, "provisioning failed")
+		return
+	}
+	if err := s.tenants.UpdateClusterInfo(t.ID, info.Host, info.Port, info.Username, passwordEnc, info.DBName); err != nil {
+		log.Printf("provision: update cluster info: %v", err)
+		s.tenants.UpdateStatus(t.ID, tenant.StatusDeleted)
+		errJSON(w, http.StatusInternalServerError, "provisioning failed")
+		return
+	}
+
+	// Step 5: Init schema on the new cluster
+	dsn := tenant.DSN(info.Host, info.Port, info.Username, info.Password, info.DBName)
+	if err := s.provisioner.InitSchema(ctx, dsn); err != nil {
+		log.Printf("provision: init schema: %v", err)
+		s.tenants.UpdateStatus(t.ID, tenant.StatusDeleted)
+		errJSON(w, http.StatusInternalServerError, "schema initialization failed")
+		return
+	}
+
+	// Step 6: Mark tenant active
+	if err := s.tenants.UpdateStatus(t.ID, tenant.StatusActive); err != nil {
+		log.Printf("provision: activate tenant: %v", err)
+		errJSON(w, http.StatusInternalServerError, "provisioning failed")
+		return
+	}
+
+	// Return the API key (only time it's exposed in plaintext)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]string{
+		"api_key":   rawKey,
+		"tenant_id": t.ID,
+		"status":    "active",
+	})
 }
 
 func errJSON(w http.ResponseWriter, code int, msg string) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -34,7 +34,7 @@ func newTestServer(t *testing.T) *Server {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return New(b)
+	return New(Config{Backend: b})
 }
 func TestWriteAndRead(t *testing.T) {
 	s := newTestServer(t)
@@ -222,7 +222,10 @@ func TestNotFound(t *testing.T) {
 	ts := httptest.NewServer(s)
 	defer ts.Close()
 
-	resp, _ := http.Get(ts.URL + "/v1/fs/nonexistent.txt")
+	resp, err := http.Get(ts.URL + "/v1/fs/nonexistent.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 404 {
 		t.Errorf("expected 404, got %d", resp.StatusCode)

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -51,7 +51,7 @@ func newTestServerWithS3(t *testing.T) (*Server, *s3client.LocalS3Client) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return New(b), s3c
+	return New(Config{Backend: b}), s3c
 }
 
 func TestLargeFilePut202(t *testing.T) {
@@ -120,7 +120,7 @@ func TestUploadCompleteEndpoint(t *testing.T) {
 	resp.Body.Close()
 
 	// Get the upload to find s3_upload_id
-	upload, _ := s.backend.GetUpload(plan.UploadID)
+	upload, _ := s.fallback.GetUpload(plan.UploadID)
 
 	// Upload all parts via S3 client directly
 	for _, p := range plan.Parts {
@@ -161,7 +161,7 @@ func TestUploadResumeEndpoint(t *testing.T) {
 	json.NewDecoder(resp.Body).Decode(&plan)
 	resp.Body.Close()
 
-	upload, _ := s.backend.GetUpload(plan.UploadID)
+	upload, _ := s.fallback.GetUpload(plan.UploadID)
 
 	// Upload only part 1
 	s3c.UploadPart(context.Background(), upload.S3UploadID, 1, bytes.NewReader(make([]byte, s3client.PartSize)))
@@ -220,7 +220,7 @@ func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 		t.Fatalf("initiate overwrite: expected 202, got %d", resp.StatusCode)
 	}
 
-	upload, err := s.backend.GetUpload(plan.UploadID)
+	upload, err := s.fallback.GetUpload(plan.UploadID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +246,7 @@ func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 		t.Fatalf("complete overwrite: expected 200, got %d", resp.StatusCode)
 	}
 
-	nf, err := s.backend.Store().Stat("/overwrite.bin")
+	nf, err := s.fallback.Store().Stat("/overwrite.bin")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,7 +350,7 @@ func TestAbortUploadEndpoint(t *testing.T) {
 	}
 
 	// Verify upload is aborted
-	upload, _ := s.backend.GetUpload(plan.UploadID)
+	upload, _ := s.fallback.GetUpload(plan.UploadID)
 	if upload.Status != meta.UploadAborted {
 		t.Errorf("expected ABORTED, got %s", upload.Status)
 	}

--- a/pkg/tenant/apikey.go
+++ b/pkg/tenant/apikey.go
@@ -1,0 +1,34 @@
+package tenant
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+const (
+	apiKeyPrefix = "dat9_"
+	apiKeyBytes  = 32 // 256-bit random key
+)
+
+// GenerateAPIKey creates a new API key with format "dat9_<hex>".
+// Returns (rawKey, prefix, sha256Hash).
+// The raw key should be returned to the caller once and never stored.
+func GenerateAPIKey() (raw, prefix, hash string, err error) {
+	b := make([]byte, apiKeyBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", "", fmt.Errorf("generate API key: %w", err)
+	}
+	raw = apiKeyPrefix + hex.EncodeToString(b)
+	prefix = raw[:8]
+	h := sha256.Sum256([]byte(raw))
+	hash = hex.EncodeToString(h[:])
+	return raw, prefix, hash, nil
+}
+
+// HashAPIKey computes the SHA-256 hex hash of a raw API key for lookup.
+func HashAPIKey(raw string) string {
+	h := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(h[:])
+}

--- a/pkg/tenant/encrypt.go
+++ b/pkg/tenant/encrypt.go
@@ -1,0 +1,48 @@
+package tenant
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+// Encryptor provides AES-256-GCM encryption for tenant DB passwords.
+type Encryptor struct {
+	gcm cipher.AEAD
+}
+
+// NewEncryptor creates an Encryptor from a 32-byte master key.
+func NewEncryptor(masterKey []byte) (*Encryptor, error) {
+	if len(masterKey) != 32 {
+		return nil, fmt.Errorf("master key must be 32 bytes, got %d", len(masterKey))
+	}
+	block, err := aes.NewCipher(masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	return &Encryptor{gcm: gcm}, nil
+}
+
+// Encrypt returns nonce+ciphertext.
+func (e *Encryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, e.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	return e.gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Decrypt expects nonce+ciphertext as produced by Encrypt.
+func (e *Encryptor) Decrypt(ciphertext []byte) ([]byte, error) {
+	ns := e.gcm.NonceSize()
+	if len(ciphertext) < ns {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+	return e.gcm.Open(nil, ciphertext[:ns], ciphertext[ns:], nil)
+}

--- a/pkg/tenant/encrypt_test.go
+++ b/pkg/tenant/encrypt_test.go
@@ -1,0 +1,64 @@
+package tenant
+
+import (
+	"crypto/rand"
+	"testing"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	enc, err := NewEncryptor(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext := "my-secret-password"
+	ct, err := enc.Encrypt([]byte(plaintext))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := enc.Decrypt(ct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != plaintext {
+		t.Errorf("got %q, want %q", got, plaintext)
+	}
+}
+
+func TestEncryptorBadKeySize(t *testing.T) {
+	_, err := NewEncryptor([]byte("too-short"))
+	if err == nil {
+		t.Error("expected error for short key")
+	}
+}
+
+func TestDecryptBadCiphertext(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+	enc, _ := NewEncryptor(key)
+
+	_, err := enc.Decrypt([]byte("short"))
+	if err == nil {
+		t.Error("expected error for short ciphertext")
+	}
+}
+
+func TestDecryptWrongKey(t *testing.T) {
+	key1 := make([]byte, 32)
+	key2 := make([]byte, 32)
+	rand.Read(key1)
+	rand.Read(key2)
+
+	enc1, _ := NewEncryptor(key1)
+	enc2, _ := NewEncryptor(key2)
+
+	ct, _ := enc1.Encrypt([]byte("secret"))
+	_, err := enc2.Decrypt(ct)
+	if err == nil {
+		t.Error("expected error decrypting with wrong key")
+	}
+}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -113,6 +113,17 @@ func (p *Pool) Get(t *Tenant) (*backend.Dat9Backend, error) {
 	return b, nil
 }
 
+// S3Backend returns the cached backend's S3 client for a tenant, if available.
+// Returns nil if the tenant is not cached or has no S3 client.
+func (p *Pool) S3Backend(tenantID string) *backend.Dat9Backend {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if elem, ok := p.items[tenantID]; ok {
+		return elem.Value.(*poolEntry).backend
+	}
+	return nil
+}
+
 // Evict removes a tenant's cached backend and closes its connections.
 func (p *Pool) Evict(tenantID string) {
 	p.mu.Lock()
@@ -163,7 +174,7 @@ func (p *Pool) createBackend(t *Tenant) (*backend.Dat9Backend, *meta.Store, erro
 	blobDir := p.cfg.BlobDir + "/" + t.ID
 	if p.cfg.S3Dir != "" {
 		s3Dir := p.cfg.S3Dir + "/" + t.ID
-		s3BaseURL := p.cfg.PublicURL + "/s3"
+		s3BaseURL := p.cfg.PublicURL + "/s3/" + t.ID
 		s3c, err := s3client.NewLocal(s3Dir, s3BaseURL)
 		if err != nil {
 			store.Close()

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -154,7 +154,7 @@ func (p *Pool) createBackend(t *Tenant) (*backend.Dat9Backend, *meta.Store, erro
 		return nil, nil, fmt.Errorf("decrypt password: %w", err)
 	}
 
-	dsn := DSN(t.DBHost, t.DBPort, t.DBUser, string(password), t.DBName)
+	dsn := DSN(t.DBHost, t.DBPort, t.DBUser, string(password), t.DBName, t.DBTLS)
 	store, err := meta.Open(dsn)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open tenant db: %w", err)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -1,0 +1,186 @@
+package tenant
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+
+	"github.com/mem9-ai/dat9/pkg/backend"
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/s3client"
+)
+
+// PoolConfig configures the tenant backend pool.
+type PoolConfig struct {
+	MaxTenants int    // max cached backends (LRU eviction beyond this)
+	BlobDir    string // base blob directory; per-tenant subdirs are created
+	S3Dir      string // base S3 directory for local S3 (empty = no S3)
+	PublicURL  string // public base URL for presigned URLs
+}
+
+// Pool caches per-tenant Dat9Backend instances with LRU eviction.
+// Revoked/suspended tenants are rejected and evicted.
+type Pool struct {
+	mu      sync.Mutex
+	cfg     PoolConfig
+	enc     *Encryptor
+	items   map[string]*list.Element // tenantID → LRU element
+	order   *list.List               // front = most recently used
+	maxSize int
+}
+
+type poolEntry struct {
+	tenantID string
+	backend  *backend.Dat9Backend
+	store    *meta.Store
+	status   Status // cached status for fast rejection
+}
+
+// NewPool creates a tenant backend pool.
+func NewPool(cfg PoolConfig, enc *Encryptor) *Pool {
+	maxSize := cfg.MaxTenants
+	if maxSize <= 0 {
+		maxSize = 128
+	}
+	return &Pool{
+		cfg:     cfg,
+		enc:     enc,
+		items:   make(map[string]*list.Element),
+		order:   list.New(),
+		maxSize: maxSize,
+	}
+}
+
+// Get returns a cached backend for the tenant, or creates one.
+// Returns error if the tenant is not active.
+func (p *Pool) Get(t *Tenant) (*backend.Dat9Backend, error) {
+	if t.Status != StatusActive {
+		// Reject and evict if cached
+		p.Evict(t.ID)
+		return nil, fmt.Errorf("tenant %s status: %s", t.ID, t.Status)
+	}
+
+	p.mu.Lock()
+	if elem, ok := p.items[t.ID]; ok {
+		entry := elem.Value.(*poolEntry)
+		// Check if tenant was revoked since cached
+		if entry.status != StatusActive {
+			p.removeLocked(elem)
+			p.mu.Unlock()
+			return nil, fmt.Errorf("tenant %s status: %s", t.ID, entry.status)
+		}
+		p.order.MoveToFront(elem)
+		b := entry.backend
+		p.mu.Unlock()
+		return b, nil
+	}
+	p.mu.Unlock()
+
+	// Create new backend outside lock
+	b, store, err := p.createBackend(t)
+	if err != nil {
+		return nil, fmt.Errorf("create backend for tenant %s: %w", t.ID, err)
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Double-check: another goroutine may have created it
+	if elem, ok := p.items[t.ID]; ok {
+		p.order.MoveToFront(elem)
+		// Close the one we just created
+		store.Close()
+		return elem.Value.(*poolEntry).backend, nil
+	}
+
+	entry := &poolEntry{
+		tenantID: t.ID,
+		backend:  b,
+		store:    store,
+		status:   t.Status,
+	}
+	elem := p.order.PushFront(entry)
+	p.items[t.ID] = elem
+
+	// Evict LRU if over capacity
+	for p.order.Len() > p.maxSize {
+		oldest := p.order.Back()
+		if oldest != nil {
+			p.removeLocked(oldest)
+		}
+	}
+
+	return b, nil
+}
+
+// Evict removes a tenant's cached backend and closes its connections.
+func (p *Pool) Evict(tenantID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if elem, ok := p.items[tenantID]; ok {
+		p.removeLocked(elem)
+	}
+}
+
+// Invalidate marks a tenant as non-active in the cache, causing the next
+// Get to reject it. Also evicts the cached backend.
+func (p *Pool) Invalidate(tenantID string) {
+	p.Evict(tenantID)
+}
+
+// Close evicts all cached backends and closes their connections.
+func (p *Pool) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for p.order.Len() > 0 {
+		p.removeLocked(p.order.Back())
+	}
+}
+
+func (p *Pool) removeLocked(elem *list.Element) {
+	entry := elem.Value.(*poolEntry)
+	p.order.Remove(elem)
+	delete(p.items, entry.tenantID)
+	// Gracefully close DB connection
+	if entry.store != nil {
+		entry.store.Close()
+	}
+}
+
+func (p *Pool) createBackend(t *Tenant) (*backend.Dat9Backend, *meta.Store, error) {
+	// Decrypt password
+	password, err := p.enc.Decrypt(t.DBPasswordEnc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decrypt password: %w", err)
+	}
+
+	dsn := DSN(t.DBHost, t.DBPort, t.DBUser, string(password), t.DBName)
+	store, err := meta.Open(dsn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open tenant db: %w", err)
+	}
+
+	blobDir := p.cfg.BlobDir + "/" + t.ID
+	if p.cfg.S3Dir != "" {
+		s3Dir := p.cfg.S3Dir + "/" + t.ID
+		s3BaseURL := p.cfg.PublicURL + "/s3"
+		s3c, err := s3client.NewLocal(s3Dir, s3BaseURL)
+		if err != nil {
+			store.Close()
+			return nil, nil, fmt.Errorf("create s3 client: %w", err)
+		}
+		b, err := backend.NewWithS3(store, blobDir, s3c)
+		if err != nil {
+			store.Close()
+			return nil, nil, err
+		}
+		return b, store, nil
+	}
+
+	b, err := backend.New(store, blobDir)
+	if err != nil {
+		store.Close()
+		return nil, nil, err
+	}
+	return b, store, nil
+}

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -10,6 +10,7 @@ type ClusterInfo struct {
 	Username  string
 	Password  string // plaintext — encrypt before storing
 	DBName    string
+	TLSMode   string // "" = no TLS, "true" = system CA, "skip-verify", or registered config name
 }
 
 // Provisioner abstracts cluster acquisition and schema initialization.

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -1,0 +1,27 @@
+package tenant
+
+import "context"
+
+// ClusterInfo holds connection details for a newly provisioned cluster.
+type ClusterInfo struct {
+	ClusterID string
+	Host      string
+	Port      int
+	Username  string
+	Password  string // plaintext — encrypt before storing
+	DBName    string
+}
+
+// Provisioner abstracts cluster acquisition and schema initialization.
+// Implementations include TiDB Cloud Starter and db9.
+type Provisioner interface {
+	// Provision acquires a new cluster and returns its connection info.
+	Provision(ctx context.Context) (*ClusterInfo, error)
+
+	// InitSchema runs dat9 schema migrations on the provisioned cluster.
+	// The dsn is built from ClusterInfo by the caller.
+	InitSchema(ctx context.Context, dsn string) error
+
+	// ProviderType returns the provisioner identifier (e.g. "tidb_starter", "db9").
+	ProviderType() string
+}

--- a/pkg/tenant/starter.go
+++ b/pkg/tenant/starter.go
@@ -1,0 +1,157 @@
+package tenant
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/meta"
+)
+
+// TiDB Cloud Starter API configuration environment variables.
+const (
+	envTiDBAPIKey    = "DAT9_TIDBCLOUD_API_KEY"    // public key for digest auth
+	envTiDBAPISecret = "DAT9_TIDBCLOUD_API_SECRET" // private key for digest auth
+	envTiDBPoolID    = "DAT9_TIDBCLOUD_POOL_ID"    // pre-provisioned cluster pool ID
+
+	tidbStarterBaseURL = "https://serverless.tidbapi.com"
+)
+
+// TiDBStarterProvisioner acquires clusters from the TiDB Cloud Starter pool.
+type TiDBStarterProvisioner struct {
+	apiKey    string
+	apiSecret string
+	poolID    string
+	baseURL   string
+	client    *http.Client
+}
+
+// NewTiDBStarterFromEnv creates a TiDB Starter provisioner from environment variables.
+func NewTiDBStarterFromEnv() (*TiDBStarterProvisioner, error) {
+	apiKey := os.Getenv(envTiDBAPIKey)
+	apiSecret := os.Getenv(envTiDBAPISecret)
+	poolID := os.Getenv(envTiDBPoolID)
+
+	if apiKey == "" || apiSecret == "" {
+		return nil, fmt.Errorf("%s and %s must be set", envTiDBAPIKey, envTiDBAPISecret)
+	}
+	if poolID == "" {
+		return nil, fmt.Errorf("%s must be set", envTiDBPoolID)
+	}
+
+	return &TiDBStarterProvisioner{
+		apiKey:    apiKey,
+		apiSecret: apiSecret,
+		poolID:    poolID,
+		baseURL:   tidbStarterBaseURL,
+		client:    &http.Client{Timeout: 60 * time.Second},
+	}, nil
+}
+
+func (p *TiDBStarterProvisioner) ProviderType() string { return "tidb_starter" }
+
+// Provision takes over a pre-provisioned cluster from the TiDB Cloud pool.
+func (p *TiDBStarterProvisioner) Provision(ctx context.Context) (*ClusterInfo, error) {
+	password, err := generateRandomPassword(16)
+	if err != nil {
+		return nil, fmt.Errorf("generate password: %w", err)
+	}
+
+	reqBody := takeoverRequest{
+		PoolID:       p.poolID,
+		RootPassword: password,
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := p.baseURL + "/v1beta1/clusters:takeoverFromPool"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(p.apiKey, p.apiSecret)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("tidb starter API call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("tidb starter API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result takeoverResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	host, port := parseEndpoint(result.Endpoints.Public)
+
+	return &ClusterInfo{
+		ClusterID: result.ClusterID,
+		Host:      host,
+		Port:      port,
+		Username:  result.UserPrefix + ".root",
+		Password:  password,
+		DBName:    "test", // TiDB Starter default database
+	}, nil
+}
+
+// InitSchema runs dat9 meta store migrations on the provisioned cluster.
+// meta.Open internally runs all table creation statements.
+func (p *TiDBStarterProvisioner) InitSchema(_ context.Context, dsn string) error {
+	store, err := meta.Open(dsn)
+	if err != nil {
+		return fmt.Errorf("init schema: %w", err)
+	}
+	store.Close()
+	return nil
+}
+
+// --- request/response types ---
+
+type takeoverRequest struct {
+	PoolID       string `json:"pool_id"`
+	RootPassword string `json:"root_password"`
+}
+
+type takeoverResponse struct {
+	ClusterID  string `json:"cluster_id"`
+	UserPrefix string `json:"user_prefix"`
+	Endpoints  struct {
+		Public string `json:"public"` // "gateway01.us-east-1.prod.aws.tidbcloud.com:4000"
+	} `json:"endpoints"`
+}
+
+// --- helpers ---
+
+func generateRandomPassword(length int) (string, error) {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func parseEndpoint(endpoint string) (host string, port int) {
+	host = endpoint
+	port = 4000 // TiDB default
+	if idx := strings.LastIndex(endpoint, ":"); idx >= 0 {
+		host = endpoint[:idx]
+		fmt.Sscanf(endpoint[idx+1:], "%d", &port)
+	}
+	return
+}

--- a/pkg/tenant/starter.go
+++ b/pkg/tenant/starter.go
@@ -106,7 +106,8 @@ func (p *TiDBStarterProvisioner) Provision(ctx context.Context) (*ClusterInfo, e
 		Port:      port,
 		Username:  result.UserPrefix + ".root",
 		Password:  password,
-		DBName:    "test", // TiDB Starter default database
+		DBName:    "test",            // TiDB Starter default database
+		TLSMode:   TLSConfigName(),   // TiDB Cloud requires TLS
 	}, nil
 }
 

--- a/pkg/tenant/starter_test.go
+++ b/pkg/tenant/starter_test.go
@@ -1,0 +1,41 @@
+package tenant
+
+import "testing"
+
+// Compile-time check: TiDBStarterProvisioner implements Provisioner.
+var _ Provisioner = (*TiDBStarterProvisioner)(nil)
+
+func TestParseEndpoint(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantHost string
+		wantPort int
+	}{
+		{"gateway01.us-east-1.prod.aws.tidbcloud.com:4000", "gateway01.us-east-1.prod.aws.tidbcloud.com", 4000},
+		{"host.example.com:3306", "host.example.com", 3306},
+		{"host.example.com", "host.example.com", 4000},
+		{"", "", 4000},
+	}
+	for _, tt := range tests {
+		host, port := parseEndpoint(tt.input)
+		if host != tt.wantHost || port != tt.wantPort {
+			t.Errorf("parseEndpoint(%q) = (%q, %d), want (%q, %d)", tt.input, host, port, tt.wantHost, tt.wantPort)
+		}
+	}
+}
+
+func TestGenerateRandomPassword(t *testing.T) {
+	pw, err := generateRandomPassword(16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pw) != 32 { // 16 bytes → 32 hex chars
+		t.Errorf("expected 32 chars, got %d: %q", len(pw), pw)
+	}
+
+	// Should be unique
+	pw2, _ := generateRandomPassword(16)
+	if pw == pw2 {
+		t.Error("two passwords should not be equal")
+	}
+}

--- a/pkg/tenant/store.go
+++ b/pkg/tenant/store.go
@@ -174,12 +174,14 @@ func (s *Store) List(status Status) ([]*Tenant, error) {
 	if status == "" {
 		rows, err = s.db.Query(`SELECT id, api_key_prefix, api_key_hash, status,
 			db_host, db_port, db_user, db_password_enc, db_name,
+			db_tls, db_params,
 			s3_bucket, s3_key_prefix, cluster_id, provisioner_type,
 			created_at, updated_at
 			FROM tenants ORDER BY created_at`)
 	} else {
 		rows, err = s.db.Query(`SELECT id, api_key_prefix, api_key_hash, status,
 			db_host, db_port, db_user, db_password_enc, db_name,
+			db_tls, db_params,
 			s3_bucket, s3_key_prefix, cluster_id, provisioner_type,
 			created_at, updated_at
 			FROM tenants WHERE status = ? ORDER BY created_at`, status)

--- a/pkg/tenant/store.go
+++ b/pkg/tenant/store.go
@@ -1,0 +1,242 @@
+package tenant
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var (
+	ErrNotFound  = errors.New("tenant not found")
+	ErrDuplicate = errors.New("duplicate API key")
+)
+
+// Store manages tenants in the control plane database.
+// This is separate from the per-tenant meta.Store.
+type Store struct {
+	db  *sql.DB
+	enc *Encryptor
+}
+
+// OpenStore opens the control plane DB and runs migrations.
+func OpenStore(dsn string, enc *Encryptor) (*Store, error) {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open control plane db: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("ping control plane db: %w", err)
+	}
+	s := &Store{db: db, enc: enc}
+	if err := s.migrate(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate control plane: %w", err)
+	}
+	return s, nil
+}
+
+func (s *Store) Close() error { return s.db.Close() }
+func (s *Store) DB() *sql.DB  { return s.db }
+
+func (s *Store) migrate() error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS tenants (
+			id               VARCHAR(64) PRIMARY KEY,
+			api_key_prefix   VARCHAR(16) NOT NULL,
+			api_key_hash     VARCHAR(128) NOT NULL,
+			status           VARCHAR(32) NOT NULL DEFAULT 'provisioning',
+			db_host          VARCHAR(255) NOT NULL DEFAULT '',
+			db_port          INT NOT NULL DEFAULT 4000,
+			db_user          VARCHAR(255) NOT NULL DEFAULT '',
+			db_password_enc  VARBINARY(512),
+			db_name          VARCHAR(255) NOT NULL DEFAULT '',
+			s3_bucket        VARCHAR(255) NOT NULL DEFAULT '',
+			s3_key_prefix    VARCHAR(255) NOT NULL DEFAULT '',
+			cluster_id       VARCHAR(255) NOT NULL DEFAULT '',
+			provisioner_type VARCHAR(64) NOT NULL DEFAULT '',
+			created_at       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
+		)`,
+		`CREATE UNIQUE INDEX idx_tenant_api_key_hash ON tenants(api_key_hash)`,
+		`CREATE INDEX idx_tenant_status ON tenants(status)`,
+		`CREATE INDEX idx_tenant_prefix ON tenants(api_key_prefix)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.Exec(stmt); err != nil {
+			if isIndexStmt(stmt) && isDuplicateIndex(err) {
+				continue
+			}
+			snippet := stmt
+			if len(snippet) > 60 {
+				snippet = snippet[:60]
+			}
+			return fmt.Errorf("exec %q: %w", snippet, err)
+		}
+	}
+	return nil
+}
+
+// Insert persists a new tenant. The caller must set all fields including
+// the encrypted password (via EncryptPassword).
+func (s *Store) Insert(t *Tenant) error {
+	_, err := s.db.Exec(`INSERT INTO tenants
+		(id, api_key_prefix, api_key_hash, status, db_host, db_port, db_user,
+		 db_password_enc, db_name, s3_bucket, s3_key_prefix, cluster_id,
+		 provisioner_type, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.ID, t.APIKeyPrefix, t.APIKeyHash, t.Status,
+		t.DBHost, t.DBPort, t.DBUser, t.DBPasswordEnc, t.DBName,
+		t.S3Bucket, t.S3KeyPrefix, t.ClusterID, t.ProvisionerType,
+		t.CreatedAt.UTC(), t.UpdatedAt.UTC())
+	if err != nil && isDuplicateEntry(err) {
+		return ErrDuplicate
+	}
+	return err
+}
+
+// GetByAPIKeyHash looks up a tenant by the SHA-256 hash of their API key.
+func (s *Store) GetByAPIKeyHash(hash string) (*Tenant, error) {
+	row := s.db.QueryRow(`SELECT id, api_key_prefix, api_key_hash, status,
+		db_host, db_port, db_user, db_password_enc, db_name,
+		s3_bucket, s3_key_prefix, cluster_id, provisioner_type,
+		created_at, updated_at
+		FROM tenants WHERE api_key_hash = ?`, hash)
+	return s.scanTenant(row)
+}
+
+// Get looks up a tenant by ID.
+func (s *Store) Get(id string) (*Tenant, error) {
+	row := s.db.QueryRow(`SELECT id, api_key_prefix, api_key_hash, status,
+		db_host, db_port, db_user, db_password_enc, db_name,
+		s3_bucket, s3_key_prefix, cluster_id, provisioner_type,
+		created_at, updated_at
+		FROM tenants WHERE id = ?`, id)
+	return s.scanTenant(row)
+}
+
+// UpdateStatus changes a tenant's status.
+func (s *Store) UpdateStatus(id string, status Status) error {
+	res, err := s.db.Exec(`UPDATE tenants SET status = ?, updated_at = ?
+		WHERE id = ?`, status, time.Now().UTC(), id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpdateClusterInfo sets the DB connection details after provisioning.
+func (s *Store) UpdateClusterInfo(id, host string, port int, user string, passwordEnc []byte, dbName string) error {
+	res, err := s.db.Exec(`UPDATE tenants SET db_host = ?, db_port = ?, db_user = ?,
+		db_password_enc = ?, db_name = ?, updated_at = ?
+		WHERE id = ?`, host, port, user, passwordEnc, dbName, time.Now().UTC(), id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// EncryptPassword encrypts a plaintext password using the store's encryptor.
+func (s *Store) EncryptPassword(plaintext string) ([]byte, error) {
+	return s.enc.Encrypt([]byte(plaintext))
+}
+
+// DecryptPassword decrypts an encrypted password from the DB.
+func (s *Store) DecryptPassword(ciphertext []byte) (string, error) {
+	b, err := s.enc.Decrypt(ciphertext)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// List returns all tenants, optionally filtered by status.
+func (s *Store) List(status Status) ([]*Tenant, error) {
+	var rows *sql.Rows
+	var err error
+	if status == "" {
+		rows, err = s.db.Query(`SELECT id, api_key_prefix, api_key_hash, status,
+			db_host, db_port, db_user, db_password_enc, db_name,
+			s3_bucket, s3_key_prefix, cluster_id, provisioner_type,
+			created_at, updated_at
+			FROM tenants ORDER BY created_at`)
+	} else {
+		rows, err = s.db.Query(`SELECT id, api_key_prefix, api_key_hash, status,
+			db_host, db_port, db_user, db_password_enc, db_name,
+			s3_bucket, s3_key_prefix, cluster_id, provisioner_type,
+			created_at, updated_at
+			FROM tenants WHERE status = ? ORDER BY created_at`, status)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var tenants []*Tenant
+	for rows.Next() {
+		t, err := s.scanTenantRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		tenants = append(tenants, t)
+	}
+	return tenants, rows.Err()
+}
+
+type scanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func (s *Store) scanTenant(sc scanner) (*Tenant, error) {
+	var t Tenant
+	var passwordEnc []byte
+	var createdAt, updatedAt time.Time
+	err := sc.Scan(&t.ID, &t.APIKeyPrefix, &t.APIKeyHash, &t.Status,
+		&t.DBHost, &t.DBPort, &t.DBUser, &passwordEnc, &t.DBName,
+		&t.S3Bucket, &t.S3KeyPrefix, &t.ClusterID, &t.ProvisionerType,
+		&createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	t.DBPasswordEnc = passwordEnc
+	t.CreatedAt = createdAt.UTC()
+	t.UpdatedAt = updatedAt.UTC()
+	return &t, nil
+}
+
+func (s *Store) scanTenantRows(rows *sql.Rows) (*Tenant, error) {
+	return s.scanTenant(rows)
+}
+
+// --- helpers ---
+
+func isIndexStmt(stmt string) bool {
+	s := strings.ToUpper(strings.TrimSpace(stmt))
+	return strings.HasPrefix(s, "CREATE INDEX") || strings.HasPrefix(s, "CREATE UNIQUE INDEX")
+}
+
+func isDuplicateIndex(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Duplicate key name")
+}
+
+func isDuplicateEntry(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Duplicate entry") || strings.Contains(msg, "UNIQUE constraint failed")
+}

--- a/pkg/tenant/store.go
+++ b/pkg/tenant/store.go
@@ -55,6 +55,8 @@ func (s *Store) migrate() error {
 			db_user          VARCHAR(255) NOT NULL DEFAULT '',
 			db_password_enc  VARBINARY(512),
 			db_name          VARCHAR(255) NOT NULL DEFAULT '',
+			db_tls           VARCHAR(64) NOT NULL DEFAULT '',
+			db_params        VARCHAR(512) NOT NULL DEFAULT '',
 			s3_bucket        VARCHAR(255) NOT NULL DEFAULT '',
 			s3_key_prefix    VARCHAR(255) NOT NULL DEFAULT '',
 			cluster_id       VARCHAR(255) NOT NULL DEFAULT '',
@@ -86,11 +88,12 @@ func (s *Store) migrate() error {
 func (s *Store) Insert(t *Tenant) error {
 	_, err := s.db.Exec(`INSERT INTO tenants
 		(id, api_key_prefix, api_key_hash, status, db_host, db_port, db_user,
-		 db_password_enc, db_name, s3_bucket, s3_key_prefix, cluster_id,
-		 provisioner_type, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 db_password_enc, db_name, db_tls, db_params, s3_bucket, s3_key_prefix,
+		 cluster_id, provisioner_type, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		t.ID, t.APIKeyPrefix, t.APIKeyHash, t.Status,
 		t.DBHost, t.DBPort, t.DBUser, t.DBPasswordEnc, t.DBName,
+		t.DBTLS, t.DBParams,
 		t.S3Bucket, t.S3KeyPrefix, t.ClusterID, t.ProvisionerType,
 		t.CreatedAt.UTC(), t.UpdatedAt.UTC())
 	if err != nil && isDuplicateEntry(err) {
@@ -103,6 +106,7 @@ func (s *Store) Insert(t *Tenant) error {
 func (s *Store) GetByAPIKeyHash(hash string) (*Tenant, error) {
 	row := s.db.QueryRow(`SELECT id, api_key_prefix, api_key_hash, status,
 		db_host, db_port, db_user, db_password_enc, db_name,
+		db_tls, db_params,
 		s3_bucket, s3_key_prefix, cluster_id, provisioner_type,
 		created_at, updated_at
 		FROM tenants WHERE api_key_hash = ?`, hash)
@@ -113,6 +117,7 @@ func (s *Store) GetByAPIKeyHash(hash string) (*Tenant, error) {
 func (s *Store) Get(id string) (*Tenant, error) {
 	row := s.db.QueryRow(`SELECT id, api_key_prefix, api_key_hash, status,
 		db_host, db_port, db_user, db_password_enc, db_name,
+		db_tls, db_params,
 		s3_bucket, s3_key_prefix, cluster_id, provisioner_type,
 		created_at, updated_at
 		FROM tenants WHERE id = ?`, id)
@@ -134,10 +139,10 @@ func (s *Store) UpdateStatus(id string, status Status) error {
 }
 
 // UpdateClusterInfo sets the DB connection details after provisioning.
-func (s *Store) UpdateClusterInfo(id, host string, port int, user string, passwordEnc []byte, dbName string) error {
+func (s *Store) UpdateClusterInfo(id, host string, port int, user string, passwordEnc []byte, dbName, dbTLS string) error {
 	res, err := s.db.Exec(`UPDATE tenants SET db_host = ?, db_port = ?, db_user = ?,
-		db_password_enc = ?, db_name = ?, updated_at = ?
-		WHERE id = ?`, host, port, user, passwordEnc, dbName, time.Now().UTC(), id)
+		db_password_enc = ?, db_name = ?, db_tls = ?, updated_at = ?
+		WHERE id = ?`, host, port, user, passwordEnc, dbName, dbTLS, time.Now().UTC(), id)
 	if err != nil {
 		return err
 	}
@@ -204,6 +209,7 @@ func (s *Store) scanTenant(sc scanner) (*Tenant, error) {
 	var createdAt, updatedAt time.Time
 	err := sc.Scan(&t.ID, &t.APIKeyPrefix, &t.APIKeyHash, &t.Status,
 		&t.DBHost, &t.DBPort, &t.DBUser, &passwordEnc, &t.DBName,
+		&t.DBTLS, &t.DBParams,
 		&t.S3Bucket, &t.S3KeyPrefix, &t.ClusterID, &t.ProvisionerType,
 		&createdAt, &updatedAt)
 	if err != nil {

--- a/pkg/tenant/store_test.go
+++ b/pkg/tenant/store_test.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"crypto/rand"
+	"strings"
 	"testing"
 	"time"
 )
@@ -203,10 +204,16 @@ func TestHashAPIKey(t *testing.T) {
 }
 
 func TestDSN(t *testing.T) {
-	got := DSN("db.example.com", 4000, "admin", "pass", "mydb")
+	got := DSN("db.example.com", 4000, "admin", "pass", "mydb", "")
 	want := "admin:pass@tcp(db.example.com:4000)/mydb?parseTime=true"
 	if got != want {
 		t.Errorf("DSN = %q, want %q", got, want)
+	}
+
+	// With TLS
+	gotTLS := DSN("cloud.tidbapi.com", 4000, "user", "pw", "test", TLSConfigName())
+	if !strings.Contains(gotTLS, "tls=tidb-cloud") {
+		t.Errorf("DSN with TLS = %q, want tls=tidb-cloud", gotTLS)
 	}
 }
 

--- a/pkg/tenant/store_test.go
+++ b/pkg/tenant/store_test.go
@@ -1,0 +1,215 @@
+package tenant
+
+import (
+	"crypto/rand"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	if testDSN == "" {
+		t.Skip("no test database available")
+	}
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := NewEncryptor(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := OpenStore(testDSN, enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		// Clean up test data
+		s.db.Exec("DELETE FROM tenants")
+		s.Close()
+	})
+	// Clean before test too
+	s.db.Exec("DELETE FROM tenants")
+	return s
+}
+
+func TestInsertAndGetByHash(t *testing.T) {
+	s := newTestStore(t)
+
+	raw, prefix, hash, err := GenerateAPIKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = raw // only returned to caller once
+
+	pwEnc, err := s.EncryptPassword("secret123")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	tenant := &Tenant{
+		ID:              "t-001",
+		APIKeyPrefix:    prefix,
+		APIKeyHash:      hash,
+		Status:          StatusProvisioning,
+		DBHost:          "127.0.0.1",
+		DBPort:          4000,
+		DBUser:          "root",
+		DBPasswordEnc:   pwEnc,
+		DBName:          "tenant_001",
+		ClusterID:       "cluster-abc",
+		ProvisionerType: "local",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := s.Insert(tenant); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// Lookup by hash
+	got, err := s.GetByAPIKeyHash(hash)
+	if err != nil {
+		t.Fatalf("GetByAPIKeyHash: %v", err)
+	}
+	if got.ID != "t-001" {
+		t.Errorf("ID = %q, want %q", got.ID, "t-001")
+	}
+	if got.Status != StatusProvisioning {
+		t.Errorf("Status = %q, want %q", got.Status, StatusProvisioning)
+	}
+	if got.DBHost != "127.0.0.1" {
+		t.Errorf("DBHost = %q", got.DBHost)
+	}
+
+	// Decrypt password
+	pw, err := s.DecryptPassword(got.DBPasswordEnc)
+	if err != nil {
+		t.Fatalf("DecryptPassword: %v", err)
+	}
+	if pw != "secret123" {
+		t.Errorf("password = %q, want %q", pw, "secret123")
+	}
+}
+
+func TestGetByID(t *testing.T) {
+	s := newTestStore(t)
+
+	_, prefix, hash, _ := GenerateAPIKey()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	s.Insert(&Tenant{
+		ID: "t-002", APIKeyPrefix: prefix, APIKeyHash: hash,
+		Status: StatusActive, CreatedAt: now, UpdatedAt: now,
+	})
+
+	got, err := s.Get("t-002")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != StatusActive {
+		t.Errorf("Status = %q", got.Status)
+	}
+}
+
+func TestUpdateStatus(t *testing.T) {
+	s := newTestStore(t)
+
+	_, prefix, hash, _ := GenerateAPIKey()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	s.Insert(&Tenant{
+		ID: "t-003", APIKeyPrefix: prefix, APIKeyHash: hash,
+		Status: StatusActive, CreatedAt: now, UpdatedAt: now,
+	})
+
+	if err := s.UpdateStatus("t-003", StatusSuspended); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.Get("t-003")
+	if got.Status != StatusSuspended {
+		t.Errorf("Status = %q, want suspended", got.Status)
+	}
+}
+
+func TestNotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.GetByAPIKeyHash("nonexistent")
+	if err != ErrNotFound {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+
+	_, err = s.Get("nonexistent")
+	if err != ErrNotFound {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDuplicateAPIKey(t *testing.T) {
+	s := newTestStore(t)
+
+	_, prefix, hash, _ := GenerateAPIKey()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	s.Insert(&Tenant{
+		ID: "t-dup1", APIKeyPrefix: prefix, APIKeyHash: hash,
+		Status: StatusActive, CreatedAt: now, UpdatedAt: now,
+	})
+
+	err := s.Insert(&Tenant{
+		ID: "t-dup2", APIKeyPrefix: prefix, APIKeyHash: hash,
+		Status: StatusActive, CreatedAt: now, UpdatedAt: now,
+	})
+	if err != ErrDuplicate {
+		t.Errorf("err = %v, want ErrDuplicate", err)
+	}
+}
+
+func TestList(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	for i, st := range []Status{StatusActive, StatusActive, StatusSuspended} {
+		_, prefix, hash, _ := GenerateAPIKey()
+		s.Insert(&Tenant{
+			ID: "t-list-" + itoa(i), APIKeyPrefix: prefix, APIKeyHash: hash,
+			Status: st, CreatedAt: now, UpdatedAt: now,
+		})
+	}
+
+	all, err := s.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("List all: got %d, want 3", len(all))
+	}
+
+	active, err := s.List(StatusActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(active) != 2 {
+		t.Fatalf("List active: got %d, want 2", len(active))
+	}
+}
+
+func TestHashAPIKey(t *testing.T) {
+	raw, _, hash, err := GenerateAPIKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if HashAPIKey(raw) != hash {
+		t.Error("HashAPIKey mismatch")
+	}
+}
+
+func TestDSN(t *testing.T) {
+	got := DSN("db.example.com", 4000, "admin", "pass", "mydb")
+	want := "admin:pass@tcp(db.example.com:4000)/mydb?parseTime=true"
+	if got != want {
+		t.Errorf("DSN = %q, want %q", got, want)
+	}
+}
+
+func itoa(i int) string {
+	return string(rune('0' + i))
+}

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -3,8 +3,11 @@
 package tenant
 
 import (
-	"strconv"
+	"crypto/tls"
+	"fmt"
 	"time"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 type Status string
@@ -27,6 +30,8 @@ type Tenant struct {
 	DBUser           string
 	DBPasswordEnc    []byte // AES-GCM encrypted
 	DBName           string
+	DBTLS            string // TLS mode: "", "true", "skip-verify", "custom"
+	DBParams         string // extra DSN params (e.g. "timeout=5s&readTimeout=10s")
 	S3Bucket         string
 	S3KeyPrefix      string
 	ClusterID        string
@@ -35,7 +40,30 @@ type Tenant struct {
 	UpdatedAt        time.Time
 }
 
-// DSN builds a MySQL DSN from the tenant's (decrypted) connection info.
-func DSN(host string, port int, user, password, dbName string) string {
-	return user + ":" + password + "@tcp(" + host + ":" + strconv.Itoa(port) + ")/" + dbName + "?parseTime=true"
+// DSN builds a MySQL DSN using mysql.Config for safe escaping of special characters.
+// tlsMode: "" = no TLS, "true" = system CA, "skip-verify" = skip verification.
+func DSN(host string, port int, user, password, dbName, tlsMode string) string {
+	cfg := mysql.NewConfig()
+	cfg.Net = "tcp"
+	cfg.Addr = fmt.Sprintf("%s:%d", host, port)
+	cfg.User = user
+	cfg.Passwd = password
+	cfg.DBName = dbName
+	cfg.ParseTime = true
+
+	if tlsMode != "" {
+		cfg.TLSConfig = tlsMode
+	}
+
+	return cfg.FormatDSN()
+}
+
+// TLSConfigName registers a TLS config for TiDB Cloud connections and returns its name.
+// Call this once at startup when using cloud endpoints that require TLS.
+func TLSConfigName() string {
+	const name = "tidb-cloud"
+	mysql.RegisterTLSConfig(name, &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	})
+	return name
 }

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -1,0 +1,41 @@
+// Package tenant implements the control plane tenant store for multi-tenant auth.
+// Each tenant has a unique API key mapped 1:1 to a dedicated db9/TiDB cluster.
+package tenant
+
+import (
+	"strconv"
+	"time"
+)
+
+type Status string
+
+const (
+	StatusProvisioning Status = "provisioning"
+	StatusActive       Status = "active"
+	StatusSuspended    Status = "suspended"
+	StatusDeleted      Status = "deleted"
+)
+
+// Tenant represents a row in the control plane tenants table.
+type Tenant struct {
+	ID               string
+	APIKeyPrefix     string // first 8 chars of the raw API key (for logs/debug)
+	APIKeyHash       string // SHA-256 hex of the full API key
+	Status           Status
+	DBHost           string
+	DBPort           int
+	DBUser           string
+	DBPasswordEnc    []byte // AES-GCM encrypted
+	DBName           string
+	S3Bucket         string
+	S3KeyPrefix      string
+	ClusterID        string
+	ProvisionerType  string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+// DSN builds a MySQL DSN from the tenant's (decrypted) connection info.
+func DSN(host string, port int, user, password, dbName string) string {
+	return user + ":" + password + "@tcp(" + host + ":" + strconv.Itoa(port) + ")/" + dbName + "?parseTime=true"
+}

--- a/pkg/tenant/testmain_test.go
+++ b/pkg/tenant/testmain_test.go
@@ -1,0 +1,32 @@
+package tenant
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/mem9-ai/dat9/internal/testmysql"
+)
+
+var testDSN string
+
+func TestMain(m *testing.M) {
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("skip DB tests (no Docker): %v", r)
+			}
+		}()
+		inst, err := testmysql.Start(context.Background())
+		if err != nil {
+			log.Printf("skip DB tests: %v", err)
+			return
+		}
+		testDSN = inst.DSN
+	}()
+
+	code := m.Run()
+
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary
- Add multi-tenant authentication: each tenant gets a unique API key mapped 1:1 to a dedicated db9/TiDB cluster
- New `pkg/tenant` package: tenant model, control plane store (MySQL), AES-GCM password encryption, API key generation (prefix + SHA-256 hash), LRU backend pool with revocation, TiDB Cloud Starter provisioner
- Auth middleware: Bearer token → hash lookup → status check → pool.Get → context injection
- `POST /v1/provision` endpoint (admin key guarded, timing-safe comparison)
- TLS-aware DSN builder using `mysql.Config.FormatDSN()` for safe escaping
- Backward compatible: local dev mode works without auth config via fallback backend injection

## Architecture
- Control plane DB separated from per-tenant DBs
- API key: `dat9_<64hex>`, stored as `prefix` (first 8 chars) + `SHA-256 hash` — plaintext returned once at provision time
- Tenant DB passwords encrypted at rest with AES-256-GCM
- Tenant status flow: `provisioning` → `active` (→ `suspended` / `deleted`)
- Status mapping: active → 200, provisioning → 503, suspended/deleted → 403

## Review
- Approved by @dat9-reviewer1 and @dat9-reviewer2
- All 8 review gates verified ✅

## Test plan
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] `go test ./pkg/tenant/...` — encrypt, apikey, DSN, store (with DB), starter tests
- [x] Auth middleware unit tests: missing key (401), invalid key (401), suspended (403), provisioning (503), local dev passthrough (200)
- [ ] Integration tests (in progress by @dat9-dev3 in #t55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)