### PR TITLE
fix: improve install onboarding, fix server URL, tune storage thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,10 @@ c.Delete("/data/file.txt")
   Dat9Backend   memfs     S3 direct
   (AGFS FileSystem)       (presigned URL,
      │                     FUSE ↔ S3)
-     ├── < 50KB → TiDB(MySQL protocol) + local blobs (P0)
-     │            db9 + fs9 (production)
+     ├── < 50,000B → TiDB(MySQL protocol) + local blobs (P0)
+     │               db9 + fs9 (production)
      │
-     └── ≥ 50KB → S3 presigned URL
+     └── ≥ 50,000B → S3 presigned URL
                   (direct upload, server not involved)
 ```
 
@@ -184,7 +184,7 @@ c.Delete("/data/file.txt")
 
 **inode model** — Paths (file_nodes) and file entities (files) are separate, just like Unix. One file can appear at multiple paths. `cp` is a zero-cost link. `mv` is metadata-only. `rm` is reference-counted.
 
-**Tiered storage** — Small files (< 50KB) go to db9 with automatic embedding and FTS indexing. Large files (≥ 50KB) go directly to S3 via presigned URLs. One path namespace spans both.
+**Tiered storage** — Small files (< 50,000 bytes) go to db9 with automatic embedding and FTS indexing. Large files (≥ 50,000 bytes) go directly to S3 via presigned URLs. One path namespace spans both.
 
 **Tiered context (L0/L1/L2)** — Every directory can carry `.abstract.md` (~100 tokens) and `.overview.md` (~1k tokens). Agents scan cheaply via L0/L1 before loading full content (L2). 10x token savings.
 

--- a/README.md
+++ b/README.md
@@ -173,10 +173,10 @@ c.Delete("/data/file.txt")
   Dat9Backend   memfs     S3 direct
   (AGFS FileSystem)       (presigned URL,
      │                     FUSE ↔ S3)
-     ├── < 1MB → TiDB(MySQL protocol) + local blobs (P0)
+     ├── < 50KB → TiDB(MySQL protocol) + local blobs (P0)
      │            db9 + fs9 (production)
      │
-     └── ≥ 1MB → S3 presigned URL
+     └── ≥ 50KB → S3 presigned URL
                   (direct upload, server not involved)
 ```
 
@@ -184,7 +184,7 @@ c.Delete("/data/file.txt")
 
 **inode model** — Paths (file_nodes) and file entities (files) are separate, just like Unix. One file can appear at multiple paths. `cp` is a zero-cost link. `mv` is metadata-only. `rm` is reference-counted.
 
-**Tiered storage** — Small files (< 1MB) go to db9 with automatic embedding and FTS indexing. Large files (≥ 1MB) go directly to S3 via presigned URLs. One path namespace spans both.
+**Tiered storage** — Small files (< 50KB) go to db9 with automatic embedding and FTS indexing. Large files (≥ 50KB) go directly to S3 via presigned URLs. One path namespace spans both.
 
 **Tiered context (L0/L1/L2)** — Every directory can carry `.abstract.md` (~100 tokens) and `.overview.md` (~1k tokens). Agents scan cheaply via L0/L1 before loading full content (L2). 10x token savings.
 

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -61,7 +61,7 @@ dat9 adds what db9 doesn't have: **large-file S3 direct upload**, **path-tree na
 
 1. **Users see only file operations** --- `cp`, `cat`, `ls`, `search`. All protocol complexity is hidden.
 2. **Leverage db9 native capabilities** --- embedding, FTS, vector search, chunking are db9 built-in. dat9 orchestrates, not reimplements.
-3. **Tiered storage** --- Small files (< 1MB) in db9 (zero network overhead, instant search). Large files (>= 1MB) in S3 (presigned URL direct upload). One path namespace spanning both.
+3. **Tiered storage** --- Small files (< 50KB) in db9 (zero network overhead, instant search). Large files (>= 50KB) in S3 (presigned URL direct upload). One path namespace spanning both.
 4. **inode model** --- Paths and file entities are separate. One file can appear at multiple paths (zero-copy `cp`). `mv` is a metadata-only operation.
 5. **Import, don't fork** --- Built on [AGFS](https://github.com/c4pt0r/agfs)'s `FileSystem` interface and `MountableFS` routing layer.
 6. **Tiered context loading** --- Inspired by [OpenViking](https://github.com/volcengine/OpenViking)'s L0/L1/L2 model. Every directory can carry a ~100-token abstract (L0) and a ~1k-token overview (L1), enabling agents to scan cheaply before loading full content (L2).
@@ -89,8 +89,8 @@ dat9 adds what db9 doesn't have: **large-file S3 direct upload**, **path-tree na
 │  │              (implements AGFS FileSystem)                         │  │
 │  │                                                                  │  │
 │  │  Write path:                                                     │  │
-│  │    < 1MB  → db9 fs9_write()        (instant, auto-embedding)     │  │
-│  │    >= 1MB → S3 presigned URL       (direct upload, never proxied)│  │
+│  │    < 50KB → db9 fs9_write()        (instant, auto-embedding)     │  │
+│  │    >= 50KB → S3 presigned URL      (direct upload, never proxied)│  │
 │  │                                                                  │  │
 │  │  Read path:                                                      │  │
 │  │    db9 file → fs9_read()           (~1ms)                        │  │
@@ -109,7 +109,7 @@ dat9 adds what db9 doesn't have: **large-file S3 direct upload**, **path-tree na
 │  │ + fs9    │  │ <ulid>   │                                          │
 │  │ + embed  │  │          │                                          │
 │  │ + FTS    │  │ 大文件    │                                          │
-│  │ + vector │  │ >= 1MB   │                                          │
+│  │ + vector │  │ >= 50KB  │                                          │
 │  └──────────┘  └──────────┘                                          │
 │                                                                       │
 │  ┌───────────────────────────────────────────────────────────────┐    │
@@ -122,7 +122,7 @@ dat9 adds what db9 doesn't have: **large-file S3 direct upload**, **path-tree na
 
 ### Why Two Storage Tiers?
 
-| Concern | db9 (< 1MB) | S3 (>= 1MB) |
+| Concern | db9 (< 50KB) | S3 (>= 50KB) |
 |---------|-------------|-------------|
 | **Latency** | ~1ms (TiKV local read) | ~50ms (HTTP round-trip) |
 | **Max size** | 100MB (db9 limit) | Unlimited |
@@ -131,7 +131,7 @@ dat9 adds what db9 doesn't have: **large-file S3 direct upload**, **path-tree na
 | **Semantic search** | Native HNSW + GIN | Only via L0 abstract (small file in db9) |
 | **Cost** | db9 compute + TiKV storage | S3 storage (cheap) + transfer |
 
-Small files benefit from db9's native embedding/FTS. Large files are too big for db9 and too expensive to embed entirely — they participate in search only through their L0 abstracts (which are small files stored in db9).
+Small files benefit from db9's native embedding/FTS. Large files are too big to embed entirely — they participate in search only through their L0 abstracts (which are small files stored in db9).
 
 ### Relationship with AGFS
 
@@ -271,7 +271,7 @@ Small files are stored in db9 via `fs9_write('/blobs/<ulid>', content)`. Same UL
 
 ## 4. Two Data Paths
 
-### Small Files (< 1MB): Server Proxy → db9
+### Small Files (< 50KB): Server Proxy → db9
 
 ```
 Client ──PUT body──▶ dat9 server
@@ -286,7 +286,7 @@ Client ◀── 200 OK ──────┘
 
 The server reads the request body, writes to db9, creates metadata, and returns. Simple, synchronous. **Embedding and FTS indexing happen automatically** via db9's `GENERATED ALWAYS AS` columns — no async pipeline needed for small files.
 
-### Large Files (>= 1MB): Presigned URL Direct Upload → S3
+### Large Files (>= 50KB): Presigned URL Direct Upload → S3
 
 ```
 Client ──PUT (Content-Length only, no body)──▶ dat9 server
@@ -318,7 +318,7 @@ Client ◀── 200 { confirmed } ───────────────
 
 The server never touches large file data. Large files have `vec=NULL` and `tsv=NULL` — they don't participate in search directly. They participate through their L0 abstracts (see §5).
 
-**Capability-aware write handler**: the server checks `backend.(filesystem.CapabilityProvider).GetCapabilities().IsObjectStore` via type assertion. If true and size >= 1MB threshold, return 202 with presigned URLs.
+**Capability-aware write handler**: the server checks `backend.(filesystem.CapabilityProvider).GetCapabilities().IsObjectStore` via type assertion. If true and size >= 50KB threshold, return 202 with presigned URLs.
 
 ### Resumable Uploads
 
@@ -344,7 +344,7 @@ Every directory in dat9 can optionally carry three layers of progressively detai
 |-------|------|-------------|---------|---------|
 | **L0** | `.abstract.md` | ~100 tokens (~400B) | Ultra-short summary. Vector search, quick filtering. | db9 (small file, auto-embedded) |
 | **L1** | `.overview.md` | ~1-2k tokens (~4KB) | Structured overview with navigation pointers. | db9 (small file, auto-embedded) |
-| **L2** | Original files | Unlimited | Full content. Loaded only when the agent confirms it needs the detail. | db9 (< 1MB) or S3 (>= 1MB) |
+| **L2** | Original files | Unlimited | Full content. Loaded only when the agent confirms it needs the detail. | db9 (< 50KB) or S3 (>= 50KB) |
 
 Example directory:
 
@@ -999,7 +999,7 @@ Raw input (URL-decoded once)
 
 | Control | Spec |
 |---------|------|
-| **TTL** | Upload: max 120 seconds. Download: max 60 seconds. |
+| **TTL** | Upload: max 10 minutes. Download: max 10 minutes. |
 | **Binding** | Upload URLs bind: part number, `Content-Length`, `x-amz-checksum-sha256`. |
 | **Log hygiene** | Redact `X-Amz-Signature` and `X-Amz-Credential` in logs. |
 | **Download indirection** | `GET /v1/fs/{path}` for large files → one-time ticket → presigned URL. |
@@ -1048,7 +1048,7 @@ Raw input (URL-decoded once)
 
 | Question | Options | Leaning |
 |---|---|---|
-| Small/large file threshold | 1MB / 5MB / 10MB | 5MB — db9 fs9 supports up to 100MB; a 3MB Markdown document benefits from auto-embedding. Higher threshold = more files get semantic search for free. Trade-off: larger db9 storage cost per tenant. |
+| Small/large file threshold | 50,000 bytes | Aligned with embedding model's max input (50,000 characters). Files below threshold get auto-embedding and FTS in db9. Files above go to S3 and participate in search via L0 abstracts. |
 | db9 embedding model | text-embedding-v4 / amazon.titan-embed-text-v2:0 | titan (matches user config) |
 | db9 FTS tokenizer | simple / jieba / chinese_ngram | jieba (Chinese support) |
 | Object store | AWS S3 / MinIO / R2 | S3 for cloud, MinIO for on-prem |

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -61,7 +61,7 @@ dat9 adds what db9 doesn't have: **large-file S3 direct upload**, **path-tree na
 
 1. **Users see only file operations** --- `cp`, `cat`, `ls`, `search`. All protocol complexity is hidden.
 2. **Leverage db9 native capabilities** --- embedding, FTS, vector search, chunking are db9 built-in. dat9 orchestrates, not reimplements.
-3. **Tiered storage** --- Small files (< 50KB) in db9 (zero network overhead, instant search). Large files (>= 50KB) in S3 (presigned URL direct upload). One path namespace spanning both.
+3. **Tiered storage** --- Small files (< 50,000 bytes) in db9 (zero network overhead, instant search). Large files (>= 50,000 bytes) in S3 (presigned URL direct upload). One path namespace spanning both.
 4. **inode model** --- Paths and file entities are separate. One file can appear at multiple paths (zero-copy `cp`). `mv` is a metadata-only operation.
 5. **Import, don't fork** --- Built on [AGFS](https://github.com/c4pt0r/agfs)'s `FileSystem` interface and `MountableFS` routing layer.
 6. **Tiered context loading** --- Inspired by [OpenViking](https://github.com/volcengine/OpenViking)'s L0/L1/L2 model. Every directory can carry a ~100-token abstract (L0) and a ~1k-token overview (L1), enabling agents to scan cheaply before loading full content (L2).
@@ -89,8 +89,8 @@ dat9 adds what db9 doesn't have: **large-file S3 direct upload**, **path-tree na
 │  │              (implements AGFS FileSystem)                         │  │
 │  │                                                                  │  │
 │  │  Write path:                                                     │  │
-│  │    < 50KB → db9 fs9_write()        (instant, auto-embedding)     │  │
-│  │    >= 50KB → S3 presigned URL      (direct upload, never proxied)│  │
+│  │    < 50,000B → db9 fs9_write()      (instant, auto-embedding)     │  │
+│  │    >= 50,000B → S3 presigned URL   (direct upload, never proxied)│  │
 │  │                                                                  │  │
 │  │  Read path:                                                      │  │
 │  │    db9 file → fs9_read()           (~1ms)                        │  │
@@ -109,7 +109,7 @@ dat9 adds what db9 doesn't have: **large-file S3 direct upload**, **path-tree na
 │  │ + fs9    │  │ <ulid>   │                                          │
 │  │ + embed  │  │          │                                          │
 │  │ + FTS    │  │ 大文件    │                                          │
-│  │ + vector │  │ >= 50KB  │                                          │
+│  │ + vector │  │ >= 50,000B│                                          │
 │  └──────────┘  └──────────┘                                          │
 │                                                                       │
 │  ┌───────────────────────────────────────────────────────────────┐    │
@@ -122,7 +122,7 @@ dat9 adds what db9 doesn't have: **large-file S3 direct upload**, **path-tree na
 
 ### Why Two Storage Tiers?
 
-| Concern | db9 (< 50KB) | S3 (>= 50KB) |
+| Concern | db9 (< 50,000B) | S3 (>= 50,000B) |
 |---------|-------------|-------------|
 | **Latency** | ~1ms (TiKV local read) | ~50ms (HTTP round-trip) |
 | **Max size** | 100MB (db9 limit) | Unlimited |
@@ -271,7 +271,7 @@ Small files are stored in db9 via `fs9_write('/blobs/<ulid>', content)`. Same UL
 
 ## 4. Two Data Paths
 
-### Small Files (< 50KB): Server Proxy → db9
+### Small Files (< 50,000 bytes): Server Proxy → db9
 
 ```
 Client ──PUT body──▶ dat9 server
@@ -286,7 +286,7 @@ Client ◀── 200 OK ──────┘
 
 The server reads the request body, writes to db9, creates metadata, and returns. Simple, synchronous. **Embedding and FTS indexing happen automatically** via db9's `GENERATED ALWAYS AS` columns — no async pipeline needed for small files.
 
-### Large Files (>= 50KB): Presigned URL Direct Upload → S3
+### Large Files (>= 50,000 bytes): Presigned URL Direct Upload → S3
 
 ```
 Client ──PUT (Content-Length only, no body)──▶ dat9 server
@@ -318,7 +318,7 @@ Client ◀── 200 { confirmed } ───────────────
 
 The server never touches large file data. Large files have `vec=NULL` and `tsv=NULL` — they don't participate in search directly. They participate through their L0 abstracts (see §5).
 
-**Capability-aware write handler**: the server checks `backend.(filesystem.CapabilityProvider).GetCapabilities().IsObjectStore` via type assertion. If true and size >= 50KB threshold, return 202 with presigned URLs.
+**Capability-aware write handler**: the server checks `backend.(filesystem.CapabilityProvider).GetCapabilities().IsObjectStore` via type assertion. If true and size >= 50,000 bytes threshold, return 202 with presigned URLs.
 
 ### Resumable Uploads
 
@@ -344,7 +344,7 @@ Every directory in dat9 can optionally carry three layers of progressively detai
 |-------|------|-------------|---------|---------|
 | **L0** | `.abstract.md` | ~100 tokens (~400B) | Ultra-short summary. Vector search, quick filtering. | db9 (small file, auto-embedded) |
 | **L1** | `.overview.md` | ~1-2k tokens (~4KB) | Structured overview with navigation pointers. | db9 (small file, auto-embedded) |
-| **L2** | Original files | Unlimited | Full content. Loaded only when the agent confirms it needs the detail. | db9 (< 50KB) or S3 (>= 50KB) |
+| **L2** | Original files | Unlimited | Full content. Loaded only when the agent confirms it needs the detail. | db9 (< 50,000B) or S3 (>= 50,000B) |
 
 Example directory:
 

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const smallFileThreshold = 50 << 10 // 50KB
+const smallFileThreshold = 50_000 // 50,000 bytes — matches embedding model max input characters
 
 // Dat9Backend implements filesystem.FileSystem with the inode model.
 type Dat9Backend struct {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const smallFileThreshold = 1 << 20 // 1MB
+const smallFileThreshold = 50 << 10 // 50KB
 
 // Dat9Backend implements filesystem.FileSystem with the inode model.
 type Dat9Backend struct {

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -37,7 +37,7 @@ type PartURL struct {
 type ProgressFunc func(partNumber, totalParts int, bytesUploaded int64)
 
 // DefaultSmallFileThreshold matches the server's threshold for direct PUT vs multipart.
-const DefaultSmallFileThreshold = 50 << 10 // 50KB
+const DefaultSmallFileThreshold = 50_000 // 50,000 bytes — matches embedding model max input characters
 
 // WriteStream uploads data from a reader. For small files (size < threshold),
 // it does a direct PUT with body. For large files, it sends a Content-Length-only

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -37,7 +37,7 @@ type PartURL struct {
 type ProgressFunc func(partNumber, totalParts int, bytesUploaded int64)
 
 // DefaultSmallFileThreshold matches the server's threshold for direct PUT vs multipart.
-const DefaultSmallFileThreshold = 1 << 20 // 1MB
+const DefaultSmallFileThreshold = 50 << 10 // 50KB
 
 // WriteStream uploads data from a reader. For small files (size < threshold),
 // it does a direct PUT with body. For large files, it sends a Content-Length-only

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -10,7 +10,7 @@ import (
 const (
 	defaultReadCacheMaxSize = 128 << 20          // 128MB
 	defaultReadCacheTTL     = 30 * time.Second   // 30s
-	smallFileThreshold      = 1 << 20            // 1MB - matches client.DefaultSmallFileThreshold
+	smallFileThreshold      = 50 << 10           // 50KB - matches client.DefaultSmallFileThreshold
 )
 
 // cacheEntry holds a single cached file's data and metadata.

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -10,7 +10,7 @@ import (
 const (
 	defaultReadCacheMaxSize = 128 << 20          // 128MB
 	defaultReadCacheTTL     = 30 * time.Second   // 30s
-	smallFileThreshold      = 50 << 10           // 50KB - matches client.DefaultSmallFileThreshold
+	smallFileThreshold      = 50_000             // 50,000 bytes — matches embedding model max input characters
 )
 
 // cacheEntry holds a single cached file's data and metadata.

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -77,8 +77,8 @@ type S3Client interface {
 
 // Default presigned URL TTLs per design doc §11.2.
 const (
-	UploadTTL   = 120 * time.Second
-	DownloadTTL = 60 * time.Second
+	UploadTTL   = 10 * time.Minute
+	DownloadTTL = 10 * time.Minute
 )
 
 // PartSize is the default multipart part size (8MB).

--- a/site/skill.md
+++ b/site/skill.md
@@ -147,7 +147,7 @@ Use `grep` to find files by what they contain. Use `find` to find files by name,
 
 | Variable | Description | Default |
 |---|---|---|
-| `DAT9_SERVER` | Server URL | `https://api.db9.ai` |
+| `DAT9_SERVER` | Server URL | `https://api.dat9.ai` |
 | `DAT9_API_KEY` | API key | (from `~/.dat9/config`) |
 
 ---


### PR DESCRIPTION
## Summary

- **install.sh**: Replace flat post-install output with numbered 1-2-3 setup flow (create workspace → verify → start using). Fix misleading "provision a new database" copy → "Create a workspace"
- **install.sh**: Bootstrap `~/.dat9/config` with server URL on install so config file exists immediately. Extract `BASE_URL` and `API_URL` as top-level variables
- **config.go**: Fix default server URL from `api.db9.ai` → `api.dat9.ai`
- **storage**: Lower small file threshold from 1MB to 50KB — files ≥ 50KB now go to S3 instead of inline DB storage
- **s3**: Increase presigned URL TTL from 2min/1min to 10min for both upload and download

## Test plan

- [ ] Run `sh site/install.sh` locally and verify post-install output shows numbered steps
- [ ] Verify `~/.dat9/config` is created with correct JSON and `api.dat9.ai` server
- [ ] Verify re-running install does not overwrite existing config
- [ ] Upload files around 50KB boundary and confirm small files go to DB, large files go to S3
- [ ] Verify presigned URLs remain valid for ~10 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)