### PR TITLE
feat: apply a $10 default monthly LLM cost cap to every tenant

### DIFF
--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -23,6 +23,17 @@ const (
 	defaultMaxUploadBytes        = int64(10 * (1 << 30)) // 10 GiB
 	defaultMaxTenantStorageBytes = int64(50 * (1 << 30)) // 50 GiB
 	defaultMaxMediaLLMFiles      = int64(500)            // 500 media files per tenant
+	// defaultMaxMonthlyLLMCostMillicents is the per-tenant monthly LLM spend
+	// cap applied when no explicit budget is configured. $10.00 USD, expressed
+	// in millicents (0.001 cents; $10 = 1000 cents = 1_000_000 millicents).
+	// This is a defense-in-depth floor, not a product pricing tier: high
+	// enough for a reasonable trial workload (hundreds of images or a few
+	// hours of audio) and low enough that a runaway tenant is noticed before
+	// meaningful financial impact. Operators who need a higher baseline raise
+	// this constant; operators who want to disable it globally pass a
+	// negative MaxMonthlyMillicents in Options.LLMCostBudget. Per-tenant
+	// overrides via meta.QuotaConfig.MaxMonthlyCostMC continue to win.
+	defaultMaxMonthlyLLMCostMillicents = int64(1_000_000) // $10.00
 )
 
 // QuotaSource controls where quota checks read authoritative state from.
@@ -70,7 +81,17 @@ type Options struct {
 // LLMCostBudgetOptions configures the monthly LLM cost budget.
 type LLMCostBudgetOptions struct {
 	// MaxMonthlyMillicents is the monthly cost cap in millicents (0.001 cents).
-	// Zero or negative disables the monthly cost budget gate.
+	//
+	// Tri-state:
+	//   > 0  — explicit per-tenant cap in millicents.
+	//   == 0 — unset; the default defense-in-depth cap
+	//          (defaultMaxMonthlyLLMCostMillicents, currently $10) is applied.
+	//   < 0  — explicit opt-out; disables the monthly cost budget gate.
+	//
+	// The zero-value meaning changed intentionally: leaving this field
+	// unset no longer yields "unlimited". Operators that truly need no
+	// monthly cap must pass a negative value. Per-tenant overrides via
+	// meta.QuotaConfig.MaxMonthlyCostMC still win over this value.
 	MaxMonthlyMillicents int64
 	// VisionCostPerKTokenMillicents is the cost per 1K tokens for Vision API calls.
 	VisionCostPerKTokenMillicents int64
@@ -153,7 +174,14 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 	}
 
 	cb := opts.LLMCostBudget
-	b.maxMonthlyLLMCostMillicents = cb.MaxMonthlyMillicents
+	switch {
+	case cb.MaxMonthlyMillicents > 0:
+		b.maxMonthlyLLMCostMillicents = cb.MaxMonthlyMillicents
+	case cb.MaxMonthlyMillicents < 0:
+		b.maxMonthlyLLMCostMillicents = 0 // explicit opt-out
+	default:
+		b.maxMonthlyLLMCostMillicents = defaultMaxMonthlyLLMCostMillicents
+	}
 	b.visionCostPerKTokenMillicents = cb.VisionCostPerKTokenMillicents
 	b.audioLLMCostPerKTokenMillicents = cb.AudioLLMCostPerKTokenMillicents
 	b.whisperCostPerMinuteMillicents = cb.WhisperCostPerMinuteMillicents

--- a/pkg/backend/options_test.go
+++ b/pkg/backend/options_test.go
@@ -1,0 +1,65 @@
+package backend
+
+import "testing"
+
+// TestConfigureOptions_MonthlyLLMCostDefault pins the tri-state handling of
+// LLMCostBudgetOptions.MaxMonthlyMillicents in configureOptions:
+//
+//	> 0 — use the explicit value
+//	== 0 — apply defaultMaxMonthlyLLMCostMillicents ($10 defense-in-depth cap)
+//	< 0 — explicit opt-out (no monthly cap)
+//
+// The zero-value branch is the defense-in-depth contract: forgetting to
+// configure a cap MUST NOT yield unlimited spend. A regression here is how
+// a new tenant silently burns through the LLM budget.
+func TestConfigureOptions_MonthlyLLMCostDefault(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int64
+		want       int64
+	}{
+		{
+			name:       "unset falls back to global default",
+			configured: 0,
+			want:       defaultMaxMonthlyLLMCostMillicents,
+		},
+		{
+			name:       "explicit positive wins over default",
+			configured: 42_000,
+			want:       42_000,
+		},
+		{
+			name:       "explicit negative disables the gate",
+			configured: -1,
+			want:       0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &Dat9Backend{}
+			b.configureOptions(Options{
+				LLMCostBudget: LLMCostBudgetOptions{
+					MaxMonthlyMillicents: tc.configured,
+				},
+			})
+			if b.maxMonthlyLLMCostMillicents != tc.want {
+				t.Fatalf("maxMonthlyLLMCostMillicents = %d, want %d (configured=%d)",
+					b.maxMonthlyLLMCostMillicents, tc.want, tc.configured)
+			}
+		})
+	}
+}
+
+// TestDefaultMaxMonthlyLLMCostMillicents_IsTenDollars pins the default at
+// exactly $10.00 in millicents. Changing the default is a policy decision
+// that should be reviewed, not a silent numeric edit.
+func TestDefaultMaxMonthlyLLMCostMillicents_IsTenDollars(t *testing.T) {
+	const tenDollarsInMillicents = int64(1_000_000)
+	if defaultMaxMonthlyLLMCostMillicents != tenDollarsInMillicents {
+		t.Fatalf("defaultMaxMonthlyLLMCostMillicents = %d, want %d ($10.00). "+
+			"Changing this default affects every tenant without a per-tenant "+
+			"override — update the tenant onboarding docs and this test together.",
+			defaultMaxMonthlyLLMCostMillicents, tenDollarsInMillicents)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix a one-field inconsistency in `configureOptions`: every other quota field (`MaxUploadBytes`, `MaxTenantStorageBytes`, `MaxMediaLLMFiles`) had a `defaultXxx` fallback; `MaxMonthlyMillicents` did not, so a tenant onboarded without an explicit LLM budget had no spend ceiling — only post-hoc accounting in the `llm_usage` table.
- Introduce `defaultMaxMonthlyLLMCostMillicents = 1_000_000` ($10.00) and switch `LLMCostBudgetOptions.MaxMonthlyMillicents` to tri-state:
  - `> 0` — explicit per-tenant cap
  - `== 0` — unset; apply the global default (new behavior)
  - `< 0` — explicit opt-out; disables the gate
- Per-tenant `QuotaConfig.MaxMonthlyCostMC` overrides continue to win; `monthlyLLMCostExceededServer` already reads per-tenant config first and falls back to `b.maxMonthlyLLMCostMillicents`, so the server-mode path picks up the new default for free.
- Existing fail-open behavior on meta-store errors is preserved. Defaults guard against misconfiguration; fail-open guards against infra outages. The two layers stay independent.

## Why $10

Low enough that a runaway tenant is noticed well before meaningful financial impact, high enough that a reasonable trial workload (hundreds of images or a few hours of audio transcription) fits comfortably. Operators who need a different baseline either raise the constant or set a per-tenant `QuotaConfig.MaxMonthlyCostMC`.

## Why change the zero-value meaning

The previous `== 0 → disabled` convention meant that forgetting to set the budget yielded unlimited spend — the most dangerous possible default. Tri-state keeps an explicit escape hatch (`< 0`) for operators who truly want no cap, while making the forgetful case safe.

## Compatibility

- Tenants with `MaxMonthlyMillicents > 0` configured: behavior unchanged.
- Tenants with per-tenant `QuotaConfig.MaxMonthlyCostMC > 0`: behavior unchanged (per-tenant still wins).
- Tenants with neither configured: now bounded at $10/month. Previously unbounded.
- `monthlyLLMCostExceeded`/`monthlyLLMCostExceededServer` semantics on the `<= 0` field value are unchanged; only the `configureOptions` input-to-field translation changed.

## Test plan

- [x] `go test ./pkg/backend/...` passes
- [x] New `TestConfigureOptions_MonthlyLLMCostDefault` covers all three branches (unset / explicit positive / explicit negative)
- [x] New `TestDefaultMaxMonthlyLLMCostMillicents_IsTenDollars` pins the constant at \$10 so it cannot be silently edited
- [x] Verified no existing test assumed `MaxMonthlyMillicents == 0` through `configureOptions` means "disabled" — the only tests that set the field directly bypass `configureOptions` and are unaffected