### PR TITLE
feat(obsidian): UX improvements P0 + P1

### DIFF
--- a/obsidian-plugin/src/conflict-resolver.ts
+++ b/obsidian-plugin/src/conflict-resolver.ts
@@ -93,14 +93,19 @@ export class ConflictResolver {
       remoteStat = { revision: 0, mtime: 0, size: remoteData.byteLength };
     }
 
-    // Check if this conflict was recently dismissed with the same fingerprint
-    const fingerprint = conflictFingerprint(path, remoteStat.revision, state.lastSyncedContentHash);
-    if (
-      state.conflictDismissedFingerprint === fingerprint &&
-      state.conflictDismissedAt &&
-      Date.now() - state.conflictDismissedAt < CONFLICT_DISMISS_MS
-    ) {
-      return;
+    // Check if this conflict was recently dismissed with the same fingerprint.
+    // Only use fingerprint when we have a real revision — fallback revision 0
+    // is ambiguous and could suppress unrelated future conflicts.
+    const hasRealRevision = remoteStat.revision > 0;
+    if (hasRealRevision) {
+      const fingerprint = conflictFingerprint(path, remoteStat.revision, state.lastSyncedContentHash);
+      if (
+        state.conflictDismissedFingerprint === fingerprint &&
+        state.conflictDismissedAt &&
+        Date.now() - state.conflictDismissedAt < CONFLICT_DISMISS_MS
+      ) {
+        return;
+      }
     }
 
     const localData = await this.vault.readBinary(localFile);
@@ -120,9 +125,13 @@ export class ConflictResolver {
     );
     const choice = await new ConflictModal(this.app, info).open();
     if (choice === null) {
-      // User dismissed modal — suppress for 30 min with this fingerprint
-      state.conflictDismissedFingerprint = fingerprint;
-      state.conflictDismissedAt = Date.now();
+      // User dismissed modal — suppress for 30 min, but only if we have a
+      // reliable fingerprint (real revision). Otherwise let it re-trigger.
+      if (hasRealRevision) {
+        const fingerprint = conflictFingerprint(path, remoteStat.revision, state.lastSyncedContentHash);
+        state.conflictDismissedFingerprint = fingerprint;
+        state.conflictDismissedAt = Date.now();
+      }
       return;
     }
     // Clear dismiss state on explicit resolution

--- a/obsidian-plugin/src/conflict-resolver.ts
+++ b/obsidian-plugin/src/conflict-resolver.ts
@@ -6,6 +6,8 @@ import { ConflictModal, createConflictInfo, isTextFile } from "./conflict-modal"
 import type { ConflictChoice } from "./conflict-modal";
 import type { SyncState } from "./types";
 
+const CONFLICT_DISMISS_MS = 30 * 60_000; // 30 minutes
+
 /**
  * ConflictResolver handles conflict and remote_deleted states
  * produced by the SyncEngine.
@@ -91,6 +93,16 @@ export class ConflictResolver {
       remoteStat = { revision: 0, mtime: 0, size: remoteData.byteLength };
     }
 
+    // Check if this conflict was recently dismissed with the same fingerprint
+    const fingerprint = conflictFingerprint(path, remoteStat.revision, state.lastSyncedContentHash);
+    if (
+      state.conflictDismissedFingerprint === fingerprint &&
+      state.conflictDismissedAt &&
+      Date.now() - state.conflictDismissedAt < CONFLICT_DISMISS_MS
+    ) {
+      return;
+    }
+
     const localData = await this.vault.readBinary(localFile);
 
     if (isTextFile(path)) {
@@ -108,9 +120,14 @@ export class ConflictResolver {
     );
     const choice = await new ConflictModal(this.app, info).open();
     if (choice === null) {
-      // User dismissed modal — keep conflict for next cycle
+      // User dismissed modal — suppress for 30 min with this fingerprint
+      state.conflictDismissedFingerprint = fingerprint;
+      state.conflictDismissedAt = Date.now();
       return;
     }
+    // Clear dismiss state on explicit resolution
+    delete state.conflictDismissedFingerprint;
+    delete state.conflictDismissedAt;
     await this.applyChoice(path, choice, localFile, localData, remoteData, remoteStat.revision);
   }
 
@@ -296,6 +313,10 @@ function makeConflictPath(path: string): string {
     return `${path}.conflict`;
   }
   return `${path.slice(0, lastDot)}.conflict${path.slice(lastDot)}`;
+}
+
+function conflictFingerprint(path: string, remoteRevision: number, contentHash?: string): string {
+  return `${path}:${remoteRevision}:${contentHash ?? ""}`;
 }
 
 function decodeText(data: ArrayBuffer): string {

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -6,6 +6,7 @@ import { ShadowStore } from "./shadow-store";
 import { ConflictResolver } from "./conflict-resolver";
 import { Drive9SettingTab } from "./settings";
 import { Drive9SearchModal } from "./search-modal";
+import { SyncPanelModal, buildSyncPanelInfo } from "./sync-panel";
 import { runFirstRunReconciliation, pullAllRemote } from "./first-run";
 import type { PluginData, Drive9Settings, SyncState } from "./types";
 import { DEFAULT_PLUGIN_DATA, DEFAULT_SETTINGS } from "./types";
@@ -71,21 +72,39 @@ export default class Drive9Plugin extends Plugin {
     }
 
     this.statusBarEl = this.addStatusBarItem();
+    this.statusBarEl.addEventListener("click", () => this.openSyncPanel());
+    this.statusBarEl.style.cursor = "pointer";
     this.updateStatusBar();
     this.syncEngine.onStatusChange(() => this.updateStatusBar());
 
     this.addSettingTab(new Drive9SettingTab(this.app, this));
 
+    this.addRibbonIcon("search", "Search drive9", () => {
+      if (!this.settings.serverUrl) {
+        new Notice("drive9: configure server URL in settings first");
+        return;
+      }
+      new Drive9SearchModal(this.app, this.client).open();
+    });
+
     this.addCommand({
       id: "drive9-search",
       name: "Search (drive9)",
-      hotkeys: [{ modifiers: ["Mod", "Shift"], key: "s" }],
       callback: () => {
         if (!this.settings.serverUrl) {
           new Notice("drive9: configure server URL in settings first");
           return;
         }
         new Drive9SearchModal(this.app, this.client).open();
+      },
+    });
+
+    this.addCommand({
+      id: "drive9-retry-sync",
+      name: "Retry failed sync (drive9)",
+      callback: () => {
+        this.syncEngine.retryFailed();
+        new Notice("drive9: retrying failed files...");
       },
     });
 
@@ -263,6 +282,30 @@ export default class Drive9Plugin extends Plugin {
     }
   }
 
+  private openSyncPanel(): void {
+    const engine = this.syncEngine;
+    if (!engine) return;
+    const info = buildSyncPanelInfo(
+      this.syncStates,
+      engine.pendingCount,
+      engine.skippedLargeFiles,
+      engine.lastErrorPath,
+      engine.status === "error",
+      engine.status === "idle" && engine.consecutiveNetworkFailures >= 3,
+    );
+    new SyncPanelModal(
+      this.app,
+      info,
+      () => {
+        engine.retryFailed();
+        new Notice("drive9: retrying failed files...");
+      },
+      (path) => {
+        void this.app.workspace.openLinkText(path, "", false);
+      },
+    ).open();
+  }
+
   private updateStatusBar(): void {
     const engine = this.syncEngine;
     if (!engine) return;
@@ -270,17 +313,31 @@ export default class Drive9Plugin extends Plugin {
     const skipped = engine.skippedLargeFiles.length;
     switch (engine.status) {
       case "syncing": {
-        const progress = engine.uploadProgressText;
-        if (progress) {
-          this.setStatusBar(`↕ drive9: ${progress}`);
+        const upload = engine.uploadProgressText;
+        const push = engine.pushProgressText;
+        if (upload) {
+          this.setStatusBar(`↕ drive9: ${upload}`);
+        } else if (push) {
+          this.setStatusBar(`↕ drive9: syncing ${push}`);
         } else {
           this.setStatusBar(`↕ drive9: syncing ${engine.pendingCount} files`);
         }
         break;
       }
-      case "error":
-        this.setStatusBar("✗ drive9: error");
+      case "error": {
+        if (engine.consecutiveNetworkFailures >= 3) {
+          this.setStatusBar("◌ drive9: offline");
+        } else {
+          const errPath = engine.lastErrorPath;
+          if (errPath) {
+            const name = errPath.includes("/") ? errPath.slice(errPath.lastIndexOf("/") + 1) : errPath;
+            this.setStatusBar(`✗ drive9: failed ${name}`);
+          } else {
+            this.setStatusBar("✗ drive9: error");
+          }
+        }
         break;
+      }
       case "idle":
         if (engine.pendingCount > 0) {
           this.setStatusBar(`↕ drive9: queued ${engine.pendingCount} files`);

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -290,8 +290,8 @@ export default class Drive9Plugin extends Plugin {
       engine.pendingCount,
       engine.skippedLargeFiles,
       engine.lastErrorPath,
-      engine.status === "error",
-      engine.status === "idle" && engine.consecutiveNetworkFailures >= 3,
+      engine.status === "error" || engine.status === "offline",
+      engine.status === "offline",
     );
     new SyncPanelModal(
       this.app,
@@ -325,19 +325,18 @@ export default class Drive9Plugin extends Plugin {
         break;
       }
       case "error": {
-        if (engine.consecutiveNetworkFailures >= 3) {
-          this.setStatusBar("◌ drive9: offline");
+        const errPath = engine.lastErrorPath;
+        if (errPath) {
+          const name = errPath.includes("/") ? errPath.slice(errPath.lastIndexOf("/") + 1) : errPath;
+          this.setStatusBar(`✗ drive9: failed ${name}`);
         } else {
-          const errPath = engine.lastErrorPath;
-          if (errPath) {
-            const name = errPath.includes("/") ? errPath.slice(errPath.lastIndexOf("/") + 1) : errPath;
-            this.setStatusBar(`✗ drive9: failed ${name}`);
-          } else {
-            this.setStatusBar("✗ drive9: error");
-          }
+          this.setStatusBar("✗ drive9: error");
         }
         break;
       }
+      case "offline":
+        this.setStatusBar("◌ drive9: offline");
+        break;
       case "idle":
         if (engine.pendingCount > 0) {
           this.setStatusBar(`↕ drive9: queued ${engine.pendingCount} files`);

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -4,7 +4,7 @@ import { IgnoreMatcher } from "./ignore";
 import type { ShadowStore } from "./shadow-store";
 import type { SyncState, Drive9Settings } from "./types";
 
-export type SyncStatus = "idle" | "syncing" | "error";
+export type SyncStatus = "idle" | "syncing" | "error" | "offline";
 
 const LOCAL_EVENT_SUPPRESS_WINDOW_MS = 1000;
 
@@ -223,7 +223,10 @@ export class SyncEngine {
       if (!errorOccurred) {
         this._lastErrorPath = "";
       }
-      this.setStatus(errorOccurred ? "error" : "idle", this.dirtyPaths.size);
+      const finalStatus: SyncStatus = errorOccurred
+        ? (this._consecutiveNetworkFailures >= 3 ? "offline" : "error")
+        : "idle";
+      this.setStatus(finalStatus, this.dirtyPaths.size);
       await this.persistData();
     });
   }

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -21,7 +21,10 @@ export class SyncEngine {
   private _status: SyncStatus = "idle";
   private _pendingCount = 0;
   private _uploadProgressText = "";
+  private _pushProgressText = "";
   private _skippedLargeFiles: string[] = [];
+  private _lastErrorPath = "";
+  private _consecutiveNetworkFailures = 0;
   private statusListeners: Array<() => void> = [];
 
   private shadowStore: ShadowStore | null = null;
@@ -52,12 +55,31 @@ export class SyncEngine {
     return this._uploadProgressText;
   }
 
+  get pushProgressText(): string {
+    return this._pushProgressText;
+  }
+
   get skippedLargeFiles(): string[] {
     return this._skippedLargeFiles;
   }
 
+  get lastErrorPath(): string {
+    return this._lastErrorPath;
+  }
+
+  get consecutiveNetworkFailures(): number {
+    return this._consecutiveNetworkFailures;
+  }
+
   onStatusChange(fn: () => void): void {
     this.statusListeners.push(fn);
+  }
+
+  retryFailed(): void {
+    if (this.dirtyPaths.size > 0) {
+      this._lastErrorPath = "";
+      this.scheduleFlush();
+    }
   }
 
   updateSettings(settings: Drive9Settings): void {
@@ -173,20 +195,34 @@ export class SyncEngine {
       this.dirtyPaths.clear();
       this._skippedLargeFiles = [];
 
-      this.setStatus("syncing", paths.length);
+      const total = paths.length;
+      this.setStatus("syncing", total);
 
       let errorOccurred = false;
+      let completed = 0;
 
       for (const path of paths) {
+        if (total > 1) {
+          this._pushProgressText = `${completed + 1}/${total}`;
+          this.notifyStatusChange();
+        }
         try {
           await this.pushOne(path);
+          this._consecutiveNetworkFailures = 0;
         } catch (e) {
           errorOccurred = true;
+          this._lastErrorPath = path;
+          this._consecutiveNetworkFailures++;
           console.error(`[drive9] push failed: ${path}`, e instanceof Error ? e.message : sanitizeError(String(e)));
           this.dirtyPaths.add(path);
         }
+        completed++;
       }
 
+      this._pushProgressText = "";
+      if (!errorOccurred) {
+        this._lastErrorPath = "";
+      }
       this.setStatus(errorOccurred ? "error" : "idle", this.dirtyPaths.size);
       await this.persistData();
     });

--- a/obsidian-plugin/src/sync-panel.ts
+++ b/obsidian-plugin/src/sync-panel.ts
@@ -1,0 +1,123 @@
+import { App, Modal } from "obsidian";
+import type { SyncState } from "./types";
+
+export interface SyncPanelInfo {
+  syncedCount: number;
+  pendingCount: number;
+  conflictPaths: string[];
+  skippedLargeFiles: string[];
+  lastErrorPath: string;
+  isError: boolean;
+  isOffline: boolean;
+}
+
+/**
+ * Modal shown when clicking the drive9 status bar.
+ * Shows sync summary, conflicts, and a retry button if needed.
+ */
+export class SyncPanelModal extends Modal {
+  constructor(
+    app: App,
+    private info: SyncPanelInfo,
+    private onRetry: () => void,
+    private onOpenConflict: (path: string) => void,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("drive9-sync-panel");
+
+    contentEl.createEl("h2", { text: "drive9 Sync Status" });
+
+    const summary = contentEl.createDiv({ cls: "drive9-sync-summary" });
+
+    if (this.info.isOffline) {
+      summary.createDiv({ text: "Status: offline", cls: "drive9-sync-offline" });
+    } else if (this.info.isError) {
+      const errorDiv = summary.createDiv({ cls: "drive9-sync-error" });
+      errorDiv.createSpan({ text: "Status: error" });
+      if (this.info.lastErrorPath) {
+        errorDiv.createSpan({
+          text: ` — ${this.info.lastErrorPath}`,
+          cls: "drive9-sync-error-path",
+        });
+      }
+    } else {
+      summary.createDiv({ text: "Status: synced" });
+    }
+
+    summary.createDiv({ text: `Synced files: ${this.info.syncedCount}` });
+
+    if (this.info.pendingCount > 0) {
+      summary.createDiv({ text: `Pending: ${this.info.pendingCount}` });
+    }
+
+    if (this.info.skippedLargeFiles.length > 0) {
+      summary.createDiv({
+        text: `Skipped (too large): ${this.info.skippedLargeFiles.length}`,
+      });
+    }
+
+    if (this.info.conflictPaths.length > 0) {
+      const conflictSection = contentEl.createDiv({ cls: "drive9-sync-conflicts" });
+      conflictSection.createEl("h3", { text: `Conflicts (${this.info.conflictPaths.length})` });
+      const list = conflictSection.createEl("ul");
+      for (const path of this.info.conflictPaths) {
+        const li = list.createEl("li");
+        const link = li.createEl("a", { text: path, href: "#" });
+        link.addEventListener("click", (e) => {
+          e.preventDefault();
+          this.close();
+          this.onOpenConflict(path);
+        });
+      }
+    }
+
+    const actions = contentEl.createDiv({ cls: "drive9-sync-actions" });
+
+    if (this.info.isError || this.info.pendingCount > 0) {
+      const retryBtn = actions.createEl("button", { text: "Retry Sync", cls: "mod-cta" });
+      retryBtn.addEventListener("click", () => {
+        this.close();
+        this.onRetry();
+      });
+    }
+
+    const closeBtn = actions.createEl("button", { text: "Close" });
+    closeBtn.addEventListener("click", () => this.close());
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+export function buildSyncPanelInfo(
+  syncStates: Record<string, SyncState>,
+  pendingCount: number,
+  skippedLargeFiles: string[],
+  lastErrorPath: string,
+  isError: boolean,
+  isOffline: boolean,
+): SyncPanelInfo {
+  let syncedCount = 0;
+  const conflictPaths: string[] = [];
+
+  for (const [path, state] of Object.entries(syncStates)) {
+    if (state.status === "synced") syncedCount++;
+    if (state.status === "conflict") conflictPaths.push(path);
+  }
+
+  return {
+    syncedCount,
+    pendingCount,
+    conflictPaths,
+    skippedLargeFiles: [...skippedLargeFiles],
+    lastErrorPath,
+    isError,
+    isOffline,
+  };
+}

--- a/obsidian-plugin/src/types.ts
+++ b/obsidian-plugin/src/types.ts
@@ -81,6 +81,10 @@ export interface SyncState {
   deleteDetectionSource?: "polling" | "sse";
   /** Number of consecutive polls where this file was absent from remote. */
   consecutiveAbsences?: number;
+  /** Fingerprint of dismissed conflict (path:revision:hash) to suppress re-popup. */
+  conflictDismissedFingerprint?: string;
+  /** Timestamp when the conflict modal was dismissed. */
+  conflictDismissedAt?: number;
 }
 
 /** Persisted plugin data (settings + sync state). */


### PR DESCRIPTION
## Summary

Implements the P0 + P1 UX improvements aligned with @adversary-1:

### P0 — Bug fixes
- **Conflict infinite popup fix**: Tracks dismiss fingerprint (path + revision + content hash) on `SyncState`. Same conflict suppressed for 30 min after dismiss. New conflict (different fingerprint) re-triggers immediately.
- **Error recovery**: Status bar shows failed file name (`✗ drive9: failed notes.md`). New `drive9-retry-sync` command to retry failed files.
- **Status bar → sync panel**: Clicking status bar opens a modal showing synced count, pending count, conflict list (clickable), skipped-large-files count, and a Retry button.

### P1 — High ROI
- **Ribbon icon**: Search entry point via `addRibbonIcon("search", ...)`.
- **Remove default hotkey**: `Cmd+Shift+S` no longer hardcoded — users bind manually via Obsidian hotkey settings.
- **Push progress**: Stable denominator `syncing 3/42` format. Total snapshotted before push loop starts.
- **Offline detection**: 3+ consecutive network failures → `◌ drive9: offline` in status bar. Resets on success.

### Constraints followed
1. Only P0 + P1 — no P2 items
2. Status bar = sync center (not search)
3. Conflict suppress uses fingerprint (path + revision + hash), not just time
4. Push progress denominator stable (snapshot, then count)

## Test plan
- [ ] Dismiss conflict modal → verify it doesn't re-appear for 30 min (same file)
- [ ] Change file on remote → new conflict triggers immediately despite previous dismiss
- [ ] Fail a sync → status bar shows file name, retry command works
- [ ] Click status bar → sync panel opens with correct counts
- [ ] Ribbon search icon opens search modal
- [ ] `Cmd+Shift+S` no longer triggers search by default
- [ ] Push 10+ files → status bar shows `syncing 3/10` progress
- [ ] Kill server → after 3 failures status bar shows `◌ drive9: offline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)