### PR TITLE
Fix content_blob contract drift across datastore schemas

### DIFF
--- a/.github/workflows/code-ci.yml
+++ b/.github/workflows/code-ci.yml
@@ -23,6 +23,20 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Cache golangci-lint binary
+        uses: actions/cache@v4
+        with:
+          path: bin/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-bin-${{ hashFiles('Makefile', 'go.mod') }}
+
+      - name: Cache golangci-lint analysis cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-cache-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-cache-
+
       - name: Lint
         run: make lint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,9 @@ DAT9_MYSQL_DSN='user:pass@tcp(127.0.0.1:3306)/dat9_test?parseTime=true' make tes
 If `DAT9_MYSQL_DSN` is unset and `podman` is available, `make test` auto-configures
 testcontainers via `scripts/test-podman.sh`. Otherwise a Docker-compatible runtime is used.
 
+If a direct `go test` run fails with `rootless Docker not found`, retry with `make test`
+so the project can use `scripts/test-podman.sh` to route testcontainers through Podman.
+
 **E2E smoke tests** (not `go test`) live in `e2e/` and target live deployments:
 
 ```bash

--- a/pkg/datastore/file_tx.go
+++ b/pkg/datastore/file_tx.go
@@ -7,22 +7,11 @@ import (
 
 // InsertFileTx inserts a file row inside an existing transaction.
 func (s *Store) InsertFileTx(db execer, f *File) error {
-	if s.hasContentBlob {
-		_, err := db.Exec(`INSERT INTO files
-			(file_id, storage_type, storage_ref, content_blob, content_type, size_bytes, checksum_sha256,
-			 revision, status, source_id, content_text, created_at, confirmed_at, expires_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			f.FileID, f.StorageType, f.StorageRef, nilBytes(f.ContentBlob), nullStr(f.ContentType),
-			f.SizeBytes, nullStr(f.ChecksumSHA256), f.Revision, f.Status,
-			nullStr(f.SourceID), nullStr(f.ContentText),
-			f.CreatedAt.UTC(), nilTime(f.ConfirmedAt), nilTime(f.ExpiresAt))
-		return err
-	}
 	_, err := db.Exec(`INSERT INTO files
-		(file_id, storage_type, storage_ref, content_type, size_bytes, checksum_sha256,
+		(file_id, storage_type, storage_ref, content_blob, content_type, size_bytes, checksum_sha256,
 		 revision, status, source_id, content_text, created_at, confirmed_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		f.FileID, f.StorageType, f.StorageRef, nullStr(f.ContentType),
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		f.FileID, f.StorageType, f.StorageRef, nilBytes(f.ContentBlob), nullStr(f.ContentType),
 		f.SizeBytes, nullStr(f.ChecksumSHA256), f.Revision, f.Status,
 		nullStr(f.SourceID), nullStr(f.ContentText),
 		f.CreatedAt.UTC(), nilTime(f.ConfirmedAt), nilTime(f.ExpiresAt))
@@ -34,31 +23,15 @@ func (s *Store) InsertFileTx(db execer, f *File) error {
 // vectors for the new revision.
 func (s *Store) UpdateFileContentTx(db execer, fileID string, storageType StorageType, storageRef, contentType, checksum, contentText string, contentBlob []byte, size int64) (int64, error) {
 	now := time.Now().UTC()
-	var res interface{ RowsAffected() (int64, error) }
-	if s.hasContentBlob {
-		r, err := db.Exec(`UPDATE files SET storage_type = ?, storage_ref = ?,
-			content_blob = ?, content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
-			embedding = NULL, embedding_revision = NULL,
-			revision = revision + 1, status = 'CONFIRMED', confirmed_at = ?
-			WHERE file_id = ?`,
-			storageType, storageRef, nilBytes(contentBlob), nullStr(contentType), size,
-			nullStr(checksum), nullStr(contentText), now, fileID)
-		if err != nil {
-			return 0, err
-		}
-		res = r
-	} else {
-		r, err := db.Exec(`UPDATE files SET storage_type = ?, storage_ref = ?,
-			content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
-			embedding = NULL, embedding_revision = NULL,
-			revision = revision + 1, status = 'CONFIRMED', confirmed_at = ?
-			WHERE file_id = ?`,
-			storageType, storageRef, nullStr(contentType), size,
-			nullStr(checksum), nullStr(contentText), now, fileID)
-		if err != nil {
-			return 0, err
-		}
-		res = r
+	res, err := db.Exec(`UPDATE files SET storage_type = ?, storage_ref = ?,
+		content_blob = ?, content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
+		embedding = NULL, embedding_revision = NULL,
+		revision = revision + 1, status = 'CONFIRMED', confirmed_at = ?
+		WHERE file_id = ?`,
+		storageType, storageRef, nilBytes(contentBlob), nullStr(contentType), size,
+		nullStr(checksum), nullStr(contentText), now, fileID)
+	if err != nil {
+		return 0, err
 	}
 	rowsAffected, err := res.RowsAffected()
 	if err != nil {
@@ -79,29 +52,14 @@ func (s *Store) UpdateFileContentTx(db execer, fileID string, storageType Storag
 // vectors from content_text, so the write path must stop clearing vector state.
 func (s *Store) UpdateFileContentAutoEmbeddingTx(db execer, fileID string, storageType StorageType, storageRef, contentType, checksum, contentText string, contentBlob []byte, size int64) (int64, error) {
 	now := time.Now().UTC()
-	var res interface{ RowsAffected() (int64, error) }
-	if s.hasContentBlob {
-		r, err := db.Exec(`UPDATE files SET storage_type = ?, storage_ref = ?,
-			content_blob = ?, content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
-			revision = revision + 1, status = 'CONFIRMED', confirmed_at = ?
-			WHERE file_id = ?`,
-			storageType, storageRef, nilBytes(contentBlob), nullStr(contentType), size,
-			nullStr(checksum), nullStr(contentText), now, fileID)
-		if err != nil {
-			return 0, err
-		}
-		res = r
-	} else {
-		r, err := db.Exec(`UPDATE files SET storage_type = ?, storage_ref = ?,
-			content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
-			revision = revision + 1, status = 'CONFIRMED', confirmed_at = ?
-			WHERE file_id = ?`,
-			storageType, storageRef, nullStr(contentType), size,
-			nullStr(checksum), nullStr(contentText), now, fileID)
-		if err != nil {
-			return 0, err
-		}
-		res = r
+	res, err := db.Exec(`UPDATE files SET storage_type = ?, storage_ref = ?,
+		content_blob = ?, content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
+		revision = revision + 1, status = 'CONFIRMED', confirmed_at = ?
+		WHERE file_id = ?`,
+		storageType, storageRef, nilBytes(contentBlob), nullStr(contentType), size,
+		nullStr(checksum), nullStr(contentText), now, fileID)
+	if err != nil {
+		return 0, err
 	}
 	rowsAffected, err := res.RowsAffected()
 	if err != nil {

--- a/pkg/datastore/schema_test.go
+++ b/pkg/datastore/schema_test.go
@@ -14,28 +14,21 @@ func TestInitSchemaProviderSplit(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = s1.Close() })
-	tests := []struct {
-		provider        string
-		wantContentBlob bool
-	}{
-		{provider: "tidb_zero", wantContentBlob: true},
-		{provider: "tidb_cloud_starter", wantContentBlob: true},
-		{provider: "db9", wantContentBlob: true},
-	}
+	providers := []string{"tidb_zero", "tidb_cloud_starter", "db9"}
 
-	for _, tc := range tests {
+	for _, provider := range providers {
 		dropDataPlaneTables(t, s1)
-		initDatastoreSchema(t, testDSN, tc.provider)
-		if got := s1.columnExists("files", "content_blob"); got != tc.wantContentBlob {
-			t.Fatalf("provider %s content_blob=%v, want %v", tc.provider, got, tc.wantContentBlob)
+		initDatastoreSchema(t, testDSN, provider)
+		if !s1.columnExists("files", "content_blob") {
+			t.Fatalf("provider %s missing files.content_blob", provider)
 		}
 		for _, col := range []string{"embedding", "embedding_revision"} {
 			if !s1.columnExists("files", col) {
-				t.Fatalf("provider %s missing files.%s", tc.provider, col)
+				t.Fatalf("provider %s missing files.%s", provider, col)
 			}
 		}
 		if !s1.columnExists("semantic_tasks", "task_id") {
-			t.Fatalf("provider %s missing semantic_tasks table", tc.provider)
+			t.Fatalf("provider %s missing semantic_tasks table", provider)
 		}
 	}
 }

--- a/pkg/datastore/schema_test.go
+++ b/pkg/datastore/schema_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestInitSchemaProviderSplit(t *testing.T) {
+func TestInitSchemaRequiredColumns(t *testing.T) {
 	// TODO(async-embedding): This test only validates schema shape through the
 	// MySQL fixture used by the current store/runtime path. It does not execute
 	// initDB9Schema on a real Postgres-backed store or validate Postgres-specific
@@ -14,22 +14,19 @@ func TestInitSchemaProviderSplit(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = s1.Close() })
-	providers := []string{"tidb_zero", "tidb_cloud_starter", "db9"}
 
-	for _, provider := range providers {
-		dropDataPlaneTables(t, s1)
-		initDatastoreSchema(t, testDSN, provider)
-		if !s1.columnExists("files", "content_blob") {
-			t.Fatalf("provider %s missing files.content_blob", provider)
+	dropDataPlaneTables(t, s1)
+	initDatastoreSchema(t, testDSN)
+	if !s1.columnExists("files", "content_blob") {
+		t.Fatal("missing files.content_blob")
+	}
+	for _, col := range []string{"embedding", "embedding_revision"} {
+		if !s1.columnExists("files", col) {
+			t.Fatalf("missing files.%s", col)
 		}
-		for _, col := range []string{"embedding", "embedding_revision"} {
-			if !s1.columnExists("files", col) {
-				t.Fatalf("provider %s missing files.%s", provider, col)
-			}
-		}
-		if !s1.columnExists("semantic_tasks", "task_id") {
-			t.Fatalf("provider %s missing semantic_tasks table", provider)
-		}
+	}
+	if !s1.columnExists("semantic_tasks", "task_id") {
+		t.Fatal("missing semantic_tasks table")
 	}
 }
 

--- a/pkg/datastore/schema_test.go
+++ b/pkg/datastore/schema_test.go
@@ -20,7 +20,7 @@ func TestInitSchemaProviderSplit(t *testing.T) {
 	}{
 		{provider: "tidb_zero", wantContentBlob: true},
 		{provider: "tidb_cloud_starter", wantContentBlob: true},
-		{provider: "db9", wantContentBlob: false},
+		{provider: "db9", wantContentBlob: true},
 	}
 
 	for _, tc := range tests {

--- a/pkg/datastore/schema_test_helper_test.go
+++ b/pkg/datastore/schema_test_helper_test.go
@@ -16,7 +16,7 @@ func initDatastoreSchema(t *testing.T, dsn, provider string) {
 	}
 	defer func() { _ = db.Close() }()
 
-	withBlob := provider == "tidb_zero" || provider == "tidb_cloud_starter"
+	withBlob := provider == "tidb_zero" || provider == "tidb_cloud_starter" || provider == "db9"
 	// The test MySQL fixture does not guarantee VECTOR support, so helper schemas
 	// store embeddings as LONGTEXT even though production tenant schemas use VECTOR.
 	contentBlobCol := ""

--- a/pkg/datastore/schema_test_helper_test.go
+++ b/pkg/datastore/schema_test_helper_test.go
@@ -16,19 +16,14 @@ func initDatastoreSchema(t *testing.T, dsn, provider string) {
 	}
 	defer func() { _ = db.Close() }()
 
-	withBlob := provider == "tidb_zero" || provider == "tidb_cloud_starter" || provider == "db9"
 	// The test MySQL fixture does not guarantee VECTOR support, so helper schemas
 	// store embeddings as LONGTEXT even though production tenant schemas use VECTOR.
-	contentBlobCol := ""
-	if withBlob {
-		contentBlobCol = "content_blob LONGBLOB,"
-	}
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (node_id VARCHAR(64) PRIMARY KEY, path VARCHAR(512) NOT NULL, parent_path VARCHAR(512) NOT NULL, name VARCHAR(255) NOT NULL, is_directory BOOLEAN NOT NULL DEFAULT FALSE, file_id VARCHAR(64), created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
 		`CREATE UNIQUE INDEX idx_path ON file_nodes(path)`,
 		`CREATE INDEX idx_parent ON file_nodes(parent_path)`,
 		`CREATE INDEX idx_file_id ON file_nodes(file_id)`,
-		`CREATE TABLE IF NOT EXISTS files (file_id VARCHAR(64) PRIMARY KEY, storage_type VARCHAR(32) NOT NULL, storage_ref TEXT NOT NULL, ` + contentBlobCol + ` content_type VARCHAR(255), size_bytes BIGINT NOT NULL DEFAULT 0, checksum_sha256 VARCHAR(128), revision BIGINT NOT NULL DEFAULT 1, status VARCHAR(32) NOT NULL DEFAULT 'PENDING', source_id VARCHAR(255), content_text LONGTEXT, embedding LONGTEXT, embedding_revision BIGINT, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), confirmed_at DATETIME(3), expires_at DATETIME(3))`,
+		`CREATE TABLE IF NOT EXISTS files (file_id VARCHAR(64) PRIMARY KEY, storage_type VARCHAR(32) NOT NULL, storage_ref TEXT NOT NULL, content_blob LONGBLOB, content_type VARCHAR(255), size_bytes BIGINT NOT NULL DEFAULT 0, checksum_sha256 VARCHAR(128), revision BIGINT NOT NULL DEFAULT 1, status VARCHAR(32) NOT NULL DEFAULT 'PENDING', source_id VARCHAR(255), content_text LONGTEXT, embedding LONGTEXT, embedding_revision BIGINT, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), confirmed_at DATETIME(3), expires_at DATETIME(3))`,
 		`CREATE INDEX idx_status ON files(status, created_at)`,
 		`CREATE TABLE IF NOT EXISTS file_tags (file_id VARCHAR(64) NOT NULL, tag_key VARCHAR(255) NOT NULL, tag_value VARCHAR(255) NOT NULL DEFAULT '', PRIMARY KEY (file_id, tag_key))`,
 		`CREATE INDEX idx_kv ON file_tags(tag_key, tag_value)`,

--- a/pkg/datastore/schema_test_helper_test.go
+++ b/pkg/datastore/schema_test_helper_test.go
@@ -8,7 +8,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-func initDatastoreSchema(t *testing.T, dsn, provider string) {
+func initDatastoreSchema(t *testing.T, dsn string) {
 	t.Helper()
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -107,8 +107,7 @@ type Upload struct {
 
 // Store is the metadata store backed by TiDB/MySQL (stand-in for db9).
 type Store struct {
-	db             *sql.DB
-	hasContentBlob bool
+	db *sql.DB
 }
 
 func Open(dsn string) (*Store, error) {
@@ -124,9 +123,7 @@ func Open(dsn string) (*Store, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping db: %w", err)
 	}
-	s := &Store{db: db}
-	s.hasContentBlob = s.columnExists("files", "content_blob")
-	return s, nil
+	return &Store{db: db}, nil
 }
 
 func (s *Store) Close() error { return s.db.Close() }
@@ -389,22 +386,11 @@ func (s *Store) InsertFile(ctx context.Context, f *File) (err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "insert_file", start, &err)
 
-	if s.hasContentBlob {
-		_, err = s.db.ExecContext(ctx, `INSERT INTO files
-			(file_id, storage_type, storage_ref, content_blob, content_type, size_bytes, checksum_sha256,
-			 revision, status, source_id, content_text, created_at, confirmed_at, expires_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			f.FileID, f.StorageType, f.StorageRef, nilBytes(f.ContentBlob), nullStr(f.ContentType),
-			f.SizeBytes, nullStr(f.ChecksumSHA256), f.Revision, f.Status,
-			nullStr(f.SourceID), nullStr(f.ContentText),
-			f.CreatedAt.UTC(), nilTime(f.ConfirmedAt), nilTime(f.ExpiresAt))
-		return err
-	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO files
-		(file_id, storage_type, storage_ref, content_type, size_bytes, checksum_sha256,
+		(file_id, storage_type, storage_ref, content_blob, content_type, size_bytes, checksum_sha256,
 		 revision, status, source_id, content_text, created_at, confirmed_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		f.FileID, f.StorageType, f.StorageRef, nullStr(f.ContentType),
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		f.FileID, f.StorageType, f.StorageRef, nilBytes(f.ContentBlob), nullStr(f.ContentType),
 		f.SizeBytes, nullStr(f.ChecksumSHA256), f.Revision, f.Status,
 		nullStr(f.SourceID), nullStr(f.ContentText),
 		f.CreatedAt.UTC(), nilTime(f.ConfirmedAt), nilTime(f.ExpiresAt))
@@ -415,19 +401,11 @@ func (s *Store) GetFile(ctx context.Context, fileID string) (out *File, err erro
 	start := time.Now()
 	defer observeStoreOp(ctx, "get_file", start, &err)
 
-	if s.hasContentBlob {
-		row := s.db.QueryRowContext(ctx, `SELECT file_id, storage_type, storage_ref, content_blob, content_type,
-			size_bytes, checksum_sha256, revision, embedding_revision, status, source_id, content_text,
-			created_at, confirmed_at, expires_at
-			FROM files WHERE file_id = ?`, fileID)
-		out, err = scanFileWithBlob(row)
-		return out, err
-	}
-	row := s.db.QueryRowContext(ctx, `SELECT file_id, storage_type, storage_ref, content_type,
+	row := s.db.QueryRowContext(ctx, `SELECT file_id, storage_type, storage_ref, content_blob, content_type,
 		size_bytes, checksum_sha256, revision, embedding_revision, status, source_id, content_text,
 		created_at, confirmed_at, expires_at
 		FROM files WHERE file_id = ?`, fileID)
-	out, err = scanFileNoBlob(row)
+	out, err = scanFileWithBlob(row)
 	return out, err
 }
 
@@ -435,26 +413,13 @@ func (s *Store) UpdateFileContent(ctx context.Context, fileID string, storageTyp
 	start := time.Now()
 	defer observeStoreOp(ctx, "update_file_content", start, &err)
 
-	var (
-		res sql.Result
-	)
-	if s.hasContentBlob {
-		res, err = s.db.ExecContext(ctx, `UPDATE files SET storage_type = ?, storage_ref = ?,
-			content_blob = ?, content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
-			revision = revision + 1, status = 'CONFIRMED',
-			confirmed_at = ?
-			WHERE file_id = ?`,
-			storageType, storageRef, nilBytes(contentBlob), nullStr(contentType), size,
-			nullStr(checksum), nullStr(contentText), time.Now().UTC(), fileID)
-	} else {
-		res, err = s.db.ExecContext(ctx, `UPDATE files SET storage_type = ?, storage_ref = ?,
-			content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
-			revision = revision + 1, status = 'CONFIRMED',
-			confirmed_at = ?
-			WHERE file_id = ?`,
-			storageType, storageRef, nullStr(contentType), size,
-			nullStr(checksum), nullStr(contentText), time.Now().UTC(), fileID)
-	}
+	res, err := s.db.ExecContext(ctx, `UPDATE files SET storage_type = ?, storage_ref = ?,
+		content_blob = ?, content_type = ?, size_bytes = ?, checksum_sha256 = ?, content_text = ?,
+		revision = revision + 1, status = 'CONFIRMED',
+		confirmed_at = ?
+		WHERE file_id = ?`,
+		storageType, storageRef, nilBytes(contentBlob), nullStr(contentType), size,
+		nullStr(checksum), nullStr(contentText), time.Now().UTC(), fileID)
 	if err != nil {
 		return 0, err
 	}
@@ -610,11 +575,7 @@ func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWith
 	defer observeStoreOp(ctx, "list_dir", start, &err)
 
 	q := `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
-		f.file_id, f.storage_type, f.storage_ref, `
-	if s.hasContentBlob {
-		q += `f.content_blob, `
-	}
-	q += `f.content_type, f.size_bytes,
+		f.file_id, f.storage_type, f.storage_ref, f.content_blob, f.content_type, f.size_bytes,
 		f.checksum_sha256, f.revision, f.embedding_revision, f.status, f.source_id, f.content_text,
 		f.created_at, f.confirmed_at, f.expires_at
 		FROM file_nodes fn
@@ -629,12 +590,7 @@ func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWith
 
 	result := make([]*NodeWithFile, 0)
 	for rows.Next() {
-		var nf *NodeWithFile
-		if s.hasContentBlob {
-			nf, err = scanNodeWithFileWithBlob(rows)
-		} else {
-			nf, err = scanNodeWithFileNoBlob(rows)
-		}
+		nf, err := scanNodeWithFileWithBlob(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -692,20 +648,11 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 		return nil, err
 	}
 
-	q := `SELECT file_id, storage_type, storage_ref, `
-	if s.hasContentBlob {
-		q += `content_blob, `
-	}
-	q += `content_type, size_bytes, checksum_sha256, revision, embedding_revision, status, source_id, content_text,
+	row := tx.QueryRow(`SELECT file_id, storage_type, storage_ref, content_blob, content_type,
+		size_bytes, checksum_sha256, revision, embedding_revision, status, source_id, content_text,
 		created_at, confirmed_at, expires_at
-		FROM files WHERE file_id = ?`
-	row := tx.QueryRow(q, fileID.String)
-	var f *File
-	if s.hasContentBlob {
-		f, err = scanFileWithBlob(row)
-	} else {
-		f, err = scanFileNoBlob(row)
-	}
+		FROM files WHERE file_id = ?`, fileID.String)
+	f, err := scanFileWithBlob(row)
 	if err != nil {
 		return nil, err
 	}
@@ -763,20 +710,11 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 		if _, err := tx.Exec(`DELETE FROM file_tags WHERE file_id = ?`, fid); err != nil {
 			return nil, err
 		}
-		q := `SELECT file_id, storage_type, storage_ref, `
-		if s.hasContentBlob {
-			q += `content_blob, `
-		}
-		q += `content_type, size_bytes, checksum_sha256, revision, embedding_revision, status, source_id, content_text,
+		row := tx.QueryRow(`SELECT file_id, storage_type, storage_ref, content_blob, content_type,
+			size_bytes, checksum_sha256, revision, embedding_revision, status, source_id, content_text,
 			created_at, confirmed_at, expires_at
-			FROM files WHERE file_id = ?`
-		row := tx.QueryRow(q, fid)
-		var f *File
-		if s.hasContentBlob {
-			f, err = scanFileWithBlob(row)
-		} else {
-			f, err = scanFileNoBlob(row)
-		}
+			FROM files WHERE file_id = ?`, fid)
+		f, err := scanFileWithBlob(row)
 		if err != nil {
 			return nil, err
 		}
@@ -944,41 +882,6 @@ func scanFileWithBlob(s scanner) (*File, error) {
 	return &f, nil
 }
 
-func scanFileNoBlob(s scanner) (*File, error) {
-	var f File
-	var contentType, checksum, sourceID, contentText sql.NullString
-	var embeddingRevision sql.NullInt64
-	var confirmedAt, expiresAt sql.NullTime
-	var createdAt time.Time
-	err := s.Scan(&f.FileID, &f.StorageType, &f.StorageRef, &contentType,
-		&f.SizeBytes, &checksum, &f.Revision, &embeddingRevision, &f.Status, &sourceID, &contentText,
-		&createdAt, &confirmedAt, &expiresAt)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, err
-	}
-	f.ContentType = contentType.String
-	f.ChecksumSHA256 = checksum.String
-	f.SourceID = sourceID.String
-	f.ContentText = contentText.String
-	if embeddingRevision.Valid {
-		rev := embeddingRevision.Int64
-		f.EmbeddingRevision = &rev
-	}
-	f.CreatedAt = createdAt.UTC()
-	if confirmedAt.Valid {
-		t := confirmedAt.Time.UTC()
-		f.ConfirmedAt = &t
-	}
-	if expiresAt.Valid {
-		t := expiresAt.Time.UTC()
-		f.ExpiresAt = &t
-	}
-	return &f, nil
-}
-
 func scanNodeWithFileWithBlob(rows *sql.Rows) (*NodeWithFile, error) {
 	var n FileNode
 	var isDir int
@@ -1011,63 +914,6 @@ func scanNodeWithFileWithBlob(rows *sql.Rows) (*NodeWithFile, error) {
 			StorageType:    StorageType(fStorageType.String),
 			StorageRef:     fStorageRef.String,
 			ContentBlob:    append([]byte(nil), fContentBlob...),
-			ContentType:    fContentType.String,
-			SizeBytes:      fSizeBytes.Int64,
-			ChecksumSHA256: fChecksum.String,
-			Revision:       fRevision.Int64,
-			Status:         FileStatus(fStatus.String),
-			SourceID:       fSourceID.String,
-			ContentText:    fContentText.String,
-		}
-		if fEmbeddingRevision.Valid {
-			rev := fEmbeddingRevision.Int64
-			nf.File.EmbeddingRevision = &rev
-		}
-		if fCreatedAt.Valid {
-			nf.File.CreatedAt = fCreatedAt.Time.UTC()
-		}
-		if fConfirmedAt.Valid {
-			t := fConfirmedAt.Time.UTC()
-			nf.File.ConfirmedAt = &t
-		}
-		if fExpiresAt.Valid {
-			t := fExpiresAt.Time.UTC()
-			nf.File.ExpiresAt = &t
-		}
-	}
-	return nf, nil
-}
-
-func scanNodeWithFileNoBlob(rows *sql.Rows) (*NodeWithFile, error) {
-	var n FileNode
-	var isDir int
-	var nodeFileID sql.NullString
-	var nodeCreatedAt time.Time
-
-	var fFileID, fStorageType, fStorageRef sql.NullString
-	var fContentType, fChecksum, fSourceID, fContentText sql.NullString
-	var fSizeBytes, fRevision, fEmbeddingRevision sql.NullInt64
-	var fStatus sql.NullString
-	var fCreatedAt, fConfirmedAt, fExpiresAt sql.NullTime
-
-	err := rows.Scan(&n.NodeID, &n.Path, &n.ParentPath, &n.Name, &isDir, &nodeFileID, &nodeCreatedAt,
-		&fFileID, &fStorageType, &fStorageRef, &fContentType, &fSizeBytes,
-		&fChecksum, &fRevision, &fEmbeddingRevision, &fStatus, &fSourceID, &fContentText,
-		&fCreatedAt, &fConfirmedAt, &fExpiresAt)
-	if err != nil {
-		return nil, err
-	}
-
-	n.IsDirectory = isDir != 0
-	n.FileID = nodeFileID.String
-	n.CreatedAt = nodeCreatedAt.UTC()
-
-	nf := &NodeWithFile{Node: n}
-	if fFileID.Valid {
-		nf.File = &File{
-			FileID:         fFileID.String,
-			StorageType:    StorageType(fStorageType.String),
-			StorageRef:     fStorageRef.String,
 			ContentType:    fContentType.String,
 			SizeBytes:      fSizeBytes.Int64,
 			ChecksumSHA256: fChecksum.String,

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -574,6 +574,8 @@ func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWith
 	start := time.Now()
 	defer observeStoreOp(ctx, "list_dir", start, &err)
 
+	// TODO(#110): ReadDir only needs lightweight file metadata. Split this into a
+	// metadata-only listing path so directory scans do not fetch or copy content_blob.
 	q := `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
 		f.file_id, f.storage_type, f.storage_ref, f.content_blob, f.content_type, f.size_bytes,
 		f.checksum_sha256, f.revision, f.embedding_revision, f.status, f.source_id, f.content_text,

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -16,7 +16,7 @@ func newTestStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatal(err)
 	}
-	initDatastoreSchema(t, testDSN, "tidb_zero")
+	initDatastoreSchema(t, testDSN)
 	testmysql.ResetDB(t, s.DB())
 	t.Cleanup(func() { _ = s.Close() })
 	return s

--- a/pkg/tenant/schema_tidb_app.go
+++ b/pkg/tenant/schema_tidb_app.go
@@ -5,11 +5,7 @@ import (
 	"strconv"
 )
 
-func tidbAppEmbeddingSchemaStatements(withContentBlob bool) []string {
-	contentBlobCol := ""
-	if withContentBlob {
-		contentBlobCol = "content_blob       LONGBLOB,"
-	}
+func tidbAppEmbeddingSchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (
 			node_id      VARCHAR(64) PRIMARY KEY,
@@ -27,7 +23,7 @@ func tidbAppEmbeddingSchemaStatements(withContentBlob bool) []string {
 			file_id            VARCHAR(64) PRIMARY KEY,
 			storage_type       VARCHAR(32) NOT NULL,
 			storage_ref        TEXT NOT NULL,
-			` + contentBlobCol + `
+			content_blob       LONGBLOB,
 			content_type       VARCHAR(255),
 			size_bytes         BIGINT NOT NULL DEFAULT 0,
 			checksum_sha256    VARCHAR(128),
@@ -99,7 +95,7 @@ func tidbAppEmbeddingSchemaStatements(withContentBlob bool) []string {
 	}
 }
 
-func initTiDBAppEmbeddingSchema(dsn string, withContentBlob bool) error {
+func initTiDBAppEmbeddingSchema(dsn string) error {
 	db, err := openTiDBSchemaDB(dsn)
 	if err != nil {
 		return err
@@ -108,7 +104,7 @@ func initTiDBAppEmbeddingSchema(dsn string, withContentBlob bool) error {
 	if !isTiDBCluster(db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
-	if err := execSchemaStatements(db, tidbAppEmbeddingSchemaStatements(withContentBlob)); err != nil {
+	if err := execSchemaStatements(db, tidbAppEmbeddingSchemaStatements()); err != nil {
 		return err
 	}
 	return ValidateTiDBSchemaForMode(db, TiDBEmbeddingModeApp)

--- a/pkg/tenant/schema_tidb_auto.go
+++ b/pkg/tenant/schema_tidb_auto.go
@@ -40,11 +40,7 @@ type tidbTableMeta struct {
 	columns   map[string]tidbColumnMeta
 }
 
-func tidbAutoEmbeddingSchemaStatements(withContentBlob bool) []string {
-	contentBlobCol := ""
-	if withContentBlob {
-		contentBlobCol = "content_blob       LONGBLOB,"
-	}
+func tidbAutoEmbeddingSchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (
 			node_id      VARCHAR(64) PRIMARY KEY,
@@ -62,7 +58,7 @@ func tidbAutoEmbeddingSchemaStatements(withContentBlob bool) []string {
 			file_id            VARCHAR(64) PRIMARY KEY,
 			storage_type       VARCHAR(32) NOT NULL,
 			storage_ref        TEXT NOT NULL,
-			` + contentBlobCol + `
+			content_blob       LONGBLOB,
 			content_type       VARCHAR(255),
 			size_bytes         BIGINT NOT NULL DEFAULT 0,
 			checksum_sha256    VARCHAR(128),
@@ -230,7 +226,7 @@ func validateTiDBSchemaMode(mode TiDBEmbeddingMode) error {
 	return nil
 }
 
-func initTiDBAutoEmbeddingSchema(dsn string, withContentBlob bool) error {
+func initTiDBAutoEmbeddingSchema(dsn string) error {
 	db, err := openTiDBSchemaDB(dsn)
 	if err != nil {
 		return err
@@ -239,7 +235,7 @@ func initTiDBAutoEmbeddingSchema(dsn string, withContentBlob bool) error {
 	if !isTiDBCluster(db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
-	if err := execSchemaStatements(db, tidbAutoEmbeddingSchemaStatements(withContentBlob)); err != nil {
+	if err := execSchemaStatements(db, tidbAutoEmbeddingSchemaStatements()); err != nil {
 		return err
 	}
 	return ValidateTiDBSchemaForMode(db, TiDBEmbeddingModeAuto)

--- a/pkg/tenant/schema_zero.go
+++ b/pkg/tenant/schema_zero.go
@@ -13,12 +13,12 @@ func InitTiDBTenantSchemaForMode(dsn string, mode TiDBEmbeddingMode) error {
 	case TiDBEmbeddingModeAuto:
 		return initZeroSchema(dsn)
 	case TiDBEmbeddingModeApp:
-		return initTiDBAppEmbeddingSchema(dsn, true)
+		return initTiDBAppEmbeddingSchema(dsn)
 	default:
 		return validateTiDBSchemaMode(mode)
 	}
 }
 
 func initZeroSchema(dsn string) error {
-	return initTiDBAutoEmbeddingSchema(dsn, true)
+	return initTiDBAutoEmbeddingSchema(dsn)
 }


### PR DESCRIPTION
## Summary
- align datastore schema tests and TiDB schema builders on the current contract that every supported provider includes `files.content_blob`
- remove legacy datastore read/write branches that tried to operate without `content_blob`, so runtime code matches the real schema
- document the `make test` Podman fallback for environments where direct `go test` fails with `rootless Docker not found`

## Testing
- `source ./scripts/test-podman.sh && go test -v ./pkg/datastore ./pkg/tenant`
- `source ./scripts/test-podman.sh && go test -v ./pkg/datastore ./pkg/backend ./pkg/server`

Closes #108