### PR TITLE
Add automatic schema diff and safe fix for tenant and meta stores

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -146,7 +146,7 @@ func main() {
 	logLocalStartupStep(startupCtx, startupStart, stepStart, "build_backend_options")
 
 	stepStart = time.Now()
-	localEmbeddingMode, err := detectLocalTiDBEmbeddingMode(store.DB(), localInitSchema, requestedEmbeddingMode, explicitEmbeddingMode)
+	localEmbeddingMode, err := detectLocalTiDBEmbeddingMode(startupCtx, store.DB(), localInitSchema, requestedEmbeddingMode, explicitEmbeddingMode)
 	if err != nil {
 		die(fmt.Errorf("detect local embedding mode: %w", err))
 	}
@@ -454,7 +454,7 @@ var (
 	localTiDBSchemaInitializer     = schema.InitTiDBTenantSchemaForModeWithOptionsContext
 )
 
-func detectLocalTiDBEmbeddingMode(db *sql.DB, schemaInitialized bool, requestedMode schema.TiDBEmbeddingMode, explicitMode bool) (schema.TiDBEmbeddingMode, error) {
+func detectLocalTiDBEmbeddingMode(ctx context.Context, db *sql.DB, schemaInitialized bool, requestedMode schema.TiDBEmbeddingMode, explicitMode bool) (schema.TiDBEmbeddingMode, error) {
 	if explicitMode {
 		if schemaInitialized {
 			return requestedMode, nil
@@ -462,7 +462,7 @@ func detectLocalTiDBEmbeddingMode(db *sql.DB, schemaInitialized bool, requestedM
 		if db == nil {
 			return schema.TiDBEmbeddingModeUnknown, fmt.Errorf("nil db")
 		}
-		if err := localTiDBSchemaValidator(db, requestedMode); err != nil {
+		if err := localTiDBSchemaValidator(ctx, db, requestedMode); err != nil {
 			return schema.TiDBEmbeddingModeUnknown, err
 		}
 		return requestedMode, nil
@@ -480,7 +480,7 @@ func detectLocalTiDBEmbeddingMode(db *sql.DB, schemaInitialized bool, requestedM
 	if mode != schema.TiDBEmbeddingModeAuto && mode != schema.TiDBEmbeddingModeApp {
 		return schema.TiDBEmbeddingModeUnknown, fmt.Errorf("unsupported TiDB embedding mode %q", mode)
 	}
-	if err := localTiDBSchemaValidator(db, mode); err != nil {
+	if err := localTiDBSchemaValidator(ctx, db, mode); err != nil {
 		return schema.TiDBEmbeddingModeUnknown, err
 	}
 	return mode, nil

--- a/cmd/drive9-server-local/main_test.go
+++ b/cmd/drive9-server-local/main_test.go
@@ -27,8 +27,9 @@ func TestDetectLocalTiDBEmbeddingMode(t *testing.T) {
 		localTiDBEmbeddingModeDetector = origDetector
 		localTiDBSchemaValidator = origValidator
 	})
+	ctx := context.Background()
 
-	mode, err := detectLocalTiDBEmbeddingMode(nil, true, schema.TiDBEmbeddingModeApp, true)
+	mode, err := detectLocalTiDBEmbeddingMode(ctx, nil, true, schema.TiDBEmbeddingModeApp, true)
 	if err != nil {
 		t.Fatalf("schema-initialized explicit app mode returned error: %v", err)
 	}
@@ -39,7 +40,7 @@ func TestDetectLocalTiDBEmbeddingMode(t *testing.T) {
 	localTiDBEmbeddingModeDetector = func(*sql.DB) (schema.TiDBEmbeddingMode, error) {
 		return schema.TiDBEmbeddingModeUnknown, errors.New("should not be called")
 	}
-	mode, err = detectLocalTiDBEmbeddingMode(nil, true, schema.TiDBEmbeddingModeUnknown, false)
+	mode, err = detectLocalTiDBEmbeddingMode(ctx, nil, true, schema.TiDBEmbeddingModeUnknown, false)
 	if err != nil {
 		t.Fatalf("schema-initialized default mode returned error: %v", err)
 	}
@@ -47,8 +48,8 @@ func TestDetectLocalTiDBEmbeddingMode(t *testing.T) {
 		t.Fatalf("schema-initialized default mode=%q, want %q", mode, schema.TiDBEmbeddingModeAuto)
 	}
 
-	localTiDBSchemaValidator = func(*sql.DB, schema.TiDBEmbeddingMode) error { return nil }
-	mode, err = detectLocalTiDBEmbeddingMode(&sql.DB{}, false, schema.TiDBEmbeddingModeApp, true)
+	localTiDBSchemaValidator = func(context.Context, *sql.DB, schema.TiDBEmbeddingMode) error { return nil }
+	mode, err = detectLocalTiDBEmbeddingMode(ctx, &sql.DB{}, false, schema.TiDBEmbeddingModeApp, true)
 	if err != nil {
 		t.Fatalf("explicit app mode returned error: %v", err)
 	}
@@ -59,7 +60,7 @@ func TestDetectLocalTiDBEmbeddingMode(t *testing.T) {
 	localTiDBEmbeddingModeDetector = func(*sql.DB) (schema.TiDBEmbeddingMode, error) {
 		return schema.TiDBEmbeddingModeAuto, nil
 	}
-	mode, err = detectLocalTiDBEmbeddingMode(&sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false)
+	mode, err = detectLocalTiDBEmbeddingMode(ctx, &sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false)
 	if err != nil {
 		t.Fatalf("detect auto mode returned error: %v", err)
 	}
@@ -70,7 +71,7 @@ func TestDetectLocalTiDBEmbeddingMode(t *testing.T) {
 	localTiDBEmbeddingModeDetector = func(*sql.DB) (schema.TiDBEmbeddingMode, error) {
 		return schema.TiDBEmbeddingModeApp, nil
 	}
-	mode, err = detectLocalTiDBEmbeddingMode(&sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false)
+	mode, err = detectLocalTiDBEmbeddingMode(ctx, &sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false)
 	if err != nil {
 		t.Fatalf("detect app mode returned error: %v", err)
 	}
@@ -81,17 +82,17 @@ func TestDetectLocalTiDBEmbeddingMode(t *testing.T) {
 	localTiDBEmbeddingModeDetector = func(*sql.DB) (schema.TiDBEmbeddingMode, error) {
 		return schema.TiDBEmbeddingModeUnknown, nil
 	}
-	if _, err := detectLocalTiDBEmbeddingMode(&sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false); err == nil {
+	if _, err := detectLocalTiDBEmbeddingMode(ctx, &sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false); err == nil {
 		t.Fatal("expected unknown mode to fail")
 	}
 
 	localTiDBEmbeddingModeDetector = func(*sql.DB) (schema.TiDBEmbeddingMode, error) {
 		return schema.TiDBEmbeddingModeAuto, nil
 	}
-	localTiDBSchemaValidator = func(*sql.DB, schema.TiDBEmbeddingMode) error {
+	localTiDBSchemaValidator = func(context.Context, *sql.DB, schema.TiDBEmbeddingMode) error {
 		return errors.New("bad schema")
 	}
-	if _, err := detectLocalTiDBEmbeddingMode(&sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false); err == nil {
+	if _, err := detectLocalTiDBEmbeddingMode(ctx, &sql.DB{}, false, schema.TiDBEmbeddingModeUnknown, false); err == nil {
 		t.Fatal("expected validation failure to propagate")
 	}
 }

--- a/internal/schemaspec/schemaspec.go
+++ b/internal/schemaspec/schemaspec.go
@@ -1,0 +1,330 @@
+// Package schemaspec provides shared helpers for parsing trusted MySQL/TiDB
+// schema statements and classifying safe repair operations.
+package schemaspec
+
+import (
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"strings"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+// NormalizeSQLFragment lowercases SQL, removes identifier quoting and TiDB's
+// _utf8mb4 marker, and collapses repeated whitespace for stable comparisons.
+func NormalizeSQLFragment(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "`", "")
+	s = strings.ReplaceAll(s, "_utf8mb4", "")
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+// CanonicalStatementForHash normalizes formatting-only differences that remain
+// after whitespace collapsing so schema-version hashing is stable across
+// cosmetic edits.
+func CanonicalStatementForHash(s string) string {
+	normalized := NormalizeSQLFragment(s)
+	for _, replacement := range [][2]string{
+		{" (", "("},
+		{"( ", "("},
+		{" )", ")"},
+		{") ", ")"},
+		{", ", ","},
+		{" ,", ","},
+	} {
+		normalized = strings.ReplaceAll(normalized, replacement[0], replacement[1])
+	}
+	return normalized
+}
+
+// SQLSnippet truncates a statement for logging and error messages.
+func SQLSnippet(stmt string) string {
+	snippet := stmt
+	if len(snippet) > 80 {
+		snippet = snippet[:80]
+	}
+	return snippet
+}
+
+// ParseCreateTableStatement extracts the table name and the top-level column /
+// constraint definition list from trusted CREATE TABLE SQL or SHOW CREATE TABLE
+// output. The scanner is intentionally lightweight and is not intended for
+// arbitrary user-supplied SQL.
+func ParseCreateTableStatement(stmt string) (tableName string, definitions string, ok bool, err error) {
+	lower := strings.ToLower(stmt)
+	prefixes := []string{"create table if not exists", "create table"}
+	start := -1
+	prefixLen := 0
+	for _, prefix := range prefixes {
+		if idx := strings.Index(lower, prefix); idx >= 0 {
+			start = idx
+			prefixLen = len(prefix)
+			break
+		}
+	}
+	if start < 0 {
+		return "", "", false, nil
+	}
+	i := start + prefixLen
+	for i < len(stmt) && (stmt[i] == ' ' || stmt[i] == '\n' || stmt[i] == '\t' || stmt[i] == '\r') {
+		i++
+	}
+	if i >= len(stmt) {
+		return "", "", false, fmt.Errorf("parse create table: missing table name")
+	}
+	nameStart := i
+	if stmt[i] == '`' {
+		i++
+		for i < len(stmt) && stmt[i] != '`' {
+			i++
+		}
+		if i >= len(stmt) {
+			return "", "", false, fmt.Errorf("parse create table: unterminated quoted table name")
+		}
+		tableName = strings.ToLower(stmt[nameStart+1 : i])
+		i++
+	} else {
+		for i < len(stmt) && stmt[i] != ' ' && stmt[i] != '\n' && stmt[i] != '\t' && stmt[i] != '(' {
+			i++
+		}
+		tableName = strings.ToLower(strings.TrimSpace(stmt[nameStart:i]))
+	}
+	for i < len(stmt) && stmt[i] != '(' {
+		i++
+	}
+	if i >= len(stmt) || stmt[i] != '(' {
+		return "", "", false, fmt.Errorf("parse create table %s: missing opening parenthesis", tableName)
+	}
+	bodyStart := i + 1
+	depth := 1
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	for i = bodyStart; i < len(stmt); i++ {
+		ch := stmt[i]
+		switch ch {
+		case '\\':
+			i++
+			continue
+		case '\'':
+			if !inDouble && !inBacktick {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBacktick {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBacktick = !inBacktick
+			}
+		case '(':
+			if !inSingle && !inDouble && !inBacktick {
+				depth++
+			}
+		case ')':
+			if !inSingle && !inDouble && !inBacktick {
+				depth--
+				if depth == 0 {
+					return tableName, stmt[bodyStart:i], true, nil
+				}
+			}
+		}
+	}
+	return "", "", false, fmt.Errorf("parse create table %s: unbalanced parentheses", tableName)
+}
+
+// SplitTopLevelComma splits a comma-delimited definition list while ignoring
+// commas inside nested parentheses or quoted strings / identifiers.
+func SplitTopLevelComma(definitions string) []string {
+	parts := make([]string, 0)
+	start := 0
+	depth := 0
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	for i := 0; i < len(definitions); i++ {
+		ch := definitions[i]
+		switch ch {
+		case '\\':
+			i++
+			continue
+		case '\'':
+			if !inDouble && !inBacktick {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBacktick {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBacktick = !inBacktick
+			}
+		case '(':
+			if !inSingle && !inDouble && !inBacktick {
+				depth++
+			}
+		case ')':
+			if !inSingle && !inDouble && !inBacktick && depth > 0 {
+				depth--
+			}
+		case ',':
+			if !inSingle && !inDouble && !inBacktick && depth == 0 {
+				parts = append(parts, strings.TrimSpace(definitions[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	if start < len(definitions) {
+		parts = append(parts, strings.TrimSpace(definitions[start:]))
+	}
+	return parts
+}
+
+// SplitIdentifierAndRest extracts the first bare or backtick-quoted identifier
+// from a trusted schema fragment and returns the remaining suffix.
+func SplitIdentifierAndRest(s string) (identifier string, rest string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ""
+	}
+	if s[0] == '`' {
+		end := strings.Index(s[1:], "`")
+		if end < 0 {
+			return "", ""
+		}
+		id := s[1 : 1+end]
+		return id, strings.TrimSpace(s[1+end+1:])
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r' {
+			return s[:i], strings.TrimSpace(s[i+1:])
+		}
+	}
+	return s, ""
+}
+
+// ParseColumnType returns the column type prefix from a trusted column
+// definition, stopping before common trailing clauses such as NULL / DEFAULT /
+// COLLATE / CHECK / STORAGE.
+func ParseColumnType(rest string) string {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return ""
+	}
+	keywords := []string{
+		" not ",
+		" null",
+		" default ",
+		" generated ",
+		" as ",
+		" primary ",
+		" unique ",
+		" comment ",
+		" references ",
+		" auto_increment",
+		" on update",
+		" character set ",
+		" collate ",
+		" check ",
+		" storage ",
+		" column_format ",
+	}
+	depth := 0
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	for i := 0; i < len(rest); i++ {
+		ch := rest[i]
+		switch ch {
+		case '\\':
+			i++
+			continue
+		case '\'':
+			if !inDouble && !inBacktick {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBacktick {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBacktick = !inBacktick
+			}
+		case '(':
+			if !inSingle && !inDouble && !inBacktick {
+				depth++
+			}
+		case ')':
+			if !inSingle && !inDouble && !inBacktick && depth > 0 {
+				depth--
+			}
+		}
+		if inSingle || inDouble || inBacktick || depth > 0 {
+			continue
+		}
+		suffix := " " + strings.ToLower(rest[i:])
+		for _, kw := range keywords {
+			if strings.HasPrefix(suffix, kw) {
+				return strings.TrimSpace(rest[:i])
+			}
+		}
+	}
+	return strings.TrimSpace(rest)
+}
+
+// IsSafeAddColumnRepairSQL identifies ALTER TABLE ... ADD COLUMN statements that
+// are safe to auto-apply to live schemas.
+func IsSafeAddColumnRepairSQL(sqlText string) bool {
+	n := NormalizeSQLFragment(sqlText)
+	if !strings.HasPrefix(n, "alter table ") || !strings.Contains(n, " add column ") {
+		return false
+	}
+	if isGeneratedColumnAddSQL(n) {
+		return false
+	}
+	if strings.Contains(n, " not null") && !strings.Contains(n, " default ") {
+		return false
+	}
+	return true
+}
+
+func isGeneratedColumnAddSQL(normalizedSQL string) bool {
+	if strings.Contains(normalizedSQL, " generated ") {
+		return true
+	}
+	if !strings.Contains(normalizedSQL, " as (") {
+		return false
+	}
+	return strings.Contains(normalizedSQL, " stored") || strings.Contains(normalizedSQL, " virtual")
+}
+
+// IsIgnorableMySQLError reports whether a DDL error is benign for idempotent
+// schema repair paths.
+func IsIgnorableMySQLError(err error) bool {
+	var me *mysql.MySQLError
+	if errors.As(err, &me) {
+		switch me.Number {
+		case 1050, 1060, 1061:
+			return true
+		}
+		msg := strings.ToLower(me.Message)
+		return strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate")
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate")
+}
+
+// CRC32Version hashes normalized schema statements and always returns a
+// non-zero integer so callers can use it as a stable schema version marker.
+func CRC32Version(stmts []string) int {
+	h := crc32.ChecksumIEEE([]byte(strings.Join(stmts, "\n")))
+	if h == 0 {
+		h = 1
+	}
+	return int(h)
+}

--- a/internal/schemaspec/schemaspec_test.go
+++ b/internal/schemaspec/schemaspec_test.go
@@ -1,0 +1,34 @@
+package schemaspec
+
+import "testing"
+
+func TestParseColumnTypeStopsAtCharacterSetAndCollate(t *testing.T) {
+	got := ParseColumnType("VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL")
+	if got != "VARCHAR(64)" {
+		t.Fatalf("ParseColumnType()=%q, want %q", got, "VARCHAR(64)")
+	}
+}
+
+func TestParseCreateTableStatementAcceptsShowCreateOutput(t *testing.T) {
+	tableName, defs, ok, err := ParseCreateTableStatement("CREATE TABLE files (file_id VARCHAR(64) PRIMARY KEY, content_text LONGTEXT)")
+	if err != nil {
+		t.Fatalf("ParseCreateTableStatement() error: %v", err)
+	}
+	if !ok {
+		t.Fatal("ParseCreateTableStatement() did not recognize CREATE TABLE")
+	}
+	if tableName != "files" {
+		t.Fatalf("tableName=%q, want %q", tableName, "files")
+	}
+	if defs == "" {
+		t.Fatal("expected non-empty definitions")
+	}
+}
+
+func TestCanonicalStatementForHashIgnoresFormattingOnlySpacing(t *testing.T) {
+	left := CanonicalStatementForHash("CREATE TABLE IF NOT EXISTS example_events (event_id VARCHAR(64) PRIMARY KEY, tenant_id VARCHAR(64) NOT NULL)")
+	right := CanonicalStatementForHash("\nCREATE TABLE IF NOT EXISTS example_events (\n    event_id VARCHAR(64) PRIMARY KEY,\n    tenant_id VARCHAR(64) NOT NULL\n)\n")
+	if left != right {
+		t.Fatalf("CanonicalStatementForHash() mismatch: %q != %q", left, right)
+	}
+}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	mysql "github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/dat9/internal/schemaspec"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/mysqlutil"
@@ -487,111 +487,11 @@ func applyMetaSchemaRepairs(ctx context.Context, db *sql.DB, stmts []string) err
 }
 
 func parseMetaCreateTableStatement(stmt string) (tableName string, definitions string, ok bool, err error) {
-	lower := strings.ToLower(stmt)
-	const prefix = "create table if not exists"
-	pos := strings.Index(lower, prefix)
-	if pos < 0 {
-		return "", "", false, nil
-	}
-	i := pos + len(prefix)
-	for i < len(stmt) && (stmt[i] == ' ' || stmt[i] == '\n' || stmt[i] == '\t' || stmt[i] == '\r') {
-		i++
-	}
-	if i >= len(stmt) {
-		return "", "", false, fmt.Errorf("parse create table: missing table name")
-	}
-	name, rest := splitMetaIdentifierAndRest(stmt[i:])
-	if name == "" {
-		return "", "", false, fmt.Errorf("parse create table: invalid table name")
-	}
-	tableName = strings.ToLower(name)
-	open := strings.Index(rest, "(")
-	if open < 0 {
-		return "", "", false, fmt.Errorf("parse create table %s: missing opening parenthesis", tableName)
-	}
-	bodyStart := i + (len(stmt[i:]) - len(rest)) + open + 1
-	depth := 1
-	inSingle := false
-	inDouble := false
-	inBacktick := false
-	for j := bodyStart; j < len(stmt); j++ {
-		ch := stmt[j]
-		switch ch {
-		case '\\':
-			j++
-			continue
-		case '\'':
-			if !inDouble && !inBacktick {
-				inSingle = !inSingle
-			}
-		case '"':
-			if !inSingle && !inBacktick {
-				inDouble = !inDouble
-			}
-		case '`':
-			if !inSingle && !inDouble {
-				inBacktick = !inBacktick
-			}
-		case '(':
-			if !inSingle && !inDouble && !inBacktick {
-				depth++
-			}
-		case ')':
-			if !inSingle && !inDouble && !inBacktick {
-				depth--
-				if depth == 0 {
-					return tableName, stmt[bodyStart:j], true, nil
-				}
-			}
-		}
-	}
-	return "", "", false, fmt.Errorf("parse create table %s: unbalanced parentheses", tableName)
+	return schemaspec.ParseCreateTableStatement(stmt)
 }
 
 func splitMetaTopLevelComma(definitions string) []string {
-	parts := make([]string, 0)
-	start := 0
-	depth := 0
-	inSingle := false
-	inDouble := false
-	inBacktick := false
-	for i := 0; i < len(definitions); i++ {
-		ch := definitions[i]
-		switch ch {
-		case '\\':
-			i++
-			continue
-		case '\'':
-			if !inDouble && !inBacktick {
-				inSingle = !inSingle
-			}
-		case '"':
-			if !inSingle && !inBacktick {
-				inDouble = !inDouble
-			}
-		case '`':
-			if !inSingle && !inDouble {
-				inBacktick = !inBacktick
-			}
-		case '(':
-			if !inSingle && !inDouble && !inBacktick {
-				depth++
-			}
-		case ')':
-			if !inSingle && !inDouble && !inBacktick && depth > 0 {
-				depth--
-			}
-		case ',':
-			if !inSingle && !inDouble && !inBacktick && depth == 0 {
-				parts = append(parts, strings.TrimSpace(definitions[start:i]))
-				start = i + 1
-			}
-		}
-	}
-	if start < len(definitions) {
-		parts = append(parts, strings.TrimSpace(definitions[start:]))
-	}
-	return parts
+	return schemaspec.SplitTopLevelComma(definitions)
 }
 
 func parseMetaInlineIndexDefinition(tableName, def string) (indexName, createSQL string, ok bool) {
@@ -675,74 +575,11 @@ func parseMetaColumnDefinition(tableName, def string) (string, metaColumnSpec, b
 }
 
 func parseMetaColumnType(rest string) string {
-	rest = strings.TrimSpace(rest)
-	if rest == "" {
-		return ""
-	}
-	keywords := []string{" not ", " null", " default ", " generated ", " as ", " primary ", " unique ", " comment ", " references ", " auto_increment", " on update"}
-	depth := 0
-	inSingle := false
-	inDouble := false
-	inBacktick := false
-	for i := 0; i < len(rest); i++ {
-		ch := rest[i]
-		switch ch {
-		case '\\':
-			i++
-			continue
-		case '\'':
-			if !inDouble && !inBacktick {
-				inSingle = !inSingle
-			}
-		case '"':
-			if !inSingle && !inBacktick {
-				inDouble = !inDouble
-			}
-		case '`':
-			if !inSingle && !inDouble {
-				inBacktick = !inBacktick
-			}
-		case '(':
-			if !inSingle && !inDouble && !inBacktick {
-				depth++
-			}
-		case ')':
-			if !inSingle && !inDouble && !inBacktick && depth > 0 {
-				depth--
-			}
-		}
-		if inSingle || inDouble || inBacktick || depth > 0 {
-			continue
-		}
-		suffix := " " + strings.ToLower(rest[i:])
-		for _, kw := range keywords {
-			if strings.HasPrefix(suffix, kw) {
-				return strings.TrimSpace(rest[:i])
-			}
-		}
-	}
-	return strings.TrimSpace(rest)
+	return schemaspec.ParseColumnType(rest)
 }
 
 func splitMetaIdentifierAndRest(s string) (identifier string, rest string) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", ""
-	}
-	if s[0] == '`' {
-		end := strings.Index(s[1:], "`")
-		if end < 0 {
-			return "", ""
-		}
-		id := s[1 : 1+end]
-		return id, strings.TrimSpace(s[1+end+1:])
-	}
-	for i := 0; i < len(s); i++ {
-		if s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r' {
-			return s[:i], strings.TrimSpace(s[i+1:])
-		}
-	}
-	return s, ""
+	return schemaspec.SplitIdentifierAndRest(s)
 }
 
 func isMetaConstraintDefinition(def string) bool {
@@ -771,39 +608,11 @@ func isSafeMetaRepairDiff(diff metaSchemaDiff, tableMissing map[string]bool) boo
 }
 
 func isSafeAddColumnRepairSQL(sqlText string) bool {
-	n := normalizeMetaSQLFragment(sqlText)
-	if !strings.HasPrefix(n, "alter table ") || !strings.Contains(n, " add column ") {
-		return false
-	}
-	// Reject generated columns in any form: GENERATED ALWAYS AS / AS (...) STORED / AS (...) VIRTUAL
-	if strings.Contains(n, " generated ") {
-		return false
-	}
-	if strings.Contains(n, " as (") &&
-		(strings.Contains(n, " stored") || strings.Contains(n, " virtual")) {
-		return false
-	}
-	if strings.Contains(n, " not null") && !strings.Contains(n, " default ") {
-		return false
-	}
-	return true
+	return schemaspec.IsSafeAddColumnRepairSQL(sqlText)
 }
 
 func isIgnorableMetaSchemaError(err error) bool {
-	var me *mysql.MySQLError
-	if errors.As(err, &me) {
-		switch me.Number {
-		case 1050, 1060, 1061:
-			return true
-		}
-		msg := strings.ToLower(me.Message)
-		if strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate") {
-			return true
-		}
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate")
+	return schemaspec.IsIgnorableMySQLError(err)
 }
 
 func loadMetaTableMeta(ctx context.Context, db *sql.DB, tableName string) (metaTableMeta, error) {
@@ -843,11 +652,7 @@ func loadMetaShowCreateTable(ctx context.Context, db *sql.DB, tableName string) 
 }
 
 func normalizeMetaSQLFragment(s string) string {
-	s = strings.ToLower(s)
-	s = strings.ReplaceAll(s, "`", "")
-	s = strings.ReplaceAll(s, "_utf8mb4", "")
-	fields := strings.Fields(s)
-	return strings.Join(fields, " ")
+	return schemaspec.NormalizeSQLFragment(s)
 }
 
 func sortedMetaColumnNames(columns map[string]metaColumnSpec) []string {
@@ -876,11 +681,7 @@ func showCreateHasMetaIndex(normalizedCreate, indexName string, spec metaIndexSp
 }
 
 func schemaSnippet(stmt string) string {
-	snippet := stmt
-	if len(snippet) > 80 {
-		snippet = snippet[:80]
-	}
-	return snippet
+	return schemaspec.SQLSnippet(stmt)
 }
 
 func (s *Store) InsertTenant(ctx context.Context, t *Tenant) (err error) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1057,6 +1057,25 @@ func (s *Store) UpdateTenantStatus(ctx context.Context, id string, status Tenant
 	return nil
 }
 
+// UpdateTenantSchemaVersion records the tenant DB schema version after a
+// successful ensure/repair cycle.  Callers should treat failures as best-
+// effort: log the error but do not fail the overall operation.
+func (s *Store) UpdateTenantSchemaVersion(ctx context.Context, id string, version int) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_tenant_schema_version", start, &err)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE tenants SET schema_version = ?, updated_at = ? WHERE id = ?`,
+		version, time.Now().UTC(), id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func observeMeta(ctx context.Context, op string, start time.Time, errp *error) {
 	result := "ok"
 	if errp != nil && *errp != nil {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/mysqlutil"
@@ -155,6 +155,7 @@ type metaSchemaDiff struct {
 	kind       metaSchemaDiffKind
 	tableName  string
 	columnName string
+	indexName  string
 	detail     string
 	repairSQL  string
 }
@@ -191,7 +192,10 @@ type metaColumnSpec struct {
 }
 
 type metaIndexSpec struct {
-	createSQL string
+	createSQL   string
+	isUnique    bool
+	isPrimary   bool
+	isRepairable bool
 }
 
 func metaInitSchemaStatements() []string {
@@ -341,8 +345,12 @@ func parseCreateMetaTableSpec(stmt string) (metaTableSpec, bool, error) {
 		if def == "" {
 			continue
 		}
+		if idxName, idxSpec, ok := parseMetaConstraintIndexDefinition(tableName, def); ok {
+			indexes[idxName] = idxSpec
+			continue
+		}
 		if idxName, idxSQL, ok := parseMetaInlineIndexDefinition(tableName, def); ok {
-			indexes[idxName] = metaIndexSpec{createSQL: idxSQL}
+			indexes[idxName] = metaIndexSpec{createSQL: idxSQL, isRepairable: true, isUnique: strings.Contains(normalizeMetaSQLFragment(idxSQL), "create unique index ")}
 			continue
 		}
 		if isMetaConstraintDefinition(def) {
@@ -351,6 +359,10 @@ func parseCreateMetaTableSpec(stmt string) (metaTableSpec, bool, error) {
 		colName, colSpec, ok := parseMetaColumnDefinition(tableName, def)
 		if ok {
 			columns[colName] = colSpec
+			normalizedDef := normalizeMetaSQLFragment(def)
+			if strings.Contains(normalizedDef, " primary key") {
+				indexes["primary"] = metaIndexSpec{isPrimary: true, isRepairable: false}
+			}
 		}
 	}
 	return metaTableSpec{
@@ -420,11 +432,16 @@ func diffMetaTableMeta(table metaTableSpec, meta metaTableMeta, createStmt strin
 	normalizedCreate := normalizeMetaSQLFragment(createStmt)
 	for _, name := range sortedMetaIndexNames(table.indexes) {
 		spec := table.indexes[name]
-		if !strings.Contains(normalizedCreate, name+" (") {
+		if !showCreateHasMetaIndex(normalizedCreate, name, spec) {
+			detail := fmt.Sprintf("%s schema contract: missing %s index", table.name, name)
+			if spec.isPrimary {
+				detail = fmt.Sprintf("%s schema contract: missing primary key constraint", table.name)
+			}
 			diffs = append(diffs, metaSchemaDiff{
 				kind:      metaSchemaDiffMissingIndex,
 				tableName: table.name,
-				detail:    fmt.Sprintf("%s schema contract: missing %s index", table.name, name),
+				indexName: name,
+				detail:    detail,
 				repairSQL: spec.createSQL,
 			})
 		}
@@ -433,10 +450,20 @@ func diffMetaTableMeta(table metaTableSpec, meta metaTableMeta, createStmt strin
 }
 
 func plannedMetaSchemaRepairs(diffs []metaSchemaDiff) []string {
+	tableMissing := make(map[string]bool)
+	for _, diff := range diffs {
+		if diff.kind == metaSchemaDiffMissingTable {
+			tableMissing[diff.tableName] = true
+		}
+	}
+
 	seen := make(map[string]struct{})
 	plans := make([]string, 0, len(diffs))
 	for _, diff := range diffs {
 		if diff.repairSQL == "" {
+			continue
+		}
+		if !isSafeMetaRepairDiff(diff, tableMissing) {
 			continue
 		}
 		if _, ok := seen[diff.repairSQL]; ok {
@@ -451,6 +478,9 @@ func plannedMetaSchemaRepairs(diffs []metaSchemaDiff) []string {
 func applyMetaSchemaRepairs(db *sql.DB, stmts []string) error {
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
+			if isIgnorableMetaSchemaError(err) {
+				continue
+			}
 			return fmt.Errorf("apply meta schema repair %q: %w", schemaSnippet(stmt), err)
 		}
 	}
@@ -584,6 +614,37 @@ func parseMetaInlineIndexDefinition(tableName, def string) (indexName, createSQL
 	return "", "", false
 }
 
+func parseMetaConstraintIndexDefinition(tableName, def string) (indexName string, spec metaIndexSpec, ok bool) {
+	n := normalizeMetaSQLFragment(def)
+	if strings.HasPrefix(n, "primary key") {
+		return "primary", metaIndexSpec{isPrimary: true, isRepairable: false}, true
+	}
+	if strings.HasPrefix(n, "unique key ") {
+		name, cols := parseMetaIndexNameAndColumns(def, "UNIQUE KEY")
+		if name == "" || cols == "" {
+			return "", metaIndexSpec{}, false
+		}
+		return name, metaIndexSpec{
+			createSQL:    fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols),
+			isUnique:     true,
+			isRepairable: false,
+		}, true
+	}
+	if strings.HasPrefix(n, "constraint ") && strings.Contains(n, " unique key ") {
+		// CONSTRAINT name UNIQUE KEY idx_name (...) -> parse using UNIQUE KEY token.
+		name, cols := parseMetaIndexNameAndColumns(def, "UNIQUE KEY")
+		if name == "" || cols == "" {
+			return "", metaIndexSpec{}, false
+		}
+		return name, metaIndexSpec{
+			createSQL:    fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols),
+			isUnique:     true,
+			isRepairable: false,
+		}, true
+	}
+	return "", metaIndexSpec{}, false
+}
+
 func parseMetaIndexNameAndColumns(def, prefix string) (indexName, columns string) {
 	trimmed := strings.TrimSpace(def)
 	upper := strings.ToUpper(trimmed)
@@ -694,6 +755,57 @@ func isMetaConstraintDefinition(def string) bool {
 	return strings.HasPrefix(n, "primary key") || strings.HasPrefix(n, "constraint ") || strings.HasPrefix(n, "unique key ")
 }
 
+func isSafeMetaRepairDiff(diff metaSchemaDiff, tableMissing map[string]bool) bool {
+	switch diff.kind {
+	case metaSchemaDiffMissingTable:
+		return true
+	case metaSchemaDiffMissingColumn:
+		return isSafeAddColumnRepairSQL(diff.repairSQL)
+	case metaSchemaDiffMissingIndex:
+		normalized := normalizeMetaSQLFragment(diff.repairSQL)
+		if strings.HasPrefix(normalized, "create index ") {
+			return true
+		}
+		if strings.HasPrefix(normalized, "create unique index ") {
+			return tableMissing[diff.tableName]
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func isSafeAddColumnRepairSQL(sqlText string) bool {
+	n := normalizeMetaSQLFragment(sqlText)
+	if !strings.HasPrefix(n, "alter table ") || !strings.Contains(n, " add column ") {
+		return false
+	}
+	if strings.Contains(n, " generated ") {
+		return false
+	}
+	if strings.Contains(n, " not null") && !strings.Contains(n, " default ") {
+		return false
+	}
+	return true
+}
+
+func isIgnorableMetaSchemaError(err error) bool {
+	var me *mysql.MySQLError
+	if errors.As(err, &me) {
+		switch me.Number {
+		case 1050, 1060, 1061:
+			return true
+		}
+		msg := strings.ToLower(me.Message)
+		if strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate") {
+			return true
+		}
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate")
+}
+
 func loadMetaTableMeta(db *sql.DB, tableName string) (metaTableMeta, error) {
 	rows, err := db.Query(`SELECT column_name, column_type
 		FROM information_schema.columns
@@ -754,6 +866,13 @@ func sortedMetaIndexNames(indexes map[string]metaIndexSpec) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+func showCreateHasMetaIndex(normalizedCreate, indexName string, spec metaIndexSpec) bool {
+	if spec.isPrimary {
+		return strings.Contains(normalizedCreate, "primary key (")
+	}
+	return strings.Contains(normalizedCreate, indexName+" (")
 }
 
 func schemaSnippet(stmt string) string {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -111,19 +111,20 @@ func applyMySQLPoolDefaults(db *sql.DB) {
 }
 
 func (s *Store) migrate() error {
+	ctx := context.Background()
 	stmts := metaInitSchemaStatements()
 	spec, err := metaSchemaSpecFromStatements(stmts)
 	if err != nil {
 		return fmt.Errorf("parse meta schema statements: %w", err)
 	}
-	diffs, err := diffMetaSchema(s.db, spec)
+	diffs, err := diffMetaSchema(ctx, s.db, spec)
 	if err != nil {
 		return fmt.Errorf("diff meta schema: %w", err)
 	}
-	if err := applyMetaSchemaRepairs(s.db, plannedMetaSchemaRepairs(diffs)); err != nil {
+	if err := applyMetaSchemaRepairs(ctx, s.db, plannedMetaSchemaRepairs(diffs)); err != nil {
 		return err
 	}
-	diffs, err = diffMetaSchema(s.db, spec)
+	diffs, err = diffMetaSchema(ctx, s.db, spec)
 	if err != nil {
 		return fmt.Errorf("re-diff meta schema: %w", err)
 	}
@@ -192,10 +193,8 @@ type metaColumnSpec struct {
 }
 
 type metaIndexSpec struct {
-	createSQL   string
-	isUnique    bool
-	isPrimary   bool
-	isRepairable bool
+	createSQL string
+	isPrimary bool
 }
 
 func metaInitSchemaStatements() []string {
@@ -350,7 +349,7 @@ func parseCreateMetaTableSpec(stmt string) (metaTableSpec, bool, error) {
 			continue
 		}
 		if idxName, idxSQL, ok := parseMetaInlineIndexDefinition(tableName, def); ok {
-			indexes[idxName] = metaIndexSpec{createSQL: idxSQL, isRepairable: true, isUnique: strings.Contains(normalizeMetaSQLFragment(idxSQL), "create unique index ")}
+			indexes[idxName] = metaIndexSpec{createSQL: idxSQL}
 			continue
 		}
 		if isMetaConstraintDefinition(def) {
@@ -361,7 +360,7 @@ func parseCreateMetaTableSpec(stmt string) (metaTableSpec, bool, error) {
 			columns[colName] = colSpec
 			normalizedDef := normalizeMetaSQLFragment(def)
 			if strings.Contains(normalizedDef, " primary key") {
-				indexes["primary"] = metaIndexSpec{isPrimary: true, isRepairable: false}
+				indexes["primary"] = metaIndexSpec{isPrimary: true}
 			}
 		}
 	}
@@ -373,10 +372,10 @@ func parseCreateMetaTableSpec(stmt string) (metaTableSpec, bool, error) {
 	}, true, nil
 }
 
-func diffMetaSchema(db *sql.DB, spec metaSchemaSpec) ([]metaSchemaDiff, error) {
+func diffMetaSchema(ctx context.Context, db *sql.DB, spec metaSchemaSpec) ([]metaSchemaDiff, error) {
 	var diffs []metaSchemaDiff
 	for _, table := range spec.tables {
-		tableDiffs, err := diffMetaTable(db, table)
+		tableDiffs, err := diffMetaTable(ctx, db, table)
 		if err != nil {
 			return nil, err
 		}
@@ -385,8 +384,8 @@ func diffMetaSchema(db *sql.DB, spec metaSchemaSpec) ([]metaSchemaDiff, error) {
 	return diffs, nil
 }
 
-func diffMetaTable(db *sql.DB, table metaTableSpec) ([]metaSchemaDiff, error) {
-	meta, err := loadMetaTableMeta(db, table.name)
+func diffMetaTable(ctx context.Context, db *sql.DB, table metaTableSpec) ([]metaSchemaDiff, error) {
+	meta, err := loadMetaTableMeta(ctx, db, table.name)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return []metaSchemaDiff{{
@@ -398,7 +397,7 @@ func diffMetaTable(db *sql.DB, table metaTableSpec) ([]metaSchemaDiff, error) {
 		}
 		return nil, fmt.Errorf("load %s table metadata: %w", table.name, err)
 	}
-	createStmt, err := loadMetaShowCreateTable(db, table.name)
+	createStmt, err := loadMetaShowCreateTable(ctx, db, table.name)
 	if err != nil {
 		return nil, fmt.Errorf("show create %s: %w", table.name, err)
 	}
@@ -475,9 +474,9 @@ func plannedMetaSchemaRepairs(diffs []metaSchemaDiff) []string {
 	return plans
 }
 
-func applyMetaSchemaRepairs(db *sql.DB, stmts []string) error {
+func applyMetaSchemaRepairs(ctx context.Context, db *sql.DB, stmts []string) error {
 	for _, stmt := range stmts {
-		if _, err := db.Exec(stmt); err != nil {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			if isIgnorableMetaSchemaError(err) {
 				continue
 			}
@@ -617,7 +616,7 @@ func parseMetaInlineIndexDefinition(tableName, def string) (indexName, createSQL
 func parseMetaConstraintIndexDefinition(tableName, def string) (indexName string, spec metaIndexSpec, ok bool) {
 	n := normalizeMetaSQLFragment(def)
 	if strings.HasPrefix(n, "primary key") {
-		return "primary", metaIndexSpec{isPrimary: true, isRepairable: false}, true
+		return "primary", metaIndexSpec{isPrimary: true}, true
 	}
 	if strings.HasPrefix(n, "unique key ") {
 		name, cols := parseMetaIndexNameAndColumns(def, "UNIQUE KEY")
@@ -625,9 +624,7 @@ func parseMetaConstraintIndexDefinition(tableName, def string) (indexName string
 			return "", metaIndexSpec{}, false
 		}
 		return name, metaIndexSpec{
-			createSQL:    fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols),
-			isUnique:     true,
-			isRepairable: false,
+			createSQL: fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols),
 		}, true
 	}
 	if strings.HasPrefix(n, "constraint ") && strings.Contains(n, " unique key ") {
@@ -637,9 +634,7 @@ func parseMetaConstraintIndexDefinition(tableName, def string) (indexName string
 			return "", metaIndexSpec{}, false
 		}
 		return name, metaIndexSpec{
-			createSQL:    fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols),
-			isUnique:     true,
-			isRepairable: false,
+			createSQL: fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols),
 		}, true
 	}
 	return "", metaIndexSpec{}, false
@@ -780,7 +775,12 @@ func isSafeAddColumnRepairSQL(sqlText string) bool {
 	if !strings.HasPrefix(n, "alter table ") || !strings.Contains(n, " add column ") {
 		return false
 	}
+	// Reject generated columns in any form: GENERATED ALWAYS AS / AS (...) STORED / AS (...) VIRTUAL
 	if strings.Contains(n, " generated ") {
+		return false
+	}
+	if strings.Contains(n, " as (") &&
+		(strings.Contains(n, " stored") || strings.Contains(n, " virtual")) {
 		return false
 	}
 	if strings.Contains(n, " not null") && !strings.Contains(n, " default ") {
@@ -806,8 +806,8 @@ func isIgnorableMetaSchemaError(err error) bool {
 	return strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate")
 }
 
-func loadMetaTableMeta(db *sql.DB, tableName string) (metaTableMeta, error) {
-	rows, err := db.Query(`SELECT column_name, column_type
+func loadMetaTableMeta(ctx context.Context, db *sql.DB, tableName string) (metaTableMeta, error) {
+	rows, err := db.QueryContext(ctx, `SELECT column_name, column_type
 		FROM information_schema.columns
 		WHERE table_schema = DATABASE() AND table_name = ?`, tableName)
 	if err != nil {
@@ -832,11 +832,11 @@ func loadMetaTableMeta(db *sql.DB, tableName string) (metaTableMeta, error) {
 	return metaTableMeta{tableName: tableName, columns: columns}, nil
 }
 
-func loadMetaShowCreateTable(db *sql.DB, tableName string) (string, error) {
+func loadMetaShowCreateTable(ctx context.Context, db *sql.DB, tableName string) (string, error) {
 	var gotTable string
 	var createStmt string
 	query := fmt.Sprintf("SHOW CREATE TABLE %s", tableName)
-	if err := db.QueryRow(query).Scan(&gotTable, &createStmt); err != nil {
+	if err := db.QueryRowContext(ctx, query).Scan(&gotTable, &createStmt); err != nil {
 		return "", err
 	}
 	return createStmt, nil

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -110,7 +111,91 @@ func applyMySQLPoolDefaults(db *sql.DB) {
 }
 
 func (s *Store) migrate() error {
-	stmts := []string{
+	stmts := metaInitSchemaStatements()
+	spec, err := metaSchemaSpecFromStatements(stmts)
+	if err != nil {
+		return fmt.Errorf("parse meta schema statements: %w", err)
+	}
+	diffs, err := diffMetaSchema(s.db, spec)
+	if err != nil {
+		return fmt.Errorf("diff meta schema: %w", err)
+	}
+	if err := applyMetaSchemaRepairs(s.db, plannedMetaSchemaRepairs(diffs)); err != nil {
+		return err
+	}
+	diffs, err = diffMetaSchema(s.db, spec)
+	if err != nil {
+		return fmt.Errorf("re-diff meta schema: %w", err)
+	}
+	if len(diffs) > 0 {
+		return &metaSchemaDiffError{diffs: diffs}
+	}
+	return nil
+}
+
+type metaColumnMeta struct {
+	columnType string
+}
+
+type metaTableMeta struct {
+	tableName string
+	columns   map[string]metaColumnMeta
+}
+
+type metaSchemaDiffKind string
+
+const (
+	metaSchemaDiffMissingTable  metaSchemaDiffKind = "missing_table"
+	metaSchemaDiffMissingColumn metaSchemaDiffKind = "missing_column"
+	metaSchemaDiffMissingIndex  metaSchemaDiffKind = "missing_index"
+	metaSchemaDiffColumnType    metaSchemaDiffKind = "column_type_mismatch"
+)
+
+type metaSchemaDiff struct {
+	kind       metaSchemaDiffKind
+	tableName  string
+	columnName string
+	detail     string
+	repairSQL  string
+}
+
+type metaSchemaDiffError struct {
+	diffs []metaSchemaDiff
+}
+
+func (e *metaSchemaDiffError) Error() string {
+	if e == nil || len(e.diffs) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(e.diffs))
+	for _, d := range e.diffs {
+		parts = append(parts, d.detail)
+	}
+	return "meta schema contract mismatch: " + strings.Join(parts, "; ")
+}
+
+type metaSchemaSpec struct {
+	tables []metaTableSpec
+}
+
+type metaTableSpec struct {
+	name            string
+	createStatement string
+	columns         map[string]metaColumnSpec
+	indexes         map[string]metaIndexSpec
+}
+
+type metaColumnSpec struct {
+	columnType string
+	addSQL     string
+}
+
+type metaIndexSpec struct {
+	createSQL string
+}
+
+func metaInitSchemaStatements() []string {
+	return []string{
 		`CREATE TABLE IF NOT EXISTS tenants (
 			id               VARCHAR(64) PRIMARY KEY,
 			status           VARCHAR(20) NOT NULL DEFAULT 'provisioning',
@@ -147,8 +232,6 @@ func (s *Store) migrate() error {
 			INDEX idx_api_keys_tenant (tenant_id, status),
 			UNIQUE INDEX idx_api_keys_tenant_name (tenant_id, key_name)
 		)`,
-		// --- LLM usage table (PR #245 migration) ---
-
 		`CREATE TABLE IF NOT EXISTS llm_usage (
 			id              BIGINT AUTO_INCREMENT PRIMARY KEY,
 			tenant_id       VARCHAR(64) NOT NULL,
@@ -161,9 +244,6 @@ func (s *Store) migrate() error {
 			INDEX idx_llm_usage_tenant_created (tenant_id, created_at),
 			INDEX idx_llm_usage_created (created_at)
 		)`,
-
-		// --- Quota tables (Rev 4 migration) ---
-
 		`CREATE TABLE IF NOT EXISTS tenant_quota_config (
 			tenant_id             VARCHAR(64) PRIMARY KEY,
 			max_storage_bytes     BIGINT NOT NULL DEFAULT 53687091200,
@@ -172,7 +252,6 @@ func (s *Store) migrate() error {
 			created_at            DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at            DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
 		)`,
-
 		`CREATE TABLE IF NOT EXISTS tenant_quota_usage (
 			tenant_id          VARCHAR(64) PRIMARY KEY,
 			storage_bytes      BIGINT NOT NULL DEFAULT 0,
@@ -180,7 +259,6 @@ func (s *Store) migrate() error {
 			media_file_count   BIGINT NOT NULL DEFAULT 0,
 			updated_at         DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
 		)`,
-
 		`CREATE TABLE IF NOT EXISTS tenant_file_meta (
 			tenant_id    VARCHAR(64) NOT NULL,
 			file_id      VARCHAR(64) NOT NULL,
@@ -190,7 +268,6 @@ func (s *Store) migrate() error {
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			PRIMARY KEY (tenant_id, file_id)
 		)`,
-
 		`CREATE TABLE IF NOT EXISTS tenant_upload_reservations (
 			tenant_id      VARCHAR(64) NOT NULL,
 			upload_id      VARCHAR(64) NOT NULL,
@@ -203,7 +280,6 @@ func (s *Store) migrate() error {
 			PRIMARY KEY (tenant_id, upload_id),
 			INDEX idx_active_reservations (tenant_id, status, expires_at)
 		)`,
-
 		`CREATE TABLE IF NOT EXISTS tenant_llm_usage (
 			id              BIGINT AUTO_INCREMENT PRIMARY KEY,
 			tenant_id       VARCHAR(64) NOT NULL,
@@ -215,14 +291,12 @@ func (s *Store) migrate() error {
 			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			INDEX idx_tenant_month (tenant_id, created_at)
 		)`,
-
 		`CREATE TABLE IF NOT EXISTS tenant_monthly_llm_cost (
 			tenant_id    VARCHAR(64) NOT NULL,
 			month_start  DATE NOT NULL,
 			total_mc     BIGINT NOT NULL DEFAULT 0,
 			PRIMARY KEY (tenant_id, month_start)
 		)`,
-
 		`CREATE TABLE IF NOT EXISTS quota_mutation_log (
 			id             BIGINT AUTO_INCREMENT PRIMARY KEY,
 			tenant_id      VARCHAR(64) NOT NULL,
@@ -236,12 +310,458 @@ func (s *Store) migrate() error {
 			INDEX idx_tenant_order (tenant_id, id)
 		)`,
 	}
+}
+
+func metaSchemaSpecFromStatements(stmts []string) (metaSchemaSpec, error) {
+	tables := make([]metaTableSpec, 0)
 	for _, stmt := range stmts {
-		if _, err := s.db.Exec(stmt); err != nil {
-			return err
+		table, ok, err := parseCreateMetaTableSpec(stmt)
+		if err != nil {
+			return metaSchemaSpec{}, err
+		}
+		if ok {
+			tables = append(tables, table)
+		}
+	}
+	return metaSchemaSpec{tables: tables}, nil
+}
+
+func parseCreateMetaTableSpec(stmt string) (metaTableSpec, bool, error) {
+	tableName, defs, ok, err := parseMetaCreateTableStatement(stmt)
+	if err != nil {
+		return metaTableSpec{}, false, err
+	}
+	if !ok {
+		return metaTableSpec{}, false, nil
+	}
+	columns := make(map[string]metaColumnSpec)
+	indexes := make(map[string]metaIndexSpec)
+	for _, def := range splitMetaTopLevelComma(defs) {
+		def = strings.TrimSpace(def)
+		if def == "" {
+			continue
+		}
+		if idxName, idxSQL, ok := parseMetaInlineIndexDefinition(tableName, def); ok {
+			indexes[idxName] = metaIndexSpec{createSQL: idxSQL}
+			continue
+		}
+		if isMetaConstraintDefinition(def) {
+			continue
+		}
+		colName, colSpec, ok := parseMetaColumnDefinition(tableName, def)
+		if ok {
+			columns[colName] = colSpec
+		}
+	}
+	return metaTableSpec{
+		name:            tableName,
+		createStatement: strings.TrimSpace(stmt),
+		columns:         columns,
+		indexes:         indexes,
+	}, true, nil
+}
+
+func diffMetaSchema(db *sql.DB, spec metaSchemaSpec) ([]metaSchemaDiff, error) {
+	var diffs []metaSchemaDiff
+	for _, table := range spec.tables {
+		tableDiffs, err := diffMetaTable(db, table)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, tableDiffs...)
+	}
+	return diffs, nil
+}
+
+func diffMetaTable(db *sql.DB, table metaTableSpec) ([]metaSchemaDiff, error) {
+	meta, err := loadMetaTableMeta(db, table.name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return []metaSchemaDiff{{
+				kind:      metaSchemaDiffMissingTable,
+				tableName: table.name,
+				detail:    fmt.Sprintf("%s schema contract: missing table", table.name),
+				repairSQL: table.createStatement,
+			}}, nil
+		}
+		return nil, fmt.Errorf("load %s table metadata: %w", table.name, err)
+	}
+	createStmt, err := loadMetaShowCreateTable(db, table.name)
+	if err != nil {
+		return nil, fmt.Errorf("show create %s: %w", table.name, err)
+	}
+	return diffMetaTableMeta(table, meta, createStmt), nil
+}
+
+func diffMetaTableMeta(table metaTableSpec, meta metaTableMeta, createStmt string) []metaSchemaDiff {
+	var diffs []metaSchemaDiff
+	for _, name := range sortedMetaColumnNames(table.columns) {
+		spec := table.columns[name]
+		col, ok := meta.columns[name]
+		if !ok {
+			diffs = append(diffs, metaSchemaDiff{
+				kind:       metaSchemaDiffMissingColumn,
+				tableName:  table.name,
+				columnName: name,
+				detail:     fmt.Sprintf("%s schema contract: missing %s column", table.name, name),
+				repairSQL:  spec.addSQL,
+			})
+			continue
+		}
+		if normalizeMetaSQLFragment(col.columnType) != normalizeMetaSQLFragment(spec.columnType) {
+			diffs = append(diffs, metaSchemaDiff{
+				kind:       metaSchemaDiffColumnType,
+				tableName:  table.name,
+				columnName: name,
+				detail:     fmt.Sprintf("%s schema contract: %s column type = %q, want %s", table.name, name, col.columnType, spec.columnType),
+			})
+		}
+	}
+	normalizedCreate := normalizeMetaSQLFragment(createStmt)
+	for _, name := range sortedMetaIndexNames(table.indexes) {
+		spec := table.indexes[name]
+		if !strings.Contains(normalizedCreate, name+" (") {
+			diffs = append(diffs, metaSchemaDiff{
+				kind:      metaSchemaDiffMissingIndex,
+				tableName: table.name,
+				detail:    fmt.Sprintf("%s schema contract: missing %s index", table.name, name),
+				repairSQL: spec.createSQL,
+			})
+		}
+	}
+	return diffs
+}
+
+func plannedMetaSchemaRepairs(diffs []metaSchemaDiff) []string {
+	seen := make(map[string]struct{})
+	plans := make([]string, 0, len(diffs))
+	for _, diff := range diffs {
+		if diff.repairSQL == "" {
+			continue
+		}
+		if _, ok := seen[diff.repairSQL]; ok {
+			continue
+		}
+		seen[diff.repairSQL] = struct{}{}
+		plans = append(plans, diff.repairSQL)
+	}
+	return plans
+}
+
+func applyMetaSchemaRepairs(db *sql.DB, stmts []string) error {
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("apply meta schema repair %q: %w", schemaSnippet(stmt), err)
 		}
 	}
 	return nil
+}
+
+func parseMetaCreateTableStatement(stmt string) (tableName string, definitions string, ok bool, err error) {
+	lower := strings.ToLower(stmt)
+	const prefix = "create table if not exists"
+	pos := strings.Index(lower, prefix)
+	if pos < 0 {
+		return "", "", false, nil
+	}
+	i := pos + len(prefix)
+	for i < len(stmt) && (stmt[i] == ' ' || stmt[i] == '\n' || stmt[i] == '\t' || stmt[i] == '\r') {
+		i++
+	}
+	if i >= len(stmt) {
+		return "", "", false, fmt.Errorf("parse create table: missing table name")
+	}
+	name, rest := splitMetaIdentifierAndRest(stmt[i:])
+	if name == "" {
+		return "", "", false, fmt.Errorf("parse create table: invalid table name")
+	}
+	tableName = strings.ToLower(name)
+	open := strings.Index(rest, "(")
+	if open < 0 {
+		return "", "", false, fmt.Errorf("parse create table %s: missing opening parenthesis", tableName)
+	}
+	bodyStart := i + (len(stmt[i:]) - len(rest)) + open + 1
+	depth := 1
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	for j := bodyStart; j < len(stmt); j++ {
+		ch := stmt[j]
+		switch ch {
+		case '\\':
+			j++
+			continue
+		case '\'':
+			if !inDouble && !inBacktick {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBacktick {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBacktick = !inBacktick
+			}
+		case '(':
+			if !inSingle && !inDouble && !inBacktick {
+				depth++
+			}
+		case ')':
+			if !inSingle && !inDouble && !inBacktick {
+				depth--
+				if depth == 0 {
+					return tableName, stmt[bodyStart:j], true, nil
+				}
+			}
+		}
+	}
+	return "", "", false, fmt.Errorf("parse create table %s: unbalanced parentheses", tableName)
+}
+
+func splitMetaTopLevelComma(definitions string) []string {
+	parts := make([]string, 0)
+	start := 0
+	depth := 0
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	for i := 0; i < len(definitions); i++ {
+		ch := definitions[i]
+		switch ch {
+		case '\\':
+			i++
+			continue
+		case '\'':
+			if !inDouble && !inBacktick {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBacktick {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBacktick = !inBacktick
+			}
+		case '(':
+			if !inSingle && !inDouble && !inBacktick {
+				depth++
+			}
+		case ')':
+			if !inSingle && !inDouble && !inBacktick && depth > 0 {
+				depth--
+			}
+		case ',':
+			if !inSingle && !inDouble && !inBacktick && depth == 0 {
+				parts = append(parts, strings.TrimSpace(definitions[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	if start < len(definitions) {
+		parts = append(parts, strings.TrimSpace(definitions[start:]))
+	}
+	return parts
+}
+
+func parseMetaInlineIndexDefinition(tableName, def string) (indexName, createSQL string, ok bool) {
+	n := normalizeMetaSQLFragment(def)
+	if strings.HasPrefix(n, "unique index ") {
+		name, cols := parseMetaIndexNameAndColumns(def, "UNIQUE INDEX")
+		if name == "" || cols == "" {
+			return "", "", false
+		}
+		return name, fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols), true
+	}
+	if strings.HasPrefix(n, "index ") {
+		name, cols := parseMetaIndexNameAndColumns(def, "INDEX")
+		if name == "" || cols == "" {
+			return "", "", false
+		}
+		return name, fmt.Sprintf("CREATE INDEX %s ON %s%s", name, tableName, cols), true
+	}
+	return "", "", false
+}
+
+func parseMetaIndexNameAndColumns(def, prefix string) (indexName, columns string) {
+	trimmed := strings.TrimSpace(def)
+	upper := strings.ToUpper(trimmed)
+	p := strings.Index(upper, prefix)
+	if p < 0 {
+		return "", ""
+	}
+	rest := strings.TrimSpace(trimmed[p+len(prefix):])
+	name, remainder := splitMetaIdentifierAndRest(rest)
+	if name == "" {
+		return "", ""
+	}
+	open := strings.Index(remainder, "(")
+	if open < 0 {
+		return "", ""
+	}
+	return strings.ToLower(name), strings.TrimSpace(remainder[open:])
+}
+
+func parseMetaColumnDefinition(tableName, def string) (string, metaColumnSpec, bool) {
+	name, rest := splitMetaIdentifierAndRest(def)
+	if name == "" || rest == "" {
+		return "", metaColumnSpec{}, false
+	}
+	colType := parseMetaColumnType(rest)
+	if colType == "" {
+		return "", metaColumnSpec{}, false
+	}
+	return strings.ToLower(name), metaColumnSpec{
+		columnType: strings.ToLower(strings.TrimSpace(colType)),
+		addSQL:     fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", tableName, name, strings.TrimSpace(rest)),
+	}, true
+}
+
+func parseMetaColumnType(rest string) string {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return ""
+	}
+	keywords := []string{" not ", " null", " default ", " generated ", " as ", " primary ", " unique ", " comment ", " references ", " auto_increment", " on update"}
+	depth := 0
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	for i := 0; i < len(rest); i++ {
+		ch := rest[i]
+		switch ch {
+		case '\\':
+			i++
+			continue
+		case '\'':
+			if !inDouble && !inBacktick {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBacktick {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBacktick = !inBacktick
+			}
+		case '(':
+			if !inSingle && !inDouble && !inBacktick {
+				depth++
+			}
+		case ')':
+			if !inSingle && !inDouble && !inBacktick && depth > 0 {
+				depth--
+			}
+		}
+		if inSingle || inDouble || inBacktick || depth > 0 {
+			continue
+		}
+		suffix := " " + strings.ToLower(rest[i:])
+		for _, kw := range keywords {
+			if strings.HasPrefix(suffix, kw) {
+				return strings.TrimSpace(rest[:i])
+			}
+		}
+	}
+	return strings.TrimSpace(rest)
+}
+
+func splitMetaIdentifierAndRest(s string) (identifier string, rest string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ""
+	}
+	if s[0] == '`' {
+		end := strings.Index(s[1:], "`")
+		if end < 0 {
+			return "", ""
+		}
+		id := s[1 : 1+end]
+		return id, strings.TrimSpace(s[1+end+1:])
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r' {
+			return s[:i], strings.TrimSpace(s[i+1:])
+		}
+	}
+	return s, ""
+}
+
+func isMetaConstraintDefinition(def string) bool {
+	n := normalizeMetaSQLFragment(def)
+	return strings.HasPrefix(n, "primary key") || strings.HasPrefix(n, "constraint ") || strings.HasPrefix(n, "unique key ")
+}
+
+func loadMetaTableMeta(db *sql.DB, tableName string) (metaTableMeta, error) {
+	rows, err := db.Query(`SELECT column_name, column_type
+		FROM information_schema.columns
+		WHERE table_schema = DATABASE() AND table_name = ?`, tableName)
+	if err != nil {
+		return metaTableMeta{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	columns := make(map[string]metaColumnMeta)
+	for rows.Next() {
+		var name, columnType string
+		if err := rows.Scan(&name, &columnType); err != nil {
+			return metaTableMeta{}, err
+		}
+		columns[strings.ToLower(name)] = metaColumnMeta{columnType: columnType}
+	}
+	if err := rows.Err(); err != nil {
+		return metaTableMeta{}, err
+	}
+	if len(columns) == 0 {
+		return metaTableMeta{}, sql.ErrNoRows
+	}
+	return metaTableMeta{tableName: tableName, columns: columns}, nil
+}
+
+func loadMetaShowCreateTable(db *sql.DB, tableName string) (string, error) {
+	var gotTable string
+	var createStmt string
+	query := fmt.Sprintf("SHOW CREATE TABLE %s", tableName)
+	if err := db.QueryRow(query).Scan(&gotTable, &createStmt); err != nil {
+		return "", err
+	}
+	return createStmt, nil
+}
+
+func normalizeMetaSQLFragment(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "`", "")
+	s = strings.ReplaceAll(s, "_utf8mb4", "")
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+func sortedMetaColumnNames(columns map[string]metaColumnSpec) []string {
+	names := make([]string, 0, len(columns))
+	for name := range columns {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedMetaIndexNames(indexes map[string]metaIndexSpec) []string {
+	names := make([]string, 0, len(indexes))
+	for name := range indexes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func schemaSnippet(stmt string) string {
+	snippet := stmt
+	if len(snippet) > 80 {
+		snippet = snippet[:80]
+	}
+	return snippet
 }
 
 func (s *Store) InsertTenant(ctx context.Context, t *Tenant) (err error) {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -2,6 +2,7 @@ package meta
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 )
@@ -142,4 +143,85 @@ func TestListTenantsByStatus(t *testing.T) {
 	if got[0].Status != TenantProvisioning || got[1].Status != TenantProvisioning {
 		t.Fatalf("unexpected statuses: %s, %s", got[0].Status, got[1].Status)
 	}
+}
+
+func TestMetaSchemaSpecFromStatementsParsesNewTable(t *testing.T) {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS tenant_custom_events (
+			event_id VARCHAR(64) PRIMARY KEY,
+			tenant_id VARCHAR(64) NOT NULL,
+			payload JSON,
+			created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			INDEX idx_tenant_custom_events_tenant (tenant_id)
+		)`,
+	}
+	spec, err := metaSchemaSpecFromStatements(stmts)
+	if err != nil {
+		t.Fatalf("metaSchemaSpecFromStatements: %v", err)
+	}
+	table := mustMetaTableSpec(t, spec, "tenant_custom_events")
+	if _, ok := table.columns["tenant_id"]; !ok {
+		t.Fatal("expected tenant_id in parsed columns")
+	}
+	if _, ok := table.indexes["idx_tenant_custom_events_tenant"]; !ok {
+		t.Fatal("expected idx_tenant_custom_events_tenant in parsed indexes")
+	}
+}
+
+func TestDiffMetaTableMetaReportsMissingColumnAndIndex(t *testing.T) {
+	spec := mustMetaTableSpec(t, mustMetaSpec(t), "tenant_api_keys")
+	meta := metaTableMeta{
+		tableName: "tenant_api_keys",
+		columns: map[string]metaColumnMeta{
+			"id":             {columnType: "varchar(64)"},
+			"tenant_id":      {columnType: "varchar(64)"},
+			"jwt_ciphertext": {columnType: "varbinary(4096)"},
+			"jwt_hash":       {columnType: "varchar(128)"},
+		},
+	}
+	createStmt := `CREATE TABLE tenant_api_keys (
+		id VARCHAR(64) PRIMARY KEY,
+		tenant_id VARCHAR(64) NOT NULL,
+		jwt_ciphertext VARBINARY(4096) NOT NULL,
+		jwt_hash VARCHAR(128) NOT NULL
+	)`
+	diffs := diffMetaTableMeta(spec, meta, createStmt)
+	if !hasMetaDiff(diffs, metaSchemaDiffMissingColumn, "key_name") {
+		t.Fatalf("expected missing key_name diff, got %#v", diffs)
+	}
+	if !hasMetaDiff(diffs, metaSchemaDiffMissingIndex, "idx_api_keys_tenant") {
+		t.Fatalf("expected missing idx_api_keys_tenant diff, got %#v", diffs)
+	}
+}
+
+func mustMetaSpec(t *testing.T) metaSchemaSpec {
+	t.Helper()
+	spec, err := metaSchemaSpecFromStatements(metaInitSchemaStatements())
+	if err != nil {
+		t.Fatalf("meta schema spec: %v", err)
+	}
+	return spec
+}
+
+func mustMetaTableSpec(t *testing.T, spec metaSchemaSpec, tableName string) metaTableSpec {
+	t.Helper()
+	for _, table := range spec.tables {
+		if table.name == tableName {
+			return table
+		}
+	}
+	t.Fatalf("missing table %q in meta schema spec", tableName)
+	return metaTableSpec{}
+}
+
+func hasMetaDiff(diffs []metaSchemaDiff, kind metaSchemaDiffKind, contains string) bool {
+	for _, diff := range diffs {
+		if diff.kind != kind {
+			continue
+		}
+		if strings.Contains(strings.ToLower(diff.detail), strings.ToLower(contains)) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -194,6 +194,61 @@ func TestDiffMetaTableMetaReportsMissingColumnAndIndex(t *testing.T) {
 	}
 }
 
+func TestMetaSchemaSpecTracksPrimaryKeyConstraint(t *testing.T) {
+	spec := mustMetaSpec(t)
+	table := mustMetaTableSpec(t, spec, "tenant_quota_config")
+	pk, ok := table.indexes["primary"]
+	if !ok {
+		t.Fatal("expected primary key constraint to be tracked in schema spec")
+	}
+	if !pk.isPrimary {
+		t.Fatal("expected primary constraint marker")
+	}
+}
+
+func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
+	spec := mustMetaTableSpec(t, mustMetaSpec(t), "tenant_quota_config")
+	meta := metaTableMeta{
+		tableName: "tenant_quota_config",
+		columns: map[string]metaColumnMeta{
+			"tenant_id":           {columnType: "varchar(64)"},
+			"max_storage_bytes":   {columnType: "bigint"},
+			"max_media_llm_files": {columnType: "bigint"},
+			"max_monthly_cost_mc": {columnType: "bigint"},
+			"created_at":          {columnType: "datetime(3)"},
+			"updated_at":          {columnType: "datetime(3)"},
+		},
+	}
+	createStmt := `CREATE TABLE tenant_quota_config (
+		tenant_id VARCHAR(64) NOT NULL,
+		max_storage_bytes BIGINT NOT NULL,
+		max_media_llm_files BIGINT NOT NULL,
+		max_monthly_cost_mc BIGINT NOT NULL,
+		created_at DATETIME(3) NOT NULL,
+		updated_at DATETIME(3) NOT NULL
+	)`
+	diffs := diffMetaTableMeta(spec, meta, createStmt)
+	if !hasMetaDiff(diffs, metaSchemaDiffMissingIndex, "missing primary key constraint") {
+		t.Fatalf("expected missing primary key diff, got %#v", diffs)
+	}
+}
+
+func TestPlannedMetaSchemaRepairsSkipsUnsafeRepairs(t *testing.T) {
+	diffs := []metaSchemaDiff{
+		{kind: metaSchemaDiffMissingColumn, tableName: "tenant_api_keys", columnName: "must_fill", repairSQL: "ALTER TABLE tenant_api_keys ADD COLUMN must_fill BIGINT NOT NULL"},
+		{kind: metaSchemaDiffMissingIndex, tableName: "tenant_api_keys", indexName: "uk_key_name", repairSQL: "CREATE UNIQUE INDEX uk_key_name ON tenant_api_keys(key_name)"},
+		{kind: metaSchemaDiffMissingIndex, tableName: "tenant_api_keys", indexName: "idx_api_keys_tenant", repairSQL: "CREATE INDEX idx_api_keys_tenant ON tenant_api_keys(tenant_id, status)"},
+	}
+
+	plans := plannedMetaSchemaRepairs(diffs)
+	if len(plans) != 1 {
+		t.Fatalf("expected exactly one safe repair, got %#v", plans)
+	}
+	if plans[0] != "CREATE INDEX idx_api_keys_tenant ON tenant_api_keys(tenant_id, status)" {
+		t.Fatalf("unexpected plan: %#v", plans)
+	}
+}
+
 func mustMetaSpec(t *testing.T) metaSchemaSpec {
 	t.Helper()
 	spec, err := metaSchemaSpecFromStatements(metaInitSchemaStatements())

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -325,7 +325,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	if opts.DatabaseAutoEmbedding && (t.Provider == ProviderTiDBZero || t.Provider == ProviderTiDBCloudStarter) {
 		if t.SchemaVersion != schema.CurrentTiDBTenantSchemaVersion {
 			ensureSchemaStart := time.Now()
-			if err := schema.EnsureTiDBSchemaForMode(store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
+			if err := schema.EnsureTiDBSchemaForMode(ctx, store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("ensure tidb auto-embedding schema: %w", err)
 			}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/backend"
@@ -39,14 +40,24 @@ type PoolConfig struct {
 }
 
 type Pool struct {
-	mu        sync.Mutex
-	cfg       PoolConfig
-	enc       encrypt.Encryptor
-	metaStore *meta.Store // central server DB for quota operations; nil disables central quota
-	items     map[string]*entry
-	order     *list.List
-	maxSize   int
+	mu                        sync.Mutex
+	cfg                       PoolConfig
+	enc                       encrypt.Encryptor
+	metaStore                 *meta.Store // central server DB for quota operations; nil disables central quota
+	items                     map[string]*entry
+	order                     *list.List
+	maxSize                   int
+	tidbSchemaValidationOpens atomic.Uint64
 }
+
+var (
+	ensureTiDBSchemaForMode   = schema.EnsureTiDBSchemaForMode
+	validateTiDBSchemaForMode = schema.ValidateTiDBSchemaForMode
+	// Validate once on the first version-matched open after process start, then
+	// periodically thereafter to catch out-of-band schema drift without putting a
+	// full schema diff on every tenant open.
+	periodicTiDBSchemaValidationEvery uint64 = 32
+)
 
 type entry struct {
 	tenantID string
@@ -325,7 +336,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	if opts.DatabaseAutoEmbedding && (t.Provider == ProviderTiDBZero || t.Provider == ProviderTiDBCloudStarter) {
 		if t.SchemaVersion != schema.CurrentTiDBTenantSchemaVersion {
 			ensureSchemaStart := time.Now()
-			if err := schema.EnsureTiDBSchemaForMode(ctx, store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
+			if err := ensureTiDBSchemaForMode(ctx, store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("ensure tidb auto-embedding schema: %w", err)
 			}
@@ -345,6 +356,13 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 						zap.Error(verErr))
 				}
 			}
+		} else if p.shouldPeriodicValidateTiDBSchemaOnOpen() {
+			validateSchemaStart := time.Now()
+			if err := validateTiDBSchemaForMode(ctx, store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
+				_ = store.Close()
+				return nil, nil, fmt.Errorf("validate tidb auto-embedding schema: %w", err)
+			}
+			ensureSchemaDurationMs = float64(time.Since(validateSchemaStart).Microseconds()) / 1000.0
 		}
 	}
 	if p.cfg.S3Bucket != "" {
@@ -441,6 +459,18 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 	p.wireQuotaStore(b, t.ID)
 	return b, store, nil
+}
+
+func (p *Pool) shouldPeriodicValidateTiDBSchemaOnOpen() bool {
+	if p == nil {
+		return false
+	}
+	every := periodicTiDBSchemaValidationEvery
+	if every == 0 {
+		return false
+	}
+	count := p.tidbSchemaValidationOpens.Add(1)
+	return count == 1 || count%every == 0
 }
 
 // wireQuotaStore sets the central quota store on a newly created backend.

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -323,7 +323,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	openStoreDurationMs := float64(time.Since(openStoreStart).Microseconds()) / 1000.0
 	ensureSchemaDurationMs := 0.0
 	if opts.DatabaseAutoEmbedding && (t.Provider == ProviderTiDBZero || t.Provider == ProviderTiDBCloudStarter) {
-		if t.SchemaVersion < schema.CurrentTiDBTenantSchemaVersion {
+		if t.SchemaVersion != schema.CurrentTiDBTenantSchemaVersion {
 			ensureSchemaStart := time.Now()
 			if err := schema.EnsureTiDBSchemaForMode(store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
 				_ = store.Close()

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -331,6 +331,13 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			}
 			ensureSchemaDurationMs = float64(time.Since(ensureSchemaStart).Microseconds()) / 1000.0
 			if p.metaStore != nil {
+				// Record the version only after EnsureTiDBSchemaForMode has
+				// succeeded. EnsureTiDBSchemaForMode ends with a call to
+				// ValidateTiDBSchemaForMode, so by the time we reach this
+				// point the schema has been confirmed to match the spec.
+				// Any tenant whose schema diverges between two consecutive
+				// opens will be caught on the next open because its stored
+				// version will differ from CurrentTiDBTenantSchemaVersion.
 				if verErr := p.metaStore.UpdateTenantSchemaVersion(ctx, t.ID, schema.CurrentTiDBTenantSchemaVersion); verErr != nil {
 					logger.Warn(ctx, "tenant_pool_update_schema_version_failed",
 						zap.String("tenant_id", t.ID),

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -323,12 +323,22 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	openStoreDurationMs := float64(time.Since(openStoreStart).Microseconds()) / 1000.0
 	ensureSchemaDurationMs := 0.0
 	if opts.DatabaseAutoEmbedding && (t.Provider == ProviderTiDBZero || t.Provider == ProviderTiDBCloudStarter) {
-		ensureSchemaStart := time.Now()
-		if err := schema.EnsureTiDBSchemaForMode(store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
-			_ = store.Close()
-			return nil, nil, fmt.Errorf("ensure tidb auto-embedding schema: %w", err)
+		if t.SchemaVersion < schema.CurrentTiDBTenantSchemaVersion {
+			ensureSchemaStart := time.Now()
+			if err := schema.EnsureTiDBSchemaForMode(store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {
+				_ = store.Close()
+				return nil, nil, fmt.Errorf("ensure tidb auto-embedding schema: %w", err)
+			}
+			ensureSchemaDurationMs = float64(time.Since(ensureSchemaStart).Microseconds()) / 1000.0
+			if p.metaStore != nil {
+				if verErr := p.metaStore.UpdateTenantSchemaVersion(ctx, t.ID, schema.CurrentTiDBTenantSchemaVersion); verErr != nil {
+					logger.Warn(ctx, "tenant_pool_update_schema_version_failed",
+						zap.String("tenant_id", t.ID),
+						zap.Int("version", schema.CurrentTiDBTenantSchemaVersion),
+						zap.Error(verErr))
+				}
+			}
 		}
-		ensureSchemaDurationMs = float64(time.Since(ensureSchemaStart).Microseconds()) / 1000.0
 	}
 	if p.cfg.S3Bucket != "" {
 		prefix := strings.Trim(p.cfg.S3Prefix, "/")

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/semantic"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
 
 func TestPoolAcquireInvalidateDefersCloseUntilRelease(t *testing.T) {
@@ -246,6 +247,78 @@ func TestPoolAutoSemanticTaskTypes(t *testing.T) {
 	gotBoth := both.AutoSemanticTaskTypes()
 	if len(gotBoth) != 2 || gotBoth[0] != semantic.TaskTypeImgExtractText || gotBoth[1] != semantic.TaskTypeAudioExtractText {
 		t.Fatalf("got %#v, want [img_extract_text audio_extract_text]", gotBoth)
+	}
+}
+
+func TestPoolCreateBackendPeriodicallyValidatesSchemaWhenVersionMatches(t *testing.T) {
+	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-validate")
+	tenant.Provider = ProviderTiDBZero
+	tenant.SchemaVersion = schema.CurrentTiDBTenantSchemaVersion
+
+	origEnsure := ensureTiDBSchemaForMode
+	origValidate := validateTiDBSchemaForMode
+	origEvery := periodicTiDBSchemaValidationEvery
+	ensureCalls := 0
+	validateCalls := 0
+	ensureTiDBSchemaForMode = func(context.Context, *sql.DB, schema.TiDBEmbeddingMode) error {
+		ensureCalls++
+		return nil
+	}
+	validateTiDBSchemaForMode = func(context.Context, *sql.DB, schema.TiDBEmbeddingMode) error {
+		validateCalls++
+		return nil
+	}
+	periodicTiDBSchemaValidationEvery = 4
+	t.Cleanup(func() {
+		ensureTiDBSchemaForMode = origEnsure
+		validateTiDBSchemaForMode = origValidate
+		periodicTiDBSchemaValidationEvery = origEvery
+	})
+
+	for i := 0; i < 4; i++ {
+		backend, store, err := pool.createBackend(context.Background(), tenant)
+		if err != nil {
+			t.Fatalf("createBackend() iteration %d: %v", i, err)
+		}
+		backend.Close()
+		if err := store.Close(); err != nil {
+			t.Fatalf("close store iteration %d: %v", i, err)
+		}
+	}
+
+	if ensureCalls != 0 {
+		t.Fatalf("ensureTiDBSchemaForMode called %d times, want 0", ensureCalls)
+	}
+	if validateCalls != 2 {
+		t.Fatalf("validateTiDBSchemaForMode called %d times, want 2", validateCalls)
+	}
+}
+
+func TestPoolCreateBackendReturnsValidationErrorWhenPeriodicCheckFails(t *testing.T) {
+	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-validate-fail")
+	tenant.Provider = ProviderTiDBZero
+	tenant.SchemaVersion = schema.CurrentTiDBTenantSchemaVersion
+
+	origEnsure := ensureTiDBSchemaForMode
+	origValidate := validateTiDBSchemaForMode
+	origEvery := periodicTiDBSchemaValidationEvery
+	ensureTiDBSchemaForMode = func(context.Context, *sql.DB, schema.TiDBEmbeddingMode) error {
+		return nil
+	}
+	validateTiDBSchemaForMode = func(context.Context, *sql.DB, schema.TiDBEmbeddingMode) error {
+		return fmt.Errorf("schema drift")
+	}
+	periodicTiDBSchemaValidationEvery = 1
+	t.Cleanup(func() {
+		ensureTiDBSchemaForMode = origEnsure
+		validateTiDBSchemaForMode = origValidate
+		periodicTiDBSchemaValidationEvery = origEvery
+	})
+
+	if _, _, err := pool.createBackend(context.Background(), tenant); err == nil {
+		t.Fatal("expected periodic validation failure to propagate")
+	} else if !strings.Contains(err.Error(), "validate tidb auto-embedding schema") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/pkg/tenant/schema/common.go
+++ b/pkg/tenant/schema/common.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	mysql "github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/dat9/internal/schemaspec"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"go.uber.org/zap"
 )
@@ -41,11 +42,7 @@ func ExecSchemaStatements(db *sql.DB, stmts []string) error {
 			if isIgnorableSchemaError(err) {
 				continue
 			}
-			snippet := stmt
-			if len(snippet) > 80 {
-				snippet = snippet[:80]
-			}
-			return fmt.Errorf("exec %q: %w", snippet, err)
+			return fmt.Errorf("exec %q: %w", schemaspec.SQLSnippet(stmt), err)
 		}
 	}
 	return nil
@@ -116,11 +113,7 @@ func isIgnorableOptionalMySQLErrorCode(code uint16) bool {
 }
 
 func schemaStatementSnippet(stmt string) string {
-	snippet := stmt
-	if len(snippet) > 80 {
-		snippet = snippet[:80]
-	}
-	return snippet
+	return schemaspec.SQLSnippet(stmt)
 }
 
 func IsTiDBCluster(ctx context.Context, db *sql.DB) bool {

--- a/pkg/tenant/schema/common.go
+++ b/pkg/tenant/schema/common.go
@@ -123,9 +123,9 @@ func schemaStatementSnippet(stmt string) string {
 	return snippet
 }
 
-func IsTiDBCluster(db *sql.DB) bool {
+func IsTiDBCluster(ctx context.Context, db *sql.DB) bool {
 	var ver string
-	if err := db.QueryRow(`SELECT VERSION()`).Scan(&ver); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT VERSION()`).Scan(&ver); err != nil {
 		return false
 	}
 	return strings.Contains(strings.ToLower(ver), "tidb")

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -138,7 +138,7 @@ func initTiDBAppEmbeddingSchema(ctx context.Context, dsn string, opts InitTiDBTe
 		return err
 	}
 	defer func() { _ = db.Close() }()
-	if !IsTiDBCluster(db) {
+	if !IsTiDBCluster(ctx, db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
 	if err := ExecSchemaStatements(db, tidbAppEmbeddingBaseSchemaStatements()); err != nil {
@@ -159,5 +159,5 @@ func initTiDBAppEmbeddingSchema(ctx context.Context, dsn string, opts InitTiDBTe
 	} else if err := ExecSchemaStatements(db, tidbAppEmbeddingOptionalSchemaStatements()); err != nil {
 		return err
 	}
-	return ValidateTiDBSchemaForMode(db, TiDBEmbeddingModeApp)
+	return ValidateTiDBSchemaForMode(ctx, db, TiDBEmbeddingModeApp)
 }

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -38,6 +39,61 @@ type tidbColumnMeta struct {
 type tidbTableMeta struct {
 	tableName string
 	columns   map[string]tidbColumnMeta
+}
+
+type tidbSchemaDiffKind string
+
+const (
+	tidbSchemaDiffMissingTable  tidbSchemaDiffKind = "missing_table"
+	tidbSchemaDiffMissingColumn tidbSchemaDiffKind = "missing_column"
+	tidbSchemaDiffMissingIndex  tidbSchemaDiffKind = "missing_index"
+	tidbSchemaDiffColumnType    tidbSchemaDiffKind = "column_type_mismatch"
+	tidbSchemaDiffTableContract tidbSchemaDiffKind = "table_contract_mismatch"
+)
+
+type tidbSchemaDiff struct {
+	kind       tidbSchemaDiffKind
+	tableName  string
+	columnName string
+	detail     string
+	repairSQL  string
+}
+
+type tidbSchemaSpec struct {
+	tables []tidbTableSpec
+}
+
+type tidbTableSpec struct {
+	name            string
+	createStatement string
+	columns         map[string]tidbColumnSpec
+	indexes         map[string]tidbIndexSpec
+	validate        func(tidbTableMeta) []tidbSchemaDiff
+}
+
+type tidbColumnSpec struct {
+	columnType string
+	addSQL     string
+}
+
+type tidbIndexSpec struct {
+	createSQL string
+}
+
+type tidbSchemaDiffError struct {
+	mode  TiDBEmbeddingMode
+	diffs []tidbSchemaDiff
+}
+
+func (e *tidbSchemaDiffError) Error() string {
+	if e == nil || len(e.diffs) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(e.diffs))
+	for _, diff := range e.diffs {
+		parts = append(parts, diff.detail)
+	}
+	return fmt.Sprintf("tidb schema contract mismatch for mode %q: %s", e.mode, strings.Join(parts, "; "))
 }
 
 // Keep this statement list aligned with the externally managed tidb_cloud_starter
@@ -208,27 +264,12 @@ func ValidateTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
 	if err := validateTiDBSchemaMode(mode); err != nil {
 		return err
 	}
-	filesMeta, err := loadTiDBTableMeta(db, "files")
+	diffs, err := diffTiDBSchemaForMode(db, mode)
 	if err != nil {
-		return fmt.Errorf("load files table metadata: %w", err)
+		return err
 	}
-	if err := validateTiDBTableForMode(mode, filesMeta); err != nil {
-		return fmt.Errorf("files schema contract: %w", err)
-	}
-	uploadsMeta, err := loadTiDBTableMeta(db, "uploads")
-	if err != nil {
-		return fmt.Errorf("load uploads table metadata: %w", err)
-	}
-	if err := validateTiDBUploadsTableBase(uploadsMeta); err != nil {
-		return fmt.Errorf("uploads schema contract: %w", err)
-	}
-	if err := ensureTiDBTableExists(db, "semantic_tasks"); err != nil {
-		return fmt.Errorf("semantic_tasks schema contract: %w", err)
-	}
-	for _, t := range []string{"vault_deks", "vault_secrets", "vault_secret_fields", "vault_tokens", "vault_grants", "vault_policies", "vault_audit_log"} {
-		if err := ensureTiDBTableExists(db, t); err != nil {
-			return fmt.Errorf("%s schema contract: %w", t, err)
-		}
+	if len(diffs) > 0 {
+		return &tidbSchemaDiffError{mode: mode, diffs: diffs}
 	}
 	return nil
 }
@@ -245,8 +286,12 @@ func EnsureTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
 	if err := validateTiDBSchemaMode(mode); err != nil {
 		return err
 	}
-	if err := repairLegacyTiDBUploadsSchema(db); err != nil {
-		return fmt.Errorf("repair uploads schema: %w", err)
+	diffs, err := diffTiDBSchemaForMode(db, mode)
+	if err != nil {
+		return err
+	}
+	if err := applyTiDBSchemaRepairs(db, plannedTiDBSchemaRepairs(diffs)); err != nil {
+		return err
 	}
 	return ValidateTiDBSchemaForMode(db, mode)
 }
@@ -354,48 +399,14 @@ func validateTiDBAutoEmbeddingFilesTable(meta tidbTableMeta) error {
 	if err := validateTiDBFilesTableBase(meta); err != nil {
 		return err
 	}
-	col, err := meta.requireColumn("embedding")
-	if err != nil {
-		return err
-	}
-	extra := normalizeSQLFragment(col.extra)
-	if !strings.Contains(extra, "generated") || !strings.Contains(extra, "stored") {
-		return errors.New("embedding column must be a stored generated column")
-	}
-	expr := normalizeSQLFragment(col.generationExpression)
-	checks := []struct {
-		pattern string
-		errMsg  string
-	}{
-		{"embed_text(", "embedding generated expression must use EMBED_TEXT"},
-		{tidbAutoEmbeddingModel, "embedding model contract mismatch"},
-		{"content_text", "generated expression must derive from content_text"},
-		{tidbAutoEmbeddingOptionsJSON, "embedding dimensions option mismatch"},
-	}
-	for _, check := range checks {
-		if !strings.Contains(expr, check.pattern) {
-			return errors.New(check.errMsg)
-		}
-	}
-	return nil
+	return schemaDiffsToError(validateTiDBAutoEmbeddingFilesDiffs(meta))
 }
 
 func validateTiDBAppEmbeddingFilesTable(meta tidbTableMeta) error {
 	if err := validateTiDBFilesTableBase(meta); err != nil {
 		return err
 	}
-	col, err := meta.requireColumn("embedding")
-	if err != nil {
-		return err
-	}
-	extra := normalizeSQLFragment(col.extra)
-	if strings.Contains(extra, "generated") {
-		return errors.New("embedding column must be writable in app mode")
-	}
-	if expr := normalizeSQLFragment(col.generationExpression); expr != "" {
-		return errors.New("embedding column must not define a generation expression in app mode")
-	}
-	return nil
+	return schemaDiffsToError(validateTiDBAppEmbeddingFilesDiffs(meta))
 }
 
 func validateTiDBFilesTableBase(meta tidbTableMeta) error {
@@ -523,4 +534,618 @@ func normalizeSQLFragment(s string) string {
 	s = strings.ReplaceAll(s, "_utf8mb4", "")
 	fields := strings.Fields(s)
 	return strings.Join(fields, " ")
+}
+
+func diffTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) ([]tidbSchemaDiff, error) {
+	spec, err := tidbSchemaSpecForMode(mode)
+	if err != nil {
+		return nil, err
+	}
+	var diffs []tidbSchemaDiff
+	for _, table := range spec.tables {
+		tableDiffs, err := diffTiDBTable(db, table)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, tableDiffs...)
+	}
+	return diffs, nil
+}
+
+func diffTiDBTable(db *sql.DB, table tidbTableSpec) ([]tidbSchemaDiff, error) {
+	meta, err := loadTiDBTableMeta(db, table.name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return []tidbSchemaDiff{missingTableDiff(table)}, nil
+		}
+		return nil, fmt.Errorf("load %s table metadata: %w", table.name, err)
+	}
+	createStmt, err := loadShowCreateTable(db, table.name)
+	if err != nil {
+		return nil, fmt.Errorf("show create %s: %w", table.name, err)
+	}
+	return diffTiDBTableMeta(table, meta, createStmt), nil
+}
+
+func tidbSchemaSpecForMode(mode TiDBEmbeddingMode) (tidbSchemaSpec, error) {
+	stmts, err := InitTiDBTenantSchemaStatementsForMode(mode)
+	if err != nil {
+		return tidbSchemaSpec{}, err
+	}
+	spec, err := tidbSchemaSpecFromStatements(stmts)
+	if err != nil {
+		return tidbSchemaSpec{}, err
+	}
+	for i := range spec.tables {
+		if spec.tables[i].name != "files" {
+			continue
+		}
+		spec.tables[i].validate = func(meta tidbTableMeta) []tidbSchemaDiff {
+			switch mode {
+			case TiDBEmbeddingModeAuto:
+				return validateTiDBAutoEmbeddingFilesDiffs(meta)
+			case TiDBEmbeddingModeApp:
+				return validateTiDBAppEmbeddingFilesDiffs(meta)
+			default:
+				return []tidbSchemaDiff{{kind: tidbSchemaDiffTableContract, tableName: "files", detail: fmt.Sprintf("files schema contract: unsupported TiDB embedding mode %q", mode)}}
+			}
+		}
+		break
+	}
+	return spec, nil
+}
+
+func tidbSchemaSpecFromStatements(stmts []string) (tidbSchemaSpec, error) {
+	tables := make([]tidbTableSpec, 0)
+	byName := make(map[string]*tidbTableSpec)
+	for _, stmt := range stmts {
+		table, ok, err := parseCreateTableSpec(stmt)
+		if err != nil {
+			return tidbSchemaSpec{}, err
+		}
+		if !ok {
+			continue
+		}
+		tables = append(tables, table)
+		byName[table.name] = &tables[len(tables)-1]
+	}
+	for _, stmt := range stmts {
+		tableName, indexName, createSQL, ok := parseCreateIndexStatement(stmt)
+		if !ok {
+			continue
+		}
+		t, exists := byName[tableName]
+		if !exists {
+			continue
+		}
+		if t.indexes == nil {
+			t.indexes = make(map[string]tidbIndexSpec)
+		}
+		t.indexes[indexName] = tidbIndexSpec{createSQL: strings.TrimSpace(createSQL)}
+	}
+	return tidbSchemaSpec{tables: tables}, nil
+}
+
+func parseCreateTableSpec(stmt string) (tidbTableSpec, bool, error) {
+	tableName, defs, ok, err := parseCreateTableStatement(stmt)
+	if err != nil {
+		return tidbTableSpec{}, false, err
+	}
+	if !ok {
+		return tidbTableSpec{}, false, nil
+	}
+	columns := make(map[string]tidbColumnSpec)
+	indexes := make(map[string]tidbIndexSpec)
+	for _, def := range splitTopLevelComma(defs) {
+		def = strings.TrimSpace(def)
+		if def == "" {
+			continue
+		}
+		if indexName, createSQL, ok := parseInlineIndexDefinition(tableName, def); ok {
+			indexes[indexName] = tidbIndexSpec{createSQL: createSQL}
+			continue
+		}
+		if isConstraintDefinition(def) {
+			continue
+		}
+		colName, colSpec, ok := parseColumnDefinition(tableName, def)
+		if !ok {
+			continue
+		}
+		columns[colName] = colSpec
+	}
+	return tidbTableSpec{
+		name:            tableName,
+		createStatement: strings.TrimSpace(stmt),
+		columns:         columns,
+		indexes:         indexes,
+	}, true, nil
+}
+
+func parseCreateTableStatement(stmt string) (tableName string, definitions string, ok bool, err error) {
+	lower := strings.ToLower(stmt)
+	const prefix = "create table if not exists"
+	start := strings.Index(lower, prefix)
+	if start < 0 {
+		return "", "", false, nil
+	}
+	i := start + len(prefix)
+	for i < len(stmt) && (stmt[i] == ' ' || stmt[i] == '\n' || stmt[i] == '\t' || stmt[i] == '\r') {
+		i++
+	}
+	if i >= len(stmt) {
+		return "", "", false, fmt.Errorf("parse create table: missing table name")
+	}
+	nameStart := i
+	if stmt[i] == '`' {
+		i++
+		for i < len(stmt) && stmt[i] != '`' {
+			i++
+		}
+		if i >= len(stmt) {
+			return "", "", false, fmt.Errorf("parse create table: unterminated quoted table name")
+		}
+		tableName = strings.ToLower(stmt[nameStart+1 : i])
+		i++
+	} else {
+		for i < len(stmt) && stmt[i] != ' ' && stmt[i] != '\n' && stmt[i] != '\t' && stmt[i] != '(' {
+			i++
+		}
+		tableName = strings.ToLower(strings.TrimSpace(stmt[nameStart:i]))
+	}
+	for i < len(stmt) && stmt[i] != '(' {
+		i++
+	}
+	if i >= len(stmt) || stmt[i] != '(' {
+		return "", "", false, fmt.Errorf("parse create table %s: missing opening parenthesis", tableName)
+	}
+	bodyStart := i + 1
+	depth := 1
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	for i = bodyStart; i < len(stmt); i++ {
+		ch := stmt[i]
+		switch ch {
+		case '\\':
+			i++
+			continue
+		case '\'':
+			if !inDouble && !inBacktick {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBacktick {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBacktick = !inBacktick
+			}
+		case '(':
+			if !inSingle && !inDouble && !inBacktick {
+				depth++
+			}
+		case ')':
+			if !inSingle && !inDouble && !inBacktick {
+				depth--
+				if depth == 0 {
+					return tableName, stmt[bodyStart:i], true, nil
+				}
+			}
+		}
+	}
+	return "", "", false, fmt.Errorf("parse create table %s: unbalanced parentheses", tableName)
+}
+
+func splitTopLevelComma(definitions string) []string {
+	parts := make([]string, 0)
+	start := 0
+	depth := 0
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	for i := 0; i < len(definitions); i++ {
+		ch := definitions[i]
+		switch ch {
+		case '\\':
+			i++
+			continue
+		case '\'':
+			if !inDouble && !inBacktick {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBacktick {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBacktick = !inBacktick
+			}
+		case '(':
+			if !inSingle && !inDouble && !inBacktick {
+				depth++
+			}
+		case ')':
+			if !inSingle && !inDouble && !inBacktick && depth > 0 {
+				depth--
+			}
+		case ',':
+			if !inSingle && !inDouble && !inBacktick && depth == 0 {
+				parts = append(parts, strings.TrimSpace(definitions[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	if start < len(definitions) {
+		parts = append(parts, strings.TrimSpace(definitions[start:]))
+	}
+	return parts
+}
+
+func parseInlineIndexDefinition(tableName, def string) (indexName, createSQL string, ok bool) {
+	normalized := normalizeSQLFragment(def)
+	if strings.HasPrefix(normalized, "unique index ") {
+		name, cols := parseIndexNameAndColumns(def, "UNIQUE INDEX")
+		if name == "" || cols == "" {
+			return "", "", false
+		}
+		return name, fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols), true
+	}
+	if strings.HasPrefix(normalized, "index ") || strings.HasPrefix(normalized, "key ") {
+		prefix := "INDEX"
+		if strings.HasPrefix(normalized, "key ") {
+			prefix = "KEY"
+		}
+		name, cols := parseIndexNameAndColumns(def, prefix)
+		if name == "" || cols == "" {
+			return "", "", false
+		}
+		return name, fmt.Sprintf("CREATE INDEX %s ON %s%s", name, tableName, cols), true
+	}
+	return "", "", false
+}
+
+func parseIndexNameAndColumns(def, prefix string) (indexName, columns string) {
+	trimmed := strings.TrimSpace(def)
+	upper := strings.ToUpper(trimmed)
+	p := strings.Index(upper, prefix)
+	if p < 0 {
+		return "", ""
+	}
+	rest := strings.TrimSpace(trimmed[p+len(prefix):])
+	if rest == "" {
+		return "", ""
+	}
+	name, remainder := splitIdentifierAndRest(rest)
+	if name == "" {
+		return "", ""
+	}
+	open := strings.Index(remainder, "(")
+	if open < 0 {
+		return "", ""
+	}
+	return strings.ToLower(name), strings.TrimSpace(remainder[open:])
+}
+
+func parseColumnDefinition(tableName, def string) (string, tidbColumnSpec, bool) {
+	name, rest := splitIdentifierAndRest(strings.TrimSpace(def))
+	if name == "" || rest == "" {
+		return "", tidbColumnSpec{}, false
+	}
+	colType := parseColumnType(rest)
+	if colType == "" {
+		return "", tidbColumnSpec{}, false
+	}
+	return strings.ToLower(name), tidbColumnSpec{
+		columnType: strings.ToLower(strings.TrimSpace(colType)),
+		addSQL:     fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", tableName, name, strings.TrimSpace(rest)),
+	}, true
+}
+
+func parseColumnType(rest string) string {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return ""
+	}
+	keywords := []string{" not ", " null", " default ", " generated ", " as ", " primary ", " unique ", " comment ", " references ", " auto_increment", " on update"}
+	depth := 0
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	for i := 0; i < len(rest); i++ {
+		ch := rest[i]
+		switch ch {
+		case '\\':
+			i++
+			continue
+		case '\'':
+			if !inDouble && !inBacktick {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle && !inBacktick {
+				inDouble = !inDouble
+			}
+		case '`':
+			if !inSingle && !inDouble {
+				inBacktick = !inBacktick
+			}
+		case '(':
+			if !inSingle && !inDouble && !inBacktick {
+				depth++
+			}
+		case ')':
+			if !inSingle && !inDouble && !inBacktick && depth > 0 {
+				depth--
+			}
+		}
+		if inSingle || inDouble || inBacktick || depth > 0 {
+			continue
+		}
+		suffix := " " + strings.ToLower(rest[i:])
+		for _, kw := range keywords {
+			if strings.HasPrefix(suffix, kw) {
+				return strings.TrimSpace(rest[:i])
+			}
+		}
+	}
+	return strings.TrimSpace(rest)
+}
+
+func splitIdentifierAndRest(s string) (identifier string, rest string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ""
+	}
+	if s[0] == '`' {
+		end := strings.Index(s[1:], "`")
+		if end < 0 {
+			return "", ""
+		}
+		id := s[1 : 1+end]
+		return id, strings.TrimSpace(s[1+end+1:])
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r' {
+			return s[:i], strings.TrimSpace(s[i+1:])
+		}
+	}
+	return s, ""
+}
+
+func isConstraintDefinition(def string) bool {
+	normalized := normalizeSQLFragment(def)
+	return strings.HasPrefix(normalized, "primary key") ||
+		strings.HasPrefix(normalized, "constraint ") ||
+		strings.HasPrefix(normalized, "unique key ")
+}
+
+func parseCreateIndexStatement(stmt string) (tableName, indexName, createSQL string, ok bool) {
+	normalized := normalizeSQLFragment(stmt)
+	prefix := ""
+	switch {
+	case strings.HasPrefix(normalized, "create unique index "):
+		prefix = "create unique index "
+	case strings.HasPrefix(normalized, "create index "):
+		prefix = "create index "
+	default:
+		return "", "", "", false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(normalized, prefix))
+	parts := strings.SplitN(rest, " on ", 2)
+	if len(parts) != 2 {
+		return "", "", "", false
+	}
+	nameFields := strings.Fields(parts[0])
+	if len(nameFields) == 0 {
+		return "", "", "", false
+	}
+	afterOn := strings.TrimSpace(parts[1])
+	if afterOn == "" {
+		return "", "", "", false
+	}
+	tableEnd := strings.IndexAny(afterOn, " (")
+	if tableEnd < 0 {
+		tableEnd = len(afterOn)
+	}
+	table := strings.TrimSpace(afterOn[:tableEnd])
+	if table == "" {
+		return "", "", "", false
+	}
+	return strings.ToLower(table), strings.ToLower(nameFields[0]), strings.TrimSpace(stmt), true
+}
+
+func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt string) []tidbSchemaDiff {
+	var diffs []tidbSchemaDiff
+	for _, name := range sortedColumnNames(table.columns) {
+		spec := table.columns[name]
+		col, err := meta.requireColumn(name)
+		if err != nil {
+			diffs = append(diffs, tidbSchemaDiff{
+				kind:       tidbSchemaDiffMissingColumn,
+				tableName:  table.name,
+				columnName: name,
+				detail:     fmt.Sprintf("%s schema contract: missing %s column", table.name, name),
+				repairSQL:  spec.addSQL,
+			})
+			continue
+		}
+		if normalizeSQLFragment(col.columnType) != normalizeSQLFragment(spec.columnType) {
+			diffs = append(diffs, tidbSchemaDiff{
+				kind:       tidbSchemaDiffColumnType,
+				tableName:  table.name,
+				columnName: name,
+				detail:     fmt.Sprintf("%s schema contract: %s column type = %q, want %s", table.name, name, col.columnType, spec.columnType),
+			})
+		}
+	}
+	normalizedCreate := normalizeSQLFragment(createStmt)
+	for _, name := range sortedIndexNames(table.indexes) {
+		spec := table.indexes[name]
+		if !showCreateHasIndex(normalizedCreate, name) {
+			diffs = append(diffs, tidbSchemaDiff{
+				kind:      tidbSchemaDiffMissingIndex,
+				tableName: table.name,
+				detail:    fmt.Sprintf("%s schema contract: missing %s index", table.name, name),
+				repairSQL: spec.createSQL,
+			})
+		}
+	}
+	if table.validate != nil {
+		diffs = append(diffs, table.validate(meta)...)
+	}
+	return diffs
+}
+
+func createTableStatementsByName(stmts []string) map[string]string {
+	out := make(map[string]string)
+	for _, stmt := range stmts {
+		normalized := normalizeSQLFragment(stmt)
+		const prefix = "create table if not exists "
+		if !strings.HasPrefix(normalized, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(normalized, prefix)
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			continue
+		}
+		out[fields[0]] = stmt
+	}
+	return out
+}
+
+func missingTableDiff(table tidbTableSpec) tidbSchemaDiff {
+	detail := fmt.Sprintf("%s schema contract: missing table", table.name)
+	if table.createStatement == "" {
+		detail = fmt.Sprintf("%s schema contract: missing table and no repair statement available", table.name)
+	}
+	return tidbSchemaDiff{
+		kind:      tidbSchemaDiffMissingTable,
+		tableName: table.name,
+		detail:    detail,
+		repairSQL: table.createStatement,
+	}
+}
+
+func plannedTiDBSchemaRepairs(diffs []tidbSchemaDiff) []string {
+	seen := make(map[string]struct{})
+	plans := make([]string, 0, len(diffs))
+	for _, diff := range diffs {
+		if diff.repairSQL == "" {
+			continue
+		}
+		if _, ok := seen[diff.repairSQL]; ok {
+			continue
+		}
+		seen[diff.repairSQL] = struct{}{}
+		plans = append(plans, diff.repairSQL)
+	}
+	return plans
+}
+
+func applyTiDBSchemaRepairs(db *sql.DB, statements []string) error {
+	if len(statements) == 0 {
+		return nil
+	}
+	if err := ExecSchemaStatements(db, statements); err != nil {
+		return fmt.Errorf("apply tidb schema repairs: %w", err)
+	}
+	return nil
+}
+
+func validateTiDBAutoEmbeddingFilesDiffs(meta tidbTableMeta) []tidbSchemaDiff {
+	col, err := meta.requireColumn("embedding")
+	if err != nil {
+		return nil
+	}
+	var diffs []tidbSchemaDiff
+	extra := normalizeSQLFragment(col.extra)
+	if !strings.Contains(extra, "generated") || !strings.Contains(extra, "stored") {
+		diffs = append(diffs, tidbSchemaDiff{
+			kind:       tidbSchemaDiffTableContract,
+			tableName:  "files",
+			columnName: "embedding",
+			detail:     "files schema contract: embedding column must be a stored generated column",
+		})
+	}
+	expr := normalizeSQLFragment(col.generationExpression)
+	checks := []struct {
+		pattern string
+		errMsg  string
+	}{
+		{"embed_text(", "files schema contract: embedding generated expression must use EMBED_TEXT"},
+		{tidbAutoEmbeddingModel, "files schema contract: embedding model contract mismatch"},
+		{"content_text", "files schema contract: generated expression must derive from content_text"},
+		{tidbAutoEmbeddingOptionsJSON, "files schema contract: embedding dimensions option mismatch"},
+	}
+	for _, check := range checks {
+		if !strings.Contains(expr, check.pattern) {
+			diffs = append(diffs, tidbSchemaDiff{
+				kind:       tidbSchemaDiffTableContract,
+				tableName:  "files",
+				columnName: "embedding",
+				detail:     check.errMsg,
+			})
+		}
+	}
+	return diffs
+}
+
+func validateTiDBAppEmbeddingFilesDiffs(meta tidbTableMeta) []tidbSchemaDiff {
+	col, err := meta.requireColumn("embedding")
+	if err != nil {
+		return nil
+	}
+	var diffs []tidbSchemaDiff
+	extra := normalizeSQLFragment(col.extra)
+	if strings.Contains(extra, "generated") {
+		diffs = append(diffs, tidbSchemaDiff{
+			kind:       tidbSchemaDiffTableContract,
+			tableName:  "files",
+			columnName: "embedding",
+			detail:     "files schema contract: embedding column must be writable in app mode",
+		})
+	}
+	if expr := normalizeSQLFragment(col.generationExpression); expr != "" {
+		diffs = append(diffs, tidbSchemaDiff{
+			kind:       tidbSchemaDiffTableContract,
+			tableName:  "files",
+			columnName: "embedding",
+			detail:     "files schema contract: embedding column must not define a generation expression in app mode",
+		})
+	}
+	return diffs
+}
+
+func schemaDiffsToError(diffs []tidbSchemaDiff) error {
+	if len(diffs) == 0 {
+		return nil
+	}
+	return errors.New(diffs[0].detail)
+}
+
+func sortedColumnNames(columns map[string]tidbColumnSpec) []string {
+	names := make([]string, 0, len(columns))
+	for name := range columns {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedIndexNames(indexes map[string]tidbIndexSpec) []string {
+	names := make([]string, 0, len(indexes))
+	for name := range indexes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func showCreateHasIndex(normalizedCreate, indexName string) bool {
+	needle := strings.ToLower(indexName) + " ("
+	return strings.Contains(normalizedCreate, needle)
 }

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -598,9 +598,19 @@ func diffTiDBTable(db *sql.DB, table tidbTableSpec) ([]tidbSchemaDiff, error) {
 }
 
 func tidbSchemaSpecForMode(mode TiDBEmbeddingMode) (tidbSchemaSpec, error) {
-	stmts, err := InitTiDBTenantSchemaStatementsForMode(mode)
-	if err != nil {
-		return tidbSchemaSpec{}, err
+	// For app mode, use only the base (required) statements. The optional
+	// indexes (FULLTEXT, VECTOR with ADD_COLUMNAR_REPLICA_ON_DEMAND) may be
+	// silently skipped on TiDB versions that do not support that syntax, so
+	// they must not be part of the enforceable schema contract.
+	var stmts []string
+	if mode == TiDBEmbeddingModeApp {
+		stmts = tidbAppEmbeddingBaseSchemaStatements()
+	} else {
+		var err error
+		stmts, err = InitTiDBTenantSchemaStatementsForMode(mode)
+		if err != nil {
+			return tidbSchemaSpec{}, err
+		}
 	}
 	spec, err := tidbSchemaSpecFromStatements(stmts)
 	if err != nil {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -1016,10 +1016,20 @@ func missingTableAndIndexDiffs(table tidbTableSpec) []tidbSchemaDiff {
 }
 
 func plannedTiDBSchemaRepairs(diffs []tidbSchemaDiff) []string {
+	tableMissing := make(map[string]bool)
+	for _, diff := range diffs {
+		if diff.kind == tidbSchemaDiffMissingTable {
+			tableMissing[diff.tableName] = true
+		}
+	}
+
 	seen := make(map[string]struct{})
 	plans := make([]string, 0, len(diffs))
 	for _, diff := range diffs {
 		if diff.repairSQL == "" {
+			continue
+		}
+		if !isSafeTiDBRepairDiff(diff, tableMissing) {
 			continue
 		}
 		if _, ok := seen[diff.repairSQL]; ok {
@@ -1029,6 +1039,40 @@ func plannedTiDBSchemaRepairs(diffs []tidbSchemaDiff) []string {
 		plans = append(plans, diff.repairSQL)
 	}
 	return plans
+}
+
+func isSafeTiDBRepairDiff(diff tidbSchemaDiff, tableMissing map[string]bool) bool {
+	switch diff.kind {
+	case tidbSchemaDiffMissingTable:
+		return true
+	case tidbSchemaDiffMissingColumn:
+		return isSafeAddColumnRepairSQL(diff.repairSQL)
+	case tidbSchemaDiffMissingIndex:
+		normalized := normalizeSQLFragment(diff.repairSQL)
+		if strings.HasPrefix(normalized, "create index ") {
+			return true
+		}
+		if strings.HasPrefix(normalized, "create unique index ") {
+			return tableMissing[diff.tableName]
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func isSafeAddColumnRepairSQL(sqlText string) bool {
+	n := normalizeSQLFragment(sqlText)
+	if !strings.HasPrefix(n, "alter table ") || !strings.Contains(n, " add column ") {
+		return false
+	}
+	if strings.Contains(n, " generated ") {
+		return false
+	}
+	if strings.Contains(n, " not null") && !strings.Contains(n, " default ") {
+		return false
+	}
+	return true
 }
 
 func applyTiDBSchemaRepairs(db *sql.DB, statements []string) error {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,14 +29,17 @@ const (
 	TiDBAutoEmbeddingDimensions = 1024
 )
 
-// CurrentTiDBTenantSchemaVersion is the expected schema version for TiDB tenant
-// databases. It must be bumped (as an integer) whenever tenant init SQL
-// statements change so that the next pool.createBackend call re-runs
-// EnsureTiDBSchemaForMode for all existing tenants.
+// CurrentTiDBTenantSchemaVersion is derived automatically from the content of
+// the tenant auto-embedding init SQL statements. It changes whenever any
+// statement changes, so callers never have to maintain a manual counter.
 //
-// Tenants recorded with schema_version >= CurrentTiDBTenantSchemaVersion in
+// Tenants recorded with schema_version == CurrentTiDBTenantSchemaVersion in
 // the meta store are considered up-to-date and skip the diff entirely.
-const CurrentTiDBTenantSchemaVersion = 2
+var CurrentTiDBTenantSchemaVersion = func() int {
+	stmts := tidbAutoEmbeddingSchemaStatements()
+	h := crc32.ChecksumIEEE([]byte(strings.Join(stmts, "\n")))
+	return int(int32(h))
+}()
 
 var tidbAutoEmbeddingOptionsJSON = fmt.Sprintf(`{"dimensions":%d}`, TiDBAutoEmbeddingDimensions)
 

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -28,6 +28,15 @@ const (
 	TiDBAutoEmbeddingDimensions = 1024
 )
 
+// CurrentTiDBTenantSchemaVersion is the expected schema version for TiDB tenant
+// databases. It must be bumped (as an integer) whenever tenant init SQL
+// statements change so that the next pool.createBackend call re-runs
+// EnsureTiDBSchemaForMode for all existing tenants.
+//
+// Tenants recorded with schema_version >= CurrentTiDBTenantSchemaVersion in
+// the meta store are considered up-to-date and skip the diff entirely.
+const CurrentTiDBTenantSchemaVersion = 2
+
 var tidbAutoEmbeddingOptionsJSON = fmt.Sprintf(`{"dimensions":%d}`, TiDBAutoEmbeddingDimensions)
 
 type tidbColumnMeta struct {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"go.uber.org/zap"
 )
@@ -262,11 +263,11 @@ func DetectTiDBEmbeddingMode(db *sql.DB) (TiDBEmbeddingMode, error) {
 	if db == nil {
 		return TiDBEmbeddingModeUnknown, fmt.Errorf("nil db")
 	}
-	if !IsTiDBCluster(db) {
+	if !IsTiDBCluster(ctx, db) {
 		return TiDBEmbeddingModeUnknown, fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
 	loadStart := time.Now()
-	filesMeta, err := loadTiDBTableMeta(db, "files")
+	filesMeta, err := loadTiDBTableMeta(ctx, db, "files")
 	if err != nil {
 		logger.Warn(ctx, "tenant_detect_tidb_embedding_mode_load_files_failed",
 			zap.Duration("elapsed", time.Since(loadStart)),
@@ -295,17 +296,17 @@ func DetectTiDBEmbeddingMode(db *sql.DB) (TiDBEmbeddingMode, error) {
 
 // ValidateTiDBSchemaForMode validates that an already-open TiDB connection
 // matches exactly one supported dat9 embedding contract for the requested mode.
-func ValidateTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
+func ValidateTiDBSchemaForMode(ctx context.Context, db *sql.DB, mode TiDBEmbeddingMode) error {
 	if db == nil {
 		return fmt.Errorf("nil db")
 	}
-	if !IsTiDBCluster(db) {
+	if !IsTiDBCluster(ctx, db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
 	if err := validateTiDBSchemaMode(mode); err != nil {
 		return err
 	}
-	diffs, err := diffTiDBSchemaForMode(db, mode)
+	diffs, err := diffTiDBSchemaForMode(ctx, db, mode)
 	if err != nil {
 		return err
 	}
@@ -317,11 +318,11 @@ func ValidateTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
 
 // EnsureTiDBSchemaForMode repairs known launch-schema drift that can be fixed
 // in place, then validates the full TiDB schema contract for the requested mode.
-func EnsureTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
+func EnsureTiDBSchemaForMode(ctx context.Context, db *sql.DB, mode TiDBEmbeddingMode) error {
 	if db == nil {
 		return fmt.Errorf("nil db")
 	}
-	if !IsTiDBCluster(db) {
+	if !IsTiDBCluster(ctx, db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
 	if err := validateTiDBSchemaMode(mode); err != nil {
@@ -329,7 +330,7 @@ func EnsureTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
 	}
 	const maxRepairPasses = 3
 	for i := 0; i < maxRepairPasses; i++ {
-		diffs, err := diffTiDBSchemaForMode(db, mode)
+		diffs, err := diffTiDBSchemaForMode(ctx, db, mode)
 		if err != nil {
 			return err
 		}
@@ -340,11 +341,11 @@ func EnsureTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
 		if len(repairs) == 0 {
 			break
 		}
-		if err := applyTiDBSchemaRepairs(db, repairs); err != nil {
+		if err := applyTiDBSchemaRepairs(ctx, db, repairs); err != nil {
 			return err
 		}
 	}
-	return ValidateTiDBSchemaForMode(db, mode)
+	return ValidateTiDBSchemaForMode(ctx, db, mode)
 }
 
 func validateTiDBSchemaMode(mode TiDBEmbeddingMode) error {
@@ -360,23 +361,23 @@ func initTiDBAutoEmbeddingSchema(dsn string) error {
 		return err
 	}
 	defer func() { _ = db.Close() }()
-	if !IsTiDBCluster(db) {
+	if !IsTiDBCluster(context.Background(), db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
 	if err := ExecSchemaStatements(db, tidbAutoEmbeddingSchemaStatements()); err != nil {
 		return err
 	}
-	return ValidateTiDBSchemaForMode(db, TiDBEmbeddingModeAuto)
+	return ValidateTiDBSchemaForMode(context.Background(), db, TiDBEmbeddingModeAuto)
 }
 
 // ValidateTiDBSchemaForModeDSN opens a DSN, validates the schema, and closes.
-func ValidateTiDBSchemaForModeDSN(dsn string, mode TiDBEmbeddingMode) error {
-	db, err := OpenTiDBSchemaDB(context.Background(), dsn)
+func ValidateTiDBSchemaForModeDSN(ctx context.Context, dsn string, mode TiDBEmbeddingMode) error {
+	db, err := OpenTiDBSchemaDB(ctx, dsn)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
-	return ValidateTiDBSchemaForMode(db, mode)
+	return ValidateTiDBSchemaForMode(ctx, db, mode)
 }
 
 // EnsureTiDBSchemaForModeDSN opens a DSN, repairs known launch-schema drift,
@@ -387,7 +388,7 @@ func EnsureTiDBSchemaForModeDSN(ctx context.Context, dsn string, mode TiDBEmbedd
 		return err
 	}
 	defer func() { _ = db.Close() }()
-	return EnsureTiDBSchemaForMode(db, mode)
+	return EnsureTiDBSchemaForMode(ctx, db, mode)
 }
 
 func OpenTiDBSchemaDB(ctx context.Context, dsn string) (*sql.DB, error) {
@@ -480,16 +481,16 @@ func legacyTiDBUploadsRepairStatements(meta tidbTableMeta) []string {
 	return []string{`ALTER TABLE uploads ADD COLUMN expected_revision BIGINT NULL`}
 }
 
-func loadTiDBTableMeta(db *sql.DB, tableName string) (tidbTableMeta, error) {
-	columns, err := loadTiDBColumnMeta(db, tableName)
+func loadTiDBTableMeta(ctx context.Context, db *sql.DB, tableName string) (tidbTableMeta, error) {
+	columns, err := loadTiDBColumnMeta(ctx, db, tableName)
 	if err != nil {
 		return tidbTableMeta{}, fmt.Errorf("load columns: %w", err)
 	}
 	return tidbTableMeta{tableName: tableName, columns: columns}, nil
 }
 
-func loadTiDBColumnMeta(db *sql.DB, tableName string) (map[string]tidbColumnMeta, error) {
-	rows, err := db.Query(`SELECT column_name, column_type, extra, generation_expression
+func loadTiDBColumnMeta(ctx context.Context, db *sql.DB, tableName string) (map[string]tidbColumnMeta, error) {
+	rows, err := db.QueryContext(ctx, `SELECT column_name, column_type, extra, generation_expression
 		FROM information_schema.columns
 		WHERE table_schema = DATABASE() AND table_name = ?`, tableName)
 	if err != nil {
@@ -538,11 +539,11 @@ func (m tidbTableMeta) requireColumnType(name, want string) error {
 	return nil
 }
 
-func loadShowCreateTable(db *sql.DB, tableName string) (string, error) {
+func loadShowCreateTable(ctx context.Context, db *sql.DB, tableName string) (string, error) {
 	var gotTable string
 	var createStmt string
 	query := fmt.Sprintf("SHOW CREATE TABLE %s", tableName)
-	if err := db.QueryRow(query).Scan(&gotTable, &createStmt); err != nil {
+	if err := db.QueryRowContext(ctx, query).Scan(&gotTable, &createStmt); err != nil {
 		return "", err
 	}
 	return createStmt, nil
@@ -566,14 +567,14 @@ func normalizeColumnTypeForCompare(s string) string {
 	}
 }
 
-func diffTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) ([]tidbSchemaDiff, error) {
+func diffTiDBSchemaForMode(ctx context.Context, db *sql.DB, mode TiDBEmbeddingMode) ([]tidbSchemaDiff, error) {
 	spec, err := tidbSchemaSpecForMode(mode)
 	if err != nil {
 		return nil, err
 	}
 	var diffs []tidbSchemaDiff
 	for _, table := range spec.tables {
-		tableDiffs, err := diffTiDBTable(db, table)
+		tableDiffs, err := diffTiDBTable(ctx, db, table)
 		if err != nil {
 			return nil, err
 		}
@@ -582,15 +583,15 @@ func diffTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) ([]tidbSchemaDiff
 	return diffs, nil
 }
 
-func diffTiDBTable(db *sql.DB, table tidbTableSpec) ([]tidbSchemaDiff, error) {
-	meta, err := loadTiDBTableMeta(db, table.name)
+func diffTiDBTable(ctx context.Context, db *sql.DB, table tidbTableSpec) ([]tidbSchemaDiff, error) {
+	meta, err := loadTiDBTableMeta(ctx, db, table.name)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return missingTableAndIndexDiffs(table), nil
 		}
 		return nil, fmt.Errorf("load %s table metadata: %w", table.name, err)
 	}
-	createStmt, err := loadShowCreateTable(db, table.name)
+	createStmt, err := loadShowCreateTable(ctx, db, table.name)
 	if err != nil {
 		return nil, fmt.Errorf("show create %s: %w", table.name, err)
 	}
@@ -1192,14 +1193,36 @@ func isSafeAddIndexRepairSQL(sqlText string, tableMissing bool) bool {
 	return false
 }
 
-func applyTiDBSchemaRepairs(db *sql.DB, statements []string) error {
+func applyTiDBSchemaRepairs(ctx context.Context, db *sql.DB, statements []string) error {
 	if len(statements) == 0 {
 		return nil
 	}
-	if err := ExecSchemaStatements(db, statements); err != nil {
-		return fmt.Errorf("apply tidb schema repairs: %w", err)
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			if isIgnorableTiDBSchemaError(err) {
+				continue
+			}
+			return fmt.Errorf("apply tidb schema repair %q: %w", schemaStatementSnippet(stmt), err)
+		}
 	}
 	return nil
+}
+
+func isIgnorableTiDBSchemaError(err error) bool {
+	var me *mysql.MySQLError
+	if errors.As(err, &me) {
+		switch me.Number {
+		case 1050, 1060, 1061:
+			return true
+		}
+		msg := strings.ToLower(me.Message)
+		if strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate") {
+			return true
+		}
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate")
 }
 
 func validateTiDBAutoEmbeddingFilesDiffs(meta tidbTableMeta) []tidbSchemaDiff {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -354,22 +354,6 @@ func OpenTiDBSchemaDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	return db, nil
 }
 
-func validateTiDBTableForMode(mode TiDBEmbeddingMode, meta tidbTableMeta) error {
-	switch meta.tableName {
-	case "files":
-		switch mode {
-		case TiDBEmbeddingModeAuto:
-			return validateTiDBAutoEmbeddingFilesTable(meta)
-		case TiDBEmbeddingModeApp:
-			return validateTiDBAppEmbeddingFilesTable(meta)
-		default:
-			return fmt.Errorf("unsupported TiDB embedding mode %q", mode)
-		}
-	default:
-		return fmt.Errorf("unsupported table %q", meta.tableName)
-	}
-}
-
 func detectTiDBEmbeddingModeFromFilesMeta(meta tidbTableMeta) (TiDBEmbeddingMode, error) {
 	col, err := meta.requireColumn("embedding")
 	if err != nil {
@@ -438,14 +422,6 @@ func validateTiDBUploadsTableBase(meta tidbTableMeta) error {
 	return meta.requireColumnType("expected_revision", "bigint")
 }
 
-func repairLegacyTiDBUploadsSchema(db *sql.DB) error {
-	uploadsMeta, err := loadTiDBTableMeta(db, "uploads")
-	if err != nil {
-		return fmt.Errorf("load uploads table metadata: %w", err)
-	}
-	return ExecSchemaStatements(db, legacyTiDBUploadsRepairStatements(uploadsMeta))
-}
-
 func legacyTiDBUploadsRepairStatements(meta tidbTableMeta) []string {
 	if _, ok := meta.columns["expected_revision"]; ok {
 		return nil
@@ -459,13 +435,6 @@ func loadTiDBTableMeta(db *sql.DB, tableName string) (tidbTableMeta, error) {
 		return tidbTableMeta{}, fmt.Errorf("load columns: %w", err)
 	}
 	return tidbTableMeta{tableName: tableName, columns: columns}, nil
-}
-
-func ensureTiDBTableExists(db *sql.DB, tableName string) error {
-	if _, err := loadShowCreateTable(db, tableName); err != nil {
-		return fmt.Errorf("show create table: %w", err)
-	}
-	return nil
 }
 
 func loadTiDBColumnMeta(db *sql.DB, tableName string) (map[string]tidbColumnMeta, error) {
@@ -512,7 +481,7 @@ func (m tidbTableMeta) requireColumnType(name, want string) error {
 	if err != nil {
 		return err
 	}
-	if normalizeSQLFragment(col.columnType) != normalizeSQLFragment(want) {
+	if normalizeColumnTypeForCompare(col.columnType) != normalizeColumnTypeForCompare(want) {
 		return fmt.Errorf("%s column type = %q, want %s", name, col.columnType, want)
 	}
 	return nil
@@ -534,6 +503,16 @@ func normalizeSQLFragment(s string) string {
 	s = strings.ReplaceAll(s, "_utf8mb4", "")
 	fields := strings.Fields(s)
 	return strings.Join(fields, " ")
+}
+
+func normalizeColumnTypeForCompare(s string) string {
+	normalized := normalizeSQLFragment(s)
+	switch normalized {
+	case "bool", "boolean", "tinyint(1)":
+		return "boolean"
+	default:
+		return normalized
+	}
 }
 
 func diffTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) ([]tidbSchemaDiff, error) {
@@ -972,7 +951,7 @@ func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt strin
 			})
 			continue
 		}
-		if normalizeSQLFragment(col.columnType) != normalizeSQLFragment(spec.columnType) {
+		if normalizeColumnTypeForCompare(col.columnType) != normalizeColumnTypeForCompare(spec.columnType) {
 			diffs = append(diffs, tidbSchemaDiff{
 				kind:       tidbSchemaDiffColumnType,
 				tableName:  table.name,
@@ -997,24 +976,6 @@ func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt strin
 		diffs = append(diffs, table.validate(meta)...)
 	}
 	return diffs
-}
-
-func createTableStatementsByName(stmts []string) map[string]string {
-	out := make(map[string]string)
-	for _, stmt := range stmts {
-		normalized := normalizeSQLFragment(stmt)
-		const prefix = "create table if not exists "
-		if !strings.HasPrefix(normalized, prefix) {
-			continue
-		}
-		rest := strings.TrimPrefix(normalized, prefix)
-		fields := strings.Fields(rest)
-		if len(fields) == 0 {
-			continue
-		}
-		out[fields[0]] = stmt
-	}
-	return out
 }
 
 func missingTableDiff(table tidbTableSpec) tidbSchemaDiff {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -110,6 +110,7 @@ type tidbTableSpec struct {
 	createStatement string
 	columns         map[string]tidbColumnSpec
 	indexes         map[string]tidbIndexSpec
+	primaryKey      tidbPrimaryKeySpec
 	validate        func(tidbTableMeta) []tidbSchemaDiff
 }
 
@@ -120,6 +121,10 @@ type tidbColumnSpec struct {
 
 type tidbIndexSpec struct {
 	createSQL string
+}
+
+type tidbPrimaryKeySpec struct {
+	columns []string
 }
 
 type tidbSchemaDiffError struct {
@@ -680,9 +685,14 @@ func parseCreateTableSpec(stmt string) (tidbTableSpec, bool, error) {
 	}
 	columns := make(map[string]tidbColumnSpec)
 	indexes := make(map[string]tidbIndexSpec)
+	var primaryKey tidbPrimaryKeySpec
 	for _, def := range splitTopLevelComma(defs) {
 		def = strings.TrimSpace(def)
 		if def == "" {
+			continue
+		}
+		if pkSpec, ok := parsePrimaryKeyDefinition(def); ok {
+			primaryKey = pkSpec
 			continue
 		}
 		if indexName, createSQL, ok := parseInlineIndexDefinition(tableName, def); ok {
@@ -697,23 +707,35 @@ func parseCreateTableSpec(stmt string) (tidbTableSpec, bool, error) {
 			continue
 		}
 		columns[colName] = colSpec
+		if pkCol, ok := parseInlinePrimaryKeyColumn(def); ok {
+			primaryKey = tidbPrimaryKeySpec{columns: []string{pkCol}}
+		}
 	}
 	return tidbTableSpec{
 		name:            tableName,
 		createStatement: strings.TrimSpace(stmt),
 		columns:         columns,
 		indexes:         indexes,
+		primaryKey:      primaryKey,
 	}, true, nil
 }
 
 func parseCreateTableStatement(stmt string) (tableName string, definitions string, ok bool, err error) {
 	lower := strings.ToLower(stmt)
-	const prefix = "create table if not exists"
-	start := strings.Index(lower, prefix)
+	prefixes := []string{"create table if not exists", "create table"}
+	start := -1
+	prefixLen := 0
+	for _, prefix := range prefixes {
+		if idx := strings.Index(lower, prefix); idx >= 0 {
+			start = idx
+			prefixLen = len(prefix)
+			break
+		}
+	}
 	if start < 0 {
 		return "", "", false, nil
 	}
-	i := start + len(prefix)
+	i := start + prefixLen
 	for i < len(stmt) && (stmt[i] == ' ' || stmt[i] == '\n' || stmt[i] == '\t' || stmt[i] == '\r') {
 		i++
 	}
@@ -871,6 +893,80 @@ func parseIndexNameAndColumns(def, prefix string) (indexName, columns string) {
 		return "", ""
 	}
 	return strings.ToLower(name), strings.TrimSpace(remainder[open:])
+}
+
+func parsePrimaryKeyDefinition(def string) (tidbPrimaryKeySpec, bool) {
+	normalized := normalizeSQLFragment(def)
+	isPrimaryConstraint := strings.HasPrefix(normalized, "primary key")
+	isNamedPrimaryConstraint := strings.HasPrefix(normalized, "constraint ") && strings.Contains(normalized, " primary key ")
+	if !isPrimaryConstraint && !isNamedPrimaryConstraint {
+		return tidbPrimaryKeySpec{}, false
+	}
+	columns := parseKeyColumnList(def, "PRIMARY KEY")
+	if len(columns) == 0 {
+		return tidbPrimaryKeySpec{}, false
+	}
+	return tidbPrimaryKeySpec{columns: columns}, true
+}
+
+func parseInlinePrimaryKeyColumn(def string) (string, bool) {
+	if !strings.Contains(normalizeSQLFragment(def), " primary key") {
+		return "", false
+	}
+	name, rest := splitIdentifierAndRest(strings.TrimSpace(def))
+	if name == "" || rest == "" {
+		return "", false
+	}
+	return strings.ToLower(name), true
+}
+
+func parseKeyColumnList(def, token string) []string {
+	upper := strings.ToUpper(def)
+	pos := strings.Index(upper, token)
+	if pos < 0 {
+		return nil
+	}
+	rest := strings.TrimSpace(def[pos+len(token):])
+	open := strings.Index(rest, "(")
+	close := strings.LastIndex(rest, ")")
+	if open < 0 || close <= open {
+		return nil
+	}
+	inner := strings.TrimSpace(rest[open+1 : close])
+	if inner == "" {
+		return nil
+	}
+	parts := splitTopLevelComma(inner)
+	columns := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name := parseColumnReferenceName(part)
+		if name == "" {
+			return nil
+		}
+		columns = append(columns, name)
+	}
+	return columns
+}
+
+func parseColumnReferenceName(def string) string {
+	trimmed := strings.TrimSpace(def)
+	if trimmed == "" {
+		return ""
+	}
+	if trimmed[0] == '`' {
+		end := strings.Index(trimmed[1:], "`")
+		if end < 0 {
+			return ""
+		}
+		return strings.ToLower(trimmed[1 : 1+end])
+	}
+	for i := 0; i < len(trimmed); i++ {
+		switch trimmed[i] {
+		case ' ', '\t', '\n', '\r', '(':
+			return strings.ToLower(trimmed[:i])
+		}
+	}
+	return strings.ToLower(trimmed)
 }
 
 func parseColumnDefinition(tableName, def string) (string, tidbColumnSpec, bool) {
@@ -1065,6 +1161,22 @@ func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt strin
 			})
 		}
 	}
+	if len(table.primaryKey.columns) > 0 {
+		actualPrimaryKey, ok := parsePrimaryKeyColumnsFromCreateStatement(createStmt)
+		if !ok {
+			diffs = append(diffs, tidbSchemaDiff{
+				kind:      tidbSchemaDiffTableContract,
+				tableName: table.name,
+				detail:    fmt.Sprintf("%s schema contract: missing primary key constraint", table.name),
+			})
+		} else if !equalStringSlices(actualPrimaryKey, table.primaryKey.columns) {
+			diffs = append(diffs, tidbSchemaDiff{
+				kind:      tidbSchemaDiffTableContract,
+				tableName: table.name,
+				detail:    fmt.Sprintf("%s schema contract: primary key columns = (%s), want (%s)", table.name, strings.Join(actualPrimaryKey, ", "), strings.Join(table.primaryKey.columns, ", ")),
+			})
+		}
+	}
 	normalizedCreate := normalizeSQLFragment(createStmt)
 	for _, name := range sortedIndexNames(table.indexes) {
 		spec := table.indexes[name]
@@ -1081,6 +1193,38 @@ func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt strin
 		diffs = append(diffs, table.validate(meta)...)
 	}
 	return diffs
+}
+
+func parsePrimaryKeyColumnsFromCreateStatement(createStmt string) ([]string, bool) {
+	_, defs, ok, err := parseCreateTableStatement(createStmt)
+	if err != nil || !ok {
+		return nil, false
+	}
+	for _, def := range splitTopLevelComma(defs) {
+		def = strings.TrimSpace(def)
+		if def == "" {
+			continue
+		}
+		if pkSpec, ok := parsePrimaryKeyDefinition(def); ok {
+			return pkSpec.columns, true
+		}
+		if columnName, ok := parseInlinePrimaryKeyColumn(def); ok {
+			return []string{columnName}, true
+		}
+	}
+	return nil, false
+}
+
+func equalStringSlices(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func missingTableDiff(table tidbTableSpec) tidbSchemaDiff {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -601,6 +601,9 @@ func tidbSchemaSpecFromStatements(stmts []string) (tidbSchemaSpec, error) {
 	for _, stmt := range stmts {
 		tableName, indexName, createSQL, ok := parseCreateIndexStatement(stmt)
 		if !ok {
+			tableName, indexName, createSQL, ok = parseAlterTableAddIndexStatement(stmt)
+		}
+		if !ok {
 			continue
 		}
 		tableIndex, exists := byName[tableName]
@@ -946,6 +949,46 @@ func parseCreateIndexStatement(stmt string) (tableName, indexName, createSQL str
 	return strings.ToLower(table), strings.ToLower(nameFields[0]), strings.TrimSpace(stmt), true
 }
 
+func parseAlterTableAddIndexStatement(stmt string) (tableName, indexName, createSQL string, ok bool) {
+	normalized := normalizeSQLFragment(stmt)
+	const prefix = "alter table "
+	if !strings.HasPrefix(normalized, prefix) {
+		return "", "", "", false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(normalized, prefix))
+	if rest == "" {
+		return "", "", "", false
+	}
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return "", "", "", false
+	}
+	table := strings.ToLower(fields[0])
+
+	markers := []string{" add fulltext index ", " add vector index ", " add unique index ", " add index ", " add key "}
+	for _, marker := range markers {
+		pos := strings.Index(normalized, marker)
+		if pos < 0 {
+			continue
+		}
+		indexPart := strings.TrimSpace(normalized[pos+len(marker):])
+		if indexPart == "" {
+			return "", "", "", false
+		}
+		name := indexPart
+		if open := strings.Index(name, "("); open >= 0 {
+			name = name[:open]
+		}
+		nameFields := strings.Fields(name)
+		if len(nameFields) == 0 {
+			return "", "", "", false
+		}
+		return table, strings.ToLower(nameFields[0]), strings.TrimSpace(stmt), true
+	}
+
+	return "", "", "", false
+}
+
 func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt string) []tidbSchemaDiff {
 	var diffs []tidbSchemaDiff
 	for _, name := range sortedColumnNames(table.columns) {
@@ -1048,14 +1091,7 @@ func isSafeTiDBRepairDiff(diff tidbSchemaDiff, tableMissing map[string]bool) boo
 	case tidbSchemaDiffMissingColumn:
 		return isSafeAddColumnRepairSQL(diff.repairSQL)
 	case tidbSchemaDiffMissingIndex:
-		normalized := normalizeSQLFragment(diff.repairSQL)
-		if strings.HasPrefix(normalized, "create index ") {
-			return true
-		}
-		if strings.HasPrefix(normalized, "create unique index ") {
-			return tableMissing[diff.tableName]
-		}
-		return false
+		return isSafeAddIndexRepairSQL(diff.repairSQL, tableMissing[diff.tableName])
 	default:
 		return false
 	}
@@ -1066,13 +1102,43 @@ func isSafeAddColumnRepairSQL(sqlText string) bool {
 	if !strings.HasPrefix(n, "alter table ") || !strings.Contains(n, " add column ") {
 		return false
 	}
-	if strings.Contains(n, " generated ") {
+	if isGeneratedColumnAddSQL(n) {
 		return false
 	}
 	if strings.Contains(n, " not null") && !strings.Contains(n, " default ") {
 		return false
 	}
 	return true
+}
+
+func isGeneratedColumnAddSQL(normalizedSQL string) bool {
+	if strings.Contains(normalizedSQL, " generated ") {
+		return true
+	}
+	hasAsExpr := strings.Contains(normalizedSQL, " as (")
+	if !hasAsExpr {
+		return false
+	}
+	return strings.Contains(normalizedSQL, " stored") || strings.Contains(normalizedSQL, " virtual")
+}
+
+func isSafeAddIndexRepairSQL(sqlText string, tableMissing bool) bool {
+	normalized := normalizeSQLFragment(sqlText)
+	if strings.HasPrefix(normalized, "create index ") {
+		return true
+	}
+	if strings.HasPrefix(normalized, "create unique index ") {
+		return tableMissing
+	}
+	if strings.HasPrefix(normalized, "alter table ") {
+		if strings.Contains(normalized, " add unique index ") || strings.Contains(normalized, " add unique key ") {
+			return tableMissing
+		}
+		if strings.Contains(normalized, " add fulltext index ") || strings.Contains(normalized, " add vector index ") || strings.Contains(normalized, " add index ") || strings.Contains(normalized, " add key ") {
+			return true
+		}
+	}
+	return false
 }
 
 func applyTiDBSchemaRepairs(db *sql.DB, statements []string) error {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -5,13 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
-	mysql "github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/dat9/internal/schemaspec"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"go.uber.org/zap"
 )
@@ -46,16 +45,15 @@ const (
 // re-applying our schema (e.g., a required migration for a new major version),
 // update any statement in tidbAutoEmbeddingSchemaStatements() to force a hash
 // change and trigger a one-time re-Ensure for all tenants.
-var CurrentTiDBTenantSchemaVersion = func() int {
-	stmts := tidbAutoEmbeddingSchemaStatements()
+var CurrentTiDBTenantSchemaVersion = currentTiDBTenantSchemaVersion(tidbAutoEmbeddingSchemaStatements())
+
+func currentTiDBTenantSchemaVersion(stmts []string) int {
 	// Hash only statements that are parsed into the schema spec (CREATE TABLE,
 	// CREATE [UNIQUE] INDEX, ALTER TABLE ... ADD ... INDEX).  Statements that
 	// fall into none of these categories (e.g. SET, comments) do not affect
 	// what ValidateTiDBSchemaForMode checks, so including them would cause
 	// unnecessary re-Ensures on unrelated edits.
 	//
-	// int(h) is safe: uint32 → int on a 64-bit platform is always non-negative,
-	// unlike int(int32(h)) which sign-extends for values with bit 31 set.
 	var specStmts []string
 	for _, stmt := range stmts {
 		n := normalizeSQLFragment(stmt)
@@ -63,12 +61,11 @@ var CurrentTiDBTenantSchemaVersion = func() int {
 			strings.HasPrefix(n, "create index ") ||
 			strings.HasPrefix(n, "create unique index ") ||
 			(strings.HasPrefix(n, "alter table ") && strings.Contains(n, " add ") && strings.Contains(n, " index ")) {
-			specStmts = append(specStmts, stmt)
+			specStmts = append(specStmts, schemaspec.CanonicalStatementForHash(stmt))
 		}
 	}
-	h := crc32.ChecksumIEEE([]byte(strings.Join(specStmts, "\n")))
-	return int(h)
-}()
+	return schemaspec.CRC32Version(specStmts)
+}
 
 var tidbAutoEmbeddingOptionsJSON = fmt.Sprintf(`{"dimensions":%d}`, TiDBAutoEmbeddingDimensions)
 
@@ -344,6 +341,7 @@ func EnsureTiDBSchemaForMode(ctx context.Context, db *sql.DB, mode TiDBEmbedding
 		}
 		repairs := plannedTiDBSchemaRepairs(diffs)
 		if len(repairs) == 0 {
+			// Drift remains but nothing in it is safe to repair automatically.
 			break
 		}
 		if err := applyTiDBSchemaRepairs(ctx, db, repairs); err != nil {
@@ -479,13 +477,6 @@ func validateTiDBUploadsTableBase(meta tidbTableMeta) error {
 	return meta.requireColumnType("expected_revision", "bigint")
 }
 
-func legacyTiDBUploadsRepairStatements(meta tidbTableMeta) []string {
-	if _, ok := meta.columns["expected_revision"]; ok {
-		return nil
-	}
-	return []string{`ALTER TABLE uploads ADD COLUMN expected_revision BIGINT NULL`}
-}
-
 func loadTiDBTableMeta(ctx context.Context, db *sql.DB, tableName string) (tidbTableMeta, error) {
 	columns, err := loadTiDBColumnMeta(ctx, db, tableName)
 	if err != nil {
@@ -555,11 +546,7 @@ func loadShowCreateTable(ctx context.Context, db *sql.DB, tableName string) (str
 }
 
 func normalizeSQLFragment(s string) string {
-	s = strings.ToLower(s)
-	s = strings.ReplaceAll(s, "`", "")
-	s = strings.ReplaceAll(s, "_utf8mb4", "")
-	fields := strings.Fields(s)
-	return strings.Join(fields, " ")
+	return schemaspec.NormalizeSQLFragment(s)
 }
 
 func normalizeColumnTypeForCompare(s string) string {
@@ -721,133 +708,11 @@ func parseCreateTableSpec(stmt string) (tidbTableSpec, bool, error) {
 }
 
 func parseCreateTableStatement(stmt string) (tableName string, definitions string, ok bool, err error) {
-	lower := strings.ToLower(stmt)
-	prefixes := []string{"create table if not exists", "create table"}
-	start := -1
-	prefixLen := 0
-	for _, prefix := range prefixes {
-		if idx := strings.Index(lower, prefix); idx >= 0 {
-			start = idx
-			prefixLen = len(prefix)
-			break
-		}
-	}
-	if start < 0 {
-		return "", "", false, nil
-	}
-	i := start + prefixLen
-	for i < len(stmt) && (stmt[i] == ' ' || stmt[i] == '\n' || stmt[i] == '\t' || stmt[i] == '\r') {
-		i++
-	}
-	if i >= len(stmt) {
-		return "", "", false, fmt.Errorf("parse create table: missing table name")
-	}
-	nameStart := i
-	if stmt[i] == '`' {
-		i++
-		for i < len(stmt) && stmt[i] != '`' {
-			i++
-		}
-		if i >= len(stmt) {
-			return "", "", false, fmt.Errorf("parse create table: unterminated quoted table name")
-		}
-		tableName = strings.ToLower(stmt[nameStart+1 : i])
-		i++
-	} else {
-		for i < len(stmt) && stmt[i] != ' ' && stmt[i] != '\n' && stmt[i] != '\t' && stmt[i] != '(' {
-			i++
-		}
-		tableName = strings.ToLower(strings.TrimSpace(stmt[nameStart:i]))
-	}
-	for i < len(stmt) && stmt[i] != '(' {
-		i++
-	}
-	if i >= len(stmt) || stmt[i] != '(' {
-		return "", "", false, fmt.Errorf("parse create table %s: missing opening parenthesis", tableName)
-	}
-	bodyStart := i + 1
-	depth := 1
-	inSingle := false
-	inDouble := false
-	inBacktick := false
-	for i = bodyStart; i < len(stmt); i++ {
-		ch := stmt[i]
-		switch ch {
-		case '\\':
-			i++
-			continue
-		case '\'':
-			if !inDouble && !inBacktick {
-				inSingle = !inSingle
-			}
-		case '"':
-			if !inSingle && !inBacktick {
-				inDouble = !inDouble
-			}
-		case '`':
-			if !inSingle && !inDouble {
-				inBacktick = !inBacktick
-			}
-		case '(':
-			if !inSingle && !inDouble && !inBacktick {
-				depth++
-			}
-		case ')':
-			if !inSingle && !inDouble && !inBacktick {
-				depth--
-				if depth == 0 {
-					return tableName, stmt[bodyStart:i], true, nil
-				}
-			}
-		}
-	}
-	return "", "", false, fmt.Errorf("parse create table %s: unbalanced parentheses", tableName)
+	return schemaspec.ParseCreateTableStatement(stmt)
 }
 
 func splitTopLevelComma(definitions string) []string {
-	parts := make([]string, 0)
-	start := 0
-	depth := 0
-	inSingle := false
-	inDouble := false
-	inBacktick := false
-	for i := 0; i < len(definitions); i++ {
-		ch := definitions[i]
-		switch ch {
-		case '\\':
-			i++
-			continue
-		case '\'':
-			if !inDouble && !inBacktick {
-				inSingle = !inSingle
-			}
-		case '"':
-			if !inSingle && !inBacktick {
-				inDouble = !inDouble
-			}
-		case '`':
-			if !inSingle && !inDouble {
-				inBacktick = !inBacktick
-			}
-		case '(':
-			if !inSingle && !inDouble && !inBacktick {
-				depth++
-			}
-		case ')':
-			if !inSingle && !inDouble && !inBacktick && depth > 0 {
-				depth--
-			}
-		case ',':
-			if !inSingle && !inDouble && !inBacktick && depth == 0 {
-				parts = append(parts, strings.TrimSpace(definitions[start:i]))
-				start = i + 1
-			}
-		}
-	}
-	if start < len(definitions) {
-		parts = append(parts, strings.TrimSpace(definitions[start:]))
-	}
-	return parts
+	return schemaspec.SplitTopLevelComma(definitions)
 }
 
 func parseInlineIndexDefinition(tableName, def string) (indexName, createSQL string, ok bool) {
@@ -985,74 +850,11 @@ func parseColumnDefinition(tableName, def string) (string, tidbColumnSpec, bool)
 }
 
 func parseColumnType(rest string) string {
-	rest = strings.TrimSpace(rest)
-	if rest == "" {
-		return ""
-	}
-	keywords := []string{" not ", " null", " default ", " generated ", " as ", " primary ", " unique ", " comment ", " references ", " auto_increment", " on update"}
-	depth := 0
-	inSingle := false
-	inDouble := false
-	inBacktick := false
-	for i := 0; i < len(rest); i++ {
-		ch := rest[i]
-		switch ch {
-		case '\\':
-			i++
-			continue
-		case '\'':
-			if !inDouble && !inBacktick {
-				inSingle = !inSingle
-			}
-		case '"':
-			if !inSingle && !inBacktick {
-				inDouble = !inDouble
-			}
-		case '`':
-			if !inSingle && !inDouble {
-				inBacktick = !inBacktick
-			}
-		case '(':
-			if !inSingle && !inDouble && !inBacktick {
-				depth++
-			}
-		case ')':
-			if !inSingle && !inDouble && !inBacktick && depth > 0 {
-				depth--
-			}
-		}
-		if inSingle || inDouble || inBacktick || depth > 0 {
-			continue
-		}
-		suffix := " " + strings.ToLower(rest[i:])
-		for _, kw := range keywords {
-			if strings.HasPrefix(suffix, kw) {
-				return strings.TrimSpace(rest[:i])
-			}
-		}
-	}
-	return strings.TrimSpace(rest)
+	return schemaspec.ParseColumnType(rest)
 }
 
 func splitIdentifierAndRest(s string) (identifier string, rest string) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", ""
-	}
-	if s[0] == '`' {
-		end := strings.Index(s[1:], "`")
-		if end < 0 {
-			return "", ""
-		}
-		id := s[1 : 1+end]
-		return id, strings.TrimSpace(s[1+end+1:])
-	}
-	for i := 0; i < len(s); i++ {
-		if s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r' {
-			return s[:i], strings.TrimSpace(s[i+1:])
-		}
-	}
-	return s, ""
+	return schemaspec.SplitIdentifierAndRest(s)
 }
 
 func isConstraintDefinition(def string) bool {
@@ -1294,28 +1096,7 @@ func isSafeTiDBRepairDiff(diff tidbSchemaDiff, tableMissing map[string]bool) boo
 }
 
 func isSafeAddColumnRepairSQL(sqlText string) bool {
-	n := normalizeSQLFragment(sqlText)
-	if !strings.HasPrefix(n, "alter table ") || !strings.Contains(n, " add column ") {
-		return false
-	}
-	if isGeneratedColumnAddSQL(n) {
-		return false
-	}
-	if strings.Contains(n, " not null") && !strings.Contains(n, " default ") {
-		return false
-	}
-	return true
-}
-
-func isGeneratedColumnAddSQL(normalizedSQL string) bool {
-	if strings.Contains(normalizedSQL, " generated ") {
-		return true
-	}
-	hasAsExpr := strings.Contains(normalizedSQL, " as (")
-	if !hasAsExpr {
-		return false
-	}
-	return strings.Contains(normalizedSQL, " stored") || strings.Contains(normalizedSQL, " virtual")
+	return schemaspec.IsSafeAddColumnRepairSQL(sqlText)
 }
 
 func isSafeAddIndexRepairSQL(sqlText string, tableMissing bool) bool {
@@ -1353,20 +1134,7 @@ func applyTiDBSchemaRepairs(ctx context.Context, db *sql.DB, statements []string
 }
 
 func isIgnorableTiDBSchemaError(err error) bool {
-	var me *mysql.MySQLError
-	if errors.As(err, &me) {
-		switch me.Number {
-		case 1050, 1060, 1061:
-			return true
-		}
-		msg := strings.ToLower(me.Message)
-		if strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate") {
-			return true
-		}
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate")
+	return schemaspec.IsIgnorableMySQLError(err)
 }
 
 func validateTiDBAutoEmbeddingFilesDiffs(meta tidbTableMeta) []tidbSchemaDiff {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -47,8 +47,26 @@ const (
 // change and trigger a one-time re-Ensure for all tenants.
 var CurrentTiDBTenantSchemaVersion = func() int {
 	stmts := tidbAutoEmbeddingSchemaStatements()
-	h := crc32.ChecksumIEEE([]byte(strings.Join(stmts, "\n")))
-	return int(int32(h))
+	// Hash only statements that are parsed into the schema spec (CREATE TABLE,
+	// CREATE [UNIQUE] INDEX, ALTER TABLE ... ADD ... INDEX).  Statements that
+	// fall into none of these categories (e.g. SET, comments) do not affect
+	// what ValidateTiDBSchemaForMode checks, so including them would cause
+	// unnecessary re-Ensures on unrelated edits.
+	//
+	// int(h) is safe: uint32 → int on a 64-bit platform is always non-negative,
+	// unlike int(int32(h)) which sign-extends for values with bit 31 set.
+	var specStmts []string
+	for _, stmt := range stmts {
+		n := normalizeSQLFragment(stmt)
+		if strings.HasPrefix(n, "create table ") ||
+			strings.HasPrefix(n, "create index ") ||
+			strings.HasPrefix(n, "create unique index ") ||
+			(strings.HasPrefix(n, "alter table ") && strings.Contains(n, " add ") && strings.Contains(n, " index ")) {
+			specStmts = append(specStmts, stmt)
+		}
+	}
+	h := crc32.ChecksumIEEE([]byte(strings.Join(specStmts, "\n")))
+	return int(h)
 }()
 
 var tidbAutoEmbeddingOptionsJSON = fmt.Sprintf(`{"dimensions":%d}`, TiDBAutoEmbeddingDimensions)

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -286,12 +286,22 @@ func EnsureTiDBSchemaForMode(db *sql.DB, mode TiDBEmbeddingMode) error {
 	if err := validateTiDBSchemaMode(mode); err != nil {
 		return err
 	}
-	diffs, err := diffTiDBSchemaForMode(db, mode)
-	if err != nil {
-		return err
-	}
-	if err := applyTiDBSchemaRepairs(db, plannedTiDBSchemaRepairs(diffs)); err != nil {
-		return err
+	const maxRepairPasses = 3
+	for i := 0; i < maxRepairPasses; i++ {
+		diffs, err := diffTiDBSchemaForMode(db, mode)
+		if err != nil {
+			return err
+		}
+		if len(diffs) == 0 {
+			return nil
+		}
+		repairs := plannedTiDBSchemaRepairs(diffs)
+		if len(repairs) == 0 {
+			break
+		}
+		if err := applyTiDBSchemaRepairs(db, repairs); err != nil {
+			return err
+		}
 	}
 	return ValidateTiDBSchemaForMode(db, mode)
 }
@@ -535,7 +545,7 @@ func diffTiDBTable(db *sql.DB, table tidbTableSpec) ([]tidbSchemaDiff, error) {
 	meta, err := loadTiDBTableMeta(db, table.name)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return []tidbSchemaDiff{missingTableDiff(table)}, nil
+			return missingTableAndIndexDiffs(table), nil
 		}
 		return nil, fmt.Errorf("load %s table metadata: %w", table.name, err)
 	}
@@ -576,7 +586,7 @@ func tidbSchemaSpecForMode(mode TiDBEmbeddingMode) (tidbSchemaSpec, error) {
 
 func tidbSchemaSpecFromStatements(stmts []string) (tidbSchemaSpec, error) {
 	tables := make([]tidbTableSpec, 0)
-	byName := make(map[string]*tidbTableSpec)
+	byName := make(map[string]int)
 	for _, stmt := range stmts {
 		table, ok, err := parseCreateTableSpec(stmt)
 		if err != nil {
@@ -586,21 +596,21 @@ func tidbSchemaSpecFromStatements(stmts []string) (tidbSchemaSpec, error) {
 			continue
 		}
 		tables = append(tables, table)
-		byName[table.name] = &tables[len(tables)-1]
+		byName[table.name] = len(tables) - 1
 	}
 	for _, stmt := range stmts {
 		tableName, indexName, createSQL, ok := parseCreateIndexStatement(stmt)
 		if !ok {
 			continue
 		}
-		t, exists := byName[tableName]
+		tableIndex, exists := byName[tableName]
 		if !exists {
 			continue
 		}
-		if t.indexes == nil {
-			t.indexes = make(map[string]tidbIndexSpec)
+		if tables[tableIndex].indexes == nil {
+			tables[tableIndex].indexes = make(map[string]tidbIndexSpec)
 		}
-		t.indexes[indexName] = tidbIndexSpec{createSQL: strings.TrimSpace(createSQL)}
+		tables[tableIndex].indexes[indexName] = tidbIndexSpec{createSQL: strings.TrimSpace(createSQL)}
 	}
 	return tidbSchemaSpec{tables: tables}, nil
 }
@@ -989,6 +999,20 @@ func missingTableDiff(table tidbTableSpec) tidbSchemaDiff {
 		detail:    detail,
 		repairSQL: table.createStatement,
 	}
+}
+
+func missingTableAndIndexDiffs(table tidbTableSpec) []tidbSchemaDiff {
+	diffs := []tidbSchemaDiff{missingTableDiff(table)}
+	for _, name := range sortedIndexNames(table.indexes) {
+		spec := table.indexes[name]
+		diffs = append(diffs, tidbSchemaDiff{
+			kind:      tidbSchemaDiffMissingIndex,
+			tableName: table.name,
+			detail:    fmt.Sprintf("%s schema contract: missing %s index", table.name, name),
+			repairSQL: spec.createSQL,
+		})
+	}
+	return diffs
 }
 
 func plannedTiDBSchemaRepairs(diffs []tidbSchemaDiff) []string {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -31,10 +31,20 @@ const (
 
 // CurrentTiDBTenantSchemaVersion is derived automatically from the content of
 // the tenant auto-embedding init SQL statements. It changes whenever any
-// statement changes, so callers never have to maintain a manual counter.
+// statement in the Go source changes, so callers never have to maintain a
+// manual counter.
 //
 // Tenants recorded with schema_version == CurrentTiDBTenantSchemaVersion in
-// the meta store are considered up-to-date and skip the diff entirely.
+// the meta store are skipped by EnsureTiDBSchemaForMode entirely.
+//
+// NOTE: this hash captures only changes to our Go-side SQL definitions, NOT
+// changes to the TiDB server version.  Upgrading TiDB itself does not change
+// the hash; existing tenant schemas therefore continue to be skipped
+// correctly, because a TiDB version upgrade does not alter the user table
+// structure that our init SQL created.  If a TiDB upgrade ever requires
+// re-applying our schema (e.g., a required migration for a new major version),
+// update any statement in tidbAutoEmbeddingSchemaStatements() to force a hash
+// change and trigger a one-time re-Ensure for all tenants.
 var CurrentTiDBTenantSchemaVersion = func() int {
 	stmts := tidbAutoEmbeddingSchemaStatements()
 	h := crc32.ChecksumIEEE([]byte(strings.Join(stmts, "\n")))

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -199,6 +199,21 @@ func TestPlannedTiDBSchemaRepairsIncludesSafeStatementsOnly(t *testing.T) {
 	}
 }
 
+func TestPlannedTiDBSchemaRepairsSkipsUnsafeUniqueIndexOnExistingTable(t *testing.T) {
+	diffs := []tidbSchemaDiff{
+		{kind: tidbSchemaDiffMissingIndex, tableName: "uploads", detail: "uploads schema contract: missing idx_upload_path index", repairSQL: "CREATE INDEX idx_upload_path ON uploads(target_path, status)"},
+		{kind: tidbSchemaDiffMissingIndex, tableName: "uploads", detail: "uploads schema contract: missing idx_idempotency index", repairSQL: "CREATE UNIQUE INDEX idx_idempotency ON uploads(idempotency_key)"},
+	}
+
+	got := plannedTiDBSchemaRepairs(diffs)
+	if len(got) != 1 {
+		t.Fatalf("expected one safe repair statement, got %#v", got)
+	}
+	if got[0] != "CREATE INDEX idx_upload_path ON uploads(target_path, status)" {
+		t.Fatalf("unexpected repair statement: %q", got[0])
+	}
+}
+
 func TestValidateTiDBAutoEmbeddingFilesDiffsReportsGeneratedContractMismatch(t *testing.T) {
 	meta := testFilesTableMeta(TiDBEmbeddingModeApp)
 	diffs := validateTiDBAutoEmbeddingFilesDiffs(meta)

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -348,6 +348,48 @@ func TestTiDBSchemaSpecForModeIncludesVaultIndexes(t *testing.T) {
 	}
 }
 
+func TestTiDBSchemaSpecForModeIncludesAlterTableIndexes(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "files")
+	if _, ok := spec.indexes["idx_fts_content"]; !ok {
+		t.Fatal("files missing idx_fts_content index spec from ALTER TABLE statement")
+	}
+	if _, ok := spec.indexes["idx_files_cosine"]; !ok {
+		t.Fatal("files missing idx_files_cosine index spec from ALTER TABLE statement")
+	}
+}
+
+func TestPlannedTiDBSchemaRepairsIncludesAlterTableIndexRepairs(t *testing.T) {
+	diffs := []tidbSchemaDiff{
+		{
+			kind:      tidbSchemaDiffMissingIndex,
+			tableName: "files",
+			detail:    "files schema contract: missing idx_fts_content index",
+			repairSQL: "ALTER TABLE files ADD FULLTEXT INDEX idx_fts_content(content_text)",
+		},
+	}
+
+	got := plannedTiDBSchemaRepairs(diffs)
+	if len(got) != 1 {
+		t.Fatalf("expected one repair statement, got %#v", got)
+	}
+	if got[0] != "ALTER TABLE files ADD FULLTEXT INDEX idx_fts_content(content_text)" {
+		t.Fatalf("unexpected repair statement: %q", got[0])
+	}
+}
+
+func TestIsSafeAddColumnRepairSQLRejectsStoredAndVirtualGeneratedColumns(t *testing.T) {
+	tests := []string{
+		"ALTER TABLE uploads ADD COLUMN active_target_path VARCHAR(512) AS (CASE WHEN status = 'UPLOADING' THEN target_path ELSE NULL END) STORED",
+		"ALTER TABLE files ADD COLUMN embedding VECTOR(1024) AS (EMBED_TEXT('m', content_text, '{\"dimensions\":1024}')) VIRTUAL",
+	}
+
+	for _, stmt := range tests {
+		if isSafeAddColumnRepairSQL(stmt) {
+			t.Fatalf("expected generated column repair to be unsafe: %s", stmt)
+		}
+	}
+}
+
 func TestInitTiDBTenantSchemaStatementsForModeIncludesVault(t *testing.T) {
 	for _, mode := range []TiDBEmbeddingMode{TiDBEmbeddingModeAuto, TiDBEmbeddingModeApp} {
 		t.Run(string(mode), func(t *testing.T) {

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -70,19 +70,6 @@ func TestValidateTiDBUploadsTableBaseRejectsMissingExpectedRevision(t *testing.T
 	}
 }
 
-func TestLegacyTiDBUploadsRepairStatements(t *testing.T) {
-	if got := legacyTiDBUploadsRepairStatements(testUploadsTableMeta(true)); len(got) != 0 {
-		t.Fatalf("expected no repair statements when expected_revision exists, got %#v", got)
-	}
-	got := legacyTiDBUploadsRepairStatements(testUploadsTableMeta(false))
-	if len(got) != 1 {
-		t.Fatalf("expected one repair statement, got %#v", got)
-	}
-	if !strings.Contains(strings.ToLower(got[0]), "add column expected_revision") {
-		t.Fatalf("unexpected repair statement: %q", got[0])
-	}
-}
-
 func TestTiDBSchemaSpecForModeIncludesCreateStatements(t *testing.T) {
 	spec, err := tidbSchemaSpecForMode(TiDBEmbeddingModeAuto)
 	if err != nil {
@@ -132,6 +119,21 @@ func TestTiDBSchemaSpecFromStatementsParsesNewTableAutomatically(t *testing.T) {
 	}
 	if !equalStringSlices(table.primaryKey.columns, []string{"event_id"}) {
 		t.Fatalf("primary key columns=%#v, want [event_id]", table.primaryKey.columns)
+	}
+}
+
+func TestCurrentTiDBTenantSchemaVersionIgnoresFormattingOnlyChanges(t *testing.T) {
+	base := []string{
+		"CREATE TABLE IF NOT EXISTS example_events (event_id VARCHAR(64) PRIMARY KEY, tenant_id VARCHAR(64) NOT NULL)",
+		"CREATE INDEX idx_example_events_tenant ON example_events(tenant_id)",
+	}
+	formatted := []string{
+		"\nCREATE TABLE IF NOT EXISTS example_events (\n    event_id VARCHAR(64) PRIMARY KEY,\n    tenant_id VARCHAR(64) NOT NULL\n)\n",
+		"CREATE   INDEX idx_example_events_tenant   ON   example_events(tenant_id)",
+	}
+
+	if got, want := currentTiDBTenantSchemaVersion(formatted), currentTiDBTenantSchemaVersion(base); got != want {
+		t.Fatalf("formatted schema version=%d, want %d", got, want)
 	}
 }
 

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -219,6 +219,38 @@ func TestDiffTiDBTableMetaReportsFileNodesAndFileTagsMissingIndexes(t *testing.T
 	}
 }
 
+func TestDiffTiDBTableMetaTreatsBooleanAndTinyIntAsEquivalent(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "file_nodes")
+	meta := tidbTableMeta{
+		tableName: "file_nodes",
+		columns: map[string]tidbColumnMeta{
+			"node_id":      {columnType: "varchar(64)"},
+			"path":         {columnType: "varchar(512)"},
+			"parent_path":  {columnType: "varchar(512)"},
+			"name":         {columnType: "varchar(255)"},
+			"is_directory": {columnType: "tinyint(1)"},
+			"file_id":      {columnType: "varchar(64)"},
+			"created_at":   {columnType: "datetime(3)"},
+		},
+	}
+
+	diffs := diffTiDBTableMeta(spec, meta, `CREATE TABLE file_nodes (
+		node_id VARCHAR(64) PRIMARY KEY,
+		path VARCHAR(512) NOT NULL,
+		parent_path VARCHAR(512) NOT NULL,
+		name VARCHAR(255) NOT NULL,
+		is_directory TINYINT(1) NOT NULL DEFAULT 0,
+		file_id VARCHAR(64),
+		created_at DATETIME(3) NOT NULL
+	)`)
+
+	for _, diff := range diffs {
+		if diff.kind == tidbSchemaDiffColumnType && diff.columnName == "is_directory" {
+			t.Fatalf("unexpected boolean/tinyint(1) column type mismatch: %#v", diff)
+		}
+	}
+}
+
 func TestDiffTiDBTableMetaReportsSemanticTasksMissingKeyColumn(t *testing.T) {
 	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "semantic_tasks")
 	meta := tidbTableMeta{

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -130,6 +130,9 @@ func TestTiDBSchemaSpecFromStatementsParsesNewTableAutomatically(t *testing.T) {
 	if _, ok := table.indexes["idx_example_events_tenant"]; !ok {
 		t.Fatal("expected idx_example_events_tenant index in parsed schema spec")
 	}
+	if !equalStringSlices(table.primaryKey.columns, []string{"event_id"}) {
+		t.Fatalf("primary key columns=%#v, want [event_id]", table.primaryKey.columns)
+	}
 }
 
 func TestTiDBSchemaSpecFromStatementsAttachesExternalIndexesWithoutStalePointers(t *testing.T) {
@@ -274,6 +277,60 @@ func TestDiffTiDBTableMetaReportsFileNodesAndFileTagsMissingIndexes(t *testing.T
 	tagsDiffs := diffTiDBTableMeta(tagsSpec, tagsMeta, `CREATE TABLE file_tags (file_id VARCHAR(64), tag_key VARCHAR(255), tag_value VARCHAR(255))`)
 	if !hasDiffKindAndDetail(tagsDiffs, tidbSchemaDiffMissingIndex, "idx_kv") {
 		t.Fatalf("expected missing idx_kv diff, got %#v", tagsDiffs)
+	}
+}
+
+func TestTiDBSchemaSpecForModeCapturesCompositePrimaryKey(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "file_tags")
+	if !equalStringSlices(spec.primaryKey.columns, []string{"file_id", "tag_key"}) {
+		t.Fatalf("file_tags primary key=%#v, want [file_id tag_key]", spec.primaryKey.columns)
+	}
+}
+
+func TestDiffTiDBTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "file_tags")
+	meta := tidbTableMeta{
+		tableName: "file_tags",
+		columns: map[string]tidbColumnMeta{
+			"file_id":   {columnType: "varchar(64)"},
+			"tag_key":   {columnType: "varchar(255)"},
+			"tag_value": {columnType: "varchar(255)"},
+		},
+	}
+	createStmt := `CREATE TABLE file_tags (
+		file_id VARCHAR(64) NOT NULL,
+		tag_key VARCHAR(255) NOT NULL,
+		tag_value VARCHAR(255),
+		KEY idx_kv (tag_key, tag_value)
+	)`
+
+	diffs := diffTiDBTableMeta(spec, meta, createStmt)
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffTableContract, "missing primary key") {
+		t.Fatalf("expected missing primary key diff, got %#v", diffs)
+	}
+}
+
+func TestDiffTiDBTableMetaReportsPrimaryKeyColumnMismatch(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "file_tags")
+	meta := tidbTableMeta{
+		tableName: "file_tags",
+		columns: map[string]tidbColumnMeta{
+			"file_id":   {columnType: "varchar(64)"},
+			"tag_key":   {columnType: "varchar(255)"},
+			"tag_value": {columnType: "varchar(255)"},
+		},
+	}
+	createStmt := `CREATE TABLE file_tags (
+		file_id VARCHAR(64) NOT NULL,
+		tag_key VARCHAR(255) NOT NULL,
+		tag_value VARCHAR(255),
+		PRIMARY KEY (tag_key, file_id),
+		KEY idx_kv (tag_key, tag_value)
+	)`
+
+	diffs := diffTiDBTableMeta(spec, meta, createStmt)
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffTableContract, "primary key columns") {
+		t.Fatalf("expected primary key mismatch diff, got %#v", diffs)
 	}
 }
 

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -479,6 +479,58 @@ func TestIsIgnorableOptionalSchemaError(t *testing.T) {
 	}
 }
 
+func TestIsIgnorableTiDBSchemaError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "duplicate table",
+			err:  &mysql.MySQLError{Number: 1050, Message: "Table 'files' already exists"},
+			want: true,
+		},
+		{
+			name: "duplicate column",
+			err:  &mysql.MySQLError{Number: 1060, Message: "Duplicate column name 'embedding_revision'"},
+			want: true,
+		},
+		{
+			name: "duplicate key name",
+			err:  &mysql.MySQLError{Number: 1061, Message: "Duplicate key name 'idx_files_status'"},
+			want: true,
+		},
+		{
+			name: "plain already exists",
+			err:  errors.New("index already exists"),
+			want: true,
+		},
+		{
+			name: "plain duplicate",
+			err:  errors.New("duplicate entry"),
+			want: true,
+		},
+		{
+			name: "non ignorable mysql",
+			err:  &mysql.MySQLError{Number: 1146, Message: "Table 'missing' doesn't exist"},
+			want: false,
+		},
+		{
+			name: "non ignorable plain",
+			err:  errors.New("permission denied"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isIgnorableTiDBSchemaError(tt.err); got != tt.want {
+				t.Fatalf("isIgnorableTiDBSchemaError()=%v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func testFilesTableMeta(mode TiDBEmbeddingMode) tidbTableMeta {
 	meta := tidbTableMeta{
 		tableName: "files",

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -83,6 +83,181 @@ func TestLegacyTiDBUploadsRepairStatements(t *testing.T) {
 	}
 }
 
+func TestTiDBSchemaSpecForModeIncludesCreateStatements(t *testing.T) {
+	spec, err := tidbSchemaSpecForMode(TiDBEmbeddingModeAuto)
+	if err != nil {
+		t.Fatalf("schema spec: %v", err)
+	}
+
+	createByTable := make(map[string]string, len(spec.tables))
+	for _, table := range spec.tables {
+		createByTable[table.name] = table.createStatement
+	}
+
+	for _, tableName := range []string{"file_nodes", "file_tags", "files", "uploads", "semantic_tasks", "vault_deks", "vault_audit_log"} {
+		stmt := createByTable[tableName]
+		if stmt == "" {
+			t.Fatalf("missing create statement for %s", tableName)
+		}
+		if !strings.Contains(strings.ToLower(stmt), "create table if not exists "+tableName) {
+			t.Fatalf("unexpected create statement for %s: %q", tableName, stmt)
+		}
+	}
+}
+
+func TestTiDBSchemaSpecFromStatementsParsesNewTableAutomatically(t *testing.T) {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS example_events (
+			event_id VARCHAR(64) PRIMARY KEY,
+			tenant_id VARCHAR(64) NOT NULL,
+			payload JSON,
+			created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+		)`,
+		`CREATE INDEX idx_example_events_tenant ON example_events(tenant_id)`,
+	}
+
+	spec, err := tidbSchemaSpecFromStatements(stmts)
+	if err != nil {
+		t.Fatalf("tidbSchemaSpecFromStatements: %v", err)
+	}
+	table := mustTableSpecFromSchemaSpec(t, spec, "example_events")
+	if _, ok := table.columns["event_id"]; !ok {
+		t.Fatal("expected event_id column in parsed schema spec")
+	}
+	if got := table.columns["created_at"].columnType; got != "datetime(3)" {
+		t.Fatalf("created_at column type=%q, want datetime(3)", got)
+	}
+	if _, ok := table.indexes["idx_example_events_tenant"]; !ok {
+		t.Fatal("expected idx_example_events_tenant index in parsed schema spec")
+	}
+}
+
+func TestPlannedTiDBSchemaRepairsIncludesSafeStatementsOnly(t *testing.T) {
+	diffs := []tidbSchemaDiff{
+		{kind: tidbSchemaDiffMissingTable, tableName: "semantic_tasks", repairSQL: "CREATE TABLE IF NOT EXISTS semantic_tasks (...)"},
+		{kind: tidbSchemaDiffMissingColumn, tableName: "uploads", columnName: "expected_revision", repairSQL: "ALTER TABLE uploads ADD COLUMN expected_revision BIGINT NULL"},
+		{kind: tidbSchemaDiffMissingIndex, tableName: "uploads", detail: "uploads schema contract: missing idx_upload_path index", repairSQL: "CREATE INDEX idx_upload_path ON uploads(target_path, status)"},
+		{kind: tidbSchemaDiffMissingColumn, tableName: "uploads", columnName: "expected_revision", repairSQL: "ALTER TABLE uploads ADD COLUMN expected_revision BIGINT NULL"},
+		{kind: tidbSchemaDiffColumnType, tableName: "files", columnName: "embedding_revision", detail: "files schema contract: embedding_revision column type = \"int\", want bigint"},
+	}
+
+	got := plannedTiDBSchemaRepairs(diffs)
+	if len(got) != 3 {
+		t.Fatalf("plannedTiDBSchemaRepairs() len=%d, want 3 (%#v)", len(got), got)
+	}
+	if got[0] != "CREATE TABLE IF NOT EXISTS semantic_tasks (...)" {
+		t.Fatalf("unexpected first repair statement: %q", got[0])
+	}
+	if got[1] != "ALTER TABLE uploads ADD COLUMN expected_revision BIGINT NULL" {
+		t.Fatalf("unexpected second repair statement: %q", got[1])
+	}
+	if got[2] != "CREATE INDEX idx_upload_path ON uploads(target_path, status)" {
+		t.Fatalf("unexpected third repair statement: %q", got[2])
+	}
+}
+
+func TestValidateTiDBAutoEmbeddingFilesDiffsReportsGeneratedContractMismatch(t *testing.T) {
+	meta := testFilesTableMeta(TiDBEmbeddingModeApp)
+	diffs := validateTiDBAutoEmbeddingFilesDiffs(meta)
+	if len(diffs) == 0 {
+		t.Fatal("expected auto embedding diffs for writable embedding column")
+	}
+	if !strings.Contains(strings.ToLower(diffs[0].detail), "stored generated") {
+		t.Fatalf("unexpected diff detail: %#v", diffs)
+	}
+}
+
+func TestDiffTiDBTableMetaReportsMissingRequiredIndex(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "uploads")
+	meta := testUploadsTableMeta(true)
+	createStmt := `CREATE TABLE uploads (
+		upload_id VARCHAR(64) PRIMARY KEY,
+		target_path VARCHAR(512) NOT NULL,
+		status VARCHAR(32) NOT NULL,
+		expected_revision BIGINT NULL
+	)`
+
+	diffs := diffTiDBTableMeta(spec, meta, createStmt)
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "idx_upload_path") {
+		t.Fatalf("expected missing idx_upload_path diff, got %#v", diffs)
+	}
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "idx_idempotency") {
+		t.Fatalf("expected missing idx_idempotency diff, got %#v", diffs)
+	}
+}
+
+func TestDiffTiDBTableMetaReportsFileNodesAndFileTagsMissingIndexes(t *testing.T) {
+	nodesSpec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "file_nodes")
+	nodesMeta := tidbTableMeta{
+		tableName: "file_nodes",
+		columns: map[string]tidbColumnMeta{
+			"node_id":     {columnType: "varchar(64)"},
+			"path":        {columnType: "varchar(512)"},
+			"parent_path": {columnType: "varchar(512)"},
+			"name":        {columnType: "varchar(255)"},
+			"file_id":     {columnType: "varchar(64)"},
+			"created_at":  {columnType: "datetime(3)"},
+		},
+	}
+	nodesDiffs := diffTiDBTableMeta(nodesSpec, nodesMeta, `CREATE TABLE file_nodes (node_id VARCHAR(64) PRIMARY KEY)`)
+	if !hasDiffKindAndDetail(nodesDiffs, tidbSchemaDiffMissingIndex, "idx_path") {
+		t.Fatalf("expected missing idx_path diff, got %#v", nodesDiffs)
+	}
+
+	tagsSpec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "file_tags")
+	tagsMeta := tidbTableMeta{
+		tableName: "file_tags",
+		columns: map[string]tidbColumnMeta{
+			"file_id":   {columnType: "varchar(64)"},
+			"tag_key":   {columnType: "varchar(255)"},
+			"tag_value": {columnType: "varchar(255)"},
+		},
+	}
+	tagsDiffs := diffTiDBTableMeta(tagsSpec, tagsMeta, `CREATE TABLE file_tags (file_id VARCHAR(64), tag_key VARCHAR(255), tag_value VARCHAR(255))`)
+	if !hasDiffKindAndDetail(tagsDiffs, tidbSchemaDiffMissingIndex, "idx_kv") {
+		t.Fatalf("expected missing idx_kv diff, got %#v", tagsDiffs)
+	}
+}
+
+func TestDiffTiDBTableMetaReportsSemanticTasksMissingKeyColumn(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "semantic_tasks")
+	meta := tidbTableMeta{
+		tableName: "semantic_tasks",
+		columns: map[string]tidbColumnMeta{
+			"task_id":          {columnType: "varchar(64)"},
+			"task_type":        {columnType: "varchar(32)"},
+			"resource_id":      {columnType: "varchar(64)"},
+			"resource_version": {columnType: "bigint"},
+			"status":           {columnType: "varchar(20)"},
+		},
+	}
+	createStmt := `CREATE TABLE semantic_tasks (
+		task_id VARCHAR(64) PRIMARY KEY,
+		task_type VARCHAR(32) NOT NULL,
+		resource_id VARCHAR(64) NOT NULL,
+		resource_version BIGINT NOT NULL,
+		status VARCHAR(20) NOT NULL
+	)`
+
+	diffs := diffTiDBTableMeta(spec, meta, createStmt)
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingColumn, "available_at") {
+		t.Fatalf("expected missing available_at diff, got %#v", diffs)
+	}
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "uk_task_resource_version") {
+		t.Fatalf("expected missing uk_task_resource_version diff, got %#v", diffs)
+	}
+}
+
+func TestTiDBSchemaSpecForModeIncludesVaultIndexes(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "vault_secrets")
+	if _, ok := spec.indexes["uk_vault_secrets_tenant_name"]; !ok {
+		t.Fatal("vault_secrets missing uk_vault_secrets_tenant_name index spec")
+	}
+	if _, ok := spec.indexes["idx_vault_secrets_tenant"]; !ok {
+		t.Fatal("vault_secrets missing idx_vault_secrets_tenant index spec")
+	}
+}
+
 func TestInitTiDBTenantSchemaStatementsForModeIncludesVault(t *testing.T) {
 	for _, mode := range []TiDBEmbeddingMode{TiDBEmbeddingModeAuto, TiDBEmbeddingModeApp} {
 		t.Run(string(mode), func(t *testing.T) {
@@ -194,4 +369,39 @@ func testUploadsTableMeta(includeExpectedRevision bool) tidbTableMeta {
 		meta.columns["expected_revision"] = tidbColumnMeta{columnType: "bigint"}
 	}
 	return meta
+}
+
+func mustTiDBTableSpecByName(t *testing.T, mode TiDBEmbeddingMode, tableName string) tidbTableSpec {
+	t.Helper()
+	spec, err := tidbSchemaSpecForMode(mode)
+	if err != nil {
+		t.Fatalf("schema spec for %q: %v", mode, err)
+	}
+	for _, table := range spec.tables {
+		if table.name == tableName {
+			return table
+		}
+	}
+	t.Fatalf("missing table spec %q", tableName)
+	return tidbTableSpec{}
+}
+
+func hasDiffKindAndDetail(diffs []tidbSchemaDiff, kind tidbSchemaDiffKind, detailSubstring string) bool {
+	for _, diff := range diffs {
+		if diff.kind == kind && strings.Contains(strings.ToLower(diff.detail), strings.ToLower(detailSubstring)) {
+			return true
+		}
+	}
+	return false
+}
+
+func mustTableSpecFromSchemaSpec(t *testing.T, spec tidbSchemaSpec, tableName string) tidbTableSpec {
+	t.Helper()
+	for _, table := range spec.tables {
+		if table.name == tableName {
+			return table
+		}
+	}
+	t.Fatalf("missing table spec %q", tableName)
+	return tidbTableSpec{}
 }

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -132,6 +132,49 @@ func TestTiDBSchemaSpecFromStatementsParsesNewTableAutomatically(t *testing.T) {
 	}
 }
 
+func TestTiDBSchemaSpecFromStatementsAttachesExternalIndexesWithoutStalePointers(t *testing.T) {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS t1 (
+			id VARCHAR(64) PRIMARY KEY
+		)`,
+		`CREATE TABLE IF NOT EXISTS t2 (
+			id VARCHAR(64) PRIMARY KEY
+		)`,
+		`CREATE INDEX idx_t1_id ON t1(id)`,
+	}
+
+	spec, err := tidbSchemaSpecFromStatements(stmts)
+	if err != nil {
+		t.Fatalf("tidbSchemaSpecFromStatements: %v", err)
+	}
+	t1 := mustTableSpecFromSchemaSpec(t, spec, "t1")
+	if _, ok := t1.indexes["idx_t1_id"]; !ok {
+		t.Fatalf("expected idx_t1_id on t1, got indexes=%#v", t1.indexes)
+	}
+}
+
+func TestMissingTableAndIndexDiffsIncludesExternalIndexes(t *testing.T) {
+	table := tidbTableSpec{
+		name:            "uploads",
+		createStatement: "CREATE TABLE IF NOT EXISTS uploads (...)",
+		indexes: map[string]tidbIndexSpec{
+			"idx_upload_path": {createSQL: "CREATE INDEX idx_upload_path ON uploads(target_path, status)"},
+			"idx_idempotency": {createSQL: "CREATE UNIQUE INDEX idx_idempotency ON uploads(idempotency_key)"},
+		},
+	}
+
+	diffs := missingTableAndIndexDiffs(table)
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingTable, "missing table") {
+		t.Fatalf("expected missing table diff, got %#v", diffs)
+	}
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "idx_upload_path") {
+		t.Fatalf("expected missing idx_upload_path diff, got %#v", diffs)
+	}
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "idx_idempotency") {
+		t.Fatalf("expected missing idx_idempotency diff, got %#v", diffs)
+	}
+}
+
 func TestPlannedTiDBSchemaRepairsIncludesSafeStatementsOnly(t *testing.T) {
 	diffs := []tidbSchemaDiff{
 		{kind: tidbSchemaDiffMissingTable, tableName: "semantic_tasks", repairSQL: "CREATE TABLE IF NOT EXISTS semantic_tasks (...)"},

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -358,6 +358,19 @@ func TestTiDBSchemaSpecForModeIncludesAlterTableIndexes(t *testing.T) {
 	}
 }
 
+func TestTiDBSchemaSpecForAppModeExcludesOptionalIndexes(t *testing.T) {
+	// Optional FULLTEXT/VECTOR indexes use ADD_COLUMNAR_REPLICA_ON_DEMAND which
+	// is not supported on all TiDB versions. They must not appear in the app
+	// mode schema contract so that validation does not fail when they are skipped.
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeApp, "files")
+	if _, ok := spec.indexes["idx_fts_content"]; ok {
+		t.Fatal("files app mode spec must not include optional idx_fts_content index")
+	}
+	if _, ok := spec.indexes["idx_files_cosine"]; ok {
+		t.Fatal("files app mode spec must not include optional idx_files_cosine index")
+	}
+}
+
 func TestPlannedTiDBSchemaRepairsIncludesAlterTableIndexRepairs(t *testing.T) {
 	diffs := []tidbSchemaDiff{
 		{


### PR DESCRIPTION
## Summary
Add init-SQL-driven schema spec parsing and safe diff/fix flows for both tenant TiDB schemas and the meta control-plane schema.

## What changed
- Tenant schema (`pkg/tenant/schema/tidb_auto.go`):
  - Refactored validation to generate structured schema diffs.
  - Added safe repair planning/execution for missing tables, columns, and indexes.
  - Switched schema spec construction to parse init SQL statements automatically.
  - Kept mode-specific `files.embedding` contract validation for auto/app modes.
- Meta schema (`pkg/meta/meta.go`):
  - Refactored `migrate()` to run parse -> diff -> safe fix -> re-diff.
  - Added init-SQL parsing for table/column/index specs in control-plane schema.
  - Added mismatch error reporting when residual non-repairable drift remains.
- Tests:
  - Extended tenant schema tests for parsed spec coverage and diff/repair behavior.
  - Added meta schema parser/diff tests.

## Validation
- `go test ./pkg/meta ./pkg/tenant/schema`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable, deterministic schema diffing that detects missing/incorrect primary keys, columns and indexes; better handling/ignoring of idempotent DB errors.

* **New Features**
  * Schema validation/ensure is context-aware and skips up-to-date tenants; system records tenant schema version after successful ensures.
  * Planned repairs apply only whitelisted safe changes.

* **Refactor**
  * Unified diff-and-repair migration pipeline with iterative revalidation.

* **Tests**
  * Expanded coverage for schema parsing, diffs, repair planning and safety filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->