### PR TITLE
fix: avoid API Gateway header overflow on large uploads

### DIFF
--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -55,13 +55,6 @@ func (c *Client) WriteStream(ctx context.Context, path string, r io.Reader, size
 		}
 		return c.Write(path, data)
 	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(path), http.NoBody)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/octet-stream")
-	req.Header.Set("X-Dat9-Content-Length", fmt.Sprintf("%d", size))
 	ra, ok := r.(io.ReaderAt)
 	if !ok {
 		return fmt.Errorf("large uploads require an io.ReaderAt (seekable source) to compute per-part checksums")
@@ -70,25 +63,86 @@ func (c *Client) WriteStream(ctx context.Context, path string, r io.Reader, size
 	if err != nil {
 		return fmt.Errorf("compute part checksums: %w", err)
 	}
+	plan, err := c.initiateUpload(ctx, path, size, checksums)
+	if err != nil {
+		return err
+	}
+	return c.uploadParts(ctx, plan, r, progress)
+}
+
+type uploadInitiateRequest struct {
+	Path          string   `json:"path"`
+	TotalSize     int64    `json:"total_size"`
+	PartChecksums []string `json:"part_checksums"`
+}
+
+func (c *Client) initiateUpload(ctx context.Context, path string, size int64, checksums []string) (UploadPlan, error) {
+	plan, resp, err := c.initiateUploadByBody(ctx, path, size, checksums)
+	if err == nil {
+		return plan, nil
+	}
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
+			return c.initiateUploadLegacy(ctx, path, size, checksums)
+		}
+		return UploadPlan{}, err
+	}
+	return UploadPlan{}, err
+}
+
+func (c *Client) initiateUploadByBody(ctx context.Context, path string, size int64, checksums []string) (UploadPlan, *http.Response, error) {
+	body, err := json.Marshal(uploadInitiateRequest{Path: path, TotalSize: size, PartChecksums: checksums})
+	if err != nil {
+		return UploadPlan{}, nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/uploads/initiate", bytes.NewReader(body))
+	if err != nil {
+		return UploadPlan{}, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return UploadPlan{}, nil, err
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		return UploadPlan{}, resp, readError(resp)
+	}
+	var plan UploadPlan
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		_ = resp.Body.Close()
+		return UploadPlan{}, nil, fmt.Errorf("decode upload plan: %w", err)
+	}
+	_ = resp.Body.Close()
+	return plan, nil, nil
+}
+
+func (c *Client) initiateUploadLegacy(ctx context.Context, path string, size int64, checksums []string) (UploadPlan, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(path), http.NoBody)
+	if err != nil {
+		return UploadPlan{}, err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("X-Dat9-Content-Length", fmt.Sprintf("%d", size))
 	if len(checksums) > 0 {
 		req.Header.Set("X-Dat9-Part-Checksums", strings.Join(checksums, ","))
 	}
 
 	resp, err := c.do(req)
 	if err != nil {
-		return err
+		return UploadPlan{}, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusAccepted {
-		return readError(resp)
+		return UploadPlan{}, readError(resp)
 	}
 
 	var plan UploadPlan
 	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
-		return fmt.Errorf("decode upload plan: %w", err)
+		return UploadPlan{}, fmt.Errorf("decode upload plan: %w", err)
 	}
-	return c.uploadParts(ctx, plan, r, progress)
+	return plan, nil
 }
 
 // uploadParts concurrently uploads parts to presigned URLs.

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -76,6 +76,10 @@ type uploadInitiateRequest struct {
 	PartChecksums []string `json:"part_checksums"`
 }
 
+type uploadResumeRequest struct {
+	PartChecksums []string `json:"part_checksums"`
+}
+
 func (c *Client) initiateUpload(ctx context.Context, path string, size int64, checksums []string) (UploadPlan, error) {
 	plan, resp, err := c.initiateUploadByBody(ctx, path, size, checksums)
 	if err == nil {
@@ -492,6 +496,54 @@ func (c *Client) queryUpload(ctx context.Context, path string) (*UploadMeta, err
 
 // requestResume asks the server to generate presigned URLs for missing parts.
 func (c *Client) requestResume(ctx context.Context, uploadID string, checksums []string) (*UploadPlan, error) {
+	plan, resp, err := c.requestResumeByBody(ctx, uploadID, checksums)
+	if err == nil {
+		return plan, nil
+	}
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode == http.StatusBadRequest && strings.Contains(strings.ToLower(err.Error()), "missing x-dat9-part-checksums header") {
+			return c.requestResumeLegacy(ctx, uploadID, checksums)
+		}
+		return nil, err
+	}
+	return nil, err
+}
+
+func (c *Client) requestResumeByBody(ctx context.Context, uploadID string, checksums []string) (*UploadPlan, *http.Response, error) {
+	body, err := json.Marshal(uploadResumeRequest{PartChecksums: checksums})
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/v1/uploads/"+uploadID+"/resume", bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if resp.StatusCode == http.StatusGone {
+		_ = resp.Body.Close()
+		return nil, nil, fmt.Errorf("upload %s has expired", uploadID)
+	}
+	if resp.StatusCode >= 300 {
+		return nil, resp, readError(resp)
+	}
+
+	var plan UploadPlan
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		_ = resp.Body.Close()
+		return nil, nil, fmt.Errorf("decode resume plan: %w", err)
+	}
+	_ = resp.Body.Close()
+	return &plan, nil, nil
+}
+
+func (c *Client) requestResumeLegacy(ctx context.Context, uploadID string, checksums []string) (*UploadPlan, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		c.baseURL+"/v1/uploads/"+uploadID+"/resume", nil)
 	if err != nil {

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -86,6 +86,9 @@ func (c *Client) initiateUpload(ctx context.Context, path string, size int64, ch
 		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
 			return c.initiateUploadLegacy(ctx, path, size, checksums)
 		}
+		if resp.StatusCode == http.StatusBadRequest && strings.Contains(strings.ToLower(err.Error()), "unknown upload action") {
+			return c.initiateUploadLegacy(ctx, path, size, checksums)
+		}
 		return UploadPlan{}, err
 	}
 	return UploadPlan{}, err

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -56,9 +56,14 @@ func TestWriteStreamLargeFile(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs/large.bin":
-			if h := r.Header.Get("X-Dat9-Content-Length"); h != "8" {
-				http.Error(w, fmt.Sprintf("expected X-Dat9-Content-Length=8, got %q", h), 400)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/initiate":
+			var req uploadInitiateRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "bad json", http.StatusBadRequest)
+				return
+			}
+			if req.Path != "/large.bin" || req.TotalSize != 8 {
+				http.Error(w, fmt.Sprintf("bad initiate payload: %+v", req), http.StatusBadRequest)
 				return
 			}
 			// Return 202 with upload plan
@@ -126,6 +131,41 @@ func TestWriteStreamLargeFile(t *testing.T) {
 	}
 	if len(progressCalls) != 2 {
 		t.Errorf("progress called %d times, want 2", len(progressCalls))
+	}
+}
+
+func TestWriteStreamLargeFileFallsBackToLegacyInitiate(t *testing.T) {
+	var usedLegacy bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/initiate":
+			http.NotFound(w, r)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs/legacy.bin":
+			usedLegacy = true
+			if h := r.Header.Get("X-Dat9-Content-Length"); h != "8" {
+				http.Error(w, "bad length", http.StatusBadRequest)
+				return
+			}
+			plan := UploadPlan{UploadID: "legacy-upload", Parts: []PartURL{{Number: 1, URL: fmt.Sprintf("http://%s/legacy/part/1", r.Host), Size: 8}}}
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(plan)
+		case r.Method == http.MethodPut && r.URL.Path == "/legacy/part/1":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/legacy-upload/complete":
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	c.smallFileThreshold = 1
+	if err := c.WriteStream(context.Background(), "/legacy.bin", bytes.NewReader([]byte("12345678")), 8, nil); err != nil {
+		t.Fatalf("WriteStream: %v", err)
+	}
+	if !usedLegacy {
+		t.Fatal("expected legacy initiate fallback to be used")
 	}
 }
 

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/mem9-ai/dat9/internal/testmysql"
@@ -135,13 +136,13 @@ func TestWriteStreamLargeFile(t *testing.T) {
 }
 
 func TestWriteStreamLargeFileFallsBackToLegacyInitiate(t *testing.T) {
-	var usedLegacy bool
+	var usedLegacy atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/initiate":
 			http.NotFound(w, r)
 		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs/legacy.bin":
-			usedLegacy = true
+			usedLegacy.Store(true)
 			if h := r.Header.Get("X-Dat9-Content-Length"); h != "8" {
 				http.Error(w, "bad length", http.StatusBadRequest)
 				return
@@ -164,7 +165,38 @@ func TestWriteStreamLargeFileFallsBackToLegacyInitiate(t *testing.T) {
 	if err := c.WriteStream(context.Background(), "/legacy.bin", bytes.NewReader([]byte("12345678")), 8, nil); err != nil {
 		t.Fatalf("WriteStream: %v", err)
 	}
-	if !usedLegacy {
+	if !usedLegacy.Load() {
+		t.Fatal("expected legacy initiate fallback to be used")
+	}
+}
+
+func TestWriteStreamLargeFileFallsBackOnUnknownUploadAction(t *testing.T) {
+	var usedLegacy atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/initiate":
+			http.Error(w, `{"error":"unknown upload action"}`, http.StatusBadRequest)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs/legacy.bin":
+			usedLegacy.Store(true)
+			plan := UploadPlan{UploadID: "legacy-upload-400", Parts: []PartURL{{Number: 1, URL: fmt.Sprintf("http://%s/legacy400/part/1", r.Host), Size: 8}}}
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(plan)
+		case r.Method == http.MethodPut && r.URL.Path == "/legacy400/part/1":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/legacy-upload-400/complete":
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	c.smallFileThreshold = 1
+	if err := c.WriteStream(context.Background(), "/legacy.bin", bytes.NewReader([]byte("12345678")), 8, nil); err != nil {
+		t.Fatalf("WriteStream: %v", err)
+	}
+	if !usedLegacy.Load() {
 		t.Fatal("expected legacy initiate fallback to be used")
 	}
 }

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -341,6 +341,17 @@ func TestResumeUpload(t *testing.T) {
 			})
 
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/resume-456/resume":
+			var req struct {
+				PartChecksums []string `json:"part_checksums"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "bad json", http.StatusBadRequest)
+				return
+			}
+			if len(req.PartChecksums) == 0 {
+				http.Error(w, "bad checksums", http.StatusBadRequest)
+				return
+			}
 			// Step 2: Return missing parts (only part 2 is missing)
 			plan := UploadPlan{
 				UploadID: "resume-456",
@@ -393,6 +404,49 @@ func TestResumeUpload(t *testing.T) {
 	}
 	if progressCalls[0] != [2]int{2, 3} {
 		t.Fatalf("progress = %v, want [[2 3]]", progressCalls)
+	}
+}
+
+func TestResumeUploadFallsBackToLegacyHeader(t *testing.T) {
+	var resumeCalls int
+	var usedLegacy atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/uploads":
+			_ = json.NewEncoder(w).Encode(struct {
+				Uploads []UploadMeta `json:"uploads"`
+			}{
+				Uploads: []UploadMeta{{UploadID: "resume-legacy", PartsTotal: 1, Status: "UPLOADING"}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/resume-legacy/resume":
+			resumeCalls++
+			if resumeCalls == 1 {
+				http.Error(w, `{"error":"missing X-Dat9-Part-Checksums header"}`, http.StatusBadRequest)
+				return
+			}
+			if r.Header.Get("X-Dat9-Part-Checksums") == "" {
+				http.Error(w, "missing legacy header", http.StatusBadRequest)
+				return
+			}
+			usedLegacy.Store(true)
+			_ = json.NewEncoder(w).Encode(UploadPlan{UploadID: "resume-legacy", PartSize: 8, Parts: []PartURL{{Number: 1, URL: fmt.Sprintf("http://%s/resume-legacy/part/1", r.Host), Size: 8}}})
+		case r.Method == http.MethodPut && r.URL.Path == "/resume-legacy/part/1":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/resume-legacy/complete":
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	if err := c.ResumeUpload(context.Background(), "/legacy-resume.bin", bytes.NewReader([]byte("12345678")), 8, nil); err != nil {
+		t.Fatalf("ResumeUpload: %v", err)
+	}
+	if !usedLegacy.Load() {
+		t.Fatal("expected legacy header fallback to be used")
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -208,6 +208,8 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case strings.HasPrefix(r.URL.Path, "/v1/fs/"):
 		s.handleFS(w, r)
+	case r.URL.Path == "/v1/uploads/initiate":
+		s.handleUploads(w, r)
 	case r.URL.Path == "/v1/uploads":
 		s.handleUploads(w, r)
 	case strings.HasPrefix(r.URL.Path, "/v1/uploads/"):

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -714,6 +714,10 @@ func (s *Server) handleUploads(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
+	if r.Method == http.MethodPost {
+		s.handleUploadInitiate(w, r, b)
+		return
+	}
 	if r.Method != http.MethodGet {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "uploads_method_not_allowed", "method", r.Method)...)
 		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -760,6 +764,71 @@ func (s *Server) handleUploads(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	_ = json.NewEncoder(w).Encode(map[string]any{"uploads": out})
+}
+
+func (s *Server) handleUploadInitiate(w http.ResponseWriter, r *http.Request, b *backend.Dat9Backend) {
+	var req struct {
+		Path          string   `json:"path"`
+		TotalSize     int64    `json:"total_size"`
+		PartChecksums []string `json:"part_checksums"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_bad_body", "error", err)...)
+		metricEvent(r.Context(), "fs_write", "result", "error")
+		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Path) == "" {
+		errJSON(w, http.StatusBadRequest, "missing path")
+		return
+	}
+	if req.TotalSize <= 0 {
+		errJSON(w, http.StatusBadRequest, "total_size must be positive")
+		return
+	}
+	if req.TotalSize > s.maxUploadBytes {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_too_large", "path", req.Path, "bytes", req.TotalSize, "max", s.maxUploadBytes)...)
+		metricEvent(r.Context(), "fs_write", "result", "error")
+		errJSON(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("upload too large: max %d bytes", s.maxUploadBytes))
+		return
+	}
+	partChecksums, err := validatePartChecksums(req.PartChecksums)
+	if err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_bad_checksums", "path", req.Path, "error", err)...)
+		metricEvent(r.Context(), "fs_write", "result", "error")
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if len(partChecksums) == 0 {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_missing_checksums", "path", req.Path)...)
+		metricEvent(r.Context(), "fs_write", "result", "error")
+		errJSON(w, http.StatusBadRequest, "missing part_checksums")
+		return
+	}
+	plan, err := b.InitiateUploadWithChecksums(r.Context(), req.Path, req.TotalSize, partChecksums)
+	if err != nil {
+		if errors.Is(err, backend.ErrPartChecksumCountMismatch) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_checksum_count_mismatch", "path", req.Path, "error", err)...)
+			metricEvent(r.Context(), "fs_write", "result", "error")
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if errors.Is(err, datastore.ErrUploadConflict) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_conflict", "path", req.Path, "error", err)...)
+			metricEvent(r.Context(), "fs_write", "result", "conflict")
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_failed", "path", req.Path, "error", err)...)
+		metricEvent(r.Context(), "fs_write", "result", "error")
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_ok", "path", req.Path, "parts", len(plan.Parts))...)
+	metricEvent(r.Context(), "fs_write", "result", "accepted")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(plan)
 }
 
 func (s *Server) handleUploadAction(w http.ResponseWriter, r *http.Request) {
@@ -882,18 +951,22 @@ func parsePartChecksumsHeader(raw string) ([]string, error) {
 		return nil, nil
 	}
 	parts := strings.Split(raw, ",")
+	return validatePartChecksums(parts)
+}
+
+func validatePartChecksums(parts []string) ([]string, error) {
 	out := make([]string, 0, len(parts))
 	for i, p := range parts {
 		v := strings.TrimSpace(p)
 		if v == "" {
-			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header: empty value at index %d", i)
+			return nil, fmt.Errorf("invalid part checksums: empty value at index %d", i)
 		}
 		decoded, err := base64.StdEncoding.DecodeString(v)
 		if err != nil {
-			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header: invalid base64 at index %d", i)
+			return nil, fmt.Errorf("invalid part checksums: invalid base64 at index %d", i)
 		}
 		if len(decoded) != 32 {
-			return nil, fmt.Errorf("invalid X-Dat9-Part-Checksums header: decoded length %d at index %d, expected 32", len(decoded), i)
+			return nil, fmt.Errorf("invalid part checksums: decoded length %d at index %d, expected 32", len(decoded), i)
 		}
 		out = append(out, v)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -904,17 +904,8 @@ func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uplo
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
-	partChecksums, err := parsePartChecksumsHeader(r.Header.Get("X-Dat9-Part-Checksums"))
+	partChecksums, err := s.parseResumePartChecksums(w, r, uploadID)
 	if err != nil {
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_bad_checksums", "upload_id", uploadID, "error", err)...)
-		metricEvent(r.Context(), "upload_resume", "result", "error")
-		errJSON(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	if len(partChecksums) == 0 {
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_missing_checksums", "upload_id", uploadID)...)
-		metricEvent(r.Context(), "upload_resume", "result", "error")
-		errJSON(w, http.StatusBadRequest, "missing X-Dat9-Part-Checksums header")
 		return
 	}
 	plan, err := b.ResumeUploadWithChecksums(r.Context(), uploadID, partChecksums)
@@ -951,6 +942,57 @@ func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uplo
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_ok", "upload_id", uploadID, "parts", len(plan.Parts))...)
 	metricEvent(r.Context(), "upload_resume", "result", "ok")
 	_ = json.NewEncoder(w).Encode(plan)
+}
+
+func (s *Server) parseResumePartChecksums(w http.ResponseWriter, r *http.Request, uploadID string) ([]string, error) {
+	contentType := strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Type")))
+	if strings.HasPrefix(contentType, "application/json") {
+		var req struct {
+			PartChecksums []string `json:"part_checksums"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_body_too_large", "upload_id", uploadID, "max", 1<<20)...)
+				metricEvent(r.Context(), "upload_resume", "result", "error")
+				errJSON(w, http.StatusRequestEntityTooLarge, "request body too large")
+				return nil, err
+			}
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_bad_body", "upload_id", uploadID, "error", err)...)
+			metricEvent(r.Context(), "upload_resume", "result", "error")
+			errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+			return nil, err
+		}
+		partChecksums, err := validatePartChecksums(req.PartChecksums)
+		if err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_bad_checksums", "upload_id", uploadID, "error", err)...)
+			metricEvent(r.Context(), "upload_resume", "result", "error")
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return nil, err
+		}
+		if len(partChecksums) == 0 {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_missing_checksums", "upload_id", uploadID)...)
+			metricEvent(r.Context(), "upload_resume", "result", "error")
+			errJSON(w, http.StatusBadRequest, "missing part_checksums")
+			return nil, errors.New("missing part_checksums")
+		}
+		return partChecksums, nil
+	}
+
+	partChecksums, err := parsePartChecksumsHeader(r.Header.Get("X-Dat9-Part-Checksums"))
+	if err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_bad_checksums", "upload_id", uploadID, "error", err)...)
+		metricEvent(r.Context(), "upload_resume", "result", "error")
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return nil, err
+	}
+	if len(partChecksums) == 0 {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_missing_checksums", "upload_id", uploadID)...)
+		metricEvent(r.Context(), "upload_resume", "result", "error")
+		errJSON(w, http.StatusBadRequest, "missing X-Dat9-Part-Checksums header")
+		return nil, errors.New("missing x-dat9-part-checksums header")
+	}
+	return partChecksums, nil
 }
 
 func parsePartChecksumsHeader(raw string) ([]string, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -774,7 +774,13 @@ func (s *Server) handleUploadInitiate(w http.ResponseWriter, r *http.Request, b 
 		TotalSize     int64    `json:"total_size"`
 		PartChecksums []string `json:"part_checksums"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_body_too_large", "max", 1<<20)...)
+			errJSON(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_bad_body", "error", err)...)
 		metricEvent(r.Context(), "fs_write", "result", "error")
 		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -97,6 +97,43 @@ func TestLargeFilePut202(t *testing.T) {
 	}
 }
 
+func TestUploadInitiateByBody202(t *testing.T) {
+	s, _ := newTestServerWithS3(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	body := make([]byte, 1<<20) // exactly 1MB
+	reqBody := map[string]any{
+		"path":           "/big-body.bin",
+		"total_size":     len(body),
+		"part_checksums": strings.Split(partChecksumHeader(body), ","),
+	}
+	p, _ := json.Marshal(reqBody)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/uploads/initiate", bytes.NewReader(p))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusAccepted {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 202, got %d: %s", resp.StatusCode, b)
+	}
+
+	var plan backend.UploadPlan
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		t.Fatal(err)
+	}
+	if plan.UploadID == "" {
+		t.Error("expected upload_id")
+	}
+	if len(plan.Parts) == 0 {
+		t.Error("expected parts")
+	}
+}
+
 func TestSmallFilePut200(t *testing.T) {
 	s, _ := newTestServerWithS3(t)
 	ts := httptest.NewServer(s)

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -254,6 +254,56 @@ func TestUploadResumeEndpoint(t *testing.T) {
 	}
 }
 
+func TestUploadResumeEndpointByBody(t *testing.T) {
+	s, s3c := newTestServerWithS3(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	totalSize := int64(20 << 20)
+	body := make([]byte, totalSize)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/resume-body-test.bin", bytes.NewReader(body))
+	req.ContentLength = totalSize
+	checksumsHeader := partChecksumHeader(body)
+	req.Header.Set("X-Dat9-Part-Checksums", checksumsHeader)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var plan backend.UploadPlan
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	upload, _ := s.fallback.GetUpload(context.Background(), plan.UploadID)
+	if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, 1, bytes.NewReader(make([]byte, s3client.PartSize))); err != nil {
+		t.Fatal(err)
+	}
+
+	resumePayload, _ := json.Marshal(map[string]any{"part_checksums": strings.Split(checksumsHeader, ",")})
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/uploads/"+plan.UploadID+"/resume", bytes.NewReader(resumePayload))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("resume by body: expected 200, got %d: %s", resp.StatusCode, b)
+	}
+
+	var resumed backend.UploadPlan
+	if err := json.NewDecoder(resp.Body).Decode(&resumed); err != nil {
+		t.Fatal(err)
+	}
+	if len(resumed.Parts) != 2 {
+		t.Errorf("expected 2 missing parts, got %d", len(resumed.Parts))
+	}
+}
+
 func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 	s, s3c := newTestServerWithS3(t)
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary
- add `POST /v1/uploads/initiate` to accept multipart upload plan requests using JSON body (`path`, `total_size`, `part_checksums`)
- update client large-upload flow to use body-based initiate first, with legacy `PUT + X-Dat9-Part-Checksums` fallback for older servers
- keep existing resume/complete flow unchanged
- add tests for server-side body initiate, client initiate path, and legacy fallback

## Why
20GB uploads were failing with HTTP 400 before reaching dat9 handlers because `X-Dat9-Part-Checksums` could exceed API Gateway header size limits.

## Validation
- `go test ./pkg/client ./pkg/server`