### PR TITLE
Add drive9-server schema dump command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,7 @@ Obtain a logger from `pkg/logger` or accept `*zap.Logger` via `Config`.
 - `pkg/tenant/schema/tidb_auto.go`, `pkg/tenant/schema/tidb_app.go`, and `pkg/tenant/db9/schema.go`
   are the source of truth for tenant init schema SQL.
 - If you change schema shape in those files — columns, indexes, generated columns, constraints,
-  defaults, or table definitions — you must also update the externally managed `tidb_zero`
+  defaults, or table definitions — you must also update the externally managed `tidb_cloud_starter`
   schema using the exported SQL from:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,3 +255,20 @@ Obtain a logger from `pkg/logger` or accept `*zap.Logger` via `Config`.
 - All drive9 paths are absolute, UTF-8, NFC-normalized, no backslashes, no `..` segments.
 - Directories always end with `/`; files never do.
 - Use `pkg/pathutil` for all path normalization — never manipulate raw strings directly.
+
+### Schema synchronization
+
+- `pkg/tenant/schema/tidb_auto.go`, `pkg/tenant/schema/tidb_app.go`, and `pkg/tenant/db9/schema.go`
+  are the source of truth for tenant init schema SQL.
+- If you change schema shape in those files — columns, indexes, generated columns, constraints,
+  defaults, or table definitions — you must also update the externally managed `tidb_zero`
+  schema using the exported SQL from:
+
+```bash
+drive9-server schema dump-init-sql --provider tidb_zero
+drive9-server schema dump-init-sql --provider tidb_cloud_starter
+drive9-server schema dump-init-sql --provider db9
+```
+
+- Do not maintain a second handwritten copy of those init SQL statements when a command can
+  export the exact runtime source of truth.

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -38,14 +39,15 @@ func main() {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "-h", "--help", "help":
-			usage()
+			usage(os.Stdout, 0)
+			return
 		case "schema":
 			die(runSchemaCommand(os.Args[2:]))
 			return
 		}
 	}
 	if len(os.Args) > 2 {
-		usage()
+		usage(os.Stderr, 2)
 	}
 
 	addr := envOr("DRIVE9_LISTEN_ADDR", defaultListenAddr)
@@ -213,8 +215,8 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
-func usage() {
-	fmt.Fprintf(os.Stderr, `usage:
+func usage(out io.Writer, exitCode int) {
+	_, _ = fmt.Fprintf(out, `usage:
   drive9-server [listen-addr]
   drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter>
 
@@ -283,7 +285,7 @@ schema tooling:
   dump-init-sql writes the exact init schema SQL to stdout so external systems
   such as tidb_cloud_starter can stay in sync with drive9's schema source of truth.
 `, server.DefaultMaxUploadBytes)
-	os.Exit(2)
+	os.Exit(exitCode)
 }
 
 func die(err error) {

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -1,8 +1,10 @@
-// Command drive9-server starts the drive9 HTTP server.
+// Command drive9-server starts the drive9 HTTP server and exposes operational
+// schema tooling.
 //
 // Usage:
 //
 //	drive9-server [listen-addr]
+//	drive9-server schema dump-init-sql [flags]
 package main
 
 import (
@@ -33,6 +35,15 @@ const (
 )
 
 func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "-h", "--help", "help":
+			usage()
+		case "schema":
+			die(runSchemaCommand(os.Args[2:]))
+			return
+		}
+	}
 	if len(os.Args) > 2 {
 		usage()
 	}
@@ -203,7 +214,9 @@ func envOr(key, fallback string) string {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, `usage: drive9-server [listen-addr]
+	fmt.Fprintf(os.Stderr, `usage:
+  drive9-server [listen-addr]
+  drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter>
 
 environment:
   DRIVE9_LISTEN_ADDR serve listen address (default: :9009)
@@ -265,6 +278,10 @@ environment:
   DRIVE9_AUDIO_EXTRACT_API_KEY  API key for DRIVE9_AUDIO_EXTRACT_API_BASE (required when enabled)
   DRIVE9_AUDIO_EXTRACT_MODEL    model name for audio transcription (required when enabled)
   DRIVE9_AUDIO_EXTRACT_PROMPT   optional provider prompt for transcription
+
+schema tooling:
+  dump-init-sql writes the exact init schema SQL to stdout so external systems
+  such as tidb_zero can stay in sync with drive9's schema source of truth.
 `, server.DefaultMaxUploadBytes)
 	os.Exit(2)
 }

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -281,7 +281,7 @@ environment:
 
 schema tooling:
   dump-init-sql writes the exact init schema SQL to stdout so external systems
-  such as tidb_zero can stay in sync with drive9's schema source of truth.
+  such as tidb_cloud_starter can stay in sync with drive9's schema source of truth.
 `, server.DefaultMaxUploadBytes)
 	os.Exit(2)
 }

--- a/cmd/drive9-server/schema.go
+++ b/cmd/drive9-server/schema.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/mem9-ai/dat9/pkg/tenant/schemadump"
+)
+
+func runSchemaCommand(args []string) error {
+	if len(args) == 0 {
+		return errors.New(schemadump.Usage())
+	}
+
+	switch args[0] {
+	case "dump-init-sql":
+		return dumpInitSQL(args[1:])
+	default:
+		return fmt.Errorf("unknown schema subcommand %q\n%s", args[0], schemadump.Usage())
+	}
+}
+
+func dumpInitSQL(args []string) error {
+	provider := ""
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--provider":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--provider requires an argument")
+			}
+			i++
+			provider = args[i]
+		default:
+			return fmt.Errorf("unknown flag %q\n%s", args[i], schemadump.Usage())
+		}
+	}
+
+	resolved, err := schemadump.ResolveProvider(provider)
+	if err != nil {
+		return err
+	}
+	sqlText, err := schemadump.SQLText(resolved)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(os.Stdout, sqlText)
+	return err
+}

--- a/cmd/drive9-server/schema_test.go
+++ b/cmd/drive9-server/schema_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSchemaDumpInitSQLByProvider(t *testing.T) {
+	out := captureSchemaStdout(t, func() {
+		if err := runSchemaCommand([]string{"dump-init-sql", "--provider", "tidb_zero"}); err != nil {
+			t.Fatalf("dump provider schema: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "CREATE TABLE IF NOT EXISTS files") {
+		t.Fatalf("dump missing files table: %q", out)
+	}
+	if !strings.Contains(out, "GENERATED ALWAYS AS (EMBED_TEXT") {
+		t.Fatalf("dump missing auto-embedding expression: %q", out)
+	}
+	if !strings.Contains(out, "CREATE INDEX idx_task_claim_type ON semantic_tasks") {
+		t.Fatalf("dump missing semantic_tasks index: %q", out)
+	}
+	if !strings.Contains(out, ";\n") {
+		t.Fatalf("dump missing SQL statement terminators: %q", out)
+	}
+}
+
+func TestSchemaDumpInitSQLByProviderIncludesVault(t *testing.T) {
+	out := captureSchemaStdout(t, func() {
+		if err := runSchemaCommand([]string{"dump-init-sql", "--provider", "db9"}); err != nil {
+			t.Fatalf("dump provider schema: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "CREATE TABLE IF NOT EXISTS vault_deks") {
+		t.Fatalf("db9 dump missing vault_deks: %q", out)
+	}
+	if !strings.Contains(out, "CREATE TABLE IF NOT EXISTS vault_audit_log") {
+		t.Fatalf("db9 dump missing vault_audit_log: %q", out)
+	}
+}
+
+func TestSchemaDumpInitSQLRequiresProvider(t *testing.T) {
+	err := runSchemaCommand([]string{"dump-init-sql"})
+	if err == nil {
+		t.Fatal("expected missing provider to fail")
+	}
+	if !strings.Contains(err.Error(), "--provider") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func captureSchemaStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+
+	os.Stdout = writer
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+	})
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+	return string(data)
+}

--- a/cmd/drive9-server/schema_test.go
+++ b/cmd/drive9-server/schema_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"strings"
@@ -8,23 +9,27 @@ import (
 )
 
 func TestSchemaDumpInitSQLByProvider(t *testing.T) {
-	out := captureSchemaStdout(t, func() {
-		if err := runSchemaCommand([]string{"dump-init-sql", "--provider", "tidb_zero"}); err != nil {
-			t.Fatalf("dump provider schema: %v", err)
-		}
-	})
+	for _, provider := range []string{"tidb_zero", "tidb_cloud_starter"} {
+		t.Run(provider, func(t *testing.T) {
+			out := captureSchemaStdout(t, func() {
+				if err := runSchemaCommand([]string{"dump-init-sql", "--provider", provider}); err != nil {
+					t.Fatalf("dump provider schema: %v", err)
+				}
+			})
 
-	if !strings.Contains(out, "CREATE TABLE IF NOT EXISTS files") {
-		t.Fatalf("dump missing files table: %q", out)
-	}
-	if !strings.Contains(out, "GENERATED ALWAYS AS (EMBED_TEXT") {
-		t.Fatalf("dump missing auto-embedding expression: %q", out)
-	}
-	if !strings.Contains(out, "CREATE INDEX idx_task_claim_type ON semantic_tasks") {
-		t.Fatalf("dump missing semantic_tasks index: %q", out)
-	}
-	if !strings.Contains(out, ";\n") {
-		t.Fatalf("dump missing SQL statement terminators: %q", out)
+			if !strings.Contains(out, "CREATE TABLE IF NOT EXISTS files") {
+				t.Fatalf("dump missing files table: %q", out)
+			}
+			if !strings.Contains(out, "GENERATED ALWAYS AS (EMBED_TEXT") {
+				t.Fatalf("dump missing auto-embedding expression: %q", out)
+			}
+			if !strings.Contains(out, "CREATE INDEX idx_task_claim_type ON semantic_tasks") {
+				t.Fatalf("dump missing semantic_tasks index: %q", out)
+			}
+			if !strings.Contains(out, ";\n") {
+				t.Fatalf("dump missing SQL statement terminators: %q", out)
+			}
+		})
 	}
 }
 
@@ -67,17 +72,21 @@ func captureSchemaStdout(t *testing.T, fn func()) string {
 		os.Stdout = originalStdout
 	})
 
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, reader)
+		done <- buf.String()
+	}()
+
 	fn()
 
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stdout writer: %v", err)
 	}
-	data, err := io.ReadAll(reader)
-	if err != nil {
-		t.Fatalf("read stdout: %v", err)
-	}
+	data := <-done
 	if err := reader.Close(); err != nil {
 		t.Fatalf("close stdout reader: %v", err)
 	}
-	return string(data)
+	return data
 }

--- a/pkg/tenant/db9/schema.go
+++ b/pkg/tenant/db9/schema.go
@@ -12,11 +12,11 @@ import (
 // InitSchemaStatements returns the exact DDL statements used by db9 tenant
 // schema initialization, including vault tables.
 func InitSchemaStatements() []string {
-	// Keep this statement list aligned with the externally managed tidb_zero
+	// Keep this statement list aligned with the externally managed tidb_cloud_starter
 	// schema. If you change columns, indexes, generated expressions, or
 	// constraints here, rerun:
 	//   drive9-server schema dump-init-sql --provider db9
-	// and update tidb_zero with the exported SQL.
+	// and update tidb_cloud_starter with the exported SQL.
 	core := []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (
 			node_id      VARCHAR(64) PRIMARY KEY,

--- a/pkg/tenant/db9/schema.go
+++ b/pkg/tenant/db9/schema.go
@@ -9,17 +9,15 @@ import (
 	"github.com/mem9-ai/dat9/pkg/vault"
 )
 
-func initDB9Schema(dsn string) error {
-	db, err := sql.Open("pgx", dsn)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = db.Close() }()
-	if err := db.Ping(); err != nil {
-		return err
-	}
-
-	stmts := []string{
+// InitSchemaStatements returns the exact DDL statements used by db9 tenant
+// schema initialization, including vault tables.
+func InitSchemaStatements() []string {
+	// Keep this statement list aligned with the externally managed tidb_zero
+	// schema. If you change columns, indexes, generated expressions, or
+	// constraints here, rerun:
+	//   drive9-server schema dump-init-sql --provider db9
+	// and update tidb_zero with the exported SQL.
+	core := []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (
 			node_id      VARCHAR(64) PRIMARY KEY,
 			path         VARCHAR(512) NOT NULL,
@@ -112,10 +110,24 @@ func initDB9Schema(dsn string) error {
 		`CREATE INDEX IF NOT EXISTS idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
 	}
+	stmts := make([]string, 0, len(core)+len(vault.SchemaStatements()))
+	stmts = append(stmts, core...)
+	stmts = append(stmts, vault.SchemaStatements()...)
+	return stmts
+}
 
-	if err := schema.ExecSchemaStatements(db, stmts); err != nil {
+func initDB9Schema(dsn string) error {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
 		return err
 	}
-	// Initialize vault tables alongside core tables.
-	return vault.InitSchema(db)
+	defer func() { _ = db.Close() }()
+	if err := db.Ping(); err != nil {
+		return err
+	}
+
+	if err := schema.ExecSchemaStatements(db, InitSchemaStatements()); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/tenant/schema/common.go
+++ b/pkg/tenant/schema/common.go
@@ -6,6 +6,27 @@ import (
 	"strings"
 )
 
+// CloneStatements returns a copy of the given schema statements so callers can
+// format or extend them without mutating the init-schema source of truth.
+func CloneStatements(stmts []string) []string {
+	cloned := make([]string, len(stmts))
+	copy(cloned, stmts)
+	return cloned
+}
+
+// FormatStatementsSQL renders schema statements as executable SQL text.
+func FormatStatementsSQL(stmts []string) string {
+	var b strings.Builder
+	for i, stmt := range stmts {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(strings.TrimSpace(stmt))
+		b.WriteString(";\n")
+	}
+	return b.String()
+}
+
 // ExecSchemaStatements executes a sequence of DDL statements, ignoring
 // duplicate-key / already-exists errors that arise from racing migrations.
 func ExecSchemaStatements(db *sql.DB, stmts []string) error {

--- a/pkg/tenant/schema/tidb.go
+++ b/pkg/tenant/schema/tidb.go
@@ -6,6 +6,19 @@ func InitTiDBTenantSchema(dsn string) error {
 	return InitTiDBTenantSchemaForMode(dsn, TiDBEmbeddingModeAuto)
 }
 
+// InitTiDBTenantSchemaStatementsForMode returns the exact DDL statements used
+// by TiDB tenant schema init for the requested embedding mode.
+func InitTiDBTenantSchemaStatementsForMode(mode TiDBEmbeddingMode) ([]string, error) {
+	switch mode {
+	case TiDBEmbeddingModeAuto:
+		return CloneStatements(tidbAutoEmbeddingSchemaStatements()), nil
+	case TiDBEmbeddingModeApp:
+		return CloneStatements(tidbAppEmbeddingSchemaStatements()), nil
+	default:
+		return nil, validateTiDBSchemaMode(mode)
+	}
+}
+
 // InitTiDBTenantSchemaForMode initializes the TiDB tenant schema for the
 // requested local embedding mode.
 func InitTiDBTenantSchemaForMode(dsn string, mode TiDBEmbeddingMode) error {

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 )
 
-// Keep this statement list aligned with the externally managed tidb_zero
+// Keep this statement list aligned with the externally managed tidb_cloud_starter
 // schema. If you change columns, indexes, generated expressions, or
 // constraints here, update the corresponding external TiDB schema workflow.
-// For tidb_zero's exported init SQL, rerun:
+// For tidb_cloud_starter's exported init SQL, rerun:
 //
 //	drive9-server schema dump-init-sql --provider tidb_zero
 func tidbAppEmbeddingSchemaStatements() []string {

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 )
 
-// Keep this statement list aligned with the externally managed tidb_cloud_starter
-// schema. If you change columns, indexes, generated expressions, or
-// constraints here, update the corresponding external TiDB schema workflow.
-// For tidb_cloud_starter's exported init SQL, rerun:
+// Keep this statement list aligned with any external workflow that manages the
+// app-embedding TiDB schema directly. If you change columns, indexes,
+// generated expressions, or constraints here, update that external workflow at
+// the same time.
 //
-//	drive9-server schema dump-init-sql --provider tidb_zero
+// There is intentionally no drive9-server dump-init-sql --provider export path
+// for this app-managed statement list.
 func tidbAppEmbeddingSchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -6,6 +6,12 @@ import (
 	"strconv"
 )
 
+// Keep this statement list aligned with the externally managed tidb_zero
+// schema. If you change columns, indexes, generated expressions, or
+// constraints here, update the corresponding external TiDB schema workflow.
+// For tidb_zero's exported init SQL, rerun:
+//
+//	drive9-server schema dump-init-sql --provider tidb_zero
 func tidbAppEmbeddingSchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -44,9 +44,9 @@ type tidbTableMeta struct {
 // schema. If you change columns, indexes, generated expressions, or
 // constraints here, rerun:
 //
-//	drive9-server schema dump-init-sql --provider tidb_zero
+//	drive9-server schema dump-init-sql --provider tidb_cloud_starter
 //
-// and update tidb_zero with the exported SQL.
+// and update tidb_cloud_starter with the exported SQL.
 func tidbAutoEmbeddingSchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -40,7 +40,7 @@ type tidbTableMeta struct {
 	columns   map[string]tidbColumnMeta
 }
 
-// Keep this statement list aligned with the externally managed tidb_zero
+// Keep this statement list aligned with the externally managed tidb_cloud_starter
 // schema. If you change columns, indexes, generated expressions, or
 // constraints here, rerun:
 //

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -40,6 +40,13 @@ type tidbTableMeta struct {
 	columns   map[string]tidbColumnMeta
 }
 
+// Keep this statement list aligned with the externally managed tidb_zero
+// schema. If you change columns, indexes, generated expressions, or
+// constraints here, rerun:
+//
+//	drive9-server schema dump-init-sql --provider tidb_zero
+//
+// and update tidb_zero with the exported SQL.
 func tidbAutoEmbeddingSchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (

--- a/pkg/tenant/schemadump/schemadump.go
+++ b/pkg/tenant/schemadump/schemadump.go
@@ -14,7 +14,7 @@ const usage = "usage: drive9-server schema dump-init-sql --provider <db9|tidb_ze
 // ResolveProvider normalizes a schema dump provider selection.
 func ResolveProvider(provider string) (string, error) {
 	if provider == "" {
-		return "", fmt.Errorf(usage)
+		return "", fmt.Errorf("%s", usage)
 	}
 	normalized, err := tenant.NormalizeProvider(provider)
 	if err != nil {

--- a/pkg/tenant/schemadump/schemadump.go
+++ b/pkg/tenant/schemadump/schemadump.go
@@ -1,0 +1,50 @@
+// Package schemadump provides tenant init schema export helpers.
+package schemadump
+
+import (
+	"fmt"
+
+	"github.com/mem9-ai/dat9/pkg/tenant"
+	tenantdb9 "github.com/mem9-ai/dat9/pkg/tenant/db9"
+	tenantschema "github.com/mem9-ai/dat9/pkg/tenant/schema"
+)
+
+const usage = "usage: drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter>"
+
+// ResolveProvider normalizes a schema dump provider selection.
+func ResolveProvider(provider string) (string, error) {
+	if provider == "" {
+		return "", fmt.Errorf(usage)
+	}
+	normalized, err := tenant.NormalizeProvider(provider)
+	if err != nil {
+		return "", err
+	}
+	return normalized, nil
+}
+
+// Statements returns the exact init schema DDL statements for a provider.
+func Statements(provider string) ([]string, error) {
+	switch provider {
+	case tenant.ProviderDB9:
+		return tenantschema.CloneStatements(tenantdb9.InitSchemaStatements()), nil
+	case tenant.ProviderTiDBZero, tenant.ProviderTiDBCloudStarter:
+		return tenantschema.InitTiDBTenantSchemaStatementsForMode(tenantschema.TiDBEmbeddingModeAuto)
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", provider)
+	}
+}
+
+// SQLText formats the init schema DDL as executable SQL text.
+func SQLText(provider string) (string, error) {
+	stmts, err := Statements(provider)
+	if err != nil {
+		return "", err
+	}
+	return tenantschema.FormatStatementsSQL(stmts), nil
+}
+
+// Usage returns the supported schema dump command syntax.
+func Usage() string {
+	return usage
+}

--- a/pkg/vault/schema.go
+++ b/pkg/vault/schema.go
@@ -8,6 +8,13 @@ import (
 
 // SchemaStatements returns the vault DDL statements used during tenant schema
 // initialization.
+//
+// These statements are appended into the exported db9 init schema. If you
+// change vault columns, indexes, or constraints here, rerun:
+//
+//	drive9-server schema dump-init-sql --provider db9
+//
+// and update any external db9 schema copy that consumes that exported SQL.
 func SchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS vault_deks (

--- a/pkg/vault/schema.go
+++ b/pkg/vault/schema.go
@@ -6,9 +6,10 @@ import (
 	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
 
-// InitSchema creates the vault tables in the tenant database.
-func InitSchema(db *sql.DB) error {
-	stmts := []string{
+// SchemaStatements returns the vault DDL statements used during tenant schema
+// initialization.
+func SchemaStatements() []string {
+	return []string{
 		`CREATE TABLE IF NOT EXISTS vault_deks (
 			tenant_id    VARCHAR(64) PRIMARY KEY,
 			wrapped_dek  BYTEA NOT NULL,
@@ -76,5 +77,9 @@ func InitSchema(db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_vault_audit_tenant_time ON vault_audit_log(tenant_id, timestamp)`,
 		`CREATE INDEX IF NOT EXISTS idx_vault_audit_secret ON vault_audit_log(secret_name, timestamp)`,
 	}
-	return schema.ExecSchemaStatements(db, stmts)
+}
+
+// InitSchema creates the vault tables in the tenant database.
+func InitSchema(db *sql.DB) error {
+	return schema.ExecSchemaStatements(db, SchemaStatements())
 }


### PR DESCRIPTION
## Summary
- add `drive9-server schema dump-init-sql --provider ...` to export the exact tenant init SQL used at runtime
- reuse the real init schema statement sources for TiDB and db9/vault instead of maintaining a second SQL copy
- add reminders in schema code and AGENTS.md that schema changes must be propagated to external tidb_cloud_starter schema management

## Testing
- go test ./cmd/drive9-server/... ./pkg/tenant/schemadump
- bash -lc 'source scripts/test-podman.sh && go test ./pkg/tenant/... ./pkg/vault'
- go run ./cmd/drive9-server schema dump-init-sql --provider tidb_zero
- go run ./cmd/drive9-server schema dump-init-sql --provider db9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `drive9-server schema dump-init-sql` CLI command to export initial database schema as SQL for multiple database providers (db9, tidb_zero, tidb_cloud_starter).

* **Documentation**
  * Added schema synchronization guidelines documenting authoritative schema sources and requirements for keeping externally managed schemas aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->