### PR TITLE
feat: switch v1 per-part checksums from SHA-256 to CRC32C

### DIFF
--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -104,7 +104,7 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 	fileID := b.genID()
 	newS3Key := "blobs/" + fileID
 
-	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key)
+	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key, s3client.ChecksumAlgoSHA256)
 	if err != nil {
 		logger.Error(ctx, "backend_patch_upload_create_mpu_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
@@ -149,7 +149,7 @@ func (b *Dat9Backend) InitiatePatchUpload(ctx context.Context, path string, newS
 			plan.CopiedParts = append(plan.CopiedParts, p.Number)
 		} else {
 			// Dirty part or new part beyond original → client must upload
-			u, err := b.s3.PresignUploadPart(ctx, newS3Key, mpu.UploadID, p.Number, p.Size, "", s3client.UploadTTL)
+			u, err := b.s3.PresignUploadPart(ctx, newS3Key, mpu.UploadID, p.Number, p.Size, s3client.ChecksumAlgoSHA256, "", s3client.UploadTTL)
 			if err != nil {
 				_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
 				logger.Error(ctx, "backend_patch_upload_presign_failed", zap.String("path", path), zap.Int("part", p.Number), zap.Error(err))

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -105,8 +105,8 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 	fileID := b.genID()
 	s3Key := "blobs/" + fileID
 
-	// Create S3 multipart upload
-	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key)
+	// Create S3 multipart upload — v1 uses CRC32C
+	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoCRC32C)
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_create_multipart_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
@@ -127,7 +127,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 		if len(partChecksums) > 0 {
 			checksum = partChecksums[i]
 		}
-		u, err := b.s3.PresignUploadPart(ctx, s3Key, mpu.UploadID, p.Number, p.Size, checksum, s3client.UploadTTL)
+		u, err := b.s3.PresignUploadPart(ctx, s3Key, mpu.UploadID, p.Number, p.Size, s3client.ChecksumAlgoCRC32C, checksum, s3client.UploadTTL)
 		if err != nil {
 			_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 			logger.Error(ctx, "backend_initiate_upload_presign_failed", zap.String("path", path), zap.Int("part_number", p.Number), zap.Error(err))
@@ -225,7 +225,7 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 	fileID := b.genID()
 	s3Key := "blobs/" + fileID
 
-	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key)
+	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoSHA256)
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_v2_create_multipart_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
@@ -343,7 +343,7 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
 		return nil, err
 	}
-	u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, partNumber, partSize, checksumSHA256, s3client.UploadTTL)
+	u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, partNumber, partSize, s3client.ChecksumAlgoSHA256, checksumSHA256, s3client.UploadTTL)
 	if err != nil {
 		logger.Error(ctx, "backend_presign_part_failed", zap.String("upload_id", uploadID), zap.Int("part_number", partNumber), zap.Error(err))
 		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
@@ -408,7 +408,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
 			return nil, err
 		}
-		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, pn, partSize, checksumSHA256, s3client.UploadTTL)
+		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, pn, partSize, s3client.ChecksumAlgoSHA256, checksumSHA256, s3client.UploadTTL)
 		if err != nil {
 			logger.Error(ctx, "backend_presign_parts_failed", zap.String("upload_id", uploadID), zap.Int("part_number", pn), zap.Error(err))
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
@@ -757,7 +757,7 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 		if len(partChecksums) > 0 {
 			checksum = partChecksums[p.Number-1]
 		}
-		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, p.Number, p.Size, checksum, s3client.UploadTTL)
+		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, p.Number, p.Size, s3client.ChecksumAlgoCRC32C, checksum, s3client.UploadTTL)
 		if err != nil {
 			logger.Error(ctx, "backend_resume_upload_presign_failed", zap.String("upload_id", uploadID), zap.Int("part_number", p.Number), zap.Error(err))
 			metrics.RecordOperation("backend", "resume_upload", "error", time.Since(start))

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -3,10 +3,11 @@ package client
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"runtime"
@@ -30,6 +31,7 @@ type PartURL struct {
 	URL            string            `json:"url"`
 	Size           int64             `json:"size"`
 	ChecksumSHA256 string            `json:"checksum_sha256,omitempty"`
+	ChecksumCRC32C string            `json:"checksum_crc32c,omitempty"`
 	Headers        map[string]string `json:"headers,omitempty"`
 	ExpiresAt      string            `json:"expires_at"`
 }
@@ -364,11 +366,10 @@ func (c *Client) uploadParts(ctx context.Context, plan UploadPlan, ra io.ReaderA
 
 // uploadOnePart PUTs data to a presigned URL and returns the ETag.
 func (c *Client) uploadOnePart(ctx context.Context, part PartURL, data []byte) (string, error) {
-	checksum := part.ChecksumSHA256
+	checksum := part.ChecksumCRC32C
 	if checksum == "" {
-		// No pre-computed checksum (legacy path) — compute it now.
-		h := sha256.Sum256(data)
-		checksum = base64.StdEncoding.EncodeToString(h[:])
+		// No pre-computed checksum — compute CRC32C now.
+		checksum = computeCRC32C(data)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, part.URL, bytes.NewReader(data))
@@ -382,7 +383,7 @@ func (c *Client) uploadOnePart(ctx context.Context, part PartURL, data []byte) (
 		req.Header.Set(k, v)
 	}
 	req.ContentLength = int64(len(data))
-	req.Header.Set("x-amz-checksum-sha256", checksum)
+	req.Header.Set("x-amz-checksum-crc32c", checksum)
 
 	resp, err := c.httpClient.Do(req) // Direct to S3, no auth header
 	if err != nil {
@@ -1172,8 +1173,7 @@ func computePartChecksumsFromReaderAt(r io.ReaderAt, totalSize int64, partSize i
 					})
 					return
 				}
-				h := sha256.Sum256(data)
-				checksums[i] = base64.StdEncoding.EncodeToString(h[:])
+				checksums[i] = computeCRC32C(data)
 			}
 		}()
 	}
@@ -1183,4 +1183,13 @@ func computePartChecksumsFromReaderAt(r io.ReaderAt, totalSize int64, partSize i
 		return nil, firstErr
 	}
 	return checksums, nil
+}
+
+var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+
+func computeCRC32C(data []byte) string {
+	v := crc32.Checksum(data, crc32cTable)
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, v)
+	return base64.StdEncoding.EncodeToString(b)
 }

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1038,7 +1038,9 @@ func TestResumeUploadIntegrationProgressTotal(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.ContentLength = plan.Parts[0].Size
-	if plan.Parts[0].ChecksumSHA256 != "" {
+	if plan.Parts[0].ChecksumCRC32C != "" {
+		req.Header.Set("x-amz-checksum-crc32c", plan.Parts[0].ChecksumCRC32C)
+	} else if plan.Parts[0].ChecksumSHA256 != "" {
 		req.Header.Set("x-amz-checksum-sha256", plan.Parts[0].ChecksumSHA256)
 	}
 	resp, err = http.DefaultClient.Do(req)

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -82,11 +82,15 @@ func (c *AWSS3Client) fullKey(key string) string {
 	return c.prefix + key
 }
 
-func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string) (*MultipartUpload, error) {
+func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo) (*MultipartUpload, error) {
+	awsAlgo := types.ChecksumAlgorithmSha256
+	if algo == ChecksumAlgoCRC32C {
+		awsAlgo = types.ChecksumAlgorithmCrc32c
+	}
 	out, err := c.client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
 		Bucket:            &c.bucket,
 		Key:               aws.String(c.fullKey(key)),
-		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
+		ChecksumAlgorithm: awsAlgo,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create multipart upload: %w", err)
@@ -97,7 +101,7 @@ func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string) (*M
 	}, nil
 }
 
-func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, checksumSHA256 string, ttl time.Duration) (*UploadPartURL, error) {
+func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, algo ChecksumAlgo, checksumValue string, ttl time.Duration) (*UploadPartURL, error) {
 	if ttl > UploadTTL {
 		ttl = UploadTTL
 	}
@@ -108,8 +112,16 @@ func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID strin
 		PartNumber:    aws.Int32(int32(partNumber)),
 		ContentLength: aws.Int64(partSize),
 	}
-	if checksumSHA256 != "" {
-		in.ChecksumSHA256 = aws.String(checksumSHA256)
+	var headerKey string
+	if checksumValue != "" {
+		switch algo {
+		case ChecksumAlgoCRC32C:
+			in.ChecksumCRC32C = aws.String(checksumValue)
+			headerKey = "x-amz-checksum-crc32c"
+		default:
+			in.ChecksumSHA256 = aws.String(checksumValue)
+			headerKey = "x-amz-checksum-sha256"
+		}
 	}
 	partPresigner := v4.NewSigner(func(o *v4.SignerOptions) {
 		o.DisableURIPathEscaping = true
@@ -123,17 +135,23 @@ func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID strin
 		return nil, fmt.Errorf("presign upload part: %w", err)
 	}
 	headers := flattenSignedHeaders(out.SignedHeader)
-	if checksumSHA256 != "" {
-		headers[strings.ToLower("x-amz-checksum-sha256")] = checksumSHA256
+	if checksumValue != "" {
+		headers[headerKey] = checksumValue
 	}
-	return &UploadPartURL{
-		Number:         partNumber,
-		URL:            out.URL,
-		Size:           partSize,
-		ChecksumSHA256: checksumSHA256,
-		Headers:        headers,
-		ExpiresAt:      time.Now().Add(ttl),
-	}, nil
+	result := &UploadPartURL{
+		Number:    partNumber,
+		URL:       out.URL,
+		Size:      partSize,
+		Headers:   headers,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+	switch algo {
+	case ChecksumAlgoCRC32C:
+		result.ChecksumCRC32C = checksumValue
+	default:
+		result.ChecksumSHA256 = checksumValue
+	}
+	return result, nil
 }
 
 func flattenSignedHeaders(h http.Header) map[string]string {
@@ -163,7 +181,9 @@ func (c *AWSS3Client) CompleteMultipartUpload(ctx context.Context, key, uploadID
 			PartNumber: aws.Int32(int32(p.Number)),
 			ETag:       aws.String(p.ETag),
 		}
-		if p.ChecksumSHA256 != "" {
+		if p.ChecksumCRC32C != "" {
+			cp.ChecksumCRC32C = aws.String(p.ChecksumCRC32C)
+		} else if p.ChecksumSHA256 != "" {
 			cp.ChecksumSHA256 = aws.String(p.ChecksumSHA256)
 		}
 		completed[i] = cp
@@ -214,6 +234,7 @@ func (c *AWSS3Client) ListParts(ctx context.Context, key, uploadID string) ([]Pa
 				Size:           aws.ToInt64(p.Size),
 				ETag:           aws.ToString(p.ETag),
 				ChecksumSHA256: aws.ToString(p.ChecksumSHA256),
+				ChecksumCRC32C: aws.ToString(p.ChecksumCRC32C),
 			})
 		}
 		if !aws.ToBool(out.IsTruncated) {

--- a/pkg/s3client/local.go
+++ b/pkg/s3client/local.go
@@ -53,7 +53,7 @@ func (c *LocalS3Client) partPath(key, uploadID string, partNumber int) string {
 	return filepath.Join(c.rootDir, "parts", uploadID, fmt.Sprintf("%05d", partNumber))
 }
 
-func (c *LocalS3Client) CreateMultipartUpload(ctx context.Context, key string) (*MultipartUpload, error) {
+func (c *LocalS3Client) CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo) (*MultipartUpload, error) {
 	uploadID := fmt.Sprintf("upload-%x", sha256.Sum256([]byte(key+time.Now().String())))[:24]
 
 	partsDir := filepath.Join(c.rootDir, "parts", uploadID)
@@ -68,20 +68,31 @@ func (c *LocalS3Client) CreateMultipartUpload(ctx context.Context, key string) (
 	return &MultipartUpload{UploadID: uploadID, Key: key}, nil
 }
 
-func (c *LocalS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, checksumSHA256 string, ttl time.Duration) (*UploadPartURL, error) {
+func (c *LocalS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, algo ChecksumAlgo, checksumValue string, ttl time.Duration) (*UploadPartURL, error) {
 	url := fmt.Sprintf("%s/upload/%s/%d", c.baseURL, uploadID, partNumber)
 	var headers map[string]string
-	if checksumSHA256 != "" {
-		headers = map[string]string{"x-amz-checksum-sha256": checksumSHA256}
+	if checksumValue != "" {
+		switch algo {
+		case ChecksumAlgoCRC32C:
+			headers = map[string]string{"x-amz-checksum-crc32c": checksumValue}
+		default:
+			headers = map[string]string{"x-amz-checksum-sha256": checksumValue}
+		}
 	}
-	return &UploadPartURL{
-		Number:         partNumber,
-		URL:            url,
-		Size:           partSize,
-		ChecksumSHA256: checksumSHA256,
-		Headers:        headers,
-		ExpiresAt:      time.Now().Add(ttl),
-	}, nil
+	result := &UploadPartURL{
+		Number:    partNumber,
+		URL:       url,
+		Size:      partSize,
+		Headers:   headers,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+	switch algo {
+	case ChecksumAlgoCRC32C:
+		result.ChecksumCRC32C = checksumValue
+	default:
+		result.ChecksumSHA256 = checksumValue
+	}
+	return result, nil
 }
 
 // UploadPart directly writes a part (used by the local presigned URL handler).

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -9,12 +9,21 @@ import (
 	"time"
 )
 
+// ChecksumAlgo identifies the checksum algorithm for a multipart upload.
+type ChecksumAlgo string
+
+const (
+	ChecksumAlgoSHA256 ChecksumAlgo = "SHA256"
+	ChecksumAlgoCRC32C ChecksumAlgo = "CRC32C"
+)
+
 // Part represents a single part in a multipart upload.
 type Part struct {
 	Number         int    // 1-based part number
 	Size           int64  // part size in bytes
 	ETag           string // returned by S3 after upload
 	ChecksumSHA256 string // base64-encoded SHA-256, set when client uploads with checksum
+	ChecksumCRC32C string // base64-encoded CRC32C, set when client uploads with CRC32C checksum
 }
 
 // UploadPartURL is a presigned URL for uploading one part.
@@ -22,7 +31,8 @@ type UploadPartURL struct {
 	Number         int               `json:"number"`                    // 1-based part number
 	URL            string            `json:"url"`                       // presigned PUT URL
 	Size           int64             `json:"size"`                      // expected part size
-	ChecksumSHA256 string            `json:"checksum_sha256,omitempty"` // expected checksum for signed uploads
+	ChecksumSHA256 string            `json:"checksum_sha256,omitempty"` // expected SHA-256 checksum for signed uploads
+	ChecksumCRC32C string            `json:"checksum_crc32c,omitempty"` // expected CRC32C checksum for signed uploads
 	Headers        map[string]string `json:"headers,omitempty"`         // required headers for presigned PUT
 	ExpiresAt      time.Time         `json:"expires_at"`                // URL expiry
 }
@@ -36,12 +46,14 @@ type MultipartUpload struct {
 // S3Client abstracts S3-compatible object store operations.
 // Implementations: LocalS3Client (testing), AWSS3Client (production).
 type S3Client interface {
-	// CreateMultipartUpload initiates a new multipart upload.
-	CreateMultipartUpload(ctx context.Context, key string) (*MultipartUpload, error)
+	// CreateMultipartUpload initiates a new multipart upload with the given checksum algorithm.
+	CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo) (*MultipartUpload, error)
 
 	// PresignUploadPart returns a presigned URL for uploading a specific part.
 	// partSize is bound into the presigned URL as Content-Length per §11.2.
-	PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, checksumSHA256 string, ttl time.Duration) (*UploadPartURL, error)
+	// algo + checksumValue work together: the value is signed into the URL under the
+	// header corresponding to algo. Pass empty checksumValue to skip checksum signing.
+	PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, algo ChecksumAlgo, checksumValue string, ttl time.Duration) (*UploadPartURL, error)
 
 	// CompleteMultipartUpload finalizes the upload with the given parts.
 	CompleteMultipartUpload(ctx context.Context, key, uploadID string, parts []Part) error

--- a/pkg/s3client/s3client_test.go
+++ b/pkg/s3client/s3client_test.go
@@ -95,7 +95,7 @@ func TestMultipartUploadComplete(t *testing.T) {
 	ctx := context.Background()
 
 	// Initiate
-	upload, err := c.CreateMultipartUpload(ctx, "blobs/big1")
+	upload, err := c.CreateMultipartUpload(ctx, "blobs/big1", ChecksumAlgoSHA256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestMultipartUploadAbort(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()
 
-	upload, err := c.CreateMultipartUpload(ctx, "blobs/aborted")
+	upload, err := c.CreateMultipartUpload(ctx, "blobs/aborted", ChecksumAlgoSHA256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,9 +167,9 @@ func TestPresignURLsGenerated(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()
 
-	upload, _ := c.CreateMultipartUpload(ctx, "blobs/presign-test")
+	upload, _ := c.CreateMultipartUpload(ctx, "blobs/presign-test", ChecksumAlgoSHA256)
 
-	url, err := c.PresignUploadPart(ctx, "blobs/presign-test", upload.UploadID, 1, 8<<20, "abc", UploadTTL)
+	url, err := c.PresignUploadPart(ctx, "blobs/presign-test", upload.UploadID, 1, 8<<20, ChecksumAlgoSHA256, "abc", UploadTTL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func TestPartialUploadAndListParts(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()
 
-	upload, _ := c.CreateMultipartUpload(ctx, "blobs/partial")
+	upload, _ := c.CreateMultipartUpload(ctx, "blobs/partial", ChecksumAlgoSHA256)
 
 	// Upload only parts 1 and 3 (skip 2 — simulates interrupted upload)
 	if _, err := c.UploadPart(ctx, upload.UploadID, 1, bytes.NewReader([]byte("PART1"))); err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1090,8 +1090,8 @@ func validatePartChecksums(parts []string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid part checksums: invalid base64 at index %d", i)
 		}
-		if len(decoded) != 32 {
-			return nil, fmt.Errorf("invalid part checksums: decoded length %d at index %d, expected 32", len(decoded), i)
+		if len(decoded) != 4 {
+			return nil, fmt.Errorf("invalid part checksums: decoded length %d at index %d, expected 4", len(decoded), i)
 		}
 		out = append(out, v)
 	}

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -3,10 +3,11 @@ package server
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -63,13 +64,16 @@ func newTestServerWithS3Config(t *testing.T, backendOpts backend.Options, worker
 }
 
 func partChecksumHeader(data []byte) string {
+	table := crc32.MakeTable(crc32.Castagnoli)
 	parts := s3client.CalcParts(int64(len(data)), s3client.PartSize)
 	out := make([]string, 0, len(parts))
 	for _, p := range parts {
 		start := int64(p.Number-1) * s3client.PartSize
 		end := start + p.Size
-		h := sha256.Sum256(data[start:end])
-		out = append(out, base64.StdEncoding.EncodeToString(h[:]))
+		v := crc32.Checksum(data[start:end], table)
+		b := make([]byte, 4)
+		binary.BigEndian.PutUint32(b, v)
+		out = append(out, base64.StdEncoding.EncodeToString(b))
 	}
 	return strings.Join(out, ",")
 }
@@ -912,7 +916,7 @@ func TestParsePartChecksumsHeaderValidation(t *testing.T) {
 
 	short := base64.StdEncoding.EncodeToString([]byte("short"))
 	_, err = parsePartChecksumsHeader(short)
-	if err == nil || !strings.Contains(err.Error(), "expected 32") {
+	if err == nil || !strings.Contains(err.Error(), "expected 4") {
 		t.Fatalf("expected decoded length error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #113

- **Algorithm-aware S3 interface**: `CreateMultipartUpload` and `PresignUploadPart` now accept a `ChecksumAlgo` parameter (`SHA256` or `CRC32C`), replacing the previous hardcoded SHA-256 assumption.
- **v1 upload chain → CRC32C**: Initiate, resume, and client-side upload all use CRC32C (4-byte, hardware-accelerated via Castagnoli). Server-side `validatePartChecksums` validates 4-byte decoded length.
- **v2 and patch paths unchanged**: Both continue using SHA256. `ChecksumContract.Supported` stays `["SHA-256"]` for v2.
- **Scope reduction**: Only v1 is changed. v2/patch are untouched.

### Files changed (10)
| File | Change |
|---|---|
| `pkg/s3client/s3client.go` | `ChecksumAlgo` type, `ChecksumCRC32C` field on `Part`/`UploadPartURL` |
| `pkg/s3client/aws.go` | Algorithm-aware `CreateMultipartUpload`, `PresignUploadPart`, `CompleteMultipartUpload`, `ListParts` |
| `pkg/s3client/local.go` | Updated to match new signatures |
| `pkg/backend/upload.go` | v1=CRC32C, v2=SHA256, resume=CRC32C |
| `pkg/backend/patch.go` | Explicit `ChecksumAlgoSHA256` |
| `pkg/client/transfer.go` | `computeCRC32C()` helper, `x-amz-checksum-crc32c` header |
| `pkg/server/server.go` | `validatePartChecksums` checks 4-byte CRC32C |
| `pkg/server/upload_test.go` | CRC32C checksum computation in test helper |
| `pkg/s3client/s3client_test.go` | Updated test call sites |
| `pkg/client/transfer_test.go` | Updated checksum field assertions |

## Deploy-time action

**Abort all in-flight v1 uploads before deploying.** Existing uploads were created with SHA256 algorithm declaration and cannot be completed with CRC32C checksums. v2 uploads are unaffected.

## Test plan

- [ ] CI passes (`go build ./pkg/...`, `go vet ./pkg/...`)
- [ ] `pkg/s3client` tests pass (CalcParts, multipart, presign)
- [ ] `pkg/server` upload tests pass (initiate, resume, complete, checksum validation)
- [ ] `pkg/client` transfer tests pass (v1 large file, resume integration)
- [ ] `pkg/backend` upload tests pass (initiate, resume, abort, v2 flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)