### PR TITLE
feat: Obsidian plugin search UI using existing grep API (#177)

### DIFF
--- a/obsidian-plugin/src/client.ts
+++ b/obsidian-plugin/src/client.ts
@@ -1,5 +1,5 @@
 import { requestUrl, RequestUrlParam, Platform } from "obsidian";
-import type { StatResult, FileInfo, ProgressFn } from "./types";
+import type { StatResult, FileInfo, ProgressFn, SearchResult } from "./types";
 
 /** Files >= this size use multipart upload (matches server threshold). */
 const MULTIPART_THRESHOLD = 50_000; // 50 KB
@@ -281,6 +281,18 @@ export class Drive9Client {
     if (data && Array.isArray((data as Record<string, unknown>).entries)) {
       return (data as Record<string, unknown>).entries as FileInfo[];
     }
+    return [];
+  }
+
+  /** GET ?grep= — hybrid search (FTS + vector + keyword fallback). */
+  async grep(query: string, limit = 20): Promise<SearchResult[]> {
+    const q = encodeURIComponent(query);
+    const resp = await this.request(
+      "GET",
+      `/v1/fs/?grep=${q}&limit=${limit}`,
+    );
+    const data = resp.json;
+    if (Array.isArray(data)) return data as SearchResult[];
     return [];
   }
 

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -5,6 +5,7 @@ import { SyncEngine } from "./sync-engine";
 import { ShadowStore } from "./shadow-store";
 import { ConflictResolver } from "./conflict-resolver";
 import { Drive9SettingTab } from "./settings";
+import { Drive9SearchModal } from "./search-modal";
 import { runFirstRunReconciliation, pullAllRemote } from "./first-run";
 import type { PluginData, Drive9Settings, SyncState } from "./types";
 import { DEFAULT_PLUGIN_DATA, DEFAULT_SETTINGS } from "./types";
@@ -74,6 +75,19 @@ export default class Drive9Plugin extends Plugin {
     this.syncEngine.onStatusChange(() => this.updateStatusBar());
 
     this.addSettingTab(new Drive9SettingTab(this.app, this));
+
+    this.addCommand({
+      id: "drive9-search",
+      name: "Search (drive9)",
+      hotkeys: [{ modifiers: ["Mod", "Shift"], key: "s" }],
+      callback: () => {
+        if (!this.settings.serverUrl) {
+          new Notice("drive9: configure server URL in settings first");
+          return;
+        }
+        new Drive9SearchModal(this.app, this.client).open();
+      },
+    });
 
     this.app.workspace.onLayoutReady(() => {
       void this.onLayoutReady();

--- a/obsidian-plugin/src/search-modal.ts
+++ b/obsidian-plugin/src/search-modal.ts
@@ -1,0 +1,102 @@
+import { App, SuggestModal, Notice } from "obsidian";
+import { Drive9Client, Drive9Error, sanitizeError } from "./client";
+import type { SearchResult } from "./types";
+
+const DEBOUNCE_MS = 300;
+const MIN_QUERY_LENGTH = 3;
+const SEARCH_LIMIT = 20;
+
+export class Drive9SearchModal extends SuggestModal<SearchResult> {
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastQuery = "";
+  private cachedResults: SearchResult[] = [];
+
+  constructor(
+    app: App,
+    private client: Drive9Client,
+  ) {
+    super(app);
+    this.setPlaceholder("Search files in drive9...");
+    this.setInstructions([
+      { command: "↑↓", purpose: "navigate" },
+      { command: "↵", purpose: "open file" },
+      { command: "esc", purpose: "dismiss" },
+    ]);
+  }
+
+  getSuggestions(query: string): SearchResult[] | Promise<SearchResult[]> {
+    if (query.length < MIN_QUERY_LENGTH) {
+      this.cachedResults = [];
+      return [];
+    }
+
+    if (query === this.lastQuery) {
+      return this.cachedResults;
+    }
+
+    return new Promise<SearchResult[]>((resolve) => {
+      if (this.debounceTimer) clearTimeout(this.debounceTimer);
+      this.debounceTimer = setTimeout(async () => {
+        try {
+          const results = await this.client.grep(query, SEARCH_LIMIT);
+          this.lastQuery = query;
+          this.cachedResults = results;
+          resolve(results);
+        } catch (e) {
+          if (e instanceof Drive9Error) {
+            new Notice(`drive9 search: ${e.message}`);
+          } else {
+            new Notice(`drive9 search: ${sanitizeError(e instanceof Error ? e.message : String(e))}`);
+          }
+          resolve(this.cachedResults);
+        }
+      }, DEBOUNCE_MS);
+    });
+  }
+
+  renderSuggestion(result: SearchResult, el: HTMLElement): void {
+    const container = el.createDiv({ cls: "drive9-search-result" });
+
+    container.createDiv({
+      cls: "drive9-search-path",
+      text: result.path,
+    });
+
+    const meta = container.createDiv({ cls: "drive9-search-meta" });
+    meta.style.fontSize = "0.85em";
+    meta.style.color = "var(--text-muted)";
+
+    const parts: string[] = [];
+    if (result.size_bytes > 0) {
+      parts.push(formatSize(result.size_bytes));
+    }
+    if (result.score != null) {
+      parts.push(`score: ${result.score.toFixed(2)}`);
+    }
+    if (parts.length > 0) {
+      meta.setText(parts.join(" · "));
+    }
+  }
+
+  onChooseSuggestion(result: SearchResult): void {
+    const file = this.app.vault.getAbstractFileByPath(result.path);
+    if (file) {
+      void this.app.workspace.openLinkText(result.path, "", false);
+    } else {
+      new Notice(`drive9: file not found locally — ${result.path}`);
+    }
+  }
+
+  onClose(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/obsidian-plugin/src/search-modal.ts
+++ b/obsidian-plugin/src/search-modal.ts
@@ -48,7 +48,7 @@ export class Drive9SearchModal extends SuggestModal<SearchResult> {
           } else {
             new Notice(`drive9 search: ${sanitizeError(e instanceof Error ? e.message : String(e))}`);
           }
-          resolve(this.cachedResults);
+          resolve([]);
         }
       }, DEBOUNCE_MS);
     });

--- a/obsidian-plugin/src/search-modal.ts
+++ b/obsidian-plugin/src/search-modal.ts
@@ -26,6 +26,7 @@ export class Drive9SearchModal extends SuggestModal<SearchResult> {
 
   getSuggestions(query: string): SearchResult[] | Promise<SearchResult[]> {
     if (query.length < MIN_QUERY_LENGTH) {
+      this.lastQuery = "";
       this.cachedResults = [];
       return [];
     }

--- a/obsidian-plugin/src/types.ts
+++ b/obsidian-plugin/src/types.ts
@@ -36,6 +36,14 @@ export interface FileInfo {
   mtime: number;
 }
 
+/** Search result from GET /v1/fs/{path}?grep=... */
+export interface SearchResult {
+  path: string;
+  name: string;
+  size_bytes: number;
+  score?: number;
+}
+
 /** Remote filesystem mutation event from /v1/events. */
 export interface ChangeEvent {
   seq: number;


### PR DESCRIPTION
## Summary

- Adds search UI to Obsidian plugin, reusing existing server `GET /v1/fs/?grep=...&limit=...` hybrid API
- No new server contract — wraps existing grep endpoint (FTS + vector + RRF + keyword fallback)
- Command name: **Search (drive9)** (not "semantic" — per @adversary-1's constraint)
- `#179` treated as follow-up enhancement, not blocker

## Changes

- **`client.ts`** — `grep(query, limit)` method wrapping `GET /v1/fs/?grep={q}&limit={n}`
- **`search-modal.ts`** (new) — `Drive9SearchModal` using Obsidian `SuggestModal`:
  - 300ms debounce, minimum 3 chars
  - Displays path, file size, relevance score
  - Click opens file in vault
  - Error degradation with Notice
- **`types.ts`** — `SearchResult` type matching server response `{ path, name, size_bytes, score? }`
- **`main.ts`** — Registers `drive9-search` command with `Cmd+Shift+S` hotkey

## @adversary-1 review constraints alignment

1. ✅ Only calls existing `GET /v1/fs/?grep=...` — no raw SQL, no `/v1/search`
2. ✅ Command named "Search (drive9)" — no "semantic" claim
3. ✅ Only uses `{ path, name, size_bytes, score }` — no snippet dependency

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Cmd+Shift+S opens search modal
- [ ] Typing >= 3 chars triggers search after 300ms debounce
- [ ] Empty/short query shows no results
- [ ] Click on result opens file
- [ ] Server error shows Notice, doesn't crash
- [ ] No server URL configured → shows "configure in settings" Notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)