### PR TITLE
Wire DRIVE9_VAULT_MASTER_KEY into server entrypoints

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"net/http"
@@ -81,6 +82,13 @@ func main() {
 	s3cfg, err := localS3ConfigFromEnv()
 	if err != nil {
 		die(err)
+	}
+	var vaultMasterKey []byte
+	if raw := os.Getenv("DRIVE9_VAULT_MASTER_KEY"); raw != "" {
+		vaultMasterKey, err = hex.DecodeString(raw)
+		if err != nil {
+			die(fmt.Errorf("invalid DRIVE9_VAULT_MASTER_KEY: %w", err))
+		}
 	}
 
 	// Local validation should be able to bootstrap a fresh tenant database without
@@ -191,6 +199,7 @@ func main() {
 	if err := server.ValidateDurableAsyncExtractRequiresSemanticWorker(server.Config{
 		Backend:          b,
 		LocalS3:          localS3,
+		VaultMasterKey:   vaultMasterKey,
 		S3Dir:            s3cfg.localDir(),
 		MaxUploadBytes:   maxUploadBytes,
 		Logger:           srvLogger,
@@ -204,6 +213,7 @@ func main() {
 	srv := server.NewWithConfig(server.Config{
 		Backend:          b,
 		LocalS3:          localS3,
+		VaultMasterKey:   vaultMasterKey,
 		S3Dir:            s3cfg.localDir(),
 		MaxUploadBytes:   maxUploadBytes,
 		Logger:           srvLogger,
@@ -257,6 +267,7 @@ environment:
   DRIVE9_LOCAL_DSN   local tenant TiDB/MySQL DSN (required)
   DRIVE9_LOCAL_INIT_SCHEMA initialize tenant schema on startup (default: false)
   DRIVE9_LOCAL_EMBEDDING_MODE auto|app|detect (default: auto when initing schema, detect otherwise)
+  DRIVE9_VAULT_MASTER_KEY 32-byte hex key for vault DEK wrapping (omit to disable vault)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
 
   S3 storage:

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -112,6 +112,7 @@ func main() {
 	masterHex := os.Getenv("DRIVE9_MASTER_KEY")
 	kmsKey := os.Getenv("DRIVE9_ENCRYPT_KEY")
 	tokenHex := os.Getenv("DRIVE9_TOKEN_SIGNING_KEY")
+	vaultMKHex := os.Getenv("DRIVE9_VAULT_MASTER_KEY")
 	providerType := envOr("DRIVE9_TENANT_PROVIDER", tenant.ProviderTiDBZero)
 	maxUploadBytes := server.DefaultMaxUploadBytes
 	if raw := os.Getenv("DRIVE9_MAX_UPLOAD_BYTES"); raw != "" {
@@ -144,6 +145,14 @@ func main() {
 		logger.Warn(context.Background(), "provisioner_not_configured", zap.String("provider", providerType), zap.Error(provisionerErr))
 	} else {
 		logger.Info(context.Background(), "provisioner_configured", zap.String("provider", providerType))
+	}
+
+	var vaultMasterKey []byte
+	if vaultMKHex != "" {
+		vaultMasterKey, err = hex.DecodeString(vaultMKHex)
+		if err != nil {
+			die(fmt.Errorf("invalid DRIVE9_VAULT_MASTER_KEY: %w", err))
+		}
 	}
 
 	var pool *tenant.Pool
@@ -194,6 +203,7 @@ func main() {
 			Pool:             pool,
 			Provisioner:      provisioner,
 			TokenSecret:      tokenSecret,
+			VaultMasterKey:   vaultMasterKey,
 			S3Dir:            s3Dir,
 			MaxUploadBytes:   maxUploadBytes,
 			Logger:           srvLogger,
@@ -209,6 +219,7 @@ func main() {
 		Pool:             pool,
 		Provisioner:      provisioner,
 		TokenSecret:      tokenSecret,
+		VaultMasterKey:   vaultMasterKey,
 		S3Dir:            s3Dir,
 		MaxUploadBytes:   maxUploadBytes,
 		Logger:           srvLogger,
@@ -242,6 +253,7 @@ environment:
   DRIVE9_MASTER_KEY  32-byte hex key for local_aes encryptor
   DRIVE9_ENCRYPT_KEY KMS key id or alias (required for kms)
   DRIVE9_TOKEN_SIGNING_KEY  32-byte hex key for JWT API key signing
+  DRIVE9_VAULT_MASTER_KEY   32-byte hex key for vault DEK wrapping (omit to disable vault)
   DRIVE9_MAX_UPLOAD_BYTES maximum allowed upload size in bytes (default: %d, minimum: 1048576)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
   DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)


### PR DESCRIPTION
## Summary
- Both `drive9-server` and `drive9-server-local` had `VaultMasterKey` on `server.Config` but never populated it from the environment, leaving `drive9 secret set` broken with "vault master key not configured"
- Read `DRIVE9_VAULT_MASTER_KEY` (hex-encoded 32-byte AES key) from env and wire it into all `server.Config` construction sites
- Added the env var to usage/help text in both entrypoints

## Test plan
- [ ] Start `drive9-server-local` with `DRIVE9_VAULT_MASTER_KEY=$(openssl rand -hex 32)` and verify `drive9 secret set test k=test1` succeeds
- [ ] Start without the env var and verify vault commands return the expected "not configured" error
- [ ] Verify `drive9-server --help` and `drive9-server-local --help` show the new env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)