### PR TITLE
Fix CLI smoke upload boundary checksums

### DIFF
--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -428,15 +428,36 @@ if [ "$RUN_CLI_UPLOAD_LIMIT_BOUNDARY" = "1" ]; then
   boundary_ok_payload="$(mktemp)"
   python3 - "cli-limit-${TS}.bin" "$CLI_UPLOAD_LIMIT_BYTES" > "$boundary_ok_payload" <<'PY'
 import base64
-import hashlib
 import json
+import struct
 import sys
+
+def _crc32c_table():
+    poly = 0x82F63B78
+    tbl = []
+    for i in range(256):
+        crc = i
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ poly
+            else:
+                crc >>= 1
+        tbl.append(crc)
+    return tbl
+
+_TABLE = _crc32c_table()
+
+def crc32c(data):
+    crc = 0xFFFFFFFF
+    for b in data:
+        crc = _TABLE[(crc ^ b) & 0xFF] ^ (crc >> 8)
+    return crc ^ 0xFFFFFFFF
 
 path = "/" + sys.argv[1].lstrip("/")
 upload_limit = int(sys.argv[2])
 part_size = 8 * 1024 * 1024
 part = b"\x00" * part_size
-checksum = base64.b64encode(hashlib.sha256(part).digest()).decode()
+checksum = base64.b64encode(struct.pack(">I", crc32c(part))).decode()
 parts = (upload_limit + part_size - 1) // part_size
 print(json.dumps({
     "path": path,
@@ -458,14 +479,35 @@ PY
   boundary_over_payload="$(mktemp)"
   python3 - "cli-limit-over-${TS}.bin" "$over" > "$boundary_over_payload" <<'PY'
 import base64
-import hashlib
 import json
+import struct
 import sys
+
+def _crc32c_table():
+    poly = 0x82F63B78
+    tbl = []
+    for i in range(256):
+        crc = i
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ poly
+            else:
+                crc >>= 1
+        tbl.append(crc)
+    return tbl
+
+_TABLE = _crc32c_table()
+
+def crc32c(data):
+    crc = 0xFFFFFFFF
+    for b in data:
+        crc = _TABLE[(crc ^ b) & 0xFF] ^ (crc >> 8)
+    return crc ^ 0xFFFFFFFF
 
 path = "/" + sys.argv[1].lstrip("/")
 over_limit = int(sys.argv[2])
 part = b"\x00" * (8 * 1024 * 1024)
-checksum = base64.b64encode(hashlib.sha256(part).digest()).decode()
+checksum = base64.b64encode(struct.pack(">I", crc32c(part))).decode()
 print(json.dumps({
     "path": path,
     "total_size": over_limit,


### PR DESCRIPTION
close https://github.com/mem9-ai/drive9/issues/217

## Summary

Fix the CLI smoke upload-limit boundary check so it matches the `/v1/uploads/initiate` contract.

The previous CLI smoke script generated `part_checksums` with SHA-256 for the boundary case, but the v1 upload initiate endpoint expects CRC32C checksums. That caused a false-negative `400` on the at-limit case even though the backend behavior was correct.

## Changes

- switch the upload-limit boundary payload generation in `e2e/cli-smoke-test.sh` from SHA-256 to CRC32C
- align the CLI smoke boundary check with `e2e/api-smoke-test.sh` and the v1 upload implementation

## Validation

Ran against dev endpoint `https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com`:

- `bash e2e/api-smoke-test.sh` -> `94/94 passed`
- `CLI_SOURCE=official bash e2e/cli-smoke-test.sh` -> `30/30 passed`

Also verified the boundary behavior directly after the fix:

- at limit -> `202`
- over limit -> `413`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CLI upload limit boundary test validation to use an improved checksum mechanism for more robust validation of multipart upload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->