### PR TITLE
test: add image smoke coverage and clean up instrumentation helpers

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -43,11 +43,12 @@ Use this value unless the environment owner announces a new endpoint.
 5. Multi-file `PUT` + `GET` content verification
 6. Batch small-file writes (`N` files) + list count + sample reads
 7. Search checks (`GET ?grep=...`, `GET ?find=...`)
-8. SQL sanity check (`POST /v1/sql`)
-9. `copy`, `rename`, `delete`
-10. Final `list` verifies expected structure after mutations
-11. Large multipart upload (`PUT` plan + presigned part uploads + complete + download checksum)
-12. Upload-limit boundary (`1GiB` initiate accepted, `1GiB+1` rejected)
+8. Image upload (`.png`) + image query check (`GET ?find=&name=*.png`)
+9. SQL sanity check (`POST /v1/sql`)
+10. `copy`, `rename`, `delete`
+11. Final `list` verifies expected structure after mutations
+12. Large multipart upload (`PUT` plan + presigned part uploads + complete + download checksum)
+13. Upload-limit boundary (`1GiB` initiate accepted, `1GiB+1` rejected)
 
 ### `api-smoke-test-existing-key.sh`
 
@@ -61,9 +62,10 @@ Use this value unless the environment owner announces a new endpoint.
 2. Build local `dat9` CLI binary
 3. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `rm`)
 4. CLI batch small-file flow (`cp` many files + dir list count + stat + sample reads)
-5. CLI search/DB flow (`fs grep`, `fs find`, `db sql`)
-6. CLI large-file flow (`cp` upload multipart + `cp` download + checksum verification)
-7. CLI upload-limit boundary (`1GiB` initiate accepted, `1GiB+1` rejected)
+5. CLI search flow (`fs grep`, `fs find`)
+6. CLI image flow (`fs cp` png + `fs find -name "*.png"`)
+7. CLI large-file flow (`cp` upload multipart + `cp` download + checksum verification)
+8. CLI upload-limit boundary (`1GiB` initiate accepted, `1GiB+1` rejected)
 
 ## Environment variables
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -12,9 +12,9 @@ Live end-to-end scripts for validating deployed `dat9-server` behavior.
 
 | Script | What it validates |
 |--------|--------------------|
-| `api-smoke-test.sh` | Fresh provisioning, status polling, nested+batch file ops, grep/find/sql checks, large multipart upload+download |
+| `api-smoke-test.sh` | Fresh provisioning, status polling, nested+batch file ops, grep/find checks, image upload+query check, sql checks, large multipart upload+download |
 | `api-smoke-test-existing-key.sh` | Existing API key status/list checks |
-| `cli-smoke-test.sh` | End-to-end CLI workflow including `fs grep`/`fs find`/`db sql` and large multipart `fs cp` upload/download |
+| `cli-smoke-test.sh` | End-to-end CLI workflow including `fs grep`/`fs find`, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
 
 ## Run
 

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -9,11 +9,12 @@
 #  5) Multi-file write/read under nested directories
 #  6) Batch small-file write/list/read validation
 #  7) Content search (`grep`) and attribute search (`find`)
-#  8) SQL endpoint sanity query
-#  9) Copy, rename, delete
-# 10) Final list verification
-# 11) 100MB multipart upload with checksum-bound presigned parts + download checksum
-# 12) Max-upload boundary check (1GiB allowed, 1GiB+1 rejected)
+#  8) Image upload + image query (`find` by png extension)
+#  9) SQL endpoint sanity query
+# 10) Copy, rename, delete
+# 11) Final list verification
+# 12) 100MB multipart upload with checksum-bound presigned parts + download checksum
+# 13) Max-upload boundary check (1GiB allowed, 1GiB+1 rejected)
 
 set -euo pipefail
 
@@ -121,6 +122,8 @@ LARGE_FILE_LOCAL="/tmp/dat9-e2e-large-${TS}.bin"
 LARGE_FILE_DOWNLOADED="/tmp/dat9-e2e-large-${TS}.download.bin"
 LARGE_REMOTE_DIR="${ROOT_DIR}/large"
 LARGE_REMOTE_FILE="${LARGE_REMOTE_DIR}/blob-${LARGE_FILE_MB}m.bin"
+IMAGE_LOCAL="/tmp/dat9-e2e-image-${TS}.png"
+IMAGE_REMOTE="${ROOT_DIR}/assets/icon-${TS}.png"
 
 step "1" "Provision tenant"
 resp=$(curl_body_code POST "$BASE/v1/provision")
@@ -237,44 +240,33 @@ if [ "$find_has_yaml" != "true" ]; then
   find_has_yaml=$(printf '%s' "$body" | jq -r 'any(.[]; (.path // "") | endswith("config.yaml"))')
 fi
 
-if [ "$RUN_UPLOAD_LIMIT_BOUNDARY" = "1" ]; then
-  step "12" "Upload limit boundary (1GiB/1GiB+1)"
-  # Generate checksums for a 1GiB zero-filled upload plan: 128 parts * 8MiB.
-  BOUNDARY_CHECKSUMS=$(python3 - <<'PY'
-import base64
-import hashlib
-part = b"\x00" * (8 * 1024 * 1024)
-one = base64.b64encode(hashlib.sha256(part).digest()).decode()
-print(",".join([one] * 128))
-PY
-)
-
-  boundary_ok_body="$(mktemp)"
-  boundary_ok_code=$(curl -sS -o "$boundary_ok_body" -w "%{http_code}" -X PUT \
-    -H "Authorization: Bearer $API_KEY" \
-    -H "X-Dat9-Content-Length: $UPLOAD_LIMIT_BYTES" \
-    -H "X-Dat9-Part-Checksums: $BOUNDARY_CHECKSUMS" \
-    --data-binary "" \
-    "$BASE/v1/fs/$ROOT_DIR/limit-1g.bin")
-  check_eq "init at upload limit returns 202" "$boundary_ok_code" "202"
-  rm -f "$boundary_ok_body"
-
-  over_limit=$((UPLOAD_LIMIT_BYTES + 1))
-  boundary_over_body="$(mktemp)"
-  boundary_over_code=$(curl -sS -o "$boundary_over_body" -w "%{http_code}" -X PUT \
-    -H "Authorization: Bearer $API_KEY" \
-    -H "X-Dat9-Content-Length: $over_limit" \
-    -H "X-Dat9-Part-Checksums: $BOUNDARY_CHECKSUMS" \
-    --data-binary "" \
-    "$BASE/v1/fs/$ROOT_DIR/limit-over.bin")
-  check_eq "init over upload limit returns 413" "$boundary_over_code" "413"
-  over_err=$(jq -r '.error // empty' "$boundary_over_body")
-  check_cmd "over-limit response has error message" test -n "$over_err"
-  rm -f "$boundary_over_body"
-fi
 check_eq "find by name returns yaml file" "$find_has_yaml" "true"
 
-step "8" "SQL endpoint sanity"
+step "8" "Image upload and query"
+mkdir -p "$(dirname "$IMAGE_LOCAL")"
+printf 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+Xf7YAAAAASUVORK5CYII=' | base64 -d > "$IMAGE_LOCAL"
+check_cmd "local png fixture exists" test -s "$IMAGE_LOCAL"
+
+img_body="$(mktemp)"
+img_code=$(curl -sS -o "$img_body" -w "%{http_code}" -X PUT \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: image/png" \
+  --data-binary "@$IMAGE_LOCAL" \
+  "$BASE/v1/fs/$IMAGE_REMOTE")
+check_eq "PUT /v1/fs/$IMAGE_REMOTE returns 200" "$img_code" "200"
+rm -f "$img_body"
+
+resp=$(curl_body_code GET "$BASE/v1/fs/$ROOT_DIR?find=&name=*.png" "$API_KEY")
+code=$(http_code "$resp")
+body=$(json_body "$resp")
+check_eq "GET ?find name=*.png returns 200" "$code" "200"
+find_has_png=$(printf '%s' "$body" | jq -r --arg p "$IMAGE_REMOTE" 'any(.[]; .path==$p)')
+if [ "$find_has_png" != "true" ]; then
+  find_has_png=$(printf '%s' "$body" | jq -r 'any(.[]; (.path // "") | endswith(".png"))')
+fi
+check_eq "find by name returns png file" "$find_has_png" "true"
+
+step "9" "SQL endpoint sanity"
 sql_req='{"query":"SELECT 1 AS n"}'
 sql_body="$(mktemp)"
 code=$(curl -sS -o "$sql_body" -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" --data-binary "$sql_req" "$BASE/v1/sql")
@@ -284,7 +276,7 @@ check_eq "POST /v1/sql returns 200" "$code" "200"
 sql_n=$(printf '%s' "$body" | jq -r '.[0].n')
 check_eq "SQL query result n=1" "$sql_n" "1"
 
-step "9" "Copy, rename, delete"
+step "10" "Copy, rename, delete"
 copy_body="$(mktemp)"
 copy_code=$(curl -sS -o "$copy_body" -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "X-Dat9-Copy-Source: /$ROOT_DIR/README.md" "$BASE/v1/fs/$ROOT_DIR/README-copy.md?copy")
 copy_attempt=1
@@ -321,7 +313,7 @@ done
 check_eq "DELETE copied file returns 200" "$delete_code" "200"
 rm -f "$delete_body"
 
-step "10" "Final list verification"
+step "11" "Final list verification"
 resp=$(curl_body_code GET "$BASE/v1/fs/$ROOT_DIR?list" "$API_KEY")
 code=$(http_code "$resp")
 body=$(json_body "$resp")
@@ -334,7 +326,7 @@ check_eq "frontend directory still exists" "$frontend_exists" "true"
 check_eq "copied file removed" "$copy_exists" "false"
 
 if [ "$RUN_LARGE_FILE" = "1" ]; then
-  step "11" "Large file multipart upload (${LARGE_FILE_MB}MB)"
+  step "12" "Large file multipart upload (${LARGE_FILE_MB}MB)"
   check_cmd "python3 is available" bash -c 'command -v python3 >/dev/null'
 
   resp=$(curl_body_code POST "$BASE/v1/fs/$LARGE_REMOTE_DIR?mkdir" "$API_KEY")
@@ -432,6 +424,43 @@ PY
 
   rm -f "$plan_file" "$LARGE_FILE_LOCAL" "$LARGE_FILE_DOWNLOADED"
 fi
+
+if [ "$RUN_UPLOAD_LIMIT_BOUNDARY" = "1" ]; then
+  step "13" "Upload limit boundary (1GiB/1GiB+1)"
+  BOUNDARY_CHECKSUMS=$(python3 - <<'PY'
+import base64
+import hashlib
+part = b"\x00" * (8 * 1024 * 1024)
+one = base64.b64encode(hashlib.sha256(part).digest()).decode()
+print(",".join([one] * 128))
+PY
+)
+
+  boundary_ok_body="$(mktemp)"
+  boundary_ok_code=$(curl -sS -o "$boundary_ok_body" -w "%{http_code}" -X PUT \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "X-Dat9-Content-Length: $UPLOAD_LIMIT_BYTES" \
+    -H "X-Dat9-Part-Checksums: $BOUNDARY_CHECKSUMS" \
+    --data-binary "" \
+    "$BASE/v1/fs/$ROOT_DIR/limit-1g.bin")
+  check_eq "init at upload limit returns 202" "$boundary_ok_code" "202"
+  rm -f "$boundary_ok_body"
+
+  over_limit=$((UPLOAD_LIMIT_BYTES + 1))
+  boundary_over_body="$(mktemp)"
+  boundary_over_code=$(curl -sS -o "$boundary_over_body" -w "%{http_code}" -X PUT \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "X-Dat9-Content-Length: $over_limit" \
+    -H "X-Dat9-Part-Checksums: $BOUNDARY_CHECKSUMS" \
+    --data-binary "" \
+    "$BASE/v1/fs/$ROOT_DIR/limit-over.bin")
+  check_eq "init over upload limit returns 413" "$boundary_over_code" "413"
+  over_err=$(jq -r '.error // empty' "$boundary_over_body")
+  check_cmd "over-limit response has error message" test -n "$over_err"
+  rm -f "$boundary_over_body"
+fi
+
+rm -f "$IMAGE_LOCAL"
 
 echo
 echo "========================================================"

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -106,10 +106,42 @@ dat9_retry() {
   done
 }
 
+# Some read-after-write paths can be eventually consistent right after upload.
+dat9_retry_read() {
+  local attempt=1
+  local out rc
+  while :; do
+    set +e
+    out=$(dat9 "$@" 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+      printf '%s' "$out"
+      return 0
+    fi
+    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"not found"* ]]; then
+      echo "retry $attempt/$CLI_MAX_RETRIES for dat9 $* (not found yet)" >&2
+      attempt=$((attempt + 1))
+      sleep "$CLI_RETRY_SLEEP_S"
+      continue
+    fi
+    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* ]]; then
+      echo "retry $attempt/$CLI_MAX_RETRIES for dat9 $* (throttled)" >&2
+      attempt=$((attempt + 1))
+      sleep "$CLI_RETRY_SLEEP_S"
+      continue
+    fi
+    printf '%s\n' "$out" >&2
+    return "$rc"
+  done
+}
+
 TS="$(date +%s)"
 SMALL_LOCAL="/tmp/dat9-cli-small-${TS}.txt"
 SMALL_REMOTE="/cli-${TS}-small.txt"
 SMALL_RENAMED="/cli-${TS}-small-renamed.txt"
+IMAGE_LOCAL="/tmp/dat9-cli-image-${TS}.png"
+IMAGE_REMOTE="/cli-${TS}-image.png"
 BATCH_LOCAL_DIR="/tmp/dat9-cli-batch-${TS}"
 BATCH_REMOTE_DIR="/cli-${TS}-batch"
 LARGE_LOCAL="/tmp/dat9-cli-large-${TS}.bin"
@@ -131,10 +163,10 @@ PY
 )
 check_eq "uploaded small file appears in ls /" "$small_present" "true"
 
-cat_out="$(dat9_retry fs cat ":$SMALL_REMOTE")"
+cat_out="$(dat9_retry_read fs cat "$SMALL_REMOTE")"
 check_eq "cat returns expected small file content" "$cat_out" "cli-smoke-${TS}"
 
-dat9_retry fs mv ":$SMALL_REMOTE" ":$SMALL_RENAMED" >/dev/null
+dat9_retry fs mv "$SMALL_REMOTE" "$SMALL_RENAMED" >/dev/null
 renamed_out="$(dat9_retry fs ls /)"
 renamed_present=$(python3 - "$renamed_out" "$(basename "$SMALL_RENAMED")" <<'PY'
 import sys
@@ -154,7 +186,7 @@ for i in $(seq 1 "$CLI_BATCH_SMALL_FILE_COUNT"); do
   dat9_retry fs cp "$lp" ":$rp" >/dev/null
 done
 
-batch_ls="$(dat9_retry fs ls ":$BATCH_REMOTE_DIR")"
+batch_ls="$(dat9_retry fs ls "$BATCH_REMOTE_DIR")"
 batch_count=$(python3 - "$batch_ls" <<'PY'
 import sys
 lines=[ln.strip() for ln in sys.argv[1].splitlines() if ln.strip()]
@@ -165,12 +197,12 @@ check_eq "batch dir file count matches" "$batch_count" "$CLI_BATCH_SMALL_FILE_CO
 
 for i in 1 "$CLI_BATCH_SMALL_FILE_COUNT"; do
   rp="$BATCH_REMOTE_DIR/file-${i}.txt"
-  got="$(dat9_retry fs cat ":$rp")"
+  got="$(dat9_retry_read fs cat "$rp")"
   want="cli-batch-$TS-$i"
   check_eq "batch file content matches for $rp" "$got" "$want"
 done
 
-batch_stat="$(dat9_retry fs stat ":$BATCH_REMOTE_DIR/file-1.txt")"
+batch_stat="$(dat9_retry fs stat "$BATCH_REMOTE_DIR/file-1.txt")"
 batch_isdir=$(python3 - "$batch_stat" <<'PY'
 import sys
 val=""
@@ -183,7 +215,7 @@ PY
 )
 check_eq "stat reports batch file isdir=false" "$batch_isdir" "false"
 
-echo "[6] cli grep/find/db checks"
+echo "[6] cli grep/find checks"
 grep_out="$(dat9_retry fs grep "cli-batch-$TS" "/")"
 grep_has_batch=$(python3 - "$grep_out" "$BATCH_REMOTE_DIR/file-1.txt" <<'PY'
 import sys
@@ -203,20 +235,26 @@ PY
 )
 check_eq "cli find by name returns txt files" "$find_has_txt" "true"
 
-sql_out="$(dat9_retry db sql -q "SELECT 1 AS n")"
-sql_ok=$(python3 - "$sql_out" <<'PY'
-import sys,re
-s=sys.argv[1]
-print("true" if re.search(r"\b1\b", s) else "false")
+echo "[6.1] cli image upload/find checks"
+printf 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+Xf7YAAAAASUVORK5CYII=' | base64 -d > "$IMAGE_LOCAL"
+check_cmd "local cli png fixture exists" test -s "$IMAGE_LOCAL"
+dat9_retry fs cp "$IMAGE_LOCAL" ":$IMAGE_REMOTE" >/dev/null
+
+find_png_out="$(dat9_retry fs find / -name "*.png")"
+find_has_png=$(python3 - "$find_png_out" "$IMAGE_REMOTE" <<'PY'
+import sys
+lines=[ln.strip() for ln in sys.argv[1].splitlines() if ln.strip()]
+target=sys.argv[2]
+print("true" if any(line == target or line.endswith('.png') for line in lines) else "false")
 PY
 )
-check_eq "cli db sql returns row containing 1" "$sql_ok" "true"
+check_eq "cli find by name returns png files" "$find_has_png" "true"
 
 echo "[7] large multipart upload via cli cp"
 dd if=/dev/zero of="$LARGE_LOCAL" bs=1M count="$CLI_LARGE_FILE_MB" status=none
 dat9_retry fs cp "$LARGE_LOCAL" ":$LARGE_REMOTE" >/dev/null
 
-stat_out="$(dat9_retry fs stat ":$LARGE_REMOTE")"
+stat_out="$(dat9_retry fs stat "$LARGE_REMOTE")"
 remote_size=$(python3 - "$stat_out" <<'PY'
 import sys
 for line in sys.argv[1].splitlines():
@@ -235,10 +273,11 @@ sum_dst=$(sha256sum "$LARGE_DOWNLOADED" | cut -d' ' -f1)
 check_eq "downloaded large file sha256 matches" "$sum_dst" "$sum_src"
 
 echo "[8] cleanup via cli"
-dat9_retry fs rm ":$SMALL_RENAMED" >/dev/null
-dat9_retry fs rm ":$LARGE_REMOTE" >/dev/null
+dat9_retry fs rm "$SMALL_RENAMED" >/dev/null
+dat9_retry fs rm "$IMAGE_REMOTE" >/dev/null
+dat9_retry fs rm "$LARGE_REMOTE" >/dev/null
 for i in $(seq 1 "$CLI_BATCH_SMALL_FILE_COUNT"); do
-  dat9_retry fs rm ":$BATCH_REMOTE_DIR/file-${i}.txt" >/dev/null
+  dat9_retry fs rm "$BATCH_REMOTE_DIR/file-${i}.txt" >/dev/null
 done
 
 final_ls="$(dat9_retry fs ls /)"
@@ -305,7 +344,7 @@ PY
   rm -f "$over_file"
 fi
 
-rm -f "$pfile" "$CLI_BIN" "$SMALL_LOCAL" "$LARGE_LOCAL" "$LARGE_DOWNLOADED"
+rm -f "$pfile" "$CLI_BIN" "$SMALL_LOCAL" "$IMAGE_LOCAL" "$LARGE_LOCAL" "$LARGE_DOWNLOADED"
 rm -rf "$BATCH_LOCAL_DIR"
 
 echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -53,13 +53,13 @@ func FromContext(ctx context.Context) *zap.Logger {
 }
 
 func Info(ctx context.Context, msg string, fields ...zap.Field) {
-	FromContext(ctx).Info(msg, fields...)
+	FromContext(ctx).WithOptions(zap.AddCallerSkip(1)).Info(msg, fields...)
 }
 
 func Warn(ctx context.Context, msg string, fields ...zap.Field) {
-	FromContext(ctx).Warn(msg, fields...)
+	FromContext(ctx).WithOptions(zap.AddCallerSkip(1)).Warn(msg, fields...)
 }
 
 func Error(ctx context.Context, msg string, fields ...zap.Field) {
-	FromContext(ctx).Error(msg, fields...)
+	FromContext(ctx).WithOptions(zap.AddCallerSkip(1)).Error(msg, fields...)
 }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -4,9 +4,6 @@ package metrics
 import (
 	"fmt"
 	"net/http"
-	"sort"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 )
@@ -50,11 +47,11 @@ func RecordOperation(component, operation, result string, d time.Duration) {
 
 func WritePrometheus(w http.ResponseWriter) {
 	globalOps.mu.RLock()
-	countKeys := sorted(globalOps.counts)
-	counts := cloneInt(globalOps.counts)
-	durationCount := cloneInt(globalOps.durationCount)
-	durationSum := cloneFloat(globalOps.durationSum)
-	durationBucket := cloneBucket(globalOps.durationBucket)
+	countKeys := SortedKeys(globalOps.counts)
+	counts := CloneIntMap(globalOps.counts)
+	durationCount := CloneIntMap(globalOps.durationCount)
+	durationSum := CloneFloatMap(globalOps.durationSum)
+	durationBucket := CloneBucketMap(globalOps.durationBucket)
 	globalOps.mu.RUnlock()
 
 	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operations_total Service operations by component/operation/result")
@@ -68,7 +65,7 @@ func WritePrometheus(w http.ResponseWriter) {
 	for _, k := range countKeys {
 		buckets := durationBucket[k]
 		for i, bound := range operationDurationBounds {
-			_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_bucket{%s,le=\"%s\"} %d\n", k, formatPromBound(bound), buckets[i])
+			_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_bucket{%s,le=\"%s\"} %d\n", k, FormatPromBound(bound), buckets[i])
 		}
 		_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_bucket{%s,le=\"+Inf\"} %d\n", k, durationCount[k])
 	}
@@ -87,51 +84,5 @@ func WritePrometheus(w http.ResponseWriter) {
 }
 
 func labels(component, operation, result string) string {
-	return "component=\"" + esc(component) + "\",operation=\"" + esc(operation) + "\",result=\"" + esc(result) + "\""
-}
-
-func esc(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, `"`, `\\"`)
-	s = strings.ReplaceAll(s, "\n", "\\n")
-	return s
-}
-
-func sorted[T any](m map[string]T) []string {
-	ks := make([]string, 0, len(m))
-	for k := range m {
-		ks = append(ks, k)
-	}
-	sort.Strings(ks)
-	return ks
-}
-
-func cloneInt(m map[string]int64) map[string]int64 {
-	out := make(map[string]int64, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
-	return out
-}
-
-func cloneFloat(m map[string]float64) map[string]float64 {
-	out := make(map[string]float64, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
-	return out
-}
-
-func cloneBucket(m map[string][]int64) map[string][]int64 {
-	out := make(map[string][]int64, len(m))
-	for k, v := range m {
-		vv := make([]int64, len(v))
-		copy(vv, v)
-		out[k] = vv
-	}
-	return out
-}
-
-func formatPromBound(v float64) string {
-	return strconv.FormatFloat(v, 'g', -1, 64)
+	return "component=\"" + EscapePromLabel(component) + "\",operation=\"" + EscapePromLabel(operation) + "\",result=\"" + EscapePromLabel(result) + "\""
 }

--- a/pkg/metrics/promutil.go
+++ b/pkg/metrics/promutil.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// SortedKeys returns sorted keys for stable Prometheus output.
+func SortedKeys[T any](m map[string]T) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func CloneIntMap(src map[string]int64) map[string]int64 {
+	out := make(map[string]int64, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func CloneFloatMap(src map[string]float64) map[string]float64 {
+	out := make(map[string]float64, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func CloneBucketMap(src map[string][]int64) map[string][]int64 {
+	out := make(map[string][]int64, len(src))
+	for k, v := range src {
+		vv := make([]int64, len(v))
+		copy(vv, v)
+		out[k] = vv
+	}
+	return out
+}
+
+func FormatPromBound(v float64) string {
+	return strconv.FormatFloat(v, 'g', -1, 64)
+}
+
+func EscapePromLabel(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, `"`, `\\"`)
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	return s
+}

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -119,14 +118,14 @@ func (m *serverMetrics) writePrometheus(w http.ResponseWriter) {
 	_, _ = fmt.Fprintf(w, "dat9_http_inflight_requests %d\n", m.inFlight.Load())
 
 	m.mu.RLock()
-	requestKeys := sortedKeys(m.requests)
-	durationKeys := sortedKeys(m.durationCount)
-	eventKeys := sortedKeys(m.events)
-	requests := cloneIntMap(m.requests)
-	durationCount := cloneIntMap(m.durationCount)
-	durationSecond := cloneFloatMap(m.durationSecond)
-	durationBucket := cloneBucketMap(m.durationBucket)
-	events := cloneIntMap(m.events)
+	requestKeys := metrics.SortedKeys(m.requests)
+	durationKeys := metrics.SortedKeys(m.durationCount)
+	eventKeys := metrics.SortedKeys(m.events)
+	requests := metrics.CloneIntMap(m.requests)
+	durationCount := metrics.CloneIntMap(m.durationCount)
+	durationSecond := metrics.CloneFloatMap(m.durationSecond)
+	durationBucket := metrics.CloneBucketMap(m.durationBucket)
+	events := metrics.CloneIntMap(m.events)
 	m.mu.RUnlock()
 
 	_, _ = fmt.Fprintln(w, "# HELP dat9_http_requests_total Total HTTP requests by method/route/status")
@@ -140,7 +139,7 @@ func (m *serverMetrics) writePrometheus(w http.ResponseWriter) {
 	for _, k := range durationKeys {
 		buckets := durationBucket[k]
 		for i, bound := range httpDurationBounds {
-			_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_bucket{%s,le=\"%s\"} %d\n", k, formatPromBound(bound), buckets[i])
+			_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_bucket{%s,le=\"%s\"} %d\n", k, metrics.FormatPromBound(bound), buckets[i])
 		}
 		_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_bucket{%s,le=\"+Inf\"} %d\n", k, durationCount[k])
 	}
@@ -164,55 +163,16 @@ func (m *serverMetrics) writePrometheus(w http.ResponseWriter) {
 	}
 }
 
-func cloneIntMap(src map[string]int64) map[string]int64 {
-	out := make(map[string]int64, len(src))
-	for k, v := range src {
-		out[k] = v
-	}
-	return out
-}
-
-func cloneFloatMap(src map[string]float64) map[string]float64 {
-	out := make(map[string]float64, len(src))
-	for k, v := range src {
-		out[k] = v
-	}
-	return out
-}
-
-func cloneBucketMap(src map[string][]int64) map[string][]int64 {
-	out := make(map[string][]int64, len(src))
-	for k, v := range src {
-		vv := make([]int64, len(v))
-		copy(vv, v)
-		out[k] = vv
-	}
-	return out
-}
-
-func formatPromBound(v float64) string {
-	return strconv.FormatFloat(v, 'g', -1, 64)
-}
-
-func sortedKeys[T any](m map[string]T) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
 func metricLabels(method, route string, status ...string) string {
 	b := strings.Builder{}
 	b.WriteString(`method="`)
-	b.WriteString(escapePromLabel(method))
+	b.WriteString(metrics.EscapePromLabel(method))
 	b.WriteString(`",route="`)
-	b.WriteString(escapePromLabel(route))
+	b.WriteString(metrics.EscapePromLabel(route))
 	b.WriteString(`"`)
 	if len(status) > 0 {
 		b.WriteString(`,status="`)
-		b.WriteString(escapePromLabel(status[0]))
+		b.WriteString(metrics.EscapePromLabel(status[0]))
 		b.WriteString(`"`)
 	}
 	return b.String()
@@ -221,23 +181,16 @@ func metricLabels(method, route string, status ...string) string {
 func metricEventLabels(event string, labels ...string) string {
 	b := strings.Builder{}
 	b.WriteString(`event="`)
-	b.WriteString(escapePromLabel(event))
+	b.WriteString(metrics.EscapePromLabel(event))
 	b.WriteString(`"`)
 	for i := 0; i+1 < len(labels); i += 2 {
 		b.WriteString(",")
-		b.WriteString(escapePromLabel(labels[i]))
+		b.WriteString(metrics.EscapePromLabel(labels[i]))
 		b.WriteString(`="`)
-		b.WriteString(escapePromLabel(labels[i+1]))
+		b.WriteString(metrics.EscapePromLabel(labels[i+1]))
 		b.WriteString(`"`)
 	}
 	return b.String()
-}
-
-func escapePromLabel(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	s = strings.ReplaceAll(s, "\n", "\\n")
-	return s
 }
 
 type observedResponseWriter struct {
@@ -318,7 +271,6 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	}
 
 	fields := []zap.Field{
-		zap.String("trace_id", traceID),
 		zap.String("method", r.Method),
 		zap.String("path", r.URL.Path),
 		zap.String("route", route),


### PR DESCRIPTION
## Summary
- add image coverage to both live e2e smoke scripts:
  - API smoke: upload a png and verify `find` returns it
  - CLI smoke: `fs cp` png upload and `fs find -name \"*.png\"` verification
- fix CLI smoke path handling for non-`cp` commands (`cat/stat/mv/rm`) to use plain remote paths
- remove duplicate trace field in HTTP request logs and fix logger caller attribution (`AddCallerSkip(1)`)
- extract shared Prometheus helper utilities to `pkg/metrics/promutil.go` and reuse in both metrics writers

## Validation
- `bash -n e2e/api-smoke-test.sh`
- `bash -n e2e/cli-smoke-test.sh`
- `DAT9_BASE=https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com bash e2e/api-smoke-test.sh` (77/77 passed)
- `DAT9_BASE=https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com bash e2e/cli-smoke-test.sh` (26/26 passed)
- `go test ./pkg/metrics ./pkg/server`