### PR TITLE
feat: monthly LLM cost budget for image/audio extract (P1)

### DIFF
--- a/cmd/drive9-server-local/local_audio_extractor.go
+++ b/cmd/drive9-server-local/local_audio_extractor.go
@@ -23,6 +23,7 @@ const (
 	envAudioExtractAPIKey         = "DRIVE9_AUDIO_EXTRACT_API_KEY"
 	envAudioExtractModel          = "DRIVE9_AUDIO_EXTRACT_MODEL"
 	envAudioExtractPrompt         = "DRIVE9_AUDIO_EXTRACT_PROMPT"
+	envAudioExtractResponseFormat = "DRIVE9_AUDIO_EXTRACT_RESPONSE_FORMAT"
 	localAudioExtractStubMode     = "stub"
 	localAudioExtractOpenAIMode   = "openai"
 )
@@ -71,11 +72,12 @@ func buildLocalAudioExtractOptionsFromEnv() (backend.AsyncAudioExtractOptions, e
 		}, nil
 	case localAudioExtractOpenAIMode:
 		extractor, err := backend.NewOpenAIAudioTextExtractor(backend.OpenAIAudioTextExtractorConfig{
-			BaseURL: strings.TrimSpace(os.Getenv(envAudioExtractAPIBase)),
-			APIKey:  strings.TrimSpace(os.Getenv(envAudioExtractAPIKey)),
-			Model:   strings.TrimSpace(os.Getenv(envAudioExtractModel)),
-			Prompt:  strings.TrimSpace(os.Getenv(envAudioExtractPrompt)),
-			Timeout: time.Duration(envInt(envAudioExtractTimeoutSeconds, 0)) * time.Second,
+			BaseURL:        strings.TrimSpace(os.Getenv(envAudioExtractAPIBase)),
+			APIKey:         strings.TrimSpace(os.Getenv(envAudioExtractAPIKey)),
+			Model:          strings.TrimSpace(os.Getenv(envAudioExtractModel)),
+			Prompt:         strings.TrimSpace(os.Getenv(envAudioExtractPrompt)),
+			ResponseFormat: strings.TrimSpace(os.Getenv(envAudioExtractResponseFormat)),
+			Timeout:        time.Duration(envInt(envAudioExtractTimeoutSeconds, 0)) * time.Second,
 		})
 		if err != nil {
 			return backend.AsyncAudioExtractOptions{}, fmt.Errorf("init local openai audio extractor: %w", err)

--- a/cmd/drive9-server-local/local_audio_extractor.go
+++ b/cmd/drive9-server-local/local_audio_extractor.go
@@ -34,16 +34,16 @@ const (
 type localStubAudioTextExtractor struct{}
 
 // ExtractAudioText implements [backend.AudioTextExtractor].
-func (localStubAudioTextExtractor) ExtractAudioText(ctx context.Context, req backend.AudioExtractRequest) (string, error) {
+func (localStubAudioTextExtractor) ExtractAudioText(ctx context.Context, req backend.AudioExtractRequest) (string, backend.AudioExtractUsage, error) {
 	if err := ctx.Err(); err != nil {
-		return "", err
+		return "", backend.AudioExtractUsage{}, err
 	}
 	p := strings.TrimSpace(req.Path)
 	base := path.Base(p)
 	if base == "." || base == "/" || base == "" {
 		base = "unknown"
 	}
-	return "audio transcript for " + base, nil
+	return "audio transcript for " + base, backend.AudioExtractUsage{}, nil
 }
 
 // buildLocalAudioExtractOptionsFromEnv returns [backend.AsyncAudioExtractOptions] for

--- a/cmd/drive9-server-local/main_test.go
+++ b/cmd/drive9-server-local/main_test.go
@@ -361,7 +361,7 @@ func TestBuildBackendOptionsFromEnvAudioOpenAI(t *testing.T) {
 
 func TestLocalStubAudioTextExtractorTranscript(t *testing.T) {
 	var ex localStubAudioTextExtractor
-	got, err := ex.ExtractAudioText(context.Background(), backend.AudioExtractRequest{Path: "/audio/clip.mp3"})
+	got, _, err := ex.ExtractAudioText(context.Background(), backend.AudioExtractRequest{Path: "/audio/clip.mp3"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -403,12 +403,14 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 			return backend.Options{}, fmt.Errorf("DRIVE9_AUDIO_EXTRACT_API_BASE, DRIVE9_AUDIO_EXTRACT_API_KEY and DRIVE9_AUDIO_EXTRACT_MODEL must be set together when DRIVE9_AUDIO_EXTRACT_ENABLED=true")
 		}
 		audioTimeout := time.Duration(envInt("DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS", 120)) * time.Second
+		audioResponseFormat := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_RESPONSE_FORMAT"))
 		audioExtractor, err := backend.NewOpenAIAudioTextExtractor(backend.OpenAIAudioTextExtractorConfig{
-			BaseURL: audioBaseURL,
-			APIKey:  audioAPIKey,
-			Model:   audioModel,
-			Prompt:  audioPrompt,
-			Timeout: audioTimeout,
+			BaseURL:        audioBaseURL,
+			APIKey:         audioAPIKey,
+			Model:          audioModel,
+			Prompt:         audioPrompt,
+			ResponseFormat: audioResponseFormat,
+			Timeout:        audioTimeout,
 		})
 		if err != nil {
 			return backend.Options{}, fmt.Errorf("init audio extractor: %w", err)

--- a/pkg/backend/audio_extract.go
+++ b/pkg/backend/audio_extract.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pingcap/failpoint"
 
 	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 )
 
 // AudioExtractRequest is the input to a pluggable audio->text extractor.
@@ -23,7 +24,7 @@ type AudioExtractRequest struct {
 
 // AudioTextExtractor extracts searchable transcript text from audio bytes.
 type AudioTextExtractor interface {
-	ExtractAudioText(ctx context.Context, req AudioExtractRequest) (string, error)
+	ExtractAudioText(ctx context.Context, req AudioExtractRequest) (string, AudioExtractUsage, error)
 }
 
 // AudioExtractTaskSpec carries the revision-scoped inputs needed to extract
@@ -51,6 +52,7 @@ const (
 	AudioExtractResultEmptyText            AudioExtractResult = "empty_text"
 	AudioExtractResultUpdateError          AudioExtractResult = "update_error"
 	AudioExtractResultWritten              AudioExtractResult = "written"
+	AudioExtractResultBudgetExhausted      AudioExtractResult = "budget_exhausted"
 )
 
 // SupportsAsyncAudioExtract reports whether this backend instance has a fully
@@ -235,6 +237,10 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 	if !b.SupportsAsyncAudioExtract() {
 		return AudioExtractResultRuntimeNotConfigured, fmt.Errorf("async audio extract runtime not configured")
 	}
+	if b.monthlyLLMCostExceeded() {
+		metrics.RecordOperation("llm_cost_budget", "process_skip", "budget_exhausted", 0)
+		return AudioExtractResultBudgetExhausted, nil
+	}
 
 	f, err := b.store.GetFile(ctx, task.FileID)
 	if err != nil {
@@ -267,7 +273,7 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 	}
 
 	taskCtx, cancel := context.WithTimeout(ctx, b.audioExtractTimeout)
-	text, err := b.audioExtractor.ExtractAudioText(taskCtx, AudioExtractRequest{
+	text, audioUsage, err := b.audioExtractor.ExtractAudioText(taskCtx, AudioExtractRequest{
 		FileID:      task.FileID,
 		Path:        task.Path,
 		ContentType: extractorContentType,
@@ -277,6 +283,7 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 	if err != nil {
 		return AudioExtractResultExtractError, fmt.Errorf("extract audio text: %w", err)
 	}
+	b.recordAudioExtractUsage(task.FileID, audioUsage)
 	text = sanitizeExtractedText(text, b.maxAudioExtractTextBytes)
 	if text == "" {
 		return AudioExtractResultEmptyText, nil

--- a/pkg/backend/audio_extract_openai.go
+++ b/pkg/backend/audio_extract_openai.go
@@ -56,7 +56,11 @@ func NewOpenAIAudioTextExtractor(cfg OpenAIAudioTextExtractorConfig) (*OpenAIAud
 	}
 	responseFormat := cfg.ResponseFormat
 	if responseFormat == "" {
-		responseFormat = "json"
+		if strings.HasPrefix(cfg.Model, "whisper") {
+			responseFormat = "verbose_json"
+		} else {
+			responseFormat = "json"
+		}
 	}
 	client := cfg.Client
 	if client == nil {

--- a/pkg/backend/audio_extract_openai.go
+++ b/pkg/backend/audio_extract_openai.go
@@ -17,22 +17,24 @@ import (
 // OpenAIAudioTextExtractorConfig configures an OpenAI-compatible audio
 // transcription endpoint.
 type OpenAIAudioTextExtractorConfig struct {
-	BaseURL string
-	APIKey  string
-	Model   string
-	Prompt  string
-	Timeout time.Duration
-	Client  *http.Client
+	BaseURL        string
+	APIKey         string
+	Model          string
+	Prompt         string
+	ResponseFormat string // "verbose_json" for whisper-1, "json" for gpt-4o-transcribe
+	Timeout        time.Duration
+	Client         *http.Client
 }
 
 // OpenAIAudioTextExtractor calls an OpenAI-compatible /v1/audio/transcriptions
 // API and returns plain transcript text.
 type OpenAIAudioTextExtractor struct {
-	endpoint string
-	apiKey   string
-	model    string
-	prompt   string
-	client   *http.Client
+	endpoint       string
+	apiKey         string
+	model          string
+	prompt         string
+	responseFormat string
+	client         *http.Client
 }
 
 // NewOpenAIAudioTextExtractor builds an audio extractor backed by an
@@ -52,6 +54,10 @@ func NewOpenAIAudioTextExtractor(cfg OpenAIAudioTextExtractorConfig) (*OpenAIAud
 	if strings.HasSuffix(base, "/v1") {
 		endpoint = base + "/audio/transcriptions"
 	}
+	responseFormat := cfg.ResponseFormat
+	if responseFormat == "" {
+		responseFormat = "json"
+	}
 	client := cfg.Client
 	if client == nil {
 		timeout := cfg.Timeout
@@ -61,79 +67,96 @@ func NewOpenAIAudioTextExtractor(cfg OpenAIAudioTextExtractorConfig) (*OpenAIAud
 		client = &http.Client{Timeout: timeout}
 	}
 	return &OpenAIAudioTextExtractor{
-		endpoint: endpoint,
-		apiKey:   cfg.APIKey,
-		model:    cfg.Model,
-		prompt:   cfg.Prompt,
-		client:   client,
+		endpoint:       endpoint,
+		apiKey:         cfg.APIKey,
+		model:          cfg.Model,
+		prompt:         cfg.Prompt,
+		responseFormat: responseFormat,
+		client:         client,
 	}, nil
 }
 
 // ExtractAudioText implements AudioTextExtractor.
-func (e *OpenAIAudioTextExtractor) ExtractAudioText(ctx context.Context, req AudioExtractRequest) (string, error) {
+func (e *OpenAIAudioTextExtractor) ExtractAudioText(ctx context.Context, req AudioExtractRequest) (string, AudioExtractUsage, error) {
 	select {
 	case <-ctx.Done():
-		return "", ctx.Err()
+		return "", AudioExtractUsage{}, ctx.Err()
 	default:
 	}
 
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	if err := writer.WriteField("model", e.model); err != nil {
-		return "", fmt.Errorf("write audio transcription model field for %q: %w", req.Path, err)
+		return "", AudioExtractUsage{}, fmt.Errorf("write audio transcription model field for %q: %w", req.Path, err)
+	}
+	if err := writer.WriteField("response_format", e.responseFormat); err != nil {
+		return "", AudioExtractUsage{}, fmt.Errorf("write audio transcription response_format field for %q: %w", req.Path, err)
 	}
 	if strings.TrimSpace(e.prompt) != "" {
 		if err := writer.WriteField("prompt", e.prompt); err != nil {
-			return "", fmt.Errorf("write audio transcription prompt field for %q: %w", req.Path, err)
+			return "", AudioExtractUsage{}, fmt.Errorf("write audio transcription prompt field for %q: %w", req.Path, err)
 		}
 	}
 	if err := writeAudioMultipartFile(writer, req); err != nil {
-		return "", fmt.Errorf("write audio transcription file part for %q: %w", req.Path, err)
+		return "", AudioExtractUsage{}, fmt.Errorf("write audio transcription file part for %q: %w", req.Path, err)
 	}
 	if err := writer.Close(); err != nil {
-		return "", fmt.Errorf("finalize audio transcription multipart body for %q: %w", req.Path, err)
+		return "", AudioExtractUsage{}, fmt.Errorf("finalize audio transcription multipart body for %q: %w", req.Path, err)
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint, bytes.NewReader(body.Bytes()))
 	if err != nil {
-		return "", fmt.Errorf("create audio transcription request for %q: %w", req.Path, err)
+		return "", AudioExtractUsage{}, fmt.Errorf("create audio transcription request for %q: %w", req.Path, err)
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+e.apiKey)
 	httpReq.Header.Set("Content-Type", writer.FormDataContentType())
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		return "", fmt.Errorf("send audio transcription request for %q: %w", req.Path, err)
+		return "", AudioExtractUsage{}, fmt.Errorf("send audio transcription request for %q: %w", req.Path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return "", fmt.Errorf("read audio transcription response for %q: %w", req.Path, err)
+		return "", AudioExtractUsage{}, fmt.Errorf("read audio transcription response for %q: %w", req.Path, err)
 	}
 	var parsed struct {
-		Text  string `json:"text"`
+		Text     string  `json:"text"`
+		Duration float64 `json:"duration"` // whisper-1 verbose_json
+		Usage    *struct {
+			InputTokens  int `json:"input_tokens"`  // gpt-4o-transcribe
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
 		Error *struct {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		if resp.StatusCode >= 300 {
-			return "", fmt.Errorf("audio transcription api status %d: %s", resp.StatusCode, truncateString(string(raw), 256))
+			return "", AudioExtractUsage{}, fmt.Errorf("audio transcription api status %d: %s", resp.StatusCode, truncateString(string(raw), 256))
 		}
-		return "", fmt.Errorf("decode audio transcription response: %w", err)
+		return "", AudioExtractUsage{}, fmt.Errorf("decode audio transcription response: %w", err)
 	}
 	if resp.StatusCode >= 300 {
 		if parsed.Error != nil && parsed.Error.Message != "" {
-			return "", fmt.Errorf("audio transcription api status %d: %s", resp.StatusCode, parsed.Error.Message)
+			return "", AudioExtractUsage{}, fmt.Errorf("audio transcription api status %d: %s", resp.StatusCode, parsed.Error.Message)
 		}
-		return "", fmt.Errorf("audio transcription api status %d", resp.StatusCode)
+		return "", AudioExtractUsage{}, fmt.Errorf("audio transcription api status %d", resp.StatusCode)
 	}
 	text := strings.TrimSpace(parsed.Text)
 	if text == "" {
-		return "", fmt.Errorf("audio transcription api returned empty text")
+		return "", AudioExtractUsage{}, fmt.Errorf("audio transcription api returned empty text")
 	}
-	return text, nil
+	var usage AudioExtractUsage
+	if parsed.Usage != nil {
+		usage.InputTokens = parsed.Usage.InputTokens
+		usage.OutputTokens = parsed.Usage.OutputTokens
+	}
+	if parsed.Duration > 0 {
+		usage.DurationSeconds = parsed.Duration
+	}
+	return text, usage, nil
 }
 
 func writeAudioMultipartFile(writer *multipart.Writer, req AudioExtractRequest) error {

--- a/pkg/backend/audio_extract_openai_test.go
+++ b/pkg/backend/audio_extract_openai_test.go
@@ -97,7 +97,7 @@ func TestOpenAIAudioTextExtractorExtractAudioText(t *testing.T) {
 		reader := multipart.NewReader(r.Body, params["boundary"])
 		defer func() { _ = r.Body.Close() }()
 
-		var model, prompt, fileName, fileContentType, fileBody string
+		var model, prompt, responseFormat, fileName, fileContentType, fileBody string
 		for {
 			part, err := reader.NextPart()
 			if err == io.EOF {
@@ -115,6 +115,8 @@ func TestOpenAIAudioTextExtractorExtractAudioText(t *testing.T) {
 				model = string(data)
 			case "prompt":
 				prompt = string(data)
+			case "response_format":
+				responseFormat = string(data)
 			case "file":
 				fileName = part.FileName()
 				fileContentType = part.Header.Get("Content-Type")
@@ -125,6 +127,9 @@ func TestOpenAIAudioTextExtractorExtractAudioText(t *testing.T) {
 		}
 		if model != "whisper-1" {
 			t.Fatalf("model=%q, want whisper-1", model)
+		}
+		if responseFormat != "json" {
+			t.Fatalf("response_format=%q, want json", responseFormat)
 		}
 		if prompt != "transcribe in zh" {
 			t.Fatalf("prompt=%q, want transcribe in zh", prompt)

--- a/pkg/backend/audio_extract_openai_test.go
+++ b/pkg/backend/audio_extract_openai_test.go
@@ -152,7 +152,7 @@ func TestOpenAIAudioTextExtractorExtractAudioText(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+	got, _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
 		Path:        "/audio/clip.mp3",
 		ContentType: "audio/mpeg",
 		Data:        []byte("fake-mp3"),
@@ -180,7 +180,7 @@ func TestOpenAIAudioTextExtractorExtractAudioTextErrorMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{}); err == nil || err.Error() != "audio transcription api status 502: upstream unavailable" {
+	if _, _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{}); err == nil || err.Error() != "audio transcription api status 502: upstream unavailable" {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -200,7 +200,7 @@ func TestOpenAIAudioTextExtractorExtractAudioTextRawErrorBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{}); err == nil || err.Error() != "audio transcription api status 400: bad gateway from proxy" {
+	if _, _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{}); err == nil || err.Error() != "audio transcription api status 400: bad gateway from proxy" {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -219,7 +219,7 @@ func TestOpenAIAudioTextExtractorExtractAudioTextEmptyText(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{}); err == nil || err.Error() != "audio transcription api returned empty text" {
+	if _, _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{}); err == nil || err.Error() != "audio transcription api returned empty text" {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -265,7 +265,7 @@ func TestOpenAIAudioTextExtractorFallsBackToGenericFilenameAndContentType(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+	if _, _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
 		Path: " ",
 		Data: []byte("x"),
 	}); err != nil {
@@ -314,7 +314,7 @@ func TestOpenAIAudioTextExtractorOmitsBlankPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+	if _, _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
 		Path: "/clip.mp3",
 		Data: []byte("x"),
 	}); err != nil {
@@ -332,7 +332,7 @@ func TestOpenAIAudioTextExtractorRejectsUnsafeMultipartFilename(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+	_, _, err = extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
 		Path:        `/music/a"b.mp3`,
 		ContentType: "audio/mpeg",
 		Data:        []byte("x"),
@@ -361,7 +361,7 @@ func TestWriteAudioMultipartFileRejectsCancelledContextIndirectly(t *testing.T) 
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if _, err := extractor.ExtractAudioText(ctx, AudioExtractRequest{}); err == nil || !strings.Contains(err.Error(), "context canceled") {
+	if _, _, err := extractor.ExtractAudioText(ctx, AudioExtractRequest{}); err == nil || !strings.Contains(err.Error(), "context canceled") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/backend/audio_extract_openai_test.go
+++ b/pkg/backend/audio_extract_openai_test.go
@@ -79,6 +79,30 @@ func TestNewOpenAIAudioTextExtractorEndpointCanonicalization(t *testing.T) {
 	}
 }
 
+func TestNewOpenAIAudioTextExtractorResponseFormatAutoSelect(t *testing.T) {
+	tests := []struct {
+		model string
+		want  string
+	}{
+		{model: "whisper-1", want: "verbose_json"},
+		{model: "gpt-4o-transcribe", want: "json"},
+		{model: "gpt-4o-mini-transcribe", want: "json"},
+	}
+	for _, tc := range tests {
+		extractor, err := NewOpenAIAudioTextExtractor(OpenAIAudioTextExtractorConfig{
+			BaseURL: "https://example.com",
+			APIKey:  "secret",
+			Model:   tc.model,
+		})
+		if err != nil {
+			t.Fatalf("NewOpenAIAudioTextExtractor(model=%q): %v", tc.model, err)
+		}
+		if extractor.responseFormat != tc.want {
+			t.Fatalf("model=%q: responseFormat=%q, want %q", tc.model, extractor.responseFormat, tc.want)
+		}
+	}
+}
+
 func TestOpenAIAudioTextExtractorExtractAudioText(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/audio/transcriptions" {
@@ -128,8 +152,8 @@ func TestOpenAIAudioTextExtractorExtractAudioText(t *testing.T) {
 		if model != "whisper-1" {
 			t.Fatalf("model=%q, want whisper-1", model)
 		}
-		if responseFormat != "json" {
-			t.Fatalf("response_format=%q, want json", responseFormat)
+		if responseFormat != "verbose_json" {
+			t.Fatalf("response_format=%q, want verbose_json", responseFormat)
 		}
 		if prompt != "transcribe in zh" {
 			t.Fatalf("prompt=%q, want transcribe in zh", prompt)

--- a/pkg/backend/audio_extract_openai_test.go
+++ b/pkg/backend/audio_extract_openai_test.go
@@ -170,6 +170,88 @@ func TestOpenAIAudioTextExtractorExtractAudioText(t *testing.T) {
 	}
 }
 
+func TestOpenAIAudioTextExtractorVerboseJSONWhisperDuration(t *testing.T) {
+	var gotResponseFormat string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mediaType, params, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if mediaType != "multipart/form-data" {
+			t.Fatalf("mediaType=%q", mediaType)
+		}
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("next part: %v", err)
+			}
+			data, _ := io.ReadAll(part)
+			if part.FormName() == "response_format" {
+				gotResponseFormat = string(data)
+			}
+		}
+		_, _ = w.Write([]byte(`{"text":"whisper transcript","duration":42.5}`))
+	}))
+	defer server.Close()
+
+	extractor, err := NewOpenAIAudioTextExtractor(OpenAIAudioTextExtractorConfig{
+		BaseURL:        server.URL,
+		APIKey:         "secret",
+		Model:          "whisper-1",
+		ResponseFormat: "verbose_json",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text, usage, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+		Path: "/clip.mp3", ContentType: "audio/mpeg", Data: []byte("x"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotResponseFormat != "verbose_json" {
+		t.Fatalf("response_format=%q, want verbose_json", gotResponseFormat)
+	}
+	if text != "whisper transcript" {
+		t.Fatalf("text=%q", text)
+	}
+	if usage.DurationSeconds != 42.5 {
+		t.Fatalf("duration=%v, want 42.5", usage.DurationSeconds)
+	}
+}
+
+func TestOpenAIAudioTextExtractorTokenUsageParsing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"text":"token transcript","usage":{"input_tokens":100,"output_tokens":50}}`))
+	}))
+	defer server.Close()
+
+	extractor, err := NewOpenAIAudioTextExtractor(OpenAIAudioTextExtractorConfig{
+		BaseURL: server.URL,
+		APIKey:  "secret",
+		Model:   "gpt-4o-transcribe",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text, usage, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+		Path: "/clip.mp3", ContentType: "audio/mpeg", Data: []byte("x"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "token transcript" {
+		t.Fatalf("text=%q", text)
+	}
+	if usage.InputTokens != 100 {
+		t.Fatalf("input_tokens=%d, want 100", usage.InputTokens)
+	}
+	if usage.OutputTokens != 50 {
+		t.Fatalf("output_tokens=%d, want 50", usage.OutputTokens)
+	}
+}
+
 func TestOpenAIAudioTextExtractorExtractAudioTextErrorMessage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)

--- a/pkg/backend/audio_extract_test.go
+++ b/pkg/backend/audio_extract_test.go
@@ -14,11 +14,11 @@ type staticAudioExtractor struct {
 	err  error
 }
 
-func (e *staticAudioExtractor) ExtractAudioText(ctx context.Context, req AudioExtractRequest) (string, error) {
+func (e *staticAudioExtractor) ExtractAudioText(ctx context.Context, req AudioExtractRequest) (string, AudioExtractUsage, error) {
 	if e.err != nil {
-		return "", e.err
+		return "", AudioExtractUsage{}, e.err
 	}
-	return e.text, nil
+	return e.text, AudioExtractUsage{}, nil
 }
 
 type recordingAudioExtractor struct {
@@ -27,12 +27,12 @@ type recordingAudioExtractor struct {
 	gotContentType string
 }
 
-func (e *recordingAudioExtractor) ExtractAudioText(ctx context.Context, req AudioExtractRequest) (string, error) {
+func (e *recordingAudioExtractor) ExtractAudioText(ctx context.Context, req AudioExtractRequest) (string, AudioExtractUsage, error) {
 	e.gotContentType = req.ContentType
 	if e.err != nil {
-		return "", e.err
+		return "", AudioExtractUsage{}, e.err
 	}
-	return e.text, nil
+	return e.text, AudioExtractUsage{}, nil
 }
 
 func TestProcessAudioExtractTaskWritesContentText(t *testing.T) {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -63,6 +63,14 @@ type Dat9Backend struct {
 	audioExtractTimeout      time.Duration
 	audioExtractMaxSize      int64
 	maxAudioExtractTextBytes int
+
+	// Monthly LLM cost budget (P1).
+	maxMonthlyLLMCostMillicents    int64
+	visionCostPerKTokenMillicents  int64
+	audioLLMCostPerKTokenMillicents int64
+	whisperCostPerMinuteMillicents int64
+	fallbackImageCostMillicents    int64
+	fallbackAudioCostMillicents    int64
 }
 
 func newBaseBackend(store *datastore.Store) *Dat9Backend {

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -28,7 +28,7 @@ type ImageExtractRequest struct {
 
 // ImageTextExtractor extracts searchable text from image bytes.
 type ImageTextExtractor interface {
-	ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error)
+	ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, ImageExtractUsage, error)
 }
 
 // ImageExtractTaskSpec carries the revision-scoped inputs needed to extract
@@ -56,6 +56,7 @@ const (
 	ImageExtractResultEmptyText            ImageExtractResult = "empty_text"
 	ImageExtractResultUpdateError          ImageExtractResult = "update_error"
 	ImageExtractResultWritten              ImageExtractResult = "written"
+	ImageExtractResultBudgetExhausted      ImageExtractResult = "budget_exhausted"
 )
 
 func isImageContentType(contentType string) bool {
@@ -232,6 +233,10 @@ func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExt
 	if !b.SupportsAsyncImageExtract() {
 		return ImageExtractResultRuntimeNotConfigured, fmt.Errorf("async image extract runtime not configured")
 	}
+	if b.monthlyLLMCostExceeded() {
+		metrics.RecordOperation("llm_cost_budget", "process_skip", "budget_exhausted", 0)
+		return ImageExtractResultBudgetExhausted, nil
+	}
 
 	f, err := b.store.GetFile(ctx, task.FileID)
 	if err != nil {
@@ -266,7 +271,7 @@ func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExt
 	}
 
 	taskCtx, cancel := context.WithTimeout(ctx, b.imageExtractTimeout)
-	text, err := b.imageExtractor.ExtractImageText(taskCtx, ImageExtractRequest{
+	text, imageUsage, err := b.imageExtractor.ExtractImageText(taskCtx, ImageExtractRequest{
 		FileID:      task.FileID,
 		Path:        task.Path,
 		ContentType: ct,
@@ -276,6 +281,7 @@ func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExt
 	if err != nil {
 		return ImageExtractResultExtractError, fmt.Errorf("extract image text: %w", err)
 	}
+	b.recordImageExtractUsage(task.FileID, imageUsage)
 	text = sanitizeExtractedText(text, b.maxExtractTextBytes)
 	if text == "" {
 		return ImageExtractResultEmptyText, nil

--- a/pkg/backend/image_extract_basic.go
+++ b/pkg/backend/image_extract_basic.go
@@ -22,22 +22,22 @@ type BasicImageTextExtractor struct{}
 
 func NewBasicImageTextExtractor() *BasicImageTextExtractor { return &BasicImageTextExtractor{} }
 
-func (e *BasicImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error) {
+func (e *BasicImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, ImageExtractUsage, error) {
 	select {
 	case <-ctx.Done():
-		return "", ctx.Err()
+		return "", ImageExtractUsage{}, ctx.Err()
 	default:
 	}
 
 	name := pathutil.BaseName(req.Path)
 	cfg, format, err := image.DecodeConfig(bytes.NewReader(req.Data))
 	if err == nil {
-		return strings.TrimSpace(fmt.Sprintf("image file %s format %s width %d height %d", name, strings.ToLower(format), cfg.Width, cfg.Height)), nil
+		return strings.TrimSpace(fmt.Sprintf("image file %s format %s width %d height %d", name, strings.ToLower(format), cfg.Width, cfg.Height)), ImageExtractUsage{}, nil
 	}
 	if req.ContentType != "" {
-		return strings.TrimSpace(fmt.Sprintf("image file %s content type %s", name, req.ContentType)), nil
+		return strings.TrimSpace(fmt.Sprintf("image file %s content type %s", name, req.ContentType)), ImageExtractUsage{}, nil
 	}
-	return strings.TrimSpace(fmt.Sprintf("image file %s", name)), nil
+	return strings.TrimSpace(fmt.Sprintf("image file %s", name)), ImageExtractUsage{}, nil
 }
 
 type fallbackImageTextExtractor struct {
@@ -56,10 +56,10 @@ func NewFallbackImageTextExtractor(primary, fallback ImageTextExtractor) ImageTe
 	return &fallbackImageTextExtractor{primary: primary, fallback: fallback}
 }
 
-func (e *fallbackImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error) {
-	text, err := e.primary.ExtractImageText(ctx, req)
+func (e *fallbackImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, ImageExtractUsage, error) {
+	text, usage, err := e.primary.ExtractImageText(ctx, req)
 	if err == nil && strings.TrimSpace(text) != "" {
-		return text, nil
+		return text, usage, nil
 	}
 	if err != nil {
 		logger.Warn(ctx, "backend_image_extract_primary_failed_use_fallback",

--- a/pkg/backend/image_extract_openai.go
+++ b/pkg/backend/image_extract_openai.go
@@ -76,7 +76,7 @@ func NewOpenAIImageTextExtractor(cfg OpenAIImageTextExtractorConfig) (*OpenAIIma
 	}, nil
 }
 
-func (e *OpenAIImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error) {
+func (e *OpenAIImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, ImageExtractUsage, error) {
 	contentType := req.ContentType
 	if contentType == "" {
 		contentType = "image/png"
@@ -98,24 +98,24 @@ func (e *OpenAIImageTextExtractor) ExtractImageText(ctx context.Context, req Ima
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return "", err
+		return "", ImageExtractUsage{}, err
 	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint, bytes.NewReader(body))
 	if err != nil {
-		return "", err
+		return "", ImageExtractUsage{}, err
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+e.apiKey)
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		return "", err
+		return "", ImageExtractUsage{}, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return "", err
+		return "", ImageExtractUsage{}, err
 	}
 	var parsed struct {
 		Error *struct {
@@ -126,27 +126,36 @@ func (e *OpenAIImageTextExtractor) ExtractImageText(ctx context.Context, req Ima
 				Content any `json:"content"`
 			} `json:"message"`
 		} `json:"choices"`
+		Usage *struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+		} `json:"usage"`
 	}
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		if resp.StatusCode >= 300 {
-			return "", fmt.Errorf("vision api status %d: %s", resp.StatusCode, truncateString(string(raw), 256))
+			return "", ImageExtractUsage{}, fmt.Errorf("vision api status %d: %s", resp.StatusCode, truncateString(string(raw), 256))
 		}
-		return "", fmt.Errorf("decode vision response: %w", err)
+		return "", ImageExtractUsage{}, fmt.Errorf("decode vision response: %w", err)
 	}
 	if resp.StatusCode >= 300 {
 		if parsed.Error != nil && parsed.Error.Message != "" {
-			return "", fmt.Errorf("vision api status %d: %s", resp.StatusCode, parsed.Error.Message)
+			return "", ImageExtractUsage{}, fmt.Errorf("vision api status %d: %s", resp.StatusCode, parsed.Error.Message)
 		}
-		return "", fmt.Errorf("vision api status %d", resp.StatusCode)
+		return "", ImageExtractUsage{}, fmt.Errorf("vision api status %d", resp.StatusCode)
 	}
 	if len(parsed.Choices) == 0 {
-		return "", fmt.Errorf("vision api returned no choices")
+		return "", ImageExtractUsage{}, fmt.Errorf("vision api returned no choices")
 	}
 	text := extractOpenAIContentText(parsed.Choices[0].Message.Content)
 	if strings.TrimSpace(text) == "" {
-		return "", fmt.Errorf("vision api returned empty text")
+		return "", ImageExtractUsage{}, fmt.Errorf("vision api returned empty text")
 	}
-	return text, nil
+	var usage ImageExtractUsage
+	if parsed.Usage != nil {
+		usage.PromptTokens = parsed.Usage.PromptTokens
+		usage.CompletionTokens = parsed.Usage.CompletionTokens
+	}
+	return text, usage, nil
 }
 
 func extractOpenAIContentText(content any) string {

--- a/pkg/backend/image_extract_test.go
+++ b/pkg/backend/image_extract_test.go
@@ -18,8 +18,8 @@ type staticImageExtractor struct {
 	text string
 }
 
-func (e *staticImageExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error) {
-	return e.text, nil
+func (e *staticImageExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, ImageExtractUsage, error) {
+	return e.text, ImageExtractUsage{}, nil
 }
 
 type gatedImageExtractor struct {
@@ -30,7 +30,7 @@ type gatedImageExtractor struct {
 	calls int
 }
 
-func (e *gatedImageExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, error) {
+func (e *gatedImageExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, ImageExtractUsage, error) {
 	e.mu.Lock()
 	e.calls++
 	call := e.calls
@@ -43,11 +43,11 @@ func (e *gatedImageExtractor) ExtractImageText(ctx context.Context, req ImageExt
 		select {
 		case <-e.release:
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return "", ImageExtractUsage{}, ctx.Err()
 		}
-		return "old caption", nil
+		return "old caption", ImageExtractUsage{}, nil
 	}
-	return "new caption", nil
+	return "new caption", ImageExtractUsage{}, nil
 }
 
 func TestAsyncImageExtractUpdatesContentText(t *testing.T) {

--- a/pkg/backend/llm_usage.go
+++ b/pkg/backend/llm_usage.go
@@ -1,0 +1,108 @@
+package backend
+
+import (
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
+
+	"go.uber.org/zap"
+)
+
+// ImageExtractUsage reports the resource consumption of one Vision API call.
+type ImageExtractUsage struct {
+	PromptTokens     int
+	CompletionTokens int
+}
+
+// TotalTokens returns the sum of prompt and completion tokens.
+func (u ImageExtractUsage) TotalTokens() int { return u.PromptTokens + u.CompletionTokens }
+
+// AudioExtractUsage reports the resource consumption of one audio transcription call.
+type AudioExtractUsage struct {
+	DurationSeconds float64 // whisper-1: from verbose_json duration field
+	InputTokens     int     // gpt-4o-transcribe: from usage.input_tokens
+	OutputTokens    int     // gpt-4o-transcribe: from usage.output_tokens
+}
+
+func (b *Dat9Backend) recordImageExtractUsage(taskID string, usage ImageExtractUsage) {
+	totalTokens := int64(usage.TotalTokens())
+	cost := b.imageTokenCostMillicents(totalTokens)
+	if cost == 0 && totalTokens == 0 {
+		cost = b.fallbackImageCostMillicents
+	}
+	if cost <= 0 {
+		return
+	}
+	if err := b.store.InsertLLMUsage("img_extract_text", taskID, cost, totalTokens, "tokens"); err != nil {
+		logger.Warn(backgroundWithTrace(), "llm_usage_insert_failed",
+			zap.String("task_type", "img_extract_text"),
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		metrics.RecordOperation("llm_cost_budget", "usage_insert", "error", 0)
+	}
+}
+
+func (b *Dat9Backend) recordAudioExtractUsage(taskID string, usage AudioExtractUsage) {
+	var cost int64
+	var rawUnits int64
+	var rawUnitType string
+
+	totalTokens := int64(usage.InputTokens + usage.OutputTokens)
+	if totalTokens > 0 {
+		cost = b.audioTokenCostMillicents(totalTokens)
+		rawUnits = totalTokens
+		rawUnitType = "tokens"
+	} else if usage.DurationSeconds > 0 {
+		cost = b.audioDurationCostMillicents(usage.DurationSeconds)
+		rawUnits = int64(usage.DurationSeconds * 1000) // store as milliseconds
+		rawUnitType = "audio_ms"
+	} else {
+		cost = b.fallbackAudioCostMillicents
+		rawUnitType = "fallback"
+	}
+	if cost <= 0 {
+		return
+	}
+	if err := b.store.InsertLLMUsage("audio_extract_text", taskID, cost, rawUnits, rawUnitType); err != nil {
+		logger.Warn(backgroundWithTrace(), "llm_usage_insert_failed",
+			zap.String("task_type", "audio_extract_text"),
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		metrics.RecordOperation("llm_cost_budget", "usage_insert", "error", 0)
+	}
+}
+
+func (b *Dat9Backend) imageTokenCostMillicents(totalTokens int64) int64 {
+	if b.visionCostPerKTokenMillicents <= 0 || totalTokens <= 0 {
+		return 0
+	}
+	return (totalTokens * b.visionCostPerKTokenMillicents) / 1000
+}
+
+func (b *Dat9Backend) audioTokenCostMillicents(totalTokens int64) int64 {
+	if b.audioLLMCostPerKTokenMillicents <= 0 || totalTokens <= 0 {
+		return 0
+	}
+	return (totalTokens * b.audioLLMCostPerKTokenMillicents) / 1000
+}
+
+func (b *Dat9Backend) audioDurationCostMillicents(durationSeconds float64) int64 {
+	if b.whisperCostPerMinuteMillicents <= 0 || durationSeconds <= 0 {
+		return 0
+	}
+	return int64(durationSeconds / 60.0 * float64(b.whisperCostPerMinuteMillicents))
+}
+
+// monthlyLLMCostExceeded checks whether the tenant has exceeded its monthly
+// LLM cost budget. Returns true when the total settled cost exceeds the limit.
+func (b *Dat9Backend) monthlyLLMCostExceeded() bool {
+	if b.maxMonthlyLLMCostMillicents <= 0 {
+		return false
+	}
+	total, err := b.store.MonthlyLLMCostMillicents()
+	if err != nil {
+		logger.Warn(backgroundWithTrace(), "llm_cost_budget_check_fail_open", zap.Error(err))
+		metrics.RecordOperation("llm_cost_budget", "quota_check", "fail_open", 0)
+		return false
+	}
+	return total > b.maxMonthlyLLMCostMillicents
+}

--- a/pkg/backend/llm_usage.go
+++ b/pkg/backend/llm_usage.go
@@ -1,10 +1,10 @@
 package backend
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"
-
-	"go.uber.org/zap"
 )
 
 // ImageExtractUsage reports the resource consumption of one Vision API call.

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -46,6 +46,29 @@ type Options struct {
 	// Files beyond this limit are still stored but their LLM tasks are not enqueued.
 	// Zero or negative means use the default (500).
 	MaxMediaLLMFiles int64
+	// LLMCostBudget configures the monthly LLM cost budget for this tenant.
+	LLMCostBudget LLMCostBudgetOptions
+}
+
+// LLMCostBudgetOptions configures the monthly LLM cost budget.
+type LLMCostBudgetOptions struct {
+	// MaxMonthlyMillicents is the monthly cost cap in millicents (0.001 cents).
+	// Zero or negative disables the monthly cost budget gate.
+	MaxMonthlyMillicents int64
+	// VisionCostPerKTokenMillicents is the cost per 1K tokens for Vision API calls.
+	VisionCostPerKTokenMillicents int64
+	// AudioLLMCostPerKTokenMillicents is the cost per 1K tokens for token-based
+	// audio models (e.g. gpt-4o-transcribe).
+	AudioLLMCostPerKTokenMillicents int64
+	// WhisperCostPerMinuteMillicents is the cost per minute for duration-based
+	// audio models (e.g. whisper-1).
+	WhisperCostPerMinuteMillicents int64
+	// FallbackImageCostMillicents is used when the Vision API does not return
+	// token usage. Must be > 0 for cost tracking to work with such providers.
+	FallbackImageCostMillicents int64
+	// FallbackAudioCostMillicents is used when the audio API returns neither
+	// duration nor token usage. Must be > 0 for cost tracking to work.
+	FallbackAudioCostMillicents int64
 }
 
 // AsyncImageExtractOptions controls async image->text extraction.
@@ -106,6 +129,14 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 	} else {
 		b.maxTenantStorageBytes = defaultMaxTenantStorageBytes
 	}
+
+	cb := opts.LLMCostBudget
+	b.maxMonthlyLLMCostMillicents = cb.MaxMonthlyMillicents
+	b.visionCostPerKTokenMillicents = cb.VisionCostPerKTokenMillicents
+	b.audioLLMCostPerKTokenMillicents = cb.AudioLLMCostPerKTokenMillicents
+	b.whisperCostPerMinuteMillicents = cb.WhisperCostPerMinuteMillicents
+	b.fallbackImageCostMillicents = cb.FallbackImageCostMillicents
+	b.fallbackAudioCostMillicents = cb.FallbackAudioCostMillicents
 
 	if opts.QueryEmbedding.Client != nil {
 		b.queryEmbedder = opts.QueryEmbedding.Client

--- a/pkg/backend/schema_test_helper.go
+++ b/pkg/backend/schema_test_helper.go
@@ -34,6 +34,8 @@ func initBackendSchema(t *testing.T, dsn string) {
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
 		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
+		`CREATE TABLE IF NOT EXISTS llm_usage (id BIGINT AUTO_INCREMENT PRIMARY KEY, task_type VARCHAR(32) NOT NULL, task_id VARCHAR(64) NOT NULL, cost_millicents BIGINT NOT NULL DEFAULT 0, raw_units BIGINT NOT NULL DEFAULT 0, raw_unit_type VARCHAR(16) NOT NULL, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
+		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/pkg/client/schema_test_helper.go
+++ b/pkg/client/schema_test_helper.go
@@ -35,6 +35,8 @@ func initClientTenantSchema(t *testing.T, dsn string) {
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
 		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
+		`CREATE TABLE IF NOT EXISTS llm_usage (id BIGINT AUTO_INCREMENT PRIMARY KEY, task_type VARCHAR(32) NOT NULL, task_id VARCHAR(64) NOT NULL, cost_millicents BIGINT NOT NULL DEFAULT 0, raw_units BIGINT NOT NULL DEFAULT 0, raw_unit_type VARCHAR(16) NOT NULL, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
+		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/pkg/datastore/llm_usage.go
+++ b/pkg/datastore/llm_usage.go
@@ -1,0 +1,23 @@
+package datastore
+
+import (
+	"time"
+)
+
+// InsertLLMUsage records one billable LLM call.
+func (s *Store) InsertLLMUsage(taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) error {
+	_, err := s.db.Exec(`INSERT INTO llm_usage (task_type, task_id, cost_millicents, raw_units, raw_unit_type, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		taskType, taskID, costMillicents, rawUnits, rawUnitType, time.Now().UTC())
+	return err
+}
+
+// MonthlyLLMCostMillicents returns the sum of cost_millicents for the current
+// calendar month (UTC). Returns 0 on error (fail-open).
+func (s *Store) MonthlyLLMCostMillicents() (int64, error) {
+	now := time.Now().UTC()
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	var total int64
+	err := s.db.QueryRow(`SELECT COALESCE(SUM(cost_millicents), 0) FROM llm_usage WHERE created_at >= ?`, monthStart).Scan(&total)
+	return total, err
+}

--- a/pkg/datastore/schema_test_helper_test.go
+++ b/pkg/datastore/schema_test_helper_test.go
@@ -35,6 +35,8 @@ func initDatastoreSchema(t *testing.T, dsn string) {
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
 		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
+		`CREATE TABLE IF NOT EXISTS llm_usage (id BIGINT AUTO_INCREMENT PRIMARY KEY, task_type VARCHAR(32) NOT NULL, task_id VARCHAR(64) NOT NULL, cost_millicents BIGINT NOT NULL DEFAULT 0, raw_units BIGINT NOT NULL DEFAULT 0, raw_unit_type VARCHAR(16) NOT NULL, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
+		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/pkg/datastore/semantic_tasks.go
+++ b/pkg/datastore/semantic_tasks.go
@@ -461,40 +461,6 @@ func (s *Store) RetrySemanticTask(ctx context.Context, taskID, receipt string, r
 	return tx.Commit()
 }
 
-// DeferSemanticTask requeues a leased task to a future time without consuming
-// an attempt. The claim-time attempt_count increment is rolled back so that
-// budget-deferred tasks are not penalized toward max_attempts.
-func (s *Store) DeferSemanticTask(ctx context.Context, taskID, receipt string, availableAt time.Time) (err error) {
-	start := time.Now()
-	defer observeStoreOp(ctx, "defer_semantic_task", start, &err)
-
-	now := semanticTaskLeaseNow()
-	if availableAt.IsZero() {
-		availableAt = now
-	} else {
-		availableAt = availableAt.UTC()
-	}
-
-	res, err := s.db.ExecContext(ctx, `UPDATE semantic_tasks
-		SET status = ?, attempt_count = GREATEST(attempt_count - 1, 0),
-		    receipt = NULL, leased_at = NULL, lease_until = NULL,
-		    available_at = ?, last_error = 'budget_exhausted', updated_at = ?
-		WHERE task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`,
-		semantic.TaskQueued, availableAt, now,
-		taskID, semantic.TaskProcessing, receipt, now)
-	if err != nil {
-		return err
-	}
-	rowsAffected, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rowsAffected > 0 {
-		return nil
-	}
-	return s.semanticTaskLeaseError(ctx, taskID)
-}
-
 // RecoverExpiredSemanticTasks requeues expired processing tasks.
 func (s *Store) RecoverExpiredSemanticTasks(ctx context.Context, now time.Time, limit int) (recovered int, err error) {
 	start := time.Now()

--- a/pkg/datastore/semantic_tasks.go
+++ b/pkg/datastore/semantic_tasks.go
@@ -461,6 +461,40 @@ func (s *Store) RetrySemanticTask(ctx context.Context, taskID, receipt string, r
 	return tx.Commit()
 }
 
+// DeferSemanticTask requeues a leased task to a future time without consuming
+// an attempt. The claim-time attempt_count increment is rolled back so that
+// budget-deferred tasks are not penalized toward max_attempts.
+func (s *Store) DeferSemanticTask(ctx context.Context, taskID, receipt string, availableAt time.Time) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "defer_semantic_task", start, &err)
+
+	now := semanticTaskLeaseNow()
+	if availableAt.IsZero() {
+		availableAt = now
+	} else {
+		availableAt = availableAt.UTC()
+	}
+
+	res, err := s.db.ExecContext(ctx, `UPDATE semantic_tasks
+		SET status = ?, attempt_count = GREATEST(attempt_count - 1, 0),
+		    receipt = NULL, leased_at = NULL, lease_until = NULL,
+		    available_at = ?, last_error = 'budget_exhausted', updated_at = ?
+		WHERE task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`,
+		semantic.TaskQueued, availableAt, now,
+		taskID, semantic.TaskProcessing, receipt, now)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected > 0 {
+		return nil
+	}
+	return s.semanticTaskLeaseError(ctx, taskID)
+}
+
 // RecoverExpiredSemanticTasks requeues expired processing tasks.
 func (s *Store) RecoverExpiredSemanticTasks(ctx context.Context, now time.Time, limit int) (recovered int, err error) {
 	start := time.Now()

--- a/pkg/server/schema_test_helper.go
+++ b/pkg/server/schema_test_helper.go
@@ -35,6 +35,8 @@ func initServerTenantSchema(t *testing.T, dsn string) {
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
 		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
+		`CREATE TABLE IF NOT EXISTS llm_usage (id BIGINT AUTO_INCREMENT PRIMARY KEY, task_type VARCHAR(32) NOT NULL, task_id VARCHAR(64) NOT NULL, cost_millicents BIGINT NOT NULL DEFAULT 0, raw_units BIGINT NOT NULL DEFAULT 0, raw_unit_type VARCHAR(16) NOT NULL, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
+		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -169,7 +169,6 @@ type semanticTaskAction string
 const (
 	semanticTaskActionAck   semanticTaskAction = "ack"
 	semanticTaskActionRetry semanticTaskAction = "retry"
-	semanticTaskActionDefer semanticTaskAction = "defer"
 )
 
 type semanticTaskOutcome struct {
@@ -405,8 +404,6 @@ func (m *semanticWorkerManager) processTask(ctx context.Context, target *semanti
 		m.ackTask(ctx, target.tenantID, target.store, task, outcome.message)
 	case semanticTaskActionRetry:
 		m.retryTask(ctx, target.tenantID, target.store, task, outcome.message)
-	case semanticTaskActionDefer:
-		m.deferTask(ctx, target.tenantID, target.store, task, outcome.message)
 	}
 }
 
@@ -457,30 +454,6 @@ func (m *semanticWorkerManager) retryTask(ctx context.Context, tenantID string, 
 		fields = append(fields, zap.Time("retry_at", retryAt))
 	}
 	logger.Warn(ctx, logMessage, fields...)
-}
-
-func (m *semanticWorkerManager) deferTask(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task, message string) {
-	start := time.Now()
-	now := time.Now().UTC()
-	nextMonth := time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, time.UTC)
-	if err := store.DeferSemanticTask(ctx, task.TaskID, task.Receipt, nextMonth); err != nil {
-		metrics.RecordOperation("semantic_worker", "defer", "error", time.Since(start))
-		logger.Warn(ctx, "semantic_worker_defer_failed",
-			append([]zap.Field{
-				zap.String("tenant_id", tenantID),
-				zap.String("result", "error"),
-				zap.String("message", message),
-			}, append(semanticTaskLogFields(task), zap.Error(err))...)...)
-		return
-	}
-	metrics.RecordOperation("semantic_worker", "defer", "ok", time.Since(start))
-	logger.Info(ctx, "semantic_worker_defer_ok",
-		append([]zap.Field{
-			zap.String("tenant_id", tenantID),
-			zap.String("result", "deferred"),
-			zap.String("message", message),
-			zap.Time("available_at", nextMonth),
-		}, semanticTaskLogFields(task)...)...)
 }
 
 func (m *semanticWorkerManager) retryDelay(attemptCount int) time.Duration {
@@ -918,7 +891,7 @@ func (m *semanticWorkerManager) processImgExtractTask(ctx context.Context, b *ba
 		return semanticTaskOutcome{action: semanticTaskActionRetry, result: string(result), message: err.Error()}
 	}
 	if result == backend.ImageExtractResultBudgetExhausted {
-		return semanticTaskOutcome{action: semanticTaskActionDefer, result: string(result), message: "monthly_llm_cost_budget_exhausted"}
+		return semanticTaskOutcome{action: semanticTaskActionAck, result: string(result), message: "monthly_llm_cost_budget_exhausted"}
 	}
 	return semanticTaskOutcome{action: semanticTaskActionAck, result: string(result), message: string(result)}
 }
@@ -929,7 +902,7 @@ func (m *semanticWorkerManager) processAudioExtractTask(ctx context.Context, b *
 		return semanticTaskOutcome{action: semanticTaskActionRetry, result: string(result), message: err.Error()}
 	}
 	if result == backend.AudioExtractResultBudgetExhausted {
-		return semanticTaskOutcome{action: semanticTaskActionDefer, result: string(result), message: "monthly_llm_cost_budget_exhausted"}
+		return semanticTaskOutcome{action: semanticTaskActionAck, result: string(result), message: "monthly_llm_cost_budget_exhausted"}
 	}
 	return semanticTaskOutcome{action: semanticTaskActionAck, result: string(result), message: string(result)}
 }

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -169,6 +169,7 @@ type semanticTaskAction string
 const (
 	semanticTaskActionAck   semanticTaskAction = "ack"
 	semanticTaskActionRetry semanticTaskAction = "retry"
+	semanticTaskActionDefer semanticTaskAction = "defer"
 )
 
 type semanticTaskOutcome struct {
@@ -404,6 +405,8 @@ func (m *semanticWorkerManager) processTask(ctx context.Context, target *semanti
 		m.ackTask(ctx, target.tenantID, target.store, task, outcome.message)
 	case semanticTaskActionRetry:
 		m.retryTask(ctx, target.tenantID, target.store, task, outcome.message)
+	case semanticTaskActionDefer:
+		m.deferTask(ctx, target.tenantID, target.store, task, outcome.message)
 	}
 }
 
@@ -454,6 +457,30 @@ func (m *semanticWorkerManager) retryTask(ctx context.Context, tenantID string, 
 		fields = append(fields, zap.Time("retry_at", retryAt))
 	}
 	logger.Warn(ctx, logMessage, fields...)
+}
+
+func (m *semanticWorkerManager) deferTask(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task, message string) {
+	start := time.Now()
+	now := time.Now().UTC()
+	nextMonth := time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, time.UTC)
+	if err := store.DeferSemanticTask(ctx, task.TaskID, task.Receipt, nextMonth); err != nil {
+		metrics.RecordOperation("semantic_worker", "defer", "error", time.Since(start))
+		logger.Warn(ctx, "semantic_worker_defer_failed",
+			append([]zap.Field{
+				zap.String("tenant_id", tenantID),
+				zap.String("result", "error"),
+				zap.String("message", message),
+			}, append(semanticTaskLogFields(task), zap.Error(err))...)...)
+		return
+	}
+	metrics.RecordOperation("semantic_worker", "defer", "ok", time.Since(start))
+	logger.Info(ctx, "semantic_worker_defer_ok",
+		append([]zap.Field{
+			zap.String("tenant_id", tenantID),
+			zap.String("result", "deferred"),
+			zap.String("message", message),
+			zap.Time("available_at", nextMonth),
+		}, semanticTaskLogFields(task)...)...)
 }
 
 func (m *semanticWorkerManager) retryDelay(attemptCount int) time.Duration {
@@ -890,6 +917,9 @@ func (m *semanticWorkerManager) processImgExtractTask(ctx context.Context, b *ba
 	if err != nil {
 		return semanticTaskOutcome{action: semanticTaskActionRetry, result: string(result), message: err.Error()}
 	}
+	if result == backend.ImageExtractResultBudgetExhausted {
+		return semanticTaskOutcome{action: semanticTaskActionDefer, result: string(result), message: "monthly_llm_cost_budget_exhausted"}
+	}
 	return semanticTaskOutcome{action: semanticTaskActionAck, result: string(result), message: string(result)}
 }
 
@@ -897,6 +927,9 @@ func (m *semanticWorkerManager) processAudioExtractTask(ctx context.Context, b *
 	result, err := b.ProcessAudioExtractTask(ctx, audioExtractTaskSpecFromSemanticTask(task))
 	if err != nil {
 		return semanticTaskOutcome{action: semanticTaskActionRetry, result: string(result), message: err.Error()}
+	}
+	if result == backend.AudioExtractResultBudgetExhausted {
+		return semanticTaskOutcome{action: semanticTaskActionDefer, result: string(result), message: "monthly_llm_cost_budget_exhausted"}
 	}
 	return semanticTaskOutcome{action: semanticTaskActionAck, result: string(result), message: string(result)}
 }

--- a/pkg/server/semantic_worker_failpoint_test.go
+++ b/pkg/server/semantic_worker_failpoint_test.go
@@ -34,14 +34,14 @@ type gatedServerImageExtractor struct {
 	canceled chan struct{}
 }
 
-func (e *gatedServerImageExtractor) ExtractImageText(ctx context.Context, req backend.ImageExtractRequest) (string, error) {
+func (e *gatedServerImageExtractor) ExtractImageText(ctx context.Context, req backend.ImageExtractRequest) (string, backend.ImageExtractUsage, error) {
 	select {
 	case e.started <- struct{}{}:
 	default:
 	}
 	select {
 	case <-e.release:
-		return e.text, nil
+		return e.text, backend.ImageExtractUsage{}, nil
 	case <-ctx.Done():
 		if e.canceled != nil {
 			select {
@@ -49,7 +49,7 @@ func (e *gatedServerImageExtractor) ExtractImageText(ctx context.Context, req ba
 			default:
 			}
 		}
-		return "", ctx.Err()
+		return "", backend.ImageExtractUsage{}, ctx.Err()
 	}
 }
 
@@ -58,7 +58,7 @@ type gatedPanicServerImageExtractor struct {
 	release chan struct{}
 }
 
-func (e *gatedPanicServerImageExtractor) ExtractImageText(context.Context, backend.ImageExtractRequest) (string, error) {
+func (e *gatedPanicServerImageExtractor) ExtractImageText(context.Context, backend.ImageExtractRequest) (string, backend.ImageExtractUsage, error) {
 	if e != nil && e.started != nil {
 		select {
 		case e.started <- struct{}{}:

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -69,11 +69,11 @@ type staticServerImageExtractor struct {
 	err  error
 }
 
-func (e staticServerImageExtractor) ExtractImageText(context.Context, backend.ImageExtractRequest) (string, error) {
+func (e staticServerImageExtractor) ExtractImageText(_ context.Context, _ backend.ImageExtractRequest) (string, backend.ImageExtractUsage, error) {
 	if e.err != nil {
-		return "", e.err
+		return "", backend.ImageExtractUsage{}, e.err
 	}
-	return e.text, nil
+	return e.text, backend.ImageExtractUsage{}, nil
 }
 
 type staticServerAudioExtractor struct {
@@ -81,11 +81,11 @@ type staticServerAudioExtractor struct {
 	err  error
 }
 
-func (e staticServerAudioExtractor) ExtractAudioText(context.Context, backend.AudioExtractRequest) (string, error) {
+func (e staticServerAudioExtractor) ExtractAudioText(_ context.Context, _ backend.AudioExtractRequest) (string, backend.AudioExtractUsage, error) {
 	if e.err != nil {
-		return "", e.err
+		return "", backend.AudioExtractUsage{}, e.err
 	}
-	return e.text, nil
+	return e.text, backend.AudioExtractUsage{}, nil
 }
 
 func newTestTenantPool(t *testing.T) *tenant.Pool {

--- a/pkg/tenant/db9/schema.go
+++ b/pkg/tenant/db9/schema.go
@@ -109,6 +109,16 @@ func InitSchemaStatements() []string {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
+		`CREATE TABLE IF NOT EXISTS llm_usage (
+			id              BIGSERIAL PRIMARY KEY,
+			task_type       VARCHAR(32) NOT NULL,
+			task_id         VARCHAR(64) NOT NULL,
+			cost_millicents BIGINT NOT NULL DEFAULT 0,
+			raw_units       BIGINT NOT NULL DEFAULT 0,
+			raw_unit_type   VARCHAR(16) NOT NULL,
+			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_llm_usage_created ON llm_usage(created_at)`,
 	}
 	stmts := make([]string, 0, len(core)+len(vault.SchemaStatements()))
 	stmts = append(stmts, core...)

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -251,6 +251,6 @@ func TestPoolAutoSemanticTaskTypes(t *testing.T) {
 
 type poolDummyAudioExtractor struct{}
 
-func (poolDummyAudioExtractor) ExtractAudioText(context.Context, backend.AudioExtractRequest) (string, error) {
-	return "", nil
+func (poolDummyAudioExtractor) ExtractAudioText(context.Context, backend.AudioExtractRequest) (string, backend.AudioExtractUsage, error) {
+	return "", backend.AudioExtractUsage{}, nil
 }

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -103,6 +103,16 @@ func tidbAppEmbeddingSchemaStatements() []string {
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
 		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
+		`CREATE TABLE IF NOT EXISTS llm_usage (
+			id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+			task_type       VARCHAR(32) NOT NULL,
+			task_id         VARCHAR(64) NOT NULL,
+			cost_millicents BIGINT NOT NULL DEFAULT 0,
+			raw_units       BIGINT NOT NULL DEFAULT 0,
+			raw_unit_type   VARCHAR(16) NOT NULL,
+			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+		)`,
+		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
 	}
 }
 

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -141,6 +141,16 @@ func tidbAutoEmbeddingSchemaStatements() []string {
 		`CREATE UNIQUE INDEX uk_task_resource_version ON semantic_tasks(task_type, resource_id, resource_version)`,
 		`CREATE INDEX idx_task_claim ON semantic_tasks(status, available_at, lease_until, created_at)`,
 		`CREATE INDEX idx_task_claim_type ON semantic_tasks(status, task_type, available_at, created_at, task_id)`,
+		`CREATE TABLE IF NOT EXISTS llm_usage (
+			id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+			task_type       VARCHAR(32) NOT NULL,
+			task_id         VARCHAR(64) NOT NULL,
+			cost_millicents BIGINT NOT NULL DEFAULT 0,
+			raw_units       BIGINT NOT NULL DEFAULT 0,
+			raw_unit_type   VARCHAR(16) NOT NULL,
+			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+		)`,
+		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Track actual LLM call costs in a new `llm_usage` table (millicents precision) and enforce a configurable monthly spending cap per tenant
- Extend `ImageTextExtractor` and `AudioTextExtractor` interfaces to return usage structs (`ImageExtractUsage`, `AudioExtractUsage`) enabling post-call cost settlement
- Support both whisper-1 (duration-based) and gpt-4o-transcribe (token-based) cost models with configurable per-K-token and per-minute rates
- Budget-exhausted semantic tasks are deferred to the 1st of next month via `DeferSemanticTask` without consuming an attempt (fail-open on errors)
- Add `LLMCostBudgetOptions` to backend options for per-tenant monthly cap configuration

## Key design decisions
- **Post-call settle, no reservation**: Cost is recorded immediately after successful LLM call. P0 file count gate bounds total concurrent overspend
- **Fail-open**: All budget checks return false (allow) on error, with logging and metrics
- **Defer, not drop**: Budget-exhausted tasks roll back `attempt_count` and requeue to next month's 1st — no permanent skip

## Files changed (26 files, +412/-92)
- `pkg/datastore/llm_usage.go` — new: InsertLLMUsage, MonthlyLLMCostMillicents
- `pkg/backend/llm_usage.go` — new: usage types, cost calculation, recording, budget check
- `pkg/backend/{image,audio}_extract.go` — budget gate + usage recording
- `pkg/backend/{image,audio}_extract_openai.go` — parse usage from API responses
- `pkg/backend/options.go` — LLMCostBudgetOptions struct + wiring
- `pkg/datastore/semantic_tasks.go` — DeferSemanticTask method
- `pkg/server/semantic_worker.go` — defer action handling + deferTask method
- Schema files (TiDB auto/app, PostgreSQL, test helpers) — llm_usage table
- Test files — updated mock extractors to new 3-return interface

## Test plan
- [ ] CI builds and passes all existing tests
- [ ] Verify llm_usage table created in schema migrations
- [ ] Verify budget check is fail-open (no cost table → still allows extraction)
- [ ] Verify budget-exhausted tasks get deferred, not dead-lettered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added monthly LLM cost budget enforcement for image and audio extraction tasks with detailed usage tracking.
  * When monthly budget is exceeded, extraction requests are blocked with a clear status message.

* **Configuration**
  * Audio extraction response format is now configurable via environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->