### PR TITLE
Fix FUSE overwrite after truncate

### DIFF
--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -637,7 +637,7 @@ if is_mounted "$MOUNT_POINT"; then
 
   if : > "$RW_TEXT_MOUNT"; then
     check_eq "truncate via mount succeeds" "true" "true"
-    truncated_size=$(stat_field "$RW_TEXT_REMOTE" "size")
+    truncated_size=$(wait_remote_stat_field_eq "$RW_TEXT_REMOTE" "size" "0")
     check_eq "truncate sets size to 0" "$truncated_size" "0"
   else
     check_eq "truncate via mount succeeds" "false" "true"

--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -11,6 +11,8 @@ MOUNT_READY_TIMEOUT_S="${MOUNT_READY_TIMEOUT_S:-20}"
 MOUNT_READY_INTERVAL_S="${MOUNT_READY_INTERVAL_S:-1}"
 REMOTE_VISIBILITY_TIMEOUT_S="${REMOTE_VISIBILITY_TIMEOUT_S:-5}"
 REMOTE_VISIBILITY_INTERVAL_S="${REMOTE_VISIBILITY_INTERVAL_S:-0.2}"
+LARGE_FILE_VISIBILITY_TIMEOUT_S="${LARGE_FILE_VISIBILITY_TIMEOUT_S:-30}"
+LARGE_FILE_VISIBILITY_INTERVAL_S="${LARGE_FILE_VISIBILITY_INTERVAL_S:-1}"
 FUSE_MOUNT_ROOT="${FUSE_MOUNT_ROOT:-/tmp}"
 CLI_SOURCE="${CLI_SOURCE:-build}"
 CLI_RELEASE_BASE_URL="${CLI_RELEASE_BASE_URL:-https://drive9.ai/releases}"
@@ -178,6 +180,63 @@ for line in text.splitlines():
         raise SystemExit(0)
 raise SystemExit(1)
 PY
+}
+
+wait_remote_stat_field_eq() {
+  local path="$1"
+  local field="$2"
+  local want="$3"
+  local timeout_s="${4:-$REMOTE_VISIBILITY_TIMEOUT_S}"
+  local interval_s="${5:-$REMOTE_VISIBILITY_INTERVAL_S}"
+  local deadline
+  local out rc got
+  deadline=$(python3 - "$timeout_s" <<'PY'
+import sys
+import time
+print(time.time() + float(sys.argv[1]))
+PY
+)
+
+  while :; do
+    set +e
+    out=$(drive9 fs stat "$path" 2>&1)
+    rc=$?
+    set -e
+
+    if [ "$rc" -eq 0 ]; then
+      got=$(python3 - "$out" "$field" <<'PY'
+import sys
+text, field = sys.argv[1], sys.argv[2].lower()
+for line in text.splitlines():
+    if line.strip().lower().startswith(field + ":"):
+        print(line.split(":", 1)[1].strip())
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+      ) || got=""
+      if [ "$got" = "$want" ]; then
+        printf '%s' "$got"
+        return 0
+      fi
+    elif [[ "$out" != *"not found"* && "$out" != *"Too Many Requests"* && "$out" != *"HTTP 429"* && "$out" != *"HTTP 403"* && "$out" != *"403 Forbidden"* ]]; then
+      printf '%s\n' "$out" >&2
+      return 1
+    fi
+
+    if python3 - "$deadline" <<'PY'
+import sys
+import time
+raise SystemExit(0 if time.time() >= float(sys.argv[1]) else 1)
+PY
+    then
+      if [ "$rc" -eq 0 ] && [ -n "$got" ]; then
+        printf '%s\n' "$got" >&2
+      fi
+      return 1
+    fi
+
+    sleep "$interval_s"
+  done
 }
 
 local_size_mtime() {
@@ -506,6 +565,9 @@ RW_TEXT_MOUNT="$MOUNT_POINT/$RW_TEXT_REL"
 RW_TEXT_RENAMED_REL="${RW_ALPHA_REL}/text-renamed.txt"
 RW_TEXT_RENAMED_REMOTE="/${RW_TEXT_RENAMED_REL}"
 RW_TEXT_RENAMED_MOUNT="$MOUNT_POINT/$RW_TEXT_RENAMED_REL"
+RW_ATTR_REL="${RW_ALPHA_REL}/attr.txt"
+RW_ATTR_REMOTE="/${RW_ATTR_REL}"
+RW_ATTR_MOUNT="$MOUNT_POINT/$RW_ATTR_REL"
 RW_ALPHA_RENAMED_REL="${ROOT_REL}/alpha-renamed"
 RW_ALPHA_RENAMED_REMOTE="/${RW_ALPHA_RENAMED_REL}"
 RW_ALPHA_RENAMED_MOUNT="$MOUNT_POINT/$RW_ALPHA_RENAMED_REL"
@@ -565,46 +627,36 @@ if is_mounted "$MOUNT_POINT"; then
   check_eq "create/read via mount" "$mounted_text" "create-${TS}"
   check_eq "create visible via remote cat" "$remote_text" "create-${TS}"
 
-  # Skip overwrite/truncate coverage for now. The mounted overwrite path can
-  # self-conflict after a truncate-to-zero write advances the server revision:
-  # https://github.com/mem9-ai/drive9/issues/247
-  #
-  echo "SKIP overwrite visible via remote cat (tracked in issue #247)"
-  echo "SKIP append visible via remote cat (blocked by issue #247)"
-  echo "SKIP truncate via mount semantics (tracked in issue #247)"
-  #
-  # printf "overwrite-%s" "$TS" > "$RW_TEXT_MOUNT"
-  # remote_overwrite=$(wait_remote_cat_eq "$RW_TEXT_REMOTE" "overwrite-${TS}")
-  # check_eq "overwrite visible via remote cat" "$remote_overwrite" "overwrite-${TS}"
-  #
-  # printf -- "-append" >> "$RW_TEXT_MOUNT"
-  # remote_append=$(wait_remote_cat_eq "$RW_TEXT_REMOTE" "overwrite-${TS}-append")
-  # check_eq "append visible via remote cat" "$remote_append" "overwrite-${TS}-append"
-  #
-  # if : > "$RW_TEXT_MOUNT"; then
-  #   check_eq "truncate via mount succeeds" "true" "true"
-  #   truncated_size=$(stat_field "$RW_TEXT_REMOTE" "size")
-  #   check_eq "truncate sets size to 0" "$truncated_size" "0"
-  # else
-  #   check_eq "truncate via mount succeeds" "false" "true"
-  # fi
-  #
+  printf "overwrite-%s" "$TS" > "$RW_TEXT_MOUNT"
+  remote_overwrite=$(wait_remote_cat_eq "$RW_TEXT_REMOTE" "overwrite-${TS}")
+  check_eq "overwrite visible via remote cat" "$remote_overwrite" "overwrite-${TS}"
+
+  printf -- "-append" >> "$RW_TEXT_MOUNT"
+  remote_append=$(wait_remote_cat_eq "$RW_TEXT_REMOTE" "overwrite-${TS}-append")
+  check_eq "append visible via remote cat" "$remote_append" "overwrite-${TS}-append"
+
+  if : > "$RW_TEXT_MOUNT"; then
+    check_eq "truncate via mount succeeds" "true" "true"
+    truncated_size=$(stat_field "$RW_TEXT_REMOTE" "size")
+    check_eq "truncate sets size to 0" "$truncated_size" "0"
+  else
+    check_eq "truncate via mount succeeds" "false" "true"
+  fi
+
   echo "[6] attribute semantics"
-  echo "SKIP attribute semantics on in-place overwrite path (blocked by issue #247)"
-  echo "SKIP mounted size / mtime checks on overwrite path (tracked in issue #247)"
-  # printf "attr-base-%s" "$TS" > "$RW_TEXT_MOUNT"
-  # stat1=$(local_size_mtime "$RW_TEXT_MOUNT")
-  # size1="${stat1%%:*}"
-  # mtime1="${stat1##*:}"
-  # sleep 1
-  # printf -- "-x" >> "$RW_TEXT_MOUNT"
-  # stat2=$(local_size_mtime "$RW_TEXT_MOUNT")
-  # size2="${stat2%%:*}"
-  # mtime2="${stat2##*:}"
-  # remote_attr_size=$(stat_field "$RW_TEXT_REMOTE" "size")
-  # check_cmd "mounted size increases after append" test "$size2" -gt "$size1"
-  # check_cmd "mounted mtime is monotonic" test "$mtime2" -ge "$mtime1"
-  # check_eq "remote stat size matches mounted size" "$remote_attr_size" "$size2"
+  printf "attr-base-%s" "$TS" > "$RW_ATTR_MOUNT"
+  stat1=$(local_size_mtime "$RW_ATTR_MOUNT")
+  size1="${stat1%%:*}"
+  mtime1="${stat1##*:}"
+  sleep 1
+  printf -- "-x" >> "$RW_ATTR_MOUNT"
+  stat2=$(local_size_mtime "$RW_ATTR_MOUNT")
+  size2="${stat2%%:*}"
+  mtime2="${stat2##*:}"
+  remote_attr_size=$(wait_remote_stat_field_eq "$RW_ATTR_REMOTE" "size" "$size2")
+  check_cmd "mounted size increases after append" test "$size2" -gt "$size1"
+  check_cmd "mounted mtime is monotonic" test "$mtime2" -ge "$mtime1"
+  check_eq "remote stat size matches mounted size" "$remote_attr_size" "$size2"
 
   echo "[7] readdir semantics"
   alpha_ls=$(ls -1 "$RW_ALPHA_MOUNT")
@@ -627,7 +679,7 @@ PY
   mv "$RW_TEXT_MOUNT" "$RW_TEXT_RENAMED_MOUNT"
   check_cmd_fail "old file path missing after rename" test -f "$RW_TEXT_MOUNT"
   renamed_text=$(drive9_retry fs cat "$RW_TEXT_RENAMED_REMOTE")
-  check_eq "renamed file readable via remote" "$renamed_text" "create-${TS}"
+  check_eq "renamed file readable via remote" "$renamed_text" ""
 
   rename_dir_ready=false
   if wait_path_exists "$RW_ALPHA_MOUNT"; then
@@ -635,7 +687,7 @@ PY
       check_eq "rename directory via mount succeeds" "true" "true"
       check_cmd "renamed directory visible via remote list" wait_remote_ls_has_name "$ROOT_REMOTE" "alpha-renamed"
       renamed_nested_text=$(drive9_retry fs cat "$RW_ALPHA_RENAMED_REMOTE/text-renamed.txt")
-      check_eq "renamed directory keeps file content" "$renamed_nested_text" "create-${TS}"
+      check_eq "renamed directory keeps file content" "$renamed_nested_text" ""
       rename_dir_ready=true
     else
       check_eq "rename directory via mount succeeds" "false" "true"
@@ -689,7 +741,7 @@ PY
   echo "[10] large-file boundary"
   if [ "$rename_dir_ready" = "true" ]; then
     dd if=/dev/zero of="$LARGE_MOUNT" bs=1M count=8 status=none
-    large_size=$(stat_field "$LARGE_REMOTE" "size")
+    large_size=$(wait_remote_stat_field_eq "$LARGE_REMOTE" "size" "8388608" "$LARGE_FILE_VISIBILITY_TIMEOUT_S" "$LARGE_FILE_VISIBILITY_INTERVAL_S")
     check_eq "8MB mounted file size matches remote stat" "$large_size" "8388608"
     drive9_retry fs cp ":$LARGE_REMOTE" "$LARGE_DOWNLOADED" >/dev/null
     check_cmd "downloaded large file exists" test -f "$LARGE_DOWNLOADED"
@@ -708,6 +760,7 @@ PY
 
   mkdir -p "$MOUNT_POINT/${ROOT_REL}/nonempty"
   printf "x" > "$MOUNT_POINT/${ROOT_REL}/nonempty/x.txt"
+  check_eq "non-empty dir child visible via remote" "$(wait_remote_cat_eq "/${ROOT_REL}/nonempty/x.txt" "x")" "x"
   check_cmd_fail "rmdir non-empty dir fails" rmdir "$MOUNT_POINT/${ROOT_REL}/nonempty"
   rm -f "$MOUNT_POINT/${ROOT_REL}/nonempty/x.txt"
   if [ -d "$MOUNT_POINT/${ROOT_REL}/nonempty" ]; then

--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -229,9 +229,8 @@ import time
 raise SystemExit(0 if time.time() >= float(sys.argv[1]) else 1)
 PY
     then
-      if [ "$rc" -eq 0 ] && [ -n "$got" ]; then
-        printf '%s\n' "$got" >&2
-      fi
+      printf 'wait_remote_stat_field_eq: timeout path=%s field=%s want=%s last_got=%s\n' \
+        "$path" "$field" "$want" "${got:-<none>}" >&2
       return 1
     fi
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -185,6 +185,26 @@ func (fs *Dat9FS) clearDirtySize(ino uint64, seq uint64) {
 	}
 }
 
+func (fs *Dat9FS) updateOpenHandleBaseRevision(path string, revision int64) {
+	if revision <= 0 {
+		return
+	}
+
+	fs.fileHandles.ForEach(func(_ uint64, fh *FileHandle) {
+		if fh == nil || fh.Path != path {
+			return
+		}
+		fh.Lock()
+		fh.BaseRev = revision
+		if fh.ShadowReady && fs.shadowStore != nil {
+			if err := fs.shadowStore.Ensure(fh.Path, fh.Dirty.Size(), revision); err != nil {
+				log.Printf("shadow base revision refresh failed for %s: %v", fh.Path, err)
+			}
+		}
+		fh.Unlock()
+	})
+}
+
 func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gofuse.Status {
 	stat, err := fs.client.StatCtx(ctx, fh.Path)
 	if err != nil {
@@ -691,6 +711,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 					if stat.Revision > 0 {
 						entry.Revision = stat.Revision
 						fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
+						fs.updateOpenHandleBaseRevision(entry.Path, stat.Revision)
 					}
 					if !stat.Mtime.IsZero() {
 						entry.Mtime = stat.Mtime

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -185,16 +185,31 @@ func (fs *Dat9FS) clearDirtySize(ino uint64, seq uint64) {
 	}
 }
 
+func shouldRefreshHandleAfterPathTruncate(fh *FileHandle) bool {
+	if fh == nil || fh.Dirty == nil {
+		return false
+	}
+	return fh.ZeroBase
+}
+
 func (fs *Dat9FS) updateOpenHandleBaseRevision(path string, revision int64) {
 	if revision <= 0 {
 		return
 	}
 
+	var matching []*FileHandle
 	for _, fh := range fs.fileHandles.Snapshot() {
-		if fh == nil || fh.Path != path {
+		if fh != nil && fh.Path == path && fh.Dirty != nil {
+			matching = append(matching, fh)
+		}
+	}
+
+	for _, fh := range matching {
+		fh.Lock()
+		if len(matching) > 1 && !shouldRefreshHandleAfterPathTruncate(fh) {
+			fh.Unlock()
 			continue
 		}
-		fh.Lock()
 		fh.BaseRev = revision
 		if fh.Streamer != nil {
 			fh.Streamer.RefreshExpectedRevision(expectedRevisionForHandle(fh))
@@ -695,6 +710,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 				// subsequent writes starting at the new size are not
 				// misdetected as back-writes (appendCursor may be stale).
 				fh.Dirty.ResetSequentialState(newSize)
+				fh.ZeroBase = newSize == 0
 				fh.DirtySeq = fs.markDirtySize(fh.Ino, fh.Dirty.Size())
 				fh.Unlock()
 			}
@@ -1405,6 +1421,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			fh.Dirty.sequential = true
 			fh.Dirty.uploadedParts = make(map[int]bool)
 			_ = fh.Dirty.Truncate(0)
+			fh.ZeroBase = true
 			fh.DirtySeq = fs.markDirtySize(fh.Ino, 0)
 			fs.inodes.UpdateSize(fh.Ino, 0)
 			if fs.shadowStore != nil && fs.pendingIndex != nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -189,24 +189,71 @@ func shouldRefreshHandleAfterPathTruncate(fh *FileHandle) bool {
 	if fh == nil || fh.Dirty == nil {
 		return false
 	}
-	return fh.ZeroBase
+	if fh.ZeroBase {
+		return true
+	}
+	return fh.Flags&syscall.O_TRUNC != 0
 }
 
-func (fs *Dat9FS) updateOpenHandleBaseRevision(path string, revision int64) {
+func shouldAdoptSingleHandlePathTruncate(fh *FileHandle, callerPID uint32, matchCount int) bool {
+	if fh == nil || fh.Dirty == nil {
+		return false
+	}
+	if callerPID == 0 || matchCount != 1 {
+		return false
+	}
+	return fh.OpenPID == callerPID
+}
+
+func (fs *Dat9FS) truncateWritableHandleLocked(fh *FileHandle, newSize int64) error {
+	if fh == nil || fh.Dirty == nil {
+		return nil
+	}
+	if err := fh.Dirty.Truncate(newSize); err != nil {
+		return err
+	}
+	if fs.shadowStore != nil && fs.pendingIndex != nil {
+		if fh.ShadowReady || fh.IsNew || newSize == 0 {
+			if err := fs.shadowStore.Truncate(fh.Path, newSize, fh.BaseRev); err != nil {
+				log.Printf("shadow truncate failed for %s: %v", fh.Path, err)
+				fs.shadowStore.Remove(fh.Path)
+				fh.ShadowReady = false
+			} else {
+				fh.ShadowReady = true
+			}
+		}
+	}
+	// Reset sequential write tracking after truncate so that
+	// subsequent writes starting at the new size are not
+	// misdetected as back-writes (appendCursor may be stale).
+	fh.Dirty.ResetSequentialState(newSize)
+	fh.ZeroBase = newSize == 0
+	fh.DirtySeq = fs.markDirtySize(fh.Ino, fh.Dirty.Size())
+	return nil
+}
+
+func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64, callerPID uint32) {
 	if revision <= 0 {
 		return
 	}
 
 	var matching []*FileHandle
 	for _, fh := range fs.fileHandles.Snapshot() {
-		if fh != nil && fh.Path == path && fh.Dirty != nil {
+		if fh != nil && fh.Path == remotePath && fh.Dirty != nil {
 			matching = append(matching, fh)
 		}
 	}
 
 	for _, fh := range matching {
 		fh.Lock()
-		if len(matching) > 1 && !shouldRefreshHandleAfterPathTruncate(fh) {
+		if shouldAdoptSingleHandlePathTruncate(fh, callerPID, len(matching)) {
+			if err := fs.truncateWritableHandleLocked(fh, 0); err != nil {
+				log.Printf("handle truncate sync failed for %s: %v", fh.Path, err)
+				fh.Unlock()
+				continue
+			}
+		}
+		if !shouldRefreshHandleAfterPathTruncate(fh) {
 			fh.Unlock()
 			continue
 		}
@@ -691,27 +738,10 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 			fh, ok := fs.fileHandles.Get(input.Fh)
 			if ok && fh.Dirty != nil {
 				fh.Lock()
-				if err := fh.Dirty.Truncate(newSize); err != nil {
+				if err := fs.truncateWritableHandleLocked(fh, newSize); err != nil {
 					fh.Unlock()
 					return gofuse.Status(syscall.EFBIG)
 				}
-				if fs.shadowStore != nil && fs.pendingIndex != nil {
-					if fh.ShadowReady || fh.IsNew || newSize == 0 {
-						if err := fs.shadowStore.Truncate(fh.Path, newSize, fh.BaseRev); err != nil {
-							log.Printf("shadow truncate failed for %s: %v", fh.Path, err)
-							fs.shadowStore.Remove(fh.Path)
-							fh.ShadowReady = false
-						} else {
-							fh.ShadowReady = true
-						}
-					}
-				}
-				// Reset sequential write tracking after truncate so that
-				// subsequent writes starting at the new size are not
-				// misdetected as back-writes (appendCursor may be stale).
-				fh.Dirty.ResetSequentialState(newSize)
-				fh.ZeroBase = newSize == 0
-				fh.DirtySeq = fs.markDirtySize(fh.Ino, fh.Dirty.Size())
 				fh.Unlock()
 			}
 		} else {
@@ -734,7 +764,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 					if stat.Revision > 0 {
 						entry.Revision = stat.Revision
 						fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
-						fs.updateOpenHandleBaseRevision(entry.Path, stat.Revision)
+						fs.updateOpenHandleBaseRevision(entry.Path, stat.Revision, input.Pid)
 					}
 					if !stat.Mtime.IsZero() {
 						entry.Mtime = stat.Mtime
@@ -1353,9 +1383,10 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 	}
 
 	fh := &FileHandle{
-		Ino:   input.NodeId,
-		Path:  p,
-		Flags: input.Flags,
+		Ino:     input.NodeId,
+		Path:    p,
+		Flags:   input.Flags,
+		OpenPID: input.Pid,
 	}
 	entry, _ := fs.inodes.GetEntry(input.NodeId)
 	if entry != nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -190,19 +190,26 @@ func (fs *Dat9FS) updateOpenHandleBaseRevision(path string, revision int64) {
 		return
 	}
 
-	fs.fileHandles.ForEach(func(_ uint64, fh *FileHandle) {
+	for _, fh := range fs.fileHandles.Snapshot() {
 		if fh == nil || fh.Path != path {
-			return
+			continue
 		}
 		fh.Lock()
 		fh.BaseRev = revision
+		if fh.Streamer != nil {
+			fh.Streamer.RefreshExpectedRevision(expectedRevisionForHandle(fh))
+		}
 		if fh.ShadowReady && fs.shadowStore != nil {
-			if err := fs.shadowStore.Ensure(fh.Path, fh.Dirty.Size(), revision); err != nil {
+			size := int64(0)
+			if fh.Dirty != nil {
+				size = fh.Dirty.Size()
+			}
+			if err := fs.shadowStore.Ensure(fh.Path, size, revision); err != nil {
 				log.Printf("shadow base revision refresh failed for %s: %v", fh.Path, err)
 			}
 		}
 		fh.Unlock()
-	})
+	}
 }
 
 func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gofuse.Status {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1,6 +1,8 @@
 package fuse
 
+
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1176,6 +1178,145 @@ func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 	}
 	if revision != 3 {
 		t.Fatalf("remote revision = %d, want 3", revision)
+	}
+}
+
+func TestSetAttr_PathTruncateDoesNotRefreshStaleWriterHandle(t *testing.T) {
+	var (
+		mu         sync.Mutex
+		revision   int64 = 1
+		content         = []byte("orig")
+		handlerErr error
+	)
+	recordHandlerErr := func(err error) {
+		if err == nil {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			mu.Lock()
+			defer mu.Unlock()
+			w.Header().Set("Content-Length", strconv.FormatInt(int64(len(content)), 10))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(revision, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				recordHandlerErr(fmt.Errorf("read body: %w", err))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			expected := r.Header.Get("X-Dat9-Expected-Revision")
+			if expected != "" && expected != strconv.FormatInt(revision, 10) {
+				http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+				return
+			}
+			content = append([]byte(nil), body...)
+			revision++
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			_, _ = w.Write(content)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	ino := fs.inodes.Lookup("/file.bin", false, int64(len(content)), time.Now())
+	fs.inodes.UpdateRevision(ino, revision)
+	fs.inodes.UpdateSize(ino, int64(len(content)))
+
+	var staleOut gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_WRONLY),
+	}, &staleOut)
+	if st != gofuse.OK {
+		t.Fatalf("stale writer Open status = %v, want OK", st)
+	}
+	staleFH, ok := fs.fileHandles.Get(staleOut.Fh)
+	if !ok {
+		t.Fatal("stale writer handle not found")
+	}
+
+	var truncOut gofuse.OpenOut
+	st = fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	}, &truncOut)
+	if st != gofuse.OK {
+		t.Fatalf("truncate handle Open status = %v, want OK", st)
+	}
+	truncFH, ok := fs.fileHandles.Get(truncOut.Fh)
+	if !ok {
+		t.Fatal("truncate handle not found")
+	}
+
+	var attrOut gofuse.AttrOut
+	st = fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &attrOut)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+
+	if staleFH.BaseRev != 1 {
+		t.Fatalf("stale writer base revision = %d, want 1", staleFH.BaseRev)
+	}
+	if truncFH.BaseRev != 2 {
+		t.Fatalf("truncate handle base revision = %d, want 2", truncFH.BaseRev)
+	}
+
+	if _, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       staleOut.Fh,
+		Offset:   0,
+	}, []byte("stale")); st != gofuse.OK {
+		t.Fatalf("stale writer Write status = %v, want OK", st)
+	}
+
+	staleFH.Lock()
+	flushStatus := fs.flushHandle(context.Background(), staleFH)
+	staleFH.Unlock()
+	if flushStatus != gofuse.EIO {
+		t.Fatalf("stale writer flush status = %v, want %v", flushStatus, gofuse.EIO)
+	}
+
+	mu.Lock()
+	if handlerErr != nil {
+		mu.Unlock()
+		t.Fatal(handlerErr)
+	}
+	defer mu.Unlock()
+	if got := string(content); got != "" {
+		t.Fatalf("remote content after stale writer conflict = %q, want empty", got)
+	}
+	if revision != 2 {
+		t.Fatalf("remote revision after stale writer conflict = %d, want 2", revision)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1,6 +1,5 @@
 package fuse
 
-
 import (
 	"context"
 	"encoding/json"
@@ -1055,10 +1054,12 @@ func TestSetAttr_TruncateWithoutHandleRefreshesRevision(t *testing.T) {
 }
 
 func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
+	const callerPID = 4242
+
 	var (
 		mu         sync.Mutex
 		revision   int64 = 1
-		content         = []byte("orig")
+		content          = []byte("orig")
 		handlerErr error
 	)
 	recordHandlerErr := func(err error) {
@@ -1117,7 +1118,7 @@ func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 
 	var openOut gofuse.OpenOut
 	st := fs.Open(nil, &gofuse.OpenIn{
-		InHeader: gofuse.InHeader{NodeId: ino},
+		InHeader: gofuse.InHeader{NodeId: ino, Caller: gofuse.Caller{Pid: callerPID}},
 		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
 	}, &openOut)
 	if st != gofuse.OK {
@@ -1135,7 +1136,7 @@ func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 	var attrOut gofuse.AttrOut
 	st = fs.SetAttr(nil, &gofuse.SetAttrIn{
 		SetAttrInCommon: gofuse.SetAttrInCommon{
-			InHeader: gofuse.InHeader{NodeId: ino},
+			InHeader: gofuse.InHeader{NodeId: ino, Caller: gofuse.Caller{Pid: callerPID}},
 			Valid:    gofuse.FATTR_SIZE,
 			Size:     0,
 		},
@@ -1181,11 +1182,148 @@ func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 	}
 }
 
-func TestSetAttr_PathTruncateDoesNotRefreshStaleWriterHandle(t *testing.T) {
+func TestSetAttr_PathTruncateSingleCallerWriterAdoptsZeroBase(t *testing.T) {
+	const callerPID = 5151
+
 	var (
 		mu         sync.Mutex
 		revision   int64 = 1
-		content         = []byte("orig")
+		content          = []byte("orig")
+		handlerErr error
+	)
+	recordHandlerErr := func(err error) {
+		if err == nil {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			mu.Lock()
+			defer mu.Unlock()
+			w.Header().Set("Content-Length", strconv.FormatInt(int64(len(content)), 10))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(revision, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				recordHandlerErr(fmt.Errorf("read body: %w", err))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			expected := r.Header.Get("X-Dat9-Expected-Revision")
+			if expected != "" && expected != strconv.FormatInt(revision, 10) {
+				http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+				return
+			}
+			content = append([]byte(nil), body...)
+			revision++
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			_, _ = w.Write(content)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	ino := fs.inodes.Lookup("/file.bin", false, int64(len(content)), time.Now())
+	fs.inodes.UpdateRevision(ino, revision)
+	fs.inodes.UpdateSize(ino, int64(len(content)))
+
+	var openOut gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino, Caller: gofuse.Caller{Pid: callerPID}},
+		Flags:    uint32(syscall.O_WRONLY),
+	}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	fh, ok := fs.fileHandles.Get(openOut.Fh)
+	if !ok {
+		t.Fatal("file handle not found")
+	}
+
+	var attrOut gofuse.AttrOut
+	st = fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino, Caller: gofuse.Caller{Pid: callerPID}},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &attrOut)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+
+	if fh.BaseRev != 2 {
+		t.Fatalf("open handle base revision after path truncate = %d, want 2", fh.BaseRev)
+	}
+	if !fh.ZeroBase {
+		t.Fatal("expected same-caller writer handle to adopt zero base")
+	}
+	if got := fh.Dirty.Size(); got != 0 {
+		t.Fatalf("dirty size after path truncate = %d, want 0", got)
+	}
+
+	if _, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       openOut.Fh,
+		Offset:   0,
+	}, []byte("overwrite")); st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+
+	fh.Lock()
+	flushStatus := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+	if flushStatus != gofuse.OK {
+		t.Fatalf("flush status = %v, want %v", flushStatus, gofuse.OK)
+	}
+
+	mu.Lock()
+	if handlerErr != nil {
+		mu.Unlock()
+		t.Fatal(handlerErr)
+	}
+	defer mu.Unlock()
+	if got := string(content); got != "overwrite" {
+		t.Fatalf("remote content = %q, want %q", got, "overwrite")
+	}
+	if revision != 3 {
+		t.Fatalf("remote revision = %d, want 3", revision)
+	}
+}
+
+func TestSetAttr_PathTruncateDoesNotRefreshStaleWriterHandle(t *testing.T) {
+	const (
+		stalePID    = 7001
+		truncatePID = 7002
+	)
+
+	var (
+		mu         sync.Mutex
+		revision   int64 = 1
+		content          = []byte("orig")
 		handlerErr error
 	)
 	recordHandlerErr := func(err error) {
@@ -1248,7 +1386,7 @@ func TestSetAttr_PathTruncateDoesNotRefreshStaleWriterHandle(t *testing.T) {
 
 	var staleOut gofuse.OpenOut
 	st := fs.Open(nil, &gofuse.OpenIn{
-		InHeader: gofuse.InHeader{NodeId: ino},
+		InHeader: gofuse.InHeader{NodeId: ino, Caller: gofuse.Caller{Pid: stalePID}},
 		Flags:    uint32(syscall.O_WRONLY),
 	}, &staleOut)
 	if st != gofuse.OK {
@@ -1261,7 +1399,7 @@ func TestSetAttr_PathTruncateDoesNotRefreshStaleWriterHandle(t *testing.T) {
 
 	var truncOut gofuse.OpenOut
 	st = fs.Open(nil, &gofuse.OpenIn{
-		InHeader: gofuse.InHeader{NodeId: ino},
+		InHeader: gofuse.InHeader{NodeId: ino, Caller: gofuse.Caller{Pid: truncatePID}},
 		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
 	}, &truncOut)
 	if st != gofuse.OK {
@@ -1275,7 +1413,7 @@ func TestSetAttr_PathTruncateDoesNotRefreshStaleWriterHandle(t *testing.T) {
 	var attrOut gofuse.AttrOut
 	st = fs.SetAttr(nil, &gofuse.SetAttrIn{
 		SetAttrInCommon: gofuse.SetAttrInCommon{
-			InHeader: gofuse.InHeader{NodeId: ino},
+			InHeader: gofuse.InHeader{NodeId: ino, Caller: gofuse.Caller{Pid: truncatePID}},
 			Valid:    gofuse.FATTR_SIZE,
 			Size:     0,
 		},
@@ -1317,6 +1455,134 @@ func TestSetAttr_PathTruncateDoesNotRefreshStaleWriterHandle(t *testing.T) {
 	}
 	if revision != 2 {
 		t.Fatalf("remote revision after stale writer conflict = %d, want 2", revision)
+	}
+}
+
+func TestSetAttr_PathTruncateSingleStaleWriterHandleKeepsOriginalRevision(t *testing.T) {
+	const (
+		stalePID    = 8001
+		truncatePID = 8002
+	)
+
+	var (
+		mu         sync.Mutex
+		revision   int64 = 1
+		content          = []byte("orig")
+		handlerErr error
+	)
+	recordHandlerErr := func(err error) {
+		if err == nil {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			mu.Lock()
+			defer mu.Unlock()
+			w.Header().Set("Content-Length", strconv.FormatInt(int64(len(content)), 10))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(revision, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				recordHandlerErr(fmt.Errorf("read body: %w", err))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			expected := r.Header.Get("X-Dat9-Expected-Revision")
+			if expected != "" && expected != strconv.FormatInt(revision, 10) {
+				http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+				return
+			}
+			content = append([]byte(nil), body...)
+			revision++
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			_, _ = w.Write(content)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	ino := fs.inodes.Lookup("/file.bin", false, int64(len(content)), time.Now())
+	fs.inodes.UpdateRevision(ino, revision)
+	fs.inodes.UpdateSize(ino, int64(len(content)))
+
+	var staleOut gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino, Caller: gofuse.Caller{Pid: stalePID}},
+		Flags:    uint32(syscall.O_WRONLY),
+	}, &staleOut)
+	if st != gofuse.OK {
+		t.Fatalf("stale writer Open status = %v, want OK", st)
+	}
+	staleFH, ok := fs.fileHandles.Get(staleOut.Fh)
+	if !ok {
+		t.Fatal("stale writer handle not found")
+	}
+
+	var attrOut gofuse.AttrOut
+	st = fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino, Caller: gofuse.Caller{Pid: truncatePID}},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &attrOut)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+
+	if staleFH.BaseRev != 1 {
+		t.Fatalf("single stale writer base revision = %d, want 1", staleFH.BaseRev)
+	}
+
+	if _, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       staleOut.Fh,
+		Offset:   0,
+	}, []byte("stale")); st != gofuse.OK {
+		t.Fatalf("single stale writer Write status = %v, want OK", st)
+	}
+
+	staleFH.Lock()
+	flushStatus := fs.flushHandle(context.Background(), staleFH)
+	staleFH.Unlock()
+	if flushStatus != gofuse.EIO {
+		t.Fatalf("single stale writer flush status = %v, want %v", flushStatus, gofuse.EIO)
+	}
+
+	mu.Lock()
+	if handlerErr != nil {
+		mu.Unlock()
+		t.Fatal(handlerErr)
+	}
+	defer mu.Unlock()
+	if got := string(content); got != "" {
+		t.Fatalf("remote content after single stale writer conflict = %q, want empty", got)
+	}
+	if revision != 2 {
+		t.Fatalf("remote revision after single stale writer conflict = %d, want 2", revision)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1054,10 +1054,21 @@ func TestSetAttr_TruncateWithoutHandleRefreshesRevision(t *testing.T) {
 
 func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 	var (
-		mu       sync.Mutex
-		revision int64 = 1
-		content       = []byte("orig")
+		mu         sync.Mutex
+		revision   int64 = 1
+		content         = []byte("orig")
+		handlerErr error
 	)
+	recordHandlerErr := func(err error) {
+		if err == nil {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -1071,7 +1082,9 @@ func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 		case http.MethodPut:
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read body: %v", err)
+				recordHandlerErr(fmt.Errorf("read body: %w", err))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
 			}
 			mu.Lock()
 			defer mu.Unlock()
@@ -1132,6 +1145,15 @@ func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 	if fh.BaseRev != 2 {
 		t.Fatalf("open handle base revision after path truncate = %d, want 2", fh.BaseRev)
 	}
+	if fh.Streamer == nil {
+		t.Fatal("expected stream uploader on O_TRUNC handle")
+	}
+	fh.Streamer.mu.Lock()
+	streamerRevision := fh.Streamer.expectedRevision
+	fh.Streamer.mu.Unlock()
+	if streamerRevision != 2 {
+		t.Fatalf("streamer expected revision after path truncate = %d, want 2", streamerRevision)
+	}
 
 	if _, st = fs.Write(nil, &gofuse.WriteIn{
 		InHeader: gofuse.InHeader{NodeId: ino},
@@ -1144,6 +1166,10 @@ func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 	fs.Release(nil, &gofuse.ReleaseIn{Fh: openOut.Fh})
 
 	mu.Lock()
+	if handlerErr != nil {
+		mu.Unlock()
+		t.Fatal(handlerErr)
+	}
 	defer mu.Unlock()
 	if got := string(content); got != "overwrite" {
 		t.Fatalf("remote content = %q, want %q", got, "overwrite")

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1052,6 +1052,107 @@ func TestSetAttr_TruncateWithoutHandleRefreshesRevision(t *testing.T) {
 	}
 }
 
+func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		revision int64 = 1
+		content       = []byte("orig")
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			mu.Lock()
+			defer mu.Unlock()
+			w.Header().Set("Content-Length", strconv.FormatInt(int64(len(content)), 10))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(revision, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			expected := r.Header.Get("X-Dat9-Expected-Revision")
+			if expected != "" && expected != strconv.FormatInt(revision, 10) {
+				http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+				return
+			}
+			content = append([]byte(nil), body...)
+			revision++
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			mu.Lock()
+			defer mu.Unlock()
+			_, _ = w.Write(content)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	ino := fs.inodes.Lookup("/file.bin", false, int64(len(content)), time.Now())
+	fs.inodes.UpdateRevision(ino, revision)
+	fs.inodes.UpdateSize(ino, int64(len(content)))
+
+	var openOut gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	fh, ok := fs.fileHandles.Get(openOut.Fh)
+	if !ok {
+		t.Fatal("file handle not found")
+	}
+	if fh.BaseRev != 1 {
+		t.Fatalf("open base revision = %d, want 1", fh.BaseRev)
+	}
+
+	var attrOut gofuse.AttrOut
+	st = fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &attrOut)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+
+	if fh.BaseRev != 2 {
+		t.Fatalf("open handle base revision after path truncate = %d, want 2", fh.BaseRev)
+	}
+
+	if _, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       openOut.Fh,
+		Offset:   0,
+	}, []byte("overwrite")); st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: openOut.Fh})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := string(content); got != "overwrite" {
+		t.Fatalf("remote content = %q, want %q", got, "overwrite")
+	}
+	if revision != 3 {
+		t.Fatalf("remote revision = %d, want 3", revision)
+	}
+}
+
 func TestLookup_UsesMtimeFromStat(t *testing.T) {
 	mtime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -8,6 +8,7 @@ type FileHandle struct {
 	Ino          uint64
 	Path         string
 	Flags        uint32          // O_RDONLY, O_WRONLY, O_RDWR, O_APPEND, etc.
+	OpenPID      uint32          // PID that opened the handle, when supplied by the kernel
 	Dirty        *WriteBuffer    // write buffer, nil for read-only opens
 	DirtySeq     uint64          // monotonic sequence for authoritative dirty-size tracking
 	WriteBackSeq uint64          // DirtySeq at time of write-back cache snapshot (0 = no snapshot)

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -106,3 +106,16 @@ func (ht *HandleTable[T]) ForEach(fn func(fh uint64, val T)) {
 		fn(fh, val)
 	}
 }
+
+// Snapshot returns a copy of the handle values present at the time of call.
+// The returned slice can be iterated without holding the table lock.
+func (ht *HandleTable[T]) Snapshot() []T {
+	ht.mu.Lock()
+	defer ht.mu.Unlock()
+
+	vals := make([]T, 0, len(ht.table))
+	for _, val := range ht.table {
+		vals = append(vals, val)
+	}
+	return vals
+}

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -13,6 +13,7 @@ type FileHandle struct {
 	WriteBackSeq uint64          // DirtySeq at time of write-back cache snapshot (0 = no snapshot)
 	OrigSize     int64           // original file size at open time (for patch detection)
 	BaseRev      int64           // server revision at open time (for conflict detection)
+	ZeroBase     bool            // true when the handle has adopted an explicit empty-file baseline
 	IsNew        bool            // true if created via Create() (no prior remote existence)
 	ShadowReady  bool            // true when the local shadow file is a safe full snapshot
 	Streamer     *StreamUploader // nil for small files / read-only; manages background part uploads

--- a/pkg/fuse/stream_upload.go
+++ b/pkg/fuse/stream_upload.go
@@ -53,6 +53,22 @@ func (su *StreamUploader) Started() bool {
 	return su.started
 }
 
+// RefreshExpectedRevision updates the conditional revision used for future
+// upload initiation if streaming has not started yet.
+func (su *StreamUploader) RefreshExpectedRevision(revision int64) bool {
+	if revision < 0 {
+		return false
+	}
+
+	su.mu.Lock()
+	defer su.mu.Unlock()
+	if su.started {
+		return false
+	}
+	su.expectedRevision = revision
+	return true
+}
+
 // HasStreamedParts reports whether any parts were uploaded during streaming
 // (i.e., during Write() calls, not at flush time).
 func (su *StreamUploader) HasStreamedParts() bool {


### PR DESCRIPTION
## Summary
Fix the FUSE overwrite path so a shell-style truncate followed by overwrite does not self-conflict on a stale base revision.

## What changed
- refresh matching open file handles after a path-level truncate updates the remote revision
- add a regression test covering the `O_TRUNC open -> path truncate -> overwrite` sequence
- restore the previously skipped overwrite, append, truncate, and attribute checks in the FUSE smoke test
- make the smoke assertions wait for remote visibility where needed and isolate the attribute test file from later rename checks

## Validation
- `go test -v ./pkg/fuse -run 'TestSetAttr_(TruncateWithoutHandleRefreshesRevision|PathTruncateRefreshesOpenHandleBaseRevision)'`
- `DRIVE9_BASE=http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com bash e2e/fuse-smoke-test.sh`
- dev FUSE smoke result: `47/47 passed, 0 failed`

## Notes
- Left unrelated local perf/docs drafts out of this PR on purpose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable large-file visibility monitoring (timeout and interval).
  * More robust remote verification after overwrites, appends, truncates and renames to ensure visible content matches expectations.

* **Bug Fixes**
  * Improved truncate and write handling so local truncates and subsequent writes stay consistent with remote state and avoid stale-write conflicts.

* **Tests**
  * Added end-to-end and unit tests covering truncation, open-handle behavior, and remote visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->