### PR TITLE
vault set: fail loud on conflict instead of silent wholesale overwrite

### DIFF
--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -59,7 +59,13 @@ func Secret(args []string) error {
 	}
 }
 
-// SecretSet creates or updates a secret.
+// SecretSet creates a new secret. It deliberately does NOT update in place on
+// conflict: the server-side UpdateSecret is a wholesale-replace (deletes all
+// existing fields before writing the new ones), so a silent fallback here
+// would drop any field the caller didn't pass on this invocation. Users who
+// actually want to replace must be explicit — either `drive9 vault rm <name>`
+// then re-set, or `drive9 vault put /n/vault/<name> --from <dir>` for the
+// atomic wholesale-replace path.
 func SecretSet(args []string) error {
 	if len(args) < 2 {
 		return fmt.Errorf("usage drive9 vault set <name> <field=value|field=@file|field=-> [more fields]")
@@ -78,13 +84,12 @@ func SecretSet(args []string) error {
 	}
 	ctx := context.Background()
 	if _, err := c.CreateVaultSecret(ctx, name, fields); err != nil {
-		if !errors.Is(err, client.ErrConflict) {
-			return err
+		if errors.Is(err, client.ErrConflict) {
+			return fmt.Errorf("secret %q already exists; `drive9 vault set` will not overwrite. "+
+				"To replace it wholesale use `drive9 vault put /n/vault/%s --from <dir>`, "+
+				"or delete first with `drive9 vault rm %s` and re-run.", name, name, name)
 		}
-		_, err = c.UpdateVaultSecret(ctx, name, fields)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	return nil
 }

--- a/cmd/drive9/cli/secret_commands_test.go
+++ b/cmd/drive9/cli/secret_commands_test.go
@@ -13,7 +13,13 @@ import (
 	"time"
 )
 
-func TestSecretSetFallsBackToUpdateOnConflict(t *testing.T) {
+// TestSecretSetRefusesToOverwriteOnConflict pins the new behavior: when the
+// server returns 409 Conflict for POST /v1/vault/secrets, SecretSet must NOT
+// fall back to PUT (the old behavior silently wholesale-replaced the secret,
+// dropping any field the caller didn't pass this time — data loss). Instead
+// it surfaces a clear error naming the offending secret and pointing at the
+// explicit replace/delete paths.
+func TestSecretSetRefusesToOverwriteOnConflict(t *testing.T) {
 	var postCount, putCount int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -25,7 +31,7 @@ func TestSecretSetFallsBackToUpdateOnConflict(t *testing.T) {
 		case r.Method == http.MethodPut && r.URL.Path == "/v1/vault/secrets/aws-prod":
 			atomic.AddInt32(&putCount, 1)
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"name":"aws-prod","secret_type":"generic","revision":2,"created_by":"drive9-cli","created_at":"2026-04-13T00:00:00Z","updated_at":"2026-04-13T00:00:00Z"}`))
+			_, _ = w.Write([]byte(`{"name":"aws-prod"}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -38,14 +44,22 @@ func TestSecretSetFallsBackToUpdateOnConflict(t *testing.T) {
 	resetCredentialCacheForTest()
 	t.Cleanup(resetCredentialCacheForTest)
 
-	if err := SecretSet([]string{"aws-prod", "access_key=AKIA", "secret_key=secret"}); err != nil {
-		t.Fatalf("SecretSet: %v", err)
+	err := SecretSet([]string{"aws-prod", "access_key=AKIA", "secret_key=secret"})
+	if err == nil {
+		t.Fatal("SecretSet should error on conflict, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"aws-prod"`) || !strings.Contains(msg, "already exists") {
+		t.Fatalf("error message should name the secret and say 'already exists', got: %q", msg)
+	}
+	if !strings.Contains(msg, "vault put") || !strings.Contains(msg, "vault rm") {
+		t.Fatalf("error message should point at the explicit replace/delete paths, got: %q", msg)
 	}
 	if atomic.LoadInt32(&postCount) != 1 {
 		t.Fatalf("POST count = %d, want 1", postCount)
 	}
-	if atomic.LoadInt32(&putCount) != 1 {
-		t.Fatalf("PUT count = %d, want 1", putCount)
+	if atomic.LoadInt32(&putCount) != 0 {
+		t.Fatalf("PUT count = %d, want 0 (must not silently update on conflict)", putCount)
 	}
 }
 

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -10,9 +10,23 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/vault"
 )
+
+// isVaultDuplicateEntryErr reports whether err is a TiDB/MySQL duplicate-key
+// error (case-insensitive match on "Duplicate entry") or a SQLite unique
+// violation. The previous lowercase-only check against "duplicate"/"unique"
+// missed TiDB's capitalized "Duplicate entry" message and surfaced a 500
+// instead of a 409.
+func isVaultDuplicateEntryErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "duplicate entry") || strings.Contains(msg, "unique constraint failed")
+}
 
 // handleVault dispatches /v1/vault/* requests.
 func (s *Server) handleVault(w http.ResponseWriter, r *http.Request) {
@@ -135,10 +149,15 @@ func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request,
 
 	sec, err := vs.CreateSecret(r.Context(), tenantID, req.Name, req.CreatedBy, secretType, fields)
 	if err != nil {
-		if strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "unique") {
+		if isVaultDuplicateEntryErr(err) {
 			errJSON(w, http.StatusConflict, "secret already exists")
 			return
 		}
+		logger.Error(r.Context(), "vault_secret_create_failed",
+			eventFields(r.Context(), "vault_secret_create_failed",
+				"tenant_id", tenantID,
+				"secret_name", req.Name,
+				"error", err.Error())...)
 		errJSON(w, http.StatusInternalServerError, "failed to create secret")
 		return
 	}
@@ -209,6 +228,11 @@ func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request,
 			errJSON(w, http.StatusNotFound, "secret not found")
 			return
 		}
+		logger.Error(r.Context(), "vault_secret_update_failed",
+			eventFields(r.Context(), "vault_secret_update_failed",
+				"tenant_id", tenantID,
+				"secret_name", name,
+				"error", err.Error())...)
 		errJSON(w, http.StatusInternalServerError, "failed to update secret")
 		return
 	}


### PR DESCRIPTION
## Summary

- `drive9 vault set <name>` used to silently fall back to `UpdateVaultSecret` on 409 Conflict — but the server-side update is a **wholesale replace** (deletes all existing fields, inserts the new set). Running `vault set existing-secret field1=value1` silently dropped every other field. Data loss, no confirmation, no log.
- The server's duplicate-detection on `CreateSecret` used case-sensitive `strings.Contains(err, "duplicate")`, which missed TiDB's `"Duplicate entry ..."` (capital D). A conflict therefore surfaced as 500 `failed to create secret` with the real error swallowed, and the CLI's conflict-handler never fired.
- CLI now fails loud on conflict with an error naming the secret and pointing at the two explicit replace paths (`vault put --from <dir>` or `vault rm` then re-set). Server now correctly returns 409 and logs underlying 500s instead of eating them.

## Changes

- `pkg/server/vault.go`: `isVaultDuplicateEntryErr` helper (case-insensitive match on `duplicate entry` / `unique constraint failed`); log the underlying error on 500 branches of create/update.
- `cmd/drive9/cli/secret.go`: on 409, return a clear error instead of silently calling `UpdateVaultSecret`.
- `cmd/drive9/cli/secret_commands_test.go`: flip `TestSecretSetFallsBackToUpdateOnConflict` → `TestSecretSetRefusesToOverwriteOnConflict`; asserts PUT count == 0 and the error names the secret + both explicit paths.

## Test plan

- [x] `go test ./cmd/drive9/cli/... ./pkg/server/... ./pkg/client/...` — all green
- [x] Reproduced original bug: `drive9 vault set test key1=value1` against prod dat9 returned generic `failed to create secret` because `test` already existed (server log showed 500 with no root cause)
- [x] New CLI test pins the new error shape: names the secret, mentions "already exists", mentions both `vault put` and `vault rm`
- [ ] After server redeploy (new image), verify prod `drive9 vault set test key1=value1` returns the new error pointing at `vault put` / `vault rm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Secret creation workflow now prevents accidental overwrites. When attempting to create a secret that already exists, the tool returns a clear error with guidance on using the explicit `vault put` replacement workflow or `vault rm` deletion command.
  * Enhanced server-side logging for secret creation and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->