### PR TITLE
Clarify vault init schema coverage

### DIFF
--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -80,6 +80,25 @@ func TestLegacyTiDBUploadsRepairStatements(t *testing.T) {
 	}
 }
 
+func TestInitTiDBTenantSchemaStatementsForModeIncludesVault(t *testing.T) {
+	for _, mode := range []TiDBEmbeddingMode{TiDBEmbeddingModeAuto, TiDBEmbeddingModeApp} {
+		t.Run(string(mode), func(t *testing.T) {
+			stmts, err := InitTiDBTenantSchemaStatementsForMode(mode)
+			if err != nil {
+				t.Fatalf("init statements for mode %q: %v", mode, err)
+			}
+
+			sqlText := strings.Join(stmts, "\n")
+			if !strings.Contains(sqlText, "CREATE TABLE IF NOT EXISTS vault_deks") {
+				t.Fatalf("mode %q missing vault_deks in init schema", mode)
+			}
+			if !strings.Contains(sqlText, "CREATE TABLE IF NOT EXISTS vault_audit_log") {
+				t.Fatalf("mode %q missing vault_audit_log in init schema", mode)
+			}
+		})
+	}
+}
+
 func testFilesTableMeta(mode TiDBEmbeddingMode) tidbTableMeta {
 	meta := tidbTableMeta{
 		tableName: "files",

--- a/pkg/tenant/schema/vault.go
+++ b/pkg/tenant/schema/vault.go
@@ -1,7 +1,8 @@
 package schema
 
 // VaultTiDBSchemaStatements returns the vault DDL statements in TiDB/MySQL
-// dialect. These are appended to the tenant schema init for all TiDB providers.
+// dialect. These are appended to the tenant init schema statement set for all
+// TiDB providers, including drive9-server schema dump-init-sql output.
 func VaultTiDBSchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS vault_deks (


### PR DESCRIPTION
## Summary
Clarify that vault schema statements are part of the TiDB tenant init SQL surface and lock that behavior in with a regression test.

## Changes
- update the vault schema comment to state that these statements are included in tenant init schema output
- add a TiDB init schema test that verifies vault tables are present for both auto-embedding and app-managed modes

## Verification
- go test ./pkg/tenant/schema ./cmd/drive9-server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for vault schema initialization in TiDB tenant configurations.

* **Documentation**
  * Clarified vault DDL statement integration documentation for TiDB providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->