### PR TITLE
PR-C: unify credential resolver (env > config) + Unsetenv mitigation

### DIFF
--- a/cmd/drive9/cli/client.go
+++ b/cmd/drive9/cli/client.go
@@ -1,21 +1,28 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/mem9-ai/dat9/pkg/client"
 )
 
+// NewFromEnv returns an owner-scoped client for the drive9 fs plane
+// (drive9 fs cp/cat/ls/mv/rm/sh/grep/find/stat). It is the single entry
+// point for runFS in cmd/drive9/main.go.
+//
+// Invariant: the fs plane is owner-only by construction — delegated JWTs
+// are not accepted on fs endpoints server-side. If a delegated credential
+// is the only one resolvable, this returns a client whose API key is
+// empty, and the request will fail with EACCES at the server (Invariant #7).
+// Callers that need to report a clearer error should check Kind themselves
+// before dispatch; retaining the lenient shape keeps parity with the pre-
+// resolver behaviour (which also returned an empty key).
+//
+// Credential resolution goes through the unified resolver per §14.2
+// (env > config, Unsetenv-after-read).
 func NewFromEnv() *client.Client {
-	server := os.Getenv("DRIVE9_SERVER")
-	apiKey := os.Getenv("DRIVE9_API_KEY")
-
-	cfg := loadConfig()
-	if server == "" {
-		server = cfg.ResolveServer()
+	r := ResolveCredentials()
+	apiKey := ""
+	if r.Kind == CredentialOwner {
+		apiKey = r.APIKey
 	}
-	if apiKey == "" {
-		apiKey = cfg.CurrentAPIKey()
-	}
-	return client.New(server, apiKey)
+	return client.New(r.Server, apiKey)
 }

--- a/cmd/drive9/cli/credentials.go
+++ b/cmd/drive9/cli/credentials.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sync"
+)
+
+// Environment variable names recognised by the credential resolver. See spec
+// §14.1. The dual-principal separation is locked — there is no single combined
+// variable; DRIVE9_VAULT_TOKEN and DRIVE9_API_KEY remain distinct knobs.
+const (
+	EnvVaultToken = "DRIVE9_VAULT_TOKEN"
+	EnvAPIKey     = "DRIVE9_API_KEY"
+	EnvServer     = "DRIVE9_SERVER"
+)
+
+// CredentialKind classifies which principal the resolved credential
+// authenticates as. Keeps callers from mis-routing an owner key to a vault
+// read-path (or vice versa).
+type CredentialKind int
+
+const (
+	CredentialNone CredentialKind = iota
+	CredentialOwner
+	CredentialDelegated
+)
+
+// ResolvedCredentials is the output of the unified credential resolver. Exactly
+// one of APIKey / Token is non-empty when Kind != CredentialNone.
+//
+// Source describes where the credential and server URL came from, for error
+// messages and debug tracing. It is informational; no authorization decision
+// depends on Source (Invariant #7 keeps enforcement server-side).
+type ResolvedCredentials struct {
+	Kind         CredentialKind
+	Server       string
+	APIKey       string // set when Kind == CredentialOwner
+	Token        string // set when Kind == CredentialDelegated
+	CredSource   string // "env:DRIVE9_VAULT_TOKEN", "env:DRIVE9_API_KEY", "config:<ctx-name>", ""
+	ServerSource string // "env:DRIVE9_SERVER", "config:<ctx-name>", "default"
+}
+
+// ResolveCredentials is the single source of truth for (credential, server)
+// resolution across all drive9 CLI call sites. Priority matches spec §14.2:
+//
+//	Credential: DRIVE9_VAULT_TOKEN > DRIVE9_API_KEY > active context
+//	Server:     DRIVE9_SERVER      > active-context.server > compiled-in default
+//
+// "First match wins" applies to *presence*, not validity. A set-but-malformed
+// env var yields a distinct error at validation time; it must never silently
+// fall through to a broader credential. This is the fix for the credential-
+// confusion bug class called out in §14.2.
+//
+// Mitigation side effect: on first call, ResolveCredentials calls os.Unsetenv
+// on the credential env vars so that child processes spawned by the current
+// CLI invocation do not inherit credentials via /proc/<pid>/environ. This
+// aligns drive9 with the "strip DRIVE9_* before exec" contract documented in
+// the vault-quickstart Part 1 §6. DRIVE9_SERVER is also unset for symmetry;
+// the credential-server mismatch surface is covered by §14.2.
+//
+// The result is cached per-process via sync.Once so that repeated calls
+// within a single invocation (e.g. SecretLs calls currentCapabilityToken()
+// and optionalVaultManagementClientFromEnv() back-to-back) see a consistent
+// snapshot rather than losing env values after the first read-and-unset.
+//
+// The resolver does not validate JWT structure or API-key shape — that is
+// deferred to the server (Invariant #7). It does trim leading/trailing
+// whitespace to match file-based ingress (`ctx import`) behaviour.
+func ResolveCredentials() ResolvedCredentials {
+	credentialOnce.Do(func() {
+		cachedCredentials = resolveCredentialsWithConfig(loadConfig())
+	})
+	return cachedCredentials
+}
+
+var (
+	credentialOnce    sync.Once
+	cachedCredentials ResolvedCredentials
+)
+
+// resetCredentialCacheForTest clears the per-process resolver cache. Test-
+// only; callers in production would see an env-read-after-unset race.
+func resetCredentialCacheForTest() {
+	credentialOnce = sync.Once{}
+	cachedCredentials = ResolvedCredentials{}
+}
+
+func resolveCredentialsWithConfig(cfg *Config) ResolvedCredentials {
+	var r ResolvedCredentials
+
+	// Consume all three credential-bearing env vars up-front so the Unsetenv
+	// mitigation fires regardless of which one "wins" priority. Otherwise a
+	// VAULT_TOKEN that wins would leave DRIVE9_API_KEY inheritable by
+	// forked children — a real leak path for `secret exec`.
+	envServer := consumeEnv(EnvServer)
+	envToken := consumeEnv(EnvVaultToken)
+	envAPIKey := consumeEnv(EnvAPIKey)
+
+	// Server resolution is orthogonal to credential resolution (§14.2).
+	if envServer != "" {
+		r.Server = envServer
+		r.ServerSource = "env:" + EnvServer
+	}
+
+	// Credential resolution: VAULT_TOKEN > API_KEY > active context.
+	if envToken != "" {
+		r.Kind = CredentialDelegated
+		r.Token = envToken
+		r.CredSource = "env:" + EnvVaultToken
+	} else if envAPIKey != "" {
+		r.Kind = CredentialOwner
+		r.APIKey = envAPIKey
+		r.CredSource = "env:" + EnvAPIKey
+	} else if ctxName := cfg.CurrentContext; ctxName != "" {
+		if ctx := cfg.Contexts[ctxName]; ctx != nil {
+			switch ctx.Type {
+			case PrincipalOwner:
+				if ctx.APIKey != "" {
+					r.Kind = CredentialOwner
+					r.APIKey = ctx.APIKey
+					r.CredSource = "config:" + ctxName
+				}
+			case PrincipalDelegated:
+				if ctx.Token != "" {
+					r.Kind = CredentialDelegated
+					r.Token = ctx.Token
+					r.CredSource = "config:" + ctxName
+				}
+			}
+			if r.Server == "" && ctx.Server != "" {
+				r.Server = ctx.Server
+				r.ServerSource = "config:" + ctxName
+			}
+		}
+	}
+
+	if r.Server == "" {
+		if cfg.Server != "" {
+			r.Server = cfg.Server
+			r.ServerSource = "config:server"
+		} else {
+			r.Server = defaultServerURL
+			r.ServerSource = "default"
+		}
+	}
+
+	return r
+}
+
+// consumeEnv reads an environment variable, trims surrounding whitespace, and
+// if the value is non-empty unsets the variable before returning. The unset
+// is what prevents a drive9 CLI invocation from leaking the credential into
+// any child process it later forks (e.g. via `secret exec`).
+//
+// If the variable is set but contains only whitespace, it is treated as
+// absent (and also unset) — this is not "malformed", it's empty-after-trim.
+// True malformed-value handling (e.g. a JWT that does not decode) is the
+// server's responsibility per Invariant #7 and returns EACCES via §11.
+func consumeEnv(name string) string {
+	raw, ok := os.LookupEnv(name)
+	if !ok {
+		return ""
+	}
+	_ = os.Unsetenv(name)
+	trimmed := trimASCIISpace(raw)
+	return trimmed
+}
+
+func trimASCIISpace(s string) string {
+	start := 0
+	for start < len(s) && isASCIISpace(s[start]) {
+		start++
+	}
+	end := len(s)
+	for end > start && isASCIISpace(s[end-1]) {
+		end--
+	}
+	return s[start:end]
+}
+
+func isASCIISpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\r', '\n':
+		return true
+	}
+	return false
+}
+
+const defaultServerURL = "https://api.drive9.ai"
+
+// rejectEmptyFlag returns an error when a credential-bearing flag was passed
+// with an explicit empty value (e.g. `--api-key=""`). Conflating explicit-empty
+// with "unset" hides the user's intent and can silently fall through to a
+// different credential; we reject at parse time per adv-2's review.
+//
+// Call this on each credential flag after flag.Parse.
+func rejectEmptyFlag(flagName, value string, provided bool) error {
+	if provided && value == "" {
+		return fmt.Errorf("--%s was given an empty value; pass a non-empty credential or omit the flag", flagName)
+	}
+	return nil
+}
+
+// flagProvided reports whether a flag was explicitly set on the command line
+// (as opposed to retaining its default value). Works for any flag.FlagSet.
+func flagProvided(fs *flag.FlagSet, name string) bool {
+	seen := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			seen = true
+		}
+	})
+	return seen
+}

--- a/cmd/drive9/cli/credentials_test.go
+++ b/cmd/drive9/cli/credentials_test.go
@@ -1,0 +1,294 @@
+package cli
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+// setResolverEnv is a test helper that configures env + cleans up resolver
+// state. It mirrors the pattern in captureStdout so tests can run in any
+// order without cache pollution.
+func setResolverEnv(t *testing.T, kv map[string]string) {
+	t.Helper()
+	// Always unset all three; tests then opt-in only the ones they want.
+	for _, name := range []string{EnvVaultToken, EnvAPIKey, EnvServer} {
+		t.Setenv(name, "") // t.Setenv will restore on cleanup
+		_ = os.Unsetenv(name)
+	}
+	for k, v := range kv {
+		t.Setenv(k, v)
+	}
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+}
+
+func TestResolveCredentials_EnvVaultTokenBeatsAPIKey(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvVaultToken: "jwt-eyAAA",
+		EnvAPIKey:     "sk-owner-key",
+		EnvServer:     "https://env.example",
+	})
+	cfg := &Config{}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.Kind != CredentialDelegated {
+		t.Fatalf("Kind = %d, want CredentialDelegated", r.Kind)
+	}
+	if r.Token != "jwt-eyAAA" {
+		t.Fatalf("Token = %q, want jwt-eyAAA", r.Token)
+	}
+	if r.APIKey != "" {
+		t.Fatalf("APIKey = %q, want empty (VAULT_TOKEN wins)", r.APIKey)
+	}
+	if r.Server != "https://env.example" {
+		t.Fatalf("Server = %q", r.Server)
+	}
+	if r.CredSource != "env:"+EnvVaultToken {
+		t.Fatalf("CredSource = %q", r.CredSource)
+	}
+}
+
+func TestResolveCredentials_EnvAPIKeyWhenNoVaultToken(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvAPIKey: "sk-owner-key",
+		EnvServer: "https://env.example",
+	})
+	cfg := &Config{}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.Kind != CredentialOwner {
+		t.Fatalf("Kind = %d, want CredentialOwner", r.Kind)
+	}
+	if r.APIKey != "sk-owner-key" {
+		t.Fatalf("APIKey = %q", r.APIKey)
+	}
+	if r.Token != "" {
+		t.Fatalf("Token = %q, want empty", r.Token)
+	}
+	if r.CredSource != "env:"+EnvAPIKey {
+		t.Fatalf("CredSource = %q", r.CredSource)
+	}
+}
+
+func TestResolveCredentials_EnvBeatsConfig(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvAPIKey: "sk-env-owner",
+	})
+	cfg := &Config{
+		CurrentContext: "prod",
+		Contexts: map[string]*Context{
+			"prod": {Type: PrincipalOwner, Server: "https://config.example", APIKey: "sk-config-owner"},
+		},
+	}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.APIKey != "sk-env-owner" {
+		t.Fatalf("APIKey = %q, want env to win", r.APIKey)
+	}
+	if r.CredSource != "env:"+EnvAPIKey {
+		t.Fatalf("CredSource = %q", r.CredSource)
+	}
+}
+
+func TestResolveCredentials_ConfigWhenEnvUnset(t *testing.T) {
+	setResolverEnv(t, nil)
+	cfg := &Config{
+		CurrentContext: "prod",
+		Contexts: map[string]*Context{
+			"prod": {Type: PrincipalOwner, Server: "https://config.example", APIKey: "sk-config-owner"},
+		},
+	}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.Kind != CredentialOwner {
+		t.Fatalf("Kind = %d", r.Kind)
+	}
+	if r.APIKey != "sk-config-owner" {
+		t.Fatalf("APIKey = %q", r.APIKey)
+	}
+	if r.Server != "https://config.example" {
+		t.Fatalf("Server = %q", r.Server)
+	}
+	if r.CredSource != "config:prod" {
+		t.Fatalf("CredSource = %q", r.CredSource)
+	}
+}
+
+func TestResolveCredentials_ConfigDelegatedContext(t *testing.T) {
+	setResolverEnv(t, nil)
+	cfg := &Config{
+		CurrentContext: "alice",
+		Contexts: map[string]*Context{
+			"alice": {Type: PrincipalDelegated, Server: "https://config.example", Token: "jwt-config-delegated"},
+		},
+	}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.Kind != CredentialDelegated {
+		t.Fatalf("Kind = %d, want CredentialDelegated", r.Kind)
+	}
+	if r.Token != "jwt-config-delegated" {
+		t.Fatalf("Token = %q", r.Token)
+	}
+}
+
+func TestResolveCredentials_EmptyWhenNothingAvailable(t *testing.T) {
+	setResolverEnv(t, nil)
+	cfg := &Config{}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.Kind != CredentialNone {
+		t.Fatalf("Kind = %d, want CredentialNone", r.Kind)
+	}
+	if r.Token != "" || r.APIKey != "" {
+		t.Fatalf("expected empty creds, got Token=%q APIKey=%q", r.Token, r.APIKey)
+	}
+	if r.Server != defaultServerURL {
+		t.Fatalf("Server = %q, want default %q", r.Server, defaultServerURL)
+	}
+	if r.ServerSource != "default" {
+		t.Fatalf("ServerSource = %q", r.ServerSource)
+	}
+}
+
+func TestResolveCredentials_ServerEnvOverridesContextServer(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvServer: "https://env.override",
+	})
+	cfg := &Config{
+		CurrentContext: "prod",
+		Contexts: map[string]*Context{
+			"prod": {Type: PrincipalOwner, Server: "https://config.example", APIKey: "sk-config-owner"},
+		},
+	}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.Server != "https://env.override" {
+		t.Fatalf("Server = %q, want env override", r.Server)
+	}
+	// Credential still from config.
+	if r.APIKey != "sk-config-owner" {
+		t.Fatalf("APIKey = %q, want config", r.APIKey)
+	}
+	if r.ServerSource != "env:"+EnvServer {
+		t.Fatalf("ServerSource = %q", r.ServerSource)
+	}
+}
+
+func TestResolveCredentials_UnsetsEnvAfterRead(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvVaultToken: "jwt-eyAAA",
+		EnvAPIKey:     "sk-owner-key",
+		EnvServer:     "https://env.example",
+	})
+	cfg := &Config{}
+
+	_ = resolveCredentialsWithConfig(cfg)
+
+	// All three credential vars MUST be unset after resolution so that any
+	// child process forked later does not inherit them via /proc/<pid>/environ.
+	for _, name := range []string{EnvVaultToken, EnvAPIKey, EnvServer} {
+		if _, ok := os.LookupEnv(name); ok {
+			t.Fatalf("%s still set after resolve (Unsetenv mitigation missing)", name)
+		}
+	}
+}
+
+func TestResolveCredentials_TrimsWhitespace(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvVaultToken: "  jwt-eyAAA\n",
+	})
+	cfg := &Config{}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.Token != "jwt-eyAAA" {
+		t.Fatalf("Token = %q, want trimmed", r.Token)
+	}
+}
+
+func TestResolveCredentials_WhitespaceOnlyTreatedAsUnset(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvVaultToken: "   \n\t",
+		EnvAPIKey:     "sk-owner-key",
+	})
+	cfg := &Config{}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	// The empty VAULT_TOKEN should not win over the API key — empty after
+	// trim is "absent", not "malformed".
+	if r.Kind != CredentialOwner {
+		t.Fatalf("Kind = %d, want CredentialOwner (empty VAULT_TOKEN should not win)", r.Kind)
+	}
+	if r.APIKey != "sk-owner-key" {
+		t.Fatalf("APIKey = %q", r.APIKey)
+	}
+}
+
+func TestRejectEmptyFlag(t *testing.T) {
+	cases := []struct {
+		name     string
+		provided bool
+		value    string
+		wantErr  bool
+	}{
+		{"unset", false, "", false},
+		{"set-non-empty", true, "v", false},
+		{"explicit-empty", true, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := rejectEmptyFlag("api-key", tc.value, tc.provided)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("rejectEmptyFlag(%v,%q) err=%v wantErr=%v", tc.provided, tc.value, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestFlagProvided(t *testing.T) {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	val := fs.String("api-key", "default", "")
+	_ = val
+	if err := fs.Parse([]string{"--api-key", "x"}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !flagProvided(fs, "api-key") {
+		t.Fatalf("flagProvided should report true when flag was given on argv")
+	}
+	if flagProvided(fs, "nonexistent") {
+		t.Fatalf("flagProvided should report false for missing flag")
+	}
+}
+
+func TestResolveCredentials_CachedPerProcess(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvVaultToken: "jwt-first",
+	})
+	cfg := &Config{}
+
+	first := resolveCredentialsWithConfig(cfg)
+	if first.Token != "jwt-first" {
+		t.Fatalf("first.Token = %q", first.Token)
+	}
+
+	// The top-level ResolveCredentials must see the cached result even after
+	// the env has been unset (which resolveCredentialsWithConfig already did).
+	cached := ResolveCredentials()
+	if cached.Token != "" && cached.Token != "jwt-first" {
+		// ResolveCredentials reads a fresh config; since env is now unset
+		// and our test config isn't on disk, Token will be empty. We assert
+		// the cache path does not explode; the real cross-call contract is
+		// exercised inside SecretLs tests.
+		t.Fatalf("unexpected cached Token = %q", cached.Token)
+	}
+}

--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/mem9-ai/dat9/pkg/client"
 )
@@ -18,7 +17,8 @@ import (
 // See migration call-out #4 in the impl PR body.
 func Create(args []string) error {
 	name := ""
-	server := os.Getenv("DRIVE9_SERVER")
+	serverFlag := ""
+	serverFlagGiven := false
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -33,17 +33,28 @@ func Create(args []string) error {
 				return fmt.Errorf("--server requires an argument")
 			}
 			i++
-			server = args[i]
+			serverFlag = args[i]
+			serverFlagGiven = true
 		default:
 			return fmt.Errorf("unknown flag %q\nusage: drive9 create [--name NAME] [--server URL]", args[i])
 		}
 	}
 
-	cfg := loadConfig()
-
-	if server == "" {
-		server = cfg.ResolveServer()
+	if err := rejectEmptyFlag("server", serverFlag, serverFlagGiven); err != nil {
+		return err
 	}
+
+	// Precedence per §14.2: explicit --server flag > DRIVE9_SERVER env > config.
+	// ResolveCredentials consumes the env var (Unsetenv mitigation), so even when
+	// the flag wins we still sink the env to keep downstream forks from inheriting
+	// it. Credential resolution is not used here — provisioning is unauthenticated.
+	r := ResolveCredentials()
+	server := serverFlag
+	if server == "" {
+		server = r.Server
+	}
+
+	cfg := loadConfig()
 
 	if name == "" {
 		name = randomName()

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -12,10 +12,19 @@ import (
 )
 
 // MountCmd handles the "drive9 mount" command.
+//
+// Credential precedence matches spec §14.2: explicit --server / --api-key flag
+// > DRIVE9_SERVER / DRIVE9_API_KEY env > active config context. The flag
+// defaults are empty strings so we can distinguish "unset" from "explicit
+// empty"; the latter is rejected (see rejectEmptyFlag).
+//
+// drive9fuse.Mount runs in-process (no fork/exec); credentials flow through
+// MountOptions{Server, APIKey}, not through the child's environment. This
+// makes the resolver's Unsetenv-after-read mitigation safe for mount.
 func MountCmd(args []string) error {
 	fs := flag.NewFlagSet("mount", flag.ExitOnError)
-	server := fs.String("server", os.Getenv("DRIVE9_SERVER"), "drive9 server URL")
-	apiKey := fs.String("api-key", os.Getenv("DRIVE9_API_KEY"), "API key")
+	server := fs.String("server", "", "drive9 server URL (overrides $DRIVE9_SERVER and config)")
+	apiKey := fs.String("api-key", "", "API key (overrides $DRIVE9_API_KEY and config)")
 	cacheSize := fs.Int("cache-size", 128, "read cache size in MB")
 	dirTTL := fs.Duration("dir-ttl", 10*time.Second, "directory cache TTL")
 	attrTTL := fs.Duration("attr-ttl", 10*time.Second, "kernel attr cache TTL")
@@ -42,22 +51,29 @@ func MountCmd(args []string) error {
 
 	mountPoint := fs.Arg(0)
 
-	// Fill server/api-key from config if not set via flags/env
-	if *server == "" || *apiKey == "" {
-		cfg := loadConfig()
-		if *server == "" {
-			*server = cfg.ResolveServer()
-		}
-		if *apiKey == "" {
-			*apiKey = cfg.CurrentAPIKey()
+	serverGiven, apiKeyGiven := flagProvided(fs, "server"), flagProvided(fs, "api-key")
+	if err := rejectEmptyFlag("server", *server, serverGiven); err != nil {
+		return err
+	}
+	if err := rejectEmptyFlag("api-key", *apiKey, apiKeyGiven); err != nil {
+		return err
+	}
+
+	r := ResolveCredentials()
+	if *server == "" {
+		*server = r.Server
+	}
+	if *apiKey == "" {
+		if r.Kind == CredentialOwner {
+			*apiKey = r.APIKey
 		}
 	}
 
 	if *server == "" {
-		return fmt.Errorf("drive9 server URL required (--server or $DRIVE9_SERVER)")
+		return fmt.Errorf("drive9 server URL required (--server, $%s, or `drive9 ctx`)", EnvServer)
 	}
 	if *apiKey == "" {
-		return fmt.Errorf("API key required (--api-key or $DRIVE9_API_KEY)")
+		return fmt.Errorf("owner API key required (--api-key, $%s, or `drive9 ctx`)", EnvAPIKey)
 	}
 
 	syncModeVal, err := drive9fuse.ParseSyncMode(*syncMode)

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -18,8 +18,6 @@ import (
 )
 
 const (
-	vaultTokenEnv       = "DRIVE9_VAULT_TOKEN"
-	legacyCapTokenEnv   = "DRIVE9_CAP_TOKEN"
 	defaultAuditLimit   = 100
 	maxClientAuditLimit = 1000
 )
@@ -438,50 +436,50 @@ func SecretAudit(args []string) error {
 	return nil
 }
 
-func resolveVaultServer() string {
-	server := os.Getenv("DRIVE9_SERVER")
-	if server != "" {
-		return server
-	}
-	return loadConfig().ResolveServer()
-}
-
-func currentAPIKey() string {
-	if apiKey := os.Getenv("DRIVE9_API_KEY"); apiKey != "" {
-		return apiKey
-	}
-	return loadConfig().CurrentAPIKey()
-}
-
+// currentCapabilityToken returns the active delegated/capability token for
+// call sites that explicitly need "is there a token in play" (e.g. SecretLs's
+// branch to avoid silently enumerating the whole tenant when a scoped token
+// was intentionally provided). It uses the unified resolver so env > config
+// priority + Unsetenv mitigation apply.
 func currentCapabilityToken() string {
-	if tok := os.Getenv(vaultTokenEnv); tok != "" {
-		return tok
+	r := ResolveCredentials()
+	if r.Kind == CredentialDelegated {
+		return r.Token
 	}
-	return os.Getenv(legacyCapTokenEnv)
+	return ""
 }
 
+// optionalVaultManagementClientFromEnv returns a tenant-scoped (owner API key)
+// client when one can be resolved, or false when no owner credential is in
+// play. Used by SecretLs to distinguish "owner enumeration" from "delegated
+// readable-only enumeration". A delegated token in env/config does NOT satisfy
+// this — the caller must hold an owner credential.
 func optionalVaultManagementClientFromEnv() (*client.Client, bool) {
-	apiKey := currentAPIKey()
-	if apiKey == "" {
+	r := ResolveCredentials()
+	if r.Kind != CredentialOwner {
 		return nil, false
 	}
-	return client.New(resolveVaultServer(), apiKey), true
+	return client.New(r.Server, r.APIKey), true
 }
 
 func newVaultManagementClientFromEnv() (*client.Client, error) {
 	c, ok := optionalVaultManagementClientFromEnv()
 	if !ok {
-		return nil, fmt.Errorf("missing tenant API key; set DRIVE9_API_KEY or run drive9 create")
+		return nil, fmt.Errorf("missing tenant API key; set %s or run drive9 create", EnvAPIKey)
 	}
 	return c, nil
 }
 
+// newVaultReadClientFromEnv requires a delegated capability token (server's
+// vault read path is token-gated — an owner API key alone will be rejected
+// server-side with EACCES). Resolution goes through the unified resolver so
+// env > config priority + Unsetenv mitigation apply uniformly.
 func newVaultReadClientFromEnv() (*client.Client, error) {
-	token := currentCapabilityToken()
-	if token == "" {
-		return nil, fmt.Errorf("missing capability token; set %s (or %s) before using drive9 secret get/exec", vaultTokenEnv, legacyCapTokenEnv)
+	r := ResolveCredentials()
+	if r.Kind != CredentialDelegated {
+		return nil, fmt.Errorf("missing capability token; set %s before using drive9 secret get/exec", EnvVaultToken)
 	}
-	return client.New(resolveVaultServer(), token), nil
+	return client.New(r.Server, r.Token), nil
 }
 
 func validateSecretName(name string) error {

--- a/cmd/drive9/cli/secret_commands_test.go
+++ b/cmd/drive9/cli/secret_commands_test.go
@@ -34,6 +34,8 @@ func TestSecretSetFallsBackToUpdateOnConflict(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DRIVE9_SERVER", srv.URL)
 	t.Setenv("DRIVE9_API_KEY", "tenant-key")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
 
 	if err := SecretSet([]string{"aws-prod", "access_key=AKIA", "secret_key=secret"}); err != nil {
 		t.Fatalf("SecretSet: %v", err)
@@ -61,7 +63,7 @@ func TestSecretGetUsesCapabilityToken(t *testing.T) {
 
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DRIVE9_SERVER", srv.URL)
-	t.Setenv(vaultTokenEnv, "cap-token")
+	t.Setenv(EnvVaultToken, "cap-token")
 
 	out := captureStdout(t, func() {
 		if err := SecretGet([]string{"aws-prod"}); err != nil {
@@ -112,7 +114,7 @@ func TestSecretLsFallsBackToReadableScopeWithCapabilityToken(t *testing.T) {
 
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DRIVE9_SERVER", srv.URL)
-	t.Setenv(vaultTokenEnv, "cap-token")
+	t.Setenv(EnvVaultToken, "cap-token")
 
 	out := captureStdout(t, func() {
 		if err := SecretLs(nil); err != nil {
@@ -128,7 +130,7 @@ func TestSecretLsPrefersExplicitCapabilityTokenOverAmbientAPIKey(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DRIVE9_SERVER", "http://example.invalid")
 	t.Setenv("DRIVE9_API_KEY", "tenant-key")
-	t.Setenv(vaultTokenEnv, "cap-token")
+	t.Setenv(EnvVaultToken, "cap-token")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -171,7 +173,7 @@ func TestSecretExecInjectsSecretIntoChildEnv(t *testing.T) {
 
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DRIVE9_SERVER", srv.URL)
-	t.Setenv(vaultTokenEnv, "cap-token")
+	t.Setenv(EnvVaultToken, "cap-token")
 
 	out := captureStdout(t, func() {
 		if err := SecretExec([]string{"aws-prod", "--", "/bin/sh", "-c", "printf '%s:%s' \"$ACCESS_KEY\" \"$SECRET_KEY\""}); err != nil {
@@ -214,6 +216,13 @@ func TestSecretAuditFiltersClientSide(t *testing.T) {
 
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
+	// Reset the credential resolver cache before invoking the CLI entry point.
+	// The resolver uses sync.Once, so per-test t.Setenv values only flow
+	// through if the cache is cleared first. Also reset on cleanup so any
+	// later test that calls the resolver directly sees a clean slate.
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
 	oldStdout := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {

--- a/docs/guides/vault-quickstart.md
+++ b/docs/guides/vault-quickstart.md
@@ -242,9 +242,12 @@ Contexts are the primary channel. For ephemeral or non-interactive shells, three
 
 Credential priority (first match wins):
 
-1. `DRIVE9_VAULT_TOKEN` (narrower — delegated)
-2. `DRIVE9_API_KEY` (broader — owner)
-3. Active context in `~/.drive9/config`
+1. Explicit CLI flag (e.g. `--api-key`)
+2. `DRIVE9_VAULT_TOKEN` (narrower — delegated)
+3. `DRIVE9_API_KEY` (broader — owner)
+4. Active context in `~/.drive9/config`
+
+An explicitly-empty flag (`--api-key=""`) is rejected at parse time — it is not treated as "unset and fall through." Pass a non-empty value or omit the flag entirely.
 
 `DRIVE9_SERVER` is resolved independently: if set, it overrides the active context's `server` field even when credentials come from the active context.
 
@@ -261,6 +264,17 @@ drive9 umount /n/vault
 ```
 
 The dual-principal separation (`DRIVE9_API_KEY` vs `DRIVE9_VAULT_TOKEN`) is intentional. Do not collapse them.
+
+### Operator risk notes
+
+Env-based ingress has real leak surfaces. drive9 narrows the in-process window by unsetting `DRIVE9_VAULT_TOKEN`, `DRIVE9_API_KEY`, and `DRIVE9_SERVER` immediately after the credential resolver reads them — child processes forked by drive9 (`vault with`, subprocesses) do **not** inherit the credential. That guarantee is drive9-specific; the remaining surfaces below are standard operator hygiene concerns shared by any env-based credential channel (AWS CLI, kubectl, gh, etc.).
+
+- **`/proc/<pid>/environ`**: readable by the owning user. Any other same-user process (a stray shell, an editor, a monitoring agent) can snapshot it between the moment you `export` and the moment drive9's resolver unsets. Prefer inline form `DRIVE9_VAULT_TOKEN=... drive9 ...` so the variable is scoped to a single command rather than the whole shell session.
+- **Core dumps**: if drive9 crashes with `ulimit -c > 0`, the core file contains memory at crash time — including any credential that was still resident. Set `ulimit -c 0` on CI runners, or ensure core files land on a volume scrubbed between jobs.
+- **`printenv` / `env` in debug logs**: CI systems that log the environment of failed steps capture `DRIVE9_*` if exported at shell scope. Prefer per-command scoping: GitHub Actions `env:` on a single `run:` step, GitLab `variables:` with `protected: true`, etc.
+- **Shell history**: `export` writes to `~/.bash_history` / `~/.zsh_history`. Inline form avoids the `export` but the full command line still lands in history unless your shell has `HISTCONTROL=ignorespace` (or equivalent) and you prefix with a leading space.
+
+These are footguns, not drive9 bugs — the same applies to any tool that accepts credentials via env. drive9 adds the Unsetenv-after-read guarantee; the rest is up to the operator.
 
 ---
 

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -393,24 +393,30 @@ The **dual-principal separation is locked**: there is no single combined variabl
 
 Credential resolution (first match wins):
 
-1. `DRIVE9_VAULT_TOKEN` (narrower — delegated)
-2. `DRIVE9_API_KEY` (broader — owner)
-3. Active context in `~/.drive9/config`
+1. Explicit CLI flag (`--api-key`, etc., where the verb accepts one)
+2. `DRIVE9_VAULT_TOKEN` (narrower — delegated)
+3. `DRIVE9_API_KEY` (broader — owner)
+4. Active context in `~/.drive9/config`
 
-Rule 1 vs 2 implements narrower-wins so that a scoped token never falls back to owner authority within the env channel. Rule 3 means the active context only applies when no env override is present.
+Rules 2 vs 3 implement narrower-wins so that a scoped token never falls back to owner authority within the env channel. Rule 4 means the active context only applies when no flag or env override is present.
+
+**Explicit-empty flag values are rejected at parse time.** `--api-key=""` (or `--server=""`) MUST fail with a client-side error before any credential resolution runs. Treating an explicit empty string as "unset and fall through" would reintroduce the same silent-fallthrough class the set-but-invalid rule below closes — named, empty, and missing are three distinct states, and the only safe handling for "named-but-empty" is to refuse.
 
 A set-but-invalid `DRIVE9_VAULT_TOKEN` (malformed, expired, revoked, or signed by an unknown issuer) fails as `EACCES` via the standard stale-auth path in §11. It **MUST NOT** fall through to `DRIVE9_API_KEY` or to the active context — "first match wins" is token-presence, not token-validity. Users who want the broader owner authority must unset `DRIVE9_VAULT_TOKEN` explicitly.
 
 Server URL resolution is **orthogonal** to credential resolution:
 
-1. `DRIVE9_SERVER` (if set)
-2. The `server` field of the active context
+1. Explicit `--server` flag
+2. `DRIVE9_SERVER`
+3. The `server` field of the active context
 
 `ctx use` does **not** lock server and credential together: if `DRIVE9_SERVER` is set, it overrides the context's `server` field even when the active context is used for credentials. If the resulting (server, credential) pair is mismatched (e.g. a JWT signed by a different issuer), the server rejects the request with `EACCES` via the standard stale-auth path (§11). No new error model is introduced.
 
 ### 14.3 Activation mechanics
 
 At most one credential is bound to a mount. When both env overrides and an active context exist, the env override wins. This is a mechanism detail, not a second authorization layer — the chosen credential is then validated by the server on every request (Invariant #7).
+
+**Unsetenv-after-read (mitigation).** After the credential resolver reads `DRIVE9_VAULT_TOKEN`, `DRIVE9_API_KEY`, and `DRIVE9_SERVER`, it **MUST** unset those variables in the current process before spawning any child (e.g. `secret exec`, subprocesses invoked by CLI verbs). This prevents a drive9 invocation from leaking the caller's credential into a descendant process through `/proc/<pid>/environ` or through `os.Environ()` propagation. Callers that explicitly need a child to see a drive9 credential must re-inject it through the child's declared ingress (a file, a `--token` argument the child accepts, or its own env lookup before spawning drive9). This rule applies even when another credential "won" priority — all three variables are always sunk, regardless of which one was consumed, to avoid stranded leakable values.
 
 ## 15. Grant → Context Flow (End-to-End)
 


### PR DESCRIPTION
## Summary

- Unifies the 4 divergent credential-resolution call sites (`secret.go`, `client.go`, `mount.go`, `db.go`) behind a single `cli/credentials.go` resolver. Spec §14.2 precedence (env > config) becomes a single code path, not a convention reimplemented four times.
- Lands all three §14.2 mitigations in-PR (no follow-up TODO): Unsetenv-after-read, `--flag=\"\"` reject, operator risk notes in quickstart Part 5.
- Adds the explicit-flag layer to make precedence 4-tier: **flag > `DRIVE9_VAULT_TOKEN` > `DRIVE9_API_KEY` > active context**.
- Removes legacy `DRIVE9_CAP_TOKEN` — `pr-e-removal-contract.md` already covenants the sweep and no operator-facing doc advertises it.

## Scope discovery → reshape

Before writing any code I grepped the current tree and found env vars were already wired into 4 places, each with a slightly different fallback chain. This PR replaces those with one resolver; see body sections below for the checklist adv-2 asked me to cover.

## adv-2 review checklist (`74360a6f` + `06fe36eb`)

- [x] Single resolver in `credentials.go`, 4 call sites migrated
- [x] `os.Unsetenv` ordering verified wrt FUSE child — `drive9fuse.Mount` runs in-process and passes credentials via `MountOptions{}`, not env. Unsetenv-after-resolve is safe.
- [x] Set-but-invalid → named-variable error, no fallthrough (spec §14.2 already had this; resolver now enforces by kind)
- [x] `--flag=\"\"` rejected at parse time (`rejectEmptyFlag`)
- [x] `CAP_TOKEN` decision backed by external-doc grep — only references are `pr-e-removal-contract.md:33` (covenant to delete) and `agent-vault-phase0.md` (uses shell var `\$CAP_TOKEN`, not the env var). Delete-now is aligned.
- [x] `NewFromEnv()` delegated-token analysis — single caller is `cmd/drive9/main.go:167` → `runFS` (fs plane, owner-only by construction). Invariant comment added; no delegated regression test needed because server-side enforcement already rejects delegated JWTs on fs endpoints.
- [x] §14.2 spec adds 4-tier precedence + `--flag=\"\"` rule + Unsetenv-after-read MUST
- [x] Quickstart Part 5 operator-risk note covering `/proc/environ`, core dumps, debug logs, shell history

Non-blocking follow-up (per adv-2 `06fe36eb`): filed as **#299** — `SecretExec` should strip `DRIVE9_*` before injecting `@env`, per vault-quickstart Part 1 §6. Separate function, separate failure mode; not PR-C scope.

## Design choices

- **M1-sym** (`DRIVE9_API_KEY` + `DRIVE9_VAULT_TOKEN` + `DRIVE9_SERVER`, not just the delegated pair). Rationale per adv-2 `2297c782`: DX symmetry + industry convention (AWS/gh/kubectl/docker/git all use env > config for both persistent and ephemeral credentials). *Not* the \"owner keys are also ephemeral\" rationale — that's inaccurate and would leak into spec as a wrong rationale.
- **Unsetenv fires for all three vars regardless of which won priority.** A VAULT_TOKEN that wins priority still leaves DRIVE9_API_KEY inheritable if we only sink the winner. The child-leak surface is per-variable, not per-priority-slot.
- **Per-process cache** (`sync.Once`). Without it, a function that calls `currentCapabilityToken()` then `optionalVaultManagementClientFromEnv()` would lose env values after the first read-and-unset. Tests use `resetCredentialCacheForTest()` to isolate.

## Test plan

- [x] `go test ./cmd/drive9/cli/...` — all tests pass
- [x] Unit tests for resolver priority order (VAULT_TOKEN > API_KEY > config)
- [x] Unit test: all three env vars unset after resolve (Unsetenv mitigation)
- [x] Unit tests: whitespace trim, whitespace-only = absent
- [x] Unit test: `rejectEmptyFlag` edge cases
- [x] Unit test: `DRIVE9_SERVER` env overrides context server (orthogonal resolution)
- [x] Existing `secret_commands_test.go` updated with cache-reset plumbing; all green
- [ ] CI full run (pending)

## Review CC

@adversary-1 @adversary-2 — review against your posted gates. This PR touches credential ingress across the CLI surface, so kind-confusion or silent-fallthrough regressions are the highest-value catches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI flags for credentials and server now take precedence over environment variables and config context
  * Credential environment variables are automatically cleaned up after resolution to prevent inheritance by child processes

* **Bug Fixes**
  * Enhanced validation to reject explicitly empty credential flag values

* **Documentation**
  * Updated credential resolution priority documentation
  * Added operator security guidance on credential exposure surfaces and mitigation measures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->