### PR TITLE
fix FUSE mkdir after transient interrupt

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -147,6 +147,10 @@ const (
 	// logged, to avoid noisy logs on hot lookup paths.
 	lookupRetrySuccessLogEvery uint64 = 200
 
+	// namespaceMutationRetryTimeout bounds detached retries for idempotent-ish
+	// namespace mutations after a FUSE interrupt or transient backend error.
+	namespaceMutationRetryTimeout = 2 * time.Second
+
 	// readTransientRetryCount is the number of detached retries after the
 	// initial remote Read attempt fails with a transient error (context
 	// canceled, deadline exceeded, network timeout, HTTP 5xx).
@@ -631,10 +635,10 @@ func httpToFuseStatus(err error) gofuse.Status {
 		case http.StatusNotFound:
 			return gofuse.ENOENT
 		case http.StatusConflict:
-			if strings.Contains(strings.ToLower(se.Message), "already exists") {
-				return gofuse.Status(syscall.EEXIST)
+			if strings.Contains(strings.ToLower(se.Message), "revision conflict") {
+				return gofuse.EIO
 			}
-			return gofuse.EIO
+			return gofuse.Status(syscall.EEXIST)
 		case http.StatusForbidden:
 			return gofuse.EACCES
 		case http.StatusRequestEntityTooLarge:
@@ -662,7 +666,7 @@ func httpToFuseStatus(err error) gofuse.Status {
 	switch {
 	case strings.Contains(lowerMsg, "not found") || strings.Contains(msg, "HTTP 404"):
 		return gofuse.ENOENT
-	case strings.Contains(lowerMsg, "already exists"):
+	case strings.Contains(lowerMsg, "already exists") || strings.Contains(msg, "HTTP 409"):
 		return gofuse.Status(syscall.EEXIST)
 	case strings.Contains(msg, "HTTP 403"):
 		return gofuse.EACCES
@@ -717,6 +721,14 @@ func isTransientLookupErr(err error) bool {
 	}
 	var netErr net.Error
 	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func isConflictErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var se *client.StatusError
+	return errors.As(err, &se) && se.StatusCode == http.StatusConflict
 }
 
 // errReadRetriesExhausted is a sentinel indicating all detached read retries
@@ -931,6 +943,56 @@ func (fs *Dat9FS) lookupListWithRetry(cancel <-chan struct{}, parentPath string)
 		lastErr = err
 	}
 	return nil, lastErr
+}
+
+func (fs *Dat9FS) remoteDirExistsDetached(localPath string) bool {
+	retryCtx, retryCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+	defer retryCancel()
+	stat, err := fs.client.StatCtx(retryCtx, fs.remotePath(localPath))
+	return err == nil && stat.IsDir
+}
+
+func (fs *Dat9FS) mkdirRemoteWithTransientRetry(cancel <-chan struct{}, localPath string) error {
+	apiPath := fs.remotePath(localPath)
+	ctx, cf := fuseCtx(cancel)
+	err := fs.client.MkdirCtx(ctx, apiPath)
+	cf()
+	if err == nil || !isTransientLookupErr(err) {
+		return err
+	}
+
+	// The first request honored the FUSE interrupt. If it was canceled after the
+	// server committed the directory, a detached stat lets us return success
+	// instead of surfacing EAGAIN to checkout-like callers that will not retry.
+	if fs.remoteDirExistsDetached(localPath) {
+		return nil
+	}
+
+	retryCount := fs.lookupStatRetryCount()
+	if retryCount <= 0 {
+		return err
+	}
+
+	lastErr := err
+	for range retryCount {
+		retryCtx, retryCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+		err = fs.client.MkdirCtx(retryCtx, apiPath)
+		retryCancel()
+		if err == nil {
+			return nil
+		}
+		if isConflictErr(err) && fs.remoteDirExistsDetached(localPath) {
+			return nil
+		}
+		if !isTransientLookupErr(err) {
+			return err
+		}
+		if fs.remoteDirExistsDetached(localPath) {
+			return nil
+		}
+		lastErr = err
+	}
+	return lastErr
 }
 
 // --- RawFileSystem methods ---------------------------------------------------
@@ -1318,15 +1380,12 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 // --- Directory operations ----------------------------------------------------
 
 func (fs *Dat9FS) Mkdir(cancel <-chan struct{}, input *gofuse.MkdirIn, name string, out *gofuse.EntryOut) gofuse.Status {
-	ctx, cf := fuseCtx(cancel)
-	defer cf()
-
 	childP, st := fs.childPath(input.NodeId, name)
 	if st != gofuse.OK {
 		return st
 	}
 
-	if err := fs.client.MkdirCtx(ctx, fs.remotePath(childP)); err != nil {
+	if err := fs.mkdirRemoteWithTransientRetry(cancel, childP); err != nil {
 		return httpToFuseStatus(err)
 	}
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1004,6 +1004,22 @@ func TestHTTPToFuseStatus_MapsGatewayTimeoutToEAGAIN(t *testing.T) {
 	}
 }
 
+func TestHTTPToFuseStatus_MapsConflictToEEXIST(t *testing.T) {
+	want := gofuse.Status(syscall.EEXIST)
+	if got := httpToFuseStatus(&client.StatusError{StatusCode: http.StatusConflict, Message: "path conflict"}); got != want {
+		t.Fatalf("status error 409 = %v, want %v", got, want)
+	}
+	if got := httpToFuseStatus(fmt.Errorf("HTTP 409: conflict")); got != want {
+		t.Fatalf("string error 409 = %v, want %v", got, want)
+	}
+}
+
+func TestHTTPToFuseStatus_PreservesRevisionConflictAsEIO(t *testing.T) {
+	if got := httpToFuseStatus(&client.StatusError{StatusCode: http.StatusConflict, Message: "revision conflict"}); got != gofuse.EIO {
+		t.Fatalf("revision conflict status = %v, want %v", got, gofuse.EIO)
+	}
+}
+
 // TestHTTPToFuseStatus_MapsClientClosedRequestToEAGAIN locks the contract
 // between the server's tenantAuthMiddleware (which writes 499 when a request
 // is canceled mid-auth) and the FUSE client. Without this mapping, a canceled
@@ -1260,6 +1276,94 @@ func TestCreateFileGetsStreamUploader(t *testing.T) {
 	}
 	if fh.Streamer == nil {
 		t.Fatal("expected StreamUploader to be set for new file")
+	}
+}
+
+func TestMkdirRetriesDetachedAfterTransientInterrupt(t *testing.T) {
+	var mkdirCalls atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.RawQuery == "mkdir":
+			if r.URL.Path != "/v1/fs/dir" {
+				t.Fatalf("POST path = %q, want /v1/fs/dir", r.URL.Path)
+			}
+			if mkdirCalls.Add(1) == 1 {
+				w.WriteHeader(statusClientClosedRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead:
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Fatalf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	var out gofuse.EntryOut
+	st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "dir", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Mkdir status = %v, want OK", st)
+	}
+	if got := mkdirCalls.Load(); got != 2 {
+		t.Fatalf("mkdir calls = %d, want 2", got)
+	}
+	if out.NodeId == 0 {
+		t.Fatal("expected mkdir response to include a node id")
+	}
+}
+
+func TestMkdirRetryTreatsRemoteDirectoryAsSuccessAfterAmbiguousCreate(t *testing.T) {
+	var mkdirCalls atomic.Int64
+	var statCalls atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.RawQuery == "mkdir":
+			switch mkdirCalls.Add(1) {
+			case 1:
+				w.WriteHeader(statusClientClosedRequest)
+			case 2:
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "path already exists"})
+			default:
+				t.Fatalf("unexpected extra mkdir call")
+			}
+		case r.Method == http.MethodHead:
+			if statCalls.Add(1) == 1 {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("X-Dat9-IsDir", "true")
+			w.Header().Set("Content-Length", "0")
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	var out gofuse.EntryOut
+	st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "dir", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Mkdir status = %v, want OK", st)
+	}
+	if got := mkdirCalls.Load(); got != 2 {
+		t.Fatalf("mkdir calls = %d, want 2", got)
+	}
+	if got := statCalls.Load(); got != 2 {
+		t.Fatalf("stat calls = %d, want 2", got)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1205,6 +1205,11 @@ func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string
 		return
 	}
 	if err := b.MkdirCtx(r.Context(), path, 0o755); err != nil {
+		if errors.Is(err, datastore.ErrPathConflict) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "mkdir_conflict", "path", path, "error", err)...)
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "mkdir_failed", "path", path, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return


### PR DESCRIPTION
## Summary
- retry FUSE Mkdir with a bounded detached context after transient interrupt/backend errors
- treat ambiguous mkdir success as OK when a detached stat confirms the remote directory exists
- return HTTP 409 for server-side mkdir path conflicts instead of 500

## Tests
- go test ./pkg/fuse -run 'TestMkdirRetriesDetachedAfterTransientInterrupt|TestMkdirRetryTreatsRemoteDirectoryAsSuccessAfterAmbiguousCreate' -count=1
- go test ./pkg/fuse -count=1
- go build ./pkg/server

Note: go test ./pkg/server -run '^$' is currently blocked by unrelated local changes in pkg/server/provision_test.go referencing Config.TenantSchemaInitEnabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added resilience improvements with automatic retries for file system operations after transient errors.

* **Bug Fixes**
  * Enhanced conflict detection during concurrent directory creation operations.
  * Improved HTTP error responses to accurately reflect conflicts and failures in file system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->