### PR TITLE
v2e: read-only vault FUSE mount (drive9 mount vault <path>)

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -13,6 +13,23 @@ import (
 
 // MountCmd handles the "drive9 mount" command.
 //
+// Dispatch fork (Row A, V2e): the first positional argument selects the
+// mount flavour. `drive9 mount vault <path>` routes to the read-only vault
+// FUSE filesystem; anything else retains the pre-V2e fs-mount behaviour
+// below. We MUST peek at the first arg before flag.Parse because the
+// vault flag set is smaller (no cache-size / write-path knobs), and a
+// single flag set would quietly accept write-path flags for a vault mount
+// — that would violate Row C (read-only) in a subtle, mount-time-visible
+// way. See docs/specs/vault-interaction-end-state.md §14.2.
+func MountCmd(args []string) error {
+	if len(args) > 0 && args[0] == "vault" {
+		return VaultMountCmd(args[1:])
+	}
+	return fsMountCmd(args)
+}
+
+// fsMountCmd is the pre-V2e writable fs mount entry point.
+//
 // Credential precedence matches spec §14.2: explicit --server / --api-key flag
 // > DRIVE9_SERVER / DRIVE9_API_KEY / DRIVE9_VAULT_TOKEN env > active config
 // context. The flag defaults are empty strings so we can distinguish "unset"
@@ -30,7 +47,7 @@ import (
 // drive9fuse.Mount runs in-process (no fork/exec); credentials flow through
 // MountOptions{Server, APIKey, Token}, not through the child's environment.
 // This makes the resolver's Unsetenv-after-read mitigation safe for mount.
-func MountCmd(args []string) error {
+func fsMountCmd(args []string) error {
 	fs := flag.NewFlagSet("mount", flag.ExitOnError)
 	server := fs.String("server", "", "drive9 server URL (overrides $DRIVE9_SERVER and config)")
 	apiKey := fs.String("api-key", "", "owner API key (overrides $DRIVE9_API_KEY and config)")

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 
 	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
@@ -14,18 +15,62 @@ import (
 // MountCmd handles the "drive9 mount" command.
 //
 // Dispatch fork (Row A, V2e): the first positional argument selects the
-// mount flavour. `drive9 mount vault <path>` routes to the read-only vault
-// FUSE filesystem; anything else retains the pre-V2e fs-mount behaviour
-// below. We MUST peek at the first arg before flag.Parse because the
-// vault flag set is smaller (no cache-size / write-path knobs), and a
-// single flag set would quietly accept write-path flags for a vault mount
-// — that would violate Row C (read-only) in a subtle, mount-time-visible
-// way. See docs/specs/vault-interaction-end-state.md §14.2.
+// mount flavour.
+//
+//   - `drive9 mount vault <path>`             → read-only vault FUSE filesystem
+//   - `drive9 mount [flags] <path>`           → legacy writable fs mount (no
+//     subcommand keyword; first positional is the mount point)
+//   - `drive9 mount <unknown> ...`            → rejected as unsupported backend
+//
+// We MUST peek at the first arg before flag.Parse because the vault flag
+// set is smaller (no cache-size / write-path knobs), and a single flag
+// set would quietly accept write-path flags for a vault mount — that
+// would violate Row C (read-only) in a subtle, mount-time-visible way.
+//
+// The unsupported-backend branch (Row A) prevents typos like
+// `drive9 mount kv /mnt/x` from being silently treated as
+// `drive9 mount kv` (with `/mnt/x` ignored). A bare-word first positional
+// that isn't a known backend keyword and isn't a path is rejected. Paths
+// (containing `/` or `.`) and flag-style args (leading `-`) flow into
+// the legacy fs mount path. See docs/specs/vault-interaction-end-state.md
+// §14.2.
 func MountCmd(args []string) error {
-	if len(args) > 0 && args[0] == "vault" {
-		return VaultMountCmd(args[1:])
+	if len(args) > 0 {
+		first := args[0]
+		switch {
+		case first == "vault":
+			return VaultMountCmd(args[1:])
+		case looksLikeMountBackendKeyword(first):
+			fmt.Fprintf(os.Stderr, "drive9 mount: unsupported backend %q (supported: vault)\n", first)
+			fmt.Fprintf(os.Stderr, "usage:\n")
+			fmt.Fprintf(os.Stderr, "  drive9 mount [flags] <mountpoint>\n")
+			fmt.Fprintf(os.Stderr, "  drive9 mount vault [flags] <mountpoint>\n")
+			return fmt.Errorf("unsupported mount backend: %s", first)
+		}
 	}
 	return fsMountCmd(args)
+}
+
+// looksLikeMountBackendKeyword decides whether s should be treated as a
+// (potentially unknown) backend selector rather than as a mount point.
+// The heuristic intentionally errs toward "is a backend keyword" so that
+// typos surface as Row A errors rather than silent accepts:
+//
+//   - leading "-" → flag, not a backend keyword
+//   - contains "/" or "." → path, not a backend keyword
+//   - empty → not a keyword
+//   - otherwise (bare alphanumeric word) → treat as a backend keyword
+func looksLikeMountBackendKeyword(s string) bool {
+	if s == "" {
+		return false
+	}
+	if strings.HasPrefix(s, "-") {
+		return false
+	}
+	if strings.ContainsAny(s, "/.") {
+		return false
+	}
+	return true
 }
 
 // fsMountCmd is the pre-V2e writable fs mount entry point.

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -53,24 +53,23 @@ func MountCmd(args []string) error {
 
 // looksLikeMountBackendKeyword decides whether s should be treated as a
 // (potentially unknown) backend selector rather than as a mount point.
-// The heuristic intentionally errs toward "is a backend keyword" so that
-// typos surface as Row A errors rather than silent accepts:
 //
-//   - leading "-" → flag, not a backend keyword
-//   - contains "/" or "." → path, not a backend keyword
-//   - empty → not a keyword
-//   - otherwise (bare alphanumeric word) → treat as a backend keyword
+// We use a closed set of plausible backend-style keywords that a user might
+// type by mistake. Bare relative paths like "mnt", "tmp", "vaultdir" must
+// NOT be caught here — they are valid legacy mountpoints.
+//
+// The set includes storage-system nouns that could plausibly be confused
+// with a drive9 mount backend but are not supported:
+//
+//	kv, s3, gcs, nfs, smb, ftp, ssh, blob, block, object
+//
+// "vault" itself is matched before this function is called.
 func looksLikeMountBackendKeyword(s string) bool {
-	if s == "" {
-		return false
+	switch strings.ToLower(s) {
+	case "kv", "s3", "gcs", "nfs", "smb", "ftp", "ssh", "blob", "block", "object":
+		return true
 	}
-	if strings.HasPrefix(s, "-") {
-		return false
-	}
-	if strings.ContainsAny(s, "/.") {
-		return false
-	}
-	return true
+	return false
 }
 
 // fsMountCmd is the pre-V2e writable fs mount entry point.

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"time"
 
 	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
@@ -17,59 +16,27 @@ import (
 // Dispatch fork (Row A, V2e): the first positional argument selects the
 // mount flavour.
 //
-//   - `drive9 mount vault <path>`             → read-only vault FUSE filesystem
-//   - `drive9 mount [flags] <path>`           → legacy writable fs mount (no
+//   - `drive9 mount vault <path>`   → read-only vault FUSE filesystem
+//   - `drive9 mount [flags] <path>` → legacy writable fs mount (no
 //     subcommand keyword; first positional is the mount point)
-//   - `drive9 mount <unknown> ...`            → rejected as unsupported backend
 //
 // We MUST peek at the first arg before flag.Parse because the vault flag
 // set is smaller (no cache-size / write-path knobs), and a single flag
 // set would quietly accept write-path flags for a vault mount — that
 // would violate Row C (read-only) in a subtle, mount-time-visible way.
 //
-// The unsupported-backend branch (Row A) prevents typos like
-// `drive9 mount kv /mnt/x` from being silently treated as
-// `drive9 mount kv` (with `/mnt/x` ignored). A bare-word first positional
-// that isn't a known backend keyword and isn't a path is rejected. Paths
-// (containing `/` or `.`) and flag-style args (leading `-`) flow into
-// the legacy fs mount path. See docs/specs/vault-interaction-end-state.md
-// §14.2.
+// Only the CURRENT supported backend keyword ("vault") is reserved here.
+// Every other first positional falls through to the legacy parser, which
+// enforces "exactly one mountpoint" so `drive9 mount kv /mnt/x` fails as
+// a positional-arity error rather than by pre-reserving backend-shaped
+// words that do not exist yet.
 func MountCmd(args []string) error {
 	if len(args) > 0 {
-		first := args[0]
-		switch {
-		case first == "vault":
+		if args[0] == "vault" {
 			return VaultMountCmd(args[1:])
-		case looksLikeMountBackendKeyword(first):
-			fmt.Fprintf(os.Stderr, "drive9 mount: unsupported backend %q (supported: vault)\n", first)
-			fmt.Fprintf(os.Stderr, "usage:\n")
-			fmt.Fprintf(os.Stderr, "  drive9 mount [flags] <mountpoint>\n")
-			fmt.Fprintf(os.Stderr, "  drive9 mount vault [flags] <mountpoint>\n")
-			return fmt.Errorf("unsupported mount backend: %s", first)
 		}
 	}
 	return fsMountCmd(args)
-}
-
-// looksLikeMountBackendKeyword decides whether s should be treated as a
-// (potentially unknown) backend selector rather than as a mount point.
-//
-// We use a closed set of plausible backend-style keywords that a user might
-// type by mistake. Bare relative paths like "mnt", "tmp", "vaultdir" must
-// NOT be caught here — they are valid legacy mountpoints.
-//
-// The set includes storage-system nouns that could plausibly be confused
-// with a drive9 mount backend but are not supported:
-//
-//	kv, s3, gcs, nfs, smb, ftp, ssh, blob, block, object
-//
-// "vault" itself is matched before this function is called.
-func looksLikeMountBackendKeyword(s string) bool {
-	switch strings.ToLower(s) {
-	case "kv", "s3", "gcs", "nfs", "smb", "ftp", "ssh", "blob", "block", "object":
-		return true
-	}
-	return false
 }
 
 // fsMountCmd is the pre-V2e writable fs mount entry point.
@@ -117,6 +84,9 @@ func fsMountCmd(args []string) error {
 	if fs.NArg() < 1 {
 		fs.Usage()
 		os.Exit(2)
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("drive9 mount: exactly one mountpoint required")
 	}
 
 	mountPoint := fs.Arg(0)

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -202,35 +202,32 @@ func TestResolveMountCredentials_MissingServer(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Row A — unknown mount backend must be rejected, not silently treated as
-// a legacy fs mount path.
+// Row A — only the CURRENT backend keyword ("vault") is special. All other
+// first positionals flow into the legacy parser, which rejects extra
+// positionals instead of pre-reserving names for future backends.
 // ---------------------------------------------------------------------------
 
-func TestMountCmd_UnsupportedBackendRejected(t *testing.T) {
-	// "kv" is a bare word — not a flag, not a path — so it should be
-	// treated as an unsupported backend keyword and rejected.
-	err := MountCmd([]string{"kv", "/mnt/x"})
+func TestMountCmd_BareWordFirstArgFlowsToLegacyArityCheck(t *testing.T) {
+	for _, s := range []string{"kv", "s3", "gcs", "nfs", "mnt", "tmp", "vaultdir", "data"} {
+		err := MountCmd([]string{s, "/mnt/x"})
+		if err == nil {
+			t.Fatalf("%q: expected positional-arity error", s)
+		}
+		if got := err.Error(); !strings.Contains(got, "exactly one mountpoint required") {
+			t.Fatalf("%q: error = %q, want positional-arity rejection", s, got)
+		}
+		if strings.Contains(err.Error(), "unsupported mount backend") {
+			t.Fatalf("%q: must not be rejected as reserved backend keyword", s)
+		}
+	}
+}
+
+func TestMountCmd_VaultStillDispatchesSeparately(t *testing.T) {
+	err := MountCmd([]string{"vault", "/mnt/a", "/mnt/b"})
 	if err == nil {
-		t.Fatal("expected error for unsupported backend 'kv'")
+		t.Fatal("expected vault subcommand arity error")
 	}
-	if got := err.Error(); !strings.Contains(got, "unsupported mount backend") {
-		t.Fatalf("error = %q, want 'unsupported mount backend'", got)
-	}
-}
-
-func TestMountCmd_PathFirstArgFlowsToLegacy(t *testing.T) {
-	// Path-like and bare relative paths must NOT be rejected as unknown
-	// backends — they should flow into the legacy fs mount path.
-	for _, s := range []string{"/mnt/drive9", "./rel", "-debug", "mnt", "tmp", "vaultdir", "data"} {
-		if looksLikeMountBackendKeyword(s) {
-			t.Fatalf("%q should not look like a backend keyword", s)
-		}
-	}
-	// Only known storage-system nouns should be caught.
-	for _, s := range []string{"kv", "s3", "gcs", "nfs"} {
-		if !looksLikeMountBackendKeyword(s) {
-			t.Fatalf("%q should look like a backend keyword", s)
-		}
+	if got := err.Error(); !strings.Contains(got, "drive9 mount vault: exactly one mountpoint required") {
+		t.Fatalf("error = %q, want vault-specific arity rejection", got)
 	}
 }
-

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -199,3 +200,37 @@ func TestResolveMountCredentials_MissingServer(t *testing.T) {
 		t.Fatal("expected error when no server URL is available")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Row A — unknown mount backend must be rejected, not silently treated as
+// a legacy fs mount path.
+// ---------------------------------------------------------------------------
+
+func TestMountCmd_UnsupportedBackendRejected(t *testing.T) {
+	// "kv" is a bare word — not a flag, not a path — so it should be
+	// treated as an unsupported backend keyword and rejected.
+	err := MountCmd([]string{"kv", "/mnt/x"})
+	if err == nil {
+		t.Fatal("expected error for unsupported backend 'kv'")
+	}
+	if got := err.Error(); !strings.Contains(got, "unsupported mount backend") {
+		t.Fatalf("error = %q, want 'unsupported mount backend'", got)
+	}
+}
+
+func TestMountCmd_PathFirstArgFlowsToLegacy(t *testing.T) {
+	// A path-like first arg (contains "/") must NOT be rejected as an
+	// unknown backend — it should flow into the legacy fs mount path.
+	// We can't fully exercise fsMountCmd here (it calls flag.ExitOnError),
+	// so we just verify looksLikeMountBackendKeyword returns false.
+	if looksLikeMountBackendKeyword("/mnt/drive9") {
+		t.Fatal("/mnt/drive9 should not look like a backend keyword")
+	}
+	if looksLikeMountBackendKeyword("./rel") {
+		t.Fatal("./rel should not look like a backend keyword")
+	}
+	if looksLikeMountBackendKeyword("-debug") {
+		t.Fatal("-debug should not look like a backend keyword")
+	}
+}
+

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -219,18 +219,18 @@ func TestMountCmd_UnsupportedBackendRejected(t *testing.T) {
 }
 
 func TestMountCmd_PathFirstArgFlowsToLegacy(t *testing.T) {
-	// A path-like first arg (contains "/") must NOT be rejected as an
-	// unknown backend — it should flow into the legacy fs mount path.
-	// We can't fully exercise fsMountCmd here (it calls flag.ExitOnError),
-	// so we just verify looksLikeMountBackendKeyword returns false.
-	if looksLikeMountBackendKeyword("/mnt/drive9") {
-		t.Fatal("/mnt/drive9 should not look like a backend keyword")
+	// Path-like and bare relative paths must NOT be rejected as unknown
+	// backends — they should flow into the legacy fs mount path.
+	for _, s := range []string{"/mnt/drive9", "./rel", "-debug", "mnt", "tmp", "vaultdir", "data"} {
+		if looksLikeMountBackendKeyword(s) {
+			t.Fatalf("%q should not look like a backend keyword", s)
+		}
 	}
-	if looksLikeMountBackendKeyword("./rel") {
-		t.Fatal("./rel should not look like a backend keyword")
-	}
-	if looksLikeMountBackendKeyword("-debug") {
-		t.Fatal("-debug should not look like a backend keyword")
+	// Only known storage-system nouns should be caught.
+	for _, s := range []string{"kv", "s3", "gcs", "nfs"} {
+		if !looksLikeMountBackendKeyword(s) {
+			t.Fatalf("%q should look like a backend keyword", s)
+		}
 	}
 }
 

--- a/cmd/drive9/cli/mount_vault.go
+++ b/cmd/drive9/cli/mount_vault.go
@@ -44,6 +44,9 @@ func VaultMountCmd(args []string) error {
 		fs.Usage()
 		os.Exit(2)
 	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("drive9 mount vault: exactly one mountpoint required")
+	}
 	mountPoint := fs.Arg(0)
 
 	serverGiven, apiKeyGiven := flagProvided(fs, "server"), flagProvided(fs, "api-key")

--- a/cmd/drive9/cli/mount_vault.go
+++ b/cmd/drive9/cli/mount_vault.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
+)
+
+// VaultMountCmd handles `drive9 mount vault [flags] <mountpoint>`.
+//
+// V2e Row A: dispatch surface. Routed to from MountCmd when args[0] == "vault".
+//
+// V2e Row B: credential resolver. Reuses the unified ResolveCredentials +
+// resolveMountCredentials pipeline shared with the writable fs mount, so
+// the priority chain (--api-key flag > DRIVE9_VAULT_TOKEN > DRIVE9_API_KEY
+// > active context) and the explicit-empty-flag rejection both apply
+// uniformly. The vault flavour does NOT introduce a new resolver path —
+// that would create a second contract surface for the credential-confusion
+// bug class called out in spec §14.2.
+//
+// V2e Row C-I: enforced by drive9fuse.MountVault — see vaultfs.go and
+// vault_mount.go for the per-row anchors. This file owns only the CLI
+// surface (flag parsing + cred resolution + handing off to MountVault).
+func VaultMountCmd(args []string) error {
+	fs := flag.NewFlagSet("mount vault", flag.ExitOnError)
+	server := fs.String("server", "", "drive9 server URL (overrides $DRIVE9_SERVER and config)")
+	apiKey := fs.String("api-key", "", "owner API key (overrides $DRIVE9_API_KEY and config)")
+	dirTTL := fs.Duration("dir-ttl", 5*time.Second, "vault list / field cache TTL")
+	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
+	debug := fs.Bool("debug", false, "enable FUSE debug logging")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: drive9 mount vault [flags] <mountpoint>\n\nflags:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
+		fs.Usage()
+		os.Exit(2)
+	}
+	mountPoint := fs.Arg(0)
+
+	serverGiven, apiKeyGiven := flagProvided(fs, "server"), flagProvided(fs, "api-key")
+	if err := rejectEmptyFlag("server", *server, serverGiven); err != nil {
+		return err
+	}
+	if err := rejectEmptyFlag("api-key", *apiKey, apiKeyGiven); err != nil {
+		return err
+	}
+
+	serverVal, apiKeyVal, tokenVal, err := resolveMountCredentials(ResolveCredentials(), *server, *apiKey)
+	if err != nil {
+		return err
+	}
+
+	opts := &drive9fuse.VaultMountOptions{
+		Server:     serverVal,
+		APIKey:     apiKeyVal,
+		Token:      tokenVal,
+		MountPoint: mountPoint,
+		DirTTL:     *dirTTL,
+		AllowOther: *allowOther,
+		Debug:      *debug,
+	}
+	return drive9fuse.MountVault(opts)
+}

--- a/pkg/fuse/vault_mount.go
+++ b/pkg/fuse/vault_mount.go
@@ -40,26 +40,26 @@ func (o *VaultMountOptions) setDefaults() {
 	}
 }
 
-// MountVault creates and serves a read-only FUSE mount that exposes vault
-// secrets readable by the bound credential. It blocks until the filesystem
-// is unmounted or SIGINT/SIGTERM is received.
-//
-// The contract row mapping is documented at the top of vaultfs.go.
-func MountVault(opts *VaultMountOptions) error {
+// probeVaultMount validates opts, constructs the vault client, and runs the
+// Row I probe. Returns the bound client and the readable-secret set on
+// success; empty secret sets are NOT an error (see the rationale on the
+// error path below). Split out so tests can exercise probe acceptance
+// without going through the full FUSE-mount blocking path.
+func probeVaultMount(opts *VaultMountOptions) (*client.Client, []string, error) {
 	if opts == nil {
-		return fmt.Errorf("mount vault: options are required")
+		return nil, nil, fmt.Errorf("mount vault: options are required")
 	}
 	opts.setDefaults()
 
 	if err := os.MkdirAll(opts.MountPoint, 0o755); err != nil {
-		return fmt.Errorf("create mount point: %w", err)
+		return nil, nil, fmt.Errorf("create mount point: %w", err)
 	}
 
 	if opts.APIKey != "" && opts.Token != "" {
-		return fmt.Errorf("mount vault: APIKey and Token are mutually exclusive (choose one principal kind at mount time)")
+		return nil, nil, fmt.Errorf("mount vault: APIKey and Token are mutually exclusive (choose one principal kind at mount time)")
 	}
 	if opts.APIKey == "" && opts.Token == "" {
-		return fmt.Errorf("mount vault: either APIKey (owner) or Token (delegated) is required")
+		return nil, nil, fmt.Errorf("mount vault: either APIKey (owner) or Token (delegated) is required")
 	}
 
 	var c *client.Client
@@ -85,7 +85,20 @@ func MountVault(opts *VaultMountOptions) error {
 	secrets, err := c.ListReadableVaultSecrets(probeCtx)
 	probeCancel()
 	if err != nil {
-		return fmt.Errorf("vault probe: %w", err)
+		return nil, nil, fmt.Errorf("vault probe: %w", err)
+	}
+	return c, secrets, nil
+}
+
+// MountVault creates and serves a read-only FUSE mount that exposes vault
+// secrets readable by the bound credential. It blocks until the filesystem
+// is unmounted or SIGINT/SIGTERM is received.
+//
+// The contract row mapping is documented at the top of vaultfs.go.
+func MountVault(opts *VaultMountOptions) error {
+	c, secrets, err := probeVaultMount(opts)
+	if err != nil {
+		return err
 	}
 
 	vfs := NewVaultFS(c, opts.DirTTL)

--- a/pkg/fuse/vault_mount.go
+++ b/pkg/fuse/vault_mount.go
@@ -1,0 +1,149 @@
+package fuse
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+// VaultMountOptions configures a `drive9 mount vault <path>` mount.
+//
+// Like MountOptions, APIKey and Token are mutually exclusive — exactly one
+// must be set, and the chosen credential is locked for the mount's lifetime
+// (Invariant #3, #6). A read-only vault mount served by a delegated token
+// can only see secrets the token's grant covers (Row D); an empty scope
+// causes Mount to fail with EACCES at probe time (Row I).
+type VaultMountOptions struct {
+	Server     string
+	APIKey     string        // owner API key (mutually exclusive with Token)
+	Token      string        // delegated capability JWT (mutually exclusive with APIKey)
+	MountPoint string        // local mount point
+	DirTTL     time.Duration // cache TTL for the secret list and per-secret field maps
+	AllowOther bool
+	Debug      bool
+}
+
+func (o *VaultMountOptions) setDefaults() {
+	if o.DirTTL <= 0 {
+		o.DirTTL = 5 * time.Second
+	}
+}
+
+// MountVault creates and serves a read-only FUSE mount that exposes vault
+// secrets readable by the bound credential. It blocks until the filesystem
+// is unmounted or SIGINT/SIGTERM is received.
+//
+// The contract row mapping is documented at the top of vaultfs.go.
+func MountVault(opts *VaultMountOptions) error {
+	opts.setDefaults()
+
+	if err := os.MkdirAll(opts.MountPoint, 0o755); err != nil {
+		return fmt.Errorf("create mount point: %w", err)
+	}
+
+	if opts.APIKey != "" && opts.Token != "" {
+		return fmt.Errorf("mount vault: APIKey and Token are mutually exclusive (choose one principal kind at mount time)")
+	}
+	if opts.APIKey == "" && opts.Token == "" {
+		return fmt.Errorf("mount vault: either APIKey (owner) or Token (delegated) is required")
+	}
+
+	var c *client.Client
+	if opts.Token != "" {
+		c = client.NewWithToken(opts.Server, opts.Token)
+	} else {
+		c = client.New(opts.Server, opts.APIKey)
+	}
+
+	// Row I — empty-scope = EACCES. Probe the vault before standing up FUSE
+	// so a token whose grant has been revoked, or that simply has no
+	// readable secrets, fails fast with a useful error rather than an
+	// empty mount point that silently swallows reads.
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	secrets, err := c.ListReadableVaultSecrets(probeCtx)
+	probeCancel()
+	if err != nil {
+		return fmt.Errorf("vault probe: %w", err)
+	}
+	if len(secrets) == 0 {
+		return fmt.Errorf("vault probe: no readable secrets for the supplied credential (EACCES)")
+	}
+
+	vfs := NewVaultFS(c, opts.DirTTL)
+
+	fuseOpts := &gofuse.MountOptions{
+		FsName:     "drive9-vault",
+		Name:       "drive9-vault",
+		Debug:      opts.Debug,
+		AllowOther: opts.AllowOther,
+		// Always read-only at the kernel level too (belt-and-braces with
+		// the in-process EROFS rejections).
+		Options: []string{"ro"},
+	}
+
+	server, err := gofuse.NewServer(vfs, opts.MountPoint, fuseOpts)
+	if err != nil {
+		return fmt.Errorf("fuse mount vault: %w", err)
+	}
+
+	go server.Serve()
+	if err := server.WaitMount(); err != nil {
+		return fmt.Errorf("fuse wait mount (vault): %w", err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		fmt.Fprintf(os.Stderr, "\ndrive9: unmounting vault %s...\n", opts.MountPoint)
+		go func() {
+			<-sigCh
+			fmt.Fprintf(os.Stderr, "drive9: forced exit\n")
+			os.Exit(1)
+		}()
+		const maxRetries = 5
+		var unmountErr error
+		for i := 0; i < maxRetries; i++ {
+			if unmountErr = server.Unmount(); unmountErr == nil {
+				return
+			}
+			fmt.Fprintf(os.Stderr, "drive9: vault unmount attempt %d/%d failed: %v\n", i+1, maxRetries, unmountErr)
+			if i < maxRetries-1 {
+				time.Sleep(500 * time.Millisecond)
+			}
+		}
+		fmt.Fprintf(os.Stderr, "drive9: vault retries exhausted, force-unmounting %s\n", opts.MountPoint)
+		forceUnmountVault(opts.MountPoint)
+	}()
+
+	fmt.Fprintf(os.Stderr, "drive9: vault mounted on %s (server: %s, secrets: %d)\n", opts.MountPoint, opts.Server, len(secrets))
+	server.Wait()
+	return nil
+}
+
+func forceUnmountVault(mountpoint string) {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "darwin" {
+		cmd = exec.Command("diskutil", "unmount", "force", mountpoint)
+	} else {
+		if _, err := exec.LookPath("fusermount"); err == nil {
+			cmd = exec.Command("fusermount", "-u", mountpoint)
+		} else {
+			cmd = exec.Command("umount", "-l", mountpoint)
+		}
+	}
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "drive9: vault force unmount failed: %v\n", err)
+	}
+}

--- a/pkg/fuse/vault_mount.go
+++ b/pkg/fuse/vault_mount.go
@@ -46,6 +46,9 @@ func (o *VaultMountOptions) setDefaults() {
 //
 // The contract row mapping is documented at the top of vaultfs.go.
 func MountVault(opts *VaultMountOptions) error {
+	if opts == nil {
+		return fmt.Errorf("mount vault: options are required")
+	}
 	opts.setDefaults()
 
 	if err := os.MkdirAll(opts.MountPoint, 0o755); err != nil {
@@ -143,7 +146,10 @@ func forceUnmountVault(mountpoint string) {
 	if runtime.GOOS == "darwin" {
 		cmd = exec.Command("diskutil", "unmount", "force", mountpoint)
 	} else {
-		if _, err := exec.LookPath("fusermount"); err == nil {
+		// Prefer fusermount3 (matches canonical selection in cmd/drive9/cli/mount.go).
+		if _, err := exec.LookPath("fusermount3"); err == nil {
+			cmd = exec.Command("fusermount3", "-u", mountpoint)
+		} else if _, err := exec.LookPath("fusermount"); err == nil {
 			cmd = exec.Command("fusermount", "-u", mountpoint)
 		} else {
 			cmd = exec.Command("umount", "-l", mountpoint)

--- a/pkg/fuse/vault_mount.go
+++ b/pkg/fuse/vault_mount.go
@@ -19,8 +19,11 @@ import (
 // Like MountOptions, APIKey and Token are mutually exclusive — exactly one
 // must be set, and the chosen credential is locked for the mount's lifetime
 // (Invariant #3, #6). A read-only vault mount served by a delegated token
-// can only see secrets the token's grant covers (Row D); an empty scope
-// causes Mount to fail with EACCES at probe time (Row I).
+// can only see secrets the token's grant covers (Row D). Probe-time mount
+// rejection is driven by the server's auth response, not by the size of the
+// readable secret set: valid credentials may legitimately enumerate zero
+// secrets, while malformed / expired / revoked tokens are rejected by the
+// server with 401 (Row I).
 type VaultMountOptions struct {
 	Server     string
 	APIKey     string        // owner API key (mutually exclusive with Token)
@@ -74,7 +77,7 @@ func MountVault(opts *VaultMountOptions) error {
 	//   - Delegated token with zero existing secrets = valid grant whose
 	//     scope targets secrets that don't exist yet or were deleted. This
 	//     is NOT the same as a revoked/malformed token (which the server
-	//     surfaces as 403, caught by the error check above).
+	//     surfaces as 401, caught by the error check above).
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	secrets, err := c.ListReadableVaultSecrets(probeCtx)
 	probeCancel()

--- a/pkg/fuse/vault_mount.go
+++ b/pkg/fuse/vault_mount.go
@@ -63,26 +63,23 @@ func MountVault(opts *VaultMountOptions) error {
 		c = client.New(opts.Server, opts.APIKey)
 	}
 
-	// Row I — empty-scope = EACCES, but ONLY for delegated tokens.
+	// Probe: verify the credential can reach the server and list secrets.
+	// This surfaces connectivity / auth failures early (before the FUSE
+	// mount is established) rather than as silent empty mounts.
 	//
-	// A delegated capability JWT with zero readable secrets means the
-	// grant has no scope (or has been revoked) — failing fast here gives
-	// the user a useful error instead of an empty mountpoint that
-	// silently swallows reads.
-	//
-	// An owner API key with zero secrets is a normal new-tenant startup
-	// state (see docs/guides/vault-quickstart.md: owner mounts the vault
-	// FIRST and then creates the first secret). For the owner kind we
-	// still probe — to surface a connectivity / auth failure early — but
-	// an empty list is allowed.
+	// We intentionally do NOT reject an empty secret list here for either
+	// principal kind:
+	//   - Owner with zero secrets = normal new-tenant startup (quickstart
+	//     flow: mount first, then create the first secret).
+	//   - Delegated token with zero existing secrets = valid grant whose
+	//     scope targets secrets that don't exist yet or were deleted. This
+	//     is NOT the same as a revoked/malformed token (which the server
+	//     surfaces as 403, caught by the error check above).
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	secrets, err := c.ListReadableVaultSecrets(probeCtx)
 	probeCancel()
 	if err != nil {
 		return fmt.Errorf("vault probe: %w", err)
-	}
-	if opts.Token != "" && len(secrets) == 0 {
-		return fmt.Errorf("vault probe: delegated token has no readable secrets (EACCES)")
 	}
 
 	vfs := NewVaultFS(c, opts.DirTTL)

--- a/pkg/fuse/vault_mount.go
+++ b/pkg/fuse/vault_mount.go
@@ -63,18 +63,26 @@ func MountVault(opts *VaultMountOptions) error {
 		c = client.New(opts.Server, opts.APIKey)
 	}
 
-	// Row I — empty-scope = EACCES. Probe the vault before standing up FUSE
-	// so a token whose grant has been revoked, or that simply has no
-	// readable secrets, fails fast with a useful error rather than an
-	// empty mount point that silently swallows reads.
+	// Row I — empty-scope = EACCES, but ONLY for delegated tokens.
+	//
+	// A delegated capability JWT with zero readable secrets means the
+	// grant has no scope (or has been revoked) — failing fast here gives
+	// the user a useful error instead of an empty mountpoint that
+	// silently swallows reads.
+	//
+	// An owner API key with zero secrets is a normal new-tenant startup
+	// state (see docs/guides/vault-quickstart.md: owner mounts the vault
+	// FIRST and then creates the first secret). For the owner kind we
+	// still probe — to surface a connectivity / auth failure early — but
+	// an empty list is allowed.
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	secrets, err := c.ListReadableVaultSecrets(probeCtx)
 	probeCancel()
 	if err != nil {
 		return fmt.Errorf("vault probe: %w", err)
 	}
-	if len(secrets) == 0 {
-		return fmt.Errorf("vault probe: no readable secrets for the supplied credential (EACCES)")
+	if opts.Token != "" && len(secrets) == 0 {
+		return fmt.Errorf("vault probe: delegated token has no readable secrets (EACCES)")
 	}
 
 	vfs := NewVaultFS(c, opts.DirTTL)

--- a/pkg/fuse/vaultfs.go
+++ b/pkg/fuse/vaultfs.go
@@ -1,0 +1,530 @@
+package fuse
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+// VaultFS is a read-only FUSE filesystem that exposes the vault secrets
+// readable by the bound capability/owner credential as a two-level tree:
+//
+//	<mount>/<secret-name>/<field-name>
+//
+// Layout decisions (V2e sealed contract rows A–I):
+//   - Row C — read-only: every mutating op (Mkdir, Unlink, Create, Write,
+//     Setattr, Rename, Rmdir, …) returns EROFS via the embedded default
+//     RawFileSystem. We do NOT inherit the writable Dat9FS path.
+//   - Row D — scope visibility: root readdir is the result of
+//     ListReadableVaultSecrets(); the server enforces per-token scope
+//     (Invariant #7), and we do not augment or filter client-side.
+//   - Row E — new-op after revoke: each readdir/open re-issues the
+//     consumption call, so a 403 from the server cleanly maps to EACCES.
+//   - Row F — existing FD after revoke must NEVER serve V2: at Open() time
+//     we materialise the field bytes once into the handle. Subsequent Read()
+//     calls are served from that snapshot — no re-fetch on the hot path.
+//     If the server later rotates the value (V2), the open FD continues to
+//     serve V1 (or returns EIO if its snapshot was lost), but never V2.
+//   - Row G — settle after put: per-secret field maps live behind a TTL
+//     cache (DirTTL); after expiry the next readdir/open fetches fresh.
+//   - Row H — TTL: enforced by vaultCache.refreshAfter == DirTTL.
+//   - Row I — empty-scope = EACCES: Mount refuses to start if the bearer
+//     has zero readable secrets at probe time.
+//
+// Inode allocation: we use a stable map keyed by absolute path. Inode 1 is
+// the root; every distinct secret directory and field file gets a fresh
+// inode the first time the kernel asks about it. We never recycle.
+type VaultFS struct {
+	gofuse.RawFileSystem
+
+	client *client.Client
+	dirTTL time.Duration
+
+	mu          sync.Mutex
+	pathToInode map[string]uint64
+	inodeToPath map[uint64]string
+	nextInode   uint64
+
+	// rootCache caches the secret-name list at the root.
+	rootCache       []string
+	rootCacheExpiry time.Time
+
+	// secretCache caches per-secret field maps so that Lookup → GetAttr →
+	// Open from the kernel for a single field share one server round-trip.
+	secretCache map[string]secretCacheEntry
+
+	// openFiles snapshots field bytes at Open() time so that revoke during
+	// an open FD never produces a post-revoke value (Row F).
+	openFiles map[uint64]*vaultOpenFile
+	openSeq   uint64
+
+	uid uint32
+	gid uint32
+}
+
+type secretCacheEntry struct {
+	fields map[string]string
+	expiry time.Time
+}
+
+type vaultOpenFile struct {
+	data []byte
+}
+
+// NewVaultFS builds a read-only vault filesystem bound to c. dirTTL controls
+// how long secret-list / field-map results are cached before refresh.
+func NewVaultFS(c *client.Client, dirTTL time.Duration) *VaultFS {
+	if dirTTL <= 0 {
+		dirTTL = 5 * time.Second
+	}
+	fs := &VaultFS{
+		RawFileSystem: gofuse.NewDefaultRawFileSystem(),
+		client:        c,
+		dirTTL:        dirTTL,
+		pathToInode:   make(map[string]uint64),
+		inodeToPath:   make(map[uint64]string),
+		nextInode:     2, // 1 is reserved for root
+		secretCache:   make(map[string]secretCacheEntry),
+		openFiles:     make(map[uint64]*vaultOpenFile),
+		uid:           uint32(os.Getuid()),
+		gid:           uint32(os.Getgid()),
+	}
+	fs.pathToInode["/"] = 1
+	fs.inodeToPath[1] = "/"
+	return fs
+}
+
+// inodeForPath returns a stable inode for path, allocating one if needed.
+func (fs *VaultFS) inodeForPath(p string) uint64 {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if ino, ok := fs.pathToInode[p]; ok {
+		return ino
+	}
+	ino := fs.nextInode
+	fs.nextInode++
+	fs.pathToInode[p] = ino
+	fs.inodeToPath[ino] = p
+	return ino
+}
+
+func (fs *VaultFS) pathForInode(ino uint64) (string, bool) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	p, ok := fs.inodeToPath[ino]
+	return p, ok
+}
+
+// listSecrets returns the cached or freshly-fetched list of readable secrets.
+func (fs *VaultFS) listSecrets(ctx context.Context) ([]string, error) {
+	fs.mu.Lock()
+	if time.Now().Before(fs.rootCacheExpiry) && fs.rootCache != nil {
+		out := append([]string(nil), fs.rootCache...)
+		fs.mu.Unlock()
+		return out, nil
+	}
+	fs.mu.Unlock()
+
+	secrets, err := fs.client.ListReadableVaultSecrets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	fs.mu.Lock()
+	fs.rootCache = append([]string(nil), secrets...)
+	fs.rootCacheExpiry = time.Now().Add(fs.dirTTL)
+	fs.mu.Unlock()
+	return secrets, nil
+}
+
+// readSecret returns the cached or freshly-fetched field map for secretName.
+func (fs *VaultFS) readSecret(ctx context.Context, secretName string) (map[string]string, error) {
+	fs.mu.Lock()
+	if entry, ok := fs.secretCache[secretName]; ok && time.Now().Before(entry.expiry) {
+		out := make(map[string]string, len(entry.fields))
+		for k, v := range entry.fields {
+			out[k] = v
+		}
+		fs.mu.Unlock()
+		return out, nil
+	}
+	fs.mu.Unlock()
+
+	fields, err := fs.client.ReadVaultSecret(ctx, secretName)
+	if err != nil {
+		return nil, err
+	}
+	fs.mu.Lock()
+	fs.secretCache[secretName] = secretCacheEntry{
+		fields: fields,
+		expiry: time.Now().Add(fs.dirTTL),
+	}
+	fs.mu.Unlock()
+	return fields, nil
+}
+
+// splitPath turns "/secret/field" into ("secret", "field"). Empty components
+// are returned for shorter paths.
+func splitVaultPath(p string) (secret, field string) {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(trimmed, "/", 2)
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return parts[0], parts[1]
+}
+
+func vaultJoin(parts ...string) string {
+	out := "/"
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		if !strings.HasSuffix(out, "/") {
+			out += "/"
+		}
+		out += p
+	}
+	return out
+}
+
+// httpStatusToFuse maps an HTTP error from the vault client into a FUSE
+// status, mirroring httpToFuseStatus but local to the vault filesystem so
+// the writable filesystem's wider mapping doesn't bleed in.
+func httpStatusToVaultFuse(err error) gofuse.Status {
+	if err == nil {
+		return gofuse.OK
+	}
+	var se *client.StatusError
+	if errors.As(err, &se) {
+		switch se.StatusCode {
+		case http.StatusNotFound:
+			return gofuse.ENOENT
+		case http.StatusForbidden, http.StatusUnauthorized:
+			return gofuse.EACCES
+		case http.StatusBadRequest:
+			return gofuse.Status(syscall.EINVAL)
+		case http.StatusGatewayTimeout, http.StatusRequestTimeout:
+			return gofuse.Status(syscall.ETIMEDOUT)
+		}
+		if se.StatusCode >= 500 {
+			return gofuse.EIO
+		}
+		return gofuse.EIO
+	}
+	return gofuse.EIO
+}
+
+// fillDirAttr populates an Attr struct for a directory inode.
+func (fs *VaultFS) fillDirAttr(out *gofuse.Attr, ino uint64) {
+	out.Ino = ino
+	out.Mode = syscall.S_IFDIR | 0o555
+	out.Nlink = 2
+	out.Uid = fs.uid
+	out.Gid = fs.gid
+}
+
+// fillFileAttr populates an Attr struct for a regular field inode.
+func (fs *VaultFS) fillFileAttr(out *gofuse.Attr, ino uint64, size int64) {
+	out.Ino = ino
+	out.Mode = syscall.S_IFREG | 0o444
+	out.Nlink = 1
+	out.Size = uint64(size)
+	out.Uid = fs.uid
+	out.Gid = fs.gid
+}
+
+// Init records the server pointer (currently unused; kept for symmetry with
+// Dat9FS so future inode-notify wiring is a one-liner).
+func (fs *VaultFS) Init(server *gofuse.Server) {
+	_ = server
+}
+
+func (fs *VaultFS) StatFs(cancel <-chan struct{}, header *gofuse.InHeader, out *gofuse.StatfsOut) gofuse.Status {
+	out.Bsize = 4096
+	out.NameLen = 255
+	return gofuse.OK
+}
+
+// ----- read path -----
+
+func (fs *VaultFS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name string, out *gofuse.EntryOut) gofuse.Status {
+	parentPath, ok := fs.pathForInode(header.NodeId)
+	if !ok {
+		return gofuse.ENOENT
+	}
+	ctx, cf := fuseCtx(cancel)
+	defer cf()
+
+	switch parentPath {
+	case "/":
+		// Looking up a secret name under root.
+		secrets, err := fs.listSecrets(ctx)
+		if err != nil {
+			return httpStatusToVaultFuse(err)
+		}
+		for _, s := range secrets {
+			if s == name {
+				p := vaultJoin(name)
+				ino := fs.inodeForPath(p)
+				fs.fillDirAttr(&out.Attr, ino)
+				out.NodeId = ino
+				out.SetEntryTimeout(fs.dirTTL)
+				out.SetAttrTimeout(fs.dirTTL)
+				return gofuse.OK
+			}
+		}
+		return gofuse.ENOENT
+	default:
+		secretName, sub := splitVaultPath(parentPath)
+		if secretName == "" || sub != "" {
+			// We only have two levels.
+			return gofuse.ENOENT
+		}
+		fields, err := fs.readSecret(ctx, secretName)
+		if err != nil {
+			return httpStatusToVaultFuse(err)
+		}
+		val, ok := fields[name]
+		if !ok {
+			return gofuse.ENOENT
+		}
+		p := vaultJoin(secretName, name)
+		ino := fs.inodeForPath(p)
+		fs.fillFileAttr(&out.Attr, ino, int64(len(val)))
+		out.NodeId = ino
+		out.SetEntryTimeout(fs.dirTTL)
+		out.SetAttrTimeout(fs.dirTTL)
+		return gofuse.OK
+	}
+}
+
+func (fs *VaultFS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *gofuse.AttrOut) gofuse.Status {
+	p, ok := fs.pathForInode(input.NodeId)
+	if !ok {
+		return gofuse.ENOENT
+	}
+	out.SetTimeout(fs.dirTTL)
+	if p == "/" {
+		fs.fillDirAttr(&out.Attr, input.NodeId)
+		return gofuse.OK
+	}
+	secretName, fieldName := splitVaultPath(p)
+	if fieldName == "" {
+		fs.fillDirAttr(&out.Attr, input.NodeId)
+		return gofuse.OK
+	}
+	ctx, cf := fuseCtx(cancel)
+	defer cf()
+	fields, err := fs.readSecret(ctx, secretName)
+	if err != nil {
+		return httpStatusToVaultFuse(err)
+	}
+	val, ok := fields[fieldName]
+	if !ok {
+		return gofuse.ENOENT
+	}
+	fs.fillFileAttr(&out.Attr, input.NodeId, int64(len(val)))
+	return gofuse.OK
+}
+
+func (fs *VaultFS) OpenDir(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse.OpenOut) gofuse.Status {
+	if _, ok := fs.pathForInode(input.NodeId); !ok {
+		return gofuse.ENOENT
+	}
+	return gofuse.OK
+}
+
+func (fs *VaultFS) ReadDir(cancel <-chan struct{}, input *gofuse.ReadIn, out *gofuse.DirEntryList) gofuse.Status {
+	return fs.readDirCommon(cancel, input, out, false)
+}
+
+func (fs *VaultFS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out *gofuse.DirEntryList) gofuse.Status {
+	return fs.readDirCommon(cancel, input, out, true)
+}
+
+func (fs *VaultFS) readDirCommon(cancel <-chan struct{}, input *gofuse.ReadIn, out *gofuse.DirEntryList, plus bool) gofuse.Status {
+	p, ok := fs.pathForInode(input.NodeId)
+	if !ok {
+		return gofuse.ENOENT
+	}
+	ctx, cf := fuseCtx(cancel)
+	defer cf()
+
+	type entry struct {
+		name string
+		mode uint32
+		ino  uint64
+		size int64
+	}
+	var entries []entry
+
+	if p == "/" {
+		secrets, err := fs.listSecrets(ctx)
+		if err != nil {
+			return httpStatusToVaultFuse(err)
+		}
+		for _, s := range secrets {
+			ino := fs.inodeForPath(vaultJoin(s))
+			entries = append(entries, entry{name: s, mode: syscall.S_IFDIR, ino: ino})
+		}
+	} else {
+		secretName, sub := splitVaultPath(p)
+		if secretName == "" || sub != "" {
+			return gofuse.ENOENT
+		}
+		fields, err := fs.readSecret(ctx, secretName)
+		if err != nil {
+			return httpStatusToVaultFuse(err)
+		}
+		for k, v := range fields {
+			ino := fs.inodeForPath(vaultJoin(secretName, k))
+			entries = append(entries, entry{name: k, mode: syscall.S_IFREG, ino: ino, size: int64(len(v))})
+		}
+	}
+
+	for i := int(input.Offset); i < len(entries); i++ {
+		e := entries[i]
+		de := gofuse.DirEntry{Name: e.name, Ino: e.ino, Mode: e.mode}
+		if plus {
+			eout := out.AddDirLookupEntry(de)
+			if eout == nil {
+				break
+			}
+			if e.mode == syscall.S_IFDIR {
+				fs.fillDirAttr(&eout.Attr, e.ino)
+			} else {
+				fs.fillFileAttr(&eout.Attr, e.ino, e.size)
+			}
+			eout.NodeId = e.ino
+			eout.SetEntryTimeout(fs.dirTTL)
+			eout.SetAttrTimeout(fs.dirTTL)
+		} else {
+			if !out.AddDirEntry(de) {
+				break
+			}
+		}
+	}
+	return gofuse.OK
+}
+
+func (fs *VaultFS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse.OpenOut) gofuse.Status {
+	// Reject any write/truncate mode at the door (Row C).
+	if input.Flags&uint32(os.O_WRONLY|os.O_RDWR|os.O_APPEND|os.O_TRUNC|os.O_CREATE) != 0 {
+		return gofuse.EROFS
+	}
+	p, ok := fs.pathForInode(input.NodeId)
+	if !ok {
+		return gofuse.ENOENT
+	}
+	secretName, fieldName := splitVaultPath(p)
+	if secretName == "" || fieldName == "" {
+		return gofuse.EISDIR
+	}
+	ctx, cf := fuseCtx(cancel)
+	defer cf()
+	// Bypass the cache for the open call: the snapshot we take here is the
+	// only data the FD will ever serve (Row F), so we want it as fresh as
+	// the bearer can legitimately read RIGHT NOW. Subsequent revocation
+	// must not produce a V2 value via this FD.
+	fields, err := fs.client.ReadVaultSecret(ctx, secretName)
+	if err != nil {
+		return httpStatusToVaultFuse(err)
+	}
+	val, ok := fields[fieldName]
+	if !ok {
+		return gofuse.ENOENT
+	}
+	snapshot := []byte(val)
+
+	fs.mu.Lock()
+	fs.openSeq++
+	fh := fs.openSeq
+	fs.openFiles[fh] = &vaultOpenFile{data: snapshot}
+	// Refresh the secretCache so neighbouring lookups see a coherent size.
+	fs.secretCache[secretName] = secretCacheEntry{
+		fields: fields,
+		expiry: time.Now().Add(fs.dirTTL),
+	}
+	fs.mu.Unlock()
+
+	out.Fh = fh
+	// DIRECT_IO so the kernel page cache can't mix V1 bytes from one FD
+	// with V2 bytes a future open might see. Each open is its own snapshot.
+	out.OpenFlags = gofuse.FOPEN_DIRECT_IO
+	return gofuse.OK
+}
+
+func (fs *VaultFS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte) (gofuse.ReadResult, gofuse.Status) {
+	fs.mu.Lock()
+	of, ok := fs.openFiles[input.Fh]
+	fs.mu.Unlock()
+	if !ok {
+		return nil, gofuse.EBADF
+	}
+	off := int64(input.Offset)
+	if off >= int64(len(of.data)) {
+		return gofuse.ReadResultData(nil), gofuse.OK
+	}
+	end := off + int64(len(buf))
+	if end > int64(len(of.data)) {
+		end = int64(len(of.data))
+	}
+	return gofuse.ReadResultData(of.data[off:end]), gofuse.OK
+}
+
+func (fs *VaultFS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
+	fs.mu.Lock()
+	delete(fs.openFiles, input.Fh)
+	fs.mu.Unlock()
+}
+
+func (fs *VaultFS) ReleaseDir(input *gofuse.ReleaseIn) {}
+
+func (fs *VaultFS) Forget(nodeId uint64, nlookup uint64) {}
+
+// ----- write path: every mutation rejected with EROFS (Row C) -----
+
+func (fs *VaultFS) Mkdir(cancel <-chan struct{}, input *gofuse.MkdirIn, name string, out *gofuse.EntryOut) gofuse.Status {
+	return gofuse.EROFS
+}
+func (fs *VaultFS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name string) gofuse.Status {
+	return gofuse.EROFS
+}
+func (fs *VaultFS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name string) gofuse.Status {
+	return gofuse.EROFS
+}
+func (fs *VaultFS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName string, newName string) gofuse.Status {
+	return gofuse.EROFS
+}
+func (fs *VaultFS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name string, out *gofuse.CreateOut) gofuse.Status {
+	return gofuse.EROFS
+}
+func (fs *VaultFS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []byte) (uint32, gofuse.Status) {
+	return 0, gofuse.EROFS
+}
+func (fs *VaultFS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *gofuse.AttrOut) gofuse.Status {
+	return gofuse.EROFS
+}
+func (fs *VaultFS) Symlink(cancel <-chan struct{}, header *gofuse.InHeader, pointedTo string, linkName string, out *gofuse.EntryOut) gofuse.Status {
+	return gofuse.EROFS
+}
+func (fs *VaultFS) Link(cancel <-chan struct{}, input *gofuse.LinkIn, name string, out *gofuse.EntryOut) gofuse.Status {
+	return gofuse.EROFS
+}
+func (fs *VaultFS) Mknod(cancel <-chan struct{}, input *gofuse.MknodIn, name string, out *gofuse.EntryOut) gofuse.Status {
+	return gofuse.EROFS
+}
+func (fs *VaultFS) Fallocate(cancel <-chan struct{}, input *gofuse.FallocateIn) gofuse.Status {
+	return gofuse.EROFS
+}

--- a/pkg/fuse/vaultfs.go
+++ b/pkg/fuse/vaultfs.go
@@ -358,6 +358,13 @@ func (fs *VaultFS) readDirCommon(cancel <-chan struct{}, input *gofuse.ReadIn, o
 	// could see entries skipped or duplicated across successive Offsets.
 	sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
 
+	// input.Offset is uint64 and can exceed math.MaxInt64; narrowing via
+	// int(input.Offset) on 64-bit turns ^uint64(0) into -1, which then
+	// indexes entries[-1] and panics. Treat any past-end offset (including
+	// overflow cases) as an empty page, consistent with the Read hardening.
+	if input.Offset >= uint64(len(entries)) {
+		return gofuse.OK
+	}
 	for i := int(input.Offset); i < len(entries); i++ {
 		e := entries[i]
 		de := gofuse.DirEntry{Name: e.name, Ino: e.ino, Mode: e.mode}

--- a/pkg/fuse/vaultfs.go
+++ b/pkg/fuse/vaultfs.go
@@ -53,14 +53,6 @@ type VaultFS struct {
 	inodeToPath map[uint64]string
 	nextInode   uint64
 
-	// rootCache caches the secret-name list at the root.
-	rootCache       []string
-	rootCacheExpiry time.Time
-
-	// secretCache caches per-secret field maps so that Lookup → GetAttr →
-	// Open from the kernel for a single field share one server round-trip.
-	secretCache map[string]secretCacheEntry
-
 	// openFiles snapshots field bytes at Open() time so that revoke during
 	// an open FD never produces a post-revoke value (Row F).
 	openFiles map[uint64]*vaultOpenFile
@@ -70,17 +62,13 @@ type VaultFS struct {
 	gid uint32
 }
 
-type secretCacheEntry struct {
-	fields map[string]string
-	expiry time.Time
-}
-
 type vaultOpenFile struct {
 	data []byte
 }
 
-// NewVaultFS builds a read-only vault filesystem bound to c. dirTTL controls
-// how long secret-list / field-map results are cached before refresh.
+// NewVaultFS builds a read-only vault filesystem bound to c. dirTTL is used
+// as the kernel entry/attr TTL hint only — there is intentionally no
+// in-process auth-decision cache (see listSecrets for the Row E rationale).
 func NewVaultFS(c *client.Client, dirTTL time.Duration) *VaultFS {
 	if dirTTL <= 0 {
 		dirTTL = 5 * time.Second
@@ -92,7 +80,6 @@ func NewVaultFS(c *client.Client, dirTTL time.Duration) *VaultFS {
 		pathToInode:   make(map[string]uint64),
 		inodeToPath:   make(map[uint64]string),
 		nextInode:     2, // 1 is reserved for root
-		secretCache:   make(map[string]secretCacheEntry),
 		openFiles:     make(map[uint64]*vaultOpenFile),
 		uid:           uint32(os.Getuid()),
 		gid:           uint32(os.Getgid()),
@@ -123,51 +110,23 @@ func (fs *VaultFS) pathForInode(ino uint64) (string, bool) {
 	return p, ok
 }
 
-// listSecrets returns the cached or freshly-fetched list of readable secrets.
+// listSecrets fetches the list of readable secrets fresh on every call.
+//
+// ❌ No in-process caching. Row E (new-op-after-revoke → EACCES) REQUIRES
+// that the very next lookup/readdir after server-side revocation returns
+// EACCES; any in-process cache served during a TTL window would create a
+// fail-open hole. DirTTL is used only as a kernel entry/attr TTL hint (so
+// the kernel may skip repeated Lookup/GetAttr roundtrips), not as an
+// in-process auth decision cache. Inner helpers intentionally have no
+// memoisation.
 func (fs *VaultFS) listSecrets(ctx context.Context) ([]string, error) {
-	fs.mu.Lock()
-	if time.Now().Before(fs.rootCacheExpiry) && fs.rootCache != nil {
-		out := append([]string(nil), fs.rootCache...)
-		fs.mu.Unlock()
-		return out, nil
-	}
-	fs.mu.Unlock()
-
-	secrets, err := fs.client.ListReadableVaultSecrets(ctx)
-	if err != nil {
-		return nil, err
-	}
-	fs.mu.Lock()
-	fs.rootCache = append([]string(nil), secrets...)
-	fs.rootCacheExpiry = time.Now().Add(fs.dirTTL)
-	fs.mu.Unlock()
-	return secrets, nil
+	return fs.client.ListReadableVaultSecrets(ctx)
 }
 
-// readSecret returns the cached or freshly-fetched field map for secretName.
+// readSecret fetches a secret's field map fresh on every call. See the
+// docstring on listSecrets for why no in-process cache exists.
 func (fs *VaultFS) readSecret(ctx context.Context, secretName string) (map[string]string, error) {
-	fs.mu.Lock()
-	if entry, ok := fs.secretCache[secretName]; ok && time.Now().Before(entry.expiry) {
-		out := make(map[string]string, len(entry.fields))
-		for k, v := range entry.fields {
-			out[k] = v
-		}
-		fs.mu.Unlock()
-		return out, nil
-	}
-	fs.mu.Unlock()
-
-	fields, err := fs.client.ReadVaultSecret(ctx, secretName)
-	if err != nil {
-		return nil, err
-	}
-	fs.mu.Lock()
-	fs.secretCache[secretName] = secretCacheEntry{
-		fields: fields,
-		expiry: time.Now().Add(fs.dirTTL),
-	}
-	fs.mu.Unlock()
-	return fields, nil
+	return fs.client.ReadVaultSecret(ctx, secretName)
 }
 
 // splitPath turns "/secret/field" into ("secret", "field"). Empty components
@@ -451,11 +410,6 @@ func (fs *VaultFS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofus
 	fs.openSeq++
 	fh := fs.openSeq
 	fs.openFiles[fh] = &vaultOpenFile{data: snapshot}
-	// Refresh the secretCache so neighbouring lookups see a coherent size.
-	fs.secretCache[secretName] = secretCacheEntry{
-		fields: fields,
-		expiry: time.Now().Add(fs.dirTTL),
-	}
 	fs.mu.Unlock()
 
 	out.Fh = fh

--- a/pkg/fuse/vaultfs.go
+++ b/pkg/fuse/vaultfs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -352,6 +353,11 @@ func (fs *VaultFS) readDirCommon(cancel <-chan struct{}, input *gofuse.ReadIn, o
 		}
 	}
 
+	// Stable order across paginated ReadDir calls — fields come from a Go map
+	// whose iteration order is nondeterministic, so without a sort the kernel
+	// could see entries skipped or duplicated across successive Offsets.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
+
 	for i := int(input.Offset); i < len(entries); i++ {
 		e := entries[i]
 		de := gofuse.DirEntry{Name: e.name, Ino: e.ino, Mode: e.mode}
@@ -426,15 +432,20 @@ func (fs *VaultFS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte
 	if !ok {
 		return nil, gofuse.EBADF
 	}
-	off := int64(input.Offset)
-	if off >= int64(len(of.data)) {
+	// input.Offset is uint64 and can exceed math.MaxInt64. Validate bounds in
+	// uint64 space, and only narrow to int after proving safety so a hostile
+	// ^uint64(0) offset cannot produce a negative slice index.
+	dataLen := uint64(len(of.data))
+	if input.Offset >= dataLen {
 		return gofuse.ReadResultData(nil), gofuse.OK
 	}
-	end := off + int64(len(buf))
-	if end > int64(len(of.data)) {
-		end = int64(len(of.data))
+	end := input.Offset + uint64(len(buf))
+	// end < input.Offset detects uint64 wraparound; end > dataLen clamps a
+	// read that would run past EOF.
+	if end < input.Offset || end > dataLen {
+		end = dataLen
 	}
-	return gofuse.ReadResultData(of.data[off:end]), gofuse.OK
+	return gofuse.ReadResultData(of.data[int(input.Offset):int(end)]), gofuse.OK
 }
 
 func (fs *VaultFS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {

--- a/pkg/fuse/vaultfs_test.go
+++ b/pkg/fuse/vaultfs_test.go
@@ -1,0 +1,366 @@
+package fuse
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeVaultServer is the test double for /v1/vault/read[/<name>].
+//
+// Witness tests for V2e contract rows interact with VaultFS through this
+// server so that revocation, value-rotation, and TTL behaviour can be
+// driven deterministically — no live tenant required.
+type fakeVaultServer struct {
+	mu sync.Mutex
+
+	// Underlying state.
+	secrets   []string
+	fields    map[string]map[string]string
+	revoked   bool
+	listCalls int32
+	readCalls int32
+}
+
+func newFakeVault() *fakeVaultServer {
+	return &fakeVaultServer{fields: map[string]map[string]string{}}
+}
+
+func (f *fakeVaultServer) setSecrets(secrets []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.secrets = append([]string(nil), secrets...)
+}
+
+func (f *fakeVaultServer) setField(secret, field, value string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.fields[secret] == nil {
+		f.fields[secret] = map[string]string{}
+	}
+	f.fields[secret][field] = value
+}
+
+func (f *fakeVaultServer) revoke() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.revoked = true
+}
+
+func (f *fakeVaultServer) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/vault/read", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		revoked := f.revoked
+		secrets := append([]string(nil), f.secrets...)
+		f.mu.Unlock()
+		atomic.AddInt32(&f.listCalls, 1)
+		if revoked {
+			http.Error(w, `{"error":"revoked"}`, http.StatusForbidden)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"secrets": secrets})
+	})
+	mux.HandleFunc("/v1/vault/read/", func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimPrefix(r.URL.Path, "/v1/vault/read/")
+		f.mu.Lock()
+		revoked := f.revoked
+		fields, hasSecret := f.fields[name]
+		copyFields := map[string]string{}
+		for k, v := range fields {
+			copyFields[k] = v
+		}
+		f.mu.Unlock()
+		atomic.AddInt32(&f.readCalls, 1)
+		if revoked {
+			http.Error(w, `{"error":"revoked"}`, http.StatusForbidden)
+			return
+		}
+		if !hasSecret {
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(copyFields)
+	})
+	return mux
+}
+
+func newTestVaultFS(t *testing.T, ttl time.Duration) (*VaultFS, *fakeVaultServer, func()) {
+	t.Helper()
+	fv := newFakeVault()
+	srv := httptest.NewServer(fv.handler())
+	c := client.NewWithToken(srv.URL, "test-token")
+	vfs := NewVaultFS(c, ttl)
+	return vfs, fv, srv.Close
+}
+
+// lookupRoot performs Lookup(root, name) and returns the resulting NodeId.
+func lookupRoot(t *testing.T, vfs *VaultFS, name string) (uint64, gofuse.Status) {
+	t.Helper()
+	hdr := &gofuse.InHeader{NodeId: 1}
+	out := &gofuse.EntryOut{}
+	st := vfs.Lookup(nil, hdr, name, out)
+	return out.NodeId, st
+}
+
+func lookupChild(t *testing.T, vfs *VaultFS, parentIno uint64, name string) (uint64, uint64, gofuse.Status) {
+	t.Helper()
+	hdr := &gofuse.InHeader{NodeId: parentIno}
+	out := &gofuse.EntryOut{}
+	st := vfs.Lookup(nil, hdr, name, out)
+	return out.NodeId, out.Attr.Size, st
+}
+
+// ---------------------------------------------------------------------------
+// Row C — read-only enforcement.
+// Witness: every mutating op returns EROFS even when the path looks plausible.
+// ---------------------------------------------------------------------------
+
+func TestVaultMountReadOnly(t *testing.T) {
+	vfs, fv, cleanup := newTestVaultFS(t, 5*time.Second)
+	defer cleanup()
+	fv.setSecrets([]string{"alpha"})
+	fv.setField("alpha", "key", "v1")
+
+	mkdirIn := &gofuse.MkdirIn{InHeader: gofuse.InHeader{NodeId: 1}}
+	st := vfs.Mkdir(nil, mkdirIn, "newdir", &gofuse.EntryOut{})
+	require.Equal(t, gofuse.EROFS, st, "mkdir under root must be EROFS")
+
+	st = vfs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, "alpha")
+	require.Equal(t, gofuse.EROFS, st, "unlink under root must be EROFS")
+
+	st = vfs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "alpha")
+	require.Equal(t, gofuse.EROFS, st, "rmdir must be EROFS")
+
+	createIn := &gofuse.CreateIn{InHeader: gofuse.InHeader{NodeId: 1}}
+	st = vfs.Create(nil, createIn, "x", &gofuse.CreateOut{})
+	require.Equal(t, gofuse.EROFS, st, "create must be EROFS")
+
+	writeIn := &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: 1}}
+	_, st = vfs.Write(nil, writeIn, []byte("hi"))
+	require.Equal(t, gofuse.EROFS, st, "write must be EROFS")
+
+	setattrIn := &gofuse.SetAttrIn{SetAttrInCommon: gofuse.SetAttrInCommon{InHeader: gofuse.InHeader{NodeId: 1}}}
+	st = vfs.SetAttr(nil, setattrIn, &gofuse.AttrOut{})
+	require.Equal(t, gofuse.EROFS, st, "setattr must be EROFS")
+
+	// Open with write flags must also be refused.
+	alphaIno, st := lookupRoot(t, vfs, "alpha")
+	require.True(t, st.Ok(), "lookup alpha should succeed")
+	keyIno, _, st := lookupChild(t, vfs, alphaIno, "key")
+	require.True(t, st.Ok(), "lookup alpha/key should succeed")
+	openIn := &gofuse.OpenIn{InHeader: gofuse.InHeader{NodeId: keyIno}, Flags: 0x0001 /* O_WRONLY */}
+	st = vfs.Open(nil, openIn, &gofuse.OpenOut{})
+	require.Equal(t, gofuse.EROFS, st, "open(O_WRONLY) on field must be EROFS")
+}
+
+// ---------------------------------------------------------------------------
+// Row D — delegated scope visibility.
+// Witness: root listing returns exactly the server-published set; lookup of a
+// secret outside that set returns ENOENT (Invariant #7 — server is the
+// authority, but the client must not invent extra entries either).
+// ---------------------------------------------------------------------------
+
+func TestVaultMountScopeVisibility(t *testing.T) {
+	vfs, fv, cleanup := newTestVaultFS(t, 5*time.Second)
+	defer cleanup()
+	fv.setSecrets([]string{"visible"})
+	fv.setField("visible", "f1", "x")
+	fv.setField("hidden", "f2", "y") // populated but NOT in the published list
+
+	ino, st := lookupRoot(t, vfs, "visible")
+	require.True(t, st.Ok())
+	require.NotZero(t, ino)
+
+	// "hidden" must not be reachable via root readdir even though the field
+	// map is internally populated — the bearer cannot see it.
+	_, st = lookupRoot(t, vfs, "hidden")
+	require.Equal(t, gofuse.ENOENT, st, "secret outside published scope must be ENOENT at root lookup")
+}
+
+// ---------------------------------------------------------------------------
+// Row E — new operation after revoke must surface as EACCES.
+// Witness: after server flips to 403, the next readdir/lookup propagates
+// EACCES once the cached list expires.
+// ---------------------------------------------------------------------------
+
+func TestVaultMountNewOpAfterRevokeEACCES(t *testing.T) {
+	const ttl = 100 * time.Millisecond
+	vfs, fv, cleanup := newTestVaultFS(t, ttl)
+	defer cleanup()
+	fv.setSecrets([]string{"alpha"})
+	fv.setField("alpha", "k", "v1")
+
+	// Warm up: succeeds.
+	_, st := lookupRoot(t, vfs, "alpha")
+	require.True(t, st.Ok())
+
+	// Revoke at the server.
+	fv.revoke()
+
+	// Eventually, after cache expires, a new lookup must surface EACCES
+	// (Row E — *new* op after revoke).
+	require.Eventually(t, func() bool {
+		_, st := lookupRoot(t, vfs, "alpha")
+		return st == gofuse.EACCES
+	}, 5*time.Second, 25*time.Millisecond, "new lookup after revoke must surface EACCES once TTL expires")
+}
+
+// ---------------------------------------------------------------------------
+// Row F — existing FD after revoke must NEVER serve a post-revoke value.
+// Witness: open snapshot is V1; server rotates to V2 and revokes; reads from
+// the held FD return V1 forever, never V2 (and never a post-revoke fetch).
+// ---------------------------------------------------------------------------
+
+func TestVaultMountRevokeExistingFD_NeverServesPostRevokeValue(t *testing.T) {
+	vfs, fv, cleanup := newTestVaultFS(t, 100*time.Millisecond)
+	defer cleanup()
+	fv.setSecrets([]string{"alpha"})
+	fv.setField("alpha", "k", "V1")
+
+	alphaIno, st := lookupRoot(t, vfs, "alpha")
+	require.True(t, st.Ok())
+	keyIno, _, st := lookupChild(t, vfs, alphaIno, "k")
+	require.True(t, st.Ok())
+
+	openIn := &gofuse.OpenIn{InHeader: gofuse.InHeader{NodeId: keyIno}, Flags: 0}
+	openOut := &gofuse.OpenOut{}
+	st = vfs.Open(nil, openIn, openOut)
+	require.True(t, st.Ok(), "open should succeed pre-revoke")
+	fh := openOut.Fh
+
+	// Mutate value and revoke at the server.
+	fv.setField("alpha", "k", "V2-NEVER-SERVE")
+	fv.revoke()
+
+	// Hammer reads on the held FD over a window > TTL. Each must return
+	// V1 (the open-time snapshot). The held FD must NEVER produce V2,
+	// regardless of how long we wait.
+	deadline := time.Now().Add(500 * time.Millisecond) // > 5×TTL
+	for time.Now().Before(deadline) {
+		buf := make([]byte, 64)
+		readIn := &gofuse.ReadIn{InHeader: gofuse.InHeader{NodeId: keyIno}, Fh: fh, Offset: 0, Size: uint32(len(buf))}
+		rr, st := vfs.Read(nil, readIn, buf)
+		require.True(t, st.Ok(), "read on held FD must not error post-revoke (snapshot lives in memory)")
+		out, _ := rr.Bytes(buf)
+		require.NotContains(t, string(out), "V2", "held FD must NEVER serve a post-revoke value")
+		require.Equal(t, "V1", string(out))
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Row G — state-after-settle. After a server-side put, eventual readdir/
+// lookup reflects the new value once TTL expires.
+// ---------------------------------------------------------------------------
+
+func TestVaultMountSettleAfterPut(t *testing.T) {
+	const ttl = 100 * time.Millisecond
+	vfs, fv, cleanup := newTestVaultFS(t, ttl)
+	defer cleanup()
+	fv.setSecrets([]string{"alpha"})
+	fv.setField("alpha", "k", "before")
+
+	alphaIno, st := lookupRoot(t, vfs, "alpha")
+	require.True(t, st.Ok())
+	_, sz, st := lookupChild(t, vfs, alphaIno, "k")
+	require.True(t, st.Ok())
+	require.EqualValues(t, len("before"), sz)
+
+	// Update the value server-side (a "put").
+	fv.setField("alpha", "k", "after-put")
+
+	// Eventually, the new size is visible (Row G witness — settle window
+	// = TTL + safety margin per pre-PR contract v4 row G).
+	require.Eventually(t, func() bool {
+		_, sz, st := lookupChild(t, vfs, alphaIno, "k")
+		return st.Ok() && sz == uint64(len("after-put"))
+	}, ttl+5*time.Second, 25*time.Millisecond, "value put must settle within TTL window")
+}
+
+// ---------------------------------------------------------------------------
+// Row H — TTL: cached list survives a full TTL window then refreshes.
+// Witness: list_calls is exactly 1 across N rapid lookups within TTL, then
+// strictly greater than 1 after TTL expires.
+// ---------------------------------------------------------------------------
+
+func TestVaultMountTTL(t *testing.T) {
+	const ttl = 100 * time.Millisecond
+	vfs, fv, cleanup := newTestVaultFS(t, ttl)
+	defer cleanup()
+	fv.setSecrets([]string{"alpha", "beta"})
+	fv.setField("alpha", "k", "x")
+	fv.setField("beta", "k", "y")
+
+	// Warm up.
+	_, st := lookupRoot(t, vfs, "alpha")
+	require.True(t, st.Ok())
+	initial := atomic.LoadInt32(&fv.listCalls)
+
+	// Hammer many lookups well within TTL — list_calls must NOT grow.
+	for i := 0; i < 20; i++ {
+		_, st := lookupRoot(t, vfs, "beta")
+		require.True(t, st.Ok())
+	}
+	require.Equal(t, initial, atomic.LoadInt32(&fv.listCalls), "lookups within TTL must reuse cache")
+
+	// Wait past TTL; the next call should refresh.
+	time.Sleep(ttl + 50*time.Millisecond)
+	_, st = lookupRoot(t, vfs, "alpha")
+	require.True(t, st.Ok())
+	require.Greater(t, atomic.LoadInt32(&fv.listCalls), initial, "lookup after TTL expiry must refresh")
+}
+
+// ---------------------------------------------------------------------------
+// Row I — empty-scope = EACCES. Mount probe rejects a credential whose
+// readable-secret list is empty.
+// ---------------------------------------------------------------------------
+
+func TestVaultMountEmptyScopeRejected(t *testing.T) {
+	fv := newFakeVault()
+	srv := httptest.NewServer(fv.handler())
+	defer srv.Close()
+	// secrets list is empty by default.
+
+	tmp := t.TempDir()
+	opts := &VaultMountOptions{
+		Server:     srv.URL,
+		Token:      "test-token",
+		MountPoint: tmp,
+		DirTTL:     100 * time.Millisecond,
+	}
+	err := MountVault(opts)
+	require.Error(t, err, "empty scope must reject mount")
+	require.Contains(t, err.Error(), "EACCES", "rejection must surface EACCES contract per Row I")
+}
+
+// ---------------------------------------------------------------------------
+// Row I (companion) — revoked credential at probe time also rejected.
+// ---------------------------------------------------------------------------
+
+func TestVaultMountRevokedCredentialRejected(t *testing.T) {
+	fv := newFakeVault()
+	fv.setSecrets([]string{"alpha"})
+	fv.revoke()
+	srv := httptest.NewServer(fv.handler())
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	opts := &VaultMountOptions{
+		Server:     srv.URL,
+		Token:      "revoked-token",
+		MountPoint: tmp,
+		DirTTL:     100 * time.Millisecond,
+	}
+	err := MountVault(opts)
+	require.Error(t, err, "revoked credential must reject mount")
+}

--- a/pkg/fuse/vaultfs_test.go
+++ b/pkg/fuse/vaultfs_test.go
@@ -189,30 +189,42 @@ func TestVaultMountScopeVisibility(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // Row E — new operation after revoke must surface as EACCES.
-// Witness: after server flips to 403, the next readdir/lookup propagates
-// EACCES once the cached list expires.
+// Witness: there is NO TTL-sized fail-open window. Each FUSE op hits the
+// server, so the very NEXT op after revoke returns EACCES — no wait, no
+// Eventually. An in-process cache would violate this row (see the
+// docstring on VaultFS.listSecrets for why there is no such cache).
 // ---------------------------------------------------------------------------
 
 func TestVaultMountNewOpAfterRevokeEACCES(t *testing.T) {
-	const ttl = 100 * time.Millisecond
-	vfs, fv, cleanup := newTestVaultFS(t, ttl)
+	vfs, fv, cleanup := newTestVaultFS(t, 5*time.Second)
 	defer cleanup()
 	fv.setSecrets([]string{"alpha"})
 	fv.setField("alpha", "k", "v1")
 
-	// Warm up: succeeds.
+	// Warm up: succeeds. This also populates any hypothetical cache — if
+	// one ever regresses into the code, the post-revoke assertion below
+	// will catch it.
 	_, st := lookupRoot(t, vfs, "alpha")
+	require.True(t, st.Ok())
+	alphaIno, st := lookupRoot(t, vfs, "alpha")
+	require.True(t, st.Ok())
+	keyIno, _, st := lookupChild(t, vfs, alphaIno, "k")
 	require.True(t, st.Ok())
 
 	// Revoke at the server.
 	fv.revoke()
 
-	// Eventually, after cache expires, a new lookup must surface EACCES
-	// (Row E — *new* op after revoke).
-	require.Eventually(t, func() bool {
-		_, st := lookupRoot(t, vfs, "alpha")
-		return st == gofuse.EACCES
-	}, 5*time.Second, 25*time.Millisecond, "new lookup after revoke must surface EACCES once TTL expires")
+	// IMMEDIATE — the NEXT op is already EACCES. No Eventually, no TTL wait.
+	_, st = lookupRoot(t, vfs, "alpha")
+	require.Equal(t, gofuse.EACCES, st, "next root Lookup after revoke must be EACCES (no TTL fail-open)")
+
+	_, _, st = lookupChild(t, vfs, alphaIno, "k")
+	require.Equal(t, gofuse.EACCES, st, "next field Lookup after revoke must be EACCES (no TTL fail-open)")
+
+	// GetAttr on a previously-known field inode must also refuse.
+	attrIn := &gofuse.GetAttrIn{InHeader: gofuse.InHeader{NodeId: keyIno}}
+	attrSt := vfs.GetAttr(nil, attrIn, &gofuse.AttrOut{})
+	require.Equal(t, gofuse.EACCES, attrSt, "GetAttr on field inode after revoke must be EACCES")
 }
 
 // ---------------------------------------------------------------------------
@@ -288,36 +300,25 @@ func TestVaultMountSettleAfterPut(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Row H — TTL: cached list survives a full TTL window then refreshes.
-// Witness: list_calls is exactly 1 across N rapid lookups within TTL, then
-// strictly greater than 1 after TTL expires.
+// Row H — no in-process cache: every lookup hits the server.
+// Witness: N lookups produce N server calls (DirTTL is a kernel hint only,
+// not an in-process auth cache — see Row E rationale in listSecrets).
 // ---------------------------------------------------------------------------
 
-func TestVaultMountTTL(t *testing.T) {
-	const ttl = 100 * time.Millisecond
-	vfs, fv, cleanup := newTestVaultFS(t, ttl)
+func TestVaultMountNoInProcessCache(t *testing.T) {
+	vfs, fv, cleanup := newTestVaultFS(t, 5*time.Second)
 	defer cleanup()
-	fv.setSecrets([]string{"alpha", "beta"})
+	fv.setSecrets([]string{"alpha"})
 	fv.setField("alpha", "k", "x")
-	fv.setField("beta", "k", "y")
 
-	// Warm up.
-	_, st := lookupRoot(t, vfs, "alpha")
-	require.True(t, st.Ok())
-	initial := atomic.LoadInt32(&fv.listCalls)
-
-	// Hammer many lookups well within TTL — list_calls must NOT grow.
-	for i := 0; i < 20; i++ {
-		_, st := lookupRoot(t, vfs, "beta")
+	before := atomic.LoadInt32(&fv.listCalls)
+	const N = 5
+	for i := 0; i < N; i++ {
+		_, st := lookupRoot(t, vfs, "alpha")
 		require.True(t, st.Ok())
 	}
-	require.Equal(t, initial, atomic.LoadInt32(&fv.listCalls), "lookups within TTL must reuse cache")
-
-	// Wait past TTL; the next call should refresh.
-	time.Sleep(ttl + 50*time.Millisecond)
-	_, st = lookupRoot(t, vfs, "alpha")
-	require.True(t, st.Ok())
-	require.Greater(t, atomic.LoadInt32(&fv.listCalls), initial, "lookup after TTL expiry must refresh")
+	after := atomic.LoadInt32(&fv.listCalls)
+	require.Equal(t, int32(N), after-before, "every lookup must hit the server (no in-process cache)")
 }
 
 // ---------------------------------------------------------------------------
@@ -363,4 +364,36 @@ func TestVaultMountRevokedCredentialRejected(t *testing.T) {
 	}
 	err := MountVault(opts)
 	require.Error(t, err, "revoked credential must reject mount")
+}
+
+// ---------------------------------------------------------------------------
+// Row I (Blocker 2 regression) — owner with zero secrets MUST be allowed.
+// An owner API key with an empty vault is a normal new-tenant startup state;
+// only delegated tokens are rejected for empty scope.
+// ---------------------------------------------------------------------------
+
+func TestVaultMountOwnerEmptyVaultAllowed(t *testing.T) {
+	fv := newFakeVault()
+	// secrets list is empty — simulates a fresh tenant with no secrets yet.
+	srv := httptest.NewServer(fv.handler())
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	opts := &VaultMountOptions{
+		Server:     srv.URL,
+		APIKey:     "owner-key", // owner, not delegated
+		MountPoint: tmp,
+		DirTTL:     100 * time.Millisecond,
+	}
+	// MountVault will try to actually FUSE-mount, which we can't do in
+	// unit tests. But the probe (Row I) runs BEFORE the mount call, so
+	// if the probe wrongly rejects an owner with empty secrets, we'd get
+	// an EACCES error. We verify it does NOT return an EACCES error.
+	err := MountVault(opts)
+	// We expect an error (FUSE mount will fail in test env), but it must
+	// NOT be the "no readable secrets (EACCES)" rejection.
+	if err != nil {
+		require.NotContains(t, err.Error(), "EACCES",
+			"owner with empty vault must NOT be rejected with EACCES")
+	}
 }

--- a/pkg/fuse/vaultfs_test.go
+++ b/pkg/fuse/vaultfs_test.go
@@ -407,9 +407,11 @@ func TestVaultMountRevokedCredentialRejected(t *testing.T) {
 		MountPoint: tmp,
 		DirTTL:     100 * time.Millisecond,
 	}
-	err := MountVault(opts)
+	// Exercise the probe directly — the server returns 401 for revoked tokens,
+	// which must propagate as a non-nil error before any FUSE wiring.
+	_, _, err := probeVaultMount(opts)
 	if err == nil {
-		t.Fatalf("MountVault with revoked credential returned nil error, want non-nil")
+		t.Fatalf("probeVaultMount with revoked credential returned nil error, want non-nil")
 	}
 }
 
@@ -438,11 +440,17 @@ func TestVaultMountEmptyScopeAllowed(t *testing.T) {
 			defer srv.Close()
 
 			tmp := t.TempDir()
-			err := MountVault(tc.opts(srv.URL, tmp))
-			// FUSE mount will fail in test env, but the probe must NOT
-			// produce an EACCES rejection for empty scope.
-			if err != nil && strings.Contains(err.Error(), "EACCES") {
-				t.Fatalf("%s with empty vault returned EACCES: %v (must NOT be rejected for empty scope)", tc.name, err)
+			// Exercise the probe directly, not the full MountVault path:
+			// MountVault blocks on server.Wait() once the FUSE mount succeeds
+			// (which it can on Linux CI with /dev/fuse available), while this
+			// test only cares about the probe verdict — empty scope must NOT
+			// be rejected with EACCES for either owner or delegated callers.
+			_, secrets, err := probeVaultMount(tc.opts(srv.URL, tmp))
+			if err != nil {
+				t.Fatalf("%s: probeVaultMount with empty vault returned %v, want nil", tc.name, err)
+			}
+			if len(secrets) != 0 {
+				t.Fatalf("%s: expected empty secret list, got %v", tc.name, secrets)
 			}
 		})
 	}

--- a/pkg/fuse/vaultfs_test.go
+++ b/pkg/fuse/vaultfs_test.go
@@ -502,3 +502,54 @@ func TestVaultMountReadOffsetOverflowSafe(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// readDirCommon must apply the same uint64-overflow hardening as Read: a
+// ReadDir/ReadDirPlus call with input.Offset = ^uint64(0) used to narrow to
+// int(-1) and panic with "index out of range [-1]". Validate in uint64 space
+// before narrowing; any past-end offset returns an empty page.
+// ---------------------------------------------------------------------------
+
+func TestVaultMountReadDirOffsetOverflowSafe(t *testing.T) {
+	vfs, fv, cleanup := newTestVaultFS(t, 5*time.Second)
+	defer cleanup()
+	fv.setSecrets([]string{"alpha", "beta"})
+	fv.setField("alpha", "f1", "x")
+	fv.setField("alpha", "f2", "y")
+
+	// Exercise both root (listSecrets path) and secret-directory (readSecret
+	// path). Each must survive a hostile Offset without panicking.
+	alphaIno, st := lookupRoot(t, vfs, "alpha")
+	if !st.Ok() {
+		t.Fatalf("lookup alpha status = %v, want OK", st)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		nodeID uint64
+	}{
+		{"root", 1},
+		{"secret-dir", alphaIno},
+	} {
+		for _, offset := range []uint64{
+			^uint64(0),      // math.MaxUint64
+			^uint64(0) - 10, // near-max
+			uint64(1) << 63, // math.MaxInt64+1 (first int64 overflow)
+		} {
+			readIn := &gofuse.ReadIn{InHeader: gofuse.InHeader{NodeId: tc.nodeID}, Offset: offset, Size: 4096}
+			// 4 KiB backing buffer matches what the kernel hands us for a
+			// normal directory read.
+			buf := make([]byte, 4096)
+			out := gofuse.NewDirEntryList(buf, offset)
+			// Both ReadDir and ReadDirPlus go through readDirCommon; smoke
+			// both so a future divergence can't hide a regression.
+			if st := vfs.ReadDir(nil, readIn, out); !st.Ok() {
+				t.Fatalf("%s ReadDir(offset=%#x) status = %v, want OK (must not panic)", tc.name, offset, st)
+			}
+			out2 := gofuse.NewDirEntryList(make([]byte, 4096), offset)
+			if st := vfs.ReadDirPlus(nil, readIn, out2); !st.Ok() {
+				t.Fatalf("%s ReadDirPlus(offset=%#x) status = %v, want OK (must not panic)", tc.name, offset, st)
+			}
+		}
+	}
+}

--- a/pkg/fuse/vaultfs_test.go
+++ b/pkg/fuse/vaultfs_test.go
@@ -12,7 +12,6 @@ import (
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/mem9-ai/dat9/pkg/client"
-	"github.com/stretchr/testify/require"
 )
 
 // fakeVaultServer is the test double for /v1/vault/read[/<name>].
@@ -118,7 +117,9 @@ func lookupChild(t *testing.T, vfs *VaultFS, parentIno uint64, name string) (uin
 	hdr := &gofuse.InHeader{NodeId: parentIno}
 	out := &gofuse.EntryOut{}
 	st := vfs.Lookup(nil, hdr, name, out)
-	return out.NodeId, out.Attr.Size, st
+	// out.Size — Attr is embedded in EntryOut; the explicit selector trips
+	// staticcheck QF1008.
+	return out.NodeId, out.Size, st
 }
 
 // ---------------------------------------------------------------------------
@@ -134,34 +135,52 @@ func TestVaultMountReadOnly(t *testing.T) {
 
 	mkdirIn := &gofuse.MkdirIn{InHeader: gofuse.InHeader{NodeId: 1}}
 	st := vfs.Mkdir(nil, mkdirIn, "newdir", &gofuse.EntryOut{})
-	require.Equal(t, gofuse.EROFS, st, "mkdir under root must be EROFS")
+	if st != gofuse.EROFS {
+		t.Fatalf("mkdir under root status = %v, want EROFS", st)
+	}
 
 	st = vfs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, "alpha")
-	require.Equal(t, gofuse.EROFS, st, "unlink under root must be EROFS")
+	if st != gofuse.EROFS {
+		t.Fatalf("unlink under root status = %v, want EROFS", st)
+	}
 
 	st = vfs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "alpha")
-	require.Equal(t, gofuse.EROFS, st, "rmdir must be EROFS")
+	if st != gofuse.EROFS {
+		t.Fatalf("rmdir status = %v, want EROFS", st)
+	}
 
 	createIn := &gofuse.CreateIn{InHeader: gofuse.InHeader{NodeId: 1}}
 	st = vfs.Create(nil, createIn, "x", &gofuse.CreateOut{})
-	require.Equal(t, gofuse.EROFS, st, "create must be EROFS")
+	if st != gofuse.EROFS {
+		t.Fatalf("create status = %v, want EROFS", st)
+	}
 
 	writeIn := &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: 1}}
 	_, st = vfs.Write(nil, writeIn, []byte("hi"))
-	require.Equal(t, gofuse.EROFS, st, "write must be EROFS")
+	if st != gofuse.EROFS {
+		t.Fatalf("write status = %v, want EROFS", st)
+	}
 
 	setattrIn := &gofuse.SetAttrIn{SetAttrInCommon: gofuse.SetAttrInCommon{InHeader: gofuse.InHeader{NodeId: 1}}}
 	st = vfs.SetAttr(nil, setattrIn, &gofuse.AttrOut{})
-	require.Equal(t, gofuse.EROFS, st, "setattr must be EROFS")
+	if st != gofuse.EROFS {
+		t.Fatalf("setattr status = %v, want EROFS", st)
+	}
 
 	// Open with write flags must also be refused.
 	alphaIno, st := lookupRoot(t, vfs, "alpha")
-	require.True(t, st.Ok(), "lookup alpha should succeed")
+	if !st.Ok() {
+		t.Fatalf("lookup alpha status = %v, want OK", st)
+	}
 	keyIno, _, st := lookupChild(t, vfs, alphaIno, "key")
-	require.True(t, st.Ok(), "lookup alpha/key should succeed")
+	if !st.Ok() {
+		t.Fatalf("lookup alpha/key status = %v, want OK", st)
+	}
 	openIn := &gofuse.OpenIn{InHeader: gofuse.InHeader{NodeId: keyIno}, Flags: 0x0001 /* O_WRONLY */}
 	st = vfs.Open(nil, openIn, &gofuse.OpenOut{})
-	require.Equal(t, gofuse.EROFS, st, "open(O_WRONLY) on field must be EROFS")
+	if st != gofuse.EROFS {
+		t.Fatalf("open(O_WRONLY) on field status = %v, want EROFS", st)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -179,13 +198,19 @@ func TestVaultMountScopeVisibility(t *testing.T) {
 	fv.setField("hidden", "f2", "y") // populated but NOT in the published list
 
 	ino, st := lookupRoot(t, vfs, "visible")
-	require.True(t, st.Ok())
-	require.NotZero(t, ino)
+	if !st.Ok() {
+		t.Fatalf("lookup visible status = %v, want OK", st)
+	}
+	if ino == 0 {
+		t.Fatalf("lookup visible returned zero NodeId")
+	}
 
 	// "hidden" must not be reachable via root readdir even though the field
 	// map is internally populated — the bearer cannot see it.
 	_, st = lookupRoot(t, vfs, "hidden")
-	require.Equal(t, gofuse.ENOENT, st, "secret outside published scope must be ENOENT at root lookup")
+	if st != gofuse.ENOENT {
+		t.Fatalf("lookup hidden status = %v, want ENOENT (outside published scope)", st)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -206,26 +231,38 @@ func TestVaultMountNewOpAfterRevokeEACCES(t *testing.T) {
 	// one ever regresses into the code, the post-revoke assertion below
 	// will catch it.
 	_, st := lookupRoot(t, vfs, "alpha")
-	require.True(t, st.Ok())
+	if !st.Ok() {
+		t.Fatalf("warmup lookup status = %v, want OK", st)
+	}
 	alphaIno, st := lookupRoot(t, vfs, "alpha")
-	require.True(t, st.Ok())
+	if !st.Ok() {
+		t.Fatalf("lookup alpha status = %v, want OK", st)
+	}
 	keyIno, _, st := lookupChild(t, vfs, alphaIno, "k")
-	require.True(t, st.Ok())
+	if !st.Ok() {
+		t.Fatalf("lookup alpha/k status = %v, want OK", st)
+	}
 
 	// Revoke at the server.
 	fv.revoke()
 
 	// IMMEDIATE — the NEXT op is already EACCES. No Eventually, no TTL wait.
 	_, st = lookupRoot(t, vfs, "alpha")
-	require.Equal(t, gofuse.EACCES, st, "next root Lookup after revoke must be EACCES (no TTL fail-open)")
+	if st != gofuse.EACCES {
+		t.Fatalf("next root Lookup after revoke status = %v, want EACCES (no TTL fail-open)", st)
+	}
 
 	_, _, st = lookupChild(t, vfs, alphaIno, "k")
-	require.Equal(t, gofuse.EACCES, st, "next field Lookup after revoke must be EACCES (no TTL fail-open)")
+	if st != gofuse.EACCES {
+		t.Fatalf("next field Lookup after revoke status = %v, want EACCES (no TTL fail-open)", st)
+	}
 
 	// GetAttr on a previously-known field inode must also refuse.
 	attrIn := &gofuse.GetAttrIn{InHeader: gofuse.InHeader{NodeId: keyIno}}
 	attrSt := vfs.GetAttr(nil, attrIn, &gofuse.AttrOut{})
-	require.Equal(t, gofuse.EACCES, attrSt, "GetAttr on field inode after revoke must be EACCES")
+	if attrSt != gofuse.EACCES {
+		t.Fatalf("GetAttr on field inode after revoke status = %v, want EACCES", attrSt)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -241,14 +278,20 @@ func TestVaultMountRevokeExistingFD_NeverServesPostRevokeValue(t *testing.T) {
 	fv.setField("alpha", "k", "V1")
 
 	alphaIno, st := lookupRoot(t, vfs, "alpha")
-	require.True(t, st.Ok())
+	if !st.Ok() {
+		t.Fatalf("lookup alpha status = %v, want OK", st)
+	}
 	keyIno, _, st := lookupChild(t, vfs, alphaIno, "k")
-	require.True(t, st.Ok())
+	if !st.Ok() {
+		t.Fatalf("lookup alpha/k status = %v, want OK", st)
+	}
 
 	openIn := &gofuse.OpenIn{InHeader: gofuse.InHeader{NodeId: keyIno}, Flags: 0}
 	openOut := &gofuse.OpenOut{}
 	st = vfs.Open(nil, openIn, openOut)
-	require.True(t, st.Ok(), "open should succeed pre-revoke")
+	if !st.Ok() {
+		t.Fatalf("open pre-revoke status = %v, want OK", st)
+	}
 	fh := openOut.Fh
 
 	// Mutate value and revoke at the server.
@@ -263,10 +306,16 @@ func TestVaultMountRevokeExistingFD_NeverServesPostRevokeValue(t *testing.T) {
 		buf := make([]byte, 64)
 		readIn := &gofuse.ReadIn{InHeader: gofuse.InHeader{NodeId: keyIno}, Fh: fh, Offset: 0, Size: uint32(len(buf))}
 		rr, st := vfs.Read(nil, readIn, buf)
-		require.True(t, st.Ok(), "read on held FD must not error post-revoke (snapshot lives in memory)")
+		if !st.Ok() {
+			t.Fatalf("read on held FD post-revoke status = %v, want OK (snapshot lives in memory)", st)
+		}
 		out, _ := rr.Bytes(buf)
-		require.NotContains(t, string(out), "V2", "held FD must NEVER serve a post-revoke value")
-		require.Equal(t, "V1", string(out))
+		if strings.Contains(string(out), "V2") {
+			t.Fatalf("held FD served post-revoke value %q; must NEVER contain V2", string(out))
+		}
+		if string(out) != "V1" {
+			t.Fatalf("held FD read = %q, want V1", string(out))
+		}
 		time.Sleep(20 * time.Millisecond)
 	}
 }
@@ -284,20 +333,33 @@ func TestVaultMountSettleAfterPut(t *testing.T) {
 	fv.setField("alpha", "k", "before")
 
 	alphaIno, st := lookupRoot(t, vfs, "alpha")
-	require.True(t, st.Ok())
+	if !st.Ok() {
+		t.Fatalf("lookup alpha status = %v, want OK", st)
+	}
 	_, sz, st := lookupChild(t, vfs, alphaIno, "k")
-	require.True(t, st.Ok())
-	require.EqualValues(t, len("before"), sz)
+	if !st.Ok() {
+		t.Fatalf("lookup alpha/k status = %v, want OK", st)
+	}
+	if sz != uint64(len("before")) {
+		t.Fatalf("initial size = %d, want %d", sz, len("before"))
+	}
 
 	// Update the value server-side (a "put").
 	fv.setField("alpha", "k", "after-put")
 
 	// Eventually, the new size is visible (Row G witness — settle window
 	// = TTL + safety margin per pre-PR contract v4 row G).
-	require.Eventually(t, func() bool {
+	deadline := time.Now().Add(ttl + 5*time.Second)
+	for {
 		_, sz, st := lookupChild(t, vfs, alphaIno, "k")
-		return st.Ok() && sz == uint64(len("after-put"))
-	}, ttl+5*time.Second, 25*time.Millisecond, "value put must settle within TTL window")
+		if st.Ok() && sz == uint64(len("after-put")) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("value put did not settle within TTL window (last sz = %d, st = %v)", sz, st)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -316,10 +378,14 @@ func TestVaultMountNoInProcessCache(t *testing.T) {
 	const N = 5
 	for i := 0; i < N; i++ {
 		_, st := lookupRoot(t, vfs, "alpha")
-		require.True(t, st.Ok())
+		if !st.Ok() {
+			t.Fatalf("lookup #%d status = %v, want OK", i, st)
+		}
 	}
 	after := atomic.LoadInt32(&fv.listCalls)
-	require.Equal(t, int32(N), after-before, "every lookup must hit the server (no in-process cache)")
+	if got := after - before; got != int32(N) {
+		t.Fatalf("listCalls delta = %d, want %d (every lookup must hit the server, no in-process cache)", got, N)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -342,7 +408,9 @@ func TestVaultMountRevokedCredentialRejected(t *testing.T) {
 		DirTTL:     100 * time.Millisecond,
 	}
 	err := MountVault(opts)
-	require.Error(t, err, "revoked credential must reject mount")
+	if err == nil {
+		t.Fatalf("MountVault with revoked credential returned nil error, want non-nil")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -373,10 +441,56 @@ func TestVaultMountEmptyScopeAllowed(t *testing.T) {
 			err := MountVault(tc.opts(srv.URL, tmp))
 			// FUSE mount will fail in test env, but the probe must NOT
 			// produce an EACCES rejection for empty scope.
-			if err != nil {
-				require.NotContains(t, err.Error(), "EACCES",
-					"%s with empty vault must NOT be rejected with EACCES", tc.name)
+			if err != nil && strings.Contains(err.Error(), "EACCES") {
+				t.Fatalf("%s with empty vault returned EACCES: %v (must NOT be rejected for empty scope)", tc.name, err)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Read must guard input.Offset (uint64) against math.MaxInt64 overflow and
+// uint64 wraparound when computing end = offset + len(buf). A hostile
+// ^uint64(0) offset or a near-max offset + buf_len wrap must be rejected as
+// empty read, never panic with a negative slice index.
+// ---------------------------------------------------------------------------
+
+func TestVaultMountReadOffsetOverflowSafe(t *testing.T) {
+	vfs, fv, cleanup := newTestVaultFS(t, 5*time.Second)
+	defer cleanup()
+	fv.setSecrets([]string{"alpha"})
+	fv.setField("alpha", "k", "payload")
+
+	alphaIno, st := lookupRoot(t, vfs, "alpha")
+	if !st.Ok() {
+		t.Fatalf("lookup alpha status = %v, want OK", st)
+	}
+	keyIno, _, st := lookupChild(t, vfs, alphaIno, "k")
+	if !st.Ok() {
+		t.Fatalf("lookup alpha/k status = %v, want OK", st)
+	}
+
+	openIn := &gofuse.OpenIn{InHeader: gofuse.InHeader{NodeId: keyIno}, Flags: 0}
+	openOut := &gofuse.OpenOut{}
+	if st := vfs.Open(nil, openIn, openOut); !st.Ok() {
+		t.Fatalf("open status = %v, want OK", st)
+	}
+	fh := openOut.Fh
+
+	for _, offset := range []uint64{
+		^uint64(0),               // math.MaxUint64
+		^uint64(0) - 10,          // near-max; offset + len(buf) wraps
+		uint64(1) << 63,          // math.MaxInt64+1 (first offset that overflows int64)
+	} {
+		buf := make([]byte, 64)
+		readIn := &gofuse.ReadIn{InHeader: gofuse.InHeader{NodeId: keyIno}, Fh: fh, Offset: offset, Size: uint32(len(buf))}
+		rr, rst := vfs.Read(nil, readIn, buf)
+		if !rst.Ok() {
+			t.Fatalf("Read(offset=%#x) status = %v, want OK (must not panic or error)", offset, rst)
+		}
+		out, _ := rr.Bytes(buf)
+		if len(out) != 0 {
+			t.Fatalf("Read(offset=%#x) returned %d bytes, want 0 (past-EOF)", offset, len(out))
+		}
 	}
 }

--- a/pkg/fuse/vaultfs_test.go
+++ b/pkg/fuse/vaultfs_test.go
@@ -19,7 +19,8 @@ import (
 //
 // Witness tests for V2e contract rows interact with VaultFS through this
 // server so that revocation, value-rotation, and TTL behaviour can be
-// driven deterministically — no live tenant required.
+// driven deterministically — no live tenant required. Auth failures use 401
+// to match pkg/server/vault.go.
 type fakeVaultServer struct {
 	mu sync.Mutex
 
@@ -65,7 +66,7 @@ func (f *fakeVaultServer) handler() http.Handler {
 		f.mu.Unlock()
 		atomic.AddInt32(&f.listCalls, 1)
 		if revoked {
-			http.Error(w, `{"error":"revoked"}`, http.StatusForbidden)
+			http.Error(w, `{"error":"revoked"}`, http.StatusUnauthorized)
 			return
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"secrets": secrets})
@@ -82,7 +83,7 @@ func (f *fakeVaultServer) handler() http.Handler {
 		f.mu.Unlock()
 		atomic.AddInt32(&f.readCalls, 1)
 		if revoked {
-			http.Error(w, `{"error":"revoked"}`, http.StatusForbidden)
+			http.Error(w, `{"error":"revoked"}`, http.StatusUnauthorized)
 			return
 		}
 		if !hasSecret {
@@ -322,7 +323,7 @@ func TestVaultMountNoInProcessCache(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Row I — revoked credential at probe time is rejected (server returns 403).
+// Row I — revoked credential at probe time is rejected (server returns 401).
 // Empty scope (zero secrets, valid token) is NOT rejected — see vault_mount.go.
 // ---------------------------------------------------------------------------
 
@@ -348,7 +349,7 @@ func TestVaultMountRevokedCredentialRejected(t *testing.T) {
 // Row I — empty scope (zero secrets) must NOT be rejected for either
 // principal kind. Owner: normal new-tenant startup. Delegated: valid grant
 // whose scope targets secrets that don't exist yet. Revoked/malformed tokens
-// are caught by the server returning 403, not by counting secrets.
+// are caught by the server returning 401, not by counting secrets.
 // ---------------------------------------------------------------------------
 
 func TestVaultMountEmptyScopeAllowed(t *testing.T) {

--- a/pkg/fuse/vaultfs_test.go
+++ b/pkg/fuse/vaultfs_test.go
@@ -322,30 +322,8 @@ func TestVaultMountNoInProcessCache(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Row I — empty-scope = EACCES. Mount probe rejects a credential whose
-// readable-secret list is empty.
-// ---------------------------------------------------------------------------
-
-func TestVaultMountEmptyScopeRejected(t *testing.T) {
-	fv := newFakeVault()
-	srv := httptest.NewServer(fv.handler())
-	defer srv.Close()
-	// secrets list is empty by default.
-
-	tmp := t.TempDir()
-	opts := &VaultMountOptions{
-		Server:     srv.URL,
-		Token:      "test-token",
-		MountPoint: tmp,
-		DirTTL:     100 * time.Millisecond,
-	}
-	err := MountVault(opts)
-	require.Error(t, err, "empty scope must reject mount")
-	require.Contains(t, err.Error(), "EACCES", "rejection must surface EACCES contract per Row I")
-}
-
-// ---------------------------------------------------------------------------
-// Row I (companion) — revoked credential at probe time also rejected.
+// Row I — revoked credential at probe time is rejected (server returns 403).
+// Empty scope (zero secrets, valid token) is NOT rejected — see vault_mount.go.
 // ---------------------------------------------------------------------------
 
 func TestVaultMountRevokedCredentialRejected(t *testing.T) {
@@ -367,33 +345,37 @@ func TestVaultMountRevokedCredentialRejected(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Row I (Blocker 2 regression) — owner with zero secrets MUST be allowed.
-// An owner API key with an empty vault is a normal new-tenant startup state;
-// only delegated tokens are rejected for empty scope.
+// Row I — empty scope (zero secrets) must NOT be rejected for either
+// principal kind. Owner: normal new-tenant startup. Delegated: valid grant
+// whose scope targets secrets that don't exist yet. Revoked/malformed tokens
+// are caught by the server returning 403, not by counting secrets.
 // ---------------------------------------------------------------------------
 
-func TestVaultMountOwnerEmptyVaultAllowed(t *testing.T) {
-	fv := newFakeVault()
-	// secrets list is empty — simulates a fresh tenant with no secrets yet.
-	srv := httptest.NewServer(fv.handler())
-	defer srv.Close()
+func TestVaultMountEmptyScopeAllowed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts func(url string, tmp string) *VaultMountOptions
+	}{
+		{"owner", func(url, tmp string) *VaultMountOptions {
+			return &VaultMountOptions{Server: url, APIKey: "owner-key", MountPoint: tmp, DirTTL: 100 * time.Millisecond}
+		}},
+		{"delegated", func(url, tmp string) *VaultMountOptions {
+			return &VaultMountOptions{Server: url, Token: "delegated-token", MountPoint: tmp, DirTTL: 100 * time.Millisecond}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fv := newFakeVault()
+			srv := httptest.NewServer(fv.handler())
+			defer srv.Close()
 
-	tmp := t.TempDir()
-	opts := &VaultMountOptions{
-		Server:     srv.URL,
-		APIKey:     "owner-key", // owner, not delegated
-		MountPoint: tmp,
-		DirTTL:     100 * time.Millisecond,
-	}
-	// MountVault will try to actually FUSE-mount, which we can't do in
-	// unit tests. But the probe (Row I) runs BEFORE the mount call, so
-	// if the probe wrongly rejects an owner with empty secrets, we'd get
-	// an EACCES error. We verify it does NOT return an EACCES error.
-	err := MountVault(opts)
-	// We expect an error (FUSE mount will fail in test env), but it must
-	// NOT be the "no readable secrets (EACCES)" rejection.
-	if err != nil {
-		require.NotContains(t, err.Error(), "EACCES",
-			"owner with empty vault must NOT be rejected with EACCES")
+			tmp := t.TempDir()
+			err := MountVault(tc.opts(srv.URL, tmp))
+			// FUSE mount will fail in test env, but the probe must NOT
+			// produce an EACCES rejection for empty scope.
+			if err != nil {
+				require.NotContains(t, err.Error(), "EACCES",
+					"%s with empty vault must NOT be rejected with EACCES", tc.name)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Implements V2e sealed contract rows A–I (pre-PR contract v4 double-ACK by adv-1 + adv-2)
- New `drive9 mount vault <path>` subcommand serving a 2-level read-only FUSE namespace `<mount>/<secret>/<field>`
- Held FDs snapshot field bytes at Open() time so revoke/rotate after open NEVER serves a post-revoke value (Row F)

## Contract row → witness mapping
| Row | Contract | Witness test |
|---|---|---|
| A | `mount vault` dispatch surface | structural (`MountCmd` first-arg fork) |
| B | unified credential resolver reuse | covered by existing `TestResolveMountCredentials_*` |
| C | every mutating op → EROFS | `TestVaultMountReadOnly` |
| D | scope visibility = server scope | `TestVaultMountScopeVisibility` |
| E | new op after revoke → EACCES | `TestVaultMountNewOpAfterRevokeEACCES` (uses `require.Eventually`) |
| F | held FD never serves V2 post-revoke | `TestVaultMountRevokeExistingFD_NeverServesPostRevokeValue` |
| G | put settles within DirTTL | `TestVaultMountSettleAfterPut` (uses `require.Eventually`) |
| H | DirTTL controls cache lifetime | `TestVaultMountTTL` |
| I | empty scope → EACCES at probe | `TestVaultMountEmptyScopeRejected` + `TestVaultMountRevokedCredentialRejected` |

## Files
- `pkg/fuse/vaultfs.go` — `VaultFS` (read-only RawFileSystem; per-FD snapshot for Row F)
- `pkg/fuse/vault_mount.go` — `MountVault` entry point + Row I probe
- `pkg/fuse/vaultfs_test.go` — fakeVaultServer + 8 witness tests
- `cmd/drive9/cli/mount.go` — first-arg dispatch fork (Row A)
- `cmd/drive9/cli/mount_vault.go` — `VaultMountCmd` flag surface

## Notes for reviewers
- VaultFS does NOT extend Dat9FS — separate filesystem so write-path code can't accidentally bleed in
- Open() bypasses the per-secret cache and takes a fresh snapshot, the only data the FD will ever serve (Row F)
- `FOPEN_DIRECT_IO` set on every Open so kernel page cache can't mix V1 / V2 across FDs
- Probe (Row I) runs before `gofuse.NewServer` — failure leaves no half-mounted state

Refs #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "drive9 mount vault": mount Vault secrets as a read-only filesystem with server/API-key auth, configurable cache TTL, status reporting, and graceful unmount handling.

* **Bug Fixes / UX**
  * CLI dispatches "vault" to the new mount path while preserving legacy mount behavior for other inputs; legacy mount now enforces exact mountpoint validation.

* **Tests**
  * New tests covering Vault FS behavior (caching, revocation, read semantics) and CLI argument parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->