### PR TITLE
fix: prevent prefetch short reads

### DIFF
--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -1016,6 +1016,54 @@ func TestPrefetcher_SubBlockReads(t *testing.T) {
 	}
 }
 
+func TestPrefetcher_LargeReadSizeDoesNotReturnShortPrefetch(t *testing.T) {
+	fileData := make([]byte, 4*1024*1024)
+	for i := range fileData {
+		fileData[i] = byte(i % 251)
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rangeHeader := r.Header.Get("Range")
+		if rangeHeader == "" {
+			_, _ = w.Write(fileData)
+			return
+		}
+		var start, end int64
+		_, _ = fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end)
+		if end >= int64(len(fileData)) {
+			end = int64(len(fileData)) - 1
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(fileData)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(fileData[start : end+1])
+	}))
+	defer ts.Close()
+
+	c := client.New(ts.URL, "")
+	p := NewPrefetcher(c, "/bigfile.bin", int64(len(fileData)))
+	defer p.Close()
+
+	const readSize = 1024 * 1024
+	p.OnRead(0, readSize)
+
+	data, ok := p.Get(readSize, readSize)
+	if !ok {
+		t.Fatal("prefetch get = miss, want hit")
+	}
+	if len(data) != readSize {
+		t.Fatalf("prefetch data len = %d, want %d", len(data), readSize)
+	}
+	for i := 0; i < readSize; i++ {
+		want := byte((readSize + i) % 251)
+		if data[i] != want {
+			t.Fatalf("data[%d] = %d, want %d", i, data[i], want)
+		}
+	}
+}
+
 // TestPrefetcher_ChunkCapBound verifies that chunk count never exceeds
 // prefetchMaxBlocks, even with tiny readSize and large window.
 func TestPrefetcher_ChunkCapBound(t *testing.T) {

--- a/pkg/fuse/prefetch.go
+++ b/pkg/fuse/prefetch.go
@@ -104,6 +104,16 @@ func (p *Prefetcher) Get(offset int64, size int) ([]byte, bool) {
 
 	// Trim to requested size
 	data := block.data
+	if len(data) < size && offset+int64(len(data)) < p.fileSize {
+		// A prefetched chunk smaller than the caller's request is only valid at
+		// EOF. Returning it for an interior range exposes a short read to FUSE.
+		p.mu.Lock()
+		if p.cache[offset] == block {
+			delete(p.cache, offset)
+		}
+		p.mu.Unlock()
+		return nil, false
+	}
 	if len(data) > size {
 		data = data[:size]
 	}
@@ -136,6 +146,9 @@ func (p *Prefetcher) OnRead(offset int64, size int) {
 	if offset == p.nextExpect {
 		// Sequential read detected — grow window
 		p.window *= 2
+		if p.window < int64(size) {
+			p.window = int64(size)
+		}
 		if p.window > prefetchMaxWindow {
 			p.window = prefetchMaxWindow
 		}
@@ -198,6 +211,12 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 	chunkSize := int64(p.readSize)
 	if chunkSize <= 0 {
 		chunkSize = 128 * 1024 // default 128KB if not yet observed
+	}
+	if length < chunkSize && offset+length < p.fileSize {
+		length = chunkSize
+		if offset+length > p.fileSize {
+			length = p.fileSize - offset
+		}
 	}
 
 	// Calculate how many chunks this window will produce, capped to avoid


### PR DESCRIPTION
Summary: ensure FUSE prefetch never returns an interior short block for large read sizes; grow the prefetch window to at least the observed read size; add a regression test for 1 MiB reads. Tests: go test ./pkg/fuse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cache validation to prevent serving incomplete buffers on non-EOF reads.
  * Enhanced adaptive window growth to properly align with read request sizes.
  * Optimized prefetch window sizing to ensure adequate response handling.

* **Tests**
  * Added regression test validating cache performance for large read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->