### PR TITLE
feat: Obsidian plugin multipart upload for large files (#184)

### DIFF
--- a/obsidian-plugin/src/client.ts
+++ b/obsidian-plugin/src/client.ts
@@ -1,5 +1,8 @@
-import { requestUrl, RequestUrlParam } from "obsidian";
-import type { StatResult, FileInfo } from "./types";
+import { requestUrl, RequestUrlParam, Platform } from "obsidian";
+import type { StatResult, FileInfo, ProgressFn } from "./types";
+
+/** Files >= this size use multipart upload (matches server threshold). */
+const MULTIPART_THRESHOLD = 50_000; // 50 KB
 
 /**
  * Drive9Client wraps the drive9 REST API using Obsidian's requestUrl
@@ -56,19 +59,32 @@ export class Drive9Client {
   }
 
   /**
-   * PUT — write file content with optional CAS revision check.
-   * Server returns {"status":"ok"} without revision, so we stat()
-   * after write to get the actual revision for future CAS.
+   * Write file content with optional CAS revision check.
+   * Files >= MULTIPART_THRESHOLD use v2 multipart upload;
+   * smaller files use direct PUT.
    *
    * Returns { revision: number } on full success, or
-   * { revision: null, writeSucceeded: true } if PUT succeeded but
+   * { revision: null, writeSucceeded: true } if write succeeded but
    * post-write stat failed (caller must not treat this as a write failure).
    */
   async write(
     path: string,
     data: ArrayBuffer,
     expectedRevision?: number | null,
+    onProgress?: ProgressFn,
   ): Promise<{ revision: number | null; writeSucceeded: boolean }> {
+    if (data.byteLength >= MULTIPART_THRESHOLD) {
+      try {
+        return await this.writeMultipart(path, data, expectedRevision, onProgress);
+      } catch (e) {
+        if (e instanceof Drive9Error && e.status === 404) {
+          // Server doesn't support v2 uploads — fall through to direct PUT.
+        } else {
+          throw e;
+        }
+      }
+    }
+
     const headers: Record<string, string> = this.mutationHeaders();
     if (expectedRevision !== undefined && expectedRevision !== null) {
       headers["X-Dat9-Expected-Revision"] = String(expectedRevision);
@@ -85,6 +101,152 @@ export class Drive9Client {
     } catch {
       return { revision: null, writeSucceeded: true };
     }
+  }
+
+  /**
+   * v2 multipart upload: initiate → presign-batch → PUT parts → complete.
+   * Parts are uploaded sequentially to keep memory bounded.
+   */
+  private async writeMultipart(
+    path: string,
+    data: ArrayBuffer,
+    expectedRevision?: number | null,
+    onProgress?: ProgressFn,
+  ): Promise<{ revision: number | null; writeSucceeded: boolean }> {
+    // 1. Initiate
+    const initBody: Record<string, unknown> = {
+      path,
+      total_size: data.byteLength,
+    };
+    if (expectedRevision !== undefined && expectedRevision !== null) {
+      initBody.expected_revision = expectedRevision;
+    }
+
+    const initResp = await this.request("POST", "/v2/uploads/initiate", {
+      body: JSON.stringify(initBody),
+      headers: { ...this.mutationHeaders(), "Content-Type": "application/json" },
+    });
+    const plan = initResp.json as {
+      upload_id: string;
+      part_size: number;
+      total_parts: number;
+    };
+
+    const uploadId = plan.upload_id;
+    const partSize = plan.part_size;
+    const totalParts = plan.total_parts;
+
+    try {
+      // 2. Presign all parts in one batch
+      const partEntries = Array.from({ length: totalParts }, (_, i) => ({
+        part_number: i + 1,
+      }));
+      const presignResp = await this.request(
+        "POST",
+        `/v2/uploads/${uploadId}/presign-batch`,
+        {
+          body: JSON.stringify({ parts: partEntries }),
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+      const presigned = (presignResp.json as { parts: PresignedPart[] }).parts;
+
+      // 3. Upload parts sequentially
+      const completedParts: Array<{ number: number; etag: string }> = [];
+
+      for (const part of presigned) {
+        const offset = (part.number - 1) * partSize;
+        const end = Math.min(offset + part.size, data.byteLength);
+        const chunk = data.slice(offset, end);
+
+        const etag = await this.uploadOnePart(uploadId, part, chunk);
+        completedParts.push({ number: part.number, etag });
+
+        if (onProgress) {
+          onProgress(part.number, totalParts);
+        }
+      }
+
+      // 4. Complete
+      await this.request("POST", `/v2/uploads/${uploadId}/complete`, {
+        body: JSON.stringify({ parts: completedParts }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // 5. Stat to get revision
+      try {
+        const st = await this.stat(path);
+        return { revision: st.revision, writeSucceeded: true };
+      } catch {
+        return { revision: null, writeSucceeded: true };
+      }
+    } catch (e) {
+      // Best-effort abort on failure
+      try {
+        await this.request("POST", `/v2/uploads/${uploadId}/abort`, {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch {
+        // Abort is best-effort.
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * PUT a single part to its presigned S3 URL.
+   * Returns the ETag from the response header.
+   */
+  private async uploadOnePart(
+    uploadId: string,
+    part: PresignedPart,
+    data: ArrayBuffer,
+    isRetry = false,
+  ): Promise<string> {
+    const headers: Record<string, string> = {};
+    if (part.headers) {
+      for (const [k, v] of Object.entries(part.headers)) {
+        if (k.toLowerCase() !== "host") {
+          headers[k] = v;
+        }
+      }
+    }
+
+    const resp = await requestUrl({
+      url: part.url,
+      method: "PUT",
+      body: data,
+      headers,
+      throw: false,
+    });
+
+    if (resp.status === 403 && !isRetry) {
+      // Presigned URL expired — re-presign and retry once
+      const fresh = await this.presignOnePart(uploadId, part.number);
+      return this.uploadOnePart(uploadId, fresh, data, true);
+    }
+
+    if (resp.status >= 300) {
+      throw new Drive9Error(`part upload failed: HTTP ${resp.status}`, resp.status);
+    }
+
+    return resp.headers["etag"] ?? resp.headers["ETag"] ?? "";
+  }
+
+  /** Fetch a fresh presigned URL for a single part (retry path). */
+  private async presignOnePart(
+    uploadId: string,
+    partNumber: number,
+  ): Promise<PresignedPart> {
+    const resp = await this.request(
+      "POST",
+      `/v2/uploads/${uploadId}/presign`,
+      {
+        body: JSON.stringify({ part_number: partNumber }),
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    return resp.json as PresignedPart;
   }
 
   /** DELETE — remove a file. */
@@ -226,6 +388,14 @@ export function sanitizeError(msg: string): string {
   return msg
     .replace(/Bearer\s+\S+/gi, "Bearer ***")
     .replace(/Authorization:\s*\S+/gi, "Authorization: ***");
+}
+
+/** Presigned part URL from the v2 presign-batch endpoint. */
+interface PresignedPart {
+  number: number;
+  url: string;
+  size: number;
+  headers?: Record<string, string>;
 }
 
 /** Encode path segments for URL (don't encode slashes). */

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -253,16 +253,25 @@ export default class Drive9Plugin extends Plugin {
     const engine = this.syncEngine;
     if (!engine) return;
 
+    const skipped = engine.skippedLargeFiles.length;
     switch (engine.status) {
-      case "syncing":
-        this.setStatusBar(`↕ drive9: syncing ${engine.pendingCount} files`);
+      case "syncing": {
+        const progress = engine.uploadProgressText;
+        if (progress) {
+          this.setStatusBar(`↕ drive9: ${progress}`);
+        } else {
+          this.setStatusBar(`↕ drive9: syncing ${engine.pendingCount} files`);
+        }
         break;
+      }
       case "error":
         this.setStatusBar("✗ drive9: error");
         break;
       case "idle":
         if (engine.pendingCount > 0) {
           this.setStatusBar(`↕ drive9: queued ${engine.pendingCount} files`);
+        } else if (skipped > 0) {
+          this.setStatusBar(`✓ drive9: synced (${skipped} skipped — too large)`);
         } else {
           this.setStatusBar("✓ drive9: synced");
         }

--- a/obsidian-plugin/src/settings.ts
+++ b/obsidian-plugin/src/settings.ts
@@ -105,6 +105,22 @@ export class Drive9SettingTab extends PluginSettingTab {
           }),
       );
 
+    new Setting(containerEl)
+      .setName("Mobile Max File Size (MB)")
+      .setDesc("Lower file size limit on mobile to avoid OOM (default: 20)")
+      .addText((text) =>
+        text
+          .setPlaceholder("20")
+          .setValue(String(Math.round(this.plugin.settings.mobileMaxFileSize / (1024 * 1024))))
+          .onChange(async (value) => {
+            const n = parseInt(value, 10);
+            if (!isNaN(n) && n >= 1) {
+              this.plugin.settings.mobileMaxFileSize = n * 1024 * 1024;
+              await this.plugin.savePluginData();
+            }
+          }),
+      );
+
     // .gitignore warning
     void this.checkGitignore(containerEl);
   }

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -20,6 +20,8 @@ export class SyncEngine {
   private operationQueue: Promise<void> = Promise.resolve();
   private _status: SyncStatus = "idle";
   private _pendingCount = 0;
+  private _uploadProgressText = "";
+  private _skippedLargeFiles: string[] = [];
   private statusListeners: Array<() => void> = [];
 
   private shadowStore: ShadowStore | null = null;
@@ -44,6 +46,14 @@ export class SyncEngine {
 
   get pendingCount(): number {
     return this._pendingCount;
+  }
+
+  get uploadProgressText(): string {
+    return this._uploadProgressText;
+  }
+
+  get skippedLargeFiles(): string[] {
+    return this._skippedLargeFiles;
   }
 
   onStatusChange(fn: () => void): void {
@@ -161,6 +171,7 @@ export class SyncEngine {
 
       const paths = [...this.dirtyPaths];
       this.dirtyPaths.clear();
+      this._skippedLargeFiles = [];
 
       this.setStatus("syncing", paths.length);
 
@@ -203,7 +214,14 @@ export class SyncEngine {
       ? Math.min(this.settings.maxFileSize, this.settings.mobileMaxFileSize)
       : this.settings.maxFileSize;
     if (file.stat.size > effectiveMaxSize) {
+      const sizeMB = (file.stat.size / (1024 * 1024)).toFixed(1);
+      const limitMB = (effectiveMaxSize / (1024 * 1024)).toFixed(0);
       console.warn(`[drive9] skipping large file: ${path} (${file.stat.size} bytes, limit ${effectiveMaxSize})`);
+      new Notice(`drive9: skipped ${path} (${sizeMB} MB exceeds ${limitMB} MB limit)`);
+      if (!this._skippedLargeFiles.includes(path)) {
+        this._skippedLargeFiles.push(path);
+      }
+      this.notifyStatusChange();
       return;
     }
 
@@ -229,8 +247,11 @@ export class SyncEngine {
 
     try {
       const result = await this.client.write(path, data, expectedRevision, (part, total) => {
-        this.setStatus("syncing", this._pendingCount);
+        const fileName = path.includes("/") ? path.slice(path.lastIndexOf("/") + 1) : path;
+        this._uploadProgressText = `${fileName} part ${part}/${total}`;
+        this.notifyStatusChange();
       });
+      this._uploadProgressText = "";
       const contentHash = await this.saveShadowIfAvailable(data);
       if (result.revision !== null) {
         this.syncStates[path] = {

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -1,4 +1,4 @@
-import { Vault, TFile, TAbstractFile, Notice } from "obsidian";
+import { Vault, TFile, TAbstractFile, Notice, Platform } from "obsidian";
 import { Drive9Client, Drive9Error, sanitizeError } from "./client";
 import { IgnoreMatcher } from "./ignore";
 import type { ShadowStore } from "./shadow-store";
@@ -199,8 +199,11 @@ export class SyncEngine {
       return;
     }
 
-    if (file.stat.size > this.settings.maxFileSize) {
-      console.warn(`[drive9] skipping large file: ${path} (${file.stat.size} bytes)`);
+    const effectiveMaxSize = Platform.isMobile
+      ? Math.min(this.settings.maxFileSize, this.settings.mobileMaxFileSize)
+      : this.settings.maxFileSize;
+    if (file.stat.size > effectiveMaxSize) {
+      console.warn(`[drive9] skipping large file: ${path} (${file.stat.size} bytes, limit ${effectiveMaxSize})`);
       return;
     }
 
@@ -225,7 +228,9 @@ export class SyncEngine {
     const expectedRevision = existingState ? existingState.remoteRevision : 0;
 
     try {
-      const result = await this.client.write(path, data, expectedRevision);
+      const result = await this.client.write(path, data, expectedRevision, (part, total) => {
+        this.setStatus("syncing", this._pendingCount);
+      });
       const contentHash = await this.saveShadowIfAvailable(data);
       if (result.revision !== null) {
         this.syncStates[path] = {

--- a/obsidian-plugin/src/types.ts
+++ b/obsidian-plugin/src/types.ts
@@ -1,3 +1,6 @@
+/** Progress callback for multipart uploads. */
+export type ProgressFn = (partNumber: number, totalParts: number) => void;
+
 /** Plugin settings persisted in data.json. */
 export interface Drive9Settings {
   serverUrl: string;
@@ -5,6 +8,7 @@ export interface Drive9Settings {
   pushDebounce: number;
   ignorePaths: string[];
   maxFileSize: number; // bytes
+  mobileMaxFileSize: number; // bytes — lower limit on mobile to avoid OOM
 }
 
 export const DEFAULT_SETTINGS: Drive9Settings = {
@@ -13,6 +17,7 @@ export const DEFAULT_SETTINGS: Drive9Settings = {
   pushDebounce: 2000,
   ignorePaths: [".obsidian/**", ".trash/**", "*.tmp", ".DS_Store"],
   maxFileSize: 100 * 1024 * 1024, // 100MB
+  mobileMaxFileSize: 20 * 1024 * 1024, // 20MB — lower limit on mobile to avoid OOM
 };
 
 /** Result of HEAD /v1/fs/{path} */


### PR DESCRIPTION
## Summary

- Files >= 50KB now use v2 multipart upload protocol (`/v2/uploads/initiate` → `presign-batch` → PUT parts → `complete`)
- Graceful fallback to direct PUT if server doesn't support v2 (404)
- Sequential part uploads to keep memory bounded in browser/mobile
- Presigned URL expiry handling: re-presign on 403, retry once
- Best-effort abort on upload failure to clean up server state
- Mobile max file size guard (default 20MB, configurable) to prevent OOM on iOS/Android
- CAS via `expected_revision` at initiate time; 409 → conflict flow
- Progress callback wired to sync engine status bar updates

## Files changed

- `client.ts` — `writeMultipart()`, `uploadOnePart()`, `presignOnePart()`, threshold routing in `write()`
- `types.ts` — `ProgressFn` type, `mobileMaxFileSize` setting
- `sync-engine.ts` — Mobile size guard using `Platform.isMobile`, progress callback
- `settings.ts` — Mobile Max File Size setting UI

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Upload file < 50KB → direct PUT (no change in behavior)
- [ ] Upload file >= 50KB → multipart flow (initiate → parts → complete)
- [ ] Upload conflict (409 at initiate) → conflict state
- [ ] Mobile: files > 20MB skipped with console warning
- [ ] Server without v2 support → graceful fallback to direct PUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic multipart uploads for large files with per-part progress reporting.
  * "Mobile Max File Size" setting to limit uploads on mobile.
  * Status bar now shows per-file/part upload progress and number of skipped-too-large files.

* **Bug Fixes**
  * Better upload reliability: retries for expired presigned URLs, aborts on multipart errors, and automatic fallback to direct upload when multipart setup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->