### PR TITLE
feat: write-success freshness (Issue #328 MVP 3)

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -486,11 +486,6 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 	return int64(len(data)), nil
 }
 
-func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWithFile, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string, description string) (int64, error) {
-	n, _, err := b.overwriteFileCtxWithRev(ctx, nf, data, offset, flags, expectedRevision, tags, description)
-	return n, err
-}
-
 func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore.NodeWithFile, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string, description string) (int64, int64, error) {
 	if nf.File == nil {
 		return 0, 0, fmt.Errorf("no file entity")

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -334,6 +334,13 @@ func (b *Dat9Backend) WriteCtxIfRevision(ctx context.Context, path string, data 
 // - zero: path must not already exist
 // - positive: file must exist at exactly that revision
 func (b *Dat9Backend) WriteCtxIfRevisionWithTags(ctx context.Context, path string, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string, description string) (n int64, err error) {
+	n, _, err = b.WriteCtxIfRevisionWithTagsResult(ctx, path, data, offset, flags, expectedRevision, tags, description)
+	return n, err
+}
+
+// WriteCtxIfRevisionWithTagsResult is like WriteCtxIfRevisionWithTags but also
+// returns the committed revision of the file after a successful write.
+func (b *Dat9Backend) WriteCtxIfRevisionWithTagsResult(ctx context.Context, path string, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string, description string) (n int64, committedRevision int64, err error) {
 	start := time.Now()
 	defer func() { observeBackend(ctx, "write", err, start) }()
 
@@ -341,42 +348,46 @@ func (b *Dat9Backend) WriteCtxIfRevisionWithTags(ctx context.Context, path strin
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
 	existing, err := b.store.Stat(ctx, path)
 	if err == datastore.ErrNotFound {
 		if expectedRevision > 0 {
-			return 0, datastore.ErrRevisionConflict
+			return 0, 0, datastore.ErrRevisionConflict
 		}
 		if flags&filesystem.WriteFlagCreate == 0 {
 			if expectedRevision == 0 {
-				return 0, datastore.ErrRevisionConflict
+				return 0, 0, datastore.ErrRevisionConflict
 			}
-			return 0, datastore.ErrNotFound
+			return 0, 0, datastore.ErrNotFound
 		}
 		n, err := b.createAndWriteCtx(ctx, path, data, tags, description)
 		if expectedRevision == 0 && errors.Is(err, datastore.ErrPathConflict) {
-			return 0, datastore.ErrRevisionConflict
+			return 0, 0, datastore.ErrRevisionConflict
 		}
-		return n, err
+		if err != nil {
+			return 0, 0, err
+		}
+		return n, 1, nil // create always produces revision 1
 	}
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	if expectedRevision == 0 {
-		return 0, datastore.ErrRevisionConflict
+		return 0, 0, datastore.ErrRevisionConflict
 	}
 	if existing.Node.IsDirectory {
-		return 0, fmt.Errorf("is a directory: %s", path)
+		return 0, 0, fmt.Errorf("is a directory: %s", path)
 	}
 	if flags&filesystem.WriteFlagExclusive != 0 {
-		return 0, fmt.Errorf("file already exists: %s", path)
+		return 0, 0, fmt.Errorf("file already exists: %s", path)
 	}
 	if expectedRevision > 0 && (existing.File == nil || existing.File.Revision != expectedRevision) {
-		return 0, datastore.ErrRevisionConflict
+		return 0, 0, datastore.ErrRevisionConflict
 	}
-	return b.overwriteFileCtx(ctx, existing, data, offset, flags, expectedRevision, tags, description)
+	n, rev, err := b.overwriteFileCtxWithRev(ctx, existing, data, offset, flags, expectedRevision, tags, description)
+	return n, rev, err
 }
 
 func cloneFileTags(tags map[string]string) map[string]string {
@@ -476,15 +487,20 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 }
 
 func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWithFile, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string, description string) (int64, error) {
+	n, _, err := b.overwriteFileCtxWithRev(ctx, nf, data, offset, flags, expectedRevision, tags, description)
+	return n, err
+}
+
+func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore.NodeWithFile, data []byte, offset int64, flags filesystem.WriteFlag, expectedRevision int64, tags map[string]string, description string) (int64, int64, error) {
 	if nf.File == nil {
-		return 0, fmt.Errorf("no file entity")
+		return 0, 0, fmt.Errorf("no file entity")
 	}
 
 	var finalData []byte
 	if flags&filesystem.WriteFlagAppend != 0 {
 		existing, err := b.readFileDataCtx(ctx, nf.File)
 		if err != nil {
-			return 0, fmt.Errorf("read existing data for append: %w", err)
+			return 0, 0, fmt.Errorf("read existing data for append: %w", err)
 		}
 		finalData = append(existing, data...)
 	} else if flags&filesystem.WriteFlagTruncate != 0 || offset <= 0 {
@@ -492,7 +508,7 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 	} else {
 		existing, err := b.readFileDataCtx(ctx, nf.File)
 		if err != nil {
-			return 0, fmt.Errorf("read existing data for offset write: %w", err)
+			return 0, 0, fmt.Errorf("read existing data for offset write: %w", err)
 		}
 		if offset > int64(len(existing)) {
 			existing = append(existing, make([]byte, offset-int64(len(existing)))...)
@@ -505,7 +521,7 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 	}
 
 	if err := b.ensureUploadSizeAllowed(int64(len(finalData))); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	contentType := detectContentType(nf.Node.Path, finalData)
 	checksum := sha256sum(finalData)
@@ -517,13 +533,13 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 		contentBlob = append([]byte(nil), finalData...)
 	} else {
 		if b.s3 == nil {
-			return 0, fmt.Errorf("s3 client not configured")
+			return 0, 0, fmt.Errorf("s3 client not configured")
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + b.genID()
 		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(finalData), int64(len(finalData))); err != nil {
 			logger.Error(ctx, "backend_overwrite_put_object_failed", zap.String("path", nf.Node.Path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(finalData)), zap.Error(err))
-			return 0, fmt.Errorf("put object: %w", err)
+			return 0, 0, fmt.Errorf("put object: %w", err)
 		}
 	}
 
@@ -578,7 +594,7 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 		if storageType == datastore.StorageS3 {
 			b.deleteBlobCtx(ctx, storageRef)
 		}
-		return 0, err
+		return 0, 0, err
 	}
 	b.syncCentralFileOverwrite(ctx, nf.File.FileID, nf.File.SizeBytes, nf.File.ContentType, int64(len(finalData)), contentType)
 	b.deleteBlobIfS3Ctx(ctx, nf.File.StorageType, nf.File.StorageRef, storageRef)
@@ -586,10 +602,10 @@ func (b *Dat9Backend) overwriteFileCtx(ctx context.Context, nf *datastore.NodeWi
 	// backend-owned image queue until its image task flow also moves to
 	// semantic_tasks.
 	if b.UsesDatabaseAutoEmbedding() {
-		return int64(len(data)), nil
+		return int64(len(data)), newRev, nil
 	}
 	b.enqueueImageExtract(nf.File.FileID, nf.Node.Path, contentType, newRev)
-	return int64(len(data)), nil
+	return int64(len(data)), newRev, nil
 }
 
 func (b *Dat9Backend) ReadDir(path string) ([]filesystem.FileInfo, error) {

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -59,6 +60,35 @@ func TestCreateAndStat(t *testing.T) {
 	}
 	if info.Name != "hello.txt" || info.IsDir || info.Size != 0 {
 		t.Errorf("unexpected: %+v", info)
+	}
+}
+
+func TestWriteCtxIfRevisionWithTagsResult_ReturnsCommittedRevision(t *testing.T) {
+	b := newTestBackend(t)
+	ctx := context.Background()
+
+	// Create: committed revision should be 1.
+	n, rev, err := b.WriteCtxIfRevisionWithTagsResult(ctx, "/rev-test.txt", []byte("v1"), 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1, nil, "")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("create bytes = %d, want 2", n)
+	}
+	if rev != 1 {
+		t.Fatalf("create revision = %d, want 1", rev)
+	}
+
+	// Overwrite with CAS revision 1: committed revision should be 2.
+	n, rev, err = b.WriteCtxIfRevisionWithTagsResult(ctx, "/rev-test.txt", []byte("v2"), 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, 1, nil, "")
+	if err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("overwrite bytes = %d, want 2", n)
+	}
+	if rev != 2 {
+		t.Fatalf("overwrite revision = %d, want 2", rev)
 	}
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -314,29 +314,48 @@ func (c *Client) WriteCtxConditionalWithDescription(ctx context.Context, path st
 }
 
 func (c *Client) writeCtxConditionalWithTagsAndDescription(ctx context.Context, path string, data []byte, expectedRevision int64, tags map[string]string, description string) error {
+	_, err := c.writeCtxConditionalFull(ctx, path, data, expectedRevision, tags, description)
+	return err
+}
+
+// WriteCtxConditionalWithRevision is like WriteCtxConditional but also returns
+// the committed revision from the server response.
+func (c *Client) WriteCtxConditionalWithRevision(ctx context.Context, path string, data []byte, expectedRevision int64) (int64, error) {
+	return c.writeCtxConditionalFull(ctx, path, data, expectedRevision, nil, "")
+}
+
+func (c *Client) writeCtxConditionalFull(ctx context.Context, path string, data []byte, expectedRevision int64, tags map[string]string, description string) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(path), bytes.NewReader(data))
 	if err != nil {
-		return err
+		return 0, err
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	if expectedRevision >= 0 {
 		req.Header.Set("X-Dat9-Expected-Revision", strconv.FormatInt(expectedRevision, 10))
 	}
 	if err := setTagHeaders(req, tags); err != nil {
-		return err
+		return 0, err
 	}
 	if description != "" {
 		req.Header.Set("X-Dat9-Description", description)
 	}
 	resp, err := c.do(req)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
-		return readError(resp)
+		return 0, readError(resp)
 	}
-	return nil
+	// Parse committed revision from response body.
+	var result struct {
+		Revision int64 `json:"revision"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		// If response doesn't contain revision (old server), return 0.
+		return 0, nil
+	}
+	return result.Revision, nil
 }
 
 // Read downloads a file's content.

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2497,7 +2497,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		}
 
 		dCtx, dCf := context.WithTimeout(context.Background(), fuseTimeout)
-		err := fs.client.WriteCtxConditional(dCtx, filePath, data, expectedRevision)
+		committedRev, err := fs.client.WriteCtxConditionalWithRevision(dCtx, filePath, data, expectedRevision)
 		dCf()
 		if err != nil {
 			handle.Unlock()
@@ -2506,12 +2506,25 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		}
 		// The handle stays locked across upload + finalize so concurrent writes
 		// cannot advance live state for data outside this committed snapshot.
-		fs.finalizeHandleFlushLocked(handle, expectedRevision)
+		if committedRev > 0 {
+			handle.IsNew = false
+			handle.BaseRev = committedRev
+			fs.inodes.UpdateRevision(ino, committedRev)
+			if handle.ZeroBase && handle.Dirty != nil && handle.Dirty.Size() > 0 {
+				handle.ZeroBase = false
+			}
+		} else {
+			fs.finalizeHandleFlushLocked(handle, expectedRevision)
+		}
 		if handle.Dirty != nil && handle.DirtySeq == snapshotSeq {
 			handle.Dirty.ClearDirty()
 		}
 		handle.Unlock()
-		fs.readCache.Invalidate(filePath)
+		if committedRev > 0 {
+			fs.readCache.Put(filePath, data, committedRev)
+		} else {
+			fs.readCache.Invalidate(filePath)
+		}
 		fs.dirCache.Invalidate(parentDir(filePath))
 		fs.inodes.UpdateSize(ino, int64(len(data)))
 		fs.notifyInode(ino)
@@ -2654,10 +2667,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 	// Path 2: No streaming uploader or small file — materialize all data for upload.
 	data := fh.Dirty.Bytes()
 	expectedRevision := expectedRevisionForHandle(fh)
+	var committedRev int64
 
 	if size < smallFileThreshold {
-		// Small file: direct PUT.
-		err = fs.client.WriteCtxConditional(ctx, fh.Path, data, expectedRevision)
+		// Small file: direct PUT with revision return for freshness seeding.
+		committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fh.Path, data, expectedRevision)
 	} else if fh.OrigSize >= smallFileThreshold {
 		dirtyParts := fh.Dirty.DirtyPartNumbers()
 		if len(dirtyParts) > 0 {
@@ -2706,10 +2720,20 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 	fh.Dirty.ClearDirty()
 	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 	fh.DirtySeq = 0
-	fs.readCache.Invalidate(fh.Path)
+	if committedRev > 0 {
+		fs.readCache.Put(fh.Path, data, committedRev)
+		fh.IsNew = false
+		fh.BaseRev = committedRev
+		fs.inodes.UpdateRevision(fh.Ino, committedRev)
+		if fh.ZeroBase && fh.Dirty != nil && fh.Dirty.Size() > 0 {
+			fh.ZeroBase = false
+		}
+	} else {
+		fs.readCache.Invalidate(fh.Path)
+		fs.finalizeHandleFlushLocked(fh, expectedRevision)
+	}
 	fs.dirCache.Invalidate(parentDir(fh.Path))
 	fs.inodes.UpdateSize(fh.Ino, size)
-	fs.finalizeHandleFlushLocked(fh, expectedRevision)
 	// Invalidate kernel attr/data cache for this inode and parent dir listing.
 	fs.notifyInode(fh.Ino)
 	parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2529,6 +2529,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		fs.inodes.UpdateSize(ino, int64(len(data)))
 		fs.notifyInode(ino)
 		parentIno, _ := fs.inodes.GetInode(parentDir(filePath))
+		fs.notifyEntry(parentIno, path.Base(filePath))
 		fs.notifyInode(parentIno)
 	})
 
@@ -2737,6 +2738,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) gofuse.Status
 	// Invalidate kernel attr/data cache for this inode and parent dir listing.
 	fs.notifyInode(fh.Ino)
 	parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
+	fs.notifyEntry(parentIno, path.Base(fh.Path))
 	fs.notifyInode(parentIno)
 	return gofuse.OK
 }

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1436,7 +1436,7 @@ func TestFlushHandle_SmallFile_SeedsReadCache(t *testing.T) {
 		case http.MethodGet:
 			getCalls.Add(1)
 			recordHandlerErr(fmt.Errorf("unexpected GET after flush — should hit cache"))
-			w.Write(content)
+			_, _ = w.Write(content)
 		case http.MethodHead:
 			headCalls.Add(1)
 			recordHandlerErr(fmt.Errorf("unexpected HEAD after flush — should hit cache"))

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1352,6 +1352,7 @@ func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
 			}
 			putCalls.Add(1)
 			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 8})
 		case http.MethodHead:
 			headCalls.Add(1)
 			http.Error(w, "unexpected post-flush HEAD", http.StatusInternalServerError)
@@ -1405,6 +1406,106 @@ func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
 	}
 	if entry.Revision != 8 {
 		t.Fatalf("inode revision = %d, want 8", entry.Revision)
+	}
+}
+
+func TestFlushHandle_SmallFile_SeedsReadCache(t *testing.T) {
+	var (
+		mu         sync.Mutex
+		handlerErr error
+		putCalls   atomic.Int32
+		getCalls   atomic.Int32
+		headCalls  atomic.Int32
+	)
+	recordHandlerErr := func(err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+
+	content := []byte("hello freshness")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 2})
+		case http.MethodGet:
+			getCalls.Add(1)
+			recordHandlerErr(fmt.Errorf("unexpected GET after flush — should hit cache"))
+			w.Write(content)
+		case http.MethodHead:
+			headCalls.Add(1)
+			recordHandlerErr(fmt.Errorf("unexpected HEAD after flush — should hit cache"))
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	ino := fs.inodes.Lookup("/fresh.txt", false, int64(len(content)), time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+	fs.inodes.UpdateSize(ino, int64(len(content)))
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    "/fresh.txt",
+		Dirty:   NewWriteBuffer("/fresh.txt", maxPreloadSize, 0),
+		BaseRev: 1,
+	}
+	if _, err := fh.Dirty.Write(0, content); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+
+	fh.Lock()
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+	if st != gofuse.OK {
+		t.Fatalf("flushHandle status = %v, want OK", st)
+	}
+
+	// Verify readCache was seeded with committed revision.
+	data, ok := fs.readCache.Get("/fresh.txt", 2)
+	if !ok {
+		t.Fatal("readCache miss after flush — freshness not seeded")
+	}
+	if string(data) != string(content) {
+		t.Fatalf("readCache content = %q, want %q", data, content)
+	}
+
+	// Verify no GET or HEAD was made (cache should serve reads).
+	mu.Lock()
+	err := handlerErr
+	mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := getCalls.Load(); got != 0 {
+		t.Fatalf("GET calls = %d, want 0", got)
+	}
+	if got := headCalls.Load(); got != 0 {
+		t.Fatalf("HEAD calls = %d, want 0", got)
+	}
+
+	// Verify inode revision updated to committed value.
+	if fh.BaseRev != 2 {
+		t.Fatalf("fh.BaseRev = %d, want 2", fh.BaseRev)
+	}
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if entry.Revision != 2 {
+		t.Fatalf("inode revision = %d, want 2", entry.Revision)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -765,7 +765,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		errJSON(w, http.StatusBadRequest, fmt.Sprintf("description exceeds %d characters", backend.MaxDescriptionLen))
 		return
 	}
-	_, err = b.WriteCtxIfRevisionWithTags(r.Context(), path, data, 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, expectedRevision, writeTags, description)
+	_, committedRevision, err := b.WriteCtxIfRevisionWithTagsResult(r.Context(), path, data, 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, expectedRevision, writeTags, description)
 	if err != nil {
 		if errors.Is(err, backend.ErrUploadTooLarge) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_too_large_backend", "path", path, "error", err)...)
@@ -793,7 +793,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "write_ok", "path", path, "bytes", len(data))...)
 	metricEvent(r.Context(), "fs_write", "result", "ok")
 	s.publishEvent(r, path, "write")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": committedRevision})
 }
 
 func (s *Server) handlePatch(w http.ResponseWriter, r *http.Request, path string) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -106,6 +106,51 @@ func TestWriteAndRead(t *testing.T) {
 	}
 }
 
+func TestWriteReturnsCommittedRevision(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Create a new file — revision should be 1.
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/data/rev.txt", strings.NewReader("v1"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("create: status %d, body %s", resp.StatusCode, body)
+	}
+	var result struct {
+		Revision int64 `json:"revision"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("unmarshal create response: %v (body: %s)", err, body)
+	}
+	if result.Revision != 1 {
+		t.Fatalf("create revision = %d, want 1", result.Revision)
+	}
+
+	// Overwrite the file — revision should increment to 2.
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/data/rev.txt", strings.NewReader("v2"))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("overwrite: status %d, body %s", resp.StatusCode, body)
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("unmarshal overwrite response: %v (body: %s)", err, body)
+	}
+	if result.Revision != 2 {
+		t.Fatalf("overwrite revision = %d, want 2", result.Revision)
+	}
+}
+
 func TestReadInlineNoRedirect(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary

- **Backend**: `WriteCtxIfRevisionWithTagsResult` returns the actual committed revision (1 for create, incremented for overwrite) alongside bytes written
- **Server**: `handleWrite` returns `{"status":"ok","revision":N}` in PUT response body
- **Client**: `WriteCtxConditionalWithRevision` parses the committed revision from the response (falls back gracefully to 0 for old servers)
- **FUSE**: Both debounced flush and `flushHandle` small-file paths now seed `readCache.Put(path, data, committedRev)` and update inode revision directly, eliminating the immediate re-stat/re-read after write

## Motivation

After a small-file write, the FUSE mount previously invalidated caches and required a full roundtrip (HEAD + GET) to serve the next read. With this change, the committed revision is propagated from server → client → FUSE, allowing the mount to serve subsequent reads from local cache immediately.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/fuse/...` passes (8.5s, no regressions)
- [ ] CI (server/client/backend tests with Docker)
- [ ] juicefs bench comparison: small-file write→read latency should drop by ~1 roundtrip

Closes part of #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)