### PR TITLE
Fix FUSE lockfile unlink after async commit

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1372,12 +1372,6 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// Remove pending cache entry to prevent future background uploads.
 		fs.writeBack.Remove(childP)
 	}
-	// Also check pendingIndex for the pending-new flag before clearing.
-	if !pendingNew && fs.pendingIndex != nil {
-		if meta, ok := fs.pendingIndex.GetMeta(childP); ok && meta.Kind == PendingNew {
-			pendingNew = true
-		}
-	}
 	// Wait for any in-flight commitQueue upload and cancel it so the
 	// background commit cannot resurrect the deleted file.
 	if fs.commitQueue != nil {
@@ -1385,8 +1379,26 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		fs.debugf("unlink wait commit start path=%s", childP)
 		fs.commitQueue.WaitPath(childP)
 		fs.debugDurationf(waitStart, 0, "unlink wait commit done path=%s", childP)
+
+		// Re-check pendingIndex after WaitPath but before CancelPath. On a
+		// successful commit, commitQueue removes pendingIndex before taking the
+		// entry out of inFlight/queue, so after WaitPath this distinguishes:
+		// still PendingNew => never uploaded; missing => uploaded or remote file.
+		if fs.pendingIndex != nil {
+			if meta, ok := fs.pendingIndex.GetMeta(childP); ok {
+				pendingNew = meta.Kind == PendingNew
+			} else {
+				pendingNew = false
+			}
+		}
 		fs.commitQueue.CancelPath(childP)
 	} else {
+		// Also check pendingIndex for the pending-new flag before clearing.
+		if !pendingNew && fs.pendingIndex != nil {
+			if meta, ok := fs.pendingIndex.GetMeta(childP); ok && meta.Kind == PendingNew {
+				pendingNew = true
+			}
+		}
 		// Clean up shadow and pending index directly when no commit queue.
 		if fs.pendingIndex != nil {
 			fs.pendingIndex.Remove(childP)
@@ -1551,7 +1563,9 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 		if isPendingNew {
 			fs.inodes.Rename(oldP, newP)
 			fs.readCache.Invalidate(oldP)
+			fs.readCache.Invalidate(newP)
 			fs.readCache.InvalidatePrefix(oldP + "/")
+			fs.readCache.InvalidatePrefix(newP + "/")
 
 			oldParent, _ := fs.inodes.GetPath(input.NodeId)
 			fs.dirCache.Invalidate(oldParent)
@@ -1613,7 +1627,9 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 
 	fs.inodes.Rename(oldP, newP)
 	fs.readCache.Invalidate(oldP)
+	fs.readCache.Invalidate(newP)
 	fs.readCache.InvalidatePrefix(oldP + "/")
+	fs.readCache.InvalidatePrefix(newP + "/")
 
 	oldParent, _ := fs.inodes.GetPath(input.NodeId)
 	fs.dirCache.Invalidate(oldParent)

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -968,6 +968,36 @@ func TestRenameFlushesWriteBack(t *testing.T) {
 	}
 }
 
+func TestRenameInvalidatesDestinationReadCache(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs.inodes.Lookup("/config.lock", false, 54, time.Now())
+	fs.inodes.Lookup("/config", false, 36, time.Now())
+	fs.readCache.Put("/config.lock", []byte("new config"), 1)
+	fs.readCache.Put("/config", []byte("old config"), 1)
+
+	st := fs.Rename(nil, &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Newdir:   1,
+	}, "config.lock", "config")
+	if st != gofuse.OK {
+		t.Fatalf("Rename: %v", st)
+	}
+
+	if _, ok := fs.readCache.Get("/config.lock", 0); ok {
+		t.Fatal("source read cache should be invalidated after rename")
+	}
+	if _, ok := fs.readCache.Get("/config", 0); ok {
+		t.Fatal("destination read cache should be invalidated after overwrite rename")
+	}
+}
+
 // TestUnlinkClearsPendingWriteBack verifies that Unlink clears any pending
 // write-back cache entry. For PendingNew files, the remote DELETE is skipped
 // (the file never existed on the server). Cache must be cleaned regardless.
@@ -1665,6 +1695,160 @@ func TestUnlink_PendingNew_SkipsRemoteDelete(t *testing.T) {
 	// Cache must be cleaned.
 	if _, ok := cache.Get("/new-only.txt"); ok {
 		t.Fatal("cache entry should be removed after Unlink")
+	}
+}
+
+func TestUnlink_PendingNewCommitQueueUploadedDeletesRemote(t *testing.T) {
+	const p = "/config.lock"
+	data := []byte("lock")
+
+	putStarted := make(chan struct{})
+	allowPut := make(chan struct{})
+	var putStartedOnce sync.Once
+	var deleteCalled atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putStartedOnce.Do(func() { close(putStarted) })
+			<-allowPut
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+		case http.MethodDelete:
+			deleteCalled.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull(p, data, 0); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(p, int64(len(data)), PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	c := client.New(ts.URL, "")
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	defer cq.DrainAll()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(c, opts)
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = cq
+	fs.inodes.Lookup(p, false, int64(len(data)), time.Now())
+
+	if err := cq.Enqueue(&CommitEntry{
+		Path:    p,
+		Inode:   2,
+		Size:    int64(len(data)),
+		Kind:    PendingNew,
+		BaseRev: 0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-putStarted:
+	case <-time.After(time.Second):
+		t.Fatal("commit queue PUT did not start")
+	}
+
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		done <- fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, "config.lock")
+	}()
+
+	select {
+	case st := <-done:
+		t.Fatalf("Unlink returned before in-flight commit finished: %v", st)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(allowPut)
+
+	select {
+	case st := <-done:
+		if st != gofuse.OK {
+			t.Fatalf("Unlink: %v", st)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Unlink did not finish after commit completed")
+	}
+	if !deleteCalled.Load() {
+		t.Fatal("Unlink should delete a PendingNew file after commitQueue uploaded it")
+	}
+}
+
+func TestUnlink_PendingNewCommitQueueNotEnqueuedSkipsRemoteDelete(t *testing.T) {
+	const p = "/config.lock"
+
+	var deleteCalled atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			deleteCalled.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull(p, []byte("local-only"), 0); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(p, int64(len("local-only")), PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	c := client.New(ts.URL, "")
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	defer cq.DrainAll()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(c, opts)
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = cq
+	fs.inodes.Lookup(p, false, int64(len("local-only")), time.Now())
+
+	st := fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, "config.lock")
+	if st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+	if deleteCalled.Load() {
+		t.Fatal("Unlink should not delete remote path for PendingNew that was never enqueued")
+	}
+	if _, ok := pending.GetMeta(p); ok {
+		t.Fatal("pending entry should be cleared after unlink")
+	}
+	if shadow.Has(p) {
+		t.Fatal("shadow should be removed after unlink")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix the git clone `config.lock` failure reproduced by the mount log:

- `Release(config.lock)` enqueues a PendingNew commit and the commit queue uploads it.
- `Unlink(config.lock)` previously still treated the file as local-only PendingNew and skipped remote DELETE.
- A later `LOOKUP config.lock` then saw the real remote file, so git failed `O_CREAT|O_EXCL` with `File exists`.

This PR makes Unlink issue a remote DELETE for PendingNew files when commitQueue mode is active. DELETE still tolerates 404, so local-only files remain safe.

Also invalidate the destination read cache on rename overwrite; the provided log showed `config` size advancing while reads still returned the older 36-byte cached content.

## Tests

- `go test ./pkg/fuse`
- `go test ./pkg/fuse -run 'TestUnlink_PendingNewCommitQueueUploadedDeletesRemote|TestRenameInvalidatesDestinationReadCache'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file deletion operations to prevent deleted files from being unexpectedly recovered in edge cases with pending uploads
  * Enhanced file rename operations to ensure system caches properly reflect changes, especially when overwriting existing files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->