### PR TITLE
feat: add tenant_id routing claim to VaultGrantClaims

### DIFF
--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -435,7 +435,7 @@ Contract rules:
 
 - Input **MUST** be a delegated JWT. If the payload indicates `principal_type=owner` (or any non-delegated credential), `ctx import` **MUST** refuse and instruct the user to use `ctx add --api-key`. `ctx import` is not a universal credential importer.
 - If the JWT's `exp` is already in the past at import time, `ctx import` **MUST** refuse (local short-circuit #1 — see §17). The `exp` check uses the local wall clock with no skew tolerance in v0; delegatees with badly skewed clocks will see spurious refusals or admissions and are expected to fix their clocks (NTP).
-- The JWT **MUST** contain all required delegated-context claims: `iss`, `exp`, `principal_type=delegated`, `agent`, `grant_id`, `scope[]` (non-empty array), and `perm` ∈ `{read, write}`. Missing or malformed required claims refuse at import; the full per-claim error mapping is in §11.
+- The JWT **MUST** contain all required delegated-context claims: `iss`, `exp`, `tenant_id`, `principal_type=delegated`, `agent`, `grant_id`, `scope[]` (non-empty array), and `perm` ∈ `{read, write}`. Missing or malformed required claims refuse at import; the full per-claim error mapping is in §11.
 - When `--from-file <path>` is given, the file **MUST** be mode `0600` (no group or world permission bits). If `stat.Mode().Perm() & 0o077 != 0`, `ctx import` refuses **before reading the contents** with `EACCES` and points the user at `chmod 600`. Rationale: a bearer-token file that has leaked to other local users is already-exposed credential; silently consuming it makes the CLI complicit in the lifecycle breach. This matches the argv-removal posture: the tool does not ingest credentials that have already escaped their intended confidentiality boundary.
 - Default context name is the JWT's `label_hint`; on collision or absence, fall back to `<agent>-<scope-root>` with a numeric suffix as needed. `--name` overrides.
 
@@ -554,6 +554,7 @@ The JWT payload is self-describing and **MUST** contain the following claims:
 |---|---|
 | `iss` | Issuer server URL; used by `ctx import` to populate the context's `server` field with no network call. |
 | `grant_id` | Server-assigned grant identifier (e.g. `grt_7f2a`); appears in audit and is the argument to `vault revoke`. |
+| `tenant_id` | **Routing-only claim.** Used by the server to resolve the correct tenant backend before HMAC verification. NOT an authorization claim — tampering routes to the wrong tenant where HMAC verification fails. |
 | `principal_type` | `delegated` (see §13.3 for the refusal rule on other kinds). |
 | `agent` | Agent ID as named by the owner at `vault grant --agent`; appears in audit and is the default prefix for context `name`. |
 | `scope[]` | List of granted paths (whole-secret or single-key; §6). |

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -242,6 +242,10 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 }
 
 func peekCapTokenTenantID(raw string) (string, error) {
+	// Try vt_ grant token first, then fall back to legacy cap token.
+	if tid, err := vault.PeekGrantTenantID(raw); err == nil {
+		return tid, nil
+	}
 	return vault.PeekCapTokenTenantID(raw)
 }
 

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -711,14 +711,15 @@ func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub str
 
 	vs := vault.NewStore(scope.Backend.Store().DB(), s.vaultMK)
 
-	// Full 4-step verification: HMAC signature → TTL → DB revocation → claims.
+	// Full verification: HMAC signature → TTL → DB revocation → claims.
 	// IMPORTANT: Do NOT write audit events before verification succeeds.
 	// The tenant_id comes from an unverified peek and could be forged;
 	// writing to tenant audit before proving token authenticity would let
 	// an attacker inject events into any tenant's audit log.
-	claims, err := vs.VerifyAndResolveCapToken(r.Context(), tenantID, raw)
+	//
+	// Try vt_ grant token first; fall back to legacy cap token.
+	claims, err := s.verifyVaultReadToken(r, vs, tenantID, raw)
 	if err != nil {
-		// Log to server-level observability only — not tenant audit.
 		if strings.Contains(err.Error(), "expired") {
 			errJSON(w, http.StatusUnauthorized, "token expired")
 		} else if strings.Contains(err.Error(), "revoked") {
@@ -749,6 +750,29 @@ func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub str
 	} else {
 		s.handleVaultReadSecret(w, r, vs, claims, secretName)
 	}
+}
+
+// verifyVaultReadToken tries vt_ grant token verification first, then falls
+// back to legacy cap token verification. Grant claims are mapped to
+// CapTokenClaims so the downstream read handlers work unchanged.
+func (s *Server) verifyVaultReadToken(r *http.Request, vs *vault.Store, tenantID, raw string) (*vault.CapTokenClaims, error) {
+	if strings.HasPrefix(raw, "vt_") {
+		grantClaims, err := vs.VerifyAndResolveGrant(r.Context(), tenantID, s.vaultIssuerURL, raw)
+		if err != nil {
+			return nil, err
+		}
+		if grantClaims.Perm != vault.GrantPermRead {
+			return nil, fmt.Errorf("grant perm is not read")
+		}
+		// Map grant claims to CapTokenClaims for downstream handler compatibility.
+		return &vault.CapTokenClaims{
+			TokenID:  grantClaims.GrantID,
+			TenantID: grantClaims.TenantID,
+			AgentID:  grantClaims.Agent,
+			Scope:    grantClaims.Scope,
+		}, nil
+	}
+	return vs.VerifyAndResolveCapToken(r.Context(), tenantID, raw)
 }
 
 func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request, vs *vault.Store, claims *vault.CapTokenClaims) {

--- a/pkg/vault/grant.go
+++ b/pkg/vault/grant.go
@@ -60,6 +60,7 @@ func (s *Store) IssueGrant(
 	claims := &VaultGrantClaims{
 		Issuer:        issuer,
 		GrantID:       grantID,
+		TenantID:      tenantID,
 		PrincipalType: principal,
 		Agent:         agent,
 		Scope:         scope,

--- a/pkg/vault/grant_sign.go
+++ b/pkg/vault/grant_sign.go
@@ -118,6 +118,9 @@ func validateClaimsForSign(c *VaultGrantClaims) error {
 	if c.GrantID == "" {
 		return fmt.Errorf("grant_id is required")
 	}
+	if c.TenantID == "" {
+		return fmt.Errorf("tenant_id is required")
+	}
 	if c.PrincipalType != PrincipalOwner && c.PrincipalType != PrincipalDelegated {
 		return fmt.Errorf("principal_type must be owner or delegated")
 	}
@@ -152,7 +155,7 @@ func validateClaimsForVerify(c *VaultGrantClaims, now time.Time) error {
 	if c.Perm != GrantPermRead && c.Perm != GrantPermWrite {
 		return fmt.Errorf("malformed grant: bad perm")
 	}
-	if c.GrantID == "" || c.Issuer == "" || c.Agent == "" {
+	if c.GrantID == "" || c.Issuer == "" || c.TenantID == "" || c.Agent == "" {
 		return fmt.Errorf("malformed grant: missing required claim")
 	}
 	if len(c.Scope) == 0 {
@@ -169,4 +172,33 @@ func validateClaimsForVerify(c *VaultGrantClaims, now time.Time) error {
 		return fmt.Errorf("grant expired")
 	}
 	return nil
+}
+
+// PeekGrantTenantID extracts tenant_id from a vt_ grant token's payload
+// WITHOUT verifying the HMAC signature. Used only to resolve the tenant
+// backend so that full verification can proceed. The caller MUST still call
+// VerifyAndResolveGrant before trusting any claims.
+func PeekGrantTenantID(raw string) (string, error) {
+	if !strings.HasPrefix(raw, grantTokenPrefix) {
+		return "", fmt.Errorf("not a grant token")
+	}
+	body := raw[len(grantTokenPrefix):]
+	parts := strings.Split(body, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid grant format")
+	}
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode payload: %w", err)
+	}
+	var peek struct {
+		TenantID string `json:"tenant_id"`
+	}
+	if err := json.Unmarshal(payloadJSON, &peek); err != nil {
+		return "", fmt.Errorf("unmarshal payload: %w", err)
+	}
+	if peek.TenantID == "" {
+		return "", fmt.Errorf("missing tenant_id in grant token")
+	}
+	return peek.TenantID, nil
 }

--- a/pkg/vault/grant_sign_test.go
+++ b/pkg/vault/grant_sign_test.go
@@ -24,6 +24,7 @@ func validClaims(exp time.Time) *VaultGrantClaims {
 	return &VaultGrantClaims{
 		Issuer:        "https://example.invalid",
 		GrantID:       "grt_test",
+		TenantID:      "test-tenant",
 		PrincipalType: PrincipalDelegated,
 		Agent:         "agent-a",
 		Scope:         []string{"aws-prod"},
@@ -181,13 +182,14 @@ func TestVerifyGrantAcceptsWithinSkew(t *testing.T) {
 
 // TestVerifyGrantRejectsUnknownClaims ensures the locked §16 claim set is
 // enforced on decode: extra JSON fields must make VerifyGrant fail, so a
-// signer that sneaks in (for example) `"tenant_id": "other"` can't smuggle
-// bonus authority into a verifier that ignores unknown keys.
+// signer that sneaks in extra claims can't smuggle bonus authority into a
+// verifier that ignores unknown keys.
 func TestVerifyGrantRejectsUnknownClaims(t *testing.T) {
 	csk := randomCSK(t)
 	tok := signHandCraftedClaims(t, csk, map[string]any{
 		"iss":            "https://example.invalid",
 		"grant_id":       "grt_test",
+		"tenant_id":      "test-tenant",
 		"principal_type": string(PrincipalDelegated),
 		"agent":          "agent-a",
 		"scope":          []string{"aws-prod"},
@@ -211,6 +213,7 @@ func TestVerifyGrantRejectsMissingRequiredClaim(t *testing.T) {
 		return map[string]any{
 			"iss":            "https://example.invalid",
 			"grant_id":       "grt_test",
+			"tenant_id":      "test-tenant",
 			"principal_type": string(PrincipalDelegated),
 			"agent":          "agent-a",
 			"scope":          []string{"aws-prod"},
@@ -218,7 +221,7 @@ func TestVerifyGrantRejectsMissingRequiredClaim(t *testing.T) {
 			"exp":            time.Now().Add(time.Hour).Unix(),
 		}
 	}
-	required := []string{"iss", "grant_id", "principal_type", "agent", "scope", "perm", "exp"}
+	required := []string{"iss", "grant_id", "tenant_id", "principal_type", "agent", "scope", "perm", "exp"}
 	for _, claim := range required {
 		t.Run("missing_"+claim, func(t *testing.T) {
 			payload := fullPayload()
@@ -240,5 +243,59 @@ func TestVerifyGrantRejectsMissingPrefix(t *testing.T) {
 	stripped := strings.TrimPrefix(tok, grantTokenPrefix)
 	if _, err := VerifyGrant(csk, stripped, time.Now()); err == nil {
 		t.Fatal("expected VerifyGrant to reject token without vt_ prefix")
+	}
+}
+
+func TestPeekGrantTenantIDHappyPath(t *testing.T) {
+	csk := randomCSK(t)
+	tok, err := SignGrant(csk, validClaims(time.Now().Add(time.Hour)))
+	if err != nil {
+		t.Fatalf("SignGrant: %v", err)
+	}
+	tid, err := PeekGrantTenantID(tok)
+	if err != nil {
+		t.Fatalf("PeekGrantTenantID: %v", err)
+	}
+	if tid != "test-tenant" {
+		t.Fatalf("tenant_id: got %q, want test-tenant", tid)
+	}
+}
+
+func TestPeekGrantTenantIDWrongPrefix(t *testing.T) {
+	if _, err := PeekGrantTenantID("cap_notavalidtoken"); err == nil {
+		t.Fatal("expected PeekGrantTenantID to reject non-vt_ token")
+	}
+}
+
+func TestPeekGrantTenantIDMissingTenantID(t *testing.T) {
+	// Hand-craft a vt_ token with no tenant_id in the payload.
+	csk := randomCSK(t)
+	tok := signHandCraftedClaims(t, csk, map[string]any{
+		"iss":            "https://example.invalid",
+		"grant_id":       "grt_test",
+		"principal_type": string(PrincipalDelegated),
+		"agent":          "agent-a",
+		"scope":          []string{"aws-prod"},
+		"perm":           string(GrantPermRead),
+		"exp":            time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := PeekGrantTenantID(tok); err == nil {
+		t.Fatal("expected PeekGrantTenantID to reject token without tenant_id")
+	}
+}
+
+// TestVerifyGrantRoundtripsTenantID ensures tenant_id survives sign→verify.
+func TestVerifyGrantRoundtripsTenantID(t *testing.T) {
+	csk := randomCSK(t)
+	tok, err := SignGrant(csk, validClaims(time.Now().Add(time.Hour)))
+	if err != nil {
+		t.Fatalf("SignGrant: %v", err)
+	}
+	claims, err := VerifyGrant(csk, tok, time.Now())
+	if err != nil {
+		t.Fatalf("VerifyGrant: %v", err)
+	}
+	if claims.TenantID != "test-tenant" {
+		t.Fatalf("tenant_id roundtrip: got %q, want test-tenant", claims.TenantID)
 	}
 }

--- a/pkg/vault/types.go
+++ b/pkg/vault/types.go
@@ -130,18 +130,20 @@ type VaultGrant struct {
 // VaultGrantClaims is the JWT payload signed into the grant token.
 //
 // Claim set is locked by spec §16:
-//   - iss, grant_id, principal_type, agent, scope, perm, exp are required
+//   - iss, grant_id, tenant_id, principal_type, agent, scope, perm, exp are required
 //   - label_hint is optional and UX-only (Invariant #7 — never authz)
 //
-// tenant_id is deliberately NOT in the payload: tenant is resolved by the
-// server from its own registry keyed on iss + the tenant-scoped CSK used for
-// HMAC verification. Putting tenant_id in the body would be forgeable prior to
-// HMAC check.
+// tenant_id is a routing claim only — it allows the server to resolve the
+// correct tenant backend before HMAC verification. It is NOT an authority
+// claim: authorization is enforced by HMAC verification with the tenant-scoped
+// CSK + DB grant row check. Tampering with tenant_id routes to the wrong
+// tenant, where HMAC verification fails.
 //
 // task_id is deliberately absent (legacy Phase-0 concept; removed per §20).
 type VaultGrantClaims struct {
 	Issuer        string        `json:"iss"`
 	GrantID       string        `json:"grant_id"`
+	TenantID      string        `json:"tenant_id"`
 	PrincipalType PrincipalType `json:"principal_type"`
 	Agent         string        `json:"agent"`
 	Scope         []string      `json:"scope"`


### PR DESCRIPTION
## Summary

- Adds `tenant_id` as a **routing-only claim** to `VaultGrantClaims` (方案 2), fixing "invalid capability token" errors when `vt_` grant tokens are used with `drive9 vault get`
- The server's `capabilityAuthMiddleware` now resolves tenant backend from both `vt_` grant tokens and legacy cap tokens
- `handleVaultRead` dispatches to `VerifyAndResolveGrant` for `vt_` tokens, enforcing full HMAC + TTL + DB revocation verification

## Security

`tenant_id` is NOT an authorization claim. It is used only for pre-auth tenant backend resolution. Tampering with `tenant_id` routes to the wrong tenant, where HMAC verification with the tenant-scoped CSK fails. Authorization remains: HMAC signature verification + DB grant row revocation check.

## Files changed (7)

| File | Change |
|---|---|
| `pkg/vault/types.go` | Add `TenantID` field to `VaultGrantClaims` |
| `pkg/vault/grant_sign.go` | Add `TenantID` validation + `PeekGrantTenantID` |
| `pkg/vault/grant.go` | Set `TenantID` in `IssueGrant` claims |
| `pkg/server/auth.go` | Route `vt_` tokens in `peekCapTokenTenantID` |
| `pkg/server/vault.go` | Add `verifyVaultReadToken` dispatch |
| `pkg/vault/grant_sign_test.go` | Update tests + add PeekGrantTenantID tests |
| `docs/specs/vault-interaction-end-state.md` | Update §16 claim table |

## Test plan

- [x] `go build ./pkg/vault/... ./pkg/server/...` passes
- [x] `go vet ./pkg/vault/... ./pkg/server/...` passes
- [x] Test binary compiles (`go test -c`)
- [ ] CI runs full test suite (requires Docker for testcontainers)
- [ ] @adversary-1 @adversary-2 review per qiffang's directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)