### PR TITLE
feat: Obsidian plugin Phase 2B — conflict resolution (#183)

### DIFF
--- a/obsidian-plugin/src/conflict-modal.ts
+++ b/obsidian-plugin/src/conflict-modal.ts
@@ -1,0 +1,146 @@
+import { App, Modal } from "obsidian";
+
+export type ConflictChoice = "keep_local" | "keep_remote" | "keep_both";
+
+interface ConflictInfo {
+  path: string;
+  localSize: number;
+  localMtime: number;
+  remoteSize: number;
+  remoteMtime: number;
+  isText: boolean;
+  diffPreview?: string;
+}
+
+/**
+ * Modal shown when automatic 3-way merge fails or for binary files.
+ * Resolves with the user's choice.
+ */
+export class ConflictModal extends Modal {
+  private resolve: ((choice: ConflictChoice | null) => void) | null = null;
+
+  constructor(
+    app: App,
+    private info: ConflictInfo,
+  ) {
+    super(app);
+  }
+
+  open(): Promise<ConflictChoice | null> {
+    return new Promise((resolve) => {
+      this.resolve = resolve;
+      super.open();
+    });
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("drive9-conflict-modal");
+
+    contentEl.createEl("h2", { text: "Sync Conflict" });
+    contentEl.createEl("p", {
+      text: this.info.path,
+      cls: "drive9-conflict-path",
+    });
+
+    const table = contentEl.createEl("table", { cls: "drive9-conflict-table" });
+    const header = table.createEl("tr");
+    header.createEl("th", { text: "" });
+    header.createEl("th", { text: "Local" });
+    header.createEl("th", { text: "Remote" });
+
+    const sizeRow = table.createEl("tr");
+    sizeRow.createEl("td", { text: "Size" });
+    sizeRow.createEl("td", { text: formatSize(this.info.localSize) });
+    sizeRow.createEl("td", { text: formatSize(this.info.remoteSize) });
+
+    const mtimeRow = table.createEl("tr");
+    mtimeRow.createEl("td", { text: "Modified" });
+    mtimeRow.createEl("td", { text: formatTime(this.info.localMtime) });
+    mtimeRow.createEl("td", { text: formatTime(this.info.remoteMtime) });
+
+    if (this.info.diffPreview) {
+      const details = contentEl.createEl("details");
+      details.createEl("summary", { text: "Diff preview" });
+      const pre = details.createEl("pre", { cls: "drive9-conflict-diff" });
+      pre.createEl("code", { text: this.info.diffPreview });
+    }
+
+    const actions = contentEl.createEl("div", { cls: "drive9-conflict-actions" });
+
+    const localBtn = actions.createEl("button", { text: "Keep Local", cls: "mod-warning" });
+    localBtn.addEventListener("click", () => this.choose("keep_local"));
+
+    const remoteBtn = actions.createEl("button", { text: "Keep Remote" });
+    remoteBtn.addEventListener("click", () => this.choose("keep_remote"));
+
+    const bothBtn = actions.createEl("button", { text: "Keep Both" });
+    bothBtn.addEventListener("click", () => this.choose("keep_both"));
+  }
+
+  onClose(): void {
+    if (this.resolve) {
+      this.resolve(null);
+      this.resolve = null;
+    }
+    this.contentEl.empty();
+  }
+
+  private choose(choice: ConflictChoice): void {
+    if (this.resolve) {
+      const r = this.resolve;
+      this.resolve = null;
+      this.close();
+      r(choice);
+    }
+  }
+}
+
+export function createConflictInfo(
+  path: string,
+  localSize: number,
+  localMtime: number,
+  remoteSize: number,
+  remoteMtime: number,
+  diffPreview?: string,
+): ConflictInfo {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  const textExtensions = new Set([
+    "md", "txt", "json", "yaml", "yml", "toml", "csv", "xml", "html",
+    "css", "js", "ts", "py", "rb", "go", "rs", "java", "c", "cpp", "h",
+    "sh", "bash", "zsh", "fish", "lua", "tex", "bib", "ini", "cfg",
+    "conf", "log", "svg",
+  ]);
+  return {
+    path,
+    localSize,
+    localMtime,
+    remoteSize,
+    remoteMtime,
+    isText: textExtensions.has(ext),
+    diffPreview,
+  };
+}
+
+export function isTextFile(path: string): boolean {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  const textExtensions = new Set([
+    "md", "txt", "json", "yaml", "yml", "toml", "csv", "xml", "html",
+    "css", "js", "ts", "py", "rb", "go", "rs", "java", "c", "cpp", "h",
+    "sh", "bash", "zsh", "fish", "lua", "tex", "bib", "ini", "cfg",
+    "conf", "log", "svg",
+  ]);
+  return textExtensions.has(ext);
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatTime(ms: number): string {
+  if (ms === 0) return "unknown";
+  return new Date(ms).toLocaleString();
+}

--- a/obsidian-plugin/src/conflict-resolver.ts
+++ b/obsidian-plugin/src/conflict-resolver.ts
@@ -136,34 +136,37 @@ export class ConflictResolver {
     const result = merge3(baseText, localText, remoteText);
 
     if (!result.hasConflicts) {
-      // Auto-merge succeeded — apply merged content
+      // Auto-merge succeeded — push to remote first, only apply locally after CAS succeeds
       const mergedData = encodeText(result.merged);
-      await this.vault.modifyBinary(this.getLocalFile(path)!, mergedData);
 
-      // Push merged version to remote — use CAS
+      let writeResult: { revision: number | null; writeSucceeded: boolean };
       try {
-        const writeResult = await this.client.write(path, mergedData, state.remoteRevision);
-
-        const updatedFile = this.getLocalFile(path);
-        const hash = await this.shadowStore.save(mergedData);
-        this.syncStates[path] = {
-          path,
-          localMtime: updatedFile?.stat.mtime ?? 0,
-          localSize: updatedFile?.stat.size ?? 0,
-          remoteRevision: writeResult.revision ?? remoteStat.revision,
-          syncedAt: Date.now(),
-          status: "synced",
-          lastSyncedContentHash: hash,
-        };
-        new Notice(`drive9: auto-merged ${path}`);
-        return true;
+        writeResult = await this.client.write(path, mergedData, state.remoteRevision);
       } catch (e) {
         if (e instanceof Drive9Error && e.status === 409) {
           // Remote changed again during merge — stay in conflict for next cycle
-          return false;
+          // Do NOT modify local vault; caller will not show modal either
+          return true;
         }
         throw e;
       }
+
+      // CAS succeeded — now apply merged content to local vault
+      await this.vault.modifyBinary(this.getLocalFile(path)!, mergedData);
+
+      const updatedFile = this.getLocalFile(path);
+      const hash = await this.shadowStore.save(mergedData);
+      this.syncStates[path] = {
+        path,
+        localMtime: updatedFile?.stat.mtime ?? 0,
+        localSize: updatedFile?.stat.size ?? 0,
+        remoteRevision: writeResult.revision ?? remoteStat.revision,
+        syncedAt: Date.now(),
+        status: "synced",
+        lastSyncedContentHash: hash,
+      };
+      new Notice(`drive9: auto-merged ${path}`);
+      return true;
     }
 
     return false;

--- a/obsidian-plugin/src/conflict-resolver.ts
+++ b/obsidian-plugin/src/conflict-resolver.ts
@@ -1,5 +1,5 @@
 import { App, Vault, TFile, Notice } from "obsidian";
-import { Drive9Client } from "./client";
+import { Drive9Client, Drive9Error } from "./client";
 import { ShadowStore } from "./shadow-store";
 import { merge3 } from "./diff3";
 import { ConflictModal, createConflictInfo, isTextFile } from "./conflict-modal";
@@ -13,6 +13,8 @@ import type { SyncState } from "./types";
 export class ConflictResolver {
   private shadowStore: ShadowStore;
   private resolving = false;
+  /** Paths that should not be synced (e.g. .conflict copies). */
+  private ignoredPaths = new Set<string>();
 
   constructor(
     private app: App,
@@ -22,6 +24,16 @@ export class ConflictResolver {
     private persistData: () => Promise<void>,
   ) {
     this.shadowStore = new ShadowStore(vault.adapter);
+  }
+
+  /** Register a path that should be ignored by the sync engine. */
+  addIgnoredPath(path: string): void {
+    this.ignoredPaths.add(path);
+  }
+
+  /** Check if a path is ignored (e.g. conflict copies). */
+  isIgnoredPath(path: string): boolean {
+    return this.ignoredPaths.has(path);
   }
 
   /**
@@ -135,22 +147,30 @@ export class ConflictResolver {
       const mergedData = encodeText(result.merged);
       await this.vault.modifyBinary(this.getLocalFile(path)!, mergedData);
 
-      // Push merged version to remote
-      const writeResult = await this.client.write(path, mergedData, state.remoteRevision);
+      // Push merged version to remote — use CAS
+      try {
+        const writeResult = await this.client.write(path, mergedData, state.remoteRevision);
 
-      const updatedFile = this.getLocalFile(path);
-      const hash = await this.shadowStore.save(mergedData);
-      this.syncStates[path] = {
-        path,
-        localMtime: updatedFile?.stat.mtime ?? 0,
-        localSize: updatedFile?.stat.size ?? 0,
-        remoteRevision: writeResult.revision ?? remoteStat.revision,
-        syncedAt: Date.now(),
-        status: "synced",
-        lastSyncedContentHash: hash,
-      };
-      new Notice(`drive9: auto-merged ${path}`);
-      return true;
+        const updatedFile = this.getLocalFile(path);
+        const hash = await this.shadowStore.save(mergedData);
+        this.syncStates[path] = {
+          path,
+          localMtime: updatedFile?.stat.mtime ?? 0,
+          localSize: updatedFile?.stat.size ?? 0,
+          remoteRevision: writeResult.revision ?? remoteStat.revision,
+          syncedAt: Date.now(),
+          status: "synced",
+          lastSyncedContentHash: hash,
+        };
+        new Notice(`drive9: auto-merged ${path}`);
+        return true;
+      } catch (e) {
+        if (e instanceof Drive9Error && e.status === 409) {
+          // Remote changed again during merge — stay in conflict for next cycle
+          return false;
+        }
+        throw e;
+      }
     }
 
     return false;
@@ -166,19 +186,28 @@ export class ConflictResolver {
   ): Promise<void> {
     switch (choice) {
       case "keep_local": {
-        // Overwrite remote with local
-        const result = await this.client.write(path, localData);
-        const hash = await this.shadowStore.save(localData);
-        this.syncStates[path] = {
-          path,
-          localMtime: localFile.stat.mtime,
-          localSize: localFile.stat.size,
-          remoteRevision: result.revision ?? remoteRevision,
-          syncedAt: Date.now(),
-          status: "synced",
-          lastSyncedContentHash: hash,
-        };
-        new Notice(`drive9: kept local version of ${path}`);
+        // Overwrite remote with local — use CAS to avoid clobbering concurrent edits
+        try {
+          const result = await this.client.write(path, localData, remoteRevision);
+          const hash = await this.shadowStore.save(localData);
+          this.syncStates[path] = {
+            path,
+            localMtime: localFile.stat.mtime,
+            localSize: localFile.stat.size,
+            remoteRevision: result.revision ?? remoteRevision,
+            syncedAt: Date.now(),
+            status: "synced",
+            lastSyncedContentHash: hash,
+          };
+          new Notice(`drive9: kept local version of ${path}`);
+        } catch (e) {
+          if (e instanceof Drive9Error && e.status === 409) {
+            this.syncStates[path] = { ...this.syncStates[path], status: "conflict" };
+            new Notice(`drive9: remote changed again during resolution of ${path}`);
+          } else {
+            throw e;
+          }
+        }
         break;
       }
 
@@ -201,7 +230,8 @@ export class ConflictResolver {
       }
 
       case "keep_both": {
-        // Save remote as {name}.conflict.{ext}
+        // Save remote as {name}.conflict.{ext} — suppress local events so
+        // the conflict copy is not treated as a new file to sync.
         const conflictPath = makeConflictPath(path);
         const dir = conflictPath.includes("/")
           ? conflictPath.slice(0, conflictPath.lastIndexOf("/"))
@@ -209,21 +239,31 @@ export class ConflictResolver {
         if (dir && !this.vault.getAbstractFileByPath(dir)) {
           await this.vault.createFolder(dir);
         }
+        this.addIgnoredPath(conflictPath);
         await this.vault.createBinary(conflictPath, remoteData);
 
-        // Mark local as synced (push it to remote)
-        const result = await this.client.write(path, localData);
-        const hash = await this.shadowStore.save(localData);
-        this.syncStates[path] = {
-          path,
-          localMtime: localFile.stat.mtime,
-          localSize: localFile.stat.size,
-          remoteRevision: result.revision ?? remoteRevision,
-          syncedAt: Date.now(),
-          status: "synced",
-          lastSyncedContentHash: hash,
-        };
-        new Notice(`drive9: kept both versions of ${path}`);
+        // Mark local as synced (push it to remote) — use CAS
+        try {
+          const result = await this.client.write(path, localData, remoteRevision);
+          const hash = await this.shadowStore.save(localData);
+          this.syncStates[path] = {
+            path,
+            localMtime: localFile.stat.mtime,
+            localSize: localFile.stat.size,
+            remoteRevision: result.revision ?? remoteRevision,
+            syncedAt: Date.now(),
+            status: "synced",
+            lastSyncedContentHash: hash,
+          };
+          new Notice(`drive9: kept both versions of ${path}`);
+        } catch (e) {
+          if (e instanceof Drive9Error && e.status === 409) {
+            this.syncStates[path] = { ...this.syncStates[path], status: "conflict" };
+            new Notice(`drive9: remote changed again during resolution of ${path}`);
+          } else {
+            throw e;
+          }
+        }
         break;
       }
     }
@@ -239,8 +279,8 @@ export class ConflictResolver {
 
     const localFile = this.getLocalFile(path);
     if (localFile) {
-      // Move to Obsidian trash — never permanent delete
-      await this.vault.trash(localFile, true);
+      // Move to Obsidian's local .trash — never system trash or permanent delete
+      await this.vault.trash(localFile, false);
     }
     delete this.syncStates[path];
   }

--- a/obsidian-plugin/src/conflict-resolver.ts
+++ b/obsidian-plugin/src/conflict-resolver.ts
@@ -1,0 +1,268 @@
+import { App, Vault, TFile, Notice } from "obsidian";
+import { Drive9Client } from "./client";
+import { ShadowStore } from "./shadow-store";
+import { merge3 } from "./diff3";
+import { ConflictModal, createConflictInfo, isTextFile } from "./conflict-modal";
+import type { ConflictChoice } from "./conflict-modal";
+import type { SyncState } from "./types";
+
+/**
+ * ConflictResolver handles conflict and remote_deleted states
+ * produced by the SyncEngine.
+ */
+export class ConflictResolver {
+  private shadowStore: ShadowStore;
+  private resolving = false;
+
+  constructor(
+    private app: App,
+    private vault: Vault,
+    private client: Drive9Client,
+    private syncStates: Record<string, SyncState>,
+    private persistData: () => Promise<void>,
+  ) {
+    this.shadowStore = new ShadowStore(vault.adapter);
+  }
+
+  /**
+   * Save a shadow copy of content after a successful sync.
+   * Returns the content hash for storing in SyncState.
+   */
+  async saveShadow(data: ArrayBuffer): Promise<string> {
+    return this.shadowStore.save(data);
+  }
+
+  /** Run GC on shadow store to clean up unreferenced files. */
+  async gcShadows(): Promise<number> {
+    return this.shadowStore.gc(this.syncStates);
+  }
+
+  /**
+   * Scan all SyncState entries and resolve pending conflicts and remote deletes.
+   * Only one resolution loop runs at a time.
+   */
+  async resolveAll(): Promise<void> {
+    if (this.resolving) return;
+    this.resolving = true;
+    try {
+      for (const [path, state] of Object.entries(this.syncStates)) {
+        switch (state.status) {
+          case "conflict":
+            await this.resolveConflict(path, state);
+            break;
+          case "remote_deleted":
+            await this.applyRemoteDelete(path, state);
+            break;
+        }
+      }
+      await this.persistData();
+    } finally {
+      this.resolving = false;
+    }
+  }
+
+  private async resolveConflict(path: string, state: SyncState): Promise<void> {
+    const localFile = this.getLocalFile(path);
+
+    if (!localFile) {
+      // Local file was deleted — remote wins by default
+      delete this.syncStates[path];
+      return;
+    }
+
+    let remoteData: ArrayBuffer;
+    try {
+      remoteData = await this.client.read(path);
+    } catch {
+      console.warn(`[drive9] cannot read remote for conflict resolution: ${path}`);
+      return;
+    }
+
+    let remoteStat: { revision: number; mtime: number; size: number };
+    try {
+      const st = await this.client.stat(path);
+      remoteStat = { revision: st.revision, mtime: st.mtime, size: st.size };
+    } catch {
+      remoteStat = { revision: 0, mtime: 0, size: remoteData.byteLength };
+    }
+
+    const localData = await this.vault.readBinary(localFile);
+
+    if (isTextFile(path)) {
+      const resolved = await this.tryTextMerge(path, state, localData, remoteData, remoteStat);
+      if (resolved) return;
+    }
+
+    // Auto-merge failed or binary file — show modal
+    const info = createConflictInfo(
+      path,
+      localFile.stat.size,
+      localFile.stat.mtime,
+      remoteStat.size,
+      remoteStat.mtime,
+    );
+    const choice = await new ConflictModal(this.app, info).open();
+    if (choice === null) {
+      // User dismissed modal — keep conflict for next cycle
+      return;
+    }
+    await this.applyChoice(path, choice, localFile, localData, remoteData, remoteStat.revision);
+  }
+
+  private async tryTextMerge(
+    path: string,
+    state: SyncState,
+    localData: ArrayBuffer,
+    remoteData: ArrayBuffer,
+    remoteStat: { revision: number; mtime: number; size: number },
+  ): Promise<boolean> {
+    const localText = decodeText(localData);
+    const remoteText = decodeText(remoteData);
+
+    // Load base from shadow store
+    let baseText = "";
+    if (state.lastSyncedContentHash) {
+      const baseData = await this.shadowStore.load(state.lastSyncedContentHash);
+      if (baseData) {
+        baseText = decodeText(baseData);
+      }
+    }
+
+    const result = merge3(baseText, localText, remoteText);
+
+    if (!result.hasConflicts) {
+      // Auto-merge succeeded — apply merged content
+      const mergedData = encodeText(result.merged);
+      await this.vault.modifyBinary(this.getLocalFile(path)!, mergedData);
+
+      // Push merged version to remote
+      const writeResult = await this.client.write(path, mergedData, state.remoteRevision);
+
+      const updatedFile = this.getLocalFile(path);
+      const hash = await this.shadowStore.save(mergedData);
+      this.syncStates[path] = {
+        path,
+        localMtime: updatedFile?.stat.mtime ?? 0,
+        localSize: updatedFile?.stat.size ?? 0,
+        remoteRevision: writeResult.revision ?? remoteStat.revision,
+        syncedAt: Date.now(),
+        status: "synced",
+        lastSyncedContentHash: hash,
+      };
+      new Notice(`drive9: auto-merged ${path}`);
+      return true;
+    }
+
+    return false;
+  }
+
+  private async applyChoice(
+    path: string,
+    choice: ConflictChoice,
+    localFile: TFile,
+    localData: ArrayBuffer,
+    remoteData: ArrayBuffer,
+    remoteRevision: number,
+  ): Promise<void> {
+    switch (choice) {
+      case "keep_local": {
+        // Overwrite remote with local
+        const result = await this.client.write(path, localData);
+        const hash = await this.shadowStore.save(localData);
+        this.syncStates[path] = {
+          path,
+          localMtime: localFile.stat.mtime,
+          localSize: localFile.stat.size,
+          remoteRevision: result.revision ?? remoteRevision,
+          syncedAt: Date.now(),
+          status: "synced",
+          lastSyncedContentHash: hash,
+        };
+        new Notice(`drive9: kept local version of ${path}`);
+        break;
+      }
+
+      case "keep_remote": {
+        // Overwrite local with remote
+        await this.vault.modifyBinary(localFile, remoteData);
+        const updatedFile = this.getLocalFile(path);
+        const hash = await this.shadowStore.save(remoteData);
+        this.syncStates[path] = {
+          path,
+          localMtime: updatedFile?.stat.mtime ?? 0,
+          localSize: updatedFile?.stat.size ?? 0,
+          remoteRevision,
+          syncedAt: Date.now(),
+          status: "synced",
+          lastSyncedContentHash: hash,
+        };
+        new Notice(`drive9: kept remote version of ${path}`);
+        break;
+      }
+
+      case "keep_both": {
+        // Save remote as {name}.conflict.{ext}
+        const conflictPath = makeConflictPath(path);
+        const dir = conflictPath.includes("/")
+          ? conflictPath.slice(0, conflictPath.lastIndexOf("/"))
+          : "";
+        if (dir && !this.vault.getAbstractFileByPath(dir)) {
+          await this.vault.createFolder(dir);
+        }
+        await this.vault.createBinary(conflictPath, remoteData);
+
+        // Mark local as synced (push it to remote)
+        const result = await this.client.write(path, localData);
+        const hash = await this.shadowStore.save(localData);
+        this.syncStates[path] = {
+          path,
+          localMtime: localFile.stat.mtime,
+          localSize: localFile.stat.size,
+          remoteRevision: result.revision ?? remoteRevision,
+          syncedAt: Date.now(),
+          status: "synced",
+          lastSyncedContentHash: hash,
+        };
+        new Notice(`drive9: kept both versions of ${path}`);
+        break;
+      }
+    }
+  }
+
+  private async applyRemoteDelete(path: string, state: SyncState): Promise<void> {
+    if (state.deleteDetectionSource === "polling") {
+      if ((state.consecutiveAbsences ?? 0) < 2) {
+        // Not stable yet — skip this cycle, will re-check next poll
+        return;
+      }
+    }
+
+    const localFile = this.getLocalFile(path);
+    if (localFile) {
+      // Move to Obsidian trash — never permanent delete
+      await this.vault.trash(localFile, true);
+    }
+    delete this.syncStates[path];
+  }
+
+  private getLocalFile(path: string): TFile | null {
+    const file = this.vault.getAbstractFileByPath(path);
+    return file instanceof TFile ? file : null;
+  }
+}
+
+function makeConflictPath(path: string): string {
+  const lastDot = path.lastIndexOf(".");
+  if (lastDot === -1) {
+    return `${path}.conflict`;
+  }
+  return `${path.slice(0, lastDot)}.conflict${path.slice(lastDot)}`;
+}
+
+function decodeText(data: ArrayBuffer): string {
+  return new TextDecoder().decode(data);
+}
+
+function encodeText(text: string): ArrayBuffer {
+  return new TextEncoder().encode(text).buffer;
+}

--- a/obsidian-plugin/src/conflict-resolver.ts
+++ b/obsidian-plugin/src/conflict-resolver.ts
@@ -13,8 +13,7 @@ import type { SyncState } from "./types";
 export class ConflictResolver {
   private shadowStore: ShadowStore;
   private resolving = false;
-  /** Paths that should not be synced (e.g. .conflict copies). */
-  private ignoredPaths = new Set<string>();
+  private suppressLocalEvent: ((path: string, fn: () => Promise<void>) => Promise<void>) | null = null;
 
   constructor(
     private app: App,
@@ -26,14 +25,8 @@ export class ConflictResolver {
     this.shadowStore = new ShadowStore(vault.adapter);
   }
 
-  /** Register a path that should be ignored by the sync engine. */
-  addIgnoredPath(path: string): void {
-    this.ignoredPaths.add(path);
-  }
-
-  /** Check if a path is ignored (e.g. conflict copies). */
-  isIgnoredPath(path: string): boolean {
-    return this.ignoredPaths.has(path);
+  setSuppressLocalEvent(fn: (path: string, cb: () => Promise<void>) => Promise<void>): void {
+    this.suppressLocalEvent = fn;
   }
 
   /**
@@ -186,7 +179,7 @@ export class ConflictResolver {
   ): Promise<void> {
     switch (choice) {
       case "keep_local": {
-        // Overwrite remote with local — use CAS to avoid clobbering concurrent edits
+        // Overwrite remote with local — use CAS to avoid overwriting newer remote versions
         try {
           const result = await this.client.write(path, localData, remoteRevision);
           const hash = await this.shadowStore.save(localData);
@@ -202,11 +195,10 @@ export class ConflictResolver {
           new Notice(`drive9: kept local version of ${path}`);
         } catch (e) {
           if (e instanceof Drive9Error && e.status === 409) {
-            this.syncStates[path] = { ...this.syncStates[path], status: "conflict" };
-            new Notice(`drive9: remote changed again during resolution of ${path}`);
-          } else {
-            throw e;
+            new Notice(`drive9: remote changed again for ${path}, retrying next cycle`);
+            return;
           }
+          throw e;
         }
         break;
       }
@@ -230,17 +222,22 @@ export class ConflictResolver {
       }
 
       case "keep_both": {
-        // Save remote as {name}.conflict.{ext} — suppress local events so
-        // the conflict copy is not treated as a new file to sync.
+        // Save remote as {name}.conflict.{ext} — suppress to prevent push-back
         const conflictPath = makeConflictPath(path);
-        const dir = conflictPath.includes("/")
-          ? conflictPath.slice(0, conflictPath.lastIndexOf("/"))
-          : "";
-        if (dir && !this.vault.getAbstractFileByPath(dir)) {
-          await this.vault.createFolder(dir);
+        const createConflictCopy = async () => {
+          const dir = conflictPath.includes("/")
+            ? conflictPath.slice(0, conflictPath.lastIndexOf("/"))
+            : "";
+          if (dir && !this.vault.getAbstractFileByPath(dir)) {
+            await this.vault.createFolder(dir);
+          }
+          await this.vault.createBinary(conflictPath, remoteData);
+        };
+        if (this.suppressLocalEvent) {
+          await this.suppressLocalEvent(conflictPath, createConflictCopy);
+        } else {
+          await createConflictCopy();
         }
-        this.addIgnoredPath(conflictPath);
-        await this.vault.createBinary(conflictPath, remoteData);
 
         // Mark local as synced (push it to remote) — use CAS
         try {
@@ -258,11 +255,10 @@ export class ConflictResolver {
           new Notice(`drive9: kept both versions of ${path}`);
         } catch (e) {
           if (e instanceof Drive9Error && e.status === 409) {
-            this.syncStates[path] = { ...this.syncStates[path], status: "conflict" };
-            new Notice(`drive9: remote changed again during resolution of ${path}`);
-          } else {
-            throw e;
+            new Notice(`drive9: remote changed again for ${path}, retrying next cycle`);
+            return;
           }
+          throw e;
         }
         break;
       }
@@ -279,7 +275,7 @@ export class ConflictResolver {
 
     const localFile = this.getLocalFile(path);
     if (localFile) {
-      // Move to Obsidian's local .trash — never system trash or permanent delete
+      // Move to Obsidian .trash — never permanent delete
       await this.vault.trash(localFile, false);
     }
     delete this.syncStates[path];

--- a/obsidian-plugin/src/diff3.ts
+++ b/obsidian-plugin/src/diff3.ts
@@ -1,0 +1,197 @@
+/**
+ * Minimal line-based 3-way merge (diff3 algorithm).
+ * No external dependencies — suitable for Obsidian plugin bundling.
+ */
+
+export interface MergeResult {
+  merged: string;
+  hasConflicts: boolean;
+}
+
+/**
+ * Attempt a 3-way merge of text content.
+ * @param base  - Common ancestor (shadow store version)
+ * @param ours  - Local version
+ * @param theirs - Remote version
+ * @returns Merged text and whether unresolved conflicts remain.
+ */
+export function merge3(base: string, ours: string, theirs: string): MergeResult {
+  if (ours === theirs) {
+    return { merged: ours, hasConflicts: false };
+  }
+  if (ours === base) {
+    return { merged: theirs, hasConflicts: false };
+  }
+  if (theirs === base) {
+    return { merged: ours, hasConflicts: false };
+  }
+
+  const baseLines = splitLines(base);
+  const oursLines = splitLines(ours);
+  const theirsLines = splitLines(theirs);
+
+  const oursEdits = diffLines(baseLines, oursLines);
+  const theirsEdits = diffLines(baseLines, theirsLines);
+
+  const result: string[] = [];
+  let hasConflicts = false;
+
+  let oIdx = 0;
+  let tIdx = 0;
+
+  while (oIdx < oursEdits.length || tIdx < theirsEdits.length) {
+    const oEdit = oIdx < oursEdits.length ? oursEdits[oIdx] : null;
+    const tEdit = tIdx < theirsEdits.length ? theirsEdits[tIdx] : null;
+
+    if (oEdit && tEdit) {
+      if (oEdit.type === "keep" && tEdit.type === "keep") {
+        result.push(oEdit.line);
+        oIdx++;
+        tIdx++;
+      } else if (oEdit.type === "keep" && tEdit.type !== "keep") {
+        // theirs changed, ours kept — take theirs
+        if (tEdit.type === "add") {
+          result.push(tEdit.line);
+          tIdx++;
+        } else {
+          // tEdit.type === "remove" — skip this base line
+          oIdx++;
+          tIdx++;
+        }
+      } else if (oEdit.type !== "keep" && tEdit.type === "keep") {
+        // ours changed, theirs kept — take ours
+        if (oEdit.type === "add") {
+          result.push(oEdit.line);
+          oIdx++;
+        } else {
+          // oEdit.type === "remove" — skip this base line
+          oIdx++;
+          tIdx++;
+        }
+      } else {
+        // Both changed the same region — conflict
+        hasConflicts = true;
+        result.push("<<<<<<< LOCAL");
+        while (oIdx < oursEdits.length && oursEdits[oIdx].type !== "keep") {
+          if (oursEdits[oIdx].type === "add") {
+            result.push(oursEdits[oIdx].line);
+          }
+          oIdx++;
+        }
+        result.push("=======");
+        while (tIdx < theirsEdits.length && theirsEdits[tIdx].type !== "keep") {
+          if (theirsEdits[tIdx].type === "add") {
+            result.push(theirsEdits[tIdx].line);
+          }
+          tIdx++;
+        }
+        result.push(">>>>>>> REMOTE");
+      }
+    } else if (oEdit) {
+      if (oEdit.type === "add" || oEdit.type === "keep") {
+        result.push(oEdit.line);
+      }
+      oIdx++;
+    } else if (tEdit) {
+      if (tEdit.type === "add" || tEdit.type === "keep") {
+        result.push(tEdit.line);
+      }
+      tIdx++;
+    }
+  }
+
+  return { merged: joinLines(result), hasConflicts };
+}
+
+interface Edit {
+  type: "keep" | "add" | "remove";
+  line: string;
+}
+
+/**
+ * Produce a sequence of edits that transforms `from` into `to`.
+ * Uses a simple LCS-based diff.
+ */
+function diffLines(from: string[], to: string[]): Edit[] {
+  const lcs = longestCommonSubsequence(from, to);
+  const edits: Edit[] = [];
+
+  let fi = 0;
+  let ti = 0;
+  let li = 0;
+
+  while (li < lcs.length) {
+    while (fi < lcs[li].fi) {
+      edits.push({ type: "remove", line: from[fi] });
+      fi++;
+    }
+    while (ti < lcs[li].ti) {
+      edits.push({ type: "add", line: to[ti] });
+      ti++;
+    }
+    edits.push({ type: "keep", line: from[fi] });
+    fi++;
+    ti++;
+    li++;
+  }
+
+  while (fi < from.length) {
+    edits.push({ type: "remove", line: from[fi] });
+    fi++;
+  }
+  while (ti < to.length) {
+    edits.push({ type: "add", line: to[ti] });
+    ti++;
+  }
+
+  return edits;
+}
+
+interface LCSEntry {
+  fi: number;
+  ti: number;
+}
+
+function longestCommonSubsequence(a: string[], b: string[]): LCSEntry[] {
+  const m = a.length;
+  const n = b.length;
+
+  // For large files, use a space-optimized approach
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      if (a[i] === b[j]) {
+        dp[i][j] = dp[i + 1][j + 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i + 1][j], dp[i][j + 1]);
+      }
+    }
+  }
+
+  const result: LCSEntry[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      result.push({ fi: i, ti: j });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+
+  return result;
+}
+
+function splitLines(text: string): string[] {
+  if (text === "") return [];
+  return text.split("\n");
+}
+
+function joinLines(lines: string[]): string {
+  return lines.join("\n");
+}

--- a/obsidian-plugin/src/first-run.ts
+++ b/obsidian-plugin/src/first-run.ts
@@ -192,11 +192,6 @@ export async function pullAllRemote(
       await vault.createBinary(entry.name, data);
     }
 
-    let contentHash: string | undefined;
-    if (shadowStore) {
-      try { contentHash = await shadowStore.save(data); } catch { /* ignore */ }
-    }
-
     const file = vault.getAbstractFileByPath(entry.name);
     if (file instanceof TFile) {
       let revision: number | null = null;
@@ -204,6 +199,10 @@ export async function pullAllRemote(
         const st = await client.stat(entry.name);
         revision = st.revision;
       } catch { /* revision stays null */ }
+      let contentHash: string | undefined;
+      if (shadowStore) {
+        try { contentHash = await shadowStore.save(data); } catch { /* shadow save best-effort */ }
+      }
       syncStates[entry.name] = {
         path: entry.name,
         localMtime: file.stat.mtime,

--- a/obsidian-plugin/src/first-run.ts
+++ b/obsidian-plugin/src/first-run.ts
@@ -1,5 +1,6 @@
 import { Vault, TFile, Modal, App, Setting, Notice } from "obsidian";
 import { Drive9Client, Drive9Error } from "./client";
+import type { ShadowStore } from "./shadow-store";
 import type { SyncState } from "./types";
 import { IgnoreMatcher } from "./ignore";
 
@@ -166,6 +167,7 @@ export async function pullAllRemote(
   client: Drive9Client,
   syncStates: Record<string, SyncState>,
   ignorePaths: string[],
+  shadowStore?: ShadowStore,
 ): Promise<void> {
   const ignore = new IgnoreMatcher(ignorePaths);
   const entries = await client.listRecursive("/");
@@ -190,6 +192,11 @@ export async function pullAllRemote(
       await vault.createBinary(entry.name, data);
     }
 
+    let contentHash: string | undefined;
+    if (shadowStore) {
+      try { contentHash = await shadowStore.save(data); } catch { /* ignore */ }
+    }
+
     const file = vault.getAbstractFileByPath(entry.name);
     if (file instanceof TFile) {
       let revision: number | null = null;
@@ -204,6 +211,7 @@ export async function pullAllRemote(
         remoteRevision: revision,
         syncedAt: Date.now(),
         status: revision !== null ? "synced" : "needs_refresh",
+        lastSyncedContentHash: contentHash,
       };
     }
     count++;

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -2,6 +2,8 @@ import { Plugin, Notice, TFile } from "obsidian";
 import { Drive9Client } from "./client";
 import { RemoteWatcher } from "./remote-watcher";
 import { SyncEngine } from "./sync-engine";
+import { ShadowStore } from "./shadow-store";
+import { ConflictResolver } from "./conflict-resolver";
 import { Drive9SettingTab } from "./settings";
 import { runFirstRunReconciliation, pullAllRemote } from "./first-run";
 import type { PluginData, Drive9Settings, SyncState } from "./types";
@@ -12,6 +14,9 @@ export default class Drive9Plugin extends Plugin {
   private client!: Drive9Client;
   private remoteWatcher: RemoteWatcher | null = null;
   private syncEngine!: SyncEngine;
+  private conflictResolver!: ConflictResolver;
+  private resolutionTimer: ReturnType<typeof setInterval> | null = null;
+  private shadowGCTimer: ReturnType<typeof setInterval> | null = null;
   private syncStates: Record<string, SyncState> = {};
   private firstRunComplete = false;
   private statusBarEl: HTMLElement | null = null;
@@ -38,6 +43,18 @@ export default class Drive9Plugin extends Plugin {
       this.settings,
       () => this.savePluginData(),
     );
+
+    const shadowStore = new ShadowStore(this.app.vault.adapter);
+    this.syncEngine.setShadowStore(shadowStore);
+
+    this.conflictResolver = new ConflictResolver(
+      this.app,
+      this.app.vault,
+      this.client,
+      this.syncStates,
+      () => this.savePluginData(),
+    );
+
     this.remoteWatcher = new RemoteWatcher(this.client, {
       onChange: (event) => this.syncEngine.onRemoteChange(event.path, event.op),
       onReset: () => this.syncEngine.fullSync(),
@@ -92,6 +109,17 @@ export default class Drive9Plugin extends Plugin {
     );
 
     this.remoteWatcher?.start();
+
+    // Resolution loop: scan for conflicts and remote_deleted every 10s
+    this.resolutionTimer = setInterval(() => {
+      void this.conflictResolver.resolveAll();
+    }, 10_000);
+
+    // Shadow GC: clean up unreferenced shadow files every 5 minutes
+    this.shadowGCTimer = setInterval(() => {
+      void this.conflictResolver.gcShadows();
+    }, 5 * 60_000);
+
     this.setStatusBar("✓ drive9: synced");
   }
 
@@ -242,6 +270,14 @@ export default class Drive9Plugin extends Plugin {
 
   onunload(): void {
     this.remoteWatcher?.stop();
+    if (this.resolutionTimer) {
+      clearInterval(this.resolutionTimer);
+      this.resolutionTimer = null;
+    }
+    if (this.shadowGCTimer) {
+      clearInterval(this.shadowGCTimer);
+      this.shadowGCTimer = null;
+    }
   }
 }
 

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -55,8 +55,9 @@ export default class Drive9Plugin extends Plugin {
       this.syncStates,
       () => this.savePluginData(),
     );
-
-    this.syncEngine.setExtraIgnoreCheck((path) => this.conflictResolver.isIgnoredPath(path));
+    this.conflictResolver.setSuppressLocalEvent(
+      (path, fn) => this.syncEngine.withSuppressedLocalEvents(path, fn),
+    );
 
     this.remoteWatcher = new RemoteWatcher(this.client, {
       onChange: (event) => this.syncEngine.onRemoteChange(event.path, event.op),

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -15,6 +15,7 @@ export default class Drive9Plugin extends Plugin {
   private remoteWatcher: RemoteWatcher | null = null;
   private syncEngine!: SyncEngine;
   private conflictResolver!: ConflictResolver;
+  private shadowStore!: ShadowStore;
   private resolutionTimer: ReturnType<typeof setInterval> | null = null;
   private shadowGCTimer: ReturnType<typeof setInterval> | null = null;
   private syncStates: Record<string, SyncState> = {};
@@ -44,8 +45,8 @@ export default class Drive9Plugin extends Plugin {
       () => this.savePluginData(),
     );
 
-    const shadowStore = new ShadowStore(this.app.vault.adapter);
-    this.syncEngine.setShadowStore(shadowStore);
+    this.shadowStore = new ShadowStore(this.app.vault.adapter);
+    this.syncEngine.setShadowStore(this.shadowStore);
 
     this.conflictResolver = new ConflictResolver(
       this.app,
@@ -54,6 +55,8 @@ export default class Drive9Plugin extends Plugin {
       this.syncStates,
       () => this.savePluginData(),
     );
+
+    this.syncEngine.setExtraIgnoreCheck((path) => this.conflictResolver.isIgnoredPath(path));
 
     this.remoteWatcher = new RemoteWatcher(this.client, {
       onChange: (event) => this.syncEngine.onRemoteChange(event.path, event.op),
@@ -148,6 +151,7 @@ export default class Drive9Plugin extends Plugin {
           this.client,
           this.syncStates,
           this.settings.ignorePaths,
+          this.shadowStore,
         );
         break;
 
@@ -179,6 +183,9 @@ export default class Drive9Plugin extends Plugin {
                   // Leave revision unknown; push path will refresh before write.
                 }
               }
+              try {
+                state.lastSyncedContentHash = await this.shadowStore.save(data);
+              } catch { /* shadow save is best-effort */ }
               const pulled = this.app.vault.getAbstractFileByPath(path);
               if (pulled instanceof TFile) {
                 state.localMtime = pulled.stat.mtime;

--- a/obsidian-plugin/src/shadow-store.ts
+++ b/obsidian-plugin/src/shadow-store.ts
@@ -1,0 +1,83 @@
+import type { DataAdapter } from "obsidian";
+import type { SyncState } from "./types";
+
+const SHADOW_DIR = ".obsidian/plugins/drive9/shadow";
+
+/**
+ * ShadowStore saves a copy of file content at last-sync for use as the
+ * merge base in 3-way conflict resolution. Files are stored by content
+ * hash (SHA-256 hex) for deduplication.
+ */
+export class ShadowStore {
+  constructor(private adapter: DataAdapter) {}
+
+  async save(data: ArrayBuffer): Promise<string> {
+    const hash = await this.hash(data);
+    const shadowPath = `${SHADOW_DIR}/${hash}.bin`;
+    if (!(await this.exists(shadowPath))) {
+      await this.ensureDir();
+      await this.adapter.writeBinary(shadowPath, data);
+    }
+    return hash;
+  }
+
+  async load(hash: string): Promise<ArrayBuffer | null> {
+    const shadowPath = `${SHADOW_DIR}/${hash}.bin`;
+    if (!(await this.exists(shadowPath))) {
+      return null;
+    }
+    return this.adapter.readBinary(shadowPath);
+  }
+
+  /**
+   * Remove shadow files that are not referenced by any SyncState.
+   */
+  async gc(syncStates: Record<string, SyncState>): Promise<number> {
+    const referencedHashes = new Set<string>();
+    for (const state of Object.values(syncStates)) {
+      if (state.lastSyncedContentHash) {
+        referencedHashes.add(state.lastSyncedContentHash);
+      }
+    }
+
+    let removed = 0;
+    if (!(await this.exists(SHADOW_DIR))) {
+      return removed;
+    }
+
+    const listing = await this.adapter.list(SHADOW_DIR);
+    for (const filePath of listing.files) {
+      const name = filePath.split("/").pop() ?? "";
+      const hash = name.replace(/\.bin$/, "");
+      if (!referencedHashes.has(hash)) {
+        try {
+          await this.adapter.remove(filePath);
+          removed++;
+        } catch {
+          // Ignore removal failures during GC.
+        }
+      }
+    }
+    return removed;
+  }
+
+  private async hash(data: ArrayBuffer): Promise<string> {
+    const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+    const bytes = new Uint8Array(hashBuffer);
+    let hex = "";
+    for (const b of bytes) {
+      hex += b.toString(16).padStart(2, "0");
+    }
+    return hex;
+  }
+
+  private async ensureDir(): Promise<void> {
+    if (!(await this.exists(SHADOW_DIR))) {
+      await this.adapter.mkdir(SHADOW_DIR);
+    }
+  }
+
+  private async exists(path: string): Promise<boolean> {
+    return this.adapter.exists(path);
+  }
+}

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -23,7 +23,6 @@ export class SyncEngine {
   private statusListeners: Array<() => void> = [];
 
   private shadowStore: ShadowStore | null = null;
-  private extraIgnoreCheck: ((path: string) => boolean) | null = null;
 
   constructor(
     private vault: Vault,
@@ -37,11 +36,6 @@ export class SyncEngine {
 
   setShadowStore(store: ShadowStore): void {
     this.shadowStore = store;
-  }
-
-  /** Register an additional ignore check (e.g. for conflict resolver ignored paths). */
-  setExtraIgnoreCheck(fn: (path: string) => boolean): void {
-    this.extraIgnoreCheck = fn;
   }
 
   get status(): SyncStatus {
@@ -141,9 +135,7 @@ export class SyncEngine {
   }
 
   private shouldIgnore(path: string): boolean {
-    if (this.ignoreMatcher.isIgnored(path)) return true;
-    if (this.extraIgnoreCheck?.(path)) return true;
-    return false;
+    return this.ignoreMatcher.isIgnored(path);
   }
 
   private markDirty(path: string): void {
@@ -288,7 +280,7 @@ export class SyncEngine {
     return (this.suppressedPaths.get(path) ?? 0) > 0;
   }
 
-  private async withSuppressedLocalEvents(path: string, fn: () => Promise<void>): Promise<void> {
+  async withSuppressedLocalEvents(path: string, fn: () => Promise<void>): Promise<void> {
     this.suppressedPaths.set(path, (this.suppressedPaths.get(path) ?? 0) + 1);
     try {
       await fn();

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -1,6 +1,7 @@
 import { Vault, TFile, TAbstractFile, Notice } from "obsidian";
 import { Drive9Client, Drive9Error } from "./client";
 import { IgnoreMatcher } from "./ignore";
+import type { ShadowStore } from "./shadow-store";
 import type { SyncState, Drive9Settings } from "./types";
 
 export type SyncStatus = "idle" | "syncing" | "error";
@@ -21,6 +22,8 @@ export class SyncEngine {
   private _pendingCount = 0;
   private statusListeners: Array<() => void> = [];
 
+  private shadowStore: ShadowStore | null = null;
+
   constructor(
     private vault: Vault,
     private client: Drive9Client,
@@ -29,6 +32,10 @@ export class SyncEngine {
     private persistData: () => Promise<void>,
   ) {
     this.ignoreMatcher = new IgnoreMatcher(settings.ignorePaths);
+  }
+
+  setShadowStore(store: ShadowStore): void {
+    this.shadowStore = store;
   }
 
   get status(): SyncStatus {
@@ -86,12 +93,12 @@ export class SyncEngine {
     }
   }
 
-  async onRemoteChange(path: string, _op: string): Promise<void> {
+  async onRemoteChange(path: string, op: string): Promise<void> {
     if (this.shouldIgnore(path)) return;
     await this.enqueue(async () => {
       this.setStatus("syncing", 1);
       try {
-        await this.reconcileRemotePath(path);
+        await this.reconcileRemotePath(path, op === "delete" ? "sse" : undefined);
       } finally {
         this.setStatus("idle", this.dirtyPaths.size);
         await this.persistData();
@@ -219,6 +226,7 @@ export class SyncEngine {
 
     try {
       const result = await this.client.write(path, data, expectedRevision);
+      const contentHash = await this.saveShadowIfAvailable(data);
       if (result.revision !== null) {
         this.syncStates[path] = {
           path,
@@ -227,6 +235,7 @@ export class SyncEngine {
           remoteRevision: result.revision,
           syncedAt: Date.now(),
           status: "synced",
+          lastSyncedContentHash: contentHash,
         };
       } else {
         this.syncStates[path] = {
@@ -236,6 +245,7 @@ export class SyncEngine {
           remoteRevision: null,
           syncedAt: Date.now(),
           status: "needs_refresh",
+          lastSyncedContentHash: contentHash,
         };
         console.warn(`[drive9] write succeeded but revision unknown for ${path}`);
       }
@@ -310,7 +320,7 @@ export class SyncEngine {
     return state.localMtime === file.stat.mtime && state.localSize === file.stat.size;
   }
 
-  private async reconcileRemotePath(path: string): Promise<void> {
+  private async reconcileRemotePath(path: string, deleteSource?: "polling" | "sse"): Promise<void> {
     const state = this.syncStates[path];
     if (state?.status === "conflict") {
       return;
@@ -324,7 +334,7 @@ export class SyncEngine {
       remoteRevision = remoteStat.revision;
     } catch (error) {
       if (error instanceof Drive9Error && error.status === 404) {
-        await this.handleRemoteMissing(path);
+        await this.handleRemoteMissing(path, deleteSource ?? "polling");
         return;
       }
       throw error;
@@ -346,7 +356,7 @@ export class SyncEngine {
     await this.pullRemoteFile(path, remoteRevision, localFile);
   }
 
-  private async handleRemoteMissing(path: string): Promise<void> {
+  private async handleRemoteMissing(path: string, source: "polling" | "sse" = "polling"): Promise<void> {
     const state = this.syncStates[path];
     if (!state || state.status === "conflict") return;
 
@@ -356,8 +366,18 @@ export class SyncEngine {
       return;
     }
 
+    if (state.status === "remote_deleted") {
+      // Already marked — increment consecutive absence count for polling
+      if (source === "polling") {
+        state.consecutiveAbsences = (state.consecutiveAbsences ?? 1) + 1;
+      }
+      return;
+    }
+
     state.status = "remote_deleted";
     state.syncedAt = Date.now();
+    state.deleteDetectionSource = source;
+    state.consecutiveAbsences = source === "polling" ? 1 : undefined;
   }
 
   private markConflict(path: string, localFile: TFile | null, remoteRevision: number | null): void {
@@ -393,6 +413,7 @@ export class SyncEngine {
       }
     });
 
+    const contentHash = await this.saveShadowIfAvailable(data);
     const updatedFile = this.getLocalFile(path);
     this.syncStates[path] = {
       path,
@@ -401,7 +422,17 @@ export class SyncEngine {
       remoteRevision,
       syncedAt: Date.now(),
       status: "synced",
+      lastSyncedContentHash: contentHash,
     };
+  }
+
+  private async saveShadowIfAvailable(data: ArrayBuffer): Promise<string | undefined> {
+    if (!this.shadowStore) return undefined;
+    try {
+      return await this.shadowStore.save(data);
+    } catch {
+      return undefined;
+    }
   }
 
   private setStatus(status: SyncStatus, pending: number): void {

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -23,6 +23,7 @@ export class SyncEngine {
   private statusListeners: Array<() => void> = [];
 
   private shadowStore: ShadowStore | null = null;
+  private extraIgnoreCheck: ((path: string) => boolean) | null = null;
 
   constructor(
     private vault: Vault,
@@ -36,6 +37,11 @@ export class SyncEngine {
 
   setShadowStore(store: ShadowStore): void {
     this.shadowStore = store;
+  }
+
+  /** Register an additional ignore check (e.g. for conflict resolver ignored paths). */
+  setExtraIgnoreCheck(fn: (path: string) => boolean): void {
+    this.extraIgnoreCheck = fn;
   }
 
   get status(): SyncStatus {
@@ -135,7 +141,9 @@ export class SyncEngine {
   }
 
   private shouldIgnore(path: string): boolean {
-    return this.ignoreMatcher.isIgnored(path);
+    if (this.ignoreMatcher.isIgnored(path)) return true;
+    if (this.extraIgnoreCheck?.(path)) return true;
+    return false;
   }
 
   private markDirty(path: string): void {

--- a/obsidian-plugin/src/types.ts
+++ b/obsidian-plugin/src/types.ts
@@ -59,6 +59,15 @@ export interface SyncState {
   remoteRevision: number | null;
   syncedAt: number;
   status: "synced" | "local_dirty" | "remote_dirty" | "remote_deleted" | "conflict" | "needs_refresh";
+  /** SHA-256 hex of content at last successful sync (for 3-way merge base). */
+  lastSyncedContentHash?: string;
+  /**
+   * How a remote_deleted status was detected.
+   * 'polling' requires 2 consecutive absences before apply; 'sse' is immediate.
+   */
+  deleteDetectionSource?: "polling" | "sse";
+  /** Number of consecutive polls where this file was absent from remote. */
+  consecutiveAbsences?: number;
 }
 
 /** Persisted plugin data (settings + sync state). */


### PR DESCRIPTION
## Summary

Implements #183 (Phase 2B: Conflict Resolution) for the Obsidian drive9 plugin.

- **Shadow Store**: Saves a content snapshot (SHA-256 deduplicated) after each successful sync, stored in `.obsidian/plugins/drive9/shadow/`. Used as merge base for 3-way conflict resolution. Includes periodic GC of unreferenced shadow files.
- **3-way Merge (diff3)**: Zero-dependency, line-based LCS diff3 implementation. Automatically resolves text file conflicts when changes don't overlap. Falls back to ConflictModal when auto-merge fails.
- **ConflictModal**: Obsidian Modal showing file path, local vs remote metadata (size/mtime), optional diff preview. User chooses: Keep Local, Keep Remote, or Keep Both (saves remote as `{name}.conflict.{ext}`).
- **Remote Delete Apply**: Files marked `remote_deleted` by Phase 2A are moved to Obsidian `.trash/` (never permanent delete). Polling-detected deletes require 2 consecutive poll absences before apply; SSE delete events apply immediately.
- **Resolution Loop**: 10s periodic scan of all SyncState entries, processing `conflict` and `remote_deleted` states.
- **SyncState extensions**: `lastSyncedContentHash`, `deleteDetectionSource`, `consecutiveAbsences` fields.

New files: `shadow-store.ts`, `diff3.ts`, `conflict-modal.ts`, `conflict-resolver.ts`
Modified: `sync-engine.ts`, `main.ts`, `types.ts`

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Shadow store saves content hash on push and pull
- [ ] Text conflict with non-overlapping changes auto-merges
- [ ] Text conflict with overlapping changes shows ConflictModal
- [ ] Binary conflict shows ConflictModal
- [ ] Keep Local / Keep Remote / Keep Both all resolve correctly
- [ ] Remote delete moves file to `.trash/`, not permanent delete
- [ ] Polling delete requires 2 consecutive absences
- [ ] SSE delete applies after single event
- [ ] Shadow GC removes unreferenced shadow files

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive conflict resolution modal with three options: keep local, keep remote, or keep both versions.
  * Implemented automatic 3-way merge for text file conflicts.
  * Enhanced handling of remotely deleted files with improved detection.
  * Background processes now automatically resolve conflicts and manage cached content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->