### PR TITLE
Optimize large-file download path by reusing presigned URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SERVER_BIN ?= $(BIN_DIR)/$(APP_NAME)
 CLI_BIN ?= $(BIN_DIR)/$(CLI_NAME)
 LOCAL_BIN ?= $(CURDIR)/bin
 VERSION ?=
+GIT_HASH ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 CLI_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
@@ -82,11 +83,13 @@ run-server-local:
 build-cli:
 	mkdir -p $(BIN_DIR)
 	@set -euo pipefail; \
+	ldflags="-X main.gitHash=$(GIT_HASH)"; \
 	if [ -n "$(VERSION)" ]; then \
-		CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -ldflags "-X main.version=$(VERSION)" -o $(CLI_BIN) ./cmd/drive9; \
+		ldflags="$$ldflags -X main.version=$(VERSION)"; \
 	else \
-		CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -o $(CLI_BIN) ./cmd/drive9; \
+		ldflags="$$ldflags -X main.version=dev"; \
 	fi; \
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -ldflags "$$ldflags" -o $(CLI_BIN) ./cmd/drive9; \
 	true
 
 build-cli-release:

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ c.Delete("/data/file.txt")
 | `DRIVE9_IMAGE_EXTRACT_PROMPT` | Custom extraction prompt | `用中文描述这张图片，用于文件搜索。包括：主要物体、场景描述、图中可见文字（OCR）、简洁标签。最后一行用英文写5-10个关键词标签（English tags），用逗号分隔。` |
 | `DRIVE9_IMAGE_EXTRACT_MAX_TOKENS` | Max output tokens for model extraction | `256` |
 | `DRIVE9_CLI_LOG_ENABLED` | Enable CLI structured log file output | `false` |
+| `DRIVE9_BENCH_JSON_ENABLED` | Emit benchmark-consumable JSON lines on CLI stderr for selected paths | `false` |
 | `DRIVE9_CLI_LOG_MAX_SIZE_MB` | CLI log rotation max size in MB | `10` |
 | `DRIVE9_CLI_LOG_MAX_BACKUPS` | CLI log rotation max backups | `5` |
 | `DRIVE9_CLI_LOG_MAX_AGE_DAYS` | CLI log rotation max age in days | `14` |

--- a/README.md
+++ b/README.md
@@ -188,8 +188,7 @@ c.Delete("/data/file.txt")
 | `DRIVE9_IMAGE_EXTRACT_MODEL` | Vision model name (for example Qwen VL model id) | |
 | `DRIVE9_IMAGE_EXTRACT_PROMPT` | Custom extraction prompt | `用中文描述这张图片，用于文件搜索。包括：主要物体、场景描述、图中可见文字（OCR）、简洁标签。最后一行用英文写5-10个关键词标签（English tags），用逗号分隔。` |
 | `DRIVE9_IMAGE_EXTRACT_MAX_TOKENS` | Max output tokens for model extraction | `256` |
-| `DRIVE9_CLI_LOG_ENABLED` | Enable CLI structured log file output | `false` |
-| `DRIVE9_BENCH_JSON_ENABLED` | Emit benchmark-consumable JSON lines on CLI stderr for selected paths | `false` |
+| `DRIVE9_CLI_LOG_ENABLED` | Enable CLI structured log file output, including benchmark-consumable transfer summary events | `false` |
 | `DRIVE9_CLI_LOG_MAX_SIZE_MB` | CLI log rotation max size in MB | `10` |
 | `DRIVE9_CLI_LOG_MAX_BACKUPS` | CLI log rotation max backups | `5` |
 | `DRIVE9_CLI_LOG_MAX_AGE_DAYS` | CLI log rotation max age in days | `14` |

--- a/cmd/drive9/cli/cp.go
+++ b/cmd/drive9/cli/cp.go
@@ -3,9 +3,11 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	"github.com/mem9-ai/dat9/pkg/client"
 )
@@ -101,20 +103,17 @@ func resumeUpload(ctx context.Context, c *client.Client, localPath, remotePath s
 }
 
 func downloadFile(ctx context.Context, c *client.Client, remotePath, localPath string) error {
-	rc, err := c.ReadStream(ctx, remotePath)
+	info, err := c.Stat(remotePath)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = rc.Close() }()
 
-	out, err := os.Create(localPath)
+	summary, err := c.DownloadToFileWithSummary(ctx, remotePath, localPath, info.Size)
 	if err != nil {
-		return fmt.Errorf("create %s: %w", localPath, err)
+		return err
 	}
-	defer func() { _ = out.Close() }()
-
-	_, err = io.Copy(out, rc)
-	return err
+	emitBenchJSON(summary)
+	return nil
 }
 
 func streamToStdout(ctx context.Context, c *client.Client, remotePath string) error {
@@ -133,4 +132,23 @@ func printProgress(partNumber, totalParts int, bytesUploaded int64) {
 	if partNumber == totalParts {
 		fmt.Fprintln(os.Stderr)
 	}
+}
+
+func benchJSONEnabled() bool {
+	raw := os.Getenv("DRIVE9_BENCH_JSON_ENABLED")
+	if raw == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false
+	}
+	return enabled
+}
+
+func emitBenchJSON(payload any) {
+	if payload == nil || !benchJSONEnabled() {
+		return
+	}
+	_ = json.NewEncoder(os.Stderr).Encode(payload)
 }

--- a/cmd/drive9/cli/cp.go
+++ b/cmd/drive9/cli/cp.go
@@ -3,13 +3,13 @@ package cli
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"go.uber.org/zap"
 )
 
 // Cp copies files between local and remote.
@@ -112,7 +112,7 @@ func downloadFile(ctx context.Context, c *client.Client, remotePath, localPath s
 	if err != nil {
 		return err
 	}
-	emitBenchJSON(summary)
+	emitDownloadSummary(summary)
 	return nil
 }
 
@@ -134,21 +134,26 @@ func printProgress(partNumber, totalParts int, bytesUploaded int64) {
 	}
 }
 
-func benchJSONEnabled() bool {
-	raw := os.Getenv("DRIVE9_BENCH_JSON_ENABLED")
-	if raw == "" {
-		return false
-	}
-	enabled, err := strconv.ParseBool(raw)
-	if err != nil {
-		return false
-	}
-	return enabled
-}
-
-func emitBenchJSON(payload any) {
-	if payload == nil || !benchJSONEnabled() {
+// emitDownloadSummary keeps benchmark-only metadata in the same structured CLI
+// log stream as the rest of the command lifecycle, instead of inventing a
+// second stderr-only output contract.
+func emitDownloadSummary(summary *client.DownloadSummary) {
+	if summary == nil || !logger.CLIEnabled() {
 		return
 	}
-	_ = json.NewEncoder(os.Stderr).Encode(payload)
+	// The benchmark harness reads this stable event from the CLI log file.
+	logger.Info(
+		context.Background(),
+		"download_summary",
+		zap.String("type", summary.Type),
+		zap.String("mode", summary.Mode),
+		zap.Int("concurrency", summary.Concurrency),
+		zap.Int64("chunk_size_bytes", summary.ChunkSizeBytes),
+		zap.Int("range_count", summary.RangeCount),
+		zap.Time("started_at", summary.StartedAt),
+		zap.Time("finished_at", summary.FinishedAt),
+		zap.Float64("elapsed_seconds", summary.ElapsedSeconds),
+		zap.String("remote_path", summary.RemotePath),
+		zap.String("local_path", summary.LocalPath),
+	)
 }

--- a/cmd/drive9/cli/cp_test.go
+++ b/cmd/drive9/cli/cp_test.go
@@ -112,7 +112,11 @@ func TestDownloadFileEmitsDownloadSummaryToCLILogForLargeFile(t *testing.T) {
 		t.Fatalf("Sync(cli log): %v", err)
 	}
 
-	logBytes, err := os.ReadFile(filepath.Join(homeDir, ".dat", "log", "dat9-cli.log"))
+	logPath, err := logger.CLILogPath()
+	if err != nil {
+		t.Fatalf("CLILogPath: %v", err)
+	}
+	logBytes, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("ReadFile(cli log): %v", err)
 	}
@@ -159,7 +163,10 @@ func TestDownloadFileSkipsDownloadSummaryWhenCLILogDisabled(t *testing.T) {
 		t.Fatalf("Sync(cli log): %v", err)
 	}
 
-	logPath := filepath.Join(homeDir, ".dat", "log", "dat9-cli.log")
+	logPath, err := logger.CLILogPath()
+	if err != nil {
+		t.Fatalf("CLILogPath: %v", err)
+	}
 	logBytes, err := os.ReadFile(logPath)
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatalf("ReadFile(cli log): %v", err)

--- a/cmd/drive9/cli/cp_test.go
+++ b/cmd/drive9/cli/cp_test.go
@@ -1,6 +1,19 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
 
 func TestParseRemote(t *testing.T) {
 	tests := []struct {
@@ -39,5 +52,106 @@ func TestParseRemote(t *testing.T) {
 				t.Errorf("ParseRemote(%q) path=%q, want %q", tt.input, rp.Path, tt.wantPath)
 			}
 		}
+	}
+}
+
+func TestDownloadFileEmitsBenchJSONForLargeFile(t *testing.T) {
+	data := bytes.Repeat([]byte("ab"), (8<<20)/2)
+	data = append(data, []byte("tail")...)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "HEAD /v1/fs/large.bin":
+			w.Header().Set("Content-Length", "8388612")
+			w.WriteHeader(http.StatusOK)
+		case "GET /v1/fs/large.bin":
+			w.Header().Set("Location", "http://"+r.Host+"/s3/presigned?token=fixed")
+			w.WriteHeader(http.StatusFound)
+		case "GET /s3/presigned":
+			rangeHeader := r.Header.Get("Range")
+			if !strings.HasPrefix(rangeHeader, "bytes=") {
+				http.Error(w, "missing range", http.StatusBadRequest)
+				return
+			}
+			var start, end int
+			if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+				http.Error(w, "bad range", http.StatusBadRequest)
+				return
+			}
+			if start < 0 || end < start || end >= len(data) {
+				http.Error(w, "range outside test data", http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(data[start : end+1])
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("DRIVE9_BENCH_JSON_ENABLED", "true")
+	localPath := filepath.Join(t.TempDir(), "large.bin")
+	c := client.New(srv.URL, "")
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	if err := downloadFile(context.Background(), c, "/large.bin", localPath); err != nil {
+		t.Fatalf("downloadFile: %v", err)
+	}
+	_ = w.Close()
+	stderrBytes, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll(stderr): %v", err)
+	}
+	if got := string(stderrBytes); !strings.Contains(got, "\"type\":\"download_summary\"") {
+		t.Fatalf("stderr missing download summary JSON: %q", got)
+	}
+}
+
+func TestDownloadFileSkipsBenchJSONWhenDisabled(t *testing.T) {
+	data := []byte("small content")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "HEAD /v1/fs/small.txt":
+			w.Header().Set("Content-Length", "13")
+			w.WriteHeader(http.StatusOK)
+		case "GET /v1/fs/small.txt":
+			_, _ = w.Write(data)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("DRIVE9_BENCH_JSON_ENABLED", "false")
+	localPath := filepath.Join(t.TempDir(), "small.txt")
+	c := client.New(srv.URL, "")
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	if err := downloadFile(context.Background(), c, "/small.txt", localPath); err != nil {
+		t.Fatalf("downloadFile: %v", err)
+	}
+	_ = w.Close()
+	stderrBytes, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll(stderr): %v", err)
+	}
+	if len(stderrBytes) != 0 {
+		t.Fatalf("expected empty stderr, got %q", string(stderrBytes))
 	}
 }

--- a/cmd/drive9/cli/cp_test.go
+++ b/cmd/drive9/cli/cp_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/logger"
 )
 
 func TestParseRemote(t *testing.T) {
@@ -55,7 +55,7 @@ func TestParseRemote(t *testing.T) {
 	}
 }
 
-func TestDownloadFileEmitsBenchJSONForLargeFile(t *testing.T) {
+func TestDownloadFileEmitsDownloadSummaryToCLILogForLargeFile(t *testing.T) {
 	data := bytes.Repeat([]byte("ab"), (8<<20)/2)
 	data = append(data, []byte("tail")...)
 
@@ -90,32 +90,38 @@ func TestDownloadFileEmitsBenchJSONForLargeFile(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("DRIVE9_BENCH_JSON_ENABLED", "true")
+	t.Setenv("DRIVE9_CLI_LOG_ENABLED", "true")
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	restoreLogger := logger.L()
+	cliLogger, err := logger.NewCLILogger()
+	if err != nil {
+		t.Fatalf("NewCLILogger: %v", err)
+	}
+	logger.Set(cliLogger)
+	defer logger.Set(restoreLogger)
+	defer func() { _ = cliLogger.Sync() }()
+
 	localPath := filepath.Join(t.TempDir(), "large.bin")
 	c := client.New(srv.URL, "")
-
-	origStderr := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stderr = w
-	defer func() { os.Stderr = origStderr }()
 
 	if err := downloadFile(context.Background(), c, "/large.bin", localPath); err != nil {
 		t.Fatalf("downloadFile: %v", err)
 	}
-	_ = w.Close()
-	stderrBytes, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("ReadAll(stderr): %v", err)
+	if err := cliLogger.Sync(); err != nil {
+		t.Fatalf("Sync(cli log): %v", err)
 	}
-	if got := string(stderrBytes); !strings.Contains(got, "\"type\":\"download_summary\"") {
-		t.Fatalf("stderr missing download summary JSON: %q", got)
+
+	logBytes, err := os.ReadFile(filepath.Join(homeDir, ".dat", "log", "dat9-cli.log"))
+	if err != nil {
+		t.Fatalf("ReadFile(cli log): %v", err)
+	}
+	if got := string(logBytes); !strings.Contains(got, "\"msg\":\"download_summary\"") || !strings.Contains(got, "\"type\":\"download_summary\"") {
+		t.Fatalf("cli log missing download summary JSON: %q", got)
 	}
 }
 
-func TestDownloadFileSkipsBenchJSONWhenDisabled(t *testing.T) {
+func TestDownloadFileSkipsDownloadSummaryWhenCLILogDisabled(t *testing.T) {
 	data := []byte("small content")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -131,27 +137,34 @@ func TestDownloadFileSkipsBenchJSONWhenDisabled(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("DRIVE9_BENCH_JSON_ENABLED", "false")
+	t.Setenv("DRIVE9_CLI_LOG_ENABLED", "false")
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	restoreLogger := logger.L()
+	cliLogger, err := logger.NewCLILogger()
+	if err != nil {
+		t.Fatalf("NewCLILogger: %v", err)
+	}
+	logger.Set(cliLogger)
+	defer logger.Set(restoreLogger)
+	defer func() { _ = cliLogger.Sync() }()
+
 	localPath := filepath.Join(t.TempDir(), "small.txt")
 	c := client.New(srv.URL, "")
-
-	origStderr := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stderr = w
-	defer func() { os.Stderr = origStderr }()
 
 	if err := downloadFile(context.Background(), c, "/small.txt", localPath); err != nil {
 		t.Fatalf("downloadFile: %v", err)
 	}
-	_ = w.Close()
-	stderrBytes, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("ReadAll(stderr): %v", err)
+	if err := cliLogger.Sync(); err != nil {
+		t.Fatalf("Sync(cli log): %v", err)
 	}
-	if len(stderrBytes) != 0 {
-		t.Fatalf("expected empty stderr, got %q", string(stderrBytes))
+
+	logPath := filepath.Join(homeDir, ".dat", "log", "dat9-cli.log")
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(cli log): %v", err)
+	}
+	if strings.Contains(string(logBytes), "\"msg\":\"download_summary\"") {
+		t.Fatalf("expected no download summary in cli log, got %q", string(logBytes))
 	}
 }

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -24,6 +24,7 @@ import (
 )
 
 var version = "dev"
+var gitHash = "unknown"
 var cliLogger *zap.Logger
 
 func main() {
@@ -32,6 +33,8 @@ func main() {
 			cliLogger = l
 			logger.Set(l)
 			defer func() { _ = cliLogger.Sync() }()
+		} else {
+			fmt.Fprintf(os.Stderr, "drive9: failed to initialize CLI logger: %v\n", err)
 		}
 	}
 
@@ -47,7 +50,7 @@ func main() {
 		if cliLogger != nil {
 			logger.Info(context.Background(), "cli_command", zap.String("command", "version"))
 		}
-		fmt.Printf("drive9 %s\n", version)
+		fmt.Print(versionString())
 	case "-h", "-help", "help":
 		if cliLogger != nil {
 			logger.Info(context.Background(), "cli_command", zap.String("command", "help"))
@@ -97,6 +100,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "drive9: unknown command %q\n", cmd)
 		usage()
 	}
+}
+
+func versionString() string {
+	return fmt.Sprintf("drive9 %s\nGit Commit Hash: %s\n", version, gitHash)
 }
 
 func runFS(args []string) {

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/mem9-ai/dat9/cmd/drive9/cli"
 	"github.com/mem9-ai/dat9/pkg/logger"
@@ -28,7 +27,7 @@ var version = "dev"
 var cliLogger *zap.Logger
 
 func main() {
-	if cliLogEnabled() {
+	if logger.CLIEnabled() {
 		if l, err := logger.NewCLILogger(); err == nil {
 			cliLogger = l
 			logger.Set(l)
@@ -98,18 +97,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "drive9: unknown command %q\n", cmd)
 		usage()
 	}
-}
-
-func cliLogEnabled() bool {
-	raw := os.Getenv("DRIVE9_CLI_LOG_ENABLED")
-	if raw == "" {
-		return false
-	}
-	v, err := strconv.ParseBool(raw)
-	if err != nil {
-		return false
-	}
-	return v
 }
 
 func runFS(args []string) {

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersionStringIncludesGitHash(t *testing.T) {
+	origVersion := version
+	origGitHash := gitHash
+	version = "v1.2.3"
+	gitHash = "abc123"
+	t.Cleanup(func() {
+		version = origVersion
+		gitHash = origGitHash
+	})
+
+	got := versionString()
+	if !strings.Contains(got, "drive9 v1.2.3\n") {
+		t.Fatalf("versionString() missing version line: %q", got)
+	}
+	if !strings.Contains(got, "Git Commit Hash: abc123\n") {
+		t.Fatalf("versionString() missing git hash line: %q", got)
+	}
+}

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -93,6 +94,8 @@ const (
 	downloadChunkSize         = 8 << 20
 	downloadMaxConcurrency    = 8
 )
+
+var errReadTargetNoRedirect = errors.New("parallel download unavailable without redirect")
 
 // DownloadSummary exposes the coarse-grained large-file download metrics that
 // the CLI emits as a structured log event when CLI logging is enabled.
@@ -925,8 +928,18 @@ func (c *Client) resolveReadTarget(ctx context.Context, path string) (*readTarge
 		return nil, readError(resp)
 
 	default:
-		return nil, fmt.Errorf("expected redirect for large download path %q, got HTTP %d", path, resp.StatusCode)
+		return nil, errReadTargetNoRedirect
 	}
+}
+
+func (c *Client) downloadToFileSequential(ctx context.Context, remotePath string, out *os.File) (*DownloadSummary, error) {
+	rc, err := c.ReadStream(ctx, remotePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+	_, err = io.Copy(out, rc)
+	return nil, err
 }
 
 // ReadStreamRange reads a byte range from a remote file. For large files the
@@ -1062,20 +1075,26 @@ func (c *Client) DownloadToFileWithSummary(ctx context.Context, remotePath, loca
 	defer func() { _ = out.Close() }()
 
 	if size < downloadParallelThreshold {
-		rc, err := c.ReadStream(ctx, remotePath)
-		if err != nil {
-			return nil, err
-		}
-		defer func() { _ = rc.Close() }()
-		_, err = io.Copy(out, rc)
-		return nil, err
+		return c.downloadToFileSequential(ctx, remotePath, out)
 	}
 
+	target, err := c.resolveReadTarget(ctx, remotePath)
+	if err != nil {
+		if errors.Is(err, errReadTargetNoRedirect) {
+			// Keep large-file downloads working when the control plane serves the
+			// object inline instead of redirecting to object storage. In that case
+			// the parallel range path is unavailable, so fall back to ReadStream.
+			return c.downloadToFileSequential(ctx, remotePath, out)
+		}
+		return nil, err
+	}
 	if err := out.Truncate(size); err != nil {
 		return nil, fmt.Errorf("preallocate %s: %w", localPath, err)
 	}
-
-	summary, err := c.downloadLargeFileParallel(ctx, remotePath, localPath, out, size)
+	// The current failure semantics intentionally keep the partially written
+	// destination file on disk when a parallel range worker fails. Follow-up:
+	// #141.
+	summary, err := c.downloadLargeFileParallel(ctx, remotePath, localPath, out, size, target)
 	if err != nil {
 		return nil, err
 	}
@@ -1085,7 +1104,7 @@ func (c *Client) DownloadToFileWithSummary(ctx context.Context, remotePath, loca
 	return summary, nil
 }
 
-func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, localPath string, out *os.File, size int64) (*DownloadSummary, error) {
+func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, localPath string, out *os.File, size int64, target *readTarget) (*DownloadSummary, error) {
 	// Resolve the presigned object URL once, then reuse it for all range GETs in
 	// this download. This avoids paying one redirect / presign round-trip per
 	// chunk while keeping the existing server contract unchanged.
@@ -1094,10 +1113,6 @@ func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, loca
 	// download. We do not capture ETag / VersionId at resolve time or attach
 	// If-Match on per-range GETs, so cross-range consistency is best-effort.
 	// Follow-up: #139.
-	target, err := c.resolveReadTarget(ctx, remotePath)
-	if err != nil {
-		return nil, err
-	}
 
 	rangeCount := int((size + downloadChunkSize - 1) / downloadChunkSize)
 	concurrency := min(downloadMaxConcurrency, rangeCount)

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -95,7 +95,7 @@ const (
 )
 
 // DownloadSummary exposes the coarse-grained large-file download metrics that
-// the benchmark harness consumes from CLI stderr.
+// the CLI emits as a structured log event when CLI logging is enabled.
 type DownloadSummary struct {
 	Type           string    `json:"type"`
 	Mode           string    `json:"mode"`
@@ -153,6 +153,9 @@ func newUploadBufferPool(bufferSize int64, count int) *uploadBufferPool {
 		count = 1
 	}
 	ch := make(chan []byte, count)
+	// Preallocate exactly one buffer per in-flight worker so uploads can reuse
+	// memory across parts instead of allocating a fresh part-sized slice on each
+	// iteration.
 	for i := 0; i < count; i++ {
 		ch <- make([]byte, bufferSize)
 	}
@@ -1071,6 +1074,9 @@ func (c *Client) DownloadToFileWithSummary(ctx context.Context, remotePath, loca
 }
 
 func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, localPath string, out *os.File, size int64) (*DownloadSummary, error) {
+	// Resolve the presigned object URL once, then reuse it for all range GETs in
+	// this download. This avoids paying one redirect / presign round-trip per
+	// chunk while keeping the existing server contract unchanged.
 	target, err := c.resolveReadTarget(ctx, remotePath)
 	if err != nil {
 		return nil, err
@@ -1110,6 +1116,8 @@ func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, loca
 					return
 				}
 
+				// Each worker reads its range fully before WriteAt so file offsets stay
+				// independent and we never coordinate shared seek state between goroutines.
 				data, readErr := io.ReadAll(rc)
 				closeErr := rc.Close()
 				if readErr != nil {

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -10,6 +10,7 @@ import (
 	"hash/crc32"
 	"io"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -86,6 +87,36 @@ const (
 	uploadMaxConcurrency = 16
 	uploadMaxBufferBytes = 256 * 1024 * 1024 // 256 MB
 )
+
+const (
+	downloadParallelThreshold = 8 << 20
+	downloadChunkSize         = 8 << 20
+	downloadMaxConcurrency    = 8
+)
+
+// DownloadSummary exposes the coarse-grained large-file download metrics that
+// the benchmark harness consumes from CLI stderr.
+type DownloadSummary struct {
+	Type           string    `json:"type"`
+	Mode           string    `json:"mode"`
+	Concurrency    int       `json:"concurrency"`
+	ChunkSizeBytes int64     `json:"chunk_size_bytes"`
+	RangeCount     int       `json:"range_count"`
+	StartedAt      time.Time `json:"started_at"`
+	FinishedAt     time.Time `json:"finished_at"`
+	ElapsedSeconds float64   `json:"elapsed_seconds"`
+	RemotePath     string    `json:"remote_path"`
+	LocalPath      string    `json:"local_path"`
+}
+
+type downloadRange struct {
+	offset int64
+	length int64
+}
+
+type readTarget struct {
+	objectURL string
+}
 
 func uploadParallelism(partSize int64) int {
 	if partSize <= 0 {
@@ -756,21 +787,7 @@ func (c *Client) abortUploadV2(ctx context.Context, uploadID string) error {
 
 // ReadStream reads a file, following 302 redirects for large files.
 func (c *Client) ReadStream(ctx context.Context, path string) (io.ReadCloser, error) {
-	// Disable redirect following so we can detect 302
-	noRedirectClient := *c.httpClient
-	noRedirectClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(path), nil)
-	if err != nil {
-		return nil, err
-	}
-	if c.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	}
-
-	resp, err := noRedirectClient.Do(req)
+	resp, err := c.readWithoutRedirect(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -807,16 +824,8 @@ func (c *Client) ReadStream(ctx context.Context, path string) (io.ReadCloser, er
 	}
 }
 
-// ReadStreamRange reads a byte range from a remote file. For large files the
-// server returns a 302 redirect to a presigned S3 URL; this method resolves
-// that redirect and issues an HTTP Range request so only the requested bytes
-// are transferred. For small files (no redirect) the full body is returned
-// and the caller should read only what it needs.
-func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, length int64) (io.ReadCloser, error) {
-	if length <= 0 {
-		return io.NopCloser(bytes.NewReader(nil)), nil
-	}
-
+func (c *Client) readWithoutRedirect(ctx context.Context, path string) (*http.Response, error) {
+	// Disable redirect following so we can detect 302
 	noRedirectClient := *c.httpClient
 	noRedirectClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
@@ -830,7 +839,43 @@ func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, lengt
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	}
 
-	resp, err := noRedirectClient.Do(req)
+	return noRedirectClient.Do(req)
+}
+
+func (c *Client) resolveReadTarget(ctx context.Context, path string) (*readTarget, error) {
+	resp, err := c.readWithoutRedirect(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == http.StatusFound || resp.StatusCode == http.StatusTemporaryRedirect:
+		location := resp.Header.Get("Location")
+		if location == "" {
+			return nil, fmt.Errorf("302 without Location header")
+		}
+		return &readTarget{objectURL: location}, nil
+
+	case resp.StatusCode >= 300:
+		return nil, readError(resp)
+
+	default:
+		return nil, fmt.Errorf("expected redirect for large download path %q, got HTTP %d", path, resp.StatusCode)
+	}
+}
+
+// ReadStreamRange reads a byte range from a remote file. For large files the
+// server returns a 302 redirect to a presigned S3 URL; this method resolves
+// that redirect and issues an HTTP Range request so only the requested bytes
+// are transferred. For small files (no redirect) the full body is returned
+// and the caller should read only what it needs.
+func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, length int64) (io.ReadCloser, error) {
+	if length <= 0 {
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+
+	resp, err := c.readWithoutRedirect(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -879,6 +924,40 @@ func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, lengt
 	}
 }
 
+func (c *Client) readObjectRangeStrict(ctx context.Context, objectURL string, offset, length int64) (io.ReadCloser, error) {
+	if length <= 0 {
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, objectURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", offset, offset+length-1))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+		return resp.Body, nil
+	case http.StatusRequestedRangeNotSatisfiable:
+		defer func() { _ = resp.Body.Close() }()
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	case http.StatusOK:
+		defer func() { _ = resp.Body.Close() }()
+		return nil, fmt.Errorf("range request was not honored for %q at offset=%d length=%d", objectURL, offset, length)
+	default:
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode >= 300 {
+			return nil, readError(resp)
+		}
+		return nil, fmt.Errorf("unexpected status %d for range request %q", resp.StatusCode, objectURL)
+	}
+}
+
 // sliceBody skips offset bytes from rc, then returns a reader limited to
 // length bytes. The original rc is closed when the returned ReadCloser is closed.
 func (c *Client) sliceBody(rc io.ReadCloser, offset, length int64) (io.ReadCloser, error) {
@@ -902,6 +981,141 @@ type limitedReadCloser struct {
 
 func (l *limitedReadCloser) Read(p []byte) (int, error) { return l.r.Read(p) }
 func (l *limitedReadCloser) Close() error               { return l.c.Close() }
+
+// DownloadToFile downloads a remote file into a local path.
+func (c *Client) DownloadToFile(ctx context.Context, remotePath, localPath string, size int64) error {
+	_, err := c.DownloadToFileWithSummary(ctx, remotePath, localPath, size)
+	return err
+}
+
+// DownloadToFileWithSummary downloads a remote file into a local path and
+// returns a coarse-grained summary when the large-file parallel path is used.
+func (c *Client) DownloadToFileWithSummary(ctx context.Context, remotePath, localPath string, size int64) (*DownloadSummary, error) {
+	out, err := os.Create(localPath)
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", localPath, err)
+	}
+	defer func() { _ = out.Close() }()
+
+	if size < downloadParallelThreshold {
+		rc, err := c.ReadStream(ctx, remotePath)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = rc.Close() }()
+		_, err = io.Copy(out, rc)
+		return nil, err
+	}
+
+	if err := out.Truncate(size); err != nil {
+		return nil, fmt.Errorf("preallocate %s: %w", localPath, err)
+	}
+
+	summary, err := c.downloadLargeFileParallel(ctx, remotePath, localPath, out, size)
+	if err != nil {
+		return nil, err
+	}
+	if err := out.Sync(); err != nil {
+		return nil, fmt.Errorf("sync %s: %w", localPath, err)
+	}
+	return summary, nil
+}
+
+func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, localPath string, out *os.File, size int64) (*DownloadSummary, error) {
+	target, err := c.resolveReadTarget(ctx, remotePath)
+	if err != nil {
+		return nil, err
+	}
+
+	rangeCount := int((size + downloadChunkSize - 1) / downloadChunkSize)
+	concurrency := min(downloadMaxConcurrency, rangeCount)
+	startedAt := time.Now()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tasks := make(chan downloadRange, concurrency)
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
+
+	reportErr := func(err error) {
+		select {
+		case errCh <- err:
+			cancel()
+		default:
+		}
+	}
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for task := range tasks {
+				if ctx.Err() != nil {
+					return
+				}
+
+				rc, err := c.readObjectRangeStrict(ctx, target.objectURL, task.offset, task.length)
+				if err != nil {
+					reportErr(err)
+					return
+				}
+
+				data, readErr := io.ReadAll(rc)
+				closeErr := rc.Close()
+				if readErr != nil {
+					reportErr(fmt.Errorf("read range offset=%d length=%d: %w", task.offset, task.length, readErr))
+					return
+				}
+				if closeErr != nil {
+					reportErr(fmt.Errorf("close range offset=%d length=%d: %w", task.offset, task.length, closeErr))
+					return
+				}
+				if int64(len(data)) != task.length {
+					reportErr(fmt.Errorf("short range read at offset=%d: got %d bytes, want %d", task.offset, len(data), task.length))
+					return
+				}
+				if _, err := out.WriteAt(data, task.offset); err != nil {
+					reportErr(fmt.Errorf("write range offset=%d length=%d: %w", task.offset, task.length, err))
+					return
+				}
+			}
+		}()
+	}
+
+enqueueLoop:
+	for offset := int64(0); offset < size; offset += downloadChunkSize {
+		length := min(size-offset, downloadChunkSize)
+		task := downloadRange{offset: offset, length: length}
+		select {
+		case tasks <- task:
+		case <-ctx.Done():
+			break enqueueLoop
+		}
+	}
+	close(tasks)
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		return nil, err
+	default:
+	}
+
+	finishedAt := time.Now()
+	return &DownloadSummary{
+		Type:           "download_summary",
+		Mode:           "parallel_range_reuse_presigned_url",
+		Concurrency:    concurrency,
+		ChunkSizeBytes: downloadChunkSize,
+		RangeCount:     rangeCount,
+		StartedAt:      startedAt,
+		FinishedAt:     finishedAt,
+		ElapsedSeconds: finishedAt.Sub(startedAt).Seconds(),
+		RemotePath:     remotePath,
+		LocalPath:      localPath,
+	}, nil
+}
 
 // UploadMeta is the server's response for querying active uploads.
 type UploadMeta struct {

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -118,6 +118,11 @@ type readTarget struct {
 	objectURL string
 }
 
+type uploadBufferPool struct {
+	size int64
+	ch   chan []byte
+}
+
 func uploadParallelism(partSize int64) int {
 	if partSize <= 0 {
 		partSize = s3client.PartSize
@@ -138,6 +143,36 @@ func checksumParallelism(partSize int64, partCount int) int {
 		byMemory = 1
 	}
 	return min(runtime.GOMAXPROCS(0), partCount, byMemory)
+}
+
+func newUploadBufferPool(bufferSize int64, count int) *uploadBufferPool {
+	if bufferSize <= 0 {
+		bufferSize = s3client.PartSize
+	}
+	if count < 1 {
+		count = 1
+	}
+	ch := make(chan []byte, count)
+	for i := 0; i < count; i++ {
+		ch <- make([]byte, bufferSize)
+	}
+	return &uploadBufferPool{size: bufferSize, ch: ch}
+}
+
+func (p *uploadBufferPool) get(ctx context.Context) ([]byte, error) {
+	select {
+	case buf := <-p.ch:
+		return buf[:p.size], nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (p *uploadBufferPool) put(buf []byte) {
+	if buf == nil {
+		return
+	}
+	p.ch <- buf[:p.size]
 }
 
 // WriteStream uploads data from a reader. For small files (size < threshold),
@@ -318,6 +353,7 @@ func (c *Client) uploadParts(ctx context.Context, plan UploadPlan, ra io.ReaderA
 		stdPartSize = s3client.PartSize
 	}
 	maxConcurrency := uploadParallelism(stdPartSize)
+	bufferPool := newUploadBufferPool(stdPartSize, maxConcurrency)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -348,7 +384,13 @@ func (c *Client) uploadParts(ctx context.Context, plan UploadPlan, ra io.ReaderA
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			data := make([]byte, p.Size)
+			fullBuf, err := bufferPool.get(ctx)
+			if err != nil {
+				return
+			}
+			defer bufferPool.put(fullBuf)
+
+			data := fullBuf[:p.Size]
 			offset := int64(p.Number-1) * stdPartSize
 			n, err := ra.ReadAt(data, offset)
 			if err != nil && err != io.EOF {
@@ -379,7 +421,7 @@ func (c *Client) uploadParts(ctx context.Context, plan UploadPlan, ra io.ReaderA
 			}
 
 			if progress != nil {
-				progress(p.Number, len(plan.Parts), int64(len(data)))
+				progress(p.Number, len(plan.Parts), p.Size)
 			}
 		}(part)
 	}
@@ -565,6 +607,7 @@ func (c *Client) uploadPartsV2(ctx context.Context, plan *uploadPlanV2, ra io.Re
 	presignCh <-chan presignedPart, presignErrCh <-chan error, progress ProgressFunc) ([]completePart, error) {
 
 	parallelism := uploadParallelism(plan.PartSize)
+	bufferPool := newUploadBufferPool(plan.PartSize, parallelism)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -604,7 +647,13 @@ func (c *Client) uploadPartsV2(ctx context.Context, plan *uploadPlanV2, ra io.Re
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			data := make([]byte, p.Size)
+			fullBuf, err := bufferPool.get(ctx)
+			if err != nil {
+				return
+			}
+			defer bufferPool.put(fullBuf)
+
+			data := fullBuf[:p.Size]
 			offset := int64(p.Number-1) * plan.PartSize
 			n, err := ra.ReadAt(data, offset)
 			if err != nil && err != io.EOF {
@@ -650,7 +699,7 @@ func (c *Client) uploadPartsV2(ctx context.Context, plan *uploadPlanV2, ra io.Re
 			results[p.Number-1] = completePart{Number: p.Number, ETag: etag}
 
 			if progress != nil {
-				progress(p.Number, plan.TotalParts, int64(len(data)))
+				progress(p.Number, plan.TotalParts, p.Size)
 			}
 		}(pp)
 	}
@@ -1273,6 +1322,7 @@ func (c *Client) uploadMissingParts(ctx context.Context, plan UploadPlan, r io.R
 		stdPartSize = s3client.PartSize
 	}
 	maxConcurrency := uploadParallelism(stdPartSize)
+	bufferPool := newUploadBufferPool(stdPartSize, maxConcurrency)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -1302,7 +1352,13 @@ func (c *Client) uploadMissingParts(ctx context.Context, plan UploadPlan, r io.R
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			data := make([]byte, p.Size)
+			fullBuf, err := bufferPool.get(ctx)
+			if err != nil {
+				return
+			}
+			defer bufferPool.put(fullBuf)
+
+			data := fullBuf[:p.Size]
 			offset := int64(p.Number-1) * stdPartSize
 			n, err := r.ReadAt(data, offset)
 			if err != nil && err != io.EOF {
@@ -1332,7 +1388,7 @@ func (c *Client) uploadMissingParts(ctx context.Context, plan UploadPlan, r io.R
 				return
 			}
 			if progress != nil {
-				progress(p.Number, totalParts, int64(len(data)))
+				progress(p.Number, totalParts, p.Size)
 			}
 		}(part)
 	}

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -114,6 +114,11 @@ type downloadRange struct {
 	length int64
 }
 
+// readTarget captures the presigned object URL resolved from the control
+// plane for one large-file download. The current parallel downloader assumes
+// this URL remains valid for the lifetime of the download; if it expires mid-
+// transfer we fail the download instead of refreshing and retrying in place.
+// Follow-up: #138.
 type readTarget struct {
 	objectURL string
 }
@@ -1077,6 +1082,11 @@ func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, loca
 	// Resolve the presigned object URL once, then reuse it for all range GETs in
 	// this download. This avoids paying one redirect / presign round-trip per
 	// chunk while keeping the existing server contract unchanged.
+	//
+	// This path currently assumes the object content stays stable for the whole
+	// download. We do not capture ETag / VersionId at resolve time or attach
+	// If-Match on per-range GETs, so cross-range consistency is best-effort.
+	// Follow-up: #139.
 	target, err := c.resolveReadTarget(ctx, remotePath)
 	if err != nil {
 		return nil, err

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -176,8 +176,15 @@ func (p *uploadBufferPool) get(ctx context.Context) ([]byte, error) {
 	}
 }
 
+// put expects a buffer previously obtained from this pool via get(). When a
+// caller returns a shortened view of that buffer, we restore its full length
+// before enqueuing it again. If a non-pool buffer with insufficient capacity is
+// passed in by mistake, drop it instead of panicking on the reslice.
 func (p *uploadBufferPool) put(buf []byte) {
 	if buf == nil {
+		return
+	}
+	if int64(cap(buf)) < p.size {
 		return
 	}
 	p.ch <- buf[:p.size]

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -69,6 +69,47 @@ func (r *shortUploadReader) ReadAt(p []byte, off int64) (int, error) {
 	return n, nil
 }
 
+func TestUploadBufferPoolRestoresFullLengthOnPut(t *testing.T) {
+	pool := newUploadBufferPool(8, 1)
+
+	buf, err := pool.get(context.Background())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(buf) != 8 {
+		t.Fatalf("initial len = %d, want 8", len(buf))
+	}
+
+	pool.put(buf[:3])
+
+	buf, err = pool.get(context.Background())
+	if err != nil {
+		t.Fatalf("second get: %v", err)
+	}
+	if len(buf) != 8 {
+		t.Fatalf("restored len = %d, want 8", len(buf))
+	}
+}
+
+func TestUploadBufferPoolGetHonorsContextCancel(t *testing.T) {
+	pool := newUploadBufferPool(4, 1)
+	buf, err := pool.get(context.Background())
+	if err != nil {
+		t.Fatalf("initial get: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := pool.get(ctx); err == nil {
+		t.Fatal("expected canceled get to fail")
+	} else if err != context.Canceled {
+		t.Fatalf("canceled get error = %v, want %v", err, context.Canceled)
+	}
+
+	pool.put(buf)
+}
+
 // TestWriteStreamSmallFile verifies that WriteStream sends a small file via single direct PUT.
 func TestWriteStreamSmallFile(t *testing.T) {
 	var writtenData []byte

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -91,6 +91,28 @@ func TestUploadBufferPoolRestoresFullLengthOnPut(t *testing.T) {
 	}
 }
 
+func TestUploadBufferPoolPutDropsForeignShortBuffer(t *testing.T) {
+	pool := newUploadBufferPool(8, 1)
+
+	buf, err := pool.get(context.Background())
+	if err != nil {
+		t.Fatalf("initial get: %v", err)
+	}
+
+	// A foreign buffer with smaller capacity should be ignored rather than
+	// panicking when put() tries to restore the pool's full buffer length.
+	pool.put(make([]byte, 4))
+	pool.put(buf[:3])
+
+	buf, err = pool.get(context.Background())
+	if err != nil {
+		t.Fatalf("second get: %v", err)
+	}
+	if len(buf) != 8 {
+		t.Fatalf("restored len = %d, want 8", len(buf))
+	}
+}
+
 func TestUploadBufferPoolGetHonorsContextCancel(t *testing.T) {
 	pool := newUploadBufferPool(4, 1)
 	buf, err := pool.get(context.Background())

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -925,6 +925,52 @@ func TestDownloadToFileWithSummaryFailsWhenRangeNotHonored(t *testing.T) {
 	}
 }
 
+func TestDownloadToFileWithSummaryFallsBackWhenReadPathDoesNotRedirect(t *testing.T) {
+	data := bytes.Repeat([]byte("q"), downloadParallelThreshold+17)
+
+	var readRequests atomic.Int32
+	var objectRequests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/fs/large.bin":
+			readRequests.Add(1)
+			_, _ = w.Write(data)
+		case "/s3/presigned":
+			objectRequests.Add(1)
+			http.Error(w, "unexpected object request", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	localPath := filepath.Join(t.TempDir(), "large.bin")
+	c := New(srv.URL, "")
+
+	summary, err := c.DownloadToFileWithSummary(context.Background(), "/large.bin", localPath, int64(len(data)))
+	if err != nil {
+		t.Fatalf("DownloadToFileWithSummary: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("expected nil summary when falling back to sequential download, got %+v", summary)
+	}
+	if got := readRequests.Load(); got != 2 {
+		t.Fatalf("expected one resolve attempt plus one sequential read, got %d requests", got)
+	}
+	if got := objectRequests.Load(); got != 0 {
+		t.Fatalf("expected no object storage requests, got %d", got)
+	}
+
+	downloaded, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(downloaded, data) {
+		t.Fatal("downloaded file content mismatch")
+	}
+}
+
 func TestDownloadToFileWithSummarySmallFileUsesSequentialPath(t *testing.T) {
 	var readRequests atomic.Int32
 	data := []byte("small content")

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -747,6 +748,155 @@ func TestReadStreamRangeLargeFileTreats416AsEOF(t *testing.T) {
 	}
 	if len(data) != 0 {
 		t.Fatalf("expected EOF empty body, got %q", data)
+	}
+}
+
+func TestDownloadToFileWithSummaryReusesPresignedURL(t *testing.T) {
+	data := bytes.Repeat([]byte("ab"), downloadChunkSize/2)
+	data = append(data, []byte("tail")...)
+
+	var readRequests atomic.Int32
+	var objectRequests atomic.Int32
+	var rangedRequests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/fs/large.bin":
+			readRequests.Add(1)
+			w.Header().Set("Location", fmt.Sprintf("http://%s/s3/presigned?token=fixed", r.Host))
+			w.WriteHeader(http.StatusFound)
+		case "/s3/presigned":
+			objectRequests.Add(1)
+			if got := r.URL.RawQuery; got != "token=fixed" {
+				http.Error(w, "wrong presigned url query: "+got, http.StatusBadRequest)
+				return
+			}
+			rangeHeader := r.Header.Get("Range")
+			if !strings.HasPrefix(rangeHeader, "bytes=") {
+				http.Error(w, "missing range", http.StatusBadRequest)
+				return
+			}
+			rangedRequests.Add(1)
+			var start, end int
+			if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+				http.Error(w, "bad range: "+rangeHeader, http.StatusBadRequest)
+				return
+			}
+			if start < 0 || end < start || end >= len(data) {
+				http.Error(w, "range outside test data", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(data[start : end+1])
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	localPath := filepath.Join(t.TempDir(), "large.bin")
+	c := New(srv.URL, "")
+
+	summary, err := c.DownloadToFileWithSummary(context.Background(), "/large.bin", localPath, int64(len(data)))
+	if err != nil {
+		t.Fatalf("DownloadToFileWithSummary: %v", err)
+	}
+	if summary == nil {
+		t.Fatal("expected download summary for large-file path")
+	}
+	if got := readRequests.Load(); got != 1 {
+		t.Fatalf("expected one /v1/fs request, got %d", got)
+	}
+	if got := objectRequests.Load(); got != 2 {
+		t.Fatalf("expected two object requests, got %d", got)
+	}
+	if got := rangedRequests.Load(); got != 2 {
+		t.Fatalf("expected two range requests, got %d", got)
+	}
+	if summary.Mode != "parallel_range_reuse_presigned_url" {
+		t.Fatalf("summary mode = %q, want %q", summary.Mode, "parallel_range_reuse_presigned_url")
+	}
+	if summary.RangeCount != 2 {
+		t.Fatalf("summary range_count = %d, want 2", summary.RangeCount)
+	}
+	if summary.Concurrency != 2 {
+		t.Fatalf("summary concurrency = %d, want 2", summary.Concurrency)
+	}
+
+	downloaded, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(downloaded, data) {
+		t.Fatal("downloaded file content mismatch")
+	}
+}
+
+func TestDownloadToFileWithSummaryFailsWhenRangeNotHonored(t *testing.T) {
+	data := bytes.Repeat([]byte("z"), downloadChunkSize+1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/fs/large.bin":
+			w.Header().Set("Location", fmt.Sprintf("http://%s/s3/presigned", r.Host))
+			w.WriteHeader(http.StatusFound)
+		case "/s3/presigned":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	localPath := filepath.Join(t.TempDir(), "large.bin")
+	c := New(srv.URL, "")
+
+	_, err := c.DownloadToFileWithSummary(context.Background(), "/large.bin", localPath, int64(len(data)))
+	if err == nil {
+		t.Fatal("expected strict range failure")
+	}
+	if !strings.Contains(err.Error(), "range request was not honored") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDownloadToFileWithSummarySmallFileUsesSequentialPath(t *testing.T) {
+	var readRequests atomic.Int32
+	data := []byte("small content")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/fs/small.txt":
+			readRequests.Add(1)
+			_, _ = w.Write(data)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	localPath := filepath.Join(t.TempDir(), "small.txt")
+	c := New(srv.URL, "")
+
+	summary, err := c.DownloadToFileWithSummary(context.Background(), "/small.txt", localPath, int64(len(data)))
+	if err != nil {
+		t.Fatalf("DownloadToFileWithSummary: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("expected nil summary for small-file path, got %+v", summary)
+	}
+	if got := readRequests.Load(); got != 1 {
+		t.Fatalf("expected one sequential read request, got %d", got)
+	}
+
+	downloaded, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(downloaded) != string(data) {
+		t.Fatalf("got %q, want %q", downloaded, data)
 	}
 }
 

--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -19,16 +19,34 @@ func CLIEnabled() bool {
 	return envBool("DRIVE9_CLI_LOG_ENABLED", false)
 }
 
-func NewCLILogger() (*zap.Logger, error) {
+func CLILogDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("resolve home: %w", err)
+		return "", fmt.Errorf("resolve home: %w", err)
 	}
-	logDir := filepath.Join(home, ".dat", "log")
+	return filepath.Join(home, ".drive9", "cli"), nil
+}
+
+func CLILogPath() (string, error) {
+	logDir, err := CLILogDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(logDir, "drive9-cli.log"), nil
+}
+
+func NewCLILogger() (*zap.Logger, error) {
+	logDir, err := CLILogDir()
+	if err != nil {
+		return nil, err
+	}
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create log dir: %w", err)
 	}
-	logPath := filepath.Join(logDir, "dat9-cli.log")
+	logPath, err := CLILogPath()
+	if err != nil {
+		return nil, err
+	}
 	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("open log file: %w", err)

--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -15,6 +15,10 @@ func NewServerLogger() (*zap.Logger, error) {
 	return zap.NewProduction()
 }
 
+func CLIEnabled() bool {
+	return envBool("DRIVE9_CLI_LOG_ENABLED", false)
+}
+
 func NewCLILogger() (*zap.Logger, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -55,6 +59,18 @@ func envInt(key string, fallback int) int {
 	}
 	v, err := strconv.Atoi(raw)
 	if err != nil || v <= 0 {
+		return fallback
+	}
+	return v
+}
+
+func envBool(key string, fallback bool) bool {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
 		return fallback
 	}
 	return v

--- a/pkg/logger/factory_test.go
+++ b/pkg/logger/factory_test.go
@@ -1,0 +1,37 @@
+package logger
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewCLILoggerCreatesLogDirAndFile(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	logPath, err := CLILogPath()
+	if err != nil {
+		t.Fatalf("CLILogPath: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(logPath)); !os.IsNotExist(err) {
+		t.Fatalf("expected log dir to be absent before init, got err=%v", err)
+	}
+
+	l, err := NewCLILogger()
+	if err != nil {
+		t.Fatalf("NewCLILogger: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Sync() })
+
+	info, err := os.Stat(filepath.Dir(logPath))
+	if err != nil {
+		t.Fatalf("Stat(log dir): %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected log dir, got file: %s", filepath.Dir(logPath))
+	}
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("Stat(log file): %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

The main change is to stop resolving a fresh redirect for every download range on large-file reads. Instead, the client resolves the presigned object URL once and reuses that URL for all parallel `Range GET` requests.

In addition to that main path change, this branch also includes the adjacent changes that are part of the current branch diff:

- reuse multipart upload buffers to reduce upload-path allocation churn
- emit benchmark download summaries through the CLI logger instead of a separate benchmark-only output path
- centralize CLI log path helpers and write logs under `.drive9/cli/drive9-cli.log`
- expose the build git hash in `drive9 version` so bench binaries can be verified explicitly

## Design Basis

The implemented shape matches the design intent:

- keep server protocol unchanged
- resolve the presigned download target once in `pkg/client`
- reuse that object URL across the parallel downloader worker pool
- keep small-file behavior unchanged
- keep coarse download summary available for benchmark collection

## What Changed

### 1. Reuse a single presigned URL for parallel large-file downloads

`pkg/client/transfer.go`

- adds a dedicated large-file download path that resolves the read target once
- issues strict parallel `Range GET` requests directly against the object URL
- keeps the single-stream path for small files
- records coarse download summary metadata for benchmark analysis

This is the core change for the `reuse-presigned-download-url` proposal.

### 2. Wire download summary through the CLI log stream

`cmd/drive9/cli/cp.go`
`pkg/logger/factory.go`

- `drive9 fs cp` downloads now emit `download_summary` through the normal CLI logger when `DRIVE9_CLI_LOG_ENABLED=true`
- benchmark parsing now relies on the CLI log file rather than a separate benchmark-only stderr contract
- the CLI logger now owns a single canonical path: `.drive9/cli/drive9-cli.log`
- the logger creates the log directory automatically before opening the file

### 3. Reuse multipart upload buffers

`pkg/client/transfer.go`

- reuses one part-sized buffer per in-flight worker on multipart upload paths
- avoids allocating a fresh part buffer on every iteration
- keeps concurrency bounded by the existing memory-based policy

### 4. Expose build commit hash in `drive9 version`

`cmd/drive9/main.go`
`Makefile`

- injects the git hash at build time
- prints the hash in `drive9 version`
- makes it practical to verify that the binary on the bench host matches the expected source commit

## Why This Change

The previous parallel-download experiment proved that simply turning on parallel ranges was not enough. It regressed because each range still went through:

1. `GET /v1/fs/<path>`
2. redirect resolution
3. object-store `Range GET`

For a 1 GiB file split into 128 ranges, that means repeating the control-plane redirect path 128 times.

This PR fixes that shape directly by resolving the presigned object URL once and reusing it for the entire parallel download.

## Benchmark

PR comparison benchmark was rerun on the bench instance after cleaning the earlier invalid runs.

Baseline commit:

- `e1e57ee3136a2d17b948a492f4b1e904ce45bae4`

Benchmarked optimized commit:

- `da2501915f317688c4c089d4c939f04ec375342c`

Note: the branch head also contains `66552b63fc92d0760ceb939ecad1acce2f44a2f6`, which only adds build-hash reporting in `drive9 version`. The performance rerun was taken on `da25019`, which is the last behavior-relevant commit for the download/logging path.

### Drive9

| Metric | Baseline | After | Delta |
| --- | ---: | ---: | ---: |
| Upload elapsed | 8.245s | 8.131s | -1.38% |
| Upload throughput | 124.221 MiB/s | 125.945 MiB/s | +1.39% |
| Download elapsed | 14.421s | 3.474s | -75.91% |
| Download throughput | 71.018 MiB/s | 294.779 MiB/s | +315.08% |
| End-to-end elapsed | 22.666s | 11.605s | -48.80% |
| End-to-end throughput | 45.178 MiB/s | 88.237 MiB/s | +95.31% |

### S3 reference

| Metric | Baseline | After | Delta |
| --- | ---: | ---: | ---: |
| Upload elapsed | 2.206s | 2.212s | +0.27% |
| Upload throughput | 464.637 MiB/s | 463.256 MiB/s | -0.30% |
| Download elapsed | 2.548s | 2.524s | -0.94% |
| Download throughput | 401.966 MiB/s | 405.859 MiB/s | +0.97% |
| End-to-end elapsed | 4.753s | 4.736s | -0.36% |
| End-to-end throughput | 215.463 MiB/s | 216.221 MiB/s | +0.35% |

### Drive9 vs S3 ratio

| Metric | Baseline | After |
| --- | ---: | ---: |
| Upload | 0.268 | 0.272 |
| Download | 0.177 | 0.727 |
| End-to-end | 0.210 | 0.408 |

Interpretation:

- the gain is concentrated on the download path, which is exactly what this proposal targets
- upload remains effectively flat
- the S3 reference remains stable, which makes the before/after comparison credible

## Scope Notes

Although the main topic of this branch is the presigned-URL download-path fix, the branch currently also includes adjacent upload-path and observability/build-traceability changes. This description reflects the actual branch contents rather than only the original proposal title.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallel large-file downloads with performance tracking
  * Download summary events emitted to CLI logs
  * CLI shows Git commit hash in version output
  * CLI logging now exposes helpers to determine log path and enabled state (creates log file/dir)

* **Tests**
  * Added tests for download behaviors, summary logging, and version string

* **Documentation**
  * Clarified that enabling CLI structured logs includes transfer summary events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->