### PR TITLE
refactor semantic task claiming API and test workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ IMAGE_REPO ?= dat9-server
 IMAGE_TAG ?= latest
 IMAGE ?= $(IMAGE_REPO):$(IMAGE_TAG)
 LINT_TIMEOUT ?= 10m
+TEST_P ?=
 
 .PHONY: mod test test-podman fmt lint install-lint build build-server build-cli run-server-local docker-build
 
@@ -34,13 +35,19 @@ mod:
 
 # Run all tests. MySQL-backed suites reuse DAT9_MYSQL_DSN when provided. When
 # it is unset and podman is available locally, automatically configure the
-# podman-backed testcontainers environment before running go test.
+# podman-backed testcontainers environment before running go test. Set TEST_P
+# to pass `-p <value>` to `go test`; by default package parallelism is not
+# limited.
 test:
 	@set -euo pipefail; \
+	test_p_flag=""; \
+	if [ -n "$(TEST_P)" ]; then \
+		test_p_flag="-p $(TEST_P)"; \
+	fi; \
 	if [ -z "$${DAT9_MYSQL_DSN:-}" ] && command -v podman >/dev/null 2>&1; then \
 		source ./scripts/test-podman.sh; \
 	fi; \
-	$(GO) test -p 1 -v ./...
+	$(GO) test $$test_p_flag -v ./...
 
 fmt:
 	$(MAKE) install-lint

--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,15 @@ mod:
 	$(GO) mod tidy
 	$(GO) mod download
 
-# Run all tests. MySQL-backed suites either start a mysql:8.0.36 container via
-# a Docker-compatible runtime or reuse DAT9_MYSQL_DSN when it is provided.
+# Run all tests. MySQL-backed suites reuse DAT9_MYSQL_DSN when provided. When
+# it is unset and podman is available locally, automatically configure the
+# podman-backed testcontainers environment before running go test.
 test:
-	$(GO) test ./...
-
-test-podman:
-	@source ./scripts/test-podman.sh && $(GO) test -v ./...
+	@set -euo pipefail; \
+	if [ -z "$${DAT9_MYSQL_DSN:-}" ] && command -v podman >/dev/null 2>&1; then \
+		source ./scripts/test-podman.sh; \
+	fi; \
+	$(GO) test -p 1 -v ./...
 
 fmt:
 	$(MAKE) install-lint

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ c.Delete("/data/file.txt")
 | `DAT9_API_KEY` | API key | |
 | `DAT9_LISTEN_ADDR` | Server listen address | `:9009` |
 | `DAT9_PUBLIC_URL` | Externally reachable base URL (required for remote clients) | |
-| `DAT9_MYSQL_DSN` | MySQL DSN (example: `user:pass@tcp(127.0.0.1:3306)/dat9?parseTime=true`) | |
+| `DAT9_MYSQL_DSN` | MySQL DSN for tests/local validation (example: `user:pass@tcp(127.0.0.1:3306)/dat9?parseTime=true`) | |
 | `DAT9_BLOB_DIR` | Blob storage directory | `./blobs` |
 | `DAT9_S3_BUCKET` | S3 bucket name (enables AWS S3 mode; omit for local mock) | |
 | `DAT9_S3_REGION` | AWS region | `us-east-1` |
@@ -217,14 +217,22 @@ POST   /v1/fs/{path}?mkdir        Create directory
 cmd/dat9/           CLI entrypoint and commands (cp, cat, ls, mount, umount, ...)
 cmd/dat9-server/    Server entrypoint
 pkg/
-  backend/          Dat9Backend — AGFS FileSystem implementation (inode model)
+  backend/          Dat9Backend — AGFS FileSystem implementation
   client/           Go SDK HTTP client
+  datastore/        Core metadata store and semantic task persistence
+  embedding/        Embedding provider integration and vector helpers
+  encrypt/          Encryption helpers
   fuse/             FUSE mount (go-fuse/v2 RawFileSystem, inode mapping, caching)
-  meta/             Metadata store (TiDB/MySQL P0 / db9 production)
+  logger/           Structured logging helpers
+  meta/             Metadata/search-facing models and helpers
+  metrics/          Metrics recording
+  semantic/         Durable semantic task types and contracts
   s3client/         S3-compatible object store interface (AWS + local mock)
   server/           HTTP server (/v1/fs/{path} router)
+  tenant/           Tenant schema management and embedding mode detection
   pathutil/         Path canonicalization and validation
   parser/           Content-aware parsing interface (future)
+  traceid/          Trace ID helpers
   treebuilder/      Parsed content → path namespace mapping (future)
 docs/
   design-overview.md  Full design document
@@ -232,14 +240,15 @@ docs/
 
 ## Metadata Schema
 
-Four tables, all in the tenant's database:
+Five core tables, all in the tenant's database:
 
 | Table | Purpose |
 |---|---|
-| `file_nodes` | Path tree (dentry) — path, parent, name, file_id reference |
-| `files` | File entity (inode) — storage type/ref, size, checksum, revision, status, content_text |
-| `file_tags` | Key-value tags for precise SQL filtering |
-| `uploads` | Large-file S3 multipart upload state tracking |
+| `file_nodes` | Path tree (dentry) — path, parent, name, directory flag, file_id reference |
+| `files` | File entity (inode) — storage location, size, checksum, revision, lifecycle status, extracted text, embedding state |
+| `file_tags` | Key-value tags for precise filtering |
+| `uploads` | Large-file multipart upload state and idempotency tracking |
+| `semantic_tasks` | Durable background work queue for async embedding and image text extraction |
 
 ## Roadmap
 
@@ -302,10 +311,13 @@ The helper script sets sensible defaults for local validation, including:
 make test
 ```
 
-`make test` runs `go test ./...` and the MySQL-backed test suites use either:
+`make test` is the standard test entrypoint and runs `go test ./...`.
 
-- a Docker-compatible container runtime to start a `mysql:8.0.36` test container automatically, or
-- an existing MySQL instance provided via the `DAT9_MYSQL_DSN` environment variable
+For MySQL-backed test suites:
+
+- if `DAT9_MYSQL_DSN` is set, the tests reuse that MySQL instance
+- otherwise, if `podman` is available locally, `make test` automatically configures the Podman-backed testcontainers environment
+- otherwise, testcontainers uses the default Docker-compatible runtime environment
 
 For example, to reuse an existing local MySQL instance:
 
@@ -313,11 +325,7 @@ For example, to reuse an existing local MySQL instance:
 DAT9_MYSQL_DSN='dat9:dat9pass@tcp(127.0.0.1:3306)/dat9_test?parseTime=true' make test
 ```
 
-With Podman on macOS or Linux, use the following command to run tests:
-
-```bash
-make test-podman
-```
+If you do not provide `DAT9_MYSQL_DSN`, make sure a Docker-compatible container runtime is available locally.
 
 ## References
 

--- a/docs/async-embedding/async-embedding-phase-1-foundation.md
+++ b/docs/async-embedding/async-embedding-phase-1-foundation.md
@@ -298,7 +298,7 @@ type ClaimResult struct {
 Corresponding methods in `pkg/datastore` are recommended as:
 
 - `EnqueueSemanticTask(ctx, task) (created bool, err error)`
-- `ClaimSemanticTask(ctx, now, leaseDuration) (*semantic.Task, bool, error)`
+- `ClaimSemanticTask(ctx, now, leaseDuration, taskTypes...) (*semantic.Task, bool, error)`
 - `AckSemanticTask(ctx, taskID, receipt) error`
 - `RetrySemanticTask(ctx, taskID, receipt, retryAt, lastErr) error`
 - `RecoverExpiredSemanticTasks(ctx, now, limit) (int, error)`
@@ -306,7 +306,7 @@ Corresponding methods in `pkg/datastore` are recommended as:
 Among them:
 
 - `Enqueue` uses the unique key `(task_type, resource_id, resource_version)` for dedupe; duplicate enqueue returns `created=false`, not an error
-- `Claim` uses `FOR UPDATE SKIP LOCKED`, sets `status=processing`, a new `receipt`, `leased_at`, `lease_until`, and increments `attempt_count` at claim time
+- `Claim` uses `FOR UPDATE SKIP LOCKED`, sets `status=processing`, a new `receipt`, `leased_at`, `lease_until`, and increments `attempt_count` at claim time; an empty `taskTypes` filter means “claim any task type”
 - `Ack` accepts only the current receipt; on success it changes status to `succeeded` and writes `completed_at`
 - `Retry` accepts only the current receipt; when not dead-lettered, it resets status to `queued` and updates `available_at` and `last_error`
 - `RecoverExpired` only handles tasks where `status=processing` and `lease_until < now`, resetting them to `queued` and clearing receipt/lease fields

--- a/docs/async-embedding/async-embedding-phase-3-worker-and-search-correctness.md
+++ b/docs/async-embedding/async-embedding-phase-3-worker-and-search-correctness.md
@@ -90,7 +90,7 @@ Background Embed Path
 ---------------------
 SemanticWorkerManager
     -> choose tenant store (local fallback or active tenant round-robin)
-    -> ClaimSemanticTask(...)
+    -> ClaimSemanticTask(..., taskTypes...)
     -> GetFile(resource_id)
     -> if missing / stale / empty: ack obsolete task
     -> embed file.ContentText

--- a/docs/img-extract-text-proposal.md
+++ b/docs/img-extract-text-proposal.md
@@ -255,7 +255,7 @@ Tenant scan should also be grouped by handler capability:
 - When only `img_extract_text` exists: scan only auto embedding tenants and the local auto fallback backend
 - When both exist: scan both sets
 
-`ClaimSemanticTask(...)` does not filter by `task_type`, see `pkg/datastore/semantic_tasks.go:227`. If an img-only worker scans an app tenant, it may claim an `embed` task first, and unsupported task types are retried as unsupported, see `pkg/server/semantic_worker.go:498`. Therefore, “img-only worker scans only auto stores” is not an optimization; it is a correctness precondition for Phase 1.
+`ClaimSemanticTask(..., taskTypes...)` can restrict claims by `task_type`, and leaving `taskTypes` empty means “claim any task”. If an img-only worker scans an app tenant without passing `img_extract_text` as an allowed type, it may claim an `embed` task first, and unsupported task types are retried as unsupported, see `pkg/server/semantic_worker.go:503`. Therefore, “img-only worker scans only auto stores” is not just an optimization; it remains a correctness precondition for Phase 1.
 
 As a rollout precondition, any store cut over to an `img_extract_text`-only handler must not have pending app-side `embed` backlog. Otherwise, even with correct scan scope, the worker may still claim historical `embed` tasks within the same store. Such stores must either be drained first or excluded from the Phase 1 cutover set.
 

--- a/pkg/datastore/semantic_tasks.go
+++ b/pkg/datastore/semantic_tasks.go
@@ -225,21 +225,12 @@ func (s *Store) ensureSemanticTaskQueuedTx(tx *sql.Tx, task *semantic.Task) (boo
 	return true, nil
 }
 
-// ClaimSemanticTask claims one queued semantic task and leases it to the caller.
-func (s *Store) ClaimSemanticTask(ctx context.Context, now time.Time, leaseDuration time.Duration) (out *semantic.Task, found bool, err error) {
+// ClaimSemanticTask claims one queued semantic task and leases it to the
+// caller. When taskTypes is empty, any queued task type is eligible.
+// Otherwise, only tasks whose task_type is included in taskTypes are eligible.
+func (s *Store) ClaimSemanticTask(ctx context.Context, now time.Time, leaseDuration time.Duration, taskTypes ...semantic.TaskType) (out *semantic.Task, found bool, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "claim_semantic_task", start, &err)
-	return s.claimSemanticTask(ctx, now, leaseDuration, nil)
-}
-
-// ClaimSemanticTaskOfTypes claims one queued semantic task whose task_type is
-// included in taskTypes and leases it to the caller.
-func (s *Store) ClaimSemanticTaskOfTypes(ctx context.Context, now time.Time, leaseDuration time.Duration, taskTypes ...semantic.TaskType) (out *semantic.Task, found bool, err error) {
-	start := time.Now()
-	defer observeStoreOp(ctx, "claim_semantic_task_of_types", start, &err)
-	if len(taskTypes) == 0 {
-		return nil, false, fmt.Errorf("claim task types are required")
-	}
 	return s.claimSemanticTask(ctx, now, leaseDuration, taskTypes)
 }
 

--- a/pkg/datastore/semantic_tasks_test.go
+++ b/pkg/datastore/semantic_tasks_test.go
@@ -147,7 +147,7 @@ func TestSemanticTaskClaimOrderByAvailableAtThenCreatedAt(t *testing.T) {
 	}
 }
 
-func TestClaimSemanticTaskOfTypesSkipsOlderDisallowedTask(t *testing.T) {
+func TestClaimSemanticTaskSkipsOlderDisallowedTask(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 	base := time.Unix(1711600350, 0).UTC()
@@ -162,7 +162,7 @@ func TestClaimSemanticTaskOfTypesSkipsOlderDisallowedTask(t *testing.T) {
 		}
 	}
 
-	claimed, found, err := s.ClaimSemanticTaskOfTypes(ctx, base.Add(5*time.Second), time.Minute, semantic.TaskTypeImgExtractText)
+	claimed, found, err := s.ClaimSemanticTask(ctx, base.Add(5*time.Second), time.Minute, semantic.TaskTypeImgExtractText)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestClaimSemanticTaskOfTypesSkipsOlderDisallowedTask(t *testing.T) {
 	}
 }
 
-func TestClaimSemanticTaskOfTypesReturnsNotFoundWhenOnlyDisallowedTasksExist(t *testing.T) {
+func TestClaimSemanticTaskReturnsNotFoundWhenOnlyDisallowedTasksExist(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 	base := time.Unix(1711600360, 0).UTC()
@@ -188,7 +188,7 @@ func TestClaimSemanticTaskOfTypesReturnsNotFoundWhenOnlyDisallowedTasksExist(t *
 		t.Fatal(err)
 	}
 
-	claimed, found, err := s.ClaimSemanticTaskOfTypes(ctx, base.Add(time.Second), time.Minute, semantic.TaskTypeImgExtractText)
+	claimed, found, err := s.ClaimSemanticTask(ctx, base.Add(time.Second), time.Minute, semantic.TaskTypeImgExtractText)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestClaimSemanticTaskOfTypesReturnsNotFoundWhenOnlyDisallowedTasksExist(t *
 	}
 }
 
-func TestClaimSemanticTaskOfTypesSupportsMultipleTaskTypes(t *testing.T) {
+func TestClaimSemanticTaskSupportsMultipleTaskTypes(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 	base := time.Unix(1711600370, 0).UTC()
@@ -217,7 +217,7 @@ func TestClaimSemanticTaskOfTypesSupportsMultipleTaskTypes(t *testing.T) {
 		}
 	}
 
-	claimed, found, err := s.ClaimSemanticTaskOfTypes(ctx, base.Add(5*time.Second), time.Minute, semantic.TaskTypeImgExtractText, semantic.TaskTypeEmbed)
+	claimed, found, err := s.ClaimSemanticTask(ctx, base.Add(5*time.Second), time.Minute, semantic.TaskTypeImgExtractText, semantic.TaskTypeEmbed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,13 +229,24 @@ func TestClaimSemanticTaskOfTypesSupportsMultipleTaskTypes(t *testing.T) {
 	}
 }
 
-func TestClaimSemanticTaskOfTypesRejectsEmptyTaskTypes(t *testing.T) {
+func TestClaimSemanticTaskWithoutFiltersClaimsAnyTask(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 	base := time.Unix(1711600380, 0).UTC()
 
-	if _, _, err := s.ClaimSemanticTaskOfTypes(ctx, base, time.Minute); err == nil {
-		t.Fatal("expected empty task types to fail")
+	if _, err := s.EnqueueSemanticTask(ctx, newSemanticTask("task-1", "file-1", 1, base, base)); err != nil {
+		t.Fatal(err)
+	}
+
+	claimed, found, err := s.ClaimSemanticTask(ctx, base.Add(time.Second), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected unfiltered claim to find task")
+	}
+	if claimed.TaskID != "task-1" {
+		t.Fatalf("claimed task=%q, want %q", claimed.TaskID, "task-1")
 	}
 }
 

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -232,7 +232,7 @@ func (m *semanticWorkerManager) processNext(ctx context.Context) bool {
 	defer target.release()
 
 	claimStart := time.Now()
-	task, found, err := target.store.ClaimSemanticTaskOfTypes(ctx, time.Now().UTC(), m.opts.LeaseDuration, target.allowedTaskTypes...)
+	task, found, err := target.store.ClaimSemanticTask(ctx, time.Now().UTC(), m.opts.LeaseDuration, target.allowedTaskTypes...)
 	if err != nil {
 		metrics.RecordOperation("semantic_worker", "claim", "error", time.Since(claimStart))
 		logger.Warn(ctx, "semantic_worker_claim_failed",


### PR DESCRIPTION
## Summary
- unify semantic task claiming under `ClaimSemanticTask(..., taskTypes...)` and document that an empty filter claims any task type
- update the semantic worker and related docs/tests to match the typed-claim contract
- make `make test` auto-configure podman when `DAT9_MYSQL_DSN` is unset and refresh the README test workflow, project structure, and metadata schema sections

## Testing
- make lint
- make test-podman