### PR TITLE
feat: add `drive9 fs mkdir` and improve mount 404 error UX

### DIFF
--- a/cmd/drive9/cli/mkdir.go
+++ b/cmd/drive9/cli/mkdir.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+// Mkdir creates a remote directory.
+//
+//	drive9 fs mkdir /path/to/dir
+//	drive9 fs mkdir :/path/to/dir
+//
+// Parent directories are created automatically by the server.
+func Mkdir(c *client.Client, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: drive9 fs mkdir <path>")
+	}
+
+	path := args[0]
+
+	// Handle ":" prefixed remote paths
+	if rp, isRemote := ParseRemote(path); isRemote {
+		path = rp.Path
+	}
+
+	if path == "" || path == "/" {
+		return fmt.Errorf("drive9 fs mkdir: cannot create root directory")
+	}
+
+	return c.Mkdir(path)
+}

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -213,12 +214,27 @@ func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 	}
 	stat, err := c.Stat(remoteRoot)
 	if err != nil {
-		return fmt.Errorf("remote root %q: %w", remoteRoot, err)
+		// Stat may fail on backends where directory stat is unsupported.
+		// Fall back to List to verify the remote root exists and is listable.
+		if _, listErr := c.List(remoteRoot); listErr != nil {
+			return remoteRootError(remoteRoot, err)
+		}
+		return nil
 	}
 	if !stat.IsDir {
 		return fmt.Errorf("remote root %q is not a directory", remoteRoot)
 	}
 	return nil
+}
+
+// remoteRootError returns an actionable error message when a remote root
+// path cannot be accessed. For 404 errors it suggests creating the directory.
+func remoteRootError(remoteRoot string, err error) error {
+	var se *client.StatusError
+	if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("remote source :%s does not exist\n\n  Create it first:\n    drive9 fs mkdir :%s\n\n  Then retry your mount command", remoteRoot, remoteRoot)
+	}
+	return fmt.Errorf("remote root %q: %w", remoteRoot, err)
 }
 
 func validateLookupRetryFlags(count int, timeout time.Duration) error {

--- a/cmd/drive9/cli/sh.go
+++ b/cmd/drive9/cli/sh.go
@@ -126,6 +126,15 @@ func Sh(c *client.Client, _ []string) error {
 				fmt.Fprintf(os.Stderr, "stat: %v\n", err)
 			}
 
+		case "mkdir":
+			if len(args) != 1 {
+				fmt.Fprintln(os.Stderr, "usage: mkdir <path>")
+				continue
+			}
+			if err := Mkdir(c, []string{resolve(cwd, args[0])}); err != nil {
+				fmt.Fprintf(os.Stderr, "mkdir: %v\n", err)
+			}
+
 		default:
 			fmt.Fprintf(os.Stderr, "unknown command: %s (type help)\n", cmd)
 		}
@@ -185,6 +194,7 @@ func shHelp() {
   mv <old> <new>  rename/move
   rm [-r|--recursive] <path>  remove
   stat <path>     file metadata
+  mkdir <path>    create directory
   help            this help
   exit            quit shell`)
 }

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -192,6 +192,8 @@ func runFS(args []string) {
 		err = cli.Mv(c, rest)
 	case "rm":
 		err = cli.Rm(c, rest)
+	case "mkdir":
+		err = cli.Mkdir(c, rest)
 	case "sh":
 		err = cli.Sh(c, rest)
 	case "grep":
@@ -273,6 +275,7 @@ commands:
   mv <old> <new>      rename/move
   rm [-r|--recursive] <path>
                        remove file or directory tree
+  mkdir <path>        create remote directory (parents created automatically)
   sh                  interactive shell
   grep <pattern> [dir] search file contents
   find [dir] [flags]   find files by attributes

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -139,6 +141,10 @@ func Mount(opts *MountOptions) error {
 			// Stat may fail on backends where directory stat is unsupported.
 			// Fall back to List to verify the remote root exists and is listable.
 			if _, listErr := c.List(remoteRoot); listErr != nil {
+				var se *client.StatusError
+				if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
+					return fmt.Errorf("remote source :%s does not exist\n\n  Create it first:\n    drive9 fs mkdir :%s\n\n  Then retry your mount command", remoteRoot, remoteRoot)
+				}
 				return fmt.Errorf("remote root %q: %w", remoteRoot, err)
 			}
 		} else if !stat.IsDir {


### PR DESCRIPTION
Add `drive9 fs mkdir :/path` CLI command for creating remote directories. Parent directories are created automatically by the server.

Also improve the mount error when remote root doesn't exist (404) to provide actionable guidance suggesting `drive9 fs mkdir` first.

- New `cmd/drive9/cli/mkdir.go`: Mkdir function, accepts `/path` and `:/path`
- Add `mkdir` case to `drive9 fs sh` interactive shell
- Add `mkdir` to `drive9 fs` usage help
- Detect 404 in mount validateRemoteRoot (CLI + FUSE) and show hint