### PR TITLE
feat: add python, rust, and typescript clients

### DIFF
--- a/clients/drive9-js/.gitignore
+++ b/clients/drive9-js/.gitignore
@@ -1,0 +1,27 @@
+# Dependencies
+node_modules/
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# Build outputs
+dist/
+*.tsbuildinfo
+
+# Test artifacts
+coverage/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*

--- a/clients/drive9-js/README.md
+++ b/clients/drive9-js/README.md
@@ -1,0 +1,107 @@
+# drive9-js
+
+TypeScript SDK for [drive9](https://github.com/mem9-ai/drive9) — an agent-native filesystem with semantic search.
+
+## Installation
+
+```bash
+npm install drive9
+```
+
+## Quick start
+
+```typescript
+import { Client } from "drive9";
+
+async function main() {
+  const client = Client.defaultClient();
+  // Or: const client = new Client("http://127.0.0.1:9009", "your-api-key");
+
+  await client.write("/hello.txt", new TextEncoder().encode("hello world"));
+  const data = await client.read("/hello.txt");
+  console.log(new TextDecoder().decode(data));
+
+  const info = await client.stat("/hello.txt");
+  console.log(`size=${info.size} revision=${info.revision}`);
+}
+
+main();
+```
+
+## Config auto-loading
+
+`Client.defaultClient()` reads `~/.drive9/config` automatically:
+
+```typescript
+const client = Client.defaultClient();
+```
+
+Expected config format:
+
+```json
+{
+  "server": "http://127.0.0.1:9009",
+  "current_context": "default",
+  "contexts": {
+    "default": { "api_key": "d9_..." }
+  }
+}
+```
+
+Environment variables `DRIVE9_SERVER` and `DRIVE9_API_KEY` take priority over the config file.
+
+## Supported operations
+
+| Operation | Method |
+|-----------|--------|
+| Write file | `client.write(path, data)` |
+| Conditional write | `client.write(path, data, expectedRevision)` |
+| Read file | `client.read(path)` |
+| List directory | `client.list(path)` |
+| Stat | `client.stat(path)` |
+| Delete | `client.delete(path)` |
+| Copy | `client.copy(src, dst)` |
+| Rename | `client.rename(old, new)` |
+| Mkdir | `client.mkdir(path)` |
+| SQL query | `client.sql(query)` |
+| Grep | `client.grep(query, prefix, limit)` |
+| Find | `client.find(prefix, params)` |
+
+### Streaming & multipart
+
+| Operation | Method |
+|-----------|--------|
+| Stream upload | `client.writeStream(path, stream, size, expectedRevision?)` |
+| Resume upload | `client.resumeUpload(path, stream, totalSize)` |
+| Read stream | `client.readStream(path)` |
+| Read range stream | `client.readStreamRange(path, offset, length)` |
+| Stream writer | `client.newStreamWriter(path, totalSize, expectedRevision?)` |
+
+### Patch (partial update)
+
+```typescript
+await client.patchFile(path, newSize, dirtyParts, readPartFn, progressFn, partSize?);
+```
+
+### Vault
+
+| Operation | Method |
+|-----------|--------|
+| Create secret | `client.createVaultSecret(name, fields)` |
+| Update secret | `client.updateVaultSecret(name, fields)` |
+| Delete secret | `client.deleteVaultSecret(name)` |
+| List secrets | `client.listVaultSecrets()` |
+| Issue token | `client.issueVaultToken(agentId, taskId, scope, ttlSeconds)` |
+| Revoke token | `client.revokeVaultToken(tokenId)` |
+| Read secret | `client.readVaultSecret(name)` |
+| Read field | `client.readVaultSecretField(name, field)` |
+
+## Testing
+
+```bash
+npm test
+```
+
+## License
+
+Apache-2.0

--- a/clients/drive9-js/README.md
+++ b/clients/drive9-js/README.md
@@ -25,7 +25,7 @@ async function main() {
   console.log(`size=${info.size} revision=${info.revision}`);
 }
 
-main();
+main().catch(console.error);
 ```
 
 ## Config auto-loading

--- a/clients/drive9-js/examples/basic.ts
+++ b/clients/drive9-js/examples/basic.ts
@@ -1,0 +1,42 @@
+import { Client } from "../src/index.js";
+
+async function main() {
+  const client = Client.defaultClient();
+  // Or: const client = new Client("http://127.0.0.1:9009", "your-api-key");
+
+  const path = "/examples/hello.txt";
+
+  // Write
+  await client.write(path, new TextEncoder().encode("hello from drive9-js"));
+  console.log("Wrote", path);
+
+  // Read back
+  const data = await client.read(path);
+  console.log("Read back:", new TextDecoder().decode(data));
+
+  // Stat
+  const info = await client.stat(path);
+  console.log(`Stat: size=${info.size} revision=${info.revision} isDir=${info.isDir}`);
+
+  // List
+  const entries = await client.list("/examples/");
+  console.log("Entries in /examples/:");
+  for (const e of entries) {
+    console.log(`  ${e.name} (${e.size} bytes)`);
+  }
+
+  // Conditional write
+  await client.write(path, new TextEncoder().encode("updated content"), info.revision);
+  console.log("Conditional write succeeded");
+
+  // Copy and rename
+  await client.copy(path, "/examples/hello-copy.txt");
+  await client.rename("/examples/hello-copy.txt", "/examples/hello-moved.txt");
+
+  // Clean up
+  await client.delete(path);
+  await client.delete("/examples/hello-moved.txt");
+  console.log("Cleaned up");
+}
+
+main().catch(console.error);

--- a/clients/drive9-js/examples/stream.ts
+++ b/clients/drive9-js/examples/stream.ts
@@ -1,0 +1,63 @@
+import { Client } from "../src/index.js";
+
+async function streamToUint8Array(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((a, b) => a + b.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    result.set(c, offset);
+    offset += c.length;
+  }
+  return result;
+}
+
+async function main() {
+  const client = Client.defaultClient();
+  // Or: const client = new Client("http://127.0.0.1:9009", "your-api-key");
+
+  const path = "/examples/stream.bin";
+  const data = new Uint8Array(1_000_000);
+  for (let i = 0; i < data.length; i++) {
+    data[i] = i % 256;
+  }
+  const size = data.length;
+
+  // Stream upload
+  await client.writeStream(path, data, size);
+  console.log(`Stream-uploaded ${size} bytes to ${path}`);
+
+  // Read back as stream
+  const stream = await client.readStream(path);
+  const readBack = await streamToUint8Array(stream);
+  console.log(`Read back ${readBack.length} bytes via stream`);
+
+  // Range read
+  const rangeStream = await client.readStreamRange(path, 0, 1024);
+  const rangeData = await streamToUint8Array(rangeStream);
+  console.log(`Range read ${rangeData.length} bytes`);
+
+  // StreamWriter (manual part-by-part)
+  const writer = client.newStreamWriter(path, size);
+  const partSize = 256_000;
+  let partNum = 1;
+  for (let offset = 0; offset < size; offset += partSize) {
+    const chunk = data.subarray(offset, offset + partSize);
+    await writer.writePart(partNum, chunk);
+    partNum++;
+  }
+  await writer.complete(partNum - 1, new Uint8Array(0));
+  console.log("Completed via StreamWriter");
+
+  // Clean up
+  await client.delete(path);
+  console.log("Cleaned up");
+}
+
+main().catch(console.error);

--- a/clients/drive9-js/examples/vault.ts
+++ b/clients/drive9-js/examples/vault.ts
@@ -1,0 +1,44 @@
+import { Client } from "../src/index.js";
+
+async function main() {
+  const client = Client.defaultClient();
+  // Or: const client = new Client("http://127.0.0.1:9009", "your-api-key");
+
+  const secretName = "example-secret";
+
+  // Create or update
+  await client.createVaultSecret(secretName, {
+    password: "hunter2",
+    api_key: "d9_xxxxxxxx",
+  });
+  console.log("Created vault secret:", secretName);
+
+  // Read
+  const secret = await client.readVaultSecret(secretName);
+  console.log("Read secret:", secret);
+
+  // Read single field
+  const field = await client.readVaultSecretField(secretName, "password");
+  console.log("Password field:", field);
+
+  // List
+  const secrets = await client.listVaultSecrets();
+  console.log("Vault secrets:");
+  for (const s of secrets) {
+    console.log(`  ${s.name}`);
+  }
+
+  // Issue token
+  const token = await client.issueVaultToken("agent-1", "task-1", ["read"], 3600);
+  console.log("Issued token:", token.token_id);
+
+  // Revoke
+  await client.revokeVaultToken(token.token_id);
+  console.log("Revoked token");
+
+  // Clean up
+  await client.deleteVaultSecret(secretName);
+  console.log("Deleted secret");
+}
+
+main().catch(console.error);

--- a/clients/drive9-js/package.json
+++ b/clients/drive9-js/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "drive9",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for drive9 — an agent-native filesystem with semantic search",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts --clean --platform node",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": [
+    "drive9",
+    "filesystem",
+    "sdk"
+  ],
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "msw": "^2.7",
+    "tsup": "^8.4",
+    "typescript": "^5.8",
+    "vitest": "^3.1"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/clients/drive9-js/src/client.ts
+++ b/clients/drive9-js/src/client.ts
@@ -1,0 +1,259 @@
+import * as fs from "fs";
+import * as path from "path";
+import { bodyInit } from "./compat.js";
+import { checkError, ConflictError, Drive9Error, StatusError } from "./error.js";
+import type { FileInfo, SearchResult, StatResult } from "./models.js";
+import { patchFileImpl, type ProgressFn, type ReadPartFn } from "./patch.js";
+import { StreamWriter } from "./stream.js";
+import { readStreamImpl, readStreamRangeImpl, resumeUploadImpl, writeStreamImpl } from "./transfer.js";
+import {
+  createVaultSecret,
+  deleteVaultSecret,
+  issueVaultToken,
+  listReadableVaultSecrets,
+  listVaultSecrets,
+  queryVaultAudit,
+  readVaultSecret,
+  readVaultSecretField,
+  revokeVaultToken,
+  updateVaultSecret,
+} from "./vault.js";
+
+const DEFAULT_SMALL_FILE_THRESHOLD = 50_000;
+
+function loadConfigFile(): { server: string; apiKey?: string } | undefined {
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  const cfgPath = path.join(home, ".drive9", "config");
+  try {
+    const data = fs.readFileSync(cfgPath, "utf-8");
+    const cfg = JSON.parse(data) as {
+      server?: string;
+      current_context?: string;
+      contexts?: Record<string, { api_key?: string }>;
+    };
+    const server = cfg.server || "https://api.drive9.ai";
+    let apiKey: string | undefined;
+    if (cfg.current_context && cfg.contexts) {
+      apiKey = cfg.contexts[cfg.current_context]?.api_key;
+    }
+    return { server, apiKey };
+  } catch {
+    return undefined;
+  }
+}
+
+function loadConfig(): { server: string; apiKey?: string } {
+  const envServer = process.env.DRIVE9_SERVER?.trim() || undefined;
+  const envKey = process.env.DRIVE9_API_KEY?.trim() || undefined;
+  const file = loadConfigFile();
+  return {
+    server: envServer || file?.server || "https://api.drive9.ai",
+    apiKey: envKey || file?.apiKey,
+  };
+}
+
+export class Client {
+  readonly baseUrl: string;
+  readonly apiKey?: string;
+  smallFileThreshold: number;
+
+  constructor(baseUrl?: string, apiKey?: string) {
+    const cfg = loadConfig();
+    this.baseUrl = (baseUrl ?? cfg.server).replace(/\/$/, "");
+    this.apiKey = (apiKey ?? cfg.apiKey) || undefined;
+    this.smallFileThreshold = DEFAULT_SMALL_FILE_THRESHOLD;
+  }
+
+  static defaultClient(): Client {
+    return new Client();
+  }
+
+  withSmallFileThreshold(threshold: number): this {
+    this.smallFileThreshold = threshold;
+    return this;
+  }
+
+  fsUrl(path: string): string {
+    const p = path.startsWith("/") ? path : `/${path}`;
+    return `${this.baseUrl}/v1/fs${p}`;
+  }
+
+  vaultUrl(path: string): string {
+    const p = path.startsWith("/") ? path : `/${path}`;
+    return `${this.baseUrl}/v1/vault${p}`;
+  }
+
+  authHeaders(init?: Record<string, string>): Record<string, string> {
+    const h: Record<string, string> = { ...init };
+    if (this.apiKey) {
+      h["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+    return h;
+  }
+
+  async write(path: string, data: Uint8Array, expectedRevision = -1): Promise<void> {
+    const headers = this.authHeaders({ "Content-Type": "application/octet-stream" });
+    if (expectedRevision >= 0) {
+      headers["X-Dat9-Expected-Revision"] = String(expectedRevision);
+    }
+    const resp = await fetch(this.fsUrl(path), { method: "PUT", headers, body: bodyInit(data) });
+    await checkError(resp);
+  }
+
+  async read(path: string): Promise<Uint8Array> {
+    const resp = await fetch(this.fsUrl(path), { headers: this.authHeaders() });
+    await checkError(resp);
+    return new Uint8Array(await resp.arrayBuffer());
+  }
+
+  async list(path: string): Promise<FileInfo[]> {
+    const resp = await fetch(`${this.fsUrl(path)}?list=1`, { headers: this.authHeaders() });
+    await checkError(resp);
+    const body = (await resp.json()) as { entries?: FileInfo[] };
+    return body.entries || [];
+  }
+
+  async stat(path: string): Promise<StatResult> {
+    const resp = await fetch(this.fsUrl(path), { method: "HEAD", headers: this.authHeaders() });
+    if (resp.status === 404) {
+      throw new Drive9Error(`not found: ${path}`);
+    }
+    if (!resp.ok) {
+      throw new StatusError(`HTTP ${resp.status}`, resp.status);
+    }
+    const size = Number(resp.headers.get("content-length") || "0");
+    const revision = Number(resp.headers.get("x-dat9-revision") || "0");
+    const mtimeHeader = resp.headers.get("x-dat9-mtime");
+    const mtime = mtimeHeader ? new Date(Number(mtimeHeader) * 1000) : undefined;
+    return {
+      size,
+      isDir: resp.headers.get("x-dat9-isdir") === "true",
+      revision,
+      mtime,
+    };
+  }
+
+  async delete(path: string): Promise<void> {
+    const resp = await fetch(this.fsUrl(path), { method: "DELETE", headers: this.authHeaders() });
+    await checkError(resp);
+  }
+
+  async copy(srcPath: string, dstPath: string): Promise<void> {
+    const headers = this.authHeaders({ "X-Dat9-Copy-Source": srcPath });
+    const resp = await fetch(`${this.fsUrl(dstPath)}?copy`, { method: "POST", headers });
+    await checkError(resp);
+  }
+
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    const headers = this.authHeaders({ "X-Dat9-Rename-Source": oldPath });
+    const resp = await fetch(`${this.fsUrl(newPath)}?rename`, { method: "POST", headers });
+    await checkError(resp);
+  }
+
+  async mkdir(path: string): Promise<void> {
+    const resp = await fetch(`${this.fsUrl(path)}?mkdir`, { method: "POST", headers: this.authHeaders() });
+    await checkError(resp);
+  }
+
+  async sql(query: string): Promise<unknown[]> {
+    const resp = await fetch(`${this.baseUrl}/v1/sql`, {
+      method: "POST",
+      headers: this.authHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({ query }),
+    });
+    await checkError(resp);
+    return (await resp.json()) as unknown[];
+  }
+
+  async grep(query: string, pathPrefix: string, limit = 0): Promise<SearchResult[]> {
+    let url = `${this.fsUrl(pathPrefix)}?grep=${encodeURIComponent(query)}`;
+    if (limit > 0) url += `&limit=${limit}`;
+    const resp = await fetch(url, { headers: this.authHeaders() });
+    await checkError(resp);
+    return (await resp.json()) as SearchResult[];
+  }
+
+  async find(pathPrefix: string, params: Record<string, string> = {}): Promise<SearchResult[]> {
+    const qs = new URLSearchParams({ find: "", ...params });
+    const resp = await fetch(`${this.fsUrl(pathPrefix)}?${qs.toString()}`, { headers: this.authHeaders() });
+    await checkError(resp);
+    return (await resp.json()) as SearchResult[];
+  }
+
+  async writeStream(
+    path: string,
+    stream: ReadableStream<Uint8Array> | Uint8Array,
+    size: number,
+    expectedRevision?: number
+  ): Promise<void> {
+    return writeStreamImpl(this, path, stream, size, expectedRevision ?? -1);
+  }
+
+  async readStream(path: string): Promise<ReadableStream<Uint8Array>> {
+    return readStreamImpl(this, path);
+  }
+
+  async readStreamRange(path: string, offset: number, length: number): Promise<ReadableStream<Uint8Array>> {
+    return readStreamRangeImpl(this, path, offset, length);
+  }
+
+  async resumeUpload(path: string, data: Uint8Array): Promise<void> {
+    return resumeUploadImpl(this, path, data);
+  }
+
+  async patchFile(
+    path: string,
+    newSize: number,
+    dirtyParts: number[],
+    readPart: ReadPartFn,
+    progress?: ProgressFn,
+    partSize?: number
+  ): Promise<void> {
+    return patchFileImpl(this, path, newSize, dirtyParts, readPart, progress, partSize);
+  }
+
+  newStreamWriter(path: string, totalSize: number, expectedRevision = -1): StreamWriter {
+    return new StreamWriter(this, path, totalSize, expectedRevision);
+  }
+
+  // Vault methods
+  async createVaultSecret(name: string, fields: Record<string, unknown>): Promise<import("./models.js").VaultSecret> {
+    return createVaultSecret(this, name, fields);
+  }
+
+  async updateVaultSecret(name: string, fields: Record<string, unknown>): Promise<import("./models.js").VaultSecret> {
+    return updateVaultSecret(this, name, fields);
+  }
+
+  async deleteVaultSecret(name: string): Promise<void> {
+    return deleteVaultSecret(this, name);
+  }
+
+  async listVaultSecrets(): Promise<import("./models.js").VaultSecret[]> {
+    return listVaultSecrets(this);
+  }
+
+  async issueVaultToken(agentId: string, taskId: string, scope: string[], ttlSeconds: number): Promise<import("./models.js").VaultTokenIssueResponse> {
+    return issueVaultToken(this, agentId, taskId, scope, ttlSeconds);
+  }
+
+  async revokeVaultToken(tokenId: string): Promise<void> {
+    return revokeVaultToken(this, tokenId);
+  }
+
+  async queryVaultAudit(secretName?: string, limit?: number): Promise<import("./models.js").VaultAuditEvent[]> {
+    return queryVaultAudit(this, secretName, limit);
+  }
+
+  async listReadableVaultSecrets(): Promise<string[]> {
+    return listReadableVaultSecrets(this);
+  }
+
+  async readVaultSecret(name: string): Promise<Record<string, unknown>> {
+    return readVaultSecret(this, name);
+  }
+
+  async readVaultSecretField(name: string, field: string): Promise<string> {
+    return readVaultSecretField(this, name, field);
+  }
+}

--- a/clients/drive9-js/src/client.ts
+++ b/clients/drive9-js/src/client.ts
@@ -221,8 +221,8 @@ export class Client {
     return patchFileImpl(this, path, newSize, dirtyParts, readPart, progress, partSize);
   }
 
-  newStreamWriter(path: string, totalSize: number, expectedRevision = -1): StreamWriter {
-    return new StreamWriter(this, path, totalSize, expectedRevision);
+  newStreamWriter(path: string, totalSize: number, expectedRevision = -1, abortOnError = true): StreamWriter {
+    return new StreamWriter(this, path, totalSize, expectedRevision, abortOnError);
   }
 
   // Vault methods

--- a/clients/drive9-js/src/client.ts
+++ b/clients/drive9-js/src/client.ts
@@ -37,7 +37,11 @@ function loadConfigFile(): { server: string; apiKey?: string } | undefined {
       apiKey = cfg.contexts[cfg.current_context]?.api_key;
     }
     return { server, apiKey };
-  } catch {
+  } catch (err) {
+    if (typeof err === "object" && err && "code" in err && err.code === "ENOENT") {
+      return undefined;
+    }
+    console.warn(`drive9: failed to load config from ${cfgPath}: ${err}`);
     return undefined;
   }
 }
@@ -109,8 +113,13 @@ export class Client {
   async list(path: string): Promise<FileInfo[]> {
     const resp = await fetch(`${this.fsUrl(path)}?list=1`, { headers: this.authHeaders() });
     await checkError(resp);
-    const body = (await resp.json()) as { entries?: FileInfo[] };
-    return body.entries || [];
+    const body = (await resp.json()) as { entries?: Array<{ name: string; size: number; isDir: boolean; mtime?: number }> };
+    return (body.entries || []).map((e) => ({
+      name: e.name,
+      size: e.size,
+      isDir: e.isDir,
+      mtime: e.mtime != null ? new Date(e.mtime * 1000) : undefined,
+    }));
   }
 
   async stat(path: string): Promise<StatResult> {

--- a/clients/drive9-js/src/compat.ts
+++ b/clients/drive9-js/src/compat.ts
@@ -1,0 +1,9 @@
+/** Return a BodyInit accepted by fetch in strict Node typings. */
+export function bodyInit(data: Uint8Array): BodyInit {
+  return Buffer.from(data);
+}
+
+/** Return an ArrayBuffer accepted by crypto.subtle.digest in strict Node typings. */
+export function bufferSource(data: Uint8Array): ArrayBuffer {
+  return data.slice().buffer;
+}

--- a/clients/drive9-js/src/error.ts
+++ b/clients/drive9-js/src/error.ts
@@ -1,0 +1,38 @@
+export class Drive9Error extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "Drive9Error";
+  }
+}
+
+export class StatusError extends Drive9Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "StatusError";
+    this.statusCode = statusCode;
+  }
+}
+
+export class ConflictError extends StatusError {
+  constructor(message: string, statusCode = 409) {
+    super(message, statusCode);
+    this.name = "ConflictError";
+  }
+}
+
+export async function checkError(resp: Response): Promise<Response> {
+  if (resp.ok) return resp;
+  let message = `HTTP ${resp.status}`;
+  try {
+    const body = (await resp.json()) as { error?: string; message?: string };
+    if (body.error) message = body.error;
+    else if (body.message) message = body.message;
+  } catch {
+    // ignore
+  }
+  if (resp.status === 409) {
+    throw new ConflictError(message, resp.status);
+  }
+  throw new StatusError(message, resp.status);
+}

--- a/clients/drive9-js/src/error.ts
+++ b/clients/drive9-js/src/error.ts
@@ -15,24 +15,34 @@ export class StatusError extends Drive9Error {
 }
 
 export class ConflictError extends StatusError {
-  constructor(message: string, statusCode = 409) {
+  serverRevision?: number;
+  constructor(message: string, statusCode = 409, serverRevision?: number) {
     super(message, statusCode);
     this.name = "ConflictError";
+    this.serverRevision = serverRevision;
   }
 }
 
 export async function checkError(resp: Response): Promise<Response> {
   if (resp.ok) return resp;
   let message = `HTTP ${resp.status}`;
+  let serverRevision: number | undefined;
   try {
-    const body = (await resp.json()) as { error?: string; message?: string };
+    const body = (await resp.json()) as {
+      error?: string;
+      message?: string;
+      server_revision?: number;
+    };
     if (body.error) message = body.error;
     else if (body.message) message = body.message;
+    if (typeof body.server_revision === "number") {
+      serverRevision = body.server_revision;
+    }
   } catch {
     // ignore
   }
   if (resp.status === 409) {
-    throw new ConflictError(message, resp.status);
+    throw new ConflictError(message, resp.status, serverRevision);
   }
   throw new StatusError(message, resp.status);
 }

--- a/clients/drive9-js/src/index.ts
+++ b/clients/drive9-js/src/index.ts
@@ -1,0 +1,20 @@
+export { Client } from "./client.js";
+export { Drive9Error, StatusError, ConflictError, checkError } from "./error.js";
+export { StreamWriter } from "./stream.js";
+export type {
+  FileInfo,
+  StatResult,
+  SearchResult,
+  PartURL,
+  UploadPlan,
+  PatchPartURL,
+  PatchPlan,
+  UploadMeta,
+  VaultSecret,
+  VaultTokenIssueResponse,
+  VaultAuditEvent,
+  CompletePart,
+  PresignedPart,
+  UploadPlanV2,
+} from "./models.js";
+export type { ReadPartFn, ProgressFn } from "./patch.js";

--- a/clients/drive9-js/src/models.ts
+++ b/clients/drive9-js/src/models.ts
@@ -1,0 +1,107 @@
+export interface FileInfo {
+  name: string;
+  size: number;
+  isDir: boolean;
+  mtime?: number;
+}
+
+export interface StatResult {
+  size: number;
+  isDir: boolean;
+  revision: number;
+  mtime?: Date;
+}
+
+export interface SearchResult {
+  path: string;
+  name: string;
+  size_bytes: number;
+  score?: number;
+}
+
+export interface PartURL {
+  number: number;
+  url: string;
+  size: number;
+  checksum_sha256?: string;
+  checksum_crc32c?: string;
+  headers?: Record<string, unknown>;
+  expires_at?: string;
+}
+
+export interface UploadPlan {
+  upload_id: string;
+  part_size: number;
+  parts: PartURL[];
+}
+
+export interface PatchPartURL {
+  number: number;
+  url: string;
+  size: number;
+  headers?: Record<string, unknown>;
+  expires_at?: string;
+  read_url?: string;
+  read_headers?: Record<string, unknown>;
+}
+
+export interface PatchPlan {
+  upload_id: string;
+  part_size: number;
+  upload_parts: PatchPartURL[];
+  copied_parts: number[];
+}
+
+export interface UploadMeta {
+  upload_id: string;
+  parts_total: number;
+  status: string;
+  expires_at: string;
+}
+
+export interface VaultSecret {
+  name: string;
+  secret_type: string;
+  revision: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface VaultTokenIssueResponse {
+  token: string;
+  token_id: string;
+  expires_at: string;
+}
+
+export interface VaultAuditEvent {
+  event_id: string;
+  event_type: string;
+  timestamp: string;
+  token_id?: string;
+  agent_id?: string;
+  task_id?: string;
+  secret_name?: string;
+  field_name?: string;
+  adapter?: string;
+  detail?: unknown;
+}
+
+export interface CompletePart {
+  number: number;
+  etag: string;
+}
+
+export interface PresignedPart {
+  number: number;
+  url: string;
+  size: number;
+  headers?: Record<string, unknown>;
+}
+
+export interface UploadPlanV2 {
+  upload_id: string;
+  key: string;
+  part_size: number;
+  total_parts: number;
+}

--- a/clients/drive9-js/src/models.ts
+++ b/clients/drive9-js/src/models.ts
@@ -2,7 +2,8 @@ export interface FileInfo {
   name: string;
   size: number;
   isDir: boolean;
-  mtime?: number;
+  /** UTC epoch seconds from server; converted to Date by the client. */
+  mtime?: Date;
 }
 
 export interface StatResult {
@@ -15,6 +16,7 @@ export interface StatResult {
 export interface SearchResult {
   path: string;
   name: string;
+  /** Mirrors the snake_case field name used by the server API. */
   size_bytes: number;
   score?: number;
 }

--- a/clients/drive9-js/src/patch.ts
+++ b/clients/drive9-js/src/patch.ts
@@ -1,0 +1,104 @@
+import { Client } from "./client.js";
+import { bodyInit, bufferSource } from "./compat.js";
+import { checkError, Drive9Error } from "./error.js";
+import type { PatchPartURL, PatchPlan } from "./models.js";
+
+const DEFAULT_PART_SIZE = 8 * 1024 * 1024;
+
+export type ReadPartFn = (partNumber: number, partSize: number, origData?: Uint8Array) => Uint8Array;
+export type ProgressFn = (uploaded: number, total: number) => void;
+
+export async function patchFileImpl(
+  client: Client,
+  path: string,
+  newSize: number,
+  dirtyParts: number[],
+  readPart: ReadPartFn,
+  progress?: ProgressFn,
+  partSize = DEFAULT_PART_SIZE
+): Promise<void> {
+  const resp = await fetch(client.fsUrl(path), {
+    method: "PATCH",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ new_size: newSize, dirty_parts: dirtyParts, part_size: partSize }),
+  });
+  await checkError(resp);
+  const plan = (await resp.json()) as PatchPlan;
+  const total = plan.upload_parts.reduce((sum, p) => sum + p.size, 0);
+  let uploaded = 0;
+
+  const parallelism = 16;
+  const semaphore = new Semaphore(parallelism);
+  const tasks: Promise<void>[] = [];
+
+  for (const part of plan.upload_parts) {
+    tasks.push(
+      (async () => {
+        await semaphore.acquire();
+        try {
+          await uploadPatchPart(client, part, readPart);
+          uploaded += part.size;
+          if (progress) progress(uploaded, total);
+        } finally {
+          semaphore.release();
+        }
+      })()
+    );
+  }
+  await Promise.all(tasks);
+}
+
+async function uploadPatchPart(client: Client, part: PatchPartURL, readPart: ReadPartFn): Promise<void> {
+  let origData: Uint8Array | undefined;
+  if (part.read_url) {
+    const headers: Record<string, string> = {};
+    if (part.read_headers) {
+      for (const [k, v] of Object.entries(part.read_headers)) {
+        if (typeof v === "string") headers[k] = v;
+      }
+    }
+    const resp = await fetch(part.read_url, { headers });
+    await checkError(resp);
+    origData = new Uint8Array(await resp.arrayBuffer());
+  }
+  const data = readPart(part.number, part.size, origData);
+  const checksum = await sha256Base64(data);
+  const headers: Record<string, string> = { "x-amz-checksum-sha256": checksum };
+  if (part.headers) {
+    for (const [k, v] of Object.entries(part.headers)) {
+      if (typeof v === "string" && k.toLowerCase() !== "host") {
+        headers[k] = v;
+      }
+    }
+  }
+  const resp = await fetch(part.url, { method: "PUT", headers, body: bodyInit(data) });
+  await checkError(resp);
+}
+
+async function sha256Base64(data: Uint8Array): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", bufferSource(data));
+  return Buffer.from(hash).toString("base64");
+}
+
+class Semaphore {
+  private permits: number;
+  private waiters: (() => void)[] = [];
+  constructor(n: number) {
+    this.permits = n;
+  }
+  acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits--;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    } else {
+      this.permits++;
+    }
+  }
+}

--- a/clients/drive9-js/src/patch.ts
+++ b/clients/drive9-js/src/patch.ts
@@ -2,6 +2,7 @@ import { Client } from "./client.js";
 import { bodyInit, bufferSource } from "./compat.js";
 import { checkError, Drive9Error } from "./error.js";
 import type { PatchPartURL, PatchPlan } from "./models.js";
+import { Semaphore } from "./utils.js";
 
 const DEFAULT_PART_SIZE = 8 * 1024 * 1024;
 
@@ -80,25 +81,3 @@ async function sha256Base64(data: Uint8Array): Promise<string> {
   return Buffer.from(hash).toString("base64");
 }
 
-class Semaphore {
-  private permits: number;
-  private waiters: (() => void)[] = [];
-  constructor(n: number) {
-    this.permits = n;
-  }
-  acquire(): Promise<void> {
-    if (this.permits > 0) {
-      this.permits--;
-      return Promise.resolve();
-    }
-    return new Promise((resolve) => this.waiters.push(resolve));
-  }
-  release(): void {
-    const next = this.waiters.shift();
-    if (next) {
-      next();
-    } else {
-      this.permits++;
-    }
-  }
-}

--- a/clients/drive9-js/src/stream.ts
+++ b/clients/drive9-js/src/stream.ts
@@ -1,0 +1,206 @@
+import { Client } from "./client.js";
+import { bodyInit } from "./compat.js";
+import { checkError, Drive9Error } from "./error.js";
+import type { CompletePart, PresignedPart, UploadPlanV2 } from "./models.js";
+
+const UPLOAD_MAX_CONCURRENCY = 16;
+
+interface StreamState {
+  started: boolean;
+  closing: boolean;
+  completed: boolean;
+  aborted: boolean;
+  plan?: UploadPlanV2;
+  uploaded: Map<number, CompletePart>;
+}
+
+export class StreamWriter {
+  private client: Client;
+  private path: string;
+  private totalSize: number;
+  private expectedRevision: number;
+  private state: StreamState;
+  private sem: Semaphore;
+
+  constructor(client: Client, path: string, totalSize: number, expectedRevision = -1) {
+    this.client = client;
+    this.path = path;
+    this.totalSize = totalSize;
+    this.expectedRevision = expectedRevision;
+    this.state = {
+      started: false,
+      closing: false,
+      completed: false,
+      aborted: false,
+      uploaded: new Map(),
+    };
+    this.sem = new Semaphore(UPLOAD_MAX_CONCURRENCY);
+  }
+
+  async writePart(partNum: number, data: Uint8Array): Promise<void> {
+    if (!this.state.started) {
+      try {
+        const plan = await this.initiate();
+        this.state.plan = plan;
+        this.state.started = true;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.includes("v2 upload API not available")) {
+          throw new Drive9Error("streaming upload requires v2 protocol: v2 upload API not available");
+        }
+        throw new Drive9Error(`initiate stream upload: ${msg}`);
+      }
+    }
+    if (this.state.completed) {
+      throw new Drive9Error("stream writer already completed");
+    }
+    if (this.state.aborted) {
+      throw new Drive9Error("stream writer already aborted");
+    }
+    if (this.state.closing) {
+      throw new Drive9Error("stream writer is closing");
+    }
+
+    const plan = this.state.plan!;
+    await this.sem.acquire();
+    const client = this.client;
+    const uploadId = plan.upload_id;
+    const p = await presignOnePart(client, uploadId, partNum);
+    try {
+      const etag = await uploadOnePartV2(client, uploadId, p, data);
+      this.state.uploaded.set(partNum, { number: partNum, etag });
+    } finally {
+      this.sem.release();
+    }
+  }
+
+  async complete(finalPartNum: number, finalPartData: Uint8Array): Promise<void> {
+    if (this.state.completed) {
+      throw new Drive9Error("stream writer already completed");
+    }
+    if (this.state.aborted) {
+      throw new Drive9Error("stream writer already aborted");
+    }
+    this.state.closing = true;
+
+    if (!this.state.started || !this.state.plan) {
+      throw new Drive9Error("stream writer was never started");
+    }
+
+    if (finalPartData.length > 0) {
+      await this.writePart(finalPartNum, finalPartData);
+    }
+
+    const plan = this.state.plan;
+    if (this.state.uploaded.size === 0) {
+      throw new Drive9Error("no parts uploaded in stream upload");
+    }
+    const maxPart = Math.max(...this.state.uploaded.keys());
+    const parts: CompletePart[] = [];
+    for (let i = 1; i <= maxPart; i++) {
+      const part = this.state.uploaded.get(i);
+      if (!part) {
+        throw new Drive9Error(`missing part ${i} in stream upload`);
+      }
+      parts.push(part);
+    }
+
+    await completeUploadV2(this.client, plan.upload_id, parts);
+    this.state.completed = true;
+  }
+
+  async abort(): Promise<void> {
+    if (this.state.completed || this.state.aborted) return;
+    this.state.aborted = true;
+    if (this.state.plan) {
+      await abortUploadV2(this.client, this.state.plan.upload_id);
+    }
+  }
+
+  private async initiate(): Promise<UploadPlanV2> {
+    const resp = await fetch(`${this.client.baseUrl}/v2/uploads/initiate`, {
+      method: "POST",
+      headers: this.client["authHeaders"]({ "Content-Type": "application/json" }),
+      body: JSON.stringify({
+        path: this.path,
+        size: this.totalSize,
+        expected_revision: this.expectedRevision,
+      }),
+    });
+    if (resp.status === 404) {
+      throw new Drive9Error("v2 upload API not available");
+    }
+    await checkError(resp);
+    return (await resp.json()) as UploadPlanV2;
+  }
+}
+
+async function presignOnePart(client: Client, uploadId: string, partNumber: number): Promise<PresignedPart> {
+  const resp = await fetch(`${client.baseUrl}/v2/uploads/${uploadId}/presign`, {
+    method: "POST",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ part_number: partNumber }),
+  });
+  await checkError(resp);
+  return (await resp.json()) as PresignedPart;
+}
+
+async function uploadOnePartV2(
+  client: Client,
+  uploadId: string,
+  part: PresignedPart,
+  data: Uint8Array
+): Promise<string> {
+  const headers: Record<string, string> = {};
+  if (part.headers) {
+    for (const [k, v] of Object.entries(part.headers)) {
+      if (typeof v === "string") headers[k] = v;
+    }
+  }
+  let resp = await fetch(part.url, { method: "PUT", headers, body: bodyInit(data) });
+  if (resp.status === 403) {
+    const fresh = await presignOnePart(client, uploadId, part.number);
+    resp = await fetch(fresh.url, { method: "PUT", headers, body: bodyInit(data) });
+  }
+  await checkError(resp);
+  return resp.headers.get("etag") || "";
+}
+
+async function completeUploadV2(client: Client, uploadId: string, parts: CompletePart[]): Promise<void> {
+  const resp = await fetch(`${client.baseUrl}/v2/uploads/${uploadId}/complete`, {
+    method: "POST",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ parts }),
+  });
+  await checkError(resp);
+}
+
+async function abortUploadV2(client: Client, uploadId: string): Promise<void> {
+  await fetch(`${client.baseUrl}/v2/uploads/${uploadId}/abort`, {
+    method: "POST",
+    headers: client["authHeaders"](),
+  });
+}
+
+class Semaphore {
+  private permits: number;
+  private waiters: (() => void)[] = [];
+  constructor(n: number) {
+    this.permits = n;
+  }
+  acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits--;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    } else {
+      this.permits++;
+    }
+  }
+}

--- a/clients/drive9-js/src/stream.ts
+++ b/clients/drive9-js/src/stream.ts
@@ -13,6 +13,7 @@ interface StreamState {
   aborted: boolean;
   plan?: UploadPlanV2;
   uploaded: Map<number, CompletePart>;
+  err?: Drive9Error;
 }
 
 export class StreamWriter {
@@ -20,16 +21,24 @@ export class StreamWriter {
   private path: string;
   private totalSize: number;
   private expectedRevision: number;
+  private abortOnError: boolean;
   private state: StreamState;
   private sem: Semaphore;
   private inflight: number;
   private inflightZeroResolvers: (() => void)[];
 
-  constructor(client: Client, path: string, totalSize: number, expectedRevision = -1) {
+  constructor(
+    client: Client,
+    path: string,
+    totalSize: number,
+    expectedRevision = -1,
+    abortOnError = true
+  ) {
     this.client = client;
     this.path = path;
     this.totalSize = totalSize;
     this.expectedRevision = expectedRevision;
+    this.abortOnError = abortOnError;
     this.state = {
       started: false,
       closing: false,
@@ -43,6 +52,9 @@ export class StreamWriter {
   }
 
   async writePart(partNum: number, data: Uint8Array): Promise<void> {
+    if (partNum < 1) {
+      throw new Drive9Error("part number must be >= 1");
+    }
     if (!this.state.started) {
       try {
         const plan = await this.initiate();
@@ -56,6 +68,9 @@ export class StreamWriter {
         throw new Drive9Error(`initiate stream upload: ${msg}`);
       }
     }
+    if (this.state.err) {
+      throw this.state.err;
+    }
     if (this.state.completed) {
       throw new Drive9Error("stream writer already completed");
     }
@@ -67,6 +82,15 @@ export class StreamWriter {
     }
 
     const plan = this.state.plan!;
+    if (plan.total_parts && partNum > plan.total_parts) {
+      throw new Drive9Error(
+        `part number ${partNum} exceeds total_parts ${plan.total_parts}`
+      );
+    }
+    if (this.state.uploaded.has(partNum)) {
+      throw new Drive9Error(`part ${partNum} already uploaded`);
+    }
+
     await this.sem.acquire();
     this.inflight++;
     const client = this.client;
@@ -75,6 +99,13 @@ export class StreamWriter {
       const p = await presignOnePart(client, uploadId, partNum);
       const etag = await uploadOnePartV2(client, uploadId, p, data);
       this.state.uploaded.set(partNum, { number: partNum, etag });
+    } catch (e) {
+      if (this.abortOnError && !this.state.aborted && !this.state.completed) {
+        this.abort().catch(() => {});
+      }
+      const msg = e instanceof Error ? e.message : String(e);
+      this.state.err = new Drive9Error(`upload part ${partNum}: ${msg}`);
+      throw this.state.err;
     } finally {
       this.sem.release();
       this.inflight--;
@@ -94,12 +125,17 @@ export class StreamWriter {
     }
     this.state.closing = true;
 
+    if (finalPartData.length > 0) {
+      await this.writePart(finalPartNum, finalPartData);
+    }
+
+    await this.waitInflight();
+
     if (!this.state.started || !this.state.plan) {
       throw new Drive9Error("stream writer was never started");
     }
-
-    if (finalPartData.length > 0) {
-      await this.writePart(finalPartNum, finalPartData);
+    if (this.state.err) {
+      throw this.state.err;
     }
 
     const plan = this.state.plan;
@@ -140,7 +176,7 @@ export class StreamWriter {
       headers: this.client["authHeaders"]({ "Content-Type": "application/json" }),
       body: JSON.stringify({
         path: this.path,
-        size: this.totalSize,
+        total_size: this.totalSize,
         expected_revision: this.expectedRevision,
       }),
     });
@@ -198,4 +234,3 @@ async function abortUploadV2(client: Client, uploadId: string): Promise<void> {
     headers: client["authHeaders"](),
   });
 }
-

--- a/clients/drive9-js/src/stream.ts
+++ b/clients/drive9-js/src/stream.ts
@@ -2,6 +2,7 @@ import { Client } from "./client.js";
 import { bodyInit } from "./compat.js";
 import { checkError, Drive9Error } from "./error.js";
 import type { CompletePart, PresignedPart, UploadPlanV2 } from "./models.js";
+import { Semaphore } from "./utils.js";
 
 const UPLOAD_MAX_CONCURRENCY = 16;
 
@@ -21,6 +22,8 @@ export class StreamWriter {
   private expectedRevision: number;
   private state: StreamState;
   private sem: Semaphore;
+  private inflight: number;
+  private inflightZeroResolvers: (() => void)[];
 
   constructor(client: Client, path: string, totalSize: number, expectedRevision = -1) {
     this.client = client;
@@ -35,6 +38,8 @@ export class StreamWriter {
       uploaded: new Map(),
     };
     this.sem = new Semaphore(UPLOAD_MAX_CONCURRENCY);
+    this.inflight = 0;
+    this.inflightZeroResolvers = [];
   }
 
   async writePart(partNum: number, data: Uint8Array): Promise<void> {
@@ -63,14 +68,20 @@ export class StreamWriter {
 
     const plan = this.state.plan!;
     await this.sem.acquire();
+    this.inflight++;
     const client = this.client;
     const uploadId = plan.upload_id;
-    const p = await presignOnePart(client, uploadId, partNum);
     try {
+      const p = await presignOnePart(client, uploadId, partNum);
       const etag = await uploadOnePartV2(client, uploadId, p, data);
       this.state.uploaded.set(partNum, { number: partNum, etag });
     } finally {
       this.sem.release();
+      this.inflight--;
+      if (this.inflight === 0) {
+        for (const r of this.inflightZeroResolvers) r();
+        this.inflightZeroResolvers = [];
+      }
     }
   }
 
@@ -112,9 +123,15 @@ export class StreamWriter {
   async abort(): Promise<void> {
     if (this.state.completed || this.state.aborted) return;
     this.state.aborted = true;
+    await this.waitInflight();
     if (this.state.plan) {
       await abortUploadV2(this.client, this.state.plan.upload_id);
     }
+  }
+
+  private async waitInflight(): Promise<void> {
+    if (this.inflight === 0) return;
+    await new Promise<void>((resolve) => this.inflightZeroResolvers.push(resolve));
   }
 
   private async initiate(): Promise<UploadPlanV2> {
@@ -182,25 +199,3 @@ async function abortUploadV2(client: Client, uploadId: string): Promise<void> {
   });
 }
 
-class Semaphore {
-  private permits: number;
-  private waiters: (() => void)[] = [];
-  constructor(n: number) {
-    this.permits = n;
-  }
-  acquire(): Promise<void> {
-    if (this.permits > 0) {
-      this.permits--;
-      return Promise.resolve();
-    }
-    return new Promise((resolve) => this.waiters.push(resolve));
-  }
-  release(): void {
-    const next = this.waiters.shift();
-    if (next) {
-      next();
-    } else {
-      this.permits++;
-    }
-  }
-}

--- a/clients/drive9-js/src/transfer.ts
+++ b/clients/drive9-js/src/transfer.ts
@@ -1,0 +1,535 @@
+import { Client } from "./client.js";
+import { bodyInit } from "./compat.js";
+import { Drive9Error, StatusError, checkError } from "./error.js";
+import type { CompletePart, PresignedPart, UploadMeta, UploadPlan, UploadPlanV2 } from "./models.js";
+
+const PART_SIZE = 8 * 1024 * 1024;
+const UPLOAD_MAX_CONCURRENCY = 16;
+const UPLOAD_MAX_BUFFER_BYTES = 256 * 1024 * 1024;
+
+function uploadParallelism(partSize: number): number {
+  const byMemory = Math.max(1, Math.floor(UPLOAD_MAX_BUFFER_BYTES / partSize));
+  return Math.min(byMemory, UPLOAD_MAX_CONCURRENCY);
+}
+
+// CRC32C lookup table (Castagnoli polynomial)
+const CRC32C_TABLE = new Int32Array(256);
+(function initTable() {
+  for (let i = 0; i < 256; i++) {
+    let crc = i;
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 1 ? (crc >>> 1) ^ 0x82f63b78 : crc >>> 1;
+    }
+    CRC32C_TABLE[i] = crc;
+  }
+})();
+
+export function computeCrc32c(data: Uint8Array): string {
+  let crc = ~0;
+  for (let i = 0; i < data.length; i++) {
+    crc = (crc >>> 8) ^ CRC32C_TABLE[(crc ^ data[i]) & 0xff];
+  }
+  crc = ~crc >>> 0;
+  return Buffer.from([
+    (crc >>> 24) & 0xff,
+    (crc >>> 16) & 0xff,
+    (crc >>> 8) & 0xff,
+    crc & 0xff,
+  ]).toString("base64");
+}
+
+async function sha256Base64(data: Uint8Array): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return Buffer.from(hash).toString("base64");
+}
+
+async function streamToUint8Array(stream: ReadableStream<Uint8Array>, size: number): Promise<Uint8Array> {
+  const result = new Uint8Array(size);
+  let offset = 0;
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    result.set(value, offset);
+    offset += value.length;
+  }
+  return result.slice(0, offset);
+}
+
+export async function readStreamImpl(client: Client, path: string): Promise<ReadableStream<Uint8Array>> {
+  const resp = await fetch(client.fsUrl(path), {
+    method: "GET",
+    headers: client["authHeaders"](),
+    redirect: "manual",
+  });
+  const status = resp.status;
+  if (status === 302 || status === 307) {
+    const location = resp.headers.get("location") || resp.headers.get("Location");
+    if (!location) throw new Drive9Error("302 without Location header");
+    const resp2 = await fetch(location, { method: "GET" });
+    await checkError(resp2);
+    if (!resp2.body) throw new Drive9Error("empty response body");
+    return resp2.body;
+  }
+  await checkError(resp);
+  if (!resp.body) throw new Drive9Error("empty response body");
+  return resp.body;
+}
+
+export async function readStreamRangeImpl(
+  client: Client,
+  path: string,
+  offset: number,
+  length: number
+): Promise<ReadableStream<Uint8Array>> {
+  if (length <= 0) {
+    return new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+  }
+  const resp = await fetch(client.fsUrl(path), {
+    method: "GET",
+    headers: client["authHeaders"](),
+    redirect: "manual",
+  });
+  const status = resp.status;
+  if (status === 302 || status === 307) {
+    const location = resp.headers.get("location") || resp.headers.get("Location");
+    if (!location) throw new Drive9Error("302 without Location header");
+    const resp2 = await fetch(location, {
+      method: "GET",
+      headers: { Range: `bytes=${offset}-${offset + length - 1}` },
+    });
+    if (resp2.status === 416) {
+      return new ReadableStream({ start(c) { c.close(); } });
+    }
+    await checkError(resp2);
+    if (!resp2.body) throw new Drive9Error("empty response body");
+    if (resp2.status === 206) return resp2.body;
+    // 200: server ignored range; slice locally
+    return sliceStream(resp2.body, offset, length);
+  }
+  if (resp.status >= 300) {
+    await checkError(resp);
+    throw new StatusError(`HTTP ${resp.status}`, resp.status);
+  }
+  if (!resp.body) throw new Drive9Error("empty response body");
+  return sliceStream(resp.body, offset, length);
+}
+
+async function sliceStream(body: ReadableStream<Uint8Array>, offset: number, length: number): Promise<ReadableStream<Uint8Array>> {
+  const reader = body.getReader();
+  let skipped = 0;
+  let emitted = 0;
+  return new ReadableStream({
+    pull(controller) {
+      return reader.read().then(({ done, value }) => {
+        if (done) {
+          controller.close();
+          return;
+        }
+        let buf = value;
+        if (skipped < offset) {
+          const toSkip = Math.min(buf.length, offset - skipped);
+          buf = buf.subarray(toSkip);
+          skipped += toSkip;
+        }
+        if (emitted < length) {
+          const toEmit = Math.min(buf.length, length - emitted);
+          if (toEmit > 0) {
+            controller.enqueue(buf.subarray(0, toEmit));
+            emitted += toEmit;
+          }
+        }
+        if (emitted >= length) {
+          controller.close();
+          reader.cancel().catch(() => {});
+        }
+      });
+    },
+    cancel() {
+      return reader.cancel();
+    },
+  });
+}
+
+export async function writeStreamImpl(
+  client: Client,
+  path: string,
+  stream: ReadableStream<Uint8Array> | Uint8Array,
+  size: number,
+  expectedRevision = -1
+): Promise<void> {
+  const threshold = client["smallFileThreshold"];
+  let data: Uint8Array;
+  if (stream instanceof Uint8Array) {
+    data = stream;
+  } else {
+    data = await streamToUint8Array(stream, size);
+  }
+  if (size < threshold) {
+    return client.write(path, data, expectedRevision);
+  }
+  try {
+    await writeStreamV2(client, path, data, expectedRevision);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("v2 upload API not available")) {
+      await writeStreamV1(client, path, data, expectedRevision);
+    } else {
+      throw err;
+    }
+  }
+}
+
+async function writeStreamV1(
+  client: Client,
+  path: string,
+  data: Uint8Array,
+  expectedRevision: number
+): Promise<void> {
+  const checksums = computePartChecksums(data, PART_SIZE);
+  const plan = await initiateUpload(client, path, data.length, checksums, expectedRevision);
+  await uploadPartsV1(client, plan, data);
+  await completeUpload(client, plan.upload_id);
+}
+
+async function writeStreamV2(
+  client: Client,
+  path: string,
+  data: Uint8Array,
+  expectedRevision: number
+): Promise<void> {
+  const plan = await initiateUploadV2(client, path, data.length, expectedRevision);
+  const parts = await uploadPartsV2(client, plan, data);
+  try {
+    await completeUploadV2(client, plan.upload_id, parts);
+  } catch (err) {
+    await abortUploadV2(client, plan.upload_id);
+    throw err;
+  }
+}
+
+function computePartChecksums(data: Uint8Array, partSize: number): string[] {
+  const count = Math.max(1, Math.ceil(data.length / partSize));
+  const out: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const start = i * partSize;
+    const end = Math.min(start + partSize, data.length);
+    out.push(computeCrc32c(data.subarray(start, end)));
+  }
+  return out;
+}
+
+async function initiateUpload(
+  client: Client,
+  path: string,
+  size: number,
+  checksums: string[],
+  expectedRevision: number
+): Promise<UploadPlan> {
+  try {
+    return await initiateUploadByBody(client, path, size, checksums, expectedRevision);
+  } catch (err) {
+    const status = err instanceof StatusError ? err.statusCode : 0;
+    const msg = err instanceof Error ? err.message : String(err);
+    if (status === 404 || status === 405) {
+      return initiateUploadLegacy(client, path, size, checksums, expectedRevision);
+    }
+    if (status === 400 && msg.toLowerCase().includes("unknown upload action")) {
+      return initiateUploadLegacy(client, path, size, checksums, expectedRevision);
+    }
+    throw err;
+  }
+}
+
+async function initiateUploadByBody(
+  client: Client,
+  path: string,
+  size: number,
+  checksums: string[],
+  expectedRevision: number
+): Promise<UploadPlan> {
+  const resp = await fetch(`${client.baseUrl}/v1/uploads/initiate`, {
+    method: "POST",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ path, size, part_checksums: checksums, expected_revision: expectedRevision }),
+  });
+  if (resp.status === 202) {
+    return (await resp.json()) as UploadPlan;
+  }
+  const text = await resp.text().catch(() => "");
+  throw new StatusError(text || `HTTP ${resp.status}`, resp.status);
+}
+
+async function initiateUploadLegacy(
+  client: Client,
+  path: string,
+  size: number,
+  checksums: string[],
+  expectedRevision: number
+): Promise<UploadPlan> {
+  const headers = client["authHeaders"]({ "Content-Type": "application/octet-stream" });
+  headers["X-Dat9-Content-Length"] = String(size);
+  if (checksums.length) headers["X-Dat9-Part-Checksums"] = checksums.join(",");
+  if (expectedRevision >= 0) headers["X-Dat9-Expected-Revision"] = String(expectedRevision);
+  const resp = await fetch(client.fsUrl(path), { method: "PUT", headers });
+  await checkError(resp);
+  return (await resp.json()) as UploadPlan;
+}
+
+async function uploadPartsV1(client: Client, plan: UploadPlan, data: Uint8Array): Promise<void> {
+  const parallelism = uploadParallelism(plan.part_size);
+  const semaphore = new Semaphore(parallelism);
+  const tasks: Promise<void>[] = [];
+  for (const part of plan.parts) {
+    const offset = (part.number - 1) * plan.part_size;
+    const chunk = data.subarray(offset, offset + part.size);
+    tasks.push(
+      (async () => {
+        await semaphore.acquire();
+        try {
+          await uploadOnePart(client, part.url, chunk, part.checksum_crc32c);
+        } finally {
+          semaphore.release();
+        }
+      })()
+    );
+  }
+  await Promise.all(tasks);
+}
+
+async function uploadOnePart(
+  client: Client,
+  url: string,
+  data: Uint8Array,
+  checksumCrc32c?: string
+): Promise<void> {
+  const checksum = checksumCrc32c || computeCrc32c(data);
+  const resp = await fetch(url, {
+    method: "PUT",
+    headers: { "x-amz-checksum-crc32c": checksum },
+    body: bodyInit(data),
+  });
+  await checkError(resp);
+}
+
+async function completeUpload(client: Client, uploadId: string): Promise<void> {
+  const resp = await fetch(`${client.baseUrl}/v1/uploads/${uploadId}/complete`, {
+    method: "POST",
+    headers: client["authHeaders"](),
+  });
+  await checkError(resp);
+}
+
+async function initiateUploadV2(
+  client: Client,
+  path: string,
+  size: number,
+  expectedRevision: number
+): Promise<UploadPlanV2> {
+  const resp = await fetch(`${client.baseUrl}/v2/uploads/initiate`, {
+    method: "POST",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ path, size, expected_revision: expectedRevision }),
+  });
+  if (resp.status === 404) {
+    throw new Drive9Error("v2 upload API not available");
+  }
+  await checkError(resp);
+  return (await resp.json()) as UploadPlanV2;
+}
+
+async function uploadPartsV2(client: Client, plan: UploadPlanV2, data: Uint8Array): Promise<CompletePart[]> {
+  const psize = plan.part_size;
+  const totalParts = Math.max(1, Math.ceil(data.length / psize));
+  const parallelism = uploadParallelism(psize);
+  const semaphore = new Semaphore(parallelism);
+  const tasks: Promise<CompletePart>[] = [];
+  const results: (CompletePart | undefined)[] = new Array(totalParts).fill(undefined);
+
+  for (let i = 1; i <= totalParts; i++) {
+    const num = i;
+    tasks.push(
+      (async () => {
+        await semaphore.acquire();
+        try {
+          const offset = (num - 1) * psize;
+          const chunk = data.subarray(offset, Math.min(offset + psize, data.length));
+          const presigned = await presignOnePart(client, plan.upload_id, num);
+          const etag = await uploadOnePartV2(client, plan.upload_id, presigned, chunk);
+          const part: CompletePart = { number: num, etag };
+          results[num - 1] = part;
+          return part;
+        } finally {
+          semaphore.release();
+        }
+      })()
+    );
+  }
+  await Promise.all(tasks);
+  return results.filter((p): p is CompletePart => p !== undefined);
+}
+
+async function presignOnePart(client: Client, uploadId: string, partNumber: number): Promise<PresignedPart> {
+  const resp = await fetch(`${client.baseUrl}/v2/uploads/${uploadId}/presign`, {
+    method: "POST",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ part_number: partNumber }),
+  });
+  await checkError(resp);
+  return (await resp.json()) as PresignedPart;
+}
+
+async function uploadOnePartV2(
+  client: Client,
+  uploadId: string,
+  part: PresignedPart,
+  data: Uint8Array
+): Promise<string> {
+  const headers: Record<string, string> = {};
+  if (part.headers) {
+    for (const [k, v] of Object.entries(part.headers)) {
+      if (typeof v === "string") headers[k] = v;
+    }
+  }
+  let resp = await fetch(part.url, { method: "PUT", headers, body: bodyInit(data) });
+  if (resp.status === 403) {
+    const fresh = await presignOnePart(client, uploadId, part.number);
+    resp = await fetch(fresh.url, { method: "PUT", headers, body: bodyInit(data) });
+  }
+  await checkError(resp);
+  return resp.headers.get("etag") || "";
+}
+
+async function completeUploadV2(client: Client, uploadId: string, parts: CompletePart[]): Promise<void> {
+  const resp = await fetch(`${client.baseUrl}/v2/uploads/${uploadId}/complete`, {
+    method: "POST",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ parts }),
+  });
+  await checkError(resp);
+}
+
+async function abortUploadV2(client: Client, uploadId: string): Promise<void> {
+  await fetch(`${client.baseUrl}/v2/uploads/${uploadId}/abort`, {
+    method: "POST",
+    headers: client["authHeaders"](),
+  });
+}
+
+export async function resumeUploadImpl(
+  client: Client,
+  path: string,
+  data: Uint8Array
+): Promise<void> {
+  const meta = await queryUpload(client, path);
+  const checksums = computePartChecksums(data, PART_SIZE);
+  const plan = await requestResume(client, meta.upload_id, checksums);
+  if (plan.parts.length === 0) {
+    await completeUpload(client, meta.upload_id);
+    return;
+  }
+  await uploadMissingParts(client, plan, data, meta.parts_total);
+  await completeUpload(client, meta.upload_id);
+}
+
+async function queryUpload(client: Client, path: string): Promise<UploadMeta> {
+  const resp = await fetch(`${client.baseUrl}/v1/uploads?path=${encodeURIComponent(path)}&status=UPLOADING`, {
+    headers: client["authHeaders"](),
+  });
+  await checkError(resp);
+  const body = (await resp.json()) as { uploads?: UploadMeta[] };
+  const uploads = body.uploads || [];
+  const first = uploads[0];
+  if (!first) throw new Drive9Error(`no active upload for ${path}`);
+  return first;
+}
+
+async function requestResume(client: Client, uploadId: string, checksums: string[]): Promise<UploadPlan> {
+  try {
+    return await requestResumeByBody(client, uploadId, checksums);
+  } catch (err) {
+    const status = err instanceof StatusError ? err.statusCode : 0;
+    const msg = err instanceof Error ? err.message : String(err);
+    if (status === 400 && msg.toLowerCase().includes("missing x-dat9-part-checksums header")) {
+      return requestResumeLegacy(client, uploadId, checksums);
+    }
+    throw err;
+  }
+}
+
+async function requestResumeByBody(client: Client, uploadId: string, checksums: string[]): Promise<UploadPlan> {
+  const resp = await fetch(`${client.baseUrl}/v1/uploads/${uploadId}/resume`, {
+    method: "POST",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ part_checksums: checksums }),
+  });
+  const status = resp.status;
+  if (status === 202) {
+    return (await resp.json()) as UploadPlan;
+  }
+  const text = await resp.text().catch(() => "");
+  throw new StatusError(text || `HTTP ${status}`, status);
+}
+
+async function requestResumeLegacy(client: Client, uploadId: string, checksums: string[]): Promise<UploadPlan> {
+  const headers = client["authHeaders"]({ "Content-Type": "application/octet-stream" });
+  if (checksums.length) headers["X-Dat9-Part-Checksums"] = checksums.join(",");
+  const resp = await fetch(`${client.baseUrl}/v1/uploads/${uploadId}/resume`, {
+    method: "POST",
+    headers,
+  });
+  if (resp.status === 410) {
+    throw new Drive9Error(`upload ${uploadId} has expired`);
+  }
+  await checkError(resp);
+  return (await resp.json()) as UploadPlan;
+}
+
+async function uploadMissingParts(client: Client, plan: UploadPlan, data: Uint8Array, partsTotal: number): Promise<void> {
+  const stdPartSize = Math.floor(data.length / partsTotal) || PART_SIZE;
+  const parallelism = uploadParallelism(stdPartSize);
+  const semaphore = new Semaphore(parallelism);
+  const tasks: Promise<void>[] = [];
+  for (const part of plan.parts) {
+    const offset = (part.number - 1) * stdPartSize;
+    const chunk = data.subarray(offset, offset + part.size);
+    tasks.push(
+      (async () => {
+        await semaphore.acquire();
+        try {
+          await uploadOnePart(client, part.url, chunk, part.checksum_crc32c);
+        } finally {
+          semaphore.release();
+        }
+      })()
+    );
+  }
+  await Promise.all(tasks);
+}
+
+class Semaphore {
+  private permits: number;
+  private waiters: (() => void)[] = [];
+  constructor(n: number) {
+    this.permits = n;
+  }
+  acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits--;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    } else {
+      this.permits++;
+    }
+  }
+}

--- a/clients/drive9-js/src/transfer.ts
+++ b/clients/drive9-js/src/transfer.ts
@@ -2,6 +2,7 @@ import { Client } from "./client.js";
 import { bodyInit } from "./compat.js";
 import { Drive9Error, StatusError, checkError } from "./error.js";
 import type { CompletePart, PresignedPart, UploadMeta, UploadPlan, UploadPlanV2 } from "./models.js";
+import { Semaphore } from "./utils.js";
 
 const PART_SIZE = 8 * 1024 * 1024;
 const UPLOAD_MAX_CONCURRENCY = 16;
@@ -511,25 +512,3 @@ async function uploadMissingParts(client: Client, plan: UploadPlan, data: Uint8A
   await Promise.all(tasks);
 }
 
-class Semaphore {
-  private permits: number;
-  private waiters: (() => void)[] = [];
-  constructor(n: number) {
-    this.permits = n;
-  }
-  acquire(): Promise<void> {
-    if (this.permits > 0) {
-      this.permits--;
-      return Promise.resolve();
-    }
-    return new Promise((resolve) => this.waiters.push(resolve));
-  }
-  release(): void {
-    const next = this.waiters.shift();
-    if (next) {
-      next();
-    } else {
-      this.permits++;
-    }
-  }
-}

--- a/clients/drive9-js/src/utils.ts
+++ b/clients/drive9-js/src/utils.ts
@@ -1,0 +1,22 @@
+export class Semaphore {
+  private permits: number;
+  private waiters: (() => void)[] = [];
+  constructor(n: number) {
+    this.permits = n;
+  }
+  acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits--;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    } else {
+      this.permits++;
+    }
+  }
+}

--- a/clients/drive9-js/src/vault.ts
+++ b/clients/drive9-js/src/vault.ts
@@ -1,0 +1,115 @@
+import { Client } from "./client.js";
+import { checkError, Drive9Error } from "./error.js";
+import type { VaultAuditEvent, VaultSecret, VaultTokenIssueResponse } from "./models.js";
+
+export async function createVaultSecret(
+  client: Client,
+  name: string,
+  fields: Record<string, unknown>
+): Promise<VaultSecret> {
+  const resp = await fetch(client.vaultUrl("/secrets"), {
+    method: "POST",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ name, fields, created_by: "drive9-cli" }),
+  });
+  await checkError(resp);
+  return (await resp.json()) as VaultSecret;
+}
+
+export async function updateVaultSecret(
+  client: Client,
+  name: string,
+  fields: Record<string, unknown>
+): Promise<VaultSecret> {
+  const resp = await fetch(client.vaultUrl(`/secrets/${encodeURIComponent(name)}`), {
+    method: "PUT",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ fields, updated_by: "drive9-cli" }),
+  });
+  await checkError(resp);
+  return (await resp.json()) as VaultSecret;
+}
+
+export async function deleteVaultSecret(client: Client, name: string): Promise<void> {
+  const resp = await fetch(client.vaultUrl(`/secrets/${encodeURIComponent(name)}`), {
+    method: "DELETE",
+    headers: client["authHeaders"](),
+  });
+  await checkError(resp);
+}
+
+export async function listVaultSecrets(client: Client): Promise<VaultSecret[]> {
+  const resp = await fetch(client.vaultUrl("/secrets"), {
+    headers: client["authHeaders"](),
+  });
+  await checkError(resp);
+  const body = (await resp.json()) as { secrets?: VaultSecret[] };
+  return body.secrets || [];
+}
+
+export async function issueVaultToken(
+  client: Client,
+  agentId: string,
+  taskId: string,
+  scope: string[],
+  ttlSeconds: number
+): Promise<VaultTokenIssueResponse> {
+  const resp = await fetch(client.vaultUrl("/tokens"), {
+    method: "POST",
+    headers: client["authHeaders"]({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ agent_id: agentId, task_id: taskId, scope, ttl_seconds: ttlSeconds }),
+  });
+  await checkError(resp);
+  return (await resp.json()) as VaultTokenIssueResponse;
+}
+
+export async function revokeVaultToken(client: Client, tokenId: string): Promise<void> {
+  const resp = await fetch(client.vaultUrl(`/tokens/${encodeURIComponent(tokenId)}`), {
+    method: "DELETE",
+    headers: client["authHeaders"](),
+  });
+  await checkError(resp);
+}
+
+export async function queryVaultAudit(
+  client: Client,
+  secretName?: string,
+  limit = 0
+): Promise<VaultAuditEvent[]> {
+  const params = new URLSearchParams();
+  if (secretName) params.set("secret", secretName);
+  if (limit > 0) params.set("limit", String(limit));
+  const qs = params.toString();
+  const url = `${client.vaultUrl("/audit")}${qs ? "?" + qs : ""}`;
+  const resp = await fetch(url, { headers: client["authHeaders"]() });
+  await checkError(resp);
+  const body = (await resp.json()) as { events?: VaultAuditEvent[] };
+  return body.events || [];
+}
+
+export async function listReadableVaultSecrets(client: Client): Promise<string[]> {
+  const resp = await fetch(client.vaultUrl("/read"), { headers: client["authHeaders"]() });
+  await checkError(resp);
+  const body = (await resp.json()) as { secrets?: string[] };
+  return body.secrets || [];
+}
+
+export async function readVaultSecret(
+  client: Client,
+  name: string
+): Promise<Record<string, unknown>> {
+  const resp = await fetch(client.vaultUrl(`/read/${encodeURIComponent(name)}`), {
+    headers: client["authHeaders"](),
+  });
+  await checkError(resp);
+  return (await resp.json()) as Record<string, unknown>;
+}
+
+export async function readVaultSecretField(client: Client, name: string, field: string): Promise<string> {
+  const resp = await fetch(
+    client.vaultUrl(`/read/${encodeURIComponent(name)}/${encodeURIComponent(field)}`),
+    { headers: client["authHeaders"]() }
+  );
+  await checkError(resp);
+  return await resp.text();
+}

--- a/clients/drive9-js/src/vault.ts
+++ b/clients/drive9-js/src/vault.ts
@@ -5,12 +5,13 @@ import type { VaultAuditEvent, VaultSecret, VaultTokenIssueResponse } from "./mo
 export async function createVaultSecret(
   client: Client,
   name: string,
-  fields: Record<string, unknown>
+  fields: Record<string, unknown>,
+  createdBy = "drive9-js"
 ): Promise<VaultSecret> {
   const resp = await fetch(client.vaultUrl("/secrets"), {
     method: "POST",
     headers: client["authHeaders"]({ "Content-Type": "application/json" }),
-    body: JSON.stringify({ name, fields, created_by: "drive9-cli" }),
+    body: JSON.stringify({ name, fields, created_by: createdBy }),
   });
   await checkError(resp);
   return (await resp.json()) as VaultSecret;
@@ -19,12 +20,13 @@ export async function createVaultSecret(
 export async function updateVaultSecret(
   client: Client,
   name: string,
-  fields: Record<string, unknown>
+  fields: Record<string, unknown>,
+  updatedBy = "drive9-js"
 ): Promise<VaultSecret> {
   const resp = await fetch(client.vaultUrl(`/secrets/${encodeURIComponent(name)}`), {
     method: "PUT",
     headers: client["authHeaders"]({ "Content-Type": "application/json" }),
-    body: JSON.stringify({ fields, updated_by: "drive9-cli" }),
+    body: JSON.stringify({ fields, updated_by: updatedBy }),
   });
   await checkError(resp);
   return (await resp.json()) as VaultSecret;

--- a/clients/drive9-js/tests/client.test.ts
+++ b/clients/drive9-js/tests/client.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+import { Client, ConflictError, Drive9Error, StatusError } from "../src/index.js";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+
+const server = setupServer();
+server.listen({ onUnhandledRequest: "error" });
+
+describe("Client basic ops", () => {
+  it("writes and reads", async () => {
+    server.use(
+      http.put("http://localhost:9009/v1/fs/hello.txt", async ({ request }) => {
+        expect(request.headers.get("authorization")).toBe("Bearer test-key");
+        return HttpResponse.text("ok");
+      }),
+      http.get("http://localhost:9009/v1/fs/hello.txt", () => {
+        return HttpResponse.arrayBuffer(new TextEncoder().encode("hello world"));
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    await client.write("/hello.txt", new TextEncoder().encode("hello world"));
+    const data = await client.read("/hello.txt");
+    expect(new TextDecoder().decode(data)).toBe("hello world");
+  });
+
+  it("lists directory", async () => {
+    server.use(
+      http.get("http://localhost:9009/v1/fs/data/?list=1", () => {
+        return HttpResponse.json({
+          entries: [
+            { name: "a.txt", size: 1, isDir: false },
+            { name: "b.txt", size: 2, isDir: false },
+          ],
+        });
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    const entries = await client.list("/data/");
+    expect(entries.length).toBe(2);
+    expect(entries[0].name).toBe("a.txt");
+  });
+
+  it("stats a file", async () => {
+    server.use(
+      http.head("http://localhost:9009/v1/fs/test.txt", () => {
+        return new HttpResponse(null, {
+          status: 200,
+          headers: {
+            "Content-Length": "4",
+            "X-Dat9-Revision": "7",
+            "X-Dat9-IsDir": "false",
+          },
+        });
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    const info = await client.stat("/test.txt");
+    expect(info.size).toBe(4);
+    expect(info.revision).toBe(7);
+    expect(info.isDir).toBe(false);
+  });
+
+  it("throws ConflictError on 409", async () => {
+    server.use(
+      http.put("http://localhost:9009/v1/fs/conflict.txt", () => {
+        return HttpResponse.json({ error: "revision mismatch" }, { status: 409 });
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    await expect(client.write("/conflict.txt", new TextEncoder().encode("x"))).rejects.toThrow(
+      ConflictError
+    );
+  });
+
+  it("throws StatusError on 500", async () => {
+    server.use(
+      http.put("http://localhost:9009/v1/fs/err.txt", () => {
+        return HttpResponse.json({ error: "boom" }, { status: 500 });
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    await expect(client.write("/err.txt", new TextEncoder().encode("x"))).rejects.toThrow(
+      StatusError
+    );
+  });
+
+  it("copies and renames", async () => {
+    server.use(
+      http.post("http://localhost:9009/v1/fs/dst.txt", ({ request }) => {
+        expect(request.headers.get("x-dat9-copy-source")).toBe("/src.txt");
+        return HttpResponse.text("ok");
+      }),
+      http.post("http://localhost:9009/v1/fs/new.txt", ({ request }) => {
+        expect(request.headers.get("x-dat9-rename-source")).toBe("/old.txt");
+        return HttpResponse.text("ok");
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    await client.copy("/src.txt", "/dst.txt");
+    await client.rename("/old.txt", "/new.txt");
+  });
+
+  it("deletes and mkdir", async () => {
+    server.use(
+      http.delete("http://localhost:9009/v1/fs/del.txt", () => HttpResponse.text("ok")),
+      http.post("http://localhost:9009/v1/fs/dir/?mkdir", () => HttpResponse.text("ok"))
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    await client.delete("/del.txt");
+    await client.mkdir("/dir/");
+  });
+
+  it("sql, grep, find", async () => {
+    server.use(
+      http.post("http://localhost:9009/v1/sql", () => HttpResponse.json([{ id: 1 }])),
+      http.get("http://localhost:9009/v1/fs/?grep=hello", () =>
+        HttpResponse.json([{ path: "/a.txt", name: "a.txt", size_bytes: 5 }])
+      ),
+      http.get("http://localhost:9009/v1/fs/?find=&type=file", () =>
+        HttpResponse.json([{ path: "/b.txt", name: "b.txt", size_bytes: 3 }])
+      )
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    const sql = await client.sql("SELECT 1");
+    expect(sql).toEqual([{ id: 1 }]);
+
+    const grep = await client.grep("hello", "/", 0);
+    expect(grep.length).toBe(1);
+
+    const find = await client.find("/", { type: "file" });
+    expect(find.length).toBe(1);
+  });
+});
+
+describe("Config loading", () => {
+  it("defaultClient loads config without panic", () => {
+    const prevHome = process.env.HOME;
+    process.env.HOME = "/nonexistent-home-" + Math.random();
+    delete process.env.DRIVE9_SERVER;
+    delete process.env.DRIVE9_API_KEY;
+    const client = Client.defaultClient();
+    expect(client.baseUrl).toBe("https://api.drive9.ai");
+    expect(client.apiKey).toBeUndefined();
+    process.env.HOME = prevHome;
+  });
+
+  it("env vars override config", () => {
+    const prev = { s: process.env.DRIVE9_SERVER, k: process.env.DRIVE9_API_KEY };
+    process.env.DRIVE9_SERVER = "http://env.drive9.ai";
+    process.env.DRIVE9_API_KEY = "env-key";
+    const client = Client.defaultClient();
+    expect(client.baseUrl).toBe("http://env.drive9.ai");
+    expect(client.apiKey).toBe("env-key");
+    process.env.DRIVE9_SERVER = prev.s;
+    process.env.DRIVE9_API_KEY = prev.k;
+  });
+});
+
+describe("Vault", () => {
+  it("createVaultSecret and listVaultSecrets", async () => {
+    server.use(
+      http.post("http://localhost:9009/v1/vault/secrets", async ({ request }) => {
+        const body = (await request.json()) as { name: string };
+        expect(body.name).toBe("aws");
+        return HttpResponse.json({ name: "aws", secret_type: "kv", revision: 1, created_by: "x", created_at: "2024-01-01T00:00:00Z", updated_at: "2024-01-01T00:00:00Z" });
+      }),
+      http.get("http://localhost:9009/v1/vault/secrets", () => {
+        return HttpResponse.json({ secrets: [{ name: "aws", secret_type: "kv", revision: 1, created_by: "x", created_at: "2024-01-01T00:00:00Z", updated_at: "2024-01-01T00:00:00Z" }] });
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    const secret = await client.createVaultSecret("aws", { key: "val" });
+    expect(secret.name).toBe("aws");
+    const list = await client.listVaultSecrets();
+    expect(list.length).toBe(1);
+  });
+
+  it("issue and revoke token", async () => {
+    server.use(
+      http.post("http://localhost:9009/v1/vault/tokens", async ({ request }) => {
+        const body = (await request.json()) as { agent_id: string };
+        expect(body.agent_id).toBe("agent-1");
+        return HttpResponse.json({ token: "tok", token_id: "tid-1", expires_at: "2024-01-01T00:00:00Z" });
+      }),
+      http.delete("http://localhost:9009/v1/vault/tokens/tid-1", () => HttpResponse.text("ok"))
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    const tok = await client.issueVaultToken("agent-1", "task-1", ["read"], 3600);
+    expect(tok.token_id).toBe("tid-1");
+    await client.revokeVaultToken(tok.token_id);
+  });
+});

--- a/clients/drive9-js/tests/transfer.test.ts
+++ b/clients/drive9-js/tests/transfer.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { Client } from "../src/index.js";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+
+const server = setupServer();
+server.listen({ onUnhandledRequest: "error" });
+
+describe("Transfer", () => {
+  it("writeStream falls back to PUT for small files", async () => {
+    let putCalled = false;
+    server.use(
+      http.put("http://localhost:9009/v1/fs/small.bin", () => {
+        putCalled = true;
+        return HttpResponse.text("ok");
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    const data = new TextEncoder().encode("tiny");
+    await client.writeStream("/small.bin", data, data.length);
+    expect(putCalled).toBe(true);
+  });
+
+  it("readStream handles 302 redirect", async () => {
+    server.use(
+      http.get("http://localhost:9009/v1/fs/large.bin", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.has("follow")) {
+          return HttpResponse.arrayBuffer(new TextEncoder().encode("s3data"));
+        }
+        return HttpResponse.json({}, { status: 302, headers: { Location: "http://localhost:9009/v1/fs/large.bin?follow=1" } });
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    const stream = await client.readStream("/large.bin");
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    const all = new Uint8Array(chunks.reduce((a, b) => a + b.length, 0));
+    let offset = 0;
+    for (const c of chunks) {
+      all.set(c, offset);
+      offset += c.length;
+    }
+    expect(new TextDecoder().decode(all)).toBe("s3data");
+  });
+
+  it("readStreamRange returns sliced stream for small files", async () => {
+    server.use(
+      http.get("http://localhost:9009/v1/fs/small.txt", () => {
+        return HttpResponse.arrayBuffer(new TextEncoder().encode("hello world"));
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    const stream = await client.readStreamRange("/small.txt", 6, 5);
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    const all = new Uint8Array(chunks.reduce((a, b) => a + b.length, 0));
+    let offset = 0;
+    for (const c of chunks) {
+      all.set(c, offset);
+      offset += c.length;
+    }
+    expect(new TextDecoder().decode(all)).toBe("world");
+  });
+});

--- a/clients/drive9-js/tsconfig.json
+++ b/clients/drive9-js/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/clients/drive9-py/.gitignore
+++ b/clients/drive9-py/.gitignore
@@ -1,0 +1,74 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Ruff
+.ruff_cache/

--- a/clients/drive9-py/README.md
+++ b/clients/drive9-py/README.md
@@ -1,0 +1,58 @@
+# Drive9 Python SDK
+
+Python SDK for [drive9](https://github.com/mem9-ai/drive9).
+
+## Install
+
+```bash
+pip install -e ".[dev]"
+```
+
+## Usage
+
+```python
+from drive9 import Client
+
+client = Client("http://localhost:8080", api_key="your-api-key")
+
+# Write / read
+client.write("/hello.txt", b"hello world")
+data = client.read("/hello.txt")
+
+# List directory
+entries = client.list("/data/")
+for entry in entries:
+    print(entry.name, entry.size, entry.is_dir)
+
+# Metadata
+info = client.stat("/hello.txt")
+print(info.size, info.revision, info.is_dir)
+
+# Directories, copies, moves
+client.mkdir("/mydir")
+client.copy("/src.txt", "/dst.txt")
+client.rename("/old.txt", "/new.txt")
+client.delete("/tmp.txt")
+
+# SQL query
+rows = client.sql('SELECT * FROM files WHERE path = "/hello.txt"')
+
+# Search
+results = client.grep("hello", "/data/", limit=10)
+results = client.find("/data/", {"name": "*.txt"})
+
+# Stream upload / download
+with open("large.bin", "rb") as f:
+    client.write_stream("/large.bin", f, size=os.path.getsize("large.bin"))
+
+body = client.read_stream("/large.bin")
+with open("out.bin", "wb") as f:
+    f.write(body.read())
+body.close()
+```
+
+## Run tests
+
+```bash
+pytest tests/
+```

--- a/clients/drive9-py/README.md
+++ b/clients/drive9-py/README.md
@@ -11,6 +11,7 @@ pip install -e ".[dev]"
 ## Usage
 
 ```python
+import os
 from drive9 import Client
 
 client = Client("http://localhost:8080", api_key="your-api-key")

--- a/clients/drive9-py/drive9/__init__.py
+++ b/clients/drive9-py/drive9/__init__.py
@@ -4,35 +4,35 @@ from .client import Client
 from .exceptions import Drive9Error, StatusError, ConflictError
 from .models import (
     FileInfo,
-    StatResult,
-    SearchResult,
-    UploadPlan,
     PartURL,
-    PatchPlan,
     PatchPartURL,
+    PatchPlan,
+    SearchResult,
+    StatResult,
     UploadMeta,
+    UploadPlan,
+    VaultAuditEvent,
     VaultSecret,
     VaultTokenIssueResponse,
-    VaultAuditEvent,
 )
 from .stream import StreamWriter
 
 __all__ = [
     "Client",
-    "Drive9Error",
-    "StatusError",
     "ConflictError",
+    "Drive9Error",
     "FileInfo",
-    "StatResult",
-    "SearchResult",
-    "UploadPlan",
     "PartURL",
-    "PatchPlan",
     "PatchPartURL",
+    "PatchPlan",
+    "SearchResult",
+    "StatResult",
+    "StatusError",
     "UploadMeta",
+    "UploadPlan",
+    "VaultAuditEvent",
     "VaultSecret",
     "VaultTokenIssueResponse",
-    "VaultAuditEvent",
     "StreamWriter",
 ]
 

--- a/clients/drive9-py/drive9/__init__.py
+++ b/clients/drive9-py/drive9/__init__.py
@@ -1,0 +1,39 @@
+"""Drive9 Python SDK."""
+
+from .client import Client
+from .exceptions import Drive9Error, StatusError, ConflictError
+from .models import (
+    FileInfo,
+    StatResult,
+    SearchResult,
+    UploadPlan,
+    PartURL,
+    PatchPlan,
+    PatchPartURL,
+    UploadMeta,
+    VaultSecret,
+    VaultTokenIssueResponse,
+    VaultAuditEvent,
+)
+from .stream import StreamWriter
+
+__all__ = [
+    "Client",
+    "Drive9Error",
+    "StatusError",
+    "ConflictError",
+    "FileInfo",
+    "StatResult",
+    "SearchResult",
+    "UploadPlan",
+    "PartURL",
+    "PatchPlan",
+    "PatchPartURL",
+    "UploadMeta",
+    "VaultSecret",
+    "VaultTokenIssueResponse",
+    "VaultAuditEvent",
+    "StreamWriter",
+]
+
+__version__ = "0.1.0"

--- a/clients/drive9-py/drive9/client.py
+++ b/clients/drive9-py/drive9/client.py
@@ -13,6 +13,11 @@ from .patch import PatchMixin
 from .stream import StreamWriter
 
 
+def _parse_iso_datetime(s: str) -> datetime:
+    """Parse ISO8601 datetime, handling Z suffix for Python < 3.11."""
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
 class Client(TransferMixin, PatchMixin):
     """The Drive9 HTTP client."""
 
@@ -56,12 +61,13 @@ class Client(TransferMixin, PatchMixin):
             small_file_threshold or self.DEFAULT_SMALL_FILE_THRESHOLD
         )
         self.session = session or requests.Session()
-        adapter = requests.adapters.HTTPAdapter(
-            pool_connections=16,
-            pool_maxsize=16,
-        )
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
+        if session is None:
+            adapter = requests.adapters.HTTPAdapter(
+                pool_connections=16,
+                pool_maxsize=16,
+            )
+            self.session.mount("http://", adapter)
+            self.session.mount("https://", adapter)
 
     def _url(self, path: str) -> str:
         if not path.startswith("/"):
@@ -272,12 +278,8 @@ class Client(TransferMixin, PatchMixin):
             secret_type=data["secret_type"],
             revision=data["revision"],
             created_by=data["created_by"],
-            created_at=datetime.fromisoformat(
-                data["created_at"].replace("Z", "+00:00")
-            ),
-            updated_at=datetime.fromisoformat(
-                data["updated_at"].replace("Z", "+00:00")
-            ),
+            created_at=_parse_iso_datetime(data["created_at"]),
+            updated_at=_parse_iso_datetime(data["updated_at"]),
         )
 
     def update_vault_secret(
@@ -299,12 +301,8 @@ class Client(TransferMixin, PatchMixin):
             secret_type=data["secret_type"],
             revision=data["revision"],
             created_by=data["created_by"],
-            created_at=datetime.fromisoformat(
-                data["created_at"].replace("Z", "+00:00")
-            ),
-            updated_at=datetime.fromisoformat(
-                data["updated_at"].replace("Z", "+00:00")
-            ),
+            created_at=_parse_iso_datetime(data["created_at"]),
+            updated_at=_parse_iso_datetime(data["updated_at"]),
         )
 
     def delete_vault_secret(self, name: str) -> None:

--- a/clients/drive9-py/drive9/client.py
+++ b/clients/drive9-py/drive9/client.py
@@ -101,10 +101,24 @@ class Client(TransferMixin, PatchMixin):
             data = resp.json()
             msg = data.get("error") or data.get("message")
         except Exception:
+            data = None
             msg = resp.text
         message = msg or f"HTTP {resp.status_code}"
         if resp.status_code == 409:
-            raise ConflictError(message, status_code=resp.status_code, response=resp)
+            server_revision = None
+            if isinstance(data, dict):
+                try:
+                    srv = data.get("server_revision")
+                    if srv is not None:
+                        server_revision = int(srv)
+                except Exception:
+                    pass
+            raise ConflictError(
+                message,
+                status_code=resp.status_code,
+                response=resp,
+                server_revision=server_revision,
+            )
         raise StatusError(message, status_code=resp.status_code, response=resp)
 
     def write(

--- a/clients/drive9-py/drive9/client.py
+++ b/clients/drive9-py/drive9/client.py
@@ -1,0 +1,477 @@
+"""Drive9 HTTP client."""
+
+from datetime import datetime
+from typing import Optional
+from urllib.parse import urlencode, quote
+
+import requests
+
+from .exceptions import Drive9Error, StatusError, ConflictError
+from .models import FileInfo, StatResult, SearchResult
+from .transfer import TransferMixin
+from .patch import PatchMixin
+from .stream import StreamWriter
+
+
+class Client(TransferMixin, PatchMixin):
+    """The Drive9 HTTP client."""
+
+    DEFAULT_SMALL_FILE_THRESHOLD = 50_000
+
+    @classmethod
+    def default(
+        cls,
+        small_file_threshold: int = 0,
+        session: Optional[requests.Session] = None,
+    ) -> "Client":
+        """Create a client using default server and API key from ~/.drive9/config."""
+        return cls(
+            "", api_key=None, small_file_threshold=small_file_threshold, session=session
+        )
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: Optional[str] = None,
+        small_file_threshold: int = 0,
+        session: Optional[requests.Session] = None,
+    ):
+        """Create a new Drive9 client.
+
+        Args:
+            base_url: The server base URL.
+            api_key: Optional API key for authorization.
+            small_file_threshold: Threshold for direct PUT vs multipart.
+                0 means use the default (50000).
+            session: Optional requests.Session to use.
+        """
+        cfg_server, cfg_key = _load_config()
+        if not base_url:
+            base_url = cfg_server
+        if api_key is None:
+            api_key = cfg_key
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.small_file_threshold = (
+            small_file_threshold or self.DEFAULT_SMALL_FILE_THRESHOLD
+        )
+        self.session = session or requests.Session()
+        adapter = requests.adapters.HTTPAdapter(
+            pool_connections=16,
+            pool_maxsize=16,
+        )
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)
+
+    def _url(self, path: str) -> str:
+        if not path.startswith("/"):
+            path = "/" + path
+        return f"{self.base_url}/v1/fs{path}"
+
+    def _vault_url(self, path: str) -> str:
+        if not path.startswith("/"):
+            path = "/" + path
+        return f"{self.base_url}/v1/vault{path}"
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        **kwargs,
+    ) -> requests.Response:
+        headers = kwargs.pop("headers", {}) or {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        try:
+            resp = self.session.request(method, url, headers=headers, **kwargs)
+        except requests.RequestException as exc:
+            raise Drive9Error(f"request failed: {exc}") from exc
+        return resp
+
+    def _check_error(self, resp: requests.Response) -> None:
+        if resp.status_code < 300:
+            return
+        try:
+            data = resp.json()
+            msg = data.get("error") or data.get("message")
+        except Exception:
+            msg = resp.text
+        message = msg or f"HTTP {resp.status_code}"
+        if resp.status_code == 409:
+            raise ConflictError(message, status_code=resp.status_code, response=resp)
+        raise StatusError(message, status_code=resp.status_code, response=resp)
+
+    def write(
+        self,
+        path: str,
+        data: bytes,
+        expected_revision: int = -1,
+    ) -> None:
+        """Upload data to a remote path.
+
+        Args:
+            expected_revision:
+                - negative: unconditional write
+                - zero: path must not already exist
+                - positive: file must exist at exactly that revision
+        """
+        headers = {"Content-Type": "application/octet-stream"}
+        if expected_revision >= 0:
+            headers["X-Dat9-Expected-Revision"] = str(expected_revision)
+        resp = self._request("PUT", self._url(path), data=data, headers=headers)
+        self._check_error(resp)
+
+    def read(self, path: str) -> bytes:
+        """Download a file's content."""
+        resp = self._request("GET", self._url(path), stream=True)
+        self._check_error(resp)
+        return resp.content
+
+    def list(self, path: str) -> list:
+        """Return the entries in a directory."""
+        resp = self._request("GET", self._url(path) + "?list=1")
+        self._check_error(resp)
+        result = resp.json()
+        entries = result.get("entries", [])
+        return [
+            FileInfo(
+                name=e["name"],
+                size=e["size"],
+                is_dir=e["isDir"],
+                mtime=e.get("mtime"),
+            )
+            for e in entries
+        ]
+
+    def stat(self, path: str) -> StatResult:
+        """Return metadata for a path."""
+        resp = self._request("HEAD", self._url(path))
+        if resp.status_code == 404:
+            raise Drive9Error(f"not found: {path}")
+        if resp.status_code >= 300:
+            self._check_error(resp)
+        size = 0
+        cl = resp.headers.get("Content-Length")
+        if cl:
+            size = int(cl)
+        revision = 0
+        rev = resp.headers.get("X-Dat9-Revision")
+        if rev:
+            revision = int(rev)
+        mtime = None
+        mt = resp.headers.get("X-Dat9-Mtime")
+        if mt:
+            try:
+                sec = int(mt)
+                from datetime import timezone
+
+                mtime = datetime.fromtimestamp(sec, tz=timezone.utc)
+            except (ValueError, OSError):
+                pass
+        return StatResult(
+            size=size,
+            is_dir=resp.headers.get("X-Dat9-IsDir") == "true",
+            revision=revision,
+            mtime=mtime,
+        )
+
+    def delete(self, path: str) -> None:
+        """Remove a file or directory."""
+        resp = self._request("DELETE", self._url(path))
+        self._check_error(resp)
+
+    def copy(self, src_path: str, dst_path: str) -> None:
+        """Perform a server-side zero-copy."""
+        resp = self._request(
+            "POST",
+            self._url(dst_path) + "?copy",
+            headers={"X-Dat9-Copy-Source": src_path},
+        )
+        self._check_error(resp)
+
+    def rename(self, old_path: str, new_path: str) -> None:
+        """Move/rename a file or directory (metadata-only)."""
+        resp = self._request(
+            "POST",
+            self._url(new_path) + "?rename",
+            headers={"X-Dat9-Rename-Source": old_path},
+        )
+        self._check_error(resp)
+
+    def mkdir(self, path: str) -> None:
+        """Create a directory."""
+        resp = self._request("POST", self._url(path) + "?mkdir")
+        self._check_error(resp)
+
+    def sql(self, query: str) -> list:
+        """Execute a SQL query."""
+        resp = self._request(
+            "POST",
+            f"{self.base_url}/v1/sql",
+            json={"query": query},
+            headers={"Content-Type": "application/json"},
+        )
+        self._check_error(resp)
+        return resp.json()
+
+    def grep(self, query: str, path_prefix: str, limit: int = 0) -> list:
+        """Search files using grep."""
+        url = self._url(path_prefix) + "?grep=" + quote(query, safe="")
+        if limit > 0:
+            url += f"&limit={limit}"
+        resp = self._request("GET", url)
+        self._check_error(resp)
+        results = resp.json()
+        return [
+            SearchResult(
+                path=r["path"],
+                name=r["name"],
+                size_bytes=r["size_bytes"],
+                score=r.get("score"),
+            )
+            for r in results
+        ]
+
+    def find(self, path_prefix: str, params: Optional[dict] = None) -> list:
+        """Search files using find."""
+        params = dict(params) if params else {}
+        params["find"] = ""
+        resp = self._request("GET", self._url(path_prefix) + "?" + urlencode(params))
+        self._check_error(resp)
+        results = resp.json()
+        return [
+            SearchResult(
+                path=r["path"],
+                name=r["name"],
+                size_bytes=r["size_bytes"],
+                score=r.get("score"),
+            )
+            for r in results
+        ]
+
+    # ------------------------------------------------------------------
+    # Vault API
+    # ------------------------------------------------------------------
+
+    def create_vault_secret(
+        self, name: str, fields: dict, created_by: str = "drive9-cli"
+    ):
+        """Create a new secret via the management API."""
+        from .models import VaultSecret
+
+        resp = self._request(
+            "POST",
+            self._vault_url("/secrets"),
+            json={"name": name, "fields": fields, "created_by": created_by},
+            headers={"Content-Type": "application/json"},
+        )
+        self._check_error(resp)
+        data = resp.json()
+        return VaultSecret(
+            name=data["name"],
+            secret_type=data["secret_type"],
+            revision=data["revision"],
+            created_by=data["created_by"],
+            created_at=datetime.fromisoformat(
+                data["created_at"].replace("Z", "+00:00")
+            ),
+            updated_at=datetime.fromisoformat(
+                data["updated_at"].replace("Z", "+00:00")
+            ),
+        )
+
+    def update_vault_secret(
+        self, name: str, fields: dict, updated_by: str = "drive9-cli"
+    ):
+        """Rotate a secret via the management API."""
+        from .models import VaultSecret
+
+        resp = self._request(
+            "PUT",
+            self._vault_url("/secrets/" + quote(name, safe="")),
+            json={"fields": fields, "updated_by": updated_by},
+            headers={"Content-Type": "application/json"},
+        )
+        self._check_error(resp)
+        data = resp.json()
+        return VaultSecret(
+            name=data["name"],
+            secret_type=data["secret_type"],
+            revision=data["revision"],
+            created_by=data["created_by"],
+            created_at=datetime.fromisoformat(
+                data["created_at"].replace("Z", "+00:00")
+            ),
+            updated_at=datetime.fromisoformat(
+                data["updated_at"].replace("Z", "+00:00")
+            ),
+        )
+
+    def delete_vault_secret(self, name: str) -> None:
+        """Delete a secret via the management API."""
+        resp = self._request(
+            "DELETE",
+            self._vault_url("/secrets/" + quote(name, safe="")),
+        )
+        self._check_error(resp)
+
+    def list_vault_secrets(self) -> list:
+        """List secret metadata via the management API."""
+        from .models import VaultSecret
+
+        resp = self._request("GET", self._vault_url("/secrets"))
+        self._check_error(resp)
+        data = resp.json()
+        secrets = data.get("secrets", []) or []
+        return [
+            VaultSecret(
+                name=s["name"],
+                secret_type=s["secret_type"],
+                revision=s["revision"],
+                created_by=s["created_by"],
+                created_at=datetime.fromisoformat(
+                    s["created_at"].replace("Z", "+00:00")
+                ),
+                updated_at=datetime.fromisoformat(
+                    s["updated_at"].replace("Z", "+00:00")
+                ),
+            )
+            for s in secrets
+        ]
+
+    def issue_vault_token(
+        self,
+        agent_id: str,
+        task_id: str,
+        scope: list,
+        ttl_seconds: int,
+    ):
+        """Issue a scoped capability token via the management API."""
+        from .models import VaultTokenIssueResponse
+
+        resp = self._request(
+            "POST",
+            self._vault_url("/tokens"),
+            json={
+                "agent_id": agent_id,
+                "task_id": task_id,
+                "scope": scope,
+                "ttl_seconds": ttl_seconds,
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        self._check_error(resp)
+        data = resp.json()
+        return VaultTokenIssueResponse(
+            token=data["token"],
+            token_id=data["token_id"],
+            expires_at=datetime.fromisoformat(
+                data["expires_at"].replace("Z", "+00:00")
+            ),
+        )
+
+    def revoke_vault_token(self, token_id: str) -> None:
+        """Revoke a capability token via the management API."""
+        resp = self._request(
+            "DELETE",
+            self._vault_url("/tokens/" + quote(token_id, safe="")),
+        )
+        self._check_error(resp)
+
+    def query_vault_audit(self, secret_name: str = "", limit: int = 0) -> list:
+        """Query the audit log via the management API."""
+        from .models import VaultAuditEvent
+
+        params = {}
+        if secret_name:
+            params["secret"] = secret_name
+        if limit > 0:
+            params["limit"] = str(limit)
+        url = self._vault_url("/audit")
+        if params:
+            url += "?" + urlencode(params)
+        resp = self._request("GET", url)
+        self._check_error(resp)
+        data = resp.json()
+        events = data.get("events", []) or []
+        return [
+            VaultAuditEvent(
+                event_id=e["event_id"],
+                event_type=e["event_type"],
+                timestamp=datetime.fromisoformat(e["timestamp"].replace("Z", "+00:00")),
+                token_id=e.get("token_id"),
+                agent_id=e.get("agent_id"),
+                task_id=e.get("task_id"),
+                secret_name=e.get("secret_name"),
+                field_name=e.get("field_name"),
+                adapter=e.get("adapter"),
+                detail=e.get("detail"),
+            )
+            for e in events
+        ]
+
+    def list_readable_vault_secrets(self) -> list:
+        """Enumerate secrets visible to the bearer capability token."""
+        resp = self._request("GET", self._vault_url("/read"))
+        self._check_error(resp)
+        data = resp.json()
+        return data.get("secrets", []) or []
+
+    def read_vault_secret(self, name: str) -> dict:
+        """Read all fields of a secret using the consumption API."""
+        resp = self._request(
+            "GET",
+            self._vault_url("/read/" + quote(name, safe="")),
+        )
+        self._check_error(resp)
+        return resp.json()
+
+    def read_vault_secret_field(self, name: str, field: str) -> str:
+        """Read a single field via the consumption API."""
+        resp = self._request(
+            "GET",
+            self._vault_url(
+                "/read/" + quote(name, safe="") + "/" + quote(field, safe="")
+            ),
+        )
+        self._check_error(resp)
+        return resp.text
+
+    # ------------------------------------------------------------------
+    # Stream writer
+    # ------------------------------------------------------------------
+
+    def new_stream_writer(
+        self, path: str, total_size: int, expected_revision: int = -1
+    ) -> StreamWriter:
+        """Create a StreamWriter for streaming multipart upload.
+
+        No network call is made until the first WritePart.
+        """
+        return StreamWriter(self, path, total_size, expected_revision)
+
+
+def _load_config() -> tuple:
+    import json
+    import os
+
+    _DEFAULT_DRIVE9_SERVER = "https://api.drive9.ai"
+
+    env_server = os.environ.get("DRIVE9_SERVER")
+    env_key = os.environ.get("DRIVE9_API_KEY")
+
+    home = os.path.expanduser("~")
+    path = os.path.join(home, ".drive9", "config")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            cfg = json.load(f)
+    except Exception:
+        return env_server or _DEFAULT_DRIVE9_SERVER, env_key
+    server = cfg.get("server") or _DEFAULT_DRIVE9_SERVER
+    current = cfg.get("current_context")
+    file_key = None
+    if current:
+        ctx = cfg.get("contexts", {}).get(current)
+        if ctx:
+            file_key = ctx.get("api_key")
+    return env_server or server, env_key or file_key

--- a/clients/drive9-py/drive9/exceptions.py
+++ b/clients/drive9-py/drive9/exceptions.py
@@ -32,5 +32,7 @@ class ConflictError(StatusError):
         message: str,
         status_code: int = 409,
         response: Optional[object] = None,
+        server_revision: Optional[int] = None,
     ):
         super().__init__(message, status_code, response)
+        self.server_revision = server_revision

--- a/clients/drive9-py/drive9/exceptions.py
+++ b/clients/drive9-py/drive9/exceptions.py
@@ -1,0 +1,36 @@
+"""Drive9 SDK exceptions."""
+
+from typing import Optional
+
+
+class Drive9Error(Exception):
+    """Base exception for Drive9 SDK errors."""
+
+    def __init__(self, message: str, response: Optional[object] = None):
+        super().__init__(message)
+        self.response = response
+
+
+class StatusError(Drive9Error):
+    """Preserves the HTTP status code for API errors."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int,
+        response: Optional[object] = None,
+    ):
+        super().__init__(message, response)
+        self.status_code = status_code
+
+
+class ConflictError(StatusError):
+    """HTTP 409 write conflict."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int = 409,
+        response: Optional[object] = None,
+    ):
+        super().__init__(message, status_code, response)

--- a/clients/drive9-py/drive9/models.py
+++ b/clients/drive9-py/drive9/models.py
@@ -49,7 +49,7 @@ class UploadPlan:
     """The server's 202 response for large file uploads."""
     upload_id: str
     part_size: int
-    parts: list
+    parts: list["PartURL"]
 
 
 @dataclass
@@ -69,8 +69,8 @@ class PatchPlan:
     """The server's response for a PATCH request."""
     upload_id: str
     part_size: int
-    upload_parts: list
-    copied_parts: list
+    upload_parts: list["PatchPartURL"]
+    copied_parts: list[int]
 
 
 @dataclass

--- a/clients/drive9-py/drive9/models.py
+++ b/clients/drive9-py/drive9/models.py
@@ -1,0 +1,116 @@
+"""Data models for the Drive9 SDK."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class FileInfo:
+    """Represents a file entry from a directory listing."""
+    name: str
+    size: int
+    is_dir: bool
+    mtime: Optional[int] = None  # Unix seconds, 0/None means unknown
+
+
+@dataclass
+class StatResult:
+    """Represents file metadata from HEAD."""
+    size: int
+    is_dir: bool
+    revision: int
+    mtime: Optional[datetime] = None
+
+
+@dataclass
+class SearchResult:
+    """Represents a search result."""
+    path: str
+    name: str
+    size_bytes: int
+    score: Optional[float] = None
+
+
+@dataclass
+class PartURL:
+    """A presigned URL for uploading one part."""
+    number: int
+    url: str
+    size: int
+    checksum_sha256: Optional[str] = None
+    checksum_crc32c: Optional[str] = None
+    headers: Optional[dict] = None
+    expires_at: Optional[str] = None
+
+
+@dataclass
+class UploadPlan:
+    """The server's 202 response for large file uploads."""
+    upload_id: str
+    part_size: int
+    parts: list
+
+
+@dataclass
+class PatchPartURL:
+    """Describes one dirty part the client must upload."""
+    number: int
+    url: str
+    size: int
+    headers: Optional[dict] = None
+    expires_at: Optional[str] = None
+    read_url: Optional[str] = None
+    read_headers: Optional[dict] = None
+
+
+@dataclass
+class PatchPlan:
+    """The server's response for a PATCH request."""
+    upload_id: str
+    part_size: int
+    upload_parts: list
+    copied_parts: list
+
+
+@dataclass
+class UploadMeta:
+    """The server's response for querying active uploads."""
+    upload_id: str
+    parts_total: int
+    status: str
+    expires_at: str
+
+
+@dataclass
+class VaultSecret:
+    """Secret metadata returned by the management API."""
+    name: str
+    secret_type: str
+    revision: int
+    created_by: str
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass
+class VaultTokenIssueResponse:
+    """Response when issuing a scoped capability token."""
+    token: str
+    token_id: str
+    expires_at: datetime
+
+
+@dataclass
+class VaultAuditEvent:
+    """Audit event returned by the vault audit API."""
+    event_id: str
+    event_type: str
+    timestamp: datetime
+    token_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    task_id: Optional[str] = None
+    secret_name: Optional[str] = None
+    field_name: Optional[str] = None
+    adapter: Optional[str] = None
+    detail: Optional[dict] = None

--- a/clients/drive9-py/drive9/patch.py
+++ b/clients/drive9-py/drive9/patch.py
@@ -1,0 +1,142 @@
+"""Patch upload helpers for partial file updates."""
+
+import base64
+import hashlib
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Optional, Callable
+
+from .exceptions import StatusError
+from .models import PatchPartURL
+
+ProgressFunc = Callable[[int, int, int], None]
+_ReadPartFunc = Callable[[int, int, Optional[bytes]], bytes]
+
+
+class PatchMixin:
+    """Mixin that adds patch file methods to Client."""
+
+    def patch_file(
+        self,
+        path: str,
+        new_size: int,
+        dirty_parts: list,
+        read_part: _ReadPartFunc,
+        progress: Optional[ProgressFunc] = None,
+        part_size: int = 0,
+    ) -> None:
+        """Perform a partial update of a large file.
+
+        Args:
+            path: Remote file path.
+            new_size: Total size of the file after patching.
+            dirty_parts: 1-based part numbers that have been modified.
+            read_part: Callback that returns the complete data for a given part.
+                Receives (part_number, part_size, orig_data).
+            progress: Optional progress callback.
+            part_size: Optional part size hint.
+        """
+        patch_req = {
+            "new_size": new_size,
+            "dirty_parts": dirty_parts,
+        }
+        if part_size > 0:
+            patch_req["part_size"] = part_size
+
+        resp = self._request(
+            "PATCH",
+            self._url(path),
+            data=json.dumps(patch_req),
+            headers={"Content-Type": "application/json"},
+        )
+        if resp.status_code != 202:
+            raise StatusError(
+                resp.text,
+                status_code=resp.status_code,
+                response=resp,
+            )
+        plan = resp.json()
+
+        upload_parts = [
+            PatchPartURL(
+                number=p["number"],
+                url=p["url"],
+                size=p["size"],
+                headers=p.get("headers"),
+                expires_at=p.get("expires_at"),
+                read_url=p.get("read_url"),
+                read_headers=p.get("read_headers"),
+            )
+            for p in plan.get("upload_parts", [])
+        ]
+        copied_parts = plan.get("copied_parts", [])
+        total_parts = len(upload_parts) + len(copied_parts)
+
+        max_concurrency = 4
+        err = None
+        err_lock = threading.Lock()
+
+        def upload_one(part: PatchPartURL):
+            nonlocal err
+            if err is not None:
+                return
+            try:
+                self._upload_patch_part(part, read_part)
+                if progress:
+                    progress(part.number, total_parts, part.size)
+            except Exception as exc:
+                with err_lock:
+                    if err is None:
+                        err = exc
+
+        executor = ThreadPoolExecutor(max_workers=max_concurrency)
+        futures = {executor.submit(upload_one, p): p for p in upload_parts}
+        try:
+            for future in as_completed(futures):
+                future.result()
+        except Exception:
+            executor.shutdown(wait=False)
+            raise
+        executor.shutdown(wait=True)
+
+        if err is not None:
+            raise err
+
+        self._complete_upload(plan["upload_id"])
+
+    def _upload_patch_part(self, part: PatchPartURL, read_part: _ReadPartFunc) -> None:
+        orig_data = None
+        if part.read_url:
+            headers = {}
+            if part.read_headers:
+                for k, v in part.read_headers.items():
+                    if k.lower() == "host":
+                        continue
+                    headers[k] = v
+            resp = self.session.get(part.read_url, headers=headers)
+            if resp.status_code >= 300:
+                raise StatusError(
+                    f"download original part: HTTP {resp.status_code}: {resp.text}",
+                    status_code=resp.status_code,
+                    response=resp,
+                )
+            orig_data = resp.content
+
+        data = read_part(part.number, part.size, orig_data)
+        checksum = base64.b64encode(hashlib.sha256(data).digest()).decode("ascii")
+
+        headers = {"x-amz-checksum-sha256": checksum}
+        if part.headers:
+            for k, v in part.headers.items():
+                if k.lower() == "host":
+                    continue
+                headers[k] = v
+
+        resp = self.session.put(part.url, data=data, headers=headers)
+        if resp.status_code >= 300:
+            raise StatusError(
+                f"upload part: HTTP {resp.status_code}: {resp.text}",
+                status_code=resp.status_code,
+                response=resp,
+            )

--- a/clients/drive9-py/drive9/stream.py
+++ b/clients/drive9-py/drive9/stream.py
@@ -2,7 +2,10 @@
 
 import threading
 
+import requests
+
 from .exceptions import Drive9Error
+from .transfer import _V2NotAvailable
 
 _UPLOAD_MAX_CONCURRENCY = 16
 
@@ -49,7 +52,7 @@ class StreamWriter:
             msg = f"initiate stream upload: {exc}"
             if isinstance(exc, Drive9Error) and "v2 protocol" in str(exc):
                 raise
-            if hasattr(exc, "__class__") and exc.__class__.__name__ == "_V2NotAvailable":
+            if isinstance(exc, _V2NotAvailable):
                 raise Drive9Error("streaming upload requires v2 protocol: v2 upload API not available") from exc
             raise Drive9Error(msg) from exc
         self._plan = plan
@@ -89,7 +92,7 @@ class StreamWriter:
                 etag = self._client._upload_one_part_v2(pp, buf)
                 with self._mu:
                     self._uploaded[part_num] = {"number": part_num, "etag": etag}
-            except Exception as exc:
+            except (requests.RequestException, OSError) as exc:
                 self._set_error(Drive9Error(f"upload part {part_num}: {exc}"))
             finally:
                 self._sem.release()
@@ -145,7 +148,9 @@ class StreamWriter:
                 parts.append(cp)
 
             self._completed = True
-            self._client._complete_upload_v2(plan["upload_id"], parts)
+            upload_id = plan["upload_id"]
+
+        self._client._complete_upload_v2(upload_id, parts)
 
     def abort(self) -> None:
         """Cancel the multipart upload and clean up server-side state."""

--- a/clients/drive9-py/drive9/stream.py
+++ b/clients/drive9-py/drive9/stream.py
@@ -1,0 +1,174 @@
+"""Streaming multipart upload helpers."""
+
+import threading
+
+from .exceptions import Drive9Error
+
+_UPLOAD_MAX_CONCURRENCY = 16
+
+
+class StreamWriter:
+    """Streaming multipart upload API where individual parts can be submitted
+    concurrently as they become available.
+
+    Wraps the v2 upload protocol (initiate → presign → upload → complete).
+    """
+
+    def __init__(self, client, path: str, total_size: int, expected_revision: int = -1):
+        self._client = client
+        self._path = path
+        self._total_size = total_size
+        self._expected_revision = expected_revision
+
+        self._mu = threading.Lock()
+        self._plan = None
+        self._uploaded = {}
+        self._inflight = 0
+        self._cond = threading.Condition(self._mu)
+        self._err = None
+        self._started = False
+        self._completed = False
+        self._aborted = False
+        self._closing = False
+
+        self._sem = threading.Semaphore(_UPLOAD_MAX_CONCURRENCY)
+
+    @property
+    def started(self) -> bool:
+        with self._mu:
+            return self._started
+
+    def _init_locked(self):
+        if self._started:
+            return
+        try:
+            plan = self._client._initiate_upload_v2(
+                self._path, self._total_size, self._expected_revision
+            )
+        except Exception as exc:
+            msg = f"initiate stream upload: {exc}"
+            if isinstance(exc, Drive9Error) and "v2 protocol" in str(exc):
+                raise
+            if hasattr(exc, "__class__") and exc.__class__.__name__ == "_V2NotAvailable":
+                raise Drive9Error("streaming upload requires v2 protocol: v2 upload API not available") from exc
+            raise Drive9Error(msg) from exc
+        self._plan = plan
+        self._started = True
+
+    def write_part(self, part_num: int, data: bytes) -> None:
+        """Upload a single part in the background. part_num is 1-based.
+
+        Data is copied internally so the caller may reuse the buffer after return.
+        """
+        with self._mu:
+            if self._err is not None:
+                raise self._err
+            if self._completed:
+                raise Drive9Error("stream writer already completed")
+            if self._aborted:
+                raise Drive9Error("stream writer already aborted")
+            if self._closing:
+                raise Drive9Error("stream writer is closing")
+
+            self._init_locked()
+            plan = self._plan
+
+            self._inflight += 1
+
+        buf = bytes(data)
+
+        acquired = self._sem.acquire(timeout=30.0)
+        if not acquired:
+            with self._mu:
+                self._inflight -= 1
+            raise Drive9Error("failed to acquire upload semaphore")
+
+        def do_upload():
+            try:
+                pp = self._client._presign_one_part(plan["upload_id"], part_num)
+                etag = self._client._upload_one_part_v2(pp, buf)
+                with self._mu:
+                    self._uploaded[part_num] = {"number": part_num, "etag": etag}
+            except Exception as exc:
+                self._set_error(Drive9Error(f"upload part {part_num}: {exc}"))
+            finally:
+                self._sem.release()
+                with self._mu:
+                    self._inflight -= 1
+                    self._cond.notify_all()
+
+        t = threading.Thread(target=do_upload, daemon=True)
+        t.start()
+
+    def complete(self, final_part_num: int = 0, final_part_data: bytes = b"") -> None:
+        """Wait for inflight parts, upload the final part (if provided), and finalize."""
+        with self._mu:
+            if self._completed:
+                raise Drive9Error("stream writer already completed")
+            if self._aborted:
+                raise Drive9Error("stream writer already aborted")
+            if self._closing:
+                raise Drive9Error("stream writer is closing")
+            self._closing = True
+
+        self._wait_inflight()
+
+        with self._mu:
+            if self._err is not None:
+                raise self._err
+            if not self._started or self._plan is None:
+                raise Drive9Error("stream writer was never started")
+            plan = self._plan
+
+        if final_part_data:
+            pp = self._client._presign_one_part(plan["upload_id"], final_part_num)
+            etag = self._client._upload_one_part_v2(pp, final_part_data)
+            with self._mu:
+                self._uploaded[final_part_num] = {
+                    "number": final_part_num,
+                    "etag": etag,
+                }
+
+        with self._mu:
+            if not self._uploaded:
+                raise Drive9Error("no parts uploaded in stream upload")
+
+            max_part = max(self._uploaded.keys())
+            parts = []
+            for i in range(1, max_part + 1):
+                cp = self._uploaded.get(i)
+                if cp is None:
+                    raise Drive9Error(
+                        f"missing part {i} in stream upload "
+                        f"(have {len(self._uploaded)} parts, max {max_part})"
+                    )
+                parts.append(cp)
+
+            self._completed = True
+            self._client._complete_upload_v2(plan["upload_id"], parts)
+
+    def abort(self) -> None:
+        """Cancel the multipart upload and clean up server-side state."""
+        with self._mu:
+            if self._aborted:
+                return
+            self._closing = True
+
+        self._wait_inflight()
+
+        with self._mu:
+            self._aborted = True
+            if not self._started or self._plan is None:
+                return
+            upload_id = self._plan["upload_id"]
+        self._client._abort_upload_v2(upload_id)
+
+    def _wait_inflight(self):
+        with self._mu:
+            while self._inflight > 0:
+                self._cond.wait(timeout=1.0)
+
+    def _set_error(self, err):
+        with self._mu:
+            if self._err is None:
+                self._err = err

--- a/clients/drive9-py/drive9/stream.py
+++ b/clients/drive9-py/drive9/stream.py
@@ -1,5 +1,6 @@
 """Streaming multipart upload helpers."""
 
+from concurrent.futures import ThreadPoolExecutor
 import threading
 
 import requests
@@ -34,7 +35,7 @@ class StreamWriter:
         self._aborted = False
         self._closing = False
 
-        self._sem = threading.Semaphore(_UPLOAD_MAX_CONCURRENCY)
+        self._executor = None
 
     @property
     def started(self) -> bool:
@@ -63,6 +64,9 @@ class StreamWriter:
 
         Data is copied internally so the caller may reuse the buffer after return.
         """
+        if part_num < 1:
+            raise Drive9Error("part number must be >= 1")
+
         with self._mu:
             if self._err is not None:
                 raise self._err
@@ -72,36 +76,39 @@ class StreamWriter:
                 raise Drive9Error("stream writer already aborted")
             if self._closing:
                 raise Drive9Error("stream writer is closing")
+            if part_num in self._uploaded:
+                raise Drive9Error(f"part {part_num} already uploaded")
 
             self._init_locked()
             plan = self._plan
 
+            total_parts = plan.get("total_parts")
+            if total_parts is not None and part_num > total_parts:
+                raise Drive9Error(
+                    f"part number {part_num} exceeds total_parts {total_parts}"
+                )
+
             self._inflight += 1
 
-        buf = bytes(data)
+            if self._executor is None:
+                self._executor = ThreadPoolExecutor(max_workers=_UPLOAD_MAX_CONCURRENCY)
 
-        acquired = self._sem.acquire(timeout=30.0)
-        if not acquired:
-            with self._mu:
-                self._inflight -= 1
-            raise Drive9Error("failed to acquire upload semaphore")
+        buf = bytes(data)
 
         def do_upload():
             try:
                 pp = self._client._presign_one_part(plan["upload_id"], part_num)
-                etag = self._client._upload_one_part_v2(pp, buf)
+                etag = self._client._upload_one_part_v2(plan["upload_id"], pp, buf)
                 with self._mu:
                     self._uploaded[part_num] = {"number": part_num, "etag": etag}
             except (requests.RequestException, OSError) as exc:
                 self._set_error(Drive9Error(f"upload part {part_num}: {exc}"))
             finally:
-                self._sem.release()
                 with self._mu:
                     self._inflight -= 1
                     self._cond.notify_all()
 
-        t = threading.Thread(target=do_upload, daemon=True)
-        t.start()
+        self._executor.submit(do_upload)
 
     def complete(self, final_part_num: int = 0, final_part_data: bytes = b"") -> None:
         """Wait for inflight parts, upload the final part (if provided), and finalize."""
@@ -125,7 +132,7 @@ class StreamWriter:
 
         if final_part_data:
             pp = self._client._presign_one_part(plan["upload_id"], final_part_num)
-            etag = self._client._upload_one_part_v2(pp, final_part_data)
+            etag = self._client._upload_one_part_v2(plan["upload_id"], pp, final_part_data)
             with self._mu:
                 self._uploaded[final_part_num] = {
                     "number": final_part_num,
@@ -150,7 +157,10 @@ class StreamWriter:
             self._completed = True
             upload_id = plan["upload_id"]
 
-        self._client._complete_upload_v2(upload_id, parts)
+        try:
+            self._client._complete_upload_v2(upload_id, parts)
+        finally:
+            self._shutdown_executor()
 
     def abort(self) -> None:
         """Cancel the multipart upload and clean up server-side state."""
@@ -164,14 +174,24 @@ class StreamWriter:
         with self._mu:
             self._aborted = True
             if not self._started or self._plan is None:
+                self._shutdown_executor()
                 return
             upload_id = self._plan["upload_id"]
-        self._client._abort_upload_v2(upload_id)
+        try:
+            self._client._abort_upload_v2(upload_id)
+        finally:
+            self._shutdown_executor()
 
     def _wait_inflight(self):
         with self._mu:
             while self._inflight > 0:
                 self._cond.wait(timeout=1.0)
+
+    def _shutdown_executor(self):
+        with self._mu:
+            if self._executor is not None:
+                self._executor.shutdown(wait=True)
+                self._executor = None
 
     def _set_error(self, err):
         with self._mu:

--- a/clients/drive9-py/drive9/transfer.py
+++ b/clients/drive9-py/drive9/transfer.py
@@ -1,0 +1,640 @@
+"""Transfer helpers for large-file uploads and stream reads."""
+
+import base64
+import json
+import math
+import struct
+import threading
+import zlib
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from io import BytesIO
+from typing import Optional, Callable
+
+from .exceptions import Drive9Error, StatusError
+from .models import UploadPlan, PartURL, UploadMeta
+
+ProgressFunc = Callable[[int, int, int], None]
+
+_PART_SIZE = 8 * 1024 * 1024  # 8 MiB
+_UPLOAD_MAX_CONCURRENCY = 16
+_UPLOAD_MAX_BUFFER_BYTES = 256 * 1024 * 1024
+
+
+def _upload_parallelism(part_size: int) -> int:
+    by_memory = max(1, _UPLOAD_MAX_BUFFER_BYTES // part_size)
+    return min(by_memory, _UPLOAD_MAX_CONCURRENCY)
+
+
+def _checksum_parallelism(part_size: int, part_count: int) -> int:
+    by_memory = max(1, _UPLOAD_MAX_BUFFER_BYTES // part_size)
+    return min(part_count, by_memory)
+
+
+def _compute_crc32c(data: bytes) -> str:
+    v = zlib.crc32(data, 0xFFFFFFFF) & 0xFFFFFFFF
+    b = struct.pack(">I", v)
+    return base64.b64encode(b).decode("ascii")
+
+
+def _calc_parts(total_size: int, part_size: int) -> list:
+    """Calculate part sizes for a multipart upload."""
+    if total_size <= 0:
+        return []
+    num_parts = math.ceil(total_size / part_size)
+    parts = []
+    for i in range(num_parts):
+        offset = i * part_size
+        size = min(part_size, total_size - offset)
+        parts.append({"number": i + 1, "size": size})
+    return parts
+
+
+def _compute_part_checksums(file_obj, total_size: int, part_size: int) -> list:
+    """Compute CRC32C checksums for all parts."""
+    parts = _calc_parts(total_size, part_size)
+    if not parts:
+        return []
+    workers = _checksum_parallelism(part_size, len(parts))
+
+    checksums = [None] * len(parts)
+    first_err = None
+    err_lock = threading.Lock()
+
+    def worker(chunk_indices):
+        nonlocal first_err
+        buf = bytearray(part_size)
+        for idx in chunk_indices:
+            if first_err is not None:
+                return
+            p = parts[idx]
+            offset = (p["number"] - 1) * part_size
+            file_obj.seek(offset)
+            n = file_obj.readinto(buf)
+            if n != p["size"]:
+                with err_lock:
+                    if first_err is None:
+                        first_err = Drive9Error(
+                            f"short read for part {p['number']}: got {n} want {p['size']}"
+                        )
+                return
+            checksums[idx] = _compute_crc32c(bytes(buf[:n]))
+
+    indices_per_worker = [[] for _ in range(workers)]
+    for i, idx in enumerate(range(len(parts))):
+        indices_per_worker[i % workers].append(idx)
+
+    threads = []
+    for worker_indices in indices_per_worker:
+        t = threading.Thread(target=worker, args=(worker_indices,))
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join()
+
+    if first_err is not None:
+        raise first_err
+    return checksums
+
+
+class TransferMixin:
+    """Mixin that adds upload/download stream methods to Client."""
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def write_stream(
+        self,
+        path: str,
+        file_obj,
+        size: int,
+        progress: Optional[ProgressFunc] = None,
+        expected_revision: int = -1,
+    ) -> None:
+        """Upload data from a file-like object.
+
+        For small files (size < threshold) it does a direct PUT.
+        For large files it uses the v2 multipart protocol, falling back to v1.
+        """
+        threshold = self.small_file_threshold or self.DEFAULT_SMALL_FILE_THRESHOLD
+        if size < threshold:
+            data = file_obj.read()
+            if isinstance(data, str):
+                data = data.encode("utf-8")
+            self.write(path, data, expected_revision=expected_revision)
+            return
+
+        if not hasattr(file_obj, "seek"):
+            raise Drive9Error("large uploads require a seekable source")
+
+        try:
+            self._write_stream_v2(path, file_obj, size, progress, expected_revision)
+        except _V2NotAvailable:
+            self._write_stream_v1(path, file_obj, size, progress, expected_revision)
+
+    def read_stream(self, path: str):
+        """Read a file, following 302 redirects for large files.
+
+        Returns a file-like object that must be closed by the caller.
+        """
+        resp = self._request(
+            "GET",
+            self._url(path),
+            allow_redirects=False,
+            stream=True,
+        )
+        if resp.status_code in (302, 307):
+            location = resp.headers.get("Location")
+            resp.close()
+            if not location:
+                raise Drive9Error("302 without Location header")
+            resp2 = self.session.get(location, stream=True)
+            if resp2.status_code >= 300:
+                resp2.close()
+                raise StatusError(
+                    f"HTTP {resp2.status_code}: {resp2.text}",
+                    status_code=resp2.status_code,
+                    response=resp2,
+                )
+            return resp2.raw
+        if resp.status_code >= 300:
+            resp.close()
+            raise StatusError(
+                f"HTTP {resp.status_code}: {resp.text}",
+                status_code=resp.status_code,
+                response=resp,
+            )
+        return resp.raw
+
+    def read_stream_range(self, path: str, offset: int, length: int):
+        """Read a byte range from a remote file.
+
+        Returns a file-like object that must be closed by the caller.
+        """
+        if length <= 0:
+            return BytesIO(b"")
+
+        resp = self._request(
+            "GET",
+            self._url(path),
+            allow_redirects=False,
+            stream=True,
+        )
+        if resp.status_code in (302, 307):
+            location = resp.headers.get("Location")
+            resp.close()
+            if not location:
+                raise Drive9Error("302 without Location header")
+            resp2 = self.session.get(
+                location,
+                headers={"Range": f"bytes={offset}-{offset + length - 1}"},
+                stream=True,
+            )
+            if resp2.status_code == 206:
+                return resp2.raw
+            if resp2.status_code == 416:
+                resp2.close()
+                return BytesIO(b"")
+            if resp2.status_code >= 300:
+                resp2.close()
+                raise StatusError(
+                    f"HTTP {resp2.status_code}: {resp2.text}",
+                    status_code=resp2.status_code,
+                    response=resp2,
+                )
+            return _slice_body(resp2.raw, offset, length)
+        if resp.status_code >= 300:
+            resp.close()
+            raise StatusError(
+                f"HTTP {resp.status_code}: {resp.text}",
+                status_code=resp.status_code,
+                response=resp,
+            )
+        return _slice_body(resp.raw, offset, length)
+
+    def resume_upload(
+        self,
+        path: str,
+        file_obj,
+        total_size: int,
+        progress: Optional[ProgressFunc] = None,
+    ) -> None:
+        """Query for an incomplete upload and resume it."""
+        meta = self._query_upload(path)
+        checksums = _compute_part_checksums(file_obj, total_size, _PART_SIZE)
+        plan = self._request_resume(meta.upload_id, checksums)
+        if not plan.parts:
+            self._complete_upload(plan.upload_id)
+            return
+        self._upload_missing_parts(plan, file_obj, meta.parts_total, progress)
+        self._complete_upload(plan.upload_id)
+
+    # ------------------------------------------------------------------
+    # v1 upload
+    # ------------------------------------------------------------------
+
+    def _write_stream_v1(self, path, file_obj, size, progress, expected_revision=-1):
+        checksums = _compute_part_checksums(file_obj, size, _PART_SIZE)
+        plan = self._initiate_upload(path, size, checksums, expected_revision)
+        self._upload_parts_v1(plan, file_obj, progress)
+
+    def _initiate_upload(
+        self, path: str, size: int, checksums: list, expected_revision: int = -1
+    ) -> UploadPlan:
+        plan, resp_err = self._initiate_upload_by_body(
+            path, size, checksums, expected_revision
+        )
+        if plan is not None:
+            return plan
+        resp, err = resp_err
+        if resp is not None:
+            if resp.status_code in (404, 405):
+                return self._initiate_upload_legacy(
+                    path, size, checksums, expected_revision
+                )
+            if resp.status_code == 400 and "unknown upload action" in err.lower():
+                return self._initiate_upload_legacy(
+                    path, size, checksums, expected_revision
+                )
+            raise StatusError(err, status_code=resp.status_code, response=resp)
+        raise Drive9Error(err)
+
+    def _initiate_upload_by_body(self, path, size, checksums, expected_revision=-1):
+        payload = {"path": path, "total_size": size, "part_checksums": checksums}
+        if expected_revision >= 0:
+            payload["expected_revision"] = expected_revision
+        body = json.dumps(payload)
+        resp = self._request(
+            "POST",
+            f"{self.base_url}/v1/uploads/initiate",
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        if resp.status_code == 202:
+            data = resp.json()
+            return self._parse_upload_plan(data), None
+        return None, (resp, resp.text)
+
+    def _initiate_upload_legacy(self, path, size, checksums, expected_revision=-1):
+        headers = {
+            "Content-Type": "application/octet-stream",
+            "X-Dat9-Content-Length": str(size),
+        }
+        if checksums:
+            headers["X-Dat9-Part-Checksums"] = ",".join(checksums)
+        if expected_revision >= 0:
+            headers["X-Dat9-Expected-Revision"] = str(expected_revision)
+        resp = self._request("PUT", self._url(path), headers=headers)
+        if resp.status_code != 202:
+            raise StatusError(resp.text, status_code=resp.status_code, response=resp)
+        return self._parse_upload_plan(resp.json())
+
+    def _parse_upload_plan(self, data: dict) -> UploadPlan:
+        parts = [
+            PartURL(
+                number=p["number"],
+                url=p["url"],
+                size=p["size"],
+                checksum_sha256=p.get("checksum_sha256"),
+                checksum_crc32c=p.get("checksum_crc32c"),
+                headers=p.get("headers"),
+                expires_at=p.get("expires_at"),
+            )
+            for p in data.get("parts", [])
+        ]
+        return UploadPlan(
+            upload_id=data["upload_id"],
+            part_size=data["part_size"],
+            parts=parts,
+        )
+
+    def _upload_parts_v1(self, plan: UploadPlan, file_obj, progress):
+        std_part_size = plan.part_size
+        if std_part_size <= 0 and plan.parts:
+            std_part_size = plan.parts[0].size
+        if std_part_size <= 0:
+            std_part_size = _PART_SIZE
+        max_concurrency = _upload_parallelism(std_part_size)
+
+        def upload_one(part: PartURL):
+            offset = (part.number - 1) * std_part_size
+            file_obj.seek(offset)
+            data = file_obj.read(part.size)
+            if len(data) != part.size:
+                raise Drive9Error(
+                    f"short read for part {part.number}: got {len(data)} want {part.size}"
+                )
+            self._upload_one_part(part, data)
+            if progress:
+                progress(part.number, len(plan.parts), len(data))
+
+        executor = ThreadPoolExecutor(max_workers=max_concurrency)
+        futures = {executor.submit(upload_one, p): p for p in plan.parts}
+        try:
+            for future in as_completed(futures):
+                future.result()
+        except Exception:
+            executor.shutdown(wait=False)
+            raise
+        executor.shutdown(wait=True)
+        self._complete_upload(plan.upload_id)
+
+    def _upload_one_part(self, part: PartURL, data: bytes) -> str:
+        checksum = part.checksum_crc32c
+        if not checksum:
+            checksum = _compute_crc32c(data)
+        headers = {"x-amz-checksum-crc32c": checksum}
+        if part.headers:
+            for k, v in part.headers.items():
+                if k.lower() == "host":
+                    continue
+                headers[k] = v
+        resp = self.session.put(part.url, data=data, headers=headers)
+        if resp.status_code >= 300:
+            raise StatusError(
+                f"HTTP {resp.status_code}: {resp.text}",
+                status_code=resp.status_code,
+                response=resp,
+            )
+        return resp.headers.get("ETag", "")
+
+    def _complete_upload(self, upload_id: str) -> None:
+        resp = self._request(
+            "POST",
+            f"{self.base_url}/v1/uploads/{upload_id}/complete",
+        )
+        if resp.status_code >= 300:
+            raise StatusError(resp.text, status_code=resp.status_code, response=resp)
+
+    # ------------------------------------------------------------------
+    # v2 upload
+    # ------------------------------------------------------------------
+
+    def _write_stream_v2(self, path, file_obj, size, progress, expected_revision=-1):
+        plan = self._initiate_upload_v2(path, size, expected_revision)
+        try:
+            parts = self._upload_parts_v2(plan, file_obj, progress)
+        except Exception:
+            self._abort_upload_v2(plan["upload_id"])
+            raise
+        try:
+            self._complete_upload_v2(plan["upload_id"], parts)
+        except Exception:
+            self._abort_upload_v2(plan["upload_id"])
+            raise
+
+    def _initiate_upload_v2(
+        self, path: str, size: int, expected_revision: int = -1
+    ) -> dict:
+        payload = {"path": path, "total_size": size}
+        if expected_revision >= 0:
+            payload["expected_revision"] = expected_revision
+        body = json.dumps(payload)
+        resp = self._request(
+            "POST",
+            f"{self.base_url}/v2/uploads/initiate",
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        if resp.status_code == 404:
+            raise _V2NotAvailable()
+        if resp.status_code != 202:
+            raise StatusError(resp.text, status_code=resp.status_code, response=resp)
+        return resp.json()
+
+    def _upload_parts_v2(self, plan: dict, file_obj, progress) -> list:
+        part_size = plan["part_size"]
+        total_parts = plan["total_parts"]
+        upload_id = plan["upload_id"]
+        parallelism = _upload_parallelism(part_size)
+
+        presigned = []
+        batch_size = parallelism
+        for start in range(1, total_parts + 1, batch_size):
+            end = min(start + batch_size - 1, total_parts)
+            batch = self._presign_batch(upload_id, start, end)
+            presigned.extend(batch)
+
+        results = [None] * total_parts
+
+        def upload_one(pp: dict):
+            offset = (pp["number"] - 1) * part_size
+            file_obj.seek(offset)
+            data = file_obj.read(pp["size"])
+            if len(data) != pp["size"]:
+                raise Drive9Error(
+                    f"short read for part {pp['number']}: got {len(data)} want {pp['size']}"
+                )
+            etag = self._upload_one_part_v2(pp, data)
+            results[pp["number"] - 1] = {"number": pp["number"], "etag": etag}
+            if progress:
+                progress(pp["number"], total_parts, len(data))
+
+        executor = ThreadPoolExecutor(max_workers=parallelism)
+        futures = {executor.submit(upload_one, p): p for p in presigned}
+        try:
+            for future in as_completed(futures):
+                future.result()
+        except Exception:
+            executor.shutdown(wait=False)
+            raise
+        executor.shutdown(wait=True)
+        return [r for r in results if r is not None]
+
+    def _presign_batch(self, upload_id: str, start: int, end: int) -> list:
+        entries = [{"part_number": i} for i in range(start, end + 1)]
+        body = json.dumps({"parts": entries})
+        resp = self._request(
+            "POST",
+            f"{self.base_url}/v2/uploads/{upload_id}/presign-batch",
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        if resp.status_code >= 300:
+            raise StatusError(resp.text, status_code=resp.status_code, response=resp)
+        return resp.json().get("parts", [])
+
+    def _upload_one_part_v2(self, part: dict, data: bytes) -> str:
+        headers = {}
+        for k, v in part.get("headers", {}).items():
+            if k.lower() == "host":
+                continue
+            headers[k] = v
+        resp = self.session.put(part["url"], data=data, headers=headers)
+        if resp.status_code == 403:
+            fresh = self._presign_one_part(part.get("upload_id", ""), part["number"])
+            resp = self.session.put(fresh["url"], data=data, headers=headers)
+        if resp.status_code >= 300:
+            raise StatusError(
+                f"HTTP {resp.status_code}: {resp.text}",
+                status_code=resp.status_code,
+                response=resp,
+            )
+        return resp.headers.get("ETag", "")
+
+    def _presign_one_part(self, upload_id: str, part_number: int) -> dict:
+        body = json.dumps({"part_number": part_number})
+        resp = self._request(
+            "POST",
+            f"{self.base_url}/v2/uploads/{upload_id}/presign",
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        if resp.status_code >= 300:
+            raise StatusError(resp.text, status_code=resp.status_code, response=resp)
+        return resp.json()
+
+    def _complete_upload_v2(self, upload_id: str, parts: list) -> None:
+        body = json.dumps({"parts": parts})
+        resp = self._request(
+            "POST",
+            f"{self.base_url}/v2/uploads/{upload_id}/complete",
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        if resp.status_code >= 300:
+            raise StatusError(resp.text, status_code=resp.status_code, response=resp)
+
+    def _abort_upload_v2(self, upload_id: str) -> None:
+        resp = self._request(
+            "POST",
+            f"{self.base_url}/v2/uploads/{upload_id}/abort",
+        )
+        if resp.status_code >= 300:
+            raise StatusError(resp.text, status_code=resp.status_code, response=resp)
+
+    # ------------------------------------------------------------------
+    # Resume helpers
+    # ------------------------------------------------------------------
+
+    def _query_upload(self, path: str) -> UploadMeta:
+        resp = self._request(
+            "GET",
+            f"{self.base_url}/v1/uploads?path={path}&status=UPLOADING",
+        )
+        if resp.status_code >= 300:
+            raise StatusError(resp.text, status_code=resp.status_code, response=resp)
+        data = resp.json()
+        uploads = data.get("uploads", [])
+        if not uploads:
+            raise Drive9Error(f"no active upload for {path}")
+        u = uploads[0]
+        return UploadMeta(
+            upload_id=u["upload_id"],
+            parts_total=u["parts_total"],
+            status=u["status"],
+            expires_at=u["expires_at"],
+        )
+
+    def _request_resume(self, upload_id: str, checksums: list) -> UploadPlan:
+        plan, resp_err = self._request_resume_by_body(upload_id, checksums)
+        if plan is not None:
+            return plan
+        resp, err = resp_err
+        if resp is not None:
+            if (
+                resp.status_code == 400
+                and "missing x-dat9-part-checksums header" in err.lower()
+            ):
+                return self._request_resume_legacy(upload_id, checksums)
+            raise StatusError(err, status_code=resp.status_code, response=resp)
+        raise Drive9Error(err)
+
+    def _request_resume_by_body(self, upload_id, checksums):
+        body = json.dumps({"part_checksums": checksums})
+        resp = self._request(
+            "POST",
+            f"{self.base_url}/v1/uploads/{upload_id}/resume",
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        if resp.status_code == 410:
+            raise Drive9Error(f"upload {upload_id} has expired")
+        if resp.status_code >= 300:
+            return None, (resp, resp.text)
+        return self._parse_upload_plan(resp.json()), None
+
+    def _request_resume_legacy(self, upload_id, checksums):
+        headers = {}
+        if checksums:
+            headers["X-Dat9-Part-Checksums"] = ",".join(checksums)
+        resp = self._request(
+            "POST",
+            f"{self.base_url}/v1/uploads/{upload_id}/resume",
+            headers=headers,
+        )
+        if resp.status_code == 410:
+            raise Drive9Error(f"upload {upload_id} has expired")
+        if resp.status_code >= 300:
+            raise StatusError(resp.text, status_code=resp.status_code, response=resp)
+        return self._parse_upload_plan(resp.json())
+
+    def _upload_missing_parts(self, plan, file_obj, total_parts, progress):
+        std_part_size = plan.part_size
+        if std_part_size <= 0:
+            std_part_size = _PART_SIZE
+        max_concurrency = _upload_parallelism(std_part_size)
+
+        def upload_one(part: PartURL):
+            offset = (part.number - 1) * std_part_size
+            file_obj.seek(offset)
+            data = file_obj.read(part.size)
+            if len(data) != part.size:
+                raise Drive9Error(
+                    f"short read for part {part.number}: got {len(data)} want {part.size}"
+                )
+            self._upload_one_part(part, data)
+            if progress:
+                progress(part.number, total_parts, len(data))
+
+        executor = ThreadPoolExecutor(max_workers=max_concurrency)
+        futures = {executor.submit(upload_one, p): p for p in plan.parts}
+        try:
+            for future in as_completed(futures):
+                future.result()
+        except Exception:
+            executor.shutdown(wait=False)
+            raise
+        executor.shutdown(wait=True)
+
+
+class _V2NotAvailable(Exception):
+    pass
+
+
+def _slice_body(body, offset: int, length: int):
+    """Skip offset bytes from body, then limit to length bytes."""
+    if offset > 0:
+        skipped = 0
+        while skipped < offset:
+            to_read = min(8192, offset - skipped)
+            chunk = body.read(to_read)
+            if not chunk:
+                body.close()
+                return BytesIO(b"")
+            skipped += len(chunk)
+    return _LimitedReadCloser(body, length)
+
+
+class _LimitedReadCloser:
+    def __init__(self, body, limit: int):
+        self._body = body
+        self._remaining = limit
+
+    def read(self, size=-1):
+        if self._remaining <= 0:
+            return b""
+        if size < 0 or size > self._remaining:
+            size = self._remaining
+        data = self._body.read(size)
+        self._remaining -= len(data)
+        return data
+
+    def close(self):
+        self._body.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/clients/drive9-py/drive9/transfer.py
+++ b/clients/drive9-py/drive9/transfer.py
@@ -431,7 +431,7 @@ class TransferMixin:
                 raise Drive9Error(
                     f"short read for part {pp['number']}: got {len(data)} want {pp['size']}"
                 )
-            etag = self._upload_one_part_v2(pp, data)
+            etag = self._upload_one_part_v2(upload_id, pp, data)
             results[pp["number"] - 1] = {"number": pp["number"], "etag": etag}
             if progress:
                 progress(pp["number"], total_parts, len(data))
@@ -460,7 +460,7 @@ class TransferMixin:
             raise StatusError(resp.text, status_code=resp.status_code, response=resp)
         return resp.json().get("parts", [])
 
-    def _upload_one_part_v2(self, part: dict, data: bytes) -> str:
+    def _upload_one_part_v2(self, upload_id: str, part: dict, data: bytes) -> str:
         headers = {}
         for k, v in part.get("headers", {}).items():
             if k.lower() == "host":
@@ -468,7 +468,7 @@ class TransferMixin:
             headers[k] = v
         resp = self.session.put(part["url"], data=data, headers=headers)
         if resp.status_code == 403:
-            fresh = self._presign_one_part(part.get("upload_id", ""), part["number"])
+            fresh = self._presign_one_part(upload_id, part["number"])
             resp = self.session.put(fresh["url"], data=data, headers=headers)
         if resp.status_code >= 300:
             raise StatusError(

--- a/clients/drive9-py/drive9/transfer.py
+++ b/clients/drive9-py/drive9/transfer.py
@@ -375,12 +375,18 @@ class TransferMixin:
         try:
             parts = self._upload_parts_v2(plan, file_obj, progress)
         except Exception:
-            self._abort_upload_v2(plan["upload_id"])
+            try:
+                self._abort_upload_v2(plan["upload_id"])
+            except Exception:
+                pass
             raise
         try:
             self._complete_upload_v2(plan["upload_id"], parts)
         except Exception:
-            self._abort_upload_v2(plan["upload_id"])
+            try:
+                self._abort_upload_v2(plan["upload_id"])
+            except Exception:
+                pass
             raise
 
     def _initiate_upload_v2(
@@ -508,9 +514,10 @@ class TransferMixin:
     # ------------------------------------------------------------------
 
     def _query_upload(self, path: str) -> UploadMeta:
+        from urllib.parse import quote
         resp = self._request(
             "GET",
-            f"{self.base_url}/v1/uploads?path={path}&status=UPLOADING",
+            f"{self.base_url}/v1/uploads?path={quote(path, safe='')}&status=UPLOADING",
         )
         if resp.status_code >= 300:
             raise StatusError(resp.text, status_code=resp.status_code, response=resp)

--- a/clients/drive9-py/pyproject.toml
+++ b/clients/drive9-py/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "drive9"
+version = "0.1.0"
+description = "Python SDK for Drive9"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.25.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "responses>=0.23.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["drive9*"]

--- a/clients/drive9-py/tests/test_client.py
+++ b/clients/drive9-py/tests/test_client.py
@@ -351,6 +351,21 @@ def test_conflict_error_raises_conflict_error(client):
     with pytest.raises(ConflictError) as exc_info:
         client.write("/conflict.txt", b"x")
     assert exc_info.value.status_code == 409
+    assert exc_info.value.server_revision is None
+
+
+@responses.activate
+def test_conflict_error_exposes_server_revision(client):
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/v1/fs/conflict2.txt",
+        json={"error": "revision mismatch", "server_revision": 42},
+        status=409,
+    )
+    with pytest.raises(ConflictError) as exc_info:
+        client.write("/conflict2.txt", b"x")
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.server_revision == 42
 
 
 @responses.activate

--- a/clients/drive9-py/tests/test_client.py
+++ b/clients/drive9-py/tests/test_client.py
@@ -1,0 +1,535 @@
+"""Tests for the Drive9 Python SDK."""
+
+import json
+from io import BytesIO
+from unittest import mock
+
+import pytest
+import responses
+
+from drive9 import Client, Drive9Error, StatusError, ConflictError
+
+BASE_URL = "http://localhost:8080"
+
+
+@pytest.fixture
+def client():
+    return Client(BASE_URL, api_key="test-key")
+
+
+@responses.activate
+def test_write_and_read(client):
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/v1/fs/hello.txt",
+        status=200,
+    )
+    client.write("/hello.txt", b"hello world")
+
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/fs/hello.txt",
+        body=b"hello world",
+        status=200,
+    )
+    data = client.read("/hello.txt")
+    assert data == b"hello world"
+
+
+@responses.activate
+def test_list_dir(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/fs/data/?list=1",
+        json={
+            "entries": [
+                {"name": "a.txt", "size": 1, "isDir": False},
+                {"name": "b.txt", "size": 2, "isDir": False},
+            ]
+        },
+        status=200,
+    )
+    entries = client.list("/data/")
+    assert len(entries) == 2
+    assert entries[0].name == "a.txt"
+    assert entries[1].size == 2
+
+
+@responses.activate
+def test_stat(client):
+    responses.add(
+        responses.HEAD,
+        f"{BASE_URL}/v1/fs/test.txt",
+        headers={
+            "Content-Length": "4",
+            "X-Dat9-IsDir": "false",
+            "X-Dat9-Revision": "7",
+        },
+        status=200,
+    )
+    info = client.stat("/test.txt")
+    assert info.size == 4
+    assert info.is_dir is False
+    assert info.revision == 7
+
+
+@responses.activate
+def test_stat_not_found(client):
+    responses.add(
+        responses.HEAD,
+        f"{BASE_URL}/v1/fs/missing.txt",
+        status=404,
+    )
+    with pytest.raises(Drive9Error):
+        client.stat("/missing.txt")
+
+
+@responses.activate
+def test_delete(client):
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/v1/fs/del.txt",
+        status=200,
+    )
+    client.delete("/del.txt")
+
+
+@responses.activate
+def test_copy(client):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v1/fs/dst.txt?copy",
+        status=200,
+    )
+    client.copy("/src.txt", "/dst.txt")
+
+
+@responses.activate
+def test_rename(client):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v1/fs/new.txt?rename",
+        status=200,
+    )
+    client.rename("/old.txt", "/new.txt")
+
+
+@responses.activate
+def test_mkdir(client):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v1/fs/mydir?mkdir",
+        status=200,
+    )
+    client.mkdir("/mydir")
+
+
+@responses.activate
+def test_sql(client):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v1/sql",
+        json=[{"id": 1, "path": "/a.txt"}],
+        status=200,
+    )
+    rows = client.sql("SELECT * FROM files")
+    assert rows == [{"id": 1, "path": "/a.txt"}]
+
+
+@responses.activate
+def test_grep(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/fs/?grep=hello",
+        json=[
+            {"path": "/a.txt", "name": "a.txt", "size_bytes": 5, "score": 0.9}
+        ],
+        status=200,
+    )
+    results = client.grep("hello", "/")
+    assert len(results) == 1
+    assert results[0].score == 0.9
+
+
+@responses.activate
+def test_find(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/fs/?find=&name=*.txt",
+        json=[{"path": "/a.txt", "name": "a.txt", "size_bytes": 5}],
+        status=200,
+    )
+    results = client.find("/", {"name": "*.txt"})
+    assert len(results) == 1
+
+
+@responses.activate
+def test_write_stream_small(client):
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/v1/fs/small.txt",
+        status=200,
+    )
+    stream = BytesIO(b"tiny")
+    client.write_stream("/small.txt", stream, size=4)
+
+
+@responses.activate
+def test_write_stream_large_v1(client):
+    # initiate -> upload part -> complete
+    data = b"x" * (9 * 1024 * 1024)  # 9 MiB
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/initiate",
+        status=404,
+    )
+    parts = [
+        {"number": 1, "size": 8 * 1024 * 1024, "url": "http://s3/up1"},
+        {"number": 2, "size": 1 * 1024 * 1024, "url": "http://s3/up2"},
+    ]
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v1/uploads/initiate",
+        json={"upload_id": "uid", "part_size": 8 * 1024 * 1024, "parts": parts},
+        status=202,
+    )
+    responses.add(
+        responses.PUT,
+        "http://s3/up1",
+        status=200,
+        headers={"ETag": '"etag1"'},
+    )
+    responses.add(
+        responses.PUT,
+        "http://s3/up2",
+        status=200,
+        headers={"ETag": '"etag2"'},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v1/uploads/uid/complete",
+        status=200,
+    )
+    stream = BytesIO(data)
+    client.write_stream("/large.txt", stream, size=len(data))
+
+
+@responses.activate
+def test_read_stream_redirect(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/fs/big.bin",
+        status=302,
+        headers={"Location": "http://s3/presigned"},
+    )
+    responses.add(
+        responses.GET,
+        "http://s3/presigned",
+        body=b"large data",
+        status=200,
+    )
+    body = client.read_stream("/big.bin")
+    assert body.read() == b"large data"
+    body.close()
+
+
+@responses.activate
+def test_read_stream_range_redirect(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/fs/big.bin",
+        status=302,
+        headers={"Location": "http://s3/presigned"},
+    )
+    responses.add(
+        responses.GET,
+        "http://s3/presigned",
+        body=b"large data",
+        status=200,
+    )
+    body = client.read_stream_range("/big.bin", 6, 4)
+    assert body.read() == b"data"
+    body.close()
+
+
+@responses.activate
+def test_patch_file(client):
+    plan = {
+        "upload_id": "puid",
+        "part_size": 1024,
+        "upload_parts": [
+            {
+                "number": 1,
+                "url": "http://s3/patch1",
+                "size": 1024,
+            }
+        ],
+        "copied_parts": [],
+    }
+    responses.add(
+        responses.PATCH,
+        f"{BASE_URL}/v1/fs/file.bin",
+        json=plan,
+        status=202,
+    )
+    responses.add(
+        responses.PUT,
+        "http://s3/patch1",
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v1/uploads/puid/complete",
+        status=200,
+    )
+
+    def read_part(part_number, part_size, orig_data):
+        return b"a" * part_size
+
+    client.patch_file("/file.bin", 1024, [1], read_part)
+
+
+
+@responses.activate
+def test_write_expected_revision(client):
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/v1/fs/cas.txt",
+        status=200,
+    )
+    client.write("/cas.txt", b"data", expected_revision=5)
+    req = responses.calls[0].request
+    assert req.headers["X-Dat9-Expected-Revision"] == "5"
+
+
+@responses.activate
+def test_stat_with_mtime(client):
+    from datetime import datetime, timezone
+
+    ts = int(datetime(2026, 4, 14, 12, 0, 0, tzinfo=timezone.utc).timestamp())
+    responses.add(
+        responses.HEAD,
+        f"{BASE_URL}/v1/fs/mtime.txt",
+        headers={
+            "Content-Length": "4",
+            "X-Dat9-IsDir": "false",
+            "X-Dat9-Revision": "1",
+            "X-Dat9-Mtime": str(ts),
+        },
+        status=200,
+    )
+    info = client.stat("/mtime.txt")
+    assert info.mtime is not None
+    assert info.mtime == datetime(2026, 4, 14, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@responses.activate
+def test_list_with_mtime(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/fs/data/?list=1",
+        json={
+            "entries": [
+                {"name": "a.txt", "size": 1, "isDir": False, "mtime": 1713091200},
+            ]
+        },
+        status=200,
+    )
+    entries = client.list("/data/")
+    assert len(entries) == 1
+    assert entries[0].mtime == 1713091200
+
+
+@responses.activate
+def test_conflict_error_raises_conflict_error(client):
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/v1/fs/conflict.txt",
+        json={"error": "revision mismatch"},
+        status=409,
+    )
+    with pytest.raises(ConflictError) as exc_info:
+        client.write("/conflict.txt", b"x")
+    assert exc_info.value.status_code == 409
+
+
+@responses.activate
+def test_status_error_for_other_codes(client):
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/v1/fs/server_err.txt",
+        json={"error": "boom"},
+        status=500,
+    )
+    with pytest.raises(StatusError) as exc_info:
+        client.write("/server_err.txt", b"x")
+    assert exc_info.value.status_code == 500
+
+
+
+def test_load_api_key_from_config():
+    cfg = {
+        "current_context": "prod",
+        "contexts": {
+            "prod": {"api_key": "cfg-key-123"},
+        },
+    }
+    m = mock.mock_open(read_data=json.dumps(cfg))
+    with mock.patch("builtins.open", m):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            client = Client("http://localhost:8080")
+    assert client.api_key == "cfg-key-123"
+
+
+def test_load_api_key_from_config_missing_context():
+    cfg = {
+        "current_context": "missing",
+        "contexts": {},
+    }
+    m = mock.mock_open(read_data=json.dumps(cfg))
+    with mock.patch("builtins.open", m):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            client = Client("http://localhost:8080")
+    assert client.api_key is None
+
+
+def test_load_api_key_from_config_no_file():
+    def raise_error(*args, **kwargs):
+        raise FileNotFoundError()
+
+    with mock.patch("builtins.open", side_effect=raise_error):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            client = Client("http://localhost:8080")
+    assert client.api_key is None
+
+
+def test_explicit_api_key_overrides_config():
+    cfg = {
+        "current_context": "prod",
+        "contexts": {
+            "prod": {"api_key": "cfg-key-123"},
+        },
+    }
+    m = mock.mock_open(read_data=json.dumps(cfg))
+    with mock.patch("builtins.open", m):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            client = Client("http://localhost:8080", api_key="explicit-key")
+    assert client.api_key == "explicit-key"
+
+
+def test_load_base_url_from_config():
+    cfg = {
+        "server": "https://api.drive9.ai",
+        "current_context": "prod",
+        "contexts": {
+            "prod": {"api_key": "cfg-key-123"},
+        },
+    }
+    m = mock.mock_open(read_data=json.dumps(cfg))
+    with mock.patch("builtins.open", m):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            client = Client("")
+    assert client.base_url == "https://api.drive9.ai"
+    assert client.api_key == "cfg-key-123"
+
+
+def test_explicit_base_url_overrides_config():
+    cfg = {
+        "server": "https://api.drive9.ai",
+        "current_context": "prod",
+        "contexts": {
+            "prod": {"api_key": "cfg-key-123"},
+        },
+    }
+    m = mock.mock_open(read_data=json.dumps(cfg))
+    with mock.patch("builtins.open", m):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            client = Client("http://custom.local")
+    assert client.base_url == "http://custom.local"
+    assert client.api_key == "cfg-key-123"
+
+
+def test_client_default():
+    cfg = {
+        "server": "https://cfg.drive9.ai",
+        "current_context": "prod",
+        "contexts": {
+            "prod": {"api_key": "cfg-key"},
+        },
+    }
+    m = mock.mock_open(read_data=json.dumps(cfg))
+    with mock.patch("builtins.open", m):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            client = Client.default()
+    assert client.base_url == "https://cfg.drive9.ai"
+    assert client.api_key == "cfg-key"
+
+
+def test_env_server_overrides_config():
+    cfg = {
+        "server": "https://cfg.drive9.ai",
+        "current_context": "prod",
+        "contexts": {
+            "prod": {"api_key": "cfg-key"},
+        },
+    }
+    m = mock.mock_open(read_data=json.dumps(cfg))
+    env = {"DRIVE9_SERVER": "http://127.0.0.1:9009"}
+    with mock.patch("builtins.open", m):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            with mock.patch.dict("os.environ", env, clear=True):
+                client = Client.default()
+    assert client.base_url == "http://127.0.0.1:9009"
+    assert client.api_key == "cfg-key"
+
+
+def test_env_api_key_overrides_config():
+    cfg = {
+        "server": "https://cfg.drive9.ai",
+        "current_context": "prod",
+        "contexts": {
+            "prod": {"api_key": "cfg-key"},
+        },
+    }
+    m = mock.mock_open(read_data=json.dumps(cfg))
+    env = {"DRIVE9_API_KEY": "env-key-123"}
+    with mock.patch("builtins.open", m):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            with mock.patch.dict("os.environ", env, clear=True):
+                client = Client.default()
+    assert client.base_url == "https://cfg.drive9.ai"
+    assert client.api_key == "env-key-123"
+
+
+def test_env_vars_used_when_config_file_missing():
+    env = {
+        "DRIVE9_SERVER": "http://127.0.0.1:9009",
+        "DRIVE9_API_KEY": "env-key-123",
+    }
+    with mock.patch("builtins.open", side_effect=FileNotFoundError()):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            with mock.patch.dict("os.environ", env, clear=True):
+                client = Client.default()
+    assert client.base_url == "http://127.0.0.1:9009"
+    assert client.api_key == "env-key-123"
+
+
+def test_explicit_args_override_env_and_config():
+    cfg = {
+        "server": "https://cfg.drive9.ai",
+        "current_context": "prod",
+        "contexts": {
+            "prod": {"api_key": "cfg-key"},
+        },
+    }
+    m = mock.mock_open(read_data=json.dumps(cfg))
+    env = {
+        "DRIVE9_SERVER": "http://env.drive9.ai",
+        "DRIVE9_API_KEY": "env-key",
+    }
+    with mock.patch("builtins.open", m):
+        with mock.patch("os.path.expanduser", return_value="/home/user"):
+            with mock.patch.dict("os.environ", env, clear=True):
+                client = Client("http://explicit.drive9.ai", "explicit-key")
+    assert client.base_url == "http://explicit.drive9.ai"
+    assert client.api_key == "explicit-key"

--- a/clients/drive9-py/tests/test_e2e.py
+++ b/clients/drive9-py/tests/test_e2e.py
@@ -1,0 +1,198 @@
+"""E2E tests for the Drive9 Python SDK.
+
+These tests target a live drive9 server.
+By default they assume a local server at http://127.0.0.1:9009.
+You can override the target with environment variables:
+
+    DRIVE9_E2E_BASE=http://127.0.0.1:9009
+    DRIVE9_E2E_API_KEY=optional-key
+
+If DRIVE9_E2E_API_KEY is unset, the client falls back to ~/.drive9/config.
+"""
+
+import os
+import time
+import uuid
+from io import BytesIO
+
+import pytest
+
+from drive9 import Client, Drive9Error
+
+E2E_BASE = os.environ.get("DRIVE9_E2E_BASE", "http://127.0.0.1:9009").rstrip("/")
+E2E_API_KEY = os.environ.get("DRIVE9_E2E_API_KEY")
+
+
+def _make_client() -> Client:
+    return Client(E2E_BASE, api_key=E2E_API_KEY)
+
+
+@pytest.fixture(scope="session")
+def client():
+    c = _make_client()
+    try:
+        c.list("/")
+    except Exception as exc:
+        pytest.skip(f"drive9 server not reachable at {E2E_BASE}: {exc}")
+    return c
+
+
+@pytest.fixture
+def prefix(client):
+    """Generate a unique prefix for test isolation."""
+    ts = int(time.time())
+    uid = uuid.uuid4().hex[:8]
+    p = f"/e2e-py-{ts}-{uid}/"
+    client.mkdir(p.rstrip("/"))
+    yield p
+    # best-effort cleanup
+    try:
+        client.delete(p.rstrip("/") + "?recursive")
+    except Exception:
+        pass
+
+
+class TestBasicOperations:
+    def test_write_and_read(self, client, prefix):
+        path = prefix + "hello.txt"
+        data = b"hello world from python e2e"
+        client.write(path, data)
+        got = client.read(path)
+        assert got == data
+
+    def test_list_directory(self, client, prefix):
+        client.write(prefix + "a.txt", b"a")
+        client.write(prefix + "b.txt", b"bb")
+        entries = client.list(prefix)
+        names = {e.name for e in entries}
+        assert "a.txt" in names
+        assert "b.txt" in names
+
+    def test_stat_file(self, client, prefix):
+        path = prefix + "stat.txt"
+        data = b"stat me"
+        client.write(path, data)
+        info = client.stat(path)
+        assert info.size == len(data)
+        assert info.is_dir is False
+        assert info.revision >= 1
+
+    def test_stat_directory(self, client, prefix):
+        info = client.stat(prefix)
+        assert info.is_dir is True
+
+    def test_mkdir_and_nested(self, client, prefix):
+        dir_path = prefix + "nested/deep/dir"
+        client.mkdir(dir_path)
+        info = client.stat(dir_path + "/")
+        assert info.is_dir is True
+
+    def test_copy(self, client, prefix):
+        src = prefix + "src.txt"
+        dst = prefix + "dst.txt"
+        data = b"zero copy content"
+        client.write(src, data)
+        client.copy(src, dst)
+        got = client.read(dst)
+        assert got == data
+
+    def test_rename(self, client, prefix):
+        old = prefix + "old.txt"
+        new = prefix + "new.txt"
+        data = b"renamed content"
+        client.write(old, data)
+        client.rename(old, new)
+        got = client.read(new)
+        assert got == data
+        with pytest.raises(Drive9Error):
+            client.read(old)
+
+    def test_delete(self, client, prefix):
+        path = prefix + "del.txt"
+        client.write(path, b"x")
+        client.delete(path)
+        with pytest.raises(Drive9Error):
+            client.read(path)
+
+
+class TestStreamOperations:
+    def test_write_stream_small(self, client, prefix):
+        path = prefix + "small-stream.txt"
+        data = b"tiny stream"
+        stream = BytesIO(data)
+        client.write_stream(path, stream, size=len(data))
+        got = client.read(path)
+        assert got == data
+
+    def test_write_stream_large(self, client, prefix):
+        path = prefix + "large-stream.bin"
+        size = 9 * 1024 * 1024  # 9 MiB, above default 50KB threshold
+        stream = BytesIO(b"x" * size)
+        client.write_stream(path, stream, size=size)
+        info = client.stat(path)
+        assert info.size == size
+
+    def test_read_stream(self, client, prefix):
+        path = prefix + "stream-read.txt"
+        data = b"stream read data"
+        client.write(path, data)
+        body = client.read_stream(path)
+        try:
+            got = body.read()
+            assert got == data
+        finally:
+            body.close()
+
+    def test_read_stream_range(self, client, prefix):
+        path = prefix + "range-read.txt"
+        data = b"0123456789"
+        client.write(path, data)
+        body = client.read_stream_range(path, 3, 4)
+        try:
+            got = body.read()
+            assert got == b"3456"
+        finally:
+            body.close()
+
+
+class TestQueryOperations:
+    def test_sql(self, client, prefix):
+        path = prefix + "sql-test.txt"
+        client.write(path, b"sql test")
+        # Give the server a moment to persist metadata
+        time.sleep(0.2)
+        rows = client.sql(
+            f"SELECT path FROM file_nodes WHERE path = '{path}' LIMIT 1"
+        )
+        assert len(rows) >= 0  # at minimum query should not error
+
+    def test_grep(self, client, prefix):
+        path = prefix + "grep-target.txt"
+        # Small file content goes into db9 and may be searchable via content_text
+        client.write(path, b"python e2e grep search keyword")
+        time.sleep(0.5)
+        results = client.grep("keyword", prefix, limit=10)
+        # Grep may match file content or path; just verify no error
+        assert isinstance(results, list)
+
+    def test_find(self, client, prefix):
+        client.write(prefix + "find-a.txt", b"a")
+        client.write(prefix + "find-b.txt", b"b")
+        time.sleep(0.2)
+        results = client.find(prefix, {"name": "find-a.txt"})
+        assert isinstance(results, list)
+        if results:
+            assert any(r.name == "find-a.txt" for r in results)
+
+
+class TestConditionalWrite:
+    def test_write_expected_revision_zero(self, client, prefix):
+        path = prefix + "cas-new.txt"
+        # expected_revision=0 means path must not exist
+        client.write(path, b"first", expected_revision=0)
+        got = client.read(path)
+        assert got == b"first"
+
+        # Second write with 0 should conflict
+        with pytest.raises(Drive9Error):
+            client.write(path, b"second", expected_revision=0)

--- a/clients/drive9-py/tests/test_e2e.py
+++ b/clients/drive9-py/tests/test_e2e.py
@@ -17,7 +17,7 @@ from io import BytesIO
 
 import pytest
 
-from drive9 import Client, Drive9Error
+from drive9 import Client, ConflictError, Drive9Error
 
 E2E_BASE = os.environ.get("DRIVE9_E2E_BASE", "http://127.0.0.1:9009").rstrip("/")
 E2E_API_KEY = os.environ.get("DRIVE9_E2E_API_KEY")
@@ -194,5 +194,5 @@ class TestConditionalWrite:
         assert got == b"first"
 
         # Second write with 0 should conflict
-        with pytest.raises(Drive9Error):
+        with pytest.raises(ConflictError):
             client.write(path, b"second", expected_revision=0)

--- a/clients/drive9-py/tests/test_stream.py
+++ b/clients/drive9-py/tests/test_stream.py
@@ -1,0 +1,171 @@
+"""Tests for StreamWriter."""
+
+import responses
+
+from drive9 import Client, Drive9Error
+
+BASE_URL = "http://localhost:8080"
+
+
+def make_client():
+    return Client(BASE_URL, api_key="test-key")
+
+
+@responses.activate
+def test_stream_writer_success():
+    client = make_client()
+    # initiate v2
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/initiate",
+        json={
+            "upload_id": "uid",
+            "part_size": 1024,
+            "total_parts": 2,
+            "key": "k",
+            "expires_at": "2026-04-14T00:00:00Z",
+            "resumable": True,
+            "checksum_contract": {"supported": [], "required": False},
+        },
+        status=202,
+    )
+    # presign part 1
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/uid/presign",
+        json={"number": 1, "url": "http://s3/up1", "size": 1024},
+        status=200,
+    )
+    # upload part 1
+    responses.add(
+        responses.PUT,
+        "http://s3/up1",
+        status=200,
+        headers={"ETag": '"etag1"'},
+    )
+    # presign part 2
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/uid/presign",
+        json={"number": 2, "url": "http://s3/up2", "size": 1024},
+        status=200,
+    )
+    # upload part 2
+    responses.add(
+        responses.PUT,
+        "http://s3/up2",
+        status=200,
+        headers={"ETag": '"etag2"'},
+    )
+    # complete
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/uid/complete",
+        status=200,
+    )
+
+    sw = client.new_stream_writer("/stream.bin", total_size=2048)
+    assert not sw.started
+    sw.write_part(1, b"a" * 1024)
+    assert sw.started
+    sw.write_part(2, b"b" * 1024)
+    sw.complete()
+
+
+@responses.activate
+def test_stream_writer_complete_with_final_part():
+    client = make_client()
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/initiate",
+        json={
+            "upload_id": "uid2",
+            "part_size": 1024,
+            "total_parts": 2,
+            "key": "k",
+            "expires_at": "2026-04-14T00:00:00Z",
+            "resumable": True,
+            "checksum_contract": {"supported": [], "required": False},
+        },
+        status=202,
+    )
+    # presign part 1
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/uid2/presign",
+        json={"number": 1, "url": "http://s3/up1", "size": 1024},
+        status=200,
+    )
+    responses.add(
+        responses.PUT,
+        "http://s3/up1",
+        status=200,
+        headers={"ETag": '"etag1"'},
+    )
+    # presign final part 2
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/uid2/presign",
+        json={"number": 2, "url": "http://s3/up2", "size": 500},
+        status=200,
+    )
+    responses.add(
+        responses.PUT,
+        "http://s3/up2",
+        status=200,
+        headers={"ETag": '"etag2"'},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/uid2/complete",
+        status=200,
+    )
+
+    sw = client.new_stream_writer("/stream2.bin", total_size=1500)
+    sw.write_part(1, b"a" * 1024)
+    sw.complete(final_part_num=2, final_part_data=b"x" * 500)
+
+
+@responses.activate
+def test_stream_writer_abort():
+    client = make_client()
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/initiate",
+        json={
+            "upload_id": "uid3",
+            "part_size": 1024,
+            "total_parts": 1,
+            "key": "k",
+            "expires_at": "2026-04-14T00:00:00Z",
+            "resumable": True,
+            "checksum_contract": {"supported": [], "required": False},
+        },
+        status=202,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/uid3/abort",
+        status=200,
+    )
+
+    sw = client.new_stream_writer("/stream3.bin", total_size=500)
+    sw.write_part(1, b"x" * 500)
+    sw.abort()
+    assert sw._aborted
+
+
+@responses.activate
+def test_stream_writer_v2_not_available():
+    client = make_client()
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v2/uploads/initiate",
+        status=404,
+    )
+    sw = client.new_stream_writer("/stream4.bin", total_size=500)
+    try:
+        sw.write_part(1, b"x")
+        assert False, "expected error"
+    except Drive9Error as exc:
+        assert "v2 protocol" in str(exc)

--- a/clients/drive9-py/tests/test_stream.py
+++ b/clients/drive9-py/tests/test_stream.py
@@ -1,5 +1,6 @@
 """Tests for StreamWriter."""
 
+import pytest
 import responses
 
 from drive9 import Client, Drive9Error
@@ -164,8 +165,5 @@ def test_stream_writer_v2_not_available():
         status=404,
     )
     sw = client.new_stream_writer("/stream4.bin", total_size=500)
-    try:
+    with pytest.raises(Drive9Error, match="v2 protocol"):
         sw.write_part(1, b"x")
-        assert False, "expected error"
-    except Drive9Error as exc:
-        assert "v2 protocol" in str(exc)

--- a/clients/drive9-py/tests/test_vault.py
+++ b/clients/drive9-py/tests/test_vault.py
@@ -1,0 +1,167 @@
+"""Tests for Vault API."""
+
+import pytest
+import responses
+
+from drive9 import Client, ConflictError
+
+BASE_URL = "http://localhost:8080"
+
+
+@pytest.fixture
+def client():
+    return Client(BASE_URL, api_key="tenant-key")
+
+
+@responses.activate
+def test_issue_vault_token(client):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v1/vault/tokens",
+        json={
+            "token": "vault_token",
+            "token_id": "cap_123",
+            "expires_at": "2026-04-14T00:00:00Z",
+        },
+        status=200,
+    )
+    resp = client.issue_vault_token(
+        "deploy-agent",
+        "task-123",
+        ["aws-prod", "db-prod/password"],
+        ttl_seconds=3600,
+    )
+    assert resp.token == "vault_token"
+    assert resp.token_id == "cap_123"
+
+    req = responses.calls[0].request
+    body = req.body
+    assert b"agent_id" in body
+    assert b"task_id" in body
+    assert b"scope" in body
+    assert b"ttl_seconds" in body
+    assert b"3600" in body
+
+
+@responses.activate
+def test_read_vault_secret_field(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/vault/read/db-prod/password",
+        body="hunter2",
+        status=200,
+    )
+    data = client.read_vault_secret_field("db-prod", "password")
+    assert data == "hunter2"
+
+
+@responses.activate
+def test_create_vault_secret_returns_status_error(client):
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v1/vault/secrets",
+        json={"error": "secret already exists"},
+        status=409,
+    )
+    with pytest.raises(ConflictError) as exc_info:
+        client.create_vault_secret("aws-prod", {"access_key": "AKIA"})
+    assert exc_info.value.status_code == 409
+
+
+@responses.activate
+def test_list_vault_secrets(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/vault/secrets",
+        json={
+            "secrets": [
+                {
+                    "name": "aws-prod",
+                    "secret_type": "generic",
+                    "revision": 3,
+                    "created_by": "alice",
+                    "created_at": "2026-04-01T00:00:00Z",
+                    "updated_at": "2026-04-10T00:00:00Z",
+                }
+            ]
+        },
+        status=200,
+    )
+    secrets = client.list_vault_secrets()
+    assert len(secrets) == 1
+    assert secrets[0].name == "aws-prod"
+    assert secrets[0].revision == 3
+
+
+@responses.activate
+def test_update_vault_secret(client):
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/v1/vault/secrets/aws-prod",
+        json={
+            "name": "aws-prod",
+            "secret_type": "generic",
+            "revision": 4,
+            "created_by": "alice",
+            "created_at": "2026-04-01T00:00:00Z",
+            "updated_at": "2026-04-11T00:00:00Z",
+        },
+        status=200,
+    )
+    secret = client.update_vault_secret("aws-prod", {"access_key": "AKIA2"})
+    assert secret.revision == 4
+
+
+@responses.activate
+def test_delete_vault_secret(client):
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/v1/vault/secrets/aws-prod",
+        status=200,
+    )
+    client.delete_vault_secret("aws-prod")
+
+
+@responses.activate
+def test_query_vault_audit(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/vault/audit?secret=aws-prod&limit=2",
+        json={
+            "events": [
+                {
+                    "event_id": "e1",
+                    "event_type": "read",
+                    "timestamp": "2026-04-14T00:00:00Z",
+                }
+            ]
+        },
+        status=200,
+    )
+    events = client.query_vault_audit("aws-prod", limit=2)
+    assert len(events) == 1
+    assert events[0].event_type == "read"
+
+
+@responses.activate
+def test_list_readable_vault_secrets(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/vault/read",
+        json={"secrets": ["db-prod", "api-key"]},
+        status=200,
+    )
+    secrets = client.list_readable_vault_secrets()
+    assert secrets == ["db-prod", "api-key"]
+
+
+@responses.activate
+def test_read_vault_secret(client):
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/vault/read/db-prod",
+        json={"host": "db.local", "port": "5432"},
+        status=200,
+    )
+    fields = client.read_vault_secret("db-prod")
+    assert fields["host"] == "db.local"

--- a/clients/drive9-rs/.gitignore
+++ b/clients/drive9-rs/.gitignore
@@ -1,0 +1,18 @@
+# Rust build artifacts
+/target
+/Cargo.lock
+
+# IDE
+.idea
+*.iml
+.vscode
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Test artifacts
+*.log

--- a/clients/drive9-rs/Cargo.toml
+++ b/clients/drive9-rs/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "drive9"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+reqwest = { version = "0.12", features = ["json", "stream"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+crc32c = "0.6"
+base64 = "0.22"
+bytes = "1.6"
+tokio = { version = "1.37", features = ["sync", "rt", "macros", "time", "fs", "io-util"] }
+futures = "0.3"
+url = "2.5"
+tokio-util = { version = "0.7", features = ["io"] }
+sha2 = "0.10"
+urlencoding = "2.1"
+
+[dev-dependencies]
+mockito = "1.4"
+tokio = { version = "1.37", features = ["full"] }
+tempfile = "3.10"

--- a/clients/drive9-rs/README.md
+++ b/clients/drive9-rs/README.md
@@ -1,0 +1,133 @@
+# drive9-rs
+
+Rust SDK for [drive9](https://github.com/mem9-ai/drive9) — an agent-native filesystem with semantic search.
+
+## Installation
+
+Add to `Cargo.toml`:
+
+```toml
+[dependencies]
+drive9 = { path = "../clients/drive9-rs" }
+```
+
+Or via git:
+
+```toml
+[dependencies]
+drive9 = { git = "https://github.com/mem9-ai/drive9.git" }
+```
+
+## Quick start
+
+```rust
+use drive9::Client;
+
+#[tokio::main]
+async fn main() -> Result<(), drive9::Drive9Error> {
+    let client = Client::new("http://127.0.0.1:9009", "your-api-key");
+
+    // Write & read
+    client.write("/hello.txt", b"hello world").await?;
+    let data = client.read("/hello.txt").await?;
+    assert_eq!(data, b"hello world");
+
+    // List directory
+    let entries = client.list("/").await?;
+    for e in entries {
+        println!("{} ({} bytes)", e.name, e.size);
+    }
+
+    // Stat
+    let info = client.stat("/hello.txt").await?;
+    println!("size={} revision={}", info.size, info.revision);
+
+    Ok(())
+}
+```
+
+## Config auto-loading
+
+`Client::default_client()` reads `~/.drive9/config` automatically:
+
+```rust
+let client = Client::default_client();
+```
+
+Expected config format:
+
+```json
+{
+  "server": "http://127.0.0.1:9009",
+  "current_context": "default",
+  "contexts": {
+    "default": { "api_key": "d9_..." }
+  }
+}
+```
+
+## Supported operations
+
+| Operation | Method |
+|-----------|--------|
+| Write file | `client.write(path, data).await` |
+| Conditional write | `client.write_with_revision(path, data, revision).await` |
+| Read file | `client.read(path).await` |
+| List directory | `client.list(path).await` |
+| Stat | `client.stat(path).await` |
+| Delete | `client.delete(path).await` |
+| Copy | `client.copy(src, dst).await` |
+| Rename | `client.rename(old, new).await` |
+| Mkdir | `client.mkdir(path).await` |
+| SQL query | `client.sql(query).await` |
+| Grep | `client.grep(query, prefix, limit).await` |
+| Find | `client.find(prefix, params).await` |
+
+### Streaming & multipart
+
+| Operation | Method |
+|-----------|--------|
+| Stream upload (v2) | `client.write_stream(path, reader, size, progress, revision).await` |
+| Resume upload | `client.resume_upload(path, reader, size, progress).await` |
+| Read stream | `client.read_stream(path).await` |
+| Read range stream | `client.read_stream_range(path, offset, length).await` |
+| Stream writer | `client.new_stream_writer(path, total_size)` |
+
+### Patch (partial update)
+
+```rust
+client.patch_file(
+    path,
+    new_size,
+    dirty_parts,
+    read_part_fn,
+    progress_fn,
+    part_size,
+).await?;
+```
+
+### Vault
+
+| Operation | Method |
+|-----------|--------|
+| Create secret | `client.create_vault_secret(name, fields).await` |
+| Update secret | `client.update_vault_secret(name, fields).await` |
+| Delete secret | `client.delete_vault_secret(name).await` |
+| List secrets | `client.list_vault_secrets().await` |
+| Issue token | `client.issue_vault_token(name, ttl, perms).await` |
+| Revoke token | `client.revoke_vault_token(token_id).await` |
+| Read secret | `client.read_vault_secret(name).await` |
+| Read field | `client.read_vault_secret_field(name, field).await` |
+
+## Testing
+
+Unit / integration tests (mocked HTTP):
+
+```bash
+cd clients/drive9-rs
+cargo test
+```
+
+## License
+
+Apache-2.0

--- a/clients/drive9-rs/README.md
+++ b/clients/drive9-rs/README.md
@@ -66,6 +66,8 @@ Expected config format:
 }
 ```
 
+Environment variables `DRIVE9_SERVER` and `DRIVE9_API_KEY` override values from the config file when set.
+
 ## Supported operations
 
 | Operation | Method |

--- a/clients/drive9-rs/examples/basic.rs
+++ b/clients/drive9-rs/examples/basic.rs
@@ -1,0 +1,44 @@
+use drive9::Client;
+
+#[tokio::main]
+async fn main() -> Result<(), drive9::Drive9Error> {
+    // Auto-load config from ~/.drive9/config or use explicit URL.
+    let client = Client::default_client();
+    // Or: let client = Client::new("http://127.0.0.1:9009", "your-api-key");
+
+    let path = "/examples/hello.txt";
+
+    // Write a file
+    client.write(path, b"hello from drive9-rs").await?;
+    println!("Wrote {}", path);
+
+    // Read it back
+    let data = client.read(path).await?;
+    println!("Read back: {}", String::from_utf8_lossy(&data));
+
+    // Stat the file
+    let info = client.stat(path).await?;
+    println!("Stat: size={} revision={} is_dir={}", info.size, info.revision, info.is_dir);
+
+    // List directory
+    let entries = client.list("/examples/").await?;
+    println!("Entries in /examples/:");
+    for e in entries {
+        println!("  {} ({} bytes)", e.name, e.size);
+    }
+
+    // Conditional write
+    client.write_with_revision(path, b"updated content", info.revision).await?;
+    println!("Conditional write succeeded");
+
+    // Copy and rename
+    client.copy(path, "/examples/hello-copy.txt").await?;
+    client.rename("/examples/hello-copy.txt", "/examples/hello-moved.txt").await?;
+
+    // Clean up
+    client.delete(path).await?;
+    client.delete("/examples/hello-moved.txt").await?;
+    println!("Cleaned up");
+
+    Ok(())
+}

--- a/clients/drive9-rs/examples/stream_upload.rs
+++ b/clients/drive9-rs/examples/stream_upload.rs
@@ -1,0 +1,49 @@
+use drive9::Client;
+use std::io::Cursor;
+use tokio::io::AsyncReadExt;
+
+#[tokio::main]
+async fn main() -> Result<(), drive9::Drive9Error> {
+    let client = Client::default_client();
+    // Or: let client = Client::new("http://127.0.0.1:9009", "your-api-key");
+
+    let path = "/examples/stream.bin";
+    let data: Vec<u8> = (0..1_000_000u64)
+        .flat_map(|i| i.to_le_bytes().to_vec())
+        .collect();
+    let size = data.len() as i64;
+
+    // Stream upload using write_stream (v2 with v1 fallback for small files)
+    let reader: Box<dyn drive9::transfer::SeekableReader> = Box::new(Cursor::new(data.clone()));
+    client.write_stream(path, reader, size).await?;
+    println!("Stream-uploaded {} bytes to {}", size, path);
+
+    // Read back as an async stream
+    let mut stream = client.read_stream(path).await?;
+    let mut read_buf = Vec::new();
+    stream.read_to_end(&mut read_buf).await?;
+    println!("Read back {} bytes via stream", read_buf.len());
+
+    // Range read
+    let mut range_stream = client.read_stream_range(path, 0, 1024).await?;
+    let mut range_buf = Vec::new();
+    range_stream.read_to_end(&mut range_buf).await?;
+    println!("Range read {} bytes", range_buf.len());
+
+    // StreamWriter (manual part-by-part upload)
+    let writer = client.new_stream_writer(path, size);
+    let part_size = 256_000usize;
+    let mut part_num = 1;
+    for chunk in data.chunks(part_size) {
+        writer.write_part(part_num, chunk.to_vec()).await?;
+        part_num += 1;
+    }
+    writer.complete(part_num - 1, vec![]).await?;
+    println!("Completed via StreamWriter");
+
+    // Clean up
+    client.delete(path).await?;
+    println!("Cleaned up");
+
+    Ok(())
+}

--- a/clients/drive9-rs/examples/vault.rs
+++ b/clients/drive9-rs/examples/vault.rs
@@ -1,0 +1,50 @@
+use drive9::Client;
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), drive9::Drive9Error> {
+    let client = Client::default_client();
+    // Or: let client = Client::new("http://127.0.0.1:9009", "your-api-key");
+
+    let secret_name = "example-secret";
+
+    // Create or update a secret
+    let mut fields = serde_json::Map::new();
+    fields.insert("password".to_string(), json!("hunter2"));
+    fields.insert("api_key".to_string(), json!("d9_xxxxxxxx"));
+
+    client.create_vault_secret(secret_name, &fields).await?;
+    println!("Created vault secret: {}", secret_name);
+
+    // Read the secret
+    let secret = client.read_vault_secret(secret_name).await?;
+    println!("Read secret: {:?}", secret);
+
+    // Read a single field
+    if let Ok(field) = client.read_vault_secret_field(secret_name, "password").await {
+        println!("Password field: {}", field);
+    }
+
+    // List secrets
+    let secrets = client.list_vault_secrets().await?;
+    println!("Vault secrets:");
+    for s in secrets {
+        println!("  {}", s.name);
+    }
+
+    // Issue a token
+    let token = client
+        .issue_vault_token("agent-1", "task-1", &["read".to_string()], 3600)
+        .await?;
+    println!("Issued token: {}", token.token_id);
+
+    // Revoke the token
+    client.revoke_vault_token(&token.token_id).await?;
+    println!("Revoked token");
+
+    // Clean up
+    client.delete_vault_secret(secret_name).await?;
+    println!("Deleted secret");
+
+    Ok(())
+}

--- a/clients/drive9-rs/src/client.rs
+++ b/clients/drive9-rs/src/client.rs
@@ -1,0 +1,358 @@
+use crate::error::{check_error, Drive9Error};
+use crate::models::{FileInfo, SearchResult, StatResult};
+use crate::stream::StreamWriter;
+use chrono::Utc;
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
+use serde_json::json;
+use std::collections::HashMap;
+
+const DEFAULT_SMALL_FILE_THRESHOLD: i64 = 50_000;
+
+fn load_config_file() -> Option<(String, Option<String>)> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_default();
+    let path = std::path::Path::new(&home).join(".drive9").join("config");
+    let data = std::fs::read_to_string(path).ok()?;
+    let cfg: serde_json::Value = serde_json::from_str(&data).ok()?;
+    let server = cfg
+        .get("server")
+        .and_then(|v| v.as_str())
+        .unwrap_or("https://api.drive9.ai")
+        .to_string();
+    let key = cfg
+        .get("current_context")
+        .and_then(|v| v.as_str())
+        .and_then(|current| {
+            cfg.get("contexts")
+                .and_then(|v| v.get(current))
+                .and_then(|v| v.get("api_key"))
+                .and_then(|v| v.as_str())
+        })
+        .map(|s| s.to_string());
+    Some((server, key))
+}
+
+fn load_config() -> (String, Option<String>) {
+    let env_server = std::env::var("DRIVE9_SERVER").ok().filter(|s| !s.is_empty());
+    let env_key = std::env::var("DRIVE9_API_KEY").ok().filter(|s| !s.is_empty());
+    let (file_server, file_key) = load_config_file().unwrap_or_default();
+    (
+        env_server.unwrap_or(file_server),
+        env_key.or(file_key),
+    )
+}
+
+#[derive(Clone, Debug)]
+pub struct Client {
+    pub(crate) base_url: String,
+    pub(crate) api_key: Option<String>,
+    pub(crate) http: reqwest::Client,
+    pub(crate) small_file_threshold: i64,
+}
+
+impl Client {
+    /// Create a new client.
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self::new_with_opts(base_url.into(), api_key.into())
+    }
+
+    /// Create a client using defaults from `~/.drive9/config`.
+    pub fn default_client() -> Self {
+        let (server, key) = load_config();
+        Self::new_with_opts(server, key.unwrap_or_default())
+    }
+
+    fn new_with_opts(base_url: String, api_key: String) -> Self {
+        let mut base = base_url.trim_end_matches('/').to_string();
+        let mut api = Some(api_key).filter(|s| !s.is_empty());
+        if api.is_none() {
+            api = load_config().1;
+        }
+        if base.is_empty() {
+            base = load_config().0;
+        }
+        let http = reqwest::Client::builder()
+            .user_agent(concat!("drive9-rs/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self {
+            base_url: base,
+            api_key: api,
+            http,
+            small_file_threshold: DEFAULT_SMALL_FILE_THRESHOLD,
+        }
+    }
+
+    pub fn with_small_file_threshold(mut self, threshold: i64) -> Self {
+        self.small_file_threshold = threshold;
+        self
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
+    }
+
+    pub(crate) fn fs_url(&self, path: &str) -> String {
+        let p = if path.starts_with('/') {
+            path
+        } else {
+            &format!("/{}", path)
+        };
+        format!("{}/v1/fs{}", self.base_url, p)
+    }
+
+    pub(crate) fn vault_url(&self, path: &str) -> String {
+        let p = if path.starts_with('/') {
+            path
+        } else {
+            &format!("/{}", path)
+        };
+        format!("{}/v1/vault{}", self.base_url, p)
+    }
+
+    pub(crate) fn auth_headers(&self) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if let Some(ref key) = self.api_key {
+            if let Ok(v) = HeaderValue::from_str(&format!("Bearer {}", key)) {
+                h.insert("Authorization", v);
+            }
+        }
+        h
+    }
+
+    pub async fn write(&self, path: &str, data: &[u8]) -> Result<(), Drive9Error> {
+        self.write_with_revision(path, data, -1).await
+    }
+
+    pub async fn write_with_revision(
+        &self,
+        path: &str,
+        data: &[u8],
+        expected_revision: i64,
+    ) -> Result<(), Drive9Error> {
+        let mut headers = self.auth_headers();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/octet-stream"),
+        );
+        if expected_revision >= 0 {
+            headers.insert(
+                "X-Dat9-Expected-Revision",
+                HeaderValue::from_str(&expected_revision.to_string()).unwrap(),
+            );
+        }
+        let resp = self
+            .http
+            .put(self.fs_url(path))
+            .headers(headers)
+            .body(data.to_vec())
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+
+    pub async fn read(&self, path: &str) -> Result<Vec<u8>, Drive9Error> {
+        let resp = self
+            .http
+            .get(self.fs_url(path))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.bytes().await?.to_vec())
+    }
+
+    pub async fn list(&self, path: &str) -> Result<Vec<FileInfo>, Drive9Error> {
+        let resp = self
+            .http
+            .get(format!("{}?list=1", self.fs_url(path)))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        let result: serde_json::Value = resp.json().await?;
+        let entries: Vec<FileInfo> =
+            serde_json::from_value(result.get("entries").cloned().unwrap_or(json!([])))?;
+        Ok(entries)
+    }
+
+    pub async fn stat(&self, path: &str) -> Result<StatResult, Drive9Error> {
+        let resp = self
+            .http
+            .head(self.fs_url(path))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let status = resp.status();
+        if status.as_u16() == 404 {
+            return Err(Drive9Error::Other(format!("not found: {}", path)));
+        }
+        if !status.is_success() {
+            return Err(Drive9Error::Status {
+                status_code: status.as_u16(),
+                message: format!("HTTP {}", status.as_u16()),
+            });
+        }
+        let headers = resp.headers();
+        let size = headers
+            .get("content-length")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0i64);
+        let revision = headers
+            .get("X-Dat9-Revision")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0i64);
+        let mtime = headers
+            .get("X-Dat9-Mtime")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<i64>().ok())
+            .map(|ts| chrono::DateTime::from_timestamp(ts, 0).unwrap_or_else(|| Utc::now()));
+        Ok(StatResult {
+            size,
+            is_dir: headers
+                .get("X-Dat9-IsDir")
+                .map(|v| v == "true")
+                .unwrap_or(false),
+            revision,
+            mtime,
+        })
+    }
+
+    pub async fn delete(&self, path: &str) -> Result<(), Drive9Error> {
+        let resp = self
+            .http
+            .delete(self.fs_url(path))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+
+    pub async fn copy(&self, src_path: &str, dst_path: &str) -> Result<(), Drive9Error> {
+        let mut headers = self.auth_headers();
+        headers.insert(
+            "X-Dat9-Copy-Source",
+            HeaderValue::from_str(src_path).unwrap(),
+        );
+        let resp = self
+            .http
+            .post(format!("{}?copy", self.fs_url(dst_path)))
+            .headers(headers)
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+
+    pub async fn rename(&self, old_path: &str, new_path: &str) -> Result<(), Drive9Error> {
+        let mut headers = self.auth_headers();
+        headers.insert(
+            "X-Dat9-Rename-Source",
+            HeaderValue::from_str(old_path).unwrap(),
+        );
+        let resp = self
+            .http
+            .post(format!("{}?rename", self.fs_url(new_path)))
+            .headers(headers)
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+
+    pub async fn mkdir(&self, path: &str) -> Result<(), Drive9Error> {
+        let resp = self
+            .http
+            .post(format!("{}?mkdir", self.fs_url(path)))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+
+    pub async fn sql(&self, query: &str) -> Result<Vec<serde_json::Value>, Drive9Error> {
+        let resp = self
+            .http
+            .post(format!("{}/v1/sql", self.base_url))
+            .headers(self.auth_headers())
+            .json(&json!({"query": query}))
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn grep(
+        &self,
+        query: &str,
+        path_prefix: &str,
+        limit: i32,
+    ) -> Result<Vec<SearchResult>, Drive9Error> {
+        let mut url = format!(
+            "{}?grep={}",
+            self.fs_url(path_prefix),
+            urlencoding::encode(query)
+        );
+        if limit > 0 {
+            url.push_str(&format!("&limit={}", limit));
+        }
+        let resp = self
+            .http
+            .get(&url)
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn find(
+        &self,
+        path_prefix: &str,
+        params: &HashMap<String, String>,
+    ) -> Result<Vec<SearchResult>, Drive9Error> {
+        let mut p = params.clone();
+        p.insert("find".to_string(), "".to_string());
+        let qs: Vec<_> = p
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect();
+        let url = format!("{}?{}", self.fs_url(path_prefix), qs.join("&"));
+        let resp = self
+            .http
+            .get(&url)
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub fn new_stream_writer(&self, path: &str, total_size: i64) -> StreamWriter {
+        StreamWriter::new(self.clone(), path.to_string(), total_size, -1)
+    }
+
+    pub fn new_stream_writer_conditional(
+        &self,
+        path: &str,
+        total_size: i64,
+        expected_revision: i64,
+    ) -> StreamWriter {
+        StreamWriter::new(
+            self.clone(),
+            path.to_string(),
+            total_size,
+            expected_revision,
+        )
+    }
+}

--- a/clients/drive9-rs/src/client.rs
+++ b/clients/drive9-rs/src/client.rs
@@ -1,7 +1,7 @@
 use crate::error::{check_error, Drive9Error};
 use crate::models::{FileInfo, SearchResult, StatResult};
 use crate::stream::StreamWriter;
-use chrono::Utc;
+
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use serde_json::json;
 use std::collections::HashMap;
@@ -36,7 +36,8 @@ fn load_config_file() -> Option<(String, Option<String>)> {
 fn load_config() -> (String, Option<String>) {
     let env_server = std::env::var("DRIVE9_SERVER").ok().filter(|s| !s.is_empty());
     let env_key = std::env::var("DRIVE9_API_KEY").ok().filter(|s| !s.is_empty());
-    let (file_server, file_key) = load_config_file().unwrap_or_default();
+    let (file_server, file_key) = load_config_file()
+        .unwrap_or_else(|| ("https://api.drive9.ai".to_string(), None));
     (
         env_server.unwrap_or(file_server),
         env_key.or(file_key),
@@ -64,13 +65,14 @@ impl Client {
     }
 
     fn new_with_opts(base_url: String, api_key: String) -> Self {
+        let (cfg_base, cfg_api) = load_config();
         let mut base = base_url.trim_end_matches('/').to_string();
         let mut api = Some(api_key).filter(|s| !s.is_empty());
         if api.is_none() {
-            api = load_config().1;
+            api = cfg_api;
         }
         if base.is_empty() {
-            base = load_config().0;
+            base = cfg_base;
         }
         let http = reqwest::Client::builder()
             .user_agent(concat!("drive9-rs/", env!("CARGO_PKG_VERSION")))
@@ -214,7 +216,7 @@ impl Client {
             .get("X-Dat9-Mtime")
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.parse::<i64>().ok())
-            .map(|ts| chrono::DateTime::from_timestamp(ts, 0).unwrap_or_else(|| Utc::now()));
+            .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0));
         Ok(StatResult {
             size,
             is_dir: headers

--- a/clients/drive9-rs/src/error.rs
+++ b/clients/drive9-rs/src/error.rs
@@ -6,7 +6,11 @@ pub enum Drive9Error {
     Status { status_code: u16, message: String },
 
     #[error("Conflict: {message}")]
-    Conflict { status_code: u16, message: String },
+    Conflict {
+        status_code: u16,
+        message: String,
+        server_revision: Option<i64>,
+    },
 
     #[error("request failed: {0}")]
     Request(#[from] reqwest::Error),
@@ -27,8 +31,9 @@ pub(crate) async fn check_error(resp: reqwest::Response) -> Result<reqwest::Resp
         return Ok(resp);
     }
     let bytes = resp.bytes().await.unwrap_or_default();
-    let message = serde_json::from_slice::<serde_json::Value>(&bytes)
-        .ok()
+    let parsed = serde_json::from_slice::<serde_json::Value>(&bytes).ok();
+    let message = parsed
+        .as_ref()
         .and_then(|v| {
             v.get("error")
                 .or_else(|| v.get("message"))
@@ -41,9 +46,13 @@ pub(crate) async fn check_error(resp: reqwest::Response) -> Result<reqwest::Resp
         })
         .unwrap_or_else(|| format!("HTTP {}", status.as_u16()));
     if status == StatusCode::CONFLICT {
+        let server_revision = parsed
+            .as_ref()
+            .and_then(|v| v.get("server_revision").and_then(|n| n.as_i64()));
         Err(Drive9Error::Conflict {
             status_code: status.as_u16(),
             message,
+            server_revision,
         })
     } else {
         Err(Drive9Error::Status {

--- a/clients/drive9-rs/src/error.rs
+++ b/clients/drive9-rs/src/error.rs
@@ -26,15 +26,18 @@ pub(crate) async fn check_error(resp: reqwest::Response) -> Result<reqwest::Resp
     if status.is_success() {
         return Ok(resp);
     }
-    let message = resp
-        .json::<serde_json::Value>()
-        .await
+    let bytes = resp.bytes().await.unwrap_or_default();
+    let message = serde_json::from_slice::<serde_json::Value>(&bytes)
         .ok()
         .and_then(|v| {
             v.get("error")
                 .or_else(|| v.get("message"))
                 .and_then(|s| s.as_str())
                 .map(|s| s.to_string())
+        })
+        .or_else(|| {
+            let text = String::from_utf8_lossy(&bytes).trim().to_string();
+            if text.is_empty() { None } else { Some(text) }
         })
         .unwrap_or_else(|| format!("HTTP {}", status.as_u16()));
     if status == StatusCode::CONFLICT {

--- a/clients/drive9-rs/src/error.rs
+++ b/clients/drive9-rs/src/error.rs
@@ -1,0 +1,51 @@
+use reqwest::StatusCode;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Drive9Error {
+    #[error("HTTP {status_code}: {message}")]
+    Status { status_code: u16, message: String },
+
+    #[error("Conflict: {message}")]
+    Conflict { status_code: u16, message: String },
+
+    #[error("request failed: {0}")]
+    Request(#[from] reqwest::Error),
+
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+pub(crate) async fn check_error(resp: reqwest::Response) -> Result<reqwest::Response, Drive9Error> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let message = resp
+        .json::<serde_json::Value>()
+        .await
+        .ok()
+        .and_then(|v| {
+            v.get("error")
+                .or_else(|| v.get("message"))
+                .and_then(|s| s.as_str())
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_else(|| format!("HTTP {}", status.as_u16()));
+    if status == StatusCode::CONFLICT {
+        Err(Drive9Error::Conflict {
+            status_code: status.as_u16(),
+            message,
+        })
+    } else {
+        Err(Drive9Error::Status {
+            status_code: status.as_u16(),
+            message,
+        })
+    }
+}

--- a/clients/drive9-rs/src/lib.rs
+++ b/clients/drive9-rs/src/lib.rs
@@ -1,0 +1,14 @@
+//! Drive9 Rust SDK.
+
+pub mod client;
+pub mod error;
+pub mod models;
+pub mod patch;
+pub mod stream;
+pub mod transfer;
+pub mod vault;
+
+pub use client::Client;
+pub use error::Drive9Error;
+pub use models::*;
+pub use stream::StreamWriter;

--- a/clients/drive9-rs/src/models.rs
+++ b/clients/drive9-rs/src/models.rs
@@ -1,0 +1,132 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FileInfo {
+    pub name: String,
+    pub size: i64,
+    #[serde(rename = "isDir")]
+    pub is_dir: bool,
+    pub mtime: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StatResult {
+    pub size: i64,
+    pub is_dir: bool,
+    pub revision: i64,
+    pub mtime: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchResult {
+    pub path: String,
+    pub name: String,
+    pub size_bytes: i64,
+    pub score: Option<f64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PartURL {
+    pub number: i32,
+    pub url: String,
+    pub size: i64,
+    pub checksum_sha256: Option<String>,
+    pub checksum_crc32c: Option<String>,
+    pub headers: Option<serde_json::Map<String, serde_json::Value>>,
+    pub expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UploadPlan {
+    pub upload_id: String,
+    pub part_size: i64,
+    pub parts: Vec<PartURL>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PatchPartURL {
+    pub number: i32,
+    pub url: String,
+    pub size: i64,
+    pub headers: Option<serde_json::Map<String, serde_json::Value>>,
+    pub expires_at: Option<String>,
+    pub read_url: Option<String>,
+    pub read_headers: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PatchPlan {
+    pub upload_id: String,
+    pub part_size: i64,
+    pub upload_parts: Vec<PatchPartURL>,
+    pub copied_parts: Vec<i32>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UploadMeta {
+    #[serde(rename = "upload_id")]
+    pub upload_id: String,
+    pub parts_total: i32,
+    pub status: String,
+    #[serde(rename = "expires_at")]
+    pub expires_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VaultSecret {
+    pub name: String,
+    pub secret_type: String,
+    pub revision: i64,
+    pub created_by: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VaultTokenIssueResponse {
+    pub token: String,
+    pub token_id: String,
+    #[serde(rename = "expires_at")]
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VaultAuditEvent {
+    pub event_id: String,
+    pub event_type: String,
+    pub timestamp: DateTime<Utc>,
+    #[serde(rename = "token_id")]
+    pub token_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub task_id: Option<String>,
+    pub secret_name: Option<String>,
+    pub field_name: Option<String>,
+    pub adapter: Option<String>,
+    pub detail: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CompletePart {
+    pub number: i32,
+    pub etag: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct PresignedPart {
+    pub number: i32,
+    pub url: String,
+    pub size: i64,
+    pub headers: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct UploadPlanV2 {
+    #[serde(rename = "upload_id")]
+    pub upload_id: String,
+    #[allow(dead_code)]
+    pub key: String,
+    #[serde(rename = "part_size")]
+    pub part_size: i64,
+    pub total_parts: i32,
+}

--- a/clients/drive9-rs/src/patch.rs
+++ b/clients/drive9-rs/src/patch.rs
@@ -1,0 +1,131 @@
+use crate::client::Client;
+use crate::error::{check_error, Drive9Error};
+use crate::models::PatchPartURL;
+use reqwest::header::{HeaderMap, HeaderName, CONTENT_TYPE};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+impl Client {
+    pub async fn patch_file<F>(
+        &self,
+        path: &str,
+        new_size: i64,
+        dirty_parts: &[i32],
+        read_part: F,
+    ) -> Result<(), Drive9Error>
+    where
+        F: Fn(i32, i64, Option<&[u8]>) -> Result<Vec<u8>, Drive9Error> + Send + Sync + 'static,
+    {
+        let body = json!({
+            "new_size": new_size,
+            "dirty_parts": dirty_parts,
+        });
+        let resp = self
+            .http
+            .patch(self.fs_url(path))
+            .headers(self.auth_headers())
+            .header(CONTENT_TYPE, "application/json")
+            .body(body.to_string())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        let plan: crate::models::PatchPlan = resp.json().await?;
+
+        let _total_parts = plan.upload_parts.len() + plan.copied_parts.len();
+        let sem = Arc::new(Semaphore::new(4));
+        let mut tasks = vec![];
+        let read_part = Arc::new(read_part);
+
+        for part in plan.upload_parts {
+            let permit = Arc::clone(&sem).acquire_owned().await.unwrap();
+            let client = self.clone();
+            let rf = Arc::clone(&read_part);
+            let task = tokio::spawn(async move {
+                let _permit = permit;
+                client.upload_patch_part(&part, rf.as_ref()).await
+            });
+            tasks.push(task);
+        }
+
+        let mut first_err = None;
+        for t in tasks {
+            match t.await {
+                Ok(Err(e)) if first_err.is_none() => first_err = Some(e),
+                Err(e) if first_err.is_none() => {
+                    first_err = Some(Drive9Error::Other(format!("task panicked: {}", e)))
+                }
+                _ => {}
+            }
+        }
+        if let Some(e) = first_err {
+            return Err(e);
+        }
+
+        self.complete_upload(&plan.upload_id).await
+    }
+
+    async fn upload_patch_part<F>(
+        &self,
+        part: &PatchPartURL,
+        read_part: &F,
+    ) -> Result<(), Drive9Error>
+    where
+        F: Fn(i32, i64, Option<&[u8]>) -> Result<Vec<u8>, Drive9Error> + Send + Sync + 'static,
+    {
+        let orig_data = if let Some(ref read_url) = part.read_url {
+            let mut headers = HeaderMap::new();
+            if let Some(ref rh) = part.read_headers {
+                for (k, v) in rh {
+                    if let Ok(hv) = reqwest::header::HeaderValue::from_str(v.as_str().unwrap_or(""))
+                    {
+                        headers.insert(
+                            HeaderName::from_bytes(k.as_bytes()).unwrap_or(CONTENT_TYPE),
+                            hv,
+                        );
+                    }
+                }
+            }
+            let resp = self.http.get(read_url).headers(headers).send().await?;
+            let resp = check_error(resp).await?;
+            Some(resp.bytes().await?.to_vec())
+        } else {
+            None
+        };
+
+        let data = read_part(part.number, part.size, orig_data.as_deref())?;
+        let checksum = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            Sha256::digest(&data),
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-amz-checksum-sha256",
+            reqwest::header::HeaderValue::from_str(&checksum).unwrap(),
+        );
+        if let Some(ref ph) = part.headers {
+            for (k, v) in ph {
+                if let Ok(hv) = reqwest::header::HeaderValue::from_str(v.as_str().unwrap_or("")) {
+                    if k.eq_ignore_ascii_case("host") {
+                        continue;
+                    }
+                    headers.insert(
+                        HeaderName::from_bytes(k.as_bytes()).unwrap_or(CONTENT_TYPE),
+                        hv,
+                    );
+                }
+            }
+        }
+        let resp = self
+            .http
+            .put(&part.url)
+            .headers(headers)
+            .body(data)
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+}

--- a/clients/drive9-rs/src/stream.rs
+++ b/clients/drive9-rs/src/stream.rs
@@ -83,6 +83,9 @@ impl StreamWriter {
     }
 
     pub async fn write_part(&self, part_num: i32, data: Vec<u8>) -> Result<(), Drive9Error> {
+        if part_num < 1 {
+            return Err(Drive9Error::Other("part number must be >= 1".to_string()));
+        }
         let mut state = self.state.lock().await;
         if let Some(ref e) = state.err {
             return Err(Drive9Error::Other(format!("{}", e)));
@@ -100,7 +103,22 @@ impl StreamWriter {
         if state.closing {
             return Err(Drive9Error::Other("stream writer is closing".to_string()));
         }
+        if state.uploaded.contains_key(&part_num) {
+            return Err(Drive9Error::Other(
+                format!("part {} already uploaded", part_num),
+            ));
+        }
         self.init_locked(&mut state).await?;
+        if let Some(ref plan) = state.plan {
+            if part_num > plan.total_parts {
+                return Err(Drive9Error::Other(
+                    format!(
+                        "part number {} exceeds total_parts {}",
+                        part_num, plan.total_parts
+                    ),
+                ));
+            }
+        }
         let plan = state.plan.clone().unwrap();
         state.inflight += 1;
         drop(state);

--- a/clients/drive9-rs/src/stream.rs
+++ b/clients/drive9-rs/src/stream.rs
@@ -1,0 +1,261 @@
+use crate::client::Client;
+use crate::error::Drive9Error;
+use crate::models::{CompletePart, UploadPlanV2};
+use std::collections::HashMap;
+use tokio::sync::{Mutex, Semaphore};
+
+const UPLOAD_MAX_CONCURRENCY: usize = 16;
+
+pub struct StreamWriter {
+    client: Client,
+    path: String,
+    total_size: i64,
+    expected_revision: i64,
+    state: std::sync::Arc<Mutex<StreamState>>,
+    sem: Semaphore,
+}
+
+struct StreamState {
+    plan: Option<UploadPlanV2>,
+    uploaded: HashMap<i32, CompletePart>,
+    inflight: usize,
+    err: Option<Drive9Error>,
+    started: bool,
+    completed: bool,
+    aborted: bool,
+    closing: bool,
+}
+
+impl StreamWriter {
+    pub(crate) fn new(
+        client: Client,
+        path: String,
+        total_size: i64,
+        expected_revision: i64,
+    ) -> Self {
+        Self {
+            client,
+            path,
+            total_size,
+            expected_revision,
+            state: std::sync::Arc::new(Mutex::new(StreamState {
+                plan: None,
+                uploaded: HashMap::new(),
+                inflight: 0,
+                err: None,
+                started: false,
+                completed: false,
+                aborted: false,
+                closing: false,
+            })),
+            sem: Semaphore::new(UPLOAD_MAX_CONCURRENCY),
+        }
+    }
+
+    pub async fn started(&self) -> bool {
+        self.state.lock().await.started
+    }
+
+    async fn init_locked(&self, state: &mut StreamState) -> Result<(), Drive9Error> {
+        if state.started {
+            return Ok(());
+        }
+        let plan = self
+            .client
+            .initiate_upload_v2(&self.path, self.total_size, self.expected_revision)
+            .await
+            .map_err(|e| {
+                let msg = format!("initiate stream upload: {}", e);
+                if msg.contains("v2 protocol")
+                    || format!("{}", e).contains("v2 upload API not available")
+                {
+                    Drive9Error::Other(
+                        "streaming upload requires v2 protocol: v2 upload API not available"
+                            .to_string(),
+                    )
+                } else {
+                    Drive9Error::Other(msg)
+                }
+            })?;
+        state.plan = Some(plan);
+        state.started = true;
+        Ok(())
+    }
+
+    pub async fn write_part(&self, part_num: i32, data: Vec<u8>) -> Result<(), Drive9Error> {
+        let mut state = self.state.lock().await;
+        if let Some(ref e) = state.err {
+            return Err(Drive9Error::Other(format!("{}", e)));
+        }
+        if state.completed {
+            return Err(Drive9Error::Other(
+                "stream writer already completed".to_string(),
+            ));
+        }
+        if state.aborted {
+            return Err(Drive9Error::Other(
+                "stream writer already aborted".to_string(),
+            ));
+        }
+        if state.closing {
+            return Err(Drive9Error::Other("stream writer is closing".to_string()));
+        }
+        self.init_locked(&mut state).await?;
+        let plan = state.plan.clone().unwrap();
+        state.inflight += 1;
+        drop(state);
+
+        let _permit = self.sem.acquire().await.unwrap();
+        let client = self.client.clone();
+        let data = data.clone();
+        let upload_id = plan.upload_id;
+
+        // Note: we spawn but do not await here; fire-and-forget like Go.
+        // The caller must later call complete()/abort() which wait for inflight.
+        let this_state = std::sync::Arc::clone(&self.state);
+        tokio::spawn(async move {
+            let result = async {
+                let pp = client.presign_one_part(&upload_id, part_num).await?;
+                let etag = client.upload_one_part_v2(&upload_id, &pp, &data).await?;
+                Ok::<String, Drive9Error>(etag)
+            }
+            .await;
+            let mut s = this_state.lock().await;
+            s.inflight -= 1;
+            match result {
+                Ok(etag) => {
+                    s.uploaded.insert(
+                        part_num,
+                        CompletePart {
+                            number: part_num,
+                            etag,
+                        },
+                    );
+                }
+                Err(e) => {
+                    if s.err.is_none() {
+                        s.err = Some(e);
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    pub async fn complete(
+        &self,
+        final_part_num: i32,
+        final_part_data: Vec<u8>,
+    ) -> Result<(), Drive9Error> {
+        {
+            let mut state = self.state.lock().await;
+            if state.completed {
+                return Err(Drive9Error::Other(
+                    "stream writer already completed".to_string(),
+                ));
+            }
+            if state.aborted {
+                return Err(Drive9Error::Other(
+                    "stream writer already aborted".to_string(),
+                ));
+            }
+            if state.closing {
+                return Err(Drive9Error::Other("stream writer is closing".to_string()));
+            }
+            state.closing = true;
+        }
+        self.wait_inflight().await;
+
+        {
+            let state = self.state.lock().await;
+            if let Some(ref e) = state.err {
+                return Err(Drive9Error::Other(format!("{}", e)));
+            }
+            if !state.started || state.plan.is_none() {
+                return Err(Drive9Error::Other(
+                    "stream writer was never started".to_string(),
+                ));
+            }
+        }
+
+        if !final_part_data.is_empty() {
+            let upload_id = {
+                let state = self.state.lock().await;
+                state.plan.as_ref().unwrap().upload_id.clone()
+            };
+            let pp = self
+                .client
+                .presign_one_part(&upload_id, final_part_num)
+                .await?;
+            let etag = self
+                .client
+                .upload_one_part_v2(&upload_id, &pp, &final_part_data)
+                .await?;
+            let mut state = self.state.lock().await;
+            state.uploaded.insert(
+                final_part_num,
+                CompletePart {
+                    number: final_part_num,
+                    etag,
+                },
+            );
+        }
+
+        let (upload_id, parts) = {
+            let mut state = self.state.lock().await;
+            if state.uploaded.is_empty() {
+                return Err(Drive9Error::Other(
+                    "no parts uploaded in stream upload".to_string(),
+                ));
+            }
+            let max_part = *state.uploaded.keys().max().unwrap();
+            let mut parts = vec![];
+            for i in 1..=max_part {
+                let cp = state.uploaded.get(&i).cloned().ok_or_else(|| {
+                    Drive9Error::Other(format!(
+                        "missing part {} in stream upload (have {} parts, max {})",
+                        i,
+                        state.uploaded.len(),
+                        max_part
+                    ))
+                })?;
+                parts.push(cp);
+            }
+            state.completed = true;
+            (state.plan.as_ref().unwrap().upload_id.clone(), parts)
+        };
+        self.client.complete_upload_v2(&upload_id, &parts).await
+    }
+
+    pub async fn abort(&self) -> Result<(), Drive9Error> {
+        {
+            let mut state = self.state.lock().await;
+            if state.aborted {
+                return Ok(());
+            }
+            state.closing = true;
+        }
+        self.wait_inflight().await;
+        let upload_id = {
+            let mut state = self.state.lock().await;
+            state.aborted = true;
+            if !state.started {
+                return Ok(());
+            }
+            state.plan.as_ref().unwrap().upload_id.clone()
+        };
+        self.client.abort_upload_v2(&upload_id).await
+    }
+
+    async fn wait_inflight(&self) {
+        loop {
+            {
+                let state = self.state.lock().await;
+                if state.inflight == 0 {
+                    break;
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        }
+    }
+}

--- a/clients/drive9-rs/src/transfer.rs
+++ b/clients/drive9-rs/src/transfer.rs
@@ -200,9 +200,20 @@ impl Client {
             .http
             .get(self.fs_url(path))
             .headers(self.auth_headers())
+            .header("Range", format!("bytes={}-{}", offset, offset + length - 1))
             .send()
             .await?;
         let status = resp.status();
+        if status.as_u16() == 206 {
+            let stream = resp.bytes_stream();
+            let reader = StreamReader::new(stream.map(|item| {
+                item.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            }));
+            return Ok(Box::new(reader));
+        }
+        if status.as_u16() == 416 {
+            return Ok(Box::new(std::io::Cursor::new(Vec::new())));
+        }
         if status.as_u16() == 302 || status.as_u16() == 307 {
             let location = resp
                 .headers()

--- a/clients/drive9-rs/src/transfer.rs
+++ b/clients/drive9-rs/src/transfer.rs
@@ -1,0 +1,892 @@
+use crate::client::Client;
+use crate::error::{check_error, Drive9Error};
+use crate::models::{CompletePart, PartURL, PresignedPart, UploadMeta, UploadPlan, UploadPlanV2};
+use bytes::Bytes;
+use futures::StreamExt;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
+use serde_json::json;
+use std::io::{Read, Seek, SeekFrom};
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+use tokio_util::io::StreamReader;
+
+const PART_SIZE: i64 = 8 * 1024 * 1024;
+const UPLOAD_MAX_CONCURRENCY: usize = 16;
+const UPLOAD_MAX_BUFFER_BYTES: i64 = 256 * 1024 * 1024;
+
+fn upload_parallelism(part_size: i64) -> usize {
+    let by_memory = (UPLOAD_MAX_BUFFER_BYTES / part_size).max(1) as usize;
+    by_memory.min(UPLOAD_MAX_CONCURRENCY)
+}
+
+fn checksum_parallelism(part_size: i64, part_count: usize) -> usize {
+    let by_memory = (UPLOAD_MAX_BUFFER_BYTES / part_size).max(1) as usize;
+    part_count.min(by_memory)
+}
+
+fn compute_crc32c(data: &[u8]) -> String {
+    let v = crc32c::crc32c(data);
+    let b = v.to_be_bytes();
+    base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b)
+}
+
+fn calc_parts(total_size: i64, part_size: i64) -> Vec<(i32, i64)> {
+    if total_size <= 0 {
+        return vec![];
+    }
+    let num_parts = (total_size + part_size - 1) / part_size;
+    (0..num_parts)
+        .map(|i| {
+            let offset = i * part_size;
+            let size = part_size.min(total_size - offset);
+            ((i + 1) as i32, size)
+        })
+        .collect()
+}
+
+pub trait SeekableReader: Read + Seek + Send {}
+impl<T: Read + Seek + Send> SeekableReader for T {}
+
+struct SyncReader {
+    inner: std::sync::Mutex<Box<dyn SeekableReader>>,
+}
+
+impl SyncReader {
+    fn new(inner: Box<dyn SeekableReader>) -> Self {
+        Self {
+            inner: std::sync::Mutex::new(inner),
+        }
+    }
+    fn seek_read(&self, offset: u64, size: usize) -> std::io::Result<Vec<u8>> {
+        let mut guard = self.inner.lock().unwrap();
+        guard.seek(SeekFrom::Start(offset))?;
+        let mut buf = vec![0u8; size];
+        guard.read_exact(&mut buf)?;
+        Ok(buf)
+    }
+}
+
+impl Client {
+    pub async fn write_stream(
+        &self,
+        path: &str,
+        reader: Box<dyn SeekableReader>,
+        size: i64,
+    ) -> Result<(), Drive9Error> {
+        self.write_stream_conditional(path, reader, size, -1).await
+    }
+
+    pub async fn write_stream_conditional(
+        &self,
+        path: &str,
+        reader: Box<dyn SeekableReader>,
+        size: i64,
+        expected_revision: i64,
+    ) -> Result<(), Drive9Error> {
+        let threshold = self.small_file_threshold;
+        if size < threshold {
+            let data = tokio::task::spawn_blocking(move || {
+                let mut buf = Vec::new();
+                let mut r = reader;
+                r.read_to_end(&mut buf)?;
+                Ok::<_, std::io::Error>(buf)
+            })
+            .await
+            .map_err(|e| Drive9Error::Other(format!("join error: {}", e)))?;
+            let data = data.map_err(Drive9Error::Io)?;
+            return self
+                .write_with_revision(path, &data, expected_revision)
+                .await;
+        }
+
+        let sync_reader = Arc::new(SyncReader::new(reader));
+
+        match self
+            .write_stream_v2(path, Arc::clone(&sync_reader), size, expected_revision)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(Drive9Error::Other(ref s)) if s.contains("v2 upload API not available") => {
+                self.write_stream_v1(path, sync_reader, size, expected_revision)
+                    .await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn write_stream_v1(
+        &self,
+        path: &str,
+        reader: Arc<SyncReader>,
+        size: i64,
+        expected_revision: i64,
+    ) -> Result<(), Drive9Error> {
+        let checksums = compute_part_checksums(Arc::clone(&reader), size, PART_SIZE).await?;
+        let plan = self
+            .initiate_upload(path, size, &checksums, expected_revision)
+            .await?;
+        self.upload_parts_v1(&plan, reader).await
+    }
+
+    async fn write_stream_v2(
+        &self,
+        path: &str,
+        reader: Arc<SyncReader>,
+        size: i64,
+        expected_revision: i64,
+    ) -> Result<(), Drive9Error> {
+        let plan = self
+            .initiate_upload_v2(path, size, expected_revision)
+            .await?;
+        let parts = match self.upload_parts_v2(&plan, reader).await {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = self.abort_upload_v2(&plan.upload_id).await;
+                return Err(e);
+            }
+        };
+        if let Err(e) = self.complete_upload_v2(&plan.upload_id, &parts).await {
+            let _ = self.abort_upload_v2(&plan.upload_id).await;
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    pub async fn read_stream(
+        &self,
+        path: &str,
+    ) -> Result<Box<dyn tokio::io::AsyncRead + Unpin + Send>, Drive9Error> {
+        let resp = self
+            .http
+            .get(self.fs_url(path))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let status = resp.status();
+        if status.as_u16() == 302 || status.as_u16() == 307 {
+            let location = resp
+                .headers()
+                .get("location")
+                .or_else(|| resp.headers().get("Location"))
+                .and_then(|v| v.to_str().ok())
+                .ok_or_else(|| Drive9Error::Other("302 without Location header".to_string()))?;
+            let resp2 = self.http.get(location).send().await?;
+            let resp2 = check_error(resp2).await?;
+            let stream = resp2.bytes_stream();
+            let reader =
+                StreamReader::new(stream.map(|item| {
+                    item.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+                }));
+            return Ok(Box::new(reader));
+        }
+        let resp = check_error(resp).await?;
+        let stream = resp.bytes_stream();
+        let reader = StreamReader::new(
+            stream.map(|item| item.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))),
+        );
+        Ok(Box::new(reader))
+    }
+
+    pub async fn read_stream_range(
+        &self,
+        path: &str,
+        offset: i64,
+        length: i64,
+    ) -> Result<Box<dyn tokio::io::AsyncRead + Unpin + Send>, Drive9Error> {
+        if length <= 0 {
+            return Ok(Box::new(std::io::Cursor::new(Vec::new())));
+        }
+        let resp = self
+            .http
+            .get(self.fs_url(path))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let status = resp.status();
+        if status.as_u16() == 302 || status.as_u16() == 307 {
+            let location = resp
+                .headers()
+                .get("location")
+                .or_else(|| resp.headers().get("Location"))
+                .and_then(|v| v.to_str().ok())
+                .ok_or_else(|| Drive9Error::Other("302 without Location header".to_string()))?;
+            let resp2 = self
+                .http
+                .get(location)
+                .header("Range", format!("bytes={}-{}", offset, offset + length - 1))
+                .send()
+                .await?;
+            let status2 = resp2.status();
+            if status2.as_u16() == 206 {
+                let stream = resp2.bytes_stream();
+                let reader = StreamReader::new(stream.map(|item| {
+                    item.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+                }));
+                return Ok(Box::new(reader));
+            }
+            if status2.as_u16() == 416 {
+                return Ok(Box::new(std::io::Cursor::new(Vec::new())));
+            }
+            let resp2 = check_error(resp2).await?;
+            let body = resp2.bytes().await?;
+            let sliced = slice_body(body, offset as usize, length as usize);
+            return Ok(Box::new(std::io::Cursor::new(sliced)));
+        }
+        let resp = check_error(resp).await?;
+        let body = resp.bytes().await?;
+        let sliced = slice_body(body, offset as usize, length as usize);
+        Ok(Box::new(std::io::Cursor::new(sliced)))
+    }
+
+    pub async fn resume_upload(
+        &self,
+        path: &str,
+        reader: Box<dyn SeekableReader>,
+        total_size: i64,
+    ) -> Result<(), Drive9Error> {
+        let meta = self.query_upload(path).await?;
+        let sync_reader = Arc::new(SyncReader::new(reader));
+        let checksums =
+            compute_part_checksums(Arc::clone(&sync_reader), total_size, PART_SIZE).await?;
+        let plan = self.request_resume(&meta.upload_id, &checksums).await?;
+        if plan.parts.is_empty() {
+            return self.complete_upload(&plan.upload_id).await;
+        }
+        self.upload_missing_parts(&plan, Arc::clone(&sync_reader), meta.parts_total)
+            .await?;
+        self.complete_upload(&plan.upload_id).await
+    }
+
+    // ------------------------------------------------------------------
+    // v1 upload internals
+    // ------------------------------------------------------------------
+
+    async fn initiate_upload(
+        &self,
+        path: &str,
+        size: i64,
+        checksums: &[String],
+        expected_revision: i64,
+    ) -> Result<UploadPlan, Drive9Error> {
+        match self
+            .initiate_upload_by_body(path, size, checksums, expected_revision)
+            .await
+        {
+            Ok(p) => return Ok(p),
+            Err((status, err)) => {
+                if status == 404 || status == 405 {
+                    return self
+                        .initiate_upload_legacy(path, size, checksums, expected_revision)
+                        .await;
+                }
+                if status == 400 && err.to_lowercase().contains("unknown upload action") {
+                    return self
+                        .initiate_upload_legacy(path, size, checksums, expected_revision)
+                        .await;
+                }
+                return Err(Drive9Error::Status {
+                    status_code: status,
+                    message: err,
+                });
+            }
+        }
+    }
+
+    async fn initiate_upload_by_body(
+        &self,
+        path: &str,
+        size: i64,
+        checksums: &[String],
+        expected_revision: i64,
+    ) -> Result<UploadPlan, (u16, String)> {
+        let mut payload = json!({
+            "path": path,
+            "total_size": size,
+            "part_checksums": checksums,
+        });
+        if expected_revision >= 0 {
+            payload["expected_revision"] = json!(expected_revision);
+        }
+        let resp = self
+            .http
+            .post(format!("{}/v1/uploads/initiate", self.base_url))
+            .headers(self.auth_headers())
+            .header(CONTENT_TYPE, "application/json")
+            .body(payload.to_string())
+            .send()
+            .await
+            .map_err(|e| (0u16, e.to_string()))?;
+        let status = resp.status().as_u16();
+        if status == 202 {
+            return resp
+                .json::<UploadPlan>()
+                .await
+                .map_err(|e| (0u16, e.to_string()));
+        }
+        let text = resp.text().await.unwrap_or_default();
+        Err((status, text))
+    }
+
+    async fn initiate_upload_legacy(
+        &self,
+        path: &str,
+        size: i64,
+        checksums: &[String],
+        expected_revision: i64,
+    ) -> Result<UploadPlan, Drive9Error> {
+        let mut headers = self.auth_headers();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/octet-stream"),
+        );
+        headers.insert(
+            "X-Dat9-Content-Length",
+            HeaderValue::from_str(&size.to_string()).unwrap(),
+        );
+        if !checksums.is_empty() {
+            headers.insert(
+                "X-Dat9-Part-Checksums",
+                HeaderValue::from_str(&checksums.join(",")).unwrap(),
+            );
+        }
+        if expected_revision >= 0 {
+            headers.insert(
+                "X-Dat9-Expected-Revision",
+                HeaderValue::from_str(&expected_revision.to_string()).unwrap(),
+            );
+        }
+        let resp = self
+            .http
+            .put(self.fs_url(path))
+            .headers(headers)
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    async fn upload_parts_v1(
+        &self,
+        plan: &UploadPlan,
+        reader: Arc<SyncReader>,
+    ) -> Result<(), Drive9Error> {
+        let mut std_part_size = plan.part_size;
+        if std_part_size <= 0 && !plan.parts.is_empty() {
+            std_part_size = plan.parts[0].size;
+        }
+        if std_part_size <= 0 {
+            std_part_size = PART_SIZE;
+        }
+        let max_concurrency = upload_parallelism(std_part_size);
+        let sem = Arc::new(Semaphore::new(max_concurrency));
+        let mut tasks = vec![];
+        for part in &plan.parts {
+            let permit = Arc::clone(&sem).acquire_owned().await.unwrap();
+            let client = self.clone();
+            let r = Arc::clone(&reader);
+            let p = part.clone();
+            let offset = (p.number - 1) as i64 * std_part_size;
+            let task = tokio::spawn(async move {
+                let _permit = permit;
+                let data = tokio::task::spawn_blocking(move || {
+                    r.seek_read(offset as u64, p.size as usize)
+                })
+                .await
+                .map_err(|e| Drive9Error::Other(format!("join error: {}", e)))?;
+                let data = data.map_err(Drive9Error::Io)?;
+                client.upload_one_part(&p, &data).await
+            });
+            tasks.push(task);
+        }
+        for t in tasks {
+            t.await
+                .map_err(|e| Drive9Error::Other(format!("task panicked: {}", e)))??;
+        }
+        self.complete_upload(&plan.upload_id).await
+    }
+
+    async fn upload_one_part(&self, part: &PartURL, data: &[u8]) -> Result<String, Drive9Error> {
+        let checksum = part
+            .checksum_crc32c
+            .clone()
+            .unwrap_or_else(|| compute_crc32c(data));
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-amz-checksum-crc32c",
+            HeaderValue::from_str(&checksum).unwrap(),
+        );
+        if let Some(ref ph) = part.headers {
+            for (k, v) in ph {
+                if let Ok(hv) = HeaderValue::from_str(v.as_str().unwrap_or("")) {
+                    if k.eq_ignore_ascii_case("host") {
+                        continue;
+                    }
+                    headers.insert(
+                        HeaderName::from_bytes(k.as_bytes()).unwrap_or(CONTENT_TYPE),
+                        hv,
+                    );
+                }
+            }
+        }
+        let resp = self
+            .http
+            .put(&part.url)
+            .headers(headers)
+            .body(data.to_vec())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp
+            .headers()
+            .get("etag")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string())
+    }
+
+    pub(crate) async fn complete_upload(&self, upload_id: &str) -> Result<(), Drive9Error> {
+        let resp = self
+            .http
+            .post(format!(
+                "{}/v1/uploads/{}/complete",
+                self.base_url, upload_id
+            ))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // v2 upload internals
+    // ------------------------------------------------------------------
+
+    pub(crate) async fn initiate_upload_v2(
+        &self,
+        path: &str,
+        size: i64,
+        expected_revision: i64,
+    ) -> Result<UploadPlanV2, Drive9Error> {
+        let mut payload = json!({
+            "path": path,
+            "total_size": size,
+        });
+        if expected_revision >= 0 {
+            payload["expected_revision"] = json!(expected_revision);
+        }
+        let resp = self
+            .http
+            .post(format!("{}/v2/uploads/initiate", self.base_url))
+            .headers(self.auth_headers())
+            .header(CONTENT_TYPE, "application/json")
+            .body(payload.to_string())
+            .send()
+            .await?;
+        if resp.status().as_u16() == 404 {
+            return Err(Drive9Error::Other(
+                "v2 upload API not available".to_string(),
+            ));
+        }
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    async fn upload_parts_v2(
+        &self,
+        plan: &UploadPlanV2,
+        reader: Arc<SyncReader>,
+    ) -> Result<Vec<CompletePart>, Drive9Error> {
+        let part_size = plan.part_size;
+        let total_parts = plan.total_parts;
+        let upload_id = plan.upload_id.clone();
+        let parallelism = upload_parallelism(part_size);
+
+        let mut presigned = vec![];
+        let batch_size = parallelism as i32;
+        let mut start = 1i32;
+        while start <= total_parts {
+            let end = (start + batch_size - 1).min(total_parts);
+            let batch = self.presign_batch(&upload_id, start, end).await?;
+            presigned.extend(batch);
+            start = end + 1;
+        }
+
+        let sem = Arc::new(Semaphore::new(parallelism));
+        let mut tasks = vec![];
+        let results: Vec<Option<CompletePart>> = vec![None; total_parts as usize];
+        let results_arc = Arc::new(tokio::sync::Mutex::new(results));
+
+        for pp in presigned {
+            let permit = Arc::clone(&sem).acquire_owned().await.unwrap();
+            let client = self.clone();
+            let r = Arc::clone(&reader);
+            let res = Arc::clone(&results_arc);
+            let psize = part_size;
+            let uid = upload_id.clone();
+            let task = tokio::spawn(async move {
+                let _permit = permit;
+                let offset = (pp.number - 1) as i64 * psize;
+                let data = tokio::task::spawn_blocking(move || {
+                    r.seek_read(offset as u64, pp.size as usize)
+                })
+                .await
+                .map_err(|e| Drive9Error::Other(format!("join error: {}", e)))?;
+                let data = data.map_err(Drive9Error::Io)?;
+                let etag = client.upload_one_part_v2(&uid, &pp, &data).await?;
+                res.lock().await[pp.number as usize - 1] = Some(CompletePart {
+                    number: pp.number,
+                    etag,
+                });
+                Ok::<(), Drive9Error>(())
+            });
+            tasks.push(task);
+        }
+        for t in tasks {
+            t.await
+                .map_err(|e| Drive9Error::Other(format!("task panicked: {}", e)))??;
+        }
+
+        let guard = results_arc.lock().await;
+        Ok(guard.iter().filter_map(|x| x.clone()).collect())
+    }
+
+    async fn presign_batch(
+        &self,
+        upload_id: &str,
+        start: i32,
+        end: i32,
+    ) -> Result<Vec<PresignedPart>, Drive9Error> {
+        let entries: Vec<_> = (start..=end).map(|i| json!({"part_number": i})).collect();
+        let resp = self
+            .http
+            .post(format!(
+                "{}/v2/uploads/{}/presign-batch",
+                self.base_url, upload_id
+            ))
+            .headers(self.auth_headers())
+            .header(CONTENT_TYPE, "application/json")
+            .json(&json!({"parts": entries}))
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        let result: serde_json::Value = resp.json().await?;
+        Ok(serde_json::from_value(
+            result.get("parts").cloned().unwrap_or(json!([])),
+        )?)
+    }
+
+    pub(crate) async fn upload_one_part_v2(
+        &self,
+        upload_id: &str,
+        part: &PresignedPart,
+        data: &[u8],
+    ) -> Result<String, Drive9Error> {
+        let mut headers = HeaderMap::new();
+        if let Some(ref ph) = part.headers {
+            for (k, v) in ph {
+                if let Ok(hv) = HeaderValue::from_str(v.as_str().unwrap_or("")) {
+                    if k.eq_ignore_ascii_case("host") {
+                        continue;
+                    }
+                    headers.insert(
+                        HeaderName::from_bytes(k.as_bytes()).unwrap_or(CONTENT_TYPE),
+                        hv,
+                    );
+                }
+            }
+        }
+        let resp = self
+            .http
+            .put(&part.url)
+            .headers(headers)
+            .body(data.to_vec())
+            .send()
+            .await?;
+        if resp.status().as_u16() == 403 {
+            let fresh = self.presign_one_part(upload_id, part.number).await?;
+            let mut headers = HeaderMap::new();
+            if let Some(ref ph) = fresh.headers {
+                for (k, v) in ph {
+                    if let Ok(hv) = HeaderValue::from_str(v.as_str().unwrap_or("")) {
+                        if k.eq_ignore_ascii_case("host") {
+                            continue;
+                        }
+                        headers.insert(
+                            HeaderName::from_bytes(k.as_bytes()).unwrap_or(CONTENT_TYPE),
+                            hv,
+                        );
+                    }
+                }
+            }
+            let resp = self
+                .http
+                .put(&fresh.url)
+                .headers(headers)
+                .body(data.to_vec())
+                .send()
+                .await?;
+            let resp = check_error(resp).await?;
+            return Ok(resp
+                .headers()
+                .get("etag")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_string());
+        }
+        let resp = check_error(resp).await?;
+        Ok(resp
+            .headers()
+            .get("etag")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string())
+    }
+
+    pub(crate) async fn presign_one_part(
+        &self,
+        upload_id: &str,
+        part_number: i32,
+    ) -> Result<PresignedPart, Drive9Error> {
+        let resp = self
+            .http
+            .post(format!(
+                "{}/v2/uploads/{}/presign",
+                self.base_url, upload_id
+            ))
+            .headers(self.auth_headers())
+            .header(CONTENT_TYPE, "application/json")
+            .json(&json!({"part_number": part_number}))
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub(crate) async fn complete_upload_v2(
+        &self,
+        upload_id: &str,
+        parts: &[CompletePart],
+    ) -> Result<(), Drive9Error> {
+        let resp = self
+            .http
+            .post(format!(
+                "{}/v2/uploads/{}/complete",
+                self.base_url, upload_id
+            ))
+            .headers(self.auth_headers())
+            .header(CONTENT_TYPE, "application/json")
+            .json(&json!({"parts": parts}))
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn abort_upload_v2(&self, upload_id: &str) -> Result<(), Drive9Error> {
+        let resp = self
+            .http
+            .post(format!("{}/v2/uploads/{}/abort", self.base_url, upload_id))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // resume helpers
+    // ------------------------------------------------------------------
+
+    async fn query_upload(&self, path: &str) -> Result<UploadMeta, Drive9Error> {
+        let resp = self
+            .http
+            .get(format!(
+                "{}/v1/uploads?path={}&status=UPLOADING",
+                self.base_url,
+                urlencoding::encode(path)
+            ))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        let result: serde_json::Value = resp.json().await?;
+        let uploads: Vec<UploadMeta> =
+            serde_json::from_value(result.get("uploads").cloned().unwrap_or(json!([])))?;
+        uploads
+            .into_iter()
+            .next()
+            .ok_or_else(|| Drive9Error::Other(format!("no active upload for {}", path)))
+    }
+
+    async fn request_resume(
+        &self,
+        upload_id: &str,
+        checksums: &[String],
+    ) -> Result<UploadPlan, Drive9Error> {
+        match self.request_resume_by_body(upload_id, checksums).await {
+            Ok(p) => return Ok(p),
+            Err((status, err)) => {
+                if status == 400
+                    && err
+                        .to_lowercase()
+                        .contains("missing x-dat9-part-checksums header")
+                {
+                    return self.request_resume_legacy(upload_id, checksums).await;
+                }
+                return Err(Drive9Error::Status {
+                    status_code: status,
+                    message: err,
+                });
+            }
+        }
+    }
+
+    async fn request_resume_by_body(
+        &self,
+        upload_id: &str,
+        checksums: &[String],
+    ) -> Result<UploadPlan, (u16, String)> {
+        let resp = self
+            .http
+            .post(format!("{}/v1/uploads/{}/resume", self.base_url, upload_id))
+            .headers(self.auth_headers())
+            .header(CONTENT_TYPE, "application/json")
+            .json(&json!({"part_checksums": checksums}))
+            .send()
+            .await
+            .map_err(|e| (0u16, e.to_string()))?;
+        let status = resp.status().as_u16();
+        if status == 410 {
+            let text = resp.text().await.unwrap_or_default();
+            return Err((status, text));
+        }
+        if !resp.status().is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err((status, text));
+        }
+        resp.json::<UploadPlan>()
+            .await
+            .map_err(|e| (0u16, e.to_string()))
+    }
+
+    async fn request_resume_legacy(
+        &self,
+        upload_id: &str,
+        checksums: &[String],
+    ) -> Result<UploadPlan, Drive9Error> {
+        let mut headers = self.auth_headers();
+        if !checksums.is_empty() {
+            headers.insert(
+                "X-Dat9-Part-Checksums",
+                HeaderValue::from_str(&checksums.join(",")).unwrap(),
+            );
+        }
+        let resp = self
+            .http
+            .post(format!("{}/v1/uploads/{}/resume", self.base_url, upload_id))
+            .headers(headers)
+            .send()
+            .await?;
+        if resp.status().as_u16() == 410 {
+            return Err(Drive9Error::Other(format!(
+                "upload {} has expired",
+                upload_id
+            )));
+        }
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    async fn upload_missing_parts(
+        &self,
+        plan: &UploadPlan,
+        reader: Arc<SyncReader>,
+        _total_parts: i32,
+    ) -> Result<(), Drive9Error> {
+        let mut std_part_size = plan.part_size;
+        if std_part_size <= 0 {
+            std_part_size = PART_SIZE;
+        }
+        let max_concurrency = upload_parallelism(std_part_size);
+        let sem = Arc::new(Semaphore::new(max_concurrency));
+        let mut tasks = vec![];
+        for part in &plan.parts {
+            let permit = Arc::clone(&sem).acquire_owned().await.unwrap();
+            let client = self.clone();
+            let r = Arc::clone(&reader);
+            let p = part.clone();
+            let offset = (p.number - 1) as i64 * std_part_size;
+            let task = tokio::spawn(async move {
+                let _permit = permit;
+                let data = tokio::task::spawn_blocking(move || {
+                    r.seek_read(offset as u64, p.size as usize)
+                })
+                .await
+                .map_err(|e| Drive9Error::Other(format!("join error: {}", e)))?;
+                let data = data.map_err(Drive9Error::Io)?;
+                client.upload_one_part(&p, &data).await
+            });
+            tasks.push(task);
+        }
+        for t in tasks {
+            t.await
+                .map_err(|e| Drive9Error::Other(format!("task panicked: {}", e)))??;
+        }
+        Ok(())
+    }
+}
+
+async fn compute_part_checksums(
+    reader: Arc<SyncReader>,
+    total_size: i64,
+    part_size: i64,
+) -> Result<Vec<String>, Drive9Error> {
+    let parts = calc_parts(total_size, part_size);
+    let part_count = parts.len();
+    if part_count == 0 {
+        return Ok(vec![]);
+    }
+    let workers = checksum_parallelism(part_size, part_count);
+    let mut handles = vec![];
+    let mut per_worker = vec![vec![]; workers];
+    for (i, p) in parts.into_iter().enumerate() {
+        per_worker[i % workers].push(p);
+    }
+    for chunk in per_worker {
+        let r = Arc::clone(&reader);
+        let psize = part_size as usize;
+        let handle = tokio::task::spawn_blocking(move || {
+            let mut out = Vec::with_capacity(chunk.len());
+            for (number, size) in chunk {
+                let data =
+                    r.seek_read(((number - 1) as i64 * psize as i64) as u64, size as usize)?;
+                out.push((number, compute_crc32c(&data)));
+            }
+            Ok::<Vec<(i32, String)>, std::io::Error>(out)
+        });
+        handles.push(handle);
+    }
+    let mut results: Vec<Option<String>> = vec![None; part_count];
+    for h in handles {
+        let chunk_results = h
+            .await
+            .map_err(|e| Drive9Error::Other(format!("join error: {}", e)))?;
+        let chunk_results = chunk_results.map_err(Drive9Error::Io)?;
+        for (number, checksum) in chunk_results {
+            results[number as usize - 1] = Some(checksum);
+        }
+    }
+    results
+        .into_iter()
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| Drive9Error::Other("checksum computation failed".to_string()))
+}
+
+fn slice_body(body: Bytes, offset: usize, length: usize) -> Vec<u8> {
+    let end = (offset + length).min(body.len());
+    if offset >= body.len() {
+        return vec![];
+    }
+    body[offset..end].to_vec()
+}

--- a/clients/drive9-rs/src/vault.rs
+++ b/clients/drive9-rs/src/vault.rs
@@ -1,0 +1,174 @@
+use crate::client::Client;
+use crate::error::{check_error, Drive9Error};
+use crate::models::{VaultAuditEvent, VaultSecret, VaultTokenIssueResponse};
+use serde_json::json;
+
+impl Client {
+    pub async fn create_vault_secret(
+        &self,
+        name: &str,
+        fields: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<VaultSecret, Drive9Error> {
+        let resp = self
+            .http
+            .post(self.vault_url("/secrets"))
+            .headers(self.auth_headers())
+            .json(&json!({"name": name, "fields": fields, "created_by": "drive9-cli"}))
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn update_vault_secret(
+        &self,
+        name: &str,
+        fields: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<VaultSecret, Drive9Error> {
+        let resp = self
+            .http
+            .put(self.vault_url(&format!("/secrets/{}", urlencoding::encode(name))))
+            .headers(self.auth_headers())
+            .json(&json!({"fields": fields, "updated_by": "drive9-cli"}))
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn delete_vault_secret(&self, name: &str) -> Result<(), Drive9Error> {
+        let resp = self
+            .http
+            .delete(self.vault_url(&format!("/secrets/{}", urlencoding::encode(name))))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+
+    pub async fn list_vault_secrets(&self) -> Result<Vec<VaultSecret>, Drive9Error> {
+        let resp = self
+            .http
+            .get(self.vault_url("/secrets"))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        let result: serde_json::Value = resp.json().await?;
+        Ok(serde_json::from_value(
+            result.get("secrets").cloned().unwrap_or(json!([])),
+        )?)
+    }
+
+    pub async fn issue_vault_token(
+        &self,
+        agent_id: &str,
+        task_id: &str,
+        scope: &[String],
+        ttl_seconds: i64,
+    ) -> Result<VaultTokenIssueResponse, Drive9Error> {
+        let resp = self
+            .http
+            .post(self.vault_url("/tokens"))
+            .headers(self.auth_headers())
+            .json(&json!({
+                "agent_id": agent_id,
+                "task_id": task_id,
+                "scope": scope,
+                "ttl_seconds": ttl_seconds,
+            }))
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn revoke_vault_token(&self, token_id: &str) -> Result<(), Drive9Error> {
+        let resp = self
+            .http
+            .delete(self.vault_url(&format!("/tokens/{}", urlencoding::encode(token_id))))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        check_error(resp).await?;
+        Ok(())
+    }
+
+    pub async fn query_vault_audit(
+        &self,
+        secret_name: Option<&str>,
+        limit: i32,
+    ) -> Result<Vec<VaultAuditEvent>, Drive9Error> {
+        let mut url = self.vault_url("/audit").to_string();
+        let mut params = vec![];
+        if let Some(s) = secret_name {
+            params.push(format!("secret={}", urlencoding::encode(s)));
+        }
+        if limit > 0 {
+            params.push(format!("limit={}", limit));
+        }
+        if !params.is_empty() {
+            url.push('?');
+            url.push_str(&params.join("&"));
+        }
+        let resp = self
+            .http
+            .get(&url)
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        let result: serde_json::Value = resp.json().await?;
+        Ok(serde_json::from_value(
+            result.get("events").cloned().unwrap_or(json!([])),
+        )?)
+    }
+
+    pub async fn list_readable_vault_secrets(&self) -> Result<Vec<String>, Drive9Error> {
+        let resp = self
+            .http
+            .get(self.vault_url("/read"))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        let result: serde_json::Value = resp.json().await?;
+        Ok(serde_json::from_value(
+            result.get("secrets").cloned().unwrap_or(json!([])),
+        )?)
+    }
+
+    pub async fn read_vault_secret(
+        &self,
+        name: &str,
+    ) -> Result<serde_json::Map<String, serde_json::Value>, Drive9Error> {
+        let resp = self
+            .http
+            .get(self.vault_url(&format!("/read/{}", urlencoding::encode(name))))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn read_vault_secret_field(
+        &self,
+        name: &str,
+        field: &str,
+    ) -> Result<String, Drive9Error> {
+        let resp = self
+            .http
+            .get(self.vault_url(&format!(
+                "/read/{}/{}",
+                urlencoding::encode(name),
+                urlencoding::encode(field)
+            )))
+            .headers(self.auth_headers())
+            .send()
+            .await?;
+        let resp = check_error(resp).await?;
+        Ok(resp.text().await?)
+    }
+}

--- a/clients/drive9-rs/src/vault.rs
+++ b/clients/drive9-rs/src/vault.rs
@@ -13,7 +13,7 @@ impl Client {
             .http
             .post(self.vault_url("/secrets"))
             .headers(self.auth_headers())
-            .json(&json!({"name": name, "fields": fields, "created_by": "drive9-cli"}))
+            .json(&json!({"name": name, "fields": fields, "created_by": "drive9-rs"}))
             .send()
             .await?;
         let resp = check_error(resp).await?;
@@ -29,7 +29,7 @@ impl Client {
             .http
             .put(self.vault_url(&format!("/secrets/{}", urlencoding::encode(name))))
             .headers(self.auth_headers())
-            .json(&json!({"fields": fields, "updated_by": "drive9-cli"}))
+            .json(&json!({"fields": fields, "updated_by": "drive9-rs"}))
             .send()
             .await?;
         let resp = check_error(resp).await?;

--- a/clients/drive9-rs/tests/test_client.rs
+++ b/clients/drive9-rs/tests/test_client.rs
@@ -1,0 +1,116 @@
+use drive9::{Client, Drive9Error};
+
+#[tokio::test]
+async fn test_write_and_read() {
+    let mut server = mockito::Server::new_async().await;
+    let _m1 = server
+        .mock("PUT", "/v1/fs/hello.txt")
+        .with_status(200)
+        .create_async()
+        .await;
+    let _m2 = server
+        .mock("GET", "/v1/fs/hello.txt")
+        .with_status(200)
+        .with_body("hello world")
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "test-key");
+    client.write("/hello.txt", b"hello world").await.unwrap();
+    let data = client.read("/hello.txt").await.unwrap();
+    assert_eq!(data, b"hello world");
+}
+
+#[tokio::test]
+async fn test_list_directory() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("GET", "/v1/fs/data/?list=1")
+        .with_status(200)
+        .with_body(r#"{"entries":[{"name":"a.txt","size":1,"isDir":false},{"name":"b.txt","size":2,"isDir":false}]}"#)
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "test-key");
+    let entries = client.list("/data/").await.unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].name, "a.txt");
+}
+
+#[tokio::test]
+async fn test_stat() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("HEAD", "/v1/fs/test.txt")
+        .with_status(200)
+        .with_header("Content-Length", "4")
+        .with_header("X-Dat9-Revision", "7")
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "test-key");
+    let info = client.stat("/test.txt").await.unwrap();
+    assert_eq!(info.size, 4);
+    assert_eq!(info.revision, 7);
+    assert!(!info.is_dir);
+}
+
+#[tokio::test]
+async fn test_conflict_error() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("PUT", "/v1/fs/conflict.txt")
+        .with_status(409)
+        .with_body(r#"{"error":"revision mismatch"}"#)
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "test-key");
+    let err = client.write("/conflict.txt", b"x").await.unwrap_err();
+    match err {
+        Drive9Error::Conflict { status_code, .. } => assert_eq!(status_code, 409),
+        _ => panic!("expected Conflict error, got {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_status_error() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("PUT", "/v1/fs/err.txt")
+        .with_status(500)
+        .with_body(r#"{"error":"boom"}"#)
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "test-key");
+    let err = client.write("/err.txt", b"x").await.unwrap_err();
+    match err {
+        Drive9Error::Status { status_code, .. } => assert_eq!(status_code, 500),
+        _ => panic!("expected Status error, got {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_grep() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("GET", "/v1/fs/?grep=hello")
+        .with_status(200)
+        .with_body(r#"[{"path":"/a.txt","name":"a.txt","size_bytes":5}]"#)
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "test-key");
+    let results = client.grep("hello", "/", 0).await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name, "a.txt");
+}
+
+#[test]
+fn test_default_client_loads_config() {
+    // This test just ensures default_client compiles and runs without panic when no config exists.
+    let client = Client::default_client();
+    // Just ensure it doesn't panic; values depend on whether ~/.drive9/config exists.
+    assert!(!client.base_url().is_empty());
+}

--- a/clients/drive9-rs/tests/test_client.rs
+++ b/clients/drive9-rs/tests/test_client.rs
@@ -109,8 +109,18 @@ async fn test_grep() {
 
 #[test]
 fn test_default_client_loads_config() {
-    // This test just ensures default_client compiles and runs without panic when no config exists.
+    let original = std::env::var("HOME").ok();
+    let temp_home = std::env::temp_dir().join(format!("drive9-test-{}", std::process::id()));
+    std::fs::create_dir_all(&temp_home).unwrap();
+    std::env::set_var("HOME", &temp_home);
+
     let client = Client::default_client();
-    // Just ensure it doesn't panic; values depend on whether ~/.drive9/config exists.
-    assert!(!client.base_url().is_empty());
+    assert_eq!(client.base_url(), "https://api.drive9.ai");
+    assert!(client.api_key().is_none());
+
+    match original {
+        Some(v) => std::env::set_var("HOME", v),
+        None => std::env::remove_var("HOME"),
+    }
+    let _ = std::fs::remove_dir_all(&temp_home);
 }

--- a/clients/drive9-rs/tests/test_client.rs
+++ b/clients/drive9-rs/tests/test_client.rs
@@ -68,7 +68,31 @@ async fn test_conflict_error() {
     let client = Client::new(server.url(), "test-key");
     let err = client.write("/conflict.txt", b"x").await.unwrap_err();
     match err {
-        Drive9Error::Conflict { status_code, .. } => assert_eq!(status_code, 409),
+        Drive9Error::Conflict { status_code, server_revision, .. } => {
+            assert_eq!(status_code, 409);
+            assert_eq!(server_revision, None);
+        }
+        _ => panic!("expected Conflict error, got {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_conflict_error_with_server_revision() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("PUT", "/v1/fs/conflict2.txt")
+        .with_status(409)
+        .with_body(r#"{"error":"revision mismatch","server_revision":42}"#)
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "test-key");
+    let err = client.write("/conflict2.txt", b"x").await.unwrap_err();
+    match err {
+        Drive9Error::Conflict { status_code, server_revision, .. } => {
+            assert_eq!(status_code, 409);
+            assert_eq!(server_revision, Some(42));
+        }
         _ => panic!("expected Conflict error, got {:?}", err),
     }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -267,6 +267,63 @@ c.Write("/output.json", result)</code>
                         <span class="replaces-item">HTTP boilerplate</span>
                     </div>
                 </div>
+
+                <!-- Feature 6: Python SDK -->
+                <div class="feature-card">
+                    <div class="feature-icon">🐍</div>
+                    <h3>Python SDK</h3>
+                    <p>Build AI pipelines with the Python SDK. Streaming uploads, vault secrets, and semantic search out of the box.</p>
+                    <div class="code-block">
+                        <code>from drive9 import Client<br>
+<br>
+c = Client("http://localhost:9009", api_key="")<br>
+c.write("/data/hello.txt", b"Hello, drive9!")<br>
+data = c.read("/data/hello.txt")</code>
+                    </div>
+                    <div class="replaces">
+                        <span class="replaces-label">replaces</span>
+                        <span class="replaces-item">boto3</span>
+                        <span class="replaces-item">requests boilerplate</span>
+                    </div>
+                </div>
+
+                <!-- Feature 7: TypeScript SDK -->
+                <div class="feature-card">
+                    <div class="feature-icon">📘</div>
+                    <h3>TypeScript SDK</h3>
+                    <p>Integrate drive9 into Node.js and browser apps with full type safety. CJS and ESM builds included.</p>
+                    <div class="code-block">
+                        <code>import { Client } from "drive9";<br>
+<br>
+const c = new Client("http://localhost:9009", "");<br>
+await c.write("/data/hello.txt", new TextEncoder().encode("Hello"));<br>
+const data = await c.read("/data/hello.txt");</code>
+                    </div>
+                    <div class="replaces">
+                        <span class="replaces-label">replaces</span>
+                        <span class="replaces-item">S3 SDKs</span>
+                        <span class="replaces-item">HTTP boilerplate</span>
+                    </div>
+                </div>
+
+                <!-- Feature 8: Rust SDK -->
+                <div class="feature-card">
+                    <div class="feature-icon">🦀</div>
+                    <h3>Rust SDK</h3>
+                    <p>High-performance async Rust SDK with Tokio. Zero-allocation reads and native multipart resume.</p>
+                    <div class="code-block">
+                        <code>use drive9::Client;<br>
+<br>
+let c = Client::new("http://localhost:9009", "test-key");<br>
+c.write("/data/hello.txt", b"Hello, drive9!").await?;<br>
+let data = c.read("/data/hello.txt").await?;</code>
+                    </div>
+                    <div class="replaces">
+                        <span class="replaces-label">replaces</span>
+                        <span class="replaces-item">rusoto</span>
+                        <span class="replaces-item">HTTP boilerplate</span>
+                    </div>
+                </div>
             </div>
         </div>
     </section>
@@ -360,11 +417,18 @@ c.Write("/output.json", result)</code>
     <!-- SDK Section -->
     <section class="sdk-section" id="sdk">
         <div class="container">
-            <h2 class="section-title">Go SDK</h2>
-            <p class="section-subtitle">Build agent tools with streaming, resume, and context support.</p>
+            <h2 class="section-title">Multi-language SDKs</h2>
+            <p class="section-subtitle">Build agent tools with streaming, resume, and context support in your language of choice.</p>
 
             <div class="sdk-code">
-                <div class="code-window">
+                <div class="sdk-tabs">
+                    <button class="sdk-tab active" data-tab="go">Go</button>
+                    <button class="sdk-tab" data-tab="python">Python</button>
+                    <button class="sdk-tab" data-tab="ts">TypeScript</button>
+                    <button class="sdk-tab" data-tab="rust">Rust</button>
+                </div>
+
+                <div class="code-window sdk-panel active" data-panel="go">
                     <div class="code-window-header">
                         <div class="code-window-dots">
                             <span></span>
@@ -379,29 +443,29 @@ c.Write("/output.json", result)</code>
     <span class="code-string">"context"</span>
     <span class="code-string">"fmt"</span>
     <span class="code-string">"log"</span>
-    
+
     <span class="code-string">"github.com/mem9-ai/drive9/pkg/client"</span>
 )
 
 <span class="code-keyword">func</span> <span class="code-function">main</span>() {
     ctx := context.Background()
-    
+
     <span class="code-comment">// Create client</span>
     c := client.New(<span class="code-string">"http://localhost:9009"</span>, <span class="code-string">""</span>)
-    
+
     <span class="code-comment">// Write file</span>
     err := c.Write(ctx, <span class="code-string">"/data/hello.txt"</span>, []byte(<span class="code-string">"Hello, drive9!"</span>))
     <span class="code-keyword">if</span> err != <span class="code-keyword">nil</span> {
         log.Fatal(err)
     }
-    
+
     <span class="code-comment">// Read file</span>
     data, err := c.Read(ctx, <span class="code-string">"/data/hello.txt"</span>)
     <span class="code-keyword">if</span> err != <span class="code-keyword">nil</span> {
         log.Fatal(err)
     }
     fmt.Println(<span class="code-keyword">string</span>(data))
-    
+
     <span class="code-comment">// List directory</span>
     entries, err := c.List(ctx, <span class="code-string">"/data/"</span>)
     <span class="code-keyword">if</span> err != <span class="code-keyword">nil</span> {
@@ -410,12 +474,125 @@ c.Write("/output.json", result)</code>
     <span class="code-keyword">for</span> _, e := <span class="code-keyword">range</span> entries {
         fmt.Println(e.Name, e.Size, e.ModTime)
     }
-    
+
     <span class="code-comment">// Zero-copy link</span>
     err = c.Copy(ctx, <span class="code-string">"/data/hello.txt"</span>, <span class="code-string">"/backup/hello.txt"</span>)
     <span class="code-keyword">if</span> err != <span class="code-keyword">nil</span> {
         log.Fatal(err)
     }
+}</code></pre>
+                </div>
+
+                <div class="code-window sdk-panel" data-panel="python">
+                    <div class="code-window-header">
+                        <div class="code-window-dots">
+                            <span></span>
+                            <span></span>
+                            <span></span>
+                        </div>
+                        <span class="code-window-title">main.py</span>
+                    </div>
+                    <pre class="code-window-content"><code><span class="code-keyword">from</span> drive9 <span class="code-keyword">import</span> Client
+
+<span class="code-comment"># Create client</span>
+c = Client(<span class="code-string">"http://localhost:9009"</span>, api_key=<span class="code-string">""</span>)
+
+<span class="code-comment"># Write file</span>
+c.write(<span class="code-string">"/data/hello.txt"</span>, <span class="code-string">b"Hello, drive9!"</span>)
+
+<span class="code-comment"># Read file</span>
+data = c.read(<span class="code-string">"/data/hello.txt"</span>)
+<span class="code-keyword">print</span>(data.decode(<span class="code-string">"utf-8"</span>))
+
+<span class="code-comment"># List directory</span>
+entries = c.list(<span class="code-string">"/data/"</span>)
+<span class="code-keyword">for</span> e <span class="code-keyword">in</span> entries:
+    <span class="code-keyword">print</span>(e.name, e.size, e.mtime)
+
+<span class="code-comment"># Zero-copy link</span>
+c.copy(<span class="code-string">"/data/hello.txt"</span>, <span class="code-string">"/backup/hello.txt"</span>)
+
+<span class="code-comment"># Stream upload</span>
+<span class="code-keyword">with</span> <span class="code-keyword">open</span>(<span class="code-string">"large.bin"</span>, <span class="code-string">"rb"</span>) <span class="code-keyword">as</span> f:
+    c.write_stream(<span class="code-string">"/data/large.bin"</span>, f, size=<span class="code-number">1024</span>*<span class="code-number">1024</span>)</code></pre>
+                </div>
+
+                <div class="code-window sdk-panel" data-panel="ts">
+                    <div class="code-window-header">
+                        <div class="code-window-dots">
+                            <span></span>
+                            <span></span>
+                            <span></span>
+                        </div>
+                        <span class="code-window-title">main.ts</span>
+                    </div>
+                    <pre class="code-window-content"><code><span class="code-keyword">import</span> { Client } <span class="code-keyword">from</span> <span class="code-string">"drive9"</span>;
+
+<span class="code-keyword">async function</span> <span class="code-function">main</span>() {
+    <span class="code-comment">// Create client</span>
+    <span class="code-keyword">const</span> c = <span class="code-keyword">new</span> Client(<span class="code-string">"http://localhost:9009"</span>, <span class="code-string">""</span>);
+
+    <span class="code-comment">// Write file</span>
+    <span class="code-keyword">await</span> c.write(<span class="code-string">"/data/hello.txt"</span>, <span class="code-keyword">new</span> TextEncoder().encode(<span class="code-string">"Hello, drive9!"</span>));
+
+    <span class="code-comment">// Read file</span>
+    <span class="code-keyword">const</span> data = <span class="code-keyword">await</span> c.read(<span class="code-string">"/data/hello.txt"</span>);
+    console.log(<span class="code-keyword">new</span> TextDecoder().decode(data));
+
+    <span class="code-comment">// List directory</span>
+    <span class="code-keyword">const</span> entries = <span class="code-keyword">await</span> c.list(<span class="code-string">"/data/"</span>);
+    <span class="code-keyword">for</span> (<span class="code-keyword">const</span> e <span class="code-keyword">of</span> entries) {
+        console.log(e.name, e.size, e.mtime);
+    }
+
+    <span class="code-comment">// Zero-copy link</span>
+    <span class="code-keyword">await</span> c.copy(<span class="code-string">"/data/hello.txt"</span>, <span class="code-string">"/backup/hello.txt"</span>);
+
+    <span class="code-comment">// Stream upload</span>
+    <span class="code-keyword">const</span> stream = await Deno.open(<span class="code-string">"large.bin"</span>);
+    <span class="code-keyword">await</span> c.writeStream(<span class="code-string">"/data/large.bin"</span>, stream.readable, size);
+}
+
+main();</code></pre>
+                </div>
+
+                <div class="code-window sdk-panel" data-panel="rust">
+                    <div class="code-window-header">
+                        <div class="code-window-dots">
+                            <span></span>
+                            <span></span>
+                            <span></span>
+                        </div>
+                        <span class="code-window-title">main.rs</span>
+                    </div>
+                    <pre class="code-window-content"><code><span class="code-keyword">use</span> drive9::Client;
+
+#[tokio::main]
+<span class="code-keyword">async fn</span> <span class="code-function">main</span>() -> Result&lt;(), drive9::Drive9Error&gt; {
+    <span class="code-comment">// Create client</span>
+    <span class="code-keyword">let</span> c = Client::new(<span class="code-string">"http://localhost:9009"</span>, <span class="code-string">""</span>);
+
+    <span class="code-comment">// Write file</span>
+    c.write(<span class="code-string">"/data/hello.txt"</span>, <span class="code-string">b"Hello, drive9!"</span>).<span class="code-keyword">await</span>?;
+
+    <span class="code-comment">// Read file</span>
+    <span class="code-keyword">let</span> data = c.read(<span class="code-string">"/data/hello.txt"</span>).<span class="code-keyword">await</span>?;
+    println!(<span class="code-string">"{}"</span>, String::from_utf8_lossy(&data));
+
+    <span class="code-comment">// List directory</span>
+    <span class="code-keyword">let</span> entries = c.list(<span class="code-string">"/data/"</span>).<span class="code-keyword">await</span>?;
+    <span class="code-keyword">for</span> e <span class="code-keyword">in</span> entries {
+        println!(<span class="code-string">"{} {} {:?}"</span>, e.name, e.size, e.mtime);
+    }
+
+    <span class="code-comment">// Zero-copy link</span>
+    c.copy(<span class="code-string">"/data/hello.txt"</span>, <span class="code-string">"/backup/hello.txt"</span>).<span class="code-keyword">await</span>?;
+
+    <span class="code-comment">// Stream upload</span>
+    <span class="code-keyword">let</span> file = tokio::fs::File::open(<span class="code-string">"large.bin"</span>).<span class="code-keyword">await</span>?;
+    c.write_stream(<span class="code-string">"/data/large.bin"</span>, file, size).<span class="code-keyword">await</span>?;
+
+    Ok(())
 }</code></pre>
                 </div>
             </div>
@@ -517,6 +694,17 @@ c.Write("/output.json", result)</code>
                 const y = e.clientY - rect.top;
                 card.style.setProperty('--mouse-x', `${x}px`);
                 card.style.setProperty('--mouse-y', `${y}px`);
+            });
+        });
+
+        // SDK tabs
+        document.querySelectorAll('.sdk-tab').forEach(tab => {
+            tab.addEventListener('click', () => {
+                const target = tab.dataset.tab;
+                document.querySelectorAll('.sdk-tab').forEach(t => t.classList.remove('active'));
+                document.querySelectorAll('.sdk-panel').forEach(p => p.classList.remove('active'));
+                tab.classList.add('active');
+                document.querySelector(`.sdk-panel[data-panel="${target}"]`).classList.add('active');
             });
         });
     </script>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1053,3 +1053,45 @@ body {
 .hero > .container > *:nth-child(4) { animation-delay: 0.4s; }
 .hero > .container > *:nth-child(5) { animation-delay: 0.5s; }
 .hero > .container > *:nth-child(6) { animation-delay: 0.6s; }
+
+/* SDK Tabs */
+.sdk-tabs {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.sdk-tab {
+    padding: 8px 16px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-primary);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.sdk-tab:hover {
+    border-color: var(--accent-gray);
+    color: var(--text-primary);
+}
+
+.sdk-tab.active {
+    background: var(--text-primary);
+    color: var(--bg-primary);
+    border-color: var(--text-primary);
+}
+
+.sdk-panel {
+    display: none;
+}
+
+.sdk-panel.active {
+    display: block;
+}
+
+.code-number { color: #ff9f43; }


### PR DESCRIPTION
This PR introduces three new language SDKs for drive9, all reaching full feature parity with the existing Go client (`pkg/client`).

### New packages
- `clients/drive9-py` — Python SDK
- `clients/drive9-rs` — Rust SDK
- `clients/drive9-js` — TypeScript / Node.js SDK

### Supported features (matching Go client)
- Basic filesystem ops: `write`, `read`, `list`, `stat`, `delete`, `copy`, `rename`, `mkdir`
- Query ops: `sql`, `grep`, `find`
- Multipart upload v1 / v2, resume, and stream writer
- Partial file update: `patchFile`
- Vault management: secrets, tokens, audit log

### Enhancements over Go `pkg/client`
All three new SDKs support **environment-variable overrides** (`DRIVE9_SERVER`, `DRIVE9_API_KEY`) in addition to `~/.drive9/config` auto-loading.

### Notable implementation details
- **Rust**: uses `reqwest` with a custom `User-Agent` (`drive9-rs/x.y.z`) to avoid WAF blocks triggered by the default `reqwest` UA.
- **TypeScript**: built on native `fetch` and Web Streams (`ReadableStream`), making it isomorphic for Node 18+, browsers, and edge runtimes.
- **Python**: 38 unit tests, lint-clean, plus e2e test suite.

### Verification
- `drive9-py`: `pytest` passes
- `drive9-rs`: `cargo test` passes
- `drive9-js`: `npm run build` and `npm test` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Drive9 SDKs for JavaScript/TypeScript, Python, and Rust with filesystem, search, streaming, multipart/resumable uploads, ranged reads, server-directed patching, and Vault secret/token management.

* **Documentation**
  * Added package READMEs, runnable examples (basic, stream, vault) and site UI showing multi-language SDK tabs and code panels.

* **Tests**
  * Added extensive test suites covering client, transfer/streaming, patch, and vault flows.

* **Chores**
  * Added package manifests, TypeScript/Python/Rust build configs, and .gitignore files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->