### PR TITLE
Fix WebDAV dead property writes

### DIFF
--- a/pkg/webdav/fs.go
+++ b/pkg/webdav/fs.go
@@ -3,13 +3,16 @@ package webdav
 import (
 	"bytes"
 	"context"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
@@ -21,6 +24,7 @@ import (
 type fileSystem struct {
 	client     *client.Client
 	remoteRoot string // normalized remote root path, default "/"
+	props      *deadPropStore
 }
 
 var _ webdav.FileSystem = (*fileSystem)(nil)
@@ -28,6 +32,13 @@ var _ webdav.FileSystem = (*fileSystem)(nil)
 // remotePath maps a local WebDAV path to the remote drive9 path.
 func (f *fileSystem) remotePath(localPath string) string {
 	return mountpath.ToRemote(f.remoteRoot, normPath(localPath))
+}
+
+func (f *fileSystem) deadProps() *deadPropStore {
+	if f.props == nil {
+		f.props = newDeadPropStore()
+	}
+	return f.props
 }
 
 func (f *fileSystem) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
@@ -51,7 +62,7 @@ func (f *fileSystem) OpenFile(ctx context.Context, name string, flag int, perm o
 		if !parent.IsDir {
 			return nil, os.ErrInvalid
 		}
-		return &writeFile{client: f.client, path: remote}, nil
+		return &writeFile{client: f.client, path: remote, props: f.deadProps()}, nil
 	}
 
 	// Stat to determine if it's a directory or file.
@@ -65,7 +76,7 @@ func (f *fileSystem) OpenFile(ctx context.Context, name string, flag int, perm o
 		if err != nil {
 			return nil, mapError(err)
 		}
-		return &dirFile{path: local, stat: stat, entries: entries}, nil
+		return &dirFile{path: local, propPath: remote, props: f.deadProps(), stat: stat, entries: entries}, nil
 	}
 
 	// Read entire file content. For the lightweight skills/config use case
@@ -76,9 +87,11 @@ func (f *fileSystem) OpenFile(ctx context.Context, name string, flag int, perm o
 	}
 
 	return &readFile{
-		path:   local,
-		stat:   stat,
-		Reader: bytes.NewReader(data),
+		path:     local,
+		propPath: remote,
+		props:    f.deadProps(),
+		stat:     stat,
+		Reader:   bytes.NewReader(data),
 	}, nil
 }
 
@@ -87,7 +100,12 @@ func (f *fileSystem) RemoveAll(ctx context.Context, name string) error {
 	if local == "/" {
 		return os.ErrInvalid
 	}
-	return mapError(f.client.RemoveAllCtx(ctx, mountpath.ToRemote(f.remoteRoot, local)))
+	remote := mountpath.ToRemote(f.remoteRoot, local)
+	if err := mapError(f.client.RemoveAllCtx(ctx, remote)); err != nil {
+		return err
+	}
+	f.deadProps().deleteTree(remote)
+	return nil
 }
 
 func (f *fileSystem) Rename(ctx context.Context, oldName, newName string) error {
@@ -97,7 +115,11 @@ func (f *fileSystem) Rename(ctx context.Context, oldName, newName string) error 
 	}
 	oldRemote := mountpath.ToRemote(f.remoteRoot, oldLocal)
 	newRemote := mountpath.ToRemote(f.remoteRoot, newLocal)
-	return mapError(f.client.RenameCtx(ctx, oldRemote, newRemote))
+	if err := mapError(f.client.RenameCtx(ctx, oldRemote, newRemote)); err != nil {
+		return err
+	}
+	f.deadProps().renameTree(oldRemote, newRemote)
+	return nil
 }
 
 func (f *fileSystem) Stat(ctx context.Context, name string) (os.FileInfo, error) {
@@ -164,15 +186,132 @@ func (fi *fileInfo) Mode() os.FileMode {
 	return 0o644
 }
 
+type deadPropStore struct {
+	mu    sync.Mutex
+	props map[string]map[xml.Name]webdav.Property
+}
+
+func newDeadPropStore() *deadPropStore {
+	return &deadPropStore{props: make(map[string]map[xml.Name]webdav.Property)}
+}
+
+func (s *deadPropStore) deadProps(name string) (map[xml.Name]webdav.Property, error) {
+	if s == nil {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current := s.props[name]
+	if len(current) == 0 {
+		return nil, nil
+	}
+	out := make(map[xml.Name]webdav.Property, len(current))
+	for k, v := range current {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (s *deadPropStore) patch(name string, patches []webdav.Proppatch) ([]webdav.Propstat, error) {
+	if s == nil {
+		pstat := webdav.Propstat{Status: http.StatusOK}
+		for _, patch := range patches {
+			for _, p := range patch.Props {
+				pstat.Props = append(pstat.Props, webdav.Property{XMLName: p.XMLName})
+			}
+		}
+		return []webdav.Propstat{pstat}, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current := s.props[name]
+	for _, patch := range patches {
+		for _, p := range patch.Props {
+			if current == nil && !patch.Remove {
+				current = make(map[xml.Name]webdav.Property)
+				s.props[name] = current
+			}
+			if patch.Remove {
+				delete(current, p.XMLName)
+				continue
+			}
+			current[p.XMLName] = p
+		}
+	}
+	if len(current) == 0 {
+		delete(s.props, name)
+	}
+
+	pstat := webdav.Propstat{Status: http.StatusOK}
+	for _, patch := range patches {
+		for _, p := range patch.Props {
+			pstat.Props = append(pstat.Props, webdav.Property{XMLName: p.XMLName})
+		}
+	}
+	return []webdav.Propstat{pstat}, nil
+}
+
+func (s *deadPropStore) deleteTree(name string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	prefix := treePrefix(name)
+	for p := range s.props {
+		if p == name || strings.HasPrefix(p, prefix) {
+			delete(s.props, p)
+		}
+	}
+}
+
+func (s *deadPropStore) renameTree(oldName, newName string) {
+	if s == nil || oldName == newName {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	oldPrefix := treePrefix(oldName)
+	updates := make(map[string]map[xml.Name]webdav.Property)
+	for p, props := range s.props {
+		switch {
+		case p == oldName:
+			updates[newName] = props
+			delete(s.props, p)
+		case strings.HasPrefix(p, oldPrefix):
+			updates[newName+strings.TrimPrefix(p, oldName)] = props
+			delete(s.props, p)
+		}
+	}
+	for p, props := range updates {
+		s.props[p] = props
+	}
+}
+
+func treePrefix(name string) string {
+	if strings.HasSuffix(name, "/") {
+		return name
+	}
+	return name + "/"
+}
+
 // dirFile is a webdav.File for directories.
 type dirFile struct {
-	path    string
-	stat    *client.StatResult
-	entries []client.FileInfo
-	pos     int
+	path     string
+	propPath string
+	props    *deadPropStore
+	stat     *client.StatResult
+	entries  []client.FileInfo
+	pos      int
 }
 
 var _ webdav.File = (*dirFile)(nil)
+var _ webdav.DeadPropsHolder = (*dirFile)(nil)
 
 func (d *dirFile) Close() error                   { return nil }
 func (d *dirFile) Read([]byte) (int, error)       { return 0, fmt.Errorf("is a directory") }
@@ -181,6 +320,14 @@ func (d *dirFile) Seek(int64, int) (int64, error) { return 0, fmt.Errorf("is a d
 
 func (d *dirFile) Stat() (os.FileInfo, error) {
 	return &fileInfo{name: path.Base(d.path), stat: d.stat}, nil
+}
+
+func (d *dirFile) DeadProps() (map[xml.Name]webdav.Property, error) {
+	return d.props.deadProps(d.propPath)
+}
+
+func (d *dirFile) Patch(patches []webdav.Proppatch) ([]webdav.Propstat, error) {
+	return d.props.patch(d.propPath, patches)
 }
 
 func (d *dirFile) Readdir(count int) ([]fs.FileInfo, error) {
@@ -217,12 +364,15 @@ func (d *dirFile) Readdir(count int) ([]fs.FileInfo, error) {
 
 // readFile is a webdav.File for reading file content.
 type readFile struct {
-	path string
-	stat *client.StatResult
+	path     string
+	propPath string
+	props    *deadPropStore
+	stat     *client.StatResult
 	*bytes.Reader
 }
 
 var _ webdav.File = (*readFile)(nil)
+var _ webdav.DeadPropsHolder = (*readFile)(nil)
 
 func (r *readFile) Close() error                       { return nil }
 func (r *readFile) Write([]byte) (int, error)          { return 0, fmt.Errorf("read-only") }
@@ -231,14 +381,24 @@ func (r *readFile) Stat() (os.FileInfo, error) {
 	return &fileInfo{name: path.Base(r.path), stat: r.stat}, nil
 }
 
+func (r *readFile) DeadProps() (map[xml.Name]webdav.Property, error) {
+	return r.props.deadProps(r.propPath)
+}
+
+func (r *readFile) Patch(patches []webdav.Proppatch) ([]webdav.Propstat, error) {
+	return r.props.patch(r.propPath, patches)
+}
+
 // writeFile is a webdav.File that buffers writes and flushes on Close.
 type writeFile struct {
 	client *client.Client
 	path   string
+	props  *deadPropStore
 	buf    bytes.Buffer
 }
 
 var _ webdav.File = (*writeFile)(nil)
+var _ webdav.DeadPropsHolder = (*writeFile)(nil)
 
 func (w *writeFile) Read([]byte) (int, error)           { return 0, fmt.Errorf("write-only") }
 func (w *writeFile) Readdir(int) ([]fs.FileInfo, error) { return nil, fmt.Errorf("not a directory") }
@@ -262,4 +422,12 @@ func (w *writeFile) Stat() (os.FileInfo, error) {
 		name: path.Base(w.path),
 		stat: &client.StatResult{Size: int64(w.buf.Len())},
 	}, nil
+}
+
+func (w *writeFile) DeadProps() (map[xml.Name]webdav.Property, error) {
+	return w.props.deadProps(w.path)
+}
+
+func (w *writeFile) Patch(patches []webdav.Proppatch) ([]webdav.Propstat, error) {
+	return w.props.patch(w.path, patches)
 }

--- a/pkg/webdav/fs_test.go
+++ b/pkg/webdav/fs_test.go
@@ -212,6 +212,64 @@ func TestHandlerPutMissingParentReturnsConflict(t *testing.T) {
 	}
 }
 
+func TestHandlerProppatchDeadPropertySucceeds(t *testing.T) {
+	c := newDeadPropTestClient(t)
+	handler := NewHandler(c, Options{})
+
+	body := `<?xml version="1.0"?>` +
+		`<D:propertyupdate xmlns:D="DAV:" xmlns:Z="urn:schemas-microsoft-com:">` +
+		`<D:set><D:prop><Z:Win32FileAttributes>00000020</Z:Win32FileAttributes></D:prop></D:set>` +
+		`</D:propertyupdate>`
+	req := httptest.NewRequest("PROPPATCH", "/dir/file.txt", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/xml")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != 207 {
+		t.Fatalf("PROPPATCH status = %d, want 207: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "HTTP/1.1 200 OK") {
+		t.Fatalf("PROPPATCH body = %q, want 200 propstat", rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "HTTP/1.1 403 Forbidden") {
+		t.Fatalf("PROPPATCH body = %q, must not reject dead property", rr.Body.String())
+	}
+}
+
+func TestHandlerPropfindReturnsPatchedDeadProperty(t *testing.T) {
+	c := newDeadPropTestClient(t)
+	handler := NewHandler(c, Options{})
+
+	patchBody := `<?xml version="1.0"?>` +
+		`<D:propertyupdate xmlns:D="DAV:" xmlns:Z="urn:schemas-microsoft-com:">` +
+		`<D:set><D:prop><Z:Win32FileAttributes>00000020</Z:Win32FileAttributes></D:prop></D:set>` +
+		`</D:propertyupdate>`
+	patchReq := httptest.NewRequest("PROPPATCH", "/dir/file.txt", strings.NewReader(patchBody))
+	patchReq.Header.Set("Content-Type", "application/xml")
+	patchRR := httptest.NewRecorder()
+	handler.ServeHTTP(patchRR, patchReq)
+	if patchRR.Code != 207 {
+		t.Fatalf("PROPPATCH status = %d, want 207: %s", patchRR.Code, patchRR.Body.String())
+	}
+
+	findBody := `<?xml version="1.0"?>` +
+		`<D:propfind xmlns:D="DAV:" xmlns:Z="urn:schemas-microsoft-com:">` +
+		`<D:prop><Z:Win32FileAttributes/></D:prop>` +
+		`</D:propfind>`
+	findReq := httptest.NewRequest("PROPFIND", "/dir/file.txt", strings.NewReader(findBody))
+	findReq.Header.Set("Depth", "0")
+	findReq.Header.Set("Content-Type", "application/xml")
+	findRR := httptest.NewRecorder()
+	handler.ServeHTTP(findRR, findReq)
+
+	if findRR.Code != 207 {
+		t.Fatalf("PROPFIND status = %d, want 207: %s", findRR.Code, findRR.Body.String())
+	}
+	if !strings.Contains(findRR.Body.String(), "00000020") {
+		t.Fatalf("PROPFIND body = %q, want patched property value", findRR.Body.String())
+	}
+}
+
 func TestReadFileSeekAndRead(t *testing.T) {
 	data := []byte("hello world")
 	rf := &readFile{
@@ -379,6 +437,46 @@ func newWriteOnlyTestClient(t *testing.T, onWrite func(string)) *client.Client {
 			_ = json.NewEncoder(w).Encode(struct {
 				Revision int64 `json:"revision"`
 			}{Revision: 1})
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(struct {
+				Error string `json:"error"`
+			}{Error: "not found"})
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return client.New(srv.URL, "test-key")
+}
+
+func newDeadPropTestClient(t *testing.T) *client.Client {
+	t.Helper()
+	files := map[string][]byte{
+		"/v1/fs/dir/file.txt": []byte("payload"),
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs/dir":
+			w.Header().Set("X-Dat9-IsDir", "true")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs/dir/file.txt":
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("Content-Length", "7")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/fs/dir/file.txt":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(files[r.URL.Path])
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs/dir/file.txt":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ReadAll body: %v", err)
+			}
+			files[r.URL.Path] = body
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(struct {
+				Revision int64 `json:"revision"`
+			}{Revision: 2})
 		default:
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)

--- a/pkg/webdav/handler.go
+++ b/pkg/webdav/handler.go
@@ -30,7 +30,7 @@ func NewHandler(c *client.Client, opts Options) http.Handler {
 	}
 	return &webdav.Handler{
 		Prefix:     opts.Prefix,
-		FileSystem: &fileSystem{client: c, remoteRoot: remoteRoot},
+		FileSystem: &fileSystem{client: c, remoteRoot: remoteRoot, props: newDeadPropStore()},
 		LockSystem: webdav.NewMemLS(),
 	}
 }


### PR DESCRIPTION
## Summary
- add per-mount WebDAV dead property storage for macOS metadata PROPPATCH requests
- make WebDAV file handles implement DeadPropsHolder so non-DAV properties no longer return 403
- keep stored dead properties in sync across remove and rename operations

## Tests
- go test ./pkg/webdav ./cmd/drive9/cli
- go build -o /tmp/drive9-webdav-check ./cmd/drive9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented WebDAV dead property support, enabling storage and management of custom metadata on files and directories
  * Dead properties are automatically preserved during file operations such as rename and delete
  * Full support for PROPPATCH and PROPFIND operations

* **Tests**
  * Added comprehensive test coverage for dead property management operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->