### PR TITLE
fix: self-filter structural SSE resets

### DIFF
--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -24,6 +24,9 @@ type ChangeEvent struct {
 type ResetEvent struct {
 	Seq    uint64 `json:"seq"`
 	Reason string `json:"reason"`
+	Path   string `json:"path,omitempty"`
+	Op     string `json:"op,omitempty"`
+	Actor  string `json:"actor,omitempty"`
 }
 
 // EventHandler receives SSE events. Exactly one of the pointer arguments is

--- a/pkg/client/events_test.go
+++ b/pkg/client/events_test.go
@@ -1,0 +1,34 @@
+package client
+
+import "testing"
+
+func TestParseAndDispatchResetIncludesStructuralFields(t *testing.T) {
+	data := `{"seq":7,"reason":"structural_change","path":"/old","op":"rename","actor":"actor1"}`
+
+	var got *ResetEvent
+	parseAndDispatch("reset", data, func(change *ChangeEvent, reset *ResetEvent) {
+		if change != nil {
+			t.Fatalf("change=%+v, want nil", change)
+		}
+		got = reset
+	})
+
+	if got == nil {
+		t.Fatal("reset event was not dispatched")
+	}
+	if got.Seq != 7 {
+		t.Errorf("Seq=%d, want 7", got.Seq)
+	}
+	if got.Reason != "structural_change" {
+		t.Errorf("Reason=%q, want structural_change", got.Reason)
+	}
+	if got.Path != "/old" {
+		t.Errorf("Path=%q, want /old", got.Path)
+	}
+	if got.Op != "rename" {
+		t.Errorf("Op=%q, want rename", got.Op)
+	}
+	if got.Actor != "actor1" {
+		t.Errorf("Actor=%q, want actor1", got.Actor)
+	}
+}

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -52,6 +52,9 @@ func (w *SSEWatcher) handleEvent(change *client.ChangeEvent, reset *client.Reset
 		return
 	}
 	if reset != nil && reset.Reason != "" {
+		if w.actor != "" && reset.Reason == "structural_change" && reset.Actor == w.actor {
+			return
+		}
 		// Only handle resets with an explicit reason (not heartbeats).
 		w.handleReset(reset)
 	}

--- a/pkg/fuse/sse_test.go
+++ b/pkg/fuse/sse_test.go
@@ -183,6 +183,39 @@ func TestSSEWatcherSelfFilterSkipsOwnEvents(t *testing.T) {
 	}
 }
 
+func TestSSEWatcherSelfFilterSkipsOwnStructuralReset(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	fs.readCache.Put("/test.txt", []byte("data"), 1)
+	fs.dirCache.Put("/", []CachedFileInfo{{Name: "test.txt", Size: 4}})
+
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+
+	w.handleEvent(nil, &client.ResetEvent{
+		Seq:    5,
+		Reason: "structural_change",
+		Path:   "/test.txt",
+		Op:     "delete",
+		Actor:  "my-actor",
+	})
+
+	if _, ok := fs.readCache.Get("/test.txt", 1); !ok {
+		t.Error("readCache should NOT be cleared after own structural reset")
+	}
+	if _, ok := fs.dirCache.Get("/"); !ok {
+		t.Error("dirCache should NOT be cleared after own structural reset")
+	}
+}
+
 func TestSSEWatcherHandleEventReset(t *testing.T) {
 	opts := &MountOptions{
 		CacheSize: 1 << 20,
@@ -208,6 +241,70 @@ func TestSSEWatcherHandleEventReset(t *testing.T) {
 	}
 	if _, ok := fs.dirCache.Get("/"); ok {
 		t.Error("dirCache should be cleared after reset")
+	}
+}
+
+func TestSSEWatcherForeignStructuralResetClearsCache(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	fs.readCache.Put("/test.txt", []byte("data"), 1)
+	fs.dirCache.Put("/", []CachedFileInfo{{Name: "test.txt", Size: 4}})
+
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+
+	w.handleEvent(nil, &client.ResetEvent{
+		Seq:    6,
+		Reason: "structural_change",
+		Path:   "/test.txt",
+		Op:     "delete",
+		Actor:  "other-actor",
+	})
+
+	if _, ok := fs.readCache.Get("/test.txt", 1); ok {
+		t.Error("readCache should be cleared after foreign structural reset")
+	}
+	if _, ok := fs.dirCache.Get("/"); ok {
+		t.Error("dirCache should be cleared after foreign structural reset")
+	}
+}
+
+func TestSSEWatcherOwnActorNonStructuralResetClearsCache(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	fs.readCache.Put("/test.txt", []byte("data"), 1)
+	fs.dirCache.Put("/", []CachedFileInfo{{Name: "test.txt", Size: 4}})
+
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+
+	w.handleEvent(nil, &client.ResetEvent{
+		Seq:    7,
+		Reason: "seq_too_old",
+		Actor:  "my-actor",
+	})
+
+	if _, ok := fs.readCache.Get("/test.txt", 1); ok {
+		t.Error("readCache should be cleared after non-structural reset")
+	}
+	if _, ok := fs.dirCache.Get("/"); ok {
+		t.Error("dirCache should be cleared after non-structural reset")
 	}
 }
 

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -321,7 +321,7 @@ func isStructuralOp(op string) bool {
 func sendSSEEvent(w *sseBufferedWriter, ev ChangeEvent) {
 	if isStructuralOp(ev.Op) {
 		// Structural ops are sent as reset events per the accepted design.
-		sendSSEReset(w, ev.Seq, "structural_change")
+		sendSSEStructuralReset(w, ev)
 		return
 	}
 	data, err := json.Marshal(ev)
@@ -334,10 +334,31 @@ func sendSSEEvent(w *sseBufferedWriter, ev ChangeEvent) {
 	}
 }
 
+type sseResetPayload struct {
+	Seq    uint64 `json:"seq"`
+	Reason string `json:"reason"`
+	Path   string `json:"path,omitempty"`
+	Op     string `json:"op,omitempty"`
+	Actor  string `json:"actor,omitempty"`
+}
+
+func sendSSEStructuralReset(w *sseBufferedWriter, ev ChangeEvent) {
+	data, _ := json.Marshal(sseResetPayload{
+		Seq:    ev.Seq,
+		Reason: "structural_change",
+		Path:   ev.Path,
+		Op:     ev.Op,
+		Actor:  ev.Actor,
+	})
+	if _, err := fmt.Fprintf(w, "event: reset\ndata: %s\n\n", data); err == nil {
+		w.recordWrite()
+	}
+}
+
 func sendSSEReset(w *sseBufferedWriter, seq uint64, reason string) {
-	data, _ := json.Marshal(map[string]interface{}{
-		"seq":    seq,
-		"reason": reason,
+	data, _ := json.Marshal(sseResetPayload{
+		Seq:    seq,
+		Reason: reason,
 	})
 	if _, err := fmt.Fprintf(w, "event: reset\ndata: %s\n\n", data); err == nil {
 		w.recordWrite()

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -84,6 +84,15 @@ func TestSSEEndpointSince0SendsReset(t *testing.T) {
 	if data["reason"] != "initial_sync" {
 		t.Errorf("reset reason=%v, want initial_sync", data["reason"])
 	}
+	if _, ok := data["actor"]; ok {
+		t.Errorf("initial_sync reset should not include actor: %+v", data)
+	}
+	if _, ok := data["path"]; ok {
+		t.Errorf("initial_sync reset should not include path: %+v", data)
+	}
+	if _, ok := data["op"]; ok {
+		t.Errorf("initial_sync reset should not include op: %+v", data)
+	}
 }
 
 func TestSSEEndpointReplay(t *testing.T) {
@@ -233,6 +242,15 @@ func TestSSEStructuralOpEmitsReset(t *testing.T) {
 	if reset1["reason"] != "structural_change" {
 		t.Errorf("rename reset reason=%v, want structural_change", reset1["reason"])
 	}
+	if reset1["actor"] != "actor1" {
+		t.Errorf("rename reset actor=%v, want actor1", reset1["actor"])
+	}
+	if reset1["path"] != "/old.txt" {
+		t.Errorf("rename reset path=%v, want /old.txt", reset1["path"])
+	}
+	if reset1["op"] != "rename" {
+		t.Errorf("rename reset op=%v, want rename", reset1["op"])
+	}
 
 	// Event 3: mkdir → also reset.
 	ev2, ok := readSSEEvent(scanner)
@@ -242,6 +260,22 @@ func TestSSEStructuralOpEmitsReset(t *testing.T) {
 	if ev2.Event != "reset" {
 		t.Fatalf("mkdir op: event=%q, want reset", ev2.Event)
 	}
+	var reset2 map[string]interface{}
+	if err := json.Unmarshal([]byte(ev2.Data), &reset2); err != nil {
+		t.Fatalf("unmarshal reset2: %v", err)
+	}
+	if reset2["reason"] != "structural_change" {
+		t.Errorf("mkdir reset reason=%v, want structural_change", reset2["reason"])
+	}
+	if reset2["actor"] != "actor1" {
+		t.Errorf("mkdir reset actor=%v, want actor1", reset2["actor"])
+	}
+	if reset2["path"] != "/dir" {
+		t.Errorf("mkdir reset path=%v, want /dir", reset2["path"])
+	}
+	if reset2["op"] != "mkdir" {
+		t.Errorf("mkdir reset op=%v, want mkdir", reset2["op"])
+	}
 
 	// Event 4: delete → also reset.
 	ev3, ok := readSSEEvent(scanner)
@@ -250,6 +284,22 @@ func TestSSEStructuralOpEmitsReset(t *testing.T) {
 	}
 	if ev3.Event != "reset" {
 		t.Fatalf("delete op: event=%q, want reset", ev3.Event)
+	}
+	var reset3 map[string]interface{}
+	if err := json.Unmarshal([]byte(ev3.Data), &reset3); err != nil {
+		t.Fatalf("unmarshal reset3: %v", err)
+	}
+	if reset3["reason"] != "structural_change" {
+		t.Errorf("delete reset reason=%v, want structural_change", reset3["reason"])
+	}
+	if reset3["actor"] != "actor1" {
+		t.Errorf("delete reset actor=%v, want actor1", reset3["actor"])
+	}
+	if reset3["path"] != "/gone.txt" {
+		t.Errorf("delete reset path=%v, want /gone.txt", reset3["path"])
+	}
+	if reset3["op"] != "delete" {
+		t.Errorf("delete reset op=%v, want delete", reset3["op"])
 	}
 }
 
@@ -295,6 +345,15 @@ func TestSSEStructuralOpLiveEmitsReset(t *testing.T) {
 	}
 	if data["reason"] != "structural_change" {
 		t.Errorf("live rename reason=%v, want structural_change", data["reason"])
+	}
+	if data["actor"] != "remote-actor" {
+		t.Errorf("live rename actor=%v, want remote-actor", data["actor"])
+	}
+	if data["path"] != "/old" {
+		t.Errorf("live rename path=%v, want /old", data["path"])
+	}
+	if data["op"] != "rename" {
+		t.Errorf("live rename op=%v, want rename", data["op"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- include actor/path/op on structural SSE reset payloads while keeping non-structural resets unchanged
- parse optional reset actor metadata in the Go client
- skip own-actor structural resets in FUSE while preserving full resets for foreign, legacy, and non-structural reset events

## Tests
- /usr/local/go/bin/go test ./pkg/fuse
- /usr/local/go/bin/go test -c ./pkg/server ./pkg/client ./pkg/fuse

Note: runtime pkg/client/pkg/server tests are blocked locally by testcontainers rootless Docker discovery, so compile-only coverage was used for those packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reset events now include Path, Operation, and Actor information for enhanced event tracking.
  * System now intelligently filters self-originated structural changes to prevent unnecessary cache invalidation.

* **Tests**
  * Added comprehensive test coverage for actor-based event filtering and structural vs. non-structural reset handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->