### PR TITLE
feat: support remote subtree mount (drive9 mount :/remote /local)

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mem9-ai/dat9/pkg/client"
 	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
+	"github.com/mem9-ai/dat9/pkg/mountpath"
 	drive9webdav "github.com/mem9-ai/dat9/pkg/webdav"
 )
 
@@ -81,19 +82,39 @@ func fsMountCmd(args []string) error {
 	debug := fs.Bool("debug", false, "enable FUSE debug logging")
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "usage: drive9 mount [flags] <mountpoint>\n\nflags:\n")
+		fmt.Fprintf(os.Stderr, "usage: drive9 mount [flags] [:/remote] <mountpoint>\n\nflags:\n")
 		fs.PrintDefaults()
 	}
 
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if fs.NArg() < 1 {
+
+	// Parse positional args: 1-arg = mountpoint; 2-arg = :/remote mountpoint.
+	var remoteRoot, mountPoint string
+	switch fs.NArg() {
+	case 1:
+		remoteRoot = "/"
+		mountPoint = fs.Arg(0)
+	case 2:
+		rp, ok := ParseRemote(fs.Arg(0))
+		if !ok {
+			return fmt.Errorf("drive9 mount: first positional argument must be a remote source (e.g. :/path), got %q", fs.Arg(0))
+		}
+		if rp.Context != "" {
+			return fmt.Errorf("drive9 mount: context-scoped remote sources (e.g. %s:/path) are not yet supported", rp.Context)
+		}
+		remoteRoot = rp.Path
+		mountPoint = fs.Arg(1)
+	default:
 		fs.Usage()
 		os.Exit(2)
 	}
-	if fs.NArg() != 1 {
-		return fmt.Errorf("drive9 mount: exactly one mountpoint required")
+
+	var err error
+	remoteRoot, err = mountpath.NormalizeRoot(remoteRoot)
+	if err != nil {
+		return fmt.Errorf("drive9 mount: %w", err)
 	}
 
 	mountMode, err := ParseMountMode(*mode)
@@ -105,8 +126,6 @@ func fsMountCmd(args []string) error {
 		return err
 	}
 	normalizedLookupRetryCount := normalizeLookupRetryCount(*lookupRetryCount)
-
-	mountPoint := fs.Arg(0)
 
 	serverGiven, apiKeyGiven := flagProvided(fs, "server"), flagProvided(fs, "api-key")
 	if err := rejectEmptyFlag("server", *server, serverGiven); err != nil {
@@ -139,11 +158,13 @@ func fsMountCmd(args []string) error {
 		} else {
 			c = client.New(*server, *apiKey)
 		}
-		if _, err := c.List("/"); err != nil {
-			return fmt.Errorf("cannot reach dat9 server: %w", err)
+
+		// Validate remote root exists and is a directory.
+		if err := validateRemoteRoot(c, remoteRoot); err != nil {
+			return err
 		}
 
-		return webdavMount(c, mountPoint)
+		return webdavMount(c, mountPoint, remoteRoot)
 	}
 
 	// FUSE path (existing behavior).
@@ -157,6 +178,7 @@ func fsMountCmd(args []string) error {
 		APIKey:             *apiKey,
 		Token:              token,
 		MountPoint:         mountPoint,
+		RemoteRoot:         remoteRoot,
 		CacheDir:           *cacheDir,
 		CacheSize:          int64(*cacheSize) << 20,
 		DirTTL:             *dirTTL,
@@ -176,8 +198,27 @@ func fsMountCmd(args []string) error {
 }
 
 // newWebDAVHandler creates an http.Handler that serves drive9 content over WebDAV.
-func newWebDAVHandler(c *client.Client, prefix string) (http.Handler, error) {
-	return drive9webdav.NewHandler(c, drive9webdav.Options{Prefix: prefix}), nil
+func newWebDAVHandler(c *client.Client, prefix string, remoteRoot string) (http.Handler, error) {
+	return drive9webdav.NewHandler(c, drive9webdav.Options{Prefix: prefix, RemoteRoot: remoteRoot}), nil
+}
+
+// validateRemoteRoot checks that the remote root path exists and is a directory.
+func validateRemoteRoot(c *client.Client, remoteRoot string) error {
+	if remoteRoot == "/" {
+		// Root always exists; verify server connectivity via List.
+		if _, err := c.List("/"); err != nil {
+			return fmt.Errorf("cannot reach dat9 server: %w", err)
+		}
+		return nil
+	}
+	stat, err := c.Stat(remoteRoot)
+	if err != nil {
+		return fmt.Errorf("remote root %q: %w", remoteRoot, err)
+	}
+	if !stat.IsDir {
+		return fmt.Errorf("remote root %q is not a directory", remoteRoot)
+	}
+	return nil
 }
 
 func validateLookupRetryFlags(count int, timeout time.Duration) error {

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -238,21 +238,18 @@ func TestNormalizeLookupRetryCount(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // Row A — only the CURRENT backend keyword ("vault") is special. All other
-// first positionals flow into the legacy parser, which rejects extra
-// positionals instead of pre-reserving names for future backends.
+// bare-word first positionals (not :/path remote sources) are rejected when
+// two args are given, since the 2-arg form requires a remote source prefix.
 // ---------------------------------------------------------------------------
 
-func TestMountCmd_BareWordFirstArgFlowsToLegacyArityCheck(t *testing.T) {
+func TestMountCmd_BareWordFirstArgRejectsNonRemoteSource(t *testing.T) {
 	for _, s := range []string{"kv", "s3", "gcs", "nfs", "mnt", "tmp", "vaultdir", "data"} {
 		err := MountCmd([]string{s, "/mnt/x"})
 		if err == nil {
-			t.Fatalf("%q: expected positional-arity error", s)
+			t.Fatalf("%q: expected error for non-remote first arg", s)
 		}
-		if got := err.Error(); !strings.Contains(got, "exactly one mountpoint required") {
-			t.Fatalf("%q: error = %q, want positional-arity rejection", s, got)
-		}
-		if strings.Contains(err.Error(), "unsupported mount backend") {
-			t.Fatalf("%q: must not be rejected as reserved backend keyword", s)
+		if got := err.Error(); !strings.Contains(got, "must be a remote source") {
+			t.Fatalf("%q: error = %q, want remote-source rejection", s, got)
 		}
 	}
 }

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -72,24 +72,26 @@ type WebDAVMountHandler interface {
 
 // webdavMount starts a local WebDAV server bound to 127.0.0.1, invokes
 // mount_webdav to attach it to mountPoint, and blocks until SIGINT/SIGTERM.
-func webdavMount(c *client.Client, mountPoint string) error {
+func webdavMount(c *client.Client, mountPoint string, remoteRoot string) error {
 	return webdavMountWithDeps(c, mountPoint, webdavMountDeps{
-		goos:      runtime.GOOS,
-		signals:   signalChannel(),
-		runMount:  runWebDAVMountCmd,
-		unmount:   webdavUnmount,
-		exit:      os.Exit,
-		newPrefix: newWebDAVNoncePrefix,
+		goos:       runtime.GOOS,
+		signals:    signalChannel(),
+		runMount:   runWebDAVMountCmd,
+		unmount:    webdavUnmount,
+		exit:       os.Exit,
+		newPrefix:  newWebDAVNoncePrefix,
+		remoteRoot: remoteRoot,
 	})
 }
 
 type webdavMountDeps struct {
-	goos      string
-	signals   <-chan os.Signal
-	runMount  func(goos, serverURL, mountPoint string) error
-	unmount   func(goos, mountPoint string)
-	exit      func(code int)
-	newPrefix func() (string, error)
+	goos       string
+	signals    <-chan os.Signal
+	runMount   func(goos, serverURL, mountPoint string) error
+	unmount    func(goos, mountPoint string)
+	exit       func(code int)
+	newPrefix  func() (string, error)
+	remoteRoot string
 }
 
 func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDeps) error {
@@ -123,7 +125,11 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 	if err != nil {
 		return err
 	}
-	handler, err := newWebDAVHandler(c, prefix)
+	remoteRoot := deps.remoteRoot
+	if remoteRoot == "" {
+		remoteRoot = "/"
+	}
+	handler, err := newWebDAVHandler(c, prefix, remoteRoot)
 	if err != nil {
 		return fmt.Errorf("webdav: %w", err)
 	}

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -150,7 +150,7 @@ func TestMountCmd_WebDAVRejectsReadOnly(t *testing.T) {
 // TestNewWebDAVHandler verifies the handler constructor doesn't panic.
 func TestNewWebDAVHandler(t *testing.T) {
 	c := client.New("http://127.0.0.1:1", "test-key")
-	handler, err := newWebDAVHandler(c, "/_drive9_test")
+	handler, err := newWebDAVHandler(c, "/_drive9_test", "/")
 	if err != nil {
 		t.Fatalf("newWebDAVHandler returned error: %v", err)
 	}
@@ -319,6 +319,55 @@ func TestParseMountModeRoundTrip(t *testing.T) {
 // helper isn't available due to build tags, duplicate it here.
 func init() {
 	_ = errors.New // ensure import used
+}
+
+// ---------------------------------------------------------------------------
+// Remote root mount (:/remote /local) CLI parsing tests
+// ---------------------------------------------------------------------------
+
+func TestFsMountCmd_RemoteSourceParsing(t *testing.T) {
+	// 2-arg with valid remote source should parse (will fail at credential
+	// resolution, but that proves parsing succeeded).
+	err := fsMountCmd([]string{":/foo/bar", "/tmp/drive9-remote-test"})
+	if err == nil {
+		t.Fatal("expected credential error, not nil")
+	}
+	// Should NOT contain "must be a remote source" — that means parsing worked.
+	if strings.Contains(err.Error(), "must be a remote source") {
+		t.Fatalf("error = %v, should have parsed remote source successfully", err)
+	}
+}
+
+func TestFsMountCmd_RejectsNonRemoteFirstArg(t *testing.T) {
+	err := fsMountCmd([]string{"/foo/bar", "/tmp/drive9-test"})
+	if err == nil {
+		t.Fatal("expected error for non-remote first arg")
+	}
+	if !strings.Contains(err.Error(), "must be a remote source") {
+		t.Fatalf("error = %v, want remote-source rejection", err)
+	}
+}
+
+func TestFsMountCmd_RejectsContextScopedRemote(t *testing.T) {
+	err := fsMountCmd([]string{"prod:/foo/bar", "/tmp/drive9-test"})
+	if err == nil {
+		t.Fatal("expected error for context-scoped remote")
+	}
+	if !strings.Contains(err.Error(), "not yet supported") {
+		t.Fatalf("error = %v, want context-scoped rejection", err)
+	}
+}
+
+func TestFsMountCmd_SingleArgDefaultsToRootRemote(t *testing.T) {
+	// Single arg should work (fail at credentials, not at parsing).
+	err := fsMountCmd([]string{"/tmp/drive9-single-arg-test"})
+	if err == nil {
+		t.Fatal("expected credential error, not nil")
+	}
+	// Should NOT contain "remote source" error.
+	if strings.Contains(err.Error(), "remote source") {
+		t.Fatalf("single arg should not trigger remote-source error: %v", err)
+	}
 }
 
 func newWebDAVLifecycleClient(t *testing.T) *client.Client {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/mountpath"
 )
 
 // commitQueueDirectPutThreshold is the size limit below which commit queue
@@ -45,6 +46,7 @@ type CommitQueue struct {
 	canceled   map[string]struct{} // paths canceled by Unlink/Rmdir (workers skip these)
 	maxPending int
 	client     *client.Client
+	remoteRoot string
 	shadows    *ShadowStore
 	index      *PendingIndex
 	journal    *Journal
@@ -61,12 +63,16 @@ type CommitQueue struct {
 }
 
 // NewCommitQueue creates a CommitQueue with background workers.
-func NewCommitQueue(c *client.Client, shadows *ShadowStore, index *PendingIndex, journal *Journal, numWorkers int, maxPending int) *CommitQueue {
+func NewCommitQueue(c *client.Client, shadows *ShadowStore, index *PendingIndex, journal *Journal, numWorkers int, maxPending int, remoteRoot ...string) *CommitQueue {
 	if numWorkers <= 0 {
 		numWorkers = 4
 	}
 	if maxPending <= 0 {
 		maxPending = maxCommitQueuePending
+	}
+	root := "/"
+	if len(remoteRoot) > 0 && remoteRoot[0] != "" {
+		root = remoteRoot[0]
 	}
 	// Buffer must be > maxPending so Enqueue's send never blocks.
 	bufSize := maxPending * 2
@@ -76,6 +82,7 @@ func NewCommitQueue(c *client.Client, shadows *ShadowStore, index *PendingIndex,
 	cq := &CommitQueue{
 		maxPending: maxPending,
 		client:     c,
+		remoteRoot: root,
 		shadows:    shadows,
 		index:      index,
 		journal:    journal,
@@ -88,6 +95,14 @@ func NewCommitQueue(c *client.Client, shadows *ShadowStore, index *PendingIndex,
 		go cq.worker()
 	}
 	return cq
+}
+
+func (cq *CommitQueue) remotePath(localPath string) string {
+	root := "/"
+	if cq != nil && cq.remoteRoot != "" {
+		root = cq.remoteRoot
+	}
+	return mountpath.ToRemote(root, localPath)
 }
 
 // Enqueue adds a commit entry to the queue. Returns an error if the queue
@@ -380,11 +395,12 @@ func (cq *CommitQueue) uploadEntry(ctx context.Context, entry *CommitEntry) (int
 	if entry.Kind == PendingOverwrite && expectedRevision <= 0 {
 		return 0, fmt.Errorf("missing base revision for overwrite: %s", entry.Path)
 	}
+	apiPath := cq.remotePath(entry.Path)
 
 	// ShadowSpill entries: stream directly from shadow file to avoid loading
 	// multi-GiB files into memory. Uses io.SectionReader over the shadow fd.
 	if entry.ShadowSpill {
-		return 0, uploadFromShadow(ctx, cq.client, cq.shadows, entry.Path, expectedRevision)
+		return 0, uploadFromShadowRemote(ctx, cq.client, cq.shadows, entry.Path, apiPath, expectedRevision)
 	}
 
 	// Non-ShadowSpill: read full content into memory.
@@ -397,12 +413,12 @@ func (cq *CommitQueue) uploadEntry(ctx context.Context, entry *CommitEntry) (int
 	// Files under commitQueueDirectPutThreshold use direct PUT to skip the
 	// multipart initiate/presign/complete/finalize overhead (~440ms).
 	if entry.Size < commitQueueDirectPutThreshold {
-		committedRev, err := cq.client.WriteCtxConditionalWithRevision(ctx, entry.Path, data, expectedRevision)
+		committedRev, err := cq.client.WriteCtxConditionalWithRevision(ctx, apiPath, data, expectedRevision)
 		return committedRev, err
 	}
 
 	// Larger non-ShadowSpill files: multipart upload.
-	return 0, uploadBufferedRemoteFile(ctx, cq.client, entry.Path, data, expectedRevision)
+	return 0, uploadBufferedRemoteFile(ctx, cq.client, apiPath, data, expectedRevision)
 }
 
 func (cq *CommitQueue) removeFromQueue(entry *CommitEntry) {
@@ -494,11 +510,12 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 		cq.onCommitTerminalFailure(entry)
 		return
 	}
+	apiPath := cq.remotePath(entry.Path)
 
 	// Fetch server's current state: revision + content.
 	// Use per-RPC timeouts so that a slow Read doesn't starve the Upload budget.
 	statCtx, statCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	stat, err := cq.client.StatCtx(statCtx, entry.Path)
+	stat, err := cq.client.StatCtx(statCtx, apiPath)
 	statCancel()
 	if err != nil {
 		log.Printf("commit queue: auto-resolve failed for %s: stat: %v", entry.Path, err)
@@ -508,7 +525,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	serverRev := stat.Revision
 
 	readCtx, readCancel := context.WithTimeout(context.Background(), uploadTimeout)
-	serverData, err := cq.client.ReadCtx(readCtx, entry.Path)
+	serverData, err := cq.client.ReadCtx(readCtx, apiPath)
 	readCancel()
 	if err != nil {
 		log.Printf("commit queue: auto-resolve failed for %s: read server: %v", entry.Path, err)
@@ -532,7 +549,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	}
 	log.Printf("commit queue: auto-resolving conflict for %s via LWW (base rev %d → server rev %d)", entry.Path, entry.BaseRev, serverRev)
 	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), releaseTimeout(int64(len(localData))))
-	err = uploadBufferedRemoteFile(uploadCtx, cq.client, entry.Path, localData, serverRev)
+	err = uploadBufferedRemoteFile(uploadCtx, cq.client, apiPath, localData, serverRev)
 	uploadCancel()
 	if err != nil {
 		log.Printf("commit queue: auto-resolve LWW re-upload failed for %s: %v", entry.Path, err)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -19,6 +19,7 @@ import (
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/mountpath"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 )
 
@@ -209,6 +210,21 @@ func parentDir(p string) string {
 	return d
 }
 
+func (fs *Dat9FS) remoteRoot() string {
+	if fs == nil || fs.opts == nil || fs.opts.RemoteRoot == "" {
+		return "/"
+	}
+	return fs.opts.RemoteRoot
+}
+
+func (fs *Dat9FS) remotePath(localPath string) string {
+	return mountpath.ToRemote(fs.remoteRoot(), localPath)
+}
+
+func (fs *Dat9FS) localPath(remotePath string) (string, bool) {
+	return mountpath.ToLocal(fs.remoteRoot(), remotePath)
+}
+
 func (fs *Dat9FS) dirtyHandleSize(ino uint64) (int64, bool) {
 	fs.dirtyMu.Lock()
 	defer fs.dirtyMu.Unlock()
@@ -334,7 +350,7 @@ func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64
 }
 
 func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gofuse.Status {
-	stat, err := fs.client.StatCtx(ctx, fh.Path)
+	stat, err := fs.client.StatCtx(ctx, fs.remotePath(fh.Path))
 	if err != nil {
 		return httpToFuseStatus(err)
 	}
@@ -366,6 +382,7 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 	// (and its held fh.mu) indefinitely.
 	c := fs.client
 	filePath := fh.Path
+	remoteFilePath := fs.remotePath(filePath)
 	fh.Dirty.LoadPart = func(partNum int) ([]byte, error) {
 		partIdx := partNum - 1
 		offset := int64(partIdx) * partSize
@@ -382,7 +399,7 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 
 		loadStart := time.Now()
 		fs.debugf("dirty load part start path=%s part=%d off=%d len=%d", filePath, partNum, offset, length)
-		rc, err := c.ReadStreamRange(lpCtx, filePath, offset, length)
+		rc, err := c.ReadStreamRange(lpCtx, remoteFilePath, offset, length)
 		if err != nil {
 			fs.debugDurationf(loadStart, 0, "dirty load part open failed path=%s part=%d off=%d len=%d err=%v", filePath, partNum, offset, length, err)
 			return nil, err
@@ -705,7 +722,8 @@ func isTransientReadErr(err error) bool {
 // readTransientRetryCount detached retries are attempted with short timeouts.
 // Returns EIO (never EAGAIN) when all retries are exhausted.
 func (fs *Dat9FS) readSmallFileWithRetry(ctx context.Context, path string) ([]byte, error) {
-	data, err := fs.client.ReadCtx(ctx, path)
+	remotePath := fs.remotePath(path)
+	data, err := fs.client.ReadCtx(ctx, remotePath)
 	if err == nil || !isTransientReadErr(err) {
 		return data, err
 	}
@@ -713,7 +731,7 @@ func (fs *Dat9FS) readSmallFileWithRetry(ctx context.Context, path string) ([]by
 	lastErr := err
 	for range readTransientRetryCount {
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), readTransientRetryTimeout)
-		data, err = fs.client.ReadCtx(retryCtx, path)
+		data, err = fs.client.ReadCtx(retryCtx, remotePath)
 		retryCancel()
 		if err == nil {
 			return data, nil
@@ -758,7 +776,7 @@ func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, off
 // All body read errors (including truncation) are returned as-is so the
 // caller can classify them for retry.
 func (fs *Dat9FS) doRangeRead(ctx context.Context, path string, offset, size int64) ([]byte, int, error) {
-	rc, err := fs.client.ReadStreamRange(ctx, path, offset, size)
+	rc, err := fs.client.ReadStreamRange(ctx, fs.remotePath(path), offset, size)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -805,9 +823,10 @@ func (fs *Dat9FS) lookupRetryStats() (total, success, exhausted uint64) {
 	return fs.lookupStatRetryTotal.Load(), fs.lookupStatRetrySuccess.Load(), fs.lookupStatRetryExhausted.Load()
 }
 
-func (fs *Dat9FS) statWithTransientRetry(cancel <-chan struct{}, remotePath string, trackLookupMetrics bool) (*client.StatResult, error) {
+func (fs *Dat9FS) statWithTransientRetry(cancel <-chan struct{}, localPath string, trackLookupMetrics bool) (*client.StatResult, error) {
+	apiPath := fs.remotePath(localPath)
 	ctx, cf := fuseCtx(cancel)
-	stat, err := fs.client.StatCtx(ctx, remotePath)
+	stat, err := fs.client.StatCtx(ctx, apiPath)
 	cf()
 	if err == nil || isNotFoundErr(err) || !isTransientLookupErr(err) {
 		return stat, err
@@ -834,13 +853,13 @@ func (fs *Dat9FS) statWithTransientRetry(cancel <-chan struct{}, remotePath stri
 		// transient failures. Keep this detached+bounded behavior unless retry
 		// semantics are redesigned.
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), fs.lookupStatRetryTimeout())
-		stat, err = fs.client.StatCtx(retryCtx, remotePath)
+		stat, err = fs.client.StatCtx(retryCtx, apiPath)
 		retryCancel()
 		if err == nil {
 			if trackLookupMetrics {
 				successCount := fs.lookupStatRetrySuccess.Add(1)
 				if successCount <= 3 || successCount%lookupRetrySuccessLogEvery == 0 {
-					log.Printf("lookup stat retry recovered for %s (success_count=%d)", remotePath, successCount)
+					log.Printf("lookup stat retry recovered for %s (success_count=%d)", localPath, successCount)
 				}
 			}
 			return stat, nil
@@ -853,7 +872,7 @@ func (fs *Dat9FS) statWithTransientRetry(cancel <-chan struct{}, remotePath stri
 
 	if trackLookupMetrics {
 		fs.lookupStatRetryExhausted.Add(1)
-		log.Printf("lookup stat retries exhausted for %s: %v", remotePath, lastErr)
+		log.Printf("lookup stat retries exhausted for %s: %v", localPath, lastErr)
 	}
 	return nil, lastErr
 }
@@ -872,7 +891,8 @@ func (fs *Dat9FS) lookupListWithRetry(cancel <-chan struct{}, parentPath string)
 	// list-fallback retries are intentionally not counted in lookupStatRetry*;
 	// those counters remain scoped to the primary Lookup->Stat path.
 	ctx, cf := fuseCtx(cancel)
-	items, err := fs.client.ListCtx(ctx, parentPath)
+	apiPath := fs.remotePath(parentPath)
+	items, err := fs.client.ListCtx(ctx, apiPath)
 	cf()
 	if err == nil || !isTransientLookupErr(err) {
 		return items, err
@@ -889,7 +909,7 @@ func (fs *Dat9FS) lookupListWithRetry(cancel <-chan struct{}, parentPath string)
 		// said "not found", and cancel-coupled retries would collapse to the
 		// original transient failure immediately.
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), fs.lookupStatRetryTimeout())
-		items, err = fs.client.ListCtx(retryCtx, parentPath)
+		items, err = fs.client.ListCtx(retryCtx, apiPath)
 		retryCancel()
 		if err == nil || !isTransientLookupErr(err) {
 			return items, err
@@ -1140,13 +1160,14 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 			if newSize == 0 {
 				ctx, cf := fuseCtx(cancel)
 				defer cf()
-				if err := fs.client.WriteCtx(ctx, entry.Path, nil); err != nil {
+				apiPath := fs.remotePath(entry.Path)
+				if err := fs.client.WriteCtx(ctx, apiPath, nil); err != nil {
 					return httpToFuseStatus(err)
 				}
 				// Refresh the inode revision after the server-side truncate so a
 				// subsequent writable open does not reuse the stale pre-truncate
 				// base revision and conflict with its own zero-byte write.
-				stat, statErr := fs.client.StatCtx(ctx, entry.Path)
+				stat, statErr := fs.client.StatCtx(ctx, apiPath)
 				if statErr != nil {
 					log.Printf("post-truncate stat refresh failed for %s (inode=%d): %v (revision may be stale)", entry.Path, input.NodeId, statErr)
 				} else if stat != nil {
@@ -1190,7 +1211,7 @@ func (fs *Dat9FS) Mkdir(cancel <-chan struct{}, input *gofuse.MkdirIn, name stri
 		return st
 	}
 
-	if err := fs.client.MkdirCtx(ctx, childP); err != nil {
+	if err := fs.client.MkdirCtx(ctx, fs.remotePath(childP)); err != nil {
 		return httpToFuseStatus(err)
 	}
 
@@ -1269,7 +1290,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// Tolerate 404 in case it was already deleted.
 		deleteStart := time.Now()
 		fs.debugf("unlink remote delete start path=%s", childP)
-		err := fs.client.DeleteCtx(ctx, childP)
+		err := fs.client.DeleteCtx(ctx, fs.remotePath(childP))
 		fs.debugDurationf(deleteStart, 0, "unlink remote delete done path=%s err=%v", childP, err)
 		if err != nil {
 			if !isNotFoundErr(err) {
@@ -1307,7 +1328,7 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 
 	deleteStart := time.Now()
 	fs.debugf("rmdir remote delete start path=%s", childP)
-	err := fs.client.DeleteCtx(ctx, childP)
+	err := fs.client.DeleteCtx(ctx, fs.remotePath(childP))
 	fs.debugDurationf(deleteStart, 0, "rmdir remote delete done path=%s err=%v", childP, err)
 	if err != nil {
 		status = httpToFuseStatus(err)
@@ -1443,7 +1464,7 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 		}
 	}
 
-	if err := fs.client.RenameCtx(ctx, oldP, newP); err != nil {
+	if err := fs.client.RenameCtx(ctx, fs.remotePath(oldP), fs.remotePath(newP)); err != nil {
 		return httpToFuseStatus(err)
 	}
 
@@ -1594,7 +1615,7 @@ func (fs *Dat9FS) listDir(ctx context.Context, dirPath string) ([]DirEntry, erro
 		return fs.mergePendingDirEntries(dirPath, entries), nil
 	}
 
-	items, err := fs.client.ListCtx(ctx, dirPath)
+	items, err := fs.client.ListCtx(ctx, fs.remotePath(dirPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1771,7 +1792,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		}
 	} else {
 		// Normal mode: attach streaming uploader for sequential write streaming.
-		fh.Streamer = NewStreamUploader(fs.client, childP, expectedRevisionForHandle(fh))
+		fh.Streamer = NewStreamUploader(fs.client, childP, expectedRevisionForHandle(fh), fs.remoteRoot())
 		streamer := fh.Streamer
 		wb.OnPartFull = func(partIdx int, data []byte) {
 			partNum := partIdx + 1
@@ -1828,7 +1849,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		// If BaseRev is 0 (e.g. inode came from readdir without revision),
 		// fetch the authoritative revision so CAS uploads work correctly.
 		if fh.BaseRev == 0 && !fh.IsNew {
-			if stat, err := fs.client.StatCtx(ctx, p); err == nil && stat != nil {
+			if stat, err := fs.client.StatCtx(ctx, fs.remotePath(p)); err == nil && stat != nil {
 				fh.BaseRev = stat.Revision
 				fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
 			}
@@ -1900,7 +1921,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 				}
 			} else {
 				// Normal mode: attach streaming uploader with OnPartFull wiring.
-				fh.Streamer = NewStreamUploader(fs.client, p, expectedRevisionForHandle(fh))
+				fh.Streamer = NewStreamUploader(fs.client, p, expectedRevisionForHandle(fh), fs.remoteRoot())
 				streamer := fh.Streamer
 				filePath := p
 				fh.Dirty.OnPartFull = func(partIdx int, data []byte) {
@@ -1917,7 +1938,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 	if fh.Dirty == nil {
 		entry, _ := fs.inodes.GetEntry(input.NodeId)
 		if entry != nil && entry.Size > smallFileThreshold {
-			fh.Prefetch = NewPrefetcher(fs.client, p, entry.Size, fs.debugEnabled())
+			fh.Prefetch = NewPrefetcher(fs.client, fs.remotePath(p), entry.Size, fs.debugEnabled())
 		}
 		// Atomically pin shadow for read-only opens so commit queue cleanup
 		// doesn't delete the shadow file while this handle is reading from it.
@@ -2512,7 +2533,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			uploadStart := time.Now()
 			fs.debugf("flush shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 			fh.Unlock()
-			err := uploadFromShadow(ctx, fs.client, fs.shadowStore, fh.Path, expectedRevisionForHandle(fh))
+			err := uploadFromShadowRemote(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevisionForHandle(fh))
 			fh.Lock()
 			fs.debugDurationf(uploadStart, 0, "flush shadowspill upload done path=%s size=%d err=%v", fh.Path, size, err)
 			if err != nil {
@@ -2665,7 +2686,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		uploadStart := time.Now()
 		fs.debugf("fsync shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 		fh.Unlock()
-		err := uploadFromShadow(ctx, fs.client, fs.shadowStore, fh.Path, expectedRevisionForHandle(fh))
+		err := uploadFromShadowRemote(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevisionForHandle(fh))
 		fh.Lock()
 		fs.debugDurationf(uploadStart, 0, "fsync shadowspill upload done path=%s size=%d err=%v", fh.Path, size, err)
 		if err != nil {
@@ -2784,7 +2805,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				phase = "shadowspill-sync-upload"
 				uploadStart := time.Now()
 				fs.debugf("release shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
-				uploadErr := uploadFromShadow(ctx, fs.client, fs.shadowStore, fh.Path, expectedRevisionForHandle(fh))
+				uploadErr := uploadFromShadowRemote(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevisionForHandle(fh))
 				fs.debugDurationf(uploadStart, 0, "release shadowspill upload done path=%s size=%d err=%v", fh.Path, size, uploadErr)
 				if uploadErr != nil {
 					flushStatus = gofuse.EIO
@@ -2959,7 +2980,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		}
 
 		dCtx, dCf := context.WithTimeout(context.Background(), fuseTimeout)
-		committedRev, err := fs.client.WriteCtxConditionalWithRevision(dCtx, filePath, data, expectedRevision)
+		committedRev, err := fs.client.WriteCtxConditionalWithRevision(dCtx, fs.remotePath(filePath), data, expectedRevision)
 		dCf()
 		if err != nil {
 			handle.Unlock()
@@ -3171,7 +3192,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		phase = "small-write"
 		writeStart := time.Now()
 		fs.debugf("flushHandle small write start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
-		committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fh.Path, data, expectedRevision)
+		committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), data, expectedRevision)
 		fs.debugDurationf(writeStart, 0, "flushHandle small write done path=%s size=%d committed_rev=%d err=%v", fh.Path, size, committedRev, err)
 	} else if fh.OrigSize >= smallFileThreshold {
 		phase = "patch-file"
@@ -3190,7 +3211,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			fs.debugf("flushHandle patch start path=%s size=%d dirty_parts=%d expected_rev=%d", fh.Path, size, len(dirtyParts), expectedRevision)
 			err = fs.client.PatchFile(
 				ctx,
-				fh.Path,
+				fs.remotePath(fh.Path),
 				size,
 				dirtyParts,
 				func(partNumber int, partSize int64, origData []byte) ([]byte, error) {
@@ -3213,7 +3234,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.debugf("flushHandle write stream start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
 		err = fs.client.WriteStreamConditional(
 			ctx,
-			fh.Path,
+			fs.remotePath(fh.Path),
 			bytes.NewReader(data),
 			size,
 			nil,

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -741,6 +741,73 @@ func TestLookupFallsBackToParentListWhenDirStatUnsupported(t *testing.T) {
 	}
 }
 
+func TestLookupUsesRemoteRootMapping(t *testing.T) {
+	var gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if r.Method != http.MethodHead {
+			t.Fatalf("method = %s, want HEAD", r.Method)
+		}
+		w.Header().Set("Content-Length", "12")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", "5")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{RemoteRoot: "/remote"}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "file.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if gotPath != "/v1/fs/remote/file.txt" {
+		t.Fatalf("lookup API path = %q, want /v1/fs/remote/file.txt", gotPath)
+	}
+	if _, ok := fs.inodes.GetInode("/file.txt"); !ok {
+		t.Fatal("lookup should keep local inode path rebased to /file.txt")
+	}
+}
+
+func TestListDirUsesRemoteRootMapping(t *testing.T) {
+	var gotPath string
+	var gotQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"entries": []map[string]any{{
+				"name":     "nested.txt",
+				"isDir":    false,
+				"size":     7,
+				"revision": 3,
+			}},
+		})
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{RemoteRoot: "/remote"}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	entries, err := fs.listDir(context.Background(), "/subdir")
+	if err != nil {
+		t.Fatalf("listDir error = %v, want nil", err)
+	}
+	if gotPath != "/v1/fs/remote/subdir" || gotQuery != "list=1" {
+		t.Fatalf("listDir request = %q?%s, want /v1/fs/remote/subdir?list=1", gotPath, gotQuery)
+	}
+	if len(entries) != 1 || entries[0].Name != "nested.txt" {
+		t.Fatalf("listDir entries = %+v, want nested.txt", entries)
+	}
+}
+
 func TestLookupRetriesTransientCanceledStat(t *testing.T) {
 	var headCalls atomic.Int32
 	firstHeadStarted := make(chan struct{}, 1)
@@ -2680,10 +2747,10 @@ func TestReleaseTimeoutScaling(t *testing.T) {
 		wantMin time.Duration
 		wantMax time.Duration
 	}{
-		{0, 60 * time.Second, 60 * time.Second},                   // small file: floor
-		{10 << 20, 60 * time.Second, 60 * time.Second},            // 10 MB: still floor
-		{1 << 30, 200 * time.Second, 220 * time.Second},           // 1 GiB: ~205s
-		{100 << 30, 15 * time.Minute, 15 * time.Minute},           // 100 GiB: capped at 15min
+		{0, 60 * time.Second, 60 * time.Second},         // small file: floor
+		{10 << 20, 60 * time.Second, 60 * time.Second},  // 10 MB: still floor
+		{1 << 30, 200 * time.Second, 220 * time.Second}, // 1 GiB: ~205s
+		{100 << 30, 15 * time.Minute, 15 * time.Minute}, // 100 GiB: capped at 15min
 	}
 	for _, tt := range tests {
 		got := releaseTimeout(tt.size)
@@ -2700,9 +2767,9 @@ func TestReleaseTimeoutScaling(t *testing.T) {
 func largeFlushStreamingMock(t *testing.T, fileSize int64, completeCh chan<- struct{}) *httptest.Server {
 	t.Helper()
 	var (
-		mu        sync.Mutex
-		uploaded  bool // set true after /complete
-		etagSeq   int
+		mu       sync.Mutex
+		uploaded bool // set true after /complete
+		etagSeq  int
 	)
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -2778,9 +2845,9 @@ func largeFlushStreamingMock(t *testing.T, fileSize int64, completeCh chan<- str
 // cache is empty, and the remote stat has not yet observed the upload.
 //
 // Repro path that previously failed:
-//   1. Create + Write 10 MiB
-//   2. Flush (was: returned OK without uploading)
-//   3. Lookup the path → must succeed
+//  1. Create + Write 10 MiB
+//  2. Flush (was: returned OK without uploading)
+//  3. Lookup the path → must succeed
 func TestFlushLargeFile_StrictUploadsBeforeReturning(t *testing.T) {
 	const fileSize = int64(writeBackThreshold) // 10 MiB — minimal trigger of the large-file path
 
@@ -2850,8 +2917,8 @@ func TestFlushLargeFile_StrictUploadsBeforeReturning(t *testing.T) {
 // CommitQueue takes over the actual server write asynchronously.
 //
 // We assert two invariants:
-//   1. Flush returns quickly without contacting the upload endpoints.
-//   2. A subsequent Lookup hits pendingIndex (no remote stat needed).
+//  1. Flush returns quickly without contacting the upload endpoints.
+//  2. A subsequent Lookup hits pendingIndex (no remote stat needed).
 func TestFlushLargeFile_InteractiveStagesShadowAndPendingIndex(t *testing.T) {
 	const fileSize = int64(writeBackThreshold) // 10 MiB
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -30,6 +30,7 @@ type MountOptions struct {
 	APIKey             string        // owner API key (mutually exclusive with Token)
 	Token              string        // delegated capability JWT (mutually exclusive with APIKey)
 	MountPoint         string        // local mount point
+	RemoteRoot         string        // remote subtree root (default "/"); set via "drive9 mount :/path /local"
 	CacheDir           string        // write-back cache directory (default ~/.cache/drive9); empty string uses default
 	CacheSize          int64         // ReadCache max size in bytes (default 128MB)
 	DirTTL             time.Duration // DirCache TTL (default 10s)
@@ -120,8 +121,24 @@ func Mount(opts *MountOptions) error {
 		c = client.New(opts.Server, opts.APIKey)
 	}
 	c.SetActor(actorID)
-	if _, err := c.List("/"); err != nil {
-		return fmt.Errorf("cannot reach dat9 server: %w", err)
+
+	// Validate remote root (or server connectivity for root mounts).
+	remoteRoot := opts.RemoteRoot
+	if remoteRoot == "" {
+		remoteRoot = "/"
+	}
+	if remoteRoot == "/" {
+		if _, err := c.List("/"); err != nil {
+			return fmt.Errorf("cannot reach dat9 server: %w", err)
+		}
+	} else {
+		stat, err := c.Stat(remoteRoot)
+		if err != nil {
+			return fmt.Errorf("remote root %q: %w", remoteRoot, err)
+		}
+		if !stat.IsDir {
+			return fmt.Errorf("remote root %q is not a directory", remoteRoot)
+		}
 	}
 
 	// Build FUSE filesystem
@@ -142,7 +159,7 @@ func Mount(opts *MountOptions) error {
 			}
 		}
 		if cacheBase != "" {
-			mh := MountHash(opts.Server, opts.MountPoint)
+			mh := MountHash(opts.Server, opts.MountPoint, opts.RemoteRoot)
 			pendingDir := filepath.Join(cacheBase, mh, "pending")
 			shadowDir := filepath.Join(cacheBase, mh, "shadow")
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -136,9 +136,12 @@ func Mount(opts *MountOptions) error {
 	} else {
 		stat, err := c.Stat(remoteRoot)
 		if err != nil {
-			return fmt.Errorf("remote root %q: %w", remoteRoot, err)
-		}
-		if !stat.IsDir {
+			// Stat may fail on backends where directory stat is unsupported.
+			// Fall back to List to verify the remote root exists and is listable.
+			if _, listErr := c.List(remoteRoot); listErr != nil {
+				return fmt.Errorf("remote root %q: %w", remoteRoot, err)
+			}
+		} else if !stat.IsDir {
 			return fmt.Errorf("remote root %q is not a directory", remoteRoot)
 		}
 	}

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -15,6 +15,7 @@ import (
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/mountpath"
 )
 
 // MountOptions configures the FUSE mount.
@@ -123,10 +124,11 @@ func Mount(opts *MountOptions) error {
 	c.SetActor(actorID)
 
 	// Validate remote root (or server connectivity for root mounts).
-	remoteRoot := opts.RemoteRoot
-	if remoteRoot == "" {
-		remoteRoot = "/"
+	remoteRoot, err := mountpath.NormalizeRoot(opts.RemoteRoot)
+	if err != nil {
+		return fmt.Errorf("mount: %w", err)
 	}
+	opts.RemoteRoot = remoteRoot
 	if remoteRoot == "/" {
 		if _, err := c.List("/"); err != nil {
 			return fmt.Errorf("cannot reach dat9 server: %w", err)
@@ -226,14 +228,14 @@ func Mount(opts *MountOptions) error {
 
 			// Initialize CommitQueue for background remote commits.
 			if shadowStore != nil && pendingIdx != nil {
-				cq := NewCommitQueue(c, shadowStore, pendingIdx, journal, opts.UploadConcurrency, maxCommitQueuePending)
+				cq := NewCommitQueue(c, shadowStore, pendingIdx, journal, opts.UploadConcurrency, maxCommitQueuePending, opts.RemoteRoot)
 				cq.OnSuccess = dat9fs.onCommitQueueSuccess
 				cq.RecoverPending()
 				dat9fs.commitQueue = cq
 			}
 
 			if wbCache != nil {
-				uploader := NewWriteBackUploader(c, wbCache, opts.UploadConcurrency)
+				uploader := NewWriteBackUploader(c, wbCache, opts.UploadConcurrency, opts.RemoteRoot)
 				dat9fs.SetWriteBack(wbCache, uploader)
 				// Recover pending uploads only when the newer commit queue is
 				// unavailable. Otherwise commitQueue owns shadow-backed recovery.

--- a/pkg/fuse/remote_upload.go
+++ b/pkg/fuse/remote_upload.go
@@ -16,13 +16,9 @@ func uploadBufferedRemoteFile(ctx context.Context, c *client.Client, remotePath 
 	return c.WriteStreamConditional(ctx, remotePath, bytes.NewReader(data), int64(len(data)), nil, expectedRevision)
 }
 
-// uploadFromShadow streams a shadow file to the server without loading the
-// entire file into memory. Uses io.SectionReader to wrap the shadow store's
-// ReadAt into an io.Reader for WriteStreamConditional.
-func uploadFromShadow(ctx context.Context, c *client.Client, shadows *ShadowStore, remotePath string, expectedRevision int64) error {
-	return uploadFromShadowRemote(ctx, c, shadows, remotePath, remotePath, expectedRevision)
-}
-
+// uploadFromShadowRemote streams a shadow file to the server without loading
+// the entire file into memory. localPath identifies the shadow entry;
+// remotePath is the API destination (may differ when using RemoteRoot).
 func uploadFromShadowRemote(ctx context.Context, c *client.Client, shadows *ShadowStore, localPath, remotePath string, expectedRevision int64) error {
 	// Sync shadow to disk before uploading to ensure all data is durable.
 	if err := shadows.Sync(localPath); err != nil {

--- a/pkg/fuse/remote_upload.go
+++ b/pkg/fuse/remote_upload.go
@@ -20,18 +20,22 @@ func uploadBufferedRemoteFile(ctx context.Context, c *client.Client, remotePath 
 // entire file into memory. Uses io.SectionReader to wrap the shadow store's
 // ReadAt into an io.Reader for WriteStreamConditional.
 func uploadFromShadow(ctx context.Context, c *client.Client, shadows *ShadowStore, remotePath string, expectedRevision int64) error {
+	return uploadFromShadowRemote(ctx, c, shadows, remotePath, remotePath, expectedRevision)
+}
+
+func uploadFromShadowRemote(ctx context.Context, c *client.Client, shadows *ShadowStore, localPath, remotePath string, expectedRevision int64) error {
 	// Sync shadow to disk before uploading to ensure all data is durable.
-	if err := shadows.Sync(remotePath); err != nil {
+	if err := shadows.Sync(localPath); err != nil {
 		return err
 	}
-	size := shadows.Size(remotePath)
+	size := shadows.Size(localPath)
 	if size < 0 {
 		return io.ErrUnexpectedEOF
 	}
 	if size == 0 {
 		return c.WriteStreamConditional(ctx, remotePath, bytes.NewReader(nil), 0, nil, expectedRevision)
 	}
-	ra := &shadowReaderAt{store: shadows, path: remotePath}
+	ra := &shadowReaderAt{store: shadows, path: localPath}
 	sr := io.NewSectionReader(ra, 0, size)
 	return c.WriteStreamConditional(ctx, remotePath, sr, size, nil, expectedRevision)
 }

--- a/pkg/fuse/remote_upload_test.go
+++ b/pkg/fuse/remote_upload_test.go
@@ -1,10 +1,12 @@
 package fuse
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -19,6 +21,7 @@ type multipartUploadRecorder struct {
 	server           *httptest.Server
 	wantPath         string
 	wantSize         int64
+	wantParts        int
 	wantExpected     *int64
 	initiateCalls    atomic.Int32
 	presignCalls     atomic.Int32
@@ -36,6 +39,7 @@ func newMultipartUploadRecorder(t *testing.T, wantPath string, wantSize int64, w
 		t:            t,
 		wantPath:     wantPath,
 		wantSize:     wantSize,
+		wantParts:    int((wantSize + int64(s3client.PartSize) - 1) / int64(s3client.PartSize)),
 		wantExpected: wantExpected,
 	}
 
@@ -77,7 +81,7 @@ func newMultipartUploadRecorder(t *testing.T, wantPath string, wantSize int64, w
 				"upload_id":   "upload-1",
 				"key":         "object-key",
 				"part_size":   int64(s3client.PartSize),
-				"total_parts": 1,
+				"total_parts": rec.wantParts,
 			})
 			return
 
@@ -94,7 +98,25 @@ func newMultipartUploadRecorder(t *testing.T, wantPath string, wantSize int64, w
 			})
 			return
 
-		case r.Method == http.MethodPut && r.URL.Path == "/s3/upload-1/1":
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/upload-1/presign":
+			rec.presignCalls.Add(1)
+			var req struct {
+				PartNumber int `json:"part_number"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode presign request: %v", err)
+			}
+			if req.PartNumber < 1 || req.PartNumber > rec.wantParts {
+				t.Fatalf("presign part = %d, want 1..%d", req.PartNumber, rec.wantParts)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number": req.PartNumber,
+				"url":    rec.server.URL + "/s3/upload-1/" + strconv.Itoa(req.PartNumber),
+				"size":   int64(s3client.PartSize),
+			})
+			return
+
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/s3/upload-1/"):
 			rec.s3PutCalls.Add(1)
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
@@ -118,8 +140,14 @@ func newMultipartUploadRecorder(t *testing.T, wantPath string, wantSize int64, w
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				t.Fatalf("decode complete request: %v", err)
 			}
-			if len(req.Parts) != 1 || req.Parts[0].Number != 1 || req.Parts[0].ETag != "etag-1" {
-				t.Fatalf("complete parts = %+v, want single part with etag-1", req.Parts)
+			if len(req.Parts) != rec.wantParts {
+				t.Fatalf("complete parts = %+v, want %d parts", req.Parts, rec.wantParts)
+			}
+			for i, part := range req.Parts {
+				wantNumber := i + 1
+				if part.Number != wantNumber || part.ETag != "etag-1" {
+					t.Fatalf("complete part[%d] = %+v, want number=%d etag=etag-1", i, part, wantNumber)
+				}
 			}
 			w.WriteHeader(http.StatusOK)
 			return
@@ -229,5 +257,93 @@ func TestWriteBackUploaderLargeNewFileUsesMultipartUpload(t *testing.T) {
 	defer rec.mu.Unlock()
 	if rec.gotUploadedBytes != int64(len(data)) {
 		t.Fatalf("uploaded bytes = %d, want %d", rec.gotUploadedBytes, len(data))
+	}
+}
+
+func TestWriteBackUploaderMapsRemoteRoot(t *testing.T) {
+	const localPath = "/large-new.bin"
+	data := make([]byte, s3client.PartSize)
+	expectedRevision := int64(0)
+	rec := newMultipartUploadRecorder(t, "/remote/large-new.bin", int64(len(data)), &expectedRevision)
+
+	cache, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Put(localPath, data, int64(len(data)), PendingNew); err != nil {
+		t.Fatal(err)
+	}
+
+	uploader := NewWriteBackUploader(rec.client(), cache, 1, "/remote")
+	uploader.Submit(localPath)
+	uploader.DrainAll()
+
+	if rec.initiateCalls.Load() != 1 {
+		t.Fatalf("initiate calls = %d, want 1", rec.initiateCalls.Load())
+	}
+	if _, ok := cache.Get(localPath); ok {
+		t.Fatal("cache entry should be removed after remote-root upload")
+	}
+}
+
+func TestCommitQueueMapsRemoteRoot(t *testing.T) {
+	const localPath = "/large-overwrite.bin"
+	data := make([]byte, s3client.PartSize)
+	expectedRevision := int64(7)
+	rec := newMultipartUploadRecorder(t, "/remote/large-overwrite.bin", int64(len(data)), &expectedRevision)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(localPath, data, expectedRevision); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(localPath, int64(len(data)), PendingOverwrite, expectedRevision); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(rec.client(), shadow, pending, nil, 1, 8, "/remote")
+	if err := cq.Enqueue(&CommitEntry{
+		Path:    localPath,
+		BaseRev: expectedRevision,
+		Size:    int64(len(data)),
+		Kind:    PendingOverwrite,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if rec.initiateCalls.Load() != 1 {
+		t.Fatalf("initiate calls = %d, want 1", rec.initiateCalls.Load())
+	}
+	if pending.HasPending(localPath) {
+		t.Fatal("pending entry should be removed after remote-root commit")
+	}
+	if shadow.Has(localPath) {
+		t.Fatal("shadow entry should be removed after remote-root commit")
+	}
+}
+
+func TestStreamUploaderMapsRemoteRoot(t *testing.T) {
+	const localPath = "/stream.bin"
+	data := make([]byte, s3client.PartSize+123)
+	expectedRevision := int64(9)
+	rec := newMultipartUploadRecorder(t, "/remote/stream.bin", int64(len(data)), &expectedRevision)
+
+	uploader := NewStreamUploader(rec.client(), localPath, expectedRevision, "/remote")
+	if err := uploader.UploadAll(context.Background(), int64(len(data)), map[int][]byte{
+		1: data[:s3client.PartSize],
+		2: data[s3client.PartSize:],
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if rec.initiateCalls.Load() != 1 || rec.completeCalls.Load() != 1 {
+		t.Fatalf("multipart calls = initiate:%d complete:%d, want 1 each", rec.initiateCalls.Load(), rec.completeCalls.Load())
 	}
 }

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -58,12 +58,16 @@ func (w *SSEWatcher) handleEvent(change *client.ChangeEvent, reset *client.Reset
 }
 
 func (w *SSEWatcher) handleChange(ce *client.ChangeEvent) {
-	p := ce.Path
-	if p == "" {
+	remotePath := ce.Path
+	if remotePath == "" {
+		return
+	}
+	p, ok := w.fs.localPath(remotePath)
+	if !ok {
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "dat9: SSE event op=%s path=%s actor=%s\n", ce.Op, p, ce.Actor)
+	fmt.Fprintf(os.Stderr, "dat9: SSE event op=%s path=%s local=%s actor=%s\n", ce.Op, remotePath, p, ce.Actor)
 
 	// Invalidate read cache for the changed file.
 	w.fs.readCache.Invalidate(p)

--- a/pkg/fuse/sse_test.go
+++ b/pkg/fuse/sse_test.go
@@ -99,6 +99,62 @@ func TestSSEWatcherHandleChangeInvalidatesCache(t *testing.T) {
 	}
 }
 
+func TestSSEWatcherHandleChangeFiltersAndRebasesRemoteRoot(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize:  1 << 20,
+		DirTTL:     5 * time.Second,
+		RemoteRoot: "/remote",
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		opts:      opts,
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	fs.inodes.Lookup("/docs/readme.md", false, 50, time.Now())
+	fs.readCache.Put("/docs/readme.md", []byte("old content"), 1)
+	fs.dirCache.Put("/docs", []CachedFileInfo{{Name: "readme.md", Size: 50}})
+	fs.readCache.Put("/outside.txt", []byte("keep"), 1)
+	fs.dirCache.Put("/", []CachedFileInfo{{Name: "outside.txt", Size: 4}})
+
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+
+	w.handleChange(&client.ChangeEvent{
+		Seq:   1,
+		Path:  "/outside.txt",
+		Op:    "write",
+		Actor: "other-actor",
+	})
+	if _, ok := fs.readCache.Get("/outside.txt", 1); !ok {
+		t.Fatal("event outside remote root should not invalidate local cache")
+	}
+
+	w.handleChange(&client.ChangeEvent{
+		Seq:   2,
+		Path:  "/remote2/docs/readme.md",
+		Op:    "write",
+		Actor: "other-actor",
+	})
+	if _, ok := fs.readCache.Get("/docs/readme.md", 1); !ok {
+		t.Fatal("prefix sibling outside remote root should not invalidate local cache")
+	}
+
+	w.handleChange(&client.ChangeEvent{
+		Seq:   3,
+		Path:  "/remote/docs/readme.md",
+		Op:    "write",
+		Actor: "other-actor",
+	})
+	if _, ok := fs.readCache.Get("/docs/readme.md", 1); ok {
+		t.Fatal("remote-root event should invalidate rebased local read cache")
+	}
+	if _, ok := fs.dirCache.Get("/docs"); ok {
+		t.Fatal("remote-root event should invalidate rebased local parent dir cache")
+	}
+}
+
 func TestSSEWatcherSelfFilterSkipsOwnEvents(t *testing.T) {
 	opts := &MountOptions{
 		CacheSize: 1 << 20,

--- a/pkg/fuse/stream_upload.go
+++ b/pkg/fuse/stream_upload.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/mountpath"
 )
 
 // StreamUploader manages parallel part uploads both during Write() for
@@ -29,6 +30,7 @@ import (
 type StreamUploader struct {
 	client           *client.Client
 	path             string
+	remotePath       string
 	expectedRevision int64
 
 	mu            sync.Mutex
@@ -41,10 +43,15 @@ type StreamUploader struct {
 
 // NewStreamUploader creates a StreamUploader for the given path.
 // No network calls are made until UploadAll or FinishStreaming is called.
-func NewStreamUploader(c *client.Client, path string, expectedRevision int64) *StreamUploader {
+func NewStreamUploader(c *client.Client, path string, expectedRevision int64, remoteRoot ...string) *StreamUploader {
+	root := "/"
+	if len(remoteRoot) > 0 && remoteRoot[0] != "" {
+		root = remoteRoot[0]
+	}
 	return &StreamUploader{
 		client:           c,
 		path:             path,
+		remotePath:       mountpath.ToRemote(root, path),
 		expectedRevision: expectedRevision,
 		streamedParts:    make(map[int]bool),
 		pendingParts:     make(map[int][]byte),
@@ -156,7 +163,7 @@ func (su *StreamUploader) FinishStreaming(ctx context.Context, totalSize int64,
 	}
 
 	// Initiate the server-side upload now that we know the exact total size.
-	su.writer = su.client.NewStreamWriterConditional(ctx, su.path, totalSize, su.expectedRevision)
+	su.writer = su.client.NewStreamWriterConditional(ctx, su.remotePath, totalSize, su.expectedRevision)
 	sw := su.writer
 
 	// Collect all buffered parts. We keep a reference so we can restore
@@ -227,7 +234,7 @@ func (su *StreamUploader) UploadAll(ctx context.Context, totalSize int64, partDa
 	}
 
 	su.mu.Lock()
-	su.writer = su.client.NewStreamWriterConditional(ctx, su.path, totalSize, su.expectedRevision)
+	su.writer = su.client.NewStreamWriterConditional(ctx, su.remotePath, totalSize, su.expectedRevision)
 	su.started = true
 	sw := su.writer
 	su.mu.Unlock()

--- a/pkg/fuse/writeback.go
+++ b/pkg/fuse/writeback.go
@@ -357,8 +357,13 @@ func fsyncDir(dir string) error {
 }
 
 // MountHash computes a short hash to distinguish cache directories for
-// different server+mountpoint combinations.
-func MountHash(serverURL, mountPoint string) string {
-	h := sha256.Sum256([]byte(serverURL + "\x00" + mountPoint))
+// different server+mountpoint+remoteRoot combinations. RemoteRoot defaults
+// to "/" so existing caches (which implicitly used root) remain stable.
+func MountHash(serverURL, mountPoint string, remoteRoot ...string) string {
+	root := "/"
+	if len(remoteRoot) > 0 && remoteRoot[0] != "" {
+		root = remoteRoot[0]
+	}
+	h := sha256.Sum256([]byte(serverURL + "\x00" + mountPoint + "\x00" + root))
 	return hex.EncodeToString(h[:8]) // 16 hex chars
 }

--- a/pkg/fuse/writeback.go
+++ b/pkg/fuse/writeback.go
@@ -357,13 +357,24 @@ func fsyncDir(dir string) error {
 }
 
 // MountHash computes a short hash to distinguish cache directories for
-// different server+mountpoint+remoteRoot combinations. RemoteRoot defaults
-// to "/" so existing caches (which implicitly used root) remain stable.
+// different server+mountpoint+remoteRoot combinations.
+//
+// For backward compatibility, when remoteRoot is "/" (the default), the hash
+// is computed without the remoteRoot segment, matching the pre-subtree-mount
+// hash: sha256(server + "\x00" + mountPoint). This ensures existing caches
+// are not orphaned on upgrade.
 func MountHash(serverURL, mountPoint string, remoteRoot ...string) string {
 	root := "/"
 	if len(remoteRoot) > 0 && remoteRoot[0] != "" {
 		root = remoteRoot[0]
 	}
-	h := sha256.Sum256([]byte(serverURL + "\x00" + mountPoint + "\x00" + root))
+	var input string
+	if root == "/" {
+		// Backward-compatible: same hash as pre-subtree-mount versions.
+		input = serverURL + "\x00" + mountPoint
+	} else {
+		input = serverURL + "\x00" + mountPoint + "\x00" + root
+	}
+	h := sha256.Sum256([]byte(input))
 	return hex.EncodeToString(h[:8]) // 16 hex chars
 }

--- a/pkg/fuse/writeback_uploader.go
+++ b/pkg/fuse/writeback_uploader.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/mountpath"
 )
 
 // Exponential backoff constants for upload retries.
@@ -39,17 +40,18 @@ type pathState struct {
 // them to the server in the background. It runs a fixed number of worker
 // goroutines that read from a shared channel.
 //
-// Per-path serialization: at most one upload per remote path is in-flight at
+// Per-path serialization: at most one upload per local namespace path is in-flight at
 // any time. WaitPath() allows Rename/Unlink/Fsync to block until the current
 // upload for a path finishes.
 type WriteBackUploader struct {
-	client   *client.Client
-	cache    *WriteBackCache
-	uploadCh chan string // remote paths to upload
-	wg       sync.WaitGroup
-	stopOnce sync.Once
-	stopped  atomic.Bool
-	stopCh   chan struct{}
+	client     *client.Client
+	cache      *WriteBackCache
+	remoteRoot string
+	uploadCh   chan string // local namespace paths to upload
+	wg         sync.WaitGroup
+	stopOnce   sync.Once
+	stopped    atomic.Bool
+	stopCh     chan struct{}
 
 	// Per-path in-flight tracking.
 	inflightMu sync.Mutex
@@ -58,16 +60,21 @@ type WriteBackUploader struct {
 
 // NewWriteBackUploader creates and starts a background uploader with
 // numWorkers goroutines. Typical value: 4.
-func NewWriteBackUploader(c *client.Client, cache *WriteBackCache, numWorkers int) *WriteBackUploader {
+func NewWriteBackUploader(c *client.Client, cache *WriteBackCache, numWorkers int, remoteRoot ...string) *WriteBackUploader {
 	if numWorkers <= 0 {
 		numWorkers = 4
 	}
+	root := "/"
+	if len(remoteRoot) > 0 && remoteRoot[0] != "" {
+		root = remoteRoot[0]
+	}
 	u := &WriteBackUploader{
-		client:   c,
-		cache:    cache,
-		uploadCh: make(chan string, 256),
-		stopCh:   make(chan struct{}),
-		inflight: make(map[string]*pathState),
+		client:     c,
+		cache:      cache,
+		remoteRoot: root,
+		uploadCh:   make(chan string, 256),
+		stopCh:     make(chan struct{}),
+		inflight:   make(map[string]*pathState),
 	}
 	for i := 0; i < numWorkers; i++ {
 		u.wg.Add(1)
@@ -76,37 +83,45 @@ func NewWriteBackUploader(c *client.Client, cache *WriteBackCache, numWorkers in
 	return u
 }
 
-// Submit enqueues a remote path for background upload. Blocks up to 5s if the
+func (u *WriteBackUploader) remotePath(localPath string) string {
+	root := "/"
+	if u != nil && u.remoteRoot != "" {
+		root = u.remoteRoot
+	}
+	return mountpath.ToRemote(root, localPath)
+}
+
+// Submit enqueues a local namespace path for background upload. Blocks up to 5s if the
 // channel is full; on timeout, falls back to synchronous upload in the current
 // goroutine so data is never silently dropped.
-func (u *WriteBackUploader) Submit(remotePath string) {
+func (u *WriteBackUploader) Submit(localPath string) {
 	if u.stopped.Load() {
-		log.Printf("writeback uploader: already stopped, uploading synchronously for %s", remotePath)
-		u.uploadOne(remotePath)
+		log.Printf("writeback uploader: already stopped, uploading synchronously for %s", localPath)
+		u.uploadOne(localPath)
 		return
 	}
 	select {
-	case u.uploadCh <- remotePath:
+	case u.uploadCh <- localPath:
 	default:
 		// Channel full — block with timeout, then fallback to sync upload.
 		timer := time.NewTimer(submitTimeout)
 		defer timer.Stop()
 		select {
-		case u.uploadCh <- remotePath:
+		case u.uploadCh <- localPath:
 		case <-timer.C:
-			log.Printf("writeback uploader: channel full after %v, uploading synchronously for %s", submitTimeout, remotePath)
-			u.uploadOne(remotePath)
+			log.Printf("writeback uploader: channel full after %v, uploading synchronously for %s", submitTimeout, localPath)
+			u.uploadOne(localPath)
 		}
 	}
 }
 
-// WaitPath blocks until any in-flight upload for remotePath completes.
+// WaitPath blocks until any in-flight upload for localPath completes.
 // Returns immediately if no upload is in progress for this path.
-// This must be called by Rename/Unlink before operating on the remote path
+// This must be called by Rename/Unlink before operating on the local path
 // to prevent the background worker from re-creating a renamed/deleted file.
-func (u *WriteBackUploader) WaitPath(remotePath string) {
+func (u *WriteBackUploader) WaitPath(localPath string) {
 	u.inflightMu.Lock()
-	ps, ok := u.inflight[remotePath]
+	ps, ok := u.inflight[localPath]
 	u.inflightMu.Unlock()
 	if ok {
 		<-ps.done
@@ -157,29 +172,29 @@ func expectedRevisionForWriteBack(meta *WriteBackMeta) (int64, error) {
 
 func (u *WriteBackUploader) worker() {
 	defer u.wg.Done()
-	for remotePath := range u.uploadCh {
-		u.uploadOne(remotePath)
+	for localPath := range u.uploadCh {
+		u.uploadOne(localPath)
 	}
 }
 
-// acquirePath registers an in-flight upload for remotePath. If another upload
+// acquirePath registers an in-flight upload for localPath. If another upload
 // for the same path is already in progress, it waits for that to finish first,
 // ensuring per-path serialization. Returns a release function that the caller
 // must call when the upload is done.
-func (u *WriteBackUploader) acquirePath(remotePath string) func() {
+func (u *WriteBackUploader) acquirePath(localPath string) func() {
 	for {
 		u.inflightMu.Lock()
-		ps, ok := u.inflight[remotePath]
+		ps, ok := u.inflight[localPath]
 		if !ok {
 			// No in-flight upload — register ours.
 			ps = &pathState{done: make(chan struct{})}
-			u.inflight[remotePath] = ps
+			u.inflight[localPath] = ps
 			u.inflightMu.Unlock()
 			return func() {
 				u.inflightMu.Lock()
 				// Only delete if it's still our state (not replaced by a new upload).
-				if cur, ok := u.inflight[remotePath]; ok && cur == ps {
-					delete(u.inflight, remotePath)
+				if cur, ok := u.inflight[localPath]; ok && cur == ps {
+					delete(u.inflight, localPath)
 				}
 				u.inflightMu.Unlock()
 				close(ps.done)
@@ -191,18 +206,18 @@ func (u *WriteBackUploader) acquirePath(remotePath string) func() {
 	}
 }
 
-func (u *WriteBackUploader) uploadOne(remotePath string) {
-	release := u.acquirePath(remotePath)
+func (u *WriteBackUploader) uploadOne(localPath string) {
+	release := u.acquirePath(localPath)
 	defer release()
 
 	// Read data and remember the generation so we can detect concurrent overwrites.
-	meta, ok := u.cache.GetMeta(remotePath)
+	meta, ok := u.cache.GetMeta(localPath)
 	if !ok {
 		return // Already uploaded or removed.
 	}
 	gen := meta.Generation
 
-	data, ok := u.cache.Get(remotePath)
+	data, ok := u.cache.Get(localPath)
 	if !ok {
 		return
 	}
@@ -212,7 +227,7 @@ func (u *WriteBackUploader) uploadOne(remotePath string) {
 		// TODO: add a migration or cleanup path for legacy overwrite entries
 		// without base revisions so they do not remain pending forever when
 		// they only flow through Flush -> Release -> background uploadOne.
-		log.Printf("writeback upload skipped for %s: %v", remotePath, err)
+		log.Printf("writeback upload skipped for %s: %v", localPath, err)
 		return
 	}
 
@@ -228,7 +243,7 @@ func (u *WriteBackUploader) uploadOne(remotePath string) {
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), uploadTimeout)
-		lastErr = uploadBufferedRemoteFile(ctx, u.client, remotePath, data, expectedRevision)
+		lastErr = uploadBufferedRemoteFile(ctx, u.client, u.remotePath(localPath), data, expectedRevision)
 		cancel()
 
 		if lastErr == nil {
@@ -237,26 +252,26 @@ func (u *WriteBackUploader) uploadOne(remotePath string) {
 		if errors.Is(lastErr, client.ErrConflict) {
 			break
 		}
-		log.Printf("writeback upload attempt %d/%d failed for %s: %v", attempt+1, uploadMaxRetries+1, remotePath, lastErr)
+		log.Printf("writeback upload attempt %d/%d failed for %s: %v", attempt+1, uploadMaxRetries+1, localPath, lastErr)
 	}
 
 	if lastErr != nil {
 		if errors.Is(lastErr, client.ErrConflict) {
 			// TODO: persist a conflict marker or resolution flow so these
 			// entries do not remain pending forever across mounts.
-			log.Printf("writeback upload conflict for %s at base revision %d (will keep local pending data)", remotePath, meta.BaseRev)
+			log.Printf("writeback upload conflict for %s at base revision %d (will keep local pending data)", localPath, meta.BaseRev)
 			return
 		}
-		log.Printf("writeback upload failed for %s after %d attempts: %v (will retry on next mount)", remotePath, uploadMaxRetries+1, lastErr)
+		log.Printf("writeback upload failed for %s after %d attempts: %v (will retry on next mount)", localPath, uploadMaxRetries+1, lastErr)
 		return
 	}
 
 	// Only remove from cache if the generation hasn't changed. If a newer
 	// Put() happened while we were uploading, the cache now holds fresher
 	// data that must not be discarded.
-	curMeta, ok := u.cache.GetMeta(remotePath)
+	curMeta, ok := u.cache.GetMeta(localPath)
 	if ok && curMeta.Generation == gen {
-		u.cache.Remove(remotePath)
+		u.cache.Remove(localPath)
 	}
 }
 
@@ -264,17 +279,17 @@ func (u *WriteBackUploader) uploadOne(remotePath string) {
 // Waits for any in-flight background upload to finish first, then uploads with
 // generation protection. Used by Fsync/Rename which require the data to be
 // persisted remotely before returning.
-func (u *WriteBackUploader) UploadSync(ctx context.Context, remotePath string) error {
+func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) error {
 	// Wait for any in-flight background upload to complete first.
-	u.WaitPath(remotePath)
+	u.WaitPath(localPath)
 
-	meta, ok := u.cache.GetMeta(remotePath)
+	meta, ok := u.cache.GetMeta(localPath)
 	if !ok {
 		return nil // not in cache (may have been uploaded by the background worker we just waited for)
 	}
 	gen := meta.Generation
 
-	data, ok := u.cache.Get(remotePath)
+	data, ok := u.cache.Get(localPath)
 	if !ok {
 		return nil
 	}
@@ -285,21 +300,21 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, remotePath string) e
 			// Backward compatibility for pre-CAS writeback entries: preserve
 			// the historical UploadSync behaviour so fsync/rename do not fail
 			// with EIO on mounts that still have legacy pending overwrites.
-			log.Printf("writeback uploadsync: legacy overwrite without base revision for %s, falling back to unconditional write", remotePath)
+			log.Printf("writeback uploadsync: legacy overwrite without base revision for %s, falling back to unconditional write", localPath)
 			expectedRevision = -1
 		} else {
-			return fmt.Errorf("resolve expected revision for %s: %w", remotePath, err)
+			return fmt.Errorf("resolve expected revision for %s: %w", localPath, err)
 		}
 	}
 
-	if err := uploadBufferedRemoteFile(ctx, u.client, remotePath, data, expectedRevision); err != nil {
+	if err := uploadBufferedRemoteFile(ctx, u.client, u.remotePath(localPath), data, expectedRevision); err != nil {
 		return err
 	}
 
 	// Only remove if generation matches — a concurrent Put() may have written newer data.
-	curMeta, ok := u.cache.GetMeta(remotePath)
+	curMeta, ok := u.cache.GetMeta(localPath)
 	if ok && curMeta.Generation == gen {
-		u.cache.Remove(remotePath)
+		u.cache.Remove(localPath)
 	}
 	return nil
 }

--- a/pkg/mountpath/mountpath.go
+++ b/pkg/mountpath/mountpath.go
@@ -1,0 +1,64 @@
+// Package mountpath provides path mapping between a local mount namespace
+// and a remote drive9 subtree. It is used by both FUSE and WebDAV mount
+// backends to translate local paths to remote paths and vice versa.
+package mountpath
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// NormalizeRoot canonicalizes a remote root path. It must be an absolute
+// path with no ".." components that escape above "/". An empty input
+// defaults to "/".
+func NormalizeRoot(root string) (string, error) {
+	if root == "" {
+		return "/", nil
+	}
+	if !strings.HasPrefix(root, "/") {
+		return "", fmt.Errorf("remote root must be an absolute path: %q", root)
+	}
+	cleaned := path.Clean(root)
+	if cleaned == "." {
+		cleaned = "/"
+	}
+	return cleaned, nil
+}
+
+// ToRemote maps a local path (relative to the mount root) to a remote
+// drive9 path by joining remoteRoot and localPath. The local path is
+// canonicalized first; any attempt to escape above "/" via ".." is
+// clamped to "/", which maps to remoteRoot itself.
+//
+// remoteRoot must already be normalized via NormalizeRoot.
+func ToRemote(remoteRoot, localPath string) string {
+	local := path.Clean("/" + localPath)
+	if remoteRoot == "/" {
+		return local
+	}
+	if local == "/" {
+		return remoteRoot
+	}
+	return remoteRoot + local
+}
+
+// ToLocal maps a remote drive9 path back to a local path relative to
+// the mount root. It returns the local path and true if the remote path
+// is within the subtree, or ("", false) if it is outside scope.
+//
+// remoteRoot must already be normalized via NormalizeRoot.
+func ToLocal(remoteRoot, remotePath string) (string, bool) {
+	remote := path.Clean(remotePath)
+	if remoteRoot == "/" {
+		return remote, true
+	}
+	if remote == remoteRoot {
+		return "/", true
+	}
+	prefix := remoteRoot + "/"
+	if strings.HasPrefix(remote, prefix) {
+		return "/" + remote[len(prefix):], true
+	}
+	return "", false
+}

--- a/pkg/mountpath/mountpath.go
+++ b/pkg/mountpath/mountpath.go
@@ -7,11 +7,14 @@ import (
 	"fmt"
 	"path"
 	"strings"
+
+	"github.com/mem9-ai/dat9/pkg/pathutil"
 )
 
 // NormalizeRoot canonicalizes a remote root path. It must be an absolute
-// path with no ".." components that escape above "/". An empty input
-// defaults to "/".
+// path with no ".." or "." segments. An empty input defaults to "/".
+// Uses pathutil.Canonicalize for consistent validation (UTF-8, NFC,
+// control characters, traversal rejection).
 func NormalizeRoot(root string) (string, error) {
 	if root == "" {
 		return "/", nil
@@ -19,9 +22,11 @@ func NormalizeRoot(root string) (string, error) {
 	if !strings.HasPrefix(root, "/") {
 		return "", fmt.Errorf("remote root must be an absolute path: %q", root)
 	}
-	cleaned := path.Clean(root)
-	if cleaned == "." {
-		cleaned = "/"
+	// Use pathutil.Canonicalize for strict validation: rejects ".." and "."
+	// segments, control characters, backslashes, and normalizes to NFC.
+	cleaned, err := pathutil.Canonicalize(root)
+	if err != nil {
+		return "", fmt.Errorf("invalid remote root %q: %w", root, err)
 	}
 	return cleaned, nil
 }

--- a/pkg/mountpath/mountpath_test.go
+++ b/pkg/mountpath/mountpath_test.go
@@ -1,0 +1,88 @@
+package mountpath
+
+import (
+	"testing"
+)
+
+func TestNormalizeRoot(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "/", false},
+		{"/", "/", false},
+		{"/foo/bar", "/foo/bar", false},
+		{"/foo/bar/", "/foo/bar", false},
+		{"/foo//bar", "/foo/bar", false},
+		{"/foo/../bar", "/bar", false},
+		{"/foo/./bar", "/foo/bar", false},
+		{"foo", "", true}, // not absolute
+	}
+	for _, tt := range tests {
+		got, err := NormalizeRoot(tt.in)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("NormalizeRoot(%q) error=%v, wantErr=%v", tt.in, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("NormalizeRoot(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestToRemote(t *testing.T) {
+	tests := []struct {
+		root, local, want string
+	}{
+		{"/", "/", "/"},
+		{"/", "/a.txt", "/a.txt"},
+		{"/", "/a/b/c", "/a/b/c"},
+		{"/foo/bar", "/", "/foo/bar"},
+		{"/foo/bar", "/a.txt", "/foo/bar/a.txt"},
+		{"/foo/bar", "/sub/dir", "/foo/bar/sub/dir"},
+		// ".." in local path is clamped to "/"
+		{"/foo/bar", "/../escape", "/foo/bar/escape"},
+		{"/foo/bar", "/../../..", "/foo/bar"},
+		// Unnormalized local paths
+		{"/foo", "//a//b", "/foo/a/b"},
+		{"/foo", "/./a", "/foo/a"},
+	}
+	for _, tt := range tests {
+		got := ToRemote(tt.root, tt.local)
+		if got != tt.want {
+			t.Errorf("ToRemote(%q, %q) = %q, want %q", tt.root, tt.local, got, tt.want)
+		}
+	}
+}
+
+func TestToLocal(t *testing.T) {
+	tests := []struct {
+		root, remote string
+		wantLocal    string
+		wantOK       bool
+	}{
+		{"/", "/", "/", true},
+		{"/", "/a.txt", "/a.txt", true},
+		{"/", "/a/b", "/a/b", true},
+		{"/foo/bar", "/foo/bar", "/", true},
+		{"/foo/bar", "/foo/bar/a.txt", "/a.txt", true},
+		{"/foo/bar", "/foo/bar/sub/dir", "/sub/dir", true},
+		// Outside scope
+		{"/foo/bar", "/foo", "", false},
+		{"/foo/bar", "/foo/baz", "", false},
+		{"/foo/bar", "/other", "", false},
+		// Prefix attack: /foo/bar2 should not match /foo/bar
+		{"/foo/bar", "/foo/bar2", "", false},
+	}
+	for _, tt := range tests {
+		gotLocal, gotOK := ToLocal(tt.root, tt.remote)
+		if gotOK != tt.wantOK {
+			t.Errorf("ToLocal(%q, %q) ok=%v, want %v", tt.root, tt.remote, gotOK, tt.wantOK)
+			continue
+		}
+		if gotLocal != tt.wantLocal {
+			t.Errorf("ToLocal(%q, %q) = %q, want %q", tt.root, tt.remote, gotLocal, tt.wantLocal)
+		}
+	}
+}

--- a/pkg/mountpath/mountpath_test.go
+++ b/pkg/mountpath/mountpath_test.go
@@ -15,9 +15,10 @@ func TestNormalizeRoot(t *testing.T) {
 		{"/foo/bar", "/foo/bar", false},
 		{"/foo/bar/", "/foo/bar", false},
 		{"/foo//bar", "/foo/bar", false},
-		{"/foo/../bar", "/bar", false},
-		{"/foo/./bar", "/foo/bar", false},
-		{"foo", "", true}, // not absolute
+		{"/foo/../bar", "", true},  // ".." rejected (not silently normalized)
+		{"/foo/./bar", "", true},   // "." rejected
+		{"/../escape", "", true},   // ".." rejected
+		{"foo", "", true},          // not absolute
 	}
 	for _, tt := range tests {
 		got, err := NormalizeRoot(tt.in)

--- a/pkg/webdav/fs.go
+++ b/pkg/webdav/fs.go
@@ -13,89 +13,101 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/mountpath"
 	"golang.org/x/net/webdav"
 )
 
 // fileSystem implements webdav.FileSystem over a drive9 client.
 type fileSystem struct {
-	client *client.Client
+	client     *client.Client
+	remoteRoot string // normalized remote root path, default "/"
 }
 
 var _ webdav.FileSystem = (*fileSystem)(nil)
 
+// remotePath maps a local WebDAV path to the remote drive9 path.
+func (f *fileSystem) remotePath(localPath string) string {
+	return mountpath.ToRemote(f.remoteRoot, normPath(localPath))
+}
+
 func (f *fileSystem) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
-	return mapError(f.client.MkdirCtx(ctx, normPath(name)))
+	return mapError(f.client.MkdirCtx(ctx, f.remotePath(name)))
 }
 
 func (f *fileSystem) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
-	p := normPath(name)
+	local := normPath(name)
+	remote := mountpath.ToRemote(f.remoteRoot, local)
 
 	// For create/truncate: return a writable file handle.
 	if flag&(os.O_CREATE|os.O_TRUNC) != 0 {
-		if p == "/" {
+		if local == "/" {
 			return nil, os.ErrInvalid
 		}
-		parent, err := f.client.StatCtx(ctx, path.Dir(p))
+		parentRemote := mountpath.ToRemote(f.remoteRoot, path.Dir(local))
+		parent, err := f.client.StatCtx(ctx, parentRemote)
 		if err != nil {
 			return nil, mapError(err)
 		}
 		if !parent.IsDir {
 			return nil, os.ErrInvalid
 		}
-		return &writeFile{client: f.client, path: p}, nil
+		return &writeFile{client: f.client, path: remote}, nil
 	}
 
 	// Stat to determine if it's a directory or file.
-	stat, err := f.client.StatCtx(ctx, p)
+	stat, err := f.client.StatCtx(ctx, remote)
 	if err != nil {
 		return nil, mapError(err)
 	}
 
 	if stat.IsDir {
-		entries, err := f.client.ListCtx(ctx, p)
+		entries, err := f.client.ListCtx(ctx, remote)
 		if err != nil {
 			return nil, mapError(err)
 		}
-		return &dirFile{path: p, stat: stat, entries: entries}, nil
+		return &dirFile{path: local, stat: stat, entries: entries}, nil
 	}
 
 	// Read entire file content. For the lightweight skills/config use case
 	// this is acceptable; large file streaming can be optimized later.
-	data, err := f.client.ReadCtx(ctx, p)
+	data, err := f.client.ReadCtx(ctx, remote)
 	if err != nil {
 		return nil, mapError(err)
 	}
 
 	return &readFile{
-		path:   p,
+		path:   local,
 		stat:   stat,
 		Reader: bytes.NewReader(data),
 	}, nil
 }
 
 func (f *fileSystem) RemoveAll(ctx context.Context, name string) error {
-	p := normPath(name)
-	if p == "/" {
+	local := normPath(name)
+	if local == "/" {
 		return os.ErrInvalid
 	}
-	return mapError(f.client.RemoveAllCtx(ctx, p))
+	return mapError(f.client.RemoveAllCtx(ctx, f.remotePath(name)))
 }
 
 func (f *fileSystem) Rename(ctx context.Context, oldName, newName string) error {
-	oldPath, newPath := normPath(oldName), normPath(newName)
-	if oldPath == "/" || newPath == "/" {
+	oldLocal, newLocal := normPath(oldName), normPath(newName)
+	if oldLocal == "/" || newLocal == "/" {
 		return os.ErrInvalid
 	}
-	return mapError(f.client.RenameCtx(ctx, oldPath, newPath))
+	oldRemote := mountpath.ToRemote(f.remoteRoot, oldLocal)
+	newRemote := mountpath.ToRemote(f.remoteRoot, newLocal)
+	return mapError(f.client.RenameCtx(ctx, oldRemote, newRemote))
 }
 
 func (f *fileSystem) Stat(ctx context.Context, name string) (os.FileInfo, error) {
-	p := normPath(name)
-	stat, err := f.client.StatCtx(ctx, p)
+	local := normPath(name)
+	remote := mountpath.ToRemote(f.remoteRoot, local)
+	stat, err := f.client.StatCtx(ctx, remote)
 	if err != nil {
 		return nil, mapError(err)
 	}
-	return &fileInfo{name: path.Base(p), stat: stat}, nil
+	return &fileInfo{name: path.Base(local), stat: stat}, nil
 }
 
 // normPath normalizes a WebDAV path to a drive9 path.

--- a/pkg/webdav/fs.go
+++ b/pkg/webdav/fs.go
@@ -87,7 +87,7 @@ func (f *fileSystem) RemoveAll(ctx context.Context, name string) error {
 	if local == "/" {
 		return os.ErrInvalid
 	}
-	return mapError(f.client.RemoveAllCtx(ctx, f.remotePath(name)))
+	return mapError(f.client.RemoveAllCtx(ctx, mountpath.ToRemote(f.remoteRoot, local)))
 }
 
 func (f *fileSystem) Rename(ctx context.Context, oldName, newName string) error {

--- a/pkg/webdav/fs_test.go
+++ b/pkg/webdav/fs_test.go
@@ -249,6 +249,117 @@ func TestReadFileSeekAndRead(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Remote root mount tests — verify path mapping in fileSystem
+// ---------------------------------------------------------------------------
+
+func TestRemoteRootStatMapsPath(t *testing.T) {
+	var statPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			statPath = r.URL.Path
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Size", "42")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "test-key")
+	fs := &fileSystem{client: c, remoteRoot: "/project/data"}
+
+	_, err := fs.Stat(t.Context(), "/readme.txt")
+	if err != nil {
+		t.Fatalf("Stat error: %v", err)
+	}
+	// The server should have received a stat for /project/data/readme.txt
+	if statPath != "/v1/fs/project/data/readme.txt" {
+		t.Fatalf("server saw stat path %q, want /v1/fs/project/data/readme.txt", statPath)
+	}
+}
+
+func TestRemoteRootMkdirMapsPath(t *testing.T) {
+	var mkdirPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Query().Get("mkdir") != "" {
+			mkdirPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		// MkdirCtx also accepts this form
+		if r.Method == http.MethodPost && strings.Contains(r.URL.RawQuery, "mkdir") {
+			mkdirPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "test-key")
+	fs := &fileSystem{client: c, remoteRoot: "/project"}
+
+	_ = fs.Mkdir(t.Context(), "/newdir", 0o755)
+	if mkdirPath != "/v1/fs/project/newdir" {
+		t.Fatalf("server saw mkdir path %q, want /v1/fs/project/newdir", mkdirPath)
+	}
+}
+
+func TestRemoteRootRootStatMapsToRemoteRoot(t *testing.T) {
+	var statPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			statPath = r.URL.Path
+			w.Header().Set("X-Dat9-IsDir", "true")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "test-key")
+	fs := &fileSystem{client: c, remoteRoot: "/project/data"}
+
+	_, err := fs.Stat(t.Context(), "/")
+	if err != nil {
+		t.Fatalf("Stat error: %v", err)
+	}
+	if statPath != "/v1/fs/project/data" {
+		t.Fatalf("root stat mapped to %q, want /v1/fs/project/data", statPath)
+	}
+}
+
+func TestRemoteRootDefaultIsRoot(t *testing.T) {
+	var statPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			statPath = r.URL.Path
+			w.Header().Set("X-Dat9-IsDir", "true")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "test-key")
+	// remoteRoot "/" means no prefix mapping.
+	fs := &fileSystem{client: c, remoteRoot: "/"}
+
+	_, err := fs.Stat(t.Context(), "/foo")
+	if err != nil {
+		t.Fatalf("Stat error: %v", err)
+	}
+	if statPath != "/v1/fs/foo" {
+		t.Fatalf("stat mapped to %q, want /v1/fs/foo", statPath)
+	}
+}
+
 func newWriteOnlyTestClient(t *testing.T, onWrite func(string)) *client.Client {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/webdav/handler.go
+++ b/pkg/webdav/handler.go
@@ -16,13 +16,21 @@ type Options struct {
 	// Prefix is the URL path prefix stripped before mapping to drive9 paths.
 	// Empty means no prefix (root mount).
 	Prefix string
+
+	// RemoteRoot is the remote drive9 directory that becomes the mount root.
+	// Empty or "/" means the entire remote filesystem.
+	RemoteRoot string
 }
 
 // NewHandler returns an http.Handler that serves drive9 content over WebDAV.
 func NewHandler(c *client.Client, opts Options) http.Handler {
+	remoteRoot := opts.RemoteRoot
+	if remoteRoot == "" {
+		remoteRoot = "/"
+	}
 	return &webdav.Handler{
 		Prefix:     opts.Prefix,
-		FileSystem: &fileSystem{client: c},
+		FileSystem: &fileSystem{client: c, remoteRoot: remoteRoot},
 		LockSystem: webdav.NewMemLS(),
 	}
 }


### PR DESCRIPTION
## Summary

Adds support for mounting a remote subdirectory: `drive9 mount :/foo/bar /local`

- **CLI**: 2-arg positional form using existing `ParseRemote` `:` syntax. Single-arg `drive9 mount /local` unchanged (defaults to remote `/`).
- **pkg/mountpath**: Shared `ToRemote`/`ToLocal` path mapper with canonicalization and escape protection. Used by both FUSE and WebDAV.
- **WebDAV**: `Options.RemoteRoot` + `fileSystem` maps all client calls through `mountpath.ToRemote`.
- **FUSE**: `MountOptions.RemoteRoot` + `MountHash` includes remote root to isolate caches. Mount-time `Stat(remoteRoot)` validation.
- Parser rejects non-remote first args (`/foo /bar` → error) and context-scoped remotes (`prod:/foo` → not yet supported).

**Note**: FUSE internal path mapping (Dat9FS operations + SSE event filter/rebase) is dat9-dev2's scope and will follow in a stacked PR.

Closes #359

## Test plan

- [x] `pkg/mountpath`: NormalizeRoot, ToRemote (escape clamping, double slash), ToLocal (scope check, prefix attack)
- [x] CLI: 2-arg remote source, 1-arg default, non-remote rejection, context-scoped rejection
- [x] WebDAV: Stat/Mkdir/OpenFile all map through remote root; root `/` maps to `remoteRoot`; default `/` is passthrough
- [x] Existing tests: all 4 affected packages pass (mountpath, webdav, cli, fuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mount command accepts an optional remote source path, allowing mounting of remote subdirectories (e.g., drive9 mount :/subdir /mnt/point).
  * WebDAV and FUSE mounts honor the selected remote root when exposing files.

* **Bug Fixes**
  * Remote-root validation now ensures the specified remote exists and is a directory before mounting.
  * Path operations reliably map between local and remote namespaces for subdirectory mounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->