### PR TITLE
fix: scale Release timeout by file size

### DIFF
--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -435,6 +435,13 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	// Read local shadow content.
 	localData, err := cq.shadows.ReadAll(entry.Path)
 	if err != nil {
+		// Shadow may have been removed by a concurrent CancelPath/CancelPrefix
+		// (Unlink/Rmdir). Treat as canceled rather than a true conflict.
+		if cq.isCanceled(entry.Path) {
+			cq.removeFromQueue(entry)
+			log.Printf("commit queue: auto-resolve skipped for %s (canceled mid-read)", entry.Path)
+			return
+		}
 		log.Printf("commit queue: auto-resolve failed for %s: read shadow: %v", entry.Path, err)
 		cq.onCommitTerminalFailure(entry)
 		return
@@ -476,7 +483,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 		return
 	}
 	log.Printf("commit queue: auto-resolving conflict for %s via LWW (base rev %d → server rev %d)", entry.Path, entry.BaseRev, serverRev)
-	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), uploadTimeout)
+	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), releaseTimeout(int64(len(localData))))
 	err = uploadBufferedRemoteFile(uploadCtx, cq.client, entry.Path, localData, serverRev)
 	uploadCancel()
 	if err != nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -149,16 +149,16 @@ const (
 // gets ~205s, which is comfortably reachable on typical home broadband.
 func releaseTimeout(size int64) time.Duration {
 	const (
-		base      = 60 * time.Second
-		cap       = 15 * time.Minute
-		bandwidth = 5 << 20 // 5 MB/s
+		minTimeout = 60 * time.Second
+		maxTimeout = 15 * time.Minute
+		bandwidth  = 5 << 20 // 5 MB/s
 	)
 	t := time.Duration(size/bandwidth) * time.Second
-	if t < base {
-		t = base
+	if t < minTimeout {
+		t = minTimeout
 	}
-	if t > cap {
-		t = cap
+	if t > maxTimeout {
+		t = maxTimeout
 	}
 	return t
 }

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -140,6 +140,29 @@ const (
 	lookupRetrySuccessLogEvery uint64 = 200
 )
 
+// releaseTimeout computes a generous timeout for synchronous uploads in
+// Release / FlushAll based on file size. The formula is:
+//
+//	max(60s, size / 5 MB/s)   capped at 15 min
+//
+// 5 MB/s is a conservative floor for cross-region S3 uploads. A 1 GiB file
+// gets ~205s, which is comfortably reachable on typical home broadband.
+func releaseTimeout(size int64) time.Duration {
+	const (
+		base      = 60 * time.Second
+		cap       = 15 * time.Minute
+		bandwidth = 5 << 20 // 5 MB/s
+	)
+	t := time.Duration(size/bandwidth) * time.Second
+	if t < base {
+		t = base
+	}
+	if t > cap {
+		t = cap
+	}
+	return t
+}
+
 // fuseCtx converts a FUSE cancel channel into a context.Context with a timeout.
 // The context is cancelled when either the FUSE operation is interrupted or the
 // timeout expires. This ensures HTTP calls never block indefinitely.
@@ -2195,12 +2218,15 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 		}
 
 		// Normal path: synchronous upload in Release.
-		// Release uses a generous timeout since it must persist data.
-		ctx, cf := context.WithTimeout(context.Background(), 60*time.Second)
-		defer cf()
-
+		// Timeout scales with file size so large uploads don't get killed.
 		fh.Lock()
+		var flushSize int64
+		if fh.Dirty != nil {
+			flushSize = fh.Dirty.Size()
+		}
+		ctx, cf := context.WithTimeout(context.Background(), releaseTimeout(flushSize))
 		st := fs.flushHandle(ctx, fh)
+		cf()
 		streamer := fh.Streamer
 		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 		fh.DirtySeq = 0
@@ -2477,10 +2503,13 @@ func (fs *Dat9FS) FlushAll() {
 		handles = append(handles, entry{fhID, fh})
 	})
 	for _, e := range handles {
-		// Per-handle timeout so each flush gets a full 60s regardless of
-		// how many handles precede it.
-		ctx, cf := context.WithTimeout(context.Background(), 60*time.Second)
+		// Per-handle timeout scaled by file size so large uploads complete.
 		e.fh.Lock()
+		var sz int64
+		if e.fh.Dirty != nil {
+			sz = e.fh.Dirty.Size()
+		}
+		ctx, cf := context.WithTimeout(context.Background(), releaseTimeout(sz))
 		fs.flushHandle(ctx, e.fh)
 		e.fh.Unlock()
 		cf()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2546,3 +2546,22 @@ func TestDebounce_ReleaseAfterFlush_NoDataLoss(t *testing.T) {
 		t.Fatal("data was never uploaded — data loss!")
 	}
 }
+
+func TestReleaseTimeoutScaling(t *testing.T) {
+	tests := []struct {
+		size    int64
+		wantMin time.Duration
+		wantMax time.Duration
+	}{
+		{0, 60 * time.Second, 60 * time.Second},                   // small file: floor
+		{10 << 20, 60 * time.Second, 60 * time.Second},            // 10 MB: still floor
+		{1 << 30, 200 * time.Second, 220 * time.Second},           // 1 GiB: ~205s
+		{100 << 30, 15 * time.Minute, 15 * time.Minute},           // 100 GiB: capped at 15min
+	}
+	for _, tt := range tests {
+		got := releaseTimeout(tt.size)
+		if got < tt.wantMin || got > tt.wantMax {
+			t.Errorf("releaseTimeout(%d) = %v, want [%v, %v]", tt.size, got, tt.wantMin, tt.wantMax)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Replace fixed 60s timeout in `Release` and `FlushAll` with `releaseTimeout(size)` = `max(60s, size / 5 MB/s)` capped at 15 min
- Fixes juicefs bench failures where 1 GiB multipart uploads were killed at exactly 60s over cross-region links
- 5 MB/s floor is conservative for cross-region S3; 1 GiB gets ~205s

## Test plan
- [x] `TestReleaseTimeoutScaling` — verifies floor (60s), scaling (1 GiB → ~205s), and cap (15 min)
- [ ] CI passes
- [ ] Re-run `juicefs bench /tmp/test2 -p 4` on Mac with cross-region backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Upload conflicts now attempt automatic resolution instead of immediate terminal failure, with last-write-wins re-upload for differing content.

* **New Features**
  * Dynamic upload timeouts now scale with file size, providing longer deadlines for large files while maintaining minimum thresholds for small files.

* **Tests**
  * Expanded test coverage for conflict auto-resolution scenarios and timeout scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->