### PR TITLE
feat: optimize image extract prompt to Chinese + English tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ c.Delete("/data/file.txt")
 | `DAT9_IMAGE_EXTRACT_API_BASE` | OpenAI-compatible base URL (optional; set with key/model) | |
 | `DAT9_IMAGE_EXTRACT_API_KEY` | API key for image extraction provider | |
 | `DAT9_IMAGE_EXTRACT_MODEL` | Vision model name (for example Qwen VL model id) | |
-| `DAT9_IMAGE_EXTRACT_PROMPT` | Custom extraction prompt | `Describe this image for file search in both Chinese and English. Include: key objects, scene description, any visible text (OCR), and concise tags. First write in Chinese, then in English. 用中文和英文双语描述这张图片，包括：主要物体、场景描述、图中可见文字（OCR）、简洁标签。先写中文，再写英文。` |
+| `DAT9_IMAGE_EXTRACT_PROMPT` | Custom extraction prompt | `用中文描述这张图片，用于文件搜索。包括：主要物体、场景描述、图中可见文字（OCR）、简洁标签。最后一行用英文写5-10个关键词标签（English tags），用逗号分隔。` |
 | `DAT9_IMAGE_EXTRACT_MAX_TOKENS` | Max output tokens for model extraction | `256` |
 
 ## Architecture

--- a/pkg/backend/image_extract_openai.go
+++ b/pkg/backend/image_extract_openai.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-const defaultImageExtractPrompt = "Describe this image for file search in both Chinese and English. Include: key objects, scene description, any visible text (OCR), and concise tags. First write in Chinese, then in English. 用中文和英文双语描述这张图片，包括：主要物体、场景描述、图中可见文字（OCR）、简洁标签。先写中文，再写英文。"
+const defaultImageExtractPrompt = "用中文描述这张图片，用于文件搜索。包括：主要物体、场景描述、图中可见文字（OCR）、简洁标签。最后一行用英文写5-10个关键词标签（English tags），用逗号分隔。"
 
 // OpenAIImageTextExtractorConfig configures an OpenAI-compatible vision endpoint.
 // This works with providers that expose the /v1/chat/completions API surface.


### PR DESCRIPTION
Use Chinese as primary description language with English keyword tags appended at the end. This cuts token consumption by ~50% compared to full bilingual output while maintaining both Chinese FTS and English FTS/vector search coverage.