### PR TITLE
feat(fuse): Obsidian compatibility — StatFs, xattr, mtime, debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,378 +1,209 @@
 # drive9
 
-> **Note**: This project was formerly known as `dat9`. The Go module path is being migrated in a separate PR.
-
-Agent-native data infrastructure — a network drive with built-in semantic search.
-
-drive9 presents a single filesystem-like interface for storing, retrieving, and querying data of any kind. Agents (or humans) interact with drive9 the same way they interact with a local filesystem: `cp`, `cat`, `ls`, `mv`, `rm`, `search`. All protocol complexity — tiered storage, embedding, full-text indexing — is invisible to the user.
-
-## Why drive9?
-
-- **Agent tool fragmentation**: each agent tool uses its own storage semantics and credentials. drive9 unifies them under one path namespace.
-- **Server bandwidth bottlenecks**: proxying large uploads is slow and expensive. drive9 uses S3 presigned URLs for direct upload — the server never touches large file data.
-- **Missing semantic discoverability**: files exist, but cannot be found by meaning. drive9 leverages [db9](https://db9.ai/)'s built-in embedding and vector search.
-- **No unified abstraction across storage tiers**: drive9 provides one path namespace spanning db9 (small files, instant, auto-embedded) and S3 (large files, cheap, unlimited).
-
-## Quick Start
-
-### CLI
+A network drive. Mount it, use it.
 
 ```bash
-# Upload a file
-drive9 cp ./dataset.tar :/data/dataset.tar
+drive9 mount ~/drive
+cp video.mp4 ~/drive/
+ls ~/drive/
+```
 
-# Read a file
-drive9 cat :/config/settings.json
+Everything is a path. `cp`, `cat`, `ls`, `mv`, `rm` — they just work. The storage backend (db9, S3, local), the upload protocol (presigned multipart, streaming, direct PUT), the semantic indexing (embedding, FTS, image OCR) — all invisible. You see a filesystem.
 
-# List directory
+Inspired by Plan 9's "everything is a file" and the idea that naming things is the only interface you need.
+
+## What it does
+
+**One path namespace, multiple storage tiers.** Small files (< 50KB) go to [db9](https://db9.ai/) — instant writes, auto-embedded, full-text indexed, vector searchable. Large files (≥ 50KB) go to S3 via presigned URLs — the server never touches the bytes.
+
+**FUSE mount with streaming I/O.** Mount as a local filesystem. Sequential writes (cp, dd, ffmpeg) stream parts directly to S3 during `write()`, releasing memory after each part uploads. A 10GB video uses ~24MB of RAM, constant. Random reads use adaptive prefetch — the read window grows from 256KB to 16MB as sequential patterns are detected.
+
+**Semantic search built in.** Every file gets background-embedded. Images get OCR'd. Directories carry `.abstract.md` (100 tokens) and `.overview.md` (1K tokens) for cheap agent scanning — 10x token savings over reading full content.
+
+**Zero-cost operations.** `cp` between drive9 paths is a metadata link (inode refcount). `mv` is a rename. No bytes move.
+
+## Quick start
+
+```bash
+# CLI
+drive9 cp ./data.tar :/data/data.tar
+drive9 cat :/config/app.json
 drive9 ls :/data/
+drive9 cp :/a.bin :/b.bin        # zero-copy
+drive9 mv :/old.bin :/new.bin    # metadata-only
 
-# Zero-copy link (no re-upload)
-drive9 cp :/data/a.bin :/shared/a.bin
-
-# Rename (metadata-only, zero storage cost)
-drive9 mv :/data/old.bin :/data/new.bin
-
-# Start the server
-drive9-server
-
-# Mount as local filesystem
+# Mount
 drive9 mount /mnt/drive9
 
 # Unmount
 drive9 umount /mnt/drive9
 ```
 
-### FUSE Mount
+### FUSE prerequisites
 
-Mount drive9 as a local filesystem — use `ls`, `cat`, `vim`, `cp` directly on your drive9 data.
+**macOS** — `brew install --cask macfuse` (Apple Silicon: approve system extension in System Settings, reboot)
 
-```bash
-drive9 mount /mnt/drive9
-```
-
-#### Prerequisites
-
-FUSE mount requires a platform-specific FUSE provider:
-
-**macOS**
-
-Install [macFUSE](https://osxfuse.github.io/):
-
-```bash
-brew install --cask macfuse
-```
-
-On Apple Silicon, you may need to approve the macFUSE system extension in **System Settings > Privacy & Security** and reboot before mounts will work.
-
-**Linux**
-
-Install FUSE 3 (or FUSE 2) via your package manager:
-
-```bash
-# Debian / Ubuntu
-sudo apt-get install fuse3
-
-# RHEL / CentOS / Fedora
-sudo dnf install fuse3
-
-# Arch
-sudo pacman -S fuse3
-```
-
-Ensure your user is in the `fuse` group (or use `allow_other` mount option with `/etc/fuse.conf`).
-
-**Windows**
-
-Not currently supported. Contributions welcome via [WinFsp](https://winfsp.dev/).
-
-#### Mount Options
-
-```
-drive9 mount [flags] <mountpoint>
-
-  --server       drive9 server URL (default: $DRIVE9_SERVER)
-  --api-key      API key (default: $DRIVE9_API_KEY)
-  --cache-size   read cache size in MB (default: 128)
-  --dir-ttl      directory cache TTL (default: 5s)
-  --attr-ttl     kernel attr cache TTL (default: 1s)
-  --entry-ttl    kernel entry cache TTL (default: 1s)
-  --allow-other  allow other users to access mount
-  --read-only    mount as read-only
-  --debug        enable FUSE debug logging
-```
+**Linux** — `apt install fuse3` / `dnf install fuse3` / `pacman -S fuse3`
 
 ### Go SDK
 
 ```go
-import "github.com/mem9-ai/drive9/pkg/client"
-
 c := client.New("http://localhost:9009", "")
-
-// Write
-c.Write("/data/file.txt", []byte("hello world"))
-
-// Read
+c.Write("/data/file.txt", []byte("hello"))
 data, _ := c.Read("/data/file.txt")
-
-// List
 entries, _ := c.List("/data/")
-
-// Zero-copy
-c.Copy("/data/file.txt", "/shared/file.txt")
-
-// Stat
-info, _ := c.Stat("/data/file.txt")
-
-// Rename
-c.Rename("/data/old.txt", "/data/new.txt")
-
-// Delete
+c.Copy("/a.txt", "/b.txt")   // zero-copy
+c.Rename("/old", "/new")     // metadata-only
 c.Delete("/data/file.txt")
 ```
-
-### Environment Variables
-
-| Variable | Description | Default |
-|---|---|---|
-| `DRIVE9_SERVER` | Server URL | `http://localhost:9009` |
-| `DRIVE9_API_KEY` | API key | |
-| `DRIVE9_LISTEN_ADDR` | Server listen address | `:9009` |
-| `DRIVE9_PUBLIC_URL` | Externally reachable base URL (required for remote clients) | |
-| `DRIVE9_META_DSN` | Control-plane MySQL DSN for the multi-tenant server | |
-| `DRIVE9_S3_BUCKET` | S3 bucket name (enables AWS S3 mode; omit for local mock) | |
-| `DRIVE9_S3_REGION` | AWS region | `us-east-1` |
-| `DRIVE9_S3_PREFIX` | S3 key prefix (e.g. `tenants/abc/`) | |
-| `DRIVE9_S3_ROLE_ARN` | IAM role ARN to assume via STS | |
-| `DRIVE9_S3_DIR` | Local S3 mock directory (only used without `DRIVE9_S3_BUCKET`) | `./s3` |
-| `DRIVE9_TENANT_PROVIDER` | Tenant provisioner: `db9`, `tidb_zero`, or `tidb_cloud_starter` | `tidb_zero` |
-| `DRIVE9_MAX_UPLOAD_BYTES` | Maximum allowed upload size in bytes | `53687091200` |
-| `DRIVE9_MAX_TENANT_STORAGE_BYTES` | Maximum logical storage per tenant in bytes | `53687091200` |
-| `DRIVE9_ZERO_API_URL` | TiDB Zero provision API base URL | |
-| `DRIVE9_TIDBCLOUD_API_URL` | TiDB Cloud Starter API base URL | |
-| `DRIVE9_TIDBCLOUD_API_KEY` | TiDB Cloud Starter API key | |
-| `DRIVE9_TIDBCLOUD_API_SECRET` | TiDB Cloud Starter API secret | |
-| `DRIVE9_TIDBCLOUD_POOL_ID` | TiDB Cloud Starter pool id | |
-| `DRIVE9_DB9_API_URL` | db9 provision API base URL | |
-| `DRIVE9_DB9_API_KEY` | db9 provision API key | |
-| `DRIVE9_ENCRYPT_TYPE` | Encryption backend: `local_aes` or `kms` | `local_aes` |
-| `DRIVE9_MASTER_KEY` | 32-byte hex key for `local_aes` encryption | |
-| `DRIVE9_ENCRYPT_KEY` | KMS key id or alias when `DRIVE9_ENCRYPT_TYPE=kms` | |
-| `DRIVE9_TOKEN_SIGNING_KEY` | 32-byte hex key for JWT API key signing | |
-| `DRIVE9_QUERY_EMBED_API_BASE` | OpenAI-compatible base URL for query embedding | |
-| `DRIVE9_QUERY_EMBED_API_KEY` | API key for query embedding | |
-| `DRIVE9_QUERY_EMBED_MODEL` | Model name for query embedding | |
-| `DRIVE9_QUERY_EMBED_DIMENSIONS` | Optional query embedding dimensions override | |
-| `DRIVE9_QUERY_EMBED_TIMEOUT_SECONDS` | Query embedding timeout seconds | `20` |
-| `DRIVE9_EMBED_API_BASE` | OpenAI-compatible base URL for background embedding | |
-| `DRIVE9_EMBED_API_KEY` | API key for background embedding | |
-| `DRIVE9_EMBED_MODEL` | Model name for background embedding | |
-| `DRIVE9_EMBED_DIMENSIONS` | Optional background embedding dimensions override | |
-| `DRIVE9_EMBED_TIMEOUT_SECONDS` | Background embedding timeout seconds | `20` |
-| `DRIVE9_SEMANTIC_WORKERS` | Number of semantic workers | `1` |
-| `DRIVE9_SEMANTIC_POLL_INTERVAL_MS` | Semantic worker poll interval in milliseconds | `200` |
-| `DRIVE9_SEMANTIC_LEASE_SECONDS` | Semantic task lease duration in seconds | `30` |
-| `DRIVE9_SEMANTIC_RECOVER_INTERVAL_MS` | Expired semantic task recover interval in milliseconds | `5000` |
-| `DRIVE9_SEMANTIC_RETRY_BASE_MS` | Base semantic retry backoff in milliseconds | `200` |
-| `DRIVE9_SEMANTIC_RETRY_MAX_MS` | Max semantic retry backoff in milliseconds | `30000` |
-| `DRIVE9_SEMANTIC_TENANT_LIMIT` | Active tenants scanned per round | `128` |
-| `DRIVE9_SEMANTIC_PER_TENANT_CONCURRENCY` | Max concurrent semantic tasks per tenant | `1` |
-| `DRIVE9_IMAGE_EXTRACT_ENABLED` | Enable async image->text extraction for search | `false` |
-| `DRIVE9_IMAGE_EXTRACT_QUEUE_SIZE` | In-memory queue size for extraction tasks | `128` |
-| `DRIVE9_IMAGE_EXTRACT_WORKERS` | Number of extraction workers | `1` |
-| `DRIVE9_IMAGE_EXTRACT_MAX_BYTES` | Max image bytes processed per task | `8388608` |
-| `DRIVE9_IMAGE_EXTRACT_TIMEOUT_SECONDS` | Timeout per extraction task | `20` |
-| `DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES` | Max extracted text stored into `files.content_text` | `8192` |
-| `DRIVE9_IMAGE_EXTRACT_API_BASE` | OpenAI-compatible base URL (optional; set with key/model) | |
-| `DRIVE9_IMAGE_EXTRACT_API_KEY` | API key for image extraction provider | |
-| `DRIVE9_IMAGE_EXTRACT_MODEL` | Vision model name (for example Qwen VL model id) | |
-| `DRIVE9_IMAGE_EXTRACT_PROMPT` | Custom extraction prompt | `用中文描述这张图片，用于文件搜索。包括：主要物体、场景描述、图中可见文字（OCR）、简洁标签。最后一行用英文写5-10个关键词标签（English tags），用逗号分隔。` |
-| `DRIVE9_IMAGE_EXTRACT_MAX_TOKENS` | Max output tokens for model extraction | `256` |
-| `DRIVE9_CLI_LOG_ENABLED` | Enable CLI structured log file output, including benchmark-consumable transfer summary events | `false` |
-| `DRIVE9_CLI_LOG_MAX_SIZE_MB` | CLI log rotation max size in MB | `10` |
-| `DRIVE9_CLI_LOG_MAX_BACKUPS` | CLI log rotation max backups | `5` |
-| `DRIVE9_CLI_LOG_MAX_AGE_DAYS` | CLI log rotation max age in days | `14` |
-| `DRIVE9_TEST_MYSQL_DSN` | MySQL/TiDB DSN reused by test suites (example: `user:pass@tcp(127.0.0.1:3306)/drive9_test?parseTime=true`) | |
-| `DRIVE9_LOCAL_DSN` | Local single-tenant datastore DSN for `drive9-server-local` | |
-| `DRIVE9_LOCAL_INIT_SCHEMA` | Initialize local tenant schema on startup | `false` |
-| `DRIVE9_LOCAL_EMBEDDING_MODE` | Local embedding mode: `auto`, `app`, or `detect` | `detect` |
 
 ## Architecture
 
 ```
-┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐
-│   CLI    │  │ Go SDK   │  │   FUSE   │  │   MCP    │
-│ drive9 cp  │  │ client   │  │drive9 mount│  │ (future) │
-└────┬─────┘  └────┬─────┘  └────┬─────┘  └────┬─────┘
-     └─────────────┼──────────────┼──────────────┘
-                   ▼              │
-         drive9 HTTP Server        │
-         /v1/fs/{path}           │
-                   │         ┌───┘
-     ┌─────────────┼─────────┤
-     ▼             ▼         ▼
-  Drive9Backend   memfs     S3 direct
-  (AGFS FileSystem)       (presigned URL,
-     │                     FUSE ↔ S3)
-     ├── < 50,000B → TiDB(MySQL protocol) + local blobs (P0)
-     │               db9 + fs9 (production)
-     │
-     └── ≥ 50,000B → S3 presigned URL
-                  (direct upload, server not involved)
+             ┌───────────────────────────────────┐
+             │           path namespace           │
+             │  /data/video.mp4  /config/app.json │
+             └──────────┬────────────────────────-┘
+                        │
+        ┌───────────────┼───────────────┐
+        │               │               │
+   ┌────▼────┐    ┌─────▼─────┐   ┌─────▼─────┐
+   │  CLI    │    │   FUSE    │   │  Go SDK   │
+   │ drive9  │    │ drive9    │   │  client   │
+   │ cp/cat  │    │ mount     │   │  pkg      │
+   └────┬────┘    └─────┬─────┘   └─────┬─────┘
+        │               │               │
+        └───────────────┼───────────────┘
+                        │
+               drive9 HTTP server
+               /v1/fs/{path}
+                        │
+          ┌─────────────┼─────────────┐
+          │                           │
+   < 50KB │                    ≥ 50KB │
+          ▼                           ▼
+   ┌─────────────┐            ┌──────────────┐
+   │    db9      │            │   S3         │
+   │  embedded   │            │  presigned   │
+   │  FTS + vec  │            │  multipart   │
+   └─────────────┘            └──────────────┘
 ```
 
-### Key Design Decisions
+### Inode model
 
-**inode model** — Paths (file_nodes) and file entities (files) are separate, just like Unix. One file can appear at multiple paths. `cp` is a zero-cost link. `mv` is metadata-only. `rm` is reference-counted.
+Paths and files are separate, just like Unix. `file_nodes` are dentries, `files` are inodes. One file can have multiple paths. `cp` increments a refcount. `mv` updates a name. `rm` decrements. Storage is GC'd when refcount hits zero.
 
-**Tiered storage** — Small files (< 50,000 bytes) go to db9 with automatic embedding and FTS indexing. Large files (≥ 50,000 bytes) go directly to S3 via presigned URLs. One path namespace spans both.
+### Upload protocol
 
-**Tiered context (L0/L1/L2)** — Every directory can carry `.abstract.md` (~100 tokens) and `.overview.md` (~1k tokens). Agents scan cheaply via L0/L1 before loading full content (L2). 10x token savings.
+Two generations:
 
-**Built on AGFS** — Imports [AGFS](https://github.com/c4pt0r/agfs)'s `FileSystem` interface and `MountableFS` radix-tree router as a Go module dependency.
+- **v1**: server-side initiate → presign all parts → parallel upload → complete. Simple, but requires knowing total parts upfront.
+- **v2**: server-side initiate → presign parts on demand → streaming upload → complete. Parts can be presigned individually as data arrives. This is what the FUSE streaming write path uses.
+
+Both use S3 presigned URLs — the server never proxies file data.
+
+### FUSE write modes
+
+The FUSE layer classifies writes at runtime:
+
+| Mode | Condition | Memory | Upload |
+|------|-----------|--------|--------|
+| Small file | < 50KB | O(size) | Direct PUT at close |
+| Sequential append | New file, append-only | ~24MB steady | Streaming: parts upload during `write()`, memory freed after each |
+| Non-sequential | New file, back-write detected | O(size) | All parts at close |
+| Existing file edit | Open without truncate | O(touched parts) | Only dirty parts at close (server-side copy for rest) |
+
+Sequential detection: track an append cursor. If writes always advance it, parts behind the cursor are provably final and can be uploaded immediately. Back-write sets `sequential = false` — no data loss, just falls back to buffered mode.
+
+### FUSE read path
+
+- **Small files**: in-memory LRU cache (128MB default)
+- **Large files, sequential**: adaptive prefetch — window doubles per sequential read (256KB → 16MB cap)
+- **Large files, random**: HTTP range reads, no prefetch
+- **Dirty handles**: read from write buffer (lazy-load unmodified parts from server on demand)
 
 ## HTTP API
 
-All file operations go through `/v1/fs/{path}`:
-
 ```
-PUT    /v1/fs/{path}              Write file
-GET    /v1/fs/{path}              Read file
+PUT    /v1/fs/{path}              Write
+GET    /v1/fs/{path}              Read
 GET    /v1/fs/{path}?list         List directory
-HEAD   /v1/fs/{path}              Stat (metadata)
+HEAD   /v1/fs/{path}              Stat
 DELETE /v1/fs/{path}              Delete
-DELETE /v1/fs/{path}?recursive    Delete recursively
-
-POST   /v1/fs/{path}?copy         Zero-copy link
-  Header: X-Drive9-Copy-Source: /source/path
-
-POST   /v1/fs/{path}?rename       Rename/move
-  Header: X-Drive9-Rename-Source: /old/path
-
-POST   /v1/fs/{path}?mkdir        Create directory
+DELETE /v1/fs/{path}?recursive    Recursive delete
+POST   /v1/fs/{path}?copy         Zero-copy (X-Drive9-Copy-Source header)
+POST   /v1/fs/{path}?rename       Rename (X-Drive9-Rename-Source header)
+POST   /v1/fs/{path}?mkdir        Mkdir
 ```
 
-## Project Structure
+## Schema
 
-```
-cmd/drive9/         CLI entrypoint and commands (cp, cat, ls, mount, umount, ...)
-cmd/drive9-server/    Server entrypoint
-pkg/
-  backend/          Drive9Backend — AGFS FileSystem implementation
-  client/           Go SDK HTTP client
-  datastore/        Core metadata store and semantic task persistence
-  embedding/        Embedding provider integration and vector helpers
-  encrypt/          Encryption helpers
-  fuse/             FUSE mount (go-fuse/v2 RawFileSystem, inode mapping, caching)
-  logger/           Structured logging helpers
-  meta/             Metadata/search-facing models and helpers
-  metrics/          Metrics recording
-  semantic/         Durable semantic task types and contracts
-  s3client/         S3-compatible object store interface (AWS + local mock)
-  server/           HTTP server (/v1/fs/{path} router)
-  tenant/           Tenant schema management and embedding mode detection
-  pathutil/         Path canonicalization and validation
-  parser/           Content-aware parsing interface (future)
-  traceid/          Trace ID helpers
-  treebuilder/      Parsed content → path namespace mapping (future)
-docs/
-  design-overview.md  Full design document
-```
+Five tables per tenant:
 
-## Metadata Schema
-
-Five core tables, all in the tenant's database:
-
-| Table | Purpose |
+| Table | Role |
 |---|---|
-| `file_nodes` | Path tree (dentry) — path, parent, name, directory flag, file_id reference |
-| `files` | File entity (inode) — storage location, size, checksum, revision, lifecycle status, extracted text, embedding state |
-| `file_tags` | Key-value tags for precise filtering |
-| `uploads` | Large-file multipart upload state and idempotency tracking |
-| `semantic_tasks` | Durable background work queue for async embedding and image text extraction |
+| `file_nodes` | Path tree (dentry) — parent, name, file_id ref |
+| `files` | File entity (inode) — storage, size, checksum, revision, embedding state |
+| `file_tags` | Key-value tags |
+| `uploads` | Multipart upload tracking |
+| `semantic_tasks` | Background work queue (embedding, image extraction) |
 
-## Roadmap
+## Mount options
 
-| Phase | Scope | Status |
-|---|---|---|
-| **P0** | Server + Drive9Backend + metadata + small-file CRUD + auth | ✅ Done |
-| **P1** | Large-file upload: 202 flow + presigned URLs + resume | Planned |
-| **P2** | CLI: full command set + progress bar + auto-resume | In Progress |
-| **P3** | Reaper + S3 Lifecycle + TTL cleanup | Planned |
-| **P4** | Tags + Query API + zero-copy cp | Planned |
-| **P5** | MCP Server | Planned |
-| **P6** | Python SDK | Planned |
-| **P7** | Server-side grep/digest | Planned |
-| **P8** | Async L0/L1 generation (LLM-powered) | Planned |
-| **P9** | Smart Parser & TreeBuilder | Planned |
-| **P10** | FUSE mount | ✅ Done |
+```
+drive9 mount [flags] <mountpoint>
+
+  --server       Server URL (default: $DRIVE9_SERVER)
+  --api-key      API key (default: $DRIVE9_API_KEY)
+  --cache-size   Read cache size in MB (default: 128)
+  --dir-ttl      Directory cache TTL (default: 5s)
+  --attr-ttl     Kernel attr cache TTL (default: 60s)
+  --entry-ttl    Kernel entry cache TTL (default: 60s)
+  --allow-other  Allow other users to access mount
+  --read-only    Mount as read-only
+  --debug        Enable FUSE debug logging
+```
 
 ## Building
 
 ```bash
-mkdir -p bin
 go build -o bin/drive9 ./cmd/drive9
 go build -o bin/drive9-server ./cmd/drive9-server
 ```
 
-## Local Validation Server
-
-For single-tenant local validation of async embedding and search correctness, use
-the dedicated local entrypoint plus the repository-owned env script:
-
-```bash
-source ./scripts/drive9-server-local-env.sh
-export DRIVE9_LOCAL_INIT_SCHEMA=true   # only for disposable local databases
-make run-server-local
-```
-
-The helper script keeps `DRIVE9_LOCAL_INIT_SCHEMA=false` by default so the local
-entrypoint does not mutate an existing database unless you opt in explicitly.
-
-Override any variables you need before `make run-server-local`, for example a
-custom local/remote TiDB DSN:
-
-```bash
-export DRIVE9_LOCAL_DSN='root@tcp(127.0.0.1:4000)/drive9_local?parseTime=true'
-export DRIVE9_LOCAL_INIT_SCHEMA=true   # only if this is a disposable database
-make run-server-local
-```
-
-The helper script sets sensible defaults for local validation, including:
-
-- `DRIVE9_LOCAL_DSN`
-- `DRIVE9_LOCAL_INIT_SCHEMA=false`
-- local mock S3 via `DRIVE9_S3_DIR`
-- local Ollama-compatible `DRIVE9_EMBED_*` defaults
-- query embedding reusing `DRIVE9_EMBED_*` unless `DRIVE9_QUERY_EMBED_*` is set explicitly
-
-## Running Tests
+## Testing
 
 ```bash
 make test
 ```
 
-`make test` is the standard test entrypoint and runs `go test ./...`.
+Uses `DRIVE9_TEST_MYSQL_DSN` if set, otherwise spins up a container via testcontainers.
 
-For MySQL-backed test suites:
+## Project layout
 
-- if `DRIVE9_TEST_MYSQL_DSN` is set, the tests reuse that MySQL instance
-- otherwise, if `podman` is available locally, `make test` automatically configures the Podman-backed testcontainers environment
-- otherwise, testcontainers uses the default Docker-compatible runtime environment
-
-For example, to reuse an existing local MySQL instance:
-
-```bash
-DRIVE9_TEST_MYSQL_DSN='drive9:drive9pass@tcp(127.0.0.1:3306)/drive9_test?parseTime=true' make test
 ```
-
-If you do not provide `DRIVE9_TEST_MYSQL_DSN`, make sure a Docker-compatible container runtime is available locally.
+cmd/drive9/          CLI (cp, cat, ls, mount, umount, ...)
+cmd/drive9-server/   Server
+pkg/
+  backend/           Drive9Backend — AGFS FileSystem impl
+  client/            Go SDK (HTTP client, streaming upload, patch)
+  datastore/         Metadata store, semantic task persistence
+  fuse/              FUSE filesystem (go-fuse/v2, streaming write, prefetch, caching)
+  server/            HTTP server (/v1/fs/{path})
+  s3client/          S3-compatible object store (AWS + local mock)
+  tenant/            Tenant schema, embedding mode detection
+  embedding/         Embedding providers, vector helpers
+  encrypt/           Encryption (AES, KMS)
+  semantic/          Durable semantic task types
+  meta/              Search-facing models
+  pathutil/          Path canonicalization
+```
 
 ## References
 
-- [db9](https://db9.ai/) — Serverless database with built-in embedding, FTS, vector search, and fs9 file storage
-- [AGFS](https://github.com/c4pt0r/agfs) — Plan 9-inspired agent filesystem (we import its core interfaces)
-- [OpenViking](https://github.com/volcengine/OpenViking) — Context database for AI agents (L0/L1/L2 design reference)
+- [db9](https://db9.ai/) — Serverless database with built-in embedding, FTS, vector search
+- [AGFS](https://github.com/c4pt0r/agfs) — Plan 9-inspired agent filesystem
+- [Plan 9](https://plan9.io/plan9/) — Everything is a file. Names are the interface.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -150,18 +150,19 @@ Five tables per tenant:
 
 ## Mount options
 
-```
+```text
 drive9 mount [flags] <mountpoint>
 
-  --server       Server URL (default: $DRIVE9_SERVER)
-  --api-key      API key (default: $DRIVE9_API_KEY)
-  --cache-size   Read cache size in MB (default: 128)
-  --dir-ttl      Directory cache TTL (default: 5s)
-  --attr-ttl     Kernel attr cache TTL (default: 60s)
-  --entry-ttl    Kernel entry cache TTL (default: 60s)
-  --allow-other  Allow other users to access mount
-  --read-only    Mount as read-only
-  --debug        Enable FUSE debug logging
+  --server           Server URL (default: $DRIVE9_SERVER)
+  --api-key          API key (default: $DRIVE9_API_KEY)
+  --cache-size       Read cache size in MB (default: 128)
+  --dir-ttl          Directory cache TTL (default: 5s)
+  --attr-ttl         Kernel attr cache TTL (default: 60s)
+  --entry-ttl        Kernel entry cache TTL (default: 60s)
+  --flush-debounce   Small-file flush debounce window (default: 2s, 0 disables)
+  --allow-other      Allow other users to access mount
+  --read-only        Mount as read-only
+  --debug            Enable FUSE debug logging
 ```
 
 ## Building

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -20,6 +20,7 @@ func MountCmd(args []string) error {
 	dirTTL := fs.Duration("dir-ttl", 5*time.Second, "directory cache TTL")
 	attrTTL := fs.Duration("attr-ttl", 1*time.Second, "kernel attr cache TTL")
 	entryTTL := fs.Duration("entry-ttl", 1*time.Second, "kernel entry cache TTL")
+	flushDebounce := fs.Duration("flush-debounce", 2*time.Second, "debounce window for small-file flush coalescing (0 disables)")
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
 	readOnly := fs.Bool("read-only", false, "mount as read-only")
 	debug := fs.Bool("debug", false, "enable FUSE debug logging")
@@ -58,16 +59,17 @@ func MountCmd(args []string) error {
 	}
 
 	opts := &drive9fuse.MountOptions{
-		Server:     *server,
-		APIKey:     *apiKey,
-		MountPoint: mountPoint,
-		CacheSize:  int64(*cacheSize) << 20,
-		DirTTL:     *dirTTL,
-		AttrTTL:    *attrTTL,
-		EntryTTL:   *entryTTL,
-		AllowOther: *allowOther,
-		ReadOnly:   *readOnly,
-		Debug:      *debug,
+		Server:        *server,
+		APIKey:        *apiKey,
+		MountPoint:    mountPoint,
+		CacheSize:     int64(*cacheSize) << 20,
+		DirTTL:        *dirTTL,
+		AttrTTL:       *attrTTL,
+		EntryTTL:      *entryTTL,
+		FlushDebounce: *flushDebounce,
+		AllowOther:    *allowOther,
+		ReadOnly:      *readOnly,
+		Debug:         *debug,
 	}
 
 	return drive9fuse.Mount(opts)

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -20,7 +20,7 @@ func MountCmd(args []string) error {
 	dirTTL := fs.Duration("dir-ttl", 5*time.Second, "directory cache TTL")
 	attrTTL := fs.Duration("attr-ttl", 1*time.Second, "kernel attr cache TTL")
 	entryTTL := fs.Duration("entry-ttl", 1*time.Second, "kernel entry cache TTL")
-	flushDebounce := fs.Duration("flush-debounce", 2*time.Second, "debounce window for small-file flush coalescing (0 disables)")
+	flushDebounce := fs.Duration("flush-debounce", -1, "debounce window for small-file flush coalescing (default 2s, 0 disables)")
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
 	readOnly := fs.Bool("read-only", false, "mount as read-only")
 	debug := fs.Bool("debug", false, "enable FUSE debug logging")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -4,13 +4,16 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Client is the dat9 HTTP client.
@@ -36,6 +39,40 @@ func New(baseURL, apiKey string) *Client {
 	}
 	transport.MaxIdleConns = 100
 	transport.MaxIdleConnsPerHost = 16
+
+	// Custom DialContext: fall back to public DNS (8.8.8.8, 1.1.1.1) when the
+	// system resolver fails. Fixes DNS on Termux and minimal containers that
+	// lack /etc/resolv.conf.
+	baseDialer := &net.Dialer{Timeout: 10 * time.Second}
+	fallbackResolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{Timeout: 5 * time.Second}
+			// Try Google DNS first, then Cloudflare.
+			conn, err := d.DialContext(ctx, "udp", "8.8.8.8:53")
+			if err != nil {
+				conn, err = d.DialContext(ctx, "udp", "1.1.1.1:53")
+			}
+			return conn, err
+		},
+	}
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		// Try system resolver first.
+		conn, err := baseDialer.DialContext(ctx, network, addr)
+		if err == nil {
+			return conn, nil
+		}
+		// System DNS failed — resolve with fallback DNS and retry.
+		host, port, splitErr := net.SplitHostPort(addr)
+		if splitErr != nil {
+			return nil, err // return original error
+		}
+		ips, resolveErr := fallbackResolver.LookupHost(ctx, host)
+		if resolveErr != nil || len(ips) == 0 {
+			return nil, err // return original dial error
+		}
+		return baseDialer.DialContext(ctx, network, net.JoinHostPort(ips[0], port))
+	}
 	return &Client{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		apiKey:  apiKey,
@@ -59,6 +96,7 @@ type FileInfo struct {
 	Name  string `json:"name"`
 	Size  int64  `json:"size"`
 	IsDir bool   `json:"isDir"`
+	Mtime int64  `json:"mtime,omitempty"` // Unix seconds, 0 means unknown
 }
 
 // StatResult represents file metadata from HEAD.
@@ -66,6 +104,7 @@ type StatResult struct {
 	Size     int64
 	IsDir    bool
 	Revision int64
+	Mtime    time.Time
 }
 
 func (c *Client) url(path string) string {
@@ -175,6 +214,11 @@ func (c *Client) Stat(path string) (*StatResult, error) {
 	}
 	if rev := resp.Header.Get("X-Dat9-Revision"); rev != "" {
 		s.Revision, _ = strconv.ParseInt(rev, 10, 64)
+	}
+	if mt := resp.Header.Get("X-Dat9-Mtime"); mt != "" {
+		if sec, err := strconv.ParseInt(mt, 10, 64); err == nil {
+			s.Mtime = time.Unix(sec, 0)
+		}
 	}
 	return s, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -62,7 +63,13 @@ func New(baseURL, apiKey string) *Client {
 		if err == nil {
 			return conn, nil
 		}
-		// System DNS failed — resolve with fallback DNS and retry.
+		// Only fall back to public DNS on actual DNS resolution errors.
+		// Non-DNS errors (connection refused, timeout, etc.) should not
+		// leak internal hostnames to public resolvers.
+		var dnsErr *net.DNSError
+		if !errors.As(err, &dnsErr) {
+			return nil, err
+		}
 		host, port, splitErr := net.SplitHostPort(addr)
 		if splitErr != nil {
 			return nil, err // return original error

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -34,6 +34,7 @@ type Dat9FS struct {
 	uid         uint32
 	gid         uint32
 	opts        *MountOptions
+	debouncer   *flushDebouncer
 
 	// server is the go-fuse server, set during Init(). Used to send
 	// kernel cache invalidation notifications (EntryNotify, InodeNotify)
@@ -60,6 +61,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		uid:           uint32(os.Getuid()),
 		gid:           uint32(os.Getgid()),
 		opts:          opts,
+		debouncer:     newFlushDebouncer(opts.FlushDebounce),
 	}
 }
 
@@ -299,7 +301,11 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 			if item.Name != name {
 				continue
 			}
-			ino := fs.inodes.Lookup(childP, item.IsDir, item.Size, time.Now())
+			mtime := time.Now()
+			if item.Mtime > 0 {
+				mtime = time.Unix(item.Mtime, 0)
+			}
+			ino := fs.inodes.Lookup(childP, item.IsDir, item.Size, mtime)
 			entry, ok := fs.inodes.GetEntry(ino)
 			if !ok {
 				return gofuse.EIO
@@ -310,7 +316,11 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		return gofuse.ENOENT
 	}
 
-	ino := fs.inodes.Lookup(childP, stat.IsDir, stat.Size, time.Now())
+	mtime := time.Now()
+	if !stat.Mtime.IsZero() {
+		mtime = stat.Mtime
+	}
+	ino := fs.inodes.Lookup(childP, stat.IsDir, stat.Size, mtime)
 	entry, ok := fs.inodes.GetEntry(ino)
 	if !ok {
 		return gofuse.EIO
@@ -343,6 +353,10 @@ func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *
 			entry.Size = stat.Size
 			entry.IsDir = stat.IsDir
 			fs.inodes.UpdateSize(input.NodeId, stat.Size)
+			if !stat.Mtime.IsZero() {
+				entry.Mtime = stat.Mtime
+				fs.inodes.UpdateMtime(input.NodeId, stat.Mtime)
+			}
 		}
 	}
 
@@ -355,6 +369,12 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 	entry, ok := fs.inodes.GetEntry(input.NodeId)
 	if !ok {
 		return gofuse.ENOENT
+	}
+
+	// Handle mtime updates
+	if mtime, ok := input.GetMTime(); ok {
+		entry.Mtime = mtime
+		fs.inodes.UpdateMtime(input.NodeId, mtime)
 	}
 
 	// Handle truncate
@@ -608,10 +628,15 @@ func (fs *Dat9FS) listDir(dirPath string) ([]DirEntry, error) {
 	// Store in dir cache
 	cached := make([]CachedFileInfo, len(items))
 	for i, item := range items {
+		var mtime time.Time
+		if item.Mtime > 0 {
+			mtime = time.Unix(item.Mtime, 0)
+		}
 		cached[i] = CachedFileInfo{
 			Name:  item.Name,
 			Size:  item.Size,
 			IsDir: item.IsDir,
+			Mtime: mtime,
 		}
 	}
 	fs.dirCache.Put(dirPath, cached)
@@ -629,7 +654,11 @@ func (fs *Dat9FS) cachedToDirEntries(dirPath string, items []CachedFileInfo) []D
 			childP = dirPath + "/" + item.Name
 		}
 
-		ino := fs.inodes.EnsureInode(childP, item.IsDir, item.Size, time.Now())
+		mtime := item.Mtime
+		if mtime.IsZero() {
+			mtime = time.Now()
+		}
+		ino := fs.inodes.EnsureInode(childP, item.IsDir, item.Size, mtime)
 
 		var mode uint32
 		if item.IsDir {
@@ -973,7 +1002,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) gofuse.St
 	fh.Lock()
 	defer fh.Unlock()
 
-	return fs.flushHandle(fh)
+	return fs.flushHandleDebounced(fh, false)
 }
 
 func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) gofuse.Status {
@@ -985,12 +1014,15 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) gofuse.St
 	fh.Lock()
 	defer fh.Unlock()
 
-	return fs.flushHandle(fh)
+	return fs.flushHandleDebounced(fh, true)
 }
 
 func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 	fh, ok := fs.fileHandles.Get(input.Fh)
 	if ok {
+		// Cancel any pending debounce for this path — Release always flushes immediately.
+		fs.debouncer.Cancel(fh.Path)
+
 		fh.Lock()
 		st := fs.flushHandle(fh)
 		streamer := fh.Streamer
@@ -1012,6 +1044,54 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 		}
 	}
 	fs.fileHandles.Delete(input.Fh)
+}
+
+// flushHandleDebounced wraps flushHandle with optional debouncing for small files.
+// When force is false and the file is small, the upload may be deferred.
+// Caller must hold fh.mu.
+func (fs *Dat9FS) flushHandleDebounced(fh *FileHandle, force bool) gofuse.Status {
+	if force || fh.Dirty == nil || !fh.Dirty.HasDirtyParts() {
+		return fs.flushHandle(fh)
+	}
+
+	size := fh.Dirty.Size()
+	if size >= smallFileThreshold || fs.debouncer.delay <= 0 {
+		return fs.flushHandle(fh)
+	}
+
+	// Small file: schedule a deferred upload.
+	// Snapshot the data so the deferred upload sees a consistent copy.
+	data := make([]byte, len(fh.Dirty.Bytes()))
+	copy(data, fh.Dirty.Bytes())
+	filePath := fh.Path
+	ino := fh.Ino
+	handle := fh // capture for goroutine
+
+	fs.debouncer.Schedule(filePath, func() {
+		if err := fs.client.Write(filePath, data); err != nil {
+			log.Printf("debounced flush failed for %s: %v", filePath, err)
+			return
+		}
+		// Clear dirty under fh.mu after successful upload so that a
+		// subsequent Release → flushHandle does not re-upload the same data.
+		handle.Lock()
+		if handle.Dirty != nil {
+			handle.Dirty.ClearDirty()
+		}
+		handle.Unlock()
+		fs.readCache.Invalidate(filePath)
+		fs.dirCache.Invalidate(parentDir(filePath))
+		fs.inodes.UpdateSize(ino, int64(len(data)))
+		fs.notifyInode(ino)
+		parentIno, _ := fs.inodes.GetInode(parentDir(filePath))
+		fs.notifyInode(parentIno)
+	})
+
+	// Do NOT ClearDirty here — the buffer stays dirty as a safety net.
+	// If Release fires before the debouncer, it cancels the timer and
+	// flushHandle will upload from the still-dirty buffer.
+	// If the debouncer fires first, its callback clears dirty state.
+	return gofuse.OK
 }
 
 // flushHandle uploads buffered data to the server. Caller must hold fh.mu.
@@ -1180,8 +1260,12 @@ func (fs *Dat9FS) flushHandle(fh *FileHandle) gofuse.Status {
 	return gofuse.OK
 }
 
-// FlushAll flushes all open file handles. Used during graceful shutdown.
+// FlushAll flushes all open file handles and drains pending debounced uploads.
+// Used during graceful shutdown.
 func (fs *Dat9FS) FlushAll() {
+	// Drain all pending debounced uploads first.
+	fs.debouncer.FlushAll()
+
 	// Snapshot handles outside the lock to avoid deadlocking with
 	// concurrent FUSE operations that need HandleTable access.
 	type entry struct {
@@ -1197,6 +1281,38 @@ func (fs *Dat9FS) FlushAll() {
 		fs.flushHandle(e.fh)
 		e.fh.Unlock()
 	}
+}
+
+// StatFs reports a generous virtual capacity so that apps (Obsidian, Finder)
+// see free space and allow writes. The actual limit is server-side.
+func (fs *Dat9FS) StatFs(cancel <-chan struct{}, header *gofuse.InHeader, out *gofuse.StatfsOut) gofuse.Status {
+	const blockSize = 4096
+	const totalBlocks = (1 << 40) / blockSize // 1 TiB
+	out.Blocks = totalBlocks
+	out.Bfree = totalBlocks - 1
+	out.Bavail = totalBlocks - 1
+	out.Bsize = blockSize
+	out.NameLen = 255
+	out.Frsize = blockSize
+	return gofuse.OK
+}
+
+// --- Xattr stubs (macOS Finder/Spotlight compatibility) ----------------------
+
+func (fs *Dat9FS) GetXAttr(cancel <-chan struct{}, header *gofuse.InHeader, attr string, dest []byte) (uint32, gofuse.Status) {
+	return 0, gofuse.ENOATTR
+}
+
+func (fs *Dat9FS) ListXAttr(cancel <-chan struct{}, header *gofuse.InHeader, dest []byte) (uint32, gofuse.Status) {
+	return 0, gofuse.OK
+}
+
+func (fs *Dat9FS) SetXAttr(cancel <-chan struct{}, input *gofuse.SetXAttrIn, attr string, data []byte) gofuse.Status {
+	return gofuse.OK
+}
+
+func (fs *Dat9FS) RemoveXAttr(cancel <-chan struct{}, header *gofuse.InHeader, attr string) gofuse.Status {
+	return gofuse.ENOATTR
 }
 
 func (fs *Dat9FS) String() string {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1065,17 +1065,18 @@ func (fs *Dat9FS) flushHandleDebounced(fh *FileHandle, force bool) gofuse.Status
 	copy(data, fh.Dirty.Bytes())
 	filePath := fh.Path
 	ino := fh.Ino
-	handle := fh // capture for goroutine
+	handle := fh          // capture for goroutine
+	snapshotSeq := fh.DirtySeq // capture current dirty sequence
 
 	fs.debouncer.Schedule(filePath, func() {
 		if err := fs.client.Write(filePath, data); err != nil {
 			log.Printf("debounced flush failed for %s: %v", filePath, err)
 			return
 		}
-		// Clear dirty under fh.mu after successful upload so that a
-		// subsequent Release → flushHandle does not re-upload the same data.
+		// Only clear dirty if no writes occurred since the snapshot was taken.
+		// If DirtySeq changed, the buffer has new data that wasn't uploaded.
 		handle.Lock()
-		if handle.Dirty != nil {
+		if handle.Dirty != nil && handle.DirtySeq == snapshotSeq {
 			handle.Dirty.ClearDirty()
 		}
 		handle.Unlock()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3,6 +3,7 @@ package fuse
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -351,5 +352,251 @@ func TestCreateFileGetsStreamUploader(t *testing.T) {
 	}
 	if fh.Streamer == nil {
 		t.Fatal("expected StreamUploader to be set for new file")
+	}
+}
+
+func TestStatFs_ReportsVirtualCapacity(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	var out gofuse.StatfsOut
+	st := fs.StatFs(nil, &gofuse.InHeader{NodeId: 1}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("StatFs status = %v, want OK", st)
+	}
+	if out.Bsize != 4096 {
+		t.Fatalf("Bsize = %d, want 4096", out.Bsize)
+	}
+	if out.Frsize != 4096 {
+		t.Fatalf("Frsize = %d, want 4096", out.Frsize)
+	}
+	if out.NameLen != 255 {
+		t.Fatalf("NameLen = %d, want 255", out.NameLen)
+	}
+	// 1 TiB in 4K blocks
+	const expectedBlocks = (1 << 40) / 4096
+	if out.Blocks != expectedBlocks {
+		t.Fatalf("Blocks = %d, want %d", out.Blocks, expectedBlocks)
+	}
+	if out.Bavail != expectedBlocks-1 {
+		t.Fatalf("Bavail = %d, want %d", out.Bavail, expectedBlocks-1)
+	}
+}
+
+func TestXAttr_GetReturnsENOATTR(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	_, st := fs.GetXAttr(nil, &gofuse.InHeader{NodeId: 1}, "user.test", nil)
+	if st != gofuse.ENOATTR {
+		t.Fatalf("GetXAttr status = %v, want ENOATTR", st)
+	}
+}
+
+func TestXAttr_ListReturnsEmpty(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	n, st := fs.ListXAttr(nil, &gofuse.InHeader{NodeId: 1}, nil)
+	if st != gofuse.OK {
+		t.Fatalf("ListXAttr status = %v, want OK", st)
+	}
+	if n != 0 {
+		t.Fatalf("ListXAttr size = %d, want 0", n)
+	}
+}
+
+func TestXAttr_SetDiscardsSilently(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	st := fs.SetXAttr(nil, &gofuse.SetXAttrIn{}, "user.test", []byte("val"))
+	if st != gofuse.OK {
+		t.Fatalf("SetXAttr status = %v, want OK", st)
+	}
+}
+
+func TestXAttr_RemoveReturnsENOATTR(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	st := fs.RemoveXAttr(nil, &gofuse.InHeader{NodeId: 1}, "user.test")
+	if st != gofuse.ENOATTR {
+		t.Fatalf("RemoveXAttr status = %v, want ENOATTR", st)
+	}
+}
+
+func TestSetAttr_MtimeUpdate(t *testing.T) {
+	fs, ino, cleanup := newTestDat9FS(t, 42, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(make([]byte, 42))
+	})
+	defer cleanup()
+
+	mtime := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	var out gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_MTIME,
+			Mtime:    uint64(mtime.Unix()),
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+
+	// Verify the inode was updated
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if !entry.Mtime.Equal(mtime) {
+		t.Fatalf("Mtime = %v, want %v", entry.Mtime, mtime)
+	}
+
+	// Verify the attr output has the correct mtime
+	if out.Mtime != uint64(mtime.Unix()) {
+		t.Fatalf("out.Mtime = %d, want %d", out.Mtime, mtime.Unix())
+	}
+}
+
+func TestSetAttr_MtimeNow(t *testing.T) {
+	fs, ino, cleanup := newTestDat9FS(t, 42, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(make([]byte, 42))
+	})
+	defer cleanup()
+
+	before := time.Now()
+
+	var out gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_MTIME | gofuse.FATTR_MTIME_NOW,
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+
+	after := time.Now()
+
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if entry.Mtime.Before(before) || entry.Mtime.After(after) {
+		t.Fatalf("Mtime = %v, expected between %v and %v", entry.Mtime, before, after)
+	}
+}
+
+func TestLookup_UsesMtimeFromStat(t *testing.T) {
+	mtime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "100")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.Header().Set("X-Dat9-Mtime", strconv.FormatInt(mtime.Unix(), 10))
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "file.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if out.Mtime != uint64(mtime.Unix()) {
+		t.Fatalf("Lookup mtime = %d, want %d", out.Mtime, mtime.Unix())
+	}
+}
+
+// TestDebounce_ReleaseAfterFlush_NoDataLoss verifies that data is not lost
+// when Release fires after a debounced Flush. This is a regression test for
+// the scenario: Flush debounces → ClearDirty → Release cancels timer →
+// flushHandle sees no dirty data → data never uploaded.
+func TestDebounce_ReleaseAfterFlush_NoDataLoss(t *testing.T) {
+	var uploaded []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "0")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			uploaded = body
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 10 * time.Second} // long debounce — won't fire naturally
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	// Create a file
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "test.md", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+
+	// Write data
+	_, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}, []byte("important data"))
+	if st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+
+	// Flush (will debounce since file < smallFileThreshold and debounce > 0)
+	st = fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+	if st != gofuse.OK {
+		t.Fatalf("Flush status = %v, want OK", st)
+	}
+
+	// Release (should cancel debounce and flush immediately)
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+
+	// Verify data was uploaded
+	if uploaded == nil {
+		t.Fatal("data was never uploaded — data loss!")
+	}
+	if string(uploaded) != "important data" {
+		t.Fatalf("uploaded = %q, want %q", uploaded, "important data")
 	}
 }

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -531,7 +531,7 @@ func TestLookup_UsesMtimeFromStat(t *testing.T) {
 // the scenario: Flush debounces → ClearDirty → Release cancels timer →
 // flushHandle sees no dirty data → data never uploaded.
 func TestDebounce_ReleaseAfterFlush_NoDataLoss(t *testing.T) {
-	var uploaded []byte
+	uploadedCh := make(chan []byte, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodHead:
@@ -547,7 +547,7 @@ func TestDebounce_ReleaseAfterFlush_NoDataLoss(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case http.MethodPut:
 			body, _ := io.ReadAll(r.Body)
-			uploaded = body
+			uploadedCh <- append([]byte(nil), body...)
 			w.WriteHeader(http.StatusOK)
 		default:
 			w.WriteHeader(http.StatusOK)
@@ -592,11 +592,13 @@ func TestDebounce_ReleaseAfterFlush_NoDataLoss(t *testing.T) {
 		Fh:       createOut.Fh,
 	})
 
-	// Verify data was uploaded
-	if uploaded == nil {
+	// Verify data was uploaded (use channel to avoid race)
+	select {
+	case uploaded := <-uploadedCh:
+		if string(uploaded) != "important data" {
+			t.Fatalf("uploaded = %q, want %q", uploaded, "important data")
+		}
+	case <-time.After(time.Second):
 		t.Fatal("data was never uploaded — data loss!")
-	}
-	if string(uploaded) != "important data" {
-		t.Fatalf("uploaded = %q, want %q", uploaded, "important data")
 	}
 }

--- a/pkg/fuse/debounce.go
+++ b/pkg/fuse/debounce.go
@@ -1,0 +1,93 @@
+package fuse
+
+import (
+	"sync"
+	"time"
+)
+
+const defaultFlushDebounce = 2 * time.Second
+
+// flushDebouncer coalesces rapid flush calls for the same path. When Schedule
+// is called for a path that already has a pending timer, the previous timer is
+// reset and the new uploadFn replaces the old one — only the latest snapshot
+// will be uploaded.
+type flushDebouncer struct {
+	mu      sync.Mutex
+	delay   time.Duration
+	pending map[string]*pendingFlush
+}
+
+type pendingFlush struct {
+	timer    *time.Timer
+	uploadFn func()
+}
+
+func newFlushDebouncer(delay time.Duration) *flushDebouncer {
+	if delay < 0 {
+		delay = 0
+	}
+	return &flushDebouncer{
+		delay:   delay,
+		pending: make(map[string]*pendingFlush),
+	}
+}
+
+// Schedule registers (or replaces) a deferred upload for path. If a previous
+// timer exists for path, it is stopped and replaced. The uploadFn is called
+// after delay elapses without another Schedule call for the same path.
+func (d *flushDebouncer) Schedule(path string, uploadFn func()) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if pf, ok := d.pending[path]; ok {
+		pf.timer.Stop()
+		pf.uploadFn = uploadFn
+		pf.timer.Reset(d.delay)
+		return
+	}
+
+	pf := &pendingFlush{uploadFn: uploadFn}
+	pf.timer = time.AfterFunc(d.delay, func() {
+		d.mu.Lock()
+		// Re-read the pending entry to get the latest uploadFn.
+		current, ok := d.pending[path]
+		if ok {
+			delete(d.pending, path)
+		}
+		d.mu.Unlock()
+
+		if ok && current.uploadFn != nil {
+			current.uploadFn()
+		}
+	})
+	d.pending[path] = pf
+}
+
+// Cancel stops and removes the pending debounce for path without executing
+// the upload. Used when Release needs to do an immediate flush.
+func (d *flushDebouncer) Cancel(path string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if pf, ok := d.pending[path]; ok {
+		pf.timer.Stop()
+		delete(d.pending, path)
+	}
+}
+
+// FlushAll executes all pending uploads immediately and clears the pending map.
+// Used during graceful shutdown.
+func (d *flushDebouncer) FlushAll() {
+	d.mu.Lock()
+	// Snapshot and clear.
+	pending := d.pending
+	d.pending = make(map[string]*pendingFlush)
+	d.mu.Unlock()
+
+	for _, pf := range pending {
+		pf.timer.Stop()
+		if pf.uploadFn != nil {
+			pf.uploadFn()
+		}
+	}
+}

--- a/pkg/fuse/dir.go
+++ b/pkg/fuse/dir.go
@@ -14,6 +14,7 @@ type CachedFileInfo struct {
 	Name  string
 	Size  int64
 	IsDir bool
+	Mtime time.Time
 }
 
 type dirCacheEntry struct {

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -1178,3 +1178,102 @@ func TestHttpToFuseStatus(t *testing.T) {
 	}
 	_ = tests // compile check — errno values vary by platform
 }
+
+// ---------------------------------------------------------------------------
+// FlushDebouncer tests
+// ---------------------------------------------------------------------------
+
+func TestFlushDebouncer_ScheduleAndFire(t *testing.T) {
+	d := newFlushDebouncer(50 * time.Millisecond)
+	done := make(chan string, 1)
+	d.Schedule("/a", func() { done <- "/a" })
+
+	select {
+	case p := <-done:
+		if p != "/a" {
+			t.Fatalf("got %q, want /a", p)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("debounce did not fire within 1s")
+	}
+}
+
+func TestFlushDebouncer_CoalescesRapidSchedules(t *testing.T) {
+	d := newFlushDebouncer(100 * time.Millisecond)
+	callCount := 0
+	var lastVal int
+	for i := 0; i < 5; i++ {
+		v := i
+		d.Schedule("/a", func() {
+			callCount++
+			lastVal = v
+		})
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Wait for the debounce to fire
+	time.Sleep(200 * time.Millisecond)
+
+	if callCount != 1 {
+		t.Fatalf("callCount = %d, want 1 (coalesced)", callCount)
+	}
+	if lastVal != 4 {
+		t.Fatalf("lastVal = %d, want 4 (latest schedule)", lastVal)
+	}
+}
+
+func TestFlushDebouncer_Cancel(t *testing.T) {
+	d := newFlushDebouncer(100 * time.Millisecond)
+	called := false
+	d.Schedule("/a", func() { called = true })
+	d.Cancel("/a")
+
+	time.Sleep(200 * time.Millisecond)
+	if called {
+		t.Fatal("upload should not have been called after Cancel")
+	}
+}
+
+func TestFlushDebouncer_FlushAll(t *testing.T) {
+	d := newFlushDebouncer(10 * time.Second) // long delay — won't fire naturally
+	results := make(map[string]bool)
+	d.Schedule("/a", func() { results["/a"] = true })
+	d.Schedule("/b", func() { results["/b"] = true })
+
+	d.FlushAll()
+
+	if !results["/a"] || !results["/b"] {
+		t.Fatalf("FlushAll should have called both uploads: %v", results)
+	}
+}
+
+func TestFlushDebouncer_IndependentPaths(t *testing.T) {
+	d := newFlushDebouncer(50 * time.Millisecond)
+	done := make(chan string, 2)
+	d.Schedule("/a", func() { done <- "/a" })
+	d.Schedule("/b", func() { done <- "/b" })
+
+	got := make(map[string]bool)
+	for i := 0; i < 2; i++ {
+		select {
+		case p := <-done:
+			got[p] = true
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for debounce")
+		}
+	}
+	if !got["/a"] || !got["/b"] {
+		t.Fatalf("expected both paths, got %v", got)
+	}
+}
+
+func TestInodeToPath_UpdateMtime(t *testing.T) {
+	m := NewInodeToPath()
+	ino := m.Lookup("/f", false, 10, time.Now())
+	newTime := time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC)
+	m.UpdateMtime(ino, newTime)
+	entry, _ := m.GetEntry(ino)
+	if !entry.Mtime.Equal(newTime) {
+		t.Fatalf("UpdateMtime: got %v, want %v", entry.Mtime, newTime)
+	}
+}

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2,6 +2,7 @@ package fuse
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1200,36 +1201,45 @@ func TestFlushDebouncer_ScheduleAndFire(t *testing.T) {
 
 func TestFlushDebouncer_CoalescesRapidSchedules(t *testing.T) {
 	d := newFlushDebouncer(100 * time.Millisecond)
-	callCount := 0
-	var lastVal int
+	var callCount atomic.Int32
+	var lastVal atomic.Int32
+	done := make(chan struct{}, 1)
 	for i := 0; i < 5; i++ {
-		v := i
+		v := int32(i)
 		d.Schedule("/a", func() {
-			callCount++
-			lastVal = v
+			callCount.Add(1)
+			lastVal.Store(v)
+			select {
+			case done <- struct{}{}:
+			default:
+			}
 		})
 		time.Sleep(20 * time.Millisecond)
 	}
 
 	// Wait for the debounce to fire
-	time.Sleep(200 * time.Millisecond)
-
-	if callCount != 1 {
-		t.Fatalf("callCount = %d, want 1 (coalesced)", callCount)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("debounce did not fire within 1s")
 	}
-	if lastVal != 4 {
-		t.Fatalf("lastVal = %d, want 4 (latest schedule)", lastVal)
+
+	if c := callCount.Load(); c != 1 {
+		t.Fatalf("callCount = %d, want 1 (coalesced)", c)
+	}
+	if v := lastVal.Load(); v != 4 {
+		t.Fatalf("lastVal = %d, want 4 (latest schedule)", v)
 	}
 }
 
 func TestFlushDebouncer_Cancel(t *testing.T) {
 	d := newFlushDebouncer(100 * time.Millisecond)
-	called := false
-	d.Schedule("/a", func() { called = true })
+	var called atomic.Bool
+	d.Schedule("/a", func() { called.Store(true) })
 	d.Cancel("/a")
 
 	time.Sleep(200 * time.Millisecond)
-	if called {
+	if called.Load() {
 		t.Fatal("upload should not have been called after Cancel")
 	}
 }

--- a/pkg/fuse/inode.go
+++ b/pkg/fuse/inode.go
@@ -189,6 +189,16 @@ func (m *InodeToPath) UpdateSize(ino uint64, size int64) {
 	}
 }
 
+// UpdateMtime updates the mtime of the entry identified by the given inode.
+func (m *InodeToPath) UpdateMtime(ino uint64, mtime time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if entry, ok := m.byInode[ino]; ok {
+		entry.Mtime = mtime
+	}
+}
+
 // Rename updates the path mapping when a file or directory is moved from
 // oldPath to newPath. If the entry is a directory, all descendant entries
 // whose paths have the prefix oldPath+"/" are also updated.

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -20,7 +20,7 @@ type MountOptions struct {
 	DirTTL        time.Duration // DirCache TTL (default 5s)
 	AttrTTL       time.Duration // kernel attr cache TTL (default 1s)
 	EntryTTL      time.Duration // kernel entry cache TTL (default 1s)
-	FlushDebounce time.Duration // debounce window for small-file flush coalescing (default 2s, 0 disables)
+	FlushDebounce time.Duration // debounce window for small-file flush coalescing (default 2s, 0 disables); set to -1 to use default
 	AllowOther    bool          // allow other users to access mount
 	ReadOnly      bool          // mount as read-only
 	Debug         bool          // enable FUSE debug logging
@@ -39,7 +39,8 @@ func (o *MountOptions) setDefaults() {
 	if o.EntryTTL <= 0 {
 		o.EntryTTL = 60 * time.Second
 	}
-	if o.FlushDebounce <= 0 {
+	// FlushDebounce: 0 means disabled, negative means unset (use default).
+	if o.FlushDebounce < 0 {
 		o.FlushDebounce = defaultFlushDebounce
 	}
 }

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -13,16 +13,17 @@ import (
 
 // MountOptions configures the FUSE mount.
 type MountOptions struct {
-	Server     string        // dat9 server URL
-	APIKey     string        // dat9 API key
-	MountPoint string        // local mount point
-	CacheSize  int64         // ReadCache max size in bytes (default 128MB)
-	DirTTL     time.Duration // DirCache TTL (default 5s)
-	AttrTTL    time.Duration // kernel attr cache TTL (default 1s)
-	EntryTTL   time.Duration // kernel entry cache TTL (default 1s)
-	AllowOther bool          // allow other users to access mount
-	ReadOnly   bool          // mount as read-only
-	Debug      bool          // enable FUSE debug logging
+	Server        string        // dat9 server URL
+	APIKey        string        // dat9 API key
+	MountPoint    string        // local mount point
+	CacheSize     int64         // ReadCache max size in bytes (default 128MB)
+	DirTTL        time.Duration // DirCache TTL (default 5s)
+	AttrTTL       time.Duration // kernel attr cache TTL (default 1s)
+	EntryTTL      time.Duration // kernel entry cache TTL (default 1s)
+	FlushDebounce time.Duration // debounce window for small-file flush coalescing (default 2s, 0 disables)
+	AllowOther    bool          // allow other users to access mount
+	ReadOnly      bool          // mount as read-only
+	Debug         bool          // enable FUSE debug logging
 }
 
 func (o *MountOptions) setDefaults() {
@@ -37,6 +38,9 @@ func (o *MountOptions) setDefaults() {
 	}
 	if o.EntryTTL <= 0 {
 		o.EntryTTL = 60 * time.Second
+	}
+	if o.FlushDebounce <= 0 {
+		o.FlushDebounce = defaultFlushDebounce
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -431,10 +431,15 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 		Name  string `json:"name"`
 		Size  int64  `json:"size"`
 		IsDir bool   `json:"isDir"`
+		Mtime int64  `json:"mtime,omitempty"`
 	}
 	out := make([]entry, 0, len(entries))
 	for _, e := range entries {
-		out = append(out, entry{Name: e.Name, Size: e.Size, IsDir: e.IsDir})
+		var mtime int64
+		if !e.ModTime.IsZero() {
+			mtime = e.ModTime.Unix()
+		}
+		out = append(out, entry{Name: e.Name, Size: e.Size, IsDir: e.IsDir, Mtime: mtime})
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"entries": out})
@@ -670,6 +675,13 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 	w.Header().Set("X-Dat9-IsDir", fmt.Sprintf("%v", nf.Node.IsDirectory))
 	if nf.File != nil {
 		w.Header().Set("X-Dat9-Revision", strconv.FormatInt(nf.File.Revision, 10))
+		if nf.File.ConfirmedAt != nil {
+			w.Header().Set("X-Dat9-Mtime", strconv.FormatInt(nf.File.ConfirmedAt.Unix(), 10))
+		} else {
+			w.Header().Set("X-Dat9-Mtime", strconv.FormatInt(nf.File.CreatedAt.Unix(), 10))
+		}
+	} else {
+		w.Header().Set("X-Dat9-Mtime", strconv.FormatInt(nf.Node.CreatedAt.Unix(), 10))
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "stat_ok", "path", path, "is_dir", nf.Node.IsDirectory)...)
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

- **StatFs**: Report 1 TiB virtual capacity so Obsidian/Finder see free space and allow writes
- **Xattr stubs**: GetXAttr/ListXAttr/SetXAttr/RemoveXAttr for macOS Finder/Spotlight compatibility
- **Mtime propagation**: Server returns `X-Dat9-Mtime` header and `mtime` JSON field in directory listings; client parses and FUSE layer propagates through Lookup, GetAttr, listDir, cachedToDirEntries
- **SetAttr mtime**: Handle `FATTR_MTIME` and `FATTR_MTIME_NOW` locally in inode entries
- **Write debounce**: Per-path coalescing for small-file flush with configurable `--flush-debounce` flag (default 2s); Flush debounces, Fsync/Release force immediate upload
- **Data loss fix**: Fixed critical bug where `ClearDirty()` in the debounce path caused Release to find no dirty data after cancelling the timer — moved ClearDirty into the debouncer callback under lock

## Test plan

- [x] `go build ./pkg/fuse/... ./pkg/client/... ./cmd/drive9/...` compiles
- [x] All 57 tests pass (`go test ./pkg/fuse/...`)
- [x] New tests: StatFs, xattr (4 stubs), SetAttr mtime/mtime_now, Lookup mtime, debouncer (5 tests), UpdateMtime, regression test for debounce→Release data loss
- [ ] Manual: `drive9 mount /tmp/d9` then open Obsidian vault, create/edit notes
- [ ] Manual: `df /tmp/d9` shows 1 TiB virtual capacity
- [ ] Manual: `stat` a file shows correct mtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable flush debouncing for small-file uploads (new delay flag/default)
  * File modification time (mtime) propagated and persisted across filesystem operations
  * macOS extended attribute (xattr) stubs and virtual filesystem stats (StatFs)

* **Bug Fixes**
  * DNS resolution fallback to improve connection reliability

* **Documentation**
  * README rewritten and condensed for a shorter overview

* **Tests**
  * Added tests for debouncing, mtime behavior, xattr contracts, and StatFs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->