### PR TITLE
fix FUSE reset invalidating cwd dentries

### DIFF
--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -111,7 +111,13 @@ func (w *SSEWatcher) handleReset(resets ...*client.ResetEvent) {
 	for _, entry := range entries {
 		w.fs.notifyInode(entry.Ino)
 
-		if entry.Path != "/" {
+		// Do not invalidate a directory's own parent dentry during a broad reset.
+		// Linux getcwd(2) walks parent dentries; dropping the dentry for a
+		// process's current working directory can make git's remote helpers fail
+		// with ENOENT even though the directory still exists. The reset already
+		// clears userspace directory caches and notifies the directory inode, so
+		// future readdir/attr paths are refreshed without detaching cwd names.
+		if entry.Path != "/" && !entry.IsDir {
 			parent := parentDir(entry.Path)
 			if parentIno, ok := w.fs.inodes.GetInode(parent); ok {
 				w.fs.notifyEntry(parentIno, path.Base(entry.Path))

--- a/pkg/fuse/sse_test.go
+++ b/pkg/fuse/sse_test.go
@@ -60,6 +60,41 @@ func TestSSEWatcherResetPreservesInodes(t *testing.T) {
 	}
 }
 
+func TestSSEWatcherResetDoesNotNotifyDirectoryParentDentries(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+		AttrTTL:   60 * time.Second,
+		EntryTTL:  60 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	fs.inodes.Lookup("/repo", true, 0, time.Now())
+	fs.inodes.Lookup("/repo/.git", true, 0, time.Now())
+	fs.inodes.Lookup("/repo/.git/config", false, 100, time.Now())
+
+	w := &SSEWatcher{fs: fs, actor: "test-actor"}
+	w.handleEvent(nil, &client.ResetEvent{Seq: 5, Reason: "seq_too_old"})
+
+	// Reset should notify all four known inodes (root + 3 entries) plus the
+	// regular file dentry. Directory parent dentries are intentionally skipped
+	// so a process whose cwd is /repo does not lose its getcwd() path.
+	if got, want := fs.notifyCount.Load(), int64(5); got != want {
+		t.Fatalf("notify count = %d, want %d", got, want)
+	}
+	if _, ok := fs.inodes.GetInode("/repo"); !ok {
+		t.Fatal("directory inode mapping for cwd candidate was lost")
+	}
+	if _, ok := fs.inodes.GetInode("/repo/.git"); !ok {
+		t.Fatal("nested directory inode mapping was lost")
+	}
+}
+
 func TestSSEWatcherHandleChangeInvalidatesCache(t *testing.T) {
 	opts := &MountOptions{
 		CacheSize: 1 << 20,


### PR DESCRIPTION
## Summary
- avoid EntryNotify on directory parent dentries during broad SSE reset
- keep reset inode notifications and userspace cache invalidation intact
- add regression coverage for seq_too_old reset preserving cwd directory dentries

## Root cause
During git pull, a seq_too_old SSE reset ran after .git/FETCH_HEAD upload and invalidated the parent dentry for the current working directory (/drive9). Linux getcwd walks parent dentries, so git's https remote helper observed ENOENT and aborted even though the directory still existed.

## Tests
- go test ./pkg/fuse -run 'TestSSEWatcherResetDoesNotNotifyDirectoryParentDentries|TestSSEWatcherResetPreservesInodes' -count=1
- go test ./pkg/fuse -count=1