### PR TITLE
docs(e2e): point dev base URL to public ALB

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -82,7 +82,7 @@ bash e2e/smoke-all.sh
 Current shared dev deployment:
 
 ```bash
-export DRIVE9_BASE="https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
+export DRIVE9_BASE="http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com"
 ```
 
 Use this value unless the environment owner announces a new endpoint.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -118,7 +118,7 @@ DRIVE9_BASE=$DEPLOY bash e2e/smoke-all.sh
 ### Dev
 
 ```bash
-export DRIVE9_BASE="https://xkopoerih4.execute-api.ap-southeast-1.amazonaws.com"
+export DRIVE9_BASE="http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com"
 ```
 
 ### Prod


### PR DESCRIPTION
## Summary
- update dev e2e documentation to use the new public ALB endpoint instead of the deleted dev API Gateway endpoint
- keep all code changes scoped to `e2e/README.md` and `e2e/AGENTS.md` only

## Validation
- confirmed branch diff against `main` contains only the two e2e docs files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated development deployment endpoint configuration in end-to-end testing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->