### PR TITLE
feat: support db9-style <name>:/path context selector in fs commands

### DIFF
--- a/cmd/dat9/cli/client.go
+++ b/cmd/dat9/cli/client.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/mem9-ai/dat9/pkg/client"
@@ -19,8 +20,15 @@ func NewClientForContext(ctxName string) *client.Client {
 		if name == "" {
 			name = cfg.CurrentContext
 		}
-		if ctx, ok := cfg.Contexts[name]; ok {
-			apiKey = ctx.APIKey
+		if name != "" {
+			ctx, ok := cfg.Contexts[name]
+			if !ok && ctxName != "" {
+				fmt.Fprintf(os.Stderr, "error: context %q not found in %s\n", ctxName, configPath())
+				os.Exit(1)
+			}
+			if ok {
+				apiKey = ctx.APIKey
+			}
 		}
 	}
 	return client.New(server, apiKey)

--- a/cmd/dat9/cli/client.go
+++ b/cmd/dat9/cli/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/client"
 )
 
-func NewFromEnv() *client.Client {
+func NewClientForContext(ctxName string) *client.Client {
 	server := os.Getenv("DAT9_SERVER")
 	apiKey := os.Getenv("DAT9_API_KEY")
 
@@ -15,7 +15,17 @@ func NewFromEnv() *client.Client {
 		server = cfg.ResolveServer()
 	}
 	if apiKey == "" {
-		apiKey = cfg.CurrentAPIKey()
+		name := ctxName
+		if name == "" {
+			name = cfg.CurrentContext
+		}
+		if ctx, ok := cfg.Contexts[name]; ok {
+			apiKey = ctx.APIKey
+		}
 	}
 	return client.New(server, apiKey)
+}
+
+func NewFromEnv() *client.Client {
+	return NewClientForContext("")
 }

--- a/cmd/dat9/cli/cp.go
+++ b/cmd/dat9/cli/cp.go
@@ -45,6 +45,9 @@ func Cp(c *client.Client, args []string) error {
 		ctxName = srcRP.Context
 	}
 	if dstIsRemote && dstRP.Context != "" {
+		if ctxName != "" && ctxName != dstRP.Context {
+			return fmt.Errorf("cross-context copy not supported: %s vs %s", ctxName, dstRP.Context)
+		}
 		ctxName = dstRP.Context
 	}
 	if ctxName != "" {

--- a/cmd/dat9/cli/cp.go
+++ b/cmd/dat9/cli/cp.go
@@ -6,21 +6,20 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/mem9-ai/dat9/pkg/client"
 )
 
 // Cp copies files between local and remote.
 //
-// Remote paths use a ":" prefix to distinguish from local paths:
+// Remote paths use ":" or "<name>:" prefix:
 //
-//	dat9 cp local.txt :/remote/path       upload
-//	dat9 cp :/remote/path local.txt       download
-//	dat9 cp :/remote/a :/remote/b         server-side copy (zero-copy)
-//	dat9 cp - :/remote/path               upload from stdin
-//	dat9 cp :/remote/path -               download to stdout
-//	dat9 cp --resume local.txt :/remote   resume interrupted upload
+//	dat9 fs cp local.txt :/remote/path          upload (current context)
+//	dat9 fs cp local.txt mydb:/remote/path      upload (mydb context)
+//	dat9 fs cp mydb:/remote/path local.txt      download
+//	dat9 fs cp :/remote/a :/remote/b            server-side copy
+//	dat9 fs cp - :/remote/path                  upload from stdin
+//	dat9 fs cp :/remote/path -                  download to stdout
 func Cp(c *client.Client, args []string) error {
 	resume := false
 	filtered := args[:0]
@@ -34,52 +33,51 @@ func Cp(c *client.Client, args []string) error {
 	args = filtered
 
 	if len(args) != 2 {
-		return fmt.Errorf("usage: dat9 cp [--resume] <src> <dst>")
+		return fmt.Errorf("usage: dat9 fs cp [--resume] <src> <dst>")
 	}
 	src, dst := args[0], args[1]
 
-	srcRemote := isRemote(src)
-	dstRemote := isRemote(dst)
+	srcRP, srcIsRemote := ParseRemote(src)
+	dstRP, dstIsRemote := ParseRemote(dst)
 
-	if srcRemote {
-		src = src[1:]
+	ctxName := ""
+	if srcIsRemote && srcRP.Context != "" {
+		ctxName = srcRP.Context
 	}
-	if dstRemote {
-		dst = dst[1:]
+	if dstIsRemote && dstRP.Context != "" {
+		ctxName = dstRP.Context
+	}
+	if ctxName != "" {
+		c = NewClientForContext(ctxName)
 	}
 
 	ctx := context.Background()
 
 	switch {
-	case src == "-" && dstRemote:
-		// stdin → remote (small files only; stdin requires full read to know size)
+	case src == "-" && dstIsRemote:
 		data, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("read stdin: %w", err)
 		}
-		return c.WriteStream(ctx, dst, bytes.NewReader(data), int64(len(data)), printProgress)
+		return c.WriteStream(ctx, dstRP.Path, bytes.NewReader(data), int64(len(data)), printProgress)
 
-	case srcRemote && dst == "-":
-		// remote → stdout
-		return streamToStdout(ctx, c, src)
+	case srcIsRemote && dst == "-":
+		return streamToStdout(ctx, c, srcRP.Path)
 
-	case !srcRemote && dstRemote:
-		// local → remote (upload)
+	case !srcIsRemote && dstIsRemote:
 		if resume {
-			return resumeUpload(ctx, c, src, dst)
+			return resumeUpload(ctx, c, src, dstRP.Path)
 		}
-		return uploadFile(ctx, c, src, dst)
+		return uploadFile(ctx, c, src, dstRP.Path)
 
-	case srcRemote && !dstRemote:
-		// remote → local (download)
-		return downloadFile(ctx, c, src, dst)
+	case srcIsRemote && !dstIsRemote:
+		return downloadFile(ctx, c, srcRP.Path, dst)
 
-	case srcRemote && dstRemote:
-		// remote → remote (server-side copy, zero-copy)
-		return c.Copy(src, dst)
+	case srcIsRemote && dstIsRemote:
+		return c.Copy(srcRP.Path, dstRP.Path)
 
 	default:
-		return fmt.Errorf("at least one path must be remote (use : prefix, e.g. :/path)")
+		return fmt.Errorf("at least one path must be remote (e.g. :/path or mydb:/path)")
 	}
 }
 
@@ -141,19 +139,9 @@ func streamToStdout(ctx context.Context, c *client.Client, remotePath string) er
 	return err
 }
 
-// printProgress displays part-level upload progress.
 func printProgress(partNumber, totalParts int, bytesUploaded int64) {
 	fmt.Fprintf(os.Stderr, "\r  part %d/%d uploaded (%d bytes)", partNumber, totalParts, bytesUploaded)
 	if partNumber == totalParts {
 		fmt.Fprintln(os.Stderr)
 	}
-}
-
-// isRemote returns true if a path refers to a remote dat9 path.
-// Remote paths use a ":" prefix (e.g., ":/data/file.txt").
-func isRemote(path string) bool {
-	if path == "-" {
-		return false
-	}
-	return strings.HasPrefix(path, ":")
 }

--- a/cmd/dat9/cli/cp_test.go
+++ b/cmd/dat9/cli/cp_test.go
@@ -18,6 +18,8 @@ func TestParseRemote(t *testing.T) {
 		{"local.txt", "", "", false},
 		{"./local.txt", "", "", false},
 		{"-", "", "", false},
+		{"C:/tmp/a.txt", "", "", false},
+		{"D:/Users/test", "", "", false},
 	}
 	for _, tt := range tests {
 		rp, ok := ParseRemote(tt.input)

--- a/cmd/dat9/cli/cp_test.go
+++ b/cmd/dat9/cli/cp_test.go
@@ -18,8 +18,12 @@ func TestParseRemote(t *testing.T) {
 		{"local.txt", "", "", false},
 		{"./local.txt", "", "", false},
 		{"-", "", "", false},
+		// Windows drive-letter paths must not be treated as remote.
 		{"C:/tmp/a.txt", "", "", false},
 		{"D:/Users/test", "", "", false},
+		{"c:/data", "", "", false},
+		// Two-char context names still work.
+		{"ab:/file.txt", "ab", "/file.txt", true},
 	}
 	for _, tt := range tests {
 		rp, ok := ParseRemote(tt.input)

--- a/cmd/dat9/cli/cp_test.go
+++ b/cmd/dat9/cli/cp_test.go
@@ -2,23 +2,36 @@ package cli
 
 import "testing"
 
-func TestIsRemote(t *testing.T) {
+func TestParseRemote(t *testing.T) {
 	tests := []struct {
-		path string
-		want bool
+		input    string
+		wantCtx  string
+		wantPath string
+		wantOK   bool
 	}{
-		{":/data/file.txt", true},
-		{":/", true},
-		{"/data/file.txt", false},
-		{"/tmp/local.txt", false},
-		{"local.txt", false},
-		{"./local.txt", false},
-		{"-", false},
+		{":/data/file.txt", "", "/data/file.txt", true},
+		{":/", "", "/", true},
+		{"test1:/TODO.md", "test1", "/TODO.md", true},
+		{"mydb:/data/file.txt", "mydb", "/data/file.txt", true},
+		{"/data/file.txt", "", "", false},
+		{"/tmp/local.txt", "", "", false},
+		{"local.txt", "", "", false},
+		{"./local.txt", "", "", false},
+		{"-", "", "", false},
 	}
 	for _, tt := range tests {
-		got := isRemote(tt.path)
-		if got != tt.want {
-			t.Errorf("isRemote(%q) = %v, want %v", tt.path, got, tt.want)
+		rp, ok := ParseRemote(tt.input)
+		if ok != tt.wantOK {
+			t.Errorf("ParseRemote(%q) ok=%v, want %v", tt.input, ok, tt.wantOK)
+			continue
+		}
+		if ok {
+			if rp.Context != tt.wantCtx {
+				t.Errorf("ParseRemote(%q) context=%q, want %q", tt.input, rp.Context, tt.wantCtx)
+			}
+			if rp.Path != tt.wantPath {
+				t.Errorf("ParseRemote(%q) path=%q, want %q", tt.input, rp.Path, tt.wantPath)
+			}
 		}
 	}
 }

--- a/cmd/dat9/cli/path.go
+++ b/cmd/dat9/cli/path.go
@@ -18,6 +18,9 @@ func ParseRemote(s string) (RemotePath, bool) {
 		}
 		return RemotePath{}, false
 	}
+	if idx == 1 {
+		return RemotePath{}, false
+	}
 	return RemotePath{
 		Context: s[:idx],
 		Path:    s[idx+1:],

--- a/cmd/dat9/cli/path.go
+++ b/cmd/dat9/cli/path.go
@@ -1,0 +1,25 @@
+package cli
+
+import "strings"
+
+type RemotePath struct {
+	Context string
+	Path    string
+}
+
+func ParseRemote(s string) (RemotePath, bool) {
+	if s == "-" {
+		return RemotePath{}, false
+	}
+	idx := strings.Index(s, ":/")
+	if idx < 0 {
+		if strings.HasPrefix(s, ":") {
+			return RemotePath{Path: s[1:]}, true
+		}
+		return RemotePath{}, false
+	}
+	return RemotePath{
+		Context: s[:idx],
+		Path:    s[idx+1:],
+	}, true
+}

--- a/cmd/dat9/main.go
+++ b/cmd/dat9/main.go
@@ -123,20 +123,21 @@ func extractContext(args []string) (string, []string) {
 			continue
 		}
 		idx := strings.Index(arg, ":/")
-		if idx >= 0 {
-			name := ""
-			if idx > 0 {
-				name = arg[:idx]
-			}
-			if name != "" && ctxName != "" && ctxName != name {
-				fmt.Fprintf(os.Stderr, "error: conflicting contexts: %s vs %s\n", ctxName, name)
-				os.Exit(1)
-			}
-			if name != "" {
-				ctxName = name
-			}
-			args[i] = arg[idx+1:]
+		if idx < 0 || idx == 1 {
+			continue
 		}
+		name := ""
+		if idx > 0 {
+			name = arg[:idx]
+		}
+		if name != "" && ctxName != "" && ctxName != name {
+			fmt.Fprintf(os.Stderr, "error: conflicting contexts: %s vs %s\n", ctxName, name)
+			os.Exit(1)
+		}
+		if name != "" {
+			ctxName = name
+		}
+		args[i] = arg[idx+1:]
 	}
 	return ctxName, args
 }

--- a/cmd/dat9/main.go
+++ b/cmd/dat9/main.go
@@ -124,8 +124,16 @@ func extractContext(args []string) (string, []string) {
 		}
 		idx := strings.Index(arg, ":/")
 		if idx >= 0 {
+			name := ""
 			if idx > 0 {
-				ctxName = arg[:idx]
+				name = arg[:idx]
+			}
+			if name != "" && ctxName != "" && ctxName != name {
+				fmt.Fprintf(os.Stderr, "error: conflicting contexts: %s vs %s\n", ctxName, name)
+				os.Exit(1)
+			}
+			if name != "" {
+				ctxName = name
 			}
 			args[i] = arg[idx+1:]
 		}

--- a/cmd/dat9/main.go
+++ b/cmd/dat9/main.go
@@ -128,7 +128,6 @@ func extractContext(args []string) (string, []string) {
 				ctxName = arg[:idx]
 			}
 			args[i] = arg[idx+1:]
-			break
 		}
 	}
 	return ctxName, args

--- a/cmd/dat9/main.go
+++ b/cmd/dat9/main.go
@@ -15,6 +15,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/mem9-ai/dat9/cmd/dat9/cli"
 )
@@ -58,32 +59,39 @@ func runFS(args []string) {
 	}
 	sub := args[0]
 	rest := args[1:]
-	c := cli.NewFromEnv()
 
-	var err error
 	switch sub {
 	case "cp":
-		err = cli.Cp(c, rest)
-	case "cat":
-		err = cli.Cat(c, rest)
-	case "ls":
-		err = cli.Ls(c, rest)
-	case "stat":
-		err = cli.Stat(c, rest)
-	case "mv":
-		err = cli.Mv(c, rest)
-	case "rm":
-		err = cli.Rm(c, rest)
-	case "sh":
-		err = cli.Sh(c, rest)
+		c := cli.NewFromEnv()
+		if err := cli.Cp(c, rest); err != nil {
+			fatal("fs cp", err)
+		}
+	case "cat", "ls", "stat", "mv", "rm", "sh":
+		ctxName, rest := extractContext(rest)
+		c := cli.NewClientForContext(ctxName)
+		var err error
+		switch sub {
+		case "cat":
+			err = cli.Cat(c, rest)
+		case "ls":
+			err = cli.Ls(c, rest)
+		case "stat":
+			err = cli.Stat(c, rest)
+		case "mv":
+			err = cli.Mv(c, rest)
+		case "rm":
+			err = cli.Rm(c, rest)
+		case "sh":
+			err = cli.Sh(c, rest)
+		}
+		if err != nil {
+			fatal("fs "+sub, err)
+		}
 	case "-h", "-help", "help":
 		fsUsage()
 	default:
 		fmt.Fprintf(os.Stderr, "dat9 fs: unknown command %q\n", sub)
 		fsUsage()
-	}
-	if err != nil {
-		fatal("fs "+sub, err)
 	}
 }
 
@@ -106,6 +114,24 @@ func runDB(args []string) {
 		fmt.Fprintf(os.Stderr, "dat9 db: unknown command %q\n", sub)
 		dbUsage()
 	}
+}
+
+func extractContext(args []string) (string, []string) {
+	ctxName := ""
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		idx := strings.Index(arg, ":/")
+		if idx >= 0 {
+			if idx > 0 {
+				ctxName = arg[:idx]
+			}
+			args[i] = arg[idx+1:]
+			break
+		}
+	}
+	return ctxName, args
 }
 
 func fatal(cmd string, err error) {


### PR DESCRIPTION
## Summary

- All `dat9 fs` commands now support `<name>:/path` to select which context (database) to use, matching db9's `db9 fs cp test1:/TODO.md test.md` pattern
- Cross-context operations (`dat9 fs mv db1:/a db2:/b`) are explicitly rejected with a clear error

## Usage

```bash
# download from specific context
dat9 fs cp test1:/TODO.md test.md

# upload to specific context
dat9 fs cp TODO.md test1:/TODO.md

# list/cat/stat with context
dat9 fs ls test1:/
dat9 fs cat test1:/config.json
dat9 fs stat test1:/data.csv

# use current context (unchanged)
dat9 fs ls :/
dat9 db sql -q "SELECT 1"

# cross-context copy rejected
dat9 fs cp db1:/a db2:/b
# → error: cross-context copy not supported: db1 vs db2
```

## Files changed

| File | Change |
|---|---|
| `cmd/dat9/cli/path.go` | NEW: `ParseRemote()` parses `test1:/path`, `:/path`, returns `(RemotePath{Context, Path}, isRemote)` |
| `cmd/dat9/cli/cp.go` | Uses `ParseRemote` for src/dst, resolves client per-context, rejects conflicting contexts |
| `cmd/dat9/cli/client.go` | `NewClientForContext(name)` resolves api_key from `~/.dat9/config` for given context |
| `cmd/dat9/main.go` | `extractContext()` strips `<name>:` from all args for non-cp fs commands, rejects conflicting contexts |
| `cmd/dat9/cli/cp_test.go` | `TestParseRemote` with 9 test cases |

## Review history

- Claude Code: SHIP ✅
- Codex: SHIP ✅ (after fixing conflicting context rejection for non-cp commands)