### PR TITLE
refactor: move auto image extraction onto durable semantic tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ tmp/
 /dat9
 dat9-server
 .gstack/
+__pycache__/
 
 # Local review artifacts
 second_opinion*

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ tmp/
 /dat9
 dat9-server
 .gstack/
+
+# Local review artifacts
+second_opinion*

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ dist/
 build/
 tmp/
 /dat9
-dat9-server
+/dat9-server
 .gstack/
 __pycache__/
 

--- a/README.md
+++ b/README.md
@@ -260,8 +260,9 @@ Four tables, all in the tenant's database:
 ## Building
 
 ```bash
-go build -o dat9 ./cmd/dat9
-go build -o dat9-server ./cmd/dat9-server
+mkdir -p bin
+go build -o bin/dat9 ./cmd/dat9
+go build -o bin/dat9-server ./cmd/dat9-server
 ```
 
 ## Local Validation Server

--- a/cmd/dat9-server-local/main.go
+++ b/cmd/dat9-server-local/main.go
@@ -105,6 +105,9 @@ func main() {
 	if err != nil {
 		die(err)
 	}
+	if strings.TrimSpace(os.Getenv("DAT9_SEMANTIC_LEASE_SECONDS")) == "" {
+		workerOpts.LeaseDuration = defaultSemanticLeaseDurationForLocal(backendOpts.AsyncImageExtract)
+	}
 	logLocalStartupStep(startupCtx, startupStart, stepStart, "build_semantic_worker_config")
 	// Keep the local entrypoint aligned with dat9-server: if only the background
 	// embedder is configured, grep reuses it for app-side query embedding.
@@ -195,7 +198,7 @@ environment:
   DAT9_EMBED_TIMEOUT_SECONDS embed request timeout seconds (default: 20)
   DAT9_SEMANTIC_WORKERS number of background workers (default: 1)
   DAT9_SEMANTIC_POLL_INTERVAL_MS worker poll interval in milliseconds (default: 200)
-  DAT9_SEMANTIC_LEASE_SECONDS task lease duration in seconds (default: 30)
+  DAT9_SEMANTIC_LEASE_SECONDS task lease duration in seconds (default: 30; when unset and image extraction is enabled, local server uses max(30, 2x image extract timeout))
   DAT9_SEMANTIC_RECOVER_INTERVAL_MS recover sweep interval in milliseconds (default: 5000)
   DAT9_SEMANTIC_RETRY_BASE_MS base retry backoff in milliseconds (default: 200)
   DAT9_SEMANTIC_RETRY_MAX_MS max retry backoff in milliseconds (default: 30000)
@@ -422,6 +425,20 @@ func buildSemanticWorkerConfigFromEnv() (embedding.Client, server.SemanticWorker
 	logger.Info(context.Background(), "semantic_embedding_mode_openai_compatible",
 		zap.String("model", model), zap.String("base_url", baseURL))
 	return client, opts, nil
+}
+
+func defaultSemanticLeaseDurationForLocal(async backend.AsyncImageExtractOptions) time.Duration {
+	lease := 30 * time.Second
+	if !async.Enabled || async.TaskTimeout <= 0 {
+		return lease
+	}
+	derived := async.TaskTimeout * 2
+	if derived > lease {
+		lease = derived
+	}
+	// TODO: Add semantic task lease renewal for long-running work, then revisit
+	// whether this conservative default lease multiplier is still necessary.
+	return lease
 }
 
 func redactDSN(dsn string) string {

--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -64,6 +64,9 @@ func main() {
 	if err != nil {
 		die(err)
 	}
+	if strings.TrimSpace(os.Getenv("DAT9_SEMANTIC_LEASE_SECONDS")) == "" {
+		semanticWorkerOpts.LeaseDuration = defaultSemanticLeaseDuration(backendOptions.AsyncImageExtract)
+	}
 	if semanticEmbedder != nil && backendOptions.QueryEmbedding.Client == nil {
 		backendOptions.QueryEmbedding = backend.QueryEmbeddingOptions{Client: semanticEmbedder}
 	}
@@ -210,7 +213,7 @@ environment:
   DAT9_EMBED_TIMEOUT_SECONDS embed request timeout seconds (default: 20)
   DAT9_SEMANTIC_WORKERS number of background workers (default: 1)
   DAT9_SEMANTIC_POLL_INTERVAL_MS worker poll interval in milliseconds (default: 200)
-  DAT9_SEMANTIC_LEASE_SECONDS task lease duration in seconds (default: 30)
+  DAT9_SEMANTIC_LEASE_SECONDS task lease duration in seconds (default: 30; when unset and image extraction is enabled, dat9-server uses max(30, 2x image extract timeout))
   DAT9_SEMANTIC_RECOVER_INTERVAL_MS recover sweep interval in milliseconds (default: 5000)
   DAT9_SEMANTIC_RETRY_BASE_MS base retry backoff in milliseconds (default: 200)
   DAT9_SEMANTIC_RETRY_MAX_MS max retry backoff in milliseconds (default: 30000)
@@ -373,6 +376,20 @@ func buildSemanticWorkerConfigFromEnv() (embedding.Client, server.SemanticWorker
 	logger.Info(context.Background(), "semantic_embedding_mode_openai_compatible",
 		zap.String("model", model), zap.String("base_url", baseURL))
 	return client, opts, nil
+}
+
+func defaultSemanticLeaseDuration(async backend.AsyncImageExtractOptions) time.Duration {
+	lease := 30 * time.Second
+	if !async.Enabled || async.TaskTimeout <= 0 {
+		return lease
+	}
+	derived := async.TaskTimeout * 2
+	if derived > lease {
+		lease = derived
+	}
+	// TODO: Add semantic task lease renewal for long-running work, then revisit
+	// whether this conservative default lease multiplier is still necessary.
+	return lease
 }
 
 func envBool(key string, fallback bool) bool {

--- a/docs/img-extract-text-proposal.md
+++ b/docs/img-extract-text-proposal.md
@@ -1,0 +1,430 @@
+# Proposal: Phase 1 rollout for durable `img_extract_text` in dat9
+
+**Date**: 2026-04-01
+**Purpose**: Based on the current `dat9` codebase, propose a production-oriented, clearly scoped, incrementally rollable Phase 1 plan to migrate the current backend-owned asynchronous image text extraction path from a best-effort in-memory queue to the durable `semantic_tasks` substrate, with priority on `auto embedding + create + overwrite + upload completion`.
+
+## Summary
+
+The current system already has most of the image extraction processing logic and the durable task substrate, but migrating the auto-embedding image path onto `semantic_tasks` requires the design to satisfy four production-grade requirements:
+
+1. Durable registration of `img_extract_text` must commit in the same transaction as file revision visibility; otherwise the system still has a correctness gap where a file revision is visible but its task is missing.
+2. Semantic worker startup and tenant scan logic cannot continue to be designed only around the app-side `embedder`; otherwise the auto embedding path may enqueue durable tasks with no worker able to process them.
+3. The runtime dependency source for the `img_extract_text` handler must be explicit. In the current code, image extraction depends on backend-owned capabilities such as the extractor, S3 client, and size/timeout limits; Phase 1 must define where those dependencies come from in multi-tenant execution.
+4. Phase 1 must define a clear coexistence strategy between auto mode and the legacy in-memory queue; otherwise durable enqueue and the old `enqueueImageExtract*()` path can both run and cause duplicate processing or duplicate writeback.
+
+This proposal follows these design principles:
+
+- Keep a single `semantic_tasks` table; do not introduce a second queueing system
+- Narrow the future reserved `extract_text` task type into the more honest `img_extract_text`
+- In Phase 1, switch only the three auto embedding write paths: `create`, `overwrite`, and `upload completion`
+- Keep semantic worker as the only delivery owner
+- Reuse the existing fallback backend and tenant backends created by `tenant.Pool` as the preferred source of `img_extract_text` runtime dependencies, instead of inventing a new generic runtime framework in Phase 1
+- Keep app embedding's `img_extract_text -> embed` flow explicitly out of Phase 1
+
+## Context
+
+### Capabilities that already exist in the current system
+
+The current repository already has most of the image text extraction machinery. What is missing is durable delivery.
+
+**Synchronous text fast path**
+
+- `extractText(data, contentType)` lives in `pkg/backend/dat9.go:719`
+- It only handles a subset of text content types; once a file exceeds `smallFileThreshold`, it returns an empty string, see `pkg/backend/dat9.go:32` and `pkg/backend/dat9.go:726`
+- This path is responsible for synchronous `content_text` production for small text files, not images
+
+**Current asynchronous image extraction prototype**
+
+- The backend starts an in-memory queue and worker in `configureOptions()` based on `AsyncImageExtractOptions`, see `pkg/backend/options.go:47`
+- When the queue is full, tasks are dropped immediately, see `pkg/backend/image_extract.go:77`
+- The image worker reads the current `files` row first, then performs revision gating, image-type checks, byte loading, extraction, sanitization, and writeback, see `pkg/backend/image_extract.go:146`
+- Successful writeback uses `UpdateFileSearchTextTx(tx, fileID, revision, text)`, see `pkg/backend/image_extract.go:215` and `pkg/datastore/store.go:487`
+- In app embedding mode, successful writeback bridges an `embed` task; in auto embedding mode it does not create an app-side `embed` task, see `pkg/backend/image_extract.go:221`
+
+**Durable substrate is already present**
+
+- Tenant schemas already include `semantic_tasks` and its unique index in both auto/app TiDB schemas, see `pkg/tenant/schema_tidb_auto.go:117` and `pkg/tenant/schema_tidb_app.go:80`
+- `semantic_tasks` already supports `Enqueue`, `EnsureQueued`, `Claim`, `Ack`, `Retry`, and `RecoverExpired`, see `pkg/datastore/semantic_tasks.go:26`, `pkg/datastore/semantic_tasks.go:227`, `pkg/datastore/semantic_tasks.go:295`, `pkg/datastore/semantic_tasks.go:318`, and `pkg/datastore/semantic_tasks.go:366`
+- Semantic worker already has polling, claiming, retry, recovery, queue gauges, and structured logging, see `pkg/server/semantic_worker.go:137`, `pkg/server/semantic_worker.go:198`, and `pkg/server/semantic_worker.go:588`
+
+### The key gap in the current system
+
+Even though the durable substrate already exists, image text production in auto embedding mode still depends on a backend-owned in-memory queue. The relevant write paths are:
+
+- `create` still directly calls `enqueueImageExtract(...)`, see `pkg/backend/dat9.go:368`
+- `overwrite` still directly calls `enqueueImageExtract(...)`, see `pkg/backend/dat9.go:450`
+- `upload completion` still directly calls `enqueueImageExtractForUpload(...)`, see `pkg/backend/upload.go:311`
+
+This means auto embedding still has the following production risks:
+
+- tasks in the queue are lost after process restart
+- new image revisions have no compensation path when the queue is full
+- in multi-tenant mode, when a backend is evicted from `tenant.Pool`, its worker stops with it, see `pkg/backend/options.go:99` and `pkg/tenant/pool.go:231`
+- large images mainly go through `upload completion`; changing only ordinary `Write()` would still leave the auto embedding image path incomplete
+
+### The current split between auto embedding and app embedding
+
+The current code already distinguishes the two embedding modes clearly:
+
+- In auto embedding mode, `files.embedding` is a stored generated column derived by the database from `content_text`, see `pkg/tenant/schema_tidb_auto.go:72`
+- Auto embedding write paths do not enqueue app-managed `embed` tasks, see `pkg/backend/dat9.go:358` and `pkg/backend/upload.go:252`
+- Auto embedding overwrite/confirm helpers do not clear embedding columns, see `pkg/datastore/file_tx.go:77` and `pkg/datastore/file_tx.go:120`
+- In auto embedding mode, grep uses `VectorSearchByText` directly instead of an app-side query embedder, see `pkg/backend/dat9.go:768`
+
+So prioritizing auto embedding in Phase 1 creates a smaller and real closed loop: once `content_text` is written back durably, the database's existing auto embedding behavior continues to work.
+
+## Goals
+
+1. In Phase 1, narrow the asynchronous image text extraction task type to `img_extract_text`.
+2. Prioritize auto embedding in Phase 1 instead of switching app embedding at the same time.
+3. Ensure all three auto-mode image write paths - `create`, `overwrite`, and `upload completion` - durably register `img_extract_text`.
+4. Ensure the successful `img_extract_text` path only performs revision-gated `content_text` writeback and does not create app-side `embed` tasks.
+5. Make semantic worker the only delivery owner so image text extraction no longer depends on backend in-memory queue delivery semantics.
+
+## Non-Goals
+
+- Do not implement generic `extract_text` in this phase.
+- Do not switch app embedding to `img_extract_text -> embed` in this phase.
+- Do not rename `AsyncImageExtractOptions` in this phase.
+- Do not solve DB9/Postgres provider-neutral runtime in this phase.
+- Do not change the synchronous `extractText()` fast path within `smallFileThreshold`.
+- Do not fully retire the legacy image queue in this phase; it remains temporarily for app embedding paths.
+
+## Support Levels
+
+| Scope | Phase 1 support level | Notes |
+| --- | --- | --- |
+| local fallback backend + auto embedding | Supported | Requires `AsyncImageExtractOptions.Enabled=true`, which is the existing image extraction runtime switch |
+| multi-tenant TiDB auto providers | Supported | Continues using the current TiDB/MySQL-oriented `datastore.Open(...)` worker runtime path |
+| app embedding | Deferred | Keeps the current `embed` and legacy image queue behavior |
+| DB9/Postgres provider-neutral runtime | Deferred | Out of scope for Phase 1 |
+
+## Architecture Comparison
+
+```text
+Current Architecture
+--------------------
+
+Request Path                                  Background Path
++----------------------------------+          +----------------------------------+
+| create / overwrite /            |          | backend-owned image worker       |
+| upload completion                |          | (started by backend options)     |
++----------------+-----------------+          +----------------+-----------------+
+                 |                                           ^
+                 v                                           |
+      +---------------------------+                +---------+---------+
+      | files revision committed  |                | in-memory image   |
+      | in tenant store           |                | queue (channel)   |
+      +-------------+-------------+                +---------+---------+
+                    |                                        ^
+                    | auto mode: no durable task             |
+                    +----------------------------------------+
+                    | enqueueImageExtract(...)
+                    v
+      +---------------------------+
+      | load image bytes +        |
+      | extract + sanitize text   |
+      +-------------+-------------+
+                    |
+                    v
+      +---------------------------+
+      | UpdateFileSearchTextTx    |
+      | (revision-gated writeback)|
+      +-------------+-------------+
+                    |
+          +---------+---------+
+          |                   |
+          v                   v
+   auto embedding       app embedding
+   stops here           may requeue / bridge embed
+
+Separate server-owned semantic worker today:
+    semantic worker in dat9-server -> only handles durable embed tasks
+
+
+Target Architecture (Phase 1)
+-----------------------------
+
+Request Path                                  Background Path
++----------------------------------+          +----------------------------------+
+| create / overwrite /            |          | semantic worker in dat9-server   |
+| upload completion                |          | (server-owned delivery owner)    |
++----------------+-----------------+          +----------------+-----------------+
+                 |                                           |
+                 v                                           v
+      +---------------------------+                +---------------------------+
+      | same DB transaction       |                | claim img_extract_text    |
+      | - write/confirm revision  |                | from semantic_tasks       |
+      | - enqueue img_extract_text|                +-------------+-------------+
+      +-------------+-------------+                              |
+                    |                                            v
+                    v                                 +---------------------------+
+      +---------------------------+                   | resolve backend runtime   |
+      | semantic_tasks            |                   | (fallback or tenant       |
+      | img_extract_text row      |                   | backend)                  |
+      +-------------+-------------+                   +-------------+-------------+
+                    |                                            |
+                    +--------------------------------------------+
+                                                                 v
+                                                      +---------------------------+
+                                                      | load image bytes +        |
+                                                      | extract + sanitize text   |
+                                                      +-------------+-------------+
+                                                                    |
+                                                                    v
+                                                      +---------------------------+
+                                                      | UpdateFileSearchTextTx    |
+                                                      | + ack / retry / recover   |
+                                                      +-------------+-------------+
+                                                                    |
+                                                                    v
+                                                      +---------------------------+
+                                                      | database auto embedding   |
+                                                      | derives vector from       |
+                                                      | latest content_text       |
+                                                      +---------------------------+
+
+Transition note:
+    legacy backend image queue remains only for app embedding paths
+```
+
+## Design
+
+### 1) Use the existing `semantic_tasks` substrate for `img_extract_text`
+
+Phase 1 continues to reuse the existing `semantic_tasks` table. It does not introduce a second task table, and it no longer treats the backend in-memory queue as the source of truth for delivery.
+
+The minimum required changes are:
+
+- Rename `semantic.TaskTypeExtractText` to `semantic.TaskTypeImgExtractText`, currently in `pkg/semantic/task.go:12`
+- Add a small helper analogous to `newEmbedTask(...)`, for example `newImgExtractTask(...)`, while keeping task identity as `(task_type, resource_id, resource_version)`
+- Continue to use the unique index `uk_task_resource_version` on `semantic_tasks`, see `pkg/tenant/schema_tidb_auto.go:135`
+
+Phase 1 does not require a generic handler registry or workflow engine. Adding one concrete case to `dispatchTask()` is sufficient, see `pkg/server/semantic_worker.go:498`.
+
+### 2) Task payload should keep only minimal non-authoritative hints
+
+`img_extract_text` needs a minimal `payload_json`. The reason is not to make payload the source of truth, but because the in-memory task currently carries `Path` and `ContentType`, while the durable `semantic.Task` model does not.
+
+The payload should contain only:
+
+- `path`
+- `content_type`
+
+Usage rules:
+
+- `resource_id + resource_version` remains the only authoritative identity
+- The handler must read the current `files` row and apply revision gating
+- Payload is only used for logging, extract requests, and image-like fallback checks when `files.content_type` is missing
+
+Phase 1 should not expand payload into a large debugging or business-state envelope.
+
+### 3) Semantic worker remains the only delivery owner
+
+In Phase 1, backend-owned goroutines no longer execute image text extraction for auto mode. The true delivery owner becomes `semanticWorkerManager`.
+
+However, this proposal does not recommend inventing a new generic runtime abstraction in Phase 1. The current code already has two stable runtime sources:
+
+- Local mode directly holds the fallback backend, see `pkg/server/server.go:138`
+- Multi-tenant mode creates tenant backends through `tenant.Pool` with shared `BackendOptions`, see `pkg/tenant/pool.go:164`
+
+So the simplest design is:
+
+- **Delivery stays in semantic worker**: claim / ack / retry / recover all continue through `datastore.Store`
+- **Image extraction runtime comes from backend**: when handling a tenant task, the handler uses the fallback backend or `tenant.Pool.Get(ctx, tenant)` to obtain the corresponding backend and reuse its image extraction capabilities
+
+This avoids redesigning extractor config, S3 client wiring, or a generic runtime framework in Phase 1, while continuing to reuse the existing runtime surface represented by `AsyncImageExtractOptions`, `ImageTextExtractor`, `loadImageBytesForExtract()`, and `sanitizeExtractedText()`. Delivery itself no longer depends on backend queue goroutines; backend becomes a runtime dependency container rather than the async task scheduler.
+
+### 4) Worker gate must depend on handler capability, not only on embedder presence
+
+The current worker gate is clearly designed for embed-only execution:
+
+- When `embedder == nil`, the manager does not start, see `pkg/server/semantic_worker.go:114`
+- Local auto fallback backend is disabled directly, see `pkg/server/semantic_worker.go:119`
+- Multi-tenant scan skips auto providers directly, see `pkg/server/semantic_worker.go:435`
+
+Phase 1 does not need full generalization; it only needs a small enablement change:
+
+- `hasEmbedHandler := embedder != nil`
+- `hasImgExtractHandler := async image extraction is enabled in the backend options represented by fallback/pool`
+- Semantic worker should start unless both are false
+
+Tenant scan should also be grouped by handler capability:
+
+- When only `embed` exists: keep current app-mode scan behavior
+- When only `img_extract_text` exists: scan only auto embedding tenants and the local auto fallback backend
+- When both exist: scan both sets
+
+`ClaimSemanticTask(...)` does not filter by `task_type`, see `pkg/datastore/semantic_tasks.go:227`. If an img-only worker scans an app tenant, it may claim an `embed` task first, and unsupported task types are retried as unsupported, see `pkg/server/semantic_worker.go:498`. Therefore, “img-only worker scans only auto stores” is not an optimization; it is a correctness precondition for Phase 1.
+
+As a rollout precondition, any store cut over to an `img_extract_text`-only handler must not have pending app-side `embed` backlog. Otherwise, even with correct scan scope, the worker may still claim historical `embed` tasks within the same store. Such stores must either be drained first or excluded from the Phase 1 cutover set.
+
+### 5) Register `img_extract_text` only when image extraction runtime is enabled
+
+Today the system only treats a revision as having an async image text source when `AsyncImageExtractOptions.Enabled` is true and an extractor is configured, see `pkg/backend/semantic_tasks.go:39` and `pkg/backend/options.go:56`.
+
+Phase 1 should keep that precondition:
+
+- Enqueue `img_extract_text` for image-like revisions only when image extraction runtime is enabled
+- If async image extraction is not enabled in the current deployment, the system should not register a durable task with no handler/runtime
+
+This both aligns with current behavior and avoids registering durable tasks that have no handler.
+
+### 6) Write paths must register `img_extract_text` inside the same transaction
+
+This is one of the most important constraints in the Phase 1 design.
+
+**Principle**: once an auto-mode image revision becomes visible to the tenant, its corresponding `img_extract_text` task must already be durably registered.
+
+Therefore, task registration must occur in the same transaction that commits the file revision.
+
+#### `create`
+
+In `createAndWriteCtx()`, an image-like small-file create should enqueue `img_extract_text` after `InsertFileTx + EnsureParentDirsTx + InsertNodeTx` succeed and before the transaction commits. Reference point: `pkg/backend/dat9.go:339`.
+
+#### `overwrite`
+
+In `overwriteFileCtx()`, an image-like overwrite should enqueue `img_extract_text` after `UpdateFileContentAutoEmbeddingTx(...)` returns the new revision and before the transaction commits. Reference point: `pkg/backend/dat9.go:422`.
+
+#### `upload completion`
+
+In `ConfirmUpload()`, image-like upload completion must enqueue `img_extract_text` inside the transaction. Reference point: `pkg/backend/upload.go:205`.
+
+Overwrite completion needs special care:
+
+- The task `resource_id` must use the surviving inode's `confirmedFileID`
+- The task `resource_version` must use the new `confirmedRevision` after overwrite
+- The system must not mistakenly use the pending upload file's `upload.FileID` as task identity
+
+This is also why `upload completion` must be included in the Phase 1 cutline: large image objects do not go through the synchronous small-file write path.
+
+### 7) Auto mode must stop double-publishing to the legacy in-memory queue
+
+Phase 1 does not require fully deleting the legacy image queue, but once auto mode switches to durable `img_extract_text`, the three paths must stop calling:
+
+- `enqueueImageExtract(...)`, see `pkg/backend/image_extract.go:61`
+- `enqueueImageExtractForUpload(...)`, see `pkg/backend/image_extract.go:91`
+
+The recommended coexistence strategy is:
+
+- **auto embedding + create/overwrite/upload completion**: register only durable `img_extract_text`; do not publish to the legacy queue
+- **app embedding**: keep the current `embed` + legacy image queue behavior
+
+This transition strategy is simple, rollback-friendly, and avoids touching app-mode task graph changes in Phase 1.
+
+### 8) Handler logic should follow the correctness contract of the current image worker
+
+The recommended `img_extract_text` handler flow is:
+
+1. claim an `img_extract_text` task
+2. read the current `files` row
+3. if file is missing, not `CONFIRMED`, or `revision != resource_version`, ack obsolete
+4. use `files.content_type` plus payload hints to determine whether the current revision is still image-like; if not, ack obsolete
+5. load image bytes through the fallback backend or tenant backend and apply the existing `MaxImageBytes` limit
+6. call `ImageTextExtractor`
+7. sanitize the result with the existing `sanitizeExtractedText()`
+8. if the sanitized result is empty, ack obsolete or `empty_result`
+9. execute `UpdateFileSearchTextTx(tx, fileID, revision, text)` in a transaction
+10. ack on success; use obsolete for permanently inapplicable cases; use retry / dead-letter for transient runtime errors
+
+Recommended error classification:
+
+- **obsolete / non-retry**: file not found, not confirmed, revision mismatch, not image, too large, empty result
+- **retry**: S3/object-store read failure, extractor API failure, transactional writeback failure, transient database error
+
+This matches the current in-memory worker behavior; it just turns implicit skip/return behavior into explicit durable task outcomes.
+
+### 9) Phase 1 convergence decisions
+
+To avoid further branching during implementation, Phase 1 adopts the following explicit decisions:
+
+1. **`too_large` and `empty_result` share the same non-retry ack delivery semantics**
+   - Neither should be retried, and both end task lifecycle through ack.
+   - Metrics and logging should still preserve finer result labels such as `too_large`, `empty_result`, `stale`, and `not_image` for operability.
+
+2. **The legacy image queue remains in Phase 1, but only for app embedding paths**
+   - Auto embedding `create`, `overwrite`, and `upload completion` no longer publish to the legacy queue.
+   - App embedding continues to depend on the current legacy queue until its image task handling also migrates to `semantic_tasks`.
+   - To prevent this transitional dependency from being mistaken for long-term design, relevant app-mode branches must include code comments stating that the logic is temporary compatibility and can be removed once app embedding switches to `semantic_tasks`.
+
+3. **In Phase 1, img-only workers scan only auto stores, and cutover stores must not retain app-side `embed` backlog**
+   - Phase 1 does not introduce `task_type`-level claim filtering; it uses tenant/store scan scope to ensure img-only workers never see app-side `embed` tasks.
+   - Any store being cut over to an img-only worker must be confirmed free of pending `embed` backlog before rollout; otherwise it is outside the supported Phase 1 cutover scope.
+
+## Incremental Plan
+
+### Step 1: narrow task type and fix worker gate
+
+1. Rename `TaskTypeExtractText` to `TaskTypeImgExtractText`
+2. Add an `img_extract_text` case to `dispatchTask()`
+3. Narrow the semantic worker startup rule from “must have embedder” to “must have at least one configured handler”
+4. Change tenant scan scope to depend on handler capability instead of hard-coded skipping of auto providers
+5. Make “img-only worker scans only auto stores” and “no `embed` backlog before cutover” explicit implementation and operational preconditions
+
+### Step 2: add minimal payload and runtime accessors
+
+6. Define a minimal `payload_json` for `img_extract_text` (`path`, `content_type`)
+7. Provide a minimal backend accessor for durable image extraction handling rather than exposing the old queue
+8. In multi-tenant mode, use `tenant.Pool.Get(...)` to obtain tenant backend as the image extraction runtime source
+
+### Step 3: connect the three auto-mode write paths
+
+9. Enqueue `img_extract_text` inside the transaction for `create`
+10. Enqueue `img_extract_text` inside the transaction for `overwrite`
+11. Enqueue `img_extract_text` inside the transaction for `upload completion`
+12. Stop calling `enqueueImageExtract*()` on those auto-mode paths
+13. Add comments in the app-mode branches that still keep the legacy queue, explicitly marking the dependency as temporary compatibility to be removed once app embedding image tasks move to `semantic_tasks`
+
+### Step 4: implement the handler and validate it
+
+14. Implement `img_extract_text` claim / ack / retry / recover
+15. Keep the success path limited to `UpdateFileSearchTextTx(...)`
+16. Preserve fine-grained metrics / logging labels such as `too_large`, `empty_result`, `stale`, and `not_image` for non-retry ack cases
+17. Add tests for stale revision, too large, empty result, extract failure, restart recovery, upload overwrite, and img-only worker scan boundaries
+
+## Validation Strategy
+
+- **Write path tests**
+  - In auto embedding mode, image `create` leaves an `img_extract_text` task after transaction commit
+  - In auto embedding mode, image `overwrite` registers `img_extract_text` for the new revision
+  - In auto embedding mode, image `upload completion` and overwrite completion both register `img_extract_text` for the surviving inode / current revision
+  - In auto embedding mode, those three paths no longer publish into the legacy image queue
+
+- **Worker startup and tenant-scope tests**
+  - The local fallback backend still starts semantic worker under `auto embedding + image extract enabled + no embedder`
+  - In multi-tenant mode, auto providers are no longer skipped unconditionally
+  - When only the image handler exists, app tenants are not scanned
+  - Stores that still have `embed` backlog are excluded from Phase 1 img-only cutover
+
+- **Handler correctness tests**
+  - `img_extract_text` success updates only the current revision's `content_text`
+  - A stale revision never overwrites the current revision
+  - A non-image task that was enqueued by mistake is acked obsolete
+  - Too-large images and empty results do not cause infinite retries
+  - Metrics / logging distinguish `too_large` from `empty_result` even though both are non-retry ack cases
+  - Auto embedding mode does not create extra `embed` tasks
+
+- **Recovery and lifecycle tests**
+  - After claim and process restart, the task can be recovered after lease expiry
+  - Tenant pool eviction no longer causes permanent task stall; the worker can resolve tenant backend runtime again on the next attempt
+  - Code branches that still keep the legacy queue for app embedding contain explicit comments stating that they are temporary compatibility logic
+
+## Risks and Mitigations
+
+1. **Auto mode and legacy queue coexist and cause duplicate processing**
+   - Keep exactly one delivery target for auto-mode `create`, `overwrite`, and `upload completion`: durable `img_extract_text`; keep legacy queue only for app mode.
+
+2. **Worker runtime and scan scope remain unclear, causing wrong claims or excessive refactoring**
+   - In Phase 1, reuse fallback backend and tenant backend as runtime sources; restrict worker scan to auto stores; require `embed` backlog to be drained before cutover.
+
+3. **Upload completion overwrite binds task identity to the pending upload file ID**
+   - Use `confirmedFileID + confirmedRevision` as durable task identity inside the transaction, and add dedicated tests for overwrite completion.
+
+4. **Phase 1 scope expands into app embedding or provider-neutral runtime**
+   - Keep app mode's `img_extract_text -> embed` and DB9/Postgres runtime explicitly deferred and separate from this phase.
+
+## Conclusion
+
+To meet production quality, Phase 1 must define transaction boundaries, worker gate behavior, runtime dependency sources, and coexistence strategy precisely. This proposal does that without expanding the abstraction surface, adding a new queue engine, or mixing in app embedding early. It focuses only on moving the three auto embedding image write paths - `create`, `overwrite`, and `upload completion` - onto durable `img_extract_text`.
+
+The benefit is concrete and verifiable: the most fragile image text production path in the current system moves from backend in-memory best-effort behavior to a durable flow that can claim, retry, and recover, while the database's existing auto embedding behavior continues to reuse `files.content_text` without redesigning vector generation in Phase 1.

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -47,7 +47,7 @@ type Dat9Backend struct {
 	// Async image -> text extraction worker (in-memory queue for P0).
 	imageExtractEnabled bool
 	imageExtractor      ImageTextExtractor
-	imageExtractQueue   chan imageExtractTask
+	imageExtractQueue   chan ImageExtractTaskSpec
 	imageExtractWG      sync.WaitGroup
 	imageExtractCancel  context.CancelFunc
 	imageExtractTimeout time.Duration

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -355,7 +355,13 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		}); err != nil {
 			return err
 		}
-		if !b.UsesDatabaseAutoEmbedding() && b.shouldEnqueueEmbedForRevision(path, contentType, contentText) {
+		if b.UsesDatabaseAutoEmbedding() {
+			if b.hasAsyncImageTextSource(path, contentType) {
+				return b.enqueueImgExtractTaskTx(tx, fileID, 1, path, contentType)
+			}
+			return nil
+		}
+		if b.shouldEnqueueEmbedForRevision(path, contentType, contentText) {
 			return b.enqueueEmbedTaskTx(tx, fileID, 1)
 		}
 		return nil
@@ -364,6 +370,12 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 			b.deleteBlobCtx(ctx, storageRef)
 		}
 		return 0, err
+	}
+	// Temporary compatibility: app embedding still relies on the legacy
+	// backend-owned image queue until its image task flow also moves to
+	// semantic_tasks.
+	if b.UsesDatabaseAutoEmbedding() {
+		return int64(len(data)), nil
 	}
 	b.enqueueImageExtract(fileID, path, contentType, 1)
 	return int64(len(data)), nil

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -447,7 +447,13 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 		if txErr != nil {
 			return txErr
 		}
-		if !b.UsesDatabaseAutoEmbedding() && b.shouldEnqueueEmbedForRevision(nf.Node.Path, contentType, contentText) {
+		if b.UsesDatabaseAutoEmbedding() {
+			if b.hasAsyncImageTextSource(nf.Node.Path, contentType) {
+				return b.enqueueImgExtractTaskTx(tx, nf.File.FileID, newRev, nf.Node.Path, contentType)
+			}
+			return nil
+		}
+		if b.shouldEnqueueEmbedForRevision(nf.Node.Path, contentType, contentText) {
 			return b.enqueueEmbedTaskTx(tx, nf.File.FileID, newRev)
 		}
 		return nil
@@ -459,6 +465,12 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 		return 0, err
 	}
 	b.deleteBlobIfS3Ctx(ctx, nf.File.StorageType, nf.File.StorageRef, storageRef)
+	// Temporary compatibility: app embedding still relies on the legacy
+	// backend-owned image queue until its image task flow also moves to
+	// semantic_tasks.
+	if b.UsesDatabaseAutoEmbedding() {
+		return int64(len(data)), nil
+	}
 	b.enqueueImageExtract(nf.File.FileID, nf.Node.Path, contentType, newRev)
 	return int64(len(data)), nil
 }

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -219,8 +219,9 @@ func (b *Dat9Backend) processQueuedImageExtractTask(ctx context.Context, task Im
 }
 
 // ProcessImageExtractTask runs the backend-owned image extraction logic for one
-// revision-scoped task. Terminal non-retry outcomes return a nil error and a
-// non-empty result label. Transient failures return a retryable error.
+// revision-scoped task. Normal terminal business outcomes return a nil error
+// and a non-empty result label. Runtime misconfiguration, misrouting, and
+// transient failures return a retryable error.
 func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExtractTaskSpec) (ImageExtractResult, error) {
 	if !b.SupportsAsyncImageExtract() {
 		return ImageExtractResultRuntimeNotConfigured, fmt.Errorf("async image extract runtime not configured")

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -29,12 +29,32 @@ type ImageTextExtractor interface {
 	ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error)
 }
 
-type imageExtractTask struct {
+// ImageExtractTaskSpec carries the revision-scoped inputs needed to extract
+// image text for one file version.
+type ImageExtractTaskSpec struct {
 	FileID      string
 	Path        string
 	ContentType string
 	Revision    int64
 }
+
+// ImageExtractResult reports the outcome of one image extraction attempt.
+type ImageExtractResult string
+
+const (
+	ImageExtractResultRuntimeNotConfigured ImageExtractResult = "runtime_not_configured"
+	ImageExtractResultGetFileError         ImageExtractResult = "get_file_error"
+	ImageExtractResultFileNotFound         ImageExtractResult = "file_not_found"
+	ImageExtractResultNotConfirmed         ImageExtractResult = "not_confirmed"
+	ImageExtractResultNotImage             ImageExtractResult = "not_image"
+	ImageExtractResultStale                ImageExtractResult = "stale"
+	ImageExtractResultLoadError            ImageExtractResult = "load_error"
+	ImageExtractResultTooLarge             ImageExtractResult = "too_large"
+	ImageExtractResultExtractError         ImageExtractResult = "extract_error"
+	ImageExtractResultEmptyText            ImageExtractResult = "empty_text"
+	ImageExtractResultUpdateError          ImageExtractResult = "update_error"
+	ImageExtractResultWritten              ImageExtractResult = "written"
+)
 
 func isImageContentType(contentType string) bool {
 	contentType = strings.ToLower(strings.TrimSpace(contentType))
@@ -58,8 +78,14 @@ func contentTypeFromPath(path string) string {
 	return ""
 }
 
+// SupportsAsyncImageExtract reports whether this backend instance has the
+// runtime dependencies needed to extract image text.
+func (b *Dat9Backend) SupportsAsyncImageExtract() bool {
+	return b.imageExtractEnabled && b.imageExtractor != nil
+}
+
 func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revision int64) {
-	if !b.imageExtractEnabled || b.imageExtractor == nil {
+	if !b.SupportsAsyncImageExtract() {
 		return
 	}
 	if !isImageContentType(contentType) {
@@ -68,7 +94,7 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 			return
 		}
 	}
-	task := imageExtractTask{
+	task := ImageExtractTaskSpec{
 		FileID:      fileID,
 		Path:        path,
 		ContentType: contentType,
@@ -89,7 +115,7 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 }
 
 func (b *Dat9Backend) enqueueImageExtractForUpload(ctx context.Context, upload *datastore.Upload, isOverwrite bool) {
-	if !b.imageExtractEnabled || b.imageExtractor == nil {
+	if !b.SupportsAsyncImageExtract() {
 		return
 	}
 	fileID := upload.FileID
@@ -138,54 +164,98 @@ func (b *Dat9Backend) runImageExtractWorker(ctx context.Context, workerID int) {
 			return
 		case task := <-b.imageExtractQueue:
 			metrics.RecordGauge("image_extract", "queue_depth", float64(len(b.imageExtractQueue)))
-			b.processImageExtractTask(ctx, task)
+			b.processQueuedImageExtractTask(ctx, task)
 		}
 	}
 }
 
-func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExtractTask) {
+func (b *Dat9Backend) processQueuedImageExtractTask(ctx context.Context, task ImageExtractTaskSpec) {
 	start := time.Now()
-	f, err := b.store.GetFile(ctx, task.FileID)
+	result, err := b.ProcessImageExtractTask(ctx, task)
+	metricResult := legacyImageExtractMetricResult(result)
 	if err != nil {
-		if !errors.Is(err, datastore.ErrNotFound) {
+		switch result {
+		case ImageExtractResultGetFileError:
 			logger.Warn(ctx, "backend_image_extract_get_file_failed",
 				zap.String("file_id", task.FileID), zap.Error(err))
+		case ImageExtractResultLoadError:
+			logger.Warn(ctx, "backend_image_extract_load_bytes_failed",
+				zap.String("file_id", task.FileID), zap.Error(err))
+		case ImageExtractResultExtractError:
+			logger.Warn(ctx, "backend_image_extract_failed",
+				zap.String("file_id", task.FileID), zap.String("path", task.Path), zap.Error(err))
+		case ImageExtractResultUpdateError:
+			logger.Warn(ctx, "backend_image_extract_update_file_failed",
+				zap.String("file_id", task.FileID), zap.Error(err))
+		default:
+			logger.Warn(ctx, "backend_image_extract_failed_unexpected",
+				zap.String("file_id", task.FileID), zap.String("path", task.Path), zap.Error(err))
 		}
-		metrics.RecordOperation("image_extract", "process", "get_file_error", time.Since(start))
+		metrics.RecordOperation("image_extract", "process", metricResult, time.Since(start))
 		return
 	}
-	if f.Status != datastore.StatusConfirmed {
-		metrics.RecordOperation("image_extract", "process", "not_confirmed", time.Since(start))
+
+	switch result {
+	case ImageExtractResultFileNotFound, ImageExtractResultNotConfirmed, ImageExtractResultNotImage:
+		metrics.RecordOperation("image_extract", "process", metricResult, time.Since(start))
 		return
+	case ImageExtractResultStale:
+		logger.Info(ctx, "backend_image_extract_skipped_stale",
+			zap.String("file_id", task.FileID), zap.String("path", task.Path))
+	case ImageExtractResultTooLarge:
+		logger.Warn(ctx, "backend_image_extract_skipped_too_large_or_empty",
+			zap.String("file_id", task.FileID),
+			zap.String("path", task.Path),
+			zap.Int64("max_bytes", b.imageExtractMaxSize))
+	case ImageExtractResultEmptyText:
+		logger.Warn(ctx, "backend_image_extract_empty_text",
+			zap.String("file_id", task.FileID),
+			zap.String("path", task.Path))
+	case ImageExtractResultWritten:
+		logger.Info(ctx, "backend_image_extract_ok",
+			zap.String("file_id", task.FileID), zap.String("path", task.Path))
+	}
+	metrics.RecordOperation("image_extract", "process", metricResult, time.Since(start))
+}
+
+// ProcessImageExtractTask runs the backend-owned image extraction logic for one
+// revision-scoped task. Terminal non-retry outcomes return a nil error and a
+// non-empty result label. Transient failures return a retryable error.
+func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExtractTaskSpec) (ImageExtractResult, error) {
+	if !b.SupportsAsyncImageExtract() {
+		return ImageExtractResultRuntimeNotConfigured, fmt.Errorf("async image extract runtime not configured")
+	}
+
+	f, err := b.store.GetFile(ctx, task.FileID)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			return ImageExtractResultFileNotFound, nil
+		}
+		return ImageExtractResultGetFileError, fmt.Errorf("get file: %w", err)
+	}
+	if f.Status != datastore.StatusConfirmed {
+		return ImageExtractResultNotConfirmed, nil
 	}
 	ct := f.ContentType
 	if ct == "" {
 		ct = task.ContentType
 	}
+	if ct == "" {
+		ct = contentTypeFromPath(task.Path)
+	}
 	if !isImageContentType(ct) {
-		metrics.RecordOperation("image_extract", "process", "not_image", time.Since(start))
-		return
+		return ImageExtractResultNotImage, nil
 	}
 	if task.Revision > 0 && f.Revision != task.Revision {
-		metrics.RecordOperation("image_extract", "process", "stale_precheck", time.Since(start))
-		return
+		return ImageExtractResultStale, nil
 	}
 
 	data, err := b.loadImageBytesForExtract(ctx, f)
 	if err != nil {
-		logger.Warn(ctx, "backend_image_extract_load_bytes_failed",
-			zap.String("file_id", task.FileID), zap.Error(err))
-		metrics.RecordOperation("image_extract", "process", "load_error", time.Since(start))
-		return
+		return ImageExtractResultLoadError, fmt.Errorf("load image bytes: %w", err)
 	}
 	if len(data) == 0 {
-		logger.Warn(ctx, "backend_image_extract_skipped_too_large_or_empty",
-			zap.String("file_id", task.FileID),
-			zap.String("path", task.Path),
-			zap.Int64("file_size", f.SizeBytes),
-			zap.Int64("max_bytes", b.imageExtractMaxSize))
-		metrics.RecordOperation("image_extract", "process", "skip_too_large", time.Since(start))
-		return
+		return ImageExtractResultTooLarge, nil
 	}
 
 	taskCtx, cancel := context.WithTimeout(ctx, b.imageExtractTimeout)
@@ -197,18 +267,11 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 	})
 	cancel()
 	if err != nil {
-		logger.Warn(ctx, "backend_image_extract_failed",
-			zap.String("file_id", task.FileID), zap.String("path", task.Path), zap.Error(err))
-		metrics.RecordOperation("image_extract", "process", "extract_error", time.Since(start))
-		return
+		return ImageExtractResultExtractError, fmt.Errorf("extract image text: %w", err)
 	}
 	text = sanitizeExtractedText(text, b.maxExtractTextBytes)
 	if text == "" {
-		logger.Warn(ctx, "backend_image_extract_empty_text",
-			zap.String("file_id", task.FileID),
-			zap.String("path", task.Path))
-		metrics.RecordOperation("image_extract", "process", "empty_text", time.Since(start))
-		return
+		return ImageExtractResultEmptyText, nil
 	}
 
 	var updated bool
@@ -225,20 +288,25 @@ func (b *Dat9Backend) processImageExtractTask(ctx context.Context, task imageExt
 		return txErr
 	})
 	if err != nil {
-		logger.Warn(ctx, "backend_image_extract_update_file_failed",
-			zap.String("file_id", task.FileID), zap.Error(err))
-		metrics.RecordOperation("image_extract", "process", "update_error", time.Since(start))
-		return
+		return ImageExtractResultUpdateError, fmt.Errorf("update file search text: %w", err)
 	}
 	if !updated {
-		logger.Info(ctx, "backend_image_extract_skipped_stale",
-			zap.String("file_id", task.FileID), zap.String("path", task.Path))
-		metrics.RecordOperation("image_extract", "process", "stale", time.Since(start))
-		return
+		return ImageExtractResultStale, nil
 	}
-	logger.Info(ctx, "backend_image_extract_ok",
-		zap.String("file_id", task.FileID), zap.String("path", task.Path), zap.Int("text_len", len(text)))
-	metrics.RecordOperation("image_extract", "process", "ok", time.Since(start))
+	return ImageExtractResultWritten, nil
+}
+
+func legacyImageExtractMetricResult(result ImageExtractResult) string {
+	switch result {
+	case ImageExtractResultFileNotFound, ImageExtractResultGetFileError:
+		return "get_file_error"
+	case ImageExtractResultTooLarge:
+		return "skip_too_large"
+	case ImageExtractResultWritten:
+		return "ok"
+	default:
+		return string(result)
+	}
 }
 
 func (b *Dat9Backend) loadImageBytesForExtract(ctx context.Context, f *datastore.File) ([]byte, error) {

--- a/pkg/backend/image_extract_test.go
+++ b/pkg/backend/image_extract_test.go
@@ -2,12 +2,15 @@ package backend
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/pathutil"
 )
 
 type staticImageExtractor struct {
@@ -271,6 +274,147 @@ func TestAsyncImageExtractStaleResultDoesNotRequeueOldRevision(t *testing.T) {
 	if tasks[1].ResourceVersion != 2 || tasks[1].Status != "queued" {
 		t.Fatalf("current revision task should remain queued, got %+v", tasks[1])
 	}
+}
+
+func TestProcessImageExtractTaskWritesContentTextAndQueuesEmbedTask(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: &staticImageExtractor{text: "cat on sofa screenshot invoice"},
+		},
+	})
+
+	fileID := insertImageFileForExtractTest(t, b, "/img/direct.png", "image/png", []byte("fake-png"))
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/direct.png",
+		ContentType: "image/png",
+		Revision:    1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != ImageExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultWritten)
+	}
+
+	nf, err := b.Store().Stat(context.Background(), "/img/direct.png")
+	if err != nil || nf.File == nil {
+		t.Fatalf("stat /img/direct.png: %v", err)
+	}
+	if !strings.Contains(nf.File.ContentText, "cat on sofa") {
+		t.Fatalf("unexpected extracted text: %q", nf.File.ContentText)
+	}
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	if len(tasks) != 1 {
+		t.Fatalf("semantic task count=%d, want 1", len(tasks))
+	}
+	if tasks[0].TaskType != "embed" || tasks[0].ResourceVersion != 1 || tasks[0].Status != "queued" {
+		t.Fatalf("unexpected semantic task: %+v", tasks[0])
+	}
+}
+
+func TestProcessImageExtractTaskAutoEmbeddingSkipsEmbedBridge(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{
+		DatabaseAutoEmbedding: true,
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: &staticImageExtractor{text: "cat on sofa screenshot invoice"},
+		},
+	})
+
+	fileID := insertImageFileForExtractTest(t, b, "/img/direct-auto.png", "image/png", []byte("fake-png"))
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/direct-auto.png",
+		ContentType: "image/png",
+		Revision:    1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != ImageExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultWritten)
+	}
+
+	nf, err := b.Store().Stat(context.Background(), "/img/direct-auto.png")
+	if err != nil || nf.File == nil {
+		t.Fatalf("stat /img/direct-auto.png: %v", err)
+	}
+	if !strings.Contains(nf.File.ContentText, "cat on sofa") {
+		t.Fatalf("unexpected extracted text: %q", nf.File.ContentText)
+	}
+	if tasks := loadSemanticTasksForFile(t, b, fileID); len(tasks) != 0 {
+		t.Fatalf("semantic task count=%d, want 0", len(tasks))
+	}
+}
+
+func TestProcessImageExtractTaskTooLargeReturnsTerminalResult(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:       true,
+			Workers:       1,
+			QueueSize:     8,
+			MaxImageBytes: 4,
+			Extractor:     &staticImageExtractor{text: "should not run"},
+		},
+	})
+
+	fileID := insertImageFileForExtractTest(t, b, "/img/large.png", "image/png", []byte("12345"))
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/large.png",
+		ContentType: "image/png",
+		Revision:    1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != ImageExtractResultTooLarge {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultTooLarge)
+	}
+}
+
+func insertImageFileForExtractTest(t *testing.T, b *Dat9Backend, path, contentType string, data []byte) string {
+	t.Helper()
+	fileID := b.genID()
+	now := time.Now().UTC()
+	err := b.Store().InTx(context.Background(), func(tx *sql.Tx) error {
+		if err := b.Store().InsertFileTx(tx, &datastore.File{
+			FileID:         fileID,
+			StorageType:    datastore.StorageDB9,
+			StorageRef:     "inline",
+			ContentBlob:    append([]byte(nil), data...),
+			ContentType:    contentType,
+			SizeBytes:      int64(len(data)),
+			Revision:       1,
+			Status:         datastore.StatusConfirmed,
+			CreatedAt:      now,
+			ConfirmedAt:    &now,
+			ChecksumSHA256: "",
+		}); err != nil {
+			return err
+		}
+		if err := b.Store().EnsureParentDirsTx(tx, path, b.genID); err != nil {
+			return err
+		}
+		return b.Store().InsertNodeTx(tx, &datastore.FileNode{
+			NodeID:     b.genID(),
+			Path:       path,
+			ParentPath: pathutil.ParentPath(path),
+			Name:       pathutil.BaseName(path),
+			FileID:     fileID,
+			CreatedAt:  now,
+		})
+	})
+	if err != nil {
+		t.Fatalf("insert image file %s: %v", path, err)
+	}
+	return fileID
 }
 
 func waitForContentText(t *testing.T, b *Dat9Backend, path string, timeout time.Duration) string {

--- a/pkg/backend/image_extract_test.go
+++ b/pkg/backend/image_extract_test.go
@@ -79,17 +79,25 @@ func TestAsyncImageExtractAutoEmbeddingUpdatesContentTextWithoutSemanticTask(t *
 			Extractor: &staticImageExtractor{text: "cat on sofa screenshot invoice"},
 		},
 	})
-
-	if _, err := b.Write("/img/auto.png", []byte("fake-png"), 0, filesystem.WriteFlagCreate); err != nil {
+	fileID := insertImageFileForExtractTest(t, b, "/img/auto.png", "image/png", []byte("fake-png"))
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/auto.png",
+		ContentType: "image/png",
+		Revision:    1,
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
+	if result != ImageExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultWritten)
+	}
 
-	got := waitForContentText(t, b, "/img/auto.png", 2*time.Second)
+	got := waitForContentText(t, b, "/img/auto.png", time.Second)
 	if !strings.Contains(got, "cat on sofa") {
 		t.Fatalf("unexpected extracted text: %q", got)
 	}
 
-	fileID, _, _, _ := mustFileForPath(t, b, "/img/auto.png")
 	if tasks := loadSemanticTasksForFile(t, b, fileID); len(tasks) != 0 {
 		t.Fatalf("semantic task count=%d, want 0", len(tasks))
 	}
@@ -144,17 +152,14 @@ func TestAsyncImageExtractAutoEmbeddingStaleResultDoesNotQueueOrOverwriteCurrent
 			Extractor: extractor,
 		},
 	})
-
-	if _, err := b.Write("/img/auto-stale.png", []byte("first-image-bytes"), 0, filesystem.WriteFlagCreate); err != nil {
-		t.Fatal(err)
-	}
+	fileID := insertImageFileForExtractTest(t, b, "/img/auto-stale.png", "image/png", []byte("first-image-bytes"))
+	b.enqueueImageExtract(fileID, "/img/auto-stale.png", "image/png", 1)
 	select {
 	case <-extractor.started:
 	case <-time.After(2 * time.Second):
 		t.Fatal("first extraction did not start")
 	}
 
-	fileID, _, _, _ := mustFileForPath(t, b, "/img/auto-stale.png")
 	if _, err := b.Write("/img/auto-stale.png", []byte("second-image-bytes"), 0, filesystem.WriteFlagTruncate); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/backend/image_extract_test.go
+++ b/pkg/backend/image_extract_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/pathutil"
+	"github.com/mem9-ai/dat9/pkg/semantic"
 )
 
 type staticImageExtractor struct {
@@ -153,7 +154,18 @@ func TestAsyncImageExtractAutoEmbeddingStaleResultDoesNotQueueOrOverwriteCurrent
 		},
 	})
 	fileID := insertImageFileForExtractTest(t, b, "/img/auto-stale.png", "image/png", []byte("first-image-bytes"))
-	b.enqueueImageExtract(fileID, "/img/auto-stale.png", "image/png", 1)
+	resultCh := make(chan ImageExtractResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+			FileID:      fileID,
+			Path:        "/img/auto-stale.png",
+			ContentType: "image/png",
+			Revision:    1,
+		})
+		resultCh <- result
+		errCh <- err
+	}()
 	select {
 	case <-extractor.started:
 	case <-time.After(2 * time.Second):
@@ -163,14 +175,36 @@ func TestAsyncImageExtractAutoEmbeddingStaleResultDoesNotQueueOrOverwriteCurrent
 	if _, err := b.Write("/img/auto-stale.png", []byte("second-image-bytes"), 0, filesystem.WriteFlagTruncate); err != nil {
 		t.Fatal(err)
 	}
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/auto-stale.png",
+		ContentType: "image/png",
+		Revision:    2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != ImageExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultWritten)
+	}
 	close(extractor.release)
+	if gotErr := <-errCh; gotErr != nil {
+		t.Fatal(gotErr)
+	}
+	if got := <-resultCh; got != ImageExtractResultStale {
+		t.Fatalf("stale result=%q, want %q", got, ImageExtractResultStale)
+	}
 
-	got := waitForContentText(t, b, "/img/auto-stale.png", 3*time.Second)
+	got := waitForContentText(t, b, "/img/auto-stale.png", time.Second)
 	if got != "new caption" {
 		t.Fatalf("expected final extracted text %q, got %q", "new caption", got)
 	}
-	if tasks := loadSemanticTasksForFile(t, b, fileID); len(tasks) != 0 {
-		t.Fatalf("semantic task count=%d, want 0", len(tasks))
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	if len(tasks) != 1 {
+		t.Fatalf("semantic task count=%d, want 1", len(tasks))
+	}
+	if tasks[0].TaskType != string(semantic.TaskTypeImgExtractText) || tasks[0].Status != "queued" || tasks[0].ResourceVersion != 2 {
+		t.Fatalf("unexpected semantic task history: %+v", tasks)
 	}
 }
 

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/embedding"
@@ -93,7 +94,12 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		go b.runImageExtractWorker(ctx, i+1)
 	}
 	logger.Info(ctx, "backend_image_extract_workers_started",
-		zap.Int("workers", cfg.Workers), zap.Int("queue_size", cfg.QueueSize))
+		zap.Int("workers", cfg.Workers),
+		zap.Int("queue_size", cfg.QueueSize),
+		zap.Duration("task_timeout", cfg.TaskTimeout),
+		zap.Int64("max_image_bytes", cfg.MaxImageBytes),
+		zap.Int("max_extract_text_bytes", cfg.MaxExtractTextBytes),
+		zap.String("extractor_type", fmt.Sprintf("%T", cfg.Extractor)))
 }
 
 // Close stops background workers owned by this backend instance.

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -81,7 +81,7 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 	b.imageExtractTimeout = cfg.TaskTimeout
 	b.imageExtractMaxSize = cfg.MaxImageBytes
 	b.maxExtractTextBytes = cfg.MaxExtractTextBytes
-	b.imageExtractQueue = make(chan imageExtractTask, cfg.QueueSize)
+	b.imageExtractQueue = make(chan ImageExtractTaskSpec, cfg.QueueSize)
 	metrics.RecordGauge("image_extract", "queue_capacity", float64(cfg.QueueSize))
 	metrics.RecordGauge("image_extract", "workers", float64(cfg.Workers))
 	metrics.RecordGauge("image_extract", "queue_depth", 0)

--- a/pkg/backend/schema_test_helper.go
+++ b/pkg/backend/schema_test_helper.go
@@ -32,6 +32,7 @@ func initBackendSchema(t *testing.T, dsn string) {
 		`CREATE TABLE IF NOT EXISTS semantic_tasks (task_id VARCHAR(64) PRIMARY KEY, task_type VARCHAR(32) NOT NULL, resource_id VARCHAR(64) NOT NULL, resource_version BIGINT NOT NULL, status VARCHAR(20) NOT NULL, attempt_count INT NOT NULL DEFAULT 0, max_attempts INT NOT NULL DEFAULT 5, receipt VARCHAR(128), leased_at DATETIME(3), lease_until DATETIME(3), available_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), payload_json JSON, last_error TEXT, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), completed_at DATETIME(3))`,
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
+		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"database/sql"
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -11,6 +12,16 @@ import (
 func (b *Dat9Backend) enqueueEmbedTaskTx(tx *sql.Tx, fileID string, revision int64) error {
 	now := time.Now().UTC()
 	_, err := b.store.EnqueueSemanticTaskTx(tx, newEmbedTask(b.genID(), fileID, revision, now))
+	return err
+}
+
+func (b *Dat9Backend) enqueueImgExtractTaskTx(tx *sql.Tx, fileID string, revision int64, path, contentType string) error {
+	now := time.Now().UTC()
+	task, err := newImgExtractTask(b.genID(), fileID, revision, path, contentType, now)
+	if err != nil {
+		return err
+	}
+	_, err = b.store.EnqueueSemanticTaskTx(tx, task)
 	return err
 }
 
@@ -27,6 +38,31 @@ func newEmbedTask(taskID, fileID string, revision int64, now time.Time) *semanti
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
+}
+
+func newImgExtractTask(taskID, fileID string, revision int64, path, contentType string, now time.Time) (*semantic.Task, error) {
+	now = now.UTC()
+	payload := semantic.ImgExtractTaskPayload{Path: path, ContentType: contentType}
+	var payloadJSON []byte
+	if payload.Path != "" || payload.ContentType != "" {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		payloadJSON = encoded
+	}
+	return &semantic.Task{
+		TaskID:          taskID,
+		TaskType:        semantic.TaskTypeImgExtractText,
+		ResourceID:      fileID,
+		ResourceVersion: revision,
+		Status:          semantic.TaskQueued,
+		MaxAttempts:     5,
+		AvailableAt:     now,
+		PayloadJSON:     payloadJSON,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}, nil
 }
 
 func (b *Dat9Backend) shouldEnqueueEmbedForRevision(path, contentType, contentText string) bool {

--- a/pkg/backend/semantic_tasks_test.go
+++ b/pkg/backend/semantic_tasks_test.go
@@ -145,6 +145,51 @@ func TestWriteCreateAutoEmbeddingSkipsEmbedTaskEvenWithTextSource(t *testing.T) 
 	}
 }
 
+func TestWriteCreateAutoEmbeddingImageEnqueuesImgExtractTaskWithoutLegacyQueue(t *testing.T) {
+	extractor := &gatedImageExtractor{started: make(chan struct{}, 1), release: make(chan struct{})}
+	b := newTestBackendWithOptions(t, Options{
+		DatabaseAutoEmbedding: true,
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: extractor,
+		},
+	})
+	if _, err := b.Write("/img/create-auto.png", []byte("fake-png"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-extractor.started:
+		close(extractor.release)
+		t.Fatal("legacy image queue should stay idle for auto create path")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	fileID, revision, embeddingRevision, _ := mustFileForPath(t, b, "/img/create-auto.png")
+	if revision != 1 {
+		t.Fatalf("revision=%d, want 1", revision)
+	}
+	if embeddingRevision != nil {
+		t.Fatalf("embedding revision should remain nil before durable worker, got %v", *embeddingRevision)
+	}
+	nf, err := b.Store().Stat(context.Background(), "/img/create-auto.png")
+	if err != nil || nf.File == nil {
+		t.Fatalf("stat /img/create-auto.png: %v", err)
+	}
+	if nf.File.ContentText != "" {
+		t.Fatalf("content_text=%q, want empty before durable worker", nf.File.ContentText)
+	}
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	if len(tasks) != 1 {
+		t.Fatalf("semantic task count=%d, want 1", len(tasks))
+	}
+	if tasks[0].TaskType != string(semantic.TaskTypeImgExtractText) || tasks[0].Status != string(semantic.TaskQueued) || tasks[0].ResourceVersion != 1 {
+		t.Fatalf("unexpected semantic task: %+v", tasks[0])
+	}
+}
+
 func TestWriteOverwriteEnqueuesNextRevisionAndClearsEmbeddingState(t *testing.T) {
 	b := newTestBackend(t)
 	if _, err := b.Write("/f.txt", []byte("old"), 0, filesystem.WriteFlagCreate); err != nil {

--- a/pkg/backend/semantic_tasks_test.go
+++ b/pkg/backend/semantic_tasks_test.go
@@ -494,6 +494,143 @@ func TestConfirmUploadOverwriteAutoEmbeddingSkipsEmbedTaskAndPreservesEmbeddingS
 	}
 }
 
+func TestConfirmUploadAutoEmbeddingImageEnqueuesImgExtractTaskWithoutLegacyQueue(t *testing.T) {
+	extractor := &gatedImageExtractor{started: make(chan struct{}, 1), release: make(chan struct{})}
+	b := newTestBackendWithOptions(t, Options{
+		DatabaseAutoEmbedding: true,
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: extractor,
+		},
+	})
+	ctx := context.Background()
+	totalSize := int64(2 << 20)
+	plan, err := b.InitiateUpload(ctx, "/img/upload-auto.png", totalSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	uploadAllPartsForPlan(t, b, plan, plan.UploadID, totalSize)
+
+	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-extractor.started:
+		close(extractor.release)
+		t.Fatal("legacy image queue should stay idle for auto upload create path")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	fileID, revision, embeddingRevision, contentType := mustFileForPath(t, b, "/img/upload-auto.png")
+	if revision != 1 {
+		t.Fatalf("revision=%d, want 1", revision)
+	}
+	if embeddingRevision != nil {
+		t.Fatalf("embedding revision should be nil before durable worker, got %v", *embeddingRevision)
+	}
+	if contentType != detectContentType("/img/upload-auto.png", nil) {
+		t.Fatalf("content_type=%q, want %q", contentType, detectContentType("/img/upload-auto.png", nil))
+	}
+	nf, err := b.Store().Stat(ctx, "/img/upload-auto.png")
+	if err != nil || nf.File == nil {
+		t.Fatalf("stat /img/upload-auto.png: %v", err)
+	}
+	if nf.File.ContentText != "" {
+		t.Fatalf("content_text=%q, want empty before durable worker", nf.File.ContentText)
+	}
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	if len(tasks) != 1 {
+		t.Fatalf("semantic task count=%d, want 1", len(tasks))
+	}
+	if tasks[0].TaskType != string(semantic.TaskTypeImgExtractText) || tasks[0].Status != string(semantic.TaskQueued) || tasks[0].ResourceVersion != 1 {
+		t.Fatalf("unexpected semantic task: %+v", tasks[0])
+	}
+}
+
+func TestConfirmUploadOverwriteAutoEmbeddingImageEnqueuesImgExtractTaskWithoutLegacyQueue(t *testing.T) {
+	extractor := &gatedImageExtractor{started: make(chan struct{}, 1), release: make(chan struct{})}
+	b := newTestBackendWithOptions(t, Options{
+		DatabaseAutoEmbedding: true,
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: extractor,
+		},
+	})
+	ctx := context.Background()
+	fileID := insertImageFileForExtractTest(t, b, "/img/upload-overwrite-auto.png", "image/png", []byte("old-image"))
+	setStoredEmbeddingState(t, b, fileID, 1)
+
+	totalSize := int64(2 << 20)
+	plan, err := b.InitiateUpload(ctx, "/img/upload-overwrite-auto.png", totalSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingUpload, err := b.GetUpload(ctx, plan.UploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingFileID := pendingUpload.FileID
+	uploadAllPartsForPlan(t, b, plan, plan.UploadID, totalSize)
+
+	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-extractor.started:
+		close(extractor.release)
+		t.Fatal("legacy image queue should stay idle for auto upload overwrite path")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	confirmedFileID, revision, embeddingRevision, contentType := mustFileForPath(t, b, "/img/upload-overwrite-auto.png")
+	if confirmedFileID != fileID {
+		t.Fatalf("overwrite should preserve inode file_id=%q, got %q", fileID, confirmedFileID)
+	}
+	if revision != 2 {
+		t.Fatalf("revision=%d, want 2", revision)
+	}
+	if embeddingRevision == nil || *embeddingRevision != 1 {
+		t.Fatalf("embedding revision should be preserved, got %v", embeddingRevision)
+	}
+	if contentType != detectContentType("/img/upload-overwrite-auto.png", nil) {
+		t.Fatalf("content_type=%q, want %q", contentType, detectContentType("/img/upload-overwrite-auto.png", nil))
+	}
+	nf, err := b.Store().Stat(ctx, "/img/upload-overwrite-auto.png")
+	if err != nil || nf.File == nil {
+		t.Fatalf("stat /img/upload-overwrite-auto.png: %v", err)
+	}
+	if nf.File.ContentText != "" {
+		t.Fatalf("content_text=%q, want empty before durable worker", nf.File.ContentText)
+	}
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	if len(tasks) != 1 {
+		t.Fatalf("semantic task count=%d, want 1", len(tasks))
+	}
+	if tasks[0].TaskType != string(semantic.TaskTypeImgExtractText) || tasks[0].Status != string(semantic.TaskQueued) || tasks[0].ResourceVersion != 2 {
+		t.Fatalf("unexpected semantic task: %+v", tasks[0])
+	}
+	upload, err := b.GetUpload(ctx, plan.UploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if upload.FileID != fileID {
+		t.Fatalf("upload file_id=%q, want surviving inode %q", upload.FileID, fileID)
+	}
+	var deletedStatus string
+	if err := b.Store().DB().QueryRow(`SELECT status FROM files WHERE file_id = ?`, pendingFileID).Scan(&deletedStatus); err != nil {
+		t.Fatal(err)
+	}
+	if deletedStatus != "DELETED" {
+		t.Fatalf("pending upload file status=%q, want DELETED", deletedStatus)
+	}
+}
+
 func TestRenameDoesNotCreateAdditionalSemanticTasks(t *testing.T) {
 	b := newTestBackend(t)
 	if _, err := b.Write("/old.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {

--- a/pkg/backend/semantic_tasks_test.go
+++ b/pkg/backend/semantic_tasks_test.go
@@ -271,6 +271,54 @@ func TestWriteOverwriteAutoEmbeddingSkipsEmbedTaskAndPreservesEmbeddingState(t *
 	}
 }
 
+func TestWriteOverwriteAutoEmbeddingImageEnqueuesImgExtractTaskWithoutLegacyQueue(t *testing.T) {
+	extractor := &gatedImageExtractor{started: make(chan struct{}, 1), release: make(chan struct{})}
+	b := newTestBackendWithOptions(t, Options{
+		DatabaseAutoEmbedding: true,
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: extractor,
+		},
+	})
+	fileID := insertImageFileForExtractTest(t, b, "/img/overwrite-auto.png", "image/png", []byte("old-image"))
+	setStoredEmbeddingState(t, b, fileID, 1)
+
+	if _, err := b.Write("/img/overwrite-auto.png", []byte("new-image"), 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-extractor.started:
+		close(extractor.release)
+		t.Fatal("legacy image queue should stay idle for auto overwrite path")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	_, revision, embeddingRevision, _ := mustFileForPath(t, b, "/img/overwrite-auto.png")
+	if revision != 2 {
+		t.Fatalf("revision=%d, want 2", revision)
+	}
+	if embeddingRevision == nil || *embeddingRevision != 1 {
+		t.Fatalf("embedding revision should be preserved, got %v", embeddingRevision)
+	}
+	nf, err := b.Store().Stat(context.Background(), "/img/overwrite-auto.png")
+	if err != nil || nf.File == nil {
+		t.Fatalf("stat /img/overwrite-auto.png: %v", err)
+	}
+	if nf.File.ContentText != "" {
+		t.Fatalf("content_text=%q, want empty before durable worker", nf.File.ContentText)
+	}
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	if len(tasks) != 1 {
+		t.Fatalf("semantic task count=%d, want 1", len(tasks))
+	}
+	if tasks[0].TaskType != string(semantic.TaskTypeImgExtractText) || tasks[0].Status != string(semantic.TaskQueued) || tasks[0].ResourceVersion != 2 {
+		t.Fatalf("unexpected semantic task: %+v", tasks[0])
+	}
+}
+
 func TestWriteOverwriteDoesNotDeleteInlineMarkerObject(t *testing.T) {
 	b := newTestBackend(t)
 	if _, err := b.Write("/f", []byte("old"), 0, filesystem.WriteFlagCreate); err != nil {

--- a/pkg/backend/semantic_tasks_test.go
+++ b/pkg/backend/semantic_tasks_test.go
@@ -3,8 +3,10 @@ package backend
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/mem9-ai/dat9/pkg/s3client"
@@ -464,5 +466,26 @@ func TestShouldEnqueueEmbedForRevisionWithoutTextSource(t *testing.T) {
 	b := newTestBackend(t)
 	if b.shouldEnqueueEmbedForRevision("/bin/a.bin", "application/octet-stream", "") {
 		t.Fatal("generic binary object should not enqueue embed work without text source")
+	}
+}
+
+func TestNewImgExtractTaskCarriesPayloadHints(t *testing.T) {
+	now := time.Now().UTC()
+	task, err := newImgExtractTask("task-1", "file-1", 7, "/img/a.png", "image/png", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.TaskType != semantic.TaskTypeImgExtractText {
+		t.Fatalf("task type=%q, want %q", task.TaskType, semantic.TaskTypeImgExtractText)
+	}
+	if task.ResourceID != "file-1" || task.ResourceVersion != 7 {
+		t.Fatalf("unexpected task identity: %+v", task)
+	}
+	var payload semantic.ImgExtractTaskPayload
+	if err := json.Unmarshal(task.PayloadJSON, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Path != "/img/a.png" || payload.ContentType != "image/png" {
+		t.Fatalf("unexpected payload: %+v", payload)
 	}
 }

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -249,7 +249,13 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 			if err != nil {
 				return err
 			}
-			if !b.UsesDatabaseAutoEmbedding() && b.shouldEnqueueEmbedForRevision(upload.TargetPath, contentType, "") {
+			if b.UsesDatabaseAutoEmbedding() {
+				if b.hasAsyncImageTextSource(upload.TargetPath, contentType) {
+					return b.enqueueImgExtractTaskTx(tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+				}
+				return nil
+			}
+			if b.shouldEnqueueEmbedForRevision(upload.TargetPath, contentType, "") {
 				return b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
 			}
 			return nil
@@ -295,7 +301,13 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 		}); err != nil {
 			return err
 		}
-		if !b.UsesDatabaseAutoEmbedding() && b.shouldEnqueueEmbedForRevision(upload.TargetPath, contentType, "") {
+		if b.UsesDatabaseAutoEmbedding() {
+			if b.hasAsyncImageTextSource(upload.TargetPath, contentType) {
+				return b.enqueueImgExtractTaskTx(tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+			}
+			return nil
+		}
+		if b.shouldEnqueueEmbedForRevision(upload.TargetPath, contentType, "") {
 			return b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
 		}
 		return nil
@@ -307,7 +319,13 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 	if isOverwrite {
 		b.deleteBlobIfS3Ctx(ctx, oldStorageType, oldStorageRef, upload.S3Key)
 	}
-
+	// Temporary compatibility: app embedding still relies on the legacy
+	// backend-owned image queue until its image task flow also moves to
+	// semantic_tasks.
+	if b.UsesDatabaseAutoEmbedding() {
+		metrics.RecordOperation("backend", "confirm_upload", "ok", time.Since(start))
+		return nil
+	}
 	b.enqueueImageExtractForUpload(ctx, upload, isOverwrite)
 
 	metrics.RecordOperation("backend", "confirm_upload", "ok", time.Since(start))

--- a/pkg/client/schema_test_helper.go
+++ b/pkg/client/schema_test_helper.go
@@ -33,6 +33,7 @@ func initClientTenantSchema(t *testing.T, dsn string) {
 		`CREATE TABLE IF NOT EXISTS semantic_tasks (task_id VARCHAR(64) PRIMARY KEY, task_type VARCHAR(32) NOT NULL, resource_id VARCHAR(64) NOT NULL, resource_version BIGINT NOT NULL, status VARCHAR(20) NOT NULL, attempt_count INT NOT NULL DEFAULT 0, max_attempts INT NOT NULL DEFAULT 5, receipt VARCHAR(128), leased_at DATETIME(3), lease_until DATETIME(3), available_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), payload_json JSON, last_error TEXT, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), completed_at DATETIME(3))`,
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
+		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/pkg/datastore/schema_test_helper_test.go
+++ b/pkg/datastore/schema_test_helper_test.go
@@ -38,6 +38,7 @@ func initDatastoreSchema(t *testing.T, dsn, provider string) {
 		`CREATE TABLE IF NOT EXISTS semantic_tasks (task_id VARCHAR(64) PRIMARY KEY, task_type VARCHAR(32) NOT NULL, resource_id VARCHAR(64) NOT NULL, resource_version BIGINT NOT NULL, status VARCHAR(20) NOT NULL, attempt_count INT NOT NULL DEFAULT 0, max_attempts INT NOT NULL DEFAULT 5, receipt VARCHAR(128), leased_at DATETIME(3), lease_until DATETIME(3), available_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), payload_json JSON, last_error TEXT, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), completed_at DATETIME(3))`,
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
+		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/pkg/datastore/semantic_tasks.go
+++ b/pkg/datastore/semantic_tasks.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -228,7 +229,21 @@ func (s *Store) ensureSemanticTaskQueuedTx(tx *sql.Tx, task *semantic.Task) (boo
 func (s *Store) ClaimSemanticTask(ctx context.Context, now time.Time, leaseDuration time.Duration) (out *semantic.Task, found bool, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "claim_semantic_task", start, &err)
+	return s.claimSemanticTask(ctx, now, leaseDuration, nil)
+}
 
+// ClaimSemanticTaskOfTypes claims one queued semantic task whose task_type is
+// included in taskTypes and leases it to the caller.
+func (s *Store) ClaimSemanticTaskOfTypes(ctx context.Context, now time.Time, leaseDuration time.Duration, taskTypes ...semantic.TaskType) (out *semantic.Task, found bool, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "claim_semantic_task_of_types", start, &err)
+	if len(taskTypes) == 0 {
+		return nil, false, fmt.Errorf("claim task types are required")
+	}
+	return s.claimSemanticTask(ctx, now, leaseDuration, taskTypes)
+}
+
+func (s *Store) claimSemanticTask(ctx context.Context, now time.Time, leaseDuration time.Duration, taskTypes []semantic.TaskType) (out *semantic.Task, found bool, err error) {
 	if now.IsZero() {
 		now = time.Now().UTC()
 	} else {
@@ -237,6 +252,10 @@ func (s *Store) ClaimSemanticTask(ctx context.Context, now time.Time, leaseDurat
 	if leaseDuration <= 0 {
 		leaseDuration = 30 * time.Second
 	}
+	normalizedTypes, err := normalizeClaimTaskTypes(taskTypes)
+	if err != nil {
+		return nil, false, err
+	}
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -244,14 +263,8 @@ func (s *Store) ClaimSemanticTask(ctx context.Context, now time.Time, leaseDurat
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	row := tx.QueryRowContext(ctx, `SELECT task_id, task_type, resource_id, resource_version, status,
-		attempt_count, max_attempts, receipt, leased_at, lease_until, available_at,
-		payload_json, last_error, created_at, updated_at, completed_at
-		FROM semantic_tasks
-		WHERE status = ? AND available_at <= ?
-		ORDER BY available_at, created_at, task_id
-		LIMIT 1
-		FOR UPDATE SKIP LOCKED`, semantic.TaskQueued, now)
+	query, args := claimSemanticTaskQuery(now, normalizedTypes)
+	row := tx.QueryRowContext(ctx, query, args...)
 	task, scanErr := scanSemanticTask(row)
 	if scanErr != nil {
 		if errors.Is(scanErr, semantic.ErrTaskNotFound) {
@@ -290,6 +303,60 @@ func (s *Store) ClaimSemanticTask(ctx context.Context, now time.Time, leaseDurat
 		return nil, false, err
 	}
 	return task, true, nil
+}
+
+func normalizeClaimTaskTypes(taskTypes []semantic.TaskType) ([]semantic.TaskType, error) {
+	if len(taskTypes) == 0 {
+		return nil, nil
+	}
+	seen := make(map[semantic.TaskType]struct{}, len(taskTypes))
+	normalized := make([]semantic.TaskType, 0, len(taskTypes))
+	for _, taskType := range taskTypes {
+		if strings.TrimSpace(string(taskType)) == "" {
+			return nil, fmt.Errorf("claim task type is required")
+		}
+		if _, ok := seen[taskType]; ok {
+			continue
+		}
+		seen[taskType] = struct{}{}
+		normalized = append(normalized, taskType)
+	}
+	return normalized, nil
+}
+
+func claimSemanticTaskQuery(now time.Time, taskTypes []semantic.TaskType) (string, []any) {
+	query := `SELECT task_id, task_type, resource_id, resource_version, status,
+		attempt_count, max_attempts, receipt, leased_at, lease_until, available_at,
+		payload_json, last_error, created_at, updated_at, completed_at
+		FROM semantic_tasks
+		WHERE status = ?`
+	args := []any{semantic.TaskQueued}
+	if len(taskTypes) == 1 {
+		query += ` AND task_type = ?`
+		args = append(args, taskTypes[0])
+	} else if len(taskTypes) > 1 {
+		query += ` AND task_type IN (` + questionPlaceholders(len(taskTypes)) + `)`
+		for _, taskType := range taskTypes {
+			args = append(args, taskType)
+		}
+	}
+	query += ` AND available_at <= ?
+		ORDER BY available_at, created_at, task_id
+		LIMIT 1
+		FOR UPDATE SKIP LOCKED`
+	args = append(args, now)
+	return query, args
+}
+
+func questionPlaceholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	parts := make([]string, n)
+	for i := range parts {
+		parts[i] = "?"
+	}
+	return strings.Join(parts, ", ")
 }
 
 // AckSemanticTask marks a leased semantic task as succeeded.

--- a/pkg/datastore/semantic_tasks_test.go
+++ b/pkg/datastore/semantic_tasks_test.go
@@ -10,9 +10,13 @@ import (
 )
 
 func newSemanticTask(taskID, resourceID string, version int64, availableAt, createdAt time.Time) *semantic.Task {
+	return newSemanticTaskOfType(semantic.TaskTypeEmbed, taskID, resourceID, version, availableAt, createdAt)
+}
+
+func newSemanticTaskOfType(taskType semantic.TaskType, taskID, resourceID string, version int64, availableAt, createdAt time.Time) *semantic.Task {
 	return &semantic.Task{
 		TaskID:          taskID,
-		TaskType:        semantic.TaskTypeEmbed,
+		TaskType:        taskType,
 		ResourceID:      resourceID,
 		ResourceVersion: version,
 		Status:          semantic.TaskQueued,
@@ -140,6 +144,98 @@ func TestSemanticTaskClaimOrderByAvailableAtThenCreatedAt(t *testing.T) {
 		if claimed.TaskID != want {
 			t.Fatalf("claimed task=%q, want %q", claimed.TaskID, want)
 		}
+	}
+}
+
+func TestClaimSemanticTaskOfTypesSkipsOlderDisallowedTask(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	base := time.Unix(1711600350, 0).UTC()
+
+	tasks := []*semantic.Task{
+		newSemanticTaskOfType(semantic.TaskTypeEmbed, "task-embed", "file-embed", 1, base, base),
+		newSemanticTaskOfType(semantic.TaskTypeImgExtractText, "task-img", "file-img", 1, base.Add(time.Second), base.Add(time.Second)),
+	}
+	for _, task := range tasks {
+		if _, err := s.EnqueueSemanticTask(ctx, task); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	claimed, found, err := s.ClaimSemanticTaskOfTypes(ctx, base.Add(5*time.Second), time.Minute, semantic.TaskTypeImgExtractText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected filtered claim to find image task")
+	}
+	if claimed.TaskID != "task-img" {
+		t.Fatalf("claimed task=%q, want %q", claimed.TaskID, "task-img")
+	}
+
+	embed := mustGetSemanticTask(t, s, "task-embed")
+	if embed.Status != semantic.TaskQueued {
+		t.Fatalf("embed task status=%q, want %q", embed.Status, semantic.TaskQueued)
+	}
+}
+
+func TestClaimSemanticTaskOfTypesReturnsNotFoundWhenOnlyDisallowedTasksExist(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	base := time.Unix(1711600360, 0).UTC()
+
+	if _, err := s.EnqueueSemanticTask(ctx, newSemanticTaskOfType(semantic.TaskTypeEmbed, "task-embed", "file-embed", 1, base, base)); err != nil {
+		t.Fatal(err)
+	}
+
+	claimed, found, err := s.ClaimSemanticTaskOfTypes(ctx, base.Add(time.Second), time.Minute, semantic.TaskTypeImgExtractText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Fatalf("unexpected claimed task: %+v", claimed)
+	}
+
+	task := mustGetSemanticTask(t, s, "task-embed")
+	if task.Status != semantic.TaskQueued {
+		t.Fatalf("task status=%q, want %q", task.Status, semantic.TaskQueued)
+	}
+}
+
+func TestClaimSemanticTaskOfTypesSupportsMultipleTaskTypes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	base := time.Unix(1711600370, 0).UTC()
+
+	tasks := []*semantic.Task{
+		newSemanticTaskOfType(semantic.TaskTypeEmbed, "task-embed", "file-embed", 1, base, base),
+		newSemanticTaskOfType(semantic.TaskTypeImgExtractText, "task-img", "file-img", 1, base.Add(time.Second), base.Add(time.Second)),
+	}
+	for _, task := range tasks {
+		if _, err := s.EnqueueSemanticTask(ctx, task); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	claimed, found, err := s.ClaimSemanticTaskOfTypes(ctx, base.Add(5*time.Second), time.Minute, semantic.TaskTypeImgExtractText, semantic.TaskTypeEmbed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected filtered claim to find a task")
+	}
+	if claimed.TaskID != "task-embed" {
+		t.Fatalf("claimed task=%q, want %q", claimed.TaskID, "task-embed")
+	}
+}
+
+func TestClaimSemanticTaskOfTypesRejectsEmptyTaskTypes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	base := time.Unix(1711600380, 0).UTC()
+
+	if _, _, err := s.ClaimSemanticTaskOfTypes(ctx, base, time.Minute); err == nil {
+		t.Fatal("expected empty task types to fail")
 	}
 }
 

--- a/pkg/semantic/task.go
+++ b/pkg/semantic/task.go
@@ -6,14 +6,21 @@ import (
 	"time"
 )
 
+// ImgExtractTaskPayload carries non-authoritative hints for durable image text
+// extraction. The task identity remains resource_id + resource_version.
+type ImgExtractTaskPayload struct {
+	Path        string `json:"path,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+}
+
 // TaskType identifies the durable semantic work to execute.
 type TaskType string
 
 const (
 	// TaskTypeEmbed generates or refreshes file embeddings.
 	TaskTypeEmbed TaskType = "embed"
-	// TaskTypeExtractText extracts or refreshes file content_text.
-	TaskTypeExtractText TaskType = "extract_text"
+	// TaskTypeImgExtractText extracts or refreshes image-derived file content_text.
+	TaskTypeImgExtractText TaskType = "img_extract_text"
 	// TaskTypeGenerateL0 generates or refreshes .abstract.md style summaries.
 	TaskTypeGenerateL0 TaskType = "generate_l0"
 	// TaskTypeGenerateL1 generates or refreshes .overview.md style summaries.

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -124,13 +124,14 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			return
 		}
 
-		b, err := pool.Get(r.Context(), &resolved.Tenant)
+		b, release, err := pool.Acquire(r.Context(), &resolved.Tenant)
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "backend_load_failed", "tenant_id", resolved.Tenant.ID, "error", err)...)
 			metricEvent(r.Context(), "tenant_backend", "result", "load_failed")
 			errJSON(w, http.StatusInternalServerError, "backend unavailable")
 			return
 		}
+		defer release()
 		metricEvent(r.Context(), "auth", "result", "ok")
 
 		scope := &TenantScope{TenantID: resolved.Tenant.ID, APIKeyID: resolved.APIKey.ID, TokenVersion: resolved.APIKey.TokenVersion, Backend: b}

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -19,7 +19,14 @@ import (
 	"github.com/mem9-ai/dat9/pkg/tenant"
 )
 
-func newAuthServer(t *testing.T) (*Server, string, func()) {
+type authTestRuntime struct {
+	meta        *meta.Store
+	pool        *tenant.Pool
+	tokenSecret []byte
+	token       string
+}
+
+func newAuthRuntime(t *testing.T) (*authTestRuntime, func()) {
 	t.Helper()
 	if testDSN == "" {
 		t.Skip("no test database available")
@@ -107,15 +114,20 @@ func newAuthServer(t *testing.T) (*Server, string, func()) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-
-	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, TokenSecret: tokenSecret})
 	cleanup := func() {
 		pool.Close()
 		_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
 		_, _ = metaStore.DB().Exec("DELETE FROM tenants")
 		_ = metaStore.Close()
 	}
-	return srv, tok, cleanup
+	return &authTestRuntime{meta: metaStore, pool: pool, tokenSecret: tokenSecret, token: tok}, cleanup
+}
+
+func newAuthServer(t *testing.T) (*Server, string, func()) {
+	t.Helper()
+	rt, cleanup := newAuthRuntime(t)
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	return srv, rt.token, cleanup
 }
 
 func mustTempDir(t *testing.T) string {
@@ -158,6 +170,35 @@ func TestAuthValidKeyCanWrite(t *testing.T) {
 	}
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+}
+
+func TestAuthKeepsBorrowedBackendValidDuringRequestAfterInvalidate(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	h := tenantAuthMiddleware(rt.meta, rt.pool, rt.tokenSecret, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scope := ScopeFromContext(r.Context())
+		if scope == nil || scope.Backend == nil {
+			t.Fatal("expected tenant scope backend")
+		}
+		rt.pool.Invalidate(scope.TenantID)
+		if err := scope.Backend.Store().DB().PingContext(r.Context()); err != nil {
+			t.Fatalf("borrowed backend store should remain usable during request: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/borrow", nil)
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
 }

--- a/pkg/server/schema_test_helper.go
+++ b/pkg/server/schema_test_helper.go
@@ -33,6 +33,7 @@ func initServerTenantSchema(t *testing.T, dsn string) {
 		`CREATE TABLE IF NOT EXISTS semantic_tasks (task_id VARCHAR(64) PRIMARY KEY, task_type VARCHAR(32) NOT NULL, resource_id VARCHAR(64) NOT NULL, resource_version BIGINT NOT NULL, status VARCHAR(20) NOT NULL, attempt_count INT NOT NULL DEFAULT 0, max_attempts INT NOT NULL DEFAULT 5, receipt VARCHAR(128), leased_at DATETIME(3), lease_until DATETIME(3), available_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), payload_json JSON, last_error TEXT, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), completed_at DATETIME(3))`,
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
+		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -34,6 +34,11 @@ const (
 
 var semanticWorkerUsesTiDBAutoEmbedding = tenant.UsesTiDBAutoEmbedding
 
+var (
+	semanticWorkerAllowedEmbedTaskTypes      = []semantic.TaskType{semantic.TaskTypeEmbed, semantic.TaskTypeGenerateL0}
+	semanticWorkerAllowedImgExtractTaskTypes = []semantic.TaskType{semantic.TaskTypeImgExtractText, semantic.TaskTypeGenerateL0}
+)
+
 // SemanticWorkerOptions controls background semantic task processing.
 type SemanticWorkerOptions struct {
 	Workers              int
@@ -98,10 +103,11 @@ type semanticTenantRef struct {
 }
 
 type semanticTarget struct {
-	tenantID string
-	backend  *backend.Dat9Backend
-	store    *datastore.Store
-	release  func()
+	tenantID         string
+	backend          *backend.Dat9Backend
+	store            *datastore.Store
+	allowedTaskTypes []semantic.TaskType
+	release          func()
 }
 
 type semanticObservationSnapshot struct {
@@ -226,7 +232,7 @@ func (m *semanticWorkerManager) processNext(ctx context.Context) bool {
 	defer target.release()
 
 	claimStart := time.Now()
-	task, found, err := target.store.ClaimSemanticTask(ctx, time.Now().UTC(), m.opts.LeaseDuration)
+	task, found, err := target.store.ClaimSemanticTaskOfTypes(ctx, time.Now().UTC(), m.opts.LeaseDuration, target.allowedTaskTypes...)
 	if err != nil {
 		metrics.RecordOperation("semantic_worker", "claim", "error", time.Since(claimStart))
 		logger.Warn(ctx, "semantic_worker_claim_failed",
@@ -386,6 +392,10 @@ func (m *semanticWorkerManager) nextTarget(ctx context.Context) (*semanticTarget
 			m.releaseTenantSlot(ref.id)
 			continue
 		}
+		if len(target.allowedTaskTypes) == 0 {
+			m.releaseTenantSlot(ref.id)
+			continue
+		}
 		target.release = func() { m.releaseTenantSlot(ref.id) }
 		return target, nil
 	}
@@ -452,7 +462,12 @@ func (m *semanticWorkerManager) targetForRef(ctx context.Context, ref semanticTe
 	if b == nil {
 		return nil, fmt.Errorf("backend missing for %s", ref.id)
 	}
-	return &semanticTarget{tenantID: ref.id, backend: b, store: b.Store()}, nil
+	return &semanticTarget{
+		tenantID:         ref.id,
+		backend:          b,
+		store:            b.Store(),
+		allowedTaskTypes: m.allowedTaskTypesForTarget(b),
+	}, nil
 }
 
 func (m *semanticWorkerManager) backendForRef(ctx context.Context, ref semanticTenantRef) (*backend.Dat9Backend, error) {
@@ -492,6 +507,10 @@ func (m *semanticWorkerManager) dispatchTask(ctx context.Context, target *semant
 }
 
 func (m *semanticWorkerManager) processEmbedTask(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task) string {
+	if m.embedder == nil {
+		m.retryTask(ctx, tenantID, store, task, "embed handler not configured")
+		return "handler_missing"
+	}
 	file, err := store.GetFile(ctx, task.ResourceID)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
@@ -653,7 +672,7 @@ func (m *semanticWorkerManager) hasImageHandler() bool {
 
 func (m *semanticWorkerManager) supportsTenantProvider(provider string) bool {
 	if semanticWorkerUsesTiDBAutoEmbedding(provider) {
-		return m.hasImageHandler()
+		return m.pool != nil && m.pool.SupportsAsyncImageExtract()
 	}
 	return m.hasEmbedHandler()
 }
@@ -666,6 +685,22 @@ func (m *semanticWorkerManager) shouldIncludeFallback() bool {
 		return m.hasImageHandler()
 	}
 	return m.hasEmbedHandler()
+}
+
+func (m *semanticWorkerManager) allowedTaskTypesForTarget(b *backend.Dat9Backend) []semantic.TaskType {
+	if m == nil || b == nil {
+		return nil
+	}
+	if b.UsesDatabaseAutoEmbedding() {
+		if b.SupportsAsyncImageExtract() {
+			return semanticWorkerAllowedImgExtractTaskTypes
+		}
+		return nil
+	}
+	if m.embedder != nil {
+		return semanticWorkerAllowedEmbedTaskTypes
+	}
+	return nil
 }
 
 func imageExtractTaskSpecFromSemanticTask(task *semantic.Task) backend.ImageExtractTaskSpec {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -33,7 +34,7 @@ const (
 
 var semanticWorkerUsesTiDBAutoEmbedding = tenant.UsesTiDBAutoEmbedding
 
-// SemanticWorkerOptions controls background embed task processing.
+// SemanticWorkerOptions controls background semantic task processing.
 type SemanticWorkerOptions struct {
 	Workers              int
 	PollInterval         time.Duration
@@ -86,7 +87,6 @@ type semanticWorkerManager struct {
 	inflight   map[string]int
 	processing int
 	rr         int
-	stores     map[string]*datastore.Store
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -99,6 +99,7 @@ type semanticTenantRef struct {
 
 type semanticTarget struct {
 	tenantID string
+	backend  *backend.Dat9Backend
 	store    *datastore.Store
 	release  func()
 }
@@ -112,15 +113,23 @@ type semanticObservationSnapshot struct {
 }
 
 func newSemanticWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Store, pool *tenant.Pool, embedder embedding.Client, opts SemanticWorkerOptions) *semanticWorkerManager {
-	if embedder == nil {
-		return nil
-	}
 	hasMultiTenant := metaStore != nil && pool != nil
-	if fallback != nil && !hasMultiTenant && fallback.UsesDatabaseAutoEmbedding() {
-		return nil
-	}
 	if fallback == nil && !hasMultiTenant {
 		return nil
+	}
+	hasEmbedHandler := embedder != nil
+	hasImageHandler := (fallback != nil && fallback.SupportsAsyncImageExtract()) || (pool != nil && pool.SupportsAsyncImageExtract())
+	if !hasEmbedHandler && !hasImageHandler {
+		return nil
+	}
+	if fallback != nil && !hasMultiTenant {
+		if fallback.UsesDatabaseAutoEmbedding() {
+			if !fallback.SupportsAsyncImageExtract() {
+				return nil
+			}
+		} else if !hasEmbedHandler {
+			return nil
+		}
 	}
 	opts.normalize()
 	return &semanticWorkerManager{
@@ -130,7 +139,6 @@ func newSemanticWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Sto
 		embedder: embedder,
 		opts:     opts,
 		inflight: make(map[string]int),
-		stores:   make(map[string]*datastore.Store),
 	}
 }
 
@@ -168,10 +176,6 @@ func (m *semanticWorkerManager) Stop() {
 	m.cancel = nil
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for tenantID, store := range m.stores {
-		_ = store.Close()
-		delete(m.stores, tenantID)
-	}
 	m.processing = 0
 	metrics.RecordGauge("semantic_worker", "workers", 0)
 	metrics.RecordGauge("semantic_worker", "inflight", 0)
@@ -230,7 +234,7 @@ func (m *semanticWorkerManager) processNext(ctx context.Context) bool {
 				zap.String("tenant_id", target.tenantID),
 				zap.String("result", "error"),
 			}, zap.Error(err))...)
-		m.invalidateTenantStore(target.tenantID)
+		m.invalidateTenantBackend(target.tenantID)
 		return false
 	}
 	if !found {
@@ -244,11 +248,11 @@ func (m *semanticWorkerManager) processNext(ctx context.Context) bool {
 		}, semanticTaskLogFields(task)...)...)
 	m.markProcessingStart()
 	defer m.markProcessingDone()
-	m.processTask(ctx, target.tenantID, target.store, task)
+	m.processTask(ctx, target, task)
 	return true
 }
 
-func (m *semanticWorkerManager) processTask(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task) {
+func (m *semanticWorkerManager) processTask(ctx context.Context, target *semanticTarget, task *semantic.Task) {
 	if task == nil {
 		return
 	}
@@ -257,7 +261,7 @@ func (m *semanticWorkerManager) processTask(ctx context.Context, tenantID string
 	defer func() {
 		metrics.RecordOperation("semantic_worker", string(task.TaskType), result, time.Since(start))
 	}()
-	result = m.dispatchTask(ctx, tenantID, store, task)
+	result = m.dispatchTask(ctx, target, task)
 }
 
 func (m *semanticWorkerManager) ackTask(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task, reason string) {
@@ -333,7 +337,7 @@ func (m *semanticWorkerManager) recoverExpired(ctx context.Context) {
 		return
 	}
 	for _, ref := range refs {
-		store, err := m.storeForRef(ctx, ref)
+		target, err := m.targetForRef(ctx, ref)
 		if err != nil {
 			logger.Warn(ctx, "semantic_worker_open_store_for_recovery_failed",
 				zap.String("tenant_id", ref.id),
@@ -341,13 +345,13 @@ func (m *semanticWorkerManager) recoverExpired(ctx context.Context) {
 			continue
 		}
 		start := time.Now()
-		recovered, err := store.RecoverExpiredSemanticTasks(ctx, time.Now().UTC(), 64)
+		recovered, err := target.store.RecoverExpiredSemanticTasks(ctx, time.Now().UTC(), 64)
 		if err != nil {
 			metrics.RecordOperation("semantic_worker", "recover", "error", time.Since(start))
 			logger.Warn(ctx, "semantic_worker_recover_failed",
 				zap.String("tenant_id", ref.id),
 				zap.Error(err))
-			m.invalidateTenantStore(ref.id)
+			m.invalidateTenantBackend(ref.id)
 			continue
 		}
 		if recovered > 0 {
@@ -374,7 +378,7 @@ func (m *semanticWorkerManager) nextTarget(ctx context.Context) (*semanticTarget
 		if !ok {
 			return nil, nil
 		}
-		store, err := m.storeForRef(ctx, ref)
+		target, err := m.targetForRef(ctx, ref)
 		if err != nil {
 			logger.Warn(ctx, "semantic_worker_open_store_failed",
 				zap.String("tenant_id", ref.id),
@@ -382,13 +386,8 @@ func (m *semanticWorkerManager) nextTarget(ctx context.Context) (*semanticTarget
 			m.releaseTenantSlot(ref.id)
 			continue
 		}
-		return &semanticTarget{
-			tenantID: ref.id,
-			store:    store,
-			release: func() {
-				m.releaseTenantSlot(ref.id)
-			},
-		}, nil
+		target.release = func() { m.releaseTenantSlot(ref.id) }
+		return target, nil
 	}
 	return nil, nil
 }
@@ -432,75 +431,62 @@ func (m *semanticWorkerManager) listTenantRefs(ctx context.Context) ([]semanticT
 		refs := make([]semanticTenantRef, 0, len(tenants))
 		for i := range tenants {
 			t := tenants[i]
-			if semanticWorkerUsesTiDBAutoEmbedding(t.Provider) {
+			if !m.supportsTenantProvider(t.Provider) {
 				continue
 			}
 			refs = append(refs, semanticTenantRef{id: t.ID, tenant: &t})
 		}
 		return refs, nil
 	}
-	if m.fallback != nil {
+	if m.shouldIncludeFallback() {
 		return []semanticTenantRef{{id: semanticLocalTenantID}}, nil
 	}
 	return nil, nil
 }
 
-func (m *semanticWorkerManager) storeForRef(ctx context.Context, ref semanticTenantRef) (*datastore.Store, error) {
-	if ref.id == semanticLocalTenantID {
-		return m.fallback.Store(), nil
+func (m *semanticWorkerManager) targetForRef(ctx context.Context, ref semanticTenantRef) (*semanticTarget, error) {
+	b, err := m.backendForRef(ctx, ref)
+	if err != nil {
+		return nil, err
 	}
-	m.mu.Lock()
-	if store := m.stores[ref.id]; store != nil {
-		m.mu.Unlock()
-		return store, nil
+	if b == nil {
+		return nil, fmt.Errorf("backend missing for %s", ref.id)
 	}
-	m.mu.Unlock()
+	return &semanticTarget{tenantID: ref.id, backend: b, store: b.Store()}, nil
+}
 
+func (m *semanticWorkerManager) backendForRef(ctx context.Context, ref semanticTenantRef) (*backend.Dat9Backend, error) {
+	if ref.id == semanticLocalTenantID {
+		return m.fallback, nil
+	}
 	if ref.tenant == nil {
 		return nil, fmt.Errorf("tenant metadata missing for %s", ref.id)
 	}
-	pass, err := m.pool.Decrypt(ctx, ref.tenant.DBPasswordCipher)
+	b, err := m.pool.Get(ctx, ref.tenant)
 	if err != nil {
-		return nil, fmt.Errorf("decrypt tenant password: %w", err)
+		return nil, fmt.Errorf("get tenant backend: %w", err)
 	}
-	// TODO(async-embedding): This worker runtime path still assumes every tenant
-	// datastore can be opened through the MySQL-oriented datastore.Open + tenantDSN
-	// flow. DB9/Postgres schema support exists at the DDL layer, but end-to-end
-	// runtime support here is not provider-neutral yet.
-	store, err := datastore.Open(tenantDSN(ref.tenant.DBUser, string(pass), ref.tenant.DBHost, ref.tenant.DBPort, ref.tenant.DBName, ref.tenant.DBTLS))
-	if err != nil {
-		return nil, fmt.Errorf("open tenant store: %w", err)
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if existing := m.stores[ref.id]; existing != nil {
-		_ = store.Close()
-		return existing, nil
-	}
-	m.stores[ref.id] = store
-	return store, nil
+	return b, nil
 }
 
-func (m *semanticWorkerManager) invalidateTenantStore(tenantID string) {
+func (m *semanticWorkerManager) invalidateTenantBackend(tenantID string) {
 	if tenantID == semanticLocalTenantID {
 		return
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	store := m.stores[tenantID]
-	if store == nil {
+	if m.pool == nil {
 		return
 	}
-	_ = store.Close()
-	delete(m.stores, tenantID)
+	m.pool.Invalidate(tenantID)
 }
 
-func (m *semanticWorkerManager) dispatchTask(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task) string {
+func (m *semanticWorkerManager) dispatchTask(ctx context.Context, target *semanticTarget, task *semantic.Task) string {
 	switch task.TaskType {
 	case semantic.TaskTypeEmbed:
-		return m.processEmbedTask(ctx, tenantID, store, task)
+		return m.processEmbedTask(ctx, target.tenantID, target.store, task)
+	case semantic.TaskTypeImgExtractText:
+		return m.processImgExtractTask(ctx, target.tenantID, target.store, target.backend, task)
 	default:
-		m.retryTask(ctx, tenantID, store, task, fmt.Sprintf("unsupported task type %q", task.TaskType))
+		m.retryTask(ctx, target.tenantID, target.store, task, fmt.Sprintf("unsupported task type %q", task.TaskType))
 		return "unsupported"
 	}
 }
@@ -541,6 +527,16 @@ func (m *semanticWorkerManager) processEmbedTask(ctx context.Context, tenantID s
 	}
 	m.ackTask(ctx, tenantID, store, task, "written")
 	return "ok"
+}
+
+func (m *semanticWorkerManager) processImgExtractTask(ctx context.Context, tenantID string, store *datastore.Store, b *backend.Dat9Backend, task *semantic.Task) string {
+	result, err := b.ProcessImageExtractTask(ctx, imageExtractTaskSpecFromSemanticTask(task))
+	if err != nil {
+		m.retryTask(ctx, tenantID, store, task, err.Error())
+		return string(result)
+	}
+	m.ackTask(ctx, tenantID, store, task, string(result))
+	return string(result)
 }
 
 func semanticTaskLogFields(task *semantic.Task) []zap.Field {
@@ -609,19 +605,19 @@ func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time
 
 	var oldest *time.Time
 	for _, ref := range refs {
-		store, err := m.storeForRef(ctx, ref)
+		target, err := m.targetForRef(ctx, ref)
 		if err != nil {
 			logger.Warn(ctx, "semantic_worker_open_store_for_observation_failed",
 				zap.String("tenant_id", ref.id),
 				zap.Error(err))
 			continue
 		}
-		obs, err := store.ObserveSemanticTasks(ctx, now)
+		obs, err := target.store.ObserveSemanticTasks(ctx, now)
 		if err != nil {
 			logger.Warn(ctx, "semantic_worker_observe_failed",
 				zap.String("tenant_id", ref.id),
 				zap.Error(err))
-			m.invalidateTenantStore(ref.id)
+			m.invalidateTenantBackend(ref.id)
 			continue
 		}
 		snapshot.queued += obs.Queued
@@ -639,4 +635,51 @@ func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time
 		}
 	}
 	return snapshot
+}
+
+func (m *semanticWorkerManager) hasEmbedHandler() bool {
+	return m != nil && m.embedder != nil
+}
+
+func (m *semanticWorkerManager) hasImageHandler() bool {
+	if m == nil {
+		return false
+	}
+	if m.fallback != nil && m.fallback.SupportsAsyncImageExtract() {
+		return true
+	}
+	return m.pool != nil && m.pool.SupportsAsyncImageExtract()
+}
+
+func (m *semanticWorkerManager) supportsTenantProvider(provider string) bool {
+	if semanticWorkerUsesTiDBAutoEmbedding(provider) {
+		return m.hasImageHandler()
+	}
+	return m.hasEmbedHandler()
+}
+
+func (m *semanticWorkerManager) shouldIncludeFallback() bool {
+	if m == nil || m.fallback == nil {
+		return false
+	}
+	if m.fallback.UsesDatabaseAutoEmbedding() {
+		return m.hasImageHandler()
+	}
+	return m.hasEmbedHandler()
+}
+
+func imageExtractTaskSpecFromSemanticTask(task *semantic.Task) backend.ImageExtractTaskSpec {
+	if task == nil {
+		return backend.ImageExtractTaskSpec{}
+	}
+	spec := backend.ImageExtractTaskSpec{FileID: task.ResourceID, Revision: task.ResourceVersion}
+	if len(task.PayloadJSON) == 0 {
+		return spec
+	}
+	var payload semantic.ImgExtractTaskPayload
+	if err := json.Unmarshal(task.PayloadJSON, &payload); err == nil {
+		spec.Path = payload.Path
+		spec.ContentType = payload.ContentType
+	}
+	return spec
 }

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -350,23 +350,26 @@ func (m *semanticWorkerManager) recoverExpired(ctx context.Context) {
 				zap.Error(err))
 			continue
 		}
-		start := time.Now()
-		recovered, err := target.store.RecoverExpiredSemanticTasks(ctx, time.Now().UTC(), 64)
-		if err != nil {
-			metrics.RecordOperation("semantic_worker", "recover", "error", time.Since(start))
-			logger.Warn(ctx, "semantic_worker_recover_failed",
-				zap.String("tenant_id", ref.id),
-				zap.Error(err))
-			m.invalidateTenantBackend(ref.id)
-			continue
-		}
-		if recovered > 0 {
-			metrics.RecordOperation("semantic_worker", "recover", "ok", time.Since(start))
-			logger.Info(ctx, "semantic_worker_recover_ok",
-				zap.String("tenant_id", ref.id),
-				zap.String("result", "ok"),
-				zap.Int("recovered", recovered))
-		}
+		func() {
+			defer target.release()
+			start := time.Now()
+			recovered, err := target.store.RecoverExpiredSemanticTasks(ctx, time.Now().UTC(), 64)
+			if err != nil {
+				metrics.RecordOperation("semantic_worker", "recover", "error", time.Since(start))
+				logger.Warn(ctx, "semantic_worker_recover_failed",
+					zap.String("tenant_id", ref.id),
+					zap.Error(err))
+				m.invalidateTenantBackend(ref.id)
+				return
+			}
+			if recovered > 0 {
+				metrics.RecordOperation("semantic_worker", "recover", "ok", time.Since(start))
+				logger.Info(ctx, "semantic_worker_recover_ok",
+					zap.String("tenant_id", ref.id),
+					zap.String("result", "ok"),
+					zap.Int("recovered", recovered))
+			}
+		}()
 	}
 }
 
@@ -392,11 +395,11 @@ func (m *semanticWorkerManager) nextTarget(ctx context.Context) (*semanticTarget
 			m.releaseTenantSlot(ref.id)
 			continue
 		}
+		target.release = chainReleases(target.release, func() { m.releaseTenantSlot(ref.id) })
 		if len(target.allowedTaskTypes) == 0 {
-			m.releaseTenantSlot(ref.id)
+			target.release()
 			continue
 		}
-		target.release = func() { m.releaseTenantSlot(ref.id) }
 		return target, nil
 	}
 	return nil, nil
@@ -455,11 +458,27 @@ func (m *semanticWorkerManager) listTenantRefs(ctx context.Context) ([]semanticT
 }
 
 func (m *semanticWorkerManager) targetForRef(ctx context.Context, ref semanticTenantRef) (*semanticTarget, error) {
-	b, err := m.backendForRef(ctx, ref)
+	if ref.id == semanticLocalTenantID {
+		if m.fallback == nil {
+			return nil, fmt.Errorf("backend missing for %s", ref.id)
+		}
+		return &semanticTarget{
+			tenantID:         ref.id,
+			backend:          m.fallback,
+			store:            m.fallback.Store(),
+			allowedTaskTypes: m.allowedTaskTypesForTarget(m.fallback),
+			release:          func() {},
+		}, nil
+	}
+	if ref.tenant == nil {
+		return nil, fmt.Errorf("tenant metadata missing for %s", ref.id)
+	}
+	b, release, err := m.pool.Acquire(ctx, ref.tenant)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("acquire tenant backend: %w", err)
 	}
 	if b == nil {
+		release()
 		return nil, fmt.Errorf("backend missing for %s", ref.id)
 	}
 	return &semanticTarget{
@@ -467,21 +486,8 @@ func (m *semanticWorkerManager) targetForRef(ctx context.Context, ref semanticTe
 		backend:          b,
 		store:            b.Store(),
 		allowedTaskTypes: m.allowedTaskTypesForTarget(b),
+		release:          release,
 	}, nil
-}
-
-func (m *semanticWorkerManager) backendForRef(ctx context.Context, ref semanticTenantRef) (*backend.Dat9Backend, error) {
-	if ref.id == semanticLocalTenantID {
-		return m.fallback, nil
-	}
-	if ref.tenant == nil {
-		return nil, fmt.Errorf("tenant metadata missing for %s", ref.id)
-	}
-	b, err := m.pool.Get(ctx, ref.tenant)
-	if err != nil {
-		return nil, fmt.Errorf("get tenant backend: %w", err)
-	}
-	return b, nil
 }
 
 func (m *semanticWorkerManager) invalidateTenantBackend(tenantID string) {
@@ -631,21 +637,24 @@ func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time
 				zap.Error(err))
 			continue
 		}
-		obs, err := target.store.ObserveSemanticTasks(ctx, now)
-		if err != nil {
-			logger.Warn(ctx, "semantic_worker_observe_failed",
-				zap.String("tenant_id", ref.id),
-				zap.Error(err))
-			m.invalidateTenantBackend(ref.id)
-			continue
-		}
-		snapshot.queued += obs.Queued
-		snapshot.processing += obs.Processing
-		snapshot.deadLettered += obs.DeadLettered
-		if obs.OldestClaimableAvailableAt != nil && (oldest == nil || obs.OldestClaimableAvailableAt.Before(*oldest)) {
-			t := obs.OldestClaimableAvailableAt.UTC()
-			oldest = &t
-		}
+		func() {
+			defer target.release()
+			obs, err := target.store.ObserveSemanticTasks(ctx, now)
+			if err != nil {
+				logger.Warn(ctx, "semantic_worker_observe_failed",
+					zap.String("tenant_id", ref.id),
+					zap.Error(err))
+				m.invalidateTenantBackend(ref.id)
+				return
+			}
+			snapshot.queued += obs.Queued
+			snapshot.processing += obs.Processing
+			snapshot.deadLettered += obs.DeadLettered
+			if obs.OldestClaimableAvailableAt != nil && (oldest == nil || obs.OldestClaimableAvailableAt.Before(*oldest)) {
+				t := obs.OldestClaimableAvailableAt.UTC()
+				oldest = &t
+			}
+		}()
 	}
 	if oldest != nil {
 		lag := now.Sub(*oldest).Seconds()
@@ -717,4 +726,15 @@ func imageExtractTaskSpecFromSemanticTask(task *semantic.Task) backend.ImageExtr
 		spec.ContentType = payload.ContentType
 	}
 	return spec
+}
+
+func chainReleases(first, second func()) func() {
+	return func() {
+		if first != nil {
+			first()
+		}
+		if second != nil {
+			second()
+		}
+	}
 }

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -35,8 +35,8 @@ const (
 var semanticWorkerUsesTiDBAutoEmbedding = tenant.UsesTiDBAutoEmbedding
 
 var (
-	semanticWorkerAllowedEmbedTaskTypes      = []semantic.TaskType{semantic.TaskTypeEmbed, semantic.TaskTypeGenerateL0}
-	semanticWorkerAllowedImgExtractTaskTypes = []semantic.TaskType{semantic.TaskTypeImgExtractText, semantic.TaskTypeGenerateL0}
+	semanticWorkerAllowedEmbedTaskTypes      = []semantic.TaskType{semantic.TaskTypeEmbed}
+	semanticWorkerAllowedImgExtractTaskTypes = []semantic.TaskType{semantic.TaskTypeImgExtractText}
 )
 
 // SemanticWorkerOptions controls background semantic task processing.

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -1254,18 +1254,6 @@ func mustServerImageFileID(t *testing.T, b *backend.Dat9Backend, path, contentTy
 	return fileID
 }
 
-func mustParseMySQLDBName(t *testing.T, dsn string) string {
-	t.Helper()
-	parsed, err := mysql.ParseDSN(dsn)
-	if err != nil {
-		t.Fatalf("parse dsn %q: %v", dsn, err)
-	}
-	if strings.TrimSpace(parsed.DBName) == "" {
-		t.Fatalf("dsn %q missing db name", dsn)
-	}
-	return parsed.DBName
-}
-
 func waitForContentTextOnServer(t *testing.T, b *backend.Dat9Backend, path, wantSubstring string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -3,8 +3,11 @@ package server
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
+	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +18,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/semantic"
 	"github.com/mem9-ai/dat9/pkg/tenant"
@@ -34,7 +38,23 @@ func (e staticSemanticEmbedder) EmbedText(context.Context, string) ([]float32, e
 	return append([]float32(nil), e.vec...), nil
 }
 
+type staticServerImageExtractor struct {
+	text string
+	err  error
+}
+
+func (e staticServerImageExtractor) ExtractImageText(context.Context, backend.ImageExtractRequest) (string, error) {
+	if e.err != nil {
+		return "", e.err
+	}
+	return e.text, nil
+}
+
 func newTestTenantPool(t *testing.T) *tenant.Pool {
+	return newTestTenantPoolWithBackendOptions(t, backend.Options{})
+}
+
+func newTestTenantPoolWithBackendOptions(t *testing.T, opts backend.Options) *tenant.Pool {
 	t.Helper()
 	master := make([]byte, 32)
 	if _, err := rand.Read(master); err != nil {
@@ -44,7 +64,7 @@ func newTestTenantPool(t *testing.T) *tenant.Pool {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost", BackendOptions: opts}, enc)
 	t.Cleanup(func() { pool.Close() })
 	return pool
 }
@@ -142,25 +162,65 @@ func TestSemanticWorkerProcessesEmbedTask(t *testing.T) {
 	waitForTaskStatus(t, b, nf.FileID, 1, string(semantic.TaskSucceeded), 3*time.Second)
 }
 
-func TestServerDoesNotStartSemanticWorkerForAutoEmbeddingFallbackBackend(t *testing.T) {
-	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{DatabaseAutoEmbedding: true})
-	s := NewWithConfig(Config{
-		Backend:          b,
-		SemanticEmbedder: staticSemanticEmbedder{vec: []float32{0.1, 0.2, 0.3}},
-		SemanticWorkers: SemanticWorkerOptions{
-			Workers:         1,
-			PollInterval:    10 * time.Millisecond,
-			RecoverInterval: 50 * time.Millisecond,
-			LeaseDuration:   200 * time.Millisecond,
+func TestSemanticWorkerProcessesImgExtractTaskWithoutEmbedder(t *testing.T) {
+	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{
+		DatabaseAutoEmbedding: true,
+		AsyncImageExtract: backend.AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: staticServerImageExtractor{text: "cat on sofa screenshot invoice"},
 		},
 	})
+	fileID := insertServerImageFileForExtractTest(t, b, "/img/worker.png", "image/png", []byte("fake-png"))
+	payload, err := json.Marshal(semantic.ImgExtractTaskPayload{Path: "/img/worker.png", ContentType: "image/png"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if _, err := b.Store().EnqueueSemanticTask(context.Background(), &semantic.Task{
+		TaskID:          "img-task-1",
+		TaskType:        semantic.TaskTypeImgExtractText,
+		ResourceID:      fileID,
+		ResourceVersion: 1,
+		Status:          semantic.TaskQueued,
+		MaxAttempts:     3,
+		AvailableAt:     now,
+		PayloadJSON:     payload,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewWithConfig(Config{Backend: b, SemanticWorkers: SemanticWorkerOptions{
+		Workers:         1,
+		PollInterval:    10 * time.Millisecond,
+		RecoverInterval: 50 * time.Millisecond,
+		LeaseDuration:   200 * time.Millisecond,
+	}})
 	t.Cleanup(func() { s.Close() })
-	if s.semanticWorker != nil {
-		t.Fatal("semantic worker should stay disabled for auto-embedding fallback backend")
+	if s.semanticWorker == nil {
+		t.Fatal("expected semantic worker to start for auto image tasks")
+	}
+
+	waitForContentTextOnServer(t, b, "/img/worker.png", "cat on sofa", 3*time.Second)
+	waitForNamedTaskStatus(t, b, "img-task-1", string(semantic.TaskSucceeded), 3*time.Second)
+	if tasks := loadSemanticTaskRowsForResource(t, b, fileID); len(tasks) != 1 || tasks[0].TaskType != string(semantic.TaskTypeImgExtractText) {
+		t.Fatalf("unexpected semantic task rows: %+v", tasks)
 	}
 }
 
-func TestSemanticWorkerMultiTenantModeIgnoresAutoEmbeddingFallbackDisable(t *testing.T) {
+func TestServerDoesNotStartSemanticWorkerWithoutHandlers(t *testing.T) {
+	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{DatabaseAutoEmbedding: true})
+	s := NewWithConfig(Config{Backend: b, SemanticWorkers: SemanticWorkerOptions{Workers: 1}})
+	t.Cleanup(func() { s.Close() })
+	if s.semanticWorker != nil {
+		t.Fatal("semantic worker should stay disabled when no handler is configured")
+	}
+}
+
+func TestSemanticWorkerManagerStartsForMultiTenantImageOnlyMode(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -169,7 +229,9 @@ func TestSemanticWorkerMultiTenantModeIgnoresAutoEmbeddingFallbackDisable(t *tes
 	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
 	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
 
-	pool := newTestTenantPool(t)
+	pool := newTestTenantPoolWithBackendOptions(t, backend.Options{
+		AsyncImageExtract: backend.AsyncImageExtractOptions{Enabled: true},
+	})
 	passCipher, err := pool.Encrypt(context.Background(), []byte("pw"))
 	if err != nil {
 		t.Fatal(err)
@@ -193,21 +255,11 @@ func TestSemanticWorkerMultiTenantModeIgnoresAutoEmbeddingFallbackDisable(t *tes
 		t.Fatal(err)
 	}
 
-	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{DatabaseAutoEmbedding: true})
-	m := newSemanticWorkerManager(b, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
+	m := newSemanticWorkerManager(nil, metaStore, pool, nil, SemanticWorkerOptions{})
 	if m == nil {
-		t.Fatal("expected semantic worker manager in multi-tenant mode")
+		t.Fatal("expected semantic worker manager in multi-tenant image-only mode")
 	}
-	refs, err := m.listTenantRefs(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(refs) != 1 {
-		t.Fatalf("tenant ref count=%d, want 1", len(refs))
-	}
-	if refs[0].id != tenantID {
-		t.Fatalf("tenant ref id=%q, want %q", refs[0].id, tenantID)
-	}
+	_ = tenantID
 }
 
 func TestSemanticWorkerAcksObsoleteRevisionAndWritesLatest(t *testing.T) {
@@ -397,7 +449,83 @@ func TestSemanticWorkerCollectObservationLocalFallback(t *testing.T) {
 	waitForNamedTaskStatus(t, b, claimed.TaskID, string(semantic.TaskProcessing), time.Second)
 }
 
-func TestSemanticWorkerListTenantRefsSkipsAutoEmbeddingProviders(t *testing.T) {
+func TestSemanticWorkerListTenantRefsImageOnlyIncludesAutoProviders(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	pool := newTestTenantPoolWithBackendOptions(t, backend.Options{
+		AsyncImageExtract: backend.AsyncImageExtractOptions{Enabled: true},
+	})
+	passCipher, err := pool.Encrypt(context.Background(), []byte("pw"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	autoTenantID := tenant.NewID()
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               autoTenantID,
+		Status:           meta.TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: passCipher,
+		DBName:           "app",
+		DBTLS:            false,
+		Provider:         tenant.ProviderTiDBZero,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	keepTenantID := tenant.NewID()
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               keepTenantID,
+		Status:           meta.TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: passCipher,
+		DBName:           "app",
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := semanticWorkerUsesTiDBAutoEmbedding
+	semanticWorkerUsesTiDBAutoEmbedding = func(provider string) bool {
+		return provider == tenant.ProviderTiDBZero
+	}
+	defer func() {
+		semanticWorkerUsesTiDBAutoEmbedding = orig
+	}()
+
+	m := newSemanticWorkerManager(nil, metaStore, pool, nil, SemanticWorkerOptions{})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	refs, err := m.listTenantRefs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("tenant ref count=%d, want 1", len(refs))
+	}
+	if refs[0].id != autoTenantID {
+		t.Fatalf("tenant ref id=%q, want %q", refs[0].id, autoTenantID)
+	}
+}
+
+func TestSemanticWorkerListTenantRefsEmbedOnlySkipsAutoProviders(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -602,6 +730,93 @@ func TestSemanticWorkerNormalizeRetryMaxDelayAtLeastBase(t *testing.T) {
 	if opts.RetryMaxDelay != opts.RetryBaseDelay {
 		t.Fatalf("RetryMaxDelay=%v, want %v", opts.RetryMaxDelay, opts.RetryBaseDelay)
 	}
+}
+
+type serverSemanticTaskRow struct {
+	TaskType string
+	Status   string
+}
+
+func insertServerImageFileForExtractTest(t *testing.T, b *backend.Dat9Backend, path, contentType string, data []byte) string {
+	t.Helper()
+	fileID := mustServerImageFileID(t, b, path, contentType, data)
+	return fileID
+}
+
+func mustServerImageFileID(t *testing.T, b *backend.Dat9Backend, path, contentType string, data []byte) string {
+	t.Helper()
+	fileID := "file-" + tenant.NewID()
+	now := time.Now().UTC()
+	err := b.Store().InTx(context.Background(), func(tx *sql.Tx) error {
+		if err := b.Store().InsertFileTx(tx, &datastore.File{
+			FileID:      fileID,
+			StorageType: datastore.StorageDB9,
+			StorageRef:  "inline",
+			ContentBlob: append([]byte(nil), data...),
+			ContentType: contentType,
+			SizeBytes:   int64(len(data)),
+			Revision:    1,
+			Status:      datastore.StatusConfirmed,
+			CreatedAt:   now,
+			ConfirmedAt: &now,
+		}); err != nil {
+			return err
+		}
+		if err := b.Store().EnsureParentDirsTx(tx, path, func() string { return tenant.NewID() }); err != nil {
+			return err
+		}
+		return b.Store().InsertNodeTx(tx, &datastore.FileNode{
+			NodeID:     tenant.NewID(),
+			Path:       path,
+			ParentPath: pathutil.ParentPath(path),
+			Name:       pathutil.BaseName(path),
+			FileID:     fileID,
+			CreatedAt:  now,
+		})
+	})
+	if err != nil {
+		t.Fatalf("insert image file %s: %v", path, err)
+	}
+	return fileID
+}
+
+func waitForContentTextOnServer(t *testing.T, b *backend.Dat9Backend, path, wantSubstring string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		nf, err := b.Store().Stat(context.Background(), path)
+		if err == nil && nf.File != nil && strings.Contains(nf.File.ContentText, wantSubstring) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	nf, err := b.Store().Stat(context.Background(), path)
+	if err != nil || nf.File == nil {
+		t.Fatalf("stat %s while waiting for content text: %v", path, err)
+	}
+	t.Fatalf("content_text=%q, want substring %q", nf.File.ContentText, wantSubstring)
+}
+
+func loadSemanticTaskRowsForResource(t *testing.T, b *backend.Dat9Backend, resourceID string) []serverSemanticTaskRow {
+	t.Helper()
+	rows, err := b.Store().DB().Query(`SELECT task_type, status FROM semantic_tasks WHERE resource_id = ? ORDER BY created_at, task_id`, resourceID)
+	if err != nil {
+		t.Fatalf("query semantic tasks for %s: %v", resourceID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []serverSemanticTaskRow
+	for rows.Next() {
+		var row serverSemanticTaskRow
+		if err := rows.Scan(&row.TaskType, &row.Status); err != nil {
+			t.Fatalf("scan semantic task for %s: %v", resourceID, err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate semantic tasks for %s: %v", resourceID, err)
+	}
+	return out
 }
 
 func mustServerFile(t *testing.T, b *backend.Dat9Backend, path string) *datastore.File {

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -975,7 +975,7 @@ func TestSemanticWorkerDeadLetterLogIncludesTaskFields(t *testing.T) {
 	}
 }
 
-func TestSemanticWorkerUnsupportedTaskTypeDeadLetters(t *testing.T) {
+func TestSemanticWorkerDoesNotClaimUnsupportedTaskType(t *testing.T) {
 	b := newTestBackendForSemanticWorker(t)
 	ctx := context.Background()
 	now := time.Now().UTC()
@@ -1001,7 +1001,11 @@ func TestSemanticWorkerUnsupportedTaskTypeDeadLetters(t *testing.T) {
 	}})
 	t.Cleanup(func() { s.Close() })
 
-	waitForNamedTaskStatus(t, b, "task-generate-l0", string(semantic.TaskDeadLettered), 3*time.Second)
+	time.Sleep(300 * time.Millisecond)
+	task := mustGetServerSemanticTask(t, b, "task-generate-l0")
+	if task.Status != string(semantic.TaskQueued) || task.AttemptCount != 0 {
+		t.Fatalf("generate_l0 task=%+v, want queued with attempt_count 0", task)
+	}
 }
 
 func TestSemanticWorkerRetryDelayHonorsConfiguredMax(t *testing.T) {

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -6,12 +6,15 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+	"github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/datastore"
@@ -38,6 +41,24 @@ func (e staticSemanticEmbedder) EmbedText(context.Context, string) ([]float32, e
 	return append([]float32(nil), e.vec...), nil
 }
 
+type gatedSemanticEmbedder struct {
+	vec     []float32
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (e *gatedSemanticEmbedder) EmbedText(context.Context, string) ([]float32, error) {
+	e.once.Do(func() {
+		select {
+		case e.started <- struct{}{}:
+		default:
+		}
+		<-e.release
+	})
+	return append([]float32(nil), e.vec...), nil
+}
+
 type staticServerImageExtractor struct {
 	text string
 	err  error
@@ -47,6 +68,24 @@ func (e staticServerImageExtractor) ExtractImageText(context.Context, backend.Im
 	if e.err != nil {
 		return "", e.err
 	}
+	return e.text, nil
+}
+
+type gatedServerImageExtractor struct {
+	text    string
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (e *gatedServerImageExtractor) ExtractImageText(context.Context, backend.ImageExtractRequest) (string, error) {
+	e.once.Do(func() {
+		select {
+		case e.started <- struct{}{}:
+		default:
+		}
+		<-e.release
+	})
 	return e.text, nil
 }
 
@@ -209,6 +248,93 @@ func TestSemanticWorkerProcessesImgExtractTaskWithoutEmbedder(t *testing.T) {
 	if tasks := loadSemanticTaskRowsForResource(t, b, fileID); len(tasks) != 1 || tasks[0].TaskType != string(semantic.TaskTypeImgExtractText) {
 		t.Fatalf("unexpected semantic task rows: %+v", tasks)
 	}
+}
+
+func TestSemanticWorkerKeepsBorrowedTenantBackendAliveDuringInvalidate(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	pool := newTestTenantPool(t)
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	tenantID := tenant.NewID()
+	tenantMeta := &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
+		t.Fatal(err)
+	}
+	b, err := pool.Get(context.Background(), tenantMeta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/docs/pinned-worker.txt", []byte("hello borrowed backend"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	nf := mustServerFile(t, b, "/docs/pinned-worker.txt")
+	embedder := &gatedSemanticEmbedder{
+		vec:     []float32{0.1, 0.2, 0.3},
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+
+	s := NewWithConfig(Config{Meta: metaStore, Pool: pool, SemanticEmbedder: embedder, SemanticWorkers: SemanticWorkerOptions{
+		Workers:         1,
+		PollInterval:    10 * time.Millisecond,
+		RecoverInterval: 50 * time.Millisecond,
+		LeaseDuration:   200 * time.Millisecond,
+	}})
+	t.Cleanup(func() { s.Close() })
+
+	select {
+	case <-embedder.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("embed task did not start")
+	}
+	pool.Invalidate(tenantID)
+	close(embedder.release)
+
+	probeStore, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = probeStore.Close() }()
+	waitForStoreEmbeddingRevision(t, probeStore, "/docs/pinned-worker.txt", 1, 3*time.Second)
+	waitForStoreTaskStatusByResource(t, probeStore, nf.FileID, 1, string(semantic.TaskSucceeded), 3*time.Second)
 }
 
 func TestSemanticWorkerImageOnlySkipsLegacyEmbedBacklog(t *testing.T) {
@@ -1081,4 +1207,77 @@ func waitForObservedLog(t *testing.T, recorded *observer.ObservedLogs, message s
 		t.Fatalf("timed out waiting for log message %q", message)
 	}
 	return entries[len(entries)-1]
+}
+
+func waitForStoreContentText(t *testing.T, store *datastore.Store, path, wantSubstring string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		nf, err := store.Stat(context.Background(), path)
+		if err == nil && nf.File != nil && strings.Contains(nf.File.ContentText, wantSubstring) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	nf, err := store.Stat(context.Background(), path)
+	if err != nil || nf.File == nil {
+		t.Fatalf("stat %s while waiting for content text: %v", path, err)
+	}
+	t.Fatalf("content_text=%q, want substring %q", nf.File.ContentText, wantSubstring)
+}
+
+func waitForStoreNamedTaskStatus(t *testing.T, store *datastore.Store, taskID, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var status string
+		err := store.DB().QueryRow(`SELECT status FROM semantic_tasks WHERE task_id = ?`, taskID).Scan(&status)
+		if err == nil && status == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	var status string
+	if err := store.DB().QueryRow(`SELECT status FROM semantic_tasks WHERE task_id = ?`, taskID).Scan(&status); err != nil {
+		t.Fatalf("wait named task status query: %v", err)
+	}
+	t.Fatalf("task %s status=%q, want %q", taskID, status, want)
+}
+
+func waitForStoreEmbeddingRevision(t *testing.T, store *datastore.Store, path string, want int64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		nf, err := store.Stat(context.Background(), path)
+		if err == nil && nf.File != nil && nf.File.EmbeddingRevision != nil && *nf.File.EmbeddingRevision == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	nf, err := store.Stat(context.Background(), path)
+	if err != nil || nf.File == nil {
+		t.Fatalf("stat %s while waiting for embedding revision: %v", path, err)
+	}
+	if nf.File.EmbeddingRevision == nil {
+		t.Fatalf("timed out waiting for embedding revision %d on %s", want, path)
+	}
+	t.Fatalf("embedding revision=%d, want %d", *nf.File.EmbeddingRevision, want)
+}
+
+func waitForStoreTaskStatusByResource(t *testing.T, store *datastore.Store, resourceID string, version int64, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var status string
+		err := store.DB().QueryRow(`SELECT status FROM semantic_tasks WHERE resource_id = ? AND resource_version = ?`, resourceID, version).Scan(&status)
+		if err == nil && status == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	var status string
+	if err := store.DB().QueryRow(`SELECT status FROM semantic_tasks WHERE resource_id = ? AND resource_version = ?`, resourceID, version).Scan(&status); err != nil {
+		t.Fatalf("wait task status by resource query: %v", err)
+	}
+	t.Fatalf("resource %s version %d status=%q, want %q", resourceID, version, status, want)
 }

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
@@ -806,6 +809,163 @@ func TestSemanticWorkerListTenantRefsEmbedOnlySkipsAutoProviders(t *testing.T) {
 	}
 }
 
+func TestSemanticWorkerHTTPMultiTenantImageOnlySkipsAppTenantEmbedTasks(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	pool := newTestTenantPoolWithBackendOptions(t, backend.Options{
+		AsyncImageExtract: backend.AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: staticServerImageExtractor{text: "auto tenant caption"},
+		},
+	})
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+
+	initServerTenantSchema(t, testDSN)
+	appStore, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetDB(t, appStore.DB())
+	if err := appStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	insertTenantWithToken := func(provider string, tenantDSN string) (*meta.Tenant, string) {
+		t.Helper()
+		parsedTenant, err := mysql.ParseDSN(tenantDSN)
+		if err != nil {
+			t.Fatal(err)
+		}
+		host, port := "127.0.0.1", 3306
+		if parsedTenant.Addr != "" {
+			h, p, _ := strings.Cut(parsedTenant.Addr, ":")
+			if h != "" {
+				host = h
+			}
+			if p != "" {
+				_, _ = fmt.Sscanf(p, "%d", &port)
+			}
+		}
+		passCipher, err := pool.Encrypt(context.Background(), []byte(parsedTenant.Passwd))
+		if err != nil {
+			t.Fatal(err)
+		}
+		now := time.Now().UTC()
+		tenantMeta := &meta.Tenant{
+			ID:               tenant.NewID(),
+			Status:           meta.TenantActive,
+			DBHost:           host,
+			DBPort:           port,
+			DBUser:           parsedTenant.User,
+			DBPasswordCipher: passCipher,
+			DBName:           parsedTenant.DBName,
+			DBTLS:            false,
+			Provider:         provider,
+			SchemaVersion:    1,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
+			t.Fatal(err)
+		}
+		tok, err := tenant.IssueToken(tokenSecret, tenantMeta.ID, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tokCipher, err := pool.Encrypt(context.Background(), []byte(tok))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := metaStore.InsertAPIKey(context.Background(), &meta.APIKey{
+			ID:            tenant.NewID(),
+			TenantID:      tenantMeta.ID,
+			KeyName:       provider,
+			JWTCiphertext: tokCipher,
+			JWTHash:       tenant.HashToken(tok),
+			TokenVersion:  1,
+			Status:        meta.APIKeyActive,
+			IssuedAt:      now,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return tenantMeta, tok
+	}
+
+	appTenant, appToken := insertTenantWithToken(tenant.ProviderDB9, testDSN)
+
+	s := NewWithConfig(Config{Meta: metaStore, Pool: pool, TokenSecret: tokenSecret, SemanticWorkers: SemanticWorkerOptions{
+		Workers:         1,
+		PollInterval:    10 * time.Millisecond,
+		RecoverInterval: 50 * time.Millisecond,
+		LeaseDuration:   200 * time.Millisecond,
+	}})
+	t.Cleanup(func() { s.Close() })
+	if s.semanticWorker == nil {
+		t.Fatal("expected semantic worker manager in multi-tenant image-only mode")
+	}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	putWithToken := func(tok, path string, body []byte) {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodPut, ts.URL+path, strings.NewReader(string(body)))
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.ContentLength = int64(len(body))
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			payload, _ := io.ReadAll(resp.Body)
+			t.Fatalf("PUT %s status=%d body=%s", path, resp.StatusCode, payload)
+		}
+	}
+
+	putWithToken(appToken, "/v1/fs/docs/app.txt", []byte("hello app tenant"))
+	appBackend, releaseApp, err := pool.Acquire(context.Background(), appTenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseApp()
+
+	appFile := mustServerFile(t, appBackend, "/docs/app.txt")
+	time.Sleep(300 * time.Millisecond)
+	var appTask serverSemanticTaskState
+	err = appBackend.Store().DB().QueryRow(`SELECT task_id, task_type, resource_id, status, attempt_count, COALESCE(last_error, '')
+		FROM semantic_tasks WHERE resource_id = ? AND resource_version = 1`, appFile.FileID).Scan(
+		&appTask.TaskID,
+		&appTask.TaskType,
+		&appTask.ResourceID,
+		&appTask.Status,
+		&appTask.AttemptCount,
+		&appTask.LastError,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if appTask.TaskType != string(semantic.TaskTypeEmbed) {
+		t.Fatalf("app task_type=%q, want %q", appTask.TaskType, semantic.TaskTypeEmbed)
+	}
+	if appTask.Status != string(semantic.TaskQueued) || appTask.AttemptCount != 0 {
+		t.Fatalf("app task=%+v, want queued with attempt_count 0", appTask)
+	}
+}
+
 func TestSemanticWorkerListTenantRefsDoesNotUseFallbackImageCapabilityForPoolTenants(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -1092,6 +1252,18 @@ func mustServerImageFileID(t *testing.T, b *backend.Dat9Backend, path, contentTy
 		t.Fatalf("insert image file %s: %v", path, err)
 	}
 	return fileID
+}
+
+func mustParseMySQLDBName(t *testing.T, dsn string) string {
+	t.Helper()
+	parsed, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("parse dsn %q: %v", dsn, err)
+	}
+	if strings.TrimSpace(parsed.DBName) == "" {
+		t.Fatalf("dsn %q missing db name", dsn)
+	}
+	return parsed.DBName
 }
 
 func waitForContentTextOnServer(t *testing.T, b *backend.Dat9Backend, path, wantSubstring string, timeout time.Duration) {

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -71,24 +71,6 @@ func (e staticServerImageExtractor) ExtractImageText(context.Context, backend.Im
 	return e.text, nil
 }
 
-type gatedServerImageExtractor struct {
-	text    string
-	started chan struct{}
-	release chan struct{}
-	once    sync.Once
-}
-
-func (e *gatedServerImageExtractor) ExtractImageText(context.Context, backend.ImageExtractRequest) (string, error) {
-	e.once.Do(func() {
-		select {
-		case e.started <- struct{}{}:
-		default:
-		}
-		<-e.release
-	})
-	return e.text, nil
-}
-
 func newTestTenantPool(t *testing.T) *tenant.Pool {
 	return newTestTenantPoolWithBackendOptions(t, backend.Options{})
 }
@@ -1207,41 +1189,6 @@ func waitForObservedLog(t *testing.T, recorded *observer.ObservedLogs, message s
 		t.Fatalf("timed out waiting for log message %q", message)
 	}
 	return entries[len(entries)-1]
-}
-
-func waitForStoreContentText(t *testing.T, store *datastore.Store, path, wantSubstring string, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		nf, err := store.Stat(context.Background(), path)
-		if err == nil && nf.File != nil && strings.Contains(nf.File.ContentText, wantSubstring) {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	nf, err := store.Stat(context.Background(), path)
-	if err != nil || nf.File == nil {
-		t.Fatalf("stat %s while waiting for content text: %v", path, err)
-	}
-	t.Fatalf("content_text=%q, want substring %q", nf.File.ContentText, wantSubstring)
-}
-
-func waitForStoreNamedTaskStatus(t *testing.T, store *datastore.Store, taskID, want string, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		var status string
-		err := store.DB().QueryRow(`SELECT status FROM semantic_tasks WHERE task_id = ?`, taskID).Scan(&status)
-		if err == nil && status == want {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	var status string
-	if err := store.DB().QueryRow(`SELECT status FROM semantic_tasks WHERE task_id = ?`, taskID).Scan(&status); err != nil {
-		t.Fatalf("wait named task status query: %v", err)
-	}
-	t.Fatalf("task %s status=%q, want %q", taskID, status, want)
 }
 
 func waitForStoreEmbeddingRevision(t *testing.T, store *datastore.Store, path string, want int64, timeout time.Duration) {

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -211,6 +211,105 @@ func TestSemanticWorkerProcessesImgExtractTaskWithoutEmbedder(t *testing.T) {
 	}
 }
 
+func TestSemanticWorkerImageOnlySkipsLegacyEmbedBacklog(t *testing.T) {
+	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{
+		DatabaseAutoEmbedding: true,
+		AsyncImageExtract: backend.AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: staticServerImageExtractor{text: "cat on sofa screenshot invoice"},
+		},
+	})
+	ctx := context.Background()
+	fileID := insertServerImageFileForExtractTest(t, b, "/img/backlog.png", "image/png", []byte("fake-png"))
+	payload, err := json.Marshal(semantic.ImgExtractTaskPayload{Path: "/img/backlog.png", ContentType: "image/png"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now().UTC()
+	if _, err := b.Store().EnqueueSemanticTask(ctx, &semantic.Task{
+		TaskID:          "legacy-embed-task",
+		TaskType:        semantic.TaskTypeEmbed,
+		ResourceID:      "legacy-embed-file",
+		ResourceVersion: 1,
+		Status:          semantic.TaskQueued,
+		MaxAttempts:     3,
+		AvailableAt:     base,
+		CreatedAt:       base,
+		UpdatedAt:       base,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Store().EnqueueSemanticTask(ctx, &semantic.Task{
+		TaskID:          "img-task-typed-claim",
+		TaskType:        semantic.TaskTypeImgExtractText,
+		ResourceID:      fileID,
+		ResourceVersion: 1,
+		Status:          semantic.TaskQueued,
+		MaxAttempts:     3,
+		AvailableAt:     base.Add(time.Second),
+		PayloadJSON:     payload,
+		CreatedAt:       base.Add(time.Second),
+		UpdatedAt:       base.Add(time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewWithConfig(Config{Backend: b, SemanticWorkers: SemanticWorkerOptions{
+		Workers:         1,
+		PollInterval:    10 * time.Millisecond,
+		RecoverInterval: 50 * time.Millisecond,
+		LeaseDuration:   200 * time.Millisecond,
+	}})
+	t.Cleanup(func() { s.Close() })
+
+	waitForContentTextOnServer(t, b, "/img/backlog.png", "cat on sofa", 3*time.Second)
+	waitForNamedTaskStatus(t, b, "img-task-typed-claim", string(semantic.TaskSucceeded), 3*time.Second)
+	legacy := mustGetServerSemanticTask(t, b, "legacy-embed-task")
+	if legacy.Status != string(semantic.TaskQueued) || legacy.AttemptCount != 0 {
+		t.Fatalf("legacy embed task=%+v, want queued with attempt_count 0", legacy)
+	}
+}
+
+func TestSemanticWorkerEmbedOnlySkipsImageTasks(t *testing.T) {
+	b := newTestBackendForSemanticWorker(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+	if _, err := b.Store().EnqueueSemanticTask(ctx, &semantic.Task{
+		TaskID:          "legacy-img-task",
+		TaskType:        semantic.TaskTypeImgExtractText,
+		ResourceID:      "legacy-image-file",
+		ResourceVersion: 1,
+		Status:          semantic.TaskQueued,
+		MaxAttempts:     3,
+		AvailableAt:     base,
+		CreatedAt:       base,
+		UpdatedAt:       base,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/docs/embed-only.txt", []byte("hello typed claim"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	nf := mustServerFile(t, b, "/docs/embed-only.txt")
+
+	s := NewWithConfig(Config{Backend: b, SemanticEmbedder: staticSemanticEmbedder{vec: []float32{0.1, 0.2, 0.3}}, SemanticWorkers: SemanticWorkerOptions{
+		Workers:         1,
+		PollInterval:    10 * time.Millisecond,
+		RecoverInterval: 50 * time.Millisecond,
+		LeaseDuration:   200 * time.Millisecond,
+	}})
+	t.Cleanup(func() { s.Close() })
+
+	waitForEmbeddingRevision(t, b, "/docs/embed-only.txt", 1, 3*time.Second)
+	waitForTaskStatus(t, b, nf.FileID, 1, string(semantic.TaskSucceeded), 3*time.Second)
+	legacy := mustGetServerSemanticTask(t, b, "legacy-img-task")
+	if legacy.Status != string(semantic.TaskQueued) || legacy.AttemptCount != 0 {
+		t.Fatalf("legacy image task=%+v, want queued with attempt_count 0", legacy)
+	}
+}
+
 func TestServerDoesNotStartSemanticWorkerWithoutHandlers(t *testing.T) {
 	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{DatabaseAutoEmbedding: true})
 	s := NewWithConfig(Config{Backend: b, SemanticWorkers: SemanticWorkerOptions{Workers: 1}})
@@ -599,6 +698,100 @@ func TestSemanticWorkerListTenantRefsEmbedOnlySkipsAutoProviders(t *testing.T) {
 	}
 }
 
+func TestSemanticWorkerListTenantRefsDoesNotUseFallbackImageCapabilityForPoolTenants(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	pool := newTestTenantPool(t)
+	passCipher, err := pool.Encrypt(context.Background(), []byte("pw"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	autoTenantID := tenant.NewID()
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               autoTenantID,
+		Status:           meta.TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: passCipher,
+		DBName:           "app",
+		DBTLS:            false,
+		Provider:         tenant.ProviderTiDBZero,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fallback := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{
+		DatabaseAutoEmbedding: true,
+		AsyncImageExtract: backend.AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 1,
+			Extractor: staticServerImageExtractor{text: "fallback only"},
+		},
+	})
+
+	orig := semanticWorkerUsesTiDBAutoEmbedding
+	semanticWorkerUsesTiDBAutoEmbedding = func(provider string) bool {
+		return provider == tenant.ProviderTiDBZero
+	}
+	defer func() {
+		semanticWorkerUsesTiDBAutoEmbedding = orig
+	}()
+
+	m := newSemanticWorkerManager(fallback, metaStore, pool, nil, SemanticWorkerOptions{})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	refs, err := m.listTenantRefs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("tenant ref count=%d, want 0", len(refs))
+	}
+}
+
+func TestSemanticWorkerProcessEmbedTaskWithoutEmbedderDoesNotPanic(t *testing.T) {
+	b := newTestBackendForSemanticWorker(t)
+	if _, err := b.Write("/docs/no-embedder.txt", []byte("hello guard"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	nf := mustServerFile(t, b, "/docs/no-embedder.txt")
+	claimed, found, err := b.Store().ClaimSemanticTask(context.Background(), time.Now().UTC(), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected embed task to be claimable")
+	}
+	var opts SemanticWorkerOptions
+	opts.normalize()
+	m := &semanticWorkerManager{fallback: b, opts: opts}
+	if got := m.processEmbedTask(context.Background(), semanticLocalTenantID, b.Store(), claimed); got != "handler_missing" {
+		t.Fatalf("process result=%q, want %q", got, "handler_missing")
+	}
+	task := mustGetServerSemanticTask(t, b, claimed.TaskID)
+	if task.Status != string(semantic.TaskQueued) {
+		t.Fatalf("task status=%q, want %q", task.Status, semantic.TaskQueued)
+	}
+	if !strings.Contains(task.LastError, "embed handler not configured") {
+		t.Fatalf("last_error=%v, want embed handler message", task.LastError)
+	}
+	if task.ResourceID != nf.FileID {
+		t.Fatalf("task resource_id=%q, want %q", task.ResourceID, nf.FileID)
+	}
+}
+
 func TestSemanticWorkerClaimAndAckLogsIncludeTaskFields(t *testing.T) {
 	core, recorded := observer.New(zap.InfoLevel)
 	restoreLogger := logger.L()
@@ -737,6 +930,15 @@ type serverSemanticTaskRow struct {
 	Status   string
 }
 
+type serverSemanticTaskState struct {
+	TaskID       string
+	TaskType     string
+	ResourceID   string
+	Status       string
+	AttemptCount int
+	LastError    string
+}
+
 func insertServerImageFileForExtractTest(t *testing.T, b *backend.Dat9Backend, path, contentType string, data []byte) string {
 	t.Helper()
 	fileID := mustServerImageFileID(t, b, path, contentType, data)
@@ -817,6 +1019,24 @@ func loadSemanticTaskRowsForResource(t *testing.T, b *backend.Dat9Backend, resou
 		t.Fatalf("iterate semantic tasks for %s: %v", resourceID, err)
 	}
 	return out
+}
+
+func mustGetServerSemanticTask(t *testing.T, b *backend.Dat9Backend, taskID string) serverSemanticTaskState {
+	t.Helper()
+	var task serverSemanticTaskState
+	err := b.Store().DB().QueryRow(`SELECT task_id, task_type, resource_id, status, attempt_count, COALESCE(last_error, '')
+		FROM semantic_tasks WHERE task_id = ?`, taskID).Scan(
+		&task.TaskID,
+		&task.TaskType,
+		&task.ResourceID,
+		&task.Status,
+		&task.AttemptCount,
+		&task.LastError,
+	)
+	if err != nil {
+		t.Fatalf("get semantic task %s: %v", taskID, err)
+	}
+	return task
 }
 
 func mustServerFile(t *testing.T, b *backend.Dat9Backend, path string) *datastore.File {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -137,7 +137,22 @@ func NewWithConfig(cfg Config) *Server {
 	}
 	s.semanticWorker = newSemanticWorkerManager(cfg.Backend, cfg.Meta, cfg.Pool, cfg.SemanticEmbedder, cfg.SemanticWorkers)
 	if s.semanticWorker != nil {
+		logger.Info("server_semantic_workers_enabled",
+			zap.Int("workers", s.semanticWorker.opts.Workers),
+			zap.Duration("poll_interval", s.semanticWorker.opts.PollInterval),
+			zap.Duration("lease_duration", s.semanticWorker.opts.LeaseDuration),
+			zap.Duration("recover_interval", s.semanticWorker.opts.RecoverInterval),
+			zap.Bool("embedder_configured", cfg.SemanticEmbedder != nil),
+			zap.Bool("fallback_image_extract_enabled", cfg.Backend != nil && cfg.Backend.SupportsAsyncImageExtract()),
+			zap.Bool("pool_image_extract_enabled", cfg.Pool != nil && cfg.Pool.SupportsAsyncImageExtract()))
 		s.semanticWorker.Start(backgroundWithTrace(context.Background()))
+	} else {
+		logger.Info("server_semantic_workers_disabled",
+			zap.Bool("embedder_configured", cfg.SemanticEmbedder != nil),
+			zap.Bool("fallback_present", cfg.Backend != nil),
+			zap.Bool("fallback_image_extract_enabled", cfg.Backend != nil && cfg.Backend.SupportsAsyncImageExtract()),
+			zap.Bool("pool_present", cfg.Pool != nil),
+			zap.Bool("pool_image_extract_enabled", cfg.Pool != nil && cfg.Pool.SupportsAsyncImageExtract()))
 	}
 	return s
 }

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -12,14 +12,21 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/s3client"
+	"github.com/mem9-ai/dat9/pkg/semantic"
 )
 
 func newTestServerWithS3(t *testing.T) (*Server, *s3client.LocalS3Client) {
+	t.Helper()
+	return newTestServerWithS3Config(t, backend.Options{}, SemanticWorkerOptions{})
+}
+
+func newTestServerWithS3Config(t *testing.T, backendOpts backend.Options, workerOpts SemanticWorkerOptions) (*Server, *s3client.LocalS3Client) {
 	t.Helper()
 	blobDir, err := os.MkdirTemp("", "dat9-srv-blobs-*")
 	if err != nil {
@@ -46,11 +53,11 @@ func newTestServerWithS3(t *testing.T) (*Server, *s3client.LocalS3Client) {
 		t.Fatal(err)
 	}
 
-	b, err := backend.NewWithS3(store, s3c)
+	b, err := backend.NewWithS3ModeAndOptions(store, s3c, true, backendOpts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return New(b), s3c
+	return NewWithConfig(Config{Backend: b, SemanticWorkers: workerOpts}), s3c
 }
 
 func partChecksumHeader(data []byte) string {
@@ -150,6 +157,49 @@ func TestSmallFilePut200(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestAutoImagePutWritesContentTextEndToEnd(t *testing.T) {
+	s, _ := newTestServerWithS3Config(t, backend.Options{
+		DatabaseAutoEmbedding: true,
+		AsyncImageExtract: backend.AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: staticServerImageExtractor{text: "caption from http put"},
+		},
+	}, SemanticWorkerOptions{
+		Workers:         1,
+		PollInterval:    10 * time.Millisecond,
+		RecoverInterval: 50 * time.Millisecond,
+		LeaseDuration:   200 * time.Millisecond,
+	})
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/e2e-put.png", bytes.NewReader([]byte("fake-png")))
+	req.ContentLength = int64(len("fake-png"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	file := mustServerFile(t, s.fallback, "/e2e-put.png")
+	waitForContentTextOnServer(t, s.fallback, "/e2e-put.png", "caption from http put", 3*time.Second)
+	waitForTaskStatus(t, s.fallback, file.FileID, 1, string(semantic.TaskSucceeded), 3*time.Second)
+
+	tasks := loadSemanticTaskRowsForResource(t, s.fallback, file.FileID)
+	if len(tasks) != 1 {
+		t.Fatalf("semantic task count=%d, want 1", len(tasks))
+	}
+	if tasks[0].TaskType != string(semantic.TaskTypeImgExtractText) || tasks[0].Status != string(semantic.TaskSucceeded) {
+		t.Fatalf("unexpected semantic task rows: %+v", tasks)
 	}
 }
 
@@ -375,6 +425,102 @@ func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 	}
 	if nf.File.SizeBytes != totalSize {
 		t.Fatalf("expected size %d, got %d", totalSize, nf.File.SizeBytes)
+	}
+}
+
+func TestAutoImageMultipartOverwriteWritesContentTextEndToEnd(t *testing.T) {
+	s, s3c := newTestServerWithS3Config(t, backend.Options{
+		DatabaseAutoEmbedding: true,
+		AsyncImageExtract: backend.AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: staticServerImageExtractor{text: "caption from multipart overwrite"},
+		},
+	}, SemanticWorkerOptions{
+		Workers:         1,
+		PollInterval:    10 * time.Millisecond,
+		RecoverInterval: 50 * time.Millisecond,
+		LeaseDuration:   200 * time.Millisecond,
+	})
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	seedReq, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/overwrite-auto.png", bytes.NewReader([]byte("seed-image")))
+	seedReq.ContentLength = int64(len("seed-image"))
+	seedResp, err := http.DefaultClient.Do(seedReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = seedResp.Body.Close() }()
+	if seedResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(seedResp.Body)
+		t.Fatalf("seed put: expected 200, got %d: %s", seedResp.StatusCode, body)
+	}
+
+	original := mustServerFile(t, s.fallback, "/overwrite-auto.png")
+	waitForContentTextOnServer(t, s.fallback, "/overwrite-auto.png", "caption from multipart overwrite", 3*time.Second)
+	waitForTaskStatus(t, s.fallback, original.FileID, 1, string(semantic.TaskSucceeded), 3*time.Second)
+
+	totalSize := int64(2 << 20)
+	body := make([]byte, totalSize)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/overwrite-auto.png", bytes.NewReader(body))
+	req.ContentLength = totalSize
+	req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(body))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var plan backend.UploadPlan
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		t.Fatalf("decode plan: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("initiate overwrite: expected 202, got %d", resp.StatusCode)
+	}
+
+	upload, err := s.fallback.GetUpload(context.Background(), plan.UploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, part := range plan.Parts {
+		start := int64(part.Number-1) * s3client.PartSize
+		end := start + part.Size
+		if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, part.Number, bytes.NewReader(make([]byte, end-start))); err != nil {
+			t.Fatalf("upload part %d: %v", part.Number, err)
+		}
+	}
+
+	completeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/uploads/"+plan.UploadID+"/complete", nil)
+	completeResp, err := http.DefaultClient.Do(completeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = completeResp.Body.Close() }()
+	if completeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(completeResp.Body)
+		t.Fatalf("complete overwrite: expected 200, got %d: %s", completeResp.StatusCode, body)
+	}
+
+	updated := mustServerFile(t, s.fallback, "/overwrite-auto.png")
+	if updated.FileID != original.FileID {
+		t.Fatalf("overwrite file_id=%q, want %q", updated.FileID, original.FileID)
+	}
+	if updated.Revision != 2 {
+		t.Fatalf("revision=%d, want 2", updated.Revision)
+	}
+	waitForContentTextOnServer(t, s.fallback, "/overwrite-auto.png", "caption from multipart overwrite", 3*time.Second)
+	waitForTaskStatus(t, s.fallback, updated.FileID, 2, string(semantic.TaskSucceeded), 3*time.Second)
+
+	tasks := loadSemanticTaskRowsForResource(t, s.fallback, updated.FileID)
+	if len(tasks) != 2 {
+		t.Fatalf("semantic task count=%d, want 2", len(tasks))
+	}
+	for _, task := range tasks {
+		if task.TaskType != string(semantic.TaskTypeImgExtractText) || task.Status != string(semantic.TaskSucceeded) {
+			t.Fatalf("unexpected semantic task rows: %+v", tasks)
+		}
 	}
 }
 

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -35,7 +35,7 @@ type Pool struct {
 	mu      sync.Mutex
 	cfg     PoolConfig
 	enc     encrypt.Encryptor
-	items   map[string]*list.Element
+	items   map[string]*entry
 	order   *list.List
 	maxSize int
 }
@@ -44,6 +44,9 @@ type entry struct {
 	tenantID string
 	backend  *backend.Dat9Backend
 	store    *datastore.Store
+	elem     *list.Element
+	refs     int
+	retired  bool
 }
 
 func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
@@ -51,7 +54,7 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 	if max <= 0 {
 		max = 128
 	}
-	return &Pool{cfg: cfg, enc: enc, items: map[string]*list.Element{}, order: list.New(), maxSize: max}
+	return &Pool{cfg: cfg, enc: enc, items: map[string]*entry{}, order: list.New(), maxSize: max}
 }
 
 func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backend, err error) {
@@ -67,9 +70,9 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 	}
 
 	p.mu.Lock()
-	if elem, ok := p.items[t.ID]; ok {
-		p.order.MoveToFront(elem)
-		b := elem.Value.(*entry).backend
+	if e, ok := p.items[t.ID]; ok {
+		p.order.MoveToFront(e.elem)
+		b := e.backend
 		p.mu.Unlock()
 		return b, nil
 	}
@@ -81,45 +84,118 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 	}
 
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	if elem, ok := p.items[t.ID]; ok {
+	if e, ok := p.items[t.ID]; ok {
 		b.Close()
 		_ = st.Close()
-		p.order.MoveToFront(elem)
-		return elem.Value.(*entry).backend, nil
+		p.order.MoveToFront(e.elem)
+		p.mu.Unlock()
+		return e.backend, nil
 	}
-	elem := p.order.PushFront(&entry{tenantID: t.ID, backend: b, store: st})
-	p.items[t.ID] = elem
+	e := &entry{tenantID: t.ID, backend: b, store: st}
+	e.elem = p.order.PushFront(e)
+	p.items[t.ID] = e
+	toClose := make([]*entry, 0, 1)
 	for p.order.Len() > p.maxSize {
 		oldest := p.order.Back()
 		if oldest != nil {
-			p.removeLocked(oldest)
+			if removed := p.removeLocked(oldest); removed != nil {
+				toClose = append(toClose, removed)
+			}
 		}
+	}
+	p.mu.Unlock()
+	for _, retired := range toClose {
+		closeEntry(retired)
 	}
 	return b, nil
 }
 
-func (p *Pool) Invalidate(tenantID string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if elem, ok := p.items[tenantID]; ok {
-		p.removeLocked(elem)
+// Acquire returns a backend that is pinned for the caller's active use. The
+// returned release callback must be called when the caller is done with the
+// backend so a retired entry can be closed.
+func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backend, release func(), err error) {
+	start := time.Now()
+	defer observePool(ctx, "acquire", t.ID, &err, start)
+
+	if t.Status != meta.TenantActive {
+		logger.Warn(ctx, "tenant_pool_get_skipped_inactive",
+			zap.String("tenant_id", t.ID),
+			zap.String("status", string(t.Status)))
+		p.Invalidate(t.ID)
+		return nil, nil, fmt.Errorf("tenant status: %s", t.Status)
 	}
+
+	p.mu.Lock()
+	if e, ok := p.items[t.ID]; ok {
+		e.refs++
+		p.order.MoveToFront(e.elem)
+		p.mu.Unlock()
+		return e.backend, p.makeRelease(e), nil
+	}
+	p.mu.Unlock()
+
+	b, st, err := p.createBackend(ctx, t)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p.mu.Lock()
+	if e, ok := p.items[t.ID]; ok {
+		e.refs++
+		p.order.MoveToFront(e.elem)
+		p.mu.Unlock()
+		b.Close()
+		_ = st.Close()
+		return e.backend, p.makeRelease(e), nil
+	}
+	e := &entry{tenantID: t.ID, backend: b, store: st, refs: 1}
+	e.elem = p.order.PushFront(e)
+	p.items[t.ID] = e
+	toClose := make([]*entry, 0, 1)
+	for p.order.Len() > p.maxSize {
+		oldest := p.order.Back()
+		if oldest != nil {
+			if removed := p.removeLocked(oldest); removed != nil {
+				toClose = append(toClose, removed)
+			}
+		}
+	}
+	p.mu.Unlock()
+	for _, retired := range toClose {
+		closeEntry(retired)
+	}
+	return b, p.makeRelease(e), nil
+}
+
+func (p *Pool) Invalidate(tenantID string) {
+	var toClose *entry
+	p.mu.Lock()
+	if e, ok := p.items[tenantID]; ok {
+		toClose = p.removeLocked(e.elem)
+	}
+	p.mu.Unlock()
+	closeEntry(toClose)
 }
 
 func (p *Pool) Close() {
+	toClose := make([]*entry, 0, p.order.Len())
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	for p.order.Len() > 0 {
-		p.removeLocked(p.order.Back())
+		if removed := p.removeLocked(p.order.Back()); removed != nil {
+			toClose = append(toClose, removed)
+		}
+	}
+	p.mu.Unlock()
+	for _, retired := range toClose {
+		closeEntry(retired)
 	}
 }
 
 func (p *Pool) S3Backend(tenantID string) *backend.Dat9Backend {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if elem, ok := p.items[tenantID]; ok {
-		return elem.Value.(*entry).backend
+	if e, ok := p.items[tenantID]; ok {
+		return e.backend
 	}
 	return nil
 }
@@ -234,10 +310,47 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	return b, store, nil
 }
 
-func (p *Pool) removeLocked(elem *list.Element) {
+func (p *Pool) removeLocked(elem *list.Element) *entry {
 	e := elem.Value.(*entry)
 	p.order.Remove(elem)
+	e.elem = nil
 	delete(p.items, e.tenantID)
+	e.retired = true
+	if e.refs == 0 {
+		return e
+	}
+	return nil
+}
+
+func (p *Pool) makeRelease(e *entry) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			p.releaseEntry(e)
+		})
+	}
+}
+
+func (p *Pool) releaseEntry(e *entry) {
+	if e == nil {
+		return
+	}
+	var toClose *entry
+	p.mu.Lock()
+	if e.refs > 0 {
+		e.refs--
+	}
+	if e.refs == 0 && e.retired {
+		toClose = e
+	}
+	p.mu.Unlock()
+	closeEntry(toClose)
+}
+
+func closeEntry(e *entry) {
+	if e == nil {
+		return
+	}
 	if e.backend != nil {
 		e.backend.Close()
 	}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -132,6 +132,12 @@ func (p *Pool) Encrypt(ctx context.Context, plain []byte) ([]byte, error) {
 	return p.enc.Encrypt(ctx, plain)
 }
 
+// SupportsAsyncImageExtract reports whether tenant backends created by this
+// pool carry the async image extraction runtime.
+func (p *Pool) SupportsAsyncImageExtract() bool {
+	return p != nil && p.cfg.BackendOptions.AsyncImageExtract.Enabled
+}
+
 func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantID string) (out *backend.Dat9Backend) {
 	start := time.Now()
 	var err error

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -1,0 +1,200 @@
+package tenant
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/dat9/internal/testmysql"
+	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/encrypt"
+	"github.com/mem9-ai/dat9/pkg/meta"
+)
+
+func TestPoolAcquireInvalidateDefersCloseUntilRelease(t *testing.T) {
+	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-a")
+	ctx := context.Background()
+
+	b1, release1, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store1 := b1.Store()
+	assertStoreOpen(t, store1)
+
+	pool.Invalidate(tenant.ID)
+	assertStoreOpen(t, store1)
+
+	b2, release2, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b1 == b2 {
+		t.Fatal("expected acquire after invalidate to create a new backend")
+	}
+	assertStoreOpen(t, b2.Store())
+
+	release1()
+	assertStoreClosed(t, store1)
+	assertStoreOpen(t, b2.Store())
+	release2()
+}
+
+func TestPoolAcquireEvictionRetiresPinnedEntry(t *testing.T) {
+	pool, tenantA := newTestPoolAndTenant(t, 1, "tenant-a")
+	ctx := context.Background()
+	bA, releaseA, err := pool.Acquire(ctx, tenantA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeA := bA.Store()
+	assertStoreOpen(t, storeA)
+
+	tenantB := cloneTenantForID(t, pool, tenantA, "tenant-b")
+	bB, err := pool.Get(ctx, tenantB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bB == nil {
+		t.Fatal("expected second backend")
+	}
+	assertStoreOpen(t, bB.Store())
+	assertStoreOpen(t, storeA)
+
+	releaseA()
+	assertStoreClosed(t, storeA)
+	assertStoreOpen(t, bB.Store())
+}
+
+func newTestPoolAndTenant(t *testing.T, maxTenants int, tenantID string) (*Pool, *meta.Tenant) {
+	t.Helper()
+	initTenantPoolSchema(t, testDSN)
+	resetStore, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetDB(t, resetStore.DB())
+	if err := resetStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := NewPool(PoolConfig{MaxTenants: maxTenants}, enc)
+	t.Cleanup(func() { pool.Close() })
+	return pool, cloneTenantForID(t, pool, nil, tenantID)
+}
+
+func initTenantPoolSchema(t *testing.T, dsn string) {
+	t.Helper()
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS file_nodes (node_id VARCHAR(64) PRIMARY KEY, path VARCHAR(512) NOT NULL, parent_path VARCHAR(512) NOT NULL, name VARCHAR(255) NOT NULL, is_directory BOOLEAN NOT NULL DEFAULT FALSE, file_id VARCHAR(64), created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
+		`CREATE UNIQUE INDEX idx_path ON file_nodes(path)`,
+		`CREATE INDEX idx_parent ON file_nodes(parent_path)`,
+		`CREATE INDEX idx_file_id ON file_nodes(file_id)`,
+		`CREATE TABLE IF NOT EXISTS files (file_id VARCHAR(64) PRIMARY KEY, storage_type VARCHAR(32) NOT NULL, storage_ref TEXT NOT NULL, content_blob LONGBLOB, content_type VARCHAR(255), size_bytes BIGINT NOT NULL DEFAULT 0, checksum_sha256 VARCHAR(128), revision BIGINT NOT NULL DEFAULT 1, status VARCHAR(32) NOT NULL DEFAULT 'PENDING', source_id VARCHAR(255), content_text LONGTEXT, embedding LONGTEXT, embedding_revision BIGINT, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), confirmed_at DATETIME(3), expires_at DATETIME(3))`,
+		`CREATE INDEX idx_status ON files(status, created_at)`,
+		`CREATE TABLE IF NOT EXISTS file_tags (file_id VARCHAR(64) NOT NULL, tag_key VARCHAR(255) NOT NULL, tag_value VARCHAR(255) NOT NULL DEFAULT '', PRIMARY KEY (file_id, tag_key))`,
+		`CREATE INDEX idx_kv ON file_tags(tag_key, tag_value)`,
+		`CREATE TABLE IF NOT EXISTS uploads (upload_id VARCHAR(64) PRIMARY KEY, file_id VARCHAR(64) NOT NULL, target_path VARCHAR(512) NOT NULL, s3_upload_id VARCHAR(255) NOT NULL, s3_key VARCHAR(2048) NOT NULL, total_size BIGINT NOT NULL, part_size BIGINT NOT NULL, parts_total INT NOT NULL, status VARCHAR(32) NOT NULL DEFAULT 'UPLOADING', fingerprint_sha256 VARCHAR(128), idempotency_key VARCHAR(255), created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3), expires_at DATETIME(3) NOT NULL, active_target_path VARCHAR(512) AS (CASE WHEN status = 'UPLOADING' THEN target_path ELSE NULL END) STORED)`,
+		`CREATE INDEX idx_upload_path ON uploads(target_path, status)`,
+		`CREATE UNIQUE INDEX idx_idempotency ON uploads(idempotency_key)`,
+		`CREATE TABLE IF NOT EXISTS semantic_tasks (task_id VARCHAR(64) PRIMARY KEY, task_type VARCHAR(32) NOT NULL, resource_id VARCHAR(64) NOT NULL, resource_version BIGINT NOT NULL, status VARCHAR(20) NOT NULL, attempt_count INT NOT NULL DEFAULT 0, max_attempts INT NOT NULL DEFAULT 5, receipt VARCHAR(128), leased_at DATETIME(3), lease_until DATETIME(3), available_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), payload_json JSON, last_error TEXT, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), completed_at DATETIME(3))`,
+		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
+		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
+		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			msg := err.Error()
+			if strings.Contains(msg, "Duplicate key name") || strings.Contains(msg, "already exists") {
+				continue
+			}
+			t.Fatal(err)
+		}
+	}
+}
+
+func cloneTenantForID(t *testing.T, pool *Pool, src *meta.Tenant, tenantID string) *meta.Tenant {
+	t.Helper()
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	passwd := parsed.Passwd
+	if src != nil {
+		plain, err := pool.Decrypt(context.Background(), src.DBPasswordCipher)
+		if err != nil {
+			t.Fatal(err)
+		}
+		passwd = string(plain)
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	provider := ProviderDB9
+	if src != nil {
+		provider = src.Provider
+	}
+	return &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         provider,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+}
+
+func assertStoreOpen(t *testing.T, store *datastore.Store) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := store.DB().PingContext(ctx); err != nil {
+		t.Fatalf("expected store to remain open: %v", err)
+	}
+}
+
+func assertStoreClosed(t *testing.T, store *datastore.Store) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := store.DB().PingContext(ctx); err == nil {
+		t.Fatal("expected store to be closed")
+	}
+}

--- a/pkg/tenant/schema_db9.go
+++ b/pkg/tenant/schema_db9.go
@@ -105,6 +105,7 @@ func initDB9Schema(dsn string) error {
 			UNIQUE (task_type, resource_id, resource_version)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
 	}
 
 	return execSchemaStatements(db, stmts)

--- a/pkg/tenant/schema_tidb_app.go
+++ b/pkg/tenant/schema_tidb_app.go
@@ -95,6 +95,7 @@ func tidbAppEmbeddingSchemaStatements(withContentBlob bool) []string {
 		)`,
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
+		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
 	}
 }
 

--- a/pkg/tenant/schema_tidb_auto.go
+++ b/pkg/tenant/schema_tidb_auto.go
@@ -134,6 +134,7 @@ func tidbAutoEmbeddingSchemaStatements(withContentBlob bool) []string {
 		)`,
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
+		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
 	}
 }
 

--- a/pkg/tenant/testmain_test.go
+++ b/pkg/tenant/testmain_test.go
@@ -1,0 +1,26 @@
+package tenant
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/mem9-ai/dat9/internal/testmysql"
+)
+
+var testDSN string
+
+func TestMain(m *testing.M) {
+	inst, err := testmysql.Start(context.Background())
+	if err != nil {
+		log.Fatalf("setup mysql test instance: %v", err)
+	}
+	testDSN = inst.DSN
+
+	code := m.Run()
+	if err := inst.Close(context.Background()); err != nil {
+		log.Printf("teardown mysql test instance: %v", err)
+	}
+	os.Exit(code)
+}

--- a/scripts/dat9-server-local-env.sh
+++ b/scripts/dat9-server-local-env.sh
@@ -9,15 +9,17 @@
 #   export DAT9_LOCAL_INIT_SCHEMA=true   # only for disposable local databases
 #   make run-server-local
 
-# Server basics
-: "${DAT9_LISTEN_ADDR:=127.0.0.1:9009}"
+# Server basics.
+# Leave DAT9_LISTEN_ADDR unset to use the built-in default (127.0.0.1:9009).
+# : "${DAT9_LISTEN_ADDR:=127.0.0.1:9009}"
 : "${DAT9_PUBLIC_URL:=http://127.0.0.1:9009}"
 
 # Local single-tenant data plane.
 # Create the database ahead of time, for example:
 #   mycli --host 127.0.0.1 --port 4000 -u root -e "CREATE DATABASE IF NOT EXISTS dat9_local;"
 : "${DAT9_LOCAL_DSN:=root@tcp(127.0.0.1:4000)/dat9_local?parseTime=true}"
-: "${DAT9_LOCAL_INIT_SCHEMA:=false}"
+# Leave DAT9_LOCAL_INIT_SCHEMA unset to use the built-in default (false).
+# : "${DAT9_LOCAL_INIT_SCHEMA:=false}"
 
 # Local mock S3 mode.
 : "${DAT9_S3_DIR:=${TMPDIR:-/tmp}/dat9-local-s3}"
@@ -30,43 +32,33 @@
 : "${DAT9_EMBED_API_BASE:=http://127.0.0.1:11434}"
 : "${DAT9_EMBED_API_KEY:=ollama}"
 : "${DAT9_EMBED_MODEL:=all-minilm}"
-: "${DAT9_EMBED_TIMEOUT_SECONDS:=20}"
-: "${DAT9_SEMANTIC_WORKERS:=1}"
-: "${DAT9_SEMANTIC_POLL_INTERVAL_MS:=200}"
-: "${DAT9_SEMANTIC_LEASE_SECONDS:=30}"
-: "${DAT9_SEMANTIC_RECOVER_INTERVAL_MS:=5000}"
-: "${DAT9_SEMANTIC_RETRY_BASE_MS:=200}"
-: "${DAT9_SEMANTIC_RETRY_MAX_MS:=30000}"
-: "${DAT9_SEMANTIC_PER_TENANT_CONCURRENCY:=1}"
+# Leave the following unset to keep using the program defaults:
+# DAT9_EMBED_TIMEOUT_SECONDS=20
+# DAT9_SEMANTIC_WORKERS=1
+# DAT9_SEMANTIC_POLL_INTERVAL_MS=200
+# DAT9_SEMANTIC_LEASE_SECONDS defaults to 30, or max(30, 2x image extract timeout)
+#   in dat9-server-local when unset and async image extraction is enabled.
+# DAT9_SEMANTIC_RECOVER_INTERVAL_MS=5000
+# DAT9_SEMANTIC_RETRY_BASE_MS=200
+# DAT9_SEMANTIC_RETRY_MAX_MS=30000
+# DAT9_SEMANTIC_PER_TENANT_CONCURRENCY=1
 
 # Query embedding.
 # Leave DAT9_QUERY_EMBED_* unset by default so dat9-server-local exercises the
 # same embedder-reuse path as dat9-server when only DAT9_EMBED_* is configured.
 
 # Optional: image extract bridge validation.
-: "${DAT9_IMAGE_EXTRACT_ENABLED:=false}"
-: "${DAT9_IMAGE_EXTRACT_QUEUE_SIZE:=128}"
-: "${DAT9_IMAGE_EXTRACT_WORKERS:=1}"
+# Leave these unset to keep image extract disabled / using built-in defaults.
+# : "${DAT9_IMAGE_EXTRACT_ENABLED:=false}"
+# : "${DAT9_IMAGE_EXTRACT_QUEUE_SIZE:=128}"
+# : "${DAT9_IMAGE_EXTRACT_WORKERS:=1}"
 
-export DAT9_LISTEN_ADDR
 export DAT9_PUBLIC_URL
 export DAT9_LOCAL_DSN
-export DAT9_LOCAL_INIT_SCHEMA
 export DAT9_S3_DIR
 export DAT9_EMBED_API_BASE
 export DAT9_EMBED_API_KEY
 export DAT9_EMBED_MODEL
-export DAT9_EMBED_TIMEOUT_SECONDS
-export DAT9_SEMANTIC_WORKERS
-export DAT9_SEMANTIC_POLL_INTERVAL_MS
-export DAT9_SEMANTIC_LEASE_SECONDS
-export DAT9_SEMANTIC_RECOVER_INTERVAL_MS
-export DAT9_SEMANTIC_RETRY_BASE_MS
-export DAT9_SEMANTIC_RETRY_MAX_MS
-export DAT9_SEMANTIC_PER_TENANT_CONCURRENCY
-export DAT9_IMAGE_EXTRACT_ENABLED
-export DAT9_IMAGE_EXTRACT_QUEUE_SIZE
-export DAT9_IMAGE_EXTRACT_WORKERS
 
 echo "Environment loaded for dat9-server-local."
 echo "Run: make run-server-local"

--- a/scripts/verify_local_img_extract.py
+++ b/scripts/verify_local_img_extract.py
@@ -4,7 +4,7 @@
 
 This script exercises two end-to-end paths:
 
-1. Small direct PUT to `/v1/fs/<path>.png`
+1. Direct PUT to `/v1/fs/<path>`
 2. Multipart upload via `/v1/uploads/initiate` -> S3 part PUTs -> `/complete`
 
 For each path it waits until:
@@ -21,6 +21,8 @@ import argparse
 import base64
 import hashlib
 import json
+import os
+from pathlib import Path
 import sys
 import time
 import urllib.request
@@ -146,14 +148,64 @@ class Verifier:
             f"timed out waiting for durable img_extract_text success for {path}; last rows: {json.dumps(last_rows, ensure_ascii=False)}"
         )
 
-    def verify_direct_put(self, path: str) -> VerificationResult:
+    def calc_part_checksums(self, payload: bytes) -> list[str]:
+        checksums = []
+        for start in range(0, len(payload), PART_SIZE):
+            chunk = payload[start : start + PART_SIZE]
+            checksums.append(base64.b64encode(hashlib.sha256(chunk).digest()).decode())
+        return checksums
+
+    def upload_parts_from_plan(self, plan: dict[str, Any], payload: bytes) -> None:
+        for part in plan["parts"]:
+            number = int(part["number"])
+            start = (number - 1) * int(plan["part_size"])
+            chunk = payload[start : start + int(part["size"])]
+            headers = {k: str(v) for k, v in (part.get("headers") or {}).items()}
+            headers["Content-Length"] = str(len(chunk))
+            req = urllib.request.Request(
+                part["url"], data=chunk, method="PUT", headers=headers
+            )
+            with urllib.request.urlopen(
+                req, timeout=max(self.timeout_seconds, 60)
+            ) as resp:
+                if resp.status != 200:
+                    raise RuntimeError(
+                        f"multipart part {number} upload failed with status {resp.status}"
+                    )
+
+    def complete_upload(self, upload_id: str, path: str) -> None:
+        complete_status, complete_body = self.request_status(
+            "POST",
+            f"/v1/uploads/{upload_id}/complete",
+            payload=b"",
+        )
+        if complete_status != 200:
+            raise RuntimeError(
+                f"multipart complete failed for {path}: status={complete_status}, body={complete_body.decode(errors='replace')}"
+            )
+
+    def verify_direct_put_bytes(self, path: str, payload: bytes) -> VerificationResult:
+        checksums = self.calc_part_checksums(payload)
         status, body = self.request_status(
             "PUT",
             "/v1/fs" + path,
-            payload=b"fake-png",
-            headers={"Content-Length": str(len(b"fake-png"))},
+            payload=payload,
+            headers={
+                "Content-Length": str(len(payload)),
+                "X-Dat9-Part-Checksums": ",".join(checksums),
+            },
         )
-        if status != 200:
+        if status == 202:
+            plan = json.loads(body.decode())
+            if (
+                not isinstance(plan, dict)
+                or not plan.get("upload_id")
+                or not plan.get("parts")
+            ):
+                raise RuntimeError(f"unexpected PUT upload plan payload: {plan!r}")
+            self.upload_parts_from_plan(plan, payload)
+            self.complete_upload(str(plan["upload_id"]), path)
+        elif status != 200:
             raise RuntimeError(
                 f"direct PUT failed for {path}: status={status}, body={body.decode(errors='replace')}"
             )
@@ -161,14 +213,9 @@ class Verifier:
         result.flow = "direct_put"
         return result
 
-    def verify_multipart(self, path: str, total_size: int) -> VerificationResult:
-        body = b"fake-png-multipart-" + (
-            b"z" * (total_size - len(b"fake-png-multipart-"))
-        )
-        checksums = []
-        for start in range(0, len(body), PART_SIZE):
-            chunk = body[start : start + PART_SIZE]
-            checksums.append(base64.b64encode(hashlib.sha256(chunk).digest()).decode())
+    def verify_multipart(self, path: str, payload: bytes) -> VerificationResult:
+        body = payload
+        checksums = self.calc_part_checksums(body)
 
         initiate_payload = json.dumps(
             {
@@ -190,41 +237,37 @@ class Verifier:
         ):
             raise RuntimeError(f"unexpected multipart initiate payload: {plan!r}")
 
-        for part in plan["parts"]:
-            number = int(part["number"])
-            start = (number - 1) * int(plan["part_size"])
-            chunk = body[start : start + int(part["size"])]
-            headers = {k: str(v) for k, v in (part.get("headers") or {}).items()}
-            headers["Content-Length"] = str(len(chunk))
-            req = urllib.request.Request(
-                part["url"], data=chunk, method="PUT", headers=headers
-            )
-            with urllib.request.urlopen(
-                req, timeout=max(self.timeout_seconds, 60)
-            ) as resp:
-                if resp.status != 200:
-                    raise RuntimeError(
-                        f"multipart part {number} upload failed with status {resp.status}"
-                    )
-
-        complete_status, complete_body = self.request_status(
-            "POST",
-            f"/v1/uploads/{plan['upload_id']}/complete",
-            payload=b"",
-        )
-        if complete_status != 200:
-            raise RuntimeError(
-                f"multipart complete failed for {path}: status={complete_status}, body={complete_body.decode(errors='replace')}"
-            )
+        self.upload_parts_from_plan(plan, body)
+        self.complete_upload(str(plan["upload_id"]), path)
 
         result = self.wait_for_img_extract_success(path)
         result.flow = "multipart"
         return result
 
 
-def make_unique_path(prefix: str) -> str:
+def normalize_remote_path(remote_path: str) -> str:
+    remote_path = remote_path.strip()
+    if not remote_path:
+        raise ValueError("remote path must not be empty")
+    if not remote_path.startswith("/"):
+        remote_path = "/" + remote_path
+    return remote_path
+
+
+def make_unique_path_like(prefix: str, source_name: str) -> str:
     suffix = uuid.uuid4().hex[:10]
-    return f"/{prefix}-{suffix}.png"
+    ext = Path(source_name).suffix or ".png"
+    return f"/{prefix}-{suffix}{ext}"
+
+
+def load_image_bytes(path: str) -> bytes:
+    file_path = Path(path).expanduser().resolve()
+    if not file_path.is_file():
+        raise FileNotFoundError(f"image file not found: {file_path}")
+    data = file_path.read_bytes()
+    if not data:
+        raise ValueError(f"image file is empty: {file_path}")
+    return data
 
 
 def print_result(result: VerificationResult) -> None:
@@ -264,13 +307,19 @@ def parse_args() -> argparse.Namespace:
         help="poll interval while waiting for task completion",
     )
     parser.add_argument(
-        "--multipart-size-bytes",
-        type=int,
-        default=(1 << 20) + 1024,
-        help=(
-            "multipart payload size; default stays above the 1 MiB multipart threshold "
-            "but below the default 8 MiB image extract max"
-        ),
+        "--image",
+        default="",
+        help="real image file to upload for both flows; if unset, the script uses built-in fake bytes",
+    )
+    parser.add_argument(
+        "--direct-image",
+        default="",
+        help="optional image file used only for the direct PUT flow",
+    )
+    parser.add_argument(
+        "--multipart-image",
+        default="",
+        help="optional image file used only for the multipart flow",
     )
     parser.add_argument(
         "--direct-path", default="", help="optional fixed path for the direct PUT flow"
@@ -280,20 +329,56 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="optional fixed path for the multipart flow",
     )
+    parser.add_argument(
+        "--skip-direct",
+        action="store_true",
+        help="skip the direct PUT flow",
+    )
+    parser.add_argument(
+        "--skip-multipart",
+        action="store_true",
+        help="skip the multipart flow",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+    if args.skip_direct and args.skip_multipart:
+        raise ValueError("cannot skip both direct and multipart flows")
+
     verifier = Verifier(args.base_url, args.timeout_seconds, args.poll_interval_seconds)
 
-    direct_path = args.direct_path or make_unique_path("verify-direct")
-    multipart_path = args.multipart_path or make_unique_path("verify-multipart")
+    direct_image = args.direct_image or args.image
+    multipart_image = args.multipart_image or args.image
+
+    direct_payload = load_image_bytes(direct_image) if direct_image else b"fake-png"
+    multipart_payload = (
+        load_image_bytes(multipart_image) if multipart_image else b"fake-png-multipart"
+    )
+
+    direct_source_name = direct_image or "fake-direct.png"
+    multipart_source_name = multipart_image or "fake-multipart.png"
+
+    direct_path = (
+        normalize_remote_path(args.direct_path)
+        if args.direct_path
+        else make_unique_path_like("verify-direct", direct_source_name)
+    )
+    multipart_path = (
+        normalize_remote_path(args.multipart_path)
+        if args.multipart_path
+        else make_unique_path_like("verify-multipart", multipart_source_name)
+    )
 
     print(
         json.dumps(
             {
                 "base_url": args.base_url,
+                "direct_image": os.path.abspath(direct_image) if direct_image else None,
+                "multipart_image": os.path.abspath(multipart_image)
+                if multipart_image
+                else None,
                 "direct_path": direct_path,
                 "multipart_path": multipart_path,
             },
@@ -301,13 +386,13 @@ def main() -> int:
         )
     )
 
-    direct_result = verifier.verify_direct_put(direct_path)
-    print_result(direct_result)
+    if not args.skip_direct:
+        direct_result = verifier.verify_direct_put_bytes(direct_path, direct_payload)
+        print_result(direct_result)
 
-    multipart_result = verifier.verify_multipart(
-        multipart_path, args.multipart_size_bytes
-    )
-    print_result(multipart_result)
+    if not args.skip_multipart:
+        multipart_result = verifier.verify_multipart(multipart_path, multipart_payload)
+        print_result(multipart_result)
 
     return 0
 

--- a/scripts/verify_local_img_extract.py
+++ b/scripts/verify_local_img_extract.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+
+"""Verify local durable img_extract_text flows against dat9-server-local.
+
+This script exercises two end-to-end paths:
+
+1. Small direct PUT to `/v1/fs/<path>.png`
+2. Multipart upload via `/v1/uploads/initiate` -> S3 part PUTs -> `/complete`
+
+For each path it waits until:
+- a durable `semantic_tasks` row exists with `task_type = 'img_extract_text'`
+- the task reaches `status = 'succeeded'`
+- `files.content_text` is written back
+
+The script exits non-zero on any failed assertion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+import time
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_BASE_URL = "http://127.0.0.1:9009"
+PART_SIZE = 8 * 1024 * 1024
+
+
+@dataclass
+class VerificationResult:
+    flow: str
+    path: str
+    file_id: str
+    revision: int
+    task_id: str
+    task_type: str
+    status: str
+    attempt_count: int
+    content_text: str
+
+
+class Verifier:
+    def __init__(
+        self, base_url: str, timeout_seconds: float, poll_interval_seconds: float
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self.poll_interval_seconds = poll_interval_seconds
+
+    def request_json(
+        self,
+        method: str,
+        path: str,
+        payload: bytes | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> Any:
+        req = urllib.request.Request(
+            self.base_url + path,
+            data=payload,
+            method=method,
+            headers=headers or {},
+        )
+        with urllib.request.urlopen(
+            req, timeout=timeout or self.timeout_seconds
+        ) as resp:
+            body = resp.read()
+            if not body:
+                return None
+            return json.loads(body.decode())
+
+    def request_status(
+        self,
+        method: str,
+        path: str,
+        payload: bytes | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> tuple[int, bytes]:
+        req = urllib.request.Request(
+            self.base_url + path,
+            data=payload,
+            method=method,
+            headers=headers or {},
+        )
+        with urllib.request.urlopen(
+            req, timeout=timeout or self.timeout_seconds
+        ) as resp:
+            return resp.status, resp.read()
+
+    def exec_sql(self, query: str) -> list[dict[str, Any]]:
+        payload = json.dumps({"query": query}).encode()
+        result = self.request_json(
+            "POST",
+            "/v1/sql",
+            payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if not isinstance(result, list):
+            raise RuntimeError(f"unexpected SQL result payload: {result!r}")
+        return result
+
+    def wait_for_img_extract_success(self, path: str) -> VerificationResult:
+        query = (
+            "SELECT n.path, f.file_id, f.revision, f.content_type, "
+            "COALESCE(f.content_text, '') AS content_text, "
+            "t.task_id, t.task_type, t.status, t.attempt_count, "
+            "COALESCE(t.last_error, '') AS last_error "
+            "FROM file_nodes n "
+            "JOIN files f ON f.file_id = n.file_id "
+            "LEFT JOIN semantic_tasks t "
+            "  ON t.resource_id = f.file_id AND t.resource_version = f.revision "
+            f"WHERE n.path = '{path}'"
+        )
+        deadline = time.time() + self.timeout_seconds
+        last_rows: list[dict[str, Any]] = []
+        while time.time() < deadline:
+            last_rows = self.exec_sql(query)
+            if last_rows:
+                row = last_rows[0]
+                if (
+                    row.get("task_type") == "img_extract_text"
+                    and row.get("status") == "succeeded"
+                    and row.get("content_text")
+                ):
+                    return VerificationResult(
+                        flow="unknown",
+                        path=row["path"],
+                        file_id=row["file_id"],
+                        revision=int(row["revision"]),
+                        task_id=row["task_id"],
+                        task_type=row["task_type"],
+                        status=row["status"],
+                        attempt_count=int(row["attempt_count"]),
+                        content_text=row["content_text"],
+                    )
+            time.sleep(self.poll_interval_seconds)
+        raise RuntimeError(
+            f"timed out waiting for durable img_extract_text success for {path}; last rows: {json.dumps(last_rows, ensure_ascii=False)}"
+        )
+
+    def verify_direct_put(self, path: str) -> VerificationResult:
+        status, body = self.request_status(
+            "PUT",
+            "/v1/fs" + path,
+            payload=b"fake-png",
+            headers={"Content-Length": str(len(b"fake-png"))},
+        )
+        if status != 200:
+            raise RuntimeError(
+                f"direct PUT failed for {path}: status={status}, body={body.decode(errors='replace')}"
+            )
+        result = self.wait_for_img_extract_success(path)
+        result.flow = "direct_put"
+        return result
+
+    def verify_multipart(self, path: str, total_size: int) -> VerificationResult:
+        body = b"fake-png-multipart-" + (
+            b"z" * (total_size - len(b"fake-png-multipart-"))
+        )
+        checksums = []
+        for start in range(0, len(body), PART_SIZE):
+            chunk = body[start : start + PART_SIZE]
+            checksums.append(base64.b64encode(hashlib.sha256(chunk).digest()).decode())
+
+        initiate_payload = json.dumps(
+            {
+                "path": path,
+                "total_size": len(body),
+                "part_checksums": checksums,
+            }
+        ).encode()
+        plan = self.request_json(
+            "POST",
+            "/v1/uploads/initiate",
+            payload=initiate_payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if (
+            not isinstance(plan, dict)
+            or not plan.get("upload_id")
+            or not plan.get("parts")
+        ):
+            raise RuntimeError(f"unexpected multipart initiate payload: {plan!r}")
+
+        for part in plan["parts"]:
+            number = int(part["number"])
+            start = (number - 1) * int(plan["part_size"])
+            chunk = body[start : start + int(part["size"])]
+            headers = {k: str(v) for k, v in (part.get("headers") or {}).items()}
+            headers["Content-Length"] = str(len(chunk))
+            req = urllib.request.Request(
+                part["url"], data=chunk, method="PUT", headers=headers
+            )
+            with urllib.request.urlopen(
+                req, timeout=max(self.timeout_seconds, 60)
+            ) as resp:
+                if resp.status != 200:
+                    raise RuntimeError(
+                        f"multipart part {number} upload failed with status {resp.status}"
+                    )
+
+        complete_status, complete_body = self.request_status(
+            "POST",
+            f"/v1/uploads/{plan['upload_id']}/complete",
+            payload=b"",
+        )
+        if complete_status != 200:
+            raise RuntimeError(
+                f"multipart complete failed for {path}: status={complete_status}, body={complete_body.decode(errors='replace')}"
+            )
+
+        result = self.wait_for_img_extract_success(path)
+        result.flow = "multipart"
+        return result
+
+
+def make_unique_path(prefix: str) -> str:
+    suffix = uuid.uuid4().hex[:10]
+    return f"/{prefix}-{suffix}.png"
+
+
+def print_result(result: VerificationResult) -> None:
+    print(
+        json.dumps(
+            {
+                "flow": result.flow,
+                "path": result.path,
+                "file_id": result.file_id,
+                "revision": result.revision,
+                "task_id": result.task_id,
+                "task_type": result.task_type,
+                "status": result.status,
+                "attempt_count": result.attempt_count,
+                "content_text": result.content_text,
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url", default=DEFAULT_BASE_URL, help="dat9-server-local base URL"
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=45.0,
+        help="overall wait timeout per flow",
+    )
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=float,
+        default=1.0,
+        help="poll interval while waiting for task completion",
+    )
+    parser.add_argument(
+        "--multipart-size-bytes",
+        type=int,
+        default=(1 << 20) + 1024,
+        help=(
+            "multipart payload size; default stays above the 1 MiB multipart threshold "
+            "but below the default 8 MiB image extract max"
+        ),
+    )
+    parser.add_argument(
+        "--direct-path", default="", help="optional fixed path for the direct PUT flow"
+    )
+    parser.add_argument(
+        "--multipart-path",
+        default="",
+        help="optional fixed path for the multipart flow",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    verifier = Verifier(args.base_url, args.timeout_seconds, args.poll_interval_seconds)
+
+    direct_path = args.direct_path or make_unique_path("verify-direct")
+    multipart_path = args.multipart_path or make_unique_path("verify-multipart")
+
+    print(
+        json.dumps(
+            {
+                "base_url": args.base_url,
+                "direct_path": direct_path,
+                "multipart_path": multipart_path,
+            },
+            ensure_ascii=False,
+        )
+    )
+
+    direct_result = verifier.verify_direct_put(direct_path)
+    print_result(direct_result)
+
+    multipart_result = verifier.verify_multipart(
+        multipart_path, args.multipart_size_bytes
+    )
+    print_result(multipart_result)
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover - CLI failure path
+        print(json.dumps({"error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- add the durable `img_extract_text` task contract, extract a reusable backend image-processing core, and keep app-mode legacy queue behavior as temporary compatibility
- make semantic workers resolve tenant backends directly, claim tasks by target capability, and avoid unsupported-task routing so image extraction runs through backend-owned runtime dependencies safely
- switch auto-embedding `create`, `overwrite`, and `upload completion` to enqueue durable image tasks transactionally, and tighten pooled backend lifetime / semantic lease handling for real image extraction workloads
- add focused regression coverage plus a local verifier script for direct and multipart `img_extract_text` e2e validation

## Deployment defaults
This PR does not introduce new `DAT9_IMAGE_EXTRACT_*` knobs; those already exist on `main`. What changes here is the runtime behavior around durable `img_extract_text` processing and the default semantic-task lease handling when async image extraction is enabled.
A few deployment notes are worth calling out:
- The numeric worker defaults are intentionally conservative and are sufficient to run the flow:
  - `DAT9_SEMANTIC_WORKERS=1`
  - `DAT9_SEMANTIC_POLL_INTERVAL_MS=200`
  - `DAT9_SEMANTIC_RECOVER_INTERVAL_MS=5000`
  - `DAT9_SEMANTIC_PER_TENANT_CONCURRENCY=1`
- `DAT9_SEMANTIC_LEASE_SECONDS` is still configurable, but when it is left unset and async image extraction is enabled, both `dat9-server` and `dat9-server-local` now derive the default lease as `max(30s, 2x DAT9_IMAGE_EXTRACT_TIMEOUT_SECONDS)`. This is meant to avoid lease expiry during slower real-image extraction workloads.
- The deployment still does **not** run the full durable image extraction flow by default unless the required runtime dependencies are configured:
  - `DAT9_META_DSN` is required for `dat9-server`
  - `DAT9_TOKEN_SIGNING_KEY` is required to create the tenant backend pool
  - this semantic handler must be configured for workers to be useful for auto-embedding tenants:
    - async image extraction via `DAT9_IMAGE_EXTRACT_ENABLED=true`
- If `DAT9_IMAGE_EXTRACT_ENABLED=true` is set without a real vision endpoint (`DAT9_IMAGE_EXTRACT_API_BASE` / `DAT9_IMAGE_EXTRACT_API_KEY` / `DAT9_IMAGE_EXTRACT_MODEL`), the durable flow can still run, but it will use the basic fallback extractor rather than a real multimodal model.
- For real production-style image extraction, operators should explicitly configure the image extract endpoint/model and size the timeout appropriately for the selected model. The new derived lease default reduces one class of failure, but it is not a substitute for proper model-specific timeout tuning.

## Testing
- make test-podman
- python3 scripts/verify_local_img_extract.py --direct-image "/Users/jayson/Projects/claw-memories/images/Biq8G72FYi.jpg" --multipart-image "/Users/jayson/Projects/claw-memories/images/images.jpeg"

## Local e2e validation for durable `img_extract_text`
I validated the new durable image extraction flow locally with `make run-server-local` against a real vision model instead of the basic fallback extractor.

### Setup
I started `dat9-server-local` in auto-embedding mode with async image extraction enabled and an OpenAI-compatible vision endpoint backed by Ollama:
- image extract model: `qwen2.5vl:3b`
- image extract timeout: `20s`
- semantic lease duration: auto-derived to `40s` in local mode
- semantic worker: enabled
- image extract worker: enabled

Relevant startup log signals:
- `image_extract_mode_openai_compatible`
- `backend_image_extract_workers_started`
- `server_semantic_workers_enabled`
- `semantic_worker_manager_started`

### How I ran it
I used the verifier script added in this branch with two real images:

```bash
python3 scripts/verify_local_img_extract.py \
  --direct-image "/Users/jayson/Projects/claw-memories/images/Biq8G72FYi.jpg" \
  --multipart-image "/Users/jayson/Projects/claw-memories/images/images.jpeg"
```

This script validates two end-to-end paths:
1. direct write / `PUT /v1/fs/<image>`
2. multipart upload / `POST /v1/uploads/initiate` -> upload part(s) -> `POST /v1/uploads/<id>/complete`

For each path it waits until:
- a durable `semantic_tasks` row exists with `task_type = 'img_extract_text'`
- the task reaches `status = 'succeeded'`
- `files.content_text` is written back

### Observed results
#### Direct image upload
Input image:
- `Biq8G72FYi.jpg`

Observed result:
- durable task created with `task_type = img_extract_text`
- final status: `succeeded`
- attempt count: `2`
- `files.content_text` was written with real model output

Example extracted text:

> 主要物体：一只橘色的小猫  
> 场景描述：小猫仰卧在白色背景上，四脚朝天，前爪抬起，显得非常可爱和活泼。  
> 图中可见文字（OCR）：图精灵616PIC.COM  
> 简洁标签：可爱小猫，仰卧，四脚朝天，橘色，白色背景  
> 英文标签：cute kitten, lying down, four legs up, orange, white background

Notes:
- the first attempt hit `context deadline exceeded`
- the worker retried successfully
- no `semantic task lease mismatch` occurred after the lease-default adjustment

#### Multipart image upload
Input image:
- `images.jpeg`

Observed result:
- durable task created with `task_type = img_extract_text`
- final status: `succeeded`
- attempt count: `1`
- `files.content_text` was written with real model output

Example extracted text:

> 主要物体：绿色的小型汽车  
> 场景描述：一辆绿色的小型汽车，侧面视角，背景为白色，没有其他物体或细节。  
> 图中可见文字（OCR）：无  
> 简洁标签：绿色汽车，小型车，侧面视角，白色背景  
> 英文标签：green car, small car, side view, white background

### Conclusion
The branch-local durable `img_extract_text` flow works end-to-end for both:
- direct file writes
- multipart uploads

and correctly:
- creates durable semantic tasks
- processes them through the semantic worker
- writes extracted text into `files.content_text`

The lease-default change fixed the earlier `semantic task lease mismatch` issue. With `qwen2.5vl:3b` and `DAT9_IMAGE_EXTRACT_TIMEOUT_SECONDS=20`, multipart succeeds on the first attempt, while the direct image still needed one retry.
