### PR TITLE
refactor(tenant): reorganize into sub-packages by concern

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/server"
-	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 	"go.uber.org/zap"
 )
 
@@ -67,7 +67,7 @@ func main() {
 		stepStart := time.Now()
 		initMode := requestedEmbeddingMode
 		if !explicitEmbeddingMode {
-			initMode = tenant.TiDBEmbeddingModeAuto
+			initMode = schema.TiDBEmbeddingModeAuto
 		}
 		if err := localTiDBSchemaInitializer(localDSN, initMode); err != nil {
 			die(fmt.Errorf("init local tenant schema: %w", err))
@@ -107,7 +107,7 @@ func main() {
 	if err != nil {
 		die(fmt.Errorf("detect local embedding mode: %w", err))
 	}
-	backendOpts.DatabaseAutoEmbedding = localEmbeddingMode == tenant.TiDBEmbeddingModeAuto
+	backendOpts.DatabaseAutoEmbedding = localEmbeddingMode == schema.TiDBEmbeddingModeAuto
 	logLocalStartupStep(startupCtx, startupStart, stepStart, "detect_local_embedding_mode",
 		zap.String("embedding_mode", string(localEmbeddingMode)))
 
@@ -270,60 +270,60 @@ func logLocalStartupStep(ctx context.Context, startupStart, stepStart time.Time,
 }
 
 var (
-	localTiDBEmbeddingModeDetector = tenant.DetectTiDBEmbeddingMode
-	localTiDBSchemaValidator       = tenant.ValidateTiDBSchemaForMode
-	localTiDBSchemaInitializer     = tenant.InitTiDBTenantSchemaForMode
+	localTiDBEmbeddingModeDetector = schema.DetectTiDBEmbeddingMode
+	localTiDBSchemaValidator       = schema.ValidateTiDBSchemaForMode
+	localTiDBSchemaInitializer     = schema.InitTiDBTenantSchemaForMode
 )
 
-func detectLocalTiDBEmbeddingMode(db *sql.DB, schemaInitialized bool, requestedMode tenant.TiDBEmbeddingMode, explicitMode bool) (tenant.TiDBEmbeddingMode, error) {
+func detectLocalTiDBEmbeddingMode(db *sql.DB, schemaInitialized bool, requestedMode schema.TiDBEmbeddingMode, explicitMode bool) (schema.TiDBEmbeddingMode, error) {
 	if explicitMode {
 		if schemaInitialized {
 			return requestedMode, nil
 		}
 		if db == nil {
-			return tenant.TiDBEmbeddingModeUnknown, fmt.Errorf("nil db")
+			return schema.TiDBEmbeddingModeUnknown, fmt.Errorf("nil db")
 		}
 		if err := localTiDBSchemaValidator(db, requestedMode); err != nil {
-			return tenant.TiDBEmbeddingModeUnknown, err
+			return schema.TiDBEmbeddingModeUnknown, err
 		}
 		return requestedMode, nil
 	}
 	if schemaInitialized {
-		return tenant.TiDBEmbeddingModeAuto, nil
+		return schema.TiDBEmbeddingModeAuto, nil
 	}
 	if db == nil {
-		return tenant.TiDBEmbeddingModeUnknown, fmt.Errorf("nil db")
+		return schema.TiDBEmbeddingModeUnknown, fmt.Errorf("nil db")
 	}
 	mode, err := localTiDBEmbeddingModeDetector(db)
 	if err != nil {
-		return tenant.TiDBEmbeddingModeUnknown, err
+		return schema.TiDBEmbeddingModeUnknown, err
 	}
-	if mode != tenant.TiDBEmbeddingModeAuto && mode != tenant.TiDBEmbeddingModeApp {
-		return tenant.TiDBEmbeddingModeUnknown, fmt.Errorf("unsupported TiDB embedding mode %q", mode)
+	if mode != schema.TiDBEmbeddingModeAuto && mode != schema.TiDBEmbeddingModeApp {
+		return schema.TiDBEmbeddingModeUnknown, fmt.Errorf("unsupported TiDB embedding mode %q", mode)
 	}
 	if err := localTiDBSchemaValidator(db, mode); err != nil {
-		return tenant.TiDBEmbeddingModeUnknown, err
+		return schema.TiDBEmbeddingModeUnknown, err
 	}
 	return mode, nil
 }
 
-func localEmbeddingModeFromEnv() (tenant.TiDBEmbeddingMode, bool, error) {
+func localEmbeddingModeFromEnv() (schema.TiDBEmbeddingMode, bool, error) {
 	raw := strings.TrimSpace(os.Getenv(envLocalEmbeddingMode))
 	switch strings.ToLower(raw) {
 	case "":
-		return tenant.TiDBEmbeddingModeUnknown, false, nil
+		return schema.TiDBEmbeddingModeUnknown, false, nil
 	case "detect":
-		return tenant.TiDBEmbeddingModeUnknown, false, nil
-	case "auto", string(tenant.TiDBEmbeddingModeAuto):
-		return tenant.TiDBEmbeddingModeAuto, true, nil
-	case "app", string(tenant.TiDBEmbeddingModeApp):
-		return tenant.TiDBEmbeddingModeApp, true, nil
+		return schema.TiDBEmbeddingModeUnknown, false, nil
+	case "auto", string(schema.TiDBEmbeddingModeAuto):
+		return schema.TiDBEmbeddingModeAuto, true, nil
+	case "app", string(schema.TiDBEmbeddingModeApp):
+		return schema.TiDBEmbeddingModeApp, true, nil
 	default:
-		return tenant.TiDBEmbeddingModeUnknown, false, fmt.Errorf("%s must be one of auto, app, or detect", envLocalEmbeddingMode)
+		return schema.TiDBEmbeddingModeUnknown, false, fmt.Errorf("%s must be one of auto, app, or detect", envLocalEmbeddingMode)
 	}
 }
 
-func localEmbeddingModeLabel(mode tenant.TiDBEmbeddingMode, explicit bool) string {
+func localEmbeddingModeLabel(mode schema.TiDBEmbeddingMode, explicit bool) string {
 	if !explicit {
 		return "detect"
 	}

--- a/cmd/drive9-server-local/main_test.go
+++ b/cmd/drive9-server-local/main_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
 
 func TestDetectLocalTiDBEmbeddingMode(t *testing.T) {
@@ -17,70 +17,70 @@ func TestDetectLocalTiDBEmbeddingMode(t *testing.T) {
 		localTiDBSchemaValidator = origValidator
 	})
 
-	mode, err := detectLocalTiDBEmbeddingMode(nil, true, tenant.TiDBEmbeddingModeApp, true)
+	mode, err := detectLocalTiDBEmbeddingMode(nil, true, schema.TiDBEmbeddingModeApp, true)
 	if err != nil {
 		t.Fatalf("schema-initialized explicit app mode returned error: %v", err)
 	}
-	if mode != tenant.TiDBEmbeddingModeApp {
-		t.Fatalf("schema-initialized explicit mode=%q, want %q", mode, tenant.TiDBEmbeddingModeApp)
+	if mode != schema.TiDBEmbeddingModeApp {
+		t.Fatalf("schema-initialized explicit mode=%q, want %q", mode, schema.TiDBEmbeddingModeApp)
 	}
 
-	localTiDBEmbeddingModeDetector = func(*sql.DB) (tenant.TiDBEmbeddingMode, error) {
-		return tenant.TiDBEmbeddingModeUnknown, errors.New("should not be called")
+	localTiDBEmbeddingModeDetector = func(*sql.DB) (schema.TiDBEmbeddingMode, error) {
+		return schema.TiDBEmbeddingModeUnknown, errors.New("should not be called")
 	}
-	mode, err = detectLocalTiDBEmbeddingMode(nil, true, tenant.TiDBEmbeddingModeUnknown, false)
+	mode, err = detectLocalTiDBEmbeddingMode(nil, true, schema.TiDBEmbeddingModeUnknown, false)
 	if err != nil {
 		t.Fatalf("schema-initialized default mode returned error: %v", err)
 	}
-	if mode != tenant.TiDBEmbeddingModeAuto {
-		t.Fatalf("schema-initialized default mode=%q, want %q", mode, tenant.TiDBEmbeddingModeAuto)
+	if mode != schema.TiDBEmbeddingModeAuto {
+		t.Fatalf("schema-initialized default mode=%q, want %q", mode, schema.TiDBEmbeddingModeAuto)
 	}
 
-	localTiDBSchemaValidator = func(*sql.DB, tenant.TiDBEmbeddingMode) error { return nil }
-	mode, err = detectLocalTiDBEmbeddingMode(&sql.DB{}, false, tenant.TiDBEmbeddingModeApp, true)
+	localTiDBSchemaValidator = func(*sql.DB, schema.TiDBEmbeddingMode) error { return nil }
+	mode, err = detectLocalTiDBEmbeddingMode(&sql.DB{}, false, schema.TiDBEmbeddingModeApp, true)
 	if err != nil {
 		t.Fatalf("explicit app mode returned error: %v", err)
 	}
-	if mode != tenant.TiDBEmbeddingModeApp {
-		t.Fatalf("explicit mode=%q, want %q", mode, tenant.TiDBEmbeddingModeApp)
+	if mode != schema.TiDBEmbeddingModeApp {
+		t.Fatalf("explicit mode=%q, want %q", mode, schema.TiDBEmbeddingModeApp)
 	}
 
-	localTiDBEmbeddingModeDetector = func(*sql.DB) (tenant.TiDBEmbeddingMode, error) {
-		return tenant.TiDBEmbeddingModeAuto, nil
+	localTiDBEmbeddingModeDetector = func(*sql.DB) (schema.TiDBEmbeddingMode, error) {
+		return schema.TiDBEmbeddingModeAuto, nil
 	}
-	mode, err = detectLocalTiDBEmbeddingMode(&sql.DB{}, false, tenant.TiDBEmbeddingModeUnknown, false)
+	mode, err = detectLocalTiDBEmbeddingMode(&sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false)
 	if err != nil {
 		t.Fatalf("detect auto mode returned error: %v", err)
 	}
-	if mode != tenant.TiDBEmbeddingModeAuto {
-		t.Fatalf("detected mode=%q, want %q", mode, tenant.TiDBEmbeddingModeAuto)
+	if mode != schema.TiDBEmbeddingModeAuto {
+		t.Fatalf("detected mode=%q, want %q", mode, schema.TiDBEmbeddingModeAuto)
 	}
 
-	localTiDBEmbeddingModeDetector = func(*sql.DB) (tenant.TiDBEmbeddingMode, error) {
-		return tenant.TiDBEmbeddingModeApp, nil
+	localTiDBEmbeddingModeDetector = func(*sql.DB) (schema.TiDBEmbeddingMode, error) {
+		return schema.TiDBEmbeddingModeApp, nil
 	}
-	mode, err = detectLocalTiDBEmbeddingMode(&sql.DB{}, false, tenant.TiDBEmbeddingModeUnknown, false)
+	mode, err = detectLocalTiDBEmbeddingMode(&sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false)
 	if err != nil {
 		t.Fatalf("detect app mode returned error: %v", err)
 	}
-	if mode != tenant.TiDBEmbeddingModeApp {
-		t.Fatalf("detected mode=%q, want %q", mode, tenant.TiDBEmbeddingModeApp)
+	if mode != schema.TiDBEmbeddingModeApp {
+		t.Fatalf("detected mode=%q, want %q", mode, schema.TiDBEmbeddingModeApp)
 	}
 
-	localTiDBEmbeddingModeDetector = func(*sql.DB) (tenant.TiDBEmbeddingMode, error) {
-		return tenant.TiDBEmbeddingModeUnknown, nil
+	localTiDBEmbeddingModeDetector = func(*sql.DB) (schema.TiDBEmbeddingMode, error) {
+		return schema.TiDBEmbeddingModeUnknown, nil
 	}
-	if _, err := detectLocalTiDBEmbeddingMode(&sql.DB{}, false, tenant.TiDBEmbeddingModeUnknown, false); err == nil {
+	if _, err := detectLocalTiDBEmbeddingMode(&sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false); err == nil {
 		t.Fatal("expected unknown mode to fail")
 	}
 
-	localTiDBEmbeddingModeDetector = func(*sql.DB) (tenant.TiDBEmbeddingMode, error) {
-		return tenant.TiDBEmbeddingModeAuto, nil
+	localTiDBEmbeddingModeDetector = func(*sql.DB) (schema.TiDBEmbeddingMode, error) {
+		return schema.TiDBEmbeddingModeAuto, nil
 	}
-	localTiDBSchemaValidator = func(*sql.DB, tenant.TiDBEmbeddingMode) error {
+	localTiDBSchemaValidator = func(*sql.DB, schema.TiDBEmbeddingMode) error {
 		return errors.New("bad schema")
 	}
-	if _, err := detectLocalTiDBEmbeddingMode(&sql.DB{}, false, tenant.TiDBEmbeddingModeUnknown, false); err == nil {
+	if _, err := detectLocalTiDBEmbeddingMode(&sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false); err == nil {
 		t.Fatal("expected validation failure to propagate")
 	}
 }
@@ -100,7 +100,7 @@ func TestLocalEmbeddingModeFromEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unset mode returned error: %v", err)
 	}
-	if explicit || mode != tenant.TiDBEmbeddingModeUnknown {
+	if explicit || mode != schema.TiDBEmbeddingModeUnknown {
 		t.Fatalf("unset mode=(%q,%v), want (unknown,false)", mode, explicit)
 	}
 
@@ -111,7 +111,7 @@ func TestLocalEmbeddingModeFromEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("auto mode returned error: %v", err)
 	}
-	if !explicit || mode != tenant.TiDBEmbeddingModeAuto {
+	if !explicit || mode != schema.TiDBEmbeddingModeAuto {
 		t.Fatalf("auto mode=(%q,%v), want (auto,true)", mode, explicit)
 	}
 
@@ -122,7 +122,7 @@ func TestLocalEmbeddingModeFromEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app mode returned error: %v", err)
 	}
-	if !explicit || mode != tenant.TiDBEmbeddingModeApp {
+	if !explicit || mode != schema.TiDBEmbeddingModeApp {
 		t.Fatalf("app mode=(%q,%v), want (app,true)", mode, explicit)
 	}
 
@@ -133,7 +133,7 @@ func TestLocalEmbeddingModeFromEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("detect mode returned error: %v", err)
 	}
-	if explicit || mode != tenant.TiDBEmbeddingModeUnknown {
+	if explicit || mode != schema.TiDBEmbeddingModeUnknown {
 		t.Fatalf("detect mode=(%q,%v), want (unknown,false)", mode, explicit)
 	}
 

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -21,6 +21,9 @@ import (
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/server"
 	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/db9"
+	"github.com/mem9-ai/dat9/pkg/tenant/starter"
+	"github.com/mem9-ai/dat9/pkg/tenant/tidbzero"
 	"go.uber.org/zap"
 )
 
@@ -112,11 +115,11 @@ func main() {
 	var provisionerErr error
 	switch providerType {
 	case tenant.ProviderTiDBZero:
-		provisioner, provisionerErr = tenant.NewZeroProvisionerFromEnv()
+		provisioner, provisionerErr = tidbzero.NewProvisionerFromEnv()
 	case tenant.ProviderTiDBCloudStarter:
-		provisioner, provisionerErr = tenant.NewStarterProvisionerFromEnv()
+		provisioner, provisionerErr = starter.NewProvisionerFromEnv()
 	case tenant.ProviderDB9:
-		provisioner, provisionerErr = tenant.NewDB9ProvisionerFromEnv()
+		provisioner, provisionerErr = db9.NewProvisionerFromEnv()
 	}
 	if provisionerErr != nil {
 		logger.Warn(context.Background(), "provisioner_not_configured", zap.String("provider", providerType), zap.Error(provisionerErr))

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
 )
 
 type scopeKey int
@@ -43,7 +44,7 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			return
 		}
 
-		resolved, err := metaStore.ResolveByAPIKeyHash(r.Context(), tenant.HashToken(tok))
+		resolved, err := metaStore.ResolveByAPIKeyHash(r.Context(), token.HashToken(tok))
 		if err != nil {
 			if errors.Is(err, meta.ErrNotFound) {
 				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_key_not_found")...)
@@ -57,7 +58,7 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			return
 		}
 
-		if subtle.ConstantTimeCompare([]byte(tenant.HashToken(tok)), []byte(resolved.APIKey.JWTHash)) != 1 {
+		if subtle.ConstantTimeCompare([]byte(token.HashToken(tok)), []byte(resolved.APIKey.JWTHash)) != 1 {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_hash_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)...)
 			metricEvent(r.Context(), "auth", "result", "hash_mismatch")
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
@@ -85,7 +86,7 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			return
 		}
 
-		claims, err := tenant.ParseAndVerifyToken(tokenSecret, tok)
+		claims, err := token.ParseAndVerifyToken(tokenSecret, tok)
 		if err != nil {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_token_invalid", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 			metricEvent(r.Context(), "auth", "result", "token_invalid")

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
 )
 
 type authTestRuntime struct {
@@ -69,14 +70,14 @@ func newAuthRuntime(t *testing.T) (*authTestRuntime, func()) {
 		}
 	}
 	now := time.Now().UTC()
-	tenantID := tenant.NewID()
+	tenantID := token.NewID()
 	tenantDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true", parsed.User, parsed.Passwd, host, port, parsed.DBName)
 	initServerTenantSchema(t, tenantDSN)
 	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
 	if err != nil {
 		t.Fatal(err)
 	}
-	tok, err := tenant.IssueToken(tokenSecret, tenantID, 1)
+	tok, err := token.IssueToken(tokenSecret, tenantID, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,11 +102,11 @@ func newAuthRuntime(t *testing.T) (*authTestRuntime, func()) {
 		t.Fatal(err)
 	}
 	if err := metaStore.InsertAPIKey(context.Background(), &meta.APIKey{
-		ID:            tenant.NewID(),
+		ID:            token.NewID(),
 		TenantID:      tenantID,
 		KeyName:       "default",
 		JWTCiphertext: tokCipher,
-		JWTHash:       tenant.HashToken(tok),
+		JWTHash:       token.HashToken(tok),
 		TokenVersion:  1,
 		Status:        meta.APIKeyActive,
 		IssuedAt:      now,

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
 )
 
 type fakeProvisioner struct {
@@ -113,7 +114,7 @@ func TestProvisionMarksTenantFailedWhenInitKeepsFailing(t *testing.T) {
 	if apiKey == "" {
 		t.Fatal("empty api_key")
 	}
-	resolved, err := metaStore.ResolveByAPIKeyHash(context.Background(), tenant.HashToken(apiKey))
+	resolved, err := metaStore.ResolveByAPIKeyHash(context.Background(), token.HashToken(apiKey))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +214,7 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	if out["api_key"] == "" {
 		t.Fatalf("unexpected provision response: %+v", out)
 	}
-	resolved, err := metaStore.ResolveByAPIKeyHash(context.Background(), tenant.HashToken(out["api_key"]))
+	resolved, err := metaStore.ResolveByAPIKeyHash(context.Background(), token.HashToken(out["api_key"]))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +281,7 @@ func TestStartupResumesProvisioningTenantInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tenantID := tenant.NewID()
+	tenantID := token.NewID()
 	now := time.Now().UTC()
 	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
 		ID:               tenantID,

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/semantic"
 	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -265,7 +266,7 @@ func TestSemanticWorkerKeepsBorrowedTenantBackendAliveDuringInvalidate(t *testin
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
-	tenantID := tenant.NewID()
+	tenantID := token.NewID()
 	tenantMeta := &meta.Tenant{
 		ID:               tenantID,
 		Status:           meta.TenantActive,
@@ -447,7 +448,7 @@ func TestSemanticWorkerManagerStartsForMultiTenantImageOnlyMode(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
-	tenantID := tenant.NewID()
+	tenantID := token.NewID()
 	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
 		ID:               tenantID,
 		Status:           meta.TenantActive,
@@ -676,7 +677,7 @@ func TestSemanticWorkerListTenantRefsImageOnlyIncludesAutoProviders(t *testing.T
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
-	autoTenantID := tenant.NewID()
+	autoTenantID := token.NewID()
 	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
 		ID:               autoTenantID,
 		Status:           meta.TenantActive,
@@ -693,7 +694,7 @@ func TestSemanticWorkerListTenantRefsImageOnlyIncludesAutoProviders(t *testing.T
 	}); err != nil {
 		t.Fatal(err)
 	}
-	keepTenantID := tenant.NewID()
+	keepTenantID := token.NewID()
 	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
 		ID:               keepTenantID,
 		Status:           meta.TenantActive,
@@ -750,7 +751,7 @@ func TestSemanticWorkerListTenantRefsEmbedOnlySkipsAutoProviders(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
-	autoTenantID := tenant.NewID()
+	autoTenantID := token.NewID()
 	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
 		ID:               autoTenantID,
 		Status:           meta.TenantActive,
@@ -767,7 +768,7 @@ func TestSemanticWorkerListTenantRefsEmbedOnlySkipsAutoProviders(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	keepTenantID := tenant.NewID()
+	keepTenantID := token.NewID()
 	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
 		ID:               keepTenantID,
 		Status:           meta.TenantActive,
@@ -864,7 +865,7 @@ func TestSemanticWorkerHTTPMultiTenantImageOnlySkipsAppTenantEmbedTasks(t *testi
 		}
 		now := time.Now().UTC()
 		tenantMeta := &meta.Tenant{
-			ID:               tenant.NewID(),
+			ID:               token.NewID(),
 			Status:           meta.TenantActive,
 			DBHost:           host,
 			DBPort:           port,
@@ -880,7 +881,7 @@ func TestSemanticWorkerHTTPMultiTenantImageOnlySkipsAppTenantEmbedTasks(t *testi
 		if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
 			t.Fatal(err)
 		}
-		tok, err := tenant.IssueToken(tokenSecret, tenantMeta.ID, 1)
+		tok, err := token.IssueToken(tokenSecret, tenantMeta.ID, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -889,11 +890,11 @@ func TestSemanticWorkerHTTPMultiTenantImageOnlySkipsAppTenantEmbedTasks(t *testi
 			t.Fatal(err)
 		}
 		if err := metaStore.InsertAPIKey(context.Background(), &meta.APIKey{
-			ID:            tenant.NewID(),
+			ID:            token.NewID(),
 			TenantID:      tenantMeta.ID,
 			KeyName:       provider,
 			JWTCiphertext: tokCipher,
-			JWTHash:       tenant.HashToken(tok),
+			JWTHash:       token.HashToken(tok),
 			TokenVersion:  1,
 			Status:        meta.APIKeyActive,
 			IssuedAt:      now,
@@ -981,7 +982,7 @@ func TestSemanticWorkerListTenantRefsDoesNotUseFallbackImageCapabilityForPoolTen
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
-	autoTenantID := tenant.NewID()
+	autoTenantID := token.NewID()
 	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
 		ID:               autoTenantID,
 		Status:           meta.TenantActive,
@@ -1219,7 +1220,7 @@ func insertServerImageFileForExtractTest(t *testing.T, b *backend.Dat9Backend, p
 
 func mustServerImageFileID(t *testing.T, b *backend.Dat9Backend, path, contentType string, data []byte) string {
 	t.Helper()
-	fileID := "file-" + tenant.NewID()
+	fileID := "file-" + token.NewID()
 	now := time.Now().UTC()
 	err := b.Store().InTx(context.Background(), func(tx *sql.Tx) error {
 		if err := b.Store().InsertFileTx(tx, &datastore.File{
@@ -1236,11 +1237,11 @@ func mustServerImageFileID(t *testing.T, b *backend.Dat9Backend, path, contentTy
 		}); err != nil {
 			return err
 		}
-		if err := b.Store().EnsureParentDirsTx(tx, path, func() string { return tenant.NewID() }); err != nil {
+		if err := b.Store().EnsureParentDirsTx(tx, path, func() string { return token.NewID() }); err != nil {
 			return err
 		}
 		return b.Store().InsertNodeTx(tx, &datastore.FileNode{
-			NodeID:     tenant.NewID(),
+			NodeID:     token.NewID(),
 			Path:       path,
 			ParentPath: pathutil.ParentPath(path),
 			Name:       pathutil.BaseName(path),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
 	"github.com/mem9-ai/dat9/pkg/traceid"
 	"go.uber.org/zap"
 )
@@ -269,7 +270,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resolved, err := s.meta.ResolveByAPIKeyHash(r.Context(), tenant.HashToken(tok))
+	resolved, err := s.meta.ResolveByAPIKeyHash(r.Context(), token.HashToken(tok))
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_key_not_found")...)
@@ -280,7 +281,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
 		return
 	}
-	if subtle.ConstantTimeCompare([]byte(tenant.HashToken(tok)), []byte(resolved.APIKey.JWTHash)) != 1 {
+	if subtle.ConstantTimeCompare([]byte(token.HashToken(tok)), []byte(resolved.APIKey.JWTHash)) != 1 {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_hash_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
@@ -301,7 +302,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
-	claims, err := tenant.ParseAndVerifyToken(s.tokenSecret, tok)
+	claims, err := token.ParseAndVerifyToken(s.tokenSecret, tok)
 	if err != nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_token_invalid", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
@@ -1402,18 +1403,18 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	tenantID := tenant.NewID()
+	tenantID := token.NewID()
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_requested", "tenant_id", tenantID, "provider", provider)...)
 	keyName := "default"
 
-	token, err := tenant.IssueToken(s.tokenSecret, tenantID, 1)
+	apiToken, err := token.IssueToken(s.tokenSecret, tenantID, 1)
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_issue_token_failed", "tenant_id", tenantID, "error", err)...)
 		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
 		errJSON(w, http.StatusInternalServerError, "failed to issue token")
 		return
 	}
-	hash := tenant.HashToken(token)
+	hash := token.HashToken(apiToken)
 	now := time.Now().UTC()
 	cluster, err := s.provisioner.Provision(r.Context(), tenantID)
 	if err != nil {
@@ -1431,7 +1432,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusInternalServerError, "failed to encrypt db password")
 		return
 	}
-	cipherToken, err := s.pool.Encrypt(r.Context(), []byte(token))
+	cipherToken, err := s.pool.Encrypt(r.Context(), []byte(apiToken))
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_encrypt_api_key_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
@@ -1463,7 +1464,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	metricEvent(r.Context(), "metadb_query", "api", "insert_tenant", "result", "ok")
-	apiKeyID := tenant.NewID()
+	apiKeyID := token.NewID()
 	if err := s.meta.InsertAPIKey(r.Context(), &meta.APIKey{
 		ID:            apiKeyID,
 		TenantID:      tenantID,
@@ -1493,7 +1494,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]string{
-		"api_key": token,
+		"api_key": apiToken,
 		"status":  string(meta.TenantProvisioning),
 	})
 }

--- a/pkg/tenant/db9/provisioner.go
+++ b/pkg/tenant/db9/provisioner.go
@@ -1,4 +1,4 @@
-package tenant
+package db9
 
 import (
 	"bytes"
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/tenant"
 )
 
 const (
@@ -17,28 +19,28 @@ const (
 	envDB9APIKey = "DRIVE9_DB9_API_KEY"
 )
 
-type DB9Provisioner struct {
+type Provisioner struct {
 	baseURL string
 	apiKey  string
 	client  *http.Client
 }
 
-func NewDB9ProvisionerFromEnv() (*DB9Provisioner, error) {
+func NewProvisionerFromEnv() (*Provisioner, error) {
 	base := os.Getenv(envDB9APIURL)
 	key := os.Getenv(envDB9APIKey)
 	if base == "" || key == "" {
 		return nil, fmt.Errorf("%s and %s are required", envDB9APIURL, envDB9APIKey)
 	}
-	return &DB9Provisioner{baseURL: strings.TrimRight(base, "/"), apiKey: key, client: &http.Client{Timeout: 30 * time.Second}}, nil
+	return &Provisioner{baseURL: strings.TrimRight(base, "/"), apiKey: key, client: &http.Client{Timeout: 30 * time.Second}}, nil
 }
 
-func (p *DB9Provisioner) ProviderType() string { return ProviderDB9 }
+func (p *Provisioner) ProviderType() string { return tenant.ProviderDB9 }
 
-func (p *DB9Provisioner) InitSchema(_ context.Context, dsn string) error {
+func (p *Provisioner) InitSchema(_ context.Context, dsn string) error {
 	return initDB9Schema(dsn)
 }
 
-func (p *DB9Provisioner) Provision(ctx context.Context, tenantID string) (*ClusterInfo, error) {
+func (p *Provisioner) Provision(ctx context.Context, tenantID string) (*tenant.ClusterInfo, error) {
 	type reqBody struct {
 		TenantID string `json:"tenant_id"`
 	}
@@ -74,7 +76,7 @@ func (p *DB9Provisioner) Provision(ctx context.Context, tenantID string) (*Clust
 	if out.Host == "" || out.Port == 0 || out.Username == "" || out.Password == "" || out.DBName == "" {
 		return nil, fmt.Errorf("db9 response missing required connection fields")
 	}
-	return &ClusterInfo{
+	return &tenant.ClusterInfo{
 		TenantID:  tenantID,
 		ClusterID: out.ClusterID,
 		Host:      out.Host,
@@ -82,6 +84,6 @@ func (p *DB9Provisioner) Provision(ctx context.Context, tenantID string) (*Clust
 		Username:  out.Username,
 		Password:  out.Password,
 		DBName:    out.DBName,
-		Provider:  ProviderDB9,
+		Provider:  tenant.ProviderDB9,
 	}, nil
 }

--- a/pkg/tenant/db9/schema.go
+++ b/pkg/tenant/db9/schema.go
@@ -1,9 +1,11 @@
-package tenant
+package db9
 
 import (
 	"database/sql"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
 
 func initDB9Schema(dsn string) error {
@@ -108,5 +110,5 @@ func initDB9Schema(dsn string) error {
 		`CREATE INDEX IF NOT EXISTS idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
 	}
 
-	return execSchemaStatements(db, stmts)
+	return schema.ExecSchemaStatements(db, stmts)
 }

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/s3client"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 	"go.uber.org/zap"
 )
 
@@ -257,7 +258,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		return nil, nil, fmt.Errorf("open datastore: %w", err)
 	}
 	if opts.DatabaseAutoEmbedding && (t.Provider == ProviderTiDBZero || t.Provider == ProviderTiDBCloudStarter) {
-		if err := ValidateTiDBSchemaForMode(store.DB(), TiDBEmbeddingModeAuto); err != nil {
+		if err := schema.ValidateTiDBSchemaForMode(store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
 			_ = store.Close()
 			return nil, nil, fmt.Errorf("validate tidb auto-embedding schema: %w", err)
 		}

--- a/pkg/tenant/schema/common.go
+++ b/pkg/tenant/schema/common.go
@@ -1,4 +1,4 @@
-package tenant
+package schema
 
 import (
 	"database/sql"
@@ -6,7 +6,9 @@ import (
 	"strings"
 )
 
-func execSchemaStatements(db *sql.DB, stmts []string) error {
+// ExecSchemaStatements executes a sequence of DDL statements, ignoring
+// duplicate-key / already-exists errors that arise from racing migrations.
+func ExecSchemaStatements(db *sql.DB, stmts []string) error {
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
 			if isIgnorableSchemaError(err) {
@@ -22,7 +24,7 @@ func execSchemaStatements(db *sql.DB, stmts []string) error {
 	return nil
 }
 
-func hasMultiStatements(dsn string) bool {
+func HasMultiStatements(dsn string) bool {
 	lower := strings.ToLower(dsn)
 	return strings.Contains(lower, "multistatements=true") || strings.Contains(lower, "multistatements=1")
 }
@@ -37,7 +39,7 @@ func isIgnorableSchemaError(err error) bool {
 		strings.Contains(msg, "duplicate column")
 }
 
-func isTiDBCluster(db *sql.DB) bool {
+func IsTiDBCluster(db *sql.DB) bool {
 	var ver string
 	if err := db.QueryRow(`SELECT VERSION()`).Scan(&ver); err != nil {
 		return false

--- a/pkg/tenant/schema/tidb.go
+++ b/pkg/tenant/schema/tidb.go
@@ -1,4 +1,4 @@
-package tenant
+package schema
 
 // InitTiDBTenantSchema initializes the TiDB launch schema baseline with the
 // shared database-managed auto-embedding contract used by TiDB tenants.
@@ -11,14 +11,10 @@ func InitTiDBTenantSchema(dsn string) error {
 func InitTiDBTenantSchemaForMode(dsn string, mode TiDBEmbeddingMode) error {
 	switch mode {
 	case TiDBEmbeddingModeAuto:
-		return initZeroSchema(dsn)
+		return initTiDBAutoEmbeddingSchema(dsn)
 	case TiDBEmbeddingModeApp:
 		return initTiDBAppEmbeddingSchema(dsn)
 	default:
 		return validateTiDBSchemaMode(mode)
 	}
-}
-
-func initZeroSchema(dsn string) error {
-	return initTiDBAutoEmbeddingSchema(dsn)
 }

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -1,4 +1,4 @@
-package tenant
+package schema
 
 import (
 	"fmt"
@@ -31,7 +31,7 @@ func tidbAppEmbeddingSchemaStatements() []string {
 			status             VARCHAR(32) NOT NULL DEFAULT 'PENDING',
 			source_id          VARCHAR(255),
 			content_text       LONGTEXT,
-			embedding          VECTOR(` + strconv.Itoa(tidbAutoEmbeddingDimensions) + `),
+			embedding          VECTOR(` + strconv.Itoa(TiDBAutoEmbeddingDimensions) + `),
 			embedding_revision BIGINT,
 			created_at         DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			confirmed_at       DATETIME(3),
@@ -96,15 +96,15 @@ func tidbAppEmbeddingSchemaStatements() []string {
 }
 
 func initTiDBAppEmbeddingSchema(dsn string) error {
-	db, err := openTiDBSchemaDB(dsn)
+	db, err := OpenTiDBSchemaDB(dsn)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
-	if !isTiDBCluster(db) {
+	if !IsTiDBCluster(db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
-	if err := execSchemaStatements(db, tidbAppEmbeddingSchemaStatements()); err != nil {
+	if err := ExecSchemaStatements(db, tidbAppEmbeddingSchemaStatements()); err != nil {
 		return err
 	}
 	return ValidateTiDBSchemaForMode(db, TiDBEmbeddingModeApp)

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -1,4 +1,4 @@
-package tenant
+package schema
 
 import (
 	"context"
@@ -24,10 +24,10 @@ const (
 // Reference of Auto Embedding in TiDB Cloud: https://docs.pingcap.com/ai/vector-search-auto-embedding-amazon-titan/
 const (
 	tidbAutoEmbeddingModel      = "tidbcloud_free/amazon/titan-embed-text-v2"
-	tidbAutoEmbeddingDimensions = 1024
+	TiDBAutoEmbeddingDimensions = 1024
 )
 
-var tidbAutoEmbeddingOptionsJSON = fmt.Sprintf(`{"dimensions":%d}`, tidbAutoEmbeddingDimensions)
+var tidbAutoEmbeddingOptionsJSON = fmt.Sprintf(`{"dimensions":%d}`, TiDBAutoEmbeddingDimensions)
 
 type tidbColumnMeta struct {
 	columnType           string
@@ -66,7 +66,7 @@ func tidbAutoEmbeddingSchemaStatements() []string {
 			status             VARCHAR(32) NOT NULL DEFAULT 'PENDING',
 			source_id          VARCHAR(255),
 			content_text       LONGTEXT,
-			embedding          VECTOR(` + strconv.Itoa(tidbAutoEmbeddingDimensions) + `) GENERATED ALWAYS AS (EMBED_TEXT(
+			embedding          VECTOR(` + strconv.Itoa(TiDBAutoEmbeddingDimensions) + `) GENERATED ALWAYS AS (EMBED_TEXT(
 				'` + tidbAutoEmbeddingModel + `',
 				content_text,
 				'` + tidbAutoEmbeddingOptionsJSON + `'
@@ -143,7 +143,7 @@ func DetectTiDBEmbeddingMode(db *sql.DB) (TiDBEmbeddingMode, error) {
 	if db == nil {
 		return TiDBEmbeddingModeUnknown, fmt.Errorf("nil db")
 	}
-	if !isTiDBCluster(db) {
+	if !IsTiDBCluster(db) {
 		return TiDBEmbeddingModeUnknown, fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
 	loadStart := time.Now()
@@ -176,31 +176,11 @@ func DetectTiDBEmbeddingMode(db *sql.DB) (TiDBEmbeddingMode, error) {
 
 // ValidateTiDBSchemaForMode validates that an already-open TiDB connection
 // matches exactly one supported dat9 embedding contract for the requested mode.
-//
-// The `mode` argument is a runtime behavior contract, not a cosmetic schema tag:
-//
-//   - `TiDBEmbeddingModeAuto` requires database-managed embedding, where
-//     `files.embedding` is a stored generated column derived from `content_text`
-//     via `EMBED_TEXT(...)`.
-//   - `TiDBEmbeddingModeApp` requires application-managed embedding, where
-//     `files.embedding` remains writable for the app-side embed worker and
-//     query-embedding path.
-//
-// The validator is intentionally strict: if the schema does not clearly satisfy
-// the requested mode, it returns an error rather than guessing or falling back
-// to the other mode.
-//
-// At the moment this contract is intentionally scoped to the tables that drive
-// embedding-mode behavior directly: `files` and `semantic_tasks`. Other TiDB
-// tables are currently outside this mode validator.
-//
-// Within that scope, `files` is validated structurally for the requested mode,
-// while `semantic_tasks` is currently checked only for table existence.
 func ValidateTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
 	if db == nil {
 		return fmt.Errorf("nil db")
 	}
-	if !isTiDBCluster(db) {
+	if !IsTiDBCluster(db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
 	if err := validateTiDBSchemaMode(mode); err != nil {
@@ -227,22 +207,23 @@ func validateTiDBSchemaMode(mode TiDBEmbeddingMode) error {
 }
 
 func initTiDBAutoEmbeddingSchema(dsn string) error {
-	db, err := openTiDBSchemaDB(dsn)
+	db, err := OpenTiDBSchemaDB(dsn)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
-	if !isTiDBCluster(db) {
+	if !IsTiDBCluster(db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
-	if err := execSchemaStatements(db, tidbAutoEmbeddingSchemaStatements()); err != nil {
+	if err := ExecSchemaStatements(db, tidbAutoEmbeddingSchemaStatements()); err != nil {
 		return err
 	}
 	return ValidateTiDBSchemaForMode(db, TiDBEmbeddingModeAuto)
 }
 
-func validateTiDBSchemaForModeDSN(dsn string, mode TiDBEmbeddingMode) error {
-	db, err := openTiDBSchemaDB(dsn)
+// ValidateTiDBSchemaForModeDSN opens a DSN, validates the schema, and closes.
+func ValidateTiDBSchemaForModeDSN(dsn string, mode TiDBEmbeddingMode) error {
+	db, err := OpenTiDBSchemaDB(dsn)
 	if err != nil {
 		return err
 	}
@@ -250,8 +231,8 @@ func validateTiDBSchemaForModeDSN(dsn string, mode TiDBEmbeddingMode) error {
 	return ValidateTiDBSchemaForMode(db, mode)
 }
 
-func openTiDBSchemaDB(dsn string) (*sql.DB, error) {
-	if hasMultiStatements(dsn) {
+func OpenTiDBSchemaDB(dsn string) (*sql.DB, error) {
+	if HasMultiStatements(dsn) {
 		return nil, fmt.Errorf("multiStatements is not allowed")
 	}
 	db, err := sql.Open("mysql", dsn)
@@ -286,7 +267,7 @@ func detectTiDBEmbeddingModeFromFilesMeta(meta tidbTableMeta) (TiDBEmbeddingMode
 	if err != nil {
 		return TiDBEmbeddingModeUnknown, err
 	}
-	if normalizeSQLFragment(col.columnType) != fmt.Sprintf("vector(%d)", tidbAutoEmbeddingDimensions) {
+	if normalizeSQLFragment(col.columnType) != fmt.Sprintf("vector(%d)", TiDBAutoEmbeddingDimensions) {
 		return TiDBEmbeddingModeUnknown, fmt.Errorf("unsupported embedding column type %q", col.columnType)
 	}
 	extra := normalizeSQLFragment(col.extra)
@@ -364,7 +345,7 @@ func validateTiDBFilesTableBase(meta tidbTableMeta) error {
 	if err := meta.requireColumnType("content_text", "longtext"); err != nil {
 		return err
 	}
-	if err := meta.requireColumnType("embedding", fmt.Sprintf("vector(%d)", tidbAutoEmbeddingDimensions)); err != nil {
+	if err := meta.requireColumnType("embedding", fmt.Sprintf("vector(%d)", TiDBAutoEmbeddingDimensions)); err != nil {
 		return err
 	}
 	return meta.requireColumnType("embedding_revision", "bigint")

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -1,4 +1,4 @@
-package tenant
+package schema
 
 import (
 	"strings"

--- a/pkg/tenant/starter/provisioner.go
+++ b/pkg/tenant/starter/provisioner.go
@@ -1,4 +1,5 @@
-package tenant
+// Package starter implements the TiDB Cloud Starter tenant provisioner.
+package starter
 
 import (
 	"bytes"
@@ -13,6 +14,9 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
 
 const (
@@ -22,7 +26,7 @@ const (
 	envTiDBPoolID    = "DRIVE9_TIDBCLOUD_POOL_ID"
 )
 
-type StarterProvisioner struct {
+type Provisioner struct {
 	apiURL    string
 	apiKey    string
 	apiSecret string
@@ -30,7 +34,7 @@ type StarterProvisioner struct {
 	client    *http.Client
 }
 
-func NewStarterProvisionerFromEnv() (*StarterProvisioner, error) {
+func NewProvisionerFromEnv() (*Provisioner, error) {
 	apiURL := os.Getenv(envTiDBAPIURL)
 	apiKey := os.Getenv(envTiDBAPIKey)
 	apiSecret := os.Getenv(envTiDBAPISecret)
@@ -38,7 +42,7 @@ func NewStarterProvisionerFromEnv() (*StarterProvisioner, error) {
 	if apiURL == "" || apiKey == "" || apiSecret == "" || poolID == "" {
 		return nil, fmt.Errorf("%s, %s, %s and %s are required", envTiDBAPIURL, envTiDBAPIKey, envTiDBAPISecret, envTiDBPoolID)
 	}
-	return &StarterProvisioner{
+	return &Provisioner{
 		apiURL:    strings.TrimRight(apiURL, "/"),
 		apiKey:    apiKey,
 		apiSecret: apiSecret,
@@ -47,15 +51,15 @@ func NewStarterProvisionerFromEnv() (*StarterProvisioner, error) {
 	}, nil
 }
 
-func (p *StarterProvisioner) ProviderType() string { return ProviderTiDBCloudStarter }
+func (p *Provisioner) ProviderType() string { return tenant.ProviderTiDBCloudStarter }
 
 // InitSchema validates the externally provisioned Starter schema against the
 // shared TiDB auto-embedding launch contract without creating or altering data.
-func (p *StarterProvisioner) InitSchema(_ context.Context, dsn string) error {
-	return validateTiDBSchemaForModeDSN(dsn, TiDBEmbeddingModeAuto)
+func (p *Provisioner) InitSchema(_ context.Context, dsn string) error {
+	return schema.ValidateTiDBSchemaForModeDSN(dsn, schema.TiDBEmbeddingModeAuto)
 }
 
-func (p *StarterProvisioner) Provision(ctx context.Context, tenantID string) (*ClusterInfo, error) {
+func (p *Provisioner) Provision(ctx context.Context, tenantID string) (*tenant.ClusterInfo, error) {
 	password, err := generateRandomPassword(24)
 	if err != nil {
 		return nil, err
@@ -89,7 +93,7 @@ func (p *StarterProvisioner) Provision(ctx context.Context, tenantID string) (*C
 		return nil, fmt.Errorf("starter response missing endpoint")
 	}
 
-	return &ClusterInfo{
+	return &tenant.ClusterInfo{
 		TenantID:  tenantID,
 		ClusterID: out.ClusterID,
 		Host:      out.Endpoints.Public.Host,
@@ -97,11 +101,11 @@ func (p *StarterProvisioner) Provision(ctx context.Context, tenantID string) (*C
 		Username:  out.UserPrefix + ".root",
 		Password:  password,
 		DBName:    "test",
-		Provider:  ProviderTiDBCloudStarter,
+		Provider:  tenant.ProviderTiDBCloudStarter,
 	}, nil
 }
 
-func (p *StarterProvisioner) doDigestAuthRequest(ctx context.Context, method, uri string, body []byte) (*http.Response, error) {
+func (p *Provisioner) doDigestAuthRequest(ctx context.Context, method, uri string, body []byte) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, uri, bytes.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/pkg/tenant/starter/provisioner_test.go
+++ b/pkg/tenant/starter/provisioner_test.go
@@ -1,4 +1,4 @@
-package tenant
+package starter
 
 import (
 	"context"
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func TestStarterProvisionerInitSchemaValidatesSchema(t *testing.T) {
-	p := &StarterProvisioner{}
+func TestProvisionerInitSchemaValidatesSchema(t *testing.T) {
+	p := &Provisioner{}
 	err := p.InitSchema(context.Background(), "ignored-dsn")
 	if err == nil {
 		t.Fatal("expected starter schema validation to reject invalid dsn")

--- a/pkg/tenant/tidbzero/provisioner.go
+++ b/pkg/tenant/tidbzero/provisioner.go
@@ -1,4 +1,4 @@
-package tenant
+package tidbzero
 
 import (
 	"bytes"
@@ -10,30 +10,33 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
 
 const envZeroAPIURL = "DRIVE9_ZERO_API_URL"
 
-type ZeroProvisioner struct {
+type Provisioner struct {
 	baseURL string
 	client  *http.Client
 }
 
-func NewZeroProvisionerFromEnv() (*ZeroProvisioner, error) {
+func NewProvisionerFromEnv() (*Provisioner, error) {
 	base := os.Getenv(envZeroAPIURL)
 	if base == "" {
 		return nil, fmt.Errorf("%s is required", envZeroAPIURL)
 	}
-	return &ZeroProvisioner{baseURL: strings.TrimRight(base, "/"), client: &http.Client{Timeout: 30 * time.Second}}, nil
+	return &Provisioner{baseURL: strings.TrimRight(base, "/"), client: &http.Client{Timeout: 30 * time.Second}}, nil
 }
 
-func (p *ZeroProvisioner) ProviderType() string { return ProviderTiDBZero }
+func (p *Provisioner) ProviderType() string { return tenant.ProviderTiDBZero }
 
-func (p *ZeroProvisioner) InitSchema(_ context.Context, dsn string) error {
-	return initZeroSchema(dsn)
+func (p *Provisioner) InitSchema(_ context.Context, dsn string) error {
+	return schema.InitTiDBTenantSchema(dsn)
 }
 
-func (p *ZeroProvisioner) Provision(ctx context.Context, tenantID string) (*ClusterInfo, error) {
+func (p *Provisioner) Provision(ctx context.Context, tenantID string) (*tenant.ClusterInfo, error) {
 	type reqBody struct {
 		Tag string `json:"tag"`
 	}
@@ -86,7 +89,7 @@ func (p *ZeroProvisioner) Provision(ctx context.Context, tenantID string) (*Clus
 		}
 	}
 
-	return &ClusterInfo{
+	return &tenant.ClusterInfo{
 		TenantID:       tenantID,
 		ClusterID:      out.Instance.ID,
 		Host:           out.Instance.Connection.Host,
@@ -94,7 +97,7 @@ func (p *ZeroProvisioner) Provision(ctx context.Context, tenantID string) (*Clus
 		Username:       out.Instance.Connection.Username,
 		Password:       out.Instance.Connection.Password,
 		DBName:         "test",
-		Provider:       ProviderTiDBZero,
+		Provider:       tenant.ProviderTiDBZero,
 		ClaimURL:       out.Instance.ClaimInfo.ClaimURL,
 		ClaimExpiresAt: claimExp,
 	}, nil

--- a/pkg/tenant/token/token.go
+++ b/pkg/tenant/token/token.go
@@ -1,4 +1,4 @@
-package tenant
+package token
 
 import (
 	"crypto/hmac"

--- a/pkg/tenant/token/token_test.go
+++ b/pkg/tenant/token/token_test.go
@@ -1,4 +1,4 @@
-package tenant
+package token
 
 import (
 	"crypto/rand"


### PR DESCRIPTION
## Summary

Reorganize `pkg/tenant/` into focused sub-packages:

| Sub-package | Contents |
|---|---|
| `tenant/db9/` | DB9 provisioner + PostgreSQL DDL |
| `tenant/tidbzero/` | TiDB Zero provisioner |
| `tenant/starter/` | TiDB Cloud Starter provisioner + test |
| `tenant/schema/` | Schema init, TiDB embedding mode detection & validation |
| `tenant/token/` | JWT token issue/parse/verify, Claims type, helpers |

Root `tenant` package retains: provider constants, `Provisioner` interface, `Pool` (LRU), and shared test infrastructure.

## Changes

- Move provider files into `db9/`, `tidbzero/`, `starter/` sub-packages
- Move schema files into `schema/` sub-package, export previously-internal helpers (`IsTiDBCluster`, `HasMultiStatements`, etc.)
- Move token files into `token/` sub-package
- Update all external consumers (`pkg/server/`, `cmd/drive9-server-local/`)
- Rename local var `token` → `apiToken` in `server.go` to avoid shadowing the new `token` package import

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Reorganized internal code structure to improve maintainability and better organize authentication, schema management, and cloud provisioning components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->