### PR TITLE
fix: mark macFUSE mounts local

### DIFF
--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -239,6 +239,14 @@ func Mount(opts *MountOptions) error {
 	if runtime.GOOS == "linux" {
 		fuseOpts.MaxWrite = 1024 * 1024 // 1MiB — Linux FUSE supports this natively
 	}
+	if runtime.GOOS == "darwin" {
+		// macFUSE can reject open/readdir before requests reach the daemon if
+		// it performs local permission checks or treats the volume as a
+		// privacy-gated network volume. drive9 authorization is remote, so
+		// defer permission decisions to the filesystem handlers and present the
+		// mount as local to ordinary CLI tools.
+		fuseOpts.Options = append(fuseOpts.Options, "defer_permissions", "local")
+	}
 	if opts.ReadOnly {
 		fuseOpts.Options = append(fuseOpts.Options, "ro")
 	}


### PR DESCRIPTION
## Summary
- add macOS macFUSE mount options to defer permission checks to drive9 handlers
- mark drive9 macFUSE mounts as local so ordinary CLI tools can open/readdir mounted directories without macOS nonlocal-volume EPERM

## Tests
- go test ./pkg/fuse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced macOS FUSE mount configuration for improved permission handling and local filesystem support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->