### PR TITLE
fix: WebDAV mount fails on macOS — root stat 404 and readiness timeout

### DIFF
--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -145,7 +145,7 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 		srvErr <- srv.Serve(ln)
 	}()
 
-	readyCtx, readyCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	if err := waitForWebDAVReady(readyCtx, serverURL); err != nil {
 		readyCancel()
 		_ = srv.Close()
@@ -281,7 +281,7 @@ func newWebDAVNoncePrefix() (string, error) {
 }
 
 func waitForWebDAVReady(ctx context.Context, serverURL string) error {
-	client := http.Client{Timeout: 200 * time.Millisecond}
+	client := http.Client{Timeout: 5 * time.Second}
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 

--- a/pkg/webdav/fs.go
+++ b/pkg/webdav/fs.go
@@ -65,6 +65,17 @@ func (f *fileSystem) OpenFile(ctx context.Context, name string, flag int, perm o
 		return &writeFile{client: f.client, path: remote, props: f.deadProps()}, nil
 	}
 
+	// The drive9 API does not support stat on "/". For root, skip stat
+	// and list directly since we know it's a directory.
+	if remote == "/" {
+		entries, err := f.client.ListCtx(ctx, remote)
+		if err != nil {
+			return nil, mapError(err)
+		}
+		rootStat := &client.StatResult{IsDir: true}
+		return &dirFile{path: local, propPath: remote, props: f.deadProps(), stat: rootStat, entries: entries}, nil
+	}
+
 	// Stat to determine if it's a directory or file.
 	stat, err := f.client.StatCtx(ctx, remote)
 	if err != nil {
@@ -125,6 +136,13 @@ func (f *fileSystem) Rename(ctx context.Context, oldName, newName string) error 
 func (f *fileSystem) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 	local := normPath(name)
 	remote := mountpath.ToRemote(f.remoteRoot, local)
+
+	// The drive9 API does not support stat on the root path "/".
+	// Return a synthetic directory entry so WebDAV PROPFIND on "/" works.
+	if remote == "/" {
+		return &fileInfo{name: "/", stat: &client.StatResult{IsDir: true}}, nil
+	}
+
 	stat, err := f.client.StatCtx(ctx, remote)
 	if err != nil {
 		return nil, mapError(err)


### PR DESCRIPTION
## Summary

- WebDAV mount (`drive9 mount -mode webdav`) was broken on macOS — `mount_webdav` failed with ENODEV (exit 19)
- **Root cause 1**: drive9 API returns 404 for `stat /`. WebDAV handler called `StatCtx("/")` during PROPFIND, resulting in 405 → `mount_webdav` rejected the mount
- **Root cause 2**: `waitForWebDAVReady` used 200ms HTTP client timeout, but the handler round-trips to drive9 API (~1.6s latency), so the 2s context deadline expired before a successful probe
- **Fix**: Synthetic root directory entries for `/` (skip API stat), increased readiness timeouts (5s client, 10s deadline)

## Test plan

- [x] `drive9 mount -mode webdav ~/drive9-mount` succeeds on macOS 14.8
- [x] `ls ~/drive9-mount/` lists remote files
- [x] `cat ~/drive9-mount/<file>` reads file content correctly
- [x] `go test ./pkg/webdav/...` passes
- [x] `go test ./cmd/drive9/cli/...` passes (mount-related tests)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved WebDAV startup stability with extended timeout values during service initialization.
  * Enhanced startup reliability by increasing HTTP request timeouts for readiness verification checks.
  * Fixed root directory handling in WebDAV mount operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->