### PR TITLE
fix: Read detached retry to prevent EAGAIN hang

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -744,8 +744,8 @@ func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, off
 }
 
 // doRangeRead performs a single range read attempt: open stream + read body.
-// Body read errors (other than EOF/ErrUnexpectedEOF) are returned as-is so
-// the caller can classify them for retry.
+// All body read errors (including truncation) are returned as-is so the
+// caller can classify them for retry.
 func (fs *Dat9FS) doRangeRead(ctx context.Context, path string, offset, size int64) ([]byte, int, error) {
 	rc, err := fs.client.ReadStreamRange(ctx, path, offset, size)
 	if err != nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -677,6 +677,10 @@ func isTransientLookupErr(err error) bool {
 	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
+// errReadRetriesExhausted is a sentinel indicating all detached read retries
+// failed with transient errors. Callers should map this to EIO.
+var errReadRetriesExhausted = errors.New("read retries exhausted")
+
 // isTransientReadErr classifies errors for Read-path detached retry.
 // Same classification as isTransientLookupErr — kept as a separate function
 // so Read and Lookup retry policies can diverge independently if needed.
@@ -708,8 +712,7 @@ func (fs *Dat9FS) readSmallFileWithRetry(ctx context.Context, path string) ([]by
 		}
 		lastErr = err
 	}
-	// Map transient-exhausted to EIO so callers never see EAGAIN.
-	return nil, fmt.Errorf("read retries exhausted for %s: %w", path, lastErr)
+	return nil, fmt.Errorf("%w: %s: %v", errReadRetriesExhausted, path, lastErr)
 }
 
 // readStreamRangeWithRetry performs a range read with bounded detached retry
@@ -737,7 +740,7 @@ func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, off
 		}
 		lastErr = err
 	}
-	return nil, 0, fmt.Errorf("range read retries exhausted for %s: %w", path, lastErr)
+	return nil, 0, fmt.Errorf("%w: %s: %v", errReadRetriesExhausted, path, lastErr)
 }
 
 // doRangeRead performs a single range read attempt: open stream + read body.
@@ -2220,7 +2223,10 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		data, err := fs.readSmallFileWithRetry(ctx, p)
 		if err != nil {
 			source = "small-read-error"
-			return nil, gofuse.EIO
+			if errors.Is(err, errReadRetriesExhausted) {
+				return nil, gofuse.EIO
+			}
+			return nil, httpToFuseStatus(err)
 		}
 		// Store with the revision from the prior Stat/Lookup.
 		fs.readCache.Put(p, data, cacheRev)
@@ -2236,9 +2242,6 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		}
 		source = "small-read"
 		bytesRead = int(end - offset)
-		if fh.Prefetch != nil {
-			fh.Prefetch.OnRead(int64(input.Offset), bytesRead)
-		}
 		return gofuse.ReadResultData(data[offset:end]), gofuse.OK
 	}
 
@@ -2252,7 +2255,10 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 	data, n, err := fs.readStreamRangeWithRetry(ctx, p, int64(input.Offset), int64(input.Size))
 	if err != nil {
 		fs.debugf("read range error path=%s off=%d req=%d got=%d source=%s dur=%s err=%v", p, input.Offset, input.Size, n, source, time.Since(rangeStart), err)
-		return nil, gofuse.EIO
+		if errors.Is(err, errReadRetriesExhausted) {
+			return nil, gofuse.EIO
+		}
+		return nil, httpToFuseStatus(err)
 	}
 	if fs.debugEnabled() && time.Since(rangeStart) >= fuseDebugSlowReadThreshold {
 		fs.debugf("read range done path=%s off=%d req=%d got=%d source=%s dur=%s", p, input.Offset, input.Size, n, source, time.Since(rangeStart))

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -753,12 +753,17 @@ func (fs *Dat9FS) doRangeRead(ctx context.Context, path string, offset, size int
 	}
 	defer func() { _ = rc.Close() }()
 
-	data := make([]byte, size)
-	n, err := io.ReadFull(rc, data)
-	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
-		return nil, n, err
+	// Use LimitReader + ReadAll instead of ReadFull so that:
+	//   - Clean EOF (server sent full response) → (data, nil) — success
+	//   - Truncated body (connection drop) → (partial, err) — surfaces
+	//     to retry helper for transient classification
+	// io.ReadFull swallows io.ErrUnexpectedEOF, hiding truncation.
+	lr := io.LimitReader(rc, size)
+	data, err := io.ReadAll(lr)
+	if err != nil {
+		return nil, len(data), err
 	}
-	return data[:n], n, nil
+	return data, len(data), nil
 }
 
 func (fs *Dat9FS) lookupStatRetryCount() int {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -138,6 +139,15 @@ const (
 	// lookupRetrySuccessLogEvery controls how often successful retry recovery is
 	// logged, to avoid noisy logs on hot lookup paths.
 	lookupRetrySuccessLogEvery uint64 = 200
+
+	// readTransientRetryCount is the number of detached retries after the
+	// initial remote Read attempt fails with a transient error (context
+	// canceled, deadline exceeded, network timeout, HTTP 5xx).
+	readTransientRetryCount = 2
+
+	// readTransientRetryTimeout keeps each detached read retry bounded.
+	// Each retry reads at most max_read (1 MiB), so 2s is generous.
+	readTransientRetryTimeout = 2 * time.Second
 )
 
 // releaseTimeout computes a generous timeout for synchronous uploads in
@@ -665,6 +675,87 @@ func isTransientLookupErr(err error) bool {
 	}
 	var netErr net.Error
 	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// isTransientReadErr classifies errors for Read-path detached retry.
+// Same classification as isTransientLookupErr — kept as a separate function
+// so Read and Lookup retry policies can diverge independently if needed.
+func isTransientReadErr(err error) bool {
+	return isTransientLookupErr(err)
+}
+
+// readSmallFileWithRetry reads a small file via ReadCtx with bounded detached
+// retry on transient failures. The first attempt uses the caller-provided ctx
+// (which honors FUSE interrupt). On transient failure, up to
+// readTransientRetryCount detached retries are attempted with short timeouts.
+// Returns EIO (never EAGAIN) when all retries are exhausted.
+func (fs *Dat9FS) readSmallFileWithRetry(ctx context.Context, path string) ([]byte, error) {
+	data, err := fs.client.ReadCtx(ctx, path)
+	if err == nil || !isTransientReadErr(err) {
+		return data, err
+	}
+
+	lastErr := err
+	for range readTransientRetryCount {
+		retryCtx, retryCancel := context.WithTimeout(context.Background(), readTransientRetryTimeout)
+		data, err = fs.client.ReadCtx(retryCtx, path)
+		retryCancel()
+		if err == nil {
+			return data, nil
+		}
+		if !isTransientReadErr(err) {
+			return nil, err
+		}
+		lastErr = err
+	}
+	// Map transient-exhausted to EIO so callers never see EAGAIN.
+	return nil, fmt.Errorf("read retries exhausted for %s: %w", path, lastErr)
+}
+
+// readStreamRangeWithRetry performs a range read with bounded detached retry
+// on transient failures. Wraps both the ReadStreamRange open and io.ReadFull
+// body read as a single retriable unit. On body-stage transient failure, the
+// stream is reopened from scratch on retry.
+// Returns (data, nil) on success. On exhausted retries, the returned error
+// is a wrapped sentinel so the caller can map it to EIO.
+func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, offset, size int64) ([]byte, int, error) {
+	data, n, err := fs.doRangeRead(ctx, path, offset, size)
+	if err == nil || !isTransientReadErr(err) {
+		return data, n, err
+	}
+
+	lastErr := err
+	for range readTransientRetryCount {
+		retryCtx, retryCancel := context.WithTimeout(context.Background(), readTransientRetryTimeout)
+		data, n, err = fs.doRangeRead(retryCtx, path, offset, size)
+		retryCancel()
+		if err == nil {
+			return data, n, nil
+		}
+		if !isTransientReadErr(err) {
+			return nil, 0, err
+		}
+		lastErr = err
+	}
+	return nil, 0, fmt.Errorf("range read retries exhausted for %s: %w", path, lastErr)
+}
+
+// doRangeRead performs a single range read attempt: open stream + read body.
+// Body read errors (other than EOF/ErrUnexpectedEOF) are returned as-is so
+// the caller can classify them for retry.
+func (fs *Dat9FS) doRangeRead(ctx context.Context, path string, offset, size int64) ([]byte, int, error) {
+	rc, err := fs.client.ReadStreamRange(ctx, path, offset, size)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = rc.Close() }()
+
+	data := make([]byte, size)
+	n, err := io.ReadFull(rc, data)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return nil, n, err
+	}
+	return data[:n], n, nil
 }
 
 func (fs *Dat9FS) lookupStatRetryCount() int {
@@ -2095,11 +2186,9 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 			bytesRead = len(data)
 			return gofuse.ReadResultData(data), gofuse.OK
 		}
-		// Cache miss — fall through to direct read, then trigger prefetch
+		// Cache miss — fall through to direct read. Prefetch is triggered
+		// only after a successful read (see below), not unconditionally.
 		source = "prefetch-miss-range"
-		defer func() {
-			fh.Prefetch.OnRead(offset, size)
-		}()
 	}
 
 	// Try read cache for small files. Use revision-aware cache: if the
@@ -2126,11 +2215,12 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		}
 
 		// Cache miss: read the file and store it. No separate Stat needed —
-		// ReadCtx fetches the data in one round-trip.
-		data, err := fs.client.ReadCtx(ctx, p)
+		// ReadCtx fetches the data in one round-trip. Uses detached retry
+		// so a single FUSE interrupt doesn't permanently return EAGAIN.
+		data, err := fs.readSmallFileWithRetry(ctx, p)
 		if err != nil {
 			source = "small-read-error"
-			return nil, httpToFuseStatus(err)
+			return nil, gofuse.EIO
 		}
 		// Store with the revision from the prior Stat/Lookup.
 		fs.readCache.Put(p, data, cacheRev)
@@ -2146,32 +2236,32 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		}
 		source = "small-read"
 		bytesRead = int(end - offset)
+		if fh.Prefetch != nil {
+			fh.Prefetch.OnRead(int64(input.Offset), bytesRead)
+		}
 		return gofuse.ReadResultData(data[offset:end]), gofuse.OK
 	}
 
-	// Large file or unknown size: range read (avoids O(offset) discard)
+	// Large file or unknown size: range read (avoids O(offset) discard).
+	// Uses detached retry so a single FUSE interrupt / transient error
+	// doesn't permanently return EAGAIN to the caller.
 	if source == "unknown" {
 		source = "range-read"
 	}
 	rangeStart := time.Now()
-	rc, err := fs.client.ReadStreamRange(ctx, p, int64(input.Offset), int64(input.Size))
+	data, n, err := fs.readStreamRangeWithRetry(ctx, p, int64(input.Offset), int64(input.Size))
 	if err != nil {
-		fs.debugf("read range open error path=%s off=%d req=%d source=%s dur=%s err=%v", p, input.Offset, input.Size, source, time.Since(rangeStart), err)
-		return nil, httpToFuseStatus(err)
-	}
-	defer func() { _ = rc.Close() }()
-
-	data := make([]byte, input.Size)
-	n, err := io.ReadFull(rc, data)
-	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
-		fs.debugf("read range body error path=%s off=%d req=%d got=%d source=%s dur=%s err=%v", p, input.Offset, input.Size, n, source, time.Since(rangeStart), err)
+		fs.debugf("read range error path=%s off=%d req=%d got=%d source=%s dur=%s err=%v", p, input.Offset, input.Size, n, source, time.Since(rangeStart), err)
 		return nil, gofuse.EIO
 	}
 	if fs.debugEnabled() && time.Since(rangeStart) >= fuseDebugSlowReadThreshold {
-		fs.debugf("read range done path=%s off=%d req=%d got=%d source=%s err=%v dur=%s", p, input.Offset, input.Size, n, source, err, time.Since(rangeStart))
+		fs.debugf("read range done path=%s off=%d req=%d got=%d source=%s dur=%s", p, input.Offset, input.Size, n, source, time.Since(rangeStart))
 	}
 	bytesRead = n
-	return gofuse.ReadResultData(data[:n]), gofuse.OK
+	if fh.Prefetch != nil {
+		fh.Prefetch.OnRead(int64(input.Offset), n)
+	}
+	return gofuse.ReadResultData(data), gofuse.OK
 }
 
 func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []byte) (written uint32, status gofuse.Status) {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3103,21 +3103,15 @@ func TestReadSmallFileRetryExhaustedReturnsEIO(t *testing.T) {
 	}
 }
 
-// TestDoRangeReadBodyErrorReturnsForRetry verifies that doRangeRead returns
-// body-stage errors (not EOF/UnexpectedEOF) so the retry helper can classify
-// and retry them. This tests the unit contract that enables body-stage retry.
-func TestDoRangeReadBodyErrorReturnsForRetry(t *testing.T) {
-	// Test that doRangeRead passes through body errors that are NOT
-	// io.EOF / io.ErrUnexpectedEOF, allowing the retry wrapper to
-	// classify and potentially retry them.
-	wantErr := context.DeadlineExceeded
-
+// TestDoRangeReadBodyTimeoutReturnsForRetry verifies that doRangeRead surfaces
+// context deadline errors during body read (not swallowed), allowing the retry
+// helper to classify and retry them.
+func TestDoRangeReadBodyTimeoutReturnsForRetry(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Send 200 with large Content-Length but write nothing.
 		// The client's context will be canceled, causing a body read error.
 		w.Header().Set("Content-Length", "1048576")
 		w.WriteHeader(http.StatusOK)
-		// Block until client gives up
 		<-r.Context().Done()
 	}))
 	defer ts.Close()
@@ -3126,7 +3120,6 @@ func TestDoRangeReadBodyErrorReturnsForRetry(t *testing.T) {
 	opts.setDefaults()
 	fs := NewDat9FS(client.New(ts.URL, ""), opts)
 
-	// Use a very short timeout so the test runs fast
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
@@ -3134,13 +3127,49 @@ func TestDoRangeReadBodyErrorReturnsForRetry(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from doRangeRead with expired context")
 	}
-	// The error should be classifiable as transient (context deadline exceeded)
 	if !isTransientReadErr(err) {
 		t.Fatalf("body-stage error %v should be classified as transient", err)
 	}
-	// Verify it wraps the expected cause
-	if !errors.Is(err, wantErr) {
+	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected DeadlineExceeded in error chain, got: %v", err)
+	}
+}
+
+// TestDoRangeReadBodyTruncationReturnsError verifies that when a server sends
+// headers successfully but closes the connection mid-body (truncation),
+// doRangeRead surfaces an error instead of silently returning partial data.
+// This enables the retry helper to detect and retry body-stage truncation.
+func TestDoRangeReadBodyTruncationReturnsError(t *testing.T) {
+	var getCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		getCalls.Add(1)
+		// Hijack the connection: send valid HTTP headers with Content-Length
+		// promising 4096 bytes, write only 10 bytes, then close.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Log("server does not support hijacking")
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		conn, buf, _ := hj.Hijack()
+		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 4096\r\n\r\n")
+		_, _ = buf.Write(make([]byte, 10)) // only 10 of 4096 bytes
+		_ = buf.Flush()
+		_ = conn.Close() // truncate
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	ctx := context.Background()
+	_, n, err := fs.doRangeRead(ctx, "/truncate.bin", 0, 4096)
+	// doRangeRead must return an error for truncated body, not silent success.
+	// The old code (io.ReadFull + ErrUnexpectedEOF filter) would return nil here.
+	if err == nil {
+		t.Fatalf("expected error from truncated body, got nil with n=%d", n)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3,6 +3,7 @@ package fuse
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -3099,6 +3100,117 @@ func TestReadSmallFileRetryExhaustedReturnsEIO(t *testing.T) {
 	wantCalls := int32(1 + readTransientRetryCount)
 	if got := getCalls.Load(); got != wantCalls {
 		t.Fatalf("GET calls = %d, want %d", got, wantCalls)
+	}
+}
+
+// TestDoRangeReadBodyErrorReturnsForRetry verifies that doRangeRead returns
+// body-stage errors (not EOF/UnexpectedEOF) so the retry helper can classify
+// and retry them. This tests the unit contract that enables body-stage retry.
+func TestDoRangeReadBodyErrorReturnsForRetry(t *testing.T) {
+	// Test that doRangeRead passes through body errors that are NOT
+	// io.EOF / io.ErrUnexpectedEOF, allowing the retry wrapper to
+	// classify and potentially retry them.
+	wantErr := context.DeadlineExceeded
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Send 200 with large Content-Length but write nothing.
+		// The client's context will be canceled, causing a body read error.
+		w.Header().Set("Content-Length", "1048576")
+		w.WriteHeader(http.StatusOK)
+		// Block until client gives up
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	// Use a very short timeout so the test runs fast
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, _, err := fs.doRangeRead(ctx, "/test.bin", 0, 4096)
+	if err == nil {
+		t.Fatal("expected error from doRangeRead with expired context")
+	}
+	// The error should be classifiable as transient (context deadline exceeded)
+	if !isTransientReadErr(err) {
+		t.Fatalf("body-stage error %v should be classified as transient", err)
+	}
+	// Verify it wraps the expected cause
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected DeadlineExceeded in error chain, got: %v", err)
+	}
+}
+
+// TestReadPrefetchNotTriggeredOnFailure verifies that Prefetch.OnRead is NOT
+// called when the remote read fails after a prefetch cache miss.
+func TestReadPrefetchNotTriggeredOnFailure(t *testing.T) {
+	fileSize := int64(1 << 20) // 1 MiB — gets a Prefetcher
+	var getCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.FormatInt(fileSize, 10))
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getCalls.Add(1)
+			// All GETs fail with 503 (transient)
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	cancel := make(chan struct{})
+	var entryOut2 gofuse.EntryOut
+	st := fs.Lookup(cancel, &gofuse.InHeader{NodeId: 1}, "prefetch-fail.bin", &entryOut2)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup: %v", st)
+	}
+
+	var openOut gofuse.OpenOut
+	st = fs.Open(cancel, &gofuse.OpenIn{InHeader: gofuse.InHeader{NodeId: entryOut2.NodeId}, Flags: syscall.O_RDONLY}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open: %v", st)
+	}
+
+	// Verify prefetcher is set
+	fh, ok := fs.fileHandles.Get(openOut.Fh)
+	if !ok {
+		t.Fatal("file handle not found")
+	}
+	if fh.Prefetch == nil {
+		t.Fatal("expected Prefetcher for large read-only file")
+	}
+
+	// Read — all remote attempts fail
+	_, st = fs.Read(cancel, &gofuse.ReadIn{Fh: openOut.Fh, Offset: 0, Size: 4096}, nil)
+	if st != gofuse.EIO {
+		t.Fatalf("Read status = %v, want EIO", st)
+	}
+
+	// Verify OnRead was NOT called by checking prefetcher state.
+	// After OnRead, readSize would be set to a non-zero value. Since we
+	// have no direct accessor, we verify indirectly: the prefetcher's
+	// internal sequential tracker should not have advanced. A successful
+	// OnRead would schedule background fetches; with a failing server,
+	// those fetches would generate additional GET calls beyond the
+	// Read retry attempts.
+	//
+	// With 1 initial + 2 retries = 3 GET calls from Read itself.
+	// If OnRead fired, the prefetcher would issue additional GETs.
+	wantMaxCalls := int32(1 + readTransientRetryCount)
+	if got := getCalls.Load(); got > wantMaxCalls {
+		t.Fatalf("GET calls = %d, want <= %d (OnRead should not trigger prefetch on failure)", got, wantMaxCalls)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2933,3 +2933,197 @@ func TestFlushLargeFile_InteractiveStagesShadowAndPendingIndex(t *testing.T) {
 		t.Fatalf("Lookup size = %d, want %d", entryOut.Size, fileSize)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Read detached retry tests
+// ---------------------------------------------------------------------------
+
+// TestReadSmallFileRetryOnTransient verifies that a transient error on the
+// first ReadCtx attempt triggers a detached retry that succeeds, returning
+// data instead of EAGAIN.
+func TestReadSmallFileRetryOnTransient(t *testing.T) {
+	var getCalls atomic.Int32
+	fileData := []byte("hello retry")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(fileData)))
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			n := getCalls.Add(1)
+			if n == 1 {
+				// First GET: simulate transient failure
+				http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			// Retry succeeds
+			w.Header().Set("Content-Length", strconv.Itoa(len(fileData)))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(fileData)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	// Register root inode and do a lookup to populate inode entry
+	cancel := make(chan struct{})
+	var entryOut2 gofuse.EntryOut
+	st := fs.Lookup(cancel, &gofuse.InHeader{NodeId: 1}, "small.txt", &entryOut2)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup: %v", st)
+	}
+
+	// Open the file
+	var openOut gofuse.OpenOut
+	st = fs.Open(cancel, &gofuse.OpenIn{InHeader: gofuse.InHeader{NodeId: entryOut2.NodeId}, Flags: syscall.O_RDONLY}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open: %v", st)
+	}
+
+	// Read — first GET fails 503, retry succeeds
+	result, st := fs.Read(cancel, &gofuse.ReadIn{Fh: openOut.Fh, Offset: 0, Size: uint32(len(fileData))}, nil)
+	if st != gofuse.OK {
+		t.Fatalf("Read status = %v, want OK (must not return EAGAIN)", st)
+	}
+	if result == nil {
+		t.Fatal("Read returned nil result")
+	}
+	got := getCalls.Load()
+	if got < 2 {
+		t.Fatalf("GET calls = %d, want >= 2 (initial + retry)", got)
+	}
+}
+
+// TestReadRangeRetryExhaustedReturnsEIO verifies that when all read retries
+// are exhausted, the Read returns EIO instead of EAGAIN.
+func TestReadRangeRetryExhaustedReturnsEIO(t *testing.T) {
+	var getCalls atomic.Int32
+	fileSize := int64(1 << 20) // 1 MiB — above smallFileThreshold
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.FormatInt(fileSize, 10))
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getCalls.Add(1)
+			// All GETs fail with 503
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	cancel := make(chan struct{})
+	var entryOut2 gofuse.EntryOut
+	st := fs.Lookup(cancel, &gofuse.InHeader{NodeId: 1}, "large.bin", &entryOut2)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup: %v", st)
+	}
+
+	var openOut gofuse.OpenOut
+	st = fs.Open(cancel, &gofuse.OpenIn{InHeader: gofuse.InHeader{NodeId: entryOut2.NodeId}, Flags: syscall.O_RDONLY}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open: %v", st)
+	}
+
+	// Read — all attempts fail 503
+	_, st = fs.Read(cancel, &gofuse.ReadIn{Fh: openOut.Fh, Offset: 0, Size: 4096}, nil)
+	if st != gofuse.EIO {
+		t.Fatalf("Read status = %v, want EIO (must not return EAGAIN)", st)
+	}
+
+	// Verify retries happened: 1 initial + readTransientRetryCount retries
+	wantCalls := int32(1 + readTransientRetryCount)
+	if got := getCalls.Load(); got != wantCalls {
+		t.Fatalf("GET calls = %d, want %d", got, wantCalls)
+	}
+}
+
+// TestReadSmallFileRetryExhaustedReturnsEIO verifies that small file read
+// retries that are all exhausted return EIO, not EAGAIN.
+func TestReadSmallFileRetryExhaustedReturnsEIO(t *testing.T) {
+	var getCalls atomic.Int32
+	fileSize := 100 // small file
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(fileSize))
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getCalls.Add(1)
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	cancel := make(chan struct{})
+	var entryOut2 gofuse.EntryOut
+	st := fs.Lookup(cancel, &gofuse.InHeader{NodeId: 1}, "tiny.txt", &entryOut2)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup: %v", st)
+	}
+
+	var openOut gofuse.OpenOut
+	st = fs.Open(cancel, &gofuse.OpenIn{InHeader: gofuse.InHeader{NodeId: entryOut2.NodeId}, Flags: syscall.O_RDONLY}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open: %v", st)
+	}
+
+	_, st = fs.Read(cancel, &gofuse.ReadIn{Fh: openOut.Fh, Offset: 0, Size: uint32(fileSize)}, nil)
+	if st != gofuse.EIO {
+		t.Fatalf("Read status = %v, want EIO", st)
+	}
+
+	wantCalls := int32(1 + readTransientRetryCount)
+	if got := getCalls.Load(); got != wantCalls {
+		t.Fatalf("GET calls = %d, want %d", got, wantCalls)
+	}
+}
+
+// TestIsTransientReadErr verifies classification of transient read errors.
+func TestIsTransientReadErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context.Canceled", context.Canceled, true},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, true},
+		{"HTTP 503", &client.StatusError{StatusCode: http.StatusServiceUnavailable, Message: "unavailable"}, true},
+		{"HTTP 504", &client.StatusError{StatusCode: http.StatusGatewayTimeout, Message: "timeout"}, true},
+		{"HTTP 500", &client.StatusError{StatusCode: http.StatusInternalServerError, Message: "error"}, true},
+		{"HTTP 404", &client.StatusError{StatusCode: http.StatusNotFound, Message: "not found"}, false},
+		{"HTTP 403", &client.StatusError{StatusCode: http.StatusForbidden, Message: "forbidden"}, false},
+		{"generic error", fmt.Errorf("something broke"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientReadErr(tt.err); got != tt.want {
+				t.Fatalf("isTransientReadErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3114,6 +3114,7 @@ func TestIsTransientReadErr(t *testing.T) {
 		{"context.DeadlineExceeded", context.DeadlineExceeded, true},
 		{"HTTP 503", &client.StatusError{StatusCode: http.StatusServiceUnavailable, Message: "unavailable"}, true},
 		{"HTTP 504", &client.StatusError{StatusCode: http.StatusGatewayTimeout, Message: "timeout"}, true},
+		{"HTTP 502", &client.StatusError{StatusCode: http.StatusBadGateway, Message: "bad gateway"}, true},
 		{"HTTP 500", &client.StatusError{StatusCode: http.StatusInternalServerError, Message: "error"}, true},
 		{"HTTP 404", &client.StatusError{StatusCode: http.StatusNotFound, Message: "not found"}, false},
 		{"HTTP 403", &client.StatusError{StatusCode: http.StatusForbidden, Message: "forbidden"}, false},


### PR DESCRIPTION
## Summary

- FUSE Read now uses bounded detached retries (2×2s) on transient errors instead of immediately returning EAGAIN
- Covers both small file `ReadCtx` and large file `ReadStreamRange`+`io.ReadFull` as full retriable units
- Retry exhausted → EIO (never EAGAIN), preventing juicefs/clients from hanging indefinitely
- `Prefetch.OnRead` only triggered on successful reads, not on failure path
- Does not change global `httpToFuseStatus()` — only the Read path is affected

## Problem

```
FUSE READ → kernel INTERRUPT → fuseCtx cancel → context.Canceled → httpToFuseStatus() → EAGAIN(11) → juicefs holds fd, never retries → hang
```

## Solution

Reuses the existing Lookup detached retry pattern (`statWithTransientRetry`): first attempt honors FUSE cancel, retries use `context.Background()` + short timeout.

## Test plan

- [x] `TestReadSmallFileRetryOnTransient` — first GET 503, retry succeeds → OK (not EAGAIN)
- [x] `TestReadRangeRetryExhaustedReturnsEIO` — all retries fail → EIO (not EAGAIN)
- [x] `TestReadSmallFileRetryExhaustedReturnsEIO` — small file all retries fail → EIO
- [x] `TestIsTransientReadErr` — transient classification table test
- [x] Full `pkg/fuse` test suite passes
- [ ] CI (lint + test + e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)