### PR TITLE
feat: migrate llm_usage to control-plane meta store

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -180,14 +180,17 @@ func main() {
 			die(fmt.Errorf("control-plane db unavailable: %w", err))
 		}
 
+		llmUsageDualRead := os.Getenv("DRIVE9_LLM_USAGE_DUAL_READ") == "true"
 		pool = tenant.NewPool(tenant.PoolConfig{
-			S3Dir:          s3Dir,
-			PublicURL:      publicBaseURL(addr),
-			S3Bucket:       s3Bucket,
-			S3Region:       s3Region,
-			S3Prefix:       s3Prefix,
-			S3RoleARN:      s3RoleARN,
-			BackendOptions: backendOptions,
+			S3Dir:            s3Dir,
+			PublicURL:        publicBaseURL(addr),
+			S3Bucket:         s3Bucket,
+			S3Region:         s3Region,
+			S3Prefix:         s3Prefix,
+			S3RoleARN:        s3RoleARN,
+			BackendOptions:   backendOptions,
+			MetaStore:        store,
+			LLMUsageDualRead: llmUsageDualRead,
 		}, enc)
 		defer pool.Close()
 	}

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -65,12 +65,17 @@ type Dat9Backend struct {
 	maxAudioExtractTextBytes int
 
 	// Monthly LLM cost budget (P1).
-	maxMonthlyLLMCostMillicents    int64
-	visionCostPerKTokenMillicents  int64
+	maxMonthlyLLMCostMillicents     int64
+	visionCostPerKTokenMillicents   int64
 	audioLLMCostPerKTokenMillicents int64
-	whisperCostPerMinuteMillicents int64
-	fallbackImageCostMillicents    int64
-	fallbackAudioCostMillicents    int64
+	whisperCostPerMinuteMillicents  int64
+	fallbackImageCostMillicents     int64
+	fallbackAudioCostMillicents     int64
+
+	// Control-plane LLM usage (meta store migration).
+	metaLLMStore     MetaLLMUsageStore // nil = write to tenant datastore only
+	tenantID         string
+	llmUsageDualRead bool
 }
 
 func newBaseBackend(store *datastore.Store) *Dat9Backend {

--- a/pkg/backend/llm_usage.go
+++ b/pkg/backend/llm_usage.go
@@ -32,13 +32,7 @@ func (b *Dat9Backend) recordImageExtractUsage(taskID string, usage ImageExtractU
 	if cost <= 0 {
 		return
 	}
-	if err := b.store.InsertLLMUsage("img_extract_text", taskID, cost, totalTokens, "tokens"); err != nil {
-		logger.Warn(backgroundWithTrace(), "llm_usage_insert_failed",
-			zap.String("task_type", "img_extract_text"),
-			zap.String("task_id", taskID),
-			zap.Error(err))
-		metrics.RecordOperation("llm_cost_budget", "usage_insert", "error", 0)
-	}
+	b.insertLLMUsage("img_extract_text", taskID, cost, totalTokens, "tokens")
 }
 
 func (b *Dat9Backend) recordAudioExtractUsage(taskID string, usage AudioExtractUsage) {
@@ -62,9 +56,28 @@ func (b *Dat9Backend) recordAudioExtractUsage(taskID string, usage AudioExtractU
 	if cost <= 0 {
 		return
 	}
-	if err := b.store.InsertLLMUsage("audio_extract_text", taskID, cost, rawUnits, rawUnitType); err != nil {
+	b.insertLLMUsage("audio_extract_text", taskID, cost, rawUnits, rawUnitType)
+}
+
+// insertLLMUsage writes a usage record to the meta store (if configured) or
+// falls back to the per-tenant datastore.
+func (b *Dat9Backend) insertLLMUsage(taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) {
+	if b.metaLLMStore != nil && b.tenantID != "" {
+		ctx := backgroundWithTrace()
+		if err := b.metaLLMStore.InsertLLMUsage(ctx, b.tenantID, taskType, taskID, costMillicents, rawUnits, rawUnitType); err != nil {
+			logger.Warn(ctx, "llm_usage_meta_insert_failed",
+				zap.String("task_type", taskType),
+				zap.String("task_id", taskID),
+				zap.String("tenant_id", b.tenantID),
+				zap.Error(err))
+			metrics.RecordOperation("llm_cost_budget", "meta_usage_insert", "error", 0)
+		}
+		return
+	}
+	// Fallback: write to tenant datastore (pre-migration path).
+	if err := b.store.InsertLLMUsage(taskType, taskID, costMillicents, rawUnits, rawUnitType); err != nil {
 		logger.Warn(backgroundWithTrace(), "llm_usage_insert_failed",
-			zap.String("task_type", "audio_extract_text"),
+			zap.String("task_type", taskType),
 			zap.String("task_id", taskID),
 			zap.Error(err))
 		metrics.RecordOperation("llm_cost_budget", "usage_insert", "error", 0)
@@ -93,16 +106,51 @@ func (b *Dat9Backend) audioDurationCostMillicents(durationSeconds float64) int64
 }
 
 // monthlyLLMCostExceeded checks whether the tenant has exceeded its monthly
-// LLM cost budget. Returns true when the total settled cost exceeds the limit.
+// LLM cost budget. When meta store is configured, it reads from there
+// (with optional dual-read summing costs from both stores during transition).
+// Returns true when the total settled cost exceeds the limit.
 func (b *Dat9Backend) monthlyLLMCostExceeded() bool {
 	if b.maxMonthlyLLMCostMillicents <= 0 {
 		return false
 	}
-	total, err := b.store.MonthlyLLMCostMillicents()
+
+	var total int64
+
+	// Read from meta store if configured.
+	if b.metaLLMStore != nil && b.tenantID != "" {
+		ctx := backgroundWithTrace()
+		metaTotal, err := b.metaLLMStore.MonthlyLLMCostMillicents(ctx, b.tenantID)
+		if err != nil {
+			logger.Warn(ctx, "llm_cost_budget_meta_check_fail_open",
+				zap.String("tenant_id", b.tenantID),
+				zap.Error(err))
+			metrics.RecordOperation("llm_cost_budget", "meta_quota_check", "fail_open", 0)
+			return false
+		}
+		total = metaTotal
+
+		// Dual-read: also sum from tenant datastore for transition month.
+		if b.llmUsageDualRead {
+			tenantTotal, err := b.store.MonthlyLLMCostMillicents()
+			if err != nil {
+				logger.Warn(ctx, "llm_cost_budget_tenant_dual_read_failed",
+					zap.String("tenant_id", b.tenantID),
+					zap.Error(err))
+				// Continue with meta-only total; don't fail-open here since
+				// we already have a valid meta store reading.
+			} else {
+				total += tenantTotal
+			}
+		}
+		return total > b.maxMonthlyLLMCostMillicents
+	}
+
+	// Pre-migration: read from tenant datastore only.
+	tenantTotal, err := b.store.MonthlyLLMCostMillicents()
 	if err != nil {
 		logger.Warn(backgroundWithTrace(), "llm_cost_budget_check_fail_open", zap.Error(err))
 		metrics.RecordOperation("llm_cost_budget", "quota_check", "fail_open", 0)
 		return false
 	}
-	return total > b.maxMonthlyLLMCostMillicents
+	return tenantTotal > b.maxMonthlyLLMCostMillicents
 }

--- a/pkg/backend/llm_usage_test.go
+++ b/pkg/backend/llm_usage_test.go
@@ -1,0 +1,172 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// mockMetaLLMStore is a test double for MetaLLMUsageStore.
+type mockMetaLLMStore struct {
+	mu       sync.Mutex
+	inserts  []mockLLMInsert
+	monthly  int64
+	queryErr error
+}
+
+type mockLLMInsert struct {
+	TenantID, TaskType, TaskID string
+	CostMillicents, RawUnits  int64
+	RawUnitType               string
+}
+
+func (m *mockMetaLLMStore) InsertLLMUsage(_ context.Context, tenantID, taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inserts = append(m.inserts, mockLLMInsert{
+		TenantID: tenantID, TaskType: taskType, TaskID: taskID,
+		CostMillicents: costMillicents, RawUnits: rawUnits, RawUnitType: rawUnitType,
+	})
+	return nil
+}
+
+func (m *mockMetaLLMStore) MonthlyLLMCostMillicents(_ context.Context, _ string) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.monthly, m.queryErr
+}
+
+func TestInsertLLMUsage_MetaStore(t *testing.T) {
+	mock := &mockMetaLLMStore{}
+	b := &Dat9Backend{
+		metaLLMStore:                  mock,
+		tenantID:                      "tenant-1",
+		visionCostPerKTokenMillicents: 100,
+	}
+	b.recordImageExtractUsage("task-1", ImageExtractUsage{PromptTokens: 500, CompletionTokens: 500})
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.inserts) != 1 {
+		t.Fatalf("expected 1 insert, got %d", len(mock.inserts))
+	}
+	ins := mock.inserts[0]
+	if ins.TenantID != "tenant-1" {
+		t.Fatalf("tenant_id=%q, want tenant-1", ins.TenantID)
+	}
+	if ins.TaskType != "img_extract_text" {
+		t.Fatalf("task_type=%q, want img_extract_text", ins.TaskType)
+	}
+	// 1000 tokens * 100 per 1K = 100
+	if ins.CostMillicents != 100 {
+		t.Fatalf("cost=%d, want 100", ins.CostMillicents)
+	}
+}
+
+func TestInsertLLMUsage_AudioMetaStore(t *testing.T) {
+	mock := &mockMetaLLMStore{}
+	b := &Dat9Backend{
+		metaLLMStore:                    mock,
+		tenantID:                        "tenant-1",
+		audioLLMCostPerKTokenMillicents: 200,
+	}
+	b.recordAudioExtractUsage("task-2", AudioExtractUsage{InputTokens: 300, OutputTokens: 200})
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.inserts) != 1 {
+		t.Fatalf("expected 1 insert, got %d", len(mock.inserts))
+	}
+	ins := mock.inserts[0]
+	if ins.TaskType != "audio_extract_text" {
+		t.Fatalf("task_type=%q, want audio_extract_text", ins.TaskType)
+	}
+	// 500 tokens * 200 per 1K = 100
+	if ins.CostMillicents != 100 {
+		t.Fatalf("cost=%d, want 100", ins.CostMillicents)
+	}
+}
+
+func TestMonthlyLLMCostExceeded_MetaStore(t *testing.T) {
+	mock := &mockMetaLLMStore{monthly: 5000}
+	b := &Dat9Backend{
+		metaLLMStore:                mock,
+		tenantID:                    "tenant-1",
+		maxMonthlyLLMCostMillicents: 4000,
+	}
+	if !b.monthlyLLMCostExceeded() {
+		t.Fatal("expected exceeded, got false")
+	}
+}
+
+func TestMonthlyLLMCostExceeded_MetaStore_NotExceeded(t *testing.T) {
+	mock := &mockMetaLLMStore{monthly: 3000}
+	b := &Dat9Backend{
+		metaLLMStore:                mock,
+		tenantID:                    "tenant-1",
+		maxMonthlyLLMCostMillicents: 4000,
+	}
+	if b.monthlyLLMCostExceeded() {
+		t.Fatal("expected not exceeded, got true")
+	}
+}
+
+func TestMonthlyLLMCostExceeded_MetaStoreFailure_FailOpen(t *testing.T) {
+	mock := &mockMetaLLMStore{queryErr: errors.New("meta db down")}
+	b := &Dat9Backend{
+		metaLLMStore:                mock,
+		tenantID:                    "tenant-1",
+		maxMonthlyLLMCostMillicents: 4000,
+	}
+	if b.monthlyLLMCostExceeded() {
+		t.Fatal("expected fail-open (false), got true")
+	}
+}
+
+func TestMonthlyLLMCostExceeded_DisabledBudget(t *testing.T) {
+	b := &Dat9Backend{
+		maxMonthlyLLMCostMillicents: 0,
+	}
+	if b.monthlyLLMCostExceeded() {
+		t.Fatal("expected false when budget disabled")
+	}
+}
+
+func TestMonthlyLLMCostExceeded_NoMetaStore_FallbackTenantStore(t *testing.T) {
+	// Without meta store, the function falls back to b.store.MonthlyLLMCostMillicents().
+	// We can't easily mock that without a real datastore, so just test the nil
+	// metaLLMStore path doesn't panic.
+	b := &Dat9Backend{
+		maxMonthlyLLMCostMillicents: 4000,
+		// store is nil — will cause a panic if the nil-meta-store path is wrong.
+		// We expect a nil dereference to be caught. Actually this path requires
+		// a real store, so we skip this test when store is nil.
+	}
+	// Without a store, this would panic. The important thing to test is the
+	// meta store path, which is covered above.
+	_ = b
+}
+
+func TestInsertLLMUsage_NoMetaStore_NoPanic(t *testing.T) {
+	// When metaLLMStore is nil and tenantID is empty, insertLLMUsage should
+	// fall back to store.InsertLLMUsage. Without a real store, we test the
+	// meta-store path doesn't fire.
+	mock := &mockMetaLLMStore{}
+	b := &Dat9Backend{
+		metaLLMStore:                  mock,
+		tenantID:                      "", // empty tenantID = no meta write
+		visionCostPerKTokenMillicents: 100,
+	}
+	// This should NOT write to meta store since tenantID is empty.
+	// It would try to write to b.store which is nil, but cost is > 0 so
+	// it will attempt and panic. That's expected in real code — the backend
+	// always has a store. Just verify the meta path gate.
+	b.tenantID = "test"
+	b.recordImageExtractUsage("task-1", ImageExtractUsage{PromptTokens: 500, CompletionTokens: 500})
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.inserts) != 1 {
+		t.Fatalf("expected 1 meta insert, got %d", len(mock.inserts))
+	}
+}

--- a/pkg/backend/llm_usage_test.go
+++ b/pkg/backend/llm_usage_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"sync"
 	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/datastore"
 )
 
 // mockMetaLLMStore is a test double for MetaLLMUsageStore.
@@ -133,40 +135,81 @@ func TestMonthlyLLMCostExceeded_DisabledBudget(t *testing.T) {
 	}
 }
 
-func TestMonthlyLLMCostExceeded_NoMetaStore_FallbackTenantStore(t *testing.T) {
-	// Without meta store, the function falls back to b.store.MonthlyLLMCostMillicents().
-	// We can't easily mock that without a real datastore, so just test the nil
-	// metaLLMStore path doesn't panic.
-	b := &Dat9Backend{
-		maxMonthlyLLMCostMillicents: 4000,
-		// store is nil — will cause a panic if the nil-meta-store path is wrong.
-		// We expect a nil dereference to be caught. Actually this path requires
-		// a real store, so we skip this test when store is nil.
+func TestMonthlyLLMCostExceeded_DualRead(t *testing.T) {
+	// Meta store has 2000, tenant store has 2500.
+	// Budget is 4000 millicents. Sum = 4500 > 4000 → exceeded.
+	mock := &mockMetaLLMStore{monthly: 2000}
+	store := newTestStore(t)
+	// Insert some usage into the tenant store.
+	if err := store.InsertLLMUsage("img_extract_text", "task-1", 2500, 100, "tokens"); err != nil {
+		t.Fatal(err)
 	}
-	// Without a store, this would panic. The important thing to test is the
-	// meta store path, which is covered above.
-	_ = b
+
+	b := &Dat9Backend{
+		store:                       store,
+		metaLLMStore:                mock,
+		tenantID:                    "tenant-1",
+		maxMonthlyLLMCostMillicents: 4000,
+		llmUsageDualRead:            true,
+	}
+	if !b.monthlyLLMCostExceeded() {
+		t.Fatal("expected exceeded with dual-read (2000+2500=4500 > 4000), got false")
+	}
 }
 
-func TestInsertLLMUsage_NoMetaStore_NoPanic(t *testing.T) {
-	// When metaLLMStore is nil and tenantID is empty, insertLLMUsage should
-	// fall back to store.InsertLLMUsage. Without a real store, we test the
-	// meta-store path doesn't fire.
-	mock := &mockMetaLLMStore{}
+func TestMonthlyLLMCostExceeded_DualRead_NotExceeded(t *testing.T) {
+	// Meta store has 1000, tenant store has 1000. Sum = 2000 < 4000.
+	mock := &mockMetaLLMStore{monthly: 1000}
+	store := newTestStore(t)
+	if err := store.InsertLLMUsage("img_extract_text", "task-1", 1000, 50, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
 	b := &Dat9Backend{
-		metaLLMStore:                  mock,
-		tenantID:                      "", // empty tenantID = no meta write
-		visionCostPerKTokenMillicents: 100,
+		store:                       store,
+		metaLLMStore:                mock,
+		tenantID:                    "tenant-1",
+		maxMonthlyLLMCostMillicents: 4000,
+		llmUsageDualRead:            true,
 	}
-	// This should NOT write to meta store since tenantID is empty.
-	// It would try to write to b.store which is nil, but cost is > 0 so
-	// it will attempt and panic. That's expected in real code — the backend
-	// always has a store. Just verify the meta path gate.
-	b.tenantID = "test"
-	b.recordImageExtractUsage("task-1", ImageExtractUsage{PromptTokens: 500, CompletionTokens: 500})
-	mock.mu.Lock()
-	defer mock.mu.Unlock()
-	if len(mock.inserts) != 1 {
-		t.Fatalf("expected 1 meta insert, got %d", len(mock.inserts))
+	if b.monthlyLLMCostExceeded() {
+		t.Fatal("expected not exceeded with dual-read (1000+1000=2000 < 4000), got true")
 	}
+}
+
+func TestMonthlyLLMCostExceeded_DualRead_TenantStoreFailure(t *testing.T) {
+	// Meta store has 3000, tenant store query fails.
+	// Should continue with meta-only total: 3000 < 4000 → not exceeded.
+	mock := &mockMetaLLMStore{monthly: 3000}
+	// Use a store with a closed DB to simulate failure.
+	store := newTestStore(t)
+	_ = store.Close() // close DB to make queries fail
+
+	b := &Dat9Backend{
+		store:                       store,
+		metaLLMStore:                mock,
+		tenantID:                    "tenant-1",
+		maxMonthlyLLMCostMillicents: 4000,
+		llmUsageDualRead:            true,
+	}
+	// Should not panic, should use meta-only total.
+	if b.monthlyLLMCostExceeded() {
+		t.Fatal("expected not exceeded (meta-only 3000 < 4000), got true")
+	}
+}
+
+// newTestStore creates a datastore.Store backed by the test MySQL instance.
+func newTestStore(t *testing.T) *datastore.Store {
+	t.Helper()
+	if testDSN == "" {
+		t.Skip("test MySQL DSN not available")
+	}
+	store, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	// Clean llm_usage table.
+	_, _ = store.DB().Exec("DELETE FROM llm_usage")
+	return store
 }

--- a/pkg/backend/meta_llm.go
+++ b/pkg/backend/meta_llm.go
@@ -1,0 +1,10 @@
+package backend
+
+import "context"
+
+// MetaLLMUsageStore is the interface for control-plane LLM usage operations.
+// It is satisfied by *meta.Store and by *meta.LLMCostCache.
+type MetaLLMUsageStore interface {
+	InsertLLMUsage(ctx context.Context, tenantID, taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) error
+	MonthlyLLMCostMillicents(ctx context.Context, tenantID string) (int64, error)
+}

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -48,6 +48,16 @@ type Options struct {
 	MaxMediaLLMFiles int64
 	// LLMCostBudget configures the monthly LLM cost budget for this tenant.
 	LLMCostBudget LLMCostBudgetOptions
+	// MetaStore is the control-plane meta store. When set, LLM usage is
+	// recorded to (and budgets read from) the meta store instead of the
+	// per-tenant datastore.
+	MetaStore MetaLLMUsageStore
+	// TenantID identifies this tenant in the meta store's llm_usage table.
+	TenantID string
+	// LLMUsageDualRead enables dual-read mode during transition: budget checks
+	// sum costs from both meta store and tenant datastore. Set this to true
+	// during the first month of migration to avoid mid-month budget resets.
+	LLMUsageDualRead bool
 }
 
 // LLMCostBudgetOptions configures the monthly LLM cost budget.
@@ -137,6 +147,10 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 	b.whisperCostPerMinuteMillicents = cb.WhisperCostPerMinuteMillicents
 	b.fallbackImageCostMillicents = cb.FallbackImageCostMillicents
 	b.fallbackAudioCostMillicents = cb.FallbackAudioCostMillicents
+
+	b.metaLLMStore = opts.MetaStore
+	b.tenantID = opts.TenantID
+	b.llmUsageDualRead = opts.LLMUsageDualRead
 
 	if opts.QueryEmbedding.Client != nil {
 		b.queryEmbedder = opts.QueryEmbedding.Client

--- a/pkg/meta/llm_usage.go
+++ b/pkg/meta/llm_usage.go
@@ -80,7 +80,7 @@ func (c *LLMCostCache) InsertLLMUsage(ctx context.Context, tenantID, taskType, t
 		if c.cached != nil {
 			c.cached = &llmCostCacheEntry{
 				total:     c.cached.total + costMillicents,
-				fetchedAt: c.cached.fetchedAt,
+				fetchedAt: time.Now(),
 			}
 		}
 		c.version++

--- a/pkg/meta/llm_usage.go
+++ b/pkg/meta/llm_usage.go
@@ -52,8 +52,14 @@ type LLMCostCache struct {
 	store *Store
 	ttl   time.Duration
 
-	mu     sync.Mutex
-	cached *llmCostCacheEntry
+	mu      sync.Mutex
+	cached  *llmCostCacheEntry
+	version uint64 // bumped on every successful insert; prevents stale DB reads from overwriting insert-advanced cache
+
+	// afterDBRead is a test hook called after the DB read completes but before
+	// the cache is updated. It allows tests to inject concurrent inserts to
+	// exercise the read/insert interleaving race.
+	afterDBRead func()
 }
 
 // NewLLMCostCache creates a cache that wraps meta store budget lookups.
@@ -77,6 +83,7 @@ func (c *LLMCostCache) InsertLLMUsage(ctx context.Context, tenantID, taskType, t
 				fetchedAt: c.cached.fetchedAt,
 			}
 		}
+		c.version++
 		c.mu.Unlock()
 	}
 	return err
@@ -86,10 +93,24 @@ func (c *LLMCostCache) InsertLLMUsage(ctx context.Context, tenantID, taskType, t
 // on meta store failure. Returns (0, nil) on cold-start + meta store failure
 // (fail-open).
 func (c *LLMCostCache) MonthlyLLMCostMillicents(ctx context.Context, tenantID string) (int64, error) {
+	// Snapshot version before the (potentially slow) DB read so we can detect
+	// concurrent inserts that advanced the cache while we were querying.
+	c.mu.Lock()
+	vBefore := c.version
+	c.mu.Unlock()
+
 	total, err := c.store.MonthlyLLMCostMillicents(ctx, tenantID)
+	if c.afterDBRead != nil {
+		c.afterDBRead()
+	}
 	if err == nil {
 		c.mu.Lock()
-		c.cached = &llmCostCacheEntry{total: total, fetchedAt: time.Now()}
+		// Only overwrite the cache if no insert bumped the version since the
+		// DB read started. This prevents a stale DB result from reverting a
+		// more recent insert-advanced total.
+		if c.version == vBefore {
+			c.cached = &llmCostCacheEntry{total: total, fetchedAt: time.Now()}
+		}
 		c.mu.Unlock()
 		return total, nil
 	}

--- a/pkg/meta/llm_usage.go
+++ b/pkg/meta/llm_usage.go
@@ -108,7 +108,9 @@ func (c *LLMCostCache) MonthlyLLMCostMillicents(ctx context.Context, tenantID st
 		// Only overwrite the cache if no insert bumped the version since the
 		// DB read started. This prevents a stale DB result from reverting a
 		// more recent insert-advanced total.
-		if c.version == vBefore {
+		// Exception: if cached is nil (cold cache), always install — discarding
+		// a valid DB result when there's no fallback value is strictly worse.
+		if c.version == vBefore || c.cached == nil {
 			c.cached = &llmCostCacheEntry{total: total, fetchedAt: time.Now()}
 		}
 		c.mu.Unlock()

--- a/pkg/meta/llm_usage.go
+++ b/pkg/meta/llm_usage.go
@@ -2,6 +2,7 @@ package meta
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/metrics"
@@ -48,16 +49,19 @@ type llmCostCacheEntry struct {
 // It also delegates InsertLLMUsage to the underlying Store so callers can
 // use a single object for both reads and writes.
 type LLMCostCache struct {
-	store    *Store
-	tenantID string
-	ttl      time.Duration
+	store *Store
+	ttl   time.Duration
 
+	mu     sync.Mutex
 	cached *llmCostCacheEntry
 }
 
 // NewLLMCostCache creates a cache that wraps meta store budget lookups.
 func NewLLMCostCache(store *Store, tenantID string, ttl time.Duration) *LLMCostCache {
-	return &LLMCostCache{store: store, tenantID: tenantID, ttl: ttl}
+	// tenantID is accepted for API compatibility but not stored — callers
+	// pass tenantID per-call via MonthlyLLMCostMillicents.
+	_ = tenantID
+	return &LLMCostCache{store: store, ttl: ttl}
 }
 
 // InsertLLMUsage delegates to the underlying Store.
@@ -71,15 +75,20 @@ func (c *LLMCostCache) InsertLLMUsage(ctx context.Context, tenantID, taskType, t
 func (c *LLMCostCache) MonthlyLLMCostMillicents(ctx context.Context, tenantID string) (int64, error) {
 	total, err := c.store.MonthlyLLMCostMillicents(ctx, tenantID)
 	if err == nil {
+		c.mu.Lock()
 		c.cached = &llmCostCacheEntry{total: total, fetchedAt: time.Now()}
+		c.mu.Unlock()
 		return total, nil
 	}
 	// Meta store failure: return stale cache if available and not expired.
-	if c.cached != nil && time.Since(c.cached.fetchedAt) < c.ttl {
+	c.mu.Lock()
+	entry := c.cached
+	c.mu.Unlock()
+	if entry != nil && time.Since(entry.fetchedAt) < c.ttl {
 		metrics.RecordOperation("llm_cost_budget", "cache_stale_hit", "ok", 0)
-		return c.cached.total, nil
+		return entry.total, nil
 	}
 	// Cold start or cache expired: fail-open.
 	metrics.RecordOperation("llm_cost_budget", "cache_miss_fail_open", "ok", 0)
-	return 0, err
+	return 0, nil
 }

--- a/pkg/meta/llm_usage.go
+++ b/pkg/meta/llm_usage.go
@@ -1,0 +1,85 @@
+package meta
+
+import (
+	"context"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/metrics"
+)
+
+// InsertLLMUsage records one billable LLM call in the control-plane store.
+func (s *Store) InsertLLMUsage(ctx context.Context, tenantID, taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "insert_llm_usage", start, &err)
+	_, err = s.db.ExecContext(ctx, `INSERT INTO llm_usage (tenant_id, task_type, task_id, cost_millicents, raw_units, raw_unit_type, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		tenantID, taskType, taskID, costMillicents, rawUnits, rawUnitType, time.Now().UTC())
+	return err
+}
+
+// MonthlyLLMCostMillicents returns the sum of cost_millicents for a tenant in
+// the current calendar month (UTC).
+func (s *Store) MonthlyLLMCostMillicents(ctx context.Context, tenantID string) (total int64, err error) {
+	start := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+		metrics.RecordOperation("meta", "monthly_llm_cost", result, time.Since(start))
+	}()
+	now := time.Now().UTC()
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	err = s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(cost_millicents), 0) FROM llm_usage WHERE tenant_id = ? AND created_at >= ?`,
+		tenantID, monthStart).Scan(&total)
+	return total, err
+}
+
+// llmCostCacheEntry holds a cached monthly cost result with expiry.
+type llmCostCacheEntry struct {
+	total     int64
+	fetchedAt time.Time
+}
+
+// LLMCostCache provides a per-process stale cache for monthly LLM cost
+// lookups. On meta store failure, it returns the last known value until TTL
+// expires, providing fail-open behavior without losing budget enforcement.
+// It also delegates InsertLLMUsage to the underlying Store so callers can
+// use a single object for both reads and writes.
+type LLMCostCache struct {
+	store    *Store
+	tenantID string
+	ttl      time.Duration
+
+	cached *llmCostCacheEntry
+}
+
+// NewLLMCostCache creates a cache that wraps meta store budget lookups.
+func NewLLMCostCache(store *Store, tenantID string, ttl time.Duration) *LLMCostCache {
+	return &LLMCostCache{store: store, tenantID: tenantID, ttl: ttl}
+}
+
+// InsertLLMUsage delegates to the underlying Store.
+func (c *LLMCostCache) InsertLLMUsage(ctx context.Context, tenantID, taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) error {
+	return c.store.InsertLLMUsage(ctx, tenantID, taskType, taskID, costMillicents, rawUnits, rawUnitType)
+}
+
+// MonthlyLLMCostMillicents returns the current monthly cost, using the cache
+// on meta store failure. Returns (0, nil) on cold-start + meta store failure
+// (fail-open).
+func (c *LLMCostCache) MonthlyLLMCostMillicents(ctx context.Context, tenantID string) (int64, error) {
+	total, err := c.store.MonthlyLLMCostMillicents(ctx, tenantID)
+	if err == nil {
+		c.cached = &llmCostCacheEntry{total: total, fetchedAt: time.Now()}
+		return total, nil
+	}
+	// Meta store failure: return stale cache if available and not expired.
+	if c.cached != nil && time.Since(c.cached.fetchedAt) < c.ttl {
+		metrics.RecordOperation("llm_cost_budget", "cache_stale_hit", "ok", 0)
+		return c.cached.total, nil
+	}
+	// Cold start or cache expired: fail-open.
+	metrics.RecordOperation("llm_cost_budget", "cache_miss_fail_open", "ok", 0)
+	return 0, err
+}

--- a/pkg/meta/llm_usage.go
+++ b/pkg/meta/llm_usage.go
@@ -64,9 +64,22 @@ func NewLLMCostCache(store *Store, tenantID string, ttl time.Duration) *LLMCostC
 	return &LLMCostCache{store: store, ttl: ttl}
 }
 
-// InsertLLMUsage delegates to the underlying Store.
+// InsertLLMUsage delegates to the underlying Store. On success, it advances
+// the cached monthly total so that a subsequent stale-cache fallback reflects
+// the newly recorded cost.
 func (c *LLMCostCache) InsertLLMUsage(ctx context.Context, tenantID, taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) error {
-	return c.store.InsertLLMUsage(ctx, tenantID, taskType, taskID, costMillicents, rawUnits, rawUnitType)
+	err := c.store.InsertLLMUsage(ctx, tenantID, taskType, taskID, costMillicents, rawUnits, rawUnitType)
+	if err == nil && costMillicents > 0 {
+		c.mu.Lock()
+		if c.cached != nil {
+			c.cached = &llmCostCacheEntry{
+				total:     c.cached.total + costMillicents,
+				fetchedAt: c.cached.fetchedAt,
+			}
+		}
+		c.mu.Unlock()
+	}
+	return err
 }
 
 // MonthlyLLMCostMillicents returns the current monthly cost, using the cache

--- a/pkg/meta/llm_usage_test.go
+++ b/pkg/meta/llm_usage_test.go
@@ -264,6 +264,69 @@ func TestLLMCostCacheReadInsertInterleaving(t *testing.T) {
 	}
 }
 
+// TestLLMCostCacheColdCacheInterleaving is a regression test for the cold-cache
+// variant of the read/insert interleaving race. When cached is nil, a concurrent
+// insert bumps the version but cannot materialize a cache entry (it doesn't know
+// the total). The DB read must still install its result so the stale fallback
+// has a value to return.
+//
+// Timeline:
+//   1. cache = nil (cold start)
+//   2. goroutine A starts MonthlyLLMCostMillicents, snapshots vBefore = 0
+//   3. (hook) goroutine B InsertLLMUsage(+200), bumps version to 1, but cached stays nil
+//   4. goroutine A's DB read succeeds — must install cache despite version mismatch
+//   5. meta store goes down; stale fallback must return the DB result, not 0
+func TestLLMCostCacheColdCacheInterleaving(t *testing.T) {
+	s := newControlStore(t)
+	_, _ = s.DB().Exec("DELETE FROM llm_usage")
+
+	ctx := context.Background()
+	// Pre-insert so the DB has a non-zero total to return.
+	if err := s.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-1", 3000, 100, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := NewLLMCostCache(s, "t1", 1*time.Hour)
+	// cache.cached is nil at this point (cold cache).
+
+	hookCalled := false
+	cache.afterDBRead = func() {
+		hookCalled = true
+		// Simulate a concurrent insert during the DB read.
+		// This bumps version but cannot create a cache entry (cached is nil).
+		if err := cache.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-2", 200, 50, "tokens"); err != nil {
+			t.Errorf("insert in hook: %v", err)
+		}
+	}
+
+	// DB read succeeds (returns 3000 or 3200 depending on insert timing).
+	// Despite version mismatch, the result must be installed because cached is nil.
+	total, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hookCalled {
+		t.Fatal("afterDBRead hook was not called")
+	}
+
+	// Clear hook and close DB to force stale fallback.
+	cache.afterDBRead = nil
+	_ = s.Close()
+
+	// Stale fallback must return a non-zero value (the installed DB result),
+	// NOT 0 (which would mean the valid DB read was discarded).
+	total, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatalf("expected stale cache hit (no error), got err: %v", err)
+	}
+	if total == 0 {
+		t.Fatal("cold-cache interleaving: stale fallback returned 0, expected non-zero (DB result was discarded)")
+	}
+	// The exact value depends on whether the DB read saw the insert (3000 or 3200).
+	// Either is acceptable; the key invariant is total != 0.
+	t.Logf("cold-cache interleaving: stale fallback returned %d (valid)", total)
+}
+
 func TestLLMCostCacheColdStart_FailOpen(t *testing.T) {
 	s := newControlStore(t)
 

--- a/pkg/meta/llm_usage_test.go
+++ b/pkg/meta/llm_usage_test.go
@@ -50,7 +50,7 @@ func TestInsertAndQueryLLMUsage(t *testing.T) {
 	}
 }
 
-func TestLLMCostCacheStaleHit(t *testing.T) {
+func TestLLMCostCacheFreshHit(t *testing.T) {
 	s := newControlStore(t)
 	_, _ = s.DB().Exec("DELETE FROM llm_usage")
 
@@ -82,5 +82,94 @@ func TestLLMCostCacheStaleHit(t *testing.T) {
 	}
 	if total != 1500 {
 		t.Fatalf("got %d, want 1500", total)
+	}
+}
+
+func TestLLMCostCacheStaleHit(t *testing.T) {
+	s := newControlStore(t)
+	_, _ = s.DB().Exec("DELETE FROM llm_usage")
+
+	ctx := context.Background()
+	if err := s.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-1", 2000, 100, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := NewLLMCostCache(s, "t1", 1*time.Hour) // long TTL so cache won't expire
+
+	// Populate cache.
+	total, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2000 {
+		t.Fatalf("got %d, want 2000", total)
+	}
+
+	// Close the store's DB to simulate meta store failure.
+	_ = s.Close()
+
+	// Cache should return stale value.
+	total, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatalf("expected stale cache hit (no error), got err: %v", err)
+	}
+	if total != 2000 {
+		t.Fatalf("stale cache: got %d, want 2000", total)
+	}
+}
+
+func TestLLMCostCacheExpired_FailOpen(t *testing.T) {
+	s := newControlStore(t)
+	_, _ = s.DB().Exec("DELETE FROM llm_usage")
+
+	ctx := context.Background()
+	if err := s.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-1", 3000, 100, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use a very short TTL that will expire immediately.
+	cache := NewLLMCostCache(s, "t1", 1*time.Nanosecond)
+
+	// Populate cache.
+	total, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3000 {
+		t.Fatalf("got %d, want 3000", total)
+	}
+
+	// Wait for cache to expire.
+	time.Sleep(10 * time.Millisecond)
+
+	// Close the store's DB to simulate meta store failure.
+	_ = s.Close()
+
+	// Cache is expired + meta store down → fail-open (return 0, nil).
+	total, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatalf("expected fail-open (no error), got err: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("fail-open: got %d, want 0", total)
+	}
+}
+
+func TestLLMCostCacheColdStart_FailOpen(t *testing.T) {
+	s := newControlStore(t)
+
+	// Close immediately — meta store is unreachable from the start.
+	_ = s.Close()
+
+	cache := NewLLMCostCache(s, "t1", 30*time.Second)
+	ctx := context.Background()
+
+	// Cold start + meta store down → fail-open (return 0, nil).
+	total, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatalf("expected fail-open (no error), got err: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("cold-start fail-open: got %d, want 0", total)
 	}
 }

--- a/pkg/meta/llm_usage_test.go
+++ b/pkg/meta/llm_usage_test.go
@@ -155,6 +155,44 @@ func TestLLMCostCacheExpired_FailOpen(t *testing.T) {
 	}
 }
 
+func TestLLMCostCacheInsertAdvancesStaleFallback(t *testing.T) {
+	s := newControlStore(t)
+	_, _ = s.DB().Exec("DELETE FROM llm_usage")
+
+	ctx := context.Background()
+	if err := s.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-1", 4900, 100, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := NewLLMCostCache(s, "t1", 1*time.Hour)
+
+	// Populate cache with 4900.
+	total, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 4900 {
+		t.Fatalf("got %d, want 4900", total)
+	}
+
+	// Insert 200 via cache — should advance cached total to 5100.
+	if err := cache.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-2", 200, 50, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Close the store to simulate meta store failure.
+	_ = s.Close()
+
+	// Stale fallback should return 5100 (4900 + 200), not 4900.
+	total, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatalf("expected stale cache hit (no error), got err: %v", err)
+	}
+	if total != 5100 {
+		t.Fatalf("stale cache after insert: got %d, want 5100", total)
+	}
+}
+
 func TestLLMCostCacheColdStart_FailOpen(t *testing.T) {
 	s := newControlStore(t)
 

--- a/pkg/meta/llm_usage_test.go
+++ b/pkg/meta/llm_usage_test.go
@@ -193,6 +193,77 @@ func TestLLMCostCacheInsertAdvancesStaleFallback(t *testing.T) {
 	}
 }
 
+// TestLLMCostCacheReadInsertInterleaving is a regression test for the
+// read/insert race: a slow DB refresh must NOT overwrite a cache that was
+// bumped by a concurrent insert.
+//
+// Timeline simulated via afterDBRead hook:
+//   1. cache = 4900 (populated by initial read)
+//   2. goroutine A starts MonthlyLLMCostMillicents, DB returns 4900
+//   3. (between DB read and cache update) goroutine B InsertLLMUsage(+200),
+//      bumping cache to 5100 and version to 1
+//   4. goroutine A tries to overwrite cache with 4900 — version check prevents it
+//   5. meta store goes down; stale fallback must return 5100, not 4900
+func TestLLMCostCacheReadInsertInterleaving(t *testing.T) {
+	s := newControlStore(t)
+	_, _ = s.DB().Exec("DELETE FROM llm_usage")
+
+	ctx := context.Background()
+	if err := s.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-1", 4900, 100, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := NewLLMCostCache(s, "t1", 1*time.Hour)
+
+	// Step 1: populate cache with 4900.
+	total, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 4900 {
+		t.Fatalf("initial cache: got %d, want 4900", total)
+	}
+
+	// Step 2-4: set up the interleaving hook. After the next DB read completes
+	// (returning 4900 or 5100 depending on timing), inject a concurrent insert
+	// that bumps the cache to 5100 and the version counter.
+	hookCalled := false
+	cache.afterDBRead = func() {
+		hookCalled = true
+		// Simulate a concurrent insert happening between DB read and cache update.
+		if err := cache.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-2", 200, 50, "tokens"); err != nil {
+			t.Errorf("insert in hook: %v", err)
+		}
+	}
+
+	// This read triggers the hook: DB read completes, then insert bumps cache,
+	// then the read tries to overwrite — version check should prevent it.
+	total, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hookCalled {
+		t.Fatal("afterDBRead hook was not called")
+	}
+
+	// Clear the hook so it doesn't fire again.
+	cache.afterDBRead = nil
+
+	// Step 5: close DB to force stale fallback.
+	_ = s.Close()
+
+	// The stale fallback must return 5100 (4900 + 200), NOT the DB-read value
+	// that the refresh tried to write. This proves the version check prevented
+	// the stale overwrite.
+	total, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatalf("expected stale cache hit (no error), got err: %v", err)
+	}
+	if total != 5100 {
+		t.Fatalf("stale cache after interleaved insert: got %d, want 5100", total)
+	}
+}
+
 func TestLLMCostCacheColdStart_FailOpen(t *testing.T) {
 	s := newControlStore(t)
 

--- a/pkg/meta/llm_usage_test.go
+++ b/pkg/meta/llm_usage_test.go
@@ -367,7 +367,7 @@ func TestLLMCostCacheColdCacheInterleaving(t *testing.T) {
 
 	// Stale fallback must return a non-zero value (the installed DB result),
 	// NOT 0 (which would mean the valid DB read was discarded).
-	total, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
+	total, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
 	if err != nil {
 		t.Fatalf("expected stale cache hit (no error), got err: %v", err)
 	}

--- a/pkg/meta/llm_usage_test.go
+++ b/pkg/meta/llm_usage_test.go
@@ -1,0 +1,86 @@
+package meta
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInsertAndQueryLLMUsage(t *testing.T) {
+	s := newControlStore(t)
+	// Clean llm_usage table.
+	_, _ = s.DB().Exec("DELETE FROM llm_usage")
+
+	ctx := context.Background()
+	if err := s.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-1", 1500, 100, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertLLMUsage(ctx, "t1", "audio_extract_text", "task-2", 2500, 200, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+	// Different tenant.
+	if err := s.InsertLLMUsage(ctx, "t2", "img_extract_text", "task-3", 9999, 50, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	total, err := s.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 4000 {
+		t.Fatalf("got %d, want 4000", total)
+	}
+
+	// t2 should have its own total.
+	total2, err := s.MonthlyLLMCostMillicents(ctx, "t2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total2 != 9999 {
+		t.Fatalf("got %d, want 9999", total2)
+	}
+
+	// Non-existent tenant returns 0.
+	total3, err := s.MonthlyLLMCostMillicents(ctx, "t-nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total3 != 0 {
+		t.Fatalf("got %d, want 0", total3)
+	}
+}
+
+func TestLLMCostCacheStaleHit(t *testing.T) {
+	s := newControlStore(t)
+	_, _ = s.DB().Exec("DELETE FROM llm_usage")
+
+	ctx := context.Background()
+	if err := s.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-1", 1000, 100, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := NewLLMCostCache(s, "t1", 30*time.Second)
+
+	// First call: populates cache.
+	total, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1000 {
+		t.Fatalf("got %d, want 1000", total)
+	}
+
+	// Insert via cache delegates to store.
+	if err := cache.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-2", 500, 50, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fresh query should include the new insert.
+	total, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1500 {
+		t.Fatalf("got %d, want 1500", total)
+	}
+}

--- a/pkg/meta/llm_usage_test.go
+++ b/pkg/meta/llm_usage_test.go
@@ -193,6 +193,58 @@ func TestLLMCostCacheInsertAdvancesStaleFallback(t *testing.T) {
 	}
 }
 
+// TestLLMCostCacheInsertRefreshesFreshness verifies that a successful insert
+// resets the cache freshness (fetchedAt) so the stale fallback doesn't expire
+// prematurely. Regression test for: insert near TTL expiry should extend the
+// cache lifetime, not leave fetchedAt at the original DB read time.
+func TestLLMCostCacheInsertRefreshesFreshness(t *testing.T) {
+	s := newControlStore(t)
+	_, _ = s.DB().Exec("DELETE FROM llm_usage")
+
+	ctx := context.Background()
+	if err := s.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-1", 4900, 100, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use a short TTL so we can test near-expiry behavior.
+	cache := NewLLMCostCache(s, "t1", 100*time.Millisecond)
+
+	// Populate cache at t=0.
+	total, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 4900 {
+		t.Fatalf("got %d, want 4900", total)
+	}
+
+	// Wait until close to TTL expiry.
+	time.Sleep(80 * time.Millisecond)
+
+	// Insert near expiry — should refresh fetchedAt to now.
+	if err := cache.InsertLLMUsage(ctx, "t1", "img_extract_text", "task-2", 200, 50, "tokens"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait past the original TTL (>100ms from initial read).
+	time.Sleep(50 * time.Millisecond)
+
+	// Close DB to force stale fallback.
+	_ = s.Close()
+
+	// If fetchedAt was refreshed by the insert, cache is still fresh (only ~50ms
+	// since insert, well within 100ms TTL). Stale fallback should return 5100.
+	// If fetchedAt was NOT refreshed, the cache expired (>100ms since original
+	// read) and we'd get 0 (fail-open).
+	total, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
+	if err != nil {
+		t.Fatalf("expected stale cache hit, got err: %v", err)
+	}
+	if total != 5100 {
+		t.Fatalf("near-expiry insert freshness: got %d, want 5100", total)
+	}
+}
+
 // TestLLMCostCacheReadInsertInterleaving is a regression test for the
 // read/insert race: a slow DB refresh must NOT overwrite a cache that was
 // bumped by a concurrent insert.
@@ -238,7 +290,7 @@ func TestLLMCostCacheReadInsertInterleaving(t *testing.T) {
 
 	// This read triggers the hook: DB read completes, then insert bumps cache,
 	// then the read tries to overwrite — version check should prevent it.
-	total, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
+	_, err = cache.MonthlyLLMCostMillicents(ctx, "t1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +353,7 @@ func TestLLMCostCacheColdCacheInterleaving(t *testing.T) {
 
 	// DB read succeeds (returns 3000 or 3200 depending on insert timing).
 	// Despite version mismatch, the result must be installed because cached is nil.
-	total, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
+	_, err := cache.MonthlyLLMCostMillicents(ctx, "t1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -145,6 +145,18 @@ func (s *Store) migrate() error {
 			INDEX idx_api_keys_tenant (tenant_id, status),
 			UNIQUE INDEX idx_api_keys_tenant_name (tenant_id, key_name)
 		)`,
+		`CREATE TABLE IF NOT EXISTS llm_usage (
+			id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+			tenant_id       VARCHAR(64) NOT NULL,
+			task_type       VARCHAR(64) NOT NULL,
+			task_id         VARCHAR(255) NOT NULL,
+			cost_millicents BIGINT NOT NULL,
+			raw_units       BIGINT NOT NULL DEFAULT 0,
+			raw_unit_type   VARCHAR(32) NOT NULL DEFAULT '',
+			created_at      DATETIME(3) NOT NULL,
+			INDEX idx_llm_usage_tenant_created (tenant_id, created_at),
+			INDEX idx_llm_usage_created (created_at)
+		)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := s.db.Exec(stmt); err != nil {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -15,6 +15,7 @@ func newControlStore(t *testing.T) *Store {
 	t.Cleanup(func() { _ = s.Close() })
 	_, _ = s.DB().Exec("DELETE FROM tenant_api_keys")
 	_, _ = s.DB().Exec("DELETE FROM tenants")
+	_, _ = s.DB().Exec("DELETE FROM llm_usage")
 	return s
 }
 

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -31,6 +31,13 @@ type PoolConfig struct {
 	S3RoleARN  string
 
 	BackendOptions backend.Options
+
+	// MetaStore is the control-plane store for LLM usage. When set, tenant
+	// backends write LLM usage to and read budgets from this store.
+	MetaStore *meta.Store
+	// LLMUsageDualRead enables summing LLM costs from both meta store and
+	// tenant datastore during the transition month.
+	LLMUsageDualRead bool
 }
 
 type Pool struct {
@@ -295,6 +302,11 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	opts := p.cfg.BackendOptions
 	if UsesTiDBAutoEmbedding(t.Provider) {
 		opts.DatabaseAutoEmbedding = true
+	}
+	if p.cfg.MetaStore != nil {
+		opts.MetaStore = meta.NewLLMCostCache(p.cfg.MetaStore, t.ID, 30*time.Second)
+		opts.TenantID = t.ID
+		opts.LLMUsageDualRead = p.cfg.LLMUsageDualRead
 	}
 	query := "parseTime=true"
 	if t.DBTLS {


### PR DESCRIPTION
## Summary

- Migrate LLM cost budget enforcement (P1) from per-tenant TiDB Zero databases to the drive9 server's control-plane meta store
- Prevents tenants from viewing/modifying their own LLM cost records (security fix)
- P0 (media file count quota) stays in tenant DB — it reuses the `files` table directly

## Changes

### Meta store (`pkg/meta`)
- Add `llm_usage` table to schema with `tenant_id VARCHAR(64)`, indexed on `(tenant_id, created_at)` and `(created_at)`
- Add `InsertLLMUsage()` and `MonthlyLLMCostMillicents()` methods
- Add `LLMCostCache` — per-process stale cache (30s TTL) for fail-open on meta store failure

### Backend (`pkg/backend`)
- Add `MetaLLMUsageStore` interface (decouples from `meta` package)
- Add `metaLLMStore`, `tenantID`, `llmUsageDualRead` fields to `Dat9Backend`
- `recordImageExtractUsage` / `recordAudioExtractUsage` → write to meta store when configured
- `monthlyLLMCostExceeded` → read from meta store with dual-read support for transition month
- Add `MetaStore`, `TenantID`, `LLMUsageDualRead` to `Options`

### Pool/Wiring (`pkg/tenant`)
- Add `MetaStore` and `LLMUsageDualRead` to `PoolConfig`
- `createBackend()` wraps meta store with `LLMCostCache` per tenant

### Server (`cmd/drive9-server`)
- Pass meta store into pool config
- Add `DRIVE9_LLM_USAGE_DUAL_READ=true` env flag for transition month

## Design decisions

- **Dual-read (runtime flag)**: During transition month, budget checks sum costs from both meta store and tenant datastore to avoid mid-month budget reset
- **Stale cache**: 30s TTL per-process cache. On meta store failure, returns last known value. Cold start + meta store unreachable = fail-open (0 cost)
- **No old data migration**: Monthly reset makes old tenant DB data naturally expire. Dual-read covers the transition
- **Tenant DB `llm_usage` table not dropped**: Left as historical record

## Test plan

- [ ] CI passes (build + lint + tests)
- [ ] `pkg/meta/llm_usage_test.go`: Insert/query integration tests, tenant isolation, LLMCostCache stale hit
- [ ] `pkg/backend/llm_usage_test.go`: Unit tests with mock MetaLLMUsageStore — meta store insert, budget exceeded/not-exceeded, meta store failure fail-open, disabled budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized LLM usage tracking infrastructure for improved cost visibility and budget management.
  * Introduced dual-read capability for budget verification across multiple sources during migration periods.
  * Implemented intelligent caching layer to optimize monthly cost calculations and budget checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->