### PR TITLE
feat: switch to create API and include tenant name

### DIFF
--- a/cmd/dat9/cli/db.go
+++ b/cmd/dat9/cli/db.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -32,9 +33,11 @@ func DBCreate(args []string) error {
 	}
 
 	c := client.New(server, "")
-	resp, err := c.RawPost("/v1/provision", nil)
+	reqBody := map[string]string{"name": name}
+	body, _ := json.Marshal(reqBody)
+	resp, err := c.RawPost("/v1/create", bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("provision request failed: %w", err)
+		return fmt.Errorf("create request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -43,17 +46,17 @@ func DBCreate(args []string) error {
 			Error string `json:"error"`
 		}
 		_ = json.NewDecoder(resp.Body).Decode(&errResp)
-		return fmt.Errorf("provision failed (HTTP %d): %s", resp.StatusCode, errResp.Error)
+		return fmt.Errorf("create failed (HTTP %d): %s", resp.StatusCode, errResp.Error)
 	}
 
 	var result struct {
-		TenantID string `json:"tenant_id"`
-		APIKey   string `json:"api_key"`
-		APIKeyID string `json:"api_key_id"`
-		Status   string `json:"status"`
+		ID     string `json:"id"`
+		Name   string `json:"name"`
+		APIKey string `json:"api_key"`
+		Status string `json:"status"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return fmt.Errorf("decode provision response: %w", err)
+		return fmt.Errorf("decode create response: %w", err)
 	}
 
 	cfg.SetDB(name, &DBEntry{
@@ -67,7 +70,7 @@ func DBCreate(args []string) error {
 		return fmt.Errorf("save credentials: %w", err)
 	}
 
-	fmt.Printf("database %q created (tenant: %s, status: %s)\n", name, result.TenantID, result.Status)
+	fmt.Printf("database %q created (id: %s, name: %s, status: %s)\n", name, result.ID, result.Name, result.Status)
 	fmt.Printf("API key saved to %s\n", configPath())
 	if cfg.DefaultDB == name {
 		fmt.Printf("set as default database\n")

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -12,7 +12,7 @@ These scripts are integration probes (not unit tests) and call real HTTP endpoin
 ```bash
 DEPLOY=https://<your-api-gateway-or-server>
 
-# Full smoke (provision -> status poll -> nested dirs -> file ops)
+# Full smoke (create -> status poll -> nested dirs -> file ops)
 DAT9_BASE=$DEPLOY bash e2e/api-smoke-test.sh
 
 # Existing key regression
@@ -33,12 +33,12 @@ Use this value unless the environment owner announces a new endpoint.
 
 ### `api-smoke-test.sh`
 
-1. `POST /v1/provision` returns `202` with only `api_key` + `status`
-2. `GET /v1/status` polled until `active`
+1. `POST /v1/create` returns `202` with `id` + `name` + `api_key` + `status`
+2. `GET /v1/status` polled until `active` and includes `id` + `name` + `status`
 3. `GET /v1/fs/?list` returns `entries[]`
 4. Nested `mkdir` (`/team/...`) across multi-level paths
 5. Multi-file `PUT` + `GET` content verification
-6. `copy`, `rename`, `delete`, `recursive delete`
+6. `copy`, `rename`, `delete`
 7. Final `list` verifies expected structure after mutations
 
 ### `api-smoke-test-existing-key.sh`
@@ -61,7 +61,7 @@ Use this value unless the environment owner announces a new endpoint.
 - Each smoke run provisions a fresh tenant and uses timestamped paths.
 - Scripts require `jq`.
 - API surface expected by these scripts:
-  - `POST /v1/provision`
+  - `POST /v1/create`
   - `GET /v1/status`
   - `/v1/fs/*` for file operations
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -35,6 +35,6 @@ export DAT9_BASE="https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
 
 ## Notes
 
-- `api-smoke-test.sh` expects `POST /v1/provision` to return only `api_key` and `status`.
-- Tenant readiness is checked through `GET /v1/status`.
+- `api-smoke-test.sh` expects `POST /v1/create` to return `id`, `name`, `api_key`, and `status`.
+- Tenant readiness is checked through `GET /v1/status`, which returns `id`, `name`, and `status`.
 - File operations use `/v1/fs/*` and include nested directory coverage.

--- a/e2e/api-smoke-test-existing-key.sh
+++ b/e2e/api-smoke-test-existing-key.sh
@@ -51,7 +51,11 @@ resp=$(curl_code GET "$BASE/v1/status")
 code=$(http_code "$resp")
 body=$(json_body "$resp")
 status=$(printf '%s' "$body" | jq -r '.status // empty')
+tenant_id=$(printf '%s' "$body" | jq -r '.id // empty')
+tenant_name=$(printf '%s' "$body" | jq -r '.name // empty')
 check_eq "GET /v1/status returns 200" "$code" "200"
+check_eq "status response has id" "$([ -n "$tenant_id" ] && echo yes || echo no)" "yes"
+check_eq "status response has name" "$([ -n "$tenant_name" ] && echo yes || echo no)" "yes"
 
 if [ "$status" = "provisioning" ]; then
   deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -2,7 +2,7 @@
 # dat9 API smoke test against a live dat9-server deployment.
 #
 # Coverage:
-#  1) Provision tenant (expect 202, api_key + status only)
+#  1) Create tenant (expect 202, id + name + api_key + status)
 #  2) Poll tenant status via GET /v1/status until active
 #  3) Root list
 #  4) Nested mkdir (multi-level directories)
@@ -107,18 +107,22 @@ ROOT_DIR="team-${TS}"
 BACKEND_DIR="${ROOT_DIR}/backend/go"
 FRONTEND_DIR="${ROOT_DIR}/frontend/web"
 
-step "1" "Provision tenant"
-resp=$(curl_body_code POST "$BASE/v1/provision")
+step "1" "Create tenant"
+resp=$(curl_body_code POST "$BASE/v1/create")
 code=$(http_code "$resp")
 body=$(json_body "$resp")
-check_eq "POST /v1/provision returns 202" "$code" "202"
+check_eq "POST /v1/create returns 202" "$code" "202"
 
+TENANT_ID=$(printf '%s' "$body" | jq -r '.id // empty')
+TENANT_NAME=$(printf '%s' "$body" | jq -r '.name // empty')
 API_KEY=$(printf '%s' "$body" | jq -r '.api_key // empty')
 INIT_STATUS=$(printf '%s' "$body" | jq -r '.status // empty')
+check_cmd "response contains id" test -n "$TENANT_ID"
+check_cmd "response contains name" test -n "$TENANT_NAME"
 check_cmd "response contains api_key" test -n "$API_KEY"
 check_eq "provision response status is provisioning" "$INIT_STATUS" "provisioning"
 keys=$(printf '%s' "$body" | jq -r 'keys_unsorted | sort | join(",")')
-check_eq "provision response only has api_key+status" "$keys" "api_key,status"
+check_eq "create response has id,name,api_key,status" "$keys" "api_key,id,name,status"
 
 step "2" "Poll tenant status via /v1/status"
 deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
@@ -128,6 +132,8 @@ while :; do
   scode=$(http_code "$sresp")
   sbody=$(json_body "$sresp")
   LAST_STATUS=$(printf '%s' "$sbody" | jq -r '.status // empty')
+  STATUS_ID=$(printf '%s' "$sbody" | jq -r '.id // empty')
+  STATUS_NAME=$(printf '%s' "$sbody" | jq -r '.name // empty')
   info "status=$LAST_STATUS"
   if [ "$scode" = "200" ] && [ "$LAST_STATUS" = "active" ]; then
     break
@@ -138,6 +144,8 @@ while :; do
   sleep "$POLL_INTERVAL_S"
 done
 check_eq "tenant eventually becomes active" "$LAST_STATUS" "active"
+check_eq "status response keeps same id" "$STATUS_ID" "$TENANT_ID"
+check_eq "status response keeps same name" "$STATUS_NAME" "$TENANT_NAME"
 
 step "3" "Root list"
 resp=$(curl_body_code GET "$BASE/v1/fs/?list" "$API_KEY")

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -35,6 +35,7 @@ const (
 
 type Tenant struct {
 	ID               string
+	Name             string
 	Status           TenantStatus
 	DBHost           string
 	DBPort           int
@@ -101,6 +102,7 @@ func (s *Store) migrate() error {
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS tenants (
 			id               VARCHAR(64) PRIMARY KEY,
+			name             VARCHAR(255) NOT NULL,
 			status           VARCHAR(20) NOT NULL DEFAULT 'provisioning',
 			db_host          VARCHAR(255) NOT NULL,
 			db_port          INT NOT NULL,
@@ -145,11 +147,15 @@ func (s *Store) migrate() error {
 }
 
 func (s *Store) InsertTenant(t *Tenant) error {
+	name := strings.TrimSpace(t.Name)
+	if name == "" {
+		name = t.ID
+	}
 	_, err := s.db.Exec(`INSERT INTO tenants
-		(id, status, db_host, db_port, db_user, db_password, db_name, db_tls,
+		(id, name, status, db_host, db_port, db_user, db_password, db_name, db_tls,
 		 provider, cluster_id, claim_url, claim_expires_at, schema_version, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		t.ID, t.Status, t.DBHost, t.DBPort, t.DBUser, t.DBPasswordCipher, t.DBName, boolToInt(t.DBTLS),
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.ID, name, t.Status, t.DBHost, t.DBPort, t.DBUser, t.DBPasswordCipher, t.DBName, boolToInt(t.DBTLS),
 		t.Provider, nullStr(t.ClusterID), nullStr(t.ClaimURL), t.ClaimExpiresAt, t.SchemaVersion, t.CreatedAt.UTC(), t.UpdatedAt.UTC())
 	if isDuplicateEntry(err) {
 		return ErrDuplicate
@@ -171,7 +177,7 @@ func (s *Store) InsertAPIKey(k *APIKey) error {
 
 func (s *Store) ResolveByAPIKeyHash(hash string) (*TenantWithAPIKey, error) {
 	row := s.db.QueryRow(`SELECT
-			t.id, t.status, t.db_host, t.db_port, t.db_user, t.db_password, t.db_name, t.db_tls,
+			t.id, t.name, t.status, t.db_host, t.db_port, t.db_user, t.db_password, t.db_name, t.db_tls,
 			t.provider, t.cluster_id, t.claim_url, t.claim_expires_at, t.schema_version, t.created_at, t.updated_at,
 			k.id, k.tenant_id, k.key_name, k.jwt_ciphertext, k.jwt_hash, k.token_version, k.status, k.issued_at,
 			k.revoked_at, k.created_at, k.updated_at
@@ -186,7 +192,7 @@ func (s *Store) ResolveByAPIKeyHash(hash string) (*TenantWithAPIKey, error) {
 	var clusterID sql.NullString
 	var revokedAt sql.NullTime
 	if err := row.Scan(
-		&out.Tenant.ID, &out.Tenant.Status, &out.Tenant.DBHost, &out.Tenant.DBPort, &out.Tenant.DBUser,
+		&out.Tenant.ID, &out.Tenant.Name, &out.Tenant.Status, &out.Tenant.DBHost, &out.Tenant.DBPort, &out.Tenant.DBUser,
 		&out.Tenant.DBPasswordCipher, &out.Tenant.DBName, &dbTLS, &out.Tenant.Provider, &clusterID,
 		&claimURL, &claimExp, &out.Tenant.SchemaVersion, &out.Tenant.CreatedAt, &out.Tenant.UpdatedAt,
 		&out.APIKey.ID, &out.APIKey.TenantID, &out.APIKey.KeyName, &out.APIKey.JWTCiphertext,
@@ -217,7 +223,7 @@ func (s *Store) ResolveByAPIKeyHash(hash string) (*TenantWithAPIKey, error) {
 }
 
 func (s *Store) GetTenant(id string) (*Tenant, error) {
-	row := s.db.QueryRow(`SELECT id, status, db_host, db_port, db_user, db_password, db_name,
+	row := s.db.QueryRow(`SELECT id, name, status, db_host, db_port, db_user, db_password, db_name,
 		db_tls, provider, cluster_id, claim_url, claim_expires_at, schema_version, created_at, updated_at
 		FROM tenants WHERE id = ?`, id)
 	var out Tenant
@@ -225,7 +231,7 @@ func (s *Store) GetTenant(id string) (*Tenant, error) {
 	var clusterID sql.NullString
 	var claimURL sql.NullString
 	var claimExp sql.NullTime
-	if err := row.Scan(&out.ID, &out.Status, &out.DBHost, &out.DBPort, &out.DBUser, &out.DBPasswordCipher,
+	if err := row.Scan(&out.ID, &out.Name, &out.Status, &out.DBHost, &out.DBPort, &out.DBUser, &out.DBPasswordCipher,
 		&out.DBName, &dbTLS, &out.Provider, &clusterID, &claimURL, &claimExp, &out.SchemaVersion,
 		&out.CreatedAt, &out.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -251,7 +257,7 @@ func (s *Store) ListTenantsByStatus(status TenantStatus, limit int) ([]Tenant, e
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := s.db.Query(`SELECT id, status, db_host, db_port, db_user, db_password, db_name,
+	rows, err := s.db.Query(`SELECT id, name, status, db_host, db_port, db_user, db_password, db_name,
 		db_tls, provider, cluster_id, claim_url, claim_expires_at, schema_version, created_at, updated_at
 		FROM tenants WHERE status = ? ORDER BY created_at ASC LIMIT ?`, status, limit)
 	if err != nil {
@@ -266,7 +272,7 @@ func (s *Store) ListTenantsByStatus(status TenantStatus, limit int) ([]Tenant, e
 		var clusterID sql.NullString
 		var claimURL sql.NullString
 		var claimExp sql.NullTime
-		if err := rows.Scan(&t.ID, &t.Status, &t.DBHost, &t.DBPort, &t.DBUser, &t.DBPasswordCipher,
+		if err := rows.Scan(&t.ID, &t.Name, &t.Status, &t.DBHost, &t.DBPort, &t.DBUser, &t.DBPasswordCipher,
 			&t.DBName, &dbTLS, &t.Provider, &clusterID, &claimURL, &claimExp, &t.SchemaVersion,
 			&t.CreatedAt, &t.UpdatedAt); err != nil {
 			return nil, err

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -167,8 +167,8 @@ func TestProvisionWithoutProvisionerReturnsNotFound(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	body, _ := json.Marshal(map[string]any{"provider": tenant.ProviderDB9})
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"name": "test-db"})
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/create", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -200,7 +200,7 @@ func TestTenantStatusWithValidKey(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if len(out) != 1 || out["status"] != string(meta.TenantActive) {
+	if out["id"] == "" || out["name"] == "" || out["status"] != string(meta.TenantActive) {
 		t.Fatalf("unexpected tenant status response: %+v", out)
 	}
 }
@@ -228,7 +228,7 @@ func TestTenantStatusReturnsProvisioningState(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if len(out) != 1 || out["status"] != string(meta.TenantProvisioning) {
+	if out["id"] == "" || out["name"] == "" || out["status"] != string(meta.TenantProvisioning) {
 		t.Fatalf("expected provisioning status, got %+v", out)
 	}
 }

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -94,8 +94,8 @@ func TestProvisionMarksTenantFailedWhenInitKeepsFailing(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	body, _ := json.Marshal(map[string]any{"provider": tenant.ProviderTiDBZero})
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"name": "failure-case"})
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/create", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -194,8 +194,8 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	body, _ := json.Marshal(map[string]any{"provider": tenant.ProviderTiDBZero, "db_tls": false})
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]any{"name": "configured-provisioner"})
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/create", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -212,6 +212,9 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	}
 	if out["api_key"] == "" {
 		t.Fatalf("unexpected provision response: %+v", out)
+	}
+	if out["id"] == "" || out["name"] == "" {
+		t.Fatalf("expected id and name in create response, got %+v", out)
 	}
 	resolved, err := metaStore.ResolveByAPIKeyHash(tenant.HashToken(out["api_key"]))
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -71,7 +71,7 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v1/uploads/", business)
 	mux.Handle("/v1/sql", business)
 	mux.HandleFunc("/v1/status", s.handleTenantStatus)
-	mux.HandleFunc("/v1/provision", s.handleProvision)
+	mux.HandleFunc("/v1/create", s.handleCreate)
 
 	local := cfg.LocalS3
 	if local == nil && cfg.Backend != nil {
@@ -223,7 +223,11 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": string(resolved.Tenant.Status)})
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"id":     resolved.Tenant.ID,
+		"name":   resolved.Tenant.Name,
+		"status": string(resolved.Tenant.Status),
+	})
 }
 
 func backendFromRequest(r *http.Request) *backend.Dat9Backend {
@@ -606,7 +610,7 @@ func (s *Server) handleUploadAbort(w http.ResponseWriter, r *http.Request, uploa
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
-func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -626,6 +630,19 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tenantID := tenant.NewID()
+	tenantName := tenant.HashToken(tenantID)
+	var req struct {
+		Name string `json:"name"`
+	}
+	if r.Body != nil {
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			errJSON(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+			return
+		}
+		if strings.TrimSpace(req.Name) != "" {
+			tenantName = strings.TrimSpace(req.Name)
+		}
+	}
 	keyName := "default"
 
 	token, err := tenant.IssueToken(s.tokenSecret, tenantID, 1)
@@ -655,6 +672,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.meta.InsertTenant(&meta.Tenant{
 		ID:               tenantID,
+		Name:             tenantName,
 		Status:           meta.TenantProvisioning,
 		DBHost:           cluster.Host,
 		DBPort:           cluster.Port,
@@ -697,6 +715,8 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]string{
+		"id":      tenantID,
+		"name":    tenantName,
 		"api_key": token,
 		"status":  string(meta.TenantProvisioning),
 	})


### PR DESCRIPTION
## Summary
- add `name` column support to `tenants` metadata model and persist/load it across control-plane queries
- replace `POST /v1/provision` with `POST /v1/create`
- support optional request body `{"name":"..."}` for create; when omitted, default tenant name is `hash(id)`
- update create response to return `id`, `name`, `api_key`, `status`
- update `GET /v1/status` response to return `id`, `name`, `status`
- update CLI create flow and e2e docs/scripts to match the new API surface

## Validation
- `go test ./...`
- `make lint`