### PR TITLE
Add shared build info for CLI and server entrypoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,18 @@ GOARCH ?= $(HOST_GOARCH)
 
 APP_NAME ?= drive9-server
 CLI_NAME ?= drive9
+LOCAL_SERVER_NAME ?= drive9-server-local
 
 BIN_DIR ?= bin
 DIST_DIR ?= dist
 SERVER_BIN ?= $(BIN_DIR)/$(APP_NAME)
 CLI_BIN ?= $(BIN_DIR)/$(CLI_NAME)
+LOCAL_SERVER_BIN ?= $(BIN_DIR)/$(LOCAL_SERVER_NAME)
 LOCAL_BIN ?= $(CURDIR)/bin
 VERSION ?=
 GIT_HASH ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+BUILD_TIME ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 CLI_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
@@ -31,7 +35,12 @@ IMAGE ?= $(IMAGE_REPO):$(IMAGE_TAG)
 LINT_TIMEOUT ?= 10m
 TEST_P ?=
 
-.PHONY: mod test test-failpoint test-podman fmt lint install-lint build build-server build-cli build-cli-release run-server-local docker-build
+BUILDINFO_LDFLAGS = -X github.com/mem9-ai/dat9/pkg/buildinfo.Version=$(if $(VERSION),$(VERSION),dev) \
+	-X github.com/mem9-ai/dat9/pkg/buildinfo.GitHash=$(GIT_HASH) \
+	-X github.com/mem9-ai/dat9/pkg/buildinfo.GitBranch=$(GIT_BRANCH) \
+	-X github.com/mem9-ai/dat9/pkg/buildinfo.BuildTime=$(BUILD_TIME)
+
+.PHONY: mod test test-failpoint test-podman fmt lint install-lint build build-server build-server-local build-cli build-cli-release run-server-local docker-build
 
 mod:
 	$(GO) mod tidy
@@ -87,22 +96,18 @@ build: build-server build-cli
 
 build-server:
 	mkdir -p $(BIN_DIR)
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -o $(SERVER_BIN) ./cmd/drive9-server
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -ldflags "$(BUILDINFO_LDFLAGS)" -o $(SERVER_BIN) ./cmd/drive9-server
+
+build-server-local:
+	mkdir -p $(BIN_DIR)
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -ldflags "$(BUILDINFO_LDFLAGS)" -o $(LOCAL_SERVER_BIN) ./cmd/drive9-server-local
 
 run-server-local:
 	@source ./scripts/drive9-server-local-env.sh && $(GO) run ./cmd/drive9-server-local
 
 build-cli:
 	mkdir -p $(BIN_DIR)
-	@set -euo pipefail; \
-	ldflags="-X main.gitHash=$(GIT_HASH)"; \
-	if [ -n "$(VERSION)" ]; then \
-		ldflags="$$ldflags -X main.version=$(VERSION)"; \
-	else \
-		ldflags="$$ldflags -X main.version=dev"; \
-	fi; \
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -ldflags "$$ldflags" -o $(CLI_BIN) ./cmd/drive9; \
-	true
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -ldflags "$(BUILDINFO_LDFLAGS)" -o $(CLI_BIN) ./cmd/drive9
 
 build-cli-release:
 	@set -euo pipefail; \

--- a/Makefile
+++ b/Makefile
@@ -15,19 +15,23 @@ CLI_NAME ?= drive9
 LOCAL_SERVER_NAME ?= drive9-server-local
 
 BIN_DIR ?= bin
+# Use an absolute GOBIN for tool installation; `go install` is more predictable
+# with an absolute path than a repo-relative bin dir.
+BIN_DIR_ABS := $(abspath $(BIN_DIR))
 DIST_DIR ?= dist
 SERVER_BIN ?= $(BIN_DIR)/$(APP_NAME)
 CLI_BIN ?= $(BIN_DIR)/$(CLI_NAME)
 LOCAL_SERVER_BIN ?= $(BIN_DIR)/$(LOCAL_SERVER_NAME)
-LOCAL_BIN ?= $(CURDIR)/bin
+
 VERSION ?=
 GIT_HASH ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
 BUILD_TIME ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+
 CLI_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
-GOLANGCI_LINT_BIN ?= $(LOCAL_BIN)/golangci-lint
+GOLANGCI_LINT_BIN ?= $(BIN_DIR)/golangci-lint
 
 IMAGE_REPO ?= drive9-server
 IMAGE_TAG ?= latest
@@ -85,9 +89,9 @@ lint:
 install-lint:
 	@echo "Checking for golangci-lint..."
 	@if [ ! -x "$(GOLANGCI_LINT_BIN)" ]; then \
-		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) to $(LOCAL_BIN)..."; \
-		mkdir -p "$(LOCAL_BIN)"; \
-		GOBIN="$(LOCAL_BIN)" $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
+		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) to $(BIN_DIR)..."; \
+		mkdir -p "$(BIN_DIR)"; \
+		GOBIN="$(BIN_DIR_ABS)" $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
 	else \
 		echo "golangci-lint already installed at $(GOLANGCI_LINT_BIN)"; \
 	fi
@@ -102,8 +106,8 @@ build-server-local:
 	mkdir -p $(BIN_DIR)
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -ldflags "$(BUILDINFO_LDFLAGS)" -o $(LOCAL_SERVER_BIN) ./cmd/drive9-server-local
 
-run-server-local:
-	@source ./scripts/drive9-server-local-env.sh && $(GO) run ./cmd/drive9-server-local
+run-server-local: build-server-local
+	@source ./scripts/drive9-server-local-env.sh && "./$(LOCAL_SERVER_BIN)"
 
 build-cli:
 	mkdir -p $(BIN_DIR)

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
+	"github.com/mem9-ai/dat9/pkg/buildinfo"
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/embedding"
 	"github.com/mem9-ai/dat9/pkg/logger"
@@ -41,13 +42,20 @@ type localS3Config struct {
 }
 
 func main() {
+	if len(os.Args) > 2 {
+		if len(os.Args) > 1 && os.Args[1] == "version" {
+			usage()
+		}
+		usage()
+	}
+	if len(os.Args) == 2 && os.Args[1] == "version" {
+		_, _ = fmt.Fprint(os.Stdout, versionText())
+		return
+	}
+
 	startupCtx := context.Background()
 	startupStart := time.Now()
 	logLocalStartupStep(startupCtx, startupStart, startupStart, "process_start")
-
-	if len(os.Args) > 2 {
-		usage()
-	}
 
 	addr := envOr("DRIVE9_LISTEN_ADDR", defaultListenAddr)
 	if len(os.Args) == 2 {
@@ -60,6 +68,7 @@ func main() {
 	}
 	defer func() { _ = srvLogger.Sync() }()
 	logger.Set(srvLogger)
+	logger.Info(startupCtx, "build_info", buildinfo.Fields("drive9-server-local")...)
 	logLocalStartupStep(startupCtx, startupStart, time.Now(), "logger_ready")
 
 	localDSN := strings.TrimSpace(os.Getenv("DRIVE9_LOCAL_DSN"))
@@ -242,6 +251,7 @@ func main() {
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `usage: drive9-server-local [listen-addr]
+       drive9-server-local version
 
 environment:
   DRIVE9_LISTEN_ADDR serve listen address (default: 127.0.0.1:9009)
@@ -305,6 +315,10 @@ environment:
   DRIVE9_AUDIO_EXTRACT_PROMPT   optional provider prompt for transcription (openai mode)
 `)
 	os.Exit(2)
+}
+
+func versionText() string {
+	return buildinfo.String("drive9-server-local")
 }
 
 func die(err error) {

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/buildinfo"
 	"github.com/mem9-ai/dat9/pkg/datastore"
@@ -22,7 +24,6 @@ import (
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/server"
 	"github.com/mem9-ai/dat9/pkg/tenant/schema"
-	"go.uber.org/zap"
 )
 
 const (
@@ -43,9 +44,6 @@ type localS3Config struct {
 
 func main() {
 	if len(os.Args) > 2 {
-		if len(os.Args) > 1 && os.Args[1] == "version" {
-			usage()
-		}
 		usage()
 	}
 	if len(os.Args) == 2 && os.Args[1] == "version" {

--- a/cmd/drive9-server-local/main_test.go
+++ b/cmd/drive9-server-local/main_test.go
@@ -6,11 +6,45 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
+	"github.com/mem9-ai/dat9/pkg/buildinfo"
 	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
+
+func TestVersionTextIncludesBuildInfo(t *testing.T) {
+	origVersion := buildinfo.Version
+	origGitHash := buildinfo.GitHash
+	origGitBranch := buildinfo.GitBranch
+	origBuildTime := buildinfo.BuildTime
+	t.Cleanup(func() {
+		buildinfo.Version = origVersion
+		buildinfo.GitHash = origGitHash
+		buildinfo.GitBranch = origGitBranch
+		buildinfo.BuildTime = origBuildTime
+	})
+
+	buildinfo.Version = "v2.1.0"
+	buildinfo.GitHash = "cafebabe"
+	buildinfo.GitBranch = "feature/local"
+	buildinfo.BuildTime = "2026-04-16T10:30:00Z"
+
+	got := versionText()
+	checks := []string{
+		"component: drive9-server-local\n",
+		"version: v2.1.0\n",
+		"git_hash: cafebabe\n",
+		"git_branch: feature/local\n",
+		"build_time: 2026-04-16T10:30:00Z\n",
+	}
+	for _, want := range checks {
+		if !strings.Contains(got, want) {
+			t.Fatalf("versionText() missing %q in %q", want, got)
+		}
+	}
+}
 
 func TestDetectLocalTiDBEmbeddingMode(t *testing.T) {
 	origDetector := localTiDBEmbeddingModeDetector

--- a/cmd/drive9-server-local/main_test.go
+++ b/cmd/drive9-server-local/main_test.go
@@ -10,39 +10,13 @@ import (
 	"testing"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
-	"github.com/mem9-ai/dat9/pkg/buildinfo"
 	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
 
-func TestVersionTextIncludesBuildInfo(t *testing.T) {
-	origVersion := buildinfo.Version
-	origGitHash := buildinfo.GitHash
-	origGitBranch := buildinfo.GitBranch
-	origBuildTime := buildinfo.BuildTime
-	t.Cleanup(func() {
-		buildinfo.Version = origVersion
-		buildinfo.GitHash = origGitHash
-		buildinfo.GitBranch = origGitBranch
-		buildinfo.BuildTime = origBuildTime
-	})
-
-	buildinfo.Version = "v2.1.0"
-	buildinfo.GitHash = "cafebabe"
-	buildinfo.GitBranch = "feature/local"
-	buildinfo.BuildTime = "2026-04-16T10:30:00Z"
-
+func TestVersionTextUsesDrive9ServerLocalComponent(t *testing.T) {
 	got := versionText()
-	checks := []string{
-		"component: drive9-server-local\n",
-		"version: v2.1.0\n",
-		"git_hash: cafebabe\n",
-		"git_branch: feature/local\n",
-		"build_time: 2026-04-16T10:30:00Z\n",
-	}
-	for _, want := range checks {
-		if !strings.Contains(got, want) {
-			t.Fatalf("versionText() missing %q in %q", want, got)
-		}
+	if !strings.Contains(got, "component: drive9-server-local\n") {
+		t.Fatalf("versionText() missing drive9-server-local component line: %q", got)
 	}
 }
 

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/buildinfo"
 	"github.com/mem9-ai/dat9/pkg/embedding"
@@ -28,7 +30,6 @@ import (
 	"github.com/mem9-ai/dat9/pkg/tenant/db9"
 	"github.com/mem9-ai/dat9/pkg/tenant/starter"
 	"github.com/mem9-ai/dat9/pkg/tenant/tidbzero"
-	"go.uber.org/zap"
 )
 
 const (

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
+	"github.com/mem9-ai/dat9/pkg/buildinfo"
 	"github.com/mem9-ai/dat9/pkg/embedding"
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/logger"
@@ -41,6 +42,12 @@ func main() {
 		case "-h", "--help", "help":
 			usage(os.Stdout, 0)
 			return
+		case "version":
+			if len(os.Args) != 2 {
+				usage(os.Stderr, 2)
+			}
+			_, _ = fmt.Fprint(os.Stdout, versionText())
+			return
 		case "schema":
 			die(runSchemaCommand(os.Args[2:]))
 			return
@@ -61,6 +68,7 @@ func main() {
 	}
 	defer func() { _ = srvLogger.Sync() }()
 	logger.Set(srvLogger)
+	logger.Info(context.Background(), "build_info", buildinfo.Fields("drive9-server")...)
 
 	metaDSN := os.Getenv("DRIVE9_META_DSN")
 	if metaDSN == "" {
@@ -215,9 +223,14 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
+func versionText() string {
+	return buildinfo.String("drive9-server")
+}
+
 func usage(out io.Writer, exitCode int) {
 	_, _ = fmt.Fprintf(out, `usage:
   drive9-server [listen-addr]
+  drive9-server version
   drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter>
 
 environment:

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -6,38 +6,12 @@ import (
 	"testing"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
-	"github.com/mem9-ai/dat9/pkg/buildinfo"
 )
 
-func TestVersionTextIncludesBuildInfo(t *testing.T) {
-	origVersion := buildinfo.Version
-	origGitHash := buildinfo.GitHash
-	origGitBranch := buildinfo.GitBranch
-	origBuildTime := buildinfo.BuildTime
-	t.Cleanup(func() {
-		buildinfo.Version = origVersion
-		buildinfo.GitHash = origGitHash
-		buildinfo.GitBranch = origGitBranch
-		buildinfo.BuildTime = origBuildTime
-	})
-
-	buildinfo.Version = "v2.0.0"
-	buildinfo.GitHash = "feedface"
-	buildinfo.GitBranch = "main"
-	buildinfo.BuildTime = "2026-04-16T10:00:00Z"
-
+func TestVersionTextUsesDrive9ServerComponent(t *testing.T) {
 	got := versionText()
-	checks := []string{
-		"component: drive9-server\n",
-		"version: v2.0.0\n",
-		"git_hash: feedface\n",
-		"git_branch: main\n",
-		"build_time: 2026-04-16T10:00:00Z\n",
-	}
-	for _, want := range checks {
-		if !strings.Contains(got, want) {
-			t.Fatalf("versionText() missing %q in %q", want, got)
-		}
+	if !strings.Contains(got, "component: drive9-server\n") {
+		t.Fatalf("versionText() missing drive9-server component line: %q", got)
 	}
 }
 

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -2,10 +2,44 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
+	"github.com/mem9-ai/dat9/pkg/buildinfo"
 )
+
+func TestVersionTextIncludesBuildInfo(t *testing.T) {
+	origVersion := buildinfo.Version
+	origGitHash := buildinfo.GitHash
+	origGitBranch := buildinfo.GitBranch
+	origBuildTime := buildinfo.BuildTime
+	t.Cleanup(func() {
+		buildinfo.Version = origVersion
+		buildinfo.GitHash = origGitHash
+		buildinfo.GitBranch = origGitBranch
+		buildinfo.BuildTime = origBuildTime
+	})
+
+	buildinfo.Version = "v2.0.0"
+	buildinfo.GitHash = "feedface"
+	buildinfo.GitBranch = "main"
+	buildinfo.BuildTime = "2026-04-16T10:00:00Z"
+
+	got := versionText()
+	checks := []string{
+		"component: drive9-server\n",
+		"version: v2.0.0\n",
+		"git_hash: feedface\n",
+		"git_branch: main\n",
+		"build_time: 2026-04-16T10:00:00Z\n",
+	}
+	for _, want := range checks {
+		if !strings.Contains(got, want) {
+			t.Fatalf("versionText() missing %q in %q", want, got)
+		}
+	}
+}
 
 func TestBuildBackendOptionsFromEnvAudioDisabled(t *testing.T) {
 	keys := []string{

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -22,12 +22,11 @@ import (
 	"sync"
 
 	"github.com/mem9-ai/dat9/cmd/drive9/cli"
+	"github.com/mem9-ai/dat9/pkg/buildinfo"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"go.uber.org/zap"
 )
 
-var version = "dev"
-var gitHash = "unknown"
 var cliLogger *zap.Logger
 var cpuProfileStop = func() {}
 var exitFunc = os.Exit
@@ -131,7 +130,7 @@ func main() {
 }
 
 func versionString() string {
-	return fmt.Sprintf("drive9 %s\nGit Commit Hash: %s\n", version, gitHash)
+	return buildinfo.String("drive9")
 }
 
 func startCPUProfileFromEnv() (func(), error) {

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -21,10 +21,11 @@ import (
 	"runtime/pprof"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"github.com/mem9-ai/dat9/cmd/drive9/cli"
 	"github.com/mem9-ai/dat9/pkg/buildinfo"
 	"github.com/mem9-ai/dat9/pkg/logger"
-	"go.uber.org/zap"
 )
 
 var cliLogger *zap.Logger

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -6,35 +6,12 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/mem9-ai/dat9/pkg/buildinfo"
 )
 
-func TestVersionStringIncludesGitHash(t *testing.T) {
-	origVersion := buildinfo.Version
-	origGitHash := buildinfo.GitHash
-	origGitBranch := buildinfo.GitBranch
-	origBuildTime := buildinfo.BuildTime
-	buildinfo.Version = "v1.2.3"
-	buildinfo.GitHash = "abc123"
-	buildinfo.GitBranch = "feature/cli"
-	buildinfo.BuildTime = "2026-04-16T09:30:00Z"
-	t.Cleanup(func() {
-		buildinfo.Version = origVersion
-		buildinfo.GitHash = origGitHash
-		buildinfo.GitBranch = origGitBranch
-		buildinfo.BuildTime = origBuildTime
-	})
-
+func TestVersionStringUsesDrive9Component(t *testing.T) {
 	got := versionString()
 	if !strings.Contains(got, "component: drive9\n") {
 		t.Fatalf("versionString() missing component line: %q", got)
-	}
-	if !strings.Contains(got, "version: v1.2.3\n") {
-		t.Fatalf("versionString() missing version line: %q", got)
-	}
-	if !strings.Contains(got, "git_hash: abc123\n") {
-		t.Fatalf("versionString() missing git hash line: %q", got)
 	}
 }
 

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -6,23 +6,34 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/buildinfo"
 )
 
 func TestVersionStringIncludesGitHash(t *testing.T) {
-	origVersion := version
-	origGitHash := gitHash
-	version = "v1.2.3"
-	gitHash = "abc123"
+	origVersion := buildinfo.Version
+	origGitHash := buildinfo.GitHash
+	origGitBranch := buildinfo.GitBranch
+	origBuildTime := buildinfo.BuildTime
+	buildinfo.Version = "v1.2.3"
+	buildinfo.GitHash = "abc123"
+	buildinfo.GitBranch = "feature/cli"
+	buildinfo.BuildTime = "2026-04-16T09:30:00Z"
 	t.Cleanup(func() {
-		version = origVersion
-		gitHash = origGitHash
+		buildinfo.Version = origVersion
+		buildinfo.GitHash = origGitHash
+		buildinfo.GitBranch = origGitBranch
+		buildinfo.BuildTime = origBuildTime
 	})
 
 	got := versionString()
-	if !strings.Contains(got, "drive9 v1.2.3\n") {
+	if !strings.Contains(got, "component: drive9\n") {
+		t.Fatalf("versionString() missing component line: %q", got)
+	}
+	if !strings.Contains(got, "version: v1.2.3\n") {
 		t.Fatalf("versionString() missing version line: %q", got)
 	}
-	if !strings.Contains(got, "Git Commit Hash: abc123\n") {
+	if !strings.Contains(got, "git_hash: abc123\n") {
 		t.Fatalf("versionString() missing git hash line: %q", got)
 	}
 }

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,3 +1,4 @@
+// Package buildinfo provides shared build metadata for drive9 binaries.
 package buildinfo
 
 import (

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,0 +1,66 @@
+package buildinfo
+
+import (
+	"fmt"
+	"runtime"
+
+	"go.uber.org/zap"
+)
+
+var (
+	Version   = "dev"
+	GitHash   = "unknown"
+	GitBranch = "unknown"
+	BuildTime = "unknown"
+)
+
+type Info struct {
+	Component string
+	Version   string
+	GitHash   string
+	GitBranch string
+	BuildTime string
+	GoVersion string
+}
+
+func Get(component string) Info {
+	return Info{
+		Component: component,
+		Version:   Version,
+		GitHash:   GitHash,
+		GitBranch: GitBranch,
+		BuildTime: BuildTime,
+		GoVersion: runtime.Version(),
+	}
+}
+
+func Fields(component string) []zap.Field {
+	return Get(component).Fields()
+}
+
+func String(component string) string {
+	return Get(component).String()
+}
+
+func (i Info) Fields() []zap.Field {
+	return []zap.Field{
+		zap.String("component", i.Component),
+		zap.String("version", i.Version),
+		zap.String("git_hash", i.GitHash),
+		zap.String("git_branch", i.GitBranch),
+		zap.String("build_time", i.BuildTime),
+		zap.String("go_version", i.GoVersion),
+	}
+}
+
+func (i Info) String() string {
+	return fmt.Sprintf(
+		"component: %s\nversion: %s\ngit_hash: %s\ngit_branch: %s\nbuild_time: %s\ngo_version: %s\n",
+		i.Component,
+		i.Version,
+		i.GitHash,
+		i.GitBranch,
+		i.BuildTime,
+		i.GoVersion,
+	)
+}

--- a/pkg/buildinfo/buildinfo_test.go
+++ b/pkg/buildinfo/buildinfo_test.go
@@ -1,0 +1,88 @@
+package buildinfo
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestStringIncludesAllFields(t *testing.T) {
+	origVersion := Version
+	origGitHash := GitHash
+	origGitBranch := GitBranch
+	origBuildTime := BuildTime
+	t.Cleanup(func() {
+		Version = origVersion
+		GitHash = origGitHash
+		GitBranch = origGitBranch
+		BuildTime = origBuildTime
+	})
+
+	Version = "v1.2.3"
+	GitHash = "abc123"
+	GitBranch = "feature/build-info"
+	BuildTime = "2026-04-16T08:15:00Z"
+
+	got := String("drive9-server")
+	checks := []string{
+		"component: drive9-server\n",
+		"version: v1.2.3\n",
+		"git_hash: abc123\n",
+		"git_branch: feature/build-info\n",
+		"build_time: 2026-04-16T08:15:00Z\n",
+		"go_version: " + runtime.Version() + "\n",
+	}
+	for _, want := range checks {
+		if !strings.Contains(got, want) {
+			t.Fatalf("String() missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestFieldsIncludeAllValues(t *testing.T) {
+	origVersion := Version
+	origGitHash := GitHash
+	origGitBranch := GitBranch
+	origBuildTime := BuildTime
+	t.Cleanup(func() {
+		Version = origVersion
+		GitHash = origGitHash
+		GitBranch = origGitBranch
+		BuildTime = origBuildTime
+	})
+
+	Version = "v9.9.9"
+	GitHash = "deadbeef"
+	GitBranch = "main"
+	BuildTime = "2026-04-16T09:00:00Z"
+
+	core, recorded := observer.New(zap.InfoLevel)
+	zap.New(core).Info("build_info", Fields("drive9-server-local")...)
+
+	entries := recorded.All()
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	ctx := entries[0].ContextMap()
+	if ctx["component"] != "drive9-server-local" {
+		t.Fatalf("component = %v, want drive9-server-local", ctx["component"])
+	}
+	if ctx["version"] != "v9.9.9" {
+		t.Fatalf("version = %v, want v9.9.9", ctx["version"])
+	}
+	if ctx["git_hash"] != "deadbeef" {
+		t.Fatalf("git_hash = %v, want deadbeef", ctx["git_hash"])
+	}
+	if ctx["git_branch"] != "main" {
+		t.Fatalf("git_branch = %v, want main", ctx["git_branch"])
+	}
+	if ctx["build_time"] != "2026-04-16T09:00:00Z" {
+		t.Fatalf("build_time = %v, want 2026-04-16T09:00:00Z", ctx["build_time"])
+	}
+	if ctx["go_version"] != runtime.Version() {
+		t.Fatalf("go_version = %v, want %s", ctx["go_version"], runtime.Version())
+	}
+}

--- a/pkg/buildinfo/buildinfo_test.go
+++ b/pkg/buildinfo/buildinfo_test.go
@@ -9,7 +9,8 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-func TestStringIncludesAllFields(t *testing.T) {
+func setBuildInfoForTest(t *testing.T, version, gitHash, gitBranch, buildTime string) {
+	t.Helper()
 	origVersion := Version
 	origGitHash := GitHash
 	origGitBranch := GitBranch
@@ -21,10 +22,14 @@ func TestStringIncludesAllFields(t *testing.T) {
 		BuildTime = origBuildTime
 	})
 
-	Version = "v1.2.3"
-	GitHash = "abc123"
-	GitBranch = "feature/build-info"
-	BuildTime = "2026-04-16T08:15:00Z"
+	Version = version
+	GitHash = gitHash
+	GitBranch = gitBranch
+	BuildTime = buildTime
+}
+
+func TestStringIncludesAllFields(t *testing.T) {
+	setBuildInfoForTest(t, "v1.2.3", "abc123", "feature/build-info", "2026-04-16T08:15:00Z")
 
 	got := String("drive9-server")
 	checks := []string{
@@ -43,21 +48,7 @@ func TestStringIncludesAllFields(t *testing.T) {
 }
 
 func TestFieldsIncludeAllValues(t *testing.T) {
-	origVersion := Version
-	origGitHash := GitHash
-	origGitBranch := GitBranch
-	origBuildTime := BuildTime
-	t.Cleanup(func() {
-		Version = origVersion
-		GitHash = origGitHash
-		GitBranch = origGitBranch
-		BuildTime = origBuildTime
-	})
-
-	Version = "v9.9.9"
-	GitHash = "deadbeef"
-	GitBranch = "main"
-	BuildTime = "2026-04-16T09:00:00Z"
+	setBuildInfoForTest(t, "v9.9.9", "deadbeef", "main", "2026-04-16T09:00:00Z")
 
 	core, recorded := observer.New(zap.InfoLevel)
 	zap.New(core).Info("build_info", Fields("drive9-server-local")...)


### PR DESCRIPTION
## Summary
- add a shared `pkg/buildinfo` package and use it across `drive9`, `drive9-server`, and `drive9-server-local`
- print a unified `build_info` startup log for both server entrypoints and add `version` subcommands for server/server-local
- inject build metadata through shared Makefile ldflags, add `build-server-local`, and simplify thin entrypoint tests plus the local run target

## Testing
- `go test ./pkg/buildinfo ./cmd/drive9 ./cmd/drive9-server ./cmd/drive9-server-local`
- `make build-cli build-server build-server-local`
- `./bin/drive9 version`
- `./bin/drive9-server version`
- `./bin/drive9-server-local version`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `version` subcommand to CLI tools (`drive9`, `drive9-server`, `drive9-server-local`) to display build information.
  * Build metadata (version, git hash, branch, build time) is now automatically embedded in binaries and logged on startup.

* **Chores**
  * Improved build system to consistently embed build information across all binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->