### PR TITLE
fix: v2 multipart upload should not declare ChecksumAlgorithm

### DIFF
--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/datastore"
@@ -59,6 +60,10 @@ type PresignPartEntry struct {
 }
 
 var ErrPartChecksumCountMismatch = errors.New("part checksum count mismatch")
+
+func normalizeETag(etag string) string {
+	return strings.Trim(etag, "\"")
+}
 
 // S3 returns the S3Client (nil when not configured).
 func (b *Dat9Backend) S3() s3client.S3Client { return b.s3 }
@@ -487,7 +492,7 @@ func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clie
 			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 			return fmt.Errorf("part %d not found in S3", partNum)
 		}
-		if clientETag != s3ETag {
+		if normalizeETag(clientETag) != normalizeETag(s3ETag) {
 			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 			return fmt.Errorf("part %d ETag mismatch: client=%q, S3=%q", partNum, clientETag, s3ETag)
 		}

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -225,7 +225,10 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 	fileID := b.genID()
 	s3Key := "blobs/" + fileID
 
-	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoSHA256)
+	// v2 does not declare a checksum algorithm at the S3 level because the
+	// client doesn't send per-part checksums yet (ChecksumContract.Required=false).
+	// When #114 adds inline checksums, switch back to a concrete algorithm.
+	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoNone)
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_v2_create_multipart_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -711,6 +711,63 @@ func TestV2CompleteETagMismatch(t *testing.T) {
 	}
 }
 
+func TestV2CompleteAcceptsQuotedClientETag(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	totalSize := int64(20 << 20)
+	plan, err := b.InitiateUploadV2(ctx, "/v2-quoted-client-etag.bin", totalSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	partNums := make([]int, plan.TotalParts)
+	for i := range partNums {
+		partNums[i] = i + 1
+	}
+	urls, err := b.PresignParts(ctx, plan.UploadID, entriesFromInts(partNums))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	upload, _ := b.GetUpload(ctx, plan.UploadID)
+	partData := make([]byte, totalSize)
+	completeParts := make([]CompletePart, len(urls))
+	for i, u := range urls {
+		start := int64(u.Number-1) * upload.PartSize
+		end := start + u.Size
+		if end > totalSize {
+			end = totalSize
+		}
+		etag, err := b.S3().(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, u.Number, bytes.NewReader(partData[start:end]))
+		if err != nil {
+			t.Fatalf("upload part %d: %v", u.Number, err)
+		}
+		completeParts[i] = CompletePart{Number: u.Number, ETag: "\"" + etag + "\""}
+	}
+
+	if err := b.ConfirmUploadV2(ctx, plan.UploadID, completeParts); err != nil {
+		t.Fatalf("ConfirmUploadV2 with quoted client ETags: %v", err)
+	}
+}
+
+func TestNormalizeETag(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "bare", in: "abc", want: "abc"},
+		{name: "quoted", in: "\"abc\"", want: "abc"},
+		{name: "double quoted empty", in: "\"\"", want: ""},
+	}
+	for _, tt := range tests {
+		if got := normalizeETag(tt.in); got != tt.want {
+			t.Fatalf("%s: normalizeETag(%q) = %q, want %q", tt.name, tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestV2CompletePartCountMismatch(t *testing.T) {
 	b := newTestBackendWithS3(t)
 	ctx := context.Background()

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -87,14 +87,12 @@ func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string, alg
 		Bucket: &c.bucket,
 		Key:    aws.String(c.fullKey(key)),
 	}
-	switch algo {
-	case ChecksumAlgoCRC32C:
-		in.ChecksumAlgorithm = types.ChecksumAlgorithmCrc32c
-	case ChecksumAlgoSHA256:
-		in.ChecksumAlgorithm = types.ChecksumAlgorithmSha256
-	default:
-		// ChecksumAlgoNone: do not set ChecksumAlgorithm — S3 won't
-		// require per-part checksum headers.
+	awsAlgo, ok, err := checksumAlgorithmForAWS(algo)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		in.ChecksumAlgorithm = awsAlgo
 	}
 	out, err := c.client.CreateMultipartUpload(ctx, in)
 	if err != nil {
@@ -104,6 +102,19 @@ func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string, alg
 		UploadID: aws.ToString(out.UploadId),
 		Key:      key,
 	}, nil
+}
+
+func checksumAlgorithmForAWS(algo ChecksumAlgo) (types.ChecksumAlgorithm, bool, error) {
+	switch algo {
+	case ChecksumAlgoNone:
+		return "", false, nil
+	case ChecksumAlgoCRC32C:
+		return types.ChecksumAlgorithmCrc32c, true, nil
+	case ChecksumAlgoSHA256:
+		return types.ChecksumAlgorithmSha256, true, nil
+	default:
+		return "", false, fmt.Errorf("unsupported checksum algorithm: %q", algo)
+	}
 }
 
 func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, algo ChecksumAlgo, checksumValue string, ttl time.Duration) (*UploadPartURL, error) {

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -83,15 +83,20 @@ func (c *AWSS3Client) fullKey(key string) string {
 }
 
 func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo) (*MultipartUpload, error) {
-	awsAlgo := types.ChecksumAlgorithmSha256
-	if algo == ChecksumAlgoCRC32C {
-		awsAlgo = types.ChecksumAlgorithmCrc32c
+	in := &s3.CreateMultipartUploadInput{
+		Bucket: &c.bucket,
+		Key:    aws.String(c.fullKey(key)),
 	}
-	out, err := c.client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
-		Bucket:            &c.bucket,
-		Key:               aws.String(c.fullKey(key)),
-		ChecksumAlgorithm: awsAlgo,
-	})
+	switch algo {
+	case ChecksumAlgoCRC32C:
+		in.ChecksumAlgorithm = types.ChecksumAlgorithmCrc32c
+	case ChecksumAlgoSHA256:
+		in.ChecksumAlgorithm = types.ChecksumAlgorithmSha256
+	default:
+		// ChecksumAlgoNone: do not set ChecksumAlgorithm — S3 won't
+		// require per-part checksum headers.
+	}
+	out, err := c.client.CreateMultipartUpload(ctx, in)
 	if err != nil {
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -13,6 +13,7 @@ import (
 type ChecksumAlgo string
 
 const (
+	ChecksumAlgoNone   ChecksumAlgo = ""       // no checksum algorithm declared
 	ChecksumAlgoSHA256 ChecksumAlgo = "SHA256"
 	ChecksumAlgoCRC32C ChecksumAlgo = "CRC32C"
 )

--- a/pkg/s3client/s3client_test.go
+++ b/pkg/s3client/s3client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -257,17 +258,51 @@ func TestMultipartUploadNoChecksumAlgo(t *testing.T) {
 	}
 }
 
+func TestChecksumAlgorithmForAWS(t *testing.T) {
+	tests := []struct {
+		name    string
+		algo    ChecksumAlgo
+		want    string
+		wantOK  bool
+		wantErr string
+	}{
+		{name: "none", algo: ChecksumAlgoNone, wantOK: false},
+		{name: "crc32c", algo: ChecksumAlgoCRC32C, want: "CRC32C", wantOK: true},
+		{name: "sha256", algo: ChecksumAlgoSHA256, want: "SHA256", wantOK: true},
+		{name: "unknown", algo: ChecksumAlgo("bogus"), wantErr: "unsupported checksum algorithm"},
+	}
+
+	for _, tt := range tests {
+		got, ok, err := checksumAlgorithmForAWS(tt.algo)
+		if tt.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("%s: expected error containing %q, got %v", tt.name, tt.wantErr, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tt.name, err)
+		}
+		if ok != tt.wantOK {
+			t.Fatalf("%s: ok=%v, want %v", tt.name, ok, tt.wantOK)
+		}
+		if string(got) != tt.want {
+			t.Fatalf("%s: got %q, want %q", tt.name, string(got), tt.want)
+		}
+	}
+}
+
 func TestCalcAdaptivePartSize(t *testing.T) {
 	tests := []struct {
-		name     string
-		total    int64
-		wantPS   int64
-		wantN    int // expected number of parts (0 = skip check)
+		name   string
+		total  int64
+		wantPS int64
+		wantN  int // expected number of parts (0 = skip check)
 	}{
 		{"small file 1 MiB", 1 << 20, PartSize, 1},
-		{"80 GiB", 80 * (1 << 30), 9 << 20, 0},           // ceil(80GiB/10000) → align up to 9 MiB
-		{"100 GiB", 100 * (1 << 30), 11 << 20, 0},        // ceil(100GiB/10000) → align up to 11 MiB
-		{"500 GiB", 500 * (1 << 30), 52 << 20, 0},        // ceil(500GiB/10000) → align up to 52 MiB
+		{"80 GiB", 80 * (1 << 30), 9 << 20, 0},    // ceil(80GiB/10000) → align up to 9 MiB
+		{"100 GiB", 100 * (1 << 30), 11 << 20, 0}, // ceil(100GiB/10000) → align up to 11 MiB
+		{"500 GiB", 500 * (1 << 30), 52 << 20, 0}, // ceil(500GiB/10000) → align up to 52 MiB
 		{"5 TiB max S3 object", 5 * (1 << 40), MaxAdaptivePartSize, 0},
 	}
 	for _, tt := range tests {

--- a/pkg/s3client/s3client_test.go
+++ b/pkg/s3client/s3client_test.go
@@ -215,6 +215,48 @@ func TestPartialUploadAndListParts(t *testing.T) {
 	}
 }
 
+func TestMultipartUploadNoChecksumAlgo(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	// Initiate with ChecksumAlgoNone — simulates v2 uploads where
+	// the client doesn't send per-part checksums.
+	upload, err := c.CreateMultipartUpload(ctx, "blobs/no-checksum", ChecksumAlgoNone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if upload.UploadID == "" {
+		t.Fatal("expected non-empty upload ID")
+	}
+
+	// Upload parts without any checksum header
+	partData := []string{"AAAA", "BB"}
+	var parts []Part
+	for i, d := range partData {
+		etag, err := c.UploadPart(ctx, upload.UploadID, i+1, bytes.NewReader([]byte(d)))
+		if err != nil {
+			t.Fatalf("upload part %d: %v", i+1, err)
+		}
+		parts = append(parts, Part{Number: i + 1, Size: int64(len(d)), ETag: etag})
+	}
+
+	// Complete should succeed without checksum validation
+	if err := c.CompleteMultipartUpload(ctx, "blobs/no-checksum", upload.UploadID, parts); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify assembled object
+	rc, err := c.GetObject(ctx, "blobs/no-checksum")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rc.Close() }()
+	got, _ := io.ReadAll(rc)
+	if string(got) != "AAAABB" {
+		t.Errorf("expected AAAABB, got %q", got)
+	}
+}
+
 func TestCalcAdaptivePartSize(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Closes #133

`InitiateUploadV2` was creating S3 multipart uploads with `ChecksumAlgorithm=SHA256`, but the v2 client never sends per-part `x-amz-checksum-sha256` headers (`ChecksumContract.Required=false`). S3 rejects parts that lack the declared checksum header with `InvalidRequest`.

**Fix**: Add `ChecksumAlgoNone` and use it for v2 initiate, so S3 does not require per-part checksums. v1 (CRC32C) and patch (SHA256) are unchanged.

### Files changed (4)
| File | Change |
|---|---|
| `pkg/s3client/s3client.go` | Add `ChecksumAlgoNone` constant |
| `pkg/s3client/aws.go` | Handle `ChecksumAlgoNone` — skip `ChecksumAlgorithm` field in `CreateMultipartUploadInput` |
| `pkg/backend/upload.go` | v2 initiate uses `ChecksumAlgoNone` instead of `ChecksumAlgoSHA256` |
| `pkg/s3client/s3client_test.go` | Add `TestMultipartUploadNoChecksumAlgo` regression test |

### What's NOT changed
- v1 upload: still uses `ChecksumAlgoCRC32C`
- patch upload: still uses `ChecksumAlgoSHA256`
- `ChecksumContract.Supported`: still `["SHA-256"]`

## Test plan

- [x] `go test ./pkg/s3client/...` — all 10 tests pass locally
- [ ] CI passes
- [ ] `pkg/backend` tests pass (v2 initiate + presign + complete)
- [ ] `pkg/server` upload tests pass
- [ ] `pkg/client` transfer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)