### PR TITLE
fix: use full model path for auto-embed model constant

### DIFF
--- a/pkg/tenant/schema_common.go
+++ b/pkg/tenant/schema_common.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const autoEmbedModel = "titan-embed-image-v1"
+const autoEmbedModel = "tidbcloud_free/amazon/titan-embed-image-v1"
 
 func execSchemaStatements(db *sql.DB, stmts []string) error {
 	for _, stmt := range stmts {


### PR DESCRIPTION
## Summary

- Fix `autoEmbedModel` from short name `titan-embed-image-v1` to full TiDB Cloud model path `tidbcloud_free/amazon/titan-embed-image-v1`

## Change

`pkg/tenant/schema_common.go`: The model constant used in `EMBED_TEXT()` for auto-embedding requires the full provider-qualified name per TiDB Cloud docs.