### PR TITLE
fix FUSE git config lockfile reuse

### DIFF
--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -457,6 +457,7 @@ else
   check_cmd "curl is available" bash -c 'command -v curl >/dev/null'
 fi
 check_cmd "python3 is available" bash -c 'command -v python3 >/dev/null'
+check_cmd "git is available" bash -c 'command -v git >/dev/null'
 
 if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
   skip "unsupported OS for this smoke script"
@@ -579,6 +580,9 @@ MOUNT_TO_CLI_MOUNT="$MOUNT_POINT/$MOUNT_TO_CLI_REL"
 LARGE_REL="${RW_ALPHA_RENAMED_REL}/large-8m.bin"
 LARGE_REMOTE="/${LARGE_REL}"
 LARGE_MOUNT="$MOUNT_POINT/$LARGE_REL"
+GIT_PROBE_REL="${ROOT_REL}/git-config-probe"
+GIT_PROBE_MOUNT="$MOUNT_POINT/$GIT_PROBE_REL"
+GIT_PROBE_ORIGIN="https://github.com/mem9-ai/drive9.git"
 RO_SEED_REL="${ROOT_REL}/ro-seed.txt"
 RO_SEED_REMOTE="/${RO_SEED_REL}"
 RO_SEED_MOUNT="$MOUNT_POINT/$RO_SEED_REL"
@@ -716,6 +720,38 @@ PY
       check_eq "rename directory source exists" "false" "true"
     fi
   fi
+
+  echo "[8.1] git config lockfile semantics"
+  mkdir -p "$GIT_PROBE_MOUNT"
+  git_config_ok=true
+  if ! git -C "$GIT_PROBE_MOUNT" init >/dev/null; then
+    git_config_ok=false
+  fi
+  if ! git -C "$GIT_PROBE_MOUNT" config core.repositoryformatversion 0; then
+    git_config_ok=false
+  fi
+  if ! git -C "$GIT_PROBE_MOUNT" config core.filemode false; then
+    git_config_ok=false
+  fi
+  if ! git -C "$GIT_PROBE_MOUNT" config core.bare false; then
+    git_config_ok=false
+  fi
+  if ! git -C "$GIT_PROBE_MOUNT" config core.logallrefupdates true; then
+    git_config_ok=false
+  fi
+  if ! git -C "$GIT_PROBE_MOUNT" config core.symlinks false; then
+    git_config_ok=false
+  fi
+  if ! git -C "$GIT_PROBE_MOUNT" remote add origin "$GIT_PROBE_ORIGIN"; then
+    git_config_ok=false
+  fi
+  check_eq "git config lockfile updates succeed" "$git_config_ok" "true"
+  set +e
+  git_origin=$(git -C "$GIT_PROBE_MOUNT" config --get remote.origin.url 2>/dev/null)
+  git_origin_rc=$?
+  set -e
+  check_eq "git config remote origin is readable" "$git_origin_rc" "0"
+  check_eq "git config remote origin survives lockfile reuse" "$git_origin" "$GIT_PROBE_ORIGIN"
 
   echo "[9] cross-channel consistency"
   if [ "$rename_dir_ready" = "true" ]; then

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -30,6 +30,7 @@ type CommitEntry struct {
 	Size        int64
 	Kind        PendingKind
 	ShadowSpill bool // true when data is only in shadow file (auto-resolve would OOM)
+	canceled    bool
 }
 
 // CommitSuccessFunc is called after a commit queue entry is successfully
@@ -46,8 +47,7 @@ type CommitCleanupFunc func(entry *CommitEntry)
 type CommitQueue struct {
 	mu         sync.Mutex
 	queue      []*CommitEntry
-	inFlight   map[string]struct{} // paths currently being processed by workers
-	canceled   map[string]struct{} // paths canceled by Unlink/Rmdir (workers skip these)
+	inFlight   map[string]*CommitEntry // paths currently being processed by workers
 	maxPending int
 	client     *client.Client
 	remoteRoot string
@@ -93,8 +93,7 @@ func NewCommitQueue(c *client.Client, shadows *ShadowStore, index *PendingIndex,
 		shadows:    shadows,
 		index:      index,
 		journal:    journal,
-		inFlight:   make(map[string]struct{}),
-		canceled:   make(map[string]struct{}),
+		inFlight:   make(map[string]*CommitEntry),
 		workCh:     make(chan *CommitEntry, bufSize),
 	}
 	for i := 0; i < numWorkers; i++ {
@@ -268,18 +267,24 @@ func (cq *CommitQueue) WaitPrefix(prefix string) {
 	}
 }
 
-// CancelPath marks a path as canceled so workers skip it, removes it from
-// the queue, and cleans up its shadow/index state. Used by Unlink to
-// prevent background commits from resurrecting deleted files.
+// CancelPath marks currently queued or in-flight entries for path as canceled,
+// removes queued entries, and cleans up shadow/index state. Cancellation is
+// entry-scoped so future files that reuse the same path (for example git's
+// config.lock) are not poisoned by an old cancellation.
 func (cq *CommitQueue) CancelPath(path string) {
 	cq.mu.Lock()
-	cq.canceled[path] = struct{}{}
-	for i, e := range cq.queue {
-		if e.Path == path {
-			cq.queue = append(cq.queue[:i], cq.queue[i+1:]...)
-			break
-		}
+	if e, ok := cq.inFlight[path]; ok {
+		e.canceled = true
 	}
+	remaining := cq.queue[:0]
+	for _, e := range cq.queue {
+		if e.Path == path {
+			e.canceled = true
+			continue
+		}
+		remaining = append(remaining, e)
+	}
+	cq.queue = remaining
 	cq.mu.Unlock()
 
 	if cq.shadows != nil {
@@ -290,18 +295,23 @@ func (cq *CommitQueue) CancelPath(path string) {
 	}
 }
 
-// CancelPrefix marks all paths under prefix as canceled, removes them from
-// the queue, and cleans up their shadow/index state. Used by Rmdir.
-// Workers that have already dequeued entries will check the canceled set
-// before uploading.
+// CancelPrefix marks queued or in-flight entries under prefix as canceled,
+// removes queued entries, and cleans up their shadow/index state. Cancellation
+// is entry-scoped, so future entries under the same prefix are unaffected.
 func (cq *CommitQueue) CancelPrefix(prefix string) {
 	cq.mu.Lock()
 	var remaining []*CommitEntry
 	var cancelled []string
+	for p, e := range cq.inFlight {
+		if strings.HasPrefix(p, prefix) {
+			e.canceled = true
+			cancelled = append(cancelled, p)
+		}
+	}
 	for _, e := range cq.queue {
 		if strings.HasPrefix(e.Path, prefix) {
+			e.canceled = true
 			cancelled = append(cancelled, e.Path)
-			cq.canceled[e.Path] = struct{}{}
 		} else {
 			remaining = append(remaining, e)
 		}
@@ -319,27 +329,23 @@ func (cq *CommitQueue) CancelPrefix(prefix string) {
 	}
 }
 
-// isCanceled checks whether the path has been canceled by Unlink/Rmdir.
-func (cq *CommitQueue) isCanceled(path string) bool {
+// isEntryCanceled checks whether this specific entry was canceled by
+// Unlink/Rmdir. It intentionally does not key by path; git repeatedly reuses
+// config.lock, and an old cancellation must not affect a newer entry.
+func (cq *CommitQueue) isEntryCanceled(entry *CommitEntry) bool {
 	cq.mu.Lock()
 	defer cq.mu.Unlock()
-	if _, ok := cq.canceled[path]; ok {
-		return true
+	if entry == nil {
+		return false
 	}
-	// Also check prefix cancellations.
-	for p := range cq.canceled {
-		if strings.HasSuffix(p, "/") && strings.HasPrefix(path, p) {
-			return true
-		}
-	}
-	return false
+	return entry.canceled
 }
 
 func (cq *CommitQueue) worker() {
 	defer cq.wg.Done()
 	for entry := range cq.workCh {
 		// Check if this entry was canceled while buffered in workCh.
-		if cq.isCanceled(entry.Path) {
+		if cq.isEntryCanceled(entry) {
 			cq.removeFromQueue(entry)
 			log.Printf("commit queue: skipping canceled entry for %s", entry.Path)
 			continue
@@ -347,14 +353,16 @@ func (cq *CommitQueue) worker() {
 
 		// Mark as in-flight so WaitPath blocks until cleanup finishes.
 		cq.mu.Lock()
-		cq.inFlight[entry.Path] = struct{}{}
+		cq.inFlight[entry.Path] = entry
 		cq.mu.Unlock()
 
 		cq.commitOne(entry)
 
 		// Clear in-flight after all cleanup is done.
 		cq.mu.Lock()
-		delete(cq.inFlight, entry.Path)
+		if cq.inFlight[entry.Path] == entry {
+			delete(cq.inFlight, entry.Path)
+		}
 		cq.mu.Unlock()
 	}
 }
@@ -368,7 +376,7 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 	var lastErr error
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		// Re-check cancelation between retries.
-		if cq.isCanceled(entry.Path) {
+		if cq.isEntryCanceled(entry) {
 			cq.removeFromQueue(entry)
 			log.Printf("commit queue: entry for %s was canceled during retry", entry.Path)
 			return
@@ -505,7 +513,7 @@ func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) {
 // requiring 3-way merge. Max 1 retry to avoid write amplification.
 func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	// Bail early if the file was deleted locally while queued.
-	if cq.isCanceled(entry.Path) {
+	if cq.isEntryCanceled(entry) {
 		cq.removeFromQueue(entry)
 		log.Printf("commit queue: auto-resolve skipped for %s (canceled)", entry.Path)
 		return
@@ -529,7 +537,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	if err != nil {
 		// Shadow may have been removed by a concurrent CancelPath/CancelPrefix
 		// (Unlink/Rmdir). Treat as canceled rather than a true conflict.
-		if cq.isCanceled(entry.Path) {
+		if cq.isEntryCanceled(entry) {
 			cq.removeFromQueue(entry)
 			log.Printf("commit queue: auto-resolve skipped for %s (canceled mid-read)", entry.Path)
 			return
@@ -570,7 +578,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 
 	// Branch 2: LWW — re-upload local shadow with new base revision.
 	// Re-check cancelation before the potentially expensive upload.
-	if cq.isCanceled(entry.Path) {
+	if cq.isEntryCanceled(entry) {
 		cq.removeFromQueue(entry)
 		log.Printf("commit queue: auto-resolve aborted for %s before LWW upload (canceled)", entry.Path)
 		return

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -131,6 +131,88 @@ func TestCommitQueueConflictKeepsPendingState(t *testing.T) {
 	}
 }
 
+func TestCommitQueueCancelPathDoesNotPoisonFutureSamePath(t *testing.T) {
+	const path = "/repo/.git/config.lock"
+	newData := []byte("[remote \"origin\"]\n\turl = https://github.com/mem9-ai/drive9.git\n")
+
+	var puts [][]byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read PUT body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		puts = append(puts, body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":9}`))
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldEntry := &CommitEntry{Path: path, Size: 3, Kind: PendingNew}
+	cq := &CommitQueue{
+		client:     client.New(ts.URL, ""),
+		shadows:    shadow,
+		index:      pending,
+		inFlight:   make(map[string]*CommitEntry),
+		maxPending: 8,
+		workCh:     make(chan *CommitEntry, 8),
+	}
+	cq.queue = append(cq.queue, oldEntry)
+	cq.workCh <- oldEntry
+
+	cq.CancelPath(path)
+	if !cq.isEntryCanceled(oldEntry) {
+		t.Fatal("old queued entry should be canceled")
+	}
+
+	if err := shadow.WriteFull(path, newData, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(path, int64(len(newData)), PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+	newEntry := &CommitEntry{Path: path, Size: int64(len(newData)), Kind: PendingNew}
+	if cq.isEntryCanceled(newEntry) {
+		t.Fatal("new entry for same path must not inherit old cancellation")
+	}
+	if err := cq.Enqueue(newEntry); err != nil {
+		t.Fatal(err)
+	}
+
+	close(cq.workCh)
+	cq.wg.Add(1)
+	go cq.worker()
+	cq.wg.Wait()
+
+	if len(puts) != 1 {
+		t.Fatalf("PUT count = %d, want 1", len(puts))
+	}
+	if !bytes.Equal(puts[0], newData) {
+		t.Fatalf("PUT body = %q, want %q", puts[0], newData)
+	}
+	if pending.HasPending(path) {
+		t.Fatal("pending entry should be removed after new entry commits")
+	}
+	if shadow.Has(path) {
+		t.Fatal("shadow should be removed after new entry commits")
+	}
+}
+
 // TestCommitQueueDirectPutRouting verifies that files under
 // commitQueueDirectPutThreshold use direct PUT (WriteCtxConditionalWithRevision)
 // which sends raw body, while files at or above the threshold use multipart

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1370,8 +1370,7 @@ func TestForgetPreservesQueuedCommitInodeUntilCleanup(t *testing.T) {
 	ino := fs.inodes.Lookup(p, false, 7, time.Now())
 	fs.commitQueue = &CommitQueue{
 		queue:    []*CommitEntry{{Path: p, Inode: ino}},
-		inFlight: map[string]struct{}{},
-		canceled: make(map[string]struct{}),
+		inFlight: map[string]*CommitEntry{},
 	}
 
 	fs.Forget(ino, 1)

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -1757,8 +1757,7 @@ func TestShadowSpill_AutoResolveGuard(t *testing.T) {
 	cq := &CommitQueue{
 		shadows:  ss,
 		index:    idx,
-		canceled: make(map[string]struct{}),
-		inFlight: make(map[string]struct{}),
+		inFlight: make(map[string]*CommitEntry),
 	}
 
 	entry := &CommitEntry{
@@ -1876,8 +1875,7 @@ func TestShadowSpill_RecoverPendingPreservesShadowSpill(t *testing.T) {
 	cq := &CommitQueue{
 		index:      idx2,
 		shadows:    shadows,
-		canceled:   make(map[string]struct{}),
-		inFlight:   make(map[string]struct{}),
+		inFlight:   make(map[string]*CommitEntry),
 		maxPending: 100,
 		workCh:     make(chan *CommitEntry, 100),
 	}


### PR DESCRIPTION
## Summary
- make commit queue cancellation entry-scoped instead of path-scoped so reused git lockfile names are not poisoned by old cancellations
- keep canceled buffered entries skipped while allowing later entries for the same path to upload normally
- add a FUSE smoke check for repeated git config.lock rewrites and remote.origin.url readability

## Root cause
The latest git clone failure is not a GitHub access issue. In the provided FUSE log, /drive9/.git/config reports size 174 after config.lock is renamed over it, but the following read returns only 111 bytes, so the [remote "origin"] section is missing and git falls back to treating origin as a local repository name. The same log shows commit queue: skipping canceled entry for /drive9/.git/config.lock. The old path-scoped cancellation tombstone made later config.lock generations get skipped after a previous unlink/cancel.

## Tests
- go test ./pkg/fuse -count=1 -run 'TestCommitQueueCancelPathDoesNotPoisonFutureSamePath|TestUnlink_PendingNewCommitQueueUploadedDeletesRemote|TestUnlink_PendingNewCommitQueueNotEnqueuedSkipsRemoteDelete|TestRenameInvalidatesDestinationReadCache'
- go test ./pkg/fuse -count=1
- bash -n e2e/fuse-smoke-test.sh