### PR TITLE
fix(fuse): refresh inode revision after flush and improve error status mapping

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -512,15 +512,24 @@ func httpToFuseStatus(err error) gofuse.Status {
 
 	// Fallback to string matching for non-StatusError errors.
 	msg := err.Error()
+	lowerMsg := strings.ToLower(msg)
 	switch {
-	case strings.Contains(msg, "not found") || strings.Contains(msg, "HTTP 404"):
+	case strings.Contains(lowerMsg, "not found") || strings.Contains(msg, "HTTP 404"):
 		return gofuse.ENOENT
-	case strings.Contains(msg, "HTTP 409") || strings.Contains(msg, "already exists"):
+	case strings.Contains(lowerMsg, "already exists"):
 		return gofuse.Status(syscall.EEXIST)
 	case strings.Contains(msg, "HTTP 403"):
 		return gofuse.EACCES
 	case strings.Contains(msg, "HTTP 413"):
 		return gofuse.Status(syscall.EFBIG)
+	case strings.Contains(msg, "HTTP 412"):
+		return gofuse.Status(syscall.ESTALE)
+	case strings.Contains(msg, "HTTP 400"):
+		return gofuse.Status(syscall.EINVAL)
+	case strings.Contains(msg, "HTTP 500") ||
+		strings.Contains(msg, "HTTP 502") ||
+		strings.Contains(msg, "HTTP 503"):
+		return gofuse.Status(syscall.EAGAIN)
 	default:
 		return gofuse.EIO
 	}
@@ -2059,12 +2068,14 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 	return gofuse.OK
 }
 
-// refreshRevisionAfterFlush updates the inode cache with the latest server
-// revision so that subsequent opens see the correct base revision for CAS
-// uploads. Callers must hold fh.mu.
+// refreshRevisionAfterFlush updates the inode cache and the open FileHandle
+// with the latest server revision so that subsequent writes use the correct
+// base revision for CAS uploads. Callers must hold fh.mu.
 func (fs *Dat9FS) refreshRevisionAfterFlush(ctx context.Context, fh *FileHandle) {
 	if stat, err := fs.client.StatCtx(ctx, fh.Path); err == nil && stat != nil {
 		fs.inodes.UpdateRevision(fh.Ino, stat.Revision)
+		fh.BaseRev = stat.Revision
+		fh.IsNew = false
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2075,15 +2075,22 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 	expectedRevision := expectedRevisionForHandle(fh)
 
 	fs.debouncer.Schedule(filePath, func() {
+		handle.Lock()
+		if handle.Dirty == nil || handle.DirtySeq != snapshotSeq {
+			handle.Unlock()
+			return
+		}
+
 		dCtx, dCf := context.WithTimeout(context.Background(), fuseTimeout)
-		defer dCf()
-		if err := fs.client.WriteCtxConditional(dCtx, filePath, data, expectedRevision); err != nil {
+		err := fs.client.WriteCtxConditional(dCtx, filePath, data, expectedRevision)
+		dCf()
+		if err != nil {
+			handle.Unlock()
 			log.Printf("debounced flush failed for %s: %v", filePath, err)
 			return
 		}
-		// Only clear dirty if no writes occurred since the snapshot was taken.
-		// If DirtySeq changed, the buffer has new data that wasn't uploaded.
-		handle.Lock()
+		// The handle stays locked across upload + finalize so concurrent writes
+		// cannot advance live state for data outside this committed snapshot.
 		fs.finalizeHandleFlushLocked(handle, expectedRevision)
 		if handle.Dirty != nil && handle.DirtySeq == snapshotSeq {
 			handle.Dirty.ClearDirty()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -359,6 +359,40 @@ func expectedRevisionForHandle(fh *FileHandle) int64 {
 	return -1
 }
 
+func committedRevisionFromExpectedRevision(expectedRevision int64) (int64, bool) {
+	if expectedRevision < 0 {
+		return 0, false
+	}
+	return expectedRevision + 1, true
+}
+
+// finalizeHandleFlushLocked updates the live handle and inode cache after a
+// successful upload using the exact CAS revision that completed, when known.
+// Callers must hold fh.mu.
+func (fs *Dat9FS) finalizeHandleFlushLocked(fh *FileHandle, expectedRevision int64) {
+	if fh == nil {
+		return
+	}
+
+	fh.IsNew = false
+	if revision, ok := committedRevisionFromExpectedRevision(expectedRevision); ok {
+		fh.BaseRev = revision
+		fs.inodes.UpdateRevision(fh.Ino, revision)
+	} else {
+		// The flush succeeded, but it was unconditional, so the precise
+		// post-commit revision is unknown. Clear the cached revision instead of
+		// keeping a known-stale positive value.
+		fh.BaseRev = 0
+		fs.inodes.UpdateRevision(fh.Ino, 0)
+	}
+	if fh.Streamer != nil {
+		fh.Streamer.ResetForNextWrite(expectedRevisionForHandle(fh))
+	}
+	if fh.ZeroBase && fh.Dirty != nil && fh.Dirty.Size() > 0 {
+		fh.ZeroBase = false
+	}
+}
+
 func (fs *Dat9FS) canStageShadowFastLocked(fh *FileHandle) bool {
 	if fs.shadowStore == nil || fs.pendingIndex == nil || fh == nil || fh.Dirty == nil {
 		return false
@@ -2038,18 +2072,19 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 	ino := fh.Ino
 	handle := fh               // capture for goroutine
 	snapshotSeq := fh.DirtySeq // capture current dirty sequence
+	expectedRevision := expectedRevisionForHandle(fh)
 
 	fs.debouncer.Schedule(filePath, func() {
 		dCtx, dCf := context.WithTimeout(context.Background(), fuseTimeout)
 		defer dCf()
-		if err := fs.client.WriteCtx(dCtx, filePath, data); err != nil {
+		if err := fs.client.WriteCtxConditional(dCtx, filePath, data, expectedRevision); err != nil {
 			log.Printf("debounced flush failed for %s: %v", filePath, err)
 			return
 		}
 		// Only clear dirty if no writes occurred since the snapshot was taken.
 		// If DirtySeq changed, the buffer has new data that wasn't uploaded.
 		handle.Lock()
-		fs.refreshRevisionAfterFlush(dCtx, handle)
+		fs.finalizeHandleFlushLocked(handle, expectedRevision)
 		if handle.Dirty != nil && handle.DirtySeq == snapshotSeq {
 			handle.Dirty.ClearDirty()
 		}
@@ -2067,17 +2102,6 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 	// flushHandle will upload from the still-dirty buffer.
 	// If the debouncer fires first, its callback clears dirty state.
 	return gofuse.OK
-}
-
-// refreshRevisionAfterFlush updates the inode cache and the open FileHandle
-// with the latest server revision so that subsequent writes use the correct
-// base revision for CAS uploads. Callers must hold fh.mu.
-func (fs *Dat9FS) refreshRevisionAfterFlush(ctx context.Context, fh *FileHandle) {
-	if stat, err := fs.client.StatCtx(ctx, fh.Path); err == nil && stat != nil && stat.Revision > 0 {
-		fs.inodes.UpdateRevision(fh.Ino, stat.Revision)
-		fh.BaseRev = stat.Revision
-		fh.IsNew = false
-	}
 }
 
 // flushHandle uploads buffered data to the server. Caller must hold fh.mu.
@@ -2100,6 +2124,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 	// This path is used for large sequential writes (cp, dd, ffmpeg).
 	// Only the final partial part and any dirty (back-written) parts need uploading.
 	if fh.Streamer != nil && fh.Streamer.HasStreamedParts() {
+		expectedRevision := fh.Streamer.ExpectedRevision()
 		partSize := fh.Dirty.PartSize()
 		numParts := int((size + partSize - 1) / partSize)
 		lastPartNum := numParts // 1-based
@@ -2143,16 +2168,17 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 		fs.readCache.Invalidate(fh.Path)
 		fs.dirCache.Invalidate(parentDir(fh.Path))
 		fs.inodes.UpdateSize(fh.Ino, size)
+		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 		fs.notifyInode(fh.Ino)
 		parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
 		fs.notifyInode(parentIno)
-		fs.refreshRevisionAfterFlush(ctx, fh)
 		return gofuse.OK
 	}
 
 	// Path 1b: Large new file with streaming uploader but no streaming parts
 	// (non-sequential writes) — upload all parts in parallel at flush time.
 	if fh.Streamer != nil && size >= smallFileThreshold {
+		expectedRevision := fh.Streamer.ExpectedRevision()
 		numParts := int((size + fh.Dirty.PartSize() - 1) / fh.Dirty.PartSize())
 		partSnapshots := make(map[int][]byte, numParts)
 		for pn := 1; pn <= numParts; pn++ {
@@ -2182,19 +2208,20 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 		fs.readCache.Invalidate(fh.Path)
 		fs.dirCache.Invalidate(parentDir(fh.Path))
 		fs.inodes.UpdateSize(fh.Ino, size)
+		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 		fs.notifyInode(fh.Ino)
 		parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
 		fs.notifyInode(parentIno)
-		fs.refreshRevisionAfterFlush(ctx, fh)
 		return gofuse.OK
 	}
 
 	// Path 2: No streaming uploader or small file — materialize all data for upload.
 	data := fh.Dirty.Bytes()
+	expectedRevision := expectedRevisionForHandle(fh)
 
 	if size < smallFileThreshold {
 		// Small file: direct PUT.
-		err = fs.client.WriteCtxConditional(ctx, fh.Path, data, expectedRevisionForHandle(fh))
+		err = fs.client.WriteCtxConditional(ctx, fh.Path, data, expectedRevision)
 	} else if fh.OrigSize >= smallFileThreshold {
 		dirtyParts := fh.Dirty.DirtyPartNumbers()
 		if len(dirtyParts) > 0 {
@@ -2220,7 +2247,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 				},
 				nil,
 				client.WithPartSize(fh.Dirty.PartSize()),
-				client.WithExpectedRevision(expectedRevisionForHandle(fh)),
+				client.WithExpectedRevision(expectedRevision),
 			)
 		}
 		// If no dirty parts, nothing changed — skip upload.
@@ -2232,7 +2259,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 			bytes.NewReader(data),
 			size,
 			nil,
-			expectedRevisionForHandle(fh),
+			expectedRevision,
 		)
 	}
 	if err != nil {
@@ -2246,11 +2273,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 	fs.readCache.Invalidate(fh.Path)
 	fs.dirCache.Invalidate(parentDir(fh.Path))
 	fs.inodes.UpdateSize(fh.Ino, size)
+	fs.finalizeHandleFlushLocked(fh, expectedRevision)
 	// Invalidate kernel attr/data cache for this inode and parent dir listing.
 	fs.notifyInode(fh.Ino)
 	parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
 	fs.notifyInode(parentIno)
-	fs.refreshRevisionAfterFlush(ctx, fh)
 	return gofuse.OK
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2049,6 +2049,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		// Only clear dirty if no writes occurred since the snapshot was taken.
 		// If DirtySeq changed, the buffer has new data that wasn't uploaded.
 		handle.Lock()
+		fs.refreshRevisionAfterFlush(dCtx, handle)
 		if handle.Dirty != nil && handle.DirtySeq == snapshotSeq {
 			handle.Dirty.ClearDirty()
 		}
@@ -2072,7 +2073,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 // with the latest server revision so that subsequent writes use the correct
 // base revision for CAS uploads. Callers must hold fh.mu.
 func (fs *Dat9FS) refreshRevisionAfterFlush(ctx context.Context, fh *FileHandle) {
-	if stat, err := fs.client.StatCtx(ctx, fh.Path); err == nil && stat != nil {
+	if stat, err := fs.client.StatCtx(ctx, fh.Path); err == nil && stat != nil && stat.Revision > 0 {
 		fs.inodes.UpdateRevision(fh.Ino, stat.Revision)
 		fh.BaseRev = stat.Revision
 		fh.IsNew = false

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3,8 +3,10 @@ package fuse
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -480,6 +482,35 @@ func httpToFuseStatus(err error) gofuse.Status {
 	if err == nil {
 		return gofuse.OK
 	}
+
+	// Prefer typed StatusError so we map by status code even when the
+	// server returns a JSON error body that doesn't contain "HTTP NNN".
+	var se *client.StatusError
+	if errors.As(err, &se) {
+		switch se.StatusCode {
+		case http.StatusNotFound:
+			return gofuse.ENOENT
+		case http.StatusConflict:
+			if strings.Contains(strings.ToLower(se.Message), "already exists") {
+				return gofuse.Status(syscall.EEXIST)
+			}
+			return gofuse.EIO
+		case http.StatusForbidden:
+			return gofuse.EACCES
+		case http.StatusRequestEntityTooLarge:
+			return gofuse.Status(syscall.EFBIG)
+		case http.StatusPreconditionFailed:
+			return gofuse.Status(syscall.ESTALE)
+		case http.StatusBadRequest:
+			return gofuse.Status(syscall.EINVAL)
+		case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable:
+			return gofuse.Status(syscall.EAGAIN)
+		default:
+			return gofuse.EIO
+		}
+	}
+
+	// Fallback to string matching for non-StatusError errors.
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "not found") || strings.Contains(msg, "HTTP 404"):
@@ -1099,6 +1130,7 @@ func (fs *Dat9FS) ReadDir(cancel <-chan struct{}, input *gofuse.ReadIn, out *gof
 		defer cf()
 		entries, err := fs.listDir(ctx, dh.Path)
 		if err != nil {
+			log.Printf("list dir failed for %s: %v", dh.Path, err)
 			return httpToFuseStatus(err)
 		}
 		dh.Entries = entries
@@ -1129,6 +1161,7 @@ func (fs *Dat9FS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out 
 		defer cf()
 		entries, err := fs.listDir(ctx, dh.Path)
 		if err != nil {
+			log.Printf("list dir plus failed for %s: %v", dh.Path, err)
 			return httpToFuseStatus(err)
 		}
 		dh.Entries = entries
@@ -2026,6 +2059,15 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 	return gofuse.OK
 }
 
+// refreshRevisionAfterFlush updates the inode cache with the latest server
+// revision so that subsequent opens see the correct base revision for CAS
+// uploads. Callers must hold fh.mu.
+func (fs *Dat9FS) refreshRevisionAfterFlush(ctx context.Context, fh *FileHandle) {
+	if stat, err := fs.client.StatCtx(ctx, fh.Path); err == nil && stat != nil {
+		fs.inodes.UpdateRevision(fh.Ino, stat.Revision)
+	}
+}
+
 // flushHandle uploads buffered data to the server. Caller must hold fh.mu.
 // NOTE: This method temporarily releases fh.mu during network calls
 // (FinishStreaming, UploadAll) to avoid deadlock with streaming upload
@@ -2079,6 +2121,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 		fh.Lock()
 
 		if err != nil {
+			log.Printf("finish streaming failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
 
@@ -2091,6 +2134,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 		fs.notifyInode(fh.Ino)
 		parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
 		fs.notifyInode(parentIno)
+		fs.refreshRevisionAfterFlush(ctx, fh)
 		return gofuse.OK
 	}
 
@@ -2116,6 +2160,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 		fh.Lock()
 
 		if err != nil {
+			log.Printf("upload all parts failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
 
@@ -2128,6 +2173,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 		fs.notifyInode(fh.Ino)
 		parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
 		fs.notifyInode(parentIno)
+		fs.refreshRevisionAfterFlush(ctx, fh)
 		return gofuse.OK
 	}
 
@@ -2178,6 +2224,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 		)
 	}
 	if err != nil {
+		log.Printf("flush upload failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}
 
@@ -2191,6 +2238,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 	fs.notifyInode(fh.Ino)
 	parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
 	fs.notifyInode(parentIno)
+	fs.refreshRevisionAfterFlush(ctx, fh)
 	return gofuse.OK
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1053,6 +1053,104 @@ func TestSetAttr_TruncateWithoutHandleRefreshesRevision(t *testing.T) {
 	}
 }
 
+func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
+	var (
+		putCalls  int32
+		headCalls int32
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			if got := r.Header.Get("X-Dat9-Expected-Revision"); got != "7" {
+				t.Fatalf("X-Dat9-Expected-Revision = %q, want %q", got, "7")
+			}
+			putCalls++
+			w.WriteHeader(http.StatusOK)
+		case http.MethodHead:
+			headCalls++
+			http.Error(w, "unexpected post-flush HEAD", http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	ino := fs.inodes.Lookup("/flush.bin", false, 4, time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    "/flush.bin",
+		Dirty:   NewWriteBuffer("/flush.bin", maxPreloadSize, 0),
+		BaseRev: 7,
+	}
+	if _, err := fh.Dirty.Write(0, []byte("next")); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+
+	fh.Lock()
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+	if st != gofuse.OK {
+		t.Fatalf("flushHandle status = %v, want OK", st)
+	}
+	if putCalls != 1 {
+		t.Fatalf("PUT calls = %d, want 1", putCalls)
+	}
+	if headCalls != 0 {
+		t.Fatalf("HEAD calls = %d, want 0", headCalls)
+	}
+	if fh.BaseRev != 8 {
+		t.Fatalf("fh.BaseRev = %d, want 8", fh.BaseRev)
+	}
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if entry.Revision != 8 {
+		t.Fatalf("inode revision = %d, want 8", entry.Revision)
+	}
+}
+
+func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	ino := fs.inodes.Lookup("/stream.bin", false, 0, time.Now())
+
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     "/stream.bin",
+		Dirty:    NewWriteBuffer("/stream.bin", maxPreloadSize, 0),
+		BaseRev:  11,
+		Streamer: NewStreamUploader(nil, "/stream.bin", 11),
+	}
+	fh.Streamer.started = true
+	fh.Streamer.streamedParts[1] = true
+
+	fh.Lock()
+	fs.finalizeHandleFlushLocked(fh, 11)
+	fh.Unlock()
+
+	if fh.BaseRev != 12 {
+		t.Fatalf("fh.BaseRev = %d, want 12", fh.BaseRev)
+	}
+	if got := fh.Streamer.ExpectedRevision(); got != 12 {
+		t.Fatalf("streamer expected revision = %d, want 12", got)
+	}
+	if fh.Streamer.Started() {
+		t.Fatal("streamer should be reset to not-started after successful flush")
+	}
+	if fh.Streamer.HasStreamedParts() {
+		t.Fatal("streamer should clear prior streamed parts after successful flush")
+	}
+}
+
 func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 	const callerPID = 4242
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1055,20 +1055,31 @@ func TestSetAttr_TruncateWithoutHandleRefreshesRevision(t *testing.T) {
 
 func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
 	var (
-		putCalls  int32
-		headCalls int32
+		mu         sync.Mutex
+		handlerErr error
+		putCalls   atomic.Int32
+		headCalls  atomic.Int32
 	)
+	recordHandlerErr := func(err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPut:
 			if got := r.Header.Get("X-Dat9-Expected-Revision"); got != "7" {
-				t.Fatalf("X-Dat9-Expected-Revision = %q, want %q", got, "7")
+				recordHandlerErr(fmt.Errorf("X-Dat9-Expected-Revision = %q, want %q", got, "7"))
+				http.Error(w, "bad expected revision", http.StatusBadRequest)
+				return
 			}
-			putCalls++
+			putCalls.Add(1)
 			w.WriteHeader(http.StatusOK)
 		case http.MethodHead:
-			headCalls++
+			headCalls.Add(1)
 			http.Error(w, "unexpected post-flush HEAD", http.StatusInternalServerError)
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
@@ -1099,11 +1110,17 @@ func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
 	if st != gofuse.OK {
 		t.Fatalf("flushHandle status = %v, want OK", st)
 	}
-	if putCalls != 1 {
-		t.Fatalf("PUT calls = %d, want 1", putCalls)
+	mu.Lock()
+	err := handlerErr
+	mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
 	}
-	if headCalls != 0 {
-		t.Fatalf("HEAD calls = %d, want 0", headCalls)
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want 1", got)
+	}
+	if got := headCalls.Load(); got != 0 {
+		t.Fatalf("HEAD calls = %d, want 0", got)
 	}
 	if fh.BaseRev != 8 {
 		t.Fatalf("fh.BaseRev = %d, want 8", fh.BaseRev)

--- a/pkg/fuse/stream_upload.go
+++ b/pkg/fuse/stream_upload.go
@@ -69,6 +69,27 @@ func (su *StreamUploader) RefreshExpectedRevision(revision int64) bool {
 	return true
 }
 
+// ExpectedRevision reports the CAS revision that will be used when the next
+// upload starts or resumes.
+func (su *StreamUploader) ExpectedRevision() int64 {
+	su.mu.Lock()
+	defer su.mu.Unlock()
+	return su.expectedRevision
+}
+
+// ResetForNextWrite prepares the uploader for another flush cycle after a
+// successful commit on the same open handle.
+func (su *StreamUploader) ResetForNextWrite(revision int64) {
+	su.mu.Lock()
+	defer su.mu.Unlock()
+
+	su.expectedRevision = revision
+	su.writer = nil
+	su.started = false
+	su.streamErr = nil
+	su.streamedParts = make(map[int]bool)
+}
+
 // HasStreamedParts reports whether any parts were uploaded during streaming
 // (i.e., during Write() calls, not at flush time).
 func (su *StreamUploader) HasStreamedParts() bool {


### PR DESCRIPTION
## Summary

Fixes the repeated `flush failed (status 5)` issue during FUSE overwrite/append workloads.

## Root Cause

`flushHandle` did not update the inode cache after a successful upload, causing subsequent overwrite/append operations to use a stale `BaseRev`. This triggered a 412 Precondition Failed from the server, which `httpToFuseStatus` did not recognize, falling through to generic `EIO` (status 5).

## Changes

- **`refreshRevisionAfterFlush()`**: Refresh inode revision and open FileHandle state after all three upload success paths (FinishStreaming, UploadAll, direct PUT/Patch).
- **`httpToFuseStatus()`**: Use `errors.As` to recognize `*client.StatusError` and map HTTP status codes precisely:
  - 412 → `ESTALE`
  - 500/502/503 → `EAGAIN`
  - 400 → `EINVAL`
  - 409 → `EEXIST` (only when message contains \"already exists\")
- **Debug logging**: Added error logging on flush failure paths.

## Testing

- `make test TEST_PKGS='./pkg/fuse/...'` ✅ all passed
- `make lint` ✅ 0 issues

Closes FUSE overwrite/append flush failure issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate mapping of HTTP errors to filesystem errors for clearer error responses (e.g., not-found, conflict, permission, size, stale, invalid, retryable, and server errors).

* **Improvements**
  * More reliable file revision updates after flush/commit so revisions reflect CAS-committed state.
  * Better diagnostic logging for directory listings and flush/upload failures.
  * Streaming uploader now advances and resets expected revision after successful commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->