### PR TITLE
V2b: rename CLI verb `drive9 secret` -> `drive9 vault` (hard-cut)

### DIFF
--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -22,10 +22,10 @@ const (
 	maxClientAuditLimit = 1000
 )
 
-// Secret dispatches drive9 secret subcommands.
+// Secret dispatches drive9 vault subcommands.
 func Secret(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage drive9 secret <set|get|exec|ls|rm|grant|revoke|audit>")
+		return fmt.Errorf("usage drive9 vault <set|get|exec|ls|rm|grant|revoke|audit>")
 	}
 	switch args[0] {
 	case "set":
@@ -45,16 +45,16 @@ func Secret(args []string) error {
 	case "audit":
 		return SecretAudit(args[1:])
 	case "-h", "--help", "help":
-		return fmt.Errorf("usage drive9 secret <set|get|exec|ls|rm|grant|revoke|audit>")
+		return fmt.Errorf("usage drive9 vault <set|get|exec|ls|rm|grant|revoke|audit>")
 	default:
-		return fmt.Errorf("unknown secret command %q", args[0])
+		return fmt.Errorf("unknown vault command %q", args[0])
 	}
 }
 
 // SecretSet creates or updates a secret.
 func SecretSet(args []string) error {
 	if len(args) < 2 {
-		return fmt.Errorf("usage drive9 secret set <name> <field=value|field=@file|field=-> [more fields]")
+		return fmt.Errorf("usage drive9 vault set <name> <field=value|field=@file|field=-> [more fields]")
 	}
 	name := args[0]
 	if err := validateSecretName(name); err != nil {
@@ -84,7 +84,7 @@ func SecretSet(args []string) error {
 // SecretGet reads a whole secret or one field.
 func SecretGet(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage drive9 secret get <name[/field]> [--json|--env]")
+		return fmt.Errorf("usage drive9 vault get <name[/field]> [--json|--env]")
 	}
 	ref := args[0]
 	name, field, err := parseSecretRef(ref)
@@ -145,7 +145,7 @@ func SecretGet(args []string) error {
 // SecretExec injects a secret into a child process environment and executes it.
 func SecretExec(args []string) error {
 	if len(args) < 3 {
-		return fmt.Errorf("usage drive9 secret exec <name> -- <command...>")
+		return fmt.Errorf("usage drive9 vault exec <name> -- <command...>")
 	}
 	name := args[0]
 	if err := validateSecretName(name); err != nil {
@@ -159,7 +159,7 @@ func SecretExec(args []string) error {
 		}
 	}
 	if sep < 0 || sep == len(args)-1 {
-		return fmt.Errorf("usage drive9 secret exec <name> -- <command...>")
+		return fmt.Errorf("usage drive9 vault exec <name> -- <command...>")
 	}
 	cmdArgs := args[sep+1:]
 
@@ -194,7 +194,7 @@ func SecretLs(args []string) error {
 		case "--json":
 			asJSON = true
 		default:
-			return fmt.Errorf("usage drive9 secret ls [--json]")
+			return fmt.Errorf("usage drive9 vault ls [--json]")
 		}
 	}
 
@@ -242,7 +242,7 @@ func SecretLs(args []string) error {
 // SecretRm deletes a secret.
 func SecretRm(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("usage drive9 secret rm <name>")
+		return fmt.Errorf("usage drive9 vault rm <name>")
 	}
 	name := args[0]
 	if err := validateSecretName(name); err != nil {
@@ -375,7 +375,7 @@ func SecretGrant(args []string) error {
 // wave.
 func SecretRevoke(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("usage drive9 secret revoke <id>")
+		return fmt.Errorf("usage drive9 vault revoke <id>")
 	}
 	id := args[0]
 	c, err := newVaultManagementClientFromEnv()
@@ -511,7 +511,7 @@ func newVaultManagementClientFromEnv() (*client.Client, error) {
 func newVaultReadClientFromEnv() (*client.Client, error) {
 	r := ResolveCredentials()
 	if r.Kind != CredentialDelegated {
-		return nil, fmt.Errorf("missing capability token; set %s before using drive9 secret get/exec", EnvVaultToken)
+		return nil, fmt.Errorf("missing capability token; set %s before using drive9 vault get/exec", EnvVaultToken)
 	}
 	return client.New(r.Server, r.Token), nil
 }

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -9,7 +9,7 @@
 //	create  provision a new database
 //	ctx     switch or list contexts
 //	fs      filesystem operations (cp, cat, ls, stat, mv, rm, sh, grep, find)
-//	secret  secret manager operations (set, get, exec, ls, rm, grant, revoke, audit)
+//	vault   vault operations (set, get, exec, ls, rm, grant, revoke, audit)
 //	mount   mount drive9 as a local FUSE filesystem
 //	umount  unmount a drive9 FUSE mount
 package main
@@ -31,6 +31,12 @@ import (
 var cliLogger *zap.Logger
 var cpuProfileStop = func() {}
 var exitFunc = os.Exit
+
+// vaultHandler is the `drive9 vault` command entry point, indirected through
+// a var so dispatch tests can swap in a spy and assert "handler reached" vs
+// "handler not reached". Production callers see no change: the default value
+// is the real cli.Secret and nothing else reassigns it outside tests.
+var vaultHandler = cli.Secret
 
 func main() {
 	if logger.CLIEnabled() {
@@ -55,9 +61,15 @@ func main() {
 		usage()
 	}
 
-	cmd := os.Args[1]
-	args := os.Args[2:]
+	dispatch(os.Args[1], os.Args[2:])
+}
 
+// dispatch routes a parsed (verb, args) pair to the matching command handler.
+// Extracted from main() so the verb table is testable without spawning a
+// subprocess. The `secret` verb was removed in V2b (hard-cut); callers
+// that still type `drive9 secret ...` fall into the default branch and hit
+// the generic `unknown command` path — there is no alias, no legacy shim.
+func dispatch(cmd string, args []string) {
 	switch cmd {
 	case "--version", "-v", "version":
 		if cliLogger != nil {
@@ -92,20 +104,20 @@ func main() {
 			logger.Info(context.Background(), "cli_command", zap.String("command", "fs"), zap.String("subcommand", sub))
 		}
 		runFS(args)
-	case "secret":
+	case "vault":
 		if cliLogger != nil {
 			sub := ""
 			if len(args) > 0 {
 				sub = args[0]
 			}
-			logger.Info(context.Background(), "cli_command", zap.String("command", "secret"), zap.String("subcommand", sub))
+			logger.Info(context.Background(), "cli_command", zap.String("command", "vault"), zap.String("subcommand", sub))
 		}
-		if err := cli.Secret(args); err != nil {
+		if err := vaultHandler(args); err != nil {
 			sub := ""
 			if len(args) > 0 {
 				sub = " " + args[0]
 			}
-			fatal("secret"+sub, err)
+			fatal("vault"+sub, err)
 		}
 	case "mount":
 		if cliLogger != nil {
@@ -217,7 +229,7 @@ commands:
   ctx [name]       switch context (or show current)
   ctx list         list all contexts
   fs               filesystem operations
-  secret           secret manager operations
+  vault            vault operations
   mount <dir>      mount drive9 as a local FUSE filesystem
   umount <dir>     unmount a drive9 FUSE mount
 `)

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +38,160 @@ func TestStartCPUProfileFromEnv(t *testing.T) {
 	}
 	if info.Size() == 0 {
 		t.Fatalf("profile file is empty: %s", profilePath)
+	}
+}
+
+// V2b: `drive9 vault <sub>` MUST route to the vault handler with args forwarded
+// verbatim (no shell parsing, no arg mangling). This is the positive half of
+// the hard-cut contract: the new verb name is live.
+func TestDispatchVaultVerbReachesHandler(t *testing.T) {
+	origHandler := vaultHandler
+	origExit := exitFunc
+	t.Cleanup(func() {
+		vaultHandler = origHandler
+		exitFunc = origExit
+	})
+	exitFunc = func(int) {} // swallow any fatal/usage exit
+
+	var gotArgs []string
+	called := false
+	vaultHandler = func(args []string) error {
+		called = true
+		gotArgs = args
+		return nil
+	}
+
+	dispatch("vault", []string{"ls", "--json"})
+
+	if !called {
+		t.Fatal("vault handler was not invoked for `drive9 vault ...`")
+	}
+	want := []string{"ls", "--json"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q", i, gotArgs[i], want[i])
+		}
+	}
+}
+
+// V2b hard-cut (G-V2b-1 / G-V2b-3): `drive9 secret <sub>` MUST NOT reach the
+// vault handler and MUST NOT get a bespoke rename hint — it falls into the
+// generic `unknown command` path shared with any typo. This pins the "no
+// silent alias, no deferred-MUST deadline" policy: the old verb is simply
+// not a command anymore.
+func TestDispatchSecretVerbIsRejected(t *testing.T) {
+	origHandler := vaultHandler
+	origExit := exitFunc
+	origStderr := os.Stderr
+	origStop := cpuProfileStop
+	t.Cleanup(func() {
+		vaultHandler = origHandler
+		exitFunc = origExit
+		os.Stderr = origStderr
+		cpuProfileStop = origStop
+	})
+
+	cpuProfileStop = func() {}
+
+	handlerCalled := false
+	vaultHandler = func(args []string) error {
+		handlerCalled = true
+		return nil
+	}
+
+	var exitCodes []int
+	exitFunc = func(code int) { exitCodes = append(exitCodes, code) }
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	dispatch("secret", []string{"ls"})
+
+	_ = w.Close()
+	stderr := <-done
+
+	if handlerCalled {
+		t.Fatal("vault handler was invoked for `drive9 secret ...` — hard-cut violated (G-V2b-1)")
+	}
+	if !strings.Contains(stderr, `drive9: unknown command "secret"`) {
+		t.Fatalf("stderr = %q, want it to contain `drive9: unknown command \"secret\"`", stderr)
+	}
+	// No bespoke rename hint allowed (G-V2b-3): `secret` must look like any
+	// other typo, not like a grandfathered-in deprecated verb.
+	lowered := strings.ToLower(stderr)
+	for _, banned := range []string{"rename", "renamed", "alias", "legacy", "deprecated", "use `vault`", "use vault"} {
+		if strings.Contains(lowered, strings.ToLower(banned)) {
+			t.Fatalf("stderr contains bespoke rename hint %q — G-V2b-3 forbids alias-style fallback: %q", banned, stderr)
+		}
+	}
+	// usage() exits with code 2; default branch prints the unknown-command
+	// line and then calls usage(). The exact exit sequence is: one call from
+	// usage() itself. We assert exit code 2 appeared.
+	found2 := false
+	for _, c := range exitCodes {
+		if c == 2 {
+			found2 = true
+			break
+		}
+	}
+	if !found2 {
+		t.Fatalf("exit codes = %v, want exit(2) from usage() after unknown command", exitCodes)
+	}
+}
+
+// V2b hard-cut is a pure removal: the generic `unknown command` path MUST
+// treat `secret` and any other unknown string (like `xyz`) with the same
+// framing. If the two diverge, it means someone smuggled a rename-aware
+// branch back in.
+func TestDispatchSecretVerbSameAsOtherUnknown(t *testing.T) {
+	origExit := exitFunc
+	origStderr := os.Stderr
+	origStop := cpuProfileStop
+	t.Cleanup(func() {
+		exitFunc = origExit
+		os.Stderr = origStderr
+		cpuProfileStop = origStop
+	})
+	cpuProfileStop = func() {}
+	exitFunc = func(int) {}
+
+	capture := func(verb string) string {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("os.Pipe: %v", err)
+		}
+		os.Stderr = w
+		done := make(chan string, 1)
+		go func() {
+			var buf bytes.Buffer
+			_, _ = io.Copy(&buf, r)
+			done <- buf.String()
+		}()
+		dispatch(verb, nil)
+		_ = w.Close()
+		return <-done
+	}
+
+	secretOut := capture("secret")
+	xyzOut := capture("xyz-typo")
+
+	// Framing must be identical except for the quoted verb name itself. If
+	// `secret` had a bespoke branch, its output would have extra text.
+	normalized := strings.Replace(secretOut, `"secret"`, `"xyz-typo"`, 1)
+	if normalized != xyzOut {
+		t.Fatalf("`secret` path diverges from generic unknown-command path.\n  secret (normalized): %q\n  xyz-typo           : %q", normalized, xyzOut)
 	}
 }
 

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -642,8 +642,8 @@ Legend:
 | `drive9 ctx import --from-file` | implemented | #284 (PR-B) |
 | `drive9 ctx ls` / `use` / `rm` | implemented | #284 (PR-B) |
 | `drive9 vault put <path> --from <dir>` | not-yet | Appendix-A alignment PR track |
-| `drive9 vault grant <scope>... --agent --perm --ttl` | not-yet | Appendix-A alignment PR track (server endpoint live in #273; CLI still on legacy `drive9 secret grant` with no `--perm`) |
-| `drive9 vault revoke <grant-id>` | not-yet | Appendix-A alignment PR track |
+| `drive9 vault grant <scope>... --agent --perm --ttl` | implemented | Appendix-A alignment PR track |
+| `drive9 vault revoke <grant-id>` | implemented | Appendix-A alignment PR track |
 | `drive9 vault with <path> -- <cmd>` | not-yet | Appendix-A alignment PR track |
 | Data-plane `cat / ls / rm / printf >` on `/n/vault/**` | implemented | pre-M1 |
 


### PR DESCRIPTION
## Summary

V2b of the vault CLI wave plan. The user-facing verb for vault management moves from `drive9 secret` to `drive9 vault` so the CLI vocabulary matches the server-side `/v1/vault/*` namespace and the spec's "vault" wording.

Per qiffang's explicit UX decision (`#onepassword` msg `2aa5887f`): **hard-cut, no alias window.** `drive9 secret` is removed from the verb table entirely and falls into the generic `unknown command` default branch alongside any other typo — same shape, no bespoke rename hint.

## Why hard-cut over alias

- **Plan 9 / Unix minimalism**: two verbs for one operation is negative optionality.
- **Fail-loud > silent-drop**: same principle that removed `--task` in V2a. Any caller still typing `drive9 secret` breaks immediately at call time — same kind of "call-time visible" break, not silent downgrade.
- **No deferred-MUST**: an alias window is a deprecation deadline shaped exactly like the trap we keep closing. Cleaner to cut once.
- **Internal user base is small**: the break cost is bounded.

## Changes

### `cmd/drive9/main.go`
- Dispatch switch `case "secret"` -> `case "vault"`.
- Extract `dispatch()` function so the verb table is testable in `package main` without spawning a subprocess.
- Indirect `cli.Secret` through a `vaultHandler` var so dispatch tests can assert "handler reached" vs "not reached" directly.
- Update package doc comment and `usage()` help text.
- Logger `command` tag now `"vault"` (no alias → no need to distinguish surfaces).

### `cmd/drive9/cli/secret.go`
- 11 user-facing strings flipped from `drive9 secret ...` to `drive9 vault ...` (usage messages, error messages, doc comment).
- Go symbol names (`package cli`, `func Secret`) and filename (`secret.go`) intentionally left alone — those are internal and deferred to the V4 cleanup wave so V2b stays minimal.

### `cmd/drive9/main_test.go`
Three new dispatch tests pinning the hard-cut contract:
- `TestDispatchVaultVerbReachesHandler`: `drive9 vault <sub>` invokes the handler with args forwarded verbatim.
- `TestDispatchSecretVerbIsRejected`: `drive9 secret <sub>` does NOT invoke the handler, stderr contains `drive9: unknown command "secret"`, and stderr contains none of `rename|renamed|alias|legacy|deprecated|use vault` (G-V2b-3 — no bespoke hint).
- `TestDispatchSecretVerbSameAsOtherUnknown`: `secret` output is byte-identical to any other unknown verb (modulo the quoted verb name), proving there's no special case for the removed verb.

### `docs/specs/vault-interaction-end-state.md` (R-V2b-4)
Appendix-A rows flipped `not-yet` -> `implemented`:
- `drive9 vault grant <scope>... --agent --perm --ttl`
- `drive9 vault revoke <grant-id>`

The spec itself (L649-650) pre-committed this acceptance criterion to the wave that lands the `vault` verb surface. `put` and `with` stay `not-yet` — those are V3.

### Out of scope (explicitly)
- `pkg/client/*`, `pkg/server/*`, test logic in `cli/secret_commands_test.go` (R-V2b-1).
- File rename `secret.go` -> `vault.go` and func rename `Secret` -> `Vault` (R-V2b-2 — V4).
- Docs sweep of `pr-a-jwt-implementation.md` / `pr-e-removal-contract.md` / `vault-quickstart.md` (R-V2b-3 — PR-E wave; also: `vault-quickstart.md` has 0 `drive9 secret` hits already).

## Reviewer gate floor (pre-registered)

| Gate | Check |
|---|---|
| G-V2b-1 | vault verb reaches handler; secret verb does not → new dispatch tests |
| G-V2b-2 | `grep "drive9 secret"` in tree → only §20.547 / §20.650 legacy/interim language + test assertion strings |
| G-V2b-3 | secret verb uses generic unknown-command branch, no bespoke rename hint → `TestDispatchSecretVerbSameAsOtherUnknown` + banned-substring check |
| G-V2b-4 | logger `command` tag = `"vault"` (secret never logged post-V2b) |
| G-V2b-5 | package doc + top-level usage + help output free of `secret` verb |
| R-V2b-1/2/3 | scope boundaries (diff stays within 4 files) |
| R-V2b-4 | spec Appendix-A rows flipped in this same PR |

## Test

```
go test ./cmd/drive9/...
ok  github.com/mem9-ai/dat9/cmd/drive9     0.642s
ok  github.com/mem9-ai/dat9/cmd/drive9/cli
```

(vault pkg testcontainers tests unaffected — don't touch `pkg/vault/` or `pkg/server/`.)

cc @adversary-1 @adversary-2 for gate floor pass.