### PR TITLE
feat(client): add recursive rm helper and CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ Inspired by Plan 9's "everything is a file" and the idea that naming things is t
 
 ```bash
 # CLI
-drive9 cp ./data.tar :/data/data.tar
-drive9 cat :/config/app.json
-drive9 ls :/data/
-drive9 cp :/a.bin :/b.bin        # zero-copy
-drive9 mv :/old.bin :/new.bin    # metadata-only
+drive9 fs cp ./data.tar :/data/data.tar
+drive9 fs cat :/config/app.json
+drive9 fs ls :/data/
+drive9 fs cp :/a.bin :/b.bin        # zero-copy
+drive9 fs mv :/old.bin :/new.bin    # metadata-only
+drive9 fs rm :/old.bin              # remove file
+drive9 fs rm -r :/old-dir/          # recursive delete
 
 # Mount
 drive9 mount /mnt/drive9

--- a/cmd/drive9/cli/rm.go
+++ b/cmd/drive9/cli/rm.go
@@ -13,27 +13,33 @@ import (
 //	drive9 fs rm --recursive :/path/to/dir/
 func Rm(c *client.Client, args []string) error {
 	var (
-		path      string
-		recursive bool
+		path       string
+		parseFlags = true
+		recursive  bool
 	)
 
 	for _, arg := range args {
-		switch arg {
-		case "-r", "--recursive":
-			recursive = true
-		default:
+		if parseFlags {
+			switch arg {
+			case "-r", "--recursive":
+				recursive = true
+				continue
+			case "--":
+				parseFlags = false
+				continue
+			}
 			if len(arg) > 0 && arg[0] == '-' {
 				return fmt.Errorf("unknown flag %q", arg)
 			}
-			if path != "" {
-				return fmt.Errorf("usage: drive9 rm [-r|--recursive] <path>")
-			}
-			path = arg
 		}
+		if path != "" {
+			return fmt.Errorf("usage: drive9 fs rm [-r|--recursive] <path>")
+		}
+		path = arg
 	}
 
 	if path == "" {
-		return fmt.Errorf("usage: drive9 rm [-r|--recursive] <path>")
+		return fmt.Errorf("usage: drive9 fs rm [-r|--recursive] <path>")
 	}
 
 	// Handle ":" prefixed remote paths like cp command

--- a/cmd/drive9/cli/rm.go
+++ b/cmd/drive9/cli/rm.go
@@ -8,16 +8,40 @@ import (
 
 // Rm removes a remote file or directory.
 //
-//	drive9 rm /path/to/file
-//	drive9 rm :/path/to/file
+//	drive9 fs rm /path/to/file
+//	drive9 fs rm -r /path/to/dir/
+//	drive9 fs rm --recursive :/path/to/dir/
 func Rm(c *client.Client, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("usage: drive9 rm <path>")
+	var (
+		path      string
+		recursive bool
+	)
+
+	for _, arg := range args {
+		switch arg {
+		case "-r", "--recursive":
+			recursive = true
+		default:
+			if len(arg) > 0 && arg[0] == '-' {
+				return fmt.Errorf("unknown flag %q", arg)
+			}
+			if path != "" {
+				return fmt.Errorf("usage: drive9 rm [-r|--recursive] <path>")
+			}
+			path = arg
+		}
 	}
-	path := args[0]
+
+	if path == "" {
+		return fmt.Errorf("usage: drive9 rm [-r|--recursive] <path>")
+	}
+
 	// Handle ":" prefixed remote paths like cp command
 	if rp, isRemote := ParseRemote(path); isRemote {
 		path = rp.Path
+	}
+	if recursive {
+		return c.RemoveAll(path)
 	}
 	return c.Delete(path)
 }

--- a/cmd/drive9/cli/rm_test.go
+++ b/cmd/drive9/cli/rm_test.go
@@ -43,10 +43,12 @@ func TestRm(t *testing.T) {
 	t.Run("recursive_delete", func(t *testing.T) {
 		var gotPath string
 		var gotRecursive bool
+		var gotRawQuery string
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotPath = r.URL.Path
 			gotRecursive = r.URL.Query().Has("recursive")
+			gotRawQuery = r.URL.RawQuery
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"status":"ok"}`))
 		}))
@@ -63,15 +65,20 @@ func TestRm(t *testing.T) {
 		if !gotRecursive {
 			t.Fatal("Rm(recursive) did not send recursive query")
 		}
+		if gotRawQuery != "recursive=1" {
+			t.Fatalf("Rm(recursive) raw query = %q, want %q", gotRawQuery, "recursive=1")
+		}
 	})
 
 	t.Run("recursive_remote_path", func(t *testing.T) {
 		var gotPath string
 		var gotRecursive bool
+		var gotRawQuery string
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotPath = r.URL.Path
 			gotRecursive = r.URL.Query().Has("recursive")
+			gotRawQuery = r.URL.RawQuery
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"status":"ok"}`))
 		}))
@@ -87,6 +94,9 @@ func TestRm(t *testing.T) {
 		}
 		if !gotRecursive {
 			t.Fatal("Rm(recursive remote) did not send recursive query")
+		}
+		if gotRawQuery != "recursive=1" {
+			t.Fatalf("Rm(recursive remote) raw query = %q, want %q", gotRawQuery, "recursive=1")
 		}
 	})
 

--- a/cmd/drive9/cli/rm_test.go
+++ b/cmd/drive9/cli/rm_test.go
@@ -89,6 +89,31 @@ func TestRm(t *testing.T) {
 			t.Fatal("Rm(recursive remote) did not send recursive query")
 		}
 	})
+
+	t.Run("double_dash_allows_dash_prefixed_path", func(t *testing.T) {
+		var gotPath string
+		var gotRecursive bool
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotRecursive = r.URL.Query().Has("recursive")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		if err := Rm(c, []string{"--", "-dash.txt"}); err != nil {
+			t.Fatalf("Rm(double dash) error = %v", err)
+		}
+
+		if gotPath != "/v1/fs/-dash.txt" {
+			t.Fatalf("Rm(double dash) path = %q, want %q", gotPath, "/v1/fs/-dash.txt")
+		}
+		if gotRecursive {
+			t.Fatal("Rm(double dash) unexpectedly sent recursive query")
+		}
+	})
 }
 
 func TestRmInvalidArgs(t *testing.T) {
@@ -107,7 +132,7 @@ func TestRmInvalidArgs(t *testing.T) {
 		{
 			name:    "missing_path",
 			args:    nil,
-			wantErr: "usage: drive9 rm [-r|--recursive] <path>",
+			wantErr: "usage: drive9 fs rm [-r|--recursive] <path>",
 		},
 		{
 			name:    "unknown_flag",
@@ -117,7 +142,7 @@ func TestRmInvalidArgs(t *testing.T) {
 		{
 			name:    "extra_path",
 			args:    []string{"-r", "/dir/", "/extra"},
-			wantErr: "usage: drive9 rm [-r|--recursive] <path>",
+			wantErr: "usage: drive9 fs rm [-r|--recursive] <path>",
 		},
 	}
 

--- a/cmd/drive9/cli/rm_test.go
+++ b/cmd/drive9/cli/rm_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+func TestRm(t *testing.T) {
+	t.Run("non_recursive_delete", func(t *testing.T) {
+		var gotMethod string
+		var gotPath string
+		var gotRecursive bool
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			gotRecursive = r.URL.Query().Has("recursive")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		if err := Rm(c, []string{"/a.txt"}); err != nil {
+			t.Fatalf("Rm(non-recursive) error = %v", err)
+		}
+
+		if gotMethod != http.MethodDelete {
+			t.Fatalf("Rm(non-recursive) method = %q, want %q", gotMethod, http.MethodDelete)
+		}
+		if gotPath != "/v1/fs/a.txt" {
+			t.Fatalf("Rm(non-recursive) path = %q, want %q", gotPath, "/v1/fs/a.txt")
+		}
+		if gotRecursive {
+			t.Fatal("Rm(non-recursive) unexpectedly sent recursive query")
+		}
+	})
+
+	t.Run("recursive_delete", func(t *testing.T) {
+		var gotPath string
+		var gotRecursive bool
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotRecursive = r.URL.Query().Has("recursive")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		if err := Rm(c, []string{"-r", "/dir/"}); err != nil {
+			t.Fatalf("Rm(recursive) error = %v", err)
+		}
+
+		if gotPath != "/v1/fs/dir/" {
+			t.Fatalf("Rm(recursive) path = %q, want %q", gotPath, "/v1/fs/dir/")
+		}
+		if !gotRecursive {
+			t.Fatal("Rm(recursive) did not send recursive query")
+		}
+	})
+
+	t.Run("recursive_remote_path", func(t *testing.T) {
+		var gotPath string
+		var gotRecursive bool
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotRecursive = r.URL.Query().Has("recursive")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		if err := Rm(c, []string{"--recursive", ":/dir/"}); err != nil {
+			t.Fatalf("Rm(recursive remote) error = %v", err)
+		}
+
+		if gotPath != "/v1/fs/dir/" {
+			t.Fatalf("Rm(recursive remote) path = %q, want %q", gotPath, "/v1/fs/dir/")
+		}
+		if !gotRecursive {
+			t.Fatal("Rm(recursive remote) did not send recursive query")
+		}
+	})
+}
+
+func TestRmInvalidArgs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing_path",
+			args:    nil,
+			wantErr: "usage: drive9 rm [-r|--recursive] <path>",
+		},
+		{
+			name:    "unknown_flag",
+			args:    []string{"-f", "/dir/"},
+			wantErr: `unknown flag "-f"`,
+		},
+		{
+			name:    "extra_path",
+			args:    []string{"-r", "/dir/", "/extra"},
+			wantErr: "usage: drive9 rm [-r|--recursive] <path>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Rm(c, tt.args)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Rm(%v) error = %q, want substring %q", tt.args, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/drive9/cli/sh.go
+++ b/cmd/drive9/cli/sh.go
@@ -113,20 +113,7 @@ func Sh(c *client.Client, _ []string) error {
 				fmt.Fprintln(os.Stderr, "usage: rm [-r|--recursive] <path>")
 				continue
 			}
-			resolvedArgs := make([]string, 0, len(args))
-			for _, arg := range args {
-				switch arg {
-				case "-r", "--recursive":
-					resolvedArgs = append(resolvedArgs, arg)
-				default:
-					if strings.HasPrefix(arg, "-") {
-						resolvedArgs = append(resolvedArgs, arg)
-						continue
-					}
-					resolvedArgs = append(resolvedArgs, resolve(cwd, arg))
-				}
-			}
-			if err := Rm(c, resolvedArgs); err != nil {
+			if err := Rm(c, resolveRmArgs(cwd, args)); err != nil {
 				fmt.Fprintf(os.Stderr, "rm: %v\n", err)
 			}
 
@@ -164,6 +151,30 @@ func resolve(cwd, path string) string {
 	return canon
 }
 
+func resolveRmArgs(cwd string, args []string) []string {
+	resolvedArgs := make([]string, 0, len(args))
+	parseFlags := true
+	for _, arg := range args {
+		if parseFlags {
+			switch arg {
+			case "-r", "--recursive":
+				resolvedArgs = append(resolvedArgs, arg)
+				continue
+			case "--":
+				parseFlags = false
+				resolvedArgs = append(resolvedArgs, arg)
+				continue
+			}
+			if strings.HasPrefix(arg, "-") {
+				resolvedArgs = append(resolvedArgs, arg)
+				continue
+			}
+		}
+		resolvedArgs = append(resolvedArgs, resolve(cwd, arg))
+	}
+	return resolvedArgs
+}
+
 func shHelp() {
 	fmt.Println(`commands:
   cd [path]       change directory
@@ -172,7 +183,7 @@ func shHelp() {
   cat <path>      read file
   cp <src> <dst>  copy files
   mv <old> <new>  rename/move
-  rm [-r] <path>  remove
+  rm [-r|--recursive] <path>  remove
   stat <path>     file metadata
   help            this help
   exit            quit shell`)

--- a/cmd/drive9/cli/sh.go
+++ b/cmd/drive9/cli/sh.go
@@ -109,11 +109,24 @@ func Sh(c *client.Client, _ []string) error {
 			}
 
 		case "rm":
-			if len(args) != 1 {
-				fmt.Fprintln(os.Stderr, "usage: rm <path>")
+			if len(args) < 1 {
+				fmt.Fprintln(os.Stderr, "usage: rm [-r|--recursive] <path>")
 				continue
 			}
-			if err := Rm(c, []string{resolve(cwd, args[0])}); err != nil {
+			resolvedArgs := make([]string, 0, len(args))
+			for _, arg := range args {
+				switch arg {
+				case "-r", "--recursive":
+					resolvedArgs = append(resolvedArgs, arg)
+				default:
+					if strings.HasPrefix(arg, "-") {
+						resolvedArgs = append(resolvedArgs, arg)
+						continue
+					}
+					resolvedArgs = append(resolvedArgs, resolve(cwd, arg))
+				}
+			}
+			if err := Rm(c, resolvedArgs); err != nil {
 				fmt.Fprintf(os.Stderr, "rm: %v\n", err)
 			}
 
@@ -159,7 +172,7 @@ func shHelp() {
   cat <path>      read file
   cp <src> <dst>  copy files
   mv <old> <new>  rename/move
-  rm <path>       remove
+  rm [-r] <path>  remove
   stat <path>     file metadata
   help            this help
   exit            quit shell`)

--- a/cmd/drive9/cli/sh_test.go
+++ b/cmd/drive9/cli/sh_test.go
@@ -1,6 +1,9 @@
 package cli
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestResolve(t *testing.T) {
 	tests := []struct {
@@ -19,5 +22,42 @@ func TestResolve(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("resolve(%q, %q) = %q, want %q", tt.cwd, tt.path, got, tt.want)
 		}
+	}
+}
+
+func TestResolveRmArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		cwd  string
+		args []string
+		want []string
+	}{
+		{
+			name: "preserves_recursive_flag",
+			cwd:  "/data/",
+			args: []string{"-r", "dir/"},
+			want: []string{"-r", "/data/dir"},
+		},
+		{
+			name: "double_dash_stops_flag_parsing",
+			cwd:  "/data/",
+			args: []string{"-r", "--", "-scratch"},
+			want: []string{"-r", "--", "/data/-scratch"},
+		},
+		{
+			name: "unknown_flag_is_left_for_rm",
+			cwd:  "/data/",
+			args: []string{"-f", "dir/"},
+			want: []string{"-f", "/data/dir"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveRmArgs(tt.cwd, tt.args)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("resolveRmArgs(%q, %v) = %v, want %v", tt.cwd, tt.args, got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -233,7 +233,8 @@ commands:
   ls [path]            list directory
   stat <path>          file metadata
   mv <old> <new>       rename/move
-  rm <path>            remove
+  rm [-r|--recursive] <path>
+                       remove file or directory tree
   sh                   interactive shell
   grep <pattern> [dir] search file contents
   find [dir] [flags]   find files by attributes

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -311,7 +311,26 @@ func (c *Client) Delete(path string) error {
 
 // DeleteCtx removes a file or directory with context support.
 func (c *Client) DeleteCtx(ctx context.Context, path string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.url(path), nil)
+	return c.deleteCtx(ctx, path, false)
+}
+
+// RemoveAll removes a file or directory tree recursively.
+func (c *Client) RemoveAll(path string) error {
+	return c.RemoveAllCtx(context.Background(), path)
+}
+
+// RemoveAllCtx removes a file or directory tree recursively with context support.
+func (c *Client) RemoveAllCtx(ctx context.Context, path string) error {
+	return c.deleteCtx(ctx, path, true)
+}
+
+func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool) error {
+	requestURL := c.url(path)
+	if recursive {
+		requestURL += "?recursive"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -332,7 +332,8 @@ func (c *Client) RemoveAllCtx(ctx context.Context, path string) error {
 func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool) error {
 	requestURL := c.url(path)
 	if recursive {
-		requestURL += "?recursive"
+		// Use an explicit value to avoid intermediaries dropping bare "?recursive".
+		requestURL += "?recursive=1"
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -315,11 +315,16 @@ func (c *Client) DeleteCtx(ctx context.Context, path string) error {
 }
 
 // RemoveAll removes a file or directory tree recursively.
+// If path names a regular file, RemoveAll behaves like Delete.
+// If path does not exist, RemoveAll returns the same 404 *StatusError as Delete
+// instead of succeeding like os.RemoveAll.
 func (c *Client) RemoveAll(path string) error {
 	return c.RemoveAllCtx(context.Background(), path)
 }
 
 // RemoveAllCtx removes a file or directory tree recursively with context support.
+// It forwards to deleteCtx with recursive=true, so regular files use Delete
+// semantics and missing paths return the same 404 *StatusError as RemoveAll.
 func (c *Client) RemoveAllCtx(ctx context.Context, path string) error {
 	return c.deleteCtx(ctx, path, true)
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -115,6 +115,34 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestRemoveAll(t *testing.T) {
+	c, cleanup := newTestClient(t)
+	defer cleanup()
+
+	if err := c.Mkdir("/data"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Write("/data/a.txt", []byte("a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Mkdir("/data/nested"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Write("/data/nested/b.txt", []byte("b")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.RemoveAll("/data/"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Stat("/data/"); err == nil {
+		t.Fatal("expected error after recursive delete")
+	}
+	if _, err := c.Read("/data/nested/b.txt"); err == nil {
+		t.Fatal("expected nested file read to fail after recursive delete")
+	}
+}
+
 func TestCopy(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -138,8 +138,20 @@ func TestRemoveAll(t *testing.T) {
 	if _, err := c.Stat("/data/"); err == nil {
 		t.Fatal("expected error after recursive delete")
 	}
+	if _, err := c.Read("/data/a.txt"); err == nil {
+		t.Fatal("expected sibling file read to fail after recursive delete")
+	}
 	if _, err := c.Read("/data/nested/b.txt"); err == nil {
 		t.Fatal("expected nested file read to fail after recursive delete")
+	}
+	entries, err := c.List("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.Name == "data" || entry.Name == "data/" {
+			t.Fatalf("expected removed directory to be absent from root listing, got entries %+v", entries)
+		}
 	}
 }
 

--- a/site/skill.md
+++ b/site/skill.md
@@ -76,6 +76,7 @@ drive9 fs stat :/path/to/file              # metadata (size, type, mtime)
 # move / remove
 drive9 fs mv :/old.txt :/new.txt
 drive9 fs rm :/path/to/file
+drive9 fs rm -r :/path/to/dir/
 
 # interactive shell
 drive9 fs sh


### PR DESCRIPTION
## Summary
- add `Client.RemoveAll` / `RemoveAllCtx` on top of the existing `DELETE ...?recursive` server API
- support `drive9 fs rm -r|--recursive <path>` in both the CLI and interactive shell
- document both file removal and recursive directory removal examples in README and CLI docs

## Testing
- `TESTCONTAINERS_RYUK_DISABLED=true go test ./pkg/client ./cmd/drive9/cli -v`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recursive directory deletion using `drive9 fs rm -r <path>` flag, allowing removal of entire directory trees alongside existing file deletion.

* **Documentation**
  * Updated CLI examples and help text to show the new `-r|--recursive` syntax for the `rm` command.

* **Tests**
  * Added test coverage for recursive and non-recursive deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->