### PR TITLE
fix: resume provisioning after restart and harden tenant keys

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -247,6 +247,49 @@ func (s *Store) GetTenant(id string) (*Tenant, error) {
 	return &out, nil
 }
 
+func (s *Store) ListTenantsByStatus(status TenantStatus, limit int) ([]Tenant, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.Query(`SELECT id, status, db_host, db_port, db_user, db_password, db_name,
+		db_tls, provider, cluster_id, claim_url, claim_expires_at, schema_version, created_at, updated_at
+		FROM tenants WHERE status = ? ORDER BY created_at ASC LIMIT ?`, status, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]Tenant, 0)
+	for rows.Next() {
+		var t Tenant
+		var dbTLS int
+		var clusterID sql.NullString
+		var claimURL sql.NullString
+		var claimExp sql.NullTime
+		if err := rows.Scan(&t.ID, &t.Status, &t.DBHost, &t.DBPort, &t.DBUser, &t.DBPasswordCipher,
+			&t.DBName, &dbTLS, &t.Provider, &clusterID, &claimURL, &claimExp, &t.SchemaVersion,
+			&t.CreatedAt, &t.UpdatedAt); err != nil {
+			return nil, err
+		}
+		t.DBTLS = dbTLS == 1
+		if clusterID.Valid {
+			t.ClusterID = clusterID.String
+		}
+		if claimURL.Valid {
+			t.ClaimURL = claimURL.String
+		}
+		if claimExp.Valid {
+			ts := claimExp.Time.UTC()
+			t.ClaimExpiresAt = &ts
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (s *Store) UpdateTenantStatus(id string, status TenantStatus) error {
 	res, err := s.db.Exec(`UPDATE tenants SET status = ?, updated_at = ? WHERE id = ?`, status, time.Now().UTC(), id)
 	if err != nil {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -100,3 +100,44 @@ func TestUpdateTenantStatus(t *testing.T) {
 		t.Fatalf("status=%s", status)
 	}
 }
+
+func TestListTenantsByStatus(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC()
+	for _, tc := range []struct {
+		id     string
+		status TenantStatus
+	}{
+		{id: "tp1", status: TenantProvisioning},
+		{id: "tp2", status: TenantProvisioning},
+		{id: "ta1", status: TenantActive},
+	} {
+		if err := s.InsertTenant(&Tenant{
+			ID:               tc.id,
+			Status:           tc.status,
+			DBHost:           "127.0.0.1",
+			DBPort:           4000,
+			DBUser:           "root",
+			DBPasswordCipher: []byte("cipher"),
+			DBName:           "tenant_db",
+			DBTLS:            true,
+			Provider:         "tidb_zero",
+			SchemaVersion:    1,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := s.ListTenantsByStatus(TenantProvisioning, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 provisioning tenants, got %d", len(got))
+	}
+	if got[0].Status != TenantProvisioning || got[1].Status != TenantProvisioning {
+		t.Fatalf("unexpected statuses: %s, %s", got[0].Status, got[1].Status)
+	}
+}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -109,9 +109,9 @@ func TestProvisionMarksTenantFailedWhenInitKeepsFailing(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	tenantID := out["tenant_id"]
+	tenantID := out["id"]
 	if tenantID == "" {
-		t.Fatal("empty tenant_id")
+		t.Fatal("empty id")
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -205,7 +205,7 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if out["tenant_id"] == "" || out["api_key"] == "" {
+	if out["id"] == "" || out["api_key"] == "" {
 		t.Fatalf("unexpected provision response: %+v", out)
 	}
 	if out["status"] != string(meta.TenantProvisioning) {
@@ -215,7 +215,7 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	deadline := time.Now().Add(3 * time.Second)
 	var status, provider, clusterID string
 	for {
-		row := metaStore.DB().QueryRow("SELECT status, provider, cluster_id FROM tenants WHERE id = ?", out["tenant_id"])
+		row := metaStore.DB().QueryRow("SELECT status, provider, cluster_id FROM tenants WHERE id = ?", out["id"])
 		if err := row.Scan(&status, &provider, &clusterID); err != nil {
 			t.Fatal(err)
 		}
@@ -229,5 +229,82 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	}
 	if provider != tenant.ProviderTiDBZero || clusterID != "cluster-1" {
 		t.Fatalf("unexpected tenant row: status=%s provider=%s cluster_id=%s", status, provider, clusterID)
+	}
+}
+
+func TestStartupResumesProvisioningTenantInit(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := "127.0.0.1"
+	port := 3306
+	if parsed.Addr != "" {
+		h, p, ok := strings.Cut(parsed.Addr, ":")
+		if ok {
+			host = h
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+
+	passCipher, err := pool.Encrypt([]byte(parsed.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID := tenant.NewID()
+	now := time.Now().UTC()
+	if err := metaStore.InsertTenant(&meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantProvisioning,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderTiDBZero,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBZero, cluster: &tenant.ClusterInfo{}}
+	_ = NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov, TokenSecret: []byte("abc")})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		row := metaStore.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", tenantID)
+		var status string
+		if err := row.Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status == string(meta.TenantActive) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("tenant did not become active after restart resume, status=%s", status)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -102,7 +102,40 @@ func NewWithConfig(cfg Config) *Server {
 	}
 
 	s.mux = mux
+	if s.meta != nil && s.pool != nil && s.provisioner != nil {
+		s.resumeProvisioningTenants()
+	}
 	return s
+}
+
+func (s *Server) resumeProvisioningTenants() {
+	tenants, err := s.meta.ListTenantsByStatus(meta.TenantProvisioning, 1000)
+	if err != nil {
+		log.Printf("list provisioning tenants failed: %v", err)
+		return
+	}
+	for i := range tenants {
+		t := tenants[i]
+		go s.resumeTenantSchemaInit(t)
+	}
+}
+
+func (s *Server) resumeTenantSchemaInit(t meta.Tenant) {
+	plain, err := s.pool.Decrypt(t.DBPasswordCipher)
+	if err != nil {
+		log.Printf("resume tenant schema init skipped: decrypt db password failed (tenant=%s): %v", t.ID, err)
+		return
+	}
+	dsn := tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS)
+	s.initTenantSchemaAsync(t.ID, dsn, t.Provider, s.provisioner.InitSchema)
+}
+
+func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled bool) string {
+	query := "parseTime=true"
+	if tlsEnabled {
+		query += "&tls=true"
+	}
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", user, password, host, port, dbName, query)
 }
 
 func injectFallbackBackend(b *backend.Dat9Backend, next http.Handler) http.Handler {
@@ -600,12 +633,12 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Initialize tenant schema asynchronously; tenant remains in provisioning state until success.
-	tenantDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true", cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName)
-	go s.initTenantSchemaAsync(tenantID, tenantDSN, provider, s.provisioner.InitSchema)
+	dsn := tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true)
+	go s.initTenantSchemaAsync(tenantID, dsn, provider, s.provisioner.InitSchema)
 
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]string{
-		"tenant_id":  tenantID,
+		"id":         tenantID,
 		"api_key":    token,
 		"api_key_id": apiKeyID,
 		"status":     string(meta.TenantProvisioning),

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -139,7 +139,11 @@ func (p *Pool) createBackend(t *meta.Tenant) (*backend.Dat9Backend, *datastore.S
 	if err != nil {
 		return nil, nil, err
 	}
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName)
+	query := "parseTime=true"
+	if t.DBTLS {
+		query += "&tls=true"
+	}
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
 	store, err := datastore.Open(dsn)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/tenant/token.go
+++ b/pkg/tenant/token.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oklog/ulid/v2"
+	"github.com/google/uuid"
 )
 
 type Claims struct {
@@ -20,7 +20,9 @@ type Claims struct {
 	ExpiresAt    int64  `json:"exp,omitempty"`
 }
 
-func NewID() string { return ulid.Make().String() }
+const tokenPrefix = "dat9_"
+
+func NewID() string { return uuid.NewString() }
 
 func HashToken(raw string) string {
 	h := sha256.Sum256([]byte(raw))
@@ -53,7 +55,8 @@ func IssueTokenWithExpiry(secret []byte, tenantID string, tokenVersion int, expi
 	mac := hmac.New(sha256.New, secret)
 	mac.Write([]byte(msg))
 	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
-	return msg + "." + sig, nil
+	jwt := msg + "." + sig
+	return tokenPrefix + base64.RawURLEncoding.EncodeToString([]byte(jwt)), nil
 }
 
 func ParseAndVerifyToken(secret []byte, raw string) (*Claims, error) {
@@ -61,6 +64,15 @@ func ParseAndVerifyToken(secret []byte, raw string) (*Claims, error) {
 }
 
 func parseAndVerifyTokenAt(secret []byte, raw string, nowUnix int64) (*Claims, error) {
+	if !strings.HasPrefix(raw, tokenPrefix) {
+		return nil, fmt.Errorf("invalid token format")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(raw, tokenPrefix))
+	if err != nil {
+		return nil, fmt.Errorf("invalid token format")
+	}
+	raw = string(decoded)
+
 	parts := strings.Split(raw, ".")
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("invalid token format")

--- a/pkg/tenant/token_test.go
+++ b/pkg/tenant/token_test.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,9 @@ func TestIssueTokenDefaultNeverExpires(t *testing.T) {
 	}
 	if claims.ExpiresAt != 0 {
 		t.Fatalf("expected default token without exp, got exp=%d", claims.ExpiresAt)
+	}
+	if strings.Count(tok, ".") != 0 {
+		t.Fatalf("expected one-segment API key format, got token=%s", tok)
 	}
 }
 
@@ -63,5 +67,23 @@ func TestParseAndVerifyTokenRejectsExpiredExpClaim(t *testing.T) {
 	_, err = parseAndVerifyTokenAt(secret, tok, claims.ExpiresAt)
 	if err == nil || !strings.Contains(err.Error(), "expired") {
 		t.Fatalf("expected expired error, got %v", err)
+	}
+}
+
+func TestParseAndVerifyTokenRejectsLegacyThreeSegmentJWT(t *testing.T) {
+	secret := testTokenSecret(t)
+	tok, err := IssueToken(secret, "tenant-1", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawJWTBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(tok, tokenPrefix))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawJWT := string(rawJWTBytes)
+
+	_, err = ParseAndVerifyToken(secret, rawJWT)
+	if err == nil || !strings.Contains(err.Error(), "invalid token format") {
+		t.Fatalf("expected invalid token format error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- resume schema initialization for tenants stuck in `provisioning` at server startup so restarts do not lose in-flight provisioning work
- enforce TLS MySQL connections for TiDB tenants (`tls=true`) in both async schema init and runtime tenant backend creation
- switch generated tenant/api-key IDs to UUID and update `/v1/provision` response field from `tenant_id` to `id`
- move API key format to single-segment opaque style (`dat9_<base64url>`) with optional `exp` claim support while keeping default provisioned keys non-expiring
- drop legacy 3-segment JWT API key acceptance and add tests for startup resume, token format, and meta status listing

## Validation
- `go test ./...`
- `make lint`