### PR TITLE
feat: implement vault owner-read (§4.2)

### DIFF
--- a/cmd/drive9/cli/credentials_test.go
+++ b/cmd/drive9/cli/credentials_test.go
@@ -2,7 +2,10 @@ package cli
 
 import (
 	"flag"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 )
 
@@ -354,6 +357,70 @@ func TestNewVaultReadClient_DelegatedActiveContext(t *testing.T) {
 	// the global ResolveCredentials() which reads from disk. Instead,
 	// verify the resolver returns CredentialDelegated, which is the
 	// sole routing input per §14.2.
+}
+
+// --- No-fallthrough integration tests (§14.2 no-fallthrough invariant) ---
+//
+// These verify that when DRIVE9_VAULT_TOKEN is set (even if the token is
+// expired, revoked, or malformed), the routing commits to the capability-read
+// path. If the server returns 401 on that path, the error surfaces to the
+// caller — it MUST NOT silently fall through to the owner-read path even
+// though a valid API key is present. This is the runtime witness for §14.2.
+
+func TestNoFallthrough_ExpiredToken(t *testing.T) {
+	testNoFallthrough(t, "expired-jwt-token", "expired token → 401, must not retry via owner path")
+}
+
+func TestNoFallthrough_RevokedToken(t *testing.T) {
+	testNoFallthrough(t, "revoked-jwt-token", "revoked token → 401, must not retry via owner path")
+}
+
+func TestNoFallthrough_MalformedToken(t *testing.T) {
+	testNoFallthrough(t, "not-a-valid-token", "malformed token → 401, must not retry via owner path")
+}
+
+// testNoFallthrough is the shared harness for the 3 no-fallthrough cases.
+// It sets up a mock server with two paths:
+//   - /v1/vault/read/test-secret  → 401 (simulates auth failure on capability path)
+//   - /v1/vault/secrets/test-secret/value → 200 with valid JSON (owner-read path)
+//
+// SecretGet MUST return an error (the 401). If it returns nil, it means
+// the code silently fell through to the owner path — a spec violation.
+func testNoFallthrough(t *testing.T, token, desc string) {
+	t.Helper()
+	var ownerPathHit int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/vault/read/test-secret":
+			// Capability-read path: simulate auth failure.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+		case r.URL.Path == "/v1/vault/secrets/test-secret/value":
+			// Owner-read path: should NEVER be reached.
+			atomic.AddInt32(&ownerPathHit, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"KEY":"VALUE"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(EnvVaultToken, token)
+	t.Setenv(EnvAPIKey, "sk-valid-owner-key")
+	t.Setenv(EnvServer, srv.URL)
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	err := SecretGet([]string{"test-secret"})
+	if err == nil {
+		t.Fatalf("%s: SecretGet returned nil; expected error from 401 on capability path", desc)
+	}
+	if atomic.LoadInt32(&ownerPathHit) != 0 {
+		t.Fatalf("%s: owner-read path was hit — no-fallthrough invariant violated", desc)
+	}
 }
 
 func TestResolveCredentials_CachedPerProcess(t *testing.T) {

--- a/cmd/drive9/cli/credentials_test.go
+++ b/cmd/drive9/cli/credentials_test.go
@@ -390,13 +390,13 @@ func testNoFallthrough(t *testing.T, token, desc string) {
 	t.Helper()
 	var ownerPathHit int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/v1/vault/read/test-secret":
+		switch r.URL.Path {
+		case "/v1/vault/read/test-secret":
 			// Capability-read path: simulate auth failure.
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
-		case r.URL.Path == "/v1/vault/secrets/test-secret/value":
+		case "/v1/vault/secrets/test-secret/value":
 			// Owner-read path: should NEVER be reached.
 			atomic.AddInt32(&ownerPathHit, 1)
 			w.Header().Set("Content-Type", "application/json")

--- a/cmd/drive9/cli/credentials_test.go
+++ b/cmd/drive9/cli/credentials_test.go
@@ -270,6 +270,92 @@ func TestFlagProvided(t *testing.T) {
 	}
 }
 
+// --- Owner-read routing tests (§4.2 / §14.2 routing invariant) ---
+
+func TestNewVaultReadClient_OwnerMode(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvAPIKey: "sk-owner-key",
+		EnvServer: "https://s.example",
+	})
+	_, ownerMode, err := newVaultReadClientFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ownerMode {
+		t.Fatal("expected ownerMode=true when CredentialOwner")
+	}
+}
+
+func TestNewVaultReadClient_DelegatedMode(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvVaultToken: "jwt-eyAAA",
+		EnvServer:     "https://s.example",
+	})
+	_, ownerMode, err := newVaultReadClientFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ownerMode {
+		t.Fatal("expected ownerMode=false when CredentialDelegated")
+	}
+}
+
+func TestNewVaultReadClient_DelegatedBeatsOwner(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvVaultToken: "jwt-eyAAA",
+		EnvAPIKey:     "sk-owner-key",
+		EnvServer:     "https://s.example",
+	})
+	_, ownerMode, err := newVaultReadClientFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ownerMode {
+		t.Fatal("expected delegated to win over owner (narrower-wins)")
+	}
+}
+
+// TestNewVaultReadClient_NoCredReturnsError verifies that the routing switch
+// in newVaultReadClientFromEnv correctly rejects CredentialNone. Since the
+// global ResolveCredentials() reads on-disk config (which may have a real
+// credential), we test the routing logic at the resolver level instead.
+func TestNewVaultReadClient_NoCredReturnsError(t *testing.T) {
+	setResolverEnv(t, nil)
+	cfg := &Config{}
+	r := resolveCredentialsWithConfig(cfg)
+	if r.Kind != CredentialNone {
+		t.Fatalf("Kind = %d, want CredentialNone with empty env+config", r.Kind)
+	}
+	// CredentialNone hits the default case in newVaultReadClientFromEnv's switch,
+	// which returns an error. This is structurally guaranteed by the code:
+	//   case CredentialDelegated: return ..., false, nil
+	//   case CredentialOwner:     return ..., true, nil
+	//   default:                  return nil, false, error
+}
+
+// TestNewVaultReadClient_DelegatedActiveContext verifies that an active
+// delegated context (from ctx import/use, no env token) routes to the
+// token-read path — not the owner-read path. This is the regression case
+// adv-1 flagged: routing must use ResolveCredentials().Kind, not raw env.
+func TestNewVaultReadClient_DelegatedActiveContext(t *testing.T) {
+	setResolverEnv(t, nil) // no env vars
+	cfg := &Config{
+		CurrentContext: "alice",
+		Contexts: map[string]*Context{
+			"alice": {Type: PrincipalDelegated, Server: "https://s.example", Token: "jwt-from-ctx"},
+		},
+	}
+	r := resolveCredentialsWithConfig(cfg)
+	if r.Kind != CredentialDelegated {
+		t.Fatalf("Kind = %d, want CredentialDelegated from active context", r.Kind)
+	}
+	// The routing decision must yield delegated (token) path.
+	// We can't call newVaultReadClientFromEnv directly because it uses
+	// the global ResolveCredentials() which reads from disk. Instead,
+	// verify the resolver returns CredentialDelegated, which is the
+	// sole routing input per §14.2.
+}
+
 func TestResolveCredentials_CachedPerProcess(t *testing.T) {
 	setResolverEnv(t, map[string]string{
 		EnvVaultToken: "jwt-first",

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -627,19 +627,6 @@ func SecretAudit(args []string) error {
 	return nil
 }
 
-// currentCapabilityToken returns the active delegated/capability token for
-// call sites that explicitly need "is there a token in play" (e.g. SecretLs's
-// branch to avoid silently enumerating the whole tenant when a scoped token
-// was intentionally provided). It uses the unified resolver so env > config
-// priority + Unsetenv mitigation apply.
-func currentCapabilityToken() string {
-	r := ResolveCredentials()
-	if r.Kind == CredentialDelegated {
-		return r.Token
-	}
-	return ""
-}
-
 // optionalVaultManagementClientFromEnv returns a tenant-scoped (owner API key)
 // client when one can be resolved, or false when no owner credential is in
 // play. Used by SecretLs to distinguish "owner enumeration" from "delegated

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -120,13 +120,18 @@ func SecretGet(args []string) error {
 		return fmt.Errorf("--json and --env are mutually exclusive")
 	}
 
-	c, err := newVaultReadClientFromEnv()
+	c, ownerMode, err := newVaultReadClientFromEnv()
 	if err != nil {
 		return err
 	}
 	ctx := context.Background()
 	if field != "" {
-		value, err := c.ReadVaultSecretField(ctx, name, field)
+		var value string
+		if ownerMode {
+			value, err = c.ReadVaultSecretFieldAsOwner(ctx, name, field)
+		} else {
+			value, err = c.ReadVaultSecretField(ctx, name, field)
+		}
 		if err != nil {
 			return err
 		}
@@ -145,7 +150,12 @@ func SecretGet(args []string) error {
 		return nil
 	}
 
-	fields, err := c.ReadVaultSecret(ctx, name)
+	var fields map[string]string
+	if ownerMode {
+		fields, err = c.ReadVaultSecretAsOwner(ctx, name)
+	} else {
+		fields, err = c.ReadVaultSecret(ctx, name)
+	}
 	if err != nil {
 		return err
 	}
@@ -205,11 +215,16 @@ func SecretWith(args []string) error {
 		return fmt.Errorf("usage drive9 vault with /n/vault/<secret> -- <command...>")
 	}
 
-	c, err := newVaultReadClientFromEnv()
+	c, ownerMode, err := newVaultReadClientFromEnv()
 	if err != nil {
 		return err
 	}
-	fields, err := c.ReadVaultSecret(context.Background(), name)
+	var fields map[string]string
+	if ownerMode {
+		fields, err = c.ReadVaultSecretAsOwner(context.Background(), name)
+	} else {
+		fields, err = c.ReadVaultSecret(context.Background(), name)
+	}
 	if err != nil {
 		return err
 	}
@@ -351,34 +366,24 @@ func SecretLs(args []string) error {
 	}
 
 	var names []string
-	if currentCapabilityToken() != "" {
-		c, err := newVaultReadClientFromEnv()
-		if err != nil {
-			return err
-		}
-		var errList error
-		names, errList = c.ListReadableVaultSecrets(context.Background())
-		if errList != nil {
-			return errList
-		}
-	} else if c, ok := optionalVaultManagementClientFromEnv(); ok {
-		secrets, err := c.ListVaultSecrets(context.Background())
-		if err != nil {
-			return err
+	c, ownerMode, err := newVaultReadClientFromEnv()
+	if err != nil {
+		return err
+	}
+	if ownerMode {
+		secrets, listErr := c.ListVaultSecrets(context.Background())
+		if listErr != nil {
+			return listErr
 		}
 		names = make([]string, 0, len(secrets))
 		for _, sec := range secrets {
 			names = append(names, sec.Name)
 		}
 	} else {
-		c, err := newVaultReadClientFromEnv()
-		if err != nil {
-			return err
-		}
-		var errList error
-		names, errList = c.ListReadableVaultSecrets(context.Background())
-		if errList != nil {
-			return errList
+		var listErr error
+		names, listErr = c.ListReadableVaultSecrets(context.Background())
+		if listErr != nil {
+			return listErr
 		}
 	}
 	sort.Strings(names)
@@ -656,16 +661,22 @@ func newVaultManagementClientFromEnv() (*client.Client, error) {
 	return c, nil
 }
 
-// newVaultReadClientFromEnv requires a delegated capability token (server's
-// vault read path is token-gated — an owner API key alone will be rejected
-// server-side with EACCES). Resolution goes through the unified resolver so
-// env > config priority + Unsetenv mitigation apply uniformly.
-func newVaultReadClientFromEnv() (*client.Client, error) {
+// newVaultReadClientFromEnv returns a client suitable for reading secret values
+// and a flag indicating whether the client is in owner mode. Routing is based
+// solely on ResolveCredentials().Kind (§14.2 routing invariant):
+//   - CredentialDelegated → capability-read path (/v1/vault/read/*)
+//   - CredentialOwner     → owner-read path (/v1/vault/secrets/{name}/value)
+//   - CredentialNone      → error
+func newVaultReadClientFromEnv() (*client.Client, bool, error) {
 	r := ResolveCredentials()
-	if r.Kind != CredentialDelegated {
-		return nil, fmt.Errorf("missing capability token; set %s before using drive9 vault get/with", EnvVaultToken)
+	switch r.Kind {
+	case CredentialDelegated:
+		return client.New(r.Server, r.Token), false, nil
+	case CredentialOwner:
+		return client.New(r.Server, r.APIKey), true, nil
+	default:
+		return nil, false, fmt.Errorf("no credential available; set %s (delegated) or %s (owner)", EnvVaultToken, EnvAPIKey)
 	}
-	return client.New(r.Server, r.Token), nil
 }
 
 func validateSecretName(name string) error {

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -386,3 +386,50 @@ func (c *Client) ReadVaultSecretField(ctx context.Context, name, field string) (
 	}
 	return string(data), nil
 }
+
+// ReadVaultSecretAsOwner reads all fields via the management API (owner-read path).
+// Response shape is identical to ReadVaultSecret (Invariant #9).
+func (c *Client) ReadVaultSecretAsOwner(ctx context.Context, name string) (map[string]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.vaultURL("/secrets/"+url.PathEscape(name)+"/value"), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode owner secret read response: %w", err)
+	}
+	if result == nil {
+		result = map[string]string{}
+	}
+	return result, nil
+}
+
+// ReadVaultSecretFieldAsOwner reads a single field via the management API (owner-read path).
+// Response shape is identical to ReadVaultSecretField (Invariant #9).
+func (c *Client) ReadVaultSecretFieldAsOwner(ctx context.Context, name, field string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.vaultURL("/secrets/"+url.PathEscape(name)+"/value/"+url.PathEscape(field)), nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return "", readError(resp)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read owner field response: %w", err)
+	}
+	return string(data), nil
+}

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -101,8 +101,30 @@ func (s *Server) handleVaultSecrets(w http.ResponseWriter, r *http.Request, sub 
 		return
 	}
 
-	// /v1/vault/secrets/{name}
+	// /v1/vault/secrets/{name}[/value[/{field}]]
 	name := strings.TrimPrefix(sub, "/")
+
+	// Owner-read: /v1/vault/secrets/{name}/value[/{field}]
+	if i := strings.Index(name, "/value"); i >= 0 {
+		secretName := name[:i]
+		rest := name[i+len("/value"):]
+		if r.Method != http.MethodGet {
+			errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		if rest == "" {
+			s.handleVaultSecretReadValue(w, r, vs, tenantID, secretName)
+		} else {
+			fieldName := strings.TrimPrefix(rest, "/")
+			if fieldName == "" {
+				errJSON(w, http.StatusBadRequest, "field name required after /value/")
+				return
+			}
+			s.handleVaultSecretReadField(w, r, vs, tenantID, secretName, fieldName)
+		}
+		return
+	}
+
 	switch r.Method {
 	case http.MethodGet:
 		s.handleVaultSecretGet(w, r, vs, tenantID, name)
@@ -198,6 +220,74 @@ func (s *Server) handleVaultSecretGet(w http.ResponseWriter, r *http.Request, vs
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(sec)
+}
+
+// handleVaultSecretReadValue returns all decrypted fields for a secret (owner-read path).
+// Response shape matches handleVaultReadSecret (Invariant #9: response schema parity).
+func (s *Server) handleVaultSecretReadValue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, secretName string) {
+	fields, err := vs.ReadSecretFields(r.Context(), tenantID, secretName)
+	if err != nil {
+		if errors.Is(err, vault.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "not found")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to read secret")
+		return
+	}
+
+	scope := ScopeFromContext(r.Context())
+	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+		TenantID:   tenantID,
+		EventType:  "secret.read",
+		TokenID:    "owner:" + scope.APIKeyID,
+		SecretName: secretName,
+		Adapter:    "management-api",
+	})
+
+	format := r.URL.Query().Get("format")
+	switch format {
+	case "env":
+		w.Header().Set("Content-Type", "text/plain")
+		for k, v := range fields {
+			_, _ = fmt.Fprintf(w, "%s=%s\n", strings.ToUpper(k), string(v))
+		}
+	case "json", "":
+		result := make(map[string]string, len(fields))
+		for k, v := range fields {
+			result[k] = string(v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(result)
+	default:
+		errJSON(w, http.StatusBadRequest, "unsupported format")
+	}
+}
+
+// handleVaultSecretReadField returns a single decrypted field (owner-read path).
+// Response shape matches handleVaultReadField (Invariant #9: response schema parity).
+func (s *Server) handleVaultSecretReadField(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, secretName, fieldName string) {
+	plaintext, err := vs.ReadSecretField(r.Context(), tenantID, secretName, fieldName)
+	if err != nil {
+		if errors.Is(err, vault.ErrNotFound) || errors.Is(err, vault.ErrFieldNotFound) {
+			errJSON(w, http.StatusNotFound, "not found")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to read field")
+		return
+	}
+
+	scope := ScopeFromContext(r.Context())
+	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
+		TenantID:   tenantID,
+		EventType:  "secret.read",
+		TokenID:    "owner:" + scope.APIKeyID,
+		SecretName: secretName,
+		FieldName:  fieldName,
+		Adapter:    "management-api",
+	})
+
+	w.Header().Set("Content-Type", "text/plain")
+	_, _ = w.Write(plaintext)
 }
 
 func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {


### PR DESCRIPTION
## Summary

Implements the vault owner-read capability defined in §4.2 of `vault-interaction-end-state.md` (spec PR #330):

- **Server**: `GET /v1/vault/secrets/{name}/value[/{field}]` — owner-read endpoints under tenant auth, response shape matches capability-read (Invariant #9)
- **Client**: `ReadVaultSecretAsOwner` / `ReadVaultSecretFieldAsOwner` methods
- **CLI**: `newVaultReadClientFromEnv` routes on `ResolveCredentials().Kind` — `CredentialDelegated` → `/v1/vault/read/*`, `CredentialOwner` → `/v1/vault/secrets/{name}/value`
- **Tests**: 5 routing tests including adv-1's regression case (delegated active context)

After this PR, `drive9 vault set test key=val && drive9 vault get test/key` works with just an owner API key — no `vault grant` needed.

## Key design decisions

- Routing is based solely on `ResolveCredentials().Kind` (§14.2 routing invariant)
- Stale delegated token never falls back to owner path (no-fallthrough invariant)
- `SecretLs` simplified to use the same routing logic instead of separate `currentCapabilityToken()` check
- Audit: `token_id=owner:<api_key_id>`, `adapter=management-api`

## Files changed

| File | Change |
|---|---|
| `pkg/server/vault.go` | Add `handleVaultSecretReadValue` / `handleVaultSecretReadField` + dispatch |
| `pkg/client/vault.go` | Add owner-read client methods |
| `cmd/drive9/cli/secret.go` | Dual-mode `newVaultReadClientFromEnv`, update `SecretGet`/`SecretWith`/`SecretLs` |
| `cmd/drive9/cli/credentials_test.go` | 5 new routing tests |

## Test plan

- [x] 5 routing tests pass locally
- [x] Full CLI test suite passes
- [x] `go build ./...` clean
- [ ] CI green
- [ ] adversary-1 code review
- [ ] adversary-2 code review

Depends on: #330 (spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)