### PR TITLE
Add DB latency metrics for meta and user stores

### DIFF
--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -131,10 +131,6 @@ func Open(dsn string) (*Store, error) {
 	return &Store{db: db}, nil
 }
 
-func applyMySQLPoolDefaults(db *sql.DB) {
-	mysqlutil.ApplyPoolDefaults(db)
-}
-
 func (s *Store) Close() error { return mysqlutil.CloseInstrumented(s.db) }
 func (s *Store) DB() *sql.DB  { return s.db }
 

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/mysqlutil"
@@ -125,14 +124,9 @@ func Open(dsn string) (*Store, error) {
 	if strings.Contains(lower, "multistatements=true") || strings.Contains(lower, "multistatements=1") {
 		return nil, fmt.Errorf("multiStatements is not allowed in production DSN")
 	}
-	db, err := sql.Open("mysql", dsn)
+	db, err := mysqlutil.OpenInstrumented(context.Background(), dsn, mysqlutil.RoleUser)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
-	}
-	applyMySQLPoolDefaults(db)
-	if err := db.Ping(); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("ping db: %w", err)
 	}
 	return &Store{db: db}, nil
 }
@@ -141,7 +135,7 @@ func applyMySQLPoolDefaults(db *sql.DB) {
 	mysqlutil.ApplyPoolDefaults(db)
 }
 
-func (s *Store) Close() error { return s.db.Close() }
+func (s *Store) Close() error { return mysqlutil.CloseInstrumented(s.db) }
 func (s *Store) DB() *sql.DB  { return s.db }
 
 // InTx runs fn inside a database transaction. If fn returns an error, the

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -101,10 +101,6 @@ func Open(dsn string) (*Store, error) {
 func (s *Store) Close() error { return mysqlutil.CloseInstrumented(s.db) }
 func (s *Store) DB() *sql.DB  { return s.db }
 
-func applyMySQLPoolDefaults(db *sql.DB) {
-	mysqlutil.ApplyPoolDefaults(db)
-}
-
 const metaSchemaMigrateLockNamePrefix = "dat9_meta_schema_migrate:"
 const metaSchemaMigrateLockTimeoutSeconds = 30
 

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
-
 	"github.com/mem9-ai/dat9/internal/schemaspec"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"
@@ -88,24 +86,19 @@ func Open(dsn string) (*Store, error) {
 	if strings.Contains(dsn, "multiStatements=true") {
 		return nil, fmt.Errorf("multiStatements=true is not allowed in production DSN")
 	}
-	db, err := sql.Open("mysql", dsn)
+	db, err := mysqlutil.OpenInstrumented(context.Background(), dsn, mysqlutil.RoleMeta)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
-	applyMySQLPoolDefaults(db)
-	if err := db.Ping(); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("ping db: %w", err)
-	}
 	s := &Store{db: db}
 	if err := s.migrate(); err != nil {
-		_ = db.Close()
+		_ = mysqlutil.CloseInstrumented(db)
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 	return s, nil
 }
 
-func (s *Store) Close() error { return s.db.Close() }
+func (s *Store) Close() error { return mysqlutil.CloseInstrumented(s.db) }
 func (s *Store) DB() *sql.DB  { return s.db }
 
 func applyMySQLPoolDefaults(db *sql.DB) {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -2,9 +2,12 @@ package meta
 
 import (
 	"context"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/metrics"
 )
 
 func newControlStore(t *testing.T) *Store {
@@ -18,6 +21,37 @@ func newControlStore(t *testing.T) *Store {
 	_, _ = s.DB().Exec("DELETE FROM tenants")
 	_, _ = s.DB().Exec("DELETE FROM llm_usage")
 	return s
+}
+
+func TestMetaDBMetrics(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertTenant(context.Background(), &Tenant{
+		ID:               "metrics-meta-tenant",
+		Status:           TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_db_metrics",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `dat9_db_operations_total{role="meta"`) {
+		t.Fatalf("expected meta db operation metric in response: %s", text)
+	}
+	if !strings.Contains(text, `dat9_db_pool_registered{role="meta"}`) {
+		t.Fatalf("expected meta db pool metric in response: %s", text)
+	}
 }
 
 func TestInsertAndResolveByAPIKeyHash(t *testing.T) {

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -1,0 +1,182 @@
+package metrics
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type dbMetrics struct {
+	mu             sync.RWMutex
+	counts         map[string]int64
+	durationCount  map[string]int64
+	durationSum    map[string]float64
+	durationBucket map[string][]int64
+	dbs            map[*sql.DB]string
+}
+
+type dbPoolTotals struct {
+	registered         int64
+	openConnections    int64
+	inUseConnections   int64
+	idleConnections    int64
+	maxOpenConnections int64
+	waitCount          int64
+	waitDuration       float64
+	maxIdleClosed      int64
+	maxIdleTimeClosed  int64
+	maxLifetimeClosed  int64
+}
+
+var dbOperationDurationBounds = []float64{0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
+
+var globalDB = &dbMetrics{
+	counts:         map[string]int64{},
+	durationCount:  map[string]int64{},
+	durationSum:    map[string]float64{},
+	durationBucket: map[string][]int64{},
+	dbs:            map[*sql.DB]string{},
+}
+
+func RecordDBOperation(role, operation, result string, d time.Duration) {
+	key := dbLabels(role, operation, result)
+	globalDB.mu.Lock()
+	globalDB.counts[key]++
+	globalDB.durationCount[key]++
+	globalDB.durationSum[key] += d.Seconds()
+	buckets := globalDB.durationBucket[key]
+	if buckets == nil {
+		buckets = make([]int64, len(dbOperationDurationBounds))
+		globalDB.durationBucket[key] = buckets
+	}
+	seconds := d.Seconds()
+	for i, bound := range dbOperationDurationBounds {
+		if seconds <= bound {
+			buckets[i]++
+		}
+	}
+	globalDB.mu.Unlock()
+}
+
+func RegisterDB(role string, db *sql.DB) {
+	if db == nil {
+		return
+	}
+	globalDB.mu.Lock()
+	globalDB.dbs[db] = role
+	globalDB.mu.Unlock()
+}
+
+func UnregisterDB(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	globalDB.mu.Lock()
+	delete(globalDB.dbs, db)
+	globalDB.mu.Unlock()
+}
+
+func writeDBPrometheus(w http.ResponseWriter) {
+	globalDB.mu.RLock()
+	countKeys := SortedKeys(globalDB.counts)
+	counts := CloneIntMap(globalDB.counts)
+	durationCount := CloneIntMap(globalDB.durationCount)
+	durationSum := CloneFloatMap(globalDB.durationSum)
+	durationBucket := CloneBucketMap(globalDB.durationBucket)
+	dbByRole := make(map[*sql.DB]string, len(globalDB.dbs))
+	for db, role := range globalDB.dbs {
+		dbByRole[db] = role
+	}
+	globalDB.mu.RUnlock()
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_db_operations_total Database operations by role/operation/result")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_operations_total counter")
+	for _, k := range countKeys {
+		_, _ = fmt.Fprintf(w, "dat9_db_operations_total{%s} %d\n", k, counts[k])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_db_operation_duration_seconds Database operation duration histogram")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_operation_duration_seconds histogram")
+	for _, k := range countKeys {
+		buckets := durationBucket[k]
+		for i, bound := range dbOperationDurationBounds {
+			_, _ = fmt.Fprintf(w, "dat9_db_operation_duration_seconds_bucket{%s,le=\"%s\"} %d\n", k, FormatPromBound(bound), buckets[i])
+		}
+		_, _ = fmt.Fprintf(w, "dat9_db_operation_duration_seconds_bucket{%s,le=\"+Inf\"} %d\n", k, durationCount[k])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_db_operation_duration_seconds_count Database operation duration count")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_operation_duration_seconds_count counter")
+	for _, k := range countKeys {
+		_, _ = fmt.Fprintf(w, "dat9_db_operation_duration_seconds_count{%s} %d\n", k, durationCount[k])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_db_operation_duration_seconds_sum Database operation duration sum in seconds")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_operation_duration_seconds_sum counter")
+	for _, k := range countKeys {
+		_, _ = fmt.Fprintf(w, "dat9_db_operation_duration_seconds_sum{%s} %.6f\n", k, durationSum[k])
+	}
+
+	poolTotals := make(map[string]dbPoolTotals)
+	for db, role := range dbByRole {
+		stats := db.Stats()
+		totals := poolTotals[role]
+		totals.registered++
+		totals.openConnections += int64(stats.OpenConnections)
+		totals.inUseConnections += int64(stats.InUse)
+		totals.idleConnections += int64(stats.Idle)
+		totals.maxOpenConnections += int64(stats.MaxOpenConnections)
+		totals.waitCount += stats.WaitCount
+		totals.waitDuration += stats.WaitDuration.Seconds()
+		totals.maxIdleClosed += stats.MaxIdleClosed
+		totals.maxIdleTimeClosed += stats.MaxIdleTimeClosed
+		totals.maxLifetimeClosed += stats.MaxLifetimeClosed
+		poolTotals[role] = totals
+	}
+	roles := SortedKeys(poolTotals)
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_db_pool_registered Database pools currently registered for metrics by role")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_pool_registered gauge")
+	for _, role := range roles {
+		_, _ = fmt.Fprintf(w, "dat9_db_pool_registered{role=\"%s\"} %d\n", EscapePromLabel(role), poolTotals[role].registered)
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_db_pool_connections Aggregated database pool connections by role/state")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_pool_connections gauge")
+	for _, role := range roles {
+		totals := poolTotals[role]
+		escapedRole := EscapePromLabel(role)
+		_, _ = fmt.Fprintf(w, "dat9_db_pool_connections{role=\"%s\",state=\"open\"} %d\n", escapedRole, totals.openConnections)
+		_, _ = fmt.Fprintf(w, "dat9_db_pool_connections{role=\"%s\",state=\"in_use\"} %d\n", escapedRole, totals.inUseConnections)
+		_, _ = fmt.Fprintf(w, "dat9_db_pool_connections{role=\"%s\",state=\"idle\"} %d\n", escapedRole, totals.idleConnections)
+		_, _ = fmt.Fprintf(w, "dat9_db_pool_connections{role=\"%s\",state=\"max_open\"} %d\n", escapedRole, totals.maxOpenConnections)
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_db_pool_wait_count_total Aggregated database pool wait count by role")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_pool_wait_count_total counter")
+	for _, role := range roles {
+		_, _ = fmt.Fprintf(w, "dat9_db_pool_wait_count_total{role=\"%s\"} %d\n", EscapePromLabel(role), poolTotals[role].waitCount)
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_db_pool_wait_duration_seconds_total Aggregated database pool wait duration by role")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_pool_wait_duration_seconds_total counter")
+	for _, role := range roles {
+		_, _ = fmt.Fprintf(w, "dat9_db_pool_wait_duration_seconds_total{role=\"%s\"} %.6f\n", EscapePromLabel(role), poolTotals[role].waitDuration)
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_db_pool_closes_total Aggregated database pool closes by role/reason")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_pool_closes_total counter")
+	for _, role := range roles {
+		totals := poolTotals[role]
+		escapedRole := EscapePromLabel(role)
+		_, _ = fmt.Fprintf(w, "dat9_db_pool_closes_total{role=\"%s\",reason=\"max_idle\"} %d\n", escapedRole, totals.maxIdleClosed)
+		_, _ = fmt.Fprintf(w, "dat9_db_pool_closes_total{role=\"%s\",reason=\"max_idle_time\"} %d\n", escapedRole, totals.maxIdleTimeClosed)
+		_, _ = fmt.Fprintf(w, "dat9_db_pool_closes_total{role=\"%s\",reason=\"max_lifetime\"} %d\n", escapedRole, totals.maxLifetimeClosed)
+	}
+}
+
+func dbLabels(role, operation, result string) string {
+	return "role=\"" + EscapePromLabel(role) + "\",operation=\"" + EscapePromLabel(operation) + "\",result=\"" + EscapePromLabel(result) + "\""
+}

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -98,6 +98,8 @@ func WritePrometheus(w http.ResponseWriter) {
 	for _, k := range gaugeKeys {
 		_, _ = fmt.Fprintf(w, "dat9_service_gauge{%s} %.6f\n", k, gauges[k])
 	}
+
+	writeDBPrometheus(w)
 }
 
 func labels(component, operation, result string) string {

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -29,7 +29,7 @@ func OpenInstrumented(ctx context.Context, dsn, role string) (*sql.DB, error) {
 	if err := db.PingContext(ctx); err != nil {
 		metrics.UnregisterDB(db)
 		_ = db.Close()
-		return nil, err
+		return nil, fmt.Errorf("ping mysql: %w", err)
 	}
 	return db, nil
 }

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -85,15 +85,7 @@ func (c instrumentedConn) Close() error {
 }
 
 func (c instrumentedConn) Begin() (driver.Tx, error) {
-	start := time.Now()
-	tx, err := c.base.Begin()
-	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(c.role, "begin", start, err)
-	}
-	if err != nil {
-		return nil, err
-	}
-	return instrumentedTx{base: tx, role: c.role}, nil
+	return c.BeginTx(context.Background(), driver.TxOptions{})
 }
 
 func (c instrumentedConn) Ping(ctx context.Context) error {
@@ -140,33 +132,7 @@ func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (d
 	if opts.Isolation != driver.IsolationLevel(0) || opts.ReadOnly {
 		return nil, fmt.Errorf("driver does not support non-default transaction options")
 	}
-	return c.Begin()
-}
-
-func (c instrumentedConn) Exec(query string, args []driver.Value) (driver.Result, error) {
-	execer, ok := c.base.(driver.Execer)
-	if !ok {
-		return nil, driver.ErrSkip
-	}
-	start := time.Now()
-	res, err := execer.Exec(query, args)
-	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(c.role, "exec", start, err)
-	}
-	return res, err
-}
-
-func (c instrumentedConn) Query(query string, args []driver.Value) (driver.Rows, error) {
-	queryer, ok := c.base.(driver.Queryer)
-	if !ok {
-		return nil, driver.ErrSkip
-	}
-	start := time.Now()
-	rows, err := queryer.Query(query, args)
-	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(c.role, "query", start, err)
-	}
-	return rows, err
+	return nil, driver.ErrSkip
 }
 
 func (c instrumentedConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -233,21 +199,11 @@ func (s instrumentedStmt) NumInput() int {
 }
 
 func (s instrumentedStmt) Exec(args []driver.Value) (driver.Result, error) {
-	start := time.Now()
-	res, err := s.base.Exec(args)
-	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(s.role, "exec", start, err)
-	}
-	return res, err
+	return s.ExecContext(context.Background(), toNamedValues(args))
 }
 
 func (s instrumentedStmt) Query(args []driver.Value) (driver.Rows, error) {
-	start := time.Now()
-	rows, err := s.base.Query(args)
-	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(s.role, "query", start, err)
-	}
-	return rows, err
+	return s.QueryContext(context.Background(), toNamedValues(args))
 }
 
 func (s instrumentedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
@@ -274,14 +230,6 @@ func (s instrumentedStmt) QueryContext(ctx context.Context, args []driver.NamedV
 		observeDBOperation(s.role, "query", start, err)
 	}
 	return rows, err
-}
-
-func (s instrumentedStmt) ColumnConverter(idx int) driver.ValueConverter {
-	converter, ok := s.base.(driver.ColumnConverter)
-	if !ok {
-		return driver.DefaultParameterConverter
-	}
-	return converter.ColumnConverter(idx)
 }
 
 func (s instrumentedStmt) CheckNamedValue(nv *driver.NamedValue) error {
@@ -332,4 +280,18 @@ func dbResult(err error) string {
 	default:
 		return "error"
 	}
+}
+
+func toNamedValues(args []driver.Value) []driver.NamedValue {
+	if len(args) == 0 {
+		return nil
+	}
+	named := make([]driver.NamedValue, 0, len(args))
+	for idx, arg := range args {
+		named = append(named, driver.NamedValue{
+			Ordinal: idx + 1,
+			Value:   arg,
+		})
+	}
+	return named
 }

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -1,0 +1,335 @@
+package mysqlutil
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/mem9-ai/dat9/pkg/metrics"
+)
+
+const (
+	RoleMeta = "meta"
+	RoleUser = "user"
+)
+
+func OpenInstrumented(ctx context.Context, dsn, role string) (*sql.DB, error) {
+	connector, err := (&mysql.MySQLDriver{}).OpenConnector(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open mysql connector: %w", err)
+	}
+	db := sql.OpenDB(instrumentedConnector{base: connector, role: role})
+	ApplyPoolDefaults(db)
+	metrics.RegisterDB(role, db)
+	if err := db.PingContext(ctx); err != nil {
+		metrics.UnregisterDB(db)
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func CloseInstrumented(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+	metrics.UnregisterDB(db)
+	return db.Close()
+}
+
+type instrumentedConnector struct {
+	base driver.Connector
+	role string
+}
+
+func (c instrumentedConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	start := time.Now()
+	conn, err := c.base.Connect(ctx)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(c.role, "connect", start, err)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return instrumentedConn{base: conn, role: c.role}, nil
+}
+
+func (c instrumentedConnector) Driver() driver.Driver {
+	return c.base.Driver()
+}
+
+type instrumentedConn struct {
+	base driver.Conn
+	role string
+}
+
+func (c instrumentedConn) Prepare(query string) (driver.Stmt, error) {
+	start := time.Now()
+	stmt, err := c.base.Prepare(query)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(c.role, "prepare", start, err)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return instrumentedStmt{base: stmt, role: c.role}, nil
+}
+
+func (c instrumentedConn) Close() error {
+	return c.base.Close()
+}
+
+func (c instrumentedConn) Begin() (driver.Tx, error) {
+	start := time.Now()
+	tx, err := c.base.Begin()
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(c.role, "begin", start, err)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return instrumentedTx{base: tx, role: c.role}, nil
+}
+
+func (c instrumentedConn) Ping(ctx context.Context) error {
+	pinger, ok := c.base.(driver.Pinger)
+	if !ok {
+		return nil
+	}
+	start := time.Now()
+	err := pinger.Ping(ctx)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(c.role, "ping", start, err)
+	}
+	return err
+}
+
+func (c instrumentedConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	prep, ok := c.base.(driver.ConnPrepareContext)
+	if !ok {
+		return c.Prepare(query)
+	}
+	start := time.Now()
+	stmt, err := prep.PrepareContext(ctx, query)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(c.role, "prepare", start, err)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return instrumentedStmt{base: stmt, role: c.role}, nil
+}
+
+func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if beginner, ok := c.base.(driver.ConnBeginTx); ok {
+		start := time.Now()
+		tx, err := beginner.BeginTx(ctx, opts)
+		if !errors.Is(err, driver.ErrSkip) {
+			observeDBOperation(c.role, "begin", start, err)
+		}
+		if err != nil {
+			return nil, err
+		}
+		return instrumentedTx{base: tx, role: c.role}, nil
+	}
+	if opts.Isolation != driver.IsolationLevel(0) || opts.ReadOnly {
+		return nil, fmt.Errorf("driver does not support non-default transaction options")
+	}
+	return c.Begin()
+}
+
+func (c instrumentedConn) Exec(query string, args []driver.Value) (driver.Result, error) {
+	execer, ok := c.base.(driver.Execer)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	start := time.Now()
+	res, err := execer.Exec(query, args)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(c.role, "exec", start, err)
+	}
+	return res, err
+}
+
+func (c instrumentedConn) Query(query string, args []driver.Value) (driver.Rows, error) {
+	queryer, ok := c.base.(driver.Queryer)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	start := time.Now()
+	rows, err := queryer.Query(query, args)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(c.role, "query", start, err)
+	}
+	return rows, err
+}
+
+func (c instrumentedConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	execer, ok := c.base.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	start := time.Now()
+	res, err := execer.ExecContext(ctx, query, args)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(c.role, "exec", start, err)
+	}
+	return res, err
+}
+
+func (c instrumentedConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	queryer, ok := c.base.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	start := time.Now()
+	rows, err := queryer.QueryContext(ctx, query, args)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(c.role, "query", start, err)
+	}
+	return rows, err
+}
+
+func (c instrumentedConn) ResetSession(ctx context.Context) error {
+	resetter, ok := c.base.(driver.SessionResetter)
+	if !ok {
+		return nil
+	}
+	return resetter.ResetSession(ctx)
+}
+
+func (c instrumentedConn) IsValid() bool {
+	validator, ok := c.base.(driver.Validator)
+	if !ok {
+		return true
+	}
+	return validator.IsValid()
+}
+
+func (c instrumentedConn) CheckNamedValue(nv *driver.NamedValue) error {
+	checker, ok := c.base.(driver.NamedValueChecker)
+	if !ok {
+		return driver.ErrSkip
+	}
+	return checker.CheckNamedValue(nv)
+}
+
+type instrumentedStmt struct {
+	base driver.Stmt
+	role string
+}
+
+func (s instrumentedStmt) Close() error {
+	return s.base.Close()
+}
+
+func (s instrumentedStmt) NumInput() int {
+	return s.base.NumInput()
+}
+
+func (s instrumentedStmt) Exec(args []driver.Value) (driver.Result, error) {
+	start := time.Now()
+	res, err := s.base.Exec(args)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(s.role, "exec", start, err)
+	}
+	return res, err
+}
+
+func (s instrumentedStmt) Query(args []driver.Value) (driver.Rows, error) {
+	start := time.Now()
+	rows, err := s.base.Query(args)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(s.role, "query", start, err)
+	}
+	return rows, err
+}
+
+func (s instrumentedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	execer, ok := s.base.(driver.StmtExecContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	start := time.Now()
+	res, err := execer.ExecContext(ctx, args)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(s.role, "exec", start, err)
+	}
+	return res, err
+}
+
+func (s instrumentedStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	queryer, ok := s.base.(driver.StmtQueryContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	start := time.Now()
+	rows, err := queryer.QueryContext(ctx, args)
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(s.role, "query", start, err)
+	}
+	return rows, err
+}
+
+func (s instrumentedStmt) ColumnConverter(idx int) driver.ValueConverter {
+	converter, ok := s.base.(driver.ColumnConverter)
+	if !ok {
+		return driver.DefaultParameterConverter
+	}
+	return converter.ColumnConverter(idx)
+}
+
+func (s instrumentedStmt) CheckNamedValue(nv *driver.NamedValue) error {
+	checker, ok := s.base.(driver.NamedValueChecker)
+	if !ok {
+		return driver.ErrSkip
+	}
+	return checker.CheckNamedValue(nv)
+}
+
+type instrumentedTx struct {
+	base driver.Tx
+	role string
+}
+
+func (tx instrumentedTx) Commit() error {
+	start := time.Now()
+	err := tx.base.Commit()
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(tx.role, "commit", start, err)
+	}
+	return err
+}
+
+func (tx instrumentedTx) Rollback() error {
+	start := time.Now()
+	err := tx.base.Rollback()
+	if !errors.Is(err, driver.ErrSkip) {
+		observeDBOperation(tx.role, "rollback", start, err)
+	}
+	return err
+}
+
+func observeDBOperation(role, operation string, start time.Time, err error) {
+	metrics.RecordDBOperation(role, operation, dbResult(err), time.Since(start))
+}
+
+func dbResult(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	case errors.Is(err, driver.ErrBadConn):
+		return "bad_conn"
+	default:
+		return "error"
+	}
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -989,6 +989,12 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `dat9_service_operation_duration_seconds_bucket{component="backend",operation="exec_sql",result="ok",le="0.01"}`) {
 		t.Fatalf("expected service operation histogram bucket in response: %s", text)
 	}
+	if !strings.Contains(text, `dat9_db_operations_total{role="user"`) {
+		t.Fatalf("expected user db operation metric in response: %s", text)
+	}
+	if !strings.Contains(text, `dat9_db_pool_registered{role="user"}`) {
+		t.Fatalf("expected user db pool metric in response: %s", text)
+	}
 	if !strings.Contains(text, `dat9_tenant_events_total{event="fs_write",result="ok"}`) {
 		t.Fatalf("expected fs_write tenant event metric in response: %s", text)
 	}

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -148,7 +148,7 @@ func initTiDBAppEmbeddingSchema(ctx context.Context, dsn string, opts InitTiDBTe
 	if err != nil {
 		return err
 	}
-	defer func() { _ = db.Close() }()
+	defer func() { _ = closeTiDBSchemaDB(db) }()
 	if !IsTiDBCluster(ctx, db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mem9-ai/dat9/internal/schemaspec"
 	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/mysqlutil"
 	"go.uber.org/zap"
 )
 
@@ -384,7 +385,7 @@ func initTiDBAutoEmbeddingSchema(dsn string) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = db.Close() }()
+	defer func() { _ = closeTiDBSchemaDB(db) }()
 	if !IsTiDBCluster(context.Background(), db) {
 		return fmt.Errorf("provider requires TiDB capabilities (FTS/VECTOR)")
 	}
@@ -400,7 +401,7 @@ func ValidateTiDBSchemaForModeDSN(ctx context.Context, dsn string, mode TiDBEmbe
 	if err != nil {
 		return err
 	}
-	defer func() { _ = db.Close() }()
+	defer func() { _ = closeTiDBSchemaDB(db) }()
 	return ValidateTiDBSchemaForMode(ctx, db, mode)
 }
 
@@ -411,7 +412,7 @@ func EnsureTiDBSchemaForModeDSN(ctx context.Context, dsn string, mode TiDBEmbedd
 	if err != nil {
 		return err
 	}
-	defer func() { _ = db.Close() }()
+	defer func() { _ = closeTiDBSchemaDB(db) }()
 	return EnsureTiDBSchemaForMode(ctx, db, mode)
 }
 
@@ -419,15 +420,15 @@ func OpenTiDBSchemaDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	if HasMultiStatements(dsn) {
 		return nil, fmt.Errorf("multiStatements is not allowed")
 	}
-	db, err := sql.Open("mysql", dsn)
+	db, err := mysqlutil.OpenInstrumented(ctx, dsn, mysqlutil.RoleUser)
 	if err != nil {
 		return nil, err
 	}
-	if err := db.PingContext(ctx); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
 	return db, nil
+}
+
+func closeTiDBSchemaDB(db *sql.DB) error {
+	return mysqlutil.CloseInstrumented(db)
 }
 
 func detectTiDBEmbeddingModeFromFilesMeta(meta tidbTableMeta) (TiDBEmbeddingMode, error) {


### PR DESCRIPTION
## Summary
Add database latency and pool metrics for both meta DB and user DB paths.

## Changes
- add driver-level MySQL instrumentation for connect, ping, prepare, query, exec, begin, commit, and rollback
- export DB latency histograms and pool metrics through the existing /metrics endpoint
- route meta store, datastore, and TiDB tenant schema open/close paths through the instrumented MySQL helper
- add tests covering meta-role and user-role DB metrics visibility

## Validation
- go test ./pkg/meta ./pkg/server ./pkg/tenant/schema ./pkg/datastore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive database operation metrics tracking including operation counts, durations, and pool statistics
  * All database connections now use centralized instrumentation for consistent monitoring
  * Metrics exposed via the metrics endpoint with role-based categorization

* **Tests**
  * Added test coverage to validate database metrics reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->