### PR TITLE
feat(obsidian): sync panel modal + conflict diff preview

### DIFF
--- a/obsidian-plugin/src/conflict-resolver.ts
+++ b/obsidian-plugin/src/conflict-resolver.ts
@@ -1,7 +1,7 @@
 import { App, Vault, TFile, Notice } from "obsidian";
 import { Drive9Client, Drive9Error } from "./client";
 import { ShadowStore } from "./shadow-store";
-import { merge3 } from "./diff3";
+import { merge3, simpleDiff } from "./diff3";
 import { ConflictModal, createConflictInfo, isTextFile } from "./conflict-modal";
 import type { ConflictChoice } from "./conflict-modal";
 import type { SyncState } from "./types";
@@ -106,12 +106,24 @@ export class ConflictResolver {
       return;
     }
 
+    let diffPreview: string | undefined;
+    if (isTextFile(path)) {
+      try {
+        const localText = decodeText(localData);
+        const remoteText = decodeText(remoteData);
+        diffPreview = simpleDiff(localText, remoteText);
+      } catch {
+        // diff preview is best-effort
+      }
+    }
+
     const info = createConflictInfo(
       path,
       localFile.stat.size,
       localFile.stat.mtime,
       remoteStat.size,
       remoteStat.mtime,
+      diffPreview,
     );
     const choice = await new ConflictModal(this.app, info).open();
     if (choice === null) {

--- a/obsidian-plugin/src/diff3.ts
+++ b/obsidian-plugin/src/diff3.ts
@@ -187,6 +187,35 @@ function longestCommonSubsequence(a: string[], b: string[]): LCSEntry[] {
   return result;
 }
 
+/**
+ * Generate a compact unified-style diff preview between two texts.
+ * Shows only changed lines with minimal context, truncated to maxLines.
+ */
+export function simpleDiff(local: string, remote: string, maxLines = 30): string {
+  const localLines = splitLines(local);
+  const remoteLines = splitLines(remote);
+  const edits = diffLines(localLines, remoteLines);
+
+  const output: string[] = [];
+  for (const edit of edits) {
+    if (output.length >= maxLines) {
+      output.push("...");
+      break;
+    }
+    switch (edit.type) {
+      case "remove":
+        output.push(`- ${edit.line}`);
+        break;
+      case "add":
+        output.push(`+ ${edit.line}`);
+        break;
+      // skip "keep" lines to keep preview compact
+    }
+  }
+
+  return output.length > 0 ? output.join("\n") : "(no textual differences)";
+}
+
 function splitLines(text: string): string[] {
   if (text === "") return [];
   return text.split("\n");

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -6,6 +6,7 @@ import { ShadowStore } from "./shadow-store";
 import { ConflictResolver } from "./conflict-resolver";
 import { Drive9SettingTab } from "./settings";
 import { Drive9SearchModal } from "./search-modal";
+import { SyncPanelModal } from "./sync-panel-modal";
 import { runFirstRunReconciliation, pullAllRemote } from "./first-run";
 import type { PluginData, Drive9Settings, SyncState } from "./types";
 import { DEFAULT_PLUGIN_DATA, DEFAULT_SETTINGS } from "./types";
@@ -336,40 +337,31 @@ export default class Drive9Plugin extends Plugin {
 
   private showSyncPanel(): void {
     const engine = this.syncEngine;
-    const conflicts = this.countConflicts();
-    const pending = engine.pendingCount;
-    const skipped = engine.skippedLargeFiles;
-    const status = engine.status;
 
-    const lines: string[] = [];
-
-    if (status === "offline") {
-      lines.push("Offline: server unreachable");
-      lines.push("Run command \"Retry failed sync\" when back online");
-    } else if (status === "error") {
-      const detail = engine.lastErrorDetail;
-      lines.push(detail ? `Error: ${detail} failed to sync` : "Error: sync failed");
-      lines.push("Run command \"Retry failed sync\" to retry");
-    } else if (status === "syncing") {
-      lines.push(`Syncing ${pending} file${pending !== 1 ? "s" : ""}...`);
-    } else {
-      lines.push("Sync: idle");
+    const conflicts: Array<{ path: string; state: SyncState }> = [];
+    for (const [path, state] of Object.entries(this.syncStates)) {
+      if (state.status === "conflict") {
+        conflicts.push({ path, state });
+      }
     }
 
-    if (conflicts > 0) {
-      lines.push(`${conflicts} conflict${conflicts > 1 ? "s" : ""} pending`);
-    }
-    if (pending > 0 && status !== "syncing") {
-      lines.push(`${pending} file${pending !== 1 ? "s" : ""} queued`);
-    }
-    if (skipped.length > 0) {
-      lines.push(`${skipped.length} file${skipped.length > 1 ? "s" : ""} skipped (too large)`);
-    }
-    if (lines.length === 1 && status === "idle" && conflicts === 0) {
-      lines.push("All files synced");
-    }
-
-    new Notice(lines.join("\n"), 8000);
+    new SyncPanelModal(this.app, {
+      status: engine.status,
+      pendingCount: engine.pendingCount,
+      lastErrorDetail: engine.lastErrorDetail,
+      skippedLargeFiles: engine.skippedLargeFiles,
+      conflicts,
+      onRetry: () => {
+        this.syncEngine.retrySync();
+        new Notice("drive9: retrying sync...");
+      },
+      onOpenFile: (path) => {
+        const file = this.app.vault.getAbstractFileByPath(path);
+        if (file instanceof TFile) {
+          void this.app.workspace.getLeaf().openFile(file);
+        }
+      },
+    }).open();
   }
 
   private setStatusBar(text: string): void {

--- a/obsidian-plugin/src/sync-panel-modal.ts
+++ b/obsidian-plugin/src/sync-panel-modal.ts
@@ -1,0 +1,103 @@
+import { App, Modal } from "obsidian";
+import type { SyncStatus } from "./sync-engine";
+import type { SyncState } from "./types";
+
+interface SyncPanelInfo {
+  status: SyncStatus;
+  pendingCount: number;
+  lastErrorDetail: string;
+  skippedLargeFiles: string[];
+  conflicts: Array<{ path: string; state: SyncState }>;
+  onRetry: () => void;
+  onOpenFile: (path: string) => void;
+}
+
+export class SyncPanelModal extends Modal {
+  constructor(
+    app: App,
+    private info: SyncPanelInfo,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("drive9-sync-panel");
+
+    contentEl.createEl("h2", { text: "drive9 Sync Status" });
+
+    // Status section
+    const statusEl = contentEl.createEl("div", { cls: "drive9-sync-status" });
+    const { status } = this.info;
+
+    if (status === "offline") {
+      statusEl.createEl("p", { text: "⏸ Offline — server unreachable", cls: "drive9-status-offline" });
+    } else if (status === "error") {
+      const detail = this.info.lastErrorDetail;
+      statusEl.createEl("p", {
+        text: detail ? `✗ Error: ${detail} failed to sync` : "✗ Error: sync failed",
+        cls: "drive9-status-error",
+      });
+    } else if (status === "syncing") {
+      statusEl.createEl("p", {
+        text: `↕ Syncing ${this.info.pendingCount} file${this.info.pendingCount !== 1 ? "s" : ""}...`,
+        cls: "drive9-status-syncing",
+      });
+    } else {
+      statusEl.createEl("p", { text: "✓ All files synced", cls: "drive9-status-ok" });
+    }
+
+    // Retry button for error/offline states
+    if (status === "error" || status === "offline") {
+      const retryBtn = statusEl.createEl("button", { text: "Retry Sync", cls: "mod-cta" });
+      retryBtn.addEventListener("click", () => {
+        this.info.onRetry();
+        this.close();
+      });
+    }
+
+    // Conflicts section
+    if (this.info.conflicts.length > 0) {
+      const conflictSection = contentEl.createEl("div", { cls: "drive9-sync-conflicts" });
+      conflictSection.createEl("h3", {
+        text: `${this.info.conflicts.length} Conflict${this.info.conflicts.length > 1 ? "s" : ""}`,
+      });
+
+      const list = conflictSection.createEl("ul", { cls: "drive9-conflict-list" });
+      for (const { path } of this.info.conflicts) {
+        const li = list.createEl("li");
+        const link = li.createEl("a", { text: path, cls: "drive9-conflict-link" });
+        link.addEventListener("click", (e) => {
+          e.preventDefault();
+          this.info.onOpenFile(path);
+          this.close();
+        });
+      }
+    }
+
+    // Pending files
+    if (this.info.pendingCount > 0 && status !== "syncing") {
+      contentEl.createEl("p", {
+        text: `${this.info.pendingCount} file${this.info.pendingCount !== 1 ? "s" : ""} queued for sync`,
+        cls: "drive9-sync-pending",
+      });
+    }
+
+    // Skipped files
+    if (this.info.skippedLargeFiles.length > 0) {
+      const skippedSection = contentEl.createEl("div", { cls: "drive9-sync-skipped" });
+      skippedSection.createEl("h3", {
+        text: `${this.info.skippedLargeFiles.length} Skipped (too large)`,
+      });
+      const list = skippedSection.createEl("ul");
+      for (const path of this.info.skippedLargeFiles) {
+        list.createEl("li", { text: path });
+      }
+    }
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}


### PR DESCRIPTION
## Summary

Two UX improvements that increase product polish and help users make better decisions:

### 1. Sync Panel Modal
- Status bar click now opens an **interactive Modal** instead of a transient Notice
- Shows current sync status with appropriate icon (✓/✗/⏸/↕)
- **Retry button** for error/offline states — one click to retry, no need to find the command
- **Clickable conflict file list** — click a conflicted file to open it in the editor
- Pending queue count and skipped large files list

### 2. Conflict Diff Preview
- Text file conflicts now show a **compact unified diff** in the conflict modal
- Only changed lines shown (- removed, + added), max 30 lines, in a collapsible `<details>` section
- Helps users understand what actually changed before choosing Keep Local / Keep Remote / Keep Both
- Binary files skip diff preview (as before)
- Uses the existing `diffLines` LCS implementation from `diff3.ts`

### Files changed
- `sync-panel-modal.ts` — new Modal component
- `main.ts` — import + wire up SyncPanelModal instead of Notice
- `conflict-resolver.ts` — generate diff preview for text files before showing conflict modal
- `diff3.ts` — export `simpleDiff()` function

## Test plan
- [ ] Click status bar → sync panel modal opens with correct status
- [ ] In error/offline state → retry button visible and works
- [ ] With conflicts → conflict files listed and clickable (opens file)
- [ ] Trigger text file conflict → diff preview visible in collapsible section
- [ ] Trigger binary file conflict → no diff preview shown
- [ ] Large diff → truncated at 30 lines with "..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)