### PR TITLE
Fix FUSE e2e skip root causes

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -583,11 +583,12 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 }
 
 func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {
-	resolvedPath, _, err := b.resolveNodePath(backgroundWithTrace(), path)
+	ctx := backgroundWithTrace()
+	resolvedPath, _, err := b.resolveNodePath(ctx, path)
 	if err != nil {
 		return nil, err
 	}
-	nf, err := b.store.Stat(backgroundWithTrace(), resolvedPath)
+	nf, err := b.store.Stat(ctx, resolvedPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -582,13 +582,33 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 	return infos, nil
 }
 
-func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {
-	ctx := backgroundWithTrace()
-	resolvedPath, _, err := b.resolveNodePath(ctx, path)
-	if err != nil {
+func (b *Dat9Backend) StatNodeCtx(ctx context.Context, path string) (*datastore.NodeWithFile, error) {
+	resolvedPath := normalizePath(path)
+	nf, err := b.store.Stat(ctx, resolvedPath)
+	if err == nil {
+		return nf, nil
+	}
+	if !errors.Is(err, datastore.ErrNotFound) || pathutil.IsDir(path) {
 		return nil, err
 	}
-	nf, err := b.store.Stat(ctx, resolvedPath)
+
+	dirPath, dirErr := pathutil.CanonicalizeDir(path)
+	if dirErr != nil || dirPath == resolvedPath {
+		return nil, err
+	}
+	dirStat, dirStatErr := b.store.Stat(ctx, dirPath)
+	if dirStatErr != nil {
+		if errors.Is(dirStatErr, datastore.ErrNotFound) {
+			return nil, err
+		}
+		return nil, dirStatErr
+	}
+	return dirStat, nil
+}
+
+func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {
+	ctx := backgroundWithTrace()
+	nf, err := b.StatNodeCtx(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -805,7 +825,10 @@ func (b *Dat9Backend) resolveNodePath(ctx context.Context, rawPath string) (stri
 	}
 	dirNode, dirLookupErr := b.store.GetNode(ctx, dirPath)
 	if dirLookupErr != nil {
-		return resolvedPath, nil, err
+		if errors.Is(dirLookupErr, datastore.ErrNotFound) {
+			return resolvedPath, nil, err
+		}
+		return resolvedPath, nil, dirLookupErr
 	}
 	return dirPath, dirNode, nil
 }

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -584,26 +584,15 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 
 func (b *Dat9Backend) StatNodeCtx(ctx context.Context, path string) (*datastore.NodeWithFile, error) {
 	resolvedPath := normalizePath(path)
-	nf, err := b.store.Stat(ctx, resolvedPath)
-	if err == nil {
-		return nf, nil
-	}
-	if !errors.Is(err, datastore.ErrNotFound) || pathutil.IsDir(path) {
-		return nil, err
+	if pathutil.IsDir(path) {
+		return b.store.Stat(ctx, resolvedPath)
 	}
 
 	dirPath, dirErr := pathutil.CanonicalizeDir(path)
 	if dirErr != nil || dirPath == resolvedPath {
-		return nil, err
+		return b.store.Stat(ctx, resolvedPath)
 	}
-	dirStat, dirStatErr := b.store.Stat(ctx, dirPath)
-	if dirStatErr != nil {
-		if errors.Is(dirStatErr, datastore.ErrNotFound) {
-			return nil, err
-		}
-		return nil, dirStatErr
-	}
-	return dirStat, nil
+	return b.store.StatPathFallback(ctx, resolvedPath, dirPath)
 }
 
 func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -219,8 +219,7 @@ func (b *Dat9Backend) RemoveCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
 	defer func() { observeBackend(ctx, "remove", err, start) }()
 
-	path = normalizePath(path)
-	node, err := b.store.GetNode(ctx, path)
+	path, node, err := b.resolveNodePath(ctx, path)
 	if err != nil {
 		return err
 	}
@@ -245,8 +244,7 @@ func (b *Dat9Backend) RemoveAllCtx(ctx context.Context, path string) (err error)
 	start := time.Now()
 	defer func() { observeBackend(ctx, "remove_all", err, start) }()
 
-	path = normalizePath(path)
-	node, err := b.store.GetNode(ctx, path)
+	path, node, err := b.resolveNodePath(ctx, path)
 	if err != nil {
 		return err
 	}
@@ -585,8 +583,11 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 }
 
 func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {
-	path = normalizePath(path)
-	nf, err := b.store.Stat(backgroundWithTrace(), path)
+	resolvedPath, _, err := b.resolveNodePath(backgroundWithTrace(), path)
+	if err != nil {
+		return nil, err
+	}
+	nf, err := b.store.Stat(backgroundWithTrace(), resolvedPath)
 	if err != nil {
 		return nil, err
 	}
@@ -617,13 +618,11 @@ func (b *Dat9Backend) RenameCtx(ctx context.Context, oldPath, newPath string) (e
 	start := time.Now()
 	defer func() { observeBackend(ctx, "rename", err, start) }()
 
-	oldPath = normalizePath(oldPath)
-	newPath = normalizePath(newPath)
-
-	node, err := b.store.GetNode(ctx, oldPath)
+	oldPath, node, err := b.resolveNodePath(ctx, oldPath)
 	if err != nil {
 		return err
 	}
+	newPath = canonicalizePathForKind(newPath, node.IsDirectory)
 	if node.IsDirectory {
 		err = b.store.EnsureParentDirs(ctx, newPath, b.genID)
 		if err != nil {
@@ -776,6 +775,38 @@ func normalizePath(path string) string {
 		return path
 	}
 	return p
+}
+
+func canonicalizePathForKind(path string, isDir bool) string {
+	if isDir {
+		p, err := pathutil.CanonicalizeDir(path)
+		if err == nil {
+			return p
+		}
+		return path
+	}
+	return normalizePath(path)
+}
+
+func (b *Dat9Backend) resolveNodePath(ctx context.Context, rawPath string) (string, *datastore.FileNode, error) {
+	resolvedPath := normalizePath(rawPath)
+	node, err := b.store.GetNode(ctx, resolvedPath)
+	if err == nil {
+		return resolvedPath, node, nil
+	}
+	if !errors.Is(err, datastore.ErrNotFound) || pathutil.IsDir(rawPath) {
+		return resolvedPath, nil, err
+	}
+
+	dirPath, dirErr := pathutil.CanonicalizeDir(rawPath)
+	if dirErr != nil || dirPath == resolvedPath {
+		return resolvedPath, nil, err
+	}
+	dirNode, dirLookupErr := b.store.GetNode(ctx, dirPath)
+	if dirLookupErr != nil {
+		return resolvedPath, nil, err
+	}
+	return dirPath, dirNode, nil
 }
 
 func backgroundWithTrace() context.Context {

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -295,6 +295,49 @@ func TestRemoveAll(t *testing.T) {
 	}
 }
 
+func TestStatDirWithoutTrailingSlash(t *testing.T) {
+	b := newTestBackend(t)
+	if err := b.Mkdir("/data", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	info, err := b.Stat("/data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.IsDir {
+		t.Fatal("expected /data to resolve as a directory without trailing slash")
+	}
+}
+
+func TestRemoveDirWithoutTrailingSlash(t *testing.T) {
+	b := newTestBackend(t)
+	if err := b.Mkdir("/data", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Remove("/data"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Stat("/data/"); err != datastore.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestRemoveAllDirWithoutTrailingSlash(t *testing.T) {
+	b := newTestBackend(t)
+	if err := b.Mkdir("/data", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/data/a.txt", []byte("a"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.RemoveAll("/data"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Stat("/data/"); err != datastore.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
 func TestRename(t *testing.T) {
 	b := newTestBackend(t)
 	if _, err := b.Write("/old.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {
@@ -407,6 +450,29 @@ func TestRenameDirUpdatesName(t *testing.T) {
 	}
 	if info.Name != "beta" {
 		t.Errorf("expected name 'beta', got %q", info.Name)
+	}
+}
+
+func TestRenameDirWithoutTrailingSlash(t *testing.T) {
+	b := newTestBackend(t)
+	if err := b.Mkdir("/alpha", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/alpha/file.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Rename("/alpha", "/beta"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Stat("/alpha/"); err != datastore.ErrNotFound {
+		t.Errorf("expected old path to be gone, got %v", err)
+	}
+	data, err := b.Read("/beta/file.txt", 0, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "data" {
+		t.Errorf("got %q", data)
 	}
 }
 

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -644,6 +644,23 @@ func (s *Store) Stat(ctx context.Context, path string) (out *NodeWithFile, err e
 	return out, nil
 }
 
+func (s *Store) StatPathFallback(ctx context.Context, primaryPath, fallbackPath string) (out *NodeWithFile, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "stat_path_fallback", start, &err)
+
+	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
+		f.file_id, f.storage_type, f.storage_ref, f.content_blob, f.content_type, f.size_bytes,
+		f.checksum_sha256, f.revision, f.embedding_revision, f.status, f.source_id, f.content_text,
+		f.created_at, f.confirmed_at, f.expires_at
+		FROM file_nodes fn
+		LEFT JOIN files f ON fn.file_id = f.file_id AND fn.is_directory = 0 AND f.status = 'CONFIRMED'
+		WHERE fn.path = ? OR fn.path = ?
+		ORDER BY CASE WHEN fn.path = ? THEN 0 ELSE 1 END
+		LIMIT 1`, primaryPath, fallbackPath, primaryPath)
+	out, err = scanNodeWithFileWithBlob(row)
+	return out, err
+}
+
 func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWithFile, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "list_dir", start, &err)
@@ -1087,7 +1104,7 @@ func scanFileWithBlob(s scanner) (*File, error) {
 	return &f, nil
 }
 
-func scanNodeWithFileWithBlob(rows *sql.Rows) (*NodeWithFile, error) {
+func scanNodeWithFileWithBlob(s scanner) (*NodeWithFile, error) {
 	var n FileNode
 	var isDir int
 	var nodeFileID sql.NullString
@@ -1100,11 +1117,14 @@ func scanNodeWithFileWithBlob(rows *sql.Rows) (*NodeWithFile, error) {
 	var fStatus sql.NullString
 	var fCreatedAt, fConfirmedAt, fExpiresAt sql.NullTime
 
-	err := rows.Scan(&n.NodeID, &n.Path, &n.ParentPath, &n.Name, &isDir, &nodeFileID, &nodeCreatedAt,
+	err := s.Scan(&n.NodeID, &n.Path, &n.ParentPath, &n.Name, &isDir, &nodeFileID, &nodeCreatedAt,
 		&fFileID, &fStorageType, &fStorageRef, &fContentBlob, &fContentType, &fSizeBytes,
 		&fChecksum, &fRevision, &fEmbeddingRevision, &fStatus, &fSourceID, &fContentText,
 		&fCreatedAt, &fConfirmedAt, &fExpiresAt)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -684,7 +684,10 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 				// Refresh the inode revision after the server-side truncate so a
 				// subsequent writable open does not reuse the stale pre-truncate
 				// base revision and conflict with its own zero-byte write.
-				if stat, err := fs.client.StatCtx(ctx, entry.Path); err == nil && stat != nil {
+				stat, statErr := fs.client.StatCtx(ctx, entry.Path)
+				if statErr != nil {
+					log.Printf("post-truncate stat refresh failed for %s (inode=%d): %v (revision may be stale)", entry.Path, input.NodeId, statErr)
+				} else if stat != nil {
 					if stat.Revision > 0 {
 						entry.Revision = stat.Revision
 						fs.inodes.UpdateRevision(input.NodeId, stat.Revision)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -681,6 +681,19 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 				if err := fs.client.WriteCtx(ctx, entry.Path, nil); err != nil {
 					return httpToFuseStatus(err)
 				}
+				// Refresh the inode revision after the server-side truncate so a
+				// subsequent writable open does not reuse the stale pre-truncate
+				// base revision and conflict with its own zero-byte write.
+				if stat, err := fs.client.StatCtx(ctx, entry.Path); err == nil && stat != nil {
+					if stat.Revision > 0 {
+						entry.Revision = stat.Revision
+						fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
+					}
+					if !stat.Mtime.IsZero() {
+						entry.Mtime = stat.Mtime
+						fs.inodes.UpdateMtime(input.NodeId, stat.Mtime)
+					}
+				}
 				fs.readCache.Invalidate(entry.Path)
 				fs.dirCache.Invalidate(parentDir(entry.Path))
 			} else if newSize != entry.Size {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -978,6 +978,80 @@ func TestSetAttr_MtimeNow(t *testing.T) {
 	}
 }
 
+func TestSetAttr_TruncateWithoutHandleRefreshesRevision(t *testing.T) {
+	var currentRevision atomic.Int64
+	currentRevision.Store(1)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "0")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(currentRevision.Load(), 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			if len(body) != 0 {
+				t.Fatalf("truncate write body = %q, want empty", string(body))
+			}
+			currentRevision.Store(2)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	ino := fs.inodes.Lookup("/file.bin", false, 42, time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+
+	var attrOut gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &attrOut)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if entry.Revision != 2 {
+		t.Fatalf("inode revision = %d, want 2", entry.Revision)
+	}
+
+	var openOut gofuse.OpenOut
+	st = fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	fh, ok := fs.fileHandles.Get(openOut.Fh)
+	if !ok {
+		t.Fatal("file handle not found")
+	}
+	if fh.BaseRev != 2 {
+		t.Fatalf("open base revision = %d, want 2", fh.BaseRev)
+	}
+}
+
 func TestLookup_UsesMtimeFromStat(t *testing.T) {
 	mtime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/embedding"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
@@ -773,6 +774,12 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 		return
 	}
 	nf, err := b.Store().Stat(r.Context(), path)
+	if err != nil && errors.Is(err, datastore.ErrNotFound) && !pathutil.IsDir(path) {
+		dirPath, dirErr := pathutil.CanonicalizeDir(path)
+		if dirErr == nil && dirPath != path {
+			nf, err = b.Store().Stat(r.Context(), dirPath)
+		}
+	}
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "stat_not_found", "path", path)...)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -19,7 +19,6 @@ import (
 	"github.com/mem9-ai/dat9/pkg/embedding"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
-	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
@@ -773,13 +772,7 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
-	nf, err := b.Store().Stat(r.Context(), path)
-	if err != nil && errors.Is(err, datastore.ErrNotFound) && !pathutil.IsDir(path) {
-		dirPath, dirErr := pathutil.CanonicalizeDir(path)
-		if dirErr == nil && dirPath != path {
-			nf, err = b.Store().Stat(r.Context(), dirPath)
-		}
-	}
+	nf, err := b.StatNodeCtx(r.Context(), path)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "stat_not_found", "path", path)...)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -164,6 +164,38 @@ func TestStat(t *testing.T) {
 	}
 }
 
+func TestStatDirectoryWithoutTrailingSlash(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/dir?mkdir", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mkdir: %d", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/dir", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stat dir without trailing slash: %d", resp.StatusCode)
+	}
+	if resp.Header.Get("X-Dat9-IsDir") != "true" {
+		t.Errorf("expected X-Dat9-IsDir true, got %s", resp.Header.Get("X-Dat9-IsDir"))
+	}
+	if resp.Header.Get("Content-Length") != "0" {
+		t.Errorf("expected Content-Length 0, got %s", resp.Header.Get("Content-Length"))
+	}
+}
+
 func TestWriteWithExpectedRevisionConflict(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/s3client"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func newTestServer(t *testing.T) *Server {
@@ -193,6 +196,41 @@ func TestStatDirectoryWithoutTrailingSlash(t *testing.T) {
 	}
 	if resp.Header.Get("Content-Length") != "0" {
 		t.Errorf("expected Content-Length 0, got %s", resp.Header.Get("Content-Length"))
+	}
+}
+
+func TestStatDirectoryWithoutTrailingSlashDoesNotLogDatastoreError(t *testing.T) {
+	core, recorded := observer.New(zap.ErrorLevel)
+	restoreLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(restoreLogger) })
+
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/dir?mkdir", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mkdir: %d", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/dir", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stat dir without trailing slash: %d", resp.StatusCode)
+	}
+
+	if entries := recorded.FilterMessage("datastore_op_failed").AllUntimed(); len(entries) != 0 {
+		t.Fatalf("expected no datastore_op_failed logs, got %d", len(entries))
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR fixes the two root causes behind the current FUSE e2e skip/failure paths.

- Resolve directory paths without trailing slashes for backend stat/remove/removeAll/rename operations so FUSE directory ops map to stored directory nodes correctly.
- Refresh inode revision after handle-less truncate-to-zero so a follow-up overwrite does not conflict with its own zero-byte write.
- Add backend and FUSE regression coverage for both behaviors.

## Why
The FUSE smoke flow currently hits two core issues:

- Directory operations from FUSE often use paths without trailing slashes, while backend metadata stores directory nodes with trailing slashes.
- Shell-style overwrite paths can issue a truncate-to-zero before the real content write, and the later write was still using the stale pre-truncate revision.

## Validation
- `go test -v ./pkg/backend -run 'Test(StatDirWithoutTrailingSlash|RemoveDirWithoutTrailingSlash|RemoveAllDirWithoutTrailingSlash|RenameDirWithoutTrailingSlash|RenameDirUpdatesName|RemoveAll)$'`
- `go test -v ./pkg/fuse -run 'Test(SetAttr_TruncateWithoutHandleRefreshesRevision|OpenTruncateWriteThroughShadow)$'`

## Notes
The dev FUSE e2e endpoint will still show the old behavior until this branch is deployed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory operations (Stat, Remove, RemoveAll, Rename) now correctly handle paths without trailing slashes.
  * Server lookups now retry using canonical directory forms so directory requests without a trailing slash succeed.
  * Truncating a file without an open handle refreshes file metadata (revision and mtime) to reflect server state.

* **Tests**
  * Added tests validating directory handling without trailing slashes and revision refresh after truncate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->