### PR TITLE
V2a: secret grant -> /v1/vault/grants with --perm; revoke dispatches by id prefix

### DIFF
--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -269,7 +269,6 @@ func SecretRm(args []string) error {
 func SecretGrant(args []string) error {
 	var (
 		agentID   string
-		taskID    string
 		ttlRaw    string
 		permRaw   string
 		asJSON    bool
@@ -285,12 +284,6 @@ func SecretGrant(args []string) error {
 			}
 			i++
 			agentID = args[i]
-		case "--task":
-			if i+1 >= len(args) {
-				return fmt.Errorf("--task requires a value")
-			}
-			i++
-			taskID = args[i]
 		case "--ttl":
 			if i+1 >= len(args) {
 				return fmt.Errorf("--ttl requires a value")
@@ -348,7 +341,10 @@ func SecretGrant(args []string) error {
 	if err != nil {
 		return err
 	}
-	_ = taskID // task_id is not part of the /v1/vault/grants contract; kept as a recognized flag for CLI continuity.
+	// `--task` was removed in V2a: task_id is not part of the /v1/vault/grants
+	// contract. Passing --task now fails loudly via the `unknown flag` branch
+	// above — we deliberately do NOT silently accept-and-drop it, because a
+	// successful return with dropped semantics is worse than a clean break.
 	resp, err := c.IssueVaultGrant(context.Background(), client.VaultGrantIssueRequest{
 		Agent:      agentID,
 		Scope:      scope,

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -255,12 +255,23 @@ func SecretRm(args []string) error {
 	return c.DeleteVaultSecret(context.Background(), name)
 }
 
-// SecretGrant issues a scoped capability token.
+// SecretGrant issues a scoped capability grant via /v1/vault/grants.
+//
+// --perm is required (one of read|write); we do not default because the spec
+// does not specify one and a silent default would bake an undocumented
+// contract into the CLI. Unknown values fail-closed before any request.
+//
+// Output:
+//   - human:  token=<token>\ngrant_id=<id>\nexpires_at=<rfc3339>
+//     (only the id label flips from token_id= to grant_id=; token= is unchanged)
+//   - --json: full VaultGrantIssueResponse (adds scope and perm to the key set)
+//   - --token-only: <token>\n  (byte-identical to the pre-V2a shape)
 func SecretGrant(args []string) error {
 	var (
 		agentID   string
 		taskID    string
 		ttlRaw    string
+		permRaw   string
 		asJSON    bool
 		tokenOnly bool
 		scope     []string
@@ -286,6 +297,12 @@ func SecretGrant(args []string) error {
 			}
 			i++
 			ttlRaw = args[i]
+		case "--perm":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--perm requires a value")
+			}
+			i++
+			permRaw = args[i]
 		case "--json":
 			asJSON = true
 		case "--token-only":
@@ -306,6 +323,12 @@ func SecretGrant(args []string) error {
 	if ttlRaw == "" {
 		return fmt.Errorf("--ttl is required")
 	}
+	if permRaw == "" {
+		return fmt.Errorf("--perm is required (read|write)")
+	}
+	if permRaw != "read" && permRaw != "write" {
+		return fmt.Errorf("invalid --perm %q: must be one of read, write", permRaw)
+	}
 	if len(scope) == 0 {
 		return fmt.Errorf("at least one scope entry is required")
 	}
@@ -325,7 +348,13 @@ func SecretGrant(args []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.IssueVaultToken(context.Background(), agentID, taskID, scope, ttl)
+	_ = taskID // task_id is not part of the /v1/vault/grants contract; kept as a recognized flag for CLI continuity.
+	resp, err := c.IssueVaultGrant(context.Background(), client.VaultGrantIssueRequest{
+		Agent:      agentID,
+		Scope:      scope,
+		Perm:       permRaw,
+		TTLSeconds: int(ttl / time.Second),
+	})
 	if err != nil {
 		return err
 	}
@@ -336,22 +365,31 @@ func SecretGrant(args []string) error {
 		return writeJSON(resp)
 	default:
 		_, _ = fmt.Fprintf(os.Stdout, "token=%s\n", resp.Token)
-		_, _ = fmt.Fprintf(os.Stdout, "token_id=%s\n", resp.TokenID)
+		_, _ = fmt.Fprintf(os.Stdout, "grant_id=%s\n", resp.GrantID)
 		_, _ = fmt.Fprintf(os.Stdout, "expires_at=%s\n", resp.ExpiresAt.Format(time.RFC3339))
 	}
 	return nil
 }
 
-// SecretRevoke revokes a capability token.
+// SecretRevoke revokes a capability token or grant. The id space is split:
+// ids with the `grt_` prefix are grants (issued via /v1/vault/grants in V2a)
+// and dispatch to RevokeVaultGrant; everything else is a legacy token id
+// (still accepted by the server under /v1/vault/tokens/<id>) and dispatches
+// to RevokeVaultToken. Both endpoints remain live until the legacy cleanup
+// wave.
 func SecretRevoke(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("usage drive9 secret revoke <token-id>")
+		return fmt.Errorf("usage drive9 secret revoke <id>")
 	}
+	id := args[0]
 	c, err := newVaultManagementClientFromEnv()
 	if err != nil {
 		return err
 	}
-	return c.RevokeVaultToken(context.Background(), args[0])
+	if strings.HasPrefix(id, "grt_") {
+		return c.RevokeVaultGrant(context.Background(), id, "cli", "")
+	}
+	return c.RevokeVaultToken(context.Background(), id)
 }
 
 // SecretAudit queries vault audit events and applies client-side filters.

--- a/cmd/drive9/cli/secret_commands_test.go
+++ b/cmd/drive9/cli/secret_commands_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -75,15 +76,15 @@ func TestSecretGetUsesCapabilityToken(t *testing.T) {
 	}
 }
 
-func TestSecretGrantPrintsTokenMetadata(t *testing.T) {
+func TestSecretGrantPrintsGrantMetadata(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/v1/vault/tokens" {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/vault/grants" {
 			http.NotFound(w, r)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"token":"vault_abc","token_id":"cap_123","expires_at":"2026-04-14T00:00:00Z"}`))
+		_, _ = w.Write([]byte(`{"token":"vt_abc","grant_id":"grt_123","expires_at":"2026-04-14T00:00:00Z","scope":["aws-prod","db-prod/password"],"perm":"read"}`))
 	}))
 	defer srv.Close()
 
@@ -92,12 +93,16 @@ func TestSecretGrantPrintsTokenMetadata(t *testing.T) {
 	t.Setenv("DRIVE9_API_KEY", "tenant-key")
 
 	out := captureStdout(t, func() {
-		if err := SecretGrant([]string{"aws-prod", "db-prod/password", "--agent", "deploy-agent", "--ttl", "1h"}); err != nil {
+		if err := SecretGrant([]string{"aws-prod", "db-prod/password", "--agent", "deploy-agent", "--ttl", "1h", "--perm", "read"}); err != nil {
 			t.Fatalf("SecretGrant: %v", err)
 		}
 	})
-	if !strings.Contains(out, "token=vault_abc") || !strings.Contains(out, "token_id=cap_123") {
+	if !strings.Contains(out, "token=vt_abc") || !strings.Contains(out, "grant_id=grt_123") {
 		t.Fatalf("output = %q", out)
+	}
+	// Pre-V2a label must be gone so automation can't false-positive on the old id field.
+	if strings.Contains(out, "token_id=") {
+		t.Fatalf("output still contains legacy token_id= label: %q", out)
 	}
 }
 
@@ -212,6 +217,267 @@ func TestSecretAuditFiltersClientSide(t *testing.T) {
 	if !strings.Contains(out, `"agent_id": "deploy-agent"`) || strings.Contains(out, `"agent_id": "test-agent"`) {
 		t.Fatalf("output = %q", out)
 	}
+}
+
+// G-V2a-5: --perm validation. `read` and `write` MUST succeed; anything else
+// (including empty / missing / "admin" / typos) MUST be rejected BEFORE any
+// HTTP call. Fail-closed is the point — there is no spec-supported default.
+func TestSecretGrantPermValidation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", "http://example.invalid")
+	t.Setenv("DRIVE9_API_KEY", "tenant-key")
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string // substring; empty means "must succeed"
+	}{
+		{
+			name:    "missing --perm",
+			args:    []string{"aws-prod", "--agent", "a", "--ttl", "1h"},
+			wantErr: "--perm is required",
+		},
+		{
+			name:    "unknown --perm value",
+			args:    []string{"aws-prod", "--agent", "a", "--ttl", "1h", "--perm", "admin"},
+			wantErr: `invalid --perm "admin"`,
+		},
+		{
+			name:    "empty --perm value",
+			args:    []string{"aws-prod", "--agent", "a", "--ttl", "1h", "--perm", ""},
+			wantErr: "--perm is required",
+		},
+		{
+			name:    "missing scope",
+			args:    []string{"--agent", "a", "--ttl", "1h", "--perm", "read"},
+			wantErr: "scope",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := SecretGrant(tc.args)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// G-V2a-5 (positive half): both valid --perm values MUST reach the server
+// with the request body echoing the flag verbatim. Server-side validation
+// of perm semantics is out of scope here; the contract is "pass through".
+func TestSecretGrantPermReadAndWriteReachServer(t *testing.T) {
+	for _, perm := range []string{"read", "write"} {
+		t.Run(perm, func(t *testing.T) {
+			var gotPerm string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/vault/grants" {
+					http.NotFound(w, r)
+					return
+				}
+				var req map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Fatalf("decode request: %v", err)
+				}
+				gotPerm, _ = req["perm"].(string)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"token":"vt_x","grant_id":"grt_x","expires_at":"2026-04-14T00:00:00Z","scope":["s"],"perm":"` + perm + `"}`))
+			}))
+			defer srv.Close()
+
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("DRIVE9_SERVER", srv.URL)
+			t.Setenv("DRIVE9_API_KEY", "tenant-key")
+
+			_ = captureStdout(t, func() {
+				if err := SecretGrant([]string{"aws-prod", "--agent", "a", "--ttl", "1h", "--perm", perm}); err != nil {
+					t.Fatalf("SecretGrant(%s): %v", perm, err)
+				}
+			})
+			if gotPerm != perm {
+				t.Fatalf("perm sent = %q, want %q", gotPerm, perm)
+			}
+		})
+	}
+}
+
+// G-V2a-5 (server 4xx): a 4xx from /v1/vault/grants MUST surface as an error
+// without synthesizing a fake grant_id locally — we never present server-side
+// rejections as success.
+func TestSecretGrantServer4xxSurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"scope out of owner's namespace"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv("DRIVE9_API_KEY", "tenant-key")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	err := SecretGrant([]string{"other-tenant/key", "--agent", "a", "--ttl", "1h", "--perm", "read"})
+	if err == nil {
+		t.Fatal("expected error from server 403, got nil")
+	}
+}
+
+// G-V2a-8: --json output MUST contain the new key set (token, grant_id,
+// expires_at, scope, perm) and MUST NOT contain the legacy token_id key.
+// This pins the machine-readable contract change so downstream tools break
+// loudly at parse time rather than silently.
+func TestSecretGrantJSONKeySet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/grants" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"vt_abc","grant_id":"grt_123","expires_at":"2026-04-14T00:00:00Z","scope":["aws-prod"],"perm":"read"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv("DRIVE9_API_KEY", "tenant-key")
+
+	out := captureStdout(t, func() {
+		if err := SecretGrant([]string{"aws-prod", "--agent", "a", "--ttl", "1h", "--perm", "read", "--json"}); err != nil {
+			t.Fatalf("SecretGrant: %v", err)
+		}
+	})
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("--json output not valid JSON: %v\n%s", err, out)
+	}
+	for _, key := range []string{"token", "grant_id", "expires_at", "scope", "perm"} {
+		if _, ok := parsed[key]; !ok {
+			t.Fatalf("--json output missing key %q: %s", key, out)
+		}
+	}
+	if _, ok := parsed["token_id"]; ok {
+		t.Fatalf("--json output still contains legacy token_id key: %s", out)
+	}
+}
+
+// --token-only stays byte-identical to the pre-V2a shape: the token string
+// followed by a single newline, nothing else. Automation pipelines that
+// already consume this form MUST NOT need to change.
+func TestSecretGrantTokenOnlyUnchanged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"vt_abc","grant_id":"grt_123","expires_at":"2026-04-14T00:00:00Z","scope":["s"],"perm":"read"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv("DRIVE9_API_KEY", "tenant-key")
+
+	out := captureStdout(t, func() {
+		if err := SecretGrant([]string{"aws-prod", "--agent", "a", "--ttl", "1h", "--perm", "read", "--token-only"}); err != nil {
+			t.Fatalf("SecretGrant: %v", err)
+		}
+	})
+	if out != "vt_abc\n" {
+		t.Fatalf("--token-only output = %q, want %q", out, "vt_abc\n")
+	}
+}
+
+// G-V2a-7 + G-V2a-9: SecretRevoke MUST dispatch by id prefix. grt_* ids
+// target DELETE /v1/vault/grants/<id> with {"revoked_by":"cli","reason":""}.
+// Non-grt_ ids (legacy token ids) target DELETE /v1/vault/tokens/<id> with
+// no body — this keeps pre-V2a tokens revocable through the cleanup wave.
+func TestSecretRevokeDispatchesByPrefix(t *testing.T) {
+	t.Run("grt_ prefix -> grants endpoint with revoke metadata", func(t *testing.T) {
+		var (
+			gotPath      string
+			gotMethod    string
+			gotRevokedBy string
+			gotReason    string
+			sawBody      bool
+		)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotMethod = r.Method
+			if r.Body != nil {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+					if v, ok := body["revoked_by"].(string); ok {
+						gotRevokedBy = v
+					}
+					if v, ok := body["reason"].(string); ok {
+						gotReason = v
+					}
+					sawBody = true
+				}
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("DRIVE9_SERVER", srv.URL)
+		t.Setenv("DRIVE9_API_KEY", "tenant-key")
+		resetCredentialCacheForTest()
+		t.Cleanup(resetCredentialCacheForTest)
+
+		if err := SecretRevoke([]string{"grt_abc123"}); err != nil {
+			t.Fatalf("SecretRevoke: %v", err)
+		}
+		if gotMethod != http.MethodDelete {
+			t.Fatalf("method = %q, want DELETE", gotMethod)
+		}
+		if gotPath != "/v1/vault/grants/grt_abc123" {
+			t.Fatalf("path = %q, want /v1/vault/grants/grt_abc123", gotPath)
+		}
+		if !sawBody {
+			t.Fatal("expected JSON body on DELETE /v1/vault/grants/<id>")
+		}
+		if gotRevokedBy != "cli" {
+			t.Fatalf("revoked_by = %q, want %q", gotRevokedBy, "cli")
+		}
+		if gotReason != "" {
+			t.Fatalf("reason = %q, want empty string", gotReason)
+		}
+	})
+
+	t.Run("legacy id -> tokens endpoint", func(t *testing.T) {
+		var (
+			gotPath   string
+			gotMethod string
+		)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotMethod = r.Method
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("DRIVE9_SERVER", srv.URL)
+		t.Setenv("DRIVE9_API_KEY", "tenant-key")
+		resetCredentialCacheForTest()
+		t.Cleanup(resetCredentialCacheForTest)
+
+		if err := SecretRevoke([]string{"cap_legacy_42"}); err != nil {
+			t.Fatalf("SecretRevoke: %v", err)
+		}
+		if gotMethod != http.MethodDelete {
+			t.Fatalf("method = %q, want DELETE", gotMethod)
+		}
+		if gotPath != "/v1/vault/tokens/cap_legacy_42" {
+			t.Fatalf("path = %q, want /v1/vault/tokens/cap_legacy_42", gotPath)
+		}
+	})
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/cmd/drive9/cli/secret_commands_test.go
+++ b/cmd/drive9/cli/secret_commands_test.go
@@ -266,6 +266,26 @@ func TestSecretGrantPermValidation(t *testing.T) {
 	}
 }
 
+// V2a removed `--task` from `secret grant` (task_id is not part of the
+// /v1/vault/grants contract). Accepting a removed flag silently would be a
+// hidden downgrade of semantics for callers still passing it; instead we
+// fail loudly via the `unknown flag` branch so automation breaks at the
+// earliest possible point rather than getting a successful return with
+// dropped inputs.
+func TestSecretGrantRejectsRemovedTaskFlag(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", "http://example.invalid")
+	t.Setenv("DRIVE9_API_KEY", "tenant-key")
+
+	err := SecretGrant([]string{"aws-prod", "--agent", "a", "--task", "t-42", "--ttl", "1h", "--perm", "read"})
+	if err == nil {
+		t.Fatal("expected error for removed --task flag, got nil")
+	}
+	if !strings.Contains(err.Error(), `unknown flag "--task"`) {
+		t.Fatalf("error = %q, want substring `unknown flag \"--task\"`", err)
+	}
+}
+
 // G-V2a-5 (positive half): both valid --perm values MUST reach the server
 // with the request body echoing the flag verbatim. Server-side validation
 // of perm semantics is out of scope here; the contract is "pass through".


### PR DESCRIPTION
## Summary

Implements wave V2a of the end-state alignment (#272 Appendix A). Moves `secret grant` to the new `/v1/vault/grants` endpoint and adds `grt_*` prefix-dispatch for `secret revoke` so the new grants become revocable the moment they exist. Verb stays `secret`; the `secret` → `vault` rename is deferred to V2b per the published wave plan.

## Changes

### `secret grant`
- POST **`/v1/vault/grants`** via new `IssueVaultGrant` helper (was `/v1/vault/tokens`)
- New **`--perm {read|write}`** flag — **required**, fail-closed on unknown values. No default (the spec doesn't specify one; a silent default would bake an undocumented contract into the CLI)
- Human output: `token=` unchanged, `token_id=` → **`grant_id=`**, `expires_at=` unchanged — only the id label flips
- `--json`: new key set `{token, grant_id, expires_at, scope, perm}`; legacy `token_id` key **removed**
- `--token-only`: **byte-identical** to pre-V2a (automation pipelines that consume this form don't need to change)

### `secret revoke`
- `grt_*` ids → `DELETE /v1/vault/grants/<id>` with `{"revoked_by":"cli","reason":""}` via new `RevokeVaultGrant` helper
- Non-`grt_*` ids → `DELETE /v1/vault/tokens/<id>` via `RevokeVaultToken` (legacy path kept live through the cleanup wave so pre-V2a tokens remain revocable)

### Scope

- No docs changes (V1 already merged spec text)
- No `vault` dispatch / verb registration (that's V2b)
- No `mount` changes (that's V2c)
- No new `put` / `with` / `delete` verbs (those are V3/V4)

## Reviewer gate compliance

| Gate | Check | Status |
|------|-------|--------|
| G-V2a-1 | Uses `IssueVaultGrant` (not `IssueVaultToken`) | ✅ `secret.go:352` |
| G-V2a-2 | `--perm` required, fail-closed | ✅ `secret.go:326-331` |
| G-V2a-3 | Human output relabels `token_id=` → `grant_id=` only | ✅ `secret.go:367-369` |
| G-V2a-4 | `--token-only` byte-identical | ✅ `secret.go:363` |
| G-V2a-5 | Tests for valid/invalid `--perm`, missing scope, server 4xx | ✅ `TestSecretGrantPermValidation`, `TestSecretGrantPermReadAndWriteReachServer`, `TestSecretGrantServer4xxSurfacesError` |
| G-V2a-6 | PR body documents `--json` key-set change | ✅ (this PR body) |
| G-V2a-7 | Revoke dispatches by prefix; both endpoints exercised | ✅ `TestSecretRevokeDispatchesByPrefix` (both subtests) |
| G-V2a-8 | `--json` key-set assertion pins new shape, rejects `token_id` | ✅ `TestSecretGrantJSONKeySet` |
| G-V2a-9 | Revoke metadata `revoked_by="cli"`, `reason=""` pinned | ✅ `TestSecretRevokeDispatchesByPrefix/grt_*` subtest |
| R-V2a-1 | Verb stays `secret`; no `vault` dispatch added | ✅ dispatch table unchanged |
| R-V2a-2 | No docs / mount / unrelated verb churn | ✅ diff is 2 files |
| R-V2a-3 | Legacy `IssueVaultToken` / `RevokeVaultToken` untouched | ✅ client helpers unchanged |
| R-V2a-5 | Error messages don't hard-wire `secret` or `vault` portability-blockers | ✅ only `usage drive9 secret ...` strings, which V2b rewrites anyway |

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/drive9/cli/...` — all passing
- [ ] CI full suite (Docker-backed `pkg/vault` / `pkg/client` integration tests only reachable in CI)

## Decision reference

- Design: X′+A — grant + revoke move together, `grt_*` immediately revocable
- Wave plan: V1 (docs, merged #303) → **V2a (this PR)** → V2b (verb rename) → V2c (mount on vault) → V3 (put+with) → V4 (delete+flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Secret grant commands now require the `--perm` flag to specify read or write permissions when issuing grants.

* **Changes**
  * Grant command output now displays `grant_id` instead of `token_id` in non-JSON modes.
  * Revoke command now intelligently routes operations based on identifier prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->