### PR TITLE
feat: Obsidian drive9 plugin Phase 1 — safe one-way push

### DIFF
--- a/obsidian-plugin/.gitignore
+++ b/obsidian-plugin/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+main.js

--- a/obsidian-plugin/esbuild.config.mjs
+++ b/obsidian-plugin/esbuild.config.mjs
@@ -1,0 +1,19 @@
+import esbuild from "esbuild";
+import process from "process";
+
+const prod = process.argv[2] === "production";
+
+esbuild
+  .build({
+    entryPoints: ["src/main.ts"],
+    bundle: true,
+    external: ["obsidian"],
+    format: "cjs",
+    target: "es2020",
+    logLevel: "info",
+    sourcemap: prod ? false : "inline",
+    treeShaking: true,
+    outfile: "main.js",
+    minify: prod,
+  })
+  .catch(() => process.exit(1));

--- a/obsidian-plugin/manifest.json
+++ b/obsidian-plugin/manifest.json
@@ -1,0 +1,9 @@
+{
+  "id": "drive9",
+  "name": "drive9",
+  "version": "0.1.0",
+  "minAppVersion": "1.5.0",
+  "description": "Sync your vault to drive9 — semantic search & AI-agent accessibility for your notes.",
+  "author": "mem9-ai",
+  "isDesktopOnly": false
+}

--- a/obsidian-plugin/package.json
+++ b/obsidian-plugin/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "obsidian-drive9",
+  "version": "0.1.0",
+  "description": "Sync your Obsidian vault to drive9 — semantic search & AI-agent accessibility",
+  "main": "main.js",
+  "scripts": {
+    "dev": "node esbuild.config.mjs",
+    "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "typecheck": "tsc -noEmit -skipLibCheck"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "esbuild": "^0.21.0",
+    "obsidian": "^1.5.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/obsidian-plugin/src/client.ts
+++ b/obsidian-plugin/src/client.ts
@@ -18,16 +18,18 @@ export class Drive9Client {
 
   /** Test connectivity. Throws on failure. */
   async ping(): Promise<void> {
-    await this.list("/");
+    await this.request("GET", "/healthz");
   }
 
   /** HEAD — get file/dir metadata including revision. */
   async stat(path: string): Promise<StatResult> {
-    // requestUrl doesn't support HEAD directly, use GET with a query param
-    // to get metadata. We'll use list on parent + filter, or just GET the file
-    // and use headers. For now, use a lightweight approach.
-    const resp = await this.request("GET", `/v1/fs/${encodePath(path)}?stat=1`);
-    return resp.json as StatResult;
+    const resp = await this.request("HEAD", `/v1/fs/${encodePath(path)}`);
+    return {
+      size: parseInt(resp.headers["content-length"] ?? "0", 10),
+      isDir: resp.headers["x-dat9-isdir"] === "true",
+      revision: parseInt(resp.headers["x-dat9-revision"] ?? "0", 10),
+      mtime: parseInt(resp.headers["x-dat9-mtime"] ?? "0", 10),
+    };
   }
 
   /** GET — read file content. */
@@ -67,9 +69,8 @@ export class Drive9Client {
 
   /** POST ?rename — rename/move a file. */
   async rename(oldPath: string, newPath: string): Promise<void> {
-    await this.request("POST", `/v1/fs/${encodePath(oldPath)}?rename`, {
-      body: JSON.stringify({ destination: newPath }),
-      headers: { "Content-Type": "application/json" },
+    await this.request("POST", `/v1/fs/${encodePath(newPath)}?rename`, {
+      headers: { "X-Dat9-Rename-Source": oldPath },
     });
   }
 
@@ -151,9 +152,14 @@ export class Drive9Client {
     const resp = await requestUrl(params);
 
     if (resp.status >= 400) {
-      const msg = typeof resp.json?.error === "string"
-        ? resp.json.error
-        : `HTTP ${resp.status}`;
+      let msg = `HTTP ${resp.status}`;
+      try {
+        if (typeof resp.json?.error === "string") {
+          msg = resp.json.error;
+        }
+      } catch {
+        // HEAD responses have no body — json access may throw.
+      }
       throw new Drive9Error(msg, resp.status);
     }
 

--- a/obsidian-plugin/src/client.ts
+++ b/obsidian-plugin/src/client.ts
@@ -1,0 +1,165 @@
+import { requestUrl, RequestUrlParam } from "obsidian";
+import type { StatResult, FileInfo } from "./types";
+
+/**
+ * Drive9Client wraps the drive9 REST API using Obsidian's requestUrl
+ * (bypasses CORS, works on mobile).
+ */
+export class Drive9Client {
+  constructor(
+    private serverUrl: string,
+    private apiKey: string,
+  ) {}
+
+  updateConfig(serverUrl: string, apiKey: string): void {
+    this.serverUrl = serverUrl;
+    this.apiKey = apiKey;
+  }
+
+  /** Test connectivity. Throws on failure. */
+  async ping(): Promise<void> {
+    await this.request("GET", "/v1/fs/");
+  }
+
+  /** HEAD — get file/dir metadata including revision. */
+  async stat(path: string): Promise<StatResult> {
+    // requestUrl doesn't support HEAD directly, use GET with a query param
+    // to get metadata. We'll use list on parent + filter, or just GET the file
+    // and use headers. For now, use a lightweight approach.
+    const resp = await this.request("GET", `/v1/fs/${encodePath(path)}?stat=1`);
+    return resp.json as StatResult;
+  }
+
+  /** GET — read file content. */
+  async read(path: string): Promise<ArrayBuffer> {
+    const resp = await this.request("GET", `/v1/fs/${encodePath(path)}`);
+    return resp.arrayBuffer;
+  }
+
+  /** PUT — write file content with optional CAS revision check. */
+  async write(
+    path: string,
+    data: ArrayBuffer,
+    expectedRevision?: number,
+  ): Promise<{ revision: number }> {
+    const headers: Record<string, string> = {};
+    if (expectedRevision !== undefined) {
+      headers["X-Dat9-Expected-Revision"] = String(expectedRevision);
+    }
+    const resp = await this.request("PUT", `/v1/fs/${encodePath(path)}`, {
+      body: data,
+      headers,
+    });
+    return resp.json as { revision: number };
+  }
+
+  /** DELETE — remove a file. */
+  async delete(path: string): Promise<void> {
+    await this.request("DELETE", `/v1/fs/${encodePath(path)}`);
+  }
+
+  /** POST ?rename — rename/move a file. */
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    await this.request("POST", `/v1/fs/${encodePath(oldPath)}?rename`, {
+      body: JSON.stringify({ destination: newPath }),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  /** POST ?mkdir — create a directory. */
+  async mkdir(path: string): Promise<void> {
+    await this.request("POST", `/v1/fs/${encodePath(path)}?mkdir`);
+  }
+
+  /** GET ?list=1 — list directory contents. */
+  async list(path: string): Promise<FileInfo[]> {
+    const resp = await this.request("GET", `/v1/fs/${encodePath(path)}?list=1`);
+    const data = resp.json;
+    // API may return { entries: [...] } or just an array
+    if (Array.isArray(data)) return data as FileInfo[];
+    if (data && Array.isArray((data as Record<string, unknown>).entries)) {
+      return (data as Record<string, unknown>).entries as FileInfo[];
+    }
+    return [];
+  }
+
+  /**
+   * Recursively list all files under a path.
+   * Returns flat list of relative paths (no leading slash).
+   */
+  async listRecursive(basePath: string): Promise<FileInfo[]> {
+    const all: FileInfo[] = [];
+    const queue = [basePath];
+
+    while (queue.length > 0) {
+      const dir = queue.pop()!;
+      let entries: FileInfo[];
+      try {
+        entries = await this.list(dir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        const fullPath = dir === "/" || dir === ""
+          ? entry.name
+          : `${dir}/${entry.name}`;
+        if (entry.isDir) {
+          queue.push(fullPath);
+        } else {
+          all.push({ ...entry, name: fullPath });
+        }
+      }
+    }
+
+    return all;
+  }
+
+  private async request(
+    method: string,
+    urlPath: string,
+    opts?: { body?: string | ArrayBuffer; headers?: Record<string, string> },
+  ) {
+    const url = `${this.serverUrl}${urlPath}`;
+    const params: RequestUrlParam = {
+      url,
+      method,
+      headers: {
+        ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
+        ...(opts?.headers ?? {}),
+      },
+      throw: false,
+    };
+    if (opts?.body !== undefined) {
+      params.body = opts.body;
+    }
+
+    const resp = await requestUrl(params);
+
+    if (resp.status >= 400) {
+      const msg = typeof resp.json?.error === "string"
+        ? resp.json.error
+        : `HTTP ${resp.status}`;
+      throw new Drive9Error(msg, resp.status);
+    }
+
+    return resp;
+  }
+}
+
+export class Drive9Error extends Error {
+  constructor(
+    message: string,
+    public status: number,
+  ) {
+    super(message);
+    this.name = "Drive9Error";
+  }
+}
+
+/** Encode path segments for URL (don't encode slashes). */
+function encodePath(path: string): string {
+  return path
+    .split("/")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+}

--- a/obsidian-plugin/src/client.ts
+++ b/obsidian-plugin/src/client.ts
@@ -18,7 +18,7 @@ export class Drive9Client {
 
   /** Test connectivity. Throws on failure. */
   async ping(): Promise<void> {
-    await this.request("GET", "/v1/fs/");
+    await this.list("/");
   }
 
   /** HEAD — get file/dir metadata including revision. */
@@ -36,7 +36,11 @@ export class Drive9Client {
     return resp.arrayBuffer;
   }
 
-  /** PUT — write file content with optional CAS revision check. */
+  /**
+   * PUT — write file content with optional CAS revision check.
+   * Server returns {"status":"ok"} without revision, so we stat()
+   * after write to get the actual revision for future CAS.
+   */
   async write(
     path: string,
     data: ArrayBuffer,
@@ -46,11 +50,14 @@ export class Drive9Client {
     if (expectedRevision !== undefined) {
       headers["X-Dat9-Expected-Revision"] = String(expectedRevision);
     }
-    const resp = await this.request("PUT", `/v1/fs/${encodePath(path)}`, {
+    await this.request("PUT", `/v1/fs/${encodePath(path)}`, {
       body: data,
       headers,
     });
-    return resp.json as { revision: number };
+    // Server does not return revision in write response.
+    // Stat to get the actual revision for future CAS writes.
+    const st = await this.stat(path);
+    return { revision: st.revision };
   }
 
   /** DELETE — remove a file. */
@@ -86,25 +93,33 @@ export class Drive9Client {
   /**
    * Recursively list all files under a path.
    * Returns flat list of relative paths (no leading slash).
+   *
+   * Root list errors are propagated (auth/network failures must not
+   * be silently treated as "remote empty"). Only subdirectory list
+   * errors are swallowed.
    */
   async listRecursive(basePath: string): Promise<FileInfo[]> {
+    // Root list must succeed — propagate errors to caller.
+    const rootEntries = await this.list(basePath);
+
     const all: FileInfo[] = [];
-    const queue = [basePath];
+    const queue: Array<{ dir: string; entries: FileInfo[] }> = [
+      { dir: basePath, entries: rootEntries },
+    ];
 
     while (queue.length > 0) {
-      const dir = queue.pop()!;
-      let entries: FileInfo[];
-      try {
-        entries = await this.list(dir);
-      } catch {
-        continue;
-      }
+      const { dir, entries } = queue.pop()!;
       for (const entry of entries) {
         const fullPath = dir === "/" || dir === ""
           ? entry.name
           : `${dir}/${entry.name}`;
         if (entry.isDir) {
-          queue.push(fullPath);
+          try {
+            const subEntries = await this.list(fullPath);
+            queue.push({ dir: fullPath, entries: subEntries });
+          } catch {
+            // Subdirectory list failures are non-fatal.
+          }
         } else {
           all.push({ ...entry, name: fullPath });
         }

--- a/obsidian-plugin/src/client.ts
+++ b/obsidian-plugin/src/client.ts
@@ -16,9 +16,9 @@ export class Drive9Client {
     this.apiKey = apiKey;
   }
 
-  /** Test connectivity. Throws on failure. */
+  /** Test connectivity and auth. Throws on failure. */
   async ping(): Promise<void> {
-    await this.request("GET", "/healthz");
+    await this.list("/");
   }
 
   /** HEAD — get file/dir metadata including revision. */

--- a/obsidian-plugin/src/client.ts
+++ b/obsidian-plugin/src/client.ts
@@ -42,24 +42,33 @@ export class Drive9Client {
    * PUT — write file content with optional CAS revision check.
    * Server returns {"status":"ok"} without revision, so we stat()
    * after write to get the actual revision for future CAS.
+   *
+   * Returns { revision: number } on full success, or
+   * { revision: null, writeSucceeded: true } if PUT succeeded but
+   * post-write stat failed (caller must not treat this as a write failure).
    */
   async write(
     path: string,
     data: ArrayBuffer,
-    expectedRevision?: number,
-  ): Promise<{ revision: number }> {
+    expectedRevision?: number | null,
+  ): Promise<{ revision: number | null; writeSucceeded: boolean }> {
     const headers: Record<string, string> = {};
-    if (expectedRevision !== undefined) {
+    if (expectedRevision !== undefined && expectedRevision !== null) {
       headers["X-Dat9-Expected-Revision"] = String(expectedRevision);
     }
     await this.request("PUT", `/v1/fs/${encodePath(path)}`, {
       body: data,
       headers,
     });
-    // Server does not return revision in write response.
-    // Stat to get the actual revision for future CAS writes.
-    const st = await this.stat(path);
-    return { revision: st.revision };
+    // PUT succeeded. Try to get the new revision for future CAS.
+    try {
+      const st = await this.stat(path);
+      return { revision: st.revision, writeSucceeded: true };
+    } catch {
+      // Post-write stat failed — write DID succeed on the server.
+      // Caller must handle this as "committed but revision unknown".
+      return { revision: null, writeSucceeded: true };
+    }
   }
 
   /** DELETE — remove a file. */

--- a/obsidian-plugin/src/first-run.ts
+++ b/obsidian-plugin/src/first-run.ts
@@ -72,25 +72,17 @@ export async function runFirstRunReconciliation(
   // Scenario 4: Both have content → reconcile.
   const onlyLocal: string[] = [];
   const onlyRemote: string[] = [];
-  const bothDifferent: string[] = [];
+  const bothPresent: string[] = []; // exists on both sides — always conflict without checksum
   const states: Record<string, SyncState> = {};
 
-  for (const [path, file] of localFiles) {
+  for (const [path] of localFiles) {
     const remote = remoteFiles.get(path);
     if (!remote) {
       onlyLocal.push(path);
-    } else if (file.stat.size !== remote.size) {
-      bothDifferent.push(path);
     } else {
-      // Same size — treat as synced (best effort without checksum).
-      states[path] = {
-        path,
-        localMtime: file.stat.mtime,
-        localSize: file.stat.size,
-        remoteRevision: 0, // unknown until stat()
-        syncedAt: Date.now(),
-        status: "synced",
-      };
+      // Without checksum, we cannot prove content is identical even if
+      // size matches. Mark as conflict per stop-and-ask safety invariant.
+      bothPresent.push(path);
     }
   }
 
@@ -100,23 +92,22 @@ export async function runFirstRunReconciliation(
     }
   }
 
-  // If there are conflicts (both have different content), stop and ask.
-  if (bothDifferent.length > 0) {
+  if (bothPresent.length > 0) {
     const msg = [
-      `Found ${bothDifferent.length} file(s) with different content on both sides.`,
+      `Found ${bothPresent.length} file(s) that exist on both sides.`,
       "",
-      bothDifferent.slice(0, 10).join("\n"),
-      bothDifferent.length > 10 ? `...and ${bothDifferent.length - 10} more` : "",
+      bothPresent.slice(0, 10).join("\n"),
+      bothPresent.length > 10 ? `...and ${bothPresent.length - 10} more` : "",
       "",
-      "These files need manual resolution. Plugin will not auto-sync until resolved.",
-      "For now, only files unique to each side will be synced.",
+      "Without checksums, content equality cannot be verified.",
+      "These files are marked as conflicts until manually resolved.",
+      "Files unique to each side will be synced normally.",
     ].join("\n");
 
     new Notice(msg, 15000);
   }
 
-  // Mark only-local files for push, only-remote for pull,
-  // both-different as conflict.
+  // Only-local files: push (no expectedRevision needed for new files).
   for (const path of onlyLocal) {
     const file = localFiles.get(path)!;
     states[path] = {
@@ -129,25 +120,36 @@ export async function runFirstRunReconciliation(
     };
   }
 
+  // Only-remote files: need real revision for future CAS.
   for (const path of onlyRemote) {
-    const remote = remoteFiles.get(path)!;
+    let revision = 0;
+    try {
+      const st = await client.stat(path);
+      revision = st.revision;
+    } catch { /* best effort */ }
     states[path] = {
       path,
       localMtime: 0,
       localSize: 0,
-      remoteRevision: 0,
+      remoteRevision: revision,
       syncedAt: 0,
       status: "remote_dirty",
     };
   }
 
-  for (const path of bothDifferent) {
+  // Both-present files: conflict. Seed revision for future resolution.
+  for (const path of bothPresent) {
     const file = localFiles.get(path)!;
+    let revision = 0;
+    try {
+      const st = await client.stat(path);
+      revision = st.revision;
+    } catch { /* best effort */ }
     states[path] = {
       path,
       localMtime: file.stat.mtime,
       localSize: file.stat.size,
-      remoteRevision: 0,
+      remoteRevision: revision,
       syncedAt: 0,
       status: "conflict",
     };

--- a/obsidian-plugin/src/first-run.ts
+++ b/obsidian-plugin/src/first-run.ts
@@ -122,11 +122,11 @@ export async function runFirstRunReconciliation(
 
   // Only-remote files: need real revision for future CAS.
   for (const path of onlyRemote) {
-    let revision = 0;
+    let revision: number | null = null;
     try {
       const st = await client.stat(path);
       revision = st.revision;
-    } catch { /* best effort */ }
+    } catch { /* stat failed — revision stays null (unknown) */ }
     states[path] = {
       path,
       localMtime: 0,
@@ -140,11 +140,11 @@ export async function runFirstRunReconciliation(
   // Both-present files: conflict. Seed revision for future resolution.
   for (const path of bothPresent) {
     const file = localFiles.get(path)!;
-    let revision = 0;
+    let revision: number | null = null;
     try {
       const st = await client.stat(path);
       revision = st.revision;
-    } catch { /* best effort */ }
+    } catch { /* stat failed — revision stays null (unknown) */ }
     states[path] = {
       path,
       localMtime: file.stat.mtime,
@@ -192,20 +192,18 @@ export async function pullAllRemote(
 
     const file = vault.getAbstractFileByPath(entry.name);
     if (file instanceof TFile) {
-      let revision = 0;
+      let revision: number | null = null;
       try {
         const st = await client.stat(entry.name);
         revision = st.revision;
-      } catch {
-        // Best-effort; will be corrected on next successful push.
-      }
+      } catch { /* revision stays null */ }
       syncStates[entry.name] = {
         path: entry.name,
         localMtime: file.stat.mtime,
         localSize: file.stat.size,
         remoteRevision: revision,
         syncedAt: Date.now(),
-        status: "synced",
+        status: revision !== null ? "synced" : "needs_refresh",
       };
     }
     count++;

--- a/obsidian-plugin/src/first-run.ts
+++ b/obsidian-plugin/src/first-run.ts
@@ -192,11 +192,18 @@ export async function pullAllRemote(
 
     const file = vault.getAbstractFileByPath(entry.name);
     if (file instanceof TFile) {
+      let revision = 0;
+      try {
+        const st = await client.stat(entry.name);
+        revision = st.revision;
+      } catch {
+        // Best-effort; will be corrected on next successful push.
+      }
       syncStates[entry.name] = {
         path: entry.name,
         localMtime: file.stat.mtime,
         localSize: file.stat.size,
-        remoteRevision: 0,
+        remoteRevision: revision,
         syncedAt: Date.now(),
         status: "synced",
       };

--- a/obsidian-plugin/src/first-run.ts
+++ b/obsidian-plugin/src/first-run.ts
@@ -1,0 +1,252 @@
+import { Vault, TFile, Modal, App, Setting, Notice } from "obsidian";
+import { Drive9Client, Drive9Error } from "./client";
+import type { SyncState } from "./types";
+import { IgnoreMatcher } from "./ignore";
+
+export type FirstRunResult =
+  | { action: "push_all" }
+  | { action: "pull_all" }
+  | { action: "reconciled"; states: Record<string, SyncState> }
+  | { action: "cancelled" };
+
+/**
+ * Detect remote state and reconcile with local vault on first run.
+ * Safety invariant: never silent overwrite.
+ */
+export async function runFirstRunReconciliation(
+  app: App,
+  vault: Vault,
+  client: Drive9Client,
+  ignorePaths: string[],
+): Promise<FirstRunResult> {
+  const ignore = new IgnoreMatcher(ignorePaths);
+
+  // Gather local files.
+  const localFiles = new Map<string, TFile>();
+  for (const file of vault.getFiles()) {
+    if (!ignore.isIgnored(file.path)) {
+      localFiles.set(file.path, file);
+    }
+  }
+
+  // Gather remote files.
+  let remoteFiles: Map<string, { size: number; mtime: number }>;
+  try {
+    const entries = await client.listRecursive("/");
+    remoteFiles = new Map(
+      entries
+        .filter((e) => !ignore.isIgnored(e.name))
+        .map((e) => [e.name, { size: e.size, mtime: e.mtime }]),
+    );
+  } catch (e) {
+    if (e instanceof Drive9Error && e.status === 404) {
+      remoteFiles = new Map();
+    } else {
+      throw e;
+    }
+  }
+
+  const localEmpty = localFiles.size === 0;
+  const remoteEmpty = remoteFiles.size === 0;
+
+  // Scenario 1: Remote empty, local has content → push all.
+  if (remoteEmpty && !localEmpty) {
+    return { action: "push_all" };
+  }
+
+  // Scenario 2: Remote has content, local empty → ask to pull.
+  if (!remoteEmpty && localEmpty) {
+    const confirmed = await askUser(
+      app,
+      "Download from drive9?",
+      `drive9 has ${remoteFiles.size} files. Download them to your vault?`,
+    );
+    return confirmed ? { action: "pull_all" } : { action: "cancelled" };
+  }
+
+  // Scenario 3: Both empty → nothing to do.
+  if (remoteEmpty && localEmpty) {
+    return { action: "reconciled", states: {} };
+  }
+
+  // Scenario 4: Both have content → reconcile.
+  const onlyLocal: string[] = [];
+  const onlyRemote: string[] = [];
+  const bothDifferent: string[] = [];
+  const states: Record<string, SyncState> = {};
+
+  for (const [path, file] of localFiles) {
+    const remote = remoteFiles.get(path);
+    if (!remote) {
+      onlyLocal.push(path);
+    } else if (file.stat.size !== remote.size) {
+      bothDifferent.push(path);
+    } else {
+      // Same size — treat as synced (best effort without checksum).
+      states[path] = {
+        path,
+        localMtime: file.stat.mtime,
+        localSize: file.stat.size,
+        remoteRevision: 0, // unknown until stat()
+        syncedAt: Date.now(),
+        status: "synced",
+      };
+    }
+  }
+
+  for (const path of remoteFiles.keys()) {
+    if (!localFiles.has(path)) {
+      onlyRemote.push(path);
+    }
+  }
+
+  // If there are conflicts (both have different content), stop and ask.
+  if (bothDifferent.length > 0) {
+    const msg = [
+      `Found ${bothDifferent.length} file(s) with different content on both sides.`,
+      "",
+      bothDifferent.slice(0, 10).join("\n"),
+      bothDifferent.length > 10 ? `...and ${bothDifferent.length - 10} more` : "",
+      "",
+      "These files need manual resolution. Plugin will not auto-sync until resolved.",
+      "For now, only files unique to each side will be synced.",
+    ].join("\n");
+
+    new Notice(msg, 15000);
+  }
+
+  // Mark only-local files for push, only-remote for pull,
+  // both-different as conflict.
+  for (const path of onlyLocal) {
+    const file = localFiles.get(path)!;
+    states[path] = {
+      path,
+      localMtime: file.stat.mtime,
+      localSize: file.stat.size,
+      remoteRevision: 0,
+      syncedAt: 0,
+      status: "local_dirty",
+    };
+  }
+
+  for (const path of onlyRemote) {
+    const remote = remoteFiles.get(path)!;
+    states[path] = {
+      path,
+      localMtime: 0,
+      localSize: 0,
+      remoteRevision: 0,
+      syncedAt: 0,
+      status: "remote_dirty",
+    };
+  }
+
+  for (const path of bothDifferent) {
+    const file = localFiles.get(path)!;
+    states[path] = {
+      path,
+      localMtime: file.stat.mtime,
+      localSize: file.stat.size,
+      remoteRevision: 0,
+      syncedAt: 0,
+      status: "conflict",
+    };
+  }
+
+  return { action: "reconciled", states };
+}
+
+/**
+ * Pull all remote files into the local vault.
+ */
+export async function pullAllRemote(
+  vault: Vault,
+  client: Drive9Client,
+  syncStates: Record<string, SyncState>,
+  ignorePaths: string[],
+): Promise<void> {
+  const ignore = new IgnoreMatcher(ignorePaths);
+  const entries = await client.listRecursive("/");
+  let count = 0;
+
+  for (const entry of entries) {
+    if (ignore.isIgnored(entry.name)) continue;
+
+    // Ensure parent directories exist.
+    const dir = entry.name.contains("/")
+      ? entry.name.substring(0, entry.name.lastIndexOf("/"))
+      : "";
+    if (dir && !vault.getAbstractFileByPath(dir)) {
+      await vault.createFolder(dir);
+    }
+
+    const data = await client.read(entry.name);
+    const existing = vault.getAbstractFileByPath(entry.name);
+    if (existing instanceof TFile) {
+      await vault.modifyBinary(existing, data);
+    } else {
+      await vault.createBinary(entry.name, data);
+    }
+
+    const file = vault.getAbstractFileByPath(entry.name);
+    if (file instanceof TFile) {
+      syncStates[entry.name] = {
+        path: entry.name,
+        localMtime: file.stat.mtime,
+        localSize: file.stat.size,
+        remoteRevision: 0,
+        syncedAt: Date.now(),
+        status: "synced",
+      };
+    }
+    count++;
+  }
+
+  new Notice(`drive9: downloaded ${count} files`);
+}
+
+// ---------------------------------------------------------------------------
+// Simple confirmation dialog
+// ---------------------------------------------------------------------------
+
+function askUser(app: App, title: string, message: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const modal = new ConfirmModal(app, title, message, resolve);
+    modal.open();
+  });
+}
+
+class ConfirmModal extends Modal {
+  constructor(
+    app: App,
+    private title: string,
+    private message: string,
+    private resolve: (confirmed: boolean) => void,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.createEl("h3", { text: this.title });
+    contentEl.createEl("p", { text: this.message });
+
+    new Setting(contentEl)
+      .addButton((btn) =>
+        btn.setButtonText("Yes").setCta().onClick(() => {
+          this.resolve(true);
+          this.close();
+        }),
+      )
+      .addButton((btn) =>
+        btn.setButtonText("Cancel").onClick(() => {
+          this.resolve(false);
+          this.close();
+        }),
+      );
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/obsidian-plugin/src/ignore.ts
+++ b/obsidian-plugin/src/ignore.ts
@@ -1,0 +1,42 @@
+/**
+ * Simple glob-based ignore matcher for file paths.
+ * Supports: ** (any path), * (any segment), exact match.
+ */
+export class IgnoreMatcher {
+  private patterns: RegExp[];
+
+  constructor(patterns: string[]) {
+    this.patterns = patterns.map(globToRegex);
+  }
+
+  isIgnored(path: string): boolean {
+    return this.patterns.some((re) => re.test(path));
+  }
+}
+
+function globToRegex(glob: string): RegExp {
+  let re = "^";
+  let i = 0;
+  while (i < glob.length) {
+    const c = glob[i];
+    if (c === "*" && glob[i + 1] === "*") {
+      re += ".*";
+      i += 2;
+      if (glob[i] === "/") i++; // skip trailing slash after **
+    } else if (c === "*") {
+      re += "[^/]*";
+      i++;
+    } else if (c === "?") {
+      re += "[^/]";
+      i++;
+    } else if (".+^${}()|[]\\".includes(c)) {
+      re += "\\" + c;
+      i++;
+    } else {
+      re += c;
+      i++;
+    }
+  }
+  re += "$";
+  return new RegExp(re);
+}

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -132,12 +132,19 @@ export default class Drive9Plugin extends Plugin {
                 await this.app.vault.createFolder(dir);
               }
               await this.app.vault.createBinary(path, data);
+              // Refresh revision if it was unknown from first-run.
+              if (state.remoteRevision === null) {
+                try {
+                  const st = await this.client.stat(path);
+                  state.remoteRevision = st.revision;
+                } catch { /* stays null — will refresh before next push */ }
+              }
               const pulled = this.app.vault.getAbstractFileByPath(path);
               if (pulled instanceof TFile) {
                 state.localMtime = pulled.stat.mtime;
                 state.localSize = pulled.stat.size;
               }
-              state.status = "synced";
+              state.status = state.remoteRevision !== null ? "synced" : "needs_refresh";
               state.syncedAt = Date.now();
             } catch (e) {
               console.error(`[drive9] pull failed: ${path}`, e);

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, Notice } from "obsidian";
+import { Plugin, Notice, TFile } from "obsidian";
 import { Drive9Client } from "./client";
 import { SyncEngine } from "./sync-engine";
 import { Drive9SettingTab } from "./settings";
@@ -132,6 +132,11 @@ export default class Drive9Plugin extends Plugin {
                 await this.app.vault.createFolder(dir);
               }
               await this.app.vault.createBinary(path, data);
+              const pulled = this.app.vault.getAbstractFileByPath(path);
+              if (pulled instanceof TFile) {
+                state.localMtime = pulled.stat.mtime;
+                state.localSize = pulled.stat.size;
+              }
               state.status = "synced";
               state.syncedAt = Date.now();
             } catch (e) {

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -1,0 +1,208 @@
+import { Plugin, Notice } from "obsidian";
+import { Drive9Client } from "./client";
+import { SyncEngine } from "./sync-engine";
+import { Drive9SettingTab } from "./settings";
+import { runFirstRunReconciliation, pullAllRemote } from "./first-run";
+import type { PluginData, Drive9Settings, SyncState } from "./types";
+import { DEFAULT_PLUGIN_DATA, DEFAULT_SETTINGS } from "./types";
+
+export default class Drive9Plugin extends Plugin {
+  settings: Drive9Settings = DEFAULT_SETTINGS;
+  private client!: Drive9Client;
+  private syncEngine!: SyncEngine;
+  private syncStates: Record<string, SyncState> = {};
+  private firstRunComplete = false;
+  private statusBarEl: HTMLElement | null = null;
+
+  async onload(): Promise<void> {
+    await this.loadPluginData();
+
+    this.client = new Drive9Client(
+      this.settings.serverUrl,
+      this.settings.apiKey,
+    );
+
+    this.syncEngine = new SyncEngine(
+      this.app.vault,
+      this.client,
+      this.syncStates,
+      this.settings,
+      () => this.savePluginData(),
+    );
+
+    // Status bar.
+    this.statusBarEl = this.addStatusBarItem();
+    this.updateStatusBar();
+    this.syncEngine.onStatusChange(() => this.updateStatusBar());
+
+    // Settings tab.
+    this.addSettingTab(new Drive9SettingTab(this.app, this));
+
+    // Wait for layout ready before registering vault events.
+    this.app.workspace.onLayoutReady(() => {
+      this.onLayoutReady();
+    });
+  }
+
+  private async onLayoutReady(): Promise<void> {
+    if (!this.settings.serverUrl) {
+      this.setStatusBar("⚙ drive9: configure in settings");
+      return;
+    }
+
+    // First-run reconciliation.
+    if (!this.firstRunComplete) {
+      try {
+        await this.doFirstRun();
+      } catch (e) {
+        console.error("[drive9] first-run failed", e);
+        new Notice(`drive9: first-run failed — ${e instanceof Error ? e.message : String(e)}`);
+        this.setStatusBar("✗ drive9: first-run failed");
+        return;
+      }
+    }
+
+    // Register vault events for ongoing sync.
+    this.registerEvent(
+      this.app.vault.on("create", (file) => this.syncEngine.onLocalCreate(file)),
+    );
+    this.registerEvent(
+      this.app.vault.on("modify", (file) => this.syncEngine.onLocalModify(file)),
+    );
+    this.registerEvent(
+      this.app.vault.on("delete", (file) => this.syncEngine.onLocalDelete(file)),
+    );
+    this.registerEvent(
+      this.app.vault.on("rename", (file, oldPath) =>
+        this.syncEngine.onLocalRename(file, oldPath),
+      ),
+    );
+
+    this.setStatusBar("✓ drive9: synced");
+  }
+
+  private async doFirstRun(): Promise<void> {
+    this.setStatusBar("↕ drive9: reconciling...");
+
+    const result = await runFirstRunReconciliation(
+      this.app,
+      this.app.vault,
+      this.client,
+      this.settings.ignorePaths,
+    );
+
+    switch (result.action) {
+      case "push_all":
+        // Mark all local files as dirty so the sync engine pushes them.
+        new Notice("drive9: uploading vault to drive9...");
+        for (const file of this.app.vault.getFiles()) {
+          this.syncEngine.onLocalCreate(file);
+        }
+        break;
+
+      case "pull_all":
+        new Notice("drive9: downloading from drive9...");
+        await pullAllRemote(
+          this.app.vault,
+          this.client,
+          this.syncStates,
+          this.settings.ignorePaths,
+        );
+        break;
+
+      case "reconciled":
+        Object.assign(this.syncStates, result.states);
+        // Push files that are only local.
+        for (const [path, state] of Object.entries(result.states)) {
+          if (state.status === "local_dirty") {
+            this.syncEngine.onLocalCreate(
+              this.app.vault.getAbstractFileByPath(path)!,
+            );
+          }
+        }
+        // Pull files that are only remote.
+        for (const [path, state] of Object.entries(result.states)) {
+          if (state.status === "remote_dirty") {
+            try {
+              const data = await this.client.read(path);
+              const dir = path.contains("/")
+                ? path.substring(0, path.lastIndexOf("/"))
+                : "";
+              if (dir && !this.app.vault.getAbstractFileByPath(dir)) {
+                await this.app.vault.createFolder(dir);
+              }
+              await this.app.vault.createBinary(path, data);
+              state.status = "synced";
+              state.syncedAt = Date.now();
+            } catch (e) {
+              console.error(`[drive9] pull failed: ${path}`, e);
+            }
+          }
+        }
+        break;
+
+      case "cancelled":
+        new Notice("drive9: first-run cancelled. Sync is disabled.");
+        return;
+    }
+
+    this.firstRunComplete = true;
+    await this.savePluginData();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Data persistence
+  // ---------------------------------------------------------------------------
+
+  async loadPluginData(): Promise<void> {
+    const raw = await this.loadData();
+    const data: PluginData = Object.assign({}, DEFAULT_PLUGIN_DATA, raw ?? {});
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, data.settings);
+    this.syncStates = data.syncStates ?? {};
+    this.firstRunComplete = data.firstRunComplete ?? false;
+  }
+
+  async savePluginData(): Promise<void> {
+    const data: PluginData = {
+      settings: this.settings,
+      syncStates: this.syncStates,
+      firstRunComplete: this.firstRunComplete,
+    };
+    await this.saveData(data);
+
+    // Keep client and sync engine in sync with settings.
+    this.client.updateConfig(this.settings.serverUrl, this.settings.apiKey);
+    this.syncEngine?.updateSettings(this.settings);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Status bar
+  // ---------------------------------------------------------------------------
+
+  private updateStatusBar(): void {
+    const engine = this.syncEngine;
+    if (!engine) return;
+
+    switch (engine.status) {
+      case "syncing":
+        this.setStatusBar(`↑ drive9: uploading ${engine.pendingCount} files`);
+        break;
+      case "error":
+        this.setStatusBar("✗ drive9: error");
+        break;
+      case "idle":
+        this.setStatusBar("✓ drive9: synced");
+        break;
+    }
+  }
+
+  private setStatusBar(text: string): void {
+    if (this.statusBarEl) {
+      this.statusBarEl.setText(text);
+    }
+  }
+
+  onunload(): void {
+    // Nothing to clean up — Obsidian handles event deregistration.
+  }
+}

--- a/obsidian-plugin/src/settings.ts
+++ b/obsidian-plugin/src/settings.ts
@@ -1,0 +1,116 @@
+import { App, PluginSettingTab, Setting, Notice } from "obsidian";
+import type Drive9Plugin from "./main";
+import { Drive9Client } from "./client";
+
+export class Drive9SettingTab extends PluginSettingTab {
+  constructor(
+    app: App,
+    private plugin: Drive9Plugin,
+  ) {
+    super(app, plugin);
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    containerEl.createEl("h2", { text: "drive9 Settings" });
+
+    new Setting(containerEl)
+      .setName("Server URL")
+      .setDesc("drive9 server address (e.g. https://api.drive9.ai)")
+      .addText((text) =>
+        text
+          .setPlaceholder("https://api.drive9.ai")
+          .setValue(this.plugin.settings.serverUrl)
+          .onChange(async (value) => {
+            this.plugin.settings.serverUrl = value.trim();
+            await this.plugin.savePluginData();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("API Key")
+      .setDesc("drive9 API key for authentication")
+      .addText((text) => {
+        text.inputEl.type = "password";
+        text
+          .setPlaceholder("your-api-key")
+          .setValue(this.plugin.settings.apiKey)
+          .onChange(async (value) => {
+            this.plugin.settings.apiKey = value.trim();
+            await this.plugin.savePluginData();
+          });
+      });
+
+    new Setting(containerEl)
+      .setName("Test Connection")
+      .setDesc("Verify server URL and API key")
+      .addButton((btn) =>
+        btn.setButtonText("Test").onClick(async () => {
+          if (!this.plugin.settings.serverUrl) {
+            new Notice("Please enter a server URL first");
+            return;
+          }
+          try {
+            const testClient = new Drive9Client(
+              this.plugin.settings.serverUrl,
+              this.plugin.settings.apiKey,
+            );
+            await testClient.ping();
+            new Notice("drive9: connection successful!");
+          } catch (e) {
+            new Notice(`drive9: connection failed — ${e instanceof Error ? e.message : String(e)}`);
+          }
+        }),
+      );
+
+    new Setting(containerEl)
+      .setName("Push Debounce (ms)")
+      .setDesc("Delay before syncing after a file change (default: 2000)")
+      .addText((text) =>
+        text
+          .setPlaceholder("2000")
+          .setValue(String(this.plugin.settings.pushDebounce))
+          .onChange(async (value) => {
+            const n = parseInt(value, 10);
+            if (!isNaN(n) && n >= 500) {
+              this.plugin.settings.pushDebounce = n;
+              await this.plugin.savePluginData();
+            }
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Ignore Paths")
+      .setDesc("Glob patterns to exclude from sync (one per line)")
+      .addTextArea((text) =>
+        text
+          .setPlaceholder(".obsidian/**\n.trash/**")
+          .setValue(this.plugin.settings.ignorePaths.join("\n"))
+          .onChange(async (value) => {
+            this.plugin.settings.ignorePaths = value
+              .split("\n")
+              .map((s) => s.trim())
+              .filter((s) => s.length > 0);
+            await this.plugin.savePluginData();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Max File Size (MB)")
+      .setDesc("Skip files larger than this (default: 100)")
+      .addText((text) =>
+        text
+          .setPlaceholder("100")
+          .setValue(String(Math.round(this.plugin.settings.maxFileSize / (1024 * 1024))))
+          .onChange(async (value) => {
+            const n = parseInt(value, 10);
+            if (!isNaN(n) && n >= 1) {
+              this.plugin.settings.maxFileSize = n * 1024 * 1024;
+              await this.plugin.savePluginData();
+            }
+          }),
+      );
+  }
+}

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -1,0 +1,202 @@
+import { Vault, TFile, TAbstractFile, Notice } from "obsidian";
+import { Drive9Client, Drive9Error } from "./client";
+import { IgnoreMatcher } from "./ignore";
+import type { SyncState, Drive9Settings } from "./types";
+
+export type SyncStatus = "idle" | "syncing" | "error";
+
+/**
+ * SyncEngine handles one-way push from local vault to drive9.
+ * Phase 1: local changes → debounce → push with CAS.
+ */
+export class SyncEngine {
+  private dirtyPaths = new Set<string>();
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private ignoreMatcher: IgnoreMatcher;
+  private _status: SyncStatus = "idle";
+  private _pendingCount = 0;
+  private statusListeners: Array<() => void> = [];
+
+  constructor(
+    private vault: Vault,
+    private client: Drive9Client,
+    private syncStates: Record<string, SyncState>,
+    private settings: Drive9Settings,
+    private persistData: () => Promise<void>,
+  ) {
+    this.ignoreMatcher = new IgnoreMatcher(settings.ignorePaths);
+  }
+
+  get status(): SyncStatus {
+    return this._status;
+  }
+
+  get pendingCount(): number {
+    return this._pendingCount;
+  }
+
+  onStatusChange(fn: () => void): void {
+    this.statusListeners.push(fn);
+  }
+
+  updateSettings(settings: Drive9Settings): void {
+    this.settings = settings;
+    this.ignoreMatcher = new IgnoreMatcher(settings.ignorePaths);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Vault event handlers
+  // ---------------------------------------------------------------------------
+
+  onLocalCreate(file: TAbstractFile): void {
+    if (!(file instanceof TFile)) return;
+    if (this.shouldIgnore(file.path)) return;
+    this.markDirty(file.path);
+  }
+
+  onLocalModify(file: TAbstractFile): void {
+    if (!(file instanceof TFile)) return;
+    if (this.shouldIgnore(file.path)) return;
+    this.markDirty(file.path);
+  }
+
+  onLocalDelete(file: TAbstractFile): void {
+    if (!(file instanceof TFile)) return;
+    if (this.shouldIgnore(file.path)) return;
+    this.markDirty(file.path);
+  }
+
+  onLocalRename(file: TAbstractFile, oldPath: string): void {
+    if (!(file instanceof TFile)) return;
+    if (this.shouldIgnore(file.path) && this.shouldIgnore(oldPath)) return;
+    // Treat rename as delete old + create new.
+    if (!this.shouldIgnore(oldPath)) {
+      this.markDirty(oldPath);
+    }
+    if (!this.shouldIgnore(file.path)) {
+      this.markDirty(file.path);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core sync logic
+  // ---------------------------------------------------------------------------
+
+  private shouldIgnore(path: string): boolean {
+    return this.ignoreMatcher.isIgnored(path);
+  }
+
+  private markDirty(path: string): void {
+    this.dirtyPaths.add(path);
+    const state = this.syncStates[path];
+    if (state) {
+      state.status = "local_dirty";
+    }
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      this.flush();
+    }, this.settings.pushDebounce);
+  }
+
+  private async flush(): Promise<void> {
+    if (this.dirtyPaths.size === 0) return;
+
+    const paths = [...this.dirtyPaths];
+    this.dirtyPaths.clear();
+
+    this.setStatus("syncing", paths.length);
+
+    let errorOccurred = false;
+
+    for (const path of paths) {
+      try {
+        await this.pushOne(path);
+      } catch (e) {
+        errorOccurred = true;
+        console.error(`[drive9] push failed: ${path}`, e);
+        // Re-add to dirty set for retry on next flush.
+        this.dirtyPaths.add(path);
+      }
+    }
+
+    this.setStatus(errorOccurred ? "error" : "idle", this.dirtyPaths.size);
+    await this.persistData();
+  }
+
+  private async pushOne(path: string): Promise<void> {
+    const file = this.vault.getAbstractFileByPath(path);
+
+    // File was deleted locally.
+    if (!file || !(file instanceof TFile)) {
+      const state = this.syncStates[path];
+      if (state) {
+        try {
+          await this.client.delete(path);
+        } catch (e) {
+          // 404 is fine — already gone on remote.
+          if (e instanceof Drive9Error && e.status === 404) {
+            // ok
+          } else {
+            throw e;
+          }
+        }
+        delete this.syncStates[path];
+      }
+      return;
+    }
+
+    // Skip files exceeding size limit.
+    if (file.stat.size > this.settings.maxFileSize) {
+      console.warn(`[drive9] skipping large file: ${path} (${file.stat.size} bytes)`);
+      return;
+    }
+
+    const data = await this.vault.readBinary(file);
+    const state = this.syncStates[path];
+    const expectedRevision = state?.remoteRevision;
+
+    try {
+      const result = await this.client.write(path, data, expectedRevision);
+      this.syncStates[path] = {
+        path,
+        localMtime: file.stat.mtime,
+        localSize: file.stat.size,
+        remoteRevision: result.revision,
+        syncedAt: Date.now(),
+        status: "synced",
+      };
+    } catch (e) {
+      if (e instanceof Drive9Error && e.status === 409) {
+        // CAS conflict — mark but don't overwrite.
+        if (state) {
+          state.status = "conflict";
+        } else {
+          this.syncStates[path] = {
+            path,
+            localMtime: file.stat.mtime,
+            localSize: file.stat.size,
+            remoteRevision: 0,
+            syncedAt: 0,
+            status: "conflict",
+          };
+        }
+        new Notice(`drive9: conflict detected for ${path}`);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private setStatus(status: SyncStatus, pending: number): void {
+    this._status = status;
+    this._pendingCount = pending;
+    for (const fn of this.statusListeners) {
+      try { fn(); } catch { /* ignore */ }
+    }
+  }
+}

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -89,7 +89,7 @@ export class SyncEngine {
   private markDirty(path: string): void {
     this.dirtyPaths.add(path);
     const state = this.syncStates[path];
-    if (state) {
+    if (state && state.status !== "conflict") {
       state.status = "local_dirty";
     }
     this.scheduleFlush();
@@ -156,31 +156,67 @@ export class SyncEngine {
       return;
     }
 
+    // Skip files in needs_refresh or conflict state — must resolve first.
+    const existingState = this.syncStates[path];
+    if (existingState?.status === "conflict") {
+      return;
+    }
+
+    // If revision is unknown (null), try to refresh before pushing.
+    // This prevents sending expectedRevision=undefined (unconditional write)
+    // for files that actually exist on the remote.
+    if (existingState && existingState.remoteRevision === null) {
+      try {
+        const st = await this.client.stat(path);
+        existingState.remoteRevision = st.revision;
+        existingState.status = "local_dirty";
+      } catch {
+        // Cannot determine revision — block push to prevent silent overwrite.
+        existingState.status = "needs_refresh";
+        console.warn(`[drive9] cannot refresh revision for ${path}, blocking push`);
+        return;
+      }
+    }
+
     const data = await this.vault.readBinary(file);
-    const state = this.syncStates[path];
-    const expectedRevision = state?.remoteRevision;
+    const expectedRevision = existingState?.remoteRevision;
 
     try {
       const result = await this.client.write(path, data, expectedRevision);
-      this.syncStates[path] = {
-        path,
-        localMtime: file.stat.mtime,
-        localSize: file.stat.size,
-        remoteRevision: result.revision,
-        syncedAt: Date.now(),
-        status: "synced",
-      };
+      if (result.revision !== null) {
+        this.syncStates[path] = {
+          path,
+          localMtime: file.stat.mtime,
+          localSize: file.stat.size,
+          remoteRevision: result.revision,
+          syncedAt: Date.now(),
+          status: "synced",
+        };
+      } else {
+        // PUT succeeded but post-write stat failed.
+        // Do NOT re-add to dirty set — the write already committed.
+        // Mark as needs_refresh so next edit will refresh before pushing.
+        this.syncStates[path] = {
+          path,
+          localMtime: file.stat.mtime,
+          localSize: file.stat.size,
+          remoteRevision: null,
+          syncedAt: Date.now(),
+          status: "needs_refresh",
+        };
+        console.warn(`[drive9] write succeeded but revision unknown for ${path}`);
+      }
     } catch (e) {
       if (e instanceof Drive9Error && e.status === 409) {
         // CAS conflict — mark but don't overwrite.
-        if (state) {
-          state.status = "conflict";
+        if (existingState) {
+          existingState.status = "conflict";
         } else {
           this.syncStates[path] = {
             path,
             localMtime: file.stat.mtime,
             localSize: file.stat.size,
-            remoteRevision: 0,
+            remoteRevision: null,
             syncedAt: 0,
             status: "conflict",
           };

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -179,7 +179,9 @@ export class SyncEngine {
     }
 
     const data = await this.vault.readBinary(file);
-    const expectedRevision = existingState?.remoteRevision;
+    // If no state exists, this is a new file — use 0 (create-if-absent).
+    // Never send undefined (unconditional overwrite).
+    const expectedRevision = existingState ? existingState.remoteRevision : 0;
 
     try {
       const result = await this.client.write(path, data, expectedRevision);

--- a/obsidian-plugin/src/types.ts
+++ b/obsidian-plugin/src/types.ts
@@ -36,9 +36,14 @@ export interface SyncState {
   path: string;
   localMtime: number;
   localSize: number;
-  remoteRevision: number;
+  /**
+   * null means "remote exists but revision is unknown" (e.g. stat failed).
+   * 0 means "create-if-absent" (file not yet on remote).
+   * Positive number is a real CAS revision.
+   */
+  remoteRevision: number | null;
   syncedAt: number;
-  status: "synced" | "local_dirty" | "remote_dirty" | "remote_deleted" | "conflict";
+  status: "synced" | "local_dirty" | "remote_dirty" | "remote_deleted" | "conflict" | "needs_refresh";
 }
 
 /** Persisted plugin data (settings + sync state). */

--- a/obsidian-plugin/src/types.ts
+++ b/obsidian-plugin/src/types.ts
@@ -1,0 +1,55 @@
+/** Plugin settings persisted in data.json. */
+export interface Drive9Settings {
+  serverUrl: string;
+  apiKey: string;
+  pushDebounce: number;
+  ignorePaths: string[];
+  maxFileSize: number; // bytes
+}
+
+export const DEFAULT_SETTINGS: Drive9Settings = {
+  serverUrl: "",
+  apiKey: "",
+  pushDebounce: 2000,
+  ignorePaths: [".obsidian/**", ".trash/**", "*.tmp", ".DS_Store"],
+  maxFileSize: 100 * 1024 * 1024, // 100MB
+};
+
+/** Result of HEAD /v1/fs/{path} */
+export interface StatResult {
+  size: number;
+  isDir: boolean;
+  revision: number;
+  mtime: number;
+}
+
+/** Entry from GET /v1/fs/{path}?list=1 */
+export interface FileInfo {
+  name: string;
+  size: number;
+  isDir: boolean;
+  mtime: number;
+}
+
+/** Per-file sync tracking. */
+export interface SyncState {
+  path: string;
+  localMtime: number;
+  localSize: number;
+  remoteRevision: number;
+  syncedAt: number;
+  status: "synced" | "local_dirty" | "remote_dirty" | "remote_deleted" | "conflict";
+}
+
+/** Persisted plugin data (settings + sync state). */
+export interface PluginData {
+  settings: Drive9Settings;
+  syncStates: Record<string, SyncState>;
+  firstRunComplete: boolean;
+}
+
+export const DEFAULT_PLUGIN_DATA: PluginData = {
+  settings: DEFAULT_SETTINGS,
+  syncStates: {},
+  firstRunComplete: false,
+};

--- a/obsidian-plugin/tsconfig.json
+++ b/obsidian-plugin/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "module": "ESNext",
+    "target": "ES2020",
+    "allowJs": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "isolatedModules": true,
+    "lib": ["DOM", "ES2020"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Implements #175: Phase 1 MVP for the Obsidian drive9 plugin.

- **Drive9Client** (`src/client.ts`): HTTP REST wrapper using Obsidian `requestUrl` (CORS-free, works on mobile). Supports stat/read/write/delete/rename/mkdir/list with CAS via `X-Dat9-Expected-Revision`.
- **First-run reconciliation** (`src/first-run.ts`): Detects remote state before any push. Never silent overwrite — remote non-empty triggers stop-and-ask.
- **SyncEngine** (`src/sync-engine.ts`): Vault events → 2s debounce → batch push with CAS. Revision conflicts marked, never overwritten. Large files skipped.
- **Settings** (`src/settings.ts`): Server URL, API key (password field), debounce, ignore patterns, max file size, test connection button.
- **Status bar**: `✓ synced` / `↑ uploading N files` / `✗ error`
- **Ignore rules** (`src/ignore.ts`): Glob-based (`.obsidian/**`, `.trash/**`, `*.tmp`, `.DS_Store`)

## Verification

- `npm run typecheck` — clean
- `npm run build` — 13.3kb production bundle

## Test plan

- [ ] Plugin loads in Obsidian desktop
- [ ] Settings: configure server URL + API key, test connection
- [ ] First-run: remote empty → push all local files
- [ ] First-run: local empty + remote has files → prompt to pull
- [ ] First-run: both have files → reconcile with stop-and-ask on conflicts
- [ ] Create/modify/delete/rename → auto-sync to drive9
- [ ] CAS conflict → Notice shown, file not overwritten
- [ ] `.obsidian/` and `.trash/` not synced
- [ ] Large files skipped with console warning
- [ ] Status bar updates correctly

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced the drive9 Obsidian plugin with one-way local-to-remote vault synchronization.
  * Added configurable settings: server URL, API key, sync debounce interval, file size limits, and path exclusion patterns.
  * Implemented first-run reconciliation offering push all, pull all, or selective sync options.
  * Sync status indicator in status bar with conflict detection and automatic retry logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->