### PR TITLE
feat: add drive9 fs mkdir + mount 404 error UX

### DIFF
--- a/cmd/drive9/cli/mkdir.go
+++ b/cmd/drive9/cli/mkdir.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+// Mkdir creates a remote directory.
+// Parent directories are created automatically.
+//
+//	drive9 fs mkdir /path/to/dir
+//	drive9 fs mkdir :/path/to/dir
+func Mkdir(c *client.Client, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: drive9 fs mkdir <path>")
+	}
+	path := args[0]
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
+	}
+	if err := c.Mkdir(path); err != nil {
+		return err
+	}
+	fmt.Printf("created %s\n", path)
+	return nil
+}

--- a/cmd/drive9/cli/mkdir_test.go
+++ b/cmd/drive9/cli/mkdir_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+func TestMkdir(t *testing.T) {
+	t.Run("creates_directory", func(t *testing.T) {
+		var gotMethod string
+		var gotPath string
+		var gotMkdir bool
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			gotMkdir = r.URL.Query().Has("mkdir")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		out, err := captureStdoutE(t, func() error { return Mkdir(c, []string{"/data"}) })
+		if err != nil {
+			t.Fatalf("Mkdir error = %v", err)
+		}
+		if gotMethod != http.MethodPost {
+			t.Fatalf("method = %q, want POST", gotMethod)
+		}
+		if gotPath != "/v1/fs/data" {
+			t.Fatalf("path = %q, want /v1/fs/data", gotPath)
+		}
+		if !gotMkdir {
+			t.Fatal("missing ?mkdir query parameter")
+		}
+		if !strings.Contains(out, "created /data") {
+			t.Fatalf("output = %q, want 'created /data'", out)
+		}
+	})
+
+	t.Run("remote_path_prefix", func(t *testing.T) {
+		var gotPath string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		_, err := captureStdoutE(t, func() error { return Mkdir(c, []string{":/workspace/logs"}) })
+		if err != nil {
+			t.Fatalf("Mkdir(remote) error = %v", err)
+		}
+		if gotPath != "/v1/fs/workspace/logs" {
+			t.Fatalf("path = %q, want /v1/fs/workspace/logs", gotPath)
+		}
+	})
+
+	t.Run("bare_path", func(t *testing.T) {
+		var gotPath string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		_, err := captureStdoutE(t, func() error { return Mkdir(c, []string{"/a/b/c"}) })
+		if err != nil {
+			t.Fatalf("Mkdir(bare) error = %v", err)
+		}
+		if gotPath != "/v1/fs/a/b/c" {
+			t.Fatalf("path = %q, want /v1/fs/a/b/c", gotPath)
+		}
+	})
+
+	t.Run("server_error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"internal error"}`))
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		err := Mkdir(c, []string{"/fail"})
+		if err == nil {
+			t.Fatal("expected error on 500")
+		}
+	})
+}
+
+func TestMkdirUsageErrors(t *testing.T) {
+	c := client.New("http://example.invalid", "")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"no_args", nil},
+		{"too_many_args", []string{"/a", "/b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Mkdir(c, tt.args)
+			if err == nil {
+				t.Fatal("expected usage error")
+			}
+			if !strings.Contains(err.Error(), "usage: drive9 fs mkdir") {
+				t.Fatalf("error = %q, want usage message", err.Error())
+			}
+		})
+	}
+}

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -213,12 +214,22 @@ func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 	}
 	stat, err := c.Stat(remoteRoot)
 	if err != nil {
-		return fmt.Errorf("remote root %q: %w", remoteRoot, err)
+		return remoteRootError(remoteRoot, err)
 	}
 	if !stat.IsDir {
 		return fmt.Errorf("remote root %q is not a directory", remoteRoot)
 	}
 	return nil
+}
+
+// remoteRootError wraps a remote-root stat/list error with actionable guidance
+// when the path does not exist (HTTP 404).
+func remoteRootError(remoteRoot string, err error) error {
+	var se *client.StatusError
+	if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("drive9 mount: remote source %q does not exist\n\n  To create it first:\n    drive9 fs mkdir :%s\n  Then retry:\n    drive9 mount :%s <mountpoint>", remoteRoot, remoteRoot, remoteRoot)
+	}
+	return fmt.Errorf("remote root %q: %w", remoteRoot, err)
 }
 
 func validateLookupRetryFlags(count int, timeout time.Duration) error {

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -204,6 +203,8 @@ func newWebDAVHandler(c *client.Client, prefix string, remoteRoot string) (http.
 }
 
 // validateRemoteRoot checks that the remote root path exists and is a directory.
+// Mirrors the FUSE path's Stat→List fallback so both mount modes behave
+// identically on backends where directory stat is unsupported.
 func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 	if remoteRoot == "/" {
 		// Root always exists; verify server connectivity via List.
@@ -214,7 +215,12 @@ func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 	}
 	stat, err := c.Stat(remoteRoot)
 	if err != nil {
-		return remoteRootError(remoteRoot, err)
+		// Stat may fail on backends where directory stat is unsupported.
+		// Fall back to List to verify the remote root exists and is listable.
+		if _, listErr := c.List(remoteRoot); listErr != nil {
+			return remoteRootError(remoteRoot, listErr)
+		}
+		return nil
 	}
 	if !stat.IsDir {
 		return fmt.Errorf("remote root %q is not a directory", remoteRoot)
@@ -225,8 +231,7 @@ func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 // remoteRootError wraps a remote-root stat/list error with actionable guidance
 // when the path does not exist (HTTP 404).
 func remoteRootError(remoteRoot string, err error) error {
-	var se *client.StatusError
-	if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
+	if client.IsNotFound(err) {
 		return fmt.Errorf("drive9 mount: remote source %q does not exist\n\n  To create it first:\n    drive9 fs mkdir :%s\n  Then retry:\n    drive9 mount :%s <mountpoint>", remoteRoot, remoteRoot, remoteRoot)
 	}
 	return fmt.Errorf("remote root %q: %w", remoteRoot, err)

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -290,5 +291,79 @@ func TestRemoteRootError_Non404WrapsOriginal(t *testing.T) {
 	}
 	if !strings.Contains(got, "server error") {
 		t.Fatalf("error = %q, want original message wrapped", got)
+	}
+}
+
+func TestValidateRemoteRoot_StatFailsListSucceeds(t *testing.T) {
+	// Backend where Stat on directories is unsupported but List works.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Has("stat") {
+			// Stat unsupported for directories on this backend.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"stat unsupported"}`))
+			return
+		}
+		if r.URL.Query().Has("list") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"entries":[]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	err := validateRemoteRoot(c, "/data")
+	if err != nil {
+		t.Fatalf("expected success when Stat fails but List succeeds: %v", err)
+	}
+}
+
+func TestValidateRemoteRoot_BothFailWith404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	err := validateRemoteRoot(c, "/data")
+	if err == nil {
+		t.Fatal("expected error when both Stat and List return 404")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "does not exist") {
+		t.Fatalf("error = %q, want 404 hint", got)
+	}
+	if !strings.Contains(got, "drive9 fs mkdir :/data") {
+		t.Fatalf("error = %q, want mkdir guidance", got)
+	}
+}
+
+func TestValidateRemoteRoot_StatNotFoundListTimeout(t *testing.T) {
+	// Stat returns 404, but List returns a different error (e.g. 500).
+	// Should NOT show 404 hint — List error takes precedence.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Has("stat") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"timeout"}`))
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	err := validateRemoteRoot(c, "/data")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	if strings.Contains(got, "does not exist") {
+		t.Fatalf("Stat 404 + List 500 should NOT show 404 hint: %q", got)
+	}
+	if !strings.Contains(got, "timeout") {
+		t.Fatalf("error = %q, want List error message", got)
 	}
 }

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"errors"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/client"
 )
 
 func fakeLookPath(binMap map[string]bool) func(string) (string, error) {
@@ -261,5 +264,31 @@ func TestMountCmd_VaultStillDispatchesSeparately(t *testing.T) {
 	}
 	if got := err.Error(); !strings.Contains(got, "drive9 mount vault: exactly one mountpoint required") {
 		t.Fatalf("error = %q, want vault-specific arity rejection", got)
+	}
+}
+
+func TestRemoteRootError_404ShowsHint(t *testing.T) {
+	err := remoteRootError("/data", &client.StatusError{StatusCode: http.StatusNotFound, Message: "not found"})
+	got := err.Error()
+	if !strings.Contains(got, "does not exist") {
+		t.Fatalf("error = %q, want 'does not exist'", got)
+	}
+	if !strings.Contains(got, "drive9 fs mkdir :/data") {
+		t.Fatalf("error = %q, want mkdir hint", got)
+	}
+	if !strings.Contains(got, "drive9 mount :/data") {
+		t.Fatalf("error = %q, want retry hint", got)
+	}
+}
+
+func TestRemoteRootError_Non404WrapsOriginal(t *testing.T) {
+	origErr := &client.StatusError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+	err := remoteRootError("/data", origErr)
+	got := err.Error()
+	if strings.Contains(got, "does not exist") {
+		t.Fatalf("500 error should not show 404 hint: %q", got)
+	}
+	if !strings.Contains(got, "server error") {
+		t.Fatalf("error = %q, want original message wrapped", got)
 	}
 }

--- a/cmd/drive9/cli/sh.go
+++ b/cmd/drive9/cli/sh.go
@@ -126,6 +126,15 @@ func Sh(c *client.Client, _ []string) error {
 				fmt.Fprintf(os.Stderr, "stat: %v\n", err)
 			}
 
+		case "mkdir":
+			if len(args) != 1 {
+				fmt.Fprintln(os.Stderr, "usage: mkdir <path>")
+				continue
+			}
+			if err := Mkdir(c, []string{resolve(cwd, args[0])}); err != nil {
+				fmt.Fprintf(os.Stderr, "mkdir: %v\n", err)
+			}
+
 		default:
 			fmt.Fprintf(os.Stderr, "unknown command: %s (type help)\n", cmd)
 		}
@@ -184,6 +193,7 @@ func shHelp() {
   cp <src> <dst>  copy files
   mv <old> <new>  rename/move
   rm [-r|--recursive] <path>  remove
+  mkdir <path>    create directory (parents auto-created)
   stat <path>     file metadata
   help            this help
   exit            quit shell`)

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -192,6 +192,8 @@ func runFS(args []string) {
 		err = cli.Mv(c, rest)
 	case "rm":
 		err = cli.Rm(c, rest)
+	case "mkdir":
+		err = cli.Mkdir(c, rest)
 	case "sh":
 		err = cli.Sh(c, rest)
 	case "grep":
@@ -271,6 +273,7 @@ commands:
   stat [-o text|json] <path>
                        file metadata
   mv <old> <new>      rename/move
+  mkdir <path>        create directory (parents auto-created)
   rm [-r|--recursive] <path>
                        remove file or directory tree
   sh                  interactive shell

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -61,6 +61,12 @@ func (e *StatusError) Is(target error) bool {
 	return target == ErrConflict && e.StatusCode == http.StatusConflict
 }
 
+// IsNotFound reports whether err is an HTTP 404 StatusError.
+func IsNotFound(err error) bool {
+	var se *StatusError
+	return errors.As(err, &se) && se.StatusCode == http.StatusNotFound
+}
+
 // New creates a new dat9 client authenticated with an owner API key.
 //
 // Owner credentials reach the tenant management plane (CreateVaultSecret,

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -141,11 +141,12 @@ func Mount(opts *MountOptions) error {
 			// Stat may fail on backends where directory stat is unsupported.
 			// Fall back to List to verify the remote root exists and is listable.
 			if _, listErr := c.List(remoteRoot); listErr != nil {
+				// Both Stat and List failed — check either error for 404.
 				var se *client.StatusError
-				if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
+				if errors.As(listErr, &se) && se.StatusCode == http.StatusNotFound {
 					return fmt.Errorf("drive9 mount: remote source %q does not exist\n\n  To create it first:\n    drive9 fs mkdir :%s\n  Then retry:\n    drive9 mount :%s <mountpoint>", remoteRoot, remoteRoot, remoteRoot)
 				}
-				return fmt.Errorf("remote root %q: %w", remoteRoot, err)
+				return fmt.Errorf("remote root %q: %w", remoteRoot, listErr)
 			}
 		} else if !stat.IsDir {
 			return fmt.Errorf("remote root %q is not a directory", remoteRoot)

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -139,6 +141,10 @@ func Mount(opts *MountOptions) error {
 			// Stat may fail on backends where directory stat is unsupported.
 			// Fall back to List to verify the remote root exists and is listable.
 			if _, listErr := c.List(remoteRoot); listErr != nil {
+				var se *client.StatusError
+				if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
+					return fmt.Errorf("drive9 mount: remote source %q does not exist\n\n  To create it first:\n    drive9 fs mkdir :%s\n  Then retry:\n    drive9 mount :%s <mountpoint>", remoteRoot, remoteRoot, remoteRoot)
+				}
 				return fmt.Errorf("remote root %q: %w", remoteRoot, err)
 			}
 		} else if !stat.IsDir {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -141,9 +139,7 @@ func Mount(opts *MountOptions) error {
 			// Stat may fail on backends where directory stat is unsupported.
 			// Fall back to List to verify the remote root exists and is listable.
 			if _, listErr := c.List(remoteRoot); listErr != nil {
-				// Both Stat and List failed — check either error for 404.
-				var se *client.StatusError
-				if errors.As(listErr, &se) && se.StatusCode == http.StatusNotFound {
+				if client.IsNotFound(listErr) {
 					return fmt.Errorf("drive9 mount: remote source %q does not exist\n\n  To create it first:\n    drive9 fs mkdir :%s\n  Then retry:\n    drive9 mount :%s <mountpoint>", remoteRoot, remoteRoot, remoteRoot)
 				}
 				return fmt.Errorf("remote root %q: %w", remoteRoot, listErr)


### PR DESCRIPTION
## Summary
- Add `drive9 fs mkdir <path>` CLI command (wraps existing `client.Mkdir`; parents auto-created)
- Add `mkdir` to interactive shell (`drive9 fs sh`)
- Improve mount error when remote source doesn't exist (HTTP 404) with actionable guidance pointing to `drive9 fs mkdir`

## Changes
- **New**: `cmd/drive9/cli/mkdir.go` — mkdir CLI command
- **Modified**: `cmd/drive9/main.go` — dispatch + usage text
- **Modified**: `cmd/drive9/cli/sh.go` — shell mode mkdir + help text
- **Modified**: `cmd/drive9/cli/mount.go` — WebDAV mount 404 error UX
- **Modified**: `pkg/fuse/mount.go` — FUSE mount 404 error UX

## Error UX (before → after)
**Before:**
```
remote root "/data": HTTP 404
```
**After:**
```
drive9 mount: remote source "/data" does not exist

  To create it first:
    drive9 fs mkdir :/data
  Then retry:
    drive9 mount :/data <mountpoint>
```

## Test plan
- [x] `go build ./cmd/drive9/`
- [x] `go test ./cmd/drive9/cli/...`
- [x] `go vet ./cmd/drive9/... ./pkg/fuse/...`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `drive9 fs mkdir` command to create remote directories with automatic parent directory creation.

* **Improvements**
  * Enhanced error messages when mount operations fail due to missing remote directories, now includes actionable CLI instructions for creating the directory and retrying the mount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->