### PR TITLE
fix: preserve flusher for SSE streaming path

### DIFF
--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -199,10 +199,13 @@ type observedResponseWriter struct {
 	size   int
 }
 
-func (w *observedResponseWriter) Flush() {
-	if f, ok := w.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
-	}
+type flusherResponseWriter struct {
+	*observedResponseWriter
+	flusher http.Flusher
+}
+
+func (w *flusherResponseWriter) Flush() {
+	w.flusher.Flush()
 }
 
 func (w *observedResponseWriter) WriteHeader(code int) {
@@ -261,10 +264,14 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 
 	start := time.Now()
 	ow := &observedResponseWriter{ResponseWriter: w}
+	rw := http.ResponseWriter(ow)
+	if f, ok := w.(http.Flusher); ok {
+		rw = &flusherResponseWriter{observedResponseWriter: ow, flusher: f}
+	}
 	s.metrics.inFlight.Add(1)
 	defer s.metrics.inFlight.Add(-1)
 
-	next.ServeHTTP(ow, r)
+	next.ServeHTTP(rw, r)
 	if ow.status == 0 {
 		ow.status = http.StatusOK
 	}

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -199,6 +199,12 @@ type observedResponseWriter struct {
 	size   int
 }
 
+func (w *observedResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 func (w *observedResponseWriter) WriteHeader(code int) {
 	w.status = code
 	w.ResponseWriter.WriteHeader(code)

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -10,6 +10,10 @@ type flushRecorder struct {
 	flushed bool
 }
 
+type plainRecorder struct {
+	header http.Header
+}
+
 func (r *flushRecorder) Header() http.Header {
 	if r.header == nil {
 		r.header = make(http.Header)
@@ -23,15 +27,37 @@ func (r *flushRecorder) WriteHeader(_ int) {}
 
 func (r *flushRecorder) Flush() { r.flushed = true }
 
-func TestObservedResponseWriterFlushDelegates(t *testing.T) {
-	rec := &flushRecorder{}
-	ow := &observedResponseWriter{ResponseWriter: rec}
+func (r *plainRecorder) Header() http.Header {
+	if r.header == nil {
+		r.header = make(http.Header)
+	}
+	return r.header
+}
 
-	if _, ok := interface{}(ow).(http.Flusher); !ok {
-		t.Fatal("observedResponseWriter should implement http.Flusher")
+func (r *plainRecorder) Write(p []byte) (int, error) { return len(p), nil }
+
+func (r *plainRecorder) WriteHeader(_ int) {}
+
+func TestObservedResponseWriterDoesNotAdvertiseFlush(t *testing.T) {
+	ow := &observedResponseWriter{ResponseWriter: &plainRecorder{}}
+
+	if _, ok := interface{}(ow).(http.Flusher); ok {
+		t.Fatal("observedResponseWriter should not implement http.Flusher")
+	}
+}
+
+func TestFlusherResponseWriterDelegatesFlush(t *testing.T) {
+	rec := &flushRecorder{}
+	fw := &flusherResponseWriter{
+		observedResponseWriter: &observedResponseWriter{ResponseWriter: rec},
+		flusher:                rec,
 	}
 
-	ow.Flush()
+	if _, ok := interface{}(fw).(http.Flusher); !ok {
+		t.Fatal("flusherResponseWriter should implement http.Flusher")
+	}
+
+	fw.Flush()
 	if !rec.flushed {
 		t.Fatal("expected Flush to delegate to wrapped writer")
 	}

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+)
+
+type flushRecorder struct {
+	header  http.Header
+	flushed bool
+}
+
+func (r *flushRecorder) Header() http.Header {
+	if r.header == nil {
+		r.header = make(http.Header)
+	}
+	return r.header
+}
+
+func (r *flushRecorder) Write(p []byte) (int, error) { return len(p), nil }
+
+func (r *flushRecorder) WriteHeader(_ int) {}
+
+func (r *flushRecorder) Flush() { r.flushed = true }
+
+func TestObservedResponseWriterFlushDelegates(t *testing.T) {
+	rec := &flushRecorder{}
+	ow := &observedResponseWriter{ResponseWriter: rec}
+
+	if _, ok := interface{}(ow).(http.Flusher); !ok {
+		t.Fatal("observedResponseWriter should implement http.Flusher")
+	}
+
+	ow.Flush()
+	if !rec.flushed {
+		t.Fatal("expected Flush to delegate to wrapped writer")
+	}
+}


### PR DESCRIPTION
Forward Flush from the observed response writer so /v1/events can stream through instrumentation middleware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP response handlers now preserve and expose flush capability so streaming clients can receive buffered output sooner.

* **Tests**
  * Added unit tests covering response writer behavior with and without flush support to ensure correct flush delegation and metrics tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->