### PR TITLE
ci: add CLI release workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -11,6 +11,10 @@ on:
       - 'Makefile'
   workflow_dispatch:
 
+concurrency:
+  group: release-cli
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Build and publish CLI
@@ -68,4 +72,5 @@ jobs:
           git add site/releases/
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "release: dat9 CLI ${{ env.VERSION }}"
+          git pull --rebase
           git push

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,71 @@
+name: Release CLI binaries
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/**'
+      - 'pkg/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Build and publish CLI
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout agfs dependency
+        run: |
+          git clone --depth 1 https://github.com/c4pt0r/agfs ../agfs
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Determine version
+        run: |
+          VERSION="${GITHUB_SHA::7}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Build CLI for all platforms
+        run: |
+          mkdir -p dist
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            os="${target%/*}"
+            arch="${target#*/}"
+            echo "Building dat9-${os}-${arch}..."
+            CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
+              go build -ldflags "-X main.version=${{ env.VERSION }}" \
+              -o "dist/dat9-${os}-${arch}" ./cmd/dat9
+          done
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum dat9-* > checksums.txt
+
+      - name: Write version file
+        run: |
+          echo "${{ env.VERSION }}" > dist/version
+
+      - name: Push to dat9-fe
+        run: |
+          git clone --depth 1 "https://x-access-token:${{ secrets.DAT9_FE_DEPLOY_TOKEN }}@github.com/mem9-ai/dat9-fe.git" /tmp/dat9-fe
+          mkdir -p /tmp/dat9-fe/site/releases
+          cp dist/* /tmp/dat9-fe/site/releases/
+          cd /tmp/dat9-fe
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add site/releases/
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "release: dat9 CLI ${{ env.VERSION }}"
+          git push


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-cli.yml` that cross-compiles the dat9 CLI for 4 platforms (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64)
- Publishes binaries + checksums + version file to `dat9-fe` site repo, served via Netlify CDN at `dat9.ai/releases/`
- Triggered on push to main (code paths) and manual workflow_dispatch

## Setup required
- Add `DAT9_FE_DEPLOY_TOKEN` secret to this repo (fine-grained PAT with `Contents: write` on `mem9-ai/dat9-fe`)

## Test plan
- [ ] Add the `DAT9_FE_DEPLOY_TOKEN` secret
- [ ] Trigger workflow manually via `workflow_dispatch`
- [ ] Verify `dat9-fe` repo has `site/releases/` with all 4 binaries, `version`, and `checksums.txt`
- [ ] Test installer: `curl -fsSL https://dat9.ai/install | sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)