### PR TITLE
feat: --cache-dir flag + disk watermark + ShadowSpill CommitQueue tests

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -62,6 +62,7 @@ func fsMountCmd(args []string) error {
 	fs := flag.NewFlagSet("mount", flag.ExitOnError)
 	server := fs.String("server", "", "drive9 server URL (overrides $DRIVE9_SERVER and config)")
 	apiKey := fs.String("api-key", "", "owner API key (overrides $DRIVE9_API_KEY and config)")
+	cacheDir := fs.String("cache-dir", "", "write-back cache directory (default ~/.cache/drive9)")
 	cacheSize := fs.Int("cache-size", 128, "read cache size in MB")
 	dirTTL := fs.Duration("dir-ttl", 10*time.Second, "directory cache TTL")
 	attrTTL := fs.Duration("attr-ttl", 10*time.Second, "kernel attr cache TTL")
@@ -122,6 +123,7 @@ func fsMountCmd(args []string) error {
 		APIKey:             *apiKey,
 		Token:              token,
 		MountPoint:         mountPoint,
+		CacheDir:           *cacheDir,
 		CacheSize:          int64(*cacheSize) << 20,
 		DirTTL:             *dirTTL,
 		AttrTTL:            *attrTTL,

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -1,6 +1,8 @@
 package fuse
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -407,5 +409,199 @@ func TestCommitQueueRecoverPendingSkipsLegacyOverwriteWithoutBaseRev(t *testing.
 	}
 	if !shadow.Has("/legacy.txt") {
 		t.Fatal("legacy shadow should remain after skipped recovery")
+	}
+}
+
+// --- ShadowSpill tests ---
+
+// TestCommitQueueShadowSpillUpload verifies that ShadowSpill entries are
+// uploaded via streaming (uploadFromShadow) rather than ReadAll, and that
+// the server receives the correct data and expected revision.
+func TestCommitQueueShadowSpillUpload(t *testing.T) {
+	var gotExpected string
+	var gotBody []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotExpected = r.Header.Get("X-Dat9-Expected-Revision")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write data to shadow file (simulates what Write() + ShadowSpill does).
+	data := bytes.Repeat([]byte("shadowspill-data-"), 100) // ~1700 bytes
+	if err := shadow.WriteFull("/big.bin", data, 12); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/big.bin", int64(len(data)), PendingOverwrite, 12); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:        "/big.bin",
+		BaseRev:     12,
+		Size:        int64(len(data)),
+		Kind:        PendingOverwrite,
+		ShadowSpill: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if gotExpected != "12" {
+		t.Fatalf("expected revision header = %q, want 12", gotExpected)
+	}
+	if !bytes.Equal(gotBody, data) {
+		t.Fatalf("server received %d bytes, want %d", len(gotBody), len(data))
+	}
+	if pending.HasPending("/big.bin") {
+		t.Fatal("pending entry should be removed after successful ShadowSpill commit")
+	}
+	if shadow.Has("/big.bin") {
+		t.Fatal("shadow should be removed after successful ShadowSpill commit")
+	}
+}
+
+// TestCommitQueueShadowSpillConflictTerminal verifies that ShadowSpill entries
+// skip auto-resolve (which would OOM) and go straight to terminal failure.
+func TestCommitQueueShadowSpillConflictTerminal(t *testing.T) {
+	var calls int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := shadow.WriteFull("/big-conflict.bin", []byte("data"), 5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/big-conflict.bin", 4, PendingOverwrite, 5); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:        "/big-conflict.bin",
+		BaseRev:     5,
+		Size:        4,
+		Kind:        PendingOverwrite,
+		ShadowSpill: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	// ShadowSpill: 409 → skip auto-resolve → terminal failure immediately.
+	// Only 1 call: the initial upload (no Stat/Read for auto-resolve).
+	if calls != 1 {
+		t.Fatalf("expected 1 call (upload only, no auto-resolve), got %d", calls)
+	}
+	if !pending.HasPending("/big-conflict.bin") {
+		t.Fatal("pending entry should be preserved after ShadowSpill terminal conflict")
+	}
+	meta, ok := pending.GetMeta("/big-conflict.bin")
+	if !ok || meta.Kind != PendingConflict {
+		t.Fatalf("pending entry should be PendingConflict, got kind=%v ok=%v", meta.Kind, ok)
+	}
+	if !shadow.Has("/big-conflict.bin") {
+		t.Fatal("shadow should be preserved after ShadowSpill terminal conflict")
+	}
+}
+
+// TestCommitQueueRecoverPendingShadowSpill verifies that crash recovery
+// preserves the ShadowSpill flag so recovered entries use streaming upload
+// (not ReadAll which would OOM for large files).
+func TestCommitQueueRecoverPendingShadowSpill(t *testing.T) {
+	var gotBody []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	shadowDir := t.TempDir()
+	pendingDir := t.TempDir()
+
+	// Phase 1: create pending entry with ShadowSpill=true, then "crash" (close everything).
+	shadow1, err := NewShadowStore(shadowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending1, err := NewPendingIndex(pendingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := bytes.Repeat([]byte("recover-"), 200)
+	if err := shadow1.WriteFull("/recover.bin", data, 8); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending1.PutShadowSpill("/recover.bin", int64(len(data)), PendingOverwrite, 8); err != nil {
+		t.Fatal(err)
+	}
+	shadow1.Close()
+
+	// Phase 2: "restart" — reopen stores and recover.
+	shadow2, err := NewShadowStore(shadowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow2.Close()
+	if err := shadow2.RecoverFromDisk(); err != nil {
+		t.Fatal(err)
+	}
+	pending2, err := NewPendingIndex(pendingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pending2.RecoverFromDisk(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the recovered meta has ShadowSpill=true.
+	meta, ok := pending2.GetMeta("/recover.bin")
+	if !ok {
+		t.Fatal("pending entry should survive restart")
+	}
+	if !meta.ShadowSpill {
+		t.Fatal("ShadowSpill flag must be persisted and recovered from disk")
+	}
+
+	// RecoverPending should reconstruct CommitEntry with ShadowSpill=true,
+	// causing uploadEntry to use streaming (uploadFromShadow) not ReadAll.
+	cq := NewCommitQueue(client.New(ts.URL, ""), shadow2, pending2, nil, 1, 8)
+	cq.RecoverPending()
+	cq.DrainAll()
+
+	// Verify data arrived correctly at the server (streaming upload worked).
+	if !bytes.Equal(gotBody, data) {
+		t.Fatalf("server received %d bytes, want %d", len(gotBody), len(data))
+	}
+	if pending2.HasPending("/recover.bin") {
+		t.Fatal("pending entry should be removed after successful recovery upload")
+	}
+	if shadow2.Has("/recover.bin") {
+		t.Fatal("shadow should be removed after successful recovery upload")
 	}
 }

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2047,6 +2047,10 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 	// EIO without touching Dirty — OnPartFull may evict the part, so writing
 	// Dirty first could lose data if shadow then fails.
 	if fh.ShadowSpill && fh.ShadowReady && fs.shadowStore != nil {
+		if !fs.shadowStore.CheckDiskSpaceThrottled() {
+			log.Printf("shadow write rejected for %s: disk space below watermark", fh.Path)
+			return 0, gofuse.Status(syscall.ENOSPC)
+		}
 		if _, err := fs.shadowStore.WriteAt(fh.Path, int64(input.Offset), data, fh.BaseRev); err != nil {
 			log.Printf("shadow write failed for ShadowSpill %s: %v", fh.Path, err)
 			return 0, gofuse.EIO

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
+	"time"
 )
 
 // smallFileShadowThreshold is the maximum file size for cached I/O mode.
@@ -15,6 +17,9 @@ const smallFileShadowThreshold = 64 << 20 // 64MB
 // diskWatermarkBytes is the minimum free disk space before ShadowStore
 // refuses to stage new writes and logs a warning.
 const diskWatermarkBytes = 1 << 30 // 1GB
+
+// diskCheckInterval is the minimum time between disk space checks.
+const diskCheckInterval = 5 * time.Second
 
 // ShadowFile represents a per-path local shadow file with extent tracking.
 type ShadowFile struct {
@@ -37,6 +42,10 @@ type ShadowStore struct {
 	dir   string
 	mu    sync.RWMutex
 	files map[string]*ShadowFile // remote path → shadow file
+
+	// Throttled disk space check state (atomic for lock-free fast path).
+	lastDiskCheck atomic.Int64 // unix nano of last check
+	diskOK        atomic.Bool  // cached result of last check
 }
 
 // NewShadowStore creates a ShadowStore rooted at dir.
@@ -44,10 +53,12 @@ func NewShadowStore(dir string) (*ShadowStore, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("shadow store dir: %w", err)
 	}
-	return &ShadowStore{
+	ss := &ShadowStore{
 		dir:   dir,
 		files: make(map[string]*ShadowFile),
-	}, nil
+	}
+	ss.diskOK.Store(true)
+	return ss, nil
 }
 
 // shadowPath returns the filesystem path for a shadow file.
@@ -63,6 +74,23 @@ func (s *ShadowStore) CheckDiskSpace() bool {
 	}
 	avail := int64(stat.Bavail) * int64(stat.Bsize)
 	return avail >= diskWatermarkBytes
+}
+
+// CheckDiskSpaceThrottled returns the cached disk space result, refreshing at
+// most once per diskCheckInterval. Safe for hot-path use (lock-free fast path).
+func (s *ShadowStore) CheckDiskSpaceThrottled() bool {
+	now := time.Now().UnixNano()
+	last := s.lastDiskCheck.Load()
+	if now-last < int64(diskCheckInterval) {
+		return s.diskOK.Load()
+	}
+	// CAS to avoid concurrent syscalls.
+	if s.lastDiskCheck.CompareAndSwap(last, now) {
+		ok := s.CheckDiskSpace()
+		s.diskOK.Store(ok)
+		return ok
+	}
+	return s.diskOK.Load()
 }
 
 func (s *ShadowStore) ensureShadowFile(remotePath string, baseRev int64) (*ShadowFile, error) {

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -170,3 +170,26 @@ func TestShadowStoreCheckDiskSpace(t *testing.T) {
 	// Just verify the function doesn't panic.
 	_ = ss.CheckDiskSpace()
 }
+
+func TestShadowStoreCheckDiskSpaceThrottled(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// First call should run the real check and cache result.
+	r1 := ss.CheckDiskSpaceThrottled()
+
+	// Second call within the interval should return cached result without syscall.
+	r2 := ss.CheckDiskSpaceThrottled()
+	if r1 != r2 {
+		t.Fatalf("throttled results differ: %v vs %v", r1, r2)
+	}
+
+	// Verify initial diskOK state matches the real check.
+	if r1 != ss.CheckDiskSpace() {
+		t.Fatal("throttled result does not match real check")
+	}
+}


### PR DESCRIPTION
## Summary
- Expose `--cache-dir` CLI flag for `drive9 mount` so users can control where shadow files go (critical for small root disks with large file writes)
- Add `CheckDiskSpaceThrottled()` to ShadowStore — lock-free atomic CAS-based check that runs `statfs` at most once per 5s, suitable for hot Write path
- Wire ENOSPC guard into ShadowSpill Write path: rejects writes when disk below 1GB watermark
- Add 3 CommitQueue regression tests for ShadowSpill paths (streaming upload, conflict terminal, crash recovery)
- Add CheckDiskSpaceThrottled unit test

## Test plan
- [x] `TestCommitQueueShadowSpillUpload` — streaming upload data correctness + expected revision header
- [x] `TestCommitQueueShadowSpillConflictTerminal` — 409 skips auto-resolve, goes to terminal failure
- [x] `TestCommitQueueRecoverPendingShadowSpill` — crash recovery round-trip preserves ShadowSpill flag
- [x] `TestShadowStoreCheckDiskSpaceThrottled` — throttled check returns consistent cached results
- [x] All existing CommitQueue + ShadowStore tests pass
- [x] CLI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)