### PR TITLE
feat: T5 — FUSE adaptive part-size boundaries

### DIFF
--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -44,7 +44,7 @@ type PatchUploadPart struct {
 //   - path: the file to patch
 //   - newSize: the total size of the file after patching
 //   - dirtyParts: 1-based part numbers that the client has modified
-func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newSize int64, dirtyParts []int) (*PatchPlan, error) {
+func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newSize int64, dirtyParts []int, clientPartSize int64) (*PatchPlan, error) {
 	start := time.Now()
 
 	path, err := pathutil.Canonicalize(path)
@@ -89,10 +89,13 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 
-	// Calculate new parts — patch path uses fixed PartSize because callers
-	// (FUSE, client) determine dirty_parts based on this boundary before
-	// the server responds. Adaptive part size for patches deferred to T5.
-	newParts := s3client.CalcParts(newSize, s3client.PartSize)
+	// Use client-provided part size if valid (>= MinPartSize); otherwise
+	// compute adaptive part size from the new file size.
+	partSize := clientPartSize
+	if partSize < s3client.MinPartSize {
+		partSize = s3client.CalcAdaptivePartSize(newSize)
+	}
+	newParts := s3client.CalcParts(newSize, partSize)
 
 	// Build dirty set for O(1) lookup
 	dirtySet := make(map[int]bool, len(dirtyParts))
@@ -103,19 +106,19 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 	// How many parts did the original file have?
 	origPartCount := 0
 	if origSize > 0 {
-		origPartCount = len(s3client.CalcParts(origSize, s3client.PartSize))
+		origPartCount = len(s3client.CalcParts(origSize, partSize))
 	}
 
 	plan := &PatchPlan{
 		UploadID: "", // set below after DB insert
-		PartSize: s3client.PartSize,
+		PartSize: partSize,
 	}
 
 	// Process each part
 	for _, p := range newParts {
 		if !dirtySet[p.Number] && p.Number <= origPartCount {
 			// Unchanged part within original file range → server-side copy
-			partStart := int64(p.Number-1) * s3client.PartSize
+			partStart := int64(p.Number-1) * partSize
 			partEnd := partStart + p.Size - 1
 			// Clamp to original file size (last part may be smaller)
 			if partEnd >= origSize {
@@ -151,7 +154,7 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 			// If this part overlaps with the original file, provide a read URL
 			// so the client can download the original data for merging.
 			if p.Number <= origPartCount {
-				partStart := int64(p.Number-1) * s3client.PartSize
+				partStart := int64(p.Number-1) * partSize
 				partEnd := partStart + p.Size - 1
 				if partEnd >= origSize {
 					partEnd = origSize - 1
@@ -200,7 +203,7 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 		S3UploadID: mpu.UploadID,
 		S3Key:      newS3Key,
 		TotalSize:  newSize,
-		PartSize:   s3client.PartSize,
+		PartSize:   partSize,
 		PartsTotal: len(newParts),
 		Status:     datastore.UploadUploading,
 		CreatedAt:  now,

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -85,6 +85,10 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 	if partSize < s3client.MinPartSize {
 		partSize = s3client.PartSize
 	}
+	if partSize > s3client.MaxPartSize {
+		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		return nil, fmt.Errorf("part_size %d exceeds S3 per-part limit of %d", partSize, s3client.MaxPartSize)
+	}
 	newParts := s3client.CalcParts(newSize, partSize)
 	if len(newParts) > MaxMultipartParts {
 		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -78,6 +78,19 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 		return nil, datastore.ErrUploadConflict
 	}
 
+	// Use client-provided part size if valid (>= MinPartSize); otherwise
+	// fall back to fixed 8 MiB for backward compatibility with old clients
+	// that compute dirty_parts at fixed 8 MiB boundaries.
+	partSize := clientPartSize
+	if partSize < s3client.MinPartSize {
+		partSize = s3client.PartSize
+	}
+	newParts := s3client.CalcParts(newSize, partSize)
+	if len(newParts) > MaxMultipartParts {
+		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		return nil, fmt.Errorf("part_size %d produces %d parts for size %d, exceeds S3 limit of %d", partSize, len(newParts), newSize, MaxMultipartParts)
+	}
+
 	// Create new S3 multipart upload (new key — old object stays until confirm)
 	fileID := b.genID()
 	newS3Key := "blobs/" + fileID
@@ -88,15 +101,6 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
-
-	// Use client-provided part size if valid (>= MinPartSize); otherwise
-	// fall back to fixed 8 MiB for backward compatibility with old clients
-	// that compute dirty_parts at fixed 8 MiB boundaries.
-	partSize := clientPartSize
-	if partSize < s3client.MinPartSize {
-		partSize = s3client.PartSize
-	}
-	newParts := s3client.CalcParts(newSize, partSize)
 
 	// Build dirty set for O(1) lookup
 	dirtySet := make(map[int]bool, len(dirtyParts))

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -90,10 +90,11 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 	}
 
 	// Use client-provided part size if valid (>= MinPartSize); otherwise
-	// compute adaptive part size from the new file size.
+	// fall back to fixed 8 MiB for backward compatibility with old clients
+	// that compute dirty_parts at fixed 8 MiB boundaries.
 	partSize := clientPartSize
 	if partSize < s3client.MinPartSize {
-		partSize = s3client.CalcAdaptivePartSize(newSize)
+		partSize = s3client.PartSize
 	}
 	newParts := s3client.CalcParts(newSize, partSize)
 

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -89,8 +89,9 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 
-	// Calculate new parts
-	newParts := s3client.CalcParts(newSize, s3client.PartSize)
+	// Calculate adaptive part size for the new upload
+	partSize := s3client.CalcAdaptivePartSize(newSize)
+	newParts := s3client.CalcParts(newSize, partSize)
 
 	// Build dirty set for O(1) lookup
 	dirtySet := make(map[int]bool, len(dirtyParts))
@@ -101,19 +102,19 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 	// How many parts did the original file have?
 	origPartCount := 0
 	if origSize > 0 {
-		origPartCount = len(s3client.CalcParts(origSize, s3client.PartSize))
+		origPartCount = len(s3client.CalcParts(origSize, partSize))
 	}
 
 	plan := &PatchPlan{
 		UploadID: "", // set below after DB insert
-		PartSize: s3client.PartSize,
+		PartSize: partSize,
 	}
 
 	// Process each part
 	for _, p := range newParts {
 		if !dirtySet[p.Number] && p.Number <= origPartCount {
 			// Unchanged part within original file range → server-side copy
-			partStart := int64(p.Number-1) * s3client.PartSize
+			partStart := int64(p.Number-1) * partSize
 			partEnd := partStart + p.Size - 1
 			// Clamp to original file size (last part may be smaller)
 			if partEnd >= origSize {
@@ -149,7 +150,7 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 			// If this part overlaps with the original file, provide a read URL
 			// so the client can download the original data for merging.
 			if p.Number <= origPartCount {
-				partStart := int64(p.Number-1) * s3client.PartSize
+				partStart := int64(p.Number-1) * partSize
 				partEnd := partStart + p.Size - 1
 				if partEnd >= origSize {
 					partEnd = origSize - 1
@@ -198,7 +199,7 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 		S3UploadID: mpu.UploadID,
 		S3Key:      newS3Key,
 		TotalSize:  newSize,
-		PartSize:   s3client.PartSize,
+		PartSize:   partSize,
 		PartsTotal: len(newParts),
 		Status:     datastore.UploadUploading,
 		CreatedAt:  now,

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -89,9 +89,10 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 
-	// Calculate adaptive part size for the new upload
-	partSize := s3client.CalcAdaptivePartSize(newSize)
-	newParts := s3client.CalcParts(newSize, partSize)
+	// Calculate new parts — patch path uses fixed PartSize because callers
+	// (FUSE, client) determine dirty_parts based on this boundary before
+	// the server responds. Adaptive part size for patches deferred to T5.
+	newParts := s3client.CalcParts(newSize, s3client.PartSize)
 
 	// Build dirty set for O(1) lookup
 	dirtySet := make(map[int]bool, len(dirtyParts))
@@ -102,19 +103,19 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 	// How many parts did the original file have?
 	origPartCount := 0
 	if origSize > 0 {
-		origPartCount = len(s3client.CalcParts(origSize, partSize))
+		origPartCount = len(s3client.CalcParts(origSize, s3client.PartSize))
 	}
 
 	plan := &PatchPlan{
 		UploadID: "", // set below after DB insert
-		PartSize: partSize,
+		PartSize: s3client.PartSize,
 	}
 
 	// Process each part
 	for _, p := range newParts {
 		if !dirtySet[p.Number] && p.Number <= origPartCount {
 			// Unchanged part within original file range → server-side copy
-			partStart := int64(p.Number-1) * partSize
+			partStart := int64(p.Number-1) * s3client.PartSize
 			partEnd := partStart + p.Size - 1
 			// Clamp to original file size (last part may be smaller)
 			if partEnd >= origSize {
@@ -150,7 +151,7 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 			// If this part overlaps with the original file, provide a read URL
 			// so the client can download the original data for merging.
 			if p.Number <= origPartCount {
-				partStart := int64(p.Number-1) * partSize
+				partStart := int64(p.Number-1) * s3client.PartSize
 				partEnd := partStart + p.Size - 1
 				if partEnd >= origSize {
 					partEnd = origSize - 1
@@ -199,7 +200,7 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 		S3UploadID: mpu.UploadID,
 		S3Key:      newS3Key,
 		TotalSize:  newSize,
-		PartSize:   partSize,
+		PartSize:   s3client.PartSize,
 		PartsTotal: len(newParts),
 		Status:     datastore.UploadUploading,
 		CreatedAt:  now,

--- a/pkg/backend/semantic_tasks_test.go
+++ b/pkg/backend/semantic_tasks_test.go
@@ -62,7 +62,7 @@ func uploadAllPartsForPlan(t *testing.T, b *Dat9Backend, plan *UploadPlan, uploa
 		partData[i] = byte(i % 251)
 	}
 	for _, part := range plan.Parts {
-		start := int64(part.Number-1) * s3client.PartSize
+		start := int64(part.Number-1) * upload.PartSize
 		end := start + part.Size
 		if end > totalSize {
 			end = totalSize

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -363,6 +363,67 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, partNum
 	return urls, nil
 }
 
+// CompletePart is a client-supplied part reference for v2 complete.
+type CompletePart struct {
+	Number int    `json:"number"`
+	ETag   string `json:"etag"`
+}
+
+// ConfirmUploadV2 validates client-supplied parts against S3, then completes the upload.
+func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clientParts []CompletePart) error {
+	start := time.Now()
+
+	upload, err := b.store.GetUpload(ctx, uploadID)
+	if err != nil {
+		metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+		return err
+	}
+	if upload.Status != datastore.UploadUploading {
+		metrics.RecordOperation("backend", "confirm_upload_v2", "not_active", time.Since(start))
+		return datastore.ErrUploadNotActive
+	}
+	if time.Now().After(upload.ExpiresAt) {
+		_ = b.store.AbortUpload(ctx, uploadID)
+		metrics.RecordOperation("backend", "confirm_upload_v2", "expired", time.Since(start))
+		return datastore.ErrUploadExpired
+	}
+
+	// Validate client-supplied part count
+	if len(clientParts) != upload.PartsTotal {
+		metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+		return fmt.Errorf("part count mismatch: client sent %d, expected %d", len(clientParts), upload.PartsTotal)
+	}
+
+	// List uploaded parts from S3
+	s3Parts, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
+	if err != nil {
+		logger.Error(ctx, "backend_confirm_upload_v2_list_parts_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+		return fmt.Errorf("list parts: %w", err)
+	}
+
+	// Cross-validate client parts against S3 parts
+	s3PartMap := make(map[int]string, len(s3Parts))
+	for _, p := range s3Parts {
+		s3PartMap[p.Number] = p.ETag
+	}
+	for _, cp := range clientParts {
+		s3ETag, ok := s3PartMap[cp.Number]
+		if !ok {
+			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+			return fmt.Errorf("part %d not found in S3", cp.Number)
+		}
+		if cp.ETag != s3ETag {
+			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+			return fmt.Errorf("part %d ETag mismatch: client=%q, S3=%q", cp.Number, cp.ETag, s3ETag)
+		}
+	}
+
+	metrics.RecordOperation("backend", "confirm_upload_v2", "ok", time.Since(start))
+	// Delegate to common confirm logic (which re-lists parts, verifies sizes, and completes)
+	return b.ConfirmUpload(ctx, uploadID)
+}
+
 // ConfirmUpload completes the multipart upload and creates the file node.
 func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error {
 	start := time.Now()

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -279,17 +279,21 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 	}, nil
 }
 
+// ErrUnsupportedAlgorithm is returned when a client supplies a checksum algorithm
+// not in ChecksumContract.Supported.
+var ErrUnsupportedAlgorithm = fmt.Errorf("unsupported checksum algorithm")
+
 // resolveChecksumSHA256 extracts the SHA-256 value from an optional checksum.
-// Phase 1 only supports SHA-256 pass-through; other algorithms are accepted
-// but ignored (the presigned URL won't include a checksum header for them).
-func resolveChecksumSHA256(cs *PresignChecksum) string {
+// Phase 1 only supports SHA-256; unsupported algorithms are rejected with
+// ErrUnsupportedAlgorithm so the contract stays honest.
+func resolveChecksumSHA256(cs *PresignChecksum) (string, error) {
 	if cs == nil || cs.Value == "" {
-		return ""
+		return "", nil
 	}
 	if cs.Algorithm == "sha256" || cs.Algorithm == "SHA256" || cs.Algorithm == "SHA-256" {
-		return cs.Value
+		return cs.Value, nil
 	}
-	return ""
+	return "", fmt.Errorf("%w: %s", ErrUnsupportedAlgorithm, cs.Algorithm)
 }
 
 // PresignPart presigns a single part URL for an active upload.
@@ -326,7 +330,11 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 	parts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	partSize := parts[partNumber-1].Size
 
-	checksumSHA256 := resolveChecksumSHA256(checksum)
+	checksumSHA256, err := resolveChecksumSHA256(checksum)
+	if err != nil {
+		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
+		return nil, err
+	}
 	u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, partNumber, partSize, checksumSHA256, s3client.UploadTTL)
 	if err != nil {
 		logger.Error(ctx, "backend_presign_part_failed", zap.String("upload_id", uploadID), zap.Int("part_number", partNumber), zap.Error(err))
@@ -387,7 +395,11 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 			return nil, fmt.Errorf("invalid part number %d: must be between 1 and %d", pn, upload.PartsTotal)
 		}
 		partSize := parts[pn-1].Size
-		checksumSHA256 := resolveChecksumSHA256(e.Checksum)
+		checksumSHA256, err := resolveChecksumSHA256(e.Checksum)
+		if err != nil {
+			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+			return nil, err
+		}
 		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, pn, partSize, checksumSHA256, s3client.UploadTTL)
 		if err != nil {
 			logger.Error(ctx, "backend_presign_parts_failed", zap.String("upload_id", uploadID), zap.Int("part_number", pn), zap.Error(err))
@@ -431,6 +443,20 @@ func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clie
 		return fmt.Errorf("part count mismatch: client sent %d, expected %d", len(clientParts), upload.PartsTotal)
 	}
 
+	// Reject duplicate part numbers and validate completeness (all 1..N present)
+	clientPartMap := make(map[int]string, len(clientParts))
+	for _, cp := range clientParts {
+		if _, dup := clientPartMap[cp.Number]; dup {
+			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+			return fmt.Errorf("duplicate part number %d in complete request", cp.Number)
+		}
+		if cp.Number < 1 || cp.Number > upload.PartsTotal {
+			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+			return fmt.Errorf("invalid part number %d: must be between 1 and %d", cp.Number, upload.PartsTotal)
+		}
+		clientPartMap[cp.Number] = cp.ETag
+	}
+
 	// List uploaded parts from S3
 	s3Parts, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
 	if err != nil {
@@ -439,20 +465,20 @@ func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clie
 		return fmt.Errorf("list parts: %w", err)
 	}
 
-	// Cross-validate client parts against S3 parts
+	// Cross-validate: every client part must match an S3 part ETag
 	s3PartMap := make(map[int]string, len(s3Parts))
 	for _, p := range s3Parts {
 		s3PartMap[p.Number] = p.ETag
 	}
-	for _, cp := range clientParts {
-		s3ETag, ok := s3PartMap[cp.Number]
+	for partNum, clientETag := range clientPartMap {
+		s3ETag, ok := s3PartMap[partNum]
 		if !ok {
 			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
-			return fmt.Errorf("part %d not found in S3", cp.Number)
+			return fmt.Errorf("part %d not found in S3", partNum)
 		}
-		if cp.ETag != s3ETag {
+		if clientETag != s3ETag {
 			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
-			return fmt.Errorf("part %d ETag mismatch: client=%q, S3=%q", cp.Number, cp.ETag, s3ETag)
+			return fmt.Errorf("part %d ETag mismatch: client=%q, S3=%q", partNum, clientETag, s3ETag)
 		}
 	}
 

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -273,7 +273,7 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 		ExpiresAt:        expiresAt.Format(time.RFC3339),
 		Resumable:        false,
 		ChecksumContract: ChecksumContract{
-			Supported: []string{"crc32c"},
+			Supported: []string{"SHA-256"},
 			Required:  false,
 		},
 	}, nil
@@ -420,7 +420,7 @@ func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clie
 		return datastore.ErrUploadNotActive
 	}
 	if time.Now().After(upload.ExpiresAt) {
-		_ = b.store.AbortUpload(ctx, uploadID)
+		_ = b.AbortUploadV2(ctx, uploadID)
 		metrics.RecordOperation("backend", "confirm_upload_v2", "expired", time.Since(start))
 		return datastore.ErrUploadExpired
 	}

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -25,12 +25,17 @@ type UploadPlan struct {
 
 // UploadPlanV2 is returned by InitiateUploadV2 — no presigned URLs.
 type UploadPlanV2 struct {
-	UploadID   string `json:"upload_id"`
-	Key        string `json:"key"`
-	PartSize   int64  `json:"part_size"`
-	TotalParts int    `json:"total_parts"`
-	ExpiresAt  string `json:"expires_at"`
+	UploadID         string `json:"upload_id"`
+	Key              string `json:"key"`
+	PartSize         int64  `json:"part_size"`
+	TotalParts       int    `json:"total_parts"`
+	ExpiresAt        string `json:"expires_at"`
+	Resumable        bool   `json:"resumable"`
+	ChecksumContract string `json:"checksum_contract"`
 }
+
+// MaxMultipartParts is the S3 hard limit on parts per multipart upload.
+const MaxMultipartParts = 10000
 
 var ErrPartChecksumCountMismatch = errors.New("part checksum count mismatch")
 
@@ -182,6 +187,12 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 
 	partSize := s3client.CalcAdaptivePartSize(totalSize)
 	parts := s3client.CalcParts(totalSize, partSize)
+	if len(parts) > MaxMultipartParts {
+		err := fmt.Errorf("file too large: %d parts exceeds S3 limit of %d", len(parts), MaxMultipartParts)
+		logger.Warn(ctx, "backend_initiate_upload_v2_too_many_parts", zap.String("path", path), zap.Int("parts", len(parts)), zap.Int64("total_size", totalSize))
+		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		return nil, err
+	}
 
 	fileID := b.genID()
 	s3Key := "blobs/" + fileID
@@ -221,7 +232,7 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 		TotalSize:  totalSize,
 		PartSize:   partSize,
 		PartsTotal: len(parts),
-		Status:     datastore.UploadUploading,
+		Status:     datastore.UploadInitiated,
 		CreatedAt:  now,
 		UpdatedAt:  now,
 		ExpiresAt:  expiresAt,
@@ -234,15 +245,18 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 	metrics.RecordOperation("backend", "initiate_upload_v2", "ok", time.Since(start))
 
 	return &UploadPlanV2{
-		UploadID:   uploadID,
-		Key:        s3Key,
-		PartSize:   partSize,
-		TotalParts: len(parts),
-		ExpiresAt:  expiresAt.Format(time.RFC3339),
+		UploadID:         uploadID,
+		Key:              s3Key,
+		PartSize:         partSize,
+		TotalParts:       len(parts),
+		ExpiresAt:        expiresAt.Format(time.RFC3339),
+		Resumable:        false,
+		ChecksumContract: "none",
 	}, nil
 }
 
 // PresignPart presigns a single part URL for an active upload.
+// Transitions INITIATED → UPLOADING on first presign.
 func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumber int) (*s3client.UploadPartURL, error) {
 	start := time.Now()
 
@@ -251,9 +265,16 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
 		return nil, err
 	}
-	if upload.Status != datastore.UploadUploading {
+	if upload.Status != datastore.UploadUploading && upload.Status != datastore.UploadInitiated {
 		metrics.RecordOperation("backend", "presign_part", "not_active", time.Since(start))
 		return nil, datastore.ErrUploadNotActive
+	}
+	if upload.Status == datastore.UploadInitiated {
+		if err := b.store.UpdateUploadStatus(ctx, uploadID, datastore.UploadUploading); err != nil {
+			logger.Error(ctx, "backend_presign_part_status_transition_failed", zap.String("upload_id", uploadID), zap.Error(err))
+			metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
+			return nil, err
+		}
 	}
 	if partNumber < 1 || partNumber > upload.PartsTotal {
 		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
@@ -274,6 +295,7 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 }
 
 // PresignParts presigns multiple part URLs for an active upload.
+// Transitions INITIATED → UPLOADING on first presign.
 func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, partNumbers []int) ([]*s3client.UploadPartURL, error) {
 	start := time.Now()
 
@@ -282,9 +304,16 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, partNum
 		metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
 		return nil, err
 	}
-	if upload.Status != datastore.UploadUploading {
+	if upload.Status != datastore.UploadUploading && upload.Status != datastore.UploadInitiated {
 		metrics.RecordOperation("backend", "presign_parts", "not_active", time.Since(start))
 		return nil, datastore.ErrUploadNotActive
+	}
+	if upload.Status == datastore.UploadInitiated {
+		if err := b.store.UpdateUploadStatus(ctx, uploadID, datastore.UploadUploading); err != nil {
+			logger.Error(ctx, "backend_presign_parts_status_transition_failed", zap.String("upload_id", uploadID), zap.Error(err))
+			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+			return nil, err
+		}
 	}
 
 	parts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
@@ -591,6 +620,35 @@ func (b *Dat9Backend) AbortUpload(ctx context.Context, uploadID string) error {
 		return err
 	}
 	metrics.RecordOperation("backend", "abort_upload", "ok", time.Since(start))
+	return nil
+}
+
+// AbortUploadV2 cancels an upload (idempotent — returns nil for not-found or already-aborted).
+func (b *Dat9Backend) AbortUploadV2(ctx context.Context, uploadID string) error {
+	start := time.Now()
+	upload, err := b.store.GetUpload(ctx, uploadID)
+	if err != nil {
+		// Not found → idempotent success
+		if errors.Is(err, datastore.ErrNotFound) {
+			metrics.RecordOperation("backend", "abort_upload_v2", "ok", time.Since(start))
+			return nil
+		}
+		metrics.RecordOperation("backend", "abort_upload_v2", "error", time.Since(start))
+		return err
+	}
+	// Already terminal → idempotent success
+	if upload.Status == datastore.UploadAborted || upload.Status == datastore.UploadCompleted || upload.Status == datastore.UploadExpired {
+		metrics.RecordOperation("backend", "abort_upload_v2", "ok", time.Since(start))
+		return nil
+	}
+
+	_ = b.s3.AbortMultipartUpload(ctx, upload.S3Key, upload.S3UploadID)
+	if err := b.store.AbortUploadV2(ctx, uploadID); err != nil {
+		logger.Error(ctx, "backend_abort_upload_v2_store_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		metrics.RecordOperation("backend", "abort_upload_v2", "error", time.Since(start))
+		return err
+	}
+	metrics.RecordOperation("backend", "abort_upload_v2", "ok", time.Since(start))
 	return nil
 }
 

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -307,12 +307,12 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 		return nil, datastore.ErrUploadNotActive
 	}
 	if time.Now().After(upload.ExpiresAt) {
-		_ = b.store.AbortUpload(ctx, uploadID)
+		_ = b.AbortUploadV2(ctx, uploadID)
 		metrics.RecordOperation("backend", "presign_part", "expired", time.Since(start))
 		return nil, datastore.ErrUploadExpired
 	}
 	if upload.Status == datastore.UploadInitiated {
-		if err := b.store.UpdateUploadStatus(ctx, uploadID, datastore.UploadUploading); err != nil {
+		if err := b.store.TransitionUploadStatus(ctx, uploadID, datastore.UploadInitiated, datastore.UploadUploading); err != nil {
 			logger.Error(ctx, "backend_presign_part_status_transition_failed", zap.String("upload_id", uploadID), zap.Error(err))
 			metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
 			return nil, err
@@ -352,7 +352,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		return nil, datastore.ErrUploadNotActive
 	}
 	if time.Now().After(upload.ExpiresAt) {
-		_ = b.store.AbortUpload(ctx, uploadID)
+		_ = b.AbortUploadV2(ctx, uploadID)
 		metrics.RecordOperation("backend", "presign_parts", "expired", time.Since(start))
 		return nil, datastore.ErrUploadExpired
 	}
@@ -370,7 +370,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		seen[e.PartNumber] = true
 	}
 	if upload.Status == datastore.UploadInitiated {
-		if err := b.store.UpdateUploadStatus(ctx, uploadID, datastore.UploadUploading); err != nil {
+		if err := b.store.TransitionUploadStatus(ctx, uploadID, datastore.UploadInitiated, datastore.UploadUploading); err != nil {
 			logger.Error(ctx, "backend_presign_parts_status_transition_failed", zap.String("upload_id", uploadID), zap.Error(err))
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
 			return nil, err

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -482,9 +482,22 @@ func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clie
 		}
 	}
 
+	// Verify part sizes match expected layout.
+	expectedParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
+	if len(s3Parts) != len(expectedParts) {
+		metrics.RecordOperation("backend", "confirm_upload_v2", "incomplete", time.Since(start))
+		return fmt.Errorf("incomplete upload: S3 has %d parts, expected %d", len(s3Parts), len(expectedParts))
+	}
+	for i, p := range s3Parts {
+		if p.Size != expectedParts[i].Size {
+			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+			return fmt.Errorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
+		}
+	}
+
+	// Complete using the already-validated parts — no second ListParts.
 	metrics.RecordOperation("backend", "confirm_upload_v2", "ok", time.Since(start))
-	// Delegate to common confirm logic (which re-lists parts, verifies sizes, and completes)
-	return b.ConfirmUpload(ctx, uploadID)
+	return b.finalizeUpload(ctx, upload, s3Parts)
 }
 
 // ConfirmUpload completes the multipart upload and creates the file node.
@@ -526,16 +539,23 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 		}
 	}
 
+	metrics.RecordOperation("backend", "confirm_upload", "ok", time.Since(start))
+	return b.finalizeUpload(ctx, upload, parts)
+}
+
+// finalizeUpload completes the S3 multipart upload and creates the file node.
+// Both ConfirmUpload (v1) and ConfirmUploadV2 call this with already-validated parts.
+func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Upload, parts []s3client.Part) error {
+	start := time.Now()
+	uploadID := upload.UploadID
+
 	// Complete S3 multipart upload (idempotent, outside transaction)
 	if err := b.s3.CompleteMultipartUpload(ctx, upload.S3Key, upload.S3UploadID, parts); err != nil {
-		logger.Error(ctx, "backend_confirm_upload_complete_multipart_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
+		logger.Error(ctx, "backend_finalize_upload_complete_multipart_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		metrics.RecordOperation("backend", "finalize_upload", "error", time.Since(start))
 		return fmt.Errorf("complete multipart: %w", err)
 	}
 
-	// Atomically: complete upload, ensure parents, create or overwrite node.
-	// Overwrite preserves inode identity by updating the existing files row
-	// in place so every hard link keeps pointing at the same file_id.
 	var oldStorageRef string
 	var oldStorageType datastore.StorageType
 	var isOverwrite bool
@@ -652,23 +672,20 @@ func (b *Dat9Backend) ConfirmUpload(ctx context.Context, uploadID string) error 
 		}
 		return nil
 	}); err != nil {
-		logger.Error(ctx, "backend_confirm_upload_tx_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
+		logger.Error(ctx, "backend_finalize_upload_tx_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		metrics.RecordOperation("backend", "finalize_upload", "error", time.Since(start))
 		return err
 	}
 	if isOverwrite {
 		b.deleteBlobIfS3Ctx(ctx, oldStorageType, oldStorageRef, upload.S3Key)
 	}
-	// Temporary compatibility: app embedding still relies on the legacy
-	// backend-owned image queue until its image task flow also moves to
-	// semantic_tasks.
 	if b.UsesDatabaseAutoEmbedding() {
-		metrics.RecordOperation("backend", "confirm_upload", "ok", time.Since(start))
+		metrics.RecordOperation("backend", "finalize_upload", "ok", time.Since(start))
 		return nil
 	}
 	b.enqueueImageExtractForUpload(ctx, upload, isOverwrite)
 
-	metrics.RecordOperation("backend", "confirm_upload", "ok", time.Since(start))
+	metrics.RecordOperation("backend", "finalize_upload", "ok", time.Since(start))
 	return nil
 }
 

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -37,6 +37,9 @@ type UploadPlanV2 struct {
 // MaxMultipartParts is the S3 hard limit on parts per multipart upload.
 const MaxMultipartParts = 10000
 
+// MaxPresignBatch is the maximum number of parts that can be presigned in a single batch request.
+const MaxPresignBatch = 500
+
 var ErrPartChecksumCountMismatch = errors.New("part checksum count mismatch")
 
 // S3 returns the S3Client (nil when not configured).
@@ -269,6 +272,11 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 		metrics.RecordOperation("backend", "presign_part", "not_active", time.Since(start))
 		return nil, datastore.ErrUploadNotActive
 	}
+	if time.Now().After(upload.ExpiresAt) {
+		_ = b.store.AbortUpload(ctx, uploadID)
+		metrics.RecordOperation("backend", "presign_part", "expired", time.Since(start))
+		return nil, datastore.ErrUploadExpired
+	}
 	if upload.Status == datastore.UploadInitiated {
 		if err := b.store.UpdateUploadStatus(ctx, uploadID, datastore.UploadUploading); err != nil {
 			logger.Error(ctx, "backend_presign_part_status_transition_failed", zap.String("upload_id", uploadID), zap.Error(err))
@@ -307,6 +315,24 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, partNum
 	if upload.Status != datastore.UploadUploading && upload.Status != datastore.UploadInitiated {
 		metrics.RecordOperation("backend", "presign_parts", "not_active", time.Since(start))
 		return nil, datastore.ErrUploadNotActive
+	}
+	if time.Now().After(upload.ExpiresAt) {
+		_ = b.store.AbortUpload(ctx, uploadID)
+		metrics.RecordOperation("backend", "presign_parts", "expired", time.Since(start))
+		return nil, datastore.ErrUploadExpired
+	}
+	if len(partNumbers) > MaxPresignBatch {
+		metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+		return nil, fmt.Errorf("batch too large: %d parts exceeds limit of %d", len(partNumbers), MaxPresignBatch)
+	}
+	// Reject duplicate part numbers in the batch.
+	seen := make(map[int]bool, len(partNumbers))
+	for _, pn := range partNumbers {
+		if seen[pn] {
+			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+			return nil, fmt.Errorf("duplicate part number %d in batch", pn)
+		}
+		seen[pn] = true
 	}
 	if upload.Status == datastore.UploadInitiated {
 		if err := b.store.UpdateUploadStatus(ctx, uploadID, datastore.UploadUploading); err != nil {

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -23,6 +23,15 @@ type UploadPlan struct {
 	Parts    []*s3client.UploadPartURL `json:"parts"`
 }
 
+// UploadPlanV2 is returned by InitiateUploadV2 — no presigned URLs.
+type UploadPlanV2 struct {
+	UploadID   string `json:"upload_id"`
+	Key        string `json:"key"`
+	PartSize   int64  `json:"part_size"`
+	TotalParts int    `json:"total_parts"`
+	ExpiresAt  string `json:"expires_at"`
+}
+
 var ErrPartChecksumCountMismatch = errors.New("part checksum count mismatch")
 
 // S3 returns the S3Client (nil when not configured).
@@ -145,6 +154,158 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 		PartSize: s3client.PartSize,
 		Parts:    urls,
 	}, nil
+}
+
+// InitiateUploadV2 creates a multipart upload with adaptive part size.
+// Unlike v1, it does NOT presign any URLs — clients fetch them on demand.
+func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSize int64) (*UploadPlanV2, error) {
+	start := time.Now()
+
+	path, err := pathutil.Canonicalize(path)
+	if err != nil {
+		logger.Warn(ctx, "backend_initiate_upload_v2_invalid_path", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		return nil, err
+	}
+	if b.s3 == nil {
+		err := fmt.Errorf("S3 not configured")
+		logger.Error(ctx, "backend_initiate_upload_v2_s3_missing", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		return nil, err
+	}
+
+	existing, err := b.store.GetUploadByPath(ctx, path)
+	if err == nil && existing != nil {
+		metrics.RecordOperation("backend", "initiate_upload_v2", "conflict", time.Since(start))
+		return nil, datastore.ErrUploadConflict
+	}
+
+	partSize := s3client.CalcAdaptivePartSize(totalSize)
+	parts := s3client.CalcParts(totalSize, partSize)
+
+	fileID := b.genID()
+	s3Key := "blobs/" + fileID
+
+	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key)
+	if err != nil {
+		logger.Error(ctx, "backend_initiate_upload_v2_create_multipart_failed", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		return nil, fmt.Errorf("create multipart upload: %w", err)
+	}
+
+	now := time.Now()
+	uploadID := b.genID()
+	expiresAt := now.Add(24 * time.Hour)
+
+	if err := b.store.InsertFile(ctx, &datastore.File{
+		FileID:      fileID,
+		StorageType: datastore.StorageS3,
+		StorageRef:  s3Key,
+		SizeBytes:   totalSize,
+		Revision:    1,
+		Status:      datastore.StatusPending,
+		CreatedAt:   now,
+	}); err != nil {
+		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
+		logger.Error(ctx, "backend_initiate_upload_v2_insert_file_failed", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		return nil, err
+	}
+
+	if err := b.store.InsertUpload(ctx, &datastore.Upload{
+		UploadID:   uploadID,
+		FileID:     fileID,
+		TargetPath: path,
+		S3UploadID: mpu.UploadID,
+		S3Key:      s3Key,
+		TotalSize:  totalSize,
+		PartSize:   partSize,
+		PartsTotal: len(parts),
+		Status:     datastore.UploadUploading,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+		ExpiresAt:  expiresAt,
+	}); err != nil {
+		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
+		logger.Error(ctx, "backend_initiate_upload_v2_insert_upload_failed", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		return nil, err
+	}
+	metrics.RecordOperation("backend", "initiate_upload_v2", "ok", time.Since(start))
+
+	return &UploadPlanV2{
+		UploadID:   uploadID,
+		Key:        s3Key,
+		PartSize:   partSize,
+		TotalParts: len(parts),
+		ExpiresAt:  expiresAt.Format(time.RFC3339),
+	}, nil
+}
+
+// PresignPart presigns a single part URL for an active upload.
+func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumber int) (*s3client.UploadPartURL, error) {
+	start := time.Now()
+
+	upload, err := b.store.GetUpload(ctx, uploadID)
+	if err != nil {
+		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
+		return nil, err
+	}
+	if upload.Status != datastore.UploadUploading {
+		metrics.RecordOperation("backend", "presign_part", "not_active", time.Since(start))
+		return nil, datastore.ErrUploadNotActive
+	}
+	if partNumber < 1 || partNumber > upload.PartsTotal {
+		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
+		return nil, fmt.Errorf("invalid part number %d: must be between 1 and %d", partNumber, upload.PartsTotal)
+	}
+
+	parts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
+	partSize := parts[partNumber-1].Size
+
+	u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, partNumber, partSize, "", s3client.UploadTTL)
+	if err != nil {
+		logger.Error(ctx, "backend_presign_part_failed", zap.String("upload_id", uploadID), zap.Int("part_number", partNumber), zap.Error(err))
+		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
+		return nil, fmt.Errorf("presign part %d: %w", partNumber, err)
+	}
+	metrics.RecordOperation("backend", "presign_part", "ok", time.Since(start))
+	return u, nil
+}
+
+// PresignParts presigns multiple part URLs for an active upload.
+func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, partNumbers []int) ([]*s3client.UploadPartURL, error) {
+	start := time.Now()
+
+	upload, err := b.store.GetUpload(ctx, uploadID)
+	if err != nil {
+		metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+		return nil, err
+	}
+	if upload.Status != datastore.UploadUploading {
+		metrics.RecordOperation("backend", "presign_parts", "not_active", time.Since(start))
+		return nil, datastore.ErrUploadNotActive
+	}
+
+	parts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
+
+	urls := make([]*s3client.UploadPartURL, len(partNumbers))
+	for i, pn := range partNumbers {
+		if pn < 1 || pn > upload.PartsTotal {
+			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+			return nil, fmt.Errorf("invalid part number %d: must be between 1 and %d", pn, upload.PartsTotal)
+		}
+		partSize := parts[pn-1].Size
+		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, pn, partSize, "", s3client.UploadTTL)
+		if err != nil {
+			logger.Error(ctx, "backend_presign_parts_failed", zap.String("upload_id", uploadID), zap.Int("part_number", pn), zap.Error(err))
+			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+			return nil, fmt.Errorf("presign part %d: %w", pn, err)
+		}
+		urls[i] = u
+	}
+	metrics.RecordOperation("backend", "presign_parts", "ok", time.Since(start))
+	return urls, nil
 }
 
 // ConfirmUpload completes the multipart upload and creates the file node.

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -23,15 +23,21 @@ type UploadPlan struct {
 	Parts    []*s3client.UploadPartURL `json:"parts"`
 }
 
+// ChecksumContract describes the checksum capabilities for v2 uploads.
+type ChecksumContract struct {
+	Supported []string `json:"supported"`
+	Required  bool     `json:"required"`
+}
+
 // UploadPlanV2 is returned by InitiateUploadV2 — no presigned URLs.
 type UploadPlanV2 struct {
-	UploadID         string `json:"upload_id"`
-	Key              string `json:"key"`
-	PartSize         int64  `json:"part_size"`
-	TotalParts       int    `json:"total_parts"`
-	ExpiresAt        string `json:"expires_at"`
-	Resumable        bool   `json:"resumable"`
-	ChecksumContract string `json:"checksum_contract"`
+	UploadID         string           `json:"upload_id"`
+	Key              string           `json:"key"`
+	PartSize         int64            `json:"part_size"`
+	TotalParts       int              `json:"total_parts"`
+	ExpiresAt        string           `json:"expires_at"`
+	Resumable        bool             `json:"resumable"`
+	ChecksumContract ChecksumContract `json:"checksum_contract"`
 }
 
 // MaxMultipartParts is the S3 hard limit on parts per multipart upload.
@@ -39,6 +45,18 @@ const MaxMultipartParts = 10000
 
 // MaxPresignBatch is the maximum number of parts that can be presigned in a single batch request.
 const MaxPresignBatch = 500
+
+// PresignChecksum is an optional checksum for a presign request (algorithm-neutral wire format).
+type PresignChecksum struct {
+	Algorithm string `json:"algorithm"`
+	Value     string `json:"value"`
+}
+
+// PresignPartEntry is a single entry in a batch presign request.
+type PresignPartEntry struct {
+	PartNumber int              `json:"part_number"`
+	Checksum   *PresignChecksum `json:"checksum,omitempty"`
+}
 
 var ErrPartChecksumCountMismatch = errors.New("part checksum count mismatch")
 
@@ -254,13 +272,29 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 		TotalParts:       len(parts),
 		ExpiresAt:        expiresAt.Format(time.RFC3339),
 		Resumable:        false,
-		ChecksumContract: "none",
+		ChecksumContract: ChecksumContract{
+			Supported: []string{"crc32c"},
+			Required:  false,
+		},
 	}, nil
+}
+
+// resolveChecksumSHA256 extracts the SHA-256 value from an optional checksum.
+// Phase 1 only supports SHA-256 pass-through; other algorithms are accepted
+// but ignored (the presigned URL won't include a checksum header for them).
+func resolveChecksumSHA256(cs *PresignChecksum) string {
+	if cs == nil || cs.Value == "" {
+		return ""
+	}
+	if cs.Algorithm == "sha256" || cs.Algorithm == "SHA256" || cs.Algorithm == "SHA-256" {
+		return cs.Value
+	}
+	return ""
 }
 
 // PresignPart presigns a single part URL for an active upload.
 // Transitions INITIATED → UPLOADING on first presign.
-func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumber int) (*s3client.UploadPartURL, error) {
+func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumber int, checksum *PresignChecksum) (*s3client.UploadPartURL, error) {
 	start := time.Now()
 
 	upload, err := b.store.GetUpload(ctx, uploadID)
@@ -292,7 +326,8 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 	parts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	partSize := parts[partNumber-1].Size
 
-	u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, partNumber, partSize, "", s3client.UploadTTL)
+	checksumSHA256 := resolveChecksumSHA256(checksum)
+	u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, partNumber, partSize, checksumSHA256, s3client.UploadTTL)
 	if err != nil {
 		logger.Error(ctx, "backend_presign_part_failed", zap.String("upload_id", uploadID), zap.Int("part_number", partNumber), zap.Error(err))
 		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
@@ -304,7 +339,7 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 
 // PresignParts presigns multiple part URLs for an active upload.
 // Transitions INITIATED → UPLOADING on first presign.
-func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, partNumbers []int) ([]*s3client.UploadPartURL, error) {
+func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries []PresignPartEntry) ([]*s3client.UploadPartURL, error) {
 	start := time.Now()
 
 	upload, err := b.store.GetUpload(ctx, uploadID)
@@ -321,18 +356,18 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, partNum
 		metrics.RecordOperation("backend", "presign_parts", "expired", time.Since(start))
 		return nil, datastore.ErrUploadExpired
 	}
-	if len(partNumbers) > MaxPresignBatch {
+	if len(entries) > MaxPresignBatch {
 		metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
-		return nil, fmt.Errorf("batch too large: %d parts exceeds limit of %d", len(partNumbers), MaxPresignBatch)
+		return nil, fmt.Errorf("batch too large: %d parts exceeds limit of %d", len(entries), MaxPresignBatch)
 	}
 	// Reject duplicate part numbers in the batch.
-	seen := make(map[int]bool, len(partNumbers))
-	for _, pn := range partNumbers {
-		if seen[pn] {
+	seen := make(map[int]bool, len(entries))
+	for _, e := range entries {
+		if seen[e.PartNumber] {
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
-			return nil, fmt.Errorf("duplicate part number %d in batch", pn)
+			return nil, fmt.Errorf("duplicate part number %d in batch", e.PartNumber)
 		}
-		seen[pn] = true
+		seen[e.PartNumber] = true
 	}
 	if upload.Status == datastore.UploadInitiated {
 		if err := b.store.UpdateUploadStatus(ctx, uploadID, datastore.UploadUploading); err != nil {
@@ -344,14 +379,16 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, partNum
 
 	parts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 
-	urls := make([]*s3client.UploadPartURL, len(partNumbers))
-	for i, pn := range partNumbers {
+	urls := make([]*s3client.UploadPartURL, len(entries))
+	for i, e := range entries {
+		pn := e.PartNumber
 		if pn < 1 || pn > upload.PartsTotal {
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
 			return nil, fmt.Errorf("invalid part number %d: must be between 1 and %d", pn, upload.PartsTotal)
 		}
 		partSize := parts[pn-1].Size
-		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, pn, partSize, "", s3client.UploadTTL)
+		checksumSHA256 := resolveChecksumSHA256(e.Checksum)
+		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, pn, partSize, checksumSHA256, s3client.UploadTTL)
 		if err != nil {
 			logger.Error(ctx, "backend_presign_parts_failed", zap.String("upload_id", uploadID), zap.Int("part_number", pn), zap.Error(err))
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -624,6 +624,7 @@ func (b *Dat9Backend) AbortUpload(ctx context.Context, uploadID string) error {
 }
 
 // AbortUploadV2 cancels an upload (idempotent — returns nil for not-found or already-aborted).
+// Cleans up: aborts S3 multipart, marks upload ABORTED, marks pending file DELETED.
 func (b *Dat9Backend) AbortUploadV2(ctx context.Context, uploadID string) error {
 	start := time.Now()
 	upload, err := b.store.GetUpload(ctx, uploadID)
@@ -647,6 +648,12 @@ func (b *Dat9Backend) AbortUploadV2(ctx context.Context, uploadID string) error 
 		logger.Error(ctx, "backend_abort_upload_v2_store_failed", zap.String("upload_id", uploadID), zap.Error(err))
 		metrics.RecordOperation("backend", "abort_upload_v2", "error", time.Since(start))
 		return err
+	}
+	// Clean up the pending file row created at initiate time.
+	if upload.FileID != "" {
+		if err := b.store.MarkFileDeleted(ctx, upload.FileID); err != nil {
+			logger.Warn(ctx, "backend_abort_upload_v2_mark_file_deleted_failed", zap.String("upload_id", uploadID), zap.String("file_id", upload.FileID), zap.Error(err))
+		}
 	}
 	metrics.RecordOperation("backend", "abort_upload_v2", "ok", time.Since(start))
 	return nil

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/mem9-ai/dat9/internal/testmysql"
@@ -253,5 +255,311 @@ func TestOneUploadPerPath(t *testing.T) {
 	_, err = b.InitiateUpload(ctx, "/dup.bin", 3<<20)
 	if err == nil {
 		t.Error("expected error for duplicate active upload")
+	}
+}
+
+// --- v2 presign tests (T2) ---
+
+func TestInitiateUploadV2(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	totalSize := int64(100 << 20) // 100 MB
+	plan, err := b.InitiateUploadV2(ctx, "/v2-test.bin", totalSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.UploadID == "" || plan.Key == "" {
+		t.Fatalf("empty plan: %+v", plan)
+	}
+	if plan.TotalParts == 0 {
+		t.Fatal("expected total_parts > 0")
+	}
+	if plan.PartSize < s3client.MinPartSize {
+		t.Errorf("part_size %d below minimum %d", plan.PartSize, s3client.MinPartSize)
+	}
+	if plan.Resumable {
+		t.Error("expected resumable=false for phase 1")
+	}
+	if plan.ChecksumContract != "none" {
+		t.Errorf("expected checksum_contract=none, got %s", plan.ChecksumContract)
+	}
+
+	// Verify upload starts in INITIATED status
+	upload, err := b.GetUpload(ctx, plan.UploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if upload.Status != datastore.UploadInitiated {
+		t.Errorf("expected INITIATED, got %s", upload.Status)
+	}
+	if upload.PartSize != plan.PartSize {
+		t.Errorf("stored part_size %d != plan part_size %d", upload.PartSize, plan.PartSize)
+	}
+}
+
+func TestPresignPartSingle(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	plan, err := b.InitiateUploadV2(ctx, "/presign-single.bin", 20<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid part number
+	u, err := b.PresignPart(ctx, plan.UploadID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.URL == "" {
+		t.Error("expected non-empty presigned URL")
+	}
+	if u.Number != 1 {
+		t.Errorf("expected part number 1, got %d", u.Number)
+	}
+
+	// After first presign, status should be UPLOADING
+	upload, _ := b.GetUpload(ctx, plan.UploadID)
+	if upload.Status != datastore.UploadUploading {
+		t.Errorf("expected UPLOADING after first presign, got %s", upload.Status)
+	}
+
+	// Invalid part number: 0
+	if _, err := b.PresignPart(ctx, plan.UploadID, 0); err == nil {
+		t.Error("expected error for part_number=0")
+	}
+
+	// Invalid part number: too large
+	if _, err := b.PresignPart(ctx, plan.UploadID, plan.TotalParts+1); err == nil {
+		t.Error("expected error for part_number > total_parts")
+	}
+
+	// Last valid part
+	u, err = b.PresignPart(ctx, plan.UploadID, plan.TotalParts)
+	if err != nil {
+		t.Fatalf("presign last part: %v", err)
+	}
+	if u.Number != plan.TotalParts {
+		t.Errorf("expected part number %d, got %d", plan.TotalParts, u.Number)
+	}
+}
+
+func TestPresignPartsBatch(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	plan, err := b.InitiateUploadV2(ctx, "/presign-batch.bin", 50<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Presign parts 1, 2, 3
+	urls, err := b.PresignParts(ctx, plan.UploadID, []int{1, 2, 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(urls) != 3 {
+		t.Fatalf("expected 3 urls, got %d", len(urls))
+	}
+	for i, u := range urls {
+		if u.URL == "" {
+			t.Errorf("part %d: empty URL", i+1)
+		}
+	}
+
+	// Verify status transitioned
+	upload, _ := b.GetUpload(ctx, plan.UploadID)
+	if upload.Status != datastore.UploadUploading {
+		t.Errorf("expected UPLOADING, got %s", upload.Status)
+	}
+}
+
+func TestPresignBatchDuplicateRejected(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	plan, err := b.InitiateUploadV2(ctx, "/presign-dup.bin", 50<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = b.PresignParts(ctx, plan.UploadID, []int{1, 2, 1})
+	if err == nil {
+		t.Fatal("expected error for duplicate part numbers")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("expected duplicate error, got: %v", err)
+	}
+}
+
+func TestPresignBatchLimitExceeded(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	// Need a large enough file for >500 parts
+	// With 8 MiB default part size, 500*8MiB = 4 GiB → use a file that yields >500 parts
+	totalSize := int64(5000 << 20) // 5000 MB ≈ ~625 parts at 8 MiB each
+	plan, err := b.InitiateUploadV2(ctx, "/presign-limit.bin", totalSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a batch of 501 parts
+	parts := make([]int, MaxPresignBatch+1)
+	for i := range parts {
+		parts[i] = i + 1
+	}
+	// Ensure we don't exceed total parts
+	if parts[len(parts)-1] > plan.TotalParts {
+		t.Skipf("not enough parts (%d) to test batch limit", plan.TotalParts)
+	}
+
+	_, err = b.PresignParts(ctx, plan.UploadID, parts)
+	if err == nil {
+		t.Fatal("expected error for batch > MaxPresignBatch")
+	}
+	if !strings.Contains(err.Error(), "batch too large") {
+		t.Errorf("expected batch too large error, got: %v", err)
+	}
+}
+
+func TestPresignAfterAbortFails(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	plan, err := b.InitiateUploadV2(ctx, "/presign-abort.bin", 20<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.AbortUploadV2(ctx, plan.UploadID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Single presign should fail
+	_, err = b.PresignPart(ctx, plan.UploadID, 1)
+	if err == nil {
+		t.Error("expected error presigning after abort")
+	}
+
+	// Batch presign should fail
+	_, err = b.PresignParts(ctx, plan.UploadID, []int{1, 2})
+	if err == nil {
+		t.Error("expected error batch presigning after abort")
+	}
+}
+
+func TestPresignExpiredUpload(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	plan, err := b.InitiateUploadV2(ctx, "/presign-expired.bin", 20<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually expire the upload by setting expires_at to the past
+	_, err = b.store.DB().ExecContext(ctx, `UPDATE uploads SET expires_at = ? WHERE upload_id = ?`,
+		time.Now().Add(-1*time.Hour), plan.UploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Single presign should fail with expired error
+	_, err = b.PresignPart(ctx, plan.UploadID, 1)
+	if err == nil {
+		t.Fatal("expected error for expired upload")
+	}
+	if err != datastore.ErrUploadExpired {
+		t.Errorf("expected ErrUploadExpired, got: %v", err)
+	}
+
+	// Batch presign on a new expired upload
+	plan2, err := b.InitiateUploadV2(ctx, "/presign-expired2.bin", 20<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.store.DB().ExecContext(ctx, `UPDATE uploads SET expires_at = ? WHERE upload_id = ?`,
+		time.Now().Add(-1*time.Hour), plan2.UploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.PresignParts(ctx, plan2.UploadID, []int{1})
+	if err == nil {
+		t.Fatal("expected error for expired upload batch")
+	}
+	if err != datastore.ErrUploadExpired {
+		t.Errorf("expected ErrUploadExpired, got: %v", err)
+	}
+}
+
+func TestV2FullUploadFlow(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	totalSize := int64(20 << 20) // 20 MB
+	plan, err := b.InitiateUploadV2(ctx, "/v2-full.bin", totalSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Status starts as INITIATED
+	upload, _ := b.GetUpload(ctx, plan.UploadID)
+	if upload.Status != datastore.UploadInitiated {
+		t.Fatalf("expected INITIATED, got %s", upload.Status)
+	}
+
+	// Presign all parts
+	partNums := make([]int, plan.TotalParts)
+	for i := range partNums {
+		partNums[i] = i + 1
+	}
+	urls, err := b.PresignParts(ctx, plan.UploadID, partNums)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Status should now be UPLOADING
+	upload, _ = b.GetUpload(ctx, plan.UploadID)
+	if upload.Status != datastore.UploadUploading {
+		t.Fatalf("expected UPLOADING, got %s", upload.Status)
+	}
+
+	// Upload all parts via S3 client
+	partData := make([]byte, totalSize)
+	for i := range partData {
+		partData[i] = byte(i % 256)
+	}
+	for _, u := range urls {
+		start := int64(u.Number-1) * upload.PartSize
+		end := start + u.Size
+		if end > totalSize {
+			end = totalSize
+		}
+		_, err := b.S3().(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, u.Number, bytes.NewReader(partData[start:end]))
+		if err != nil {
+			t.Fatalf("upload part %d: %v", u.Number, err)
+		}
+	}
+
+	// Confirm upload
+	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify completed
+	upload, _ = b.GetUpload(ctx, plan.UploadID)
+	if upload.Status != datastore.UploadCompleted {
+		t.Errorf("expected COMPLETED, got %s", upload.Status)
+	}
+
+	// Verify file node
+	info, err := b.Stat("/v2-full.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size != totalSize {
+		t.Errorf("expected size %d, got %d", totalSize, info.Size)
 	}
 }

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -14,6 +14,15 @@ import (
 	"github.com/mem9-ai/dat9/pkg/s3client"
 )
 
+// entriesFromInts converts a slice of part numbers to PresignPartEntry slice (no checksums).
+func entriesFromInts(nums []int) []PresignPartEntry {
+	entries := make([]PresignPartEntry, len(nums))
+	for i, n := range nums {
+		entries[i] = PresignPartEntry{PartNumber: n}
+	}
+	return entries
+}
+
 func newTestBackendWithS3(t *testing.T) *Dat9Backend {
 	t.Helper()
 	s3Dir, err := os.MkdirTemp("", "dat9-s3-*")
@@ -281,8 +290,11 @@ func TestInitiateUploadV2(t *testing.T) {
 	if plan.Resumable {
 		t.Error("expected resumable=false for phase 1")
 	}
-	if plan.ChecksumContract != "none" {
-		t.Errorf("expected checksum_contract=none, got %s", plan.ChecksumContract)
+	if plan.ChecksumContract.Required {
+		t.Error("expected checksum_contract.required=false for phase 1")
+	}
+	if len(plan.ChecksumContract.Supported) == 0 {
+		t.Error("expected checksum_contract.supported to be non-empty")
 	}
 
 	// Verify upload starts in INITIATED status
@@ -308,7 +320,7 @@ func TestPresignPartSingle(t *testing.T) {
 	}
 
 	// Valid part number
-	u, err := b.PresignPart(ctx, plan.UploadID, 1)
+	u, err := b.PresignPart(ctx, plan.UploadID, 1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,17 +338,17 @@ func TestPresignPartSingle(t *testing.T) {
 	}
 
 	// Invalid part number: 0
-	if _, err := b.PresignPart(ctx, plan.UploadID, 0); err == nil {
+	if _, err := b.PresignPart(ctx, plan.UploadID, 0, nil); err == nil {
 		t.Error("expected error for part_number=0")
 	}
 
 	// Invalid part number: too large
-	if _, err := b.PresignPart(ctx, plan.UploadID, plan.TotalParts+1); err == nil {
+	if _, err := b.PresignPart(ctx, plan.UploadID, plan.TotalParts+1, nil); err == nil {
 		t.Error("expected error for part_number > total_parts")
 	}
 
 	// Last valid part
-	u, err = b.PresignPart(ctx, plan.UploadID, plan.TotalParts)
+	u, err = b.PresignPart(ctx, plan.UploadID, plan.TotalParts, nil)
 	if err != nil {
 		t.Fatalf("presign last part: %v", err)
 	}
@@ -355,7 +367,7 @@ func TestPresignPartsBatch(t *testing.T) {
 	}
 
 	// Presign parts 1, 2, 3
-	urls, err := b.PresignParts(ctx, plan.UploadID, []int{1, 2, 3})
+	urls, err := b.PresignParts(ctx, plan.UploadID, entriesFromInts([]int{1, 2, 3}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -384,7 +396,7 @@ func TestPresignBatchDuplicateRejected(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = b.PresignParts(ctx, plan.UploadID, []int{1, 2, 1})
+	_, err = b.PresignParts(ctx, plan.UploadID, entriesFromInts([]int{1, 2, 1}))
 	if err == nil {
 		t.Fatal("expected error for duplicate part numbers")
 	}
@@ -415,7 +427,7 @@ func TestPresignBatchLimitExceeded(t *testing.T) {
 		t.Skipf("not enough parts (%d) to test batch limit", plan.TotalParts)
 	}
 
-	_, err = b.PresignParts(ctx, plan.UploadID, parts)
+	_, err = b.PresignParts(ctx, plan.UploadID, entriesFromInts(parts))
 	if err == nil {
 		t.Fatal("expected error for batch > MaxPresignBatch")
 	}
@@ -438,13 +450,13 @@ func TestPresignAfterAbortFails(t *testing.T) {
 	}
 
 	// Single presign should fail
-	_, err = b.PresignPart(ctx, plan.UploadID, 1)
+	_, err = b.PresignPart(ctx, plan.UploadID, 1, nil)
 	if err == nil {
 		t.Error("expected error presigning after abort")
 	}
 
 	// Batch presign should fail
-	_, err = b.PresignParts(ctx, plan.UploadID, []int{1, 2})
+	_, err = b.PresignParts(ctx, plan.UploadID, entriesFromInts([]int{1, 2}))
 	if err == nil {
 		t.Error("expected error batch presigning after abort")
 	}
@@ -467,7 +479,7 @@ func TestPresignExpiredUpload(t *testing.T) {
 	}
 
 	// Single presign should fail with expired error
-	_, err = b.PresignPart(ctx, plan.UploadID, 1)
+	_, err = b.PresignPart(ctx, plan.UploadID, 1, nil)
 	if err == nil {
 		t.Fatal("expected error for expired upload")
 	}
@@ -485,7 +497,7 @@ func TestPresignExpiredUpload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.PresignParts(ctx, plan2.UploadID, []int{1})
+	_, err = b.PresignParts(ctx, plan2.UploadID, entriesFromInts([]int{1}))
 	if err == nil {
 		t.Fatal("expected error for expired upload batch")
 	}
@@ -515,7 +527,7 @@ func TestV2FullUploadFlow(t *testing.T) {
 	for i := range partNums {
 		partNums[i] = i + 1
 	}
-	urls, err := b.PresignParts(ctx, plan.UploadID, partNums)
+	urls, err := b.PresignParts(ctx, plan.UploadID, entriesFromInts(partNums))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -581,7 +593,7 @@ func TestV2CompleteETagMismatch(t *testing.T) {
 	for i := range partNums {
 		partNums[i] = i + 1
 	}
-	urls, err := b.PresignParts(ctx, plan.UploadID, partNums)
+	urls, err := b.PresignParts(ctx, plan.UploadID, entriesFromInts(partNums))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -624,7 +636,7 @@ func TestV2CompletePartCountMismatch(t *testing.T) {
 	}
 
 	// Transition to UPLOADING
-	if _, err := b.PresignPart(ctx, plan.UploadID, 1); err != nil {
+	if _, err := b.PresignPart(ctx, plan.UploadID, 1, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -138,7 +138,7 @@ func TestInitiateAndConfirmUpload(t *testing.T) {
 	}
 
 	for _, p := range plan.Parts {
-		start := int64(p.Number-1) * s3client.PartSize
+		start := int64(p.Number-1) * plan.PartSize
 		end := start + p.Size
 		if end > totalSize {
 			end = totalSize
@@ -193,7 +193,7 @@ func TestResumeUpload(t *testing.T) {
 	upload, _ := b.GetUpload(ctx, plan.UploadID)
 
 	// Upload only part 1 (simulate partial upload)
-	data := make([]byte, s3client.PartSize)
+	data := make([]byte, upload.PartSize)
 	if _, err := b.S3().(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, 1, bytes.NewReader(data)); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -526,25 +526,27 @@ func TestV2FullUploadFlow(t *testing.T) {
 		t.Fatalf("expected UPLOADING, got %s", upload.Status)
 	}
 
-	// Upload all parts via S3 client
+	// Upload all parts via S3 client, collecting ETags for v2 complete
 	partData := make([]byte, totalSize)
 	for i := range partData {
 		partData[i] = byte(i % 256)
 	}
-	for _, u := range urls {
+	completeParts := make([]CompletePart, len(urls))
+	for i, u := range urls {
 		start := int64(u.Number-1) * upload.PartSize
 		end := start + u.Size
 		if end > totalSize {
 			end = totalSize
 		}
-		_, err := b.S3().(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, u.Number, bytes.NewReader(partData[start:end]))
+		etag, err := b.S3().(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, u.Number, bytes.NewReader(partData[start:end]))
 		if err != nil {
 			t.Fatalf("upload part %d: %v", u.Number, err)
 		}
+		completeParts[i] = CompletePart{Number: u.Number, ETag: etag}
 	}
 
-	// Confirm upload
-	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
+	// Confirm upload via v2 (with client-supplied parts)
+	if err := b.ConfirmUploadV2(ctx, plan.UploadID, completeParts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -561,5 +563,77 @@ func TestV2FullUploadFlow(t *testing.T) {
 	}
 	if info.Size != totalSize {
 		t.Errorf("expected size %d, got %d", totalSize, info.Size)
+	}
+}
+
+func TestV2CompleteETagMismatch(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	totalSize := int64(20 << 20)
+	plan, err := b.InitiateUploadV2(ctx, "/v2-etag-mismatch.bin", totalSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Presign and upload all parts
+	partNums := make([]int, plan.TotalParts)
+	for i := range partNums {
+		partNums[i] = i + 1
+	}
+	urls, err := b.PresignParts(ctx, plan.UploadID, partNums)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	upload, _ := b.GetUpload(ctx, plan.UploadID)
+	partData := make([]byte, totalSize)
+	completeParts := make([]CompletePart, len(urls))
+	for i, u := range urls {
+		start := int64(u.Number-1) * upload.PartSize
+		end := start + u.Size
+		if end > totalSize {
+			end = totalSize
+		}
+		etag, err := b.S3().(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, u.Number, bytes.NewReader(partData[start:end]))
+		if err != nil {
+			t.Fatalf("upload part %d: %v", u.Number, err)
+		}
+		completeParts[i] = CompletePart{Number: u.Number, ETag: etag}
+	}
+
+	// Tamper with the first part's ETag
+	completeParts[0].ETag = "bad-etag"
+
+	err = b.ConfirmUploadV2(ctx, plan.UploadID, completeParts)
+	if err == nil {
+		t.Fatal("expected error for ETag mismatch")
+	}
+	if !strings.Contains(err.Error(), "ETag mismatch") {
+		t.Errorf("expected ETag mismatch error, got: %v", err)
+	}
+}
+
+func TestV2CompletePartCountMismatch(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	plan, err := b.InitiateUploadV2(ctx, "/v2-partcount.bin", 20<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Transition to UPLOADING
+	if _, err := b.PresignPart(ctx, plan.UploadID, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to complete with wrong number of parts
+	err = b.ConfirmUploadV2(ctx, plan.UploadID, []CompletePart{{Number: 1, ETag: "x"}})
+	if err == nil {
+		t.Fatal("expected error for part count mismatch")
+	}
+	if !strings.Contains(err.Error(), "part count mismatch") {
+		t.Errorf("expected part count mismatch error, got: %v", err)
 	}
 }

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -32,6 +32,19 @@ type PatchPartURL struct {
 	ReadHeaders map[string]string `json:"read_headers,omitempty"`
 }
 
+type patchOptions struct {
+	partSize int64
+}
+
+// PatchOption configures a PatchFile call.
+type PatchOption func(*patchOptions)
+
+// WithPartSize tells the server which part boundary the client used for
+// dirty-part tracking. If omitted the server picks adaptively.
+func WithPartSize(ps int64) PatchOption {
+	return func(o *patchOptions) { o.partSize = ps }
+}
+
 // PatchFile performs a partial update of a large file using S3 UploadPartCopy
 // for unchanged parts. Only the dirty parts are transferred over the network.
 //
@@ -44,12 +57,21 @@ type PatchPartURL struct {
 //     and the original data for that part (downloaded from ReadURL; nil if the
 //     part is entirely new beyond the original file). It must return the final
 //     part data to upload.
-func (c *Client) PatchFile(ctx context.Context, path string, newSize int64, dirtyParts []int, readPart func(partNumber int, partSize int64, origData []byte) ([]byte, error), progress ProgressFunc) error {
+func (c *Client) PatchFile(ctx context.Context, path string, newSize int64, dirtyParts []int, readPart func(partNumber int, partSize int64, origData []byte) ([]byte, error), progress ProgressFunc, opts ...PatchOption) error {
+	var po patchOptions
+	for _, o := range opts {
+		o(&po)
+	}
+
 	// Step 1: Request patch plan from server
-	reqBody, err := json.Marshal(map[string]any{
+	patchReq := map[string]any{
 		"new_size":    newSize,
 		"dirty_parts": dirtyParts,
-	})
+	}
+	if po.partSize > 0 {
+		patchReq["part_size"] = po.partSize
+	}
+	reqBody, err := json.Marshal(patchReq)
 	if err != nil {
 		return fmt.Errorf("marshal patch request: %w", err)
 	}

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -178,12 +178,17 @@ func (c *Client) writeStreamV2(ctx context.Context, path string, ra io.ReaderAt,
 	// Upload parts, collecting ETags for the complete call.
 	parts, err := c.uploadPartsV2(ctx, plan, ra, presignCh, presignErrCh, progress)
 	if err != nil {
-		// Best-effort abort
 		_ = c.abortUploadV2(context.Background(), plan.UploadID)
 		return err
 	}
 
-	return c.completeUploadV2(ctx, plan.UploadID, parts)
+	if err := c.completeUploadV2(ctx, plan.UploadID, parts); err != nil {
+		// Complete failed (network error, 5xx, 409, 410) — best-effort abort
+		// to avoid leaving orphaned multipart uploads / upload rows.
+		_ = c.abortUploadV2(context.Background(), plan.UploadID)
+		return err
+	}
+	return nil
 }
 
 type uploadInitiateRequest struct {

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/mem9-ai/dat9/pkg/s3client"
 )
@@ -31,6 +32,40 @@ type PartURL struct {
 	ChecksumSHA256 string            `json:"checksum_sha256,omitempty"`
 	Headers        map[string]string `json:"headers,omitempty"`
 	ExpiresAt      string            `json:"expires_at"`
+}
+
+// --- v2 upload types (on-demand presign, no upfront checksum) ---
+
+// uploadPlanV2 mirrors the server's UploadPlanV2 response.
+type uploadPlanV2 struct {
+	UploadID         string           `json:"upload_id"`
+	Key              string           `json:"key"`
+	PartSize         int64            `json:"part_size"`
+	TotalParts       int              `json:"total_parts"`
+	ExpiresAt        string           `json:"expires_at"`
+	Resumable        bool             `json:"resumable"`
+	ChecksumContract checksumContract `json:"checksum_contract"`
+}
+
+type checksumContract struct {
+	Supported []string `json:"supported"`
+	Required  bool     `json:"required"`
+}
+
+// presignedPart is a presigned URL received from the v2 presign-batch endpoint.
+type presignedPart struct {
+	Number         int               `json:"number"`
+	URL            string            `json:"url"`
+	Size           int64             `json:"size"`
+	ChecksumSHA256 string            `json:"checksum_sha256,omitempty"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	ExpiresAt      time.Time         `json:"expires_at"`
+}
+
+// completePart is sent to the v2 complete endpoint.
+type completePart struct {
+	Number int    `json:"number"`
+	ETag   string `json:"etag"`
 }
 
 // ProgressFunc is called after each part upload completes.
@@ -73,8 +108,8 @@ func checksumParallelism(partSize int64, partCount int) int {
 }
 
 // WriteStream uploads data from a reader. For small files (size < threshold),
-// it does a direct PUT with body. For large files, it sends a Content-Length-only
-// PUT to get a 202 with presigned URLs, then uploads parts concurrently.
+// it does a direct PUT with body. For large files, it tries the v2 protocol
+// (on-demand presign, no upfront checksum) first, falling back to v1 on 404.
 func (c *Client) WriteStream(ctx context.Context, path string, r io.Reader, size int64, progress ProgressFunc) error {
 	threshold := int64(DefaultSmallFileThreshold)
 	if c.smallFileThreshold > 0 {
@@ -90,8 +125,24 @@ func (c *Client) WriteStream(ctx context.Context, path string, r io.Reader, size
 	}
 	ra, ok := r.(io.ReaderAt)
 	if !ok {
-		return fmt.Errorf("large uploads require an io.ReaderAt (seekable source) to compute per-part checksums")
+		return fmt.Errorf("large uploads require an io.ReaderAt (seekable source)")
 	}
+
+	// Try v2 protocol first (on-demand presign, no checksum pre-computation).
+	err := c.writeStreamV2(ctx, path, ra, size, progress)
+	if err == errV2NotAvailable {
+		// Server doesn't support v2 — fall back to v1.
+		return c.writeStreamV1(ctx, path, ra, size, progress)
+	}
+	return err
+}
+
+// errV2NotAvailable is a sentinel indicating the server returned 404 for
+// the v2 initiate endpoint, so the caller should fall back to v1.
+var errV2NotAvailable = fmt.Errorf("v2 upload API not available")
+
+// writeStreamV1 is the original v1 upload path: pre-compute checksums → initiate → upload all.
+func (c *Client) writeStreamV1(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc) error {
 	checksums, err := computePartChecksumsFromReaderAt(ra, size, s3client.PartSize)
 	if err != nil {
 		return fmt.Errorf("compute part checksums: %w", err)
@@ -101,6 +152,38 @@ func (c *Client) WriteStream(ctx context.Context, path string, r io.Reader, size
 		return err
 	}
 	return c.uploadParts(ctx, plan, ra, progress)
+}
+
+// writeStreamV2 implements the v2 upload protocol:
+// 1. Initiate (no checksums, server returns part_size + total_parts)
+// 2. Pipelined presign: background goroutine fetches presigned URLs in batches
+// 3. Upload goroutines consume presigned URLs from channel
+// 4. Complete with part ETags, or abort on failure
+func (c *Client) writeStreamV2(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc) error {
+	plan, err := c.initiateUploadV2(ctx, path, size)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Pipelined presign: feed presigned URLs into a buffered channel.
+	parallelism := uploadParallelism(plan.PartSize)
+	presignCh := make(chan presignedPart, parallelism)
+	presignErrCh := make(chan error, 1)
+
+	go c.presignPipeline(ctx, plan, parallelism, presignCh, presignErrCh)
+
+	// Upload parts, collecting ETags for the complete call.
+	parts, err := c.uploadPartsV2(ctx, plan, ra, presignCh, presignErrCh, progress)
+	if err != nil {
+		// Best-effort abort
+		_ = c.abortUploadV2(context.Background(), plan.UploadID)
+		return err
+	}
+
+	return c.completeUploadV2(ctx, plan.UploadID, parts)
 }
 
 type uploadInitiateRequest struct {
@@ -325,6 +408,293 @@ func (c *Client) completeUpload(ctx context.Context, uploadID string) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode >= 300 {
+		return readError(resp)
+	}
+	return nil
+}
+
+// --- v2 upload methods ---
+
+// initiateUploadV2 calls POST /v2/uploads/initiate.
+// Returns errV2NotAvailable if the server responds with 404.
+func (c *Client) initiateUploadV2(ctx context.Context, path string, size int64) (*uploadPlanV2, error) {
+	body, err := json.Marshal(struct {
+		Path      string `json:"path"`
+		TotalSize int64  `json:"total_size"`
+	}{Path: path, TotalSize: size})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v2/uploads/initiate", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errV2NotAvailable
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		return nil, readError(resp)
+	}
+	var plan uploadPlanV2
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		return nil, fmt.Errorf("decode v2 upload plan: %w", err)
+	}
+	return &plan, nil
+}
+
+// presignPipeline runs in a background goroutine. It fetches presigned URLs
+// in batches via POST /v2/uploads/{id}/presign-batch and sends them to presignCh.
+// The channel is closed when all parts have been presigned or an error occurs.
+func (c *Client) presignPipeline(ctx context.Context, plan *uploadPlanV2, batchSize int, presignCh chan<- presignedPart, errCh chan<- error) {
+	defer close(presignCh)
+
+	for start := 1; start <= plan.TotalParts; start += batchSize {
+		end := start + batchSize - 1
+		if end > plan.TotalParts {
+			end = plan.TotalParts
+		}
+
+		// Build batch request (no checksums in phase 1)
+		entries := make([]struct {
+			PartNumber int `json:"part_number"`
+		}, 0, end-start+1)
+		for i := start; i <= end; i++ {
+			entries = append(entries, struct {
+				PartNumber int `json:"part_number"`
+			}{PartNumber: i})
+		}
+
+		body, err := json.Marshal(struct {
+			Parts any `json:"parts"`
+		}{Parts: entries})
+		if err != nil {
+			errCh <- fmt.Errorf("marshal presign batch: %w", err)
+			return
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			c.baseURL+"/v2/uploads/"+plan.UploadID+"/presign-batch", bytes.NewReader(body))
+		if err != nil {
+			errCh <- fmt.Errorf("create presign batch request: %w", err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.do(req)
+		if err != nil {
+			errCh <- fmt.Errorf("presign batch: %w", err)
+			return
+		}
+
+		if resp.StatusCode >= 300 {
+			err = readError(resp)
+			_ = resp.Body.Close()
+			errCh <- fmt.Errorf("presign batch HTTP %d: %w", resp.StatusCode, err)
+			return
+		}
+
+		var result struct {
+			Parts []presignedPart `json:"parts"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			_ = resp.Body.Close()
+			errCh <- fmt.Errorf("decode presign batch: %w", err)
+			return
+		}
+		_ = resp.Body.Close()
+
+		for _, p := range result.Parts {
+			select {
+			case presignCh <- p:
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+			}
+		}
+	}
+}
+
+// uploadPartsV2 reads presigned URLs from presignCh and uploads parts concurrently.
+// Returns the completed parts (number + etag) in order.
+func (c *Client) uploadPartsV2(ctx context.Context, plan *uploadPlanV2, ra io.ReaderAt,
+	presignCh <-chan presignedPart, presignErrCh <-chan error, progress ProgressFunc) ([]completePart, error) {
+
+	parallelism := uploadParallelism(plan.PartSize)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make([]completePart, plan.TotalParts)
+	errCh := make(chan error, 1)
+	sem := make(chan struct{}, parallelism)
+	var wg sync.WaitGroup
+
+	for pp := range presignCh {
+		// Check for presign pipeline errors
+		select {
+		case err := <-presignErrCh:
+			cancel()
+			wg.Wait()
+			return nil, fmt.Errorf("presign pipeline: %w", err)
+		default:
+		}
+
+		// Check for prior upload errors
+		select {
+		case err := <-errCh:
+			cancel()
+			wg.Wait()
+			return nil, err
+		default:
+		}
+
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return nil, ctx.Err()
+		}
+
+		wg.Add(1)
+		go func(p presignedPart) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			data := make([]byte, p.Size)
+			offset := int64(p.Number-1) * plan.PartSize
+			n, err := ra.ReadAt(data, offset)
+			if err != nil && err != io.EOF {
+				select {
+				case errCh <- fmt.Errorf("read part %d: %w", p.Number, err):
+				default:
+				}
+				cancel()
+				return
+			}
+			if int64(n) != p.Size {
+				select {
+				case errCh <- fmt.Errorf("short read for part %d: got %d want %d", p.Number, n, p.Size):
+				default:
+				}
+				cancel()
+				return
+			}
+
+			etag, err := c.uploadOnePartV2(ctx, p, data)
+			if err != nil {
+				select {
+				case errCh <- fmt.Errorf("part %d: %w", p.Number, err):
+				default:
+				}
+				cancel()
+				return
+			}
+
+			results[p.Number-1] = completePart{Number: p.Number, ETag: etag}
+
+			if progress != nil {
+				progress(p.Number, plan.TotalParts, int64(len(data)))
+			}
+		}(pp)
+	}
+
+	wg.Wait()
+
+	// Check for any remaining errors
+	select {
+	case err := <-presignErrCh:
+		return nil, fmt.Errorf("presign pipeline: %w", err)
+	default:
+	}
+	select {
+	case err := <-errCh:
+		return nil, err
+	default:
+	}
+
+	return results, nil
+}
+
+// uploadOnePartV2 PUTs data to a presigned URL and returns the ETag.
+// Unlike v1, no checksum header is sent (phase 1: required=false).
+func (c *Client) uploadOnePartV2(ctx context.Context, part presignedPart, data []byte) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, part.URL, bytes.NewReader(data))
+	if err != nil {
+		return "", err
+	}
+	for k, v := range part.Headers {
+		if strings.EqualFold(k, "host") {
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+	req.ContentLength = int64(len(data))
+
+	// Compute and send SHA-256 inline — S3 requires it for data integrity
+	// even though the v2 protocol doesn't mandate pre-computed checksums.
+	h := sha256.Sum256(data)
+	req.Header.Set("x-amz-checksum-sha256", base64.StdEncoding.EncodeToString(h[:]))
+
+	resp, err := c.httpClient.Do(req) // Direct to S3, no auth header
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	return resp.Header.Get("ETag"), nil
+}
+
+// completeUploadV2 sends the part list to POST /v2/uploads/{id}/complete.
+func (c *Client) completeUploadV2(ctx context.Context, uploadID string, parts []completePart) error {
+	body, err := json.Marshal(struct {
+		Parts []completePart `json:"parts"`
+	}{Parts: parts})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/v2/uploads/"+uploadID+"/complete", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		return readError(resp)
+	}
+	return nil
+}
+
+// abortUploadV2 sends POST /v2/uploads/{id}/abort.
+func (c *Client) abortUploadV2(ctx context.Context, uploadID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/v2/uploads/"+uploadID+"/abort", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return readError(resp)
 	}

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -588,6 +588,19 @@ func (c *Client) uploadPartsV2(ctx context.Context, plan *uploadPlanV2, ra io.Re
 			}
 
 			etag, err := c.uploadOnePartV2(ctx, p, data)
+			if err == errPresignExpired {
+				// Presigned URL expired — fetch a fresh one and retry once.
+				fresh, presignErr := c.presignOnePart(ctx, plan.UploadID, p.Number)
+				if presignErr != nil {
+					select {
+					case errCh <- fmt.Errorf("re-presign part %d: %w", p.Number, presignErr):
+					default:
+					}
+					cancel()
+					return
+				}
+				etag, err = c.uploadOnePartV2(ctx, *fresh, data)
+			}
 			if err != nil {
 				select {
 				case errCh <- fmt.Errorf("part %d: %w", p.Number, err):
@@ -622,8 +635,12 @@ func (c *Client) uploadPartsV2(ctx context.Context, plan *uploadPlanV2, ra io.Re
 	return results, nil
 }
 
+// errPresignExpired indicates S3 returned 403, likely due to an expired presigned URL.
+var errPresignExpired = fmt.Errorf("presigned URL expired")
+
 // uploadOnePartV2 PUTs data to a presigned URL and returns the ETag.
-// Unlike v1, no checksum header is sent (phase 1: required=false).
+// Phase 1: no per-part checksum header — checksum negotiation deferred to #113/#114.
+// Returns errPresignExpired on 403 so callers can re-presign and retry.
 func (c *Client) uploadOnePartV2(ctx context.Context, part presignedPart, data []byte) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, part.URL, bytes.NewReader(data))
 	if err != nil {
@@ -637,23 +654,53 @@ func (c *Client) uploadOnePartV2(ctx context.Context, part presignedPart, data [
 	}
 	req.ContentLength = int64(len(data))
 
-	// Compute and send SHA-256 inline — S3 requires it for data integrity
-	// even though the v2 protocol doesn't mandate pre-computed checksums.
-	h := sha256.Sum256(data)
-	req.Header.Set("x-amz-checksum-sha256", base64.StdEncoding.EncodeToString(h[:]))
-
 	resp, err := c.httpClient.Do(req) // Direct to S3, no auth header
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusForbidden {
+		return "", errPresignExpired
+	}
 	if resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
 		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
 	return resp.Header.Get("ETag"), nil
+}
+
+// presignOnePart fetches a fresh presigned URL for a single part via
+// POST /v2/uploads/{id}/presign. Used to retry after presigned URL expiry.
+func (c *Client) presignOnePart(ctx context.Context, uploadID string, partNumber int) (*presignedPart, error) {
+	body, err := json.Marshal(struct {
+		PartNumber int `json:"part_number"`
+	}{PartNumber: partNumber})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/v2/uploads/"+uploadID+"/presign", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var p presignedPart
+	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+		return nil, fmt.Errorf("decode presign response: %w", err)
+	}
+	return &p, nil
 }
 
 // completeUploadV2 sends the part list to POST /v2/uploads/{id}/complete.

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -102,6 +102,10 @@ func TestWriteStreamLargeFile(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/initiate":
+			// v2 not supported by this mock — trigger v1 fallback
+			http.NotFound(w, r)
+
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/initiate":
 			var req uploadInitiateRequest
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -147,6 +151,9 @@ func TestWriteStreamLargeFile(t *testing.T) {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/upload-123/complete":
 			completeCalled.Store(true)
 			w.WriteHeader(http.StatusOK)
+
+		default:
+			http.NotFound(w, r)
 		}
 	}))
 	defer srv.Close()

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -44,6 +44,7 @@ const (
 type UploadStatus string
 
 const (
+	UploadInitiated UploadStatus = "INITIATED"
 	UploadUploading UploadStatus = "UPLOADING"
 	UploadCompleted UploadStatus = "COMPLETED"
 	UploadAborted   UploadStatus = "ABORTED"
@@ -792,6 +793,29 @@ func (s *Store) AbortUpload(ctx context.Context, uploadID string) (err error) {
 	_, err = s.db.ExecContext(ctx, `UPDATE uploads SET status = 'ABORTED',
 		updated_at = ?
 		WHERE upload_id = ? AND status = 'UPLOADING'`, time.Now().UTC(), uploadID)
+	return err
+}
+
+// AbortUploadV2 sets an upload to ABORTED from either INITIATED or UPLOADING.
+// Returns nil (idempotent) if the upload is already aborted or not found.
+func (s *Store) AbortUploadV2(ctx context.Context, uploadID string) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "abort_upload_v2", start, &err)
+
+	_, err = s.db.ExecContext(ctx, `UPDATE uploads SET status = 'ABORTED',
+		updated_at = ?
+		WHERE upload_id = ? AND status IN ('INITIATED', 'UPLOADING')`, time.Now().UTC(), uploadID)
+	return err
+}
+
+// UpdateUploadStatus transitions an upload to a new status.
+func (s *Store) UpdateUploadStatus(ctx context.Context, uploadID string, status UploadStatus) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "update_upload_status", start, &err)
+
+	_, err = s.db.ExecContext(ctx, `UPDATE uploads SET status = ?,
+		updated_at = ?
+		WHERE upload_id = ?`, string(status), time.Now().UTC(), uploadID)
 	return err
 }
 

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -770,7 +770,7 @@ func (s *Store) GetUploadByPath(ctx context.Context, targetPath string) (out *Up
 	row := s.db.QueryRowContext(ctx, `SELECT upload_id, file_id, target_path, s3_upload_id, s3_key,
 		total_size, part_size, parts_total, status, fingerprint_sha256, idempotency_key,
 		created_at, updated_at, expires_at
-		FROM uploads WHERE target_path = ? AND status = 'UPLOADING'
+		FROM uploads WHERE target_path = ? AND status IN ('INITIATED', 'UPLOADING')
 		ORDER BY created_at DESC LIMIT 1`, targetPath)
 	out, err = scanUpload(row)
 	return out, err

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -819,6 +819,28 @@ func (s *Store) UpdateUploadStatus(ctx context.Context, uploadID string, status 
 	return err
 }
 
+// TransitionUploadStatus atomically transitions an upload from expectedStatus to newStatus.
+// Returns ErrUploadNotActive if the current status doesn't match expectedStatus.
+func (s *Store) TransitionUploadStatus(ctx context.Context, uploadID string, expectedStatus, newStatus UploadStatus) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "transition_upload_status", start, &err)
+
+	res, err := s.db.ExecContext(ctx, `UPDATE uploads SET status = ?,
+		updated_at = ?
+		WHERE upload_id = ? AND status = ?`, string(newStatus), time.Now().UTC(), uploadID, string(expectedStatus))
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return ErrUploadNotActive
+	}
+	return nil
+}
+
 func (s *Store) ListUploadsByPath(ctx context.Context, targetPath string, status UploadStatus) (out []*Upload, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "list_uploads_by_path", start, &err)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -13,6 +13,7 @@ import (
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/s3client"
 )
 
 // Dat9FS implements the go-fuse RawFileSystem interface, bridging FUSE
@@ -129,7 +130,7 @@ func (fs *Dat9FS) preloadWritableHandle(fh *FileHandle) gofuse.Status {
 	if bufMax < defaultWriteBufferMaxSize {
 		bufMax = defaultWriteBufferMaxSize
 	}
-	fh.Dirty = NewWriteBuffer(fh.Path, bufMax)
+	fh.Dirty = NewWriteBuffer(fh.Path, bufMax, s3client.CalcAdaptivePartSize(stat.Size))
 
 	var data []byte
 	if stat.Size <= smallFileThreshold {
@@ -595,7 +596,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		return gofuse.EIO
 	}
 
-	wb := NewWriteBuffer(childP, maxPreloadSize)
+	wb := NewWriteBuffer(childP, maxPreloadSize, 0)
 	wb.touched = true
 	fh := &FileHandle{
 		Ino:   ino,
@@ -631,7 +632,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		if fs.opts.ReadOnly {
 			return gofuse.EROFS
 		}
-		fh.Dirty = NewWriteBuffer(p, maxPreloadSize)
+		fh.Dirty = NewWriteBuffer(p, maxPreloadSize, 0)
 
 		// Preload existing content for non-truncating opens so that
 		// random writes don't discard the original file data.
@@ -755,7 +756,7 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 	defer fh.Unlock()
 
 	if fh.Dirty == nil {
-		fh.Dirty = NewWriteBuffer(fh.Path, 0)
+		fh.Dirty = NewWriteBuffer(fh.Path, 0, 0)
 	}
 
 	n, err := fh.Dirty.Write(int64(input.Offset), data)
@@ -844,6 +845,7 @@ func (fs *Dat9FS) flushHandle(fh *FileHandle) gofuse.Status {
 					return origData, nil
 				},
 				nil,
+				client.WithPartSize(fh.Dirty.PartSize()),
 			)
 		}
 		// If no dirty parts, nothing changed — skip upload.

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -79,7 +79,7 @@ func TestGetAttrPrefersDirtyHandleSize(t *testing.T) {
 	fh := &FileHandle{
 		Ino:   ino,
 		Path:  "/file.bin",
-		Dirty: NewWriteBuffer("/file.bin", 0),
+		Dirty: NewWriteBuffer("/file.bin", 0, 0),
 	}
 	if _, err := fh.Dirty.Write(0, []byte("dirty-size")); err != nil {
 		t.Fatal(err)
@@ -108,12 +108,12 @@ func TestGetAttrUsesLatestDirtyHandleSize(t *testing.T) {
 	fh1 := &FileHandle{
 		Ino:   ino,
 		Path:  "/file.bin",
-		Dirty: NewWriteBuffer("/file.bin", 0),
+		Dirty: NewWriteBuffer("/file.bin", 0, 0),
 	}
 	fh2 := &FileHandle{
 		Ino:   ino,
 		Path:  "/file.bin",
-		Dirty: NewWriteBuffer("/file.bin", 0),
+		Dirty: NewWriteBuffer("/file.bin", 0, 0),
 	}
 	fhID1 := fs.fileHandles.Allocate(fh1)
 	fhID2 := fs.fileHandles.Allocate(fh2)

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -290,7 +290,7 @@ func TestReadCache_InvalidatePrefix(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestWriteBuffer_Sequential(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 	n, err := wb.Write(0, []byte("hello"))
 	if err != nil || n != 5 {
 		t.Fatalf("Write: n=%d, err=%v", n, err)
@@ -308,7 +308,7 @@ func TestWriteBuffer_Sequential(t *testing.T) {
 }
 
 func TestWriteBuffer_RandomWrite(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 	_, _ = wb.Write(0, []byte("aaaa"))
 	_, _ = wb.Write(2, []byte("bb"))
 	if string(wb.Bytes()) != "aabb" {
@@ -317,7 +317,7 @@ func TestWriteBuffer_RandomWrite(t *testing.T) {
 }
 
 func TestWriteBuffer_GapFill(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 	_, _ = wb.Write(5, []byte("x"))
 	if wb.Size() != 6 {
 		t.Fatalf("Size = %d, want 6", wb.Size())
@@ -331,7 +331,7 @@ func TestWriteBuffer_GapFill(t *testing.T) {
 }
 
 func TestWriteBuffer_Truncate(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 	_, _ = wb.Write(0, []byte("hello world"))
 
 	if err := wb.Truncate(5); err != nil {
@@ -351,7 +351,7 @@ func TestWriteBuffer_Truncate(t *testing.T) {
 }
 
 func TestWriteBuffer_EFBIG(t *testing.T) {
-	wb := NewWriteBuffer("/test", 100)
+	wb := NewWriteBuffer("/test", 100, 0)
 	_, err := wb.Write(0, make([]byte, 101))
 	if err == nil {
 		t.Fatal("expected EFBIG error")
@@ -360,7 +360,7 @@ func TestWriteBuffer_EFBIG(t *testing.T) {
 
 func TestWriteBuffer_PreloadThenRandomWrite(t *testing.T) {
 	// Simulates the Open() preload path: load existing content, then pwrite
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 
 	// Preload original file content (what Open does via client.Read)
 	original := []byte("hello world, this is the original content!")
@@ -386,7 +386,7 @@ func TestWriteBuffer_PreloadThenRandomWrite(t *testing.T) {
 }
 
 func TestWriteBuffer_Reset(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 	_, _ = wb.Write(0, []byte("data"))
 	wb.Reset()
 	if wb.Size() != 0 {
@@ -398,7 +398,7 @@ func TestWriteBuffer_Reset(t *testing.T) {
 }
 
 func TestWriteBuffer_DirtyParts_SinglePart(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 	// Write within the first 8MB part
 	_, _ = wb.Write(0, []byte("hello"))
 	dirty := wb.DirtyPartNumbers()
@@ -408,13 +408,13 @@ func TestWriteBuffer_DirtyParts_SinglePart(t *testing.T) {
 }
 
 func TestWriteBuffer_DirtyParts_MultipleParts(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 	// Write at beginning of part 1
 	_, _ = wb.Write(0, []byte("a"))
 	// Write at beginning of part 2 (offset 8MB)
-	_, _ = wb.Write(partSize, []byte("b"))
+	_, _ = wb.Write(DefaultPartSize, []byte("b"))
 	// Write at beginning of part 3 (offset 16MB)
-	_, _ = wb.Write(2*partSize, []byte("c"))
+	_, _ = wb.Write(2*DefaultPartSize, []byte("c"))
 
 	dirty := wb.DirtyPartNumbers()
 	if len(dirty) != 3 {
@@ -430,10 +430,10 @@ func TestWriteBuffer_DirtyParts_MultipleParts(t *testing.T) {
 }
 
 func TestWriteBuffer_DirtyParts_CrossPartBoundary(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 	// Write across the boundary of part 1 and part 2
 	data := make([]byte, 100)
-	_, _ = wb.Write(partSize-50, data) // straddles parts 1 and 2
+	_, _ = wb.Write(DefaultPartSize-50, data) // straddles parts 1 and 2
 	dirty := wb.DirtyPartNumbers()
 	if len(dirty) != 2 {
 		t.Fatalf("expected 2 dirty parts, got %v", dirty)
@@ -442,8 +442,8 @@ func TestWriteBuffer_DirtyParts_CrossPartBoundary(t *testing.T) {
 
 func TestWriteBuffer_DirtyParts_PreloadClearsFlags(t *testing.T) {
 	// Simulates large file open: preload then clear dirty flags
-	wb := NewWriteBuffer("/test", 0)
-	data := make([]byte, partSize*2) // 16MB, 2 parts
+	wb := NewWriteBuffer("/test", 0, 0)
+	data := make([]byte, DefaultPartSize*2) // 16MB, 2 parts
 	for i := range data {
 		data[i] = byte(i % 256)
 	}
@@ -458,7 +458,7 @@ func TestWriteBuffer_DirtyParts_PreloadClearsFlags(t *testing.T) {
 	}
 
 	// Now write to part 2 only
-	_, _ = wb.Write(partSize+100, []byte("modified"))
+	_, _ = wb.Write(DefaultPartSize+100, []byte("modified"))
 	dirty := wb.DirtyPartNumbers()
 	if len(dirty) != 1 || dirty[0] != 2 {
 		t.Fatalf("expected dirty=[2], got %v", dirty)
@@ -466,14 +466,14 @@ func TestWriteBuffer_DirtyParts_PreloadClearsFlags(t *testing.T) {
 }
 
 func TestWriteBuffer_DirtyParts_TruncateShrink(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 	// Write 3 parts
-	data := make([]byte, partSize*3)
+	data := make([]byte, DefaultPartSize*3)
 	_, _ = wb.Write(0, data)
 	wb.ClearDirty()
 
 	// Truncate to 1 part
-	_ = wb.Truncate(partSize / 2)
+	_ = wb.Truncate(DefaultPartSize / 2)
 	dirty := wb.DirtyPartNumbers()
 	// Part 1 should be dirty (it was truncated within)
 	if len(dirty) != 1 || dirty[0] != 1 {
@@ -482,11 +482,11 @@ func TestWriteBuffer_DirtyParts_TruncateShrink(t *testing.T) {
 }
 
 func TestWriteBuffer_DirtyParts_TruncateShrinkAtBoundary(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
-	_, _ = wb.Write(0, make([]byte, partSize*3))
+	wb := NewWriteBuffer("/test", 0, 0)
+	_, _ = wb.Write(0, make([]byte, DefaultPartSize*3))
 	wb.ClearDirty()
 
-	_ = wb.Truncate(partSize)
+	_ = wb.Truncate(DefaultPartSize)
 	dirty := wb.DirtyPartNumbers()
 	if len(dirty) != 1 || dirty[0] != 1 {
 		t.Fatalf("expected dirty=[1] after boundary truncate, got %v", dirty)
@@ -494,12 +494,12 @@ func TestWriteBuffer_DirtyParts_TruncateShrinkAtBoundary(t *testing.T) {
 }
 
 func TestWriteBuffer_DirtyParts_TruncateExtend(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
-	_, _ = wb.Write(0, make([]byte, partSize)) // 1 full part
+	wb := NewWriteBuffer("/test", 0, 0)
+	_, _ = wb.Write(0, make([]byte, DefaultPartSize)) // 1 full part
 	wb.dirtyParts = nil                        // clear as if preloaded
 
 	// Extend to 3 parts
-	_ = wb.Truncate(partSize*3 - 100)
+	_ = wb.Truncate(DefaultPartSize*3 - 100)
 	dirty := wb.DirtyPartNumbers()
 	// Parts 2 and 3 should be dirty (extended region)
 	if len(dirty) != 2 {
@@ -508,18 +508,18 @@ func TestWriteBuffer_DirtyParts_TruncateExtend(t *testing.T) {
 }
 
 func TestWriteBuffer_PartData(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
+	wb := NewWriteBuffer("/test", 0, 0)
 	// Write 2 full parts + partial third
-	data := make([]byte, partSize*2+100)
+	data := make([]byte, DefaultPartSize*2+100)
 	for i := range data {
 		data[i] = byte(i % 256)
 	}
 	_, _ = wb.Write(0, data)
 
-	// Part 1 should be exactly partSize bytes
+	// Part 1 should be exactly DefaultPartSize bytes
 	p1 := wb.PartData(1)
-	if len(p1) != int(partSize) {
-		t.Fatalf("part 1 size: got %d, want %d", len(p1), partSize)
+	if len(p1) != int(DefaultPartSize) {
+		t.Fatalf("part 1 size: got %d, want %d", len(p1), DefaultPartSize)
 	}
 
 	// Part 3 should be 100 bytes (last partial part)
@@ -536,8 +536,8 @@ func TestWriteBuffer_PartData(t *testing.T) {
 }
 
 func TestWriteBuffer_MarkAllDirty(t *testing.T) {
-	wb := NewWriteBuffer("/test", 0)
-	_, _ = wb.Write(0, make([]byte, partSize*3))
+	wb := NewWriteBuffer("/test", 0, 0)
+	_, _ = wb.Write(0, make([]byte, DefaultPartSize*3))
 	wb.dirtyParts = nil // clear
 
 	wb.MarkAllDirty()

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -4,12 +4,12 @@ import "syscall"
 
 const (
 	defaultWriteBufferMaxSize = 64 << 20  // 64MB per file
-	partSize                  = 8 << 20   // 8MB - must match s3client.PartSize
+	DefaultPartSize           = 8 << 20   // 8MB - default for v1 uploads; v2 may use adaptive sizes
 	maxPreloadSize            = 256 << 20 // 256MB - hard limit for preloading existing files into memory
 )
 
 // WriteBuffer accumulates write data for a single file.
-// It tracks which 8MB parts have been modified so that on flush,
+// It tracks which parts have been modified so that on flush,
 // only dirty parts need to be uploaded (unchanged parts are copied
 // server-side via S3 UploadPartCopy).
 // It is NOT thread-safe; callers must hold the FileHandle mutex.
@@ -17,19 +17,25 @@ type WriteBuffer struct {
 	path       string
 	buf        []byte
 	maxSize    int64
+	partSize   int64
 	dirtyParts []bool
 	touched    bool
 }
 
 // NewWriteBuffer creates a new WriteBuffer for the given path.
 // If maxSize <= 0, defaultWriteBufferMaxSize (64MB) is used.
-func NewWriteBuffer(path string, maxSize int64) *WriteBuffer {
+// If partSize <= 0, DefaultPartSize (8MB) is used.
+func NewWriteBuffer(path string, maxSize int64, partSize int64) *WriteBuffer {
 	if maxSize <= 0 {
 		maxSize = defaultWriteBufferMaxSize
 	}
+	if partSize <= 0 {
+		partSize = DefaultPartSize
+	}
 	return &WriteBuffer{
-		path:    path,
-		maxSize: maxSize,
+		path:     path,
+		maxSize:  maxSize,
+		partSize: partSize,
 	}
 }
 
@@ -64,8 +70,8 @@ func (wb *WriteBuffer) Write(offset int64, data []byte) (uint32, error) {
 
 // markDirty marks all parts that overlap with [start, end) as dirty.
 func (wb *WriteBuffer) markDirty(start, end int64) {
-	firstPart := int(start / partSize)
-	lastPart := int((end - 1) / partSize)
+	firstPart := int(start / wb.partSize)
+	lastPart := int((end - 1) / wb.partSize)
 	if end <= start {
 		return
 	}
@@ -107,11 +113,11 @@ func (wb *WriteBuffer) Truncate(size int64) error {
 		}
 		wb.buf = wb.buf[:size]
 		// Shrink dirtyParts if we now have fewer parts.
-		newParts := int((size + partSize - 1) / partSize)
+		newParts := int((size + wb.partSize - 1) / wb.partSize)
 		if newParts < len(wb.dirtyParts) {
 			wb.dirtyParts = wb.dirtyParts[:newParts]
 		}
-		if size > 0 && size%partSize == 0 && newParts > 0 {
+		if size > 0 && size%wb.partSize == 0 && newParts > 0 {
 			// Exact-boundary shrinks still need a PATCH/flush to update the
 			// remote object size, even if no part payload changed.
 			wb.dirtyParts[newParts-1] = true
@@ -138,6 +144,11 @@ func (wb *WriteBuffer) Truncate(size int64) error {
 // Size returns the current buffer length.
 func (wb *WriteBuffer) Size() int64 {
 	return int64(len(wb.buf))
+}
+
+// PartSize returns the part size used for dirty-part boundary calculations.
+func (wb *WriteBuffer) PartSize() int64 {
+	return wb.partSize
 }
 
 func (wb *WriteBuffer) HasDirtyParts() bool {
@@ -173,7 +184,7 @@ func (wb *WriteBuffer) DirtyPartNumbers() []int {
 // MarkAllDirty marks every part in the current buffer as dirty.
 // Used when the entire file content is loaded (e.g., new file or full rewrite).
 func (wb *WriteBuffer) MarkAllDirty() {
-	n := int((wb.Size() + partSize - 1) / partSize)
+	n := int((wb.Size() + wb.partSize - 1) / wb.partSize)
 	wb.dirtyParts = make([]bool, n)
 	for i := range wb.dirtyParts {
 		wb.dirtyParts[i] = true
@@ -183,11 +194,11 @@ func (wb *WriteBuffer) MarkAllDirty() {
 // PartData returns the data for a specific 1-based part number.
 // Returns nil if the part is out of range.
 func (wb *WriteBuffer) PartData(partNum int) []byte {
-	start := int64(partNum-1) * partSize
+	start := int64(partNum-1) * wb.partSize
 	if start >= int64(len(wb.buf)) {
 		return nil
 	}
-	end := start + partSize
+	end := start + wb.partSize
 	if end > int64(len(wb.buf)) {
 		end = int64(len(wb.buf))
 	}

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -90,6 +90,9 @@ const MinPartSize = 5 << 20
 // MaxAdaptivePartSize is the upper bound for adaptive part size (512 MiB).
 const MaxAdaptivePartSize = 512 << 20
 
+// MaxPartSize is the S3 hard limit for a single multipart part (5 GiB).
+const MaxPartSize = 5 << 30
+
 // CalcAdaptivePartSize returns a part size tuned for totalSize.
 // Formula: ceil(fileSize / 10000) aligned up to 1 MiB, clamped to [8 MiB, 512 MiB].
 // This is the single authoritative implementation — do not duplicate elsewhere.

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -84,6 +84,34 @@ const (
 // PartSize is the default multipart part size (8MB).
 const PartSize = 8 << 20
 
+// MinPartSize is the S3 minimum part size (5MB).
+const MinPartSize = 5 << 20
+
+// MaxAdaptivePartSize is the upper bound for adaptive part size (512 MiB).
+const MaxAdaptivePartSize = 512 << 20
+
+// CalcAdaptivePartSize returns a part size tuned for totalSize.
+// Formula: ceil(fileSize / 10000) aligned up to 1 MiB, clamped to [8 MiB, 512 MiB].
+// This is the single authoritative implementation — do not duplicate elsewhere.
+func CalcAdaptivePartSize(totalSize int64) int64 {
+	const align = 1 << 20 // 1 MiB alignment
+
+	// ceil(totalSize / 10000)
+	ps := (totalSize + 9999) / 10000
+
+	// Align up to 1 MiB boundary
+	ps = ((ps + align - 1) / align) * align
+
+	// Clamp
+	if ps < PartSize {
+		ps = PartSize // 8 MiB minimum
+	}
+	if ps > MaxAdaptivePartSize {
+		ps = MaxAdaptivePartSize
+	}
+	return ps
+}
+
 // CalcParts computes the number of parts and individual part sizes.
 func CalcParts(totalSize int64, partSize int64) []Part {
 	if partSize <= 0 {

--- a/pkg/s3client/s3client_test.go
+++ b/pkg/s3client/s3client_test.go
@@ -214,3 +214,73 @@ func TestPartialUploadAndListParts(t *testing.T) {
 		t.Errorf("unexpected part numbers: %v", listed)
 	}
 }
+
+func TestCalcAdaptivePartSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		total    int64
+		wantPS   int64
+		wantN    int // expected number of parts (0 = skip check)
+	}{
+		{"small file 1 MiB", 1 << 20, PartSize, 1},
+		{"80 GiB", 80 * (1 << 30), 9 << 20, 0},           // ceil(80GiB/10000) → align up to 9 MiB
+		{"100 GiB", 100 * (1 << 30), 11 << 20, 0},        // ceil(100GiB/10000) → align up to 11 MiB
+		{"500 GiB", 500 * (1 << 30), 52 << 20, 0},        // ceil(500GiB/10000) → align up to 52 MiB
+		{"5 TiB max S3 object", 5 * (1 << 40), MaxAdaptivePartSize, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ps := CalcAdaptivePartSize(tt.total)
+			if ps < PartSize {
+				t.Errorf("part size %d < minimum %d", ps, PartSize)
+			}
+			if ps > MaxAdaptivePartSize {
+				t.Errorf("part size %d > maximum %d", ps, MaxAdaptivePartSize)
+			}
+			// Check 1 MiB alignment
+			if ps%(1<<20) != 0 {
+				t.Errorf("part size %d not aligned to 1 MiB", ps)
+			}
+			if tt.wantPS != 0 && ps != tt.wantPS {
+				t.Errorf("CalcAdaptivePartSize(%d) = %d, want %d", tt.total, ps, tt.wantPS)
+			}
+			if tt.wantN != 0 {
+				parts := CalcParts(tt.total, ps)
+				if len(parts) != tt.wantN {
+					t.Errorf("CalcParts(%d, %d) = %d parts, want %d", tt.total, ps, len(parts), tt.wantN)
+				}
+			}
+		})
+	}
+}
+
+func TestCalcAdaptivePartSizeInvariants(t *testing.T) {
+	// Monotonicity: larger files should produce >= part sizes
+	prev := CalcAdaptivePartSize(1)
+	for _, size := range []int64{
+		1 << 20, 10 << 20, 100 << 20, 1 << 30, 10 * (1 << 30),
+		50 * (1 << 30), 100 * (1 << 30), 500 * (1 << 30), 1 << 40, 5 * (1 << 40),
+	} {
+		ps := CalcAdaptivePartSize(size)
+		if ps < prev {
+			t.Errorf("monotonicity violated: CalcAdaptivePartSize(%d)=%d < CalcAdaptivePartSize(prev)=%d", size, ps, prev)
+		}
+		prev = ps
+	}
+
+	// Zero and negative sizes should still return PartSize (minimum clamp)
+	if ps := CalcAdaptivePartSize(0); ps != PartSize {
+		t.Errorf("CalcAdaptivePartSize(0) = %d, want %d", ps, PartSize)
+	}
+	if ps := CalcAdaptivePartSize(-1); ps != PartSize {
+		t.Errorf("CalcAdaptivePartSize(-1) = %d, want %d", ps, PartSize)
+	}
+
+	// Files within MaxAdaptivePartSize * 10000 should produce <= 10000 parts
+	maxSafe := int64(MaxAdaptivePartSize) * 10000
+	ps := CalcAdaptivePartSize(maxSafe)
+	parts := CalcParts(maxSafe, ps)
+	if len(parts) > 10000 {
+		t.Errorf("CalcAdaptivePartSize(%d) = %d → %d parts, exceeds S3 limit of 10000", maxSafe, ps, len(parts))
+	}
+}

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -231,6 +231,8 @@ func requestRoute(path string) string {
 		return "/v1/uploads"
 	case strings.HasPrefix(path, "/v1/uploads/"):
 		return "/v1/uploads/*"
+	case strings.HasPrefix(path, "/v2/uploads/"):
+		return "/v2/uploads/*"
 	case strings.HasPrefix(path, "/s3/"):
 		return "/s3/*"
 	default:

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -96,6 +96,7 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v1/fs/", business)
 	mux.Handle("/v1/uploads", business)
 	mux.Handle("/v1/uploads/", business)
+	mux.Handle("/v2/uploads/", business)
 	mux.Handle("/v1/sql", business)
 	mux.HandleFunc("/v1/status", s.handleTenantStatus)
 	mux.HandleFunc("/v1/provision", s.handleProvision)
@@ -231,6 +232,8 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 		s.handleUploads(w, r)
 	case strings.HasPrefix(r.URL.Path, "/v1/uploads/"):
 		s.handleUploadAction(w, r)
+	case strings.HasPrefix(r.URL.Path, "/v2/uploads/"):
+		s.handleV2Uploads(w, r)
 	case r.URL.Path == "/v1/sql":
 		s.handleSQL(w, r)
 	default:
@@ -1063,6 +1066,164 @@ func (s *Server) handleUploadAbort(w http.ResponseWriter, r *http.Request, uploa
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_abort_ok", "upload_id", uploadID)...)
 	metricEvent(r.Context(), "upload_abort", "result", "ok")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// --- v2 upload handlers (on-demand presign, adaptive part size) ---
+
+func (s *Server) handleV2Uploads(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, "/v2/uploads/")
+	parts := strings.SplitN(rest, "/", 2)
+	seg0 := parts[0]
+	action := ""
+	if len(parts) > 1 {
+		action = strings.Trim(parts[1], "/")
+	}
+
+	switch {
+	case seg0 == "initiate" && r.Method == http.MethodPost:
+		s.handleV2UploadInitiate(w, r)
+	case seg0 != "" && action == "presign" && r.Method == http.MethodPost:
+		s.handleV2PresignPart(w, r, seg0)
+	case seg0 != "" && action == "presign-batch" && r.Method == http.MethodPost:
+		s.handleV2PresignBatch(w, r, seg0)
+	case seg0 != "" && action == "complete" && r.Method == http.MethodPost:
+		s.handleUploadComplete(w, r, seg0)
+	case seg0 != "" && action == "" && r.Method == http.MethodDelete:
+		s.handleUploadAbort(w, r, seg0)
+	default:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_uploads_unknown_route", "path", r.URL.Path, "method", r.Method)...)
+		errJSON(w, http.StatusNotFound, "not found")
+	}
+}
+
+func (s *Server) handleV2UploadInitiate(w http.ResponseWriter, r *http.Request) {
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_missing_scope")...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	var req struct {
+		Path      string `json:"path"`
+		TotalSize int64  `json:"total_size"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			errJSON(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_bad_body", "error", err)...)
+		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Path) == "" {
+		errJSON(w, http.StatusBadRequest, "missing path")
+		return
+	}
+	if req.TotalSize <= 0 {
+		errJSON(w, http.StatusBadRequest, "total_size must be positive")
+		return
+	}
+	if req.TotalSize > s.maxUploadBytes {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_too_large", "path", req.Path, "bytes", req.TotalSize, "max", s.maxUploadBytes)...)
+		errJSON(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("upload too large: max %d bytes", s.maxUploadBytes))
+		return
+	}
+	plan, err := b.InitiateUploadV2(r.Context(), req.Path, req.TotalSize)
+	if err != nil {
+		if errors.Is(err, datastore.ErrUploadConflict) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_conflict", "path", req.Path, "error", err)...)
+			metricEvent(r.Context(), "v2_upload_initiate", "result", "conflict")
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_failed", "path", req.Path, "error", err)...)
+		metricEvent(r.Context(), "v2_upload_initiate", "result", "error")
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_ok", "path", req.Path, "part_size", plan.PartSize, "total_parts", plan.TotalParts)...)
+	metricEvent(r.Context(), "v2_upload_initiate", "result", "ok")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(plan)
+}
+
+func (s *Server) handleV2PresignPart(w http.ResponseWriter, r *http.Request, uploadID string) {
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_missing_scope", "upload_id", uploadID)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	var req struct {
+		PartNumber int `json:"part_number"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_bad_body", "upload_id", uploadID, "error", err)...)
+		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if req.PartNumber < 1 {
+		errJSON(w, http.StatusBadRequest, "part_number must be >= 1")
+		return
+	}
+	url, err := b.PresignPart(r.Context(), uploadID, req.PartNumber)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if errors.Is(err, datastore.ErrUploadNotActive) || errors.Is(err, datastore.ErrUploadExpired) {
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_failed", "upload_id", uploadID, "part", req.PartNumber, "error", err)...)
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_ok", "upload_id", uploadID, "part", req.PartNumber)...)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(url)
+}
+
+func (s *Server) handleV2PresignBatch(w http.ResponseWriter, r *http.Request, uploadID string) {
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_missing_scope", "upload_id", uploadID)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	var req struct {
+		PartNumbers []int `json:"part_numbers"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_bad_body", "upload_id", uploadID, "error", err)...)
+		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if len(req.PartNumbers) == 0 {
+		errJSON(w, http.StatusBadRequest, "part_numbers must not be empty")
+		return
+	}
+	urls, err := b.PresignParts(r.Context(), uploadID, req.PartNumbers)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if errors.Is(err, datastore.ErrUploadNotActive) || errors.Is(err, datastore.ErrUploadExpired) {
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_failed", "upload_id", uploadID, "error", err)...)
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_ok", "upload_id", uploadID, "parts", len(urls))...)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"parts": urls})
 }
 
 func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1087,7 +1087,7 @@ func (s *Server) handleV2Uploads(w http.ResponseWriter, r *http.Request) {
 	case seg0 != "" && action == "presign-batch" && r.Method == http.MethodPost:
 		s.handleV2PresignBatch(w, r, seg0)
 	case seg0 != "" && action == "complete" && r.Method == http.MethodPost:
-		s.handleUploadComplete(w, r, seg0)
+		s.handleV2UploadComplete(w, r, seg0)
 	case seg0 != "" && action == "abort" && r.Method == http.MethodPost:
 		s.handleV2UploadAbort(w, r, seg0)
 	default:
@@ -1238,6 +1238,55 @@ func (s *Server) handleV2PresignBatch(w http.ResponseWriter, r *http.Request, up
 	metricEvent(r.Context(), "v2_presign_batch", "result", "ok")
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"parts": urls})
+}
+
+func (s *Server) handleV2UploadComplete(w http.ResponseWriter, r *http.Request, uploadID string) {
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_missing_scope", "upload_id", uploadID)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	var req struct {
+		Parts []backend.CompletePart `json:"parts"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_bad_body", "upload_id", uploadID, "error", err)...)
+		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if len(req.Parts) == 0 {
+		errJSON(w, http.StatusBadRequest, "parts must not be empty")
+		return
+	}
+	if err := b.ConfirmUploadV2(r.Context(), uploadID, req.Parts); err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "upload not found")
+			return
+		}
+		if errors.Is(err, datastore.ErrUploadExpired) {
+			metricEvent(r.Context(), "v2_upload_complete", "result", "expired")
+			errJSON(w, http.StatusGone, "upload expired")
+			return
+		}
+		if errors.Is(err, datastore.ErrUploadNotActive) {
+			errJSON(w, http.StatusConflict, "upload is not active")
+			return
+		}
+		if errors.Is(err, datastore.ErrPathConflict) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_conflict", "upload_id", uploadID, "error", err)...)
+			metricEvent(r.Context(), "v2_upload_complete", "result", "conflict")
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_failed", "upload_id", uploadID, "error", err)...)
+		metricEvent(r.Context(), "v2_upload_complete", "result", "error")
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_ok", "upload_id", uploadID)...)
+	metricEvent(r.Context(), "v2_upload_complete", "result", "ok")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "completed"})
 }
 
 func (s *Server) handleV2UploadAbort(w http.ResponseWriter, r *http.Request, uploadID string) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1082,6 +1082,12 @@ func (s *Server) handleV2Uploads(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case seg0 == "initiate" && r.Method == http.MethodPost:
 		s.handleV2UploadInitiate(w, r)
+	case seg0 != "" && action == "presign" && r.Method == http.MethodPost:
+		s.handleV2PresignPart(w, r, seg0)
+	case seg0 != "" && action == "presign-batch" && r.Method == http.MethodPost:
+		s.handleV2PresignBatch(w, r, seg0)
+	case seg0 != "" && action == "complete" && r.Method == http.MethodPost:
+		s.handleUploadComplete(w, r, seg0)
 	case seg0 != "" && action == "abort" && r.Method == http.MethodPost:
 		s.handleV2UploadAbort(w, r, seg0)
 	default:
@@ -1142,6 +1148,96 @@ func (s *Server) handleV2UploadInitiate(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(plan)
+}
+
+func (s *Server) handleV2PresignPart(w http.ResponseWriter, r *http.Request, uploadID string) {
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_missing_scope", "upload_id", uploadID)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	var req struct {
+		PartNumber int `json:"part_number"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_bad_body", "upload_id", uploadID, "error", err)...)
+		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if req.PartNumber < 1 {
+		errJSON(w, http.StatusBadRequest, "part_number must be >= 1")
+		return
+	}
+	u, err := b.PresignPart(r.Context(), uploadID, req.PartNumber)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "upload not found")
+			return
+		}
+		if errors.Is(err, datastore.ErrUploadExpired) {
+			metricEvent(r.Context(), "v2_presign_part", "result", "expired")
+			errJSON(w, http.StatusGone, "upload expired")
+			return
+		}
+		if errors.Is(err, datastore.ErrUploadNotActive) {
+			errJSON(w, http.StatusConflict, "upload is not active")
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_failed", "upload_id", uploadID, "part_number", req.PartNumber, "error", err)...)
+		metricEvent(r.Context(), "v2_presign_part", "result", "error")
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_ok", "upload_id", uploadID, "part_number", req.PartNumber)...)
+	metricEvent(r.Context(), "v2_presign_part", "result", "ok")
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(u)
+}
+
+func (s *Server) handleV2PresignBatch(w http.ResponseWriter, r *http.Request, uploadID string) {
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_missing_scope", "upload_id", uploadID)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	var req struct {
+		PartNumbers []int `json:"part_numbers"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_bad_body", "upload_id", uploadID, "error", err)...)
+		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if len(req.PartNumbers) == 0 {
+		errJSON(w, http.StatusBadRequest, "part_numbers must not be empty")
+		return
+	}
+	urls, err := b.PresignParts(r.Context(), uploadID, req.PartNumbers)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "upload not found")
+			return
+		}
+		if errors.Is(err, datastore.ErrUploadExpired) {
+			metricEvent(r.Context(), "v2_presign_batch", "result", "expired")
+			errJSON(w, http.StatusGone, "upload expired")
+			return
+		}
+		if errors.Is(err, datastore.ErrUploadNotActive) {
+			errJSON(w, http.StatusConflict, "upload is not active")
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_failed", "upload_id", uploadID, "error", err)...)
+		metricEvent(r.Context(), "v2_presign_batch", "result", "error")
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_ok", "upload_id", uploadID, "count", len(urls))...)
+	metricEvent(r.Context(), "v2_presign_batch", "result", "ok")
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"parts": urls})
 }
 
 func (s *Server) handleV2UploadAbort(w http.ResponseWriter, r *http.Request, uploadID string) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -550,6 +550,7 @@ func (s *Server) handlePatch(w http.ResponseWriter, r *http.Request, path string
 	var req struct {
 		NewSize    int64 `json:"new_size"`
 		DirtyParts []int `json:"dirty_parts"`
+		PartSize   int64 `json:"part_size,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "patch_bad_body", "path", path, "error", err)...)
@@ -566,7 +567,7 @@ func (s *Server) handlePatch(w http.ResponseWriter, r *http.Request, path string
 		return
 	}
 
-	plan, err := b.InitiatePatchUpload(r.Context(), path, req.NewSize, req.DirtyParts)
+	plan, err := b.InitiatePatchUpload(r.Context(), path, req.NewSize, req.DirtyParts, req.PartSize)
 	if err != nil {
 		if errors.Is(err, datastore.ErrUploadConflict) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "patch_upload_conflict", "path", path)...)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1158,7 +1158,8 @@ func (s *Server) handleV2PresignPart(w http.ResponseWriter, r *http.Request, upl
 		return
 	}
 	var req struct {
-		PartNumber int `json:"part_number"`
+		PartNumber int                      `json:"part_number"`
+		Checksum   *backend.PresignChecksum `json:"checksum,omitempty"`
 	}
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_bad_body", "upload_id", uploadID, "error", err)...)
@@ -1169,7 +1170,7 @@ func (s *Server) handleV2PresignPart(w http.ResponseWriter, r *http.Request, upl
 		errJSON(w, http.StatusBadRequest, "part_number must be >= 1")
 		return
 	}
-	u, err := b.PresignPart(r.Context(), uploadID, req.PartNumber)
+	u, err := b.PresignPart(r.Context(), uploadID, req.PartNumber, req.Checksum)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "upload not found")
@@ -1203,18 +1204,18 @@ func (s *Server) handleV2PresignBatch(w http.ResponseWriter, r *http.Request, up
 		return
 	}
 	var req struct {
-		PartNumbers []int `json:"part_numbers"`
+		Parts []backend.PresignPartEntry `json:"parts"`
 	}
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_bad_body", "upload_id", uploadID, "error", err)...)
 		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 		return
 	}
-	if len(req.PartNumbers) == 0 {
-		errJSON(w, http.StatusBadRequest, "part_numbers must not be empty")
+	if len(req.Parts) == 0 {
+		errJSON(w, http.StatusBadRequest, "parts must not be empty")
 		return
 	}
-	urls, err := b.PresignParts(r.Context(), uploadID, req.PartNumbers)
+	urls, err := b.PresignParts(r.Context(), uploadID, req.Parts)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "upload not found")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1082,8 +1082,6 @@ func (s *Server) handleV2Uploads(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case seg0 == "initiate" && r.Method == http.MethodPost:
 		s.handleV2UploadInitiate(w, r)
-	case seg0 != "" && action == "complete" && r.Method == http.MethodPost:
-		s.handleUploadComplete(w, r, seg0)
 	case seg0 != "" && action == "abort" && r.Method == http.MethodPost:
 		s.handleV2UploadAbort(w, r, seg0)
 	default:

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1082,14 +1082,10 @@ func (s *Server) handleV2Uploads(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case seg0 == "initiate" && r.Method == http.MethodPost:
 		s.handleV2UploadInitiate(w, r)
-	case seg0 != "" && action == "presign" && r.Method == http.MethodPost:
-		s.handleV2PresignPart(w, r, seg0)
-	case seg0 != "" && action == "presign-batch" && r.Method == http.MethodPost:
-		s.handleV2PresignBatch(w, r, seg0)
 	case seg0 != "" && action == "complete" && r.Method == http.MethodPost:
 		s.handleUploadComplete(w, r, seg0)
-	case seg0 != "" && action == "" && r.Method == http.MethodDelete:
-		s.handleUploadAbort(w, r, seg0)
+	case seg0 != "" && action == "abort" && r.Method == http.MethodPost:
+		s.handleV2UploadAbort(w, r, seg0)
 	default:
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_uploads_unknown_route", "path", r.URL.Path, "method", r.Method)...)
 		errJSON(w, http.StatusNotFound, "not found")
@@ -1150,80 +1146,22 @@ func (s *Server) handleV2UploadInitiate(w http.ResponseWriter, r *http.Request) 
 	_ = json.NewEncoder(w).Encode(plan)
 }
 
-func (s *Server) handleV2PresignPart(w http.ResponseWriter, r *http.Request, uploadID string) {
+func (s *Server) handleV2UploadAbort(w http.ResponseWriter, r *http.Request, uploadID string) {
 	b := backendFromRequest(r)
 	if b == nil {
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_missing_scope", "upload_id", uploadID)...)
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_abort_missing_scope", "upload_id", uploadID)...)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
-	var req struct {
-		PartNumber int `json:"part_number"`
-	}
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_bad_body", "upload_id", uploadID, "error", err)...)
-		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
-		return
-	}
-	if req.PartNumber < 1 {
-		errJSON(w, http.StatusBadRequest, "part_number must be >= 1")
-		return
-	}
-	url, err := b.PresignPart(r.Context(), uploadID, req.PartNumber)
-	if err != nil {
-		if errors.Is(err, datastore.ErrNotFound) {
-			errJSON(w, http.StatusNotFound, err.Error())
-			return
-		}
-		if errors.Is(err, datastore.ErrUploadNotActive) || errors.Is(err, datastore.ErrUploadExpired) {
-			errJSON(w, http.StatusConflict, err.Error())
-			return
-		}
-		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_failed", "upload_id", uploadID, "part", req.PartNumber, "error", err)...)
+	if err := b.AbortUploadV2(r.Context(), uploadID); err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_abort_failed", "upload_id", uploadID, "error", err)...)
+		metricEvent(r.Context(), "v2_upload_abort", "result", "error")
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_ok", "upload_id", uploadID, "part", req.PartNumber)...)
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(url)
-}
-
-func (s *Server) handleV2PresignBatch(w http.ResponseWriter, r *http.Request, uploadID string) {
-	b := backendFromRequest(r)
-	if b == nil {
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_missing_scope", "upload_id", uploadID)...)
-		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
-		return
-	}
-	var req struct {
-		PartNumbers []int `json:"part_numbers"`
-	}
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_bad_body", "upload_id", uploadID, "error", err)...)
-		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
-		return
-	}
-	if len(req.PartNumbers) == 0 {
-		errJSON(w, http.StatusBadRequest, "part_numbers must not be empty")
-		return
-	}
-	urls, err := b.PresignParts(r.Context(), uploadID, req.PartNumbers)
-	if err != nil {
-		if errors.Is(err, datastore.ErrNotFound) {
-			errJSON(w, http.StatusNotFound, err.Error())
-			return
-		}
-		if errors.Is(err, datastore.ErrUploadNotActive) || errors.Is(err, datastore.ErrUploadExpired) {
-			errJSON(w, http.StatusConflict, err.Error())
-			return
-		}
-		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_failed", "upload_id", uploadID, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_ok", "upload_id", uploadID, "parts", len(urls))...)
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]any{"parts": urls})
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_abort_ok", "upload_id", uploadID)...)
+	metricEvent(r.Context(), "v2_upload_abort", "result", "ok")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -229,7 +229,7 @@ func TestUploadCompleteEndpoint(t *testing.T) {
 
 	// Upload all parts via S3 client directly
 	for _, p := range plan.Parts {
-		start := int64(p.Number-1) * s3client.PartSize
+		start := int64(p.Number-1) * plan.PartSize
 		end := start + p.Size
 		if end > int64(len(body)) {
 			end = int64(len(body))
@@ -277,7 +277,7 @@ func TestUploadResumeEndpoint(t *testing.T) {
 	upload, _ := s.fallback.GetUpload(context.Background(), plan.UploadID)
 
 	// Upload only part 1
-	if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, 1, bytes.NewReader(make([]byte, s3client.PartSize))); err != nil {
+	if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, 1, bytes.NewReader(make([]byte, upload.PartSize))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -327,7 +327,7 @@ func TestUploadResumeEndpointByBody(t *testing.T) {
 	_ = resp.Body.Close()
 
 	upload, _ := s.fallback.GetUpload(context.Background(), plan.UploadID)
-	if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, 1, bytes.NewReader(make([]byte, s3client.PartSize))); err != nil {
+	if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, 1, bytes.NewReader(make([]byte, upload.PartSize))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -397,7 +397,7 @@ func TestLargeUploadOverwritesExistingSmallFile(t *testing.T) {
 
 	// Upload all parts through the local S3 stand-in.
 	for _, p := range plan.Parts {
-		start := int64(p.Number-1) * s3client.PartSize
+		start := int64(p.Number-1) * plan.PartSize
 		end := start + p.Size
 		if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, p.Number,
 			bytes.NewReader(make([]byte, end-start))); err != nil {
@@ -485,7 +485,7 @@ func TestAutoImageMultipartOverwriteWritesContentTextEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, part := range plan.Parts {
-		start := int64(part.Number-1) * s3client.PartSize
+		start := int64(part.Number-1) * plan.PartSize
 		end := start + part.Size
 		if _, err := s3c.UploadPart(context.Background(), upload.S3UploadID, part.Number, bytes.NewReader(make([]byte, end-start))); err != nil {
 			t.Fatalf("upload part %d: %v", part.Number, err)


### PR DESCRIPTION
## Summary
- **`pkg/fuse/write.go`** — `WriteBuffer.partSize` is now a configurable field (default 8 MiB) instead of a package constant. Added `PartSize()` getter and exported `DefaultPartSize`.
- **`pkg/fuse/dat9fs.go`** — When opening existing files for writing, computes adaptive part size via `s3client.CalcAdaptivePartSize(stat.Size)`. Sends the part size to the server at flush time via `client.WithPartSize()`.
- **`pkg/client/patch.go`** — New `PatchOption`/`WithPartSize` option. Sends `part_size` in the PATCH request body so server uses matching boundaries.
- **`pkg/backend/patch.go`** — `InitiatePatchUpload` accepts `clientPartSize`. Uses it if valid (≥ `MinPartSize`), otherwise falls back to `CalcAdaptivePartSize(newSize)`. All 6 hardcoded `s3client.PartSize` refs replaced.
- **`pkg/server/server.go`** — Parses optional `part_size` from PATCH request body, passes to backend.
- **Tests** — All `NewWriteBuffer` calls updated for new 3-arg signature. `partSize` constant refs → `DefaultPartSize`.

## Design decisions
- **Client tells server its part size**: The client computes dirty-part boundaries at write time (before the server responds), so the server must use the same boundary. The client sends `part_size` explicitly in the PATCH request.
- **Backward compatible**: If `part_size` is omitted (old clients), server falls back to `CalcAdaptivePartSize(newSize)` which returns 8 MiB for files ≤ ~80 GB.
- **Adaptive part size for existing files**: FUSE uses `CalcAdaptivePartSize(originalFileSize)` when creating the WriteBuffer for existing files. For new files and lazy-init paths, defaults to 8 MiB.

## Test plan
- [x] `go vet ./pkg/fuse/... ./pkg/backend/... ./pkg/server/... ./pkg/client/...` — clean
- [x] `go test ./pkg/fuse/...` — all 41 tests pass
- [x] `go test -c ./pkg/backend/...` — compiles
- [x] `go test -c ./pkg/server/...` — compiles
- [x] `go test -c ./pkg/client/...` — compiles
- [ ] Runtime `go test` for backend/server/client blocked by `rootless Docker not found` / testcontainers

Stacked on T4 (`feat/t4-pipelined-presign`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)