### PR TITLE
fix(drive9-rs): move semaphore permit into spawned upload task

### DIFF
--- a/clients/drive9-rs/src/stream.rs
+++ b/clients/drive9-rs/src/stream.rs
@@ -123,7 +123,7 @@ impl StreamWriter {
         state.inflight += 1;
         drop(state);
 
-        let _permit = self.sem.acquire().await.unwrap();
+        let permit = self.sem.acquire().await.unwrap();
         let client = self.client.clone();
         let data = data.clone();
         let upload_id = plan.upload_id;
@@ -132,6 +132,7 @@ impl StreamWriter {
         // The caller must later call complete()/abort() which wait for inflight.
         let this_state = std::sync::Arc::clone(&self.state);
         tokio::spawn(async move {
+            let _permit = permit;
             let result = async {
                 let pp = client.presign_one_part(&upload_id, part_num).await?;
                 let etag = client.upload_one_part_v2(&upload_id, &pp, &data).await?;


### PR DESCRIPTION
## Summary

`StreamWriter::write_part()` acquired a semaphore permit but bound it to `let _permit`, which was dropped at the end of the `write_part` scope — before the spawned Tokio task actually completed. This defeated the `UPLOAD_MAX_CONCURRENCY` limit and allowed all parts to be uploaded simultaneously.

## Changes

Move the permit into the spawned task (rename to `permit`, capture it in the closure, and hold it until the task finishes) so that the semaphore correctly limits the number of concurrent part uploads.

Closes #233