### PR TITLE
fix(drive9-py): call _check_error() in patch_file before fallback StatusError

### DIFF
--- a/clients/drive9-py/drive9/patch.py
+++ b/clients/drive9-py/drive9/patch.py
@@ -51,6 +51,7 @@ class PatchMixin:
             headers={"Content-Type": "application/json"},
         )
         if resp.status_code != 202:
+            self._check_error(resp)
             raise StatusError(
                 resp.text,
                 status_code=resp.status_code,


### PR DESCRIPTION
## Summary

`patch_file()` raised a raw `StatusError` for any non-202 response from the PATCH plan endpoint, bypassing the shared `_check_error()` logic used by every other client method. This meant HTTP 409 (conflict) responses no longer surfaced as `ConflictError`, breaking the public error contract.

## Changes

Call `self._check_error(resp)` before the fallback `StatusError` so that 409s continue to be mapped correctly.

Closes #236