### PR TITLE
PR-D: mount-time delegated token consumer (Invariant #3, reauth deferred post-M1)

### DIFF
--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -524,9 +524,11 @@ func formatExpiresAt(t time.Time) string {
 //	<type-specific descriptor line>
 //
 // Per Invariant #6, activating a context does NOT re-bind any running mount.
-// The only way to rebind a mount is `drive9 vault reauth`. This is enforced
-// by `ctx use` doing no FUSE-side work; it only rewrites the active context
-// pointer in ~/.drive9/config.
+// The only way to rebind a mount in M1 is `umount` + `mount` again (see
+// spec §12, §17). An in-process `vault reauth` verb was considered and
+// deferred post-M1 (#302). This is enforced by `ctx use` doing no
+// FUSE-side work; it only rewrites the active context pointer in
+// ~/.drive9/config.
 //
 // Per §17 short-circuit, an already-expired delegated context is refused.
 func ctxUseCmd(args []string) error {

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -14,17 +14,26 @@ import (
 // MountCmd handles the "drive9 mount" command.
 //
 // Credential precedence matches spec §14.2: explicit --server / --api-key flag
-// > DRIVE9_SERVER / DRIVE9_API_KEY env > active config context. The flag
-// defaults are empty strings so we can distinguish "unset" from "explicit
-// empty"; the latter is rejected (see rejectEmptyFlag).
+// > DRIVE9_SERVER / DRIVE9_API_KEY / DRIVE9_VAULT_TOKEN env > active config
+// context. The flag defaults are empty strings so we can distinguish "unset"
+// from "explicit empty"; the latter is rejected (see rejectEmptyFlag).
+//
+// A mount is bound to exactly one principal at mount time (Invariant #3).
+// If the resolver returns a delegated credential (owner JWT / `ctx use <alice>`),
+// Mount is created via client.NewWithToken and bound to that capability for
+// the mount's lifetime. If the active principal changes later (`ctx use` to
+// another context), the running mount keeps its original binding — changing
+// a running mount's credential requires umount + remount (Invariant #6).
+// `vault reauth` is not part of M1; see docs/specs/vault-interaction-end-state.md
+// §17.
 //
 // drive9fuse.Mount runs in-process (no fork/exec); credentials flow through
-// MountOptions{Server, APIKey}, not through the child's environment. This
-// makes the resolver's Unsetenv-after-read mitigation safe for mount.
+// MountOptions{Server, APIKey, Token}, not through the child's environment.
+// This makes the resolver's Unsetenv-after-read mitigation safe for mount.
 func MountCmd(args []string) error {
 	fs := flag.NewFlagSet("mount", flag.ExitOnError)
 	server := fs.String("server", "", "drive9 server URL (overrides $DRIVE9_SERVER and config)")
-	apiKey := fs.String("api-key", "", "API key (overrides $DRIVE9_API_KEY and config)")
+	apiKey := fs.String("api-key", "", "owner API key (overrides $DRIVE9_API_KEY and config)")
 	cacheSize := fs.Int("cache-size", 128, "read cache size in MB")
 	dirTTL := fs.Duration("dir-ttl", 10*time.Second, "directory cache TTL")
 	attrTTL := fs.Duration("attr-ttl", 10*time.Second, "kernel attr cache TTL")
@@ -59,22 +68,12 @@ func MountCmd(args []string) error {
 		return err
 	}
 
-	r := ResolveCredentials()
-	if *server == "" {
-		*server = r.Server
+	serverVal, apiKeyVal, tokenVal, err := resolveMountCredentials(ResolveCredentials(), *server, *apiKey)
+	if err != nil {
+		return err
 	}
-	if *apiKey == "" {
-		if r.Kind == CredentialOwner {
-			*apiKey = r.APIKey
-		}
-	}
-
-	if *server == "" {
-		return fmt.Errorf("drive9 server URL required (--server, $%s, or `drive9 ctx`)", EnvServer)
-	}
-	if *apiKey == "" {
-		return fmt.Errorf("owner API key required (--api-key, $%s, or `drive9 ctx`)", EnvAPIKey)
-	}
+	*server, *apiKey = serverVal, apiKeyVal
+	token := tokenVal
 
 	syncModeVal, err := drive9fuse.ParseSyncMode(*syncMode)
 	if err != nil {
@@ -84,6 +83,7 @@ func MountCmd(args []string) error {
 	opts := &drive9fuse.MountOptions{
 		Server:        *server,
 		APIKey:        *apiKey,
+		Token:         token,
 		MountPoint:    mountPoint,
 		CacheSize:     int64(*cacheSize) << 20,
 		DirTTL:        *dirTTL,
@@ -115,6 +115,41 @@ func UmountCmd(args []string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// resolveMountCredentials selects the (server, apiKey, token) triple that a
+// fresh mount will be bound to. It locks the principal kind at mount time
+// per Invariant #3 — once this function returns, the chosen credential is
+// fixed for the mount's lifetime. An explicit --api-key flag always means
+// owner; delegated JWTs only reach this layer through the active context
+// or DRIVE9_VAULT_TOKEN (resolver output).
+//
+// Returned token is non-empty iff the resolver produced a delegated
+// credential and no --api-key flag was passed. apiKey and token are
+// mutually exclusive; exactly one is non-empty on success.
+func resolveMountCredentials(r ResolvedCredentials, flagServer, flagAPIKey string) (server, apiKey, token string, err error) {
+	server = flagServer
+	if server == "" {
+		server = r.Server
+	}
+
+	apiKey = flagAPIKey
+	if apiKey == "" {
+		switch r.Kind {
+		case CredentialOwner:
+			apiKey = r.APIKey
+		case CredentialDelegated:
+			token = r.Token
+		}
+	}
+
+	if server == "" {
+		return "", "", "", fmt.Errorf("drive9 server URL required (--server, $%s, or `drive9 ctx`)", EnvServer)
+	}
+	if apiKey == "" && token == "" {
+		return "", "", "", fmt.Errorf("owner API key or delegated token required (--api-key, $%s, $%s, or `drive9 ctx`)", EnvAPIKey, EnvVaultToken)
+	}
+	return server, apiKey, token, nil
 }
 
 func umountArgv(goos string, lookPath func(string) (string, error), mountPoint string) ([]string, error) {

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -73,3 +73,129 @@ func TestUmountArgvNoBinary(t *testing.T) {
 		t.Fatal("expected error when no unmount binaries are available")
 	}
 }
+
+// TestResolveMountCredentials_OwnerFromResolver binds a mount to an owner
+// API key sourced from the resolver (no --api-key flag). Asserts that
+// apiKey routes through MountOptions.APIKey and token stays empty, which
+// in pkg/fuse.Mount dispatches to client.New (tenantAuthMiddleware path).
+func TestResolveMountCredentials_OwnerFromResolver(t *testing.T) {
+	r := ResolvedCredentials{
+		Kind:   CredentialOwner,
+		Server: "https://owner.example",
+		APIKey: "sk-owner",
+	}
+	server, apiKey, token, err := resolveMountCredentials(r, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if server != "https://owner.example" {
+		t.Fatalf("server = %q", server)
+	}
+	if apiKey != "sk-owner" {
+		t.Fatalf("apiKey = %q, want sk-owner", apiKey)
+	}
+	if token != "" {
+		t.Fatalf("token = %q, want empty (owner path)", token)
+	}
+}
+
+// TestResolveMountCredentials_DelegatedFromResolver binds a mount to a
+// delegated JWT sourced from the resolver (active context or
+// DRIVE9_VAULT_TOKEN). Asserts that token routes through MountOptions.Token
+// and apiKey stays empty, which in pkg/fuse.Mount dispatches to
+// client.NewWithToken (capabilityAuthMiddleware path).
+func TestResolveMountCredentials_DelegatedFromResolver(t *testing.T) {
+	r := ResolvedCredentials{
+		Kind:   CredentialDelegated,
+		Server: "https://delegated.example",
+		Token:  "jwt-aaa.bbb.ccc",
+	}
+	server, apiKey, token, err := resolveMountCredentials(r, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if server != "https://delegated.example" {
+		t.Fatalf("server = %q", server)
+	}
+	if apiKey != "" {
+		t.Fatalf("apiKey = %q, want empty (delegated path)", apiKey)
+	}
+	if token != "jwt-aaa.bbb.ccc" {
+		t.Fatalf("token = %q, want jwt-aaa.bbb.ccc", token)
+	}
+}
+
+// TestResolveMountCredentials_Invariant6Snapshot is the CLI-layer half of
+// Invariant #6: the credential captured at mount time MUST NOT be
+// retroactively overridden by a later resolver snapshot (e.g. `ctx use`
+// between call and mount). We simulate by taking two independent
+// snapshots and asserting both were captured as-of their respective
+// resolver states. There is no shared mutable state the second call can
+// mutate into the first.
+func TestResolveMountCredentials_Invariant6Snapshot(t *testing.T) {
+	first := ResolvedCredentials{Kind: CredentialDelegated, Server: "https://s.example", Token: "jwt-original"}
+	_, _, tok1, err := resolveMountCredentials(first, "", "")
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+
+	// Simulate `ctx use other-context` happening between two mount
+	// attempts. Since the helper is pure, the second call cannot affect
+	// the first's result — the first mount's binding is already frozen
+	// into its returned triple.
+	second := ResolvedCredentials{Kind: CredentialOwner, Server: "https://s.example", APIKey: "sk-rotated"}
+	_, api2, tok2, err := resolveMountCredentials(second, "", "")
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	if tok1 != "jwt-original" {
+		t.Fatalf("first mount token = %q, want jwt-original (Invariant #6: first mount binding is frozen)", tok1)
+	}
+	if api2 != "sk-rotated" || tok2 != "" {
+		t.Fatalf("second mount (apiKey=%q, token=%q) want (sk-rotated, empty)", api2, tok2)
+	}
+}
+
+// TestResolveMountCredentials_FlagAPIKeyBeatsResolver documents that an
+// explicit --api-key flag forces the owner path even when the resolver
+// would otherwise return a delegated token. The flag is owner-only by
+// construction; there is no --token flag.
+func TestResolveMountCredentials_FlagAPIKeyBeatsResolver(t *testing.T) {
+	r := ResolvedCredentials{
+		Kind:   CredentialDelegated,
+		Server: "https://s.example",
+		Token:  "jwt-should-be-ignored",
+	}
+	_, apiKey, token, err := resolveMountCredentials(r, "", "sk-flag-owner")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if apiKey != "sk-flag-owner" {
+		t.Fatalf("apiKey = %q, want sk-flag-owner (flag wins)", apiKey)
+	}
+	if token != "" {
+		t.Fatalf("token = %q, want empty when --api-key given", token)
+	}
+}
+
+// TestResolveMountCredentials_MissingCredential rejects mounts where
+// neither a flag nor resolver produced a credential. Mount must refuse
+// rather than silently succeed against a public endpoint.
+func TestResolveMountCredentials_MissingCredential(t *testing.T) {
+	r := ResolvedCredentials{Server: "https://s.example"} // Kind=CredentialNone
+	_, _, _, err := resolveMountCredentials(r, "", "")
+	if err == nil {
+		t.Fatal("expected error when no credential is available")
+	}
+}
+
+// TestResolveMountCredentials_MissingServer rejects mounts with no
+// server URL (neither flag, env, nor config).
+func TestResolveMountCredentials_MissingServer(t *testing.T) {
+	r := ResolvedCredentials{Kind: CredentialOwner, APIKey: "sk-owner"}
+	_, _, _, err := resolveMountCredentials(r, "", "")
+	if err == nil {
+		t.Fatal("expected error when no server URL is available")
+	}
+}

--- a/docs/guides/vault-quickstart.md
+++ b/docs/guides/vault-quickstart.md
@@ -7,8 +7,8 @@ This guide walks through using `drive9 vault` end-to-end. For the normative spec
 - A **secret** is a directory (e.g. `prod-db`).
 - A **key** is a file inside that directory (e.g. `prod-db/DB_URL`).
 - You read/write keys with ordinary POSIX commands (`cat`, `printf >`, `ls`, `rm`).
-- The control plane has 5 verbs: `put`, `grant`, `revoke`, `with`, `reauth`.
-- Credentials live in `~/.drive9/config` as **contexts**. The active context governs what **new** `mount` and invocation-time verbs (`vault grant`, `vault with`, `ctx import`) authenticate as. Already-mounted mounts are bound to whichever credential was active at mount time and keep that binding until `vault reauth` (Invariant #3 / §17 in the spec).
+- The control plane has 4 verbs: `put`, `grant`, `revoke`, `with`. (A post-M1 `reauth` verb is deferred — see spec §17.)
+- Credentials live in `~/.drive9/config` as **contexts**. The active context governs what **new** `mount` and invocation-time verbs (`vault grant`, `vault with`, `ctx import`) authenticate as. Already-mounted mounts are bound to whichever credential was active at mount time and keep that binding for the mount's lifetime — to rotate, `umount` and `mount` again (Invariant #3 / §17 in the spec).
 
 ---
 
@@ -201,7 +201,9 @@ drive9 ctx ls
 
 ---
 
-## Part 4 — Revocation and re-auth
+## Part 4 — Revocation and remount
+
+A running mount is bound to the credential that was active at mount time (Invariant #3). In M1 there is no in-process rebind — to rotate to a new credential you `umount` and `mount` again. A post-M1 `vault reauth` verb is tracked as a follow-up (see spec §17).
 
 ### Owner revokes early
 
@@ -213,12 +215,12 @@ drive9 vault revoke grt_7f2a
 
 ```bash
 cat /n/vault/prod-db/DB_URL
-# cat: Permission denied  (run `drive9 vault reauth` after updating the context)
+# cat: Permission denied   (rotate the context, then umount and mount again)
 ```
 
-### Rotate the context and rebind
+### Rotate the context and remount
 
-If the delegatee receives a new grant, they import it, switch, and rebind the running mount without unmounting:
+If the delegatee receives a new grant, they import it, switch contexts, and then remount:
 
 ```bash
 install -m 600 /dev/null ~/alice-grant-v2.jwt
@@ -227,8 +229,15 @@ drive9 ctx import --from-file ~/alice-grant-v2.jwt
 rm ~/alice-grant-v2.jwt
 
 drive9 ctx use alice-prod-db-v2
-drive9 vault reauth /n/vault
+drive9 umount /n/vault
+drive9 mount vault /n/vault
 ```
+
+### Operator notes for remount
+
+- **Close open FDs first.** `umount` fails with `EBUSY` (Linux) or "Resource busy" (macOS) while any process still has a file open under the mount point. Stop editors, shells with `cwd` inside the mount, and any long-running readers before calling `umount`. On Linux, `fuser -vm /n/vault` and `lsof /n/vault` list holders.
+- **Pending writes are best-effort across the remount boundary.** Writes that were queued against the old credential may not replay cleanly under the new credential (the new principal may lack permission on the same paths, or the owner may have revoked the underlying grant). M1 preserves the write-back cache on disk and re-plays what it can on the next mount, but does not promise lossless recovery. If loss is unacceptable, drain writes (`sync` on files of interest, wait for the cache to settle) **before** `umount`.
+- **The new mount picks up whatever context is active at `mount` time.** If you forgot to `ctx use` after import, the new mount will bind to the previous active context. `drive9 ctx ls` before `mount` is the cheapest way to confirm.
 
 ---
 
@@ -330,7 +339,7 @@ drive9 vault revoke grt_7f2a
 
 ```bash
 cat /n/vault/prod-db/DB_URL
-# cat: Permission denied   (run `drive9 vault reauth` after rotating the context)
+# cat: Permission denied   (rotate the context, then umount and mount again)
 ```
 
 ---
@@ -352,7 +361,7 @@ cat /n/vault/prod-db/DB_URL
 | Inject env | `drive9 vault with /n/vault/<s> -- <cmd>` |
 | Grant | `drive9 vault grant <scope>... --agent <a> --perm <p> --ttl <t>` |
 | Revoke | `drive9 vault revoke <grant-id>` |
-| Rebind after rotation | `drive9 vault reauth /n/vault` |
+| Rebind after rotation (M1) | `drive9 umount /n/vault && drive9 mount vault /n/vault` |
 
 ## Errno quick reference
 
@@ -361,7 +370,7 @@ cat /n/vault/prod-db/DB_URL
 | Key/secret not found | `ENOENT` |
 | Key exists but not visible under current context | `ENOENT` (intentional) |
 | Write without permission | `EACCES` |
-| Context/token expired or revoked (runtime) | `EACCES` + `vault reauth` hint |
+| Context/token expired or revoked (runtime) | `EACCES` + umount+mount hint |
 | `ctx use` on a locally-expired context | client-side error (not a new errno) |
 | Backend / FUSE failure | `EIO` |
 

--- a/docs/specs/pr-b-ctx-implementation.md
+++ b/docs/specs/pr-b-ctx-implementation.md
@@ -24,7 +24,7 @@ PR-B is the **CLI side** of the grant → context flow: the verbs that take a JW
 **Explicitly deferred to later PRs:**
 - Env-var resolution (`DRIVE9_VAULT_TOKEN` / `DRIVE9_API_KEY` / `DRIVE9_SERVER`) → **PR-C**
 - Legacy `cap_token` / `CapTokenClaims` / `vault_tokens` table deletion → **PR-E** (§10 deletion contract, binding)
-- Mount-layer credential re-binding (`drive9 vault reauth`, Invariant #6) → **PR-D**
+- Mount-layer credential consume (delegated JWT in `cmd/drive9/cli/mount.go` resolver path, Invariant #6) → **PR-D**. An in-process `drive9 vault reauth` verb was originally scoped here and has been deferred post-M1 (#302); M1 rebind path is `umount + mount` (see `vault-interaction-end-state.md` §12, §17).
 - Any issuer allow-list hardening beyond trust-on-first-use → follow-up (§13.3 issuer trust note)
 
 ### Non-goals
@@ -219,7 +219,7 @@ switched to context "owner-prod"
   owner credentials, server https://drive9.dev
 ```
 
-**Invariant #6 (no auto-rebind):** `ctx use` does **no** FUSE-side work. It only rewrites `~/.drive9/config`. Running mounts continue to hold whatever credential they were bound to at mount time; the only way to rebind is `drive9 vault reauth` (PR-D). This is enforced structurally by `ctx use` not depending on any mount-manager package.
+**Invariant #6 (no auto-rebind):** `ctx use` does **no** FUSE-side work. It only rewrites `~/.drive9/config`. Running mounts continue to hold whatever credential they were bound to at mount time; the only way to rebind in M1 is `umount` + `mount` again (see `vault-interaction-end-state.md` §12, §17). A `drive9 vault reauth` verb was considered for in-process rebind and deferred post-M1 (#302). This is enforced structurally by `ctx use` not depending on any mount-manager package.
 
 ### 2.5 `drive9 ctx rm <name>`
 
@@ -535,7 +535,7 @@ See `docs/specs/pr-b-review-checklist.md`. Each item is traceable to a numbered 
 | `DRIVE9_VAULT_TOKEN` env var resolution | PR-C | Per `pr-a-jwt-implementation.md` line 31, env vars are a separate concern. Folding them here doubles the review surface. |
 | `DRIVE9_API_KEY` env var resolution | PR-C | Same. |
 | `DRIVE9_SERVER` env var resolution | PR-C | Same. |
-| `drive9 vault reauth` (mount rebind) | PR-D | Mount-layer work; depends on FUSE manager refactor that is not in PR-B. |
+| `drive9 vault reauth` (in-process mount rebind) | post-M1 (#302) | Originally scoped to PR-D; descoped per qiffang directive `06f1cd95` to keep M1 as a minimal Unix/Plan 9-shaped prototype. M1 rebind path is `umount + mount` (see `vault-interaction-end-state.md` §12, §17). |
 | `CapToken*` / `vault_tokens` deletion | PR-E | §10 deletion contract is binding. PR-B adds **zero** references to legacy types. |
 | Issuer allow-list / `--expect-issuer` | future hardening | Out of scope per end-state §13.3 trust note. |
 | `drive9 ctx` bare-form removal | separate UX-cleanup PR | Non-spec compat carry-over, noted in §4.5. |

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -13,7 +13,7 @@ This spec is the single source of truth for the terminal shape of vault UX. It i
 - **secret** = directory (e.g. `prod-db`)
 - **key** = file inside that directory (e.g. `prod-db/DB_URL`)
 - **Read/write a key**: POSIX file ops on `/n/vault/**` (`cat`, `printf >`, `ls`, `rm`)
-- **Control plane**: 5 verbs — `put`, `grant`, `revoke`, `with`, `reauth`
+- **Control plane**: 4 verbs — `put`, `grant`, `revoke`, `with`. A running mount's credential binding is fixed at mount time (Invariant #3); to change it, `umount` and `mount` again. An in-process rebind verb (`vault reauth`) was considered for M1 and deferred to a post-M1 increment — see §17.
 
 One principle: authority follows the credential, not the command. Owners and delegatees use the same CLI; only the credential binding differs.
 
@@ -219,7 +219,7 @@ tail -f /n/vault/@audit                   # global stream
 tail -f /n/vault/prod-db/@audit           # per-secret stream
 ```
 
-Events: `put / read / write / grant / revoke / rm / reauth`.
+Events: `put / read / write / grant / revoke / rm`.
 `rm key` events carry `affected_grants`.
 
 Grant introspection:
@@ -244,7 +244,7 @@ cat /n/vault/prod-db/@grants/grt_7f2a
 | Key does not exist | `ENOENT` |
 | Key exists but current principal has no permission | `ENOENT` (existence-oracle defense) |
 | Current principal attempts an unauthorized **write** | `EACCES` |
-| Bound credential expired / revoked | `EACCES` + reauth hint |
+| Bound credential expired / revoked | `EACCES` + remount hint |
 | Infrastructure failure (FUSE daemon, backend) | `EIO` |
 
 Core rules:
@@ -274,16 +274,19 @@ Core rules:
 
 This table is locked. The auth lifecycle (§17) layers **local short-circuits** (e.g. `ctx use` on an expired context refuses client-side) **on top of** the server-side stale-auth case — those short-circuits do not introduce a new errno.
 
-**Annotation convention.** Where example outputs in this spec and the quickstart show errno lines followed by parenthetical guidance (e.g. `cat: Permission denied  (run 'drive9 vault reauth' after updating the context)`), the parenthetical is a **documentation annotation** intended for the reader, not literal `cat`/`ls` stderr output. The POSIX `cat`/`ls` utilities emit only the errno text; the reauth hint is a spec-level explanation of what the user should do next, delivered out-of-band (man page, quickstart, CLI `drive9 vault reauth` documentation). No new verb is introduced to deliver this hint inline.
+**Annotation convention.** Where example outputs in this spec and the quickstart show errno lines followed by parenthetical guidance (e.g. `cat: Permission denied  (run 'drive9 umount /n/vault && drive9 mount vault /n/vault' after updating the context)`), the parenthetical is a **documentation annotation** intended for the reader, not literal `cat`/`ls` stderr output. The POSIX `cat`/`ls` utilities emit only the errno text; the remount hint is a spec-level explanation of what the user should do next, delivered out-of-band (man page, quickstart). No new verb is introduced to deliver this hint inline.
 
 ## 12. Recovery After Credential Rotation
 
 ```bash
 drive9 ctx use <new-context>
-drive9 vault reauth /n/vault
+drive9 umount /n/vault
+drive9 mount vault /n/vault
 ```
 
-`reauth` rebinds the running mount to the current active context without unmount/remount. The next syscall succeeds if the new credential is valid.
+A mount's credential binding is fixed at mount time (Invariant #3). To rotate to a new context, `umount` the running mount and `mount` again — the new mount picks up the active context on startup. There is no in-process rebind in M1; `vault reauth` is deferred to a post-M1 increment (§17).
+
+Operator note: `umount` refuses with `EBUSY` while any process holds an open file descriptor under the mount (Linux `fusermount3 -u`; macOS `umount`). Stop or detach those processes before unmounting. Best-effort: writes that are already staged in the write-back cache survive a clean `umount` and are re-attempted by the next `mount` instance; they are **not** guaranteed to recover losslessly under arbitrary failure modes (e.g. token expiry mid-flush) — the supported pattern is to quiesce writers before remounting.
 
 ---
 
@@ -469,7 +472,7 @@ drive9 vault revoke grt_7f2a
 
 ```bash
 cat /n/vault/prod-db/DB_URL
-# cat: Permission denied  (run `drive9 vault reauth` after updating the context)
+# cat: Permission denied  (run `drive9 umount /n/vault && drive9 mount vault /n/vault` after updating the context)
 ```
 
 ## 16. Security Note (Normative MUST)
@@ -501,7 +504,9 @@ This is locked as Invariant #7.
 
 ## 17. Auth Lifecycle — Local Short-Circuits vs Server Checks
 
-A mount is bound to one credential at mount time and does not silently follow later context changes (Invariant #3). Running `ctx use <other>` after mounting **does not re-bind** the mount; the owner must call `vault reauth <mountpoint>` (§12) to rebind to the current active context. This is the intended behaviour — it keeps the authority model predictable for long-running mounts — and is captured in Invariant #6.
+A mount is bound to one credential at mount time and does not silently follow later context changes (Invariant #3). Running `ctx use <other>` after mounting **does not re-bind** the mount. To change a running mount's credential, the owner `umount`s and then `mount`s again; the new mount binds to whatever the active context (or env override) resolves to at startup. This is the intended behaviour — it keeps the authority model predictable for long-running mounts — and is captured in Invariant #6.
+
+**`vault reauth` is deferred.** An in-process rebind verb was considered for M1 and excluded: introducing it requires a second drive9-process control plane (Unix-domain socket listener in the mount process, a CLI-side dialer, a mount-disambiguation identity, and atomic client-pointer swap inside every FUSE op). The `umount + mount` escape hatch covers the same functional contract without expanding the IPC surface. A post-M1 spec increment MAY reintroduce `vault reauth` if operational evidence shows the remount cadence is disruptive; that increment is additive and does not alter the rules below.
 
 Local short-circuits exist to make UX responsive. They are layered **on top of** the normative errno table (§11), not instead of it.
 
@@ -510,11 +515,10 @@ Local short-circuits exist to make UX responsive. They are layered **on top of**
 | `ctx import` | `exp` in past? | local refuse (no new errno; command error) |
 | `ctx ls` | `exp` in past? | row marked `expired` |
 | `ctx use <name>` | target context expired? | local error, do not activate |
-| `vault reauth <mountpoint>` | active context valid locally? | local refuse if target context is already locally expired; otherwise proceed and let the server bind |
 | `mount` | context valid locally? | proceed; server then validates |
-| Any FS op | server says stale / revoked | `EACCES` + reauth hint (§11) |
+| Any FS op | server says stale / revoked | `EACCES` + remount hint (§11) |
 
-The four local short-circuits (`ctx import` / `ctx ls` / `ctx use` / `vault reauth`) are client-side UX. They do **not** introduce a new errno case. The locked 6-row errno table in §11 is unchanged.
+The three local short-circuits (`ctx import` / `ctx ls` / `ctx use`) are client-side UX. They do **not** introduce a new errno case. The locked 6-row errno table in §11 is unchanged.
 
 ## 18. Invariants (Normative, numbered)
 
@@ -523,7 +527,7 @@ The four local short-circuits (`ctx import` / `ctx ls` / `ctx use` / `vault reau
 3. **One mount, one principal**: a mount is bound to exactly one credential at mount time; stale/revoked credentials do not silently fall back to any other identity.
 4. **Field names are sensitive metadata**: key names are not disclosed via errno, audit (to the delegatee), or listing unless the principal has permission.
 5. **Grants do not cascade-revoke on `rm`**: removing a key leaves existing grants syntactically intact; holders observe `ENOENT`, and audit records `affected_grants`.
-6. **One active context at a time**: `~/.drive9/config` MAY hold any number of contexts (owner and delegated, mixed); at most one is active. Switching contexts does not silently re-bind an already-mounted mount (use `reauth`).
+6. **One active context at a time**: `~/.drive9/config` MAY hold any number of contexts (owner and delegated, mixed); at most one is active. Switching contexts does not silently re-bind an already-mounted mount. To change a running mount's credential, `umount` and `mount` again; the new mount picks up the current active context (or env override) at startup. An in-process rebind (`vault reauth`) is **not** part of M1 (§17) — it MAY be added in a later spec increment without altering this invariant.
 7. **Client-side JWT decoding is UX-only**: local decode populates `ctx` metadata and enables offline `ctx ls`; it **MUST NOT** substitute for server-side validation. The server **MUST** re-check signature, TTL, and revocation on every request.
 8. **Issuer trust is TOFU (trust-on-first-use) in v0**: `ctx import` populates the context's `server` field from the JWT's `iss` claim with no network round-trip and no allow-list check. Invariant #7 does **not** protect against a malicious `iss` — the server being contacted is itself attacker-controlled and will validate its own signatures. Mitigation is delivery-channel-level (see §13.3 and §16); an issuer allow-list / `--expect-issuer` path is deferred (see §22). Implementations **MUST NOT** add a silent issuer check that only validates shape or reachability; such a check provides false assurance and is prohibited.
 
@@ -531,7 +535,7 @@ The four local short-circuits (`ctx import` / `ctx ls` / `ctx use` / `vault reau
 
 | Failure | Detection | Client visible |
 |---|---|---|
-| Expired / revoked credential | server on next request | `EACCES` + reauth hint |
+| Expired / revoked credential | server on next request | `EACCES` + remount hint |
 | Server unreachable | client | `EIO` |
 | FUSE daemon crash | kernel | `EIO` |
 | Malformed JWT at `ctx import` | client local decode | command error, no context written |
@@ -596,7 +600,7 @@ cat ids.txt | xargs drive9 vault revoke
 
 ### Rule 4 — State-binding verbs are not filters
 
-Verbs that bind local state (current context, mount credential binding, filesystem mount point) — `ctx use`, `mount`, `vault reauth` — MUST take their target as an explicit argv argument and MUST NOT read stdin. They produce a single human confirmation line on stdout and are **exempt from Rule 1's `--json`/`--token-only` surface**.
+Verbs that bind local state (current context, filesystem mount point) — `ctx use`, `mount` — MUST take their target as an explicit argv argument and MUST NOT read stdin. They produce a single human confirmation line on stdout and are **exempt from Rule 1's `--json`/`--token-only` surface**. A future `vault reauth` verb (see §17, deferred post-M1) falls under this rule when introduced.
 
 Rationale: state-binding verbs change global principal or mount identity. Allowing them to be the right-hand side of a pipe (`… | ctx use`) would let an unrelated producer silently rebind credentials for subsequent commands. The contract forbids it structurally; if a caller wants scripted rebinding, they compose with argv (`ctx use "$(compute_name)"`) so the data flow is explicit.
 
@@ -640,7 +644,8 @@ Appendix A — Command surface at a glance:
 | `drive9 vault grant <scope>... --agent --perm --ttl` | Issue a scoped JWT. |
 | `drive9 vault revoke <grant-id>` | Revoke a grant. |
 | `drive9 vault with <path> -- <cmd>` | Exec child with `@env` injected. |
-| `drive9 vault reauth <mountpoint>` | Rebind a running mount to the current context. |
 | `cat / ls / rm / printf >` on `/n/vault/**` | Data plane. |
+
+Deferred post-M1 (tracked as a follow-up increment, see §17): `drive9 vault reauth <mountpoint>` — rebind a running mount to the current context without `umount`.
 
 Appendix B — Canonical history: §0–§12 absorb `89603ee6`; §13–§17 are the v2 context-unified credential increment over that canonical; Invariants #1–#5 derive from `89603ee6`; Invariants #6–#7 are new.

--- a/pkg/client/auth_test.go
+++ b/pkg/client/auth_test.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestNewSendsBearerAPIKey asserts that New() authenticates with
+// `Authorization: Bearer <api-key>`. Server-side disambiguation between
+// owner API keys and delegated JWTs happens in middleware
+// (pkg/server/auth.go); the wire format is identical.
+func TestNewSendsBearerAPIKey(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"entries":[]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "owner-api-key-xyz")
+	if _, err := c.List("/"); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if gotAuth != "Bearer owner-api-key-xyz" {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer owner-api-key-xyz")
+	}
+}
+
+// TestNewWithTokenSendsBearerJWT asserts that NewWithToken() also uses
+// `Authorization: Bearer`. The constructor name is the sole call-site
+// discriminator; there is no `X-Dat9-Capability` or similar side-channel
+// header. Server middleware routes via the `iss` claim (tenant vs. capability).
+func TestNewWithTokenSendsBearerJWT(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"entries":[]}`))
+	}))
+	defer srv.Close()
+
+	c := NewWithToken(srv.URL, "jwt-aaa.bbb.ccc")
+	if _, err := c.List("/"); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if gotAuth != "Bearer jwt-aaa.bbb.ccc" {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer jwt-aaa.bbb.ccc")
+	}
+}
+
+// TestClientCredentialIsImmutableAfterConstruction is the client-side
+// half of Invariant #6: once a *client.Client has been constructed, its
+// credential cannot be mutated through any exported API. Subsequent
+// resolver / config changes only take effect via a new constructor call —
+// which, at the mount layer, requires umount+mount (see spec §12, §17).
+//
+// This test pins the absence of a setter. If a future change adds
+// SetAPIKey/SetToken/Rebind, the test must be updated alongside an
+// explicit spec amendment to §17 and Invariant #6.
+func TestClientCredentialIsImmutableAfterConstruction(t *testing.T) {
+	t.Parallel()
+
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"entries":[]}`))
+	}))
+	defer srv.Close()
+
+	c := NewWithToken(srv.URL, "jwt-original")
+
+	// Simulate what would happen if the resolver were re-run while a
+	// client is in flight: a *new* client for the new credential can
+	// exist, but the original must keep sending its original token.
+	_ = NewWithToken(srv.URL, "jwt-rotated")
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.List("/"); err != nil {
+			t.Fatalf("List #%d: %v", i, err)
+		}
+	}
+
+	for i, auth := range seen {
+		if auth != "Bearer jwt-original" {
+			t.Fatalf("request %d Authorization = %q, want %q (credential must not rotate mid-life)", i, auth, "Bearer jwt-original")
+		}
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -46,8 +46,36 @@ func (e *StatusError) Is(target error) bool {
 	return target == ErrConflict && e.StatusCode == http.StatusConflict
 }
 
-// New creates a new dat9 client.
+// New creates a new dat9 client authenticated with an owner API key.
+//
+// Owner credentials reach the tenant management plane (CreateVaultSecret,
+// IssueVaultGrant, audit, etc.) as well as the data plane. Use NewWithToken
+// for delegated capability tokens; the two kinds are distinct in caller
+// capability even though both are carried as `Authorization: Bearer` on the
+// wire (server-side middleware disambiguates — see pkg/server/auth.go).
 func New(baseURL, apiKey string) *Client {
+	return newClient(baseURL, apiKey)
+}
+
+// NewWithToken creates a new dat9 client authenticated with a delegated
+// capability token (JWT). Delegated callers can only reach read-path vault
+// endpoints and the FUSE data-plane routes that capabilityAuthMiddleware
+// resolves; admin-plane endpoints will 401 server-side. Choosing the
+// constructor at the call site makes the principal kind explicit per Plan 9
+// orthogonality — a "forget to check kind" bug class doesn't get a
+// construction path.
+func NewWithToken(baseURL, token string) *Client {
+	return newClient(baseURL, token)
+}
+
+// newClient is the shared internal constructor for New and NewWithToken.
+// Both credential kinds travel as `Authorization: Bearer` on the wire, so
+// they share the same httpClient/transport wiring. Kind differentiation
+// lives at the call site (constructor name) — there is no internal
+// discriminator field. If a per-call-kind bug surfaces later, the minimal
+// fix is a discriminator; meanwhile Invariant #7 keeps all authorization
+// decisions server-side.
+func newClient(baseURL, credential string) *Client {
 	// Clone DefaultTransport to preserve Proxy, HTTP/2, dialer, and TLS defaults,
 	// then tune connection pooling for concurrent multipart uploads to S3.
 	// Default MaxIdleConnsPerHost=2 forces new TLS handshakes for every
@@ -103,7 +131,7 @@ func New(baseURL, apiKey string) *Client {
 	}
 	return &Client{
 		baseURL: strings.TrimRight(baseURL, "/"),
-		apiKey:  apiKey,
+		apiKey:  credential,
 		httpClient: &http.Client{
 			Transport: transport,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -18,9 +18,17 @@ import (
 )
 
 // MountOptions configures the FUSE mount.
+//
+// Credential kind: APIKey and Token are mutually exclusive. APIKey is an
+// owner tenant API key (full management + data plane); Token is a delegated
+// capability JWT (read-path only). Exactly one must be non-empty at
+// Mount() time — the running mount is bound to that single credential for
+// its entire lifetime (Invariant #3). To change credentials, umount and
+// remount; there is no in-process rebind.
 type MountOptions struct {
 	Server            string        // dat9 server URL
-	APIKey            string        // dat9 API key
+	APIKey            string        // owner API key (mutually exclusive with Token)
+	Token             string        // delegated capability JWT (mutually exclusive with APIKey)
 	MountPoint        string        // local mount point
 	CacheDir          string        // write-back cache directory (default ~/.cache/drive9); empty string uses default
 	CacheSize         int64         // ReadCache max size in bytes (default 128MB)
@@ -75,11 +83,30 @@ func Mount(opts *MountOptions) error {
 		return fmt.Errorf("create mount point: %w", err)
 	}
 
+	// Validate credential inputs. MountOptions.APIKey and MountOptions.Token
+	// are mutually exclusive (Invariant #3 — one mount, one principal).
+	// Both empty is caller error; both non-empty would let a silent
+	// priority rule override what the caller wrote, which we refuse.
+	if opts.APIKey != "" && opts.Token != "" {
+		return fmt.Errorf("mount: APIKey and Token are mutually exclusive (choose one principal kind at mount time)")
+	}
+	if opts.APIKey == "" && opts.Token == "" {
+		return fmt.Errorf("mount: either APIKey (owner) or Token (delegated) is required")
+	}
+
 	// Generate per-mount actor ID for SSE self-filtering.
 	actorID := generateMountID()
 
-	// Create client and verify connectivity
-	c := client.New(opts.Server, opts.APIKey)
+	// Create client and verify connectivity. The constructor choice binds
+	// the mount's principal kind for its entire lifetime (see Invariant #3
+	// and Invariant #6 — running mount credential change requires umount
+	// and remount).
+	var c *client.Client
+	if opts.Token != "" {
+		c = client.NewWithToken(opts.Server, opts.Token)
+	} else {
+		c = client.New(opts.Server, opts.APIKey)
+	}
 	c.SetActor(actorID)
 	if _, err := c.List("/"); err != nil {
 		return fmt.Errorf("cannot reach dat9 server: %w", err)


### PR DESCRIPTION
## Summary

Minimal MVP wiring so `drive9 mount` actually uses a delegated JWT when the resolver returns one. Per the #onepassword descope consensus (qiffang `06f1cd95`, adv-1 `ab590ef1` + `9e8aa0c2`, adv-2 `57921bd1` + `059d10dc`), `vault reauth` and the whole hot-rebind control plane (UDS, `atomic.Pointer[client.Client]`, ping-before-swap) are **out of scope** for M1. Running mounts bind at mount time; to rotate, `umount` and `mount` again.

## Scope (5-gate floor, adv-2 `57921bd1`)

- **Gate 1 (PR-C reuse).** `MountCmd` goes through `ResolveCredentials()` only; `r.Kind` drives the owner / delegated dispatch. No parallel env reads.
- **Gate 2 (spec sync).** §17 + Invariant #6 + surrounding surfaces (§0, §10, §11, §12, §15, §19, §20 Rule 4, Appendix A) rewritten to contract "umount+mount to rebind; `vault reauth` deferred post-M1".
- **Gate 3 (3 regression tests).** Owner `Bearer`, delegated `Bearer`, Invariant #6 snapshot freeze. No 4th pending-recovery test per adv-1 `9e8aa0c2` refinement — Quickstart Part 4 describes pending as best-effort instead.
- **Gate 4 (follow-up issue).** `vault reauth (hot credential rebind)` opened but not scheduled. Reference design preserved for when real operational signal shows up.
- **Gate 5 (honest docs).** Quickstart Part 4 says "pending writes are best-effort across the remount boundary" — no lossless-recovery promise.

## Plan 9 shape (adv-2 `0687e641` / `059d10dc`)

`client.New(apiKey)` unchanged. New sibling `client.NewWithToken(jwt)`. Wire is identical (`Authorization: Bearer`); the constructor differentiates **capability**, not header shape. No internal `credKind` field per `feedback_negative_optionality` — choose once at construction, bake it in.

`MountOptions{APIKey, Token}` mutually exclusive; `Mount()` rejects both-empty and both-set at the boundary (Invariant #3 — one mount, one principal).

## IPC surface

Zero new drive9↔drive9 IPC. M1 keeps only the pre-existing boundaries: kernel↔FUSE, mount↔drive9-server.

## Test plan

- [ ] `pkg/client` tests: `TestNewSendsBearerAPIKey`, `TestNewWithTokenSendsBearerJWT`, `TestClientCredentialIsImmutableAfterConstruction`
- [ ] `cmd/drive9/cli` tests: `TestResolveMountCredentials_{OwnerFromResolver,DelegatedFromResolver,Invariant6Snapshot,FlagAPIKeyBeatsResolver,MissingCredential,MissingServer}`
- [ ] CI `go build ./...` + `go test ./pkg/client/... ./cmd/drive9/cli/...` green
- [ ] Spec + quickstart diff reviewed for residual reauth references

## Follow-ups (out of this PR)

- Narrow #286 scope to mount-time delegated consume only
- New issue: post-M1 `vault reauth (hot credential rebind)` with reference design link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for delegated capability tokens as an alternative to API keys for mount authentication.
  * Mount credentials are now fixed at mount time; token/key rotation requires `umount` followed by `mount`.

* **Documentation**
  * Updated quickstart and specifications to reflect deferred `vault reauth` command (post-M1).
  * Clarified mount credential binding invariants and remount workflow for credential rotation.

* **Tests**
  * Added comprehensive tests for delegated token credential resolution and client authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->