### PR TITLE
Add upload benchmark diagnostics and AWS-backed local-server support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,13 @@ test:
 		test_p_flag="-p $(TEST_P)"; \
 	fi; \
 	if [ -z "$${DRIVE9_TEST_MYSQL_DSN:-}" ] && command -v podman >/dev/null 2>&1; then \
-		source ./scripts/test-podman.sh; \
+		if podman_env="$$(bash -lc 'source ./scripts/test-podman.sh && env | grep -E "^(DOCKER_HOST|TESTCONTAINERS_RYUK_DISABLED)="')"; then \
+			while IFS= read -r line; do \
+				export "$$line"; \
+			done <<< "$$podman_env"; \
+		else \
+			echo "make test: Podman testcontainers setup unavailable, falling back to default runtime" >&2; \
+		fi; \
 	fi; \
 	$(GO) test $$test_p_flag -v ./...
 

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -344,9 +345,10 @@ func logLocalStartupStep(ctx context.Context, startupStart, stepStart time.Time,
 
 func localS3ConfigFromEnv() (localS3Config, error) {
 	bucket := strings.TrimSpace(os.Getenv("DRIVE9_S3_BUCKET"))
-	dirSet := strings.TrimSpace(os.Getenv("DRIVE9_S3_DIR"))
+	dirSet := normalizeLocalS3Dir(os.Getenv("DRIVE9_S3_DIR"))
+	defaultDir := defaultLocalS3Dir()
 	if bucket != "" {
-		if dirSet != "" {
+		if dirSet != "" && dirSet != defaultDir {
 			return localS3Config{}, fmt.Errorf("DRIVE9_S3_BUCKET and DRIVE9_S3_DIR are mutually exclusive; unset DRIVE9_S3_DIR when using AWS S3 mode")
 		}
 		return localS3Config{
@@ -357,9 +359,12 @@ func localS3ConfigFromEnv() (localS3Config, error) {
 			RoleARN: strings.TrimSpace(os.Getenv("DRIVE9_S3_ROLE_ARN")),
 		}, nil
 	}
+	if dirSet == "" {
+		dirSet = defaultDir
+	}
 	return localS3Config{
 		Mode: "local",
-		Dir:  envOr("DRIVE9_S3_DIR", defaultS3Dir),
+		Dir:  dirSet,
 	}, nil
 }
 
@@ -573,10 +578,26 @@ func redactDSN(dsn string) string {
 }
 
 func envOr(key, fallback string) string {
-	if value := os.Getenv(key); value != "" {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
 		return value
 	}
 	return fallback
+}
+
+func defaultLocalS3Dir() string {
+	base := strings.TrimSpace(os.Getenv("TMPDIR"))
+	if base == "" {
+		return defaultS3Dir
+	}
+	return filepath.Join(base, "drive9-local-s3")
+}
+
+func normalizeLocalS3Dir(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	return filepath.Clean(value)
 }
 
 func envBool(key string, fallback bool) bool {

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -249,6 +249,7 @@ environment:
   DRIVE9_LOCAL_DSN   local tenant TiDB/MySQL DSN (required)
   DRIVE9_LOCAL_INIT_SCHEMA initialize tenant schema on startup (default: false)
   DRIVE9_LOCAL_EMBEDDING_MODE auto|app|detect (default: auto when initing schema, detect otherwise)
+  DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
 
   S3 storage:
   Set DRIVE9_S3_BUCKET to enable AWS S3 mode.

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -26,8 +26,18 @@ import (
 const (
 	defaultListenAddr     = "127.0.0.1:9009"
 	defaultS3Dir          = "/tmp/drive9-local-s3"
+	defaultS3Region       = "us-east-1"
 	envLocalEmbeddingMode = "DRIVE9_LOCAL_EMBEDDING_MODE"
 )
+
+type localS3Config struct {
+	Mode    string
+	Dir     string
+	Bucket  string
+	Region  string
+	Prefix  string
+	RoleARN string
+}
 
 func main() {
 	startupCtx := context.Background()
@@ -57,6 +67,10 @@ func main() {
 	}
 	localInitSchema := envBool("DRIVE9_LOCAL_INIT_SCHEMA", false)
 	requestedEmbeddingMode, explicitEmbeddingMode, err := localEmbeddingModeFromEnv()
+	if err != nil {
+		die(err)
+	}
+	s3cfg, err := localS3ConfigFromEnv()
 	if err != nil {
 		die(err)
 	}
@@ -123,18 +137,43 @@ func main() {
 		backendOpts.QueryEmbedding = backend.QueryEmbeddingOptions{Client: semanticEmbedder}
 	}
 
-	s3Dir := envOr("DRIVE9_S3_DIR", defaultS3Dir)
-	// Even in local single-tenant mode we keep the same S3-facing upload code path
-	// by backing it with the local mock implementation.
+	var (
+		s3c     s3client.S3Client
+		localS3 *s3client.LocalS3Client
+	)
 	stepStart = time.Now()
-	localS3, err := s3client.NewLocal(s3Dir, publicBaseURL(addr)+"/s3")
-	if err != nil {
-		die(fmt.Errorf("create local s3: %w", err))
+	switch s3cfg.Mode {
+	case "aws":
+		s3c, err = s3client.NewAWS(startupCtx, s3client.AWSConfig{
+			Region:  s3cfg.Region,
+			Bucket:  s3cfg.Bucket,
+			Prefix:  s3cfg.Prefix,
+			RoleARN: s3cfg.RoleARN,
+		})
+		if err != nil {
+			die(fmt.Errorf("create aws s3 client: %w", err))
+		}
+		logLocalStartupStep(startupCtx, startupStart, stepStart, "create_aws_s3",
+			zap.String("bucket", s3cfg.Bucket),
+			zap.String("region", s3cfg.Region),
+			zap.String("prefix", s3cfg.Prefix),
+			zap.String("role", localS3RoleLogValue(s3cfg.RoleARN)))
+	case "local":
+		// Even in local single-tenant mode we keep the same S3-facing upload code path
+		// by backing it with the local mock implementation.
+		localS3, err = s3client.NewLocal(s3cfg.Dir, publicBaseURL(addr)+"/s3")
+		if err != nil {
+			die(fmt.Errorf("create local s3: %w", err))
+		}
+		s3c = localS3
+		logLocalStartupStep(startupCtx, startupStart, stepStart, "create_local_s3",
+			zap.String("dir", s3cfg.Dir))
+	default:
+		die(fmt.Errorf("unsupported local S3 mode %q", s3cfg.Mode))
 	}
-	logLocalStartupStep(startupCtx, startupStart, stepStart, "create_local_s3")
 
 	stepStart = time.Now()
-	b, err := backend.NewWithS3ModeAndOptions(store, localS3, true, backendOpts)
+	b, err := backend.NewWithS3ModeAndOptions(store, s3c, true, backendOpts)
 	if err != nil {
 		die(fmt.Errorf("create local backend: %w", err))
 	}
@@ -144,7 +183,7 @@ func main() {
 	if err := server.ValidateDurableAsyncExtractRequiresSemanticWorker(server.Config{
 		Backend:          b,
 		LocalS3:          localS3,
-		S3Dir:            s3Dir,
+		S3Dir:            s3cfg.localDir(),
 		MaxUploadBytes:   maxUploadBytes,
 		Logger:           srvLogger,
 		SemanticEmbedder: semanticEmbedder,
@@ -157,7 +196,7 @@ func main() {
 	srv := server.NewWithConfig(server.Config{
 		Backend:          b,
 		LocalS3:          localS3,
-		S3Dir:            s3Dir,
+		S3Dir:            s3cfg.localDir(),
 		MaxUploadBytes:   maxUploadBytes,
 		Logger:           srvLogger,
 		SemanticEmbedder: semanticEmbedder,
@@ -170,7 +209,12 @@ func main() {
 	logger.Info(startupCtx, "local_server_mode",
 		zap.String("listen_addr", addr),
 		zap.String("local_dsn", redactDSN(localDSN)),
-		zap.String("s3_dir", s3Dir),
+		zap.String("s3_mode", s3cfg.Mode),
+		zap.String("s3_dir", s3cfg.localDir()),
+		zap.String("s3_bucket", s3cfg.Bucket),
+		zap.String("s3_region", s3cfg.Region),
+		zap.String("s3_prefix", s3cfg.Prefix),
+		zap.String("s3_role", localS3RoleLogValue(s3cfg.RoleARN)),
 		zap.Bool("local_init_schema", localInitSchema),
 		zap.String("requested_embedding_mode", localEmbeddingModeLabel(requestedEmbeddingMode, explicitEmbeddingMode)),
 		zap.String("embedding_mode", string(localEmbeddingMode)),
@@ -204,7 +248,14 @@ environment:
   DRIVE9_LOCAL_DSN   local tenant TiDB/MySQL DSN (required)
   DRIVE9_LOCAL_INIT_SCHEMA initialize tenant schema on startup (default: false)
   DRIVE9_LOCAL_EMBEDDING_MODE auto|app|detect (default: auto when initing schema, detect otherwise)
-  DRIVE9_S3_DIR      local S3 mock root directory (default: /tmp/drive9-local-s3)
+
+  S3 storage:
+  Set DRIVE9_S3_BUCKET to enable AWS S3 mode.
+  DRIVE9_S3_BUCKET   S3 bucket name (enables AWS S3 mode; mutually exclusive with DRIVE9_S3_DIR)
+  DRIVE9_S3_REGION   AWS region (default: us-east-1)
+  DRIVE9_S3_PREFIX   S3 key prefix (optional)
+  DRIVE9_S3_ROLE_ARN IAM role ARN to assume via STS (optional)
+  DRIVE9_S3_DIR      local S3 mock root directory (default: /tmp/drive9-local-s3, only used without DRIVE9_S3_BUCKET)
 
   Query embedding (app-side semantic query embedding for grep):
   DRIVE9_QUERY_EMBED_API_BASE OpenAI-compatible base URL (optional)
@@ -289,6 +340,41 @@ func logLocalStartupStep(ctx context.Context, startupStart, stepStart time.Time,
 	}
 	fields = append(fields, extra...)
 	logger.Info(ctx, "local_server_startup_step", fields...)
+}
+
+func localS3ConfigFromEnv() (localS3Config, error) {
+	bucket := strings.TrimSpace(os.Getenv("DRIVE9_S3_BUCKET"))
+	dirSet := strings.TrimSpace(os.Getenv("DRIVE9_S3_DIR"))
+	if bucket != "" {
+		if dirSet != "" {
+			return localS3Config{}, fmt.Errorf("DRIVE9_S3_BUCKET and DRIVE9_S3_DIR are mutually exclusive; unset DRIVE9_S3_DIR when using AWS S3 mode")
+		}
+		return localS3Config{
+			Mode:    "aws",
+			Bucket:  bucket,
+			Region:  envOr("DRIVE9_S3_REGION", defaultS3Region),
+			Prefix:  strings.TrimSpace(os.Getenv("DRIVE9_S3_PREFIX")),
+			RoleARN: strings.TrimSpace(os.Getenv("DRIVE9_S3_ROLE_ARN")),
+		}, nil
+	}
+	return localS3Config{
+		Mode: "local",
+		Dir:  envOr("DRIVE9_S3_DIR", defaultS3Dir),
+	}, nil
+}
+
+func (c localS3Config) localDir() string {
+	if c.Mode != "local" {
+		return ""
+	}
+	return c.Dir
+}
+
+func localS3RoleLogValue(roleARN string) string {
+	if roleARN == "" {
+		return "default-credentials"
+	}
+	return roleARN
 }
 
 var (

--- a/cmd/drive9-server-local/main_test.go
+++ b/cmd/drive9-server-local/main_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
@@ -144,6 +145,92 @@ func TestLocalEmbeddingModeFromEnv(t *testing.T) {
 	}
 	if _, _, err := localEmbeddingModeFromEnv(); err == nil {
 		t.Fatal("expected invalid mode to fail")
+	}
+}
+
+func TestLocalS3ConfigFromEnv(t *testing.T) {
+	keys := []string{
+		"TMPDIR",
+		"DRIVE9_S3_BUCKET",
+		"DRIVE9_S3_DIR",
+		"DRIVE9_S3_REGION",
+		"DRIVE9_S3_PREFIX",
+		"DRIVE9_S3_ROLE_ARN",
+	}
+	prev := make(map[string]string, len(keys))
+	for _, k := range keys {
+		prev[k] = os.Getenv(k)
+	}
+	t.Cleanup(func() {
+		for _, k := range keys {
+			if prev[k] == "" {
+				_ = os.Unsetenv(k)
+			} else {
+				_ = os.Setenv(k, prev[k])
+			}
+		}
+	})
+
+	unsetAll := func() {
+		for _, k := range keys {
+			_ = os.Unsetenv(k)
+		}
+	}
+
+	unsetAll()
+	if err := os.Setenv("TMPDIR", filepath.Join(string(os.PathSeparator), "tmp", "podman")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("DRIVE9_S3_BUCKET", "  bench-bucket  "); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("DRIVE9_S3_DIR", filepath.Join(os.Getenv("TMPDIR"), "drive9-local-s3")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("DRIVE9_S3_REGION", "  us-west-2  "); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("DRIVE9_S3_PREFIX", "  uploads/  "); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("DRIVE9_S3_ROLE_ARN", "  arn:aws:iam::123456789012:role/test  "); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := localS3ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("aws config with default local dir should succeed: %v", err)
+	}
+	if cfg.Mode != "aws" || cfg.Bucket != "bench-bucket" || cfg.Region != "us-west-2" {
+		t.Fatalf("unexpected aws config: %+v", cfg)
+	}
+	if cfg.Prefix != "uploads/" || cfg.RoleARN != "arn:aws:iam::123456789012:role/test" {
+		t.Fatalf("unexpected trimmed aws fields: %+v", cfg)
+	}
+
+	unsetAll()
+	if err := os.Setenv("DRIVE9_S3_BUCKET", "bucket"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("DRIVE9_S3_DIR", " /tmp/custom-local-s3 "); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := localS3ConfigFromEnv(); err == nil {
+		t.Fatal("expected explicit local dir to conflict with aws bucket")
+	}
+
+	unsetAll()
+	if err := os.Setenv("DRIVE9_S3_DIR", " /tmp/local-s3//nested/ "); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = localS3ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("local config returned error: %v", err)
+	}
+	if cfg.Mode != "local" {
+		t.Fatalf("mode = %q, want local", cfg.Mode)
+	}
+	if cfg.Dir != "/tmp/local-s3/nested" {
+		t.Fatalf("dir = %q, want %q", cfg.Dir, "/tmp/local-s3/nested")
 	}
 }
 

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -229,6 +229,7 @@ environment:
   DRIVE9_ENCRYPT_KEY KMS key id or alias (required for kms)
   DRIVE9_TOKEN_SIGNING_KEY  32-byte hex key for JWT API key signing
   DRIVE9_MAX_UPLOAD_BYTES maximum allowed upload size in bytes (default: %d, minimum: 1048576)
+  DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
   DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)
   S3 storage (set DRIVE9_S3_BUCKET to enable AWS S3, otherwise local mock):
   DRIVE9_S3_BUCKET   S3 bucket name (enables AWS S3 mode)

--- a/cmd/drive9/cli/cp.go
+++ b/cmd/drive9/cli/cp.go
@@ -54,7 +54,7 @@ func Cp(c *client.Client, args []string) error {
 		if err != nil {
 			return err
 		}
-		emitUploadSummary(summary, "-")
+		emitUploadSummary(ctx, summary, "-")
 		return nil
 
 	case srcIsRemote && dst == "-":
@@ -93,7 +93,7 @@ func uploadFile(ctx context.Context, c *client.Client, localPath, remotePath str
 	if err != nil {
 		return err
 	}
-	emitUploadSummary(summary, localPath)
+	emitUploadSummary(ctx, summary, localPath)
 	return nil
 }
 
@@ -113,7 +113,7 @@ func resumeUpload(ctx context.Context, c *client.Client, localPath, remotePath s
 	if err != nil {
 		return err
 	}
-	emitUploadSummary(summary, localPath)
+	emitUploadSummary(ctx, summary, localPath)
 	return nil
 }
 
@@ -173,12 +173,12 @@ func emitDownloadSummary(summary *client.DownloadSummary) {
 	)
 }
 
-func emitUploadSummary(summary *client.UploadSummary, localPath string) {
+func emitUploadSummary(ctx context.Context, summary *client.UploadSummary, localPath string) {
 	if summary == nil || !logger.CLIEnabled() {
 		return
 	}
 	logger.Info(
-		context.Background(),
+		ctx,
 		"upload_summary",
 		zap.String("type", summary.Type),
 		zap.String("mode", summary.Mode),

--- a/cmd/drive9/cli/cp.go
+++ b/cmd/drive9/cli/cp.go
@@ -50,7 +50,12 @@ func Cp(c *client.Client, args []string) error {
 		if err != nil {
 			return fmt.Errorf("read stdin: %w", err)
 		}
-		return c.WriteStream(ctx, dstRP.Path, bytes.NewReader(data), int64(len(data)), printProgress)
+		summary, err := c.WriteStreamWithSummary(ctx, dstRP.Path, bytes.NewReader(data), int64(len(data)), printProgress)
+		if err != nil {
+			return err
+		}
+		emitUploadSummary(summary, "-")
+		return nil
 
 	case srcIsRemote && dst == "-":
 		return streamToStdout(ctx, c, srcRP.Path)
@@ -84,7 +89,12 @@ func uploadFile(ctx context.Context, c *client.Client, localPath, remotePath str
 		return fmt.Errorf("stat %s: %w", localPath, err)
 	}
 
-	return c.WriteStream(ctx, remotePath, f, info.Size(), printProgress)
+	summary, err := c.WriteStreamWithSummary(ctx, remotePath, f, info.Size(), printProgress)
+	if err != nil {
+		return err
+	}
+	emitUploadSummary(summary, localPath)
+	return nil
 }
 
 func resumeUpload(ctx context.Context, c *client.Client, localPath, remotePath string) error {
@@ -99,7 +109,12 @@ func resumeUpload(ctx context.Context, c *client.Client, localPath, remotePath s
 		return fmt.Errorf("stat %s: %w", localPath, err)
 	}
 
-	return c.ResumeUpload(ctx, remotePath, f, info.Size(), printProgress)
+	summary, err := c.ResumeUploadWithSummary(ctx, remotePath, f, info.Size(), printProgress)
+	if err != nil {
+		return err
+	}
+	emitUploadSummary(summary, localPath)
+	return nil
 }
 
 func downloadFile(ctx context.Context, c *client.Client, remotePath, localPath string) error {
@@ -155,5 +170,35 @@ func emitDownloadSummary(summary *client.DownloadSummary) {
 		zap.Float64("elapsed_seconds", summary.ElapsedSeconds),
 		zap.String("remote_path", summary.RemotePath),
 		zap.String("local_path", summary.LocalPath),
+	)
+}
+
+func emitUploadSummary(summary *client.UploadSummary, localPath string) {
+	if summary == nil || !logger.CLIEnabled() {
+		return
+	}
+	logger.Info(
+		context.Background(),
+		"upload_summary",
+		zap.String("type", summary.Type),
+		zap.String("mode", summary.Mode),
+		zap.Int64("total_bytes", summary.TotalBytes),
+		zap.Int64("part_size_bytes", summary.PartSizeBytes),
+		zap.Int("total_parts", summary.TotalParts),
+		zap.Int("uploaded_parts", summary.UploadedParts),
+		zap.Int("parallelism", summary.Parallelism),
+		zap.Time("started_at", summary.StartedAt),
+		zap.Time("finished_at", summary.FinishedAt),
+		zap.Float64("elapsed_seconds", summary.ElapsedSeconds),
+		zap.Float64("query_seconds", summary.QuerySeconds),
+		zap.Float64("checksum_seconds", summary.ChecksumSeconds),
+		zap.Float64("initiate_seconds", summary.InitiateSeconds),
+		zap.Float64("resume_seconds", summary.ResumeSeconds),
+		zap.Float64("presign_seconds", summary.PresignSeconds),
+		zap.Float64("upload_seconds", summary.UploadSeconds),
+		zap.Float64("complete_seconds", summary.CompleteSeconds),
+		zap.Float64("direct_write_seconds", summary.DirectWriteSeconds),
+		zap.String("remote_path", summary.RemotePath),
+		zap.String("local_path", localPath),
 	)
 }

--- a/cmd/drive9/cli/cp_test.go
+++ b/cmd/drive9/cli/cp_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -173,5 +174,69 @@ func TestDownloadFileSkipsDownloadSummaryWhenCLILogDisabled(t *testing.T) {
 	}
 	if strings.Contains(string(logBytes), "\"msg\":\"download_summary\"") {
 		t.Fatalf("expected no download summary in cli log, got %q", string(logBytes))
+	}
+}
+
+func TestUploadFileEmitsUploadSummaryToCLILog(t *testing.T) {
+	var uploaded bytes.Buffer
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "PUT /v1/fs/upload.txt":
+			data, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			uploaded.Write(data)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("DRIVE9_CLI_LOG_ENABLED", "true")
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	restoreLogger := logger.L()
+	cliLogger, err := logger.NewCLILogger()
+	if err != nil {
+		t.Fatalf("NewCLILogger: %v", err)
+	}
+	logger.Set(cliLogger)
+	defer logger.Set(restoreLogger)
+	defer func() { _ = cliLogger.Sync() }()
+
+	localPath := filepath.Join(t.TempDir(), "upload.txt")
+	if err := os.WriteFile(localPath, []byte("hello upload"), 0o644); err != nil {
+		t.Fatalf("WriteFile(local): %v", err)
+	}
+
+	c := client.New(srv.URL, "")
+	if err := uploadFile(context.Background(), c, localPath, "/upload.txt"); err != nil {
+		t.Fatalf("uploadFile: %v", err)
+	}
+	if got := uploaded.String(); got != "hello upload" {
+		t.Fatalf("uploaded body = %q, want %q", got, "hello upload")
+	}
+	if err := cliLogger.Sync(); err != nil {
+		t.Fatalf("Sync(cli log): %v", err)
+	}
+
+	logPath, err := logger.CLILogPath()
+	if err != nil {
+		t.Fatalf("CLILogPath: %v", err)
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(cli log): %v", err)
+	}
+	got := string(logBytes)
+	if !strings.Contains(got, "\"msg\":\"upload_summary\"") || !strings.Contains(got, "\"type\":\"upload_summary\"") {
+		t.Fatalf("cli log missing upload summary JSON: %q", got)
+	}
+	if !strings.Contains(got, "\"mode\":\"direct_put\"") {
+		t.Fatalf("cli log missing upload mode: %q", got)
 	}
 }

--- a/cmd/drive9/cli/cp_test.go
+++ b/cmd/drive9/cli/cp_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/mem9-ai/dat9/pkg/client"
 	"github.com/mem9-ai/dat9/pkg/logger"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestParseRemote(t *testing.T) {
@@ -238,5 +240,33 @@ func TestUploadFileEmitsUploadSummaryToCLILog(t *testing.T) {
 	}
 	if !strings.Contains(got, "\"mode\":\"direct_put\"") {
 		t.Fatalf("cli log missing upload mode: %q", got)
+	}
+}
+
+func TestEmitUploadSummaryUsesContextLogger(t *testing.T) {
+	t.Setenv("DRIVE9_CLI_LOG_ENABLED", "true")
+
+	core, recorded := observer.New(zap.InfoLevel)
+	ctx := logger.WithContext(context.Background(), zap.New(core))
+
+	emitUploadSummary(ctx, &client.UploadSummary{
+		Type:       "upload_summary",
+		Mode:       "direct_put",
+		RemotePath: "/upload.txt",
+	}, "/tmp/upload.txt")
+
+	entries := recorded.All()
+	if len(entries) != 1 {
+		t.Fatalf("recorded %d log entries, want 1", len(entries))
+	}
+	if entries[0].Message != "upload_summary" {
+		t.Fatalf("message = %q, want upload_summary", entries[0].Message)
+	}
+	fields := entries[0].ContextMap()
+	if fields["remote_path"] != "/upload.txt" {
+		t.Fatalf("remote_path = %#v, want %q", fields["remote_path"], "/upload.txt")
+	}
+	if fields["local_path"] != "/tmp/upload.txt" {
+		t.Fatalf("local_path = %#v, want %q", fields["local_path"], "/tmp/upload.txt")
 	}
 }

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/pprof"
+	"sync"
 
 	"github.com/mem9-ai/dat9/cmd/drive9/cli"
 	"github.com/mem9-ai/dat9/pkg/logger"
@@ -28,6 +29,8 @@ import (
 var version = "dev"
 var gitHash = "unknown"
 var cliLogger *zap.Logger
+var cpuProfileStop = func() {}
+var exitFunc = os.Exit
 
 func main() {
 	if logger.CLIEnabled() {
@@ -45,7 +48,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "drive9: %v\n", err)
 		os.Exit(1)
 	}
-	defer stopCPUProfile()
+	cpuProfileStop = stopCPUProfile
+	defer cpuProfileStop()
 
 	if len(os.Args) < 2 {
 		usage()
@@ -145,9 +149,12 @@ func startCPUProfileFromEnv() (func(), error) {
 		return nil, fmt.Errorf("start cpu profile %s: %w", profilePath, err)
 	}
 
+	var stopOnce sync.Once
 	return func() {
-		pprof.StopCPUProfile()
-		_ = f.Close()
+		stopOnce.Do(func() {
+			pprof.StopCPUProfile()
+			_ = f.Close()
+		})
 	}, nil
 }
 
@@ -197,9 +204,9 @@ func fatal(cmd string, err error) {
 	fmt.Fprintf(os.Stderr, "%s: %v\n", cmd, err)
 	type exitCoder interface{ ExitCode() int }
 	if ec, ok := err.(exitCoder); ok && ec.ExitCode() > 0 {
-		os.Exit(ec.ExitCode())
+		exitWithCode(ec.ExitCode())
 	}
-	os.Exit(1)
+	exitWithCode(1)
 }
 
 func usage() {
@@ -214,7 +221,7 @@ commands:
   mount <dir>      mount drive9 as a local FUSE filesystem
   umount <dir>     unmount a drive9 FUSE mount
 `)
-	os.Exit(2)
+	exitWithCode(2)
 }
 
 func fsUsage() {
@@ -236,5 +243,10 @@ commands:
     -older <YYYY-MM-DD>  modified before date
     -size <+N|-N>        size filter in bytes
 `)
-	os.Exit(2)
+	exitWithCode(2)
+}
+
+func exitWithCode(code int) {
+	cpuProfileStop()
+	exitFunc(code)
 }

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime/pprof"
 
 	"github.com/mem9-ai/dat9/cmd/drive9/cli"
 	"github.com/mem9-ai/dat9/pkg/logger"
@@ -38,6 +39,13 @@ func main() {
 			fmt.Fprintf(os.Stderr, "drive9: failed to initialize CLI logger: %v\n", err)
 		}
 	}
+
+	stopCPUProfile, err := startCPUProfileFromEnv()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "drive9: %v\n", err)
+		os.Exit(1)
+	}
+	defer stopCPUProfile()
 
 	if len(os.Args) < 2 {
 		usage()
@@ -120,6 +128,27 @@ func main() {
 
 func versionString() string {
 	return fmt.Sprintf("drive9 %s\nGit Commit Hash: %s\n", version, gitHash)
+}
+
+func startCPUProfileFromEnv() (func(), error) {
+	profilePath := os.Getenv("DRIVE9_PROF_CPU_PROFILE")
+	if profilePath == "" {
+		return func() {}, nil
+	}
+
+	f, err := os.Create(profilePath)
+	if err != nil {
+		return nil, fmt.Errorf("create cpu profile %s: %w", profilePath, err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("start cpu profile %s: %w", profilePath, err)
+	}
+
+	return func() {
+		pprof.StopCPUProfile()
+		_ = f.Close()
+	}, nil
 }
 
 func runFS(args []string) {

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -50,3 +50,26 @@ func TestStartCPUProfileFromEnv(t *testing.T) {
 		t.Fatalf("profile file is empty: %s", profilePath)
 	}
 }
+
+func TestExitWithCodeStopsCPUProfile(t *testing.T) {
+	origStop := cpuProfileStop
+	origExit := exitFunc
+	t.Cleanup(func() {
+		cpuProfileStop = origStop
+		exitFunc = origExit
+	})
+
+	stopped := false
+	exitCode := -1
+	cpuProfileStop = func() { stopped = true }
+	exitFunc = func(code int) { exitCode = code }
+
+	exitWithCode(7)
+
+	if !stopped {
+		t.Fatal("expected exitWithCode to stop CPU profiling")
+	}
+	if exitCode != 7 {
+		t.Fatalf("exit code = %d, want 7", exitCode)
+	}
+}

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestVersionStringIncludesGitHash(t *testing.T) {
@@ -21,5 +24,29 @@ func TestVersionStringIncludesGitHash(t *testing.T) {
 	}
 	if !strings.Contains(got, "Git Commit Hash: abc123\n") {
 		t.Fatalf("versionString() missing git hash line: %q", got)
+	}
+}
+
+func TestStartCPUProfileFromEnv(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), "drive9.cpu.pprof")
+	t.Setenv("DRIVE9_PROF_CPU_PROFILE", profilePath)
+
+	stopCPUProfile, err := startCPUProfileFromEnv()
+	if err != nil {
+		t.Fatalf("startCPUProfileFromEnv: %v", err)
+	}
+
+	deadline := time.Now().Add(20 * time.Millisecond)
+	for time.Now().Before(deadline) {
+	}
+
+	stopCPUProfile()
+
+	info, err := os.Stat(profilePath)
+	if err != nil {
+		t.Fatalf("Stat(profile): %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("profile file is empty: %s", profilePath)
 	}
 }

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -90,8 +90,12 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 	origSize := nf.File.SizeBytes
 
 	// Enforce one active upload per path
-	existing, err := b.store.GetUploadByPath(ctx, path)
-	if err == nil && existing != nil {
+	existing, err := b.activeUploadByPath(ctx, path)
+	if err != nil {
+		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		return nil, fmt.Errorf("lookup active upload for %s: %w", path, err)
+	}
+	if existing != nil {
 		metrics.RecordOperation("backend", "patch_upload", "conflict", time.Since(start))
 		return nil, datastore.ErrUploadConflict
 	}

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -410,7 +410,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		return nil, err
 	}
 	txDurationMs := uploadPhaseMs(txStart)
-	logger.Info(ctx, "backend_initiate_upload_v2_timing",
+	logger.InfoBenchTiming(ctx, "backend_initiate_upload_v2_timing",
 		zap.String("path", path),
 		zap.Int64("total_size", totalSize),
 		zap.Int("total_parts", len(parts)),
@@ -595,7 +595,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 	if len(entries) > 0 {
 		s3PresignAvgMs = s3PresignTotalMs / float64(len(entries))
 	}
-	logger.Info(ctx, "backend_presign_parts_timing",
+	logger.InfoBenchTiming(ctx, "backend_presign_parts_timing",
 		zap.String("upload_id", uploadID),
 		zap.String("status_before", string(statusBefore)),
 		zap.Int("entries_total", len(entries)),
@@ -714,7 +714,7 @@ func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clie
 		return err
 	}
 	finalizeDurationMs := uploadPhaseMs(finalizeStart)
-	logger.Info(ctx, "backend_confirm_upload_v2_timing",
+	logger.InfoBenchTiming(ctx, "backend_confirm_upload_v2_timing",
 		zap.String("upload_id", uploadID),
 		zap.Int("parts_total", upload.PartsTotal),
 		zap.Float64("get_upload_ms", getUploadDurationMs),
@@ -975,7 +975,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	if isOverwrite {
 		b.deleteBlobIfS3Ctx(ctx, oldStorageType, oldStorageRef, upload.S3Key)
 	}
-	logger.Info(ctx, "backend_finalize_upload_timing",
+	logger.InfoBenchTiming(ctx, "backend_finalize_upload_timing",
 		zap.String("upload_id", uploadID),
 		zap.String("path", upload.TargetPath),
 		zap.String("branch", branch),

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -65,6 +65,10 @@ func normalizeETag(etag string) string {
 	return strings.Trim(etag, "\"")
 }
 
+func uploadPhaseMs(start time.Time) float64 {
+	return float64(time.Since(start).Microseconds()) / 1000.0
+}
+
 // S3 returns the S3Client (nil when not configured).
 func (b *Dat9Backend) S3() s3client.S3Client { return b.s3 }
 
@@ -270,6 +274,7 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 // InitiateUploadV2IfRevision starts a v2 multipart upload with optional CAS semantics.
 func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path string, totalSize int64, expectedRevision int64) (*UploadPlanV2, error) {
 	start := time.Now()
+	validateStart := time.Now()
 	if err := b.ensureUploadSizeAllowed(totalSize); err != nil {
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
@@ -295,12 +300,15 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		}
 		return nil, err
 	}
+	validateDurationMs := uploadPhaseMs(validateStart)
 
+	activeUploadLookupStart := time.Now()
 	existing, err := b.store.GetUploadByPath(ctx, path)
 	if err == nil && existing != nil {
 		metrics.RecordOperation("backend", "initiate_upload_v2", "conflict", time.Since(start))
 		return nil, datastore.ErrUploadConflict
 	}
+	activeUploadLookupDurationMs := uploadPhaseMs(activeUploadLookupStart)
 
 	partSize := s3client.CalcAdaptivePartSize(totalSize)
 	parts := s3client.CalcParts(totalSize, partSize)
@@ -317,21 +325,30 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 	// v2 does not declare a checksum algorithm at the S3 level because the
 	// client doesn't send per-part checksums yet (ChecksumContract.Required=false).
 	// When #114 adds inline checksums, switch back to a concrete algorithm.
+	createMultipartStart := time.Now()
 	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoNone)
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_v2_create_multipart_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
+	createMultipartDurationMs := uploadPhaseMs(createMultipartStart)
 
 	now := time.Now()
 	uploadID := b.genID()
 	expiresAt := now.Add(24 * time.Hour)
 
+	txStart := time.Now()
+	var quotaDurationMs float64
+	var insertFileDurationMs float64
+	var insertUploadDurationMs float64
 	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
+		stepStart := time.Now()
 		if err := b.ensureTenantStorageQuotaTx(tx, path, totalSize); err != nil {
 			return err
 		}
+		quotaDurationMs = uploadPhaseMs(stepStart)
+		stepStart = time.Now()
 		if err := b.store.InsertFileTx(tx, &datastore.File{
 			FileID:      fileID,
 			StorageType: datastore.StorageS3,
@@ -343,7 +360,9 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		}); err != nil {
 			return err
 		}
-		return b.store.InsertUploadTx(tx, &datastore.Upload{
+		insertFileDurationMs = uploadPhaseMs(stepStart)
+		stepStart = time.Now()
+		if err := b.store.InsertUploadTx(tx, &datastore.Upload{
 			UploadID:         uploadID,
 			FileID:           fileID,
 			TargetPath:       path,
@@ -357,13 +376,32 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 			CreatedAt:        now,
 			UpdatedAt:        now,
 			ExpiresAt:        expiresAt,
-		})
+		}); err != nil {
+			return err
+		}
+		insertUploadDurationMs = uploadPhaseMs(stepStart)
+		return nil
 	}); err != nil {
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 		logger.Error(ctx, "backend_initiate_upload_v2_insert_upload_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
+	txDurationMs := uploadPhaseMs(txStart)
+	logger.Info(ctx, "backend_initiate_upload_v2_timing",
+		zap.String("path", path),
+		zap.Int64("total_size", totalSize),
+		zap.Int("total_parts", len(parts)),
+		zap.Int64("part_size", partSize),
+		zap.Float64("validate_target_ms", validateDurationMs),
+		zap.Float64("active_upload_lookup_ms", activeUploadLookupDurationMs),
+		zap.Float64("create_multipart_ms", createMultipartDurationMs),
+		zap.Float64("quota_check_ms", quotaDurationMs),
+		zap.Float64("insert_file_ms", insertFileDurationMs),
+		zap.Float64("insert_upload_ms", insertUploadDurationMs),
+		zap.Float64("tx_ms", txDurationMs),
+		zap.Float64("total_ms", uploadPhaseMs(start)),
+	)
 	metrics.RecordOperation("backend", "initiate_upload_v2", "ok", time.Since(start))
 
 	return &UploadPlanV2{
@@ -451,11 +489,14 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries []PresignPartEntry) ([]*s3client.UploadPartURL, error) {
 	start := time.Now()
 
+	getUploadStart := time.Now()
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
 		metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
 		return nil, err
 	}
+	getUploadDurationMs := uploadPhaseMs(getUploadStart)
+	statusBefore := upload.Status
 	if upload.Status != datastore.UploadUploading && upload.Status != datastore.UploadInitiated {
 		metrics.RecordOperation("backend", "presign_parts", "not_active", time.Since(start))
 		return nil, datastore.ErrUploadNotActive
@@ -478,17 +519,26 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		}
 		seen[e.PartNumber] = true
 	}
+	statusTransitionDurationMs := 0.0
 	if upload.Status == datastore.UploadInitiated {
+		statusTransitionStart := time.Now()
 		if err := b.store.TransitionUploadStatus(ctx, uploadID, datastore.UploadInitiated, datastore.UploadUploading); err != nil {
 			logger.Error(ctx, "backend_presign_parts_status_transition_failed", zap.String("upload_id", uploadID), zap.Error(err))
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
 			return nil, err
 		}
+		statusTransitionDurationMs = uploadPhaseMs(statusTransitionStart)
 	}
 
+	calcPartsStart := time.Now()
 	parts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
+	calcPartsDurationMs := uploadPhaseMs(calcPartsStart)
 
 	urls := make([]*s3client.UploadPartURL, len(entries))
+	presignLoopStart := time.Now()
+	resolveChecksumTotalMs := 0.0
+	s3PresignTotalMs := 0.0
+	s3PresignMaxMs := 0.0
 	for i, e := range entries {
 		pn := e.PartNumber
 		if pn < 1 || pn > upload.PartsTotal {
@@ -496,12 +546,21 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 			return nil, fmt.Errorf("invalid part number %d: must be between 1 and %d", pn, upload.PartsTotal)
 		}
 		partSize := parts[pn-1].Size
+		resolveChecksumStart := time.Now()
 		checksumSHA256, err := resolveChecksumSHA256(e.Checksum)
+		resolveChecksumDurationMs := uploadPhaseMs(resolveChecksumStart)
+		resolveChecksumTotalMs += resolveChecksumDurationMs
 		if err != nil {
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
 			return nil, err
 		}
+		s3PresignStart := time.Now()
 		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, pn, partSize, s3client.ChecksumAlgoSHA256, checksumSHA256, s3client.UploadTTL)
+		s3PresignDurationMs := uploadPhaseMs(s3PresignStart)
+		s3PresignTotalMs += s3PresignDurationMs
+		if s3PresignDurationMs > s3PresignMaxMs {
+			s3PresignMaxMs = s3PresignDurationMs
+		}
 		if err != nil {
 			logger.Error(ctx, "backend_presign_parts_failed", zap.String("upload_id", uploadID), zap.Int("part_number", pn), zap.Error(err))
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
@@ -509,6 +568,26 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		}
 		urls[i] = u
 	}
+	presignLoopDurationMs := uploadPhaseMs(presignLoopStart)
+	s3PresignAvgMs := 0.0
+	if len(entries) > 0 {
+		s3PresignAvgMs = s3PresignTotalMs / float64(len(entries))
+	}
+	logger.Info(ctx, "backend_presign_parts_timing",
+		zap.String("upload_id", uploadID),
+		zap.String("status_before", string(statusBefore)),
+		zap.Int("entries_total", len(entries)),
+		zap.Int("parts_total", upload.PartsTotal),
+		zap.Float64("get_upload_ms", getUploadDurationMs),
+		zap.Float64("status_transition_ms", statusTransitionDurationMs),
+		zap.Float64("calc_parts_ms", calcPartsDurationMs),
+		zap.Float64("resolve_checksum_total_ms", resolveChecksumTotalMs),
+		zap.Float64("presign_loop_total_ms", presignLoopDurationMs),
+		zap.Float64("s3_presign_total_ms", s3PresignTotalMs),
+		zap.Float64("s3_presign_avg_ms", s3PresignAvgMs),
+		zap.Float64("s3_presign_max_ms", s3PresignMaxMs),
+		zap.Float64("total_ms", uploadPhaseMs(start)),
+	)
 	metrics.RecordOperation("backend", "presign_parts", "ok", time.Since(start))
 	return urls, nil
 }
@@ -524,11 +603,13 @@ type CompletePart struct {
 func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clientParts []CompletePart) error {
 	start := time.Now()
 
+	getUploadStart := time.Now()
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
 		metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 		return err
 	}
+	getUploadDurationMs := uploadPhaseMs(getUploadStart)
 	if upload.Status != datastore.UploadUploading {
 		metrics.RecordOperation("backend", "confirm_upload_v2", "not_active", time.Since(start))
 		return datastore.ErrUploadNotActive
@@ -540,6 +621,7 @@ func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clie
 	}
 
 	// Validate client-supplied part count
+	clientValidationStart := time.Now()
 	if len(clientParts) != upload.PartsTotal {
 		metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 		return fmt.Errorf("part count mismatch: client sent %d, expected %d", len(clientParts), upload.PartsTotal)
@@ -558,16 +640,20 @@ func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clie
 		}
 		clientPartMap[cp.Number] = cp.ETag
 	}
+	clientValidationDurationMs := uploadPhaseMs(clientValidationStart)
 
 	// List uploaded parts from S3
+	listPartsStart := time.Now()
 	s3Parts, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
 	if err != nil {
 		logger.Error(ctx, "backend_confirm_upload_v2_list_parts_failed", zap.String("upload_id", uploadID), zap.Error(err))
 		metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 		return fmt.Errorf("list parts: %w", err)
 	}
+	listPartsDurationMs := uploadPhaseMs(listPartsStart)
 
 	// Cross-validate: every client part must match an S3 part ETag
+	etagValidationStart := time.Now()
 	s3PartMap := make(map[int]string, len(s3Parts))
 	for _, p := range s3Parts {
 		s3PartMap[p.Number] = p.ETag
@@ -583,8 +669,10 @@ func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clie
 			return fmt.Errorf("part %d ETag mismatch: client=%q, S3=%q", partNum, clientETag, s3ETag)
 		}
 	}
+	etagValidationDurationMs := uploadPhaseMs(etagValidationStart)
 
 	// Verify part sizes match expected layout.
+	sizeValidationStart := time.Now()
 	expectedParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	if len(s3Parts) != len(expectedParts) {
 		metrics.RecordOperation("backend", "confirm_upload_v2", "incomplete", time.Since(start))
@@ -596,10 +684,27 @@ func (b *Dat9Backend) ConfirmUploadV2(ctx context.Context, uploadID string, clie
 			return fmt.Errorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
 		}
 	}
+	sizeValidationDurationMs := uploadPhaseMs(sizeValidationStart)
 
 	// Complete using the already-validated parts — no second ListParts.
+	finalizeStart := time.Now()
+	if err := b.finalizeUpload(ctx, upload, s3Parts); err != nil {
+		return err
+	}
+	finalizeDurationMs := uploadPhaseMs(finalizeStart)
+	logger.Info(ctx, "backend_confirm_upload_v2_timing",
+		zap.String("upload_id", uploadID),
+		zap.Int("parts_total", upload.PartsTotal),
+		zap.Float64("get_upload_ms", getUploadDurationMs),
+		zap.Float64("client_validation_ms", clientValidationDurationMs),
+		zap.Float64("list_parts_ms", listPartsDurationMs),
+		zap.Float64("etag_validation_ms", etagValidationDurationMs),
+		zap.Float64("size_validation_ms", sizeValidationDurationMs),
+		zap.Float64("finalize_upload_ms", finalizeDurationMs),
+		zap.Float64("total_ms", uploadPhaseMs(start)),
+	)
 	metrics.RecordOperation("backend", "confirm_upload_v2", "ok", time.Since(start))
-	return b.finalizeUpload(ctx, upload, s3Parts)
+	return nil
 }
 
 // ConfirmUpload completes the multipart upload and creates the file node.
@@ -658,12 +763,13 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	uploadID := upload.UploadID
 	expectedRevision := uploadExpectedRevision(upload)
 
-	// Complete S3 multipart upload (idempotent, outside transaction)
+	completeMultipartStart := time.Now()
 	if err := b.s3.CompleteMultipartUpload(ctx, upload.S3Key, upload.S3UploadID, parts); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_complete_multipart_failed", zap.String("upload_id", uploadID), zap.Error(err))
 		metrics.RecordOperation("backend", "finalize_upload", "error", time.Since(start))
 		return fmt.Errorf("complete multipart: %w", err)
 	}
+	completeMultipartDurationMs := uploadPhaseMs(completeMultipartStart)
 
 	var oldStorageRef string
 	var oldStorageType datastore.StorageType
@@ -671,25 +777,44 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	var confirmedFileID string
 	var confirmedRevision int64
 	contentType := detectContentType(upload.TargetPath, nil)
+	branch := "create"
+	txStart := time.Now()
+	var completeUploadTxDurationMs float64
+	var ensureParentDirsDurationMs float64
+	var lookupExistingNodeDurationMs float64
+	var existingFileLookupDurationMs float64
+	var updateFileContentDurationMs float64
+	var confirmPendingFileDurationMs float64
+	var insertNodeDurationMs float64
+	var semanticEnqueueDurationMs float64
 	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
+		stepStart := time.Now()
 		if err := b.store.CompleteUploadTx(tx, uploadID); err != nil {
 			return err
 		}
+		completeUploadTxDurationMs = uploadPhaseMs(stepStart)
+
+		stepStart = time.Now()
 		if err := b.store.EnsureParentDirsTx(tx, upload.TargetPath, b.genID); err != nil {
 			return err
 		}
+		ensureParentDirsDurationMs = uploadPhaseMs(stepStart)
 
 		var existingFileID sql.NullString
+		stepStart = time.Now()
 		err := tx.QueryRow(`SELECT file_id FROM file_nodes WHERE path = ? FOR UPDATE`, upload.TargetPath).Scan(&existingFileID)
+		lookupExistingNodeDurationMs = uploadPhaseMs(stepStart)
 		if err == nil && existingFileID.Valid {
 			if expectedRevision == 0 {
 				return datastore.ErrRevisionConflict
 			}
 			isOverwrite = true
+			branch = "overwrite"
 			confirmedFileID = existingFileID.String
 
 			var oldRef string
 			var currentRevision int64
+			stepStart = time.Now()
 			if err := tx.QueryRow(`SELECT storage_type, storage_ref, revision FROM files WHERE file_id = ? AND status = 'CONFIRMED' FOR UPDATE`, existingFileID.String).Scan(&oldStorageType, &oldRef, &currentRevision); err == nil {
 				oldStorageRef = oldRef
 				if expectedRevision > 0 && currentRevision != expectedRevision {
@@ -700,8 +825,10 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 			} else {
 				return err
 			}
+			existingFileLookupDurationMs = uploadPhaseMs(stepStart)
 
 			var newRev int64
+			stepStart = time.Now()
 			if b.UsesDatabaseAutoEmbedding() && expectedRevision > 0 {
 				newRev, err = b.store.UpdateFileContentAutoEmbeddingIfRevisionTx(tx,
 					existingFileID.String, expectedRevision, datastore.StorageS3, upload.S3Key,
@@ -726,24 +853,27 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 			if err != nil {
 				return err
 			}
+			updateFileContentDurationMs = uploadPhaseMs(stepStart)
 			confirmedRevision = newRev
 
-			_, err = tx.Exec(`UPDATE files SET status = 'DELETED', storage_ref = '' WHERE file_id = ?`, upload.FileID)
-			if err != nil {
+			if _, err = tx.Exec(`UPDATE files SET status = 'DELETED', storage_ref = '' WHERE file_id = ?`, upload.FileID); err != nil {
 				return err
 			}
-			// Rebind upload record to the surviving inode so the uploads row
-			// never points at a tombstoned file.
-			_, err = tx.Exec(`UPDATE uploads SET file_id = ? WHERE upload_id = ?`,
-				existingFileID.String, uploadID)
-			if err != nil {
+			if _, err = tx.Exec(`UPDATE uploads SET file_id = ? WHERE upload_id = ?`,
+				existingFileID.String, uploadID); err != nil {
 				return err
 			}
 			if b.UsesDatabaseAutoEmbedding() {
-				return b.enqueueTiDBAutoSemanticTasksTx(tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+				stepStart = time.Now()
+				err := b.enqueueTiDBAutoSemanticTasksTx(tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+				semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
+				return err
 			}
 			if b.shouldEnqueueEmbedForRevision(upload.TargetPath, contentType, "") {
-				return b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
+				stepStart = time.Now()
+				err := b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
+				semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
+				return err
 			}
 			return nil
 		}
@@ -755,13 +885,16 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		}
 
 		if b.UsesDatabaseAutoEmbedding() {
+			stepStart = time.Now()
 			if err := b.store.ConfirmPendingFileAutoEmbeddingTx(tx,
 				upload.FileID, datastore.StorageS3, upload.S3Key, contentType, upload.TotalSize,
 			); err != nil {
 				return err
 			}
+			confirmPendingFileDurationMs = uploadPhaseMs(stepStart)
 		} else {
 			now := time.Now().UTC()
+			stepStart = time.Now()
 			res, err := tx.Exec(`UPDATE files SET storage_type = ?, storage_ref = ?, content_type = ?,
 				size_bytes = ?, checksum_sha256 = NULL, content_text = NULL,
 				embedding = NULL, embedding_revision = NULL,
@@ -778,9 +911,11 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 			if rowsAffected == 0 {
 				return datastore.ErrNotFound
 			}
+			confirmPendingFileDurationMs = uploadPhaseMs(stepStart)
 		}
 		confirmedFileID = upload.FileID
 		confirmedRevision = 1
+		stepStart = time.Now()
 		if err := b.store.InsertNodeTx(tx, &datastore.FileNode{
 			NodeID:     b.genID(),
 			Path:       upload.TargetPath,
@@ -794,11 +929,18 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 			}
 			return err
 		}
+		insertNodeDurationMs = uploadPhaseMs(stepStart)
 		if b.UsesDatabaseAutoEmbedding() {
-			return b.enqueueTiDBAutoSemanticTasksTx(tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+			stepStart = time.Now()
+			err := b.enqueueTiDBAutoSemanticTasksTx(tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
+			return err
 		}
 		if b.shouldEnqueueEmbedForRevision(upload.TargetPath, contentType, "") {
-			return b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
+			stepStart = time.Now()
+			err := b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
+			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
+			return err
 		}
 		return nil
 	}); err != nil {
@@ -807,9 +949,27 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		metrics.RecordOperation("backend", "finalize_upload", "error", time.Since(start))
 		return err
 	}
+	txDurationMs := uploadPhaseMs(txStart)
 	if isOverwrite {
 		b.deleteBlobIfS3Ctx(ctx, oldStorageType, oldStorageRef, upload.S3Key)
 	}
+	logger.Info(ctx, "backend_finalize_upload_timing",
+		zap.String("upload_id", uploadID),
+		zap.String("path", upload.TargetPath),
+		zap.String("branch", branch),
+		zap.Int("parts_total", len(parts)),
+		zap.Float64("complete_multipart_ms", completeMultipartDurationMs),
+		zap.Float64("complete_upload_tx_ms", completeUploadTxDurationMs),
+		zap.Float64("ensure_parent_dirs_ms", ensureParentDirsDurationMs),
+		zap.Float64("lookup_existing_node_ms", lookupExistingNodeDurationMs),
+		zap.Float64("existing_file_lookup_ms", existingFileLookupDurationMs),
+		zap.Float64("update_file_content_ms", updateFileContentDurationMs),
+		zap.Float64("confirm_pending_file_ms", confirmPendingFileDurationMs),
+		zap.Float64("insert_node_ms", insertNodeDurationMs),
+		zap.Float64("semantic_enqueue_ms", semanticEnqueueDurationMs),
+		zap.Float64("tx_ms", txDurationMs),
+		zap.Float64("total_ms", uploadPhaseMs(start)),
+	)
 	if b.UsesDatabaseAutoEmbedding() {
 		metrics.RecordOperation("backend", "finalize_upload", "ok", time.Since(start))
 		return nil

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -60,6 +60,9 @@ type PresignPartEntry struct {
 }
 
 var ErrPartChecksumCountMismatch = errors.New("part checksum count mismatch")
+var lookupActiveUploadByPath = func(store *datastore.Store, ctx context.Context, path string) (*datastore.Upload, error) {
+	return store.GetUploadByPath(ctx, path)
+}
 
 func normalizeETag(etag string) string {
 	return strings.Trim(etag, "\"")
@@ -85,6 +88,17 @@ func uploadExpectedRevision(upload *datastore.Upload) int64 {
 		return -1
 	}
 	return *upload.ExpectedRevision
+}
+
+func (b *Dat9Backend) activeUploadByPath(ctx context.Context, path string) (*datastore.Upload, error) {
+	upload, err := lookupActiveUploadByPath(b.store, ctx, path)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return upload, nil
 }
 
 func (b *Dat9Backend) validateUploadTargetRevision(ctx context.Context, path string, expectedRevision int64) error {
@@ -175,8 +189,12 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 	}
 
 	// Enforce one active upload per path
-	existing, err := b.store.GetUploadByPath(ctx, path)
-	if err == nil && existing != nil {
+	existing, err := b.activeUploadByPath(ctx, path)
+	if err != nil {
+		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		return nil, fmt.Errorf("lookup active upload for %s: %w", path, err)
+	}
+	if existing != nil {
 		metrics.RecordOperation("backend", "initiate_upload", "conflict", time.Since(start))
 		return nil, datastore.ErrUploadConflict
 	}
@@ -303,12 +321,16 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 	validateDurationMs := uploadPhaseMs(validateStart)
 
 	activeUploadLookupStart := time.Now()
-	existing, err := b.store.GetUploadByPath(ctx, path)
-	if err == nil && existing != nil {
+	existing, err := b.activeUploadByPath(ctx, path)
+	activeUploadLookupDurationMs := uploadPhaseMs(activeUploadLookupStart)
+	if err != nil {
+		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		return nil, fmt.Errorf("lookup active upload for %s: %w", path, err)
+	}
+	if existing != nil {
 		metrics.RecordOperation("backend", "initiate_upload_v2", "conflict", time.Since(start))
 		return nil, datastore.ErrUploadConflict
 	}
-	activeUploadLookupDurationMs := uploadPhaseMs(activeUploadLookupStart)
 
 	partSize := s3client.CalcAdaptivePartSize(totalSize)
 	parts := s3client.CalcParts(totalSize, partSize)

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -108,6 +108,42 @@ func TestIsLargeFile(t *testing.T) {
 	}
 }
 
+func TestInitiateUploadPropagatesActiveUploadLookupError(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	origLookup := lookupActiveUploadByPath
+	t.Cleanup(func() { lookupActiveUploadByPath = origLookup })
+
+	lookupActiveUploadByPath = func(*datastore.Store, context.Context, string) (*datastore.Upload, error) {
+		return nil, errors.New("lookup failed")
+	}
+
+	_, err := b.InitiateUpload(context.Background(), "/lookup-error.bin", 2<<20)
+	if err == nil {
+		t.Fatal("expected initiate upload to fail")
+	}
+	if !strings.Contains(err.Error(), "lookup active upload") || !strings.Contains(err.Error(), "lookup failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInitiateUploadV2PropagatesActiveUploadLookupError(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	origLookup := lookupActiveUploadByPath
+	t.Cleanup(func() { lookupActiveUploadByPath = origLookup })
+
+	lookupActiveUploadByPath = func(*datastore.Store, context.Context, string) (*datastore.Upload, error) {
+		return nil, errors.New("lookup failed")
+	}
+
+	_, err := b.InitiateUploadV2(context.Background(), "/lookup-error-v2.bin", 2<<20)
+	if err == nil {
+		t.Fatal("expected initiate upload v2 to fail")
+	}
+	if !strings.Contains(err.Error(), "lookup active upload") || !strings.Contains(err.Error(), "lookup failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestInitiateAndConfirmUpload(t *testing.T) {
 	b := newTestBackendWithS3(t)
 	ctx := context.Background()

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -112,6 +112,30 @@ type DownloadSummary struct {
 	LocalPath      string    `json:"local_path"`
 }
 
+// UploadSummary exposes coarse-grained upload timings for CLI benchmark and
+// diagnosis workflows.
+type UploadSummary struct {
+	Type               string    `json:"type"`
+	Mode               string    `json:"mode"`
+	StartedAt          time.Time `json:"started_at"`
+	FinishedAt         time.Time `json:"finished_at"`
+	ElapsedSeconds     float64   `json:"elapsed_seconds"`
+	RemotePath         string    `json:"remote_path"`
+	TotalBytes         int64     `json:"total_bytes"`
+	PartSizeBytes      int64     `json:"part_size_bytes"`
+	TotalParts         int       `json:"total_parts"`
+	UploadedParts      int       `json:"uploaded_parts"`
+	Parallelism        int       `json:"parallelism"`
+	QuerySeconds       float64   `json:"query_seconds"`
+	ChecksumSeconds    float64   `json:"checksum_seconds"`
+	InitiateSeconds    float64   `json:"initiate_seconds"`
+	ResumeSeconds      float64   `json:"resume_seconds"`
+	PresignSeconds     float64   `json:"presign_seconds"`
+	UploadSeconds      float64   `json:"upload_seconds"`
+	CompleteSeconds    float64   `json:"complete_seconds"`
+	DirectWriteSeconds float64   `json:"direct_write_seconds"`
+}
+
 type downloadRange struct {
 	offset int64
 	length int64
@@ -197,52 +221,139 @@ func (p *uploadBufferPool) put(buf []byte) {
 // it does a direct PUT with body. For large files, it tries the v2 protocol
 // (on-demand presign, no upfront checksum) first, falling back to v1 on 404.
 func (c *Client) WriteStream(ctx context.Context, path string, r io.Reader, size int64, progress ProgressFunc) error {
-	return c.WriteStreamConditional(ctx, path, r, size, progress, -1)
+	_, err := c.WriteStreamWithSummary(ctx, path, r, size, progress)
+	return err
+}
+
+// WriteStreamWithSummary uploads data from a reader and returns coarse-grained
+// phase timings for the completed upload.
+func (c *Client) WriteStreamWithSummary(ctx context.Context, path string, r io.Reader, size int64, progress ProgressFunc) (*UploadSummary, error) {
+	return c.writeStreamConditionalWithSummary(ctx, path, r, size, progress, -1)
 }
 
 // WriteStreamConditional uploads data from a reader with optional CAS semantics.
 func (c *Client) WriteStreamConditional(ctx context.Context, path string, r io.Reader, size int64, progress ProgressFunc, expectedRevision int64) error {
+	_, err := c.writeStreamConditionalWithSummary(ctx, path, r, size, progress, expectedRevision)
+	return err
+}
+
+func (c *Client) writeStreamConditionalWithSummary(ctx context.Context, path string, r io.Reader, size int64, progress ProgressFunc, expectedRevision int64) (*UploadSummary, error) {
 	threshold := int64(DefaultSmallFileThreshold)
 	if c.smallFileThreshold > 0 {
 		threshold = c.smallFileThreshold
 	}
+	summary := &UploadSummary{
+		Type:       "upload_summary",
+		StartedAt:  time.Now(),
+		RemotePath: path,
+		TotalBytes: size,
+	}
 	if size < threshold {
+		summary.Mode = "direct_put"
+		summary.PartSizeBytes = size
+		summary.TotalParts = 1
+		summary.UploadedParts = 1
+		summary.Parallelism = 1
 		// Small file: direct PUT with body
+		directWriteStart := time.Now()
 		data, err := io.ReadAll(r)
 		if err != nil {
-			return fmt.Errorf("read data: %w", err)
+			return nil, fmt.Errorf("read data: %w", err)
 		}
-		return c.WriteCtxConditional(ctx, path, data, expectedRevision)
+		if err := c.WriteCtxConditional(ctx, path, data, expectedRevision); err != nil {
+			return nil, err
+		}
+		summary.DirectWriteSeconds = time.Since(directWriteStart).Seconds()
+		return finishUploadSummary(summary), nil
 	}
 	ra, ok := r.(io.ReaderAt)
 	if !ok {
-		return fmt.Errorf("large uploads require an io.ReaderAt (seekable source)")
+		return nil, fmt.Errorf("large uploads require an io.ReaderAt (seekable source)")
 	}
 
 	// Try v2 protocol first (on-demand presign, no checksum pre-computation).
-	err := c.writeStreamV2(ctx, path, ra, size, progress, expectedRevision)
+	err := c.writeStreamV2WithSummary(ctx, path, ra, size, progress, expectedRevision, summary)
 	if err == errV2NotAvailable {
 		// Server doesn't support v2 — fall back to v1.
-		return c.writeStreamV1(ctx, path, ra, size, progress, expectedRevision)
+		if err := c.writeStreamV1WithSummary(ctx, path, ra, size, progress, expectedRevision, summary); err != nil {
+			return nil, err
+		}
+		return finishUploadSummary(summary), nil
 	}
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return finishUploadSummary(summary), nil
 }
 
 // errV2NotAvailable is a sentinel indicating the server returned 404 for
 // the v2 initiate endpoint, so the caller should fall back to v1.
 var errV2NotAvailable = fmt.Errorf("v2 upload API not available")
 
+func finishUploadSummary(summary *UploadSummary) *UploadSummary {
+	if summary == nil {
+		return nil
+	}
+	summary.FinishedAt = time.Now()
+	summary.ElapsedSeconds = summary.FinishedAt.Sub(summary.StartedAt).Seconds()
+	return summary
+}
+
 // writeStreamV1 is the original v1 upload path: pre-compute checksums → initiate → upload all.
 func (c *Client) writeStreamV1(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc, expectedRevision int64) error {
+	return c.writeStreamV1WithSummary(ctx, path, ra, size, progress, expectedRevision, nil)
+}
+
+func (c *Client) writeStreamV1WithSummary(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc, expectedRevision int64, summary *UploadSummary) error {
+	if summary != nil {
+		summary.Mode = "multipart_v1"
+	}
+
+	checksumStart := time.Now()
 	checksums, err := computePartChecksumsFromReaderAt(ra, size, s3client.PartSize)
 	if err != nil {
 		return fmt.Errorf("compute part checksums: %w", err)
 	}
+	if summary != nil {
+		summary.ChecksumSeconds = time.Since(checksumStart).Seconds()
+	}
+
+	initiateStart := time.Now()
 	plan, err := c.initiateUpload(ctx, path, size, checksums, expectedRevision)
 	if err != nil {
 		return err
 	}
-	return c.uploadParts(ctx, plan, ra, progress)
+	if summary != nil {
+		summary.InitiateSeconds = time.Since(initiateStart).Seconds()
+		stdPartSize := plan.PartSize
+		if stdPartSize <= 0 && len(plan.Parts) > 0 {
+			stdPartSize = plan.Parts[0].Size
+		}
+		if stdPartSize <= 0 {
+			stdPartSize = s3client.PartSize
+		}
+		summary.PartSizeBytes = stdPartSize
+		summary.TotalParts = len(plan.Parts)
+		summary.UploadedParts = len(plan.Parts)
+		summary.Parallelism = uploadParallelism(stdPartSize)
+	}
+
+	uploadStart := time.Now()
+	if err := c.uploadPartsOnly(ctx, plan, ra, progress); err != nil {
+		return err
+	}
+	if summary != nil {
+		summary.UploadSeconds = time.Since(uploadStart).Seconds()
+	}
+
+	completeStart := time.Now()
+	if err := c.completeUpload(ctx, plan.UploadID); err != nil {
+		return err
+	}
+	if summary != nil {
+		summary.CompleteSeconds = time.Since(completeStart).Seconds()
+	}
+	return nil
 }
 
 // writeStreamV2 implements the v2 upload protocol:
@@ -251,9 +362,22 @@ func (c *Client) writeStreamV1(ctx context.Context, path string, ra io.ReaderAt,
 // 3. Upload goroutines consume presigned URLs from channel
 // 4. Complete with part ETags, or abort on failure
 func (c *Client) writeStreamV2(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc, expectedRevision int64) error {
+	return c.writeStreamV2WithSummary(ctx, path, ra, size, progress, expectedRevision, nil)
+}
+
+func (c *Client) writeStreamV2WithSummary(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc, expectedRevision int64, summary *UploadSummary) error {
+	initiateStart := time.Now()
 	plan, err := c.initiateUploadV2(ctx, path, size, expectedRevision)
 	if err != nil {
 		return err
+	}
+	if summary != nil {
+		summary.Mode = "multipart_v2"
+		summary.InitiateSeconds = time.Since(initiateStart).Seconds()
+		summary.PartSizeBytes = plan.PartSize
+		summary.TotalParts = plan.TotalParts
+		summary.UploadedParts = plan.TotalParts
+		summary.Parallelism = uploadParallelism(plan.PartSize)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -263,21 +387,39 @@ func (c *Client) writeStreamV2(ctx context.Context, path string, ra io.ReaderAt,
 	parallelism := uploadParallelism(plan.PartSize)
 	presignCh := make(chan presignedPart, parallelism)
 	presignErrCh := make(chan error, 1)
+	presignDurationCh := make(chan time.Duration, 1)
 
-	go c.presignPipeline(ctx, plan, parallelism, presignCh, presignErrCh)
+	go func() {
+		start := time.Now()
+		c.presignPipeline(ctx, plan, parallelism, presignCh, presignErrCh)
+		presignDurationCh <- time.Since(start)
+	}()
 
 	// Upload parts, collecting ETags for the complete call.
+	uploadStart := time.Now()
 	parts, err := c.uploadPartsV2(ctx, plan, ra, presignCh, presignErrCh, progress)
 	if err != nil {
 		_ = c.abortUploadV2(context.Background(), plan.UploadID)
 		return err
 	}
+	if summary != nil {
+		summary.UploadSeconds = time.Since(uploadStart).Seconds()
+		select {
+		case dur := <-presignDurationCh:
+			summary.PresignSeconds = dur.Seconds()
+		default:
+		}
+	}
 
+	completeStart := time.Now()
 	if err := c.completeUploadV2(ctx, plan.UploadID, parts); err != nil {
 		// Complete failed (network error, 5xx, 409, 410) — best-effort abort
 		// to avoid leaving orphaned multipart uploads / upload rows.
 		_ = c.abortUploadV2(context.Background(), plan.UploadID)
 		return err
+	}
+	if summary != nil {
+		summary.CompleteSeconds = time.Since(completeStart).Seconds()
 	}
 	return nil
 }
@@ -385,6 +527,13 @@ func (c *Client) initiateUploadLegacy(ctx context.Context, path string, size int
 // Each goroutine reads its part directly via ReaderAt (parallel disk reads),
 // with at most maxConcurrency in-flight to bound memory usage.
 func (c *Client) uploadParts(ctx context.Context, plan UploadPlan, ra io.ReaderAt, progress ProgressFunc) error {
+	if err := c.uploadPartsOnly(ctx, plan, ra, progress); err != nil {
+		return err
+	}
+	return c.completeUpload(ctx, plan.UploadID)
+}
+
+func (c *Client) uploadPartsOnly(ctx context.Context, plan UploadPlan, ra io.ReaderAt, progress ProgressFunc) error {
 	stdPartSize := plan.PartSize
 	if stdPartSize <= 0 && len(plan.Parts) > 0 {
 		stdPartSize = plan.Parts[0].Size
@@ -474,7 +623,7 @@ func (c *Client) uploadParts(ctx context.Context, plan UploadPlan, ra io.ReaderA
 	default:
 	}
 
-	return c.completeUpload(ctx, plan.UploadID)
+	return nil
 }
 
 // uploadOnePart PUTs data to a presigned URL and returns the ETag.
@@ -1240,34 +1389,72 @@ type UploadMeta struct {
 // ResumeUpload queries for an incomplete upload and resumes it.
 // Two-step flow: GET query → POST resume (get missing part URLs) → upload → complete.
 func (c *Client) ResumeUpload(ctx context.Context, path string, r io.ReaderAt, totalSize int64, progress ProgressFunc) error {
-	// Step 1: Query for active upload (no side effects)
-	meta, err := c.queryUpload(ctx, path)
-	if err != nil {
-		return err
+	_, err := c.ResumeUploadWithSummary(ctx, path, r, totalSize, progress)
+	return err
+}
+
+// ResumeUploadWithSummary resumes an incomplete upload and returns coarse-grained
+// phase timings for the completed resume flow.
+func (c *Client) ResumeUploadWithSummary(ctx context.Context, path string, r io.ReaderAt, totalSize int64, progress ProgressFunc) (*UploadSummary, error) {
+	summary := &UploadSummary{
+		Type:       "upload_summary",
+		Mode:       "resume_v1",
+		StartedAt:  time.Now(),
+		RemotePath: path,
+		TotalBytes: totalSize,
 	}
 
+	// Step 1: Query for active upload (no side effects)
+	queryStart := time.Now()
+	meta, err := c.queryUpload(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	summary.QuerySeconds = time.Since(queryStart).Seconds()
+
 	// Step 2: Request resume — server returns presigned URLs for missing parts
+	checksumStart := time.Now()
 	checksums, err := computePartChecksumsFromReaderAt(r, totalSize, s3client.PartSize)
 	if err != nil {
-		return fmt.Errorf("compute part checksums: %w", err)
+		return nil, fmt.Errorf("compute part checksums: %w", err)
 	}
+	summary.ChecksumSeconds = time.Since(checksumStart).Seconds()
+
+	resumeStart := time.Now()
 	plan, err := c.requestResume(ctx, meta.UploadID, checksums)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	summary.ResumeSeconds = time.Since(resumeStart).Seconds()
+	summary.PartSizeBytes = plan.PartSize
+	summary.TotalParts = meta.PartsTotal
+	summary.UploadedParts = len(plan.Parts)
+	summary.Parallelism = uploadParallelism(plan.PartSize)
 
 	if len(plan.Parts) == 0 {
 		// All parts uploaded, just complete
-		return c.completeUpload(ctx, plan.UploadID)
+		completeStart := time.Now()
+		if err := c.completeUpload(ctx, plan.UploadID); err != nil {
+			return nil, err
+		}
+		summary.CompleteSeconds = time.Since(completeStart).Seconds()
+		return finishUploadSummary(summary), nil
 	}
 
 	// Step 3: Upload missing parts concurrently
+	uploadStart := time.Now()
 	if err := c.uploadMissingParts(ctx, *plan, r, meta.PartsTotal, progress); err != nil {
-		return err
+		return nil, err
 	}
+	summary.UploadSeconds = time.Since(uploadStart).Seconds()
 
 	// Step 4: Complete
-	return c.completeUpload(ctx, plan.UploadID)
+	completeStart := time.Now()
+	if err := c.completeUpload(ctx, plan.UploadID); err != nil {
+		return nil, err
+	}
+	summary.CompleteSeconds = time.Since(completeStart).Seconds()
+	return finishUploadSummary(summary), nil
 }
 
 // queryUpload finds an active upload for the given path.

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -299,11 +299,6 @@ func finishUploadSummary(summary *UploadSummary) *UploadSummary {
 	return summary
 }
 
-// writeStreamV1 is the original v1 upload path: pre-compute checksums → initiate → upload all.
-func (c *Client) writeStreamV1(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc, expectedRevision int64) error {
-	return c.writeStreamV1WithSummary(ctx, path, ra, size, progress, expectedRevision, nil)
-}
-
 func (c *Client) writeStreamV1WithSummary(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc, expectedRevision int64, summary *UploadSummary) error {
 	if summary != nil {
 		summary.Mode = "multipart_v1"
@@ -354,15 +349,6 @@ func (c *Client) writeStreamV1WithSummary(ctx context.Context, path string, ra i
 		summary.CompleteSeconds = time.Since(completeStart).Seconds()
 	}
 	return nil
-}
-
-// writeStreamV2 implements the v2 upload protocol:
-// 1. Initiate (no checksums, server returns part_size + total_parts)
-// 2. Pipelined presign: background goroutine fetches presigned URLs in batches
-// 3. Upload goroutines consume presigned URLs from channel
-// 4. Complete with part ETags, or abort on failure
-func (c *Client) writeStreamV2(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc, expectedRevision int64) error {
-	return c.writeStreamV2WithSummary(ctx, path, ra, size, progress, expectedRevision, nil)
 }
 
 func (c *Client) writeStreamV2WithSummary(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc, expectedRevision int64, summary *UploadSummary) error {
@@ -521,16 +507,6 @@ func (c *Client) initiateUploadLegacy(ctx context.Context, path string, size int
 		return UploadPlan{}, fmt.Errorf("decode upload plan: %w", err)
 	}
 	return plan, nil
-}
-
-// uploadParts concurrently uploads parts to presigned URLs.
-// Each goroutine reads its part directly via ReaderAt (parallel disk reads),
-// with at most maxConcurrency in-flight to bound memory usage.
-func (c *Client) uploadParts(ctx context.Context, plan UploadPlan, ra io.ReaderAt, progress ProgressFunc) error {
-	if err := c.uploadPartsOnly(ctx, plan, ra, progress); err != nil {
-		return err
-	}
-	return c.completeUpload(ctx, plan.UploadID)
 }
 
 func (c *Client) uploadPartsOnly(ctx context.Context, plan UploadPlan, ra io.ReaderAt, progress ProgressFunc) error {

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/s3client"
@@ -153,6 +154,24 @@ type readTarget struct {
 type uploadBufferPool struct {
 	size int64
 	ch   chan []byte
+}
+
+type uploadDurationRecorder struct {
+	nanos atomic.Int64
+}
+
+func (r *uploadDurationRecorder) Add(d time.Duration) {
+	if r == nil || d <= 0 {
+		return
+	}
+	r.nanos.Add(d.Nanoseconds())
+}
+
+func (r *uploadDurationRecorder) Seconds() float64 {
+	if r == nil {
+		return 0
+	}
+	return time.Duration(r.nanos.Load()).Seconds()
 }
 
 func uploadParallelism(partSize int64) int {
@@ -373,28 +392,22 @@ func (c *Client) writeStreamV2WithSummary(ctx context.Context, path string, ra i
 	parallelism := uploadParallelism(plan.PartSize)
 	presignCh := make(chan presignedPart, parallelism)
 	presignErrCh := make(chan error, 1)
-	presignDurationCh := make(chan time.Duration, 1)
+	presignRecorder := &uploadDurationRecorder{}
 
 	go func() {
-		start := time.Now()
-		c.presignPipeline(ctx, plan, parallelism, presignCh, presignErrCh)
-		presignDurationCh <- time.Since(start)
+		c.presignPipeline(ctx, plan, parallelism, presignCh, presignErrCh, presignRecorder)
 	}()
 
 	// Upload parts, collecting ETags for the complete call.
 	uploadStart := time.Now()
-	parts, err := c.uploadPartsV2(ctx, plan, ra, presignCh, presignErrCh, progress)
+	parts, err := c.uploadPartsV2(ctx, plan, ra, presignCh, presignErrCh, presignRecorder, progress)
 	if err != nil {
 		_ = c.abortUploadV2(context.Background(), plan.UploadID)
 		return err
 	}
 	if summary != nil {
 		summary.UploadSeconds = time.Since(uploadStart).Seconds()
-		select {
-		case dur := <-presignDurationCh:
-			summary.PresignSeconds = dur.Seconds()
-		default:
-		}
+		summary.PresignSeconds = presignRecorder.Seconds()
 	}
 
 	completeStart := time.Now()
@@ -698,7 +711,7 @@ func (c *Client) initiateUploadV2(ctx context.Context, path string, size int64, 
 // presignPipeline runs in a background goroutine. It fetches presigned URLs
 // in batches via POST /v2/uploads/{id}/presign-batch and sends them to presignCh.
 // The channel is closed when all parts have been presigned or an error occurs.
-func (c *Client) presignPipeline(ctx context.Context, plan *uploadPlanV2, batchSize int, presignCh chan<- presignedPart, errCh chan<- error) {
+func (c *Client) presignPipeline(ctx context.Context, plan *uploadPlanV2, batchSize int, presignCh chan<- presignedPart, errCh chan<- error, recorder *uploadDurationRecorder) {
 	defer close(presignCh)
 
 	for start := 1; start <= plan.TotalParts; start += batchSize {
@@ -733,6 +746,7 @@ func (c *Client) presignPipeline(ctx context.Context, plan *uploadPlanV2, batchS
 		}
 		req.Header.Set("Content-Type", "application/json")
 
+		batchStart := time.Now()
 		resp, err := c.do(req)
 		if err != nil {
 			errCh <- fmt.Errorf("presign batch: %w", err)
@@ -755,6 +769,7 @@ func (c *Client) presignPipeline(ctx context.Context, plan *uploadPlanV2, batchS
 			return
 		}
 		_ = resp.Body.Close()
+		recorder.Add(time.Since(batchStart))
 
 		for _, p := range result.Parts {
 			select {
@@ -770,7 +785,7 @@ func (c *Client) presignPipeline(ctx context.Context, plan *uploadPlanV2, batchS
 // uploadPartsV2 reads presigned URLs from presignCh and uploads parts concurrently.
 // Returns the completed parts (number + etag) in order.
 func (c *Client) uploadPartsV2(ctx context.Context, plan *uploadPlanV2, ra io.ReaderAt,
-	presignCh <-chan presignedPart, presignErrCh <-chan error, progress ProgressFunc) ([]completePart, error) {
+	presignCh <-chan presignedPart, presignErrCh <-chan error, recorder *uploadDurationRecorder, progress ProgressFunc) ([]completePart, error) {
 
 	parallelism := uploadParallelism(plan.PartSize)
 	bufferPool := newUploadBufferPool(plan.PartSize, parallelism)
@@ -842,7 +857,9 @@ func (c *Client) uploadPartsV2(ctx context.Context, plan *uploadPlanV2, ra io.Re
 			etag, err := c.uploadOnePartV2(ctx, p, data)
 			if err == errPresignExpired {
 				// Presigned URL expired — fetch a fresh one and retry once.
+				presignStart := time.Now()
 				fresh, presignErr := c.presignOnePart(ctx, plan.UploadID, p.Number)
+				recorder.Add(time.Since(presignStart))
 				if presignErr != nil {
 					select {
 					case errCh <- fmt.Errorf("re-presign part %d: %w", p.Number, presignErr):

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -602,6 +603,74 @@ func TestWriteStreamV2RePresignsExpiredPart(t *testing.T) {
 	}
 	if !completeCalled.Load() {
 		t.Fatal("complete was not called after re-presign retry")
+	}
+}
+
+func TestPresignPipelineRecorderExcludesSendBlocking(t *testing.T) {
+	var requests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/v2-blocked/presign-batch":
+			requests.Add(1)
+			_ = json.NewEncoder(w).Encode(struct {
+				Parts []presignedPart `json:"parts"`
+			}{
+				Parts: []presignedPart{
+					{Number: 1, URL: "http://example.invalid/1", Size: 1, ExpiresAt: time.Now().Add(time.Minute)},
+					{Number: 2, URL: "http://example.invalid/2", Size: 1, ExpiresAt: time.Now().Add(time.Minute)},
+					{Number: 3, URL: "http://example.invalid/3", Size: 1, ExpiresAt: time.Now().Add(time.Minute)},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	recorder := &uploadDurationRecorder{}
+	presignCh := make(chan presignedPart, 1)
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		c.presignPipeline(ctx, &uploadPlanV2{UploadID: "v2-blocked", TotalParts: 3}, 3, presignCh, errCh, recorder)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for len(presignCh) != 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("presign pipeline did not enqueue the first part")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	time.Sleep(75 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("presign pipeline did not exit after cancellation")
+	}
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("presign pipeline error = %v, want context canceled", err)
+		}
+	default:
+		t.Fatal("expected presign pipeline to report cancellation")
+	}
+
+	if requests.Load() != 1 {
+		t.Fatalf("presign batch requests = %d, want 1", requests.Load())
+	}
+	if got := recorder.Seconds(); got >= 0.05 {
+		t.Fatalf("presign recorder included channel blocking: got %.3fs", got)
 	}
 }
 

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -159,6 +159,42 @@ func TestWriteStreamSmallFile(t *testing.T) {
 	}
 }
 
+func TestWriteStreamWithSummarySmallFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && r.URL.Path == "/v1/fs/small-summary.txt" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	data := []byte("summary me")
+	summary, err := c.WriteStreamWithSummary(context.Background(), "/small-summary.txt", bytes.NewReader(data), int64(len(data)), nil)
+	if err != nil {
+		t.Fatalf("WriteStreamWithSummary: %v", err)
+	}
+	if summary == nil {
+		t.Fatal("summary is nil")
+	}
+	if summary.Type != "upload_summary" {
+		t.Fatalf("summary.Type = %q, want upload_summary", summary.Type)
+	}
+	if summary.Mode != "direct_put" {
+		t.Fatalf("summary.Mode = %q, want direct_put", summary.Mode)
+	}
+	if summary.TotalBytes != int64(len(data)) {
+		t.Fatalf("summary.TotalBytes = %d, want %d", summary.TotalBytes, len(data))
+	}
+	if summary.DirectWriteSeconds < 0 {
+		t.Fatalf("summary.DirectWriteSeconds = %f, want >= 0", summary.DirectWriteSeconds)
+	}
+	if summary.ElapsedSeconds < 0 {
+		t.Fatalf("summary.ElapsedSeconds = %f, want >= 0", summary.ElapsedSeconds)
+	}
+}
+
 // TestWriteStreamLargeFile verifies the 202 + multipart upload flow.
 func TestWriteStreamLargeFile(t *testing.T) {
 	var mu sync.Mutex

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -20,10 +20,10 @@ import (
 )
 
 var (
-	ErrNotFound         = errors.New("not found")
-	ErrUploadNotActive  = errors.New("upload is not in UPLOADING state")
-	ErrUploadExpired    = errors.New("upload has expired")
-	ErrPathConflict     = errors.New("path already exists")
+	ErrNotFound            = errors.New("not found")
+	ErrUploadNotActive     = errors.New("upload is not in UPLOADING state")
+	ErrUploadExpired       = errors.New("upload has expired")
+	ErrPathConflict        = errors.New("path already exists")
 	ErrUploadConflict      = errors.New("active upload already exists for this path")
 	ErrIdempotencyConflict = errors.New("duplicate idempotency key")
 	ErrRevisionConflict    = errors.New("revision conflict")
@@ -837,14 +837,87 @@ func (s *Store) InsertUploadTx(db execer, u *Upload) error {
 
 func (s *Store) GetUpload(ctx context.Context, uploadID string) (out *Upload, err error) {
 	start := time.Now()
-	defer observeStoreOp(ctx, "get_upload", start, &err)
+	var opErr error
+	defer observeStoreOp(ctx, "get_upload", start, &opErr)
 
-	row := s.db.QueryRowContext(ctx, `SELECT upload_id, file_id, target_path, s3_upload_id, s3_key,
+	queryStart := time.Now()
+	rows, err := s.db.QueryContext(ctx, `SELECT upload_id, file_id, target_path, s3_upload_id, s3_key,
 		total_size, part_size, parts_total, expected_revision, status, fingerprint_sha256, idempotency_key,
 		created_at, updated_at, expires_at
 		FROM uploads WHERE upload_id = ?`, uploadID)
-	out, err = scanUpload(row)
-	return out, err
+	queryContextDurationMs := datastorePhaseMs(queryStart)
+	if err != nil {
+		opErr = err
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	firstRowStart := time.Now()
+	if !rows.Next() {
+		firstRowDurationMs := datastorePhaseMs(firstRowStart)
+		if err := rows.Err(); err != nil {
+			opErr = err
+			return nil, err
+		}
+		logger.Info(ctx, "datastore_get_upload_timing",
+			zap.String("upload_id", uploadID),
+			zap.Float64("query_context_ms", queryContextDurationMs),
+			zap.Float64("first_row_ms", firstRowDurationMs),
+			zap.Float64("scan_ms", 0),
+			zap.Float64("hydrate_ms", 0),
+			zap.String("result", "not_found"),
+			zap.Float64("total_ms", datastorePhaseMs(start)),
+		)
+		opErr = ErrNotFound
+		return nil, ErrNotFound
+	}
+	firstRowDurationMs := datastorePhaseMs(firstRowStart)
+
+	var u Upload
+	var fingerprint, idempotencyKey sql.NullString
+	var expectedRevision sql.NullInt64
+	var createdAt, updatedAt, expiresAt time.Time
+	scanStart := time.Now()
+	err = rows.Scan(&u.UploadID, &u.FileID, &u.TargetPath, &u.S3UploadID, &u.S3Key,
+		&u.TotalSize, &u.PartSize, &u.PartsTotal, &expectedRevision, &u.Status,
+		&fingerprint, &idempotencyKey,
+		&createdAt, &updatedAt, &expiresAt)
+	scanDurationMs := datastorePhaseMs(scanStart)
+	if err != nil {
+		opErr = err
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		opErr = err
+		return nil, err
+	}
+
+	hydrateStart := time.Now()
+	u.FingerprintSHA = fingerprint.String
+	u.IdempotencyKey = idempotencyKey.String
+	if expectedRevision.Valid {
+		rev := expectedRevision.Int64
+		u.ExpectedRevision = &rev
+	}
+	u.CreatedAt = createdAt.UTC()
+	u.UpdatedAt = updatedAt.UTC()
+	u.ExpiresAt = expiresAt.UTC()
+	hydrateDurationMs := datastorePhaseMs(hydrateStart)
+
+	logger.Info(ctx, "datastore_get_upload_timing",
+		zap.String("upload_id", uploadID),
+		zap.Int("parts_total", u.PartsTotal),
+		zap.String("status", string(u.Status)),
+		zap.Float64("query_context_ms", queryContextDurationMs),
+		zap.Float64("first_row_ms", firstRowDurationMs),
+		zap.Float64("scan_ms", scanDurationMs),
+		zap.Float64("hydrate_ms", hydrateDurationMs),
+		zap.String("result", "ok"),
+		zap.Float64("total_ms", datastorePhaseMs(start)),
+	)
+
+	out = &u
+	return out, nil
 }
 
 func (s *Store) GetUploadByPath(ctx context.Context, targetPath string) (out *Upload, err error) {
@@ -1163,6 +1236,10 @@ var wsNorm = regexp.MustCompile(`\s+`)
 
 func normalizeSQL(s string) string {
 	return wsNorm.ReplaceAllString(strings.TrimSpace(s), " ")
+}
+
+func datastorePhaseMs(start time.Time) float64 {
+	return float64(time.Since(start).Microseconds()) / 1000.0
 }
 
 func observeStoreOp(ctx context.Context, op string, start time.Time, errp *error) {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -859,7 +859,7 @@ func (s *Store) GetUpload(ctx context.Context, uploadID string) (out *Upload, er
 			opErr = err
 			return nil, err
 		}
-		logger.Info(ctx, "datastore_get_upload_timing",
+		logger.InfoBenchTiming(ctx, "datastore_get_upload_timing",
 			zap.String("upload_id", uploadID),
 			zap.Float64("query_context_ms", queryContextDurationMs),
 			zap.Float64("first_row_ms", firstRowDurationMs),
@@ -904,7 +904,7 @@ func (s *Store) GetUpload(ctx context.Context, uploadID string) (out *Upload, er
 	u.ExpiresAt = expiresAt.UTC()
 	hydrateDurationMs := datastorePhaseMs(hydrateStart)
 
-	logger.Info(ctx, "datastore_get_upload_timing",
+	logger.InfoBenchTiming(ctx, "datastore_get_upload_timing",
 		zap.String("upload_id", uploadID),
 		zap.Int("parts_total", u.PartsTotal),
 		zap.String("status", string(u.Status)),

--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -5,14 +5,42 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync/atomic"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
+const envBenchTimingLogEnabled = "DRIVE9_BENCH_TIMING_LOG_ENABLED"
+
+const (
+	benchTimingLogUnknown uint32 = iota
+	benchTimingLogDisabled
+	benchTimingLogEnabled
+)
+
+var benchTimingLogState atomic.Uint32
+
 func NewServerLogger() (*zap.Logger, error) {
 	return zap.NewProduction()
+}
+
+func BenchTimingLogEnabled() bool {
+	switch benchTimingLogState.Load() {
+	case benchTimingLogDisabled:
+		return false
+	case benchTimingLogEnabled:
+		return true
+	}
+
+	enabled := envBool(envBenchTimingLogEnabled, false)
+	if enabled {
+		benchTimingLogState.Store(benchTimingLogEnabled)
+		return true
+	}
+	benchTimingLogState.Store(benchTimingLogDisabled)
+	return false
 }
 
 func CLIEnabled() bool {
@@ -92,4 +120,8 @@ func envBool(key string, fallback bool) bool {
 		return fallback
 	}
 	return v
+}
+
+func resetBenchTimingLogEnabledForTest() {
+	benchTimingLogState.Store(benchTimingLogUnknown)
 }

--- a/pkg/logger/factory_test.go
+++ b/pkg/logger/factory_test.go
@@ -1,9 +1,13 @@
 package logger
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestNewCLILoggerCreatesLogDirAndFile(t *testing.T) {
@@ -33,5 +37,50 @@ func TestNewCLILoggerCreatesLogDirAndFile(t *testing.T) {
 	}
 	if _, err := os.Stat(logPath); err != nil {
 		t.Fatalf("Stat(log file): %v", err)
+	}
+}
+
+func TestBenchTimingLogEnabledCachesUntilReset(t *testing.T) {
+	resetBenchTimingLogEnabledForTest()
+	t.Cleanup(resetBenchTimingLogEnabledForTest)
+
+	t.Setenv(envBenchTimingLogEnabled, "true")
+	if !BenchTimingLogEnabled() {
+		t.Fatal("expected bench timing log to be enabled")
+	}
+
+	t.Setenv(envBenchTimingLogEnabled, "false")
+	if !BenchTimingLogEnabled() {
+		t.Fatal("expected cached enabled value to remain true before reset")
+	}
+
+	resetBenchTimingLogEnabledForTest()
+	if BenchTimingLogEnabled() {
+		t.Fatal("expected bench timing log to be disabled after reset")
+	}
+}
+
+func TestInfoBenchTimingHonorsEnabledFlag(t *testing.T) {
+	resetBenchTimingLogEnabledForTest()
+	t.Cleanup(resetBenchTimingLogEnabledForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	ctx := WithContext(context.Background(), zap.New(core))
+
+	t.Setenv(envBenchTimingLogEnabled, "false")
+	InfoBenchTiming(ctx, "timing_disabled")
+	if entries := recorded.All(); len(entries) != 0 {
+		t.Fatalf("recorded %d entries with timing disabled, want 0", len(entries))
+	}
+
+	resetBenchTimingLogEnabledForTest()
+	t.Setenv(envBenchTimingLogEnabled, "true")
+	InfoBenchTiming(ctx, "timing_enabled")
+	entries := recorded.All()
+	if len(entries) != 1 {
+		t.Fatalf("recorded %d entries with timing enabled, want 1", len(entries))
+	}
+	if entries[0].Message != "timing_enabled" {
+		t.Fatalf("message = %q, want timing_enabled", entries[0].Message)
 	}
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -56,6 +56,13 @@ func Info(ctx context.Context, msg string, fields ...zap.Field) {
 	FromContext(ctx).WithOptions(zap.AddCallerSkip(1)).Info(msg, fields...)
 }
 
+func InfoBenchTiming(ctx context.Context, msg string, fields ...zap.Field) {
+	if !BenchTimingLogEnabled() {
+		return
+	}
+	FromContext(ctx).WithOptions(zap.AddCallerSkip(1)).Info(msg, fields...)
+}
+
 func Warn(ctx context.Context, msg string, fields ...zap.Field) {
 	FromContext(ctx).WithOptions(zap.AddCallerSkip(1)).Warn(msg, fields...)
 }

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -150,7 +150,7 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 		}
 		defer release()
 		metricEvent(r.Context(), "auth", "result", "ok")
-		logger.Info(r.Context(), "tenant_auth_timing",
+		logger.InfoBenchTiming(r.Context(), "tenant_auth_timing",
 			zap.String("path", r.URL.Path),
 			zap.String("method", r.Method),
 			zap.String("tenant_id", resolved.Tenant.ID),

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/logger"
@@ -13,6 +14,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
 	"github.com/mem9-ai/dat9/pkg/vault"
+	"go.uber.org/zap"
 )
 
 type scopeKey int
@@ -35,8 +37,13 @@ func withScope(ctx context.Context, scope *TenantScope) context.Context {
 	return context.WithValue(ctx, tenantScopeKey, scope)
 }
 
+func authPhaseMs(start time.Time) float64 {
+	return float64(time.Since(start).Microseconds()) / 1000.0
+}
+
 func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret []byte, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authStart := time.Now()
 		tok := bearerToken(r)
 		if tok == "" {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_missing_token")...)
@@ -45,7 +52,9 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			return
 		}
 
+		resolveStart := time.Now()
 		resolved, err := metaStore.ResolveByAPIKeyHash(r.Context(), token.HashToken(tok))
+		resolveDurationMs := authPhaseMs(resolveStart)
 		if err != nil {
 			if errors.Is(err, meta.ErrNotFound) {
 				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_key_not_found")...)
@@ -73,7 +82,9 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			return
 		}
 
+		decryptStart := time.Now()
 		plain, err := poolDecryptToken(r.Context(), pool, resolved.APIKey.JWTCiphertext)
+		decryptDurationMs := authPhaseMs(decryptStart)
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_decrypt_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 			metricEvent(r.Context(), "auth", "result", "decrypt_failed")
@@ -87,7 +98,9 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			return
 		}
 
+		verifyStart := time.Now()
 		claims, err := token.ParseAndVerifyToken(tokenSecret, tok)
+		verifyDurationMs := authPhaseMs(verifyStart)
 		if err != nil {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_token_invalid", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 			metricEvent(r.Context(), "auth", "result", "token_invalid")
@@ -126,7 +139,9 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			return
 		}
 
+		acquireStart := time.Now()
 		b, release, err := pool.Acquire(r.Context(), &resolved.Tenant)
+		acquireDurationMs := authPhaseMs(acquireStart)
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "backend_load_failed", "tenant_id", resolved.Tenant.ID, "error", err)...)
 			metricEvent(r.Context(), "tenant_backend", "result", "load_failed")
@@ -135,6 +150,17 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 		}
 		defer release()
 		metricEvent(r.Context(), "auth", "result", "ok")
+		logger.Info(r.Context(), "tenant_auth_timing",
+			zap.String("path", r.URL.Path),
+			zap.String("method", r.Method),
+			zap.String("tenant_id", resolved.Tenant.ID),
+			zap.String("api_key_id", resolved.APIKey.ID),
+			zap.Float64("resolve_api_key_hash_ms", resolveDurationMs),
+			zap.Float64("decrypt_token_ms", decryptDurationMs),
+			zap.Float64("verify_token_ms", verifyDurationMs),
+			zap.Float64("pool_acquire_ms", acquireDurationMs),
+			zap.Float64("total_ms", authPhaseMs(authStart)),
+		)
 
 		scope := &TenantScope{TenantID: resolved.Tenant.ID, APIKeyID: resolved.APIKey.ID, TokenVersion: resolved.APIKey.TokenVersion, Backend: b}
 		next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -132,7 +132,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 		e.refs++
 		p.order.MoveToFront(e.elem)
 		p.mu.Unlock()
-		logger.Info(ctx, "tenant_pool_acquire_timing",
+		logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
 			zap.String("tenant_id", t.ID),
 			zap.Bool("cache_hit", true),
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
@@ -154,7 +154,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 		p.mu.Unlock()
 		b.Close()
 		_ = st.Close()
-		logger.Info(ctx, "tenant_pool_acquire_timing",
+		logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
 			zap.String("tenant_id", t.ID),
 			zap.Bool("cache_hit", true),
 			zap.Float64("create_backend_ms", createBackendDurationMs),
@@ -177,7 +177,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	for _, retired := range toClose {
 		closeEntry(retired)
 	}
-	logger.Info(ctx, "tenant_pool_acquire_timing",
+	logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
 		zap.String("tenant_id", t.ID),
 		zap.Bool("cache_hit", false),
 		zap.Float64("create_backend_ms", createBackendDurationMs),
@@ -342,7 +342,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			return nil, nil, fmt.Errorf("create backend with s3 mode: %w", err)
 		}
 		backendCreateDurationMs := float64(time.Since(backendCreateStart).Microseconds()) / 1000.0
-		logger.Info(ctx, "tenant_pool_create_backend_timing",
+		logger.InfoBenchTiming(ctx, "tenant_pool_create_backend_timing",
 			zap.String("tenant_id", t.ID),
 			zap.String("provider", t.Provider),
 			zap.String("storage_mode", "aws_s3"),
@@ -372,7 +372,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			return nil, nil, fmt.Errorf("create backend with local s3 mode: %w", err)
 		}
 		backendCreateDurationMs := float64(time.Since(backendCreateStart).Microseconds()) / 1000.0
-		logger.Info(ctx, "tenant_pool_create_backend_timing",
+		logger.InfoBenchTiming(ctx, "tenant_pool_create_backend_timing",
 			zap.String("tenant_id", t.ID),
 			zap.String("provider", t.Provider),
 			zap.String("storage_mode", "local_s3"),
@@ -391,7 +391,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		return nil, nil, fmt.Errorf("create backend: %w", err)
 	}
 	backendCreateDurationMs := float64(time.Since(backendCreateStart).Microseconds()) / 1000.0
-	logger.Info(ctx, "tenant_pool_create_backend_timing",
+	logger.InfoBenchTiming(ctx, "tenant_pool_create_backend_timing",
 		zap.String("tenant_id", t.ID),
 		zap.String("provider", t.Provider),
 		zap.String("storage_mode", "db_only"),

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -132,14 +132,20 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 		e.refs++
 		p.order.MoveToFront(e.elem)
 		p.mu.Unlock()
+		logger.Info(ctx, "tenant_pool_acquire_timing",
+			zap.String("tenant_id", t.ID),
+			zap.Bool("cache_hit", true),
+			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		return e.backend, p.makeRelease(e), nil
 	}
 	p.mu.Unlock()
 
+	createBackendStart := time.Now()
 	b, st, err := p.createBackend(ctx, t)
 	if err != nil {
 		return nil, nil, err
 	}
+	createBackendDurationMs := float64(time.Since(createBackendStart).Microseconds()) / 1000.0
 
 	p.mu.Lock()
 	if e, ok := p.items[t.ID]; ok {
@@ -148,6 +154,11 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 		p.mu.Unlock()
 		b.Close()
 		_ = st.Close()
+		logger.Info(ctx, "tenant_pool_acquire_timing",
+			zap.String("tenant_id", t.ID),
+			zap.Bool("cache_hit", true),
+			zap.Float64("create_backend_ms", createBackendDurationMs),
+			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		return e.backend, p.makeRelease(e), nil
 	}
 	e := &entry{tenantID: t.ID, backend: b, store: st, refs: 1}
@@ -166,6 +177,11 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	for _, retired := range toClose {
 		closeEntry(retired)
 	}
+	logger.Info(ctx, "tenant_pool_acquire_timing",
+		zap.String("tenant_id", t.ID),
+		zap.Bool("cache_hit", false),
+		zap.Float64("create_backend_ms", createBackendDurationMs),
+		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 	return b, p.makeRelease(e), nil
 }
 
@@ -269,10 +285,13 @@ func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantI
 }
 
 func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9Backend, *datastore.Store, error) {
+	start := time.Now()
+	decryptStart := time.Now()
 	pass, err := p.enc.Decrypt(ctx, t.DBPasswordCipher)
 	if err != nil {
 		return nil, nil, fmt.Errorf("decrypt db password: %w", err)
 	}
+	decryptDurationMs := float64(time.Since(decryptStart).Microseconds()) / 1000.0
 	opts := p.cfg.BackendOptions
 	if UsesTiDBAutoEmbedding(t.Provider) {
 		opts.DatabaseAutoEmbedding = true
@@ -282,15 +301,20 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		query += "&tls=true"
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
+	openStoreStart := time.Now()
 	store, err := datastore.Open(dsn)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open datastore: %w", err)
 	}
+	openStoreDurationMs := float64(time.Since(openStoreStart).Microseconds()) / 1000.0
+	ensureSchemaDurationMs := 0.0
 	if opts.DatabaseAutoEmbedding && (t.Provider == ProviderTiDBZero || t.Provider == ProviderTiDBCloudStarter) {
+		ensureSchemaStart := time.Now()
 		if err := schema.EnsureTiDBSchemaForMode(store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
 			_ = store.Close()
 			return nil, nil, fmt.Errorf("ensure tidb auto-embedding schema: %w", err)
 		}
+		ensureSchemaDurationMs = float64(time.Since(ensureSchemaStart).Microseconds()) / 1000.0
 	}
 	if p.cfg.S3Bucket != "" {
 		prefix := strings.Trim(p.cfg.S3Prefix, "/")
@@ -298,6 +322,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			prefix += "/"
 		}
 		prefix += t.ID + "/"
+		s3ClientStart := time.Now()
 		s3c, err := s3client.NewAWS(ctx, s3client.AWSConfig{
 			Region:  p.cfg.S3Region,
 			Bucket:  p.cfg.S3Bucket,
@@ -308,35 +333,74 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			_ = store.Close()
 			return nil, nil, fmt.Errorf("create aws s3 client: %w", err)
 		}
+		s3ClientDurationMs := float64(time.Since(s3ClientStart).Microseconds()) / 1000.0
 		smallInDB := SmallInDB(t.Provider)
+		backendCreateStart := time.Now()
 		b, err := backend.NewWithS3ModeAndOptions(store, s3c, smallInDB, opts)
 		if err != nil {
 			_ = store.Close()
 			return nil, nil, fmt.Errorf("create backend with s3 mode: %w", err)
 		}
+		backendCreateDurationMs := float64(time.Since(backendCreateStart).Microseconds()) / 1000.0
+		logger.Info(ctx, "tenant_pool_create_backend_timing",
+			zap.String("tenant_id", t.ID),
+			zap.String("provider", t.Provider),
+			zap.String("storage_mode", "aws_s3"),
+			zap.Float64("decrypt_db_password_ms", decryptDurationMs),
+			zap.Float64("open_datastore_ms", openStoreDurationMs),
+			zap.Float64("ensure_schema_ms", ensureSchemaDurationMs),
+			zap.Float64("create_s3_client_ms", s3ClientDurationMs),
+			zap.Float64("create_backend_ms", backendCreateDurationMs),
+			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		return b, store, nil
 	}
 	if p.cfg.S3Dir != "" {
 		s3Dir := p.cfg.S3Dir + "/" + t.ID
 		s3BaseURL := p.cfg.PublicURL + "/s3/" + t.ID
+		s3ClientStart := time.Now()
 		s3c, err := s3client.NewLocal(s3Dir, s3BaseURL)
 		if err != nil {
 			_ = store.Close()
 			return nil, nil, fmt.Errorf("create local s3 client: %w", err)
 		}
+		s3ClientDurationMs := float64(time.Since(s3ClientStart).Microseconds()) / 1000.0
 		smallInDB := SmallInDB(t.Provider)
+		backendCreateStart := time.Now()
 		b, err := backend.NewWithS3ModeAndOptions(store, s3c, smallInDB, opts)
 		if err != nil {
 			_ = store.Close()
 			return nil, nil, fmt.Errorf("create backend with local s3 mode: %w", err)
 		}
+		backendCreateDurationMs := float64(time.Since(backendCreateStart).Microseconds()) / 1000.0
+		logger.Info(ctx, "tenant_pool_create_backend_timing",
+			zap.String("tenant_id", t.ID),
+			zap.String("provider", t.Provider),
+			zap.String("storage_mode", "local_s3"),
+			zap.Float64("decrypt_db_password_ms", decryptDurationMs),
+			zap.Float64("open_datastore_ms", openStoreDurationMs),
+			zap.Float64("ensure_schema_ms", ensureSchemaDurationMs),
+			zap.Float64("create_s3_client_ms", s3ClientDurationMs),
+			zap.Float64("create_backend_ms", backendCreateDurationMs),
+			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		return b, store, nil
 	}
+	backendCreateStart := time.Now()
 	b, err := backend.NewWithOptions(store, opts)
 	if err != nil {
 		_ = store.Close()
 		return nil, nil, fmt.Errorf("create backend: %w", err)
 	}
+	backendCreateDurationMs := float64(time.Since(backendCreateStart).Microseconds()) / 1000.0
+	logger.Info(ctx, "tenant_pool_create_backend_timing",
+		zap.String("tenant_id", t.ID),
+		zap.String("provider", t.Provider),
+		zap.String("storage_mode", "db_only"),
+		zap.Float64("decrypt_db_password_ms", decryptDurationMs),
+		zap.Float64("open_datastore_ms", openStoreDurationMs),
+		zap.Float64("ensure_schema_ms", ensureSchemaDurationMs),
+		zap.Float64("create_s3_client_ms", 0),
+		zap.Float64("create_backend_ms", backendCreateDurationMs),
+		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 	return b, store, nil
 }
 

--- a/scripts/drive9-server-local-env.sh
+++ b/scripts/drive9-server-local-env.sh
@@ -21,8 +21,17 @@
 # Leave DRIVE9_LOCAL_INIT_SCHEMA unset to use the built-in default (false).
 # : "${DRIVE9_LOCAL_INIT_SCHEMA:=false}"
 
-# Local mock S3 mode.
+# S3 mode selection for drive9-server-local.
+# Default: local mock S3 when DRIVE9_S3_BUCKET is unset.
+# AWS mode: set DRIVE9_S3_BUCKET (and optionally DRIVE9_S3_REGION,
+# DRIVE9_S3_PREFIX, DRIVE9_S3_ROLE_ARN). In AWS mode, do not export
+# DRIVE9_S3_DIR; drive9-server-local treats it as a configuration error.
 : "${DRIVE9_S3_DIR:=${TMPDIR:-/tmp}/drive9-local-s3}"
+# Example AWS mode:
+# export DRIVE9_S3_BUCKET=my-drive9-test-bucket
+# export DRIVE9_S3_REGION=us-east-1
+# export DRIVE9_S3_PREFIX=drive9-local
+# export DRIVE9_S3_ROLE_ARN=arn:aws:iam::123456789012:role/drive9-local
 
 # Run the following command to pull the embedding model before starting drive9-server-local.
 # ollama pull all-minilm
@@ -70,12 +79,21 @@
 
 export DRIVE9_PUBLIC_URL
 export DRIVE9_LOCAL_DSN
-export DRIVE9_S3_DIR
+if [[ -z "${DRIVE9_S3_BUCKET:-}" ]]; then
+  export DRIVE9_S3_DIR
+else
+  unset DRIVE9_S3_DIR
+fi
 export DRIVE9_EMBED_API_BASE
 export DRIVE9_EMBED_API_KEY
 export DRIVE9_EMBED_MODEL
 
 echo "Environment loaded for drive9-server-local."
+if [[ -n "${DRIVE9_S3_BUCKET:-}" ]]; then
+  echo "S3 mode: aws (${DRIVE9_S3_BUCKET} in ${DRIVE9_S3_REGION:-us-east-1})"
+else
+  echo "S3 mode: local (${DRIVE9_S3_DIR})"
+fi
 echo "Run: make run-server-local"
 echo ""
 echo "Audio extract e2e (optional): enable stub runtime, then run the verifier, e.g."

--- a/scripts/test-podman.sh
+++ b/scripts/test-podman.sh
@@ -33,7 +33,7 @@ case "$(uname -s)" in
     if [ -z "$podman_socket" ]; then
       fail "could not determine the Podman socket path from podman info"
     fi
-    if [ "$podman_socket_exists" != "true" ]; then
+    if [ -n "$podman_socket_exists" ] && [ "$podman_socket_exists" != "true" ]; then
       fail "Podman reports remote socket unavailable at $podman_socket; start the Podman API service (for example: systemctl --user start podman.socket or podman system service --time=0 unix://$podman_socket)"
     fi
     if [ ! -S "$podman_socket" ]; then

--- a/scripts/test-podman.sh
+++ b/scripts/test-podman.sh
@@ -29,8 +29,15 @@ case "$(uname -s)" in
     ;;
   Linux)
     podman_socket="$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null || true)"
+    podman_socket_exists="$(podman info --format '{{.Host.RemoteSocket.Exists}}' 2>/dev/null || true)"
     if [ -z "$podman_socket" ]; then
       fail "could not determine the Podman socket path from podman info"
+    fi
+    if [ "$podman_socket_exists" != "true" ]; then
+      fail "Podman reports remote socket unavailable at $podman_socket; start the Podman API service (for example: systemctl --user start podman.socket or podman system service --time=0 unix://$podman_socket)"
+    fi
+    if [ ! -S "$podman_socket" ]; then
+      fail "Podman socket path does not exist or is not a Unix socket: $podman_socket"
     fi
     ;;
   *)
@@ -46,3 +53,4 @@ if ! podman info >/dev/null 2>&1; then
 fi
 
 unset podman_socket
+unset podman_socket_exists


### PR DESCRIPTION
## Summary
- add upload benchmark diagnostics across the CLI and server, including upload summaries, optional CPU profiling, and server-side timing instrumentation for initiate/presign/confirm/finalize plus auth and tenant-pool phases
- let `drive9-server-local` target AWS S3 directly so local benchmark runs can exercise the same object storage path as hosted deployments
- harden local benchmark and test ergonomics, including Podman setup diagnostics and fallback-to-default-runtime behavior when Podman setup is unavailable
- address review follow-ups around local AWS env handling, `drive9-server-local` env parsing, CLI summary context propagation, upload lookup error handling, presign timing semantics, and hot-path benchmark timing log gating via `DRIVE9_BENCH_TIMING_LOG_ENABLED`

## Testing
- `make lint`
- `make build`
- `make test TEST_P=1`
- `make test-failpoint`
