### PR TITLE
docs: improve Go SDK example with real endpoint and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,33 @@ drive9 umount /mnt/drive9
 ### Go SDK
 
 ```go
-c := client.New("http://localhost:9009", "")
-c.Write("/data/file.txt", []byte("hello"))
-data, _ := c.Read("/data/file.txt")
-entries, _ := c.List("/data/")
-c.Copy("/a.txt", "/b.txt")   // zero-copy
-c.Rename("/old", "/new")     // metadata-only
-c.Delete("/data/file.txt")
+import "github.com/mem9-ai/drive9/pkg/client"
+
+// Create client (get API key from 'drive9 create' or drive9.ai console)
+c := client.New("https://api.drive9.ai", "your-api-key")
+
+// Write file (auto-handles small/large files)
+if err := c.Write("/data/file.txt", []byte("hello")); err != nil {
+    log.Fatal(err)
+}
+
+// Read file
+data, err := c.Read("/data/file.txt")
+if err != nil {
+    log.Fatal(err)
+}
+
+// List directory
+entries, err := c.List("/data/")
+
+// Copy (zero-copy, metadata only)
+err = c.Copy("/a.txt", "/b.txt")
+
+// Rename (metadata only)
+err = c.Rename("/old.txt", "/new.txt")
+
+// Delete
+err = c.Delete("/data/file.txt")
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

Improves the Go SDK example in README to be more helpful for new users.

## Changes

- Update endpoint from localhost:9009 to https://api.drive9.ai
- Add proper import path (github.com/mem9-ai/drive9/pkg/client)
- Add error handling examples
- Clarify how to get API key (drive9 create or console)
- Add comments explaining each operation

## Before
Old example used localhost:9009 with no API key and no error handling.

## After
New example uses real endpoint, shows how to get API key, and includes proper error handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Go SDK example to demonstrate production-ready usage patterns with explicit error handling throughout
  * Changed client initialization from local development endpoint to cloud-based API endpoint configuration with required authentication
  * Improved file paths in example operations for consistency with production best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->