### PR TITLE
feat(obsidian): i18n framework with en + zh-CN

### DIFF
--- a/obsidian-plugin/src/conflict-modal.ts
+++ b/obsidian-plugin/src/conflict-modal.ts
@@ -1,4 +1,5 @@
 import { App, Modal } from "obsidian";
+import { t } from "./i18n";
 
 export type ConflictChoice = "keep_local" | "keep_remote" | "keep_both";
 
@@ -38,7 +39,7 @@ export class ConflictModal extends Modal {
     contentEl.empty();
     contentEl.addClass("drive9-conflict-modal");
 
-    contentEl.createEl("h2", { text: "Sync Conflict" });
+    contentEl.createEl("h2", { text: t("conflict.title") });
     contentEl.createEl("p", {
       text: this.info.path,
       cls: "drive9-conflict-path",
@@ -47,35 +48,35 @@ export class ConflictModal extends Modal {
     const table = contentEl.createEl("table", { cls: "drive9-conflict-table" });
     const header = table.createEl("tr");
     header.createEl("th", { text: "" });
-    header.createEl("th", { text: "Local" });
-    header.createEl("th", { text: "Remote" });
+    header.createEl("th", { text: t("conflict.local") });
+    header.createEl("th", { text: t("conflict.remote") });
 
     const sizeRow = table.createEl("tr");
-    sizeRow.createEl("td", { text: "Size" });
+    sizeRow.createEl("td", { text: t("conflict.size") });
     sizeRow.createEl("td", { text: formatSize(this.info.localSize) });
     sizeRow.createEl("td", { text: formatSize(this.info.remoteSize) });
 
     const mtimeRow = table.createEl("tr");
-    mtimeRow.createEl("td", { text: "Modified" });
+    mtimeRow.createEl("td", { text: t("conflict.modified") });
     mtimeRow.createEl("td", { text: formatTime(this.info.localMtime) });
     mtimeRow.createEl("td", { text: formatTime(this.info.remoteMtime) });
 
     if (this.info.diffPreview) {
       const details = contentEl.createEl("details");
-      details.createEl("summary", { text: "Diff preview" });
+      details.createEl("summary", { text: t("conflict.diffPreview") });
       const pre = details.createEl("pre", { cls: "drive9-conflict-diff" });
       pre.createEl("code", { text: this.info.diffPreview });
     }
 
     const actions = contentEl.createEl("div", { cls: "drive9-conflict-actions" });
 
-    const localBtn = actions.createEl("button", { text: "Keep Local", cls: "mod-warning" });
+    const localBtn = actions.createEl("button", { text: t("conflict.keepLocal"), cls: "mod-warning" });
     localBtn.addEventListener("click", () => this.choose("keep_local"));
 
-    const remoteBtn = actions.createEl("button", { text: "Keep Remote" });
+    const remoteBtn = actions.createEl("button", { text: t("conflict.keepRemote") });
     remoteBtn.addEventListener("click", () => this.choose("keep_remote"));
 
-    const bothBtn = actions.createEl("button", { text: "Keep Both" });
+    const bothBtn = actions.createEl("button", { text: t("conflict.keepBoth") });
     bothBtn.addEventListener("click", () => this.choose("keep_both"));
   }
 

--- a/obsidian-plugin/src/conflict-resolver.ts
+++ b/obsidian-plugin/src/conflict-resolver.ts
@@ -3,6 +3,7 @@ import { Drive9Client, Drive9Error } from "./client";
 import { ShadowStore } from "./shadow-store";
 import { merge3, simpleDiff } from "./diff3";
 import { ConflictModal, createConflictInfo, isTextFile } from "./conflict-modal";
+import { t } from "./i18n";
 import type { ConflictChoice } from "./conflict-modal";
 import type { SyncState } from "./types";
 
@@ -189,7 +190,7 @@ export class ConflictResolver {
         status: "synced",
         lastSyncedContentHash: hash,
       };
-      new Notice(`drive9: auto-merged ${path}`);
+      new Notice(t("notice.autoMerged", { path }));
       return true;
     }
 
@@ -219,10 +220,10 @@ export class ConflictResolver {
             status: "synced",
             lastSyncedContentHash: hash,
           };
-          new Notice(`drive9: kept local version of ${path}`);
+          new Notice(t("notice.keptLocal", { path }));
         } catch (e) {
           if (e instanceof Drive9Error && e.status === 409) {
-            new Notice(`drive9: remote changed again for ${path}, retrying next cycle`);
+            new Notice(t("notice.remoteChangedRetry", { path }));
             return;
           }
           throw e;
@@ -244,7 +245,7 @@ export class ConflictResolver {
           status: "synced",
           lastSyncedContentHash: hash,
         };
-        new Notice(`drive9: kept remote version of ${path}`);
+        new Notice(t("notice.keptRemote", { path }));
         break;
       }
 
@@ -279,10 +280,10 @@ export class ConflictResolver {
             status: "synced",
             lastSyncedContentHash: hash,
           };
-          new Notice(`drive9: kept both versions of ${path}`);
+          new Notice(t("notice.keptBoth", { path }));
         } catch (e) {
           if (e instanceof Drive9Error && e.status === 409) {
-            new Notice(`drive9: remote changed again for ${path}, retrying next cycle`);
+            new Notice(t("notice.remoteChangedRetry", { path }));
             return;
           }
           throw e;

--- a/obsidian-plugin/src/first-run.ts
+++ b/obsidian-plugin/src/first-run.ts
@@ -1,5 +1,6 @@
 import { Vault, TFile, Modal, App, Setting, Notice } from "obsidian";
 import { Drive9Client, Drive9Error } from "./client";
+import { t } from "./i18n";
 import type { ShadowStore } from "./shadow-store";
 import type { SyncState } from "./types";
 import { IgnoreMatcher } from "./ignore";
@@ -59,8 +60,8 @@ export async function runFirstRunReconciliation(
   if (!remoteEmpty && localEmpty) {
     const confirmed = await askUser(
       app,
-      "Download from drive9?",
-      `drive9 has ${remoteFiles.size} files. Download them to your vault?`,
+      t("firstRun.downloadTitle"),
+      t("firstRun.downloadMsg", { count: remoteFiles.size }),
     );
     return confirmed ? { action: "pull_all" } : { action: "cancelled" };
   }
@@ -94,16 +95,10 @@ export async function runFirstRunReconciliation(
   }
 
   if (bothPresent.length > 0) {
-    const msg = [
-      `Found ${bothPresent.length} file(s) that exist on both sides.`,
-      "",
-      bothPresent.slice(0, 10).join("\n"),
-      bothPresent.length > 10 ? `...and ${bothPresent.length - 10} more` : "",
-      "",
-      "Without checksums, content equality cannot be verified.",
-      "These files are marked as conflicts until manually resolved.",
-      "Files unique to each side will be synced normally.",
-    ].join("\n");
+    const fileList = bothPresent.slice(0, 10).join("\n");
+    const more = bothPresent.length > 10 ? t("firstRun.andMore", { count: bothPresent.length - 10 }) : "";
+    const files = more ? `${fileList}\n${more}` : fileList;
+    const msg = t("firstRun.bothSidesNotice", { count: bothPresent.length, files });
 
     new Notice(msg, 15000);
   }
@@ -216,7 +211,7 @@ export async function pullAllRemote(
     count++;
   }
 
-  new Notice(`drive9: downloaded ${count} files`);
+  new Notice(t("notice.downloaded", { count }));
 }
 
 // ---------------------------------------------------------------------------
@@ -247,13 +242,13 @@ class ConfirmModal extends Modal {
 
     new Setting(contentEl)
       .addButton((btn) =>
-        btn.setButtonText("Yes").setCta().onClick(() => {
+        btn.setButtonText(t("firstRun.yes")).setCta().onClick(() => {
           this.resolve(true);
           this.close();
         }),
       )
       .addButton((btn) =>
-        btn.setButtonText("Cancel").onClick(() => {
+        btn.setButtonText(t("firstRun.cancel")).onClick(() => {
           this.resolve(false);
           this.close();
         }),

--- a/obsidian-plugin/src/i18n.ts
+++ b/obsidian-plugin/src/i18n.ts
@@ -1,0 +1,52 @@
+/**
+ * Lightweight i18n helper for drive9 Obsidian plugin.
+ *
+ * - Follows Obsidian's language setting (moment.locale())
+ * - Falls back to English for unknown locales
+ * - Supports simple {param} interpolation
+ */
+import en from "./locales/en";
+import zhCN from "./locales/zh-CN";
+import type { LocaleKeys } from "./locales/en";
+
+type LocaleDict = Record<LocaleKeys, string>;
+
+const locales: Record<string, LocaleDict> = {
+  en,
+  "zh-cn": zhCN,
+  zh: zhCN,
+};
+
+let currentLocale: LocaleDict = en;
+
+/**
+ * Detect Obsidian's language and set the active locale.
+ * Call once during plugin onload().
+ */
+export function initLocale(): void {
+  // Obsidian uses moment.locale() which reflects the user's language setting.
+  // Common values: "en", "zh-cn", "zh-tw", "ja", "ko", "de", "fr", etc.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const m = (globalThis as any).moment;
+  const lang = (m?.locale?.() ?? "en").toLowerCase();
+
+  // Try exact match first, then base language
+  currentLocale = locales[lang] ?? locales[lang.split("-")[0]] ?? en;
+}
+
+/**
+ * Translate a key with optional parameter interpolation.
+ *
+ * Usage:
+ *   t("notice.uploading", { count: 42 })
+ *   // → "drive9: uploading 42 files to drive9..."
+ */
+export function t(key: LocaleKeys, params?: Record<string, string | number>): string {
+  let text = currentLocale[key] ?? en[key] ?? key;
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      text = text.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+    }
+  }
+  return text;
+}

--- a/obsidian-plugin/src/locales/en.ts
+++ b/obsidian-plugin/src/locales/en.ts
@@ -71,6 +71,11 @@ const en = {
   "search.minChars": "Type at least 3 characters to search",
   "search.searching": "Searching...",
   "search.noResults": "No results found",
+  "search.navigate": "navigate",
+  "search.open": "open file",
+  "search.dismiss": "dismiss",
+  "search.error": "drive9 search: {detail}",
+  "search.score": "score: {score}",
   "search.notFoundLocally": "drive9: file not found locally — {path}",
 
   // Conflict modal

--- a/obsidian-plugin/src/locales/en.ts
+++ b/obsidian-plugin/src/locales/en.ts
@@ -1,0 +1,112 @@
+/** English locale — the fallback language. */
+const en = {
+  // Settings
+  "settings.title": "drive9 Settings",
+  "settings.serverUrl": "Server URL",
+  "settings.serverUrl.desc": "drive9 server address (e.g. https://api.drive9.ai)",
+  "settings.apiKey": "API Key",
+  "settings.apiKey.desc": "drive9 API key for authentication",
+  "settings.testConnection": "Test Connection",
+  "settings.testConnection.desc": "Verify server URL and API key",
+  "settings.testConnection.btn": "Test",
+  "settings.pushDebounce": "Push Debounce (ms)",
+  "settings.pushDebounce.desc": "Delay before syncing after a file change (default: 2000)",
+  "settings.ignorePaths": "Ignore Paths",
+  "settings.ignorePaths.desc": "Glob patterns to exclude from sync (one per line)",
+  "settings.maxFileSize": "Max File Size (MB)",
+  "settings.maxFileSize.desc": "Skip files larger than this (default: 100)",
+  "settings.mobileMaxFileSize": "Mobile Max File Size (MB)",
+  "settings.mobileMaxFileSize.desc": "Lower file size limit on mobile to avoid OOM (default: 20)",
+  "settings.enterServerUrl": "Please enter a server URL first",
+  "settings.enterApiKey": "Please enter an API key first",
+  "settings.connectionSuccess": "drive9: connection successful!",
+  "settings.connectionFailed": "drive9: connection failed — {error}",
+  "settings.securityWarning": "⚠ Security Warning: ",
+  "settings.gitignoreNoFile": "No .gitignore found. Your API key in .obsidian/ could be committed to git.",
+  "settings.gitignoreNoCoverage": ".gitignore does not cover .obsidian/ — your API key could be committed to git.",
+
+  // Status bar
+  "status.configure": "⚙ drive9: configure in settings",
+  "status.reconciling": "↕ drive9: reconciling...",
+  "status.synced": "✓ drive9: synced",
+  "status.syncedSkipped": "✓ drive9: synced ({count} skipped — too large)",
+  "status.syncing": "↕ drive9: syncing {count} files",
+  "status.syncingProgress": "↕ drive9: {progress}",
+  "status.offline": "⏸ drive9: offline",
+  "status.error": "✗ drive9: error",
+  "status.errorDetail": "✗ drive9: {detail} failed",
+  "status.queued": "↕ drive9: queued {count} files",
+  "status.conflicts": "⚠ drive9: {count} conflict",
+  "status.conflictsPlural": "⚠ drive9: {count} conflicts",
+  "status.firstRunFailed": "✗ drive9: first-run failed",
+  "status.queuing": "↕ drive9: queuing {current}/{total} files",
+
+  // Commands
+  "cmd.search": "Search (drive9)",
+  "cmd.retrySync": "Retry failed sync (drive9)",
+  "cmd.searchRibbon": "Search drive9",
+
+  // Notices — main
+  "notice.configureFirst": "drive9: configure server URL in settings first",
+  "notice.retrying": "drive9: retrying sync...",
+  "notice.firstRunFailed": "drive9: first-run failed — {error}",
+  "notice.uploading": "drive9: uploading {count} files to drive9...",
+  "notice.downloading": "drive9: downloading from drive9...",
+  "notice.downloaded": "drive9: downloaded {count} files",
+  "notice.firstRunCancelled": "drive9: first-run cancelled. Sync is disabled.",
+
+  // Notices — sync engine
+  "notice.skippedLarge": "drive9: skipped {path} ({sizeMB} MB exceeds {limitMB} MB limit)",
+  "notice.conflictDetected": "drive9: conflict detected for {path}",
+
+  // Notices — conflict resolver
+  "notice.autoMerged": "drive9: auto-merged {path}",
+  "notice.keptLocal": "drive9: kept local version of {path}",
+  "notice.keptRemote": "drive9: kept remote version of {path}",
+  "notice.keptBoth": "drive9: kept both versions of {path}",
+  "notice.remoteChangedRetry": "drive9: remote changed again for {path}, retrying next cycle",
+
+  // Search modal
+  "search.placeholder": "Search files in drive9...",
+  "search.minChars": "Type at least 3 characters to search",
+  "search.searching": "Searching...",
+  "search.noResults": "No results found",
+  "search.notFoundLocally": "drive9: file not found locally — {path}",
+
+  // Conflict modal
+  "conflict.title": "Sync Conflict",
+  "conflict.local": "Local",
+  "conflict.remote": "Remote",
+  "conflict.size": "Size",
+  "conflict.modified": "Modified",
+  "conflict.diffPreview": "Diff preview",
+  "conflict.keepLocal": "Keep Local",
+  "conflict.keepRemote": "Keep Remote",
+  "conflict.keepBoth": "Keep Both",
+
+  // Sync panel modal
+  "syncPanel.title": "drive9 Sync Status",
+  "syncPanel.offline": "⏸ Offline — server unreachable",
+  "syncPanel.error": "✗ Error: sync failed",
+  "syncPanel.errorDetail": "✗ Error: {detail} failed to sync",
+  "syncPanel.syncing": "↕ Syncing {count} file...",
+  "syncPanel.syncingPlural": "↕ Syncing {count} files...",
+  "syncPanel.allSynced": "✓ All files synced",
+  "syncPanel.retryBtn": "Retry Sync",
+  "syncPanel.conflictsTitle": "{count} Conflict",
+  "syncPanel.conflictsTitlePlural": "{count} Conflicts",
+  "syncPanel.pendingFiles": "{count} file queued for sync",
+  "syncPanel.pendingFilesPlural": "{count} files queued for sync",
+  "syncPanel.skippedTitle": "{count} Skipped (too large)",
+
+  // First run
+  "firstRun.downloadTitle": "Download from drive9?",
+  "firstRun.downloadMsg": "drive9 has {count} files. Download them to your vault?",
+  "firstRun.yes": "Yes",
+  "firstRun.cancel": "Cancel",
+  "firstRun.bothSidesNotice": "Found {count} file(s) that exist on both sides.\n\n{files}\n\nWithout checksums, content equality cannot be verified.\nThese files are marked as conflicts until manually resolved.\nFiles unique to each side will be synced normally.",
+  "firstRun.andMore": "...and {count} more",
+} as const;
+
+export type LocaleKeys = keyof typeof en;
+export default en;

--- a/obsidian-plugin/src/locales/zh-CN.ts
+++ b/obsidian-plugin/src/locales/zh-CN.ts
@@ -1,0 +1,113 @@
+/** Simplified Chinese locale. */
+import type { LocaleKeys } from "./en";
+
+const zhCN: Record<LocaleKeys, string> = {
+  // Settings
+  "settings.title": "drive9 设置",
+  "settings.serverUrl": "服务器地址",
+  "settings.serverUrl.desc": "drive9 服务器地址（例如 https://api.drive9.ai）",
+  "settings.apiKey": "API 密钥",
+  "settings.apiKey.desc": "drive9 身份验证密钥",
+  "settings.testConnection": "测试连接",
+  "settings.testConnection.desc": "验证服务器地址和 API 密钥",
+  "settings.testConnection.btn": "测试",
+  "settings.pushDebounce": "推送延迟（毫秒）",
+  "settings.pushDebounce.desc": "文件修改后延迟同步的时间（默认：2000）",
+  "settings.ignorePaths": "忽略路径",
+  "settings.ignorePaths.desc": "排除同步的 glob 模式（每行一个）",
+  "settings.maxFileSize": "最大文件大小（MB）",
+  "settings.maxFileSize.desc": "跳过超过此大小的文件（默认：100）",
+  "settings.mobileMaxFileSize": "移动端最大文件大小（MB）",
+  "settings.mobileMaxFileSize.desc": "移动端文件大小上限，避免内存不足（默认：20）",
+  "settings.enterServerUrl": "请先输入服务器地址",
+  "settings.enterApiKey": "请先输入 API 密钥",
+  "settings.connectionSuccess": "drive9：连接成功！",
+  "settings.connectionFailed": "drive9：连接失败 — {error}",
+  "settings.securityWarning": "⚠ 安全警告：",
+  "settings.gitignoreNoFile": "未找到 .gitignore 文件。.obsidian/ 中的 API 密钥可能会被提交到 git。",
+  "settings.gitignoreNoCoverage": ".gitignore 未覆盖 .obsidian/ — API 密钥可能会被提交到 git。",
+
+  // Status bar
+  "status.configure": "⚙ drive9：请在设置中配置",
+  "status.reconciling": "↕ drive9：正在对账...",
+  "status.synced": "✓ drive9：已同步",
+  "status.syncedSkipped": "✓ drive9：已同步（{count} 个文件因过大被跳过）",
+  "status.syncing": "↕ drive9：正在同步 {count} 个文件",
+  "status.syncingProgress": "↕ drive9：{progress}",
+  "status.offline": "⏸ drive9：离线",
+  "status.error": "✗ drive9：错误",
+  "status.errorDetail": "✗ drive9：{detail} 同步失败",
+  "status.queued": "↕ drive9：已排队 {count} 个文件",
+  "status.conflicts": "⚠ drive9：{count} 个冲突",
+  "status.conflictsPlural": "⚠ drive9：{count} 个冲突",
+  "status.firstRunFailed": "✗ drive9：首次运行失败",
+  "status.queuing": "↕ drive9：排队中 {current}/{total} 个文件",
+
+  // Commands
+  "cmd.search": "搜索（drive9）",
+  "cmd.retrySync": "重试失败的同步（drive9）",
+  "cmd.searchRibbon": "搜索 drive9",
+
+  // Notices — main
+  "notice.configureFirst": "drive9：请先在设置中配置服务器地址",
+  "notice.retrying": "drive9：正在重试同步...",
+  "notice.firstRunFailed": "drive9：首次运行失败 — {error}",
+  "notice.uploading": "drive9：正在上传 {count} 个文件到 drive9...",
+  "notice.downloading": "drive9：正在从 drive9 下载...",
+  "notice.downloaded": "drive9：已下载 {count} 个文件",
+  "notice.firstRunCancelled": "drive9：首次运行已取消。同步已禁用。",
+
+  // Notices — sync engine
+  "notice.skippedLarge": "drive9：已跳过 {path}（{sizeMB} MB 超过 {limitMB} MB 限制）",
+  "notice.conflictDetected": "drive9：检测到 {path} 的冲突",
+
+  // Notices — conflict resolver
+  "notice.autoMerged": "drive9：已自动合并 {path}",
+  "notice.keptLocal": "drive9：已保留 {path} 的本地版本",
+  "notice.keptRemote": "drive9：已保留 {path} 的远程版本",
+  "notice.keptBoth": "drive9：已保留 {path} 的两个版本",
+  "notice.remoteChangedRetry": "drive9：{path} 的远程内容再次变更，下个周期重试",
+
+  // Search modal
+  "search.placeholder": "在 drive9 中搜索文件...",
+  "search.minChars": "请输入至少 3 个字符以搜索",
+  "search.searching": "搜索中...",
+  "search.noResults": "未找到结果",
+  "search.notFoundLocally": "drive9：本地未找到文件 — {path}",
+
+  // Conflict modal
+  "conflict.title": "同步冲突",
+  "conflict.local": "本地",
+  "conflict.remote": "远程",
+  "conflict.size": "大小",
+  "conflict.modified": "修改时间",
+  "conflict.diffPreview": "差异预览",
+  "conflict.keepLocal": "保留本地",
+  "conflict.keepRemote": "保留远程",
+  "conflict.keepBoth": "保留两者",
+
+  // Sync panel modal
+  "syncPanel.title": "drive9 同步状态",
+  "syncPanel.offline": "⏸ 离线 — 无法连接服务器",
+  "syncPanel.error": "✗ 错误：同步失败",
+  "syncPanel.errorDetail": "✗ 错误：{detail} 同步失败",
+  "syncPanel.syncing": "↕ 正在同步 {count} 个文件...",
+  "syncPanel.syncingPlural": "↕ 正在同步 {count} 个文件...",
+  "syncPanel.allSynced": "✓ 所有文件已同步",
+  "syncPanel.retryBtn": "重试同步",
+  "syncPanel.conflictsTitle": "{count} 个冲突",
+  "syncPanel.conflictsTitlePlural": "{count} 个冲突",
+  "syncPanel.pendingFiles": "{count} 个文件等待同步",
+  "syncPanel.pendingFilesPlural": "{count} 个文件等待同步",
+  "syncPanel.skippedTitle": "{count} 个文件被跳过（过大）",
+
+  // First run
+  "firstRun.downloadTitle": "从 drive9 下载？",
+  "firstRun.downloadMsg": "drive9 上有 {count} 个文件。是否下载到你的仓库？",
+  "firstRun.yes": "是",
+  "firstRun.cancel": "取消",
+  "firstRun.bothSidesNotice": "发现 {count} 个文件在两端都存在。\n\n{files}\n\n无法在没有校验和的情况下验证内容一致性。\n这些文件将被标记为冲突，直到手动解决。\n仅存在于一端的文件将正常同步。",
+  "firstRun.andMore": "...以及其他 {count} 个文件",
+};
+
+export default zhCN;

--- a/obsidian-plugin/src/locales/zh-CN.ts
+++ b/obsidian-plugin/src/locales/zh-CN.ts
@@ -73,6 +73,11 @@ const zhCN: Record<LocaleKeys, string> = {
   "search.minChars": "请输入至少 3 个字符以搜索",
   "search.searching": "搜索中...",
   "search.noResults": "未找到结果",
+  "search.navigate": "导航",
+  "search.open": "打开文件",
+  "search.dismiss": "关闭",
+  "search.error": "drive9 搜索：{detail}",
+  "search.score": "分数：{score}",
   "search.notFoundLocally": "drive9：本地未找到文件 — {path}",
 
   // Conflict modal

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -8,6 +8,7 @@ import { Drive9SettingTab } from "./settings";
 import { Drive9SearchModal } from "./search-modal";
 import { SyncPanelModal } from "./sync-panel-modal";
 import { runFirstRunReconciliation, pullAllRemote } from "./first-run";
+import { initLocale, t } from "./i18n";
 import type { PluginData, Drive9Settings, SyncState } from "./types";
 import { DEFAULT_PLUGIN_DATA, DEFAULT_SETTINGS } from "./types";
 
@@ -26,6 +27,7 @@ export default class Drive9Plugin extends Plugin {
   private actorId = "";
 
   async onload(): Promise<void> {
+    initLocale();
     await this.loadPluginData();
 
     const needsActorId = !this.actorId;
@@ -81,10 +83,10 @@ export default class Drive9Plugin extends Plugin {
 
     this.addCommand({
       id: "drive9-search",
-      name: "Search (drive9)",
+      name: t("cmd.search"),
       callback: () => {
         if (!this.settings.serverUrl) {
-          new Notice("drive9: configure server URL in settings first");
+          new Notice(t("notice.configureFirst"));
           return;
         }
         new Drive9SearchModal(this.app, this.client).open();
@@ -93,16 +95,16 @@ export default class Drive9Plugin extends Plugin {
 
     this.addCommand({
       id: "drive9-retry-sync",
-      name: "Retry failed sync (drive9)",
+      name: t("cmd.retrySync"),
       callback: () => {
         this.syncEngine.retrySync();
-        new Notice("drive9: retrying sync...");
+        new Notice(t("notice.retrying"));
       },
     });
 
-    this.addRibbonIcon("search", "Search drive9", () => {
+    this.addRibbonIcon("search", t("cmd.searchRibbon"), () => {
       if (!this.settings.serverUrl) {
-        new Notice("drive9: configure server URL in settings first");
+        new Notice(t("notice.configureFirst"));
         return;
       }
       new Drive9SearchModal(this.app, this.client).open();
@@ -115,7 +117,7 @@ export default class Drive9Plugin extends Plugin {
 
   private async onLayoutReady(): Promise<void> {
     if (!this.settings.serverUrl) {
-      this.setStatusBar("⚙ drive9: configure in settings");
+      this.setStatusBar(t("status.configure"));
       return;
     }
 
@@ -124,8 +126,8 @@ export default class Drive9Plugin extends Plugin {
         await this.doFirstRun();
       } catch (e) {
         console.error("[drive9] first-run failed", e instanceof Error ? e.message : sanitizeError(String(e)));
-        new Notice(`drive9: first-run failed — ${e instanceof Error ? e.message : sanitizeError(String(e))}`);
-        this.setStatusBar("✗ drive9: first-run failed");
+        new Notice(t("notice.firstRunFailed", { error: e instanceof Error ? e.message : sanitizeError(String(e)) }));
+        this.setStatusBar(t("status.firstRunFailed"));
         return;
       }
     }
@@ -157,11 +159,11 @@ export default class Drive9Plugin extends Plugin {
       void this.conflictResolver.gcShadows();
     }, 5 * 60_000);
 
-    this.setStatusBar("✓ drive9: synced");
+    this.setStatusBar(t("status.synced"));
   }
 
   private async doFirstRun(): Promise<void> {
-    this.setStatusBar("↕ drive9: reconciling...");
+    this.setStatusBar(t("status.reconciling"));
 
     const result = await runFirstRunReconciliation(
       this.app,
@@ -174,19 +176,19 @@ export default class Drive9Plugin extends Plugin {
       case "push_all": {
         const files = this.app.vault.getFiles();
         const total = files.length;
-        new Notice(`drive9: uploading ${total} files to drive9...`);
-        this.setStatusBar(`↕ drive9: queuing 0/${total} files`);
+        new Notice(t("notice.uploading", { count: total }));
+        this.setStatusBar(t("status.queuing", { current: 0, total }));
         for (let i = 0; i < files.length; i++) {
           this.syncEngine.onLocalCreate(files[i]);
           if ((i + 1) % 50 === 0 || i === files.length - 1) {
-            this.setStatusBar(`↕ drive9: queuing ${i + 1}/${total} files`);
+            this.setStatusBar(t("status.queuing", { current: i + 1, total }));
           }
         }
         break;
       }
 
       case "pull_all":
-        new Notice("drive9: downloading from drive9...");
+        new Notice(t("notice.downloading"));
         await pullAllRemote(
           this.app.vault,
           this.client,
@@ -242,7 +244,7 @@ export default class Drive9Plugin extends Plugin {
         break;
 
       case "cancelled":
-        new Notice("drive9: first-run cancelled. Sync is disabled.");
+        new Notice(t("notice.firstRunCancelled"));
         return;
     }
 
@@ -299,29 +301,29 @@ export default class Drive9Plugin extends Plugin {
       case "syncing": {
         const progress = engine.uploadProgressText;
         if (progress) {
-          this.setStatusBar(`↕ drive9: ${progress}`);
+          this.setStatusBar(t("status.syncingProgress", { progress }));
         } else {
-          this.setStatusBar(`↕ drive9: syncing ${engine.pendingCount} files`);
+          this.setStatusBar(t("status.syncing", { count: engine.pendingCount }));
         }
         break;
       }
       case "offline":
-        this.setStatusBar("⏸ drive9: offline");
+        this.setStatusBar(t("status.offline"));
         break;
       case "error": {
         const detail = engine.lastErrorDetail;
-        this.setStatusBar(detail ? `✗ drive9: ${detail} failed` : "✗ drive9: error");
+        this.setStatusBar(detail ? t("status.errorDetail", { detail }) : t("status.error"));
         break;
       }
       case "idle":
         if (engine.pendingCount > 0) {
-          this.setStatusBar(`↕ drive9: queued ${engine.pendingCount} files`);
+          this.setStatusBar(t("status.queued", { count: engine.pendingCount }));
         } else if (conflicts > 0) {
-          this.setStatusBar(`⚠ drive9: ${conflicts} conflict${conflicts > 1 ? "s" : ""}`);
+          this.setStatusBar(t(conflicts > 1 ? "status.conflictsPlural" : "status.conflicts", { count: conflicts }));
         } else if (skipped > 0) {
-          this.setStatusBar(`✓ drive9: synced (${skipped} skipped — too large)`);
+          this.setStatusBar(t("status.syncedSkipped", { count: skipped }));
         } else {
-          this.setStatusBar("✓ drive9: synced");
+          this.setStatusBar(t("status.synced"));
         }
         break;
     }
@@ -353,7 +355,7 @@ export default class Drive9Plugin extends Plugin {
       conflicts,
       onRetry: () => {
         this.syncEngine.retrySync();
-        new Notice("drive9: retrying sync...");
+        new Notice(t("notice.retrying"));
       },
       onOpenFile: (path) => {
         const file = this.app.vault.getAbstractFileByPath(path);

--- a/obsidian-plugin/src/search-modal.ts
+++ b/obsidian-plugin/src/search-modal.ts
@@ -32,9 +32,9 @@ export class Drive9SearchModal extends SuggestModal<SearchResult> {
     super(app);
     this.setPlaceholder(t("search.placeholder"));
     this.setInstructions([
-      { command: "↑↓", purpose: "navigate" },
-      { command: "↵", purpose: "open file" },
-      { command: "esc", purpose: "dismiss" },
+      { command: "↑↓", purpose: t("search.navigate") },
+      { command: "↵", purpose: t("search.open") },
+      { command: "esc", purpose: t("search.dismiss") },
     ]);
   }
 
@@ -66,9 +66,9 @@ export class Drive9SearchModal extends SuggestModal<SearchResult> {
         this.lastQuery = query;
         this.cachedResults = [];
         if (e instanceof Drive9Error) {
-          new Notice(`drive9 search: ${e.message}`);
+          new Notice(t("search.error", { detail: e.message }));
         } else {
-          new Notice(`drive9 search: ${sanitizeError(e instanceof Error ? e.message : String(e))}`);
+          new Notice(t("search.error", { detail: sanitizeError(e instanceof Error ? e.message : String(e)) }));
         }
       }
       this.searching = false;
@@ -115,7 +115,7 @@ export class Drive9SearchModal extends SuggestModal<SearchResult> {
       parts.push(formatSize(result.size_bytes));
     }
     if (result.score != null) {
-      parts.push(`score: ${result.score.toFixed(2)}`);
+      parts.push(t("search.score", { score: result.score.toFixed(2) }));
     }
     if (parts.length > 0) {
       meta.setText(parts.join(" · "));

--- a/obsidian-plugin/src/search-modal.ts
+++ b/obsidian-plugin/src/search-modal.ts
@@ -1,6 +1,7 @@
 import { App, SuggestModal, Notice, TFile } from "obsidian";
 import { Drive9Client, Drive9Error, sanitizeError } from "./client";
 import { isTextFile } from "./conflict-modal";
+import { t } from "./i18n";
 import type { SearchResult } from "./types";
 
 const DEBOUNCE_MS = 300;
@@ -29,7 +30,7 @@ export class Drive9SearchModal extends SuggestModal<SearchResult> {
     private client: Drive9Client,
   ) {
     super(app);
-    this.setPlaceholder("Search files in drive9...");
+    this.setPlaceholder(t("search.placeholder"));
     this.setInstructions([
       { command: "↑↓", purpose: "navigate" },
       { command: "↵", purpose: "open file" },
@@ -80,19 +81,19 @@ export class Drive9SearchModal extends SuggestModal<SearchResult> {
 
   renderSuggestion(result: SearchResult, el: HTMLElement): void {
     if (result === EMPTY_STATE) {
-      el.createDiv({ cls: "drive9-search-state", text: "Type at least 3 characters to search" });
+      el.createDiv({ cls: "drive9-search-state", text: t("search.minChars") });
       el.style.color = "var(--text-muted)";
       el.style.fontStyle = "italic";
       return;
     }
     if (result === LOADING_STATE) {
-      el.createDiv({ cls: "drive9-search-state", text: "Searching..." });
+      el.createDiv({ cls: "drive9-search-state", text: t("search.searching") });
       el.style.color = "var(--text-muted)";
       el.style.fontStyle = "italic";
       return;
     }
     if (result === NO_RESULTS_STATE) {
-      el.createDiv({ cls: "drive9-search-state", text: "No results found" });
+      el.createDiv({ cls: "drive9-search-state", text: t("search.noResults") });
       el.style.color = "var(--text-muted)";
       el.style.fontStyle = "italic";
       return;
@@ -146,7 +147,7 @@ export class Drive9SearchModal extends SuggestModal<SearchResult> {
     if (file) {
       void this.app.workspace.openLinkText(result.path, "", false);
     } else {
-      new Notice(`drive9: file not found locally — ${result.path}`);
+      new Notice(t("search.notFoundLocally", { path: result.path }));
     }
   }
 

--- a/obsidian-plugin/src/settings.ts
+++ b/obsidian-plugin/src/settings.ts
@@ -1,6 +1,7 @@
 import { App, PluginSettingTab, Setting, Notice } from "obsidian";
 import type Drive9Plugin from "./main";
 import { Drive9Client, sanitizeError } from "./client";
+import { t } from "./i18n";
 
 export class Drive9SettingTab extends PluginSettingTab {
   private validateTimer: ReturnType<typeof setTimeout> | null = null;
@@ -16,11 +17,11 @@ export class Drive9SettingTab extends PluginSettingTab {
     const { containerEl } = this;
     containerEl.empty();
 
-    containerEl.createEl("h2", { text: "drive9 Settings" });
+    containerEl.createEl("h2", { text: t("settings.title") });
 
     new Setting(containerEl)
-      .setName("Server URL")
-      .setDesc("drive9 server address (e.g. https://api.drive9.ai)")
+      .setName(t("settings.serverUrl"))
+      .setDesc(t("settings.serverUrl.desc"))
       .addText((text) =>
         text
           .setPlaceholder("https://api.drive9.ai")
@@ -33,8 +34,8 @@ export class Drive9SettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("API Key")
-      .setDesc("drive9 API key for authentication")
+      .setName(t("settings.apiKey"))
+      .setDesc(t("settings.apiKey.desc"))
       .addText((text) => {
         text.inputEl.type = "password";
         text.inputEl.autocomplete = "off";
@@ -49,17 +50,17 @@ export class Drive9SettingTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName("Test Connection")
-      .setDesc("Verify server URL and API key")
+      .setName(t("settings.testConnection"))
+      .setDesc(t("settings.testConnection.desc"))
       .addButton((btn) =>
-        btn.setButtonText("Test").onClick(async () => {
+        btn.setButtonText(t("settings.testConnection.btn")).onClick(async () => {
           await this.testConnection();
         }),
       );
 
     new Setting(containerEl)
-      .setName("Push Debounce (ms)")
-      .setDesc("Delay before syncing after a file change (default: 2000)")
+      .setName(t("settings.pushDebounce"))
+      .setDesc(t("settings.pushDebounce.desc"))
       .addText((text) =>
         text
           .setPlaceholder("2000")
@@ -74,8 +75,8 @@ export class Drive9SettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Ignore Paths")
-      .setDesc("Glob patterns to exclude from sync (one per line)")
+      .setName(t("settings.ignorePaths"))
+      .setDesc(t("settings.ignorePaths.desc"))
       .addTextArea((text) =>
         text
           .setPlaceholder(".obsidian/**\n.trash/**")
@@ -90,8 +91,8 @@ export class Drive9SettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Max File Size (MB)")
-      .setDesc("Skip files larger than this (default: 100)")
+      .setName(t("settings.maxFileSize"))
+      .setDesc(t("settings.maxFileSize.desc"))
       .addText((text) =>
         text
           .setPlaceholder("100")
@@ -106,8 +107,8 @@ export class Drive9SettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Mobile Max File Size (MB)")
-      .setDesc("Lower file size limit on mobile to avoid OOM (default: 20)")
+      .setName(t("settings.mobileMaxFileSize"))
+      .setDesc(t("settings.mobileMaxFileSize.desc"))
       .addText((text) =>
         text
           .setPlaceholder("20")
@@ -135,11 +136,11 @@ export class Drive9SettingTab extends PluginSettingTab {
 
   private async testConnection(): Promise<void> {
     if (!this.plugin.settings.serverUrl) {
-      new Notice("Please enter a server URL first");
+      new Notice(t("settings.enterServerUrl"));
       return;
     }
     if (!this.plugin.settings.apiKey) {
-      new Notice("Please enter an API key first");
+      new Notice(t("settings.enterApiKey"));
       return;
     }
     try {
@@ -148,10 +149,10 @@ export class Drive9SettingTab extends PluginSettingTab {
         this.plugin.settings.apiKey,
       );
       await testClient.ping();
-      new Notice("drive9: connection successful!");
+      new Notice(t("settings.connectionSuccess"));
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      new Notice(`drive9: connection failed — ${sanitizeError(msg)}`);
+      new Notice(t("settings.connectionFailed", { error: sanitizeError(msg) }));
     }
   }
 
@@ -168,7 +169,7 @@ export class Drive9SettingTab extends PluginSettingTab {
       if (!fs.existsSync(`${vaultRoot}/.git`)) return;
 
       if (!fs.existsSync(gitignorePath)) {
-        this.addGitignoreWarning(containerEl, "No .gitignore found. Your API key in .obsidian/ could be committed to git.");
+        this.addGitignoreWarning(containerEl, t("settings.gitignoreNoFile"));
         return;
       }
 
@@ -186,7 +187,7 @@ export class Drive9SettingTab extends PluginSettingTab {
       });
 
       if (!coversObsidian) {
-        this.addGitignoreWarning(containerEl, ".gitignore does not cover .obsidian/ — your API key could be committed to git.");
+        this.addGitignoreWarning(containerEl, t("settings.gitignoreNoCoverage"));
       }
     } catch {
       // Not on desktop or fs access failed — skip warning
@@ -200,7 +201,7 @@ export class Drive9SettingTab extends PluginSettingTab {
     warning.style.borderRadius = "4px";
     warning.style.backgroundColor = "var(--background-modifier-error)";
     warning.style.color = "var(--text-on-accent)";
-    warning.createEl("strong", { text: "⚠ Security Warning: " });
+    warning.createEl("strong", { text: t("settings.securityWarning") });
     warning.createSpan({ text: message });
   }
 }

--- a/obsidian-plugin/src/sync-engine.ts
+++ b/obsidian-plugin/src/sync-engine.ts
@@ -1,6 +1,7 @@
 import { Vault, TFile, TAbstractFile, Notice, Platform } from "obsidian";
 import { Drive9Client, Drive9Error, sanitizeError } from "./client";
 import { IgnoreMatcher } from "./ignore";
+import { t } from "./i18n";
 import type { ShadowStore } from "./shadow-store";
 import type { SyncState, Drive9Settings } from "./types";
 
@@ -250,7 +251,7 @@ export class SyncEngine {
       const sizeMB = (file.stat.size / (1024 * 1024)).toFixed(1);
       const limitMB = (effectiveMaxSize / (1024 * 1024)).toFixed(0);
       console.warn(`[drive9] skipping large file: ${path} (${file.stat.size} bytes, limit ${effectiveMaxSize})`);
-      new Notice(`drive9: skipped ${path} (${sizeMB} MB exceeds ${limitMB} MB limit)`);
+      new Notice(t("notice.skippedLarge", { path, sizeMB, limitMB }));
       if (!this._skippedLargeFiles.includes(path)) {
         this._skippedLargeFiles.push(path);
       }
@@ -322,7 +323,7 @@ export class SyncEngine {
             status: "conflict",
           };
         }
-        new Notice(`drive9: conflict detected for ${path}`);
+        new Notice(t("notice.conflictDetected", { path }));
         return;
       }
       throw e;
@@ -453,7 +454,7 @@ export class SyncEngine {
     };
 
     if (!wasConflict) {
-      new Notice(`drive9: conflict detected for ${path}`);
+      new Notice(t("notice.conflictDetected", { path }));
     }
   }
 

--- a/obsidian-plugin/src/sync-panel-modal.ts
+++ b/obsidian-plugin/src/sync-panel-modal.ts
@@ -1,4 +1,5 @@
 import { App, Modal } from "obsidian";
+import { t } from "./i18n";
 import type { SyncStatus } from "./sync-engine";
 import type { SyncState } from "./types";
 
@@ -25,32 +26,33 @@ export class SyncPanelModal extends Modal {
     contentEl.empty();
     contentEl.addClass("drive9-sync-panel");
 
-    contentEl.createEl("h2", { text: "drive9 Sync Status" });
+    contentEl.createEl("h2", { text: t("syncPanel.title") });
 
     // Status section
     const statusEl = contentEl.createEl("div", { cls: "drive9-sync-status" });
     const { status } = this.info;
 
     if (status === "offline") {
-      statusEl.createEl("p", { text: "⏸ Offline — server unreachable", cls: "drive9-status-offline" });
+      statusEl.createEl("p", { text: t("syncPanel.offline"), cls: "drive9-status-offline" });
     } else if (status === "error") {
       const detail = this.info.lastErrorDetail;
       statusEl.createEl("p", {
-        text: detail ? `✗ Error: ${detail} failed to sync` : "✗ Error: sync failed",
+        text: detail ? t("syncPanel.errorDetail", { detail }) : t("syncPanel.error"),
         cls: "drive9-status-error",
       });
     } else if (status === "syncing") {
+      const count = this.info.pendingCount;
       statusEl.createEl("p", {
-        text: `↕ Syncing ${this.info.pendingCount} file${this.info.pendingCount !== 1 ? "s" : ""}...`,
+        text: t(count !== 1 ? "syncPanel.syncingPlural" : "syncPanel.syncing", { count }),
         cls: "drive9-status-syncing",
       });
     } else {
-      statusEl.createEl("p", { text: "✓ All files synced", cls: "drive9-status-ok" });
+      statusEl.createEl("p", { text: t("syncPanel.allSynced"), cls: "drive9-status-ok" });
     }
 
     // Retry button for error/offline states
     if (status === "error" || status === "offline") {
-      const retryBtn = statusEl.createEl("button", { text: "Retry Sync", cls: "mod-cta" });
+      const retryBtn = statusEl.createEl("button", { text: t("syncPanel.retryBtn"), cls: "mod-cta" });
       retryBtn.addEventListener("click", () => {
         this.info.onRetry();
         this.close();
@@ -60,8 +62,9 @@ export class SyncPanelModal extends Modal {
     // Conflicts section
     if (this.info.conflicts.length > 0) {
       const conflictSection = contentEl.createEl("div", { cls: "drive9-sync-conflicts" });
+      const cLen = this.info.conflicts.length;
       conflictSection.createEl("h3", {
-        text: `${this.info.conflicts.length} Conflict${this.info.conflicts.length > 1 ? "s" : ""}`,
+        text: t(cLen > 1 ? "syncPanel.conflictsTitlePlural" : "syncPanel.conflictsTitle", { count: cLen }),
       });
 
       const list = conflictSection.createEl("ul", { cls: "drive9-conflict-list" });
@@ -78,8 +81,9 @@ export class SyncPanelModal extends Modal {
 
     // Pending files
     if (this.info.pendingCount > 0 && status !== "syncing") {
+      const pCount = this.info.pendingCount;
       contentEl.createEl("p", {
-        text: `${this.info.pendingCount} file${this.info.pendingCount !== 1 ? "s" : ""} queued for sync`,
+        text: t(pCount !== 1 ? "syncPanel.pendingFilesPlural" : "syncPanel.pendingFiles", { count: pCount }),
         cls: "drive9-sync-pending",
       });
     }
@@ -88,7 +92,7 @@ export class SyncPanelModal extends Modal {
     if (this.info.skippedLargeFiles.length > 0) {
       const skippedSection = contentEl.createEl("div", { cls: "drive9-sync-skipped" });
       skippedSection.createEl("h3", {
-        text: `${this.info.skippedLargeFiles.length} Skipped (too large)`,
+        text: t("syncPanel.skippedTitle", { count: this.info.skippedLargeFiles.length }),
       });
       const list = skippedSection.createEl("ul");
       for (const path of this.info.skippedLargeFiles) {


### PR DESCRIPTION
## Summary
- Add lightweight i18n infrastructure: `t(key, params?)` helper + locale dictionaries
- Extract **all user-visible strings** from 8 source files into `locales/en.ts` and `locales/zh-CN.ts`
- Auto-detect language from Obsidian's `moment.locale()`, fallback to English
- Simple `{param}` interpolation, no heavy ICU/plural framework

## Scope (per @adversary-1 review)
- **Only i18n baseline** — no onboarding interaction changes
- **Only user-visible text** — status bar, Notice, settings, modals, panels, commands
- Console/debug logs and command IDs not localized
- Key design is flat and stable

## Files changed
| File | Change |
|------|--------|
| `src/i18n.ts` | New — `initLocale()` + `t()` helper |
| `src/locales/en.ts` | New — English dictionary (type-safe keys) |
| `src/locales/zh-CN.ts` | New — Simplified Chinese dictionary |
| `src/main.ts` | Extract status bar, Notice, command names |
| `src/settings.ts` | Extract setting names, descriptions, notices |
| `src/search-modal.ts` | Extract placeholder, states, error text |
| `src/conflict-modal.ts` | Extract title, headers, button labels |
| `src/conflict-resolver.ts` | Extract Notice messages |
| `src/sync-panel-modal.ts` | Extract panel text |
| `src/first-run.ts` | Extract dialog text, notices |
| `src/sync-engine.ts` | Extract Notice messages |

## Test plan
- [ ] Build passes (`npm run build` ✅)
- [ ] Set Obsidian to Chinese → verify all UI shows Chinese
- [ ] Set Obsidian to English → verify English fallback
- [ ] Verify no regression in sync, conflict, search functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)