### PR TITLE
feat: Obsidian plugin search UI reusing server grep API

### DIFF
--- a/obsidian-plugin/src/client.ts
+++ b/obsidian-plugin/src/client.ts
@@ -1,5 +1,5 @@
 import { requestUrl, RequestUrlParam, Platform } from "obsidian";
-import type { StatResult, FileInfo, ProgressFn } from "./types";
+import type { StatResult, FileInfo, ProgressFn, SearchResult } from "./types";
 
 /** Files >= this size use multipart upload (matches server threshold). */
 const MULTIPART_THRESHOLD = 50_000; // 50 KB
@@ -271,6 +271,15 @@ export class Drive9Client {
     await this.request("POST", `/v1/fs/${encodePath(path)}?mkdir`, {
       headers: this.mutationHeaders(),
     });
+  }
+
+  /** GET ?grep= — hybrid search (FTS + vector + RRF merge + keyword fallback). */
+  async grep(query: string, pathPrefix = "/", limit = 20): Promise<SearchResult[]> {
+    const qs = `grep=${encodeURIComponent(query)}&limit=${limit}`;
+    const resp = await this.request("GET", `/v1/fs/${encodePath(pathPrefix)}?${qs}`);
+    const data = resp.json;
+    if (Array.isArray(data)) return data as SearchResult[];
+    return [];
   }
 
   /** GET ?list=1 — list directory contents. */

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -5,6 +5,7 @@ import { SyncEngine } from "./sync-engine";
 import { ShadowStore } from "./shadow-store";
 import { ConflictResolver } from "./conflict-resolver";
 import { Drive9SettingTab } from "./settings";
+import { Drive9SearchModal } from "./search-modal";
 import { runFirstRunReconciliation, pullAllRemote } from "./first-run";
 import type { PluginData, Drive9Settings, SyncState } from "./types";
 import { DEFAULT_PLUGIN_DATA, DEFAULT_SETTINGS } from "./types";
@@ -74,6 +75,12 @@ export default class Drive9Plugin extends Plugin {
     this.syncEngine.onStatusChange(() => this.updateStatusBar());
 
     this.addSettingTab(new Drive9SettingTab(this.app, this));
+
+    this.addCommand({
+      id: "drive9-search",
+      name: "Search (drive9)",
+      callback: () => new Drive9SearchModal(this.app, this.client).open(),
+    });
 
     this.app.workspace.onLayoutReady(() => {
       void this.onLayoutReady();

--- a/obsidian-plugin/src/search-modal.ts
+++ b/obsidian-plugin/src/search-modal.ts
@@ -1,0 +1,77 @@
+import { App, SuggestModal, Notice } from "obsidian";
+import type { Drive9Client } from "./client";
+import { Drive9Error, sanitizeError } from "./client";
+import type { SearchResult } from "./types";
+
+const MIN_QUERY_LENGTH = 3;
+const DEBOUNCE_MS = 300;
+
+export class Drive9SearchModal extends SuggestModal<SearchResult> {
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastQuery = "";
+  private cachedResults: SearchResult[] = [];
+
+  constructor(
+    app: App,
+    private client: Drive9Client,
+  ) {
+    super(app);
+    this.setPlaceholder("Search your drive9 files…");
+    this.emptyStateText = "Type at least 3 characters to search";
+    this.limit = 20;
+  }
+
+  getSuggestions(query: string): SearchResult[] | Promise<SearchResult[]> {
+    if (query.length < MIN_QUERY_LENGTH) {
+      this.cachedResults = [];
+      return [];
+    }
+
+    if (query === this.lastQuery && this.cachedResults.length > 0) {
+      return this.cachedResults;
+    }
+
+    return new Promise((resolve) => {
+      if (this.debounceTimer) clearTimeout(this.debounceTimer);
+      this.debounceTimer = setTimeout(async () => {
+        try {
+          const results = await this.client.grep(query, "/", 20);
+          this.lastQuery = query;
+          this.cachedResults = results;
+          resolve(results);
+        } catch (e) {
+          if (e instanceof Drive9Error) {
+            new Notice(`drive9 search failed: ${e.message}`);
+          } else {
+            new Notice(`drive9 search failed: ${sanitizeError(String(e))}`);
+          }
+          resolve([]);
+        }
+      }, DEBOUNCE_MS);
+    });
+  }
+
+  renderSuggestion(result: SearchResult, el: HTMLElement): void {
+    el.createEl("div", { text: result.path, cls: "drive9-search-path" });
+    const meta: string[] = [];
+    if (result.score != null) {
+      meta.push(`score: ${result.score.toFixed(2)}`);
+    }
+    if (result.size_bytes > 0) {
+      meta.push(formatSize(result.size_bytes));
+    }
+    if (meta.length > 0) {
+      el.createEl("small", { text: meta.join(" · "), cls: "drive9-search-meta" });
+    }
+  }
+
+  onChooseSuggestion(result: SearchResult): void {
+    this.app.workspace.openLinkText(result.path, "");
+  }
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/obsidian-plugin/src/types.ts
+++ b/obsidian-plugin/src/types.ts
@@ -75,6 +75,14 @@ export interface SyncState {
   consecutiveAbsences?: number;
 }
 
+/** Result from GET /v1/fs/{path}?grep=<query> */
+export interface SearchResult {
+  path: string;
+  name: string;
+  size_bytes: number;
+  score?: number;
+}
+
 /** Persisted plugin data (settings + sync state). */
 export interface PluginData {
   settings: Drive9Settings;


### PR DESCRIPTION
## Summary

Implements #177 (Phase 3: Semantic Search UI) by reusing the existing server-side `GET /v1/fs/{path}?grep=<query>&limit=<n>` endpoint — the same API that the CLI `drive9 fs grep` uses.

- **`client.ts`**: Add `grep()` method calling the existing hybrid search endpoint (FTS + vector + RRF merge + keyword fallback)
- **`types.ts`**: Add `SearchResult` type matching server response `{ path, name, size_bytes, score }`
- **`search-modal.ts`**: New `SuggestModal` with 300ms debounced search, min 3 chars, shows path + score + size, click opens file
- **`main.ts`**: Register "Search (drive9)" command

No new server-side changes needed — fully reuses existing infrastructure.

## Test plan

- [ ] Open command palette → "Search (drive9)" opens modal
- [ ] Type 3+ chars → results appear with path and score
- [ ] Click result → opens the file in vault
- [ ] Empty/short query → shows placeholder text
- [ ] Server unreachable → Notice with error message
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes (38.8kb)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)