### PR TITLE
fix: revert auto-embed model to titan-embed-text-v2

### DIFF
--- a/pkg/tenant/schema_common.go
+++ b/pkg/tenant/schema_common.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const autoEmbedModel = "tidbcloud_free/amazon/titan-embed-image-v1"
+const autoEmbedModel = "tidbcloud_free/amazon/titan-embed-text-v2"
 
 func execSchemaStatements(db *sql.DB, stmts []string) error {
 	for _, stmt := range stmts {


### PR DESCRIPTION
## Summary

- Revert `autoEmbedModel` from `tidbcloud_free/amazon/titan-embed-image-v1` back to `tidbcloud_free/amazon/titan-embed-text-v2`

## Reason

The image embedding model (`titan-embed-image-v1`) requires a separate column and different handling (image vs text input). The shared `autoEmbedModel` constant is used for text content embedding via `EMBED_TEXT()`, so it must point to the text model.