### PR TITLE
test: expand api and cli e2e coverage

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -17,6 +17,9 @@ DAT9_BASE=$DEPLOY bash e2e/api-smoke-test.sh
 
 # Existing key regression
 DAT9_BASE=$DEPLOY DAT9_API_KEY=dat9_xxx bash e2e/api-smoke-test-existing-key.sh
+
+# CLI smoke (provision + dat9 fs workflows + large file cp)
+DAT9_BASE=$DEPLOY bash e2e/cli-smoke-test.sh
 ```
 
 ## Dev endpoint
@@ -38,14 +41,24 @@ Use this value unless the environment owner announces a new endpoint.
 3. `GET /v1/fs/?list` returns `entries[]`
 4. Nested `mkdir` (`/team/...`) across multi-level paths
 5. Multi-file `PUT` + `GET` content verification
-6. `copy`, `rename`, `delete`, `recursive delete`
-7. Final `list` verifies expected structure after mutations
+6. Batch small-file writes (`N` files) + list count + sample reads
+7. `copy`, `rename`, `delete`
+8. Final `list` verifies expected structure after mutations
+9. Large multipart upload (`PUT` plan + presigned part uploads + complete + download checksum)
 
 ### `api-smoke-test-existing-key.sh`
 
 1. Existing API key auth on `GET /v1/status`
 2. Optional poll from `provisioning` to `active`
 3. `GET /v1/fs/?list` baseline read check
+
+### `cli-smoke-test.sh`
+
+1. Provision + readiness polling
+2. Build local `dat9` CLI binary
+3. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `rm`)
+4. CLI batch small-file flow (`cp` many files + dir list count + stat + sample reads)
+5. CLI large-file flow (`cp` upload multipart + `cp` download + checksum verification)
 
 ## Environment variables
 
@@ -55,6 +68,11 @@ Use this value unless the environment owner announces a new endpoint.
 | `DAT9_API_KEY` | - | `api-smoke-test-existing-key.sh` |
 | `POLL_TIMEOUT_S` | `120` (smoke), `60` (existing-key) | polling scripts |
 | `POLL_INTERVAL_S` | `5` | polling scripts |
+| `RUN_LARGE_FILE` | `1` | `api-smoke-test.sh` |
+| `LARGE_FILE_MB` | `100` | `api-smoke-test.sh` |
+| `BATCH_SMALL_FILE_COUNT` | `10` | `api-smoke-test.sh` |
+| `CLI_LARGE_FILE_MB` | `100` | `cli-smoke-test.sh` |
+| `CLI_BATCH_SMALL_FILE_COUNT` | `10` | `cli-smoke-test.sh` |
 
 ## Conventions
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -14,6 +14,7 @@ Live end-to-end scripts for validating deployed `dat9-server` behavior.
 |--------|--------------------|
 | `api-smoke-test.sh` | Fresh provisioning, status polling, nested directories, multi-file CRUD-style operations |
 | `api-smoke-test-existing-key.sh` | Existing API key status/list checks |
+| `cli-smoke-test.sh` | End-to-end CLI workflow including large multipart `fs cp` upload/download |
 
 ## Run
 
@@ -23,6 +24,8 @@ DEPLOY=https://<api-endpoint>
 DAT9_BASE=$DEPLOY bash e2e/api-smoke-test.sh
 
 DAT9_BASE=$DEPLOY DAT9_API_KEY=dat9_xxx bash e2e/api-smoke-test-existing-key.sh
+
+DAT9_BASE=$DEPLOY bash e2e/cli-smoke-test.sh
 ```
 
 ## Dev endpoint
@@ -38,3 +41,8 @@ export DAT9_BASE="https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
 - `api-smoke-test.sh` expects `POST /v1/provision` to return only `api_key` and `status`.
 - Tenant readiness is checked through `GET /v1/status`.
 - File operations use `/v1/fs/*` and include nested directory coverage.
+- Large-file scenario is enabled by default (`RUN_LARGE_FILE=1`) and runs a multipart upload using checksum-bound presigned parts.
+- You can tune size with `LARGE_FILE_MB` (default `100`).
+- CLI smoke large-file size can be tuned with `CLI_LARGE_FILE_MB` (default `100`).
+- API batch small-file coverage can be tuned with `BATCH_SMALL_FILE_COUNT` (default `10`).
+- CLI batch small-file coverage can be tuned with `CLI_BATCH_SMALL_FILE_COUNT` (default `10`).

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -7,14 +7,19 @@
 #  3) Root list
 #  4) Nested mkdir (multi-level directories)
 #  5) Multi-file write/read under nested directories
+#  6) Batch small-file write/list/read validation
 #  6) Copy, rename, delete
 #  7) Final list verification
+#  8) 100MB multipart upload with checksum-bound presigned parts
 
 set -euo pipefail
 
 BASE="${DAT9_BASE:-http://127.0.0.1:9009}"
 POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-120}"
 POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+RUN_LARGE_FILE="${RUN_LARGE_FILE:-1}"
+LARGE_FILE_MB="${LARGE_FILE_MB:-100}"
+BATCH_SMALL_FILE_COUNT="${BATCH_SMALL_FILE_COUNT:-10}"
 
 PASS=0
 FAIL=0
@@ -106,6 +111,12 @@ TS="$(date +%s)"
 ROOT_DIR="team-${TS}"
 BACKEND_DIR="${ROOT_DIR}/backend/go"
 FRONTEND_DIR="${ROOT_DIR}/frontend/web"
+BATCH_DIR="${ROOT_DIR}/batch"
+LARGE_FILE_BYTES=$((LARGE_FILE_MB * 1024 * 1024))
+LARGE_FILE_LOCAL="/tmp/dat9-e2e-large-${TS}.bin"
+LARGE_FILE_DOWNLOADED="/tmp/dat9-e2e-large-${TS}.download.bin"
+LARGE_REMOTE_DIR="${ROOT_DIR}/large"
+LARGE_REMOTE_FILE="${LARGE_REMOTE_DIR}/blob-${LARGE_FILE_MB}m.bin"
 
 step "1" "Provision tenant"
 resp=$(curl_body_code POST "$BASE/v1/provision")
@@ -148,7 +159,7 @@ entries_type=$(printf '%s' "$body" | jq -r '.entries | type')
 check_eq "list response contains entries array" "$entries_type" "array"
 
 step "4" "Create nested directories"
-for d in "$ROOT_DIR" "${ROOT_DIR}/backend" "$BACKEND_DIR" "${ROOT_DIR}/frontend" "$FRONTEND_DIR"; do
+for d in "$ROOT_DIR" "${ROOT_DIR}/backend" "$BACKEND_DIR" "${ROOT_DIR}/frontend" "$FRONTEND_DIR" "$BATCH_DIR"; do
   resp=$(curl_body_code POST "$BASE/v1/fs/$d?mkdir" "$API_KEY")
   code=$(http_code "$resp")
   check_eq "POST /v1/fs/$d?mkdir returns 200" "$code" "200"
@@ -177,7 +188,33 @@ for item in "${FILES[@]}"; do
   check_eq "read back content matches for $path" "$rbody" "$payload"
 done
 
-step "6" "Copy, rename, delete"
+step "6" "Batch small-file write/list/read validation"
+for i in $(seq 1 "$BATCH_SMALL_FILE_COUNT"); do
+  path="$BATCH_DIR/file-${i}.txt"
+  payload="batch-$TS-$i"
+  resp=$(curl_body_code PUT "$BASE/v1/fs/$path" "$API_KEY" "$payload")
+  code=$(http_code "$resp")
+  check_eq "PUT /v1/fs/$path returns 200" "$code" "200"
+done
+
+resp=$(curl_body_code GET "$BASE/v1/fs/$BATCH_DIR?list" "$API_KEY")
+code=$(http_code "$resp")
+body=$(json_body "$resp")
+check_eq "GET /v1/fs/$BATCH_DIR?list returns 200" "$code" "200"
+batch_count=$(printf '%s' "$body" | jq -r '.entries | length')
+check_eq "batch dir entry count matches" "$batch_count" "$BATCH_SMALL_FILE_COUNT"
+
+for i in 1 "$BATCH_SMALL_FILE_COUNT"; do
+  path="$BATCH_DIR/file-${i}.txt"
+  expected="batch-$TS-$i"
+  rresp=$(curl_body_code GET "$BASE/v1/fs/$path" "$API_KEY")
+  rcode=$(http_code "$rresp")
+  rbody=$(json_body "$rresp")
+  check_eq "GET /v1/fs/$path returns 200" "$rcode" "200"
+  check_eq "batch file content matches for $path" "$rbody" "$expected"
+done
+
+step "7" "Copy, rename, delete"
 resp=$(curl -sS -o /tmp/dat9-copy.out -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "X-Dat9-Copy-Source: /$ROOT_DIR/README.md" "$BASE/v1/fs/$ROOT_DIR/README-copy.md?copy")
 check_eq "POST ?copy returns 200" "$resp" "200"
 
@@ -187,7 +224,7 @@ check_eq "POST ?rename returns 200" "$resp" "200"
 resp=$(curl -sS -o /tmp/dat9-delete.out -w "%{http_code}" -X DELETE -H "Authorization: Bearer $API_KEY" "$BASE/v1/fs/$ROOT_DIR/README-copy.md")
 check_eq "DELETE copied file returns 200" "$resp" "200"
 
-step "7" "Final list verification"
+step "8" "Final list verification"
 resp=$(curl_body_code GET "$BASE/v1/fs/$ROOT_DIR?list" "$API_KEY")
 code=$(http_code "$resp")
 body=$(json_body "$resp")
@@ -198,6 +235,106 @@ copy_exists=$(printf '%s' "$body" | jq -r 'any(.entries[]; .name=="README-copy.m
 check_eq "backend directory still exists" "$backend_exists" "true"
 check_eq "frontend directory still exists" "$frontend_exists" "true"
 check_eq "copied file removed" "$copy_exists" "false"
+
+if [ "$RUN_LARGE_FILE" = "1" ]; then
+  step "9" "Large file multipart upload (${LARGE_FILE_MB}MB)"
+  check_cmd "python3 is available" bash -c 'command -v python3 >/dev/null'
+
+  resp=$(curl_body_code POST "$BASE/v1/fs/$LARGE_REMOTE_DIR?mkdir" "$API_KEY")
+  code=$(http_code "$resp")
+  check_eq "POST /v1/fs/$LARGE_REMOTE_DIR?mkdir returns 200" "$code" "200"
+
+  dd if=/dev/zero of="$LARGE_FILE_LOCAL" bs=1M count="$LARGE_FILE_MB" status=none
+  check_cmd "local large file created" test -f "$LARGE_FILE_LOCAL"
+
+  PART_CHECKSUMS=$(python3 - "$LARGE_FILE_LOCAL" <<'PY'
+import base64
+import hashlib
+import sys
+
+part_size = 8 * 1024 * 1024
+out = []
+with open(sys.argv[1], "rb") as f:
+    while True:
+        chunk = f.read(part_size)
+        if not chunk:
+            break
+        out.append(base64.b64encode(hashlib.sha256(chunk).digest()).decode())
+print(",".join(out))
+PY
+)
+
+  plan_file="$(mktemp)"
+  plan_code=$(curl -sS -o "$plan_file" -w "%{http_code}" -X PUT \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "X-Dat9-Content-Length: $LARGE_FILE_BYTES" \
+    -H "X-Dat9-Part-Checksums: $PART_CHECKSUMS" \
+    --data-binary "" \
+    "$BASE/v1/fs/$LARGE_REMOTE_FILE")
+  check_eq "initiate multipart upload returns 202" "$plan_code" "202"
+
+  upload_id=$(jq -r '.upload_id // empty' "$plan_file")
+  part_count=$(jq -r '.parts | length' "$plan_file")
+  check_cmd "multipart upload_id exists" test -n "$upload_id"
+  check_cmd "multipart has presigned parts" test "$part_count" -gt 0
+
+  python3 - "$plan_file" "$LARGE_FILE_LOCAL" <<'PY'
+import json
+import sys
+import urllib.request
+
+plan_path, file_path = sys.argv[1], sys.argv[2]
+with open(plan_path, "r", encoding="utf-8") as f:
+    plan = json.load(f)
+
+parts = plan.get("parts", [])
+with open(file_path, "rb") as data_file:
+    for idx, p in enumerate(parts, 1):
+        url = p["url"]
+        size = int(p["size"])
+        data = data_file.read(size)
+        if len(data) != size:
+            raise SystemExit(f"short read for part {idx}: got {len(data)} expected {size}")
+
+        req = urllib.request.Request(url, data=data, method="PUT")
+        req.add_header("Content-Length", str(size))
+        for hk, hv in (p.get("headers") or {}).items():
+            req.add_header(hk, hv)
+        if p.get("checksum_sha256"):
+            req.add_header("x-amz-checksum-sha256", p["checksum_sha256"])
+
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            status = getattr(resp, "status", 200)
+            if status >= 300:
+                raise SystemExit(f"part {idx} failed: HTTP {status}")
+PY
+  check_eq "multipart part upload script exits successfully" "$?" "0"
+
+  resp=$(curl_body_code POST "$BASE/v1/uploads/$upload_id/complete" "$API_KEY")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  complete_status=$(printf '%s' "$body" | jq -r '.status // empty')
+  check_eq "POST /v1/uploads/$upload_id/complete returns 200" "$code" "200"
+  check_eq "complete response status is ok" "$complete_status" "ok"
+
+  resp=$(curl_body_code GET "$BASE/v1/fs/$LARGE_REMOTE_DIR?list" "$API_KEY")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  check_eq "GET /v1/fs/$LARGE_REMOTE_DIR?list returns 200" "$code" "200"
+  large_exists=$(printf '%s' "$body" | jq -r --arg name "blob-${LARGE_FILE_MB}m.bin" 'any(.entries[]; .name==$name and .isDir==false)')
+  large_size=$(printf '%s' "$body" | jq -r --arg name "blob-${LARGE_FILE_MB}m.bin" '.entries[] | select(.name==$name) | .size')
+  check_eq "large file appears in list" "$large_exists" "true"
+  check_eq "large file size matches" "$large_size" "$LARGE_FILE_BYTES"
+
+  download_code=$(curl -sS -L -o "$LARGE_FILE_DOWNLOADED" -w "%{http_code}" -H "Authorization: Bearer $API_KEY" "$BASE/v1/fs/$LARGE_REMOTE_FILE")
+  check_eq "download large file returns 200" "$download_code" "200"
+  check_cmd "downloaded large file exists" test -f "$LARGE_FILE_DOWNLOADED"
+  src_sum=$(sha256sum "$LARGE_FILE_LOCAL" | cut -d' ' -f1)
+  dst_sum=$(sha256sum "$LARGE_FILE_DOWNLOADED" | cut -d' ' -f1)
+  check_eq "downloaded large file sha256 matches" "$dst_sum" "$src_sum"
+
+  rm -f "$plan_file" "$LARGE_FILE_LOCAL" "$LARGE_FILE_DOWNLOADED"
+fi
 
 rm -f /tmp/dat9-copy.out /tmp/dat9-rename.out /tmp/dat9-delete.out
 

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# dat9 CLI smoke test against a live deployment.
+
+set -euo pipefail
+
+BASE="${DAT9_BASE:-http://127.0.0.1:9009}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-120}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+CLI_LARGE_FILE_MB="${CLI_LARGE_FILE_MB:-100}"
+CLI_BATCH_SMALL_FILE_COUNT="${CLI_BATCH_SMALL_FILE_COUNT:-10}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+check_eq() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL+1))
+  if [ "$got" = "$want" ]; then
+    echo "PASS $desc (got=$got)"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL $desc (want=$want got=$got)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+check_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL+1))
+  if "$@"; then
+    echo "PASS $desc"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL $desc"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+echo "=== dat9 CLI smoke test ==="
+echo "BASE=$BASE"
+
+check_cmd "jq is available" bash -c 'command -v jq >/dev/null'
+check_cmd "go is available" bash -c 'command -v go >/dev/null'
+
+echo "[1] provision tenant"
+pfile="$(mktemp)"
+pcode=$(curl -sS -o "$pfile" -w "%{http_code}" -X POST "$BASE/v1/provision")
+check_eq "POST /v1/provision returns 202" "$pcode" "202"
+API_KEY=$(jq -r '.api_key // empty' "$pfile")
+check_cmd "provision returns api_key" test -n "$API_KEY"
+
+echo "[2] wait tenant active"
+deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+state=""
+while :; do
+  sfile="$(mktemp)"
+  scode=$(curl -sS -o "$sfile" -w "%{http_code}" -H "Authorization: Bearer $API_KEY" "$BASE/v1/status")
+  state=$(jq -r '.status // empty' "$sfile")
+  rm -f "$sfile"
+  echo "status=${scode}:${state}"
+  if [ "$scode" = "200" ] && [ "$state" = "active" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    break
+  fi
+  sleep "$POLL_INTERVAL_S"
+done
+check_eq "tenant becomes active" "$state" "active"
+
+echo "[3] build dat9 cli"
+CLI_BIN="$(mktemp)"
+go build -o "$CLI_BIN" ./cmd/dat9
+check_cmd "dat9 binary built" test -x "$CLI_BIN"
+
+dat9() {
+  DAT9_SERVER="$BASE" DAT9_API_KEY="$API_KEY" "$CLI_BIN" "$@"
+}
+
+TS="$(date +%s)"
+SMALL_LOCAL="/tmp/dat9-cli-small-${TS}.txt"
+SMALL_REMOTE="/cli-${TS}-small.txt"
+SMALL_RENAMED="/cli-${TS}-small-renamed.txt"
+BATCH_LOCAL_DIR="/tmp/dat9-cli-batch-${TS}"
+BATCH_REMOTE_DIR="/cli-${TS}-batch"
+LARGE_LOCAL="/tmp/dat9-cli-large-${TS}.bin"
+LARGE_REMOTE="/cli-${TS}-large-${CLI_LARGE_FILE_MB}m.bin"
+LARGE_DOWNLOADED="/tmp/dat9-cli-large-${TS}.download.bin"
+LARGE_BYTES=$((CLI_LARGE_FILE_MB * 1024 * 1024))
+
+echo "[4] small file ops via cli"
+printf "cli-smoke-%s" "$TS" > "$SMALL_LOCAL"
+dat9 fs cp "$SMALL_LOCAL" ":$SMALL_REMOTE"
+
+ls_out="$(dat9 fs ls /)"
+small_present=$(python3 - "$ls_out" "$(basename "$SMALL_REMOTE")" <<'PY'
+import sys
+out=sys.argv[1].splitlines()
+name=sys.argv[2]
+print("true" if any(line.strip()==name for line in out) else "false")
+PY
+)
+check_eq "uploaded small file appears in ls /" "$small_present" "true"
+
+cat_out="$(dat9 fs cat ":$SMALL_REMOTE")"
+check_eq "cat returns expected small file content" "$cat_out" "cli-smoke-${TS}"
+
+dat9 fs mv ":$SMALL_REMOTE" ":$SMALL_RENAMED"
+renamed_out="$(dat9 fs ls /)"
+renamed_present=$(python3 - "$renamed_out" "$(basename "$SMALL_RENAMED")" <<'PY'
+import sys
+out=sys.argv[1].splitlines()
+name=sys.argv[2]
+print("true" if any(line.strip()==name for line in out) else "false")
+PY
+)
+check_eq "mv renames remote file" "$renamed_present" "true"
+
+echo "[5] batch small-file upload/list/read via cli"
+mkdir -p "$BATCH_LOCAL_DIR"
+for i in $(seq 1 "$CLI_BATCH_SMALL_FILE_COUNT"); do
+  lp="$BATCH_LOCAL_DIR/file-${i}.txt"
+  rp="$BATCH_REMOTE_DIR/file-${i}.txt"
+  printf "cli-batch-%s-%s" "$TS" "$i" > "$lp"
+  dat9 fs cp "$lp" ":$rp"
+done
+
+batch_ls="$(dat9 fs ls ":$BATCH_REMOTE_DIR")"
+batch_count=$(python3 - "$batch_ls" <<'PY'
+import sys
+lines=[ln.strip() for ln in sys.argv[1].splitlines() if ln.strip()]
+print(len(lines))
+PY
+)
+check_eq "batch dir file count matches" "$batch_count" "$CLI_BATCH_SMALL_FILE_COUNT"
+
+for i in 1 "$CLI_BATCH_SMALL_FILE_COUNT"; do
+  rp="$BATCH_REMOTE_DIR/file-${i}.txt"
+  got="$(dat9 fs cat ":$rp")"
+  want="cli-batch-$TS-$i"
+  check_eq "batch file content matches for $rp" "$got" "$want"
+done
+
+batch_stat="$(dat9 fs stat ":$BATCH_REMOTE_DIR/file-1.txt")"
+batch_isdir=$(python3 - "$batch_stat" <<'PY'
+import sys
+val=""
+for line in sys.argv[1].splitlines():
+    if line.strip().startswith("isdir:"):
+        val=line.split(":",1)[1].strip().lower()
+        break
+print(val)
+PY
+)
+check_eq "stat reports batch file isdir=false" "$batch_isdir" "false"
+
+echo "[6] large multipart upload via cli cp"
+dd if=/dev/zero of="$LARGE_LOCAL" bs=1M count="$CLI_LARGE_FILE_MB" status=none
+dat9 fs cp "$LARGE_LOCAL" ":$LARGE_REMOTE"
+
+stat_out="$(dat9 fs stat ":$LARGE_REMOTE")"
+remote_size=$(python3 - "$stat_out" <<'PY'
+import sys
+for line in sys.argv[1].splitlines():
+    if line.strip().startswith("size:"):
+        print(line.split(":",1)[1].strip())
+        break
+PY
+)
+check_eq "large remote size matches" "$remote_size" "$LARGE_BYTES"
+
+dat9 fs cp ":$LARGE_REMOTE" "$LARGE_DOWNLOADED"
+check_cmd "downloaded large file exists" test -f "$LARGE_DOWNLOADED"
+
+sum_src=$(sha256sum "$LARGE_LOCAL" | cut -d' ' -f1)
+sum_dst=$(sha256sum "$LARGE_DOWNLOADED" | cut -d' ' -f1)
+check_eq "downloaded large file sha256 matches" "$sum_dst" "$sum_src"
+
+echo "[7] cleanup via cli"
+dat9 fs rm ":$SMALL_RENAMED"
+dat9 fs rm ":$LARGE_REMOTE"
+for i in $(seq 1 "$CLI_BATCH_SMALL_FILE_COUNT"); do
+  dat9 fs rm ":$BATCH_REMOTE_DIR/file-${i}.txt"
+done
+
+final_ls="$(dat9 fs ls /)"
+small_left=$(python3 - "$final_ls" "$(basename "$SMALL_RENAMED")" <<'PY'
+import sys
+out=sys.argv[1].splitlines()
+name=sys.argv[2]
+print("true" if any(line.strip()==name for line in out) else "false")
+PY
+)
+large_left=$(python3 - "$final_ls" "$(basename "$LARGE_REMOTE")" <<'PY'
+import sys
+out=sys.argv[1].splitlines()
+name=sys.argv[2]
+print("true" if any(line.strip()==name for line in out) else "false")
+PY
+)
+check_eq "small file removed" "$small_left" "false"
+check_eq "large file removed" "$large_left" "false"
+
+batch_ls_after="$(dat9 fs ls /)"
+batch_left=$(python3 - "$batch_ls_after" "$(basename "$BATCH_REMOTE_DIR")" <<'PY'
+import sys
+out=sys.argv[1].splitlines()
+name=sys.argv[2]
+print("true" if any(line.strip()==name or line.strip()==name+"/" for line in out) else "false")
+PY
+)
+# Directory may remain empty after file deletions depending on backend semantics.
+check_eq "batch directory remains visible after file cleanup" "$batch_left" "true"
+
+rm -f "$pfile" "$CLI_BIN" "$SMALL_LOCAL" "$LARGE_LOCAL" "$LARGE_DOWNLOADED"
+rm -rf "$BATCH_LOCAL_DIR"
+
+echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"
+exit "$FAIL"


### PR DESCRIPTION
## Summary
- expand API e2e smoke coverage with batch small-file scenarios (write/list/read) in addition to nested directory checks
- extend API large-file scenario to include multipart upload completion and download checksum verification
- add new `e2e/cli-smoke-test.sh` covering provision, small-file CLI flows, batch small-file flows, and large-file upload/download verification
- update e2e docs (`AGENTS.md`, `README.md`) with new coverage and environment knobs

## Validation
- `bash -n e2e/api-smoke-test.sh`
- `bash -n e2e/cli-smoke-test.sh`
- `DAT9_BASE=https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com RUN_LARGE_FILE=1 LARGE_FILE_MB=8 BATCH_SMALL_FILE_COUNT=4 POLL_TIMEOUT_S=90 bash e2e/api-smoke-test.sh` (currently exposes a deployed large-download signature issue)
- `DAT9_BASE=https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com CLI_LARGE_FILE_MB=8 CLI_BATCH_SMALL_FILE_COUNT=4 POLL_TIMEOUT_S=90 bash e2e/cli-smoke-test.sh` (currently exposes the same deployed large-download signature issue)