### PR TITLE
fix: trust Stat 404 over List empty success for mount validation

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -215,8 +215,14 @@ func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 	}
 	stat, err := c.Stat(remoteRoot)
 	if err != nil {
-		// Stat may fail on backends where directory stat is unsupported.
-		// Fall back to List to verify the remote root exists and is listable.
+		// If Stat explicitly says "not found", trust it — don't fall back
+		// to List which may return empty success for non-existent paths.
+		if client.IsNotFound(err) {
+			return remoteRootError(remoteRoot, err)
+		}
+		// Stat may fail on backends where directory stat is unsupported
+		// (non-404 error). Fall back to List to verify the remote root
+		// exists and is listable.
 		if _, listErr := c.List(remoteRoot); listErr != nil {
 			return remoteRootError(remoteRoot, listErr)
 		}

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -295,12 +295,11 @@ func TestRemoteRootError_Non404WrapsOriginal(t *testing.T) {
 }
 
 func TestValidateRemoteRoot_StatFailsListSucceeds(t *testing.T) {
-	// Backend where Stat on directories is unsupported but List works.
+	// Backend where Stat (HEAD) on directories is unsupported but List works.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Has("stat") {
-			// Stat unsupported for directories on this backend.
+		if r.Method == http.MethodHead {
+			// Stat unsupported for directories on this backend (non-404).
 			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte(`{"error":"stat unsupported"}`))
 			return
 		}
 		if r.URL.Query().Has("list") {
@@ -320,9 +319,9 @@ func TestValidateRemoteRoot_StatFailsListSucceeds(t *testing.T) {
 }
 
 func TestValidateRemoteRoot_BothFailWith404(t *testing.T) {
+	// Both Stat (HEAD) and List return 404.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error":"not found"}`))
 	}))
 	defer srv.Close()
 
@@ -340,13 +339,41 @@ func TestValidateRemoteRoot_BothFailWith404(t *testing.T) {
 	}
 }
 
-func TestValidateRemoteRoot_StatNotFoundListTimeout(t *testing.T) {
-	// Stat returns 404, but List returns a different error (e.g. 500).
-	// Should NOT show 404 hint — List error takes precedence.
+func TestValidateRemoteRoot_Stat404TrustedOverList(t *testing.T) {
+	// Stat (HEAD) returns 404 — we trust it immediately and show the hint,
+	// even if List would succeed (server returns empty entries for
+	// non-existent paths).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Has("stat") {
+		if r.Method == http.MethodHead {
 			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(`{"error":"not found"}`))
+			return
+		}
+		// List would succeed with empty entries
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"entries":[]}`))
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	err := validateRemoteRoot(c, "/data")
+	if err == nil {
+		t.Fatal("expected error when Stat returns 404")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "does not exist") {
+		t.Fatalf("error = %q, want 404 hint", got)
+	}
+	if !strings.Contains(got, "drive9 fs mkdir :/data") {
+		t.Fatalf("error = %q, want mkdir guidance", got)
+	}
+}
+
+func TestValidateRemoteRoot_StatNon404ListFails(t *testing.T) {
+	// Stat (HEAD) returns non-404 error (unsupported), List also fails with 500.
+	// Should show List error, not 404 hint.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(http.StatusInternalServerError)
@@ -361,7 +388,7 @@ func TestValidateRemoteRoot_StatNotFoundListTimeout(t *testing.T) {
 	}
 	got := err.Error()
 	if strings.Contains(got, "does not exist") {
-		t.Fatalf("Stat 404 + List 500 should NOT show 404 hint: %q", got)
+		t.Fatalf("non-404 Stat + List 500 should NOT show 404 hint: %q", got)
 	}
 	if !strings.Contains(got, "timeout") {
 		t.Fatalf("error = %q, want List error message", got)

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -136,8 +136,13 @@ func Mount(opts *MountOptions) error {
 	} else {
 		stat, err := c.Stat(remoteRoot)
 		if err != nil {
-			// Stat may fail on backends where directory stat is unsupported.
-			// Fall back to List to verify the remote root exists and is listable.
+			// If Stat explicitly says "not found", trust it — don't fall back
+			// to List which may return empty success for non-existent paths.
+			if client.IsNotFound(err) {
+				return fmt.Errorf("drive9 mount: remote source %q does not exist\n\n  To create it first:\n    drive9 fs mkdir :%s\n  Then retry:\n    drive9 mount :%s <mountpoint>", remoteRoot, remoteRoot, remoteRoot)
+			}
+			// Stat may fail on backends where directory stat is unsupported
+			// (non-404 error). Fall back to List to verify existence.
 			if _, listErr := c.List(remoteRoot); listErr != nil {
 				if client.IsNotFound(listErr) {
 					return fmt.Errorf("drive9 mount: remote source %q does not exist\n\n  To create it first:\n    drive9 fs mkdir :%s\n  Then retry:\n    drive9 mount :%s <mountpoint>", remoteRoot, remoteRoot, remoteRoot)


### PR DESCRIPTION
## Summary
- Cherry-pick of `8f036e4` from PR #366 branch that was not included in the squash merge
- When `Stat` explicitly returns 404, trust it immediately — don't fall back to `List` which may return empty success for non-existent paths (server List endpoint returns `200 + empty entries` for missing directories)
- Without this fix, `drive9 mount :/data` where `/data` doesn't exist passes CLI preflight validation and falls through to `mount_webdav`, resulting in `exit status 19 / ENODEV`

## What changed
- `validateRemoteRoot()`: Stat 404 → return actionable hint immediately, no List fallback
- FUSE `Mount()`: same Stat 404 trust logic
- Tests updated: mocks use `HEAD` method (matching actual `Stat` implementation), new test for "Stat 404 + List would succeed → still reports missing"

## Test plan
- [x] `go test -count=1 ./cmd/drive9/cli/...`
- [x] `go vet ./cmd/drive9/... ./pkg/fuse/...`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)