### PR TITLE
Fix TiDB schema index auto-repair

### DIFF
--- a/internal/schemaspec/schemaspec.go
+++ b/internal/schemaspec/schemaspec.go
@@ -215,6 +215,7 @@ func ParseColumnType(rest string) string {
 	if rest == "" {
 		return ""
 	}
+	lowerRest := strings.ToLower(rest)
 	keywords := []string{
 		" not ",
 		" null",
@@ -267,7 +268,7 @@ func ParseColumnType(rest string) string {
 		if inSingle || inDouble || inBacktick || depth > 0 {
 			continue
 		}
-		suffix := " " + strings.ToLower(rest[i:])
+		suffix := " " + lowerRest[i:]
 		for _, kw := range keywords {
 			if strings.HasPrefix(suffix, kw) {
 				return strings.TrimSpace(rest[:i])
@@ -287,10 +288,16 @@ func IsSafeAddColumnRepairSQL(sqlText string) bool {
 	if isGeneratedColumnAddSQL(n) {
 		return false
 	}
-	if strings.Contains(n, " not null") && !strings.Contains(n, " default ") {
+	if strings.Contains(n, " not null") && !hasDefaultClause(n) {
 		return false
 	}
 	return true
+}
+
+func hasDefaultClause(normalizedSQL string) bool {
+	return strings.Contains(normalizedSQL, " default ") ||
+		strings.Contains(normalizedSQL, " default(") ||
+		strings.HasSuffix(normalizedSQL, " default")
 }
 
 func isGeneratedColumnAddSQL(normalizedSQL string) bool {
@@ -312,11 +319,16 @@ func IsIgnorableMySQLError(err error) bool {
 		case 1050, 1060, 1061:
 			return true
 		}
-		msg := strings.ToLower(me.Message)
-		return strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate")
+		return isIgnorableDDLMessage(me.Message)
 	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate")
+	return isIgnorableDDLMessage(err.Error())
+}
+
+func isIgnorableDDLMessage(msg string) bool {
+	msg = strings.ToLower(msg)
+	return strings.Contains(msg, "already exists") ||
+		strings.Contains(msg, "duplicate column name") ||
+		strings.Contains(msg, "duplicate key name")
 }
 
 // CRC32Version hashes normalized schema statements and always returns a

--- a/internal/schemaspec/schemaspec.go
+++ b/internal/schemaspec/schemaspec.go
@@ -313,6 +313,9 @@ func isGeneratedColumnAddSQL(normalizedSQL string) bool {
 // IsIgnorableMySQLError reports whether a DDL error is benign for idempotent
 // schema repair paths.
 func IsIgnorableMySQLError(err error) bool {
+	if err == nil {
+		return false
+	}
 	var me *mysql.MySQLError
 	if errors.As(err, &me) {
 		switch me.Number {

--- a/internal/schemaspec/schemaspec_test.go
+++ b/internal/schemaspec/schemaspec_test.go
@@ -66,12 +66,17 @@ func TestIsIgnorableMySQLErrorRejectsDuplicateEntry(t *testing.T) {
 			err:  errors.New("index already exists"),
 			want: true,
 		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsIgnorableMySQLError(tt.err); got != tt.want {
-				t.Fatalf("IsIgnorableMySQLError()=%v, want %v", got, tt.want)
+				t.Errorf("IsIgnorableMySQLError()=%v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/schemaspec/schemaspec_test.go
+++ b/internal/schemaspec/schemaspec_test.go
@@ -1,6 +1,11 @@
 package schemaspec
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
 
 func TestParseColumnTypeStopsAtCharacterSetAndCollate(t *testing.T) {
 	got := ParseColumnType("VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL")
@@ -30,5 +35,44 @@ func TestCanonicalStatementForHashIgnoresFormattingOnlySpacing(t *testing.T) {
 	right := CanonicalStatementForHash("\nCREATE TABLE IF NOT EXISTS example_events (\n    event_id VARCHAR(64) PRIMARY KEY,\n    tenant_id VARCHAR(64) NOT NULL\n)\n")
 	if left != right {
 		t.Fatalf("CanonicalStatementForHash() mismatch: %q != %q", left, right)
+	}
+}
+
+func TestIsSafeAddColumnRepairSQLAcceptsDefaultFunction(t *testing.T) {
+	stmt := "ALTER TABLE tenants ADD COLUMN created_at DATETIME NOT NULL DEFAULT(CURRENT_TIMESTAMP())"
+	if !IsSafeAddColumnRepairSQL(stmt) {
+		t.Fatalf("expected %q to be safe", stmt)
+	}
+}
+
+func TestIsIgnorableMySQLErrorRejectsDuplicateEntry(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "mysql duplicate key name",
+			err:  &mysql.MySQLError{Number: 1061, Message: "Duplicate key name 'idx_status'"},
+			want: true,
+		},
+		{
+			name: "plain duplicate entry",
+			err:  errors.New("duplicate entry 'abc' for key 'uk_hash'"),
+			want: false,
+		},
+		{
+			name: "plain already exists",
+			err:  errors.New("index already exists"),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsIgnorableMySQLError(tt.err); got != tt.want {
+				t.Fatalf("IsIgnorableMySQLError()=%v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -110,8 +110,20 @@ func applyMySQLPoolDefaults(db *sql.DB) {
 	mysqlutil.ApplyPoolDefaults(db)
 }
 
-func (s *Store) migrate() error {
+const metaSchemaMigrateLockTimeoutSeconds = 30
+
+func (s *Store) migrate() (err error) {
 	ctx := context.Background()
+	releaseLock, err := acquireMetaSchemaMigrationLock(ctx, s.db)
+	if err != nil {
+		return fmt.Errorf("acquire meta schema migration lock: %w", err)
+	}
+	defer func() {
+		if releaseErr := releaseLock(); releaseErr != nil {
+			err = errors.Join(err, fmt.Errorf("release meta schema migration lock: %w", releaseErr))
+		}
+	}()
+
 	stmts := metaInitSchemaStatements()
 	spec, err := metaSchemaSpecFromStatements(stmts)
 	if err != nil {
@@ -132,6 +144,48 @@ func (s *Store) migrate() error {
 		return &metaSchemaDiffError{diffs: diffs}
 	}
 	return nil
+}
+
+func acquireMetaSchemaMigrationLock(ctx context.Context, db *sql.DB) (func() error, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var got sql.NullInt64
+	if err := conn.QueryRowContext(ctx,
+		"SELECT GET_LOCK(CONCAT('drive9_meta_schema_migrate:', DATABASE()), ?)",
+		metaSchemaMigrateLockTimeoutSeconds,
+	).Scan(&got); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if !got.Valid {
+		_ = conn.Close()
+		return nil, fmt.Errorf("named lock returned NULL")
+	}
+	if got.Int64 != 1 {
+		_ = conn.Close()
+		return nil, fmt.Errorf("timed out waiting for named lock")
+	}
+
+	return func() error {
+		defer func() { _ = conn.Close() }()
+
+		var released sql.NullInt64
+		if err := conn.QueryRowContext(ctx,
+			"SELECT RELEASE_LOCK(CONCAT('drive9_meta_schema_migrate:', DATABASE()))",
+		).Scan(&released); err != nil {
+			return err
+		}
+		if !released.Valid {
+			return fmt.Errorf("named lock release returned NULL")
+		}
+		if released.Int64 != 1 {
+			return fmt.Errorf("named lock was not held by current connection")
+		}
+		return nil
+	}, nil
 }
 
 type metaColumnMeta struct {
@@ -397,14 +451,18 @@ func diffMetaTable(ctx context.Context, db *sql.DB, table metaTableSpec) ([]meta
 		}
 		return nil, fmt.Errorf("load %s table metadata: %w", table.name, err)
 	}
-	createStmt, err := loadMetaShowCreateTable(ctx, db, table.name)
+	indexNames, err := loadMetaIndexNames(ctx, db, table.name)
 	if err != nil {
-		return nil, fmt.Errorf("show create %s: %w", table.name, err)
+		return nil, fmt.Errorf("load %s index metadata: %w", table.name, err)
 	}
-	return diffMetaTableMeta(table, meta, createStmt), nil
+	return diffMetaTableMetaWithObservedIndexes(table, meta, "", indexNames), nil
 }
 
 func diffMetaTableMeta(table metaTableSpec, meta metaTableMeta, createStmt string) []metaSchemaDiff {
+	return diffMetaTableMetaWithObservedIndexes(table, meta, createStmt, parseObservedMetaIndexes(createStmt))
+}
+
+func diffMetaTableMetaWithObservedIndexes(table metaTableSpec, meta metaTableMeta, createStmt string, observedIndexes map[string]struct{}) []metaSchemaDiff {
 	var diffs []metaSchemaDiff
 	for _, name := range sortedMetaColumnNames(table.columns) {
 		spec := table.columns[name]
@@ -428,10 +486,9 @@ func diffMetaTableMeta(table metaTableSpec, meta metaTableMeta, createStmt strin
 			})
 		}
 	}
-	normalizedCreate := normalizeMetaSQLFragment(createStmt)
 	for _, name := range sortedMetaIndexNames(table.indexes) {
 		spec := table.indexes[name]
-		if !showCreateHasMetaIndex(normalizedCreate, name, spec) {
+		if !hasObservedMetaIndex(observedIndexes, name, spec) {
 			detail := fmt.Sprintf("%s schema contract: missing %s index", table.name, name)
 			if spec.isPrimary {
 				detail = fmt.Sprintf("%s schema contract: missing primary key constraint", table.name)
@@ -446,6 +503,44 @@ func diffMetaTableMeta(table metaTableSpec, meta metaTableMeta, createStmt strin
 		}
 	}
 	return diffs
+}
+
+func hasObservedMetaIndex(observedIndexes map[string]struct{}, indexName string, spec metaIndexSpec) bool {
+	if len(observedIndexes) == 0 {
+		return false
+	}
+	name := strings.ToLower(indexName)
+	if spec.isPrimary {
+		name = "primary"
+	}
+	_, ok := observedIndexes[name]
+	return ok
+}
+
+func parseObservedMetaIndexes(createStmt string) map[string]struct{} {
+	_, defs, ok, err := parseMetaCreateTableStatement(createStmt)
+	if err != nil || !ok {
+		return nil
+	}
+	observed := make(map[string]struct{})
+	for _, def := range splitMetaTopLevelComma(defs) {
+		def = strings.TrimSpace(def)
+		if def == "" {
+			continue
+		}
+		if idxName, _, ok := parseMetaConstraintIndexDefinition("", def); ok {
+			observed[strings.ToLower(idxName)] = struct{}{}
+			continue
+		}
+		if idxName, _, ok := parseMetaInlineIndexDefinition("", def); ok {
+			observed[strings.ToLower(idxName)] = struct{}{}
+			continue
+		}
+		if strings.Contains(normalizeMetaSQLFragment(def), " primary key") {
+			observed["primary"] = struct{}{}
+		}
+	}
+	return observed
 }
 
 func plannedMetaSchemaRepairs(diffs []metaSchemaDiff) []string {
@@ -641,14 +736,27 @@ func loadMetaTableMeta(ctx context.Context, db *sql.DB, tableName string) (metaT
 	return metaTableMeta{tableName: tableName, columns: columns}, nil
 }
 
-func loadMetaShowCreateTable(ctx context.Context, db *sql.DB, tableName string) (string, error) {
-	var gotTable string
-	var createStmt string
-	query := fmt.Sprintf("SHOW CREATE TABLE %s", tableName)
-	if err := db.QueryRowContext(ctx, query).Scan(&gotTable, &createStmt); err != nil {
-		return "", err
+func loadMetaIndexNames(ctx context.Context, db *sql.DB, tableName string) (map[string]struct{}, error) {
+	rows, err := db.QueryContext(ctx, `SELECT DISTINCT index_name
+		FROM information_schema.statistics
+		WHERE table_schema = DATABASE() AND table_name = ?`, tableName)
+	if err != nil {
+		return nil, err
 	}
-	return createStmt, nil
+	defer func() { _ = rows.Close() }()
+
+	indexNames := make(map[string]struct{})
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		indexNames[strings.ToLower(name)] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return indexNames, nil
 }
 
 func normalizeMetaSQLFragment(s string) string {
@@ -671,13 +779,6 @@ func sortedMetaIndexNames(indexes map[string]metaIndexSpec) []string {
 	}
 	sort.Strings(names)
 	return names
-}
-
-func showCreateHasMetaIndex(normalizedCreate, indexName string, spec metaIndexSpec) bool {
-	if spec.isPrimary {
-		return strings.Contains(normalizedCreate, "primary key (")
-	}
-	return strings.Contains(normalizedCreate, indexName+" (")
 }
 
 func schemaSnippet(stmt string) string {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -112,6 +112,7 @@ func applyMySQLPoolDefaults(db *sql.DB) {
 	mysqlutil.ApplyPoolDefaults(db)
 }
 
+const metaSchemaMigrateLockNamePrefix = "dat9_meta_schema_migrate:"
 const metaSchemaMigrateLockTimeoutSeconds = 30
 
 func (s *Store) migrate() (err error) {
@@ -156,7 +157,8 @@ func acquireMetaSchemaMigrationLock(ctx context.Context, db *sql.DB) (func() err
 
 	var got sql.NullInt64
 	if err := conn.QueryRowContext(ctx,
-		"SELECT GET_LOCK(CONCAT('drive9_meta_schema_migrate:', DATABASE()), ?)",
+		"SELECT GET_LOCK(CONCAT(?, DATABASE()), ?)",
+		metaSchemaMigrateLockNamePrefix,
 		metaSchemaMigrateLockTimeoutSeconds,
 	).Scan(&got); err != nil {
 		_ = conn.Close()
@@ -176,7 +178,8 @@ func acquireMetaSchemaMigrationLock(ctx context.Context, db *sql.DB) (func() err
 
 		var released sql.NullInt64
 		if err := conn.QueryRowContext(ctx,
-			"SELECT RELEASE_LOCK(CONCAT('drive9_meta_schema_migrate:', DATABASE()))",
+			"SELECT RELEASE_LOCK(CONCAT(?, DATABASE()))",
+			metaSchemaMigrateLockNamePrefix,
 		).Scan(&released); err != nil {
 			return err
 		}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	_ "github.com/go-sql-driver/mysql"
+
 	"github.com/mem9-ai/dat9/internal/schemaspec"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -350,10 +350,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 				// opens will be caught on the next open because its stored
 				// version will differ from CurrentTiDBTenantSchemaVersion.
 				if verErr := p.metaStore.UpdateTenantSchemaVersion(ctx, t.ID, schema.CurrentTiDBTenantSchemaVersion); verErr != nil {
-					logger.Warn(ctx, "tenant_pool_update_schema_version_failed",
-						zap.String("tenant_id", t.ID),
-						zap.Int("version", schema.CurrentTiDBTenantSchemaVersion),
-						zap.Error(verErr))
+					recordTenantSchemaVersionUpdateFailure(ctx, t.ID, schema.CurrentTiDBTenantSchemaVersion, verErr)
 				}
 			}
 		} else if p.shouldPeriodicValidateTiDBSchemaOnOpen() {
@@ -471,6 +468,14 @@ func (p *Pool) shouldPeriodicValidateTiDBSchemaOnOpen() bool {
 	}
 	count := p.tidbSchemaValidationOpens.Add(1)
 	return count == 1 || count%every == 0
+}
+
+func recordTenantSchemaVersionUpdateFailure(ctx context.Context, tenantID string, version int, err error) {
+	logger.Warn(ctx, "tenant_pool_update_schema_version_failed",
+		zap.String("tenant_id", tenantID),
+		zap.Int("version", version),
+		zap.Error(err))
+	metrics.RecordOperation("tenant_pool", "update_schema_version_failed", "error", 0)
 }
 
 // wireQuotaStore sets the central quota store on a newly created backend.

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -349,8 +349,9 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 				// Any tenant whose schema diverges between two consecutive
 				// opens will be caught on the next open because its stored
 				// version will differ from CurrentTiDBTenantSchemaVersion.
+				updateSchemaVersionStart := time.Now()
 				if verErr := p.metaStore.UpdateTenantSchemaVersion(ctx, t.ID, schema.CurrentTiDBTenantSchemaVersion); verErr != nil {
-					recordTenantSchemaVersionUpdateFailure(ctx, t.ID, schema.CurrentTiDBTenantSchemaVersion, verErr)
+					recordTenantSchemaVersionUpdateFailure(ctx, t.ID, schema.CurrentTiDBTenantSchemaVersion, time.Since(updateSchemaVersionStart), verErr)
 				}
 			}
 		} else if p.shouldPeriodicValidateTiDBSchemaOnOpen() {
@@ -470,12 +471,12 @@ func (p *Pool) shouldPeriodicValidateTiDBSchemaOnOpen() bool {
 	return count == 1 || count%every == 0
 }
 
-func recordTenantSchemaVersionUpdateFailure(ctx context.Context, tenantID string, version int, err error) {
+func recordTenantSchemaVersionUpdateFailure(ctx context.Context, tenantID string, version int, d time.Duration, err error) {
 	logger.Warn(ctx, "tenant_pool_update_schema_version_failed",
 		zap.String("tenant_id", tenantID),
 		zap.Int("version", version),
 		zap.Error(err))
-	metrics.RecordOperation("tenant_pool", "update_schema_version_failed", "error", 0)
+	metrics.RecordOperation("tenant_pool", "update_schema_version_failed", "error", d)
 }
 
 // wireQuotaStore sets the central quota store on a newly created backend.

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -327,19 +328,32 @@ func TestPoolCreateBackendReturnsValidationErrorWhenPeriodicCheckFails(t *testin
 func TestRecordTenantSchemaVersionUpdateFailureRecordsMetric(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	metrics.WritePrometheus(recorder)
-	before := recorder.Body.String()
-	if strings.Contains(before, `dat9_service_operations_total{component="tenant_pool",operation="update_schema_version_failed",result="error"}`) {
-		t.Fatal("unexpected pre-existing update_schema_version_failed metric")
-	}
+	before := operationMetricValue(t, recorder.Body.String(), `component="tenant_pool",operation="update_schema_version_failed",result="error"`)
 
 	recordTenantSchemaVersionUpdateFailure(context.Background(), "tenant-metric", 42, fmt.Errorf("meta unavailable"))
 
 	recorder = httptest.NewRecorder()
 	metrics.WritePrometheus(recorder)
-	after := recorder.Body.String()
-	if !strings.Contains(after, `dat9_service_operations_total{component="tenant_pool",operation="update_schema_version_failed",result="error"} 1`) {
-		t.Fatalf("expected update_schema_version_failed metric in output: %s", after)
+	after := operationMetricValue(t, recorder.Body.String(), `component="tenant_pool",operation="update_schema_version_failed",result="error"`)
+	if after != before+1 {
+		t.Fatalf("expected update_schema_version_failed metric to increment by 1, before=%d after=%d", before, after)
 	}
+}
+
+func operationMetricValue(t *testing.T, output, labels string) uint64 {
+	t.Helper()
+	prefix := `dat9_service_operations_total{` + labels + `} `
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		value, err := strconv.ParseUint(strings.TrimSpace(strings.TrimPrefix(line, prefix)), 10, 64)
+		if err != nil {
+			t.Fatalf("parse metric %q: %v", line, err)
+		}
+		return value
+	}
+	return 0
 }
 
 type poolDummyAudioExtractor struct{}

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"fmt"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/semantic"
 	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
@@ -319,6 +321,24 @@ func TestPoolCreateBackendReturnsValidationErrorWhenPeriodicCheckFails(t *testin
 		t.Fatal("expected periodic validation failure to propagate")
 	} else if !strings.Contains(err.Error(), "validate tidb auto-embedding schema") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRecordTenantSchemaVersionUpdateFailureRecordsMetric(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	metrics.WritePrometheus(recorder)
+	before := recorder.Body.String()
+	if strings.Contains(before, `dat9_service_operations_total{component="tenant_pool",operation="update_schema_version_failed",result="error"}`) {
+		t.Fatal("unexpected pre-existing update_schema_version_failed metric")
+	}
+
+	recordTenantSchemaVersionUpdateFailure(context.Background(), "tenant-metric", 42, fmt.Errorf("meta unavailable"))
+
+	recorder = httptest.NewRecorder()
+	metrics.WritePrometheus(recorder)
+	after := recorder.Body.String()
+	if !strings.Contains(after, `dat9_service_operations_total{component="tenant_pool",operation="update_schema_version_failed",result="error"} 1`) {
+		t.Fatalf("expected update_schema_version_failed metric in output: %s", after)
 	}
 }
 

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -325,12 +325,15 @@ func TestPoolCreateBackendReturnsValidationErrorWhenPeriodicCheckFails(t *testin
 	}
 }
 
+// This test reads global metrics emitted by recordTenantSchemaVersionUpdateFailure
+// via operationMetricValue, so it must stay non-parallel unless the metric state
+// is isolated.
 func TestRecordTenantSchemaVersionUpdateFailureRecordsMetric(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	metrics.WritePrometheus(recorder)
 	before := operationMetricValue(t, recorder.Body.String(), `component="tenant_pool",operation="update_schema_version_failed",result="error"`)
 
-	recordTenantSchemaVersionUpdateFailure(context.Background(), "tenant-metric", 42, fmt.Errorf("meta unavailable"))
+	recordTenantSchemaVersionUpdateFailure(context.Background(), "tenant-metric", 42, time.Millisecond, fmt.Errorf("meta unavailable"))
 
 	recorder = httptest.NewRecorder()
 	metrics.WritePrometheus(recorder)

--- a/pkg/tenant/schema/testmain_test.go
+++ b/pkg/tenant/schema/testmain_test.go
@@ -1,0 +1,26 @@
+package schema
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/mem9-ai/dat9/internal/testmysql"
+)
+
+var testDSN string
+
+func TestMain(m *testing.M) {
+	inst, err := testmysql.Start(context.Background())
+	if err != nil {
+		log.Fatalf("setup mysql test instance: %v", err)
+	}
+	testDSN = inst.DSN
+
+	code := m.Run()
+	if err := inst.Close(context.Background()); err != nil {
+		log.Printf("teardown mysql test instance: %v", err)
+	}
+	os.Exit(code)
+}

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -124,6 +124,12 @@ type tidbPrimaryKeySpec struct {
 	columns []string
 }
 
+type tidbUniqueIndexRepair struct {
+	tableName string
+	indexName string
+	columns   []string
+}
+
 type tidbSchemaDiffError struct {
 	mode  TiDBEmbeddingMode
 	diffs []tidbSchemaDiff
@@ -610,11 +616,25 @@ func diffTiDBTable(ctx context.Context, db *sql.DB, table tidbTableSpec) ([]tidb
 	if err != nil {
 		return nil, fmt.Errorf("show create %s: %w", table.name, err)
 	}
-	indexNames, err := loadTiDBIndexNames(ctx, db, table.name)
-	if err != nil {
-		return nil, fmt.Errorf("load %s index metadata: %w", table.name, err)
+	observedIndexes, indexesObserved := loadObservedTiDBIndexes(ctx, db, table.name, createStmt)
+	return diffTiDBTableMetaWithObservedIndexes(table, meta, createStmt, observedIndexes, indexesObserved), nil
+}
+
+func loadObservedTiDBIndexes(ctx context.Context, db *sql.DB, tableName, createStmt string) (map[string]struct{}, bool) {
+	indexNames, err := loadTiDBIndexNames(ctx, db, tableName)
+	if err == nil {
+		return indexNames, true
 	}
-	return diffTiDBTableMetaWithObservedIndexes(table, meta, createStmt, indexNames), nil
+	logger.Warn(ctx, "tenant_tidb_schema_load_index_metadata_failed",
+		zap.String("table", tableName),
+		zap.Error(err))
+	observedIndexes, ok := parseObservedTiDBIndexes(createStmt)
+	if ok {
+		return observedIndexes, true
+	}
+	logger.Warn(ctx, "tenant_tidb_schema_parse_show_create_indexes_failed",
+		zap.String("table", tableName))
+	return nil, false
 }
 
 func tidbSchemaSpecForMode(mode TiDBEmbeddingMode) (tidbSchemaSpec, error) {
@@ -744,11 +764,18 @@ func splitTopLevelComma(definitions string) []string {
 
 func parseInlineIndexDefinition(tableName, def string) (indexName, createSQL string, ok bool) {
 	normalized := normalizeSQLFragment(def)
-	if strings.HasPrefix(normalized, "unique index ") {
-		name, cols := parseIndexNameAndColumns(def, "UNIQUE INDEX")
+	if strings.HasPrefix(normalized, "unique index ") || strings.HasPrefix(normalized, "unique key ") {
+		prefix := "UNIQUE INDEX"
+		if strings.HasPrefix(normalized, "unique key ") {
+			prefix = "UNIQUE KEY"
+		}
+		name, cols := parseIndexNameAndColumns(def, prefix)
 		if name == "" || cols == "" {
 			return "", "", false
 		}
+		return name, fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols), true
+	}
+	if name, cols, ok := parseConstraintUniqueIndexDefinition(def); ok {
 		return name, fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols), true
 	}
 	if strings.HasPrefix(normalized, "index ") || strings.HasPrefix(normalized, "key ") {
@@ -763,6 +790,31 @@ func parseInlineIndexDefinition(tableName, def string) (indexName, createSQL str
 		return name, fmt.Sprintf("CREATE INDEX %s ON %s%s", name, tableName, cols), true
 	}
 	return "", "", false
+}
+
+func parseConstraintUniqueIndexDefinition(def string) (indexName, columns string, ok bool) {
+	trimmed := strings.TrimSpace(def)
+	upper := strings.ToUpper(trimmed)
+	if !strings.HasPrefix(upper, "CONSTRAINT ") {
+		return "", "", false
+	}
+	rest := strings.TrimSpace(trimmed[len("CONSTRAINT "):])
+	name, remainder := splitIdentifierAndRest(rest)
+	if name == "" || remainder == "" {
+		return "", "", false
+	}
+	remainder = strings.TrimSpace(remainder)
+	upperRemainder := strings.ToUpper(remainder)
+	switch {
+	case strings.HasPrefix(upperRemainder, "UNIQUE KEY"):
+		return strings.ToLower(name), parseIndexColumnsSuffix(remainder[len("UNIQUE KEY"):]), true
+	case strings.HasPrefix(upperRemainder, "UNIQUE INDEX"):
+		return strings.ToLower(name), parseIndexColumnsSuffix(remainder[len("UNIQUE INDEX"):]), true
+	case strings.HasPrefix(upperRemainder, "UNIQUE"):
+		return strings.ToLower(name), parseIndexColumnsSuffix(remainder[len("UNIQUE"):]), true
+	default:
+		return "", "", false
+	}
 }
 
 func parseIndexNameAndColumns(def, prefix string) (indexName, columns string) {
@@ -785,6 +837,15 @@ func parseIndexNameAndColumns(def, prefix string) (indexName, columns string) {
 		return "", ""
 	}
 	return strings.ToLower(name), strings.TrimSpace(remainder[open:])
+}
+
+func parseIndexColumnsSuffix(s string) string {
+	trimmed := strings.TrimSpace(s)
+	open := strings.Index(trimmed, "(")
+	if open < 0 {
+		return ""
+	}
+	return strings.TrimSpace(trimmed[open:])
 }
 
 func parsePrimaryKeyDefinition(def string) (tidbPrimaryKeySpec, bool) {
@@ -884,6 +945,27 @@ func splitIdentifierAndRest(s string) (identifier string, rest string) {
 	return schemaspec.SplitIdentifierAndRest(s)
 }
 
+func splitIdentifierAndSuffix(s string) (identifier string, rest string) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return "", ""
+	}
+	if trimmed[0] == '`' {
+		end := strings.Index(trimmed[1:], "`")
+		if end < 0 {
+			return "", ""
+		}
+		return trimmed[1 : 1+end], strings.TrimSpace(trimmed[1+end+1:])
+	}
+	for i := 0; i < len(trimmed); i++ {
+		switch trimmed[i] {
+		case ' ', '\t', '\n', '\r', '(':
+			return trimmed[:i], strings.TrimSpace(trimmed[i:])
+		}
+	}
+	return trimmed, ""
+}
+
 func isConstraintDefinition(def string) bool {
 	normalized := normalizeSQLFragment(def)
 	return strings.HasPrefix(normalized, "primary key") ||
@@ -967,10 +1049,11 @@ func parseAlterTableAddIndexStatement(stmt string) (tableName, indexName, create
 }
 
 func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt string) []tidbSchemaDiff {
-	return diffTiDBTableMetaWithObservedIndexes(table, meta, createStmt, parseObservedTiDBIndexes(createStmt))
+	observedIndexes, ok := parseObservedTiDBIndexes(createStmt)
+	return diffTiDBTableMetaWithObservedIndexes(table, meta, createStmt, observedIndexes, ok)
 }
 
-func diffTiDBTableMetaWithObservedIndexes(table tidbTableSpec, meta tidbTableMeta, createStmt string, observedIndexes map[string]struct{}) []tidbSchemaDiff {
+func diffTiDBTableMetaWithObservedIndexes(table tidbTableSpec, meta tidbTableMeta, createStmt string, observedIndexes map[string]struct{}, indexesObserved bool) []tidbSchemaDiff {
 	var diffs []tidbSchemaDiff
 	for _, name := range sortedColumnNames(table.columns) {
 		spec := table.columns[name]
@@ -1010,15 +1093,25 @@ func diffTiDBTableMetaWithObservedIndexes(table tidbTableSpec, meta tidbTableMet
 			})
 		}
 	}
-	for _, name := range sortedIndexNames(table.indexes) {
-		spec := table.indexes[name]
-		if !hasObservedTiDBIndex(observedIndexes, name) {
+	if !indexesObserved {
+		if len(table.indexes) > 0 {
 			diffs = append(diffs, tidbSchemaDiff{
-				kind:      tidbSchemaDiffMissingIndex,
+				kind:      tidbSchemaDiffTableContract,
 				tableName: table.name,
-				detail:    fmt.Sprintf("%s schema contract: missing %s index", table.name, name),
-				repairSQL: spec.createSQL,
+				detail:    fmt.Sprintf("%s schema contract: unable to inspect indexes", table.name),
 			})
+		}
+	} else {
+		for _, name := range sortedIndexNames(table.indexes) {
+			spec := table.indexes[name]
+			if !hasObservedTiDBIndex(observedIndexes, name) {
+				diffs = append(diffs, tidbSchemaDiff{
+					kind:      tidbSchemaDiffMissingIndex,
+					tableName: table.name,
+					detail:    fmt.Sprintf("%s schema contract: missing %s index", table.name, name),
+					repairSQL: spec.createSQL,
+				})
+			}
 		}
 	}
 	if table.validate != nil {
@@ -1035,10 +1128,10 @@ func hasObservedTiDBIndex(observedIndexes map[string]struct{}, indexName string)
 	return ok
 }
 
-func parseObservedTiDBIndexes(createStmt string) map[string]struct{} {
+func parseObservedTiDBIndexes(createStmt string) (map[string]struct{}, bool) {
 	_, defs, ok, err := parseCreateTableStatement(createStmt)
 	if err != nil || !ok {
-		return nil
+		return nil, false
 	}
 	observed := make(map[string]struct{})
 	for _, def := range splitTopLevelComma(defs) {
@@ -1050,8 +1143,8 @@ func parseObservedTiDBIndexes(createStmt string) map[string]struct{} {
 		switch {
 		case strings.HasPrefix(normalized, "primary key") || strings.Contains(normalized, " primary key"):
 			observed["primary"] = struct{}{}
-		case strings.HasPrefix(normalized, "constraint ") && strings.Contains(normalized, " unique key "):
-			if name, _ := parseIndexNameAndColumns(def, "UNIQUE KEY"); name != "" {
+		case strings.HasPrefix(normalized, "constraint "):
+			if name, _, ok := parseConstraintUniqueIndexDefinition(def); ok {
 				observed[name] = struct{}{}
 			}
 		case strings.HasPrefix(normalized, "unique key "):
@@ -1072,7 +1165,44 @@ func parseObservedTiDBIndexes(createStmt string) map[string]struct{} {
 			}
 		}
 	}
-	return observed
+	return observed, true
+}
+
+func parseIndexColumnList(def string) []string {
+	inner, ok := parseParenthesizedList(def)
+	if !ok {
+		return nil
+	}
+	parts := splitTopLevelComma(inner)
+	columns := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name := parseColumnReferenceName(part)
+		if name == "" {
+			return nil
+		}
+		columns = append(columns, name)
+	}
+	return columns
+}
+
+func parseParenthesizedList(s string) (string, bool) {
+	open := strings.Index(s, "(")
+	if open < 0 {
+		return "", false
+	}
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(s[open+1 : i]), true
+			}
+		}
+	}
+	return "", false
 }
 
 func parsePrimaryKeyColumnsFromCreateStatement(createStmt string) ([]string, bool) {
@@ -1201,6 +1331,15 @@ func applyTiDBSchemaRepairs(ctx context.Context, db *sql.DB, statements []string
 		return nil
 	}
 	for _, stmt := range statements {
+		if isUniqueIndexRepairSQL(stmt) {
+			repair, ok := parseUniqueIndexRepairStatement(stmt)
+			if !ok {
+				return fmt.Errorf("preflight unique index repair %q: unsupported statement", schemaStatementSnippet(stmt))
+			}
+			if err := ensureUniqueIndexRepairSafe(ctx, db, repair); err != nil {
+				return err
+			}
+		}
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			if isIgnorableTiDBSchemaError(err) {
 				continue
@@ -1209,6 +1348,116 @@ func applyTiDBSchemaRepairs(ctx context.Context, db *sql.DB, statements []string
 		}
 	}
 	return nil
+}
+
+func isUniqueIndexRepairSQL(sqlText string) bool {
+	normalized := normalizeSQLFragment(sqlText)
+	if strings.HasPrefix(normalized, "create unique index ") {
+		return true
+	}
+	return strings.HasPrefix(normalized, "alter table ") &&
+		(strings.Contains(normalized, " add unique index ") || strings.Contains(normalized, " add unique key "))
+}
+
+func parseUniqueIndexRepairStatement(stmt string) (tidbUniqueIndexRepair, bool) {
+	if tableName, indexName, columns, ok := parseCreateUniqueIndexRepairStatement(stmt); ok {
+		return tidbUniqueIndexRepair{tableName: tableName, indexName: indexName, columns: columns}, true
+	}
+	if tableName, indexName, columns, ok := parseAlterTableAddUniqueIndexRepairStatement(stmt); ok {
+		return tidbUniqueIndexRepair{tableName: tableName, indexName: indexName, columns: columns}, true
+	}
+	return tidbUniqueIndexRepair{}, false
+}
+
+func parseCreateUniqueIndexRepairStatement(stmt string) (tableName, indexName string, columns []string, ok bool) {
+	trimmed := strings.TrimSpace(stmt)
+	upper := strings.ToUpper(trimmed)
+	const prefix = "CREATE UNIQUE INDEX "
+	if !strings.HasPrefix(upper, prefix) {
+		return "", "", nil, false
+	}
+	rest := strings.TrimSpace(trimmed[len(prefix):])
+	name, remainder := splitIdentifierAndSuffix(rest)
+	if name == "" || remainder == "" {
+		return "", "", nil, false
+	}
+	remainder = strings.TrimSpace(remainder)
+	upperRemainder := strings.ToUpper(remainder)
+	if !strings.HasPrefix(upperRemainder, "ON ") {
+		return "", "", nil, false
+	}
+	afterOn := strings.TrimSpace(remainder[len("ON "):])
+	table, columnRemainder := splitIdentifierAndSuffix(afterOn)
+	if table == "" || columnRemainder == "" {
+		return "", "", nil, false
+	}
+	parsedColumns := parseIndexColumnList(columnRemainder)
+	if len(parsedColumns) == 0 {
+		return "", "", nil, false
+	}
+	return strings.ToLower(table), strings.ToLower(name), parsedColumns, true
+}
+
+func parseAlterTableAddUniqueIndexRepairStatement(stmt string) (tableName, indexName string, columns []string, ok bool) {
+	trimmed := strings.TrimSpace(stmt)
+	upper := strings.ToUpper(trimmed)
+	const prefix = "ALTER TABLE "
+	if !strings.HasPrefix(upper, prefix) {
+		return "", "", nil, false
+	}
+	rest := strings.TrimSpace(trimmed[len(prefix):])
+	table, remainder := splitIdentifierAndRest(rest)
+	if table == "" || remainder == "" {
+		return "", "", nil, false
+	}
+	remainder = strings.TrimSpace(remainder)
+	upperRemainder := strings.ToUpper(remainder)
+	for _, marker := range []string{"ADD UNIQUE INDEX ", "ADD UNIQUE KEY "} {
+		if !strings.HasPrefix(upperRemainder, marker) {
+			continue
+		}
+		afterMarker := strings.TrimSpace(remainder[len(marker):])
+		name, columnRemainder := splitIdentifierAndSuffix(afterMarker)
+		if name == "" || columnRemainder == "" {
+			return "", "", nil, false
+		}
+		parsedColumns := parseIndexColumnList(columnRemainder)
+		if len(parsedColumns) == 0 {
+			return "", "", nil, false
+		}
+		return strings.ToLower(table), strings.ToLower(name), parsedColumns, true
+	}
+	return "", "", nil, false
+}
+
+func ensureUniqueIndexRepairSafe(ctx context.Context, db *sql.DB, repair tidbUniqueIndexRepair) error {
+	var exists int
+	err := db.QueryRowContext(ctx, buildUniqueIndexDuplicateCheckSQL(repair)).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("preflight unique index repair %s on %s: %w", repair.indexName, repair.tableName, err)
+	}
+	return fmt.Errorf("cannot auto-repair unique index %s on %s: duplicate rows exist for columns (%s)", repair.indexName, repair.tableName, strings.Join(repair.columns, ", "))
+}
+
+func buildUniqueIndexDuplicateCheckSQL(repair tidbUniqueIndexRepair) string {
+	quotedColumns := make([]string, 0, len(repair.columns))
+	nonNullPredicates := make([]string, 0, len(repair.columns))
+	for _, column := range repair.columns {
+		quoted := quoteSQLIdentifier(column)
+		quotedColumns = append(quotedColumns, quoted)
+		nonNullPredicates = append(nonNullPredicates, quoted+" IS NOT NULL")
+	}
+	return fmt.Sprintf("SELECT 1 FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1 LIMIT 1",
+		quoteSQLIdentifier(repair.tableName),
+		strings.Join(nonNullPredicates, " AND "),
+		strings.Join(quotedColumns, ", "))
+}
+
+func quoteSQLIdentifier(identifier string) string {
+	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
 }
 
 func isIgnorableTiDBSchemaError(err error) bool {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -545,6 +545,29 @@ func loadShowCreateTable(ctx context.Context, db *sql.DB, tableName string) (str
 	return createStmt, nil
 }
 
+func loadTiDBIndexNames(ctx context.Context, db *sql.DB, tableName string) (map[string]struct{}, error) {
+	rows, err := db.QueryContext(ctx, `SELECT DISTINCT index_name
+		FROM information_schema.statistics
+		WHERE table_schema = DATABASE() AND table_name = ?`, tableName)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	indexNames := make(map[string]struct{})
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		indexNames[strings.ToLower(name)] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return indexNames, nil
+}
+
 func normalizeSQLFragment(s string) string {
 	return schemaspec.NormalizeSQLFragment(s)
 }
@@ -587,7 +610,11 @@ func diffTiDBTable(ctx context.Context, db *sql.DB, table tidbTableSpec) ([]tidb
 	if err != nil {
 		return nil, fmt.Errorf("show create %s: %w", table.name, err)
 	}
-	return diffTiDBTableMeta(table, meta, createStmt), nil
+	indexNames, err := loadTiDBIndexNames(ctx, db, table.name)
+	if err != nil {
+		return nil, fmt.Errorf("load %s index metadata: %w", table.name, err)
+	}
+	return diffTiDBTableMetaWithObservedIndexes(table, meta, createStmt, indexNames), nil
 }
 
 func tidbSchemaSpecForMode(mode TiDBEmbeddingMode) (tidbSchemaSpec, error) {
@@ -940,6 +967,10 @@ func parseAlterTableAddIndexStatement(stmt string) (tableName, indexName, create
 }
 
 func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt string) []tidbSchemaDiff {
+	return diffTiDBTableMetaWithObservedIndexes(table, meta, createStmt, parseObservedTiDBIndexes(createStmt))
+}
+
+func diffTiDBTableMetaWithObservedIndexes(table tidbTableSpec, meta tidbTableMeta, createStmt string, observedIndexes map[string]struct{}) []tidbSchemaDiff {
 	var diffs []tidbSchemaDiff
 	for _, name := range sortedColumnNames(table.columns) {
 		spec := table.columns[name]
@@ -979,10 +1010,9 @@ func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt strin
 			})
 		}
 	}
-	normalizedCreate := normalizeSQLFragment(createStmt)
 	for _, name := range sortedIndexNames(table.indexes) {
 		spec := table.indexes[name]
-		if !showCreateHasIndex(normalizedCreate, name) {
+		if !hasObservedTiDBIndex(observedIndexes, name) {
 			diffs = append(diffs, tidbSchemaDiff{
 				kind:      tidbSchemaDiffMissingIndex,
 				tableName: table.name,
@@ -995,6 +1025,54 @@ func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt strin
 		diffs = append(diffs, table.validate(meta)...)
 	}
 	return diffs
+}
+
+func hasObservedTiDBIndex(observedIndexes map[string]struct{}, indexName string) bool {
+	if len(observedIndexes) == 0 {
+		return false
+	}
+	_, ok := observedIndexes[strings.ToLower(indexName)]
+	return ok
+}
+
+func parseObservedTiDBIndexes(createStmt string) map[string]struct{} {
+	_, defs, ok, err := parseCreateTableStatement(createStmt)
+	if err != nil || !ok {
+		return nil
+	}
+	observed := make(map[string]struct{})
+	for _, def := range splitTopLevelComma(defs) {
+		def = strings.TrimSpace(def)
+		if def == "" {
+			continue
+		}
+		normalized := normalizeSQLFragment(def)
+		switch {
+		case strings.HasPrefix(normalized, "primary key") || strings.Contains(normalized, " primary key"):
+			observed["primary"] = struct{}{}
+		case strings.HasPrefix(normalized, "constraint ") && strings.Contains(normalized, " unique key "):
+			if name, _ := parseIndexNameAndColumns(def, "UNIQUE KEY"); name != "" {
+				observed[name] = struct{}{}
+			}
+		case strings.HasPrefix(normalized, "unique key "):
+			if name, _ := parseIndexNameAndColumns(def, "UNIQUE KEY"); name != "" {
+				observed[name] = struct{}{}
+			}
+		case strings.HasPrefix(normalized, "unique index "):
+			if name, _ := parseIndexNameAndColumns(def, "UNIQUE INDEX"); name != "" {
+				observed[name] = struct{}{}
+			}
+		case strings.HasPrefix(normalized, "index "):
+			if name, _ := parseIndexNameAndColumns(def, "INDEX"); name != "" {
+				observed[name] = struct{}{}
+			}
+		case strings.HasPrefix(normalized, "key "):
+			if name, _ := parseIndexNameAndColumns(def, "KEY"); name != "" {
+				observed[name] = struct{}{}
+			}
+		}
+	}
+	return observed
 }
 
 func parsePrimaryKeyColumnsFromCreateStatement(createStmt string) ([]string, bool) {
@@ -1105,11 +1183,11 @@ func isSafeAddIndexRepairSQL(sqlText string, tableMissing bool) bool {
 		return true
 	}
 	if strings.HasPrefix(normalized, "create unique index ") {
-		return tableMissing
+		return true
 	}
 	if strings.HasPrefix(normalized, "alter table ") {
 		if strings.Contains(normalized, " add unique index ") || strings.Contains(normalized, " add unique key ") {
-			return tableMissing
+			return true
 		}
 		if strings.Contains(normalized, " add fulltext index ") || strings.Contains(normalized, " add vector index ") || strings.Contains(normalized, " add index ") || strings.Contains(normalized, " add key ") {
 			return true
@@ -1224,9 +1302,4 @@ func sortedIndexNames(indexes map[string]tidbIndexSpec) []string {
 	}
 	sort.Strings(names)
 	return names
-}
-
-func showCreateHasIndex(normalizedCreate, indexName string) bool {
-	needle := strings.ToLower(indexName) + " ("
-	return strings.Contains(normalizedCreate, needle)
 }

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -807,14 +807,31 @@ func parseConstraintUniqueIndexDefinition(def string) (indexName, columns string
 	upperRemainder := strings.ToUpper(remainder)
 	switch {
 	case strings.HasPrefix(upperRemainder, "UNIQUE KEY"):
-		return strings.ToLower(name), parseIndexColumnsSuffix(remainder[len("UNIQUE KEY"):]), true
+		return parseConstraintUniqueIndexSuffix(name, remainder[len("UNIQUE KEY"):])
 	case strings.HasPrefix(upperRemainder, "UNIQUE INDEX"):
-		return strings.ToLower(name), parseIndexColumnsSuffix(remainder[len("UNIQUE INDEX"):]), true
+		return parseConstraintUniqueIndexSuffix(name, remainder[len("UNIQUE INDEX"):])
 	case strings.HasPrefix(upperRemainder, "UNIQUE"):
-		return strings.ToLower(name), parseIndexColumnsSuffix(remainder[len("UNIQUE"):]), true
+		return parseConstraintUniqueIndexSuffix(name, remainder[len("UNIQUE"):])
 	default:
 		return "", "", false
 	}
+}
+
+func parseConstraintUniqueIndexSuffix(defaultName, suffix string) (indexName, columns string, ok bool) {
+	suffix = strings.TrimSpace(suffix)
+	if suffix == "" {
+		return "", "", false
+	}
+	name, columnSuffix := splitIdentifierAndSuffix(suffix)
+	if name == "" {
+		name = defaultName
+		columnSuffix = suffix
+	}
+	cols := parseIndexColumnsSuffix(columnSuffix)
+	if cols == "" {
+		return "", "", false
+	}
+	return strings.ToLower(name), cols, true
 }
 
 func parseIndexNameAndColumns(def, prefix string) (indexName, columns string) {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -1093,7 +1093,6 @@ func diffTiDBTableMetaWithObservedIndexes(table tidbTableSpec, meta tidbTableMet
 			})
 		}
 	}
-<<<<<<< HEAD
 	if !indexesObserved {
 		if len(table.indexes) > 0 {
 			diffs = append(diffs, tidbSchemaDiff{

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -1024,7 +1024,7 @@ func parseAlterTableAddIndexStatement(stmt string) (tableName, indexName, create
 	}
 	table := strings.ToLower(fields[0])
 
-	markers := []string{" add fulltext index ", " add vector index ", " add unique index ", " add index ", " add key "}
+	markers := []string{" add fulltext index ", " add vector index ", " add unique index ", " add unique key ", " add index ", " add key "}
 	for _, marker := range markers {
 		pos := strings.Index(normalized, marker)
 		if pos < 0 {
@@ -1093,6 +1093,7 @@ func diffTiDBTableMetaWithObservedIndexes(table tidbTableSpec, meta tidbTableMet
 			})
 		}
 	}
+<<<<<<< HEAD
 	if !indexesObserved {
 		if len(table.indexes) > 0 {
 			diffs = append(diffs, tidbSchemaDiff{
@@ -1319,7 +1320,10 @@ func isSafeAddIndexRepairSQL(sqlText string, tableMissing bool) bool {
 		if strings.Contains(normalized, " add unique index ") || strings.Contains(normalized, " add unique key ") {
 			return true
 		}
-		if strings.Contains(normalized, " add fulltext index ") || strings.Contains(normalized, " add vector index ") || strings.Contains(normalized, " add index ") || strings.Contains(normalized, " add key ") {
+		if strings.Contains(normalized, " add fulltext index ") || strings.Contains(normalized, " add vector index ") {
+			return tableMissing
+		}
+		if strings.Contains(normalized, " add index ") || strings.Contains(normalized, " add key ") {
 			return true
 		}
 	}

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -343,6 +343,53 @@ func TestDiffTiDBTableMetaRecognizesUniqueIndexFromCreateStatement(t *testing.T)
 	}
 }
 
+func TestDiffTiDBTableUsesInformationSchemaIndexesForUploads(t *testing.T) {
+	if testDSN == "" {
+		t.Skip("mysql test DSN not configured")
+	}
+
+	db, err := sql.Open("mysql", testDSN)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec("DROP TABLE IF EXISTS uploads"); err != nil {
+		t.Fatalf("drop uploads: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.Exec("DROP TABLE IF EXISTS uploads")
+	})
+
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "uploads")
+	if _, err := db.Exec(spec.createStatement); err != nil {
+		t.Fatalf("create uploads table: %v", err)
+	}
+	for _, indexName := range sortedIndexNames(spec.indexes) {
+		if _, err := db.Exec(spec.indexes[indexName].createSQL); err != nil {
+			t.Fatalf("create %s: %v", indexName, err)
+		}
+	}
+
+	diffs, err := diffTiDBTable(context.Background(), db, spec)
+	if err != nil {
+		t.Fatalf("diffTiDBTable: %v", err)
+	}
+	if hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "idx_uploads_active") {
+		t.Fatalf("did not expect idx_uploads_active to be reported missing via information_schema path, got %#v", diffs)
+	}
+	if len(diffs) != 0 {
+		t.Fatalf("expected uploads table created from schema spec to have no diffs, got %#v", diffs)
+	}
+	observed, ok := loadObservedTiDBIndexes(context.Background(), db, "uploads", spec.createStatement)
+	if !ok {
+		t.Fatal("expected loadObservedTiDBIndexes to observe indexes from information_schema")
+	}
+	if !hasObservedTiDBIndex(observed, "idx_uploads_active") {
+		t.Fatalf("expected idx_uploads_active in observed indexes, got %#v", observed)
+	}
+}
+
 func TestDiffTiDBTableMetaReportsIndexInspectionFailureInsteadOfFalsePositives(t *testing.T) {
 	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "uploads")
 	meta := testUploadsTableMeta(true)

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -1,8 +1,14 @@
 package schema
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
 	"errors"
+	"io"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -222,6 +228,50 @@ func TestPlannedTiDBSchemaRepairsAllowsUniqueIndexOnExistingTable(t *testing.T) 
 	}
 }
 
+func TestParseUniqueIndexRepairStatement(t *testing.T) {
+	repair, ok := parseUniqueIndexRepairStatement("ALTER TABLE semantic_tasks ADD UNIQUE KEY uk_task_resource_version(task_type, resource_id, resource_version)")
+	if !ok {
+		t.Fatal("expected unique index repair statement to parse")
+	}
+	if repair.tableName != "semantic_tasks" || repair.indexName != "uk_task_resource_version" {
+		t.Fatalf("unexpected repair target: %#v", repair)
+	}
+	if !equalStringSlices(repair.columns, []string{"task_type", "resource_id", "resource_version"}) {
+		t.Fatalf("unexpected repair columns: %#v", repair.columns)
+	}
+}
+
+func TestBuildUniqueIndexDuplicateCheckSQL(t *testing.T) {
+	repair := tidbUniqueIndexRepair{
+		tableName: "uploads",
+		indexName: "idx_uploads_active",
+		columns:   []string{"active_target_path"},
+	}
+	got := buildUniqueIndexDuplicateCheckSQL(repair)
+	want := "SELECT 1 FROM `uploads` WHERE `active_target_path` IS NOT NULL GROUP BY `active_target_path` HAVING COUNT(*) > 1 LIMIT 1"
+	if got != want {
+		t.Fatalf("duplicate check SQL=%q, want %q", got, want)
+	}
+}
+
+func TestApplyTiDBSchemaRepairsPreflightsUniqueIndexDuplicates(t *testing.T) {
+	db, cleanup := newTestRepairDB(t, func(query string) testRepairQueryResult {
+		if strings.Contains(query, "GROUP BY `idempotency_key`") {
+			return testRepairQueryResult{columns: []string{"1"}, rows: [][]driver.Value{{int64(1)}}}
+		}
+		return testRepairQueryResult{}
+	}, nil)
+	defer cleanup()
+
+	err := applyTiDBSchemaRepairs(context.Background(), db, []string{"CREATE UNIQUE INDEX idx_idempotency ON uploads(idempotency_key)"})
+	if err == nil {
+		t.Fatal("expected duplicate preflight to reject repair")
+	}
+	if !strings.Contains(err.Error(), "duplicate rows exist") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestValidateTiDBAutoEmbeddingFilesDiffsReportsGeneratedContractMismatch(t *testing.T) {
 	meta := testFilesTableMeta(TiDBEmbeddingModeApp)
 	diffs := validateTiDBAutoEmbeddingFilesDiffs(meta)
@@ -267,6 +317,51 @@ func TestDiffTiDBTableMetaRecognizesUniqueIndexFromCreateStatement(t *testing.T)
 	diffs := diffTiDBTableMeta(spec, meta, createStmt)
 	if hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "idx_uploads_active") {
 		t.Fatalf("did not expect idx_uploads_active to be reported missing, got %#v", diffs)
+	}
+}
+
+func TestDiffTiDBTableMetaReportsIndexInspectionFailureInsteadOfFalsePositives(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "uploads")
+	meta := testUploadsTableMeta(true)
+	diffs := diffTiDBTableMetaWithObservedIndexes(spec, meta, `CREATE TABLE uploads (upload_id VARCHAR(64) PRIMARY KEY)`, nil, false)
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffTableContract, "unable to inspect indexes") {
+		t.Fatalf("expected unable to inspect indexes diff, got %#v", diffs)
+	}
+	if hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "idx_uploads_active") {
+		t.Fatalf("did not expect false-positive missing index diff, got %#v", diffs)
+	}
+}
+
+func TestParseObservedTiDBIndexesRecognizesConstraintUnique(t *testing.T) {
+	createStmt := `CREATE TABLE uploads (
+		upload_id VARCHAR(64) PRIMARY KEY,
+		active_target_path VARCHAR(512),
+		CONSTRAINT idx_uploads_active UNIQUE (active_target_path)
+	)`
+	observed, ok := parseObservedTiDBIndexes(createStmt)
+	if !ok {
+		t.Fatal("expected observed indexes parse to succeed")
+	}
+	if !hasObservedTiDBIndex(observed, "idx_uploads_active") {
+		t.Fatalf("expected idx_uploads_active to be observed, got %#v", observed)
+	}
+}
+
+func TestTiDBSchemaSpecFromStatementsParsesConstraintUniqueDefinition(t *testing.T) {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS uploads (
+			upload_id VARCHAR(64) PRIMARY KEY,
+			active_target_path VARCHAR(512),
+			CONSTRAINT idx_uploads_active UNIQUE (active_target_path)
+		)`,
+	}
+	spec, err := tidbSchemaSpecFromStatements(stmts)
+	if err != nil {
+		t.Fatalf("tidbSchemaSpecFromStatements: %v", err)
+	}
+	table := mustTableSpecFromSchemaSpec(t, spec, "uploads")
+	if _, ok := table.indexes["idx_uploads_active"]; !ok {
+		t.Fatalf("expected idx_uploads_active index in parsed schema spec, got %#v", table.indexes)
 	}
 }
 
@@ -681,4 +776,81 @@ func mustTableSpecFromSchemaSpec(t *testing.T, spec tidbSchemaSpec, tableName st
 	}
 	t.Fatalf("missing table spec %q", tableName)
 	return tidbTableSpec{}
+}
+
+type testRepairQueryResult struct {
+	columns []string
+	rows    [][]driver.Value
+	err     error
+}
+
+type testRepairDriver struct {
+	queryFn func(string) testRepairQueryResult
+	execFn  func(string) error
+}
+
+type testRepairConn struct {
+	queryFn func(string) testRepairQueryResult
+	execFn  func(string) error
+}
+
+type testRepairRows struct {
+	columns []string
+	rows    [][]driver.Value
+	index   int
+}
+
+var testRepairDriverCounter uint64
+
+func newTestRepairDB(t *testing.T, queryFn func(string) testRepairQueryResult, execFn func(string) error) (*sql.DB, func()) {
+	t.Helper()
+	name := "test-repair-driver-" + strconv.FormatUint(atomic.AddUint64(&testRepairDriverCounter, 1), 10)
+	sql.Register(name, testRepairDriver{queryFn: queryFn, execFn: execFn})
+	db, err := sql.Open(name, "")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	return db, func() { _ = db.Close() }
+}
+
+func (d testRepairDriver) Open(string) (driver.Conn, error) {
+	return testRepairConn{queryFn: d.queryFn, execFn: d.execFn}, nil
+}
+
+func (c testRepairConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+func (c testRepairConn) Close() error              { return nil }
+func (c testRepairConn) Begin() (driver.Tx, error) { return nil, errors.New("not implemented") }
+
+func (c testRepairConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	result := c.queryFn(query)
+	if result.err != nil {
+		return nil, result.err
+	}
+	if len(result.columns) == 0 {
+		return &testRepairRows{}, nil
+	}
+	return &testRepairRows{columns: result.columns, rows: result.rows}, nil
+}
+
+func (c testRepairConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	if c.execFn != nil {
+		if err := c.execFn(query); err != nil {
+			return nil, err
+		}
+	}
+	return driver.RowsAffected(1), nil
+}
+
+func (r *testRepairRows) Columns() []string { return r.columns }
+func (r *testRepairRows) Close() error      { return nil }
+
+func (r *testRepairRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.index])
+	r.index++
+	return nil
 }

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -853,7 +853,7 @@ func newTestRepairDB(t *testing.T, queryFn func(string) testRepairQueryResult, e
 }
 
 func (d testRepairDriver) Open(string) (driver.Conn, error) {
-	return testRepairConn{queryFn: d.queryFn, execFn: d.execFn}, nil
+	return testRepairConn(d), nil
 }
 
 func (c testRepairConn) Prepare(string) (driver.Stmt, error) {

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -255,13 +255,12 @@ func TestBuildUniqueIndexDuplicateCheckSQL(t *testing.T) {
 }
 
 func TestApplyTiDBSchemaRepairsPreflightsUniqueIndexDuplicates(t *testing.T) {
-	db, cleanup := newTestRepairDB(t, func(query string) testRepairQueryResult {
+	db := newTestRepairDB(t, func(query string) testRepairQueryResult {
 		if strings.Contains(query, "GROUP BY `idempotency_key`") {
 			return testRepairQueryResult{columns: []string{"1"}, rows: [][]driver.Value{{int64(1)}}}
 		}
 		return testRepairQueryResult{}
 	}, nil)
-	defer cleanup()
 
 	err := applyTiDBSchemaRepairs(context.Background(), db, []string{"CREATE UNIQUE INDEX idx_idempotency ON uploads(idempotency_key)"})
 	if err == nil {
@@ -275,7 +274,7 @@ func TestApplyTiDBSchemaRepairsPreflightsUniqueIndexDuplicates(t *testing.T) {
 func TestApplyTiDBSchemaRepairsPreflightsUniqueIndexNoDuplicatesExecutesRepair(t *testing.T) {
 	var executed atomic.Int32
 
-	db, cleanup := newTestRepairDB(t, func(query string) testRepairQueryResult {
+	db := newTestRepairDB(t, func(query string) testRepairQueryResult {
 		if strings.Contains(query, "GROUP BY `idempotency_key`") {
 			return testRepairQueryResult{}
 		}
@@ -286,7 +285,6 @@ func TestApplyTiDBSchemaRepairsPreflightsUniqueIndexNoDuplicatesExecutesRepair(t
 		}
 		return nil
 	})
-	defer cleanup()
 
 	err := applyTiDBSchemaRepairs(context.Background(), db, []string{"CREATE UNIQUE INDEX idx_idempotency ON uploads(idempotency_key)"})
 	if err != nil {
@@ -791,7 +789,6 @@ func testFilesTableMeta(mode TiDBEmbeddingMode) tidbTableMeta {
 	}
 	return meta
 }
-
 func testUploadsTableMeta(includeExpectedRevision bool) tidbTableMeta {
 	meta := tidbTableMeta{
 		tableName: "uploads",
@@ -805,6 +802,21 @@ func testUploadsTableMeta(includeExpectedRevision bool) tidbTableMeta {
 		meta.columns["expected_revision"] = tidbColumnMeta{columnType: "bigint"}
 	}
 	return meta
+}
+
+func TestParseConstraintUniqueIndexDefinitionUsesExplicitIndexName(t *testing.T) {
+	indexName, columns, ok := parseConstraintUniqueIndexDefinition(
+		"CONSTRAINT uploads_active_constraint UNIQUE KEY idx_uploads_active (active_target_path)",
+	)
+	if !ok {
+		t.Fatal("expected constraint unique definition to parse")
+	}
+	if indexName != "idx_uploads_active" {
+		t.Fatalf("indexName=%q, want idx_uploads_active", indexName)
+	}
+	if columns != "(active_target_path)" {
+		t.Fatalf("columns=%q, want (active_target_path)", columns)
+	}
 }
 
 func mustTiDBTableSpecByName(t *testing.T, mode TiDBEmbeddingMode, tableName string) tidbTableSpec {
@@ -866,7 +878,7 @@ type testRepairRows struct {
 
 var testRepairDriverCounter uint64
 
-func newTestRepairDB(t *testing.T, queryFn func(string) testRepairQueryResult, execFn func(string) error) (*sql.DB, func()) {
+func newTestRepairDB(t *testing.T, queryFn func(string) testRepairQueryResult, execFn func(string) error) *sql.DB {
 	t.Helper()
 	name := "test-repair-driver-" + strconv.FormatUint(atomic.AddUint64(&testRepairDriverCounter, 1), 10)
 	sql.Register(name, testRepairDriver{queryFn: queryFn, execFn: execFn})
@@ -874,7 +886,8 @@ func newTestRepairDB(t *testing.T, queryFn func(string) testRepairQueryResult, e
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
 	}
-	return db, func() { _ = db.Close() }
+	t.Cleanup(func() { _ = db.Close() })
+	return db
 }
 
 func (d testRepairDriver) Open(string) (driver.Conn, error) {

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -546,7 +546,7 @@ func TestTiDBSchemaSpecForAppModeExcludesOptionalIndexes(t *testing.T) {
 	}
 }
 
-func TestPlannedTiDBSchemaRepairsIncludesAlterTableIndexRepairs(t *testing.T) {
+func TestPlannedTiDBSchemaRepairsSkipsHeavyAlterTableIndexRepairsOnExistingTable(t *testing.T) {
 	diffs := []tidbSchemaDiff{
 		{
 			kind:      tidbSchemaDiffMissingIndex,
@@ -557,11 +557,32 @@ func TestPlannedTiDBSchemaRepairsIncludesAlterTableIndexRepairs(t *testing.T) {
 	}
 
 	got := plannedTiDBSchemaRepairs(diffs)
-	if len(got) != 1 {
-		t.Fatalf("expected one repair statement, got %#v", got)
+	if len(got) != 0 {
+		t.Fatalf("expected heavy index repair to be skipped on existing table, got %#v", got)
 	}
-	if got[0] != "ALTER TABLE files ADD FULLTEXT INDEX idx_fts_content(content_text)" {
-		t.Fatalf("unexpected repair statement: %q", got[0])
+}
+
+func TestPlannedTiDBSchemaRepairsAllowsHeavyAlterTableIndexRepairsWhenTableMissing(t *testing.T) {
+	diffs := []tidbSchemaDiff{
+		{
+			kind:      tidbSchemaDiffMissingTable,
+			tableName: "files",
+			repairSQL: "CREATE TABLE IF NOT EXISTS files (...)",
+		},
+		{
+			kind:      tidbSchemaDiffMissingIndex,
+			tableName: "files",
+			detail:    "files schema contract: missing idx_fts_content index",
+			repairSQL: "ALTER TABLE files ADD FULLTEXT INDEX idx_fts_content(content_text)",
+		},
+	}
+
+	got := plannedTiDBSchemaRepairs(diffs)
+	if len(got) != 2 {
+		t.Fatalf("expected create table and heavy index repair, got %#v", got)
+	}
+	if got[1] != "ALTER TABLE files ADD FULLTEXT INDEX idx_fts_content(content_text)" {
+		t.Fatalf("unexpected second repair statement: %q", got[1])
 	}
 }
 
@@ -683,7 +704,7 @@ func TestIsIgnorableTiDBSchemaError(t *testing.T) {
 		{
 			name: "plain duplicate",
 			err:  errors.New("duplicate entry"),
-			want: true,
+			want: false,
 		},
 		{
 			name: "non ignorable mysql",
@@ -703,6 +724,24 @@ func TestIsIgnorableTiDBSchemaError(t *testing.T) {
 				t.Fatalf("isIgnorableTiDBSchemaError()=%v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseAlterTableAddIndexStatementAcceptsUniqueKey(t *testing.T) {
+	tableName, indexName, createSQL, ok := parseAlterTableAddIndexStatement(
+		"ALTER TABLE uploads ADD UNIQUE KEY uk_uploads_target (target_path)",
+	)
+	if !ok {
+		t.Fatal("expected ALTER TABLE ... ADD UNIQUE KEY to parse")
+	}
+	if tableName != "uploads" {
+		t.Fatalf("tableName=%q, want uploads", tableName)
+	}
+	if indexName != "uk_uploads_target" {
+		t.Fatalf("indexName=%q, want uk_uploads_target", indexName)
+	}
+	if createSQL != "ALTER TABLE uploads ADD UNIQUE KEY uk_uploads_target (target_path)" {
+		t.Fatalf("createSQL=%q", createSQL)
 	}
 }
 

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -272,6 +272,31 @@ func TestApplyTiDBSchemaRepairsPreflightsUniqueIndexDuplicates(t *testing.T) {
 	}
 }
 
+func TestApplyTiDBSchemaRepairsPreflightsUniqueIndexNoDuplicatesExecutesRepair(t *testing.T) {
+	var executed atomic.Int32
+
+	db, cleanup := newTestRepairDB(t, func(query string) testRepairQueryResult {
+		if strings.Contains(query, "GROUP BY `idempotency_key`") {
+			return testRepairQueryResult{}
+		}
+		return testRepairQueryResult{}
+	}, func(query string) error {
+		if strings.Contains(query, "CREATE UNIQUE INDEX idx_idempotency ON uploads(idempotency_key)") {
+			executed.Add(1)
+		}
+		return nil
+	})
+	defer cleanup()
+
+	err := applyTiDBSchemaRepairs(context.Background(), db, []string{"CREATE UNIQUE INDEX idx_idempotency ON uploads(idempotency_key)"})
+	if err != nil {
+		t.Fatalf("expected repair to succeed when preflight finds no duplicates: %v", err)
+	}
+	if executed.Load() != 1 {
+		t.Fatalf("expected repair statement to execute once, executed=%d", executed.Load())
+	}
+}
+
 func TestValidateTiDBAutoEmbeddingFilesDiffsReportsGeneratedContractMismatch(t *testing.T) {
 	meta := testFilesTableMeta(TiDBEmbeddingModeApp)
 	diffs := validateTiDBAutoEmbeddingFilesDiffs(meta)

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -204,18 +204,21 @@ func TestPlannedTiDBSchemaRepairsIncludesSafeStatementsOnly(t *testing.T) {
 	}
 }
 
-func TestPlannedTiDBSchemaRepairsSkipsUnsafeUniqueIndexOnExistingTable(t *testing.T) {
+func TestPlannedTiDBSchemaRepairsAllowsUniqueIndexOnExistingTable(t *testing.T) {
 	diffs := []tidbSchemaDiff{
 		{kind: tidbSchemaDiffMissingIndex, tableName: "uploads", detail: "uploads schema contract: missing idx_upload_path index", repairSQL: "CREATE INDEX idx_upload_path ON uploads(target_path, status)"},
 		{kind: tidbSchemaDiffMissingIndex, tableName: "uploads", detail: "uploads schema contract: missing idx_idempotency index", repairSQL: "CREATE UNIQUE INDEX idx_idempotency ON uploads(idempotency_key)"},
 	}
 
 	got := plannedTiDBSchemaRepairs(diffs)
-	if len(got) != 1 {
-		t.Fatalf("expected one safe repair statement, got %#v", got)
+	if len(got) != 2 {
+		t.Fatalf("expected both missing indexes to be auto-repaired, got %#v", got)
 	}
 	if got[0] != "CREATE INDEX idx_upload_path ON uploads(target_path, status)" {
-		t.Fatalf("unexpected repair statement: %q", got[0])
+		t.Fatalf("unexpected first repair statement: %q", got[0])
+	}
+	if got[1] != "CREATE UNIQUE INDEX idx_idempotency ON uploads(idempotency_key)" {
+		t.Fatalf("unexpected second repair statement: %q", got[1])
 	}
 }
 
@@ -246,6 +249,24 @@ func TestDiffTiDBTableMetaReportsMissingRequiredIndex(t *testing.T) {
 	}
 	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "idx_idempotency") {
 		t.Fatalf("expected missing idx_idempotency diff, got %#v", diffs)
+	}
+}
+
+func TestDiffTiDBTableMetaRecognizesUniqueIndexFromCreateStatement(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "uploads")
+	meta := testUploadsTableMeta(true)
+	createStmt := `CREATE TABLE uploads (
+		upload_id VARCHAR(64) PRIMARY KEY,
+		target_path VARCHAR(512) NOT NULL,
+		status VARCHAR(32) NOT NULL,
+		expected_revision BIGINT NULL,
+		active_target_path VARCHAR(512),
+		UNIQUE KEY idx_uploads_active (active_target_path)
+	)`
+
+	diffs := diffTiDBTableMeta(spec, meta, createStmt)
+	if hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "idx_uploads_active") {
+		t.Fatalf("did not expect idx_uploads_active to be reported missing, got %#v", diffs)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix TiDB tenant schema auto-repair so missing required indexes on existing tenants can actually be repaired instead of being re-reported as schema drift.

## What changed
- switch TiDB index existence detection away from SHOW CREATE substring matching to observed index names parsed from schema metadata / create output
- allow missing unique indexes to participate in auto-repair for existing tables so required indexes like `idx_uploads_active` are restored
- add and update focused tests for observed-index detection and repair planning

## Verification
- `go test ./pkg/tenant/schema ./pkg/tenant`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection of missing indexes and safer unique-index repairs with preflight duplicate-row checks; improved handling of index definitions and DDL error classification; migration now uses a lock when applying meta schema diffs.

* **Tests**
  * Expanded end-to-end and unit tests for unique-index detection/repairs, index-parsing, duplicate-row preflight behavior, error classification, and migration metrics.

* **Chores**
  * Added metric emission for schema-version update failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->