### PR TITLE
fix: improve dat9 FUSE compatibility for OpenClaw workflows

### DIFF
--- a/cmd/dat9/cli/mount.go
+++ b/cmd/dat9/cli/mount.go
@@ -80,14 +80,28 @@ func UmountCmd(args []string) error {
 	}
 	mountPoint := args[0]
 
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("umount", mountPoint)
-	default:
-		cmd = exec.Command("fusermount", "-u", mountPoint)
+	argv, err := umountArgv(runtime.GOOS, exec.LookPath, mountPoint)
+	if err != nil {
+		return err
 	}
+	cmd := exec.Command(argv[0], argv[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func umountArgv(goos string, lookPath func(string) (string, error), mountPoint string) ([]string, error) {
+	if goos == "darwin" {
+		return []string{"umount", mountPoint}, nil
+	}
+	if _, err := lookPath("fusermount3"); err == nil {
+		return []string{"fusermount3", "-u", mountPoint}, nil
+	}
+	if _, err := lookPath("fusermount"); err == nil {
+		return []string{"fusermount", "-u", mountPoint}, nil
+	}
+	if _, err := lookPath("umount"); err == nil {
+		return []string{"umount", mountPoint}, nil
+	}
+	return nil, fmt.Errorf("umount: no supported unmount binary found (tried fusermount3, fusermount, umount)")
 }

--- a/cmd/dat9/cli/mount_test.go
+++ b/cmd/dat9/cli/mount_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func fakeLookPath(binMap map[string]bool) func(string) (string, error) {
+	return func(name string) (string, error) {
+		if binMap[name] {
+			return "/usr/bin/" + name, nil
+		}
+		return "", errors.New("not found")
+	}
+}
+
+func TestUmountArgvDarwin(t *testing.T) {
+	got, err := umountArgv("darwin", fakeLookPath(nil), "/mnt/dat9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"umount", "/mnt/dat9"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("argv = %v, want %v", got, want)
+	}
+}
+
+func TestUmountArgvPrefersFusermount3(t *testing.T) {
+	got, err := umountArgv("linux", fakeLookPath(map[string]bool{
+		"fusermount3": true,
+		"fusermount":  true,
+		"umount":      true,
+	}), "/mnt/dat9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"fusermount3", "-u", "/mnt/dat9"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("argv = %v, want %v", got, want)
+	}
+}
+
+func TestUmountArgvFallsBackToFusermount(t *testing.T) {
+	got, err := umountArgv("linux", fakeLookPath(map[string]bool{
+		"fusermount": true,
+	}), "/mnt/dat9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"fusermount", "-u", "/mnt/dat9"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("argv = %v, want %v", got, want)
+	}
+}
+
+func TestUmountArgvFallsBackToUmount(t *testing.T) {
+	got, err := umountArgv("linux", fakeLookPath(map[string]bool{
+		"umount": true,
+	}), "/mnt/dat9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"umount", "/mnt/dat9"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("argv = %v, want %v", got, want)
+	}
+}
+
+func TestUmountArgvNoBinary(t *testing.T) {
+	_, err := umountArgv("linux", fakeLookPath(nil), "/mnt/dat9")
+	if err == nil {
+		t.Fatal("expected error when no unmount binaries are available")
+	}
+}

--- a/docs/openclaw-dat9-fuse.md
+++ b/docs/openclaw-dat9-fuse.md
@@ -2,7 +2,7 @@
 name: dat9-fuse-openclaw
 version: 0.1.0
 description: Use dat9 FUSE as OpenClaw workspace storage for persistent files.
-homepage: https://github.com/mem9-ai/dat9
+homepage: https://dat9.ai
 ---
 
 # dat9 FUSE for OpenClaw
@@ -38,22 +38,28 @@ dat9 mount "$HOME/dat9-openclaw"
 
 Keep this process running in a tmux/screen session or as a service.
 
-## 3) Point OpenClaw HOME/workspace into the mount
+## 3) Run OpenClaw in an isolated shell rooted on the mount
+
+Do not overwrite your global shell `HOME`. Use a subshell so only OpenClaw
+state/config writes into dat9.
 
 ```bash
 mkdir -p "$HOME/dat9-openclaw/openclaw-home"
-export HOME="$HOME/dat9-openclaw/openclaw-home"
-openclaw --version
+(
+  export HOME="$HOME/dat9-openclaw/openclaw-home"
+  openclaw --version
+)
 ```
-
-OpenClaw state now persists under the mounted dat9 filesystem.
 
 ## 4) Skill/plugin operations (example)
 
 ```bash
-openclaw plugins --help
-openclaw plugins install @tencent-weixin/openclaw-weixin
-openclaw plugins list
+(
+  export HOME="$HOME/dat9-openclaw/openclaw-home"
+  openclaw plugins --help
+  openclaw plugins install @tencent-weixin/openclaw-weixin
+  openclaw plugins list
+)
 ```
 
 If remote registry throttles (`429`) or plugin install is memory-heavy, retry later or use a larger instance.
@@ -62,7 +68,7 @@ If remote registry throttles (`429`) or plugin install is memory-heavy, retry la
 
 ```bash
 # Write via mounted path
-echo "openclaw-fuse-ok" > "$HOME/fuse-check.txt"
+echo "openclaw-fuse-ok" > "$HOME/dat9-openclaw/openclaw-home/fuse-check.txt"
 
 # Read via dat9 API/CLI path
 dat9 fs cat /openclaw-home/fuse-check.txt

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -114,7 +114,8 @@ func (c *Client) Read(path string) ([]byte, error) {
 
 // List returns the entries in a directory.
 func (c *Client) List(path string) ([]FileInfo, error) {
-	req, err := http.NewRequest(http.MethodGet, c.url(path)+"?list", nil)
+	// Use an explicit value to avoid intermediaries dropping bare "?list".
+	req, err := http.NewRequest(http.MethodGet, c.url(path)+"?list=1", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -86,7 +86,7 @@ func TestListDir(t *testing.T) {
 	}
 
 	// List
-	resp, err := http.Get(ts.URL + "/v1/fs/data/?list")
+	resp, err := http.Get(ts.URL + "/v1/fs/data/?list=1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/skills/openclaw/dat9-fuse.md
+++ b/skills/openclaw/dat9-fuse.md
@@ -1,0 +1,79 @@
+---
+name: dat9-fuse-openclaw
+version: 0.1.0
+description: Use dat9 FUSE as OpenClaw workspace storage for persistent files.
+homepage: https://github.com/mem9-ai/dat9
+---
+
+# dat9 FUSE for OpenClaw
+
+Mount a dat9 tenant locally, then point OpenClaw workspace paths into the mount so files survive host restarts and can be queried through dat9.
+
+## Prerequisites
+
+- `dat9` CLI installed and authenticated (`DAT9_SERVER`, `DAT9_API_KEY` or `dat9 ctx`)
+- `openclaw` CLI installed
+- Linux: `fuse3` package installed (`fusermount3` available)
+
+Install `dat9` using the standard entrypoint:
+
+```bash
+curl -fsSL https://dat9.ai/install | sh
+dat9 --version
+```
+
+## 1) Provision (or reuse) a dat9 tenant
+
+```bash
+dat9 create --name openclaw
+dat9 ctx openclaw
+```
+
+## 2) Mount dat9
+
+```bash
+mkdir -p "$HOME/dat9-openclaw"
+dat9 mount "$HOME/dat9-openclaw"
+```
+
+Keep this process running in a tmux/screen session or as a service.
+
+## 3) Point OpenClaw HOME/workspace into the mount
+
+```bash
+mkdir -p "$HOME/dat9-openclaw/openclaw-home"
+export HOME="$HOME/dat9-openclaw/openclaw-home"
+openclaw --version
+```
+
+OpenClaw state now persists under the mounted dat9 filesystem.
+
+## 4) Skill/plugin operations (example)
+
+```bash
+openclaw plugins --help
+openclaw plugins install @tencent-weixin/openclaw-weixin
+openclaw plugins list
+```
+
+If remote registry throttles (`429`) or plugin install is memory-heavy, retry later or use a larger instance.
+
+## 5) Verify data is really in dat9
+
+```bash
+# Write via mounted path
+echo "openclaw-fuse-ok" > "$HOME/fuse-check.txt"
+
+# Read via dat9 API/CLI path
+dat9 fs cat /openclaw-home/fuse-check.txt
+```
+
+If output is `openclaw-fuse-ok`, OpenClaw-visible files are persisted in dat9.
+
+## 6) Unmount safely
+
+```bash
+dat9 umount "$HOME/dat9-openclaw"
+```
+
+On Linux, dat9 now prefers `fusermount3`, then falls back to `fusermount`, then `umount`.


### PR DESCRIPTION
## Summary
- make `dat9 umount` Linux-compatible across distros by preferring `fusermount3` and falling back to `fusermount`/`umount`
- stabilize FUSE connectivity precheck calls by changing directory list requests from `?list` to `?list=1` to avoid proxy/query normalization issues
- add CLI unit tests for unmount binary selection and include a new OpenClaw skill guide for using and verifying dat9 FUSE persistence

## Validation
- `go test ./cmd/dat9/cli -run UmountArgv`
- `go test ./pkg/client -run TestListDir`