### PR TITLE
fix: use List instead of Stat for mount connectivity check

### DIFF
--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -51,7 +51,7 @@ func Mount(opts *MountOptions) error {
 
 	// Create client and verify connectivity
 	c := client.New(opts.Server, opts.APIKey)
-	if _, err := c.Stat("/"); err != nil {
+	if _, err := c.List("/"); err != nil {
 		return fmt.Errorf("cannot reach dat9 server: %w", err)
 	}
 


### PR DESCRIPTION
Stat('/') returns 404 on new tenants with no files. List('/') returns empty list, which is a valid response.