### PR TITLE
feat(obsidian): UX polish — conflict dismiss, error recovery, ribbon, status bar

### DIFF
--- a/obsidian-plugin/src/conflict-resolver.ts
+++ b/obsidian-plugin/src/conflict-resolver.ts
@@ -99,8 +99,10 @@ export class ConflictResolver {
     }
 
     // Auto-merge failed or binary file — check if user already dismissed this conflict
-    const fingerprint = `${path}:${remoteStat.revision}`;
-    if (state.dismissedFingerprint === fingerprint) {
+    // Only use fingerprint when we have a real revision (not the fallback 0)
+    const hasRealRevision = remoteStat.revision > 0;
+    const fingerprint = hasRealRevision ? `${path}:${remoteStat.revision}` : null;
+    if (fingerprint && state.dismissedFingerprint === fingerprint) {
       return;
     }
 
@@ -113,8 +115,11 @@ export class ConflictResolver {
     );
     const choice = await new ConflictModal(this.app, info).open();
     if (choice === null) {
-      // User dismissed modal — record fingerprint to suppress re-popup until conflict changes
-      state.dismissedFingerprint = fingerprint;
+      // User dismissed modal — only record fingerprint if we have a real revision
+      // When revision is unknown, allow re-popup next cycle rather than permanently suppress
+      if (fingerprint) {
+        state.dismissedFingerprint = fingerprint;
+      }
       return;
     }
     state.dismissedFingerprint = undefined;

--- a/obsidian-plugin/src/conflict-resolver.ts
+++ b/obsidian-plugin/src/conflict-resolver.ts
@@ -98,7 +98,12 @@ export class ConflictResolver {
       if (resolved) return;
     }
 
-    // Auto-merge failed or binary file — show modal
+    // Auto-merge failed or binary file — check if user already dismissed this conflict
+    const fingerprint = `${path}:${remoteStat.revision}`;
+    if (state.dismissedFingerprint === fingerprint) {
+      return;
+    }
+
     const info = createConflictInfo(
       path,
       localFile.stat.size,
@@ -108,9 +113,11 @@ export class ConflictResolver {
     );
     const choice = await new ConflictModal(this.app, info).open();
     if (choice === null) {
-      // User dismissed modal — keep conflict for next cycle
+      // User dismissed modal — record fingerprint to suppress re-popup until conflict changes
+      state.dismissedFingerprint = fingerprint;
       return;
     }
+    state.dismissedFingerprint = undefined;
     await this.applyChoice(path, choice, localFile, localData, remoteData, remoteStat.revision);
   }
 

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -304,6 +304,9 @@ export default class Drive9Plugin extends Plugin {
         }
         break;
       }
+      case "offline":
+        this.setStatusBar("⏸ drive9: offline");
+        break;
       case "error": {
         const detail = engine.lastErrorDetail;
         this.setStatusBar(detail ? `✗ drive9: ${detail} failed` : "✗ drive9: error");
@@ -340,7 +343,10 @@ export default class Drive9Plugin extends Plugin {
 
     const lines: string[] = [];
 
-    if (status === "error") {
+    if (status === "offline") {
+      lines.push("Offline: server unreachable");
+      lines.push("Run command \"Retry failed sync\" when back online");
+    } else if (status === "error") {
       const detail = engine.lastErrorDetail;
       lines.push(detail ? `Error: ${detail} failed to sync` : "Error: sync failed");
       lines.push("Run command \"Retry failed sync\" to retry");

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -71,6 +71,8 @@ export default class Drive9Plugin extends Plugin {
     }
 
     this.statusBarEl = this.addStatusBarItem();
+    this.statusBarEl.addClass("mod-clickable");
+    this.statusBarEl.addEventListener("click", () => this.showSyncPanel());
     this.updateStatusBar();
     this.syncEngine.onStatusChange(() => this.updateStatusBar());
 
@@ -79,7 +81,6 @@ export default class Drive9Plugin extends Plugin {
     this.addCommand({
       id: "drive9-search",
       name: "Search (drive9)",
-      hotkeys: [{ modifiers: ["Mod", "Shift"], key: "s" }],
       callback: () => {
         if (!this.settings.serverUrl) {
           new Notice("drive9: configure server URL in settings first");
@@ -87,6 +88,23 @@ export default class Drive9Plugin extends Plugin {
         }
         new Drive9SearchModal(this.app, this.client).open();
       },
+    });
+
+    this.addCommand({
+      id: "drive9-retry-sync",
+      name: "Retry failed sync (drive9)",
+      callback: () => {
+        this.syncEngine.retrySync();
+        new Notice("drive9: retrying sync...");
+      },
+    });
+
+    this.addRibbonIcon("search", "Search drive9", () => {
+      if (!this.settings.serverUrl) {
+        new Notice("drive9: configure server URL in settings first");
+        return;
+      }
+      new Drive9SearchModal(this.app, this.client).open();
     });
 
     this.app.workspace.onLayoutReady(() => {
@@ -152,12 +170,19 @@ export default class Drive9Plugin extends Plugin {
     );
 
     switch (result.action) {
-      case "push_all":
-        new Notice("drive9: uploading vault to drive9...");
-        for (const file of this.app.vault.getFiles()) {
-          this.syncEngine.onLocalCreate(file);
+      case "push_all": {
+        const files = this.app.vault.getFiles();
+        const total = files.length;
+        new Notice(`drive9: uploading ${total} files to drive9...`);
+        this.setStatusBar(`↕ drive9: queuing 0/${total} files`);
+        for (let i = 0; i < files.length; i++) {
+          this.syncEngine.onLocalCreate(files[i]);
+          if ((i + 1) % 50 === 0 || i === files.length - 1) {
+            this.setStatusBar(`↕ drive9: queuing ${i + 1}/${total} files`);
+          }
         }
         break;
+      }
 
       case "pull_all":
         new Notice("drive9: downloading from drive9...");
@@ -268,6 +293,7 @@ export default class Drive9Plugin extends Plugin {
     if (!engine) return;
 
     const skipped = engine.skippedLargeFiles.length;
+    const conflicts = this.countConflicts();
     switch (engine.status) {
       case "syncing": {
         const progress = engine.uploadProgressText;
@@ -278,12 +304,16 @@ export default class Drive9Plugin extends Plugin {
         }
         break;
       }
-      case "error":
-        this.setStatusBar("✗ drive9: error");
+      case "error": {
+        const detail = engine.lastErrorDetail;
+        this.setStatusBar(detail ? `✗ drive9: ${detail} failed` : "✗ drive9: error");
         break;
+      }
       case "idle":
         if (engine.pendingCount > 0) {
           this.setStatusBar(`↕ drive9: queued ${engine.pendingCount} files`);
+        } else if (conflicts > 0) {
+          this.setStatusBar(`⚠ drive9: ${conflicts} conflict${conflicts > 1 ? "s" : ""}`);
         } else if (skipped > 0) {
           this.setStatusBar(`✓ drive9: synced (${skipped} skipped — too large)`);
         } else {
@@ -291,6 +321,49 @@ export default class Drive9Plugin extends Plugin {
         }
         break;
     }
+  }
+
+  private countConflicts(): number {
+    let count = 0;
+    for (const state of Object.values(this.syncStates)) {
+      if (state.status === "conflict") count++;
+    }
+    return count;
+  }
+
+  private showSyncPanel(): void {
+    const engine = this.syncEngine;
+    const conflicts = this.countConflicts();
+    const pending = engine.pendingCount;
+    const skipped = engine.skippedLargeFiles;
+    const status = engine.status;
+
+    const lines: string[] = [];
+
+    if (status === "error") {
+      const detail = engine.lastErrorDetail;
+      lines.push(detail ? `Error: ${detail} failed to sync` : "Error: sync failed");
+      lines.push("Run command \"Retry failed sync\" to retry");
+    } else if (status === "syncing") {
+      lines.push(`Syncing ${pending} file${pending !== 1 ? "s" : ""}...`);
+    } else {
+      lines.push("Sync: idle");
+    }
+
+    if (conflicts > 0) {
+      lines.push(`${conflicts} conflict${conflicts > 1 ? "s" : ""} pending`);
+    }
+    if (pending > 0 && status !== "syncing") {
+      lines.push(`${pending} file${pending !== 1 ? "s" : ""} queued`);
+    }
+    if (skipped.length > 0) {
+      lines.push(`${skipped.length} file${skipped.length > 1 ? "s" : ""} skipped (too large)`);
+    }
+    if (lines.length === 1 && status === "idle" && conflicts === 0) {
+      lines.push("All files synced");
+    }
+
+    new Notice(lines.join("\n"), 8000);
   }
 
   private setStatusBar(text: string): void {

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -213,6 +213,9 @@ export class SyncEngine {
       this._lastErrorDetail = lastFailedPath;
       if (networkError) {
         this._consecutiveNetworkFailures++;
+      } else if (errorOccurred) {
+        // Non-network error breaks the consecutive network failure streak
+        this._consecutiveNetworkFailures = 0;
       }
       const finalStatus: SyncStatus = errorOccurred
         ? (this._consecutiveNetworkFailures >= OFFLINE_THRESHOLD ? "offline" : "error")

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -22,6 +22,7 @@ export class SyncEngine {
   private _pendingCount = 0;
   private _uploadProgressText = "";
   private _skippedLargeFiles: string[] = [];
+  private _lastErrorDetail = "";
   private statusListeners: Array<() => void> = [];
 
   private shadowStore: ShadowStore | null = null;
@@ -56,8 +57,20 @@ export class SyncEngine {
     return this._skippedLargeFiles;
   }
 
+  get lastErrorDetail(): string {
+    return this._lastErrorDetail;
+  }
+
   onStatusChange(fn: () => void): void {
     this.statusListeners.push(fn);
+  }
+
+  retrySync(): void {
+    if (this._status === "error" && this.dirtyPaths.size > 0) {
+      this._lastErrorDetail = "";
+      this.setStatus("idle", this.dirtyPaths.size);
+      this.scheduleFlush();
+    }
   }
 
   updateSettings(settings: Drive9Settings): void {
@@ -176,17 +189,20 @@ export class SyncEngine {
       this.setStatus("syncing", paths.length);
 
       let errorOccurred = false;
+      let lastFailedPath = "";
 
       for (const path of paths) {
         try {
           await this.pushOne(path);
         } catch (e) {
           errorOccurred = true;
+          lastFailedPath = path;
           console.error(`[drive9] push failed: ${path}`, e instanceof Error ? e.message : sanitizeError(String(e)));
           this.dirtyPaths.add(path);
         }
       }
 
+      this._lastErrorDetail = lastFailedPath;
       this.setStatus(errorOccurred ? "error" : "idle", this.dirtyPaths.size);
       await this.persistData();
     });

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -4,9 +4,10 @@ import { IgnoreMatcher } from "./ignore";
 import type { ShadowStore } from "./shadow-store";
 import type { SyncState, Drive9Settings } from "./types";
 
-export type SyncStatus = "idle" | "syncing" | "error";
+export type SyncStatus = "idle" | "syncing" | "error" | "offline";
 
 const LOCAL_EVENT_SUPPRESS_WINDOW_MS = 1000;
+const OFFLINE_THRESHOLD = 3; // consecutive network failures before going offline
 
 /**
  * SyncEngine owns the local/remote sync state machine.
@@ -23,6 +24,7 @@ export class SyncEngine {
   private _uploadProgressText = "";
   private _skippedLargeFiles: string[] = [];
   private _lastErrorDetail = "";
+  private _consecutiveNetworkFailures = 0;
   private statusListeners: Array<() => void> = [];
 
   private shadowStore: ShadowStore | null = null;
@@ -66,8 +68,9 @@ export class SyncEngine {
   }
 
   retrySync(): void {
-    if (this._status === "error" && this.dirtyPaths.size > 0) {
+    if ((this._status === "error" || this._status === "offline") && this.dirtyPaths.size > 0) {
       this._lastErrorDetail = "";
+      this._consecutiveNetworkFailures = 0;
       this.setStatus("idle", this.dirtyPaths.size);
       this.scheduleFlush();
     }
@@ -190,20 +193,31 @@ export class SyncEngine {
 
       let errorOccurred = false;
       let lastFailedPath = "";
+      let networkError = false;
 
       for (const path of paths) {
         try {
           await this.pushOne(path);
+          this._consecutiveNetworkFailures = 0;
         } catch (e) {
           errorOccurred = true;
           lastFailedPath = path;
+          if (this.isNetworkError(e)) {
+            networkError = true;
+          }
           console.error(`[drive9] push failed: ${path}`, e instanceof Error ? e.message : sanitizeError(String(e)));
           this.dirtyPaths.add(path);
         }
       }
 
       this._lastErrorDetail = lastFailedPath;
-      this.setStatus(errorOccurred ? "error" : "idle", this.dirtyPaths.size);
+      if (networkError) {
+        this._consecutiveNetworkFailures++;
+      }
+      const finalStatus: SyncStatus = errorOccurred
+        ? (this._consecutiveNetworkFailures >= OFFLINE_THRESHOLD ? "offline" : "error")
+        : "idle";
+      this.setStatus(finalStatus, this.dirtyPaths.size);
       await this.persistData();
     });
   }
@@ -491,5 +505,18 @@ export class SyncEngine {
         // Ignore status listener failures.
       }
     }
+  }
+
+  private isNetworkError(e: unknown): boolean {
+    if (e instanceof Drive9Error) {
+      // 0 = no response (network), 502/503/504 = server unreachable
+      return e.status === 0 || e.status >= 502;
+    }
+    if (e instanceof TypeError) {
+      // fetch() throws TypeError on network failure
+      return true;
+    }
+    const msg = e instanceof Error ? e.message : "";
+    return /network|fetch|ECONNREFUSED|ENOTFOUND|ETIMEDOUT/i.test(msg);
   }
 }

--- a/obsidian-plugin/src/types.ts
+++ b/obsidian-plugin/src/types.ts
@@ -81,6 +81,8 @@ export interface SyncState {
   deleteDetectionSource?: "polling" | "sse";
   /** Number of consecutive polls where this file was absent from remote. */
   consecutiveAbsences?: number;
+  /** Fingerprint of a dismissed conflict (path:remoteRevision). Suppresses re-popup until conflict changes. */
+  dismissedFingerprint?: string;
 }
 
 /** Persisted plugin data (settings + sync state). */


### PR DESCRIPTION
## Summary

P0+P1 UX improvements for the drive9 Obsidian plugin, based on @qiffang's UX optimization suggestions refined with @adversary-1's review.

### P0 — Bug fixes
- **Conflict infinite popup**: Dismissed conflicts record a `dismissedFingerprint` (`path:revision`) and won't re-popup until the conflict actually changes (new remote revision)
- **Error recovery**: Status bar shows the failed file name (`✗ drive9: notes/foo.md failed`), new `drive9-retry-sync` command re-queues dirty paths

### P1 — High ROI
- **Ribbon icon**: Search entry point via ribbon magnifying glass icon (replaces reliance on hotkey)
- **Status bar clickable**: Click opens sync panel Notice showing conflict count, pending files, error detail, retry instructions
- **Remove default `Cmd+Shift+S`**: Avoids conflicting with Obsidian's built-in save; users configure their own binding
- **Conflict count in status bar**: Shows `⚠ drive9: N conflicts` when idle with unresolved conflicts
- **First push progress**: `push_all` shows `queuing 42/500 files` with stable denominator

### Files changed
- `conflict-resolver.ts` — fingerprint check before showing modal, set on dismiss
- `sync-engine.ts` — `lastErrorDetail` getter, `retrySync()` method
- `main.ts` — ribbon icon, retry command, clickable status bar, sync panel, conflict count, push progress
- `types.ts` — `dismissedFingerprint` field on `SyncState`

## Test plan
- [ ] Trigger a conflict, dismiss modal → verify it doesn't re-popup on next 10s cycle
- [ ] Trigger a new conflict (different remote revision) → verify modal appears again
- [ ] Cause a push error (e.g., disconnect server) → verify status bar shows file name
- [ ] Run "Retry failed sync" command → verify sync retries
- [ ] Click ribbon icon → verify search modal opens
- [ ] Click status bar → verify sync panel Notice appears with correct details
- [ ] First run with empty remote → verify "queuing X/Y files" progress in status bar
- [ ] Verify no default hotkey conflict with Cmd+Shift+S

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clickable status bar displays detailed sync information panel
  * Added retry sync command to recover from sync errors
  * Status bar now shows conflict counts and specific error details

* **Improvements**
  * Dismissed conflicts no longer re-prompt until remote changes occur
  * Enhanced error tracking with specific failure path details
  * Improved status updates during initial file sync

<!-- end of auto-generated comment: release notes by coderabbit.ai -->