### PR TITLE
fix: sanitize storage backend errors

### DIFF
--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -64,6 +64,22 @@ type PresignPartEntry struct {
 }
 
 var ErrPartChecksumCountMismatch = errors.New("part checksum count mismatch")
+var ErrUploadClientProtocol = errors.New("upload client protocol error")
+
+type uploadClientProtocolError struct {
+	msg string
+}
+
+func (e uploadClientProtocolError) Error() string { return e.msg }
+
+func (e uploadClientProtocolError) Is(target error) bool {
+	return target == ErrUploadClientProtocol
+}
+
+func uploadClientProtocolErrorf(format string, args ...any) error {
+	return uploadClientProtocolError{msg: fmt.Sprintf(format, args...)}
+}
+
 var lookupActiveUploadByPath = func(store *datastore.Store, ctx context.Context, path string) (*datastore.Upload, error) {
 	return store.GetUploadByPath(ctx, path)
 }
@@ -576,7 +592,7 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 	}
 	if partNumber < 1 || partNumber > upload.PartsTotal {
 		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
-		return nil, fmt.Errorf("invalid part number %d: must be between 1 and %d", partNumber, upload.PartsTotal)
+		return nil, uploadClientProtocolErrorf("invalid part number %d: must be between 1 and %d", partNumber, upload.PartsTotal)
 	}
 
 	parts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
@@ -630,14 +646,14 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 	}
 	if len(entries) > MaxPresignBatch {
 		metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
-		return nil, fmt.Errorf("batch too large: %d parts exceeds limit of %d", len(entries), MaxPresignBatch)
+		return nil, uploadClientProtocolErrorf("batch too large: %d parts exceeds limit of %d", len(entries), MaxPresignBatch)
 	}
 	// Reject duplicate part numbers in the batch.
 	seen := make(map[int]bool, len(entries))
 	for _, e := range entries {
 		if seen[e.PartNumber] {
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
-			return nil, fmt.Errorf("duplicate part number %d in batch", e.PartNumber)
+			return nil, uploadClientProtocolErrorf("duplicate part number %d in batch", e.PartNumber)
 		}
 		seen[e.PartNumber] = true
 	}
@@ -655,7 +671,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		pn := e.PartNumber
 		if pn < 1 || pn > upload.PartsTotal {
 			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
-			return nil, fmt.Errorf("invalid part number %d: must be between 1 and %d", pn, upload.PartsTotal)
+			return nil, uploadClientProtocolErrorf("invalid part number %d: must be between 1 and %d", pn, upload.PartsTotal)
 		}
 		partSize := parts[pn-1].Size
 		resolveChecksumStart := time.Now()
@@ -745,7 +761,7 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	clientValidationStart := time.Now()
 	if len(clientParts) != upload.PartsTotal {
 		metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
-		return fmt.Errorf("part count mismatch: client sent %d, expected %d", len(clientParts), upload.PartsTotal)
+		return uploadClientProtocolErrorf("part count mismatch: client sent %d, expected %d", len(clientParts), upload.PartsTotal)
 	}
 
 	// Reject duplicate part numbers and validate completeness (all 1..N present)
@@ -753,11 +769,11 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	for _, cp := range clientParts {
 		if _, dup := clientPartMap[cp.Number]; dup {
 			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
-			return fmt.Errorf("duplicate part number %d in complete request", cp.Number)
+			return uploadClientProtocolErrorf("duplicate part number %d in complete request", cp.Number)
 		}
 		if cp.Number < 1 || cp.Number > upload.PartsTotal {
 			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
-			return fmt.Errorf("invalid part number %d: must be between 1 and %d", cp.Number, upload.PartsTotal)
+			return uploadClientProtocolErrorf("invalid part number %d: must be between 1 and %d", cp.Number, upload.PartsTotal)
 		}
 		clientPartMap[cp.Number] = cp.ETag
 	}
@@ -783,11 +799,11 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 		s3ETag, ok := s3PartMap[partNum]
 		if !ok {
 			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
-			return fmt.Errorf("part %d not found in S3", partNum)
+			return uploadClientProtocolErrorf("part %d not found in S3", partNum)
 		}
 		if normalizeETag(clientETag) != normalizeETag(s3ETag) {
 			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
-			return fmt.Errorf("part %d ETag mismatch: client=%q, S3=%q", partNum, clientETag, s3ETag)
+			return uploadClientProtocolErrorf("part %d ETag mismatch: client=%q, S3=%q", partNum, clientETag, s3ETag)
 		}
 	}
 	etagValidationDurationMs := uploadPhaseMs(etagValidationStart)
@@ -797,12 +813,12 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	expectedParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	if len(s3Parts) != len(expectedParts) {
 		metrics.RecordOperation("backend", "confirm_upload_v2", "incomplete", time.Since(start))
-		return fmt.Errorf("incomplete upload: S3 has %d parts, expected %d", len(s3Parts), len(expectedParts))
+		return uploadClientProtocolErrorf("incomplete upload: S3 has %d parts, expected %d", len(s3Parts), len(expectedParts))
 	}
 	for i, p := range s3Parts {
 		if p.Size != expectedParts[i].Size {
 			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
-			return fmt.Errorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
+			return uploadClientProtocolErrorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
 		}
 	}
 	sizeValidationDurationMs := uploadPhaseMs(sizeValidationStart)
@@ -864,17 +880,17 @@ func (b *Dat9Backend) ConfirmUploadWithTags(ctx context.Context, uploadID string
 	// Verify all parts are present, correctly sized, and have ETags
 	if len(parts) != upload.PartsTotal {
 		metrics.RecordOperation("backend", "confirm_upload", "incomplete", time.Since(start))
-		return fmt.Errorf("incomplete upload: got %d parts, expected %d", len(parts), upload.PartsTotal)
+		return uploadClientProtocolErrorf("incomplete upload: got %d parts, expected %d", len(parts), upload.PartsTotal)
 	}
 	expectedParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	for i, p := range parts {
 		if p.Size != expectedParts[i].Size {
 			metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
-			return fmt.Errorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
+			return uploadClientProtocolErrorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
 		}
 		if p.ETag == "" {
 			metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
-			return fmt.Errorf("part %d missing ETag", p.Number)
+			return uploadClientProtocolErrorf("part %d missing ETag", p.Number)
 		}
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -798,7 +798,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "write_upload_initiate_failed", "path", path, "error", err)...)
 			metricEvent(r.Context(), "fs_write", "result", "error")
-			errJSON(w, http.StatusInternalServerError, err.Error())
+			errJSONInternalStorage(w)
 			return
 		}
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "write_upload_initiated", "path", path, "parts", len(plan.Parts))...)
@@ -850,7 +850,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "write_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "fs_write", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "write_ok", "path", path, "bytes", len(data))...)
@@ -943,7 +943,7 @@ func (s *Server) handlePatch(w http.ResponseWriter, r *http.Request, path string
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "patch_upload_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "fs_patch", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 
@@ -1029,7 +1029,7 @@ func (s *Server) handleAppend(w http.ResponseWriter, r *http.Request, path strin
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "append_upload_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "fs_append", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 
@@ -1361,7 +1361,7 @@ func (s *Server) handleUploadInitiate(w http.ResponseWriter, r *http.Request, b 
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_failed", "path", req.Path, "error", err)...)
 		metricEvent(r.Context(), "fs_write", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_ok", "path", req.Path, "parts", len(plan.Parts))...)
@@ -1416,7 +1416,7 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "upload_complete", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	tags, err := parseUploadCompleteTags(w, r)
@@ -1438,6 +1438,12 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
+		if errors.Is(err, backend.ErrUploadClientProtocol) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_client_protocol_error", "upload_id", uploadID, "error", err)...)
+			metricEvent(r.Context(), "upload_complete", "result", "error")
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		if errors.Is(err, datastore.ErrRevisionConflict) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_revision_conflict", "upload_id", uploadID, "error", err)...)
 			metricEvent(r.Context(), "upload_complete", "result", "conflict")
@@ -1446,7 +1452,7 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "upload_complete", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_ok", "upload_id", uploadID)...)
@@ -1495,7 +1501,7 @@ func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uplo
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "upload_resume", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_ok", "upload_id", uploadID, "parts", len(plan.Parts))...)
@@ -1659,7 +1665,7 @@ func (s *Server) handleUploadAbort(w http.ResponseWriter, r *http.Request, uploa
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_abort_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "upload_abort", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_abort_ok", "upload_id", uploadID)...)
@@ -1771,7 +1777,7 @@ func (s *Server) handleV2UploadInitiate(w http.ResponseWriter, r *http.Request) 
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_failed", "path", req.Path, "error", err)...)
 		metricEvent(r.Context(), "v2_upload_initiate", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_ok", "path", req.Path, "part_size", plan.PartSize, "total_parts", plan.TotalParts)...)
@@ -1816,9 +1822,15 @@ func (s *Server) handleV2PresignPart(w http.ResponseWriter, r *http.Request, upl
 			errJSON(w, http.StatusConflict, "upload is not active")
 			return
 		}
+		if errors.Is(err, backend.ErrUploadClientProtocol) || errors.Is(err, backend.ErrUnsupportedAlgorithm) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_client_protocol_error", "upload_id", uploadID, "part_number", req.PartNumber, "error", err)...)
+			metricEvent(r.Context(), "v2_presign_part", "result", "error")
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_failed", "upload_id", uploadID, "part_number", req.PartNumber, "error", err)...)
 		metricEvent(r.Context(), "v2_presign_part", "result", "error")
-		errJSON(w, http.StatusBadRequest, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_ok", "upload_id", uploadID, "part_number", req.PartNumber)...)
@@ -1861,9 +1873,15 @@ func (s *Server) handleV2PresignBatch(w http.ResponseWriter, r *http.Request, up
 			errJSON(w, http.StatusConflict, "upload is not active")
 			return
 		}
+		if errors.Is(err, backend.ErrUploadClientProtocol) || errors.Is(err, backend.ErrUnsupportedAlgorithm) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_client_protocol_error", "upload_id", uploadID, "error", err)...)
+			metricEvent(r.Context(), "v2_presign_batch", "result", "error")
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "v2_presign_batch", "result", "error")
-		errJSON(w, http.StatusBadRequest, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_ok", "upload_id", uploadID, "count", len(urls))...)
@@ -1911,7 +1929,7 @@ func (s *Server) handleV2UploadComplete(w http.ResponseWriter, r *http.Request, 
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "v2_upload_complete", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	if err := b.ConfirmUploadV2WithTags(r.Context(), uploadID, req.Parts, req.Tags); err != nil {
@@ -1940,9 +1958,15 @@ func (s *Server) handleV2UploadComplete(w http.ResponseWriter, r *http.Request, 
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
+		if errors.Is(err, backend.ErrUploadClientProtocol) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_client_protocol_error", "upload_id", uploadID, "error", err)...)
+			metricEvent(r.Context(), "v2_upload_complete", "result", "error")
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "v2_upload_complete", "result", "error")
-		errJSON(w, http.StatusBadRequest, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_ok", "upload_id", uploadID)...)
@@ -1961,7 +1985,7 @@ func (s *Server) handleV2UploadAbort(w http.ResponseWriter, r *http.Request, upl
 	if err := b.AbortUploadV2(r.Context(), uploadID); err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_abort_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "v2_upload_abort", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSONInternalStorage(w)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_abort_ok", "upload_id", uploadID)...)
@@ -2166,6 +2190,12 @@ func errJSON(w http.ResponseWriter, code int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+const internalStorageErrorMessage = "storage backend unavailable; contact support"
+
+func errJSONInternalStorage(w http.ResponseWriter) {
+	errJSON(w, http.StatusInternalServerError, internalStorageErrorMessage)
 }
 
 func (s *Server) handleSQL(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -61,6 +62,50 @@ func newTestServerWithS3Config(t *testing.T, backendOpts backend.Options, worker
 		t.Fatal(err)
 	}
 	return NewWithConfig(Config{Backend: b, SemanticWorkers: workerOpts}), s3c
+}
+
+type failingCreateMultipartS3 struct {
+	*s3client.LocalS3Client
+	err error
+}
+
+func (s *failingCreateMultipartS3) CreateMultipartUpload(ctx context.Context, key string, algo s3client.ChecksumAlgo, encOpts s3client.EncryptionOpts) (*s3client.MultipartUpload, error) {
+	return nil, s.err
+}
+
+func newTestServerWithCreateMultipartError(t *testing.T, err error) *Server {
+	t.Helper()
+
+	blobDir, err2 := os.MkdirTemp("", "dat9-srv-blobs-*")
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(blobDir) })
+
+	s3Dir, err2 := os.MkdirTemp("", "dat9-srv-s3-*")
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
+
+	initServerTenantSchema(t, testDSN)
+	store, err2 := datastore.Open(testDSN)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	testmysql.ResetDB(t, store.DB())
+	t.Cleanup(func() { _ = store.Close() })
+
+	localS3, err2 := s3client.NewLocal(s3Dir, "http://localhost:9091/s3")
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	failingS3 := &failingCreateMultipartS3{LocalS3Client: localS3, err: err}
+	b, err2 := backend.NewWithS3ModeAndOptions(store, failingS3, true, backend.Options{})
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	return NewWithConfig(Config{Backend: b})
 }
 
 func partChecksumHeader(data []byte) string {
@@ -251,6 +296,188 @@ func TestUploadInitiateByBody202(t *testing.T) {
 	if len(plan.Parts) == 0 {
 		t.Error("expected parts")
 	}
+}
+
+func TestUploadInitiateSanitizesCreateMultipartProviderError(t *testing.T) {
+	leakedErr := errors.New("operation error S3: CreateMultipartUpload, https response error StatusCode: 403, RequestID: QCRQPQAG0J880ZFK, HostID: KAjMF1T1LtFzMU/V7Tzp0rt14AqR7irO2HJtlHdXBCQioAv14tJsNkbUWvBZbSGYcFxqroX6fdo=, api error AccessDenied: User: arn:aws:sts::401696231252:assumed-role/prod-dat9-server-irsa/1777968029598718639 is not authorized to perform: kms:GenerateDataKey on resource: arn:aws:kms:ap-southeast-1:401696231252:key/fca526d7-bbff-44d4-9eee-7dd44053e85b")
+	s := newTestServerWithCreateMultipartError(t, leakedErr)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	body := make([]byte, 1<<20)
+	v1Body, _ := json.Marshal(map[string]any{
+		"path":           "/leak-v1.bin",
+		"total_size":     len(body),
+		"part_checksums": strings.Split(partChecksumHeader(body), ","),
+	})
+	v2Body, _ := json.Marshal(map[string]any{
+		"path":       "/leak-v2.bin",
+		"total_size": len(body),
+	})
+
+	tests := []struct {
+		name        string
+		req         *http.Request
+		contentType string
+	}{
+		{
+			name:        "large put",
+			req:         mustNewRequest(t, http.MethodPut, ts.URL+"/v1/fs/leak-put.bin", bytes.NewReader(body)),
+			contentType: "",
+		},
+		{
+			name:        "v1 initiate",
+			req:         mustNewRequest(t, http.MethodPost, ts.URL+"/v1/uploads/initiate", bytes.NewReader(v1Body)),
+			contentType: "application/json",
+		},
+		{
+			name:        "v2 initiate",
+			req:         mustNewRequest(t, http.MethodPost, ts.URL+"/v2/uploads/initiate", bytes.NewReader(v2Body)),
+			contentType: "application/json",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.contentType != "" {
+				tt.req.Header.Set("Content-Type", tt.contentType)
+			}
+			if tt.req.Method == http.MethodPut {
+				tt.req.ContentLength = int64(len(body))
+				tt.req.Header.Set("X-Dat9-Part-Checksums", partChecksumHeader(body))
+			}
+			resp, err := http.DefaultClient.Do(tt.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusInternalServerError {
+				respBody, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 500: %s", resp.StatusCode, respBody)
+			}
+			respBody, _ := io.ReadAll(resp.Body)
+			text := string(respBody)
+			if !strings.Contains(text, internalStorageErrorMessage) {
+				t.Fatalf("response = %q, want sanitized storage error", text)
+			}
+			for _, leaked := range []string{
+				"arn:aws",
+				"RequestID",
+				"HostID",
+				"GenerateDataKey",
+				"prod-dat9-server-irsa",
+				"operation error S3",
+				"fca526d7-bbff-44d4-9eee-7dd44053e85b",
+			} {
+				if strings.Contains(text, leaked) {
+					t.Fatalf("response leaked %q: %s", leaked, text)
+				}
+			}
+		})
+	}
+}
+
+func TestV2PresignValidationErrorRemainsClientError(t *testing.T) {
+	s, _ := newTestServerWithS3(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	plan := mustInitiateV2Upload(t, ts, "/v2-presign-invalid.bin", 20<<20)
+
+	body, _ := json.Marshal(map[string]any{"part_number": plan.TotalParts + 1})
+	req := mustNewRequest(t, http.MethodPost, ts.URL+"/v2/uploads/"+plan.UploadID+"/presign", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, respBody)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	text := string(respBody)
+	if !strings.Contains(text, "invalid part number") {
+		t.Fatalf("response = %q, want invalid part number", text)
+	}
+	if strings.Contains(text, internalStorageErrorMessage) {
+		t.Fatalf("response = %q, want client error not internal storage error", text)
+	}
+}
+
+func TestV2CompleteValidationErrorRemainsClientError(t *testing.T) {
+	s, _ := newTestServerWithS3(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	plan := mustInitiateV2Upload(t, ts, "/v2-complete-invalid.bin", 20<<20)
+	presignBody, _ := json.Marshal(map[string]any{"part_number": 1})
+	req := mustNewRequest(t, http.MethodPost, ts.URL+"/v2/uploads/"+plan.UploadID+"/presign", bytes.NewReader(presignBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("presign status = %d, want 200", resp.StatusCode)
+	}
+
+	completeBody, _ := json.Marshal(map[string]any{
+		"parts": []map[string]any{{"number": 1, "etag": "etag-1"}},
+	})
+	req = mustNewRequest(t, http.MethodPost, ts.URL+"/v2/uploads/"+plan.UploadID+"/complete", bytes.NewReader(completeBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, respBody)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	text := string(respBody)
+	if !strings.Contains(text, "part count mismatch") {
+		t.Fatalf("response = %q, want part count mismatch", text)
+	}
+	if strings.Contains(text, internalStorageErrorMessage) {
+		t.Fatalf("response = %q, want client error not internal storage error", text)
+	}
+}
+
+func mustInitiateV2Upload(t *testing.T, ts *httptest.Server, path string, totalSize int64) backend.UploadPlanV2 {
+	t.Helper()
+	reqBody, _ := json.Marshal(map[string]any{
+		"path":       path,
+		"total_size": totalSize,
+	})
+	req := mustNewRequest(t, http.MethodPost, ts.URL+"/v2/uploads/initiate", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("initiate status = %d, want 202: %s", resp.StatusCode, body)
+	}
+	var plan backend.UploadPlanV2
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+func mustNewRequest(t *testing.T, method, url string, body io.Reader) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
 }
 
 func TestV1UploadInitiateReturnsAllPresignedParts(t *testing.T) {


### PR DESCRIPTION
## Summary\n- replace unexpected storage write/upload API failures with a stable sanitized client error\n- keep provider details in server logs instead of response bodies\n- add regression coverage for CreateMultipartUpload failures leaking AWS ARN/RequestID/HostID/KMS details\n\n## Validation\n- /usr/local/go/bin/go test -c ./pkg/server\n- /usr/local/go/bin/go test -c ./pkg/... ./cmd/...\n- /usr/local/go/bin/go test ./cmd/drive9-server ./cmd/drive9-server-local\n- git diff --check\n\n## Local test note\n- /usr/local/go/bin/go test ./pkg/server -run TestUploadInitiateSanitizesCreateMultipartProviderError -count=1 is blocked locally by testcontainers: rootless Docker not found\n- PATH="/usr/local/go/bin:/Users/qiffang/.codex/tmp/arg0/codex-arg0CjlbdM:/Users/qiffang/.slock/agents/27e7bfef-4ef8-4cd6-ba5f-057142b2827e/.slock:/Users/qiffang/.npm/_npx/277f35d2ed0078b9/node_modules/.bin:/Users/qiffang/node_modules/.bin:/Users/node_modules/.bin:/node_modules/.bin:/opt/homebrew/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/node-gyp-bin:/Users/qiffang/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" make test TEST_PKGS='./pkg/server' TEST_RUN='TestUploadInitiateSanitizesCreateMultipartProviderError' hits the same local testcontainers blocker\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal storage error responses now sanitize sensitive provider information, preventing leakage of identifiers and backend-specific details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->