### PR TITLE
Fix TiDB auto repair for description embedding

### DIFF
--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -684,6 +684,15 @@ func tidbSchemaSpecForMode(mode TiDBEmbeddingMode) (tidbSchemaSpec, error) {
 		if spec.tables[i].name != "files" {
 			continue
 		}
+		if mode == TiDBEmbeddingModeAuto {
+			if col, ok := spec.tables[i].columns["description_embedding"]; ok {
+				col.addSQL = fmt.Sprintf(
+					"ALTER TABLE files ADD COLUMN description_embedding VECTOR(%d) DEFAULT NULL",
+					TiDBAutoEmbeddingDimensions,
+				)
+				spec.tables[i].columns["description_embedding"] = col
+			}
+		}
 		spec.tables[i].validate = func(meta tidbTableMeta) []tidbSchemaDiff {
 			switch mode {
 			case TiDBEmbeddingModeAuto:
@@ -1539,24 +1548,33 @@ func isIgnorableTiDBSchemaError(err error) bool {
 func validateTiDBAutoEmbeddingFilesDiffs(meta tidbTableMeta) []tidbSchemaDiff {
 	var diffs []tidbSchemaDiff
 	for _, spec := range []struct {
-		column string
-		source string
+		column        string
+		source        string
+		allowWritable bool
 	}{
-		{"embedding", "content_text"},
-		{"description_embedding", "description"},
+		{"embedding", "content_text", false},
+		{"description_embedding", "description", true},
 	} {
 		col, err := meta.requireColumn(spec.column)
 		if err != nil {
 			return nil
 		}
 		extra := normalizeSQLFragment(col.extra)
-		if !strings.Contains(extra, "generated") || !strings.Contains(extra, "stored") {
+		isStoredGenerated := strings.Contains(extra, "generated") && strings.Contains(extra, "stored")
+		if !isStoredGenerated {
+			if spec.allowWritable {
+				expr := normalizeSQLFragment(col.generationExpression)
+				if !strings.Contains(extra, "generated") && expr == "" {
+					continue
+				}
+			}
 			diffs = append(diffs, tidbSchemaDiff{
 				kind:       tidbSchemaDiffTableContract,
 				tableName:  "files",
 				columnName: spec.column,
 				detail:     fmt.Sprintf("files schema contract: %s column must be a stored generated column", spec.column),
 			})
+			continue
 		}
 		expr := normalizeSQLFragment(col.generationExpression)
 		checks := []struct {

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -306,6 +306,17 @@ func TestValidateTiDBAutoEmbeddingFilesDiffsReportsGeneratedContractMismatch(t *
 	}
 }
 
+func TestValidateTiDBAutoEmbeddingFilesDiffsAllowsWritableDescriptionEmbeddingCompat(t *testing.T) {
+	meta := testFilesTableMeta(TiDBEmbeddingModeAuto)
+	meta.columns["description_embedding"] = tidbColumnMeta{columnType: "vector(1024)"}
+	diffs := validateTiDBAutoEmbeddingFilesDiffs(meta)
+	for _, diff := range diffs {
+		if diff.columnName == "description_embedding" {
+			t.Fatalf("expected writable description_embedding compat column to be accepted, got %#v", diffs)
+		}
+	}
+}
+
 func TestDiffTiDBTableMetaReportsMissingRequiredIndex(t *testing.T) {
 	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "uploads")
 	meta := testUploadsTableMeta(true)
@@ -609,6 +620,12 @@ func TestTiDBSchemaSpecForModeIncludesAlterTableIndexes(t *testing.T) {
 	}
 	if _, ok := spec.indexes["idx_files_desc_cosine"]; !ok {
 		t.Fatal("files auto mode spec must include idx_files_desc_cosine index")
+	}
+	if _, ok := spec.columns["description_embedding"]; !ok {
+		t.Fatal("files auto mode spec must include description_embedding column")
+	}
+	if got := spec.columns["description_embedding"].addSQL; got != "ALTER TABLE files ADD COLUMN description_embedding VECTOR(1024) DEFAULT NULL" {
+		t.Fatalf("description_embedding addSQL=%q, want writable VECTOR compat repair SQL", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix TiDB auto-repair for legacy auto-embedding tenants by aligning the files.description_embedding repair SQL with a shape TiDB can actually add on an existing table.

## What changed
- override the auto-mode repair SQL for files.description_embedding to use a writable VECTOR column
- treat that repaired writable description_embedding shape as contract-compatible during auto-mode schema validation
- add tests covering the repair SQL and compat validation behavior

## Validation
- go test ./pkg/tenant/schema/... -count=1
- go test ./pkg/backend/... ./pkg/server/... ./pkg/datastore/... -run '^$' -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and handling of embedding columns in auto-embedding mode for database schema operations. The system now properly manages description embedding columns during schema migrations, allowing for better data consistency and compatibility.

* **Tests**
  * Added test coverage to verify correct handling and validation of embedding columns in schema specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->