### PR TITLE
fix: explain mount_webdav exit codes with actionable hints

### DIFF
--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -168,7 +169,7 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 	// Invoke mount_webdav.
 	if err := deps.runMount(deps.goos, serverURL, mountPoint); err != nil {
 		_ = srv.Close()
-		return fmt.Errorf("webdav: mount_webdav failed: %w", err)
+		return explainMountError(deps.goos, mountPoint, err)
 	}
 
 	fmt.Fprintf(os.Stderr, "dat9: mounted on %s via WebDAV (%s)\n", mountPoint, serverURL)
@@ -214,6 +215,44 @@ func runWebDAVMountCmd(goos, serverURL, mountPoint string) error {
 	mountCmd.Stdout = os.Stderr
 	mountCmd.Stderr = os.Stderr
 	return mountCmd.Run()
+}
+
+// explainMountError turns the opaque "exit status N" from mount_webdav into
+// an actionable message. The underlying error is preserved via %w so callers
+// (and tests) can still match on it.
+func explainMountError(goos, mountPoint string, err error) error {
+	hint := mountErrorHint(goos, mountPoint, err)
+	if hint == "" {
+		return fmt.Errorf("webdav: mount_webdav failed: %w", err)
+	}
+	return fmt.Errorf("webdav: mount_webdav failed: %w\n  %s", err, hint)
+}
+
+// mountErrorHint returns a human-readable explanation for known mount_webdav
+// exit codes on macOS. Returns "" when no specific hint applies.
+//
+// Codes follow mount_webdav(8) DIAGNOSTICS: ENOENT (invalid node path),
+// ENODEV (server not WebDAV-enabled, missing, or inaccessible), ECANCELED
+// (auth canceled). EBUSY surfaces when a mount already covers the point.
+func mountErrorHint(goos, mountPoint string, err error) string {
+	if goos != "darwin" {
+		return ""
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		return ""
+	}
+	switch ee.ExitCode() {
+	case 2: // ENOENT
+		return fmt.Sprintf("mount point %q does not exist or is not accessible.", mountPoint)
+	case 16: // EBUSY
+		return fmt.Sprintf("mount point %q is busy — a filesystem may already be mounted there. Run `mount | grep %q` and `drive9 umount %s` to clean up.", mountPoint, mountPoint, mountPoint)
+	case 19: // ENODEV
+		return fmt.Sprintf("the kernel rejected the WebDAV mount at %q (ENODEV). Common causes: a stale mount still attached at this path (try `mount | grep %q` then `drive9 umount %s`); the local WebDAV bridge was unreachable; or the mount point is on a filesystem that does not support WebDAV mounts (e.g. some network volumes). Try a fresh path under your home directory.", mountPoint, mountPoint, mountPoint)
+	case 77: // ECANCELED
+		return "authentication was canceled by mount_webdav. Re-run the command and ensure credentials are configured (`drive9 ctx`)."
+	}
+	return ""
 }
 
 // webdavMountCmd builds the OS command to mount a WebDAV URL at mountPoint.

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -3,9 +3,11 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -300,6 +302,124 @@ func TestErrorPathWebdavUnmount(t *testing.T) {
 	// webdavUnmount with a non-existent mountpoint should not panic.
 	// It prints to stderr but returns no error (fire-and-forget).
 	webdavUnmount("darwin", "/nonexistent/path/drive9-test-unmount")
+}
+
+// TestMountErrorHint verifies that known macOS mount_webdav exit codes are
+// translated into actionable messages, while unknown errors fall through.
+func TestMountErrorHint(t *testing.T) {
+	mp := "/tmp/drive9-test-mp"
+
+	tests := []struct {
+		name     string
+		goos     string
+		err      error
+		wantSubs []string // all must appear in the hint
+		wantHint bool
+	}{
+		{
+			name:     "darwin ENODEV (19)",
+			goos:     "darwin",
+			err:      exitErrorWithCode(t, 19),
+			wantSubs: []string{"ENODEV", "stale mount", "drive9 umount"},
+			wantHint: true,
+		},
+		{
+			name:     "darwin ENOENT (2)",
+			goos:     "darwin",
+			err:      exitErrorWithCode(t, 2),
+			wantSubs: []string{"does not exist"},
+			wantHint: true,
+		},
+		{
+			name:     "darwin EBUSY (16)",
+			goos:     "darwin",
+			err:      exitErrorWithCode(t, 16),
+			wantSubs: []string{"busy", "drive9 umount"},
+			wantHint: true,
+		},
+		{
+			name:     "darwin ECANCELED (77)",
+			goos:     "darwin",
+			err:      exitErrorWithCode(t, 77),
+			wantSubs: []string{"authentication"},
+			wantHint: true,
+		},
+		{
+			name:     "darwin unknown exit code falls through",
+			goos:     "darwin",
+			err:      exitErrorWithCode(t, 42),
+			wantHint: false,
+		},
+		{
+			name:     "darwin non-ExitError falls through",
+			goos:     "darwin",
+			err:      errors.New("plain error"),
+			wantHint: false,
+		},
+		{
+			name:     "linux gets no hint",
+			goos:     "linux",
+			err:      exitErrorWithCode(t, 19),
+			wantHint: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hint := mountErrorHint(tt.goos, mp, tt.err)
+			if tt.wantHint && hint == "" {
+				t.Fatalf("expected hint, got empty string")
+			}
+			if !tt.wantHint && hint != "" {
+				t.Fatalf("expected no hint, got %q", hint)
+			}
+			for _, sub := range tt.wantSubs {
+				if !strings.Contains(hint, sub) {
+					t.Errorf("hint = %q, want substring %q", hint, sub)
+				}
+			}
+		})
+	}
+}
+
+// TestExplainMountError checks that explainMountError preserves the underlying
+// error (so errors.Is/As keep working) and appends the hint when applicable.
+func TestExplainMountError(t *testing.T) {
+	underlying := exitErrorWithCode(t, 19)
+	wrapped := explainMountError("darwin", "/tmp/mp", underlying)
+
+	if !errors.Is(wrapped, underlying) {
+		t.Fatalf("wrapped error must wrap the original; got %v", wrapped)
+	}
+	if !strings.Contains(wrapped.Error(), "mount_webdav failed") {
+		t.Errorf("missing prefix; got %q", wrapped.Error())
+	}
+	if !strings.Contains(wrapped.Error(), "ENODEV") {
+		t.Errorf("missing hint; got %q", wrapped.Error())
+	}
+
+	// Plain errors (non-ExitError) get the original wrapping with no hint.
+	plain := errors.New("plain")
+	wrapped2 := explainMountError("darwin", "/tmp/mp", plain)
+	if !strings.Contains(wrapped2.Error(), "plain") {
+		t.Errorf("plain error not preserved; got %q", wrapped2.Error())
+	}
+	if strings.Contains(wrapped2.Error(), "ENODEV") {
+		t.Errorf("plain error should not get an ENODEV hint; got %q", wrapped2.Error())
+	}
+}
+
+// exitErrorWithCode runs a tiny shell command that exits with the given code
+// and returns the resulting *exec.ExitError. This is the only portable way
+// to construct one — its internal fields are unexported.
+func exitErrorWithCode(t *testing.T, code int) error {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code))
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected non-zero exit, got nil")
+	}
+	return err
 }
 
 // TestParseMountModeRoundTrip ensures every MountMode constant is parseable.


### PR DESCRIPTION
## Summary
- `drive9 mount :/ ~/drive9` failing with `webdav: mount_webdav failed: exit status 19` was unhelpful — users had no way to know that 19 means ENODEV, or what to do about it.
- Map the common macOS `mount_webdav` exit codes to human-readable hints with the next command to try; unknown codes and non-darwin platforms fall through to the original message.
- `errors.Is` / `errors.As` still unwrap to the underlying `*exec.ExitError`, so the existing failure-propagation test keeps passing.

### New output for the reported case
```
webdav: mount_webdav failed: exit status 19
  the kernel rejected the WebDAV mount at "/Users/.../drive9" (ENODEV). Common causes: a stale mount still attached at this path (try `mount | grep ...` then `drive9 umount ...`); the local WebDAV bridge was unreachable; or the mount point is on a filesystem that does not support WebDAV mounts. Try a fresh path under your home directory.
```

### Codes covered
| Code | errno      | Hint focus                                              |
|------|------------|---------------------------------------------------------|
| 2    | ENOENT     | Mount point doesn't exist / not accessible              |
| 16   | EBUSY      | Filesystem already mounted there — point at `umount`    |
| 19   | ENODEV     | Stale mount / bridge unreachable / unsupported FS       |
| 77   | ECANCELED  | Auth was canceled — re-run after configuring `drive9 ctx` |

## Test plan
- [x] `go test ./cmd/drive9/cli/ -count=1` — all existing tests still pass
- [x] New `TestMountErrorHint` covers each known exit code + fall-through (non-ExitError, unknown code, non-darwin)
- [x] New `TestExplainMountError` verifies `errors.Is` chain to the underlying `*exec.ExitError` is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebDAV mount failures on macOS now provide targeted error messages with specific guidance for common issues, including instructions for resolving mount-related problems.

* **Tests**
  * Added comprehensive test coverage for mount error scenarios across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->