### PR TITLE
feat: Obsidian plugin auth & security hardening (#185)

### DIFF
--- a/obsidian-plugin/src/client.ts
+++ b/obsidian-plugin/src/client.ts
@@ -216,9 +216,16 @@ export class Drive9Error extends Error {
     message: string,
     public status: number,
   ) {
-    super(message);
+    super(sanitizeError(message));
     this.name = "Drive9Error";
   }
+}
+
+/** Strip auth material (Bearer tokens, API keys) from error strings. */
+export function sanitizeError(msg: string): string {
+  return msg
+    .replace(/Bearer\s+\S+/gi, "Bearer ***")
+    .replace(/Authorization:\s*\S+/gi, "Authorization: ***");
 }
 
 /** Encode path segments for URL (don't encode slashes). */

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -1,5 +1,5 @@
 import { Plugin, Notice, TFile } from "obsidian";
-import { Drive9Client } from "./client";
+import { Drive9Client, sanitizeError } from "./client";
 import { RemoteWatcher } from "./remote-watcher";
 import { SyncEngine } from "./sync-engine";
 import { ShadowStore } from "./shadow-store";
@@ -90,8 +90,8 @@ export default class Drive9Plugin extends Plugin {
       try {
         await this.doFirstRun();
       } catch (e) {
-        console.error("[drive9] first-run failed", e);
-        new Notice(`drive9: first-run failed — ${e instanceof Error ? e.message : String(e)}`);
+        console.error("[drive9] first-run failed", e instanceof Error ? e.message : sanitizeError(String(e)));
+        new Notice(`drive9: first-run failed — ${e instanceof Error ? e.message : sanitizeError(String(e))}`);
         this.setStatusBar("✗ drive9: first-run failed");
         return;
       }
@@ -195,7 +195,7 @@ export default class Drive9Plugin extends Plugin {
               state.status = state.remoteRevision !== null ? "synced" : "needs_refresh";
               state.syncedAt = Date.now();
             } catch (e) {
-              console.error(`[drive9] pull failed: ${path}`, e);
+              console.error(`[drive9] pull failed: ${path}`, e instanceof Error ? e.message : sanitizeError(String(e)));
             }
           }
         }

--- a/obsidian-plugin/src/remote-watcher.ts
+++ b/obsidian-plugin/src/remote-watcher.ts
@@ -1,5 +1,5 @@
 import { Platform } from "obsidian";
-import { Drive9Client } from "./client";
+import { Drive9Client, sanitizeError } from "./client";
 import type { ChangeEvent, ResetEvent } from "./types";
 
 const POLL_INTERVAL_MS = 30_000;
@@ -75,7 +75,7 @@ export class RemoteWatcher {
         try {
           await this.streamOnce();
         } catch (error) {
-          console.warn("[drive9] SSE disconnected", error);
+          console.warn("[drive9] SSE disconnected", error instanceof Error ? error.message : sanitizeError(String(error)));
         }
         if (this.stopped) return;
 
@@ -112,7 +112,7 @@ export class RemoteWatcher {
     try {
       await this.callbacks.onPoll();
     } catch (error) {
-      console.warn("[drive9] polling sync failed", error);
+      console.warn("[drive9] polling sync failed", error instanceof Error ? error.message : sanitizeError(String(error)));
     } finally {
       this.pollInFlight = false;
     }

--- a/obsidian-plugin/src/settings.ts
+++ b/obsidian-plugin/src/settings.ts
@@ -1,6 +1,6 @@
 import { App, PluginSettingTab, Setting, Notice } from "obsidian";
 import type Drive9Plugin from "./main";
-import { Drive9Client } from "./client";
+import { Drive9Client, sanitizeError } from "./client";
 
 export class Drive9SettingTab extends PluginSettingTab {
   private validateTimer: ReturnType<typeof setTimeout> | null = null;
@@ -158,9 +158,16 @@ export class Drive9SettingTab extends PluginSettingTab {
 
       const content = fs.readFileSync(gitignorePath, "utf-8");
       const lines = content.split("\n").map((l: string) => l.trim());
-      const coversObsidian = lines.some((l: string) =>
-        l === ".obsidian" || l === ".obsidian/" || l === ".obsidian/**" || l === ".obsidian/*",
-      );
+      const coversObsidian = lines.some((l: string) => {
+        // Strip comments and empty lines
+        if (!l || l.startsWith("#")) return false;
+        // Match common patterns that cover .obsidian/ or the plugin data dir
+        return /^\/?\.obsidian(\/.*)?$/.test(l)
+          || l === ".obsidian"
+          || l === ".obsidian/"
+          || l === ".obsidian/**"
+          || l === ".obsidian/*";
+      });
 
       if (!coversObsidian) {
         this.addGitignoreWarning(containerEl, ".gitignore does not cover .obsidian/ — your API key could be committed to git.");
@@ -182,8 +189,3 @@ export class Drive9SettingTab extends PluginSettingTab {
   }
 }
 
-/** Strip any potential API key / auth token from error messages. */
-function sanitizeError(msg: string): string {
-  // Remove Bearer tokens
-  return msg.replace(/Bearer\s+\S+/gi, "Bearer ***");
-}

--- a/obsidian-plugin/src/settings.ts
+++ b/obsidian-plugin/src/settings.ts
@@ -3,6 +3,8 @@ import type Drive9Plugin from "./main";
 import { Drive9Client } from "./client";
 
 export class Drive9SettingTab extends PluginSettingTab {
+  private validateTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(
     app: App,
     private plugin: Drive9Plugin,
@@ -26,6 +28,7 @@ export class Drive9SettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.serverUrl = value.trim();
             await this.plugin.savePluginData();
+            this.scheduleValidation();
           }),
       );
 
@@ -34,12 +37,14 @@ export class Drive9SettingTab extends PluginSettingTab {
       .setDesc("drive9 API key for authentication")
       .addText((text) => {
         text.inputEl.type = "password";
+        text.inputEl.autocomplete = "off";
         text
           .setPlaceholder("your-api-key")
           .setValue(this.plugin.settings.apiKey)
           .onChange(async (value) => {
             this.plugin.settings.apiKey = value.trim();
             await this.plugin.savePluginData();
+            this.scheduleValidation();
           });
       });
 
@@ -48,20 +53,7 @@ export class Drive9SettingTab extends PluginSettingTab {
       .setDesc("Verify server URL and API key")
       .addButton((btn) =>
         btn.setButtonText("Test").onClick(async () => {
-          if (!this.plugin.settings.serverUrl) {
-            new Notice("Please enter a server URL first");
-            return;
-          }
-          try {
-            const testClient = new Drive9Client(
-              this.plugin.settings.serverUrl,
-              this.plugin.settings.apiKey,
-            );
-            await testClient.ping();
-            new Notice("drive9: connection successful!");
-          } catch (e) {
-            new Notice(`drive9: connection failed — ${e instanceof Error ? e.message : String(e)}`);
-          }
+          await this.testConnection();
         }),
       );
 
@@ -112,5 +104,86 @@ export class Drive9SettingTab extends PluginSettingTab {
             }
           }),
       );
+
+    // .gitignore warning
+    void this.checkGitignore(containerEl);
   }
+
+  private scheduleValidation(): void {
+    if (this.validateTimer) clearTimeout(this.validateTimer);
+    this.validateTimer = setTimeout(() => {
+      this.validateTimer = null;
+      void this.testConnection();
+    }, 1500);
+  }
+
+  private async testConnection(): Promise<void> {
+    if (!this.plugin.settings.serverUrl) {
+      new Notice("Please enter a server URL first");
+      return;
+    }
+    if (!this.plugin.settings.apiKey) {
+      new Notice("Please enter an API key first");
+      return;
+    }
+    try {
+      const testClient = new Drive9Client(
+        this.plugin.settings.serverUrl,
+        this.plugin.settings.apiKey,
+      );
+      await testClient.ping();
+      new Notice("drive9: connection successful!");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      new Notice(`drive9: connection failed — ${sanitizeError(msg)}`);
+    }
+  }
+
+  private async checkGitignore(containerEl: HTMLElement): Promise<void> {
+    const adapter = this.app.vault.adapter;
+    const vaultRoot = (adapter as { getBasePath?: () => string }).getBasePath?.();
+    if (!vaultRoot) return;
+
+    try {
+      const gitignorePath = `${vaultRoot}/.gitignore`;
+      const fs = (globalThis as { require?: (name: string) => { existsSync: (p: string) => boolean; readFileSync: (p: string, e: string) => string } }).require?.("fs");
+      if (!fs) return;
+
+      if (!fs.existsSync(`${vaultRoot}/.git`)) return;
+
+      if (!fs.existsSync(gitignorePath)) {
+        this.addGitignoreWarning(containerEl, "No .gitignore found. Your API key in .obsidian/ could be committed to git.");
+        return;
+      }
+
+      const content = fs.readFileSync(gitignorePath, "utf-8");
+      const lines = content.split("\n").map((l: string) => l.trim());
+      const coversObsidian = lines.some((l: string) =>
+        l === ".obsidian" || l === ".obsidian/" || l === ".obsidian/**" || l === ".obsidian/*",
+      );
+
+      if (!coversObsidian) {
+        this.addGitignoreWarning(containerEl, ".gitignore does not cover .obsidian/ — your API key could be committed to git.");
+      }
+    } catch {
+      // Not on desktop or fs access failed — skip warning
+    }
+  }
+
+  private addGitignoreWarning(containerEl: HTMLElement, message: string): void {
+    const warning = containerEl.createEl("div", { cls: "drive9-gitignore-warning" });
+    warning.style.padding = "8px 12px";
+    warning.style.marginTop = "12px";
+    warning.style.borderRadius = "4px";
+    warning.style.backgroundColor = "var(--background-modifier-error)";
+    warning.style.color = "var(--text-on-accent)";
+    warning.createEl("strong", { text: "⚠ Security Warning: " });
+    warning.createSpan({ text: message });
+  }
+}
+
+/** Strip any potential API key / auth token from error messages. */
+function sanitizeError(msg: string): string {
+  // Remove Bearer tokens
+  return msg.replace(/Bearer\s+\S+/gi, "Bearer ***");
 }

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -1,5 +1,5 @@
 import { Vault, TFile, TAbstractFile, Notice } from "obsidian";
-import { Drive9Client, Drive9Error } from "./client";
+import { Drive9Client, Drive9Error, sanitizeError } from "./client";
 import { IgnoreMatcher } from "./ignore";
 import type { ShadowStore } from "./shadow-store";
 import type { SyncState, Drive9Settings } from "./types";
@@ -171,7 +171,7 @@ export class SyncEngine {
           await this.pushOne(path);
         } catch (e) {
           errorOccurred = true;
-          console.error(`[drive9] push failed: ${path}`, e);
+          console.error(`[drive9] push failed: ${path}`, e instanceof Error ? e.message : sanitizeError(String(e)));
           this.dirtyPaths.add(path);
         }
       }


### PR DESCRIPTION
## Summary
- Auto-validate API key on settings change (debounced 1.5s)
- .gitignore warning when vault is a git repo without .obsidian/ coverage
- Error sanitization to strip Bearer tokens from user-facing messages
- API key input: `autocomplete="off"` added

## Acceptance criteria from #185
- [x] API key never appears in logs or error output
- [x] Settings UI uses password field for API key
- [x] Plugin warns if .gitignore doesn't cover plugin directory
- [x] API key validated on save (auto test connection with debounce)
- [x] Default ignore rules prevent API key from being synced

## Test plan
- [ ] Open settings, enter server URL + API key → auto-validates after 1.5s
- [ ] In a vault that is a git repo without .obsidian in .gitignore → warning banner shows
- [ ] In a vault that is a git repo with .obsidian in .gitignore → no warning
- [ ] In a vault that is not a git repo → no warning
- [ ] Error messages in Notices do not contain API key or Bearer token

🤖 Generated with [Claude Code](https://claude.com/claude-code)