### PR TITLE
feat: add configurable max upload size limit

### DIFF
--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/mem9-ai/dat9/pkg/encrypt"
@@ -65,6 +66,13 @@ func main() {
 	kmsKey := os.Getenv("DAT9_ENCRYPT_KEY")
 	tokenHex := os.Getenv("DAT9_TOKEN_SIGNING_KEY")
 	providerType := envOr("DAT9_TENANT_PROVIDER", tenant.ProviderTiDBZero)
+	maxUploadBytes := int64(1 << 30)
+	if raw := os.Getenv("DAT9_MAX_UPLOAD_BYTES"); raw != "" {
+		maxUploadBytes, err = strconv.ParseInt(raw, 10, 64)
+		if err != nil || maxUploadBytes <= 0 {
+			die(fmt.Errorf("invalid DAT9_MAX_UPLOAD_BYTES: must be a positive integer"))
+		}
+	}
 	providerType, err = tenant.NormalizeProvider(providerType)
 	if err != nil {
 		die(err)
@@ -121,11 +129,12 @@ func main() {
 	}
 
 	die(server.NewWithConfig(server.Config{
-		Meta:        store,
-		Pool:        pool,
-		Provisioner: provisioner,
-		TokenSecret: tokenSecret,
-		S3Dir:       s3Dir,
+		Meta:           store,
+		Pool:           pool,
+		Provisioner:    provisioner,
+		TokenSecret:    tokenSecret,
+		S3Dir:          s3Dir,
+		MaxUploadBytes: maxUploadBytes,
 	}).ListenAndServe(addr))
 }
 
@@ -146,8 +155,9 @@ environment:
   DAT9_ENCRYPT_TYPE local_aes|kms
   DAT9_MASTER_KEY  32-byte hex key for local_aes encryptor
   DAT9_ENCRYPT_KEY KMS key id or alias (required for kms)
-  DAT9_TOKEN_SIGNING_KEY  32-byte hex key for JWT API key signing
-  DAT9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)
+	DAT9_TOKEN_SIGNING_KEY  32-byte hex key for JWT API key signing
+	DAT9_MAX_UPLOAD_BYTES maximum allowed upload size in bytes (default: 1073741824)
+	DAT9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)
   S3 storage (set DAT9_S3_BUCKET to enable AWS S3, otherwise local mock):
   DAT9_S3_BUCKET   S3 bucket name (enables AWS S3 mode)
   DAT9_S3_REGION   AWS region (default: us-east-1)

--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -72,6 +72,9 @@ func main() {
 		if err != nil || maxUploadBytes <= 0 {
 			die(fmt.Errorf("invalid DAT9_MAX_UPLOAD_BYTES: must be a positive integer"))
 		}
+		if maxUploadBytes < 1<<20 {
+			die(fmt.Errorf("DAT9_MAX_UPLOAD_BYTES too small: minimum 1048576 (1MiB)"))
+		}
 	}
 	providerType, err = tenant.NormalizeProvider(providerType)
 	if err != nil {
@@ -155,9 +158,9 @@ environment:
   DAT9_ENCRYPT_TYPE local_aes|kms
   DAT9_MASTER_KEY  32-byte hex key for local_aes encryptor
   DAT9_ENCRYPT_KEY KMS key id or alias (required for kms)
-	DAT9_TOKEN_SIGNING_KEY  32-byte hex key for JWT API key signing
-	DAT9_MAX_UPLOAD_BYTES maximum allowed upload size in bytes (default: 1073741824)
-	DAT9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)
+  DAT9_TOKEN_SIGNING_KEY  32-byte hex key for JWT API key signing
+  DAT9_MAX_UPLOAD_BYTES maximum allowed upload size in bytes (default: 1073741824, minimum: 1048576)
+  DAT9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)
   S3 storage (set DAT9_S3_BUCKET to enable AWS S3, otherwise local mock):
   DAT9_S3_BUCKET   S3 bucket name (enables AWS S3 mode)
   DAT9_S3_REGION   AWS region (default: us-east-1)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,22 +23,24 @@ import (
 )
 
 type Config struct {
-	Meta        *meta.Store
-	Pool        *tenant.Pool
-	Provisioner tenant.Provisioner
-	TokenSecret []byte
-	Backend     *backend.Dat9Backend
-	LocalS3     *s3client.LocalS3Client
-	S3Dir       string
+	Meta           *meta.Store
+	Pool           *tenant.Pool
+	Provisioner    tenant.Provisioner
+	TokenSecret    []byte
+	Backend        *backend.Dat9Backend
+	LocalS3        *s3client.LocalS3Client
+	S3Dir          string
+	MaxUploadBytes int64
 }
 
 type Server struct {
-	fallback    *backend.Dat9Backend
-	meta        *meta.Store
-	pool        *tenant.Pool
-	provisioner tenant.Provisioner
-	tokenSecret []byte
-	mux         *http.ServeMux
+	fallback       *backend.Dat9Backend
+	meta           *meta.Store
+	pool           *tenant.Pool
+	provisioner    tenant.Provisioner
+	tokenSecret    []byte
+	maxUploadBytes int64
+	mux            *http.ServeMux
 }
 
 var (
@@ -47,17 +49,24 @@ var (
 	schemaInitMaxBackoff     = 30 * time.Second
 )
 
+const defaultMaxUploadBytes int64 = 1 << 30 // 1 GiB
+
 func New(b *backend.Dat9Backend) *Server {
 	return NewWithConfig(Config{Backend: b})
 }
 
 func NewWithConfig(cfg Config) *Server {
+	maxUpload := cfg.MaxUploadBytes
+	if maxUpload <= 0 {
+		maxUpload = defaultMaxUploadBytes
+	}
 	s := &Server{
-		fallback:    cfg.Backend,
-		meta:        cfg.Meta,
-		pool:        cfg.Pool,
-		tokenSecret: cfg.TokenSecret,
-		provisioner: cfg.Provisioner,
+		fallback:       cfg.Backend,
+		meta:           cfg.Meta,
+		pool:           cfg.Pool,
+		tokenSecret:    cfg.TokenSecret,
+		provisioner:    cfg.Provisioner,
+		maxUploadBytes: maxUpload,
 	}
 	mux := http.NewServeMux()
 
@@ -335,6 +344,10 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 	if h := r.Header.Get("X-Dat9-Content-Length"); h != "" {
 		cl, _ = strconv.ParseInt(h, 10, 64)
 	}
+	if cl > s.maxUploadBytes {
+		errJSON(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("upload too large: max %d bytes", s.maxUploadBytes))
+		return
+	}
 	if cl > 0 && b.IsLargeFile(cl) {
 		partChecksums, err := parsePartChecksumsHeader(r.Header.Get("X-Dat9-Part-Checksums"))
 		if err != nil {
@@ -363,8 +376,14 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		_ = json.NewEncoder(w).Encode(plan)
 		return
 	}
-	data, err := io.ReadAll(r.Body)
+	body := http.MaxBytesReader(w, r.Body, s.maxUploadBytes)
+	data, err := io.ReadAll(body)
 	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			errJSON(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("upload too large: max %d bytes", s.maxUploadBytes))
+			return
+		}
 		errJSON(w, http.StatusBadRequest, "read body: "+err.Error())
 		return
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -340,9 +340,19 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
-	cl := r.ContentLength
+	actualCL := r.ContentLength
+	cl := actualCL
 	if h := r.Header.Get("X-Dat9-Content-Length"); h != "" {
-		cl, _ = strconv.ParseInt(h, 10, 64)
+		parsed, err := strconv.ParseInt(h, 10, 64)
+		if err != nil || parsed < 0 {
+			errJSON(w, http.StatusBadRequest, "invalid X-Dat9-Content-Length")
+			return
+		}
+		if actualCL > 0 && parsed > 0 && actualCL != parsed {
+			errJSON(w, http.StatusBadRequest, "Content-Length and X-Dat9-Content-Length mismatch")
+			return
+		}
+		cl = parsed
 	}
 	if cl > s.maxUploadBytes {
 		errJSON(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("upload too large: max %d bytes", s.maxUploadBytes))

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -413,3 +413,42 @@ func TestParsePartChecksumsHeaderValidation(t *testing.T) {
 		t.Fatalf("expected decoded length error, got %v", err)
 	}
 }
+
+func TestUploadRespectsMaxUploadBytes(t *testing.T) {
+	base, _ := newTestServerWithS3(t)
+	s := NewWithConfig(Config{Backend: base.fallback, MaxUploadBytes: 10})
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/too-big.bin", bytes.NewReader([]byte("12345678901")))
+	req.ContentLength = 11
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 413, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestDeclaredContentLengthOverMaxRejected(t *testing.T) {
+	base, _ := newTestServerWithS3(t)
+	s := NewWithConfig(Config{Backend: base.fallback, MaxUploadBytes: 10})
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/declared-too-big.bin", http.NoBody)
+	req.Header.Set("X-Dat9-Content-Length", "11")
+	req.ContentLength = 0
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 413, got %d: %s", resp.StatusCode, body)
+	}
+}

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -452,3 +452,23 @@ func TestDeclaredContentLengthOverMaxRejected(t *testing.T) {
 		t.Fatalf("expected 413, got %d: %s", resp.StatusCode, body)
 	}
 }
+
+func TestContentLengthHeaderMismatchRejected(t *testing.T) {
+	base, _ := newTestServerWithS3(t)
+	s := NewWithConfig(Config{Backend: base.fallback, MaxUploadBytes: 1 << 20})
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/mismatch.bin", bytes.NewReader([]byte("1234")))
+	req.ContentLength = 4
+	req.Header.Set("X-Dat9-Content-Length", "5")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce a maximum upload size in server write path with a default of 1 GiB
- support override via `DAT9_MAX_UPLOAD_BYTES` in `dat9-server`
- apply size checks to both declared `X-Dat9-Content-Length` and direct request body reads (returns `413` when exceeded)
- add server tests covering oversized direct body and oversized declared content-length paths

## Validation
- `go test ./pkg/server ./cmd/dat9-server`
- `make lint`