### PR TITLE
fix: defer streaming upload from Flush to Release for large files

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2080,6 +2080,14 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) gofuse.St
 		}
 	}
 
+	// Streaming uploads of large files can take minutes. The FUSE Flush
+	// context has a fixed 30s timeout which is too short. Defer the upload
+	// to Release, which uses releaseTimeout(size) — a size-proportional
+	// timeout. The data is safe in pendingParts + WriteBuffer until then.
+	if fh.Streamer != nil && fh.Streamer.HasStreamedParts() {
+		return gofuse.OK
+	}
+
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2080,11 +2080,12 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) gofuse.St
 		}
 	}
 
-	// Streaming uploads of large files can take minutes. The FUSE Flush
-	// context has a fixed 30s timeout which is too short. Defer the upload
-	// to Release, which uses releaseTimeout(size) — a size-proportional
-	// timeout. The data is safe in pendingParts + WriteBuffer until then.
-	if fh.Streamer != nil && fh.Streamer.HasStreamedParts() {
+	// Large file uploads (streaming or non-sequential) can take minutes.
+	// The FUSE Flush context has a fixed 30s timeout which is too short.
+	// Defer the upload to Release, which uses releaseTimeout(size) — a
+	// size-proportional timeout that scales with the file.
+	// The data is safe in pendingParts + WriteBuffer until Release.
+	if fh.Dirty != nil && fh.Dirty.Size() >= writeBackThreshold {
 		return gofuse.OK
 	}
 

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -1173,17 +1173,17 @@ func TestStreamUploader_HasStreamedParts(t *testing.T) {
 func TestStreamUploader_FinishStreamingRestoresPendingOnFailure(t *testing.T) {
 	var initiateCalls int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/v2/uploads/initiate":
+		switch r.URL.Path {
+		case "/v2/uploads/initiate":
 			initiateCalls++
 			// Return a valid upload plan so initiation succeeds.
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 			_, _ = w.Write([]byte(`{"upload_id":"test-upload","total_parts":2}`))
-		case r.URL.Path == "/v2/uploads/test-upload/presign-batch":
+		case "/v2/uploads/test-upload/presign-batch":
 			// Fail presign to simulate S3 error during WritePart.
 			http.Error(w, `{"error":"simulated S3 failure"}`, http.StatusInternalServerError)
-		case r.URL.Path == "/v2/uploads/test-upload/abort":
+		case "/v2/uploads/test-upload/abort":
 			w.WriteHeader(http.StatusOK)
 		default:
 			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -1,10 +1,15 @@
 package fuse
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/client"
 )
 
 // ---------------------------------------------------------------------------
@@ -1159,6 +1164,73 @@ func TestStreamUploader_HasStreamedParts(t *testing.T) {
 	su := NewStreamUploader(nil, "/test", -1)
 	if su.HasStreamedParts() {
 		t.Fatal("should have no streamed parts initially")
+	}
+}
+
+// TestStreamUploader_FinishStreamingRestoresPendingOnFailure verifies that
+// when FinishStreaming fails (e.g. S3 connection reset, timeout), the
+// pendingParts are restored so the operation can be retried.
+func TestStreamUploader_FinishStreamingRestoresPendingOnFailure(t *testing.T) {
+	var initiateCalls int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/uploads/initiate":
+			initiateCalls++
+			// Return a valid upload plan so initiation succeeds.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"upload_id":"test-upload","total_parts":2}`))
+		case r.URL.Path == "/v2/uploads/test-upload/presign-batch":
+			// Fail presign to simulate S3 error during WritePart.
+			http.Error(w, `{"error":"simulated S3 failure"}`, http.StatusInternalServerError)
+		case r.URL.Path == "/v2/uploads/test-upload/abort":
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	c := client.New(ts.URL, "")
+	su := NewStreamUploader(c, "/retry-test.bin", -1)
+
+	// Submit 2 parts.
+	part1 := []byte("part-1-data-here")
+	part2 := []byte("part-2-data-here")
+	if err := su.SubmitPart(context.Background(), 1, part1, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := su.SubmitPart(context.Background(), 2, part2, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// First FinishStreaming should fail (presign returns 500).
+	err := su.FinishStreaming(context.Background(), 32, 2, []byte("last"), nil)
+	if err == nil {
+		t.Fatal("expected FinishStreaming to fail")
+	}
+
+	// pendingParts should be restored — verify by checking the internal state.
+	su.mu.Lock()
+	restoredCount := len(su.pendingParts)
+	has1 := su.pendingParts[1] != nil
+	has2 := su.pendingParts[2] != nil
+	writerNil := su.writer == nil
+	su.mu.Unlock()
+
+	if restoredCount != 2 {
+		t.Fatalf("pendingParts count after failure = %d, want 2", restoredCount)
+	}
+	if !has1 || !has2 {
+		t.Fatalf("pendingParts missing parts: has1=%v has2=%v", has1, has2)
+	}
+	if !writerNil {
+		t.Fatal("writer should be nil after failure to allow fresh initiate on retry")
+	}
+
+	// Verify initiate was called (upload was attempted, not short-circuited).
+	if initiateCalls < 1 {
+		t.Fatalf("initiate calls = %d, want >= 1", initiateCalls)
 	}
 }
 

--- a/pkg/fuse/stream_upload.go
+++ b/pkg/fuse/stream_upload.go
@@ -159,10 +159,23 @@ func (su *StreamUploader) FinishStreaming(ctx context.Context, totalSize int64,
 	su.writer = su.client.NewStreamWriterConditional(ctx, su.path, totalSize, su.expectedRevision)
 	sw := su.writer
 
-	// Collect all buffered parts.
+	// Collect all buffered parts. We keep a reference so we can restore
+	// them on failure — making this method safe to retry.
 	pending := su.pendingParts
 	su.pendingParts = make(map[int][]byte)
 	su.mu.Unlock()
+
+	// restoreOnError puts pending parts back so a subsequent call can retry.
+	restoreOnError := func() {
+		su.mu.Lock()
+		defer su.mu.Unlock()
+		for pn, data := range pending {
+			if _, exists := su.pendingParts[pn]; !exists {
+				su.pendingParts[pn] = data
+			}
+		}
+		su.writer = nil // allow fresh initiate on retry
+	}
 
 	// Upload all buffered parts (from SubmitPart during Write).
 	for pn, data := range pending {
@@ -176,6 +189,7 @@ func (su *StreamUploader) FinishStreaming(ctx context.Context, totalSize int64,
 			abortCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			_ = sw.Abort(abortCtx)
 			cancel()
+			restoreOnError()
 			return err
 		}
 	}
@@ -186,6 +200,7 @@ func (su *StreamUploader) FinishStreaming(ctx context.Context, totalSize int64,
 			abortCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			_ = sw.Abort(abortCtx)
 			cancel()
+			restoreOnError()
 			return err
 		}
 	}
@@ -196,6 +211,7 @@ func (su *StreamUploader) FinishStreaming(ctx context.Context, totalSize int64,
 		abortCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		_ = sw.Abort(abortCtx)
 		cancel()
+		restoreOnError()
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Flush uses a fixed 30s FUSE timeout (`fuseCtx`), too short for large streaming uploads (1 GiB = 128 parts)
- When `FinishStreaming` times out in Flush, it consumes `pendingParts` state. Release then retries with an empty state → `stream writer was never started`
- Fix: large files (≥ writeBackThreshold / 10MB) defer upload from Flush to Release, which uses `releaseTimeout(size)` (PR #335)
- Fix: `FinishStreaming` is now idempotent — on failure, `pendingParts` are restored so retry is possible (handles S3 connection resets, network flakes)
- Flush deferral gate widened from `HasStreamedParts()` to `size >= writeBackThreshold` to cover non-sequential large files too

## Test plan
- [x] CI passes (unit + e2e)
- [x] `TestStreamUploader_FinishStreamingRestoresPendingOnFailure` — verifies pendingParts restored after upload failure
- [ ] juicefs bench with 1 GiB files no longer times out (requires merge + CLI rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)