### PR TITLE
docs(vault): PR-B spec — ctx verbs + drop positional JWT import (spec-first gate)

### DIFF
--- a/docs/guides/vault-quickstart.md
+++ b/docs/guides/vault-quickstart.md
@@ -110,7 +110,7 @@ expires_at: 2026-04-18T19:00:00Z
 
 Send the whole block to Alice over a secure channel (email with a password-protected attachment, password manager share, Signal, etc.). Alice will save the JWT to a file and pipe it into `ctx import` (see Part 3). The JWT is displayed once and is not re-fetchable — if it is lost, issue a new grant.
 
-Avoid distributing the JWT as a copyable one-liner (`drive9 ctx import <jwt>`). That form is valid (see Part 3) but records the token in the delegatee's shell history and process argument list.
+Distribute the JWT as a file attachment or as piped input — never as a positional argument to a shell command. The positional form (`drive9 ctx import <jwt>`) is not accepted; it was removed because a runtime warning cannot unexpose a secret that has already reached shell history and `/proc/<pid>/cmdline`.
 
 ### Script-friendly output
 
@@ -169,7 +169,7 @@ pbpaste | drive9 ctx import --from-file -
 
 Either form writes a **delegated** context to Alice's `~/.drive9/config`. The JWT is decoded locally; no server round-trip is required. If the token is already expired, import is refused immediately. The JWT never lands in shell history or `/proc/<pid>/cmdline`.
 
-`drive9 ctx import <jwt>` (positional) also works, but it will be recorded in shell history. Use it only for scripting and testing.
+When stdin is a pipe (`isatty(0) == false`), `drive9 ctx import` with no arguments reads the JWT from stdin by default — the explicit `--from-file -` form is accepted for scripts that want the intent to be unambiguous. When stdin is a TTY and no flag is given, `ctx import` exits with a one-line help pointing at the canonical forms.
 
 ### 2. Activate and mount
 

--- a/docs/specs/pr-b-ctx-implementation.md
+++ b/docs/specs/pr-b-ctx-implementation.md
@@ -1,0 +1,500 @@
+# PR-B — CLI `ctx` verb family (owner + delegated context management)
+
+**Status:** draft (spec-first; SHA-bound sign-off gate)
+**Author:** @dat9-dev1
+**Reviewers:** @adversary-1, @adversary-2
+**Related:** end-state `docs/specs/vault-interaction-end-state.md` §13 / §14 / §15; impl `docs/specs/pr-a-jwt-implementation.md` §1 file-map partition
+
+---
+
+## 0. Context and scope
+
+PR-A (#273, `3960805`, merged 2026-04-19) shipped the JWT grant primitive on the server side: `POST /v1/vault/grants`, `DELETE /v1/vault/grants/{grant_id}`, HMAC verify path, audit events with §5 Detail conformance.
+
+PR-B is the **CLI side** of the grant → context flow: the verbs that take a JWT produced by `drive9 vault grant` and install it into the delegatee's `~/.drive9/config`, plus the owner-side `ctx add --api-key` bootstrap. After PR-B, the user-facing path described in end-state §15 (Owner issues grant → Alice imports → Alice reads under narrowed authority) is executable end-to-end from the CLI for the first time.
+
+### Scope lock
+
+**In scope for PR-B (this PR):**
+- 5 CLI verbs per end-state §13.2: `drive9 ctx add`, `drive9 ctx import`, `drive9 ctx ls`, `drive9 ctx use`, `drive9 ctx rm`
+- Client-side JWT payload decode (UX only; server remains authoritative per Invariant #7)
+- `~/.drive9/config` schema extension for dual-principal (owner / delegated) contexts
+- Minor edits to already-merged `docs/specs/vault-interaction-end-state.md` to drop the positional-JWT import form (§13.2 table, §13.3 contract, §15 Alice example, §6 grant-output note, §11 errno table)
+
+**Explicitly deferred to later PRs:**
+- Env-var resolution (`DRIVE9_VAULT_TOKEN` / `DRIVE9_API_KEY` / `DRIVE9_SERVER`) → **PR-C**
+- Legacy `cap_token` / `CapTokenClaims` / `vault_tokens` table deletion → **PR-E** (§10 deletion contract, binding)
+- Mount-layer credential re-binding (`drive9 vault reauth`, Invariant #6) → **PR-D**
+- Any issuer allow-list hardening beyond trust-on-first-use → follow-up (§13.3 issuer trust note)
+
+### Non-goals
+
+- No change to any server endpoint, DB schema, or audit event written by PR-A.
+- No new CLI verb outside the five locked in §13.2. The `drive9 ctx` bare form (no verb) remains a non-spec compatibility convenience that prints the current context name; it is not load-bearing.
+- No auto-mint, auto-refresh, auto-rotate, or auto-anything at `ctx` layer. A context that expires is refused on `ctx use`; the user must re-import.
+
+---
+
+## 1. Files touched
+
+Code (final list; B2 cherry-picks, B3 reconciles):
+
+| Path | Change | Origin |
+| --- | --- | --- |
+| `cmd/drive9/cli/ctx.go` | **new** — 5-verb dispatcher + handlers | port of PR #274 with positional form removed |
+| `cmd/drive9/cli/ctx_test.go` | **new** — table-driven tests for 5 verbs | port of PR #274, regression tests added per §6 below |
+| `cmd/drive9/cli/jwt.go` | **new** — client-side JWT payload decode (no verify) | port of PR #274 |
+| `cmd/drive9/cli/config.go` | **extend** — `Context` dual-principal fields, `Config.loadConfig` default-type backfill | port of PR #274 |
+| `cmd/drive9/cli/main.go` | **edit** — route `drive9 ctx` to `cli.Ctx` | minimal wiring; one-line change |
+| `cmd/drive9/cli/randomname.go` | **new, tiny** — entropy-backed default-name generator when JWT has no `label_hint` | new, see §4.3 |
+
+Spec (this PR):
+
+| Path | Change |
+| --- | --- |
+| `docs/specs/pr-b-ctx-implementation.md` | **new** — this document |
+| `docs/specs/pr-b-review-checklist.md` | **new** — mirrors `pr-a-review-checklist.md` shape |
+| `docs/specs/vault-interaction-end-state.md` | **edit** §13.2 / §13.3 / §15 / §6 / §11 — drop positional-JWT import, add TTY/pipe default, consistent Alice example |
+| `docs/guides/vault-quickstart.md` | **edit** lines 113, 172, 329 — drop positional mentions, align with stdin/`--from-file` canonical forms |
+
+Explicitly NOT touched:
+- `pkg/server/**` — no server change.
+- `pkg/vault/**` — no store, sign, verify change.
+- `pkg/client/vault.go` — no env-var wiring (that is PR-C).
+- Legacy `CapToken*` / `vault_tokens*` — zero references added (enforced by B1 review gate "grep=0").
+
+---
+
+## 2. Behavior — verb by verb
+
+End-state §13.2 is the source of truth. This section is **operational**: it says how each verb behaves on the happy and sad paths, what it writes to `~/.drive9/config`, and what stderr/stdout look like. Where §13.2 is silent, this section fills the gap; any fill-in is flagged `[fill]` so reviewers can decide whether to fold back into end-state.
+
+### 2.1 `drive9 ctx add`
+
+```
+drive9 ctx add --api-key <key> [--name <n>] [--server <url>]
+```
+
+Owner-principal context bootstrap. Writes a `Context{Type: "owner", APIKey: <key>, Server: <resolved>}` entry.
+
+- `--api-key`: **required**. No prompt, no stdin fallback in PR-B (API keys are pasted once at setup; a prompt would be kubectl-style bloat). Empty / missing → error `"--api-key is required"`, exit 1.
+- `--name`: optional. On absence, generate a random two-word name (adjective-noun, ~10 bits) so first-time users never have to think of one. On collision with an existing context, append a numeric suffix.
+- `--server`: optional. On absence, inherit from `Config.Server` (populated by a prior `ctx add` or `ctx use`); if that is also empty, fall back to the compiled default `https://drive9.dev` `[fill]` — this matches §14.3 resolution for unset `DRIVE9_SERVER`.
+- If `Config.CurrentContext == ""` at save time, the new context becomes current. Spec §13.1 invariant: "exactly one current context, or zero iff Contexts is empty".
+
+Output on success:
+
+```
+added context "owner-prod" (owner)
+current context is now "owner-prod"
+```
+
+If the new context did not become current (i.e. there was already one), the second line is omitted.
+
+### 2.2 `drive9 ctx import`
+
+```
+drive9 ctx import --from-file <path>           # explicit file
+drive9 ctx import --from-file -                # explicit stdin
+drive9 ctx import                              # default: stdin iff !isatty(0)
+```
+
+Delegated-principal context bootstrap from a JWT minted by `drive9 vault grant`.
+
+**Input resolution ladder (PR-B lock):**
+
+1. If `--from-file <path>` given and `path != "-"` → read file.
+2. If `--from-file -` given → read stdin until EOF.
+3. If no flag given AND `isatty(0) == false` → read stdin until EOF (matches `pass insert`, `gpg --import`, `vault login -method=token`).
+4. If no flag given AND `isatty(0) == true` → **error** with exact message:
+
+   ```
+   error: no JWT on stdin. Use one of:
+     drive9 ctx import --from-file <path>
+     <producer> | drive9 ctx import
+   ```
+
+   Exit 1, mapped to `EINVAL` per §11.
+
+The positional-JWT form (`drive9 ctx import <jwt>`) is **not** accepted — see §3 for the end-state spec edit that drops it. If a bare positional argument is present (e.g. `drive9 ctx import eyJhbGc...`), the verb errors with the same "no JWT on stdin" message **plus** a one-line postscript: `note: the positional-JWT form was removed; paste via stdin or save to a file first.` This protects users migrating from older docs or the PR #274 prior draft.
+
+**Parse-stability fork (end-state §19 / §13.3 refusal cases), in order:**
+
+1. Input empty after whitespace trim → `EINVAL`, message `"ctx import: empty input"`.
+2. Not a structurally valid JWT (three base64url segments, JSON middle) → `EINVAL`, message `"ctx import: not a valid JWT: <decode error>"`.
+3. `principal_type` claim is not `"delegated"` → `EINVAL`, message `"ctx import: token principal_type is %q, not \"delegated\"; use \`drive9 ctx add --api-key\` for owner credentials"`.
+4. `exp` claim is in the past (local wall clock, no skew tolerance — matches end-state §17 short-circuit #1) → `EACCES`, message `"ctx import: token already expired at <RFC3339>"`.
+5. `iss` claim is empty → `EINVAL`, message `"ctx import: token is missing the \`iss\` claim"`.
+6. `perm` claim is not one of `{"read", "write"}` → `EINVAL`, message `"ctx import: token perm is %q, expected one of {read, write}"`.
+
+All six refusals happen **before** any write to `~/.drive9/config`. No partial-write state is ever reachable.
+
+**On success:**
+- Default name derivation (matches merged §13.3):
+  1. `claims.LabelHint` if set AND not already in use.
+  2. Else `<agent>-<first-scope-root>` where `<first-scope-root>` is the secret name from `/n/vault/<secret>[/<key>]`.
+  3. Else `<agent>` alone.
+  4. Else `<first-scope-root>` alone.
+  5. Else random name.
+  6. On collision, append `-2`, `-3`, …
+- `--name <n>` overrides (1)–(5) entirely.
+- Context fields populated from JWT claims per §13.1:
+  - `Type: "delegated"`
+  - `Server: claims.iss` (trust-on-first-use; §13.3 issuer trust note applies)
+  - `Token: <raw JWT string>` (stored verbatim for re-transmission)
+  - `Agent, Scope, Perm, ExpiresAt, GrantID, LabelHint` from the corresponding claims
+- If `Config.CurrentContext == ""` → new context becomes current.
+- If `Config.Server == ""` → `Config.Server = claims.iss` (first-server-wins).
+
+Output on success:
+
+```
+imported context "alice-prod-db" (delegated, grant grt_7f2a...)
+current context is now "alice-prod-db"
+```
+
+(Second line omitted if another context was already current.)
+
+### 2.3 `drive9 ctx ls [-l|--json]`
+
+Output matches end-state §13.2 (`CURRENT NAME TYPE SCOPE PERM EXPIRES_AT STATUS`).
+
+- No args → default table form, SCOPE rendered as `first +N` for multi-scope delegated contexts.
+- `-l` / `--long` → SCOPE rendered as comma-joined full list.
+- `--json` → `{current_context, contexts: [{name, current, type, server, scope[], perm, expires_at, status, agent, grant_id}]}`, indent 2 spaces. Stable key order.
+- `-l` and `--json` are mutually exclusive → `EINVAL`.
+- Empty context set → stdout:
+  ```
+  no contexts configured
+  run: drive9 ctx add --api-key <key>  (owner)
+       <producer> | drive9 ctx import  (delegated)
+  ```
+- `STATUS` computed at display time from `ExpiresAt` (§17 local short-circuit). Owner contexts always `active`. Delegated contexts: `expired` iff `!ExpiresAt.IsZero() && !ExpiresAt.After(now)`, else `active`. No other values in PR-B.
+
+### 2.4 `drive9 ctx use <name>`
+
+Activates a context (rewrites `Config.CurrentContext`).
+
+- No-arg / flag-arg / >1-arg → `EINVAL`, message `"usage: drive9 ctx use <name>"`.
+- Name not in `Config.Contexts` → `ENOENT`-equivalent exit, message `"context %q not found; run: drive9 ctx ls"`.
+- Context is `delegated` with expired `exp` → **refuse** (§17 short-circuit on activation), message `"context %q expired at %s; request a new grant and re-import"`.
+- Context is already current → still succeed, print `"context %q is already active"` + descriptor line. No-op on `saveConfig` (avoids atime/mtime churn).
+
+**Descriptor line** (per end-state §15 F15, two-line success notice):
+
+```
+switched to context "alice-prod-db"
+  delegated: scope prod-db/DB_URL, perm read, expires 2026-04-18T19:00:00Z
+```
+
+Or for owner:
+
+```
+switched to context "owner-prod"
+  owner credentials, server https://drive9.dev
+```
+
+**Invariant #6 (no auto-rebind):** `ctx use` does **no** FUSE-side work. It only rewrites `~/.drive9/config`. Running mounts continue to hold whatever credential they were bound to at mount time; the only way to rebind is `drive9 vault reauth` (PR-D). This is enforced structurally by `ctx use` not depending on any mount-manager package.
+
+### 2.5 `drive9 ctx rm <name>`
+
+Deletes a context entry.
+
+- Args-validation identical to `ctx use`.
+- Name not found → `ENOENT`-equivalent, message `"context %q not found"`.
+- Delete the entry from `Config.Contexts`. If it was current, set `Config.CurrentContext = ""`.
+- Output:
+  ```
+  removed context "alice-prod-db"
+  ```
+  If current was cleared, add a second line: `no current context; run 'drive9 ctx use <name>' to activate one`.
+- Does **not** attempt to notify the server (delegated revocation is server-side via `drive9 vault revoke`, not client-side via `ctx rm`). `ctx rm` is a purely local operation. Stale audit would record `grant.revoked` via a separate command; §13.3 notes this separation.
+
+---
+
+## 3. End-state spec edits (in this PR)
+
+The following edits to `docs/specs/vault-interaction-end-state.md` drop the positional-JWT `ctx import` form and tighten the TTY / pipe default. All other §13 invariants (schema, verb set, resolution ladder, trust-on-first-use) are unchanged.
+
+### 3.1 §13.2 verb table
+
+**Before** (current merged, lines 266–272):
+
+```
+drive9 ctx add --api-key <key> [--name <n>] [--server <url>]      # add owner context
+drive9 ctx import --from-file <path>                              # add delegated context from a file (recommended)
+drive9 ctx import --from-file -                                   # add delegated context from stdin (recommended)
+drive9 ctx import <jwt>                                           # convenience form; JWT leaks to shell history
+drive9 ctx ls [-l|--json]                                         # list contexts (offline — reads only local config)
+drive9 ctx use <name>                                             # activate a context
+drive9 ctx rm <name>                                              # delete a context
+```
+
+**After:**
+
+```
+drive9 ctx add --api-key <key> [--name <n>] [--server <url>]      # add owner context
+drive9 ctx import --from-file <path>                              # add delegated context from a file
+drive9 ctx import [--from-file -]                                 # add delegated context from stdin (default when stdin is a pipe)
+drive9 ctx ls [-l|--json]                                         # list contexts (offline — reads only local config)
+drive9 ctx use <name>                                             # activate a context
+drive9 ctx rm <name>                                              # delete a context
+```
+
+Following paragraph (current line 273) becomes:
+
+> Both `ctx import` forms are equivalent in effect. Stdin is read by default when stdin is a pipe (`isatty(0) == false`); the explicit `--from-file -` form is accepted for scripts that want the intent to be unambiguous. When stdin is a TTY and no `--from-file` is supplied, `ctx import` exits with `EINVAL` and prints a one-line help pointing at the two canonical forms.
+
+### 3.2 §13.3 ctx import contract
+
+Delete current lines 298–302 (the three-bullet input-modes list) and replace with:
+
+> Input modes:
+>
+> - `drive9 ctx import --from-file <path>` reads the JWT from a file.
+> - `drive9 ctx import --from-file -` reads the JWT from stdin explicitly.
+> - `drive9 ctx import` (no arguments) reads the JWT from stdin iff stdin is not a TTY. When stdin is a TTY, `ctx import` exits `EINVAL` and prints:
+>
+>   ```
+>   error: no JWT on stdin. Use one of:
+>     drive9 ctx import --from-file <path>
+>     <producer> | drive9 ctx import
+>   ```
+>
+> In all three modes, the JWT must be a single token with surrounding whitespace trimmed. The JWT **MUST NOT** be passed as a positional argument; that form was removed in PR-B because a warning cannot unexpose a secret that has already reached shell history and `/proc/<pid>/cmdline`.
+
+Delete current lines 309 (the SHOULD-NOT positional-argument paragraph) — rationale is now captured in the removal note above.
+
+Delete current line 125 (the "Delegatees **SHOULD NOT** paste" paragraph in §6) — same reason; the form no longer exists.
+
+### 3.3 §15 Alice example
+
+The Alice block at lines 373–379 is already correct (uses `--from-file ~/alice-grant.jwt`) — no edit needed.
+
+### 3.4 §6 grant output
+
+Line 115 currently shows the default human output:
+
+```
+drive9 ctx import --from-file -
+<jwt>
+---
+...
+```
+
+This remains pipe-friendly and correct after the positional drop. No edit.
+
+Line 125 (the `SHOULD NOT` paragraph about positional paste) is deleted as noted in §3.2 above.
+
+### 3.5 `docs/guides/vault-quickstart.md` doc-cascade
+
+Per `feedback_review_gate_blindness.md` round-4 (stale cross-doc references surviving a supposedly-complete spec pass), the user-facing quickstart must be kept in lock-step with the end-state spec. Verified via `grep -n 'ctx import\|positional\|<jwt>' docs/guides/vault-quickstart.md` (SHA `3b65a3c`):
+
+- Line 113 — "Avoid distributing the JWT as a copyable one-liner (`drive9 ctx import <jwt>`). That form is valid (see Part 3) but records the token in the delegatee's shell history and process argument list." → **rewrite**: "Distribute the JWT as a file attachment or as piped input. Do not paste it as a positional argument; the positional form was removed for this reason."
+- Line 172 — "`drive9 ctx import <jwt>` (positional) also works, but it will be recorded in shell history. Use it only for scripting and testing." → **delete**.
+- Line 329 (quick reference table) — already says `drive9 ctx import --from-file <path>` (or `--from-file -` for stdin). **No edit** — already correct.
+- Other `ctx import <jwt>` references: none beyond 113 and 172.
+
+No other doc files require edits (verified by `git grep -l 'ctx import <jwt>' -- docs/ README.md` returns only `end-state` and `quickstart`).
+
+### 3.6 §11 errno table
+
+Current `§11 Errno Table (Normative)` lines 208–215 do not explicitly cover `ctx import` EINVAL / EACCES / ENOENT cases. Add a new sub-table under the existing one:
+
+```
+| `ctx import` refusal cause | Errno |
+| --- | --- |
+| Empty / unparseable / structurally invalid JWT | `EINVAL` |
+| Missing required claim (`iss`, `exp`, `perm`, `principal_type`, `agent`) | `EINVAL` |
+| Token `principal_type` is not `"delegated"` | `EINVAL` |
+| Token `exp` already in the past at import | `EACCES` |
+| `--from-file <path>` names a non-existent or unreadable file | `ENOENT` |
+| Stdin is a TTY and no input flag given | `EINVAL` (with help pointer) |
+```
+
+---
+
+## 4. Implementation notes (B3 reconciliation)
+
+PR #274's `ctx.go` is the starting point. B3 work:
+
+### 4.1 Drop positional-JWT
+
+PR #274 accepts a bare positional JWT after `--from-file` check (ctx.go:195). B3 removes that branch and replaces with the TTY-detection default.
+
+- Add `isatty(0)` check via `golang.org/x/term`. We already depend on `x/term` transitively via FUSE; if not, add it.
+- If `--from-file` flag is absent and `isatty(0) == true` → return the §2.2 error verbatim.
+- If a bare non-flag positional is present → same error plus the migration postscript.
+
+### 4.2 Friend-of-cherry-pick regression tests
+
+Port PR #274's `ctx_test.go`, then add (B3-new) tests for:
+
+- `TestCtxImport_TTYWithoutFlag`: fake TTY stdin, no flag → `EINVAL` exit, stderr contains the exact help-pointer string.
+- `TestCtxImport_TTYWithBarePositional`: fake TTY stdin, bare positional → same error + postscript line.
+- `TestCtxImport_PipedStdinDefault`: non-TTY stdin with JWT bytes, no flag → imports successfully.
+- `TestCtxImport_ExpiredToken`: JWT with `exp = now - 1h` → `EACCES` exit, no config write. Read `~/.drive9/config` afterwards, assert the context does **not** appear.
+- `TestCtxImport_PrincipalTypeOwner`: JWT with `principal_type=owner` → `EINVAL` exit, stderr directs to `ctx add --api-key`.
+- `TestCtxImport_EmptyIss`: JWT missing `iss` claim → `EINVAL` exit.
+- `TestCtxImport_LabelHintNewlineEscape`: `label_hint` = `"evil\n[INJECTED]"`. After import, `ctx ls` renders it on a single line (tabwriter). Matches `pr-a-review-checklist.md` §I silent-requirement bullet on `label_hint` injection.
+- `TestCtxUse_ExpiredDelegated`: importing a not-yet-expired grant, then fast-forwarding time past `exp` and calling `ctx use` → refused with exact message.
+- `TestCtxUse_ActivateOwner`: owner context descriptor line format check.
+- `TestCtxAdd_GeneratesName`: no `--name` → generated name of form `<adj>-<noun>` (regex `^[a-z]+-[a-z]+$`).
+- `TestCtxAdd_CollisionSuffix`: two `ctx add` without `--name`, force seed to collide → second gets `-2` suffix.
+- `TestCtxRm_CurrentClears`: removing the current context → `CurrentContext == ""` in persisted config.
+- `TestConfig_LoadDefaultTypeBackfill`: old-format `~/.drive9/config` (no `type` field on Context) → loaded with `Type = "owner"`. Ensures first-run users who upgrade don't lose access. **This is a silent-requirement test** (`feedback_silent_requirement_blind_spot.md`): the spec doesn't explicitly say "backfill", but the alternative (refuse old configs) would break every existing user. The backfill is in PR #274's `loadConfig`; this test pins it.
+
+All tests are `testify/require`-style per agent standard.
+
+### 4.3 Random name generator
+
+PR #274's `randomName` uses `crypto/rand` over a small wordlist. Keep that — do **not** use `math/rand` even with seeding, because a predictable context name is a weak-but-real information leak (config file contents are not public, but an attacker who gets a shell can enumerate).
+
+Wordlist sizing:
+- Adjectives: ≥32 (5 bits)
+- Nouns: ≥32 (5 bits)
+- 10 bits → ~1000 name combinations. Collision probability at N contexts: `N*(N-1)/2 * 1/1024`. For N ≤ 10 (realistic ceiling), collision is <5%. Adequate — we fall back to `-2` suffix on collision anyway.
+
+### 4.4 `Context` JSON compatibility
+
+`~/.drive9/config` is a single JSON file, 0600, written atomically via `os.WriteFile`. Schema extension in PR #274 is additive: old configs have only `api_key`, new configs have `type, server, api_key, token, agent, scope, perm, expires_at, grant_id, label_hint`. `loadConfig` backfills `type=owner` for old entries (see §4.2 test).
+
+**Atomic write check:** PR #274 uses `os.WriteFile(path, data, 0o600)`. That is **not atomic** on POSIX — a crash mid-write leaves a truncated file. B3 task: replace with write-to-`path.tmp`+`rename`, which is atomic on POSIX. Regression test: simulate a partial write (write only half the bytes, then crash), reload → old config still intact.
+
+### 4.5 `drive9 ctx` bare form (compatibility)
+
+Current pre-PR-B implementation: `drive9 ctx` (no verb) prints the current context name. This is a non-spec convenience not listed in §13.2. Keep it as-is for backwards compat; the dispatcher routes `args == []` to `ctxShow()`. **Flag this in PR-B body as a known non-spec carry-over**; removal would be a separate UX-cleanup PR, not a bundle into PR-B.
+
+---
+
+## 5. Security review lines (to walk)
+
+These are the adversary-hat concerns. Each is a reviewer gate in `pr-b-review-checklist.md`.
+
+### 5.1 Client-side decode ≠ server authority (Invariant #7)
+
+Claim: "the JWT payload is decoded client-side at `ctx import` time and used to populate context fields for display / activation; authorization always remains server-side."
+
+Test: grep the B2/B3 diff for any use of decoded claims that *gates* a request. Acceptable uses: display in `ctx ls`, scope rendering, expired-on-activation refusal (local short-circuit §17). Unacceptable uses: any code path that denies a read/write based on the client-decoded `perm` or `scope` without the server being consulted. There should be zero in PR-B because PR-B does not touch the data plane — but the gate is here in case the cherry-pick drags in a client-side authz check.
+
+### 5.2 Config file security
+
+- Mode must be `0600` at both create and save time. (PR #274 does this.)
+- Directory `~/.drive9/` must be `0700`. Check / enforce on every save.
+- Atomic write via `.tmp` + `rename` (see §4.4).
+
+Test: after any `ctx` verb, assert `stat(~/.drive9/config).mode & 0o777 == 0o600` and `stat(~/.drive9).mode & 0o777 == 0o700`.
+
+### 5.3 No secret-in-argv, ever
+
+Enforced by §3.2 end-state edit + §2.2 behavior. Regression test: `TestCtxImport_TTYWithBarePositional`.
+
+Additional check: `drive9 ctx add --api-key <key>` passes the API key in argv, which has the same `/proc/<pid>/cmdline` exposure. This is accepted by the current spec because API keys are setup-time credentials (paste-once) and the alternative (stdin prompt) complicates the bootstrap. **Flag for qiffang** as a known-accepted tradeoff; a `--api-key-file` option could be a follow-up. Not blocking for PR-B.
+
+### 5.4 Trust-on-first-use on `iss`
+
+`ctx import` writes `Context.Server = claims.iss` with no network check. Attack: owner crafts a grant with `iss=https://evil.example.com`; delegatee imports; delegatee's subsequent requests hit the attacker's server.
+
+Mitigation (per end-state §13.3 issuer trust note): the owner's distribution channel is the trust anchor, not the CLI. PR-B does not add an allow-list. Follow-up work: `--expect-issuer` flag or allow-list pinned at `ctx add --api-key` time.
+
+Test: `TestCtxImport_TofuIssuerPopulated`. Import a JWT with a specific `iss`, read back the context, assert `Server == iss`. Documents the behavior; does not prevent the attack.
+
+### 5.5 `label_hint` log injection (§I silent-requirement)
+
+`label_hint` is attacker-controllable (the owner picks it, but a compromised owner or a delegated-redelegation chain future-PR could introduce untrusted values). If `label_hint` is `"evil\n[INJECTED]"`, it MUST NOT break audit-log parsing or table output.
+
+Test: `TestCtxImport_LabelHintNewlineEscape` — verifies tabwriter output stays on one physical line (tabwriter quotes newlines implicitly? verify). If tabwriter does **not** escape, B3 must escape explicitly in `renderScope` / table-format code.
+
+### 5.6 Clock skew on `exp` check
+
+End-state §13.3 locks **zero** clock skew on the local short-circuit. Test: grant with `exp = now + 500ms`, import succeeds; sleep 1s; `ctx use` fails. This matches merged spec behavior exactly and prevents drift.
+
+Server-side verification has ±60s leeway (§16 / PR-A). Client-side has 0. Document this asymmetry in `pr-b-review-checklist.md` for reviewer awareness.
+
+---
+
+## 6. Test plan (must ship with PR)
+
+Reconciles PR #274's test coverage (18 tests) with B3-new tests from §4.2. Full list (22 cases after consolidation):
+
+**From PR #274 (port as-is):**
+1. `TestCtxAdd_Owner_WritesConfig`
+2. `TestCtxAdd_MultipleContexts_NewBecomesNonCurrent`
+3. `TestCtxAdd_DuplicateName_Rejected`
+4. `TestCtxImport_Delegated_FromFile_WritesContext`
+5. `TestCtxImport_Delegated_FromStdin`
+6. `TestCtxImport_DefaultNameFromLabelHint`
+7. `TestCtxImport_DefaultNameFromAgentScope`
+8. `TestCtxLs_TableOutput`
+9. `TestCtxLs_JSONOutput`
+10. `TestCtxLs_EmptySetHelpMessage`
+11. `TestCtxUse_SwitchesCurrent`
+12. `TestCtxUse_NotFound`
+13. `TestCtxRm_Removes`
+14. `TestCtxRm_NotFound`
+
+**B3-new:**
+15. `TestCtxImport_TTYWithoutFlag` (§5.3, §4.2)
+16. `TestCtxImport_TTYWithBarePositional` (§5.3, §4.2)
+17. `TestCtxImport_ExpiredToken_NoConfigWrite` (§4.2)
+18. `TestCtxImport_PrincipalTypeOwner_Rejected` (§4.2)
+19. `TestCtxImport_EmptyIss_Rejected` (§4.2)
+20. `TestCtxImport_LabelHintNewlineEscape` (§5.5)
+21. `TestCtxUse_ExpiredDelegated_Refused` (§5.6)
+22. `TestConfig_LoadDefaultTypeBackfill` (§4.2)
+23. `TestConfig_AtomicWriteSurvivesPartialCrash` (§4.4)
+24. `TestCtxAdd_ConfigMode0600` (§5.2)
+25. `TestCtxImport_TofuIssuerPopulated` (§5.4, documents behavior)
+
+(Final count may shift; B3 adds any missing per review.)
+
+**CI matrix:** linux-amd64, darwin-amd64, darwin-arm64 (already covered by main matrix). No Windows (FUSE dep elsewhere already excludes Windows).
+
+---
+
+## 7. PR mechanics
+
+- **Branch:** `dev1/vault-impl-pr-b` (code), `dev1/vault-impl-pr-b-spec` (this spec).
+- **Commit identity:** `qiffang <qiffang33@gmail.com>` per memory `feedback_git_commit_email.md`.
+- **CI gates (mandatory green):** `go test ./...`, `go vet`, `staticcheck`, gofmt.
+- **Review protocol:** SHA-bound sign-off per `678e76a9` / `ccb1755d`. adversaries run the checklist against a specific SHA and `APPROVE SHA=<...>` or `REQUEST CHANGES SHA=<...>`. Any post-approval edit above-trivial (>5 lines, behavioral) triggers delta-review against the new SHA.
+
+---
+
+## 8. Cross-reference to review checklist
+
+See `docs/specs/pr-b-review-checklist.md`. Each item is traceable to a numbered section here.
+
+---
+
+## 9. Deferred explicitly
+
+| Item | Deferred to | Reason |
+| --- | --- | --- |
+| `DRIVE9_VAULT_TOKEN` env var resolution | PR-C | Per `pr-a-jwt-implementation.md` line 31, env vars are a separate concern. Folding them here doubles the review surface. |
+| `DRIVE9_API_KEY` env var resolution | PR-C | Same. |
+| `DRIVE9_SERVER` env var resolution | PR-C | Same. |
+| `drive9 vault reauth` (mount rebind) | PR-D | Mount-layer work; depends on FUSE manager refactor that is not in PR-B. |
+| `CapToken*` / `vault_tokens` deletion | PR-E | §10 deletion contract is binding. PR-B adds **zero** references to legacy types. |
+| Issuer allow-list / `--expect-issuer` | future hardening | Out of scope per end-state §13.3 trust note. |
+| `drive9 ctx` bare-form removal | separate UX-cleanup PR | Non-spec compat carry-over, noted in §4.5. |
+
+---
+
+## 10. Non-regression with PR-A
+
+PR-B adds no DB query, no HTTP handler, no audit event, no token signing path. Grep rules for reviewer:
+
+- `git diff main...dev1/vault-impl-pr-b -- 'pkg/**'` must be empty (no server-side change).
+- `git diff main...dev1/vault-impl-pr-b -- 'cmd/drive9/cli/**'` is the full PR-B code surface.
+- Zero matches for `CapToken`, `CapTokenClaims`, `vault_tokens`, `cap_token` in the diff.
+
+Enforced mechanically in `pr-b-review-checklist.md` §B.
+
+---
+
+## 11. Open items (for sign-off)
+
+- [ ] adversary-1 sign-off on this spec SHA
+- [ ] adversary-2 sign-off on this spec SHA
+- [ ] qiffang notice (spec PR opened; no action needed unless the verb-surface question from `31d41dc7` / `5e171449` warrants escalation — retracted in `7efae6dc`, noted here for traceability)

--- a/docs/specs/pr-b-ctx-implementation.md
+++ b/docs/specs/pr-b-ctx-implementation.md
@@ -55,7 +55,7 @@ Spec (this PR):
 | `docs/specs/pr-b-ctx-implementation.md` | **new** — this document |
 | `docs/specs/pr-b-review-checklist.md` | **new** — mirrors `pr-a-review-checklist.md` shape |
 | `docs/specs/vault-interaction-end-state.md` | **edit** §13.2 / §13.3 / §15 / §6 / §11 — drop positional-JWT import, add TTY/pipe default, consistent Alice example |
-| `docs/guides/vault-quickstart.md` | **edit** lines 113, 172, 329 — drop positional mentions, align with stdin/`--from-file` canonical forms |
+| `docs/guides/vault-quickstart.md` | **edit** lines 113 + 172 — drop positional mentions, align with stdin/`--from-file` canonical forms (line 329 quick-reference already correct, not touched) |
 
 Explicitly NOT touched:
 - `pkg/server/**` — no server change.
@@ -77,7 +77,7 @@ drive9 ctx add --api-key <key> [--name <n>] [--server <url>]
 
 Owner-principal context bootstrap. Writes a `Context{Type: "owner", APIKey: <key>, Server: <resolved>}` entry.
 
-- `--api-key`: **required**. No prompt, no stdin fallback in PR-B (API keys are pasted once at setup; a prompt would be kubectl-style bloat). Empty / missing → error `"--api-key is required"`, exit 1.
+- `--api-key`: **required**. No prompt, no stdin fallback in PR-B (API keys are pasted once at setup; a prompt would be kubectl-style bloat). Empty / missing → error `"--api-key is required"`, CLI exit code `2` (usage).
 - `--name`: optional. On absence, generate a random two-word name (adjective-noun, ~10 bits) so first-time users never have to think of one. On collision with an existing context, append a numeric suffix.
 - `--server`: optional. On absence, inherit from `Config.Server` (populated by a prior `ctx add` or `ctx use`); if that is also empty, fall back to the compiled default `https://drive9.dev` `[fill]` — this matches §14.3 resolution for unset `DRIVE9_SERVER`.
 - If `Config.CurrentContext == ""` at save time, the new context becomes current. Spec §13.1 invariant: "exactly one current context, or zero iff Contexts is empty".
@@ -103,7 +103,10 @@ Delegated-principal context bootstrap from a JWT minted by `drive9 vault grant`.
 
 **Input resolution ladder (PR-B lock):**
 
-1. If `--from-file <path>` given and `path != "-"` → read file.
+1. If `--from-file <path>` given and `path != "-"`:
+   - If the path does not exist or is unreadable → `ENOENT`, CLI exit `1`, message `"ctx import: cannot read %q: %s"` (underlying OS error).
+   - If the file exists but `stat.Mode().Perm() & 0o077 != 0` (i.e. any group or world bit set) → refuse **before reading the contents**, `EACCES`, CLI exit `1`, message `"ctx import: refusing to read grant file %q: mode %#o is group- or world-readable; run: chmod 600 %q"`. Rationale: a bearer-token file with `0644`/`0640` has already leaked to any local user; accepting it silently makes the CLI complicit in the credential lifecycle breach. The same reasoning that drops positional-argv applies to permissive file modes.
+   - Otherwise → read file.
 2. If `--from-file -` given → read stdin until EOF.
 3. If no flag given AND `isatty(0) == false` → read stdin until EOF (matches `pass insert`, `gpg --import`, `vault login -method=token`).
 4. If no flag given AND `isatty(0) == true` → **error** with exact message:
@@ -114,20 +117,42 @@ Delegated-principal context bootstrap from a JWT minted by `drive9 vault grant`.
      <producer> | drive9 ctx import
    ```
 
-   Exit 1, mapped to `EINVAL` per §11.
+   CLI exit code `2` (usage error, per `sysexits.h` `EX_USAGE`). The end-state §11 errno column classifies this as `EINVAL`; `EINVAL` is the POSIX errno *class* the scenario maps to, and the CLI *exit code* is `2`. The two are distinct concepts — §11 is the errno classification (for man-page / spec reasoning), and the CLI exit code is what a shell `$?` observes.
 
 The positional-JWT form (`drive9 ctx import <jwt>`) is **not** accepted — see §3 for the end-state spec edit that drops it. If a bare positional argument is present (e.g. `drive9 ctx import eyJhbGc...`), the verb errors with the same "no JWT on stdin" message **plus** a one-line postscript: `note: the positional-JWT form was removed; paste via stdin or save to a file first.` This protects users migrating from older docs or the PR #274 prior draft.
 
+**CLI exit code convention (PR-B lock):**
+
+| Errno class (§11) | CLI exit code | Rationale |
+| --- | --- | --- |
+| `EINVAL` | `2` | Usage / input-shape error (`sysexits.h` `EX_USAGE`). Shell tools that diff usage errors from runtime denials rely on this split. |
+| `EACCES` | `1` | Authoritative denial (expired token, permission refused). |
+| `ENOENT` | `1` | Resource not found (e.g. `--from-file` path missing). |
+
+CLI exit code is what `$?` observes after the process exits. Errno class is the POSIX-named category used in §11 for semantic reasoning / man pages. The two are distinct concepts; both are pinned so implementations cannot diverge.
+
 **Parse-stability fork (end-state §19 / §13.3 refusal cases), in order:**
+
+The fork is exhaustive over all required delegated-context claims enumerated by end-state §13.1 + §16. Order is chosen so cheap structural checks run before claim checks, and so error messages guide the user to the most actionable fix first.
 
 1. Input empty after whitespace trim → `EINVAL`, message `"ctx import: empty input"`.
 2. Not a structurally valid JWT (three base64url segments, JSON middle) → `EINVAL`, message `"ctx import: not a valid JWT: <decode error>"`.
-3. `principal_type` claim is not `"delegated"` → `EINVAL`, message `"ctx import: token principal_type is %q, not \"delegated\"; use \`drive9 ctx add --api-key\` for owner credentials"`.
-4. `exp` claim is in the past (local wall clock, no skew tolerance — matches end-state §17 short-circuit #1) → `EACCES`, message `"ctx import: token already expired at <RFC3339>"`.
-5. `iss` claim is empty → `EINVAL`, message `"ctx import: token is missing the \`iss\` claim"`.
-6. `perm` claim is not one of `{"read", "write"}` → `EINVAL`, message `"ctx import: token perm is %q, expected one of {read, write}"`.
+3. Missing or empty `principal_type` claim → `EINVAL`, message `"ctx import: token is missing the \`principal_type\` claim"`.
+4. `principal_type` claim is not `"delegated"` → `EINVAL`, message `"ctx import: token principal_type is %q, not \"delegated\"; use \`drive9 ctx add --api-key\` for owner credentials"`.
+5. Missing or zero `exp` claim → `EINVAL`, message `"ctx import: token is missing the \`exp\` claim"`.
+6. `exp` claim is in the past (local wall clock, no skew tolerance — matches end-state §17 short-circuit #1) → `EACCES`, message `"ctx import: token already expired at <RFC3339>"`.
+7. Missing or empty `iss` claim → `EINVAL`, message `"ctx import: token is missing the \`iss\` claim"`.
+8. Missing or empty `agent` claim → `EINVAL`, message `"ctx import: token is missing the \`agent\` claim"`.
+9. Missing or empty `grant_id` claim → `EINVAL`, message `"ctx import: token is missing the \`grant_id\` claim"`.
+10. Missing `scope` claim, or `scope` is not a non-empty JSON array of non-empty strings → `EINVAL`, message `"ctx import: token is missing a non-empty \`scope\` array"`.
+11. Missing or empty `perm` claim → `EINVAL`, message `"ctx import: token is missing the \`perm\` claim"`.
+12. `perm` claim is not one of `{"read", "write"}` → `EINVAL`, message `"ctx import: token perm is %q, expected one of {read, write}"`.
 
-All six refusals happen **before** any write to `~/.drive9/config`. No partial-write state is ever reachable.
+All twelve refusals happen **before** any write to `~/.drive9/config`. No partial-write state is ever reachable.
+
+Rationale for exhaustiveness: end-state §13.1 lists the required fields of a delegated context, and §16 lists the required JWT payload claims. A JWT that passes partial checks but is missing `grant_id` or `scope[]` cannot populate a valid delegated `Context` entry — accepting it would either silently insert an invalid row or silently drop claims, both undefined-behavior contract violations. The twelve-step fork is the union of {structural, principal_type, lifecycle, identity, payload schema, authority} required claims.
+
+The end-state §11 errno sub-table for `ctx import` is a 1:1 mapping of the twelve refusals above, plus the file-mode and file-read rows defined under the `--from-file` contract. See §11 for the full row-by-row mapping.
 
 **On success:**
 - Default name derivation (matches merged §13.3):
@@ -282,7 +307,17 @@ drive9 ctx import --from-file -
 ...
 ```
 
-This remains pipe-friendly and correct after the positional drop. No edit.
+This default form is **human-only** (not pipe-safe): `vault grant` also prints `grant_id` and `expires_at` metadata to stdout (`cmd/drive9/cli/secret.go:340-342`), so piping the default output directly into `ctx import` would feed those extra lines through the JWT parser.
+
+The **canonical pipe form** is:
+
+```
+drive9 vault grant <scope> --agent <a> --perm <p> --ttl <t> --token-only | drive9 ctx import
+```
+
+`--token-only` exists already (`cmd/drive9/cli/secret.go:293-294, 335-336`): in that mode, stdout is a single line containing only the bare JWT. `drive9 ctx import` with no flag reads stdin by default when stdin is not a TTY (§2.2), so the handoff is pipe-safe end-to-end.
+
+Add a corresponding bullet in §13.2 (end-state) after the verb table that names the canonical pipe form. No change to the default human output; it stays human-only / non-parseable by design.
 
 Line 125 (the `SHOULD NOT` paragraph about positional paste) is deleted as noted in §3.2 above.
 
@@ -299,18 +334,27 @@ No other doc files require edits (verified by `git grep -l 'ctx import <jwt>' --
 
 ### 3.6 §11 errno table
 
-Current `§11 Errno Table (Normative)` lines 208–215 do not explicitly cover `ctx import` EINVAL / EACCES / ENOENT cases. Add a new sub-table under the existing one:
+Current `§11 Errno Table (Normative)` does not explicitly cover `ctx import` EINVAL / EACCES / ENOENT cases. Add a new sub-table under the existing one, 1:1 with the parse-stability fork in §2.2 plus the `--from-file` contract. The full row set is:
 
-```
-| `ctx import` refusal cause | Errno |
-| --- | --- |
-| Empty / unparseable / structurally invalid JWT | `EINVAL` |
-| Missing required claim (`iss`, `exp`, `perm`, `principal_type`, `agent`) | `EINVAL` |
-| Token `principal_type` is not `"delegated"` | `EINVAL` |
-| Token `exp` already in the past at import | `EACCES` |
-| `--from-file <path>` names a non-existent or unreadable file | `ENOENT` |
-| Stdin is a TTY and no input flag given | `EINVAL` (with help pointer) |
-```
+| `ctx import` refusal cause | Errno | Exit code |
+| --- | --- | --- |
+| Input empty after whitespace trim | `EINVAL` | `2` |
+| Not a structurally valid JWT (three base64url segments, JSON middle) | `EINVAL` | `2` |
+| Missing `principal_type` claim | `EINVAL` | `2` |
+| `principal_type` is not `"delegated"` | `EINVAL` | `2` |
+| Missing `exp` claim | `EINVAL` | `2` |
+| `exp` already in the past at import | `EACCES` | `1` |
+| Missing `iss` claim | `EINVAL` | `2` |
+| Missing `agent` claim | `EINVAL` | `2` |
+| Missing `grant_id` claim | `EINVAL` | `2` |
+| Missing or empty `scope[]` claim | `EINVAL` | `2` |
+| Missing `perm` claim | `EINVAL` | `2` |
+| `perm` not in `{read, write}` | `EINVAL` | `2` |
+| `--from-file <path>` names a non-existent or unreadable file | `ENOENT` | `1` |
+| `--from-file <path>` has mode group- or world-readable (`mode & 0o077 != 0`) | `EACCES` | `1` |
+| Stdin is a TTY and no input flag given | `EINVAL` (with help pointer) | `2` |
+
+The end-state §11 sub-table mirrors this exactly. Any future addition to the parse fork **MUST** add a row here and in end-state §11 in the same change; the checklist enforces this.
 
 ---
 
@@ -411,11 +455,19 @@ End-state §13.3 locks **zero** clock skew on the local short-circuit. Test: gra
 
 Server-side verification has ±60s leeway (§16 / PR-A). Client-side has 0. Document this asymmetry in `pr-b-review-checklist.md` for reviewer awareness.
 
+### 5.7 Grant file permissions
+
+`--from-file <path>` **MUST** refuse any file whose mode has group or world permission bits set (`stat.Mode().Perm() & 0o077 != 0`). The refusal happens **before** reading the file contents: a `0644` bearer-token file has already leaked to any local user; silently consuming it would make the CLI complicit in the credential lifecycle breach.
+
+Rationale symmetry with positional-drop: argv removal was motivated by credential hygiene (JWT in `/proc/<pid>/cmdline` is post-hoc unrecoverable). Ingesting a world-readable token file is the same category of breach. The spec posture is consistent: credentials that have already escaped their intended confidentiality boundary are refused, not consumed.
+
+Test: `TestCtxImport_InsecureGrantFileMode_Refused` — create a temp grant file with `0644`, run `ctx import --from-file <path>`, assert: exit code `1`, errno class `EACCES`, error message contains `"chmod 600"`, file contents **not** read (verify via afero / fake-fs spy or by checking that the parser was never invoked).
+
 ---
 
 ## 6. Test plan (must ship with PR)
 
-Reconciles PR #274's test coverage (18 tests) with B3-new tests from §4.2. Full list (22 cases after consolidation):
+Reconciles PR #274's test coverage (14 ports — three prototype tests in PR #274 are dropped as superseded: the positional-form happy path, the positional-form warning, and the positional-form collision case, all obsolete after §3 drops positional entirely) with B3-new tests from §4.2 / §5. Full list (28 cases):
 
 **From PR #274 (port as-is):**
 1. `TestCtxAdd_Owner_WritesConfig`
@@ -439,14 +491,17 @@ Reconciles PR #274's test coverage (18 tests) with B3-new tests from §4.2. Full
 17. `TestCtxImport_ExpiredToken_NoConfigWrite` (§4.2)
 18. `TestCtxImport_PrincipalTypeOwner_Rejected` (§4.2)
 19. `TestCtxImport_EmptyIss_Rejected` (§4.2)
-20. `TestCtxImport_LabelHintNewlineEscape` (§5.5)
-21. `TestCtxUse_ExpiredDelegated_Refused` (§5.6)
-22. `TestConfig_LoadDefaultTypeBackfill` (§4.2)
-23. `TestConfig_AtomicWriteSurvivesPartialCrash` (§4.4)
-24. `TestCtxAdd_ConfigMode0600` (§5.2)
-25. `TestCtxImport_TofuIssuerPopulated` (§5.4, documents behavior)
+20. `TestCtxImport_MissingGrantID_Rejected` (§2.2 step 9)
+21. `TestCtxImport_EmptyScope_Rejected` (§2.2 step 10)
+22. `TestCtxImport_InsecureGrantFileMode_Refused` (§5.7 / §2.2 step 1)
+23. `TestCtxImport_LabelHintNewlineEscape` (§5.5)
+24. `TestCtxUse_ExpiredDelegated_Refused` (§5.6)
+25. `TestConfig_LoadDefaultTypeBackfill` (§4.2)
+26. `TestConfig_AtomicWriteSurvivesPartialCrash` (§4.4)
+27. `TestCtxAdd_ConfigMode0600` (§5.2)
+28. `TestCtxImport_TofuIssuerPopulated` (§5.4, documents behavior)
 
-(Final count may shift; B3 adds any missing per review.)
+If review surfaces additional required cases, they are added to this enumeration and the count is updated in the same delta — the header number and the enumeration are kept in lock-step.
 
 **CI matrix:** linux-amd64, darwin-amd64, darwin-arm64 (already covered by main matrix). No Windows (FUSE dep elsewhere already excludes Windows).
 

--- a/docs/specs/pr-b-ctx-implementation.md
+++ b/docs/specs/pr-b-ctx-implementation.md
@@ -377,11 +377,11 @@ Port PR #274's `ctx_test.go`, then add (B3-new) tests for:
 - `TestCtxImport_TTYWithoutFlag`: fake TTY stdin, no flag → `EINVAL` exit, stderr contains the exact help-pointer string.
 - `TestCtxImport_TTYWithBarePositional`: fake TTY stdin, bare positional → same error + postscript line.
 - `TestCtxImport_PipedStdinDefault`: non-TTY stdin with JWT bytes, no flag → imports successfully.
-- `TestCtxImport_ExpiredToken`: JWT with `exp = now - 1h` → `EACCES` exit, no config write. Read `~/.drive9/config` afterwards, assert the context does **not** appear.
-- `TestCtxImport_PrincipalTypeOwner`: JWT with `principal_type=owner` → `EINVAL` exit, stderr directs to `ctx add --api-key`.
-- `TestCtxImport_EmptyIss`: JWT missing `iss` claim → `EINVAL` exit.
+- `TestCtxImport_ExpiredToken_NoConfigWrite`: JWT with `exp = now - 1h` → `EACCES` exit, no config write. Read `~/.drive9/config` afterwards, assert the context does **not** appear.
+- `TestCtxImport_PrincipalTypeOwner_Rejected`: JWT with `principal_type=owner` → `EINVAL` exit, stderr directs to `ctx add --api-key`.
+- `TestCtxImport_EmptyIss_Rejected`: JWT missing `iss` claim → `EINVAL` exit.
 - `TestCtxImport_LabelHintNewlineEscape`: `label_hint` = `"evil\n[INJECTED]"`. After import, `ctx ls` renders it on a single line (tabwriter). Matches `pr-a-review-checklist.md` §I silent-requirement bullet on `label_hint` injection.
-- `TestCtxUse_ExpiredDelegated`: importing a not-yet-expired grant, then fast-forwarding time past `exp` and calling `ctx use` → refused with exact message.
+- `TestCtxUse_ExpiredDelegated_Refused`: importing a not-yet-expired grant, then fast-forwarding time past `exp` and calling `ctx use` → refused with exact message.
 - `TestCtxUse_ActivateOwner`: owner context descriptor line format check.
 - `TestCtxAdd_GeneratesName`: no `--name` → generated name of form `<adj>-<noun>` (regex `^[a-z]+-[a-z]+$`).
 - `TestCtxAdd_CollisionSuffix`: two `ctx add` without `--name`, force seed to collide → second gets `-2` suffix.
@@ -467,7 +467,7 @@ Test: `TestCtxImport_InsecureGrantFileMode_Refused` — create a temp grant file
 
 ## 6. Test plan (must ship with PR)
 
-Reconciles PR #274's test coverage (14 ports — three prototype tests in PR #274 are dropped as superseded: the positional-form happy path, the positional-form warning, and the positional-form collision case, all obsolete after §3 drops positional entirely) with B3-new tests from §4.2 / §5. Full list (28 cases):
+Reconciles PR #274's test coverage (14 ports — three prototype tests in PR #274 are dropped as superseded: the positional-form happy path, the positional-form warning, and the positional-form collision case, all obsolete after §3 drops positional entirely) with B3-new tests from §4.2 / §5. Full list (33 cases). This enumeration is **canonical** — any test mentioned in §4.2 / §5 / checklist must appear here with matching name; any addition updates the count in the same delta.
 
 **From PR #274 (port as-is):**
 1. `TestCtxAdd_Owner_WritesConfig`
@@ -488,18 +488,23 @@ Reconciles PR #274's test coverage (14 ports — three prototype tests in PR #27
 **B3-new:**
 15. `TestCtxImport_TTYWithoutFlag` (§5.3, §4.2)
 16. `TestCtxImport_TTYWithBarePositional` (§5.3, §4.2)
-17. `TestCtxImport_ExpiredToken_NoConfigWrite` (§4.2)
-18. `TestCtxImport_PrincipalTypeOwner_Rejected` (§4.2)
-19. `TestCtxImport_EmptyIss_Rejected` (§4.2)
-20. `TestCtxImport_MissingGrantID_Rejected` (§2.2 step 9)
-21. `TestCtxImport_EmptyScope_Rejected` (§2.2 step 10)
-22. `TestCtxImport_InsecureGrantFileMode_Refused` (§5.7 / §2.2 step 1)
-23. `TestCtxImport_LabelHintNewlineEscape` (§5.5)
-24. `TestCtxUse_ExpiredDelegated_Refused` (§5.6)
-25. `TestConfig_LoadDefaultTypeBackfill` (§4.2)
-26. `TestConfig_AtomicWriteSurvivesPartialCrash` (§4.4)
-27. `TestCtxAdd_ConfigMode0600` (§5.2)
-28. `TestCtxImport_TofuIssuerPopulated` (§5.4, documents behavior)
+17. `TestCtxImport_PipedStdinDefault` (§4.2)
+18. `TestCtxImport_ExpiredToken_NoConfigWrite` (§4.2)
+19. `TestCtxImport_PrincipalTypeOwner_Rejected` (§4.2)
+20. `TestCtxImport_EmptyIss_Rejected` (§4.2)
+21. `TestCtxImport_MissingGrantID_Rejected` (§2.2 step 9)
+22. `TestCtxImport_EmptyScope_Rejected` (§2.2 step 10)
+23. `TestCtxImport_InsecureGrantFileMode_Refused` (§5.7 / §2.2 step 1)
+24. `TestCtxImport_LabelHintNewlineEscape` (§5.5)
+25. `TestCtxUse_ExpiredDelegated_Refused` (§5.6)
+26. `TestCtxUse_ActivateOwner` (§4.2)
+27. `TestCtxAdd_GeneratesName` (§4.2 / §4.3)
+28. `TestCtxAdd_CollisionSuffix` (§4.2 / §4.3)
+29. `TestCtxRm_CurrentClears` (§4.2)
+30. `TestConfig_LoadDefaultTypeBackfill` (§4.2)
+31. `TestConfig_AtomicWriteSurvivesPartialCrash` (§4.4)
+32. `TestCtxAdd_ConfigMode0600` (§5.2)
+33. `TestCtxImport_TofuIssuerPopulated` (§5.4, documents behavior)
 
 If review surfaces additional required cases, they are added to this enumeration and the count is updated in the same delta — the header number and the enumeration are kept in lock-step.
 

--- a/docs/specs/pr-b-ctx-implementation.md
+++ b/docs/specs/pr-b-ctx-implementation.md
@@ -467,7 +467,7 @@ Test: `TestCtxImport_InsecureGrantFileMode_Refused` — create a temp grant file
 
 ## 6. Test plan (must ship with PR)
 
-Reconciles PR #274's test coverage (14 ports — three prototype tests in PR #274 are dropped as superseded: the positional-form happy path, the positional-form warning, and the positional-form collision case, all obsolete after §3 drops positional entirely) with B3-new tests from §4.2 / §5. Full list (33 cases). This enumeration is **canonical** — any test mentioned in §4.2 / §5 / checklist must appear here with matching name; any addition updates the count in the same delta.
+Reconciles PR #274's test coverage (14 ports — three prototype tests in PR #274 are dropped as superseded: the positional-form happy path, the positional-form warning, and the positional-form collision case, all obsolete after §3 drops positional entirely) with B3-new tests from §4.2 / §5 / checklist §K. Full list (34 cases). This enumeration is **canonical** — any test mentioned in §4.2 / §5 / checklist must appear here with matching name; any addition updates the count in the same delta.
 
 **From PR #274 (port as-is):**
 1. `TestCtxAdd_Owner_WritesConfig`
@@ -505,6 +505,7 @@ Reconciles PR #274's test coverage (14 ports — three prototype tests in PR #27
 31. `TestConfig_AtomicWriteSurvivesPartialCrash` (§4.4)
 32. `TestCtxAdd_ConfigMode0600` (§5.2)
 33. `TestCtxImport_TofuIssuerPopulated` (§5.4, documents behavior)
+34. `TestCtxImport_LabelHintCollidesWithExistingOwner` (checklist §K silent-requirement — attacker-chosen label_hint matching an existing owner name; default-name collision appends numeric suffix, owner not overwritten)
 
 If review surfaces additional required cases, they are added to this enumeration and the count is updated in the same delta — the header number and the enumeration are kept in lock-step.
 

--- a/docs/specs/pr-b-review-checklist.md
+++ b/docs/specs/pr-b-review-checklist.md
@@ -1,0 +1,144 @@
+# PR-B review checklist
+
+**Use with:** `docs/specs/pr-b-ctx-implementation.md` and `docs/specs/vault-interaction-end-state.md`.
+
+**Reviewers:** `@adversary-1`, `@adversary-2`. Walk every item. Sign-off is SHA-bound: `APPROVE SHA=<git-sha>` or `REQUEST CHANGES SHA=<git-sha>`. Partial approvals are rejected in favor of REQUEST CHANGES — name the specific items that failed.
+
+**Review is two-pass:** first the spec-only PR (this B1 PR), then the code PR (B2/B3/B4). This checklist covers **both** passes; items are tagged `[spec]` (B1 gate) or `[code]` (B2/B3/B4 gate). Items untagged apply to both.
+
+Per `feedback_review_gate_axis_enumeration.md`: before sign-off, walk every numbered section of `vault-interaction-end-state.md §13`, `§14`, `§15`, `§6`, `§11`, `§17`, `§19` and ask **"is this a contract axis I need to verify against code / spec?"** The checklist below is the axis list *we currently know about* — the enumeration pass is the safety net against axes we forgot.
+
+---
+
+## A. Spec conformance (§13.1 / §13.2 / §13.3 / §14 / §15)
+
+- [ ] **[spec+code]** Verb set is exactly `{add, import, ls, use, rm}`. No `create`, no `sh`, no `login`, no aliases beyond the `ls` / `list` synonym already in merged §13.2.
+- [ ] **[spec]** §13.2 verb table in `vault-interaction-end-state.md` has positional-JWT row removed; `ctx import` rows show `--from-file <path>` and `--from-file -` only.
+- [ ] **[spec]** §13.3 "Input modes" bullet list contains exactly three bullets: `--from-file <path>`, `--from-file -`, and no-arg (pipe default).
+- [ ] **[spec]** §13.3 includes the literal TTY-detection error string:
+  ```
+  error: no JWT on stdin. Use one of:
+    drive9 ctx import --from-file <path>
+    <producer> | drive9 ctx import
+  ```
+  (exact wording so implementations cannot diverge).
+- [ ] **[spec]** §13.3 no longer contains the `SHOULD NOT` paragraph about positional-in-interactive-shell (line 309 of pre-B1) — it is obsolete after positional removal.
+- [ ] **[spec]** §15 Alice flow uses `ctx import --from-file ~/alice-grant.jwt` (or piped stdin); no positional form.
+- [ ] **[spec]** §6 grant default output block line 125 `SHOULD NOT` paragraph is removed (positional no longer exists to warn about).
+- [ ] **[spec]** `docs/guides/vault-quickstart.md` line 113 rewritten; line 172 deleted. `grep -n 'ctx import <jwt>' docs/` returns zero matches.
+- [ ] **[code]** `cmd/drive9/cli/ctx.go` dispatcher does not accept a bare positional JWT. A bare non-flag arg on `ctx import` triggers the §2.2 error message (including migration postscript).
+
+## B. Zero-legacy gate (§10 deletion contract)
+
+- [ ] **[code]** `git diff main...<pr-b-branch>` returns **zero** matches for: `CapToken`, `CapTokenClaims`, `vault_tokens`, `cap_token`. This is mechanical; any hit blocks.
+- [ ] **[code]** No new call into `pkg/vault/tokens*.go` or any file owned by the PR-E deletion list.
+- [ ] **[code]** `pkg/**` is not modified at all by PR-B code diff. (Spec edits allowed in `docs/specs/`.)
+
+## C. TTY / pipe / argv behavior (§5.3 of impl spec)
+
+- [ ] **[code]** `isatty(0) == false` + no flag → stdin is read. Regression test: `TestCtxImport_PipedStdinDefault`.
+- [ ] **[code]** `isatty(0) == true` + no flag → `EINVAL` with exact error string (§A). Regression test: `TestCtxImport_TTYWithoutFlag`.
+- [ ] **[code]** Bare positional arg on `ctx import` → same `EINVAL` plus migration postscript. Regression test: `TestCtxImport_TTYWithBarePositional`.
+- [ ] **[code]** `--from-file <path>` and `--from-file -` both work regardless of `isatty(0)`.
+- [ ] **[code]** `--from-file <path>` where `path` is unreadable → `ENOENT`. Regression test required.
+- [ ] **[code]** `ctx add --api-key <key>` passes the key in argv. This is a known-accepted tradeoff for bootstrap (see impl §5.3). Confirm it is **flagged in the PR-B body** as a non-regression tradeoff. No silent shipping.
+
+## D. Parse-stability fork (§13.3 + §17 short-circuit #1)
+
+- [ ] **[code]** Order of refusal on `ctx import`, enforced in code: empty → not-JWT → `principal_type` != delegated → `exp` past → `iss` empty → `perm` not in {read,write}. **Each** refusal happens before any config write. Regression test per case.
+- [ ] **[code]** `principal_type=owner` → `EINVAL` with message directing to `ctx add --api-key`. Regression test: `TestCtxImport_PrincipalTypeOwner_Rejected`.
+- [ ] **[code]** `exp` already-past → `EACCES`, no config write. Regression test: `TestCtxImport_ExpiredToken_NoConfigWrite`. After the test, `~/.drive9/config` does not contain the rejected context — verify via read-back, not just err check.
+- [ ] **[code]** `exp` check uses local wall clock with **zero** skew tolerance (matches merged §13.3). Server verify tolerates ±60s (§16); client does not. Asymmetry documented in impl §5.6.
+- [ ] **[code]** `iss` empty → `EINVAL`. Regression test: `TestCtxImport_EmptyIss_Rejected`.
+- [ ] **[code]** `perm` not in enum → `EINVAL`. Regression test required.
+
+## E. Config file security (§5.2 of impl spec)
+
+- [ ] **[code]** `~/.drive9/config` mode is `0600` after every `ctx` verb that writes. Regression test: `TestCtxAdd_ConfigMode0600`.
+- [ ] **[code]** `~/.drive9/` directory mode is `0700`. Enforced at save time.
+- [ ] **[code]** Save is atomic: write to `<path>.tmp`, `rename` to `<path>`. Regression test: `TestConfig_AtomicWriteSurvivesPartialCrash`.
+- [ ] **[code]** Old-format configs (no `type` field on Context) are loaded with `Type = "owner"` backfill. Regression test: `TestConfig_LoadDefaultTypeBackfill`. **Silent-requirement bullet** — the spec does not say "backfill"; refusing old configs is the alternative and would break all existing users.
+
+## F. Client decode ≠ server authority (Invariant #7)
+
+- [ ] **[code]** `pkg/client/vault.go` and `cmd/drive9/cli/jwt.go` decode the JWT payload for UX only. No client code gates a data-plane request on the decoded `perm` / `scope`.
+- [ ] **[code]** grep `cmd/drive9/cli/**` for any `claims.Perm` / `claims.Scope` check that short-circuits a read or write request to the server. Expected count: **zero** in PR-B (PR-B does not touch the data plane).
+- [ ] **[code]** Local short-circuit on `ctx use` for expired delegated context (§17 #1) is acceptable — it refuses to activate a context whose `exp` is in the past. This is not "client authorizing", it is "client not wasting a round trip". Regression test: `TestCtxUse_ExpiredDelegated_Refused`.
+
+## G. `label_hint` handling (Invariant #7 + §I silent-requirement)
+
+- [ ] **[code]** `label_hint` is used only in: (a) display in `ctx ls`, (b) default-name derivation on `ctx import`, (c) audit-log string (server side, already done in PR-A). It **MUST NOT** appear in any authz decision. grep confirms this.
+- [ ] **[code]** `label_hint` with newlines / escape sequences / shell metachars does not break `ctx ls` table output or JSON output. Regression test: `TestCtxImport_LabelHintNewlineEscape` with `"evil\n[INJECTED]"` — output remains one logical row (tabwriter does NOT escape by default; impl must escape explicitly in the render path).
+
+## H. `ctx ls` output contract (§13.2)
+
+- [ ] **[spec+code]** Table header is exactly `CURRENT\tNAME\tTYPE\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS` (tab-separated, tabwriter-rendered).
+- [ ] **[code]** `CURRENT` column holds `*` for exactly one row, or blank on all rows if `Config.CurrentContext == ""`.
+- [ ] **[code]** Multi-scope delegated context renders as `<first> +N` in default mode, comma-joined in `-l` mode.
+- [ ] **[code]** Owner context renders SCOPE as `*`, PERM as `rw`, EXPIRES_AT as `—` (em-dash).
+- [ ] **[code]** `--json` output has stable field order (`name, current, type, server, scope, perm, expires_at, status, agent, grant_id`). Indent is 2 spaces.
+- [ ] **[code]** `-l` and `--json` mutually exclusive → `EINVAL`.
+- [ ] **[code]** Empty context set prints the two-line help. Regression test: `TestCtxLs_EmptySetHelpMessage`.
+
+## I. `ctx use` / `ctx rm` invariants
+
+- [ ] **[code]** `ctx use` does no FUSE-side work. Invariant #6. grep `cmd/drive9/cli/ctx.go` for any call into `pkg/mount` or similar — expected zero.
+- [ ] **[code]** `ctx use <already-current>` is a no-op on `saveConfig` (avoids mtime churn). It still prints the descriptor line.
+- [ ] **[code]** `ctx rm <current>` clears `Config.CurrentContext` and prints the "no current context" hint.
+- [ ] **[code]** `ctx rm` does not contact the server. Server-side revocation is a separate verb (`drive9 vault revoke`, PR-A).
+
+## J. Test suite
+
+- [ ] **[code]** All 22+ test cases from impl §6 present and passing in CI.
+- [ ] **[code]** No `t.Skip` in the new tests.
+- [ ] **[code]** Tests assert exact errno / exit code, not just `err != nil`.
+- [ ] **[code]** Tests use `testify/require` per agent standard. No hand-rolled assertions.
+- [ ] **[code]** CI green on linux-amd64, darwin-amd64, darwin-arm64.
+
+## K. Silent-requirement pass
+
+**Run this pass last**, as a separate gate — not folded into any of A–J above. For each externally observable behavior of the `ctx` verbs, ask: **"if a strict implementer took the spec literally with no additional assumption, is the default safe / fail-closed?"**
+
+Specific cases:
+
+- [ ] **TTY detection reliability:** `isatty(0)` returns false on pipe, false on `</dev/null`, true on terminal. The `</dev/null` case → reads EOF immediately → empty input → refused at step 1 of parse-stability fork (EINVAL). Verify the error message in that edge case is sensible (not "not a valid JWT" which would be misleading on zero bytes). Regression test recommended.
+- [ ] **Config file TOCTOU:** between `load` and `save` a concurrent `ctx` command could corrupt state. PR-B does not lock `~/.drive9/config`. Document as known limitation; add flock in a follow-up if it becomes a real issue. Not blocking for PR-B because CLI is single-user single-process typical use.
+- [ ] **Grant replay across servers:** a grant minted at server A is imported at a client whose TOFU populates `Context.Server = claims.iss`. If the user later runs `drive9 ctx add --api-key --server B` and swaps which context is current, subsequent requests hit server B with a grant issued by A — which A's HMAC key will reject on verify. Covered server-side by PR-A. Client-side: no additional check. Document.
+- [ ] **`label_hint` injection into randomName fallback:** if label_hint is `../../etc/passwd`, does it get used as default name and then fail on JSON map key? `Context.Name` is only a config-map key (in-process JSON), not a filesystem path. Safe. Verify by reading impl.
+- [ ] **Timing on HMAC / decode:** PR-B does **not** do HMAC verify (server side only). Decode of JWT payload is `base64url + json.Unmarshal`. No timing leak concern at decode level. Document as non-applicable to PR-B.
+- [ ] **`ctx import` + `--name` collision with existing delegated context:** attacker gives user a grant with `label_hint = owner-prod` (the user's existing owner context name). Default-name derivation uses label_hint → collision detected → numeric suffix appended. Owner context not overwritten. Regression test: `TestCtxImport_LabelHintCollidesWithExistingOwner`.
+
+If any silent-requirement item uncovers a gap, the fix is typically a MUST line added to `vault-interaction-end-state.md` §13.3 (follow-up PR to spec) plus a check in `ctx.go`. Do not let PR-B merge with a known silent-requirement gap.
+
+## L. Doc-cascade (per `e4f41feb` / `bb68b6e6` convergence)
+
+- [ ] **[spec]** `docs/guides/vault-quickstart.md` edits listed in impl §3.5 are applied in the same spec PR.
+- [ ] **[spec]** After the spec PR merges, `git grep 'ctx import <jwt>'` across `docs/ README.md` returns zero matches.
+- [ ] **[spec]** No other doc file (CHANGELOG, cmd-help strings in Go, e2e test fixtures) contains stale positional-form references that would survive the spec edit. Grep check at B1 review time; flag any findings as "fold into B1 or ship as B1.1 doc-only PR".
+
+## M. Axis-enumeration sweep (per `feedback_review_gate_axis_enumeration.md`)
+
+Before signing off, walk these end-state sections and confirm each is **either** mirrored in this checklist **or** out of scope for PR-B:
+
+- `§13.1 context schema` → mirrored in §E, §F above. Covered.
+- `§13.2 verb surface` → mirrored in §A. Covered.
+- `§13.3 ctx import contract` → mirrored in §A, §C, §D. Covered.
+- `§14 env vars` → **out of scope for PR-B** (deferred to PR-C per impl spec §0 scope-lock).
+- `§15 grant → context flow` → mirrored in §A (Alice example edit). Covered.
+- `§16 JWT claim set` → **out of scope for PR-B** (locked by PR-A; PR-B decodes, does not define).
+- `§17 short-circuit table` → mirrored in §D, §F. Covered.
+- `§19 parse stability` → mirrored in §D. Covered.
+- `§6 grant output` → mirrored in §A. Covered.
+- `§11 errno table` → mirrored in §A (§3.6 addition). Covered.
+
+**If this sweep reveals an end-state section that is neither mirrored nor deferred, it is a silent-requirement bug in this checklist. Block and add a bullet before signing off.**
+
+---
+
+## Sign-off
+
+Both adversaries must post one of:
+- `APPROVE SHA=<spec-sha>` (B1 gate) or `APPROVE SHA=<code-sha>` (B4 gate) — walked all applicable items, no gaps
+- `REQUEST CHANGES SHA=<sha> — items [X.N, Y.M] failed: ...`
+
+Partial approvals ("approve A–H, not checked I–M") are not acceptable — block instead. Post-approval edits above-trivial trigger delta review against the new SHA.

--- a/docs/specs/pr-b-review-checklist.md
+++ b/docs/specs/pr-b-review-checklist.md
@@ -107,7 +107,7 @@ Per `feedback_review_gate_axis_enumeration.md`: before sign-off, walk every numb
 
 ## J. Test suite
 
-- [ ] **[code]** All 33 test cases from impl §6 present and passing in CI. §6 is the **canonical** enumeration; §4.2 / §5 prose mentions must name tests by the same identifier as §6. If the enumeration changes, header count + prose + checklist update in the same delta.
+- [ ] **[code]** All 34 test cases from impl §6 present and passing in CI. §6 is the **canonical** enumeration; §4.2 / §5 / §K prose mentions must name tests by the same identifier as §6. If the enumeration changes, header count + prose + checklist update in the same delta.
 - [ ] **[code]** No `t.Skip` in the new tests.
 - [ ] **[code]** Tests assert exact errno / exit code, not just `err != nil`.
 - [ ] **[code]** Tests use `testify/require` per agent standard. No hand-rolled assertions.

--- a/docs/specs/pr-b-review-checklist.md
+++ b/docs/specs/pr-b-review-checklist.md
@@ -107,7 +107,7 @@ Per `feedback_review_gate_axis_enumeration.md`: before sign-off, walk every numb
 
 ## J. Test suite
 
-- [ ] **[code]** All 28 test cases from impl §6 present and passing in CI. If the enumeration changes, header count updates in the same delta.
+- [ ] **[code]** All 33 test cases from impl §6 present and passing in CI. §6 is the **canonical** enumeration; §4.2 / §5 prose mentions must name tests by the same identifier as §6. If the enumeration changes, header count + prose + checklist update in the same delta.
 - [ ] **[code]** No `t.Skip` in the new tests.
 - [ ] **[code]** Tests assert exact errno / exit code, not just `err != nil`.
 - [ ] **[code]** Tests use `testify/require` per agent standard. No hand-rolled assertions.

--- a/docs/specs/pr-b-review-checklist.md
+++ b/docs/specs/pr-b-review-checklist.md
@@ -12,7 +12,7 @@ Per `feedback_review_gate_axis_enumeration.md`: before sign-off, walk every numb
 
 ## A. Spec conformance (§13.1 / §13.2 / §13.3 / §14 / §15)
 
-- [ ] **[spec+code]** Verb set is exactly `{add, import, ls, use, rm}`. No `create`, no `sh`, no `login`, no aliases beyond the `ls` / `list` synonym already in merged §13.2.
+- [ ] **[spec+code]** Verb set is exactly `{add, import, ls, use, rm}` plus the bare `ctx` (no-verb) carry-over whose contract is "print the current context name, or 'no current context'; no side effects; not listed in §13.2". No `create`, no `sh`, no `login`, no other aliases beyond the `ls` / `list` synonym already in merged §13.2. The bare form is a documented non-spec compat (impl §4.5), not a silent sixth verb.
 - [ ] **[spec]** §13.2 verb table in `vault-interaction-end-state.md` has positional-JWT row removed; `ctx import` rows show `--from-file <path>` and `--from-file -` only.
 - [ ] **[spec]** §13.3 "Input modes" bullet list contains exactly three bullets: `--from-file <path>`, `--from-file -`, and no-arg (pipe default).
 - [ ] **[spec]** §13.3 includes the literal TTY-detection error string:
@@ -25,12 +25,12 @@ Per `feedback_review_gate_axis_enumeration.md`: before sign-off, walk every numb
 - [ ] **[spec]** §13.3 no longer contains the `SHOULD NOT` paragraph about positional-in-interactive-shell (line 309 of pre-B1) — it is obsolete after positional removal.
 - [ ] **[spec]** §15 Alice flow uses `ctx import --from-file ~/alice-grant.jwt` (or piped stdin); no positional form.
 - [ ] **[spec]** §6 grant default output block line 125 `SHOULD NOT` paragraph is removed (positional no longer exists to warn about).
-- [ ] **[spec]** `docs/guides/vault-quickstart.md` line 113 rewritten; line 172 deleted. `grep -n 'ctx import <jwt>' docs/` returns zero matches.
+- [ ] **[spec]** `docs/guides/vault-quickstart.md` line 113 rewritten (from endorsement to anti-endorsement with explicit removal note); line 172 deleted. Grep gate is scoped to **normative user-facing docs and executable code**: `git grep -n 'ctx import <jwt>' -- 'docs/guides/**' 'docs/reference/**' 'README.md' 'cmd/**' 'pkg/**'` returns zero matches. The PR-B impl spec and checklist in `docs/specs/` are exempt because they intentionally cite the removed form in migration / before-after / gate text; treating those as violations would make the gate unsatisfiable.
 - [ ] **[code]** `cmd/drive9/cli/ctx.go` dispatcher does not accept a bare positional JWT. A bare non-flag arg on `ctx import` triggers the §2.2 error message (including migration postscript).
 
 ## B. Zero-legacy gate (§10 deletion contract)
 
-- [ ] **[code]** `git diff main...<pr-b-branch>` returns **zero** matches for: `CapToken`, `CapTokenClaims`, `vault_tokens`, `cap_token`. This is mechanical; any hit blocks.
+- [ ] **[code]** `git diff main...<pr-b-branch> -- 'cmd/**' 'pkg/**'` returns **zero** matches for: `CapToken`, `CapTokenClaims`, `vault_tokens`, `cap_token`. Scope is **executable code only** (`cmd/** pkg/**`) — not `docs/**`, because the impl spec and checklist intentionally cite the removed positional form in migration / before-after / gate text. This is mechanical; any hit in the scoped paths blocks.
 - [ ] **[code]** No new call into `pkg/vault/tokens*.go` or any file owned by the PR-E deletion list.
 - [ ] **[code]** `pkg/**` is not modified at all by PR-B code diff. (Spec edits allowed in `docs/specs/`.)
 
@@ -41,16 +41,34 @@ Per `feedback_review_gate_axis_enumeration.md`: before sign-off, walk every numb
 - [ ] **[code]** Bare positional arg on `ctx import` → same `EINVAL` plus migration postscript. Regression test: `TestCtxImport_TTYWithBarePositional`.
 - [ ] **[code]** `--from-file <path>` and `--from-file -` both work regardless of `isatty(0)`.
 - [ ] **[code]** `--from-file <path>` where `path` is unreadable → `ENOENT`. Regression test required.
+- [ ] **[code]** `--from-file <path>` where `path` has mode bits `0o077` set (group- or world-readable) → `EACCES`, refused **before reading file contents**, error message names `chmod 600`. Regression test: `TestCtxImport_InsecureGrantFileMode_Refused`. Verify the file body is never parsed (fake-fs spy or parser-invocation assertion).
 - [ ] **[code]** `ctx add --api-key <key>` passes the key in argv. This is a known-accepted tradeoff for bootstrap (see impl §5.3). Confirm it is **flagged in the PR-B body** as a non-regression tradeoff. No silent shipping.
 
 ## D. Parse-stability fork (§13.3 + §17 short-circuit #1)
 
-- [ ] **[code]** Order of refusal on `ctx import`, enforced in code: empty → not-JWT → `principal_type` != delegated → `exp` past → `iss` empty → `perm` not in {read,write}. **Each** refusal happens before any config write. Regression test per case.
+- [ ] **[code]** Order of refusal on `ctx import`, enforced in code (twelve steps per impl §2.2):
+  1. empty input → `EINVAL`
+  2. not-JWT → `EINVAL`
+  3. missing `principal_type` → `EINVAL`
+  4. `principal_type` != `delegated` → `EINVAL`
+  5. missing `exp` → `EINVAL`
+  6. `exp` in past → `EACCES`
+  7. missing `iss` → `EINVAL`
+  8. missing `agent` → `EINVAL`
+  9. missing `grant_id` → `EINVAL`
+  10. missing or empty `scope[]` → `EINVAL`
+  11. missing `perm` → `EINVAL`
+  12. `perm` not in `{read, write}` → `EINVAL`
+
+  **Each** refusal happens before any config write. Regression test per case.
 - [ ] **[code]** `principal_type=owner` → `EINVAL` with message directing to `ctx add --api-key`. Regression test: `TestCtxImport_PrincipalTypeOwner_Rejected`.
 - [ ] **[code]** `exp` already-past → `EACCES`, no config write. Regression test: `TestCtxImport_ExpiredToken_NoConfigWrite`. After the test, `~/.drive9/config` does not contain the rejected context — verify via read-back, not just err check.
 - [ ] **[code]** `exp` check uses local wall clock with **zero** skew tolerance (matches merged §13.3). Server verify tolerates ±60s (§16); client does not. Asymmetry documented in impl §5.6.
 - [ ] **[code]** `iss` empty → `EINVAL`. Regression test: `TestCtxImport_EmptyIss_Rejected`.
+- [ ] **[code]** Missing `grant_id` → `EINVAL`. Regression test: `TestCtxImport_MissingGrantID_Rejected`.
+- [ ] **[code]** Missing or empty `scope[]` → `EINVAL`. Regression test: `TestCtxImport_EmptyScope_Rejected`.
 - [ ] **[code]** `perm` not in enum → `EINVAL`. Regression test required.
+- [ ] **[spec+code]** Parse fork in impl §2.2, end-state §11 sub-table, and `cmd/drive9/cli/ctx.go` are 1:1 in rows and order. Any row added to one MUST be added to all three in the same change — enforced at review time by column-count diff.
 
 ## E. Config file security (§5.2 of impl spec)
 
@@ -89,7 +107,7 @@ Per `feedback_review_gate_axis_enumeration.md`: before sign-off, walk every numb
 
 ## J. Test suite
 
-- [ ] **[code]** All 22+ test cases from impl §6 present and passing in CI.
+- [ ] **[code]** All 28 test cases from impl §6 present and passing in CI. If the enumeration changes, header count updates in the same delta.
 - [ ] **[code]** No `t.Skip` in the new tests.
 - [ ] **[code]** Tests assert exact errno / exit code, not just `err != nil`.
 - [ ] **[code]** Tests use `testify/require` per agent standard. No hand-rolled assertions.
@@ -113,8 +131,8 @@ If any silent-requirement item uncovers a gap, the fix is typically a MUST line 
 ## L. Doc-cascade (per `e4f41feb` / `bb68b6e6` convergence)
 
 - [ ] **[spec]** `docs/guides/vault-quickstart.md` edits listed in impl §3.5 are applied in the same spec PR.
-- [ ] **[spec]** After the spec PR merges, `git grep 'ctx import <jwt>'` across `docs/ README.md` returns zero matches.
-- [ ] **[spec]** No other doc file (CHANGELOG, cmd-help strings in Go, e2e test fixtures) contains stale positional-form references that would survive the spec edit. Grep check at B1 review time; flag any findings as "fold into B1 or ship as B1.1 doc-only PR".
+- [ ] **[spec]** After the spec PR merges, `git grep 'ctx import <jwt>' -- 'docs/guides/**' 'docs/reference/**' 'README.md' 'cmd/**' 'pkg/**'` returns zero matches. Scope excludes `docs/specs/` because the PR-B impl spec and checklist intentionally cite the removed form in migration / before-after / gate text — treating those as violations would make the gate unsatisfiable.
+- [ ] **[spec]** No other user-facing doc file (CHANGELOG, cmd-help strings in Go, e2e test fixtures) contains stale positional-form references that would survive the spec edit. Grep check at B1 review time; flag any findings as "fold into B1 or ship as B1.1 doc-only PR".
 
 ## M. Axis-enumeration sweep (per `feedback_review_gate_axis_enumeration.md`)
 

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -78,6 +78,41 @@ ls /n/vault/prod-db
 
 `ls` lists only the keys the current principal can see. Keys the principal cannot see are **indistinguishable from non-existent** (see §11 Errno table).
 
+## 4.1 Virtual-File Output Contract (`@env`)
+
+`@env` is a virtual file whose byte contract is normative. Consumers (human pipeline, `drive9 vault with`, CI scripts) MUST be able to parse it with no ambiguity.
+
+### 4.1.1 Output format
+
+For each key–value pair visible under the current principal, `cat @env` emits exactly one line:
+
+```
+<KEY>=<QUOTED_VALUE>\n
+```
+
+- `<KEY>` is the secret key name, unchanged, restricted to the charset `[A-Z_][A-Z0-9_]*`. Any key outside this charset MUST NOT appear in `@env`; see §4.1.3.
+- `<QUOTED_VALUE>` is the value escaped per POSIX `printf %q` semantics (shell-safe round-trippable).
+- Line terminator is `\n` (LF) only. The last line MUST also be LF-terminated.
+- Lines are emitted in **lexicographic order of `<KEY>`** (byte-wise ASCII sort) so output is deterministic and diff-stable.
+
+### 4.1.2 Empty-secret semantics
+
+- Secret exists but has zero visible keys → `cat @env` writes 0 bytes and exits 0.
+- Secret does not exist (or is invisible under the current principal) → `cat @env` fails with `ENOENT` (see §11). Consumers MUST distinguish "empty" (exit 0, 0 bytes) from "missing" (ENOENT) by exit code, not by byte count.
+
+### 4.1.3 Illegal-key handling (fail-fast)
+
+If any visible key violates `[A-Z_][A-Z0-9_]*`, `cat @env` MUST fail with `EACCES` and emit no partial output. The spec does not silently skip illegal keys, and does not coerce them (no lower-to-upper casing, no `-` → `_` substitution). Callers wanting to inject such keys into a child process must materialise them explicitly via `drive9 vault with` (which applies the same rejection) or handle them out of band.
+
+If any value contains a control character (`\x00`–`\x1f` except `\t`) the same `EACCES` rule applies; `printf %q` is not defined over unrestricted control bytes and the contract refuses to invent framing.
+
+### 4.1.4 Other whole-secret views
+
+- `cat @all` — JSON object of all visible keys. **Byte-exact contract (key ordering, whitespace, escaping) is deferred to a follow-up spec** (PR-F). In v0, `@all` is consumed as valid JSON only; consumers MUST NOT depend on formatting.
+- `cat @grants/<grant-id>` — owner-only introspection of a grant. **Byte-exact contract deferred to PR-F** (same reason). In v0, only presence/absence and the grant's scope/perm/expiry fields are stable; string representation is not.
+
+Consumers that need stable byte output today MUST use `@env` (or `--json` on a control-plane verb; see §20).
+
 ## 5. Delete
 
 ```bash
@@ -484,7 +519,7 @@ The four local short-circuits (`ctx import` / `ctx ls` / `ctx use` / `vault reau
 5. **Grants do not cascade-revoke on `rm`**: removing a key leaves existing grants syntactically intact; holders observe `ENOENT`, and audit records `affected_grants`.
 6. **One active context at a time**: `~/.drive9/config` MAY hold any number of contexts (owner and delegated, mixed); at most one is active. Switching contexts does not silently re-bind an already-mounted mount (use `reauth`).
 7. **Client-side JWT decoding is UX-only**: local decode populates `ctx` metadata and enables offline `ctx ls`; it **MUST NOT** substitute for server-side validation. The server **MUST** re-check signature, TTL, and revocation on every request.
-8. **Issuer trust is TOFU (trust-on-first-use) in v0**: `ctx import` populates the context's `server` field from the JWT's `iss` claim with no network round-trip and no allow-list check. Invariant #7 does **not** protect against a malicious `iss` — the server being contacted is itself attacker-controlled and will validate its own signatures. Mitigation is delivery-channel-level (see §13.3 and §16); an issuer allow-list / `--expect-issuer` path is deferred (see §21). Implementations **MUST NOT** add a silent issuer check that only validates shape or reachability; such a check provides false assurance and is prohibited.
+8. **Issuer trust is TOFU (trust-on-first-use) in v0**: `ctx import` populates the context's `server` field from the JWT's `iss` claim with no network round-trip and no allow-list check. Invariant #7 does **not** protect against a malicious `iss` — the server being contacted is itself attacker-controlled and will validate its own signatures. Mitigation is delivery-channel-level (see §13.3 and §16); an issuer allow-list / `--expect-issuer` path is deferred (see §22). Implementations **MUST NOT** add a silent issuer check that only validates shape or reachability; such a check provides false assurance and is prohibited.
 
 ## 19. Failure Model (Summary)
 
@@ -497,7 +532,79 @@ The four local short-circuits (`ctx import` / `ctx ls` / `ctx use` / `vault reau
 | Import of wrong credential kind (owner JWT, random string) | client local decode | command error, directing user to `ctx add --api-key` |
 | Concurrent `put --prune` reads during transaction | server transaction | atomic — readers see old or new (Invariant #1) |
 
-## 20. Non-Goals
+## 20. I/O Contracts (CLI Emit Surface, Normative)
+
+§20 defines the I/O framing contract for every `drive9` CLI verb specified at or after this section. It exists to preserve Unix-pipe composability ("reuse POSIX, don't invent new fan-in/fan-out protocols") while keeping credential-material and identifier-material on strictly separated channels.
+
+**Scope.** Rules 1–5 apply to **Layer 2 (control-plane emit surface)** and **Layer 3 (state-binding verbs)** of the CLI. They do **not** apply to:
+- **Layer 1** data-plane reads through the mounted FUSE tree (`cat /n/vault/<s>/<k>`, `ls`, `rm`, `printf >`) — the POSIX byte contract governs those, not §20.
+- Verbs specified **before** this spec increment (legacy `drive9 secret get/grant/revoke/exec` etc.) — §20 is **applies-forward** and does not re-spec those surfaces.
+
+**Identifier Invariant (Normative MUST).** The tokens `grant_id`, context name, and `scope path` are **handles**, not credentials. No verb MUST accept them as authentication input or as a means to re-derive/retrieve a token. They are safe to pass as command-line arguments, to log, and to distribute in-band. Credentials (`DRIVE9_API_KEY`, `DRIVE9_VAULT_TOKEN`, JWT bodies) remain §14 / §16 governed and MUST NOT flow through argv.
+
+### Rule 1 — Emit mode is a three-way mutex
+
+Every Layer-2 verb that produces machine-readable output MUST expose exactly one of three emit modes per invocation, selected by mutually-exclusive flags:
+
+| Mode | Flag | Shape |
+|---|---|---|
+| `human` (default) | (no flag) | Unstructured multi-line text for terminal use. Not a stable contract. |
+| `json` | `--json` | Single JSON object to stdout, trailing LF. Stable contract. |
+| `token-only` | `--token-only` | Raw credential/artifact bytes to stdout, trailing LF. Stable contract. Intended for pipe composition. |
+
+Any two flags combined → `EINVAL` with message `"--<a> and --<b> are mutually exclusive"`. The mutex is enforced per-verb with a spec-locked flag-class table; a verb MUST declare which modes it supports and MUST reject unsupported mode flags at argv-parse time.
+
+**Out of scope for Rule 1.** Layer-3 state-binding verbs (§Rule 4) emit a single human confirmation line only; they do **not** expose `--json` or `--token-only`.
+
+### Rule 2 — Exit codes follow sysexits.h
+
+- `0` — success
+- `1` — runtime errno mapped from the operation (e.g. ENOENT, EACCES). stderr carries the human errno hint.
+- `2` — EINVAL: argv parse failure, flag mutex violation, missing required flag. stderr carries the usage line.
+- `≥64` — reserved for future sysexits codes; not used in v0.
+
+No verb may exit 0 on a partially-satisfied request. See Rule 3 for multi-scope continue-on-error semantics.
+
+### Rule 3 — Stdin vs argv is determined by payload class
+
+Verbs MUST route input by the **class of payload**, not by convenience:
+
+| Class | Channel | Rationale |
+|---|---|---|
+| **1. Credential / bulk payload** (JWT body, large blob) | stdin (default when stdin is a pipe); optional `--from-file <path>` for explicit file read; `--from-file -` for explicit stdin | Credential material MUST NOT appear in argv (visible in `ps`, shell history, `/proc/<pid>/cmdline`). Bulk payloads exceed argv size limits on some platforms. |
+| **2. Identifier list** (`grant_id`, context name, scope path) | Variadic argv: `<id1> <id2> …` | Identifiers are non-credential handles (Identifier Invariant). Fan-in composition MUST use POSIX `xargs`, not a CLI-internal stdin protocol. |
+
+**Fan-in example** (class 2):
+
+```bash
+drive9 vault revoke grt_7f2a grt_9c13 grt_bbaa
+# or via xargs:
+cat ids.txt | xargs drive9 vault revoke
+```
+
+**Continue-on-error semantics for variadic class-2 verbs.** When processing more than one identifier, the verb MUST attempt every identifier, collect per-identifier errors, and exit with the **first** non-zero errno (preserving the semantic of the earliest failure). stderr emits one line per failed identifier. A partial success MUST NOT exit 0.
+
+**Class-2 verbs ignore stdin.** When argv supplies one or more identifiers, stdin is not consumed. Redirecting stdin into a class-2 verb is not an error but the input is discarded — the verb is not a filter.
+
+**Not in scope for Rule 3.** `drive9 ctx rm <name>` remains single-arg per §13 / B1; this increment does not re-spec it as variadic. A future spec increment may extend `ctx rm` if needed.
+
+### Rule 4 — State-binding verbs are not filters
+
+Verbs that bind local state (current context, mount credential binding, filesystem mount point) — `ctx use`, `mount`, `vault reauth` — MUST take their target as an explicit argv argument and MUST NOT read stdin. They produce a single human confirmation line on stdout and are **exempt from Rule 1's `--json`/`--token-only` surface**.
+
+Rationale: state-binding verbs change global principal or mount identity. Allowing them to be the right-hand side of a pipe (`… | ctx use`) would let an unrelated producer silently rebind credentials for subsequent commands. The contract forbids it structurally; if a caller wants scripted rebinding, they compose with argv (`ctx use "$(compute_name)"`) so the data flow is explicit.
+
+### Rule 5 — Advertised composition requires an executable example
+
+Every verb that documents a pipe or composition pattern (`A | B`, `A | xargs B`) MUST ship at least one runnable example in the quickstart (`docs/guides/vault-quickstart.md`) whose exit code is asserted. Compliance is checked by the `quickstart-smoke-test` CI harness when available.
+
+**Transition clause (rule #5 enforcement deferral).** Until the `quickstart-smoke-test` CI harness (introduced by a future PR, PR-G) lands, "literal runnable" is satisfied by **review-time manual grep plus an exit-code assertion written in the code block's inline comment** (e.g. `# exit 0`). **PR-G merge is the sole triggering SHA for rule #5 enforcement**: once PR-G merges, the harness MUST run on CI before the next spec/code PR cycle (i.e. the harness becomes a required check). PR-G is the sole deferral gate; **no calendar fallback is set**. If PR-G is re-scoped or cancelled, the owner of this spec (`dev1` as §20 author) MUST open a follow-up spec-increment to explicitly adjust rule #5's enforcement path. Silent decay is not permitted.
+
+---
+
+**Appliesforward scope.** §20 applies to verbs specified at or after this section's merge SHA. Pre-existing verbs retain their current contract; any subsequent spec increment that touches one of them MUST bring it into §20 compliance as part of the same delta.
+
+## 21. Non-Goals
 
 - No migration or backward-compatibility surface in this spec; this document is terminal-state only.
 - No single unified credential variable that merges `DRIVE9_API_KEY` and `DRIVE9_VAULT_TOKEN` (the dual-principal separation is a contract, §14.1).
@@ -506,7 +613,7 @@ The four local short-circuits (`ctx import` / `ctx ls` / `ctx use` / `vault reau
 - No automatic token auto-mint on behalf of the owner; every delegated credential must come from an explicit `vault grant`.
 - No client-side issuer pinning or allow-list in v0. `ctx import` trusts the JWT `iss` on first use (§13.3 TOFU note). A follow-up spec may introduce `ctx add --trusted-issuer` and/or an `--expect-issuer` flag on `ctx import`; both are additive and do not change §13.1 or §16.
 
-## 21. Open Questions (Spec-Level)
+## 22. Open Questions (Spec-Level)
 
 - **Issuer trust hardening (TOFU → pinned).** Invariant #8 locks v0 at trust-on-first-use. A follow-up spec should decide between (a) an issuer allow-list pinned at `ctx add --api-key` time, (b) an `--expect-issuer <url>` flag on `ctx import`, or (c) an out-of-band manifest fetched from the owner server during `ctx add`. Each has different forward-compat implications for `/etc/drive9.conf` site-policy files; none are trivially additive once deployed. Resolution target: the release that introduces multi-issuer federation.
 - **Forward-compat of the `iss` claim under server rebranding / domain migration.** If an owner server migrates from `https://d9.old.example` to `https://d9.new.example`, all outstanding delegated contexts hold the old `iss` and will route to the old host. v0 has no in-band way to rotate `iss` across existing grants. A follow-up should specify whether this is handled by (a) explicit re-grant + `ctx import`, (b) a server-signed redirect manifest keyed off the old `iss`, or (c) left as "owner reissues all delegated tokens". Resolution target: the release that introduces `vault reauth --server <new>` or equivalent.

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -122,8 +122,6 @@ expires_at: 2026-04-18T19:00:00Z
 
 Owner sends this message to the delegatee over a secure channel. The delegatee copies the JWT line and pipes it into `ctx import` (see §13.3 for supported input modes). The JWT is displayed once by the server and is not re-fetchable.
 
-Delegatees **SHOULD NOT** paste the JWT as a positional argument in an interactive shell — it would land in shell history and in `/proc/<pid>/cmdline` while the import is running. `ctx import --from-file <path>` and `ctx import --from-file -` (stdin) are the safe forms; see §13.3.
-
 The default human output is **not a stable parse target** — the exact layout (label prefix, `---` separator, field ordering) may change for readability. Scripts **MUST** use `--json` or `--token-only`.
 
 ### Machine output
@@ -219,6 +217,17 @@ Core rules:
 - **Writes**: `EACCES`. The write intent already names the key, so a fake-not-found would be a lie without benefit.
 - **Stale auth**: `EACCES`, distinguished from “not found.”
 
+`ctx import` refusal causes — these are client-side command errors that also map to POSIX errno when the CLI exits:
+
+| `ctx import` refusal cause | Errno |
+|---|---|
+| Empty / unparseable / structurally invalid JWT | `EINVAL` |
+| Missing required claim (`iss`, `exp`, `perm`, `principal_type`, `agent`) | `EINVAL` |
+| Token `principal_type` is not `"delegated"` | `EINVAL` |
+| Token `exp` already in the past at import | `EACCES` |
+| `--from-file <path>` names a non-existent or unreadable file | `ENOENT` |
+| Stdin is a TTY and no input flag given | `EINVAL` (with help pointer) |
+
 This table is locked. The auth lifecycle (§17) layers **local short-circuits** (e.g. `ctx use` on an expired context refuses client-side) **on top of** the server-side stale-auth case — those short-circuits do not introduce a new errno.
 
 **Annotation convention.** Where example outputs in this spec and the quickstart show errno lines followed by parenthetical guidance (e.g. `cat: Permission denied  (run 'drive9 vault reauth' after updating the context)`), the parenthetical is a **documentation annotation** intended for the reader, not literal `cat`/`ls` stderr output. The POSIX `cat`/`ls` utilities emit only the errno text; the reauth hint is a spec-level explanation of what the user should do next, delivered out-of-band (man page, quickstart, CLI `drive9 vault reauth` documentation). No new verb is introduced to deliver this hint inline.
@@ -262,15 +271,14 @@ The delegated fields are populated by locally decoding the JWT payload (see §16
 
 ```bash
 drive9 ctx add --api-key <key> [--name <n>] [--server <url>]      # add owner context
-drive9 ctx import --from-file <path>                              # add delegated context from a file (recommended)
-drive9 ctx import --from-file -                                   # add delegated context from stdin (recommended)
-drive9 ctx import <jwt>                                           # convenience form; JWT leaks to shell history
+drive9 ctx import --from-file <path>                              # add delegated context from a file
+drive9 ctx import [--from-file -]                                 # add delegated context from stdin (default when stdin is a pipe)
 drive9 ctx ls [-l|--json]                                         # list contexts (offline — reads only local config)
 drive9 ctx use <name>                                             # activate a context
 drive9 ctx rm <name>                                              # delete a context
 ```
 
-All three `ctx import` forms are equivalent in effect. The file-based and stdin forms are safer for bearer credentials because the JWT never touches the shell's history file or `/proc/<pid>/cmdline`. The positional-argument form is retained for scripting and local testing only.
+Both `ctx import` forms are equivalent in effect. Stdin is read by default when stdin is a pipe (`isatty(0) == false`); the explicit `--from-file -` form is accepted for scripts that want the intent to be unambiguous. When stdin is a TTY and no `--from-file` is supplied, `ctx import` exits with `EINVAL` and prints a one-line help pointing at the two canonical forms (see §13.3).
 
 `ctx ls` output:
 
@@ -296,17 +304,22 @@ SCOPE rendering:
 Input modes:
 
 - `drive9 ctx import --from-file <path>` reads the JWT from a file.
-- `drive9 ctx import --from-file -` reads the JWT from stdin.
-- `drive9 ctx import <jwt>` reads the JWT from the positional argument (convenience; see security note below).
+- `drive9 ctx import --from-file -` reads the JWT from stdin explicitly.
+- `drive9 ctx import` (no arguments) reads the JWT from stdin iff stdin is not a TTY. When stdin is a TTY, `ctx import` exits `EINVAL` and prints:
 
-In all three modes, the JWT must be a single token with surrounding whitespace trimmed.
+  ```
+  error: no JWT on stdin. Use one of:
+    drive9 ctx import --from-file <path>
+    <producer> | drive9 ctx import
+  ```
+
+In both modes (file and stdin), the JWT must be a single token with surrounding whitespace trimmed. The JWT **MUST NOT** be passed as a positional argument; that form was removed because a runtime warning cannot unexpose a secret that has already reached shell history and `/proc/<pid>/cmdline`.
 
 Contract rules:
 
 - Input **MUST** be a delegated JWT. If the payload indicates `principal_type=owner` (or any non-delegated credential), `ctx import` **MUST** refuse and instruct the user to use `ctx add --api-key`. `ctx import` is not a universal credential importer.
 - If the JWT's `exp` is already in the past at import time, `ctx import` **MUST** refuse (local short-circuit #1 — see §17). The `exp` check uses the local wall clock with no skew tolerance in v0; delegatees with badly skewed clocks will see spurious refusals or admissions and are expected to fix their clocks (NTP).
 - Default context name is the JWT's `label_hint`; on collision or absence, fall back to `<agent>-<scope-root>` with a numeric suffix as needed. `--name` overrides.
-- The positional-argument form **SHOULD NOT** be used in interactive shells — the JWT would be recorded in shell history and exposed via `/proc/<pid>/cmdline` while the process runs. Owners **SHOULD** distribute grants as files or piped input; the default grant output (§6) is formatted accordingly.
 
 **Issuer trust note (client-side first-use trust).** `ctx import` populates the delegated context's `server` field from the JWT's `iss` claim with **no network round-trip and no allow-list check**. This is trust-on-first-use: a fresh delegatee who imports a maliciously crafted JWT with attacker-controlled `iss` (self-signed by the attacker) will write an attacker server URL into their config, and subsequent requests will be routed there. Invariant #7 ("server MUST re-validate") does **not** protect against this path — the server being contacted is itself attacker-controlled and will happily validate its own signatures. Mitigation is out of scope for v0 and lives with the owner's distribution channel: grants **MUST** be transmitted through a channel that authenticates the sender (password-manager share, Signal, GPG-signed email — not plaintext email, not public paste services). A follow-up hardening path (issuer allow-list pinned at `ctx add --api-key` time, or an explicit `--expect-issuer` flag on `ctx import`) is tracked as a non-blocking follow-up; it is additive to the current payload and does not change §13.1 / §13.2 / §16.
 
@@ -368,7 +381,7 @@ drive9 vault grant /n/vault/prod-db/DB_URL --agent alice --perm read --ttl 1h
 # expires_at: 2026-04-18T19:00:00Z
 ```
 
-Owner sends Alice the whole block through a secure channel (password-manager share, Signal, password-protected email). The JWT line is the bearer credential; do not paste it as a positional arg into a shell.
+Owner sends Alice the whole block through a secure channel (password-manager share, Signal, password-protected email). The JWT line is the bearer credential; Alice saves it to a file or pipes it into `ctx import` — see §13.3.
 
 ### Alice
 
@@ -434,7 +447,7 @@ Local short-circuits exist to make UX responsive. They are layered **on top of**
 
 | Stage | Check | Outcome |
 |---|---|---|
-| `ctx import <jwt>` | `exp` in past? | local refuse (no new errno; command error) |
+| `ctx import` | `exp` in past? | local refuse (no new errno; command error) |
 | `ctx ls` | `exp` in past? | row marked `expired` |
 | `ctx use <name>` | target context expired? | local error, do not activate |
 | `vault reauth <mountpoint>` | active context valid locally? | local refuse if target context is already locally expired; otherwise proceed and let the server bind |
@@ -489,8 +502,7 @@ Appendix A — Command surface at a glance:
 | `drive9 umount <path>` | Unmount. |
 | `drive9 ctx add --api-key <k>` | Register an owner context. |
 | `drive9 ctx import --from-file <path>` | Register a delegated context from a grant JWT file (primary UX). |
-| `drive9 ctx import --from-file -` | Same, reading the JWT from stdin (recommended for piping). |
-| `drive9 ctx import <jwt>` | Convenience form; leaks to shell history (see §13.3 / §16). |
+| `drive9 ctx import [--from-file -]` | Same, reading the JWT from stdin (default when stdin is a pipe). |
 | `drive9 ctx ls / use / rm` | Manage contexts (offline). |
 | `drive9 vault put <path> --from <dir> [--prune]` | Atomic batch write. |
 | `drive9 vault grant <scope>... --agent --perm --ttl` | Issue a scoped JWT. |

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -217,16 +217,25 @@ Core rules:
 - **Writes**: `EACCES`. The write intent already names the key, so a fake-not-found would be a lie without benefit.
 - **Stale auth**: `EACCES`, distinguished from “not found.”
 
-`ctx import` refusal causes — these are client-side command errors that also map to POSIX errno when the CLI exits:
+`ctx import` refusal causes — these are client-side command errors that also map to POSIX errno when the CLI exits. The CLI exit code convention is `2` for `EINVAL` (usage, per `sysexits.h` `EX_USAGE`) and `1` for `EACCES` / `ENOENT`.
 
-| `ctx import` refusal cause | Errno |
-|---|---|
-| Empty / unparseable / structurally invalid JWT | `EINVAL` |
-| Missing required claim (`iss`, `exp`, `perm`, `principal_type`, `agent`) | `EINVAL` |
-| Token `principal_type` is not `"delegated"` | `EINVAL` |
-| Token `exp` already in the past at import | `EACCES` |
-| `--from-file <path>` names a non-existent or unreadable file | `ENOENT` |
-| Stdin is a TTY and no input flag given | `EINVAL` (with help pointer) |
+| `ctx import` refusal cause | Errno | Exit code |
+|---|---|---|
+| Input empty after whitespace trim | `EINVAL` | `2` |
+| Not a structurally valid JWT (three base64url segments, JSON middle) | `EINVAL` | `2` |
+| Missing `principal_type` claim | `EINVAL` | `2` |
+| `principal_type` is not `"delegated"` | `EINVAL` | `2` |
+| Missing `exp` claim | `EINVAL` | `2` |
+| `exp` already in the past at import | `EACCES` | `1` |
+| Missing `iss` claim | `EINVAL` | `2` |
+| Missing `agent` claim | `EINVAL` | `2` |
+| Missing `grant_id` claim | `EINVAL` | `2` |
+| Missing or empty `scope[]` claim | `EINVAL` | `2` |
+| Missing `perm` claim | `EINVAL` | `2` |
+| `perm` not in `{read, write}` | `EINVAL` | `2` |
+| `--from-file <path>` names a non-existent or unreadable file | `ENOENT` | `1` |
+| `--from-file <path>` has mode group- or world-readable (`mode & 0o077 != 0`) | `EACCES` | `1` |
+| Stdin is a TTY and no input flag given | `EINVAL` (with help pointer) | `2` |
 
 This table is locked. The auth lifecycle (§17) layers **local short-circuits** (e.g. `ctx use` on an expired context refuses client-side) **on top of** the server-side stale-auth case — those short-circuits do not introduce a new errno.
 
@@ -280,6 +289,14 @@ drive9 ctx rm <name>                                              # delete a con
 
 Both `ctx import` forms are equivalent in effect. Stdin is read by default when stdin is a pipe (`isatty(0) == false`); the explicit `--from-file -` form is accepted for scripts that want the intent to be unambiguous. When stdin is a TTY and no `--from-file` is supplied, `ctx import` exits with `EINVAL` and prints a one-line help pointing at the two canonical forms (see §13.3).
 
+**Canonical pipe handoff.** The default human output of `drive9 vault grant` (see §6) is *not* pipe-safe — it prints `grant_id` and `expires_at` lines in addition to the JWT. To pipe grant output directly into `ctx import`, use `drive9 vault grant ... --token-only`, which prints only the bare JWT. The end-to-end canonical pipeline is:
+
+```bash
+drive9 vault grant <scope> --agent <a> --perm <p> --ttl <t> --token-only | drive9 ctx import
+```
+
+The human default form is intentionally non-parseable; it exists so an owner reading their terminal can eyeball the grant id and expiry, not so it can be piped.
+
 `ctx ls` output:
 
 ```
@@ -319,6 +336,8 @@ Contract rules:
 
 - Input **MUST** be a delegated JWT. If the payload indicates `principal_type=owner` (or any non-delegated credential), `ctx import` **MUST** refuse and instruct the user to use `ctx add --api-key`. `ctx import` is not a universal credential importer.
 - If the JWT's `exp` is already in the past at import time, `ctx import` **MUST** refuse (local short-circuit #1 — see §17). The `exp` check uses the local wall clock with no skew tolerance in v0; delegatees with badly skewed clocks will see spurious refusals or admissions and are expected to fix their clocks (NTP).
+- The JWT **MUST** contain all required delegated-context claims: `iss`, `exp`, `principal_type=delegated`, `agent`, `grant_id`, `scope[]` (non-empty array), and `perm` ∈ `{read, write}`. Missing or malformed required claims refuse at import; the full per-claim error mapping is in §11.
+- When `--from-file <path>` is given, the file **MUST** be mode `0600` (no group or world permission bits). If `stat.Mode().Perm() & 0o077 != 0`, `ctx import` refuses **before reading the contents** with `EACCES` and points the user at `chmod 600`. Rationale: a bearer-token file that has leaked to other local users is already-exposed credential; silently consuming it makes the CLI complicit in the lifecycle breach. This matches the argv-removal posture: the tool does not ingest credentials that have already escaped their intended confidentiality boundary.
 - Default context name is the JWT's `label_hint`; on collision or absence, fall back to `<agent>-<scope-root>` with a numeric suffix as needed. `--name` overrides.
 
 **Issuer trust note (client-side first-use trust).** `ctx import` populates the delegated context's `server` field from the JWT's `iss` claim with **no network round-trip and no allow-list check**. This is trust-on-first-use: a fresh delegatee who imports a maliciously crafted JWT with attacker-controlled `iss` (self-signed by the attacker) will write an attacker server URL into their config, and subsequent requests will be routed there. Invariant #7 ("server MUST re-validate") does **not** protect against this path — the server being contacted is itself attacker-controlled and will happily validate its own signatures. Mitigation is out of scope for v0 and lives with the owner's distribution channel: grants **MUST** be transmitted through a channel that authenticates the sender (password-manager share, Signal, GPG-signed email — not plaintext email, not public paste services). A follow-up hardening path (issuer allow-list pinned at `ctx add --api-key` time, or an explicit `--expect-issuer` flag on `ctx import`) is tracked as a non-blocking follow-up; it is additive to the current payload and does not change §13.1 / §13.2 / §16.


### PR DESCRIPTION
## Purpose

Spec-first PR for **PR-B** (the CLI `ctx` verb family) of the vault-implementation 7-PR plan.
Code will land in a follow-up PR (B2/B3/B4) cherry-picked against **this PR's merge SHA**.

Per the SHA-bound handoff protocol converged in #onepassword (`678e76a9`, `ccb1755d`), this PR is the review gate for the full PR-B contract. Code PR cannot start until both adversaries sign off on this spec SHA.

## What this PR contains

**New:**
- `docs/specs/pr-b-ctx-implementation.md` — per-verb behavior, test plan, file map, zero-legacy gate, scope lock.
- `docs/specs/pr-b-review-checklist.md` — SHA-bound review checklist.

**Edits to merged end-state spec** (per adv-1 `4f032af0` + adv-2 `7efae6dc` converged sign-off criteria):
- `§13.2` verb table — drop positional `ctx import <jwt>` row; stdin row shows default-when-pipe + explicit `--from-file -`. Adds canonical-pipe-form bullet naming `drive9 vault grant ... --token-only | drive9 ctx import`.
- `§13.3` input modes — two forms (file, stdin-default); TTY-no-flag exits `EINVAL` with literal help-pointer string. Adds required-claim MUST list (iss/exp/principal_type/agent/grant_id/scope[]/perm). Adds `--from-file` mode-bit refusal (mode & 0o077 != 0 → EACCES before read).
- `§6` grant output — drop obsolete SHOULD-NOT positional warning.
- `§15` Alice block — prose no longer references positional pasting.
- `§17` short-circuit table — `ctx import` row refreshed.
- `§11` errno table — add `ctx import` refusal sub-table with 15 rows (1:1 with parse fork + file-read + file-mode + TTY-no-flag), including explicit CLI exit code column.

**Edits to user-facing guide** (per adv-1 `4f032af0` repo-grounded line scope):
- `docs/guides/vault-quickstart.md:113, :172` — drop positional endorsement; pipe-default explained.

## Why drop the positional form

Plan 9 / Unix convention: bearer material never in `argv`. Matches `ssh-add`, `pass insert`, `gpg --import`, `vault login -method=token`. A runtime warning cannot unexpose a secret that has already reached shell history or `/proc/<pid>/cmdline` — removing the form is the only real fix. Per @qiffang `82a43eb2` directive: "非常非常的优雅, 符合 unix 和 plan9 的设计哲学".

## Known non-regression tradeoff — `ctx add --api-key <key>` (M1)

`drive9 ctx add --api-key <key>` passes the API key as an argv token. Same `/proc/<pid>/cmdline` and shell-history exposure profile as the removed positional JWT form. Retained for PR-B because:

- API keys are paste-once, setup-time credentials — a stdin-prompt bootstrap flow is kubectl-style bloat for a single interactive step.
- No existing stream-handoff pattern for the owner credential (JWT has `vault grant --token-only`; API key has no producer).

Mitigations to consider in a follow-up (non-blocking for PR-B):
- `--api-key-file <path>` with mode-bit check (mirror of F8 on `ctx import --from-file`).
- `DRIVE9_API_KEY` env var (in PR-C scope).

Flagged here so it ships openly, not silently. If @qiffang or reviewers think this tradeoff is wrong, surface now rather than after B4.

## Scope lock (what this PR does NOT change)

- Verb surface remains **5 verbs** (`add / import / ls / use / rm`) plus the bare `ctx` no-verb compatibility form that prints the current context name — locked by merged PR #272 §13.2. Any 3-verb redesign is a post-PR-E conversation (adv-2 retract in `7efae6dc`).
- Env-var resolution (`DRIVE9_VAULT_TOKEN` / `DRIVE9_API_KEY` / `DRIVE9_SERVER`) deferred to **PR-C**.
- Legacy `CapToken*` / `vault_tokens` deletion deferred to **PR-E** (§10 binding contract).
- Mount-rebind (`vault reauth`) deferred to **PR-D**.
- No code change. `pkg/**` and `cmd/**` are untouched. Review gate §B enforces grep=0 on legacy token types within `cmd/** pkg/**` (the `docs/specs/` migration text is exempt, per M2 rescope).

## Reviewer protocol

**Sign-off is SHA-bound.** Post exactly one of:

- `APPROVE SHA=<sha>` — walked every item in the checklist, no gaps.
- `REQUEST CHANGES SHA=<sha> — items [X.N, Y.M] failed: ...`

Partial approvals are rejected in favor of REQUEST CHANGES.

**Axis-enumeration sweep required** (per `feedback_review_gate_axis_enumeration.md`): walk every numbered §13/§14/§15/§6/§11/§17/§19 section and confirm each is either mirrored in the checklist or explicitly deferred. The checklist §M enumerates this explicitly so there's a single checkable list.

## Related

- Implements: https://github.com/mem9-ai/drive9/pull/273 (PR-A, merged `3960805`)
- Partial borrow: https://github.com/mem9-ai/drive9/pull/274 (dev3 PR — `ctx.go` / `ctx_test.go` / `jwt.go` / `config.go` will be cherry-picked in B2, stripped of `CapToken` mutations)
- Impl spec (this repo): `docs/specs/pr-a-jwt-implementation.md` line 29 places `ctx` in PR-B; line 31 places env-vars in PR-C (the scope-partition anchor).

## Reviewers

@adversary-1 @adversary-2 — ping once you sign off with SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed positional JWT import; only file attachment or piped stdin supported.
  * Clarified stdin behavior: pipe ⇒ read JWT by default; TTY ⇒ refuse with short help unless explicit file flag used.
  * Added permission/security requirements for grant files and explicit errno/exit-code behaviors.
  * Added comprehensive spec and review-checklist covering the `ctx` command family, output formats, and CLI I/O contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->