### PR TITLE
fix(drive9-rs): add part_size and expected_revision to patch_file

### DIFF
--- a/clients/drive9-rs/src/patch.rs
+++ b/clients/drive9-rs/src/patch.rs
@@ -14,14 +14,22 @@ impl Client {
         new_size: i64,
         dirty_parts: &[i32],
         read_part: F,
+        part_size: Option<i64>,
+        expected_revision: Option<i64>,
     ) -> Result<(), Drive9Error>
     where
         F: Fn(i32, i64, Option<&[u8]>) -> Result<Vec<u8>, Drive9Error> + Send + Sync + 'static,
     {
-        let body = json!({
+        let mut body = json!({
             "new_size": new_size,
             "dirty_parts": dirty_parts,
         });
+        if let Some(ps) = part_size {
+            body["part_size"] = json!(ps);
+        }
+        if let Some(er) = expected_revision {
+            body["expected_revision"] = json!(er);
+        }
         let resp = self
             .http
             .patch(self.fs_url(path))


### PR DESCRIPTION
## Summary

The Rust SDK's `patch_file()` only sent `new_size` and `dirty_parts`, but the Go client also exposes `part_size` and `expected_revision`. Omitting these fields meant the Rust SDK lacked full feature parity and could not enforce CAS semantics for concurrent updates.

## Changes

- Add `part_size: Option<i64>` and `expected_revision: Option<i64>` parameters to `patch_file`.
- Include the fields in the PATCH request body when they are provided.

Closes #231