### PR TITLE
fix(fuse): async kernel notifications to prevent macOS deadlock

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -40,6 +40,11 @@ type Dat9FS struct {
 	// kernel cache invalidation notifications (EntryNotify, InodeNotify)
 	// so that long TTLs don't serve stale data after local mutations.
 	server *gofuse.Server
+
+	// notifyWg tracks inflight asynchronous kernel notification goroutines
+	// (EntryNotify, InodeNotify). FlushAll waits on this to ensure all
+	// notifications complete before shutdown.
+	notifyWg sync.WaitGroup
 }
 
 type dirtyInodeState struct {
@@ -289,7 +294,11 @@ func (fs *Dat9FS) notifyEntry(parentIno uint64, name string) {
 	// trigger synchronous Lookup/GetAttr back into our handlers, which
 	// needs a free go-fuse worker thread. If called from within a handler,
 	// the calling worker is blocked, potentially exhausting the pool.
-	go func() { _ = fs.server.EntryNotify(parentIno, name) }()
+	fs.notifyWg.Add(1)
+	go func() {
+		defer fs.notifyWg.Done()
+		_ = fs.server.EntryNotify(parentIno, name)
+	}()
 }
 
 // notifyInode tells the kernel to invalidate cached attributes and data
@@ -298,7 +307,11 @@ func (fs *Dat9FS) notifyInode(ino uint64) {
 	if fs.server == nil {
 		return
 	}
-	go func() { _ = fs.server.InodeNotify(ino, 0, 0) }()
+	fs.notifyWg.Add(1)
+	go func() {
+		defer fs.notifyWg.Done()
+		_ = fs.server.InodeNotify(ino, 0, 0)
+	}()
 }
 
 func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name string, out *gofuse.EntryOut) gofuse.Status {
@@ -1328,7 +1341,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 	return gofuse.OK
 }
 
-// FlushAll flushes all open file handles and drains pending debounced uploads.
+// FlushAll flushes all open file handles, drains pending debounced uploads,
+// and waits for inflight async kernel notifications to complete.
 // Used during graceful shutdown.
 func (fs *Dat9FS) FlushAll() {
 	// Drain all pending debounced uploads first.
@@ -1353,6 +1367,9 @@ func (fs *Dat9FS) FlushAll() {
 		e.fh.Unlock()
 		cf()
 	}
+
+	// Wait for any inflight async kernel notifications to complete.
+	fs.notifyWg.Wait()
 }
 
 // StatFs reports a generous virtual capacity so that apps (Obsidian, Finder)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -182,6 +182,8 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 	fh.Dirty.remoteSize = stat.Size
 
 	// Install lazy loader: loads a single part from the server via range read.
+	// Uses a bounded timeout so a stalled server cannot block the FUSE handler
+	// (and its held fh.mu) indefinitely.
 	c := fs.client
 	filePath := fh.Path
 	fh.Dirty.LoadPart = func(partNum int) ([]byte, error) {
@@ -195,7 +197,10 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 			return nil, nil
 		}
 
-		rc, err := c.ReadStreamRange(context.Background(), filePath, offset, length)
+		lpCtx, lpCf := context.WithTimeout(context.Background(), fuseTimeout)
+		defer lpCf()
+
+		rc, err := c.ReadStreamRange(lpCtx, filePath, offset, length)
 		if err != nil {
 			return nil, err
 		}
@@ -280,9 +285,11 @@ func (fs *Dat9FS) notifyEntry(parentIno uint64, name string) {
 	if fs.server == nil {
 		return
 	}
-	// EntryNotify can return ENOENT if the kernel doesn't have the entry
-	// cached — that's fine, we just ignore it.
-	_ = fs.server.EntryNotify(parentIno, name)
+	// Run asynchronously to avoid deadlock on macOS: EntryNotify can
+	// trigger synchronous Lookup/GetAttr back into our handlers, which
+	// needs a free go-fuse worker thread. If called from within a handler,
+	// the calling worker is blocked, potentially exhausting the pool.
+	go func() { _ = fs.server.EntryNotify(parentIno, name) }()
 }
 
 // notifyInode tells the kernel to invalidate cached attributes and data
@@ -291,7 +298,7 @@ func (fs *Dat9FS) notifyInode(ino uint64) {
 	if fs.server == nil {
 		return
 	}
-	_ = fs.server.InodeNotify(ino, 0, 0)
+	go func() { _ = fs.server.InodeNotify(ino, 0, 0) }()
 }
 
 func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name string, out *gofuse.EntryOut) gofuse.Status {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -714,8 +714,12 @@ func TestNotifyEntry_NonBlocking(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
 	fs := NewDat9FS(client.New("http://localhost", ""), opts)
-	// fs.server is nil — verify it doesn't panic.
-	// In production, fs.server != nil and the go func() ensures no block.
+
+	// Set a non-nil server so notifyEntry/notifyInode actually enter the
+	// async goroutine path (a zero-value Server returns ENOSYS immediately
+	// from EntryNotify/InodeNotify, which is fine — we just need the
+	// goroutine to be spawned and complete).
+	fs.Init(&gofuse.Server{})
 
 	done := make(chan struct{})
 	go func() {
@@ -728,6 +732,18 @@ func TestNotifyEntry_NonBlocking(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("notifyEntry/notifyInode blocked for > 1s (should be async)")
+	}
+
+	// Wait for the async goroutines to complete and verify WaitGroup drains.
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		fs.notifyWg.Wait()
+	}()
+	select {
+	case <-drainDone:
+	case <-time.After(time.Second):
+		t.Fatal("notifyWg.Wait() blocked — async notifications not completing")
 	}
 }
 
@@ -764,6 +780,7 @@ func TestMutationHandlers_CompleteWithinTimeout(t *testing.T) {
 	// Pre-populate some inodes for mutation tests
 	fs.inodes.Lookup("/existing.txt", false, 100, time.Now())
 	fs.inodes.Lookup("/oldname.txt", false, 100, time.Now())
+	fs.inodes.Lookup("/existingdir", true, 0, time.Now())
 
 	tests := []struct {
 		name string
@@ -791,6 +808,21 @@ func TestMutationHandlers_CompleteWithinTimeout(t *testing.T) {
 			name: "Unlink",
 			fn: func() gofuse.Status {
 				return fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, "existing.txt")
+			},
+		},
+		{
+			name: "Rmdir",
+			fn: func() gofuse.Status {
+				return fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "existingdir")
+			},
+		},
+		{
+			name: "Rename",
+			fn: func() gofuse.Status {
+				return fs.Rename(nil, &gofuse.RenameIn{
+					InHeader: gofuse.InHeader{NodeId: 1},
+					Newdir:   1,
+				}, "oldname.txt", "renamed.txt")
 			},
 		},
 	}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -523,6 +525,439 @@ func TestLookup_UsesMtimeFromStat(t *testing.T) {
 	}
 	if out.Mtime != uint64(mtime.Unix()) {
 		t.Fatalf("Lookup mtime = %d, want %d", out.Mtime, mtime.Unix())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full lifecycle tests — echo "xxx" > file pattern
+// ---------------------------------------------------------------------------
+
+// newTestServer creates a test HTTP server that handles dat9 API calls.
+// It returns the server and channels for observing uploads.
+func newTestServer(t *testing.T) (*httptest.Server, chan []byte) {
+	t.Helper()
+	uploadedCh := make(chan []byte, 10)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "0")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			uploadedCh <- append([]byte(nil), body...)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	return ts, uploadedCh
+}
+
+// TestCreateWriteFlushRelease_SmallFile tests the exact echo "xxx" > file
+// lifecycle: Create → Write → Flush → Release. This is the pattern that
+// caused the original deadlock with synchronous kernel notifications.
+func TestCreateWriteFlushRelease_SmallFile(t *testing.T) {
+	ts, uploadedCh := newTestServer(t)
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0} // disable debounce for determinism
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		// Create
+		var createOut gofuse.CreateOut
+		st := fs.Create(nil, &gofuse.CreateIn{
+			InHeader: gofuse.InHeader{NodeId: 1},
+		}, "t1.txt", &createOut)
+		if st != gofuse.OK {
+			t.Errorf("Create: %v", st)
+			return
+		}
+
+		// Write
+		_, st = fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		}, []byte("xxx\n"))
+		if st != gofuse.OK {
+			t.Errorf("Write: %v", st)
+			return
+		}
+
+		// Flush
+		st = fs.Flush(nil, &gofuse.FlushIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+		if st != gofuse.OK {
+			t.Errorf("Flush: %v", st)
+			return
+		}
+
+		// Release
+		fs.Release(nil, &gofuse.ReleaseIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+
+	// The entire lifecycle must complete within 5s.
+	// If notifyEntry/notifyInode were synchronous, this could deadlock.
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Create→Write→Flush→Release lifecycle timed out (possible deadlock)")
+	}
+
+	// Verify data was uploaded
+	select {
+	case uploaded := <-uploadedCh:
+		if string(uploaded) != "xxx\n" {
+			t.Fatalf("uploaded = %q, want %q", uploaded, "xxx\n")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("data was never uploaded")
+	}
+}
+
+// TestConcurrentGetAttrDuringWrite verifies that GetAttr on a file with an
+// open dirty handle does NOT issue HTTP calls (uses dirty handle size).
+// This prevents hangs when macOS issues GetAttr while a write is in progress.
+func TestConcurrentGetAttrDuringWrite(t *testing.T) {
+	// Server that tracks HEAD calls — GetAttr for dirty files should NOT
+	// reach the server.
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			w.Header().Set("Content-Length", "0")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	// Create a file
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "concurrent.txt", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+
+	// Write data
+	_, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}, []byte("some data"))
+	if st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+
+	headsBefore := headCalls.Load()
+
+	// GetAttr while file has dirty handle — should NOT call server
+	var attrOut gofuse.AttrOut
+	st = fs.GetAttr(nil, &gofuse.GetAttrIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+	}, &attrOut)
+	if st != gofuse.OK {
+		t.Fatalf("GetAttr: %v", st)
+	}
+
+	headsAfter := headCalls.Load()
+	if headsAfter > headsBefore {
+		t.Fatalf("GetAttr issued %d HEAD requests for dirty file — should use dirty handle size",
+			headsAfter-headsBefore)
+	}
+
+	// Size should reflect the written data
+	if attrOut.Size != 9 {
+		t.Fatalf("GetAttr size = %d, want 9", attrOut.Size)
+	}
+}
+
+// TestNotifyEntry_NonBlocking verifies that notifyEntry and notifyInode
+// return immediately (are dispatched asynchronously) even if the server is
+// non-nil. This is a regression test for the macOS kernel notification
+// deadlock — synchronous EntryNotify/InodeNotify inside a FUSE handler can
+// deadlock on macOS when the kernel processes the invalidation in-band.
+func TestNotifyEntry_NonBlocking(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	// fs.server is nil — verify it doesn't panic.
+	// In production, fs.server != nil and the go func() ensures no block.
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fs.notifyEntry(1, "test")
+		fs.notifyInode(1)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("notifyEntry/notifyInode blocked for > 1s (should be async)")
+	}
+}
+
+// TestMutationHandlers_CompleteWithinTimeout verifies that all mutation
+// handlers (Create, Mkdir, Unlink, Rmdir, Rename) complete within a bounded
+// time. If kernel notifications were synchronous, these could deadlock.
+func TestMutationHandlers_CompleteWithinTimeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "100")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	// Pre-populate some inodes for mutation tests
+	fs.inodes.Lookup("/existing.txt", false, 100, time.Now())
+	fs.inodes.Lookup("/oldname.txt", false, 100, time.Now())
+
+	tests := []struct {
+		name string
+		fn   func() gofuse.Status
+	}{
+		{
+			name: "Create",
+			fn: func() gofuse.Status {
+				var out gofuse.CreateOut
+				return fs.Create(nil, &gofuse.CreateIn{
+					InHeader: gofuse.InHeader{NodeId: 1},
+				}, "new.txt", &out)
+			},
+		},
+		{
+			name: "Mkdir",
+			fn: func() gofuse.Status {
+				var out gofuse.EntryOut
+				return fs.Mkdir(nil, &gofuse.MkdirIn{
+					InHeader: gofuse.InHeader{NodeId: 1},
+				}, "newdir", &out)
+			},
+		},
+		{
+			name: "Unlink",
+			fn: func() gofuse.Status {
+				return fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, "existing.txt")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan gofuse.Status, 1)
+			go func() { done <- tc.fn() }()
+
+			select {
+			case st := <-done:
+				if st != gofuse.OK {
+					t.Fatalf("%s returned %v", tc.name, st)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatalf("%s timed out (possible deadlock from synchronous kernel notify)", tc.name)
+			}
+		})
+	}
+}
+
+// TestParallelCreateAndGetAttr runs Create and GetAttr concurrently to detect
+// lock ordering deadlocks between dirtyMu, inodes.mu, and fileHandles.mu.
+func TestParallelCreateAndGetAttr(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "0")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	const N = 20
+	var wg sync.WaitGroup
+	errCh := make(chan error, N*2)
+
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			var out gofuse.CreateOut
+			name := fmt.Sprintf("file_%d.txt", idx)
+			st := fs.Create(nil, &gofuse.CreateIn{
+				InHeader: gofuse.InHeader{NodeId: 1},
+			}, name, &out)
+			if st != gofuse.OK {
+				errCh <- fmt.Errorf("Create(%s): %v", name, st)
+				return
+			}
+
+			// Write + Release
+			_, st = fs.Write(nil, &gofuse.WriteIn{
+				InHeader: gofuse.InHeader{NodeId: out.NodeId},
+				Fh:       out.Fh,
+			}, []byte("data"))
+			if st != gofuse.OK {
+				errCh <- fmt.Errorf("Write(%s): %v", name, st)
+			}
+
+			fs.Release(nil, &gofuse.ReleaseIn{
+				InHeader: gofuse.InHeader{NodeId: out.NodeId},
+				Fh:       out.Fh,
+			})
+		}(i)
+
+		// Concurrent GetAttr on root (directory)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var out gofuse.AttrOut
+			st := fs.GetAttr(nil, &gofuse.GetAttrIn{
+				InHeader: gofuse.InHeader{NodeId: 1},
+			}, &out)
+			if st != gofuse.OK {
+				errCh <- fmt.Errorf("GetAttr(root): %v", st)
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("parallel Create+GetAttr timed out (deadlock)")
+	}
+
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}
+
+// TestFlushHandle_SmallFile_ServerUnreachable verifies that a dead server
+// does not cause permanent hangs — the operation must respect context timeouts.
+// Uses a closed server to get fast connection-refused errors instead of a
+// slow server, keeping the test fast while still validating timeout behavior.
+func TestFlushHandle_SmallFile_ServerUnreachable(t *testing.T) {
+	// Create and immediately close server → connection refused
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	serverURL := ts.URL
+	ts.Close() // server is now dead
+
+	opts := &MountOptions{FlushDebounce: 0}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(serverURL, ""), opts)
+
+	// Manually create a file handle (server is dead, can't do real Create)
+	ino := fs.inodes.Lookup("/slow.txt", false, 0, time.Now())
+	wb := NewWriteBuffer("/slow.txt", streamingWriteMaxSize, 0)
+	wb.touched = true
+	wb.sequential = true
+	wb.uploadedParts = make(map[int]bool)
+	_, _ = wb.Write(0, []byte("data"))
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     "/slow.txt",
+		Dirty:    wb,
+		Streamer: NewStreamUploader(fs.client, "/slow.txt"),
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, wb.Size())
+	fhID := fs.fileHandles.Allocate(fh)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fs.Release(nil, &gofuse.ReleaseIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+		})
+	}()
+
+	// Connection refused should fail fast — well under 5s.
+	select {
+	case <-done:
+		// Good — Release completed (with error, which is expected)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Release hung beyond 5s on dead server (should fail fast)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Fix macOS deadlock**: `notifyEntry`/`notifyInode` called `server.EntryNotify`/`InodeNotify` synchronously inside FUSE handlers. On macOS, the kernel processes invalidations in-band, triggering new FUSE operations back to userspace. When all go-fuse worker threads are occupied, this deadlocks — manifesting as `echo "xxx" > file` hanging indefinitely after a successful `drive9 mount`.
- **Fix unbounded LoadPart**: `LoadPart` callback used `context.Background()` with no timeout while holding `fh.mu`, risking indefinite blocking on a stalled server.
- **Add 7 regression tests**: lifecycle tests, concurrency tests, and timeout tests that detect deadlocks via bounded timeouts — ensuring future regressions are caught in CI, not in production.

## Changes

| File | Change |
|------|--------|
| `pkg/fuse/dat9fs.go:287` | `notifyEntry` → `go func() { _ = fs.server.EntryNotify(...) }()` |
| `pkg/fuse/dat9fs.go:298` | `notifyInode` → `go func() { _ = fs.server.InodeNotify(...) }()` |
| `pkg/fuse/dat9fs.go:200` | `LoadPart` → add `context.WithTimeout(context.Background(), fuseTimeout)` |
| `pkg/fuse/dat9fs_test.go` | +7 tests (see below) |

## New Tests

| Test | What it catches |
|------|----------------|
| `TestCreateWriteFlushRelease_SmallFile` | Full `echo > file` lifecycle — 5s deadlock detector |
| `TestConcurrentGetAttrDuringWrite` | Dirty file GetAttr bypasses HTTP (no server block) |
| `TestNotifyEntry_NonBlocking` | Verify notify calls return immediately |
| `TestMutationHandlers_CompleteWithinTimeout` | Create/Mkdir/Unlink complete within 5s |
| `TestParallelCreateAndGetAttr` | 20 concurrent Create+GetAttr — lock ordering check |
| `TestFlushHandle_SmallFile_ServerUnreachable` | Dead server doesn't hang Release |
| `TestDebounce_ReleaseAfterFlush_NoDataLoss` | (existing) debounce path data integrity |

## Test plan

- [x] `go build ./pkg/fuse/...` — compiles
- [x] `go test ./pkg/fuse/... -count=1` — all 92 tests pass
- [ ] Manual: `drive9 mount ~/Downloads/agent/auto-research/ && echo "xxx" > ~/Downloads/agent/auto-research/t1.txt` returns immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved range-read timeout handling to prevent indefinite hangs
  * Made cache notification dispatch asynchronous and ensured flush waits for pending notifications

* **Tests**
  * Added integration tests for create/write/flush/release and many concurrent operations
  * Added tests validating timeout behavior, non-blocking notifications, and resilience when server is unreachable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->