### PR TITLE
fix: unify default upload limit config

### DIFF
--- a/cmd/dat9-server/main.go
+++ b/cmd/dat9-server/main.go
@@ -91,7 +91,7 @@ func main() {
 	kmsKey := os.Getenv("DAT9_ENCRYPT_KEY")
 	tokenHex := os.Getenv("DAT9_TOKEN_SIGNING_KEY")
 	providerType := envOr("DAT9_TENANT_PROVIDER", tenant.ProviderTiDBZero)
-	maxUploadBytes := int64(1 << 30)
+	maxUploadBytes := server.DefaultMaxUploadBytes
 	if raw := os.Getenv("DAT9_MAX_UPLOAD_BYTES"); raw != "" {
 		maxUploadBytes, err = strconv.ParseInt(raw, 10, 64)
 		if err != nil || maxUploadBytes <= 0 {
@@ -191,7 +191,7 @@ environment:
   DAT9_MASTER_KEY  32-byte hex key for local_aes encryptor
   DAT9_ENCRYPT_KEY KMS key id or alias (required for kms)
   DAT9_TOKEN_SIGNING_KEY  32-byte hex key for JWT API key signing
-  DAT9_MAX_UPLOAD_BYTES maximum allowed upload size in bytes (default: 1073741824, minimum: 1048576)
+  DAT9_MAX_UPLOAD_BYTES maximum allowed upload size in bytes (default: %d, minimum: 1048576)
   DAT9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)
   S3 storage (set DAT9_S3_BUCKET to enable AWS S3, otherwise local mock):
   DAT9_S3_BUCKET   S3 bucket name (enables AWS S3 mode)
@@ -231,7 +231,7 @@ environment:
   DAT9_IMAGE_EXTRACT_MODEL    model name for vision extraction (optional)
   DAT9_IMAGE_EXTRACT_PROMPT   custom extraction prompt (optional)
   DAT9_IMAGE_EXTRACT_MAX_TOKENS max model output tokens (default: 256)
-`)
+`, server.DefaultMaxUploadBytes)
 	os.Exit(2)
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -58,7 +58,9 @@ var (
 	schemaInitMaxBackoff     = 30 * time.Second
 )
 
-const defaultMaxUploadBytes int64 = 50 * (1 << 30) // 50 GiB
+// DefaultMaxUploadBytes is the server-wide fallback upload size limit.
+// Keep callers on this exported constant so the default stays consistent.
+const DefaultMaxUploadBytes int64 = 50 * (1 << 30) // 50 GiB
 
 func New(b *backend.Dat9Backend) *Server {
 	return NewWithConfig(Config{Backend: b})
@@ -67,7 +69,7 @@ func New(b *backend.Dat9Backend) *Server {
 func NewWithConfig(cfg Config) *Server {
 	maxUpload := cfg.MaxUploadBytes
 	if maxUpload <= 0 {
-		maxUpload = defaultMaxUploadBytes
+		maxUpload = DefaultMaxUploadBytes
 	}
 	logger := cfg.Logger
 	if logger == nil {

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -666,6 +666,14 @@ func TestUploadRespectsMaxUploadBytes(t *testing.T) {
 	}
 }
 
+func TestNewWithConfigUsesDefaultMaxUploadBytes(t *testing.T) {
+	base, _ := newTestServerWithS3(t)
+	s := NewWithConfig(Config{Backend: base.fallback})
+	if s.maxUploadBytes != DefaultMaxUploadBytes {
+		t.Fatalf("default maxUploadBytes = %d, want %d", s.maxUploadBytes, DefaultMaxUploadBytes)
+	}
+}
+
 func TestDeclaredContentLengthOverMaxRejected(t *testing.T) {
 	base, _ := newTestServerWithS3(t)
 	s := NewWithConfig(Config{Backend: base.fallback, MaxUploadBytes: 10})


### PR DESCRIPTION
## Summary
- unify the server default upload limit behind a single exported `server.DefaultMaxUploadBytes` constant
- update `dat9-server` to reuse that default for runtime config after https://github.com/mem9-ai/drive9/pull/97 and help text instead of keeping a separate 1GiB fallback
- add a server test to lock the default fallback behavior and prevent future drift