### PR TITLE
fix: ensure legacy TiDB uploads schema includes expected_revision

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -293,7 +293,7 @@ func logLocalStartupStep(ctx context.Context, startupStart, stepStart time.Time,
 
 var (
 	localTiDBEmbeddingModeDetector = schema.DetectTiDBEmbeddingMode
-	localTiDBSchemaValidator       = schema.ValidateTiDBSchemaForMode
+	localTiDBSchemaValidator       = schema.EnsureTiDBSchemaForMode
 	localTiDBSchemaInitializer     = schema.InitTiDBTenantSchemaForMode
 )
 

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -287,9 +287,9 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		return nil, nil, fmt.Errorf("open datastore: %w", err)
 	}
 	if opts.DatabaseAutoEmbedding && (t.Provider == ProviderTiDBZero || t.Provider == ProviderTiDBCloudStarter) {
-		if err := schema.ValidateTiDBSchemaForMode(store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
+		if err := schema.EnsureTiDBSchemaForMode(store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
 			_ = store.Close()
-			return nil, nil, fmt.Errorf("validate tidb auto-embedding schema: %w", err)
+			return nil, nil, fmt.Errorf("ensure tidb auto-embedding schema: %w", err)
 		}
 	}
 	if p.cfg.S3Bucket != "" {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -196,10 +196,35 @@ func ValidateTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
 	if err := validateTiDBTableForMode(mode, filesMeta); err != nil {
 		return fmt.Errorf("files schema contract: %w", err)
 	}
+	uploadsMeta, err := loadTiDBTableMeta(db, "uploads")
+	if err != nil {
+		return fmt.Errorf("load uploads table metadata: %w", err)
+	}
+	if err := validateTiDBUploadsTableBase(uploadsMeta); err != nil {
+		return fmt.Errorf("uploads schema contract: %w", err)
+	}
 	if err := ensureTiDBTableExists(db, "semantic_tasks"); err != nil {
 		return fmt.Errorf("semantic_tasks schema contract: %w", err)
 	}
 	return nil
+}
+
+// EnsureTiDBSchemaForMode repairs known launch-schema drift that can be fixed
+// in place, then validates the full TiDB schema contract for the requested mode.
+func EnsureTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
+	if db == nil {
+		return fmt.Errorf("nil db")
+	}
+	if !IsTiDBCluster(db) {
+		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
+	}
+	if err := validateTiDBSchemaMode(mode); err != nil {
+		return err
+	}
+	if err := repairLegacyTiDBUploadsSchema(db); err != nil {
+		return fmt.Errorf("repair uploads schema: %w", err)
+	}
+	return ValidateTiDBSchemaForMode(db, mode)
 }
 
 func validateTiDBSchemaMode(mode TiDBEmbeddingMode) error {
@@ -352,6 +377,34 @@ func validateTiDBFilesTableBase(meta tidbTableMeta) error {
 		return err
 	}
 	return meta.requireColumnType("embedding_revision", "bigint")
+}
+
+func validateTiDBUploadsTableBase(meta tidbTableMeta) error {
+	if err := meta.requireColumnType("upload_id", "varchar(64)"); err != nil {
+		return err
+	}
+	if err := meta.requireColumnType("target_path", "varchar(512)"); err != nil {
+		return err
+	}
+	if err := meta.requireColumnType("status", "varchar(32)"); err != nil {
+		return err
+	}
+	return meta.requireColumnType("expected_revision", "bigint")
+}
+
+func repairLegacyTiDBUploadsSchema(db *sql.DB) error {
+	uploadsMeta, err := loadTiDBTableMeta(db, "uploads")
+	if err != nil {
+		return fmt.Errorf("load uploads table metadata: %w", err)
+	}
+	return ExecSchemaStatements(db, legacyTiDBUploadsRepairStatements(uploadsMeta))
+}
+
+func legacyTiDBUploadsRepairStatements(meta tidbTableMeta) []string {
+	if _, ok := meta.columns["expected_revision"]; ok {
+		return nil
+	}
+	return []string{`ALTER TABLE uploads ADD COLUMN expected_revision BIGINT NULL`}
 }
 
 func loadTiDBTableMeta(db *sql.DB, tableName string) (tidbTableMeta, error) {

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -51,6 +51,35 @@ func TestValidateTiDBAppEmbeddingFilesTableRejectsGeneratedEmbedding(t *testing.
 	}
 }
 
+func TestValidateTiDBUploadsTableBaseAcceptsExpectedRevision(t *testing.T) {
+	if err := validateTiDBUploadsTableBase(testUploadsTableMeta(true)); err != nil {
+		t.Fatalf("expected uploads table to validate: %v", err)
+	}
+}
+
+func TestValidateTiDBUploadsTableBaseRejectsMissingExpectedRevision(t *testing.T) {
+	err := validateTiDBUploadsTableBase(testUploadsTableMeta(false))
+	if err == nil {
+		t.Fatal("expected missing expected_revision to fail validation")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "expected_revision") {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestLegacyTiDBUploadsRepairStatements(t *testing.T) {
+	if got := legacyTiDBUploadsRepairStatements(testUploadsTableMeta(true)); len(got) != 0 {
+		t.Fatalf("expected no repair statements when expected_revision exists, got %#v", got)
+	}
+	got := legacyTiDBUploadsRepairStatements(testUploadsTableMeta(false))
+	if len(got) != 1 {
+		t.Fatalf("expected one repair statement, got %#v", got)
+	}
+	if !strings.Contains(strings.ToLower(got[0]), "add column expected_revision") {
+		t.Fatalf("unexpected repair statement: %q", got[0])
+	}
+}
+
 func testFilesTableMeta(mode TiDBEmbeddingMode) tidbTableMeta {
 	meta := tidbTableMeta{
 		tableName: "files",
@@ -69,6 +98,21 @@ func testFilesTableMeta(mode TiDBEmbeddingMode) tidbTableMeta {
 			generationExpression: "embed_text(_utf8mb4'tidbcloud_free/amazon/titan-embed-text-v2', `content_text`, _utf8mb4'{\"dimensions\":1024}')",
 		}
 		return meta
+	}
+	return meta
+}
+
+func testUploadsTableMeta(includeExpectedRevision bool) tidbTableMeta {
+	meta := tidbTableMeta{
+		tableName: "uploads",
+		columns: map[string]tidbColumnMeta{
+			"upload_id":   {columnType: "varchar(64)"},
+			"target_path": {columnType: "varchar(512)"},
+			"status":      {columnType: "varchar(32)"},
+		},
+	}
+	if includeExpectedRevision {
+		meta.columns["expected_revision"] = tidbColumnMeta{columnType: "bigint"}
 	}
 	return meta
 }


### PR DESCRIPTION
close https://github.com/mem9-ai/drive9/issues/196

## Summary
- repair legacy TiDB tenant schemas that are missing `uploads.expected_revision` before backend startup continues
- validate the `uploads` table contract alongside the existing TiDB schema checks so schema drift fails fast
- add focused schema tests for the new validation and repair paths

## Testing
- `make test TEST_P=1`

## Context
- fixes the runtime `fs cp` failure reported in #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TiDB auto-embedding schema handling with automatic repair of common schema issues instead of validation-only mode.

* **Tests**
  * Added unit tests for schema validation and legacy repair behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->