### PR TITLE
fix(cli): support ':' prefixed paths in stat, rm, mv, find, grep, and sh commands

### DIFF
--- a/cmd/dat9/cli/cat.go
+++ b/cmd/dat9/cli/cat.go
@@ -13,11 +13,17 @@ import (
 // Uses ReadStream to handle both small files (direct) and large files (presigned URL).
 //
 //	dat9 cat /path/to/file
+//	dat9 cat :/path/to/file
 func Cat(c *client.Client, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("usage: dat9 cat <path>")
 	}
-	rc, err := c.ReadStream(context.Background(), args[0])
+	path := args[0]
+	// Handle ":" prefixed remote paths like cp command
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
+	}
+	rc, err := c.ReadStream(context.Background(), path)
 	if err != nil {
 		return err
 	}

--- a/cmd/dat9/cli/find.go
+++ b/cmd/dat9/cli/find.go
@@ -62,6 +62,11 @@ func Find(c *client.Client, args []string) error {
 		}
 	}
 
+	// Handle ":" prefixed remote paths like cp command
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
+	}
+
 	results, err := c.Find(path, params)
 	if err != nil {
 		return err

--- a/cmd/dat9/cli/grep.go
+++ b/cmd/dat9/cli/grep.go
@@ -18,6 +18,11 @@ func Grep(c *client.Client, args []string) error {
 		path = args[1]
 	}
 
+	// Handle ":" prefixed remote paths like cp command
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
+	}
+
 	results, err := c.Grep(query, path, 20)
 	if err != nil {
 		return err
@@ -44,6 +49,12 @@ func GrepJSON(c *client.Client, args []string) error {
 	if len(args) > 1 {
 		path = args[1]
 	}
+
+	// Handle ":" prefixed remote paths like cp command
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
+	}
+
 	results, err := c.Grep(query, path, 20)
 	if err != nil {
 		return err

--- a/cmd/dat9/cli/ls.go
+++ b/cmd/dat9/cli/ls.go
@@ -13,6 +13,7 @@ import (
 //	dat9 ls           list /
 //	dat9 ls /path/    list /path/
 //	dat9 ls -l /path  long format with size
+//	dat9 ls :/path    list using remote path prefix
 func Ls(c *client.Client, args []string) error {
 	long := false
 	path := "/"
@@ -24,6 +25,11 @@ func Ls(c *client.Client, args []string) error {
 		default:
 			path = arg
 		}
+	}
+
+	// Handle ":" prefixed remote paths like cp command
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
 	}
 
 	entries, err := c.List(path)

--- a/cmd/dat9/cli/mv.go
+++ b/cmd/dat9/cli/mv.go
@@ -9,9 +9,19 @@ import (
 // Mv renames or moves a remote file/directory. Metadata-only, zero S3 cost.
 //
 //	dat9 mv /old/path /new/path
+//	dat9 mv :/old/path :/new/path
 func Mv(c *client.Client, args []string) error {
 	if len(args) != 2 {
 		return fmt.Errorf("usage: dat9 mv <old> <new>")
 	}
-	return c.Rename(args[0], args[1])
+	oldPath := args[0]
+	newPath := args[1]
+	// Handle ":" prefixed remote paths like cp command
+	if rp, isRemote := ParseRemote(oldPath); isRemote {
+		oldPath = rp.Path
+	}
+	if rp, isRemote := ParseRemote(newPath); isRemote {
+		newPath = rp.Path
+	}
+	return c.Rename(oldPath, newPath)
 }

--- a/cmd/dat9/cli/rm.go
+++ b/cmd/dat9/cli/rm.go
@@ -9,9 +9,15 @@ import (
 // Rm removes a remote file or directory.
 //
 //	dat9 rm /path/to/file
+//	dat9 rm :/path/to/file
 func Rm(c *client.Client, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("usage: dat9 rm <path>")
 	}
-	return c.Delete(args[0])
+	path := args[0]
+	// Handle ":" prefixed remote paths like cp command
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
+	}
+	return c.Delete(path)
 }

--- a/cmd/dat9/cli/sh.go
+++ b/cmd/dat9/cli/sh.go
@@ -133,7 +133,12 @@ func Sh(c *client.Client, _ []string) error {
 }
 
 // resolve resolves a path relative to the current working directory.
+// Handles ":" prefixed remote paths like cp command (fixes issue #19).
 func resolve(cwd, path string) string {
+	// Handle ":" prefixed remote paths
+	if rp, isRemote := ParseRemote(path); isRemote {
+		return rp.Path
+	}
 	if strings.HasPrefix(path, "/") {
 		return path
 	}

--- a/cmd/dat9/cli/stat.go
+++ b/cmd/dat9/cli/stat.go
@@ -9,11 +9,17 @@ import (
 // Stat shows metadata for a remote path.
 //
 //	dat9 stat /path/to/file
+//	dat9 stat :/path/to/file
 func Stat(c *client.Client, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("usage: dat9 stat <path>")
 	}
-	s, err := c.Stat(args[0])
+	path := args[0]
+	// Handle ":" prefixed remote paths like cp command
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
+	}
+	s, err := c.Stat(path)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/c4pt0r/agfs/agfs-server v0.0.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/uuid v1.6.0
+	github.com/hanwen/go-fuse/v2 v2.9.0
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.41.0
@@ -56,7 +57,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/hanwen/go-fuse/v2 v2.9.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkV
 github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
+github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
+github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
 github.com/moby/sys/sequential v0.6.0/go.mod h1:uyv8EUTrca5PnDsdMGXhZe6CCe8U/UiTWd+lL+7b/Ko=
 github.com/moby/sys/user v0.4.0 h1:jhcMKit7SA80hivmFJcbB1vqmw//wU61Zdui2eQXuMs=


### PR DESCRIPTION
## Summary

This PR extends the fix from #86 to add ':' prefixed remote path support to remaining CLI commands.

## Changes

Add `ParseRemote()` support to handle ':/path' format in:
- **stat** - metadata display  
- **rm** - file removal
- **mv** - rename/move operations (both source and destination)
- **find** - file search
- **grep** - content search (both Grep and GrepJSON functions)
- **sh** - interactive shell resolve() function

## Related Issues

- Builds on #86 (already merged)
- Fixes #19 (shell resolve() handles directory paths incorrectly)
- Related to #85

## Testing

All commands now handle ':' prefixed paths consistently:
- ✓ `dat9 fs stat :/path/to/file`
- ✓ `dat9 fs rm :/path/to/file`
- ✓ `dat9 fs mv :/old/path :/new/path`
- ✓ `dat9 fs find :/path -name *.txt`
- ✓ `dat9 fs grep pattern :/path`
- ✓ `dat9 fs sh` with cd/cat/ls commands

## Code Quality

- ✓ golangci-lint v2.5.0: 0 issues
- ✓ Backward compatible (paths without ':' still work)
- ✓ Consistent with cp command behavior