### PR TITLE
fix(drive9-js): abort v2 upload when uploadPartsV2 fails

### DIFF
--- a/clients/drive9-js/src/transfer.ts
+++ b/clients/drive9-js/src/transfer.ts
@@ -204,8 +204,8 @@ async function writeStreamV2(
   expectedRevision: number
 ): Promise<void> {
   const plan = await initiateUploadV2(client, path, data.length, expectedRevision);
-  const parts = await uploadPartsV2(client, plan, data);
   try {
+    const parts = await uploadPartsV2(client, plan, data);
     await completeUploadV2(client, plan.upload_id, parts);
   } catch (err) {
     await abortUploadV2(client, plan.upload_id);


### PR DESCRIPTION
## Summary

`writeStreamV2()` only called `abortUploadV2()` when `completeUploadV2()` failed. If `uploadPartsV2()` threw an exception, the server-side upload remained orphaned and active.

## Changes

Wrap both `uploadPartsV2` and `completeUploadV2` in a try/catch so that any failure in either step triggers `abortUploadV2(client, plan.upload_id)` before rethrowing the original error.

Closes #235