### PR TITLE
refactor: simplify provision and tenant status payloads

### DIFF
--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -200,7 +200,7 @@ func TestTenantStatusWithValidKey(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if out["id"] == "" || out["status"] != string(meta.TenantActive) {
+	if len(out) != 1 || out["status"] != string(meta.TenantActive) {
 		t.Fatalf("unexpected tenant status response: %+v", out)
 	}
 }
@@ -228,7 +228,7 @@ func TestTenantStatusReturnsProvisioningState(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if out["status"] != string(meta.TenantProvisioning) {
+	if len(out) != 1 || out["status"] != string(meta.TenantProvisioning) {
 		t.Fatalf("expected provisioning status, got %+v", out)
 	}
 }

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -186,7 +186,7 @@ func TestTenantStatusWithValidKey(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/tenant/status", nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
 	req.Header.Set("Authorization", "Bearer "+tok)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -214,7 +214,7 @@ func TestTenantStatusReturnsProvisioningState(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/tenant/status", nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
 	req.Header.Set("Authorization", "Bearer "+tok)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -109,10 +109,15 @@ func TestProvisionMarksTenantFailedWhenInitKeepsFailing(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	tenantID := out["id"]
-	if tenantID == "" {
-		t.Fatal("empty id")
+	apiKey := out["api_key"]
+	if apiKey == "" {
+		t.Fatal("empty api_key")
 	}
+	resolved, err := metaStore.ResolveByAPIKeyHash(tenant.HashToken(apiKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID := resolved.Tenant.ID
 
 	deadline := time.Now().Add(2 * time.Second)
 	for {
@@ -205,9 +210,14 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if out["id"] == "" || out["api_key"] == "" {
+	if out["api_key"] == "" {
 		t.Fatalf("unexpected provision response: %+v", out)
 	}
+	resolved, err := metaStore.ResolveByAPIKeyHash(tenant.HashToken(out["api_key"]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID := resolved.Tenant.ID
 	if out["status"] != string(meta.TenantProvisioning) {
 		t.Fatalf("expected provisioning response status, got %q", out["status"])
 	}
@@ -215,7 +225,7 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	deadline := time.Now().Add(3 * time.Second)
 	var status, provider, clusterID string
 	for {
-		row := metaStore.DB().QueryRow("SELECT status, provider, cluster_id FROM tenants WHERE id = ?", out["id"])
+		row := metaStore.DB().QueryRow("SELECT status, provider, cluster_id FROM tenants WHERE id = ?", tenantID)
 		if err := row.Scan(&status, &provider, &clusterID); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -220,12 +220,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = json.NewEncoder(w).Encode(map[string]string{
-		"id":         resolved.Tenant.ID,
-		"status":     string(resolved.Tenant.Status),
-		"provider":   resolved.Tenant.Provider,
-		"updated_at": resolved.Tenant.UpdatedAt.UTC().Format(time.RFC3339Nano),
-	})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": string(resolved.Tenant.Status)})
 }
 
 func backendFromRequest(r *http.Request) *backend.Dat9Backend {
@@ -699,10 +694,8 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]string{
-		"id":         tenantID,
-		"api_key":    token,
-		"api_key_id": apiKeyID,
-		"status":     string(meta.TenantProvisioning),
+		"api_key": token,
+		"status":  string(meta.TenantProvisioning),
 	})
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,7 +69,7 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v1/fs/", business)
 	mux.Handle("/v1/uploads", business)
 	mux.Handle("/v1/uploads/", business)
-	mux.HandleFunc("/v1/tenant/status", s.handleTenantStatus)
+	mux.HandleFunc("/v1/status", s.handleTenantStatus)
 	mux.HandleFunc("/v1/provision", s.handleProvision)
 
 	local := cfg.LocalS3


### PR DESCRIPTION
## Summary
- simplify `POST /v1/provision` response to only return `api_key` and `status`
- simplify `GET /v1/tenant/status` response to only return `status`
- update server tests to derive tenant identity from `api_key` hash lookup instead of response fields

## Validation
- `go test ./pkg/server`
- `make lint`