### PR TITLE
Support Qwen-ASR audio extraction

### DIFF
--- a/cmd/drive9-server-local/local_audio_extractor.go
+++ b/cmd/drive9-server-local/local_audio_extractor.go
@@ -26,6 +26,7 @@ const (
 	envAudioExtractResponseFormat = "DRIVE9_AUDIO_EXTRACT_RESPONSE_FORMAT"
 	localAudioExtractStubMode     = "stub"
 	localAudioExtractOpenAIMode   = "openai"
+	localAudioExtractQwenASRMode  = "qwen-asr"
 )
 
 // localStubAudioTextExtractor implements backend.AudioTextExtractor for local e2e.
@@ -49,9 +50,9 @@ func (localStubAudioTextExtractor) ExtractAudioText(ctx context.Context, req bac
 
 // buildLocalAudioExtractOptionsFromEnv returns [backend.AsyncAudioExtractOptions] for
 // drive9-server-local. When DRIVE9_AUDIO_EXTRACT_ENABLED is false, the zero value is
-// returned. When true, DRIVE9_AUDIO_EXTRACT_MODE must be either "stub" or
-// "openai". The local entrypoint keeps stub mode for deterministic e2e while
-// also allowing real provider smoke checks against OpenAI-compatible ASR.
+// returned. When true, DRIVE9_AUDIO_EXTRACT_MODE must be "stub", "openai", or
+// "qwen-asr". The local entrypoint keeps stub mode for deterministic e2e while
+// also allowing real provider smoke checks against external ASR services.
 func buildLocalAudioExtractOptionsFromEnv() (backend.AsyncAudioExtractOptions, error) {
 	if !envBool(envAudioExtractEnabled, false) {
 		return backend.AsyncAudioExtractOptions{}, nil
@@ -89,7 +90,25 @@ func buildLocalAudioExtractOptionsFromEnv() (backend.AsyncAudioExtractOptions, e
 			MaxExtractTextBytes: envInt(envAudioExtractMaxTextBytes, 0),
 			Extractor:           extractor,
 		}, nil
+	case localAudioExtractQwenASRMode:
+		extractor, err := backend.NewQwenASRAudioTextExtractor(backend.QwenASRAudioTextExtractorConfig{
+			BaseURL: strings.TrimSpace(os.Getenv(envAudioExtractAPIBase)),
+			APIKey:  strings.TrimSpace(os.Getenv(envAudioExtractAPIKey)),
+			Model:   strings.TrimSpace(os.Getenv(envAudioExtractModel)),
+			Prompt:  strings.TrimSpace(os.Getenv(envAudioExtractPrompt)),
+			Timeout: time.Duration(envInt(envAudioExtractTimeoutSeconds, 0)) * time.Second,
+		})
+		if err != nil {
+			return backend.AsyncAudioExtractOptions{}, fmt.Errorf("init local qwen asr audio extractor: %w", err)
+		}
+		return backend.AsyncAudioExtractOptions{
+			Enabled:             true,
+			MaxAudioBytes:       envInt64(envAudioExtractMaxBytes, 0),
+			TaskTimeout:         time.Duration(envInt(envAudioExtractTimeoutSeconds, 0)) * time.Second,
+			MaxExtractTextBytes: envInt(envAudioExtractMaxTextBytes, 0),
+			Extractor:           extractor,
+		}, nil
 	default:
-		return backend.AsyncAudioExtractOptions{}, fmt.Errorf("%s must be %q or %q for drive9-server-local (got %q)", envAudioExtractMode, localAudioExtractStubMode, localAudioExtractOpenAIMode, mode)
+		return backend.AsyncAudioExtractOptions{}, fmt.Errorf("%s must be %q, %q, or %q for drive9-server-local (got %q)", envAudioExtractMode, localAudioExtractStubMode, localAudioExtractOpenAIMode, localAudioExtractQwenASRMode, mode)
 	}
 }

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -384,14 +384,14 @@ environment:
 
   Async audio transcript extract (TiDB auto-embedding durable tasks):
   DRIVE9_AUDIO_EXTRACT_ENABLED true|false (default: false)
-  DRIVE9_AUDIO_EXTRACT_MODE stub|openai (required when enabled)
+  DRIVE9_AUDIO_EXTRACT_MODE stub|openai|qwen-asr (required when enabled)
   DRIVE9_AUDIO_EXTRACT_MAX_BYTES max audio bytes per task (optional; backend default when unset)
   DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS extractor timeout seconds (optional; backend default when unset)
   DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES max transcript bytes stored in files.content_text (optional; backend default when unset)
-  DRIVE9_AUDIO_EXTRACT_API_BASE OpenAI-compatible base URL (required for openai mode)
-  DRIVE9_AUDIO_EXTRACT_API_KEY  API key for DRIVE9_AUDIO_EXTRACT_API_BASE (required for openai mode)
-  DRIVE9_AUDIO_EXTRACT_MODEL    model name for audio transcription (required for openai mode)
-  DRIVE9_AUDIO_EXTRACT_PROMPT   optional provider prompt for transcription (openai mode)
+  DRIVE9_AUDIO_EXTRACT_API_BASE OpenAI-compatible base URL (required for openai/qwen-asr mode)
+  DRIVE9_AUDIO_EXTRACT_API_KEY  API key for DRIVE9_AUDIO_EXTRACT_API_BASE (required for openai/qwen-asr mode)
+  DRIVE9_AUDIO_EXTRACT_MODEL    model name for audio transcription (required for openai/qwen-asr mode)
+  DRIVE9_AUDIO_EXTRACT_PROMPT   optional provider prompt for transcription (openai/qwen-asr mode)
 `)
 	os.Exit(2)
 }

--- a/cmd/drive9-server-local/main_test.go
+++ b/cmd/drive9-server-local/main_test.go
@@ -481,6 +481,63 @@ func TestBuildBackendOptionsFromEnvAudioOpenAI(t *testing.T) {
 	}
 }
 
+func TestBuildBackendOptionsFromEnvAudioQwenASR(t *testing.T) {
+	keys := []string{
+		"DRIVE9_QUERY_EMBED_API_BASE",
+		"DRIVE9_QUERY_EMBED_API_KEY",
+		"DRIVE9_QUERY_EMBED_MODEL",
+		"DRIVE9_IMAGE_EXTRACT_ENABLED",
+		envAudioExtractEnabled,
+		envAudioExtractMode,
+		envAudioExtractAPIBase,
+		envAudioExtractAPIKey,
+		envAudioExtractModel,
+		envAudioExtractPrompt,
+		envAudioExtractTimeoutSeconds,
+		envAudioExtractMaxBytes,
+		envAudioExtractMaxTextBytes,
+	}
+	prev := make(map[string]string, len(keys))
+	for _, k := range keys {
+		prev[k] = os.Getenv(k)
+	}
+	t.Cleanup(func() {
+		for _, k := range keys {
+			if prev[k] == "" {
+				_ = os.Unsetenv(k)
+			} else {
+				_ = os.Setenv(k, prev[k])
+			}
+		}
+	})
+	for _, k := range keys {
+		_ = os.Unsetenv(k)
+	}
+
+	if err := os.Setenv(envAudioExtractEnabled, "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv(envAudioExtractMode, "qwen-asr"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv(envAudioExtractAPIBase, "https://dashscope.aliyuncs.com/compatible-mode/v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv(envAudioExtractAPIKey, "secret"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv(envAudioExtractModel, "qwen3-asr-flash"); err != nil {
+		t.Fatal(err)
+	}
+	opts, err := buildBackendOptionsFromEnv()
+	if err != nil {
+		t.Fatalf("buildBackendOptionsFromEnv: %v", err)
+	}
+	if !backend.AsyncAudioExtractWillWireRuntime(opts.AsyncAudioExtract) {
+		t.Fatalf("expected async audio in backend options, got %+v", opts.AsyncAudioExtract)
+	}
+}
+
 func TestLocalStubAudioTextExtractorTranscript(t *testing.T) {
 	var ex localStubAudioTextExtractor
 	got, _, err := ex.ExtractAudioText(context.Background(), backend.AudioExtractRequest{Path: "/audio/clip.mp3"})

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -399,7 +399,7 @@ environment:
   not enable that semantic_tasks pipeline. When enabled, explicit provider wiring is required:
   DRIVE9_AUDIO_EXTRACT_ENABLED true|false (default: false)
   DRIVE9_AUDIO_EXTRACT_MODE     openai|qwen-asr (default: openai)
-  DRIVE9_AUDIO_EXTRACT_MAX_BYTES max audio bytes processed per task (default: 33554432)
+  DRIVE9_AUDIO_EXTRACT_MAX_BYTES max audio bytes processed per task (default: 33554432 for openai, 10485760 for qwen-asr)
   DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS extractor timeout seconds (default: 120)
   DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES max transcript bytes stored in files.content_text (default: 8192)
   DRIVE9_AUDIO_EXTRACT_API_BASE OpenAI-compatible base URL (required when enabled)
@@ -495,108 +495,133 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 			zap.String("model", queryModel), zap.String("base_url", queryBaseURL))
 	}
 
-	if envBool("DRIVE9_IMAGE_EXTRACT_ENABLED", false) {
-		async := backend.AsyncImageExtractOptions{
-			Enabled:             true,
-			QueueSize:           envInt("DRIVE9_IMAGE_EXTRACT_QUEUE_SIZE", 128),
-			Workers:             envInt("DRIVE9_IMAGE_EXTRACT_WORKERS", 1),
-			MaxImageBytes:       envInt64("DRIVE9_IMAGE_EXTRACT_MAX_BYTES", 8<<20),
-			TaskTimeout:         time.Duration(envInt("DRIVE9_IMAGE_EXTRACT_TIMEOUT_SECONDS", 20)) * time.Second,
-			MaxExtractTextBytes: envInt("DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES", 8<<10),
-		}
-
-		baseURL := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_API_BASE"))
-		apiKey := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_API_KEY"))
-		model := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_MODEL"))
-		prompt := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_PROMPT"))
-		maxTokens := envInt("DRIVE9_IMAGE_EXTRACT_MAX_TOKENS", 256)
-
-		configured := baseURL != "" || apiKey != "" || model != ""
-		if configured {
-			if baseURL == "" || apiKey == "" || model == "" {
-				logger.Error(context.Background(), "image_extract_mode_invalid_config",
-					zap.Bool("base_url_present", baseURL != ""),
-					zap.Bool("api_key_present", apiKey != ""),
-					zap.Bool("model_present", model != ""))
-				return backend.Options{}, fmt.Errorf("DRIVE9_IMAGE_EXTRACT_API_BASE, DRIVE9_IMAGE_EXTRACT_API_KEY and DRIVE9_IMAGE_EXTRACT_MODEL must be set together")
-			}
-			extractor, err := backend.NewOpenAIImageTextExtractor(backend.OpenAIImageTextExtractorConfig{
-				BaseURL:   baseURL,
-				APIKey:    apiKey,
-				Model:     model,
-				Prompt:    prompt,
-				MaxTokens: maxTokens,
-				Timeout:   async.TaskTimeout,
-			})
-			if err != nil {
-				return backend.Options{}, fmt.Errorf("init image extractor: %w", err)
-			}
-			async.Extractor = backend.NewFallbackImageTextExtractor(extractor, backend.NewBasicImageTextExtractor())
-			logger.Info(context.Background(), "image_extract_mode_openai_compatible",
-				zap.String("model", model), zap.String("base_url", baseURL))
-		} else {
-			async.Extractor = backend.NewBasicImageTextExtractor()
-			logger.Info(context.Background(), "image_extract_mode_basic_fallback")
-		}
-
-		opts.AsyncImageExtract = async
+	imageExtract, err := buildImageExtractOptionsFromEnv()
+	if err != nil {
+		return backend.Options{}, err
 	}
-
-	if envBool("DRIVE9_AUDIO_EXTRACT_ENABLED", false) {
-		audioMode := strings.ToLower(strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_MODE")))
-		if audioMode == "" {
-			audioMode = "openai"
-		}
-		audioBaseURL := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_API_BASE"))
-		audioAPIKey := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_API_KEY"))
-		audioModel := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_MODEL"))
-		audioPrompt := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_PROMPT"))
-		if audioBaseURL == "" || audioAPIKey == "" || audioModel == "" {
-			return backend.Options{}, fmt.Errorf("DRIVE9_AUDIO_EXTRACT_API_BASE, DRIVE9_AUDIO_EXTRACT_API_KEY and DRIVE9_AUDIO_EXTRACT_MODEL must be set together when DRIVE9_AUDIO_EXTRACT_ENABLED=true")
-		}
-		audioTimeout := time.Duration(envInt("DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS", 120)) * time.Second
-		var audioExtractor backend.AudioTextExtractor
-		switch audioMode {
-		case "openai":
-			audioResponseFormat := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_RESPONSE_FORMAT"))
-			extractor, err := backend.NewOpenAIAudioTextExtractor(backend.OpenAIAudioTextExtractorConfig{
-				BaseURL:        audioBaseURL,
-				APIKey:         audioAPIKey,
-				Model:          audioModel,
-				Prompt:         audioPrompt,
-				ResponseFormat: audioResponseFormat,
-				Timeout:        audioTimeout,
-			})
-			if err != nil {
-				return backend.Options{}, fmt.Errorf("init openai audio extractor: %w", err)
-			}
-			audioExtractor = extractor
-		case "qwen-asr":
-			extractor, err := backend.NewQwenASRAudioTextExtractor(backend.QwenASRAudioTextExtractorConfig{
-				BaseURL: audioBaseURL,
-				APIKey:  audioAPIKey,
-				Model:   audioModel,
-				Prompt:  audioPrompt,
-				Timeout: audioTimeout,
-			})
-			if err != nil {
-				return backend.Options{}, fmt.Errorf("init qwen asr audio extractor: %w", err)
-			}
-			audioExtractor = extractor
-		default:
-			return backend.Options{}, fmt.Errorf("DRIVE9_AUDIO_EXTRACT_MODE must be %q or %q when DRIVE9_AUDIO_EXTRACT_ENABLED=true (got %q)", "openai", "qwen-asr", audioMode)
-		}
-		opts.AsyncAudioExtract = backend.AsyncAudioExtractOptions{
-			Enabled:             true,
-			MaxAudioBytes:       envInt64("DRIVE9_AUDIO_EXTRACT_MAX_BYTES", 32<<20),
-			TaskTimeout:         audioTimeout,
-			MaxExtractTextBytes: envInt("DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES", 8<<10),
-			Extractor:           audioExtractor,
-		}
-		logger.Info(context.Background(), "audio_extract_mode_configured",
-			zap.String("mode", audioMode), zap.String("model", audioModel), zap.String("base_url", audioBaseURL))
+	if imageExtract.Enabled {
+		opts.AsyncImageExtract = imageExtract
+	}
+	audioExtract, err := buildAudioExtractOptionsFromEnv()
+	if err != nil {
+		return backend.Options{}, err
+	}
+	if audioExtract.Enabled {
+		opts.AsyncAudioExtract = audioExtract
 	}
 	return opts, nil
+}
+
+func buildImageExtractOptionsFromEnv() (backend.AsyncImageExtractOptions, error) {
+	if !envBool("DRIVE9_IMAGE_EXTRACT_ENABLED", false) {
+		return backend.AsyncImageExtractOptions{}, nil
+	}
+	async := backend.AsyncImageExtractOptions{
+		Enabled:             true,
+		QueueSize:           envInt("DRIVE9_IMAGE_EXTRACT_QUEUE_SIZE", 128),
+		Workers:             envInt("DRIVE9_IMAGE_EXTRACT_WORKERS", 1),
+		MaxImageBytes:       envInt64("DRIVE9_IMAGE_EXTRACT_MAX_BYTES", 8<<20),
+		TaskTimeout:         time.Duration(envInt("DRIVE9_IMAGE_EXTRACT_TIMEOUT_SECONDS", 20)) * time.Second,
+		MaxExtractTextBytes: envInt("DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES", 8<<10),
+	}
+
+	baseURL := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_API_BASE"))
+	apiKey := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_API_KEY"))
+	model := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_MODEL"))
+	prompt := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_PROMPT"))
+	maxTokens := envInt("DRIVE9_IMAGE_EXTRACT_MAX_TOKENS", 256)
+
+	configured := baseURL != "" || apiKey != "" || model != ""
+	if configured {
+		if baseURL == "" || apiKey == "" || model == "" {
+			logger.Error(context.Background(), "image_extract_mode_invalid_config",
+				zap.Bool("base_url_present", baseURL != ""),
+				zap.Bool("api_key_present", apiKey != ""),
+				zap.Bool("model_present", model != ""))
+			return backend.AsyncImageExtractOptions{}, fmt.Errorf("DRIVE9_IMAGE_EXTRACT_API_BASE, DRIVE9_IMAGE_EXTRACT_API_KEY and DRIVE9_IMAGE_EXTRACT_MODEL must be set together")
+		}
+		extractor, err := backend.NewOpenAIImageTextExtractor(backend.OpenAIImageTextExtractorConfig{
+			BaseURL:   baseURL,
+			APIKey:    apiKey,
+			Model:     model,
+			Prompt:    prompt,
+			MaxTokens: maxTokens,
+			Timeout:   async.TaskTimeout,
+		})
+		if err != nil {
+			return backend.AsyncImageExtractOptions{}, fmt.Errorf("init image extractor: %w", err)
+		}
+		async.Extractor = backend.NewFallbackImageTextExtractor(extractor, backend.NewBasicImageTextExtractor())
+		logger.Info(context.Background(), "image_extract_mode_openai_compatible",
+			zap.String("model", model), zap.String("base_url", baseURL))
+	} else {
+		async.Extractor = backend.NewBasicImageTextExtractor()
+		logger.Info(context.Background(), "image_extract_mode_basic_fallback")
+	}
+
+	return async, nil
+}
+
+func buildAudioExtractOptionsFromEnv() (backend.AsyncAudioExtractOptions, error) {
+	if !envBool("DRIVE9_AUDIO_EXTRACT_ENABLED", false) {
+		return backend.AsyncAudioExtractOptions{}, nil
+	}
+	audioMode := strings.ToLower(strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_MODE")))
+	if audioMode == "" {
+		audioMode = "openai"
+	}
+	audioBaseURL := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_API_BASE"))
+	audioAPIKey := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_API_KEY"))
+	audioModel := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_MODEL"))
+	audioPrompt := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_PROMPT"))
+	if audioBaseURL == "" || audioAPIKey == "" || audioModel == "" {
+		return backend.AsyncAudioExtractOptions{}, fmt.Errorf("DRIVE9_AUDIO_EXTRACT_API_BASE, DRIVE9_AUDIO_EXTRACT_API_KEY and DRIVE9_AUDIO_EXTRACT_MODEL must be set together when DRIVE9_AUDIO_EXTRACT_ENABLED=true")
+	}
+	audioTimeout := time.Duration(envInt("DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS", 120)) * time.Second
+	var audioExtractor backend.AudioTextExtractor
+	maxAudioBytesDefault := int64(32 << 20)
+	switch audioMode {
+	case "openai":
+		audioResponseFormat := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_RESPONSE_FORMAT"))
+		extractor, err := backend.NewOpenAIAudioTextExtractor(backend.OpenAIAudioTextExtractorConfig{
+			BaseURL:        audioBaseURL,
+			APIKey:         audioAPIKey,
+			Model:          audioModel,
+			Prompt:         audioPrompt,
+			ResponseFormat: audioResponseFormat,
+			Timeout:        audioTimeout,
+		})
+		if err != nil {
+			return backend.AsyncAudioExtractOptions{}, fmt.Errorf("init openai audio extractor: %w", err)
+		}
+		audioExtractor = extractor
+	case "qwen-asr":
+		maxAudioBytesDefault = 10 << 20
+		extractor, err := backend.NewQwenASRAudioTextExtractor(backend.QwenASRAudioTextExtractorConfig{
+			BaseURL: audioBaseURL,
+			APIKey:  audioAPIKey,
+			Model:   audioModel,
+			Prompt:  audioPrompt,
+			Timeout: audioTimeout,
+		})
+		if err != nil {
+			return backend.AsyncAudioExtractOptions{}, fmt.Errorf("init qwen asr audio extractor: %w", err)
+		}
+		audioExtractor = extractor
+	default:
+		return backend.AsyncAudioExtractOptions{}, fmt.Errorf("DRIVE9_AUDIO_EXTRACT_MODE must be %q or %q when DRIVE9_AUDIO_EXTRACT_ENABLED=true (got %q)", "openai", "qwen-asr", audioMode)
+	}
+
+	async := backend.AsyncAudioExtractOptions{
+		Enabled:             true,
+		MaxAudioBytes:       envInt64("DRIVE9_AUDIO_EXTRACT_MAX_BYTES", maxAudioBytesDefault),
+		TaskTimeout:         audioTimeout,
+		MaxExtractTextBytes: envInt("DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES", 8<<10),
+		Extractor:           audioExtractor,
+	}
+	logger.Info(context.Background(), "audio_extract_mode_configured",
+		zap.String("mode", audioMode), zap.String("model", audioModel), zap.String("base_url", audioBaseURL))
+	return async, nil
 }
 
 func buildSemanticWorkerConfigFromEnv() (embedding.Client, server.SemanticWorkerOptions, error) {

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -344,6 +344,7 @@ environment:
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
   DRIVE9_QUOTA_SOURCE tenant|server quota enforcement source (default: tenant)
   DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)
+
   S3 storage (set DRIVE9_S3_BUCKET to enable AWS S3, otherwise local mock):
   DRIVE9_S3_BUCKET   S3 bucket name (enables AWS S3 mode)
   DRIVE9_S3_REGION   AWS region (default: us-east-1)
@@ -355,18 +356,21 @@ environment:
   DRIVE9_S3_SESSION_TOKEN static S3 session token (optional; requires DRIVE9_S3_ACCESS_KEY_ID and DRIVE9_S3_SECRET_ACCESS_KEY)
   DRIVE9_S3_ROLE_ARN IAM role ARN to assume via STS (optional)
   DRIVE9_S3_DIR      local s3 mock root directory (default: ./s3, only used without DRIVE9_S3_BUCKET)
+
   Query embedding (app-side semantic query embedding for grep):
   DRIVE9_QUERY_EMBED_API_BASE OpenAI-compatible base URL (optional)
   DRIVE9_QUERY_EMBED_API_KEY  API key for DRIVE9_QUERY_EMBED_API_BASE (optional)
   DRIVE9_QUERY_EMBED_MODEL    model name for query embedding (optional)
   DRIVE9_QUERY_EMBED_DIMENSIONS optional embedding dimensions override
   DRIVE9_QUERY_EMBED_TIMEOUT_SECONDS embed request timeout seconds (default: 20)
+
   Async semantic embedding worker:
   DRIVE9_EMBED_API_BASE OpenAI-compatible base URL for background embedding (optional)
   DRIVE9_EMBED_API_KEY  API key for DRIVE9_EMBED_API_BASE (optional)
   DRIVE9_EMBED_MODEL    model name for background embedding (optional)
   DRIVE9_EMBED_DIMENSIONS optional embedding dimensions override
   DRIVE9_EMBED_TIMEOUT_SECONDS embed request timeout seconds (default: 20)
+
   DRIVE9_SEMANTIC_WORKERS number of background workers (default: 1)
   DRIVE9_SEMANTIC_POLL_INTERVAL_MS worker poll interval in milliseconds (default: 200)
   DRIVE9_SEMANTIC_LEASE_SECONDS task lease duration in seconds (default: 30)
@@ -375,6 +379,7 @@ environment:
   DRIVE9_SEMANTIC_RETRY_MAX_MS max retry backoff in milliseconds (default: 30000)
   DRIVE9_SEMANTIC_TENANT_LIMIT active tenants scanned per round (default: 128)
   DRIVE9_SEMANTIC_PER_TENANT_CONCURRENCY max concurrent tasks per tenant (default: 1)
+
   Image extraction (async image -> text for search):
   DRIVE9_IMAGE_EXTRACT_ENABLED true|false (default: false)
   DRIVE9_IMAGE_EXTRACT_QUEUE_SIZE buffered task queue size (default: 128)
@@ -387,11 +392,13 @@ environment:
   DRIVE9_IMAGE_EXTRACT_MODEL    model name for vision extraction (optional)
   DRIVE9_IMAGE_EXTRACT_PROMPT   custom extraction prompt (optional)
   DRIVE9_IMAGE_EXTRACT_MAX_TOKENS max model output tokens (default: 256)
+
   Audio extraction (async audio -> text for search; MVP durable path is TiDB auto-embedding only):
   Durable audio_extract_text tasks enqueue only for tenants with database auto-embedding
   (tidb_zero / tidb_cloud_starter). For db9-only or other app-managed tenants these vars do
   not enable that semantic_tasks pipeline. When enabled, explicit provider wiring is required:
   DRIVE9_AUDIO_EXTRACT_ENABLED true|false (default: false)
+  DRIVE9_AUDIO_EXTRACT_MODE     openai|qwen-asr (default: openai)
   DRIVE9_AUDIO_EXTRACT_MAX_BYTES max audio bytes processed per task (default: 33554432)
   DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS extractor timeout seconds (default: 120)
   DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES max transcript bytes stored in files.content_text (default: 8192)
@@ -536,6 +543,10 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 	}
 
 	if envBool("DRIVE9_AUDIO_EXTRACT_ENABLED", false) {
+		audioMode := strings.ToLower(strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_MODE")))
+		if audioMode == "" {
+			audioMode = "openai"
+		}
 		audioBaseURL := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_API_BASE"))
 		audioAPIKey := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_API_KEY"))
 		audioModel := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_MODEL"))
@@ -544,17 +555,36 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 			return backend.Options{}, fmt.Errorf("DRIVE9_AUDIO_EXTRACT_API_BASE, DRIVE9_AUDIO_EXTRACT_API_KEY and DRIVE9_AUDIO_EXTRACT_MODEL must be set together when DRIVE9_AUDIO_EXTRACT_ENABLED=true")
 		}
 		audioTimeout := time.Duration(envInt("DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS", 120)) * time.Second
-		audioResponseFormat := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_RESPONSE_FORMAT"))
-		audioExtractor, err := backend.NewOpenAIAudioTextExtractor(backend.OpenAIAudioTextExtractorConfig{
-			BaseURL:        audioBaseURL,
-			APIKey:         audioAPIKey,
-			Model:          audioModel,
-			Prompt:         audioPrompt,
-			ResponseFormat: audioResponseFormat,
-			Timeout:        audioTimeout,
-		})
-		if err != nil {
-			return backend.Options{}, fmt.Errorf("init audio extractor: %w", err)
+		var audioExtractor backend.AudioTextExtractor
+		switch audioMode {
+		case "openai":
+			audioResponseFormat := strings.TrimSpace(os.Getenv("DRIVE9_AUDIO_EXTRACT_RESPONSE_FORMAT"))
+			extractor, err := backend.NewOpenAIAudioTextExtractor(backend.OpenAIAudioTextExtractorConfig{
+				BaseURL:        audioBaseURL,
+				APIKey:         audioAPIKey,
+				Model:          audioModel,
+				Prompt:         audioPrompt,
+				ResponseFormat: audioResponseFormat,
+				Timeout:        audioTimeout,
+			})
+			if err != nil {
+				return backend.Options{}, fmt.Errorf("init openai audio extractor: %w", err)
+			}
+			audioExtractor = extractor
+		case "qwen-asr":
+			extractor, err := backend.NewQwenASRAudioTextExtractor(backend.QwenASRAudioTextExtractorConfig{
+				BaseURL: audioBaseURL,
+				APIKey:  audioAPIKey,
+				Model:   audioModel,
+				Prompt:  audioPrompt,
+				Timeout: audioTimeout,
+			})
+			if err != nil {
+				return backend.Options{}, fmt.Errorf("init qwen asr audio extractor: %w", err)
+			}
+			audioExtractor = extractor
+		default:
+			return backend.Options{}, fmt.Errorf("DRIVE9_AUDIO_EXTRACT_MODE must be %q or %q when DRIVE9_AUDIO_EXTRACT_ENABLED=true (got %q)", "openai", "qwen-asr", audioMode)
 		}
 		opts.AsyncAudioExtract = backend.AsyncAudioExtractOptions{
 			Enabled:             true,
@@ -563,8 +593,8 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 			MaxExtractTextBytes: envInt("DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES", 8<<10),
 			Extractor:           audioExtractor,
 		}
-		logger.Info(context.Background(), "audio_extract_mode_openai_compatible",
-			zap.String("model", audioModel), zap.String("base_url", audioBaseURL))
+		logger.Info(context.Background(), "audio_extract_mode_configured",
+			zap.String("mode", audioMode), zap.String("model", audioModel), zap.String("base_url", audioBaseURL))
 	}
 	return opts, nil
 }

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -168,6 +168,69 @@ func TestBuildBackendOptionsFromEnvAudioQwenASR(t *testing.T) {
 	}
 }
 
+func TestBuildAudioExtractOptionsFromEnvOpenAIDefaultMaxBytes(t *testing.T) {
+	keys := []string{
+		"DRIVE9_AUDIO_EXTRACT_ENABLED",
+		"DRIVE9_AUDIO_EXTRACT_MODE",
+		"DRIVE9_AUDIO_EXTRACT_API_BASE",
+		"DRIVE9_AUDIO_EXTRACT_API_KEY",
+		"DRIVE9_AUDIO_EXTRACT_MODEL",
+		"DRIVE9_AUDIO_EXTRACT_PROMPT",
+		"DRIVE9_AUDIO_EXTRACT_RESPONSE_FORMAT",
+		"DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS",
+		"DRIVE9_AUDIO_EXTRACT_MAX_BYTES",
+		"DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES",
+	}
+	restore := snapshotEnv(t, keys)
+	t.Cleanup(func() { restoreEnv(t, restore) })
+	unsetEnv(t, keys)
+
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_ENABLED", "true")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MODE", "openai")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_API_BASE", "https://example.com/v1")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_API_KEY", "secret")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MODEL", "whisper-1")
+
+	opts, err := buildAudioExtractOptionsFromEnv()
+	if err != nil {
+		t.Fatalf("buildAudioExtractOptionsFromEnv: %v", err)
+	}
+	if opts.MaxAudioBytes != 33554432 {
+		t.Fatalf("MaxAudioBytes=%d, want 33554432", opts.MaxAudioBytes)
+	}
+}
+
+func TestBuildAudioExtractOptionsFromEnvQwenASRDefaultMaxBytes(t *testing.T) {
+	keys := []string{
+		"DRIVE9_AUDIO_EXTRACT_ENABLED",
+		"DRIVE9_AUDIO_EXTRACT_MODE",
+		"DRIVE9_AUDIO_EXTRACT_API_BASE",
+		"DRIVE9_AUDIO_EXTRACT_API_KEY",
+		"DRIVE9_AUDIO_EXTRACT_MODEL",
+		"DRIVE9_AUDIO_EXTRACT_PROMPT",
+		"DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS",
+		"DRIVE9_AUDIO_EXTRACT_MAX_BYTES",
+		"DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES",
+	}
+	restore := snapshotEnv(t, keys)
+	t.Cleanup(func() { restoreEnv(t, restore) })
+	unsetEnv(t, keys)
+
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_ENABLED", "true")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MODE", "qwen-asr")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_API_BASE", "https://dashscope.aliyuncs.com/compatible-mode/v1")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_API_KEY", "secret")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MODEL", "qwen3-asr-flash")
+
+	opts, err := buildAudioExtractOptionsFromEnv()
+	if err != nil {
+		t.Fatalf("buildAudioExtractOptionsFromEnv: %v", err)
+	}
+	if opts.MaxAudioBytes != 10485760 {
+		t.Fatalf("MaxAudioBytes=%d, want 10485760", opts.MaxAudioBytes)
+	}
+}
+
 func TestS3ConfigFromEnv(t *testing.T) {
 	keys := []string{
 		"DRIVE9_S3_DIR",

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -22,6 +22,7 @@ func TestBuildBackendOptionsFromEnvAudioDisabled(t *testing.T) {
 		"DRIVE9_QUERY_EMBED_MODEL",
 		"DRIVE9_IMAGE_EXTRACT_ENABLED",
 		"DRIVE9_AUDIO_EXTRACT_ENABLED",
+		"DRIVE9_AUDIO_EXTRACT_MODE",
 		"DRIVE9_AUDIO_EXTRACT_API_BASE",
 		"DRIVE9_AUDIO_EXTRACT_API_KEY",
 		"DRIVE9_AUDIO_EXTRACT_MODEL",
@@ -50,6 +51,7 @@ func TestBuildBackendOptionsFromEnvAudioMissingRequiredConfig(t *testing.T) {
 		"DRIVE9_QUERY_EMBED_MODEL",
 		"DRIVE9_IMAGE_EXTRACT_ENABLED",
 		"DRIVE9_AUDIO_EXTRACT_ENABLED",
+		"DRIVE9_AUDIO_EXTRACT_MODE",
 		"DRIVE9_AUDIO_EXTRACT_API_BASE",
 		"DRIVE9_AUDIO_EXTRACT_API_KEY",
 		"DRIVE9_AUDIO_EXTRACT_MODEL",
@@ -79,6 +81,7 @@ func TestBuildBackendOptionsFromEnvAudioOpenAI(t *testing.T) {
 		"DRIVE9_QUERY_EMBED_MODEL",
 		"DRIVE9_IMAGE_EXTRACT_ENABLED",
 		"DRIVE9_AUDIO_EXTRACT_ENABLED",
+		"DRIVE9_AUDIO_EXTRACT_MODE",
 		"DRIVE9_AUDIO_EXTRACT_API_BASE",
 		"DRIVE9_AUDIO_EXTRACT_API_KEY",
 		"DRIVE9_AUDIO_EXTRACT_MODEL",
@@ -96,6 +99,53 @@ func TestBuildBackendOptionsFromEnvAudioOpenAI(t *testing.T) {
 	setEnv(t, "DRIVE9_AUDIO_EXTRACT_API_KEY", "secret")
 	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MODEL", "whisper-1")
 	setEnv(t, "DRIVE9_AUDIO_EXTRACT_PROMPT", "transcribe in zh")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS", "45")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MAX_BYTES", "1234")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES", "5678")
+
+	opts, err := buildBackendOptionsFromEnv()
+	if err != nil {
+		t.Fatalf("buildBackendOptionsFromEnv: %v", err)
+	}
+	if !backend.AsyncAudioExtractWillWireRuntime(opts.AsyncAudioExtract) {
+		t.Fatalf("expected audio runtime wired, got %+v", opts.AsyncAudioExtract)
+	}
+	if opts.AsyncAudioExtract.MaxAudioBytes != 1234 {
+		t.Fatalf("MaxAudioBytes=%d, want 1234", opts.AsyncAudioExtract.MaxAudioBytes)
+	}
+	if opts.AsyncAudioExtract.MaxExtractTextBytes != 5678 {
+		t.Fatalf("MaxExtractTextBytes=%d, want 5678", opts.AsyncAudioExtract.MaxExtractTextBytes)
+	}
+	if got := opts.AsyncAudioExtract.TaskTimeout.Seconds(); got != 45 {
+		t.Fatalf("TaskTimeout=%v, want 45s", opts.AsyncAudioExtract.TaskTimeout)
+	}
+}
+
+func TestBuildBackendOptionsFromEnvAudioQwenASR(t *testing.T) {
+	keys := []string{
+		"DRIVE9_QUERY_EMBED_API_BASE",
+		"DRIVE9_QUERY_EMBED_API_KEY",
+		"DRIVE9_QUERY_EMBED_MODEL",
+		"DRIVE9_IMAGE_EXTRACT_ENABLED",
+		"DRIVE9_AUDIO_EXTRACT_ENABLED",
+		"DRIVE9_AUDIO_EXTRACT_MODE",
+		"DRIVE9_AUDIO_EXTRACT_API_BASE",
+		"DRIVE9_AUDIO_EXTRACT_API_KEY",
+		"DRIVE9_AUDIO_EXTRACT_MODEL",
+		"DRIVE9_AUDIO_EXTRACT_PROMPT",
+		"DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS",
+		"DRIVE9_AUDIO_EXTRACT_MAX_BYTES",
+		"DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES",
+	}
+	restore := snapshotEnv(t, keys)
+	t.Cleanup(func() { restoreEnv(t, restore) })
+	unsetEnv(t, keys)
+
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_ENABLED", "true")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MODE", "qwen-asr")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_API_BASE", "https://dashscope.aliyuncs.com/compatible-mode/v1")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_API_KEY", "secret")
+	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MODEL", "qwen3-asr-flash")
 	setEnv(t, "DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS", "45")
 	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MAX_BYTES", "1234")
 	setEnv(t, "DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES", "5678")

--- a/pkg/backend/audio_extract_qwen_asr.go
+++ b/pkg/backend/audio_extract_qwen_asr.go
@@ -14,6 +14,7 @@ import (
 
 // QwenASRAudioTextExtractorConfig configures Alibaba Cloud Model Studio
 // Qwen-ASR through DashScope's OpenAI-compatible chat/completions endpoint.
+// Reference: https://help.aliyun.com/zh/model-studio/qwen-asr-api-reference
 type QwenASRAudioTextExtractorConfig struct {
 	BaseURL string
 	APIKey  string

--- a/pkg/backend/audio_extract_qwen_asr.go
+++ b/pkg/backend/audio_extract_qwen_asr.go
@@ -1,0 +1,170 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// QwenASRAudioTextExtractorConfig configures Alibaba Cloud Model Studio
+// Qwen-ASR through DashScope's OpenAI-compatible chat/completions endpoint.
+type QwenASRAudioTextExtractorConfig struct {
+	BaseURL string
+	APIKey  string
+	Model   string
+	Prompt  string
+	Timeout time.Duration
+	Client  *http.Client
+}
+
+// QwenASRAudioTextExtractor calls DashScope compatible-mode /chat/completions
+// with an input_audio message and returns the assistant transcript text.
+type QwenASRAudioTextExtractor struct {
+	endpoint string
+	apiKey   string
+	model    string
+	prompt   string
+	client   *http.Client
+}
+
+// NewQwenASRAudioTextExtractor builds an extractor for Qwen3-ASR-Flash.
+func NewQwenASRAudioTextExtractor(cfg QwenASRAudioTextExtractorConfig) (*QwenASRAudioTextExtractor, error) {
+	base := strings.TrimRight(cfg.BaseURL, "/")
+	if base == "" {
+		return nil, fmt.Errorf("qwen asr extractor base url is required")
+	}
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("qwen asr extractor api key is required")
+	}
+	if cfg.Model == "" {
+		return nil, fmt.Errorf("qwen asr extractor model is required")
+	}
+	endpoint := base + "/v1/chat/completions"
+	if strings.HasSuffix(base, "/v1") {
+		endpoint = base + "/chat/completions"
+	}
+	client := cfg.Client
+	if client == nil {
+		timeout := cfg.Timeout
+		if timeout <= 0 {
+			timeout = defaultAudioExtractTimeout
+		}
+		client = &http.Client{Timeout: timeout}
+	}
+	return &QwenASRAudioTextExtractor{
+		endpoint: endpoint,
+		apiKey:   cfg.APIKey,
+		model:    cfg.Model,
+		prompt:   cfg.Prompt,
+		client:   client,
+	}, nil
+}
+
+// ExtractAudioText implements AudioTextExtractor.
+func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req AudioExtractRequest) (string, AudioExtractUsage, error) {
+	select {
+	case <-ctx.Done():
+		return "", AudioExtractUsage{}, ctx.Err()
+	default:
+	}
+
+	contentType := stripMIMEParams(req.ContentType)
+	if contentType == "" {
+		contentType = "audio/mpeg"
+	}
+	audioURL := "data:" + contentType + ";base64," + base64.StdEncoding.EncodeToString(req.Data)
+	messages := make([]map[string]any, 0, 2)
+	if strings.TrimSpace(e.prompt) != "" {
+		messages = append(messages, map[string]any{
+			"role": "system",
+			"content": []map[string]any{
+				{"text": e.prompt},
+			},
+		})
+	}
+	messages = append(messages, map[string]any{
+		"role": "user",
+		"content": []map[string]any{
+			{
+				"type": "input_audio",
+				"input_audio": map[string]any{
+					"data": audioURL,
+				},
+			},
+		},
+	})
+	payload := map[string]any{
+		"model":    e.model,
+		"messages": messages,
+		"stream":   false,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", AudioExtractUsage{}, fmt.Errorf("encode qwen asr request for %q: %w", req.Path, err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", AudioExtractUsage{}, fmt.Errorf("create qwen asr request for %q: %w", req.Path, err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+e.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(httpReq)
+	if err != nil {
+		return "", AudioExtractUsage{}, fmt.Errorf("send qwen asr request for %q: %w", req.Path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", AudioExtractUsage{}, fmt.Errorf("read qwen asr response for %q: %w", req.Path, err)
+	}
+	var parsed struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+		Choices []struct {
+			Message struct {
+				Content any `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage *struct {
+			PromptTokens     int     `json:"prompt_tokens"`
+			CompletionTokens int     `json:"completion_tokens"`
+			Seconds          float64 `json:"seconds"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		if resp.StatusCode >= 300 {
+			return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api status %d: %s", resp.StatusCode, truncateString(string(raw), 256))
+		}
+		return "", AudioExtractUsage{}, fmt.Errorf("decode qwen asr response: %w", err)
+	}
+	if resp.StatusCode >= 300 {
+		if parsed.Error != nil && parsed.Error.Message != "" {
+			return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api status %d: %s", resp.StatusCode, parsed.Error.Message)
+		}
+		return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api status %d", resp.StatusCode)
+	}
+	if len(parsed.Choices) == 0 {
+		return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api returned no choices")
+	}
+	text := extractOpenAIContentText(parsed.Choices[0].Message.Content)
+	if strings.TrimSpace(text) == "" {
+		return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api returned empty text")
+	}
+	var usage AudioExtractUsage
+	if parsed.Usage != nil {
+		usage.InputTokens = parsed.Usage.PromptTokens
+		usage.OutputTokens = parsed.Usage.CompletionTokens
+		usage.DurationSeconds = parsed.Usage.Seconds
+	}
+	return text, usage, nil
+}

--- a/pkg/backend/audio_extract_qwen_asr_test.go
+++ b/pkg/backend/audio_extract_qwen_asr_test.go
@@ -1,0 +1,188 @@
+package backend
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewQwenASRAudioTextExtractorValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  QwenASRAudioTextExtractorConfig
+		want string
+	}{
+		{
+			name: "missing_base_url",
+			cfg: QwenASRAudioTextExtractorConfig{
+				APIKey: "secret",
+				Model:  "qwen3-asr-flash",
+			},
+			want: "qwen asr extractor base url is required",
+		},
+		{
+			name: "missing_api_key",
+			cfg: QwenASRAudioTextExtractorConfig{
+				BaseURL: "https://example.com",
+				Model:   "qwen3-asr-flash",
+			},
+			want: "qwen asr extractor api key is required",
+		},
+		{
+			name: "missing_model",
+			cfg: QwenASRAudioTextExtractorConfig{
+				BaseURL: "https://example.com",
+				APIKey:  "secret",
+			},
+			want: "qwen asr extractor model is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewQwenASRAudioTextExtractor(tc.cfg)
+			if err == nil || err.Error() != tc.want {
+				t.Fatalf("err=%v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewQwenASRAudioTextExtractorEndpointCanonicalization(t *testing.T) {
+	tests := []struct {
+		baseURL string
+		want    string
+	}{
+		{baseURL: "https://dashscope.aliyuncs.com/compatible-mode", want: "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"},
+		{baseURL: "https://dashscope.aliyuncs.com/compatible-mode/", want: "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"},
+		{baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1", want: "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"},
+		{baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1/", want: "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"},
+	}
+
+	for _, tc := range tests {
+		extractor, err := NewQwenASRAudioTextExtractor(QwenASRAudioTextExtractorConfig{
+			BaseURL: tc.baseURL,
+			APIKey:  "secret",
+			Model:   "qwen3-asr-flash",
+		})
+		if err != nil {
+			t.Fatalf("NewQwenASRAudioTextExtractor(%q): %v", tc.baseURL, err)
+		}
+		if extractor.endpoint != tc.want {
+			t.Fatalf("endpoint=%q, want %q", extractor.endpoint, tc.want)
+		}
+	}
+}
+
+func TestQwenASRAudioTextExtractorExtractAudioText(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path=%q, want /v1/chat/completions", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer secret" {
+			t.Fatalf("authorization=%q, want Bearer secret", auth)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Fatalf("content-type=%q, want application/json", ct)
+		}
+		var payload struct {
+			Model    string `json:"model"`
+			Stream   bool   `json:"stream"`
+			Messages []struct {
+				Role    string `json:"role"`
+				Content []struct {
+					Text       string `json:"text"`
+					Type       string `json:"type"`
+					InputAudio *struct {
+						Data string `json:"data"`
+					} `json:"input_audio"`
+				} `json:"content"`
+			} `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload.Model != "qwen3-asr-flash" {
+			t.Fatalf("model=%q, want qwen3-asr-flash", payload.Model)
+		}
+		if payload.Stream {
+			t.Fatal("stream=true, want false")
+		}
+		if len(payload.Messages) != 2 {
+			t.Fatalf("messages=%d, want 2", len(payload.Messages))
+		}
+		if payload.Messages[0].Role != "system" || payload.Messages[0].Content[0].Text != "transcribe in zh" {
+			t.Fatalf("system message=%#v", payload.Messages[0])
+		}
+		user := payload.Messages[1]
+		if user.Role != "user" || len(user.Content) != 1 {
+			t.Fatalf("user message=%#v", user)
+		}
+		audio := user.Content[0]
+		if audio.Type != "input_audio" || audio.InputAudio == nil {
+			t.Fatalf("audio content=%#v", audio)
+		}
+		wantData := "data:audio/mpeg;base64," + base64.StdEncoding.EncodeToString([]byte("fake-mp3"))
+		if audio.InputAudio.Data != wantData {
+			t.Fatalf("audio data=%q, want %q", audio.InputAudio.Data, wantData)
+		}
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":" spoken transcript "}}],"usage":{"prompt_tokens":42,"completion_tokens":7,"seconds":3}}`))
+	}))
+	defer server.Close()
+
+	extractor, err := NewQwenASRAudioTextExtractor(QwenASRAudioTextExtractorConfig{
+		BaseURL: server.URL + "/v1",
+		APIKey:  "secret",
+		Model:   "qwen3-asr-flash",
+		Prompt:  "transcribe in zh",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, usage, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+		Path:        "/audio/clip.mp3",
+		ContentType: "audio/mpeg; charset=binary",
+		Data:        []byte("fake-mp3"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "spoken transcript" {
+		t.Fatalf("text=%q, want spoken transcript", got)
+	}
+	if usage.InputTokens != 42 {
+		t.Fatalf("input_tokens=%d, want 42", usage.InputTokens)
+	}
+	if usage.OutputTokens != 7 {
+		t.Fatalf("output_tokens=%d, want 7", usage.OutputTokens)
+	}
+	if usage.DurationSeconds != 3 {
+		t.Fatalf("duration=%v, want 3", usage.DurationSeconds)
+	}
+}
+
+func TestQwenASRAudioTextExtractorErrorMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":{"message":"upstream unavailable"}}`))
+	}))
+	defer server.Close()
+
+	extractor, err := NewQwenASRAudioTextExtractor(QwenASRAudioTextExtractorConfig{
+		BaseURL: server.URL,
+		APIKey:  "secret",
+		Model:   "qwen3-asr-flash",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = extractor.ExtractAudioText(context.Background(), AudioExtractRequest{Path: "/audio/clip.mp3", Data: []byte("fake")})
+	if err == nil || !strings.Contains(err.Error(), "qwen asr api status 502: upstream unavailable") {
+		t.Fatalf("err=%v, want upstream unavailable status", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Qwen-ASR audio text extractor using DashScope OpenAI-compatible chat completions
- wire DRIVE9_AUDIO_EXTRACT_MODE=qwen-asr for drive9-server and drive9-server-local
- split image/audio extract env parsing and use mode-specific audio size defaults

## Tests
- make test TEST_PKGS='./pkg/backend ./cmd/drive9-server ./cmd/drive9-server-local' TEST_RUN='Test(NewQwenASRAudioTextExtractor|QwenASRAudioTextExtractor|BuildBackendOptionsFromEnvAudio|BuildAudioExtractOptionsFromEnv)'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added Qwen-ASR as an alternative audio extraction mode alongside existing options
- Audio transcription now supports configurable extraction backends with service-specific settings and defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->