### PR TITLE
fix: harden mysql pool and starter schema init

### DIFF
--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"
+	"github.com/mem9-ai/dat9/pkg/mysqlutil"
 	"go.uber.org/zap"
 )
 
@@ -132,9 +133,7 @@ func Open(dsn string) (*Store, error) {
 }
 
 func applyMySQLPoolDefaults(db *sql.DB) {
-	// Rotate and prune idle conns before common LB/NAT idle timeout windows.
-	db.SetConnMaxLifetime(5 * time.Minute)
-	db.SetConnMaxIdleTime(45 * time.Second)
+	mysqlutil.ApplyPoolDefaults(db)
 }
 
 func (s *Store) Close() error { return s.db.Close() }

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -123,11 +123,18 @@ func Open(dsn string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
+	applyMySQLPoolDefaults(db)
 	if err := db.Ping(); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping db: %w", err)
 	}
 	return &Store{db: db}, nil
+}
+
+func applyMySQLPoolDefaults(db *sql.DB) {
+	// Rotate and prune idle conns before common LB/NAT idle timeout windows.
+	db.SetConnMaxLifetime(5 * time.Minute)
+	db.SetConnMaxIdleTime(45 * time.Second)
 }
 
 func (s *Store) Close() error { return s.db.Close() }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -86,6 +86,7 @@ func Open(dsn string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
+	applyMySQLPoolDefaults(db)
 	if err := db.Ping(); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping db: %w", err)
@@ -100,6 +101,12 @@ func Open(dsn string) (*Store, error) {
 
 func (s *Store) Close() error { return s.db.Close() }
 func (s *Store) DB() *sql.DB  { return s.db }
+
+func applyMySQLPoolDefaults(db *sql.DB) {
+	// Rotate and prune idle conns before common LB/NAT idle timeout windows.
+	db.SetConnMaxLifetime(5 * time.Minute)
+	db.SetConnMaxIdleTime(45 * time.Second)
+}
 
 func (s *Store) migrate() error {
 	stmts := []string{

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"
+	"github.com/mem9-ai/dat9/pkg/mysqlutil"
 	"go.uber.org/zap"
 )
 
@@ -103,9 +104,7 @@ func (s *Store) Close() error { return s.db.Close() }
 func (s *Store) DB() *sql.DB  { return s.db }
 
 func applyMySQLPoolDefaults(db *sql.DB) {
-	// Rotate and prune idle conns before common LB/NAT idle timeout windows.
-	db.SetConnMaxLifetime(5 * time.Minute)
-	db.SetConnMaxIdleTime(45 * time.Second)
+	mysqlutil.ApplyPoolDefaults(db)
 }
 
 func (s *Store) migrate() error {

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -1,0 +1,19 @@
+// Package mysqlutil provides shared helpers for MySQL client configuration.
+package mysqlutil
+
+import (
+	"database/sql"
+	"time"
+)
+
+const (
+	defaultConnMaxLifetime = 5 * time.Minute
+	defaultConnMaxIdleTime = 45 * time.Second
+)
+
+// ApplyPoolDefaults rotates and prunes idle connections before common LB/NAT
+// idle timeout windows.
+func ApplyPoolDefaults(db *sql.DB) {
+	db.SetConnMaxLifetime(defaultConnMaxLifetime)
+	db.SetConnMaxIdleTime(defaultConnMaxIdleTime)
+}

--- a/pkg/tenant/schema/common.go
+++ b/pkg/tenant/schema/common.go
@@ -35,7 +35,7 @@ func isIgnorableSchemaError(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "duplicate key") ||
-		strings.Contains(msg, "already exists") ||
+		strings.Contains(msg, "already exist") ||
 		strings.Contains(msg, "duplicate column")
 }
 

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 )
@@ -99,7 +100,7 @@ func tidbAppEmbeddingSchemaStatements() []string {
 }
 
 func initTiDBAppEmbeddingSchema(dsn string) error {
-	db, err := OpenTiDBSchemaDB(dsn)
+	db, err := OpenTiDBSchemaDB(context.Background(), dsn)
 	if err != nil {
 		return err
 	}

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -259,6 +259,17 @@ func ValidateTiDBSchemaForModeDSN(dsn string, mode TiDBEmbeddingMode) error {
 	return ValidateTiDBSchemaForMode(db, mode)
 }
 
+// EnsureTiDBSchemaForModeDSN opens a DSN, repairs known launch-schema drift,
+// validates the schema contract, and closes.
+func EnsureTiDBSchemaForModeDSN(dsn string, mode TiDBEmbeddingMode) error {
+	db, err := OpenTiDBSchemaDB(dsn)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return EnsureTiDBSchemaForMode(db, mode)
+}
+
 func OpenTiDBSchemaDB(dsn string) (*sql.DB, error) {
 	if HasMultiStatements(dsn) {
 		return nil, fmt.Errorf("multiStatements is not allowed")

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -235,7 +235,7 @@ func validateTiDBSchemaMode(mode TiDBEmbeddingMode) error {
 }
 
 func initTiDBAutoEmbeddingSchema(dsn string) error {
-	db, err := OpenTiDBSchemaDB(dsn)
+	db, err := OpenTiDBSchemaDB(context.Background(), dsn)
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func initTiDBAutoEmbeddingSchema(dsn string) error {
 
 // ValidateTiDBSchemaForModeDSN opens a DSN, validates the schema, and closes.
 func ValidateTiDBSchemaForModeDSN(dsn string, mode TiDBEmbeddingMode) error {
-	db, err := OpenTiDBSchemaDB(dsn)
+	db, err := OpenTiDBSchemaDB(context.Background(), dsn)
 	if err != nil {
 		return err
 	}
@@ -261,8 +261,8 @@ func ValidateTiDBSchemaForModeDSN(dsn string, mode TiDBEmbeddingMode) error {
 
 // EnsureTiDBSchemaForModeDSN opens a DSN, repairs known launch-schema drift,
 // validates the schema contract, and closes.
-func EnsureTiDBSchemaForModeDSN(dsn string, mode TiDBEmbeddingMode) error {
-	db, err := OpenTiDBSchemaDB(dsn)
+func EnsureTiDBSchemaForModeDSN(ctx context.Context, dsn string, mode TiDBEmbeddingMode) error {
+	db, err := OpenTiDBSchemaDB(ctx, dsn)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ func EnsureTiDBSchemaForModeDSN(dsn string, mode TiDBEmbeddingMode) error {
 	return EnsureTiDBSchemaForMode(db, mode)
 }
 
-func OpenTiDBSchemaDB(dsn string) (*sql.DB, error) {
+func OpenTiDBSchemaDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	if HasMultiStatements(dsn) {
 		return nil, fmt.Errorf("multiStatements is not allowed")
 	}
@@ -278,7 +278,7 @@ func OpenTiDBSchemaDB(dsn string) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := db.Ping(); err != nil {
+	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
 		return nil, err
 	}

--- a/pkg/tenant/starter/provisioner.go
+++ b/pkg/tenant/starter/provisioner.go
@@ -53,10 +53,10 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 
 func (p *Provisioner) ProviderType() string { return tenant.ProviderTiDBCloudStarter }
 
-// InitSchema validates the externally provisioned Starter schema against the
-// shared TiDB auto-embedding launch contract without creating or altering data.
+// InitSchema repairs known launch-schema drift (for example, missing uploads
+// columns from legacy tenants) and validates the TiDB auto-embedding contract.
 func (p *Provisioner) InitSchema(_ context.Context, dsn string) error {
-	return schema.ValidateTiDBSchemaForModeDSN(dsn, schema.TiDBEmbeddingModeAuto)
+	return schema.EnsureTiDBSchemaForModeDSN(dsn, schema.TiDBEmbeddingModeAuto)
 }
 
 func (p *Provisioner) Provision(ctx context.Context, tenantID string) (*tenant.ClusterInfo, error) {

--- a/pkg/tenant/starter/provisioner.go
+++ b/pkg/tenant/starter/provisioner.go
@@ -55,8 +55,8 @@ func (p *Provisioner) ProviderType() string { return tenant.ProviderTiDBCloudSta
 
 // InitSchema repairs known launch-schema drift (for example, missing uploads
 // columns from legacy tenants) and validates the TiDB auto-embedding contract.
-func (p *Provisioner) InitSchema(_ context.Context, dsn string) error {
-	return schema.EnsureTiDBSchemaForModeDSN(dsn, schema.TiDBEmbeddingModeAuto)
+func (p *Provisioner) InitSchema(ctx context.Context, dsn string) error {
+	return schema.EnsureTiDBSchemaForModeDSN(ctx, dsn, schema.TiDBEmbeddingModeAuto)
 }
 
 func (p *Provisioner) Provision(ctx context.Context, tenantID string) (*tenant.ClusterInfo, error) {


### PR DESCRIPTION
## Summary
- set conservative MySQL pool aging defaults in control/data plane stores
- use ensure+validate schema path for tidb_cloud_starter init to repair legacy uploads drift
- include existing schema error text normalization tweak in common schema helper

## Validation
- go test ./pkg/meta ./pkg/datastore ./pkg/tenant/schema ./pkg/tenant/starter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DSN-based schema initialization with automatic repair capability.

* **Bug Fixes**
  * Improved schema error handling to recognize additional error message variants.
  * Enhanced Starter schema initialization to repair known drift before validation.

* **Refactor**
  * Optimized MySQL connection pooling with configurable timeouts for improved resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->