### PR TITLE
feat: improve observability across image extract and search chains

### DIFF
--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -252,6 +252,10 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 	configured := baseURL != "" || apiKey != "" || model != ""
 	if configured {
 		if baseURL == "" || apiKey == "" || model == "" {
+			logger.Error(context.Background(), "image_extract_mode_invalid_config",
+				zap.Bool("base_url_present", baseURL != ""),
+				zap.Bool("api_key_present", apiKey != ""),
+				zap.Bool("model_present", model != ""))
 			return backend.Options{}, fmt.Errorf("DAT9_IMAGE_EXTRACT_API_BASE, DAT9_IMAGE_EXTRACT_API_KEY and DAT9_IMAGE_EXTRACT_MODEL must be set together")
 		}
 		extractor, err := backend.NewOpenAIImageTextExtractor(backend.OpenAIImageTextExtractorConfig{

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -59,11 +59,19 @@ func contentTypeFromPath(path string) string {
 
 func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revision int64) {
 	if !b.imageExtractEnabled || b.imageExtractor == nil {
+		logger.Info(backgroundWithTrace(), "backend_image_extract_enqueue_skipped",
+			zap.String("file_id", fileID),
+			zap.String("path", path),
+			zap.String("reason", "disabled_or_extractor_missing"))
 		return
 	}
 	if !isImageContentType(contentType) {
 		contentType = contentTypeFromPath(path)
 		if !isImageContentType(contentType) {
+			logger.Info(backgroundWithTrace(), "backend_image_extract_enqueue_skipped",
+				zap.String("file_id", fileID),
+				zap.String("path", path),
+				zap.String("reason", "not_image"))
 			return
 		}
 	}
@@ -76,6 +84,13 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 	select {
 	case b.imageExtractQueue <- task:
 		metrics.RecordOperation("image_extract", "enqueue", "ok", 0)
+		logger.Info(backgroundWithTrace(), "backend_image_extract_enqueued",
+			zap.String("file_id", fileID),
+			zap.String("path", path),
+			zap.String("content_type", contentType),
+			zap.Int64("revision", revision),
+			zap.Int("queue_depth", len(b.imageExtractQueue)),
+			zap.Int("queue_size", cap(b.imageExtractQueue)))
 	default:
 		metrics.RecordOperation("image_extract", "enqueue", "queue_full", 0)
 		logger.Warn(backgroundWithTrace(), "backend_image_extract_queue_full_drop",
@@ -87,32 +102,55 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 
 func (b *Dat9Backend) enqueueImageExtractForUpload(ctx context.Context, upload *datastore.Upload, isOverwrite bool) {
 	if !b.imageExtractEnabled || b.imageExtractor == nil {
+		logger.Info(ctx, "backend_image_extract_upload_enqueue_skipped",
+			zap.String("upload_id", upload.UploadID),
+			zap.String("path", upload.TargetPath),
+			zap.Bool("is_overwrite", isOverwrite),
+			zap.String("reason", "disabled_or_extractor_missing"))
 		return
 	}
 	fileID := upload.FileID
 	if isOverwrite {
 		nf, err := b.store.Stat(ctx, upload.TargetPath)
 		if err != nil || nf.File == nil {
+			logger.Warn(ctx, "backend_image_extract_upload_enqueue_stat_failed",
+				zap.String("upload_id", upload.UploadID),
+				zap.String("path", upload.TargetPath),
+				zap.Error(err))
 			return
 		}
 		fileID = nf.File.FileID
 	}
 	f, err := b.store.GetFile(ctx, fileID)
 	if err != nil {
+		logger.Warn(ctx, "backend_image_extract_upload_enqueue_get_file_failed",
+			zap.String("upload_id", upload.UploadID),
+			zap.String("file_id", fileID),
+			zap.String("path", upload.TargetPath),
+			zap.Error(err))
 		return
 	}
 	ct := f.ContentType
 	if ct == "" {
 		ct = contentTypeFromPath(upload.TargetPath)
 	}
+	logger.Info(ctx, "backend_image_extract_upload_enqueue_resolved",
+		zap.String("upload_id", upload.UploadID),
+		zap.String("file_id", fileID),
+		zap.String("path", upload.TargetPath),
+		zap.String("content_type", ct),
+		zap.Int64("revision", f.Revision),
+		zap.Bool("is_overwrite", isOverwrite))
 	b.enqueueImageExtract(fileID, upload.TargetPath, ct, f.Revision)
 }
 
-func (b *Dat9Backend) runImageExtractWorker(ctx context.Context) {
+func (b *Dat9Backend) runImageExtractWorker(ctx context.Context, workerID int) {
 	defer b.imageExtractWG.Done()
+	logger.Info(ctx, "backend_image_extract_worker_started", zap.Int("worker_id", workerID))
 	for {
 		select {
 		case <-ctx.Done():
+			logger.Info(ctx, "backend_image_extract_worker_stopped", zap.Int("worker_id", workerID), zap.String("reason", "context_canceled"))
 			return
 		case task := <-b.imageExtractQueue:
 			b.processImageExtractTask(ctx, task)
@@ -122,6 +160,13 @@ func (b *Dat9Backend) runImageExtractWorker(ctx context.Context) {
 
 func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExtractTask) {
 	start := time.Now()
+	logger.Info(ctx, "backend_image_extract_task_started",
+		zap.String("file_id", task.FileID),
+		zap.String("path", task.Path),
+		zap.String("content_type", task.ContentType),
+		zap.Int64("revision", task.Revision),
+		zap.Int("queue_depth", len(b.imageExtractQueue)),
+		zap.Int("queue_size", cap(b.imageExtractQueue)))
 	f, err := b.store.GetFile(ctx, task.FileID)
 	if err != nil {
 		if !errors.Is(err, datastore.ErrNotFound) {
@@ -132,6 +177,11 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 		return
 	}
 	if f.Status != datastore.StatusConfirmed {
+		logger.Info(ctx, "backend_image_extract_task_skipped",
+			zap.String("file_id", task.FileID),
+			zap.String("path", task.Path),
+			zap.String("reason", "not_confirmed"),
+			zap.String("status", string(f.Status)))
 		metrics.RecordOperation("image_extract", "process", "not_confirmed", time.Since(start))
 		return
 	}
@@ -140,10 +190,21 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 		ct = task.ContentType
 	}
 	if !isImageContentType(ct) {
+		logger.Info(ctx, "backend_image_extract_task_skipped",
+			zap.String("file_id", task.FileID),
+			zap.String("path", task.Path),
+			zap.String("reason", "not_image"),
+			zap.String("content_type", ct))
 		metrics.RecordOperation("image_extract", "process", "not_image", time.Since(start))
 		return
 	}
 	if task.Revision > 0 && f.Revision != task.Revision {
+		logger.Info(ctx, "backend_image_extract_task_skipped",
+			zap.String("file_id", task.FileID),
+			zap.String("path", task.Path),
+			zap.String("reason", "stale_precheck"),
+			zap.Int64("task_revision", task.Revision),
+			zap.Int64("current_revision", f.Revision))
 		metrics.RecordOperation("image_extract", "process", "stale_precheck", time.Since(start))
 		return
 	}
@@ -156,6 +217,12 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 		return
 	}
 	if len(data) == 0 {
+		logger.Info(ctx, "backend_image_extract_task_skipped",
+			zap.String("file_id", task.FileID),
+			zap.String("path", task.Path),
+			zap.String("reason", "too_large_or_empty"),
+			zap.Int64("file_size", f.SizeBytes),
+			zap.Int64("max_bytes", b.imageExtractMaxSize))
 		metrics.RecordOperation("image_extract", "process", "skip_too_large", time.Since(start))
 		return
 	}
@@ -176,6 +243,10 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 	}
 	text = sanitizeExtractedText(text, b.maxExtractTextBytes)
 	if text == "" {
+		logger.Info(ctx, "backend_image_extract_task_skipped",
+			zap.String("file_id", task.FileID),
+			zap.String("path", task.Path),
+			zap.String("reason", "empty_text"))
 		metrics.RecordOperation("image_extract", "process", "empty_text", time.Since(start))
 		return
 	}

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -76,8 +76,10 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 	select {
 	case b.imageExtractQueue <- task:
 		metrics.RecordOperation("image_extract", "enqueue", "ok", 0)
+		metrics.RecordGauge("image_extract", "queue_depth", float64(len(b.imageExtractQueue)))
 	default:
 		metrics.RecordOperation("image_extract", "enqueue", "queue_full", 0)
+		metrics.RecordGauge("image_extract", "queue_depth", float64(len(b.imageExtractQueue)))
 		logger.Warn(backgroundWithTrace(), "backend_image_extract_queue_full_drop",
 			zap.String("file_id", fileID),
 			zap.String("path", path),
@@ -113,6 +115,14 @@ func (b *Dat9Backend) enqueueImageExtractForUpload(ctx context.Context, upload *
 	ct := f.ContentType
 	if ct == "" {
 		ct = contentTypeFromPath(upload.TargetPath)
+		if ct == "" {
+			logger.Warn(ctx, "backend_image_extract_upload_enqueue_skipped_unknown_content_type",
+				zap.String("upload_id", upload.UploadID),
+				zap.String("file_id", fileID),
+				zap.String("path", upload.TargetPath),
+				zap.String("reason", "content_type_missing_and_extension_unknown"))
+			return
+		}
 	}
 	b.enqueueImageExtract(fileID, upload.TargetPath, ct, f.Revision)
 }
@@ -126,6 +136,7 @@ func (b *Dat9Backend) runImageExtractWorker(ctx context.Context, workerID int) {
 			logger.Info(ctx, "backend_image_extract_worker_stopped", zap.Int("worker_id", workerID), zap.String("reason", "context_canceled"))
 			return
 		case task := <-b.imageExtractQueue:
+			metrics.RecordGauge("image_extract", "queue_depth", float64(len(b.imageExtractQueue)))
 			b.processImageExtractTask(ctx, task)
 		}
 	}

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -59,19 +59,11 @@ func contentTypeFromPath(path string) string {
 
 func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revision int64) {
 	if !b.imageExtractEnabled || b.imageExtractor == nil {
-		logger.Info(backgroundWithTrace(), "backend_image_extract_enqueue_skipped",
-			zap.String("file_id", fileID),
-			zap.String("path", path),
-			zap.String("reason", "disabled_or_extractor_missing"))
 		return
 	}
 	if !isImageContentType(contentType) {
 		contentType = contentTypeFromPath(path)
 		if !isImageContentType(contentType) {
-			logger.Info(backgroundWithTrace(), "backend_image_extract_enqueue_skipped",
-				zap.String("file_id", fileID),
-				zap.String("path", path),
-				zap.String("reason", "not_image"))
 			return
 		}
 	}
@@ -84,13 +76,6 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 	select {
 	case b.imageExtractQueue <- task:
 		metrics.RecordOperation("image_extract", "enqueue", "ok", 0)
-		logger.Info(backgroundWithTrace(), "backend_image_extract_enqueued",
-			zap.String("file_id", fileID),
-			zap.String("path", path),
-			zap.String("content_type", contentType),
-			zap.Int64("revision", revision),
-			zap.Int("queue_depth", len(b.imageExtractQueue)),
-			zap.Int("queue_size", cap(b.imageExtractQueue)))
 	default:
 		metrics.RecordOperation("image_extract", "enqueue", "queue_full", 0)
 		logger.Warn(backgroundWithTrace(), "backend_image_extract_queue_full_drop",
@@ -102,11 +87,6 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 
 func (b *Dat9Backend) enqueueImageExtractForUpload(ctx context.Context, upload *datastore.Upload, isOverwrite bool) {
 	if !b.imageExtractEnabled || b.imageExtractor == nil {
-		logger.Info(ctx, "backend_image_extract_upload_enqueue_skipped",
-			zap.String("upload_id", upload.UploadID),
-			zap.String("path", upload.TargetPath),
-			zap.Bool("is_overwrite", isOverwrite),
-			zap.String("reason", "disabled_or_extractor_missing"))
 		return
 	}
 	fileID := upload.FileID
@@ -134,13 +114,6 @@ func (b *Dat9Backend) enqueueImageExtractForUpload(ctx context.Context, upload *
 	if ct == "" {
 		ct = contentTypeFromPath(upload.TargetPath)
 	}
-	logger.Info(ctx, "backend_image_extract_upload_enqueue_resolved",
-		zap.String("upload_id", upload.UploadID),
-		zap.String("file_id", fileID),
-		zap.String("path", upload.TargetPath),
-		zap.String("content_type", ct),
-		zap.Int64("revision", f.Revision),
-		zap.Bool("is_overwrite", isOverwrite))
 	b.enqueueImageExtract(fileID, upload.TargetPath, ct, f.Revision)
 }
 
@@ -160,13 +133,6 @@ func (b *Dat9Backend) runImageExtractWorker(ctx context.Context, workerID int) {
 
 func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExtractTask) {
 	start := time.Now()
-	logger.Info(ctx, "backend_image_extract_task_started",
-		zap.String("file_id", task.FileID),
-		zap.String("path", task.Path),
-		zap.String("content_type", task.ContentType),
-		zap.Int64("revision", task.Revision),
-		zap.Int("queue_depth", len(b.imageExtractQueue)),
-		zap.Int("queue_size", cap(b.imageExtractQueue)))
 	f, err := b.store.GetFile(ctx, task.FileID)
 	if err != nil {
 		if !errors.Is(err, datastore.ErrNotFound) {
@@ -177,11 +143,6 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 		return
 	}
 	if f.Status != datastore.StatusConfirmed {
-		logger.Info(ctx, "backend_image_extract_task_skipped",
-			zap.String("file_id", task.FileID),
-			zap.String("path", task.Path),
-			zap.String("reason", "not_confirmed"),
-			zap.String("status", string(f.Status)))
 		metrics.RecordOperation("image_extract", "process", "not_confirmed", time.Since(start))
 		return
 	}
@@ -190,21 +151,10 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 		ct = task.ContentType
 	}
 	if !isImageContentType(ct) {
-		logger.Info(ctx, "backend_image_extract_task_skipped",
-			zap.String("file_id", task.FileID),
-			zap.String("path", task.Path),
-			zap.String("reason", "not_image"),
-			zap.String("content_type", ct))
 		metrics.RecordOperation("image_extract", "process", "not_image", time.Since(start))
 		return
 	}
 	if task.Revision > 0 && f.Revision != task.Revision {
-		logger.Info(ctx, "backend_image_extract_task_skipped",
-			zap.String("file_id", task.FileID),
-			zap.String("path", task.Path),
-			zap.String("reason", "stale_precheck"),
-			zap.Int64("task_revision", task.Revision),
-			zap.Int64("current_revision", f.Revision))
 		metrics.RecordOperation("image_extract", "process", "stale_precheck", time.Since(start))
 		return
 	}
@@ -217,10 +167,9 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 		return
 	}
 	if len(data) == 0 {
-		logger.Info(ctx, "backend_image_extract_task_skipped",
+		logger.Warn(ctx, "backend_image_extract_skipped_too_large_or_empty",
 			zap.String("file_id", task.FileID),
 			zap.String("path", task.Path),
-			zap.String("reason", "too_large_or_empty"),
 			zap.Int64("file_size", f.SizeBytes),
 			zap.Int64("max_bytes", b.imageExtractMaxSize))
 		metrics.RecordOperation("image_extract", "process", "skip_too_large", time.Since(start))
@@ -243,10 +192,9 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 	}
 	text = sanitizeExtractedText(text, b.maxExtractTextBytes)
 	if text == "" {
-		logger.Info(ctx, "backend_image_extract_task_skipped",
+		logger.Warn(ctx, "backend_image_extract_empty_text",
 			zap.String("file_id", task.FileID),
-			zap.String("path", task.Path),
-			zap.String("reason", "empty_text"))
+			zap.String("path", task.Path))
 		metrics.RecordOperation("image_extract", "process", "empty_text", time.Since(start))
 		return
 	}

--- a/pkg/backend/image_extract_basic.go
+++ b/pkg/backend/image_extract_basic.go
@@ -68,7 +68,7 @@ func (e *fallbackImageTextExtractor) ExtractImageText(ctx context.Context, req I
 			zap.Error(err))
 		metrics.RecordOperation("image_extract", "fallback", "primary_error", 0)
 	} else {
-		logger.Info(ctx, "backend_image_extract_primary_empty_use_fallback",
+		logger.Warn(ctx, "backend_image_extract_primary_empty_use_fallback",
 			zap.String("file_id", req.FileID),
 			zap.String("path", req.Path))
 		metrics.RecordOperation("image_extract", "fallback", "primary_empty", 0)

--- a/pkg/backend/image_extract_basic.go
+++ b/pkg/backend/image_extract_basic.go
@@ -10,7 +10,10 @@ import (
 	_ "image/png"
 	"strings"
 
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/pathutil"
+	"go.uber.org/zap"
 )
 
 // BasicImageTextExtractor is a deterministic fallback extractor used when no
@@ -57,6 +60,18 @@ func (e *fallbackImageTextExtractor) ExtractImageText(ctx context.Context, req I
 	text, err := e.primary.ExtractImageText(ctx, req)
 	if err == nil && strings.TrimSpace(text) != "" {
 		return text, nil
+	}
+	if err != nil {
+		logger.Warn(ctx, "backend_image_extract_primary_failed_use_fallback",
+			zap.String("file_id", req.FileID),
+			zap.String("path", req.Path),
+			zap.Error(err))
+		metrics.RecordOperation("image_extract", "fallback", "primary_error", 0)
+	} else {
+		logger.Info(ctx, "backend_image_extract_primary_empty_use_fallback",
+			zap.String("file_id", req.FileID),
+			zap.String("path", req.Path))
+		metrics.RecordOperation("image_extract", "fallback", "primary_empty", 0)
 	}
 	return e.fallback.ExtractImageText(ctx, req)
 }

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -67,7 +67,7 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 	b.imageExtractCancel = cancel
 	for i := 0; i < cfg.Workers; i++ {
 		b.imageExtractWG.Add(1)
-		go b.runImageExtractWorker(ctx)
+		go b.runImageExtractWorker(ctx, i+1)
 	}
 	logger.Info(ctx, "backend_image_extract_workers_started",
 		zap.Int("workers", cfg.Workers), zap.Int("queue_size", cfg.QueueSize))
@@ -81,5 +81,7 @@ func (b *Dat9Backend) Close() {
 	b.imageExtractCancel()
 	b.imageExtractWG.Wait()
 	b.imageExtractCancel = nil
-	logger.Info(backgroundWithTrace(), "backend_image_extract_workers_stopped")
+	logger.Info(backgroundWithTrace(), "backend_image_extract_workers_stopped",
+		zap.Int("queue_depth", len(b.imageExtractQueue)),
+		zap.Int("queue_size", cap(b.imageExtractQueue)))
 }

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"go.uber.org/zap"
 )
 
@@ -62,6 +63,9 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 	b.imageExtractMaxSize = cfg.MaxImageBytes
 	b.maxExtractTextBytes = cfg.MaxExtractTextBytes
 	b.imageExtractQueue = make(chan imageExtractTask, cfg.QueueSize)
+	metrics.RecordGauge("image_extract", "queue_capacity", float64(cfg.QueueSize))
+	metrics.RecordGauge("image_extract", "workers", float64(cfg.Workers))
+	metrics.RecordGauge("image_extract", "queue_depth", 0)
 
 	ctx, cancel := context.WithCancel(backgroundWithTrace())
 	b.imageExtractCancel = cancel
@@ -81,6 +85,8 @@ func (b *Dat9Backend) Close() {
 	b.imageExtractCancel()
 	b.imageExtractWG.Wait()
 	b.imageExtractCancel = nil
+	metrics.RecordGauge("image_extract", "workers", 0)
+	metrics.RecordGauge("image_extract", "queue_depth", 0)
 	logger.Info(backgroundWithTrace(), "backend_image_extract_workers_stopped",
 		zap.Int("queue_depth", len(b.imageExtractQueue)),
 		zap.Int("queue_size", cap(b.imageExtractQueue)))

--- a/pkg/datastore/search.go
+++ b/pkg/datastore/search.go
@@ -6,6 +6,9 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"go.uber.org/zap"
 )
 
 type SearchResult struct {
@@ -114,6 +117,11 @@ func (s *Store) vectorSearch(ctx context.Context, query, pathPrefix string, limi
 
 	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
+		logger.Warn(ctx, "datastore_vector_search_query_failed",
+			zap.Int("query_len", len(query)),
+			zap.String("path_prefix", pathPrefix),
+			zap.Int("limit", limit),
+			zap.Error(err))
 		return nil
 	}
 	defer func() { _ = rows.Close() }()
@@ -122,7 +130,8 @@ func (s *Store) vectorSearch(ctx context.Context, query, pathPrefix string, limi
 	for rows.Next() {
 		var r SearchResult
 		var dist float64
-		if rows.Scan(&r.Path, &r.Name, &r.SizeBytes, &dist) != nil {
+		if err := rows.Scan(&r.Path, &r.Name, &r.SizeBytes, &dist); err != nil {
+			logger.Warn(ctx, "datastore_vector_search_scan_failed", zap.Error(err))
 			break
 		}
 		sc := 1.0 - dist
@@ -131,6 +140,9 @@ func (s *Store) vectorSearch(ctx context.Context, query, pathPrefix string, limi
 		}
 		r.Score = &sc
 		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		logger.Warn(ctx, "datastore_vector_search_rows_failed", zap.Error(err))
 	}
 	return out
 }
@@ -168,6 +180,11 @@ func (s *Store) ftsSearch(ctx context.Context, query, pathPrefix string, limit i
 
 	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
+		logger.Warn(ctx, "datastore_fts_search_query_failed",
+			zap.Int("query_len", len(query)),
+			zap.String("path_prefix", pathPrefix),
+			zap.Int("limit", limit),
+			zap.Error(err))
 		return nil
 	}
 	defer func() { _ = rows.Close() }()
@@ -176,11 +193,15 @@ func (s *Store) ftsSearch(ctx context.Context, query, pathPrefix string, limit i
 	for rows.Next() {
 		var r SearchResult
 		var sc float64
-		if rows.Scan(&r.Path, &r.Name, &r.SizeBytes, &sc) != nil {
+		if err := rows.Scan(&r.Path, &r.Name, &r.SizeBytes, &sc); err != nil {
+			logger.Warn(ctx, "datastore_fts_search_scan_failed", zap.Error(err))
 			break
 		}
 		r.Score = &sc
 		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		logger.Warn(ctx, "datastore_fts_search_rows_failed", zap.Error(err))
 	}
 	return out
 }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -14,6 +14,7 @@ type opMetrics struct {
 	durationCount  map[string]int64
 	durationSum    map[string]float64
 	durationBucket map[string][]int64
+	gauges         map[string]float64
 }
 
 var operationDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
@@ -23,6 +24,7 @@ var globalOps = &opMetrics{
 	durationCount:  map[string]int64{},
 	durationSum:    map[string]float64{},
 	durationBucket: map[string][]int64{},
+	gauges:         map[string]float64{},
 }
 
 func RecordOperation(component, operation, result string, d time.Duration) {
@@ -45,6 +47,13 @@ func RecordOperation(component, operation, result string, d time.Duration) {
 	globalOps.mu.Unlock()
 }
 
+func RecordGauge(component, name string, value float64) {
+	key := gaugeLabels(component, name)
+	globalOps.mu.Lock()
+	globalOps.gauges[key] = value
+	globalOps.mu.Unlock()
+}
+
 func WritePrometheus(w http.ResponseWriter) {
 	globalOps.mu.RLock()
 	countKeys := SortedKeys(globalOps.counts)
@@ -52,6 +61,8 @@ func WritePrometheus(w http.ResponseWriter) {
 	durationCount := CloneIntMap(globalOps.durationCount)
 	durationSum := CloneFloatMap(globalOps.durationSum)
 	durationBucket := CloneBucketMap(globalOps.durationBucket)
+	gaugeKeys := SortedKeys(globalOps.gauges)
+	gauges := CloneFloatMap(globalOps.gauges)
 	globalOps.mu.RUnlock()
 
 	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operations_total Service operations by component/operation/result")
@@ -81,8 +92,18 @@ func WritePrometheus(w http.ResponseWriter) {
 	for _, k := range countKeys {
 		_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_sum{%s} %.6f\n", k, durationSum[k])
 	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_service_gauge Service gauges by component/name")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_gauge gauge")
+	for _, k := range gaugeKeys {
+		_, _ = fmt.Fprintf(w, "dat9_service_gauge{%s} %.6f\n", k, gauges[k])
+	}
 }
 
 func labels(component, operation, result string) string {
 	return "component=\"" + EscapePromLabel(component) + "\",operation=\"" + EscapePromLabel(operation) + "\",result=\"" + EscapePromLabel(result) + "\""
+}
+
+func gaugeLabels(component, name string) string {
+	return "component=\"" + EscapePromLabel(component) + "\",name=\"" + EscapePromLabel(name) + "\""
 }

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -59,6 +59,9 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 	defer observePool(ctx, "get", t.ID, &err, start)
 
 	if t.Status != meta.TenantActive {
+		logger.Warn(ctx, "tenant_pool_get_skipped_inactive",
+			zap.String("tenant_id", t.ID),
+			zap.String("status", string(t.Status)))
 		p.Invalidate(t.ID)
 		return nil, fmt.Errorf("tenant status: %s", t.Status)
 	}
@@ -68,9 +71,11 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 		p.order.MoveToFront(elem)
 		b := elem.Value.(*entry).backend
 		p.mu.Unlock()
+		logger.Info(ctx, "tenant_pool_cache_hit", zap.String("tenant_id", t.ID))
 		return b, nil
 	}
 	p.mu.Unlock()
+	logger.Info(ctx, "tenant_pool_cache_miss", zap.String("tenant_id", t.ID), zap.String("provider", t.Provider))
 
 	b, st, err := p.createBackend(ctx, t)
 	if err != nil {
@@ -83,14 +88,16 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 		b.Close()
 		_ = st.Close()
 		p.order.MoveToFront(elem)
+		logger.Info(ctx, "tenant_pool_cache_race_reuse", zap.String("tenant_id", t.ID))
 		return elem.Value.(*entry).backend, nil
 	}
 	elem := p.order.PushFront(&entry{tenantID: t.ID, backend: b, store: st})
 	p.items[t.ID] = elem
+	logger.Info(ctx, "tenant_pool_cache_inserted", zap.String("tenant_id", t.ID), zap.Int("pool_size", p.order.Len()))
 	for p.order.Len() > p.maxSize {
 		oldest := p.order.Back()
 		if oldest != nil {
-			p.removeLocked(oldest)
+			p.removeLocked(ctx, oldest, "evict_lru")
 		}
 	}
 	return b, nil
@@ -100,7 +107,7 @@ func (p *Pool) Invalidate(tenantID string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if elem, ok := p.items[tenantID]; ok {
-		p.removeLocked(elem)
+		p.removeLocked(context.Background(), elem, "invalidate")
 	}
 }
 
@@ -108,7 +115,7 @@ func (p *Pool) Close() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	for p.order.Len() > 0 {
-		p.removeLocked(p.order.Back())
+		p.removeLocked(context.Background(), p.order.Back(), "close")
 	}
 }
 
@@ -136,8 +143,10 @@ func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantI
 
 	b := p.S3Backend(tenantID)
 	if b != nil {
+		logger.Info(ctx, "tenant_pool_load_s3_backend_hit", zap.String("tenant_id", tenantID))
 		return b
 	}
+	logger.Info(ctx, "tenant_pool_load_s3_backend_miss", zap.String("tenant_id", tenantID))
 	tenant, err := metaStore.GetTenant(ctx, tenantID)
 	if err != nil {
 		if !errors.Is(err, meta.ErrNotFound) {
@@ -154,9 +163,10 @@ func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantI
 }
 
 func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9Backend, *datastore.Store, error) {
+	logger.Info(ctx, "tenant_pool_create_backend_started", zap.String("tenant_id", t.ID), zap.String("provider", t.Provider))
 	pass, err := p.enc.Decrypt(ctx, t.DBPasswordCipher)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("decrypt db password: %w", err)
 	}
 	query := "parseTime=true"
 	if t.DBTLS {
@@ -165,7 +175,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
 	store, err := datastore.Open(dsn)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("open datastore: %w", err)
 	}
 	if p.cfg.S3Bucket != "" {
 		prefix := strings.Trim(p.cfg.S3Prefix, "/")
@@ -181,14 +191,18 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		})
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("create aws s3 client: %w", err)
 		}
 		smallInDB := SmallInDB(t.Provider)
 		b, err := backend.NewWithS3ModeAndOptions(store, s3c, smallInDB, p.cfg.BackendOptions)
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("create backend with s3 mode: %w", err)
 		}
+		logger.Info(ctx, "tenant_pool_create_backend_ok",
+			zap.String("tenant_id", t.ID),
+			zap.String("provider", t.Provider),
+			zap.String("storage_mode", "s3_aws"))
 		return b, store, nil
 	}
 	if p.cfg.S3Dir != "" {
@@ -197,25 +211,33 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		s3c, err := s3client.NewLocal(s3Dir, s3BaseURL)
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("create local s3 client: %w", err)
 		}
 		smallInDB := SmallInDB(t.Provider)
 		b, err := backend.NewWithS3ModeAndOptions(store, s3c, smallInDB, p.cfg.BackendOptions)
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("create backend with local s3 mode: %w", err)
 		}
+		logger.Info(ctx, "tenant_pool_create_backend_ok",
+			zap.String("tenant_id", t.ID),
+			zap.String("provider", t.Provider),
+			zap.String("storage_mode", "s3_local"))
 		return b, store, nil
 	}
 	b, err := backend.NewWithOptions(store, p.cfg.BackendOptions)
 	if err != nil {
 		_ = store.Close()
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("create backend: %w", err)
 	}
+	logger.Info(ctx, "tenant_pool_create_backend_ok",
+		zap.String("tenant_id", t.ID),
+		zap.String("provider", t.Provider),
+		zap.String("storage_mode", "db_only"))
 	return b, store, nil
 }
 
-func (p *Pool) removeLocked(elem *list.Element) {
+func (p *Pool) removeLocked(ctx context.Context, elem *list.Element, reason string) {
 	e := elem.Value.(*entry)
 	p.order.Remove(elem)
 	delete(p.items, e.tenantID)
@@ -225,6 +247,10 @@ func (p *Pool) removeLocked(elem *list.Element) {
 	if e.store != nil {
 		_ = e.store.Close()
 	}
+	logger.Info(ctx, "tenant_pool_entry_removed",
+		zap.String("tenant_id", e.tenantID),
+		zap.String("reason", reason),
+		zap.Int("pool_size", p.order.Len()))
 }
 
 func observePool(ctx context.Context, op, tenantID string, errp *error, start time.Time) {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -71,11 +71,9 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 		p.order.MoveToFront(elem)
 		b := elem.Value.(*entry).backend
 		p.mu.Unlock()
-		logger.Info(ctx, "tenant_pool_cache_hit", zap.String("tenant_id", t.ID))
 		return b, nil
 	}
 	p.mu.Unlock()
-	logger.Info(ctx, "tenant_pool_cache_miss", zap.String("tenant_id", t.ID), zap.String("provider", t.Provider))
 
 	b, st, err := p.createBackend(ctx, t)
 	if err != nil {
@@ -88,12 +86,10 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 		b.Close()
 		_ = st.Close()
 		p.order.MoveToFront(elem)
-		logger.Info(ctx, "tenant_pool_cache_race_reuse", zap.String("tenant_id", t.ID))
 		return elem.Value.(*entry).backend, nil
 	}
 	elem := p.order.PushFront(&entry{tenantID: t.ID, backend: b, store: st})
 	p.items[t.ID] = elem
-	logger.Info(ctx, "tenant_pool_cache_inserted", zap.String("tenant_id", t.ID), zap.Int("pool_size", p.order.Len()))
 	for p.order.Len() > p.maxSize {
 		oldest := p.order.Back()
 		if oldest != nil {
@@ -143,10 +139,8 @@ func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantI
 
 	b := p.S3Backend(tenantID)
 	if b != nil {
-		logger.Info(ctx, "tenant_pool_load_s3_backend_hit", zap.String("tenant_id", tenantID))
 		return b
 	}
-	logger.Info(ctx, "tenant_pool_load_s3_backend_miss", zap.String("tenant_id", tenantID))
 	tenant, err := metaStore.GetTenant(ctx, tenantID)
 	if err != nil {
 		if !errors.Is(err, meta.ErrNotFound) {
@@ -163,7 +157,6 @@ func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantI
 }
 
 func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9Backend, *datastore.Store, error) {
-	logger.Info(ctx, "tenant_pool_create_backend_started", zap.String("tenant_id", t.ID), zap.String("provider", t.Provider))
 	pass, err := p.enc.Decrypt(ctx, t.DBPasswordCipher)
 	if err != nil {
 		return nil, nil, fmt.Errorf("decrypt db password: %w", err)
@@ -199,10 +192,6 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			_ = store.Close()
 			return nil, nil, fmt.Errorf("create backend with s3 mode: %w", err)
 		}
-		logger.Info(ctx, "tenant_pool_create_backend_ok",
-			zap.String("tenant_id", t.ID),
-			zap.String("provider", t.Provider),
-			zap.String("storage_mode", "s3_aws"))
 		return b, store, nil
 	}
 	if p.cfg.S3Dir != "" {
@@ -219,10 +208,6 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			_ = store.Close()
 			return nil, nil, fmt.Errorf("create backend with local s3 mode: %w", err)
 		}
-		logger.Info(ctx, "tenant_pool_create_backend_ok",
-			zap.String("tenant_id", t.ID),
-			zap.String("provider", t.Provider),
-			zap.String("storage_mode", "s3_local"))
 		return b, store, nil
 	}
 	b, err := backend.NewWithOptions(store, p.cfg.BackendOptions)
@@ -230,10 +215,6 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		_ = store.Close()
 		return nil, nil, fmt.Errorf("create backend: %w", err)
 	}
-	logger.Info(ctx, "tenant_pool_create_backend_ok",
-		zap.String("tenant_id", t.ID),
-		zap.String("provider", t.Provider),
-		zap.String("storage_mode", "db_only"))
 	return b, store, nil
 }
 
@@ -247,10 +228,8 @@ func (p *Pool) removeLocked(ctx context.Context, elem *list.Element, reason stri
 	if e.store != nil {
 		_ = e.store.Close()
 	}
-	logger.Info(ctx, "tenant_pool_entry_removed",
-		zap.String("tenant_id", e.tenantID),
-		zap.String("reason", reason),
-		zap.Int("pool_size", p.order.Len()))
+	_ = ctx
+	_ = reason
 }
 
 func observePool(ctx context.Context, op, tenantID string, errp *error, start time.Time) {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -93,7 +93,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 	for p.order.Len() > p.maxSize {
 		oldest := p.order.Back()
 		if oldest != nil {
-			p.removeLocked(ctx, oldest, "evict_lru")
+			p.removeLocked(oldest)
 		}
 	}
 	return b, nil
@@ -103,7 +103,7 @@ func (p *Pool) Invalidate(tenantID string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if elem, ok := p.items[tenantID]; ok {
-		p.removeLocked(context.Background(), elem, "invalidate")
+		p.removeLocked(elem)
 	}
 }
 
@@ -111,7 +111,7 @@ func (p *Pool) Close() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	for p.order.Len() > 0 {
-		p.removeLocked(context.Background(), p.order.Back(), "close")
+		p.removeLocked(p.order.Back())
 	}
 }
 
@@ -218,7 +218,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	return b, store, nil
 }
 
-func (p *Pool) removeLocked(ctx context.Context, elem *list.Element, reason string) {
+func (p *Pool) removeLocked(elem *list.Element) {
 	e := elem.Value.(*entry)
 	p.order.Remove(elem)
 	delete(p.items, e.tenantID)
@@ -228,8 +228,6 @@ func (p *Pool) removeLocked(ctx context.Context, elem *list.Element, reason stri
 	if e.store != nil {
 		_ = e.store.Close()
 	}
-	_ = ctx
-	_ = reason
 }
 
 func observePool(ctx context.Context, op, tenantID string, errp *error, start time.Time) {


### PR DESCRIPTION
## What changed
- expanded observability coverage for the async image extraction pipeline and related chains
- reduced high-frequency info noise, while ensuring unexpected paths emit `warn`/`error`
- added service gauge metrics to expose image extraction queue depth/capacity and worker count

## Details
- image extraction chain (`pkg/backend/image_extract.go`):
  - warn on upload enqueue skip due to unknown content-type/extension
  - keep/strengthen warn logs for queue full, load/extract/update failures, empty text, oversized input
  - publish queue depth gauge updates at enqueue/dequeue points
- backend options (`pkg/backend/options.go`):
  - publish image extract gauges on startup/shutdown:
    - `queue_capacity`
    - `workers`
    - `queue_depth`
- metrics package (`pkg/metrics/operations.go`):
  - added generic gauge support:
    - `RecordGauge(component, name, value)`
    - `dat9_service_gauge{component,name}` Prometheus metric
- datastore search (`pkg/datastore/search.go`):
  - added warn logs for vector/fts query, row scan, and rows iteration failures
- server startup config (`cmd/dat9-server/main.go`):
  - log explicit error when image extract OpenAI-compatible env config is partially set

## Validation
- `go test ./pkg/metrics ./pkg/backend ./pkg/datastore ./cmd/dat9-server`