### PR TITLE
fix(drive9-rs): skip Host headers and reject invalid header names in patch.rs

### DIFF
--- a/clients/drive9-rs/src/patch.rs
+++ b/clients/drive9-rs/src/patch.rs
@@ -78,12 +78,15 @@ impl Client {
             let mut headers = HeaderMap::new();
             if let Some(ref rh) = part.read_headers {
                 for (k, v) in rh {
+                    if k.eq_ignore_ascii_case("host") {
+                        continue;
+                    }
                     if let Ok(hv) = reqwest::header::HeaderValue::from_str(v.as_str().unwrap_or(""))
                     {
-                        headers.insert(
-                            HeaderName::from_bytes(k.as_bytes()).unwrap_or(CONTENT_TYPE),
-                            hv,
-                        );
+                        let name = HeaderName::from_bytes(k.as_bytes()).map_err(|_| {
+                            Drive9Error::Other(format!("invalid header name: {}", k))
+                        })?;
+                        headers.insert(name, hv);
                     }
                 }
             }
@@ -107,14 +110,14 @@ impl Client {
         );
         if let Some(ref ph) = part.headers {
             for (k, v) in ph {
+                if k.eq_ignore_ascii_case("host") {
+                    continue;
+                }
                 if let Ok(hv) = reqwest::header::HeaderValue::from_str(v.as_str().unwrap_or("")) {
-                    if k.eq_ignore_ascii_case("host") {
-                        continue;
-                    }
-                    headers.insert(
-                        HeaderName::from_bytes(k.as_bytes()).unwrap_or(CONTENT_TYPE),
-                        hv,
-                    );
+                    let name = HeaderName::from_bytes(k.as_bytes()).map_err(|_| {
+                        Drive9Error::Other(format!("invalid header name: {}", k))
+                    })?;
+                    headers.insert(name, hv);
                 }
             }
         }


### PR DESCRIPTION
## Summary

`patch.rs` forwarded presigned headers directly into `reqwest` requests, but had two correctness issues:

1. It did not skip `Host` headers on the read-side (`read_headers`), which can invalidate presigned read URLs.
2. It used `HeaderName::from_bytes(k.as_bytes()).unwrap_or(CONTENT_TYPE)` for both read and upload headers. Invalid header names were silently rewritten to `Content-Type`, which could overwrite legitimate content-type headers with unrelated metadata.

## Changes

- Skip `Host` headers (case-insensitive) in both `read_headers` and `part.headers` loops.
- Return a proper `Drive9Error` instead of silently substituting `CONTENT_TYPE` when `HeaderName::from_bytes` fails.

Closes #238