### PR TITLE
feat: Agent Vault Phase 1 & 2 — data model, management API, encryption, consumption API

### DIFF
--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -162,14 +162,12 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 			return
 		}
 
-		// Look up tenant to make sure it exists and is active.
+		// Look up tenant and load backend. Use a uniform 401 for all
+		// failure modes to avoid leaking tenant existence or status to
+		// unauthenticated callers (tenant_id is from unverified peek).
 		tenant, err := metaStore.GetTenant(r.Context(), tenantID)
-		if err != nil {
-			errJSON(w, http.StatusUnauthorized, "unauthorized")
-			return
-		}
-		if tenant.Status != meta.TenantActive {
-			errJSON(w, http.StatusForbidden, "tenant is unavailable")
+		if err != nil || tenant.Status != meta.TenantActive {
+			errJSON(w, http.StatusUnauthorized, "invalid capability token")
 			return
 		}
 

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
+	"github.com/mem9-ai/dat9/pkg/vault"
 )
 
 type scopeKey int
@@ -138,6 +139,55 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 		scope := &TenantScope{TenantID: resolved.Tenant.ID, APIKeyID: resolved.APIKey.ID, TokenVersion: resolved.APIKey.TokenVersion, Backend: b}
 		next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))
 	})
+}
+
+// capabilityAuthMiddleware returns a handler that resolves the tenant backend
+// from a capability token's tenant_id claim. It does NOT do full token verification
+// (signature, TTL, revocation) — that is handled by handleVaultRead itself.
+// This middleware only exists to load the correct tenant DB so the handler can
+// access vault tables.
+func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tok := bearerToken(r)
+		if tok == "" {
+			errJSON(w, http.StatusUnauthorized, "missing capability token")
+			return
+		}
+
+		// Peek at claims to get tenant_id. We only need the payload, not
+		// full HMAC verification (handleVaultRead does that).
+		tenantID, err := peekCapTokenTenantID(tok)
+		if err != nil {
+			errJSON(w, http.StatusUnauthorized, "invalid capability token")
+			return
+		}
+
+		// Look up tenant to make sure it exists and is active.
+		tenant, err := metaStore.GetTenant(r.Context(), tenantID)
+		if err != nil {
+			errJSON(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		if tenant.Status != meta.TenantActive {
+			errJSON(w, http.StatusForbidden, "tenant is unavailable")
+			return
+		}
+
+		b, release, err := pool.Acquire(r.Context(), tenant)
+		if err != nil {
+			errJSON(w, http.StatusInternalServerError, "backend unavailable")
+			return
+		}
+		defer release()
+
+		scope := &TenantScope{TenantID: tenantID, Backend: b}
+		sub := strings.TrimPrefix(r.URL.Path, "/v1/vault/read")
+		s.handleVaultRead(w, r.WithContext(withScope(r.Context(), scope)), sub)
+	})
+}
+
+func peekCapTokenTenantID(raw string) (string, error) {
+	return vault.PeekCapTokenTenantID(raw)
 }
 
 func poolDecryptToken(ctx context.Context, pool *tenant.Pool, cipher []byte) ([]byte, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -111,7 +111,25 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v1/uploads/", business)
 	mux.Handle("/v2/uploads/", business)
 	mux.Handle("/v1/sql", business)
-	mux.Handle("/v1/vault/", business)
+	// Vault management API goes through tenant auth.
+	mux.Handle("/v1/vault/secrets", business)
+	mux.Handle("/v1/vault/secrets/", business)
+	mux.Handle("/v1/vault/tokens", business)
+	mux.Handle("/v1/vault/tokens/", business)
+	mux.Handle("/v1/vault/audit", business)
+	// Vault read (consumption) API: authenticated by capability token, NOT tenant token.
+	if s.vaultMK != nil && cfg.Pool != nil && cfg.Meta != nil {
+		mux.Handle("/v1/vault/read/", s.capabilityAuthMiddleware(cfg.Meta, cfg.Pool))
+		mux.Handle("/v1/vault/read", s.capabilityAuthMiddleware(cfg.Meta, cfg.Pool))
+	} else if s.vaultMK != nil && cfg.Backend != nil {
+		// Single-tenant fallback: inject local scope and serve directly.
+		mux.Handle("/v1/vault/read/", injectFallbackBackend(cfg.Backend, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			s.handleVaultRead(w, r, strings.TrimPrefix(r.URL.Path, "/v1/vault/read"))
+		})))
+		mux.Handle("/v1/vault/read", injectFallbackBackend(cfg.Backend, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			s.handleVaultRead(w, r, "")
+		})))
+	}
 	mux.HandleFunc("/v1/status", s.handleTenantStatus)
 	mux.HandleFunc("/v1/provision", s.handleProvision)
 	mux.HandleFunc("/healthz", s.handleHealthz)
@@ -264,7 +282,7 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 		s.handleV2Uploads(w, r)
 	case r.URL.Path == "/v1/sql":
 		s.handleSQL(w, r)
-	case strings.HasPrefix(r.URL.Path, "/v1/vault/"):
+	case strings.HasPrefix(r.URL.Path, "/v1/vault/secrets"), strings.HasPrefix(r.URL.Path, "/v1/vault/tokens"), strings.HasPrefix(r.URL.Path, "/v1/vault/audit"):
 		s.handleVault(w, r)
 	default:
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "business_route_not_found", "path", r.URL.Path, "method", r.Method)...)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
 	"github.com/mem9-ai/dat9/pkg/traceid"
+	"github.com/mem9-ai/dat9/pkg/vault"
 	"go.uber.org/zap"
 )
 
@@ -31,6 +32,7 @@ type Config struct {
 	Pool             *tenant.Pool
 	Provisioner      tenant.Provisioner
 	TokenSecret      []byte
+	VaultMasterKey   []byte // 32-byte AES key for vault DEK wrapping; nil disables vault
 	Backend          *backend.Dat9Backend
 	LocalS3          *s3client.LocalS3Client
 	S3Dir            string
@@ -46,6 +48,7 @@ type Server struct {
 	pool           *tenant.Pool
 	provisioner    tenant.Provisioner
 	tokenSecret    []byte
+	vaultMK        *vault.MasterKey
 	maxUploadBytes int64
 	metrics        *serverMetrics
 	logger         *zap.Logger
@@ -76,11 +79,20 @@ func NewWithConfig(cfg Config) *Server {
 	if logger == nil {
 		logger, _ = zap.NewProduction()
 	}
+	var vaultMK *vault.MasterKey
+	if len(cfg.VaultMasterKey) > 0 {
+		var err error
+		vaultMK, err = vault.NewMasterKey(cfg.VaultMasterKey)
+		if err != nil {
+			logger.Warn("vault master key invalid, vault disabled", zap.Error(err))
+		}
+	}
 	s := &Server{
 		fallback:       cfg.Backend,
 		meta:           cfg.Meta,
 		pool:           cfg.Pool,
 		tokenSecret:    cfg.TokenSecret,
+		vaultMK:        vaultMK,
 		provisioner:    cfg.Provisioner,
 		maxUploadBytes: maxUpload,
 		metrics:        newServerMetrics(),
@@ -99,6 +111,7 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v1/uploads/", business)
 	mux.Handle("/v2/uploads/", business)
 	mux.Handle("/v1/sql", business)
+	mux.Handle("/v1/vault/", business)
 	mux.HandleFunc("/v1/status", s.handleTenantStatus)
 	mux.HandleFunc("/v1/provision", s.handleProvision)
 	mux.HandleFunc("/healthz", s.handleHealthz)
@@ -251,6 +264,8 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 		s.handleV2Uploads(w, r)
 	case r.URL.Path == "/v1/sql":
 		s.handleSQL(w, r)
+	case strings.HasPrefix(r.URL.Path, "/v1/vault/"):
+		s.handleVault(w, r)
 	default:
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "business_route_not_found", "path", r.URL.Path, "method", r.Method)...)
 		errJSON(w, http.StatusNotFound, "not found")

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -530,7 +530,7 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 	case "env":
 		w.Header().Set("Content-Type", "text/plain")
 		for k, v := range fields {
-			fmt.Fprintf(w, "%s=%s\n", strings.ToUpper(k), string(v))
+			_, _ = fmt.Fprintf(w, "%s=%s\n", strings.ToUpper(k), string(v))
 		}
 	case "json", "":
 		result := make(map[string]string, len(fields))

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -1,0 +1,588 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/vault"
+)
+
+// handleVault dispatches /v1/vault/* requests.
+func (s *Server) handleVault(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, "/v1/vault/")
+
+	// Management API: /v1/vault/secrets, /v1/vault/tokens, /v1/vault/audit
+	// Authenticated by tenant token (existing auth middleware).
+	if strings.HasPrefix(rest, "secrets") {
+		s.handleVaultSecrets(w, r, strings.TrimPrefix(rest, "secrets"))
+		return
+	}
+	if strings.HasPrefix(rest, "tokens") {
+		s.handleVaultTokens(w, r, strings.TrimPrefix(rest, "tokens"))
+		return
+	}
+	if rest == "audit" || strings.HasPrefix(rest, "audit") {
+		s.handleVaultAudit(w, r)
+		return
+	}
+
+	// Consumption API: /v1/vault/read/*
+	// Authenticated by capability token.
+	if strings.HasPrefix(rest, "read") {
+		s.handleVaultRead(w, r, strings.TrimPrefix(rest, "read"))
+		return
+	}
+
+	errJSON(w, http.StatusNotFound, "not found")
+}
+
+// vaultStore returns the vault store for the current tenant.
+func (s *Server) vaultStore(r *http.Request) (*vault.Store, error) {
+	scope := ScopeFromContext(r.Context())
+	if scope == nil || scope.Backend == nil {
+		return nil, fmt.Errorf("no tenant scope")
+	}
+	if s.vaultMK == nil {
+		return nil, fmt.Errorf("vault master key not configured")
+	}
+	return vault.NewStore(scope.Backend.Store().DB(), s.vaultMK), nil
+}
+
+// ---- Management API: /v1/vault/secrets ----
+
+func (s *Server) handleVaultSecrets(w http.ResponseWriter, r *http.Request, sub string) {
+	vs, err := s.vaultStore(r)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	scope := ScopeFromContext(r.Context())
+	tenantID := scope.TenantID
+
+	// /v1/vault/secrets (no name)
+	if sub == "" || sub == "/" {
+		switch r.Method {
+		case http.MethodPost:
+			s.handleVaultSecretCreate(w, r, vs, tenantID)
+		case http.MethodGet:
+			s.handleVaultSecretList(w, r, vs, tenantID)
+		default:
+			errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+		return
+	}
+
+	// /v1/vault/secrets/{name}
+	name := strings.TrimPrefix(sub, "/")
+	switch r.Method {
+	case http.MethodGet:
+		s.handleVaultSecretGet(w, r, vs, tenantID, name)
+	case http.MethodPut:
+		s.handleVaultSecretUpdate(w, r, vs, tenantID, name)
+	case http.MethodDelete:
+		s.handleVaultSecretDelete(w, r, vs, tenantID, name)
+	default:
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
+	var req struct {
+		Name       string            `json:"name"`
+		SecretType string            `json:"secret_type"`
+		Fields     map[string]string `json:"fields"`
+		CreatedBy  string            `json:"created_by"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		errJSON(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if req.Name == "" {
+		errJSON(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if len(req.Fields) == 0 {
+		errJSON(w, http.StatusBadRequest, "fields are required")
+		return
+	}
+	if req.CreatedBy == "" {
+		req.CreatedBy = "api"
+	}
+	secretType := vault.SecretType(req.SecretType)
+	if secretType == "" {
+		secretType = vault.SecretTypeGeneric
+	}
+
+	fields := make(map[string][]byte, len(req.Fields))
+	for k, v := range req.Fields {
+		fields[k] = []byte(v)
+	}
+
+	sec, err := vs.CreateSecret(r.Context(), tenantID, req.Name, req.CreatedBy, secretType, fields)
+	if err != nil {
+		if strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "unique") {
+			errJSON(w, http.StatusConflict, "secret already exists")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to create secret")
+		return
+	}
+
+	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+		TenantID:   tenantID,
+		EventType:  "secret.created",
+		SecretName: req.Name,
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(sec)
+}
+
+func (s *Server) handleVaultSecretList(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
+	secrets, err := vs.ListSecrets(r.Context(), tenantID)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to list secrets")
+		return
+	}
+	if secrets == nil {
+		secrets = []*vault.Secret{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"secrets": secrets})
+}
+
+func (s *Server) handleVaultSecretGet(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
+	sec, err := vs.GetSecret(r.Context(), tenantID, name)
+	if err != nil {
+		if errors.Is(err, vault.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "secret not found")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to get secret")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(sec)
+}
+
+func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
+	var req struct {
+		Fields    map[string]string `json:"fields"`
+		UpdatedBy string            `json:"updated_by"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		errJSON(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if len(req.Fields) == 0 {
+		errJSON(w, http.StatusBadRequest, "fields are required")
+		return
+	}
+	if req.UpdatedBy == "" {
+		req.UpdatedBy = "api"
+	}
+
+	fields := make(map[string][]byte, len(req.Fields))
+	for k, v := range req.Fields {
+		fields[k] = []byte(v)
+	}
+
+	sec, err := vs.UpdateSecret(r.Context(), tenantID, name, req.UpdatedBy, fields)
+	if err != nil {
+		if errors.Is(err, vault.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "secret not found")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to update secret")
+		return
+	}
+
+	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+		TenantID:   tenantID,
+		EventType:  "secret.rotated",
+		SecretName: name,
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(sec)
+}
+
+func (s *Server) handleVaultSecretDelete(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
+	err := vs.DeleteSecret(r.Context(), tenantID, name)
+	if err != nil {
+		if errors.Is(err, vault.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "secret not found")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to delete secret")
+		return
+	}
+
+	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+		TenantID:   tenantID,
+		EventType:  "secret.deleted",
+		SecretName: name,
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// ---- Management API: /v1/vault/tokens ----
+
+func (s *Server) handleVaultTokens(w http.ResponseWriter, r *http.Request, sub string) {
+	vs, err := s.vaultStore(r)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	scope := ScopeFromContext(r.Context())
+	tenantID := scope.TenantID
+
+	if sub == "" || sub == "/" {
+		if r.Method == http.MethodPost {
+			s.handleVaultTokenIssue(w, r, vs, tenantID)
+			return
+		}
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// DELETE /v1/vault/tokens/{token_id}
+	tokenID := strings.TrimPrefix(sub, "/")
+	if r.Method == http.MethodDelete {
+		s.handleVaultTokenRevoke(w, r, vs, tenantID, tokenID)
+		return
+	}
+	errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+}
+
+func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
+	var req struct {
+		AgentID string   `json:"agent_id"`
+		TaskID  string   `json:"task_id"`
+		Scope   []string `json:"scope"`
+		TTLSecs int      `json:"ttl_seconds"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		errJSON(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if req.AgentID == "" {
+		errJSON(w, http.StatusBadRequest, "agent_id is required")
+		return
+	}
+	if len(req.Scope) == 0 {
+		errJSON(w, http.StatusBadRequest, "scope is required")
+		return
+	}
+	ttl := time.Duration(req.TTLSecs) * time.Second
+	if ttl <= 0 {
+		ttl = time.Hour // default 1 hour
+	}
+
+	tokenStr, capToken, err := vs.IssueCapToken(r.Context(), tenantID, req.AgentID, req.TaskID, req.Scope, ttl)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to issue token")
+		return
+	}
+
+	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+		TenantID:  tenantID,
+		EventType: "token.issued",
+		TokenID:   capToken.TokenID,
+		AgentID:   req.AgentID,
+		TaskID:    req.TaskID,
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"token":      tokenStr,
+		"token_id":   capToken.TokenID,
+		"expires_at": capToken.ExpiresAt,
+	})
+}
+
+func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, tokenID string) {
+	var req struct {
+		RevokedBy string `json:"revoked_by"`
+		Reason    string `json:"reason"`
+	}
+	// Body is optional for DELETE.
+	_ = json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req)
+	if req.RevokedBy == "" {
+		req.RevokedBy = "api"
+	}
+
+	err := vs.RevokeCapToken(r.Context(), tokenID, req.RevokedBy, req.Reason)
+	if err != nil {
+		if errors.Is(err, vault.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "token not found or already revoked")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to revoke token")
+		return
+	}
+
+	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+		TenantID:  tenantID,
+		EventType: "token.revoked",
+		TokenID:   tokenID,
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// ---- Management API: /v1/vault/audit ----
+
+func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	vs, err := s.vaultStore(r)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	scope := ScopeFromContext(r.Context())
+
+	secretName := r.URL.Query().Get("secret")
+	limit := 100
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 1000 {
+			limit = n
+		}
+	}
+
+	events, err := vs.QueryAuditLog(r.Context(), scope.TenantID, secretName, limit)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to query audit log")
+		return
+	}
+	if events == nil {
+		events = []*vault.AuditEvent{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"events": events})
+}
+
+// ---- Consumption API: /v1/vault/read ----
+// Authenticated by capability token (NOT tenant token).
+
+func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub string) {
+	if r.Method != http.MethodGet {
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Extract capability token from Authorization header.
+	raw := bearerToken(r)
+	if raw == "" {
+		errJSON(w, http.StatusUnauthorized, "missing capability token")
+		return
+	}
+
+	// We need a tenant scope to get the DB. For the consumption API,
+	// we extract tenant_id from the token itself, but we need the tenant's
+	// backend to access the vault DB. Check if tenant scope is already set
+	// (management auth middleware), otherwise we need the cap token's tenant_id.
+	scope := ScopeFromContext(r.Context())
+	if scope == nil || scope.Backend == nil {
+		errJSON(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	tenantID := scope.TenantID
+
+	if s.vaultMK == nil {
+		errJSON(w, http.StatusInternalServerError, "vault master key not configured")
+		return
+	}
+
+	vs := vault.NewStore(scope.Backend.Store().DB(), s.vaultMK)
+
+	// Full 4-step verification.
+	claims, err := vs.VerifyAndResolveCapToken(r.Context(), tenantID, raw)
+	if err != nil {
+		_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+			TenantID:  tenantID,
+			EventType: "secret.denied",
+			Detail:    map[string]string{"reason": err.Error()},
+		})
+		if strings.Contains(err.Error(), "expired") {
+			errJSON(w, http.StatusUnauthorized, "token expired")
+		} else if strings.Contains(err.Error(), "revoked") {
+			errJSON(w, http.StatusUnauthorized, "token revoked")
+		} else {
+			errJSON(w, http.StatusUnauthorized, "invalid capability token")
+		}
+		return
+	}
+
+	// Parse path: /v1/vault/read, /v1/vault/read/{name}, /v1/vault/read/{name}/{field}
+	sub = strings.TrimPrefix(sub, "/")
+	if sub == "" {
+		// Enumerate: list secrets in scope.
+		s.handleVaultReadEnumerate(w, r, vs, claims)
+		return
+	}
+
+	parts := strings.SplitN(sub, "/", 2)
+	secretName := parts[0]
+	fieldName := ""
+	if len(parts) > 1 {
+		fieldName = parts[1]
+	}
+
+	if fieldName != "" {
+		s.handleVaultReadField(w, r, vs, claims, secretName, fieldName)
+	} else {
+		s.handleVaultReadSecret(w, r, vs, claims, secretName)
+	}
+}
+
+func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request, vs *vault.Store, claims *vault.CapTokenClaims) {
+	scopedNames := vault.ScopedSecretNames(claims.Scope)
+	// Filter to secrets that actually exist.
+	var available []string
+	for _, name := range scopedNames {
+		_, err := vs.GetSecret(r.Context(), claims.TenantID, name)
+		if err == nil {
+			available = append(available, name)
+		}
+	}
+
+	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+		TenantID:  claims.TenantID,
+		EventType: "secret.list",
+		TokenID:   claims.TokenID,
+		AgentID:   claims.AgentID,
+		TaskID:    claims.TaskID,
+		Adapter:   "api",
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	if available == nil {
+		available = []string{}
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"secrets": available})
+}
+
+func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, vs *vault.Store, claims *vault.CapTokenClaims, secretName string) {
+	// Scope check.
+	allFields, allowedFields := vault.AllowedFields(claims.Scope, secretName)
+	if !allFields && len(allowedFields) == 0 {
+		_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+			TenantID:   claims.TenantID,
+			EventType:  "secret.denied",
+			TokenID:    claims.TokenID,
+			AgentID:    claims.AgentID,
+			SecretName: secretName,
+			Detail:     map[string]string{"reason": "out_of_scope"},
+		})
+		// Return 404 to avoid leaking secret existence.
+		errJSON(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	fields, err := vs.ReadSecretFields(r.Context(), claims.TenantID, secretName)
+	if err != nil {
+		if errors.Is(err, vault.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "not found")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to read secret")
+		return
+	}
+
+	// Filter fields if scope is field-level.
+	if !allFields {
+		allowed := make(map[string]bool)
+		for _, f := range allowedFields {
+			allowed[f] = true
+		}
+		for k := range fields {
+			if !allowed[k] {
+				delete(fields, k)
+			}
+		}
+	}
+
+	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+		TenantID:   claims.TenantID,
+		EventType:  "secret.read",
+		TokenID:    claims.TokenID,
+		AgentID:    claims.AgentID,
+		TaskID:     claims.TaskID,
+		SecretName: secretName,
+		Adapter:    "api",
+	})
+
+	format := r.URL.Query().Get("format")
+	switch format {
+	case "env":
+		w.Header().Set("Content-Type", "text/plain")
+		for k, v := range fields {
+			fmt.Fprintf(w, "%s=%s\n", strings.ToUpper(k), string(v))
+		}
+	case "json", "":
+		result := make(map[string]string, len(fields))
+		for k, v := range fields {
+			result[k] = string(v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(result)
+	default:
+		errJSON(w, http.StatusBadRequest, "unsupported format")
+	}
+}
+
+func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs *vault.Store, claims *vault.CapTokenClaims, secretName, fieldName string) {
+	// Scope check.
+	if !vault.CheckScope(claims.Scope, secretName, fieldName) {
+		_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+			TenantID:   claims.TenantID,
+			EventType:  "secret.denied",
+			TokenID:    claims.TokenID,
+			AgentID:    claims.AgentID,
+			SecretName: secretName,
+			FieldName:  fieldName,
+			Detail:     map[string]string{"reason": "out_of_scope"},
+		})
+		errJSON(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	plaintext, err := vs.ReadSecretField(r.Context(), claims.TenantID, secretName, fieldName)
+	if err != nil {
+		if errors.Is(err, vault.ErrNotFound) || errors.Is(err, vault.ErrFieldNotFound) {
+			errJSON(w, http.StatusNotFound, "not found")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to read field")
+		return
+	}
+
+	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+		TenantID:   claims.TenantID,
+		EventType:  "secret.read",
+		TokenID:    claims.TokenID,
+		AgentID:    claims.AgentID,
+		TaskID:     claims.TaskID,
+		SecretName: secretName,
+		FieldName:  fieldName,
+		Adapter:    "api",
+	})
+
+	w.Header().Set("Content-Type", "text/plain")
+	_, _ = w.Write(plaintext)
+}

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -32,13 +32,7 @@ func (s *Server) handleVault(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Consumption API: /v1/vault/read/*
-	// Authenticated by capability token.
-	if strings.HasPrefix(rest, "read") {
-		s.handleVaultRead(w, r, strings.TrimPrefix(rest, "read"))
-		return
-	}
-
+	// /v1/vault/read/* is routed separately via capabilityAuthMiddleware.
 	errJSON(w, http.StatusNotFound, "not found")
 }
 
@@ -283,6 +277,14 @@ func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, v
 		errJSON(w, http.StatusBadRequest, "scope is required")
 		return
 	}
+	// Reject wildcard scope entries — not yet implemented.
+	// Without expansion, a wildcard token would silently fail scope checks.
+	for _, entry := range req.Scope {
+		if strings.Contains(entry, "*") {
+			errJSON(w, http.StatusBadRequest, "wildcard scope is not supported yet; specify exact secret names")
+			return
+		}
+	}
 	ttl := time.Duration(req.TTLSecs) * time.Second
 	if ttl <= 0 {
 		ttl = time.Hour // default 1 hour
@@ -322,7 +324,7 @@ func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, 
 		req.RevokedBy = "api"
 	}
 
-	err := vs.RevokeCapToken(r.Context(), tokenID, req.RevokedBy, req.Reason)
+	err := vs.RevokeCapToken(r.Context(), tenantID, tokenID, req.RevokedBy, req.Reason)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "token not found or already revoked")

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -277,13 +277,9 @@ func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, v
 		errJSON(w, http.StatusBadRequest, "scope is required")
 		return
 	}
-	// Reject wildcard scope entries — not yet implemented.
-	// Without expansion, a wildcard token would silently fail scope checks.
-	for _, entry := range req.Scope {
-		if strings.Contains(entry, "*") {
-			errJSON(w, http.StatusBadRequest, "wildcard scope is not supported yet; specify exact secret names")
-			return
-		}
+	if err := vault.ValidateScope(req.Scope); err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
 	}
 	ttl := time.Duration(req.TTLSecs) * time.Second
 	if ttl <= 0 {

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -408,14 +408,14 @@ func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub str
 
 	vs := vault.NewStore(scope.Backend.Store().DB(), s.vaultMK)
 
-	// Full 4-step verification.
+	// Full 4-step verification: HMAC signature → TTL → DB revocation → claims.
+	// IMPORTANT: Do NOT write audit events before verification succeeds.
+	// The tenant_id comes from an unverified peek and could be forged;
+	// writing to tenant audit before proving token authenticity would let
+	// an attacker inject events into any tenant's audit log.
 	claims, err := vs.VerifyAndResolveCapToken(r.Context(), tenantID, raw)
 	if err != nil {
-		_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
-			TenantID:  tenantID,
-			EventType: "secret.denied",
-			Detail:    map[string]string{"reason": err.Error()},
-		})
+		// Log to server-level observability only — not tenant audit.
 		if strings.Contains(err.Error(), "expired") {
 			errJSON(w, http.StatusUnauthorized, "token expired")
 		} else if strings.Contains(err.Error(), "revoked") {

--- a/pkg/tenant/db9/schema.go
+++ b/pkg/tenant/db9/schema.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/mem9-ai/dat9/pkg/tenant/schema"
+	"github.com/mem9-ai/dat9/pkg/vault"
 )
 
 func initDB9Schema(dsn string) error {
@@ -112,5 +113,9 @@ func initDB9Schema(dsn string) error {
 		`CREATE INDEX IF NOT EXISTS idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
 	}
 
-	return schema.ExecSchemaStatements(db, stmts)
+	if err := schema.ExecSchemaStatements(db, stmts); err != nil {
+		return err
+	}
+	// Initialize vault tables alongside core tables.
+	return vault.InitSchema(db)
 }

--- a/pkg/vault/crypto.go
+++ b/pkg/vault/crypto.go
@@ -178,6 +178,44 @@ func VerifyCapToken(csk []byte, raw string, now time.Time) (*CapTokenClaims, err
 	return &claims, nil
 }
 
+// PeekCapTokenTenantID extracts the tenant_id from a capability token's payload
+// WITHOUT verifying the HMAC signature. This is used only to resolve the tenant
+// backend so that the full verification can proceed. The caller MUST still do
+// full verification (SignCapToken/VerifyCapToken) before trusting any claims.
+func PeekCapTokenTenantID(raw string) (string, error) {
+	if len(raw) < len(capTokenPrefix) {
+		return "", fmt.Errorf("invalid capability token format")
+	}
+	body := raw[len(capTokenPrefix):]
+
+	dotIdx := -1
+	for i := len(body) - 1; i >= 0; i-- {
+		if body[i] == '.' {
+			dotIdx = i
+			break
+		}
+	}
+	if dotIdx < 0 {
+		return "", fmt.Errorf("invalid capability token format")
+	}
+	payloadB64 := body[:dotIdx]
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(payloadB64)
+	if err != nil {
+		return "", fmt.Errorf("decode payload: %w", err)
+	}
+	var peek struct {
+		TenantID string `json:"tenant_id"`
+	}
+	if err := json.Unmarshal(payloadJSON, &peek); err != nil {
+		return "", fmt.Errorf("unmarshal claims: %w", err)
+	}
+	if peek.TenantID == "" {
+		return "", fmt.Errorf("missing tenant_id in token")
+	}
+	return peek.TenantID, nil
+}
+
 // GenerateNonce returns a random 16-byte nonce as hex string.
 func GenerateNonce() (string, error) {
 	b := make([]byte, 16)

--- a/pkg/vault/crypto.go
+++ b/pkg/vault/crypto.go
@@ -1,0 +1,188 @@
+package vault
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// MasterKey wraps the server-wide master key used to wrap/unwrap tenant DEKs
+// and derive capability signing keys.
+type MasterKey struct {
+	key []byte
+	gcm cipher.AEAD
+}
+
+// NewMasterKey creates a MasterKey from raw 32-byte key material.
+func NewMasterKey(key []byte) (*MasterKey, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("vault master key must be 32 bytes, got %d", len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("cipher.NewGCM: %w", err)
+	}
+	return &MasterKey{key: key, gcm: gcm}, nil
+}
+
+// GenerateDEK creates a new random 32-byte DEK and returns it wrapped (encrypted by MK).
+func (mk *MasterKey) GenerateDEK() (plainDEK []byte, wrappedDEK []byte, err error) {
+	plainDEK = make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, plainDEK); err != nil {
+		return nil, nil, fmt.Errorf("generate DEK: %w", err)
+	}
+	nonce := make([]byte, mk.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, nil, fmt.Errorf("generate nonce: %w", err)
+	}
+	wrappedDEK = mk.gcm.Seal(nonce, nonce, plainDEK, nil)
+	return plainDEK, wrappedDEK, nil
+}
+
+// UnwrapDEK decrypts a wrapped DEK using the master key.
+func (mk *MasterKey) UnwrapDEK(wrappedDEK []byte) ([]byte, error) {
+	ns := mk.gcm.NonceSize()
+	if len(wrappedDEK) < ns {
+		return nil, fmt.Errorf("wrapped DEK too short")
+	}
+	plainDEK, err := mk.gcm.Open(nil, wrappedDEK[:ns], wrappedDEK[ns:], nil)
+	if err != nil {
+		return nil, fmt.Errorf("unwrap DEK: %w", err)
+	}
+	return plainDEK, nil
+}
+
+// DeriveCSK derives the Capability Signing Key from MK + tenantID.
+func (mk *MasterKey) DeriveCSK(tenantID string) []byte {
+	mac := hmac.New(sha256.New, mk.key)
+	mac.Write([]byte("vault-csk:" + tenantID))
+	return mac.Sum(nil)
+}
+
+// FieldEncryptor encrypts/decrypts individual secret field values using a DEK.
+type FieldEncryptor struct {
+	gcm cipher.AEAD
+}
+
+// NewFieldEncryptor creates a field encryptor from a plaintext DEK.
+func NewFieldEncryptor(dek []byte) (*FieldEncryptor, error) {
+	if len(dek) != 32 {
+		return nil, fmt.Errorf("DEK must be 32 bytes")
+	}
+	block, err := aes.NewCipher(dek)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return &FieldEncryptor{gcm: gcm}, nil
+}
+
+// Encrypt encrypts a plaintext field value. Returns (ciphertext, nonce).
+func (fe *FieldEncryptor) Encrypt(plaintext []byte) (ciphertext []byte, nonce []byte, err error) {
+	nonce = make([]byte, fe.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, nil, err
+	}
+	ciphertext = fe.gcm.Seal(nil, nonce, plaintext, nil)
+	return ciphertext, nonce, nil
+}
+
+// Decrypt decrypts a field value given ciphertext and nonce.
+func (fe *FieldEncryptor) Decrypt(ciphertext, nonce []byte) ([]byte, error) {
+	return fe.gcm.Open(nil, nonce, ciphertext, nil)
+}
+
+// ---- Capability Token signing/verification ----
+
+const capTokenPrefix = "vault_"
+
+// SignCapToken signs a CapTokenClaims payload with the tenant's CSK.
+func SignCapToken(csk []byte, claims *CapTokenClaims) (string, error) {
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal claims: %w", err)
+	}
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+
+	mac := hmac.New(sha256.New, csk)
+	mac.Write([]byte(payloadB64))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return capTokenPrefix + payloadB64 + "." + sig, nil
+}
+
+// VerifyCapToken verifies an HMAC-signed capability token and returns claims.
+// This only checks signature and TTL — caller must also check DB revocation.
+func VerifyCapToken(csk []byte, raw string, now time.Time) (*CapTokenClaims, error) {
+	if len(raw) < len(capTokenPrefix) {
+		return nil, fmt.Errorf("invalid capability token format")
+	}
+	body := raw[len(capTokenPrefix):]
+
+	// Split payload.sig
+	dotIdx := -1
+	for i := len(body) - 1; i >= 0; i-- {
+		if body[i] == '.' {
+			dotIdx = i
+			break
+		}
+	}
+	if dotIdx < 0 {
+		return nil, fmt.Errorf("invalid capability token format")
+	}
+	payloadB64 := body[:dotIdx]
+	sigB64 := body[dotIdx+1:]
+
+	// Verify HMAC signature.
+	mac := hmac.New(sha256.New, csk)
+	mac.Write([]byte(payloadB64))
+	expectedSig := mac.Sum(nil)
+
+	sig, err := base64.RawURLEncoding.DecodeString(sigB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode signature: %w", err)
+	}
+	if !hmac.Equal(sig, expectedSig) {
+		return nil, fmt.Errorf("invalid token signature")
+	}
+
+	// Decode claims.
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(payloadB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode payload: %w", err)
+	}
+	var claims CapTokenClaims
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		return nil, fmt.Errorf("unmarshal claims: %w", err)
+	}
+
+	// Check TTL.
+	if now.Unix() > claims.ExpiresAt {
+		return nil, fmt.Errorf("token expired")
+	}
+
+	return &claims, nil
+}
+
+// GenerateNonce returns a random 16-byte nonce as hex string.
+func GenerateNonce() (string, error) {
+	b := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
+}

--- a/pkg/vault/crypto_test.go
+++ b/pkg/vault/crypto_test.go
@@ -136,7 +136,7 @@ func TestCapTokenSignVerify(t *testing.T) {
 
 func TestCapTokenExpired(t *testing.T) {
 	key := make([]byte, 32)
-	rand.Read(key)
+	_, _ = rand.Read(key)
 	mk, _ := NewMasterKey(key)
 	csk := mk.DeriveCSK("tenant-1")
 
@@ -160,7 +160,7 @@ func TestCapTokenExpired(t *testing.T) {
 
 func TestCapTokenBadSignature(t *testing.T) {
 	key := make([]byte, 32)
-	rand.Read(key)
+	_, _ = rand.Read(key)
 	mk, _ := NewMasterKey(key)
 	csk := mk.DeriveCSK("tenant-1")
 
@@ -186,7 +186,7 @@ func TestCapTokenBadSignature(t *testing.T) {
 
 func TestPeekCapTokenTenantID(t *testing.T) {
 	key := make([]byte, 32)
-	rand.Read(key)
+	_, _ = rand.Read(key)
 	mk, _ := NewMasterKey(key)
 	csk := mk.DeriveCSK("tenant-42")
 
@@ -218,7 +218,7 @@ func TestPeekCapTokenTenantID(t *testing.T) {
 
 func TestDeriveCSKDifferentTenants(t *testing.T) {
 	key := make([]byte, 32)
-	rand.Read(key)
+	_, _ = rand.Read(key)
 	mk, _ := NewMasterKey(key)
 
 	csk1 := mk.DeriveCSK("tenant-1")

--- a/pkg/vault/crypto_test.go
+++ b/pkg/vault/crypto_test.go
@@ -1,0 +1,198 @@
+package vault
+
+import (
+	"crypto/rand"
+	"testing"
+	"time"
+)
+
+func TestMasterKeyGenerateAndUnwrapDEK(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	mk, err := NewMasterKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plainDEK, wrappedDEK, err := mk.GenerateDEK()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plainDEK) != 32 {
+		t.Fatalf("expected 32-byte DEK, got %d", len(plainDEK))
+	}
+	if len(wrappedDEK) == 0 {
+		t.Fatal("wrapped DEK is empty")
+	}
+
+	unwrapped, err := mk.UnwrapDEK(wrappedDEK)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(unwrapped) != string(plainDEK) {
+		t.Fatal("unwrapped DEK does not match original")
+	}
+}
+
+func TestMasterKeyBadSize(t *testing.T) {
+	_, err := NewMasterKey([]byte("too-short"))
+	if err == nil {
+		t.Fatal("expected error for short key")
+	}
+}
+
+func TestFieldEncryptorRoundTrip(t *testing.T) {
+	dek := make([]byte, 32)
+	if _, err := rand.Read(dek); err != nil {
+		t.Fatal(err)
+	}
+	fe, err := NewFieldEncryptor(dek)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext := []byte("my-secret-password")
+	ciphertext, nonce, err := fe.Encrypt(plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ciphertext) == 0 || len(nonce) == 0 {
+		t.Fatal("ciphertext or nonce is empty")
+	}
+
+	decrypted, err := fe.Decrypt(ciphertext, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decrypted) != string(plaintext) {
+		t.Fatalf("decrypted %q != original %q", decrypted, plaintext)
+	}
+}
+
+func TestFieldEncryptorDifferentNonces(t *testing.T) {
+	dek := make([]byte, 32)
+	if _, err := rand.Read(dek); err != nil {
+		t.Fatal(err)
+	}
+	fe, err := NewFieldEncryptor(dek)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext := []byte("same-value")
+	ct1, n1, _ := fe.Encrypt(plaintext)
+	ct2, n2, _ := fe.Encrypt(plaintext)
+
+	// Same plaintext should produce different ciphertexts (different nonces).
+	if string(ct1) == string(ct2) {
+		t.Fatal("identical ciphertexts for same plaintext — nonce reuse")
+	}
+	if string(n1) == string(n2) {
+		t.Fatal("identical nonces")
+	}
+}
+
+func TestCapTokenSignVerify(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	mk, _ := NewMasterKey(key)
+	csk := mk.DeriveCSK("tenant-1")
+
+	claims := &CapTokenClaims{
+		TokenID:   "cap_test123",
+		TenantID:  "tenant-1",
+		AgentID:   "agent-1",
+		TaskID:    "task-1",
+		Scope:     []string{"aws-prod", "db-prod/password"},
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		Nonce:     "deadbeef",
+	}
+
+	tokenStr, err := SignCapToken(csk, claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify should succeed.
+	parsed, err := VerifyCapToken(csk, tokenStr, time.Now())
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	if parsed.TokenID != claims.TokenID {
+		t.Fatalf("token_id mismatch: %s != %s", parsed.TokenID, claims.TokenID)
+	}
+	if parsed.AgentID != claims.AgentID {
+		t.Fatalf("agent_id mismatch")
+	}
+	if len(parsed.Scope) != 2 {
+		t.Fatalf("scope length mismatch")
+	}
+}
+
+func TestCapTokenExpired(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+	mk, _ := NewMasterKey(key)
+	csk := mk.DeriveCSK("tenant-1")
+
+	claims := &CapTokenClaims{
+		TokenID:   "cap_expired",
+		TenantID:  "tenant-1",
+		AgentID:   "agent-1",
+		Scope:     []string{"test"},
+		IssuedAt:  time.Now().Add(-2 * time.Hour).Unix(),
+		ExpiresAt: time.Now().Add(-1 * time.Hour).Unix(),
+		Nonce:     "abc",
+	}
+
+	tokenStr, _ := SignCapToken(csk, claims)
+
+	_, err := VerifyCapToken(csk, tokenStr, time.Now())
+	if err == nil {
+		t.Fatal("expected error for expired token")
+	}
+}
+
+func TestCapTokenBadSignature(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+	mk, _ := NewMasterKey(key)
+	csk := mk.DeriveCSK("tenant-1")
+
+	claims := &CapTokenClaims{
+		TokenID:   "cap_badsig",
+		TenantID:  "tenant-1",
+		AgentID:   "agent-1",
+		Scope:     []string{"test"},
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		Nonce:     "xyz",
+	}
+
+	tokenStr, _ := SignCapToken(csk, claims)
+
+	// Use wrong CSK.
+	wrongCSK := mk.DeriveCSK("tenant-2")
+	_, err := VerifyCapToken(wrongCSK, tokenStr, time.Now())
+	if err == nil {
+		t.Fatal("expected error for wrong signature")
+	}
+}
+
+func TestDeriveCSKDifferentTenants(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+	mk, _ := NewMasterKey(key)
+
+	csk1 := mk.DeriveCSK("tenant-1")
+	csk2 := mk.DeriveCSK("tenant-2")
+
+	if string(csk1) == string(csk2) {
+		t.Fatal("different tenants should have different CSKs")
+	}
+}

--- a/pkg/vault/crypto_test.go
+++ b/pkg/vault/crypto_test.go
@@ -184,6 +184,38 @@ func TestCapTokenBadSignature(t *testing.T) {
 	}
 }
 
+func TestPeekCapTokenTenantID(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+	mk, _ := NewMasterKey(key)
+	csk := mk.DeriveCSK("tenant-42")
+
+	claims := &CapTokenClaims{
+		TokenID:   "cap_test",
+		TenantID:  "tenant-42",
+		AgentID:   "agent-1",
+		Scope:     []string{"secret-a"},
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		Nonce:     "abc",
+	}
+	tokenStr, _ := SignCapToken(csk, claims)
+
+	tenantID, err := PeekCapTokenTenantID(tokenStr)
+	if err != nil {
+		t.Fatalf("PeekCapTokenTenantID failed: %v", err)
+	}
+	if tenantID != "tenant-42" {
+		t.Fatalf("expected tenant-42, got %s", tenantID)
+	}
+
+	// Invalid token.
+	_, err = PeekCapTokenTenantID("garbage")
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}
+
 func TestDeriveCSKDifferentTenants(t *testing.T) {
 	key := make([]byte, 32)
 	rand.Read(key)

--- a/pkg/vault/errors.go
+++ b/pkg/vault/errors.go
@@ -1,0 +1,11 @@
+package vault
+
+import "errors"
+
+var (
+	ErrNotFound      = errors.New("vault: not found")
+	ErrFieldNotFound = errors.New("vault: field not found")
+	ErrOutOfScope    = errors.New("vault: secret not in token scope")
+	ErrTokenExpired  = errors.New("vault: token expired")
+	ErrTokenRevoked  = errors.New("vault: token revoked")
+)

--- a/pkg/vault/schema.go
+++ b/pkg/vault/schema.go
@@ -1,0 +1,80 @@
+package vault
+
+import (
+	"database/sql"
+
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
+)
+
+// InitSchema creates the vault tables in the tenant database.
+func InitSchema(db *sql.DB) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS vault_deks (
+			tenant_id    VARCHAR(64) PRIMARY KEY,
+			wrapped_dek  BYTEA NOT NULL,
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_secrets (
+			secret_id    VARCHAR(64) PRIMARY KEY,
+			tenant_id    VARCHAR(64) NOT NULL,
+			name         VARCHAR(255) NOT NULL,
+			secret_type  VARCHAR(32) NOT NULL DEFAULT 'generic',
+			revision     BIGINT NOT NULL DEFAULT 1,
+			created_by   VARCHAR(255) NOT NULL,
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			deleted_at   TIMESTAMPTZ,
+			UNIQUE (tenant_id, name)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_vault_secrets_tenant ON vault_secrets(tenant_id)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_secret_fields (
+			secret_id       VARCHAR(64) NOT NULL,
+			field_name      VARCHAR(255) NOT NULL,
+			encrypted_value BYTEA NOT NULL,
+			nonce           BYTEA NOT NULL,
+			PRIMARY KEY (secret_id, field_name)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_tokens (
+			token_id      VARCHAR(64) PRIMARY KEY,
+			tenant_id     VARCHAR(64) NOT NULL,
+			agent_id      VARCHAR(255) NOT NULL,
+			task_id       VARCHAR(255),
+			scope_json    JSONB NOT NULL,
+			issued_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			expires_at    TIMESTAMPTZ NOT NULL,
+			revoked_at    TIMESTAMPTZ,
+			revoked_by    VARCHAR(255),
+			revoke_reason VARCHAR(255)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_vault_token_tenant ON vault_tokens(tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_vault_token_agent ON vault_tokens(agent_id)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_policies (
+			policy_id   VARCHAR(64) PRIMARY KEY,
+			tenant_id   VARCHAR(64) NOT NULL,
+			name        VARCHAR(255) NOT NULL,
+			rules_json  JSONB NOT NULL,
+			created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_audit_log (
+			event_id     VARCHAR(64) PRIMARY KEY,
+			tenant_id    VARCHAR(64) NOT NULL,
+			event_type   VARCHAR(32) NOT NULL,
+			token_id     VARCHAR(64),
+			agent_id     VARCHAR(255),
+			task_id      VARCHAR(255),
+			secret_name  VARCHAR(255),
+			field_name   VARCHAR(255),
+			adapter      VARCHAR(16),
+			detail_json  JSONB,
+			timestamp    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_vault_audit_tenant_time ON vault_audit_log(tenant_id, timestamp)`,
+		`CREATE INDEX IF NOT EXISTS idx_vault_audit_secret ON vault_audit_log(secret_name, timestamp)`,
+	}
+	return schema.ExecSchemaStatements(db, stmts)
+}

--- a/pkg/vault/scope.go
+++ b/pkg/vault/scope.go
@@ -1,0 +1,63 @@
+package vault
+
+import "strings"
+
+// CheckScope verifies that a requested secret/field is within the token's scope.
+// Scope entries:
+//   - "aws-prod" → access all fields of aws-prod
+//   - "db-prod/password" → access only the password field of db-prod
+func CheckScope(scope []string, secretName, fieldName string) bool {
+	for _, entry := range scope {
+		if entry == secretName {
+			return true // full secret access
+		}
+		if fieldName != "" {
+			// Check field-level scope: "secret/field"
+			if entry == secretName+"/"+fieldName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ScopedSecretNames returns the set of secret names the token can access.
+func ScopedSecretNames(scope []string) []string {
+	seen := make(map[string]bool)
+	var names []string
+	for _, entry := range scope {
+		name := entry
+		if idx := strings.IndexByte(entry, '/'); idx >= 0 {
+			name = entry[:idx]
+		}
+		if !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// HasFullSecretAccess returns true if the scope grants access to all fields.
+func HasFullSecretAccess(scope []string, secretName string) bool {
+	for _, entry := range scope {
+		if entry == secretName {
+			return true
+		}
+	}
+	return false
+}
+
+// AllowedFields returns the set of field names allowed by scope for a given secret.
+// If the scope grants full secret access, returns nil (meaning all fields allowed).
+func AllowedFields(scope []string, secretName string) (allFields bool, fields []string) {
+	for _, entry := range scope {
+		if entry == secretName {
+			return true, nil
+		}
+		if strings.HasPrefix(entry, secretName+"/") {
+			fields = append(fields, entry[len(secretName)+1:])
+		}
+	}
+	return false, fields
+}

--- a/pkg/vault/scope.go
+++ b/pkg/vault/scope.go
@@ -1,6 +1,30 @@
 package vault
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateScope checks that all scope entries are well-formed. Returns an error
+// for entries containing wildcards (*) or empty segments.
+func ValidateScope(scope []string) error {
+	for _, entry := range scope {
+		if entry == "" {
+			return fmt.Errorf("empty scope entry")
+		}
+		if strings.Contains(entry, "*") {
+			return fmt.Errorf("wildcard scope entries are not supported: %q", entry)
+		}
+		parts := strings.SplitN(entry, "/", 2)
+		if parts[0] == "" {
+			return fmt.Errorf("empty secret name in scope entry: %q", entry)
+		}
+		if len(parts) == 2 && parts[1] == "" {
+			return fmt.Errorf("empty field name in scope entry: %q", entry)
+		}
+	}
+	return nil
+}
 
 // CheckScope verifies that a requested secret/field is within the token's scope.
 // Scope entries:

--- a/pkg/vault/scope_test.go
+++ b/pkg/vault/scope_test.go
@@ -1,0 +1,80 @@
+package vault
+
+import (
+	"testing"
+)
+
+func TestCheckScope(t *testing.T) {
+	scope := []string{"aws-prod", "db-prod/password", "github-token"}
+
+	tests := []struct {
+		name      string
+		secret    string
+		field     string
+		want      bool
+	}{
+		{"full secret access", "aws-prod", "", true},
+		{"full secret with field", "aws-prod", "access-key", true},
+		{"field-level access", "db-prod", "password", true},
+		{"wrong field", "db-prod", "host", false},
+		{"no field specified for field-level", "db-prod", "", false},
+		{"not in scope", "unknown", "", false},
+		{"not in scope with field", "unknown", "key", false},
+		{"github-token full access", "github-token", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckScope(scope, tt.secret, tt.field)
+			if got != tt.want {
+				t.Errorf("CheckScope(%q, %q) = %v, want %v", tt.secret, tt.field, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopedSecretNames(t *testing.T) {
+	scope := []string{"aws-prod", "db-prod/password", "db-prod/host", "github-token"}
+	names := ScopedSecretNames(scope)
+
+	expected := map[string]bool{"aws-prod": true, "db-prod": true, "github-token": true}
+	if len(names) != len(expected) {
+		t.Fatalf("expected %d names, got %d: %v", len(expected), len(names), names)
+	}
+	for _, n := range names {
+		if !expected[n] {
+			t.Errorf("unexpected name: %s", n)
+		}
+	}
+}
+
+func TestAllowedFields(t *testing.T) {
+	scope := []string{"aws-prod", "db-prod/password", "db-prod/host"}
+
+	// Full access.
+	allFields, fields := AllowedFields(scope, "aws-prod")
+	if !allFields {
+		t.Error("expected full access for aws-prod")
+	}
+	if fields != nil {
+		t.Error("expected nil fields for full access")
+	}
+
+	// Field-level access.
+	allFields, fields = AllowedFields(scope, "db-prod")
+	if allFields {
+		t.Error("expected field-level access for db-prod")
+	}
+	if len(fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(fields))
+	}
+
+	// No access.
+	allFields, fields = AllowedFields(scope, "unknown")
+	if allFields {
+		t.Error("expected no access for unknown")
+	}
+	if len(fields) != 0 {
+		t.Errorf("expected 0 fields, got %d", len(fields))
+	}
+}

--- a/pkg/vault/scope_test.go
+++ b/pkg/vault/scope_test.go
@@ -48,6 +48,31 @@ func TestScopedSecretNames(t *testing.T) {
 	}
 }
 
+func TestValidateScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		scope   []string
+		wantErr bool
+	}{
+		{"valid simple", []string{"aws-prod", "db-prod/password"}, false},
+		{"wildcard rejected", []string{"aws-*"}, true},
+		{"wildcard in field", []string{"db-prod/*"}, true},
+		{"empty entry", []string{""}, true},
+		{"empty secret name", []string{"/password"}, true},
+		{"empty field name", []string{"db-prod/"}, true},
+		{"valid single", []string{"github-token"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateScope(tt.scope)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateScope(%v) error = %v, wantErr %v", tt.scope, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestAllowedFields(t *testing.T) {
 	scope := []string{"aws-prod", "db-prod/password", "db-prod/host"}
 

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -326,7 +326,7 @@ func (s *Store) ReadSecretField(ctx context.Context, tenantID, name, fieldName s
 
 // IssueCapToken creates a capability token and persists its server-side state.
 func (s *Store) IssueCapToken(ctx context.Context, tenantID, agentID, taskID string, scope []string, ttl time.Duration) (string, *CapToken, error) {
-	tokenID := "cap_" + uuid.NewString()[:8]
+	tokenID := "cap_" + uuid.NewString()
 	now := time.Now()
 	expiresAt := now.Add(ttl)
 
@@ -382,11 +382,11 @@ func (s *Store) VerifyAndResolveCapToken(ctx context.Context, tenantID, raw stri
 		return nil, err
 	}
 
-	// DB revocation check.
+	// DB revocation check — scoped to tenant for isolation.
 	var revokedAt *time.Time
 	err = s.db.QueryRowContext(ctx,
-		`SELECT revoked_at FROM vault_tokens WHERE token_id = $1`,
-		claims.TokenID,
+		`SELECT revoked_at FROM vault_tokens WHERE tenant_id = $1 AND token_id = $2`,
+		tenantID, claims.TokenID,
 	).Scan(&revokedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("token not found")
@@ -402,12 +402,13 @@ func (s *Store) VerifyAndResolveCapToken(ctx context.Context, tenantID, raw stri
 }
 
 // RevokeCapToken sets revoked_at on a capability token.
-func (s *Store) RevokeCapToken(ctx context.Context, tokenID, revokedBy, reason string) error {
+// tenantID is required to enforce tenant isolation.
+func (s *Store) RevokeCapToken(ctx context.Context, tenantID, tokenID, revokedBy, reason string) error {
 	now := time.Now()
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE vault_tokens SET revoked_at = $1, revoked_by = $2, revoke_reason = $3
-		 WHERE token_id = $4 AND revoked_at IS NULL`,
-		now, revokedBy, reason, tokenID,
+		 WHERE tenant_id = $4 AND token_id = $5 AND revoked_at IS NULL`,
+		now, revokedBy, reason, tenantID, tokenID,
 	)
 	if err != nil {
 		return err

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -1,0 +1,480 @@
+package vault
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Store provides CRUD operations for the vault data model.
+type Store struct {
+	db *sql.DB
+	mk *MasterKey
+}
+
+// NewStore creates a new vault store.
+func NewStore(db *sql.DB, mk *MasterKey) *Store {
+	return &Store{db: db, mk: mk}
+}
+
+// DB returns the underlying database connection.
+func (s *Store) DB() *sql.DB { return s.db }
+
+// ---- DEK Management ----
+
+// GetOrCreateDEK returns the plaintext DEK for a tenant, creating one if needed.
+func (s *Store) GetOrCreateDEK(ctx context.Context, tenantID string) ([]byte, error) {
+	var wrappedDEK []byte
+	err := s.db.QueryRowContext(ctx,
+		`SELECT wrapped_dek FROM vault_deks WHERE tenant_id = $1`, tenantID,
+	).Scan(&wrappedDEK)
+
+	if err == nil {
+		return s.mk.UnwrapDEK(wrappedDEK)
+	}
+	if err != sql.ErrNoRows {
+		return nil, fmt.Errorf("query DEK: %w", err)
+	}
+
+	// Generate new DEK.
+	_, wrappedDEK, err = s.mk.GenerateDEK()
+	if err != nil {
+		return nil, err
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO vault_deks (tenant_id, wrapped_dek) VALUES ($1, $2) ON CONFLICT (tenant_id) DO NOTHING`,
+		tenantID, wrappedDEK,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert DEK: %w", err)
+	}
+
+	// Re-read in case of race (another process inserted first).
+	err = s.db.QueryRowContext(ctx,
+		`SELECT wrapped_dek FROM vault_deks WHERE tenant_id = $1`, tenantID,
+	).Scan(&wrappedDEK)
+	if err != nil {
+		return nil, fmt.Errorf("re-read DEK: %w", err)
+	}
+	return s.mk.UnwrapDEK(wrappedDEK)
+}
+
+// fieldEncryptor returns a FieldEncryptor for the given tenant.
+func (s *Store) fieldEncryptor(ctx context.Context, tenantID string) (*FieldEncryptor, error) {
+	dek, err := s.GetOrCreateDEK(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	return NewFieldEncryptor(dek)
+}
+
+// ---- Secret CRUD ----
+
+// CreateSecret creates a new secret with encrypted fields.
+func (s *Store) CreateSecret(ctx context.Context, tenantID, name, createdBy string, secretType SecretType, fields map[string][]byte) (*Secret, error) {
+	fe, err := s.fieldEncryptor(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	secretID := uuid.NewString()
+	now := time.Now()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO vault_secrets (secret_id, tenant_id, name, secret_type, revision, created_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 1, $5, $6, $6)`,
+		secretID, tenantID, name, string(secretType), createdBy, now,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert secret: %w", err)
+	}
+
+	for fieldName, plaintext := range fields {
+		ciphertext, nonce, err := fe.Encrypt(plaintext)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt field %s: %w", fieldName, err)
+		}
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO vault_secret_fields (secret_id, field_name, encrypted_value, nonce)
+			 VALUES ($1, $2, $3, $4)`,
+			secretID, fieldName, ciphertext, nonce,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("insert field %s: %w", fieldName, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &Secret{
+		SecretID:   secretID,
+		TenantID:   tenantID,
+		Name:       name,
+		SecretType: secretType,
+		Revision:   1,
+		CreatedBy:  createdBy,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}, nil
+}
+
+// GetSecret returns secret metadata (no decrypted values).
+func (s *Store) GetSecret(ctx context.Context, tenantID, name string) (*Secret, error) {
+	var sec Secret
+	err := s.db.QueryRowContext(ctx,
+		`SELECT secret_id, tenant_id, name, secret_type, revision, created_by, created_at, updated_at, deleted_at
+		 FROM vault_secrets WHERE tenant_id = $1 AND name = $2 AND deleted_at IS NULL`,
+		tenantID, name,
+	).Scan(&sec.SecretID, &sec.TenantID, &sec.Name, &sec.SecretType, &sec.Revision,
+		&sec.CreatedBy, &sec.CreatedAt, &sec.UpdatedAt, &sec.DeletedAt)
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &sec, nil
+}
+
+// ListSecrets returns metadata for all non-deleted secrets in a tenant.
+func (s *Store) ListSecrets(ctx context.Context, tenantID string) ([]*Secret, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT secret_id, tenant_id, name, secret_type, revision, created_by, created_at, updated_at
+		 FROM vault_secrets WHERE tenant_id = $1 AND deleted_at IS NULL ORDER BY name`,
+		tenantID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var secrets []*Secret
+	for rows.Next() {
+		var sec Secret
+		if err := rows.Scan(&sec.SecretID, &sec.TenantID, &sec.Name, &sec.SecretType,
+			&sec.Revision, &sec.CreatedBy, &sec.CreatedAt, &sec.UpdatedAt); err != nil {
+			return nil, err
+		}
+		secrets = append(secrets, &sec)
+	}
+	return secrets, rows.Err()
+}
+
+// UpdateSecret rotates a secret's field values and bumps revision.
+func (s *Store) UpdateSecret(ctx context.Context, tenantID, name, updatedBy string, fields map[string][]byte) (*Secret, error) {
+	fe, err := s.fieldEncryptor(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var secretID string
+	var revision int64
+	now := time.Now()
+
+	err = tx.QueryRowContext(ctx,
+		`SELECT secret_id, revision FROM vault_secrets
+		 WHERE tenant_id = $1 AND name = $2 AND deleted_at IS NULL
+		 FOR UPDATE`,
+		tenantID, name,
+	).Scan(&secretID, &revision)
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	newRevision := revision + 1
+	_, err = tx.ExecContext(ctx,
+		`UPDATE vault_secrets SET revision = $1, updated_at = $2 WHERE secret_id = $3`,
+		newRevision, now, secretID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Delete old fields, insert new ones.
+	_, err = tx.ExecContext(ctx, `DELETE FROM vault_secret_fields WHERE secret_id = $1`, secretID)
+	if err != nil {
+		return nil, err
+	}
+	for fieldName, plaintext := range fields {
+		ciphertext, nonce, err := fe.Encrypt(plaintext)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt field %s: %w", fieldName, err)
+		}
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO vault_secret_fields (secret_id, field_name, encrypted_value, nonce)
+			 VALUES ($1, $2, $3, $4)`,
+			secretID, fieldName, ciphertext, nonce,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &Secret{
+		SecretID:  secretID,
+		TenantID:  tenantID,
+		Name:      name,
+		Revision:  newRevision,
+		UpdatedAt: now,
+	}, nil
+}
+
+// DeleteSecret soft-deletes a secret.
+func (s *Store) DeleteSecret(ctx context.Context, tenantID, name string) error {
+	now := time.Now()
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE vault_secrets SET deleted_at = $1 WHERE tenant_id = $2 AND name = $3 AND deleted_at IS NULL`,
+		now, tenantID, name,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ReadSecretFields decrypts and returns all fields of a secret.
+func (s *Store) ReadSecretFields(ctx context.Context, tenantID, name string) (map[string][]byte, error) {
+	sec, err := s.GetSecret(ctx, tenantID, name)
+	if err != nil {
+		return nil, err
+	}
+	fe, err := s.fieldEncryptor(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT field_name, encrypted_value, nonce FROM vault_secret_fields WHERE secret_id = $1`,
+		sec.SecretID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	fields := make(map[string][]byte)
+	for rows.Next() {
+		var fieldName string
+		var ciphertext, nonce []byte
+		if err := rows.Scan(&fieldName, &ciphertext, &nonce); err != nil {
+			return nil, err
+		}
+		plaintext, err := fe.Decrypt(ciphertext, nonce)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt field %s: %w", fieldName, err)
+		}
+		fields[fieldName] = plaintext
+	}
+	return fields, rows.Err()
+}
+
+// ReadSecretField decrypts and returns a single field of a secret.
+func (s *Store) ReadSecretField(ctx context.Context, tenantID, name, fieldName string) ([]byte, error) {
+	sec, err := s.GetSecret(ctx, tenantID, name)
+	if err != nil {
+		return nil, err
+	}
+	fe, err := s.fieldEncryptor(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	var ciphertext, nonce []byte
+	err = s.db.QueryRowContext(ctx,
+		`SELECT encrypted_value, nonce FROM vault_secret_fields WHERE secret_id = $1 AND field_name = $2`,
+		sec.SecretID, fieldName,
+	).Scan(&ciphertext, &nonce)
+	if err == sql.ErrNoRows {
+		return nil, ErrFieldNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return fe.Decrypt(ciphertext, nonce)
+}
+
+// ---- Capability Token ----
+
+// IssueCapToken creates a capability token and persists its server-side state.
+func (s *Store) IssueCapToken(ctx context.Context, tenantID, agentID, taskID string, scope []string, ttl time.Duration) (string, *CapToken, error) {
+	tokenID := "cap_" + uuid.NewString()[:8]
+	now := time.Now()
+	expiresAt := now.Add(ttl)
+
+	nonce, err := GenerateNonce()
+	if err != nil {
+		return "", nil, err
+	}
+
+	claims := &CapTokenClaims{
+		TokenID:   tokenID,
+		TenantID:  tenantID,
+		AgentID:   agentID,
+		TaskID:    taskID,
+		Scope:     scope,
+		IssuedAt:  now.Unix(),
+		ExpiresAt: expiresAt.Unix(),
+		Nonce:     nonce,
+	}
+
+	csk := s.mk.DeriveCSK(tenantID)
+	tokenStr, err := SignCapToken(csk, claims)
+	if err != nil {
+		return "", nil, err
+	}
+
+	scopeJSON, _ := json.Marshal(scope)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO vault_tokens (token_id, tenant_id, agent_id, task_id, scope_json, issued_at, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		tokenID, tenantID, agentID, taskID, scopeJSON, now, expiresAt,
+	)
+	if err != nil {
+		return "", nil, fmt.Errorf("insert token: %w", err)
+	}
+
+	return tokenStr, &CapToken{
+		TokenID:   tokenID,
+		TenantID:  tenantID,
+		AgentID:   agentID,
+		TaskID:    taskID,
+		Scope:     scope,
+		IssuedAt:  now,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// VerifyAndResolveCapToken performs the full 4-step verification flow.
+// 1. HMAC signature check  2. TTL check  3. DB revocation check  4. Returns claims for scope check
+func (s *Store) VerifyAndResolveCapToken(ctx context.Context, tenantID, raw string) (*CapTokenClaims, error) {
+	csk := s.mk.DeriveCSK(tenantID)
+	claims, err := VerifyCapToken(csk, raw, time.Now())
+	if err != nil {
+		return nil, err
+	}
+
+	// DB revocation check.
+	var revokedAt *time.Time
+	err = s.db.QueryRowContext(ctx,
+		`SELECT revoked_at FROM vault_tokens WHERE token_id = $1`,
+		claims.TokenID,
+	).Scan(&revokedAt)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("token not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query token: %w", err)
+	}
+	if revokedAt != nil {
+		return nil, fmt.Errorf("token revoked")
+	}
+
+	return claims, nil
+}
+
+// RevokeCapToken sets revoked_at on a capability token.
+func (s *Store) RevokeCapToken(ctx context.Context, tokenID, revokedBy, reason string) error {
+	now := time.Now()
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE vault_tokens SET revoked_at = $1, revoked_by = $2, revoke_reason = $3
+		 WHERE token_id = $4 AND revoked_at IS NULL`,
+		now, revokedBy, reason, tokenID,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ---- Audit Log ----
+
+// WriteAuditEvent appends an audit event.
+func (s *Store) WriteAuditEvent(ctx context.Context, event *AuditEvent) error {
+	if event.EventID == "" {
+		event.EventID = uuid.NewString()
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+	var detailJSON []byte
+	if event.Detail != nil {
+		detailJSON, _ = json.Marshal(event.Detail)
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO vault_audit_log (event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		event.EventID, event.TenantID, event.EventType, event.TokenID, event.AgentID,
+		event.TaskID, event.SecretName, event.FieldName, event.Adapter, detailJSON, event.Timestamp,
+	)
+	return err
+}
+
+// QueryAuditLog returns audit events for a tenant, with optional filters.
+func (s *Store) QueryAuditLog(ctx context.Context, tenantID string, secretName string, limit int) ([]*AuditEvent, error) {
+	var query string
+	var args []any
+
+	if secretName != "" {
+		query = `SELECT event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp
+			FROM vault_audit_log WHERE tenant_id = $1 AND secret_name = $2 ORDER BY timestamp DESC LIMIT $3`
+		args = []any{tenantID, secretName, limit}
+	} else {
+		query = `SELECT event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp
+			FROM vault_audit_log WHERE tenant_id = $1 ORDER BY timestamp DESC LIMIT $2`
+		args = []any{tenantID, limit}
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var events []*AuditEvent
+	for rows.Next() {
+		var ev AuditEvent
+		var detailJSON []byte
+		if err := rows.Scan(&ev.EventID, &ev.TenantID, &ev.EventType, &ev.TokenID, &ev.AgentID,
+			&ev.TaskID, &ev.SecretName, &ev.FieldName, &ev.Adapter, &detailJSON, &ev.Timestamp); err != nil {
+			return nil, err
+		}
+		if detailJSON != nil {
+			_ = json.Unmarshal(detailJSON, &ev.Detail)
+		}
+		events = append(events, &ev)
+	}
+	return events, rows.Err()
+}

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -158,7 +158,7 @@ func (s *Store) ListSecrets(ctx context.Context, tenantID string) ([]*Secret, er
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var secrets []*Secret
 	for rows.Next() {
@@ -279,7 +279,7 @@ func (s *Store) ReadSecretFields(ctx context.Context, tenantID, name string) (ma
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	fields := make(map[string][]byte)
 	for rows.Next() {
@@ -462,7 +462,7 @@ func (s *Store) QueryAuditLog(ctx context.Context, tenantID string, secretName s
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var events []*AuditEvent
 	for rows.Next() {

--- a/pkg/vault/types.go
+++ b/pkg/vault/types.go
@@ -1,0 +1,84 @@
+package vault
+
+import "time"
+
+// SecretType identifies the kind of secret stored.
+type SecretType string
+
+const (
+	SecretTypeGeneric        SecretType = "generic"
+	SecretTypeAWSCredentials SecretType = "aws_credentials"
+	SecretTypeDatabase       SecretType = "database"
+	SecretTypeAPIKey         SecretType = "api_key"
+	SecretTypeSSHKey         SecretType = "ssh_key"
+	SecretTypeTLSCert        SecretType = "tls_cert"
+)
+
+// Secret is the metadata for a stored secret (no plaintext values).
+type Secret struct {
+	SecretID   string     `json:"secret_id"`
+	TenantID   string     `json:"tenant_id"`
+	Name       string     `json:"name"`
+	SecretType SecretType `json:"secret_type"`
+	Revision   int64      `json:"revision"`
+	CreatedBy  string     `json:"created_by"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+	DeletedAt  *time.Time `json:"deleted_at,omitempty"`
+}
+
+// SecretField holds the encrypted value and nonce for one field.
+type SecretField struct {
+	SecretID       string `json:"-"`
+	FieldName      string `json:"field_name"`
+	EncryptedValue []byte `json:"-"`
+	Nonce          []byte `json:"-"`
+}
+
+// CapToken is the server-side state for a capability token.
+type CapToken struct {
+	TokenID     string     `json:"token_id"`
+	TenantID    string     `json:"tenant_id"`
+	AgentID     string     `json:"agent_id"`
+	TaskID      string     `json:"task_id,omitempty"`
+	Scope       []string   `json:"scope"`
+	IssuedAt    time.Time  `json:"issued_at"`
+	ExpiresAt   time.Time  `json:"expires_at"`
+	RevokedAt   *time.Time `json:"revoked_at,omitempty"`
+	RevokedBy   string     `json:"revoked_by,omitempty"`
+	RevokeReason string    `json:"revoke_reason,omitempty"`
+}
+
+// CapTokenClaims is the payload signed into the bearer token.
+type CapTokenClaims struct {
+	TokenID   string   `json:"token_id"`
+	TenantID  string   `json:"tenant_id"`
+	AgentID   string   `json:"agent_id"`
+	TaskID    string   `json:"task_id,omitempty"`
+	Scope     []string `json:"scope"`
+	IssuedAt  int64    `json:"iat"`
+	ExpiresAt int64    `json:"exp"`
+	Nonce     string   `json:"nonce"`
+}
+
+// AuditEvent is an append-only audit log entry.
+type AuditEvent struct {
+	EventID    string     `json:"event_id"`
+	TenantID   string     `json:"tenant_id"`
+	EventType  string     `json:"event_type"`
+	TokenID    string     `json:"token_id,omitempty"`
+	AgentID    string     `json:"agent_id,omitempty"`
+	TaskID     string     `json:"task_id,omitempty"`
+	SecretName string     `json:"secret_name,omitempty"`
+	FieldName  string     `json:"field_name,omitempty"`
+	Adapter    string     `json:"adapter,omitempty"`
+	Detail     any        `json:"detail,omitempty"`
+	Timestamp  time.Time  `json:"timestamp"`
+}
+
+// TenantDEK holds the wrapped (encrypted) data encryption key for a tenant.
+type TenantDEK struct {
+	TenantID   string    `json:"tenant_id"`
+	WrappedDEK []byte    `json:"-"`
+	CreatedAt  time.Time `json:"created_at"`
+}


### PR DESCRIPTION
## Summary

Implements Agent Vault Phase 1 (#192) and Phase 2 (#193) — the server-side secret management system for drive9.

**Phase 1 (Issue #192):**
- Data model: `vault_secrets`, `vault_secret_fields`, `vault_tokens`, `vault_policies`, `vault_audit_log`, `vault_deks` tables
- Per-tenant DEK management: AES-256-GCM encrypted by Master Key, race-safe generation
- Field-level encryption: each secret field encrypted individually with tenant DEK + random nonce
- Management API: CRUD for secrets, capability token issuance/revocation, audit log query
- Capability token: HMAC-SHA256 signed, scoped, with server-side revocation support
- Schema init wired into tenant provisioner

**Phase 2 (Issue #193):**
- Consumption API: `GET /v1/vault/read/*` with capability token authentication
- 4-step verification flow: HMAC signature → TTL expiry → DB revocation → scope check
- Scope enforcement: secret-level and field-level access control
- Format support: `?format=json` (default), `?format=env`
- Enumeration endpoint: `GET /v1/vault/read` lists only in-scope secrets
- Audit logging for all reads and denials (404 for out-of-scope to prevent info leakage)

**Files:**
- `pkg/vault/` — Core package (types, schema, crypto, store, scope, errors)
- `pkg/server/vault.go` — HTTP handlers for management + consumption APIs
- `pkg/server/server.go` — Wired vault MK config + routes
- `pkg/tenant/db9/schema.go` — Vault schema init on provisioning

**Tests:** 11 tests covering crypto round-trip (DEK, field encryption, cap token sign/verify, expiry, wrong signature) and scope checking.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./pkg/vault/ -v` — 11/11 pass
- [ ] Integration test with real DB (CI)
- [ ] End-to-end: create secret → issue token → read with cap token → rotate → re-read → revoke → read fails

Closes #192, closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)