### PR TITLE
fix(drive9-js): upload final part before setting closing in StreamWriter.complete()

### DIFF
--- a/clients/drive9-js/src/stream.ts
+++ b/clients/drive9-js/src/stream.ts
@@ -123,12 +123,11 @@ export class StreamWriter {
     if (this.state.aborted) {
       throw new Drive9Error("stream writer already aborted");
     }
-    this.state.closing = true;
-
     if (finalPartData.length > 0) {
       await this.writePart(finalPartNum, finalPartData);
     }
 
+    this.state.closing = true;
     await this.waitInflight();
 
     if (!this.state.started || !this.state.plan) {


### PR DESCRIPTION
## Summary

`StreamWriter.complete()` set `state.closing = true` before calling `writePart()` for the final chunk. However, `writePart()` immediately rejects with "stream writer is closing" when `closing` is already `true`. This meant any stream upload that provided a non-empty final part would fail.

## Changes

Move the closing guard so that the final part is submitted via `writePart()` first, then `closing` is set and we wait for all inflight uploads to finish.

Closes #232