### PR TITLE
Implement drive9 secret CLI v0

### DIFF
--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -186,8 +186,9 @@ func SecretExec(args []string) error {
 	return cmd.Run()
 }
 
-// SecretLs lists secret names. With a management token it lists all secrets;
-// with only a capability token it enumerates the visible scope.
+// SecretLs lists secret names. An explicit capability token always wins over
+// any ambient tenant API key/config so agents do not silently enumerate the
+// whole tenant when a scoped token was intentionally provided.
 func SecretLs(args []string) error {
 	asJSON := false
 	for _, arg := range args {
@@ -200,7 +201,17 @@ func SecretLs(args []string) error {
 	}
 
 	var names []string
-	if c, ok := optionalVaultManagementClientFromEnv(); ok {
+	if currentCapabilityToken() != "" {
+		c, err := newVaultReadClientFromEnv()
+		if err != nil {
+			return err
+		}
+		var errList error
+		names, errList = c.ListReadableVaultSecrets(context.Background())
+		if errList != nil {
+			return errList
+		}
+	} else if c, ok := optionalVaultManagementClientFromEnv(); ok {
 		secrets, err := c.ListVaultSecrets(context.Background())
 		if err != nil {
 			return err
@@ -481,6 +492,9 @@ func validateSecretName(name string) error {
 	if strings.Contains(name, "/") {
 		return fmt.Errorf("secret name %q must be flat in v0; use <name/field> only for reads and scopes", name)
 	}
+	if strings.Contains(name, "*") {
+		return fmt.Errorf("wildcard scope entries are not supported in v0: %q", name)
+	}
 	return nil
 }
 
@@ -499,6 +513,9 @@ func parseSecretRef(raw string) (string, string, error) {
 	field := parts[1]
 	if field == "" {
 		return "", "", fmt.Errorf("field name is required in %q", raw)
+	}
+	if strings.Contains(field, "*") {
+		return "", "", fmt.Errorf("wildcard scope entries are not supported in v0: %q", raw)
 	}
 	return name, field, nil
 }

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -27,7 +27,7 @@ const (
 // Secret dispatches drive9 secret subcommands.
 func Secret(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: drive9 secret <set|get|exec|ls|rm|grant|revoke|audit> ...")
+		return fmt.Errorf("usage drive9 secret <set|get|exec|ls|rm|grant|revoke|audit> ...")
 	}
 	switch args[0] {
 	case "set":
@@ -47,7 +47,7 @@ func Secret(args []string) error {
 	case "audit":
 		return SecretAudit(args[1:])
 	case "-h", "--help", "help":
-		return fmt.Errorf("usage: drive9 secret <set|get|exec|ls|rm|grant|revoke|audit> ...")
+		return fmt.Errorf("usage drive9 secret <set|get|exec|ls|rm|grant|revoke|audit> ...")
 	default:
 		return fmt.Errorf("unknown secret command %q", args[0])
 	}
@@ -56,7 +56,7 @@ func Secret(args []string) error {
 // SecretSet creates or updates a secret.
 func SecretSet(args []string) error {
 	if len(args) < 2 {
-		return fmt.Errorf("usage: drive9 secret set <name> <field=value|field=@file|field=->...")
+		return fmt.Errorf("usage drive9 secret set <name> <field=value|field=@file|field=->...")
 	}
 	name := args[0]
 	if err := validateSecretName(name); err != nil {
@@ -86,7 +86,7 @@ func SecretSet(args []string) error {
 // SecretGet reads a whole secret or one field.
 func SecretGet(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: drive9 secret get <name[/field]> [--json|--env]")
+		return fmt.Errorf("usage drive9 secret get <name[/field]> [--json|--env]")
 	}
 	ref := args[0]
 	name, field, err := parseSecretRef(ref)
@@ -147,7 +147,7 @@ func SecretGet(args []string) error {
 // SecretExec injects a secret into a child process environment and executes it.
 func SecretExec(args []string) error {
 	if len(args) < 3 {
-		return fmt.Errorf("usage: drive9 secret exec <name> -- <command...>")
+		return fmt.Errorf("usage drive9 secret exec <name> -- <command...>")
 	}
 	name := args[0]
 	if err := validateSecretName(name); err != nil {
@@ -161,7 +161,7 @@ func SecretExec(args []string) error {
 		}
 	}
 	if sep < 0 || sep == len(args)-1 {
-		return fmt.Errorf("usage: drive9 secret exec <name> -- <command...>")
+		return fmt.Errorf("usage drive9 secret exec <name> -- <command...>")
 	}
 	cmdArgs := args[sep+1:]
 
@@ -196,7 +196,7 @@ func SecretLs(args []string) error {
 		case "--json":
 			asJSON = true
 		default:
-			return fmt.Errorf("usage: drive9 secret ls [--json]")
+			return fmt.Errorf("usage drive9 secret ls [--json]")
 		}
 	}
 
@@ -244,7 +244,7 @@ func SecretLs(args []string) error {
 // SecretRm deletes a secret.
 func SecretRm(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("usage: drive9 secret rm <name>")
+		return fmt.Errorf("usage drive9 secret rm <name>")
 	}
 	name := args[0]
 	if err := validateSecretName(name); err != nil {
@@ -347,7 +347,7 @@ func SecretGrant(args []string) error {
 // SecretRevoke revokes a capability token.
 func SecretRevoke(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("usage: drive9 secret revoke <token-id>")
+		return fmt.Errorf("usage drive9 secret revoke <token-id>")
 	}
 	c, err := newVaultManagementClientFromEnv()
 	if err != nil {
@@ -425,7 +425,6 @@ func SecretAudit(args []string) error {
 			return fmt.Errorf("--since must be positive")
 		}
 		events = filterAuditEvents(events, agentID, time.Now().Add(-d))
-		agentID = ""
 	} else if agentID != "" {
 		events = filterAuditEvents(events, agentID, time.Time{})
 	}
@@ -622,14 +621,6 @@ func envMapFromSecret(fields map[string]string) map[string]string {
 		panic(err)
 	}
 	return env
-}
-
-func secretEnvVars(fields map[string]string) []string {
-	env, err := buildSecretEnvMap(fields)
-	if err != nil {
-		panic(err)
-	}
-	return mergeEnv(nil, env)
 }
 
 func filterAuditEvents(events []client.VaultAuditEvent, agentID string, since time.Time) []client.VaultAuditEvent {

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -27,7 +27,7 @@ const (
 // Secret dispatches drive9 secret subcommands.
 func Secret(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage drive9 secret <set|get|exec|ls|rm|grant|revoke|audit> ...")
+		return fmt.Errorf("usage drive9 secret <set|get|exec|ls|rm|grant|revoke|audit>")
 	}
 	switch args[0] {
 	case "set":
@@ -47,7 +47,7 @@ func Secret(args []string) error {
 	case "audit":
 		return SecretAudit(args[1:])
 	case "-h", "--help", "help":
-		return fmt.Errorf("usage drive9 secret <set|get|exec|ls|rm|grant|revoke|audit> ...")
+		return fmt.Errorf("usage drive9 secret <set|get|exec|ls|rm|grant|revoke|audit>")
 	default:
 		return fmt.Errorf("unknown secret command %q", args[0])
 	}
@@ -56,7 +56,7 @@ func Secret(args []string) error {
 // SecretSet creates or updates a secret.
 func SecretSet(args []string) error {
 	if len(args) < 2 {
-		return fmt.Errorf("usage drive9 secret set <name> <field=value|field=@file|field=->...")
+		return fmt.Errorf("usage drive9 secret set <name> <field=value|field=@file|field=-> [more fields]")
 	}
 	name := args[0]
 	if err := validateSecretName(name); err != nil {

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -1,0 +1,680 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+const (
+	vaultTokenEnv       = "DRIVE9_VAULT_TOKEN"
+	legacyCapTokenEnv   = "DRIVE9_CAP_TOKEN"
+	defaultAuditLimit   = 100
+	maxClientAuditLimit = 1000
+)
+
+// Secret dispatches drive9 secret subcommands.
+func Secret(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: drive9 secret <set|get|exec|ls|rm|grant|revoke|audit> ...")
+	}
+	switch args[0] {
+	case "set":
+		return SecretSet(args[1:])
+	case "get":
+		return SecretGet(args[1:])
+	case "exec":
+		return SecretExec(args[1:])
+	case "ls":
+		return SecretLs(args[1:])
+	case "rm":
+		return SecretRm(args[1:])
+	case "grant":
+		return SecretGrant(args[1:])
+	case "revoke":
+		return SecretRevoke(args[1:])
+	case "audit":
+		return SecretAudit(args[1:])
+	case "-h", "--help", "help":
+		return fmt.Errorf("usage: drive9 secret <set|get|exec|ls|rm|grant|revoke|audit> ...")
+	default:
+		return fmt.Errorf("unknown secret command %q", args[0])
+	}
+}
+
+// SecretSet creates or updates a secret.
+func SecretSet(args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("usage: drive9 secret set <name> <field=value|field=@file|field=->...")
+	}
+	name := args[0]
+	if err := validateSecretName(name); err != nil {
+		return err
+	}
+	fields, err := parseSecretFields(args[1:])
+	if err != nil {
+		return err
+	}
+	c, err := newVaultManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	if _, err := c.CreateVaultSecret(ctx, name, fields); err != nil {
+		if !errors.Is(err, client.ErrConflict) {
+			return err
+		}
+		_, err = c.UpdateVaultSecret(ctx, name, fields)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SecretGet reads a whole secret or one field.
+func SecretGet(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: drive9 secret get <name[/field]> [--json|--env]")
+	}
+	ref := args[0]
+	name, field, err := parseSecretRef(ref)
+	if err != nil {
+		return err
+	}
+	asJSON := false
+	asEnv := false
+	for _, arg := range args[1:] {
+		switch arg {
+		case "--json":
+			asJSON = true
+		case "--env":
+			asEnv = true
+		default:
+			return fmt.Errorf("unknown flag %q", arg)
+		}
+	}
+	if asJSON && asEnv {
+		return fmt.Errorf("--json and --env are mutually exclusive")
+	}
+
+	c, err := newVaultReadClientFromEnv()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	if field != "" {
+		value, err := c.ReadVaultSecretField(ctx, name, field)
+		if err != nil {
+			return err
+		}
+		switch {
+		case asEnv:
+			envKey, err := normalizeSecretEnvKey(field)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(os.Stdout, "%s=%s\n", envKey, value)
+		case asJSON:
+			return writeJSON(map[string]string{field: value})
+		default:
+			_, _ = fmt.Fprintln(os.Stdout, value)
+		}
+		return nil
+	}
+
+	fields, err := c.ReadVaultSecret(ctx, name)
+	if err != nil {
+		return err
+	}
+	if asEnv {
+		return printEnv(fields)
+	}
+	return writeJSON(fields)
+}
+
+// SecretExec injects a secret into a child process environment and executes it.
+func SecretExec(args []string) error {
+	if len(args) < 3 {
+		return fmt.Errorf("usage: drive9 secret exec <name> -- <command...>")
+	}
+	name := args[0]
+	if err := validateSecretName(name); err != nil {
+		return err
+	}
+	sep := -1
+	for i := 1; i < len(args); i++ {
+		if args[i] == "--" {
+			sep = i
+			break
+		}
+	}
+	if sep < 0 || sep == len(args)-1 {
+		return fmt.Errorf("usage: drive9 secret exec <name> -- <command...>")
+	}
+	cmdArgs := args[sep+1:]
+
+	c, err := newVaultReadClientFromEnv()
+	if err != nil {
+		return err
+	}
+	fields, err := c.ReadVaultSecret(context.Background(), name)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	envMap, err := buildSecretEnvMap(fields)
+	if err != nil {
+		return err
+	}
+	cmd.Env = mergeEnv(os.Environ(), envMap)
+	return cmd.Run()
+}
+
+// SecretLs lists secret names. With a management token it lists all secrets;
+// with only a capability token it enumerates the visible scope.
+func SecretLs(args []string) error {
+	asJSON := false
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+			asJSON = true
+		default:
+			return fmt.Errorf("usage: drive9 secret ls [--json]")
+		}
+	}
+
+	var names []string
+	if c, ok := optionalVaultManagementClientFromEnv(); ok {
+		secrets, err := c.ListVaultSecrets(context.Background())
+		if err != nil {
+			return err
+		}
+		names = make([]string, 0, len(secrets))
+		for _, sec := range secrets {
+			names = append(names, sec.Name)
+		}
+	} else {
+		c, err := newVaultReadClientFromEnv()
+		if err != nil {
+			return err
+		}
+		var errList error
+		names, errList = c.ListReadableVaultSecrets(context.Background())
+		if errList != nil {
+			return errList
+		}
+	}
+	sort.Strings(names)
+	if asJSON {
+		return writeJSON(map[string]any{"secrets": names})
+	}
+	for _, name := range names {
+		fmt.Println(name)
+	}
+	return nil
+}
+
+// SecretRm deletes a secret.
+func SecretRm(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: drive9 secret rm <name>")
+	}
+	name := args[0]
+	if err := validateSecretName(name); err != nil {
+		return err
+	}
+	c, err := newVaultManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	return c.DeleteVaultSecret(context.Background(), name)
+}
+
+// SecretGrant issues a scoped capability token.
+func SecretGrant(args []string) error {
+	var (
+		agentID   string
+		taskID    string
+		ttlRaw    string
+		asJSON    bool
+		tokenOnly bool
+		scope     []string
+	)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--agent":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--agent requires a value")
+			}
+			i++
+			agentID = args[i]
+		case "--task":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--task requires a value")
+			}
+			i++
+			taskID = args[i]
+		case "--ttl":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--ttl requires a value")
+			}
+			i++
+			ttlRaw = args[i]
+		case "--json":
+			asJSON = true
+		case "--token-only":
+			tokenOnly = true
+		default:
+			if strings.HasPrefix(arg, "--") {
+				return fmt.Errorf("unknown flag %q", arg)
+			}
+			scope = append(scope, arg)
+		}
+	}
+	if asJSON && tokenOnly {
+		return fmt.Errorf("--json and --token-only are mutually exclusive")
+	}
+	if agentID == "" {
+		return fmt.Errorf("--agent is required")
+	}
+	if ttlRaw == "" {
+		return fmt.Errorf("--ttl is required")
+	}
+	if len(scope) == 0 {
+		return fmt.Errorf("at least one scope entry is required")
+	}
+	for _, entry := range scope {
+		if _, _, err := parseSecretRef(entry); err != nil {
+			return fmt.Errorf("invalid scope %q: %w", entry, err)
+		}
+	}
+	ttl, err := time.ParseDuration(ttlRaw)
+	if err != nil {
+		return fmt.Errorf("invalid --ttl %q: %w", ttlRaw, err)
+	}
+	if ttl <= 0 {
+		return fmt.Errorf("--ttl must be positive")
+	}
+	c, err := newVaultManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	resp, err := c.IssueVaultToken(context.Background(), agentID, taskID, scope, ttl)
+	if err != nil {
+		return err
+	}
+	switch {
+	case tokenOnly:
+		_, _ = fmt.Fprintln(os.Stdout, resp.Token)
+	case asJSON:
+		return writeJSON(resp)
+	default:
+		_, _ = fmt.Fprintf(os.Stdout, "token=%s\n", resp.Token)
+		_, _ = fmt.Fprintf(os.Stdout, "token_id=%s\n", resp.TokenID)
+		_, _ = fmt.Fprintf(os.Stdout, "expires_at=%s\n", resp.ExpiresAt.Format(time.RFC3339))
+	}
+	return nil
+}
+
+// SecretRevoke revokes a capability token.
+func SecretRevoke(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: drive9 secret revoke <token-id>")
+	}
+	c, err := newVaultManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	return c.RevokeVaultToken(context.Background(), args[0])
+}
+
+// SecretAudit queries vault audit events and applies client-side filters.
+func SecretAudit(args []string) error {
+	var (
+		secretName string
+		agentID    string
+		sinceRaw   string
+		limit      = defaultAuditLimit
+		asJSON     bool
+	)
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--secret":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--secret requires a value")
+			}
+			i++
+			secretName = args[i]
+		case "--agent":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--agent requires a value")
+			}
+			i++
+			agentID = args[i]
+		case "--since":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--since requires a value")
+			}
+			i++
+			sinceRaw = args[i]
+		case "--limit":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--limit requires a value")
+			}
+			i++
+			n, err := strconv.Atoi(args[i])
+			if err != nil || n <= 0 {
+				return fmt.Errorf("invalid --limit %q", args[i])
+			}
+			limit = n
+		case "--json":
+			asJSON = true
+		default:
+			return fmt.Errorf("unknown flag %q", args[i])
+		}
+	}
+	c, err := newVaultManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	queryLimit := limit
+	if agentID != "" || sinceRaw != "" {
+		queryLimit = maxClientAuditLimit
+	}
+	if queryLimit > maxClientAuditLimit {
+		queryLimit = maxClientAuditLimit
+	}
+	events, err := c.QueryVaultAudit(context.Background(), secretName, queryLimit)
+	if err != nil {
+		return err
+	}
+	if sinceRaw != "" {
+		d, err := time.ParseDuration(sinceRaw)
+		if err != nil {
+			return fmt.Errorf("invalid --since %q: %w", sinceRaw, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("--since must be positive")
+		}
+		events = filterAuditEvents(events, agentID, time.Now().Add(-d))
+		agentID = ""
+	} else if agentID != "" {
+		events = filterAuditEvents(events, agentID, time.Time{})
+	}
+	if len(events) > limit {
+		events = events[:limit]
+	}
+	if asJSON {
+		return writeJSON(map[string]any{"events": events})
+	}
+	printAudit(events)
+	return nil
+}
+
+func resolveVaultServer() string {
+	server := os.Getenv("DRIVE9_SERVER")
+	if server != "" {
+		return server
+	}
+	return loadConfig().ResolveServer()
+}
+
+func currentAPIKey() string {
+	if apiKey := os.Getenv("DRIVE9_API_KEY"); apiKey != "" {
+		return apiKey
+	}
+	return loadConfig().CurrentAPIKey()
+}
+
+func currentCapabilityToken() string {
+	if tok := os.Getenv(vaultTokenEnv); tok != "" {
+		return tok
+	}
+	return os.Getenv(legacyCapTokenEnv)
+}
+
+func optionalVaultManagementClientFromEnv() (*client.Client, bool) {
+	apiKey := currentAPIKey()
+	if apiKey == "" {
+		return nil, false
+	}
+	return client.New(resolveVaultServer(), apiKey), true
+}
+
+func newVaultManagementClientFromEnv() (*client.Client, error) {
+	c, ok := optionalVaultManagementClientFromEnv()
+	if !ok {
+		return nil, fmt.Errorf("missing tenant API key; set DRIVE9_API_KEY or run drive9 create")
+	}
+	return c, nil
+}
+
+func newVaultReadClientFromEnv() (*client.Client, error) {
+	token := currentCapabilityToken()
+	if token == "" {
+		return nil, fmt.Errorf("missing capability token; set %s (or %s) before using drive9 secret get/exec", vaultTokenEnv, legacyCapTokenEnv)
+	}
+	return client.New(resolveVaultServer(), token), nil
+}
+
+func validateSecretName(name string) error {
+	if name == "" {
+		return fmt.Errorf("secret name is required")
+	}
+	if strings.Contains(name, "/") {
+		return fmt.Errorf("secret name %q must be flat in v0; use <name/field> only for reads and scopes", name)
+	}
+	return nil
+}
+
+func parseSecretRef(raw string) (string, string, error) {
+	if raw == "" {
+		return "", "", fmt.Errorf("secret reference is required")
+	}
+	parts := strings.SplitN(raw, "/", 2)
+	name := parts[0]
+	if err := validateSecretName(name); err != nil {
+		return "", "", err
+	}
+	if len(parts) == 1 {
+		return name, "", nil
+	}
+	field := parts[1]
+	if field == "" {
+		return "", "", fmt.Errorf("field name is required in %q", raw)
+	}
+	return name, field, nil
+}
+
+func parseSecretFields(args []string) (map[string]string, error) {
+	fields := make(map[string]string, len(args))
+	var stdinValue []byte
+	stdinRead := false
+	for _, arg := range args {
+		key, valueSpec, ok := strings.Cut(arg, "=")
+		if !ok || key == "" {
+			return nil, fmt.Errorf("field assignment must be field=value, field=@file, or field=-: %q", arg)
+		}
+		var value string
+		switch {
+		case valueSpec == "-":
+			if !stdinRead {
+				data, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return nil, fmt.Errorf("read stdin: %w", err)
+				}
+				stdinValue = data
+				stdinRead = true
+			}
+			value = string(stdinValue)
+		case strings.HasPrefix(valueSpec, "@"):
+			data, err := os.ReadFile(valueSpec[1:])
+			if err != nil {
+				return nil, fmt.Errorf("read %s: %w", valueSpec[1:], err)
+			}
+			value = string(data)
+		default:
+			value = valueSpec
+		}
+		fields[key] = value
+	}
+	return fields, nil
+}
+
+func parseFieldAssignments(args []string) (map[string]string, error) {
+	return parseSecretFields(args)
+}
+
+func writeJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func printEnv(fields map[string]string) error {
+	envMap, err := buildSecretEnvMap(fields)
+	if err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(envMap))
+	for k := range envMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fmt.Printf("%s=%s\n", key, envMap[key])
+	}
+	return nil
+}
+
+func printAudit(events []client.VaultAuditEvent) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "TIME\tAGENT\tACTION\tSECRET\tFIELD")
+	for _, ev := range events {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			ev.Timestamp.Format(time.RFC3339),
+			ev.AgentID,
+			ev.EventType,
+			ev.SecretName,
+			ev.FieldName,
+		)
+	}
+	_ = w.Flush()
+}
+
+// Secret fields map to env vars via a stable upper-snake transformation:
+// non [A-Za-z0-9_] chars become '_', and leading digits are prefixed with '_'.
+// Normalization collisions are rejected instead of silently overriding values.
+func buildSecretEnvMap(fields map[string]string) (map[string]string, error) {
+	env := make(map[string]string, len(fields))
+	owners := make(map[string]string, len(fields))
+	for field, value := range fields {
+		envKey, err := normalizeSecretEnvKey(field)
+		if err != nil {
+			return nil, err
+		}
+		if prevField, exists := owners[envKey]; exists {
+			return nil, fmt.Errorf("secret fields %q and %q both normalize to env var %q", prevField, field, envKey)
+		}
+		owners[envKey] = field
+		env[envKey] = value
+	}
+	return env, nil
+}
+
+func envMapFromSecret(fields map[string]string) map[string]string {
+	env, err := buildSecretEnvMap(fields)
+	if err != nil {
+		panic(err)
+	}
+	return env
+}
+
+func secretEnvVars(fields map[string]string) []string {
+	env, err := buildSecretEnvMap(fields)
+	if err != nil {
+		panic(err)
+	}
+	return mergeEnv(nil, env)
+}
+
+func filterAuditEvents(events []client.VaultAuditEvent, agentID string, since time.Time) []client.VaultAuditEvent {
+	filtered := make([]client.VaultAuditEvent, 0, len(events))
+	for _, ev := range events {
+		if agentID != "" && ev.AgentID != agentID {
+			continue
+		}
+		if !since.IsZero() && ev.Timestamp.Before(since) {
+			continue
+		}
+		filtered = append(filtered, ev)
+	}
+	return filtered
+}
+
+func mergeEnv(base []string, overrides map[string]string) []string {
+	merged := make(map[string]string, len(base)+len(overrides))
+	for _, entry := range base {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			merged[key] = value
+		}
+	}
+	for k, v := range overrides {
+		merged[k] = v
+	}
+	keys := make([]string, 0, len(merged))
+	for k := range merged {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	env := make([]string, 0, len(keys))
+	for _, k := range keys {
+		env = append(env, k+"="+merged[k])
+	}
+	return env
+}
+
+func normalizeSecretEnvKey(field string) (string, error) {
+	if field == "" {
+		return "", fmt.Errorf("secret field name is required")
+	}
+	var b strings.Builder
+	b.Grow(len(field) + 1)
+	for i := 0; i < len(field); i++ {
+		ch := field[i]
+		switch {
+		case ch >= 'a' && ch <= 'z':
+			b.WriteByte(ch - ('a' - 'A'))
+		case ch >= 'A' && ch <= 'Z', ch >= '0' && ch <= '9', ch == '_':
+			b.WriteByte(ch)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	key := b.String()
+	if key == "" {
+		return "", fmt.Errorf("secret field name is required")
+	}
+	if key[0] >= '0' && key[0] <= '9' {
+		key = "_" + key
+	}
+	return key, nil
+}

--- a/cmd/drive9/cli/secret_commands_test.go
+++ b/cmd/drive9/cli/secret_commands_test.go
@@ -1,0 +1,202 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSecretSetFallsBackToUpdateOnConflict(t *testing.T) {
+	var postCount, putCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/vault/secrets":
+			atomic.AddInt32(&postCount, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error":"secret already exists"}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/vault/secrets/aws-prod":
+			atomic.AddInt32(&putCount, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"aws-prod","secret_type":"generic","revision":2,"created_by":"drive9-cli","created_at":"2026-04-13T00:00:00Z","updated_at":"2026-04-13T00:00:00Z"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv("DRIVE9_API_KEY", "tenant-key")
+
+	if err := SecretSet([]string{"aws-prod", "access_key=AKIA", "secret_key=secret"}); err != nil {
+		t.Fatalf("SecretSet: %v", err)
+	}
+	if atomic.LoadInt32(&postCount) != 1 {
+		t.Fatalf("POST count = %d, want 1", postCount)
+	}
+	if atomic.LoadInt32(&putCount) != 1 {
+		t.Fatalf("PUT count = %d, want 1", putCount)
+	}
+}
+
+func TestSecretGetUsesCapabilityToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer cap-token" {
+			t.Fatalf("Authorization = %q, want Bearer cap-token", got)
+		}
+		if r.URL.Path != "/v1/vault/read/aws-prod" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_key":"AKIA","secret_key":"SECRET"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv(vaultTokenEnv, "cap-token")
+
+	out := captureStdout(t, func() {
+		if err := SecretGet([]string{"aws-prod"}); err != nil {
+			t.Fatalf("SecretGet: %v", err)
+		}
+	})
+	if !strings.Contains(out, `"access_key": "AKIA"`) {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestSecretGrantPrintsTokenMetadata(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/vault/tokens" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"vault_abc","token_id":"cap_123","expires_at":"2026-04-14T00:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv("DRIVE9_API_KEY", "tenant-key")
+
+	out := captureStdout(t, func() {
+		if err := SecretGrant([]string{"aws-prod", "db-prod/password", "--agent", "deploy-agent", "--ttl", "1h"}); err != nil {
+			t.Fatalf("SecretGrant: %v", err)
+		}
+	})
+	if !strings.Contains(out, "token=vault_abc") || !strings.Contains(out, "token_id=cap_123") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestSecretLsFallsBackToReadableScopeWithCapabilityToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/read" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"secrets":["db-prod","aws-prod"]}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv(vaultTokenEnv, "cap-token")
+
+	out := captureStdout(t, func() {
+		if err := SecretLs(nil); err != nil {
+			t.Fatalf("SecretLs: %v", err)
+		}
+	})
+	if out != "aws-prod\ndb-prod\n" {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestSecretExecInjectsSecretIntoChildEnv(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/read/aws-prod" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_key":"AKIA","secret_key":"SECRET"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv(vaultTokenEnv, "cap-token")
+
+	out := captureStdout(t, func() {
+		if err := SecretExec([]string{"aws-prod", "--", "/bin/sh", "-c", "printf '%s:%s' \"$ACCESS_KEY\" \"$SECRET_KEY\""}); err != nil {
+			t.Fatalf("SecretExec: %v", err)
+		}
+	})
+	if out != "AKIA:SECRET" {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestSecretAuditFiltersClientSide(t *testing.T) {
+	now := time.Now().UTC()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/audit" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"events":[` +
+			`{"event_id":"1","event_type":"secret.read","agent_id":"deploy-agent","secret_name":"aws-prod","timestamp":"` + now.Add(-10*time.Minute).Format(time.RFC3339) + `"},` +
+			`{"event_id":"2","event_type":"secret.read","agent_id":"test-agent","secret_name":"aws-prod","timestamp":"` + now.Add(-2*time.Hour).Format(time.RFC3339) + `"}` +
+			`]}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv("DRIVE9_API_KEY", "tenant-key")
+
+	out := captureStdout(t, func() {
+		if err := SecretAudit([]string{"--agent", "deploy-agent", "--since", "1h", "--json"}); err != nil {
+			t.Fatalf("SecretAudit: %v", err)
+		}
+	})
+	if !strings.Contains(out, `"agent_id": "deploy-agent"`) || strings.Contains(out, `"agent_id": "test-agent"`) {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	_ = w.Close()
+	return <-done
+}

--- a/cmd/drive9/cli/secret_commands_test.go
+++ b/cmd/drive9/cli/secret_commands_test.go
@@ -124,6 +124,40 @@ func TestSecretLsFallsBackToReadableScopeWithCapabilityToken(t *testing.T) {
 	}
 }
 
+func TestSecretLsPrefersExplicitCapabilityTokenOverAmbientAPIKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", "http://example.invalid")
+	t.Setenv("DRIVE9_API_KEY", "tenant-key")
+	t.Setenv(vaultTokenEnv, "cap-token")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/vault/read":
+			if got := r.Header.Get("Authorization"); got != "Bearer cap-token" {
+				t.Fatalf("Authorization = %q, want Bearer cap-token", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"secrets":["scoped-secret"]}`))
+		case "/v1/vault/secrets":
+			t.Fatalf("management list should not be used when an explicit capability token is set")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+
+	out := captureStdout(t, func() {
+		if err := SecretLs(nil); err != nil {
+			t.Fatalf("SecretLs: %v", err)
+		}
+	})
+	if out != "scoped-secret\n" {
+		t.Fatalf("output = %q", out)
+	}
+}
+
 func TestSecretExecInjectsSecretIntoChildEnv(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/vault/read/aws-prod" {

--- a/cmd/drive9/cli/secret_test.go
+++ b/cmd/drive9/cli/secret_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseSecretRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in        string
+		wantName  string
+		wantField string
+		wantErr   bool
+	}{
+		{in: "aws-prod", wantName: "aws-prod"},
+		{in: "db-prod/password", wantName: "db-prod", wantField: "password"},
+		{in: "", wantErr: true},
+		{in: "/password", wantErr: true},
+		{in: "db-prod/", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		name, field, err := parseSecretRef(tt.in)
+		if (err != nil) != tt.wantErr {
+			t.Fatalf("parseSecretRef(%q) err=%v wantErr=%v", tt.in, err, tt.wantErr)
+		}
+		if err == nil && (name != tt.wantName || field != tt.wantField) {
+			t.Fatalf("parseSecretRef(%q) = (%q,%q), want (%q,%q)", tt.in, name, field, tt.wantName, tt.wantField)
+		}
+	}
+}
+
+func TestParseFieldAssignmentsReadsLiteralAndFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	if err := os.WriteFile(certPath, []byte("CERTDATA"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	fields, err := parseFieldAssignments([]string{"access_key=AKIA", "cert=@" + certPath})
+	if err != nil {
+		t.Fatalf("parseFieldAssignments: %v", err)
+	}
+	want := map[string]string{
+		"access_key": "AKIA",
+		"cert":       "CERTDATA",
+	}
+	if !reflect.DeepEqual(fields, want) {
+		t.Fatalf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestEnvMapFromSecretUppercasesKeys(t *testing.T) {
+	t.Parallel()
+
+	got := envMapFromSecret(map[string]string{
+		"secret_key": "b",
+		"access_key": "a",
+	})
+	want := map[string]string{
+		"ACCESS_KEY": "a",
+		"SECRET_KEY": "b",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("env = %#v, want %#v", got, want)
+	}
+}
+
+func TestEnvMapFromSecretNormalizesUnsafeFieldNames(t *testing.T) {
+	t.Parallel()
+
+	got := envMapFromSecret(map[string]string{
+		"db-password": "pw",
+		"9token":      "tok",
+	})
+	want := map[string]string{
+		"DB_PASSWORD": "pw",
+		"_9TOKEN":     "tok",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("env = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildSecretEnvMapRejectsNormalizationCollisions(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildSecretEnvMap(map[string]string{
+		"db-password": "a",
+		"db_password": "b",
+	})
+	if err == nil {
+		t.Fatal("expected collision error")
+	}
+}
+
+func TestMergeEnvOverridesExistingValues(t *testing.T) {
+	t.Parallel()
+
+	got := mergeEnv([]string{"PATH=/bin", "ACCESS_KEY=old"}, map[string]string{
+		"ACCESS_KEY": "new",
+		"SECRET_KEY": "sec",
+	})
+	want := []string{
+		"ACCESS_KEY=new",
+		"PATH=/bin",
+		"SECRET_KEY=sec",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mergeEnv = %#v, want %#v", got, want)
+	}
+}

--- a/cmd/drive9/cli/secret_test.go
+++ b/cmd/drive9/cli/secret_test.go
@@ -18,6 +18,8 @@ func TestParseSecretRef(t *testing.T) {
 	}{
 		{in: "aws-prod", wantName: "aws-prod"},
 		{in: "db-prod/password", wantName: "db-prod", wantField: "password"},
+		{in: "prod/*", wantErr: true},
+		{in: "db-prod/pass*", wantErr: true},
 		{in: "", wantErr: true},
 		{in: "/password", wantErr: true},
 		{in: "db-prod/", wantErr: true},
@@ -53,6 +55,14 @@ func TestParseFieldAssignmentsReadsLiteralAndFile(t *testing.T) {
 	}
 	if !reflect.DeepEqual(fields, want) {
 		t.Fatalf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestValidateSecretNameRejectsWildcard(t *testing.T) {
+	t.Parallel()
+
+	if err := validateSecretName("prod-*"); err == nil {
+		t.Fatal("expected wildcard rejection")
 	}
 }
 

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -9,6 +9,7 @@
 //	create  provision a new database
 //	ctx     switch or list contexts
 //	fs      filesystem operations (cp, cat, ls, stat, mv, rm, sh, grep, find)
+//	secret  secret manager operations (set, get, exec, ls, rm, grant, revoke, audit)
 //	mount   mount drive9 as a local FUSE filesystem
 //	umount  unmount a drive9 FUSE mount
 package main
@@ -79,6 +80,21 @@ func main() {
 			logger.Info(context.Background(), "cli_command", zap.String("command", "fs"), zap.String("subcommand", sub))
 		}
 		runFS(args)
+	case "secret":
+		if cliLogger != nil {
+			sub := ""
+			if len(args) > 0 {
+				sub = args[0]
+			}
+			logger.Info(context.Background(), "cli_command", zap.String("command", "secret"), zap.String("subcommand", sub))
+		}
+		if err := cli.Secret(args); err != nil {
+			sub := ""
+			if len(args) > 0 {
+				sub = " " + args[0]
+			}
+			fatal("secret"+sub, err)
+		}
 	case "mount":
 		if cliLogger != nil {
 			logger.Info(context.Background(), "cli_command", zap.String("command", "mount"))
@@ -150,6 +166,10 @@ func fatal(cmd string, err error) {
 		logger.Error(context.Background(), "cli_command_failed", zap.String("command", cmd), zap.Error(err))
 	}
 	fmt.Fprintf(os.Stderr, "%s: %v\n", cmd, err)
+	type exitCoder interface{ ExitCode() int }
+	if ec, ok := err.(exitCoder); ok && ec.ExitCode() > 0 {
+		os.Exit(ec.ExitCode())
+	}
 	os.Exit(1)
 }
 
@@ -161,6 +181,7 @@ commands:
   ctx [name]       switch context (or show current)
   ctx list         list all contexts
   fs               filesystem operations
+  secret           secret manager operations
   mount <dir>      mount drive9 as a local FUSE filesystem
   umount <dir>     unmount a drive9 FUSE mount
 `)

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -1,0 +1,311 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// VaultSecret holds secret metadata returned by the management API.
+type VaultSecret struct {
+	Name       string    `json:"name"`
+	SecretType string    `json:"secret_type"`
+	Revision   int64     `json:"revision"`
+	CreatedBy  string    `json:"created_by"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// VaultTokenIssueResponse is returned when issuing a scoped capability token.
+type VaultTokenIssueResponse struct {
+	Token     string    `json:"token"`
+	TokenID   string    `json:"token_id"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// VaultAuditEvent is an audit event returned by the vault audit API.
+type VaultAuditEvent struct {
+	EventID    string         `json:"event_id"`
+	EventType  string         `json:"event_type"`
+	TokenID    string         `json:"token_id,omitempty"`
+	AgentID    string         `json:"agent_id,omitempty"`
+	TaskID     string         `json:"task_id,omitempty"`
+	SecretName string         `json:"secret_name,omitempty"`
+	FieldName  string         `json:"field_name,omitempty"`
+	Adapter    string         `json:"adapter,omitempty"`
+	Detail     map[string]any `json:"detail,omitempty"`
+	Timestamp  time.Time      `json:"timestamp"`
+}
+
+func (c *Client) vaultURL(path string) string {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return c.baseURL + "/v1/vault" + path
+}
+
+// CreateVaultSecret creates a new secret via the management API.
+func (c *Client) CreateVaultSecret(ctx context.Context, name string, fields map[string]string) (*VaultSecret, error) {
+	body, err := json.Marshal(map[string]any{
+		"name":       name,
+		"fields":     fields,
+		"created_by": "drive9-cli",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal secret create request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.vaultURL("/secrets"), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var sec VaultSecret
+	if err := json.NewDecoder(resp.Body).Decode(&sec); err != nil {
+		return nil, fmt.Errorf("decode secret create response: %w", err)
+	}
+	return &sec, nil
+}
+
+// UpdateVaultSecret rotates a secret via the management API.
+func (c *Client) UpdateVaultSecret(ctx context.Context, name string, fields map[string]string) (*VaultSecret, error) {
+	body, err := json.Marshal(map[string]any{
+		"fields":     fields,
+		"updated_by": "drive9-cli",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal secret update request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.vaultURL("/secrets/"+url.PathEscape(name)), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var sec VaultSecret
+	if err := json.NewDecoder(resp.Body).Decode(&sec); err != nil {
+		return nil, fmt.Errorf("decode secret update response: %w", err)
+	}
+	return &sec, nil
+}
+
+// DeleteVaultSecret deletes a secret via the management API.
+func (c *Client) DeleteVaultSecret(ctx context.Context, name string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.vaultURL("/secrets/"+url.PathEscape(name)), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return readError(resp)
+	}
+	return nil
+}
+
+// ListVaultSecrets lists secret metadata via the management API.
+func (c *Client) ListVaultSecrets(ctx context.Context) ([]VaultSecret, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.vaultURL("/secrets"), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result struct {
+		Secrets []VaultSecret `json:"secrets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode secret list response: %w", err)
+	}
+	if result.Secrets == nil {
+		result.Secrets = []VaultSecret{}
+	}
+	return result.Secrets, nil
+}
+
+// IssueVaultToken issues a scoped capability token via the management API.
+func (c *Client) IssueVaultToken(ctx context.Context, agentID, taskID string, scope []string, ttl time.Duration) (*VaultTokenIssueResponse, error) {
+	ttlSeconds := int(ttl / time.Second)
+	body, err := json.Marshal(map[string]any{
+		"agent_id":    agentID,
+		"task_id":     taskID,
+		"scope":       scope,
+		"ttl_seconds": ttlSeconds,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal token issue request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.vaultURL("/tokens"), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result VaultTokenIssueResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode token issue response: %w", err)
+	}
+	return &result, nil
+}
+
+// RevokeVaultToken revokes a capability token via the management API.
+func (c *Client) RevokeVaultToken(ctx context.Context, tokenID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.vaultURL("/tokens/"+url.PathEscape(tokenID)), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return readError(resp)
+	}
+	return nil
+}
+
+// QueryVaultAudit queries the audit log via the management API.
+func (c *Client) QueryVaultAudit(ctx context.Context, secretName string, limit int) ([]VaultAuditEvent, error) {
+	u, err := url.Parse(c.vaultURL("/audit"))
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	if secretName != "" {
+		q.Set("secret", secretName)
+	}
+	if limit > 0 {
+		q.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result struct {
+		Events []VaultAuditEvent `json:"events"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode audit response: %w", err)
+	}
+	if result.Events == nil {
+		result.Events = []VaultAuditEvent{}
+	}
+	return result.Events, nil
+}
+
+// ListReadableVaultSecrets enumerates secrets visible to the bearer capability token.
+func (c *Client) ListReadableVaultSecrets(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.vaultURL("/read"), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result struct {
+		Secrets []string `json:"secrets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode readable secret list response: %w", err)
+	}
+	if result.Secrets == nil {
+		result.Secrets = []string{}
+	}
+	return result.Secrets, nil
+}
+
+// ReadVaultSecret reads all fields of a secret using the consumption API.
+func (c *Client) ReadVaultSecret(ctx context.Context, name string) (map[string]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.vaultURL("/read/"+url.PathEscape(name)), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode secret read response: %w", err)
+	}
+	if result == nil {
+		result = map[string]string{}
+	}
+	return result, nil
+}
+
+// ReadVaultSecretField reads a single field via the consumption API.
+func (c *Client) ReadVaultSecretField(ctx context.Context, name, field string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.vaultURL("/read/"+url.PathEscape(name)+"/"+url.PathEscape(field)), nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return "", readError(resp)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read field response: %w", err)
+	}
+	return string(data), nil
+}

--- a/pkg/client/vault_test.go
+++ b/pkg/client/vault_test.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestIssueVaultTokenUsesManagementAuthAndPayload(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/vault/tokens" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tenant-key" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		var req struct {
+			AgentID string   `json:"agent_id"`
+			TaskID  string   `json:"task_id"`
+			Scope   []string `json:"scope"`
+			TTLSecs int      `json:"ttl_seconds"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		if req.AgentID != "deploy-agent" || req.TaskID != "task-123" {
+			t.Fatalf("unexpected request: %+v", req)
+		}
+		if req.TTLSecs != 3600 {
+			t.Fatalf("ttl_seconds = %d, want 3600", req.TTLSecs)
+		}
+		if len(req.Scope) != 2 || req.Scope[0] != "aws-prod" || req.Scope[1] != "db-prod/password" {
+			t.Fatalf("scope = %+v", req.Scope)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      "vault_token",
+			"token_id":   "cap_123",
+			"expires_at": "2026-04-14T00:00:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tenant-key")
+	resp, err := c.IssueVaultToken(context.Background(), "deploy-agent", "task-123", []string{"aws-prod", "db-prod/password"}, time.Hour)
+	if err != nil {
+		t.Fatalf("IssueVaultToken: %v", err)
+	}
+	if resp.Token != "vault_token" || resp.TokenID != "cap_123" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestReadVaultSecretFieldUsesCapabilityToken(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/read/db-prod/password" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer cap-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		_, _ = w.Write([]byte("hunter2"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "cap-token")
+	data, err := c.ReadVaultSecretField(context.Background(), "db-prod", "password")
+	if err != nil {
+		t.Fatalf("ReadVaultSecretField: %v", err)
+	}
+	if data != "hunter2" {
+		t.Fatalf("data = %q", data)
+	}
+}
+
+func TestCreateVaultSecretReturnsStatusError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"secret already exists"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tenant-key")
+	_, err := c.CreateVaultSecret(context.Background(), "aws-prod", map[string]string{"access_key": "AKIA"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusConflict {
+		t.Fatalf("statusErr = %#v", statusErr)
+	}
+}


### PR DESCRIPTION
## Summary
- add the frozen drive9 secret v0 CLI surface for set/get/exec/ls/rm/grant/revoke/audit
- wire the top-level drive9 secret entrypoint and add vault management/read client helpers
- encode the current server contract in the CLI, including capability-token auth for plaintext reads and explicit env-var normalization for exec/--env
- prefer an explicit capability token over any ambient tenant API key/config for secret ls, and reject wildcard scope entries locally in v0

## Contract notes
- secret name stays flat in v0
- scope is <name> or <name/field>
- no wildcard, no mv, no silent autoprovision, no grants list
- management commands use tenant API key auth
- get / exec use capability token auth via DRIVE9_VAULT_TOKEN, with legacy DRIVE9_CAP_TOKEN compatibility
- audit --agent / --since are filtered client-side because the current server audit API only exposes secret + limit

## Validation
- /usr/local/go/bin/go test ./cmd/drive9/...
- /usr/local/go/bin/go build ./cmd/drive9
