### PR TITLE
fix(drive9-js): replace Buffer.from with isomorphic bytesToBase64 helper

### DIFF
--- a/clients/drive9-js/src/patch.ts
+++ b/clients/drive9-js/src/patch.ts
@@ -76,8 +76,13 @@ async function uploadPatchPart(client: Client, part: PatchPartURL, readPart: Rea
   await checkError(resp);
 }
 
+function bytesToBase64(bytes: Uint8Array): string {
+  const binString = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
+  return (globalThis as any).btoa(binString);
+}
+
 async function sha256Base64(data: Uint8Array): Promise<string> {
   const hash = await crypto.subtle.digest("SHA-256", bufferSource(data));
-  return Buffer.from(hash).toString("base64");
+  return bytesToBase64(new Uint8Array(hash));
 }
 

--- a/clients/drive9-js/src/transfer.ts
+++ b/clients/drive9-js/src/transfer.ts
@@ -25,23 +25,30 @@ const CRC32C_TABLE = new Int32Array(256);
   }
 })();
 
+function bytesToBase64(bytes: Uint8Array): string {
+  const binString = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
+  return (globalThis as any).btoa(binString);
+}
+
 export function computeCrc32c(data: Uint8Array): string {
   let crc = ~0;
   for (let i = 0; i < data.length; i++) {
     crc = (crc >>> 8) ^ CRC32C_TABLE[(crc ^ data[i]) & 0xff];
   }
   crc = ~crc >>> 0;
-  return Buffer.from([
-    (crc >>> 24) & 0xff,
-    (crc >>> 16) & 0xff,
-    (crc >>> 8) & 0xff,
-    crc & 0xff,
-  ]).toString("base64");
+  return bytesToBase64(
+    new Uint8Array([
+      (crc >>> 24) & 0xff,
+      (crc >>> 16) & 0xff,
+      (crc >>> 8) & 0xff,
+      crc & 0xff,
+    ])
+  );
 }
 
 async function sha256Base64(data: Uint8Array): Promise<string> {
   const hash = await crypto.subtle.digest("SHA-256", data);
-  return Buffer.from(hash).toString("base64");
+  return bytesToBase64(new Uint8Array(hash));
 }
 
 async function streamToUint8Array(stream: ReadableStream<Uint8Array>, size: number): Promise<Uint8Array> {


### PR DESCRIPTION
## Summary

The TypeScript SDK used `Buffer.from(...).toString("base64")`, which is a Node.js-only API and breaks in browsers and edge runtimes without a polyfill.

## Changes

Replace all occurrences with a small `bytesToBase64` helper that uses `String.fromCharCode` + `globalThis.btoa`, which works in both Node 18+ and browser/edge environments.

Affected files:
- `src/transfer.ts` (`computeCrc32c` and `sha256Base64`)
- `src/patch.ts` (`sha256Base64`)

Closes #234