### PR TITLE
feat: StatLite + ReadPlanCtx for lightweight stat/read (Issue #328 MVP 1+2)

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -660,6 +660,68 @@ func (b *Dat9Backend) StatNodeLiteCtx(ctx context.Context, path string) (*datast
 	return b.store.StatPathFallbackLite(ctx, resolvedPath, dirPath)
 }
 
+// ReadPlan describes how to serve a GET request after a single metadata query.
+type ReadPlan struct {
+	// InlineData is non-nil for db9-stored files — the body to return directly.
+	InlineData []byte
+	// PresignURL is non-empty for S3-stored files — the 302 redirect target.
+	PresignURL string
+	// Size is the file size in bytes.
+	Size int64
+}
+
+// ReadPlanCtx resolves a file path into a ReadPlan with a single metadata query.
+// For db9 inline files: returns InlineData (no second stat needed).
+// For S3 files: uses the storage_ref from the same query to presign, returns PresignURL.
+func (b *Dat9Backend) ReadPlanCtx(ctx context.Context, path string) (*ReadPlan, error) {
+	resolvedPath := normalizePath(path)
+	var nf *datastore.NodeWithFile
+	var err error
+
+	if pathutil.IsDir(path) {
+		nf, err = b.store.StatForRead(ctx, resolvedPath)
+	} else {
+		dirPath, dirErr := pathutil.CanonicalizeDir(path)
+		if dirErr != nil || dirPath == resolvedPath {
+			nf, err = b.store.StatForRead(ctx, resolvedPath)
+		} else {
+			nf, err = b.store.StatPathFallbackForRead(ctx, resolvedPath, dirPath)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if nf.Node.IsDirectory {
+		return nil, fmt.Errorf("is a directory: %s", resolvedPath)
+	}
+	if nf.File == nil {
+		return nil, fmt.Errorf("no file entity for path: %s", resolvedPath)
+	}
+
+	switch nf.File.StorageType {
+	case datastore.StorageDB9:
+		return &ReadPlan{
+			InlineData: nf.File.ContentBlob,
+			Size:       nf.File.SizeBytes,
+		}, nil
+	case datastore.StorageS3:
+		if b.s3 == nil {
+			return nil, ErrS3NotConfigured
+		}
+		url, err := b.s3.PresignGetObject(ctx, nf.File.StorageRef, s3client.DownloadTTL)
+		if err != nil {
+			logger.Error(ctx, "backend_read_plan_presign_failed", zap.String("path", resolvedPath), zap.Error(err))
+			return nil, err
+		}
+		return &ReadPlan{
+			PresignURL: url,
+			Size:       nf.File.SizeBytes,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported storage type for read plan: %s", nf.File.StorageType)
+	}
+}
+
 func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {
 	ctx := backgroundWithTrace()
 	nf, err := b.StatNodeCtx(ctx, path)

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -645,6 +645,21 @@ func (b *Dat9Backend) StatNodeCtx(ctx context.Context, path string) (*datastore.
 	return b.store.StatPathFallback(ctx, resolvedPath, dirPath)
 }
 
+// StatNodeLiteCtx returns lightweight metadata (no blob/text/description)
+// suitable for HEAD/stat operations.
+func (b *Dat9Backend) StatNodeLiteCtx(ctx context.Context, path string) (*datastore.NodeWithFile, error) {
+	resolvedPath := normalizePath(path)
+	if pathutil.IsDir(path) {
+		return b.store.StatLite(ctx, resolvedPath)
+	}
+
+	dirPath, dirErr := pathutil.CanonicalizeDir(path)
+	if dirErr != nil || dirPath == resolvedPath {
+		return b.store.StatLite(ctx, resolvedPath)
+	}
+	return b.store.StatPathFallbackLite(ctx, resolvedPath, dirPath)
+}
+
 func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {
 	ctx := backgroundWithTrace()
 	nf, err := b.StatNodeCtx(ctx, path)

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -673,29 +673,22 @@ type ReadPlan struct {
 // ReadPlanCtx resolves a file path into a ReadPlan with a single metadata query.
 // For db9 inline files: returns InlineData (no second stat needed).
 // For S3 files: uses the storage_ref from the same query to presign, returns PresignURL.
+// Only resolves file-form paths (no directory fallback) to maintain GET /dir → 404 behavior.
 func (b *Dat9Backend) ReadPlanCtx(ctx context.Context, path string) (*ReadPlan, error) {
-	resolvedPath := normalizePath(path)
-	var nf *datastore.NodeWithFile
-	var err error
-
-	if pathutil.IsDir(path) {
-		nf, err = b.store.StatForRead(ctx, resolvedPath)
-	} else {
-		dirPath, dirErr := pathutil.CanonicalizeDir(path)
-		if dirErr != nil || dirPath == resolvedPath {
-			nf, err = b.store.StatForRead(ctx, resolvedPath)
-		} else {
-			nf, err = b.store.StatPathFallbackForRead(ctx, resolvedPath, dirPath)
-		}
+	resolvedPath, err := pathutil.Canonicalize(path)
+	if err != nil {
+		return nil, err
 	}
+
+	nf, err := b.store.StatForRead(ctx, resolvedPath)
 	if err != nil {
 		return nil, err
 	}
 	if nf.Node.IsDirectory {
-		return nil, fmt.Errorf("is a directory: %s", resolvedPath)
+		return nil, datastore.ErrNotFound
 	}
 	if nf.File == nil {
-		return nil, fmt.Errorf("no file entity for path: %s", resolvedPath)
+		return nil, datastore.ErrNotFound
 	}
 
 	switch nf.File.StorageType {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -779,6 +779,39 @@ func (s *Store) StatPathFallback(ctx context.Context, primaryPath, fallbackPath 
 	return out, err
 }
 
+// StatPathFallbackLite is like StatPathFallback but only fetches lightweight
+// metadata fields needed for FUSE stat/HEAD operations. It skips content_blob,
+// content_text, description, embedding columns, checksum, and source_id.
+func (s *Store) StatPathFallbackLite(ctx context.Context, primaryPath, fallbackPath string) (out *NodeWithFile, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "stat_path_fallback_lite", start, &err)
+
+	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
+		f.file_id, f.size_bytes, f.revision, f.status, f.created_at, f.confirmed_at
+		FROM file_nodes fn
+		LEFT JOIN files f ON fn.file_id = f.file_id AND fn.is_directory = 0 AND f.status = 'CONFIRMED'
+		WHERE fn.path = ? OR fn.path = ?
+		ORDER BY CASE WHEN fn.path = ? THEN 0 ELSE 1 END
+		LIMIT 1`, primaryPath, fallbackPath, primaryPath)
+	out, err = scanNodeWithFileLite(row)
+	return out, err
+}
+
+// StatLite is like Stat but only fetches lightweight metadata fields.
+func (s *Store) StatLite(ctx context.Context, path string) (out *NodeWithFile, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "stat_lite", start, &err)
+
+	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
+		f.file_id, f.size_bytes, f.revision, f.status, f.created_at, f.confirmed_at
+		FROM file_nodes fn
+		LEFT JOIN files f ON fn.file_id = f.file_id AND fn.is_directory = 0 AND f.status = 'CONFIRMED'
+		WHERE fn.path = ?
+		LIMIT 1`, path)
+	out, err = scanNodeWithFileLite(row)
+	return out, err
+}
+
 func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWithFile, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "list_dir", start, &err)
@@ -1293,6 +1326,52 @@ func scanNodeWithFileWithBlob(s scanner) (*NodeWithFile, error) {
 		if fExpiresAt.Valid {
 			t := fExpiresAt.Time.UTC()
 			nf.File.ExpiresAt = &t
+		}
+	}
+	return nf, nil
+}
+
+// scanNodeWithFileLite scans a lite result set that only includes metadata
+// fields needed for stat/HEAD: node fields + file_id, size_bytes, revision,
+// status, created_at, confirmed_at. No blob/text/description/embedding columns.
+func scanNodeWithFileLite(s scanner) (*NodeWithFile, error) {
+	var n FileNode
+	var isDir int
+	var nodeFileID sql.NullString
+	var nodeCreatedAt time.Time
+
+	var fFileID sql.NullString
+	var fSizeBytes, fRevision sql.NullInt64
+	var fStatus sql.NullString
+	var fCreatedAt, fConfirmedAt sql.NullTime
+
+	err := s.Scan(&n.NodeID, &n.Path, &n.ParentPath, &n.Name, &isDir, &nodeFileID, &nodeCreatedAt,
+		&fFileID, &fSizeBytes, &fRevision, &fStatus, &fCreatedAt, &fConfirmedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	n.IsDirectory = isDir != 0
+	n.FileID = nodeFileID.String
+	n.CreatedAt = nodeCreatedAt.UTC()
+
+	nf := &NodeWithFile{Node: n}
+	if fFileID.Valid {
+		nf.File = &File{
+			FileID:   fFileID.String,
+			SizeBytes: fSizeBytes.Int64,
+			Revision:  fRevision.Int64,
+			Status:    FileStatus(fStatus.String),
+		}
+		if fCreatedAt.Valid {
+			nf.File.CreatedAt = fCreatedAt.Time.UTC()
+		}
+		if fConfirmedAt.Valid {
+			t := fConfirmedAt.Time.UTC()
+			nf.File.ConfirmedAt = &t
 		}
 	}
 	return nf, nil

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -812,6 +812,40 @@ func (s *Store) StatLite(ctx context.Context, path string) (out *NodeWithFile, e
 	return out, err
 }
 
+// StatForRead fetches the minimal fields needed to serve a GET request in a
+// single pass: storage_type, storage_ref, content_blob (for db9), size_bytes,
+// revision, and confirmed_at. This avoids the two-stat pattern of
+// PresignGetObject-then-ReadCtx.
+func (s *Store) StatForRead(ctx context.Context, path string) (out *NodeWithFile, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "stat_for_read", start, &err)
+
+	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
+		f.file_id, f.storage_type, f.storage_ref, f.content_blob, f.size_bytes, f.revision, f.status, f.created_at, f.confirmed_at
+		FROM file_nodes fn
+		LEFT JOIN files f ON fn.file_id = f.file_id AND fn.is_directory = 0 AND f.status = 'CONFIRMED'
+		WHERE fn.path = ?
+		LIMIT 1`, path)
+	out, err = scanNodeWithFileForRead(row)
+	return out, err
+}
+
+// StatPathFallbackForRead is like StatForRead but with primary/fallback path resolution.
+func (s *Store) StatPathFallbackForRead(ctx context.Context, primaryPath, fallbackPath string) (out *NodeWithFile, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "stat_path_fallback_for_read", start, &err)
+
+	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
+		f.file_id, f.storage_type, f.storage_ref, f.content_blob, f.size_bytes, f.revision, f.status, f.created_at, f.confirmed_at
+		FROM file_nodes fn
+		LEFT JOIN files f ON fn.file_id = f.file_id AND fn.is_directory = 0 AND f.status = 'CONFIRMED'
+		WHERE fn.path = ? OR fn.path = ?
+		ORDER BY CASE WHEN fn.path = ? THEN 0 ELSE 1 END
+		LIMIT 1`, primaryPath, fallbackPath, primaryPath)
+	out, err = scanNodeWithFileForRead(row)
+	return out, err
+}
+
 func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWithFile, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "list_dir", start, &err)
@@ -1326,6 +1360,57 @@ func scanNodeWithFileWithBlob(s scanner) (*NodeWithFile, error) {
 		if fExpiresAt.Valid {
 			t := fExpiresAt.Time.UTC()
 			nf.File.ExpiresAt = &t
+		}
+	}
+	return nf, nil
+}
+
+// scanNodeWithFileForRead scans the result set for ReadPlan: node fields +
+// file_id, storage_type, storage_ref, content_blob, size_bytes, revision,
+// status, created_at, confirmed_at. Includes blob for db9 inline reads but
+// excludes content_text, description, embedding columns.
+func scanNodeWithFileForRead(s scanner) (*NodeWithFile, error) {
+	var n FileNode
+	var isDir int
+	var nodeFileID sql.NullString
+	var nodeCreatedAt time.Time
+
+	var fFileID, fStorageType, fStorageRef sql.NullString
+	var fContentBlob []byte
+	var fSizeBytes, fRevision sql.NullInt64
+	var fStatus sql.NullString
+	var fCreatedAt, fConfirmedAt sql.NullTime
+
+	err := s.Scan(&n.NodeID, &n.Path, &n.ParentPath, &n.Name, &isDir, &nodeFileID, &nodeCreatedAt,
+		&fFileID, &fStorageType, &fStorageRef, &fContentBlob, &fSizeBytes, &fRevision, &fStatus, &fCreatedAt, &fConfirmedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	n.IsDirectory = isDir != 0
+	n.FileID = nodeFileID.String
+	n.CreatedAt = nodeCreatedAt.UTC()
+
+	nf := &NodeWithFile{Node: n}
+	if fFileID.Valid {
+		nf.File = &File{
+			FileID:      fFileID.String,
+			StorageType: StorageType(fStorageType.String),
+			StorageRef:  fStorageRef.String,
+			ContentBlob: append([]byte(nil), fContentBlob...),
+			SizeBytes:   fSizeBytes.Int64,
+			Revision:    fRevision.Int64,
+			Status:      FileStatus(fStatus.String),
+		}
+		if fCreatedAt.Valid {
+			nf.File.CreatedAt = fCreatedAt.Time.UTC()
+		}
+		if fConfirmedAt.Valid {
+			t := fConfirmedAt.Time.UTC()
+			nf.File.ConfirmedAt = &t
 		}
 	}
 	return nf, nil

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -209,6 +209,50 @@ func TestStatPathFallbackLite(t *testing.T) {
 	}
 }
 
+func TestStatForRead(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	if err := s.InsertFile(ctx, &File{
+		FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		ContentBlob: []byte("inline data here"), SizeBytes: 16, Revision: 5,
+		Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(ctx, &FileNode{NodeID: "n1", Path: "/read.txt", ParentPath: "/", Name: "read.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	nf, err := s.StatForRead(ctx, "/read.txt")
+	if err != nil {
+		t.Fatalf("StatForRead: %v", err)
+	}
+	if nf.File == nil {
+		t.Fatal("file is nil")
+	}
+	// StatForRead MUST return storage_type + content_blob for inline reads.
+	if nf.File.StorageType != StorageDB9 {
+		t.Fatalf("storage_type=%q, want db9", nf.File.StorageType)
+	}
+	if string(nf.File.ContentBlob) != "inline data here" {
+		t.Fatalf("content_blob=%q, want 'inline data here'", nf.File.ContentBlob)
+	}
+	if nf.File.SizeBytes != 16 {
+		t.Fatalf("size=%d, want 16", nf.File.SizeBytes)
+	}
+	if nf.File.Revision != 5 {
+		t.Fatalf("revision=%d, want 5", nf.File.Revision)
+	}
+	// But it should NOT return text/description/embedding fields.
+	if nf.File.ContentText != "" {
+		t.Fatalf("ContentText should be empty, got %q", nf.File.ContentText)
+	}
+	if nf.File.Description != "" {
+		t.Fatalf("Description should be empty, got %q", nf.File.Description)
+	}
+}
+
 func TestListDir(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -118,6 +118,97 @@ func TestStat(t *testing.T) {
 	requireEmbeddingRevision(t, nf.File.EmbeddingRevision, 11)
 }
 
+func TestStatLite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	// Insert a file with content_blob and content_text populated.
+	if err := s.InsertFile(ctx, &File{
+		FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		ContentBlob: []byte("hello world"), ContentText: "hello world",
+		SizeBytes: 11, Revision: 3, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().Exec(`UPDATE files SET description = 'test desc' WHERE file_id = 'f1'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(ctx, &FileNode{NodeID: "n1", Path: "/lite.txt", ParentPath: "/", Name: "lite.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	// StatLite should return metadata but NOT blob/text/description.
+	nf, err := s.StatLite(ctx, "/lite.txt")
+	if err != nil {
+		t.Fatalf("StatLite: %v", err)
+	}
+	if nf.Node.Path != "/lite.txt" {
+		t.Fatalf("path=%q, want /lite.txt", nf.Node.Path)
+	}
+	if nf.File == nil {
+		t.Fatal("StatLite: file is nil")
+	}
+	if nf.File.SizeBytes != 11 {
+		t.Fatalf("size=%d, want 11", nf.File.SizeBytes)
+	}
+	if nf.File.Revision != 3 {
+		t.Fatalf("revision=%d, want 3", nf.File.Revision)
+	}
+	if nf.File.ConfirmedAt == nil {
+		t.Fatal("confirmed_at is nil")
+	}
+	// These fields must be zero/empty — lite path does not fetch them.
+	if len(nf.File.ContentBlob) != 0 {
+		t.Fatalf("ContentBlob should be empty in lite path, got %d bytes", len(nf.File.ContentBlob))
+	}
+	if nf.File.ContentText != "" {
+		t.Fatalf("ContentText should be empty in lite path, got %q", nf.File.ContentText)
+	}
+	if nf.File.Description != "" {
+		t.Fatalf("Description should be empty in lite path, got %q", nf.File.Description)
+	}
+	if nf.File.StorageType != "" {
+		t.Fatalf("StorageType should be empty in lite path, got %q", nf.File.StorageType)
+	}
+}
+
+func TestStatPathFallbackLite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	if err := s.InsertFile(ctx, &File{
+		FileID: "f2", StorageType: StorageDB9, StorageRef: "/blobs/f2",
+		ContentBlob: []byte("data"), SizeBytes: 4, Revision: 7,
+		Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(ctx, &FileNode{NodeID: "n2", Path: "/fb.txt", ParentPath: "/", Name: "fb.txt", FileID: "f2", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Primary path match.
+	nf, err := s.StatPathFallbackLite(ctx, "/fb.txt", "/nonexist")
+	if err != nil {
+		t.Fatalf("StatPathFallbackLite: %v", err)
+	}
+	if nf.File == nil || nf.File.Revision != 7 {
+		t.Fatalf("unexpected file: %+v", nf.File)
+	}
+	if len(nf.File.ContentBlob) != 0 {
+		t.Fatal("lite fallback should not return ContentBlob")
+	}
+
+	// Fallback path match.
+	nf2, err := s.StatPathFallbackLite(ctx, "/nonexist", "/fb.txt")
+	if err != nil {
+		t.Fatalf("StatPathFallbackLite fallback: %v", err)
+	}
+	if nf2.File == nil || nf2.File.Revision != 7 {
+		t.Fatalf("fallback: unexpected file: %+v", nf2.File)
+	}
+}
+
 func TestListDir(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -491,17 +491,10 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
-	if b.S3() != nil {
-		url, err := b.PresignGetObject(r.Context(), path)
-		if err == nil {
-			logger.Info(r.Context(), "server_event", eventFields(r.Context(), "read_presigned_redirect", "path", path)...)
-			metricEvent(r.Context(), "fs_read", "result", "ok")
-			http.Redirect(w, r, url, http.StatusFound)
-			return
-		}
-	}
 
-	data, err := b.ReadCtx(r.Context(), path, 0, -1)
+	// Single-pass read plan: one metadata query routes to either inline
+	// response (db9) or presigned redirect (S3). No fallback double-stat.
+	plan, err := b.ReadPlanCtx(r.Context(), path)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "read_not_found", "path", path)...)
@@ -514,11 +507,19 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "read_ok", "path", path, "bytes", len(data))...)
+
+	if plan.PresignURL != "" {
+		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "read_presigned_redirect", "path", path)...)
+		metricEvent(r.Context(), "fs_read", "result", "ok")
+		http.Redirect(w, r, plan.PresignURL, http.StatusFound)
+		return
+	}
+
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "read_ok", "path", path, "bytes", len(plan.InlineData))...)
 	metricEvent(r.Context(), "fs_read", "result", "ok")
 	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
-	_, _ = w.Write(data)
+	w.Header().Set("Content-Length", strconv.Itoa(len(plan.InlineData)))
+	_, _ = w.Write(plan.InlineData)
 }
 
 func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -984,7 +984,7 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
-	nf, err := b.StatNodeCtx(r.Context(), path)
+	nf, err := b.StatNodeLiteCtx(r.Context(), path)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "stat_not_found", "path", path)...)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -106,6 +106,65 @@ func TestWriteAndRead(t *testing.T) {
 	}
 }
 
+func TestReadInlineNoRedirect(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Write a small file (db-inline, no S3).
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/inline.txt", strings.NewReader("tiny"))
+	resp, _ := http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+
+	// GET should return 200 with inline body, not a 302 redirect.
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse // don't follow redirects
+	}}
+	resp, err := client.Get(ts.URL + "/v1/fs/inline.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200 for db-inline GET, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "tiny" {
+		t.Errorf("body=%q, want 'tiny'", body)
+	}
+}
+
+func TestReadDirectoryReturns404(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Create a directory by writing a file inside it.
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/mydir/file.txt", strings.NewReader("x"))
+	resp, _ := http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+
+	// GET on the directory path should return 404, not 500.
+	resp, err := http.Get(ts.URL + "/v1/fs/mydir/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Fatalf("GET directory: expected 404, got %d", resp.StatusCode)
+	}
+
+	// Also test without trailing slash.
+	resp, err = http.Get(ts.URL + "/v1/fs/mydir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Fatalf("GET directory (no slash): expected 404, got %d", resp.StatusCode)
+	}
+}
+
 func TestListDir(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary
**MVP 1 (StatLite):** Metadata-only stat queries for HEAD/Lookup/GetAttr
- `StatLite` / `StatPathFallbackLite` + `scanNodeWithFileLite` — skips content_blob, content_text, description, embeddings
- `StatNodeLiteCtx` in backend, `handleStat` uses it

**MVP 2 (ReadPlanCtx):** Single-pass GET replacing double-stat pattern
- `StatForRead` / `StatPathFallbackForRead` + `scanNodeWithFileForRead` — fetches storage_type + content_blob (for db9) in one query
- `ReadPlanCtx` in backend returns `ReadPlan{InlineData, PresignURL, Size}`
- `handleRead` uses `ReadPlanCtx` exclusively — db9 inline: 1 query → 200; S3: 1 query + presign → 302

## Context
Issue #328 — small file performance. These two changes eliminate:
1. Scanning large blob columns during FUSE stat/HEAD (MVP 1)
2. The two-stat PresignGetObject→fallback→ReadCtx pattern for db-inline GET (MVP 2)

## Test plan
- [x] `TestStatLite` — lite path returns metadata, not blob/text/description
- [x] `TestStatPathFallbackLite` — fallback behavior with lite query
- [x] `TestStatForRead` — read-path returns storage_type + content_blob, not text/desc
- [x] Existing `TestWriteAndRead` validates full write→GET→inline body via ReadPlanCtx
- [x] Existing `TestStat` validates HEAD still works via lite path

🤖 Generated with [Claude Code](https://claude.com/claude-code)