### PR TITLE
fix(drive9-py): catch all exceptions in StreamWriter worker thread

### DIFF
--- a/clients/drive9-py/drive9/stream.py
+++ b/clients/drive9-py/drive9/stream.py
@@ -101,7 +101,7 @@ class StreamWriter:
                 etag = self._client._upload_one_part_v2(plan["upload_id"], pp, buf)
                 with self._mu:
                     self._uploaded[part_num] = {"number": part_num, "etag": etag}
-            except (requests.RequestException, OSError) as exc:
+            except Exception as exc:
                 self._set_error(Drive9Error(f"upload part {part_num}: {exc}"))
             finally:
                 with self._mu:


### PR DESCRIPTION
## Summary

`StreamWriter`'s `do_upload` worker only caught `requests.RequestException` and `OSError`. If `_presign_one_part()` or `_upload_one_part_v2()` raised a `StatusError` (or any other `Drive9Error` subclass), the exception propagated uncaught and crashed the thread-pool worker without calling `_set_error()`. Other code waiting on the stream would hang or never see the failure.

## Changes

Broaden the except clause to catch `Exception` so that any upload failure is properly recorded via `_set_error()` and the stream can fail gracefully.

Closes #237