### PR TITLE
Fix concurrent v2 presign status transition

### DIFF
--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -90,6 +90,39 @@ func uploadExpectedRevision(upload *datastore.Upload) int64 {
 	return *upload.ExpectedRevision
 }
 
+func (b *Dat9Backend) ensureUploadPresignable(ctx context.Context, uploadID string, upload *datastore.Upload) (*datastore.Upload, error) {
+	if upload.Status != datastore.UploadUploading && upload.Status != datastore.UploadInitiated {
+		return nil, datastore.ErrUploadNotActive
+	}
+	if time.Now().After(upload.ExpiresAt) {
+		_ = b.AbortUploadV2(ctx, uploadID)
+		return nil, datastore.ErrUploadExpired
+	}
+	if upload.Status != datastore.UploadInitiated {
+		return upload, nil
+	}
+	if err := b.store.TransitionUploadStatus(ctx, uploadID, datastore.UploadInitiated, datastore.UploadUploading); err == nil {
+		upload.Status = datastore.UploadUploading
+		return upload, nil
+	} else if !errors.Is(err, datastore.ErrUploadNotActive) {
+		return nil, err
+	}
+
+	// Another concurrent presign may have already advanced INITIATED -> UPLOADING.
+	refreshed, err := b.store.GetUpload(ctx, uploadID)
+	if err != nil {
+		return nil, err
+	}
+	if refreshed.Status != datastore.UploadUploading {
+		if time.Now().After(refreshed.ExpiresAt) {
+			_ = b.AbortUploadV2(ctx, uploadID)
+			return nil, datastore.ErrUploadExpired
+		}
+		return nil, datastore.ErrUploadNotActive
+	}
+	return refreshed, nil
+}
+
 func (b *Dat9Backend) activeUploadByPath(ctx context.Context, path string) (*datastore.Upload, error) {
 	upload, err := lookupActiveUploadByPath(b.store, ctx, path)
 	if err != nil {
@@ -467,21 +500,18 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
 		return nil, err
 	}
-	if upload.Status != datastore.UploadUploading && upload.Status != datastore.UploadInitiated {
-		metrics.RecordOperation("backend", "presign_part", "not_active", time.Since(start))
-		return nil, datastore.ErrUploadNotActive
-	}
-	if time.Now().After(upload.ExpiresAt) {
-		_ = b.AbortUploadV2(ctx, uploadID)
-		metrics.RecordOperation("backend", "presign_part", "expired", time.Since(start))
-		return nil, datastore.ErrUploadExpired
-	}
-	if upload.Status == datastore.UploadInitiated {
-		if err := b.store.TransitionUploadStatus(ctx, uploadID, datastore.UploadInitiated, datastore.UploadUploading); err != nil {
+	upload, err = b.ensureUploadPresignable(ctx, uploadID, upload)
+	if err != nil {
+		switch {
+		case errors.Is(err, datastore.ErrUploadExpired):
+			metrics.RecordOperation("backend", "presign_part", "expired", time.Since(start))
+		case errors.Is(err, datastore.ErrUploadNotActive):
+			metrics.RecordOperation("backend", "presign_part", "not_active", time.Since(start))
+		default:
 			logger.Error(ctx, "backend_presign_part_status_transition_failed", zap.String("upload_id", uploadID), zap.Error(err))
 			metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
-			return nil, err
 		}
+		return nil, err
 	}
 	if partNumber < 1 || partNumber > upload.PartsTotal {
 		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
@@ -519,15 +549,6 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 	}
 	getUploadDurationMs := uploadPhaseMs(getUploadStart)
 	statusBefore := upload.Status
-	if upload.Status != datastore.UploadUploading && upload.Status != datastore.UploadInitiated {
-		metrics.RecordOperation("backend", "presign_parts", "not_active", time.Since(start))
-		return nil, datastore.ErrUploadNotActive
-	}
-	if time.Now().After(upload.ExpiresAt) {
-		_ = b.AbortUploadV2(ctx, uploadID)
-		metrics.RecordOperation("backend", "presign_parts", "expired", time.Since(start))
-		return nil, datastore.ErrUploadExpired
-	}
 	if len(entries) > MaxPresignBatch {
 		metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
 		return nil, fmt.Errorf("batch too large: %d parts exceeds limit of %d", len(entries), MaxPresignBatch)
@@ -542,13 +563,21 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		seen[e.PartNumber] = true
 	}
 	statusTransitionDurationMs := 0.0
-	if upload.Status == datastore.UploadInitiated {
-		statusTransitionStart := time.Now()
-		if err := b.store.TransitionUploadStatus(ctx, uploadID, datastore.UploadInitiated, datastore.UploadUploading); err != nil {
+	statusTransitionStart := time.Now()
+	upload, err = b.ensureUploadPresignable(ctx, uploadID, upload)
+	if err != nil {
+		switch {
+		case errors.Is(err, datastore.ErrUploadExpired):
+			metrics.RecordOperation("backend", "presign_parts", "expired", time.Since(start))
+		case errors.Is(err, datastore.ErrUploadNotActive):
+			metrics.RecordOperation("backend", "presign_parts", "not_active", time.Since(start))
+		default:
 			logger.Error(ctx, "backend_presign_parts_status_transition_failed", zap.String("upload_id", uploadID), zap.Error(err))
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
-			return nil, err
 		}
+		return nil, err
+	}
+	if statusBefore == datastore.UploadInitiated {
 		statusTransitionDurationMs = uploadPhaseMs(statusTransitionStart)
 	}
 

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -113,14 +113,17 @@ func (b *Dat9Backend) ensureUploadPresignable(ctx context.Context, uploadID stri
 	if err != nil {
 		return nil, err
 	}
-	if refreshed.Status != datastore.UploadUploading {
-		if time.Now().After(refreshed.ExpiresAt) {
-			_ = b.AbortUploadV2(ctx, uploadID)
-			return nil, datastore.ErrUploadExpired
-		}
+	if refreshed.Status == datastore.UploadUploading {
+		return refreshed, nil
+	}
+	if refreshed.Status != datastore.UploadInitiated {
 		return nil, datastore.ErrUploadNotActive
 	}
-	return refreshed, nil
+	if time.Now().After(refreshed.ExpiresAt) {
+		_ = b.AbortUploadV2(ctx, uploadID)
+		return nil, datastore.ErrUploadExpired
+	}
+	return nil, datastore.ErrUploadNotActive
 }
 
 func (b *Dat9Backend) activeUploadByPath(ctx context.Context, path string) (*datastore.Upload, error) {
@@ -508,7 +511,7 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 		case errors.Is(err, datastore.ErrUploadNotActive):
 			metrics.RecordOperation("backend", "presign_part", "not_active", time.Since(start))
 		default:
-			logger.Error(ctx, "backend_presign_part_status_transition_failed", zap.String("upload_id", uploadID), zap.Error(err))
+			logger.Error(ctx, "backend_presign_part_ensure_presignable_failed", zap.String("upload_id", uploadID), zap.Error(err))
 			metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
 		}
 		return nil, err
@@ -549,6 +552,24 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 	}
 	getUploadDurationMs := uploadPhaseMs(getUploadStart)
 	statusBefore := upload.Status
+	statusTransitionDurationMs := 0.0
+	statusTransitionStart := time.Now()
+	upload, err = b.ensureUploadPresignable(ctx, uploadID, upload)
+	if err != nil {
+		switch {
+		case errors.Is(err, datastore.ErrUploadExpired):
+			metrics.RecordOperation("backend", "presign_parts", "expired", time.Since(start))
+		case errors.Is(err, datastore.ErrUploadNotActive):
+			metrics.RecordOperation("backend", "presign_parts", "not_active", time.Since(start))
+		default:
+			logger.Error(ctx, "backend_presign_parts_ensure_presignable_failed", zap.String("upload_id", uploadID), zap.Error(err))
+			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+		}
+		return nil, err
+	}
+	if statusBefore == datastore.UploadInitiated {
+		statusTransitionDurationMs = uploadPhaseMs(statusTransitionStart)
+	}
 	if len(entries) > MaxPresignBatch {
 		metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
 		return nil, fmt.Errorf("batch too large: %d parts exceeds limit of %d", len(entries), MaxPresignBatch)
@@ -561,24 +582,6 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 			return nil, fmt.Errorf("duplicate part number %d in batch", e.PartNumber)
 		}
 		seen[e.PartNumber] = true
-	}
-	statusTransitionDurationMs := 0.0
-	statusTransitionStart := time.Now()
-	upload, err = b.ensureUploadPresignable(ctx, uploadID, upload)
-	if err != nil {
-		switch {
-		case errors.Is(err, datastore.ErrUploadExpired):
-			metrics.RecordOperation("backend", "presign_parts", "expired", time.Since(start))
-		case errors.Is(err, datastore.ErrUploadNotActive):
-			metrics.RecordOperation("backend", "presign_parts", "not_active", time.Since(start))
-		default:
-			logger.Error(ctx, "backend_presign_parts_status_transition_failed", zap.String("upload_id", uploadID), zap.Error(err))
-			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
-		}
-		return nil, err
-	}
-	if statusBefore == datastore.UploadInitiated {
-		statusTransitionDurationMs = uploadPhaseMs(statusTransitionStart)
 	}
 
 	calcPartsStart := time.Now()

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -423,6 +424,54 @@ func TestPresignPartSingle(t *testing.T) {
 	}
 	if u.Number != plan.TotalParts {
 		t.Errorf("expected part number %d, got %d", plan.TotalParts, u.Number)
+	}
+}
+
+func TestPresignPartConcurrentTransition(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	plan, err := b.InitiateUploadV2(ctx, "/presign-concurrent.bin", 256<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+
+	for i := 0; i < workers; i++ {
+		partNumber := i + 1
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			u, err := b.PresignPart(ctx, plan.UploadID, partNumber, nil)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if u == nil || u.URL == "" || u.Number != partNumber {
+				errCh <- errors.New("unexpected presign response")
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Fatalf("concurrent presign failed: %v", err)
+	}
+
+	upload, err := b.GetUpload(ctx, plan.UploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if upload.Status != datastore.UploadUploading {
+		t.Fatalf("expected UPLOADING after concurrent presign, got %s", upload.Status)
 	}
 }
 

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -436,7 +436,7 @@ func TestPresignPartConcurrentTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const workers = 32
+	workers := plan.TotalParts
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	errCh := make(chan error, workers)
@@ -577,6 +577,53 @@ func TestPresignAfterAbortFails(t *testing.T) {
 	_, err = b.PresignParts(ctx, plan.UploadID, entriesFromInts([]int{1, 2}))
 	if err == nil {
 		t.Error("expected error batch presigning after abort")
+	}
+}
+
+func TestPresignPartsInactiveUploadTakesPrecedenceOverBatchValidation(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	plan, err := b.InitiateUploadV2(ctx, "/presign-inactive-priority.bin", 20<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.AbortUploadV2(ctx, plan.UploadID); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = b.PresignParts(ctx, plan.UploadID, entriesFromInts([]int{1, 1}))
+	if !errors.Is(err, datastore.ErrUploadNotActive) {
+		t.Fatalf("expected ErrUploadNotActive, got %v", err)
+	}
+}
+
+func TestPresignPartsExpiredUploadTakesPrecedenceOverBatchValidation(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx := context.Background()
+
+	totalSize := int64(5000 << 20)
+	plan, err := b.InitiateUploadV2(ctx, "/presign-expired-priority.bin", totalSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.store.DB().ExecContext(ctx, `UPDATE uploads SET expires_at = ? WHERE upload_id = ?`,
+		time.Now().Add(-1*time.Hour), plan.UploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parts := make([]int, MaxPresignBatch+1)
+	for i := range parts {
+		parts[i] = i + 1
+	}
+	if parts[len(parts)-1] > plan.TotalParts {
+		t.Skipf("not enough parts (%d) to test batch limit precedence", plan.TotalParts)
+	}
+
+	_, err = b.PresignParts(ctx, plan.UploadID, entriesFromInts(parts))
+	if !errors.Is(err, datastore.ErrUploadExpired) {
+		t.Fatalf("expected ErrUploadExpired, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix the v2 multipart presign race where concurrent `PresignPart` / `PresignParts` requests can incorrectly fail while one request is moving an upload from `INITIATED` to `UPLOADING`.

Closes #263.

## Problem

Before this change, `PresignPart` and `PresignParts` both expected to win the `INITIATED -> UPLOADING` transition themselves.

With concurrent requests, the first caller could successfully transition the upload to `UPLOADING`, while a second caller racing just behind it would see the transition fail and treat that as a hard error, even though the upload was still active and already in the correct state.

That made concurrent presign traffic flaky and could surface 409-style failures for an otherwise healthy upload.

## Root cause

The backend treated a failed `TransitionUploadStatus(uploadID, INITIATED, UPLOADING)` as a terminal error, instead of re-reading the upload state and accepting the case where another concurrent request had already moved it into `UPLOADING`.

## Fix

- add a backend helper that re-checks the upload after a failed transition attempt
- allow `PresignPart` and `PresignParts` to proceed when the upload is already active in `UPLOADING`
- preserve the existing failure semantics for genuinely inactive / expired / invalid uploads
- add a regression test that exercises the concurrent transition race directly

## Testing

Passed:

```bash
DRIVE9_TEST_MYSQL_DSN='...'
go test ./pkg/backend -run 'TestPresignPart(Single|ConcurrentTransition)|TestPresignPartsBatch' -count=1
```

```bash
DRIVE9_TEST_MYSQL_DSN='...'
go test ./pkg/backend -run 'TestPresignPartConcurrentTransition' -count=10
```

Also checked:
- `go test ./pkg/backend -count=1` still has pre-existing environment/schema failures unrelated to this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of multi-part uploads by improving concurrent request handling and state management during presign operations.
  * Centralized eligibility verification to prevent race conditions and ensure consistent behavior.

* **Tests**
  * Added concurrency tests validating upload stability under simultaneous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->