### PR TITLE
fix: include signed upload headers in multipart plans

### DIFF
--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -24,11 +24,12 @@ type UploadPlan struct {
 
 // PartURL is a presigned URL for uploading one part.
 type PartURL struct {
-	Number         int    `json:"number"`
-	URL            string `json:"url"`
-	Size           int64  `json:"size"`
-	ChecksumSHA256 string `json:"checksum_sha256,omitempty"`
-	ExpiresAt      string `json:"expires_at"`
+	Number         int               `json:"number"`
+	URL            string            `json:"url"`
+	Size           int64             `json:"size"`
+	ChecksumSHA256 string            `json:"checksum_sha256,omitempty"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	ExpiresAt      string            `json:"expires_at"`
 }
 
 // ProgressFunc is called after each part upload completes.
@@ -168,6 +169,12 @@ func (c *Client) uploadOnePart(ctx context.Context, part PartURL, data []byte) (
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, part.URL, bytes.NewReader(data))
 	if err != nil {
 		return "", err
+	}
+	for k, v := range part.Headers {
+		if strings.EqualFold(k, "host") {
+			continue
+		}
+		req.Header.Set(k, v)
 	}
 	req.ContentLength = int64(len(data))
 	req.Header.Set("x-amz-checksum-sha256", checksum)

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -53,9 +55,13 @@ func NewAWS(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {
 	}
 
 	client := s3.NewFromConfig(awsCfg)
+	presigner := v4.NewSigner(func(o *v4.SignerOptions) {
+		o.DisableURIPathEscaping = true
+		o.DisableHeaderHoisting = true
+	})
 	return &AWSS3Client{
 		client:  client,
-		presign: s3.NewPresignClient(client),
+		presign: s3.NewPresignClient(client, func(o *s3.PresignOptions) { o.Presigner = presigner }),
 		bucket:  cfg.Bucket,
 		prefix:  normalizePrefix(cfg.Prefix),
 	}, nil
@@ -112,13 +118,38 @@ func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID strin
 	if err != nil {
 		return nil, fmt.Errorf("presign upload part: %w", err)
 	}
+	headers := flattenSignedHeaders(out.SignedHeader)
+	if checksumSHA256 != "" {
+		headers[strings.ToLower("x-amz-checksum-sha256")] = checksumSHA256
+	}
 	return &UploadPartURL{
 		Number:         partNumber,
 		URL:            out.URL,
 		Size:           partSize,
 		ChecksumSHA256: checksumSHA256,
+		Headers:        headers,
 		ExpiresAt:      time.Now().Add(ttl),
 	}, nil
+}
+
+func flattenSignedHeaders(h http.Header) map[string]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(h))
+	for k, vs := range h {
+		if len(vs) == 0 {
+			continue
+		}
+		if strings.EqualFold(k, "host") {
+			continue
+		}
+		out[strings.ToLower(k)] = vs[0]
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (c *AWSS3Client) CompleteMultipartUpload(ctx context.Context, key, uploadID string, parts []Part) error {

--- a/pkg/s3client/local.go
+++ b/pkg/s3client/local.go
@@ -70,11 +70,16 @@ func (c *LocalS3Client) CreateMultipartUpload(ctx context.Context, key string) (
 
 func (c *LocalS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, checksumSHA256 string, ttl time.Duration) (*UploadPartURL, error) {
 	url := fmt.Sprintf("%s/upload/%s/%d", c.baseURL, uploadID, partNumber)
+	var headers map[string]string
+	if checksumSHA256 != "" {
+		headers = map[string]string{"x-amz-checksum-sha256": checksumSHA256}
+	}
 	return &UploadPartURL{
 		Number:         partNumber,
 		URL:            url,
 		Size:           partSize,
 		ChecksumSHA256: checksumSHA256,
+		Headers:        headers,
 		ExpiresAt:      time.Now().Add(ttl),
 	}, nil
 }

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -19,11 +19,12 @@ type Part struct {
 
 // UploadPartURL is a presigned URL for uploading one part.
 type UploadPartURL struct {
-	Number         int       `json:"number"`                    // 1-based part number
-	URL            string    `json:"url"`                       // presigned PUT URL
-	Size           int64     `json:"size"`                      // expected part size
-	ChecksumSHA256 string    `json:"checksum_sha256,omitempty"` // expected checksum for signed uploads
-	ExpiresAt      time.Time `json:"expires_at"`                // URL expiry
+	Number         int               `json:"number"`                    // 1-based part number
+	URL            string            `json:"url"`                       // presigned PUT URL
+	Size           int64             `json:"size"`                      // expected part size
+	ChecksumSHA256 string            `json:"checksum_sha256,omitempty"` // expected checksum for signed uploads
+	Headers        map[string]string `json:"headers,omitempty"`         // required headers for presigned PUT
+	ExpiresAt      time.Time         `json:"expires_at"`                // URL expiry
 }
 
 // MultipartUpload holds the state of an initiated multipart upload.

--- a/pkg/s3client/s3client_test.go
+++ b/pkg/s3client/s3client_test.go
@@ -169,12 +169,15 @@ func TestPresignURLsGenerated(t *testing.T) {
 
 	upload, _ := c.CreateMultipartUpload(ctx, "blobs/presign-test")
 
-	url, err := c.PresignUploadPart(ctx, "blobs/presign-test", upload.UploadID, 1, 8<<20, "", UploadTTL)
+	url, err := c.PresignUploadPart(ctx, "blobs/presign-test", upload.UploadID, 1, 8<<20, "abc", UploadTTL)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if url.URL == "" || url.Number != 1 {
 		t.Errorf("unexpected presigned URL: %+v", url)
+	}
+	if url.Headers["x-amz-checksum-sha256"] != "abc" {
+		t.Fatalf("expected checksum header in presigned part, got %+v", url.Headers)
 	}
 
 	getURL, err := c.PresignGetObject(ctx, "blobs/presign-test", DownloadTTL)


### PR DESCRIPTION
## Summary
- disable S3 presign header hoisting for upload-part URLs so checksum header signing stays consistent
- include required signed headers in upload plan part payload (`headers`) and apply them on client part uploads
- keep checksum-bound multipart behavior while fixing S3 `HeadersNotSigned=x-amz-checksum-sha256` failures on large uploads

## Validation
- `go test ./...`
- `make lint`