### PR TITLE
fix(drive9-py): use CRC32C instead of CRC32 for part checksums

### DIFF
--- a/clients/drive9-py/drive9/transfer.py
+++ b/clients/drive9-py/drive9/transfer.py
@@ -30,9 +30,28 @@ def _checksum_parallelism(part_size: int, part_count: int) -> int:
     return min(part_count, by_memory)
 
 
+def _make_crc32c_table():
+    table = [0] * 256
+    for i in range(256):
+        crc = i
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ 0x82F63B78
+            else:
+                crc >>= 1
+        table[i] = crc
+    return table
+
+
+_CRC32C_TABLE = _make_crc32c_table()
+
+
 def _compute_crc32c(data: bytes) -> str:
-    v = zlib.crc32(data, 0xFFFFFFFF) & 0xFFFFFFFF
-    b = struct.pack(">I", v)
+    crc = 0xFFFFFFFF
+    for byte in data:
+        crc = _CRC32C_TABLE[(crc ^ byte) & 0xFF] ^ (crc >> 8)
+    crc = (~crc) & 0xFFFFFFFF
+    b = struct.pack(">I", crc)
     return base64.b64encode(b).decode("ascii")
 
 


### PR DESCRIPTION
## Summary

The Python SDK was using `zlib.crc32()`, which implements the IEEE CRC32 polynomial, not the Castagnoli CRC32C polynomial required by the S3-compatible multipart protocol (`x-amz-checksum-crc32c`). This caused uploads initiated by the Python SDK to generate checksums incompatible with the Go client and server-side validation.

## Changes

Replace `_compute_crc32c` with a pure-Python CRC32C lookup-table implementation so that checksums match the Go client without adding an external dependency.

Closes #229