### PR TITLE
fix: preserve FUSE lockfile namespace during chmod

### DIFF
--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -37,6 +37,10 @@ type CommitEntry struct {
 // 0 for multipart where the revision is not returned inline).
 type CommitSuccessFunc func(entry *CommitEntry, committedRev int64)
 
+// CommitCleanupFunc is called after a successful commit's local shadow/index
+// state has been removed but before the queue entry is dequeued.
+type CommitCleanupFunc func(entry *CommitEntry)
+
 // CommitQueue manages ordered background remote commits with baseRev tracking.
 // It provides backpressure when the queue exceeds maxPending items.
 type CommitQueue struct {
@@ -56,6 +60,9 @@ type CommitQueue struct {
 	// OnSuccess is called after successful upload with the committed
 	// revision. Used by dat9fs to seed readCache and update inode revision.
 	OnSuccess CommitSuccessFunc
+
+	// OnCleanup is called after local commit state has been removed.
+	OnCleanup CommitCleanupFunc
 
 	// workCh dispatches entries to upload workers. The buffer is always
 	// larger than maxPending so Enqueue never blocks.
@@ -213,6 +220,24 @@ func (cq *CommitQueue) WaitPath(path string) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+}
+
+// HasPath reports whether a path is queued or currently in flight.
+func (cq *CommitQueue) HasPath(path string) bool {
+	if cq == nil {
+		return false
+	}
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	if _, inflight := cq.inFlight[path]; inflight {
+		return true
+	}
+	for _, e := range cq.queue {
+		if e.Path == path {
+			return true
+		}
+	}
+	return false
 }
 
 // WaitPrefix blocks until all in-flight or queued commits under the given
@@ -458,6 +483,9 @@ func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) {
 	}
 	if cq.index != nil {
 		cq.index.Remove(entry.Path)
+	}
+	if cq.OnCleanup != nil {
+		cq.OnCleanup(entry)
 	}
 
 	// Remove from queue AFTER all cleanup so WaitPath sees the entry

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1121,8 +1121,16 @@ func (fs *Dat9FS) openHandleEntry(p string) (*InodeEntry, bool) {
 		fh.Lock()
 		size := fh.Dirty.Size()
 		fh.Unlock()
-		ino := fs.inodes.Lookup(p, false, size, time.Now())
-		return fs.inodes.GetEntry(ino)
+		// This path reconstructs a dentry for an already-open writable file
+		// after the kernel dropped its lookup ref. Reuse the handle's inode
+		// instead of path Lookup so a stale/missing path map cannot allocate a
+		// second inode for the same open file.
+		if !fs.inodes.IncrementLookup(fh.Ino) {
+			return nil, false
+		}
+		fs.inodes.UpdateSize(fh.Ino, size)
+		fs.inodes.UpdateMtime(fh.Ino, time.Now())
+		return fs.inodes.GetEntry(fh.Ino)
 	}
 	return nil, false
 }
@@ -1131,6 +1139,9 @@ func (fs *Dat9FS) cleanupReleasedInode(ino uint64, p string) {
 	if fs.hasOpenHandle(ino, p) || fs.hasPendingLocalState(p) || fs.hasQueuedCommit(p) {
 		return
 	}
+	// Concurrent Release/commit cleanup for the same path is safe here:
+	// RemoveFileIfUnreferenced holds the inode map lock and is idempotent when
+	// another goroutine already removed the forgotten regular-file mapping.
 	fs.inodes.RemoveFileIfUnreferenced(ino)
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1079,6 +1079,8 @@ func (fs *Dat9FS) shouldPreserveForgottenInode(entry *InodeEntry) bool {
 }
 
 func (fs *Dat9FS) hasOpenHandle(ino uint64, p string) bool {
+	// TODO: if git/package-manager workloads keep many handles open, maintain
+	// path/inode indexes instead of scanning the whole handle table.
 	for _, fh := range fs.fileHandles.Snapshot() {
 		if fh == nil {
 			continue
@@ -2825,6 +2827,9 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 	fh, ok := fs.fileHandles.Get(input.Fh)
 	if ok {
 		defer func() {
+			if fh.Prefetch != nil {
+				fh.Prefetch.Close()
+			}
 			fs.fileHandles.Delete(input.Fh)
 			fs.cleanupReleasedInode(fh.Ino, fh.Path)
 		}()
@@ -2910,10 +2915,6 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			fs.notifyInode(fh.Ino)
 			parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
 			fs.notifyInode(parentIno)
-			if fh.Prefetch != nil {
-				fh.Prefetch.Close()
-			}
-			fs.fileHandles.Delete(input.Fh)
 			return
 		}
 
@@ -2983,12 +2984,6 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				fs.notifyInode(fh.Ino)
 				parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
 				fs.notifyInode(parentIno)
-
-				// Close prefetcher to cancel inflight goroutines.
-				if fh.Prefetch != nil {
-					fh.Prefetch.Close()
-				}
-				fs.fileHandles.Delete(input.Fh)
 				return
 			}
 			// Stale cache — remove it, fall through to sync upload.
@@ -3032,12 +3027,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			log.Printf("flush failed for %s (status %d), aborted stream upload", fh.Path, st)
 		}
 
-		// Close prefetcher to cancel inflight goroutines.
-		if fh.Prefetch != nil {
-			fh.Prefetch.Close()
-		}
 	}
-	fs.fileHandles.Delete(input.Fh)
 }
 
 // flushHandleDebounced wraps flushHandle with optional debouncing for small files.

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -993,6 +993,16 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		}
 	}
 
+	// Open-created namespace overlay: a file may be open and dirty before
+	// Flush has staged it into PendingIndex. Git's lock-file path can chmod
+	// such a file by path while the kernel has already forgotten the original
+	// lookup ref; resolving from the open handle keeps POSIX create->chmod
+	// sequences from seeing a false ENOENT.
+	if entry, ok := fs.openHandleEntry(childP); ok {
+		fs.fillEntryOut(entry, out)
+		return gofuse.OK
+	}
+
 	stat, err := fs.lookupStatWithRetry(cancel, childP)
 	if err != nil {
 		if !isNotFoundErr(err) {
@@ -1050,7 +1060,83 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 }
 
 func (fs *Dat9FS) Forget(nodeId uint64, nlookup uint64) {
+	entry, ok := fs.inodes.GetEntry(nodeId)
+	if ok && !entry.IsDir && fs.shouldPreserveForgottenInode(entry) {
+		fs.inodes.ForgetKeepMapping(nodeId, nlookup)
+		return
+	}
 	fs.inodes.Forget(nodeId, nlookup)
+}
+
+func (fs *Dat9FS) shouldPreserveForgottenInode(entry *InodeEntry) bool {
+	if entry == nil {
+		return false
+	}
+	if fs.hasOpenHandle(entry.Ino, entry.Path) {
+		return true
+	}
+	return fs.hasPendingLocalState(entry.Path) || fs.hasQueuedCommit(entry.Path)
+}
+
+func (fs *Dat9FS) hasOpenHandle(ino uint64, p string) bool {
+	for _, fh := range fs.fileHandles.Snapshot() {
+		if fh == nil {
+			continue
+		}
+		if fh.Ino == ino || fh.Path == p {
+			return true
+		}
+	}
+	return false
+}
+
+func (fs *Dat9FS) hasPendingLocalState(p string) bool {
+	if fs.pendingIndex != nil {
+		if _, ok := fs.pendingIndex.GetMeta(p); ok {
+			return true
+		}
+	}
+	if fs.writeBack != nil {
+		if _, ok := fs.writeBack.GetMeta(p); ok {
+			return true
+		}
+	}
+	if fs.shadowStore != nil && fs.shadowStore.Has(p) {
+		return true
+	}
+	return false
+}
+
+func (fs *Dat9FS) hasQueuedCommit(p string) bool {
+	return fs.commitQueue != nil && fs.commitQueue.HasPath(p)
+}
+
+func (fs *Dat9FS) openHandleEntry(p string) (*InodeEntry, bool) {
+	for _, fh := range fs.fileHandles.Snapshot() {
+		if fh == nil || fh.Path != p || fh.Dirty == nil {
+			continue
+		}
+		fh.Lock()
+		size := fh.Dirty.Size()
+		fh.Unlock()
+		ino := fs.inodes.Lookup(p, false, size, time.Now())
+		return fs.inodes.GetEntry(ino)
+	}
+	return nil, false
+}
+
+func (fs *Dat9FS) cleanupReleasedInode(ino uint64, p string) {
+	if fs.hasOpenHandle(ino, p) || fs.hasPendingLocalState(p) || fs.hasQueuedCommit(p) {
+		return
+	}
+	fs.inodes.RemoveFileIfUnreferenced(ino)
+}
+
+func (fs *Dat9FS) cleanupCommittedInode(ino uint64, p string) {
+	if fs.hasOpenHandle(ino, p) || fs.hasPendingLocalState(p) {
+		return
+	}
+	fs.inodes.RemoveFileIfUnreferenced(ino)
 }
 
 func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *gofuse.AttrOut) gofuse.Status {
@@ -2738,6 +2824,11 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 	fh, ok := fs.fileHandles.Get(input.Fh)
 	if ok {
+		defer func() {
+			fs.fileHandles.Delete(input.Fh)
+			fs.cleanupReleasedInode(fh.Ino, fh.Path)
+		}()
+
 		// Unpin shadow if this handle pinned it, so deferred removals can proceed.
 		if fh.ShadowPinned && fs.shadowStore != nil {
 			defer fs.shadowStore.Unpin(fh.ShadowGen)
@@ -3381,6 +3472,13 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 		fs.readCache.Invalidate(entry.Path)
 		fs.dirCache.Invalidate(parentDir(entry.Path))
 	}
+}
+
+func (fs *Dat9FS) onCommitQueueCleanup(entry *CommitEntry) {
+	if entry == nil || entry.Inode == 0 {
+		return
+	}
+	fs.cleanupCommittedInode(entry.Inode, entry.Path)
 }
 
 func (fs *Dat9FS) String() string {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1205,6 +1205,129 @@ func TestCreateFileGetsStreamUploader(t *testing.T) {
 	}
 }
 
+func TestLookupOpenCreatedFileAfterForgetSupportsGitChmodLock(t *testing.T) {
+	var remoteCalls atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "remote should not be consulted for open-created file", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_CREAT),
+	}, "config.lock", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	if _, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Offset:   0,
+	}, []byte("[core]\n\tfilemode = false\n")); st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+
+	// The kernel may drop the lookup ref while the file handle is still open.
+	// A subsequent chmod(path), as used by git's lock-file code, must resolve
+	// the still-open local file rather than returning ENOENT before Flush has
+	// staged it into PendingIndex.
+	fs.Forget(createOut.NodeId, 1)
+
+	var lookupOut gofuse.EntryOut
+	st = fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "config.lock", &lookupOut)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup after Forget status = %v, want OK", st)
+	}
+	if lookupOut.NodeId != createOut.NodeId {
+		t.Fatalf("Lookup NodeId = %d, want original inode %d", lookupOut.NodeId, createOut.NodeId)
+	}
+
+	var attrOut gofuse.AttrOut
+	st = fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+			Valid:    gofuse.FATTR_MODE,
+			Mode:     0o644,
+		},
+	}, &attrOut)
+	if st != gofuse.OK {
+		t.Fatalf("mode-only SetAttr after Lookup status = %v, want OK", st)
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote calls = %d, want 0 for open-created lookup", got)
+	}
+}
+
+func TestCommitQueueCleanupRemovesForgottenPendingInode(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	const p = "/config.lock"
+	ino := fs.inodes.Lookup(p, false, 7, time.Now())
+	if err := shadow.WriteFull(p, []byte("config\n"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(p, 7, PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	fs.Forget(ino, 1)
+	if _, ok := fs.inodes.GetPath(ino); !ok {
+		t.Fatal("Forget removed pending inode mapping; chmod/rename may see ENOENT")
+	}
+
+	pending.Remove(p)
+	shadow.Remove(p)
+	fs.onCommitQueueCleanup(&CommitEntry{Path: p, Inode: ino})
+	if _, ok := fs.inodes.GetPath(ino); ok {
+		t.Fatal("commit cleanup left forgotten inode mapping after local state was removed")
+	}
+}
+
+func TestForgetPreservesQueuedCommitInodeUntilCleanup(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	const p = "/config.lock"
+	ino := fs.inodes.Lookup(p, false, 7, time.Now())
+	fs.commitQueue = &CommitQueue{
+		queue:    []*CommitEntry{{Path: p, Inode: ino}},
+		inFlight: map[string]struct{}{},
+		canceled: make(map[string]struct{}),
+	}
+
+	fs.Forget(ino, 1)
+	if _, ok := fs.inodes.GetPath(ino); !ok {
+		t.Fatal("Forget removed queued commit inode mapping before commit cleanup")
+	}
+
+	fs.commitQueue.queue = nil
+	fs.onCommitQueueCleanup(&CommitEntry{Path: p, Inode: ino})
+	if _, ok := fs.inodes.GetPath(ino); ok {
+		t.Fatal("commit cleanup left queued inode mapping after queue/local state cleared")
+	}
+}
+
 func TestStatFs_ReportsVirtualCapacity(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1328,6 +1328,38 @@ func TestForgetPreservesQueuedCommitInodeUntilCleanup(t *testing.T) {
 	}
 }
 
+func TestReleaseCleansForgottenInodeWithoutLocalState(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	const p = "/config.lock"
+	ino := fs.inodes.Lookup(p, false, 7, time.Now())
+
+	var openOut gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	fs.Forget(ino, 1)
+	if _, ok := fs.inodes.GetPath(ino); !ok {
+		t.Fatal("Forget removed inode mapping while file handle was still open")
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: openOut.Fh})
+
+	if _, ok := fs.fileHandles.Get(openOut.Fh); ok {
+		t.Fatal("Release left closed file handle in handle table")
+	}
+	if _, ok := fs.inodes.GetPath(ino); ok {
+		t.Fatal("Release cleanup left forgotten inode mapping after local state was gone")
+	}
+}
+
 func TestStatFs_ReportsVirtualCapacity(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/inode.go
+++ b/pkg/fuse/inode.go
@@ -180,6 +180,42 @@ func (m *InodeToPath) Forget(ino uint64, nlookup uint64) {
 	}
 }
 
+// ForgetKeepMapping decrements the kernel lookup count without removing the
+// inode/path mapping. Use this when a regular file is still represented by
+// local open or pending state even though the kernel dropped its lookup ref.
+func (m *InodeToPath) ForgetKeepMapping(ino uint64, nlookup uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.byInode[ino]
+	if !ok {
+		return
+	}
+	entry.Nlookup -= int64(nlookup)
+	if entry.Nlookup < 0 {
+		entry.Nlookup = 0
+	}
+}
+
+// RemoveFileIfUnreferenced removes a regular-file mapping only when the kernel
+// no longer holds lookup refs. Directory and root mappings are intentionally
+// preserved because later directory operations may still reference them.
+func (m *InodeToPath) RemoveFileIfUnreferenced(ino uint64) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.byInode[ino]
+	if !ok {
+		return false
+	}
+	if ino == 1 || entry.IsDir || entry.Nlookup > 0 {
+		return false
+	}
+	delete(m.byPath, entry.Path)
+	delete(m.byInode, ino)
+	return true
+}
+
 // UpdateSize updates the size of the entry identified by the given inode.
 func (m *InodeToPath) UpdateSize(ino uint64, size int64) {
 	m.mu.Lock()

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -241,6 +241,7 @@ func Mount(opts *MountOptions) error {
 			if shadowStore != nil && pendingIdx != nil {
 				cq := NewCommitQueue(c, shadowStore, pendingIdx, journal, opts.UploadConcurrency, maxCommitQueuePending, opts.RemoteRoot)
 				cq.OnSuccess = dat9fs.onCommitQueueSuccess
+				cq.OnCleanup = dat9fs.onCommitQueueCleanup
 				cq.RecoverPending()
 				dat9fs.commitQueue = cq
 			}


### PR DESCRIPTION
## Summary
- preserve regular-file inode mappings while open, pending, or queued local state still represents the path
- resolve open dirty handles during Lookup before falling back to remote Stat
- add commit-queue cleanup hook to remove forgotten stale mappings only after local commit state is gone

## Tests
- /usr/local/go/bin/go test ./pkg/fuse/...
- /usr/local/go/bin/go test -c ./pkg/fuse ./cmd/drive9
- git diff --check

## Notes
This targets the Ubuntu FUSE git lock-file failure: create/write/close/chmod/rename on .git/config.lock can otherwise observe a false ENOENT when kernel Forget races local pending/commit state. Real Ubuntu FUSE git clone should still be used to verify the live path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved inode lifecycle management for files with open handles or pending local state
  * Added commit queue cleanup callback support

* **Tests**
  * New test validating file lookup behavior and git compatibility after kernel forget operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->