### PR TITLE
Limit text extraction before TiDB auto embedding

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -30,7 +30,13 @@ import (
 	"go.uber.org/zap"
 )
 
-const smallFileThreshold = 50_000 // 50,000 bytes — matches embedding model max input characters
+const (
+	smallFileThreshold = 50_000 // 50,000 bytes; controls DB-inline storage.
+	// TiDB auto embedding currently rejects inputs over 8192 tokens. Use a
+	// conservative byte cap for synchronous text extraction so text-heavy small
+	// files do not fail the whole write through the generated embedding column.
+	textExtractMaxBytes = 8_192
+)
 
 // Dat9Backend implements filesystem.FileSystem with the inode model.
 type Dat9Backend struct {
@@ -1100,7 +1106,7 @@ func extractText(data []byte, contentType string) string {
 		contentType != "application/yaml" {
 		return ""
 	}
-	if len(data) > smallFileThreshold {
+	if len(data) > textExtractMaxBytes {
 		return ""
 	}
 	return string(data)

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -189,6 +189,26 @@ func TestDat9BackendAutoSemanticTaskTypes(t *testing.T) {
 	})
 }
 
+func TestExtractTextUsesEmbeddingSafeLimit(t *testing.T) {
+	if textExtractMaxBytes >= smallFileThreshold {
+		t.Fatalf("textExtractMaxBytes=%d must stay below smallFileThreshold=%d", textExtractMaxBytes, smallFileThreshold)
+	}
+	exact := make([]byte, textExtractMaxBytes)
+	for i := range exact {
+		exact[i] = 'a'
+	}
+	if got := extractText(exact, "application/json"); len(got) != textExtractMaxBytes {
+		t.Fatalf("exact limit extracted length=%d, want %d", len(got), textExtractMaxBytes)
+	}
+	oversized := append(exact, 'a')
+	if got := extractText(oversized, "application/json"); got != "" {
+		t.Fatalf("oversized text should not be extracted, got length %d", len(got))
+	}
+	if got := extractText([]byte("hello"), "text/plain"); got != "hello" {
+		t.Fatalf("small text extracted as %q, want hello", got)
+	}
+}
+
 func TestWriteAndRead(t *testing.T) {
 	b := newTestBackend(t)
 	n, err := b.Write("/data/file.txt", []byte("hello world"), 0, filesystem.WriteFlagCreate)


### PR DESCRIPTION
## Summary
- split the DB-inline small-file threshold from synchronous semantic text extraction
- cap extracted text at 8192 bytes so TiDB auto embedding generated columns do not reject writes for token-heavy small files
- add a backend unit test for the extraction boundary

## Tests
- go test ./pkg/backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text extraction limits to prevent issues when processing large text content during synchronous extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->