### PR TITLE
Fix schema_version overflow: INT → INT UNSIGNED with auto-repair

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -483,13 +483,22 @@ func diffMetaTableMetaWithObservedIndexes(table metaTableSpec, meta metaTableMet
 			})
 			continue
 		}
-		if normalizeMetaSQLFragment(col.columnType) != normalizeMetaSQLFragment(spec.columnType) {
+		observedType := normalizeMetaSQLFragment(col.columnType)
+		desiredType := normalizeMetaSQLFragment(spec.columnType)
+		if observedType != desiredType {
+			// Only generate repair SQL for the one known-safe widening:
+			// tenants.schema_version INT → INT UNSIGNED.
+			var repairSQL string
+			if table.name == "tenants" && name == "schema_version" &&
+				observedType == "int" && desiredType == "int unsigned" {
+				repairSQL = spec.modifySQL
+			}
 			diffs = append(diffs, metaSchemaDiff{
 				kind:       metaSchemaDiffColumnType,
 				tableName:  table.name,
 				columnName: name,
 				detail:     fmt.Sprintf("%s schema contract: %s column type = %q, want %s", table.name, name, col.columnType, spec.columnType),
-				repairSQL:  spec.modifySQL,
+				repairSQL:  repairSQL,
 			})
 		}
 	}
@@ -706,7 +715,7 @@ func isSafeMetaRepairDiff(diff metaSchemaDiff, tableMissing map[string]bool) boo
 		}
 		return false
 	case metaSchemaDiffColumnType:
-		return isSafeModifyColumnRepairSQL(diff.repairSQL)
+		return isSafeModifyColumnRepairSQL(diff)
 	default:
 		return false
 	}
@@ -716,13 +725,17 @@ func isSafeAddColumnRepairSQL(sqlText string) bool {
 	return schemaspec.IsSafeAddColumnRepairSQL(sqlText)
 }
 
-// isSafeModifyColumnRepairSQL returns true for MODIFY COLUMN statements that
-// only widen a column type without data loss (e.g. INT → INT UNSIGNED).
-func isSafeModifyColumnRepairSQL(sqlText string) bool {
-	n := normalizeMetaSQLFragment(sqlText)
-	// Only allow: ALTER TABLE <t> MODIFY COLUMN <col> INT UNSIGNED ...
-	// This covers the schema_version INT → INT UNSIGNED upgrade path.
-	return strings.Contains(n, " modify column ") && strings.Contains(n, " int unsigned ")
+// isSafeModifyColumnRepairSQL returns true only for the single known-safe
+// column widening: tenants.schema_version INT → INT UNSIGNED.
+// schema_version values come from CRC32Version which produces uint32 (non-negative);
+// widening from INT to INT UNSIGNED is data-preserving for this column.
+// General MODIFY COLUMN is not considered safe without an explicit entry here.
+func isSafeModifyColumnRepairSQL(diff metaSchemaDiff) bool {
+	if diff.tableName != "tenants" || diff.columnName != "schema_version" {
+		return false
+	}
+	n := strings.TrimSuffix(normalizeMetaSQLFragment(diff.repairSQL), ";")
+	return n == "alter table tenants modify column schema_version int unsigned not null default 1"
 }
 
 func isIgnorableMetaSchemaError(err error) bool {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -249,6 +249,7 @@ type metaTableSpec struct {
 type metaColumnSpec struct {
 	columnType string
 	addSQL     string
+	modifySQL  string
 }
 
 type metaIndexSpec struct {
@@ -271,7 +272,7 @@ func metaInitSchemaStatements() []string {
 			cluster_id       VARCHAR(255) NULL,
 			claim_url        TEXT NULL,
 			claim_expires_at DATETIME(3) NULL,
-			schema_version   INT NOT NULL DEFAULT 1,
+			schema_version   INT UNSIGNED NOT NULL DEFAULT 1,
 			created_at       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			deleted_at       DATETIME(3) NULL,
@@ -488,6 +489,7 @@ func diffMetaTableMetaWithObservedIndexes(table metaTableSpec, meta metaTableMet
 				tableName:  table.name,
 				columnName: name,
 				detail:     fmt.Sprintf("%s schema contract: %s column type = %q, want %s", table.name, name, col.columnType, spec.columnType),
+				repairSQL:  spec.modifySQL,
 			})
 		}
 	}
@@ -671,6 +673,7 @@ func parseMetaColumnDefinition(tableName, def string) (string, metaColumnSpec, b
 	return strings.ToLower(name), metaColumnSpec{
 		columnType: strings.ToLower(strings.TrimSpace(colType)),
 		addSQL:     fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", tableName, name, strings.TrimSpace(rest)),
+		modifySQL:  fmt.Sprintf("ALTER TABLE %s MODIFY COLUMN %s %s", tableName, name, strings.TrimSpace(rest)),
 	}, true
 }
 
@@ -702,6 +705,8 @@ func isSafeMetaRepairDiff(diff metaSchemaDiff, tableMissing map[string]bool) boo
 			return tableMissing[diff.tableName]
 		}
 		return false
+	case metaSchemaDiffColumnType:
+		return isSafeModifyColumnRepairSQL(diff.repairSQL)
 	default:
 		return false
 	}
@@ -709,6 +714,15 @@ func isSafeMetaRepairDiff(diff metaSchemaDiff, tableMissing map[string]bool) boo
 
 func isSafeAddColumnRepairSQL(sqlText string) bool {
 	return schemaspec.IsSafeAddColumnRepairSQL(sqlText)
+}
+
+// isSafeModifyColumnRepairSQL returns true for MODIFY COLUMN statements that
+// only widen a column type without data loss (e.g. INT → INT UNSIGNED).
+func isSafeModifyColumnRepairSQL(sqlText string) bool {
+	n := normalizeMetaSQLFragment(sqlText)
+	// Only allow: ALTER TABLE <t> MODIFY COLUMN <col> INT UNSIGNED ...
+	// This covers the schema_version INT → INT UNSIGNED upgrade path.
+	return strings.Contains(n, " modify column ") && strings.Contains(n, " int unsigned ")
 }
 
 func isIgnorableMetaSchemaError(err error) bool {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -280,3 +280,83 @@ func hasMetaDiff(diffs []metaSchemaDiff, kind metaSchemaDiffKind, contains strin
 	}
 	return false
 }
+
+func TestColumnTypeMismatchSchemaVersionPlansRepair(t *testing.T) {
+	spec := mustMetaSpec(t)
+	tenantsSpec := mustMetaTableSpec(t, spec, "tenants")
+
+	// Simulate tenants table with schema_version as INT (old type).
+	observed := metaTableMeta{
+		tableName: "tenants",
+		columns:   map[string]metaColumnMeta{"schema_version": {columnType: "int"}},
+	}
+	diffs := diffMetaTableMetaWithObservedIndexes(tenantsSpec, observed, "", map[string]struct{}{})
+
+	var typeDiff *metaSchemaDiff
+	for i := range diffs {
+		if diffs[i].kind == metaSchemaDiffColumnType && diffs[i].columnName == "schema_version" {
+			typeDiff = &diffs[i]
+			break
+		}
+	}
+	if typeDiff == nil {
+		t.Fatal("expected a column_type_mismatch diff for schema_version, got none")
+	}
+	if typeDiff.repairSQL == "" {
+		t.Fatal("expected repairSQL to be set for schema_version type mismatch")
+	}
+
+	plans := plannedMetaSchemaRepairs([]metaSchemaDiff{*typeDiff})
+	if len(plans) != 1 {
+		t.Fatalf("expected exactly one planned repair, got %#v", plans)
+	}
+	want := "ALTER TABLE tenants MODIFY COLUMN schema_version INT UNSIGNED NOT NULL DEFAULT 1"
+	if plans[0] != want {
+		t.Fatalf("unexpected repair plan:\n  got  %q\n  want %q", plans[0], want)
+	}
+}
+
+func TestColumnTypeMismatchOtherColumnsNoRepair(t *testing.T) {
+	spec := mustMetaSpec(t)
+	tenantsSpec := mustMetaTableSpec(t, spec, "tenants")
+
+	// Simulate a type mismatch on a column other than schema_version — no auto-repair expected.
+	observed := metaTableMeta{
+		tableName: "tenants",
+		columns:   map[string]metaColumnMeta{"db_port": {columnType: "bigint"}},
+	}
+	diffs := diffMetaTableMetaWithObservedIndexes(tenantsSpec, observed, "", map[string]struct{}{})
+
+	for _, d := range diffs {
+		if d.kind == metaSchemaDiffColumnType && d.columnName != "schema_version" && d.repairSQL != "" {
+			t.Errorf("unexpected repairSQL for non-schema_version column %q: %q", d.columnName, d.repairSQL)
+		}
+	}
+}
+
+func TestIsSafeModifyColumnRepairSQLAcceptsSchemaVersion(t *testing.T) {
+	diff := metaSchemaDiff{
+		tableName:  "tenants",
+		columnName: "schema_version",
+		repairSQL:  "ALTER TABLE tenants MODIFY COLUMN schema_version INT UNSIGNED NOT NULL DEFAULT 1",
+	}
+	if !isSafeModifyColumnRepairSQL(diff) {
+		t.Fatal("expected isSafeModifyColumnRepairSQL to return true for schema_version repair")
+	}
+}
+
+func TestIsSafeModifyColumnRepairSQLRejectsOtherCases(t *testing.T) {
+	cases := []metaSchemaDiff{
+		{tableName: "tenants", columnName: "db_port", repairSQL: "ALTER TABLE tenants MODIFY COLUMN db_port INT UNSIGNED NOT NULL"},
+		{tableName: "tenant_api_keys", columnName: "schema_version", repairSQL: "ALTER TABLE tenant_api_keys MODIFY COLUMN schema_version INT UNSIGNED NOT NULL DEFAULT 1"},
+		{tableName: "tenants", columnName: "schema_version", repairSQL: "ALTER TABLE tenants MODIFY COLUMN schema_version BIGINT NOT NULL DEFAULT 1"},
+		{tableName: "tenants", columnName: "schema_version", repairSQL: ""},
+		{tableName: "tenants", columnName: "schema_version", repairSQL: "ALTER TABLE tenants MODIFY COLUMN schema_version INT UNSIGNED"},
+	}
+	for _, diff := range cases {
+		if isSafeModifyColumnRepairSQL(diff) {
+			t.Errorf("isSafeModifyColumnRepairSQL(%q.%q sql=%q) = true, want false",
+				diff.tableName, diff.columnName, diff.repairSQL)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Production error observed on 2026-04-24:

```
Error 1264 (22003): Out of range value for column 'schema_version' at row 1
```

`CRC32Version` returns `uint32` values (range 0–4294967295), but the `schema_version` column in the `tenants` table was typed `INT` (signed, max 2,147,483,647). The current schema version `2326288672` exceeds the signed INT max, causing `UpdateTenantSchemaVersion` to fail with an out-of-range error.

## Changes

### `pkg/meta/meta.go`

- **Column definition**: `schema_version INT NOT NULL DEFAULT 1` → `INT UNSIGNED NOT NULL DEFAULT 1`
- **`metaColumnSpec`**: Added `modifySQL` field that holds `ALTER TABLE … MODIFY COLUMN …` so the migration engine can repair an existing wrong-typed column
- **`parseMetaColumnDefinition`**: Populates `modifySQL` alongside `addSQL`
- **`diffMetaTableMetaWithObservedIndexes`**: Sets `repairSQL = spec.modifySQL` on `metaSchemaDiffColumnType` diffs (previously `repairSQL` was empty, so the diff was never repaired)
- **`isSafeMetaRepairDiff`**: Added `metaSchemaDiffColumnType` case delegating to the new `isSafeModifyColumnRepairSQL` helper
- **`isSafeModifyColumnRepairSQL`** (new): Whitelists `MODIFY COLUMN … INT UNSIGNED …` as a safe, data-preserving widening conversion

## Behaviour

On server startup `migrate()` now detects an existing `INT`-typed `schema_version` column and automatically runs:

```sql
ALTER TABLE tenants MODIFY COLUMN schema_version INT UNSIGNED NOT NULL DEFAULT 1
```

This unblocks any tenant that previously hit the overflow and requires no manual intervention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced schema repair to automatically detect and fix column type mismatches in database contracts, improving data integrity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->