### PR TITLE
fix(drive9-js): send total_size instead of size in v2 upload initiate

### DIFF
--- a/clients/drive9-js/src/transfer.ts
+++ b/clients/drive9-js/src/transfer.ts
@@ -334,7 +334,7 @@ async function initiateUploadV2(
   const resp = await fetch(`${client.baseUrl}/v2/uploads/initiate`, {
     method: "POST",
     headers: client["authHeaders"]({ "Content-Type": "application/json" }),
-    body: JSON.stringify({ path, size, expected_revision: expectedRevision }),
+    body: JSON.stringify({ path, total_size: size, expected_revision: expectedRevision }),
   });
   if (resp.status === 404) {
     throw new Drive9Error("v2 upload API not available");


### PR DESCRIPTION
## Summary

The TypeScript SDK was sending `"size"` in the JSON body when initiating a v2 upload, but the backend contract expects `"total_size"`. This protocol mismatch broke large-file v2 uploads against the current backend.

## Changes

Change the payload key from `size` to `total_size` in `initiateUploadV2`.

Closes #230