### PR TITLE
feat add histogram buckets for p95 p99 p999 latency metrics

### DIFF
--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -5,22 +5,27 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
 type opMetrics struct {
-	mu            sync.RWMutex
-	counts        map[string]int64
-	durationCount map[string]int64
-	durationSum   map[string]float64
+	mu             sync.RWMutex
+	counts         map[string]int64
+	durationCount  map[string]int64
+	durationSum    map[string]float64
+	durationBucket map[string][]int64
 }
 
+var operationDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
+
 var globalOps = &opMetrics{
-	counts:        map[string]int64{},
-	durationCount: map[string]int64{},
-	durationSum:   map[string]float64{},
+	counts:         map[string]int64{},
+	durationCount:  map[string]int64{},
+	durationSum:    map[string]float64{},
+	durationBucket: map[string][]int64{},
 }
 
 func RecordOperation(component, operation, result string, d time.Duration) {
@@ -29,6 +34,17 @@ func RecordOperation(component, operation, result string, d time.Duration) {
 	globalOps.counts[key]++
 	globalOps.durationCount[key]++
 	globalOps.durationSum[key] += d.Seconds()
+	buckets := globalOps.durationBucket[key]
+	if buckets == nil {
+		buckets = make([]int64, len(operationDurationBounds))
+		globalOps.durationBucket[key] = buckets
+	}
+	seconds := d.Seconds()
+	for i, bound := range operationDurationBounds {
+		if seconds <= bound {
+			buckets[i]++
+		}
+	}
 	globalOps.mu.Unlock()
 }
 
@@ -38,12 +54,23 @@ func WritePrometheus(w http.ResponseWriter) {
 	counts := cloneInt(globalOps.counts)
 	durationCount := cloneInt(globalOps.durationCount)
 	durationSum := cloneFloat(globalOps.durationSum)
+	durationBucket := cloneBucket(globalOps.durationBucket)
 	globalOps.mu.RUnlock()
 
 	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operations_total Service operations by component/operation/result")
 	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_operations_total counter")
 	for _, k := range countKeys {
 		_, _ = fmt.Fprintf(w, "dat9_service_operations_total{%s} %d\n", k, counts[k])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operation_duration_seconds Service operation duration histogram")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_operation_duration_seconds histogram")
+	for _, k := range countKeys {
+		buckets := durationBucket[k]
+		for i, bound := range operationDurationBounds {
+			_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_bucket{%s,le=\"%s\"} %d\n", k, formatPromBound(bound), buckets[i])
+		}
+		_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_bucket{%s,le=\"+Inf\"} %d\n", k, durationCount[k])
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operation_duration_seconds_count Service operation duration count")
@@ -93,4 +120,18 @@ func cloneFloat(m map[string]float64) map[string]float64 {
 		out[k] = v
 	}
 	return out
+}
+
+func cloneBucket(m map[string][]int64) map[string][]int64 {
+	out := make(map[string][]int64, len(m))
+	for k, v := range m {
+		vv := make([]int64, len(v))
+		copy(vv, v)
+		out[k] = vv
+	}
+	return out
+}
+
+func formatPromBound(v float64) string {
+	return strconv.FormatFloat(v, 'g', -1, 64)
 }

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -66,14 +66,18 @@ type serverMetrics struct {
 	requests       map[string]int64
 	durationCount  map[string]int64
 	durationSecond map[string]float64
+	durationBucket map[string][]int64
 	events         map[string]int64
 }
+
+var httpDurationBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
 
 func newServerMetrics() *serverMetrics {
 	return &serverMetrics{
 		requests:       make(map[string]int64),
 		durationCount:  make(map[string]int64),
 		durationSecond: make(map[string]float64),
+		durationBucket: make(map[string][]int64),
 		events:         make(map[string]int64),
 	}
 }
@@ -86,6 +90,17 @@ func (m *serverMetrics) record(method, route string, status int, d time.Duration
 	m.requests[statusKey]++
 	m.durationCount[durationKey]++
 	m.durationSecond[durationKey] += d.Seconds()
+	buckets := m.durationBucket[durationKey]
+	if buckets == nil {
+		buckets = make([]int64, len(httpDurationBounds))
+		m.durationBucket[durationKey] = buckets
+	}
+	seconds := d.Seconds()
+	for i, bound := range httpDurationBounds {
+		if seconds <= bound {
+			buckets[i]++
+		}
+	}
 	m.mu.Unlock()
 }
 
@@ -110,6 +125,7 @@ func (m *serverMetrics) writePrometheus(w http.ResponseWriter) {
 	requests := cloneIntMap(m.requests)
 	durationCount := cloneIntMap(m.durationCount)
 	durationSecond := cloneFloatMap(m.durationSecond)
+	durationBucket := cloneBucketMap(m.durationBucket)
 	events := cloneIntMap(m.events)
 	m.mu.RUnlock()
 
@@ -117,6 +133,16 @@ func (m *serverMetrics) writePrometheus(w http.ResponseWriter) {
 	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_requests_total counter")
 	for _, k := range requestKeys {
 		_, _ = fmt.Fprintf(w, "dat9_http_requests_total{%s} %d\n", k, requests[k])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_http_request_duration_seconds HTTP request duration histogram by method/route")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_request_duration_seconds histogram")
+	for _, k := range durationKeys {
+		buckets := durationBucket[k]
+		for i, bound := range httpDurationBounds {
+			_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_bucket{%s,le=\"%s\"} %d\n", k, formatPromBound(bound), buckets[i])
+		}
+		_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_bucket{%s,le=\"+Inf\"} %d\n", k, durationCount[k])
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP dat9_http_request_duration_seconds_count HTTP request duration count by method/route")
@@ -152,6 +178,20 @@ func cloneFloatMap(src map[string]float64) map[string]float64 {
 		out[k] = v
 	}
 	return out
+}
+
+func cloneBucketMap(src map[string][]int64) map[string][]int64 {
+	out := make(map[string][]int64, len(src))
+	for k, v := range src {
+		vv := make([]int64, len(v))
+		copy(vv, v)
+		out[k] = vv
+	}
+	return out
+}
+
+func formatPromBound(v float64) string {
+	return strconv.FormatFloat(v, 'g', -1, 64)
 }
 
 func sortedKeys[T any](m map[string]T) []string {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -378,6 +378,12 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `dat9_service_operations_total{component="backend",operation="exec_sql",result="ok"}`) {
 		t.Fatalf("expected backend service metric in response: %s", text)
 	}
+	if !strings.Contains(text, `dat9_http_request_duration_seconds_bucket{method="GET",route="/v1/fs/*",le="0.1"}`) {
+		t.Fatalf("expected http duration histogram bucket in response: %s", text)
+	}
+	if !strings.Contains(text, `dat9_service_operation_duration_seconds_bucket{component="backend",operation="exec_sql",result="ok",le="0.01"}`) {
+		t.Fatalf("expected service operation histogram bucket in response: %s", text)
+	}
 	if !strings.Contains(text, `dat9_tenant_events_total{event="fs_write",result="ok"}`) {
 		t.Fatalf("expected fs_write tenant event metric in response: %s", text)
 	}


### PR DESCRIPTION
## Summary
- Add Prometheus histogram buckets for HTTP request latency in `pkg/server/instrumentation.go` via `dat9_http_request_duration_seconds_bucket` (+ existing `_count`/`_sum`).
- Add Prometheus histogram buckets for service operation latency in `pkg/metrics/operations.go` via `dat9_service_operation_duration_seconds_bucket` (+ existing `_count`/`_sum`).
- Keep existing count/sum metrics and labels; this change enables direct `histogram_quantile()` for P95/P99/P999 dashboards.
- Extend `pkg/server/server_test.go` metrics assertions to verify both HTTP and service histogram bucket output.

## Why
The previous count/sum-only latency metrics could not support P95/P99/P999 quantile dashboards directly. Histogram buckets are required for reliable percentile SLOs.

## Validation
- `make lint`
- `go test ./...`