### PR TITLE
feat: SSE change notification stream (Issue #150)

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -109,6 +109,7 @@ func New(baseURL, apiKey string) *Client {
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				if len(via) > 0 && req.URL.Host != via[0].URL.Host {
 					req.Header.Del("Authorization")
+					req.Header.Del("X-Dat9-Actor")
 				}
 				if len(via) >= 10 {
 					return fmt.Errorf("too many redirects")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,6 +21,7 @@ import (
 type Client struct {
 	baseURL            string
 	apiKey             string
+	actor              string // X-Dat9-Actor header value (per-mount ID)
 	httpClient         *http.Client
 	smallFileThreshold int64 // 0 means use DefaultSmallFileThreshold
 }
@@ -150,9 +151,28 @@ func (c *Client) RawPost(endpoint string, body io.Reader) (*http.Response, error
 	return c.do(req)
 }
 
+// SetActor sets the X-Dat9-Actor header value for all subsequent requests.
+// Used by FUSE mounts to identify the per-mount actor for SSE self-filtering.
+func (c *Client) SetActor(actor string) {
+	c.actor = actor
+}
+
+// BaseURL returns the server base URL.
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
+// APIKey returns the API key.
+func (c *Client) APIKey() string {
+	return c.apiKey
+}
+
 func (c *Client) do(req *http.Request) (*http.Response, error) {
 	if c.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	if c.actor != "" {
+		req.Header.Set("X-Dat9-Actor", c.actor)
 	}
 	return c.httpClient.Do(req)
 }

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -1,0 +1,148 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ChangeEvent represents a server-sent filesystem change event.
+type ChangeEvent struct {
+	Seq   uint64 `json:"seq"`
+	Path  string `json:"path"`
+	Op    string `json:"op"`
+	Actor string `json:"actor,omitempty"`
+	Ts    int64  `json:"ts"`
+}
+
+// ResetEvent is delivered when the server cannot replay events and the client
+// must invalidate all caches.
+type ResetEvent struct {
+	Seq    uint64 `json:"seq"`
+	Reason string `json:"reason"`
+}
+
+// EventHandler receives SSE events. Exactly one of the pointer arguments is
+// non-nil per call.
+type EventHandler func(change *ChangeEvent, reset *ResetEvent)
+
+const (
+	sseInitialBackoff = 1 * time.Second
+	sseMaxBackoff     = 30 * time.Second
+)
+
+// WatchEvents connects to the SSE endpoint and delivers events to handler.
+// It automatically reconnects with exponential backoff on disconnection.
+// The caller should cancel ctx to stop watching.
+// actor is the per-mount identifier used for self-event filtering.
+func (c *Client) WatchEvents(ctx context.Context, actor string, handler EventHandler) {
+	var lastSeq uint64
+	backoff := sseInitialBackoff
+
+	for {
+		err := c.streamEvents(ctx, lastSeq, actor, func(change *ChangeEvent, reset *ResetEvent) {
+			if change != nil && change.Seq > lastSeq {
+				lastSeq = change.Seq
+			}
+			if reset != nil && reset.Seq > lastSeq {
+				lastSeq = reset.Seq
+			}
+			handler(change, reset)
+		})
+
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		if err != nil {
+			time.Sleep(backoff)
+			backoff *= 2
+			if backoff > sseMaxBackoff {
+				backoff = sseMaxBackoff
+			}
+		} else {
+			backoff = sseInitialBackoff
+		}
+	}
+}
+
+func (c *Client) streamEvents(ctx context.Context, since uint64, actor string, handler EventHandler) error {
+	url := fmt.Sprintf("%s/v1/events?since=%d", c.baseURL, since)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create SSE request: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	if actor != "" {
+		req.Header.Set("X-Dat9-Actor", actor)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("SSE connect: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("SSE status %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	var eventType string
+	var dataLine string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if line == "" {
+			// End of event.
+			if dataLine != "" {
+				parseAndDispatch(eventType, dataLine, handler)
+			}
+			eventType = ""
+			dataLine = ""
+			continue
+		}
+
+		if strings.HasPrefix(line, "event: ") {
+			eventType = strings.TrimPrefix(line, "event: ")
+		} else if strings.HasPrefix(line, "data: ") {
+			dataLine = strings.TrimPrefix(line, "data: ")
+		}
+	}
+	return scanner.Err()
+}
+
+func parseAndDispatch(eventType, data string, handler EventHandler) {
+	switch eventType {
+	case "file_changed":
+		var ev ChangeEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			return
+		}
+		handler(&ev, nil)
+	case "reset":
+		var ev ResetEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			return
+		}
+		handler(nil, &ev)
+	case "heartbeat":
+		// Heartbeats carry seq for liveness but don't need dispatching.
+		var ev ResetEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			return
+		}
+		// Update lastSeq via reset path (same struct shape).
+		handler(nil, &ev)
+	}
+}

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -90,7 +90,7 @@ func (c *Client) streamEvents(ctx context.Context, since uint64, actor string, h
 	if err != nil {
 		return fmt.Errorf("SSE connect: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("SSE status %d", resp.StatusCode)

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -60,8 +60,13 @@ func (c *Client) WatchEvents(ctx context.Context, actor string, handler EventHan
 		default:
 		}
 
+		// Always backoff on disconnect (err or clean EOF).
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return
+		}
 		if err != nil {
-			time.Sleep(backoff)
 			backoff *= 2
 			if backoff > sseMaxBackoff {
 				backoff = sseMaxBackoff
@@ -137,12 +142,6 @@ func parseAndDispatch(eventType, data string, handler EventHandler) {
 		}
 		handler(nil, &ev)
 	case "heartbeat":
-		// Heartbeats carry seq for liveness but don't need dispatching.
-		var ev ResetEvent
-		if err := json.Unmarshal([]byte(data), &ev); err != nil {
-			return
-		}
-		// Update lastSeq via reset path (same struct shape).
-		handler(nil, &ev)
+		// Heartbeats are connection-liveness signals only; do not dispatch.
 	}
 }

--- a/pkg/fuse/inode.go
+++ b/pkg/fuse/inode.go
@@ -252,15 +252,18 @@ func (m *InodeToPath) Rename(oldPath, newPath string) {
 	}
 }
 
-// ForEach calls fn for each entry in the map while holding a read lock.
-// fn receives copies of entries to avoid data races.
-func (m *InodeToPath) ForEach(fn func(ino uint64, entry InodeEntry)) {
+// Snapshot returns a copy of all entries. The caller can iterate outside
+// the lock, avoiding holding the read-lock during expensive callbacks
+// (e.g. kernel inode/entry notifications).
+func (m *InodeToPath) Snapshot() []InodeEntry {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	for ino, e := range m.byInode {
-		fn(ino, *e)
+	entries := make([]InodeEntry, 0, len(m.byInode))
+	for _, e := range m.byInode {
+		entries = append(entries, *e)
 	}
+	return entries
 }
 
 // Remove deletes the entry for the given path from both maps.

--- a/pkg/fuse/inode.go
+++ b/pkg/fuse/inode.go
@@ -252,6 +252,17 @@ func (m *InodeToPath) Rename(oldPath, newPath string) {
 	}
 }
 
+// ForEach calls fn for each entry in the map while holding a read lock.
+// fn receives copies of entries to avoid data races.
+func (m *InodeToPath) ForEach(fn func(ino uint64, entry InodeEntry)) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for ino, e := range m.byInode {
+		fn(ino, *e)
+	}
+}
+
 // Remove deletes the entry for the given path from both maps.
 func (m *InodeToPath) Remove(path string) {
 	m.mu.Lock()

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -2,6 +2,8 @@ package fuse
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -73,8 +75,12 @@ func Mount(opts *MountOptions) error {
 		return fmt.Errorf("create mount point: %w", err)
 	}
 
+	// Generate per-mount actor ID for SSE self-filtering.
+	actorID := generateMountID()
+
 	// Create client and verify connectivity
 	c := client.New(opts.Server, opts.APIKey)
+	c.SetActor(actorID)
 	if _, err := c.List("/"); err != nil {
 		return fmt.Errorf("cannot reach dat9 server: %w", err)
 	}
@@ -204,6 +210,9 @@ func Mount(opts *MountOptions) error {
 		return fmt.Errorf("fuse mount: %w", err)
 	}
 
+	// Start SSE watcher for remote change notifications.
+	sseWatcher := StartSSEWatcher(dat9fs, opts.Server, opts.APIKey, actorID)
+
 	// Start serving in a background goroutine so WaitMount can proceed.
 	// On macOS, Serve() must be running before WaitMount() returns because
 	// mount_macfuse waits for STATFS (handled in the serve loop) before
@@ -236,6 +245,7 @@ func Mount(opts *MountOptions) error {
 			os.Exit(1)
 		}()
 
+		sseWatcher.Stop()
 		dat9fs.FlushAll()
 
 		// Retry unmount up to 5 times — EBUSY is transient (Spotlight, Finder).
@@ -256,8 +266,9 @@ func Mount(opts *MountOptions) error {
 		forceUnmount(opts.MountPoint)
 	}()
 
-	fmt.Fprintf(os.Stderr, "dat9: mounted on %s (server: %s)\n", opts.MountPoint, opts.Server)
+	fmt.Fprintf(os.Stderr, "dat9: mounted on %s (server: %s, actor: %s)\n", opts.MountPoint, opts.Server, actorID)
 	server.Wait()
+	sseWatcher.Stop()
 	return nil
 }
 
@@ -279,4 +290,14 @@ func forceUnmount(mountpoint string) {
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "dat9: force unmount failed: %v\n", err)
 	}
+}
+
+// generateMountID creates a random 16-byte hex ID for this mount instance.
+func generateMountID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback to timestamp if crypto/rand fails (shouldn't happen).
+		return fmt.Sprintf("mount-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
 }

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -211,7 +211,7 @@ func Mount(opts *MountOptions) error {
 	}
 
 	// Start SSE watcher for remote change notifications.
-	sseWatcher := StartSSEWatcher(dat9fs, opts.Server, opts.APIKey, actorID)
+	sseWatcher := StartSSEWatcher(dat9fs, c, actorID)
 
 	// Start serving in a background goroutine so WaitMount can proceed.
 	// On macOS, Serve() must be running before WaitMount() returns because

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -163,6 +163,16 @@ func (rc *ReadCache) InvalidatePrefix(prefix string) {
 	}
 }
 
+// InvalidateAll removes all entries from the cache.
+func (rc *ReadCache) InvalidateAll() {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	rc.items = make(map[string]*cacheEntry)
+	rc.order.Init()
+	rc.size = 0
+}
+
 // evict removes an entry from the items map, the LRU list, and decrements
 // the total cached size. The caller must hold rc.mu.
 func (rc *ReadCache) evict(entry *cacheEntry) {

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -1,73 +1,37 @@
 package fuse
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
-	"log"
-	"net/http"
+	"os"
 	"path"
-	"strings"
-	"time"
-)
 
-// sseEvent represents a parsed SSE event.
-type sseEvent struct {
-	Type string // "file_changed", "reset", "heartbeat"
-	Data json.RawMessage
-}
-
-// changeEvent mirrors the server-side ChangeEvent.
-type changeEvent struct {
-	Seq   uint64 `json:"seq"`
-	Path  string `json:"path"`
-	Op    string `json:"op"`
-	Actor string `json:"actor"`
-	Ts    int64  `json:"ts"`
-}
-
-// resetEvent represents a server-sent reset notification.
-type resetEvent struct {
-	Seq    uint64 `json:"seq"`
-	Reason string `json:"reason"`
-}
-
-// heartbeatEvent represents a server-sent heartbeat.
-type heartbeatEvent struct {
-	Seq uint64 `json:"seq"`
-}
-
-const (
-	sseReconnectMin = 1 * time.Second
-	sseReconnectMax = 30 * time.Second
+	"github.com/mem9-ai/dat9/pkg/client"
 )
 
 // SSEWatcher connects to the dat9 server SSE endpoint and invalidates
 // local FUSE caches when remote changes are detected.
 type SSEWatcher struct {
-	fs       *Dat9FS
-	baseURL  string
-	apiKey   string
-	actor    string // our own actor ID for self-filtering
-	lastSeq  uint64
-	cancel   context.CancelFunc
-	doneCh   chan struct{}
+	fs     *Dat9FS
+	actor  string // our own actor ID for self-filtering
+	cancel context.CancelFunc
+	doneCh chan struct{}
 }
 
 // StartSSEWatcher starts a background goroutine that connects to the
 // server's /v1/events SSE endpoint and invalidates local caches.
-func StartSSEWatcher(fs *Dat9FS, baseURL, apiKey, actor string) *SSEWatcher {
+func StartSSEWatcher(fs *Dat9FS, c *client.Client, actor string) *SSEWatcher {
 	ctx, cancel := context.WithCancel(context.Background())
 	w := &SSEWatcher{
-		fs:      fs,
-		baseURL: strings.TrimRight(baseURL, "/"),
-		apiKey:  apiKey,
-		actor:   actor,
-		cancel:  cancel,
-		doneCh:  make(chan struct{}),
+		fs:     fs,
+		actor:  actor,
+		cancel: cancel,
+		doneCh: make(chan struct{}),
 	}
-	go w.run(ctx)
+	go func() {
+		defer close(w.doneCh)
+		c.WatchEvents(ctx, actor, w.handleEvent)
+	}()
 	return w
 }
 
@@ -77,140 +41,28 @@ func (w *SSEWatcher) Stop() {
 	<-w.doneCh
 }
 
-func (w *SSEWatcher) run(ctx context.Context) {
-	defer close(w.doneCh)
-
-	backoff := sseReconnectMin
-	for {
-		err := w.connect(ctx)
-		if ctx.Err() != nil {
-			return
-		}
-		if err != nil {
-			log.Printf("dat9: SSE connection error: %v (reconnecting in %v)", err, backoff)
-		}
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(backoff):
-		}
-
-		// Exponential backoff capped at sseReconnectMax.
-		backoff = backoff * 2
-		if backoff > sseReconnectMax {
-			backoff = sseReconnectMax
-		}
-	}
-}
-
-func (w *SSEWatcher) connect(ctx context.Context) error {
-	url := fmt.Sprintf("%s/v1/events?since=%d", w.baseURL, w.lastSeq)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-	if w.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+w.apiKey)
-	}
-	req.Header.Set("Accept", "text/event-stream")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("connect: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
-	}
-
-	// Reset backoff on successful connection.
-	scanner := bufio.NewScanner(resp.Body)
-	// SSE max line is typically small, but allow generous buffer.
-	scanner.Buffer(make([]byte, 0, 64*1024), 64*1024)
-
-	var eventType string
-	var dataLines []string
-
-	for scanner.Scan() {
-		if ctx.Err() != nil {
-			return nil
-		}
-		line := scanner.Text()
-
-		if line == "" {
-			// Empty line = end of event.
-			if eventType != "" && len(dataLines) > 0 {
-				data := strings.Join(dataLines, "\n")
-				w.handleEvent(sseEvent{
-					Type: eventType,
-					Data: json.RawMessage(data),
-				})
-			}
-			eventType = ""
-			dataLines = nil
-			continue
-		}
-
-		if strings.HasPrefix(line, "event: ") {
-			eventType = strings.TrimPrefix(line, "event: ")
-		} else if strings.HasPrefix(line, "data: ") {
-			dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
-		}
-		// Ignore "id:", "retry:", comments (":"), etc.
-	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("read: %w", err)
-	}
-	return fmt.Errorf("stream closed by server")
-}
-
-func (w *SSEWatcher) handleEvent(ev sseEvent) {
-	switch ev.Type {
-	case "file_changed":
-		var ce changeEvent
-		if err := json.Unmarshal(ev.Data, &ce); err != nil {
-			log.Printf("dat9: SSE unmarshal file_changed: %v", err)
-			return
-		}
-		if ce.Seq > w.lastSeq {
-			w.lastSeq = ce.Seq
-		}
+func (w *SSEWatcher) handleEvent(change *client.ChangeEvent, reset *client.ResetEvent) {
+	if change != nil {
 		// Skip events from our own mount.
-		if w.actor != "" && ce.Actor == w.actor {
+		if w.actor != "" && change.Actor == w.actor {
 			return
 		}
-		w.handleChange(ce)
-
-	case "reset":
-		var re resetEvent
-		if err := json.Unmarshal(ev.Data, &re); err != nil {
-			log.Printf("dat9: SSE unmarshal reset: %v", err)
-			return
-		}
-		if re.Seq > w.lastSeq {
-			w.lastSeq = re.Seq
-		}
+		w.handleChange(change)
+		return
+	}
+	if reset != nil && reset.Reason != "" {
+		// Only handle resets with an explicit reason (not heartbeats).
 		w.handleReset()
-
-	case "heartbeat":
-		var he heartbeatEvent
-		if err := json.Unmarshal(ev.Data, &he); err != nil {
-			return
-		}
-		if he.Seq > w.lastSeq {
-			w.lastSeq = he.Seq
-		}
 	}
 }
 
-func (w *SSEWatcher) handleChange(ce changeEvent) {
+func (w *SSEWatcher) handleChange(ce *client.ChangeEvent) {
 	p := ce.Path
 	if p == "" {
 		return
 	}
+
+	fmt.Fprintf(os.Stderr, "dat9: SSE event op=%s path=%s actor=%s\n", ce.Op, p, ce.Actor)
 
 	// Invalidate read cache for the changed file.
 	w.fs.readCache.Invalidate(p)
@@ -228,6 +80,8 @@ func (w *SSEWatcher) handleChange(ce changeEvent) {
 }
 
 func (w *SSEWatcher) handleReset() {
+	fmt.Fprintf(os.Stderr, "dat9: SSE reset — invalidating all caches\n")
+
 	// 1. Clear all user-space caches.
 	w.fs.readCache.InvalidateAll()
 	w.fs.dirCache.InvalidateAll()

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -1,0 +1,250 @@
+package fuse
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+)
+
+// sseEvent represents a parsed SSE event.
+type sseEvent struct {
+	Type string // "file_changed", "reset", "heartbeat"
+	Data json.RawMessage
+}
+
+// changeEvent mirrors the server-side ChangeEvent.
+type changeEvent struct {
+	Seq   uint64 `json:"seq"`
+	Path  string `json:"path"`
+	Op    string `json:"op"`
+	Actor string `json:"actor"`
+	Ts    int64  `json:"ts"`
+}
+
+// resetEvent represents a server-sent reset notification.
+type resetEvent struct {
+	Seq    uint64 `json:"seq"`
+	Reason string `json:"reason"`
+}
+
+// heartbeatEvent represents a server-sent heartbeat.
+type heartbeatEvent struct {
+	Seq uint64 `json:"seq"`
+}
+
+const (
+	sseReconnectMin = 1 * time.Second
+	sseReconnectMax = 30 * time.Second
+)
+
+// SSEWatcher connects to the dat9 server SSE endpoint and invalidates
+// local FUSE caches when remote changes are detected.
+type SSEWatcher struct {
+	fs       *Dat9FS
+	baseURL  string
+	apiKey   string
+	actor    string // our own actor ID for self-filtering
+	lastSeq  uint64
+	cancel   context.CancelFunc
+	doneCh   chan struct{}
+}
+
+// StartSSEWatcher starts a background goroutine that connects to the
+// server's /v1/events SSE endpoint and invalidates local caches.
+func StartSSEWatcher(fs *Dat9FS, baseURL, apiKey, actor string) *SSEWatcher {
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &SSEWatcher{
+		fs:      fs,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		apiKey:  apiKey,
+		actor:   actor,
+		cancel:  cancel,
+		doneCh:  make(chan struct{}),
+	}
+	go w.run(ctx)
+	return w
+}
+
+// Stop signals the watcher to disconnect and waits for it to finish.
+func (w *SSEWatcher) Stop() {
+	w.cancel()
+	<-w.doneCh
+}
+
+func (w *SSEWatcher) run(ctx context.Context) {
+	defer close(w.doneCh)
+
+	backoff := sseReconnectMin
+	for {
+		err := w.connect(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			log.Printf("dat9: SSE connection error: %v (reconnecting in %v)", err, backoff)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		// Exponential backoff capped at sseReconnectMax.
+		backoff = backoff * 2
+		if backoff > sseReconnectMax {
+			backoff = sseReconnectMax
+		}
+	}
+}
+
+func (w *SSEWatcher) connect(ctx context.Context) error {
+	url := fmt.Sprintf("%s/v1/events?since=%d", w.baseURL, w.lastSeq)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if w.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+w.apiKey)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	// Reset backoff on successful connection.
+	scanner := bufio.NewScanner(resp.Body)
+	// SSE max line is typically small, but allow generous buffer.
+	scanner.Buffer(make([]byte, 0, 64*1024), 64*1024)
+
+	var eventType string
+	var dataLines []string
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return nil
+		}
+		line := scanner.Text()
+
+		if line == "" {
+			// Empty line = end of event.
+			if eventType != "" && len(dataLines) > 0 {
+				data := strings.Join(dataLines, "\n")
+				w.handleEvent(sseEvent{
+					Type: eventType,
+					Data: json.RawMessage(data),
+				})
+			}
+			eventType = ""
+			dataLines = nil
+			continue
+		}
+
+		if strings.HasPrefix(line, "event: ") {
+			eventType = strings.TrimPrefix(line, "event: ")
+		} else if strings.HasPrefix(line, "data: ") {
+			dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+		}
+		// Ignore "id:", "retry:", comments (":"), etc.
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	return fmt.Errorf("stream closed by server")
+}
+
+func (w *SSEWatcher) handleEvent(ev sseEvent) {
+	switch ev.Type {
+	case "file_changed":
+		var ce changeEvent
+		if err := json.Unmarshal(ev.Data, &ce); err != nil {
+			log.Printf("dat9: SSE unmarshal file_changed: %v", err)
+			return
+		}
+		if ce.Seq > w.lastSeq {
+			w.lastSeq = ce.Seq
+		}
+		// Skip events from our own mount.
+		if w.actor != "" && ce.Actor == w.actor {
+			return
+		}
+		w.handleChange(ce)
+
+	case "reset":
+		var re resetEvent
+		if err := json.Unmarshal(ev.Data, &re); err != nil {
+			log.Printf("dat9: SSE unmarshal reset: %v", err)
+			return
+		}
+		if re.Seq > w.lastSeq {
+			w.lastSeq = re.Seq
+		}
+		w.handleReset()
+
+	case "heartbeat":
+		var he heartbeatEvent
+		if err := json.Unmarshal(ev.Data, &he); err != nil {
+			return
+		}
+		if he.Seq > w.lastSeq {
+			w.lastSeq = he.Seq
+		}
+	}
+}
+
+func (w *SSEWatcher) handleChange(ce changeEvent) {
+	p := ce.Path
+	if p == "" {
+		return
+	}
+
+	// Invalidate read cache for the changed file.
+	w.fs.readCache.Invalidate(p)
+
+	// Invalidate directory cache for the parent directory.
+	w.fs.dirCache.Invalidate(parentDir(p))
+
+	// Notify kernel about the change.
+	if ino, ok := w.fs.inodes.GetInode(p); ok {
+		w.fs.notifyInode(ino)
+	}
+	if parentIno, ok := w.fs.inodes.GetInode(parentDir(p)); ok {
+		w.fs.notifyEntry(parentIno, path.Base(p))
+	}
+}
+
+func (w *SSEWatcher) handleReset() {
+	// 1. Clear all user-space caches.
+	w.fs.readCache.InvalidateAll()
+	w.fs.dirCache.InvalidateAll()
+
+	// 2. Best-effort kernel cache invalidation for all known inodes.
+	//    InodeToPath is kept intact (stale but resolvable).
+	//    Kernel will re-Lookup on next access, which re-validates against server.
+	w.fs.inodes.ForEach(func(ino uint64, entry InodeEntry) {
+		// InodeNotify invalidates cached attrs and page data.
+		w.fs.notifyInode(ino)
+
+		// EntryNotify invalidates parent's dentry cache for this name.
+		if entry.Path != "/" {
+			parent := parentDir(entry.Path)
+			if parentIno, ok := w.fs.inodes.GetInode(parent); ok {
+				w.fs.notifyEntry(parentIno, path.Base(entry.Path))
+			}
+		}
+	})
+}

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -87,18 +87,18 @@ func (w *SSEWatcher) handleReset() {
 	w.fs.dirCache.InvalidateAll()
 
 	// 2. Best-effort kernel cache invalidation for all known inodes.
+	//    Snapshot entries first so we don't hold the inode map lock during
+	//    potentially slow kernel notify calls.
 	//    InodeToPath is kept intact (stale but resolvable).
-	//    Kernel will re-Lookup on next access, which re-validates against server.
-	w.fs.inodes.ForEach(func(ino uint64, entry InodeEntry) {
-		// InodeNotify invalidates cached attrs and page data.
-		w.fs.notifyInode(ino)
+	entries := w.fs.inodes.Snapshot()
+	for _, entry := range entries {
+		w.fs.notifyInode(entry.Ino)
 
-		// EntryNotify invalidates parent's dentry cache for this name.
 		if entry.Path != "/" {
 			parent := parentDir(entry.Path)
 			if parentIno, ok := w.fs.inodes.GetInode(parent); ok {
 				w.fs.notifyEntry(parentIno, path.Base(entry.Path))
 			}
 		}
-	})
+	}
 }

--- a/pkg/fuse/sse_test.go
+++ b/pkg/fuse/sse_test.go
@@ -1,7 +1,6 @@
 package fuse
 
 import (
-	"path"
 	"testing"
 	"time"
 
@@ -190,10 +189,7 @@ func TestParentDir(t *testing.T) {
 		{"/", "/"},
 	}
 	for _, tt := range tests {
-		got := path.Dir(tt.input)
-		if got == "." {
-			got = "/"
-		}
+		got := parentDir(tt.input)
 		if got != tt.want {
 			t.Errorf("parentDir(%q) = %q, want %q", tt.input, got, tt.want)
 		}

--- a/pkg/fuse/sse_test.go
+++ b/pkg/fuse/sse_test.go
@@ -4,6 +4,8 @@ import (
 	"path"
 	"testing"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/client"
 )
 
 func TestSSEWatcherResetPreservesInodes(t *testing.T) {
@@ -78,7 +80,7 @@ func TestSSEWatcherHandleChangeInvalidatesCache(t *testing.T) {
 	w := &SSEWatcher{fs: fs, actor: "my-actor"}
 
 	// A change from a different actor should invalidate caches.
-	w.handleChange(changeEvent{
+	w.handleChange(&client.ChangeEvent{
 		Seq:   1,
 		Path:  "/docs/readme.md",
 		Op:    "write",
@@ -115,14 +117,66 @@ func TestSSEWatcherSelfFilterSkipsOwnEvents(t *testing.T) {
 	w := &SSEWatcher{fs: fs, actor: "my-actor"}
 
 	// An event from our own actor should be skipped.
-	w.handleEvent(sseEvent{
-		Type: "file_changed",
-		Data: []byte(`{"seq":1,"path":"/test.txt","op":"write","actor":"my-actor"}`),
-	})
+	w.handleEvent(
+		&client.ChangeEvent{Seq: 1, Path: "/test.txt", Op: "write", Actor: "my-actor"},
+		nil,
+	)
 
 	// Cache should NOT be invalidated because we skip our own events.
 	if _, ok := fs.readCache.Get("/test.txt", 1); !ok {
 		t.Error("readCache should NOT be invalidated for own actor's events")
+	}
+}
+
+func TestSSEWatcherHandleEventReset(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	fs.readCache.Put("/test.txt", []byte("data"), 1)
+	fs.dirCache.Put("/", []CachedFileInfo{{Name: "test.txt", Size: 4}})
+
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+
+	// A reset event should clear caches.
+	w.handleEvent(nil, &client.ResetEvent{Seq: 5, Reason: "structural_change"})
+
+	if _, ok := fs.readCache.Get("/test.txt", 1); ok {
+		t.Error("readCache should be cleared after reset")
+	}
+	if _, ok := fs.dirCache.Get("/"); ok {
+		t.Error("dirCache should be cleared after reset")
+	}
+}
+
+func TestSSEWatcherHeartbeatDoesNotReset(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	fs.readCache.Put("/test.txt", []byte("data"), 1)
+
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+
+	// A heartbeat (reset with empty reason) should NOT clear caches.
+	w.handleEvent(nil, &client.ResetEvent{Seq: 5, Reason: ""})
+
+	if _, ok := fs.readCache.Get("/test.txt", 1); !ok {
+		t.Error("readCache should NOT be cleared after heartbeat")
 	}
 }
 

--- a/pkg/fuse/sse_test.go
+++ b/pkg/fuse/sse_test.go
@@ -1,0 +1,147 @@
+package fuse
+
+import (
+	"path"
+	"testing"
+	"time"
+)
+
+func TestSSEWatcherResetPreservesInodes(t *testing.T) {
+	// Set up a Dat9FS with some cached inodes (no real server needed).
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+		AttrTTL:   60 * time.Second,
+		EntryTTL:  60 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	// Simulate some looked-up inodes.
+	ino1 := fs.inodes.Lookup("/project", true, 0, time.Now())
+	ino2 := fs.inodes.Lookup("/project/foo.txt", false, 100, time.Now())
+	ino3 := fs.inodes.Lookup("/other/bar.txt", false, 200, time.Now())
+
+	// Put some data in caches.
+	fs.readCache.Put("/project/foo.txt", []byte("hello"), 1)
+	fs.dirCache.Put("/project", []CachedFileInfo{{Name: "foo.txt", Size: 100}})
+
+	// Create an SSE watcher (no real connection needed for this test).
+	w := &SSEWatcher{
+		fs:    fs,
+		actor: "test-actor",
+	}
+
+	// Trigger reset.
+	w.handleReset()
+
+	// Verify: InodeToPath entries are still alive.
+	if _, ok := fs.inodes.GetPath(ino1); !ok {
+		t.Error("inode for /project was lost after reset")
+	}
+	if _, ok := fs.inodes.GetPath(ino2); !ok {
+		t.Error("inode for /project/foo.txt was lost after reset")
+	}
+	if _, ok := fs.inodes.GetPath(ino3); !ok {
+		t.Error("inode for /other/bar.txt was lost after reset")
+	}
+
+	// Verify: caches are cleared.
+	if _, ok := fs.readCache.Get("/project/foo.txt", 1); ok {
+		t.Error("readCache should be empty after reset")
+	}
+	if _, ok := fs.dirCache.Get("/project"); ok {
+		t.Error("dirCache should be empty after reset")
+	}
+}
+
+func TestSSEWatcherHandleChangeInvalidatesCache(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	fs.inodes.Lookup("/docs/readme.md", false, 50, time.Now())
+	fs.readCache.Put("/docs/readme.md", []byte("old content"), 1)
+	fs.dirCache.Put("/docs", []CachedFileInfo{{Name: "readme.md", Size: 50}})
+
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+
+	// A change from a different actor should invalidate caches.
+	w.handleChange(changeEvent{
+		Seq:   1,
+		Path:  "/docs/readme.md",
+		Op:    "write",
+		Actor: "other-actor",
+	})
+
+	if _, ok := fs.readCache.Get("/docs/readme.md", 1); ok {
+		t.Error("readCache entry should be invalidated after change")
+	}
+	if _, ok := fs.dirCache.Get("/docs"); ok {
+		t.Error("dirCache entry for parent dir should be invalidated after change")
+	}
+
+	// Inode should still be there.
+	if _, ok := fs.inodes.GetInode("/docs/readme.md"); !ok {
+		t.Error("inode should survive a change event")
+	}
+}
+
+func TestSSEWatcherSelfFilterSkipsOwnEvents(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	fs.readCache.Put("/test.txt", []byte("data"), 1)
+
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+
+	// An event from our own actor should be skipped.
+	w.handleEvent(sseEvent{
+		Type: "file_changed",
+		Data: []byte(`{"seq":1,"path":"/test.txt","op":"write","actor":"my-actor"}`),
+	})
+
+	// Cache should NOT be invalidated because we skip our own events.
+	if _, ok := fs.readCache.Get("/test.txt", 1); !ok {
+		t.Error("readCache should NOT be invalidated for own actor's events")
+	}
+}
+
+func TestParentDir(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"/foo/bar.txt", "/foo"},
+		{"/bar.txt", "/"},
+		{"/a/b/c", "/a/b"},
+		{"/", "/"},
+	}
+	for _, tt := range tests {
+		got := path.Dir(tt.input)
+		if got == "." {
+			got = "/"
+		}
+		if got != tt.want {
+			t.Errorf("parentDir(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -23,8 +22,8 @@ const (
 // EventBus is a per-tenant in-memory event hub backed by a fixed-size ring buffer.
 // Single-instance only — does not survive restarts or replicate across processes.
 type EventBus struct {
-	seq       atomic.Uint64
 	mu        sync.Mutex
+	seq       uint64 // monotonic counter, protected by mu
 	ring      [eventBusRingSize]ChangeEvent
 	head      int // next write position
 	count     int // entries currently stored (max eventBusRingSize)
@@ -41,16 +40,15 @@ func NewEventBus() *EventBus {
 
 // Publish appends a new event to the ring buffer and wakes all subscribers.
 func (eb *EventBus) Publish(path, op, actor string) {
-	seq := eb.seq.Add(1)
+	eb.mu.Lock()
+	eb.seq++
 	ev := ChangeEvent{
-		Seq:   seq,
+		Seq:   eb.seq,
 		Path:  path,
 		Op:    op,
 		Actor: actor,
 		Ts:    time.Now().UnixMilli(),
 	}
-
-	eb.mu.Lock()
 	eb.ring[eb.head] = ev
 	eb.head = (eb.head + 1) % eventBusRingSize
 	if eb.count < eventBusRingSize {
@@ -94,7 +92,9 @@ func (eb *EventBus) Unsubscribe(id uint64) {
 
 // Seq returns the current sequence number (0 if no events published).
 func (eb *EventBus) Seq() uint64 {
-	return eb.seq.Load()
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	return eb.seq
 }
 
 // EventsSince returns all events with seq > since. If since is too old

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -123,8 +123,10 @@ func (eb *EventBus) EventsSince(since uint64) (events []ChangeEvent, headSeq uin
 	oldestSeq := eb.ring[oldestIdx].Seq
 	newestSeq := eb.ring[(eb.head-1+eventBusRingSize)%eventBusRingSize].Seq
 
-	if since < oldestSeq {
+	if since+1 < oldestSeq {
 		// Ring has wrapped past the client's position.
+		// since+1 is the first seq the client needs; if it's older than
+		// the oldest retained event, we can't replay.
 		return nil, headSeq, false
 	}
 	if since > newestSeq {

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -97,23 +97,25 @@ func (eb *EventBus) Seq() uint64 {
 	return eb.seq
 }
 
-// EventsSince returns all events with seq > since. If since is too old
-// (the ring has wrapped past it) or from a future/different server lifetime,
-// ok is false and the caller should send a reset.
+// EventsSince returns all events with seq > since and the current head seq.
+// If since is too old (ring wrapped), from the future, or zero, ok is false
+// and the caller should send a reset using the returned headSeq.
 //
-// When since == 0, this always returns ok=false (caller should send reset +
-// start live from current head).
-func (eb *EventBus) EventsSince(since uint64) (events []ChangeEvent, ok bool) {
-	if since == 0 {
-		return nil, false
-	}
-
+// headSeq is always returned from the same lock acquisition as the event
+// scan, guaranteeing a consistent snapshot for reset cursor positioning.
+func (eb *EventBus) EventsSince(since uint64) (events []ChangeEvent, headSeq uint64, ok bool) {
 	eb.mu.Lock()
 	defer eb.mu.Unlock()
 
+	headSeq = eb.seq
+
+	if since == 0 {
+		return nil, headSeq, false
+	}
+
 	if eb.count == 0 {
 		// No events ever published. since > 0 means stale client.
-		return nil, false
+		return nil, headSeq, false
 	}
 
 	// Find the oldest seq in the ring.
@@ -123,15 +125,15 @@ func (eb *EventBus) EventsSince(since uint64) (events []ChangeEvent, ok bool) {
 
 	if since < oldestSeq {
 		// Ring has wrapped past the client's position.
-		return nil, false
+		return nil, headSeq, false
 	}
 	if since > newestSeq {
 		// Client is ahead of us (e.g. server restarted). Send reset.
-		return nil, false
+		return nil, headSeq, false
 	}
 	if since == newestSeq {
 		// Client is caught up, no new events.
-		return nil, true
+		return nil, headSeq, true
 	}
 
 	// Walk the ring from oldest to newest, collecting events with seq > since.
@@ -143,5 +145,5 @@ func (eb *EventBus) EventsSince(since uint64) (events []ChangeEvent, ok bool) {
 			result = append(result, ev)
 		}
 	}
-	return result, true
+	return result, headSeq, true
 }

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ChangeEvent represents a single filesystem mutation event.
+type ChangeEvent struct {
+	Seq   uint64 `json:"seq"`              // monotonic per-bus sequence number
+	Path  string `json:"path"`             // affected path
+	Op    string `json:"op"`               // "write" | "delete" | "rename" | "mkdir" | "copy" | "upload_complete"
+	Actor string `json:"actor,omitempty"`  // X-Dat9-Actor header value (per-mount ID)
+	Ts    int64  `json:"ts"`               // unix milliseconds
+}
+
+const (
+	eventBusRingSize         = 10000
+	eventBusListenerChanSize = 1 // signal-only channel
+)
+
+// EventBus is a per-tenant in-memory event hub backed by a fixed-size ring buffer.
+// Single-instance only — does not survive restarts or replicate across processes.
+type EventBus struct {
+	seq       atomic.Uint64
+	mu        sync.Mutex
+	ring      [eventBusRingSize]ChangeEvent
+	head      int // next write position
+	count     int // entries currently stored (max eventBusRingSize)
+	listeners map[uint64]chan struct{}
+	nextID    uint64
+}
+
+// NewEventBus creates a new EventBus.
+func NewEventBus() *EventBus {
+	return &EventBus{
+		listeners: make(map[uint64]chan struct{}),
+	}
+}
+
+// Publish appends a new event to the ring buffer and wakes all subscribers.
+func (eb *EventBus) Publish(path, op, actor string) {
+	seq := eb.seq.Add(1)
+	ev := ChangeEvent{
+		Seq:   seq,
+		Path:  path,
+		Op:    op,
+		Actor: actor,
+		Ts:    time.Now().UnixMilli(),
+	}
+
+	eb.mu.Lock()
+	eb.ring[eb.head] = ev
+	eb.head = (eb.head + 1) % eventBusRingSize
+	if eb.count < eventBusRingSize {
+		eb.count++
+	}
+
+	// Wake all listeners (non-blocking send on signal channel).
+	for _, ch := range eb.listeners {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+	eb.mu.Unlock()
+}
+
+// Subscribe registers a new listener. Returns a unique ID and a signal channel.
+// The channel receives a signal whenever new events are published.
+// Call Unsubscribe with the returned ID to clean up.
+func (eb *EventBus) Subscribe() (uint64, chan struct{}) {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+
+	id := eb.nextID
+	eb.nextID++
+	ch := make(chan struct{}, eventBusListenerChanSize)
+	eb.listeners[id] = ch
+	return id, ch
+}
+
+// Unsubscribe removes a listener and closes its channel.
+func (eb *EventBus) Unsubscribe(id uint64) {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+
+	if ch, ok := eb.listeners[id]; ok {
+		delete(eb.listeners, id)
+		close(ch)
+	}
+}
+
+// Seq returns the current sequence number (0 if no events published).
+func (eb *EventBus) Seq() uint64 {
+	return eb.seq.Load()
+}
+
+// EventsSince returns all events with seq > since. If since is too old
+// (the ring has wrapped past it) or from a future/different server lifetime,
+// ok is false and the caller should send a reset.
+//
+// When since == 0, this always returns ok=false (caller should send reset +
+// start live from current head).
+func (eb *EventBus) EventsSince(since uint64) (events []ChangeEvent, ok bool) {
+	if since == 0 {
+		return nil, false
+	}
+
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+
+	if eb.count == 0 {
+		// No events ever published. since > 0 means stale client.
+		return nil, false
+	}
+
+	// Find the oldest seq in the ring.
+	oldestIdx := (eb.head - eb.count + eventBusRingSize) % eventBusRingSize
+	oldestSeq := eb.ring[oldestIdx].Seq
+	newestSeq := eb.ring[(eb.head-1+eventBusRingSize)%eventBusRingSize].Seq
+
+	if since < oldestSeq {
+		// Ring has wrapped past the client's position.
+		return nil, false
+	}
+	if since > newestSeq {
+		// Client is ahead of us (e.g. server restarted). Send reset.
+		return nil, false
+	}
+	if since == newestSeq {
+		// Client is caught up, no new events.
+		return nil, true
+	}
+
+	// Walk the ring from oldest to newest, collecting events with seq > since.
+	result := make([]ChangeEvent, 0, 64)
+	for i := 0; i < eb.count; i++ {
+		idx := (oldestIdx + i) % eventBusRingSize
+		ev := eb.ring[idx]
+		if ev.Seq > since {
+			result = append(result, ev)
+		}
+	}
+	return result, true
+}

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -150,6 +150,27 @@ func TestEventBusConcurrentPublish(t *testing.T) {
 	}
 }
 
+func TestEventBusSinceBoundaryNoFalseReset(t *testing.T) {
+	bus := NewEventBus()
+	// Fill ring so oldestSeq > 1: publish eventBusRingSize+2 events
+	// so ring contains seqs [3, 4, ..., ringSize+2] with oldestSeq=3.
+	for i := 0; i < eventBusRingSize+2; i++ {
+		bus.Publish("/file.txt", "write", "")
+	}
+	// since=2 means client needs seq 3+, which is exactly oldestSeq.
+	// This should NOT trigger a reset — all needed events are in the ring.
+	events, _, ok := bus.EventsSince(2)
+	if !ok {
+		t.Fatal("expected ok=true for since=oldestSeq-1 (all needed events are in the ring)")
+	}
+	if len(events) != eventBusRingSize {
+		t.Fatalf("expected %d events, got %d", eventBusRingSize, len(events))
+	}
+	if events[0].Seq != 3 {
+		t.Fatalf("first event seq=%d, want 3", events[0].Seq)
+	}
+}
+
 func TestEventBusEmptyRingSincePositive(t *testing.T) {
 	bus := NewEventBus()
 	// No events published; client has since=5 (stale from previous server life).

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -74,19 +74,29 @@ func TestEventBusCaughtUp(t *testing.T) {
 
 func TestEventBusRingOverflow(t *testing.T) {
 	bus := NewEventBus()
-	// Fill ring + 1 to trigger wrap.
-	for i := 0; i < eventBusRingSize+1; i++ {
+	// Fill ring + 2 to trigger wrap; ring holds seqs [3..ringSize+2],
+	// so seq 1 is truly evicted (since+1=2 < oldestSeq=3 → reset).
+	for i := 0; i < eventBusRingSize+2; i++ {
 		bus.Publish("/file.txt", "write", "")
 	}
 
-	// Seq 1 should be evicted from the ring.
+	// Seq 1 is evicted: client needs seq 2, but oldest in ring is 3.
 	_, _, ok := bus.EventsSince(1)
 	if ok {
 		t.Fatal("expected ok=false for seq that's been overwritten")
 	}
 
+	// since=2 is the boundary: client needs seq 3 = oldestSeq, all present.
+	events, _, ok := bus.EventsSince(2)
+	if !ok {
+		t.Fatal("expected ok=true for since=oldestSeq-1 (boundary)")
+	}
+	if len(events) != eventBusRingSize {
+		t.Fatalf("expected %d events, got %d", eventBusRingSize, len(events))
+	}
+
 	// Most recent seq should still be reachable.
-	events, _, ok := bus.EventsSince(uint64(eventBusRingSize))
+	events, _, ok = bus.EventsSince(uint64(eventBusRingSize + 1))
 	if !ok {
 		t.Fatal("expected ok=true for recent seq")
 	}

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -26,12 +26,15 @@ func TestEventBusSince0ReturnsNotOK(t *testing.T) {
 	bus := NewEventBus()
 	bus.Publish("/a.txt", "write", "")
 
-	events, ok := bus.EventsSince(0)
+	events, headSeq, ok := bus.EventsSince(0)
 	if ok {
 		t.Fatal("EventsSince(0) should return ok=false (initial sync → reset)")
 	}
 	if events != nil {
 		t.Fatalf("expected nil events, got %d", len(events))
+	}
+	if headSeq != 1 {
+		t.Fatalf("headSeq=%d, want 1", headSeq)
 	}
 }
 
@@ -41,7 +44,7 @@ func TestEventBusReplay(t *testing.T) {
 	bus.Publish("/b.txt", "write", "")
 	bus.Publish("/c.txt", "delete", "")
 
-	events, ok := bus.EventsSince(1) // since seq=1, want seq=2,3
+	events, _, ok := bus.EventsSince(1) // since seq=1, want seq=2,3
 	if !ok {
 		t.Fatal("EventsSince(1) returned not ok")
 	}
@@ -60,7 +63,7 @@ func TestEventBusCaughtUp(t *testing.T) {
 	bus := NewEventBus()
 	bus.Publish("/a.txt", "write", "")
 
-	events, ok := bus.EventsSince(1)
+	events, _, ok := bus.EventsSince(1)
 	if !ok {
 		t.Fatal("expected ok=true when caught up")
 	}
@@ -77,13 +80,13 @@ func TestEventBusRingOverflow(t *testing.T) {
 	}
 
 	// Seq 1 should be evicted from the ring.
-	_, ok := bus.EventsSince(1)
+	_, _, ok := bus.EventsSince(1)
 	if ok {
 		t.Fatal("expected ok=false for seq that's been overwritten")
 	}
 
 	// Most recent seq should still be reachable.
-	events, ok := bus.EventsSince(uint64(eventBusRingSize))
+	events, _, ok := bus.EventsSince(uint64(eventBusRingSize))
 	if !ok {
 		t.Fatal("expected ok=true for recent seq")
 	}
@@ -97,7 +100,7 @@ func TestEventBusFutureSeq(t *testing.T) {
 	bus.Publish("/a.txt", "write", "")
 
 	// Client has seq=999 but server only has seq=1 (e.g. server restarted).
-	_, ok := bus.EventsSince(999)
+	_, _, ok := bus.EventsSince(999)
 	if ok {
 		t.Fatal("expected ok=false for future seq (server restart)")
 	}
@@ -150,7 +153,7 @@ func TestEventBusConcurrentPublish(t *testing.T) {
 func TestEventBusEmptyRingSincePositive(t *testing.T) {
 	bus := NewEventBus()
 	// No events published; client has since=5 (stale from previous server life).
-	_, ok := bus.EventsSince(5)
+	_, _, ok := bus.EventsSince(5)
 	if ok {
 		t.Fatal("expected ok=false when ring is empty and since > 0")
 	}

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestEventBusPublishAndSeq(t *testing.T) {
+	bus := NewEventBus()
+	if bus.Seq() != 0 {
+		t.Fatalf("initial seq=%d, want 0", bus.Seq())
+	}
+
+	bus.Publish("/a.txt", "write", "actor1")
+	if bus.Seq() != 1 {
+		t.Fatalf("seq after 1 publish=%d, want 1", bus.Seq())
+	}
+
+	bus.Publish("/b.txt", "delete", "actor2")
+	if bus.Seq() != 2 {
+		t.Fatalf("seq after 2 publishes=%d, want 2", bus.Seq())
+	}
+}
+
+func TestEventBusSince0ReturnsNotOK(t *testing.T) {
+	bus := NewEventBus()
+	bus.Publish("/a.txt", "write", "")
+
+	events, ok := bus.EventsSince(0)
+	if ok {
+		t.Fatal("EventsSince(0) should return ok=false (initial sync → reset)")
+	}
+	if events != nil {
+		t.Fatalf("expected nil events, got %d", len(events))
+	}
+}
+
+func TestEventBusReplay(t *testing.T) {
+	bus := NewEventBus()
+	bus.Publish("/a.txt", "write", "")
+	bus.Publish("/b.txt", "write", "")
+	bus.Publish("/c.txt", "delete", "")
+
+	events, ok := bus.EventsSince(1) // since seq=1, want seq=2,3
+	if !ok {
+		t.Fatal("EventsSince(1) returned not ok")
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Seq != 2 || events[0].Path != "/b.txt" {
+		t.Errorf("event[0] = %+v", events[0])
+	}
+	if events[1].Seq != 3 || events[1].Path != "/c.txt" {
+		t.Errorf("event[1] = %+v", events[1])
+	}
+}
+
+func TestEventBusCaughtUp(t *testing.T) {
+	bus := NewEventBus()
+	bus.Publish("/a.txt", "write", "")
+
+	events, ok := bus.EventsSince(1)
+	if !ok {
+		t.Fatal("expected ok=true when caught up")
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events when caught up, got %d", len(events))
+	}
+}
+
+func TestEventBusRingOverflow(t *testing.T) {
+	bus := NewEventBus()
+	// Fill ring + 1 to trigger wrap.
+	for i := 0; i < eventBusRingSize+1; i++ {
+		bus.Publish("/file.txt", "write", "")
+	}
+
+	// Seq 1 should be evicted from the ring.
+	_, ok := bus.EventsSince(1)
+	if ok {
+		t.Fatal("expected ok=false for seq that's been overwritten")
+	}
+
+	// Most recent seq should still be reachable.
+	events, ok := bus.EventsSince(uint64(eventBusRingSize))
+	if !ok {
+		t.Fatal("expected ok=true for recent seq")
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+}
+
+func TestEventBusFutureSeq(t *testing.T) {
+	bus := NewEventBus()
+	bus.Publish("/a.txt", "write", "")
+
+	// Client has seq=999 but server only has seq=1 (e.g. server restarted).
+	_, ok := bus.EventsSince(999)
+	if ok {
+		t.Fatal("expected ok=false for future seq (server restart)")
+	}
+}
+
+func TestEventBusSubscribeNotify(t *testing.T) {
+	bus := NewEventBus()
+	id, ch := bus.Subscribe()
+	defer bus.Unsubscribe(id)
+
+	bus.Publish("/a.txt", "write", "")
+
+	select {
+	case <-ch:
+		// OK — received signal.
+	default:
+		t.Fatal("expected signal on subscriber channel after publish")
+	}
+}
+
+func TestEventBusUnsubscribeCloses(t *testing.T) {
+	bus := NewEventBus()
+	id, ch := bus.Subscribe()
+	bus.Unsubscribe(id)
+
+	_, open := <-ch
+	if open {
+		t.Fatal("expected channel to be closed after unsubscribe")
+	}
+}
+
+func TestEventBusConcurrentPublish(t *testing.T) {
+	bus := NewEventBus()
+	var wg sync.WaitGroup
+	n := 100
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			bus.Publish("/file.txt", "write", "")
+		}()
+	}
+	wg.Wait()
+
+	if bus.Seq() != uint64(n) {
+		t.Fatalf("seq=%d, want %d", bus.Seq(), n)
+	}
+}
+
+func TestEventBusEmptyRingSincePositive(t *testing.T) {
+	bus := NewEventBus()
+	// No events published; client has since=5 (stale from previous server life).
+	_, ok := bus.EventsSince(5)
+	if ok {
+		t.Fatal("expected ok=false when ring is empty and since > 0")
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -53,6 +53,7 @@ type Server struct {
 	metrics        *serverMetrics
 	logger         *zap.Logger
 	mux            *http.ServeMux
+	events         *eventBuses
 	semanticWorker *semanticWorkerManager
 }
 
@@ -97,6 +98,7 @@ func NewWithConfig(cfg Config) *Server {
 		maxUploadBytes: maxUpload,
 		metrics:        newServerMetrics(),
 		logger:         logger,
+		events:         newEventBuses(),
 	}
 	mux := http.NewServeMux()
 
@@ -111,6 +113,7 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v1/uploads/", business)
 	mux.Handle("/v2/uploads/", business)
 	mux.Handle("/v1/sql", business)
+	mux.Handle("/v1/events", business)
 	// Vault management API goes through tenant auth.
 	mux.Handle("/v1/vault/secrets", business)
 	mux.Handle("/v1/vault/secrets/", business)
@@ -282,6 +285,8 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 		s.handleV2Uploads(w, r)
 	case r.URL.Path == "/v1/sql":
 		s.handleSQL(w, r)
+	case r.URL.Path == "/v1/events":
+		s.handleEvents(w, r)
 	case strings.HasPrefix(r.URL.Path, "/v1/vault/secrets"), strings.HasPrefix(r.URL.Path, "/v1/vault/tokens"), strings.HasPrefix(r.URL.Path, "/v1/vault/audit"):
 		s.handleVault(w, r)
 	default:
@@ -629,6 +634,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "write_ok", "path", path, "bytes", len(data))...)
 	metricEvent(r.Context(), "fs_write", "result", "ok")
+	s.publishEvent(r, path, "write")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
@@ -791,6 +797,7 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path strin
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "delete_ok", "path", path, "recursive", recursive)...)
+	s.publishEvent(r, path, "delete")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
@@ -818,6 +825,7 @@ func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath stri
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "copy_ok", "src_path", srcPath, "dst_path", dstPath)...)
+	s.publishEvent(r, dstPath, "copy")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
@@ -845,6 +853,7 @@ func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath st
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "rename_ok", "old_path", oldPath, "new_path", newPath)...)
+	s.publishEvent(r, newPath, "rename")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
@@ -861,6 +870,7 @@ func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "mkdir_ok", "path", path)...)
+	s.publishEvent(r, path, "mkdir")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
@@ -1055,6 +1065,20 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
+	// Fetch upload before confirming so we can publish the target path in the event.
+	upload, err := b.Store().GetUpload(r.Context(), uploadID)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_not_found", "upload_id", uploadID)...)
+			metricEvent(r.Context(), "upload_complete", "result", "error")
+			errJSON(w, http.StatusNotFound, err.Error())
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_failed", "upload_id", uploadID, "error", err)...)
+		metricEvent(r.Context(), "upload_complete", "result", "error")
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	if err := b.ConfirmUpload(r.Context(), uploadID); err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_not_found", "upload_id", uploadID)...)
@@ -1081,6 +1105,7 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_ok", "upload_id", uploadID)...)
 	metricEvent(r.Context(), "upload_complete", "result", "ok")
+	s.publishEvent(r, upload.TargetPath, "upload_complete")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
@@ -1467,6 +1492,18 @@ func (s *Server) handleV2UploadComplete(w http.ResponseWriter, r *http.Request, 
 		errJSON(w, http.StatusBadRequest, "parts must not be empty")
 		return
 	}
+	// Fetch upload before confirming so we can publish the target path in the event.
+	upload, err := b.Store().GetUpload(r.Context(), uploadID)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "upload not found")
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_failed", "upload_id", uploadID, "error", err)...)
+		metricEvent(r.Context(), "v2_upload_complete", "result", "error")
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	if err := b.ConfirmUploadV2(r.Context(), uploadID, req.Parts); err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "upload not found")
@@ -1500,6 +1537,7 @@ func (s *Server) handleV2UploadComplete(w http.ResponseWriter, r *http.Request, 
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_ok", "upload_id", uploadID)...)
 	metricEvent(r.Context(), "v2_upload_complete", "result", "ok")
+	s.publishEvent(r, upload.TargetPath, "upload_complete")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "completed"})
 }
 

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/logger"
+)
+
+const (
+	sseHeartbeatInterval = 30 * time.Second
+)
+
+// eventBuses manages per-tenant EventBus instances. For single-tenant mode
+// (fallback backend), the empty-string key is used.
+type eventBuses struct {
+	mu    sync.RWMutex
+	buses map[string]*EventBus
+}
+
+func newEventBuses() *eventBuses {
+	return &eventBuses{
+		buses: make(map[string]*EventBus),
+	}
+}
+
+func (ebs *eventBuses) get(tenantID string) *EventBus {
+	ebs.mu.RLock()
+	bus, ok := ebs.buses[tenantID]
+	ebs.mu.RUnlock()
+	if ok {
+		return bus
+	}
+
+	ebs.mu.Lock()
+	defer ebs.mu.Unlock()
+	// Double-check after acquiring write lock.
+	if bus, ok = ebs.buses[tenantID]; ok {
+		return bus
+	}
+	bus = NewEventBus()
+	ebs.buses[tenantID] = bus
+	return bus
+}
+
+func (s *Server) tenantEventBus(r *http.Request) *EventBus {
+	scope := ScopeFromContext(r.Context())
+	if scope != nil {
+		return s.events.get(scope.TenantID)
+	}
+	// Single-tenant / fallback mode.
+	return s.events.get("")
+}
+
+func (s *Server) publishEvent(r *http.Request, path, op string) {
+	actor := r.Header.Get("X-Dat9-Actor")
+	bus := s.tenantEventBus(r)
+	bus.Publish(path, op, actor)
+}
+
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		errJSON(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	sinceStr := r.URL.Query().Get("since")
+	var since uint64
+	if sinceStr != "" {
+		v, err := strconv.ParseUint(sinceStr, 10, 64)
+		if err != nil {
+			errJSON(w, http.StatusBadRequest, "invalid since parameter")
+			return
+		}
+		since = v
+	}
+
+	bus := s.tenantEventBus(r)
+	subID, notify := bus.Subscribe()
+	defer bus.Unsubscribe(subID)
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	ctx := r.Context()
+
+	// Phase 1: Replay or Reset.
+	lastSeen := since
+	if since == 0 {
+		// Initial connection: send reset with current seq.
+		sendSSEReset(w, bus.Seq(), "initial_sync")
+		lastSeen = bus.Seq()
+		flusher.Flush()
+	} else {
+		events, ok := bus.EventsSince(since)
+		if !ok {
+			// Gap detected: send reset.
+			currentSeq := bus.Seq()
+			reason := "seq_too_old"
+			if since > currentSeq {
+				reason = "server_restart"
+			}
+			sendSSEReset(w, currentSeq, reason)
+			lastSeen = currentSeq
+		} else {
+			for _, ev := range events {
+				sendSSEEvent(w, ev)
+				lastSeen = ev.Seq
+			}
+		}
+		flusher.Flush()
+	}
+
+	// Phase 2: Live stream.
+	heartbeat := time.NewTicker(sseHeartbeatInterval)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-heartbeat.C:
+			sendSSEHeartbeat(w, bus.Seq())
+			flusher.Flush()
+		case _, open := <-notify:
+			if !open {
+				return
+			}
+			events, ok := bus.EventsSince(lastSeen)
+			if !ok {
+				sendSSEReset(w, bus.Seq(), "seq_too_old")
+				lastSeen = bus.Seq()
+			} else {
+				for _, ev := range events {
+					sendSSEEvent(w, ev)
+					lastSeen = ev.Seq
+				}
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func sendSSEEvent(w http.ResponseWriter, ev ChangeEvent) {
+	data, err := json.Marshal(ev)
+	if err != nil {
+		logger.Error(nil, "sse_marshal_event_failed")
+		return
+	}
+	fmt.Fprintf(w, "event: file_changed\ndata: %s\n\n", data)
+}
+
+func sendSSEReset(w http.ResponseWriter, seq uint64, reason string) {
+	data, _ := json.Marshal(map[string]interface{}{
+		"seq":    seq,
+		"reason": reason,
+	})
+	fmt.Fprintf(w, "event: reset\ndata: %s\n\n", data)
+}
+
+func sendSSEHeartbeat(w http.ResponseWriter, seq uint64) {
+	data, _ := json.Marshal(map[string]interface{}{
+		"seq": seq,
+	})
+	fmt.Fprintf(w, "event: heartbeat\ndata: %s\n\n", data)
+}

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -103,8 +103,9 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	lastSeen := since
 	if since == 0 {
 		// Initial connection: send reset with current seq.
-		sendSSEReset(w, bus.Seq(), "initial_sync")
-		lastSeen = bus.Seq()
+		seq := bus.Seq()
+		sendSSEReset(w, seq, "initial_sync")
+		lastSeen = seq
 		flusher.Flush()
 	} else {
 		events, ok := bus.EventsSince(since)
@@ -135,7 +136,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		case <-ctx.Done():
 			return
 		case <-heartbeat.C:
-			sendSSEHeartbeat(w, bus.Seq())
+			sendSSEHeartbeat(w, lastSeen)
 			flusher.Flush()
 		case _, open := <-notify:
 			if !open {
@@ -143,8 +144,9 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			}
 			events, ok := bus.EventsSince(lastSeen)
 			if !ok {
-				sendSSEReset(w, bus.Seq(), "seq_too_old")
-				lastSeen = bus.Seq()
+				resetSeq := bus.Seq()
+				sendSSEReset(w, resetSeq, "seq_too_old")
+				lastSeen = resetSeq
 			} else {
 				for _, ev := range events {
 					sendSSEEvent(w, ev)
@@ -156,7 +158,24 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// isStructuralOp returns true for operations that change namespace structure
+// (rename, delete, mkdir, copy). These ops require a full reset on the client
+// because targeted invalidation cannot reliably cover old paths, subtrees,
+// and parent directory caches.
+func isStructuralOp(op string) bool {
+	switch op {
+	case "rename", "delete", "mkdir", "copy":
+		return true
+	}
+	return false
+}
+
 func sendSSEEvent(w http.ResponseWriter, ev ChangeEvent) {
+	if isStructuralOp(ev.Op) {
+		// Structural ops are sent as reset events per the accepted design.
+		sendSSEReset(w, ev.Seq, "structural_change")
+		return
+	}
 	data, err := json.Marshal(ev)
 	if err != nil {
 		logger.Error(context.TODO(), "sse_marshal_event_failed")

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -158,10 +159,10 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 func sendSSEEvent(w http.ResponseWriter, ev ChangeEvent) {
 	data, err := json.Marshal(ev)
 	if err != nil {
-		logger.Error(nil, "sse_marshal_event_failed")
+		logger.Error(context.TODO(), "sse_marshal_event_failed")
 		return
 	}
-	fmt.Fprintf(w, "event: file_changed\ndata: %s\n\n", data)
+	_, _ = fmt.Fprintf(w, "event: file_changed\ndata: %s\n\n", data)
 }
 
 func sendSSEReset(w http.ResponseWriter, seq uint64, reason string) {
@@ -169,12 +170,12 @@ func sendSSEReset(w http.ResponseWriter, seq uint64, reason string) {
 		"seq":    seq,
 		"reason": reason,
 	})
-	fmt.Fprintf(w, "event: reset\ndata: %s\n\n", data)
+	_, _ = fmt.Fprintf(w, "event: reset\ndata: %s\n\n", data)
 }
 
 func sendSSEHeartbeat(w http.ResponseWriter, seq uint64) {
 	data, _ := json.Marshal(map[string]interface{}{
 		"seq": seq,
 	})
-	fmt.Fprintf(w, "event: heartbeat\ndata: %s\n\n", data)
+	_, _ = fmt.Fprintf(w, "event: heartbeat\ndata: %s\n\n", data)
 }

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -100,32 +100,27 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	// Phase 1: Replay or Reset.
+	// EventsSince returns headSeq from the same lock acquisition as the
+	// ring scan, so reset cursor and ring state are a consistent snapshot.
+	events, headSeq, ok := bus.EventsSince(since)
 	lastSeen := since
-	if since == 0 {
-		// Initial connection: send reset with current seq.
-		seq := bus.Seq()
-		sendSSEReset(w, seq, "initial_sync")
-		lastSeen = seq
-		flusher.Flush()
-	} else {
-		events, ok := bus.EventsSince(since)
-		if !ok {
-			// Gap detected: send reset.
-			currentSeq := bus.Seq()
-			reason := "seq_too_old"
-			if since > currentSeq {
+	if !ok {
+		reason := "initial_sync"
+		if since > 0 {
+			reason = "seq_too_old"
+			if since > headSeq {
 				reason = "server_restart"
 			}
-			sendSSEReset(w, currentSeq, reason)
-			lastSeen = currentSeq
-		} else {
-			for _, ev := range events {
-				sendSSEEvent(w, ev)
-				lastSeen = ev.Seq
-			}
 		}
-		flusher.Flush()
+		sendSSEReset(w, headSeq, reason)
+		lastSeen = headSeq
+	} else {
+		for _, ev := range events {
+			sendSSEEvent(w, ev)
+			lastSeen = ev.Seq
+		}
 	}
+	flusher.Flush()
 
 	// Phase 2: Live stream.
 	heartbeat := time.NewTicker(sseHeartbeatInterval)
@@ -142,13 +137,12 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			if !open {
 				return
 			}
-			events, ok := bus.EventsSince(lastSeen)
-			if !ok {
-				resetSeq := bus.Seq()
-				sendSSEReset(w, resetSeq, "seq_too_old")
-				lastSeen = resetSeq
+			liveEvents, liveHead, liveOK := bus.EventsSince(lastSeen)
+			if !liveOK {
+				sendSSEReset(w, liveHead, "seq_too_old")
+				lastSeen = liveHead
 			} else {
-				for _, ev := range events {
+				for _, ev := range liveEvents {
 					sendSSEEvent(w, ev)
 					lastSeen = ev.Seq
 				}

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -90,7 +90,7 @@ func TestSSEEndpointReplay(t *testing.T) {
 	bus := srv.events.get("")
 
 	bus.Publish("/a.txt", "write", "actor1")
-	bus.Publish("/b.txt", "delete", "actor2")
+	bus.Publish("/b.txt", "write", "actor2")
 	bus.Publish("/c.txt", "write", "actor1")
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +123,7 @@ func TestSSEEndpointReplay(t *testing.T) {
 	if err := json.Unmarshal([]byte(ev1.Data), &data1); err != nil {
 		t.Fatalf("unmarshal event1: %v", err)
 	}
-	if data1.Path != "/b.txt" || data1.Op != "delete" {
+	if data1.Path != "/b.txt" || data1.Op != "write" {
 		t.Errorf("event1 data: %+v", data1)
 	}
 

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -187,6 +187,116 @@ func TestSSEEndpointLiveEvent(t *testing.T) {
 	}
 }
 
+func TestSSEStructuralOpEmitsReset(t *testing.T) {
+	srv := &Server{events: newEventBuses()}
+	bus := srv.events.get("")
+
+	// Publish a mix: write (file_changed) then rename (structural → reset).
+	bus.Publish("/a.txt", "write", "actor1")
+	bus.Publish("/old.txt", "rename", "actor1")
+	bus.Publish("/dir", "mkdir", "actor1")
+	bus.Publish("/gone.txt", "delete", "actor1")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), tenantScopeKey, &TenantScope{TenantID: ""})
+		srv.handleEvents(w, r.WithContext(ctx))
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Replay from seq=0 → initial reset, then connect at head for live.
+	// Instead, replay from seq=1 to get events 2,3,4.
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"?since=1", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	scanner := bufio.NewScanner(resp.Body)
+
+	// Event 2: rename → should be reset with reason structural_change.
+	ev1, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected first event")
+	}
+	if ev1.Event != "reset" {
+		t.Fatalf("rename op: event=%q, want reset", ev1.Event)
+	}
+	var reset1 map[string]interface{}
+	if err := json.Unmarshal([]byte(ev1.Data), &reset1); err != nil {
+		t.Fatalf("unmarshal reset1: %v", err)
+	}
+	if reset1["reason"] != "structural_change" {
+		t.Errorf("rename reset reason=%v, want structural_change", reset1["reason"])
+	}
+
+	// Event 3: mkdir → also reset.
+	ev2, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected second event")
+	}
+	if ev2.Event != "reset" {
+		t.Fatalf("mkdir op: event=%q, want reset", ev2.Event)
+	}
+
+	// Event 4: delete → also reset.
+	ev3, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected third event")
+	}
+	if ev3.Event != "reset" {
+		t.Fatalf("delete op: event=%q, want reset", ev3.Event)
+	}
+}
+
+func TestSSEStructuralOpLiveEmitsReset(t *testing.T) {
+	srv := &Server{events: newEventBuses()}
+	bus := srv.events.get("")
+
+	bus.Publish("/existing.txt", "write", "")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), tenantScopeKey, &TenantScope{TenantID: ""})
+		srv.handleEvents(w, r.WithContext(ctx))
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"?since=1", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Publish a structural op live.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		bus.Publish("/old", "rename", "remote-actor")
+	}()
+
+	scanner := bufio.NewScanner(resp.Body)
+	ev, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected live event")
+	}
+	if ev.Event != "reset" {
+		t.Fatalf("live rename: event=%q, want reset", ev.Event)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(ev.Data), &data); err != nil {
+		t.Fatalf("unmarshal live reset: %v", err)
+	}
+	if data["reason"] != "structural_change" {
+		t.Errorf("live rename reason=%v, want structural_change", data["reason"])
+	}
+}
+
 func TestSSEEndpointMethodNotAllowed(t *testing.T) {
 	srv := &Server{events: newEventBuses()}
 	w := httptest.NewRecorder()

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -58,7 +58,7 @@ func TestSSEEndpointSince0SendsReset(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d, want 200", resp.StatusCode)
@@ -107,7 +107,7 @@ func TestSSEEndpointReplay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	scanner := bufio.NewScanner(resp.Body)
 
@@ -120,7 +120,9 @@ func TestSSEEndpointReplay(t *testing.T) {
 		t.Fatalf("event1=%q, want file_changed", ev1.Event)
 	}
 	var data1 ChangeEvent
-	json.Unmarshal([]byte(ev1.Data), &data1)
+	if err := json.Unmarshal([]byte(ev1.Data), &data1); err != nil {
+		t.Fatalf("unmarshal event1: %v", err)
+	}
 	if data1.Path != "/b.txt" || data1.Op != "delete" {
 		t.Errorf("event1 data: %+v", data1)
 	}
@@ -130,7 +132,9 @@ func TestSSEEndpointReplay(t *testing.T) {
 		t.Fatal("expected second replayed event")
 	}
 	var data2 ChangeEvent
-	json.Unmarshal([]byte(ev2.Data), &data2)
+	if err := json.Unmarshal([]byte(ev2.Data), &data2); err != nil {
+		t.Fatalf("unmarshal event2: %v", err)
+	}
 	if data2.Path != "/c.txt" || data2.Op != "write" {
 		t.Errorf("event2 data: %+v", data2)
 	}
@@ -158,7 +162,7 @@ func TestSSEEndpointLiveEvent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Publish a new event after connection is established.
 	go func() {
@@ -175,7 +179,9 @@ func TestSSEEndpointLiveEvent(t *testing.T) {
 		t.Fatalf("live event=%q, want file_changed", ev.Event)
 	}
 	var data ChangeEvent
-	json.Unmarshal([]byte(ev.Data), &data)
+	if err := json.Unmarshal([]byte(ev.Data), &data); err != nil {
+		t.Fatalf("unmarshal live event: %v", err)
+	}
 	if data.Path != "/new.txt" || data.Actor != "remote-actor" {
 		t.Errorf("live event data: %+v", data)
 	}

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -1,0 +1,202 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// sseEvent represents a parsed SSE event.
+type sseEvent struct {
+	Event string
+	Data  string
+}
+
+// readSSEEvent reads one SSE event from the scanner.
+func readSSEEvent(scanner *bufio.Scanner) (sseEvent, bool) {
+	var ev sseEvent
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if ev.Event != "" || ev.Data != "" {
+				return ev, true
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "event: ") {
+			ev.Event = strings.TrimPrefix(line, "event: ")
+		} else if strings.HasPrefix(line, "data: ") {
+			ev.Data = strings.TrimPrefix(line, "data: ")
+		}
+	}
+	return ev, false
+}
+
+func TestSSEEndpointSince0SendsReset(t *testing.T) {
+	srv := &Server{events: newEventBuses()}
+	bus := srv.events.get("")
+
+	bus.Publish("/existing.txt", "write", "")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Inject fallback scope context.
+		ctx := context.WithValue(r.Context(), tenantScopeKey, &TenantScope{TenantID: ""})
+		srv.handleEvents(w, r.WithContext(ctx))
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"?since=0", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("Content-Type=%q, want text/event-stream", ct)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	ev, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected at least one SSE event")
+	}
+	if ev.Event != "reset" {
+		t.Fatalf("first event=%q, want 'reset'", ev.Event)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(ev.Data), &data); err != nil {
+		t.Fatalf("unmarshal reset data: %v", err)
+	}
+	if data["reason"] != "initial_sync" {
+		t.Errorf("reset reason=%v, want initial_sync", data["reason"])
+	}
+}
+
+func TestSSEEndpointReplay(t *testing.T) {
+	srv := &Server{events: newEventBuses()}
+	bus := srv.events.get("")
+
+	bus.Publish("/a.txt", "write", "actor1")
+	bus.Publish("/b.txt", "delete", "actor2")
+	bus.Publish("/c.txt", "write", "actor1")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), tenantScopeKey, &TenantScope{TenantID: ""})
+		srv.handleEvents(w, r.WithContext(ctx))
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"?since=1", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+
+	// Should get 2 events (seq=2 and seq=3).
+	ev1, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected first replayed event")
+	}
+	if ev1.Event != "file_changed" {
+		t.Fatalf("event1=%q, want file_changed", ev1.Event)
+	}
+	var data1 ChangeEvent
+	json.Unmarshal([]byte(ev1.Data), &data1)
+	if data1.Path != "/b.txt" || data1.Op != "delete" {
+		t.Errorf("event1 data: %+v", data1)
+	}
+
+	ev2, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected second replayed event")
+	}
+	var data2 ChangeEvent
+	json.Unmarshal([]byte(ev2.Data), &data2)
+	if data2.Path != "/c.txt" || data2.Op != "write" {
+		t.Errorf("event2 data: %+v", data2)
+	}
+}
+
+func TestSSEEndpointLiveEvent(t *testing.T) {
+	srv := &Server{events: newEventBuses()}
+	bus := srv.events.get("")
+
+	// Pre-publish one event so since=1 is valid.
+	bus.Publish("/existing.txt", "write", "")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), tenantScopeKey, &TenantScope{TenantID: ""})
+		srv.handleEvents(w, r.WithContext(ctx))
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// Connect at current head (since=1), so no replay.
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"?since=1", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// Publish a new event after connection is established.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		bus.Publish("/new.txt", "write", "remote-actor")
+	}()
+
+	scanner := bufio.NewScanner(resp.Body)
+	ev, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected live event")
+	}
+	if ev.Event != "file_changed" {
+		t.Fatalf("live event=%q, want file_changed", ev.Event)
+	}
+	var data ChangeEvent
+	json.Unmarshal([]byte(ev.Data), &data)
+	if data.Path != "/new.txt" || data.Actor != "remote-actor" {
+		t.Errorf("live event data: %+v", data)
+	}
+}
+
+func TestSSEEndpointMethodNotAllowed(t *testing.T) {
+	srv := &Server{events: newEventBuses()}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/events", nil)
+	srv.handleEvents(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status=%d, want 405", w.Code)
+	}
+}
+
+func TestSSEEndpointBadSince(t *testing.T) {
+	srv := &Server{events: newEventBuses()}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/v1/events?since=abc", nil)
+	srv.handleEvents(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary

Add Server-Sent Events endpoint for real-time filesystem change notifications, enabling multi-client FUSE cache invalidation.

**Server:**
- `EventBus`: per-tenant in-memory ring buffer (10k events) with monotonic sequence counter and pub/sub fan-out
- SSE endpoint: `GET /v1/events?since={seq}` with replay, live streaming, and 30s heartbeat
- Mutation hooks in all write/delete/rename/copy/mkdir/upload complete handlers (both v1 and v2)
- Deterministic since/reset contract: `since=0` → reset, gap → reset, server restart → reset

**Client:**
- `WatchEvents` SDK with exponential backoff reconnect
- `X-Dat9-Actor` header injection for per-mount self-filtering
- `SetActor`/`BaseURL`/`APIKey` helpers on Client

**FUSE:**
- `SSEWatcher` background goroutine using `client.WatchEvents`
- Targeted invalidation for `file_changed` events (readCache + dirCache + kernel InodeNotify/EntryNotify)
- Full cache invalidation on reset while **preserving InodeToPath identity** (stale but resolvable — never bulk-wiped)
- Per-mount actor ID generation for self-filtering

**Design constraints (P0, single-instance):**
- In-memory event bus — not persisted or replicated across processes
- Revision resets on server restart (clients receive `reset` event)

Closes #150

## Test plan
- [x] `TestEventBusPublishAndSeq` — seq monotonicity
- [x] `TestEventBusSince0ReturnsNotOK` — since=0 → reset contract
- [x] `TestEventBusReplay` — partial replay from ring
- [x] `TestEventBusCaughtUp` — no replay when caught up
- [x] `TestEventBusRingOverflow` — old seqs correctly evicted
- [x] `TestEventBusFutureSeq` — server restart detection
- [x] `TestEventBusConcurrentPublish` — thread safety
- [x] `TestSSEEndpointSince0SendsReset` — SSE initial sync reset
- [x] `TestSSEEndpointReplay` — SSE event replay
- [x] `TestSSEEndpointLiveEvent` — live event delivery
- [x] `TestSSEEndpointMethodNotAllowed` — 405 for POST
- [x] `TestSSEEndpointBadSince` — 400 for invalid since
- [x] `TestSSEWatcherResetPreservesInodes` — live inodes survive reset (regression test for @adversary-1's blocker)
- [x] `TestSSEWatcherHandleChangeInvalidatesCache` — targeted cache invalidation
- [x] `TestSSEWatcherSelfFilterSkipsOwnEvents` — self-filtering by actor
- [x] `TestSSEWatcherHandleEventReset` — reset clears caches
- [x] `TestSSEWatcherHeartbeatDoesNotReset` — heartbeats don't trigger reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time file change stream (SSE) with reconnect/backoff and heartbeat.
  * Per-mount identity so mounts ignore their own changes.
  * Server emits events for writes, deletes, copies, renames, mkdirs and upload completions.

* **Behavior**
  * Automatic selective cache invalidation on remote changes and full cache reset when sync gaps occur.
  * Mount startup/shutdown manages SSE lifecycle and logs the mount actor id.

* **Tests**
  * Added unit and integration tests covering SSE replay, live delivery, reconnection, self-filtering and cache effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->