### PR TITLE
fix(cli): support ':' prefixed remote paths in ls and cat

### DIFF
--- a/cmd/dat9/cli/cat.go
+++ b/cmd/dat9/cli/cat.go
@@ -13,11 +13,17 @@ import (
 // Uses ReadStream to handle both small files (direct) and large files (presigned URL).
 //
 //	dat9 cat /path/to/file
+//	dat9 cat :/path/to/file
 func Cat(c *client.Client, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("usage: dat9 cat <path>")
 	}
-	rc, err := c.ReadStream(context.Background(), args[0])
+	path := args[0]
+	// Handle ":" prefixed remote paths like cp command
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
+	}
+	rc, err := c.ReadStream(context.Background(), path)
 	if err != nil {
 		return err
 	}

--- a/cmd/dat9/cli/ls.go
+++ b/cmd/dat9/cli/ls.go
@@ -13,6 +13,7 @@ import (
 //	dat9 ls           list /
 //	dat9 ls /path/    list /path/
 //	dat9 ls -l /path  long format with size
+//	dat9 ls :/path    list using remote path prefix
 func Ls(c *client.Client, args []string) error {
 	long := false
 	path := "/"
@@ -24,6 +25,11 @@ func Ls(c *client.Client, args []string) error {
 		default:
 			path = arg
 		}
+	}
+
+	// Handle ":" prefixed remote paths like cp command
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
 	}
 
 	entries, err := c.List(path)


### PR DESCRIPTION
## Summary

Fixes #85 - CLI `ls` and `cat` commands now support ':' prefixed remote paths consistently with `cp` command.

## Changes

- `cmd/dat9/cli/ls.go`: Add `ParseRemote()` support to handle ':/path' format
- `cmd/dat9/cli/cat.go`: Add `ParseRemote()` support to handle ':/path/to/file' format

## Testing

All tests passed:
- ✓ `dat9 fs ls :/data/testdir/` - lists directory with ':' prefix
- ✓ `dat9 fs ls /data/testdir/` - lists directory without prefix (backward compatible)
- ✓ `dat9 fs cat :/data/testdir/test-file.txt` - reads file with ':' prefix  
- ✓ `dat9 fs cat /data/testdir/test-file.txt` - reads file without prefix (backward compatible)
- ✓ `dat9 fs ls -l :/data/testdir/` - works with flags
- ✓ `dat9 fs cp :/path` - existing functionality preserved

## Code Quality

- ✓ golangci-lint v2.5.0: 0 issues
- ✓ Backward compatible (paths without ':' still work)
- ✓ Consistent with existing cp command behavior

## Related

Fixes #85