### PR TITLE
refactor observability structure and simplify key metrics

### DIFF
--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -9,15 +9,16 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/mem9-ai/dat9/pkg/encrypt"
+	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/server"
 	"github.com/mem9-ai/dat9/pkg/tenant"
+	"go.uber.org/zap"
 )
 
 const (
@@ -34,6 +35,13 @@ func main() {
 	if len(os.Args) == 2 {
 		addr = os.Args[1]
 	}
+
+	srvLogger, err := logger.NewServerLogger()
+	if err != nil {
+		die(fmt.Errorf("create logger: %w", err))
+	}
+	defer func() { _ = srvLogger.Sync() }()
+	logger.Set(srvLogger)
 
 	metaDSN := os.Getenv("DAT9_META_DSN")
 	if metaDSN == "" {
@@ -56,9 +64,9 @@ func main() {
 		if err := os.MkdirAll(s3Dir, 0o755); err != nil {
 			die(fmt.Errorf("create s3 dir: %w", err))
 		}
-		log.Printf("using local S3 root directory (dir=%s)", s3Dir)
+		logger.Info(context.Background(), "s3_mode_local", zap.String("dir", s3Dir))
 	} else {
-		log.Printf("using AWS S3 (bucket=%s region=%s role=%s)", s3Bucket, s3Region, envOr("DAT9_S3_ROLE_ARN", "default-credentials"))
+		logger.Info(context.Background(), "s3_mode_aws", zap.String("bucket", s3Bucket), zap.String("region", s3Region), zap.String("role", envOr("DAT9_S3_ROLE_ARN", "default-credentials")))
 	}
 
 	encryptType := envOr("DAT9_ENCRYPT_TYPE", "local_aes")
@@ -92,7 +100,7 @@ func main() {
 		provisioner, provisionerErr = tenant.NewDB9ProvisionerFromEnv()
 	}
 	if provisionerErr != nil {
-		log.Printf("provider %s is not configured for auto provisioning: %v", providerType, provisionerErr)
+		logger.Warn(context.Background(), "provisioner_not_configured", zap.String("provider", providerType), zap.Error(provisionerErr))
 	}
 
 	var pool *tenant.Pool
@@ -138,6 +146,7 @@ func main() {
 		TokenSecret:    tokenSecret,
 		S3Dir:          s3Dir,
 		MaxUploadBytes: maxUploadBytes,
+		Logger:         srvLogger,
 	}).ListenAndServe(addr))
 }
 
@@ -194,8 +203,8 @@ func publicBaseURL(listenAddr string) string {
 	case strings.HasPrefix(listenAddr, "http://"), strings.HasPrefix(listenAddr, "https://"):
 		return strings.TrimRight(listenAddr, "/")
 	default:
-		log.Fatalf("DAT9_PUBLIC_URL is required when listen address is %q (wildcard or non-loopback). "+
-			"Set DAT9_PUBLIC_URL to the externally reachable base URL.", listenAddr)
+		fmt.Fprintf(os.Stderr, "dat9-server: DAT9_PUBLIC_URL is required when listen address is %q (wildcard or non-loopback). Set DAT9_PUBLIC_URL to the externally reachable base URL.\n", listenAddr)
+		os.Exit(1)
 		return "" // unreachable
 	}
 }

--- a/cmd/dat9/main.go
+++ b/cmd/dat9/main.go
@@ -12,15 +12,28 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/mem9-ai/dat9/cmd/dat9/cli"
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"go.uber.org/zap"
 )
 
 var version = "dev"
+var cliLogger *zap.Logger
 
 func main() {
+	if cliLogEnabled() {
+		if l, err := logger.NewCLILogger(); err == nil {
+			cliLogger = l
+			logger.Set(l)
+			defer func() { _ = cliLogger.Sync() }()
+		}
+	}
+
 	if len(os.Args) < 2 {
 		usage()
 	}
@@ -30,23 +43,57 @@ func main() {
 
 	switch cmd {
 	case "--version", "-v", "version":
+		if cliLogger != nil {
+			logger.Info(context.Background(), "cli_command", zap.String("command", "version"))
+		}
 		fmt.Printf("dat9 %s\n", version)
 	case "-h", "-help", "help":
+		if cliLogger != nil {
+			logger.Info(context.Background(), "cli_command", zap.String("command", "help"))
+		}
 		usage()
 	case "create":
+		if cliLogger != nil {
+			logger.Info(context.Background(), "cli_command", zap.String("command", "create"))
+		}
 		if err := cli.Create(args); err != nil {
 			fatal("create", err)
 		}
 	case "ctx":
+		if cliLogger != nil {
+			logger.Info(context.Background(), "cli_command", zap.String("command", "ctx"))
+		}
 		if err := cli.Ctx(args); err != nil {
 			fatal("ctx", err)
 		}
 	case "fs":
+		if cliLogger != nil {
+			sub := ""
+			if len(args) > 0 {
+				sub = args[0]
+			}
+			logger.Info(context.Background(), "cli_command", zap.String("command", "fs"), zap.String("subcommand", sub))
+		}
 		runFS(args)
 	default:
+		if cliLogger != nil {
+			logger.Warn(context.Background(), "cli_unknown_command", zap.String("command", cmd))
+		}
 		fmt.Fprintf(os.Stderr, "dat9: unknown command %q\n", cmd)
 		usage()
 	}
+}
+
+func cliLogEnabled() bool {
+	raw := os.Getenv("DAT9_CLI_LOG_ENABLED")
+	if raw == "" {
+		return false
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false
+	}
+	return v
 }
 
 func runFS(args []string) {
@@ -89,6 +136,9 @@ func runFS(args []string) {
 }
 
 func fatal(cmd string, err error) {
+	if cliLogger != nil {
+		logger.Error(context.Background(), "cli_command_failed", zap.String("command", cmd), zap.Error(err))
+	}
 	fmt.Fprintf(os.Stderr, "%s: %v\n", cmd, err)
 	os.Exit(1)
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,9 @@ require (
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.41.0
+	go.uber.org/zap v1.27.0
 	golang.org/x/text v0.35.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (
@@ -85,6 +87,7 @@ require (
 	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,12 @@ go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa
 go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
@@ -215,6 +221,8 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -17,9 +18,13 @@ import (
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/s3client"
+	"github.com/mem9-ai/dat9/pkg/traceid"
 	"github.com/oklog/ulid/v2"
+	"go.uber.org/zap"
 )
 
 const smallFileThreshold = 1 << 20 // 1MB
@@ -72,7 +77,14 @@ func (b *Dat9Backend) genID() string {
 }
 
 func (b *Dat9Backend) Create(path string) error {
-	path, err := pathutil.Canonicalize(path)
+	return b.CreateCtx(backgroundWithTrace(), path)
+}
+
+func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "create", err, start) }()
+
+	path, err = pathutil.Canonicalize(path)
 	if err != nil {
 		return err
 	}
@@ -90,86 +102,120 @@ func (b *Dat9Backend) Create(path string) error {
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + fileID
-		if err := b.s3.PutObject(context.Background(), storageRef, bytes.NewReader(nil), 0); err != nil {
+		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(nil), 0); err != nil {
+			logger.Error(ctx, "backend_create_put_object_failed", zap.String("path", path), zap.String("storage_ref", storageRef), zap.Error(err))
 			return fmt.Errorf("put object: %w", err)
 		}
 	}
 
-	if err := b.store.InsertFile(&datastore.File{
+	err = b.store.InsertFile(ctx, &datastore.File{
 		FileID: fileID, StorageType: storageType, StorageRef: storageRef,
 		ContentBlob: contentBlob,
 		SizeBytes:   0, Revision: 1, Status: datastore.StatusConfirmed,
 		CreatedAt: now, ConfirmedAt: &now,
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
-	if err := b.store.EnsureParentDirs(path, b.genID); err != nil {
+	err = b.store.EnsureParentDirs(ctx, path, b.genID)
+	if err != nil {
 		return err
 	}
-	return b.store.InsertNode(&datastore.FileNode{
+	err = b.store.InsertNode(ctx, &datastore.FileNode{
 		NodeID: b.genID(), Path: path, ParentPath: pathutil.ParentPath(path),
 		Name: pathutil.BaseName(path), FileID: fileID, CreatedAt: now,
 	})
+	return err
 }
 
 func (b *Dat9Backend) Mkdir(path string, perm uint32) error {
+	return b.MkdirCtx(backgroundWithTrace(), path, perm)
+}
+
+func (b *Dat9Backend) MkdirCtx(ctx context.Context, path string, perm uint32) (err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "mkdir", err, start) }()
+
 	dirPath, err := pathutil.CanonicalizeDir(path)
 	if err != nil {
 		return err
 	}
-	if err := b.store.EnsureParentDirs(dirPath, b.genID); err != nil {
+	err = b.store.EnsureParentDirs(ctx, dirPath, b.genID)
+	if err != nil {
 		return err
 	}
-	return b.store.InsertNode(&datastore.FileNode{
+	err = b.store.InsertNode(ctx, &datastore.FileNode{
 		NodeID: b.genID(), Path: dirPath, ParentPath: pathutil.ParentPath(dirPath),
 		Name: pathutil.BaseName(dirPath), IsDirectory: true, CreatedAt: time.Now(),
 	})
+	return err
 }
 
 func (b *Dat9Backend) Remove(path string) error {
+	return b.RemoveCtx(backgroundWithTrace(), path)
+}
+
+func (b *Dat9Backend) RemoveCtx(ctx context.Context, path string) (err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "remove", err, start) }()
+
 	path = normalizePath(path)
-	node, err := b.store.GetNode(path)
+	node, err := b.store.GetNode(ctx, path)
 	if err != nil {
 		return err
 	}
 	if node.IsDirectory {
-		return b.store.DeleteEmptyDir(path)
+		return b.store.DeleteEmptyDir(ctx, path)
 	}
-	deleted, err := b.store.DeleteFileWithRefCheck(path)
+	deleted, err := b.store.DeleteFileWithRefCheck(ctx, path)
 	if err != nil {
 		return err
 	}
 	if deleted != nil {
-		b.deleteBlob(deleted.StorageRef)
+		b.deleteBlobCtx(ctx, deleted.StorageRef)
 	}
 	return nil
 }
 
 func (b *Dat9Backend) RemoveAll(path string) error {
+	return b.RemoveAllCtx(backgroundWithTrace(), path)
+}
+
+func (b *Dat9Backend) RemoveAllCtx(ctx context.Context, path string) (err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "remove_all", err, start) }()
+
 	path = normalizePath(path)
-	node, err := b.store.GetNode(path)
+	node, err := b.store.GetNode(ctx, path)
 	if err != nil {
 		return err
 	}
 	if !node.IsDirectory {
-		return b.Remove(path)
+		return b.RemoveCtx(ctx, path)
 	}
-	orphaned, err := b.store.DeleteDirRecursive(path)
+	orphaned, err := b.store.DeleteDirRecursive(ctx, path)
 	if err != nil {
 		return err
 	}
 	for _, f := range orphaned {
-		b.deleteBlob(f.StorageRef)
+		b.deleteBlobCtx(ctx, f.StorageRef)
 	}
 	return nil
 }
 
 func (b *Dat9Backend) Read(path string, offset int64, size int64) ([]byte, error) {
-	path, err := pathutil.Canonicalize(path)
+	return b.ReadCtx(backgroundWithTrace(), path, offset, size)
+}
+
+func (b *Dat9Backend) ReadCtx(ctx context.Context, path string, offset int64, size int64) (data []byte, err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "read", err, start) }()
+
+	path, err = pathutil.Canonicalize(path)
 	if err != nil {
 		return nil, err
 	}
-	nf, err := b.store.Stat(path)
+	nf, err := b.store.Stat(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +226,7 @@ func (b *Dat9Backend) Read(path string, offset int64, size int64) ([]byte, error
 		return nil, fmt.Errorf("no file entity for path: %s", path)
 	}
 
-	data, err := b.readFileData(nf.File)
+	data, err = b.readFileDataCtx(ctx, nf.File)
 	if err != nil {
 		return nil, err
 	}
@@ -197,17 +243,24 @@ func (b *Dat9Backend) Read(path string, offset int64, size int64) ([]byte, error
 }
 
 func (b *Dat9Backend) Write(path string, data []byte, offset int64, flags filesystem.WriteFlag) (int64, error) {
-	path, err := pathutil.Canonicalize(path)
+	return b.WriteCtx(backgroundWithTrace(), path, data, offset, flags)
+}
+
+func (b *Dat9Backend) WriteCtx(ctx context.Context, path string, data []byte, offset int64, flags filesystem.WriteFlag) (n int64, err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "write", err, start) }()
+
+	path, err = pathutil.Canonicalize(path)
 	if err != nil {
 		return 0, err
 	}
 
-	existing, err := b.store.Stat(path)
+	existing, err := b.store.Stat(ctx, path)
 	if err == datastore.ErrNotFound {
 		if flags&filesystem.WriteFlagCreate == 0 {
 			return 0, datastore.ErrNotFound
 		}
-		return b.createAndWrite(path, data)
+		return b.createAndWriteCtx(ctx, path, data)
 	}
 	if err != nil {
 		return 0, err
@@ -218,10 +271,10 @@ func (b *Dat9Backend) Write(path string, data []byte, offset int64, flags filesy
 	if flags&filesystem.WriteFlagExclusive != 0 {
 		return 0, fmt.Errorf("file already exists: %s", path)
 	}
-	return b.overwriteFile(existing, data, offset, flags)
+	return b.overwriteFileCtx(ctx, existing, data, offset, flags)
 }
 
-func (b *Dat9Backend) createAndWrite(path string, data []byte) (int64, error) {
+func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data []byte) (int64, error) {
 	fileID := b.genID()
 	now := time.Now()
 
@@ -240,12 +293,13 @@ func (b *Dat9Backend) createAndWrite(path string, data []byte) (int64, error) {
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + fileID
-		if err := b.s3.PutObject(context.Background(), storageRef, bytes.NewReader(data), int64(len(data))); err != nil {
+		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(data), int64(len(data))); err != nil {
+			logger.Error(ctx, "backend_create_and_write_put_object_failed", zap.String("path", path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(data)), zap.Error(err))
 			return 0, fmt.Errorf("put object: %w", err)
 		}
 	}
 
-	if err := b.store.InsertFile(&datastore.File{
+	if err := b.store.InsertFile(ctx, &datastore.File{
 		FileID: fileID, StorageType: storageType, StorageRef: storageRef,
 		ContentBlob: contentBlob,
 		ContentType: contentType, SizeBytes: int64(len(data)),
@@ -254,10 +308,10 @@ func (b *Dat9Backend) createAndWrite(path string, data []byte) (int64, error) {
 	}); err != nil {
 		return 0, err
 	}
-	if err := b.store.EnsureParentDirs(path, b.genID); err != nil {
+	if err := b.store.EnsureParentDirs(ctx, path, b.genID); err != nil {
 		return 0, err
 	}
-	if err := b.store.InsertNode(&datastore.FileNode{
+	if err := b.store.InsertNode(ctx, &datastore.FileNode{
 		NodeID: b.genID(), Path: path, ParentPath: pathutil.ParentPath(path),
 		Name: pathutil.BaseName(path), FileID: fileID, CreatedAt: now,
 	}); err != nil {
@@ -266,14 +320,14 @@ func (b *Dat9Backend) createAndWrite(path string, data []byte) (int64, error) {
 	return int64(len(data)), nil
 }
 
-func (b *Dat9Backend) overwriteFile(nf *datastore.NodeWithFile, data []byte, offset int64, flags filesystem.WriteFlag) (int64, error) {
+func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWithFile, data []byte, offset int64, flags filesystem.WriteFlag) (int64, error) {
 	if nf.File == nil {
 		return 0, fmt.Errorf("no file entity")
 	}
 
 	var finalData []byte
 	if flags&filesystem.WriteFlagAppend != 0 {
-		existing, err := b.readFileData(nf.File)
+		existing, err := b.readFileDataCtx(ctx, nf.File)
 		if err != nil {
 			return 0, fmt.Errorf("read existing data for append: %w", err)
 		}
@@ -281,7 +335,7 @@ func (b *Dat9Backend) overwriteFile(nf *datastore.NodeWithFile, data []byte, off
 	} else if flags&filesystem.WriteFlagTruncate != 0 || offset <= 0 {
 		finalData = data
 	} else {
-		existing, err := b.readFileData(nf.File)
+		existing, err := b.readFileDataCtx(ctx, nf.File)
 		if err != nil {
 			return 0, fmt.Errorf("read existing data for offset write: %w", err)
 		}
@@ -309,37 +363,45 @@ func (b *Dat9Backend) overwriteFile(nf *datastore.NodeWithFile, data []byte, off
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + b.genID()
-		if err := b.s3.PutObject(context.Background(), storageRef, bytes.NewReader(finalData), int64(len(finalData))); err != nil {
+		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(finalData), int64(len(finalData))); err != nil {
+			logger.Error(ctx, "backend_overwrite_put_object_failed", zap.String("path", nf.Node.Path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(finalData)), zap.Error(err))
 			return 0, fmt.Errorf("put object: %w", err)
 		}
 	}
 
-	if err := b.store.UpdateFileContent(
+	if err := b.store.UpdateFileContent(ctx,
 		nf.File.FileID, storageType, storageRef,
 		contentType, checksum, contentText, contentBlob, int64(len(finalData)),
 	); err != nil {
 		if storageType == datastore.StorageS3 {
-			b.deleteBlob(storageRef)
+			b.deleteBlobCtx(ctx, storageRef)
 		}
 		return 0, err
 	}
 	if nf.File.StorageRef != "" && nf.File.StorageRef != storageRef {
-		b.deleteBlob(nf.File.StorageRef)
+		b.deleteBlobCtx(ctx, nf.File.StorageRef)
 	}
 	return int64(len(data)), nil
 }
 
 func (b *Dat9Backend) ReadDir(path string) ([]filesystem.FileInfo, error) {
+	return b.ReadDirCtx(backgroundWithTrace(), path)
+}
+
+func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []filesystem.FileInfo, err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "read_dir", err, start) }()
+
 	dirPath, err := pathutil.CanonicalizeDir(path)
 	if err != nil {
 		return nil, err
 	}
-	entries, err := b.store.ListDir(dirPath)
+	entries, err := b.store.ListDir(ctx, dirPath)
 	if err != nil {
 		return nil, err
 	}
 
-	var infos []filesystem.FileInfo
+	infos = make([]filesystem.FileInfo, 0, len(entries))
 	for _, e := range entries {
 		info := filesystem.FileInfo{
 			Name: e.Node.Name, IsDir: e.Node.IsDirectory, Mode: 0o644,
@@ -364,7 +426,7 @@ func (b *Dat9Backend) ReadDir(path string) ([]filesystem.FileInfo, error) {
 
 func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {
 	path = normalizePath(path)
-	nf, err := b.store.Stat(path)
+	nf, err := b.store.Stat(backgroundWithTrace(), path)
 	if err != nil {
 		return nil, err
 	}
@@ -388,24 +450,34 @@ func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {
 }
 
 func (b *Dat9Backend) Rename(oldPath, newPath string) error {
+	return b.RenameCtx(backgroundWithTrace(), oldPath, newPath)
+}
+
+func (b *Dat9Backend) RenameCtx(ctx context.Context, oldPath, newPath string) (err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "rename", err, start) }()
+
 	oldPath = normalizePath(oldPath)
 	newPath = normalizePath(newPath)
 
-	node, err := b.store.GetNode(oldPath)
+	node, err := b.store.GetNode(ctx, oldPath)
 	if err != nil {
 		return err
 	}
 	if node.IsDirectory {
-		if err := b.store.EnsureParentDirs(newPath, b.genID); err != nil {
+		err = b.store.EnsureParentDirs(ctx, newPath, b.genID)
+		if err != nil {
 			return err
 		}
-		_, err := b.store.RenameDir(oldPath, newPath)
+		_, err = b.store.RenameDir(ctx, oldPath, newPath)
 		return err
 	}
-	if err := b.store.EnsureParentDirs(newPath, b.genID); err != nil {
+	err = b.store.EnsureParentDirs(ctx, newPath, b.genID)
+	if err != nil {
 		return err
 	}
-	return b.store.UpdateNodePath(oldPath, newPath, pathutil.ParentPath(newPath), pathutil.BaseName(newPath))
+	err = b.store.UpdateNodePath(ctx, oldPath, newPath, pathutil.ParentPath(newPath), pathutil.BaseName(newPath))
+	return err
 }
 
 func (b *Dat9Backend) Chmod(path string, mode uint32) error { return nil }
@@ -441,7 +513,14 @@ var _ filesystem.CapabilityProvider = (*Dat9Backend)(nil)
 
 // CopyFile performs a zero-copy cp (new file_node pointing to same file_id).
 func (b *Dat9Backend) CopyFile(srcPath, dstPath string) error {
-	srcPath, err := pathutil.Canonicalize(srcPath)
+	return b.CopyFileCtx(backgroundWithTrace(), srcPath, dstPath)
+}
+
+func (b *Dat9Backend) CopyFileCtx(ctx context.Context, srcPath, dstPath string) (err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "copy_file", err, start) }()
+
+	srcPath, err = pathutil.Canonicalize(srcPath)
 	if err != nil {
 		return err
 	}
@@ -449,29 +528,35 @@ func (b *Dat9Backend) CopyFile(srcPath, dstPath string) error {
 	if err != nil {
 		return err
 	}
-	srcNode, err := b.store.GetNode(srcPath)
+	srcNode, err := b.store.GetNode(ctx, srcPath)
 	if err != nil {
 		return err
 	}
 	if srcNode.IsDirectory {
 		return fmt.Errorf("cannot copy directory with CopyFile: %s", srcPath)
 	}
-	if err := b.store.EnsureParentDirs(dstPath, b.genID); err != nil {
+	if err := b.store.EnsureParentDirs(ctx, dstPath, b.genID); err != nil {
 		return err
 	}
-	return b.store.InsertNode(&datastore.FileNode{
+	return b.store.InsertNode(ctx, &datastore.FileNode{
 		NodeID: b.genID(), Path: dstPath, ParentPath: pathutil.ParentPath(dstPath),
 		Name: pathutil.BaseName(dstPath), FileID: srcNode.FileID, CreatedAt: time.Now(),
 	})
 }
 
 func (b *Dat9Backend) deleteBlob(ref string) {
+	b.deleteBlobCtx(backgroundWithTrace(), ref)
+}
+
+func (b *Dat9Backend) deleteBlobCtx(ctx context.Context, ref string) {
 	if b.s3 != nil && ref != "" {
-		_ = b.s3.DeleteObject(context.Background(), ref)
+		if err := b.s3.DeleteObject(ctx, ref); err != nil {
+			logger.Warn(ctx, "backend_delete_blob_failed", zap.String("storage_ref", ref), zap.Error(err))
+		}
 	}
 }
 
-func (b *Dat9Backend) readFileData(f *datastore.File) ([]byte, error) {
+func (b *Dat9Backend) readFileDataCtx(ctx context.Context, f *datastore.File) ([]byte, error) {
 	if f == nil {
 		return nil, fmt.Errorf("nil file")
 	}
@@ -479,8 +564,9 @@ func (b *Dat9Backend) readFileData(f *datastore.File) ([]byte, error) {
 		if b.s3 == nil {
 			return nil, fmt.Errorf("s3 client not configured")
 		}
-		rc, err := b.s3.GetObject(context.Background(), f.StorageRef)
+		rc, err := b.s3.GetObject(ctx, f.StorageRef)
 		if err != nil {
+			logger.Error(ctx, "backend_read_get_object_failed", zap.String("storage_ref", f.StorageRef), zap.Error(err))
 			return nil, err
 		}
 		defer func() { _ = rc.Close() }()
@@ -529,6 +615,10 @@ func normalizePath(path string) string {
 	return p
 }
 
+func backgroundWithTrace() context.Context {
+	return traceid.Background()
+}
+
 func sha256sum(data []byte) string {
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
@@ -570,13 +660,46 @@ func extractText(data []byte, contentType string) string {
 }
 
 func (b *Dat9Backend) ExecSQL(ctx context.Context, query string) ([]map[string]interface{}, error) {
-	return b.store.ExecSQL(ctx, query)
+	start := time.Now()
+	rows, err := b.store.ExecSQL(ctx, query)
+	observeBackend(ctx, "exec_sql", err, start)
+	if err != nil {
+		logger.Error(ctx, "backend_exec_sql_failed", zap.Int("query_len", len(query)), zap.Error(err))
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (b *Dat9Backend) Grep(ctx context.Context, query, pathPrefix string, limit int) ([]datastore.SearchResult, error) {
-	return b.store.Grep(ctx, query, pathPrefix, limit)
+	start := time.Now()
+	rows, err := b.store.Grep(ctx, query, pathPrefix, limit)
+	observeBackend(ctx, "grep", err, start)
+	if err != nil {
+		logger.Error(ctx, "backend_grep_failed", zap.Int("query_len", len(query)), zap.String("path_prefix", pathPrefix), zap.Int("limit", limit), zap.Error(err))
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (b *Dat9Backend) Find(ctx context.Context, f *datastore.FindFilter) ([]datastore.SearchResult, error) {
-	return b.store.Find(ctx, f)
+	start := time.Now()
+	rows, err := b.store.Find(ctx, f)
+	observeBackend(ctx, "find", err, start)
+	if err != nil {
+		logger.Error(ctx, "backend_find_failed", zap.String("path", f.PathPrefix), zap.String("name", f.NameGlob), zap.Error(err))
+		return nil, err
+	}
+	return rows, nil
+}
+
+func observeBackend(ctx context.Context, op string, err error, start time.Time) {
+	result := "ok"
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			result = "not_found"
+		} else {
+			result = "error"
+		}
+	}
+	metrics.RecordOperation("backend", op, result, time.Since(start))
 }

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -5,12 +5,14 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/s3client"
+	"go.uber.org/zap"
 )
 
 // UploadPlan is returned by InitiateUpload for the 202 response.
@@ -39,17 +41,25 @@ func (b *Dat9Backend) InitiateUpload(ctx context.Context, path string, totalSize
 }
 
 func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path string, totalSize int64, partChecksums []string) (*UploadPlan, error) {
+	start := time.Now()
+
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
+		logger.Warn(ctx, "backend_initiate_upload_invalid_path", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if b.s3 == nil {
-		return nil, fmt.Errorf("S3 not configured")
+		err := fmt.Errorf("S3 not configured")
+		logger.Error(ctx, "backend_initiate_upload_s3_missing", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		return nil, err
 	}
 
 	// Enforce one active upload per path
-	existing, err := b.store.GetUploadByPath(path)
+	existing, err := b.store.GetUploadByPath(ctx, path)
 	if err == nil && existing != nil {
+		metrics.RecordOperation("backend", "initiate_upload", "conflict", time.Since(start))
 		return nil, datastore.ErrUploadConflict
 	}
 
@@ -59,12 +69,15 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 	// Create S3 multipart upload
 	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key)
 	if err != nil {
+		logger.Error(ctx, "backend_initiate_upload_create_multipart_failed", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 
 	// Calculate parts
 	parts := s3client.CalcParts(totalSize, s3client.PartSize)
 	if len(partChecksums) > 0 && len(partChecksums) != len(parts) {
+		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("%w: got %d, expected %d", ErrPartChecksumCountMismatch, len(partChecksums), len(parts))
 	}
 
@@ -78,6 +91,8 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 		u, err := b.s3.PresignUploadPart(ctx, s3Key, mpu.UploadID, p.Number, p.Size, checksum, s3client.UploadTTL)
 		if err != nil {
 			_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
+			logger.Error(ctx, "backend_initiate_upload_presign_failed", zap.String("path", path), zap.Int("part_number", p.Number), zap.Error(err))
+			metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 			return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
 		}
 		urls[i] = u
@@ -87,7 +102,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 	uploadID := b.genID()
 
 	// Insert PENDING file record
-	if err := b.store.InsertFile(&datastore.File{
+	if err := b.store.InsertFile(ctx, &datastore.File{
 		FileID:      fileID,
 		StorageType: datastore.StorageS3,
 		StorageRef:  s3Key,
@@ -97,11 +112,13 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 		CreatedAt:   now,
 	}); err != nil {
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
+		logger.Error(ctx, "backend_initiate_upload_insert_file_failed", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 
 	// Insert upload record
-	if err := b.store.InsertUpload(&datastore.Upload{
+	if err := b.store.InsertUpload(ctx, &datastore.Upload{
 		UploadID:   uploadID,
 		FileID:     fileID,
 		TargetPath: path,
@@ -116,8 +133,11 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 		ExpiresAt:  now.Add(24 * time.Hour),
 	}); err != nil {
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
+		logger.Error(ctx, "backend_initiate_upload_insert_upload_failed", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
+	metrics.RecordOperation("backend", "initiate_upload", "ok", time.Since(start))
 
 	return &UploadPlan{
 		UploadID: uploadID,
@@ -129,36 +149,47 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 
 // ConfirmUpload completes the multipart upload and creates the file node.
 func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error {
-	upload, err := b.store.GetUpload(uploadID)
+	start := time.Now()
+
+	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
+		metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
 		return err
 	}
 	if upload.Status != datastore.UploadUploading {
+		metrics.RecordOperation("backend", "confirm_upload", "not_active", time.Since(start))
 		return datastore.ErrUploadNotActive
 	}
 
 	// List uploaded parts from S3
 	parts, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
 	if err != nil {
+		logger.Error(ctx, "backend_confirm_upload_list_parts_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
 		return fmt.Errorf("list parts: %w", err)
 	}
 
 	// Verify all parts are present, correctly sized, and have ETags
 	if len(parts) != upload.PartsTotal {
+		metrics.RecordOperation("backend", "confirm_upload", "incomplete", time.Since(start))
 		return fmt.Errorf("incomplete upload: got %d parts, expected %d", len(parts), upload.PartsTotal)
 	}
 	expectedParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	for i, p := range parts {
 		if p.Size != expectedParts[i].Size {
+			metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
 			return fmt.Errorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
 		}
 		if p.ETag == "" {
+			metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
 			return fmt.Errorf("part %d missing ETag", p.Number)
 		}
 	}
 
 	// Complete S3 multipart upload (idempotent, outside transaction)
 	if err := b.s3.CompleteMultipartUpload(ctx, upload.S3Key, upload.S3UploadID, parts); err != nil {
+		logger.Error(ctx, "backend_confirm_upload_complete_multipart_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
 		return fmt.Errorf("complete multipart: %w", err)
 	}
 
@@ -167,7 +198,7 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 	// in place so every hard link keeps pointing at the same file_id.
 	var oldStorageRef string
 	var isOverwrite bool
-	if err := b.store.InTx(func(tx *sql.Tx) error {
+	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
 		if err := b.store.CompleteUploadTx(tx, uploadID); err != nil {
 			return err
 		}
@@ -218,11 +249,14 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 			CreatedAt:  time.Now(),
 		})
 	}); err != nil {
+		logger.Error(ctx, "backend_confirm_upload_tx_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
 		return err
 	}
 	if isOverwrite && oldStorageRef != "" {
 		b.deleteBlob(oldStorageRef)
 	}
+	metrics.RecordOperation("backend", "confirm_upload", "ok", time.Since(start))
 	return nil
 }
 
@@ -232,11 +266,15 @@ func (b *Dat9Backend) ResumeUpload(ctx context.Context, uploadID string) (*Uploa
 }
 
 func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID string, partChecksums []string) (*UploadPlan, error) {
-	upload, err := b.store.GetUpload(uploadID)
+	start := time.Now()
+
+	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
+		metrics.RecordOperation("backend", "resume_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if upload.Status != datastore.UploadUploading {
+		metrics.RecordOperation("backend", "resume_upload", "not_active", time.Since(start))
 		return nil, datastore.ErrUploadNotActive
 	}
 
@@ -245,15 +283,18 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 	// if the abort call fails transiently.
 	if time.Now().After(upload.ExpiresAt) {
 		if err := b.s3.AbortMultipartUpload(ctx, upload.S3Key, upload.S3UploadID); err != nil {
-			log.Printf("WARNING: failed to abort expired multipart upload %s: %v", uploadID, err)
+			logger.Warn(ctx, "backend_resume_upload_abort_expired_failed", zap.String("upload_id", uploadID), zap.Error(err))
 		}
-		_ = b.store.AbortUpload(uploadID)
+		_ = b.store.AbortUpload(ctx, uploadID)
+		metrics.RecordOperation("backend", "resume_upload", "expired", time.Since(start))
 		return nil, datastore.ErrUploadExpired
 	}
 
 	// List already-uploaded parts
 	uploaded, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
 	if err != nil {
+		logger.Error(ctx, "backend_resume_upload_list_parts_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		metrics.RecordOperation("backend", "resume_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("list parts: %w", err)
 	}
 
@@ -265,6 +306,7 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 	// Calculate all expected parts
 	allParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	if len(partChecksums) > 0 && len(partChecksums) != len(allParts) {
+		metrics.RecordOperation("backend", "resume_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("%w: got %d, expected %d", ErrPartChecksumCountMismatch, len(partChecksums), len(allParts))
 	}
 
@@ -280,11 +322,14 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 		}
 		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, p.Number, p.Size, checksum, s3client.UploadTTL)
 		if err != nil {
+			logger.Error(ctx, "backend_resume_upload_presign_failed", zap.String("upload_id", uploadID), zap.Int("part_number", p.Number), zap.Error(err))
+			metrics.RecordOperation("backend", "resume_upload", "error", time.Since(start))
 			return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
 		}
 		urls = append(urls, u)
 	}
 
+	metrics.RecordOperation("backend", "resume_upload", "ok", time.Since(start))
 	return &UploadPlan{
 		UploadID: uploadID,
 		Key:      upload.S3Key,
@@ -295,47 +340,68 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 
 // AbortUpload cancels an in-progress upload.
 func (b *Dat9Backend) AbortUpload(ctx context.Context, uploadID string) error {
-	upload, err := b.store.GetUpload(uploadID)
+	start := time.Now()
+	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
+		metrics.RecordOperation("backend", "abort_upload", "error", time.Since(start))
 		return err
 	}
 	if upload.Status != datastore.UploadUploading {
+		metrics.RecordOperation("backend", "abort_upload", "not_active", time.Since(start))
 		return datastore.ErrUploadNotActive
 	}
 
 	_ = b.s3.AbortMultipartUpload(ctx, upload.S3Key, upload.S3UploadID)
-	return b.store.AbortUpload(uploadID)
+	if err := b.store.AbortUpload(ctx, uploadID); err != nil {
+		logger.Error(ctx, "backend_abort_upload_store_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		metrics.RecordOperation("backend", "abort_upload", "error", time.Since(start))
+		return err
+	}
+	metrics.RecordOperation("backend", "abort_upload", "ok", time.Since(start))
+	return nil
 }
 
 // GetUpload returns the upload record.
-func (b *Dat9Backend) GetUpload(uploadID string) (*datastore.Upload, error) {
-	return b.store.GetUpload(uploadID)
+func (b *Dat9Backend) GetUpload(ctx context.Context, uploadID string) (*datastore.Upload, error) {
+	return b.store.GetUpload(ctx, uploadID)
 }
 
 // ListUploads returns uploads for a given path and status.
-func (b *Dat9Backend) ListUploads(path string, status datastore.UploadStatus) ([]*datastore.Upload, error) {
+func (b *Dat9Backend) ListUploads(ctx context.Context, path string, status datastore.UploadStatus) ([]*datastore.Upload, error) {
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
 		return nil, err
 	}
-	return b.store.ListUploadsByPath(path, status)
+	return b.store.ListUploadsByPath(ctx, path, status)
 }
 
 // PresignGetObject returns a presigned URL for reading an S3-stored file.
 func (b *Dat9Backend) PresignGetObject(ctx context.Context, path string) (string, error) {
+	start := time.Now()
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
+		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", err
 	}
-	nf, err := b.store.Stat(path)
+	nf, err := b.store.Stat(ctx, path)
 	if err != nil {
+		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", err
 	}
 	if nf.File == nil {
+		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", fmt.Errorf("no file entity for path: %s", path)
 	}
 	if nf.File.StorageType != datastore.StorageS3 {
+		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", fmt.Errorf("file is not S3-stored: %s", path)
 	}
-	return b.s3.PresignGetObject(ctx, nf.File.StorageRef, s3client.DownloadTTL)
+	url, err := b.s3.PresignGetObject(ctx, nf.File.StorageRef, s3client.DownloadTTL)
+	if err != nil {
+		logger.Error(ctx, "backend_presign_get_object_failed", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
+		return "", err
+	}
+	metrics.RecordOperation("backend", "presign_get_object", "ok", time.Since(start))
+	return url, nil
 }

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -109,7 +109,7 @@ func TestInitiateAndConfirmUpload(t *testing.T) {
 	}
 
 	// Verify upload record exists
-	upload, err := b.GetUpload(plan.UploadID)
+	upload, err := b.GetUpload(ctx, plan.UploadID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestInitiateAndConfirmUpload(t *testing.T) {
 	}
 
 	// Verify upload is completed
-	upload, _ = b.GetUpload(plan.UploadID)
+	upload, _ = b.GetUpload(ctx, plan.UploadID)
 	if upload.Status != datastore.UploadCompleted {
 		t.Errorf("expected COMPLETED, got %s", upload.Status)
 	}
@@ -179,7 +179,7 @@ func TestResumeUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	upload, _ := b.GetUpload(plan.UploadID)
+	upload, _ := b.GetUpload(ctx, plan.UploadID)
 
 	// Upload only part 1 (simulate partial upload)
 	data := make([]byte, s3client.PartSize)
@@ -213,7 +213,7 @@ func TestAbortUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	upload, _ := b.GetUpload(plan.UploadID)
+	upload, _ := b.GetUpload(ctx, plan.UploadID)
 	if upload.Status != datastore.UploadAborted {
 		t.Errorf("expected ABORTED, got %s", upload.Status)
 	}
@@ -231,7 +231,7 @@ func TestListUploads(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	uploadsA, err := b.ListUploads("/list-a.bin", datastore.UploadUploading)
+	uploadsA, err := b.ListUploads(ctx, "/list-a.bin", datastore.UploadUploading)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -13,6 +13,9 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
+	"go.uber.org/zap"
 )
 
 var (
@@ -129,8 +132,11 @@ func (s *Store) DB() *sql.DB  { return s.db }
 
 // InTx runs fn inside a database transaction. If fn returns an error, the
 // transaction is rolled back; otherwise it is committed.
-func (s *Store) InTx(fn func(tx *sql.Tx) error) error {
-	tx, err := s.db.Begin()
+func (s *Store) InTx(ctx context.Context, fn func(tx *sql.Tx) error) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "in_tx", start, &err)
+
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -138,7 +144,8 @@ func (s *Store) InTx(fn func(tx *sql.Tx) error) error {
 	if err := fn(tx); err != nil {
 		return err
 	}
-	return tx.Commit()
+	err = tx.Commit()
+	return err
 }
 
 func (s *Store) columnExists(table, column string) bool {
@@ -151,30 +158,45 @@ func (s *Store) columnExists(table, column string) bool {
 
 // --- file_nodes operations ---
 
-func (s *Store) InsertNode(n *FileNode) error {
-	_, err := s.db.Exec(`INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, file_id, created_at)
+func (s *Store) InsertNode(ctx context.Context, n *FileNode) error {
+	start := time.Now()
+	var opErr error
+	defer observeStoreOp(ctx, "insert_node", start, &opErr)
+
+	_, err := s.db.ExecContext(ctx, `INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, file_id, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		n.NodeID, n.Path, n.ParentPath, n.Name, n.IsDirectory, nullStr(n.FileID), n.CreatedAt.UTC())
 	if isUniqueViolation(err) {
+		opErr = ErrPathConflict
 		return ErrPathConflict
 	}
+	opErr = err
 	return err
 }
 
-func (s *Store) GetNode(path string) (*FileNode, error) {
-	row := s.db.QueryRow(`SELECT node_id, path, parent_path, name, is_directory, file_id, created_at
+func (s *Store) GetNode(ctx context.Context, path string) (*FileNode, error) {
+	start := time.Now()
+	var opErr error
+	defer observeStoreOp(ctx, "get_node", start, &opErr)
+
+	row := s.db.QueryRowContext(ctx, `SELECT node_id, path, parent_path, name, is_directory, file_id, created_at
 		FROM file_nodes WHERE path = ?`, path)
-	return scanNode(row)
+	n, err := scanNode(row)
+	opErr = err
+	return n, err
 }
 
-func (s *Store) ListNodes(parentPath string) ([]*FileNode, error) {
-	rows, err := s.db.Query(`SELECT node_id, path, parent_path, name, is_directory, file_id, created_at
+func (s *Store) ListNodes(ctx context.Context, parentPath string) (out []*FileNode, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "list_nodes", start, &err)
+
+	rows, err := s.db.QueryContext(ctx, `SELECT node_id, path, parent_path, name, is_directory, file_id, created_at
 		FROM file_nodes WHERE parent_path = ? ORDER BY name`, parentPath)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	var nodes []*FileNode
+	nodes := make([]*FileNode, 0)
 	for rows.Next() {
 		n, err := scanNode(rows)
 		if err != nil {
@@ -182,11 +204,18 @@ func (s *Store) ListNodes(parentPath string) ([]*FileNode, error) {
 		}
 		nodes = append(nodes, n)
 	}
-	return nodes, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out = nodes
+	return out, nil
 }
 
-func (s *Store) DeleteNode(path string) error {
-	res, err := s.db.Exec(`DELETE FROM file_nodes WHERE path = ?`, path)
+func (s *Store) DeleteNode(ctx context.Context, path string) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "delete_node", start, &err)
+
+	res, err := s.db.ExecContext(ctx, `DELETE FROM file_nodes WHERE path = ?`, path)
 	if err != nil {
 		return err
 	}
@@ -198,8 +227,11 @@ func (s *Store) DeleteNode(path string) error {
 }
 
 // DeleteEmptyDir atomically checks a directory is empty and deletes it.
-func (s *Store) DeleteEmptyDir(path string) error {
-	tx, err := s.db.Begin()
+func (s *Store) DeleteEmptyDir(ctx context.Context, path string) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "delete_empty_dir", start, &err)
+
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -220,20 +252,28 @@ func (s *Store) DeleteEmptyDir(path string) error {
 	if n == 0 {
 		return ErrNotFound
 	}
-	return tx.Commit()
+	err = tx.Commit()
+	return err
 }
 
-func (s *Store) DeleteNodesByPrefix(prefix string) (int64, error) {
-	res, err := s.db.Exec(`DELETE FROM file_nodes WHERE path = ? OR path LIKE ?`,
+func (s *Store) DeleteNodesByPrefix(ctx context.Context, prefix string) (n int64, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "delete_nodes_by_prefix", start, &err)
+
+	res, err := s.db.ExecContext(ctx, `DELETE FROM file_nodes WHERE path = ? OR path LIKE ?`,
 		prefix, prefix+"%")
 	if err != nil {
 		return 0, err
 	}
-	return res.RowsAffected()
+	n, err = res.RowsAffected()
+	return n, err
 }
 
-func (s *Store) UpdateNodePath(oldPath, newPath, newParentPath, newName string) error {
-	res, err := s.db.Exec(`UPDATE file_nodes SET path = ?, parent_path = ?, name = ?
+func (s *Store) UpdateNodePath(ctx context.Context, oldPath, newPath, newParentPath, newName string) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "update_node_path", start, &err)
+
+	res, err := s.db.ExecContext(ctx, `UPDATE file_nodes SET path = ?, parent_path = ?, name = ?
 		WHERE path = ?`, newPath, newParentPath, newName, oldPath)
 	if err != nil {
 		return err
@@ -245,8 +285,11 @@ func (s *Store) UpdateNodePath(oldPath, newPath, newParentPath, newName string) 
 	return nil
 }
 
-func (s *Store) RenameDir(oldPrefix, newPrefix string) (int64, error) {
-	tx, err := s.db.Begin()
+func (s *Store) RenameDir(ctx context.Context, oldPrefix, newPrefix string) (count int64, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "rename_dir", start, &err)
+
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -294,16 +337,22 @@ func (s *Store) RenameDir(oldPrefix, newPrefix string) (int64, error) {
 	if err := tx.Commit(); err != nil {
 		return 0, err
 	}
-	return int64(len(updates)), nil
+	count = int64(len(updates))
+	return count, nil
 }
 
-func (s *Store) RefCount(fileID string) (int64, error) {
-	var count int64
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE file_id = ?`, fileID).Scan(&count)
+func (s *Store) RefCount(ctx context.Context, fileID string) (count int64, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "ref_count", start, &err)
+
+	err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM file_nodes WHERE file_id = ?`, fileID).Scan(&count)
 	return count, err
 }
 
-func (s *Store) EnsureParentDirs(path string, genID func() string) error {
+func (s *Store) EnsureParentDirs(ctx context.Context, path string, genID func() string) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "ensure_parent_dirs", start, &err)
+
 	var ancestors []string
 	cur := path
 	for {
@@ -320,7 +369,7 @@ func (s *Store) EnsureParentDirs(path string, genID func() string) error {
 		dirPath := ancestors[i]
 		pp := parentPath(dirPath)
 		name := baseName(dirPath)
-		_, err := s.db.Exec(`INSERT INTO file_nodes
+		_, err := s.db.ExecContext(ctx, `INSERT INTO file_nodes
 			(node_id, path, parent_path, name, is_directory, created_at)
 			VALUES (?, ?, ?, ?, 1, ?)
 			ON DUPLICATE KEY UPDATE node_id = node_id`,
@@ -334,9 +383,12 @@ func (s *Store) EnsureParentDirs(path string, genID func() string) error {
 
 // --- files operations ---
 
-func (s *Store) InsertFile(f *File) error {
+func (s *Store) InsertFile(ctx context.Context, f *File) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "insert_file", start, &err)
+
 	if s.hasContentBlob {
-		_, err := s.db.Exec(`INSERT INTO files
+		_, err = s.db.ExecContext(ctx, `INSERT INTO files
 			(file_id, storage_type, storage_ref, content_blob, content_type, size_bytes, checksum_sha256,
 			 revision, status, source_id, content_text, created_at, confirmed_at, expires_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -346,7 +398,7 @@ func (s *Store) InsertFile(f *File) error {
 			f.CreatedAt.UTC(), nilTime(f.ConfirmedAt), nilTime(f.ExpiresAt))
 		return err
 	}
-	_, err := s.db.Exec(`INSERT INTO files
+	_, err = s.db.ExecContext(ctx, `INSERT INTO files
 		(file_id, storage_type, storage_ref, content_type, size_bytes, checksum_sha256,
 		 revision, status, source_id, content_text, created_at, confirmed_at, expires_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -357,28 +409,35 @@ func (s *Store) InsertFile(f *File) error {
 	return err
 }
 
-func (s *Store) GetFile(fileID string) (*File, error) {
+func (s *Store) GetFile(ctx context.Context, fileID string) (out *File, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "get_file", start, &err)
+
 	if s.hasContentBlob {
-		row := s.db.QueryRow(`SELECT file_id, storage_type, storage_ref, content_blob, content_type,
+		row := s.db.QueryRowContext(ctx, `SELECT file_id, storage_type, storage_ref, content_blob, content_type,
 			size_bytes, checksum_sha256, revision, status, source_id, content_text,
 			created_at, confirmed_at, expires_at
 			FROM files WHERE file_id = ?`, fileID)
-		return scanFileWithBlob(row)
+		out, err = scanFileWithBlob(row)
+		return out, err
 	}
-	row := s.db.QueryRow(`SELECT file_id, storage_type, storage_ref, content_type,
+	row := s.db.QueryRowContext(ctx, `SELECT file_id, storage_type, storage_ref, content_type,
 		size_bytes, checksum_sha256, revision, status, source_id, content_text,
 		created_at, confirmed_at, expires_at
 		FROM files WHERE file_id = ?`, fileID)
-	return scanFileNoBlob(row)
+	out, err = scanFileNoBlob(row)
+	return out, err
 }
 
-func (s *Store) UpdateFileContent(fileID string, storageType StorageType, storageRef, contentType, checksum, contentText string, contentBlob []byte, size int64) error {
+func (s *Store) UpdateFileContent(ctx context.Context, fileID string, storageType StorageType, storageRef, contentType, checksum, contentText string, contentBlob []byte, size int64) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "update_file_content", start, &err)
+
 	var (
 		res sql.Result
-		err error
 	)
 	if s.hasContentBlob {
-		res, err = s.db.Exec(`UPDATE files SET storage_type = ?, storage_ref = ?,
+		res, err = s.db.ExecContext(ctx, `UPDATE files SET storage_type = ?, storage_ref = ?,
 			content_blob = ?, content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
 			revision = revision + 1, status = 'CONFIRMED',
 			confirmed_at = ?
@@ -386,7 +445,7 @@ func (s *Store) UpdateFileContent(fileID string, storageType StorageType, storag
 			storageType, storageRef, nilBytes(contentBlob), nullStr(contentType), size,
 			nullStr(checksum), nullStr(contentText), time.Now().UTC(), fileID)
 	} else {
-		res, err = s.db.Exec(`UPDATE files SET storage_type = ?, storage_ref = ?,
+		res, err = s.db.ExecContext(ctx, `UPDATE files SET storage_type = ?, storage_ref = ?,
 			content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
 			revision = revision + 1, status = 'CONFIRMED',
 			confirmed_at = ?
@@ -404,8 +463,14 @@ func (s *Store) UpdateFileContent(fileID string, storageType StorageType, storag
 	return nil
 }
 
-func (s *Store) ConfirmFile(fileID string) error {
-	return s.ConfirmFileTx(s.db, fileID)
+func (s *Store) ConfirmFile(ctx context.Context, fileID string) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "confirm_file", start, &err)
+
+	_, err = s.db.ExecContext(ctx, `UPDATE files SET status = 'CONFIRMED',
+		confirmed_at = ?
+		WHERE file_id = ? AND status = 'PENDING'`, time.Now().UTC(), fileID)
+	return err
 }
 
 // execer abstracts *sql.DB and *sql.Tx for shared query execution.
@@ -467,30 +532,40 @@ func (s *Store) InsertNodeTx(db execer, n *FileNode) error {
 	return err
 }
 
-func (s *Store) MarkFileDeleted(fileID string) error {
-	_, err := s.db.Exec(`UPDATE files SET status = 'DELETED' WHERE file_id = ?`, fileID)
+func (s *Store) MarkFileDeleted(ctx context.Context, fileID string) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "mark_file_deleted", start, &err)
+
+	_, err = s.db.ExecContext(ctx, `UPDATE files SET status = 'DELETED' WHERE file_id = ?`, fileID)
 	return err
 }
 
 // --- composite operations ---
 
-func (s *Store) Stat(path string) (*NodeWithFile, error) {
-	node, err := s.GetNode(path)
+func (s *Store) Stat(ctx context.Context, path string) (out *NodeWithFile, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "stat", start, &err)
+
+	node, err := s.GetNode(ctx, path)
 	if err != nil {
 		return nil, err
 	}
 	nf := &NodeWithFile{Node: *node}
 	if !node.IsDirectory && node.FileID != "" {
-		f, err := s.GetFile(node.FileID)
+		f, err := s.GetFile(ctx, node.FileID)
 		if err != nil {
 			return nil, err
 		}
 		nf.File = f
 	}
-	return nf, nil
+	out = nf
+	return out, nil
 }
 
-func (s *Store) ListDir(parentPath string) ([]*NodeWithFile, error) {
+func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWithFile, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "list_dir", start, &err)
+
 	q := `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
 		f.file_id, f.storage_type, f.storage_ref, `
 	if s.hasContentBlob {
@@ -503,13 +578,13 @@ func (s *Store) ListDir(parentPath string) ([]*NodeWithFile, error) {
 		LEFT JOIN files f ON fn.file_id = f.file_id AND f.status = 'CONFIRMED'
 		WHERE fn.parent_path = ?
 		ORDER BY fn.name`
-	rows, err := s.db.Query(q, parentPath)
+	rows, err := s.db.QueryContext(ctx, q, parentPath)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 
-	var result []*NodeWithFile
+	result := make([]*NodeWithFile, 0)
 	for rows.Next() {
 		var nf *NodeWithFile
 		if s.hasContentBlob {
@@ -522,11 +597,18 @@ func (s *Store) ListDir(parentPath string) ([]*NodeWithFile, error) {
 		}
 		result = append(result, nf)
 	}
-	return result, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out = result
+	return out, nil
 }
 
-func (s *Store) DeleteFileWithRefCheck(path string) (*File, error) {
-	tx, err := s.db.Begin()
+func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *File, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "delete_file_with_ref_check", start, &err)
+
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -588,11 +670,15 @@ func (s *Store) DeleteFileWithRefCheck(path string) (*File, error) {
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	return f, nil
+	out = f
+	return out, nil
 }
 
-func (s *Store) DeleteDirRecursive(dirPath string) ([]*File, error) {
-	tx, err := s.db.Begin()
+func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*File, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "delete_dir_recursive", start, &err)
+
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -657,13 +743,17 @@ func (s *Store) DeleteDirRecursive(dirPath string) ([]*File, error) {
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	return orphaned, nil
+	out = orphaned
+	return out, nil
 }
 
 // --- uploads operations ---
 
-func (s *Store) InsertUpload(u *Upload) error {
-	_, err := s.db.Exec(`INSERT INTO uploads
+func (s *Store) InsertUpload(ctx context.Context, u *Upload) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "insert_upload", start, &err)
+
+	_, err = s.db.ExecContext(ctx, `INSERT INTO uploads
 		(upload_id, file_id, target_path, s3_upload_id, s3_key, total_size, part_size,
 		 parts_total, status, fingerprint_sha256, idempotency_key, created_at, updated_at, expires_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -677,39 +767,56 @@ func (s *Store) InsertUpload(u *Upload) error {
 	return err
 }
 
-func (s *Store) GetUpload(uploadID string) (*Upload, error) {
-	row := s.db.QueryRow(`SELECT upload_id, file_id, target_path, s3_upload_id, s3_key,
+func (s *Store) GetUpload(ctx context.Context, uploadID string) (out *Upload, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "get_upload", start, &err)
+
+	row := s.db.QueryRowContext(ctx, `SELECT upload_id, file_id, target_path, s3_upload_id, s3_key,
 		total_size, part_size, parts_total, status, fingerprint_sha256, idempotency_key,
 		created_at, updated_at, expires_at
 		FROM uploads WHERE upload_id = ?`, uploadID)
-	return scanUpload(row)
+	out, err = scanUpload(row)
+	return out, err
 }
 
-func (s *Store) GetUploadByPath(targetPath string) (*Upload, error) {
-	row := s.db.QueryRow(`SELECT upload_id, file_id, target_path, s3_upload_id, s3_key,
+func (s *Store) GetUploadByPath(ctx context.Context, targetPath string) (out *Upload, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "get_upload_by_path", start, &err)
+
+	row := s.db.QueryRowContext(ctx, `SELECT upload_id, file_id, target_path, s3_upload_id, s3_key,
 		total_size, part_size, parts_total, status, fingerprint_sha256, idempotency_key,
 		created_at, updated_at, expires_at
 		FROM uploads WHERE target_path = ? AND status = 'UPLOADING'
 		ORDER BY created_at DESC LIMIT 1`, targetPath)
-	return scanUpload(row)
+	out, err = scanUpload(row)
+	return out, err
 }
 
-func (s *Store) CompleteUpload(uploadID string) error {
-	_, err := s.db.Exec(`UPDATE uploads SET status = 'COMPLETED',
+func (s *Store) CompleteUpload(ctx context.Context, uploadID string) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "complete_upload", start, &err)
+
+	_, err = s.db.ExecContext(ctx, `UPDATE uploads SET status = 'COMPLETED',
 		updated_at = ?
 		WHERE upload_id = ? AND status = 'UPLOADING'`, time.Now().UTC(), uploadID)
 	return err
 }
 
-func (s *Store) AbortUpload(uploadID string) error {
-	_, err := s.db.Exec(`UPDATE uploads SET status = 'ABORTED',
+func (s *Store) AbortUpload(ctx context.Context, uploadID string) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "abort_upload", start, &err)
+
+	_, err = s.db.ExecContext(ctx, `UPDATE uploads SET status = 'ABORTED',
 		updated_at = ?
 		WHERE upload_id = ? AND status = 'UPLOADING'`, time.Now().UTC(), uploadID)
 	return err
 }
 
-func (s *Store) ListUploadsByPath(targetPath string, status UploadStatus) ([]*Upload, error) {
-	rows, err := s.db.Query(`SELECT upload_id, file_id, target_path, s3_upload_id, s3_key,
+func (s *Store) ListUploadsByPath(ctx context.Context, targetPath string, status UploadStatus) (out []*Upload, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "list_uploads_by_path", start, &err)
+
+	rows, err := s.db.QueryContext(ctx, `SELECT upload_id, file_id, target_path, s3_upload_id, s3_key,
 		total_size, part_size, parts_total, status, fingerprint_sha256, idempotency_key,
 		created_at, updated_at, expires_at
 		FROM uploads WHERE target_path = ? AND status = ?
@@ -718,7 +825,7 @@ func (s *Store) ListUploadsByPath(targetPath string, status UploadStatus) ([]*Up
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	var uploads []*Upload
+	uploads := make([]*Upload, 0)
 	for rows.Next() {
 		u, err := scanUpload(rows)
 		if err != nil {
@@ -726,7 +833,11 @@ func (s *Store) ListUploadsByPath(targetPath string, status UploadStatus) ([]*Up
 		}
 		uploads = append(uploads, u)
 	}
-	return uploads, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out = uploads
+	return out, nil
 }
 
 // --- scan helpers ---
@@ -1003,7 +1114,32 @@ func normalizeSQL(s string) string {
 	return wsNorm.ReplaceAllString(strings.TrimSpace(s), " ")
 }
 
-func (s *Store) ExecSQL(ctx context.Context, query string) ([]map[string]interface{}, error) {
+func observeStoreOp(ctx context.Context, op string, start time.Time, errp *error) {
+	result := "ok"
+	if errp != nil && *errp != nil {
+		switch {
+		case errors.Is(*errp, ErrNotFound):
+			result = "not_found"
+		case errors.Is(*errp, ErrPathConflict), errors.Is(*errp, ErrUploadConflict):
+			result = "conflict"
+		default:
+			result = "error"
+		}
+		logger.Error(ctx, "datastore_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
+	}
+	metrics.RecordOperation("datastore", op, result, time.Since(start))
+}
+
+func (s *Store) ExecSQL(ctx context.Context, query string) (out []map[string]interface{}, err error) {
+	start := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+		metrics.RecordOperation("datastore", "exec_sql", result, time.Since(start))
+	}()
+
 	q := strings.TrimSpace(query)
 	norm := strings.ToUpper(normalizeSQL(q))
 
@@ -1052,10 +1188,14 @@ func (s *Store) ExecSQL(ctx context.Context, query string) ([]map[string]interfa
 	}
 
 	if !isSelect && !isTagWrite {
-		return nil, fmt.Errorf("only SELECT queries and INSERT/UPDATE/DELETE on file_tags are allowed")
+		err = fmt.Errorf("only SELECT queries and INSERT/UPDATE/DELETE on file_tags are allowed")
+		logger.Warn(ctx, "datastore_exec_sql_rejected", zap.Int("query_len", len(q)), zap.Error(err))
+		return nil, err
 	}
 	if s == nil || s.db == nil {
-		return nil, fmt.Errorf("database is closed")
+		err = fmt.Errorf("database is closed")
+		logger.Error(ctx, "datastore_exec_sql_closed", zap.Error(err))
+		return nil, err
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -1064,6 +1204,7 @@ func (s *Store) ExecSQL(ctx context.Context, query string) ([]map[string]interfa
 	if isTagWrite {
 		res, err := s.db.ExecContext(ctx, q)
 		if err != nil {
+			logger.Error(ctx, "datastore_exec_sql_tag_write_failed", zap.Int("query_len", len(q)), zap.Error(err))
 			return nil, err
 		}
 		affected, _ := res.RowsAffected()
@@ -1072,6 +1213,7 @@ func (s *Store) ExecSQL(ctx context.Context, query string) ([]map[string]interfa
 
 	rows, err := s.db.QueryContext(ctx, q)
 	if err != nil {
+		logger.Error(ctx, "datastore_exec_sql_query_failed", zap.Int("query_len", len(q)), zap.Error(err))
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
@@ -1082,7 +1224,7 @@ func (s *Store) ExecSQL(ctx context.Context, query string) ([]map[string]interfa
 	}
 
 	const maxRows = 1000
-	var result []map[string]interface{}
+	result := make([]map[string]interface{}, 0)
 	for rows.Next() {
 		if len(result) >= maxRows {
 			break
@@ -1106,8 +1248,9 @@ func (s *Store) ExecSQL(ctx context.Context, query string) ([]map[string]interfa
 		}
 		result = append(result, row)
 	}
-	if result == nil {
-		result = []map[string]interface{}{}
+	if err := rows.Err(); err != nil {
+		logger.Error(ctx, "datastore_exec_sql_scan_failed", zap.Int("query_len", len(q)), zap.Error(err))
+		return nil, err
 	}
-	return result, rows.Err()
+	return result, nil
 }

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -34,10 +35,10 @@ func TestInsertAndGetNode(t *testing.T) {
 		NodeID: "n1", Path: "/data/file.txt", ParentPath: "/data/",
 		Name: "file.txt", FileID: "f1", CreatedAt: now,
 	}
-	if err := s.InsertNode(node); err != nil {
+	if err := s.InsertNode(context.Background(), node); err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.GetNode("/data/file.txt")
+	got, err := s.GetNode(context.Background(), "/data/file.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +49,7 @@ func TestInsertAndGetNode(t *testing.T) {
 
 func TestGetNodeNotFound(t *testing.T) {
 	s := newTestStore(t)
-	_, err := s.GetNode("/nonexistent")
+	_, err := s.GetNode(context.Background(), "/nonexistent")
 	if err != ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
@@ -63,10 +64,10 @@ func TestInsertAndGetFile(t *testing.T) {
 		Status: StatusConfirmed, ContentText: "hello world",
 		CreatedAt: now, ConfirmedAt: &now,
 	}
-	if err := s.InsertFile(f); err != nil {
+	if err := s.InsertFile(context.Background(), f); err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.GetFile("f1")
+	got, err := s.GetFile(context.Background(), "f1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,15 +79,15 @@ func TestInsertAndGetFile(t *testing.T) {
 func TestStat(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+	if err := s.InsertFile(context.Background(), &File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
 		SizeBytes: 42, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
 
-	nf, err := s.Stat("/a.txt")
+	nf, err := s.Stat(context.Background(), "/a.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,21 +99,21 @@ func TestStat(t *testing.T) {
 func TestListDir(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	if err := s.InsertNode(&FileNode{NodeID: "d1", Path: "/data/", ParentPath: "/", Name: "data", IsDirectory: true, CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "d1", Path: "/data/", ParentPath: "/", Name: "data", IsDirectory: true, CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+	if err := s.InsertFile(context.Background(), &File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
 		SizeBytes: 10, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/data/a.txt", ParentPath: "/data/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n1", Path: "/data/a.txt", ParentPath: "/data/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "d2", Path: "/data/sub/", ParentPath: "/data/", Name: "sub", IsDirectory: true, CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "d2", Path: "/data/sub/", ParentPath: "/data/", Name: "sub", IsDirectory: true, CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
 
-	entries, err := s.ListDir("/data/")
+	entries, err := s.ListDir(context.Background(), "/data/")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,18 +128,18 @@ func TestListDir(t *testing.T) {
 func TestZeroCopyCp(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageS3, StorageRef: "blobs/f1",
+	if err := s.InsertFile(context.Background(), &File{FileID: "f1", StorageType: StorageS3, StorageRef: "blobs/f1",
 		SizeBytes: 1000000, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/a.bin", ParentPath: "/", Name: "a.bin", FileID: "f1", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n1", Path: "/a.bin", ParentPath: "/", Name: "a.bin", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n2", Path: "/b.bin", ParentPath: "/", Name: "b.bin", FileID: "f1", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n2", Path: "/b.bin", ParentPath: "/", Name: "b.bin", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
 
-	count, err := s.RefCount("f1")
+	count, err := s.RefCount(context.Background(), "f1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,18 +151,18 @@ func TestZeroCopyCp(t *testing.T) {
 func TestDeleteWithRefCount(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+	if err := s.InsertFile(context.Background(), &File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
 		SizeBytes: 50, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n2", Path: "/b.txt", ParentPath: "/", Name: "b.txt", FileID: "f1", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n2", Path: "/b.txt", ParentPath: "/", Name: "b.txt", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
 
-	deleted, err := s.DeleteFileWithRefCheck("/a.txt")
+	deleted, err := s.DeleteFileWithRefCheck(context.Background(), "/a.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +170,7 @@ func TestDeleteWithRefCount(t *testing.T) {
 		t.Error("expected nil (file should survive, refcount > 0)")
 	}
 
-	deleted, err = s.DeleteFileWithRefCheck("/b.txt")
+	deleted, err = s.DeleteFileWithRefCheck(context.Background(), "/b.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,28 +182,28 @@ func TestDeleteWithRefCount(t *testing.T) {
 func TestDeleteDirRecursive(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	if err := s.InsertNode(&FileNode{NodeID: "d1", Path: "/data/", ParentPath: "/", Name: "data", IsDirectory: true, CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "d1", Path: "/data/", ParentPath: "/", Name: "data", IsDirectory: true, CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+	if err := s.InsertFile(context.Background(), &File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
 		SizeBytes: 10, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertFile(&File{FileID: "f2", StorageType: StorageDB9, StorageRef: "/blobs/f2",
+	if err := s.InsertFile(context.Background(), &File{FileID: "f2", StorageType: StorageDB9, StorageRef: "/blobs/f2",
 		SizeBytes: 20, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/data/a.txt", ParentPath: "/data/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n1", Path: "/data/a.txt", ParentPath: "/data/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n2", Path: "/data/b.txt", ParentPath: "/data/", Name: "b.txt", FileID: "f2", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n2", Path: "/data/b.txt", ParentPath: "/data/", Name: "b.txt", FileID: "f2", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n3", Path: "/shared.txt", ParentPath: "/", Name: "shared.txt", FileID: "f1", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n3", Path: "/shared.txt", ParentPath: "/", Name: "shared.txt", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
 
-	orphaned, err := s.DeleteDirRecursive("/data/")
+	orphaned, err := s.DeleteDirRecursive(context.Background(), "/data/")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,11 +211,11 @@ func TestDeleteDirRecursive(t *testing.T) {
 		t.Fatalf("expected 1 orphaned (f2), got %d", len(orphaned))
 	}
 
-	_, err = s.GetNode("/data/")
+	_, err = s.GetNode(context.Background(), "/data/")
 	if err != ErrNotFound {
 		t.Error("expected /data/ deleted")
 	}
-	_, err = s.GetNode("/shared.txt")
+	_, err = s.GetNode(context.Background(), "/shared.txt")
 	if err != nil {
 		t.Error("expected /shared.txt to survive")
 	}
@@ -222,11 +223,11 @@ func TestDeleteDirRecursive(t *testing.T) {
 
 func TestEnsureParentDirs(t *testing.T) {
 	s := newTestStore(t)
-	if err := s.EnsureParentDirs("/a/b/c/file.txt", genID); err != nil {
+	if err := s.EnsureParentDirs(context.Background(), "/a/b/c/file.txt", genID); err != nil {
 		t.Fatal(err)
 	}
 	for _, p := range []string{"/a/", "/a/b/", "/a/b/c/"} {
-		n, err := s.GetNode(p)
+		n, err := s.GetNode(context.Background(), p)
 		if err != nil {
 			t.Errorf("expected dir at %s: %v", p, err)
 			continue
@@ -236,7 +237,7 @@ func TestEnsureParentDirs(t *testing.T) {
 		}
 	}
 	// Idempotent
-	if err := s.EnsureParentDirs("/a/b/c/file.txt", genID); err != nil {
+	if err := s.EnsureParentDirs(context.Background(), "/a/b/c/file.txt", genID); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -244,17 +245,17 @@ func TestEnsureParentDirs(t *testing.T) {
 func TestRenameFile(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/old.txt", ParentPath: "/", Name: "old.txt", FileID: "f1", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n1", Path: "/old.txt", ParentPath: "/", Name: "old.txt", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := s.UpdateNodePath("/old.txt", "/new.txt", "/", "new.txt"); err != nil {
+	if err := s.UpdateNodePath(context.Background(), "/old.txt", "/new.txt", "/", "new.txt"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.GetNode("/old.txt"); err != ErrNotFound {
+	if _, err := s.GetNode(context.Background(), "/old.txt"); err != ErrNotFound {
 		t.Error("old path should be gone")
 	}
-	got, _ := s.GetNode("/new.txt")
+	got, _ := s.GetNode(context.Background(), "/new.txt")
 	if got.Name != "new.txt" || got.FileID != "f1" {
 		t.Errorf("unexpected: %+v", got)
 	}
@@ -263,31 +264,31 @@ func TestRenameFile(t *testing.T) {
 func TestRenameDir(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	if err := s.InsertNode(&FileNode{NodeID: "d1", Path: "/old/", ParentPath: "/", Name: "old", IsDirectory: true, CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "d1", Path: "/old/", ParentPath: "/", Name: "old", IsDirectory: true, CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n1", Path: "/old/a.txt", ParentPath: "/old/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n1", Path: "/old/a.txt", ParentPath: "/old/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "d2", Path: "/old/sub/", ParentPath: "/old/", Name: "sub", IsDirectory: true, CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "d2", Path: "/old/sub/", ParentPath: "/old/", Name: "sub", IsDirectory: true, CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.InsertNode(&FileNode{NodeID: "n2", Path: "/old/sub/b.txt", ParentPath: "/old/sub/", Name: "b.txt", FileID: "f2", CreatedAt: now}); err != nil {
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n2", Path: "/old/sub/b.txt", ParentPath: "/old/sub/", Name: "b.txt", FileID: "f2", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
 
-	count, err := s.RenameDir("/old/", "/new/")
+	count, err := s.RenameDir(context.Background(), "/old/", "/new/")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if count != 4 {
 		t.Errorf("expected 4 updated, got %d", count)
 	}
-	if _, err := s.GetNode("/old/"); err != ErrNotFound {
+	if _, err := s.GetNode(context.Background(), "/old/"); err != ErrNotFound {
 		t.Error("/old/ should be gone")
 	}
 	for _, p := range []string{"/new/", "/new/a.txt", "/new/sub/", "/new/sub/b.txt"} {
-		if _, err := s.GetNode(p); err != nil {
+		if _, err := s.GetNode(context.Background(), p); err != nil {
 			t.Errorf("expected %s: %v", p, err)
 		}
 	}
@@ -296,15 +297,15 @@ func TestRenameDir(t *testing.T) {
 func TestUpdateFileContent(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
-	if err := s.InsertFile(&File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+	if err := s.InsertFile(context.Background(), &File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
 		SizeBytes: 10, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := s.UpdateFileContent("f1", StorageDB9, "/blobs/f1-v2", "text/plain", "abc123", "new content", []byte("blob"), 42); err != nil {
+	if err := s.UpdateFileContent(context.Background(), "f1", StorageDB9, "/blobs/f1-v2", "text/plain", "abc123", "new content", []byte("blob"), 42); err != nil {
 		t.Fatal(err)
 	}
-	got, _ := s.GetFile("f1")
+	got, _ := s.GetFile(context.Background(), "f1")
 	if got.Revision != 2 || got.SizeBytes != 42 || got.ContentText != "new content" {
 		t.Errorf("unexpected: %+v", got)
 	}

--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+func NewServerLogger() (*zap.Logger, error) {
+	return zap.NewProduction()
+}
+
+func NewCLILogger() (*zap.Logger, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home: %w", err)
+	}
+	logDir := filepath.Join(home, ".dat", "log")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create log dir: %w", err)
+	}
+	logPath := filepath.Join(logDir, "dat9-cli.log")
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open log file: %w", err)
+	}
+	_ = f.Close()
+
+	rotate := &lumberjack.Logger{
+		Filename:   logPath,
+		MaxSize:    envInt("DAT9_CLI_LOG_MAX_SIZE_MB", 10),
+		MaxBackups: envInt("DAT9_CLI_LOG_MAX_BACKUPS", 5),
+		MaxAge:     envInt("DAT9_CLI_LOG_MAX_AGE_DAYS", 14),
+		Compress:   true,
+	}
+
+	encoderCfg := zap.NewProductionEncoderConfig()
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(encoderCfg),
+		zapcore.AddSync(rotate),
+		zap.InfoLevel,
+	)
+	return zap.New(core), nil
+}
+
+func envInt(key string, fallback int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return fallback
+	}
+	return v
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,65 @@
+package logger
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/mem9-ai/dat9/pkg/traceid"
+	"go.uber.org/zap"
+)
+
+type contextKeyType int
+
+const contextKey contextKeyType = iota
+
+var global atomic.Pointer[zap.Logger]
+
+func init() {
+	l, _ := zap.NewProduction()
+	global.Store(l)
+	zap.ReplaceGlobals(l)
+}
+
+func Set(l *zap.Logger) {
+	if l == nil {
+		return
+	}
+	global.Store(l)
+	zap.ReplaceGlobals(l)
+}
+
+func L() *zap.Logger {
+	if l := global.Load(); l != nil {
+		return l
+	}
+	return zap.L()
+}
+
+func WithContext(ctx context.Context, l *zap.Logger) context.Context {
+	if l == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, contextKey, l)
+}
+
+func FromContext(ctx context.Context) *zap.Logger {
+	if l, _ := ctx.Value(contextKey).(*zap.Logger); l != nil {
+		return l
+	}
+	if traceID := traceid.FromContext(ctx); traceID != "" {
+		return L().With(zap.String("trace_id", traceID))
+	}
+	return L()
+}
+
+func Info(ctx context.Context, msg string, fields ...zap.Field) {
+	FromContext(ctx).Info(msg, fields...)
+}
+
+func Warn(ctx context.Context, msg string, fields ...zap.Field) {
+	FromContext(ctx).Warn(msg, fields...)
+}
+
+func Error(ctx context.Context, msg string, fields ...zap.Field) {
+	FromContext(ctx).Error(msg, fields...)
+}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2,6 +2,7 @@
 package meta
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -9,6 +10,9 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
+	"go.uber.org/zap"
 )
 
 var (
@@ -144,8 +148,10 @@ func (s *Store) migrate() error {
 	return nil
 }
 
-func (s *Store) InsertTenant(t *Tenant) error {
-	_, err := s.db.Exec(`INSERT INTO tenants
+func (s *Store) InsertTenant(ctx context.Context, t *Tenant) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "insert_tenant", start, &err)
+	_, err = s.db.ExecContext(ctx, `INSERT INTO tenants
 		(id, status, db_host, db_port, db_user, db_password, db_name, db_tls,
 		 provider, cluster_id, claim_url, claim_expires_at, schema_version, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -157,8 +163,10 @@ func (s *Store) InsertTenant(t *Tenant) error {
 	return err
 }
 
-func (s *Store) InsertAPIKey(k *APIKey) error {
-	_, err := s.db.Exec(`INSERT INTO tenant_api_keys
+func (s *Store) InsertAPIKey(ctx context.Context, k *APIKey) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "insert_api_key", start, &err)
+	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_api_keys
 		(id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, issued_at, revoked_at, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		k.ID, k.TenantID, k.KeyName, k.JWTCiphertext, k.JWTHash, k.TokenVersion, k.Status,
@@ -169,8 +177,10 @@ func (s *Store) InsertAPIKey(k *APIKey) error {
 	return err
 }
 
-func (s *Store) ResolveByAPIKeyHash(hash string) (*TenantWithAPIKey, error) {
-	row := s.db.QueryRow(`SELECT
+func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *TenantWithAPIKey, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "resolve_api_key_hash", start, &err)
+	row := s.db.QueryRowContext(ctx, `SELECT
 			t.id, t.status, t.db_host, t.db_port, t.db_user, t.db_password, t.db_name, t.db_tls,
 			t.provider, t.cluster_id, t.claim_url, t.claim_expires_at, t.schema_version, t.created_at, t.updated_at,
 			k.id, k.tenant_id, k.key_name, k.jwt_ciphertext, k.jwt_hash, k.token_version, k.status, k.issued_at,
@@ -179,79 +189,87 @@ func (s *Store) ResolveByAPIKeyHash(hash string) (*TenantWithAPIKey, error) {
 		JOIN tenants t ON t.id = k.tenant_id
 		WHERE k.jwt_hash = ?`, hash)
 
-	var out TenantWithAPIKey
+	var rec TenantWithAPIKey
 	var dbTLS int
 	var claimURL sql.NullString
 	var claimExp sql.NullTime
 	var clusterID sql.NullString
 	var revokedAt sql.NullTime
-	if err := row.Scan(
-		&out.Tenant.ID, &out.Tenant.Status, &out.Tenant.DBHost, &out.Tenant.DBPort, &out.Tenant.DBUser,
-		&out.Tenant.DBPasswordCipher, &out.Tenant.DBName, &dbTLS, &out.Tenant.Provider, &clusterID,
-		&claimURL, &claimExp, &out.Tenant.SchemaVersion, &out.Tenant.CreatedAt, &out.Tenant.UpdatedAt,
-		&out.APIKey.ID, &out.APIKey.TenantID, &out.APIKey.KeyName, &out.APIKey.JWTCiphertext,
-		&out.APIKey.JWTHash, &out.APIKey.TokenVersion, &out.APIKey.Status, &out.APIKey.IssuedAt,
-		&revokedAt, &out.APIKey.CreatedAt, &out.APIKey.UpdatedAt,
+	if err = row.Scan(
+		&rec.Tenant.ID, &rec.Tenant.Status, &rec.Tenant.DBHost, &rec.Tenant.DBPort, &rec.Tenant.DBUser,
+		&rec.Tenant.DBPasswordCipher, &rec.Tenant.DBName, &dbTLS, &rec.Tenant.Provider, &clusterID,
+		&claimURL, &claimExp, &rec.Tenant.SchemaVersion, &rec.Tenant.CreatedAt, &rec.Tenant.UpdatedAt,
+		&rec.APIKey.ID, &rec.APIKey.TenantID, &rec.APIKey.KeyName, &rec.APIKey.JWTCiphertext,
+		&rec.APIKey.JWTHash, &rec.APIKey.TokenVersion, &rec.APIKey.Status, &rec.APIKey.IssuedAt,
+		&revokedAt, &rec.APIKey.CreatedAt, &rec.APIKey.UpdatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrNotFound
+			err = ErrNotFound
+			return nil, err
 		}
 		return nil, err
 	}
-	out.Tenant.DBTLS = dbTLS == 1
+	rec.Tenant.DBTLS = dbTLS == 1
 	if clusterID.Valid {
-		out.Tenant.ClusterID = clusterID.String
+		rec.Tenant.ClusterID = clusterID.String
 	}
 	if claimURL.Valid {
-		out.Tenant.ClaimURL = claimURL.String
+		rec.Tenant.ClaimURL = claimURL.String
 	}
 	if claimExp.Valid {
 		t := claimExp.Time.UTC()
-		out.Tenant.ClaimExpiresAt = &t
+		rec.Tenant.ClaimExpiresAt = &t
 	}
 	if revokedAt.Valid {
 		t := revokedAt.Time.UTC()
-		out.APIKey.RevokedAt = &t
+		rec.APIKey.RevokedAt = &t
 	}
-	return &out, nil
+	out = &rec
+	return out, nil
 }
 
-func (s *Store) GetTenant(id string) (*Tenant, error) {
-	row := s.db.QueryRow(`SELECT id, status, db_host, db_port, db_user, db_password, db_name,
+func (s *Store) GetTenant(ctx context.Context, id string) (out *Tenant, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "get_tenant", start, &err)
+	row := s.db.QueryRowContext(ctx, `SELECT id, status, db_host, db_port, db_user, db_password, db_name,
 		db_tls, provider, cluster_id, claim_url, claim_expires_at, schema_version, created_at, updated_at
 		FROM tenants WHERE id = ?`, id)
-	var out Tenant
 	var dbTLS int
 	var clusterID sql.NullString
 	var claimURL sql.NullString
 	var claimExp sql.NullTime
-	if err := row.Scan(&out.ID, &out.Status, &out.DBHost, &out.DBPort, &out.DBUser, &out.DBPasswordCipher,
-		&out.DBName, &dbTLS, &out.Provider, &clusterID, &claimURL, &claimExp, &out.SchemaVersion,
-		&out.CreatedAt, &out.UpdatedAt); err != nil {
+	var rec Tenant
+	if err = row.Scan(&rec.ID, &rec.Status, &rec.DBHost, &rec.DBPort, &rec.DBUser, &rec.DBPasswordCipher,
+		&rec.DBName, &dbTLS, &rec.Provider, &clusterID, &claimURL, &claimExp, &rec.SchemaVersion,
+		&rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrNotFound
+			err = ErrNotFound
+			return nil, err
 		}
 		return nil, err
 	}
-	out.DBTLS = dbTLS == 1
+	rec.DBTLS = dbTLS == 1
 	if clusterID.Valid {
-		out.ClusterID = clusterID.String
+		rec.ClusterID = clusterID.String
 	}
 	if claimURL.Valid {
-		out.ClaimURL = claimURL.String
+		rec.ClaimURL = claimURL.String
 	}
 	if claimExp.Valid {
 		t := claimExp.Time.UTC()
-		out.ClaimExpiresAt = &t
+		rec.ClaimExpiresAt = &t
 	}
-	return &out, nil
+	out = &rec
+	return out, nil
 }
 
-func (s *Store) ListTenantsByStatus(status TenantStatus, limit int) ([]Tenant, error) {
+func (s *Store) ListTenantsByStatus(ctx context.Context, status TenantStatus, limit int) (out []Tenant, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_tenants_by_status", start, &err)
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := s.db.Query(`SELECT id, status, db_host, db_port, db_user, db_password, db_name,
+	rows, err := s.db.QueryContext(ctx, `SELECT id, status, db_host, db_port, db_user, db_password, db_name,
 		db_tls, provider, cluster_id, claim_url, claim_expires_at, schema_version, created_at, updated_at
 		FROM tenants WHERE status = ? ORDER BY created_at ASC LIMIT ?`, status, limit)
 	if err != nil {
@@ -259,7 +277,7 @@ func (s *Store) ListTenantsByStatus(status TenantStatus, limit int) ([]Tenant, e
 	}
 	defer func() { _ = rows.Close() }()
 
-	out := make([]Tenant, 0)
+	out = make([]Tenant, 0)
 	for rows.Next() {
 		var t Tenant
 		var dbTLS int
@@ -290,8 +308,10 @@ func (s *Store) ListTenantsByStatus(status TenantStatus, limit int) ([]Tenant, e
 	return out, nil
 }
 
-func (s *Store) UpdateTenantStatus(id string, status TenantStatus) error {
-	res, err := s.db.Exec(`UPDATE tenants SET status = ?, updated_at = ? WHERE id = ?`, status, time.Now().UTC(), id)
+func (s *Store) UpdateTenantStatus(ctx context.Context, id string, status TenantStatus) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_tenant_status", start, &err)
+	res, err := s.db.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ? WHERE id = ?`, status, time.Now().UTC(), id)
 	if err != nil {
 		return err
 	}
@@ -300,6 +320,22 @@ func (s *Store) UpdateTenantStatus(id string, status TenantStatus) error {
 		return ErrNotFound
 	}
 	return nil
+}
+
+func observeMeta(ctx context.Context, op string, start time.Time, errp *error) {
+	result := "ok"
+	if errp != nil && *errp != nil {
+		switch {
+		case errors.Is(*errp, ErrNotFound):
+			result = "not_found"
+		case errors.Is(*errp, ErrDuplicate):
+			result = "duplicate"
+		default:
+			result = "error"
+		}
+		logger.Error(ctx, "meta_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
+	}
+	metrics.RecordOperation("meta", op, result, time.Since(start))
 }
 
 func boolToInt(v bool) int {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -34,7 +35,7 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 		CreatedAt:        now,
 		UpdatedAt:        now,
 	}
-	if err := s.InsertTenant(tenant); err != nil {
+	if err := s.InsertTenant(context.Background(), tenant); err != nil {
 		t.Fatal(err)
 	}
 	key := &APIKey{
@@ -49,11 +50,11 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
-	if err := s.InsertAPIKey(key); err != nil {
+	if err := s.InsertAPIKey(context.Background(), key); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := s.ResolveByAPIKeyHash("hash1")
+	got, err := s.ResolveByAPIKeyHash(context.Background(), "hash1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +72,7 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 func TestUpdateTenantStatus(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC()
-	if err := s.InsertTenant(&Tenant{
+	if err := s.InsertTenant(context.Background(), &Tenant{
 		ID:               "t2",
 		Status:           TenantProvisioning,
 		DBHost:           "127.0.0.1",
@@ -87,7 +88,7 @@ func TestUpdateTenantStatus(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.UpdateTenantStatus("t2", TenantSuspended); err != nil {
+	if err := s.UpdateTenantStatus(context.Background(), "t2", TenantSuspended); err != nil {
 		t.Fatal(err)
 	}
 
@@ -112,7 +113,7 @@ func TestListTenantsByStatus(t *testing.T) {
 		{id: "tp2", status: TenantProvisioning},
 		{id: "ta1", status: TenantActive},
 	} {
-		if err := s.InsertTenant(&Tenant{
+		if err := s.InsertTenant(context.Background(), &Tenant{
 			ID:               tc.id,
 			Status:           tc.status,
 			DBHost:           "127.0.0.1",
@@ -130,7 +131,7 @@ func TestListTenantsByStatus(t *testing.T) {
 		}
 	}
 
-	got, err := s.ListTenantsByStatus(TenantProvisioning, 10)
+	got, err := s.ListTenantsByStatus(context.Background(), TenantProvisioning, 10)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -1,0 +1,96 @@
+// Package metrics provides process-wide service operation metrics.
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type opMetrics struct {
+	mu            sync.RWMutex
+	counts        map[string]int64
+	durationCount map[string]int64
+	durationSum   map[string]float64
+}
+
+var globalOps = &opMetrics{
+	counts:        map[string]int64{},
+	durationCount: map[string]int64{},
+	durationSum:   map[string]float64{},
+}
+
+func RecordOperation(component, operation, result string, d time.Duration) {
+	key := labels(component, operation, result)
+	globalOps.mu.Lock()
+	globalOps.counts[key]++
+	globalOps.durationCount[key]++
+	globalOps.durationSum[key] += d.Seconds()
+	globalOps.mu.Unlock()
+}
+
+func WritePrometheus(w http.ResponseWriter) {
+	globalOps.mu.RLock()
+	countKeys := sorted(globalOps.counts)
+	counts := cloneInt(globalOps.counts)
+	durationCount := cloneInt(globalOps.durationCount)
+	durationSum := cloneFloat(globalOps.durationSum)
+	globalOps.mu.RUnlock()
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operations_total Service operations by component/operation/result")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_operations_total counter")
+	for _, k := range countKeys {
+		_, _ = fmt.Fprintf(w, "dat9_service_operations_total{%s} %d\n", k, counts[k])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operation_duration_seconds_count Service operation duration count")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_operation_duration_seconds_count counter")
+	for _, k := range countKeys {
+		_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_count{%s} %d\n", k, durationCount[k])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operation_duration_seconds_sum Service operation duration sum in seconds")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_operation_duration_seconds_sum counter")
+	for _, k := range countKeys {
+		_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_sum{%s} %.6f\n", k, durationSum[k])
+	}
+}
+
+func labels(component, operation, result string) string {
+	return "component=\"" + esc(component) + "\",operation=\"" + esc(operation) + "\",result=\"" + esc(result) + "\""
+}
+
+func esc(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, `"`, `\\"`)
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	return s
+}
+
+func sorted[T any](m map[string]T) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+func cloneInt(m map[string]int64) map[string]int64 {
+	out := make(map[string]int64, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneFloat(m map[string]float64) map[string]float64 {
+	out := make(map[string]float64, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/s3client/handler.go
+++ b/pkg/s3client/handler.go
@@ -1,7 +1,6 @@
 package s3client
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -39,7 +38,7 @@ func (c *LocalS3Client) handleUploadPart(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	etag, err := c.UploadPart(context.Background(), uploadID, partNumber, r.Body)
+	etag, err := c.UploadPart(r.Context(), uploadID, partNumber, r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -57,7 +56,7 @@ func (c *LocalS3Client) handleGetObject(w http.ResponseWriter, r *http.Request) 
 	}
 
 	key := strings.TrimPrefix(r.URL.Path, "/objects/")
-	rc, err := c.GetObject(context.Background(), key)
+	rc, err := c.GetObject(r.Context(), key)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
+	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
 )
@@ -36,46 +37,64 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tok := bearerToken(r)
 		if tok == "" {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_missing_token")...)
+			metricEvent(r.Context(), "auth", "result", "missing_token")
 			errJSON(w, http.StatusUnauthorized, "missing or malformed Authorization header")
 			return
 		}
 
-		resolved, err := metaStore.ResolveByAPIKeyHash(tenant.HashToken(tok))
+		resolved, err := metaStore.ResolveByAPIKeyHash(r.Context(), tenant.HashToken(tok))
 		if err != nil {
 			if errors.Is(err, meta.ErrNotFound) {
+				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_key_not_found")...)
+				metricEvent(r.Context(), "auth", "result", "key_not_found")
 				errJSON(w, http.StatusUnauthorized, "invalid API key")
 				return
 			}
+			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_backend_unavailable", "error", err)...)
+			metricEvent(r.Context(), "auth", "result", "meta_backend_error")
 			errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
 			return
 		}
 
 		if subtle.ConstantTimeCompare([]byte(tenant.HashToken(tok)), []byte(resolved.APIKey.JWTHash)) != 1 {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_hash_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)...)
+			metricEvent(r.Context(), "auth", "result", "hash_mismatch")
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
 
 		if resolved.APIKey.Status != meta.APIKeyActive {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_key_inactive", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "status", resolved.APIKey.Status)...)
+			metricEvent(r.Context(), "auth", "result", "key_inactive")
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
 
 		plain, err := poolDecryptToken(pool, resolved.APIKey.JWTCiphertext)
 		if err != nil {
+			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_decrypt_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
+			metricEvent(r.Context(), "auth", "result", "decrypt_failed")
 			errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
 			return
 		}
 		if subtle.ConstantTimeCompare([]byte(tok), plain) != 1 {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_token_cipher_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)...)
+			metricEvent(r.Context(), "auth", "result", "cipher_mismatch")
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
 
 		claims, err := tenant.ParseAndVerifyToken(tokenSecret, tok)
 		if err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_token_invalid", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
+			metricEvent(r.Context(), "auth", "result", "token_invalid")
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
 		if claims.TenantID != resolved.Tenant.ID || claims.TokenVersion != resolved.APIKey.TokenVersion {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_claims_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "claim_tenant", claims.TenantID, "claim_version", claims.TokenVersion)...)
+			metricEvent(r.Context(), "auth", "result", "claims_mismatch")
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
@@ -83,25 +102,36 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 		switch resolved.Tenant.Status {
 		case meta.TenantActive:
 		case meta.TenantProvisioning:
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_provisioning", "tenant_id", resolved.Tenant.ID)...)
+			metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantProvisioning))
 			errJSON(w, http.StatusServiceUnavailable, "tenant is provisioning")
 			return
 		case meta.TenantFailed:
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_failed", "tenant_id", resolved.Tenant.ID)...)
+			metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantFailed))
 			errJSON(w, http.StatusServiceUnavailable, "tenant provisioning failed")
 			return
 		case meta.TenantSuspended, meta.TenantDeleted:
 			pool.Invalidate(resolved.Tenant.ID)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_blocked", "tenant_id", resolved.Tenant.ID, "status", resolved.Tenant.Status)...)
+			metricEvent(r.Context(), "tenant_status", "status", string(resolved.Tenant.Status))
 			errJSON(w, http.StatusForbidden, "tenant is suspended")
 			return
 		default:
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_unavailable", "tenant_id", resolved.Tenant.ID, "status", resolved.Tenant.Status)...)
+			metricEvent(r.Context(), "tenant_status", "status", string(resolved.Tenant.Status))
 			errJSON(w, http.StatusForbidden, "tenant is unavailable")
 			return
 		}
 
-		b, err := pool.Get(&resolved.Tenant)
+		b, err := pool.Get(r.Context(), &resolved.Tenant)
 		if err != nil {
+			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "backend_load_failed", "tenant_id", resolved.Tenant.ID, "error", err)...)
+			metricEvent(r.Context(), "tenant_backend", "result", "load_failed")
 			errJSON(w, http.StatusInternalServerError, "backend unavailable")
 			return
 		}
+		metricEvent(r.Context(), "auth", "result", "ok")
 
 		scope := &TenantScope{TenantID: resolved.Tenant.ID, APIKeyID: resolved.APIKey.ID, TokenVersion: resolved.APIKey.TokenVersion, Backend: b}
 		next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -71,7 +71,7 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			return
 		}
 
-		plain, err := poolDecryptToken(pool, resolved.APIKey.JWTCiphertext)
+		plain, err := poolDecryptToken(r.Context(), pool, resolved.APIKey.JWTCiphertext)
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_decrypt_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 			metricEvent(r.Context(), "auth", "result", "decrypt_failed")
@@ -138,10 +138,10 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 	})
 }
 
-func poolDecryptToken(pool *tenant.Pool, cipher []byte) ([]byte, error) {
+func poolDecryptToken(ctx context.Context, pool *tenant.Pool, cipher []byte) ([]byte, error) {
 	// Decrypt is tenant-independent and uses pool encryptor shared for API key storage.
 	// Keep this helper to avoid exposing raw encryptor in handlers.
-	return pool.Decrypt(cipher)
+	return pool.Decrypt(ctx, cipher)
 }
 
 func bearerToken(r *http.Request) string {

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -76,7 +77,7 @@ func newAuthServer(t *testing.T) (*Server, string, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := metaStore.InsertTenant(&meta.Tenant{
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
 		ID:               tenantID,
 		Status:           meta.TenantActive,
 		DBHost:           host,
@@ -92,7 +93,7 @@ func newAuthServer(t *testing.T) (*Server, string, func()) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := metaStore.InsertAPIKey(&meta.APIKey{
+	if err := metaStore.InsertAPIKey(context.Background(), &meta.APIKey{
 		ID:            tenant.NewID(),
 		TenantID:      tenantID,
 		KeyName:       "default",

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -65,7 +65,7 @@ func newAuthServer(t *testing.T) (*Server, string, func()) {
 	tenantID := tenant.NewID()
 	tenantDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true", parsed.User, parsed.Passwd, host, port, parsed.DBName)
 	initServerTenantSchema(t, tenantDSN)
-	passCipher, err := pool.Encrypt([]byte(parsed.Passwd))
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func newAuthServer(t *testing.T) (*Server, string, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tokCipher, err := pool.Encrypt([]byte(tok))
+	tokCipher, err := pool.Encrypt(context.Background(), []byte(tok))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -1,0 +1,307 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
+	"github.com/mem9-ai/dat9/pkg/traceid"
+	"go.uber.org/zap"
+)
+
+type metricsKeyType int
+
+const metricsKey metricsKeyType = iota
+
+func eventFields(ctx context.Context, event string, kv ...any) []zap.Field {
+	fields := make([]zap.Field, 0, len(kv)/2+3)
+	fields = append(fields, zap.String("event", event))
+	if scope := ScopeFromContext(ctx); scope != nil {
+		if scope.TenantID != "" {
+			fields = append(fields, zap.String("tenant_id", scope.TenantID))
+		}
+		if scope.APIKeyID != "" {
+			fields = append(fields, zap.String("api_key_id", scope.APIKeyID))
+		}
+	}
+	for i := 0; i+1 < len(kv); i += 2 {
+		key := strings.ReplaceAll(fmt.Sprint(kv[i]), " ", "_")
+		if key == "" {
+			continue
+		}
+		fields = append(fields, zap.Any(key, kv[i+1]))
+	}
+	return fields
+}
+
+func withMetrics(ctx context.Context, m *serverMetrics) context.Context {
+	return context.WithValue(ctx, metricsKey, m)
+}
+
+func metricsFromContext(ctx context.Context) *serverMetrics {
+	v, _ := ctx.Value(metricsKey).(*serverMetrics)
+	return v
+}
+
+func metricEvent(ctx context.Context, event string, labels ...string) {
+	m := metricsFromContext(ctx)
+	if m == nil {
+		return
+	}
+	m.recordEvent(event, labels...)
+}
+
+type serverMetrics struct {
+	inFlight atomic.Int64
+
+	mu             sync.RWMutex
+	requests       map[string]int64
+	durationCount  map[string]int64
+	durationSecond map[string]float64
+	events         map[string]int64
+}
+
+func newServerMetrics() *serverMetrics {
+	return &serverMetrics{
+		requests:       make(map[string]int64),
+		durationCount:  make(map[string]int64),
+		durationSecond: make(map[string]float64),
+		events:         make(map[string]int64),
+	}
+}
+
+func (m *serverMetrics) record(method, route string, status int, d time.Duration) {
+	statusKey := metricLabels(method, route, strconv.Itoa(status))
+	durationKey := metricLabels(method, route)
+
+	m.mu.Lock()
+	m.requests[statusKey]++
+	m.durationCount[durationKey]++
+	m.durationSecond[durationKey] += d.Seconds()
+	m.mu.Unlock()
+}
+
+func (m *serverMetrics) recordEvent(event string, labels ...string) {
+	key := metricEventLabels(event, labels...)
+	m.mu.Lock()
+	m.events[key]++
+	m.mu.Unlock()
+}
+
+func (m *serverMetrics) writePrometheus(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_http_inflight_requests Current in-flight HTTP requests")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_inflight_requests gauge")
+	_, _ = fmt.Fprintf(w, "dat9_http_inflight_requests %d\n", m.inFlight.Load())
+
+	m.mu.RLock()
+	requestKeys := sortedKeys(m.requests)
+	durationKeys := sortedKeys(m.durationCount)
+	eventKeys := sortedKeys(m.events)
+	requests := cloneIntMap(m.requests)
+	durationCount := cloneIntMap(m.durationCount)
+	durationSecond := cloneFloatMap(m.durationSecond)
+	events := cloneIntMap(m.events)
+	m.mu.RUnlock()
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_http_requests_total Total HTTP requests by method/route/status")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_requests_total counter")
+	for _, k := range requestKeys {
+		_, _ = fmt.Fprintf(w, "dat9_http_requests_total{%s} %d\n", k, requests[k])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_http_request_duration_seconds_count HTTP request duration count by method/route")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_request_duration_seconds_count counter")
+	for _, k := range durationKeys {
+		_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_count{%s} %d\n", k, durationCount[k])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_http_request_duration_seconds_sum HTTP request duration sum in seconds by method/route")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_request_duration_seconds_sum counter")
+	for _, k := range durationKeys {
+		_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_sum{%s} %.6f\n", k, durationSecond[k])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_tenant_events_total Tenant/business lifecycle events")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_tenant_events_total counter")
+	for _, k := range eventKeys {
+		_, _ = fmt.Fprintf(w, "dat9_tenant_events_total{%s} %d\n", k, events[k])
+	}
+}
+
+func cloneIntMap(src map[string]int64) map[string]int64 {
+	out := make(map[string]int64, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneFloatMap(src map[string]float64) map[string]float64 {
+	out := make(map[string]float64, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func sortedKeys[T any](m map[string]T) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func metricLabels(method, route string, status ...string) string {
+	b := strings.Builder{}
+	b.WriteString(`method="`)
+	b.WriteString(escapePromLabel(method))
+	b.WriteString(`",route="`)
+	b.WriteString(escapePromLabel(route))
+	b.WriteString(`"`)
+	if len(status) > 0 {
+		b.WriteString(`,status="`)
+		b.WriteString(escapePromLabel(status[0]))
+		b.WriteString(`"`)
+	}
+	return b.String()
+}
+
+func metricEventLabels(event string, labels ...string) string {
+	b := strings.Builder{}
+	b.WriteString(`event="`)
+	b.WriteString(escapePromLabel(event))
+	b.WriteString(`"`)
+	for i := 0; i+1 < len(labels); i += 2 {
+		b.WriteString(",")
+		b.WriteString(escapePromLabel(labels[i]))
+		b.WriteString(`="`)
+		b.WriteString(escapePromLabel(labels[i+1]))
+		b.WriteString(`"`)
+	}
+	return b.String()
+}
+
+func escapePromLabel(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	return s
+}
+
+type observedResponseWriter struct {
+	http.ResponseWriter
+	status int
+	size   int
+}
+
+func (w *observedResponseWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *observedResponseWriter) Write(p []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	n, err := w.ResponseWriter.Write(p)
+	w.size += n
+	return n, err
+}
+
+func requestRoute(path string) string {
+	switch {
+	case path == "/metrics":
+		return "/metrics"
+	case path == "/v1/provision":
+		return "/v1/provision"
+	case path == "/v1/status":
+		return "/v1/status"
+	case path == "/v1/sql":
+		return "/v1/sql"
+	case strings.HasPrefix(path, "/v1/fs/"):
+		return "/v1/fs/*"
+	case path == "/v1/uploads":
+		return "/v1/uploads"
+	case strings.HasPrefix(path, "/v1/uploads/"):
+		return "/v1/uploads/*"
+	case strings.HasPrefix(path, "/s3/"):
+		return "/s3/*"
+	default:
+		return "other"
+	}
+}
+
+func generateTraceID() string { return traceid.Generate() }
+
+func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Request) {
+	traceID := strings.TrimSpace(r.Header.Get("X-Trace-ID"))
+	if traceID == "" {
+		traceID = generateTraceID()
+	}
+
+	r = r.WithContext(traceid.With(r.Context(), traceID))
+	r = r.WithContext(logger.WithContext(r.Context(), s.logger.With(zap.String("trace_id", traceID))))
+	r = r.WithContext(withMetrics(r.Context(), s.metrics))
+	w.Header().Set("X-Trace-ID", traceID)
+
+	start := time.Now()
+	ow := &observedResponseWriter{ResponseWriter: w}
+	s.metrics.inFlight.Add(1)
+	defer s.metrics.inFlight.Add(-1)
+
+	next.ServeHTTP(ow, r)
+	if ow.status == 0 {
+		ow.status = http.StatusOK
+	}
+
+	dur := time.Since(start)
+	route := requestRoute(r.URL.Path)
+	s.metrics.record(r.Method, route, ow.status, dur)
+
+	tenantID := ""
+	apiKeyID := ""
+	if scope := ScopeFromContext(r.Context()); scope != nil {
+		tenantID = scope.TenantID
+		apiKeyID = scope.APIKeyID
+	}
+
+	fields := []zap.Field{
+		zap.String("trace_id", traceID),
+		zap.String("method", r.Method),
+		zap.String("path", r.URL.Path),
+		zap.String("route", route),
+		zap.Int("status", ow.status),
+		zap.Int("bytes", ow.size),
+		zap.Float64("duration_ms", dur.Seconds()*1000),
+		zap.String("remote", r.RemoteAddr),
+		zap.String("user_agent", r.UserAgent()),
+	}
+	if tenantID != "" {
+		fields = append(fields, zap.String("tenant_id", tenantID))
+	}
+	if apiKeyID != "" {
+		fields = append(fields, zap.String("api_key_id", apiKeyID))
+	}
+	logger.Info(r.Context(), "http_request", fields...)
+}
+
+func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	s.metrics.writePrometheus(w)
+	metrics.WritePrometheus(w)
+}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -276,7 +276,7 @@ func TestStartupResumesProvisioningTenantInit(t *testing.T) {
 		}
 	}
 
-	passCipher, err := pool.Encrypt([]byte(parsed.Passwd))
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -113,7 +113,7 @@ func TestProvisionMarksTenantFailedWhenInitKeepsFailing(t *testing.T) {
 	if apiKey == "" {
 		t.Fatal("empty api_key")
 	}
-	resolved, err := metaStore.ResolveByAPIKeyHash(tenant.HashToken(apiKey))
+	resolved, err := metaStore.ResolveByAPIKeyHash(context.Background(), tenant.HashToken(apiKey))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +213,7 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	if out["api_key"] == "" {
 		t.Fatalf("unexpected provision response: %+v", out)
 	}
-	resolved, err := metaStore.ResolveByAPIKeyHash(tenant.HashToken(out["api_key"]))
+	resolved, err := metaStore.ResolveByAPIKeyHash(context.Background(), tenant.HashToken(out["api_key"]))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +282,7 @@ func TestStartupResumesProvisioningTenantInit(t *testing.T) {
 	}
 	tenantID := tenant.NewID()
 	now := time.Now().UTC()
-	if err := metaStore.InsertTenant(&meta.Tenant{
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
 		ID:               tenantID,
 		Status:           meta.TenantProvisioning,
 		DBHost:           host,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -17,9 +16,12 @@ import (
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/traceid"
+	"go.uber.org/zap"
 )
 
 type Config struct {
@@ -31,6 +33,7 @@ type Config struct {
 	LocalS3        *s3client.LocalS3Client
 	S3Dir          string
 	MaxUploadBytes int64
+	Logger         *zap.Logger
 }
 
 type Server struct {
@@ -40,6 +43,8 @@ type Server struct {
 	provisioner    tenant.Provisioner
 	tokenSecret    []byte
 	maxUploadBytes int64
+	metrics        *serverMetrics
+	logger         *zap.Logger
 	mux            *http.ServeMux
 }
 
@@ -60,6 +65,10 @@ func NewWithConfig(cfg Config) *Server {
 	if maxUpload <= 0 {
 		maxUpload = defaultMaxUploadBytes
 	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger, _ = zap.NewProduction()
+	}
 	s := &Server{
 		fallback:       cfg.Backend,
 		meta:           cfg.Meta,
@@ -67,6 +76,8 @@ func NewWithConfig(cfg Config) *Server {
 		tokenSecret:    cfg.TokenSecret,
 		provisioner:    cfg.Provisioner,
 		maxUploadBytes: maxUpload,
+		metrics:        newServerMetrics(),
+		logger:         logger,
 	}
 	mux := http.NewServeMux()
 
@@ -82,6 +93,7 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v1/sql", business)
 	mux.HandleFunc("/v1/status", s.handleTenantStatus)
 	mux.HandleFunc("/v1/provision", s.handleProvision)
+	mux.HandleFunc("/metrics", s.handleMetrics)
 
 	local := cfg.LocalS3
 	if local == nil && cfg.Backend != nil {
@@ -99,7 +111,7 @@ func NewWithConfig(cfg Config) *Server {
 				http.Error(w, "not found", http.StatusNotFound)
 				return
 			}
-			b := cfg.Pool.LoadS3Backend(cfg.Meta, tenantID)
+			b := cfg.Pool.LoadS3Backend(r.Context(), cfg.Meta, tenantID)
 			if b == nil || b.S3() == nil {
 				http.Error(w, "not found", http.StatusNotFound)
 				return
@@ -122,9 +134,10 @@ func NewWithConfig(cfg Config) *Server {
 }
 
 func (s *Server) resumeProvisioningTenants() {
-	tenants, err := s.meta.ListTenantsByStatus(meta.TenantProvisioning, 1000)
+	ctx := backgroundWithTrace(context.Background())
+	tenants, err := s.meta.ListTenantsByStatus(ctx, meta.TenantProvisioning, 1000)
 	if err != nil {
-		log.Printf("list provisioning tenants failed: %v", err)
+		logger.Error(ctx, "resume_provisioning_list_failed", zap.Error(err))
 		return
 	}
 	for i := range tenants {
@@ -134,13 +147,22 @@ func (s *Server) resumeProvisioningTenants() {
 }
 
 func (s *Server) resumeTenantSchemaInit(t meta.Tenant) {
+	ctx := backgroundWithTrace(context.Background())
 	plain, err := s.pool.Decrypt(t.DBPasswordCipher)
 	if err != nil {
-		log.Printf("resume tenant schema init skipped: decrypt db password failed (tenant=%s): %v", t.ID, err)
+		logger.Warn(ctx, "resume_schema_init_skipped", zap.String("tenant_id", t.ID), zap.Error(err))
 		return
 	}
 	dsn := tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS)
-	s.initTenantSchemaAsync(t.ID, dsn, t.Provider, s.provisioner.InitSchema)
+	s.initTenantSchemaAsync(ctx, t.ID, dsn, t.Provider, s.provisioner.InitSchema)
+}
+
+func backgroundWithTrace(ctx context.Context) context.Context {
+	traceID := traceid.FromContext(ctx)
+	if traceID == "" {
+		traceID = traceid.Generate()
+	}
+	return traceid.With(context.Background(), traceID)
 }
 
 func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled bool) string {
@@ -159,11 +181,11 @@ func injectFallbackBackend(b *backend.Dat9Backend, next http.Handler) http.Handl
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.mux.ServeHTTP(w, r)
+	s.observe(s.mux, w, r)
 }
 
 func (s *Server) ListenAndServe(addr string) error {
-	log.Printf("dat9 server listening on %s", addr)
+	logger.Info(backgroundWithTrace(context.Background()), "server_start", zap.String("addr", addr), zap.Int64("max_upload_bytes", s.maxUploadBytes))
 	return http.ListenAndServe(addr, s)
 }
 
@@ -178,61 +200,74 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 	case r.URL.Path == "/v1/sql":
 		s.handleSQL(w, r)
 	default:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "business_route_not_found", "path", r.URL.Path, "method", r.Method)...)
 		errJSON(w, http.StatusNotFound, "not found")
 	}
 }
 
 func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_method_not_allowed", "method", r.Method)...)
 		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 	if s.meta == nil || s.pool == nil || len(s.tokenSecret) == 0 {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_not_enabled")...)
 		errJSON(w, http.StatusNotFound, "tenant status not enabled")
 		return
 	}
 	tok := bearerToken(r)
 	if tok == "" {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_missing_token")...)
 		errJSON(w, http.StatusUnauthorized, "missing or malformed Authorization header")
 		return
 	}
 
-	resolved, err := s.meta.ResolveByAPIKeyHash(tenant.HashToken(tok))
+	resolved, err := s.meta.ResolveByAPIKeyHash(r.Context(), tenant.HashToken(tok))
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_key_not_found")...)
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_meta_unavailable", "error", err)...)
 		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
 		return
 	}
 	if subtle.ConstantTimeCompare([]byte(tenant.HashToken(tok)), []byte(resolved.APIKey.JWTHash)) != 1 {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_hash_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
 	if resolved.APIKey.Status != meta.APIKeyActive {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_key_inactive", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "status", resolved.APIKey.Status)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
 	plain, err := poolDecryptToken(s.pool, resolved.APIKey.JWTCiphertext)
 	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_decrypt_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
 		return
 	}
 	if subtle.ConstantTimeCompare([]byte(tok), plain) != 1 {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_token_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
 	claims, err := tenant.ParseAndVerifyToken(s.tokenSecret, tok)
 	if err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_token_invalid", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
 	if claims.TenantID != resolved.Tenant.ID || claims.TokenVersion != resolved.APIKey.TokenVersion {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_claims_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "claim_tenant", claims.TenantID, "claim_version", claims.TokenVersion)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
 
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_ok", "tenant_id", resolved.Tenant.ID, "status", resolved.Tenant.Status)...)
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": string(resolved.Tenant.Status)})
 }
 
@@ -275,9 +310,11 @@ func (s *Server) handleFS(w http.ResponseWriter, r *http.Request) {
 		} else if r.URL.Query().Has("mkdir") {
 			s.handleMkdir(w, r, path)
 		} else {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "fs_unknown_post_action", "path", path)...)
 			errJSON(w, http.StatusBadRequest, "unknown POST action")
 		}
 	default:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "fs_method_not_allowed", "path", path, "method", r.Method)...)
 		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
 }
@@ -285,26 +322,36 @@ func (s *Server) handleFS(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "read_missing_scope", "path", path)...)
+		metricEvent(r.Context(), "fs_read", "result", "error")
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	if b.S3() != nil {
 		url, err := b.PresignGetObject(r.Context(), path)
 		if err == nil {
+			logger.Info(r.Context(), "server_event", eventFields(r.Context(), "read_presigned_redirect", "path", path)...)
+			metricEvent(r.Context(), "fs_read", "result", "ok")
 			http.Redirect(w, r, url, http.StatusFound)
 			return
 		}
 	}
 
-	data, err := b.Read(path, 0, -1)
+	data, err := b.ReadCtx(r.Context(), path, 0, -1)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "read_not_found", "path", path)...)
+			metricEvent(r.Context(), "fs_read", "result", "error")
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "read_failed", "path", path, "error", err)...)
+		metricEvent(r.Context(), "fs_read", "result", "error")
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "read_ok", "path", path, "bytes", len(data))...)
+	metricEvent(r.Context(), "fs_read", "result", "ok")
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
 	_, _ = w.Write(data)
@@ -313,18 +360,24 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "list_missing_scope", "path", path)...)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
-	entries, err := b.ReadDir(path)
+	entries, err := b.ReadDirCtx(r.Context(), path)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "list_not_found", "path", path)...)
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "list_failed", "path", path, "error", err)...)
+		metricEvent(r.Context(), "userdb_query", "api", "list", "result", "error")
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	metricEvent(r.Context(), "userdb_query", "api", "list", "result", "ok")
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "list_ok", "path", path, "entries", len(entries))...)
 	type entry struct {
 		Name  string `json:"name"`
 		Size  int64  `json:"size"`
@@ -341,6 +394,8 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_missing_scope", "path", path)...)
+		metricEvent(r.Context(), "fs_write", "result", "error")
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
@@ -349,42 +404,60 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 	if h := r.Header.Get("X-Dat9-Content-Length"); h != "" {
 		parsed, err := strconv.ParseInt(h, 10, 64)
 		if err != nil || parsed < 0 {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_invalid_declared_length", "path", path, "header", h)...)
+			metricEvent(r.Context(), "fs_write", "result", "error")
 			errJSON(w, http.StatusBadRequest, "invalid X-Dat9-Content-Length")
 			return
 		}
 		if actualCL > 0 && parsed > 0 && actualCL != parsed {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_length_mismatch", "path", path, "content_length", actualCL, "declared_length", parsed)...)
+			metricEvent(r.Context(), "fs_write", "result", "error")
 			errJSON(w, http.StatusBadRequest, "Content-Length and X-Dat9-Content-Length mismatch")
 			return
 		}
 		cl = parsed
 	}
 	if cl > s.maxUploadBytes {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_too_large", "path", path, "bytes", cl, "max", s.maxUploadBytes)...)
+		metricEvent(r.Context(), "fs_write", "result", "error")
 		errJSON(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("upload too large: max %d bytes", s.maxUploadBytes))
 		return
 	}
 	if cl > 0 && b.IsLargeFile(cl) {
 		partChecksums, err := parsePartChecksumsHeader(r.Header.Get("X-Dat9-Part-Checksums"))
 		if err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_bad_checksums_header", "path", path, "error", err)...)
+			metricEvent(r.Context(), "fs_write", "result", "error")
 			errJSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		if len(partChecksums) == 0 {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_missing_checksums_header", "path", path)...)
+			metricEvent(r.Context(), "fs_write", "result", "error")
 			errJSON(w, http.StatusBadRequest, "missing X-Dat9-Part-Checksums header")
 			return
 		}
 		plan, err := b.InitiateUploadWithChecksums(r.Context(), path, cl, partChecksums)
 		if err != nil {
 			if errors.Is(err, backend.ErrPartChecksumCountMismatch) {
+				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_checksum_count_mismatch", "path", path, "error", err)...)
+				metricEvent(r.Context(), "fs_write", "result", "error")
 				errJSON(w, http.StatusBadRequest, err.Error())
 				return
 			}
 			if errors.Is(err, datastore.ErrUploadConflict) {
+				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_upload_conflict", "path", path, "error", err)...)
+				metricEvent(r.Context(), "fs_write", "result", "conflict")
 				errJSON(w, http.StatusConflict, err.Error())
 				return
 			}
+			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "write_upload_initiate_failed", "path", path, "error", err)...)
+			metricEvent(r.Context(), "fs_write", "result", "error")
 			errJSON(w, http.StatusInternalServerError, err.Error())
 			return
 		}
+		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "write_upload_initiated", "path", path, "parts", len(plan.Parts))...)
+		metricEvent(r.Context(), "fs_write", "result", "accepted")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(plan)
@@ -395,32 +468,43 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 	if err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_body_too_large", "path", path, "max", s.maxUploadBytes)...)
+			metricEvent(r.Context(), "fs_write", "result", "error")
 			errJSON(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("upload too large: max %d bytes", s.maxUploadBytes))
 			return
 		}
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_body_read_failed", "path", path, "error", err)...)
+		metricEvent(r.Context(), "fs_write", "result", "error")
 		errJSON(w, http.StatusBadRequest, "read body: "+err.Error())
 		return
 	}
-	_, err = b.Write(path, data, 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate)
+	_, err = b.WriteCtx(r.Context(), path, data, 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate)
 	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "write_failed", "path", path, "error", err)...)
+		metricEvent(r.Context(), "fs_write", "result", "error")
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "write_ok", "path", path, "bytes", len(data))...)
+	metricEvent(r.Context(), "fs_write", "result", "ok")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "stat_missing_scope", "path", path)...)
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
-	nf, err := b.Store().Stat(path)
+	nf, err := b.Store().Stat(r.Context(), path)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "stat_not_found", "path", path)...)
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "stat_failed", "path", path, "error", err)...)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -433,102 +517,123 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 	if nf.File != nil {
 		w.Header().Set("X-Dat9-Revision", strconv.FormatInt(nf.File.Revision, 10))
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "stat_ok", "path", path, "is_dir", nf.Node.IsDirectory)...)
 	w.WriteHeader(http.StatusOK)
 }
 
 func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "delete_missing_scope", "path", path)...)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	recursive := r.URL.Query().Has("recursive")
 	var err error
 	if recursive {
-		err = b.RemoveAll(path)
+		err = b.RemoveAllCtx(r.Context(), path)
 	} else {
-		err = b.Remove(path)
+		err = b.RemoveCtx(r.Context(), path)
 	}
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "delete_not_found", "path", path, "recursive", recursive)...)
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "delete_failed", "path", path, "recursive", recursive, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "delete_ok", "path", path, "recursive", recursive)...)
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "copy_missing_scope", "dst_path", dstPath)...)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	srcPath := r.Header.Get("X-Dat9-Copy-Source")
 	if srcPath == "" {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "copy_missing_source_header", "dst_path", dstPath)...)
 		errJSON(w, http.StatusBadRequest, "missing X-Dat9-Copy-Source header")
 		return
 	}
-	if err := b.CopyFile(srcPath, dstPath); err != nil {
+	if err := b.CopyFileCtx(r.Context(), srcPath, dstPath); err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "copy_not_found", "src_path", srcPath, "dst_path", dstPath)...)
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "copy_failed", "src_path", srcPath, "dst_path", dstPath, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "copy_ok", "src_path", srcPath, "dst_path", dstPath)...)
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "rename_missing_scope", "new_path", newPath)...)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	oldPath := r.Header.Get("X-Dat9-Rename-Source")
 	if oldPath == "" {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "rename_missing_source_header", "new_path", newPath)...)
 		errJSON(w, http.StatusBadRequest, "missing X-Dat9-Rename-Source header")
 		return
 	}
-	if err := b.Rename(oldPath, newPath); err != nil {
+	if err := b.RenameCtx(r.Context(), oldPath, newPath); err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "rename_not_found", "old_path", oldPath, "new_path", newPath)...)
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "rename_failed", "old_path", oldPath, "new_path", newPath, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "rename_ok", "old_path", oldPath, "new_path", newPath)...)
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "mkdir_missing_scope", "path", path)...)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
-	if err := b.Mkdir(path, 0o755); err != nil {
+	if err := b.MkdirCtx(r.Context(), path, 0o755); err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "mkdir_failed", "path", path, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "mkdir_ok", "path", path)...)
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleUploads(w http.ResponseWriter, r *http.Request) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "uploads_missing_scope")...)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	if r.Method != http.MethodGet {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "uploads_method_not_allowed", "method", r.Method)...)
 		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 	path := r.URL.Query().Get("path")
 	if path == "" {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "uploads_missing_path")...)
 		errJSON(w, http.StatusBadRequest, "missing path parameter")
 		return
 	}
@@ -536,11 +641,15 @@ func (s *Server) handleUploads(w http.ResponseWriter, r *http.Request) {
 	if status == "" {
 		status = string(datastore.UploadUploading)
 	}
-	uploads, err := b.ListUploads(path, datastore.UploadStatus(status))
+	uploads, err := b.ListUploads(r.Context(), path, datastore.UploadStatus(status))
 	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "uploads_list_failed", "path", path, "status", status, "error", err)...)
+		metricEvent(r.Context(), "metadb_query", "api", "uploads_list", "result", "error")
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	metricEvent(r.Context(), "metadb_query", "api", "uploads_list", "result", "ok")
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "uploads_list_ok", "path", path, "status", status, "count", len(uploads))...)
 	type uploadEntry struct {
 		UploadID   string `json:"upload_id"`
 		Path       string `json:"path"`
@@ -574,6 +683,7 @@ func (s *Server) handleUploadAction(w http.ResponseWriter, r *http.Request) {
 		action = strings.Trim(parts[1], "/")
 	}
 	if uploadID == "" {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_action_missing_upload_id", "path", r.URL.Path)...)
 		errJSON(w, http.StatusBadRequest, "missing upload ID")
 		return
 	}
@@ -585,6 +695,7 @@ func (s *Server) handleUploadAction(w http.ResponseWriter, r *http.Request) {
 	case r.Method == http.MethodDelete && action == "":
 		s.handleUploadAbort(w, r, uploadID)
 	default:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_action_unknown", "upload_id", uploadID, "action", action, "method", r.Method)...)
 		errJSON(w, http.StatusBadRequest, "unknown upload action")
 	}
 }
@@ -592,60 +703,88 @@ func (s *Server) handleUploadAction(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, uploadID string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_missing_scope", "upload_id", uploadID)...)
+		metricEvent(r.Context(), "upload_complete", "result", "error")
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	if err := b.ConfirmUpload(r.Context(), uploadID); err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_not_found", "upload_id", uploadID)...)
+			metricEvent(r.Context(), "upload_complete", "result", "error")
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
 		if errors.Is(err, datastore.ErrUploadNotActive) || errors.Is(err, datastore.ErrPathConflict) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_conflict", "upload_id", uploadID, "error", err)...)
+			metricEvent(r.Context(), "upload_complete", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_failed", "upload_id", uploadID, "error", err)...)
+		metricEvent(r.Context(), "upload_complete", "result", "error")
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_ok", "upload_id", uploadID)...)
+	metricEvent(r.Context(), "upload_complete", "result", "ok")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uploadID string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_missing_scope", "upload_id", uploadID)...)
+		metricEvent(r.Context(), "upload_resume", "result", "error")
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	partChecksums, err := parsePartChecksumsHeader(r.Header.Get("X-Dat9-Part-Checksums"))
 	if err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_bad_checksums", "upload_id", uploadID, "error", err)...)
+		metricEvent(r.Context(), "upload_resume", "result", "error")
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if len(partChecksums) == 0 {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_missing_checksums", "upload_id", uploadID)...)
+		metricEvent(r.Context(), "upload_resume", "result", "error")
 		errJSON(w, http.StatusBadRequest, "missing X-Dat9-Part-Checksums header")
 		return
 	}
 	plan, err := b.ResumeUploadWithChecksums(r.Context(), uploadID, partChecksums)
 	if err != nil {
 		if errors.Is(err, backend.ErrPartChecksumCountMismatch) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_checksum_count_mismatch", "upload_id", uploadID, "error", err)...)
+			metricEvent(r.Context(), "upload_resume", "result", "error")
 			errJSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_not_found", "upload_id", uploadID)...)
+			metricEvent(r.Context(), "upload_resume", "result", "error")
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
 		if errors.Is(err, datastore.ErrUploadExpired) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_expired", "upload_id", uploadID)...)
+			metricEvent(r.Context(), "upload_resume", "result", "error")
 			errJSON(w, http.StatusGone, err.Error())
 			return
 		}
 		if errors.Is(err, datastore.ErrUploadNotActive) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_not_active", "upload_id", uploadID)...)
+			metricEvent(r.Context(), "upload_resume", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_failed", "upload_id", uploadID, "error", err)...)
+		metricEvent(r.Context(), "upload_resume", "result", "error")
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_ok", "upload_id", uploadID, "parts", len(plan.Parts))...)
+	metricEvent(r.Context(), "upload_resume", "result", "ok")
 	_ = json.NewEncoder(w).Encode(plan)
 }
 
@@ -676,44 +815,63 @@ func parsePartChecksumsHeader(raw string) ([]string, error) {
 func (s *Server) handleUploadAbort(w http.ResponseWriter, r *http.Request, uploadID string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_abort_missing_scope", "upload_id", uploadID)...)
+		metricEvent(r.Context(), "upload_abort", "result", "error")
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	if err := b.AbortUpload(r.Context(), uploadID); err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_abort_not_found", "upload_id", uploadID)...)
+			metricEvent(r.Context(), "upload_abort", "result", "error")
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_abort_failed", "upload_id", uploadID, "error", err)...)
+		metricEvent(r.Context(), "upload_abort", "result", "error")
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_abort_ok", "upload_id", uploadID)...)
+	metricEvent(r.Context(), "upload_abort", "result", "ok")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_method_not_allowed", "method", r.Method)...)
+		metricEvent(r.Context(), "tenant_provision", "result", "error")
 		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 	if s.meta == nil || s.pool == nil || len(s.tokenSecret) == 0 {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_not_enabled")...)
+		metricEvent(r.Context(), "tenant_provision", "result", "error")
 		errJSON(w, http.StatusNotFound, "provisioning not enabled")
 		return
 	}
 	if s.provisioner == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provisioner_not_configured")...)
+		metricEvent(r.Context(), "tenant_provision", "result", "error")
 		errJSON(w, http.StatusNotFound, "provisioner not configured")
 		return
 	}
 	provider := s.provisioner.ProviderType()
 	provider, err := tenant.NormalizeProvider(provider)
 	if err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_provider_invalid", "provider", provider, "error", err)...)
+		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	tenantID := tenant.NewID()
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_requested", "tenant_id", tenantID, "provider", provider)...)
 	keyName := "default"
 
 	token, err := tenant.IssueToken(s.tokenSecret, tenantID, 1)
 	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_issue_token_failed", "tenant_id", tenantID, "error", err)...)
+		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
 		errJSON(w, http.StatusInternalServerError, "failed to issue token")
 		return
 	}
@@ -721,6 +879,8 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	cluster, err := s.provisioner.Provision(r.Context(), tenantID)
 	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "cluster_error")
 		errJSON(w, http.StatusBadGateway, fmt.Sprintf("provision tenant cluster failed: %v", err))
 		return
 	}
@@ -728,16 +888,20 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 
 	cipherPass, err := s.pool.Encrypt([]byte(cluster.Password))
 	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_encrypt_db_password_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
 		errJSON(w, http.StatusInternalServerError, "failed to encrypt db password")
 		return
 	}
 	cipherToken, err := s.pool.Encrypt([]byte(token))
 	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_encrypt_api_key_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
 		errJSON(w, http.StatusInternalServerError, "failed to encrypt api key")
 		return
 	}
 
-	if err := s.meta.InsertTenant(&meta.Tenant{
+	if err := s.meta.InsertTenant(r.Context(), &meta.Tenant{
 		ID:               tenantID,
 		Status:           meta.TenantProvisioning,
 		DBHost:           cluster.Host,
@@ -754,11 +918,15 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		CreatedAt:        now,
 		UpdatedAt:        now,
 	}); err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_insert_tenant_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
+		metricEvent(r.Context(), "metadb_query", "api", "insert_tenant", "result", "error")
 		errJSON(w, http.StatusInternalServerError, "failed to persist tenant")
 		return
 	}
+	metricEvent(r.Context(), "metadb_query", "api", "insert_tenant", "result", "ok")
 	apiKeyID := tenant.NewID()
-	if err := s.meta.InsertAPIKey(&meta.APIKey{
+	if err := s.meta.InsertAPIKey(r.Context(), &meta.APIKey{
 		ID:            apiKeyID,
 		TenantID:      tenantID,
 		KeyName:       keyName,
@@ -770,14 +938,20 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}); err != nil {
-		_ = s.meta.UpdateTenantStatus(tenantID, meta.TenantDeleted)
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_insert_api_key_failed", "tenant_id", tenantID, "api_key_id", apiKeyID, "error", err)...)
+		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
+		metricEvent(r.Context(), "metadb_query", "api", "insert_api_key", "result", "error")
+		_ = s.meta.UpdateTenantStatus(r.Context(), tenantID, meta.TenantDeleted)
 		errJSON(w, http.StatusInternalServerError, "failed to persist api key")
 		return
 	}
+	metricEvent(r.Context(), "metadb_query", "api", "insert_api_key", "result", "ok")
 
 	// Initialize tenant schema asynchronously; tenant remains in provisioning state until success.
 	dsn := tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true)
-	go s.initTenantSchemaAsync(tenantID, dsn, provider, s.provisioner.InitSchema)
+	go s.initTenantSchemaAsync(backgroundWithTrace(r.Context()), tenantID, dsn, provider, s.provisioner.InitSchema)
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_accepted", "tenant_id", tenantID, "provider", provider)...)
+	metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "accepted")
 
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]string{
@@ -786,26 +960,42 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *Server) initTenantSchemaAsync(tenantID, tenantDSN, provider string, schemaInit func(context.Context, string) error) {
+func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN, provider string, schemaInit func(context.Context, string) error) {
+	ctx = backgroundWithTrace(ctx)
+	logger.Info(ctx, "server_event", eventFields(ctx, "schema_init_started", "tenant_id", tenantID, "provider", provider)...)
 	deadline := time.Now().Add(schemaInitRetryWindow)
 	backoff := schemaInitInitialBackoff
 	attempt := 1
 	for {
-		if err := schemaInit(context.Background(), tenantDSN); err == nil {
-			if err := s.meta.UpdateTenantStatus(tenantID, meta.TenantActive); err != nil {
-				log.Printf("activate tenant %s failed after schema init: %v", tenantID, err)
+		if err := schemaInit(ctx, tenantDSN); err == nil {
+			logger.Info(ctx, "server_event", eventFields(ctx, "schema_init_ok", "tenant_id", tenantID, "provider", provider, "attempt", attempt)...)
+			if s.metrics != nil {
+				s.metrics.recordEvent("tenant_schema_init", "provider", provider, "result", "ok")
+			}
+			if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantActive); err != nil {
+				logger.Error(ctx, "schema_init_activate_failed", zap.String("tenant_id", tenantID), zap.Error(err))
 			}
 			return
 		} else {
+			logger.Error(ctx, "server_event", eventFields(ctx, "schema_init_failed", "tenant_id", tenantID, "provider", provider, "attempt", attempt, "error", err)...)
+			if s.metrics != nil {
+				s.metrics.recordEvent("tenant_schema_init", "provider", provider, "result", "error")
+			}
 			remaining := time.Until(deadline)
 			if remaining <= 0 {
-				if uerr := s.meta.UpdateTenantStatus(tenantID, meta.TenantFailed); uerr != nil {
-					log.Printf("mark tenant %s failed after init retries exhausted: update status failed: %v", tenantID, uerr)
+				if uerr := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantFailed); uerr != nil {
+					logger.Error(ctx, "schema_init_mark_failed_update_error", zap.String("tenant_id", tenantID), zap.Error(uerr))
 				}
-				log.Printf("tenant %s marked failed after schema init retries exhausted: %v", tenantID, err)
+				logger.Error(ctx, "schema_init_retry_exhausted", zap.String("tenant_id", tenantID), zap.Error(err))
 				return
 			}
-			log.Printf("init tenant schema failed (tenant=%s provider=%s attempt=%d remaining=%s): %v", tenantID, provider, attempt, remaining.Round(time.Second), err)
+			logger.Warn(ctx, "schema_init_attempt_failed",
+				zap.String("tenant_id", tenantID),
+				zap.String("provider", provider),
+				zap.Int("attempt", attempt),
+				zap.String("remaining", remaining.Round(time.Second).String()),
+				zap.Error(err),
+			)
 		}
 		sleepFor := backoff
 		if sleepFor > schemaInitMaxBackoff {
@@ -830,12 +1020,14 @@ func errJSON(w http.ResponseWriter, code int, msg string) {
 
 func (s *Server) handleSQL(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "sql_method_not_allowed", "method", r.Method)...)
 		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "sql_missing_scope")...)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
@@ -844,19 +1036,25 @@ func (s *Server) handleSQL(w http.ResponseWriter, r *http.Request) {
 		Query string `json:"query"`
 	}
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "sql_bad_json", "error", err)...)
 		errJSON(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
 	if req.Query == "" {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "sql_empty_query")...)
 		errJSON(w, http.StatusBadRequest, "empty query")
 		return
 	}
 
 	rows, err := b.ExecSQL(r.Context(), req.Query)
 	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "sql_exec_failed", "query_len", len(req.Query), "error", err)...)
+		metricEvent(r.Context(), "userdb_query", "api", "sql", "result", "error")
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	metricEvent(r.Context(), "userdb_query", "api", "sql", "result", "ok")
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "sql_exec_ok", "query_len", len(req.Query), "rows", len(rows))...)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(rows)
@@ -865,11 +1063,13 @@ func (s *Server) handleSQL(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "grep_missing_scope", "path", path)...)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	query := r.URL.Query().Get("grep")
 	if query == "" {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "grep_empty_query", "path", path)...)
 		errJSON(w, http.StatusBadRequest, "empty grep query")
 		return
 	}
@@ -877,6 +1077,7 @@ func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string)
 	if v := r.URL.Query().Get("limit"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "grep_invalid_limit", "path", path, "limit", v)...)
 			errJSON(w, http.StatusBadRequest, "invalid limit: "+v)
 			return
 		}
@@ -884,9 +1085,13 @@ func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string)
 	}
 	results, err := b.Grep(r.Context(), query, path, limit)
 	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "grep_failed", "path", path, "query_len", len(query), "limit", limit, "error", err)...)
+		metricEvent(r.Context(), "userdb_query", "api", "grep", "result", "error")
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	metricEvent(r.Context(), "userdb_query", "api", "grep", "result", "ok")
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "grep_ok", "path", path, "query_len", len(query), "limit", limit, "results", len(results))...)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(results)
 }
@@ -894,6 +1099,7 @@ func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string)
 func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string) {
 	b := backendFromRequest(r)
 	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "find_missing_scope", "path", path)...)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
@@ -908,6 +1114,7 @@ func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string)
 	if v := q.Get("newer"); v != "" {
 		t, err := time.Parse("2006-01-02", v)
 		if err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "find_invalid_newer", "path", path, "value", v)...)
 			errJSON(w, http.StatusBadRequest, "invalid newer date: "+v)
 			return
 		}
@@ -916,6 +1123,7 @@ func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string)
 	if v := q.Get("older"); v != "" {
 		t, err := time.Parse("2006-01-02", v)
 		if err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "find_invalid_older", "path", path, "value", v)...)
 			errJSON(w, http.StatusBadRequest, "invalid older date: "+v)
 			return
 		}
@@ -924,6 +1132,7 @@ func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string)
 	if v := q.Get("minsize"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "find_invalid_minsize", "path", path, "value", v)...)
 			errJSON(w, http.StatusBadRequest, "invalid minsize: "+v)
 			return
 		}
@@ -932,6 +1141,7 @@ func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string)
 	if v := q.Get("maxsize"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "find_invalid_maxsize", "path", path, "value", v)...)
 			errJSON(w, http.StatusBadRequest, "invalid maxsize: "+v)
 			return
 		}
@@ -940,6 +1150,7 @@ func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string)
 	if v := q.Get("limit"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "find_invalid_limit", "path", path, "value", v)...)
 			errJSON(w, http.StatusBadRequest, "invalid limit: "+v)
 			return
 		}
@@ -947,9 +1158,13 @@ func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string)
 	}
 	results, err := b.Find(r.Context(), f)
 	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "find_failed", "path", path, "error", err)...)
+		metricEvent(r.Context(), "userdb_query", "api", "find", "result", "error")
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	metricEvent(r.Context(), "userdb_query", "api", "find", "result", "ok")
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "find_ok", "path", path, "results", len(results), "name", f.NameGlob, "tag_key", f.TagKey)...)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(results)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -148,7 +148,7 @@ func (s *Server) resumeProvisioningTenants() {
 
 func (s *Server) resumeTenantSchemaInit(t meta.Tenant) {
 	ctx := backgroundWithTrace(context.Background())
-	plain, err := s.pool.Decrypt(t.DBPasswordCipher)
+	plain, err := s.pool.Decrypt(ctx, t.DBPasswordCipher)
 	if err != nil {
 		logger.Warn(ctx, "resume_schema_init_skipped", zap.String("tenant_id", t.ID), zap.Error(err))
 		return
@@ -244,7 +244,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
-	plain, err := poolDecryptToken(s.pool, resolved.APIKey.JWTCiphertext)
+	plain, err := poolDecryptToken(r.Context(), s.pool, resolved.APIKey.JWTCiphertext)
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_decrypt_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
@@ -886,14 +886,14 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	}
 	cluster.Provider = provider
 
-	cipherPass, err := s.pool.Encrypt([]byte(cluster.Password))
+	cipherPass, err := s.pool.Encrypt(r.Context(), []byte(cluster.Password))
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_encrypt_db_password_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
 		errJSON(w, http.StatusInternalServerError, "failed to encrypt db password")
 		return
 	}
-	cipherToken, err := s.pool.Encrypt([]byte(token))
+	cipherToken, err := s.pool.Encrypt(r.Context(), []byte(token))
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_encrypt_api_key_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -239,3 +239,226 @@ func TestNotFound(t *testing.T) {
 		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
 }
+
+func TestTraceIDHeaderPropagation(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/nonexistent.txt", nil)
+	req.Header.Set("X-Trace-ID", "trace-e2e-123")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if got := resp.Header.Get("X-Trace-ID"); got != "trace-e2e-123" {
+		t.Fatalf("expected trace header echo, got %q", got)
+	}
+
+	resp2, err := http.Get(ts.URL + "/v1/fs/nonexistent.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+	if got := resp2.Header.Get("X-Trace-ID"); got == "" {
+		t.Fatal("expected generated X-Trace-ID header")
+	}
+}
+
+func TestMetricsEndpoint(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/m.txt", strings.NewReader("abc"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	sqlReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/sql", strings.NewReader(`{"query":"SELECT 1"}`))
+	sqlReq.Header.Set("Content-Type", "application/json")
+	sqlResp, err := http.DefaultClient.Do(sqlReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = sqlResp.Body.Close()
+
+	readResp, err := http.Get(ts.URL + "/v1/fs/m.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = readResp.Body.Close()
+
+	statReq, _ := http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/m.txt", nil)
+	statResp, err := http.DefaultClient.Do(statReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = statResp.Body.Close()
+
+	badFSReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/m.txt?unknown=1", nil)
+	badFSResp, err := http.DefaultClient.Do(badFSReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = badFSResp.Body.Close()
+
+	methodFSReq, _ := http.NewRequest(http.MethodPatch, ts.URL+"/v1/fs/m.txt", nil)
+	methodFSResp, err := http.DefaultClient.Do(methodFSReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = methodFSResp.Body.Close()
+
+	statusMethodReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/status", nil)
+	statusMethodResp, err := http.DefaultClient.Do(statusMethodReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = statusMethodResp.Body.Close()
+
+	statusReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
+	statusResp, err := http.DefaultClient.Do(statusReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = statusResp.Body.Close()
+
+	provisionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", nil)
+	provisionResp, err := http.DefaultClient.Do(provisionReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = provisionResp.Body.Close()
+
+	badSQLReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/sql", strings.NewReader(`{"query":""}`))
+	badSQLReq.Header.Set("Content-Type", "application/json")
+	badSQLResp, err := http.DefaultClient.Do(badSQLReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = badSQLResp.Body.Close()
+
+	grepBadReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/m.txt?grep=abc&limit=NaN", nil)
+	grepBadResp, err := http.DefaultClient.Do(grepBadReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = grepBadResp.Body.Close()
+
+	findBadReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/m.txt?find=1&newer=bad-date", nil)
+	findBadResp, err := http.DefaultClient.Do(findBadReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = findBadResp.Body.Close()
+
+	resp, err = http.Get(ts.URL + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("metrics status: %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	text := string(body)
+	if !strings.Contains(text, "dat9_http_requests_total") {
+		t.Fatalf("expected requests metric in response: %s", text)
+	}
+	if !strings.Contains(text, `route="/v1/fs/*"`) {
+		t.Fatalf("expected fs route metric label in response: %s", text)
+	}
+	if !strings.Contains(text, "dat9_http_inflight_requests") {
+		t.Fatalf("expected inflight metric in response: %s", text)
+	}
+	if !strings.Contains(text, `dat9_service_operations_total{component="backend",operation="exec_sql",result="ok"}`) {
+		t.Fatalf("expected backend service metric in response: %s", text)
+	}
+	if !strings.Contains(text, `dat9_tenant_events_total{event="fs_write",result="ok"}`) {
+		t.Fatalf("expected fs_write tenant event metric in response: %s", text)
+	}
+	if !strings.Contains(text, `dat9_tenant_events_total{event="fs_read",result="ok"}`) {
+		t.Fatalf("expected fs_read tenant event metric in response: %s", text)
+	}
+	if !strings.Contains(text, `dat9_tenant_events_total{event="tenant_provision",result="error"}`) {
+		t.Fatalf("expected tenant_provision error metric in response: %s", text)
+	}
+}
+
+func TestUploadActionMetrics(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	completeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/uploads/nonexistent/complete", nil)
+	completeResp, err := http.DefaultClient.Do(completeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = completeResp.Body.Close()
+	if completeResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for upload complete, got %d", completeResp.StatusCode)
+	}
+
+	resumeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/uploads/nonexistent/resume", nil)
+	resumeResp, err := http.DefaultClient.Do(resumeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resumeResp.Body.Close()
+	if resumeResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for upload resume, got %d", resumeResp.StatusCode)
+	}
+
+	abortReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/v1/uploads/nonexistent", nil)
+	abortResp, err := http.DefaultClient.Do(abortReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = abortResp.Body.Close()
+	if abortResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for upload abort, got %d", abortResp.StatusCode)
+	}
+
+	uploadsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/uploads", nil)
+	uploadsResp, err := http.DefaultClient.Do(uploadsReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = uploadsResp.Body.Close()
+	if uploadsResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for uploads list without path, got %d", uploadsResp.StatusCode)
+	}
+
+	uploadActionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/uploads/nonexistent/unknown", nil)
+	uploadActionResp, err := http.DefaultClient.Do(uploadActionReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = uploadActionResp.Body.Close()
+	if uploadActionResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown upload action, got %d", uploadActionResp.StatusCode)
+	}
+
+	metricsResp, err := http.Get(ts.URL + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metricsResp.Body.Close() }()
+	body, _ := io.ReadAll(metricsResp.Body)
+	text := string(body)
+
+	if !strings.Contains(text, `dat9_tenant_events_total{event="upload_complete",result="error"}`) {
+		t.Fatalf("expected upload_complete metric, got: %s", text)
+	}
+	if !strings.Contains(text, `dat9_tenant_events_total{event="upload_resume",result="error"}`) {
+		t.Fatalf("expected upload_resume metric, got: %s", text)
+	}
+	if !strings.Contains(text, `dat9_tenant_events_total{event="upload_abort",result="error"}`) {
+		t.Fatalf("expected upload_abort metric, got: %s", text)
+	}
+}

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -138,7 +138,7 @@ func TestUploadCompleteEndpoint(t *testing.T) {
 	_ = resp.Body.Close()
 
 	// Get the upload to find s3_upload_id
-	upload, _ := s.fallback.GetUpload(plan.UploadID)
+	upload, _ := s.fallback.GetUpload(context.Background(), plan.UploadID)
 
 	// Upload all parts via S3 client directly
 	for _, p := range plan.Parts {
@@ -187,7 +187,7 @@ func TestUploadResumeEndpoint(t *testing.T) {
 	}
 	_ = resp.Body.Close()
 
-	upload, _ := s.fallback.GetUpload(plan.UploadID)
+	upload, _ := s.fallback.GetUpload(context.Background(), plan.UploadID)
 
 	// Upload only part 1
 	if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, 1, bytes.NewReader(make([]byte, s3client.PartSize))); err != nil {
@@ -253,7 +253,7 @@ func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 		t.Fatalf("initiate overwrite: expected 202, got %d", resp.StatusCode)
 	}
 
-	upload, err := s.fallback.GetUpload(plan.UploadID)
+	upload, err := s.fallback.GetUpload(context.Background(), plan.UploadID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +279,7 @@ func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 		t.Fatalf("complete overwrite: expected 200, got %d", resp.StatusCode)
 	}
 
-	nf, err := s.fallback.Store().Stat("/overwrite.bin")
+	nf, err := s.fallback.Store().Stat(context.Background(), "/overwrite.bin")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -391,7 +391,7 @@ func TestAbortUploadEndpoint(t *testing.T) {
 	}
 
 	// Verify upload is aborted
-	upload, _ := s.fallback.GetUpload(plan.UploadID)
+	upload, _ := s.fallback.GetUpload(context.Background(), plan.UploadID)
 	if upload.Status != datastore.UploadAborted {
 		t.Errorf("expected ABORTED, got %s", upload.Status)
 	}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -16,7 +16,6 @@ import (
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/s3client"
-	"github.com/mem9-ai/dat9/pkg/traceid"
 	"go.uber.org/zap"
 )
 
@@ -119,12 +118,12 @@ func (p *Pool) S3Backend(tenantID string) *backend.Dat9Backend {
 	return nil
 }
 
-func (p *Pool) Decrypt(cipher []byte) ([]byte, error) {
-	return p.enc.Decrypt(poolBackgroundContext(), cipher)
+func (p *Pool) Decrypt(ctx context.Context, cipher []byte) ([]byte, error) {
+	return p.enc.Decrypt(ctx, cipher)
 }
 
-func (p *Pool) Encrypt(plain []byte) ([]byte, error) {
-	return p.enc.Encrypt(poolBackgroundContext(), plain)
+func (p *Pool) Encrypt(ctx context.Context, plain []byte) ([]byte, error) {
+	return p.enc.Encrypt(ctx, plain)
 }
 
 func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantID string) (out *backend.Dat9Backend) {
@@ -234,8 +233,4 @@ func observePool(ctx context.Context, op, tenantID string, errp *error, start ti
 		logger.Error(ctx, "tenant_pool_op_failed", zap.String("operation", op), zap.String("tenant_id", tenantID), zap.String("result", result), zap.Error(*errp))
 	}
 	metrics.RecordOperation("tenant_pool", op, result, time.Since(start))
-}
-
-func poolBackgroundContext() context.Context {
-	return traceid.Background()
 }

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -3,15 +3,21 @@ package tenant
 import (
 	"container/list"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/encrypt"
+	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/s3client"
+	"github.com/mem9-ai/dat9/pkg/traceid"
+	"go.uber.org/zap"
 )
 
 type PoolConfig struct {
@@ -47,7 +53,10 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 	return &Pool{cfg: cfg, enc: enc, items: map[string]*list.Element{}, order: list.New(), maxSize: max}
 }
 
-func (p *Pool) Get(t *meta.Tenant) (*backend.Dat9Backend, error) {
+func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backend, err error) {
+	start := time.Now()
+	defer observePool(ctx, "get", t.ID, &err, start)
+
 	if t.Status != meta.TenantActive {
 		p.Invalidate(t.ID)
 		return nil, fmt.Errorf("tenant status: %s", t.Status)
@@ -62,7 +71,7 @@ func (p *Pool) Get(t *meta.Tenant) (*backend.Dat9Backend, error) {
 	}
 	p.mu.Unlock()
 
-	b, st, err := p.createBackend(t)
+	b, st, err := p.createBackend(ctx, t)
 	if err != nil {
 		return nil, err
 	}
@@ -111,31 +120,39 @@ func (p *Pool) S3Backend(tenantID string) *backend.Dat9Backend {
 }
 
 func (p *Pool) Decrypt(cipher []byte) ([]byte, error) {
-	return p.enc.Decrypt(context.Background(), cipher)
+	return p.enc.Decrypt(poolBackgroundContext(), cipher)
 }
 
 func (p *Pool) Encrypt(plain []byte) ([]byte, error) {
-	return p.enc.Encrypt(context.Background(), plain)
+	return p.enc.Encrypt(poolBackgroundContext(), plain)
 }
 
-func (p *Pool) LoadS3Backend(metaStore *meta.Store, tenantID string) *backend.Dat9Backend {
+func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantID string) (out *backend.Dat9Backend) {
+	start := time.Now()
+	var err error
+	defer observePool(ctx, "load_s3_backend", tenantID, &err, start)
+
 	b := p.S3Backend(tenantID)
 	if b != nil {
 		return b
 	}
-	tenant, err := metaStore.GetTenant(tenantID)
+	tenant, err := metaStore.GetTenant(ctx, tenantID)
 	if err != nil {
+		if !errors.Is(err, meta.ErrNotFound) {
+			logger.Error(ctx, "tenant_pool_load_s3_backend_failed", zap.String("tenant_id", tenantID), zap.Error(err))
+		}
 		return nil
 	}
-	b, err = p.Get(tenant)
+	b, err = p.Get(ctx, tenant)
 	if err != nil {
+		logger.Error(ctx, "tenant_pool_get_failed", zap.String("tenant_id", tenantID), zap.Error(err))
 		return nil
 	}
 	return b
 }
 
-func (p *Pool) createBackend(t *meta.Tenant) (*backend.Dat9Backend, *datastore.Store, error) {
-	pass, err := p.enc.Decrypt(context.Background(), t.DBPasswordCipher)
+func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9Backend, *datastore.Store, error) {
+	pass, err := p.enc.Decrypt(ctx, t.DBPasswordCipher)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -154,7 +171,7 @@ func (p *Pool) createBackend(t *meta.Tenant) (*backend.Dat9Backend, *datastore.S
 			prefix += "/"
 		}
 		prefix += t.ID + "/"
-		s3c, err := s3client.NewAWS(context.Background(), s3client.AWSConfig{
+		s3c, err := s3client.NewAWS(ctx, s3client.AWSConfig{
 			Region:  p.cfg.S3Region,
 			Bucket:  p.cfg.S3Bucket,
 			Prefix:  prefix,
@@ -203,4 +220,22 @@ func (p *Pool) removeLocked(elem *list.Element) {
 	if e.store != nil {
 		_ = e.store.Close()
 	}
+}
+
+func observePool(ctx context.Context, op, tenantID string, errp *error, start time.Time) {
+	result := "ok"
+	if errp != nil && *errp != nil {
+		switch {
+		case errors.Is(*errp, meta.ErrNotFound):
+			result = "not_found"
+		default:
+			result = "error"
+		}
+		logger.Error(ctx, "tenant_pool_op_failed", zap.String("operation", op), zap.String("tenant_id", tenantID), zap.String("result", result), zap.Error(*errp))
+	}
+	metrics.RecordOperation("tenant_pool", op, result, time.Since(start))
+}
+
+func poolBackgroundContext() context.Context {
+	return traceid.Background()
 }

--- a/pkg/traceid/traceid.go
+++ b/pkg/traceid/traceid.go
@@ -1,0 +1,35 @@
+// Package traceid manages trace IDs in contexts.
+package traceid
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strconv"
+	"time"
+)
+
+type keyType int
+
+const key keyType = iota
+
+func FromContext(ctx context.Context) string {
+	v, _ := ctx.Value(key).(string)
+	return v
+}
+
+func With(ctx context.Context, traceID string) context.Context {
+	return context.WithValue(ctx, key, traceID)
+}
+
+func Generate() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return hex.EncodeToString(b)
+}
+
+func Background() context.Context {
+	return With(context.Background(), Generate())
+}


### PR DESCRIPTION
## Summary
- Split observability concerns into dedicated packages: `pkg/logger` (logging + CLI log rotation), `pkg/metrics` (service operation metrics), and `pkg/traceid` (trace context helpers), and removed the old mixed `pkg/observability` package.
- Standardized context propagation and logging across server/backend/meta/datastore/tenant paths, with trace-aware `logger.Level(ctx, ...)` usage and context-aware data-layer APIs.
- Simplified tenant event metrics to focus on key-chain signals (`ok/error` plus a small set like `accepted/conflict/cluster_error`), while keeping detailed failure reasons in structured logs.
- Hardened CLI logging defaults: CLI log writing is now disabled by default (`DAT9_CLI_LOG_ENABLED` to enable), with rotation cleanup retained and compression always enabled.
- Updated and expanded tests to assert key metrics behavior and preserve full regression coverage after the refactor.

## Validation
- `make lint`
- `go test ./...`