### PR TITLE
docs(e2e): add prod endpoint to deployment endpoints section

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,12 +28,18 @@ DAT9_BASE=$DEPLOY DAT9_API_KEY=dat9_xxx bash e2e/api-smoke-test-existing-key.sh
 DAT9_BASE=$DEPLOY bash e2e/cli-smoke-test.sh
 ```
 
-## Dev endpoint
+## Deployment Endpoints
 
-Current dev deployment endpoint:
+### Dev
 
 ```bash
 export DAT9_BASE="https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
+```
+
+### Prod
+
+```bash
+export DAT9_BASE="https://4w9z8cd9b7.execute-api.ap-southeast-1.amazonaws.com"
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary

Adds production API endpoint to the E2E README for easier environment switching.

## Changes

- Renamed 'Dev endpoint' section to 'Deployment Endpoints'
- Added both dev and prod endpoints:
  - **Dev**: `https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com`
  - **Prod**: `https://4w9z8cd9b7.execute-api.ap-southeast-1.amazonaws.com`

## Why

This allows developers to quickly switch between environments when running E2E tests:

```bash
# Dev
export DAT9_BASE="https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"

# Prod
export DAT9_BASE="https://4w9z8cd9b7.execute-api.ap-southeast-1.amazonaws.com"

DAT9_BASE=$DAT9_BASE bash e2e/api-smoke-test.sh
```