### PR TITLE
feat: wire S3 encryption policy into backend writes

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -213,6 +213,15 @@ func main() {
 	}
 
 	stepStart = time.Now()
+	resolvedEncryptionPolicy, err := meta.ResolveS3EncryptionPolicy(
+		s3cfg.EncryptionPolicy,
+		meta.S3EncryptionPolicy{Mode: meta.S3EncryptionModeInherit},
+	)
+	if err != nil {
+		die(fmt.Errorf("resolve local s3 encryption policy: %w", err))
+	}
+	backendOpts.TenantID = "local-tenant"
+	backendOpts.S3EncryptionPolicy = resolvedEncryptionPolicy
 	b, err := backend.NewWithS3ModeAndOptions(store, s3c, true, backendOpts)
 	if err != nil {
 		die(fmt.Errorf("create local backend: %w", err))

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -204,18 +204,19 @@ func main() {
 		}
 
 		pool = tenant.NewPool(tenant.PoolConfig{
-			S3Dir:             s3cfg.Dir,
-			PublicURL:         publicBaseURL(addr),
-			S3Bucket:          s3cfg.Bucket,
-			S3Region:          s3cfg.Region,
-			S3Prefix:          s3cfg.Prefix,
-			S3RoleARN:         s3cfg.RoleARN,
-			S3Endpoint:        s3cfg.Endpoint,
-			S3ForcePathStyle:  s3cfg.ForcePathStyle,
-			S3AccessKeyID:     s3cfg.AccessKeyID,
-			S3SecretAccessKey: s3cfg.SecretAccessKey,
-			S3SessionToken:    s3cfg.SessionToken,
-			BackendOptions:    backendOptions,
+			S3Dir:              s3cfg.Dir,
+			PublicURL:          publicBaseURL(addr),
+			S3Bucket:           s3cfg.Bucket,
+			S3Region:           s3cfg.Region,
+			S3Prefix:           s3cfg.Prefix,
+			S3RoleARN:          s3cfg.RoleARN,
+			S3Endpoint:         s3cfg.Endpoint,
+			S3ForcePathStyle:   s3cfg.ForcePathStyle,
+			S3AccessKeyID:      s3cfg.AccessKeyID,
+			S3SecretAccessKey:  s3cfg.SecretAccessKey,
+			S3SessionToken:     s3cfg.SessionToken,
+			S3EncryptionPolicy: s3cfg.EncryptionPolicy,
+			BackendOptions:     backendOptions,
 		}, enc)
 		defer pool.Close()
 	}

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/embedding"
 	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/s3client"
@@ -58,6 +59,8 @@ type Dat9Backend struct {
 	tenantID    string
 	metaStore   MetaQuotaStore // nil when central quota is not wired (tests, fallback)
 	quotaSource QuotaSource    // "tenant" (default) or "server"
+
+	s3EncryptionPolicy meta.ResolvedS3EncryptionPolicy
 
 	// Async image -> text extraction worker (in-memory queue for P0).
 	imageExtractEnabled bool
@@ -169,7 +172,8 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + fileID
-		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(nil), 0, s3client.EncryptionOpts{}); err != nil {
+		encOpts, _, _ := b.s3WriteEncryption()
+		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(nil), 0, encOpts); err != nil {
 			logger.Error(ctx, "backend_create_put_object_failed", zap.String("path", path), zap.String("storage_ref", storageRef), zap.Error(err))
 			return fmt.Errorf("put object: %w", err)
 		}
@@ -177,8 +181,10 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 
 	err = b.store.InsertFile(ctx, &datastore.File{
 		FileID: fileID, StorageType: storageType, StorageRef: storageRef,
-		ContentBlob: contentBlob,
-		SizeBytes:   0, Revision: 1, Status: datastore.StatusConfirmed,
+		StorageEncryptionMode:  b.fileStorageEncryptionMode(storageType),
+		StorageEncryptionKeyID: b.fileStorageEncryptionKeyID(storageType),
+		ContentBlob:            contentBlob,
+		SizeBytes:              0, Revision: 1, Status: datastore.StatusConfirmed,
 		CreatedAt: now, ConfirmedAt: &now,
 	})
 	if err != nil {
@@ -429,7 +435,8 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + fileID
-		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(data), int64(len(data)), s3client.EncryptionOpts{}); err != nil {
+		encOpts, _, _ := b.s3WriteEncryption()
+		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(data), int64(len(data)), encOpts); err != nil {
 			logger.Error(ctx, "backend_create_and_write_put_object_failed", zap.String("path", path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(data)), zap.Error(err))
 			return 0, fmt.Errorf("put object: %w", err)
 		}
@@ -442,8 +449,10 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		fileRev := int64(1)
 		insertFile := &datastore.File{
 			FileID: fileID, StorageType: storageType, StorageRef: storageRef,
-			ContentBlob: contentBlob,
-			ContentType: contentType, SizeBytes: int64(len(data)),
+			StorageEncryptionMode:  b.fileStorageEncryptionMode(storageType),
+			StorageEncryptionKeyID: b.fileStorageEncryptionKeyID(storageType),
+			ContentBlob:            contentBlob,
+			ContentType:            contentType, SizeBytes: int64(len(data)),
 			ChecksumSHA256: checksum, Revision: fileRev, Status: datastore.StatusConfirmed,
 			ContentText: contentText, Description: description, CreatedAt: now, ConfirmedAt: &now,
 		}
@@ -538,7 +547,8 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + b.genID()
-		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(finalData), int64(len(finalData)), s3client.EncryptionOpts{}); err != nil {
+		encOpts, _, _ := b.s3WriteEncryption()
+		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(finalData), int64(len(finalData)), encOpts); err != nil {
 			logger.Error(ctx, "backend_overwrite_put_object_failed", zap.String("path", nf.Node.Path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(finalData)), zap.Error(err))
 			return 0, 0, fmt.Errorf("put object: %w", err)
 		}
@@ -577,6 +587,10 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 		}
 		if txErr != nil {
 			return txErr
+		}
+		if err := b.store.UpdateFileStorageEncryptionTx(tx, nf.File.FileID,
+			b.fileStorageEncryptionMode(storageType), b.fileStorageEncryptionKeyID(storageType)); err != nil {
+			return err
 		}
 		if tags != nil {
 			if err := b.store.ReplaceFileTagsTx(tx, nf.File.FileID, tags); err != nil {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -163,6 +163,8 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 	now := time.Now()
 	storageType := datastore.StorageDB9
 	storageRef := "inline"
+	storageEncryptionMode := datastore.StorageEncryptionNone
+	storageEncryptionKeyID := ""
 	var contentBlob []byte
 	if b.shouldStoreInDB(0) {
 		contentBlob = []byte{}
@@ -172,7 +174,9 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + fileID
-		encOpts, _, _ := b.s3WriteEncryption()
+		encOpts, encMode, encKeyID := b.s3WriteEncryption(storageRef)
+		storageEncryptionMode = encMode
+		storageEncryptionKeyID = encKeyID
 		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(nil), 0, encOpts); err != nil {
 			logger.Error(ctx, "backend_create_put_object_failed", zap.String("path", path), zap.String("storage_ref", storageRef), zap.Error(err))
 			return fmt.Errorf("put object: %w", err)
@@ -181,8 +185,8 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 
 	err = b.store.InsertFile(ctx, &datastore.File{
 		FileID: fileID, StorageType: storageType, StorageRef: storageRef,
-		StorageEncryptionMode:  b.fileStorageEncryptionMode(storageType),
-		StorageEncryptionKeyID: b.fileStorageEncryptionKeyID(storageType),
+		StorageEncryptionMode:  storageEncryptionMode,
+		StorageEncryptionKeyID: storageEncryptionKeyID,
 		ContentBlob:            contentBlob,
 		SizeBytes:              0, Revision: 1, Status: datastore.StatusConfirmed,
 		CreatedAt: now, ConfirmedAt: &now,
@@ -426,6 +430,8 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 
 	storageType := datastore.StorageDB9
 	storageRef := "inline"
+	storageEncryptionMode := datastore.StorageEncryptionNone
+	storageEncryptionKeyID := ""
 	var contentBlob []byte
 	if b.shouldStoreInDB(int64(len(data))) {
 		contentBlob = append([]byte(nil), data...)
@@ -435,7 +441,9 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + fileID
-		encOpts, _, _ := b.s3WriteEncryption()
+		encOpts, encMode, encKeyID := b.s3WriteEncryption(storageRef)
+		storageEncryptionMode = encMode
+		storageEncryptionKeyID = encKeyID
 		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(data), int64(len(data)), encOpts); err != nil {
 			logger.Error(ctx, "backend_create_and_write_put_object_failed", zap.String("path", path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(data)), zap.Error(err))
 			return 0, fmt.Errorf("put object: %w", err)
@@ -449,8 +457,8 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		fileRev := int64(1)
 		insertFile := &datastore.File{
 			FileID: fileID, StorageType: storageType, StorageRef: storageRef,
-			StorageEncryptionMode:  b.fileStorageEncryptionMode(storageType),
-			StorageEncryptionKeyID: b.fileStorageEncryptionKeyID(storageType),
+			StorageEncryptionMode:  storageEncryptionMode,
+			StorageEncryptionKeyID: storageEncryptionKeyID,
 			ContentBlob:            contentBlob,
 			ContentType:            contentType, SizeBytes: int64(len(data)),
 			ChecksumSHA256: checksum, Revision: fileRev, Status: datastore.StatusConfirmed,
@@ -538,6 +546,8 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 	contentText := extractText(finalData, contentType)
 	storageType := datastore.StorageDB9
 	storageRef := "inline"
+	storageEncryptionMode := datastore.StorageEncryptionNone
+	storageEncryptionKeyID := ""
 	var contentBlob []byte
 	if b.shouldStoreInDB(int64(len(finalData))) {
 		contentBlob = append([]byte(nil), finalData...)
@@ -547,7 +557,9 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 		}
 		storageType = datastore.StorageS3
 		storageRef = "blobs/" + b.genID()
-		encOpts, _, _ := b.s3WriteEncryption()
+		encOpts, encMode, encKeyID := b.s3WriteEncryption(storageRef)
+		storageEncryptionMode = encMode
+		storageEncryptionKeyID = encKeyID
 		if err := b.s3.PutObject(ctx, storageRef, bytes.NewReader(finalData), int64(len(finalData)), encOpts); err != nil {
 			logger.Error(ctx, "backend_overwrite_put_object_failed", zap.String("path", nf.Node.Path), zap.String("storage_ref", storageRef), zap.Int("bytes", len(finalData)), zap.Error(err))
 			return 0, 0, fmt.Errorf("put object: %w", err)
@@ -588,8 +600,7 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 		if txErr != nil {
 			return txErr
 		}
-		if err := b.store.UpdateFileStorageEncryptionTx(tx, nf.File.FileID,
-			b.fileStorageEncryptionMode(storageType), b.fileStorageEncryptionKeyID(storageType)); err != nil {
+		if err := b.store.UpdateFileStorageEncryptionTx(tx, nf.File.FileID, storageEncryptionMode, storageEncryptionKeyID); err != nil {
 			return err
 		}
 		if tags != nil {

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mem9-ai/dat9/pkg/embedding"
 	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/metrics"
 	"go.uber.org/zap"
 )
@@ -80,6 +81,11 @@ type Options struct {
 	// QuotaSource selects where quota enforcement reads authoritative state.
 	// "tenant" (default) uses per-tenant DB; "server" uses the central server DB.
 	QuotaSource QuotaSource
+	// TenantID is used for per-write S3 encryption context and audit metadata.
+	TenantID string
+	// S3EncryptionPolicy is the already-resolved policy for this backend.
+	// The zero value is normalized to the global default of explicit no encryption.
+	S3EncryptionPolicy meta.ResolvedS3EncryptionPolicy
 }
 
 // LLMCostBudgetOptions configures the monthly LLM cost budget.
@@ -155,7 +161,17 @@ type QueryEmbeddingOptions struct {
 }
 
 func (b *Dat9Backend) configureOptions(opts Options) {
+	if opts.TenantID != "" {
+		b.tenantID = opts.TenantID
+	}
 	b.databaseAutoEmbedding = opts.DatabaseAutoEmbedding
+	b.s3EncryptionPolicy = opts.S3EncryptionPolicy
+	if b.s3EncryptionPolicy.Mode == "" {
+		resolved, err := meta.ResolveS3EncryptionPolicy(meta.DefaultS3EncryptionPolicy(), meta.S3EncryptionPolicy{Mode: meta.S3EncryptionModeInherit})
+		if err == nil {
+			b.s3EncryptionPolicy = resolved
+		}
+	}
 	if opts.QuotaSource == QuotaSourceServer {
 		b.quotaSource = QuotaSourceServer
 	} else {

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -212,7 +212,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 	// Create new S3 multipart upload (new key — old object stays until confirm)
 	fileID := b.genID()
 	newS3Key := "blobs/" + fileID
-	encOpts, encMode, encKeyID := b.s3WriteEncryption()
+	encOpts, encMode, encKeyID := b.s3WriteEncryption(newS3Key)
 
 	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key, s3client.ChecksumAlgoSHA256, encOpts)
 	if err != nil {

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -212,8 +212,9 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 	// Create new S3 multipart upload (new key — old object stays until confirm)
 	fileID := b.genID()
 	newS3Key := "blobs/" + fileID
+	encOpts, encMode, encKeyID := b.s3WriteEncryption()
 
-	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key, s3client.ChecksumAlgoSHA256, s3client.EncryptionOpts{})
+	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key, s3client.ChecksumAlgoSHA256, encOpts)
 	if err != nil {
 		logger.Error(ctx, "backend_patch_upload_create_mpu_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
@@ -318,30 +319,34 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 			return err
 		}
 		if err := b.store.InsertFileTx(tx, &datastore.File{
-			FileID:      fileID,
-			StorageType: datastore.StorageS3,
-			StorageRef:  newS3Key,
-			SizeBytes:   newSize,
-			Revision:    1,
-			Status:      datastore.StatusPending,
-			CreatedAt:   now,
+			FileID:                 fileID,
+			StorageType:            datastore.StorageS3,
+			StorageRef:             newS3Key,
+			StorageEncryptionMode:  encMode,
+			StorageEncryptionKeyID: encKeyID,
+			SizeBytes:              newSize,
+			Revision:               1,
+			Status:                 datastore.StatusPending,
+			CreatedAt:              now,
 		}); err != nil {
 			return err
 		}
 		return b.store.InsertUploadTx(tx, &datastore.Upload{
-			UploadID:         uploadID,
-			FileID:           fileID,
-			TargetPath:       path,
-			S3UploadID:       mpu.UploadID,
-			S3Key:            newS3Key,
-			TotalSize:        newSize,
-			PartSize:         partSize,
-			PartsTotal:       len(newParts),
-			ExpectedRevision: expectedRevisionPtr(expectedRevision),
-			Status:           datastore.UploadUploading,
-			CreatedAt:        now,
-			UpdatedAt:        now,
-			ExpiresAt:        expiresAt,
+			UploadID:               uploadID,
+			FileID:                 fileID,
+			TargetPath:             path,
+			S3UploadID:             mpu.UploadID,
+			S3Key:                  newS3Key,
+			StorageEncryptionMode:  encMode,
+			StorageEncryptionKeyID: encKeyID,
+			TotalSize:              newSize,
+			PartSize:               partSize,
+			PartsTotal:             len(newParts),
+			ExpectedRevision:       expectedRevisionPtr(expectedRevision),
+			Status:                 datastore.UploadUploading,
+			CreatedAt:              now,
+			UpdatedAt:              now,
+			ExpiresAt:              expiresAt,
 		})
 	}); err != nil {
 		if reserved {

--- a/pkg/backend/s3_encryption.go
+++ b/pkg/backend/s3_encryption.go
@@ -1,0 +1,31 @@
+package backend
+
+import (
+	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/s3client"
+)
+
+func (b *Dat9Backend) s3WriteEncryption() (s3client.EncryptionOpts, datastore.StorageEncryptionMode, string) {
+	policy := b.s3EncryptionPolicy
+	context := map[string]string(nil)
+	if b.tenantID != "" {
+		context = map[string]string{"tenant_id": b.tenantID}
+	}
+	return policy.EncryptionOpts(context), datastore.StorageEncryptionMode(policy.Mode), policy.KMSKeyID
+}
+
+func (b *Dat9Backend) fileStorageEncryptionMode(storageType datastore.StorageType) datastore.StorageEncryptionMode {
+	if storageType != datastore.StorageS3 {
+		return datastore.StorageEncryptionNone
+	}
+	_, mode, _ := b.s3WriteEncryption()
+	return mode
+}
+
+func (b *Dat9Backend) fileStorageEncryptionKeyID(storageType datastore.StorageType) string {
+	if storageType != datastore.StorageS3 {
+		return ""
+	}
+	_, _, keyID := b.s3WriteEncryption()
+	return keyID
+}

--- a/pkg/backend/s3_encryption.go
+++ b/pkg/backend/s3_encryption.go
@@ -5,27 +5,34 @@ import (
 	"github.com/mem9-ai/dat9/pkg/s3client"
 )
 
-func (b *Dat9Backend) s3WriteEncryption() (s3client.EncryptionOpts, datastore.StorageEncryptionMode, string) {
+func (b *Dat9Backend) s3WriteEncryption(objectKey string) (s3client.EncryptionOpts, datastore.StorageEncryptionMode, string) {
 	policy := b.s3EncryptionPolicy
 	context := map[string]string(nil)
 	if b.tenantID != "" {
 		context = map[string]string{"tenant_id": b.tenantID}
 	}
-	return policy.EncryptionOpts(context), datastore.StorageEncryptionMode(policy.Mode), policy.KMSKeyID
+	if objectKey != "" {
+		if context == nil {
+			context = map[string]string{}
+		}
+		context["object_key"] = objectKey
+	}
+	return policy.EncryptionOpts(context), storageEncryptionModeFromS3(policy.Mode), policy.KMSKeyID
 }
 
-func (b *Dat9Backend) fileStorageEncryptionMode(storageType datastore.StorageType) datastore.StorageEncryptionMode {
-	if storageType != datastore.StorageS3 {
+func storageEncryptionModeFromS3(mode s3client.EncryptionMode) datastore.StorageEncryptionMode {
+	switch mode {
+	case s3client.EncryptionModeLegacy:
+		return datastore.StorageEncryptionLegacy
+	case s3client.EncryptionModeNone:
+		return datastore.StorageEncryptionNone
+	case s3client.EncryptionModeSSES3:
+		return datastore.StorageEncryptionSSES3
+	case s3client.EncryptionModeSSEKMS:
+		return datastore.StorageEncryptionSSEKMS
+	case s3client.EncryptionModeDSSEKMS:
+		return datastore.StorageEncryptionDSSEKMS
+	default:
 		return datastore.StorageEncryptionNone
 	}
-	_, mode, _ := b.s3WriteEncryption()
-	return mode
-}
-
-func (b *Dat9Backend) fileStorageEncryptionKeyID(storageType datastore.StorageType) string {
-	if storageType != datastore.StorageS3 {
-		return ""
-	}
-	_, _, keyID := b.s3WriteEncryption()
-	return keyID
 }

--- a/pkg/backend/s3_encryption_test.go
+++ b/pkg/backend/s3_encryption_test.go
@@ -116,6 +116,9 @@ func TestS3EncryptionPolicyDrivesPutObjectAndFileMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
+	if rec.lastPutEncryption.EncryptionContext["object_key"] != nf.File.StorageRef {
+		t.Fatalf("PutObject object_key context=%q, want %q", rec.lastPutEncryption.EncryptionContext["object_key"], nf.File.StorageRef)
+	}
 	if nf.File.StorageEncryptionMode != datastore.StorageEncryptionSSEKMS {
 		t.Fatalf("file encryption mode=%q, want %q", nf.File.StorageEncryptionMode, datastore.StorageEncryptionSSEKMS)
 	}
@@ -183,6 +186,9 @@ func TestS3EncryptionPolicyDrivesMultipartAndUploadMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get upload: %v", err)
 	}
+	if rec.lastMPUEncryption.EncryptionContext["object_key"] != upload.S3Key {
+		t.Fatalf("CreateMultipartUpload object_key context=%q, want %q", rec.lastMPUEncryption.EncryptionContext["object_key"], upload.S3Key)
+	}
 	if upload.StorageEncryptionMode != datastore.StorageEncryptionSSEKMS {
 		t.Fatalf("upload encryption mode=%q, want %q", upload.StorageEncryptionMode, datastore.StorageEncryptionSSEKMS)
 	}
@@ -245,8 +251,99 @@ func TestPatchUploadUsesResolvedEncryptionForNewTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get upload: %v", err)
 	}
+	if rec.lastMPUEncryption.EncryptionContext["object_key"] != upload.S3Key {
+		t.Fatalf("patch upload object_key context=%q, want %q", rec.lastMPUEncryption.EncryptionContext["object_key"], upload.S3Key)
+	}
 	if upload.StorageEncryptionMode != datastore.StorageEncryptionSSEKMS {
 		t.Fatalf("patch upload encryption mode=%q, want %q", upload.StorageEncryptionMode, datastore.StorageEncryptionSSEKMS)
+	}
+}
+
+func TestOverwriteLegacyS3FileRecordsResolvedEncryption(t *testing.T) {
+	b, rec := newTestBackendWithRecordingS3(t, false, Options{
+		TenantID:           "tenant-a",
+		S3EncryptionPolicy: resolvedSSEKMSTestPolicy(),
+	})
+	insertLegacyS3File(t, b, "/overwrite.bin", "legacy-file")
+
+	_, rev, err := b.WriteCtxIfRevisionWithTagsResult(
+		context.Background(),
+		"/overwrite.bin",
+		[]byte("encrypted overwrite"),
+		0,
+		filesystem.WriteFlagTruncate,
+		1,
+		nil,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	if rev != 2 {
+		t.Fatalf("revision=%d, want 2", rev)
+	}
+	if rec.lastPutEncryption.Mode != s3client.EncryptionModeSSEKMS {
+		t.Fatalf("PutObject mode=%q, want %q", rec.lastPutEncryption.Mode, s3client.EncryptionModeSSEKMS)
+	}
+
+	nf, err := b.store.Stat(context.Background(), "/overwrite.bin")
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if rec.lastPutEncryption.EncryptionContext["object_key"] != nf.File.StorageRef {
+		t.Fatalf("PutObject object_key context=%q, want %q", rec.lastPutEncryption.EncryptionContext["object_key"], nf.File.StorageRef)
+	}
+	if nf.File.StorageEncryptionMode != datastore.StorageEncryptionSSEKMS {
+		t.Fatalf("file encryption mode=%q, want %q", nf.File.StorageEncryptionMode, datastore.StorageEncryptionSSEKMS)
+	}
+	if nf.File.StorageEncryptionKeyID != resolvedSSEKMSTestPolicy().KMSKeyID {
+		t.Fatalf("file encryption key=%q, want %q", nf.File.StorageEncryptionKeyID, resolvedSSEKMSTestPolicy().KMSKeyID)
+	}
+}
+
+func TestMultipartOverwriteLegacyS3FileRecordsResolvedEncryption(t *testing.T) {
+	b, rec := newTestBackendWithRecordingS3(t, true, Options{
+		TenantID:           "tenant-a",
+		S3EncryptionPolicy: resolvedSSEKMSTestPolicy(),
+	})
+	insertLegacyS3File(t, b, "/upload-overwrite.bin", "legacy-upload-file")
+
+	ctx := context.Background()
+	totalSize := int64(s3client.PartSize)
+	plan, err := b.InitiateUploadWithChecksumsIfRevision(ctx, "/upload-overwrite.bin", totalSize, nil, 1, "")
+	if err != nil {
+		t.Fatalf("initiate upload: %v", err)
+	}
+	upload, err := b.store.GetUpload(ctx, plan.UploadID)
+	if err != nil {
+		t.Fatalf("get upload: %v", err)
+	}
+	partData := bytes.Repeat([]byte("x"), int(totalSize))
+	if _, err := b.S3().(*recordingS3Client).S3Client.(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, 1, bytes.NewReader(partData)); err != nil {
+		t.Fatalf("upload part: %v", err)
+	}
+	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
+		t.Fatalf("confirm upload: %v", err)
+	}
+
+	if rec.lastMPUEncryption.EncryptionContext["object_key"] != upload.S3Key {
+		t.Fatalf("CreateMultipartUpload object_key context=%q, want %q", rec.lastMPUEncryption.EncryptionContext["object_key"], upload.S3Key)
+	}
+	nf, err := b.store.Stat(ctx, "/upload-overwrite.bin")
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if nf.File.FileID != "legacy-upload-file" {
+		t.Fatalf("file_id=%q, want existing file id", nf.File.FileID)
+	}
+	if nf.File.Revision != 2 {
+		t.Fatalf("revision=%d, want 2", nf.File.Revision)
+	}
+	if nf.File.StorageEncryptionMode != datastore.StorageEncryptionSSEKMS {
+		t.Fatalf("file encryption mode=%q, want %q", nf.File.StorageEncryptionMode, datastore.StorageEncryptionSSEKMS)
+	}
+	if nf.File.StorageEncryptionKeyID != resolvedSSEKMSTestPolicy().KMSKeyID {
+		t.Fatalf("file encryption key=%q, want %q", nf.File.StorageEncryptionKeyID, resolvedSSEKMSTestPolicy().KMSKeyID)
 	}
 }
 
@@ -325,5 +422,33 @@ func TestReadPlanDoesNotUseEncryptionHeaders(t *testing.T) {
 	}
 	if rec.lastPutEncryption.Mode != "" {
 		t.Fatalf("read path mutated write encryption mode=%q", rec.lastPutEncryption.Mode)
+	}
+}
+
+func insertLegacyS3File(t *testing.T, b *Dat9Backend, path, fileID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := b.store.InsertFile(context.Background(), &datastore.File{
+		FileID:                fileID,
+		StorageType:           datastore.StorageS3,
+		StorageRef:            "blobs/" + fileID,
+		StorageEncryptionMode: datastore.StorageEncryptionLegacy,
+		SizeBytes:             1,
+		Revision:              1,
+		Status:                datastore.StatusConfirmed,
+		CreatedAt:             now,
+		ConfirmedAt:           &now,
+	}); err != nil {
+		t.Fatalf("insert legacy file: %v", err)
+	}
+	if err := b.store.InsertNode(context.Background(), &datastore.FileNode{
+		NodeID:     "node-" + fileID,
+		Path:       path,
+		ParentPath: pathutil.ParentPath(path),
+		Name:       pathutil.BaseName(path),
+		FileID:     fileID,
+		CreatedAt:  now,
+	}); err != nil {
+		t.Fatalf("insert legacy node: %v", err)
 	}
 }

--- a/pkg/backend/s3_encryption_test.go
+++ b/pkg/backend/s3_encryption_test.go
@@ -1,0 +1,329 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+	"github.com/mem9-ai/dat9/internal/testmysql"
+	"github.com/mem9-ai/dat9/pkg/datastore"
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/pathutil"
+	"github.com/mem9-ai/dat9/pkg/s3client"
+)
+
+type recordingS3Client struct {
+	s3client.S3Client
+	lastPutEncryption s3client.EncryptionOpts
+	lastMPUEncryption s3client.EncryptionOpts
+	failPut           bool
+	failMPU           bool
+}
+
+func (c *recordingS3Client) PutObject(ctx context.Context, key string, body io.Reader, size int64, encOpts s3client.EncryptionOpts) error {
+	c.lastPutEncryption = encOpts
+	if c.failPut {
+		return errors.New("kms access denied")
+	}
+	return c.S3Client.PutObject(ctx, key, body, size, encOpts)
+}
+
+func (c *recordingS3Client) CreateMultipartUpload(ctx context.Context, key string, algo s3client.ChecksumAlgo, encOpts s3client.EncryptionOpts) (*s3client.MultipartUpload, error) {
+	c.lastMPUEncryption = encOpts
+	if c.failMPU {
+		return nil, errors.New("kms access denied")
+	}
+	return c.S3Client.CreateMultipartUpload(ctx, key, algo, encOpts)
+}
+
+func newTestBackendWithRecordingS3(t *testing.T, smallInDB bool, opts Options) (*Dat9Backend, *recordingS3Client) {
+	t.Helper()
+
+	s3Dir, err := os.MkdirTemp("", "dat9-s3-encryption-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
+
+	initBackendSchema(t, testDSN)
+	store, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetDB(t, store.DB())
+	t.Cleanup(func() { _ = store.Close() })
+
+	localS3, err := s3client.NewLocal(s3Dir, "http://localhost:9091/s3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := &recordingS3Client{S3Client: localS3}
+	b, err := NewWithS3ModeAndOptions(store, rec, smallInDB, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { b.Close() })
+	return b, rec
+}
+
+func resolvedSSEKMSTestPolicy() meta.ResolvedS3EncryptionPolicy {
+	return meta.ResolvedS3EncryptionPolicy{
+		Mode:             s3client.EncryptionModeSSEKMS,
+		KMSKeyID:         "arn:aws:kms:ap-southeast-1:123456789012:key/test",
+		BucketKeyEnabled: true,
+	}
+}
+
+func TestS3EncryptionPolicyDrivesPutObjectAndFileMetadata(t *testing.T) {
+	b, rec := newTestBackendWithRecordingS3(t, false, Options{
+		TenantID:           "tenant-a",
+		S3EncryptionPolicy: resolvedSSEKMSTestPolicy(),
+	})
+
+	_, _, err := b.WriteCtxIfRevisionWithTagsResult(
+		context.Background(),
+		"/kms.txt",
+		[]byte("encrypted"),
+		0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate,
+		-1,
+		nil,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if rec.lastPutEncryption.Mode != s3client.EncryptionModeSSEKMS {
+		t.Fatalf("PutObject mode=%q, want %q", rec.lastPutEncryption.Mode, s3client.EncryptionModeSSEKMS)
+	}
+	if rec.lastPutEncryption.KMSKeyID != resolvedSSEKMSTestPolicy().KMSKeyID {
+		t.Fatalf("PutObject key=%q, want %q", rec.lastPutEncryption.KMSKeyID, resolvedSSEKMSTestPolicy().KMSKeyID)
+	}
+	if !rec.lastPutEncryption.BucketKeyEnabled {
+		t.Fatal("PutObject bucket key disabled, want enabled")
+	}
+	if rec.lastPutEncryption.EncryptionContext["tenant_id"] != "tenant-a" {
+		t.Fatalf("PutObject tenant context=%q, want tenant-a", rec.lastPutEncryption.EncryptionContext["tenant_id"])
+	}
+
+	nf, err := b.store.Stat(context.Background(), "/kms.txt")
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if nf.File.StorageEncryptionMode != datastore.StorageEncryptionSSEKMS {
+		t.Fatalf("file encryption mode=%q, want %q", nf.File.StorageEncryptionMode, datastore.StorageEncryptionSSEKMS)
+	}
+	if nf.File.StorageEncryptionKeyID != resolvedSSEKMSTestPolicy().KMSKeyID {
+		t.Fatalf("file encryption key=%q, want %q", nf.File.StorageEncryptionKeyID, resolvedSSEKMSTestPolicy().KMSKeyID)
+	}
+}
+
+func TestDB9WriteRecordsExplicitNoneEvenWhenS3PolicyIsKMS(t *testing.T) {
+	b, rec := newTestBackendWithRecordingS3(t, true, Options{
+		TenantID:           "tenant-a",
+		S3EncryptionPolicy: resolvedSSEKMSTestPolicy(),
+	})
+
+	_, _, err := b.WriteCtxIfRevisionWithTagsResult(
+		context.Background(),
+		"/small.txt",
+		[]byte("small"),
+		0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate,
+		-1,
+		nil,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if rec.lastPutEncryption.Mode != "" {
+		t.Fatalf("PutObject was called with mode=%q for db9 write", rec.lastPutEncryption.Mode)
+	}
+
+	nf, err := b.store.Stat(context.Background(), "/small.txt")
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if nf.File.StorageType != datastore.StorageDB9 {
+		t.Fatalf("storage type=%q, want %q", nf.File.StorageType, datastore.StorageDB9)
+	}
+	if nf.File.StorageEncryptionMode != datastore.StorageEncryptionNone {
+		t.Fatalf("file encryption mode=%q, want %q", nf.File.StorageEncryptionMode, datastore.StorageEncryptionNone)
+	}
+	if nf.File.StorageEncryptionKeyID != "" {
+		t.Fatalf("file encryption key=%q, want empty", nf.File.StorageEncryptionKeyID)
+	}
+}
+
+func TestS3EncryptionPolicyDrivesMultipartAndUploadMetadata(t *testing.T) {
+	b, rec := newTestBackendWithRecordingS3(t, true, Options{
+		TenantID:           "tenant-a",
+		S3EncryptionPolicy: resolvedSSEKMSTestPolicy(),
+	})
+
+	plan, err := b.InitiateUploadV2IfRevision(context.Background(), "/large.bin", int64(s3client.MinPartSize), -1, "")
+	if err != nil {
+		t.Fatalf("initiate upload: %v", err)
+	}
+	if rec.lastMPUEncryption.Mode != s3client.EncryptionModeSSEKMS {
+		t.Fatalf("CreateMultipartUpload mode=%q, want %q", rec.lastMPUEncryption.Mode, s3client.EncryptionModeSSEKMS)
+	}
+	if rec.lastMPUEncryption.KMSKeyID != resolvedSSEKMSTestPolicy().KMSKeyID {
+		t.Fatalf("CreateMultipartUpload key=%q, want %q", rec.lastMPUEncryption.KMSKeyID, resolvedSSEKMSTestPolicy().KMSKeyID)
+	}
+
+	upload, err := b.store.GetUpload(context.Background(), plan.UploadID)
+	if err != nil {
+		t.Fatalf("get upload: %v", err)
+	}
+	if upload.StorageEncryptionMode != datastore.StorageEncryptionSSEKMS {
+		t.Fatalf("upload encryption mode=%q, want %q", upload.StorageEncryptionMode, datastore.StorageEncryptionSSEKMS)
+	}
+	if upload.StorageEncryptionKeyID != resolvedSSEKMSTestPolicy().KMSKeyID {
+		t.Fatalf("upload encryption key=%q, want %q", upload.StorageEncryptionKeyID, resolvedSSEKMSTestPolicy().KMSKeyID)
+	}
+
+	file, err := b.store.GetFile(context.Background(), upload.FileID)
+	if err != nil {
+		t.Fatalf("get pending file: %v", err)
+	}
+	if file.StorageEncryptionMode != upload.StorageEncryptionMode ||
+		file.StorageEncryptionKeyID != upload.StorageEncryptionKeyID {
+		t.Fatalf("file encryption=%q/%q, upload encryption=%q/%q",
+			file.StorageEncryptionMode, file.StorageEncryptionKeyID,
+			upload.StorageEncryptionMode, upload.StorageEncryptionKeyID)
+	}
+}
+
+func TestPatchUploadUsesResolvedEncryptionForNewTarget(t *testing.T) {
+	b, rec := newTestBackendWithRecordingS3(t, true, Options{
+		TenantID:           "tenant-a",
+		S3EncryptionPolicy: resolvedSSEKMSTestPolicy(),
+	})
+
+	now := time.Now().UTC()
+	if err := b.store.InsertFile(context.Background(), &datastore.File{
+		FileID:                "source-file",
+		StorageType:           datastore.StorageS3,
+		StorageRef:            "blobs/source-file",
+		StorageEncryptionMode: datastore.StorageEncryptionLegacy,
+		SizeBytes:             1,
+		Revision:              1,
+		Status:                datastore.StatusConfirmed,
+		CreatedAt:             now,
+		ConfirmedAt:           &now,
+	}); err != nil {
+		t.Fatalf("insert source file: %v", err)
+	}
+	if err := b.store.InsertNode(context.Background(), &datastore.FileNode{
+		NodeID:     "node-source-file",
+		Path:       "/patch.bin",
+		ParentPath: pathutil.ParentPath("/patch.bin"),
+		Name:       pathutil.BaseName("/patch.bin"),
+		FileID:     "source-file",
+		CreatedAt:  now,
+	}); err != nil {
+		t.Fatalf("insert source node: %v", err)
+	}
+
+	plan, err := b.InitiatePatchUploadIfRevision(context.Background(), "/patch.bin", int64(s3client.MinPartSize), []int{1}, s3client.MinPartSize, 1)
+	if err != nil {
+		t.Fatalf("initiate patch: %v", err)
+	}
+	if rec.lastMPUEncryption.Mode != s3client.EncryptionModeSSEKMS {
+		t.Fatalf("CreateMultipartUpload mode=%q, want %q", rec.lastMPUEncryption.Mode, s3client.EncryptionModeSSEKMS)
+	}
+
+	upload, err := b.store.GetUpload(context.Background(), plan.UploadID)
+	if err != nil {
+		t.Fatalf("get upload: %v", err)
+	}
+	if upload.StorageEncryptionMode != datastore.StorageEncryptionSSEKMS {
+		t.Fatalf("patch upload encryption mode=%q, want %q", upload.StorageEncryptionMode, datastore.StorageEncryptionSSEKMS)
+	}
+}
+
+func TestKMSWriteFailureDoesNotFallbackToPlaintext(t *testing.T) {
+	b, rec := newTestBackendWithRecordingS3(t, false, Options{
+		TenantID:           "tenant-a",
+		S3EncryptionPolicy: resolvedSSEKMSTestPolicy(),
+	})
+	rec.failPut = true
+
+	_, _, err := b.WriteCtxIfRevisionWithTagsResult(
+		context.Background(),
+		"/kms-fail.txt",
+		[]byte("data"),
+		0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate,
+		-1,
+		nil,
+		"",
+	)
+	if err == nil {
+		t.Fatal("write error = nil, want KMS failure")
+	}
+	if rec.lastPutEncryption.Mode != s3client.EncryptionModeSSEKMS {
+		t.Fatalf("failed PutObject mode=%q, want %q", rec.lastPutEncryption.Mode, s3client.EncryptionModeSSEKMS)
+	}
+	if _, statErr := b.store.Stat(context.Background(), "/kms-fail.txt"); !errors.Is(statErr, datastore.ErrNotFound) {
+		t.Fatalf("stat after failed write error=%v, want ErrNotFound", statErr)
+	}
+}
+
+func TestKMSMultipartFailureDoesNotFallbackToPlaintext(t *testing.T) {
+	b, rec := newTestBackendWithRecordingS3(t, true, Options{
+		TenantID:           "tenant-a",
+		S3EncryptionPolicy: resolvedSSEKMSTestPolicy(),
+	})
+	rec.failMPU = true
+
+	_, err := b.InitiateUploadV2IfRevision(context.Background(), "/kms-fail.bin", int64(s3client.MinPartSize), -1, "")
+	if err == nil {
+		t.Fatal("initiate upload error = nil, want KMS failure")
+	}
+	if rec.lastMPUEncryption.Mode != s3client.EncryptionModeSSEKMS {
+		t.Fatalf("failed CreateMultipartUpload mode=%q, want %q", rec.lastMPUEncryption.Mode, s3client.EncryptionModeSSEKMS)
+	}
+	if _, statErr := b.store.Stat(context.Background(), "/kms-fail.bin"); !errors.Is(statErr, datastore.ErrNotFound) {
+		t.Fatalf("stat after failed initiate error=%v, want ErrNotFound", statErr)
+	}
+}
+
+func TestReadPlanDoesNotUseEncryptionHeaders(t *testing.T) {
+	b, rec := newTestBackendWithRecordingS3(t, false, Options{
+		TenantID:           "tenant-a",
+		S3EncryptionPolicy: resolvedSSEKMSTestPolicy(),
+	})
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(
+		context.Background(),
+		"/read.bin",
+		bytes.Repeat([]byte("x"), smallFileThreshold),
+		0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate,
+		-1,
+		nil,
+		"",
+	); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	rec.lastPutEncryption = s3client.EncryptionOpts{}
+
+	plan, err := b.ReadPlanCtx(context.Background(), "/read.bin")
+	if err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+	if plan.PresignURL == "" {
+		t.Fatal("read plan PresignURL is empty")
+	}
+	if rec.lastPutEncryption.Mode != "" {
+		t.Fatalf("read path mutated write encryption mode=%q", rec.lastPutEncryption.Mode)
+	}
+}

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -245,9 +245,10 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 
 	fileID := b.genID()
 	s3Key := "blobs/" + fileID
+	encOpts, encMode, encKeyID := b.s3WriteEncryption()
 
 	// Create S3 multipart upload — v1 uses CRC32C
-	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoCRC32C, s3client.EncryptionOpts{})
+	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoCRC32C, encOpts)
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_create_multipart_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
@@ -299,31 +300,35 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 			}
 		}
 		if err := b.store.InsertFileTx(tx, &datastore.File{
-			FileID:      fileID,
-			StorageType: datastore.StorageS3,
-			StorageRef:  s3Key,
-			SizeBytes:   totalSize,
-			Revision:    1,
-			Status:      datastore.StatusPending,
-			CreatedAt:   now,
+			FileID:                 fileID,
+			StorageType:            datastore.StorageS3,
+			StorageRef:             s3Key,
+			StorageEncryptionMode:  encMode,
+			StorageEncryptionKeyID: encKeyID,
+			SizeBytes:              totalSize,
+			Revision:               1,
+			Status:                 datastore.StatusPending,
+			CreatedAt:              now,
 		}); err != nil {
 			return err
 		}
 		return b.store.InsertUploadTx(tx, &datastore.Upload{
-			UploadID:         uploadID,
-			FileID:           fileID,
-			TargetPath:       path,
-			S3UploadID:       mpu.UploadID,
-			S3Key:            s3Key,
-			TotalSize:        totalSize,
-			PartSize:         s3client.PartSize,
-			PartsTotal:       len(parts),
-			ExpectedRevision: expectedRevisionPtr(expectedRevision),
-			Status:           datastore.UploadUploading,
-			Description:      description,
-			CreatedAt:        now,
-			UpdatedAt:        now,
-			ExpiresAt:        now.Add(24 * time.Hour),
+			UploadID:               uploadID,
+			FileID:                 fileID,
+			TargetPath:             path,
+			S3UploadID:             mpu.UploadID,
+			S3Key:                  s3Key,
+			StorageEncryptionMode:  encMode,
+			StorageEncryptionKeyID: encKeyID,
+			TotalSize:              totalSize,
+			PartSize:               s3client.PartSize,
+			PartsTotal:             len(parts),
+			ExpectedRevision:       expectedRevisionPtr(expectedRevision),
+			Status:                 datastore.UploadUploading,
+			Description:            description,
+			CreatedAt:              now,
+			UpdatedAt:              now,
+			ExpiresAt:              now.Add(24 * time.Hour),
 		})
 	}); err != nil {
 		// Compensating abort: release server reservation on tenant DB failure.
@@ -409,12 +414,13 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 
 	fileID := b.genID()
 	s3Key := "blobs/" + fileID
+	encOpts, encMode, encKeyID := b.s3WriteEncryption()
 
 	// v2 does not declare a checksum algorithm at the S3 level because the
 	// client doesn't send per-part checksums yet (ChecksumContract.Required=false).
 	// When #114 adds inline checksums, switch back to a concrete algorithm.
 	createMultipartStart := time.Now()
-	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoNone, s3client.EncryptionOpts{})
+	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoNone, encOpts)
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_v2_create_multipart_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
@@ -451,33 +457,37 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		quotaDurationMs = uploadPhaseMs(stepStart)
 		stepStart = time.Now()
 		if err := b.store.InsertFileTx(tx, &datastore.File{
-			FileID:      fileID,
-			StorageType: datastore.StorageS3,
-			StorageRef:  s3Key,
-			SizeBytes:   totalSize,
-			Revision:    1,
-			Status:      datastore.StatusPending,
-			CreatedAt:   now,
+			FileID:                 fileID,
+			StorageType:            datastore.StorageS3,
+			StorageRef:             s3Key,
+			StorageEncryptionMode:  encMode,
+			StorageEncryptionKeyID: encKeyID,
+			SizeBytes:              totalSize,
+			Revision:               1,
+			Status:                 datastore.StatusPending,
+			CreatedAt:              now,
 		}); err != nil {
 			return err
 		}
 		insertFileDurationMs = uploadPhaseMs(stepStart)
 		stepStart = time.Now()
 		if err := b.store.InsertUploadTx(tx, &datastore.Upload{
-			UploadID:         uploadID,
-			FileID:           fileID,
-			TargetPath:       path,
-			S3UploadID:       mpu.UploadID,
-			S3Key:            s3Key,
-			TotalSize:        totalSize,
-			PartSize:         partSize,
-			PartsTotal:       len(parts),
-			ExpectedRevision: expectedRevisionPtr(expectedRevision),
-			Status:           datastore.UploadInitiated,
-			Description:      description,
-			CreatedAt:        now,
-			UpdatedAt:        now,
-			ExpiresAt:        expiresAt,
+			UploadID:               uploadID,
+			FileID:                 fileID,
+			TargetPath:             path,
+			S3UploadID:             mpu.UploadID,
+			S3Key:                  s3Key,
+			StorageEncryptionMode:  encMode,
+			StorageEncryptionKeyID: encKeyID,
+			TotalSize:              totalSize,
+			PartSize:               partSize,
+			PartsTotal:             len(parts),
+			ExpectedRevision:       expectedRevisionPtr(expectedRevision),
+			Status:                 datastore.UploadInitiated,
+			Description:            description,
+			CreatedAt:              now,
+			UpdatedAt:              now,
+			ExpiresAt:              expiresAt,
 		}); err != nil {
 			return err
 		}
@@ -976,6 +986,9 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 				)
 			}
 			if err != nil {
+				return err
+			}
+			if err := b.store.UpdateFileStorageEncryptionTx(tx, existingFileID.String, upload.StorageEncryptionMode, upload.StorageEncryptionKeyID); err != nil {
 				return err
 			}
 			updateFileContentDurationMs = uploadPhaseMs(stepStart)

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -245,7 +245,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 
 	fileID := b.genID()
 	s3Key := "blobs/" + fileID
-	encOpts, encMode, encKeyID := b.s3WriteEncryption()
+	encOpts, encMode, encKeyID := b.s3WriteEncryption(s3Key)
 
 	// Create S3 multipart upload — v1 uses CRC32C
 	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoCRC32C, encOpts)
@@ -414,7 +414,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 
 	fileID := b.genID()
 	s3Key := "blobs/" + fileID
-	encOpts, encMode, encKeyID := b.s3WriteEncryption()
+	encOpts, encMode, encKeyID := b.s3WriteEncryption(s3Key)
 
 	// v2 does not declare a checksum algorithm at the S3 level because the
 	// client doesn't send per-part checksums yet (ChecksumContract.Required=false).

--- a/pkg/datastore/file_tx.go
+++ b/pkg/datastore/file_tx.go
@@ -98,6 +98,23 @@ func (s *Store) updateFileContentTx(db execer, fileID string, expectedRevision i
 	return rev, nil
 }
 
+// UpdateFileStorageEncryptionTx updates storage encryption metadata inside an existing transaction.
+func (s *Store) UpdateFileStorageEncryptionTx(db execer, fileID string, mode StorageEncryptionMode, keyID string) error {
+	res, err := db.Exec(`UPDATE files SET storage_encryption_mode = ?, storage_encryption_key_id = ? WHERE file_id = ?`,
+		fileStorageEncryptionModeForWrite(mode), keyID, fileID)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // UpdateFileContentAutoEmbeddingTx updates file bytes/metadata without touching
 // embedding columns. TiDB auto-embedding mode relies on the database to derive
 // vectors from content_text, so the write path must stop clearing vector state.

--- a/pkg/datastore/file_tx.go
+++ b/pkg/datastore/file_tx.go
@@ -110,7 +110,13 @@ func (s *Store) UpdateFileStorageEncryptionTx(db execer, fileID string, mode Sto
 		return err
 	}
 	if rowsAffected == 0 {
-		return ErrNotFound
+		var exists int
+		if err := db.QueryRow(`SELECT 1 FROM files WHERE file_id = ?`, fileID).Scan(&exists); err != nil {
+			if err == sql.ErrNoRows {
+				return ErrNotFound
+			}
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/datastore/file_tx.go
+++ b/pkg/datastore/file_tx.go
@@ -8,14 +8,15 @@ import (
 
 // InsertFileTx inserts a file row inside an existing transaction.
 func (s *Store) InsertFileTx(db execer, f *File) error {
+	mode := fileStorageEncryptionModeForWrite(f.StorageEncryptionMode)
 	_, err := db.Exec(`INSERT INTO files
 		(file_id, storage_type, storage_ref, storage_encryption_mode, storage_encryption_key_id,
 		 content_blob, content_type, size_bytes, checksum_sha256,
 		 revision, status, source_id, content_text, description, description_embedding_revision,
 		 created_at, confirmed_at, expires_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		f.FileID, f.StorageType, f.StorageRef, fileStorageEncryptionModeForWrite(f.StorageEncryptionMode),
-		f.StorageEncryptionKeyID, nilBytes(f.ContentBlob), nullStr(f.ContentType),
+		f.FileID, f.StorageType, f.StorageRef, mode,
+		storageEncryptionKeyIDForWrite(mode, f.StorageEncryptionKeyID), nilBytes(f.ContentBlob), nullStr(f.ContentType),
 		f.SizeBytes, nullStr(f.ChecksumSHA256), f.Revision, f.Status,
 		nullStr(f.SourceID), nullStr(f.ContentText), nullStr(f.Description),
 		nullInt64Ptr(f.DescriptionEmbeddingRevision),
@@ -100,8 +101,9 @@ func (s *Store) updateFileContentTx(db execer, fileID string, expectedRevision i
 
 // UpdateFileStorageEncryptionTx updates storage encryption metadata inside an existing transaction.
 func (s *Store) UpdateFileStorageEncryptionTx(db execer, fileID string, mode StorageEncryptionMode, keyID string) error {
+	mode = fileStorageEncryptionModeForWrite(mode)
 	res, err := db.Exec(`UPDATE files SET storage_encryption_mode = ?, storage_encryption_key_id = ? WHERE file_id = ?`,
-		fileStorageEncryptionModeForWrite(mode), keyID, fileID)
+		mode, storageEncryptionKeyIDForWrite(mode, keyID), fileID)
 	if err != nil {
 		return err
 	}

--- a/pkg/datastore/file_tx_test.go
+++ b/pkg/datastore/file_tx_test.go
@@ -39,6 +39,70 @@ func TestInsertFileTx(t *testing.T) {
 	}
 }
 
+func TestInsertFileClearsKeyIDForNonKMSMode(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertFile(context.Background(), &File{
+		FileID:                 "f1",
+		StorageType:            StorageS3,
+		StorageRef:             "/blobs/f1",
+		StorageEncryptionMode:  StorageEncryptionSSES3,
+		StorageEncryptionKeyID: "stale-key",
+		SizeBytes:              10,
+		Revision:               1,
+		Status:                 StatusConfirmed,
+		CreatedAt:              now,
+		ConfirmedAt:            &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetFile(context.Background(), "f1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.StorageEncryptionMode != StorageEncryptionSSES3 {
+		t.Fatalf("storage_encryption_mode=%q, want %q", got.StorageEncryptionMode, StorageEncryptionSSES3)
+	}
+	if got.StorageEncryptionKeyID != "" {
+		t.Fatalf("storage_encryption_key_id=%q, want empty", got.StorageEncryptionKeyID)
+	}
+}
+
+func TestInsertUploadClearsKeyIDForNonKMSMode(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertUpload(context.Background(), &Upload{
+		UploadID:               "u1",
+		FileID:                 "f1",
+		TargetPath:             "/upload.bin",
+		S3UploadID:             "s3-upload",
+		S3Key:                  "blobs/f1",
+		StorageEncryptionMode:  StorageEncryptionNone,
+		StorageEncryptionKeyID: "stale-key",
+		TotalSize:              10,
+		PartSize:               10,
+		PartsTotal:             1,
+		Status:                 UploadUploading,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+		ExpiresAt:              now.Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetUpload(context.Background(), "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.StorageEncryptionMode != StorageEncryptionNone {
+		t.Fatalf("storage_encryption_mode=%q, want %q", got.StorageEncryptionMode, StorageEncryptionNone)
+	}
+	if got.StorageEncryptionKeyID != "" {
+		t.Fatalf("storage_encryption_key_id=%q, want empty", got.StorageEncryptionKeyID)
+	}
+}
+
 func TestUpdateFileContentTxClearsEmbeddingState(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now().UTC()
@@ -137,6 +201,42 @@ func TestUpdateFileStorageEncryptionTxSameValues(t *testing.T) {
 		return s.UpdateFileStorageEncryptionTx(tx, "f1", StorageEncryptionNone, "")
 	}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestUpdateFileStorageEncryptionTxClearsKeyIDForNonKMSMode(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertFile(context.Background(), &File{
+		FileID:                 "f1",
+		StorageType:            StorageS3,
+		StorageRef:             "/blobs/f1",
+		StorageEncryptionMode:  StorageEncryptionSSEKMS,
+		StorageEncryptionKeyID: "arn:aws:kms:ap-southeast-1:123456789012:key/test",
+		SizeBytes:              10,
+		Revision:               1,
+		Status:                 StatusConfirmed,
+		CreatedAt:              now,
+		ConfirmedAt:            &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.InTx(context.Background(), func(tx *sql.Tx) error {
+		return s.UpdateFileStorageEncryptionTx(tx, "f1", StorageEncryptionNone, "stale-key")
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetFile(context.Background(), "f1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.StorageEncryptionMode != StorageEncryptionNone {
+		t.Fatalf("storage_encryption_mode=%q, want %q", got.StorageEncryptionMode, StorageEncryptionNone)
+	}
+	if got.StorageEncryptionKeyID != "" {
+		t.Fatalf("storage_encryption_key_id=%q, want empty", got.StorageEncryptionKeyID)
 	}
 }
 

--- a/pkg/datastore/file_tx_test.go
+++ b/pkg/datastore/file_tx_test.go
@@ -80,6 +80,41 @@ func TestUpdateFileContentTxClearsEmbeddingState(t *testing.T) {
 	}
 }
 
+func TestUpdateFileStorageEncryptionTx(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertFile(context.Background(), &File{
+		FileID:                "f1",
+		StorageType:           StorageS3,
+		StorageRef:            "/blobs/f1",
+		StorageEncryptionMode: StorageEncryptionLegacy,
+		SizeBytes:             10,
+		Revision:              1,
+		Status:                StatusConfirmed,
+		CreatedAt:             now,
+		ConfirmedAt:           &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.InTx(context.Background(), func(tx *sql.Tx) error {
+		return s.UpdateFileStorageEncryptionTx(tx, "f1", StorageEncryptionSSEKMS, "arn:aws:kms:ap-southeast-1:123456789012:key/test")
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetFile(context.Background(), "f1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.StorageEncryptionMode != StorageEncryptionSSEKMS {
+		t.Fatalf("storage_encryption_mode=%q, want %q", got.StorageEncryptionMode, StorageEncryptionSSEKMS)
+	}
+	if got.StorageEncryptionKeyID != "arn:aws:kms:ap-southeast-1:123456789012:key/test" {
+		t.Fatalf("storage_encryption_key_id=%q", got.StorageEncryptionKeyID)
+	}
+}
+
 func TestClearFileEmbeddingStateTx(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now().UTC()

--- a/pkg/datastore/file_tx_test.go
+++ b/pkg/datastore/file_tx_test.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -112,6 +113,40 @@ func TestUpdateFileStorageEncryptionTx(t *testing.T) {
 	}
 	if got.StorageEncryptionKeyID != "arn:aws:kms:ap-southeast-1:123456789012:key/test" {
 		t.Fatalf("storage_encryption_key_id=%q", got.StorageEncryptionKeyID)
+	}
+}
+
+func TestUpdateFileStorageEncryptionTxSameValues(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertFile(context.Background(), &File{
+		FileID:                "f1",
+		StorageType:           StorageDB9,
+		StorageRef:            "/blobs/f1",
+		StorageEncryptionMode: StorageEncryptionNone,
+		SizeBytes:             10,
+		Revision:              1,
+		Status:                StatusConfirmed,
+		CreatedAt:             now,
+		ConfirmedAt:           &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.InTx(context.Background(), func(tx *sql.Tx) error {
+		return s.UpdateFileStorageEncryptionTx(tx, "f1", StorageEncryptionNone, "")
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdateFileStorageEncryptionTxMissingFile(t *testing.T) {
+	s := newTestStore(t)
+	err := s.InTx(context.Background(), func(tx *sql.Tx) error {
+		return s.UpdateFileStorageEncryptionTx(tx, "missing", StorageEncryptionNone, "")
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err=%v, want %v", err, ErrNotFound)
 	}
 }
 

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -405,13 +405,14 @@ func (s *Store) InsertFile(ctx context.Context, f *File) (err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "insert_file", start, &err)
 
+	mode := fileStorageEncryptionModeForWrite(f.StorageEncryptionMode)
 	_, err = s.db.ExecContext(ctx, `INSERT INTO files
 		(file_id, storage_type, storage_ref, storage_encryption_mode, storage_encryption_key_id,
 		 content_blob, content_type, size_bytes, checksum_sha256,
 		 revision, status, source_id, content_text, description, created_at, confirmed_at, expires_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		f.FileID, f.StorageType, f.StorageRef, fileStorageEncryptionModeForWrite(f.StorageEncryptionMode),
-		f.StorageEncryptionKeyID, nilBytes(f.ContentBlob), nullStr(f.ContentType),
+		f.FileID, f.StorageType, f.StorageRef, mode,
+		storageEncryptionKeyIDForWrite(mode, f.StorageEncryptionKeyID), nilBytes(f.ContentBlob), nullStr(f.ContentType),
 		f.SizeBytes, nullStr(f.ChecksumSHA256), f.Revision, f.Status,
 		nullStr(f.SourceID), nullStr(f.ContentText), nullStr(f.Description),
 		f.CreatedAt.UTC(), nilTime(f.ConfirmedAt), nilTime(f.ExpiresAt))
@@ -1068,13 +1069,14 @@ func (s *Store) InsertUpload(ctx context.Context, u *Upload) (err error) {
 }
 
 func (s *Store) InsertUploadTx(db execer, u *Upload) error {
+	mode := uploadStorageEncryptionModeForWrite(u.StorageEncryptionMode)
 	_, err := db.Exec(`INSERT INTO uploads
 		(upload_id, file_id, target_path, s3_upload_id, s3_key, storage_encryption_mode,
 		 storage_encryption_key_id, total_size, part_size,
 		 parts_total, expected_revision, status, fingerprint_sha256, idempotency_key, description, created_at, updated_at, expires_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		u.UploadID, u.FileID, u.TargetPath, u.S3UploadID, u.S3Key,
-		uploadStorageEncryptionModeForWrite(u.StorageEncryptionMode), u.StorageEncryptionKeyID,
+		mode, storageEncryptionKeyIDForWrite(mode, u.StorageEncryptionKeyID),
 		u.TotalSize, u.PartSize, u.PartsTotal, nullInt64Ptr(u.ExpectedRevision), u.Status,
 		nullStr(u.FingerprintSHA), nullStr(u.IdempotencyKey), nullStr(u.Description),
 		u.CreatedAt.UTC(), u.UpdatedAt.UTC(), u.ExpiresAt.UTC())
@@ -1542,6 +1544,15 @@ func uploadStorageEncryptionModeForWrite(mode StorageEncryptionMode) StorageEncr
 		return StorageEncryptionNone
 	}
 	return mode
+}
+
+func storageEncryptionKeyIDForWrite(mode StorageEncryptionMode, keyID string) string {
+	switch mode {
+	case StorageEncryptionSSEKMS, StorageEncryptionDSSEKMS:
+		return keyID
+	default:
+		return ""
+	}
 }
 
 func scanUpload(s scanner) (*Upload, error) {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -23,18 +23,19 @@ import (
 )
 
 type PoolConfig struct {
-	MaxTenants        int
-	S3Dir             string
-	PublicURL         string
-	S3Bucket          string
-	S3Region          string
-	S3Prefix          string
-	S3RoleARN         string
-	S3Endpoint        string
-	S3ForcePathStyle  bool
-	S3AccessKeyID     string
-	S3SecretAccessKey string
-	S3SessionToken    string
+	MaxTenants         int
+	S3Dir              string
+	PublicURL          string
+	S3Bucket           string
+	S3Region           string
+	S3Prefix           string
+	S3RoleARN          string
+	S3Endpoint         string
+	S3ForcePathStyle   bool
+	S3AccessKeyID      string
+	S3SecretAccessKey  string
+	S3SessionToken     string
+	S3EncryptionPolicy meta.S3EncryptionPolicy
 
 	BackendOptions backend.Options
 
@@ -323,6 +324,12 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	decryptDurationMs := float64(time.Since(decryptStart).Microseconds()) / 1000.0
 	opts := p.cfg.BackendOptions
+	resolvedEncryptionPolicy, err := meta.ResolveS3EncryptionPolicy(p.cfg.S3EncryptionPolicy, t.S3EncryptionPolicy())
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve s3 encryption policy: %w", err)
+	}
+	opts.TenantID = t.ID
+	opts.S3EncryptionPolicy = resolvedEncryptionPolicy
 	if UsesTiDBAutoEmbedding(t.Provider) {
 		opts.DatabaseAutoEmbedding = true
 	}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -66,12 +66,13 @@ var (
 )
 
 type entry struct {
-	tenantID string
-	backend  *backend.Dat9Backend
-	store    *datastore.Store
-	elem     *list.Element
-	refs     int
-	retired  bool
+	tenantID           string
+	s3EncryptionPolicy meta.S3EncryptionPolicy
+	backend            *backend.Dat9Backend
+	store              *datastore.Store
+	elem               *list.Element
+	refs               int
+	retired            bool
 }
 
 func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
@@ -102,14 +103,27 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 		return nil, fmt.Errorf("tenant status: %s", t.Status)
 	}
 
+	s3EncryptionPolicy := t.S3EncryptionPolicy()
+	var toClose []*entry
 	p.mu.Lock()
 	if e, ok := p.items[t.ID]; ok {
-		p.order.MoveToFront(e.elem)
-		b := e.backend
+		if e.s3EncryptionPolicy == s3EncryptionPolicy {
+			p.order.MoveToFront(e.elem)
+			b := e.backend
+			p.mu.Unlock()
+			return b, nil
+		}
+		if removed := p.removeLocked(e.elem); removed != nil {
+			toClose = append(toClose, removed)
+		}
 		p.mu.Unlock()
-		return b, nil
+		for _, retired := range toClose {
+			closeEntry(retired)
+		}
+		toClose = nil
+	} else {
+		p.mu.Unlock()
 	}
-	p.mu.Unlock()
 
 	b, st, err := p.createBackend(ctx, t)
 	if err != nil {
@@ -118,16 +132,20 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 
 	p.mu.Lock()
 	if e, ok := p.items[t.ID]; ok {
-		b.Close()
-		_ = st.Close()
-		p.order.MoveToFront(e.elem)
-		p.mu.Unlock()
-		return e.backend, nil
+		if e.s3EncryptionPolicy == s3EncryptionPolicy {
+			b.Close()
+			_ = st.Close()
+			p.order.MoveToFront(e.elem)
+			p.mu.Unlock()
+			return e.backend, nil
+		}
+		if removed := p.removeLocked(e.elem); removed != nil {
+			toClose = append(toClose, removed)
+		}
 	}
-	e := &entry{tenantID: t.ID, backend: b, store: st}
+	e := &entry{tenantID: t.ID, s3EncryptionPolicy: s3EncryptionPolicy, backend: b, store: st}
 	e.elem = p.order.PushFront(e)
 	p.items[t.ID] = e
-	toClose := make([]*entry, 0, 1)
 	for p.order.Len() > p.maxSize {
 		oldest := p.order.Back()
 		if oldest != nil {
@@ -158,18 +176,31 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 		return nil, nil, fmt.Errorf("tenant status: %s", t.Status)
 	}
 
+	s3EncryptionPolicy := t.S3EncryptionPolicy()
+	var toClose []*entry
 	p.mu.Lock()
 	if e, ok := p.items[t.ID]; ok {
-		e.refs++
-		p.order.MoveToFront(e.elem)
+		if e.s3EncryptionPolicy == s3EncryptionPolicy {
+			e.refs++
+			p.order.MoveToFront(e.elem)
+			p.mu.Unlock()
+			logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
+				zap.String("tenant_id", t.ID),
+				zap.Bool("cache_hit", true),
+				zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
+			return e.backend, p.makeRelease(e), nil
+		}
+		if removed := p.removeLocked(e.elem); removed != nil {
+			toClose = append(toClose, removed)
+		}
 		p.mu.Unlock()
-		logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
-			zap.String("tenant_id", t.ID),
-			zap.Bool("cache_hit", true),
-			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
-		return e.backend, p.makeRelease(e), nil
+		for _, retired := range toClose {
+			closeEntry(retired)
+		}
+		toClose = nil
+	} else {
+		p.mu.Unlock()
 	}
-	p.mu.Unlock()
 
 	createBackendStart := time.Now()
 	b, st, err := p.createBackend(ctx, t)
@@ -180,22 +211,26 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 
 	p.mu.Lock()
 	if e, ok := p.items[t.ID]; ok {
-		e.refs++
-		p.order.MoveToFront(e.elem)
-		p.mu.Unlock()
-		b.Close()
-		_ = st.Close()
-		logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
-			zap.String("tenant_id", t.ID),
-			zap.Bool("cache_hit", true),
-			zap.Float64("create_backend_ms", createBackendDurationMs),
-			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
-		return e.backend, p.makeRelease(e), nil
+		if e.s3EncryptionPolicy == s3EncryptionPolicy {
+			e.refs++
+			p.order.MoveToFront(e.elem)
+			p.mu.Unlock()
+			b.Close()
+			_ = st.Close()
+			logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
+				zap.String("tenant_id", t.ID),
+				zap.Bool("cache_hit", true),
+				zap.Float64("create_backend_ms", createBackendDurationMs),
+				zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
+			return e.backend, p.makeRelease(e), nil
+		}
+		if removed := p.removeLocked(e.elem); removed != nil {
+			toClose = append(toClose, removed)
+		}
 	}
-	e := &entry{tenantID: t.ID, backend: b, store: st, refs: 1}
+	e := &entry{tenantID: t.ID, s3EncryptionPolicy: s3EncryptionPolicy, backend: b, store: st, refs: 1}
 	e.elem = p.order.PushFront(e)
 	p.items[t.ID] = e
-	toClose := make([]*entry, 0, 1)
 	for p.order.Len() > p.maxSize {
 		oldest := p.order.Back()
 		if oldest != nil {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/backend"
@@ -77,7 +78,70 @@ func TestPoolAcquireEvictionRetiresPinnedEntry(t *testing.T) {
 	assertStoreOpen(t, bB.Store())
 }
 
+func TestPoolAcquireReloadsS3EncryptionPolicyForNextWrite(t *testing.T) {
+	globalKeyID := "arn:aws:kms:ap-southeast-1:123456789012:key/pool-test"
+	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants: 2,
+		S3Dir:      t.TempDir(),
+		PublicURL:  "http://localhost:9091",
+		S3EncryptionPolicy: meta.S3EncryptionPolicy{
+			Mode:             meta.S3EncryptionModeSSEKMS,
+			KMSKeyID:         globalKeyID,
+			BucketKeyEnabled: true,
+		},
+	}, "tenant-a")
+	disabledBucketKey := false
+	tenant.S3EncryptionMode = meta.S3EncryptionModeNone
+	tenant.S3BucketKeyEnabled = &disabledBucketKey
+	ctx := context.Background()
+
+	b1, release1, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release1()
+	if _, _, err := b1.WriteCtxIfRevisionWithTagsResult(ctx, "/before.bin", []byte("before"), 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1, nil, ""); err != nil {
+		t.Fatalf("write before policy change: %v", err)
+	}
+	before, err := b1.Store().Stat(ctx, "/before.bin")
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+	if before.File.StorageEncryptionMode != datastore.StorageEncryptionNone {
+		t.Fatalf("before encryption mode=%q, want %q", before.File.StorageEncryptionMode, datastore.StorageEncryptionNone)
+	}
+
+	changed := *tenant
+	changed.S3EncryptionMode = meta.S3EncryptionModeSSEKMS
+	b2, release2, err := pool.Acquire(ctx, &changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release2()
+	if b1 == b2 {
+		t.Fatal("expected tenant policy change to recreate cached backend")
+	}
+	if _, _, err := b2.WriteCtxIfRevisionWithTagsResult(ctx, "/after.bin", []byte("after"), 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1, nil, ""); err != nil {
+		t.Fatalf("write after policy change: %v", err)
+	}
+	after, err := b2.Store().Stat(ctx, "/after.bin")
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if after.File.StorageEncryptionMode != datastore.StorageEncryptionSSEKMS {
+		t.Fatalf("after encryption mode=%q, want %q", after.File.StorageEncryptionMode, datastore.StorageEncryptionSSEKMS)
+	}
+	if after.File.StorageEncryptionKeyID != globalKeyID {
+		t.Fatalf("after encryption key=%q, want %q", after.File.StorageEncryptionKeyID, globalKeyID)
+	}
+}
+
 func newTestPoolAndTenant(t *testing.T, maxTenants int, tenantID string) (*Pool, *meta.Tenant) {
+	t.Helper()
+	return newTestPoolAndTenantWithConfig(t, PoolConfig{MaxTenants: maxTenants}, tenantID)
+}
+
+func newTestPoolAndTenantWithConfig(t *testing.T, cfg PoolConfig, tenantID string) (*Pool, *meta.Tenant) {
 	t.Helper()
 	initTenantPoolSchema(t, testDSN)
 	resetStore, err := datastore.Open(testDSN)
@@ -97,7 +161,7 @@ func newTestPoolAndTenant(t *testing.T, maxTenants int, tenantID string) (*Pool,
 	if err != nil {
 		t.Fatal(err)
 	}
-	pool := NewPool(PoolConfig{MaxTenants: maxTenants}, enc)
+	pool := NewPool(cfg, enc)
 	t.Cleanup(func() { pool.Close() })
 	return pool, cloneTenantForID(t, pool, nil, tenantID)
 }


### PR DESCRIPTION
## Summary
- resolves tenant/global S3 encryption policy into backend instances
- passes one resolved EncryptionOpts into PutObject/CreateMultipartUpload and stores matching file/upload encryption metadata
- records new db9-stored writes as explicit none instead of legacy
- adds regression coverage for S3 direct writes, multipart initiate, patch initiate, KMS failure no-fallback, and read-plan behavior

## Validation
- /usr/local/go/bin/go test -c ./pkg/...
- /usr/local/go/bin/go test -c ./cmd/...
- /usr/local/go/bin/go test ./cmd/drive9-server ./cmd/drive9-server-local
- git diff --check

Runtime pkg/backend focused tests are blocked locally by the existing rootless Docker/testcontainers issue; CI is expected to run them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 storage encryption policies are now fully integrated and applied to all file write operations.
  * Encryption metadata (mode and key ID) is persisted to the database for tracking and auditability.
  * Multi-level encryption policy configuration support across servers, tenants, and backend instances.

* **Tests**
  * Added comprehensive test coverage for S3 encryption behavior, including KMS integration, multipart uploads, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->