### PR TITLE
V2c: add drive9 vault with; hard-cut drive9 vault exec

### DIFF
--- a/cmd/drive9/cli/credentials.go
+++ b/cmd/drive9/cli/credentials.go
@@ -10,6 +10,16 @@ import (
 // Environment variable names recognised by the credential resolver. See spec
 // §14.1. The dual-principal separation is locked — there is no single combined
 // variable; DRIVE9_VAULT_TOKEN and DRIVE9_API_KEY remain distinct knobs.
+//
+// This exact set of three names is also the F14 scrub whitelist for
+// `drive9 vault with` (spec §9 L209): the child process MUST NOT inherit
+// any of these three from the parent, even when they are unset, absent, or
+// identical to the current mount's credential. Other DRIVE9_* vars
+// (profiling, log level, etc.) are outside the scrub — they do not grant
+// authority — and flow through untouched. `scrubDrive9CredEnv` in
+// secret.go imports these constants by name, so adding a new credential
+// env var here requires a matching update there (and a new V2c-style
+// review gate). The exactness of this list IS the contract.
 const (
 	EnvVaultToken = "DRIVE9_VAULT_TOKEN"
 	EnvAPIKey     = "DRIVE9_API_KEY"

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -185,17 +185,18 @@ func SecretWith(args []string) error {
 	if err != nil {
 		return err
 	}
-	sep := -1
-	for i := 1; i < len(args); i++ {
-		if args[i] == "--" {
-			sep = i
-			break
-		}
+	// Strict argv shape: exactly one path, then `--`, then the child
+	// command. Anything between the path and `--` is rejected rather
+	// than silently dropped — V2c pinned a single explicit argv shape
+	// for `vault with`, and accept-and-ignore here would undercut that
+	// contract (reviewer blocker flagged by adv-1 on PR #306).
+	if args[1] != "--" {
+		return fmt.Errorf("usage drive9 vault with /n/vault/<secret> -- <command...> (unexpected argument %q before `--`)", args[1])
 	}
-	if sep < 0 || sep == len(args)-1 {
+	cmdArgs := args[2:]
+	if len(cmdArgs) == 0 {
 		return fmt.Errorf("usage drive9 vault with /n/vault/<secret> -- <command...>")
 	}
-	cmdArgs := args[sep+1:]
 
 	c, err := newVaultReadClientFromEnv()
 	if err != nil {
@@ -655,7 +656,7 @@ func newVaultManagementClientFromEnv() (*client.Client, error) {
 func newVaultReadClientFromEnv() (*client.Client, error) {
 	r := ResolveCredentials()
 	if r.Kind != CredentialDelegated {
-		return nil, fmt.Errorf("missing capability token; set %s before using drive9 vault get/exec", EnvVaultToken)
+		return nil, fmt.Errorf("missing capability token; set %s before using drive9 vault get/with", EnvVaultToken)
 	}
 	return client.New(r.Server, r.Token), nil
 }

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -23,17 +23,23 @@ const (
 )
 
 // Secret dispatches drive9 vault subcommands.
+//
+// V2c hard-cut: `exec` is removed. Callers that still type `drive9 vault exec`
+// fall into the `unknown vault command` branch — no bespoke rename hint, no
+// alias — identical framing to any other typo. The replacement is
+// `drive9 vault with <path> -- <cmd>` (spec §9). See PR body for the
+// rationale on fail-loud > silent-drop.
 func Secret(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage drive9 vault <set|get|exec|ls|rm|grant|revoke|audit>")
+		return fmt.Errorf("usage drive9 vault <set|get|with|ls|rm|grant|revoke|audit>")
 	}
 	switch args[0] {
 	case "set":
 		return SecretSet(args[1:])
 	case "get":
 		return SecretGet(args[1:])
-	case "exec":
-		return SecretExec(args[1:])
+	case "with":
+		return SecretWith(args[1:])
 	case "ls":
 		return SecretLs(args[1:])
 	case "rm":
@@ -45,7 +51,7 @@ func Secret(args []string) error {
 	case "audit":
 		return SecretAudit(args[1:])
 	case "-h", "--help", "help":
-		return fmt.Errorf("usage drive9 vault <set|get|exec|ls|rm|grant|revoke|audit>")
+		return fmt.Errorf("usage drive9 vault <set|get|with|ls|rm|grant|revoke|audit>")
 	default:
 		return fmt.Errorf("unknown vault command %q", args[0])
 	}
@@ -142,13 +148,41 @@ func SecretGet(args []string) error {
 	return writeJSON(fields)
 }
 
-// SecretExec injects a secret into a child process environment and executes it.
-func SecretExec(args []string) error {
+// vaultPathPrefix is the only accepted CLI spelling for a vault secret path,
+// per spec §9 L204 (`drive9 vault with /n/vault/<secret> -- <cmd>`). Bare
+// secret names (`drive9 vault with aws-prod -- env`) are NOT accepted: that
+// would create a second path-shape contract outside the spec, and would
+// collide with the mount-path namespace (§7) when V2e ships. Rejecting
+// here — loudly, at the CLI boundary — keeps the namespace single-valued.
+const vaultPathPrefix = "/n/vault/"
+
+// SecretWith implements `drive9 vault with /n/vault/<secret> -- <cmd...>`
+// per spec §9. It reads the secret via the normal vault read path, parses
+// the `@env` byte contract (§4.1) strictly, scrubs DRIVE9_* credential env
+// vars (§9 L209 F14 scrub), then execs the child with the parsed key/value
+// pairs injected. The child's exit code is propagated verbatim.
+//
+// Semantics that deliberately DIFFER from the removed `SecretExec`:
+//   - Path shape: only `/n/vault/<secret>` is accepted; bare names rejected.
+//   - Env key charset: strict `^[A-Z_][A-Z0-9_]*$` (spec §4.1 L89). No
+//     coerce-normalize (no lowercase→upper, no `-`→`_`). An illegal key
+//     fails the whole command with an EACCES-shaped error — no partial
+//     injection (spec §4.1.3 L101).
+//   - Value charset: control bytes `\x00`–`\x1f` except `\t` are rejected
+//     identically (spec §4.1.3 L103).
+//   - Empty ≠ missing: a secret with 0 visible keys still forks the child
+//     with no injected env (§4.1.2 L96). A missing/invisible secret
+//     surfaces as an error before fork (ENOENT-shaped).
+//   - Credential scrub: DRIVE9_API_KEY, DRIVE9_VAULT_TOKEN, DRIVE9_SERVER
+//     are removed from the child's base env unconditionally (§9 L209).
+//     Only those three are scrubbed; unrelated DRIVE9_* (profiling, log
+//     level) pass through untouched.
+func SecretWith(args []string) error {
 	if len(args) < 3 {
-		return fmt.Errorf("usage drive9 vault exec <name> -- <command...>")
+		return fmt.Errorf("usage drive9 vault with /n/vault/<secret> -- <command...>")
 	}
-	name := args[0]
-	if err := validateSecretName(name); err != nil {
+	name, err := parseVaultPath(args[0])
+	if err != nil {
 		return err
 	}
 	sep := -1
@@ -159,7 +193,7 @@ func SecretExec(args []string) error {
 		}
 	}
 	if sep < 0 || sep == len(args)-1 {
-		return fmt.Errorf("usage drive9 vault exec <name> -- <command...>")
+		return fmt.Errorf("usage drive9 vault with /n/vault/<secret> -- <command...>")
 	}
 	cmdArgs := args[sep+1:]
 
@@ -171,17 +205,127 @@ func SecretExec(args []string) error {
 	if err != nil {
 		return err
 	}
+	envMap, err := validateVaultEnvFields(fields)
+	if err != nil {
+		return err
+	}
 
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	envMap, err := buildSecretEnvMap(fields)
-	if err != nil {
-		return err
-	}
-	cmd.Env = mergeEnv(os.Environ(), envMap)
+	cmd.Env = mergeEnv(scrubDrive9CredEnv(os.Environ()), envMap)
 	return cmd.Run()
+}
+
+// parseVaultPath enforces G-V2c-1: the only accepted CLI spelling is
+// `/n/vault/<secret>` with a non-empty, single-segment secret name. Bare
+// names, subpaths (`/n/vault/a/b`), empty names, and any other path prefix
+// are rejected. validateSecretName pins the `*` / empty rules so this
+// stays in sync with the read-path validation used by `vault get`.
+func parseVaultPath(raw string) (string, error) {
+	if !strings.HasPrefix(raw, vaultPathPrefix) {
+		return "", fmt.Errorf("vault path %q must start with %s (bare secret names are not accepted)", raw, vaultPathPrefix)
+	}
+	rest := raw[len(vaultPathPrefix):]
+	if rest == "" {
+		return "", fmt.Errorf("vault path %q is missing a secret name", raw)
+	}
+	if strings.Contains(rest, "/") {
+		return "", fmt.Errorf("vault path %q must name exactly one secret; subpath selection is not supported by `vault with`", raw)
+	}
+	if err := validateSecretName(rest); err != nil {
+		return "", err
+	}
+	return rest, nil
+}
+
+// validateVaultEnvFields is the CLI-side enforcement of the `@env` byte
+// contract (spec §4.1 + §4.1.3). It is intentionally separate from
+// buildSecretEnvMap: that function coerce-normalizes (lowercase→upper,
+// non-alnum→`_`) to fit the legacy `SecretExec` shape, which directly
+// contradicts §4.1.3 L101 ("does not coerce them"). `vault with` must
+// reject, not coerce.
+//
+// Returns an error on the FIRST illegal key or value. No partial map is
+// returned — §4.1.3 L101 forbids partial output, so partial injection is
+// equally forbidden.
+func validateVaultEnvFields(fields map[string]string) (map[string]string, error) {
+	env := make(map[string]string, len(fields))
+	for key, value := range fields {
+		if !isValidVaultEnvKey(key) {
+			return nil, fmt.Errorf("secret key %q violates @env charset [A-Z_][A-Z0-9_]*: refusing to inject (EACCES)", key)
+		}
+		if idx := indexOfForbiddenEnvByte(value); idx >= 0 {
+			return nil, fmt.Errorf("secret value for key %q contains forbidden control byte 0x%02x at offset %d: refusing to inject (EACCES)", key, value[idx], idx)
+		}
+		env[key] = value
+	}
+	return env, nil
+}
+
+// isValidVaultEnvKey implements the strict charset `^[A-Z_][A-Z0-9_]*$`
+// from spec §4.1 L89. No Unicode, no lowercase, no non-alnum punctuation.
+func isValidVaultEnvKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i := 0; i < len(key); i++ {
+		ch := key[i]
+		switch {
+		case ch >= 'A' && ch <= 'Z', ch == '_':
+			// allowed in any position
+		case ch >= '0' && ch <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// indexOfForbiddenEnvByte returns the index of the first control byte
+// outlawed by spec §4.1.3 L103 (`\x00`–`\x1f` except `\t`), or -1 if the
+// value is clean. Bytes ≥ 0x20 and DEL (0x7f) pass through — the contract
+// only singles out the C0 control range because `printf %q` is undefined
+// over it. Tab (`\t`, 0x09) is explicitly carved out.
+func indexOfForbiddenEnvByte(value string) int {
+	for i := 0; i < len(value); i++ {
+		b := value[i]
+		if b < 0x20 && b != '\t' {
+			return i
+		}
+	}
+	return -1
+}
+
+// scrubDrive9CredEnv implements the F14 scrub from spec §9 L209. Exactly
+// three variables are dropped from the child's base env:
+//
+//	DRIVE9_API_KEY, DRIVE9_VAULT_TOKEN, DRIVE9_SERVER
+//
+// Any other DRIVE9_* (e.g. DRIVE9_PROF_CPU_PROFILE, DRIVE9_CLI_LOG_*) is
+// preserved — profiling and logging controls are developer-side knobs that
+// do not grant authority and MUST flow through to children. The scrub is
+// unconditional: we drop the names whether or not they are present in
+// os.Environ(), so behavior does not depend on parent state (§9 L209).
+func scrubDrive9CredEnv(base []string) []string {
+	out := make([]string, 0, len(base))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			out = append(out, entry)
+			continue
+		}
+		switch key {
+		case EnvAPIKey, EnvVaultToken, EnvServer:
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 // SecretLs lists secret names. An explicit capability token always wins over

--- a/cmd/drive9/cli/secret_commands_test.go
+++ b/cmd/drive9/cli/secret_commands_test.go
@@ -165,14 +165,19 @@ func TestSecretLsPrefersExplicitCapabilityTokenOverAmbientAPIKey(t *testing.T) {
 	}
 }
 
-func TestSecretExecInjectsSecretIntoChildEnv(t *testing.T) {
+// G-V2c-1 (positive half): the spec-shaped path `/n/vault/<secret>` MUST
+// reach the server at `/v1/vault/read/<secret>` and the child MUST see the
+// injected env vars. The two keys are strict-charset legal and values are
+// plain printable, so the happy path exercises the "uncoerced pass-through"
+// side of SecretWith in isolation.
+func TestSecretWithInjectsSecretIntoChildEnv(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/vault/read/aws-prod" {
 			http.NotFound(w, r)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_key":"AKIA","secret_key":"SECRET"}`))
+		_, _ = w.Write([]byte(`{"ACCESS_KEY":"AKIA","SECRET_KEY":"SECRET"}`))
 	}))
 	defer srv.Close()
 
@@ -181,8 +186,8 @@ func TestSecretExecInjectsSecretIntoChildEnv(t *testing.T) {
 	t.Setenv(EnvVaultToken, "cap-token")
 
 	out := captureStdout(t, func() {
-		if err := SecretExec([]string{"aws-prod", "--", "/bin/sh", "-c", "printf '%s:%s' \"$ACCESS_KEY\" \"$SECRET_KEY\""}); err != nil {
-			t.Fatalf("SecretExec: %v", err)
+		if err := SecretWith([]string{"/n/vault/aws-prod", "--", "/bin/sh", "-c", "printf '%s:%s' \"$ACCESS_KEY\" \"$SECRET_KEY\""}); err != nil {
+			t.Fatalf("SecretWith: %v", err)
 		}
 	})
 	if out != "AKIA:SECRET" {

--- a/cmd/drive9/cli/secret_with_test.go
+++ b/cmd/drive9/cli/secret_with_test.go
@@ -1,0 +1,384 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// This file holds the V2c `drive9 vault with` gate-floor test matrix:
+//
+//	G-V2c-1   path shape: only `/n/vault/<secret>` accepted; bare/subpath rejected
+//	G-V2c-2   F14 scrub drops exactly {API_KEY, VAULT_TOKEN, SERVER}
+//	G-V2c-3   @env key charset is strict [A-Z_][A-Z0-9_]*
+//	G-V2c-4   @env value forbids control bytes 0x00-0x1f except \t
+//	G-V2c-5   empty secret (0 visible keys) → child still runs, 0 injected vars
+//	G-V2c-7   child exit/signal pass-through (covered indirectly via *exec.ExitError
+//	          surfacing to main.go fatal()'s exitCoder branch)
+//	G-V2c-8   any illegal key → whole EACCES, no partial inject
+//	G-V2c-9   legal+illegal mix → whole EACCES, no partial inject
+//
+// G-V2c-6 (`drive9 vault exec` falls to generic unknown-command) and
+// G-V2c-10 (SecretExec is undefined) live in TestSecretDispatchRemovesExec
+// and at compile time respectively — see notes on that test.
+
+// G-V2c-1: path shape enforcement. The CLI accepts EXACTLY `/n/vault/<secret>`.
+// Bare names, subpaths, and empty names are rejected loudly with a message
+// that names the required prefix (so operators migrating from `vault exec`
+// learn the new shape from the first failure, without us adding a bespoke
+// rename hint in the dispatch layer — the error is a path-validation
+// error, not an alias lookup failure).
+func TestSecretWithPathShapeEnforcement(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", "http://example.invalid")
+	t.Setenv(EnvVaultToken, "cap-token")
+
+	cases := []struct {
+		name    string
+		path    string
+		wantSub string
+	}{
+		{"bare name rejected", "aws-prod", "must start with /n/vault/"},
+		{"wrong prefix rejected", "/mnt/vault/aws-prod", "must start with /n/vault/"},
+		{"empty name rejected", "/n/vault/", "missing a secret name"},
+		{"subpath rejected", "/n/vault/aws-prod/access_key", "subpath selection is not supported"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCredentialCacheForTest()
+			t.Cleanup(resetCredentialCacheForTest)
+			err := SecretWith([]string{tc.path, "--", "/bin/true"})
+			if err == nil {
+				t.Fatalf("expected error for path %q, got nil", tc.path)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error = %q, want substring %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// G-V2c-2: the F14 scrub MUST drop exactly DRIVE9_API_KEY, DRIVE9_VAULT_TOKEN,
+// and DRIVE9_SERVER from the child's environment, and MUST preserve every
+// other variable — including unrelated DRIVE9_* knobs like profiling or log
+// level. This pins the scrub as a whitelist-of-removals, not a blanket
+// "strip all DRIVE9_*" which would break profiling and debug pipelines.
+//
+// Note on credential resolver behavior: ResolveCredentials consumes (reads
+// and os.Unsetenv's) DRIVE9_VAULT_TOKEN / DRIVE9_API_KEY / DRIVE9_SERVER on
+// first call. So by the time the child forks, those three are already
+// gone from os.Environ() regardless of the scrub. The scrub's job is to
+// hold the line if that resolver behavior ever changes, or if a future
+// call path skips it — hence we assert the scrub on os.Environ() directly,
+// separately from the end-to-end SecretWith test.
+func TestScrubDrive9CredEnv(t *testing.T) {
+	base := []string{
+		"PATH=/usr/bin",
+		"DRIVE9_API_KEY=owner-key",
+		"DRIVE9_VAULT_TOKEN=cap-token",
+		"DRIVE9_SERVER=https://api.example",
+		"DRIVE9_PROF_CPU_PROFILE=/tmp/cpu.pprof", // preserved (profiling knob)
+		"DRIVE9_CLI_LOG_LEVEL=debug",             // preserved (log knob)
+		"HOME=/home/drive9",
+	}
+	got := scrubDrive9CredEnv(base)
+
+	mustHave := []string{
+		"PATH=/usr/bin",
+		"DRIVE9_PROF_CPU_PROFILE=/tmp/cpu.pprof",
+		"DRIVE9_CLI_LOG_LEVEL=debug",
+		"HOME=/home/drive9",
+	}
+	mustNotHave := []string{
+		"DRIVE9_API_KEY=owner-key",
+		"DRIVE9_VAULT_TOKEN=cap-token",
+		"DRIVE9_SERVER=https://api.example",
+	}
+	for _, want := range mustHave {
+		if !containsEntry(got, want) {
+			t.Fatalf("scrubbed env missing %q: %v", want, got)
+		}
+	}
+	for _, banned := range mustNotHave {
+		if containsEntry(got, banned) {
+			t.Fatalf("scrubbed env still contains %q: %v", banned, got)
+		}
+	}
+
+	// Scrub is also unconditional: if the three vars are absent, the
+	// scrub MUST still not blow up and MUST still preserve everything
+	// else. This covers the §9 L209 "even when ... unset, absent" clause.
+	baseNoCreds := []string{"PATH=/usr/bin", "HOME=/home/drive9"}
+	gotNoCreds := scrubDrive9CredEnv(baseNoCreds)
+	if len(gotNoCreds) != len(baseNoCreds) {
+		t.Fatalf("scrub changed env when no credentials were present: got %v, want %v", gotNoCreds, baseNoCreds)
+	}
+}
+
+func containsEntry(env []string, want string) bool {
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}
+
+// G-V2c-3: the @env key charset is the strict spec charset. The parser
+// REJECTS lowercase, hyphens, digit-prefix keys, and Unicode. It does NOT
+// normalize — that is the whole point of separating this from the legacy
+// buildSecretEnvMap path. (R-V2c-3 enforces the isolation.)
+func TestIsValidVaultEnvKey(t *testing.T) {
+	cases := []struct {
+		key  string
+		want bool
+	}{
+		{"ACCESS_KEY", true},
+		{"_LEADING_UNDERSCORE", true},
+		{"WITH9DIGIT", true},
+		{"A", true},
+		{"_", true},
+
+		{"", false},               // empty
+		{"access_key", false},     // lowercase
+		{"AccessKey", false},      // mixed case
+		{"ACCESS-KEY", false},     // hyphen
+		{"9DIGIT_FIRST", false},   // leading digit
+		{"ACCESS.KEY", false},     // dot
+		{"ACCESS KEY", false},     // space
+		{"ACCESS_KEY\x00", false}, // embedded NUL
+		{"ÄCCESS", false},         // non-ASCII
+	}
+	for _, tc := range cases {
+		if got := isValidVaultEnvKey(tc.key); got != tc.want {
+			t.Fatalf("isValidVaultEnvKey(%q) = %v, want %v", tc.key, got, tc.want)
+		}
+	}
+}
+
+// G-V2c-4: value-side control byte enforcement. 0x00-0x1f is banned EXCEPT
+// 0x09 (tab). 0x20 (space) and above pass. DEL (0x7f) passes — the spec
+// only outlaws the C0 control range.
+func TestIndexOfForbiddenEnvByte(t *testing.T) {
+	cases := []struct {
+		name string
+		v    string
+		want int
+	}{
+		{"plain ascii", "hello world", -1},
+		{"tab allowed", "col1\tcol2", -1},
+		{"high bit allowed", "café", -1},
+		{"del allowed", "x\x7fy", -1},
+		{"space allowed", " leading", -1},
+
+		{"embedded NUL", "bad\x00value", 3},
+		{"embedded LF", "multi\nline", 5},
+		{"embedded CR", "cr\rhere", 2},
+		{"leading control", "\x01rest", 0},
+		{"bell", "ring\x07bell", 4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := indexOfForbiddenEnvByte(tc.v); got != tc.want {
+				t.Fatalf("indexOfForbiddenEnvByte(%q) = %d, want %d", tc.v, got, tc.want)
+			}
+		})
+	}
+}
+
+// G-V2c-5: empty ≠ missing. A secret that exists but has zero visible keys
+// MUST fork the child with zero injected vars (spec §4.1.2 L96). The read
+// path returns 200 with `{}`. The child should run normally and see no
+// DRIVE9_* credential from the parent (F14 scrub).
+func TestSecretWithEmptySecretStillForksChild(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/read/empty-prod" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv(EnvVaultToken, "cap-token")
+
+	out := captureStdout(t, func() {
+		// The child writes `ran-with-no-injection` to stdout unconditionally.
+		// If the CLI had refused to fork on empty, SecretWith would return
+		// an error and stdout would stay empty.
+		if err := SecretWith([]string{"/n/vault/empty-prod", "--", "/bin/sh", "-c", "printf ran-with-no-injection"}); err != nil {
+			t.Fatalf("SecretWith(empty): %v", err)
+		}
+	})
+	if out != "ran-with-no-injection" {
+		t.Fatalf("child output = %q, want %q", out, "ran-with-no-injection")
+	}
+}
+
+// G-V2c-7: when the child exits non-zero, SecretWith returns an error that
+// carries the child's exit code via the exitCoder interface that main.go's
+// fatal() already understands (see cmd/drive9/main.go exitCoder branch).
+// We assert the error is an *exec.ExitError and that ExitCode() matches.
+func TestSecretWithPropagatesChildExitCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv(EnvVaultToken, "cap-token")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	err := SecretWith([]string{"/n/vault/anything", "--", "/bin/sh", "-c", "exit 42"})
+	if err == nil {
+		t.Fatal("expected error from child exit 42, got nil")
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("error type = %T, want *exec.ExitError", err)
+	}
+	if code := exitErr.ExitCode(); code != 42 {
+		t.Fatalf("child exit code = %d, want 42", code)
+	}
+}
+
+// G-V2c-8: a single illegal key fails the WHOLE command with an EACCES
+// message. The error mentions the offending key so operators can fix the
+// secret. No partial injection — validateVaultEnvFields never returns a
+// mixed map. We assert via SecretWith end-to-end: if the child had been
+// forked, the command would have succeeded (/bin/true returns 0).
+func TestSecretWithIllegalKeyFailsWhole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/read/bad-keys" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access-key":"AKIA"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv(EnvVaultToken, "cap-token")
+
+	err := SecretWith([]string{"/n/vault/bad-keys", "--", "/bin/true"})
+	if err == nil {
+		t.Fatal("expected EACCES-shaped error for illegal key, got nil")
+	}
+	if !strings.Contains(err.Error(), `"access-key"`) {
+		t.Fatalf("error should name offending key: %q", err)
+	}
+	if !strings.Contains(err.Error(), "EACCES") {
+		t.Fatalf("error should mention EACCES: %q", err)
+	}
+}
+
+// G-V2c-9: a mix of legal and illegal keys fails the WHOLE command — the
+// legal key MUST NOT leak into the child. We verify this by running the
+// child as a script that would print the legal key's value if injected;
+// any non-empty stdout would mean partial injection happened.
+func TestSecretWithLegalPlusIllegalFailsWhole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/read/mixed" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// ACCESS_KEY is legal; illegal-key has a hyphen.
+		_, _ = w.Write([]byte(`{"ACCESS_KEY":"AKIA","illegal-key":"x"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv(EnvVaultToken, "cap-token")
+
+	out := captureStdout(t, func() {
+		err := SecretWith([]string{"/n/vault/mixed", "--", "/bin/sh", "-c", `printf 'LEAK:%s' "$ACCESS_KEY"`})
+		if err == nil {
+			t.Fatal("expected error for legal+illegal mix, got nil")
+		}
+	})
+	if out != "" {
+		t.Fatalf("partial injection detected: child stdout = %q; expected no child to have run", out)
+	}
+}
+
+// G-V2c-4 end-to-end: a control byte in a value rejects the whole command
+// with the same EACCES framing. This is the value-side twin of the
+// illegal-key test and keeps the two branches of §4.1.3 (L101 key rule +
+// L103 value rule) covered from user-visible behavior, not just from unit
+// tests on the helpers.
+func TestSecretWithControlByteValueFailsWhole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/read/has-nl" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Value contains a literal LF (0x0a). JSON-escaped as `\n`.
+		_, _ = w.Write([]byte(`{"MULTILINE":"line1\nline2"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv(EnvVaultToken, "cap-token")
+
+	err := SecretWith([]string{"/n/vault/has-nl", "--", "/bin/true"})
+	if err == nil {
+		t.Fatal("expected EACCES-shaped error for control byte in value, got nil")
+	}
+	if !strings.Contains(err.Error(), "MULTILINE") {
+		t.Fatalf("error should name offending key: %q", err)
+	}
+	if !strings.Contains(err.Error(), "EACCES") {
+		t.Fatalf("error should mention EACCES: %q", err)
+	}
+}
+
+// G-V2c-6: `drive9 vault exec` MUST fall into the `unknown vault command`
+// branch with no bespoke rename hint. Framing must be identical to any
+// other typo. This pins the hard-cut policy: the old verb is simply not
+// part of the vault sub-dispatcher anymore.
+func TestSecretDispatchRemovesExec(t *testing.T) {
+	execErr := Secret([]string{"exec", "aws-prod", "--", "/bin/true"})
+	if execErr == nil {
+		t.Fatal("expected error for `vault exec` after V2c hard-cut, got nil")
+	}
+	if !strings.Contains(execErr.Error(), `unknown vault command "exec"`) {
+		t.Fatalf("expected generic unknown-command framing, got: %q", execErr)
+	}
+
+	// And the framing must be identical to any other typo — no bespoke
+	// rename hint for `exec`. If someone smuggled a "use `with` instead"
+	// hint back in, the two errors would diverge.
+	typoErr := Secret([]string{"xyz-typo"})
+	normalized := strings.Replace(execErr.Error(), `"exec"`, `"xyz-typo"`, 1)
+	if normalized != typoErr.Error() {
+		t.Fatalf("`exec` path diverges from generic unknown-vault-command path.\n  exec (normalized): %q\n  xyz-typo         : %q", normalized, typoErr)
+	}
+
+	// Same policy for banned substrings: no alias, no rename, no "use `with`".
+	lowered := strings.ToLower(execErr.Error())
+	for _, banned := range []string{"rename", "renamed", "alias", "legacy", "deprecated", "use `with`", "use with", "replaced"} {
+		if strings.Contains(lowered, banned) {
+			t.Fatalf("`vault exec` error contains bespoke hint %q: %q", banned, execErr)
+		}
+	}
+}
+
+// G-V2c-10 is a compile-time contract: the symbol `SecretExec` MUST NOT
+// exist in package cli. The compiler is the assertion. If SecretExec came
+// back, `vault exec` would start routing again and G-V2c-6 would start
+// failing — but that's downstream. The durable artifact for this gate is
+// the git diff on this PR, which deletes the function outright.

--- a/cmd/drive9/cli/secret_with_test.go
+++ b/cmd/drive9/cli/secret_with_test.go
@@ -60,6 +60,29 @@ func TestSecretWithPathShapeEnforcement(t *testing.T) {
 	}
 }
 
+// G-V2c-1 (argv shape): the single-path-then-`--` argv contract is pinned.
+// V2c picked a single explicit CLI shape; accept-and-ignore of extra args
+// between the path and `--` would be a silent second contract. Fail-fast
+// with a message that names the offending argument.
+func TestSecretWithRejectsGarbageBeforeSeparator(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", "http://example.invalid")
+	t.Setenv(EnvVaultToken, "cap-token")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	err := SecretWith([]string{"/n/vault/aws-prod", "garbage", "--", "/bin/true"})
+	if err == nil {
+		t.Fatal("expected error for stray argument before `--`, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected argument") {
+		t.Fatalf("error should flag unexpected argument: %q", err)
+	}
+	if !strings.Contains(err.Error(), `"garbage"`) {
+		t.Fatalf("error should name offending argument: %q", err)
+	}
+}
+
 // G-V2c-2: the F14 scrub MUST drop exactly DRIVE9_API_KEY, DRIVE9_VAULT_TOKEN,
 // and DRIVE9_SERVER from the child's environment, and MUST preserve every
 // other variable — including unrelated DRIVE9_* knobs like profiling or log
@@ -206,6 +229,8 @@ func TestSecretWithEmptySecretStillForksChild(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DRIVE9_SERVER", srv.URL)
 	t.Setenv(EnvVaultToken, "cap-token")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
 
 	out := captureStdout(t, func() {
 		// The child writes `ran-with-no-injection` to stdout unconditionally.
@@ -235,6 +260,8 @@ func TestSecretWithMissingSecretNoFork(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DRIVE9_SERVER", srv.URL)
 	t.Setenv(EnvVaultToken, "cap-token")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
 
 	out := captureStdout(t, func() {
 		// Child would print something on stdout if it ever ran.
@@ -298,6 +325,8 @@ func TestSecretWithIllegalKeyFailsWhole(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DRIVE9_SERVER", srv.URL)
 	t.Setenv(EnvVaultToken, "cap-token")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
 
 	var gotErr error
 	out := captureStdout(t, func() {
@@ -337,6 +366,8 @@ func TestSecretWithLegalPlusIllegalFailsWhole(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DRIVE9_SERVER", srv.URL)
 	t.Setenv(EnvVaultToken, "cap-token")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
 
 	out := captureStdout(t, func() {
 		err := SecretWith([]string{"/n/vault/mixed", "--", "/bin/sh", "-c", `printf 'LEAK:%s' "$ACCESS_KEY"`})
@@ -369,6 +400,8 @@ func TestSecretWithControlByteValueFailsWhole(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DRIVE9_SERVER", srv.URL)
 	t.Setenv(EnvVaultToken, "cap-token")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
 
 	err := SecretWith([]string{"/n/vault/has-nl", "--", "/bin/true"})
 	if err == nil {

--- a/cmd/drive9/cli/secret_with_test.go
+++ b/cmd/drive9/cli/secret_with_test.go
@@ -220,6 +220,34 @@ func TestSecretWithEmptySecretStillForksChild(t *testing.T) {
 	}
 }
 
+// G-V2c-5 (missing half): a secret that doesn't exist (server 404) MUST
+// surface an error BEFORE the child is forked. This is the symmetric twin
+// of the empty-secret test — both halves of "empty ≠ missing" are pinned
+// by user-visible behavior. captureStdout asserting an empty stdout is
+// the same "no-fork witness" shape used by G-V2c-9 so the two gates share
+// the same test form.
+func TestSecretWithMissingSecretNoFork(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DRIVE9_SERVER", srv.URL)
+	t.Setenv(EnvVaultToken, "cap-token")
+
+	out := captureStdout(t, func() {
+		// Child would print something on stdout if it ever ran.
+		err := SecretWith([]string{"/n/vault/does-not-exist", "--", "/bin/sh", "-c", "printf CHILD-RAN"})
+		if err == nil {
+			t.Fatal("expected error for missing secret, got nil")
+		}
+	})
+	if out != "" {
+		t.Fatalf("child forked despite missing secret: stdout = %q", out)
+	}
+}
+
 // G-V2c-7: when the child exits non-zero, SecretWith returns an error that
 // carries the child's exit code via the exitCoder interface that main.go's
 // fatal() already understands (see cmd/drive9/main.go exitCoder branch).
@@ -253,8 +281,9 @@ func TestSecretWithPropagatesChildExitCode(t *testing.T) {
 // G-V2c-8: a single illegal key fails the WHOLE command with an EACCES
 // message. The error mentions the offending key so operators can fix the
 // secret. No partial injection — validateVaultEnvFields never returns a
-// mixed map. We assert via SecretWith end-to-end: if the child had been
-// forked, the command would have succeeded (/bin/true returns 0).
+// mixed map. We assert via SecretWith end-to-end and use the same
+// no-fork witness shape (captureStdout == "") as G-V2c-9 so the two
+// symmetric gates have symmetric tests.
 func TestSecretWithIllegalKeyFailsWhole(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/vault/read/bad-keys" {
@@ -270,15 +299,22 @@ func TestSecretWithIllegalKeyFailsWhole(t *testing.T) {
 	t.Setenv("DRIVE9_SERVER", srv.URL)
 	t.Setenv(EnvVaultToken, "cap-token")
 
-	err := SecretWith([]string{"/n/vault/bad-keys", "--", "/bin/true"})
-	if err == nil {
+	var gotErr error
+	out := captureStdout(t, func() {
+		// Child would print something on stdout if it ever ran.
+		gotErr = SecretWith([]string{"/n/vault/bad-keys", "--", "/bin/sh", "-c", "printf CHILD-RAN"})
+	})
+	if gotErr == nil {
 		t.Fatal("expected EACCES-shaped error for illegal key, got nil")
 	}
-	if !strings.Contains(err.Error(), `"access-key"`) {
-		t.Fatalf("error should name offending key: %q", err)
+	if !strings.Contains(gotErr.Error(), `"access-key"`) {
+		t.Fatalf("error should name offending key: %q", gotErr)
 	}
-	if !strings.Contains(err.Error(), "EACCES") {
-		t.Fatalf("error should mention EACCES: %q", err)
+	if !strings.Contains(gotErr.Error(), "EACCES") {
+		t.Fatalf("error should mention EACCES: %q", gotErr)
+	}
+	if out != "" {
+		t.Fatalf("child forked despite illegal key: stdout = %q", out)
 	}
 }
 

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -9,7 +9,7 @@
 //	create  provision a new database
 //	ctx     switch or list contexts
 //	fs      filesystem operations (cp, cat, ls, stat, mv, rm, sh, grep, find)
-//	vault   vault operations (set, get, exec, ls, rm, grant, revoke, audit)
+//	vault   vault operations (set, get, with, ls, rm, grant, revoke, audit)
 //	mount   mount drive9 as a local FUSE filesystem
 //	umount  unmount a drive9 FUSE mount
 package main

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -644,7 +644,7 @@ Legend:
 | `drive9 vault put <path> --from <dir>` | not-yet | Appendix-A alignment PR track |
 | `drive9 vault grant <scope>... --agent --perm --ttl` | implemented | Appendix-A alignment PR track |
 | `drive9 vault revoke <grant-id>` | implemented | Appendix-A alignment PR track |
-| `drive9 vault with <path> -- <cmd>` | not-yet | Appendix-A alignment PR track |
+| `drive9 vault with <path> -- <cmd>` | implemented | Appendix-A alignment PR track |
 | Data-plane `cat / ls / rm / printf >` on `/n/vault/**` | implemented | pre-M1 |
 
 Rows record the **final user-visible verb**. Interim steps (for example, fixing the legacy `drive9 secret grant` call path to hit `/v1/vault/grants` with `--perm` before the `vault` verb lands) do **not** flip `drive9 vault grant` to `implemented` — that row only flips when the `drive9 vault grant` CLI surface itself is live on `main`.


### PR DESCRIPTION
## Summary

Hard-cut rename per spec §9 + §4.1:

- **Removed**: `drive9 vault exec <name> -- <cmd>` (V2c hard-cut)
- **Added**: `drive9 vault with /n/vault/<secret> -- <cmd>`

Migration: `drive9 vault exec aws-prod --` → `drive9 vault with /n/vault/aws-prod --`. No alias, no rename hint. Fail-loud > silent-drop (same policy as V2a `--task` and V2b `secret` → `vault`).

## Gate floor (10 gates + 5 review rules, pre-PR-aligned with adv-1/adv-2)

| Gate | Contract |
|---|---|
| G-V2c-1 | Path shape: only `/n/vault/<secret>` accepted; bare name, subpath, wrong prefix, empty name rejected at CLI boundary |
| G-V2c-2 | F14 scrub drops EXACTLY `{DRIVE9_API_KEY, DRIVE9_VAULT_TOKEN, DRIVE9_SERVER}`; unrelated `DRIVE9_*` (profiling, log level) preserved; scrub unconditional |
| G-V2c-3 | `@env` key charset `^[A-Z_][A-Z0-9_]*$` strictly enforced — no coerce-normalize |
| G-V2c-4 | `@env` value forbids `\x00`-`\x1f` except `\t` (spec §4.1.3 L103) |
| G-V2c-5 | Empty secret (0 visible keys) forks child with 0 injected vars; missing secret surfaces error before fork |
| G-V2c-6 | `drive9 vault exec ...` falls into generic `unknown vault command` branch — identical framing to any typo |
| G-V2c-7 | Child exit code propagates via `*exec.ExitError.ExitCode()` (already consumed by `main.go` `fatal()`'s `exitCoder` branch) |
| G-V2c-8 | Any single illegal key → whole EACCES, no partial inject |
| G-V2c-9 | Legal+illegal mix → whole EACCES, child never forks |
| G-V2c-10 | Symbol `SecretExec` deleted (compile-time) |

| Rule | Contract |
|---|---|
| R-V2c-1 | Appendix A L647 `vault with` row: `not-yet` → `implemented` |
| R-V2c-2 | No bridge/alias/legacy-hint between exec and with |
| R-V2c-3 | `SecretWith` isolated from `buildSecretEnvMap` / `normalizeSecretEnvKey` (those legacy coerce paths stay in place for `SecretGet --env`, which is pre-V2c behavior and out of scope) |
| R-V2c-4 | Error messages minimal: name offending key/path, no hints |
| R-V2c-5 | `credentials.go` const block annotated as the F14 scrub whitelist authority |

## Why path shape is `/n/vault/<secret>` and not bare name

Policy 1 resolved with qiffang in `#onepassword` `81aa2b0c`: **B** — accept only `/n/vault/<secret>`. Rationale:

1. Spec §9 L204 example uses this form verbatim.
2. Same path namespace as the future mount (§7 `drive9 mount vault /n/vault`), so `vault with /n/vault/prod-db` and `cat /n/vault/prod-db/@env` refer to the same thing. Accepting bare names would introduce a second spelling that has no analog under mount.
3. Single spelling = single G-V2c-1 assertion; bare-name tolerance would split the test matrix.

## Test plan

- [ ] CI `go build ./...` green
- [ ] CI `go vet ./...` green
- [ ] CI `go test ./cmd/drive9/cli/... -run 'TestSecretWith|TestSecretDispatchRemovesExec|TestScrubDrive9CredEnv|TestIsValidVaultEnvKey|TestIndexOfForbiddenEnvByte'` green
- [ ] All pre-existing `cmd/drive9/cli` tests still green (legacy `SecretGet --env` coerce path untouched per R-V2c-3)
- [ ] `cmd/drive9` dispatch tests (`TestDispatchVaultVerbReachesHandler`, `TestDispatchSecretVerbSameAsOtherUnknown`) unchanged and still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched `drive9 vault with` subcommand to replace the deprecated `exec` command. The new command enforces strict path formatting and improved environment variable handling for secure credential injection into child processes.

* **Documentation**
  * Updated vault interaction spec to reflect the availability of the `with` subcommand on main.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->