### PR TITLE
fix: convert vault SQL to TiDB/MySQL dialect

### DIFF
--- a/cmd/drive9-server/schema_test.go
+++ b/cmd/drive9-server/schema_test.go
@@ -34,17 +34,21 @@ func TestSchemaDumpInitSQLByProvider(t *testing.T) {
 }
 
 func TestSchemaDumpInitSQLByProviderIncludesVault(t *testing.T) {
-	out := captureSchemaStdout(t, func() {
-		if err := runSchemaCommand([]string{"dump-init-sql", "--provider", "db9"}); err != nil {
-			t.Fatalf("dump provider schema: %v", err)
-		}
-	})
+	for _, provider := range []string{"tidb_zero", "tidb_cloud_starter"} {
+		t.Run(provider, func(t *testing.T) {
+			out := captureSchemaStdout(t, func() {
+				if err := runSchemaCommand([]string{"dump-init-sql", "--provider", provider}); err != nil {
+					t.Fatalf("dump provider schema: %v", err)
+				}
+			})
 
-	if !strings.Contains(out, "CREATE TABLE IF NOT EXISTS vault_deks") {
-		t.Fatalf("db9 dump missing vault_deks: %q", out)
-	}
-	if !strings.Contains(out, "CREATE TABLE IF NOT EXISTS vault_audit_log") {
-		t.Fatalf("db9 dump missing vault_audit_log: %q", out)
+			if !strings.Contains(out, "CREATE TABLE IF NOT EXISTS vault_deks") {
+				t.Fatalf("%s dump missing vault_deks: %q", provider, out)
+			}
+			if !strings.Contains(out, "CREATE TABLE IF NOT EXISTS vault_audit_log") {
+				t.Fatalf("%s dump missing vault_audit_log: %q", provider, out)
+			}
+		})
 	}
 }
 

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -25,6 +25,7 @@ type TenantScope struct {
 	TenantID     string
 	APIKeyID     string
 	TokenVersion int
+	Provider     string
 	Backend      *backend.Dat9Backend
 }
 
@@ -162,7 +163,7 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			zap.Float64("total_ms", authPhaseMs(authStart)),
 		)
 
-		scope := &TenantScope{TenantID: resolved.Tenant.ID, APIKeyID: resolved.APIKey.ID, TokenVersion: resolved.APIKey.TokenVersion, Backend: b}
+		scope := &TenantScope{TenantID: resolved.Tenant.ID, APIKeyID: resolved.APIKey.ID, TokenVersion: resolved.APIKey.TokenVersion, Provider: resolved.Tenant.Provider, Backend: b}
 		next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))
 	})
 }
@@ -204,7 +205,7 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 		}
 		defer release()
 
-		scope := &TenantScope{TenantID: tenantID, Backend: b}
+		scope := &TenantScope{TenantID: tenantID, Provider: tenant.Provider, Backend: b}
 		sub := strings.TrimPrefix(r.URL.Path, "/v1/vault/read")
 		s.handleVaultRead(w, r.WithContext(withScope(r.Context(), scope)), sub)
 	})

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/vault"
 )
 
@@ -37,10 +38,14 @@ func (s *Server) handleVault(w http.ResponseWriter, r *http.Request) {
 }
 
 // vaultStore returns the vault store for the current tenant.
+// Vault is only supported on TiDB providers; db9 tenants get a clear error.
 func (s *Server) vaultStore(r *http.Request) (*vault.Store, error) {
 	scope := ScopeFromContext(r.Context())
 	if scope == nil || scope.Backend == nil {
 		return nil, fmt.Errorf("no tenant scope")
+	}
+	if scope.Provider == tenant.ProviderDB9 {
+		return nil, fmt.Errorf("vault is not supported for provider %q", scope.Provider)
 	}
 	if s.vaultMK == nil {
 		return nil, fmt.Errorf("vault master key not configured")
@@ -401,6 +406,10 @@ func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub str
 	}
 	tenantID := scope.TenantID
 
+	if scope.Provider == tenant.ProviderDB9 {
+		errJSON(w, http.StatusNotImplemented, "vault is not supported for this provider")
+		return
+	}
 	if s.vaultMK == nil {
 		errJSON(w, http.StatusInternalServerError, "vault master key not configured")
 		return

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -37,6 +37,8 @@ func (s *Server) handleVault(w http.ResponseWriter, r *http.Request) {
 	errJSON(w, http.StatusNotFound, "not found")
 }
 
+var errVaultUnsupported = errors.New("vault is not supported for this provider")
+
 // vaultStore returns the vault store for the current tenant.
 // Vault is only supported on TiDB providers; db9 tenants get a clear error.
 func (s *Server) vaultStore(r *http.Request) (*vault.Store, error) {
@@ -45,7 +47,7 @@ func (s *Server) vaultStore(r *http.Request) (*vault.Store, error) {
 		return nil, fmt.Errorf("no tenant scope")
 	}
 	if scope.Provider == tenant.ProviderDB9 {
-		return nil, fmt.Errorf("vault is not supported for provider %q", scope.Provider)
+		return nil, errVaultUnsupported
 	}
 	if s.vaultMK == nil {
 		return nil, fmt.Errorf("vault master key not configured")
@@ -58,6 +60,10 @@ func (s *Server) vaultStore(r *http.Request) (*vault.Store, error) {
 func (s *Server) handleVaultSecrets(w http.ResponseWriter, r *http.Request, sub string) {
 	vs, err := s.vaultStore(r)
 	if err != nil {
+		if errors.Is(err, errVaultUnsupported) {
+			errJSON(w, http.StatusNotImplemented, err.Error())
+			return
+		}
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -239,6 +245,10 @@ func (s *Server) handleVaultSecretDelete(w http.ResponseWriter, r *http.Request,
 func (s *Server) handleVaultTokens(w http.ResponseWriter, r *http.Request, sub string) {
 	vs, err := s.vaultStore(r)
 	if err != nil {
+		if errors.Is(err, errVaultUnsupported) {
+			errJSON(w, http.StatusNotImplemented, err.Error())
+			return
+		}
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -354,6 +364,10 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 	}
 	vs, err := s.vaultStore(r)
 	if err != nil {
+		if errors.Is(err, errVaultUnsupported) {
+			errJSON(w, http.StatusNotImplemented, err.Error())
+			return
+		}
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/pkg/tenant/db9/schema.go
+++ b/pkg/tenant/db9/schema.go
@@ -119,81 +119,10 @@ func InitSchemaStatements() []string {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_llm_usage_created ON llm_usage(created_at)`,
 	}
-	// Vault DDL — PostgreSQL-native syntax for the db9 provider.
-	// vault.SchemaStatements() now returns TiDB/MySQL-compatible DDL,
-	// so we inline the PG-native equivalents here.
-	vaultPG := []string{
-		`CREATE TABLE IF NOT EXISTS vault_deks (
-			tenant_id    VARCHAR(64) PRIMARY KEY,
-			wrapped_dek  BYTEA NOT NULL,
-			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		)`,
-
-		`CREATE TABLE IF NOT EXISTS vault_secrets (
-			secret_id    VARCHAR(64) PRIMARY KEY,
-			tenant_id    VARCHAR(64) NOT NULL,
-			name         VARCHAR(255) NOT NULL,
-			secret_type  VARCHAR(32) NOT NULL DEFAULT 'generic',
-			revision     BIGINT NOT NULL DEFAULT 1,
-			created_by   VARCHAR(255) NOT NULL,
-			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			deleted_at   TIMESTAMPTZ,
-			UNIQUE (tenant_id, name)
-		)`,
-		`CREATE INDEX IF NOT EXISTS idx_vault_secrets_tenant ON vault_secrets(tenant_id)`,
-
-		`CREATE TABLE IF NOT EXISTS vault_secret_fields (
-			secret_id       VARCHAR(64) NOT NULL,
-			field_name      VARCHAR(255) NOT NULL,
-			encrypted_value BYTEA NOT NULL,
-			nonce           BYTEA NOT NULL,
-			PRIMARY KEY (secret_id, field_name)
-		)`,
-
-		`CREATE TABLE IF NOT EXISTS vault_tokens (
-			token_id      VARCHAR(64) PRIMARY KEY,
-			tenant_id     VARCHAR(64) NOT NULL,
-			agent_id      VARCHAR(255) NOT NULL,
-			task_id       VARCHAR(255),
-			scope_json    JSONB NOT NULL,
-			issued_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			expires_at    TIMESTAMPTZ NOT NULL,
-			revoked_at    TIMESTAMPTZ,
-			revoked_by    VARCHAR(255),
-			revoke_reason VARCHAR(255)
-		)`,
-		`CREATE INDEX IF NOT EXISTS idx_vault_token_tenant ON vault_tokens(tenant_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_vault_token_agent ON vault_tokens(agent_id)`,
-
-		`CREATE TABLE IF NOT EXISTS vault_policies (
-			policy_id   VARCHAR(64) PRIMARY KEY,
-			tenant_id   VARCHAR(64) NOT NULL,
-			name        VARCHAR(255) NOT NULL,
-			rules_json  JSONB NOT NULL,
-			created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		)`,
-
-		`CREATE TABLE IF NOT EXISTS vault_audit_log (
-			event_id     VARCHAR(64) PRIMARY KEY,
-			tenant_id    VARCHAR(64) NOT NULL,
-			event_type   VARCHAR(32) NOT NULL,
-			token_id     VARCHAR(64),
-			agent_id     VARCHAR(255),
-			task_id      VARCHAR(255),
-			secret_name  VARCHAR(255),
-			field_name   VARCHAR(255),
-			adapter      VARCHAR(16),
-			detail_json  JSONB,
-			timestamp    TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		)`,
-		`CREATE INDEX IF NOT EXISTS idx_vault_audit_tenant_time ON vault_audit_log(tenant_id, timestamp)`,
-		`CREATE INDEX IF NOT EXISTS idx_vault_audit_secret ON vault_audit_log(secret_name, timestamp)`,
-	}
-	stmts := make([]string, 0, len(core)+len(vaultPG))
-	stmts = append(stmts, core...)
-	stmts = append(stmts, vaultPG...)
-	return stmts
+	// Vault tables are TiDB/MySQL-only and are not created via the db9
+	// PostgreSQL schema init path. They are initialized through the TiDB
+	// tenant schema init (see pkg/tenant/schema/vault.go).
+	return core
 }
 
 func initDB9Schema(dsn string) error {

--- a/pkg/tenant/db9/schema.go
+++ b/pkg/tenant/db9/schema.go
@@ -6,7 +6,6 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/mem9-ai/dat9/pkg/tenant/schema"
-	"github.com/mem9-ai/dat9/pkg/vault"
 )
 
 // InitSchemaStatements returns the exact DDL statements used by db9 tenant
@@ -120,9 +119,80 @@ func InitSchemaStatements() []string {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_llm_usage_created ON llm_usage(created_at)`,
 	}
-	stmts := make([]string, 0, len(core)+len(vault.SchemaStatements()))
+	// Vault DDL — PostgreSQL-native syntax for the db9 provider.
+	// vault.SchemaStatements() now returns TiDB/MySQL-compatible DDL,
+	// so we inline the PG-native equivalents here.
+	vaultPG := []string{
+		`CREATE TABLE IF NOT EXISTS vault_deks (
+			tenant_id    VARCHAR(64) PRIMARY KEY,
+			wrapped_dek  BYTEA NOT NULL,
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_secrets (
+			secret_id    VARCHAR(64) PRIMARY KEY,
+			tenant_id    VARCHAR(64) NOT NULL,
+			name         VARCHAR(255) NOT NULL,
+			secret_type  VARCHAR(32) NOT NULL DEFAULT 'generic',
+			revision     BIGINT NOT NULL DEFAULT 1,
+			created_by   VARCHAR(255) NOT NULL,
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			deleted_at   TIMESTAMPTZ,
+			UNIQUE (tenant_id, name)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_vault_secrets_tenant ON vault_secrets(tenant_id)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_secret_fields (
+			secret_id       VARCHAR(64) NOT NULL,
+			field_name      VARCHAR(255) NOT NULL,
+			encrypted_value BYTEA NOT NULL,
+			nonce           BYTEA NOT NULL,
+			PRIMARY KEY (secret_id, field_name)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_tokens (
+			token_id      VARCHAR(64) PRIMARY KEY,
+			tenant_id     VARCHAR(64) NOT NULL,
+			agent_id      VARCHAR(255) NOT NULL,
+			task_id       VARCHAR(255),
+			scope_json    JSONB NOT NULL,
+			issued_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			expires_at    TIMESTAMPTZ NOT NULL,
+			revoked_at    TIMESTAMPTZ,
+			revoked_by    VARCHAR(255),
+			revoke_reason VARCHAR(255)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_vault_token_tenant ON vault_tokens(tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_vault_token_agent ON vault_tokens(agent_id)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_policies (
+			policy_id   VARCHAR(64) PRIMARY KEY,
+			tenant_id   VARCHAR(64) NOT NULL,
+			name        VARCHAR(255) NOT NULL,
+			rules_json  JSONB NOT NULL,
+			created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_audit_log (
+			event_id     VARCHAR(64) PRIMARY KEY,
+			tenant_id    VARCHAR(64) NOT NULL,
+			event_type   VARCHAR(32) NOT NULL,
+			token_id     VARCHAR(64),
+			agent_id     VARCHAR(255),
+			task_id      VARCHAR(255),
+			secret_name  VARCHAR(255),
+			field_name   VARCHAR(255),
+			adapter      VARCHAR(16),
+			detail_json  JSONB,
+			timestamp    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_vault_audit_tenant_time ON vault_audit_log(tenant_id, timestamp)`,
+		`CREATE INDEX IF NOT EXISTS idx_vault_audit_secret ON vault_audit_log(secret_name, timestamp)`,
+	}
+	stmts := make([]string, 0, len(core)+len(vaultPG))
 	stmts = append(stmts, core...)
-	stmts = append(stmts, vault.SchemaStatements()...)
+	stmts = append(stmts, vaultPG...)
 	return stmts
 }
 

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -14,7 +14,7 @@ import (
 // There is intentionally no drive9-server dump-init-sql --provider export path
 // for this app-managed statement list.
 func tidbAppEmbeddingSchemaStatements() []string {
-	return []string{
+	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (
 			node_id      VARCHAR(64) PRIMARY KEY,
 			path         VARCHAR(512) NOT NULL,
@@ -114,6 +114,8 @@ func tidbAppEmbeddingSchemaStatements() []string {
 		)`,
 		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
 	}
+	stmts = append(stmts, VaultTiDBSchemaStatements()...)
+	return stmts
 }
 
 func initTiDBAppEmbeddingSchema(dsn string) error {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -48,7 +48,7 @@ type tidbTableMeta struct {
 //
 // and update tidb_cloud_starter with the exported SQL.
 func tidbAutoEmbeddingSchemaStatements() []string {
-	return []string{
+	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (
 			node_id      VARCHAR(64) PRIMARY KEY,
 			path         VARCHAR(512) NOT NULL,
@@ -152,6 +152,8 @@ func tidbAutoEmbeddingSchemaStatements() []string {
 		)`,
 		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
 	}
+	stmts = append(stmts, VaultTiDBSchemaStatements()...)
+	return stmts
 }
 
 // DetectTiDBEmbeddingMode inspects the TiDB files-table embedding contract and
@@ -222,6 +224,11 @@ func ValidateTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
 	}
 	if err := ensureTiDBTableExists(db, "semantic_tasks"); err != nil {
 		return fmt.Errorf("semantic_tasks schema contract: %w", err)
+	}
+	for _, t := range []string{"vault_deks", "vault_secrets", "vault_secret_fields", "vault_tokens", "vault_policies", "vault_audit_log"} {
+		if err := ensureTiDBTableExists(db, t); err != nil {
+			return fmt.Errorf("%s schema contract: %w", t, err)
+		}
 	}
 	return nil
 }

--- a/pkg/tenant/schema/vault.go
+++ b/pkg/tenant/schema/vault.go
@@ -1,0 +1,74 @@
+package schema
+
+// VaultTiDBSchemaStatements returns the vault DDL statements in TiDB/MySQL
+// dialect. These are appended to the tenant schema init for all TiDB providers.
+func VaultTiDBSchemaStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS vault_deks (
+			tenant_id    VARCHAR(64) PRIMARY KEY,
+			wrapped_dek  BLOB NOT NULL,
+			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_secrets (
+			secret_id    VARCHAR(64) PRIMARY KEY,
+			tenant_id    VARCHAR(64) NOT NULL,
+			name         VARCHAR(255) NOT NULL,
+			secret_type  VARCHAR(32) NOT NULL DEFAULT 'generic',
+			revision     BIGINT NOT NULL DEFAULT 1,
+			created_by   VARCHAR(255) NOT NULL,
+			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			deleted_at   DATETIME(3),
+			UNIQUE INDEX uk_vault_secrets_tenant_name (tenant_id, name),
+			INDEX idx_vault_secrets_tenant (tenant_id)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_secret_fields (
+			secret_id       VARCHAR(64) NOT NULL,
+			field_name      VARCHAR(255) NOT NULL,
+			encrypted_value BLOB NOT NULL,
+			nonce           BLOB NOT NULL,
+			PRIMARY KEY (secret_id, field_name)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_tokens (
+			token_id      VARCHAR(64) PRIMARY KEY,
+			tenant_id     VARCHAR(64) NOT NULL,
+			agent_id      VARCHAR(255) NOT NULL,
+			task_id       VARCHAR(255),
+			scope_json    JSON NOT NULL,
+			issued_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			expires_at    DATETIME(3) NOT NULL,
+			revoked_at    DATETIME(3),
+			revoked_by    VARCHAR(255),
+			revoke_reason VARCHAR(255),
+			INDEX idx_vault_token_tenant (tenant_id),
+			INDEX idx_vault_token_agent (agent_id)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_policies (
+			policy_id   VARCHAR(64) PRIMARY KEY,
+			tenant_id   VARCHAR(64) NOT NULL,
+			name        VARCHAR(255) NOT NULL,
+			rules_json  JSON NOT NULL,
+			created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_audit_log (
+			event_id     VARCHAR(64) PRIMARY KEY,
+			tenant_id    VARCHAR(64) NOT NULL,
+			event_type   VARCHAR(32) NOT NULL,
+			token_id     VARCHAR(64),
+			agent_id     VARCHAR(255),
+			task_id      VARCHAR(255),
+			secret_name  VARCHAR(255),
+			field_name   VARCHAR(255),
+			adapter      VARCHAR(16),
+			detail_json  JSON,
+			timestamp    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			INDEX idx_vault_audit_tenant_time (tenant_id, timestamp),
+			INDEX idx_vault_audit_secret (secret_name, timestamp)
+		)`,
+	}
+}

--- a/pkg/vault/schema.go
+++ b/pkg/vault/schema.go
@@ -6,84 +6,11 @@ import (
 	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
 
-// SchemaStatements returns the vault DDL statements used during tenant schema
-// initialization (TiDB/MySQL-compatible).
-//
-// These statements are appended into the exported db9 init schema. If you
-// change vault columns, indexes, or constraints here, rerun:
-//
-//	drive9-server schema dump-init-sql --provider db9
-//
-// and update any external db9 schema copy that consumes that exported SQL.
+// SchemaStatements returns the vault DDL statements (TiDB/MySQL-compatible).
+// The canonical DDL lives in pkg/tenant/schema.VaultTiDBSchemaStatements();
+// this is a convenience re-export.
 func SchemaStatements() []string {
-	return []string{
-		`CREATE TABLE IF NOT EXISTS vault_deks (
-			tenant_id    VARCHAR(64) PRIMARY KEY,
-			wrapped_dek  BLOB NOT NULL,
-			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
-		)`,
-
-		`CREATE TABLE IF NOT EXISTS vault_secrets (
-			secret_id    VARCHAR(64) PRIMARY KEY,
-			tenant_id    VARCHAR(64) NOT NULL,
-			name         VARCHAR(255) NOT NULL,
-			secret_type  VARCHAR(32) NOT NULL DEFAULT 'generic',
-			revision     BIGINT NOT NULL DEFAULT 1,
-			created_by   VARCHAR(255) NOT NULL,
-			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-			deleted_at   DATETIME(3),
-			UNIQUE INDEX uk_vault_secrets_tenant_name (tenant_id, name),
-			INDEX idx_vault_secrets_tenant (tenant_id)
-		)`,
-
-		`CREATE TABLE IF NOT EXISTS vault_secret_fields (
-			secret_id       VARCHAR(64) NOT NULL,
-			field_name      VARCHAR(255) NOT NULL,
-			encrypted_value BLOB NOT NULL,
-			nonce           BLOB NOT NULL,
-			PRIMARY KEY (secret_id, field_name)
-		)`,
-
-		`CREATE TABLE IF NOT EXISTS vault_tokens (
-			token_id      VARCHAR(64) PRIMARY KEY,
-			tenant_id     VARCHAR(64) NOT NULL,
-			agent_id      VARCHAR(255) NOT NULL,
-			task_id       VARCHAR(255),
-			scope_json    JSON NOT NULL,
-			issued_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-			expires_at    DATETIME(3) NOT NULL,
-			revoked_at    DATETIME(3),
-			revoked_by    VARCHAR(255),
-			revoke_reason VARCHAR(255),
-			INDEX idx_vault_token_tenant (tenant_id),
-			INDEX idx_vault_token_agent (agent_id)
-		)`,
-
-		`CREATE TABLE IF NOT EXISTS vault_policies (
-			policy_id   VARCHAR(64) PRIMARY KEY,
-			tenant_id   VARCHAR(64) NOT NULL,
-			name        VARCHAR(255) NOT NULL,
-			rules_json  JSON NOT NULL,
-			created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
-		)`,
-
-		`CREATE TABLE IF NOT EXISTS vault_audit_log (
-			event_id     VARCHAR(64) PRIMARY KEY,
-			tenant_id    VARCHAR(64) NOT NULL,
-			event_type   VARCHAR(32) NOT NULL,
-			token_id     VARCHAR(64),
-			agent_id     VARCHAR(255),
-			task_id      VARCHAR(255),
-			secret_name  VARCHAR(255),
-			field_name   VARCHAR(255),
-			adapter      VARCHAR(16),
-			detail_json  JSON,
-			timestamp    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-			INDEX idx_vault_audit_tenant_time (tenant_id, timestamp),
-			INDEX idx_vault_audit_secret (secret_name, timestamp)
-		)`,
-	}
+	return schema.VaultTiDBSchemaStatements()
 }
 
 // InitSchema creates the vault tables in the tenant database.

--- a/pkg/vault/schema.go
+++ b/pkg/vault/schema.go
@@ -7,7 +7,7 @@ import (
 )
 
 // SchemaStatements returns the vault DDL statements used during tenant schema
-// initialization.
+// initialization (TiDB/MySQL-compatible).
 //
 // These statements are appended into the exported db9 init schema. If you
 // change vault columns, indexes, or constraints here, rerun:
@@ -19,8 +19,8 @@ func SchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS vault_deks (
 			tenant_id    VARCHAR(64) PRIMARY KEY,
-			wrapped_dek  BYTEA NOT NULL,
-			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+			wrapped_dek  BLOB NOT NULL,
+			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
 		)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_secrets (
@@ -30,18 +30,18 @@ func SchemaStatements() []string {
 			secret_type  VARCHAR(32) NOT NULL DEFAULT 'generic',
 			revision     BIGINT NOT NULL DEFAULT 1,
 			created_by   VARCHAR(255) NOT NULL,
-			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			deleted_at   TIMESTAMPTZ,
-			UNIQUE (tenant_id, name)
+			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			deleted_at   DATETIME(3),
+			UNIQUE INDEX uk_vault_secrets_tenant_name (tenant_id, name),
+			INDEX idx_vault_secrets_tenant (tenant_id)
 		)`,
-		`CREATE INDEX IF NOT EXISTS idx_vault_secrets_tenant ON vault_secrets(tenant_id)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_secret_fields (
 			secret_id       VARCHAR(64) NOT NULL,
 			field_name      VARCHAR(255) NOT NULL,
-			encrypted_value BYTEA NOT NULL,
-			nonce           BYTEA NOT NULL,
+			encrypted_value BLOB NOT NULL,
+			nonce           BLOB NOT NULL,
 			PRIMARY KEY (secret_id, field_name)
 		)`,
 
@@ -50,22 +50,22 @@ func SchemaStatements() []string {
 			tenant_id     VARCHAR(64) NOT NULL,
 			agent_id      VARCHAR(255) NOT NULL,
 			task_id       VARCHAR(255),
-			scope_json    JSONB NOT NULL,
-			issued_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			expires_at    TIMESTAMPTZ NOT NULL,
-			revoked_at    TIMESTAMPTZ,
+			scope_json    JSON NOT NULL,
+			issued_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			expires_at    DATETIME(3) NOT NULL,
+			revoked_at    DATETIME(3),
 			revoked_by    VARCHAR(255),
-			revoke_reason VARCHAR(255)
+			revoke_reason VARCHAR(255),
+			INDEX idx_vault_token_tenant (tenant_id),
+			INDEX idx_vault_token_agent (agent_id)
 		)`,
-		`CREATE INDEX IF NOT EXISTS idx_vault_token_tenant ON vault_tokens(tenant_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_vault_token_agent ON vault_tokens(agent_id)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_policies (
 			policy_id   VARCHAR(64) PRIMARY KEY,
 			tenant_id   VARCHAR(64) NOT NULL,
 			name        VARCHAR(255) NOT NULL,
-			rules_json  JSONB NOT NULL,
-			created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+			rules_json  JSON NOT NULL,
+			created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
 		)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_audit_log (
@@ -78,11 +78,11 @@ func SchemaStatements() []string {
 			secret_name  VARCHAR(255),
 			field_name   VARCHAR(255),
 			adapter      VARCHAR(16),
-			detail_json  JSONB,
-			timestamp    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+			detail_json  JSON,
+			timestamp    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			INDEX idx_vault_audit_tenant_time (tenant_id, timestamp),
+			INDEX idx_vault_audit_secret (secret_name, timestamp)
 		)`,
-		`CREATE INDEX IF NOT EXISTS idx_vault_audit_tenant_time ON vault_audit_log(tenant_id, timestamp)`,
-		`CREATE INDEX IF NOT EXISTS idx_vault_audit_secret ON vault_audit_log(secret_name, timestamp)`,
 	}
 }
 

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -30,7 +30,7 @@ func (s *Store) DB() *sql.DB { return s.db }
 func (s *Store) GetOrCreateDEK(ctx context.Context, tenantID string) ([]byte, error) {
 	var wrappedDEK []byte
 	err := s.db.QueryRowContext(ctx,
-		`SELECT wrapped_dek FROM vault_deks WHERE tenant_id = $1`, tenantID,
+		`SELECT wrapped_dek FROM vault_deks WHERE tenant_id = ?`, tenantID,
 	).Scan(&wrappedDEK)
 
 	if err == nil {
@@ -46,7 +46,7 @@ func (s *Store) GetOrCreateDEK(ctx context.Context, tenantID string) ([]byte, er
 		return nil, err
 	}
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO vault_deks (tenant_id, wrapped_dek) VALUES ($1, $2) ON CONFLICT (tenant_id) DO NOTHING`,
+		`INSERT IGNORE INTO vault_deks (tenant_id, wrapped_dek) VALUES (?, ?)`,
 		tenantID, wrappedDEK,
 	)
 	if err != nil {
@@ -55,7 +55,7 @@ func (s *Store) GetOrCreateDEK(ctx context.Context, tenantID string) ([]byte, er
 
 	// Re-read in case of race (another process inserted first).
 	err = s.db.QueryRowContext(ctx,
-		`SELECT wrapped_dek FROM vault_deks WHERE tenant_id = $1`, tenantID,
+		`SELECT wrapped_dek FROM vault_deks WHERE tenant_id = ?`, tenantID,
 	).Scan(&wrappedDEK)
 	if err != nil {
 		return nil, fmt.Errorf("re-read DEK: %w", err)
@@ -92,8 +92,8 @@ func (s *Store) CreateSecret(ctx context.Context, tenantID, name, createdBy stri
 
 	_, err = tx.ExecContext(ctx,
 		`INSERT INTO vault_secrets (secret_id, tenant_id, name, secret_type, revision, created_by, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, 1, $5, $6, $6)`,
-		secretID, tenantID, name, string(secretType), createdBy, now,
+		 VALUES (?, ?, ?, ?, 1, ?, ?, ?)`,
+		secretID, tenantID, name, string(secretType), createdBy, now, now,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert secret: %w", err)
@@ -106,7 +106,7 @@ func (s *Store) CreateSecret(ctx context.Context, tenantID, name, createdBy stri
 		}
 		_, err = tx.ExecContext(ctx,
 			`INSERT INTO vault_secret_fields (secret_id, field_name, encrypted_value, nonce)
-			 VALUES ($1, $2, $3, $4)`,
+			 VALUES (?, ?, ?, ?)`,
 			secretID, fieldName, ciphertext, nonce,
 		)
 		if err != nil {
@@ -135,7 +135,7 @@ func (s *Store) GetSecret(ctx context.Context, tenantID, name string) (*Secret, 
 	var sec Secret
 	err := s.db.QueryRowContext(ctx,
 		`SELECT secret_id, tenant_id, name, secret_type, revision, created_by, created_at, updated_at, deleted_at
-		 FROM vault_secrets WHERE tenant_id = $1 AND name = $2 AND deleted_at IS NULL`,
+		 FROM vault_secrets WHERE tenant_id = ? AND name = ? AND deleted_at IS NULL`,
 		tenantID, name,
 	).Scan(&sec.SecretID, &sec.TenantID, &sec.Name, &sec.SecretType, &sec.Revision,
 		&sec.CreatedBy, &sec.CreatedAt, &sec.UpdatedAt, &sec.DeletedAt)
@@ -152,7 +152,7 @@ func (s *Store) GetSecret(ctx context.Context, tenantID, name string) (*Secret, 
 func (s *Store) ListSecrets(ctx context.Context, tenantID string) ([]*Secret, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT secret_id, tenant_id, name, secret_type, revision, created_by, created_at, updated_at
-		 FROM vault_secrets WHERE tenant_id = $1 AND deleted_at IS NULL ORDER BY name`,
+		 FROM vault_secrets WHERE tenant_id = ? AND deleted_at IS NULL ORDER BY name`,
 		tenantID,
 	)
 	if err != nil {
@@ -191,7 +191,7 @@ func (s *Store) UpdateSecret(ctx context.Context, tenantID, name, updatedBy stri
 
 	err = tx.QueryRowContext(ctx,
 		`SELECT secret_id, revision FROM vault_secrets
-		 WHERE tenant_id = $1 AND name = $2 AND deleted_at IS NULL
+		 WHERE tenant_id = ? AND name = ? AND deleted_at IS NULL
 		 FOR UPDATE`,
 		tenantID, name,
 	).Scan(&secretID, &revision)
@@ -204,7 +204,7 @@ func (s *Store) UpdateSecret(ctx context.Context, tenantID, name, updatedBy stri
 
 	newRevision := revision + 1
 	_, err = tx.ExecContext(ctx,
-		`UPDATE vault_secrets SET revision = $1, updated_at = $2 WHERE secret_id = $3`,
+		`UPDATE vault_secrets SET revision = ?, updated_at = ? WHERE secret_id = ?`,
 		newRevision, now, secretID,
 	)
 	if err != nil {
@@ -212,7 +212,7 @@ func (s *Store) UpdateSecret(ctx context.Context, tenantID, name, updatedBy stri
 	}
 
 	// Delete old fields, insert new ones.
-	_, err = tx.ExecContext(ctx, `DELETE FROM vault_secret_fields WHERE secret_id = $1`, secretID)
+	_, err = tx.ExecContext(ctx, `DELETE FROM vault_secret_fields WHERE secret_id = ?`, secretID)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (s *Store) UpdateSecret(ctx context.Context, tenantID, name, updatedBy stri
 		}
 		_, err = tx.ExecContext(ctx,
 			`INSERT INTO vault_secret_fields (secret_id, field_name, encrypted_value, nonce)
-			 VALUES ($1, $2, $3, $4)`,
+			 VALUES (?, ?, ?, ?)`,
 			secretID, fieldName, ciphertext, nonce,
 		)
 		if err != nil {
@@ -248,7 +248,7 @@ func (s *Store) UpdateSecret(ctx context.Context, tenantID, name, updatedBy stri
 func (s *Store) DeleteSecret(ctx context.Context, tenantID, name string) error {
 	now := time.Now()
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE vault_secrets SET deleted_at = $1 WHERE tenant_id = $2 AND name = $3 AND deleted_at IS NULL`,
+		`UPDATE vault_secrets SET deleted_at = ? WHERE tenant_id = ? AND name = ? AND deleted_at IS NULL`,
 		now, tenantID, name,
 	)
 	if err != nil {
@@ -273,7 +273,7 @@ func (s *Store) ReadSecretFields(ctx context.Context, tenantID, name string) (ma
 	}
 
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT field_name, encrypted_value, nonce FROM vault_secret_fields WHERE secret_id = $1`,
+		`SELECT field_name, encrypted_value, nonce FROM vault_secret_fields WHERE secret_id = ?`,
 		sec.SecretID,
 	)
 	if err != nil {
@@ -310,7 +310,7 @@ func (s *Store) ReadSecretField(ctx context.Context, tenantID, name, fieldName s
 
 	var ciphertext, nonce []byte
 	err = s.db.QueryRowContext(ctx,
-		`SELECT encrypted_value, nonce FROM vault_secret_fields WHERE secret_id = $1 AND field_name = $2`,
+		`SELECT encrypted_value, nonce FROM vault_secret_fields WHERE secret_id = ? AND field_name = ?`,
 		sec.SecretID, fieldName,
 	).Scan(&ciphertext, &nonce)
 	if err == sql.ErrNoRows {
@@ -355,7 +355,7 @@ func (s *Store) IssueCapToken(ctx context.Context, tenantID, agentID, taskID str
 	scopeJSON, _ := json.Marshal(scope)
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO vault_tokens (token_id, tenant_id, agent_id, task_id, scope_json, issued_at, expires_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		tokenID, tenantID, agentID, taskID, scopeJSON, now, expiresAt,
 	)
 	if err != nil {
@@ -385,7 +385,7 @@ func (s *Store) VerifyAndResolveCapToken(ctx context.Context, tenantID, raw stri
 	// DB revocation check — scoped to tenant for isolation.
 	var revokedAt *time.Time
 	err = s.db.QueryRowContext(ctx,
-		`SELECT revoked_at FROM vault_tokens WHERE tenant_id = $1 AND token_id = $2`,
+		`SELECT revoked_at FROM vault_tokens WHERE tenant_id = ? AND token_id = ?`,
 		tenantID, claims.TokenID,
 	).Scan(&revokedAt)
 	if err == sql.ErrNoRows {
@@ -406,8 +406,8 @@ func (s *Store) VerifyAndResolveCapToken(ctx context.Context, tenantID, raw stri
 func (s *Store) RevokeCapToken(ctx context.Context, tenantID, tokenID, revokedBy, reason string) error {
 	now := time.Now()
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE vault_tokens SET revoked_at = $1, revoked_by = $2, revoke_reason = $3
-		 WHERE tenant_id = $4 AND token_id = $5 AND revoked_at IS NULL`,
+		`UPDATE vault_tokens SET revoked_at = ?, revoked_by = ?, revoke_reason = ?
+		 WHERE tenant_id = ? AND token_id = ? AND revoked_at IS NULL`,
 		now, revokedBy, reason, tenantID, tokenID,
 	)
 	if err != nil {
@@ -436,7 +436,7 @@ func (s *Store) WriteAuditEvent(ctx context.Context, event *AuditEvent) error {
 	}
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO vault_audit_log (event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		event.EventID, event.TenantID, event.EventType, event.TokenID, event.AgentID,
 		event.TaskID, event.SecretName, event.FieldName, event.Adapter, detailJSON, event.Timestamp,
 	)
@@ -450,11 +450,11 @@ func (s *Store) QueryAuditLog(ctx context.Context, tenantID string, secretName s
 
 	if secretName != "" {
 		query = `SELECT event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp
-			FROM vault_audit_log WHERE tenant_id = $1 AND secret_name = $2 ORDER BY timestamp DESC LIMIT $3`
+			FROM vault_audit_log WHERE tenant_id = ? AND secret_name = ? ORDER BY timestamp DESC LIMIT ?`
 		args = []any{tenantID, secretName, limit}
 	} else {
 		query = `SELECT event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp
-			FROM vault_audit_log WHERE tenant_id = $1 ORDER BY timestamp DESC LIMIT $2`
+			FROM vault_audit_log WHERE tenant_id = ? ORDER BY timestamp DESC LIMIT ?`
 		args = []any{tenantID, limit}
 	}
 

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -1,0 +1,239 @@
+package vault
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	mk, err := NewMasterKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Clean vault tables before each test.
+	for _, tbl := range []string{"vault_audit_log", "vault_tokens", "vault_secret_fields", "vault_secrets", "vault_deks", "vault_policies"} {
+		if _, err := testDB.Exec("DELETE FROM " + tbl); err != nil {
+			t.Fatalf("clean %s: %v", tbl, err)
+		}
+	}
+	return NewStore(testDB, mk)
+}
+
+func TestStoreDEKRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// First call creates a new DEK.
+	dek1, err := s.GetOrCreateDEK(ctx, "tenant-1")
+	if err != nil {
+		t.Fatalf("GetOrCreateDEK: %v", err)
+	}
+	if len(dek1) != 32 {
+		t.Fatalf("expected 32-byte DEK, got %d", len(dek1))
+	}
+
+	// Second call returns the same DEK (idempotent).
+	dek2, err := s.GetOrCreateDEK(ctx, "tenant-1")
+	if err != nil {
+		t.Fatalf("GetOrCreateDEK second call: %v", err)
+	}
+	if string(dek1) != string(dek2) {
+		t.Fatal("DEK should be stable across calls")
+	}
+
+	// Different tenant gets a different DEK.
+	dek3, err := s.GetOrCreateDEK(ctx, "tenant-2")
+	if err != nil {
+		t.Fatalf("GetOrCreateDEK tenant-2: %v", err)
+	}
+	if string(dek1) == string(dek3) {
+		t.Fatal("different tenants should have different DEKs")
+	}
+}
+
+func TestStoreSecretCRUD(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	tenantID := "tenant-crud"
+
+	// Create
+	fields := map[string][]byte{
+		"username": []byte("admin"),
+		"password": []byte("s3cret"),
+	}
+	sec, err := s.CreateSecret(ctx, tenantID, "db-prod", "agent-1", SecretTypeDatabase, fields)
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	if sec.Name != "db-prod" || sec.Revision != 1 {
+		t.Fatalf("unexpected secret: name=%s rev=%d", sec.Name, sec.Revision)
+	}
+
+	// Get
+	got, err := s.GetSecret(ctx, tenantID, "db-prod")
+	if err != nil {
+		t.Fatalf("GetSecret: %v", err)
+	}
+	if got.SecretID != sec.SecretID {
+		t.Fatalf("GetSecret ID mismatch: %s != %s", got.SecretID, sec.SecretID)
+	}
+
+	// ReadSecretFields — decrypt and verify round-trip
+	decrypted, err := s.ReadSecretFields(ctx, tenantID, "db-prod")
+	if err != nil {
+		t.Fatalf("ReadSecretFields: %v", err)
+	}
+	if string(decrypted["username"]) != "admin" || string(decrypted["password"]) != "s3cret" {
+		t.Fatalf("decrypted fields mismatch: %v", decrypted)
+	}
+
+	// ReadSecretField — single field
+	pw, err := s.ReadSecretField(ctx, tenantID, "db-prod", "password")
+	if err != nil {
+		t.Fatalf("ReadSecretField: %v", err)
+	}
+	if string(pw) != "s3cret" {
+		t.Fatalf("ReadSecretField mismatch: %q", pw)
+	}
+
+	// List
+	list, err := s.ListSecrets(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "db-prod" {
+		t.Fatalf("ListSecrets unexpected: %d", len(list))
+	}
+
+	// Update — bumps revision, re-encrypts fields
+	newFields := map[string][]byte{
+		"username": []byte("admin"),
+		"password": []byte("n3wpass"),
+	}
+	updated, err := s.UpdateSecret(ctx, tenantID, "db-prod", "agent-1", newFields)
+	if err != nil {
+		t.Fatalf("UpdateSecret: %v", err)
+	}
+	if updated.Revision != 2 {
+		t.Fatalf("expected revision 2, got %d", updated.Revision)
+	}
+
+	// Verify updated field
+	pw2, err := s.ReadSecretField(ctx, tenantID, "db-prod", "password")
+	if err != nil {
+		t.Fatalf("ReadSecretField after update: %v", err)
+	}
+	if string(pw2) != "n3wpass" {
+		t.Fatalf("updated password mismatch: %q", pw2)
+	}
+
+	// Delete (soft)
+	if err := s.DeleteSecret(ctx, tenantID, "db-prod"); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	// Get after delete should fail
+	_, err = s.GetSecret(ctx, tenantID, "db-prod")
+	if err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound after delete, got: %v", err)
+	}
+
+	// Delete non-existent should fail
+	if err := s.DeleteSecret(ctx, tenantID, "db-prod"); err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound for double delete, got: %v", err)
+	}
+}
+
+func TestStoreCapTokenIssueRevokeVerify(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	tenantID := "tenant-token"
+
+	tokenStr, capToken, err := s.IssueCapToken(ctx, tenantID, "agent-1", "task-1", []string{"secret-a"}, time.Hour)
+	if err != nil {
+		t.Fatalf("IssueCapToken: %v", err)
+	}
+	if tokenStr == "" || capToken.TokenID == "" {
+		t.Fatal("empty token")
+	}
+
+	// Verify should succeed.
+	resolved, err := s.VerifyAndResolveCapToken(ctx, tenantID, tokenStr)
+	if err != nil {
+		t.Fatalf("VerifyAndResolveCapToken: %v", err)
+	}
+	if resolved.TokenID != capToken.TokenID {
+		t.Fatalf("token ID mismatch: %s != %s", resolved.TokenID, capToken.TokenID)
+	}
+
+	// Revoke.
+	if err := s.RevokeCapToken(ctx, tenantID, capToken.TokenID, "admin", "test revoke"); err != nil {
+		t.Fatalf("RevokeCapToken: %v", err)
+	}
+
+	// Verify after revoke should fail.
+	_, err = s.VerifyAndResolveCapToken(ctx, tenantID, tokenStr)
+	if err == nil {
+		t.Fatal("expected error for revoked token")
+	}
+
+	// Double revoke should fail.
+	if err := s.RevokeCapToken(ctx, tenantID, capToken.TokenID, "admin", "again"); err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound for double revoke, got: %v", err)
+	}
+}
+
+func TestStoreAuditWriteQuery(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	tenantID := "tenant-audit"
+
+	event := &AuditEvent{
+		EventID:    "evt-1",
+		TenantID:   tenantID,
+		EventType:  "secret.read",
+		AgentID:    "agent-1",
+		SecretName: "db-prod",
+		FieldName:  "password",
+		Adapter:    "env",
+		Detail:     map[string]string{"reason": "task execution"},
+		Timestamp:  time.Now(),
+	}
+	if err := s.WriteAuditEvent(ctx, event); err != nil {
+		t.Fatalf("WriteAuditEvent: %v", err)
+	}
+
+	// Query by tenant.
+	events, err := s.QueryAuditLog(ctx, tenantID, "", 10)
+	if err != nil {
+		t.Fatalf("QueryAuditLog: %v", err)
+	}
+	if len(events) != 1 || events[0].EventID != "evt-1" {
+		t.Fatalf("unexpected audit events: %d", len(events))
+	}
+
+	// Query by secret name.
+	events2, err := s.QueryAuditLog(ctx, tenantID, "db-prod", 10)
+	if err != nil {
+		t.Fatalf("QueryAuditLog by secret: %v", err)
+	}
+	if len(events2) != 1 {
+		t.Fatalf("expected 1 audit event for db-prod, got %d", len(events2))
+	}
+
+	// Query for non-existent secret returns empty.
+	events3, err := s.QueryAuditLog(ctx, tenantID, "nonexistent", 10)
+	if err != nil {
+		t.Fatalf("QueryAuditLog nonexistent: %v", err)
+	}
+	if len(events3) != 0 {
+		t.Fatalf("expected 0 events for nonexistent, got %d", len(events3))
+	}
+}

--- a/pkg/vault/testmain_test.go
+++ b/pkg/vault/testmain_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"testing"
 
+	_ "github.com/go-sql-driver/mysql"
+
 	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )

--- a/pkg/vault/testmain_test.go
+++ b/pkg/vault/testmain_test.go
@@ -1,0 +1,38 @@
+package vault
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/mem9-ai/dat9/internal/testmysql"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
+)
+
+var testDB *sql.DB
+
+func TestMain(m *testing.M) {
+	inst, err := testmysql.Start(context.Background())
+	if err != nil {
+		log.Fatalf("setup mysql test instance: %v", err)
+	}
+
+	db, err := sql.Open("mysql", inst.DSN)
+	if err != nil {
+		log.Fatalf("open test db: %v", err)
+	}
+	if err := schema.ExecSchemaStatements(db, schema.VaultTiDBSchemaStatements()); err != nil {
+		log.Fatalf("init vault schema: %v", err)
+	}
+	testDB = db
+
+	code := m.Run()
+
+	_ = db.Close()
+	if err := inst.Close(context.Background()); err != nil {
+		log.Printf("teardown mysql test instance: %v", err)
+	}
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary
Convert vault SQL from PostgreSQL to TiDB/MySQL dialect and wire vault DDL into TiDB tenant schema init.

### Changes
- **`pkg/vault/store.go`**: `$N`→`?` placeholders, `ON CONFLICT DO NOTHING`→`INSERT IGNORE`
- **`pkg/vault/schema.go`**: Delegates to `schema.VaultTiDBSchemaStatements()` (single source of truth)
- **`pkg/tenant/schema/vault.go`** (new): Canonical vault TiDB DDL — `BLOB`, `DATETIME(3)`, `JSON`, `CURRENT_TIMESTAMP(3)`, inline `INDEX`
- **`pkg/tenant/schema/tidb_app.go`**: Appends vault DDL to app-embedding schema statements
- **`pkg/tenant/schema/tidb_auto.go`**: Appends vault DDL to auto-embedding schema statements; `ValidateTiDBSchemaForMode` now validates all 6 vault tables
- **`pkg/tenant/db9/schema.go`**: Removed PG-native vault DDL (vault is TiDB/MySQL-only per product decision)
- **`cmd/drive9-server/schema_test.go`**: Vault table checks moved from db9 to tidb_zero/tidb_cloud_starter

## Context
Vault tables failed to create on TiDB tenant DB with syntax error:
> You have an error in your SQL syntax ... near "BYTEA NOT NULL, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()"

Root cause: `pkg/vault` used PostgreSQL dialect but vault runs on tenant DB via TiDB/MySQL datastore path.

## Design decisions
- **Single source of truth**: Vault DDL defined once in `schema.VaultTiDBSchemaStatements()`, consumed by TiDB init and `vault.SchemaStatements()`
- **TiDB-only**: Per @qiffang's directive, vault is TiDB/MySQL-only. PG vault DDL removed from db9.
- **INSERT IGNORE**: Used only in `GetOrCreateDEK` for insert-if-not-exist + re-read pattern. Only suppresses duplicate key on `vault_deks` PK. Re-read ensures correctness.
- **Schema validation**: All 6 vault tables added to `ValidateTiDBSchemaForMode` via `ensureTiDBTableExists`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] CI green
- [ ] Vault tables created on TiDB tenant DB (schema dump includes vault DDL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)