### PR TITLE
Add structured image extraction tags

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -376,12 +376,12 @@ environment:
   DRIVE9_IMAGE_EXTRACT_WORKERS number of workers (default: 1)
   DRIVE9_IMAGE_EXTRACT_MAX_BYTES max image bytes processed per task (default: 8388608)
   DRIVE9_IMAGE_EXTRACT_TIMEOUT_SECONDS extractor timeout seconds (default: 20)
-  DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES max extracted text stored in files.content_text (default: 8192)
+  DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES max extracted text stored in files.content_text (default: 32768)
   DRIVE9_IMAGE_EXTRACT_API_BASE OpenAI-compatible base URL (optional)
   DRIVE9_IMAGE_EXTRACT_API_KEY  API key for DRIVE9_IMAGE_EXTRACT_API_BASE (optional)
   DRIVE9_IMAGE_EXTRACT_MODEL    model name for vision extraction (optional)
   DRIVE9_IMAGE_EXTRACT_PROMPT   custom extraction prompt (optional)
-  DRIVE9_IMAGE_EXTRACT_MAX_TOKENS max model output tokens (default: 256)
+  DRIVE9_IMAGE_EXTRACT_MAX_TOKENS max model output tokens (default: 4096)
 
   Async audio transcript extract (TiDB auto-embedding durable tasks):
   DRIVE9_AUDIO_EXTRACT_ENABLED true|false (default: false)
@@ -592,14 +592,14 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 			Workers:             envInt("DRIVE9_IMAGE_EXTRACT_WORKERS", 1),
 			MaxImageBytes:       envInt64("DRIVE9_IMAGE_EXTRACT_MAX_BYTES", 8<<20),
 			TaskTimeout:         time.Duration(envInt("DRIVE9_IMAGE_EXTRACT_TIMEOUT_SECONDS", 20)) * time.Second,
-			MaxExtractTextBytes: envInt("DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES", 8<<10),
+			MaxExtractTextBytes: envInt("DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES", backend.DefaultImageExtractMaxTextBytes),
 		}
 
 		baseURL := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_API_BASE"))
 		apiKey := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_API_KEY"))
 		model := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_MODEL"))
 		prompt := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_PROMPT"))
-		maxTokens := envInt("DRIVE9_IMAGE_EXTRACT_MAX_TOKENS", 256)
+		maxTokens := envInt("DRIVE9_IMAGE_EXTRACT_MAX_TOKENS", backend.DefaultOpenAIImageExtractMaxTokens)
 
 		configured := baseURL != "" || apiKey != "" || model != ""
 		if configured {

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -387,12 +387,12 @@ environment:
   DRIVE9_IMAGE_EXTRACT_WORKERS number of workers (default: 1)
   DRIVE9_IMAGE_EXTRACT_MAX_BYTES max image bytes processed per task (default: 8388608)
   DRIVE9_IMAGE_EXTRACT_TIMEOUT_SECONDS extractor timeout seconds (default: 20)
-  DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES max extracted text stored in files.content_text (default: 8192)
+  DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES max extracted text stored in files.content_text (default: 32768)
   DRIVE9_IMAGE_EXTRACT_API_BASE OpenAI-compatible base URL (optional)
   DRIVE9_IMAGE_EXTRACT_API_KEY  API key for DRIVE9_IMAGE_EXTRACT_API_BASE (optional)
   DRIVE9_IMAGE_EXTRACT_MODEL    model name for vision extraction (optional)
   DRIVE9_IMAGE_EXTRACT_PROMPT   custom extraction prompt (optional)
-  DRIVE9_IMAGE_EXTRACT_MAX_TOKENS max model output tokens (default: 256)
+  DRIVE9_IMAGE_EXTRACT_MAX_TOKENS max model output tokens (default: 4096)
 
   Audio extraction (async audio -> text for search; MVP durable path is TiDB auto-embedding only):
   Durable audio_extract_text tasks enqueue only for tenants with database auto-embedding
@@ -523,14 +523,14 @@ func buildImageExtractOptionsFromEnv() (backend.AsyncImageExtractOptions, error)
 		Workers:             envInt("DRIVE9_IMAGE_EXTRACT_WORKERS", 1),
 		MaxImageBytes:       envInt64("DRIVE9_IMAGE_EXTRACT_MAX_BYTES", 8<<20),
 		TaskTimeout:         time.Duration(envInt("DRIVE9_IMAGE_EXTRACT_TIMEOUT_SECONDS", 20)) * time.Second,
-		MaxExtractTextBytes: envInt("DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES", 8<<10),
+		MaxExtractTextBytes: envInt("DRIVE9_IMAGE_EXTRACT_MAX_TEXT_BYTES", backend.DefaultImageExtractMaxTextBytes),
 	}
 
 	baseURL := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_API_BASE"))
 	apiKey := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_API_KEY"))
 	model := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_MODEL"))
 	prompt := strings.TrimSpace(os.Getenv("DRIVE9_IMAGE_EXTRACT_PROMPT"))
-	maxTokens := envInt("DRIVE9_IMAGE_EXTRACT_MAX_TOKENS", 256)
+	maxTokens := envInt("DRIVE9_IMAGE_EXTRACT_MAX_TOKENS", backend.DefaultOpenAIImageExtractMaxTokens)
 
 	configured := baseURL != "" || apiKey != "" || model != ""
 	if configured {

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -282,8 +282,8 @@ func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExt
 		return ImageExtractResultExtractError, fmt.Errorf("extract image text: %w", err)
 	}
 	b.recordImageExtractUsage(task.FileID, imageUsage)
-	text = sanitizeExtractedText(text, b.maxExtractTextBytes)
-	if text == "" {
+	writeback := prepareImageExtractWriteback(text, b.maxExtractTextBytes)
+	if writeback.text == "" {
 		return ImageExtractResultEmptyText, nil
 	}
 
@@ -293,11 +293,17 @@ func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExt
 			return err
 		}
 		var txErr error
-		updated, txErr = b.store.UpdateFileSearchTextTx(tx, task.FileID, task.Revision, text)
+		updated, txErr = b.store.UpdateFileSearchTextTx(tx, task.FileID, task.Revision, writeback.text)
 		if txErr != nil {
 			return txErr
 		}
-		if !updated || b.UsesDatabaseAutoEmbedding() {
+		if !updated {
+			return nil
+		}
+		if txErr = b.store.ReplaceFileTagsByPrefixTx(tx, task.FileID, imageExtractTagPrefix, writeback.tags); txErr != nil {
+			return txErr
+		}
+		if b.UsesDatabaseAutoEmbedding() {
 			return nil
 		}
 		if err := injectedImageExtractWritebackError("imageExtractWritebackQueueEmbedTaskError"); err != nil {
@@ -388,6 +394,10 @@ func sanitizeExtractedText(in string, maxBytes int) string {
 	if maxBytes <= 0 || len(in) <= maxBytes {
 		return in
 	}
+	return truncateUTF8Bytes(in, maxBytes)
+}
+
+func truncateUTF8Bytes(in string, maxBytes int) string {
 	var (
 		total int
 		out   strings.Builder

--- a/pkg/backend/image_extract_openai.go
+++ b/pkg/backend/image_extract_openai.go
@@ -12,7 +12,30 @@ import (
 	"time"
 )
 
-const defaultImageExtractPrompt = "用中文描述这张图片，用于文件搜索。包括：主要物体、场景描述、图中可见文字（OCR）、简洁标签。最后一行用英文写5-10个关键词标签（English tags），用逗号分隔。"
+const (
+	defaultImageExtractPrompt = `请分析这张图片，输出用于 Drive9 文件搜索的结构化 JSON。只输出一个 JSON 对象，不要 Markdown，不要解释。字段固定为：
+{
+  "caption_zh": "中文一句话摘要，<=120字",
+  "description_zh": "中文详细描述，覆盖主体、场景、动作、颜色、构图、风格、时间/季节/地点线索，<=1200字",
+  "caption_en": "one concise English caption, <=30 words",
+  "description_en": "English description covering subjects, scene, action, colors, composition, style, time/season/location clues, <=260 words",
+  "ocr_text": ["图中可见文字；没有则空数组；最多100条，每条<=160字"],
+  "tags_zh": ["中文搜索标签，5-30个，短词，不要泛词"],
+  "tags_en": ["English search tags, 5-30, lowercase short phrases, no generic words like image/photo/picture/ocr/text"],
+  "search_queries_zh": ["中文自然搜索短语，3-12个"],
+  "search_queries_en": ["English natural search phrases, 3-12"]
+}
+要求：
+- 中英文都要覆盖可搜索信息，但不要逐字翻译造成重复堆砌。
+- 标签优先使用具体物体、场景、风格、颜色、季节、地点、动作、可见文字主题。
+- 若不确定不要编造；没有 OCR 就使用 []。
+- 整个 JSON 控制在 16000 字符以内。`
+
+	// DefaultOpenAIImageExtractMaxTokens leaves enough completion budget for
+	// structured bilingual extraction while the writeback path still enforces
+	// Drive9's embedding input safety limits.
+	DefaultOpenAIImageExtractMaxTokens = 4096
+)
 
 // OpenAIImageTextExtractorConfig configures an OpenAI-compatible vision endpoint.
 // This works with providers that expose the /v1/chat/completions API surface.
@@ -56,7 +79,7 @@ func NewOpenAIImageTextExtractor(cfg OpenAIImageTextExtractorConfig) (*OpenAIIma
 		cfg.Prompt = defaultImageExtractPrompt
 	}
 	if cfg.MaxTokens <= 0 {
-		cfg.MaxTokens = 256
+		cfg.MaxTokens = DefaultOpenAIImageExtractMaxTokens
 	}
 	client := cfg.Client
 	if client == nil {

--- a/pkg/backend/image_extract_structured.go
+++ b/pkg/backend/image_extract_structured.go
@@ -1,0 +1,359 @@
+package backend
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const (
+	imageExtractTagPrefix        = "drive9.image."
+	imageExtractStructuredSchema = "structured_v1"
+	imageExtractSource           = "image_extract"
+
+	maxStructuredImageExtractEstimatedTokens = 8000
+	maxImageExtractCaptionZHRuneCount        = 120
+	maxImageExtractDescriptionZHRuneCount    = 1200
+	maxImageExtractCaptionENRuneCount        = 240
+	maxImageExtractDescriptionENRuneCount    = 1800
+	maxImageExtractListItemRuneCount         = 160
+	maxImageExtractTagRuneCount              = 64
+	maxImageExtractOCRItems                  = 100
+	maxImageExtractTags                      = 30
+	maxImageExtractSearchQueries             = 12
+)
+
+type imageExtractWriteback struct {
+	text string
+	tags map[string]string
+}
+
+type structuredImageExtractResponse struct {
+	CaptionZH       string                 `json:"caption_zh"`
+	DescriptionZH   string                 `json:"description_zh"`
+	CaptionEN       string                 `json:"caption_en"`
+	DescriptionEN   string                 `json:"description_en"`
+	OCRText         imageExtractStringList `json:"ocr_text"`
+	TagsZH          imageExtractStringList `json:"tags_zh"`
+	TagsEN          imageExtractStringList `json:"tags_en"`
+	SearchQueriesZH imageExtractStringList `json:"search_queries_zh"`
+	SearchQueriesEN imageExtractStringList `json:"search_queries_en"`
+}
+
+type normalizedStructuredImageExtract struct {
+	captionZH       string
+	descriptionZH   string
+	captionEN       string
+	descriptionEN   string
+	ocrText         []string
+	tagsZH          []string
+	tagsEN          []string
+	searchQueriesZH []string
+	searchQueriesEN []string
+}
+
+type imageExtractStringList []string
+
+func (l *imageExtractStringList) UnmarshalJSON(data []byte) error {
+	if strings.EqualFold(strings.TrimSpace(string(data)), "null") {
+		*l = nil
+		return nil
+	}
+	var values []string
+	if err := json.Unmarshal(data, &values); err == nil {
+		*l = values
+		return nil
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err == nil {
+		if strings.TrimSpace(value) == "" {
+			*l = nil
+		} else {
+			*l = []string{value}
+		}
+		return nil
+	}
+	return nil
+}
+
+func prepareImageExtractWriteback(raw string, maxBytes int) imageExtractWriteback {
+	meta, ok := parseStructuredImageExtract(raw)
+	if !ok {
+		return imageExtractWriteback{
+			text: sanitizeExtractedText(raw, maxBytes),
+			tags: map[string]string{},
+		}
+	}
+
+	text := buildStructuredImageExtractText(meta)
+	text = truncateByEstimatedTokens(text, maxStructuredImageExtractEstimatedTokens)
+	text = sanitizeStructuredImageExtractText(text, maxBytes)
+	return imageExtractWriteback{
+		text: text,
+		tags: buildStructuredImageExtractTags(meta),
+	}
+}
+
+func parseStructuredImageExtract(raw string) (normalizedStructuredImageExtract, bool) {
+	candidate, ok := structuredImageExtractJSONCandidate(raw)
+	if !ok {
+		return normalizedStructuredImageExtract{}, false
+	}
+	var resp structuredImageExtractResponse
+	if err := json.Unmarshal([]byte(candidate), &resp); err != nil {
+		return normalizedStructuredImageExtract{}, false
+	}
+	meta := normalizeStructuredImageExtract(resp)
+	if meta.empty() {
+		return normalizedStructuredImageExtract{}, false
+	}
+	return meta, true
+}
+
+func structuredImageExtractJSONCandidate(raw string) (string, bool) {
+	text := strings.TrimSpace(strings.TrimPrefix(raw, "\ufeff"))
+	if text == "" {
+		return "", false
+	}
+	if strings.HasPrefix(text, "```") {
+		lines := strings.Split(text, "\n")
+		if len(lines) >= 2 && strings.HasPrefix(strings.TrimSpace(lines[0]), "```") {
+			lines = lines[1:]
+			if len(lines) > 0 && strings.HasPrefix(strings.TrimSpace(lines[len(lines)-1]), "```") {
+				lines = lines[:len(lines)-1]
+			}
+			text = strings.TrimSpace(strings.Join(lines, "\n"))
+		}
+	}
+	if strings.HasPrefix(text, "{") && strings.HasSuffix(text, "}") {
+		return text, true
+	}
+	start := strings.Index(text, "{")
+	end := strings.LastIndex(text, "}")
+	if start < 0 || end <= start {
+		return "", false
+	}
+	return text[start : end+1], true
+}
+
+func normalizeStructuredImageExtract(resp structuredImageExtractResponse) normalizedStructuredImageExtract {
+	return normalizedStructuredImageExtract{
+		captionZH:       cleanImageExtractField(resp.CaptionZH, maxImageExtractCaptionZHRuneCount),
+		descriptionZH:   cleanImageExtractField(resp.DescriptionZH, maxImageExtractDescriptionZHRuneCount),
+		captionEN:       cleanImageExtractField(resp.CaptionEN, maxImageExtractCaptionENRuneCount),
+		descriptionEN:   cleanImageExtractField(resp.DescriptionEN, maxImageExtractDescriptionENRuneCount),
+		ocrText:         cleanImageExtractList(resp.OCRText, maxImageExtractOCRItems, maxImageExtractListItemRuneCount),
+		tagsZH:          cleanImageExtractTags(resp.TagsZH, maxImageExtractTags, false),
+		tagsEN:          cleanImageExtractTags(resp.TagsEN, maxImageExtractTags, true),
+		searchQueriesZH: cleanImageExtractList(resp.SearchQueriesZH, maxImageExtractSearchQueries, maxImageExtractListItemRuneCount),
+		searchQueriesEN: cleanImageExtractList(resp.SearchQueriesEN, maxImageExtractSearchQueries, maxImageExtractListItemRuneCount),
+	}
+}
+
+func (m normalizedStructuredImageExtract) empty() bool {
+	return m.captionZH == "" &&
+		m.descriptionZH == "" &&
+		m.captionEN == "" &&
+		m.descriptionEN == "" &&
+		len(m.ocrText) == 0 &&
+		len(m.tagsZH) == 0 &&
+		len(m.tagsEN) == 0 &&
+		len(m.searchQueriesZH) == 0 &&
+		len(m.searchQueriesEN) == 0
+}
+
+func buildStructuredImageExtractText(meta normalizedStructuredImageExtract) string {
+	lines := make([]string, 0, 9)
+	addLine := func(label, value string) {
+		if value != "" {
+			lines = append(lines, label+"："+value)
+		}
+	}
+	addLine("中文摘要", meta.captionZH)
+	addLine("中文描述", meta.descriptionZH)
+	addLine("英文摘要", meta.captionEN)
+	addLine("英文描述", meta.descriptionEN)
+	if len(meta.ocrText) > 0 {
+		addLine("图中文字", strings.Join(meta.ocrText, "；"))
+	}
+	if len(meta.tagsZH) > 0 {
+		addLine("中文标签", strings.Join(meta.tagsZH, "，"))
+	}
+	if len(meta.tagsEN) > 0 {
+		addLine("英文标签", strings.Join(meta.tagsEN, ", "))
+	}
+	if len(meta.searchQueriesZH) > 0 {
+		addLine("中文搜索短语", strings.Join(meta.searchQueriesZH, "；"))
+	}
+	if len(meta.searchQueriesEN) > 0 {
+		addLine("英文搜索短语", strings.Join(meta.searchQueriesEN, "; "))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func sanitizeStructuredImageExtractText(in string, maxBytes int) string {
+	in = strings.TrimSpace(in)
+	if in == "" {
+		return ""
+	}
+	rawLines := strings.Split(in, "\n")
+	lines := make([]string, 0, len(rawLines))
+	for _, line := range rawLines {
+		line = strings.Join(strings.Fields(strings.TrimSpace(line)), " ")
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	text := strings.Join(lines, "\n")
+	if maxBytes <= 0 || len(text) <= maxBytes {
+		return text
+	}
+	return truncateUTF8Bytes(text, maxBytes)
+}
+
+func buildStructuredImageExtractTags(meta normalizedStructuredImageExtract) map[string]string {
+	tags := map[string]string{
+		imageExtractTagPrefix + "schema": imageExtractStructuredSchema,
+		imageExtractTagPrefix + "source": imageExtractSource,
+	}
+	for i, tag := range meta.tagsZH {
+		tags[imageExtractTagPrefix+"tag.zh."+strconv.Itoa(i)] = tag
+	}
+	for i, tag := range meta.tagsEN {
+		tags[imageExtractTagPrefix+"tag.en."+strconv.Itoa(i)] = tag
+	}
+	return tags
+}
+
+func cleanImageExtractList(values []string, maxItems int, maxRunes int) []string {
+	if maxItems <= 0 {
+		return nil
+	}
+	out := make([]string, 0, min(len(values), maxItems))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		cleaned := cleanImageExtractField(value, maxRunes)
+		if cleaned == "" {
+			continue
+		}
+		key := strings.ToLower(cleaned)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, cleaned)
+		if len(out) >= maxItems {
+			break
+		}
+	}
+	return out
+}
+
+func cleanImageExtractTags(values []string, maxItems int, lowercase bool) []string {
+	if maxItems <= 0 {
+		return nil
+	}
+	out := make([]string, 0, min(len(values), maxItems))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		cleaned := cleanImageExtractTag(value, lowercase)
+		if cleaned == "" || isGenericImageExtractTag(cleaned) {
+			continue
+		}
+		key := strings.ToLower(cleaned)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, cleaned)
+		if len(out) >= maxItems {
+			break
+		}
+	}
+	return out
+}
+
+func cleanImageExtractTag(value string, lowercase bool) string {
+	value = strings.TrimSpace(value)
+	value = strings.Trim(value, `"'“”‘’.,;:!?()[]{}<>#|`)
+	value = strings.ReplaceAll(value, "_", " ")
+	value = strings.Join(strings.Fields(value), " ")
+	if lowercase {
+		value = strings.ToLower(value)
+	}
+	return truncateRunes(value, maxImageExtractTagRuneCount)
+}
+
+func cleanImageExtractField(value string, maxRunes int) string {
+	value = strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+	if value == "" {
+		return ""
+	}
+	return truncateRunes(value, maxRunes)
+}
+
+func truncateRunes(value string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	return strings.TrimSpace(string(runes[:maxRunes]))
+}
+
+func isGenericImageExtractTag(tag string) bool {
+	switch strings.ToLower(strings.TrimSpace(tag)) {
+	case "image", "photo", "picture", "pic", "photograph", "ocr", "text", "visible text", "caption", "description", "tag", "tags", "file",
+		"图片", "图像", "照片", "文字", "标签", "描述":
+		return true
+	default:
+		return false
+	}
+}
+
+func truncateByEstimatedTokens(value string, maxTokens int) string {
+	if maxTokens <= 0 || estimateImageExtractTokens(value) <= maxTokens {
+		return value
+	}
+	runes := []rune(value)
+	lo, hi := 0, len(runes)
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if estimateImageExtractTokens(string(runes[:mid])) <= maxTokens {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return strings.TrimSpace(string(runes[:lo]))
+}
+
+func estimateImageExtractTokens(value string) int {
+	var tokens int
+	var asciiRunes int
+	flushASCII := func() {
+		if asciiRunes > 0 {
+			tokens += (asciiRunes + 3) / 4
+			asciiRunes = 0
+		}
+	}
+	for _, r := range value {
+		if r <= unicode.MaxASCII && (unicode.IsLetter(r) || unicode.IsDigit(r)) {
+			asciiRunes++
+			continue
+		}
+		flushASCII()
+		if unicode.IsSpace(r) {
+			continue
+		}
+		tokens++
+	}
+	flushASCII()
+	if tokens == 0 && strings.TrimSpace(value) != "" {
+		return 1
+	}
+	return tokens
+}

--- a/pkg/backend/image_extract_structured_test.go
+++ b/pkg/backend/image_extract_structured_test.go
@@ -1,0 +1,143 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrepareImageExtractWritebackStructuredJSON(t *testing.T) {
+	raw := `{
+  "caption_zh": "秋季林荫道路",
+  "description_zh": "一条蜿蜒柏油路穿过金黄色树林，阳光穿过树冠形成斑驳光影。",
+  "caption_en": "Autumn tree-lined road",
+  "description_en": "A winding asphalt road runs through tall trees with golden leaves and warm sunlight.",
+  "ocr_text": [],
+  "tags_zh": ["秋季", "林荫路", "树木", "金黄色", "暖色调", "照片"],
+  "tags_en": ["Autumn", "tree-lined road", "golden leaves", "warm light", "photo", "ocr"],
+  "search_queries_zh": ["秋天金黄色树林道路", "暖色调林荫路风景"],
+  "search_queries_en": ["autumn golden tree road", "warm tree-lined road landscape"]
+}`
+
+	writeback := prepareImageExtractWriteback(raw, 32<<10)
+	if writeback.text == "" {
+		t.Fatal("text is empty")
+	}
+	if strings.Contains(writeback.text, "caption_zh") || strings.Contains(writeback.text, "{") {
+		t.Fatalf("text should be canonical text, got %q", writeback.text)
+	}
+	if !strings.Contains(writeback.text, "秋季林荫道路\n中文描述") {
+		t.Fatalf("structured text should preserve line breaks, got %q", writeback.text)
+	}
+	for _, want := range []string{
+		"中文摘要：秋季林荫道路",
+		"中文描述：一条蜿蜒柏油路穿过金黄色树林",
+		"英文摘要：Autumn tree-lined road",
+		"英文标签：autumn, tree-lined road, golden leaves, warm light",
+		"中文搜索短语：秋天金黄色树林道路",
+	} {
+		if !strings.Contains(writeback.text, want) {
+			t.Fatalf("text %q does not contain %q", writeback.text, want)
+		}
+	}
+	if writeback.tags[imageExtractTagPrefix+"schema"] != imageExtractStructuredSchema {
+		t.Fatalf("schema tag=%q, want %q", writeback.tags[imageExtractTagPrefix+"schema"], imageExtractStructuredSchema)
+	}
+	if writeback.tags[imageExtractTagPrefix+"source"] != imageExtractSource {
+		t.Fatalf("source tag=%q, want %q", writeback.tags[imageExtractTagPrefix+"source"], imageExtractSource)
+	}
+	if got := writeback.tags[imageExtractTagPrefix+"tag.en.0"]; got != "autumn" {
+		t.Fatalf("tag.en.0=%q, want autumn", got)
+	}
+	if got := writeback.tags[imageExtractTagPrefix+"tag.en.3"]; got != "warm light" {
+		t.Fatalf("tag.en.3=%q, want warm light", got)
+	}
+	if _, ok := writeback.tags[imageExtractTagPrefix+"tag.en.4"]; ok {
+		t.Fatalf("generic English tags should be filtered, got %+v", writeback.tags)
+	}
+	if _, ok := writeback.tags[imageExtractTagPrefix+"tag.zh.5"]; ok {
+		t.Fatalf("generic Chinese tags should be filtered, got %+v", writeback.tags)
+	}
+}
+
+func TestOpenAIImageTextExtractorStructuredDefaults(t *testing.T) {
+	extractor, err := NewOpenAIImageTextExtractor(OpenAIImageTextExtractorConfig{
+		BaseURL: "https://example.com/v1",
+		APIKey:  "secret",
+		Model:   "vision-model",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if extractor.maxTokens != DefaultOpenAIImageExtractMaxTokens {
+		t.Fatalf("maxTokens=%d, want %d", extractor.maxTokens, DefaultOpenAIImageExtractMaxTokens)
+	}
+	if !strings.Contains(extractor.prompt, `"caption_zh"`) || !strings.Contains(extractor.prompt, `"tags_en"`) {
+		t.Fatalf("default prompt is not structured JSON prompt: %q", extractor.prompt)
+	}
+}
+
+func TestPrepareImageExtractWritebackParsesMarkdownFencedJSON(t *testing.T) {
+	raw := "```json\n" + `{
+  "caption_zh": "白板会议",
+  "description_zh": "办公室里有人在白板前讨论。",
+  "caption_en": "Whiteboard meeting",
+  "description_en": "People discuss ideas in front of a whiteboard.",
+  "ocr_text": "Q2 Roadmap",
+  "tags_zh": ["白板", "会议"],
+  "tags_en": ["whiteboard", "meeting"],
+  "search_queries_zh": [],
+  "search_queries_en": []
+}` + "\n```"
+
+	writeback := prepareImageExtractWriteback(raw, 32<<10)
+	if !strings.Contains(writeback.text, "图中文字：Q2 Roadmap") {
+		t.Fatalf("expected OCR text in canonical output, got %q", writeback.text)
+	}
+	if got := writeback.tags[imageExtractTagPrefix+"tag.en.1"]; got != "meeting" {
+		t.Fatalf("tag.en.1=%q, want meeting", got)
+	}
+}
+
+func TestPrepareImageExtractWritebackFallbackRawText(t *testing.T) {
+	raw := "cat on sofa screenshot invoice"
+	writeback := prepareImageExtractWriteback(raw, 32<<10)
+	if writeback.text != raw {
+		t.Fatalf("text=%q, want %q", writeback.text, raw)
+	}
+	if len(writeback.tags) != 0 {
+		t.Fatalf("fallback tags=%+v, want empty", writeback.tags)
+	}
+}
+
+func TestPrepareImageExtractWritebackAppliesByteLimit(t *testing.T) {
+	raw := `{
+  "caption_zh": "很长的描述",
+  "description_zh": "` + strings.Repeat("秋", 200) + `",
+  "caption_en": "",
+  "description_en": "",
+  "ocr_text": [],
+  "tags_zh": ["秋季"],
+  "tags_en": ["autumn"],
+  "search_queries_zh": [],
+  "search_queries_en": []
+}`
+
+	writeback := prepareImageExtractWriteback(raw, 64)
+	if len(writeback.text) > 64 {
+		t.Fatalf("text length=%d, want <=64", len(writeback.text))
+	}
+	if writeback.tags[imageExtractTagPrefix+"tag.zh.0"] != "秋季" {
+		t.Fatalf("tags should still be generated after text truncation, got %+v", writeback.tags)
+	}
+}
+
+func TestTruncateByEstimatedTokens(t *testing.T) {
+	text := strings.Repeat("秋", 9000)
+	got := truncateByEstimatedTokens(text, 8000)
+	if estimateImageExtractTokens(got) > 8000 {
+		t.Fatalf("estimated tokens=%d, want <=8000", estimateImageExtractTokens(got))
+	}
+	if len([]rune(got)) != 8000 {
+		t.Fatalf("rune count=%d, want 8000", len([]rune(got)))
+	}
+}

--- a/pkg/backend/image_extract_test.go
+++ b/pkg/backend/image_extract_test.go
@@ -355,6 +355,117 @@ func TestProcessImageExtractTaskWritesContentTextAndQueuesEmbedTask(t *testing.T
 	}
 }
 
+func TestProcessImageExtractTaskStructuredJSONWritesCanonicalTextAndDrive9Tags(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: &staticImageExtractor{text: `{
+  "caption_zh": "秋季林荫道路",
+  "description_zh": "一条蜿蜒柏油路穿过金黄色树林。",
+  "caption_en": "Autumn tree-lined road",
+  "description_en": "A winding asphalt road runs through tall trees with golden leaves.",
+  "ocr_text": [],
+  "tags_zh": ["秋季", "林荫路"],
+  "tags_en": ["Autumn", "tree-lined road"],
+  "search_queries_zh": ["秋天金黄色树林道路"],
+  "search_queries_en": ["autumn golden tree road"]
+}`},
+		},
+	})
+
+	fileID := insertImageFileForExtractTest(t, b, "/img/structured.png", "image/png", []byte("fake-png"))
+	err := b.Store().InTx(context.Background(), func(tx *sql.Tx) error {
+		return b.Store().ReplaceFileTagsTx(tx, fileID, map[string]string{
+			"album":                  "Inbox",
+			"drive9.image.tag.en.0":  "old",
+			"drive9.thumbnail.ready": "true",
+		})
+	})
+	if err != nil {
+		t.Fatalf("seed tags: %v", err)
+	}
+
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/structured.png",
+		ContentType: "image/png",
+		Revision:    1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != ImageExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultWritten)
+	}
+
+	nf, err := b.Store().Stat(context.Background(), "/img/structured.png")
+	if err != nil || nf.File == nil {
+		t.Fatalf("stat /img/structured.png: %v", err)
+	}
+	if strings.Contains(nf.File.ContentText, "caption_zh") || !strings.Contains(nf.File.ContentText, "中文摘要：秋季林荫道路") {
+		t.Fatalf("unexpected semantic text: %q", nf.File.ContentText)
+	}
+	tags, err := b.Store().GetFileTags(context.Background(), fileID)
+	if err != nil {
+		t.Fatalf("GetFileTags: %v", err)
+	}
+	if tags["album"] != "Inbox" || tags["drive9.thumbnail.ready"] != "true" {
+		t.Fatalf("application tags were not preserved: %+v", tags)
+	}
+	if tags["drive9.image.schema"] != imageExtractStructuredSchema {
+		t.Fatalf("drive9.image.schema=%q, want %q", tags["drive9.image.schema"], imageExtractStructuredSchema)
+	}
+	if tags["drive9.image.tag.en.0"] != "autumn" || tags["drive9.image.tag.zh.1"] != "林荫路" {
+		t.Fatalf("unexpected drive9 image tags: %+v", tags)
+	}
+}
+
+func TestProcessImageExtractTaskFallbackTextClearsDrive9ImageTagsOnly(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 8,
+			Extractor: &staticImageExtractor{text: "cat on sofa screenshot invoice"},
+		},
+	})
+
+	fileID := insertImageFileForExtractTest(t, b, "/img/fallback-tags.png", "image/png", []byte("fake-png"))
+	err := b.Store().InTx(context.Background(), func(tx *sql.Tx) error {
+		return b.Store().ReplaceFileTagsTx(tx, fileID, map[string]string{
+			"album":                 "Inbox",
+			"drive9.image.schema":   imageExtractStructuredSchema,
+			"drive9.image.tag.en.0": "old",
+		})
+	})
+	if err != nil {
+		t.Fatalf("seed tags: %v", err)
+	}
+
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/fallback-tags.png",
+		ContentType: "image/png",
+		Revision:    1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != ImageExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultWritten)
+	}
+
+	tags, err := b.Store().GetFileTags(context.Background(), fileID)
+	if err != nil {
+		t.Fatalf("GetFileTags: %v", err)
+	}
+	if tags["album"] != "Inbox" || len(tags) != 1 {
+		t.Fatalf("tags after fallback writeback = %+v, want only album=Inbox", tags)
+	}
+}
+
 func TestProcessImageExtractTaskAutoEmbeddingSkipsEmbedBridge(t *testing.T) {
 	b := newTestBackendWithOptions(t, Options{
 		DatabaseAutoEmbedding: true,

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -16,13 +16,17 @@ const (
 	defaultImageExtractWorkers   = 1
 	defaultImageExtractMaxSize   = int64(8 << 20) // 8 MiB
 	defaultImageExtractTimeout   = 20 * time.Second
-	defaultMaxExtractedTextBytes = 8 << 10               // 8 KiB
-	defaultAudioExtractMaxSize   = int64(32 << 20)       // 32 MiB
-	defaultAudioExtractTimeout   = 2 * time.Minute
-	defaultMaxAudioExtractedTextBytes = 8 << 10          // 8 KiB
-	defaultMaxUploadBytes        = int64(10 * (1 << 30)) // 10 GiB
-	defaultMaxTenantStorageBytes = int64(50 * (1 << 30)) // 50 GiB
-	defaultMaxMediaLLMFiles      = int64(500)            // 500 media files per tenant
+	// DefaultImageExtractMaxTextBytes is the default stored semantic text cap
+	// for image extraction. The image writeback path also enforces an
+	// estimated-token cap before this byte cap is applied.
+	DefaultImageExtractMaxTextBytes   = 32 << 10 // 32 KiB
+	defaultMaxExtractedTextBytes      = DefaultImageExtractMaxTextBytes
+	defaultAudioExtractMaxSize        = int64(32 << 20) // 32 MiB
+	defaultAudioExtractTimeout        = 2 * time.Minute
+	defaultMaxAudioExtractedTextBytes = 8 << 10               // 8 KiB
+	defaultMaxUploadBytes             = int64(10 * (1 << 30)) // 10 GiB
+	defaultMaxTenantStorageBytes      = int64(50 * (1 << 30)) // 50 GiB
+	defaultMaxMediaLLMFiles           = int64(500)            // 500 media files per tenant
 	// defaultMaxMonthlyLLMCostMillicents is the per-tenant monthly LLM spend
 	// cap applied when no explicit budget is configured. $10.00 USD, expressed
 	// in millicents (0.001 cents; $10 = 1000 cents = 1_000_000 millicents).

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -512,6 +512,46 @@ func (s *Store) ReplaceFileTagsTx(db execer, fileID string, tags map[string]stri
 	return nil
 }
 
+// ReplaceFileTagsByPrefixTx replaces only tags whose key starts with prefix
+// inside an existing transaction.
+//
+// This is intended for system-owned tag namespaces. Passing an empty map clears
+// that namespace while preserving all other file tags.
+func (s *Store) ReplaceFileTagsByPrefixTx(db execer, fileID string, prefix string, tags map[string]string) error {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return fmt.Errorf("tag prefix is required")
+	}
+	pattern := likeLiteralPrefixPattern(prefix)
+	if _, err := db.Exec(`DELETE FROM file_tags WHERE file_id = ? AND tag_key LIKE ? ESCAPE '\\'`, fileID, pattern); err != nil {
+		return err
+	}
+	if len(tags) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		if !strings.HasPrefix(k, prefix) {
+			return fmt.Errorf("tag key %q does not match prefix %q", k, prefix)
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		if _, err := db.Exec(`INSERT INTO file_tags (file_id, tag_key, tag_value) VALUES (?, ?, ?)`, fileID, k, tags[k]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func likeLiteralPrefixPattern(prefix string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return replacer.Replace(prefix) + "%"
+}
+
 // GetFileTags returns all tags for fileID.
 func (s *Store) GetFileTags(ctx context.Context, fileID string) (out map[string]string, err error) {
 	start := time.Now()

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -438,6 +438,75 @@ func TestReplaceFileTagsTxAndGetFileTags(t *testing.T) {
 	}
 }
 
+func TestReplaceFileTagsByPrefixTxPreservesOtherTags(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now()
+	if err := s.InsertFile(context.Background(), &File{
+		FileID:      "f-prefix-tags",
+		StorageType: StorageDB9,
+		StorageRef:  "inline",
+		Revision:    1,
+		Status:      StatusConfirmed,
+		CreatedAt:   now,
+		ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := s.InTx(context.Background(), func(tx *sql.Tx) error {
+		return s.ReplaceFileTagsTx(tx, "f-prefix-tags", map[string]string{
+			"album":                  "Inbox",
+			"drive9.image.schema":    "old_schema",
+			"drive9.image.tag.en.0":  "old",
+			"drive9.thumbnail.ready": "true",
+		})
+	})
+	if err != nil {
+		t.Fatalf("ReplaceFileTagsTx(initial): %v", err)
+	}
+
+	err = s.InTx(context.Background(), func(tx *sql.Tx) error {
+		return s.ReplaceFileTagsByPrefixTx(tx, "f-prefix-tags", "drive9.image.", map[string]string{
+			"drive9.image.schema":   "structured_v1",
+			"drive9.image.tag.en.0": "autumn road",
+		})
+	})
+	if err != nil {
+		t.Fatalf("ReplaceFileTagsByPrefixTx(replace): %v", err)
+	}
+	tags, err := s.GetFileTags(context.Background(), "f-prefix-tags")
+	if err != nil {
+		t.Fatalf("GetFileTags(replace): %v", err)
+	}
+	want := map[string]string{
+		"album":                  "Inbox",
+		"drive9.image.schema":    "structured_v1",
+		"drive9.image.tag.en.0":  "autumn road",
+		"drive9.thumbnail.ready": "true",
+	}
+	if fmt.Sprint(tags) != fmt.Sprint(want) {
+		t.Fatalf("tags after prefix replace = %+v, want %+v", tags, want)
+	}
+
+	err = s.InTx(context.Background(), func(tx *sql.Tx) error {
+		return s.ReplaceFileTagsByPrefixTx(tx, "f-prefix-tags", "drive9.image.", nil)
+	})
+	if err != nil {
+		t.Fatalf("ReplaceFileTagsByPrefixTx(clear): %v", err)
+	}
+	tags, err = s.GetFileTags(context.Background(), "f-prefix-tags")
+	if err != nil {
+		t.Fatalf("GetFileTags(clear): %v", err)
+	}
+	want = map[string]string{
+		"album":                  "Inbox",
+		"drive9.thumbnail.ready": "true",
+	}
+	if fmt.Sprint(tags) != fmt.Sprint(want) {
+		t.Fatalf("tags after prefix clear = %+v, want %+v", tags, want)
+	}
+}
+
 func TestZeroCopyCp(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -484,7 +485,7 @@ func TestReplaceFileTagsByPrefixTxPreservesOtherTags(t *testing.T) {
 		"drive9.image.tag.en.0":  "autumn road",
 		"drive9.thumbnail.ready": "true",
 	}
-	if fmt.Sprint(tags) != fmt.Sprint(want) {
+	if !reflect.DeepEqual(tags, want) {
 		t.Fatalf("tags after prefix replace = %+v, want %+v", tags, want)
 	}
 
@@ -502,7 +503,7 @@ func TestReplaceFileTagsByPrefixTxPreservesOtherTags(t *testing.T) {
 		"album":                  "Inbox",
 		"drive9.thumbnail.ready": "true",
 	}
-	if fmt.Sprint(tags) != fmt.Sprint(want) {
+	if !reflect.DeepEqual(tags, want) {
 		t.Fatalf("tags after prefix clear = %+v, want %+v", tags, want)
 	}
 }


### PR DESCRIPTION
## Summary
- make image extraction use structured bilingual JSON by default
- convert structured output into formatted semantic_text without changing the API shape
- write extracted image tags under the drive9.image.* namespace while preserving app tags
- add token/byte safeguards for TiDB auto embedding input limits

## Tests
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image text extraction now outputs structured JSON with bilingual captions, descriptions, OCR text, and auto-generated tags for improved search and organization.
  * Increased default extraction limits (32 KB text, 4096 tokens) to enhance quality and completeness of extracted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->