### PR TITLE
fix: raise default upload limit to 50GiB

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -62,7 +62,8 @@ export DAT9_BASE="https://api.dat9.ai"
 12. `copy`, `rename`, `delete`
 13. Final `list` verifies expected structure after mutations
 14. Large multipart upload (`POST /v1/uploads/initiate` + presigned part uploads + complete + download checksum)
-15. Upload-limit boundary (`1GiB` initiate accepted, `1GiB+1` rejected)
+
+15. Upload-limit boundary (`50GiB` initiate accepted, `50GiB+1` rejected)
 
 ### `api-smoke-test-existing-key.sh`
 
@@ -80,7 +81,7 @@ export DAT9_BASE="https://api.dat9.ai"
 6. CLI semantic and image-associated recall flow (`fs grep` paraphrase + image caption recall) with async polling
 7. CLI image flow (`fs cp` jpg + `fs find -name "*.jpg"`)
 8. CLI large-file flow (`cp` upload multipart + `cp` download + checksum verification)
-9. CLI upload-limit boundary (`1GiB` initiate accepted, `1GiB+1` rejected)
+9. CLI upload-limit boundary (`50GiB` initiate accepted, `50GiB+1` rejected)
 
 ### `fuse-smoke-test.sh`
 
@@ -124,7 +125,7 @@ Notes:
 | `REQUEST_MAX_RETRIES` | `8` | `api-smoke-test.sh` |
 | `REQUEST_RETRY_SLEEP_S` | `2` | `api-smoke-test.sh` |
 | `RUN_UPLOAD_LIMIT_BOUNDARY` | `1` | `api-smoke-test.sh` |
-| `UPLOAD_LIMIT_BYTES` | `1073741824` | `api-smoke-test.sh` |
+| `UPLOAD_LIMIT_BYTES` | `53687091200` | `api-smoke-test.sh` |
 | `SEMANTIC_TIMEOUT_S` | `90` | `api-smoke-test.sh` |
 | `SEMANTIC_INTERVAL_S` | `3` | `api-smoke-test.sh` |
 | `CLI_LARGE_FILE_MB` | `100` | `cli-smoke-test.sh` |
@@ -132,7 +133,7 @@ Notes:
 | `CLI_MAX_RETRIES` | `8` | `cli-smoke-test.sh` |
 | `CLI_RETRY_SLEEP_S` | `2` | `cli-smoke-test.sh` |
 | `RUN_CLI_UPLOAD_LIMIT_BOUNDARY` | `1` | `cli-smoke-test.sh` |
-| `CLI_UPLOAD_LIMIT_BYTES` | `1073741824` | `cli-smoke-test.sh` |
+| `CLI_UPLOAD_LIMIT_BYTES` | `53687091200` | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_TIMEOUT_S` | `90` | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_INTERVAL_S` | `3` | `cli-smoke-test.sh` |
 | `CLI_SOURCE` | `build` (`build` or `official`) | `cli-smoke-test.sh`, `fuse-smoke-test.sh` |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -72,7 +72,7 @@ export DAT9_BASE="https://api.dat9.ai"
 - FUSE mount readiness knobs are `MOUNT_READY_TIMEOUT_S`, `MOUNT_READY_INTERVAL_S`, and `FUSE_MOUNT_ROOT`.
 - CLI source knobs are `CLI_SOURCE` (`build` or `official`), `CLI_RELEASE_BASE_URL`, and optional `CLI_RELEASE_VERSION`.
 - API upload-limit boundary check is enabled by default via `RUN_UPLOAD_LIMIT_BOUNDARY=1`.
-- `UPLOAD_LIMIT_BYTES` controls the boundary value checked by API e2e (default `1073741824`).
+- `UPLOAD_LIMIT_BYTES` controls the boundary value checked by API e2e (default `53687091200`).
 - CLI upload-limit boundary check is enabled by default via `RUN_CLI_UPLOAD_LIMIT_BOUNDARY=1`.
-- `CLI_UPLOAD_LIMIT_BYTES` controls the boundary value checked by CLI e2e (default `1073741824`).
-- `fuse-smoke-test.sh` will `SKIP` when host prerequisites are missing (for example no `/dev/fuse`) or when the server does not support mount precheck `stat /`.
+- `CLI_UPLOAD_LIMIT_BYTES` controls the boundary value checked by CLI e2e (default `53687091200`).
+- `fuse-smoke-test.sh` will `SKIP` when host prerequisites are missing (for example no `/dev/fuse`) or when the server does not support mount precheck `ls /`.

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -16,7 +16,7 @@
 # 12) Copy, rename, delete
 # 13) Final list verification
 # 14) 100MB multipart upload via POST /v1/uploads/initiate + download checksum
-# 15) Max-upload boundary check (1GiB allowed, 1GiB+1 rejected)
+# 15) Max-upload boundary check (limit allowed, limit+1 rejected)
 
 set -euo pipefail
 
@@ -31,7 +31,7 @@ BATCH_SMALL_FILE_COUNT="${BATCH_SMALL_FILE_COUNT:-10}"
 REQUEST_MAX_RETRIES="${REQUEST_MAX_RETRIES:-8}"
 REQUEST_RETRY_SLEEP_S="${REQUEST_RETRY_SLEEP_S:-2}"
 RUN_UPLOAD_LIMIT_BOUNDARY="${RUN_UPLOAD_LIMIT_BOUNDARY:-1}"
-UPLOAD_LIMIT_BYTES="${UPLOAD_LIMIT_BYTES:-1073741824}"
+UPLOAD_LIMIT_BYTES="${UPLOAD_LIMIT_BYTES:-53687091200}"
 SEMANTIC_TIMEOUT_S="${SEMANTIC_TIMEOUT_S:-90}"
 SEMANTIC_INTERVAL_S="${SEMANTIC_INTERVAL_S:-3}"
 
@@ -636,13 +636,17 @@ PY
 fi
 
 if [ "$RUN_UPLOAD_LIMIT_BOUNDARY" = "1" ]; then
-  step "15" "Upload limit boundary (1GiB/1GiB+1)"
+  step "15" "Upload limit boundary (limit/limit+1)"
   BOUNDARY_CHECKSUMS=$(python3 - <<'PY'
 import base64
 import hashlib
+import os
 part = b"\x00" * (8 * 1024 * 1024)
 one = base64.b64encode(hashlib.sha256(part).digest()).decode()
-print(",".join([one] * 128))
+upload_limit = int(os.environ["UPLOAD_LIMIT_BYTES"])
+part_size = 8 * 1024 * 1024
+parts = (upload_limit + part_size - 1) // part_size
+print(",".join([one] * parts))
 PY
 )
 

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -16,7 +16,7 @@ CLI_BATCH_SMALL_FILE_COUNT="${CLI_BATCH_SMALL_FILE_COUNT:-10}"
 CLI_MAX_RETRIES="${CLI_MAX_RETRIES:-8}"
 CLI_RETRY_SLEEP_S="${CLI_RETRY_SLEEP_S:-2}"
 RUN_CLI_UPLOAD_LIMIT_BOUNDARY="${RUN_CLI_UPLOAD_LIMIT_BOUNDARY:-1}"
-CLI_UPLOAD_LIMIT_BYTES="${CLI_UPLOAD_LIMIT_BYTES:-1073741824}"
+CLI_UPLOAD_LIMIT_BYTES="${CLI_UPLOAD_LIMIT_BYTES:-53687091200}"
 CLI_SEMANTIC_TIMEOUT_S="${CLI_SEMANTIC_TIMEOUT_S:-90}"
 CLI_SEMANTIC_INTERVAL_S="${CLI_SEMANTIC_INTERVAL_S:-3}"
 
@@ -428,9 +428,13 @@ if [ "$RUN_CLI_UPLOAD_LIMIT_BOUNDARY" = "1" ]; then
   boundary_checksums=$(python3 - <<'PY'
 import base64
 import hashlib
+import os
 part = b"\x00" * (8 * 1024 * 1024)
 one = base64.b64encode(hashlib.sha256(part).digest()).decode()
-print(",".join([one] * 128))
+upload_limit = int(os.environ["CLI_UPLOAD_LIMIT_BYTES"])
+part_size = 8 * 1024 * 1024
+parts = (upload_limit + part_size - 1) // part_size
+print(",".join([one] * parts))
 PY
 )
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -58,7 +58,7 @@ var (
 	schemaInitMaxBackoff     = 30 * time.Second
 )
 
-const defaultMaxUploadBytes int64 = 1 << 30 // 1 GiB
+const defaultMaxUploadBytes int64 = 50 * (1 << 30) // 50 GiB
 
 func New(b *backend.Dat9Backend) *Server {
 	return NewWithConfig(Config{Backend: b})


### PR DESCRIPTION
## Summary
- increase dat9 server default `maxUploadBytes` from 1GiB to 50GiB to unblock 20GiB upload workloads
- align API/CLI e2e upload-boundary defaults with the new limit (`53687091200`) and make boundary checksum part-count dynamic from limit bytes
- update e2e docs to match the new upload-boundary defaults and current FUSE precheck wording

## Validation
- `go test ./pkg/server`
- `bash -n e2e/api-smoke-test.sh`
- `bash -n e2e/cli-smoke-test.sh`