### PR TITLE
Trigger CLI release after successful prod deployment

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,14 +1,10 @@
 name: Release CLI binaries
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'cmd/**'
-      - 'pkg/**'
-      - 'go.mod'
-      - 'go.sum'
-      - 'Makefile'
+  workflow_run:
+    workflows: ["Deploy server to prod"]
+    types:
+      - completed
   workflow_dispatch:
 
 concurrency:
@@ -18,12 +14,15 @@ concurrency:
 jobs:
   release:
     name: Build and publish CLI
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Checkout agfs dependency
         run: |
@@ -37,7 +36,8 @@ jobs:
 
       - name: Determine version
         run: |
-          VERSION="${GITHUB_SHA::7}"
+          SOURCE_SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
+          VERSION="${SOURCE_SHA::7}"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Build CLI for all platforms


### PR DESCRIPTION
## Summary
- change release-cli to run from the prod deployment workflow via workflow_run
- only execute the release job when prod-cd completed successfully, while keeping manual dispatch available
- build and version the CLI from the triggering prod-cd commit SHA so the released artifacts match the deployed revision

## Why
The CLI release should follow a successful prod deployment instead of running directly on every main push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored the release automation trigger mechanism to depend on the completion of the deployment workflow, ensuring better coordination between deployment and release processes.
  * Updated version derivation logic for improved consistency across release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->