### PR TITLE
fix(drive9-py): protect concurrent seek+read with locks in upload paths

### DIFF
--- a/clients/drive9-py/drive9/transfer.py
+++ b/clients/drive9-py/drive9/transfer.py
@@ -59,6 +59,7 @@ def _compute_part_checksums(file_obj, total_size: int, part_size: int) -> list:
     checksums = [None] * len(parts)
     first_err = None
     err_lock = threading.Lock()
+    file_lock = threading.Lock()
 
     def worker(chunk_indices):
         nonlocal first_err
@@ -68,8 +69,9 @@ def _compute_part_checksums(file_obj, total_size: int, part_size: int) -> list:
                 return
             p = parts[idx]
             offset = (p["number"] - 1) * part_size
-            file_obj.seek(offset)
-            n = file_obj.readinto(buf)
+            with file_lock:
+                file_obj.seek(offset)
+                n = file_obj.readinto(buf)
             if n != p["size"]:
                 with err_lock:
                     if first_err is None:
@@ -315,11 +317,13 @@ class TransferMixin:
         if std_part_size <= 0:
             std_part_size = _PART_SIZE
         max_concurrency = _upload_parallelism(std_part_size)
+        file_lock = threading.Lock()
 
         def upload_one(part: PartURL):
             offset = (part.number - 1) * std_part_size
-            file_obj.seek(offset)
-            data = file_obj.read(part.size)
+            with file_lock:
+                file_obj.seek(offset)
+                data = file_obj.read(part.size)
             if len(data) != part.size:
                 raise Drive9Error(
                     f"short read for part {part.number}: got {len(data)} want {part.size}"
@@ -422,11 +426,13 @@ class TransferMixin:
             presigned.extend(batch)
 
         results = [None] * total_parts
+        file_lock = threading.Lock()
 
         def upload_one(pp: dict):
             offset = (pp["number"] - 1) * part_size
-            file_obj.seek(offset)
-            data = file_obj.read(pp["size"])
+            with file_lock:
+                file_obj.seek(offset)
+                data = file_obj.read(pp["size"])
             if len(data) != pp["size"]:
                 raise Drive9Error(
                     f"short read for part {pp['number']}: got {len(data)} want {pp['size']}"
@@ -581,11 +587,13 @@ class TransferMixin:
         if std_part_size <= 0:
             std_part_size = _PART_SIZE
         max_concurrency = _upload_parallelism(std_part_size)
+        file_lock = threading.Lock()
 
         def upload_one(part: PartURL):
             offset = (part.number - 1) * std_part_size
-            file_obj.seek(offset)
-            data = file_obj.read(part.size)
+            with file_lock:
+                file_obj.seek(offset)
+                data = file_obj.read(part.size)
             if len(data) != part.size:
                 raise Drive9Error(
                     f"short read for part {part.number}: got {len(data)} want {part.size}"


### PR DESCRIPTION
## Summary

Multiple upload workers perform `seek()` followed by `read()/readinto()` on a shared `file_obj` without any synchronization. Because multiple threads update the shared file position concurrently, they can race and silently checksum or upload the wrong bytes.

## Changes

Add a `threading.Lock()` around each seek-read pair in:

- `_compute_part_checksums`
- `_upload_parts_v1`
- `_upload_parts_v2`
- `_upload_missing_parts`

This is the simplest fallback suggested in the issue (option 3).

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety for concurrent file transfer operations to prevent potential data inconsistencies during simultaneous file access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->