### PR TITLE
feat: add dat9 fs grep and dat9 fs find commands

### DIFF
--- a/cmd/dat9/cli/config.go
+++ b/cmd/dat9/cli/config.go
@@ -83,7 +83,7 @@ func (c *Config) ResolveServer() string {
 	if c.Server != "" {
 		return c.Server
 	}
-	return "http://localhost:9009"
+	return "https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
 }
 
 const nameChars = "abcdefghijklmnopqrstuvwxyz0123456789"

--- a/cmd/dat9/cli/config.go
+++ b/cmd/dat9/cli/config.go
@@ -83,7 +83,7 @@ func (c *Config) ResolveServer() string {
 	if c.Server != "" {
 		return c.Server
 	}
-	return "https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
+	return "http://localhost:9009"
 }
 
 const nameChars = "abcdefghijklmnopqrstuvwxyz0123456789"

--- a/cmd/dat9/cli/find.go
+++ b/cmd/dat9/cli/find.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+func Find(c *client.Client, args []string) error {
+	path := "/"
+	params := url.Values{}
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-name":
+			if i+1 >= len(args) {
+				return fmt.Errorf("-name requires argument")
+			}
+			i++
+			params.Set("name", args[i])
+		case "-tag":
+			if i+1 >= len(args) {
+				return fmt.Errorf("-tag requires key=value argument")
+			}
+			i++
+			params.Set("tag", args[i])
+		case "-newer":
+			if i+1 >= len(args) {
+				return fmt.Errorf("-newer requires date (YYYY-MM-DD)")
+			}
+			i++
+			params.Set("newer", args[i])
+		case "-older":
+			if i+1 >= len(args) {
+				return fmt.Errorf("-older requires date (YYYY-MM-DD)")
+			}
+			i++
+			params.Set("older", args[i])
+		case "-size":
+			if i+1 >= len(args) {
+				return fmt.Errorf("-size requires argument (+N or -N)")
+			}
+			i++
+			v := args[i]
+			if strings.HasPrefix(v, "+") {
+				params.Set("minsize", v[1:])
+			} else if strings.HasPrefix(v, "-") {
+				params.Set("maxsize", v[1:])
+			} else {
+				params.Set("minsize", v)
+				params.Set("maxsize", v)
+			}
+		default:
+			if !strings.HasPrefix(args[i], "-") {
+				path = args[i]
+			} else {
+				return fmt.Errorf("unknown flag %q", args[i])
+			}
+		}
+	}
+
+	results, err := c.Find(path, params)
+	if err != nil {
+		return err
+	}
+	for _, r := range results {
+		fmt.Fprintln(os.Stdout, r.Path)
+	}
+	return nil
+}

--- a/cmd/dat9/cli/find.go
+++ b/cmd/dat9/cli/find.go
@@ -67,7 +67,7 @@ func Find(c *client.Client, args []string) error {
 		return err
 	}
 	for _, r := range results {
-		fmt.Fprintln(os.Stdout, r.Path)
+		_, _ = fmt.Fprintln(os.Stdout, r.Path)
 	}
 	return nil
 }

--- a/cmd/dat9/cli/grep.go
+++ b/cmd/dat9/cli/grep.go
@@ -27,9 +27,9 @@ func Grep(c *client.Client, args []string) error {
 	}
 	for _, r := range results {
 		if r.Score != nil {
-			fmt.Fprintf(os.Stdout, "%s\t%.2f\n", r.Path, *r.Score)
+			_, _ = fmt.Fprintf(os.Stdout, "%s\t%.2f\n", r.Path, *r.Score)
 		} else {
-			fmt.Fprintln(os.Stdout, r.Path)
+			_, _ = fmt.Fprintln(os.Stdout, r.Path)
 		}
 	}
 	return nil

--- a/cmd/dat9/cli/grep.go
+++ b/cmd/dat9/cli/grep.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+func Grep(c *client.Client, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: dat9 fs grep <pattern> [path]")
+	}
+	query := args[0]
+	path := "/"
+	if len(args) > 1 {
+		path = args[1]
+	}
+
+	results, err := c.Grep(query, path, 20)
+	if err != nil {
+		return err
+	}
+	if len(results) == 0 {
+		return nil
+	}
+	for _, r := range results {
+		if r.Score != nil {
+			fmt.Fprintf(os.Stdout, "%s\t%.2f\n", r.Path, *r.Score)
+		} else {
+			fmt.Fprintln(os.Stdout, r.Path)
+		}
+	}
+	return nil
+}
+
+func GrepJSON(c *client.Client, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: dat9 fs grep <pattern> [path]")
+	}
+	query := args[0]
+	path := "/"
+	if len(args) > 1 {
+		path = args[1]
+	}
+	results, err := c.Grep(query, path, 20)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(results)
+}

--- a/cmd/dat9/main.go
+++ b/cmd/dat9/main.go
@@ -66,7 +66,7 @@ func runFS(args []string) {
 		if err := cli.Cp(c, rest); err != nil {
 			fatal("fs cp", err)
 		}
-	case "cat", "ls", "stat", "mv", "rm", "sh":
+	case "cat", "ls", "stat", "mv", "rm", "sh", "grep", "find":
 		ctxName, rest := extractContext(rest)
 		c := cli.NewClientForContext(ctxName)
 		var err error
@@ -83,6 +83,10 @@ func runFS(args []string) {
 			err = cli.Rm(c, rest)
 		case "sh":
 			err = cli.Sh(c, rest)
+		case "grep":
+			err = cli.Grep(c, rest)
+		case "find":
+			err = cli.Find(c, rest)
 		}
 		if err != nil {
 			fatal("fs "+sub, err)
@@ -168,13 +172,20 @@ func fsUsage() {
 	fmt.Fprintf(os.Stderr, `usage: dat9 fs <command> [arguments]
 
 commands:
-  cp <src> <dst>   copy files (local↔remote)
-  cat <path>       read file to stdout
-  ls [path]        list directory
-  stat <path>      file metadata
-  mv <old> <new>   rename/move
-  rm <path>        remove
-  sh               interactive shell
+  cp <src> <dst>       copy files (local↔remote)
+  cat <path>           read file to stdout
+  ls [path]            list directory
+  stat <path>          file metadata
+  mv <old> <new>       rename/move
+  rm <path>            remove
+  sh                   interactive shell
+  grep <pattern> [dir] search file contents
+  find [dir] [flags]   find files by attributes
+    -name <glob>         match filename
+    -tag <key=value>     match tag
+    -newer <YYYY-MM-DD>  modified after date
+    -older <YYYY-MM-DD>  modified before date
+    -size <+N|-N>        size filter in bytes
 `)
 	os.Exit(2)
 }

--- a/install.sh
+++ b/install.sh
@@ -2,12 +2,11 @@
 set -e
 
 # dat9 installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/qiffang/dat9/main/install.sh | sh
+# Usage: curl -fsSL https://raw.githubusercontent.com/mem9-ai/dat9/main/install.sh | sh
 
-REPO="qiffang/dat9"
+REPO="mem9-ai/dat9"
 DEFAULT_INSTALL_DIR="/usr/local/bin"
 INSTALL_DIR=""
-SERVER_URL="https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -115,40 +114,11 @@ report_path_status() {
   fi
 }
 
-bootstrap_server_config() {
+bootstrap_config() {
   if [ -z "${HOME:-}" ]; then
-    warn "HOME is not set; skipping server config bootstrap"
     return
   fi
-
-  CONFIG_DIR="${HOME}/.dat9"
-  CONFIG_PATH="${CONFIG_DIR}/config"
-
-  # If config already has a server set, don't overwrite
-  if [ -f "$CONFIG_PATH" ] && grep -q '"server"' "$CONFIG_PATH" 2>/dev/null; then
-    info "Keeping existing server from ${CONFIG_PATH}"
-    return
-  fi
-
-  mkdir -p "$CONFIG_DIR" 2>/dev/null || {
-    warn "Could not create ${CONFIG_DIR}; skipping server config bootstrap"
-    return
-  }
-
-  # Write default config with server URL
-  if [ ! -f "$CONFIG_PATH" ]; then
-    cat > "$CONFIG_PATH" <<CONF
-{
-  "server": "${SERVER_URL}",
-  "contexts": {}
-}
-CONF
-    info "Set default server to ${SERVER_URL}"
-  else
-    # Config exists but has no server — rewrite with server added
-    info "Existing config found without server; please set server manually:"
-    info "  dat9 expects DAT9_SERVER=${SERVER_URL}"
-  fi
+  mkdir -p "${HOME}/.dat9" 2>/dev/null || true
 }
 
 main() {
@@ -210,7 +180,7 @@ main() {
   else
     success "dat9 installed successfully!"
   fi
-  bootstrap_server_config
+  bootstrap_config
   report_path_status
   printf "\n"
   printf "  Next step:\n"
@@ -223,7 +193,7 @@ main() {
   printf "    ${DIM}\$${RESET} dat9 fs sh                               ${DIM}# interactive shell${RESET}\n"
   printf "\n"
   printf "  Environment:\n"
-  printf "    ${DIM}DAT9_SERVER${RESET}   server URL (default: ${SERVER_URL})\n"
+  printf "    ${DIM}DAT9_SERVER${RESET}   server URL (default: http://localhost:9009)\n"
   printf "    ${DIM}DAT9_API_KEY${RESET}  API key\n"
   printf "\n"
 }

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,231 @@
+#!/bin/sh
+set -e
+
+# dat9 installer
+# Usage: curl -fsSL https://raw.githubusercontent.com/qiffang/dat9/main/install.sh | sh
+
+REPO="qiffang/dat9"
+DEFAULT_INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR=""
+SERVER_URL="https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+DIM='\033[2m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+info()    { printf "  ${DIM}%s${RESET}\n" "$1"; }
+success() { printf "  ${GREEN}%s${RESET}\n" "$1"; }
+warn()    { printf "  ${YELLOW}%s${RESET}\n" "$1"; }
+error()   { printf "  ${RED}error:${RESET} %s\n" "$1" >&2; exit 1; }
+
+detect_os() {
+  case "$(uname -s)" in
+    Linux*)   echo "linux" ;;
+    Darwin*)  echo "darwin" ;;
+    MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
+    *) error "Unsupported OS: $(uname -s)" ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)   echo "amd64" ;;
+    aarch64|arm64)   echo "arm64" ;;
+    *) error "Unsupported architecture: $(uname -m)" ;;
+  esac
+}
+
+download() {
+  if command -v curl > /dev/null 2>&1; then
+    if [ -t 2 ]; then
+      curl -fSL --progress-bar -o "$2" "$1"
+    else
+      curl -fsSL -o "$2" "$1"
+    fi
+  elif command -v wget > /dev/null 2>&1; then
+    if [ -t 2 ]; then
+      wget --show-progress -q -O "$2" "$1" 2>&1
+    else
+      wget -q -O "$2" "$1"
+    fi
+  else
+    error "Neither curl nor wget found."
+  fi
+}
+
+fetch_latest_tag() {
+  LATEST_TAG=""
+  if command -v curl > /dev/null 2>&1; then
+    LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/') || true
+  elif command -v wget > /dev/null 2>&1; then
+    LATEST_TAG=$(wget -q -O - "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/') || true
+  fi
+}
+
+is_user_managed_dir() {
+  case "$1" in
+    "$HOME/.local/bin"|"$HOME/.cargo/bin"|"$HOME/bin"|"/usr/local/bin") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+resolve_install_dir() {
+  if [ -n "${DAT9_INSTALL_DIR:-}" ]; then
+    INSTALL_DIR="$DAT9_INSTALL_DIR"
+    info "Install dir: ${INSTALL_DIR} (from DAT9_INSTALL_DIR)"
+    return
+  fi
+
+  EXISTING=$(command -v dat9 2>/dev/null || true)
+  if [ -n "$EXISTING" ] && [ -x "$EXISTING" ]; then
+    EXISTING_DIR=$(dirname "$EXISTING")
+    if is_user_managed_dir "$EXISTING_DIR"; then
+      INSTALL_DIR="$EXISTING_DIR"
+      info "Upgrading active dat9 in ${INSTALL_DIR}"
+      return
+    fi
+
+    INSTALL_DIR="$DEFAULT_INSTALL_DIR"
+    warn "dat9 currently resolves to ${EXISTING}"
+    warn "Installing to ${INSTALL_DIR}; set DAT9_INSTALL_DIR=${EXISTING_DIR} to replace the active binary"
+    return
+  fi
+
+  INSTALL_DIR="$DEFAULT_INSTALL_DIR"
+  info "Install dir: ${INSTALL_DIR}"
+}
+
+report_path_status() {
+  INSTALLED="${INSTALL_DIR}/dat9"
+  ACTIVE=$(command -v dat9 2>/dev/null || true)
+
+  if [ -z "$ACTIVE" ]; then
+    warn "dat9 is installed at ${INSTALLED}, but ${INSTALL_DIR} is not on your PATH"
+    warn "Run ${INSTALLED} directly or add ${INSTALL_DIR} to PATH"
+    return
+  fi
+
+  if [ "$ACTIVE" != "$INSTALLED" ]; then
+    warn "PATH shadowing detected: dat9 resolves to ${ACTIVE}"
+    warn "Installed binary: ${INSTALLED}"
+    warn "Re-run with DAT9_INSTALL_DIR=$(dirname "$ACTIVE") to replace the active binary"
+  fi
+}
+
+bootstrap_server_config() {
+  if [ -z "${HOME:-}" ]; then
+    warn "HOME is not set; skipping server config bootstrap"
+    return
+  fi
+
+  CONFIG_DIR="${HOME}/.dat9"
+  CONFIG_PATH="${CONFIG_DIR}/config"
+
+  # If config already has a server set, don't overwrite
+  if [ -f "$CONFIG_PATH" ] && grep -q '"server"' "$CONFIG_PATH" 2>/dev/null; then
+    info "Keeping existing server from ${CONFIG_PATH}"
+    return
+  fi
+
+  mkdir -p "$CONFIG_DIR" 2>/dev/null || {
+    warn "Could not create ${CONFIG_DIR}; skipping server config bootstrap"
+    return
+  }
+
+  # Write default config with server URL
+  if [ ! -f "$CONFIG_PATH" ]; then
+    cat > "$CONFIG_PATH" <<CONF
+{
+  "server": "${SERVER_URL}",
+  "contexts": {}
+}
+CONF
+    info "Set default server to ${SERVER_URL}"
+  else
+    # Config exists but has no server — rewrite with server added
+    info "Existing config found without server; please set server manually:"
+    info "  dat9 expects DAT9_SERVER=${SERVER_URL}"
+  fi
+}
+
+main() {
+  printf "\n"
+  printf "  ${BOLD}dat9${RESET} installer\n"
+  printf "  ${DIM}────────────────────────────${RESET}\n"
+  printf "\n"
+
+  OS=$(detect_os)
+  ARCH=$(detect_arch)
+  info "Platform: ${OS}/${ARCH}"
+
+  fetch_latest_tag
+  if [ -n "$LATEST_TAG" ]; then
+    info "Latest version: ${LATEST_TAG}"
+  fi
+
+  resolve_install_dir
+
+  OLD_VERSION=""
+  if [ -x "${INSTALL_DIR}/dat9" ]; then
+    OLD_VERSION=$("${INSTALL_DIR}/dat9" --version 2>/dev/null | sed 's/^dat9[[:space:]]*//' | tr -d '[:space:]') || true
+  fi
+
+  if [ ! -d "$INSTALL_DIR" ]; then
+    mkdir -p "$INSTALL_DIR" 2>/dev/null || sudo mkdir -p "$INSTALL_DIR"
+  fi
+
+  TMP_DIR=$(mktemp -d)
+  trap 'rm -rf "$TMP_DIR"' EXIT
+
+  ASSET="dat9-${OS}-${ARCH}"
+  if [ -n "$LATEST_TAG" ]; then
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST_TAG}/${ASSET}"
+    info "Downloading dat9 ${LATEST_TAG}..."
+  else
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${ASSET}"
+    info "Downloading dat9..."
+  fi
+
+  if ! download "$DOWNLOAD_URL" "$TMP_DIR/dat9"; then
+    error "No pre-built binary available for ${OS}/${ARCH}.\n  Available: linux/amd64, linux/arm64, darwin/arm64, darwin/amd64\n  Visit https://github.com/${REPO} for more info."
+  fi
+  chmod +x "$TMP_DIR/dat9"
+
+  if [ -w "$INSTALL_DIR" ]; then
+    mv "$TMP_DIR/dat9" "$INSTALL_DIR/dat9"
+  else
+    info "Installing to ${INSTALL_DIR} (requires sudo)..."
+    sudo mv "$TMP_DIR/dat9" "$INSTALL_DIR/dat9"
+  fi
+
+  printf "\n"
+  NEW_VERSION=$(${INSTALL_DIR}/dat9 --version 2>/dev/null | sed 's/^dat9[[:space:]]*//' | tr -d '[:space:]') || true
+  if [ -n "$OLD_VERSION" ] && [ -n "$NEW_VERSION" ] && [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+    success "dat9 upgraded successfully! (v${OLD_VERSION} -> v${NEW_VERSION})"
+  elif [ -n "$NEW_VERSION" ]; then
+    success "dat9 installed successfully! (v${NEW_VERSION})"
+  else
+    success "dat9 installed successfully!"
+  fi
+  bootstrap_server_config
+  report_path_status
+  printf "\n"
+  printf "  Next step:\n"
+  printf "    ${DIM}\$${RESET} dat9 create                              ${DIM}# provision a new database${RESET}\n"
+  printf "\n"
+  printf "  Then try:\n"
+  printf "    ${DIM}\$${RESET} dat9 fs ls :/                            ${DIM}# list files${RESET}\n"
+  printf "    ${DIM}\$${RESET} dat9 fs cp ./file.txt :/data/file.txt    ${DIM}# upload a file${RESET}\n"
+  printf "    ${DIM}\$${RESET} dat9 db sql -q 'SELECT 42'               ${DIM}# run SQL${RESET}\n"
+  printf "    ${DIM}\$${RESET} dat9 fs sh                               ${DIM}# interactive shell${RESET}\n"
+  printf "\n"
+  printf "  Environment:\n"
+  printf "    ${DIM}DAT9_SERVER${RESET}   server URL (default: ${SERVER_URL})\n"
+  printf "    ${DIM}DAT9_API_KEY${RESET}  API key\n"
+  printf "\n"
+}
+
+main

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -572,3 +572,11 @@ func extractText(data []byte, contentType string) string {
 func (b *Dat9Backend) ExecSQL(ctx context.Context, query string) ([]map[string]interface{}, error) {
 	return b.store.ExecSQL(ctx, query)
 }
+
+func (b *Dat9Backend) Grep(ctx context.Context, query, pathPrefix string, limit int) ([]datastore.SearchResult, error) {
+	return b.store.Grep(ctx, query, pathPrefix, limit)
+}
+
+func (b *Dat9Backend) Find(ctx context.Context, f *datastore.FindFilter) ([]datastore.SearchResult, error) {
+	return b.store.Find(ctx, f)
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -257,4 +258,57 @@ func (c *Client) SQL(query string) ([]map[string]interface{}, error) {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
 	return rows, nil
+}
+
+type SearchResult struct {
+	Path      string   `json:"path"`
+	Name      string   `json:"name"`
+	SizeBytes int64    `json:"size_bytes"`
+	Score     *float64 `json:"score,omitempty"`
+}
+
+func (c *Client) Grep(query, pathPrefix string, limit int) ([]SearchResult, error) {
+	u := c.url(pathPrefix) + "?grep=" + url.QueryEscape(query)
+	if limit > 0 {
+		u += "&limit=" + strconv.Itoa(limit)
+	}
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var results []SearchResult
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (c *Client) Find(pathPrefix string, params url.Values) ([]SearchResult, error) {
+	params.Set("find", "")
+	u := c.url(pathPrefix) + "?" + params.Encode()
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var results []SearchResult
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		return nil, err
+	}
+	return results, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -280,7 +280,7 @@ func (c *Client) Grep(query, pathPrefix string, limit int) ([]SearchResult, erro
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return nil, readError(resp)
 	}
@@ -302,7 +302,7 @@ func (c *Client) Find(pathPrefix string, params url.Values) ([]SearchResult, err
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return nil, readError(resp)
 	}

--- a/pkg/datastore/search.go
+++ b/pkg/datastore/search.go
@@ -88,6 +88,9 @@ func rrfMerge(fts, vec []SearchResult, limit int) []SearchResult {
 }
 
 func subtreeCond(prefix string) (string, []any) {
+	if prefix != "/" {
+		prefix = strings.TrimRight(prefix, "/")
+	}
 	return "(fn.path = ? OR fn.path LIKE ?)", []any{prefix, prefix + "/%"}
 }
 

--- a/pkg/datastore/search.go
+++ b/pkg/datastore/search.go
@@ -87,13 +87,18 @@ func rrfMerge(fts, vec []SearchResult, limit int) []SearchResult {
 	return merged
 }
 
+func subtreeCond(prefix string) (string, []any) {
+	return "(fn.path = ? OR fn.path LIKE ?)", []any{prefix, prefix + "/%"}
+}
+
 func (s *Store) vectorSearch(ctx context.Context, query, pathPrefix string, limit int) []SearchResult {
 	conds := []string{"f.status = 'CONFIRMED'", "f.embedding IS NOT NULL"}
 	args := []any{query}
 
 	if pathPrefix != "" && pathPrefix != "/" {
-		conds = append(conds, "fn.path LIKE ?")
-		args = append(args, pathPrefix+"%")
+		cond, pargs := subtreeCond(pathPrefix)
+		conds = append(conds, cond)
+		args = append(args, pargs...)
 	}
 	args = append(args, query, limit)
 
@@ -108,7 +113,7 @@ func (s *Store) vectorSearch(ctx context.Context, query, pathPrefix string, limi
 	if err != nil {
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var out []SearchResult
 	for rows.Next() {
@@ -146,8 +151,9 @@ func (s *Store) ftsSearch(ctx context.Context, query, pathPrefix string, limit i
 	var args []any
 
 	if pathPrefix != "" && pathPrefix != "/" {
-		conds = append(conds, "fn.path LIKE ?")
-		args = append(args, pathPrefix+"%")
+		cond, pargs := subtreeCond(pathPrefix)
+		conds = append(conds, cond)
+		args = append(args, pargs...)
 	}
 	args = append(args, limit)
 
@@ -161,7 +167,7 @@ func (s *Store) ftsSearch(ctx context.Context, query, pathPrefix string, limit i
 	if err != nil {
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var out []SearchResult
 	for rows.Next() {
@@ -181,8 +187,9 @@ func (s *Store) keywordSearch(ctx context.Context, query, pathPrefix string, lim
 	args := []any{query}
 
 	if pathPrefix != "" && pathPrefix != "/" {
-		conds = append(conds, "fn.path LIKE ?")
-		args = append(args, pathPrefix+"%")
+		cond, pargs := subtreeCond(pathPrefix)
+		conds = append(conds, cond)
+		args = append(args, pargs...)
 	}
 	args = append(args, limit)
 
@@ -195,7 +202,7 @@ func (s *Store) keywordSearch(ctx context.Context, query, pathPrefix string, lim
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var out []SearchResult
 	for rows.Next() {
@@ -217,8 +224,9 @@ func (s *Store) Find(ctx context.Context, f *FindFilter) ([]SearchResult, error)
 	var args []any
 
 	if f.PathPrefix != "" && f.PathPrefix != "/" {
-		conds = append(conds, "fn.path LIKE ?")
-		args = append(args, f.PathPrefix+"%")
+		cond, pargs := subtreeCond(f.PathPrefix)
+		conds = append(conds, cond)
+		args = append(args, pargs...)
 	}
 	if f.NameGlob != "" {
 		pattern := strings.ReplaceAll(strings.ReplaceAll(f.NameGlob, "*", "%"), "?", "_")
@@ -261,7 +269,7 @@ func (s *Store) Find(ctx context.Context, f *FindFilter) ([]SearchResult, error)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var out []SearchResult
 	for rows.Next() {

--- a/pkg/datastore/search.go
+++ b/pkg/datastore/search.go
@@ -130,6 +130,11 @@ func (s *Store) vectorSearch(ctx context.Context, query, pathPrefix string, limi
 func ftsSafe(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `'`, `''`)
+	s = strings.ReplaceAll(s, `;`, "")
+	s = strings.ReplaceAll(s, `--`, "")
+	s = strings.ReplaceAll(s, `/*`, "")
+	s = strings.ReplaceAll(s, `*/`, "")
+	s = strings.ReplaceAll(s, "\x00", "")
 	return s
 }
 

--- a/pkg/datastore/search.go
+++ b/pkg/datastore/search.go
@@ -1,0 +1,270 @@
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+type SearchResult struct {
+	Path      string   `json:"path"`
+	Name      string   `json:"name"`
+	SizeBytes int64    `json:"size_bytes"`
+	Score     *float64 `json:"score,omitempty"`
+}
+
+type FindFilter struct {
+	PathPrefix string
+	NameGlob   string
+	TagKey     string
+	TagValue   string
+	After      *time.Time
+	Before     *time.Time
+	MinSize    int64
+	MaxSize    int64
+	Limit      int
+}
+
+const rrfK = 60.0
+
+func (s *Store) Grep(ctx context.Context, query, pathPrefix string, limit int) ([]SearchResult, error) {
+	if query == "" {
+		return nil, fmt.Errorf("empty query")
+	}
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	fetch := limit * 3
+
+	vecCh := make(chan []SearchResult, 1)
+	ftsCh := make(chan []SearchResult, 1)
+
+	go func() { vecCh <- s.vectorSearch(ctx, query, pathPrefix, fetch) }()
+	go func() { ftsCh <- s.ftsSearch(ctx, query, pathPrefix, fetch) }()
+
+	vec := <-vecCh
+	fts := <-ftsCh
+
+	if len(vec) == 0 && len(fts) == 0 {
+		return s.keywordSearch(ctx, query, pathPrefix, limit)
+	}
+	return rrfMerge(fts, vec, limit), nil
+}
+
+func rrfMerge(fts, vec []SearchResult, limit int) []SearchResult {
+	scores := make(map[string]float64)
+	for rank, r := range fts {
+		scores[r.Path] += 1.0 / (rrfK + float64(rank+1))
+	}
+	for rank, r := range vec {
+		scores[r.Path] += 1.0 / (rrfK + float64(rank+1))
+	}
+
+	all := make(map[string]SearchResult)
+	for _, r := range fts {
+		all[r.Path] = r
+	}
+	for _, r := range vec {
+		if _, ok := all[r.Path]; !ok {
+			all[r.Path] = r
+		}
+	}
+
+	merged := make([]SearchResult, 0, len(all))
+	for _, r := range all {
+		sc := scores[r.Path]
+		r.Score = &sc
+		merged = append(merged, r)
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		return *merged[i].Score > *merged[j].Score
+	})
+	if len(merged) > limit {
+		merged = merged[:limit]
+	}
+	return merged
+}
+
+func (s *Store) vectorSearch(ctx context.Context, query, pathPrefix string, limit int) []SearchResult {
+	conds := []string{"f.status = 'CONFIRMED'", "f.embedding IS NOT NULL"}
+	args := []any{query}
+
+	if pathPrefix != "" && pathPrefix != "/" {
+		conds = append(conds, "fn.path LIKE ?")
+		args = append(args, pathPrefix+"%")
+	}
+	args = append(args, query, limit)
+
+	q := `SELECT fn.path, fn.name, f.size_bytes,
+		VEC_EMBED_COSINE_DISTANCE(f.embedding, ?) AS distance
+		FROM file_nodes fn JOIN files f ON fn.file_id = f.file_id
+		WHERE ` + strings.Join(conds, " AND ") + `
+		ORDER BY VEC_EMBED_COSINE_DISTANCE(f.embedding, ?)
+		LIMIT ?`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []SearchResult
+	for rows.Next() {
+		var r SearchResult
+		var dist float64
+		if rows.Scan(&r.Path, &r.Name, &r.SizeBytes, &dist) != nil {
+			break
+		}
+		sc := 1.0 - dist
+		if sc < 0.3 {
+			continue
+		}
+		r.Score = &sc
+		out = append(out, r)
+	}
+	return out
+}
+
+func ftsSafe(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `''`)
+	return s
+}
+
+func (s *Store) ftsSearch(ctx context.Context, query, pathPrefix string, limit int) []SearchResult {
+	safe := ftsSafe(query)
+	ftsExpr := "fts_match_word('" + safe + "', f.content_text)"
+
+	conds := []string{"f.status = 'CONFIRMED'", ftsExpr}
+	var args []any
+
+	if pathPrefix != "" && pathPrefix != "/" {
+		conds = append(conds, "fn.path LIKE ?")
+		args = append(args, pathPrefix+"%")
+	}
+	args = append(args, limit)
+
+	q := `SELECT fn.path, fn.name, f.size_bytes, ` + ftsExpr + ` AS score
+		FROM file_nodes fn JOIN files f ON fn.file_id = f.file_id
+		WHERE ` + strings.Join(conds, " AND ") + `
+		ORDER BY ` + ftsExpr + ` DESC
+		LIMIT ?`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []SearchResult
+	for rows.Next() {
+		var r SearchResult
+		var sc float64
+		if rows.Scan(&r.Path, &r.Name, &r.SizeBytes, &sc) != nil {
+			break
+		}
+		r.Score = &sc
+		out = append(out, r)
+	}
+	return out
+}
+
+func (s *Store) keywordSearch(ctx context.Context, query, pathPrefix string, limit int) ([]SearchResult, error) {
+	conds := []string{"f.status = 'CONFIRMED'", "f.content_text LIKE CONCAT('%', ?, '%')"}
+	args := []any{query}
+
+	if pathPrefix != "" && pathPrefix != "/" {
+		conds = append(conds, "fn.path LIKE ?")
+		args = append(args, pathPrefix+"%")
+	}
+	args = append(args, limit)
+
+	q := `SELECT fn.path, fn.name, f.size_bytes
+		FROM file_nodes fn JOIN files f ON fn.file_id = f.file_id
+		WHERE ` + strings.Join(conds, " AND ") + `
+		ORDER BY f.confirmed_at DESC LIMIT ?`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []SearchResult
+	for rows.Next() {
+		var r SearchResult
+		if err := rows.Scan(&r.Path, &r.Name, &r.SizeBytes); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) Find(ctx context.Context, f *FindFilter) ([]SearchResult, error) {
+	if f.Limit <= 0 || f.Limit > 1000 {
+		f.Limit = 100
+	}
+
+	conds := []string{"f.status = 'CONFIRMED'", "fn.is_directory = 0"}
+	var args []any
+
+	if f.PathPrefix != "" && f.PathPrefix != "/" {
+		conds = append(conds, "fn.path LIKE ?")
+		args = append(args, f.PathPrefix+"%")
+	}
+	if f.NameGlob != "" {
+		pattern := strings.ReplaceAll(strings.ReplaceAll(f.NameGlob, "*", "%"), "?", "_")
+		conds = append(conds, "fn.name LIKE ?")
+		args = append(args, pattern)
+	}
+	if f.TagKey != "" {
+		if f.TagValue != "" {
+			conds = append(conds, `EXISTS (SELECT 1 FROM file_tags t WHERE t.file_id = f.file_id AND t.tag_key = ? AND t.tag_value = ?)`)
+			args = append(args, f.TagKey, f.TagValue)
+		} else {
+			conds = append(conds, `EXISTS (SELECT 1 FROM file_tags t WHERE t.file_id = f.file_id AND t.tag_key = ?)`)
+			args = append(args, f.TagKey)
+		}
+	}
+	if f.After != nil {
+		conds = append(conds, "f.confirmed_at > ?")
+		args = append(args, f.After.UTC())
+	}
+	if f.Before != nil {
+		conds = append(conds, "f.confirmed_at < ?")
+		args = append(args, f.Before.UTC())
+	}
+	if f.MinSize > 0 {
+		conds = append(conds, "f.size_bytes >= ?")
+		args = append(args, f.MinSize)
+	}
+	if f.MaxSize > 0 {
+		conds = append(conds, "f.size_bytes <= ?")
+		args = append(args, f.MaxSize)
+	}
+	args = append(args, f.Limit)
+
+	q := `SELECT fn.path, fn.name, f.size_bytes
+		FROM file_nodes fn JOIN files f ON fn.file_id = f.file_id
+		WHERE ` + strings.Join(conds, " AND ") + `
+		ORDER BY fn.path LIMIT ?`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []SearchResult
+	for rows.Next() {
+		var r SearchResult
+		if err := rows.Scan(&r.Path, &r.Name, &r.SizeBytes); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -846,10 +846,12 @@ func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string)
 	}
 	limit := 20
 	if v := r.URL.Query().Get("limit"); v != "" {
-		if _, err := fmt.Sscanf(v, "%d", &limit); err != nil {
+		n, err := strconv.Atoi(v)
+		if err != nil {
 			errJSON(w, http.StatusBadRequest, "invalid limit: "+v)
 			return
 		}
+		limit = n
 	}
 	results, err := b.Grep(r.Context(), query, path, limit)
 	if err != nil {
@@ -891,22 +893,28 @@ func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string)
 		f.Before = &t
 	}
 	if v := q.Get("minsize"); v != "" {
-		if _, err := fmt.Sscanf(v, "%d", &f.MinSize); err != nil {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
 			errJSON(w, http.StatusBadRequest, "invalid minsize: "+v)
 			return
 		}
+		f.MinSize = n
 	}
 	if v := q.Get("maxsize"); v != "" {
-		if _, err := fmt.Sscanf(v, "%d", &f.MaxSize); err != nil {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
 			errJSON(w, http.StatusBadRequest, "invalid maxsize: "+v)
 			return
 		}
+		f.MaxSize = n
 	}
 	if v := q.Get("limit"); v != "" {
-		if _, err := fmt.Sscanf(v, "%d", &f.Limit); err != nil {
+		n, err := strconv.Atoi(v)
+		if err != nil {
 			errJSON(w, http.StatusBadRequest, "invalid limit: "+v)
 			return
 		}
+		f.Limit = n
 	}
 	results, err := b.Find(r.Context(), f)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -828,3 +828,69 @@ func (s *Server) handleSQL(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(rows)
 }
+
+func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string) {
+	b := backendFromRequest(r)
+	if b == nil {
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	query := r.URL.Query().Get("grep")
+	if query == "" {
+		errJSON(w, http.StatusBadRequest, "empty grep query")
+		return
+	}
+	limit := 20
+	if v := r.URL.Query().Get("limit"); v != "" {
+		fmt.Sscanf(v, "%d", &limit)
+	}
+	results, err := b.Grep(r.Context(), query, path, limit)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(results)
+}
+
+func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string) {
+	b := backendFromRequest(r)
+	if b == nil {
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	q := r.URL.Query()
+	f := &datastore.FindFilter{PathPrefix: path}
+	f.NameGlob = q.Get("name")
+	if tag := q.Get("tag"); tag != "" {
+		k, v, _ := strings.Cut(tag, "=")
+		f.TagKey = k
+		f.TagValue = v
+	}
+	if v := q.Get("newer"); v != "" {
+		if t, err := time.Parse("2006-01-02", v); err == nil {
+			f.After = &t
+		}
+	}
+	if v := q.Get("older"); v != "" {
+		if t, err := time.Parse("2006-01-02", v); err == nil {
+			f.Before = &t
+		}
+	}
+	if v := q.Get("minsize"); v != "" {
+		fmt.Sscanf(v, "%d", &f.MinSize)
+	}
+	if v := q.Get("maxsize"); v != "" {
+		fmt.Sscanf(v, "%d", &f.MaxSize)
+	}
+	if v := q.Get("limit"); v != "" {
+		fmt.Sscanf(v, "%d", &f.Limit)
+	}
+	results, err := b.Find(r.Context(), f)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(results)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -846,7 +846,10 @@ func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string)
 	}
 	limit := 20
 	if v := r.URL.Query().Get("limit"); v != "" {
-		fmt.Sscanf(v, "%d", &limit)
+		if _, err := fmt.Sscanf(v, "%d", &limit); err != nil {
+			errJSON(w, http.StatusBadRequest, "invalid limit: "+v)
+			return
+		}
 	}
 	results, err := b.Grep(r.Context(), query, path, limit)
 	if err != nil {
@@ -872,23 +875,38 @@ func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string)
 		f.TagValue = v
 	}
 	if v := q.Get("newer"); v != "" {
-		if t, err := time.Parse("2006-01-02", v); err == nil {
-			f.After = &t
+		t, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			errJSON(w, http.StatusBadRequest, "invalid newer date: "+v)
+			return
 		}
+		f.After = &t
 	}
 	if v := q.Get("older"); v != "" {
-		if t, err := time.Parse("2006-01-02", v); err == nil {
-			f.Before = &t
+		t, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			errJSON(w, http.StatusBadRequest, "invalid older date: "+v)
+			return
 		}
+		f.Before = &t
 	}
 	if v := q.Get("minsize"); v != "" {
-		fmt.Sscanf(v, "%d", &f.MinSize)
+		if _, err := fmt.Sscanf(v, "%d", &f.MinSize); err != nil {
+			errJSON(w, http.StatusBadRequest, "invalid minsize: "+v)
+			return
+		}
 	}
 	if v := q.Get("maxsize"); v != "" {
-		fmt.Sscanf(v, "%d", &f.MaxSize)
+		if _, err := fmt.Sscanf(v, "%d", &f.MaxSize); err != nil {
+			errJSON(w, http.StatusBadRequest, "invalid maxsize: "+v)
+			return
+		}
 	}
 	if v := q.Get("limit"); v != "" {
-		fmt.Sscanf(v, "%d", &f.Limit)
+		if _, err := fmt.Sscanf(v, "%d", &f.Limit); err != nil {
+			errJSON(w, http.StatusBadRequest, "invalid limit: "+v)
+			return
+		}
 	}
 	results, err := b.Find(r.Context(), f)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -243,7 +243,11 @@ func (s *Server) handleFS(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet:
-		if r.URL.Query().Has("list") {
+		if r.URL.Query().Has("grep") {
+			s.handleGrep(w, r, path)
+		} else if r.URL.Query().Has("find") {
+			s.handleFind(w, r, path)
+		} else if r.URL.Query().Has("list") {
 			s.handleList(w, r, path)
 		} else {
 			s.handleRead(w, r, path)


### PR DESCRIPTION
## Summary

Add `grep` and `find` to `dat9 fs` — standard Unix commands that agents already know.

- `dat9 fs grep` — hybrid search over file contents (vector + FTS + keyword fallback, RRF merge)
- `dat9 fs find` — metadata query (filename glob, tags, date range, size)

## Usage

```bash
# grep: search file contents (hybrid: semantic + keyword)
dat9 fs grep "pricing discussion" /sessions/
dat9 fs grep "TODO" /

# find: search by file attributes
dat9 fs find / -name "*.md"
dat9 fs find / -tag topic=pricing
dat9 fs find / -newer 2026-03-01
dat9 fs find / -size +1048576
```

## Architecture

```
dat9 fs grep "pricing" /sessions/
  → GET /v1/fs/sessions/?grep=pricing
  → datastore.Grep:
      vector: VEC_EMBED_COSINE_DISTANCE (TiDB auto-embedding)
      FTS:    fts_match_word (TiDB BM25)
      → RRF merge (k=60)
      → fallback: LIKE keyword search

dat9 fs find / -name "*.md"
  → GET /v1/fs/?find&name=*.md
  → datastore.Find: WHERE clauses on file_nodes + files + file_tags
```

## Files

| File | Description |
|---|---|
| `pkg/datastore/search.go` | Hybrid search engine: Grep (vector‖FTS → RRF) + Find (metadata) |
| `pkg/backend/dat9.go` | Grep + Find pass-through |
| `pkg/server/server.go` | `?grep=` and `?find` query params on `GET /v1/fs/` |
| `pkg/client/client.go` | Grep + Find SDK methods |
| `cmd/dat9/cli/grep.go` | CLI grep command |
| `cmd/dat9/cli/find.go` | CLI find command (Unix find flags) |
| `cmd/dat9/main.go` | Register grep + find under fs |

## Design notes

- **grep is transparent**: agent writes `grep`, server does the best search available (vector if embedding exists, FTS if index exists, LIKE fallback). No new concepts to learn.
- **find uses Unix flags**: `-name`, `-tag`, `-newer`, `-older`, `-size` — all familiar to agents.
- **RRF merge**: Same algorithm as mem9 (k=60), combines vector + FTS rankings.
- **ftsSafe**: Escapes quotes, strips semicolons/comments/null bytes for fts_match_word inline literal (TiDB requires non-parameterized FTS).
- **Graceful degradation**: Vector/FTS errors return empty (not error), falls to keyword search.

## Review

- Claude Code: SHIP ✅
- Codex: SHIP ✅