### PR TITLE
fix: vault grant token tenant routing

### DIFF
--- a/docs/specs/pr-a-jwt-implementation.md
+++ b/docs/specs/pr-a-jwt-implementation.md
@@ -36,12 +36,13 @@ Submitting a PR that grows beyond the table above = automatic block. Keep sub-PR
 
 ## 2. JWT payload — the **exact** claim set (§16)
 
-The payload MUST contain **all** of these claims and **only** these claims (no `task_id`, no `tenant_id`, no `iat` in the token body — `VerifyGrant` uses `DisallowUnknownFields` and `VaultGrantClaims` has exactly the 8 fields below):
+The payload MUST contain **all** of these claims and **only** these claims (no `task_id`, no `iat` in the token body — `VerifyGrant` uses `DisallowUnknownFields` and `VaultGrantClaims` has exactly the 9 fields below):
 
 | JSON key | Go field | Type | Required | Notes |
 |---|---|---|---|---|
 | `iss` | `Issuer` | `string` | ✅ | The server URL the grant was minted at. Delegatees trust this via TOFU on `ctx import` (§13.3). Treat as opaque; do not parse. |
 | `grant_id` | `GrantID` | `string` | ✅ | Server-unique grant id. Prefix `grt_` per quickstart example. |
+| `tenant_id` | `TenantID` | `string` | ✅ | **Routing-only claim.** Used by the server to resolve the correct tenant backend before HMAC verification. NOT an authorization claim — tampering routes to the wrong tenant where HMAC verification with the tenant-scoped CSK fails. Added in PR #354 to fix multi-tenant read routing. |
 | `principal_type` | `PrincipalType` | `string` enum | ✅ | Exactly one of: `"owner"` or `"delegated"`. No other values. |
 | `agent` | `Agent` | `string` | ✅ | Opaque label the owner supplies at issue time (`--agent alice`). Not validated against any identity system in v0. |
 | `scope` | `Scope` | `[]string` | ✅ | Non-empty. Path-style entries like `prod-db` (whole secret) or `prod-db/DB_URL` (single key). Validated by `vault.ValidateScope`. |
@@ -51,7 +52,7 @@ The payload MUST contain **all** of these claims and **only** these claims (no `
 
 **Removed vs current `CapTokenClaims`**:
 - `token_id` → renamed to `grant_id`
-- `tenant_id` → **removed from the token body**. Server derives tenant from the `iss` + its own registry, or from the auth middleware scope (for owner endpoints); tenant MUST NOT be trusted from the token body. (This closes a forgery class where an attacker sets `tenant_id` in an unsigned portion of the token.)
+- `tenant_id` → **re-added as a routing-only claim** (PR #354). Used by the server to resolve the correct tenant backend before HMAC verification. NOT an authorization claim — tampering routes to the wrong tenant where HMAC verification with the tenant-scoped CSK fails. The original concern (forgery of unsigned `tenant_id`) is moot because `tenant_id` is inside the HMAC-signed payload; the server cross-checks `claims.TenantID == routingTenantID` after verification as defense-in-depth.
 - `task_id` → removed entirely (§20 no-backward-compat; was a Phase-0 concept).
 - `agent_id` → renamed to `agent`.
 - `iat` → **removed entirely**. Not in `VaultGrantClaims`, not signed, and rejected at verify time by `DisallowUnknownFields`. Freshness is via `exp` only. (Earlier drafts left `iat` optional; the shipped code forbids it — this line is the source of truth.)
@@ -175,7 +176,7 @@ New tests live in `pkg/vault/grant_test.go` + `pkg/vault/grant_sign_test.go` (ne
 4. **Revoked**: issue → revoke → verify → EACCES "revoked". Double-revoke returns `ErrNotFound`.
 5. **Cross-tenant replay**: issue under tenant A, verify under tenant B → CSK mismatch → EACCES "invalid".
 6. **Missing required claim**: table-driven over all §16 required claims — hand-craft HMAC-valid token with one claim deleted → `VerifyGrant` rejects. (Lives in `grant_sign_test.go`.)
-7. **Unknown claim**: hand-craft HMAC-valid token with a smuggled field (e.g. `tenant_id`) → `VerifyGrant` rejects via `DisallowUnknownFields`.
+7. **Unknown claim**: hand-craft HMAC-valid token with a smuggled field (e.g. `bogus`) → `VerifyGrant` rejects via `DisallowUnknownFields`.
 8. **Bad `perm` value** at issue time (e.g. `"admin"`) → `IssueGrant` rejects. At sign time, `SignGrant` also rejects.
 9. **Bad `principal_type`** at issue time (e.g. `"root"`) → `IssueGrant` rejects. `SignGrant` also rejects.
 10. **Empty scope / empty agent / empty issuer / ttl≤0** at issue time → `IssueGrant` rejects. At HTTP boundary, ttl≤0 → HTTP 400 `"ttl_seconds is required and must be > 0"`.

--- a/docs/specs/pr-a-review-checklist.md
+++ b/docs/specs/pr-a-review-checklist.md
@@ -8,8 +8,8 @@ Reviewers: `@adversary-1`, `@adversary-2`. Walk every item. If any item fails, b
 
 ## A. Claim-set conformance (§16)
 
-- [ ] Payload contains exactly `iss, grant_id, principal_type, agent, scope, perm, exp, label_hint` — no more, no fewer.
-- [ ] `tenant_id` is NOT in the token payload. (If you find `TenantID` in `VaultGrantClaims`, block.)
+- [ ] Payload contains exactly `iss, grant_id, tenant_id, principal_type, agent, scope, perm, exp, label_hint` — no more, no fewer.
+- [ ] `tenant_id` IS in the token payload as a **routing-only claim** (NOT an authorization claim). Server cross-checks `claims.TenantID == routingTenantID` after HMAC verification.
 - [ ] `task_id` is NOT in the token payload. (Block if carried over from `CapTokenClaims`.)
 - [ ] `agent_id` renamed to `agent`.
 - [ ] `token_id` renamed to `grant_id`.

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -435,7 +435,7 @@ Contract rules:
 
 - Input **MUST** be a delegated JWT. If the payload indicates `principal_type=owner` (or any non-delegated credential), `ctx import` **MUST** refuse and instruct the user to use `ctx add --api-key`. `ctx import` is not a universal credential importer.
 - If the JWT's `exp` is already in the past at import time, `ctx import` **MUST** refuse (local short-circuit #1 — see §17). The `exp` check uses the local wall clock with no skew tolerance in v0; delegatees with badly skewed clocks will see spurious refusals or admissions and are expected to fix their clocks (NTP).
-- The JWT **MUST** contain all required delegated-context claims: `iss`, `exp`, `principal_type=delegated`, `agent`, `grant_id`, `scope[]` (non-empty array), and `perm` ∈ `{read, write}`. Missing or malformed required claims refuse at import; the full per-claim error mapping is in §11.
+- The JWT **MUST** contain all required delegated-context claims: `iss`, `exp`, `tenant_id`, `principal_type=delegated`, `agent`, `grant_id`, `scope[]` (non-empty array), and `perm` ∈ `{read, write}`. Missing or malformed required claims refuse at import; the full per-claim error mapping is in §11.
 - When `--from-file <path>` is given, the file **MUST** be mode `0600` (no group or world permission bits). If `stat.Mode().Perm() & 0o077 != 0`, `ctx import` refuses **before reading the contents** with `EACCES` and points the user at `chmod 600`. Rationale: a bearer-token file that has leaked to other local users is already-exposed credential; silently consuming it makes the CLI complicit in the lifecycle breach. This matches the argv-removal posture: the tool does not ingest credentials that have already escaped their intended confidentiality boundary.
 - Default context name is the JWT's `label_hint`; on collision or absence, fall back to `<agent>-<scope-root>` with a numeric suffix as needed. `--name` overrides.
 
@@ -554,6 +554,7 @@ The JWT payload is self-describing and **MUST** contain the following claims:
 |---|---|
 | `iss` | Issuer server URL; used by `ctx import` to populate the context's `server` field with no network call. |
 | `grant_id` | Server-assigned grant identifier (e.g. `grt_7f2a`); appears in audit and is the argument to `vault revoke`. |
+| `tenant_id` | **Routing-only claim.** Used by the server to resolve the correct tenant backend before HMAC verification. NOT an authorization claim — tampering routes to the wrong tenant where HMAC verification fails. |
 | `principal_type` | `delegated` (see §13.3 for the refusal rule on other kinds). |
 | `agent` | Agent ID as named by the owner at `vault grant --agent`; appears in audit and is the default prefix for context `name`. |
 | `scope[]` | List of granted paths (whole-secret or single-key; §6). |

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -242,10 +242,6 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 	})
 }
 
-func peekCapTokenTenantID(raw string) (string, error) {
-	return vault.PeekCapTokenTenantID(raw)
-}
-
 // peekTokenTenantID extracts tenant_id from either a legacy cap token (vault_
 // prefix) or a grant token (vt_ prefix). Used by capabilityAuthMiddleware for
 // pre-auth tenant routing.

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -213,7 +213,8 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 
 		// Peek at claims to get tenant_id. We only need the payload, not
 		// full HMAC verification (handleVaultRead does that).
-		tenantID, err := peekCapTokenTenantID(tok)
+		// Support both legacy cap tokens (vault_ prefix) and grant tokens (vt_ prefix).
+		tenantID, err := peekTokenTenantID(tok)
 		if err != nil {
 			errJSON(w, http.StatusUnauthorized, "invalid capability token")
 			return
@@ -242,6 +243,16 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 }
 
 func peekCapTokenTenantID(raw string) (string, error) {
+	return vault.PeekCapTokenTenantID(raw)
+}
+
+// peekTokenTenantID extracts tenant_id from either a legacy cap token (vault_
+// prefix) or a grant token (vt_ prefix). Used by capabilityAuthMiddleware for
+// pre-auth tenant routing.
+func peekTokenTenantID(raw string) (string, error) {
+	if strings.HasPrefix(raw, "vt_") {
+		return vault.PeekGrantTenantID(raw)
+	}
 	return vault.PeekCapTokenTenantID(raw)
 }
 

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -674,7 +674,18 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---- Consumption API: /v1/vault/read ----
-// Authenticated by capability token (NOT tenant token).
+// Authenticated by capability token or grant token (NOT tenant token).
+
+// vaultReadPrincipal is the unified read-path identity extracted from either
+// a legacy cap token (vault_ prefix) or a grant token (vt_ prefix). The
+// handlers below operate on this struct, not on raw token types.
+type vaultReadPrincipal struct {
+	TenantID string
+	TokenID  string   // grant_id or cap token_id — used for audit
+	AgentID  string   // agent field from token
+	TaskID   string   // legacy cap tokens only; empty for grants
+	Scope    []string // secret scope
+}
 
 func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub string) {
 	if r.Method != http.MethodGet {
@@ -711,12 +722,12 @@ func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub str
 
 	vs := vault.NewStore(scope.Backend.Store().DB(), s.vaultMK)
 
-	// Full 4-step verification: HMAC signature → TTL → DB revocation → claims.
+	// Full verification: HMAC signature → TTL → DB revocation → claims.
 	// IMPORTANT: Do NOT write audit events before verification succeeds.
 	// The tenant_id comes from an unverified peek and could be forged;
 	// writing to tenant audit before proving token authenticity would let
 	// an attacker inject events into any tenant's audit log.
-	claims, err := vs.VerifyAndResolveCapToken(r.Context(), tenantID, raw)
+	principal, err := s.verifyVaultReadToken(r, vs, tenantID, raw)
 	if err != nil {
 		// Log to server-level observability only — not tenant audit.
 		if strings.Contains(err.Error(), "expired") {
@@ -733,7 +744,7 @@ func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub str
 	sub = strings.TrimPrefix(sub, "/")
 	if sub == "" {
 		// Enumerate: list secrets in scope.
-		s.handleVaultReadEnumerate(w, r, vs, claims)
+		s.handleVaultReadEnumerate(w, r, vs, principal)
 		return
 	}
 
@@ -745,29 +756,72 @@ func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub str
 	}
 
 	if fieldName != "" {
-		s.handleVaultReadField(w, r, vs, claims, secretName, fieldName)
+		s.handleVaultReadField(w, r, vs, principal, secretName, fieldName)
 	} else {
-		s.handleVaultReadSecret(w, r, vs, claims, secretName)
+		s.handleVaultReadSecret(w, r, vs, principal, secretName)
 	}
 }
 
-func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request, vs *vault.Store, claims *vault.CapTokenClaims) {
-	scopedNames := vault.ScopedSecretNames(claims.Scope)
+// verifyVaultReadToken verifies a capability or grant token and returns a
+// unified vaultReadPrincipal. Supports both legacy cap tokens (vault_ prefix)
+// and grant tokens (vt_ prefix).
+func (s *Server) verifyVaultReadToken(r *http.Request, vs *vault.Store, tenantID, raw string) (*vaultReadPrincipal, error) {
+	if strings.HasPrefix(raw, "vt_") {
+		return s.verifyGrantReadToken(r, vs, tenantID, raw)
+	}
+	return s.verifyCapReadToken(r, vs, tenantID, raw)
+}
+
+// verifyCapReadToken verifies a legacy cap token and maps to vaultReadPrincipal.
+func (s *Server) verifyCapReadToken(r *http.Request, vs *vault.Store, tenantID, raw string) (*vaultReadPrincipal, error) {
+	claims, err := vs.VerifyAndResolveCapToken(r.Context(), tenantID, raw)
+	if err != nil {
+		return nil, err
+	}
+	return &vaultReadPrincipal{
+		TenantID: claims.TenantID,
+		TokenID:  claims.TokenID,
+		AgentID:  claims.AgentID,
+		TaskID:   claims.TaskID,
+		Scope:    claims.Scope,
+	}, nil
+}
+
+// verifyGrantReadToken verifies a grant token and maps to vaultReadPrincipal.
+// Grant tokens must have perm == "read" for the read path.
+func (s *Server) verifyGrantReadToken(r *http.Request, vs *vault.Store, tenantID, raw string) (*vaultReadPrincipal, error) {
+	claims, err := vs.VerifyAndResolveGrant(r.Context(), tenantID, s.vaultIssuerURL, raw)
+	if err != nil {
+		return nil, err
+	}
+	if claims.Perm != vault.GrantPermRead {
+		return nil, fmt.Errorf("grant perm must be read")
+	}
+	return &vaultReadPrincipal{
+		TenantID: claims.TenantID,
+		TokenID:  claims.GrantID,
+		AgentID:  claims.Agent,
+		Scope:    claims.Scope,
+	}, nil
+}
+
+func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal) {
+	scopedNames := vault.ScopedSecretNames(p.Scope)
 	// Filter to secrets that actually exist.
 	var available []string
 	for _, name := range scopedNames {
-		_, err := vs.GetSecret(r.Context(), claims.TenantID, name)
+		_, err := vs.GetSecret(r.Context(), p.TenantID, name)
 		if err == nil {
 			available = append(available, name)
 		}
 	}
 
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
-		TenantID:  claims.TenantID,
+		TenantID:  p.TenantID,
 		EventType: "secret.list",
-		TokenID:   claims.TokenID,
-		AgentID:   claims.AgentID,
-		TaskID:    claims.TaskID,
+		TokenID:   p.TokenID,
+		AgentID:   p.AgentID,
+		TaskID:    p.TaskID,
 		Adapter:   "api",
 	})
 
@@ -778,15 +832,15 @@ func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request
 	_ = json.NewEncoder(w).Encode(map[string]any{"secrets": available})
 }
 
-func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, vs *vault.Store, claims *vault.CapTokenClaims, secretName string) {
+func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal, secretName string) {
 	// Scope check.
-	allFields, allowedFields := vault.AllowedFields(claims.Scope, secretName)
+	allFields, allowedFields := vault.AllowedFields(p.Scope, secretName)
 	if !allFields && len(allowedFields) == 0 {
 		_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
-			TenantID:   claims.TenantID,
+			TenantID:   p.TenantID,
 			EventType:  "secret.denied",
-			TokenID:    claims.TokenID,
-			AgentID:    claims.AgentID,
+			TokenID:    p.TokenID,
+			AgentID:    p.AgentID,
 			SecretName: secretName,
 			Detail:     map[string]string{"reason": "out_of_scope"},
 		})
@@ -795,7 +849,7 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 		return
 	}
 
-	fields, err := vs.ReadSecretFields(r.Context(), claims.TenantID, secretName)
+	fields, err := vs.ReadSecretFields(r.Context(), p.TenantID, secretName)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "not found")
@@ -819,11 +873,11 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 	}
 
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
-		TenantID:   claims.TenantID,
+		TenantID:   p.TenantID,
 		EventType:  "secret.read",
-		TokenID:    claims.TokenID,
-		AgentID:    claims.AgentID,
-		TaskID:     claims.TaskID,
+		TokenID:    p.TokenID,
+		AgentID:    p.AgentID,
+		TaskID:     p.TaskID,
 		SecretName: secretName,
 		Adapter:    "api",
 	})
@@ -847,14 +901,14 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 	}
 }
 
-func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs *vault.Store, claims *vault.CapTokenClaims, secretName, fieldName string) {
+func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal, secretName, fieldName string) {
 	// Scope check.
-	if !vault.CheckScope(claims.Scope, secretName, fieldName) {
+	if !vault.CheckScope(p.Scope, secretName, fieldName) {
 		_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
-			TenantID:   claims.TenantID,
+			TenantID:   p.TenantID,
 			EventType:  "secret.denied",
-			TokenID:    claims.TokenID,
-			AgentID:    claims.AgentID,
+			TokenID:    p.TokenID,
+			AgentID:    p.AgentID,
 			SecretName: secretName,
 			FieldName:  fieldName,
 			Detail:     map[string]string{"reason": "out_of_scope"},
@@ -863,7 +917,7 @@ func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs
 		return
 	}
 
-	plaintext, err := vs.ReadSecretField(r.Context(), claims.TenantID, secretName, fieldName)
+	plaintext, err := vs.ReadSecretField(r.Context(), p.TenantID, secretName, fieldName)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) || errors.Is(err, vault.ErrFieldNotFound) {
 			errJSON(w, http.StatusNotFound, "not found")
@@ -874,11 +928,11 @@ func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs
 	}
 
 	_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
-		TenantID:   claims.TenantID,
+		TenantID:   p.TenantID,
 		EventType:  "secret.read",
-		TokenID:    claims.TokenID,
-		AgentID:    claims.AgentID,
-		TaskID:     claims.TaskID,
+		TokenID:    p.TokenID,
+		AgentID:    p.AgentID,
+		TaskID:     p.TaskID,
 		SecretName: secretName,
 		FieldName:  fieldName,
 		Adapter:    "api",

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -86,7 +86,7 @@ func newVaultGrantReadRuntime(t *testing.T) *vaultGrantReadRuntime {
 			DBPasswordCipher: passCipher,
 			DBName:           parsed.DBName,
 			DBTLS:            false,
-			Provider:         tenant.ProviderTiDBZero,
+			Provider:         tenant.ProviderDB9,
 			SchemaVersion:    1,
 			CreatedAt:        now,
 			UpdatedAt:        now,

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
 	"github.com/mem9-ai/dat9/pkg/vault"
 )
@@ -86,8 +87,8 @@ func newVaultGrantReadRuntime(t *testing.T) *vaultGrantReadRuntime {
 			DBPasswordCipher: passCipher,
 			DBName:           parsed.DBName,
 			DBTLS:            false,
-			Provider:         tenant.ProviderDB9,
-			SchemaVersion:    1,
+			Provider:         tenant.ProviderTiDBZero,
+			SchemaVersion:    schema.CurrentTiDBTenantSchemaVersion,
 			CreatedAt:        now,
 			UpdatedAt:        now,
 		}

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -1,307 +1,332 @@
 package server
 
 import (
+	"bytes"
+	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/mem9-ai/dat9/internal/testmysql"
-	"github.com/mem9-ai/dat9/pkg/backend"
-	"github.com/mem9-ai/dat9/pkg/datastore"
-	"github.com/mem9-ai/dat9/pkg/s3client"
-	"github.com/mem9-ai/dat9/pkg/tenant/schema"
+	"github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/dat9/pkg/encrypt"
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
 	"github.com/mem9-ai/dat9/pkg/vault"
 )
 
-// newVaultReadTestServer creates a single-tenant server with vault enabled.
-// It returns the server, httptest server, vault store, and vault master key.
-func newVaultReadTestServer(t *testing.T) (*httptest.Server, *vault.Store, *vault.MasterKey) {
+type vaultGrantReadRuntime struct {
+	server   *Server
+	store    *vault.Store
+	tenantID string
+	otherID  string
+	issuer   string
+	cleanup  func()
+}
+
+func newVaultGrantReadRuntime(t *testing.T) *vaultGrantReadRuntime {
 	t.Helper()
+	if testDSN == "" {
+		t.Skip("no test database available")
+	}
 
-	s3Dir, err := os.MkdirTemp("", "dat9-vault-read-*")
+	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
 
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
 	initServerTenantSchema(t, testDSN)
-	store, err := datastore.Open(testDSN)
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
 	if err != nil {
 		t.Fatal(err)
 	}
-	testmysql.ResetDB(t, store.DB())
-	// Init vault tables on the same DB.
-	if err := schema.ExecSchemaStatements(store.DB(), schema.VaultTiDBSchemaStatements()); err != nil {
-		t.Fatal(err)
+	now := time.Now().UTC()
+	tenantID := token.NewID()
+	otherID := token.NewID()
+	newTenantMeta := func(id string) *meta.Tenant {
+		return &meta.Tenant{
+			ID:               id,
+			Status:           meta.TenantActive,
+			DBHost:           host,
+			DBPort:           port,
+			DBUser:           parsed.User,
+			DBPasswordCipher: passCipher,
+			DBName:           parsed.DBName,
+			DBTLS:            false,
+			Provider:         tenant.ProviderTiDBZero,
+			SchemaVersion:    1,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
 	}
-	t.Cleanup(func() { _ = store.Close() })
-
-	s3c, err := s3client.NewLocal(s3Dir, "/s3")
+	tenantMeta := newTenantMeta(tenantID)
+	for _, tenantRecord := range []*meta.Tenant{tenantMeta, newTenantMeta(otherID)} {
+		if err := metaStore.InsertTenant(context.Background(), tenantRecord); err != nil {
+			t.Fatal(err)
+		}
+	}
+	backend, release, err := pool.Acquire(context.Background(), tenantMeta)
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := backend.NewWithS3(store, s3c)
-	if err != nil {
-		t.Fatal(err)
+	release()
+	if err := vault.InitSchema(backend.Store().DB()); err != nil {
+		t.Fatalf("init vault schema: %v", err)
+	}
+	for _, tbl := range []string{
+		"vault_audit_log",
+		"vault_grants",
+		"vault_tokens",
+		"vault_secret_fields",
+		"vault_secrets",
+		"vault_deks",
+		"vault_policies",
+	} {
+		if _, err := backend.Store().DB().Exec("DELETE FROM " + tbl); err != nil {
+			t.Fatalf("clean %s: %v", tbl, err)
+		}
 	}
 
 	vaultKey := make([]byte, 32)
 	if _, err := rand.Read(vaultKey); err != nil {
 		t.Fatal(err)
 	}
-	mk, err := vault.NewMasterKey(vaultKey)
+	issuer := "https://vault-test.invalid"
+	store := vault.NewStore(backend.Store().DB(), mustVaultMasterKey(t, vaultKey))
+	server := NewWithConfig(Config{
+		Meta:           metaStore,
+		Pool:           pool,
+		TokenSecret:    []byte("test-token-secret"),
+		VaultMasterKey: vaultKey,
+		VaultIssuerURL: issuer,
+	})
+
+	return &vaultGrantReadRuntime{
+		server:   server,
+		store:    store,
+		tenantID: tenantID,
+		otherID:  otherID,
+		issuer:   issuer,
+		cleanup: func() {
+			pool.Close()
+			_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+			_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+			_ = metaStore.Close()
+		},
+	}
+}
+
+func mustVaultMasterKey(t *testing.T, raw []byte) *vault.MasterKey {
+	t.Helper()
+	mk, err := vault.NewMasterKey(raw)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	srv := NewWithConfig(Config{
-		Backend:        b,
-		VaultMasterKey: vaultKey,
-		VaultIssuerURL: "https://test.invalid",
-	})
-	ts := httptest.NewServer(srv)
-	t.Cleanup(ts.Close)
-
-	vs := vault.NewStore(store.DB(), mk)
-	return ts, vs, mk
+	return mk
 }
 
-func vaultReadReq(t *testing.T, ts *httptest.Server, path, token string) *http.Response {
+func (rt *vaultGrantReadRuntime) issueGrant(t *testing.T, scope []string, perm vault.GrantPerm) (string, *vault.VaultGrant) {
 	t.Helper()
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+path, nil)
+	tok, grant, err := rt.store.IssueGrant(
+		context.Background(), rt.tenantID, rt.issuer,
+		vault.PrincipalDelegated, "agent-test", scope, perm, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant: %v", err)
+	}
+	return tok, grant
+}
+
+func (rt *vaultGrantReadRuntime) createSecret(t *testing.T) {
+	t.Helper()
+	_, err := rt.store.CreateSecret(context.Background(), rt.tenantID, "test3", "owner", vault.SecretTypeGeneric, map[string][]byte{
+		"k1": []byte("value1"),
+		"k2": []byte("value2"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+}
+
+func doVaultGrantRead(t *testing.T, srv *Server, token, path string) (*http.Response, []byte) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := http.DefaultClient.Do(req)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	resp := rec.Result()
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
 	if err != nil {
-		t.Fatalf("request %s: %v", path, err)
+		t.Fatalf("read response body: %v", err)
 	}
-	return resp
+	return resp, body
 }
 
-// TestVaultReadGrantTokenSuccess proves the full /v1/vault/read/* path works
-// with a vt_ grant token: issue grant → store secret → read via HTTP.
-func TestVaultReadGrantTokenSuccess(t *testing.T) {
-	ts, vs, _ := newVaultReadTestServer(t)
-	tenantID := "local" // single-tenant fallback uses "local"
-
-	// Store a secret.
-	_, err := vs.CreateSecret(t.Context(), tenantID, "db-prod", "test", vault.SecretTypeGeneric, map[string][]byte{
-		"password": []byte("s3cret"),
-		"host":     []byte("db.example.com"),
-	})
-	if err != nil {
-		t.Fatalf("CreateSecret: %v", err)
+func tamperGrantTenantID(t *testing.T, raw, tenantID string) string {
+	t.Helper()
+	if !strings.HasPrefix(raw, "vt_") {
+		t.Fatal("grant token prefix is not vt_")
 	}
-
-	// Issue a read grant.
-	tok, _, err := vs.IssueGrant(
-		t.Context(), tenantID, "https://test.invalid",
-		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
-		vault.GrantPermRead, time.Hour, "",
-	)
-	if err != nil {
-		t.Fatalf("IssueGrant: %v", err)
+	body := strings.TrimPrefix(raw, "vt_")
+	parts := strings.Split(body, ".")
+	if len(parts) != 3 {
+		t.Fatalf("grant token parts = %d, want 3", len(parts))
 	}
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(payloadJSON, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	payload["tenant_id"] = tenantID
+	payloadJSON, err = json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	parts[1] = base64.RawURLEncoding.EncodeToString(payloadJSON)
+	return "vt_" + strings.Join(parts, ".")
+}
 
-	// Read whole secret.
-	resp := vaultReadReq(t, ts, "/v1/vault/read/db-prod", tok)
-	defer resp.Body.Close()
+func TestVaultGrantReadTokenSuccessResponseShape(t *testing.T) {
+	rt := newVaultGrantReadRuntime(t)
+	defer rt.cleanup()
+	rt.createSecret(t)
+	tok, _ := rt.issueGrant(t, []string{"test3"}, vault.GrantPermRead)
+
+	resp, body := doVaultGrantRead(t, rt.server, tok, "/v1/vault/read/test3?format=json")
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		t.Fatalf("whole secret status=%d body=%s", resp.StatusCode, body)
 	}
-	var secretResp map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&secretResp); err != nil {
-		t.Fatalf("decode: %v", err)
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("whole secret content-type = %q, want application/json", ct)
 	}
-	fields, ok := secretResp["fields"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected fields map, got %T: %v", secretResp["fields"], secretResp)
+	var fields map[string]string
+	if err := json.Unmarshal(body, &fields); err != nil {
+		t.Fatalf("decode whole secret JSON: %v body=%s", err, body)
 	}
-	if fields["password"] != "s3cret" {
-		t.Fatalf("password: got %v", fields["password"])
+	if fields["k1"] != "value1" || fields["k2"] != "value2" {
+		t.Fatalf("fields = %#v", fields)
 	}
 
-	// Read single field.
-	resp2 := vaultReadReq(t, ts, "/v1/vault/read/db-prod/host", tok)
-	defer resp2.Body.Close()
-	if resp2.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp2.Body)
-		t.Fatalf("field read: expected 200, got %d: %s", resp2.StatusCode, body)
+	resp, body = doVaultGrantRead(t, rt.server, tok, "/v1/vault/read/test3/k1")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("field status=%d body=%s", resp.StatusCode, body)
 	}
-	fieldBody, _ := io.ReadAll(resp2.Body)
-	if string(fieldBody) != "db.example.com" {
-		t.Fatalf("field value: got %q", fieldBody)
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("field content-type = %q, want text/plain", ct)
+	}
+	if string(body) != "value1" {
+		t.Fatalf("field body = %q, want value1", body)
 	}
 }
 
-// TestVaultReadGrantTokenScopeDenied proves that a grant token cannot read
-// secrets outside its scope.
-func TestVaultReadGrantTokenScopeDenied(t *testing.T) {
-	ts, vs, _ := newVaultReadTestServer(t)
-	tenantID := "local"
+func TestVaultGrantReadScopeDenied(t *testing.T) {
+	rt := newVaultGrantReadRuntime(t)
+	defer rt.cleanup()
+	rt.createSecret(t)
+	tok, _ := rt.issueGrant(t, []string{"test3/k2"}, vault.GrantPermRead)
 
-	_, err := vs.CreateSecret(t.Context(), tenantID, "aws-prod", "test", vault.SecretTypeGeneric, map[string][]byte{
-		"key": []byte("AKIA..."),
-	})
-	if err != nil {
-		t.Fatalf("CreateSecret: %v", err)
-	}
-
-	// Grant scoped to "db-prod" only.
-	tok, _, err := vs.IssueGrant(
-		t.Context(), tenantID, "https://test.invalid",
-		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
-		vault.GrantPermRead, time.Hour, "",
-	)
-	if err != nil {
-		t.Fatalf("IssueGrant: %v", err)
-	}
-
-	// Try reading "aws-prod" — should be denied.
-	resp := vaultReadReq(t, ts, "/v1/vault/read/aws-prod", tok)
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusForbidden {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 403, got %d: %s", resp.StatusCode, body)
+	resp, body := doVaultGrantRead(t, rt.server, tok, "/v1/vault/read/test3/k1")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", resp.StatusCode, body)
 	}
 }
 
-// TestVaultReadGrantTokenRevoked proves that a revoked grant token is rejected
-// on the read path.
-func TestVaultReadGrantTokenRevoked(t *testing.T) {
-	ts, vs, _ := newVaultReadTestServer(t)
-	tenantID := "local"
-
-	_, err := vs.CreateSecret(t.Context(), tenantID, "db-prod", "test", vault.SecretTypeGeneric, map[string][]byte{
-		"password": []byte("s3cret"),
-	})
-	if err != nil {
-		t.Fatalf("CreateSecret: %v", err)
-	}
-
-	tok, grant, err := vs.IssueGrant(
-		t.Context(), tenantID, "https://test.invalid",
-		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
-		vault.GrantPermRead, time.Hour, "",
-	)
-	if err != nil {
-		t.Fatalf("IssueGrant: %v", err)
-	}
-
-	// Revoke the grant.
-	if err := vs.RevokeGrant(t.Context(), tenantID, grant.GrantID, "admin", "rotated"); err != nil {
+func TestVaultGrantReadRevoked(t *testing.T) {
+	rt := newVaultGrantReadRuntime(t)
+	defer rt.cleanup()
+	rt.createSecret(t)
+	tok, grant := rt.issueGrant(t, []string{"test3"}, vault.GrantPermRead)
+	if err := rt.store.RevokeGrant(context.Background(), rt.tenantID, grant.GrantID, "owner", "test"); err != nil {
 		t.Fatalf("RevokeGrant: %v", err)
 	}
 
-	resp := vaultReadReq(t, ts, "/v1/vault/read/db-prod", tok)
-	defer resp.Body.Close()
+	resp, body := doVaultGrantRead(t, rt.server, tok, "/v1/vault/read/test3/k1")
 	if resp.StatusCode != http.StatusUnauthorized {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 401, got %d: %s", resp.StatusCode, body)
+		t.Fatalf("status=%d body=%s, want 401", resp.StatusCode, body)
+	}
+	if !bytes.Contains(body, []byte("token revoked")) {
+		t.Fatalf("body=%s, want token revoked", body)
 	}
 }
 
-// TestVaultReadGrantTokenPermNotRead proves that a write-perm grant token is
-// rejected by the server read path (verifyGrantReadToken enforces perm==read).
-func TestVaultReadGrantTokenPermNotRead(t *testing.T) {
-	ts, vs, _ := newVaultReadTestServer(t)
-	tenantID := "local"
-
-	_, err := vs.CreateSecret(t.Context(), tenantID, "db-prod", "test", vault.SecretTypeGeneric, map[string][]byte{
-		"password": []byte("s3cret"),
-	})
+func TestVaultGrantReadTamperedTenantIDFailsNoFallback(t *testing.T) {
+	rt := newVaultGrantReadRuntime(t)
+	defer rt.cleanup()
+	rt.createSecret(t)
+	tok, _ := rt.issueGrant(t, []string{"test3"}, vault.GrantPermRead)
+	tampered := tamperGrantTenantID(t, tok, rt.otherID)
+	peekedTenant, err := vault.PeekGrantTenantID(tampered)
 	if err != nil {
-		t.Fatalf("CreateSecret: %v", err)
+		t.Fatalf("PeekGrantTenantID: %v", err)
+	}
+	if peekedTenant != rt.otherID {
+		t.Fatalf("peeked tenant = %q, want forged route %q", peekedTenant, rt.otherID)
+	}
+	if _, err := rt.store.VerifyAndResolveGrant(context.Background(), rt.otherID, rt.issuer, tampered); err == nil {
+		t.Fatal("expected tampered tenant_id to fail HMAC verification under forged tenant")
 	}
 
-	// Issue a WRITE grant — should be rejected on the read path.
-	tok, _, err := vs.IssueGrant(
-		t.Context(), tenantID, "https://test.invalid",
-		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
-		vault.GrantPermWrite, time.Hour, "",
-	)
-	if err != nil {
-		t.Fatalf("IssueGrant: %v", err)
-	}
-
-	resp := vaultReadReq(t, ts, "/v1/vault/read/db-prod", tok)
-	defer resp.Body.Close()
+	resp, body := doVaultGrantRead(t, rt.server, tampered, "/v1/vault/read/test3/k1")
 	if resp.StatusCode != http.StatusUnauthorized {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 401 for write-perm grant on read path, got %d: %s", resp.StatusCode, body)
+		t.Fatalf("status=%d body=%s, want 401", resp.StatusCode, body)
+	}
+	if bytes.Contains(body, []byte("value1")) {
+		t.Fatalf("tampered tenant_id unexpectedly read secret: %s", body)
 	}
 }
 
-// TestVaultReadGrantTokenTamperedTenantID proves that a vt_ grant token with a
-// tampered tenant_id (peeked for routing) fails at HMAC verification because
-// the server derives a different CSK for the wrong tenant.
-//
-// In single-tenant fallback mode, tenant_id is always "local" from the
-// injected scope, so a token issued for a different tenant_id will fail because
-// VerifyAndResolveGrant derives CSK from "local" but the token was signed with
-// CSK derived from a different tenant.
-func TestVaultReadGrantTokenTamperedTenantID(t *testing.T) {
-	ts, vs, _ := newVaultReadTestServer(t)
-
-	// Issue a grant for tenant "evil-tenant" — this uses a different CSK.
-	tok, _, err := vs.IssueGrant(
-		t.Context(), "evil-tenant", "https://test.invalid",
-		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
-		vault.GrantPermRead, time.Hour, "",
-	)
+func TestVaultGrantReadRejectsWritePermAfterVerify(t *testing.T) {
+	rt := newVaultGrantReadRuntime(t)
+	defer rt.cleanup()
+	rt.createSecret(t)
+	tok, _ := rt.issueGrant(t, []string{"test3"}, vault.GrantPermWrite)
+	claims, err := rt.store.VerifyAndResolveGrant(context.Background(), rt.tenantID, rt.issuer, tok)
 	if err != nil {
-		t.Fatalf("IssueGrant: %v", err)
+		t.Fatalf("VerifyAndResolveGrant: %v", err)
+	}
+	if claims.Perm != vault.GrantPermWrite {
+		t.Fatalf("verified perm = %q, want write", claims.Perm)
 	}
 
-	// Send to the server — scope.TenantID is "local", but the token was signed
-	// for "evil-tenant". HMAC verification will fail (different CSK).
-	resp := vaultReadReq(t, ts, "/v1/vault/read/db-prod", tok)
-	defer resp.Body.Close()
+	resp, body := doVaultGrantRead(t, rt.server, tok, "/v1/vault/read/test3/k1")
 	if resp.StatusCode != http.StatusUnauthorized {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 401 for tampered tenant_id, got %d: %s", resp.StatusCode, body)
-	}
-}
-
-// TestVaultReadFieldContentType proves response-shape parity: single-field
-// reads return application/octet-stream (raw bytes), not JSON.
-func TestVaultReadFieldContentType(t *testing.T) {
-	ts, vs, _ := newVaultReadTestServer(t)
-	tenantID := "local"
-
-	_, err := vs.CreateSecret(t.Context(), tenantID, "db-prod", "test", vault.SecretTypeGeneric, map[string][]byte{
-		"password": []byte("s3cret"),
-	})
-	if err != nil {
-		t.Fatalf("CreateSecret: %v", err)
-	}
-
-	tok, _, err := vs.IssueGrant(
-		t.Context(), tenantID, "https://test.invalid",
-		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
-		vault.GrantPermRead, time.Hour, "",
-	)
-	if err != nil {
-		t.Fatalf("IssueGrant: %v", err)
-	}
-
-	resp := vaultReadReq(t, ts, "/v1/vault/read/db-prod/password", tok)
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
-	}
-	ct := resp.Header.Get("Content-Type")
-	if ct != "application/octet-stream" {
-		t.Fatalf("Content-Type: got %q, want application/octet-stream", ct)
-	}
-	body, _ := io.ReadAll(resp.Body)
-	if string(body) != "s3cret" {
-		t.Fatalf("field value: got %q", body)
+		t.Fatalf("status=%d body=%s, want 401", resp.StatusCode, body)
 	}
 }

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -52,7 +52,7 @@ func newVaultGrantReadRuntime(t *testing.T) *vaultGrantReadRuntime {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost", SkipTiDBSchemaCheck: true}, enc)
 
 	parsed, err := mysql.ParseDSN(testDSN)
 	if err != nil {
@@ -86,7 +86,7 @@ func newVaultGrantReadRuntime(t *testing.T) *vaultGrantReadRuntime {
 			DBPasswordCipher: passCipher,
 			DBName:           parsed.DBName,
 			DBTLS:            false,
-			Provider:         tenant.ProviderDB9,
+			Provider:         tenant.ProviderTiDBZero,
 			SchemaVersion:    1,
 			CreatedAt:        now,
 			UpdatedAt:        now,

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -1,0 +1,307 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/dat9/internal/testmysql"
+	"github.com/mem9-ai/dat9/pkg/backend"
+	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/s3client"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
+	"github.com/mem9-ai/dat9/pkg/vault"
+)
+
+// newVaultReadTestServer creates a single-tenant server with vault enabled.
+// It returns the server, httptest server, vault store, and vault master key.
+func newVaultReadTestServer(t *testing.T) (*httptest.Server, *vault.Store, *vault.MasterKey) {
+	t.Helper()
+
+	s3Dir, err := os.MkdirTemp("", "dat9-vault-read-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
+
+	initServerTenantSchema(t, testDSN)
+	store, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetDB(t, store.DB())
+	// Init vault tables on the same DB.
+	if err := schema.ExecSchemaStatements(store.DB(), schema.VaultTiDBSchemaStatements()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	s3c, err := s3client.NewLocal(s3Dir, "/s3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := backend.NewWithS3(store, s3c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vaultKey := make([]byte, 32)
+	if _, err := rand.Read(vaultKey); err != nil {
+		t.Fatal(err)
+	}
+	mk, err := vault.NewMasterKey(vaultKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewWithConfig(Config{
+		Backend:        b,
+		VaultMasterKey: vaultKey,
+		VaultIssuerURL: "https://test.invalid",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	vs := vault.NewStore(store.DB(), mk)
+	return ts, vs, mk
+}
+
+func vaultReadReq(t *testing.T, ts *httptest.Server, path, token string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request %s: %v", path, err)
+	}
+	return resp
+}
+
+// TestVaultReadGrantTokenSuccess proves the full /v1/vault/read/* path works
+// with a vt_ grant token: issue grant → store secret → read via HTTP.
+func TestVaultReadGrantTokenSuccess(t *testing.T) {
+	ts, vs, _ := newVaultReadTestServer(t)
+	tenantID := "local" // single-tenant fallback uses "local"
+
+	// Store a secret.
+	_, err := vs.CreateSecret(t.Context(), tenantID, "db-prod", "test", vault.SecretTypeGeneric, map[string][]byte{
+		"password": []byte("s3cret"),
+		"host":     []byte("db.example.com"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Issue a read grant.
+	tok, _, err := vs.IssueGrant(
+		t.Context(), tenantID, "https://test.invalid",
+		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
+		vault.GrantPermRead, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant: %v", err)
+	}
+
+	// Read whole secret.
+	resp := vaultReadReq(t, ts, "/v1/vault/read/db-prod", tok)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var secretResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&secretResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	fields, ok := secretResp["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fields map, got %T: %v", secretResp["fields"], secretResp)
+	}
+	if fields["password"] != "s3cret" {
+		t.Fatalf("password: got %v", fields["password"])
+	}
+
+	// Read single field.
+	resp2 := vaultReadReq(t, ts, "/v1/vault/read/db-prod/host", tok)
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("field read: expected 200, got %d: %s", resp2.StatusCode, body)
+	}
+	fieldBody, _ := io.ReadAll(resp2.Body)
+	if string(fieldBody) != "db.example.com" {
+		t.Fatalf("field value: got %q", fieldBody)
+	}
+}
+
+// TestVaultReadGrantTokenScopeDenied proves that a grant token cannot read
+// secrets outside its scope.
+func TestVaultReadGrantTokenScopeDenied(t *testing.T) {
+	ts, vs, _ := newVaultReadTestServer(t)
+	tenantID := "local"
+
+	_, err := vs.CreateSecret(t.Context(), tenantID, "aws-prod", "test", vault.SecretTypeGeneric, map[string][]byte{
+		"key": []byte("AKIA..."),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Grant scoped to "db-prod" only.
+	tok, _, err := vs.IssueGrant(
+		t.Context(), tenantID, "https://test.invalid",
+		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
+		vault.GrantPermRead, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant: %v", err)
+	}
+
+	// Try reading "aws-prod" — should be denied.
+	resp := vaultReadReq(t, ts, "/v1/vault/read/aws-prod", tok)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 403, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+// TestVaultReadGrantTokenRevoked proves that a revoked grant token is rejected
+// on the read path.
+func TestVaultReadGrantTokenRevoked(t *testing.T) {
+	ts, vs, _ := newVaultReadTestServer(t)
+	tenantID := "local"
+
+	_, err := vs.CreateSecret(t.Context(), tenantID, "db-prod", "test", vault.SecretTypeGeneric, map[string][]byte{
+		"password": []byte("s3cret"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	tok, grant, err := vs.IssueGrant(
+		t.Context(), tenantID, "https://test.invalid",
+		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
+		vault.GrantPermRead, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant: %v", err)
+	}
+
+	// Revoke the grant.
+	if err := vs.RevokeGrant(t.Context(), tenantID, grant.GrantID, "admin", "rotated"); err != nil {
+		t.Fatalf("RevokeGrant: %v", err)
+	}
+
+	resp := vaultReadReq(t, ts, "/v1/vault/read/db-prod", tok)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+// TestVaultReadGrantTokenPermNotRead proves that a write-perm grant token is
+// rejected by the server read path (verifyGrantReadToken enforces perm==read).
+func TestVaultReadGrantTokenPermNotRead(t *testing.T) {
+	ts, vs, _ := newVaultReadTestServer(t)
+	tenantID := "local"
+
+	_, err := vs.CreateSecret(t.Context(), tenantID, "db-prod", "test", vault.SecretTypeGeneric, map[string][]byte{
+		"password": []byte("s3cret"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Issue a WRITE grant — should be rejected on the read path.
+	tok, _, err := vs.IssueGrant(
+		t.Context(), tenantID, "https://test.invalid",
+		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
+		vault.GrantPermWrite, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant: %v", err)
+	}
+
+	resp := vaultReadReq(t, ts, "/v1/vault/read/db-prod", tok)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401 for write-perm grant on read path, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+// TestVaultReadGrantTokenTamperedTenantID proves that a vt_ grant token with a
+// tampered tenant_id (peeked for routing) fails at HMAC verification because
+// the server derives a different CSK for the wrong tenant.
+//
+// In single-tenant fallback mode, tenant_id is always "local" from the
+// injected scope, so a token issued for a different tenant_id will fail because
+// VerifyAndResolveGrant derives CSK from "local" but the token was signed with
+// CSK derived from a different tenant.
+func TestVaultReadGrantTokenTamperedTenantID(t *testing.T) {
+	ts, vs, _ := newVaultReadTestServer(t)
+
+	// Issue a grant for tenant "evil-tenant" — this uses a different CSK.
+	tok, _, err := vs.IssueGrant(
+		t.Context(), "evil-tenant", "https://test.invalid",
+		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
+		vault.GrantPermRead, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant: %v", err)
+	}
+
+	// Send to the server — scope.TenantID is "local", but the token was signed
+	// for "evil-tenant". HMAC verification will fail (different CSK).
+	resp := vaultReadReq(t, ts, "/v1/vault/read/db-prod", tok)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401 for tampered tenant_id, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+// TestVaultReadFieldContentType proves response-shape parity: single-field
+// reads return application/octet-stream (raw bytes), not JSON.
+func TestVaultReadFieldContentType(t *testing.T) {
+	ts, vs, _ := newVaultReadTestServer(t)
+	tenantID := "local"
+
+	_, err := vs.CreateSecret(t.Context(), tenantID, "db-prod", "test", vault.SecretTypeGeneric, map[string][]byte{
+		"password": []byte("s3cret"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	tok, _, err := vs.IssueGrant(
+		t.Context(), tenantID, "https://test.invalid",
+		vault.PrincipalDelegated, "agent-1", []string{"db-prod"},
+		vault.GrantPermRead, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant: %v", err)
+	}
+
+	resp := vaultReadReq(t, ts, "/v1/vault/read/db-prod/password", tok)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if ct != "application/octet-stream" {
+		t.Fatalf("Content-Type: got %q, want application/octet-stream", ct)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "s3cret" {
+		t.Fatalf("field value: got %q", body)
+	}
+}

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
-	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
 	"github.com/mem9-ai/dat9/pkg/vault"
 )
@@ -87,8 +86,8 @@ func newVaultGrantReadRuntime(t *testing.T) *vaultGrantReadRuntime {
 			DBPasswordCipher: passCipher,
 			DBName:           parsed.DBName,
 			DBTLS:            false,
-			Provider:         tenant.ProviderTiDBZero,
-			SchemaVersion:    schema.CurrentTiDBTenantSchemaVersion,
+			Provider:         tenant.ProviderDB9,
+			SchemaVersion:    1,
 			CreatedAt:        now,
 			UpdatedAt:        now,
 		}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -37,6 +37,11 @@ type PoolConfig struct {
 	S3SessionToken    string
 
 	BackendOptions backend.Options
+
+	// SkipTiDBSchemaCheck disables the TiDB auto-embedding schema
+	// ensure/validate steps during Acquire. Used in tests that run
+	// against plain MySQL but need a TiDB-class provider for vault.
+	SkipTiDBSchemaCheck bool
 }
 
 type Pool struct {
@@ -333,7 +338,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	openStoreDurationMs := float64(time.Since(openStoreStart).Microseconds()) / 1000.0
 	ensureSchemaDurationMs := 0.0
-	if opts.DatabaseAutoEmbedding && (t.Provider == ProviderTiDBZero || t.Provider == ProviderTiDBCloudStarter) {
+	if !p.cfg.SkipTiDBSchemaCheck && opts.DatabaseAutoEmbedding && (t.Provider == ProviderTiDBZero || t.Provider == ProviderTiDBCloudStarter) {
 		if t.SchemaVersion != schema.CurrentTiDBTenantSchemaVersion {
 			ensureSchemaStart := time.Now()
 			if err := ensureTiDBSchemaForMode(ctx, store.DB(), schema.TiDBEmbeddingModeAuto); err != nil {

--- a/pkg/vault/grant.go
+++ b/pkg/vault/grant.go
@@ -60,6 +60,7 @@ func (s *Store) IssueGrant(
 	claims := &VaultGrantClaims{
 		Issuer:        issuer,
 		GrantID:       grantID,
+		TenantID:      tenantID,
 		PrincipalType: principal,
 		Agent:         agent,
 		Scope:         scope,

--- a/pkg/vault/grant.go
+++ b/pkg/vault/grant.go
@@ -128,6 +128,12 @@ func (s *Store) VerifyAndResolveGrant(
 		return nil, err
 	}
 
+	// Defense-in-depth: after HMAC verification succeeds, the verified
+	// tenant_id claim must match the routing tenant_id used to derive CSK.
+	if claims.TenantID != tenantID {
+		return nil, fmt.Errorf("tenant_id mismatch")
+	}
+
 	if expectedIssuer != "" && claims.Issuer != expectedIssuer {
 		return nil, fmt.Errorf("invalid issuer")
 	}

--- a/pkg/vault/grant_sign.go
+++ b/pkg/vault/grant_sign.go
@@ -105,6 +105,35 @@ func VerifyGrant(csk []byte, raw string, now time.Time) (*VaultGrantClaims, erro
 	return &claims, nil
 }
 
+// PeekGrantTenantID extracts the tenant_id from a grant token's payload
+// WITHOUT verifying the HMAC signature. This is used only to resolve the tenant
+// backend so that full verification can proceed. The caller MUST still call
+// VerifyAndResolveGrant before trusting any claims.
+func PeekGrantTenantID(raw string) (string, error) {
+	if !strings.HasPrefix(raw, grantTokenPrefix) {
+		return "", fmt.Errorf("invalid grant token format")
+	}
+	body := raw[len(grantTokenPrefix):]
+	parts := strings.SplitN(body, ".", 3)
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid grant token format")
+	}
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode payload: %w", err)
+	}
+	var peek struct {
+		TenantID string `json:"tenant_id"`
+	}
+	if err := json.Unmarshal(payloadJSON, &peek); err != nil {
+		return "", fmt.Errorf("unmarshal claims: %w", err)
+	}
+	if peek.TenantID == "" {
+		return "", fmt.Errorf("missing tenant_id in grant token")
+	}
+	return peek.TenantID, nil
+}
+
 // validateClaimsForSign enforces minimum structural invariants before the
 // server mints a token. These are redundant with validateClaimsForVerify but
 // they prevent writing a malformed token to the DB.
@@ -117,6 +146,9 @@ func validateClaimsForSign(c *VaultGrantClaims) error {
 	}
 	if c.GrantID == "" {
 		return fmt.Errorf("grant_id is required")
+	}
+	if c.TenantID == "" {
+		return fmt.Errorf("tenant_id is required")
 	}
 	if c.PrincipalType != PrincipalOwner && c.PrincipalType != PrincipalDelegated {
 		return fmt.Errorf("principal_type must be owner or delegated")
@@ -152,7 +184,7 @@ func validateClaimsForVerify(c *VaultGrantClaims, now time.Time) error {
 	if c.Perm != GrantPermRead && c.Perm != GrantPermWrite {
 		return fmt.Errorf("malformed grant: bad perm")
 	}
-	if c.GrantID == "" || c.Issuer == "" || c.Agent == "" {
+	if c.GrantID == "" || c.Issuer == "" || c.Agent == "" || c.TenantID == "" {
 		return fmt.Errorf("malformed grant: missing required claim")
 	}
 	if len(c.Scope) == 0 {

--- a/pkg/vault/grant_sign_test.go
+++ b/pkg/vault/grant_sign_test.go
@@ -24,6 +24,7 @@ func validClaims(exp time.Time) *VaultGrantClaims {
 	return &VaultGrantClaims{
 		Issuer:        "https://example.invalid",
 		GrantID:       "grt_test",
+		TenantID:      "tenant-test",
 		PrincipalType: PrincipalDelegated,
 		Agent:         "agent-a",
 		Scope:         []string{"aws-prod"},
@@ -181,13 +182,14 @@ func TestVerifyGrantAcceptsWithinSkew(t *testing.T) {
 
 // TestVerifyGrantRejectsUnknownClaims ensures the locked §16 claim set is
 // enforced on decode: extra JSON fields must make VerifyGrant fail, so a
-// signer that sneaks in (for example) `"tenant_id": "other"` can't smuggle
-// bonus authority into a verifier that ignores unknown keys.
+// signer that sneaks in bonus fields can't smuggle authority into a verifier
+// that ignores unknown keys.
 func TestVerifyGrantRejectsUnknownClaims(t *testing.T) {
 	csk := randomCSK(t)
 	tok := signHandCraftedClaims(t, csk, map[string]any{
 		"iss":            "https://example.invalid",
 		"grant_id":       "grt_test",
+		"tenant_id":      "tenant-test",
 		"principal_type": string(PrincipalDelegated),
 		"agent":          "agent-a",
 		"scope":          []string{"aws-prod"},
@@ -211,6 +213,7 @@ func TestVerifyGrantRejectsMissingRequiredClaim(t *testing.T) {
 		return map[string]any{
 			"iss":            "https://example.invalid",
 			"grant_id":       "grt_test",
+			"tenant_id":      "tenant-test",
 			"principal_type": string(PrincipalDelegated),
 			"agent":          "agent-a",
 			"scope":          []string{"aws-prod"},
@@ -218,7 +221,7 @@ func TestVerifyGrantRejectsMissingRequiredClaim(t *testing.T) {
 			"exp":            time.Now().Add(time.Hour).Unix(),
 		}
 	}
-	required := []string{"iss", "grant_id", "principal_type", "agent", "scope", "perm", "exp"}
+	required := []string{"iss", "grant_id", "tenant_id", "principal_type", "agent", "scope", "perm", "exp"}
 	for _, claim := range required {
 		t.Run("missing_"+claim, func(t *testing.T) {
 			payload := fullPayload()
@@ -240,5 +243,50 @@ func TestVerifyGrantRejectsMissingPrefix(t *testing.T) {
 	stripped := strings.TrimPrefix(tok, grantTokenPrefix)
 	if _, err := VerifyGrant(csk, stripped, time.Now()); err == nil {
 		t.Fatal("expected VerifyGrant to reject token without vt_ prefix")
+	}
+}
+
+func TestPeekGrantTenantID(t *testing.T) {
+	csk := randomCSK(t)
+	claims := validClaims(time.Now().Add(time.Hour))
+	claims.TenantID = "tenant-peek-42"
+	tok, err := SignGrant(csk, claims)
+	if err != nil {
+		t.Fatalf("SignGrant: %v", err)
+	}
+
+	tenantID, err := PeekGrantTenantID(tok)
+	if err != nil {
+		t.Fatalf("PeekGrantTenantID: %v", err)
+	}
+	if tenantID != "tenant-peek-42" {
+		t.Fatalf("expected tenant-peek-42, got %s", tenantID)
+	}
+
+	// Invalid token.
+	if _, err := PeekGrantTenantID("garbage"); err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+
+	// Legacy cap token prefix should fail.
+	if _, err := PeekGrantTenantID("vault_something.sig"); err == nil {
+		t.Fatal("expected error for vault_ prefix token")
+	}
+}
+
+func TestPeekGrantTenantIDMissingTenantID(t *testing.T) {
+	// Hand-craft a grant token without tenant_id to ensure PeekGrantTenantID rejects it.
+	csk := randomCSK(t)
+	tok := signHandCraftedClaims(t, csk, map[string]any{
+		"iss":            "https://example.invalid",
+		"grant_id":       "grt_test",
+		"principal_type": string(PrincipalDelegated),
+		"agent":          "agent-a",
+		"scope":          []string{"aws-prod"},
+		"perm":           string(GrantPermRead),
+		"exp":            time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := PeekGrantTenantID(tok); err == nil {
+		t.Fatal("expected error for grant token missing tenant_id")
 	}
 }

--- a/pkg/vault/grant_test.go
+++ b/pkg/vault/grant_test.go
@@ -185,6 +185,107 @@ func TestIssueGrantRejectsNonPositiveTTL(t *testing.T) {
 	}
 }
 
+// TestVerifyGrantTenantIDRoundtrip proves tenant_id survives issue → verify
+// and that VerifyAndResolveGrant cross-checks the routing tenant_id against
+// the verified claim. This is the vault-layer regression for adv-1 gate #4
+// "tampered tenant_id".
+func TestVerifyGrantTenantIDRoundtrip(t *testing.T) {
+	s := newGrantTestStore(t)
+	ctx := context.Background()
+
+	tok, _, err := s.IssueGrant(
+		ctx, "tenant-a", "https://srv.invalid",
+		PrincipalDelegated, "agent-1", []string{"aws-prod"},
+		GrantPermRead, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant: %v", err)
+	}
+
+	// Verify with correct tenant — succeeds.
+	claims, err := s.VerifyAndResolveGrant(ctx, "tenant-a", "", tok)
+	if err != nil {
+		t.Fatalf("VerifyAndResolveGrant: %v", err)
+	}
+	if claims.TenantID != "tenant-a" {
+		t.Fatalf("tenant_id roundtrip: got %q, want tenant-a", claims.TenantID)
+	}
+
+	// Verify with wrong tenant — fails at HMAC (different CSK).
+	// This is the "tampered tenant_id" scenario: if an attacker modifies the
+	// routing tenant_id, the server routes to the wrong tenant backend where
+	// DeriveCSK produces a different key and HMAC verification fails.
+	if _, err := s.VerifyAndResolveGrant(ctx, "tenant-evil", "", tok); err == nil {
+		t.Fatal("expected tampered tenant_id to fail HMAC verification")
+	}
+}
+
+// TestVerifyGrantPermReadWrite proves both read and write grants verify
+// successfully. The perm check (read-only for /v1/vault/read) is enforced
+// at the server layer (verifyGrantReadToken), not here.
+func TestVerifyGrantPermReadWrite(t *testing.T) {
+	s := newGrantTestStore(t)
+	ctx := context.Background()
+
+	// Read grant.
+	readTok, _, err := s.IssueGrant(
+		ctx, "tenant-a", "https://srv.invalid",
+		PrincipalDelegated, "agent-1", []string{"aws-prod"},
+		GrantPermRead, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant read: %v", err)
+	}
+	readClaims, err := s.VerifyAndResolveGrant(ctx, "tenant-a", "", readTok)
+	if err != nil {
+		t.Fatalf("VerifyAndResolveGrant read: %v", err)
+	}
+	if readClaims.Perm != GrantPermRead {
+		t.Fatalf("perm: got %q, want read", readClaims.Perm)
+	}
+
+	// Write grant — verifies at vault layer but server read path rejects.
+	writeTok, _, err := s.IssueGrant(
+		ctx, "tenant-a", "https://srv.invalid",
+		PrincipalDelegated, "agent-1", []string{"aws-prod"},
+		GrantPermWrite, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant write: %v", err)
+	}
+	writeClaims, err := s.VerifyAndResolveGrant(ctx, "tenant-a", "", writeTok)
+	if err != nil {
+		t.Fatalf("VerifyAndResolveGrant write: %v", err)
+	}
+	if writeClaims.Perm != GrantPermWrite {
+		t.Fatalf("perm: got %q, want write", writeClaims.Perm)
+	}
+}
+
+// TestVerifyGrantScopePreserved proves scope round-trips through issue → verify
+// so the server read path can enforce scope checks accurately.
+func TestVerifyGrantScopePreserved(t *testing.T) {
+	s := newGrantTestStore(t)
+	ctx := context.Background()
+
+	scope := []string{"db-prod/password", "aws-prod"}
+	tok, _, err := s.IssueGrant(
+		ctx, "tenant-a", "https://srv.invalid",
+		PrincipalDelegated, "agent-1", scope,
+		GrantPermRead, time.Hour, "",
+	)
+	if err != nil {
+		t.Fatalf("IssueGrant: %v", err)
+	}
+	claims, err := s.VerifyAndResolveGrant(ctx, "tenant-a", "", tok)
+	if err != nil {
+		t.Fatalf("VerifyAndResolveGrant: %v", err)
+	}
+	if len(claims.Scope) != 2 || claims.Scope[0] != "db-prod/password" || claims.Scope[1] != "aws-prod" {
+		t.Fatalf("scope roundtrip: got %v", claims.Scope)
+	}
+}
+
 // TestAuditGrantIssuedDetailContract asserts the grant.issued audit event
 // carries the exact Detail map the impl spec §5 requires:
 // grant_id, agent, principal_type, perm, scope. Mirrors the AuditEvent the

--- a/pkg/vault/types.go
+++ b/pkg/vault/types.go
@@ -130,18 +130,20 @@ type VaultGrant struct {
 // VaultGrantClaims is the JWT payload signed into the grant token.
 //
 // Claim set is locked by spec §16:
-//   - iss, grant_id, principal_type, agent, scope, perm, exp are required
+//   - iss, grant_id, tenant_id, principal_type, agent, scope, perm, exp are required
 //   - label_hint is optional and UX-only (Invariant #7 — never authz)
 //
-// tenant_id is deliberately NOT in the payload: tenant is resolved by the
-// server from its own registry keyed on iss + the tenant-scoped CSK used for
-// HMAC verification. Putting tenant_id in the body would be forgeable prior to
-// HMAC check.
+// tenant_id is a routing claim only: it allows the server to resolve the
+// correct tenant backend BEFORE HMAC verification. It is NOT an authority
+// claim — authorization is always determined by the HMAC signature (using
+// the tenant-scoped CSK) plus the DB grant row. A forged tenant_id routes
+// to the wrong tenant whose CSK will fail HMAC verification.
 //
 // task_id is deliberately absent (legacy Phase-0 concept; removed per §20).
 type VaultGrantClaims struct {
 	Issuer        string        `json:"iss"`
 	GrantID       string        `json:"grant_id"`
+	TenantID      string        `json:"tenant_id"`
 	PrincipalType PrincipalType `json:"principal_type"`
 	Agent         string        `json:"agent"`
 	Scope         []string      `json:"scope"`


### PR DESCRIPTION
## Summary
- Fix `vault get: invalid capability token` error when using grant tokens (`vt_` prefix) on the read path
- Add `tenant_id` as a routing claim to `VaultGrantClaims` — used only for pre-auth tenant backend resolution, NOT for authorization (HMAC with tenant-scoped CSK remains the authz gate)
- `capabilityAuthMiddleware` now supports both `vault_` (legacy) and `vt_` (grant) token prefixes
- `handleVaultRead` dispatches to `VerifyAndResolveGrant` for `vt_` tokens with `perm==read` enforcement
- Unified read handlers via `vaultReadPrincipal` struct

## Security invariants
1. `tenant_id` is a routing claim only — never used for authorization
2. Read path: `unverified decode tenant_id → pool.Acquire → VerifyAndResolveGrant → perm/scope check → read`
3. Tampered `tenant_id` routes to wrong tenant → HMAC verification fails (different CSK)
4. Grant tokens with `perm != read` are rejected on the read path

## Test plan
- [x] `PeekGrantTenantID` happy path + invalid + missing tenant_id
- [x] Existing grant sign/verify tests updated for new `tenant_id` claim
- [x] Full build passes (`go build ./...`)
- [ ] CI: code-ci + local-e2e
- [ ] Adversary review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified tenant routing for multiple token types so tenant identity is resolved consistently for vault reads; grant tokens must include tenant_id and are cross-checked during verification.
  * Vault read access now enforces grant permissions and uses resolved principal information for access decisions and auditing.

* **Tests**
  * Expanded integration and unit tests covering tenant_id handling, token forgery rejection, revocation behavior, and read-permission enforcement.

* **Documentation**
  * Updated specs/checklists to require tenant_id as a routing-only claim and describe verification expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->