### PR TITLE
fix: server-side stat root for WebDAV mount

### DIFF
--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -145,7 +145,7 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 		srvErr <- srv.Serve(ln)
 	}()
 
-	readyCtx, readyCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	if err := waitForWebDAVReady(readyCtx, serverURL); err != nil {
 		readyCancel()
 		_ = srv.Close()
@@ -281,7 +281,7 @@ func newWebDAVNoncePrefix() (string, error) {
 }
 
 func waitForWebDAVReady(ctx context.Context, serverURL string) error {
-	client := http.Client{Timeout: 200 * time.Millisecond}
+	client := http.Client{Timeout: 5 * time.Second}
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1026,6 +1026,19 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
+
+	// Root "/" is an implicit directory that has no file_nodes row.
+	// Return a synthetic stat response so clients (WebDAV mount, SDK)
+	// can stat the root like any other directory.
+	if path == "/" {
+		w.Header().Set("Content-Length", "0")
+		w.Header().Set("X-Dat9-IsDir", "true")
+		w.Header().Set("X-Dat9-Mtime", "0")
+		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "stat_ok", "path", path, "is_dir", true)...)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	logger.InfoBenchTiming(r.Context(), "server_stat_start", zap.String("path", path))
 	statStart := time.Now()
 	nf, err := b.StatNodeLiteCtx(r.Context(), path)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -604,6 +604,29 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
+	// Root "/" is an implicit directory with no file_nodes row.
+	if path == "/" {
+		zero := int64(0)
+		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "stat_metadata_ok", "path", path, "is_dir", true)...)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Dat9-Mtime", "0")
+		_ = json.NewEncoder(w).Encode(struct {
+			Size         int64             `json:"size"`
+			IsDir        bool              `json:"isdir"`
+			ResourceID   string            `json:"resource_id"`
+			Revision     int64             `json:"revision"`
+			Mtime        *int64            `json:"mtime,omitempty"`
+			ContentType  string            `json:"content_type"`
+			SemanticText string            `json:"semantic_text"`
+			Tags         map[string]string `json:"tags"`
+		}{
+			IsDir: true,
+			Mtime: &zero,
+			Tags:  make(map[string]string),
+		})
+		return
+	}
+
 	nf, err := b.StatNodeCtx(r.Context(), path)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -488,7 +488,7 @@ func TestStatMetadataRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		t.Fatalf("stat metadata root: expected 200, got %d", resp.StatusCode)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -478,6 +478,36 @@ func TestStatRoot(t *testing.T) {
 	}
 }
 
+func TestStatMetadataRoot(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/?stat=1", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("stat metadata root: expected 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		IsDir bool              `json:"isdir"`
+		Mtime *int64            `json:"mtime"`
+		Tags  map[string]string `json:"tags"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.IsDir {
+		t.Error("expected isdir true")
+	}
+	if body.Mtime == nil || *body.Mtime != 0 {
+		t.Errorf("expected mtime 0, got %v", body.Mtime)
+	}
+}
+
 func TestStatDirectoryWithoutTrailingSlash(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -456,6 +456,28 @@ func TestWriteRejectsTagsOnLegacyLargeFileInitiate(t *testing.T) {
 	}
 }
 
+func TestStatRoot(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("stat root: expected 200, got %d", resp.StatusCode)
+	}
+	if resp.Header.Get("X-Dat9-IsDir") != "true" {
+		t.Errorf("expected X-Dat9-IsDir true, got %s", resp.Header.Get("X-Dat9-IsDir"))
+	}
+	if resp.Header.Get("Content-Length") != "0" {
+		t.Errorf("expected Content-Length 0, got %s", resp.Header.Get("Content-Length"))
+	}
+}
+
 func TestStatDirectoryWithoutTrailingSlash(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary
- Return synthetic directory response for `stat /` in `handleStat` before querying the datastore, since root `/` has no `file_nodes` row
- This fixes WebDAV mount failure (ENODEV exit 19) where `mount_webdav` sends PROPFIND to root → stat("/") → 404 → mount rejected
- Increase WebDAV readiness probe timeouts for higher-latency environments (200ms→5s client, 2s→10s deadline)

## Root Cause
Root `/` is an implicit directory — no row exists in `file_nodes`. `StatLite("/")` returns `ErrNotFound`, which the server maps to HTTP 404. The WebDAV handler then fails the PROPFIND, and macOS `mount_webdav` rejects the mount with ENODEV.

## Fix
Handle `path == "/"` in `handleStat` before the datastore query, returning `X-Dat9-IsDir: true` with `Content-Length: 0`. This is consistent with Unix/Plan 9 semantics where root always exists.

## Test plan
- [ ] `TestStatRoot` verifies `HEAD /v1/fs/` returns 200 with correct headers
- [ ] Existing `TestStatDirectory*` tests still pass
- [ ] Manual: `drive9 mount ~/drive9` succeeds on macOS

Supersedes #373 (client-side workaround — this is the proper server-side fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)