### PR TITLE
test: add MaxMonthlyCostMC data-layer coverage to quota E2E

### DIFF
--- a/e2e/server-quota/TEST_REPORT.md
+++ b/e2e/server-quota/TEST_REPORT.md
@@ -77,8 +77,8 @@
 
 | Metric | Value |
 |--------|-------|
-| Total assertions | 17 |
-| Passed | 17 |
+| Total assertions | 19 |
+| Passed | 19 |
 | Failed | 0 |
 
 All server-mode quota enforcement features validated successfully:
@@ -89,3 +89,4 @@ All server-mode quota enforcement features validated successfully:
 - Multipart upload reservation saga (reserve / abort release)
 - Quota mutation log persistence
 - Backfill CLI consistency with tenant DB
+- Monthly LLM cost quota config (`max_monthly_cost_mc`) and central counter (`tenant_monthly_llm_cost`)

--- a/e2e/server-quota/quota-server-e2e.sh
+++ b/e2e/server-quota/quota-server-e2e.sh
@@ -145,6 +145,13 @@ get_pending_mutations() {
     "SELECT COUNT(*) FROM quota_mutation_log WHERE tenant_id='local-tenant' AND status='pending';" 2>/dev/null
 }
 
+# Query central monthly LLM cost counter
+get_monthly_llm_cost() {
+  local month_start="$1"
+  mysql -h127.0.0.1 -P13306 -uroot -proot drive9_meta -N -s -e \
+    "SELECT COALESCE(total_mc, 0) FROM tenant_monthly_llm_cost WHERE tenant_id='local-tenant' AND month_start='${month_start}';" 2>/dev/null
+}
+
 # Wait until all mutations for local-tenant are applied (or timeout)
 wait_mutations_applied() {
   local timeout_sec="${1:-10}"
@@ -415,6 +422,37 @@ STORAGE_BYTES=$(echo "$QUOTA" | awk '{print $1}')
 MEDIA_COUNT=$(echo "$QUOTA" | awk '{print $3}')
 check_eq "backfilled storage_bytes matches tenant DB" "${STORAGE_BYTES:-0}" "${BACKFILL_STORAGE:-0}"
 check_eq "backfilled media_file_count matches tenant DB" "${MEDIA_COUNT:-0}" "${BACKFILL_MEDIA:-0}"
+
+# --- Test 11: monthly LLM cost quota (data-layer validation) ---------------
+step "Test 11: monthly LLM cost quota config and counter"
+MONTH_START=$(date -u +%Y-%m-01)
+
+# Set a low monthly cost limit in central config
+info "Setting max_monthly_cost_mc = 100 ..."
+mysql -h127.0.0.1 -P13306 -uroot -proot drive9_meta -e \
+  "UPDATE tenant_quota_config SET max_monthly_cost_mc = 100 WHERE tenant_id='local-tenant';" 2>/dev/null || true
+
+# Insert simulated LLM cost for the current month (simulates usage accumulation)
+info "Injecting simulated LLM cost of 150 millicents ..."
+mysql -h127.0.0.1 -P13306 -uroot -proot drive9_meta -e \
+  "INSERT INTO tenant_monthly_llm_cost (tenant_id, month_start, total_mc) VALUES ('local-tenant', '${MONTH_START}', 150) ON DUPLICATE KEY UPDATE total_mc = total_mc + 150;" 2>/dev/null || true
+
+# Verify config reads correctly
+CONFIG_MC=$(mysql -h127.0.0.1 -P13306 -uroot -proot drive9_meta -N -s -e \
+  "SELECT max_monthly_cost_mc FROM tenant_quota_config WHERE tenant_id='local-tenant';" 2>/dev/null)
+check_eq "max_monthly_cost_mc config should be 100" "${CONFIG_MC:-0}" "100"
+
+# Verify central counter reads correctly
+COST_MC=$(get_monthly_llm_cost "$MONTH_START")
+info "monthly LLM cost counter: ${COST_MC:-0} millicents"
+TOTAL=$((TOTAL+1))
+if [ "${COST_MC:-0}" -ge 150 ]; then
+  ok "monthly LLM cost counter >= 150 (got=${COST_MC})"
+  PASS=$((PASS+1))
+else
+  fail "monthly LLM cost counter should be >= 150 (got=${COST_MC:-0})"
+  FAIL=$((FAIL+1))
+fi
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

Add data-layer coverage for `MaxMonthlyCostMC` (monthly LLM cost quota) to the server-mode quota E2E test suite.

## Changes

- `e2e/server-quota/quota-server-e2e.sh`
  - Add `get_monthly_llm_cost()` helper to query the central `tenant_monthly_llm_cost` counter
  - Add **Test 11** with 2 assertions:
    1. Set `max_monthly_cost_mc = 100` in `tenant_quota_config`, verify it reads back correctly
    2. Inject 150 millicents into `tenant_monthly_llm_cost` for the current month, verify counter reads `>= 150`
- `e2e/server-quota/TEST_REPORT.md`
  - Update assertion count: 17 → 19

## Why data-layer only

`monthlyLLMCostExceeded()` is only called from `image_extract.go` / `audio_extract.go` background tasks (semantic workers). The current E2E architecture (`drive9-server-local` + `app-managed` embedding mode) does not run semantic workers, so there is no HTTP endpoint or CLI command that exercises the budget-exhaustion rejection path. Full behavior coverage will be added separately when the E2E can spin up semantic workers with a stub embedder.

## Test result

✅ **19/19 tests passed**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded E2E test coverage with two additional passing validations (19/19 tests passing).
  * Enhanced validation for monthly LLM cost quota configuration and cost tracking mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->