### PR TITLE
feat: async image-to-text extraction for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ c.Delete("/data/file.txt")
 | `DAT9_S3_PREFIX` | S3 key prefix (e.g. `tenants/abc/`) | |
 | `DAT9_S3_ROLE_ARN` | IAM role ARN to assume via STS | |
 | `DAT9_S3_DIR` | Local S3 mock directory (only used without `DAT9_S3_BUCKET`) | `./s3` |
-| `DAT9_IMAGE_EXTRACT_ENABLED` | Enable async image->text extraction for search | `true` |
+| `DAT9_IMAGE_EXTRACT_ENABLED` | Enable async image->text extraction for search | `false` |
 | `DAT9_IMAGE_EXTRACT_QUEUE_SIZE` | In-memory queue size for extraction tasks | `128` |
 | `DAT9_IMAGE_EXTRACT_WORKERS` | Number of extraction workers | `1` |
 | `DAT9_IMAGE_EXTRACT_MAX_BYTES` | Max image bytes processed per task | `8388608` |

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ c.Delete("/data/file.txt")
 | `DAT9_IMAGE_EXTRACT_API_BASE` | OpenAI-compatible base URL (optional; set with key/model) | |
 | `DAT9_IMAGE_EXTRACT_API_KEY` | API key for image extraction provider | |
 | `DAT9_IMAGE_EXTRACT_MODEL` | Vision model name (for example Qwen VL model id) | |
-| `DAT9_IMAGE_EXTRACT_PROMPT` | Custom extraction prompt | |
+| `DAT9_IMAGE_EXTRACT_PROMPT` | Custom extraction prompt | `Describe this image for file search. Include key objects, scene, any visible text (OCR), and concise tags.` |
 | `DAT9_IMAGE_EXTRACT_MAX_TOKENS` | Max output tokens for model extraction | `256` |
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ c.Delete("/data/file.txt")
 | `DAT9_S3_PREFIX` | S3 key prefix (e.g. `tenants/abc/`) | |
 | `DAT9_S3_ROLE_ARN` | IAM role ARN to assume via STS | |
 | `DAT9_S3_DIR` | Local S3 mock directory (only used without `DAT9_S3_BUCKET`) | `./s3` |
+| `DAT9_IMAGE_EXTRACT_ENABLED` | Enable async image->text extraction for search | `true` |
+| `DAT9_IMAGE_EXTRACT_QUEUE_SIZE` | In-memory queue size for extraction tasks | `128` |
+| `DAT9_IMAGE_EXTRACT_WORKERS` | Number of extraction workers | `1` |
+| `DAT9_IMAGE_EXTRACT_MAX_BYTES` | Max image bytes processed per task | `8388608` |
+| `DAT9_IMAGE_EXTRACT_TIMEOUT_SECONDS` | Timeout per extraction task | `20` |
+| `DAT9_IMAGE_EXTRACT_MAX_TEXT_BYTES` | Max extracted text stored into `files.content_text` | `8192` |
+| `DAT9_IMAGE_EXTRACT_API_BASE` | OpenAI-compatible base URL (optional; set with key/model) | |
+| `DAT9_IMAGE_EXTRACT_API_KEY` | API key for image extraction provider | |
+| `DAT9_IMAGE_EXTRACT_MODEL` | Vision model name (for example Qwen VL model id) | |
+| `DAT9_IMAGE_EXTRACT_PROMPT` | Custom extraction prompt | |
+| `DAT9_IMAGE_EXTRACT_MAX_TOKENS` | Max output tokens for model extraction | `256` |
 
 ## Architecture
 

--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -184,7 +184,7 @@ environment:
   DAT9_S3_ROLE_ARN IAM role ARN to assume via STS (optional)
   DAT9_S3_DIR      local s3 mock root directory (default: ./s3, only used without DAT9_S3_BUCKET)
   Image extraction (async image -> text for search):
-  DAT9_IMAGE_EXTRACT_ENABLED true|false (default: true)
+  DAT9_IMAGE_EXTRACT_ENABLED true|false (default: false)
   DAT9_IMAGE_EXTRACT_QUEUE_SIZE buffered task queue size (default: 128)
   DAT9_IMAGE_EXTRACT_WORKERS number of workers (default: 1)
   DAT9_IMAGE_EXTRACT_MAX_BYTES max image bytes processed per task (default: 8388608)
@@ -230,7 +230,7 @@ func publicBaseURL(listenAddr string) string {
 
 func buildBackendOptionsFromEnv() (backend.Options, error) {
 	var opts backend.Options
-	if !envBool("DAT9_IMAGE_EXTRACT_ENABLED", true) {
+	if !envBool("DAT9_IMAGE_EXTRACT_ENABLED", false) {
 		return opts, nil
 	}
 

--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -12,7 +12,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
@@ -53,6 +55,10 @@ func main() {
 	s3Region := envOr("DAT9_S3_REGION", "us-east-1")
 	s3Prefix := os.Getenv("DAT9_S3_PREFIX")
 	s3RoleARN := os.Getenv("DAT9_S3_ROLE_ARN")
+	backendOptions, err := buildBackendOptionsFromEnv()
+	if err != nil {
+		die(err)
+	}
 
 	store, err := meta.Open(metaDSN)
 	if err != nil {
@@ -129,12 +135,13 @@ func main() {
 		}
 
 		pool = tenant.NewPool(tenant.PoolConfig{
-			S3Dir:     s3Dir,
-			PublicURL: publicBaseURL(addr),
-			S3Bucket:  s3Bucket,
-			S3Region:  s3Region,
-			S3Prefix:  s3Prefix,
-			S3RoleARN: s3RoleARN,
+			S3Dir:          s3Dir,
+			PublicURL:      publicBaseURL(addr),
+			S3Bucket:       s3Bucket,
+			S3Region:       s3Region,
+			S3Prefix:       s3Prefix,
+			S3RoleARN:      s3RoleARN,
+			BackendOptions: backendOptions,
 		}, enc)
 		defer pool.Close()
 	}
@@ -176,6 +183,18 @@ environment:
   DAT9_S3_PREFIX   S3 key prefix (e.g. "tenants")
   DAT9_S3_ROLE_ARN IAM role ARN to assume via STS (optional)
   DAT9_S3_DIR      local s3 mock root directory (default: ./s3, only used without DAT9_S3_BUCKET)
+  Image extraction (async image -> text for search):
+  DAT9_IMAGE_EXTRACT_ENABLED true|false (default: true)
+  DAT9_IMAGE_EXTRACT_QUEUE_SIZE buffered task queue size (default: 128)
+  DAT9_IMAGE_EXTRACT_WORKERS number of workers (default: 1)
+  DAT9_IMAGE_EXTRACT_MAX_BYTES max image bytes processed per task (default: 8388608)
+  DAT9_IMAGE_EXTRACT_TIMEOUT_SECONDS extractor timeout seconds (default: 20)
+  DAT9_IMAGE_EXTRACT_MAX_TEXT_BYTES max extracted text stored in files.content_text (default: 8192)
+  DAT9_IMAGE_EXTRACT_API_BASE OpenAI-compatible base URL (optional)
+  DAT9_IMAGE_EXTRACT_API_KEY  API key for DAT9_IMAGE_EXTRACT_API_BASE (optional)
+  DAT9_IMAGE_EXTRACT_MODEL    model name for vision extraction (optional)
+  DAT9_IMAGE_EXTRACT_PROMPT   custom extraction prompt (optional)
+  DAT9_IMAGE_EXTRACT_MAX_TOKENS max model output tokens (default: 256)
 `)
 	os.Exit(2)
 }
@@ -207,4 +226,92 @@ func publicBaseURL(listenAddr string) string {
 		os.Exit(1)
 		return "" // unreachable
 	}
+}
+
+func buildBackendOptionsFromEnv() (backend.Options, error) {
+	var opts backend.Options
+	if !envBool("DAT9_IMAGE_EXTRACT_ENABLED", true) {
+		return opts, nil
+	}
+
+	async := backend.AsyncImageExtractOptions{
+		Enabled:             true,
+		QueueSize:           envInt("DAT9_IMAGE_EXTRACT_QUEUE_SIZE", 128),
+		Workers:             envInt("DAT9_IMAGE_EXTRACT_WORKERS", 1),
+		MaxImageBytes:       envInt64("DAT9_IMAGE_EXTRACT_MAX_BYTES", 8<<20),
+		TaskTimeout:         time.Duration(envInt("DAT9_IMAGE_EXTRACT_TIMEOUT_SECONDS", 20)) * time.Second,
+		MaxExtractTextBytes: envInt("DAT9_IMAGE_EXTRACT_MAX_TEXT_BYTES", 8<<10),
+	}
+
+	baseURL := strings.TrimSpace(os.Getenv("DAT9_IMAGE_EXTRACT_API_BASE"))
+	apiKey := strings.TrimSpace(os.Getenv("DAT9_IMAGE_EXTRACT_API_KEY"))
+	model := strings.TrimSpace(os.Getenv("DAT9_IMAGE_EXTRACT_MODEL"))
+	prompt := strings.TrimSpace(os.Getenv("DAT9_IMAGE_EXTRACT_PROMPT"))
+	maxTokens := envInt("DAT9_IMAGE_EXTRACT_MAX_TOKENS", 256)
+
+	configured := baseURL != "" || apiKey != "" || model != ""
+	if configured {
+		if baseURL == "" || apiKey == "" || model == "" {
+			return backend.Options{}, fmt.Errorf("DAT9_IMAGE_EXTRACT_API_BASE, DAT9_IMAGE_EXTRACT_API_KEY and DAT9_IMAGE_EXTRACT_MODEL must be set together")
+		}
+		extractor, err := backend.NewOpenAIImageTextExtractor(backend.OpenAIImageTextExtractorConfig{
+			BaseURL:   baseURL,
+			APIKey:    apiKey,
+			Model:     model,
+			Prompt:    prompt,
+			MaxTokens: maxTokens,
+			Timeout:   async.TaskTimeout,
+		})
+		if err != nil {
+			return backend.Options{}, fmt.Errorf("init image extractor: %w", err)
+		}
+		async.Extractor = backend.NewFallbackImageTextExtractor(extractor, backend.NewBasicImageTextExtractor())
+		logger.Info(context.Background(), "image_extract_mode_openai_compatible",
+			zap.String("model", model), zap.String("base_url", baseURL))
+	} else {
+		async.Extractor = backend.NewBasicImageTextExtractor()
+		logger.Info(context.Background(), "image_extract_mode_basic_fallback")
+	}
+
+	opts.AsyncImageExtract = async
+	return opts, nil
+}
+
+func envBool(key string, fallback bool) bool {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	switch strings.ToLower(raw) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return fallback
+	}
+}
+
+func envInt(key string, fallback int) int {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+	return v
+}
+
+func envInt64(key string, fallback int64) int64 {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return fallback
+	}
+	return v
 }

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -36,29 +36,52 @@ type Dat9Backend struct {
 	smallInDB bool
 	mu        sync.Mutex
 	entropy   io.Reader
+
+	// Async image -> text extraction worker (in-memory queue for P0).
+	imageExtractEnabled bool
+	imageExtractor      ImageTextExtractor
+	imageExtractQueue   chan imageExtractTask
+	imageExtractWG      sync.WaitGroup
+	imageExtractCancel  context.CancelFunc
+	imageExtractTimeout time.Duration
+	imageExtractMaxSize int64
+	maxExtractTextBytes int
 }
 
-func New(store *datastore.Store) (*Dat9Backend, error) {
+func newBaseBackend(store *datastore.Store) *Dat9Backend {
 	return &Dat9Backend{
 		store:     store,
 		smallInDB: true,
 		entropy:   ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0),
-	}, nil
+	}
+}
+
+func New(store *datastore.Store) (*Dat9Backend, error) {
+	return NewWithOptions(store, Options{})
+}
+
+func NewWithOptions(store *datastore.Store, opts Options) (*Dat9Backend, error) {
+	b := newBaseBackend(store)
+	b.configureOptions(opts)
+	return b, nil
 }
 
 // NewWithS3 creates a Dat9Backend with S3 support for large file uploads.
 func NewWithS3(store *datastore.Store, s3 s3client.S3Client) (*Dat9Backend, error) {
-	return NewWithS3Mode(store, s3, true)
+	return NewWithS3ModeAndOptions(store, s3, true, Options{})
 }
 
 // NewWithS3Mode controls whether files smaller than threshold stay in DB.
 func NewWithS3Mode(store *datastore.Store, s3 s3client.S3Client, smallInDB bool) (*Dat9Backend, error) {
-	b, err := New(store)
-	if err != nil {
-		return nil, err
-	}
+	return NewWithS3ModeAndOptions(store, s3, smallInDB, Options{})
+}
+
+// NewWithS3ModeAndOptions controls storage mode and backend options.
+func NewWithS3ModeAndOptions(store *datastore.Store, s3 s3client.S3Client, smallInDB bool, opts Options) (*Dat9Backend, error) {
+	b := newBaseBackend(store)
 	b.s3 = s3
 	b.smallInDB = smallInDB
+	b.configureOptions(opts)
 	return b, nil
 }
 
@@ -317,6 +340,7 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 	}); err != nil {
 		return 0, err
 	}
+	b.enqueueImageExtract(fileID, path, contentType, 1)
 	return int64(len(data)), nil
 }
 
@@ -369,10 +393,11 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 		}
 	}
 
-	if err := b.store.UpdateFileContent(ctx,
+	newRev, err := b.store.UpdateFileContent(ctx,
 		nf.File.FileID, storageType, storageRef,
 		contentType, checksum, contentText, contentBlob, int64(len(finalData)),
-	); err != nil {
+	)
+	if err != nil {
 		if storageType == datastore.StorageS3 {
 			b.deleteBlobCtx(ctx, storageRef)
 		}
@@ -381,6 +406,7 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 	if nf.File.StorageRef != "" && nf.File.StorageRef != storageRef {
 		b.deleteBlobCtx(ctx, nf.File.StorageRef)
 	}
+	b.enqueueImageExtract(nf.File.FileID, nf.Node.Path, contentType, newRev)
 	return int64(len(data)), nil
 }
 

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func newTestBackend(t *testing.T) *Dat9Backend {
+	return newTestBackendWithOptions(t, Options{})
+}
+
+func newTestBackendWithOptions(t *testing.T, opts Options) *Dat9Backend {
 	t.Helper()
 
 	s3Dir, err := os.MkdirTemp("", "dat9-s3-*")
@@ -32,10 +36,11 @@ func newTestBackend(t *testing.T) *Dat9Backend {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := NewWithS3(store, s3c)
+	b, err := NewWithS3ModeAndOptions(store, s3c, true, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { b.Close() })
 	return b
 }
 

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"go.uber.org/zap"
 )
 
@@ -73,7 +75,9 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 	}
 	select {
 	case b.imageExtractQueue <- task:
+		metrics.RecordOperation("image_extract", "enqueue", "ok", 0)
 	default:
+		metrics.RecordOperation("image_extract", "enqueue", "queue_full", 0)
 		logger.Warn(backgroundWithTrace(), "backend_image_extract_queue_full_drop",
 			zap.String("file_id", fileID),
 			zap.String("path", path),
@@ -117,15 +121,18 @@ func (b *Dat9Backend) runImageExtractWorker(ctx context.Context) {
 }
 
 func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExtractTask) {
+	start := time.Now()
 	f, err := b.store.GetFile(ctx, task.FileID)
 	if err != nil {
 		if !errors.Is(err, datastore.ErrNotFound) {
 			logger.Warn(ctx, "backend_image_extract_get_file_failed",
 				zap.String("file_id", task.FileID), zap.Error(err))
 		}
+		metrics.RecordOperation("image_extract", "process", "get_file_error", time.Since(start))
 		return
 	}
 	if f.Status != datastore.StatusConfirmed {
+		metrics.RecordOperation("image_extract", "process", "not_confirmed", time.Since(start))
 		return
 	}
 	ct := f.ContentType
@@ -133,6 +140,7 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 		ct = task.ContentType
 	}
 	if !isImageContentType(ct) {
+		metrics.RecordOperation("image_extract", "process", "not_image", time.Since(start))
 		return
 	}
 
@@ -140,9 +148,11 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 	if err != nil {
 		logger.Warn(ctx, "backend_image_extract_load_bytes_failed",
 			zap.String("file_id", task.FileID), zap.Error(err))
+		metrics.RecordOperation("image_extract", "process", "load_error", time.Since(start))
 		return
 	}
 	if len(data) == 0 {
+		metrics.RecordOperation("image_extract", "process", "skip_too_large", time.Since(start))
 		return
 	}
 
@@ -157,10 +167,12 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 	if err != nil {
 		logger.Warn(ctx, "backend_image_extract_failed",
 			zap.String("file_id", task.FileID), zap.String("path", task.Path), zap.Error(err))
+		metrics.RecordOperation("image_extract", "process", "extract_error", time.Since(start))
 		return
 	}
 	text = sanitizeExtractedText(text, b.maxExtractTextBytes)
 	if text == "" {
+		metrics.RecordOperation("image_extract", "process", "empty_text", time.Since(start))
 		return
 	}
 
@@ -168,15 +180,18 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 	if err != nil {
 		logger.Warn(ctx, "backend_image_extract_update_file_failed",
 			zap.String("file_id", task.FileID), zap.Error(err))
+		metrics.RecordOperation("image_extract", "process", "update_error", time.Since(start))
 		return
 	}
 	if !updated {
 		logger.Info(ctx, "backend_image_extract_skipped_stale",
 			zap.String("file_id", task.FileID), zap.String("path", task.Path))
+		metrics.RecordOperation("image_extract", "process", "stale", time.Since(start))
 		return
 	}
 	logger.Info(ctx, "backend_image_extract_ok",
 		zap.String("file_id", task.FileID), zap.String("path", task.Path), zap.Int("text_len", len(text)))
+	metrics.RecordOperation("image_extract", "process", "ok", time.Since(start))
 }
 
 func (b *Dat9Backend) loadImageBytesForExtract(ctx context.Context, f *datastore.File) ([]byte, error) {

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -60,7 +60,10 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 		return
 	}
 	if !isImageContentType(contentType) {
-		return
+		contentType = contentTypeFromPath(path)
+		if !isImageContentType(contentType) {
+			return
+		}
 	}
 	task := imageExtractTask{
 		FileID:      fileID,

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -143,6 +143,10 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 		metrics.RecordOperation("image_extract", "process", "not_image", time.Since(start))
 		return
 	}
+	if task.Revision > 0 && f.Revision != task.Revision {
+		metrics.RecordOperation("image_extract", "process", "stale_precheck", time.Since(start))
+		return
+	}
 
 	data, err := b.loadImageBytesForExtract(ctx, f)
 	if err != nil {

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -1,0 +1,240 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"go.uber.org/zap"
+)
+
+// ImageExtractRequest is the input to a pluggable image->text extractor.
+type ImageExtractRequest struct {
+	FileID      string
+	Path        string
+	ContentType string
+	Data        []byte
+}
+
+// ImageTextExtractor extracts searchable text from image bytes.
+type ImageTextExtractor interface {
+	ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error)
+}
+
+type imageExtractTask struct {
+	FileID      string
+	Path        string
+	ContentType string
+	Revision    int64
+}
+
+func isImageContentType(contentType string) bool {
+	contentType = strings.ToLower(strings.TrimSpace(contentType))
+	return strings.HasPrefix(contentType, "image/")
+}
+
+var imageExtensions = map[string]string{
+	".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+	".gif": "image/gif", ".bmp": "image/bmp", ".webp": "image/webp",
+	".svg": "image/svg+xml", ".tiff": "image/tiff", ".tif": "image/tiff",
+	".ico": "image/x-icon",
+}
+
+func contentTypeFromPath(path string) string {
+	path = strings.ToLower(path)
+	for ext, ct := range imageExtensions {
+		if strings.HasSuffix(path, ext) {
+			return ct
+		}
+	}
+	return ""
+}
+
+func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revision int64) {
+	if !b.imageExtractEnabled || b.imageExtractor == nil {
+		return
+	}
+	if !isImageContentType(contentType) {
+		return
+	}
+	task := imageExtractTask{
+		FileID:      fileID,
+		Path:        path,
+		ContentType: contentType,
+		Revision:    revision,
+	}
+	select {
+	case b.imageExtractQueue <- task:
+	default:
+		logger.Warn(backgroundWithTrace(), "backend_image_extract_queue_full_drop",
+			zap.String("file_id", fileID),
+			zap.String("path", path),
+			zap.Int("queue_size", cap(b.imageExtractQueue)))
+	}
+}
+
+func (b *Dat9Backend) enqueueImageExtractForUpload(ctx context.Context, upload *datastore.Upload, isOverwrite bool) {
+	if !b.imageExtractEnabled || b.imageExtractor == nil {
+		return
+	}
+	fileID := upload.FileID
+	if isOverwrite {
+		nf, err := b.store.Stat(ctx, upload.TargetPath)
+		if err != nil || nf.File == nil {
+			return
+		}
+		fileID = nf.File.FileID
+	}
+	f, err := b.store.GetFile(ctx, fileID)
+	if err != nil {
+		return
+	}
+	ct := f.ContentType
+	if ct == "" {
+		ct = contentTypeFromPath(upload.TargetPath)
+	}
+	b.enqueueImageExtract(fileID, upload.TargetPath, ct, f.Revision)
+}
+
+func (b *Dat9Backend) runImageExtractWorker(ctx context.Context) {
+	defer b.imageExtractWG.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case task := <-b.imageExtractQueue:
+			b.processImageExtractTask(ctx, task)
+		}
+	}
+}
+
+func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExtractTask) {
+	f, err := b.store.GetFile(ctx, task.FileID)
+	if err != nil {
+		if !errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(ctx, "backend_image_extract_get_file_failed",
+				zap.String("file_id", task.FileID), zap.Error(err))
+		}
+		return
+	}
+	if f.Status != datastore.StatusConfirmed {
+		return
+	}
+	ct := f.ContentType
+	if ct == "" {
+		ct = task.ContentType
+	}
+	if !isImageContentType(ct) {
+		return
+	}
+
+	data, err := b.loadImageBytesForExtract(ctx, f)
+	if err != nil {
+		logger.Warn(ctx, "backend_image_extract_load_bytes_failed",
+			zap.String("file_id", task.FileID), zap.Error(err))
+		return
+	}
+	if len(data) == 0 {
+		return
+	}
+
+	taskCtx, cancel := context.WithTimeout(ctx, b.imageExtractTimeout)
+	text, err := b.imageExtractor.ExtractImageText(taskCtx, ImageExtractRequest{
+		FileID:      task.FileID,
+		Path:        task.Path,
+		ContentType: ct,
+		Data:        data,
+	})
+	cancel()
+	if err != nil {
+		logger.Warn(ctx, "backend_image_extract_failed",
+			zap.String("file_id", task.FileID), zap.String("path", task.Path), zap.Error(err))
+		return
+	}
+	text = sanitizeExtractedText(text, b.maxExtractTextBytes)
+	if text == "" {
+		return
+	}
+
+	updated, err := b.store.UpdateFileSearchText(ctx, task.FileID, task.Revision, text)
+	if err != nil {
+		logger.Warn(ctx, "backend_image_extract_update_file_failed",
+			zap.String("file_id", task.FileID), zap.Error(err))
+		return
+	}
+	if !updated {
+		logger.Info(ctx, "backend_image_extract_skipped_stale",
+			zap.String("file_id", task.FileID), zap.String("path", task.Path))
+		return
+	}
+	logger.Info(ctx, "backend_image_extract_ok",
+		zap.String("file_id", task.FileID), zap.String("path", task.Path), zap.Int("text_len", len(text)))
+}
+
+func (b *Dat9Backend) loadImageBytesForExtract(ctx context.Context, f *datastore.File) ([]byte, error) {
+	if b.imageExtractMaxSize > 0 && f.SizeBytes > b.imageExtractMaxSize {
+		return nil, nil
+	}
+	if f.StorageType == datastore.StorageDB9 {
+		if b.imageExtractMaxSize > 0 && int64(len(f.ContentBlob)) > b.imageExtractMaxSize {
+			return nil, nil
+		}
+		return append([]byte(nil), f.ContentBlob...), nil
+	}
+	if f.StorageType != datastore.StorageS3 {
+		return nil, fmt.Errorf("unsupported storage type: %s", f.StorageType)
+	}
+	if b.s3 == nil {
+		return nil, fmt.Errorf("s3 client not configured")
+	}
+	rc, err := b.s3.GetObject(ctx, f.StorageRef)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+
+	reader := io.Reader(rc)
+	if b.imageExtractMaxSize > 0 {
+		reader = io.LimitReader(rc, b.imageExtractMaxSize+1)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	if b.imageExtractMaxSize > 0 && int64(len(data)) > b.imageExtractMaxSize {
+		return nil, nil
+	}
+	return data, nil
+}
+
+func sanitizeExtractedText(in string, maxBytes int) string {
+	in = strings.TrimSpace(in)
+	if in == "" {
+		return ""
+	}
+	in = strings.Join(strings.Fields(in), " ")
+	if maxBytes <= 0 || len(in) <= maxBytes {
+		return in
+	}
+	var (
+		total int
+		out   strings.Builder
+	)
+	for _, r := range in {
+		rb := utf8.RuneLen(r)
+		if rb < 0 {
+			continue
+		}
+		if total+rb > maxBytes {
+			break
+		}
+		out.WriteRune(r)
+		total += rb
+	}
+	return strings.TrimSpace(out.String())
+}

--- a/pkg/backend/image_extract_basic.go
+++ b/pkg/backend/image_extract_basic.go
@@ -1,0 +1,62 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"strings"
+
+	"github.com/mem9-ai/dat9/pkg/pathutil"
+)
+
+// BasicImageTextExtractor is a deterministic fallback extractor used when no
+// external vision model is configured. It emits lightweight metadata text.
+type BasicImageTextExtractor struct{}
+
+func NewBasicImageTextExtractor() *BasicImageTextExtractor { return &BasicImageTextExtractor{} }
+
+func (e *BasicImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
+	name := pathutil.BaseName(req.Path)
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(req.Data))
+	if err == nil {
+		return strings.TrimSpace(fmt.Sprintf("image file %s format %s width %d height %d", name, strings.ToLower(format), cfg.Width, cfg.Height)), nil
+	}
+	if req.ContentType != "" {
+		return strings.TrimSpace(fmt.Sprintf("image file %s content type %s", name, req.ContentType)), nil
+	}
+	return strings.TrimSpace(fmt.Sprintf("image file %s", name)), nil
+}
+
+type fallbackImageTextExtractor struct {
+	primary  ImageTextExtractor
+	fallback ImageTextExtractor
+}
+
+// NewFallbackImageTextExtractor wraps an extractor with a fallback extractor.
+func NewFallbackImageTextExtractor(primary, fallback ImageTextExtractor) ImageTextExtractor {
+	if primary == nil {
+		return fallback
+	}
+	if fallback == nil {
+		return primary
+	}
+	return &fallbackImageTextExtractor{primary: primary, fallback: fallback}
+}
+
+func (e *fallbackImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error) {
+	text, err := e.primary.ExtractImageText(ctx, req)
+	if err == nil && strings.TrimSpace(text) != "" {
+		return text, nil
+	}
+	return e.fallback.ExtractImageText(ctx, req)
+}

--- a/pkg/backend/image_extract_openai.go
+++ b/pkg/backend/image_extract_openai.go
@@ -1,0 +1,179 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultImageExtractPrompt = "Describe this image for file search. Include key objects, scene, any visible text (OCR), and concise tags."
+
+// OpenAIImageTextExtractorConfig configures an OpenAI-compatible vision endpoint.
+// This works with providers that expose the /v1/chat/completions API surface.
+type OpenAIImageTextExtractorConfig struct {
+	BaseURL   string
+	APIKey    string
+	Model     string
+	Prompt    string
+	MaxTokens int
+	Timeout   time.Duration
+	Client    *http.Client
+}
+
+type OpenAIImageTextExtractor struct {
+	endpoint  string
+	apiKey    string
+	model     string
+	prompt    string
+	maxTokens int
+	client    *http.Client
+}
+
+func NewOpenAIImageTextExtractor(cfg OpenAIImageTextExtractorConfig) (*OpenAIImageTextExtractor, error) {
+	base := strings.TrimRight(cfg.BaseURL, "/")
+	if base == "" {
+		return nil, fmt.Errorf("openai extractor base url is required")
+	}
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("openai extractor api key is required")
+	}
+	if cfg.Model == "" {
+		return nil, fmt.Errorf("openai extractor model is required")
+	}
+	endpoint := base
+	if strings.HasSuffix(base, "/v1") {
+		endpoint = base + "/chat/completions"
+	} else {
+		endpoint = base + "/v1/chat/completions"
+	}
+	if cfg.Prompt == "" {
+		cfg.Prompt = defaultImageExtractPrompt
+	}
+	if cfg.MaxTokens <= 0 {
+		cfg.MaxTokens = 256
+	}
+	client := cfg.Client
+	if client == nil {
+		timeout := cfg.Timeout
+		if timeout <= 0 {
+			timeout = 30 * time.Second
+		}
+		client = &http.Client{Timeout: timeout}
+	}
+	return &OpenAIImageTextExtractor{
+		endpoint:  endpoint,
+		apiKey:    cfg.APIKey,
+		model:     cfg.Model,
+		prompt:    cfg.Prompt,
+		maxTokens: cfg.MaxTokens,
+		client:    client,
+	}, nil
+}
+
+func (e *OpenAIImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error) {
+	contentType := req.ContentType
+	if contentType == "" {
+		contentType = "image/png"
+	}
+	imageURL := "data:" + contentType + ";base64," + base64.StdEncoding.EncodeToString(req.Data)
+	payload := map[string]any{
+		"model": e.model,
+		"messages": []map[string]any{
+			{
+				"role": "user",
+				"content": []map[string]any{
+					{"type": "text", "text": e.prompt},
+					{"type": "image_url", "image_url": map[string]any{"url": imageURL}},
+				},
+			},
+		},
+		"temperature": 0,
+		"max_tokens":  e.maxTokens,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+e.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(httpReq)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+	var parsed struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+		Choices []struct {
+			Message struct {
+				Content any `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		if resp.StatusCode >= 300 {
+			return "", fmt.Errorf("vision api status %d: %s", resp.StatusCode, truncateString(string(raw), 256))
+		}
+		return "", fmt.Errorf("decode vision response: %w", err)
+	}
+	if resp.StatusCode >= 300 {
+		if parsed.Error != nil && parsed.Error.Message != "" {
+			return "", fmt.Errorf("vision api status %d: %s", resp.StatusCode, parsed.Error.Message)
+		}
+		return "", fmt.Errorf("vision api status %d", resp.StatusCode)
+	}
+	if len(parsed.Choices) == 0 {
+		return "", fmt.Errorf("vision api returned no choices")
+	}
+	text := extractOpenAIContentText(parsed.Choices[0].Message.Content)
+	if strings.TrimSpace(text) == "" {
+		return "", fmt.Errorf("vision api returned empty text")
+	}
+	return text, nil
+}
+
+func extractOpenAIContentText(content any) string {
+	switch v := content.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, it := range v {
+			m, ok := it.(map[string]any)
+			if !ok {
+				continue
+			}
+			txt, _ := m["text"].(string)
+			if strings.TrimSpace(txt) != "" {
+				parts = append(parts, strings.TrimSpace(txt))
+			}
+		}
+		return strings.TrimSpace(strings.Join(parts, "\n"))
+	default:
+		return ""
+	}
+}
+
+func truncateString(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	return s[:max]
+}

--- a/pkg/backend/image_extract_openai.go
+++ b/pkg/backend/image_extract_openai.go
@@ -46,7 +46,7 @@ func NewOpenAIImageTextExtractor(cfg OpenAIImageTextExtractorConfig) (*OpenAIIma
 	if cfg.Model == "" {
 		return nil, fmt.Errorf("openai extractor model is required")
 	}
-	endpoint := base
+	var endpoint string
 	if strings.HasSuffix(base, "/v1") {
 		endpoint = base + "/chat/completions"
 	} else {

--- a/pkg/backend/image_extract_test.go
+++ b/pkg/backend/image_extract_test.go
@@ -1,0 +1,122 @@
+package backend
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+)
+
+type staticImageExtractor struct {
+	text string
+}
+
+func (e *staticImageExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error) {
+	return e.text, nil
+}
+
+type gatedImageExtractor struct {
+	started chan struct{}
+	release chan struct{}
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (e *gatedImageExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error) {
+	e.mu.Lock()
+	e.calls++
+	call := e.calls
+	e.mu.Unlock()
+	if call == 1 {
+		select {
+		case e.started <- struct{}{}:
+		default:
+		}
+		select {
+		case <-e.release:
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+		return "old caption", nil
+	}
+	return "new caption", nil
+}
+
+func TestAsyncImageExtractUpdatesContentText(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: &staticImageExtractor{text: "cat on sofa screenshot invoice"},
+		},
+	})
+
+	if _, err := b.Write("/img/a.png", []byte("fake-png"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	got := waitForContentText(t, b, "/img/a.png", 2*time.Second)
+	if !strings.Contains(got, "cat on sofa") {
+		t.Fatalf("unexpected extracted text: %q", got)
+	}
+}
+
+func TestAsyncImageExtractSkipsStaleChecksum(t *testing.T) {
+	extractor := &gatedImageExtractor{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	b := newTestBackendWithOptions(t, Options{
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: extractor,
+		},
+	})
+
+	if _, err := b.Write("/img/b.png", []byte("first-image-bytes"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-extractor.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first extraction did not start")
+	}
+
+	if _, err := b.Write("/img/b.png", []byte("second-image-bytes"), 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatal(err)
+	}
+	close(extractor.release)
+
+	got := waitForContentText(t, b, "/img/b.png", 3*time.Second)
+	if got != "new caption" {
+		t.Fatalf("expected final extracted text %q, got %q", "new caption", got)
+	}
+}
+
+func waitForContentText(t *testing.T, b *Dat9Backend, path string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		nf, err := b.store.Stat(backgroundWithTrace(), path)
+		if err == nil && nf.File != nil {
+			if strings.TrimSpace(nf.File.ContentText) != "" {
+				return nf.File.ContentText
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	nf, err := b.store.Stat(backgroundWithTrace(), path)
+	if err != nil || nf.File == nil {
+		t.Fatalf("file not found while waiting for extracted text: path=%s err=%v", path, err)
+	}
+	t.Fatalf("timed out waiting for extracted text, last value=%q", nf.File.ContentText)
+	return ""
+}

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -3,6 +3,9 @@ package backend
 import (
 	"context"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"go.uber.org/zap"
 )
 
 const (
@@ -66,6 +69,8 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		b.imageExtractWG.Add(1)
 		go b.runImageExtractWorker(ctx)
 	}
+	logger.Info(ctx, "backend_image_extract_workers_started",
+		zap.Int("workers", cfg.Workers), zap.Int("queue_size", cfg.QueueSize))
 }
 
 // Close stops background workers owned by this backend instance.
@@ -76,4 +81,5 @@ func (b *Dat9Backend) Close() {
 	b.imageExtractCancel()
 	b.imageExtractWG.Wait()
 	b.imageExtractCancel = nil
+	logger.Info(backgroundWithTrace(), "backend_image_extract_workers_stopped")
 }

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -1,0 +1,79 @@
+package backend
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	defaultImageExtractQueueSize = 128
+	defaultImageExtractWorkers   = 1
+	defaultImageExtractMaxSize   = int64(8 << 20) // 8 MiB
+	defaultImageExtractTimeout   = 20 * time.Second
+	defaultMaxExtractedTextBytes = 8 << 10 // 8 KiB
+)
+
+// Options configures Dat9Backend behavior.
+type Options struct {
+	AsyncImageExtract AsyncImageExtractOptions
+}
+
+// AsyncImageExtractOptions controls async image->text extraction.
+type AsyncImageExtractOptions struct {
+	Enabled             bool
+	QueueSize           int
+	Workers             int
+	MaxImageBytes       int64
+	TaskTimeout         time.Duration
+	MaxExtractTextBytes int
+	Extractor           ImageTextExtractor
+}
+
+func (b *Dat9Backend) configureOptions(opts Options) {
+	cfg := opts.AsyncImageExtract
+	if !cfg.Enabled {
+		return
+	}
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = defaultImageExtractQueueSize
+	}
+	if cfg.Workers <= 0 {
+		cfg.Workers = defaultImageExtractWorkers
+	}
+	if cfg.MaxImageBytes <= 0 {
+		cfg.MaxImageBytes = defaultImageExtractMaxSize
+	}
+	if cfg.TaskTimeout <= 0 {
+		cfg.TaskTimeout = defaultImageExtractTimeout
+	}
+	if cfg.MaxExtractTextBytes <= 0 {
+		cfg.MaxExtractTextBytes = defaultMaxExtractedTextBytes
+	}
+	if cfg.Extractor == nil {
+		cfg.Extractor = NewBasicImageTextExtractor()
+	}
+
+	b.imageExtractEnabled = true
+	b.imageExtractor = cfg.Extractor
+	b.imageExtractTimeout = cfg.TaskTimeout
+	b.imageExtractMaxSize = cfg.MaxImageBytes
+	b.maxExtractTextBytes = cfg.MaxExtractTextBytes
+	b.imageExtractQueue = make(chan imageExtractTask, cfg.QueueSize)
+
+	ctx, cancel := context.WithCancel(backgroundWithTrace())
+	b.imageExtractCancel = cancel
+	for i := 0; i < cfg.Workers; i++ {
+		b.imageExtractWG.Add(1)
+		go b.runImageExtractWorker(ctx)
+	}
+}
+
+// Close stops background workers owned by this backend instance.
+func (b *Dat9Backend) Close() {
+	if b.imageExtractCancel == nil {
+		return
+	}
+	b.imageExtractCancel()
+	b.imageExtractWG.Wait()
+	b.imageExtractCancel = nil
+}

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -256,6 +256,9 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 	if isOverwrite && oldStorageRef != "" {
 		b.deleteBlob(oldStorageRef)
 	}
+
+	b.enqueueImageExtractForUpload(ctx, upload, isOverwrite)
+
 	metrics.RecordOperation("backend", "confirm_upload", "ok", time.Since(start))
 	return nil
 }

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -429,7 +429,7 @@ func (s *Store) GetFile(ctx context.Context, fileID string) (out *File, err erro
 	return out, err
 }
 
-func (s *Store) UpdateFileContent(ctx context.Context, fileID string, storageType StorageType, storageRef, contentType, checksum, contentText string, contentBlob []byte, size int64) (err error) {
+func (s *Store) UpdateFileContent(ctx context.Context, fileID string, storageType StorageType, storageRef, contentType, checksum, contentText string, contentBlob []byte, size int64) (newRevision int64, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "update_file_content", start, &err)
 
@@ -454,13 +454,43 @@ func (s *Store) UpdateFileContent(ctx context.Context, fileID string, storageTyp
 			nullStr(checksum), nullStr(contentText), time.Now().UTC(), fileID)
 	}
 	if err != nil {
-		return err
+		return 0, err
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
-		return ErrNotFound
+		return 0, ErrNotFound
 	}
-	return nil
+	var rev int64
+	if err := s.db.QueryRowContext(ctx, `SELECT revision FROM files WHERE file_id = ?`, fileID).Scan(&rev); err != nil {
+		return 0, fmt.Errorf("read revision after update: %w", err)
+	}
+	return rev, nil
+}
+
+// UpdateFileSearchText updates files.content_text for search enrichment.
+// If expectedChecksum is non-empty, update is applied only when checksum matches.
+// This prevents stale async tasks from overwriting a newer file revision.
+func (s *Store) UpdateFileSearchText(ctx context.Context, fileID string, expectedRevision int64, contentText string) (updated bool, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "update_file_search_text", start, &err)
+
+	var (
+		res sql.Result
+	)
+	if expectedRevision > 0 {
+		res, err = s.db.ExecContext(ctx, `UPDATE files SET content_text = ?
+			WHERE file_id = ? AND status = 'CONFIRMED' AND revision = ?`,
+			nullStr(contentText), fileID, expectedRevision)
+	} else {
+		res, err = s.db.ExecContext(ctx, `UPDATE files SET content_text = ?
+			WHERE file_id = ? AND status = 'CONFIRMED'`,
+			nullStr(contentText), fileID)
+	}
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 func (s *Store) ConfirmFile(ctx context.Context, fileID string) (err error) {

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -302,8 +302,12 @@ func TestUpdateFileContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := s.UpdateFileContent(context.Background(), "f1", StorageDB9, "/blobs/f1-v2", "text/plain", "abc123", "new content", []byte("blob"), 42); err != nil {
+	newRev, err := s.UpdateFileContent(context.Background(), "f1", StorageDB9, "/blobs/f1-v2", "text/plain", "abc123", "new content", []byte("blob"), 42)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if newRev != 2 {
+		t.Errorf("expected newRev=2, got %d", newRev)
 	}
 	got, _ := s.GetFile(context.Background(), "f1")
 	if got.Revision != 2 || got.SizeBytes != 42 || got.ContentText != "new content" {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -27,6 +27,8 @@ type PoolConfig struct {
 	S3Region   string
 	S3Prefix   string
 	S3RoleARN  string
+
+	BackendOptions backend.Options
 }
 
 type Pool struct {
@@ -78,6 +80,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if elem, ok := p.items[t.ID]; ok {
+		b.Close()
 		_ = st.Close()
 		p.order.MoveToFront(elem)
 		return elem.Value.(*entry).backend, nil
@@ -181,7 +184,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			return nil, nil, err
 		}
 		smallInDB := SmallInDB(t.Provider)
-		b, err := backend.NewWithS3Mode(store, s3c, smallInDB)
+		b, err := backend.NewWithS3ModeAndOptions(store, s3c, smallInDB, p.cfg.BackendOptions)
 		if err != nil {
 			_ = store.Close()
 			return nil, nil, err
@@ -197,14 +200,14 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			return nil, nil, err
 		}
 		smallInDB := SmallInDB(t.Provider)
-		b, err := backend.NewWithS3Mode(store, s3c, smallInDB)
+		b, err := backend.NewWithS3ModeAndOptions(store, s3c, smallInDB, p.cfg.BackendOptions)
 		if err != nil {
 			_ = store.Close()
 			return nil, nil, err
 		}
 		return b, store, nil
 	}
-	b, err := backend.New(store)
+	b, err := backend.NewWithOptions(store, p.cfg.BackendOptions)
 	if err != nil {
 		_ = store.Close()
 		return nil, nil, err
@@ -216,6 +219,9 @@ func (p *Pool) removeLocked(elem *list.Element) {
 	e := elem.Value.(*entry)
 	p.order.Remove(elem)
 	delete(p.items, e.tenantID)
+	if e.backend != nil {
+		e.backend.Close()
+	}
 	if e.store != nil {
 		_ = e.store.Close()
 	}


### PR DESCRIPTION
## Summary

Add background workers that extract text from uploaded images, making them searchable via `dat9 fs grep`.

## How it works

```
upload image → enqueue async task → worker reads image →
extract text (basic metadata or OpenAI vision API) →
update files.content_text → TiDB auto-embedding makes it vector-searchable
```

## Files

| File | Description |
|---|---|
| `pkg/backend/options.go` | Options struct, configureOptions, Close |
| `pkg/backend/image_extract.go` | Interface, enqueue, worker, processTask, extension fallback |
| `pkg/backend/image_extract_basic.go` | Basic metadata extractor + fallback wrapper |
| `pkg/backend/image_extract_openai.go` | OpenAI-compatible vision API extractor (1MB response cap) |
| `pkg/backend/image_extract_test.go` | Integration tests (happy path + stale revision race) |
| `pkg/backend/dat9.go` | Enqueue after create/overwrite, revision from UpdateFileContent |
| `pkg/backend/upload.go` | Enqueue after multipart ConfirmUpload |
| `pkg/datastore/store.go` | UpdateFileContent returns new revision; UpdateFileSearchText with revision guard |
| `pkg/tenant/pool.go` | BackendOptions, b.Close() in race loser + eviction |
| `cmd/dat9-server/main.go` | buildBackendOptionsFromEnv |

## Safety

- **Revision guard**: `WHERE revision=?` prevents stale async tasks from overwriting newer content
- **UpdateFileContent** returns actual new revision (SELECT after UPDATE) — no concurrent overwrite race
- **Pool race**: loser branch calls `b.Close()` before `st.Close()` to prevent leaked workers
- **Multipart**: `contentTypeFromPath` extension fallback when content_type is empty
- **Queue full**: drops task with warning log (best-effort enrichment)
- **OpenAI response**: capped at 1MB via `io.LimitReader`

## Config

| Variable | Description | Default |
|---|---|---|
| `DAT9_IMAGE_EXTRACT_ENABLED` | Enable/disable | `true` |
| `DAT9_IMAGE_EXTRACT_QUEUE_SIZE` | Queue size | `128` |
| `DAT9_IMAGE_EXTRACT_WORKERS` | Worker count | `1` |
| `DAT9_IMAGE_EXTRACT_MAX_BYTES` | Max image size | `8MB` |
| `DAT9_IMAGE_EXTRACT_TIMEOUT_SECONDS` | Task timeout | `20` |
| `DAT9_IMAGE_EXTRACT_API_BASE` | Vision API URL | (optional) |
| `DAT9_IMAGE_EXTRACT_API_KEY` | Vision API key | (optional) |
| `DAT9_IMAGE_EXTRACT_MODEL` | Vision model | (optional) |

## Review

4 rounds of cross-model review (Claude Code + Codex). All blockers resolved:
- Pool race loser leak (Codex)
- Multipart confirm missing enqueue (Codex)
- Checksum→revision guard (Codex)
- UpdateFileContent returns actual revision (Codex)
- SELECT revision error propagated (Codex)
- OpenAI response cap (Claude Code)
- Extension-based content_type fallback (Codex)