### PR TITLE
perf: eliminate post-write Stat round-trip and add SSE batch flush

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -332,6 +332,21 @@ func (b *Dat9Backend) WriteCtxIfRevision(ctx context.Context, path string, data 
 // - zero: path must not already exist
 // - positive: file must exist at exactly that revision
 func (b *Dat9Backend) WriteCtxIfRevisionWithTags(ctx context.Context, path string, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string) (n int64, err error) {
+	n, _, err = b.writeCtxIfRevisionWithTagsRev(ctx, path, data, offset, flags, expectedRevision, tags)
+	return n, err
+}
+
+// WriteCtxIfRevisionWithTagsReturningRevision is like WriteCtxIfRevisionWithTags
+// but also returns the new file revision. It is used by the HTTP server to
+// avoid an extra Stat round-trip.
+func (b *Dat9Backend) WriteCtxIfRevisionWithTagsReturningRevision(ctx context.Context, path string, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string) (n int64, newRev int64, err error) {
+	return b.writeCtxIfRevisionWithTagsRev(ctx, path, data, offset, flags, expectedRevision, tags)
+}
+
+// writeCtxIfRevisionWithTagsRev is the internal implementation that also
+// returns the new file revision. It is used by the HTTP server to avoid an
+// extra Stat round-trip.
+func (b *Dat9Backend) writeCtxIfRevisionWithTagsRev(ctx context.Context, path string, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string) (n int64, newRev int64, err error) {
 	start := time.Now()
 	defer func() { observeBackend(ctx, "write", err, start) }()
 
@@ -339,40 +354,40 @@ func (b *Dat9Backend) WriteCtxIfRevisionWithTags(ctx context.Context, path strin
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
 	existing, err := b.store.Stat(ctx, path)
 	if err == datastore.ErrNotFound {
 		if expectedRevision > 0 {
-			return 0, datastore.ErrRevisionConflict
+			return 0, 0, datastore.ErrRevisionConflict
 		}
 		if flags&filesystem.WriteFlagCreate == 0 {
 			if expectedRevision == 0 {
-				return 0, datastore.ErrRevisionConflict
+				return 0, 0, datastore.ErrRevisionConflict
 			}
-			return 0, datastore.ErrNotFound
+			return 0, 0, datastore.ErrNotFound
 		}
-		n, err := b.createAndWriteCtx(ctx, path, data, tags)
+		n, newRev, err := b.createAndWriteCtx(ctx, path, data, tags)
 		if expectedRevision == 0 && errors.Is(err, datastore.ErrPathConflict) {
-			return 0, datastore.ErrRevisionConflict
+			return 0, 0, datastore.ErrRevisionConflict
 		}
-		return n, err
+		return n, newRev, err
 	}
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	if expectedRevision == 0 {
-		return 0, datastore.ErrRevisionConflict
+		return 0, 0, datastore.ErrRevisionConflict
 	}
 	if existing.Node.IsDirectory {
-		return 0, fmt.Errorf("is a directory: %s", path)
+		return 0, 0, fmt.Errorf("is a directory: %s", path)
 	}
 	if flags&filesystem.WriteFlagExclusive != 0 {
-		return 0, fmt.Errorf("file already exists: %s", path)
+		return 0, 0, fmt.Errorf("file already exists: %s", path)
 	}
 	if expectedRevision > 0 && (existing.File == nil || existing.File.Revision != expectedRevision) {
-		return 0, datastore.ErrRevisionConflict
+		return 0, 0, datastore.ErrRevisionConflict
 	}
 	return b.overwriteFileCtx(ctx, existing, data, offset, flags, expectedRevision, tags)
 }
@@ -388,9 +403,9 @@ func cloneFileTags(tags map[string]string) map[string]string {
 	return out
 }
 
-func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data []byte, tags map[string]string) (int64, error) {
+func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data []byte, tags map[string]string) (int64, int64, error) {
 	if err := b.ensureUploadSizeAllowed(int64(len(data))); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	fileID := b.genID()
 	now := time.Now()
@@ -406,13 +421,13 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		contentBlob = append([]byte(nil), data...)
 	} else {
 		if b.s3 == nil {
-			return 0, fmt.Errorf("s3 client not configured")
+			return 0, 0, fmt.Errorf("s3 client not configured")
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + fileID
 		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(data), int64(len(data))); err != nil {
 			logger.Error(ctx, "backend_create_and_write_put_object_failed", zap.String("path", path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(data)), zap.Error(err))
-			return 0, fmt.Errorf("put object: %w", err)
+			return 0, 0, fmt.Errorf("put object: %w", err)
 		}
 	}
 
@@ -454,30 +469,30 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		if storageType == datastore.StorageS3 {
 			b.deleteBlobCtx(ctx, storageRef)
 		}
-		return 0, err
+		return 0, 0, err
 	}
 	// Temporary compatibility: app embedding still relies on the legacy
 	// backend-owned image queue until its image task flow also moves to
 	// semantic_tasks.
 	if b.UsesDatabaseAutoEmbedding() {
 		b.syncCentralFileCreate(ctx, fileID, int64(len(data)), contentType)
-		return int64(len(data)), nil
+		return int64(len(data)), 1, nil
 	}
 	b.syncCentralFileCreate(ctx, fileID, int64(len(data)), contentType)
 	b.enqueueImageExtract(fileID, path, contentType, 1)
-	return int64(len(data)), nil
+	return int64(len(data)), 1, nil
 }
 
-func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWithFile, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string) (int64, error) {
+func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWithFile, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string) (int64, int64, error) {
 	if nf.File == nil {
-		return 0, fmt.Errorf("no file entity")
+		return 0, 0, fmt.Errorf("no file entity")
 	}
 
 	var finalData []byte
 	if flags&filesystem.WriteFlagAppend != 0 {
 		existing, err := b.readFileDataCtx(ctx, nf.File)
 		if err != nil {
-			return 0, fmt.Errorf("read existing data for append: %w", err)
+			return 0, 0, fmt.Errorf("read existing data for append: %w", err)
 		}
 		finalData = append(existing, data...)
 	} else if flags&filesystem.WriteFlagTruncate != 0 || offset <= 0 {
@@ -485,7 +500,7 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 	} else {
 		existing, err := b.readFileDataCtx(ctx, nf.File)
 		if err != nil {
-			return 0, fmt.Errorf("read existing data for offset write: %w", err)
+			return 0, 0, fmt.Errorf("read existing data for offset write: %w", err)
 		}
 		if offset > int64(len(existing)) {
 			existing = append(existing, make([]byte, offset-int64(len(existing)))...)
@@ -498,7 +513,7 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 	}
 
 	if err := b.ensureUploadSizeAllowed(int64(len(finalData))); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	contentType := detectContentType(nf.Node.Path, finalData)
 	checksum := sha256sum(finalData)
@@ -510,13 +525,13 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 		contentBlob = append([]byte(nil), finalData...)
 	} else {
 		if b.s3 == nil {
-			return 0, fmt.Errorf("s3 client not configured")
+			return 0, 0, fmt.Errorf("s3 client not configured")
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + b.genID()
 		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(finalData), int64(len(finalData))); err != nil {
 			logger.Error(ctx, "backend_overwrite_put_object_failed", zap.String("path", nf.Node.Path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(finalData)), zap.Error(err))
-			return 0, fmt.Errorf("put object: %w", err)
+			return 0, 0, fmt.Errorf("put object: %w", err)
 		}
 	}
 
@@ -571,7 +586,7 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 		if storageType == datastore.StorageS3 {
 			b.deleteBlobCtx(ctx, storageRef)
 		}
-		return 0, err
+		return 0, 0, err
 	}
 	b.syncCentralFileOverwrite(ctx, nf.File.FileID, nf.File.SizeBytes, nf.File.ContentType, int64(len(finalData)), contentType)
 	b.deleteBlobIfS3Ctx(ctx, nf.File.StorageType, nf.File.StorageRef, storageRef)
@@ -579,10 +594,10 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 	// backend-owned image queue until its image task flow also moves to
 	// semantic_tasks.
 	if b.UsesDatabaseAutoEmbedding() {
-		return int64(len(data)), nil
+		return int64(len(data)), newRev, nil
 	}
 	b.enqueueImageExtract(nf.File.FileID, nf.Node.Path, contentType, newRev)
-	return int64(len(data)), nil
+	return int64(len(data)), newRev, nil
 }
 
 func (b *Dat9Backend) ReadDir(path string) ([]filesystem.FileInfo, error) {

--- a/pkg/client/append_test.go
+++ b/pkg/client/append_test.go
@@ -30,7 +30,9 @@ func TestAppendStreamCreatesMissingFile(t *testing.T) {
 				return
 			}
 			putBody = append([]byte(nil), body...)
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 1})
 		default:
 			http.NotFound(w, r)
 		}
@@ -67,7 +69,9 @@ func TestAppendStreamZeroSizeCreatesMissingFile(t *testing.T) {
 				return
 			}
 			putBody = append([]byte(nil), body...)
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 1})
 		default:
 			http.NotFound(w, r)
 		}
@@ -115,7 +119,9 @@ func TestAppendStreamFallsBackToRewriteForSmallExistingFile(t *testing.T) {
 				return
 			}
 			putBody = append([]byte(nil), body...)
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 8})
 		default:
 			http.NotFound(w, r)
 		}
@@ -270,7 +276,9 @@ func TestAppendStreamFallsBackToRewriteWhenAppendActionUnsupported(t *testing.T)
 				return
 			}
 			putBody = append([]byte(nil), body...)
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 8})
 		default:
 			http.NotFound(w, r)
 		}
@@ -318,7 +326,9 @@ func TestAppendStreamFallsBackToRewriteWhenS3NotConfigured(t *testing.T) {
 				return
 			}
 			putBody = append([]byte(nil), body...)
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 12})
 		default:
 			http.NotFound(w, r)
 		}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -223,28 +223,31 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 	return c.httpClient.Do(req)
 }
 
-// Write uploads data to a remote path.
-func (c *Client) Write(path string, data []byte) error {
+// Write uploads data to a remote path and returns the new file revision.
+func (c *Client) Write(path string, data []byte) (int64, error) {
 	return c.WriteCtx(context.Background(), path, data)
 }
 
-// WriteCtx uploads data to a remote path with context support.
-func (c *Client) WriteCtx(ctx context.Context, path string, data []byte) error {
+// WriteCtx uploads data to a remote path with context support and returns
+// the new file revision.
+func (c *Client) WriteCtx(ctx context.Context, path string, data []byte) (int64, error) {
 	return c.WriteCtxConditional(ctx, path, data, -1)
 }
 
 // WriteCtxConditional uploads data to a remote path and applies the write only
 // when expectedRevision matches the current server revision.
+// Returns the new file revision.
 // expectedRevision semantics:
 // - negative: unconditional write
 // - zero: path must not already exist
 // - positive: file must exist at exactly that revision
-func (c *Client) WriteCtxConditional(ctx context.Context, path string, data []byte, expectedRevision int64) error {
+func (c *Client) WriteCtxConditional(ctx context.Context, path string, data []byte, expectedRevision int64) (int64, error) {
 	return c.WriteCtxConditionalWithTags(ctx, path, data, expectedRevision, nil)
 }
 
 // WriteCtxConditionalWithTags uploads data to a remote path with optional
 // compare-and-set semantics and optional file tags.
+// Returns the new file revision.
 // This method issues a single PUT request and is therefore intended for direct
 // write paths. When tags are provided for a large file, the server rejects the
 // request because large-file uploads must send tags in the multipart complete
@@ -256,27 +259,37 @@ func (c *Client) WriteCtxConditional(ctx context.Context, path string, data []by
 // - negative: unconditional write
 // - zero: path must not already exist
 // - positive: file must exist at exactly that revision
-func (c *Client) WriteCtxConditionalWithTags(ctx context.Context, path string, data []byte, expectedRevision int64, tags map[string]string) error {
+func (c *Client) WriteCtxConditionalWithTags(ctx context.Context, path string, data []byte, expectedRevision int64, tags map[string]string) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(path), bytes.NewReader(data))
 	if err != nil {
-		return err
+		return 0, err
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	if expectedRevision >= 0 {
 		req.Header.Set("X-Dat9-Expected-Revision", strconv.FormatInt(expectedRevision, 10))
 	}
 	if err := setTagHeaders(req, tags); err != nil {
-		return err
+		return 0, err
 	}
 	resp, err := c.do(req)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
-		return readError(resp)
+		return 0, readError(resp)
 	}
-	return nil
+	var result struct {
+		Status   string `json:"status"`
+		Revision int64  `json:"revision"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		if err == io.EOF {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return result.Revision, nil
 }
 
 // Read downloads a file's content.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -67,7 +67,7 @@ func TestWriteAndRead(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	if err := c.Write("/hello.txt", []byte("hello world")); err != nil {
+	if _, err := c.Write("/hello.txt", []byte("hello world")); err != nil {
 		t.Fatal(err)
 	}
 	data, err := c.Read("/hello.txt")
@@ -83,10 +83,10 @@ func TestListDir(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	if err := c.Write("/data/a.txt", []byte("a")); err != nil {
+	if _, err := c.Write("/data/a.txt", []byte("a")); err != nil {
 		t.Fatal(err)
 	}
-	if err := c.Write("/data/b.txt", []byte("bb")); err != nil {
+	if _, err := c.Write("/data/b.txt", []byte("bb")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -103,7 +103,7 @@ func TestStat(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	if err := c.Write("/test.txt", []byte("data")); err != nil {
+	if _, err := c.Write("/test.txt", []byte("data")); err != nil {
 		t.Fatal(err)
 	}
 	info, err := c.Stat("/test.txt")
@@ -119,7 +119,7 @@ func TestStatMetadataIncludesTagsAndSupportsTagReplace(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	err := c.WriteCtxConditionalWithTags(context.Background(), "/meta.txt", []byte("hello"), -1, map[string]string{
+	_, err := c.WriteCtxConditionalWithTags(context.Background(), "/meta.txt", []byte("hello"), -1, map[string]string{
 		"owner": "alice",
 		"topic": "note",
 	})
@@ -147,7 +147,7 @@ func TestStatMetadataIncludesTagsAndSupportsTagReplace(t *testing.T) {
 		t.Fatalf("tags = %+v, want owner/topic", meta.Tags)
 	}
 
-	err = c.WriteCtxConditionalWithTags(context.Background(), "/meta.txt", []byte("hello v2"), -1, map[string]string{
+	_, err = c.WriteCtxConditionalWithTags(context.Background(), "/meta.txt", []byte("hello v2"), -1, map[string]string{
 		"owner": "bob",
 	})
 	if err != nil {
@@ -459,7 +459,7 @@ func TestWriteCtxConditionalWithTagsRejectsInvalidHeaderTags(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			requests = 0
 			c := New(ts.URL, "")
-			err := c.WriteCtxConditionalWithTags(context.Background(), "/bad-tags.txt", []byte("x"), -1, tc.tags)
+			_, err := c.WriteCtxConditionalWithTags(context.Background(), "/bad-tags.txt", []byte("x"), -1, tc.tags)
 			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 				t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
 			}
@@ -474,7 +474,7 @@ func TestDelete(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	if err := c.Write("/del.txt", []byte("x")); err != nil {
+	if _, err := c.Write("/del.txt", []byte("x")); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.Delete("/del.txt"); err != nil {
@@ -493,13 +493,13 @@ func TestRemoveAll(t *testing.T) {
 	if err := c.Mkdir("/data"); err != nil {
 		t.Fatal(err)
 	}
-	if err := c.Write("/data/a.txt", []byte("a")); err != nil {
+	if _, err := c.Write("/data/a.txt", []byte("a")); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.Mkdir("/data/nested"); err != nil {
 		t.Fatal(err)
 	}
-	if err := c.Write("/data/nested/b.txt", []byte("b")); err != nil {
+	if _, err := c.Write("/data/nested/b.txt", []byte("b")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -530,7 +530,7 @@ func TestCopy(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	if err := c.Write("/src.txt", []byte("shared")); err != nil {
+	if _, err := c.Write("/src.txt", []byte("shared")); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.Copy("/src.txt", "/dst.txt"); err != nil {
@@ -546,7 +546,7 @@ func TestRename(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()
 
-	if err := c.Write("/old.txt", []byte("data")); err != nil {
+	if _, err := c.Write("/old.txt", []byte("data")); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.Rename("/old.txt", "/new.txt"); err != nil {

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -297,7 +297,7 @@ func (c *Client) writeStreamConditionalWithSummary(ctx context.Context, path str
 		if err != nil {
 			return nil, fmt.Errorf("read data: %w", err)
 		}
-		if err := c.WriteCtxConditionalWithTags(ctx, path, data, expectedRevision, tags); err != nil {
+		if _, err := c.WriteCtxConditionalWithTags(ctx, path, data, expectedRevision, tags); err != nil {
 			return nil, err
 		}
 		summary.DirectWriteSeconds = time.Since(directWriteStart).Seconds()

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -141,7 +141,9 @@ func TestWriteStreamSmallFile(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == "/v1/fs/small.txt" {
 			requestCount++
 			writtenData, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 1})
 		}
 	}))
 	defer srv.Close()
@@ -163,7 +165,9 @@ func TestWriteStreamSmallFile(t *testing.T) {
 func TestWriteStreamWithSummarySmallFile(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut && r.URL.Path == "/v1/fs/small-summary.txt" {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 1})
 			return
 		}
 		http.NotFound(w, r)
@@ -212,7 +216,9 @@ func TestWriteStreamWithSummaryAndTagsSmallFileSetsTagHeaders(t *testing.T) {
 			return
 		}
 		gotBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 1})
 	}))
 	defer srv.Close()
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -825,24 +825,29 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 			if newSize == 0 {
 				ctx, cf := fuseCtx(cancel)
 				defer cf()
-				if err := fs.client.WriteCtx(ctx, entry.Path, nil); err != nil {
+				newRev, err := fs.client.WriteCtx(ctx, entry.Path, nil)
+				if err != nil {
 					return httpToFuseStatus(err)
 				}
 				// Refresh the inode revision after the server-side truncate so a
 				// subsequent writable open does not reuse the stale pre-truncate
 				// base revision and conflict with its own zero-byte write.
-				stat, statErr := fs.client.StatCtx(ctx, entry.Path)
-				if statErr != nil {
-					log.Printf("post-truncate stat refresh failed for %s (inode=%d): %v (revision may be stale)", entry.Path, input.NodeId, statErr)
-				} else if stat != nil {
-					if stat.Revision > 0 {
-						entry.Revision = stat.Revision
-						fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
-						fs.updateOpenHandleBaseRevision(entry.Path, stat.Revision, input.Pid)
-					}
-					if !stat.Mtime.IsZero() {
-						entry.Mtime = stat.Mtime
-						fs.inodes.UpdateMtime(input.NodeId, stat.Mtime)
+				if newRev > 0 {
+					fs.inodes.UpdateRevision(input.NodeId, newRev)
+				} else {
+					stat, statErr := fs.client.StatCtx(ctx, entry.Path)
+					if statErr != nil {
+						log.Printf("post-truncate stat refresh failed for %s (inode=%d): %v (revision may be stale)", entry.Path, input.NodeId, statErr)
+					} else if stat != nil {
+						if stat.Revision > 0 {
+							entry.Revision = stat.Revision
+							fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
+							fs.updateOpenHandleBaseRevision(entry.Path, stat.Revision, input.Pid)
+						}
+						if !stat.Mtime.IsZero() {
+							entry.Mtime = stat.Mtime
+							fs.inodes.UpdateMtime(input.NodeId, stat.Mtime)
+						}
 					}
 				}
 				fs.readCache.Invalidate(entry.Path)
@@ -2082,7 +2087,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		}
 
 		dCtx, dCf := context.WithTimeout(context.Background(), fuseTimeout)
-		err := fs.client.WriteCtxConditional(dCtx, filePath, data, expectedRevision)
+		_, err := fs.client.WriteCtxConditional(dCtx, filePath, data, expectedRevision)
 		dCf()
 		if err != nil {
 			handle.Unlock()
@@ -2228,7 +2233,12 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 
 	if size < smallFileThreshold {
 		// Small file: direct PUT.
-		err = fs.client.WriteCtxConditional(ctx, fh.Path, data, expectedRevision)
+		var newRev int64
+		newRev, err = fs.client.WriteCtxConditional(ctx, fh.Path, data, expectedRevision)
+		if err == nil && newRev > 0 {
+			fh.BaseRev = newRev
+			fh.IsNew = false
+		}
 	} else if fh.OrigSize >= smallFileThreshold {
 		dirtyParts := fh.Dirty.DirtyPartNumbers()
 		if len(dirtyParts) > 0 {

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -9,11 +9,15 @@ import (
 const (
 	defaultConnMaxLifetime = 5 * time.Minute
 	defaultConnMaxIdleTime = 45 * time.Second
+	defaultMaxOpenConns    = 50
+	defaultMaxIdleConns    = 10
 )
 
 // ApplyPoolDefaults rotates and prunes idle connections before common LB/NAT
-// idle timeout windows.
+// idle timeout windows, and caps pool size to prevent connection storms.
 func ApplyPoolDefaults(db *sql.DB) {
 	db.SetConnMaxLifetime(defaultConnMaxLifetime)
 	db.SetConnMaxIdleTime(defaultConnMaxIdleTime)
+	db.SetMaxOpenConns(defaultMaxOpenConns)
+	db.SetMaxIdleConns(defaultMaxIdleConns)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -737,7 +737,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		errJSON(w, http.StatusBadRequest, "read body: "+err.Error())
 		return
 	}
-	_, err = b.WriteCtxIfRevisionWithTags(r.Context(), path, data, 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, expectedRevision, writeTags)
+	_, newRev, err := b.WriteCtxIfRevisionWithTagsReturningRevision(r.Context(), path, data, 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, expectedRevision, writeTags)
 	if err != nil {
 		if errors.Is(err, backend.ErrUploadTooLarge) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_too_large_backend", "path", path, "error", err)...)
@@ -765,7 +765,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "write_ok", "path", path, "bytes", len(data))...)
 	metricEvent(r.Context(), "fs_write", "result", "ok")
 	s.publishEvent(r, path, "write")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": newRev})
 }
 
 func (s *Server) handlePatch(w http.ResponseWriter, r *http.Request, path string) {

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -14,6 +15,8 @@ import (
 
 const (
 	sseHeartbeatInterval = 30 * time.Second
+	sseFlushBatchSize    = 10
+	sseFlushMaxDelay     = 5 * time.Millisecond
 )
 
 // eventBuses manages per-tenant EventBus instances. For single-tenant mode
@@ -99,6 +102,17 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
+	// Wrap the response writer with a buffered writer to reduce syscalls
+	// when sending many small SSE events in rapid succession.
+	bw := newSSEBufferedWriter(w)
+
+	// flush sends any buffered data to the client. It flushes the bufio
+	// buffer first, then the HTTP flusher.
+	flush := func() {
+		_ = bw.Flush()
+		flusher.Flush()
+	}
+
 	// Phase 1: Replay or Reset.
 	// EventsSince returns headSeq from the same lock acquisition as the
 	// ring scan, so reset cursor and ring state are a consistent snapshot.
@@ -112,42 +126,71 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 				reason = "server_restart"
 			}
 		}
-		sendSSEReset(w, headSeq, reason)
+		sendSSEReset(bw, headSeq, reason)
 		lastSeen = headSeq
 	} else {
 		for _, ev := range events {
-			sendSSEEvent(w, ev)
+			sendSSEEvent(bw, ev)
 			lastSeen = ev.Seq
 		}
 	}
-	flusher.Flush()
+	flush()
 
-	// Phase 2: Live stream.
+	// Phase 2: Live stream with micro-batching.
+	// Instead of flushing after every single notify, we accumulate events
+	// and flush at heartbeat boundaries or when the batch size is reached.
 	heartbeat := time.NewTicker(sseHeartbeatInterval)
 	defer heartbeat.Stop()
+
+	pending := 0
+	flushTimer := time.NewTimer(0)
+	flushTimer.Stop()
+	defer flushTimer.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-heartbeat.C:
-			sendSSEHeartbeat(w, lastSeen)
-			flusher.Flush()
+			sendSSEHeartbeat(bw, lastSeen)
+			flush()
+			pending = 0
+		case <-flushTimer.C:
+			if pending > 0 {
+				flush()
+				pending = 0
+			}
 		case _, open := <-notify:
 			if !open {
 				return
 			}
 			liveEvents, liveHead, liveOK := bus.EventsSince(lastSeen)
 			if !liveOK {
-				sendSSEReset(w, liveHead, "seq_too_old")
+				sendSSEReset(bw, liveHead, "seq_too_old")
 				lastSeen = liveHead
 			} else {
 				for _, ev := range liveEvents {
-					sendSSEEvent(w, ev)
+					sendSSEEvent(bw, ev)
 					lastSeen = ev.Seq
+					pending++
 				}
 			}
-			flusher.Flush()
+			// Batch flush: either when we have enough events or after a
+			// short delay to allow more events to arrive.
+			if pending >= sseFlushBatchSize {
+				flush()
+				pending = 0
+				flushTimer.Stop()
+			} else {
+				// Restart the micro-delay timer.
+				if !flushTimer.Stop() {
+					select {
+					case <-flushTimer.C:
+					default:
+					}
+				}
+				flushTimer.Reset(sseFlushMaxDelay)
+			}
 		}
 	}
 }
@@ -191,4 +234,26 @@ func sendSSEHeartbeat(w http.ResponseWriter, seq uint64) {
 		"seq": seq,
 	})
 	_, _ = fmt.Fprintf(w, "event: heartbeat\ndata: %s\n\n", data)
+}
+
+// sseBufferedWriter wraps http.ResponseWriter with a bufio.Writer to reduce
+// syscalls when sending many small SSE events in rapid succession.
+type sseBufferedWriter struct {
+	http.ResponseWriter
+	buf *bufio.Writer
+}
+
+func newSSEBufferedWriter(w http.ResponseWriter) *sseBufferedWriter {
+	return &sseBufferedWriter{
+		ResponseWriter: w,
+		buf:            bufio.NewWriterSize(w, 4096),
+	}
+}
+
+func (bw *sseBufferedWriter) Write(p []byte) (int, error) {
+	return bw.buf.Write(p)
+}
+
+func (bw *sseBufferedWriter) Flush() error {
+	return bw.buf.Flush()
 }


### PR DESCRIPTION
## Summary

This PR implements three performance optimizations:

1. **Write response returns revision** — Server now returns `{"status":"ok","revision":N}` on successful writes. The client parses this revision and the FUSE layer uses it directly to update `BaseRev`, eliminating the extra `Stat` round-trip after flush.

2. **Database connection pool defaults** — Added `MaxOpenConns=50` and `MaxIdleConns=10` to prevent connection storms.

3. **SSE batch flush** — Introduced micro-batching for SSE events (flush every 10 events or 5ms) to reduce system calls during high-throughput streaming.

## Key design decision

To maintain `filesystem.FileSystem` interface compatibility, the revision-returning logic was extracted into an internal method, with `WriteCtxIfRevisionWithTagsReturningRevision` exposed for server-side use. The public `Write` method signature remains unchanged.

## Testing

All `pkg/...` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Write operations now return file revision information to avoid unnecessary additional lookups.

* **Performance**
  * Optimized database connection pooling with configurable connection limits.
  * Improved server-side event streaming with buffering and batching for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->