### PR TITLE
Handle non-retryable audio extract errors

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -333,6 +333,7 @@ environment:
   DRIVE9_LOCAL_EMBEDDING_MODE auto|app|detect (default: auto when initing schema, detect otherwise)
   DRIVE9_LOCAL_META_DSN  local control-plane MySQL DSN for central quota (optional; enables server-mode quota enforcement)
   DRIVE9_VAULT_MASTER_KEY 32-byte hex key for vault DEK wrapping (omit to disable vault)
+  DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
 
   S3 storage:

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -341,6 +341,7 @@ environment:
   DRIVE9_TOKEN_SIGNING_KEY  32-byte hex key for JWT API key signing
   DRIVE9_VAULT_MASTER_KEY   32-byte hex key for vault DEK wrapping (omit to disable vault)
   DRIVE9_MAX_UPLOAD_BYTES maximum allowed upload size in bytes (default: %d, minimum: 1048576)
+  DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
   DRIVE9_QUOTA_SOURCE tenant|server quota enforcement source (default: tenant)
   DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -399,7 +399,7 @@ environment:
   not enable that semantic_tasks pipeline. When enabled, explicit provider wiring is required:
   DRIVE9_AUDIO_EXTRACT_ENABLED true|false (default: false)
   DRIVE9_AUDIO_EXTRACT_MODE     openai|qwen-asr (default: openai)
-  DRIVE9_AUDIO_EXTRACT_MAX_BYTES max audio bytes processed per task (default: 33554432 for openai, 10485760 for qwen-asr)
+  DRIVE9_AUDIO_EXTRACT_MAX_BYTES max audio bytes processed per task (default: 33554432 for openai, 7340032 for qwen-asr)
   DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS extractor timeout seconds (default: 120)
   DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES max transcript bytes stored in files.content_text (default: 8192)
   DRIVE9_AUDIO_EXTRACT_API_BASE OpenAI-compatible base URL (required when enabled)
@@ -596,7 +596,9 @@ func buildAudioExtractOptionsFromEnv() (backend.AsyncAudioExtractOptions, error)
 		}
 		audioExtractor = extractor
 	case "qwen-asr":
-		maxAudioBytesDefault = 10 << 20
+		// Qwen-ASR enforces a 10 MB cap on the base64-encoded data URL.
+		// 7 MiB raw audio encodes to about 9.8 MB, leaving room for the prefix.
+		maxAudioBytesDefault = 7 << 20
 		extractor, err := backend.NewQwenASRAudioTextExtractor(backend.QwenASRAudioTextExtractorConfig{
 			BaseURL: audioBaseURL,
 			APIKey:  audioAPIKey,

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -226,8 +226,8 @@ func TestBuildAudioExtractOptionsFromEnvQwenASRDefaultMaxBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildAudioExtractOptionsFromEnv: %v", err)
 	}
-	if opts.MaxAudioBytes != 10485760 {
-		t.Fatalf("MaxAudioBytes=%d, want 10485760", opts.MaxAudioBytes)
+	if opts.MaxAudioBytes != 7340032 {
+		t.Fatalf("MaxAudioBytes=%d, want 7340032", opts.MaxAudioBytes)
 	}
 }
 

--- a/cmd/drive9/cli/stat.go
+++ b/cmd/drive9/cli/stat.go
@@ -60,6 +60,9 @@ func Stat(c *client.Client, args []string) error {
 
 	fmt.Printf("size: %d\n", m.Size)
 	fmt.Printf("isdir: %v\n", m.IsDir)
+	if m.ResourceID != "" {
+		fmt.Printf("resource_id: %s\n", m.ResourceID)
+	}
 	fmt.Printf("revision: %d\n", m.Revision)
 	if m.Mtime != nil {
 		fmt.Printf("mtime: %s\n", time.Unix(*m.Mtime, 0).UTC().Format(time.RFC3339))

--- a/cmd/drive9/cli/stat_test.go
+++ b/cmd/drive9/cli/stat_test.go
@@ -20,6 +20,7 @@ func TestStatDefaultOutputIncludesMetadataFields(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"size":          12,
 			"isdir":         false,
+			"resource_id":   "file-meta",
 			"revision":      3,
 			"mtime":         1700000000,
 			"content_type":  "text/plain",
@@ -42,6 +43,9 @@ func TestStatDefaultOutputIncludesMetadataFields(t *testing.T) {
 	}
 	if !strings.Contains(out, "semantic_text: hello world\n") {
 		t.Fatalf("output missing semantic_text: %q", out)
+	}
+	if !strings.Contains(out, "resource_id: file-meta\n") {
+		t.Fatalf("output missing resource_id: %q", out)
 	}
 	if !strings.Contains(out, "mtime: 2023-11-14T22:13:20Z\n") {
 		t.Fatalf("output missing RFC3339 mtime: %q", out)
@@ -66,6 +70,7 @@ func TestStatJSONOutput(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"size":          5,
 			"isdir":         false,
+			"resource_id":   "file-doc",
 			"revision":      1,
 			"content_type":  "text/plain",
 			"semantic_text": "hello",
@@ -85,7 +90,7 @@ func TestStatJSONOutput(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &got); err != nil {
 		t.Fatalf("json.Unmarshal output: %v\noutput=%q", err, out)
 	}
-	if got.Size != 5 || got.Revision != 1 || got.Tags["k"] != "v" {
+	if got.Size != 5 || got.ResourceID != "file-doc" || got.Revision != 1 || got.Tags["k"] != "v" {
 		t.Fatalf("unexpected json output: %+v", got)
 	}
 }

--- a/pkg/backend/audio_extract.go
+++ b/pkg/backend/audio_extract.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/pingcap/failpoint"
@@ -25,6 +26,51 @@ type AudioExtractRequest struct {
 // AudioTextExtractor extracts searchable transcript text from audio bytes.
 type AudioTextExtractor interface {
 	ExtractAudioText(ctx context.Context, req AudioExtractRequest) (string, AudioExtractUsage, error)
+}
+
+// AudioExtractAPIError describes an HTTP/API failure returned by an audio
+// transcription provider.
+type AudioExtractAPIError struct {
+	Provider   string
+	StatusCode int
+	Message    string
+}
+
+func (e *AudioExtractAPIError) Error() string {
+	provider := strings.TrimSpace(e.Provider)
+	if provider == "" {
+		provider = "audio extract"
+	}
+	if e.Message != "" {
+		return fmt.Sprintf("%s api status %d: %s", provider, e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("%s api status %d", provider, e.StatusCode)
+}
+
+// NonRetryableAudioExtract reports whether retrying the same audio bytes cannot
+// reasonably succeed without changing the request, file, or provider account.
+func (e *AudioExtractAPIError) NonRetryableAudioExtract() bool {
+	switch e.StatusCode {
+	case http.StatusBadRequest,
+		http.StatusForbidden:
+		return true
+	default:
+		return false
+	}
+}
+
+type nonRetryableAudioExtractError interface {
+	NonRetryableAudioExtract() bool
+}
+
+// IsNonRetryableAudioExtractError reports whether err should bypass normal
+// semantic worker retry scheduling for an audio_extract_text task.
+func IsNonRetryableAudioExtractError(err error) bool {
+	var permanent nonRetryableAudioExtractError
+	if errors.As(err, &permanent) {
+		return permanent.NonRetryableAudioExtract()
+	}
+	return false
 }
 
 // AudioExtractTaskSpec carries the revision-scoped inputs needed to extract

--- a/pkg/backend/audio_extract_qwen_asr.go
+++ b/pkg/backend/audio_extract_qwen_asr.go
@@ -152,7 +152,7 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 		return "", AudioExtractUsage{}, fmt.Errorf("read qwen asr response for %q: %w", req.Path, err)
 	}
 	if responseTooLarge {
-		message := fmt.Sprintf("qwen asr response exceeds %d byte limit (raw=%s)", qwenASRMaxResponseBytes, truncateString(string(raw), 256))
+		message := fmt.Sprintf("qwen asr response exceeds %d byte limit (response_bytes>%d)", qwenASRMaxResponseBytes, qwenASRMaxResponseBytes)
 		if resp.StatusCode >= 300 {
 			return "", AudioExtractUsage{}, &AudioExtractAPIError{
 				Provider:   "qwen asr",
@@ -162,7 +162,9 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 		}
 		return "", AudioExtractUsage{}, errors.New(message)
 	}
+	maskedResponse := maskQwenASRResponseBodyForLog(raw)
 	var parsed struct {
+		ID    string `json:"id"`
 		Error *struct {
 			Message string `json:"message"`
 		} `json:"error"`
@@ -181,21 +183,21 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		// If we can't parse the response, include the raw body in the error for debugging.
 		if resp.StatusCode >= 300 {
 			return "", AudioExtractUsage{}, &AudioExtractAPIError{
 				Provider:   "qwen asr",
 				StatusCode: resp.StatusCode,
-				Message:    truncateString(string(raw), 256),
+				Message:    "invalid response body",
 			}
 		}
-		return "", AudioExtractUsage{}, fmt.Errorf("decode qwen asr response: %w (raw=%s)", err, truncateString(string(raw), 256))
+		return "", AudioExtractUsage{}, fmt.Errorf("decode qwen asr response: %w", err)
 	}
 	logger.Debug(ctx, "qwen_asr_response_body",
 		zap.String("path", req.Path),
 		zap.Int("status_code", resp.StatusCode),
+		zap.String("provider_request_id", parsed.ID),
 		zap.Int("response_bytes", len(raw)),
-		zap.String("response_body", maskQwenASRResponseBodyForLog(raw)))
+		zap.String("response_body", maskedResponse))
 
 	// Reference: https://help.aliyun.com/zh/model-studio/error-code
 	// If the status code indicates an error, return an API error with details if available.
@@ -213,7 +215,7 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 		}
 	}
 	if len(parsed.Choices) == 0 {
-		return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api returned no choices (raw=%s)", truncateString(string(raw), 256))
+		return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api returned no choices (response=%s)", maskedResponse)
 	}
 	text := extractOpenAIContentText(parsed.Choices[0].Message.Content)
 	if strings.TrimSpace(text) == "" {
@@ -242,12 +244,12 @@ func readQwenASRResponseBody(r io.Reader) ([]byte, bool, error) {
 func maskQwenASRResponseBodyForLog(raw []byte) string {
 	var body any
 	if err := json.Unmarshal(raw, &body); err != nil {
-		return truncateString(string(raw), 4096)
+		return "[unparseable response body]"
 	}
 	maskQwenASRChoicesContent(body)
 	masked, err := json.Marshal(body)
 	if err != nil {
-		return truncateString(string(raw), 4096)
+		return "[unparseable response body]"
 	}
 	return truncateString(string(masked), 4096)
 }

--- a/pkg/backend/audio_extract_qwen_asr.go
+++ b/pkg/backend/audio_extract_qwen_asr.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const qwenASRMaxDataURLBytes = 10_000_000
+
 // QwenASRAudioTextExtractorConfig configures Alibaba Cloud Model Studio
 // Qwen-ASR through DashScope's OpenAI-compatible chat/completions endpoint.
 // Reference: https://help.aliyun.com/zh/model-studio/qwen-asr-api-reference
@@ -79,9 +81,22 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 	if contentType == "" {
 		contentType = "audio/mpeg"
 	}
-	audioURL := "data:" + contentType + ";base64," + base64.StdEncoding.EncodeToString(req.Data)
+	audioURLPrefix := "data:" + contentType + ";base64,"
+	encodedAudioBytes := base64.StdEncoding.EncodedLen(len(req.Data)) + len(audioURLPrefix)
+	if encodedAudioBytes > qwenASRMaxDataURLBytes {
+		return "", AudioExtractUsage{}, &AudioExtractAPIError{
+			Provider:   "qwen asr",
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintf("base64 data URL size %d exceeds qwen asr 10 MB limit", encodedAudioBytes),
+		}
+	}
+	audioURL := audioURLPrefix + base64.StdEncoding.EncodeToString(req.Data)
 	messages := make([]map[string]any, 0, 2)
 	if strings.TrimSpace(e.prompt) != "" {
+		// The Qwen-ASR API reference documents language and ITN tuning under
+		// asr_options, while the OpenAI-compatible request format also accepts
+		// optional system messages. Keep Prompt as a system message for backward
+		// compatibility with existing deployments.
 		messages = append(messages, map[string]any{
 			"role": "system",
 			"content": []map[string]any{
@@ -136,6 +151,9 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 				Content any `json:"content"`
 			} `json:"message"`
 		} `json:"choices"`
+		// Qwen-ASR OpenAI-compatible responses place audio duration at
+		// usage.seconds, not usage.completion_tokens_details.seconds.
+		// Reference: https://help.aliyun.com/zh/model-studio/qwen-asr-api-reference
 		Usage *struct {
 			PromptTokens     int     `json:"prompt_tokens"`
 			CompletionTokens int     `json:"completion_tokens"`
@@ -170,7 +188,7 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 		}
 	}
 	if len(parsed.Choices) == 0 {
-		return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api returned no choices")
+		return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api returned no choices (raw=%s)", truncateString(string(raw), 256))
 	}
 	text := extractOpenAIContentText(parsed.Choices[0].Message.Content)
 	if strings.TrimSpace(text) == "" {

--- a/pkg/backend/audio_extract_qwen_asr.go
+++ b/pkg/backend/audio_extract_qwen_asr.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,10 @@ import (
 	"time"
 )
 
-const qwenASRMaxDataURLBytes = 10_000_000
+const (
+	qwenASRMaxDataURLBytes  = 10_000_000
+	qwenASRMaxResponseBytes = 32 << 20
+)
 
 // QwenASRAudioTextExtractorConfig configures Alibaba Cloud Model Studio
 // Qwen-ASR through DashScope's OpenAI-compatible chat/completions endpoint.
@@ -138,9 +142,20 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	raw, responseTooLarge, err := readQwenASRResponseBody(resp.Body)
 	if err != nil {
 		return "", AudioExtractUsage{}, fmt.Errorf("read qwen asr response for %q: %w", req.Path, err)
+	}
+	if responseTooLarge {
+		message := fmt.Sprintf("qwen asr response exceeds %d byte limit (raw=%s)", qwenASRMaxResponseBytes, truncateString(string(raw), 256))
+		if resp.StatusCode >= 300 {
+			return "", AudioExtractUsage{}, &AudioExtractAPIError{
+				Provider:   "qwen asr",
+				StatusCode: resp.StatusCode,
+				Message:    message,
+			}
+		}
+		return "", AudioExtractUsage{}, errors.New(message)
 	}
 	var parsed struct {
 		Error *struct {
@@ -169,7 +184,7 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 				Message:    truncateString(string(raw), 256),
 			}
 		}
-		return "", AudioExtractUsage{}, fmt.Errorf("decode qwen asr response: %w", err)
+		return "", AudioExtractUsage{}, fmt.Errorf("decode qwen asr response: %w (raw=%s)", err, truncateString(string(raw), 256))
 	}
 
 	// Reference: https://help.aliyun.com/zh/model-studio/error-code
@@ -201,4 +216,15 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 		usage.DurationSeconds = parsed.Usage.Seconds
 	}
 	return text, usage, nil
+}
+
+func readQwenASRResponseBody(r io.Reader) ([]byte, bool, error) {
+	raw, err := io.ReadAll(io.LimitReader(r, qwenASRMaxResponseBytes+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(raw) > qwenASRMaxResponseBytes {
+		return raw[:qwenASRMaxResponseBytes], true, nil
+	}
+	return raw, false, nil
 }

--- a/pkg/backend/audio_extract_qwen_asr.go
+++ b/pkg/backend/audio_extract_qwen_asr.go
@@ -11,11 +11,16 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/mem9-ai/dat9/pkg/logger"
 )
 
 const (
 	qwenASRMaxDataURLBytes  = 10_000_000
 	qwenASRMaxResponseBytes = 32 << 20
+	qwenASRMaskedContent    = "[masked]"
 )
 
 // QwenASRAudioTextExtractorConfig configures Alibaba Cloud Model Studio
@@ -186,6 +191,11 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 		}
 		return "", AudioExtractUsage{}, fmt.Errorf("decode qwen asr response: %w (raw=%s)", err, truncateString(string(raw), 256))
 	}
+	logger.Debug(ctx, "qwen_asr_response_body",
+		zap.String("path", req.Path),
+		zap.Int("status_code", resp.StatusCode),
+		zap.Int("response_bytes", len(raw)),
+		zap.String("response_body", maskQwenASRResponseBodyForLog(raw)))
 
 	// Reference: https://help.aliyun.com/zh/model-studio/error-code
 	// If the status code indicates an error, return an API error with details if available.
@@ -227,4 +237,41 @@ func readQwenASRResponseBody(r io.Reader) ([]byte, bool, error) {
 		return raw[:qwenASRMaxResponseBytes], true, nil
 	}
 	return raw, false, nil
+}
+
+func maskQwenASRResponseBodyForLog(raw []byte) string {
+	var body any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return truncateString(string(raw), 4096)
+	}
+	maskQwenASRChoicesContent(body)
+	masked, err := json.Marshal(body)
+	if err != nil {
+		return truncateString(string(raw), 4096)
+	}
+	return truncateString(string(masked), 4096)
+}
+
+func maskQwenASRChoicesContent(body any) {
+	obj, ok := body.(map[string]any)
+	if !ok {
+		return
+	}
+	choices, ok := obj["choices"].([]any)
+	if !ok {
+		return
+	}
+	for _, choice := range choices {
+		choiceObj, ok := choice.(map[string]any)
+		if !ok {
+			continue
+		}
+		message, ok := choiceObj["message"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, ok := message["content"]; ok {
+			message["content"] = qwenASRMaskedContent
+		}
+	}
 }

--- a/pkg/backend/audio_extract_qwen_asr.go
+++ b/pkg/backend/audio_extract_qwen_asr.go
@@ -143,16 +143,31 @@ func (e *QwenASRAudioTextExtractor) ExtractAudioText(ctx context.Context, req Au
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(raw, &parsed); err != nil {
+		// If we can't parse the response, include the raw body in the error for debugging.
 		if resp.StatusCode >= 300 {
-			return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api status %d: %s", resp.StatusCode, truncateString(string(raw), 256))
+			return "", AudioExtractUsage{}, &AudioExtractAPIError{
+				Provider:   "qwen asr",
+				StatusCode: resp.StatusCode,
+				Message:    truncateString(string(raw), 256),
+			}
 		}
 		return "", AudioExtractUsage{}, fmt.Errorf("decode qwen asr response: %w", err)
 	}
+
+	// Reference: https://help.aliyun.com/zh/model-studio/error-code
+	// If the status code indicates an error, return an API error with details if available.
 	if resp.StatusCode >= 300 {
 		if parsed.Error != nil && parsed.Error.Message != "" {
-			return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api status %d: %s", resp.StatusCode, parsed.Error.Message)
+			return "", AudioExtractUsage{}, &AudioExtractAPIError{
+				Provider:   "qwen asr",
+				StatusCode: resp.StatusCode,
+				Message:    parsed.Error.Message,
+			}
 		}
-		return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api status %d", resp.StatusCode)
+		return "", AudioExtractUsage{}, &AudioExtractAPIError{
+			Provider:   "qwen asr",
+			StatusCode: resp.StatusCode,
+		}
 	}
 	if len(parsed.Choices) == 0 {
 		return "", AudioExtractUsage{}, fmt.Errorf("qwen asr api returned no choices")

--- a/pkg/backend/audio_extract_qwen_asr_test.go
+++ b/pkg/backend/audio_extract_qwen_asr_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -184,5 +185,65 @@ func TestQwenASRAudioTextExtractorErrorMessage(t *testing.T) {
 	_, _, err = extractor.ExtractAudioText(context.Background(), AudioExtractRequest{Path: "/audio/clip.mp3", Data: []byte("fake")})
 	if err == nil || !strings.Contains(err.Error(), "qwen asr api status 502: upstream unavailable") {
 		t.Fatalf("err=%v, want upstream unavailable status", err)
+	}
+	if IsNonRetryableAudioExtractError(err) {
+		t.Fatalf("err=%v, should be retryable", err)
+	}
+}
+
+func TestQwenASRAudioTextExtractorNonRetryableClientErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		message    string
+	}{
+		{
+			name:       "free_tier_exhausted",
+			statusCode: http.StatusForbidden,
+			message:    "The free tier of the model has been exhausted.",
+		},
+		{
+			name:       "illegal_audio_format",
+			statusCode: http.StatusBadRequest,
+			message:    "<400> InternalError.Algo.InvalidParameter: The audio format is illegal and cannot be opened",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]string{"message": tc.message},
+				})
+			}))
+			defer server.Close()
+
+			extractor, err := NewQwenASRAudioTextExtractor(QwenASRAudioTextExtractorConfig{
+				BaseURL: server.URL,
+				APIKey:  "secret",
+				Model:   "qwen3-asr-flash",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _, err = extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+				Path: "/audio/clip.mp3",
+				Data: []byte("fake"),
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			var apiErr *AudioExtractAPIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("err=%T %[1]v, want AudioExtractAPIError", err)
+			}
+			if apiErr.StatusCode != tc.statusCode {
+				t.Fatalf("status=%d, want %d", apiErr.StatusCode, tc.statusCode)
+			}
+			if !IsNonRetryableAudioExtractError(err) {
+				t.Fatalf("err=%v, want non-retryable", err)
+			}
+		})
 	}
 }

--- a/pkg/backend/audio_extract_qwen_asr_test.go
+++ b/pkg/backend/audio_extract_qwen_asr_test.go
@@ -260,6 +260,63 @@ func TestQwenASRAudioTextExtractorNoChoicesErrorIncludesRawResponse(t *testing.T
 	}
 }
 
+func TestQwenASRAudioTextExtractorAllowsLargeSuccessfulResponse(t *testing.T) {
+	transcript := strings.Repeat("a", (1<<20)+1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"content": transcript}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	extractor, err := NewQwenASRAudioTextExtractor(QwenASRAudioTextExtractorConfig{
+		BaseURL: server.URL,
+		APIKey:  "secret",
+		Model:   "qwen3-asr-flash",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+		Path: "/audio/long.mp3",
+		Data: []byte("fake"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != transcript {
+		t.Fatalf("text length=%d, want %d", len(got), len(transcript))
+	}
+}
+
+func TestQwenASRAudioTextExtractorDecodeErrorIncludesRawResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[`))
+	}))
+	defer server.Close()
+
+	extractor, err := NewQwenASRAudioTextExtractor(QwenASRAudioTextExtractorConfig{
+		BaseURL: server.URL,
+		APIKey:  "secret",
+		Model:   "qwen3-asr-flash",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+		Path: "/audio/bad-json.mp3",
+		Data: []byte("fake"),
+	})
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if !strings.Contains(err.Error(), "decode qwen asr response") || !strings.Contains(err.Error(), `raw={"choices":[`) {
+		t.Fatalf("err=%v, want raw response detail", err)
+	}
+}
+
 func TestQwenASRAudioTextExtractorNonRetryableClientErrors(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/backend/audio_extract_qwen_asr_test.go
+++ b/pkg/backend/audio_extract_qwen_asr_test.go
@@ -317,6 +317,42 @@ func TestQwenASRAudioTextExtractorDecodeErrorIncludesRawResponse(t *testing.T) {
 	}
 }
 
+func TestMaskQwenASRResponseBodyForLogMasksChoiceContent(t *testing.T) {
+	raw := []byte(`{"id":"resp-1","choices":[{"message":{"role":"assistant","content":"sensitive transcript"}},{"message":{"role":"assistant","content":[{"type":"text","text":"another secret"}]}}],"usage":{"seconds":3}}`)
+
+	masked := maskQwenASRResponseBodyForLog(raw)
+	if strings.Contains(masked, "sensitive transcript") || strings.Contains(masked, "another secret") {
+		t.Fatalf("masked response leaked transcript content: %s", masked)
+	}
+
+	var parsed struct {
+		ID      string `json:"id"`
+		Choices []struct {
+			Message struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			Seconds float64 `json:"seconds"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal([]byte(masked), &parsed); err != nil {
+		t.Fatalf("unmarshal masked response: %v", err)
+	}
+	if parsed.ID != "resp-1" || parsed.Usage.Seconds != 3 {
+		t.Fatalf("masked response lost non-content fields: %+v", parsed)
+	}
+	for i, choice := range parsed.Choices {
+		if choice.Message.Role != "assistant" {
+			t.Fatalf("choice %d role=%q, want assistant", i, choice.Message.Role)
+		}
+		if choice.Message.Content != qwenASRMaskedContent {
+			t.Fatalf("choice %d content=%q, want mask", i, choice.Message.Content)
+		}
+	}
+}
+
 func TestQwenASRAudioTextExtractorNonRetryableClientErrors(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/backend/audio_extract_qwen_asr_test.go
+++ b/pkg/backend/audio_extract_qwen_asr_test.go
@@ -183,8 +183,12 @@ func TestQwenASRAudioTextExtractorErrorMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, _, err = extractor.ExtractAudioText(context.Background(), AudioExtractRequest{Path: "/audio/clip.mp3", Data: []byte("fake")})
-	if err == nil || !strings.Contains(err.Error(), "qwen asr api status 502: upstream unavailable") {
-		t.Fatalf("err=%v, want upstream unavailable status", err)
+	var apiErr *AudioExtractAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err=%T %[1]v, want AudioExtractAPIError", err)
+	}
+	if apiErr.StatusCode != http.StatusBadGateway || apiErr.Message != "upstream unavailable" {
+		t.Fatalf("apiErr=%+v, want 502 upstream unavailable", apiErr)
 	}
 	if IsNonRetryableAudioExtractError(err) {
 		t.Fatalf("err=%v, should be retryable", err)
@@ -234,9 +238,9 @@ func TestQwenASRAudioTextExtractorRejectsOversizedBase64Payload(t *testing.T) {
 	}
 }
 
-func TestQwenASRAudioTextExtractorNoChoicesErrorIncludesRawResponse(t *testing.T) {
+func TestQwenASRAudioTextExtractorNoChoicesErrorIncludesMaskedResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"choices":[],"request_id":"abc"}`))
+		_, _ = w.Write([]byte(`{"id":"resp-abc","choices":[]}`))
 	}))
 	defer server.Close()
 
@@ -255,8 +259,8 @@ func TestQwenASRAudioTextExtractorNoChoicesErrorIncludesRawResponse(t *testing.T
 	if err == nil {
 		t.Fatal("expected no choices error")
 	}
-	if !strings.Contains(err.Error(), "qwen asr api returned no choices") || !strings.Contains(err.Error(), `"request_id":"abc"`) {
-		t.Fatalf("err=%v, want raw response detail", err)
+	if !strings.Contains(err.Error(), "qwen asr api returned no choices") || !strings.Contains(err.Error(), `"id":"resp-abc"`) {
+		t.Fatalf("err=%v, want masked response detail", err)
 	}
 }
 
@@ -291,7 +295,7 @@ func TestQwenASRAudioTextExtractorAllowsLargeSuccessfulResponse(t *testing.T) {
 	}
 }
 
-func TestQwenASRAudioTextExtractorDecodeErrorIncludesRawResponse(t *testing.T) {
+func TestQwenASRAudioTextExtractorDecodeErrorExcludesRawResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"choices":[`))
 	}))
@@ -312,20 +316,27 @@ func TestQwenASRAudioTextExtractorDecodeErrorIncludesRawResponse(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected decode error")
 	}
-	if !strings.Contains(err.Error(), "decode qwen asr response") || !strings.Contains(err.Error(), `raw={"choices":[`) {
-		t.Fatalf("err=%v, want raw response detail", err)
+	if !strings.Contains(err.Error(), "decode qwen asr response") {
+		t.Fatalf("err=%v, want decode response error", err)
+	}
+	if strings.Contains(err.Error(), `{"choices":[`) || strings.Contains(err.Error(), "raw=") {
+		t.Fatalf("err leaked raw response: %v", err)
 	}
 }
 
-func TestMaskQwenASRResponseBodyForLogMasksChoiceContent(t *testing.T) {
-	raw := []byte(`{"id":"resp-1","choices":[{"message":{"role":"assistant","content":"sensitive transcript"}},{"message":{"role":"assistant","content":[{"type":"text","text":"another secret"}]}}],"usage":{"seconds":3}}`)
+func TestMaskQwenASRResponseBodyForLogMasksChoiceMessageContent(t *testing.T) {
+	raw := []byte(`{"id":"resp-1","content":"top-level secret","choices":[{"message":{"role":"assistant","content":"sensitive transcript"}},{"message":{"role":"assistant","content":[{"type":"text","text":"another secret"}]}}],"usage":{"seconds":3}}`)
 
 	masked := maskQwenASRResponseBodyForLog(raw)
 	if strings.Contains(masked, "sensitive transcript") || strings.Contains(masked, "another secret") {
-		t.Fatalf("masked response leaked transcript content: %s", masked)
+		t.Fatalf("masked response leaked choice message content: %s", masked)
+	}
+	if !strings.Contains(masked, "top-level secret") {
+		t.Fatalf("masked response unexpectedly removed non-choice content field: %s", masked)
 	}
 
 	var parsed struct {
+		Content string `json:"content"`
 		ID      string `json:"id"`
 		Choices []struct {
 			Message struct {
@@ -342,6 +353,9 @@ func TestMaskQwenASRResponseBodyForLogMasksChoiceContent(t *testing.T) {
 	}
 	if parsed.ID != "resp-1" || parsed.Usage.Seconds != 3 {
 		t.Fatalf("masked response lost non-content fields: %+v", parsed)
+	}
+	if parsed.Content != "top-level secret" {
+		t.Fatalf("top-level content=%q, want preserved", parsed.Content)
 	}
 	for i, choice := range parsed.Choices {
 		if choice.Message.Role != "assistant" {

--- a/pkg/backend/audio_extract_qwen_asr_test.go
+++ b/pkg/backend/audio_extract_qwen_asr_test.go
@@ -191,6 +191,75 @@ func TestQwenASRAudioTextExtractorErrorMessage(t *testing.T) {
 	}
 }
 
+func TestQwenASRAudioTextExtractorRejectsOversizedBase64Payload(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	extractor, err := NewQwenASRAudioTextExtractor(QwenASRAudioTextExtractorConfig{
+		BaseURL: server.URL,
+		APIKey:  "secret",
+		Model:   "qwen3-asr-flash",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+		Path:        "/audio/too-large.mp3",
+		ContentType: "audio/mpeg",
+		Data:        make([]byte, 8<<20),
+	})
+	if err == nil {
+		t.Fatal("expected oversized payload error")
+	}
+	var apiErr *AudioExtractAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err=%T %[1]v, want AudioExtractAPIError", err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want %d", apiErr.StatusCode, http.StatusBadRequest)
+	}
+	if !strings.Contains(apiErr.Message, "10 MB limit") {
+		t.Fatalf("message=%q, want limit detail", apiErr.Message)
+	}
+	if !IsNonRetryableAudioExtractError(err) {
+		t.Fatalf("err=%v, want non-retryable", err)
+	}
+	if called {
+		t.Fatal("server should not be called for oversized payload")
+	}
+}
+
+func TestQwenASRAudioTextExtractorNoChoicesErrorIncludesRawResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[],"request_id":"abc"}`))
+	}))
+	defer server.Close()
+
+	extractor, err := NewQwenASRAudioTextExtractor(QwenASRAudioTextExtractorConfig{
+		BaseURL: server.URL,
+		APIKey:  "secret",
+		Model:   "qwen3-asr-flash",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = extractor.ExtractAudioText(context.Background(), AudioExtractRequest{
+		Path: "/audio/malformed.mp3",
+		Data: []byte("fake"),
+	})
+	if err == nil {
+		t.Fatal("expected no choices error")
+	}
+	if !strings.Contains(err.Error(), "qwen asr api returned no choices") || !strings.Contains(err.Error(), `"request_id":"abc"`) {
+		t.Fatalf("err=%v, want raw response detail", err)
+	}
+}
+
 func TestQwenASRAudioTextExtractorNonRetryableClientErrors(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -183,6 +183,7 @@ type StatResult struct {
 type StatMetadataResult struct {
 	Size         int64             `json:"size"`
 	IsDir        bool              `json:"isdir"`
+	ResourceID   string            `json:"resource_id,omitempty"`
 	Revision     int64             `json:"revision"`
 	Mtime        *int64            `json:"mtime,omitempty"` // Unix seconds when known
 	ContentType  string            `json:"content_type"`

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -134,6 +134,9 @@ func TestStatMetadataIncludesTagsAndSupportsTagReplace(t *testing.T) {
 	if meta.Size != 5 || meta.IsDir || meta.Revision != 1 {
 		t.Fatalf("unexpected stat metadata: %+v", meta)
 	}
+	if meta.ResourceID == "" {
+		t.Fatalf("resource_id should not be empty: %+v", meta)
+	}
 	if meta.Mtime == nil || *meta.Mtime <= 0 {
 		t.Fatalf("mtime = %v, want > 0", meta.Mtime)
 	}

--- a/pkg/datastore/semantic_tasks.go
+++ b/pkg/datastore/semantic_tasks.go
@@ -375,6 +375,30 @@ func (s *Store) AckSemanticTask(ctx context.Context, taskID, receipt string) (er
 	return s.semanticTaskLeaseError(ctx, taskID)
 }
 
+// DeadLetterSemanticTask marks a leased semantic task as permanently failed
+// without scheduling another retry.
+func (s *Store) DeadLetterSemanticTask(ctx context.Context, taskID, receipt, lastErr string) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "dead_letter_semantic_task", start, &err)
+
+	now := semanticTaskLeaseNow()
+	res, err := s.db.ExecContext(ctx, `UPDATE semantic_tasks SET status = ?, receipt = NULL,
+		leased_at = NULL, lease_until = NULL, last_error = ?, completed_at = ?, updated_at = ?
+		WHERE task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`,
+		semantic.TaskDeadLettered, nullStr(lastErr), now, now, taskID, semantic.TaskProcessing, receipt, now)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected > 0 {
+		return nil
+	}
+	return s.semanticTaskLeaseError(ctx, taskID)
+}
+
 // RenewSemanticTask extends the lease for a currently owned processing task.
 // The renewal succeeds only when task ownership is still valid, meaning:
 // status is processing, receipt matches, and lease_until has not expired.

--- a/pkg/datastore/semantic_tasks_test.go
+++ b/pkg/datastore/semantic_tasks_test.go
@@ -117,6 +117,44 @@ func TestSemanticTaskAckWrongReceiptFails(t *testing.T) {
 	}
 }
 
+func TestSemanticTaskDeadLetterWithoutRetry(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if _, err := s.EnqueueSemanticTask(ctx, newSemanticTask("task-1", "file-1", 1, now, now)); err != nil {
+		t.Fatal(err)
+	}
+	claimed, found, err := s.ClaimSemanticTask(ctx, now.Add(time.Second), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected claim to find task")
+	}
+
+	if err := s.DeadLetterSemanticTask(ctx, claimed.TaskID, claimed.Receipt, "permanent audio extract error"); err != nil {
+		t.Fatal(err)
+	}
+
+	task := mustGetSemanticTask(t, s, claimed.TaskID)
+	if task.Status != semantic.TaskDeadLettered {
+		t.Fatalf("status=%q, want %q", task.Status, semantic.TaskDeadLettered)
+	}
+	if task.AttemptCount != 1 {
+		t.Fatalf("attempt_count=%d, want 1", task.AttemptCount)
+	}
+	if task.LastError != "permanent audio extract error" {
+		t.Fatalf("last_error=%q", task.LastError)
+	}
+	if task.CompletedAt == nil {
+		t.Fatal("expected completed_at after dead-letter")
+	}
+	if task.Receipt != "" || task.LeasedAt != nil || task.LeaseUntil != nil {
+		t.Fatalf("dead-letter should clear lease fields: %+v", task)
+	}
+}
+
 func TestSemanticTaskRenewExtendsLease(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync/atomic"
 
 	"go.uber.org/zap"
@@ -12,7 +13,10 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
-const envBenchTimingLogEnabled = "DRIVE9_BENCH_TIMING_LOG_ENABLED"
+const (
+	envBenchTimingLogEnabled = "DRIVE9_BENCH_TIMING_LOG_ENABLED"
+	envLogLevel              = "DRIVE9_LOG_LEVEL"
+)
 
 const (
 	benchTimingLogUnknown uint32 = iota
@@ -23,7 +27,19 @@ const (
 var benchTimingLogState atomic.Uint32
 
 func NewServerLogger() (*zap.Logger, error) {
-	return zap.NewProduction()
+	cfg := zap.NewProductionConfig()
+	rawLevel := strings.TrimSpace(os.Getenv(envLogLevel))
+	if rawLevel != "" {
+		var level zapcore.Level
+		if err := level.UnmarshalText([]byte(strings.ToLower(rawLevel))); err != nil {
+			return nil, fmt.Errorf("%s must be one of debug, info, warn, or error: %w", envLogLevel, err)
+		}
+		if level < zapcore.DebugLevel || level > zapcore.ErrorLevel {
+			return nil, fmt.Errorf("%s must be one of debug, info, warn, or error", envLogLevel)
+		}
+		cfg.Level.SetLevel(level)
+	}
+	return cfg.Build()
 }
 
 func BenchTimingLogEnabled() bool {

--- a/pkg/logger/factory_test.go
+++ b/pkg/logger/factory_test.go
@@ -40,6 +40,52 @@ func TestNewCLILoggerCreatesLogDirAndFile(t *testing.T) {
 	}
 }
 
+func TestNewServerLoggerHonorsLogLevel(t *testing.T) {
+	tests := []struct {
+		name         string
+		level        string
+		debugEnabled bool
+		infoEnabled  bool
+	}{
+		{name: "default_info", infoEnabled: true},
+		{name: "debug", level: "debug", debugEnabled: true, infoEnabled: true},
+		{name: "uppercase_warn", level: "WARN"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.level != "" {
+				t.Setenv(envLogLevel, tc.level)
+			} else {
+				t.Setenv(envLogLevel, "")
+			}
+			l, err := NewServerLogger()
+			if err != nil {
+				t.Fatalf("NewServerLogger: %v", err)
+			}
+			t.Cleanup(func() { _ = l.Sync() })
+			if got := l.Core().Enabled(zap.DebugLevel); got != tc.debugEnabled {
+				t.Fatalf("debug enabled=%v, want %v", got, tc.debugEnabled)
+			}
+			if got := l.Core().Enabled(zap.InfoLevel); got != tc.infoEnabled {
+				t.Fatalf("info enabled=%v, want %v", got, tc.infoEnabled)
+			}
+		})
+	}
+}
+
+func TestNewServerLoggerRejectsInvalidLogLevel(t *testing.T) {
+	tests := []string{"verbose", "dpanic", "panic", "fatal"}
+	for _, level := range tests {
+		t.Run(level, func(t *testing.T) {
+			t.Setenv(envLogLevel, level)
+			if _, err := NewServerLogger(); err == nil {
+				t.Fatal("expected invalid log level error")
+			}
+		})
+	}
+}
+
 func TestBenchTimingLogEnabledCachesUntilReset(t *testing.T) {
 	resetBenchTimingLogEnabledForTest()
 	t.Cleanup(resetBenchTimingLogEnabledForTest)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -52,6 +52,10 @@ func FromContext(ctx context.Context) *zap.Logger {
 	return L()
 }
 
+func Debug(ctx context.Context, msg string, fields ...zap.Field) {
+	FromContext(ctx).WithOptions(zap.AddCallerSkip(1)).Debug(msg, fields...)
+}
+
 func Info(ctx context.Context, msg string, fields ...zap.Field) {
 	FromContext(ctx).WithOptions(zap.AddCallerSkip(1)).Info(msg, fields...)
 }

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -167,8 +167,9 @@ type semanticObservationSnapshot struct {
 type semanticTaskAction string
 
 const (
-	semanticTaskActionAck   semanticTaskAction = "ack"
-	semanticTaskActionRetry semanticTaskAction = "retry"
+	semanticTaskActionAck        semanticTaskAction = "ack"
+	semanticTaskActionRetry      semanticTaskAction = "retry"
+	semanticTaskActionDeadLetter semanticTaskAction = "dead_letter"
 )
 
 type semanticTaskOutcome struct {
@@ -404,6 +405,8 @@ func (m *semanticWorkerManager) processTask(ctx context.Context, target *semanti
 		m.ackTask(ctx, target.tenantID, target.store, task, outcome.message)
 	case semanticTaskActionRetry:
 		m.retryTask(ctx, target.tenantID, target.store, task, outcome.message)
+	case semanticTaskActionDeadLetter:
+		m.deadLetterTask(ctx, target.tenantID, target.store, task, outcome.message)
 	}
 }
 
@@ -454,6 +457,26 @@ func (m *semanticWorkerManager) retryTask(ctx context.Context, tenantID string, 
 		fields = append(fields, zap.Time("retry_at", retryAt))
 	}
 	logger.Warn(ctx, logMessage, fields...)
+}
+
+func (m *semanticWorkerManager) deadLetterTask(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task, message string) {
+	start := time.Now()
+	if err := store.DeadLetterSemanticTask(ctx, task.TaskID, task.Receipt, message); err != nil {
+		metrics.RecordOperation("semantic_worker", "dead_letter", "error", time.Since(start))
+		logger.Warn(ctx, "semantic_worker_dead_letter_failed",
+			append([]zap.Field{
+				zap.String("tenant_id", tenantID),
+				zap.String("result", "error"),
+			}, append(semanticTaskLogFields(task), zap.Error(err))...)...)
+		return
+	}
+	metrics.RecordOperation("semantic_worker", "dead_letter", "dead_lettered", time.Since(start))
+	logger.Warn(ctx, "semantic_worker_dead_lettered",
+		append([]zap.Field{
+			zap.String("tenant_id", tenantID),
+			zap.String("result", "dead_lettered"),
+			zap.String("message", message),
+		}, semanticTaskLogFields(task)...)...)
 }
 
 func (m *semanticWorkerManager) retryDelay(attemptCount int) time.Duration {
@@ -919,6 +942,9 @@ func (m *semanticWorkerManager) processImgExtractTask(ctx context.Context, b *ba
 func (m *semanticWorkerManager) processAudioExtractTask(ctx context.Context, b *backend.Dat9Backend, task *semantic.Task) semanticTaskOutcome {
 	result, err := b.ProcessAudioExtractTask(ctx, audioExtractTaskSpecFromSemanticTask(task))
 	if err != nil {
+		if backend.IsNonRetryableAudioExtractError(err) {
+			return semanticTaskOutcome{action: semanticTaskActionDeadLetter, result: string(result), message: err.Error()}
+		}
 		return semanticTaskOutcome{action: semanticTaskActionRetry, result: string(result), message: err.Error()}
 	}
 	if result == backend.AudioExtractResultBudgetExhausted {

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -296,6 +296,59 @@ func TestSemanticWorkerProcessesAudioExtractTaskWithoutEmbedder(t *testing.T) {
 	}
 }
 
+func TestSemanticWorkerDeadLettersNonRetryableAudioExtractError(t *testing.T) {
+	extractErr := &backend.AudioExtractAPIError{
+		Provider:   "qwen asr",
+		StatusCode: http.StatusBadRequest,
+		Message:    "<400> InternalError.Algo.InvalidParameter: The audio format is illegal and cannot be opened",
+	}
+	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{
+		DatabaseAutoEmbedding: true,
+		AsyncAudioExtract: backend.AsyncAudioExtractOptions{
+			Enabled:   true,
+			Extractor: staticServerAudioExtractor{err: extractErr},
+		},
+	})
+	fileID := insertServerImageFileForExtractTest(t, b, "/rec/bad.mp3", "audio/mpeg", []byte{0xff, 0xf3})
+	payload, err := json.Marshal(semantic.AudioExtractTaskPayload{Path: "/rec/bad.mp3", ContentType: "audio/mpeg"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if _, err := b.Store().EnqueueSemanticTask(context.Background(), &semantic.Task{
+		TaskID:          "audio-task-non-retryable",
+		TaskType:        semantic.TaskTypeAudioExtractText,
+		ResourceID:      fileID,
+		ResourceVersion: 1,
+		Status:          semantic.TaskQueued,
+		MaxAttempts:     5,
+		AvailableAt:     now,
+		PayloadJSON:     payload,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewWithConfig(Config{Backend: b, SemanticWorkers: SemanticWorkerOptions{
+		Workers:         1,
+		PollInterval:    10 * time.Millisecond,
+		RecoverInterval: 50 * time.Millisecond,
+		LeaseDuration:   200 * time.Millisecond,
+		RetryBaseDelay:  10 * time.Millisecond,
+	}})
+	t.Cleanup(func() { s.Close() })
+
+	waitForNamedTaskStatus(t, b, "audio-task-non-retryable", string(semantic.TaskDeadLettered), 3*time.Second)
+	task := mustGetServerSemanticTask(t, b, "audio-task-non-retryable")
+	if task.AttemptCount != 1 {
+		t.Fatalf("attempt_count=%d, want 1", task.AttemptCount)
+	}
+	if !strings.Contains(task.LastError, "audio format is illegal") {
+		t.Fatalf("last_error=%q, want audio format error", task.LastError)
+	}
+}
+
 func TestSemanticWorkerProcessesMP4AudioExtractTaskWithoutEmbedder(t *testing.T) {
 	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{
 		DatabaseAutoEmbedding: true,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -586,7 +586,9 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 	var mtime *int64
 	var contentType string
 	var semanticText string
+	resourceID := nf.Node.NodeID
 	if nf.File != nil {
+		resourceID = nf.File.FileID
 		size = nf.File.SizeBytes
 		revision = nf.File.Revision
 		if nf.File.ConfirmedAt != nil {
@@ -616,6 +618,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 	_ = json.NewEncoder(w).Encode(struct {
 		Size         int64             `json:"size"`
 		IsDir        bool              `json:"isdir"`
+		ResourceID   string            `json:"resource_id"`
 		Revision     int64             `json:"revision"`
 		Mtime        *int64            `json:"mtime,omitempty"`
 		ContentType  string            `json:"content_type"`
@@ -624,6 +627,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 	}{
 		Size:         size,
 		IsDir:        nf.Node.IsDirectory,
+		ResourceID:   resourceID,
 		Revision:     revision,
 		Mtime:        mtime,
 		ContentType:  contentType,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -300,6 +300,7 @@ func TestStatMetadataIncludesTagsAndSemanticText(t *testing.T) {
 	var out struct {
 		Size         int64             `json:"size"`
 		IsDir        bool              `json:"isdir"`
+		ResourceID   string            `json:"resource_id"`
 		Revision     int64             `json:"revision"`
 		Mtime        *int64            `json:"mtime"`
 		ContentType  string            `json:"content_type"`
@@ -312,6 +313,9 @@ func TestStatMetadataIncludesTagsAndSemanticText(t *testing.T) {
 	if out.Size != int64(len("hello metadata")) || out.IsDir || out.Revision != 1 {
 		t.Fatalf("unexpected metadata shape: %+v", out)
 	}
+	if out.ResourceID == "" {
+		t.Fatalf("expected resource_id, got %+v", out)
+	}
 	if out.ContentType == "" || out.SemanticText == "" {
 		t.Fatalf("expected content_type and semantic_text, got %+v", out)
 	}
@@ -323,6 +327,35 @@ func TestStatMetadataIncludesTagsAndSemanticText(t *testing.T) {
 	}
 	if out.Tags["owner"] != "alice" || out.Tags["topic"] != "note" || len(out.Tags) != 2 {
 		t.Fatalf("unexpected tags: %+v", out.Tags)
+	}
+
+	mkdirReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/dir?mkdir", nil)
+	mkdirResp, err := http.DefaultClient.Do(mkdirReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = mkdirResp.Body.Close()
+	if mkdirResp.StatusCode != http.StatusOK {
+		t.Fatalf("mkdir: %d", mkdirResp.StatusCode)
+	}
+
+	dirResp, err := http.Get(ts.URL + "/v1/fs/dir?stat=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = dirResp.Body.Close() }()
+	if dirResp.StatusCode != http.StatusOK {
+		t.Fatalf("dir stat metadata: %d", dirResp.StatusCode)
+	}
+	var dirOut struct {
+		IsDir      bool   `json:"isdir"`
+		ResourceID string `json:"resource_id"`
+	}
+	if err := json.NewDecoder(dirResp.Body).Decode(&dirOut); err != nil {
+		t.Fatalf("decode dir metadata: %v", err)
+	}
+	if !dirOut.IsDir || dirOut.ResourceID == "" {
+		t.Fatalf("expected directory resource_id, got %+v", dirOut)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR improves audio extraction reliability and observability for Drive9 semantic tasks. Also address some comments on https://github.com/mem9-ai/drive9/pull/342

- Introduce structured audio extraction API errors and classify Qwen ASR `400 Bad Request` and `403 Forbidden` failures as non-retryable.
- Dead-letter non-retryable `audio_extract_text` semantic tasks immediately instead of spending all retry attempts on requests that cannot succeed without changing the input or provider/account configuration.
- Harden Qwen ASR handling by enforcing the provider's base64 data URL size limit, increasing bounded response reads to support larger valid responses, surfacing provider error messages, and logging masked debug response bodies.
- Add `DRIVE9_LOG_LEVEL` for configurable server log verbosity.
- Expose `resource_id` in `drive9 fs stat` metadata so files and directories can be correlated with semantic worker logs.

## Testing

- `make lint`
- `make build`
- `make test TEST_P=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DRIVE9_LOG_LEVEL` environment variable to control logging verbosity (debug, info, warn, error).
  * File and directory stat responses now include a `resource_id` field for identification.
  * Added debug-level logging capability.

* **Bug Fixes**
  * Audio extraction now properly handles non-retryable errors by terminating tasks instead of retrying.
  * Improved error messages and handling for audio extraction failures.

* **Changes**
  * Reduced default maximum audio file size limit for qwen-asr mode from 10 MiB to 7 MiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->