### PR TITLE
Fix FUSE rename overwrite semantics

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -904,6 +904,9 @@ func (b *Dat9Backend) RenameCtx(ctx context.Context, oldPath, newPath string) (e
 		return err
 	}
 	newPath = canonicalizePathForKind(newPath, node.IsDirectory)
+	if oldPath == newPath {
+		return nil
+	}
 	if node.IsDirectory {
 		err = b.store.EnsureParentDirs(ctx, newPath, b.genID)
 		if err != nil {
@@ -916,8 +919,15 @@ func (b *Dat9Backend) RenameCtx(ctx context.Context, oldPath, newPath string) (e
 	if err != nil {
 		return err
 	}
-	err = b.store.UpdateNodePath(ctx, oldPath, newPath, pathutil.ParentPath(newPath), pathutil.BaseName(newPath))
-	return err
+	deleted, err := b.store.RenameFileReplacingTarget(ctx, oldPath, newPath, pathutil.ParentPath(newPath), pathutil.BaseName(newPath))
+	if err != nil {
+		return err
+	}
+	if deleted != nil {
+		b.syncCentralFileDelete(ctx, deleted.FileID, deleted.SizeBytes, deleted.ContentType)
+		b.deleteBlobCtx(ctx, deleted.StorageRef)
+	}
+	return nil
 }
 
 func (b *Dat9Backend) Chmod(path string, mode uint32) error { return nil }

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -405,6 +405,29 @@ func TestRename(t *testing.T) {
 	}
 }
 
+func TestRenameReplacesExistingFile(t *testing.T) {
+	b := newTestBackend(t)
+	if _, err := b.Write("/config", []byte("old"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/config.lock", []byte("new config"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Rename("/config.lock", "/config"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Stat("/config.lock"); err != datastore.ErrNotFound {
+		t.Fatalf("old path err = %v, want ErrNotFound", err)
+	}
+	data, err := b.Read("/config", 0, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "new config" {
+		t.Fatalf("config = %q, want new config", data)
+	}
+}
+
 func TestZeroCopyCp(t *testing.T) {
 	b := newTestBackend(t)
 	if _, err := b.Write("/a.txt", []byte("shared"), 0, filesystem.WriteFlagCreate); err != nil {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -303,6 +303,105 @@ func (s *Store) UpdateNodePath(ctx context.Context, oldPath, newPath, newParentP
 	return nil
 }
 
+// RenameFileReplacingTarget atomically renames a file node. If newPath already
+// names a file, that target dentry is replaced and its file is marked deleted
+// when no other nodes reference it.
+func (s *Store) RenameFileReplacingTarget(ctx context.Context, oldPath, newPath, newParentPath, newName string) (out *File, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "rename_file_replacing_target", start, &err)
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	type nodeRef struct {
+		nodeID string
+		fileID sql.NullString
+		isDir  bool
+	}
+	var old nodeRef
+	err = tx.QueryRow(`SELECT node_id, file_id, is_directory FROM file_nodes WHERE path = ? FOR UPDATE`, oldPath).
+		Scan(&old.nodeID, &old.fileID, &old.isDir)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if old.isDir {
+		return nil, fmt.Errorf("source is a directory: %s", oldPath)
+	}
+	if oldPath == newPath {
+		return nil, tx.Commit()
+	}
+
+	var dst nodeRef
+	hasDst := false
+	err = tx.QueryRow(`SELECT node_id, file_id, is_directory FROM file_nodes WHERE path = ? FOR UPDATE`, newPath).
+		Scan(&dst.nodeID, &dst.fileID, &dst.isDir)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+	} else {
+		hasDst = true
+		if dst.isDir {
+			return nil, ErrPathConflict
+		}
+		if dst.nodeID == old.nodeID {
+			return nil, tx.Commit()
+		}
+		if _, err := tx.Exec(`DELETE FROM file_nodes WHERE node_id = ?`, dst.nodeID); err != nil {
+			return nil, err
+		}
+	}
+
+	res, err := tx.Exec(`UPDATE file_nodes SET path = ?, parent_path = ?, name = ? WHERE node_id = ?`,
+		newPath, newParentPath, newName, old.nodeID)
+	if isUniqueViolation(err) {
+		return nil, ErrPathConflict
+	}
+	if err != nil {
+		return nil, err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return nil, ErrNotFound
+	}
+
+	if hasDst && dst.fileID.Valid && dst.fileID.String != "" {
+		var count int64
+		if err := tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE file_id = ? FOR UPDATE`, dst.fileID.String).Scan(&count); err != nil {
+			return nil, err
+		}
+		if count == 0 {
+			if _, err := tx.Exec(`UPDATE files SET status = 'DELETED' WHERE file_id = ?`, dst.fileID.String); err != nil {
+				return nil, err
+			}
+			if _, err := tx.Exec(`DELETE FROM file_tags WHERE file_id = ?`, dst.fileID.String); err != nil {
+				return nil, err
+			}
+			row := tx.QueryRow(`SELECT file_id, storage_type, storage_ref, storage_encryption_mode,
+				storage_encryption_key_id, content_blob, content_type,
+				size_bytes, checksum_sha256, revision, embedding_revision, status, source_id, content_text,
+				description, description_embedding_revision, created_at, confirmed_at, expires_at
+				FROM files WHERE file_id = ?`, dst.fileID.String)
+			f, err := scanFileWithBlob(row)
+			if err != nil {
+				return nil, err
+			}
+			out = f
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (s *Store) RenameDir(ctx context.Context, oldPrefix, newPrefix string) (count int64, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "rename_dir", start, &err)

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -649,6 +649,62 @@ func TestRenameFile(t *testing.T) {
 	}
 }
 
+func TestRenameFileReplacingTarget(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	for _, f := range []*File{
+		{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1", SizeBytes: 4, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now},
+		{FileID: "f2", StorageType: StorageDB9, StorageRef: "/blobs/f2", SizeBytes: 3, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now},
+	} {
+		if err := s.InsertFile(ctx, f); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.InsertNode(ctx, &FileNode{NodeID: "n1", Path: "/config.lock", ParentPath: "/", Name: "config.lock", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(ctx, &FileNode{NodeID: "n2", Path: "/config", ParentPath: "/", Name: "config", FileID: "f2", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().Exec(`INSERT INTO file_tags (file_id, tag_key, tag_value) VALUES (?, ?, ?)`, "f2", "old", "target"); err != nil {
+		t.Fatal(err)
+	}
+
+	deleted, err := s.RenameFileReplacingTarget(ctx, "/config.lock", "/config", "/", "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted == nil || deleted.FileID != "f2" {
+		t.Fatalf("deleted = %+v, want f2", deleted)
+	}
+	if _, err := s.GetNode(ctx, "/config.lock"); err != ErrNotFound {
+		t.Fatalf("old path err = %v, want ErrNotFound", err)
+	}
+	got, err := s.GetNode(ctx, "/config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.NodeID != "n1" || got.FileID != "f1" || got.Name != "config" {
+		t.Fatalf("renamed target = %+v, want source node/file at /config", got)
+	}
+	replaced, err := s.GetFile(ctx, "f2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replaced.Status != StatusDeleted {
+		t.Fatalf("replaced file status = %s, want %s", replaced.Status, StatusDeleted)
+	}
+	var tags int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM file_tags WHERE file_id = ?`, "f2").Scan(&tags); err != nil {
+		t.Fatal(err)
+	}
+	if tags != 0 {
+		t.Fatalf("replaced file tags = %d, want 0", tags)
+	}
+}
+
 func TestRenameDir(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -103,6 +103,25 @@ func TestInodeToPath_Rename(t *testing.T) {
 	}
 }
 
+func TestInodeToPath_RenameReplacesDestination(t *testing.T) {
+	m := NewInodeToPath()
+	srcIno := m.Lookup("/config.lock", false, 10, time.Now())
+	dstIno := m.Lookup("/config", false, 5, time.Now())
+
+	m.Rename("/config.lock", "/config")
+
+	gotIno, ok := m.GetInode("/config")
+	if !ok || gotIno != srcIno {
+		t.Fatalf("GetInode(/config) = %d, %v; want %d, true", gotIno, ok, srcIno)
+	}
+	if p, ok := m.GetPath(srcIno); !ok || p != "/config" {
+		t.Fatalf("source path = %q, %v; want /config, true", p, ok)
+	}
+	if p, ok := m.GetPath(dstIno); ok {
+		t.Fatalf("replaced destination inode still mapped to %q", p)
+	}
+}
+
 func TestInodeToPath_RenameDir(t *testing.T) {
 	m := NewInodeToPath()
 	m.Lookup("/dir", true, 0, time.Now())

--- a/pkg/fuse/inode.go
+++ b/pkg/fuse/inode.go
@@ -262,6 +262,9 @@ func (m *InodeToPath) Rename(oldPath, newPath string) {
 
 	// Update the entry itself.
 	delete(m.byPath, oldPath)
+	if replacedIno, ok := m.byPath[newPath]; ok && replacedIno != ino {
+		delete(m.byInode, replacedIno)
+	}
 	m.byPath[newPath] = ino
 	entry.Path = newPath
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1183,6 +1183,11 @@ func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath st
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
+		if errors.Is(err, datastore.ErrPathConflict) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "rename_conflict", "old_path", oldPath, "new_path", newPath)...)
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "rename_failed", "old_path", oldPath, "new_path", newPath, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -800,6 +800,46 @@ func TestRename(t *testing.T) {
 	}
 }
 
+func TestRenameReplacesExistingFile(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/config", strings.NewReader("old"))
+	resp, _ := http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write config: %d", resp.StatusCode)
+	}
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/config.lock", strings.NewReader("new config"))
+	resp, _ = http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write config.lock: %d", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/config?rename", nil)
+	req.Header.Set("X-Dat9-Rename-Source", "/config.lock")
+	resp, _ = http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("rename replace: %d", resp.StatusCode)
+	}
+
+	resp, _ = http.Get(ts.URL + "/v1/fs/config")
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if string(body) != "new config" {
+		t.Fatalf("config = %q, want new config", body)
+	}
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/config.lock", nil)
+	resp, _ = http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("config.lock status = %d, want 404", resp.StatusCode)
+	}
+}
+
 func TestPatchMissingPathReturnsNotFound(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary
- support POSIX-style file rename over existing files in datastore/backend
- return rename target conflicts as HTTP 409 instead of transient FUSE EAGAIN
- clean up replaced destination inode mappings and add coverage for git-style config.lock replacement

## Tests
- go test ./pkg/datastore ./pkg/backend ./pkg/server ./pkg/fuse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File rename operations now support replacing existing destination files.

* **Bug Fixes**
  * Improved cleanup of file mappings when rename operations affect existing files.
  * Enhanced error handling for rename operations resulting in path conflicts.

* **Tests**
  * Added test coverage for rename operations that replace existing destination files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->