### PR TITLE
test: add dat9 live e2e smoke scripts and docs

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,0 +1,72 @@
+---
+title: e2e - Live end-to-end scripts
+---
+
+## Overview
+
+This directory contains live end-to-end tests for deployed dat9-server instances.
+These scripts are integration probes (not unit tests) and call real HTTP endpoints.
+
+## Quick start
+
+```bash
+DEPLOY=https://<your-api-gateway-or-server>
+
+# Full smoke (provision -> status poll -> nested dirs -> file ops)
+DAT9_BASE=$DEPLOY bash e2e/api-smoke-test.sh
+
+# Existing key regression
+DAT9_BASE=$DEPLOY DAT9_API_KEY=dat9_xxx bash e2e/api-smoke-test-existing-key.sh
+```
+
+## Dev endpoint
+
+Current shared dev deployment:
+
+```bash
+export DAT9_BASE="https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
+```
+
+Use this value unless the environment owner announces a new endpoint.
+
+## Coverage
+
+### `api-smoke-test.sh`
+
+1. `POST /v1/provision` returns `202` with only `api_key` + `status`
+2. `GET /v1/status` polled until `active`
+3. `GET /v1/fs/?list` returns `entries[]`
+4. Nested `mkdir` (`/team/...`) across multi-level paths
+5. Multi-file `PUT` + `GET` content verification
+6. `copy`, `rename`, `delete`, `recursive delete`
+7. Final `list` verifies expected structure after mutations
+
+### `api-smoke-test-existing-key.sh`
+
+1. Existing API key auth on `GET /v1/status`
+2. Optional poll from `provisioning` to `active`
+3. `GET /v1/fs/?list` baseline read check
+
+## Environment variables
+
+| Variable | Default | Used by |
+|----------|---------|---------|
+| `DAT9_BASE` | `http://127.0.0.1:9009` | all scripts |
+| `DAT9_API_KEY` | - | `api-smoke-test-existing-key.sh` |
+| `POLL_TIMEOUT_S` | `120` (smoke), `60` (existing-key) | polling scripts |
+| `POLL_INTERVAL_S` | `5` | polling scripts |
+
+## Conventions
+
+- Each smoke run provisions a fresh tenant and uses timestamped paths.
+- Scripts require `jq`.
+- API surface expected by these scripts:
+  - `POST /v1/provision`
+  - `GET /v1/status`
+  - `/v1/fs/*` for file operations
+
+## Anti-patterns
+
+- Do not hardcode long-lived secrets in scripts.
+- Do not use these scripts as unit-test substitutes.
+- Do not change API paths casually; scripts serve as executable API docs.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,40 @@
+# dat9 E2E tests
+
+Live end-to-end scripts for validating deployed `dat9-server` behavior.
+
+## Prerequisites
+
+- A running server endpoint (`DAT9_BASE`)
+- `jq` installed
+- Bash 4+
+
+## Scripts
+
+| Script | What it validates |
+|--------|--------------------|
+| `api-smoke-test.sh` | Fresh provisioning, status polling, nested directories, multi-file CRUD-style operations |
+| `api-smoke-test-existing-key.sh` | Existing API key status/list checks |
+
+## Run
+
+```bash
+DEPLOY=https://<api-endpoint>
+
+DAT9_BASE=$DEPLOY bash e2e/api-smoke-test.sh
+
+DAT9_BASE=$DEPLOY DAT9_API_KEY=dat9_xxx bash e2e/api-smoke-test-existing-key.sh
+```
+
+## Dev endpoint
+
+Current dev deployment endpoint:
+
+```bash
+export DAT9_BASE="https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
+```
+
+## Notes
+
+- `api-smoke-test.sh` expects `POST /v1/provision` to return only `api_key` and `status`.
+- Tenant readiness is checked through `GET /v1/status`.
+- File operations use `/v1/fs/*` and include nested directory coverage.

--- a/e2e/api-smoke-test-existing-key.sh
+++ b/e2e/api-smoke-test-existing-key.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Validate a pre-existing dat9 API key against deployed endpoints.
+
+set -euo pipefail
+
+BASE="${DAT9_BASE:-http://127.0.0.1:9009}"
+API_KEY="${DAT9_API_KEY:-}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-60}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+
+if [ -z "$API_KEY" ]; then
+  echo "DAT9_API_KEY is required"
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+check_eq() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL+1))
+  if [ "$got" = "$want" ]; then
+    echo "PASS $desc (got=$got)"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL $desc (want=$want got=$got)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+curl_code() {
+  local method="$1"
+  local url="$2"
+  local body_file
+  body_file="$(mktemp)"
+  local code
+  code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $API_KEY" "$url")
+  cat "$body_file"
+  echo
+  echo "__HTTP__${code}"
+  rm -f "$body_file"
+}
+
+http_code() { printf '%s' "$1" | awk -F'__HTTP__' 'NF>1{print $2}' | tr -d '\n'; }
+json_body() { printf '%s' "$1" | sed '/__HTTP__/d'; }
+
+echo "Base: $BASE"
+
+resp=$(curl_code GET "$BASE/v1/status")
+code=$(http_code "$resp")
+body=$(json_body "$resp")
+status=$(printf '%s' "$body" | jq -r '.status // empty')
+check_eq "GET /v1/status returns 200" "$code" "200"
+
+if [ "$status" = "provisioning" ]; then
+  deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    sleep "$POLL_INTERVAL_S"
+    resp=$(curl_code GET "$BASE/v1/status")
+    body=$(json_body "$resp")
+    status=$(printf '%s' "$body" | jq -r '.status // empty')
+    echo "status=$status"
+    [ "$status" = "active" ] && break
+  done
+fi
+
+check_eq "tenant status is active" "$status" "active"
+
+resp=$(curl_code GET "$BASE/v1/fs/?list")
+code=$(http_code "$resp")
+body=$(json_body "$resp")
+check_eq "GET /v1/fs/?list returns 200" "$code" "200"
+entries_type=$(printf '%s' "$body" | jq -r '.entries | type')
+check_eq "entries is array" "$entries_type" "array"
+
+echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"
+exit "$FAIL"

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# dat9 API smoke test against a live dat9-server deployment.
+#
+# Coverage:
+#  1) Provision tenant (expect 202, api_key + status only)
+#  2) Poll tenant status via GET /v1/status until active
+#  3) Root list
+#  4) Nested mkdir (multi-level directories)
+#  5) Multi-file write/read under nested directories
+#  6) Copy, rename, delete
+#  7) Final list verification
+
+set -euo pipefail
+
+BASE="${DAT9_BASE:-http://127.0.0.1:9009}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-120}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RESET='\033[0m'
+
+step() { echo -e "\n${YELLOW}[$1]${RESET} $2"; }
+ok() { echo -e "${GREEN}  PASS${RESET} $*"; }
+fail() { echo -e "${RED}  FAIL${RESET} $*"; }
+info() { echo -e "${CYAN}  ->${RESET} $*"; }
+
+check_eq() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL+1))
+  if [ "$got" = "$want" ]; then
+    ok "$desc (got=$got)"
+    PASS=$((PASS+1))
+  else
+    fail "$desc (want=$want got=$got)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+check_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL+1))
+  if "$@"; then
+    ok "$desc"
+    PASS=$((PASS+1))
+  else
+    fail "$desc"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+curl_body_code() {
+  local method="$1"
+  local url="$2"
+  local auth="${3:-}"
+  local data="${4:-}"
+
+  local body_file
+  body_file="$(mktemp)"
+
+  if [ -n "$auth" ] && [ -n "$data" ]; then
+    local code
+    code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $auth" --data-binary "$data" "$url")
+    cat "$body_file"
+    echo
+    echo "__HTTP__${code}"
+    rm -f "$body_file"
+    return
+  fi
+
+  if [ -n "$auth" ]; then
+    local code
+    code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $auth" "$url")
+    cat "$body_file"
+    echo
+    echo "__HTTP__${code}"
+    rm -f "$body_file"
+    return
+  fi
+
+  local code
+  code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" "$url")
+  cat "$body_file"
+  echo
+  echo "__HTTP__${code}"
+  rm -f "$body_file"
+}
+
+http_code() { printf '%s' "$1" | awk -F'__HTTP__' 'NF>1{print $2}' | tr -d '\n'; }
+json_body() { printf '%s' "$1" | sed '/__HTTP__/d'; }
+
+echo "========================================================"
+echo "  dat9 API smoke test"
+echo "  Base URL : $BASE"
+echo "  Started  : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "========================================================"
+
+TS="$(date +%s)"
+ROOT_DIR="team-${TS}"
+BACKEND_DIR="${ROOT_DIR}/backend/go"
+FRONTEND_DIR="${ROOT_DIR}/frontend/web"
+
+step "1" "Provision tenant"
+resp=$(curl_body_code POST "$BASE/v1/provision")
+code=$(http_code "$resp")
+body=$(json_body "$resp")
+check_eq "POST /v1/provision returns 202" "$code" "202"
+
+API_KEY=$(printf '%s' "$body" | jq -r '.api_key // empty')
+INIT_STATUS=$(printf '%s' "$body" | jq -r '.status // empty')
+check_cmd "response contains api_key" test -n "$API_KEY"
+check_eq "provision response status is provisioning" "$INIT_STATUS" "provisioning"
+keys=$(printf '%s' "$body" | jq -r 'keys_unsorted | sort | join(",")')
+check_eq "provision response only has api_key+status" "$keys" "api_key,status"
+
+step "2" "Poll tenant status via /v1/status"
+deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+LAST_STATUS=""
+while :; do
+  sresp=$(curl_body_code GET "$BASE/v1/status" "$API_KEY")
+  scode=$(http_code "$sresp")
+  sbody=$(json_body "$sresp")
+  LAST_STATUS=$(printf '%s' "$sbody" | jq -r '.status // empty')
+  info "status=$LAST_STATUS"
+  if [ "$scode" = "200" ] && [ "$LAST_STATUS" = "active" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    break
+  fi
+  sleep "$POLL_INTERVAL_S"
+done
+check_eq "tenant eventually becomes active" "$LAST_STATUS" "active"
+
+step "3" "Root list"
+resp=$(curl_body_code GET "$BASE/v1/fs/?list" "$API_KEY")
+code=$(http_code "$resp")
+body=$(json_body "$resp")
+check_eq "GET /v1/fs/?list returns 200" "$code" "200"
+entries_type=$(printf '%s' "$body" | jq -r '.entries | type')
+check_eq "list response contains entries array" "$entries_type" "array"
+
+step "4" "Create nested directories"
+for d in "$ROOT_DIR" "${ROOT_DIR}/backend" "$BACKEND_DIR" "${ROOT_DIR}/frontend" "$FRONTEND_DIR"; do
+  resp=$(curl_body_code POST "$BASE/v1/fs/$d?mkdir" "$API_KEY")
+  code=$(http_code "$resp")
+  check_eq "POST /v1/fs/$d?mkdir returns 200" "$code" "200"
+done
+
+step "5" "Write and read multiple files"
+declare -a FILES
+FILES=(
+  "$ROOT_DIR/README.md|team-root-$TS"
+  "$BACKEND_DIR/main.go|package main\n// smoke-$TS\nfunc main() {}\n"
+  "$FRONTEND_DIR/index.html|<html><body>smoke-$TS</body></html>"
+  "$BACKEND_DIR/config.yaml|env: smoke-$TS"
+)
+
+for item in "${FILES[@]}"; do
+  path="${item%%|*}"
+  payload="${item#*|}"
+  resp=$(curl_body_code PUT "$BASE/v1/fs/$path" "$API_KEY" "$payload")
+  code=$(http_code "$resp")
+  check_eq "PUT /v1/fs/$path returns 200" "$code" "200"
+
+  rresp=$(curl_body_code GET "$BASE/v1/fs/$path" "$API_KEY")
+  rcode=$(http_code "$rresp")
+  rbody=$(json_body "$rresp")
+  check_eq "GET /v1/fs/$path returns 200" "$rcode" "200"
+  check_eq "read back content matches for $path" "$rbody" "$payload"
+done
+
+step "6" "Copy, rename, delete"
+resp=$(curl -sS -o /tmp/dat9-copy.out -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "X-Dat9-Copy-Source: /$ROOT_DIR/README.md" "$BASE/v1/fs/$ROOT_DIR/README-copy.md?copy")
+check_eq "POST ?copy returns 200" "$resp" "200"
+
+resp=$(curl -sS -o /tmp/dat9-rename.out -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "X-Dat9-Rename-Source: /$BACKEND_DIR/config.yaml" "$BASE/v1/fs/$BACKEND_DIR/config-renamed.yaml?rename")
+check_eq "POST ?rename returns 200" "$resp" "200"
+
+resp=$(curl -sS -o /tmp/dat9-delete.out -w "%{http_code}" -X DELETE -H "Authorization: Bearer $API_KEY" "$BASE/v1/fs/$ROOT_DIR/README-copy.md")
+check_eq "DELETE copied file returns 200" "$resp" "200"
+
+step "7" "Final list verification"
+resp=$(curl_body_code GET "$BASE/v1/fs/$ROOT_DIR?list" "$API_KEY")
+code=$(http_code "$resp")
+body=$(json_body "$resp")
+check_eq "GET /v1/fs/$ROOT_DIR?list returns 200" "$code" "200"
+backend_exists=$(printf '%s' "$body" | jq -r 'any(.entries[]; .name=="backend" and .isDir==true)')
+frontend_exists=$(printf '%s' "$body" | jq -r 'any(.entries[]; .name=="frontend" and .isDir==true)')
+copy_exists=$(printf '%s' "$body" | jq -r 'any(.entries[]; .name=="README-copy.md")')
+check_eq "backend directory still exists" "$backend_exists" "true"
+check_eq "frontend directory still exists" "$frontend_exists" "true"
+check_eq "copied file removed" "$copy_exists" "false"
+
+rm -f /tmp/dat9-copy.out /tmp/dat9-rename.out /tmp/dat9-delete.out
+
+echo
+echo "========================================================"
+echo "  RESULTS: $PASS / $TOTAL passed, $FAIL failed"
+echo "  Base URL : $BASE"
+echo "  Finished : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+if [ "$FAIL" -eq 0 ]; then
+  echo -e "  ${GREEN}All tests passed.${RESET}"
+else
+  echo -e "  ${RED}$FAIL test(s) failed.${RESET}"
+fi
+echo "========================================================"
+
+exit "$FAIL"

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1054,6 +1054,9 @@ func (s *Store) ExecSQL(ctx context.Context, query string) ([]map[string]interfa
 	if !isSelect && !isTagWrite {
 		return nil, fmt.Errorf("only SELECT queries and INSERT/UPDATE/DELETE on file_tags are allowed")
 	}
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("database is closed")
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary
- add a new `e2e/` suite for dat9 live smoke testing, modeled after mem9's e2e structure
- add `e2e/api-smoke-test.sh` covering provision, status polling, nested directories, multi-file read/write, and copy/rename/delete checks
- add `e2e/api-smoke-test-existing-key.sh` for pre-existing key regression checks
- add `e2e/AGENTS.md` and `e2e/README.md` with usage docs, conventions, and the current shared dev endpoint

## Validation
- `bash -n e2e/api-smoke-test.sh`
- `bash -n e2e/api-smoke-test-existing-key.sh`
- `DAT9_BASE=https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com POLL_TIMEOUT_S=90 bash e2e/api-smoke-test.sh`
- `DAT9_BASE=https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com DAT9_API_KEY=<provisioned-key> POLL_TIMEOUT_S=90 bash e2e/api-smoke-test-existing-key.sh`