### PR TITLE
Improve local test and e2e workflows

### DIFF
--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -1,0 +1,207 @@
+name: local-e2e
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/local-e2e.yml"
+      - "cmd/**"
+      - "pkg/**"
+      - "internal/**"
+      - "scripts/**"
+      - "e2e/**"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: local-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TIDB_VERSION: v8.5.5
+  DRIVE9_BASE: http://127.0.0.1:9009
+  DRIVE9_LOCAL_DSN: root@tcp(127.0.0.1:4000)/drive9_local?parseTime=true
+  DRIVE9_LOCAL_INIT_SCHEMA: "true"
+  DRIVE9_LOCAL_EMBEDDING_MODE: app
+  RUN_SEMANTIC_CHECKS: "0"
+  RUN_CLI_SEMANTIC_CHECKS: "0"
+
+jobs:
+  local-e2e:
+    name: drive9-server-local e2e smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y default-mysql-client fuse3
+
+      - name: Cache TiUP artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.tiup/bin
+            ~/.tiup/components
+            ~/.tiup/manifests
+            ~/.tiup/manifest
+          key: ${{ runner.os }}-tiup-${{ env.TIDB_VERSION }}
+
+      - name: Install TiUP and TiDB components
+        run: |
+          if [ ! -x "$HOME/.tiup/bin/tiup" ]; then
+            curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
+          fi
+          echo "$HOME/.tiup/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.tiup/bin:$PATH"
+          tiup telemetry disable || true
+          tiup install playground
+          tiup install tidb:${TIDB_VERSION} pd:${TIDB_VERSION} tikv:${TIDB_VERSION}
+          tiup --version
+
+      - name: Start TiDB playground
+        run: |
+          export PATH="$HOME/.tiup/bin:$PATH"
+          nohup tiup playground ${TIDB_VERSION} --tiflash 0 --without-monitor > /tmp/tiup-playground.log 2>&1 &
+          echo $! > /tmp/tiup-playground.pid
+
+      - name: Wait for TiDB readiness
+        run: |
+          for _ in {1..60}; do
+            if curl -sf http://127.0.0.1:10080/status > /tmp/tidb-status.json; then
+              cat /tmp/tidb-status.json
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "TiDB playground did not become ready in time" >&2
+          exit 1
+
+      - name: Create drive9 local database
+        run: |
+          mysql --protocol=tcp -h 127.0.0.1 -P 4000 -u root -e "CREATE DATABASE IF NOT EXISTS drive9_local;"
+
+      - name: Start drive9-server-local
+        run: |
+          nohup make run-server-local > /tmp/drive9-server-local.log 2>&1 &
+          echo $! > /tmp/drive9-server-local.pid
+
+      - name: Wait for drive9-server-local readiness
+        run: |
+          for _ in {1..60}; do
+            if curl -sf "$DRIVE9_BASE/healthz" > /tmp/drive9-healthz.json; then
+              cat /tmp/drive9-healthz.json
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "drive9-server-local did not become ready in time" >&2
+          exit 1
+
+      - name: Run API smoke
+        id: api-smoke
+        continue-on-error: true
+        run: bash e2e/api-smoke-test.sh
+
+      - name: Run existing-key smoke
+        id: existing-key-smoke
+        continue-on-error: true
+        env:
+          DRIVE9_API_KEY: local-dev-key
+        run: bash e2e/api-smoke-test-existing-key.sh
+
+      - name: Run CLI smoke
+        id: cli-smoke
+        continue-on-error: true
+        run: bash e2e/cli-smoke-test.sh
+
+      - name: Run FUSE smoke
+        id: fuse-smoke
+        continue-on-error: true
+        run: bash e2e/fuse-smoke-test.sh
+
+      - name: Publish local e2e summary
+        if: always()
+        run: |
+          {
+            echo "## drive9-server-local e2e"
+            echo
+            echo "| Check | Outcome |"
+            echo "| --- | --- |"
+            echo "| API smoke | ${{ steps.api-smoke.outcome || 'skipped' }} |"
+            echo "| Existing-key smoke | ${{ steps.existing-key-smoke.outcome || 'skipped' }} |"
+            echo "| CLI smoke | ${{ steps.cli-smoke.outcome || 'skipped' }} |"
+            echo "| FUSE smoke | ${{ steps.fuse-smoke.outcome || 'skipped' }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dump TiDB playground logs
+        if: always()
+        run: |
+          if [ -f /tmp/tiup-playground.log ]; then
+            echo "=== tiup playground log ==="
+            cat /tmp/tiup-playground.log
+          fi
+
+      - name: Dump drive9-server-local logs
+        if: always()
+        run: |
+          if [ -f /tmp/drive9-server-local.log ]; then
+            echo "=== drive9-server-local log ==="
+            cat /tmp/drive9-server-local.log
+          fi
+
+      - name: Stop drive9-server-local
+        if: always()
+        run: |
+          if [ -f /tmp/drive9-server-local.pid ]; then
+            kill "$(cat /tmp/drive9-server-local.pid)" || true
+          fi
+
+      - name: Stop TiDB playground
+        if: always()
+        run: |
+          if [ -f /tmp/tiup-playground.pid ]; then
+            kill "$(cat /tmp/tiup-playground.pid)" || true
+          fi
+
+      - name: Enforce smoke results
+        if: always()
+        run: |
+          failed=0
+
+          check_required() {
+            local name="$1"
+            local outcome="$2"
+            if [ "$outcome" != "success" ]; then
+              echo "$name did not succeed (outcome: $outcome)"
+              failed=1
+            fi
+          }
+
+          check_required "API smoke" "${{ steps.api-smoke.outcome }}"
+          check_required "Existing-key smoke" "${{ steps.existing-key-smoke.outcome }}"
+          check_required "CLI smoke" "${{ steps.cli-smoke.outcome }}"
+          check_required "FUSE smoke" "${{ steps.fuse-smoke.outcome }}"
+
+          exit "$failed"

--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -77,30 +77,29 @@ jobs:
           export PATH="$HOME/.tiup/bin:$PATH"
           tiup telemetry disable || true
           tiup install playground
-          tiup install tidb:${TIDB_VERSION} pd:${TIDB_VERSION} tikv:${TIDB_VERSION}
+          tiup install "tidb:${TIDB_VERSION}" "pd:${TIDB_VERSION}" "tikv:${TIDB_VERSION}"
           tiup --version
 
       - name: Start TiDB playground
         run: |
           export PATH="$HOME/.tiup/bin:$PATH"
-          nohup tiup playground ${TIDB_VERSION} --tiflash 0 --without-monitor > /tmp/tiup-playground.log 2>&1 &
+          nohup tiup playground "${TIDB_VERSION}" --tiflash 0 --without-monitor > /tmp/tiup-playground.log 2>&1 &
           echo $! > /tmp/tiup-playground.pid
 
-      - name: Wait for TiDB readiness
+      - name: Wait for TiDB readiness and create local database
         run: |
           for _ in {1..60}; do
-            if curl -sf http://127.0.0.1:10080/status > /tmp/tidb-status.json; then
+            if curl -sf http://127.0.0.1:10080/status > /tmp/tidb-status.json \
+              && mysql --protocol=tcp -h 127.0.0.1 -P 4000 -u root \
+                -e "CREATE DATABASE IF NOT EXISTS drive9_local;" > /tmp/tidb-sql-ready.log 2>&1; then
               cat /tmp/tidb-status.json
               exit 0
             fi
             sleep 5
           done
           echo "TiDB playground did not become ready in time" >&2
+          cat /tmp/tidb-sql-ready.log >&2 || true
           exit 1
-
-      - name: Create drive9 local database
-        run: |
-          mysql --protocol=tcp -h 127.0.0.1 -P 4000 -u root -e "CREATE DATABASE IF NOT EXISTS drive9_local;"
 
       - name: Start drive9-server-local
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,9 @@ Go version: 1.25.1 (see `go.mod`)
 ## Build commands
 
 ```bash
-make build           # build server + CLI → bin/drive9-server, bin/drive9
-make build-server    # server only
-make build-cli       # CLI only (supports VERSION= for ldflags)
+make build              # build server + CLI → bin/drive9-server, bin/drive9
+make build-server       # server only
+make build-cli          # CLI only (supports VERSION= for ldflags)
 make build-cli-release  # cross-compile for linux/amd64|arm64, darwin/amd64|arm64
 ```
 
@@ -35,10 +35,12 @@ All binaries are built with `CGO_ENABLED=0`.
 ## Test commands
 
 ```bash
-make test                          # go test -v ./... (all packages)
-go test -v ./pkg/datastore/...     # single package
-go test -v -run TestInsertAndGetNode ./pkg/datastore/   # single test
-go test -v ./...                   # full suite
+# full suite
+make test
+# single package
+make test TEST_PKGS='./pkg/datastore/...'
+# single test
+make test TEST_RUN='TestInsertAndGetNode' TEST_PKGS='./pkg/datastore/...'
 ```
 
 MySQL-backed tests require a container runtime or an explicit DSN:
@@ -54,7 +56,11 @@ testcontainers via `scripts/test-podman.sh`. Otherwise a Docker-compatible runti
 If a direct `go test` run fails with `rootless Docker not found`, retry with `make test`
 so the project can use `scripts/test-podman.sh` to route testcontainers through Podman.
 
-**E2E smoke tests** (not `go test`) live in `e2e/` and target live deployments:
+**E2E smoke tests** (not `go test`) live in `e2e/` and target live deployments.
+Read `e2e/AGENTS.md` first for endpoint selection, `drive9-server-local` workflow,
+environment variables, script coverage, and known expectations.
+
+Common entry points:
 
 ```bash
 DRIVE9_BASE=https://... bash e2e/api-smoke-test.sh
@@ -114,7 +120,7 @@ pkg/
   traceid/              Trace ID helpers
 internal/
   testmysql/            MySQL test helpers (shared across packages)
-e2e/                    Live bash smoke tests (not go test)
+e2e/                    Live bash smoke tests; read e2e/AGENTS.md first
 scripts/                Shell helpers for local dev and test
 docs/                   Design documents
 site/                   Frontend / release assets

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ IMAGE_TAG ?= latest
 IMAGE ?= $(IMAGE_REPO):$(IMAGE_TAG)
 LINT_TIMEOUT ?= 10m
 TEST_P ?=
+TEST_RUN ?=
+TEST_PKGS ?= ./...
 
 BUILDINFO_LDFLAGS = -X github.com/mem9-ai/dat9/pkg/buildinfo.Version=$(if $(VERSION),$(VERSION),dev) \
 	-X github.com/mem9-ai/dat9/pkg/buildinfo.GitHash=$(GIT_HASH) \
@@ -50,16 +52,21 @@ mod:
 	$(GO) mod tidy
 	$(GO) mod download
 
-# Run all tests. MySQL-backed suites reuse DRIVE9_TEST_MYSQL_DSN when provided. When
+# Run tests. MySQL-backed suites reuse DRIVE9_TEST_MYSQL_DSN when provided. When
 # it is unset and podman is available locally, automatically configure the
-# podman-backed testcontainers environment before running go test. Set TEST_P
-# to pass `-p <value>` to `go test`; by default package parallelism is not
-# limited.
+# podman-backed testcontainers environment before running go test.
+# - TEST_P to pass `-p <value>` to `go test`
+# - TEST_RUN to pass `-run <regex>` to `go test`
+# - TEST_PKGS to choose the packages under test (defaults to `./...`).
 test:
 	@set -euo pipefail; \
 	test_p_flag=""; \
+	test_run_flag=""; \
 	if [ -n "$(TEST_P)" ]; then \
 		test_p_flag="-p $(TEST_P)"; \
+	fi; \
+	if [ -n "$(TEST_RUN)" ]; then \
+		test_run_flag="-run $(TEST_RUN)"; \
 	fi; \
 	if [ -z "$${DRIVE9_TEST_MYSQL_DSN:-}" ] && command -v podman >/dev/null 2>&1; then \
 		if podman_env="$$(bash -lc 'source ./scripts/test-podman.sh && env | grep -E "^(DOCKER_HOST|TESTCONTAINERS_RYUK_DISABLED)="')"; then \
@@ -70,7 +77,7 @@ test:
 			echo "make test: Podman testcontainers setup unavailable, falling back to default runtime" >&2; \
 		fi; \
 	fi; \
-	$(GO) test $$test_p_flag -v ./...
+	$(GO) test $$test_p_flag $$test_run_flag -v $(TEST_PKGS)
 
 # Run only failpoint-tagged tests through repository-wide instrumentation.
 # Do not run this concurrently with the normal test target because failpoint-ctl

--- a/README.md
+++ b/README.md
@@ -200,9 +200,12 @@ go build -o bin/drive9-server ./cmd/drive9-server
 
 ```bash
 make test
+make test TEST_RUN='TestInsertAndGetNode' TEST_PKGS='./pkg/datastore/...'
 ```
 
 Uses `DRIVE9_TEST_MYSQL_DSN` if set, otherwise spins up a container via testcontainers.
+Set `TEST_RUN` to pass a `go test -run` regex and `TEST_PKGS` to narrow the target packages
+while still reusing the Podman-aware test setup from `make test`.
 
 ### Failpoint tests
 

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -105,7 +105,14 @@ func main() {
 		if !explicitEmbeddingMode {
 			initMode = schema.TiDBEmbeddingModeAuto
 		}
-		if err := localTiDBSchemaInitializer(localDSN, initMode); err != nil {
+		initOpts := schema.InitTiDBTenantSchemaOptions{}
+		if initMode == schema.TiDBEmbeddingModeApp {
+			// drive9-server-local can bootstrap app-managed schema on TiDB builds
+			// that lack optional FTS/vector index features; shared schema init paths
+			// remain strict.
+			initOpts.AllowUnsupportedOptionalIndexes = true
+		}
+		if err := localTiDBSchemaInitializer(localDSN, initMode, initOpts); err != nil {
 			die(fmt.Errorf("init local tenant schema: %w", err))
 		}
 		logLocalStartupStep(startupCtx, startupStart, stepStart, "init_local_tenant_schema",
@@ -433,7 +440,7 @@ func (c localS3Config) localDir() string {
 var (
 	localTiDBEmbeddingModeDetector = schema.DetectTiDBEmbeddingMode
 	localTiDBSchemaValidator       = schema.EnsureTiDBSchemaForMode
-	localTiDBSchemaInitializer     = schema.InitTiDBTenantSchemaForMode
+	localTiDBSchemaInitializer     = schema.InitTiDBTenantSchemaForModeWithOptions
 )
 
 func detectLocalTiDBEmbeddingMode(db *sql.DB, schemaInitialized bool, requestedMode schema.TiDBEmbeddingMode, explicitMode bool) (schema.TiDBEmbeddingMode, error) {

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -112,7 +112,7 @@ func main() {
 			// remain strict.
 			initOpts.AllowUnsupportedOptionalIndexes = true
 		}
-		if err := localTiDBSchemaInitializer(localDSN, initMode, initOpts); err != nil {
+		if err := localTiDBSchemaInitializer(startupCtx, localDSN, initMode, initOpts); err != nil {
 			die(fmt.Errorf("init local tenant schema: %w", err))
 		}
 		logLocalStartupStep(startupCtx, startupStart, stepStart, "init_local_tenant_schema",
@@ -440,7 +440,7 @@ func (c localS3Config) localDir() string {
 var (
 	localTiDBEmbeddingModeDetector = schema.DetectTiDBEmbeddingMode
 	localTiDBSchemaValidator       = schema.EnsureTiDBSchemaForMode
-	localTiDBSchemaInitializer     = schema.InitTiDBTenantSchemaForModeWithOptions
+	localTiDBSchemaInitializer     = schema.InitTiDBTenantSchemaForModeWithOptionsContext
 )
 
 func detectLocalTiDBEmbeddingMode(db *sql.DB, schemaInitialized bool, requestedMode schema.TiDBEmbeddingMode, explicitMode bool) (schema.TiDBEmbeddingMode, error) {

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -7,57 +7,102 @@ title: e2e - Live end-to-end scripts
 This directory contains live end-to-end tests for deployed drive9-server instances.
 These scripts are integration probes (not unit tests) and call real HTTP endpoints.
 
-## Quick start
+## Run
+
+Use a hosted deployment by default. For local development on this machine, use
+`drive9-server-local` instead.
+
+### Hosted endpoints
+
+#### Deployment endpoints
+
+Current shared dev deployment:
 
 ```bash
-DEPLOY=https://<your-api-gateway-or-server>
+# Dev
+export DRIVE9_BASE="http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com"
 
-# Full smoke (provision -> status poll -> nested dirs -> file ops)
-DRIVE9_BASE=$DEPLOY bash e2e/api-smoke-test.sh
-
-# Existing key regression
-DRIVE9_BASE=$DEPLOY DRIVE9_API_KEY=drive9_xxx bash e2e/api-smoke-test-existing-key.sh
-
-# CLI smoke (provision + drive9 fs workflows + large file cp)
-DRIVE9_BASE=$DEPLOY bash e2e/cli-smoke-test.sh
-
-# FUSE smoke (mount + bidirectional filesystem checks)
-DRIVE9_BASE=$DEPLOY bash e2e/fuse-smoke-test.sh
-
-# Run all smoke scripts in sequence
-DRIVE9_BASE=$DEPLOY bash e2e/smoke-all.sh
+# Prod
+export DRIVE9_BASE="https://api.drive9.ai"
 ```
 
-## `drive9-server-local` workflow
+Use the dev value unless the environment owner announces a new endpoint.
+
+#### Run smoke scripts
+
+```bash
+# Full smoke (provision -> status poll -> nested dirs -> file ops)
+bash e2e/api-smoke-test.sh
+
+# Existing key regression
+DRIVE9_API_KEY=drive9_xxx bash e2e/api-smoke-test-existing-key.sh
+
+# CLI smoke (provision + drive9 fs workflows + large file cp)
+bash e2e/cli-smoke-test.sh
+
+# FUSE smoke (mount + bidirectional filesystem checks)
+bash e2e/fuse-smoke-test.sh
+
+# Run all smoke scripts in sequence
+bash e2e/smoke-all.sh
+```
+
+### Local via `drive9-server-local`
 
 When the task is specifically about local validation on this machine, prefer
 `drive9-server-local` over hosted endpoints.
 
-### Server startup
+`scripts/drive9-server-local-env.sh` is the source of truth for local default
+environment values.
+
+### Prerequisites
+
+- Choose one of the following local validation setups before startup:
+- Use TiDB Starter with auto-embedding enabled. Set `DRIVE9_LOCAL_DSN` to the
+  Starter instance DSN. This is the easier path for semantic smoke coverage
+  because it does not require a local Ollama deployment.
+- Use a local TiDB/MySQL instance together with a local embedding service.
+  Create the database referenced by `DRIVE9_LOCAL_DSN` before startup, then
+  make sure the embedding endpoint is available. The default env script expects
+  Ollama at `http://127.0.0.1:11434` with model `bge-m3`.
+
+### Terminal 1: start `drive9-server-local`
 
 ```bash
-export DRIVE9_LOCAL_DIR=/path/to/dir-containing-run-drive9-server-local.sh
-cd "$DRIVE9_LOCAL_DIR"
-./run-drive9-server-local.sh 2>&1 | tee local-server.log
-curl http://127.0.0.1:9009/healthz
+export DRIVE9_REPO_ROOT=/path/to/drive9
+cd "$DRIVE9_REPO_ROOT"
+
+export DRIVE9_LOCAL_DSN='root@tcp(127.0.0.1:4000)/drive9_local?parseTime=true'   # optional if you use the default local DSN; replace with your TiDB Starter DSN when applicable
+export DRIVE9_LOCAL_INIT_SCHEMA=true   # only for a fresh/disposable database
+make run-server-local
+```
+
+`make run-server-local` already sources `scripts/drive9-server-local-env.sh` and
+stays attached to the foreground. Export any overrides before invoking it, then
+run the smoke scripts from a second terminal after the server is healthy.
+
+### Terminal 2: verify health and run E2E
+
+```bash
+export DRIVE9_REPO_ROOT=/path/to/drive9
+cd "$DRIVE9_REPO_ROOT"
+
+export DRIVE9_BASE=http://127.0.0.1:9009
+
+curl "$DRIVE9_BASE/healthz"
+
+bash e2e/api-smoke-test.sh
+DRIVE9_API_KEY='local-dev-key' bash e2e/api-smoke-test-existing-key.sh
+bash e2e/cli-smoke-test.sh
+bash e2e/fuse-smoke-test.sh
+bash e2e/smoke-all.sh
 ```
 
 Use `http://127.0.0.1:9009` as `DRIVE9_BASE` once `healthz` returns
 `{"status":"ok"}`.
 
-### E2E execution against `drive9-server-local`
-
-```bash
-export DRIVE9_REPO_ROOT=/path/to/drive9
-cd "$DRIVE9_REPO_ROOT"
-export DRIVE9_BASE=http://127.0.0.1:9009
-
-bash e2e/api-smoke-test.sh
-DRIVE9_API_KEY="${DRIVE9_LOCAL_API_KEY:-local-dev-key}" bash e2e/api-smoke-test-existing-key.sh
-bash e2e/cli-smoke-test.sh
-bash e2e/fuse-smoke-test.sh
-bash e2e/smoke-all.sh
-```
+If you overrode `DRIVE9_LOCAL_API_KEY` before starting `drive9-server-local`,
+use the same value as `DRIVE9_API_KEY` here.
 
 ### Local-server-specific expectations
 
@@ -66,32 +111,11 @@ bash e2e/smoke-all.sh
   not overridden.
 - `api-smoke-test-existing-key.sh` should use that built-in key instead of
   provisioning a new tenant.
-- `api-smoke-test.sh` and `cli-smoke-test.sh` have been validated end-to-end
-  against `drive9-server-local`.
-- `fuse-smoke-test.sh` still has a known failure on directory rename via the
-  mount path; do not mislabel that as a new regression unless the failure shape
-  changes.
 - Upload-limit boundary failures (`507` on the `limit-1g.bin` initiate step)
   can be caused by stale multipart reservations in the tenant `uploads` table,
   not by current file-tree contents.
 - If quota looks polluted, inspect and clear `INITIATED` / `UPLOADING` rows for
   the tenant before rerunning the smoke suite.
-
-## Dev endpoint
-
-Current shared dev deployment:
-
-```bash
-export DRIVE9_BASE="http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com"
-```
-
-Use this value unless the environment owner announces a new endpoint.
-
-## Prod endpoint
-
-```bash
-export DRIVE9_BASE="https://api.drive9.ai"
-```
 
 ## Coverage
 

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -199,6 +199,7 @@ Notes:
 | `REQUEST_RETRY_SLEEP_S` | `2` | `api-smoke-test.sh` |
 | `RUN_UPLOAD_LIMIT_BOUNDARY` | `1` | `api-smoke-test.sh` |
 | `UPLOAD_LIMIT_BYTES` | `10737418240` | `api-smoke-test.sh` |
+| `RUN_SEMANTIC_CHECKS` | `1` | `api-smoke-test.sh` |
 | `SEMANTIC_TIMEOUT_S` | `90` | `api-smoke-test.sh` |
 | `SEMANTIC_INTERVAL_S` | `3` | `api-smoke-test.sh` |
 | `CLI_LARGE_FILE_MB` | `100` | `cli-smoke-test.sh` |
@@ -207,6 +208,7 @@ Notes:
 | `CLI_RETRY_SLEEP_S` | `2` | `cli-smoke-test.sh` |
 | `RUN_CLI_UPLOAD_LIMIT_BOUNDARY` | `1` | `cli-smoke-test.sh` |
 | `CLI_UPLOAD_LIMIT_BYTES` | `10737418240` | `cli-smoke-test.sh` |
+| `RUN_CLI_SEMANTIC_CHECKS` | `1` | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_TIMEOUT_S` | `90` | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_INTERVAL_S` | `3` | `cli-smoke-test.sh` |
 | `CLI_SOURCE` | `build` (`build` or `official`) | `cli-smoke-test.sh`, `fuse-smoke-test.sh` |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -156,7 +156,9 @@ CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
 - Tenant readiness is checked through `GET /v1/status`.
 - File operations use `/v1/fs/*` and include nested directory coverage.
 - Semantic recall polling knobs for API smoke are `SEMANTIC_TIMEOUT_S` and `SEMANTIC_INTERVAL_S`.
+- Set `RUN_SEMANTIC_CHECKS=0` to skip semantic text recall and image-associated recall in `api-smoke-test.sh`.
 - Semantic recall polling knobs for CLI smoke are `CLI_SEMANTIC_TIMEOUT_S` and `CLI_SEMANTIC_INTERVAL_S`.
+- Set `RUN_CLI_SEMANTIC_CHECKS=0` to skip semantic text recall and image-associated recall in `cli-smoke-test.sh`.
 - Image fixture path is `DRIVE9_IMAGE_FIXTURE_PATH` (default `e2e/fixtures/cat03.jpg`) and uses the repo-local fixture.
 - Large-file scenario is enabled by default (`RUN_LARGE_FILE=1`) and runs a multipart upload using checksum-bound presigned parts.
 - You can tune size with `LARGE_FILE_MB` (default `100`).

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,78 +9,6 @@ including local single-tenant validation via `drive9-server-local`.
 - `jq` installed
 - Bash 4+
 
-## Run Against `drive9-server-local`
-
-The local smoke flow that is currently exercised on this machine uses
-`drive9-server-local`, not the old hosted/local-server path.
-
-1. Start `drive9-server-local`.
-
-```bash
-export DRIVE9_LOCAL_DIR=/path/to/dir-containing-run-drive9-server-local.sh
-cd "$DRIVE9_LOCAL_DIR"
-./run-drive9-server-local.sh 2>&1 | tee local-server.log
-```
-
-2. Confirm the server is healthy.
-
-```bash
-curl http://127.0.0.1:9009/healthz
-```
-
-Expected response:
-
-```json
-{"status":"ok"}
-```
-
-3. Run the e2e smoke scripts against the local endpoint.
-
-```bash
-export DRIVE9_REPO_ROOT=/path/to/drive9
-cd "$DRIVE9_REPO_ROOT"
-
-export DRIVE9_BASE=http://127.0.0.1:9009
-
-# Full API smoke on a fresh locally provisioned tenant.
-bash e2e/api-smoke-test.sh
-
-# Existing-key regression against the built-in local tenant.
-DRIVE9_API_KEY="${DRIVE9_LOCAL_API_KEY:-local-dev-key}" bash e2e/api-smoke-test-existing-key.sh
-
-# CLI smoke using the repo build.
-bash e2e/cli-smoke-test.sh
-
-# FUSE smoke using the repo build.
-bash e2e/fuse-smoke-test.sh
-
-# Run API + CLI + FUSE in sequence.
-bash e2e/smoke-all.sh
-```
-
-4. Optional: use an already-built or official CLI instead of rebuilding.
-
-```bash
-CLI_SOURCE=official bash e2e/cli-smoke-test.sh
-CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
-```
-
-### `drive9-server-local` notes
-
-- `drive9-server-local` serves a single local tenant with API key
-  `${DRIVE9_LOCAL_API_KEY:-local-dev-key}` by default.
-- `api-smoke-test.sh`, `cli-smoke-test.sh`, and `fuse-smoke-test.sh` still
-  provision fresh timestamped test paths as part of the smoke flow.
-- `api-smoke-test-existing-key.sh` is the script that should be pointed at the
-  built-in local tenant key.
-- If the final upload-limit boundary check unexpectedly returns `507` instead of
-  `202`, inspect tenant `uploads` records before blaming the test itself.
-  Stale `INITIATED` / `UPLOADING` multipart rows can consume reserved quota even
-  when the file tree looks empty.
-- On this branch, `api` and `cli` smoke are passing against
-  `drive9-server-local`. `fuse` still has a known directory-rename failure path
-  tracked separately, so `smoke-all.sh` can still end in `PASS=2 FAIL=1`.
-
 ## Scripts
 
 | Script | What it validates |
@@ -93,39 +21,134 @@ CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
 
 ## Run
 
-```bash
-DEPLOY=https://<api-endpoint>
+Use a hosted deployment by default. For local development on this machine, use
+`drive9-server-local` instead.
 
-DRIVE9_BASE=$DEPLOY bash e2e/api-smoke-test.sh
+### Hosted endpoints
 
-DRIVE9_BASE=$DEPLOY DRIVE9_API_KEY=drive9_xxx bash e2e/api-smoke-test-existing-key.sh
-
-DRIVE9_BASE=$DEPLOY bash e2e/cli-smoke-test.sh
-
-# Use official released drive9 CLI instead of local build
-DRIVE9_BASE=$DEPLOY CLI_SOURCE=official bash e2e/cli-smoke-test.sh
-
-DRIVE9_BASE=$DEPLOY bash e2e/fuse-smoke-test.sh
-
-# Use official released drive9 CLI for FUSE smoke
-DRIVE9_BASE=$DEPLOY CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
-
-DRIVE9_BASE=$DEPLOY bash e2e/smoke-all.sh
-```
-
-## Deployment Endpoints
-
-### Dev
+#### Deployment endpoints
 
 ```bash
+# Dev
 export DRIVE9_BASE="http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com"
-```
 
-### Prod
-
-```bash
+# Prod
 export DRIVE9_BASE="https://api.drive9.ai"
 ```
+
+#### Run smoke scripts
+
+```bash
+bash e2e/api-smoke-test.sh
+
+DRIVE9_API_KEY=drive9_xxx bash e2e/api-smoke-test-existing-key.sh
+
+bash e2e/cli-smoke-test.sh
+
+# Use official released drive9 CLI instead of local build
+CLI_SOURCE=official bash e2e/cli-smoke-test.sh
+
+bash e2e/fuse-smoke-test.sh
+
+# Use official released drive9 CLI for FUSE smoke
+CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
+
+bash e2e/smoke-all.sh
+```
+
+### Local via `drive9-server-local`
+
+The local smoke flow that is currently exercised on this machine uses
+`drive9-server-local`, not the old hosted/local-server path.
+
+`scripts/drive9-server-local-env.sh` is the source of truth for local default
+environment values.
+
+1. Confirm local prerequisites.
+
+- Create the local database referenced by `DRIVE9_LOCAL_DSN` before startup.
+- For full smoke coverage, ensure the embedding endpoint is available. The
+  default env script expects Ollama at `http://127.0.0.1:11434` with model
+  `bge-m3`.
+
+2. In terminal 1, start `drive9-server-local` from the repository root.
+
+```bash
+export DRIVE9_REPO_ROOT=/path/to/drive9
+cd "$DRIVE9_REPO_ROOT"
+
+export DRIVE9_LOCAL_DSN='root@tcp(127.0.0.1:4000)/drive9_local?parseTime=true'   # optional if you use the default local DSN; replace with your TiDB Starter DSN when applicable
+export DRIVE9_LOCAL_INIT_SCHEMA=true   # only for a fresh/disposable database
+make run-server-local
+```
+
+`make run-server-local` already sources `scripts/drive9-server-local-env.sh` and
+stays attached to the foreground. Export any overrides before invoking it,
+leave it running, and use a second terminal for the smoke scripts.
+
+3. In terminal 2, confirm the server is healthy.
+
+```bash
+export DRIVE9_REPO_ROOT=/path/to/drive9
+cd "$DRIVE9_REPO_ROOT"
+
+export DRIVE9_BASE=http://127.0.0.1:9009
+
+curl "$DRIVE9_BASE/healthz"
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+4. Run the e2e smoke scripts against the local endpoint.
+
+```bash
+export DRIVE9_REPO_ROOT=/path/to/drive9
+cd "$DRIVE9_REPO_ROOT"
+
+export DRIVE9_BASE=http://127.0.0.1:9009
+
+# Full API smoke on a fresh locally provisioned tenant.
+bash e2e/api-smoke-test.sh
+
+# Existing-key regression against the built-in local tenant.
+DRIVE9_API_KEY='local-dev-key' bash e2e/api-smoke-test-existing-key.sh
+
+# CLI smoke using the repo build.
+bash e2e/cli-smoke-test.sh
+
+# FUSE smoke using the repo build.
+bash e2e/fuse-smoke-test.sh
+
+# Run API + CLI + FUSE in sequence.
+bash e2e/smoke-all.sh
+```
+
+If you overrode `DRIVE9_LOCAL_API_KEY` before starting `drive9-server-local`,
+use the same value as `DRIVE9_API_KEY` here.
+
+5. Optional: use an already-built or official CLI instead of rebuilding.
+
+```bash
+CLI_SOURCE=official bash e2e/cli-smoke-test.sh
+CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
+```
+
+#### `drive9-server-local` notes
+
+- `drive9-server-local` serves a single local tenant with API key
+  `${DRIVE9_LOCAL_API_KEY:-local-dev-key}` by default.
+- `api-smoke-test.sh`, `cli-smoke-test.sh`, and `fuse-smoke-test.sh` still
+  provision fresh timestamped test paths as part of the smoke flow.
+- `api-smoke-test-existing-key.sh` is the script that should be pointed at the
+  built-in local tenant key.
+- If the final upload-limit boundary check unexpectedly returns `507` instead of
+  `202`, inspect tenant `uploads` records before blaming the test itself.
+  Stale `INITIATED` / `UPLOADING` multipart rows can consume reserved quota even
+  when the file tree looks empty.
 
 ## Notes
 

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -34,9 +34,11 @@ RUN_UPLOAD_LIMIT_BOUNDARY="${RUN_UPLOAD_LIMIT_BOUNDARY:-1}"
 UPLOAD_LIMIT_BYTES="${UPLOAD_LIMIT_BYTES:-10737418240}"
 SEMANTIC_TIMEOUT_S="${SEMANTIC_TIMEOUT_S:-90}"
 SEMANTIC_INTERVAL_S="${SEMANTIC_INTERVAL_S:-3}"
+RUN_SEMANTIC_CHECKS="${RUN_SEMANTIC_CHECKS:-1}"
 
 PASS=0
 FAIL=0
+SKIP=0
 TOTAL=0
 
 RED='\033[0;31m'
@@ -48,6 +50,12 @@ RESET='\033[0m'
 step() { echo -e "\n${YELLOW}[$1]${RESET} $2"; }
 ok() { echo -e "${GREEN}  PASS${RESET} $*"; }
 fail() { echo -e "${RED}  FAIL${RESET} $*"; }
+skip_check() {
+  local desc="$1"
+  TOTAL=$((TOTAL+1))
+  SKIP=$((SKIP+1))
+  echo -e "${YELLOW}  SKIP${RESET} $desc"
+}
 info() { echo -e "${CYAN}  ->${RESET} $*"; }
 
 check_eq() {
@@ -453,45 +461,64 @@ fi
 check_eq "find by name returns jpg file" "$find_has_png" "true"
 
 step "9" "Semantic text recall checks"
-resp=$(curl_body_code POST "$BASE/v1/fs/${ROOT_DIR}/notes?mkdir" "$API_KEY")
-code=$(http_code "$resp")
-check_eq "POST /v1/fs/${ROOT_DIR}/notes?mkdir returns 200" "$code" "200"
+if [ "$RUN_SEMANTIC_CHECKS" = "1" ]; then
+  resp=$(curl_body_code POST "$BASE/v1/fs/${ROOT_DIR}/notes?mkdir" "$API_KEY")
+  code=$(http_code "$resp")
+  check_eq "POST /v1/fs/${ROOT_DIR}/notes?mkdir returns 200" "$code" "200"
 
-resp=$(curl_body_code PUT "$BASE/v1/fs/$SEM_TEXT_TARGET" "$API_KEY" "A cat is resting on a sofa near a window.")
-code=$(http_code "$resp")
-check_eq "PUT semantic target text returns 200" "$code" "200"
+  resp=$(curl_body_code PUT "$BASE/v1/fs/$SEM_TEXT_TARGET" "$API_KEY" "A cat is resting on a sofa near a window.")
+  code=$(http_code "$resp")
+  check_eq "PUT semantic target text returns 200" "$code" "200"
 
-resp=$(curl_body_code PUT "$BASE/v1/fs/$SEM_TEXT_OTHER" "$API_KEY" "A dog is running in a field under bright sun.")
-code=$(http_code "$resp")
-check_eq "PUT semantic distractor text returns 200" "$code" "200"
+  resp=$(curl_body_code PUT "$BASE/v1/fs/$SEM_TEXT_OTHER" "$API_KEY" "A dog is running in a field under bright sun.")
+  code=$(http_code "$resp")
+  check_eq "PUT semantic distractor text returns 200" "$code" "200"
 
-resp=$(curl_body_code GET "$BASE/v1/fs/$ROOT_DIR?grep=feline%20sofa&limit=20" "$API_KEY")
-code=$(http_code "$resp")
-body=$(json_body "$resp")
-check_eq "GET semantic grep returns 200" "$code" "200"
-wait_grep_contains_path "semantic grep includes cat-story target" "feline%20sofa" "${ROOT_DIR}/notes" "$SEM_TEXT_TARGET" "cat-story"
-wait_grep_contains_path "semantic grep includes dog-story target" "canine%20field" "${ROOT_DIR}/notes" "$SEM_TEXT_OTHER" "dog-story"
+  resp=$(curl_body_code GET "$BASE/v1/fs/$ROOT_DIR?grep=feline%20sofa&limit=20" "$API_KEY")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  check_eq "GET semantic grep returns 200" "$code" "200"
+  wait_grep_contains_path "semantic grep includes cat-story target" "feline%20sofa" "${ROOT_DIR}/notes" "$SEM_TEXT_TARGET" "cat-story"
+  wait_grep_contains_path "semantic grep includes dog-story target" "canine%20field" "${ROOT_DIR}/notes" "$SEM_TEXT_OTHER" "dog-story"
+else
+  info "semantic text recall checks skipped (RUN_SEMANTIC_CHECKS=$RUN_SEMANTIC_CHECKS)"
+  skip_check "POST /v1/fs/${ROOT_DIR}/notes?mkdir returns 200"
+  skip_check "PUT semantic target text returns 200"
+  skip_check "PUT semantic distractor text returns 200"
+  skip_check "GET semantic grep returns 200"
+  skip_check "semantic grep includes cat-story target"
+  skip_check "semantic grep includes dog-story target"
+fi
 
 step "10" "Image-associated recall checks"
-resp=$(curl_body_code PUT "$BASE/v1/fs/$IMAGE_CAPTION_REMOTE" "$API_KEY" "This image shows a cat face icon.")
-code=$(http_code "$resp")
-check_eq "PUT image caption text returns 200" "$code" "200"
+if [ "$RUN_SEMANTIC_CHECKS" = "1" ]; then
+  resp=$(curl_body_code PUT "$BASE/v1/fs/$IMAGE_CAPTION_REMOTE" "$API_KEY" "This image shows a cat face icon.")
+  code=$(http_code "$resp")
+  check_eq "PUT image caption text returns 200" "$code" "200"
 
-resp=$(curl_body_code GET "$BASE/v1/fs/$ROOT_DIR?grep=feline%20face%20icon&limit=20" "$API_KEY")
-code=$(http_code "$resp")
-body=$(json_body "$resp")
-check_eq "GET image-associated grep returns 200" "$code" "200"
-wait_grep_contains_path "image-associated recall includes caption" "feline%20face%20icon" "${ROOT_DIR}/assets" "$IMAGE_CAPTION_REMOTE" "caption"
+  resp=$(curl_body_code GET "$BASE/v1/fs/$ROOT_DIR?grep=feline%20face%20icon&limit=20" "$API_KEY")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  check_eq "GET image-associated grep returns 200" "$code" "200"
+  wait_grep_contains_path "image-associated recall includes caption" "feline%20face%20icon" "${ROOT_DIR}/assets" "$IMAGE_CAPTION_REMOTE" "caption"
 
-resp=$(curl_body_code GET "$BASE/v1/fs/$ROOT_DIR?find=&name=*.jpg" "$API_KEY")
-code=$(http_code "$resp")
-body=$(json_body "$resp")
-check_eq "GET image find returns 200" "$code" "200"
-image_file_present=$(printf '%s' "$body" | jq -r --arg p "$IMAGE_REMOTE" 'any(.[]; .path==$p)')
-if [ "$image_file_present" != "true" ]; then
-  image_file_present=$(printf '%s' "$body" | jq -r 'any(.[]; (.path // "") | endswith(".jpg"))')
+  resp=$(curl_body_code GET "$BASE/v1/fs/$ROOT_DIR?find=&name=*.jpg" "$API_KEY")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  check_eq "GET image find returns 200" "$code" "200"
+  image_file_present=$(printf '%s' "$body" | jq -r --arg p "$IMAGE_REMOTE" 'any(.[]; .path==$p)')
+  if [ "$image_file_present" != "true" ]; then
+    image_file_present=$(printf '%s' "$body" | jq -r 'any(.[]; (.path // "") | endswith(".jpg"))')
+  fi
+  check_eq "image file remains discoverable" "$image_file_present" "true"
+else
+  info "image-associated recall checks skipped (RUN_SEMANTIC_CHECKS=$RUN_SEMANTIC_CHECKS)"
+  skip_check "PUT image caption text returns 200"
+  skip_check "GET image-associated grep returns 200"
+  skip_check "image-associated recall includes caption"
+  skip_check "GET image find returns 200"
+  skip_check "image file remains discoverable"
 fi
-check_eq "image file remains discoverable" "$image_file_present" "true"
 
 step "11" "SQL endpoint sanity"
 sql_req='{"query":"SELECT 1 AS n"}'
@@ -789,11 +816,15 @@ rm -f "$IMAGE_LOCAL"
 
 echo
 echo "========================================================"
-echo "  RESULTS: $PASS / $TOTAL passed, $FAIL failed"
+echo "  RESULTS: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total"
 echo "  Base URL : $BASE"
 echo "  Finished : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 if [ "$FAIL" -eq 0 ]; then
-  echo -e "  ${GREEN}All tests passed.${RESET}"
+  if [ "$SKIP" -eq 0 ]; then
+    echo -e "  ${GREEN}All tests passed.${RESET}"
+  else
+    echo -e "  ${GREEN}All executed tests passed.${RESET}"
+  fi
 else
   echo -e "  ${RED}$FAIL test(s) failed.${RESET}"
 fi

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -19,9 +19,11 @@ RUN_CLI_UPLOAD_LIMIT_BOUNDARY="${RUN_CLI_UPLOAD_LIMIT_BOUNDARY:-1}"
 CLI_UPLOAD_LIMIT_BYTES="${CLI_UPLOAD_LIMIT_BYTES:-10737418240}"
 CLI_SEMANTIC_TIMEOUT_S="${CLI_SEMANTIC_TIMEOUT_S:-90}"
 CLI_SEMANTIC_INTERVAL_S="${CLI_SEMANTIC_INTERVAL_S:-3}"
+RUN_CLI_SEMANTIC_CHECKS="${RUN_CLI_SEMANTIC_CHECKS:-1}"
 
 PASS=0
 FAIL=0
+SKIP=0
 TOTAL=0
 
 check_eq() {
@@ -47,6 +49,13 @@ check_cmd() {
     echo "FAIL $desc"
     FAIL=$((FAIL+1))
   fi
+}
+
+skip_check() {
+  local desc="$1"
+  TOTAL=$((TOTAL+1))
+  SKIP=$((SKIP+1))
+  echo "SKIP $desc"
 }
 
 detect_release_target() {
@@ -249,6 +258,7 @@ LARGE_LOCAL="/tmp/drive9-cli-large-${TS}.bin"
 LARGE_REMOTE="/cli-${TS}-large-${CLI_LARGE_FILE_MB}m.bin"
 LARGE_DOWNLOADED="/tmp/drive9-cli-large-${TS}.download.bin"
 LARGE_BYTES=$((CLI_LARGE_FILE_MB * 1024 * 1024))
+CLI_IMAGE_UPLOADED=0
 
 echo "[4] small file ops via cli"
 printf "cli-smoke-%s" "$TS" > "$SMALL_LOCAL"
@@ -337,32 +347,46 @@ PY
 check_eq "cli find by name returns txt files" "$find_has_txt" "true"
 
 echo "[6.1] cli semantic text recall checks"
-printf "A cat is resting on a sofa near a window." > "/tmp/drive9-cli-sem-target-${TS}.txt"
-printf "A dog is running in a field under bright sun." > "/tmp/drive9-cli-sem-other-${TS}.txt"
-drive9_retry fs cp "/tmp/drive9-cli-sem-target-${TS}.txt" ":$SEM_TEXT_TARGET" >/dev/null
-drive9_retry fs cp "/tmp/drive9-cli-sem-other-${TS}.txt" ":$SEM_TEXT_OTHER" >/dev/null
+if [ "$RUN_CLI_SEMANTIC_CHECKS" = "1" ]; then
+  printf "A cat is resting on a sofa near a window." > "/tmp/drive9-cli-sem-target-${TS}.txt"
+  printf "A dog is running in a field under bright sun." > "/tmp/drive9-cli-sem-other-${TS}.txt"
+  drive9_retry fs cp "/tmp/drive9-cli-sem-target-${TS}.txt" ":$SEM_TEXT_TARGET" >/dev/null
+  drive9_retry fs cp "/tmp/drive9-cli-sem-other-${TS}.txt" ":$SEM_TEXT_OTHER" >/dev/null
 
-wait_cli_grep_target "cli semantic grep includes cat-story target" "feline sofa" "$SEM_TEXT_TARGET"
-wait_cli_grep_target "cli semantic grep includes dog-story target" "canine field" "$SEM_TEXT_OTHER"
+  wait_cli_grep_target "cli semantic grep includes cat-story target" "feline sofa" "$SEM_TEXT_TARGET"
+  wait_cli_grep_target "cli semantic grep includes dog-story target" "canine field" "$SEM_TEXT_OTHER"
+else
+  echo "semantic text recall checks skipped (RUN_CLI_SEMANTIC_CHECKS=$RUN_CLI_SEMANTIC_CHECKS)"
+  skip_check "cli semantic grep includes cat-story target"
+  skip_check "cli semantic grep includes dog-story target"
+fi
 
 echo "[6.2] cli image-associated recall checks"
-cp "$DRIVE9_IMAGE_FIXTURE_PATH" "$IMAGE_LOCAL"
-check_cmd "local cli jpg fixture exists" test -s "$IMAGE_LOCAL"
-drive9_retry fs cp "$IMAGE_LOCAL" ":$IMAGE_REMOTE" >/dev/null
-printf "This image shows a cat face icon." > "/tmp/drive9-cli-image-caption-${TS}.txt"
-drive9_retry fs cp "/tmp/drive9-cli-image-caption-${TS}.txt" ":$IMAGE_CAPTION_REMOTE" >/dev/null
+if [ "$RUN_CLI_SEMANTIC_CHECKS" = "1" ]; then
+  cp "$DRIVE9_IMAGE_FIXTURE_PATH" "$IMAGE_LOCAL"
+  check_cmd "local cli jpg fixture exists" test -s "$IMAGE_LOCAL"
+  drive9_retry fs cp "$IMAGE_LOCAL" ":$IMAGE_REMOTE" >/dev/null
+  CLI_IMAGE_UPLOADED=1
+  printf "This image shows a cat face icon." > "/tmp/drive9-cli-image-caption-${TS}.txt"
+  drive9_retry fs cp "/tmp/drive9-cli-image-caption-${TS}.txt" ":$IMAGE_CAPTION_REMOTE" >/dev/null
 
-wait_cli_grep_target "cli image-associated grep includes caption" "feline face icon" "$IMAGE_CAPTION_REMOTE"
+  wait_cli_grep_target "cli image-associated grep includes caption" "feline face icon" "$IMAGE_CAPTION_REMOTE"
 
-find_png_out="$(drive9_retry fs find / -name "*.jpg")"
-find_has_png=$(python3 - "$find_png_out" "$IMAGE_REMOTE" <<'PY'
+  find_png_out="$(drive9_retry fs find / -name "*.jpg")"
+  find_has_png=$(python3 - "$find_png_out" "$IMAGE_REMOTE" <<'PY'
 import sys
 lines=[ln.strip() for ln in sys.argv[1].splitlines() if ln.strip()]
 target=sys.argv[2]
 print("true" if any(line == target or line.endswith('.jpg') for line in lines) else "false")
 PY
 )
-check_eq "cli find by name returns jpg files" "$find_has_png" "true"
+  check_eq "cli find by name returns jpg files" "$find_has_png" "true"
+else
+  echo "image-associated recall checks skipped (RUN_CLI_SEMANTIC_CHECKS=$RUN_CLI_SEMANTIC_CHECKS)"
+  skip_check "local cli jpg fixture exists"
+  skip_check "cli image-associated grep includes caption"
+  skip_check "cli find by name returns jpg files"
+fi
 
 echo "[7] large multipart upload via cli cp"
 dd if=/dev/zero of="$LARGE_LOCAL" bs=1M count="$CLI_LARGE_FILE_MB" status=none
@@ -388,7 +412,9 @@ check_eq "downloaded large file sha256 matches" "$sum_dst" "$sum_src"
 
 echo "[8] cleanup via cli"
 drive9_retry fs rm "$SMALL_RENAMED" >/dev/null
-drive9_retry fs rm "$IMAGE_REMOTE" >/dev/null
+if [ "$CLI_IMAGE_UPLOADED" = "1" ]; then
+  drive9_retry fs rm "$IMAGE_REMOTE" >/dev/null
+fi
 drive9_retry fs rm "$LARGE_REMOTE" >/dev/null
 for i in $(seq 1 "$CLI_BATCH_SMALL_FILE_COUNT"); do
   drive9_retry fs rm "$BATCH_REMOTE_DIR/file-${i}.txt" >/dev/null
@@ -531,5 +557,5 @@ rm -f "$pfile" "$CLI_BIN" "$SMALL_LOCAL" "$IMAGE_LOCAL" "$LARGE_LOCAL" "$LARGE_D
 rm -f "/tmp/drive9-cli-sem-target-${TS}.txt" "/tmp/drive9-cli-sem-other-${TS}.txt" "/tmp/drive9-cli-image-caption-${TS}.txt"
 rm -rf "$BATCH_LOCAL_DIR"
 
-echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"
+echo "RESULT: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total"
 exit "$FAIL"

--- a/pkg/tenant/schema/common.go
+++ b/pkg/tenant/schema/common.go
@@ -3,9 +3,11 @@ package schema
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"go.uber.org/zap"
 )
@@ -53,7 +55,7 @@ func ExecSchemaStatements(db *sql.DB, stmts []string) error {
 // feature-specific failures that can happen on TiDB deployments without FTS,
 // vector indexing, or columnar replica support. It returns the number of
 // statements skipped for those unsupported features.
-func ExecOptionalSchemaStatements(db *sql.DB, stmts []string) (int, error) {
+func ExecOptionalSchemaStatements(ctx context.Context, db *sql.DB, stmts []string) (int, error) {
 	skipped := 0
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
@@ -62,7 +64,7 @@ func ExecOptionalSchemaStatements(db *sql.DB, stmts []string) (int, error) {
 			}
 			if isIgnorableOptionalSchemaError(err) {
 				skipped++
-				logger.Warn(context.Background(), "optional_schema_statement_skipped",
+				logger.Warn(ctx, "optional_schema_statement_skipped",
 					zap.String("statement", schemaStatementSnippet(stmt)),
 					zap.Error(err))
 				continue
@@ -92,12 +94,25 @@ func isIgnorableOptionalSchemaError(err error) bool {
 	if err == nil {
 		return false
 	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && !isIgnorableOptionalMySQLErrorCode(mysqlErr.Number) {
+		return false
+	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "add_columnar_replica_on_demand") ||
 		strings.Contains(msg, "with parser multilingual") ||
 		strings.Contains(msg, "fulltext") ||
 		strings.Contains(msg, "vector index") ||
 		strings.Contains(msg, "vec_cosine_distance")
+}
+
+func isIgnorableOptionalMySQLErrorCode(code uint16) bool {
+	switch code {
+	case 1064, 1105, 1235, 8200:
+		return true
+	default:
+		return false
+	}
 }
 
 func schemaStatementSnippet(stmt string) string {

--- a/pkg/tenant/schema/common.go
+++ b/pkg/tenant/schema/common.go
@@ -1,9 +1,13 @@
 package schema
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"go.uber.org/zap"
 )
 
 // CloneStatements returns a copy of the given schema statements so callers can
@@ -45,6 +49,30 @@ func ExecSchemaStatements(db *sql.DB, stmts []string) error {
 	return nil
 }
 
+// ExecOptionalSchemaStatements executes optional DDL statements and skips
+// feature-specific failures that can happen on TiDB deployments without FTS,
+// vector indexing, or columnar replica support. It returns the number of
+// statements skipped for those unsupported features.
+func ExecOptionalSchemaStatements(db *sql.DB, stmts []string) (int, error) {
+	skipped := 0
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			if isIgnorableSchemaError(err) {
+				continue
+			}
+			if isIgnorableOptionalSchemaError(err) {
+				skipped++
+				logger.Warn(context.Background(), "optional_schema_statement_skipped",
+					zap.String("statement", schemaStatementSnippet(stmt)),
+					zap.Error(err))
+				continue
+			}
+			return skipped, fmt.Errorf("exec optional %q: %w", schemaStatementSnippet(stmt), err)
+		}
+	}
+	return skipped, nil
+}
+
 func HasMultiStatements(dsn string) bool {
 	lower := strings.ToLower(dsn)
 	return strings.Contains(lower, "multistatements=true") || strings.Contains(lower, "multistatements=1")
@@ -58,6 +86,26 @@ func isIgnorableSchemaError(err error) bool {
 	return strings.Contains(msg, "duplicate key") ||
 		strings.Contains(msg, "already exist") ||
 		strings.Contains(msg, "duplicate column")
+}
+
+func isIgnorableOptionalSchemaError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "add_columnar_replica_on_demand") ||
+		strings.Contains(msg, "with parser multilingual") ||
+		strings.Contains(msg, "fulltext") ||
+		strings.Contains(msg, "vector index") ||
+		strings.Contains(msg, "vec_cosine_distance")
+}
+
+func schemaStatementSnippet(stmt string) string {
+	snippet := stmt
+	if len(snippet) > 80 {
+		snippet = snippet[:80]
+	}
+	return snippet
 }
 
 func IsTiDBCluster(db *sql.DB) bool {

--- a/pkg/tenant/schema/tidb.go
+++ b/pkg/tenant/schema/tidb.go
@@ -1,5 +1,12 @@
 package schema
 
+type InitTiDBTenantSchemaOptions struct {
+	// AllowUnsupportedOptionalIndexes is only for local bootstrap flows that need
+	// the app-managed schema without requiring every TiDB deployment to support
+	// FTS/vector optional DDL during init.
+	AllowUnsupportedOptionalIndexes bool
+}
+
 // InitTiDBTenantSchema initializes the TiDB launch schema baseline with the
 // shared database-managed auto-embedding contract used by TiDB tenants.
 func InitTiDBTenantSchema(dsn string) error {
@@ -22,11 +29,18 @@ func InitTiDBTenantSchemaStatementsForMode(mode TiDBEmbeddingMode) ([]string, er
 // InitTiDBTenantSchemaForMode initializes the TiDB tenant schema for the
 // requested local embedding mode.
 func InitTiDBTenantSchemaForMode(dsn string, mode TiDBEmbeddingMode) error {
+	return InitTiDBTenantSchemaForModeWithOptions(dsn, mode, InitTiDBTenantSchemaOptions{})
+}
+
+// InitTiDBTenantSchemaForModeWithOptions initializes the TiDB tenant schema for
+// the requested local embedding mode with caller-controlled compatibility
+// toggles.
+func InitTiDBTenantSchemaForModeWithOptions(dsn string, mode TiDBEmbeddingMode, opts InitTiDBTenantSchemaOptions) error {
 	switch mode {
 	case TiDBEmbeddingModeAuto:
 		return initTiDBAutoEmbeddingSchema(dsn)
 	case TiDBEmbeddingModeApp:
-		return initTiDBAppEmbeddingSchema(dsn)
+		return initTiDBAppEmbeddingSchema(dsn, opts)
 	default:
 		return validateTiDBSchemaMode(mode)
 	}

--- a/pkg/tenant/schema/tidb.go
+++ b/pkg/tenant/schema/tidb.go
@@ -1,5 +1,7 @@
 package schema
 
+import "context"
+
 type InitTiDBTenantSchemaOptions struct {
 	// AllowUnsupportedOptionalIndexes is only for local bootstrap flows that need
 	// the app-managed schema without requiring every TiDB deployment to support
@@ -36,11 +38,18 @@ func InitTiDBTenantSchemaForMode(dsn string, mode TiDBEmbeddingMode) error {
 // the requested local embedding mode with caller-controlled compatibility
 // toggles.
 func InitTiDBTenantSchemaForModeWithOptions(dsn string, mode TiDBEmbeddingMode, opts InitTiDBTenantSchemaOptions) error {
+	return InitTiDBTenantSchemaForModeWithOptionsContext(context.Background(), dsn, mode, opts)
+}
+
+// InitTiDBTenantSchemaForModeWithOptionsContext initializes the TiDB tenant
+// schema for the requested local embedding mode with caller-controlled
+// compatibility toggles and log context.
+func InitTiDBTenantSchemaForModeWithOptionsContext(ctx context.Context, dsn string, mode TiDBEmbeddingMode, opts InitTiDBTenantSchemaOptions) error {
 	switch mode {
 	case TiDBEmbeddingModeAuto:
 		return initTiDBAutoEmbeddingSchema(dsn)
 	case TiDBEmbeddingModeApp:
-		return initTiDBAppEmbeddingSchema(dsn, opts)
+		return initTiDBAppEmbeddingSchema(ctx, dsn, opts)
 	default:
 		return validateTiDBSchemaMode(mode)
 	}

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -132,8 +132,8 @@ func tidbAppEmbeddingOptionalSchemaStatements() []string {
 	}
 }
 
-func initTiDBAppEmbeddingSchema(dsn string, opts InitTiDBTenantSchemaOptions) error {
-	db, err := OpenTiDBSchemaDB(context.Background(), dsn)
+func initTiDBAppEmbeddingSchema(ctx context.Context, dsn string, opts InitTiDBTenantSchemaOptions) error {
+	db, err := OpenTiDBSchemaDB(ctx, dsn)
 	if err != nil {
 		return err
 	}
@@ -147,12 +147,12 @@ func initTiDBAppEmbeddingSchema(dsn string, opts InitTiDBTenantSchemaOptions) er
 	if opts.AllowUnsupportedOptionalIndexes {
 		// Local-only compatibility mode can continue without these indexes; other
 		// callers still execute the same statements strictly below.
-		skipped, err := ExecOptionalSchemaStatements(db, tidbAppEmbeddingOptionalSchemaStatements())
+		skipped, err := ExecOptionalSchemaStatements(ctx, db, tidbAppEmbeddingOptionalSchemaStatements())
 		if err != nil {
 			return err
 		}
 		if skipped > 0 {
-			logger.Warn(context.Background(), "tidb_app_optional_indexes_skipped",
+			logger.Warn(ctx, "tidb_app_optional_indexes_skipped",
 				zap.Int("skipped_count", skipped),
 				zap.String("reason", "allow_unsupported_optional_indexes"))
 		}

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"go.uber.org/zap"
 )
 
 // Keep this statement list aligned with any external workflow that manages the
@@ -14,6 +17,12 @@ import (
 // There is intentionally no drive9-server dump-init-sql --provider export path
 // for this app-managed statement list.
 func tidbAppEmbeddingSchemaStatements() []string {
+	stmts := tidbAppEmbeddingBaseSchemaStatements()
+	stmts = append(stmts, tidbAppEmbeddingOptionalSchemaStatements()...)
+	return stmts
+}
+
+func tidbAppEmbeddingBaseSchemaStatements() []string {
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (
 			node_id      VARCHAR(64) PRIMARY KEY,
@@ -46,13 +55,6 @@ func tidbAppEmbeddingSchemaStatements() []string {
 			expires_at         DATETIME(3)
 		)`,
 		`CREATE INDEX idx_status ON files(status, created_at)`,
-		`ALTER TABLE files
-			ADD FULLTEXT INDEX idx_fts_content(content_text)
-			WITH PARSER MULTILINGUAL
-			ADD_COLUMNAR_REPLICA_ON_DEMAND`,
-		`ALTER TABLE files
-			ADD VECTOR INDEX idx_files_cosine((VEC_COSINE_DISTANCE(embedding)))
-			ADD_COLUMNAR_REPLICA_ON_DEMAND`,
 		`CREATE TABLE IF NOT EXISTS file_tags (
 			file_id   VARCHAR(64) NOT NULL,
 			tag_key   VARCHAR(255) NOT NULL,
@@ -118,7 +120,19 @@ func tidbAppEmbeddingSchemaStatements() []string {
 	return stmts
 }
 
-func initTiDBAppEmbeddingSchema(dsn string) error {
+func tidbAppEmbeddingOptionalSchemaStatements() []string {
+	return []string{
+		`ALTER TABLE files
+			ADD FULLTEXT INDEX idx_fts_content(content_text)
+			WITH PARSER MULTILINGUAL
+			ADD_COLUMNAR_REPLICA_ON_DEMAND`,
+		`ALTER TABLE files
+			ADD VECTOR INDEX idx_files_cosine((VEC_COSINE_DISTANCE(embedding)))
+			ADD_COLUMNAR_REPLICA_ON_DEMAND`,
+	}
+}
+
+func initTiDBAppEmbeddingSchema(dsn string, opts InitTiDBTenantSchemaOptions) error {
 	db, err := OpenTiDBSchemaDB(context.Background(), dsn)
 	if err != nil {
 		return err
@@ -127,7 +141,22 @@ func initTiDBAppEmbeddingSchema(dsn string) error {
 	if !IsTiDBCluster(db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
-	if err := ExecSchemaStatements(db, tidbAppEmbeddingSchemaStatements()); err != nil {
+	if err := ExecSchemaStatements(db, tidbAppEmbeddingBaseSchemaStatements()); err != nil {
+		return err
+	}
+	if opts.AllowUnsupportedOptionalIndexes {
+		// Local-only compatibility mode can continue without these indexes; other
+		// callers still execute the same statements strictly below.
+		skipped, err := ExecOptionalSchemaStatements(db, tidbAppEmbeddingOptionalSchemaStatements())
+		if err != nil {
+			return err
+		}
+		if skipped > 0 {
+			logger.Warn(context.Background(), "tidb_app_optional_indexes_skipped",
+				zap.Int("skipped_count", skipped),
+				zap.String("reason", "allow_unsupported_optional_indexes"))
+		}
+	} else if err := ExecSchemaStatements(db, tidbAppEmbeddingOptionalSchemaStatements()); err != nil {
 		return err
 	}
 	return ValidateTiDBSchemaForMode(db, TiDBEmbeddingModeApp)

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -94,6 +95,43 @@ func TestInitTiDBTenantSchemaStatementsForModeIncludesVault(t *testing.T) {
 			}
 			if !strings.Contains(sqlText, "CREATE TABLE IF NOT EXISTS vault_audit_log") {
 				t.Fatalf("mode %q missing vault_audit_log in init schema", mode)
+			}
+		})
+	}
+}
+
+func TestIsIgnorableOptionalSchemaError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "columnar replica syntax",
+			err:  errors.New("Error 1064 (42000): syntax error near \"ADD_COLUMNAR_REPLICA_ON_DEMAND\""),
+			want: true,
+		},
+		{
+			name: "fulltext unsupported",
+			err:  errors.New("FULLTEXT index is not supported"),
+			want: true,
+		},
+		{
+			name: "vector index unsupported",
+			err:  errors.New("VECTOR INDEX is not supported"),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("permission denied"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isIgnorableOptionalSchemaError(tt.err); got != tt.want {
+				t.Fatalf("isIgnorableOptionalSchemaError()=%v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
 )
 
 func TestDetectTiDBEmbeddingModeFromFilesMeta(t *testing.T) {
@@ -108,22 +110,42 @@ func TestIsIgnorableOptionalSchemaError(t *testing.T) {
 	}{
 		{
 			name: "columnar replica syntax",
-			err:  errors.New("Error 1064 (42000): syntax error near \"ADD_COLUMNAR_REPLICA_ON_DEMAND\""),
+			err:  &mysql.MySQLError{Number: 1064, Message: "syntax error near \"ADD_COLUMNAR_REPLICA_ON_DEMAND\""},
 			want: true,
 		},
 		{
 			name: "fulltext unsupported",
-			err:  errors.New("FULLTEXT index is not supported"),
+			err:  &mysql.MySQLError{Number: 1105, Message: "FULLTEXT index is not supported"},
 			want: true,
 		},
 		{
 			name: "vector index unsupported",
-			err:  errors.New("VECTOR INDEX is not supported"),
+			err:  &mysql.MySQLError{Number: 8200, Message: "VECTOR INDEX is not supported"},
 			want: true,
+		},
+		{
+			name: "vec cosine unsupported",
+			err:  errors.New("vec_cosine_distance is not supported"),
+			want: true,
+		},
+		{
+			name: "parser multilingual unsupported",
+			err:  errors.New("WITH PARSER multilingual is not supported"),
+			want: true,
+		},
+		{
+			name: "mysql syntax without optional markers",
+			err:  &mysql.MySQLError{Number: 1064, Message: "syntax error near \"ALTER TABLE files ADD INDEX idx_status\""},
+			want: false,
 		},
 		{
 			name: "unrelated error",
 			err:  errors.New("permission denied"),
+			want: false,
+		},
+		{
+			name: "mysql unrelated code with keyword should not skip",
+			err:  &mysql.MySQLError{Number: 1146, Message: "FULLTEXT index is not supported"},
 			want: false,
 		},
 	}

--- a/scripts/drive9-server-local-env.sh
+++ b/scripts/drive9-server-local-env.sh
@@ -40,17 +40,17 @@
 # export DRIVE9_S3_REGION=us-east-1
 # export DRIVE9_S3_ENDPOINT=http://127.0.0.1:9000
 # export DRIVE9_S3_FORCE_PATH_STYLE=true
-# export DRIVE9_S3_ACCESS_KEY_ID=minioadmin
-# export DRIVE9_S3_SECRET_ACCESS_KEY=minioadmin
+# Set the S3 access key env var for your MinIO user.
+# Set the S3 secret key env var for your MinIO user.
 
 # Run the following command to pull the embedding model before starting drive9-server-local.
-# ollama pull all-minilm
-# curl http://localhost:11434/v1/embeddings -H "Content-Type: application/json" -d '{"model":"all-minilm", "input": "This is an embedding test"}'
+# ollama pull bge-m3 # "bge-m3" provide 1024-dimensional embeddings.
+# curl http://localhost:11434/v1/embeddings -H "Content-Type: application/json" -d '{"model":"bge-m3", "input": "This is an embedding test"}'
 
 # Background semantic embedding worker.
 : "${DRIVE9_EMBED_API_BASE:=http://127.0.0.1:11434}"
 : "${DRIVE9_EMBED_API_KEY:=ollama}"
-: "${DRIVE9_EMBED_MODEL:=all-minilm}"
+: "${DRIVE9_EMBED_MODEL:=bge-m3}"
 # Leave the following unset to keep using the program defaults:
 # DRIVE9_EMBED_TIMEOUT_SECONDS=20
 # DRIVE9_SEMANTIC_WORKERS=1


### PR DESCRIPTION
## Summary
- add `make test` filters and refresh the root/e2e docs so local and Podman-backed test flows are easier to run consistently
- let `drive9-server-local` bootstrap app-managed TiDB schema on local builds that lack optional FTS/vector index features, while keeping shared schema init paths strict and logging the degraded mode
- add a GitHub Actions workflow that starts TiDB with TiUP, launches `drive9-server-local`, and runs the local API, existing-key, CLI, and FUSE smoke scripts with semantic checks explicitly skippable for reduced local environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to skip semantic checks in e2e smoke tests via environment flags
  * Support for selective test execution using `TEST_RUN` and `TEST_PKGS` parameters
  * Added automated local e2e testing workflow with database playground integration

* **Documentation**
  * Improved e2e testing setup guides with streamlined local development workflow
  * Updated test execution documentation with examples for targeting specific tests and packages

* **Refactor**
  * Enhanced schema initialization to gracefully handle optional indexes when unsupported

<!-- end of auto-generated comment: release notes by coderabbit.ai -->