### PR TITLE
PR-V1: vault spec §2 wholesale-only + Implementation status table

### DIFF
--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -41,11 +41,7 @@ printf '%s' 'super-secret-password'              > ./prod-db.envdir/DB_PASSWORD
 drive9 vault put /n/vault/prod-db --from ./prod-db.envdir
 ```
 
-Whole-replace (delete keys not present in the source directory):
-
-```bash
-drive9 vault put /n/vault/prod-db --from ./prod-db.envdir --prune
-```
+`put` is defined as **wholesale replace**: the secret's visible key set after the call equals the key set in `<dir>`. Keys that exist server-side but are absent from `<dir>` are deleted; keys present in `<dir>` are written. There is exactly one mode — no merge/upsert flag, no `--prune` flag. Incremental edits use the data-plane (§3 `printf >` / §5 `rm`).
 
 Contract: `put` is a single transaction; concurrent readers see either the old complete state or the new complete state, never a half-update.
 
@@ -522,7 +518,7 @@ The three local short-circuits (`ctx import` / `ctx ls` / `ctx use`) are client-
 
 ## 18. Invariants (Normative, numbered)
 
-1. **Atomic `put --prune`**: a put transaction is visible to concurrent readers either entirely in the old state or entirely in the new state; no half-update is observable.
+1. **Atomic `put`**: a put transaction is visible to concurrent readers either entirely in the old state or entirely in the new state; no half-update is observable. `put` has exactly one mode (wholesale replace, §2).
 2. **Existence oracle defense**: reads return `ENOENT` for both non-existent and invisible keys; the two are indistinguishable to clients.
 3. **One mount, one principal**: a mount is bound to exactly one credential at mount time; stale/revoked credentials do not silently fall back to any other identity.
 4. **Field names are sensitive metadata**: key names are not disclosed via errno, audit (to the delegatee), or listing unless the principal has permission.
@@ -540,7 +536,7 @@ The three local short-circuits (`ctx import` / `ctx ls` / `ctx use`) are client-
 | FUSE daemon crash | kernel | `EIO` |
 | Malformed JWT at `ctx import` | client local decode | command error, no context written |
 | Import of wrong credential kind (owner JWT, random string) | client local decode | command error, directing user to `ctx add --api-key` |
-| Concurrent `put --prune` reads during transaction | server transaction | atomic — readers see old or new (Invariant #1) |
+| Concurrent `put` reads during transaction | server transaction | atomic — readers see old or new (Invariant #1) |
 
 ## 20. I/O Contracts (CLI Emit Surface, Normative)
 
@@ -630,6 +626,33 @@ Every verb that documents a pipe or composition pattern (`A | B`, `A | xargs B`)
 
 ---
 
+## Implementation status
+
+The table below tracks whether each Appendix A verb is live on `main`. It is the single source of truth that reviewers use to decide when `Status: Proposed` may flip to `Accepted` (see header): the flip happens only once every row in the `drive9 vault` / `drive9 mount vault` block reads `implemented`. Rows for verbs already shipped by merged PRs are pinned here for auditability; subsequent PRs in the Appendix-A alignment track MUST update this table in the same commit that ships the verb.
+
+Legend:
+- **implemented** — landed on `main`; verb shape matches the spec row above.
+- **not-yet** — verb defined in Appendix A; no CLI entry on `main` yet. Scheduled within the Appendix-A alignment PR track; status flips in the PR that ships the verb.
+- **descoped-#NNN** — explicitly removed from M1; follow-up issue carries the residual scope.
+
+| Verb (Appendix A) | Status | Landed / tracked |
+|---|---|---|
+| `drive9 mount vault <path>` | not-yet | Appendix-A alignment PR track |
+| `drive9 umount <path>` | implemented | pre-M1 |
+| `drive9 ctx add --api-key` | implemented | #284 (PR-B) |
+| `drive9 ctx import --from-file` | implemented | #284 (PR-B) |
+| `drive9 ctx ls` / `use` / `rm` | implemented | #284 (PR-B) |
+| `drive9 vault put <path> --from <dir>` | not-yet | Appendix-A alignment PR track |
+| `drive9 vault grant <scope>... --agent --perm --ttl` | not-yet | Appendix-A alignment PR track (server endpoint live in #273; CLI still on legacy `drive9 secret grant` with no `--perm`) |
+| `drive9 vault revoke <grant-id>` | not-yet | Appendix-A alignment PR track |
+| `drive9 vault with <path> -- <cmd>` | not-yet | Appendix-A alignment PR track |
+| `drive9 vault reauth <mountpoint>` | descoped-#302 | deferred post-M1 (§17) |
+| Data-plane `cat / ls / rm / printf >` on `/n/vault/**` | implemented | pre-M1 |
+
+Rows record the **final user-visible verb**. Interim steps (for example, fixing the legacy `drive9 secret grant` call path to hit `/v1/vault/grants` with `--perm` before the `vault` verb lands) do **not** flip `drive9 vault grant` to `implemented` — that row only flips when the `drive9 vault grant` CLI surface itself is live on `main`.
+
+---
+
 Appendix A — Command surface at a glance:
 
 | Command | Role |
@@ -640,7 +663,7 @@ Appendix A — Command surface at a glance:
 | `drive9 ctx import --from-file <path>` | Register a delegated context from a grant JWT file (primary UX). |
 | `drive9 ctx import [--from-file -]` | Same, reading the JWT from stdin (default when stdin is a pipe). |
 | `drive9 ctx ls / use / rm` | Manage contexts (offline). |
-| `drive9 vault put <path> --from <dir> [--prune]` | Atomic batch write. |
+| `drive9 vault put <path> --from <dir>` | Atomic wholesale-replace batch write (§2). |
 | `drive9 vault grant <scope>... --agent --perm --ttl` | Issue a scoped JWT. |
 | `drive9 vault revoke <grant-id>` | Revoke a grant. |
 | `drive9 vault with <path> -- <cmd>` | Exec child with `@env` injected. |

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -30,7 +30,7 @@ drive9 mount vault /n/vault
 - One mount binds one principal; the namespace the user sees is exactly what that principal can access.
 - After the bound credential becomes invalid (expired / revoked), the mount does **not** fall back — the next syscall returns `EACCES`.
 
-## 2. Create a Secret (Batch Write)
+## 2. Create or Replace a Secret (Batch Write)
 
 ```bash
 mkdir -p ./prod-db.envdir

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -628,12 +628,11 @@ Every verb that documents a pipe or composition pattern (`A | B`, `A | xargs B`)
 
 ## Implementation status
 
-The table below tracks whether each Appendix A verb is live on `main`. It is the single source of truth that reviewers use to decide when `Status: Proposed` may flip to `Accepted` (see header): the flip happens only once every row in the `drive9 vault` / `drive9 mount vault` block reads either `implemented` or `descoped-#NNN` (i.e. no row is left `not-yet`). Rows for verbs already shipped by merged PRs are pinned here for auditability; subsequent PRs in the Appendix-A alignment track MUST update this table in the same commit that ships the verb.
+The table below tracks whether each Appendix A verb is live on `main`. It is the single source of truth that reviewers use to decide when `Status: Proposed` may flip to `Accepted` (see header): the flip happens only once every row in the `drive9 vault` / `drive9 mount vault` block reads `implemented`. Rows for verbs already shipped by merged PRs are pinned here for auditability; subsequent PRs in the Appendix-A alignment track MUST update this table in the same commit that ships the verb. Verbs explicitly deferred post-M1 (e.g. `drive9 vault reauth`, see §17 and Appendix A tail) are not tracked here; they have no accounting row and do not gate the flip.
 
 Legend:
 - **implemented** — landed on `main`; verb shape matches the spec row above.
 - **not-yet** — verb defined in Appendix A; no CLI entry on `main` yet. Scheduled within the Appendix-A alignment PR track; status flips in the PR that ships the verb.
-- **descoped-#NNN** — explicitly removed from M1; follow-up issue carries the residual scope.
 
 | Verb (Appendix A) | Status | Landed / tracked |
 |---|---|---|
@@ -646,7 +645,6 @@ Legend:
 | `drive9 vault grant <scope>... --agent --perm --ttl` | not-yet | Appendix-A alignment PR track (server endpoint live in #273; CLI still on legacy `drive9 secret grant` with no `--perm`) |
 | `drive9 vault revoke <grant-id>` | not-yet | Appendix-A alignment PR track |
 | `drive9 vault with <path> -- <cmd>` | not-yet | Appendix-A alignment PR track |
-| `drive9 vault reauth <mountpoint>` | descoped-#302 | deferred post-M1 (§17) |
 | Data-plane `cat / ls / rm / printf >` on `/n/vault/**` | implemented | pre-M1 |
 
 Rows record the **final user-visible verb**. Interim steps (for example, fixing the legacy `drive9 secret grant` call path to hit `/v1/vault/grants` with `--perm` before the `vault` verb lands) do **not** flip `drive9 vault grant` to `implemented` — that row only flips when the `drive9 vault grant` CLI surface itself is live on `main`.

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -1,7 +1,7 @@
 # drive9 vault — End-State Interaction Spec
 
 Status: Proposed (four-way review: dev1 author, architect-1 / dev2 / adversary-2 review)
-Scope: End-state CLI only. No current-implementation references, no transition/migration, no P0 tactics.
+Scope: End-state CLI is the normative surface (§0–§22 + Appendices). No P0 tactics. The `## Implementation status` section is the single allowed exception to "end-state only": it exists purely so reviewers can audit whether every Appendix A verb is live on `main` and gate the `Proposed → Accepted` flip; the normative spec itself does not describe any transitional shape.
 
 This spec is the single source of truth for the terminal shape of vault UX. It is the merged canonical of:
 
@@ -628,7 +628,7 @@ Every verb that documents a pipe or composition pattern (`A | B`, `A | xargs B`)
 
 ## Implementation status
 
-The table below tracks whether each Appendix A verb is live on `main`. It is the single source of truth that reviewers use to decide when `Status: Proposed` may flip to `Accepted` (see header): the flip happens only once every row in the `drive9 vault` / `drive9 mount vault` block reads `implemented`. Rows for verbs already shipped by merged PRs are pinned here for auditability; subsequent PRs in the Appendix-A alignment track MUST update this table in the same commit that ships the verb.
+The table below tracks whether each Appendix A verb is live on `main`. It is the single source of truth that reviewers use to decide when `Status: Proposed` may flip to `Accepted` (see header): the flip happens only once every row in the `drive9 vault` / `drive9 mount vault` block reads either `implemented` or `descoped-#NNN` (i.e. no row is left `not-yet`). Rows for verbs already shipped by merged PRs are pinned here for auditability; subsequent PRs in the Appendix-A alignment track MUST update this table in the same commit that ships the verb.
 
 Legend:
 - **implemented** — landed on `main`; verb shape matches the spec row above.


### PR DESCRIPTION
## Scope

**Docs-only.** First of six waves aligning `docs/specs/vault-interaction-end-state.md` (the `#272` end-state) with `main`, per qiffang `2ab09345` (`Q1=A, Q2=(ii), Q3=接受, Q4=(III)`) and the reviewer floor converged in `628cc12e` (G1–G5) + `be0fb65b` (G6) + `5493c519`/`fad73b7c` (R1/R2).

Zero code changes. All edits are in `docs/specs/vault-interaction-end-state.md`.

## What this PR does

1. **§2 rewrite → `vault put` is single-mode wholesale replace.** Drop the `--prune` variant and the dual-mode atomic contract. Incremental edits are the data-plane (`printf >` / `rm`). This implements `Q4=(III)`: we do not introduce a server-side merge API in this track.
2. **Scrub residual `--prune` qualifiers** in Invariant #1 and §19's concurrency row; `put` is now always wholesale.
3. **Appendix A `put` row** updated to match the single-mode shape.
4. **New `## Implementation status` section** listing every Appendix-A verb with a status in `{implemented, not-yet, descoped-#NNN}`. Rows record the **final user-visible verb**; legacy-surface semantic fixes (e.g. V2a fixing `drive9 secret grant` to hit `/v1/vault/grants`) do **not** flip `drive9 vault grant` to `implemented`.
5. **`Status: Proposed` header is deliberately unchanged.** It flips to `Accepted` only in V4, after every alignment-track row reads `implemented`.

## 6-wave map this PR unblocks

| PR | Scope |
|----|-------|
| **V1 (this PR)** | Docs-only: §2 single-mode rewrite + Implementation status table. **No `Accepted` flip.** |
| V2a | `SecretGrant` switches to `/v1/vault/grants` with `--perm`; legacy verb name still `drive9 secret grant`. Closes the dual-principal P0 user-flow break. |
| V2b | New `cmd/drive9/cli/vault.go`; `cmd/drive9/main.go` dispatch adds `case "vault"`; `vault grant` / `vault revoke` land as first-class verbs. |
| V2c | `drive9 mount vault <path>` argv shape; bare `drive9 mount <path>` is rejected (Q2=(ii)). |
| V3 | `vault put <path> --from <dir>` (wholesale) + `vault with <path> -- <cmd>` (`@env` injection). |
| V4 | Delete `cmd/drive9/cli/secret.go` + tests + scripts + README mentions; flip header to `Status: Accepted`. |

## Reviewer floor response

### G1 — Appendix A verb shape alignment
Not exercised in V1 (docs-only). Status table pins **what must be aligned**; G1 is evaluated on V2b/V2c/V3.

### G2 — endpoint switch to `/v1/vault/grants` + `perm` claim
Not exercised in V1. Target PR is V2a.

### G3 — minimal-set scope creep
- `--prune` removed (not a scope-creep guard so much as the Q4=(III) contract narrowing).
- No speculative flags added anywhere.

### G4 — deprecation of `drive9 secret`
Already chosen by qiffang: **Plan A (delete in V4)**. V1 records this by leaving no mention of `drive9 secret` as a primary surface; the status table's `vault *` rows carry the lineage note where relevant.

### G5 — pipe design by payload class
Not exercised in V1 (no new verbs). The wholesale-only `put` keeps directory-of-files as the bulk-payload mode (`--from <dir>`); no `--stdin` added.

### G6 — server-side atomic batch TX for `put`
**Pre-verified** before this PR:
- `pkg/server/vault.go:184` — `handleVaultSecretUpdate` (`PUT /v1/vault/secrets/<name>`) is the wholesale-replace handler.
- `pkg/vault/store.go:176` — `UpdateSecret` runs a single TX: `SELECT … FOR UPDATE` → `DELETE FROM vault_secret_fields WHERE secret_id = ?` → `INSERT` loop. Wholesale-replace is atomic server-side.

V3 (the PR that ships the CLI) must restate this grep + additionally evidence the single-`audit_event` property (§10). V1 just records that the wire contract makes `Q4=(III)` trivially implementable CLI-side.

### S1 — orthogonality / Plan 9 minimalism
Enforced by `Q2=(ii)` (one mount-path shape) and the single-mode `put`. Recorded in §2 rewrite.

### S2 — minimal diff
Files touched: 1. Lines: +31 / −8. No cross-layer edits.

### Second-pass 1–5 (gate-blindness guard)
1. **No `Accepted` flip.** Verified by header still reading `Status: Proposed`.
2. **No silent alias.** No mention of `drive9 secret` as a valid entry anywhere in the spec.
3. **No implicit stdin/state mix-up.** V1 has no verb body changes.
4. **Status table records final user-visible verb.** Interim `secret grant` endpoint fix will not flip `drive9 vault grant`. (adv-1 `3568ecda` / `c0ac584e` accounting guard.)
5. **`vault put` is not missing from any PR.** Explicitly carried to V3 in the map above. (adv-1 `b70c48ef` catch.)

## Why no code changes

Qiffang `b44a4f21`: "代码最小集合实现". Splitting the spec narrowing (`Q4=(III)`) and the status-table gate into their own docs-only PR keeps each subsequent code PR's diff reviewable against a stable contract.

## Tests / CI

Docs-only; the CI docs-only path handles this. No new tests.

## Follow-ups this PR does **not** do

- All Appendix-A verbs carrying `not-yet` (V2a/V2b/V2c/V3).
- `Status: Accepted` flip (V4).
- `drive9 vault reauth` (descoped, #302).

cc @adversary-1 @adversary-2 — floor is G1–G6 + S1–S2 + second-pass 1–5; this PR exercises G3/G6/S1/S2 + the full second-pass sweep.

Refs #272.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated vault command specification**: Clarified that `drive9 vault put` performs atomic wholesale replacement of secrets, replacing the previous dual-mode behavior.
* **Removed `--prune` flag**: The put command now operates in a single mode without the optional flag.
* **Added implementation status section**: New tracking table shows the availability status of vault commands on main.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->