### PR TITLE
fix: remove redundant kernel notify from local FUSE handlers

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -75,6 +75,10 @@ type Dat9FS struct {
 	// notifications complete before shutdown.
 	notifyWg sync.WaitGroup
 
+	// notifyCount tracks total kernel notify calls (EntryNotify + InodeNotify)
+	// for observability and testing. Incremented even when fs.server is nil.
+	notifyCount atomic.Int64
+
 	// lookupStatRetry* counters track only the Lookup->Stat retry path so
 	// operators can distinguish absorbed interrupt noise from exhausted retries
 	// on the primary probe route. GetAttr and list-fallback retries intentionally
@@ -928,6 +932,7 @@ func (fs *Dat9FS) Init(server *gofuse.Server) {
 // notifyEntry tells the kernel to invalidate a directory entry cache.
 // Safe to call even if the server is not yet initialized (e.g., during tests).
 func (fs *Dat9FS) notifyEntry(parentIno uint64, name string) {
+	fs.notifyCount.Add(1)
 	if fs.server == nil {
 		return
 	}
@@ -945,6 +950,7 @@ func (fs *Dat9FS) notifyEntry(parentIno uint64, name string) {
 // notifyInode tells the kernel to invalidate cached attributes and data
 // for an inode. off=0, sz=0 means invalidate all cached data.
 func (fs *Dat9FS) notifyInode(ino uint64) {
+	fs.notifyCount.Add(1)
 	if fs.server == nil {
 		return
 	}
@@ -1290,8 +1296,8 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 		}
 		entry.Size = newSize
 		fs.inodes.UpdateSize(input.NodeId, newSize)
-		// Invalidate kernel attr cache for the truncated inode.
-		fs.notifyInode(input.NodeId)
+		// Kernel already receives updated attrs via the SetAttr reply —
+		// no need for an explicit notifyInode here.
 	}
 
 	fs.fillAttr(entry, &out.Attr)
@@ -1322,9 +1328,8 @@ func (fs *Dat9FS) Mkdir(cancel <-chan struct{}, input *gofuse.MkdirIn, name stri
 
 	parentPath, _ := fs.inodes.GetPath(input.NodeId)
 	fs.dirCache.Invalidate(parentPath)
-	fs.notifyEntry(input.NodeId, name)
-	// Invalidate kernel's cached directory listing for parent.
-	fs.notifyInode(input.NodeId)
+	// Kernel already receives the new entry via the Mkdir reply —
+	// no need for notifyEntry/notifyInode here.
 
 	fs.fillEntryOut(entry, out)
 	return gofuse.OK
@@ -1404,9 +1409,8 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 
 	parentPath, _ := fs.inodes.GetPath(header.NodeId)
 	fs.dirCache.Invalidate(parentPath)
-	// Tell kernel the entry no longer exists and parent dir changed.
-	fs.notifyEntry(header.NodeId, name)
-	fs.notifyInode(header.NodeId)
+	// Kernel initiated the unlink and receives OK — it already
+	// removes the dentry. No notifyEntry/notifyInode needed.
 	return gofuse.OK
 }
 
@@ -1475,9 +1479,8 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 
 	parentPath, _ := fs.inodes.GetPath(header.NodeId)
 	fs.dirCache.Invalidate(parentPath)
-	// Tell kernel the entry no longer exists and parent dir changed.
-	fs.notifyEntry(header.NodeId, name)
-	fs.notifyInode(header.NodeId)
+	// Kernel initiated the rmdir and receives OK — it already
+	// removes the dentry. No notifyEntry/notifyInode needed.
 	return gofuse.OK
 }
 
@@ -1539,14 +1542,12 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 
 			oldParent, _ := fs.inodes.GetPath(input.NodeId)
 			fs.dirCache.Invalidate(oldParent)
-			fs.notifyEntry(input.NodeId, oldName)
-			fs.notifyInode(input.NodeId)
 			if input.Newdir != input.NodeId {
 				newParent, _ := fs.inodes.GetPath(input.Newdir)
 				fs.dirCache.Invalidate(newParent)
-				fs.notifyEntry(input.Newdir, newName)
-				fs.notifyInode(input.Newdir)
 			}
+			// Kernel initiated the rename and receives OK — it already
+			// updates its dentry cache. No notifyEntry/notifyInode needed.
 			return gofuse.OK
 		}
 
@@ -1602,16 +1603,12 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 
 	oldParent, _ := fs.inodes.GetPath(input.NodeId)
 	fs.dirCache.Invalidate(oldParent)
-	// Tell kernel old entry is gone and old parent dir changed.
-	fs.notifyEntry(input.NodeId, oldName)
-	fs.notifyInode(input.NodeId)
 	if input.Newdir != input.NodeId {
 		newParent, _ := fs.inodes.GetPath(input.Newdir)
 		fs.dirCache.Invalidate(newParent)
-		// Tell kernel new parent dir changed too.
-		fs.notifyEntry(input.Newdir, newName)
-		fs.notifyInode(input.Newdir)
 	}
+	// Kernel initiated the rename and receives OK — it already
+	// updates its dentry cache. No notifyEntry/notifyInode needed.
 	return gofuse.OK
 }
 
@@ -1911,9 +1908,8 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 
 	parentPath, _ := fs.inodes.GetPath(input.NodeId)
 	fs.dirCache.Invalidate(parentPath)
-	fs.notifyEntry(input.NodeId, name)
-	// Invalidate kernel's cached directory listing for parent.
-	fs.notifyInode(input.NodeId)
+	// Kernel initiated the create and receives the new entry via reply —
+	// no need for notifyEntry/notifyInode here.
 	return gofuse.OK
 }
 
@@ -2923,9 +2919,8 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 
 			fs.readCache.Invalidate(fh.Path)
 			fs.dirCache.Invalidate(parentDir(fh.Path))
-			fs.notifyInode(fh.Ino)
-			parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
-			fs.notifyInode(parentIno)
+			// Local release — kernel already knows about this close.
+			// No notifyInode needed; userspace caches are invalidated above.
 			return
 		}
 
@@ -2992,9 +2987,8 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				// Invalidate caches so subsequent reads see fresh data.
 				fs.readCache.Invalidate(fh.Path)
 				fs.dirCache.Invalidate(parentDir(fh.Path))
-				fs.notifyInode(fh.Ino)
-				parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
-				fs.notifyInode(parentIno)
+				// Local release — kernel already knows about this close.
+				// No notifyInode needed; userspace caches are invalidated above.
 				return
 			}
 			// Stale cache — remove it, fall through to sync upload.
@@ -3102,10 +3096,9 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		}
 		fs.dirCache.Invalidate(parentDir(filePath))
 		fs.inodes.UpdateSize(ino, int64(len(data)))
-		fs.notifyInode(ino)
-		parentIno, _ := fs.inodes.GetInode(parentDir(filePath))
-		fs.notifyEntry(parentIno, path.Base(filePath))
-		fs.notifyInode(parentIno)
+		// Local debounced flush — kernel is not aware of this async
+		// operation and does not need notify. Userspace caches are
+		// updated above; kernel will pick up new attrs on next getattr.
 	})
 
 	// Do NOT ClearDirty here — the buffer stays dirty as a safety net.
@@ -3217,9 +3210,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			fs.pendingIndex.Remove(fh.Path)
 		}
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
-		fs.notifyInode(fh.Ino)
-		parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
-		fs.notifyInode(parentIno)
+		// Local flush — kernel receives the Flush reply with status.
+		// No notifyInode needed; kernel will refresh attrs on next access.
 		return gofuse.OK
 	}
 
@@ -3268,9 +3260,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			fs.pendingIndex.Remove(fh.Path)
 		}
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
-		fs.notifyInode(fh.Ino)
-		parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
-		fs.notifyInode(parentIno)
+		// Local flush — kernel receives the Flush reply with status.
+		// No notifyInode needed; kernel will refresh attrs on next access.
 		return gofuse.OK
 	}
 
@@ -3356,11 +3347,9 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	}
 	fs.dirCache.Invalidate(parentDir(fh.Path))
 	fs.inodes.UpdateSize(fh.Ino, size)
-	// Invalidate kernel attr/data cache for this inode and parent dir listing.
-	fs.notifyInode(fh.Ino)
-	parentIno, _ := fs.inodes.GetInode(parentDir(fh.Path))
-	fs.notifyEntry(parentIno, path.Base(fh.Path))
-	fs.notifyInode(parentIno)
+	// Local flush — kernel receives the Flush reply with status.
+	// No notifyInode/notifyEntry needed; userspace caches are updated
+	// above and kernel will refresh attrs on next getattr/lookup.
 	return gofuse.OK
 }
 
@@ -3465,10 +3454,9 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 		fs.inodes.UpdateRevision(entry.Inode, committedRev)
 		fs.inodes.UpdateSize(entry.Inode, entry.Size)
 		fs.dirCache.Invalidate(parentDir(entry.Path))
-		fs.notifyInode(entry.Inode)
-		parentIno, _ := fs.inodes.GetInode(parentDir(entry.Path))
-		fs.notifyEntry(parentIno, path.Base(entry.Path))
-		fs.notifyInode(parentIno)
+		// Local async commit completion — this is not an external change.
+		// Kernel does not need notify; userspace caches and inode state
+		// are updated above. Kernel will see new attrs on next access.
 	} else {
 		fs.readCache.Invalidate(entry.Path)
 		fs.dirCache.Invalidate(parentDir(entry.Path))

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -67,7 +67,9 @@ type Dat9FS struct {
 
 	// server is the go-fuse server, set during Init(). Used to send
 	// kernel cache invalidation notifications (EntryNotify, InodeNotify)
-	// so that long TTLs don't serve stale data after local mutations.
+	// for external/SSE-driven changes that the kernel doesn't know about.
+	// Local FUSE mutations do NOT use server notify — the kernel updates
+	// its own cache from the FUSE reply.
 	server *gofuse.Server
 
 	// notifyWg tracks inflight asynchronous kernel notification goroutines

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3516,3 +3516,235 @@ func TestIsTransientReadErr(t *testing.T) {
 		})
 	}
 }
+
+// TestLocalMutations_NoKernelNotify verifies that local FUSE mutations
+// (Create, Mkdir, Unlink, Rmdir, Rename) do NOT produce kernel
+// notifyEntry/notifyInode calls. The kernel already knows the result
+// of its own syscalls via the FUSE reply — redundant notify floods
+// the FUSE channel and causes EAGAIN under load (git clone).
+func TestLocalMutations_NoKernelNotify(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "100")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	// Pre-populate inodes for mutation targets.
+	fs.inodes.Lookup("/existing.txt", false, 100, time.Now())
+	fs.inodes.Lookup("/oldname.txt", false, 100, time.Now())
+	fs.inodes.Lookup("/existingdir", true, 0, time.Now())
+
+	tests := []struct {
+		name string
+		fn   func() gofuse.Status
+	}{
+		{
+			name: "Create",
+			fn: func() gofuse.Status {
+				var out gofuse.CreateOut
+				return fs.Create(nil, &gofuse.CreateIn{
+					InHeader: gofuse.InHeader{NodeId: 1},
+				}, "new.txt", &out)
+			},
+		},
+		{
+			name: "Mkdir",
+			fn: func() gofuse.Status {
+				var out gofuse.EntryOut
+				return fs.Mkdir(nil, &gofuse.MkdirIn{
+					InHeader: gofuse.InHeader{NodeId: 1},
+				}, "newdir", &out)
+			},
+		},
+		{
+			name: "Unlink",
+			fn: func() gofuse.Status {
+				return fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, "existing.txt")
+			},
+		},
+		{
+			name: "Rmdir",
+			fn: func() gofuse.Status {
+				return fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "existingdir")
+			},
+		},
+		{
+			name: "Rename",
+			fn: func() gofuse.Status {
+				return fs.Rename(nil, &gofuse.RenameIn{
+					InHeader: gofuse.InHeader{NodeId: 1},
+					Newdir:   1,
+				}, "oldname.txt", "renamed.txt")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			before := fs.notifyCount.Load()
+			st := tc.fn()
+			after := fs.notifyCount.Load()
+			if st != gofuse.OK {
+				t.Fatalf("%s returned %v, want OK", tc.name, st)
+			}
+			if delta := after - before; delta != 0 {
+				t.Fatalf("%s produced %d kernel notify calls, want 0", tc.name, delta)
+			}
+		})
+	}
+}
+
+// TestCreateWriteFlushRelease_NoKernelNotify verifies that the full
+// create→write→flush→release lifecycle produces zero kernel notify calls.
+// Previously each step (Create, Release, commit queue success) would send
+// redundant NOTIFY_INVAL_ENTRY/INODE calls that flooded the FUSE channel.
+func TestCreateWriteFlushRelease_NoKernelNotify(t *testing.T) {
+	ts, uploadedCh := newTestServer(t)
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	before := fs.notifyCount.Load()
+
+	// Create
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "hook.sample", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+
+	// Write
+	_, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}, []byte("#!/bin/sh\nexit 0\n"))
+	if st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+
+	// Flush
+	st = fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+	if st != gofuse.OK {
+		t.Fatalf("Flush: %v", st)
+	}
+
+	// Release
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+
+	// Wait for commit queue upload.
+	select {
+	case <-uploadedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("commit queue upload timed out")
+	}
+
+	// Allow async commit queue success callback to run.
+	time.Sleep(50 * time.Millisecond)
+
+	after := fs.notifyCount.Load()
+	if delta := after - before; delta != 0 {
+		t.Fatalf("create→write→flush→release→commit produced %d kernel notify calls, want 0", delta)
+	}
+}
+
+// TestSSEForeignChange_StillNotifiesKernel verifies that SSE-driven
+// invalidation (from a foreign actor) still produces kernel notify calls.
+// Only local-initiated operations should skip notify; external changes
+// must still invalidate the kernel cache.
+func TestSSEForeignChange_StillNotifiesKernel(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	// Pre-populate an inode so SSE invalidation has something to notify.
+	fs.inodes.Lookup("/remote-file.txt", false, 100, time.Now())
+
+	before := fs.notifyCount.Load()
+
+	// Simulate SSE-driven cache invalidation (same code path as sse.go handleChange).
+	ino, ok := fs.inodes.GetInode("/remote-file.txt")
+	if !ok {
+		t.Fatal("expected inode for /remote-file.txt")
+	}
+	fs.readCache.Invalidate("/remote-file.txt")
+	fs.dirCache.Invalidate("/")
+	// These are the same calls SSE watcher makes for foreign changes.
+	fs.notifyInode(ino)
+	parentIno, _ := fs.inodes.GetInode("/")
+	fs.notifyEntry(parentIno, "remote-file.txt")
+
+	after := fs.notifyCount.Load()
+	if delta := after - before; delta != 2 {
+		t.Fatalf("SSE foreign change produced %d kernel notify calls, want 2", delta)
+	}
+}
+
+// TestSetAttr_NoKernelNotify verifies that SetAttr (truncate) does not
+// produce redundant kernel notify. The kernel receives updated attrs
+// via the SetAttr reply itself.
+func TestSetAttr_NoKernelNotify(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	ino := fs.inodes.Lookup("/trunc.txt", false, 100, time.Now())
+
+	// Open with O_RDWR so there's a dirty handle for truncate.
+	fh := &FileHandle{
+		Ino:   ino,
+		Path:  "/trunc.txt",
+		Flags: uint32(syscall.O_RDWR),
+		Dirty: NewWriteBuffer("/trunc.txt", 100, 8*1024*1024),
+	}
+	fhID := fs.fileHandles.Allocate(fh)
+
+	before := fs.notifyCount.Load()
+
+	var out gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_SIZE | gofuse.FATTR_FH,
+			Fh:      fhID,
+			Size:    0,
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr: %v", st)
+	}
+
+	after := fs.notifyCount.Load()
+	if delta := after - before; delta != 0 {
+		t.Fatalf("SetAttr produced %d kernel notify calls, want 0", delta)
+	}
+}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3615,9 +3615,8 @@ func TestLocalMutations_NoKernelNotify(t *testing.T) {
 }
 
 // TestCreateWriteFlushRelease_NoKernelNotify verifies that the full
-// create→write→flush→release lifecycle produces zero kernel notify calls.
-// Previously each step (Create, Release, commit queue success) would send
-// redundant NOTIFY_INVAL_ENTRY/INODE calls that flooded the FUSE channel.
+// create→write→flush→release lifecycle produces zero kernel notify calls
+// AND that userspace visibility is preserved (inode size, dirCache).
 func TestCreateWriteFlushRelease_NoKernelNotify(t *testing.T) {
 	ts, uploadedCh := newTestServer(t)
 	defer ts.Close()
@@ -3637,11 +3636,13 @@ func TestCreateWriteFlushRelease_NoKernelNotify(t *testing.T) {
 		t.Fatalf("Create: %v", st)
 	}
 
+	wantData := []byte("#!/bin/sh\nexit 0\n")
+
 	// Write
 	_, st = fs.Write(nil, &gofuse.WriteIn{
 		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
 		Fh:       createOut.Fh,
-	}, []byte("#!/bin/sh\nexit 0\n"))
+	}, wantData)
 	if st != gofuse.OK {
 		t.Fatalf("Write: %v", st)
 	}
@@ -3675,12 +3676,93 @@ func TestCreateWriteFlushRelease_NoKernelNotify(t *testing.T) {
 	if delta := after - before; delta != 0 {
 		t.Fatalf("create→write→flush→release→commit produced %d kernel notify calls, want 0", delta)
 	}
+
+	// Verify userspace state is still correct despite no kernel notify.
+	// This is the key behavioral assertion: "no notify AND no visibility regression".
+
+	// 1. Inode size should reflect the written data.
+	wantSize := int64(len(wantData))
+	entry, ok := fs.inodes.GetEntry(createOut.NodeId)
+	if !ok {
+		t.Fatal("inode entry not found after commit")
+	}
+	if entry.Size != wantSize {
+		t.Fatalf("inode size = %d, want %d", entry.Size, wantSize)
+	}
+
+	// 2. dirCache for parent should have been invalidated (not stale).
+	if _, cached := fs.dirCache.Get("/"); cached {
+		t.Fatal("parent dirCache should have been invalidated after create+commit")
+	}
+}
+
+// TestOnCommitQueueSuccess_NoKernelNotify_SeedsReadCache verifies that
+// onCommitQueueSuccess updates userspace state (readCache, inode revision/size)
+// without producing kernel notify calls. This is the mechanism that ensures
+// same-mount read-after-close returns correct content.
+func TestOnCommitQueueSuccess_NoKernelNotify_SeedsReadCache(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+
+	// Set up shadowStore with test data (simulates what Flush stages).
+	shadowDir := t.TempDir()
+	shadow, err := NewShadowStore(shadowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+
+	wantData := []byte("#!/bin/sh\nexit 0\n")
+
+	// Pre-populate inode and write shadow data (mimics Flush staging).
+	ino := fs.inodes.Lookup("/hook.sample", false, 0, time.Now())
+	if err := shadow.WriteFull("/hook.sample", wantData, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	before := fs.notifyCount.Load()
+
+	// Simulate commit queue success callback.
+	fs.onCommitQueueSuccess(&CommitEntry{
+		Path:  "/hook.sample",
+		Inode: ino,
+		Size:  int64(len(wantData)),
+	}, 42) // committedRev=42
+
+	after := fs.notifyCount.Load()
+	if delta := after - before; delta != 0 {
+		t.Fatalf("onCommitQueueSuccess produced %d kernel notify calls, want 0", delta)
+	}
+
+	// Verify readCache was seeded with correct data.
+	cachedData, hit := fs.readCache.Get("/hook.sample", 0)
+	if !hit {
+		t.Fatal("readCache miss after onCommitQueueSuccess — read-after-close would hit remote")
+	}
+	if string(cachedData) != string(wantData) {
+		t.Fatalf("readCache content = %q, want %q", cachedData, wantData)
+	}
+
+	// Verify inode revision and size updated.
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode entry not found")
+	}
+	if entry.Size != int64(len(wantData)) {
+		t.Fatalf("inode size = %d, want %d", entry.Size, len(wantData))
+	}
+
+	// Verify dirCache was invalidated.
+	if _, cached := fs.dirCache.Get("/"); cached {
+		t.Fatal("parent dirCache should have been invalidated")
+	}
 }
 
 // TestSSEForeignChange_StillNotifiesKernel verifies that SSE-driven
-// invalidation (from a foreign actor) still produces kernel notify calls.
-// Only local-initiated operations should skip notify; external changes
-// must still invalidate the kernel cache.
+// invalidation (from a foreign actor) still produces kernel notify calls
+// through the actual SSEWatcher.handleEvent code path. Only local-initiated
+// operations skip notify; external changes must invalidate the kernel cache.
 func TestSSEForeignChange_StillNotifiesKernel(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
@@ -3689,23 +3771,53 @@ func TestSSEForeignChange_StillNotifiesKernel(t *testing.T) {
 	// Pre-populate an inode so SSE invalidation has something to notify.
 	fs.inodes.Lookup("/remote-file.txt", false, 100, time.Now())
 
+	// Create an SSEWatcher with our own actor ID.
+	w := &SSEWatcher{fs: fs, actor: "mount-abc"}
+
+	// --- Foreign actor change event → should notify kernel ---
 	before := fs.notifyCount.Load()
-
-	// Simulate SSE-driven cache invalidation (same code path as sse.go handleChange).
-	ino, ok := fs.inodes.GetInode("/remote-file.txt")
-	if !ok {
-		t.Fatal("expected inode for /remote-file.txt")
+	w.handleEvent(&client.ChangeEvent{
+		Path:  "/remote-file.txt",
+		Op:    "write",
+		Actor: "other-mount-xyz",
+	}, nil)
+	afterChange := fs.notifyCount.Load()
+	if delta := afterChange - before; delta == 0 {
+		t.Fatal("SSE foreign ChangeEvent produced 0 kernel notify calls, want >0")
 	}
-	fs.readCache.Invalidate("/remote-file.txt")
-	fs.dirCache.Invalidate("/")
-	// These are the same calls SSE watcher makes for foreign changes.
-	fs.notifyInode(ino)
-	parentIno, _ := fs.inodes.GetInode("/")
-	fs.notifyEntry(parentIno, "remote-file.txt")
 
-	after := fs.notifyCount.Load()
-	if delta := after - before; delta != 2 {
-		t.Fatalf("SSE foreign change produced %d kernel notify calls, want 2", delta)
+	// --- Own actor change event → should NOT notify kernel ---
+	before2 := fs.notifyCount.Load()
+	w.handleEvent(&client.ChangeEvent{
+		Path:  "/remote-file.txt",
+		Op:    "write",
+		Actor: "mount-abc", // same as our actor
+	}, nil)
+	afterSelf := fs.notifyCount.Load()
+	if delta := afterSelf - before2; delta != 0 {
+		t.Fatalf("SSE own-actor ChangeEvent produced %d kernel notify calls, want 0", delta)
+	}
+
+	// --- Foreign structural reset → should notify kernel ---
+	before3 := fs.notifyCount.Load()
+	w.handleEvent(nil, &client.ResetEvent{
+		Reason: "structural_change",
+		Actor:  "other-mount-xyz",
+	})
+	afterReset := fs.notifyCount.Load()
+	if delta := afterReset - before3; delta == 0 {
+		t.Fatal("SSE foreign ResetEvent produced 0 kernel notify calls, want >0")
+	}
+
+	// --- Own actor structural reset → should NOT notify kernel ---
+	before4 := fs.notifyCount.Load()
+	w.handleEvent(nil, &client.ResetEvent{
+		Reason: "structural_change",
+		Actor:  "mount-abc",
+	})
+	afterSelfReset := fs.notifyCount.Load()
+	if delta := afterSelfReset - before4; delta != 0 {
+		t.Fatalf("SSE own-actor ResetEvent produced %d kernel notify calls, want 0", delta)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove all `notifyEntry`/`notifyInode` calls from local FUSE mutation handlers (Create, Mkdir, Unlink, Rmdir, Rename) and local write completion paths (Flush, Release, commit queue success, flush debouncer)
- Preserve kernel notify calls in SSE watcher (`sse.go`) for external/foreign-actor changes
- Add `notifyCount` atomic counter for observability and testing

## Root Cause

`git clone` on FUSE mount fails with `EAGAIN` (Resource temporarily unavailable). Each local FUSE operation (create, write, close, unlink) was sending 2-3 redundant `NOTIFY_INVAL_ENTRY/INODE` calls to the kernel. During `git clone` which creates ~20+ hook files in rapid succession, this produced 40-60+ kernel notifications that flooded the FUSE channel → backpressure → EAGAIN on subsequent requests.

These notifications are redundant because the kernel already updates its dentry/attr cache from the FUSE reply itself. `NOTIFY_INVAL_*` is designed for **external changes** the kernel doesn't know about (e.g., another client modifying files via SSE).

## What Changed

**Removed** (~15 call sites in `dat9fs.go`):
- `SetAttr`: kernel receives updated attrs via reply
- `Mkdir/Create`: kernel receives new entry via reply  
- `Unlink/Rmdir`: kernel removes dentry on OK reply
- `Rename`: kernel updates dentries on OK reply
- `Release` (sync + writeback paths): kernel knows about close
- `flushHandle` (paths 1a, 1b, 2): local flush, not external change
- Flush debouncer callback: local async flush
- `onCommitQueueSuccess`: local async commit completion

**Preserved** (4 calls in `sse.go`):
- `handleChange`: foreign actor file changes
- `handleReset`: foreign actor structural changes

**All userspace cache invalidation preserved** — `readCache`, `dirCache`, inode map updates, `pendingIndex` operations are unchanged.

## Test plan

- [x] `TestLocalMutations_NoKernelNotify` — Create/Mkdir/Unlink/Rmdir/Rename produce 0 kernel notify
- [x] `TestCreateWriteFlushRelease_NoKernelNotify` — Full create→write→flush→release→commit lifecycle produces 0 kernel notify  
- [x] `TestSSEForeignChange_StillNotifiesKernel` — SSE foreign changes still produce kernel notify
- [x] `TestSetAttr_NoKernelNotify` — Truncate via SetAttr produces 0 kernel notify
- [x] All existing tests pass (no regressions)
- [ ] Manual validation: `git clone` on Ubuntu FUSE mount (pending @qiffang)

Fixes #fuse task #11 (EAGAIN on git clone after PR #380 + #381)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Reduced unnecessary kernel notifications during file operations, improving system efficiency and responsiveness.

* **Monitoring**
  * Added enhanced internal metrics to track kernel interaction activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->