### PR TITLE
feat: per-tenant media LLM file count budget (P0)

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -43,6 +43,7 @@ type Dat9Backend struct {
 	databaseAutoEmbedding bool
 	maxUploadBytes        int64
 	maxTenantStorageBytes int64
+	maxMediaLLMFiles      int64
 	mu                    sync.Mutex
 	entropy               io.Reader
 

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -96,6 +96,10 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 			return
 		}
 	}
+	if b.mediaLLMQuotaExceeded() {
+		metrics.RecordOperation("media_llm_budget", "enqueue_skip", "quota_exceeded", 0)
+		return
+	}
 	task := ImageExtractTaskSpec{
 		FileID:      fileID,
 		Path:        path,

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -22,6 +22,7 @@ const (
 	defaultMaxAudioExtractedTextBytes = 8 << 10          // 8 KiB
 	defaultMaxUploadBytes        = int64(10 * (1 << 30)) // 10 GiB
 	defaultMaxTenantStorageBytes = int64(50 * (1 << 30)) // 50 GiB
+	defaultMaxMediaLLMFiles      = int64(500)            // 500 media files per tenant
 )
 
 // Options configures Dat9Backend behavior.
@@ -40,6 +41,11 @@ type Options struct {
 	// database itself rather than by the app-managed embed worker. When enabled,
 	// runtime write/query paths rely on database-side embedding behavior.
 	DatabaseAutoEmbedding bool
+	// MaxMediaLLMFiles caps the number of confirmed image+audio files per tenant
+	// that trigger LLM extraction tasks (img_extract_text, audio_extract_text).
+	// Files beyond this limit are still stored but their LLM tasks are not enqueued.
+	// Zero or negative means use the default (500).
+	MaxMediaLLMFiles int64
 }
 
 // AsyncImageExtractOptions controls async image->text extraction.
@@ -89,6 +95,11 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		b.maxUploadBytes = opts.MaxUploadBytes
 	} else {
 		b.maxUploadBytes = defaultMaxUploadBytes
+	}
+	if opts.MaxMediaLLMFiles > 0 {
+		b.maxMediaLLMFiles = opts.MaxMediaLLMFiles
+	} else {
+		b.maxMediaLLMFiles = defaultMaxMediaLLMFiles
 	}
 	if opts.MaxTenantStorageBytes > 0 {
 		b.maxTenantStorageBytes = opts.MaxTenantStorageBytes

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -5,9 +5,10 @@ import (
 	"errors"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"
-	"go.uber.org/zap"
 )
 
 var (

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -4,6 +4,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
+	"go.uber.org/zap"
 )
 
 var (
@@ -32,7 +36,9 @@ func (b *Dat9Backend) mediaLLMQuotaExceededTx(tx *sql.Tx) bool {
 	}
 	count, err := b.store.ConfirmedMediaFileCountTx(tx)
 	if err != nil {
-		return false // on error, allow enqueue (fail open)
+		logger.Warn(backgroundWithTrace(), "media_llm_quota_check_fail_open", zap.Error(err))
+		metrics.RecordOperation("media_llm_budget", "quota_check", "fail_open", 0)
+		return false
 	}
 	return count >= b.maxMediaLLMFiles
 }
@@ -46,6 +52,8 @@ func (b *Dat9Backend) mediaLLMQuotaExceeded() bool {
 	}
 	count, err := b.store.ConfirmedMediaFileCountTx(b.store.DB())
 	if err != nil {
+		logger.Warn(backgroundWithTrace(), "media_llm_quota_check_fail_open", zap.Error(err))
+		metrics.RecordOperation("media_llm_budget", "quota_check", "fail_open", 0)
 		return false
 	}
 	return count >= b.maxMediaLLMFiles

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	ErrUploadTooLarge       = errors.New("upload too large")
-	ErrStorageQuotaExceeded = errors.New("tenant storage quota exceeded")
+	ErrUploadTooLarge        = errors.New("upload too large")
+	ErrStorageQuotaExceeded  = errors.New("tenant storage quota exceeded")
+	ErrMediaLLMQuotaExceeded = errors.New("tenant media LLM file quota exceeded")
 )
 
 func (b *Dat9Backend) ensureUploadSizeAllowed(size int64) error {
@@ -19,6 +20,35 @@ func (b *Dat9Backend) ensureUploadSizeAllowed(size int64) error {
 		return fmt.Errorf("%w: max %d bytes", ErrUploadTooLarge, b.maxUploadBytes)
 	}
 	return nil
+}
+
+// mediaLLMQuotaExceededTx checks whether the tenant has exceeded its media LLM
+// file quota inside a transaction. Returns true when the count of confirmed
+// image+audio files meets or exceeds the configured limit. Files are still
+// stored; only LLM task enqueue is skipped.
+func (b *Dat9Backend) mediaLLMQuotaExceededTx(tx *sql.Tx) bool {
+	if b.maxMediaLLMFiles <= 0 {
+		return false
+	}
+	count, err := b.store.ConfirmedMediaFileCountTx(tx)
+	if err != nil {
+		return false // on error, allow enqueue (fail open)
+	}
+	return count >= b.maxMediaLLMFiles
+}
+
+// mediaLLMQuotaExceeded is the non-transactional variant for code paths that
+// enqueue LLM tasks outside a database transaction (e.g. the legacy in-memory
+// image extract queue).
+func (b *Dat9Backend) mediaLLMQuotaExceeded() bool {
+	if b.maxMediaLLMFiles <= 0 {
+		return false
+	}
+	count, err := b.store.ConfirmedMediaFileCountTx(b.store.DB())
+	if err != nil {
+		return false
+	}
+	return count >= b.maxMediaLLMFiles
 }
 
 func (b *Dat9Backend) ensureTenantStorageQuotaTx(tx *sql.Tx, path string, newSize int64) error {

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -28,8 +28,10 @@ func (b *Dat9Backend) ensureUploadSizeAllowed(size int64) error {
 
 // mediaLLMQuotaExceededTx checks whether the tenant has exceeded its media LLM
 // file quota inside a transaction. Returns true when the count of confirmed
-// image+audio files meets or exceeds the configured limit. Files are still
-// stored; only LLM task enqueue is skipped.
+// image+audio files strictly exceeds the configured limit. Using ">" (not ">=")
+// is deliberate: the current file may already be counted (new inserts are
+// CONFIRMED before enqueue in the same Tx), so ">" ensures the Nth file is
+// still allowed and overwrites of existing media files are never blocked.
 func (b *Dat9Backend) mediaLLMQuotaExceededTx(tx *sql.Tx) bool {
 	if b.maxMediaLLMFiles <= 0 {
 		return false
@@ -40,7 +42,7 @@ func (b *Dat9Backend) mediaLLMQuotaExceededTx(tx *sql.Tx) bool {
 		metrics.RecordOperation("media_llm_budget", "quota_check", "fail_open", 0)
 		return false
 	}
-	return count >= b.maxMediaLLMFiles
+	return count > b.maxMediaLLMFiles
 }
 
 // mediaLLMQuotaExceeded is the non-transactional variant for code paths that
@@ -56,7 +58,7 @@ func (b *Dat9Backend) mediaLLMQuotaExceeded() bool {
 		metrics.RecordOperation("media_llm_budget", "quota_check", "fail_open", 0)
 		return false
 	}
-	return count >= b.maxMediaLLMFiles
+	return count > b.maxMediaLLMFiles
 }
 
 func (b *Dat9Backend) ensureTenantStorageQuotaTx(tx *sql.Tx, path string, newSize int64) error {

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/semantic"
 )
 
@@ -37,7 +38,13 @@ func (b *Dat9Backend) enqueueAudioExtractTaskTx(tx *sql.Tx, fileID string, revis
 
 // enqueueTiDBAutoSemanticTasksTx registers durable img_extract_text and/or
 // audio_extract_text tasks for one confirmed file revision in TiDB auto-embedding mode.
+// When the tenant's media LLM file quota is exceeded, no extraction tasks are
+// enqueued but the file write itself succeeds normally.
 func (b *Dat9Backend) enqueueTiDBAutoSemanticTasksTx(tx *sql.Tx, fileID string, revision int64, path, contentType string) error {
+	if b.mediaLLMQuotaExceededTx(tx) {
+		metrics.RecordOperation("media_llm_budget", "enqueue_skip", "quota_exceeded", 0)
+		return nil
+	}
 	if b.hasAsyncImageTextSource(path, contentType) {
 		if err := b.enqueueImgExtractTaskTx(tx, fileID, revision, path, contentType); err != nil {
 			return err

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -41,16 +41,21 @@ func (b *Dat9Backend) enqueueAudioExtractTaskTx(tx *sql.Tx, fileID string, revis
 // When the tenant's media LLM file quota is exceeded, no extraction tasks are
 // enqueued but the file write itself succeeds normally.
 func (b *Dat9Backend) enqueueTiDBAutoSemanticTasksTx(tx *sql.Tx, fileID string, revision int64, path, contentType string) error {
+	isImage := b.hasAsyncImageTextSource(path, contentType)
+	isAudio := b.shouldEnqueueAudioExtractTask(path, contentType)
+	if !isImage && !isAudio {
+		return nil
+	}
 	if b.mediaLLMQuotaExceededTx(tx) {
 		metrics.RecordOperation("media_llm_budget", "enqueue_skip", "quota_exceeded", 0)
 		return nil
 	}
-	if b.hasAsyncImageTextSource(path, contentType) {
+	if isImage {
 		if err := b.enqueueImgExtractTaskTx(tx, fileID, revision, path, contentType); err != nil {
 			return err
 		}
 	}
-	if b.shouldEnqueueAudioExtractTask(path, contentType) {
+	if isAudio {
 		if err := b.enqueueAudioExtractTaskTx(tx, fileID, revision, path, contentType); err != nil {
 			return err
 		}

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -568,6 +568,19 @@ func (s *Store) ConfirmedStorageBytesTx(db execer) (int64, error) {
 	return total.Int64, nil
 }
 
+// ConfirmedMediaFileCountTx returns the number of confirmed files whose
+// content_type starts with "image/" or "audio/". This count drives the
+// per-tenant media LLM budget gate: files that exceed the quota are still
+// stored but their LLM extraction tasks (img_extract_text, audio_extract_text)
+// are not enqueued.
+func (s *Store) ConfirmedMediaFileCountTx(db execer) (int64, error) {
+	var count sql.NullInt64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM files WHERE status = 'CONFIRMED' AND (content_type LIKE 'image/%' OR content_type LIKE 'audio/%')`).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count.Int64, nil
+}
+
 // ActiveUploadReservedBytesTx returns the additional bytes reserved by active
 // multipart uploads beyond what is already counted by the confirmed file set.
 func (s *Store) ActiveUploadReservedBytesTx(db execer) (int64, error) {


### PR DESCRIPTION
## Summary

- Gate image extract and audio extract LLM task enqueue behind a per-tenant media file count limit
- When confirmed `image/*` + `audio/*` files exceed `MaxMediaLLMFiles` (default 500), new extraction tasks are silently skipped
- Files are still stored normally — only LLM task enqueue is blocked
- Follows the existing `ConfirmedStorageBytesTx` / `ensureTenantStorageQuotaTx` pattern

## Changes

| File | Change |
|------|--------|
| `pkg/datastore/store.go` | Add `ConfirmedMediaFileCountTx` — counts confirmed image+audio files |
| `pkg/backend/quota.go` | Add `ErrMediaLLMQuotaExceeded`, `mediaLLMQuotaExceededTx` (Tx path), `mediaLLMQuotaExceeded` (non-Tx path) |
| `pkg/backend/options.go` | Add `MaxMediaLLMFiles` option with default 500 |
| `pkg/backend/dat9.go` | Add `maxMediaLLMFiles` field to `Dat9Backend` struct |
| `pkg/backend/semantic_tasks.go` | Gate `enqueueTiDBAutoSemanticTasksTx` — TiDB auto path |
| `pkg/backend/image_extract.go` | Gate `enqueueImageExtract` — legacy in-memory queue path |

## Design decisions

- **Fail open**: if the count query errors, allow enqueue rather than block
- **Two check variants**: Tx version for `enqueueTiDBAutoSemanticTasksTx` (runs inside write Tx), non-Tx version for `enqueueImageExtract` (legacy path, no Tx context)
- **Metrics**: `media_llm_budget/enqueue_skip/quota_exceeded` recorded at both gate points
- **Default 500**: conservative limit; configurable via `Options.MaxMediaLLMFiles`

## Context

This is P0 of the tenant LLM budget control. P1 (token-based budget with usage tracking) will follow separately.

In the current TiDB auto-embedding production path, the only app-side LLM costs are:
1. Image extract (Vision API)
2. Audio extract (Whisper API)

Embedding and query embedding are handled by TiDB database-side and don't incur app-side LLM costs.

## Test plan

- [ ] CI passes (build + existing tests)
- [ ] Verify `ConfirmedMediaFileCountTx` returns correct count
- [ ] Verify enqueue is skipped when count >= limit
- [ ] Verify files still store normally when quota exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-tenant media LLM file quotas to limit how many confirmed image/audio files will be considered for LLM extraction.
  * New configuration option to set the maximum number of media files eligible for extraction.

* **Chores**
  * Extraction task enqueueing now respects the media LLM quota and will skip enqueueing when the quota is exceeded, recording quota metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->