### PR TITLE
Lane A + Lane B wire-shape convergence + B5 iss re-validation (partial 083aab8 impl)

### DIFF
--- a/clients/drive9-js/examples/vault.ts
+++ b/clients/drive9-js/examples/vault.ts
@@ -28,13 +28,13 @@ async function main() {
     console.log(`  ${s.name}`);
   }
 
-  // Issue token
-  const token = await client.issueVaultToken("agent-1", "task-1", ["read"], 3600);
-  console.log("Issued token:", token.token_id);
+  // Issue grant (spec §6)
+  const grant = await client.issueVaultToken("agent-1", [secretName], "read", 3600);
+  console.log("Issued grant:", grant.grant_id, "perm:", grant.perm, "ttl:", grant.ttl);
 
   // Revoke
-  await client.revokeVaultToken(token.token_id);
-  console.log("Revoked token");
+  await client.revokeVaultToken(grant.grant_id);
+  console.log("Revoked grant");
 
   // Clean up
   await client.deleteVaultSecret(secretName);

--- a/clients/drive9-js/src/client.ts
+++ b/clients/drive9-js/src/client.ts
@@ -242,12 +242,18 @@ export class Client {
     return listVaultSecrets(this);
   }
 
-  async issueVaultToken(agentId: string, taskId: string, scope: string[], ttlSeconds: number): Promise<import("./models.js").VaultTokenIssueResponse> {
-    return issueVaultToken(this, agentId, taskId, scope, ttlSeconds);
+  async issueVaultToken(
+    agent: string,
+    scope: string[],
+    perm: string,
+    ttlSeconds: number,
+    labelHint?: string,
+  ): Promise<import("./models.js").VaultTokenIssueResponse> {
+    return issueVaultToken(this, agent, scope, perm, ttlSeconds, labelHint);
   }
 
-  async revokeVaultToken(tokenId: string): Promise<void> {
-    return revokeVaultToken(this, tokenId);
+  async revokeVaultToken(grantId: string): Promise<void> {
+    return revokeVaultToken(this, grantId);
   }
 
   async queryVaultAudit(secretName?: string, limit?: number): Promise<import("./models.js").VaultAuditEvent[]> {

--- a/clients/drive9-js/src/models.ts
+++ b/clients/drive9-js/src/models.ts
@@ -70,19 +70,26 @@ export interface VaultSecret {
   updated_at: string;
 }
 
+/**
+ * Response for POST /v1/vault/tokens per spec 083aab8 line 133.
+ * Wire shape: {token, grant_id, expires_at, scope[], perm, ttl}.
+ */
 export interface VaultTokenIssueResponse {
   token: string;
-  token_id: string;
+  grant_id: string;
   expires_at: string;
+  scope: string[];
+  perm: string;
+  ttl: number;
 }
 
+/** Audit event returned by GET /v1/vault/audit (spec §16). */
 export interface VaultAuditEvent {
   event_id: string;
   event_type: string;
   timestamp: string;
-  token_id?: string;
-  agent_id?: string;
-  task_id?: string;
+  grant_id?: string;
+  agent?: string;
   secret_name?: string;
   field_name?: string;
   adapter?: string;

--- a/clients/drive9-js/src/vault.ts
+++ b/clients/drive9-js/src/vault.ts
@@ -49,24 +49,37 @@ export async function listVaultSecrets(client: Client): Promise<VaultSecret[]> {
   return body.secrets || [];
 }
 
+/**
+ * Issue a scoped capability grant (spec §6).
+ * Request body: {agent, scope[], perm, ttl_seconds, label_hint?}.
+ * Response: {token, grant_id, expires_at, scope[], perm, ttl}.
+ */
 export async function issueVaultToken(
   client: Client,
-  agentId: string,
-  taskId: string,
+  agent: string,
   scope: string[],
-  ttlSeconds: number
+  perm: string,
+  ttlSeconds: number,
+  labelHint?: string
 ): Promise<VaultTokenIssueResponse> {
+  const body: Record<string, unknown> = {
+    agent,
+    scope,
+    perm,
+    ttl_seconds: ttlSeconds,
+  };
+  if (labelHint) body.label_hint = labelHint;
   const resp = await fetch(client.vaultUrl("/tokens"), {
     method: "POST",
     headers: client["authHeaders"]({ "Content-Type": "application/json" }),
-    body: JSON.stringify({ agent_id: agentId, task_id: taskId, scope, ttl_seconds: ttlSeconds }),
+    body: JSON.stringify(body),
   });
   await checkError(resp);
   return (await resp.json()) as VaultTokenIssueResponse;
 }
 
-export async function revokeVaultToken(client: Client, tokenId: string): Promise<void> {
-  const resp = await fetch(client.vaultUrl(`/tokens/${encodeURIComponent(tokenId)}`), {
+export async function revokeVaultToken(client: Client, grantId: string): Promise<void> {
+  const resp = await fetch(client.vaultUrl(`/tokens/${encodeURIComponent(grantId)}`), {
     method: "DELETE",
     headers: client["authHeaders"](),
   });

--- a/clients/drive9-js/tests/client.test.ts
+++ b/clients/drive9-js/tests/client.test.ts
@@ -175,18 +175,92 @@ describe("Vault", () => {
     expect(list.length).toBe(1);
   });
 
-  it("issue and revoke token", async () => {
+  it("issueVaultToken wire shape (spec 083aab8 line 133)", async () => {
+    // Native assertion of the terminal wire shape:
+    //   request  = {agent, scope[], perm, ttl_seconds, label_hint?}
+    //   response = {token, grant_id, expires_at, scope[], perm, ttl}
+    let capturedBody: Record<string, unknown> | undefined;
     server.use(
       http.post("http://localhost:9009/v1/vault/tokens", async ({ request }) => {
-        const body = (await request.json()) as { agent_id: string };
-        expect(body.agent_id).toBe("agent-1");
-        return HttpResponse.json({ token: "tok", token_id: "tid-1", expires_at: "2024-01-01T00:00:00Z" });
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            token: "vault_abc",
+            grant_id: "grt_123",
+            expires_at: "2026-04-14T00:00:00Z",
+            scope: ["aws-prod", "db-prod/password"],
+            perm: "read",
+            ttl: 3600,
+          },
+          { status: 201 }
+        );
       }),
-      http.delete("http://localhost:9009/v1/vault/tokens/tid-1", () => HttpResponse.text("ok"))
+      http.delete("http://localhost:9009/v1/vault/tokens/grt_123", () => HttpResponse.text("ok"))
     );
     const client = new Client("http://localhost:9009", "test-key");
-    const tok = await client.issueVaultToken("agent-1", "task-1", ["read"], 3600);
-    expect(tok.token_id).toBe("tid-1");
-    await client.revokeVaultToken(tok.token_id);
+    const grant = await client.issueVaultToken(
+      "deploy-agent",
+      ["aws-prod", "db-prod/password"],
+      "read",
+      3600,
+      "nightly"
+    );
+    expect(grant.token).toBe("vault_abc");
+    expect(grant.grant_id).toBe("grt_123");
+    expect(grant.scope).toEqual(["aws-prod", "db-prod/password"]);
+    expect(grant.perm).toBe("read");
+    expect(grant.ttl).toBe(3600);
+
+    expect(capturedBody).toBeDefined();
+    expect(capturedBody!.agent).toBe("deploy-agent");
+    expect(capturedBody!.scope).toEqual(["aws-prod", "db-prod/password"]);
+    expect(capturedBody!.perm).toBe("read");
+    expect(capturedBody!.ttl_seconds).toBe(3600);
+    expect(capturedBody!.label_hint).toBe("nightly");
+    // Terminal-state reshape removed agent_id/task_id per spec §20.
+    expect(capturedBody!.agent_id).toBeUndefined();
+    expect(capturedBody!.task_id).toBeUndefined();
+
+    await client.revokeVaultToken(grant.grant_id);
+  });
+
+  it("audit event wire shape (spec §16)", async () => {
+    // Native assertion that audit events carry {grant_id, agent}
+    // instead of the legacy {token_id, agent_id, task_id} trio.
+    server.use(
+      http.get("http://localhost:9009/v1/vault/audit", () =>
+        HttpResponse.json({
+          events: [
+            {
+              event_id: "e1",
+              event_type: "secret.read",
+              timestamp: "2026-04-14T00:00:00Z",
+              grant_id: "grt_123",
+              agent: "deploy-agent",
+              secret_name: "aws-prod",
+              field_name: "access_key",
+              adapter: "api",
+            },
+          ],
+        })
+      )
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    const events = await client.queryVaultAudit("aws-prod", 5);
+    expect(events.length).toBe(1);
+    const ev = events[0];
+    expect(ev.grant_id).toBe("grt_123");
+    expect(ev.agent).toBe("deploy-agent");
+    expect(ev.secret_name).toBe("aws-prod");
+    expect(ev.field_name).toBe("access_key");
+    expect(ev.adapter).toBe("api");
+    // The dataclass-equivalent assertion: legacy fields do not exist on
+    // VaultAuditEvent per the terminal type.
+    // @ts-expect-error — legacy field removed from VaultAuditEvent
+    expect(ev.token_id).toBeUndefined();
+    // @ts-expect-error — legacy field removed from VaultAuditEvent
+    expect(ev.agent_id).toBeUndefined();
+    // @ts-expect-error — legacy field removed from VaultAuditEvent
+    expect(ev.task_id).toBeUndefined();
   });
 });

--- a/clients/drive9-py/drive9/client.py
+++ b/clients/drive9-py/drive9/client.py
@@ -353,40 +353,51 @@ class Client(TransferMixin, PatchMixin):
 
     def issue_vault_token(
         self,
-        agent_id: str,
-        task_id: str,
+        agent: str,
         scope: list,
+        perm: str,
         ttl_seconds: int,
+        label_hint: str = "",
     ):
-        """Issue a scoped capability token via the management API."""
+        """Issue a scoped capability grant via the management API (spec §6).
+
+        Request body: {agent, scope[], perm, ttl_seconds, label_hint?}.
+        Response: {token, grant_id, expires_at, scope[], perm, ttl}.
+        """
         from .models import VaultTokenIssueResponse
 
+        body = {
+            "agent": agent,
+            "scope": scope,
+            "perm": perm,
+            "ttl_seconds": ttl_seconds,
+        }
+        if label_hint:
+            body["label_hint"] = label_hint
         resp = self._request(
             "POST",
             self._vault_url("/tokens"),
-            json={
-                "agent_id": agent_id,
-                "task_id": task_id,
-                "scope": scope,
-                "ttl_seconds": ttl_seconds,
-            },
+            json=body,
             headers={"Content-Type": "application/json"},
         )
         self._check_error(resp)
         data = resp.json()
         return VaultTokenIssueResponse(
             token=data["token"],
-            token_id=data["token_id"],
+            grant_id=data["grant_id"],
             expires_at=datetime.fromisoformat(
                 data["expires_at"].replace("Z", "+00:00")
             ),
+            scope=data.get("scope", []) or [],
+            perm=data["perm"],
+            ttl=data["ttl"],
         )
 
-    def revoke_vault_token(self, token_id: str) -> None:
-        """Revoke a capability token via the management API."""
+    def revoke_vault_token(self, grant_id: str) -> None:
+        """Revoke a capability grant via the management API."""
         resp = self._request(
             "DELETE",
-            self._vault_url("/tokens/" + quote(token_id, safe="")),
+            self._vault_url("/tokens/" + quote(grant_id, safe="")),
         )
         self._check_error(resp)
 
@@ -411,9 +422,8 @@ class Client(TransferMixin, PatchMixin):
                 event_id=e["event_id"],
                 event_type=e["event_type"],
                 timestamp=datetime.fromisoformat(e["timestamp"].replace("Z", "+00:00")),
-                token_id=e.get("token_id"),
-                agent_id=e.get("agent_id"),
-                task_id=e.get("task_id"),
+                grant_id=e.get("grant_id"),
+                agent=e.get("agent"),
                 secret_name=e.get("secret_name"),
                 field_name=e.get("field_name"),
                 adapter=e.get("adapter"),

--- a/clients/drive9-py/drive9/models.py
+++ b/clients/drive9-py/drive9/models.py
@@ -95,21 +95,26 @@ class VaultSecret:
 
 @dataclass
 class VaultTokenIssueResponse:
-    """Response when issuing a scoped capability token."""
+    """Response when issuing a scoped capability grant (spec 083aab8 line 133).
+
+    Wire shape: {token, grant_id, expires_at, scope[], perm, ttl}.
+    """
     token: str
-    token_id: str
+    grant_id: str
     expires_at: datetime
+    scope: list
+    perm: str
+    ttl: int
 
 
 @dataclass
 class VaultAuditEvent:
-    """Audit event returned by the vault audit API."""
+    """Audit event returned by the vault audit API (spec §16)."""
     event_id: str
     event_type: str
     timestamp: datetime
-    token_id: Optional[str] = None
-    agent_id: Optional[str] = None
-    task_id: Optional[str] = None
+    grant_id: Optional[str] = None
+    agent: Optional[str] = None
     secret_name: Optional[str] = None
     field_name: Optional[str] = None
     adapter: Optional[str] = None

--- a/clients/drive9-py/tests/test_vault.py
+++ b/clients/drive9-py/tests/test_vault.py
@@ -14,33 +14,86 @@ def client():
 
 
 @responses.activate
-def test_issue_vault_token(client):
+def test_issue_vault_token_wire_shape(client):
+    """Native assertion of spec 083aab8 line 133 wire shape:
+    request  = {agent, scope[], perm, ttl_seconds, label_hint?}
+    response = {token, grant_id, expires_at, scope[], perm, ttl}
+    """
+    import json as _json
+
     responses.add(
         responses.POST,
         f"{BASE_URL}/v1/vault/tokens",
         json={
-            "token": "vault_token",
-            "token_id": "cap_123",
+            "token": "vault_abc",
+            "grant_id": "grt_123",
             "expires_at": "2026-04-14T00:00:00Z",
+            "scope": ["aws-prod", "db-prod/password"],
+            "perm": "read",
+            "ttl": 3600,
         },
-        status=200,
+        status=201,
     )
     resp = client.issue_vault_token(
         "deploy-agent",
-        "task-123",
         ["aws-prod", "db-prod/password"],
+        perm="read",
         ttl_seconds=3600,
+        label_hint="nightly",
     )
-    assert resp.token == "vault_token"
-    assert resp.token_id == "cap_123"
+    assert resp.token == "vault_abc"
+    assert resp.grant_id == "grt_123"
+    assert resp.scope == ["aws-prod", "db-prod/password"]
+    assert resp.perm == "read"
+    assert resp.ttl == 3600
 
-    req = responses.calls[0].request
-    body = req.body
-    assert b"agent_id" in body
-    assert b"task_id" in body
-    assert b"scope" in body
-    assert b"ttl_seconds" in body
-    assert b"3600" in body
+    req_body = _json.loads(responses.calls[0].request.body)
+    assert req_body["agent"] == "deploy-agent"
+    assert req_body["scope"] == ["aws-prod", "db-prod/password"]
+    assert req_body["perm"] == "read"
+    assert req_body["ttl_seconds"] == 3600
+    assert req_body["label_hint"] == "nightly"
+    # Terminal-state reshape removed agent_id/task_id per spec §20.
+    assert "agent_id" not in req_body
+    assert "task_id" not in req_body
+
+
+@responses.activate
+def test_audit_event_wire_shape(client):
+    """Native assertion of spec §16 audit event shape:
+    {grant_id, agent} — not {token_id, agent_id, task_id}.
+    """
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/v1/vault/audit?secret=aws-prod&limit=5",
+        json={
+            "events": [
+                {
+                    "event_id": "e1",
+                    "event_type": "secret.read",
+                    "timestamp": "2026-04-14T00:00:00Z",
+                    "grant_id": "grt_123",
+                    "agent": "deploy-agent",
+                    "secret_name": "aws-prod",
+                    "field_name": "access_key",
+                    "adapter": "api",
+                }
+            ]
+        },
+        status=200,
+    )
+    events = client.query_vault_audit("aws-prod", limit=5)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.grant_id == "grt_123"
+    assert ev.agent == "deploy-agent"
+    assert ev.secret_name == "aws-prod"
+    assert ev.field_name == "access_key"
+    assert ev.adapter == "api"
+    # Terminal state removed the legacy attributes.
+    assert not hasattr(ev, "token_id")
+    assert not hasattr(ev, "agent_id")
+    assert not hasattr(ev, "task_id")
 
 
 @responses.activate

--- a/clients/drive9-rs/examples/vault.rs
+++ b/clients/drive9-rs/examples/vault.rs
@@ -32,15 +32,21 @@ async fn main() -> Result<(), drive9::Drive9Error> {
         println!("  {}", s.name);
     }
 
-    // Issue a token
-    let token = client
-        .issue_vault_token("agent-1", "task-1", &["read".to_string()], 3600)
+    // Issue a capability grant (spec §6)
+    let grant = client
+        .issue_vault_token(
+            "agent-1",
+            &["example-secret".to_string()],
+            "read",
+            3600,
+            Some("example-grant"),
+        )
         .await?;
-    println!("Issued token: {}", token.token_id);
+    println!("Issued grant: {} (perm={}, ttl={}s)", grant.grant_id, grant.perm, grant.ttl);
 
-    // Revoke the token
-    client.revoke_vault_token(&token.token_id).await?;
-    println!("Revoked token");
+    // Revoke the grant
+    client.revoke_vault_token(&grant.grant_id).await?;
+    println!("Revoked grant");
 
     // Clean up
     client.delete_vault_secret(secret_name).await?;

--- a/clients/drive9-rs/src/models.rs
+++ b/clients/drive9-rs/src/models.rs
@@ -83,23 +83,26 @@ pub struct VaultSecret {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Response for POST /v1/vault/tokens per spec 083aab8 line 133.
+/// Wire shape: {token, grant_id, expires_at, scope[], perm, ttl}.
 #[derive(Debug, Clone, Deserialize)]
 pub struct VaultTokenIssueResponse {
     pub token: String,
-    pub token_id: String,
-    #[serde(rename = "expires_at")]
+    pub grant_id: String,
     pub expires_at: DateTime<Utc>,
+    pub scope: Vec<String>,
+    pub perm: String,
+    pub ttl: i64,
 }
 
+/// Audit event returned by GET /v1/vault/audit (spec §16).
 #[derive(Debug, Clone, Deserialize)]
 pub struct VaultAuditEvent {
     pub event_id: String,
     pub event_type: String,
     pub timestamp: DateTime<Utc>,
-    #[serde(rename = "token_id")]
-    pub token_id: Option<String>,
-    pub agent_id: Option<String>,
-    pub task_id: Option<String>,
+    pub grant_id: Option<String>,
+    pub agent: Option<String>,
     pub secret_name: Option<String>,
     pub field_name: Option<String>,
     pub adapter: Option<String>,

--- a/clients/drive9-rs/src/vault.rs
+++ b/clients/drive9-rs/src/vault.rs
@@ -61,33 +61,41 @@ impl Client {
         )?)
     }
 
+    /// Issue a scoped capability grant (spec §6).
+    /// Request body: {agent, scope[], perm, ttl_seconds, label_hint?}.
+    /// Response: {token, grant_id, expires_at, scope[], perm, ttl}.
     pub async fn issue_vault_token(
         &self,
-        agent_id: &str,
-        task_id: &str,
+        agent: &str,
         scope: &[String],
+        perm: &str,
         ttl_seconds: i64,
+        label_hint: Option<&str>,
     ) -> Result<VaultTokenIssueResponse, Drive9Error> {
+        let mut body = json!({
+            "agent": agent,
+            "scope": scope,
+            "perm": perm,
+            "ttl_seconds": ttl_seconds,
+        });
+        if let Some(hint) = label_hint {
+            body["label_hint"] = json!(hint);
+        }
         let resp = self
             .http
             .post(self.vault_url("/tokens"))
             .headers(self.auth_headers())
-            .json(&json!({
-                "agent_id": agent_id,
-                "task_id": task_id,
-                "scope": scope,
-                "ttl_seconds": ttl_seconds,
-            }))
+            .json(&body)
             .send()
             .await?;
         let resp = check_error(resp).await?;
         Ok(resp.json().await?)
     }
 
-    pub async fn revoke_vault_token(&self, token_id: &str) -> Result<(), Drive9Error> {
+    pub async fn revoke_vault_token(&self, grant_id: &str) -> Result<(), Drive9Error> {
         let resp = self
             .http
-            .delete(self.vault_url(&format!("/tokens/{}", urlencoding::encode(token_id))))
+            .delete(self.vault_url(&format!("/tokens/{}", urlencoding::encode(grant_id))))
             .headers(self.auth_headers())
             .send()
             .await?;

--- a/clients/drive9-rs/tests/test_client.rs
+++ b/clients/drive9-rs/tests/test_client.rs
@@ -148,3 +148,74 @@ fn test_default_client_loads_config() {
     }
     let _ = std::fs::remove_dir_all(&temp_home);
 }
+
+/// Asserts the new terminal-state wire shape for POST /v1/vault/tokens
+/// (spec 083aab8 line 133: {token, grant_id, expires_at, scope[], perm, ttl}).
+/// This is the field-level native assertion required by reviewer pin
+/// msg 000002c8, not a mechanical smoke test.
+#[tokio::test]
+async fn test_issue_vault_token_wire_shape() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("POST", "/v1/vault/tokens")
+        .match_body(mockito::Matcher::JsonString(
+            r#"{"agent":"deploy-agent","scope":["aws-prod","db-prod/password"],"perm":"read","ttl_seconds":3600,"label_hint":"deploy-2026"}"#
+                .to_string(),
+        ))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"token":"vault_abc","grant_id":"grt_123","expires_at":"2026-04-14T00:00:00Z","scope":["aws-prod","db-prod/password"],"perm":"read","ttl":3600}"#,
+        )
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "tenant-key");
+    let grant = client
+        .issue_vault_token(
+            "deploy-agent",
+            &["aws-prod".to_string(), "db-prod/password".to_string()],
+            "read",
+            3600,
+            Some("deploy-2026"),
+        )
+        .await
+        .unwrap();
+
+    // Field-level new-shape assertions (not smoke tests).
+    assert_eq!(grant.token, "vault_abc");
+    assert_eq!(grant.grant_id, "grt_123");
+    assert_eq!(grant.perm, "read");
+    assert_eq!(grant.ttl, 3600);
+    assert_eq!(grant.scope.len(), 2);
+    assert_eq!(grant.scope[0], "aws-prod");
+    assert_eq!(grant.scope[1], "db-prod/password");
+}
+
+/// Asserts VaultAuditEvent deserializes from the new-shape wire
+/// ({grant_id, agent}) and NOT from the old-shape ({token_id, agent_id, task_id}).
+#[tokio::test]
+async fn test_audit_event_wire_shape() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("GET", "/v1/vault/audit?secret=aws-prod&limit=10")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"events":[{"event_id":"ev_1","event_type":"secret.read","grant_id":"grt_123","agent":"deploy-agent","secret_name":"aws-prod","field_name":"password","adapter":"api","timestamp":"2026-04-14T00:00:00Z"}]}"#,
+        )
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "tenant-key");
+    let events = client.query_vault_audit(Some("aws-prod"), 10).await.unwrap();
+
+    assert_eq!(events.len(), 1);
+    let ev = &events[0];
+    assert_eq!(ev.event_type, "secret.read");
+    assert_eq!(ev.grant_id.as_deref(), Some("grt_123"));
+    assert_eq!(ev.agent.as_deref(), Some("deploy-agent"));
+    assert_eq!(ev.adapter.as_deref(), Some("api"));
+    assert_eq!(ev.secret_name.as_deref(), Some("aws-prod"));
+    assert_eq!(ev.field_name.as_deref(), Some("password"));
+}

--- a/cmd/drive9/cli/config.go
+++ b/cmd/drive9/cli/config.go
@@ -6,10 +6,48 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"time"
 )
 
+// PrincipalType identifies whether a context holds an owner API key or a
+// delegated JWT. See spec §13.1.
+type PrincipalType string
+
+const (
+	PrincipalOwner     PrincipalType = "owner"
+	PrincipalDelegated PrincipalType = "delegated"
+)
+
+// Perm is the scope permission carried by a delegated context's JWT. Spec §6
+// restricts this to {read, write}; "admin" is NOT a valid value.
+type Perm string
+
+const (
+	PermRead  Perm = "read"
+	PermWrite Perm = "write"
+)
+
+// Context is a single entry in ~/.drive9/config. Field presence depends on
+// Type per spec §13.1:
+//
+//   - owner:     APIKey, Server
+//   - delegated: Token, Server (from iss), Agent, Scope[], Perm, ExpiresAt,
+//                GrantID, optional LabelHint
+//
+// The delegated fields are populated by locally decoding the JWT payload at
+// `ctx import` time. This is UX-only — authorization remains server-side
+// (Invariant #7).
 type Context struct {
-	APIKey string `json:"api_key"`
+	Type      PrincipalType `json:"type"`
+	Server    string        `json:"server,omitempty"`
+	APIKey    string        `json:"api_key,omitempty"`
+	Token     string        `json:"token,omitempty"`
+	Agent     string        `json:"agent,omitempty"`
+	Scope     []string      `json:"scope,omitempty"`
+	Perm      Perm          `json:"perm,omitempty"`
+	ExpiresAt time.Time     `json:"expires_at,omitempty"`
+	GrantID   string        `json:"grant_id,omitempty"`
+	LabelHint string        `json:"label_hint,omitempty"`
 }
 
 type Config struct {
@@ -34,6 +72,9 @@ func configPath() string {
 	return filepath.Join(dir, "config")
 }
 
+// loadConfig reads ~/.drive9/config. Missing / malformed files yield an empty
+// Config. Contexts without an explicit Type are treated as owner-kind so that
+// configs written by the pre-spec single-field form continue to resolve.
 func loadConfig() *Config {
 	path := configPath()
 	if path == "" {
@@ -49,6 +90,14 @@ func loadConfig() *Config {
 	}
 	if cfg.Contexts == nil {
 		cfg.Contexts = map[string]*Context{}
+	}
+	for _, ctx := range cfg.Contexts {
+		if ctx == nil {
+			continue
+		}
+		if ctx.Type == "" {
+			ctx.Type = PrincipalOwner
+		}
 	}
 	return &cfg
 }
@@ -68,18 +117,43 @@ func saveConfig(cfg *Config) error {
 	return os.WriteFile(configPath(), append(data, '\n'), 0o600)
 }
 
+// CurrentAPIKey returns the active owner context's API key, or empty when the
+// active context is delegated or absent.
 func (c *Config) CurrentAPIKey() string {
-	if c.CurrentContext == "" {
-		return ""
-	}
-	ctx, ok := c.Contexts[c.CurrentContext]
-	if !ok {
+	ctx := c.currentContextEntry()
+	if ctx == nil || ctx.Type != PrincipalOwner {
 		return ""
 	}
 	return ctx.APIKey
 }
 
+// CurrentToken returns the active delegated context's JWT, or empty when the
+// active context is owner-kind or absent.
+func (c *Config) CurrentToken() string {
+	ctx := c.currentContextEntry()
+	if ctx == nil || ctx.Type != PrincipalDelegated {
+		return ""
+	}
+	return ctx.Token
+}
+
+func (c *Config) currentContextEntry() *Context {
+	if c.CurrentContext == "" {
+		return nil
+	}
+	ctx, ok := c.Contexts[c.CurrentContext]
+	if !ok {
+		return nil
+	}
+	return ctx
+}
+
+// ResolveServer returns the active context's server URL when set, falling back
+// to the top-level Config.Server and finally the compiled-in default.
 func (c *Config) ResolveServer() string {
+	if ctx := c.currentContextEntry(); ctx != nil && ctx.Server != "" {
+		return ctx.Server
+	}
 	if c.Server != "" {
 		return c.Server
 	}

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -1,0 +1,541 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+)
+
+// Ctx dispatches drive9 ctx subcommands per spec §13.2.
+//
+// The 5 normative verbs are: add / import / ls / use / rm.
+//
+// Bare `drive9 ctx` (no verb) is retained as a non-spec compatibility
+// convenience that prints the current context name. See migration call-out
+// #7 in the impl PR body.
+func Ctx(args []string) error {
+	if len(args) == 0 {
+		return ctxShow()
+	}
+	switch args[0] {
+	case "add":
+		return ctxAddCmd(args[1:])
+	case "import":
+		return ctxImportCmd(args[1:])
+	case "ls", "list":
+		return ctxListCmd(args[1:])
+	case "use":
+		return ctxUseCmd(args[1:])
+	case "rm":
+		return ctxRmCmd(args[1:])
+	case "-h", "--help", "help":
+		return ctxUsageErr()
+	default:
+		return fmt.Errorf("unknown ctx command %q\n%s", args[0], ctxUsage())
+	}
+}
+
+func ctxUsage() string {
+	return `usage: drive9 ctx <add|import|ls|use|rm>
+  add --api-key <key> [--name <n>] [--server <url>]   add owner context
+  import --from-file <path|->                         add delegated context from file or stdin
+  import <jwt>                                        add delegated context from positional arg (unsafe)
+  ls [-l|--json]                                      list contexts
+  use <name>                                          activate a context
+  rm <name>                                           delete a context`
+}
+
+func ctxUsageErr() error {
+	return fmt.Errorf("%s", ctxUsage())
+}
+
+func ctxShow() error {
+	cfg := loadConfig()
+	if cfg.CurrentContext == "" {
+		fmt.Println("no current context")
+		return nil
+	}
+	fmt.Println(cfg.CurrentContext)
+	return nil
+}
+
+// ctxAddCmd is the user-facing `drive9 ctx add` verb. Internally it delegates
+// to ctxAdd, the shared Go helper that is ALSO called by `drive9 create`.
+// This keeps a single config-writer code path (no exec.Command, no cmd
+// re-entry) so the invariant "exactly one place writes ~/.drive9/config" is
+// preserved.
+func ctxAddCmd(args []string) error {
+	var (
+		apiKey string
+		name   string
+		server string
+	)
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--api-key":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--api-key requires a value")
+			}
+			i++
+			apiKey = args[i]
+		case "--name":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--name requires a value")
+			}
+			i++
+			name = args[i]
+		case "--server":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--server requires a value")
+			}
+			i++
+			server = args[i]
+		default:
+			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx add --api-key <key> [--name <n>] [--server <url>]", args[i])
+		}
+	}
+	if apiKey == "" {
+		return fmt.Errorf("--api-key is required")
+	}
+
+	cfg := loadConfig()
+	if server == "" {
+		server = cfg.ResolveServer()
+	}
+	if name == "" {
+		name = randomName()
+	}
+	if _, err := ctxAdd(cfg, name, &Context{
+		Type:   PrincipalOwner,
+		Server: server,
+		APIKey: apiKey,
+	}); err != nil {
+		return err
+	}
+	if err := saveConfig(cfg); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	fmt.Printf("added context %q (owner)\n", name)
+	if cfg.CurrentContext == name {
+		fmt.Printf("current context is now %q\n", name)
+	}
+	return nil
+}
+
+// ctxAdd registers a new context entry in cfg. It is the single writer for
+// both `drive9 ctx add` and `drive9 create`. Collision on name is rejected;
+// if cfg has no current context, the new entry becomes current.
+//
+// ctxAdd does NOT save cfg; callers are responsible for persistence. Returning
+// the inserted *Context lets callers print per-kind success output without a
+// second lookup.
+func ctxAdd(cfg *Config, name string, ctx *Context) (*Context, error) {
+	if name == "" {
+		return nil, fmt.Errorf("context name is required")
+	}
+	if cfg.Contexts == nil {
+		cfg.Contexts = map[string]*Context{}
+	}
+	if _, exists := cfg.Contexts[name]; exists {
+		return nil, fmt.Errorf("context %q already exists; use a different name or run: drive9 ctx rm %s", name, name)
+	}
+	cfg.Contexts[name] = ctx
+	if cfg.CurrentContext == "" {
+		cfg.CurrentContext = name
+	}
+	if cfg.Server == "" && ctx.Server != "" {
+		cfg.Server = ctx.Server
+	}
+	return ctx, nil
+}
+
+// ctxImportCmd implements `drive9 ctx import` per spec §13.2/§13.3. Input
+// modes: --from-file <path>, --from-file -, positional <jwt>. All three forms
+// are equivalent after whitespace trim.
+//
+// The §19 parse-stability fork rejects before any config write:
+//  1. structurally unparseable JWT                 -> command error
+//  2. parseable but principal_type != "delegated"  -> command error, direct to ctx add
+//  3. parseable delegated but exp already past     -> command error (§17 short-circuit #1)
+//  4. parseable delegated with exp in the future   -> TOFU on iss, store
+func ctxImportCmd(args []string) error {
+	var (
+		fromFile string
+		name     string
+		positional string
+	)
+	haveFromFile := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--from-file":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--from-file requires a value (path or -)")
+			}
+			i++
+			fromFile = args[i]
+			haveFromFile = true
+		case "--name":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--name requires a value")
+			}
+			i++
+			name = args[i]
+		default:
+			if strings.HasPrefix(args[i], "--") {
+				return fmt.Errorf("unknown flag %q", args[i])
+			}
+			if positional != "" {
+				return fmt.Errorf("ctx import takes at most one positional JWT argument")
+			}
+			positional = args[i]
+		}
+	}
+	if haveFromFile && positional != "" {
+		return fmt.Errorf("--from-file and positional JWT are mutually exclusive")
+	}
+
+	raw, err := readImportToken(fromFile, haveFromFile, positional)
+	if err != nil {
+		return err
+	}
+
+	claims, err := decodeJWTPayload(raw)
+	if err != nil {
+		return fmt.Errorf("ctx import: %w (use `drive9 ctx add --api-key` for owner credentials)", err)
+	}
+	if claims.PrincipalType != string(PrincipalDelegated) {
+		return fmt.Errorf("ctx import: token principal_type is %q, not %q; use `drive9 ctx add --api-key` for owner credentials", claims.PrincipalType, PrincipalDelegated)
+	}
+	exp := claims.expTime()
+	if !exp.IsZero() && exp.Before(time.Now()) {
+		return fmt.Errorf("ctx import: token already expired at %s", exp.Format(time.RFC3339))
+	}
+	if claims.Iss == "" {
+		return fmt.Errorf("ctx import: token is missing the `iss` claim")
+	}
+	perm := Perm(claims.Perm)
+	if perm != PermRead && perm != PermWrite {
+		return fmt.Errorf("ctx import: token perm is %q, expected one of {read, write}", claims.Perm)
+	}
+
+	cfg := loadConfig()
+	if name == "" {
+		name = defaultImportName(cfg, claims)
+	}
+	if _, err := ctxAdd(cfg, name, &Context{
+		Type:      PrincipalDelegated,
+		Server:    claims.Iss, // TOFU — see Invariant #8 / §18
+		Token:     raw,
+		Agent:     claims.Agent,
+		Scope:     append([]string(nil), claims.Scope...),
+		Perm:      perm,
+		ExpiresAt: exp,
+		GrantID:   claims.GrantID,
+		LabelHint: claims.LabelHint,
+	}); err != nil {
+		return err
+	}
+	if err := saveConfig(cfg); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	fmt.Printf("imported context %q (delegated, grant %s)\n", name, claims.GrantID)
+	if cfg.CurrentContext == name {
+		fmt.Printf("current context is now %q\n", name)
+	}
+	return nil
+}
+
+func readImportToken(fromFile string, haveFromFile bool, positional string) (string, error) {
+	switch {
+	case haveFromFile && fromFile == "-":
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("read stdin: %w", err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	case haveFromFile:
+		data, err := os.ReadFile(fromFile)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", fromFile, err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	case positional != "":
+		return strings.TrimSpace(positional), nil
+	default:
+		return "", fmt.Errorf("ctx import requires a token: --from-file <path>, --from-file -, or a positional JWT argument")
+	}
+}
+
+// defaultImportName derives the default context name from (in order):
+//  1. JWT label_hint (if set and not already taken),
+//  2. agent-<first-scope-root>,
+// with a numeric suffix appended on collision.
+func defaultImportName(cfg *Config, claims *jwtClaims) string {
+	base := claims.LabelHint
+	if base == "" {
+		scopeRoot := ""
+		if len(claims.Scope) > 0 {
+			scopeRoot = scopeRootSegment(claims.Scope[0])
+		}
+		if claims.Agent != "" && scopeRoot != "" {
+			base = claims.Agent + "-" + scopeRoot
+		} else if claims.Agent != "" {
+			base = claims.Agent
+		} else if scopeRoot != "" {
+			base = scopeRoot
+		} else {
+			base = randomName()
+		}
+	}
+	if _, exists := cfg.Contexts[base]; !exists {
+		return base
+	}
+	for i := 2; i < 1000; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if _, exists := cfg.Contexts[candidate]; !exists {
+			return candidate
+		}
+	}
+	return base + "-" + randomName()
+}
+
+func scopeRootSegment(scope string) string {
+	// Scope is of the form /n/vault/<secret>[/<key>]; return <secret>.
+	parts := strings.Split(strings.Trim(scope, "/"), "/")
+	if len(parts) >= 3 && parts[0] == "n" && parts[1] == "vault" {
+		return parts[2]
+	}
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return ""
+}
+
+// ctxListCmd implements `drive9 ctx ls` per spec §13.2. Output format (table):
+//
+//	CURRENT   NAME  TYPE  SCOPE  PERM  EXPIRES_AT  STATUS
+//
+// CURRENT is a dedicated column (exactly one row holds `*`), replacing the
+// pre-spec `*` marker prefix on NAME (F16).
+//
+// Status is computed locally from ExpiresAt at display time (§17 short-circuit).
+func ctxListCmd(args []string) error {
+	longForm := false
+	asJSON := false
+	for _, arg := range args {
+		switch arg {
+		case "-l", "--long":
+			longForm = true
+		case "--json":
+			asJSON = true
+		default:
+			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx ls [-l|--json]", arg)
+		}
+	}
+	if longForm && asJSON {
+		return fmt.Errorf("-l/--long and --json are mutually exclusive")
+	}
+	cfg := loadConfig()
+	if asJSON {
+		return writeCtxListJSON(cfg)
+	}
+	return writeCtxListTable(cfg, longForm)
+}
+
+type ctxListEntry struct {
+	Name      string    `json:"name"`
+	Current   bool      `json:"current"`
+	Type      string    `json:"type"`
+	Server    string    `json:"server,omitempty"`
+	Scope     []string  `json:"scope,omitempty"`
+	Perm      string    `json:"perm,omitempty"`
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	Status    string    `json:"status"`
+	Agent     string    `json:"agent,omitempty"`
+	GrantID   string    `json:"grant_id,omitempty"`
+}
+
+func writeCtxListJSON(cfg *Config) error {
+	entries := buildCtxListEntries(cfg)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(map[string]any{
+		"current_context": cfg.CurrentContext,
+		"contexts":        entries,
+	})
+}
+
+func writeCtxListTable(cfg *Config, longForm bool) error {
+	entries := buildCtxListEntries(cfg)
+	if len(entries) == 0 {
+		fmt.Println("no contexts configured")
+		fmt.Println("run: drive9 ctx add --api-key <key>  (owner)")
+		fmt.Println("     drive9 ctx import --from-file <path>  (delegated)")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS")
+	for _, e := range entries {
+		cur := " "
+		if e.Current {
+			cur = "*"
+		}
+		scope := renderScope(e.Scope, e.Type, longForm)
+		perm := e.Perm
+		if e.Type == string(PrincipalOwner) {
+			perm = "rw"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			cur,
+			e.Name,
+			e.Type,
+			scope,
+			perm,
+			formatExpiresAt(e.ExpiresAt),
+			e.Status,
+		)
+	}
+	return w.Flush()
+}
+
+func buildCtxListEntries(cfg *Config) []ctxListEntry {
+	names := make([]string, 0, len(cfg.Contexts))
+	for n := range cfg.Contexts {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	entries := make([]ctxListEntry, 0, len(names))
+	now := time.Now()
+	for _, n := range names {
+		c := cfg.Contexts[n]
+		if c == nil {
+			continue
+		}
+		entries = append(entries, ctxListEntry{
+			Name:      n,
+			Current:   n == cfg.CurrentContext,
+			Type:      string(c.Type),
+			Server:    c.Server,
+			Scope:     c.Scope,
+			Perm:      string(c.Perm),
+			ExpiresAt: c.ExpiresAt,
+			Status:    ctxStatus(c, now),
+			Agent:     c.Agent,
+			GrantID:   c.GrantID,
+		})
+	}
+	return entries
+}
+
+func ctxStatus(c *Context, now time.Time) string {
+	if c.Type == PrincipalDelegated && !c.ExpiresAt.IsZero() && !c.ExpiresAt.After(now) {
+		return "expired"
+	}
+	return "active"
+}
+
+func renderScope(scope []string, kind string, longForm bool) string {
+	if kind == string(PrincipalOwner) {
+		return "*"
+	}
+	if len(scope) == 0 {
+		return "—"
+	}
+	if longForm || len(scope) == 1 {
+		return strings.Join(scope, ",")
+	}
+	return fmt.Sprintf("%s +%d", scope[0], len(scope)-1)
+}
+
+func formatExpiresAt(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// ctxUseCmd implements `drive9 ctx use <name>` per spec §13.2 and §15.
+// Output is the spec-pinned two-line notice (F15):
+//
+//	switched to context "<name>"
+//	<type-specific descriptor line>
+//
+// Per Invariant #6, activating a context does NOT re-bind any running mount.
+// The only way to rebind a mount is `drive9 vault reauth`. This is enforced
+// by `ctx use` doing no FUSE-side work; it only rewrites the active context
+// pointer in ~/.drive9/config.
+//
+// Per §17 short-circuit, an already-expired delegated context is refused.
+func ctxUseCmd(args []string) error {
+	if len(args) != 1 || strings.HasPrefix(args[0], "--") {
+		return fmt.Errorf("usage: drive9 ctx use <name>")
+	}
+	name := args[0]
+	cfg := loadConfig()
+	c, ok := cfg.Contexts[name]
+	if !ok {
+		return fmt.Errorf("context %q not found; run: drive9 ctx ls", name)
+	}
+	if c.Type == PrincipalDelegated && !c.ExpiresAt.IsZero() && !c.ExpiresAt.After(time.Now()) {
+		return fmt.Errorf("context %q expired at %s; request a new grant and re-import", name, c.ExpiresAt.Format(time.RFC3339))
+	}
+	if cfg.CurrentContext == name {
+		fmt.Printf("context %q is already active\n", name)
+		fmt.Println(ctxUseDescriptor(c))
+		return nil
+	}
+	cfg.CurrentContext = name
+	if err := saveConfig(cfg); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	fmt.Printf("switched to context %q\n", name)
+	fmt.Println(ctxUseDescriptor(c))
+	return nil
+}
+
+func ctxUseDescriptor(c *Context) string {
+	switch c.Type {
+	case PrincipalOwner:
+		return fmt.Sprintf("  owner credentials, server %s", c.Server)
+	case PrincipalDelegated:
+		scope := "—"
+		if len(c.Scope) > 0 {
+			scope = c.Scope[0]
+			if len(c.Scope) > 1 {
+				scope = fmt.Sprintf("%s +%d", scope, len(c.Scope)-1)
+			}
+		}
+		return fmt.Sprintf("  delegated: scope %s, perm %s, expires %s", scope, c.Perm, formatExpiresAt(c.ExpiresAt))
+	default:
+		return ""
+	}
+}
+
+// ctxRmCmd implements `drive9 ctx rm <name>` per spec §13.2.
+func ctxRmCmd(args []string) error {
+	if len(args) != 1 || strings.HasPrefix(args[0], "--") {
+		return fmt.Errorf("usage: drive9 ctx rm <name>")
+	}
+	name := args[0]
+	cfg := loadConfig()
+	if _, ok := cfg.Contexts[name]; !ok {
+		return fmt.Errorf("context %q not found", name)
+	}
+	delete(cfg.Contexts, name)
+	if cfg.CurrentContext == name {
+		cfg.CurrentContext = ""
+	}
+	if err := saveConfig(cfg); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	fmt.Printf("removed context %q\n", name)
+	if cfg.CurrentContext == "" {
+		fmt.Println("no current context; run `drive9 ctx use <name>` to activate one")
+	}
+	return nil
+}

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -1,0 +1,380 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// makeJWT builds a syntactically valid three-segment JWT with the given
+// payload claims. The header and signature are placeholders — local decode
+// in Lane A does not verify signatures (Inv #7).
+func makeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payloadJSON, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	sig := base64.RawURLEncoding.EncodeToString([]byte("placeholder-signature"))
+	return header + "." + payload + "." + sig
+}
+
+// withIsolatedHome redirects ~/.drive9/config to a test-local tmp dir for the
+// duration of the test. Returns the tmp dir path.
+func withIsolatedHome(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	// Some macOS Go versions cache UserHomeDir via getenv; t.Setenv is
+	// sufficient since os.UserHomeDir() consults $HOME directly.
+	return tmp
+}
+
+func captureStdoutE(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan []byte, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.Bytes()
+	}()
+	runErr := fn()
+	_ = w.Close()
+	out := <-done
+	return string(out), runErr
+}
+
+// TestF_ImportRejectsUnparseableToken — §19 row 4: malformed JWT → command
+// error, no context written.
+func TestF_ImportRejectsUnparseableToken(t *testing.T) {
+	home := withIsolatedHome(t)
+	err := Ctx([]string{"import", "not-a-jwt"})
+	if err == nil {
+		t.Fatalf("expected error for malformed JWT, got nil")
+	}
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Errorf("expected error to mention 'malformed'; got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".drive9", "config")); !os.IsNotExist(statErr) {
+		t.Errorf("config should not exist after failed import; stat err: %v", statErr)
+	}
+}
+
+// TestF_ImportRejectsOwnerJWT — §19 row 5 / §13.3 contract rule: importing a
+// credential with principal_type != "delegated" must fail and direct the user
+// to `ctx add --api-key`.
+func TestF_ImportRejectsOwnerJWT(t *testing.T) {
+	home := withIsolatedHome(t)
+	tok := makeJWT(t, map[string]any{
+		"iss":            "https://api.example.com",
+		"principal_type": "owner",
+		"exp":            time.Now().Add(time.Hour).Unix(),
+	})
+	err := Ctx([]string{"import", tok})
+	if err == nil {
+		t.Fatalf("expected error for owner JWT, got nil")
+	}
+	if !strings.Contains(err.Error(), "ctx add --api-key") {
+		t.Errorf("expected error to direct to `ctx add --api-key`; got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".drive9", "config")); !os.IsNotExist(statErr) {
+		t.Errorf("config should not exist after failed import; stat err: %v", statErr)
+	}
+}
+
+// TestF_ImportRejectsExpiredDelegatedJWT — §17 short-circuit #1: importing a
+// delegated JWT with exp in the past is a local refuse, no context written.
+func TestF_ImportRejectsExpiredDelegatedJWT(t *testing.T) {
+	home := withIsolatedHome(t)
+	tok := makeJWT(t, map[string]any{
+		"iss":            "https://api.example.com",
+		"principal_type": "delegated",
+		"grant_id":       "grt_expired",
+		"agent":          "alice",
+		"scope":          []string{"/n/vault/prod-db/DB_URL"},
+		"perm":           "read",
+		"exp":            time.Now().Add(-time.Hour).Unix(),
+	})
+	err := Ctx([]string{"import", tok})
+	if err == nil {
+		t.Fatalf("expected error for expired JWT, got nil")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected error to mention 'expired'; got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".drive9", "config")); !os.IsNotExist(statErr) {
+		t.Errorf("config should not exist after failed import; stat err: %v", statErr)
+	}
+}
+
+// TestF_ImportStoresDelegatedContext — positive path: a well-formed delegated
+// JWT with future exp is accepted; server field is populated from iss (TOFU,
+// Invariant #8); config file is written with 0600 perms.
+func TestF_ImportStoresDelegatedContext(t *testing.T) {
+	home := withIsolatedHome(t)
+	exp := time.Now().Add(time.Hour).Truncate(time.Second)
+	tok := makeJWT(t, map[string]any{
+		"iss":            "https://api.example.com",
+		"principal_type": "delegated",
+		"grant_id":       "grt_7f2a",
+		"agent":          "alice",
+		"scope":          []string{"/n/vault/prod-db/DB_URL"},
+		"perm":           "read",
+		"exp":            exp.Unix(),
+		"label_hint":     "alice-prod-db",
+	})
+	if _, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"import", tok})
+	}); err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+
+	cfgPath := filepath.Join(home, ".drive9", "config")
+	st, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if st.Mode().Perm() != 0o600 {
+		t.Errorf("config perms = %o, want 0600", st.Mode().Perm())
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if cfg.CurrentContext != "alice-prod-db" {
+		t.Errorf("current_context = %q, want %q", cfg.CurrentContext, "alice-prod-db")
+	}
+	got := cfg.Contexts["alice-prod-db"]
+	if got == nil {
+		t.Fatalf("context %q missing", "alice-prod-db")
+	}
+	if got.Type != PrincipalDelegated {
+		t.Errorf("type = %q, want delegated", got.Type)
+	}
+	if got.Server != "https://api.example.com" {
+		t.Errorf("server = %q, want iss-derived", got.Server)
+	}
+	if got.GrantID != "grt_7f2a" {
+		t.Errorf("grant_id = %q, want grt_7f2a", got.GrantID)
+	}
+	if got.Perm != PermRead {
+		t.Errorf("perm = %q, want read", got.Perm)
+	}
+}
+
+// TestF15_CtxUseIsExplicitVerb — spec §13.2 / F15: `ctx use` must be an
+// explicit verb. The positional-switch form `drive9 ctx <name>` is retired.
+func TestF15_CtxUseIsExplicitVerb(t *testing.T) {
+	_ = withIsolatedHome(t)
+	// Pre-seed two owner contexts.
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "alpha", &Context{Type: PrincipalOwner, APIKey: "k1", Server: "https://s"}); err != nil {
+		t.Fatalf("seed alpha: %v", err)
+	}
+	if _, err := ctxAdd(cfg, "beta", &Context{Type: PrincipalOwner, APIKey: "k2", Server: "https://s"}); err != nil {
+		t.Fatalf("seed beta: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Positional form must error, not silently switch.
+	err := Ctx([]string{"beta"})
+	if err == nil {
+		t.Errorf("positional `ctx beta` should be an error; got nil")
+	}
+
+	// Explicit `ctx use` must switch.
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"use", "beta"}) })
+	if err != nil {
+		t.Fatalf("ctx use beta: %v", err)
+	}
+	if !strings.Contains(out, `switched to context "beta"`) {
+		t.Errorf("expected spec-pinned success notice; got: %q", out)
+	}
+	// F15 second line — descriptor.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 2 {
+		t.Errorf("expected a two-line success notice; got %d line(s)", len(lines))
+	}
+}
+
+// TestF15_CtxUseRejectsExpiredDelegated — §17 short-circuit: ctx use must not
+// activate an already-expired delegated context.
+func TestF15_CtxUseRejectsExpiredDelegated(t *testing.T) {
+	_ = withIsolatedHome(t)
+	cfg := loadConfig()
+	_, _ = ctxAdd(cfg, "fresh", &Context{Type: PrincipalOwner, APIKey: "k", Server: "https://s"})
+	_, _ = ctxAdd(cfg, "stale", &Context{
+		Type:      PrincipalDelegated,
+		Server:    "https://api.example.com",
+		Token:     "irrelevant",
+		Agent:     "alice",
+		Scope:     []string{"/n/vault/x"},
+		Perm:      PermRead,
+		ExpiresAt: time.Now().Add(-time.Hour),
+		GrantID:   "grt_x",
+	})
+	// "fresh" is current (first-added); "stale" is not.
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	err := Ctx([]string{"use", "stale"})
+	if err == nil {
+		t.Fatalf("expected error activating expired context")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected 'expired' in error; got: %v", err)
+	}
+	post := loadConfig()
+	if post.CurrentContext != "fresh" {
+		t.Errorf("current context should remain %q; got %q", "fresh", post.CurrentContext)
+	}
+}
+
+// TestF16_CtxListUsesCurrentColumn — spec §13.2 / F16: `ctx ls` renders a
+// dedicated CURRENT column (* in its own cell), not a `*` marker prefixed
+// onto NAME.
+func TestF16_CtxListUsesCurrentColumn(t *testing.T) {
+	_ = withIsolatedHome(t)
+	cfg := loadConfig()
+	_, _ = ctxAdd(cfg, "owner-prod", &Context{Type: PrincipalOwner, APIKey: "k", Server: "https://s"})
+	_, _ = ctxAdd(cfg, "alice", &Context{
+		Type:      PrincipalDelegated,
+		Server:    "https://s",
+		Token:     "t",
+		Agent:     "alice",
+		Scope:     []string{"/n/vault/prod-db/DB_URL"},
+		Perm:      PermRead,
+		ExpiresAt: time.Now().Add(time.Hour),
+		GrantID:   "grt_1",
+	})
+	cfg.CurrentContext = "alice"
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"ls"}) })
+	if err != nil {
+		t.Fatalf("ctx ls: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 3 { // header + 2 rows
+		t.Fatalf("expected at least 3 output lines, got %d: %q", len(lines), out)
+	}
+	header := lines[0]
+	if !strings.HasPrefix(strings.TrimLeft(header, " "), "CURRENT") {
+		t.Errorf("expected header to start with CURRENT column; got: %q", header)
+	}
+	// No row's NAME column should carry a leading `*`.
+	for _, line := range lines[1:] {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if strings.HasPrefix(fields[1], "*") {
+			t.Errorf("NAME column must not carry `*` marker (F16); got line: %q", line)
+		}
+	}
+	// Exactly one row holds `*` in CURRENT column.
+	stars := 0
+	for _, line := range lines[1:] {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == "*" {
+			stars++
+		}
+	}
+	if stars != 1 {
+		t.Errorf("expected exactly one row with * in CURRENT column; got %d", stars)
+	}
+}
+
+// TestF13_NoDaemonStateBetweenCalls — spec F13: a CLI invocation that
+// succeeds purely on ~/.drive9/config may not leave other process-visible
+// state behind (no lockfiles, no sockets from the CLI itself, no /tmp
+// droppings). Lane A verbs are all stateless on the CLI side; this test
+// pins it.
+func TestF13_NoDaemonStateBetweenCalls(t *testing.T) {
+	home := withIsolatedHome(t)
+	// Snapshot pre-state of common leak sinks.
+	preEntries := func() []string {
+		var out []string
+		for _, d := range []string{home, filepath.Join(home, ".drive9"), os.TempDir()} {
+			ents, err := os.ReadDir(d)
+			if err != nil {
+				continue
+			}
+			for _, e := range ents {
+				out = append(out, filepath.Join(d, e.Name()))
+			}
+		}
+		return out
+	}
+	before := preEntries()
+
+	_, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"add", "--api-key", "sk_test", "--name", "t1"})
+	})
+	if err != nil {
+		t.Fatalf("ctx add: %v", err)
+	}
+	_, _ = captureStdoutE(t, func() error { return Ctx([]string{"ls"}) })
+	_, _ = captureStdoutE(t, func() error { return Ctx([]string{"use", "t1"}) })
+
+	after := preEntries()
+	// The only new path allowed is ~/.drive9 and ~/.drive9/config.
+	seen := map[string]struct{}{}
+	for _, p := range before {
+		seen[p] = struct{}{}
+	}
+	for _, p := range after {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		rel := p
+		if strings.HasPrefix(p, home) {
+			rel = strings.TrimPrefix(p, home)
+		}
+		switch rel {
+		case "/.drive9", "/.drive9/config":
+			// allowed
+		default:
+			t.Errorf("unexpected filesystem side effect from Lane A verb: %s", p)
+		}
+	}
+}
+
+func TestCtxAddIsSingleConfigWriter(t *testing.T) {
+	_ = withIsolatedHome(t)
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "first", &Context{Type: PrincipalOwner, APIKey: "k", Server: "https://s"}); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	// Collision must be rejected by the same helper Create uses, proving the
+	// invariant that Create shares the config-writing code path.
+	if _, err := ctxAdd(cfg, "first", &Context{Type: PrincipalOwner, APIKey: "k2", Server: "https://s"}); err == nil {
+		t.Errorf("expected collision error from ctxAdd")
+	}
+}

--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -5,11 +5,17 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"sort"
 
 	"github.com/mem9-ai/dat9/pkg/client"
 )
 
+// Create provisions a new tenant and registers the returned API key as a
+// local owner context. Both steps are performed from a single Go code path:
+// Create calls ctxAdd(name, &Context{...}) after provisioning, which is the
+// same helper `drive9 ctx add` calls. There is one writer for
+// ~/.drive9/config — not a sub-command spawn, not a cmd re-entry.
+//
+// See migration call-out #4 in the impl PR body.
 func Create(args []string) error {
 	name := ""
 	server := os.Getenv("DRIVE9_SERVER")
@@ -71,12 +77,12 @@ func Create(args []string) error {
 		return fmt.Errorf("decode response: %w", err)
 	}
 
-	if cfg.Server == "" {
-		cfg.Server = server
-	}
-	cfg.Contexts[name] = &Context{APIKey: result.APIKey}
-	if cfg.CurrentContext == "" {
-		cfg.CurrentContext = name
+	if _, err := ctxAdd(cfg, name, &Context{
+		Type:   PrincipalOwner,
+		Server: server,
+		APIKey: result.APIKey,
+	}); err != nil {
+		return err
 	}
 	if err := saveConfig(cfg); err != nil {
 		return fmt.Errorf("save config: %w", err)
@@ -87,67 +93,5 @@ func Create(args []string) error {
 		fmt.Printf("switched to context %q\n", name)
 	}
 	fmt.Printf("config: %s\n", configPath())
-	return nil
-}
-
-func Ctx(args []string) error {
-	if len(args) == 0 {
-		return ctxShow()
-	}
-	switch args[0] {
-	case "list", "ls":
-		return ctxList()
-	default:
-		return ctxSwitch(args[0])
-	}
-}
-
-func ctxShow() error {
-	cfg := loadConfig()
-	if cfg.CurrentContext == "" {
-		fmt.Println("no current context")
-		return nil
-	}
-	fmt.Println(cfg.CurrentContext)
-	return nil
-}
-
-func ctxList() error {
-	cfg := loadConfig()
-	if len(cfg.Contexts) == 0 {
-		fmt.Println("no contexts configured")
-		fmt.Println("run: drive9 create --name <name>")
-		return nil
-	}
-	names := make([]string, 0, len(cfg.Contexts))
-	for name := range cfg.Contexts {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
-		marker := "  "
-		if name == cfg.CurrentContext {
-			marker = "* "
-		}
-		ctx := cfg.Contexts[name]
-		masked := ctx.APIKey
-		if len(masked) > 12 {
-			masked = masked[:8] + "..." + masked[len(masked)-4:]
-		}
-		fmt.Printf("%s%s  (key=%s)\n", marker, name, masked)
-	}
-	return nil
-}
-
-func ctxSwitch(name string) error {
-	cfg := loadConfig()
-	if _, ok := cfg.Contexts[name]; !ok {
-		return fmt.Errorf("context %q not found; run: drive9 ctx list", name)
-	}
-	cfg.CurrentContext = name
-	if err := saveConfig(cfg); err != nil {
-		return err
-	}
-	fmt.Printf("switched to context %q\n", name)
 	return nil
 }

--- a/cmd/drive9/cli/jwt.go
+++ b/cmd/drive9/cli/jwt.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// jwtClaims holds the subset of JWT payload fields the CLI consumes to
+// populate a delegated Context. Per spec §16 these are required on a
+// delegated JWT; see §13.1 for how they map into Context fields.
+//
+// Decoding is UX-only. Authorization is server-side (Invariant #7); the server
+// MUST re-validate signature, TTL, and revocation on every request.
+type jwtClaims struct {
+	Iss           string   `json:"iss"`
+	GrantID       string   `json:"grant_id"`
+	PrincipalType string   `json:"principal_type"`
+	Agent         string   `json:"agent"`
+	Scope         []string `json:"scope"`
+	Perm          string   `json:"perm"`
+	Exp           int64    `json:"exp"`
+	LabelHint     string   `json:"label_hint,omitempty"`
+}
+
+// decodeJWTPayload returns the parsed payload of a JWT without verifying its
+// signature. Signature verification is the issuing server's responsibility
+// (Invariant #7); this decode is strictly for local UX purposes (populating
+// `ctx ls` and running the §17 short-circuits).
+//
+// Returns an error with a stable prefix for each distinguishable failure
+// class so that callers can surface actionable messages without string-match:
+//   - "malformed": token shape (not three dot-separated base64url segments)
+//   - "decode":    base64url or JSON parse failed on the payload
+func decodeJWTPayload(raw string) (*jwtClaims, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("malformed: empty token")
+	}
+	parts := strings.Split(raw, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("malformed: expected 3 dot-separated segments, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode: base64 payload: %w", err)
+	}
+	var claims jwtClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("decode: json payload: %w", err)
+	}
+	return &claims, nil
+}
+
+// expTime converts the JWT exp claim to a time.Time in UTC.
+func (c *jwtClaims) expTime() time.Time {
+	if c.Exp == 0 {
+		return time.Time{}
+	}
+	return time.Unix(c.Exp, 0).UTC()
+}

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -257,12 +257,13 @@ func SecretRm(args []string) error {
 	return c.DeleteVaultSecret(context.Background(), name)
 }
 
-// SecretGrant issues a scoped capability token.
+// SecretGrant issues a scoped capability grant per spec §6.
 func SecretGrant(args []string) error {
 	var (
-		agentID   string
-		taskID    string
+		agent     string
+		perm      string
 		ttlRaw    string
+		labelHint string
 		asJSON    bool
 		tokenOnly bool
 		scope     []string
@@ -275,19 +276,25 @@ func SecretGrant(args []string) error {
 				return fmt.Errorf("--agent requires a value")
 			}
 			i++
-			agentID = args[i]
-		case "--task":
+			agent = args[i]
+		case "--perm":
 			if i+1 >= len(args) {
-				return fmt.Errorf("--task requires a value")
+				return fmt.Errorf("--perm requires a value")
 			}
 			i++
-			taskID = args[i]
+			perm = args[i]
 		case "--ttl":
 			if i+1 >= len(args) {
 				return fmt.Errorf("--ttl requires a value")
 			}
 			i++
 			ttlRaw = args[i]
+		case "--label-hint":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--label-hint requires a value")
+			}
+			i++
+			labelHint = args[i]
 		case "--json":
 			asJSON = true
 		case "--token-only":
@@ -302,8 +309,14 @@ func SecretGrant(args []string) error {
 	if asJSON && tokenOnly {
 		return fmt.Errorf("--json and --token-only are mutually exclusive")
 	}
-	if agentID == "" {
+	if agent == "" {
 		return fmt.Errorf("--agent is required")
+	}
+	if perm == "" {
+		return fmt.Errorf("--perm is required (read|write)")
+	}
+	if perm != "read" && perm != "write" {
+		return fmt.Errorf("--perm must be 'read' or 'write'")
 	}
 	if ttlRaw == "" {
 		return fmt.Errorf("--ttl is required")
@@ -327,7 +340,7 @@ func SecretGrant(args []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.IssueVaultToken(context.Background(), agentID, taskID, scope, ttl)
+	resp, err := c.IssueVaultToken(context.Background(), agent, scope, perm, ttl, labelHint)
 	if err != nil {
 		return err
 	}
@@ -338,16 +351,19 @@ func SecretGrant(args []string) error {
 		return writeJSON(resp)
 	default:
 		_, _ = fmt.Fprintf(os.Stdout, "token=%s\n", resp.Token)
-		_, _ = fmt.Fprintf(os.Stdout, "token_id=%s\n", resp.TokenID)
+		_, _ = fmt.Fprintf(os.Stdout, "grant_id=%s\n", resp.GrantID)
+		_, _ = fmt.Fprintf(os.Stdout, "perm=%s\n", resp.Perm)
+		_, _ = fmt.Fprintf(os.Stdout, "scope=%s\n", strings.Join(resp.Scope, ","))
+		_, _ = fmt.Fprintf(os.Stdout, "ttl=%d\n", resp.TTL)
 		_, _ = fmt.Fprintf(os.Stdout, "expires_at=%s\n", resp.ExpiresAt.Format(time.RFC3339))
 	}
 	return nil
 }
 
-// SecretRevoke revokes a capability token.
+// SecretRevoke revokes a capability grant.
 func SecretRevoke(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("usage drive9 secret revoke <token-id>")
+		return fmt.Errorf("usage drive9 secret revoke <grant-id>")
 	}
 	c, err := newVaultManagementClientFromEnv()
 	if err != nil {
@@ -586,7 +602,7 @@ func printAudit(events []client.VaultAuditEvent) {
 	for _, ev := range events {
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 			ev.Timestamp.Format(time.RFC3339),
-			ev.AgentID,
+			ev.Agent,
 			ev.EventType,
 			ev.SecretName,
 			ev.FieldName,
@@ -623,10 +639,10 @@ func envMapFromSecret(fields map[string]string) map[string]string {
 	return env
 }
 
-func filterAuditEvents(events []client.VaultAuditEvent, agentID string, since time.Time) []client.VaultAuditEvent {
+func filterAuditEvents(events []client.VaultAuditEvent, agent string, since time.Time) []client.VaultAuditEvent {
 	filtered := make([]client.VaultAuditEvent, 0, len(events))
 	for _, ev := range events {
-		if agentID != "" && ev.AgentID != agentID {
+		if agent != "" && ev.Agent != agent {
 			continue
 		}
 		if !since.IsZero() && ev.Timestamp.Before(since) {

--- a/cmd/drive9/cli/secret_commands_test.go
+++ b/cmd/drive9/cli/secret_commands_test.go
@@ -81,7 +81,7 @@ func TestSecretGrantPrintsTokenMetadata(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"token":"vault_abc","token_id":"cap_123","expires_at":"2026-04-14T00:00:00Z"}`))
+		_, _ = w.Write([]byte(`{"token":"vault_abc","grant_id":"grt_123","expires_at":"2026-04-14T00:00:00Z","scope":["aws-prod","db-prod/password"],"perm":"read","ttl":3600}`))
 	}))
 	defer srv.Close()
 
@@ -90,12 +90,15 @@ func TestSecretGrantPrintsTokenMetadata(t *testing.T) {
 	t.Setenv("DRIVE9_API_KEY", "tenant-key")
 
 	out := captureStdout(t, func() {
-		if err := SecretGrant([]string{"aws-prod", "db-prod/password", "--agent", "deploy-agent", "--ttl", "1h"}); err != nil {
+		if err := SecretGrant([]string{"aws-prod", "db-prod/password", "--agent", "deploy-agent", "--perm", "read", "--ttl", "1h"}); err != nil {
 			t.Fatalf("SecretGrant: %v", err)
 		}
 	})
-	if !strings.Contains(out, "token=vault_abc") || !strings.Contains(out, "token_id=cap_123") {
+	if !strings.Contains(out, "token=vault_abc") || !strings.Contains(out, "grant_id=grt_123") {
 		t.Fatalf("output = %q", out)
+	}
+	if !strings.Contains(out, "perm=read") || !strings.Contains(out, "ttl=3600") {
+		t.Fatalf("output missing perm/ttl: %q", out)
 	}
 }
 
@@ -192,8 +195,8 @@ func TestSecretAuditFiltersClientSide(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"events":[` +
-			`{"event_id":"1","event_type":"secret.read","agent_id":"deploy-agent","secret_name":"aws-prod","timestamp":"` + now.Add(-10*time.Minute).Format(time.RFC3339) + `"},` +
-			`{"event_id":"2","event_type":"secret.read","agent_id":"test-agent","secret_name":"aws-prod","timestamp":"` + now.Add(-2*time.Hour).Format(time.RFC3339) + `"}` +
+			`{"event_id":"1","event_type":"secret.read","agent":"deploy-agent","secret_name":"aws-prod","timestamp":"` + now.Add(-10*time.Minute).Format(time.RFC3339) + `"},` +
+			`{"event_id":"2","event_type":"secret.read","agent":"test-agent","secret_name":"aws-prod","timestamp":"` + now.Add(-2*time.Hour).Format(time.RFC3339) + `"}` +
 			`]}`))
 	}))
 	defer srv.Close()
@@ -207,7 +210,7 @@ func TestSecretAuditFiltersClientSide(t *testing.T) {
 			t.Fatalf("SecretAudit: %v", err)
 		}
 	})
-	if !strings.Contains(out, `"agent_id": "deploy-agent"`) || strings.Contains(out, `"agent_id": "test-agent"`) {
+	if !strings.Contains(out, `"agent": "deploy-agent"`) || strings.Contains(out, `"agent": "test-agent"`) {
 		t.Fatalf("output = %q", out)
 	}
 }

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -22,20 +22,23 @@ type VaultSecret struct {
 	UpdatedAt  time.Time `json:"updated_at"`
 }
 
-// VaultTokenIssueResponse is returned when issuing a scoped capability token.
+// VaultTokenIssueResponse is returned when issuing a scoped capability grant.
+// Wire shape per spec 083aab8 line 133: {token, grant_id, expires_at, scope[], perm, ttl}.
 type VaultTokenIssueResponse struct {
 	Token     string    `json:"token"`
-	TokenID   string    `json:"token_id"`
+	GrantID   string    `json:"grant_id"`
 	ExpiresAt time.Time `json:"expires_at"`
+	Scope     []string  `json:"scope"`
+	Perm      string    `json:"perm"`
+	TTL       int       `json:"ttl"`
 }
 
-// VaultAuditEvent is an audit event returned by the vault audit API.
+// VaultAuditEvent is an audit event returned by the vault audit API (spec §16).
 type VaultAuditEvent struct {
 	EventID    string         `json:"event_id"`
 	EventType  string         `json:"event_type"`
-	TokenID    string         `json:"token_id,omitempty"`
-	AgentID    string         `json:"agent_id,omitempty"`
-	TaskID     string         `json:"task_id,omitempty"`
+	GrantID    string         `json:"grant_id,omitempty"`
+	Agent      string         `json:"agent,omitempty"`
 	SecretName string         `json:"secret_name,omitempty"`
 	FieldName  string         `json:"field_name,omitempty"`
 	Adapter    string         `json:"adapter,omitempty"`
@@ -152,17 +155,22 @@ func (c *Client) ListVaultSecrets(ctx context.Context) ([]VaultSecret, error) {
 	return result.Secrets, nil
 }
 
-// IssueVaultToken issues a scoped capability token via the management API.
-func (c *Client) IssueVaultToken(ctx context.Context, agentID, taskID string, scope []string, ttl time.Duration) (*VaultTokenIssueResponse, error) {
+// IssueVaultToken issues a scoped capability grant via the management API.
+// Request shape matches spec §6 `vault grant`: {agent, scope[], perm, ttl_seconds, label_hint?}.
+func (c *Client) IssueVaultToken(ctx context.Context, agent string, scope []string, perm string, ttl time.Duration, labelHint string) (*VaultTokenIssueResponse, error) {
 	ttlSeconds := int(ttl / time.Second)
-	body, err := json.Marshal(map[string]any{
-		"agent_id":    agentID,
-		"task_id":     taskID,
+	payload := map[string]any{
+		"agent":       agent,
 		"scope":       scope,
+		"perm":        perm,
 		"ttl_seconds": ttlSeconds,
-	})
+	}
+	if labelHint != "" {
+		payload["label_hint"] = labelHint
+	}
+	body, err := json.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("marshal token issue request: %w", err)
+		return nil, fmt.Errorf("marshal grant issue request: %w", err)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.vaultURL("/tokens"), bytes.NewReader(body))
 	if err != nil {
@@ -179,14 +187,14 @@ func (c *Client) IssueVaultToken(ctx context.Context, agentID, taskID string, sc
 	}
 	var result VaultTokenIssueResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("decode token issue response: %w", err)
+		return nil, fmt.Errorf("decode grant issue response: %w", err)
 	}
 	return &result, nil
 }
 
-// RevokeVaultToken revokes a capability token via the management API.
-func (c *Client) RevokeVaultToken(ctx context.Context, tokenID string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.vaultURL("/tokens/"+url.PathEscape(tokenID)), nil)
+// RevokeVaultToken revokes a capability grant via the management API.
+func (c *Client) RevokeVaultToken(ctx context.Context, grantID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.vaultURL("/tokens/"+url.PathEscape(grantID)), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/vault_test.go
+++ b/pkg/client/vault_test.go
@@ -24,19 +24,26 @@ func TestIssueVaultTokenUsesManagementAuthAndPayload(t *testing.T) {
 			t.Fatalf("Authorization = %q", got)
 		}
 		var req struct {
-			AgentID string   `json:"agent_id"`
-			TaskID  string   `json:"task_id"`
-			Scope   []string `json:"scope"`
-			TTLSecs int      `json:"ttl_seconds"`
+			Agent     string   `json:"agent"`
+			Scope     []string `json:"scope"`
+			Perm      string   `json:"perm"`
+			TTLSecs   int      `json:"ttl_seconds"`
+			LabelHint string   `json:"label_hint"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("Decode: %v", err)
 		}
-		if req.AgentID != "deploy-agent" || req.TaskID != "task-123" {
-			t.Fatalf("unexpected request: %+v", req)
+		if req.Agent != "deploy-agent" {
+			t.Fatalf("agent = %q, want deploy-agent", req.Agent)
+		}
+		if req.Perm != "read" {
+			t.Fatalf("perm = %q, want read", req.Perm)
 		}
 		if req.TTLSecs != 3600 {
 			t.Fatalf("ttl_seconds = %d, want 3600", req.TTLSecs)
+		}
+		if req.LabelHint != "deploy-2026" {
+			t.Fatalf("label_hint = %q, want deploy-2026", req.LabelHint)
 		}
 		if len(req.Scope) != 2 || req.Scope[0] != "aws-prod" || req.Scope[1] != "db-prod/password" {
 			t.Fatalf("scope = %+v", req.Scope)
@@ -44,19 +51,28 @@ func TestIssueVaultTokenUsesManagementAuthAndPayload(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"token":      "vault_token",
-			"token_id":   "cap_123",
+			"grant_id":   "grt_123",
 			"expires_at": "2026-04-14T00:00:00Z",
+			"scope":      []string{"aws-prod", "db-prod/password"},
+			"perm":       "read",
+			"ttl":        3600,
 		})
 	}))
 	defer srv.Close()
 
 	c := New(srv.URL, "tenant-key")
-	resp, err := c.IssueVaultToken(context.Background(), "deploy-agent", "task-123", []string{"aws-prod", "db-prod/password"}, time.Hour)
+	resp, err := c.IssueVaultToken(context.Background(), "deploy-agent", []string{"aws-prod", "db-prod/password"}, "read", time.Hour, "deploy-2026")
 	if err != nil {
 		t.Fatalf("IssueVaultToken: %v", err)
 	}
-	if resp.Token != "vault_token" || resp.TokenID != "cap_123" {
+	if resp.Token != "vault_token" || resp.GrantID != "grt_123" {
 		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if resp.Perm != "read" || resp.TTL != 3600 {
+		t.Fatalf("unexpected shape: perm=%q ttl=%d", resp.Perm, resp.TTL)
+	}
+	if len(resp.Scope) != 2 {
+		t.Fatalf("scope = %+v", resp.Scope)
 	}
 }
 

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -142,6 +142,7 @@ func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request,
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 		TenantID:   tenantID,
 		EventType:  "secret.created",
+		Agent:      req.CreatedBy,
 		SecretName: req.Name,
 	})
 
@@ -212,6 +213,7 @@ func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request,
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 		TenantID:   tenantID,
 		EventType:  "secret.rotated",
+		Agent:      req.UpdatedBy,
 		SecretName: name,
 	})
 
@@ -220,6 +222,15 @@ func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request,
 }
 
 func (s *Server) handleVaultSecretDelete(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
+	var req struct {
+		DeletedBy string `json:"deleted_by"`
+	}
+	// Body is optional for DELETE.
+	_ = json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req)
+	if req.DeletedBy == "" {
+		req.DeletedBy = "api"
+	}
+
 	err := vs.DeleteSecret(r.Context(), tenantID, name)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
@@ -233,6 +244,7 @@ func (s *Server) handleVaultSecretDelete(w http.ResponseWriter, r *http.Request,
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 		TenantID:   tenantID,
 		EventType:  "secret.deleted",
+		Agent:      req.DeletedBy,
 		SecretName: name,
 	})
 
@@ -391,6 +403,7 @@ func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, 
 		TenantID:  tenantID,
 		EventType: "grant.revoked",
 		GrantID:   grantID,
+		Agent:     req.RevokedBy,
 	})
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -562,6 +562,7 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 			GrantID:    claims.GrantID,
 			Agent:      claims.Agent,
 			SecretName: secretName,
+			Adapter:    "api",
 			Detail:     map[string]string{"reason": "out_of_scope"},
 		})
 		// Return 404 to avoid leaking secret existence.
@@ -630,6 +631,7 @@ func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs
 			Agent:      claims.Agent,
 			SecretName: secretName,
 			FieldName:  fieldName,
+			Adapter:    "api",
 			Detail:     map[string]string{"reason": "out_of_scope"},
 		})
 		errJSON(w, http.StatusNotFound, "not found")

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -264,28 +264,31 @@ func (s *Server) handleVaultTokens(w http.ResponseWriter, r *http.Request, sub s
 		return
 	}
 
-	// DELETE /v1/vault/tokens/{token_id}
-	tokenID := strings.TrimPrefix(sub, "/")
+	// DELETE /v1/vault/tokens/{grant_id}
+	grantID := strings.TrimPrefix(sub, "/")
 	if r.Method == http.MethodDelete {
-		s.handleVaultTokenRevoke(w, r, vs, tenantID, tokenID)
+		s.handleVaultTokenRevoke(w, r, vs, tenantID, grantID)
 		return
 	}
 	errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
 }
 
 func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
+	// Request body matches spec §6 `vault grant`:
+	//   {agent, scope[], perm: "read"|"write", ttl_seconds, label_hint?}
 	var req struct {
-		AgentID string   `json:"agent_id"`
-		TaskID  string   `json:"task_id"`
-		Scope   []string `json:"scope"`
-		TTLSecs int      `json:"ttl_seconds"`
+		Agent     string   `json:"agent"`
+		Scope     []string `json:"scope"`
+		Perm      string   `json:"perm"`
+		TTLSecs   int      `json:"ttl_seconds"`
+		LabelHint string   `json:"label_hint"`
 	}
 	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
 		errJSON(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
-	if req.AgentID == "" {
-		errJSON(w, http.StatusBadRequest, "agent_id is required")
+	if req.Agent == "" {
+		errJSON(w, http.StatusBadRequest, "agent is required")
 		return
 	}
 	if len(req.Scope) == 0 {
@@ -296,35 +299,74 @@ func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, v
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	ttl := time.Duration(req.TTLSecs) * time.Second
-	if ttl <= 0 {
-		ttl = time.Hour // default 1 hour
+	perm := vault.Perm(req.Perm)
+	if perm != vault.PermRead && perm != vault.PermWrite {
+		errJSON(w, http.StatusBadRequest, "perm must be 'read' or 'write'")
+		return
 	}
+	// Spec §6: --ttl is required; reject zero / negative.
+	if req.TTLSecs <= 0 {
+		errJSON(w, http.StatusBadRequest, "ttl_seconds is required and must be positive")
+		return
+	}
+	ttl := time.Duration(req.TTLSecs) * time.Second
 
-	tokenStr, capToken, err := vs.IssueCapToken(r.Context(), tenantID, req.AgentID, req.TaskID, req.Scope, ttl)
+	issuer := requestIssuer(r)
+	tokenStr, capToken, err := vs.IssueCapToken(r.Context(), vault.IssueCapTokenParams{
+		TenantID:      tenantID,
+		Issuer:        issuer,
+		PrincipalType: vault.PrincipalDelegated,
+		Agent:         req.Agent,
+		Scope:         req.Scope,
+		Perm:          perm,
+		LabelHint:     req.LabelHint,
+		TTL:           ttl,
+	})
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to issue token")
+		errJSON(w, http.StatusInternalServerError, "failed to issue grant")
 		return
 	}
 
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 		TenantID:  tenantID,
-		EventType: "token.issued",
-		TokenID:   capToken.TokenID,
-		AgentID:   req.AgentID,
-		TaskID:    req.TaskID,
+		EventType: "grant.issued",
+		GrantID:   capToken.GrantID,
+		Agent:     req.Agent,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
+	// Response shape matches spec §6 line 133: {token, grant_id, expires_at, scope[], perm, ttl}
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"token":      tokenStr,
-		"token_id":   capToken.TokenID,
+		"grant_id":   capToken.GrantID,
 		"expires_at": capToken.ExpiresAt,
+		"scope":      capToken.Scope,
+		"perm":       string(capToken.Perm),
+		"ttl":        int(ttl / time.Second),
 	})
 }
 
-func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, tokenID string) {
+// requestIssuer derives the iss claim for grants issued on this request.
+// Uses the request's scheme+host; for production deployments behind a proxy,
+// the reverse proxy MUST set X-Forwarded-Proto / Host correctly.
+func requestIssuer(r *http.Request) string {
+	scheme := "https"
+	if r.TLS == nil {
+		if xfp := r.Header.Get("X-Forwarded-Proto"); xfp != "" {
+			scheme = xfp
+		} else {
+			scheme = "http"
+		}
+	}
+	host := r.Host
+	if xfh := r.Header.Get("X-Forwarded-Host"); xfh != "" {
+		host = xfh
+	}
+	return scheme + "://" + host
+}
+
+func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, grantID string) {
 	var req struct {
 		RevokedBy string `json:"revoked_by"`
 		Reason    string `json:"reason"`
@@ -335,20 +377,20 @@ func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, 
 		req.RevokedBy = "api"
 	}
 
-	err := vs.RevokeCapToken(r.Context(), tenantID, tokenID, req.RevokedBy, req.Reason)
+	err := vs.RevokeCapToken(r.Context(), tenantID, grantID, req.RevokedBy, req.Reason)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
-			errJSON(w, http.StatusNotFound, "token not found or already revoked")
+			errJSON(w, http.StatusNotFound, "grant not found or already revoked")
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, "failed to revoke token")
+		errJSON(w, http.StatusInternalServerError, "failed to revoke grant")
 		return
 	}
 
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 		TenantID:  tenantID,
-		EventType: "token.revoked",
-		TokenID:   tokenID,
+		EventType: "grant.revoked",
+		GrantID:   grantID,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
@@ -485,9 +527,8 @@ func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 		TenantID:  claims.TenantID,
 		EventType: "secret.list",
-		TokenID:   claims.TokenID,
-		AgentID:   claims.AgentID,
-		TaskID:    claims.TaskID,
+		GrantID:   claims.GrantID,
+		Agent:     claims.Agent,
 		Adapter:   "api",
 	})
 
@@ -505,8 +546,8 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 		_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 			TenantID:   claims.TenantID,
 			EventType:  "secret.denied",
-			TokenID:    claims.TokenID,
-			AgentID:    claims.AgentID,
+			GrantID:    claims.GrantID,
+			Agent:      claims.Agent,
 			SecretName: secretName,
 			Detail:     map[string]string{"reason": "out_of_scope"},
 		})
@@ -541,9 +582,8 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 		TenantID:   claims.TenantID,
 		EventType:  "secret.read",
-		TokenID:    claims.TokenID,
-		AgentID:    claims.AgentID,
-		TaskID:     claims.TaskID,
+		GrantID:    claims.GrantID,
+		Agent:      claims.Agent,
 		SecretName: secretName,
 		Adapter:    "api",
 	})
@@ -573,8 +613,8 @@ func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs
 		_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 			TenantID:   claims.TenantID,
 			EventType:  "secret.denied",
-			TokenID:    claims.TokenID,
-			AgentID:    claims.AgentID,
+			GrantID:    claims.GrantID,
+			Agent:      claims.Agent,
 			SecretName: secretName,
 			FieldName:  fieldName,
 			Detail:     map[string]string{"reason": "out_of_scope"},
@@ -596,9 +636,8 @@ func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 		TenantID:   claims.TenantID,
 		EventType:  "secret.read",
-		TokenID:    claims.TokenID,
-		AgentID:    claims.AgentID,
-		TaskID:     claims.TaskID,
+		GrantID:    claims.GrantID,
+		Agent:      claims.Agent,
 		SecretName: secretName,
 		FieldName:  fieldName,
 		Adapter:    "api",

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -486,12 +486,18 @@ func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub str
 
 	vs := vault.NewStore(scope.Backend.Store().DB(), s.vaultMK)
 
-	// Full 4-step verification: HMAC signature → TTL → DB revocation → claims.
+	// Full 5-step verification: HMAC signature → TTL → issuer match → DB revocation → claims.
 	// IMPORTANT: Do NOT write audit events before verification succeeds.
 	// The tenant_id comes from an unverified peek and could be forged;
 	// writing to tenant audit before proving token authenticity would let
 	// an attacker inject events into any tenant's audit log.
-	claims, err := vs.VerifyAndResolveCapToken(r.Context(), tenantID, raw)
+	//
+	// The expected issuer is derived from this request (spec Invariant #7):
+	// a token minted on server A for tenant T must not be accepted by server B
+	// for the same tenant. Derivation matches IssueCapToken's issuer derivation
+	// at handleVaultTokenIssue so a token re-presented to the same deployment
+	// always passes.
+	claims, err := vs.VerifyAndResolveCapToken(r.Context(), tenantID, requestIssuer(r), raw)
 	if err != nil {
 		// Log to server-level observability only — not tenant audit.
 		if strings.Contains(err.Error(), "expired") {

--- a/pkg/tenant/schema/vault.go
+++ b/pkg/tenant/schema/vault.go
@@ -3,6 +3,10 @@ package schema
 // VaultTiDBSchemaStatements returns the vault DDL statements in TiDB/MySQL
 // dialect. These are appended to the tenant init schema statement set for all
 // TiDB providers, including drive9-server schema dump-init-sql output.
+//
+// Schema shape follows spec 083aab8 §16: capability grants are identified by
+// grant_id (stable revocation handle), bind to a single agent + issuer +
+// principal_type + perm, and carry a scope list plus optional label_hint.
 func VaultTiDBSchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS vault_deks (
@@ -34,18 +38,21 @@ func VaultTiDBSchemaStatements() []string {
 		)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_tokens (
-			token_id      VARCHAR(64) PRIMARY KEY,
-			tenant_id     VARCHAR(64) NOT NULL,
-			agent_id      VARCHAR(255) NOT NULL,
-			task_id       VARCHAR(255),
-			scope_json    JSON NOT NULL,
-			issued_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-			expires_at    DATETIME(3) NOT NULL,
-			revoked_at    DATETIME(3),
-			revoked_by    VARCHAR(255),
-			revoke_reason VARCHAR(255),
+			grant_id       VARCHAR(64) PRIMARY KEY,
+			tenant_id      VARCHAR(64) NOT NULL,
+			issuer         VARCHAR(512) NOT NULL,
+			principal_type VARCHAR(16) NOT NULL,
+			agent          VARCHAR(255) NOT NULL,
+			scope_json     JSON NOT NULL,
+			perm           VARCHAR(16) NOT NULL,
+			label_hint     VARCHAR(255),
+			issued_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			expires_at     DATETIME(3) NOT NULL,
+			revoked_at     DATETIME(3),
+			revoked_by     VARCHAR(255),
+			revoke_reason  VARCHAR(255),
 			INDEX idx_vault_token_tenant (tenant_id),
-			INDEX idx_vault_token_agent (agent_id)
+			INDEX idx_vault_token_agent (agent)
 		)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_policies (
@@ -60,9 +67,8 @@ func VaultTiDBSchemaStatements() []string {
 			event_id     VARCHAR(64) PRIMARY KEY,
 			tenant_id    VARCHAR(64) NOT NULL,
 			event_type   VARCHAR(32) NOT NULL,
-			token_id     VARCHAR(64),
-			agent_id     VARCHAR(255),
-			task_id      VARCHAR(255),
+			grant_id     VARCHAR(64),
+			agent        VARCHAR(255),
 			secret_name  VARCHAR(255),
 			field_name   VARCHAR(255),
 			adapter      VARCHAR(16),

--- a/pkg/vault/crypto.go
+++ b/pkg/vault/crypto.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
@@ -160,14 +161,29 @@ func VerifyCapToken(csk []byte, raw string, now time.Time) (*CapTokenClaims, err
 		return nil, fmt.Errorf("invalid token signature")
 	}
 
-	// Decode claims.
+	// Decode claims. CapTokenClaims is a locked payload shape (spec §16);
+	// any extra field is either a malformed forgery or a silently-introduced
+	// payload from a newer signer we don't trust, so reject unknown fields.
 	payloadJSON, err := base64.RawURLEncoding.DecodeString(payloadB64)
 	if err != nil {
 		return nil, fmt.Errorf("decode payload: %w", err)
 	}
 	var claims CapTokenClaims
-	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(payloadJSON))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&claims); err != nil {
 		return nil, fmt.Errorf("unmarshal claims: %w", err)
+	}
+
+	// Enum fail-closed (spec §16): a forged payload carrying an unknown
+	// principal_type or perm must be rejected here, not silently propagated
+	// to downstream handlers / audit log writers that treat claims.Perm as
+	// a trusted string.
+	if claims.PrincipalType != PrincipalOwner && claims.PrincipalType != PrincipalDelegated {
+		return nil, fmt.Errorf("invalid principal_type")
+	}
+	if claims.Perm != PermRead && claims.Perm != PermWrite {
+		return nil, fmt.Errorf("invalid perm")
 	}
 
 	// Check TTL.

--- a/pkg/vault/crypto_test.go
+++ b/pkg/vault/crypto_test.go
@@ -103,14 +103,17 @@ func TestCapTokenSignVerify(t *testing.T) {
 	csk := mk.DeriveCSK("tenant-1")
 
 	claims := &CapTokenClaims{
-		TokenID:   "cap_test123",
-		TenantID:  "tenant-1",
-		AgentID:   "agent-1",
-		TaskID:    "task-1",
-		Scope:     []string{"aws-prod", "db-prod/password"},
-		IssuedAt:  time.Now().Unix(),
-		ExpiresAt: time.Now().Add(time.Hour).Unix(),
-		Nonce:     "deadbeef",
+		Issuer:        "https://drive9.example.com",
+		PrincipalType: PrincipalDelegated,
+		GrantID:       "grt_test123",
+		TenantID:      "tenant-1",
+		Agent:         "agent-1",
+		Scope:         []string{"aws-prod", "db-prod/password"},
+		Perm:          PermRead,
+		IssuedAt:      time.Now().Unix(),
+		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+		LabelHint:     "agent-1-aws-prod",
+		Nonce:         "deadbeef",
 	}
 
 	tokenStr, err := SignCapToken(csk, claims)
@@ -123,11 +126,23 @@ func TestCapTokenSignVerify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verify failed: %v", err)
 	}
-	if parsed.TokenID != claims.TokenID {
-		t.Fatalf("token_id mismatch: %s != %s", parsed.TokenID, claims.TokenID)
+	if parsed.GrantID != claims.GrantID {
+		t.Fatalf("grant_id mismatch: %s != %s", parsed.GrantID, claims.GrantID)
 	}
-	if parsed.AgentID != claims.AgentID {
-		t.Fatalf("agent_id mismatch")
+	if parsed.Agent != claims.Agent {
+		t.Fatalf("agent mismatch")
+	}
+	if parsed.Issuer != claims.Issuer {
+		t.Fatalf("iss mismatch: %s != %s", parsed.Issuer, claims.Issuer)
+	}
+	if parsed.PrincipalType != PrincipalDelegated {
+		t.Fatalf("principal_type mismatch: %s", parsed.PrincipalType)
+	}
+	if parsed.Perm != PermRead {
+		t.Fatalf("perm mismatch: %s", parsed.Perm)
+	}
+	if parsed.LabelHint != claims.LabelHint {
+		t.Fatalf("label_hint mismatch")
 	}
 	if len(parsed.Scope) != 2 {
 		t.Fatalf("scope length mismatch")
@@ -141,13 +156,16 @@ func TestCapTokenExpired(t *testing.T) {
 	csk := mk.DeriveCSK("tenant-1")
 
 	claims := &CapTokenClaims{
-		TokenID:   "cap_expired",
-		TenantID:  "tenant-1",
-		AgentID:   "agent-1",
-		Scope:     []string{"test"},
-		IssuedAt:  time.Now().Add(-2 * time.Hour).Unix(),
-		ExpiresAt: time.Now().Add(-1 * time.Hour).Unix(),
-		Nonce:     "abc",
+		Issuer:        "https://drive9.example.com",
+		PrincipalType: PrincipalDelegated,
+		GrantID:       "grt_expired",
+		TenantID:      "tenant-1",
+		Agent:         "agent-1",
+		Scope:         []string{"test"},
+		Perm:          PermRead,
+		IssuedAt:      time.Now().Add(-2 * time.Hour).Unix(),
+		ExpiresAt:     time.Now().Add(-1 * time.Hour).Unix(),
+		Nonce:         "abc",
 	}
 
 	tokenStr, _ := SignCapToken(csk, claims)
@@ -165,13 +183,16 @@ func TestCapTokenBadSignature(t *testing.T) {
 	csk := mk.DeriveCSK("tenant-1")
 
 	claims := &CapTokenClaims{
-		TokenID:   "cap_badsig",
-		TenantID:  "tenant-1",
-		AgentID:   "agent-1",
-		Scope:     []string{"test"},
-		IssuedAt:  time.Now().Unix(),
-		ExpiresAt: time.Now().Add(time.Hour).Unix(),
-		Nonce:     "xyz",
+		Issuer:        "https://drive9.example.com",
+		PrincipalType: PrincipalDelegated,
+		GrantID:       "grt_badsig",
+		TenantID:      "tenant-1",
+		Agent:         "agent-1",
+		Scope:         []string{"test"},
+		Perm:          PermRead,
+		IssuedAt:      time.Now().Unix(),
+		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+		Nonce:         "xyz",
 	}
 
 	tokenStr, _ := SignCapToken(csk, claims)
@@ -191,13 +212,16 @@ func TestPeekCapTokenTenantID(t *testing.T) {
 	csk := mk.DeriveCSK("tenant-42")
 
 	claims := &CapTokenClaims{
-		TokenID:   "cap_test",
-		TenantID:  "tenant-42",
-		AgentID:   "agent-1",
-		Scope:     []string{"secret-a"},
-		IssuedAt:  time.Now().Unix(),
-		ExpiresAt: time.Now().Add(time.Hour).Unix(),
-		Nonce:     "abc",
+		Issuer:        "https://drive9.example.com",
+		PrincipalType: PrincipalDelegated,
+		GrantID:       "grt_peek",
+		TenantID:      "tenant-42",
+		Agent:         "agent-1",
+		Scope:         []string{"secret-a"},
+		Perm:          PermRead,
+		IssuedAt:      time.Now().Unix(),
+		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+		Nonce:         "abc",
 	}
 	tokenStr, _ := SignCapToken(csk, claims)
 

--- a/pkg/vault/crypto_test.go
+++ b/pkg/vault/crypto_test.go
@@ -1,7 +1,10 @@
 package vault
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"testing"
 	"time"
 )
@@ -250,5 +253,62 @@ func TestDeriveCSKDifferentTenants(t *testing.T) {
 
 	if string(csk1) == string(csk2) {
 		t.Fatal("different tenants should have different CSKs")
+	}
+}
+
+// TestVerifyCapToken_RejectsUnknownFields covers the locked-payload invariant:
+// a forged payload carrying a silently-introduced field must be rejected even
+// if the HMAC matches, to prevent attackers (or a compromised signer) from
+// smuggling fields a future verifier might start honoring.
+func TestVerifyCapToken_RejectsUnknownFields(t *testing.T) {
+	key := make([]byte, 32)
+	_, _ = rand.Read(key)
+	mk, _ := NewMasterKey(key)
+	csk := mk.DeriveCSK("tenant-unk")
+
+	// Forge a payload with a valid MAC but an extra `admin` field the struct
+	// doesn't declare. We do the MAC ourselves since SignCapToken marshals
+	// CapTokenClaims directly and can't emit unknown fields.
+	forgedPayload := []byte(`{"iss":"https://drive9.example.com","principal_type":"delegated","grant_id":"grt_x","tenant_id":"tenant-unk","agent":"a","scope":["s"],"perm":"read","iat":1,"exp":9999999999,"nonce":"n","admin":true}`)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(forgedPayload)
+	mac := hmac.New(sha256.New, csk)
+	mac.Write([]byte(payloadB64))
+	sigB64 := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	tokenStr := capTokenPrefix + payloadB64 + "." + sigB64
+
+	_, err := VerifyCapToken(csk, tokenStr, time.Now())
+	if err == nil {
+		t.Fatal("expected rejection of payload with unknown field, got nil")
+	}
+}
+
+// TestVerifyCapToken_RejectsBadEnums covers fail-closed enum validation on the
+// verify path: a forged payload with an out-of-spec principal_type or perm
+// must not propagate to downstream callers (handlers / audit writers) that
+// treat claims.Perm as a trusted string.
+func TestVerifyCapToken_RejectsBadEnums(t *testing.T) {
+	key := make([]byte, 32)
+	_, _ = rand.Read(key)
+	mk, _ := NewMasterKey(key)
+	csk := mk.DeriveCSK("tenant-enum")
+
+	forgeSigned := func(payload string) string {
+		payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+		mac := hmac.New(sha256.New, csk)
+		mac.Write([]byte(payloadB64))
+		sigB64 := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+		return capTokenPrefix + payloadB64 + "." + sigB64
+	}
+
+	// Bad principal_type.
+	tokBadPrincipal := forgeSigned(`{"iss":"https://drive9.example.com","principal_type":"superuser","grant_id":"grt_x","tenant_id":"tenant-enum","agent":"a","scope":["s"],"perm":"read","iat":1,"exp":9999999999,"nonce":"n"}`)
+	if _, err := VerifyCapToken(csk, tokBadPrincipal, time.Now()); err == nil {
+		t.Fatal("expected rejection of bad principal_type, got nil")
+	}
+
+	// Bad perm.
+	tokBadPerm := forgeSigned(`{"iss":"https://drive9.example.com","principal_type":"delegated","grant_id":"grt_x","tenant_id":"tenant-enum","agent":"a","scope":["s"],"perm":"admin","iat":1,"exp":9999999999,"nonce":"n"}`)
+	if _, err := VerifyCapToken(csk, tokBadPerm, time.Now()); err == nil {
+		t.Fatal("expected rejection of bad perm, got nil")
 	}
 }

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -392,13 +392,24 @@ func (s *Store) IssueCapToken(ctx context.Context, p IssueCapTokenParams) (strin
 	}, nil
 }
 
-// VerifyAndResolveCapToken performs the full 4-step verification flow.
-// 1. HMAC signature check  2. TTL check  3. DB revocation check  4. Returns claims for scope check
-func (s *Store) VerifyAndResolveCapToken(ctx context.Context, tenantID, raw string) (*CapTokenClaims, error) {
+// VerifyAndResolveCapToken performs the full 5-step verification flow (spec Invariant #7).
+// 1. HMAC signature check  2. TTL check  3. Issuer match check  4. DB revocation check  5. Returns claims for scope check
+//
+// expectedIssuer is the issuer URL this server would mint under right now (derived from
+// the incoming request at the call site). Tokens carrying a different iss claim —
+// e.g. minted for a sibling deployment of the same tenant — are rejected. Prevents
+// cross-server token replay within a tenant.
+func (s *Store) VerifyAndResolveCapToken(ctx context.Context, tenantID, expectedIssuer, raw string) (*CapTokenClaims, error) {
 	csk := s.mk.DeriveCSK(tenantID)
 	claims, err := VerifyCapToken(csk, raw, time.Now())
 	if err != nil {
 		return nil, err
+	}
+
+	// Issuer match (spec Invariant #7). Empty expectedIssuer disables the check
+	// for call paths that cannot derive a canonical server URL (e.g. batch jobs).
+	if expectedIssuer != "" && claims.Issuer != expectedIssuer {
+		return nil, fmt.Errorf("issuer mismatch")
 	}
 
 	// DB revocation check — scoped to tenant for isolation.

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -322,13 +322,26 @@ func (s *Store) ReadSecretField(ctx context.Context, tenantID, name, fieldName s
 	return fe.Decrypt(ciphertext, nonce)
 }
 
-// ---- Capability Token ----
+// ---- Capability Grant ----
 
-// IssueCapToken creates a capability token and persists its server-side state.
-func (s *Store) IssueCapToken(ctx context.Context, tenantID, agentID, taskID string, scope []string, ttl time.Duration) (string, *CapToken, error) {
-	tokenID := "cap_" + uuid.NewString()
+// IssueCapTokenParams holds the parameters for issuing a capability grant (spec §6).
+type IssueCapTokenParams struct {
+	TenantID      string
+	Issuer        string        // JWT iss claim — the server URL the delegatee will contact
+	PrincipalType PrincipalType // owner or delegated; vault grant always emits delegated
+	Agent         string
+	Scope         []string
+	Perm          Perm
+	LabelHint     string
+	TTL           time.Duration
+}
+
+// IssueCapToken creates a capability grant and persists its server-side row.
+// Returns the signed JWT bearer string and the CapToken row.
+func (s *Store) IssueCapToken(ctx context.Context, p IssueCapTokenParams) (string, *CapToken, error) {
+	grantID := "grt_" + uuid.NewString()[:8]
 	now := time.Now()
-	expiresAt := now.Add(ttl)
+	expiresAt := now.Add(p.TTL)
 
 	nonce, err := GenerateNonce()
 	if err != nil {
@@ -336,40 +349,46 @@ func (s *Store) IssueCapToken(ctx context.Context, tenantID, agentID, taskID str
 	}
 
 	claims := &CapTokenClaims{
-		TokenID:   tokenID,
-		TenantID:  tenantID,
-		AgentID:   agentID,
-		TaskID:    taskID,
-		Scope:     scope,
-		IssuedAt:  now.Unix(),
-		ExpiresAt: expiresAt.Unix(),
-		Nonce:     nonce,
+		Issuer:        p.Issuer,
+		PrincipalType: p.PrincipalType,
+		GrantID:       grantID,
+		TenantID:      p.TenantID,
+		Agent:         p.Agent,
+		Scope:         p.Scope,
+		Perm:          p.Perm,
+		IssuedAt:      now.Unix(),
+		ExpiresAt:     expiresAt.Unix(),
+		LabelHint:     p.LabelHint,
+		Nonce:         nonce,
 	}
 
-	csk := s.mk.DeriveCSK(tenantID)
+	csk := s.mk.DeriveCSK(p.TenantID)
 	tokenStr, err := SignCapToken(csk, claims)
 	if err != nil {
 		return "", nil, err
 	}
 
-	scopeJSON, _ := json.Marshal(scope)
+	scopeJSON, _ := json.Marshal(p.Scope)
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO vault_tokens (token_id, tenant_id, agent_id, task_id, scope_json, issued_at, expires_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		tokenID, tenantID, agentID, taskID, scopeJSON, now, expiresAt,
+		`INSERT INTO vault_tokens (grant_id, tenant_id, issuer, principal_type, agent, scope_json, perm, label_hint, issued_at, expires_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		grantID, p.TenantID, p.Issuer, string(p.PrincipalType), p.Agent, scopeJSON, string(p.Perm), p.LabelHint, now, expiresAt,
 	)
 	if err != nil {
-		return "", nil, fmt.Errorf("insert token: %w", err)
+		return "", nil, fmt.Errorf("insert grant: %w", err)
 	}
 
 	return tokenStr, &CapToken{
-		TokenID:   tokenID,
-		TenantID:  tenantID,
-		AgentID:   agentID,
-		TaskID:    taskID,
-		Scope:     scope,
-		IssuedAt:  now,
-		ExpiresAt: expiresAt,
+		GrantID:       grantID,
+		TenantID:      p.TenantID,
+		Issuer:        p.Issuer,
+		PrincipalType: p.PrincipalType,
+		Agent:         p.Agent,
+		Scope:         p.Scope,
+		Perm:          p.Perm,
+		LabelHint:     p.LabelHint,
+		IssuedAt:      now,
+		ExpiresAt:     expiresAt,
 	}, nil
 }
 
@@ -385,30 +404,30 @@ func (s *Store) VerifyAndResolveCapToken(ctx context.Context, tenantID, raw stri
 	// DB revocation check — scoped to tenant for isolation.
 	var revokedAt *time.Time
 	err = s.db.QueryRowContext(ctx,
-		`SELECT revoked_at FROM vault_tokens WHERE tenant_id = ? AND token_id = ?`,
-		tenantID, claims.TokenID,
+		`SELECT revoked_at FROM vault_tokens WHERE tenant_id = ? AND grant_id = ?`,
+		tenantID, claims.GrantID,
 	).Scan(&revokedAt)
 	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("token not found")
+		return nil, fmt.Errorf("grant not found")
 	}
 	if err != nil {
-		return nil, fmt.Errorf("query token: %w", err)
+		return nil, fmt.Errorf("query grant: %w", err)
 	}
 	if revokedAt != nil {
-		return nil, fmt.Errorf("token revoked")
+		return nil, fmt.Errorf("grant revoked")
 	}
 
 	return claims, nil
 }
 
-// RevokeCapToken sets revoked_at on a capability token.
+// RevokeCapToken sets revoked_at on a capability grant (spec §8).
 // tenantID is required to enforce tenant isolation.
-func (s *Store) RevokeCapToken(ctx context.Context, tenantID, tokenID, revokedBy, reason string) error {
+func (s *Store) RevokeCapToken(ctx context.Context, tenantID, grantID, revokedBy, reason string) error {
 	now := time.Now()
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE vault_tokens SET revoked_at = ?, revoked_by = ?, revoke_reason = ?
-		 WHERE tenant_id = ? AND token_id = ? AND revoked_at IS NULL`,
-		now, revokedBy, reason, tenantID, tokenID,
+		 WHERE tenant_id = ? AND grant_id = ? AND revoked_at IS NULL`,
+		now, revokedBy, reason, tenantID, grantID,
 	)
 	if err != nil {
 		return err
@@ -435,10 +454,10 @@ func (s *Store) WriteAuditEvent(ctx context.Context, event *AuditEvent) error {
 		detailJSON, _ = json.Marshal(event.Detail)
 	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO vault_audit_log (event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		event.EventID, event.TenantID, event.EventType, event.TokenID, event.AgentID,
-		event.TaskID, event.SecretName, event.FieldName, event.Adapter, detailJSON, event.Timestamp,
+		`INSERT INTO vault_audit_log (event_id, tenant_id, event_type, grant_id, agent, secret_name, field_name, adapter, detail_json, timestamp)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		event.EventID, event.TenantID, event.EventType, event.GrantID, event.Agent,
+		event.SecretName, event.FieldName, event.Adapter, detailJSON, event.Timestamp,
 	)
 	return err
 }
@@ -449,11 +468,11 @@ func (s *Store) QueryAuditLog(ctx context.Context, tenantID string, secretName s
 	var args []any
 
 	if secretName != "" {
-		query = `SELECT event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp
+		query = `SELECT event_id, tenant_id, event_type, grant_id, agent, secret_name, field_name, adapter, detail_json, timestamp
 			FROM vault_audit_log WHERE tenant_id = ? AND secret_name = ? ORDER BY timestamp DESC LIMIT ?`
 		args = []any{tenantID, secretName, limit}
 	} else {
-		query = `SELECT event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp
+		query = `SELECT event_id, tenant_id, event_type, grant_id, agent, secret_name, field_name, adapter, detail_json, timestamp
 			FROM vault_audit_log WHERE tenant_id = ? ORDER BY timestamp DESC LIMIT ?`
 		args = []any{tenantID, limit}
 	}
@@ -468,10 +487,13 @@ func (s *Store) QueryAuditLog(ctx context.Context, tenantID string, secretName s
 	for rows.Next() {
 		var ev AuditEvent
 		var detailJSON []byte
-		if err := rows.Scan(&ev.EventID, &ev.TenantID, &ev.EventType, &ev.TokenID, &ev.AgentID,
-			&ev.TaskID, &ev.SecretName, &ev.FieldName, &ev.Adapter, &detailJSON, &ev.Timestamp); err != nil {
+		var grantID, agent sql.NullString
+		if err := rows.Scan(&ev.EventID, &ev.TenantID, &ev.EventType, &grantID, &agent,
+			&ev.SecretName, &ev.FieldName, &ev.Adapter, &detailJSON, &ev.Timestamp); err != nil {
 			return nil, err
 		}
+		ev.GrantID = grantID.String
+		ev.Agent = agent.String
 		if detailJSON != nil {
 			_ = json.Unmarshal(detailJSON, &ev.Detail)
 		}

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -156,12 +156,24 @@ func TestStoreCapTokenIssueRevokeVerify(t *testing.T) {
 	ctx := context.Background()
 	tenantID := "tenant-token"
 
-	tokenStr, capToken, err := s.IssueCapToken(ctx, tenantID, "agent-1", "task-1", []string{"secret-a"}, time.Hour)
+	tokenStr, capToken, err := s.IssueCapToken(ctx, IssueCapTokenParams{
+		TenantID:      tenantID,
+		Issuer:        "https://drive9.example.com",
+		PrincipalType: PrincipalDelegated,
+		Agent:         "agent-1",
+		Scope:         []string{"secret-a"},
+		Perm:          PermRead,
+		LabelHint:     "agent-1-secret-a",
+		TTL:           time.Hour,
+	})
 	if err != nil {
 		t.Fatalf("IssueCapToken: %v", err)
 	}
-	if tokenStr == "" || capToken.TokenID == "" {
+	if tokenStr == "" || capToken.GrantID == "" {
 		t.Fatal("empty token")
+	}
+	if capToken.Perm != PermRead {
+		t.Fatalf("perm not set: %s", capToken.Perm)
 	}
 
 	// Verify should succeed.
@@ -169,12 +181,15 @@ func TestStoreCapTokenIssueRevokeVerify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("VerifyAndResolveCapToken: %v", err)
 	}
-	if resolved.TokenID != capToken.TokenID {
-		t.Fatalf("token ID mismatch: %s != %s", resolved.TokenID, capToken.TokenID)
+	if resolved.GrantID != capToken.GrantID {
+		t.Fatalf("grant ID mismatch: %s != %s", resolved.GrantID, capToken.GrantID)
+	}
+	if resolved.Issuer != "https://drive9.example.com" {
+		t.Fatalf("issuer mismatch: %s", resolved.Issuer)
 	}
 
 	// Revoke.
-	if err := s.RevokeCapToken(ctx, tenantID, capToken.TokenID, "admin", "test revoke"); err != nil {
+	if err := s.RevokeCapToken(ctx, tenantID, capToken.GrantID, "admin", "test revoke"); err != nil {
 		t.Fatalf("RevokeCapToken: %v", err)
 	}
 
@@ -185,7 +200,7 @@ func TestStoreCapTokenIssueRevokeVerify(t *testing.T) {
 	}
 
 	// Double revoke should fail.
-	if err := s.RevokeCapToken(ctx, tenantID, capToken.TokenID, "admin", "again"); err != ErrNotFound {
+	if err := s.RevokeCapToken(ctx, tenantID, capToken.GrantID, "admin", "again"); err != ErrNotFound {
 		t.Fatalf("expected ErrNotFound for double revoke, got: %v", err)
 	}
 }
@@ -199,7 +214,7 @@ func TestStoreAuditWriteQuery(t *testing.T) {
 		EventID:    "evt-1",
 		TenantID:   tenantID,
 		EventType:  "secret.read",
-		AgentID:    "agent-1",
+		Agent:      "agent-1",
 		SecretName: "db-prod",
 		FieldName:  "password",
 		Adapter:    "env",

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"context"
 	"crypto/rand"
+	"strings"
 	"testing"
 	"time"
 )
@@ -176,8 +177,8 @@ func TestStoreCapTokenIssueRevokeVerify(t *testing.T) {
 		t.Fatalf("perm not set: %s", capToken.Perm)
 	}
 
-	// Verify should succeed.
-	resolved, err := s.VerifyAndResolveCapToken(ctx, tenantID, tokenStr)
+	// Verify should succeed when expected issuer matches.
+	resolved, err := s.VerifyAndResolveCapToken(ctx, tenantID, "https://drive9.example.com", tokenStr)
 	if err != nil {
 		t.Fatalf("VerifyAndResolveCapToken: %v", err)
 	}
@@ -194,7 +195,7 @@ func TestStoreCapTokenIssueRevokeVerify(t *testing.T) {
 	}
 
 	// Verify after revoke should fail.
-	_, err = s.VerifyAndResolveCapToken(ctx, tenantID, tokenStr)
+	_, err = s.VerifyAndResolveCapToken(ctx, tenantID, "https://drive9.example.com", tokenStr)
 	if err == nil {
 		t.Fatal("expected error for revoked token")
 	}
@@ -250,5 +251,48 @@ func TestStoreAuditWriteQuery(t *testing.T) {
 	}
 	if len(events3) != 0 {
 		t.Fatalf("expected 0 events for nonexistent, got %d", len(events3))
+	}
+}
+
+// TestVerifyAndResolveCapToken_RejectsCrossIssuer covers spec Invariant #7:
+// a token minted by server A (iss=A) presented to server B (expecting iss=B)
+// must be rejected even though HMAC, TTL, and DB revocation checks all pass
+// (CSK derives from tenant MK and is identical across both servers).
+func TestVerifyAndResolveCapToken_RejectsCrossIssuer(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	tenantID := "tenant-iss"
+
+	tokenStr, _, err := s.IssueCapToken(ctx, IssueCapTokenParams{
+		TenantID:      tenantID,
+		Issuer:        "https://server-a.drive9.example.com",
+		PrincipalType: PrincipalDelegated,
+		Agent:         "agent-iss",
+		Scope:         []string{"secret-a"},
+		Perm:          PermRead,
+		TTL:           time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("IssueCapToken: %v", err)
+	}
+
+	// Same server URL: accept.
+	if _, err := s.VerifyAndResolveCapToken(ctx, tenantID, "https://server-a.drive9.example.com", tokenStr); err != nil {
+		t.Fatalf("same-issuer verify should succeed: %v", err)
+	}
+
+	// Sibling server URL: reject with issuer-mismatch error.
+	_, err = s.VerifyAndResolveCapToken(ctx, tenantID, "https://server-b.drive9.example.com", tokenStr)
+	if err == nil {
+		t.Fatal("expected issuer mismatch rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "issuer mismatch") {
+		t.Fatalf("expected 'issuer mismatch' error, got: %v", err)
+	}
+
+	// Empty expected issuer: backward-compat path for call sites that cannot derive
+	// a canonical URL (batch jobs). Must still accept the token (other checks still run).
+	if _, err := s.VerifyAndResolveCapToken(ctx, tenantID, "", tokenStr); err != nil {
+		t.Fatalf("empty-expected-issuer verify should succeed: %v", err)
 	}
 }

--- a/pkg/vault/types.go
+++ b/pkg/vault/types.go
@@ -14,6 +14,23 @@ const (
 	SecretTypeTLSCert        SecretType = "tls_cert"
 )
 
+// PrincipalType is the kind of principal bound to a credential (spec §16).
+// "owner" credentials come from ctx add --api-key; "delegated" from vault grant.
+type PrincipalType string
+
+const (
+	PrincipalOwner     PrincipalType = "owner"
+	PrincipalDelegated PrincipalType = "delegated"
+)
+
+// Perm is the permission level carried by a delegated grant (spec §6).
+type Perm string
+
+const (
+	PermRead  Perm = "read"
+	PermWrite Perm = "write"
+)
+
 // Secret is the metadata for a stored secret (no plaintext values).
 type Secret struct {
 	SecretID   string     `json:"secret_id"`
@@ -35,45 +52,52 @@ type SecretField struct {
 	Nonce          []byte `json:"-"`
 }
 
-// CapToken is the server-side state for a capability token.
+// CapToken is the server-side row for a capability grant (spec §16).
+// GrantID is the stable identifier used by `vault revoke grt_...`.
 type CapToken struct {
-	TokenID     string     `json:"token_id"`
-	TenantID    string     `json:"tenant_id"`
-	AgentID     string     `json:"agent_id"`
-	TaskID      string     `json:"task_id,omitempty"`
-	Scope       []string   `json:"scope"`
-	IssuedAt    time.Time  `json:"issued_at"`
-	ExpiresAt   time.Time  `json:"expires_at"`
-	RevokedAt   *time.Time `json:"revoked_at,omitempty"`
-	RevokedBy   string     `json:"revoked_by,omitempty"`
-	RevokeReason string    `json:"revoke_reason,omitempty"`
+	GrantID       string        `json:"grant_id"`
+	TenantID      string        `json:"tenant_id"`
+	Issuer        string        `json:"iss"`
+	PrincipalType PrincipalType `json:"principal_type"`
+	Agent         string        `json:"agent"`
+	Scope         []string      `json:"scope"`
+	Perm          Perm          `json:"perm"`
+	LabelHint     string        `json:"label_hint,omitempty"`
+	IssuedAt      time.Time     `json:"issued_at"`
+	ExpiresAt     time.Time     `json:"expires_at"`
+	RevokedAt     *time.Time    `json:"revoked_at,omitempty"`
+	RevokedBy     string        `json:"revoked_by,omitempty"`
+	RevokeReason  string        `json:"revoke_reason,omitempty"`
 }
 
-// CapTokenClaims is the payload signed into the bearer token.
+// CapTokenClaims is the signed JWT-style payload (spec §16).
+// Wire shape is fixed by spec; JSON tags MUST match exactly.
 type CapTokenClaims struct {
-	TokenID   string   `json:"token_id"`
-	TenantID  string   `json:"tenant_id"`
-	AgentID   string   `json:"agent_id"`
-	TaskID    string   `json:"task_id,omitempty"`
-	Scope     []string `json:"scope"`
-	IssuedAt  int64    `json:"iat"`
-	ExpiresAt int64    `json:"exp"`
-	Nonce     string   `json:"nonce"`
+	Issuer        string        `json:"iss"`
+	PrincipalType PrincipalType `json:"principal_type"`
+	GrantID       string        `json:"grant_id"`
+	TenantID      string        `json:"tenant_id"`
+	Agent         string        `json:"agent"`
+	Scope         []string      `json:"scope"`
+	Perm          Perm          `json:"perm"`
+	IssuedAt      int64         `json:"iat"`
+	ExpiresAt     int64         `json:"exp"`
+	LabelHint     string        `json:"label_hint,omitempty"`
+	Nonce         string        `json:"nonce"`
 }
 
 // AuditEvent is an append-only audit log entry.
 type AuditEvent struct {
-	EventID    string     `json:"event_id"`
-	TenantID   string     `json:"tenant_id"`
-	EventType  string     `json:"event_type"`
-	TokenID    string     `json:"token_id,omitempty"`
-	AgentID    string     `json:"agent_id,omitempty"`
-	TaskID     string     `json:"task_id,omitempty"`
-	SecretName string     `json:"secret_name,omitempty"`
-	FieldName  string     `json:"field_name,omitempty"`
-	Adapter    string     `json:"adapter,omitempty"`
-	Detail     any        `json:"detail,omitempty"`
-	Timestamp  time.Time  `json:"timestamp"`
+	EventID    string    `json:"event_id"`
+	TenantID   string    `json:"tenant_id"`
+	EventType  string    `json:"event_type"`
+	GrantID    string    `json:"grant_id,omitempty"`
+	Agent      string    `json:"agent,omitempty"`
+	SecretName string    `json:"secret_name,omitempty"`
+	FieldName  string    `json:"field_name,omitempty"`
+	Adapter    string    `json:"adapter,omitempty"`
+	Detail     any       `json:"detail,omitempty"`
+	Timestamp  time.Time `json:"timestamp"`
 }
 
 // TenantDEK holds the wrapped (encrypted) data encryption key for a tenant.


### PR DESCRIPTION
## Status — terminal tip at `39c5836` (scope-reduced)

Per release-scope directive from @4idxta4 (2026-04-19, msg `000002ff`), this PR is scope-reduced to **Lane A + Lane B wire-shape convergence + B5 (P-ISS-1) fix + PR-#273 borrow hardenings** of spec `083aab8`. Lane C (FUSE F8), Lane D (F3 / F14 / §11 errno), B3 (five-verb CLI dispatch), and B4 (pass-criteria tests beyond `TestF13`) are tracked in follow-up issues and ship in follow-up PR(s).

Reviewer-1 (@adversary-1) APPROVED `898e8c6` under reduced scope. The new tip `39c5836` adds two verify-path hardenings borrowed from parallel PR #273 — scoped to the verify path only, no wire / SDK / client / CLI change from `898e8c6`. Reviewer-1 delta re-review requested.

## Wire contract (verbatim, spec 083aab8 line 133)

Request  = `{agent, scope[], perm, ttl_seconds, label_hint?}`
Response = `{token, grant_id, expires_at, scope[], perm, ttl}`
Audit event (§16) = `{event_id, event_type, timestamp, grant_id, agent, secret_name, field_name, adapter, detail}`

`token_id / agent_id / task_id` are gone everywhere in the vault reshape zone.

## Convergence SHAs on `dev1/vault-end-state-impl`

| SHA | Scope | Evidence |
| --- | --- | --- |
| `037e6c4` | Lane A (ctx control plane) — untouched | previously landed |
| `c2f856b` | Lane B data layer: `pkg/vault/*`, `pkg/server/vault.go`, `pkg/tenant/schema/vault.go` | `go test ./...` green across 22 packages |
| `2573849` | Lane B client + CLI reshape: `pkg/client/vault.go`, `cmd/drive9/cli/secret.go`, regression tests | `TestIssueVaultTokenUsesManagementAuthAndPayload`, `TestSecretGrantPrintsTokenMetadata` assert new shape |
| `8bdc872` | A2-F1 + A4-F1 + A4-F2 audit hygiene: `Agent:` on `secret.created / secret.rotated / secret.deleted / grant.revoked`, `Adapter:"api"` on both `secret.denied` sites, optional `{deleted_by}` body | control-plane audit actor attribution now spec-compliant |
| `61dadf9` | `clients/drive9-rs` reshape | 10/10 cargo tests incl. `test_issue_vault_token_wire_shape` + `test_audit_event_wire_shape` |
| `a916020` | `clients/drive9-py` reshape | 47/47 pytest incl. `test_issue_vault_token_wire_shape` + `test_audit_event_wire_shape` |
| `f63a12b` | `clients/drive9-js` reshape | 16/16 vitest incl. `issueVaultToken wire shape (spec 083aab8 line 133)` + `audit event wire shape (spec §16)` with `@ts-expect-error` markers proving legacy fields removed at the type level |
| `898e8c6` | B5 fix — server-side iss re-validation (spec Invariant #7) | `TestVerifyAndResolveCapToken_RejectsCrossIssuer` covers same-issuer accept / sibling-issuer reject / empty-expected fallback; full `go test ./...` green across 22 packages |
| `39c5836` | **PR-#273 borrow: `VerifyCapToken` hardenings** — **terminal tip** | `TestVerifyCapToken_RejectsUnknownFields` + `TestVerifyCapToken_RejectsBadEnums`; full `go test ./...` green across 22 packages |

Each SDK carries **at least one native test that asserts the new wire shape** (not a mechanical rename with smoke tests) — per reviewer-2 pin `000002c8`.

## B5 fix detail (spec Invariant #7)

`pkg/vault/store.go:VerifyAndResolveCapToken` was doing HMAC + TTL + DB revocation + tenant isolation, but not comparing `claims.Issuer` against the server's own canonical URL. A token minted on server A for tenant T was accepted by server B for the same tenant, because the CSK derives from the tenant MK and is identical on both servers.

Fix at `898e8c6`:
- Signature gains `expectedIssuer string` parameter. Mismatch → `"issuer mismatch"` error.
- Empty `expectedIssuer` disables the check (call paths that cannot derive a canonical URL, e.g. batch jobs). Current request-time path at `pkg/server/vault.go:handleVaultRead` always supplies `requestIssuer(r)`, which matches the derivation used at issue-time in `handleVaultTokenIssue`.
- Test `TestVerifyAndResolveCapToken_RejectsCrossIssuer` at `pkg/vault/store_test.go:261` covers all three cases (same-issuer accept, sibling-issuer reject, empty-expected fallback).

Scoped narrowly — no other call sites of `VerifyAndResolveCapToken` exist in the codebase.

## Cross-borrow from parallel PR #273 (at `39c5836`)

Per @4idxta4's directive to cross-reference PR #273 (parallel vault end-state rollout, dev1/vault-impl-pr-a-jwt-server, additive-coexistence strategy), two verify-path hardenings picked up. Both are scoped to `pkg/vault/crypto.go:VerifyCapToken` — no wire change, no SDK change, no client/CLI change relative to `898e8c6`.

1. **`DisallowUnknownFields()` on payload unmarshal.** `CapTokenClaims` is a locked payload shape (spec §16); a forged payload carrying an extra field must be rejected even if the HMAC matches. Test: `TestVerifyCapToken_RejectsUnknownFields` at `pkg/vault/crypto_test.go:257`.
2. **Enum fail-closed on `principal_type` and `perm` inside Verify.** Today a forged payload with `perm:"admin"` passes Verify and propagates into `claims.Perm` which flows into audit records (`string(claims.Perm)`) and downstream string compares. Moving enum validation into Verify itself prevents non-conforming values from ever reaching handler code. Test: `TestVerifyCapToken_RejectsBadEnums` at `pkg/vault/crypto_test.go:282`.

**Not cross-borrowed (decided explicitly, listed for reviewer transparency):**
- JWT header + header-aware MAC — PR #273's `vt_` surface owns that wire shape and the legacy cap-token surface is deleted in PR-E per that rollout's removal contract; changing cap-token wire here would break the 3 SDK SHAs and the client/CLI SHAs reviewer-1 already APPROVED.
- `MaxGrantTTL` hard cap at store boundary — policy choice, not spec-mandated; would break batch-job callers that mint >24h tokens.
- ±60s clock skew leeway on TTL — behavior-change on verify that relaxes TTL enforcement; out-of-scope for a borrow-only follow-up.
- `DRIVE9_VAULT_ISSUER_URL` config-time issuer binding — our request-time `requestIssuer(r)` derivation at `898e8c6` is equally-valid architecturally and already APPROVED; swapping modes late would invalidate that review without a security gain.
- `validateClaimsForSign` / `validateClaimsForVerify` split, `nullableString` NULL helper, error-prefix 400/500 split — readability/cosmetic, no behavior value for this PR's scope.

## Client↔server wire agreement at the tip

`pkg/client/vault.go` struct JSON tags (`token`, `grant_id`, `expires_at`, `scope`, `perm`, `ttl`) match the byte-for-byte server emission in `pkg/server/vault.go:352-358`. `git grep -n -E 'TokenID|AgentID|TaskID|token_id|agent_id|task_id' -- 'pkg/vault/*.go' 'pkg/server/vault*.go' 'pkg/client/vault*.go' 'cmd/drive9/cli/secret*.go' 'pkg/tenant/schema/vault.go'` returns **zero hits** at `898e8c6`.

Five independent implementations now assert on the same wire shape (Go server handler, Go client `_test.go`, Go CLI `_test.go`, rs `tests/test_client.rs`, py `tests/test_vault.py`, js `tests/client.test.ts`).

## Deployment Impact (ops-visible)

**Read before merging — this PR intentionally takes the spec §20 "no-migration" posture.**

- `VaultTiDBSchemaStatements()` is CREATE-IF-NOT-EXISTS only. Tenants that already have pre-reshape `vault_tokens` / `vault_audit_log` tables will silently skip DDL and hit `grant_id` / `agent` column-not-found at runtime. There is no in-place migration shim.
- Deployable posture at this tip: green-field tenants only (fresh init picks up the new DDL). Existing tenants require either (a) a destructive pre-drop of `vault_tokens` + `vault_audit_log` in a maintenance window, or (b) a new-tenant cutover. @4idxta4 owns the (i)/(ii) merge-timing call.
- Per §20 this is intentional, not a bug. Flagged by reviewer-1 checkpoint Flag 2.
- **Audit log `task_id` column dropped** per spec §6 (no `--task` flag). Task-level grant correlation is out-of-scope in v0. Any external observability tooling keying on `task_id` breaks. Flagged by reviewer-1 A2-F2.

## Reviewer pin-sheet (carried forward to the tip)

- **Flag 1** (checkpoint nonce leak): verified closed at tip — `grep -n Nonce` in server/client/CLI/SDKs returns zero.
- **Flag 2** (migration gap): acknowledged in Deployment Impact above.
- **Flag 3** (`Issuer` / `iss` naming): noted, low-stakes, no action.
- **Flag 4** (handler-body identifier migration): closed at tip by the zero-hit sweep above.
- **Flag 5 / P-ISS-1**: **closed at `898e8c6`.** Server now re-validates `claims.Issuer` against `requestIssuer(r)` as spec Invariant #7 mandates.
- **P-ACTOR-1** (DELETE-body actor fragility): both `handleVaultSecretDelete` and `handleVaultTokenRevoke` read the actor (`deleted_by` / `revoked_by`) from the optional DELETE body and fall back to `"api"` when absent (pattern (a)). On proxy paths that strip DELETE bodies, the audit record collapses to `"api"` and loses actor distinction. Tradeoff accepted at this tip; robust fix is pattern (c) — an `X-Drive9-Actor` request header plumbed through Go client + CLI + 3 SDKs — cross-codebase change out of scope here. Logged for follow-up PR.

## Still out of scope (tracked in follow-up issues)

- **Lane C** — FUSE F8 owner-only `@grants` / `@audit` pseudo-files (ENOENT for delegated principal)
- **Lane D** — F3 dual-principal env separation, F14 `vault with` env scrub (DRIVE9_* subtraction), §11 errno table conformance
- **B3** — five-verb vault CLI dispatch (`put` / `grant` / `revoke` / `with` / `reauth`); currently under `secret` verb
- **B4** — pre-published pass-criteria tests beyond `TestF13` (need `TestF1_*`, `TestF3_*`, `TestF8_*`, `TestF14_*`, `TestF15_*`, `TestF16_*`)
- **P-ACTOR-1** — DELETE-body actor fragility (pattern (c) header-based fix)

## Ownership / authorization

- Repo: `mem9-ai/drive9` (owned by @4idxta4)
- Spec: `083aab8` (partial terminal — Lane A + Lane B + B5 ship here; Lane C / Lane D follow)
- Release-scope call: path (i) scope-reduction merge — set by @4idxta4 at msg `000002ff`
- Author email: `qiffang33@gmail.com` per @4idxta4's branch policy
- Branch: `dev1/vault-end-state-impl`
- Lane A (`037e6c4`): unchanged, nothing regressed.
