### PR TITLE
fix: classify canceled auth as client canceled

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -604,7 +604,11 @@ func httpToFuseStatus(err error) gofuse.Status {
 			return gofuse.Status(syscall.EINVAL)
 		// Keep status mapping aligned with isTransientLookupErr so retry-exhausted
 		// timeout paths remain retryable to callers instead of regressing to EIO.
-		case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		// 499 (Client Closed Request) is emitted by tenantAuthMiddleware when
+		// the request context is canceled before auth completes; treat it
+		// identically to context.Canceled so the FUSE caller sees a
+		// retryable EAGAIN rather than an opaque EIO.
+		case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, statusClientClosedRequest:
 			return gofuse.Status(syscall.EAGAIN)
 		default:
 			return gofuse.EIO
@@ -627,7 +631,8 @@ func httpToFuseStatus(err error) gofuse.Status {
 		return gofuse.Status(syscall.ESTALE)
 	case strings.Contains(msg, "HTTP 400"):
 		return gofuse.Status(syscall.EINVAL)
-	case strings.Contains(msg, "HTTP 500") ||
+	case strings.Contains(msg, "HTTP 499") ||
+		strings.Contains(msg, "HTTP 500") ||
 		strings.Contains(msg, "HTTP 502") ||
 		strings.Contains(msg, "HTTP 503") ||
 		strings.Contains(msg, "HTTP 504"):
@@ -636,6 +641,12 @@ func httpToFuseStatus(err error) gofuse.Status {
 		return gofuse.EIO
 	}
 }
+
+// statusClientClosedRequest mirrors the non-standard 499 status emitted by the
+// server's auth middleware when the client cancels mid-auth. Tracked here so
+// httpToFuseStatus / isTransientLookupErr stay aligned with the server contract
+// without taking a server package dependency.
+const statusClientClosedRequest = 499
 
 func isNotFoundErr(err error) bool {
 	if err == nil {
@@ -659,7 +670,7 @@ func isTransientLookupErr(err error) bool {
 	var se *client.StatusError
 	if errors.As(err, &se) {
 		switch se.StatusCode {
-		case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, statusClientClosedRequest:
 			return true
 		}
 	}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -936,6 +936,31 @@ func TestHTTPToFuseStatus_MapsGatewayTimeoutToEAGAIN(t *testing.T) {
 	}
 }
 
+// TestHTTPToFuseStatus_MapsClientClosedRequestToEAGAIN locks the contract
+// between the server's tenantAuthMiddleware (which writes 499 when a request
+// is canceled mid-auth) and the FUSE client. Without this mapping, a canceled
+// read/lookup would surface as EIO instead of going through the existing
+// retryable EAGAIN path that other transient/canceled errors use.
+func TestHTTPToFuseStatus_MapsClientClosedRequestToEAGAIN(t *testing.T) {
+	want := gofuse.Status(syscall.EAGAIN)
+	if got := httpToFuseStatus(&client.StatusError{StatusCode: 499, Message: ""}); got != want {
+		t.Fatalf("status error 499 = %v, want %v", got, want)
+	}
+	if got := httpToFuseStatus(fmt.Errorf("HTTP 499: client closed request")); got != want {
+		t.Fatalf("string error 499 = %v, want %v", got, want)
+	}
+}
+
+// TestIsTransientLookupErr_Treats499AsTransient ensures the retry path used by
+// Lookup/GetAttr classifies a 499 (Client Closed Request) the same way it
+// treats context.Canceled and 5xx, keeping retry-after-cancel semantics aligned
+// with the server's auth middleware.
+func TestIsTransientLookupErr_Treats499AsTransient(t *testing.T) {
+	if !isTransientLookupErr(&client.StatusError{StatusCode: 499, Message: ""}) {
+		t.Fatal("499 should be classified as transient")
+	}
+}
+
 func TestOpenReadOnlyLargeFileGetsPrefetcher(t *testing.T) {
 	size := int64(1024 * 1024) // 1MB — above smallFileThreshold
 	data := make([]byte, size)

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -29,6 +29,8 @@ type TenantScope struct {
 	Backend      *backend.Dat9Backend
 }
 
+const statusClientClosedRequest = 499
+
 func ScopeFromContext(ctx context.Context) *TenantScope {
 	s, _ := ctx.Value(tenantScopeKey).(*TenantScope)
 	return s
@@ -40,6 +42,19 @@ func withScope(ctx context.Context, scope *TenantScope) context.Context {
 
 func authPhaseMs(start time.Time) float64 {
 	return float64(time.Since(start).Microseconds()) / 1000.0
+}
+
+func isClientCanceled(ctx context.Context, err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
+}
+
+func logAuthClientCanceled(ctx context.Context, event string, kv ...any) {
+	logger.Info(ctx, "server_event", eventFields(ctx, event, kv...)...)
+	metricEvent(ctx, "auth", "result", "client_canceled")
+}
+
+func writeClientCanceled(w http.ResponseWriter) {
+	w.WriteHeader(statusClientClosedRequest)
 }
 
 func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret []byte, next http.Handler) http.Handler {
@@ -61,6 +76,11 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_key_not_found")...)
 				metricEvent(r.Context(), "auth", "result", "key_not_found")
 				errJSON(w, http.StatusUnauthorized, "invalid API key")
+				return
+			}
+			if isClientCanceled(r.Context(), err) {
+				logAuthClientCanceled(r.Context(), "auth_client_canceled")
+				writeClientCanceled(w)
 				return
 			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_backend_unavailable", "error", err)...)
@@ -87,6 +107,11 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 		plain, err := poolDecryptToken(r.Context(), pool, resolved.APIKey.JWTCiphertext)
 		decryptDurationMs := authPhaseMs(decryptStart)
 		if err != nil {
+			if isClientCanceled(r.Context(), err) {
+				logAuthClientCanceled(r.Context(), "auth_decrypt_client_canceled", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)
+				writeClientCanceled(w)
+				return
+			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_decrypt_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 			metricEvent(r.Context(), "auth", "result", "decrypt_failed")
 			errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
@@ -144,6 +169,11 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 		b, release, err := pool.Acquire(r.Context(), &resolved.Tenant)
 		acquireDurationMs := authPhaseMs(acquireStart)
 		if err != nil {
+			if isClientCanceled(r.Context(), err) {
+				logAuthClientCanceled(r.Context(), "backend_load_client_canceled", "tenant_id", resolved.Tenant.ID)
+				writeClientCanceled(w)
+				return
+			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "backend_load_failed", "tenant_id", resolved.Tenant.ID, "error", err)...)
 			metricEvent(r.Context(), "tenant_backend", "result", "load_failed")
 			errJSON(w, http.StatusInternalServerError, "backend unavailable")

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -15,9 +15,12 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/pkg/encrypt"
+	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type authTestRuntime struct {
@@ -201,6 +204,43 @@ func TestAuthKeepsBorrowedBackendValidDuringRequestAfterInvalidate(t *testing.T)
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("status=%d", resp.StatusCode)
+	}
+}
+
+func TestAuthClientCanceledDoesNotLogBackendUnavailable(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+
+	core, recorded := observer.New(zap.InfoLevel)
+	restoreLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(restoreLogger) })
+
+	calledNext := false
+	h := tenantAuthMiddleware(rt.meta, rt.pool, rt.tokenSecret, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calledNext = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodGet, "/v1/fs/canceled.txt", nil).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if calledNext {
+		t.Fatal("next handler should not be called after canceled auth")
+	}
+	if rec.Code != statusClientClosedRequest {
+		t.Fatalf("status=%d, want %d", rec.Code, statusClientClosedRequest)
+	}
+	if entries := recorded.FilterField(zap.String("event", "auth_backend_unavailable")).AllUntimed(); len(entries) != 0 {
+		t.Fatalf("auth_backend_unavailable logs = %d, want 0", len(entries))
+	}
+	if entries := recorded.FilterField(zap.String("event", "auth_client_canceled")).AllUntimed(); len(entries) != 1 {
+		t.Fatalf("auth_client_canceled logs = %d, want 1", len(entries))
 	}
 }
 


### PR DESCRIPTION
## Summary
- classify tenant-auth context cancellations as client-canceled/499-style events
- avoid logging canceled auth as auth_backend_unavailable or backend load failures
- add regression coverage for canceled auth logging

## Validation
- /usr/local/go/bin/go test -c ./pkg/server
- /usr/local/go/bin/go test -c ./pkg/fuse

Note: runtime pkg/server test is blocked locally by testcontainers/rootless Docker on this host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication now detects canceled client requests and responds with a client-closed status, with clearer logging and auth metrics.

* **Bug Fixes**
  * Lookup/retry logic updated so canceled-client responses are treated as transient, improving reliability of filesystem lookups under client disconnects.

* **Tests**
  * Added tests covering canceled-request handling and the transient behavior for lookup retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->