### PR TITLE
feat: add explicit S3 encryption options

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -169,7 +169,7 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + fileID
-		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(nil), 0); err != nil {
+		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(nil), 0, s3client.EncryptionOpts{}); err != nil {
 			logger.Error(ctx, "backend_create_put_object_failed", zap.String("path", path), zap.String("storage_ref", storageRef), zap.Error(err))
 			return fmt.Errorf("put object: %w", err)
 		}
@@ -429,7 +429,7 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + fileID
-		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(data), int64(len(data))); err != nil {
+		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(data), int64(len(data)), s3client.EncryptionOpts{}); err != nil {
 			logger.Error(ctx, "backend_create_and_write_put_object_failed", zap.String("path", path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(data)), zap.Error(err))
 			return 0, fmt.Errorf("put object: %w", err)
 		}
@@ -538,7 +538,7 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + b.genID()
-		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(finalData), int64(len(finalData))); err != nil {
+		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(finalData), int64(len(finalData)), s3client.EncryptionOpts{}); err != nil {
 			logger.Error(ctx, "backend_overwrite_put_object_failed", zap.String("path", nf.Node.Path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(finalData)), zap.Error(err))
 			return 0, 0, fmt.Errorf("put object: %w", err)
 		}

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -213,7 +213,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 	fileID := b.genID()
 	newS3Key := "blobs/" + fileID
 
-	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key, s3client.ChecksumAlgoSHA256)
+	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key, s3client.ChecksumAlgoSHA256, s3client.EncryptionOpts{})
 	if err != nil {
 		logger.Error(ctx, "backend_patch_upload_create_mpu_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))

--- a/pkg/backend/semantic_tasks_test.go
+++ b/pkg/backend/semantic_tasks_test.go
@@ -523,7 +523,7 @@ func TestWriteOverwriteDoesNotDeleteInlineMarkerObject(t *testing.T) {
 	if _, err := b.Write("/f", []byte("old"), 0, filesystem.WriteFlagCreate); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.S3().PutObject(context.Background(), "inline", bytes.NewReader([]byte("marker")), int64(len("marker"))); err != nil {
+	if err := b.S3().PutObject(context.Background(), "inline", bytes.NewReader([]byte("marker")), int64(len("marker")), s3client.EncryptionOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	large := bytes.Repeat([]byte("a"), 2<<20)

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -247,7 +247,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 	s3Key := "blobs/" + fileID
 
 	// Create S3 multipart upload — v1 uses CRC32C
-	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoCRC32C)
+	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoCRC32C, s3client.EncryptionOpts{})
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_create_multipart_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
@@ -414,7 +414,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 	// client doesn't send per-part checksums yet (ChecksumContract.Required=false).
 	// When #114 adds inline checksums, switch back to a concrete algorithm.
 	createMultipartStart := time.Now()
-	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoNone)
+	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoNone, s3client.EncryptionOpts{})
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_v2_create_multipart_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -410,6 +410,12 @@ func awsEncryptionFields(encOpts EncryptionOpts) (awsEncryptionFieldSet, error) 
 	case "", EncryptionModeLegacy, EncryptionModeNone:
 		return fields, nil
 	case EncryptionModeSSES3:
+		if encOpts.BucketKeyEnabled {
+			return fields, fmt.Errorf("bucket key is not supported for sse-s3 encryption")
+		}
+		if len(encOpts.EncryptionContext) != 0 {
+			return fields, fmt.Errorf("encryption context is not supported for sse-s3 encryption")
+		}
 		fields.serverSideEncryption = types.ServerSideEncryptionAes256
 		return fields, nil
 	case EncryptionModeSSEKMS:
@@ -418,9 +424,7 @@ func awsEncryptionFields(encOpts EncryptionOpts) (awsEncryptionFieldSet, error) 
 		}
 		fields.serverSideEncryption = types.ServerSideEncryptionAwsKms
 		fields.kmsKeyID = aws.String(encOpts.KMSKeyID)
-		if encOpts.BucketKeyEnabled {
-			fields.bucketKeyEnabled = aws.Bool(true)
-		}
+		fields.bucketKeyEnabled = aws.Bool(encOpts.BucketKeyEnabled)
 	case EncryptionModeDSSEKMS:
 		if encOpts.KMSKeyID == "" {
 			return fields, fmt.Errorf("dsse-kms encryption requires KMS key ID")

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -2,6 +2,8 @@ package s3client
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -152,10 +154,13 @@ func (c *AWSS3Client) fullKey(key string) string {
 	return c.prefix + key
 }
 
-func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo) (*MultipartUpload, error) {
+func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo, encOpts EncryptionOpts) (*MultipartUpload, error) {
 	in := &s3.CreateMultipartUploadInput{
 		Bucket: &c.bucket,
 		Key:    aws.String(c.fullKey(key)),
+	}
+	if err := applyEncryptionToCreateMultipartUploadInput(in, encOpts); err != nil {
+		return nil, err
 	}
 	awsAlgo, ok, err := checksumAlgorithmForAWS(algo)
 	if err != nil {
@@ -345,17 +350,106 @@ func (c *AWSS3Client) PresignGetObject(ctx context.Context, key string, ttl time
 	return out.URL, nil
 }
 
-func (c *AWSS3Client) PutObject(ctx context.Context, key string, body io.Reader, size int64) error {
-	_, err := c.client.PutObject(ctx, &s3.PutObjectInput{
+func (c *AWSS3Client) PutObject(ctx context.Context, key string, body io.Reader, size int64, encOpts EncryptionOpts) error {
+	in := &s3.PutObjectInput{
 		Bucket:        &c.bucket,
 		Key:           aws.String(c.fullKey(key)),
 		Body:          body,
 		ContentLength: aws.Int64(size),
-	})
+	}
+	if err := applyEncryptionToPutObjectInput(in, encOpts); err != nil {
+		return err
+	}
+	_, err := c.client.PutObject(ctx, in)
 	if err != nil {
 		return fmt.Errorf("put object: %w", err)
 	}
 	return nil
+}
+
+func applyEncryptionToCreateMultipartUploadInput(in *s3.CreateMultipartUploadInput, encOpts EncryptionOpts) error {
+	fields, err := awsEncryptionFields(encOpts)
+	if err != nil {
+		return err
+	}
+	if fields.serverSideEncryption == "" {
+		return nil
+	}
+	in.ServerSideEncryption = fields.serverSideEncryption
+	in.SSEKMSKeyId = fields.kmsKeyID
+	in.BucketKeyEnabled = fields.bucketKeyEnabled
+	in.SSEKMSEncryptionContext = fields.encryptionContext
+	return nil
+}
+
+func applyEncryptionToPutObjectInput(in *s3.PutObjectInput, encOpts EncryptionOpts) error {
+	fields, err := awsEncryptionFields(encOpts)
+	if err != nil {
+		return err
+	}
+	if fields.serverSideEncryption == "" {
+		return nil
+	}
+	in.ServerSideEncryption = fields.serverSideEncryption
+	in.SSEKMSKeyId = fields.kmsKeyID
+	in.BucketKeyEnabled = fields.bucketKeyEnabled
+	in.SSEKMSEncryptionContext = fields.encryptionContext
+	return nil
+}
+
+type awsEncryptionFieldSet struct {
+	serverSideEncryption types.ServerSideEncryption
+	kmsKeyID             *string
+	bucketKeyEnabled     *bool
+	encryptionContext    *string
+}
+
+func awsEncryptionFields(encOpts EncryptionOpts) (awsEncryptionFieldSet, error) {
+	var fields awsEncryptionFieldSet
+	switch encOpts.Mode {
+	case "", EncryptionModeLegacy, EncryptionModeNone:
+		return fields, nil
+	case EncryptionModeSSES3:
+		fields.serverSideEncryption = types.ServerSideEncryptionAes256
+		return fields, nil
+	case EncryptionModeSSEKMS:
+		if encOpts.KMSKeyID == "" {
+			return fields, fmt.Errorf("sse-kms encryption requires KMS key ID")
+		}
+		fields.serverSideEncryption = types.ServerSideEncryptionAwsKms
+		fields.kmsKeyID = aws.String(encOpts.KMSKeyID)
+		if encOpts.BucketKeyEnabled {
+			fields.bucketKeyEnabled = aws.Bool(true)
+		}
+	case EncryptionModeDSSEKMS:
+		if encOpts.KMSKeyID == "" {
+			return fields, fmt.Errorf("dsse-kms encryption requires KMS key ID")
+		}
+		if encOpts.BucketKeyEnabled {
+			return fields, fmt.Errorf("bucket key is not supported for dsse-kms encryption")
+		}
+		fields.serverSideEncryption = types.ServerSideEncryptionAwsKmsDsse
+		fields.kmsKeyID = aws.String(encOpts.KMSKeyID)
+	default:
+		return fields, fmt.Errorf("unsupported encryption mode: %q", encOpts.Mode)
+	}
+	contextValue, err := encodeKMSEncryptionContext(encOpts.EncryptionContext)
+	if err != nil {
+		return fields, err
+	}
+	fields.encryptionContext = contextValue
+	return fields, nil
+}
+
+func encodeKMSEncryptionContext(contextMap map[string]string) (*string, error) {
+	if len(contextMap) == 0 {
+		return nil, nil
+	}
+	payload, err := json.Marshal(contextMap)
+	if err != nil {
+		return nil, fmt.Errorf("encode KMS encryption context: %w", err)
+	}
+	return aws.String(base64.StdEncoding.EncodeToString(payload)), nil
 }
 
 func (c *AWSS3Client) GetObject(ctx context.Context, key string) (io.ReadCloser, error) {

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -408,13 +408,13 @@ func awsEncryptionFields(encOpts EncryptionOpts) (awsEncryptionFieldSet, error) 
 	var fields awsEncryptionFieldSet
 	switch encOpts.Mode {
 	case "", EncryptionModeLegacy, EncryptionModeNone:
+		if err := rejectUnusedEncryptionFields(encOpts); err != nil {
+			return fields, err
+		}
 		return fields, nil
 	case EncryptionModeSSES3:
-		if encOpts.BucketKeyEnabled {
-			return fields, fmt.Errorf("bucket key is not supported for sse-s3 encryption")
-		}
-		if len(encOpts.EncryptionContext) != 0 {
-			return fields, fmt.Errorf("encryption context is not supported for sse-s3 encryption")
+		if err := rejectUnusedEncryptionFields(encOpts); err != nil {
+			return fields, err
 		}
 		fields.serverSideEncryption = types.ServerSideEncryptionAes256
 		return fields, nil
@@ -443,6 +443,26 @@ func awsEncryptionFields(encOpts EncryptionOpts) (awsEncryptionFieldSet, error) 
 	}
 	fields.encryptionContext = contextValue
 	return fields, nil
+}
+
+func rejectUnusedEncryptionFields(encOpts EncryptionOpts) error {
+	if encOpts.KMSKeyID != "" {
+		return fmt.Errorf("KMS key ID is not supported for %s encryption", noEncryptionModeLabel(encOpts.Mode))
+	}
+	if encOpts.BucketKeyEnabled {
+		return fmt.Errorf("bucket key is not supported for %s encryption", noEncryptionModeLabel(encOpts.Mode))
+	}
+	if len(encOpts.EncryptionContext) != 0 {
+		return fmt.Errorf("encryption context is not supported for %s encryption", noEncryptionModeLabel(encOpts.Mode))
+	}
+	return nil
+}
+
+func noEncryptionModeLabel(mode EncryptionMode) string {
+	if mode == "" {
+		return "zero-value"
+	}
+	return string(mode)
 }
 
 func encodeKMSEncryptionContext(contextMap map[string]string) (*string, error) {

--- a/pkg/s3client/aws_test.go
+++ b/pkg/s3client/aws_test.go
@@ -213,6 +213,24 @@ func TestApplyEncryptionSSES3(t *testing.T) {
 	}
 }
 
+func TestApplyEncryptionSSES3RejectsUnsupportedOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts EncryptionOpts
+	}{
+		{name: "bucket key", opts: EncryptionOpts{Mode: EncryptionModeSSES3, BucketKeyEnabled: true}},
+		{name: "encryption context", opts: EncryptionOpts{Mode: EncryptionModeSSES3, EncryptionContext: map[string]string{"tenant_id": "tenant-1"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := applyEncryptionToPutObjectInput(&s3.PutObjectInput{}, tt.opts)
+			if err == nil {
+				t.Fatal("apply encryption error = nil, want error")
+			}
+		})
+	}
+}
+
 func TestApplyEncryptionSSEKMS(t *testing.T) {
 	contextMap := map[string]string{
 		"tenant_id":  "tenant-1",
@@ -236,6 +254,23 @@ func TestApplyEncryptionSSEKMS(t *testing.T) {
 		t.Fatalf("apply create encryption error = %v", err)
 	}
 	assertSSEKMSHeaders(t, createInput.ServerSideEncryption, createInput.SSEKMSKeyId, createInput.BucketKeyEnabled, createInput.SSEKMSEncryptionContext, opts.KMSKeyID, contextMap)
+}
+
+func TestApplyEncryptionSSEKMSBucketKeyFalseIsExplicit(t *testing.T) {
+	input := &s3.PutObjectInput{}
+	err := applyEncryptionToPutObjectInput(input, EncryptionOpts{
+		Mode:     EncryptionModeSSEKMS,
+		KMSKeyID: "arn:aws:kms:ap-southeast-1:123456789012:key/test",
+	})
+	if err != nil {
+		t.Fatalf("apply encryption error = %v", err)
+	}
+	if input.BucketKeyEnabled == nil {
+		t.Fatal("BucketKeyEnabled = nil, want explicit false")
+	}
+	if aws.ToBool(input.BucketKeyEnabled) {
+		t.Fatal("BucketKeyEnabled = true, want false")
+	}
 }
 
 func TestApplyEncryptionDSSEKMS(t *testing.T) {

--- a/pkg/s3client/aws_test.go
+++ b/pkg/s3client/aws_test.go
@@ -180,15 +180,36 @@ func TestApplyEncryptionLegacyAndNoneNoop(t *testing.T) {
 	for _, mode := range []EncryptionMode{EncryptionModeLegacy, EncryptionModeNone} {
 		t.Run(string(mode), func(t *testing.T) {
 			input := &s3.PutObjectInput{}
-			err := applyEncryptionToPutObjectInput(input, EncryptionOpts{
-				Mode:             mode,
-				KMSKeyID:         "ignored",
-				BucketKeyEnabled: true,
-			})
+			err := applyEncryptionToPutObjectInput(input, EncryptionOpts{Mode: mode})
 			if err != nil {
 				t.Fatalf("apply encryption error = %v", err)
 			}
 			assertNoEncryptionHeaders(t, input.ServerSideEncryption, input.SSEKMSKeyId, input.BucketKeyEnabled, input.SSEKMSEncryptionContext)
+		})
+	}
+}
+
+func TestApplyEncryptionNoEncryptionModesRejectUnusedFields(t *testing.T) {
+	tests := []struct {
+		name string
+		opts EncryptionOpts
+	}{
+		{name: "zero value with key", opts: EncryptionOpts{KMSKeyID: "key"}},
+		{name: "zero value with bucket key", opts: EncryptionOpts{BucketKeyEnabled: true}},
+		{name: "zero value with context", opts: EncryptionOpts{EncryptionContext: map[string]string{"tenant_id": "tenant-1"}}},
+		{name: "legacy with key", opts: EncryptionOpts{Mode: EncryptionModeLegacy, KMSKeyID: "key"}},
+		{name: "legacy with bucket key", opts: EncryptionOpts{Mode: EncryptionModeLegacy, BucketKeyEnabled: true}},
+		{name: "legacy with context", opts: EncryptionOpts{Mode: EncryptionModeLegacy, EncryptionContext: map[string]string{"tenant_id": "tenant-1"}}},
+		{name: "none with key", opts: EncryptionOpts{Mode: EncryptionModeNone, KMSKeyID: "key"}},
+		{name: "none with bucket key", opts: EncryptionOpts{Mode: EncryptionModeNone, BucketKeyEnabled: true}},
+		{name: "none with context", opts: EncryptionOpts{Mode: EncryptionModeNone, EncryptionContext: map[string]string{"tenant_id": "tenant-1"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := applyEncryptionToPutObjectInput(&s3.PutObjectInput{}, tt.opts)
+			if err == nil {
+				t.Fatal("apply encryption error = nil, want error")
+			}
 		})
 	}
 }
@@ -218,6 +239,7 @@ func TestApplyEncryptionSSES3RejectsUnsupportedOptions(t *testing.T) {
 		name string
 		opts EncryptionOpts
 	}{
+		{name: "kms key", opts: EncryptionOpts{Mode: EncryptionModeSSES3, KMSKeyID: "key"}},
 		{name: "bucket key", opts: EncryptionOpts{Mode: EncryptionModeSSES3, BucketKeyEnabled: true}},
 		{name: "encryption context", opts: EncryptionOpts{Mode: EncryptionModeSSES3, EncryptionContext: map[string]string{"tenant_id": "tenant-1"}}},
 	}

--- a/pkg/s3client/aws_test.go
+++ b/pkg/s3client/aws_test.go
@@ -2,9 +2,13 @@ package s3client
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 func TestAWSConfigValidate(t *testing.T) {
@@ -155,5 +159,169 @@ func TestApplyS3Options(t *testing.T) {
 	}
 	if opts.UsePathStyle {
 		t.Fatal("UsePathStyle = true, want false")
+	}
+}
+
+func TestApplyEncryptionZeroValueNoop(t *testing.T) {
+	putInput := &s3.PutObjectInput{}
+	if err := applyEncryptionToPutObjectInput(putInput, EncryptionOpts{}); err != nil {
+		t.Fatalf("apply put encryption error = %v", err)
+	}
+	assertNoEncryptionHeaders(t, putInput.ServerSideEncryption, putInput.SSEKMSKeyId, putInput.BucketKeyEnabled, putInput.SSEKMSEncryptionContext)
+
+	createInput := &s3.CreateMultipartUploadInput{}
+	if err := applyEncryptionToCreateMultipartUploadInput(createInput, EncryptionOpts{}); err != nil {
+		t.Fatalf("apply create encryption error = %v", err)
+	}
+	assertNoEncryptionHeaders(t, createInput.ServerSideEncryption, createInput.SSEKMSKeyId, createInput.BucketKeyEnabled, createInput.SSEKMSEncryptionContext)
+}
+
+func TestApplyEncryptionLegacyAndNoneNoop(t *testing.T) {
+	for _, mode := range []EncryptionMode{EncryptionModeLegacy, EncryptionModeNone} {
+		t.Run(string(mode), func(t *testing.T) {
+			input := &s3.PutObjectInput{}
+			err := applyEncryptionToPutObjectInput(input, EncryptionOpts{
+				Mode:             mode,
+				KMSKeyID:         "ignored",
+				BucketKeyEnabled: true,
+			})
+			if err != nil {
+				t.Fatalf("apply encryption error = %v", err)
+			}
+			assertNoEncryptionHeaders(t, input.ServerSideEncryption, input.SSEKMSKeyId, input.BucketKeyEnabled, input.SSEKMSEncryptionContext)
+		})
+	}
+}
+
+func TestApplyEncryptionSSES3(t *testing.T) {
+	input := &s3.PutObjectInput{}
+	err := applyEncryptionToPutObjectInput(input, EncryptionOpts{Mode: EncryptionModeSSES3})
+	if err != nil {
+		t.Fatalf("apply encryption error = %v", err)
+	}
+	if input.ServerSideEncryption != types.ServerSideEncryptionAes256 {
+		t.Fatalf("ServerSideEncryption = %q, want %q", input.ServerSideEncryption, types.ServerSideEncryptionAes256)
+	}
+	if input.SSEKMSKeyId != nil {
+		t.Fatalf("SSEKMSKeyId = %q, want nil", aws.ToString(input.SSEKMSKeyId))
+	}
+	if input.BucketKeyEnabled != nil {
+		t.Fatalf("BucketKeyEnabled = %v, want nil", aws.ToBool(input.BucketKeyEnabled))
+	}
+	if input.SSEKMSEncryptionContext != nil {
+		t.Fatalf("SSEKMSEncryptionContext = %q, want nil", aws.ToString(input.SSEKMSEncryptionContext))
+	}
+}
+
+func TestApplyEncryptionSSEKMS(t *testing.T) {
+	contextMap := map[string]string{
+		"tenant_id":  "tenant-1",
+		"object_key": "blobs/object",
+	}
+	opts := EncryptionOpts{
+		Mode:              EncryptionModeSSEKMS,
+		KMSKeyID:          "arn:aws:kms:ap-southeast-1:123456789012:key/test",
+		BucketKeyEnabled:  true,
+		EncryptionContext: contextMap,
+	}
+
+	putInput := &s3.PutObjectInput{}
+	if err := applyEncryptionToPutObjectInput(putInput, opts); err != nil {
+		t.Fatalf("apply put encryption error = %v", err)
+	}
+	assertSSEKMSHeaders(t, putInput.ServerSideEncryption, putInput.SSEKMSKeyId, putInput.BucketKeyEnabled, putInput.SSEKMSEncryptionContext, opts.KMSKeyID, contextMap)
+
+	createInput := &s3.CreateMultipartUploadInput{}
+	if err := applyEncryptionToCreateMultipartUploadInput(createInput, opts); err != nil {
+		t.Fatalf("apply create encryption error = %v", err)
+	}
+	assertSSEKMSHeaders(t, createInput.ServerSideEncryption, createInput.SSEKMSKeyId, createInput.BucketKeyEnabled, createInput.SSEKMSEncryptionContext, opts.KMSKeyID, contextMap)
+}
+
+func TestApplyEncryptionDSSEKMS(t *testing.T) {
+	input := &s3.CreateMultipartUploadInput{}
+	err := applyEncryptionToCreateMultipartUploadInput(input, EncryptionOpts{
+		Mode:     EncryptionModeDSSEKMS,
+		KMSKeyID: "arn:aws:kms:ap-southeast-1:123456789012:key/test",
+	})
+	if err != nil {
+		t.Fatalf("apply encryption error = %v", err)
+	}
+	if input.ServerSideEncryption != types.ServerSideEncryptionAwsKmsDsse {
+		t.Fatalf("ServerSideEncryption = %q, want %q", input.ServerSideEncryption, types.ServerSideEncryptionAwsKmsDsse)
+	}
+	if aws.ToString(input.SSEKMSKeyId) != "arn:aws:kms:ap-southeast-1:123456789012:key/test" {
+		t.Fatalf("SSEKMSKeyId = %q, want test key", aws.ToString(input.SSEKMSKeyId))
+	}
+	if input.BucketKeyEnabled != nil {
+		t.Fatalf("BucketKeyEnabled = %v, want nil", aws.ToBool(input.BucketKeyEnabled))
+	}
+}
+
+func TestApplyEncryptionRejectsInvalidOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts EncryptionOpts
+	}{
+		{name: "sse kms missing key", opts: EncryptionOpts{Mode: EncryptionModeSSEKMS}},
+		{name: "dsse kms missing key", opts: EncryptionOpts{Mode: EncryptionModeDSSEKMS}},
+		{name: "dsse kms bucket key", opts: EncryptionOpts{Mode: EncryptionModeDSSEKMS, KMSKeyID: "key", BucketKeyEnabled: true}},
+		{name: "unknown mode", opts: EncryptionOpts{Mode: EncryptionMode("unknown")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := applyEncryptionToPutObjectInput(&s3.PutObjectInput{}, tt.opts)
+			if err == nil {
+				t.Fatal("apply encryption error = nil, want error")
+			}
+		})
+	}
+}
+
+func assertNoEncryptionHeaders(t *testing.T, mode types.ServerSideEncryption, keyID *string, bucketKey *bool, contextValue *string) {
+	t.Helper()
+	if mode != "" {
+		t.Fatalf("ServerSideEncryption = %q, want empty", mode)
+	}
+	if keyID != nil {
+		t.Fatalf("SSEKMSKeyId = %q, want nil", aws.ToString(keyID))
+	}
+	if bucketKey != nil {
+		t.Fatalf("BucketKeyEnabled = %v, want nil", aws.ToBool(bucketKey))
+	}
+	if contextValue != nil {
+		t.Fatalf("SSEKMSEncryptionContext = %q, want nil", aws.ToString(contextValue))
+	}
+}
+
+func assertSSEKMSHeaders(t *testing.T, mode types.ServerSideEncryption, keyID *string, bucketKey *bool, contextValue *string, wantKey string, wantContext map[string]string) {
+	t.Helper()
+	if mode != types.ServerSideEncryptionAwsKms {
+		t.Fatalf("ServerSideEncryption = %q, want %q", mode, types.ServerSideEncryptionAwsKms)
+	}
+	if aws.ToString(keyID) != wantKey {
+		t.Fatalf("SSEKMSKeyId = %q, want %q", aws.ToString(keyID), wantKey)
+	}
+	if !aws.ToBool(bucketKey) {
+		t.Fatal("BucketKeyEnabled = false, want true")
+	}
+	if contextValue == nil {
+		t.Fatal("SSEKMSEncryptionContext = nil, want encoded context")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(aws.ToString(contextValue))
+	if err != nil {
+		t.Fatalf("decode context: %v", err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(decoded, &got); err != nil {
+		t.Fatalf("unmarshal context: %v", err)
+	}
+	if len(got) != len(wantContext) {
+		t.Fatalf("context len = %d, want %d", len(got), len(wantContext))
+	}
+	for k, want := range wantContext {
+		if got[k] != want {
+			t.Fatalf("context[%q] = %q, want %q", k, got[k], want)
+		}
 	}
 }

--- a/pkg/s3client/local.go
+++ b/pkg/s3client/local.go
@@ -53,7 +53,7 @@ func (c *LocalS3Client) partPath(key, uploadID string, partNumber int) string {
 	return filepath.Join(c.rootDir, "parts", uploadID, fmt.Sprintf("%05d", partNumber))
 }
 
-func (c *LocalS3Client) CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo) (*MultipartUpload, error) {
+func (c *LocalS3Client) CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo, encOpts EncryptionOpts) (*MultipartUpload, error) {
 	uploadID := fmt.Sprintf("upload-%x", sha256.Sum256([]byte(key+time.Now().String())))[:24]
 
 	partsDir := filepath.Join(c.rootDir, "parts", uploadID)
@@ -206,7 +206,7 @@ func (c *LocalS3Client) PresignGetObject(ctx context.Context, key string, ttl ti
 	return url, nil
 }
 
-func (c *LocalS3Client) PutObject(ctx context.Context, key string, body io.Reader, size int64) error {
+func (c *LocalS3Client) PutObject(ctx context.Context, key string, body io.Reader, size int64, encOpts EncryptionOpts) error {
 	objPath := c.objectPath(key)
 	if err := os.MkdirAll(filepath.Dir(objPath), 0o755); err != nil {
 		return err

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -9,11 +9,31 @@ import (
 	"time"
 )
 
+// EncryptionMode identifies the storage encryption mode used for an object.
+type EncryptionMode string
+
+const (
+	EncryptionModeLegacy  EncryptionMode = "legacy"
+	EncryptionModeNone    EncryptionMode = "none"
+	EncryptionModeSSES3   EncryptionMode = "sse-s3"
+	EncryptionModeSSEKMS  EncryptionMode = "sse-kms"
+	EncryptionModeDSSEKMS EncryptionMode = "dsse-kms"
+)
+
+// EncryptionOpts describes server-side encryption for a single S3 write.
+// The zero value is a no-op: no SSE headers are sent.
+type EncryptionOpts struct {
+	Mode              EncryptionMode
+	KMSKeyID          string
+	BucketKeyEnabled  bool
+	EncryptionContext map[string]string
+}
+
 // ChecksumAlgo identifies the checksum algorithm for a multipart upload.
 type ChecksumAlgo string
 
 const (
-	ChecksumAlgoNone   ChecksumAlgo = ""       // no checksum algorithm declared
+	ChecksumAlgoNone   ChecksumAlgo = "" // no checksum algorithm declared
 	ChecksumAlgoSHA256 ChecksumAlgo = "SHA256"
 	ChecksumAlgoCRC32C ChecksumAlgo = "CRC32C"
 )
@@ -48,7 +68,7 @@ type MultipartUpload struct {
 // Implementations: LocalS3Client (testing), AWSS3Client (production).
 type S3Client interface {
 	// CreateMultipartUpload initiates a new multipart upload with the given checksum algorithm.
-	CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo) (*MultipartUpload, error)
+	CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo, encOpts EncryptionOpts) (*MultipartUpload, error)
 
 	// PresignUploadPart returns a presigned URL for uploading a specific part.
 	// partSize is bound into the presigned URL as Content-Length per §11.2.
@@ -69,7 +89,7 @@ type S3Client interface {
 	PresignGetObject(ctx context.Context, key string, ttl time.Duration) (string, error)
 
 	// PutObject uploads a small object directly (used for testing/fallback).
-	PutObject(ctx context.Context, key string, body io.Reader, size int64) error
+	PutObject(ctx context.Context, key string, body io.Reader, size int64, encOpts EncryptionOpts) error
 
 	// GetObject reads an object's contents.
 	GetObject(ctx context.Context, key string) (io.ReadCloser, error)

--- a/pkg/s3client/s3client_test.go
+++ b/pkg/s3client/s3client_test.go
@@ -60,7 +60,7 @@ func TestPutAndGetObject(t *testing.T) {
 	ctx := context.Background()
 
 	data := []byte("hello world")
-	if err := c.PutObject(ctx, "blobs/test1", bytes.NewReader(data), int64(len(data))); err != nil {
+	if err := c.PutObject(ctx, "blobs/test1", bytes.NewReader(data), int64(len(data)), EncryptionOpts{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -79,7 +79,7 @@ func TestDeleteObject(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()
 
-	if err := c.PutObject(ctx, "blobs/del", bytes.NewReader([]byte("x")), 1); err != nil {
+	if err := c.PutObject(ctx, "blobs/del", bytes.NewReader([]byte("x")), 1, EncryptionOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.DeleteObject(ctx, "blobs/del"); err != nil {
@@ -96,7 +96,7 @@ func TestMultipartUploadComplete(t *testing.T) {
 	ctx := context.Background()
 
 	// Initiate
-	upload, err := c.CreateMultipartUpload(ctx, "blobs/big1", ChecksumAlgoSHA256)
+	upload, err := c.CreateMultipartUpload(ctx, "blobs/big1", ChecksumAlgoSHA256, EncryptionOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestMultipartUploadAbort(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()
 
-	upload, err := c.CreateMultipartUpload(ctx, "blobs/aborted", ChecksumAlgoSHA256)
+	upload, err := c.CreateMultipartUpload(ctx, "blobs/aborted", ChecksumAlgoSHA256, EncryptionOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestPresignURLsGenerated(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()
 
-	upload, _ := c.CreateMultipartUpload(ctx, "blobs/presign-test", ChecksumAlgoSHA256)
+	upload, _ := c.CreateMultipartUpload(ctx, "blobs/presign-test", ChecksumAlgoSHA256, EncryptionOpts{})
 
 	url, err := c.PresignUploadPart(ctx, "blobs/presign-test", upload.UploadID, 1, 8<<20, ChecksumAlgoSHA256, "abc", UploadTTL)
 	if err != nil {
@@ -194,7 +194,7 @@ func TestPartialUploadAndListParts(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()
 
-	upload, _ := c.CreateMultipartUpload(ctx, "blobs/partial", ChecksumAlgoSHA256)
+	upload, _ := c.CreateMultipartUpload(ctx, "blobs/partial", ChecksumAlgoSHA256, EncryptionOpts{})
 
 	// Upload only parts 1 and 3 (skip 2 — simulates interrupted upload)
 	if _, err := c.UploadPart(ctx, upload.UploadID, 1, bytes.NewReader([]byte("PART1"))); err != nil {
@@ -222,7 +222,7 @@ func TestMultipartUploadNoChecksumAlgo(t *testing.T) {
 
 	// Initiate with ChecksumAlgoNone — simulates v2 uploads where
 	// the client doesn't send per-part checksums.
-	upload, err := c.CreateMultipartUpload(ctx, "blobs/no-checksum", ChecksumAlgoNone)
+	upload, err := c.CreateMultipartUpload(ctx, "blobs/no-checksum", ChecksumAlgoNone, EncryptionOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- Add `s3client.EncryptionOpts` with zero-value no-op contract
- Pass explicit encryption options through `PutObject` and `CreateMultipartUpload`
- Map SSE-S3, SSE-KMS, and DSSE-KMS options to AWS S3 write inputs while preserving empty opts behavior
- Update current callers to pass `EncryptionOpts{}` so behavior remains unchanged for PR 1 of Issue #375

## Issue #375 coverage
- Invariant #10: `EncryptionOpts{}` zero value sends no SSE headers
- PR 1 boundary only: no tenant resolver, DB schema, BYOK, backfill, or backend metadata integration yet

## Tests
- `/usr/local/go/bin/go test ./pkg/s3client`
- `/usr/local/go/bin/go test -c ./pkg/s3client`
- `/usr/local/go/bin/go test -c ./pkg/backend`
- `/usr/local/go/bin/go test -c ./pkg/...`

## Known local limitation
- `/usr/local/go/bin/go test ./pkg/backend -run ^$` is blocked on this host by `panic: rootless Docker not found` from testcontainers, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable S3 server-side encryption with multiple modes: SSE-S3, SSE-KMS, and DSSE-KMS, including KMS key ID and encryption context configuration.

* **Tests**
  * Added comprehensive unit tests for encryption option validation across different encryption modes and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->