### PR TITLE
[WIP] tighten async embedding phase-b write-path behavior

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -429,9 +429,7 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 		}
 		return 0, err
 	}
-	if nf.File.StorageRef != "" && nf.File.StorageRef != storageRef {
-		b.deleteBlobCtx(ctx, nf.File.StorageRef)
-	}
+	b.deleteBlobIfS3Ctx(ctx, nf.File.StorageType, nf.File.StorageRef, storageRef)
 	b.enqueueImageExtract(nf.File.FileID, nf.Node.Path, contentType, newRev)
 	return int64(len(data)), nil
 }
@@ -606,6 +604,13 @@ func (b *Dat9Backend) deleteBlobCtx(ctx context.Context, ref string) {
 			logger.Warn(ctx, "backend_delete_blob_failed", zap.String("storage_ref", ref), zap.Error(err))
 		}
 	}
+}
+
+func (b *Dat9Backend) deleteBlobIfS3Ctx(ctx context.Context, storageType datastore.StorageType, storageRef, keepRef string) {
+	if storageType != datastore.StorageS3 || storageRef == "" || storageRef == keepRef {
+		return
+	}
+	b.deleteBlobCtx(ctx, storageRef)
 }
 
 func (b *Dat9Backend) readFileDataCtx(ctx context.Context, f *datastore.File) ([]byte, error) {

--- a/pkg/backend/semantic_tasks_test.go
+++ b/pkg/backend/semantic_tasks_test.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"bytes"
 	"context"
+	"io"
 	"testing"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
@@ -176,6 +177,32 @@ func TestWriteOverwriteSkipsEmbedTaskWithoutTextSource(t *testing.T) {
 	}
 	if tasks[0].ResourceVersion != 1 {
 		t.Fatalf("unexpected semantic task history: %+v", tasks)
+	}
+}
+
+func TestWriteOverwriteDoesNotDeleteInlineMarkerObject(t *testing.T) {
+	b := newTestBackend(t)
+	if _, err := b.Write("/f", []byte("old"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.S3().PutObject(context.Background(), "inline", bytes.NewReader([]byte("marker")), int64(len("marker"))); err != nil {
+		t.Fatal(err)
+	}
+	large := bytes.Repeat([]byte("a"), 2<<20)
+	if _, err := b.Write("/f", large, 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatal(err)
+	}
+	rc, err := b.S3().GetObject(context.Background(), "inline")
+	if err != nil {
+		t.Fatalf("inline marker object should survive overwrite cleanup: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "marker" {
+		t.Fatalf("marker object=%q, want %q", data, "marker")
 	}
 }
 

--- a/pkg/backend/semantic_tasks_test.go
+++ b/pkg/backend/semantic_tasks_test.go
@@ -297,6 +297,46 @@ func TestConfirmUploadOverwriteSkipsEmbedTaskWithoutTextSourceAndRebindsUpload(t
 	}
 }
 
+func TestRenameDoesNotCreateAdditionalSemanticTasks(t *testing.T) {
+	b := newTestBackend(t)
+	if _, err := b.Write("/old.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	fileID, _, _, _ := mustFileForPath(t, b, "/old.txt")
+	if err := b.Rename("/old.txt", "/new.txt"); err != nil {
+		t.Fatal(err)
+	}
+
+	newFileID, _, _, _ := mustFileForPath(t, b, "/new.txt")
+	if newFileID != fileID {
+		t.Fatalf("rename should preserve file_id=%q, got %q", fileID, newFileID)
+	}
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	if len(tasks) != 1 {
+		t.Fatalf("semantic task count=%d, want 1", len(tasks))
+	}
+}
+
+func TestCopyFileDoesNotCreateAdditionalSemanticTasks(t *testing.T) {
+	b := newTestBackend(t)
+	if _, err := b.Write("/src.txt", []byte("shared"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	fileID, _, _, _ := mustFileForPath(t, b, "/src.txt")
+	if err := b.CopyFile("/src.txt", "/dst.txt"); err != nil {
+		t.Fatal(err)
+	}
+
+	dstFileID, _, _, _ := mustFileForPath(t, b, "/dst.txt")
+	if dstFileID != fileID {
+		t.Fatalf("copy should preserve file_id=%q, got %q", fileID, dstFileID)
+	}
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	if len(tasks) != 1 {
+		t.Fatalf("semantic task count=%d, want 1", len(tasks))
+	}
+}
+
 func TestShouldEnqueueEmbedForRevisionWithSynchronousText(t *testing.T) {
 	b := newTestBackend(t)
 	if !b.shouldEnqueueEmbedForRevision("/docs/a.txt", "text/plain", "hello world") {

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -197,6 +197,7 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 	// Overwrite preserves inode identity by updating the existing files row
 	// in place so every hard link keeps pointing at the same file_id.
 	var oldStorageRef string
+	var oldStorageType datastore.StorageType
 	var isOverwrite bool
 	var confirmedFileID string
 	var confirmedRevision int64
@@ -216,7 +217,7 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 			confirmedFileID = existingFileID.String
 
 			var oldRef string
-			if err := tx.QueryRow(`SELECT storage_ref FROM files WHERE file_id = ?`, existingFileID.String).Scan(&oldRef); err == nil {
+			if err := tx.QueryRow(`SELECT storage_type, storage_ref FROM files WHERE file_id = ?`, existingFileID.String).Scan(&oldStorageType, &oldRef); err == nil {
 				oldStorageRef = oldRef
 			}
 
@@ -287,8 +288,8 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 		metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
 		return err
 	}
-	if isOverwrite && oldStorageRef != "" {
-		b.deleteBlob(oldStorageRef)
+	if isOverwrite {
+		b.deleteBlobIfS3Ctx(ctx, oldStorageType, oldStorageRef, upload.S3Key)
 	}
 
 	b.enqueueImageExtractForUpload(ctx, upload, isOverwrite)


### PR DESCRIPTION
## Summary
- align small-file and multipart write paths with the phase-b embed enqueue policy so revisions without a current or future text source do not create guaranteed-noop embed tasks
- keep the small-write cleanup path safe by preserving the inline marker object behavior while retaining the async image bridge atomicity already rebased from phase-a
- add backend regressions for small-write negative cases, multipart overwrite behavior, and inline cleanup safety

## Testing
- `source ./scripts/test-podman.sh && go test ./pkg/backend -run 'TestShouldEnqueueEmbedForRevision|TestWriteCreateEnqueuesEmbedTask|TestWriteCreateSkipsEmbedTaskWithoutTextSource|TestWriteOverwriteEnqueuesNextRevisionAndClearsEmbeddingState|TestWriteOverwriteSkipsEmbedTaskWithoutTextSource|TestConfirmUploadSkipsEmbedTaskWithoutTextSource|TestConfirmUploadOverwriteSkipsEmbedTaskWithoutTextSourceAndRebindsUpload' -count=1`
- `source ./scripts/test-podman.sh && go test ./pkg/backend -run 'TestAsyncImageExtractUpdatesContentText|TestAsyncImageExtractRequeuesSucceededEmbedTask|TestAsyncImageExtractStaleResultDoesNotRequeueOldRevision' -count=1`