### PR TITLE
fix: sign multipart part checksums in upload plans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,13 @@ SHELL := /bin/bash
 GO ?= go
 DOCKER ?= docker
 
+HOST_GOOS ?= $(shell $(GO) env GOOS)
+HOST_GOARCH ?= $(shell $(GO) env GOARCH)
+
+# Build target defaults to the local environment; callers can override.
+GOOS ?= $(HOST_GOOS)
+GOARCH ?= $(HOST_GOARCH)
+
 APP_NAME ?= dat9-server
 CLI_NAME ?= dat9
 
@@ -50,11 +57,11 @@ build: build-server build-cli
 
 build-server:
 	mkdir -p $(BIN_DIR)
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -o $(SERVER_BIN) ./cmd/dat9-server
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -o $(SERVER_BIN) ./cmd/dat9-server
 
 build-cli:
 	mkdir -p $(BIN_DIR)
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -o $(CLI_BIN) ./cmd/dat9
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -o $(CLI_BIN) ./cmd/dat9
 
 docker-build: build-server
 	DOCKER_BUILDKIT=0 $(DOCKER) build -t $(IMAGE) .

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -32,6 +32,10 @@ func (b *Dat9Backend) IsLargeFile(size int64) bool {
 // InitiateUpload creates a multipart upload for a large file.
 // Returns an UploadPlan with presigned URLs for all parts.
 func (b *Dat9Backend) InitiateUpload(ctx context.Context, path string, totalSize int64) (*UploadPlan, error) {
+	return b.InitiateUploadWithChecksums(ctx, path, totalSize, nil)
+}
+
+func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path string, totalSize int64, partChecksums []string) (*UploadPlan, error) {
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
 		return nil, err
@@ -57,11 +61,18 @@ func (b *Dat9Backend) InitiateUpload(ctx context.Context, path string, totalSize
 
 	// Calculate parts
 	parts := s3client.CalcParts(totalSize, s3client.PartSize)
+	if len(partChecksums) > 0 && len(partChecksums) != len(parts) {
+		return nil, fmt.Errorf("part checksum count mismatch: got %d, expected %d", len(partChecksums), len(parts))
+	}
 
 	// Presign all part URLs
 	urls := make([]*s3client.UploadPartURL, len(parts))
 	for i, p := range parts {
-		u, err := b.s3.PresignUploadPart(ctx, s3Key, mpu.UploadID, p.Number, p.Size, s3client.UploadTTL)
+		checksum := ""
+		if len(partChecksums) > 0 {
+			checksum = partChecksums[i]
+		}
+		u, err := b.s3.PresignUploadPart(ctx, s3Key, mpu.UploadID, p.Number, p.Size, checksum, s3client.UploadTTL)
 		if err != nil {
 			_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 			return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
@@ -214,6 +225,10 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 
 // ResumeUpload returns presigned URLs for the missing parts of an in-progress upload.
 func (b *Dat9Backend) ResumeUpload(ctx context.Context, uploadID string) (*UploadPlan, error) {
+	return b.ResumeUploadWithChecksums(ctx, uploadID, nil)
+}
+
+func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID string, partChecksums []string) (*UploadPlan, error) {
 	upload, err := b.store.GetUpload(uploadID)
 	if err != nil {
 		return nil, err
@@ -246,6 +261,9 @@ func (b *Dat9Backend) ResumeUpload(ctx context.Context, uploadID string) (*Uploa
 
 	// Calculate all expected parts
 	allParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
+	if len(partChecksums) > 0 && len(partChecksums) != len(allParts) {
+		return nil, fmt.Errorf("part checksum count mismatch: got %d, expected %d", len(partChecksums), len(allParts))
+	}
 
 	// Presign only the missing parts
 	var urls []*s3client.UploadPartURL
@@ -253,7 +271,11 @@ func (b *Dat9Backend) ResumeUpload(ctx context.Context, uploadID string) (*Uploa
 		if uploadedSet[p.Number] {
 			continue
 		}
-		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, p.Number, p.Size, s3client.UploadTTL)
+		checksum := ""
+		if len(partChecksums) > 0 {
+			checksum = partChecksums[p.Number-1]
+		}
+		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, p.Number, p.Size, checksum, s3client.UploadTTL)
 		if err != nil {
 			return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
 		}

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -19,6 +20,8 @@ type UploadPlan struct {
 	PartSize int64                     `json:"part_size"`
 	Parts    []*s3client.UploadPartURL `json:"parts"`
 }
+
+var ErrPartChecksumCountMismatch = errors.New("part checksum count mismatch")
 
 // S3 returns the S3Client (nil when not configured).
 func (b *Dat9Backend) S3() s3client.S3Client { return b.s3 }
@@ -62,7 +65,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 	// Calculate parts
 	parts := s3client.CalcParts(totalSize, s3client.PartSize)
 	if len(partChecksums) > 0 && len(partChecksums) != len(parts) {
-		return nil, fmt.Errorf("part checksum count mismatch: got %d, expected %d", len(partChecksums), len(parts))
+		return nil, fmt.Errorf("%w: got %d, expected %d", ErrPartChecksumCountMismatch, len(partChecksums), len(parts))
 	}
 
 	// Presign all part URLs
@@ -262,7 +265,7 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 	// Calculate all expected parts
 	allParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	if len(partChecksums) > 0 && len(partChecksums) != len(allParts) {
-		return nil, fmt.Errorf("part checksum count mismatch: got %d, expected %d", len(partChecksums), len(allParts))
+		return nil, fmt.Errorf("%w: got %d, expected %d", ErrPartChecksumCountMismatch, len(partChecksums), len(allParts))
 	}
 
 	// Presign only the missing parts

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/mem9-ai/dat9/pkg/s3client"
@@ -23,10 +24,11 @@ type UploadPlan struct {
 
 // PartURL is a presigned URL for uploading one part.
 type PartURL struct {
-	Number    int    `json:"number"`
-	URL       string `json:"url"`
-	Size      int64  `json:"size"`
-	ExpiresAt string `json:"expires_at"`
+	Number         int    `json:"number"`
+	URL            string `json:"url"`
+	Size           int64  `json:"size"`
+	ChecksumSHA256 string `json:"checksum_sha256,omitempty"`
+	ExpiresAt      string `json:"expires_at"`
 }
 
 // ProgressFunc is called after each part upload completes.
@@ -59,6 +61,15 @@ func (c *Client) WriteStream(ctx context.Context, path string, r io.Reader, size
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("X-Dat9-Content-Length", fmt.Sprintf("%d", size))
+	if ra, ok := r.(io.ReaderAt); ok {
+		checksums, err := computePartChecksumsFromReaderAt(ra, size, s3client.PartSize)
+		if err != nil {
+			return fmt.Errorf("compute part checksums: %w", err)
+		}
+		if len(checksums) > 0 {
+			req.Header.Set("X-Dat9-Part-Checksums", strings.Join(checksums, ","))
+		}
+	}
 
 	resp, err := c.do(req)
 	if err != nil {
@@ -118,7 +129,7 @@ func (c *Client) uploadParts(ctx context.Context, plan UploadPlan, r io.Reader, 
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			_, err := c.uploadOnePart(ctx, p.URL, data)
+			_, err := c.uploadOnePart(ctx, p, data)
 			if err != nil {
 				select {
 				case errCh <- fmt.Errorf("part %d: %w", p.Number, err):
@@ -145,11 +156,14 @@ func (c *Client) uploadParts(ctx context.Context, plan UploadPlan, r io.Reader, 
 }
 
 // uploadOnePart PUTs data to a presigned URL and returns the ETag.
-func (c *Client) uploadOnePart(ctx context.Context, url string, data []byte) (string, error) {
+func (c *Client) uploadOnePart(ctx context.Context, part PartURL, data []byte) (string, error) {
 	h := sha256.Sum256(data)
 	checksum := base64.StdEncoding.EncodeToString(h[:])
+	if part.ChecksumSHA256 != "" && part.ChecksumSHA256 != checksum {
+		return "", fmt.Errorf("checksum mismatch for part %d", part.Number)
+	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, part.URL, bytes.NewReader(data))
 	if err != nil {
 		return "", err
 	}
@@ -262,7 +276,11 @@ func (c *Client) ResumeUpload(ctx context.Context, path string, r io.ReaderAt, t
 	}
 
 	// Step 2: Request resume — server returns presigned URLs for missing parts
-	plan, err := c.requestResume(ctx, meta.UploadID)
+	checksums, err := computePartChecksumsFromReaderAt(r, totalSize, s3client.PartSize)
+	if err != nil {
+		return fmt.Errorf("compute part checksums: %w", err)
+	}
+	plan, err := c.requestResume(ctx, meta.UploadID, checksums)
 	if err != nil {
 		return err
 	}
@@ -311,11 +329,14 @@ func (c *Client) queryUpload(ctx context.Context, path string) (*UploadMeta, err
 }
 
 // requestResume asks the server to generate presigned URLs for missing parts.
-func (c *Client) requestResume(ctx context.Context, uploadID string) (*UploadPlan, error) {
+func (c *Client) requestResume(ctx context.Context, uploadID string, checksums []string) (*UploadPlan, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		c.baseURL+"/v1/uploads/"+uploadID+"/resume", nil)
 	if err != nil {
 		return nil, err
+	}
+	if len(checksums) > 0 {
+		req.Header.Set("X-Dat9-Part-Checksums", strings.Join(checksums, ","))
 	}
 	resp, err := c.do(req)
 	if err != nil {
@@ -384,7 +405,7 @@ func (c *Client) uploadMissingParts(ctx context.Context, plan UploadPlan, r io.R
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			_, err := c.uploadOnePart(ctx, p.URL, d)
+			_, err := c.uploadOnePart(ctx, p, d)
 			if err != nil {
 				select {
 				case errCh <- fmt.Errorf("part %d: %w", p.Number, err):
@@ -407,4 +428,26 @@ func (c *Client) uploadMissingParts(ctx context.Context, plan UploadPlan, r io.R
 	}
 
 	return nil
+}
+
+func computePartChecksumsFromReaderAt(r io.ReaderAt, totalSize int64, partSize int64) ([]string, error) {
+	if totalSize <= 0 {
+		return nil, nil
+	}
+	parts := s3client.CalcParts(totalSize, partSize)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		buf := make([]byte, p.Size)
+		offset := int64(p.Number-1) * partSize
+		n, err := r.ReadAt(buf, offset)
+		if err != nil && err != io.EOF {
+			return nil, fmt.Errorf("read part %d: %w", p.Number, err)
+		}
+		if int64(n) != p.Size {
+			return nil, fmt.Errorf("short read for part %d: got %d want %d", p.Number, n, p.Size)
+		}
+		h := sha256.Sum256(buf)
+		out = append(out, base64.StdEncoding.EncodeToString(h[:]))
+	}
+	return out, nil
 }

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -63,7 +63,7 @@ func (c *Client) WriteStream(ctx context.Context, path string, r io.Reader, size
 	req.Header.Set("X-Dat9-Content-Length", fmt.Sprintf("%d", size))
 	ra, ok := r.(io.ReaderAt)
 	if !ok {
-		return fmt.Errorf("large uploads require a seekable reader")
+		return fmt.Errorf("large uploads require an io.ReaderAt (seekable source) to compute per-part checksums")
 	}
 	checksums, err := computePartChecksumsFromReaderAt(ra, size, s3client.PartSize)
 	if err != nil {

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -61,14 +61,16 @@ func (c *Client) WriteStream(ctx context.Context, path string, r io.Reader, size
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("X-Dat9-Content-Length", fmt.Sprintf("%d", size))
-	if ra, ok := r.(io.ReaderAt); ok {
-		checksums, err := computePartChecksumsFromReaderAt(ra, size, s3client.PartSize)
-		if err != nil {
-			return fmt.Errorf("compute part checksums: %w", err)
-		}
-		if len(checksums) > 0 {
-			req.Header.Set("X-Dat9-Part-Checksums", strings.Join(checksums, ","))
-		}
+	ra, ok := r.(io.ReaderAt)
+	if !ok {
+		return fmt.Errorf("large uploads require a seekable reader")
+	}
+	checksums, err := computePartChecksumsFromReaderAt(ra, size, s3client.PartSize)
+	if err != nil {
+		return fmt.Errorf("compute part checksums: %w", err)
+	}
+	if len(checksums) > 0 {
+		req.Header.Set("X-Dat9-Part-Checksums", strings.Join(checksums, ","))
 	}
 
 	resp, err := c.do(req)

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -125,6 +126,20 @@ func TestWriteStreamLargeFile(t *testing.T) {
 	}
 	if len(progressCalls) != 2 {
 		t.Errorf("progress called %d times, want 2", len(progressCalls))
+	}
+}
+
+func TestWriteStreamLargeFileRequiresSeekableReader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("server should not be called for non-seekable large upload")
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	c.smallFileThreshold = 1
+
+	if err := c.WriteStream(context.Background(), "/large.bin", io.NopCloser(bytes.NewReader([]byte("12345678"))), 8, nil); err == nil {
+		t.Fatal("expected error for non-seekable large upload")
 	}
 }
 
@@ -305,6 +320,11 @@ func TestResumeUploadIntegrationProgressTotal(t *testing.T) {
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("X-Dat9-Content-Length", fmt.Sprintf("%d", len(data)))
+	checksums, err := computePartChecksumsFromReaderAt(bytes.NewReader(data), int64(len(data)), s3client.PartSize)
+	if err != nil {
+		t.Fatalf("compute checksums: %v", err)
+	}
+	req.Header.Set("X-Dat9-Part-Checksums", strings.Join(checksums, ","))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -328,6 +348,9 @@ func TestResumeUploadIntegrationProgressTotal(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.ContentLength = plan.Parts[0].Size
+	if plan.Parts[0].ChecksumSHA256 != "" {
+		req.Header.Set("x-amz-checksum-sha256", plan.Parts[0].ChecksumSHA256)
+	}
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -94,25 +94,30 @@ func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string) (*M
 	}, nil
 }
 
-func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, ttl time.Duration) (*UploadPartURL, error) {
+func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, checksumSHA256 string, ttl time.Duration) (*UploadPartURL, error) {
 	if ttl > UploadTTL {
 		ttl = UploadTTL
 	}
-	out, err := c.presign.PresignUploadPart(ctx, &s3.UploadPartInput{
+	in := &s3.UploadPartInput{
 		Bucket:        &c.bucket,
 		Key:           aws.String(c.fullKey(key)),
 		UploadId:      &uploadID,
 		PartNumber:    aws.Int32(int32(partNumber)),
 		ContentLength: aws.Int64(partSize),
-	}, s3.WithPresignExpires(ttl))
+	}
+	if checksumSHA256 != "" {
+		in.ChecksumSHA256 = aws.String(checksumSHA256)
+	}
+	out, err := c.presign.PresignUploadPart(ctx, in, s3.WithPresignExpires(ttl))
 	if err != nil {
 		return nil, fmt.Errorf("presign upload part: %w", err)
 	}
 	return &UploadPartURL{
-		Number:    partNumber,
-		URL:       out.URL,
-		Size:      partSize,
-		ExpiresAt: time.Now().Add(ttl),
+		Number:         partNumber,
+		URL:            out.URL,
+		Size:           partSize,
+		ChecksumSHA256: checksumSHA256,
+		ExpiresAt:      time.Now().Add(ttl),
 	}, nil
 }
 

--- a/pkg/s3client/local.go
+++ b/pkg/s3client/local.go
@@ -68,13 +68,14 @@ func (c *LocalS3Client) CreateMultipartUpload(ctx context.Context, key string) (
 	return &MultipartUpload{UploadID: uploadID, Key: key}, nil
 }
 
-func (c *LocalS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, ttl time.Duration) (*UploadPartURL, error) {
+func (c *LocalS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, checksumSHA256 string, ttl time.Duration) (*UploadPartURL, error) {
 	url := fmt.Sprintf("%s/upload/%s/%d", c.baseURL, uploadID, partNumber)
 	return &UploadPartURL{
-		Number:    partNumber,
-		URL:       url,
-		Size:      partSize,
-		ExpiresAt: time.Now().Add(ttl),
+		Number:         partNumber,
+		URL:            url,
+		Size:           partSize,
+		ChecksumSHA256: checksumSHA256,
+		ExpiresAt:      time.Now().Add(ttl),
 	}, nil
 }
 

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -19,10 +19,11 @@ type Part struct {
 
 // UploadPartURL is a presigned URL for uploading one part.
 type UploadPartURL struct {
-	Number    int       // 1-based part number
-	URL       string    // presigned PUT URL
-	Size      int64     // expected part size
-	ExpiresAt time.Time // URL expiry
+	Number         int       `json:"number"`                    // 1-based part number
+	URL            string    `json:"url"`                       // presigned PUT URL
+	Size           int64     `json:"size"`                      // expected part size
+	ChecksumSHA256 string    `json:"checksum_sha256,omitempty"` // expected checksum for signed uploads
+	ExpiresAt      time.Time `json:"expires_at"`                // URL expiry
 }
 
 // MultipartUpload holds the state of an initiated multipart upload.
@@ -39,7 +40,7 @@ type S3Client interface {
 
 	// PresignUploadPart returns a presigned URL for uploading a specific part.
 	// partSize is bound into the presigned URL as Content-Length per §11.2.
-	PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, ttl time.Duration) (*UploadPartURL, error)
+	PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, checksumSHA256 string, ttl time.Duration) (*UploadPartURL, error)
 
 	// CompleteMultipartUpload finalizes the upload with the given parts.
 	CompleteMultipartUpload(ctx context.Context, key, uploadID string, parts []Part) error

--- a/pkg/s3client/s3client_test.go
+++ b/pkg/s3client/s3client_test.go
@@ -169,7 +169,7 @@ func TestPresignURLsGenerated(t *testing.T) {
 
 	upload, _ := c.CreateMultipartUpload(ctx, "blobs/presign-test")
 
-	url, err := c.PresignUploadPart(ctx, "blobs/presign-test", upload.UploadID, 1, 8<<20, UploadTTL)
+	url, err := c.PresignUploadPart(ctx, "blobs/presign-test", upload.UploadID, 1, 8<<20, "", UploadTTL)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -340,9 +341,13 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 			errJSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
+		if len(partChecksums) == 0 {
+			errJSON(w, http.StatusBadRequest, "missing X-Dat9-Part-Checksums header")
+			return
+		}
 		plan, err := b.InitiateUploadWithChecksums(r.Context(), path, cl, partChecksums)
 		if err != nil {
-			if strings.Contains(err.Error(), "checksum") {
+			if errors.Is(err, backend.ErrPartChecksumCountMismatch) {
 				errJSON(w, http.StatusBadRequest, err.Error())
 				return
 			}
@@ -583,9 +588,13 @@ func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uplo
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if len(partChecksums) == 0 {
+		errJSON(w, http.StatusBadRequest, "missing X-Dat9-Part-Checksums header")
+		return
+	}
 	plan, err := b.ResumeUploadWithChecksums(r.Context(), uploadID, partChecksums)
 	if err != nil {
-		if strings.Contains(err.Error(), "checksum") {
+		if errors.Is(err, backend.ErrPartChecksumCountMismatch) {
 			errJSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
@@ -617,6 +626,10 @@ func parsePartChecksumsHeader(raw string) ([]string, error) {
 	for _, p := range parts {
 		v := strings.TrimSpace(p)
 		if v == "" {
+			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header")
+		}
+		decoded, err := base64.StdEncoding.DecodeString(v)
+		if err != nil || len(decoded) != 32 {
 			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header")
 		}
 		out = append(out, v)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -335,8 +335,17 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		cl, _ = strconv.ParseInt(h, 10, 64)
 	}
 	if cl > 0 && b.IsLargeFile(cl) {
-		plan, err := b.InitiateUpload(r.Context(), path, cl)
+		partChecksums, err := parsePartChecksumsHeader(r.Header.Get("X-Dat9-Part-Checksums"))
 		if err != nil {
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		plan, err := b.InitiateUploadWithChecksums(r.Context(), path, cl, partChecksums)
+		if err != nil {
+			if strings.Contains(err.Error(), "checksum") {
+				errJSON(w, http.StatusBadRequest, err.Error())
+				return
+			}
 			if errors.Is(err, datastore.ErrUploadConflict) {
 				errJSON(w, http.StatusConflict, err.Error())
 				return
@@ -569,8 +578,17 @@ func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uplo
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
-	plan, err := b.ResumeUpload(r.Context(), uploadID)
+	partChecksums, err := parsePartChecksumsHeader(r.Header.Get("X-Dat9-Part-Checksums"))
 	if err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	plan, err := b.ResumeUploadWithChecksums(r.Context(), uploadID, partChecksums)
+	if err != nil {
+		if strings.Contains(err.Error(), "checksum") {
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		if errors.Is(err, datastore.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
@@ -587,6 +605,23 @@ func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uplo
 		return
 	}
 	_ = json.NewEncoder(w).Encode(plan)
+}
+
+func parsePartChecksumsHeader(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		v := strings.TrimSpace(p)
+		if v == "" {
+			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header")
+		}
+		out = append(out, v)
+	}
+	return out, nil
 }
 
 func (s *Server) handleUploadAbort(w http.ResponseWriter, r *http.Request, uploadID string) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -623,14 +623,17 @@ func parsePartChecksumsHeader(raw string) ([]string, error) {
 	}
 	parts := strings.Split(raw, ",")
 	out := make([]string, 0, len(parts))
-	for _, p := range parts {
+	for i, p := range parts {
 		v := strings.TrimSpace(p)
 		if v == "" {
-			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header")
+			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header: empty value at index %d", i)
 		}
 		decoded, err := base64.StdEncoding.DecodeString(v)
-		if err != nil || len(decoded) != 32 {
-			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header")
+		if err != nil {
+			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header: invalid base64 at index %d", i)
+		}
+		if len(decoded) != 32 {
+			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header: decoded length %d at index %d, expected 32", len(decoded), i)
 		}
 		out = append(out, v)
 	}

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -396,3 +396,20 @@ func TestAbortUploadEndpoint(t *testing.T) {
 		t.Errorf("expected ABORTED, got %s", upload.Status)
 	}
 }
+
+func TestParsePartChecksumsHeaderValidation(t *testing.T) {
+	if _, err := parsePartChecksumsHeader(""); err != nil {
+		t.Fatalf("empty header should be allowed: %v", err)
+	}
+
+	_, err := parsePartChecksumsHeader("not-base64")
+	if err == nil || !strings.Contains(err.Error(), "invalid base64") {
+		t.Fatalf("expected base64 error, got %v", err)
+	}
+
+	short := base64.StdEncoding.EncodeToString([]byte("short"))
+	_, err = parsePartChecksumsHeader(short)
+	if err == nil || !strings.Contains(err.Error(), "expected 32") {
+		t.Fatalf("expected decoded length error, got %v", err)
+	}
+}

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -3,11 +3,14 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/mem9-ai/dat9/internal/testmysql"
@@ -50,6 +53,18 @@ func newTestServerWithS3(t *testing.T) (*Server, *s3client.LocalS3Client) {
 	return New(b), s3c
 }
 
+func partChecksumHeader(data []byte) string {
+	parts := s3client.CalcParts(int64(len(data)), s3client.PartSize)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		start := int64(p.Number-1) * s3client.PartSize
+		end := start + p.Size
+		h := sha256.Sum256(data[start:end])
+		out = append(out, base64.StdEncoding.EncodeToString(h[:]))
+	}
+	return strings.Join(out, ",")
+}
+
 func TestLargeFilePut202(t *testing.T) {
 	s, _ := newTestServerWithS3(t)
 	ts := httptest.NewServer(s)
@@ -59,6 +74,7 @@ func TestLargeFilePut202(t *testing.T) {
 	body := make([]byte, 1<<20) // exactly 1MB
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/big.bin", bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
+	req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(body))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -109,6 +125,7 @@ func TestUploadCompleteEndpoint(t *testing.T) {
 	body := make([]byte, 1<<20)
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/complete-test.bin", bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
+	req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(body))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -158,6 +175,7 @@ func TestUploadResumeEndpoint(t *testing.T) {
 	body := make([]byte, totalSize)
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/resume-test.bin", bytes.NewReader(body))
 	req.ContentLength = totalSize
+	req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(body))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -178,6 +196,7 @@ func TestUploadResumeEndpoint(t *testing.T) {
 
 	// POST /v1/uploads/{id}/resume
 	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/uploads/"+plan.UploadID+"/resume", nil)
+	req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(body))
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -217,8 +236,10 @@ func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 
 	// Initiate a large upload to the same path.
 	totalSize := int64(2 << 20)
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/overwrite.bin", bytes.NewReader(make([]byte, totalSize)))
+	largeBody := make([]byte, totalSize)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/overwrite.bin", bytes.NewReader(largeBody))
 	req.ContentLength = totalSize
+	req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(largeBody))
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -279,6 +300,7 @@ func TestListUploadsEndpoint(t *testing.T) {
 	body := make([]byte, 1<<20)
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/list-test.bin", bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
+	req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(body))
 	resp, _ := http.DefaultClient.Do(req)
 	_ = resp.Body.Close()
 
@@ -320,6 +342,7 @@ func TestOneUploadPerPath(t *testing.T) {
 	body := make([]byte, 1<<20)
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/dup-test.bin", bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
+	req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(body))
 	resp, _ := http.DefaultClient.Do(req)
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted {
@@ -329,6 +352,7 @@ func TestOneUploadPerPath(t *testing.T) {
 	// Second upload for same path should fail
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/dup-test.bin", bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
+	req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(body))
 	resp, _ = http.DefaultClient.Do(req)
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusConflict {
@@ -345,6 +369,7 @@ func TestAbortUploadEndpoint(t *testing.T) {
 	body := make([]byte, 1<<20)
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/abort-test.bin", bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
+	req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(body))
 	resp, _ := http.DefaultClient.Do(req)
 
 	var plan backend.UploadPlan


### PR DESCRIPTION
## Summary
- keep multipart uploads on checksum mode and include per-part `x-amz-checksum-sha256` in presigned upload-part signatures
- extend upload plan part payload to expose `checksum_sha256` so clients can upload with checksum headers that match signed requests
- add server support for `X-Dat9-Part-Checksums` on initiate/resume and validate checksum-count consistency
- update backend and client upload/resume flows to propagate per-part checksums end-to-end

## Validation
- `go test ./...`
- `make lint`