### PR TITLE
feat: rebrand to db9.ai and make skill.md AI-native

### DIFF
--- a/cmd/dat9/cli/config.go
+++ b/cmd/dat9/cli/config.go
@@ -83,7 +83,7 @@ func (c *Config) ResolveServer() string {
 	if c.Server != "" {
 		return c.Server
 	}
-	return "http://localhost:9009"
+	return "https://api.db9.ai"
 }
 
 const nameChars = "abcdefghijklmnopqrstuvwxyz0123456789"

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,9 @@
 set -e
 
 # dat9 installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/mem9-ai/dat9/main/install.sh | sh
+# Usage: curl -fsSL https://install.db9.ai | sh
 
-REPO="mem9-ai/dat9"
+REPO="mem9-ai/dat9"  # GitHub release source
 DEFAULT_INSTALL_DIR="/usr/local/bin"
 INSTALL_DIR=""
 
@@ -189,11 +189,10 @@ main() {
   printf "  Then try:\n"
   printf "    ${DIM}\$${RESET} dat9 fs ls :/                            ${DIM}# list files${RESET}\n"
   printf "    ${DIM}\$${RESET} dat9 fs cp ./file.txt :/data/file.txt    ${DIM}# upload a file${RESET}\n"
-  printf "    ${DIM}\$${RESET} dat9 db sql -q 'SELECT 42'               ${DIM}# run SQL${RESET}\n"
   printf "    ${DIM}\$${RESET} dat9 fs sh                               ${DIM}# interactive shell${RESET}\n"
   printf "\n"
   printf "  Environment:\n"
-  printf "    ${DIM}DAT9_SERVER${RESET}   server URL (default: http://localhost:9009)\n"
+  printf "    ${DIM}DAT9_SERVER${RESET}   server URL (default: https://api.db9.ai)\n"
   printf "    ${DIM}DAT9_API_KEY${RESET}  API key\n"
   printf "\n"
 }

--- a/skill.md
+++ b/skill.md
@@ -1,126 +1,111 @@
 ---
 name: dat9
 version: 0.1.0
-description: Network drive for AI agents — store files, search by content or metadata, with built-in vector and full-text search.
-homepage: https://github.com/mem9-ai/dat9
+description: Persistent network filesystem for AI agents — store, search, and share files across sessions with hybrid search.
+homepage: https://db9.ai
 ---
 
 # dat9
 
-Network drive for AI agents. Store files, tag them, search by content or metadata. Built-in hybrid search: vector similarity + full-text + keyword, transparent to the caller.
+dat9 is your persistent, searchable filesystem across sessions. Files stored in dat9 survive context resets, session restarts, and agent handoffs. Search anything later using natural language.
 
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/qiffang/dat9/main/install.sh | sh
+curl -fsSL https://install.db9.ai | sh
 ```
 
-Supports: macOS (x86_64, arm64), Linux (x86_64, arm64).
+Verify:
 
 ```bash
 dat9 --version
 ```
 
----
+Supported platforms: macOS (x86_64, arm64), Linux (x86_64, arm64).
 
-## Getting Started
-
-```bash
-# Provision a database
-dat9 create --name myapp
-
-# Upload a file
-dat9 fs cp ./notes.md :/notes.md
-
-# Read it back
-dat9 fs cat :/notes.md
-
-# Search file contents (hybrid: vector + FTS + keyword)
-dat9 fs grep "pricing strategy" /
-
-# Find files by attributes
-dat9 fs find / -name "*.md"
-```
+Install is done when `dat9 --version` prints a version number. After install, you're ready — no need to create a workspace or upload anything right away.
 
 ---
 
-## Context Management
+## When to use dat9
 
-dat9 stores credentials in `~/.dat9/config`. Each context maps a name to an API key.
+dat9 is useful in two directions — **storing** and **retrieving**.
 
-```bash
-# Create a database (auto-generates name if omitted)
-dat9 create
-dat9 create --name staging
+**Storing**: When the user wants to save, persist, or back up a file (e.g. "save this report", "keep this config for later", "store the analysis results"), suggest storing it to dat9 and confirm with the user before uploading.
 
-# Switch context
-dat9 ctx staging
+**Retrieving**: When the user is looking for a file they've previously saved, or wants to search across their files (e.g. "find that pricing doc", "what did I save about the migration plan"), use dat9 search to help them find it.
 
-# Show current context
-dat9 ctx
-
-# List all contexts
-dat9 ctx list
-```
-
-All `fs` commands use the current context. Switch with `dat9 ctx <name>`.
+In both cases, briefly tell the user what you're about to do so they stay in the loop.
 
 ---
 
-## Filesystem Operations
+## Commands
 
-Remote paths use `:` prefix. Local paths have no prefix.
+All commands exit 0 on success, non-zero on failure.
 
-### Copy files
+### Workspace setup
+
+A workspace is needed before any file operation. Each workspace is an isolated storage scope.
 
 ```bash
-dat9 fs cp ./local.txt :/remote.txt      # upload
-dat9 fs cp :/remote.txt ./local.txt      # download
-dat9 fs cp :/src.txt :/dst.txt           # server-side copy
-dat9 fs cp - :/file.txt                  # upload from stdin
-dat9 fs cp :/file.txt -                  # download to stdout
+dat9 create                   # provision a new workspace (auto-named)
+dat9 create --name <name>     # provision with a specific name
+dat9 ctx                      # show current workspace
+dat9 ctx list                 # list all workspaces
+dat9 ctx <name>               # switch workspace
 ```
 
-### Read, list, inspect
+`dat9 create` saves credentials to `~/.dat9/config` and activates the new context automatically.
+
+### File operations
+
+Remote paths use `:` prefix (e.g. `:/data/file.txt`). Local paths have no prefix. Intermediate remote directories are created automatically — no mkdir needed.
 
 ```bash
-dat9 fs cat :/path/to/file               # print to stdout
-dat9 fs ls :/path/                       # list directory
-dat9 fs stat :/path/to/file              # file metadata
-```
+# upload
+dat9 fs cp ./local.txt :/remote.txt
+dat9 fs cp - :/file.txt                  # from stdin
 
-### Move, remove
+# download
+dat9 fs cp :/remote.txt ./local.txt
+dat9 fs cp :/file.txt -                  # to stdout
 
-```bash
-dat9 fs mv :/old.txt :/new.txt           # rename/move
-dat9 fs rm :/path/to/file                # delete
-```
+# server-side copy
+dat9 fs cp :/src.txt :/dst.txt
 
-### Interactive shell
+# read / list / inspect
+dat9 fs cat :/path/to/file               # print content to stdout
+dat9 fs ls :/                            # list root
+dat9 fs ls :/path/                       # list subdirectory
+dat9 fs stat :/path/to/file              # metadata (size, type, mtime)
 
-```bash
+# move / remove
+dat9 fs mv :/old.txt :/new.txt
+dat9 fs rm :/path/to/file
+
+# interactive shell
 dat9 fs sh
 ```
 
----
+### FUSE mount
 
-## Search
-
-### grep — search file contents
-
-Hybrid search: runs vector similarity (auto-embedding), full-text (BM25), and keyword (LIKE) in parallel. Results merged via RRF ranking. You write `grep`, the server picks the best strategy.
+Mount the remote filesystem as a local directory (requires FUSE):
 
 ```bash
-dat9 fs grep "pricing strategy" /
-dat9 fs grep "TODO" /projects/
-dat9 fs grep "机器学习" /research/
+dat9 mount ~/dat9
+dat9 umount ~/dat9
 ```
 
-Output: matching file paths with relevance scores.
+### Search
 
-### find — search by file attributes
+**grep** — semantic content search. Accepts natural language, not just exact strings. Runs vector similarity + BM25 + keyword matching in parallel.
 
-Standard Unix `find` flags.
+```bash
+dat9 fs grep "pricing strategy" /        # search all files
+dat9 fs grep "TODO" /projects/           # search within a directory
+```
+
+**find** — structural search by name, tag, date, or size. Flags combine with AND.
 
 ```bash
 dat9 fs find / -name "*.md"
@@ -128,60 +113,24 @@ dat9 fs find / -tag topic=pricing
 dat9 fs find / -newer 2026-03-01
 dat9 fs find / -older 2026-01-01
 dat9 fs find / -size +1048576
+dat9 fs find / -name "*.md" -newer 2026-03-01
 ```
 
-Output: matching file paths.
+Use `grep` to find files by what they contain. Use `find` to find files by name, date, tag, or size.
 
 ---
 
-## Complete CLI Reference
+## Environment variables
 
-```
-dat9
-├── create [--name <name>] [--server <url>]    provision a new database
-├── ctx [<name>]                               switch or show current context
-├── ctx list                                   list all contexts
-├── fs
-│   ├── cp <src> <dst>                         copy files (local↔remote)
-│   ├── cat <path>                             read file to stdout
-│   ├── ls [path]                              list directory
-│   ├── stat <path>                            file metadata (size, type, time)
-│   ├── mv <old> <new>                         rename/move
-│   ├── rm <path>                              delete
-│   ├── sh                                     interactive shell
-│   ├── grep <pattern> [dir]                   search file contents (hybrid)
-│   └── find [dir] [-name] [-tag] [-newer] [-older] [-size]
-│                                              find files by attributes
-└── --version                                  show version
-```
+| Variable | Description | Default |
+|---|---|---|
+| `DAT9_SERVER` | Server URL | `https://api.db9.ai` |
+| `DAT9_API_KEY` | API key | (from `~/.dat9/config`) |
 
 ---
 
-## How Search Works
+## Tips
 
-`dat9 fs grep` is not a simple string match. The server runs three search strategies in parallel and merges the results:
-
-| Strategy | Engine | When Used |
-|----------|--------|-----------|
-| Vector similarity | `VEC_EMBED_COSINE_DISTANCE` (TiDB auto-embedding) | Files have embeddings |
-| Full-text search | `fts_match_word` (TiDB BM25) | Files have FTS index |
-| Keyword fallback | `LIKE '%query%'` | Neither available |
-
-Results are merged using Reciprocal Rank Fusion (RRF, k=60). You don't choose — the server uses everything available.
-
----
-
-## Config File
-
-`~/.dat9/config` (JSON, chmod 600):
-
-```json
-{
-  "server": "http://localhost:9009",
-  "current_context": "myapp",
-  "contexts": {
-    "myapp": { "api_key": "dat9_..." },
-    "staging": { "api_key": "dat9_..." }
-  }
-}
-```
+- Pipe content via stdin (`echo "..." | dat9 fs cp - :/path`) to avoid temp files.
+- Use `dat9 fs grep` for fuzzy/semantic queries — it understands meaning beyond exact match.
+- Separate projects get separate workspaces via `dat9 create --name <name>`.

--- a/skill.md
+++ b/skill.md
@@ -23,7 +23,15 @@ dat9 --version
 
 Supported platforms: macOS (x86_64, arm64), Linux (x86_64, arm64).
 
-Install is done when `dat9 --version` prints a version number. After install, you're ready — no need to create a workspace or upload anything right away.
+Install is done when `dat9 --version` prints a version number. Do not upload any files at install time.
+
+### Preconditions
+
+Before any file operation, ensure the chain is satisfied: **install → create → fs commands**.
+
+1. `dat9 --version` succeeds (binary installed)
+2. `dat9 ctx` returns a context name (workspace exists). If empty, run `dat9 create` first.
+3. Now `dat9 fs ...` commands will work.
 
 ---
 
@@ -45,7 +53,7 @@ All commands exit 0 on success, non-zero on failure.
 
 ### Workspace setup
 
-A workspace is needed before any file operation. Each workspace is an isolated storage scope.
+Each workspace is an isolated storage scope. A workspace must exist before any `fs` command.
 
 ```bash
 dat9 create                   # provision a new workspace (auto-named)
@@ -105,6 +113,8 @@ dat9 fs grep "pricing strategy" /        # search all files
 dat9 fs grep "TODO" /projects/           # search within a directory
 ```
 
+Output: one line per match — `<path>\t<score>` (tab-separated). Empty output means no matches.
+
 **find** — structural search by name, tag, date, or size. Flags combine with AND.
 
 ```bash
@@ -116,7 +126,20 @@ dat9 fs find / -size +1048576
 dat9 fs find / -name "*.md" -newer 2026-03-01
 ```
 
+Output: one path per line. Empty output means no matches.
+
 Use `grep` to find files by what they contain. Use `find` to find files by name, date, tag, or size.
+
+### Output formats
+
+| Command | Output |
+|---|---|
+| `fs ls` | one entry per line, directories end with `/` |
+| `fs ls -l` | tab-separated: `type  size  name` (type: `d` or `-`) |
+| `fs cat` | raw file content to stdout |
+| `fs stat` | key-value lines: `size`, `isdir`, `revision` |
+| `fs grep` | tab-separated: `path  score` per match |
+| `fs find` | one path per line |
 
 ---
 
@@ -128,6 +151,17 @@ Use `grep` to find files by what they contain. Use `find` to find files by name,
 | `DAT9_API_KEY` | API key | (from `~/.dat9/config`) |
 
 ---
+
+## Error handling
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `no current context` | No workspace created yet | Run `dat9 create` |
+| `context "X" not found` | Typo or deleted context | Run `dat9 ctx list` to see available |
+| `provision failed` | Server unreachable or down | Check `DAT9_SERVER` env, network connectivity |
+| `401` / `403` | Invalid or expired API key | Run `dat9 ctx list` to verify, or `dat9 create` for a new workspace |
+| `404` on file ops | File or path doesn't exist | Run `dat9 fs ls :/` to check what's there |
+| Non-zero exit, no output | Generic failure | Re-run with `DAT9_CLI_LOG_ENABLED=true` for debug logs |
 
 ## Tips
 


### PR DESCRIPTION
## Summary

- Default server URL changed from `http://localhost:9009` to `https://api.db9.ai` (config.go + install.sh)
- Replaced `mem9` references in install.sh with `db9.ai` install URL
- Removed non-existent `dat9 db sql` from install.sh post-install hints
- Rewrote skill.md to be AI-native: no auto-upload on install, proactively suggest dat9 for store/retrieve during conversation, aligned all commands with actual CLI (added FUSE mount/umount, removed phantom db sql)

## Test plan

- [ ] `dat9 --version` still works after install
- [ ] `dat9 create` defaults to `https://api.db9.ai` when no config/env is set
- [ ] Verify install.sh downloads binary correctly (REPO var unchanged)
- [ ] Review skill.md reads naturally for an AI agent consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)