### PR TITLE
fix(fuse): rename pending git loose objects locally

### DIFF
--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -31,6 +31,7 @@ type CommitEntry struct {
 	Kind         PendingKind
 	ShadowSpill  bool // true when data is only in shadow file (auto-resolve would OOM)
 	canceled     bool
+	cancelCommit context.CancelFunc
 	cancelUpload context.CancelFunc
 }
 
@@ -296,6 +297,9 @@ func (cq *CommitQueue) cancelPath(path string, preserveLocal bool) {
 			return
 		}
 		seen[e] = struct{}{}
+		if e.cancelCommit != nil {
+			cancels = append(cancels, e.cancelCommit)
+		}
 		if e.cancelUpload != nil {
 			cancels = append(cancels, e.cancelUpload)
 		}
@@ -348,6 +352,9 @@ func (cq *CommitQueue) CancelPrefix(prefix string) {
 			return
 		}
 		seen[e] = struct{}{}
+		if e.cancelCommit != nil {
+			cancels = append(cancels, e.cancelCommit)
+		}
 		if e.cancelUpload != nil {
 			cancels = append(cancels, e.cancelUpload)
 		}
@@ -426,6 +433,25 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 	const baseDelay = 200 * time.Millisecond
 	const maxDelay = 30 * time.Second
 
+	entryCtx, entryCancel := context.WithCancel(context.Background())
+	cq.mu.Lock()
+	if entry.canceled {
+		cq.mu.Unlock()
+		entryCancel()
+		cq.removeFromQueue(entry)
+		log.Printf("commit queue: entry for %s was canceled before retry loop", entry.Path)
+		return
+	}
+	entry.cancelCommit = entryCancel
+	cq.mu.Unlock()
+	defer func() {
+		cq.mu.Lock()
+		entry.cancelCommit = nil
+		entry.cancelUpload = nil
+		cq.mu.Unlock()
+		entryCancel()
+	}()
+
 	var lastErr error
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		// Re-check cancelation between retries.
@@ -440,14 +466,18 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 			if delay > maxDelay {
 				delay = maxDelay
 			}
-			time.Sleep(delay)
+			if !sleepWithCancel(entryCtx, delay) {
+				cq.removeFromQueue(entry)
+				log.Printf("commit queue: entry for %s was canceled during retry backoff", entry.Path)
+				return
+			}
 		}
 
 		timeout := uploadTimeout
 		if entry.ShadowSpill {
 			timeout = releaseTimeout(entry.Size)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(entryCtx, timeout)
 		cq.mu.Lock()
 		if entry.canceled {
 			cq.mu.Unlock()
@@ -486,6 +516,29 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 
 	log.Printf("commit queue: giving up on %s after %d retries: %v", entry.Path, maxRetries, lastErr)
 	cq.onCommitTerminalFailure(entry)
+}
+
+func sleepWithCancel(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// CommitNow uploads an entry synchronously through the same commit path used
+// by workers. It is used as a fallback when the async queue rejects an entry
+// after local state has already moved to the final path.
+func (cq *CommitQueue) CommitNow(ctx context.Context, entry *CommitEntry) error {
+	committedRev, err := cq.uploadEntry(ctx, entry)
+	if err != nil {
+		return err
+	}
+	cq.onCommitSuccess(entry, committedRev)
+	return nil
 }
 
 // uploadEntry uploads entry data to the server. Returns (committedRev, error).

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -24,13 +24,14 @@ const commitQueueDirectPutThreshold = client.DefaultSmallFileThreshold
 
 // CommitEntry represents a pending remote commit.
 type CommitEntry struct {
-	Path        string
-	Inode       uint64
-	BaseRev     int64 // revision when we started editing
-	Size        int64
-	Kind        PendingKind
-	ShadowSpill bool // true when data is only in shadow file (auto-resolve would OOM)
-	canceled    bool
+	Path         string
+	Inode        uint64
+	BaseRev      int64 // revision when we started editing
+	Size         int64
+	Kind         PendingKind
+	ShadowSpill  bool // true when data is only in shadow file (auto-resolve would OOM)
+	canceled     bool
+	cancelUpload context.CancelFunc
 }
 
 // CommitSuccessFunc is called after a commit queue entry is successfully
@@ -272,14 +273,42 @@ func (cq *CommitQueue) WaitPrefix(prefix string) {
 // entry-scoped so future files that reuse the same path (for example git's
 // config.lock) are not poisoned by an old cancellation.
 func (cq *CommitQueue) CancelPath(path string) {
+	cq.cancelPath(path, false)
+}
+
+// CancelPathPreserveLocal cancels queued or in-flight uploads for path without
+// removing the local shadow/index state. Rename uses this for Git's loose-object
+// temp files: the temp upload must stop, but the bytes must survive while the
+// pending entry moves to the content-addressed final path.
+func (cq *CommitQueue) CancelPathPreserveLocal(path string) {
+	cq.cancelPath(path, true)
+}
+
+func (cq *CommitQueue) cancelPath(path string, preserveLocal bool) {
+	var cancels []context.CancelFunc
+	seen := make(map[*CommitEntry]struct{})
+	markCanceled := func(e *CommitEntry) {
+		if e == nil {
+			return
+		}
+		e.canceled = true
+		if _, ok := seen[e]; ok {
+			return
+		}
+		seen[e] = struct{}{}
+		if e.cancelUpload != nil {
+			cancels = append(cancels, e.cancelUpload)
+		}
+	}
+
 	cq.mu.Lock()
 	if e, ok := cq.inFlight[path]; ok {
-		e.canceled = true
+		markCanceled(e)
 	}
 	remaining := cq.queue[:0]
 	for _, e := range cq.queue {
 		if e.Path == path {
-			e.canceled = true
+			markCanceled(e)
 			continue
 		}
 		remaining = append(remaining, e)
@@ -287,6 +316,12 @@ func (cq *CommitQueue) CancelPath(path string) {
 	cq.queue = remaining
 	cq.mu.Unlock()
 
+	for _, cancel := range cancels {
+		cancel()
+	}
+	if preserveLocal {
+		return
+	}
 	if cq.shadows != nil {
 		cq.shadows.Remove(path)
 	}
@@ -302,15 +337,30 @@ func (cq *CommitQueue) CancelPrefix(prefix string) {
 	cq.mu.Lock()
 	var remaining []*CommitEntry
 	var cancelled []string
+	var cancels []context.CancelFunc
+	seen := make(map[*CommitEntry]struct{})
+	markCanceled := func(e *CommitEntry) {
+		if e == nil {
+			return
+		}
+		e.canceled = true
+		if _, ok := seen[e]; ok {
+			return
+		}
+		seen[e] = struct{}{}
+		if e.cancelUpload != nil {
+			cancels = append(cancels, e.cancelUpload)
+		}
+	}
 	for p, e := range cq.inFlight {
 		if strings.HasPrefix(p, prefix) {
-			e.canceled = true
+			markCanceled(e)
 			cancelled = append(cancelled, p)
 		}
 	}
 	for _, e := range cq.queue {
 		if strings.HasPrefix(e.Path, prefix) {
-			e.canceled = true
+			markCanceled(e)
 			cancelled = append(cancelled, e.Path)
 		} else {
 			remaining = append(remaining, e)
@@ -319,6 +369,9 @@ func (cq *CommitQueue) CancelPrefix(prefix string) {
 	cq.queue = remaining
 	cq.mu.Unlock()
 
+	for _, cancel := range cancels {
+		cancel()
+	}
 	for _, p := range cancelled {
 		if cq.shadows != nil {
 			cq.shadows.Remove(p)
@@ -395,12 +448,31 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 			timeout = releaseTimeout(entry.Size)
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		cq.mu.Lock()
+		if entry.canceled {
+			cq.mu.Unlock()
+			cancel()
+			cq.removeFromQueue(entry)
+			log.Printf("commit queue: entry for %s was canceled before upload", entry.Path)
+			return
+		}
+		entry.cancelUpload = cancel
+		cq.mu.Unlock()
+
 		committedRev, err := cq.uploadEntry(ctx, entry)
+		cq.mu.Lock()
+		entry.cancelUpload = nil
+		cq.mu.Unlock()
 		cancel()
 
 		if err == nil {
 			// Success — clean up.
 			cq.onCommitSuccess(entry, committedRev)
+			return
+		}
+		if cq.isEntryCanceled(entry) {
+			cq.removeFromQueue(entry)
+			log.Printf("commit queue: entry for %s was canceled during upload", entry.Path)
 			return
 		}
 		if errors.Is(err, client.ErrConflict) {

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -5,7 +5,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
 )
@@ -210,6 +212,70 @@ func TestCommitQueueCancelPathDoesNotPoisonFutureSamePath(t *testing.T) {
 	}
 	if shadow.Has(path) {
 		t.Fatal("shadow should be removed after new entry commits")
+	}
+}
+
+func TestCommitQueueCancelPathCancelsRetryBackoff(t *testing.T) {
+	const path = "/retry.txt"
+	var calls atomic.Int32
+	firstAttemptDone := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			call := calls.Add(1)
+			http.Error(w, `{"error":"temporary"}`, http.StatusServiceUnavailable)
+			if call == 1 {
+				close(firstAttemptDone)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(path, []byte("data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(path, 4, PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	defer cq.DrainAll()
+	if err := cq.Enqueue(&CommitEntry{Path: path, Size: 4, Kind: PendingNew}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-firstAttemptDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first upload attempt did not finish")
+	}
+
+	start := time.Now()
+	cq.CancelPath(path)
+	done := make(chan struct{})
+	go func() {
+		cq.WaitPath(path)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(150 * time.Millisecond):
+		t.Fatal("WaitPath did not unblock during retry backoff cancellation")
+	}
+	if elapsed := time.Since(start); elapsed >= 150*time.Millisecond {
+		t.Fatalf("cancel during backoff took %s, want <150ms", elapsed)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("upload attempts after cancellation = %d, want 1", got)
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1565,6 +1565,73 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 	return gofuse.OK
 }
 
+func (fs *Dat9FS) renamePendingNewCommit(input *gofuse.RenameIn, oldP, newP string) bool {
+	if fs.pendingIndex == nil {
+		return false
+	}
+	meta, ok := fs.pendingIndex.GetMeta(oldP)
+	if !ok || meta.Kind != PendingNew {
+		return false
+	}
+
+	if fs.commitQueue != nil {
+		fs.commitQueue.CancelPathPreserveLocal(oldP)
+		fs.commitQueue.WaitPath(oldP)
+		fs.commitQueue.WaitPath(newP)
+
+		// The cancel may have raced with a successful upload. If so, the old
+		// path now exists remotely and the normal server-side rename is correct.
+		meta, ok = fs.pendingIndex.GetMeta(oldP)
+		if !ok || meta.Kind != PendingNew {
+			return false
+		}
+	}
+
+	if fs.shadowStore != nil {
+		if !fs.shadowStore.Rename(oldP, newP) {
+			log.Printf("rename: move pending shadow %s -> %s failed", oldP, newP)
+			return false
+		}
+	}
+	if !fs.pendingIndex.RenamePending(oldP, newP) {
+		log.Printf("rename: move pending index %s -> %s failed", oldP, newP)
+		return false
+	}
+
+	fs.finishLocalRename(input, oldP, newP)
+
+	if fs.commitQueue != nil {
+		ino, _ := fs.inodes.GetInode(newP)
+		entry := &CommitEntry{
+			Path:        newP,
+			Inode:       ino,
+			BaseRev:     meta.BaseRev,
+			Size:        meta.Size,
+			Kind:        meta.Kind,
+			ShadowSpill: meta.ShadowSpill,
+		}
+		if err := fs.commitQueue.Enqueue(entry); err != nil {
+			log.Printf("rename: enqueue pending-new commit for %s: %v", newP, err)
+		}
+	}
+	return true
+}
+
+func (fs *Dat9FS) finishLocalRename(input *gofuse.RenameIn, oldP, newP string) {
+	fs.inodes.Rename(oldP, newP)
+	fs.readCache.Invalidate(oldP)
+	fs.readCache.Invalidate(newP)
+	fs.readCache.InvalidatePrefix(oldP + "/")
+	fs.readCache.InvalidatePrefix(newP + "/")
+
+	oldParent, _ := fs.inodes.GetPath(input.NodeId)
+	fs.dirCache.Invalidate(oldParent)
+	if input.Newdir != input.NodeId {
+		newParent, _ := fs.inodes.GetPath(input.Newdir)
+		fs.dirCache.Invalidate(newParent)
+	}
+}
+
 func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName string, newName string) gofuse.Status {
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
@@ -1578,6 +1645,10 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 		return st
 	}
 	if oldP == newP {
+		return gofuse.OK
+	}
+
+	if fs.renamePendingNewCommit(input, oldP, newP) {
 		return gofuse.OK
 	}
 
@@ -1610,28 +1681,11 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 			isPendingNew = true
 		}
 		// Also check pendingIndex for files handed to commitQueue after Release.
-		if !isPendingNew && fs.pendingIndex != nil {
-			if meta, ok := fs.pendingIndex.GetMeta(oldP); ok && meta.Kind == PendingNew {
-				if fs.shadowStore != nil {
-					fs.shadowStore.Rename(oldP, newP)
-				}
-				fs.pendingIndex.RenamePending(oldP, newP)
-				isPendingNew = true
-			}
+		if !isPendingNew && fs.renamePendingNewCommit(input, oldP, newP) {
+			return gofuse.OK
 		}
 		if isPendingNew {
-			fs.inodes.Rename(oldP, newP)
-			fs.readCache.Invalidate(oldP)
-			fs.readCache.Invalidate(newP)
-			fs.readCache.InvalidatePrefix(oldP + "/")
-			fs.readCache.InvalidatePrefix(newP + "/")
-
-			oldParent, _ := fs.inodes.GetPath(input.NodeId)
-			fs.dirCache.Invalidate(oldParent)
-			if input.Newdir != input.NodeId {
-				newParent, _ := fs.inodes.GetPath(input.Newdir)
-				fs.dirCache.Invalidate(newParent)
-			}
+			fs.finishLocalRename(input, oldP, newP)
 			// Kernel initiated the rename and receives OK. Lock files opt out
 			// of entry caching at create/lookup time, so the next O_CREAT|O_EXCL
 			// revalidates without a synchronous EntryNotify from this handler.
@@ -1684,18 +1738,7 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 		}
 	}
 
-	fs.inodes.Rename(oldP, newP)
-	fs.readCache.Invalidate(oldP)
-	fs.readCache.Invalidate(newP)
-	fs.readCache.InvalidatePrefix(oldP + "/")
-	fs.readCache.InvalidatePrefix(newP + "/")
-
-	oldParent, _ := fs.inodes.GetPath(input.NodeId)
-	fs.dirCache.Invalidate(oldParent)
-	if input.Newdir != input.NodeId {
-		newParent, _ := fs.inodes.GetPath(input.Newdir)
-		fs.dirCache.Invalidate(newParent)
-	}
+	fs.finishLocalRename(input, oldP, newP)
 	return gofuse.OK
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1565,37 +1565,64 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 	return gofuse.OK
 }
 
-func (fs *Dat9FS) renamePendingNewCommit(input *gofuse.RenameIn, oldP, newP string) bool {
+type pendingRenameResult int
+
+const (
+	pendingRenameNotApplicable pendingRenameResult = iota
+	pendingRenameRemoteFallback
+	pendingRenameHandled
+)
+
+func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.RenameIn, oldP, newP string) (pendingRenameResult, error) {
 	if fs.pendingIndex == nil {
-		return false
+		return pendingRenameNotApplicable, nil
 	}
 	meta, ok := fs.pendingIndex.GetMeta(oldP)
 	if !ok || meta.Kind != PendingNew {
-		return false
+		return pendingRenameNotApplicable, nil
+	}
+
+	// Only use the local fast path when the final path is truly absent.
+	// Git lockfile replacement (for example config.lock -> config) must keep
+	// the old server-side rename semantics so the existing target is replaced
+	// atomically after the temp file upload completes.
+	if fs.commitQueue != nil {
+		fs.commitQueue.WaitPath(newP)
+	}
+	targetExists, err := fs.pendingRenameTargetExists(ctx, newP)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return pendingRenameNotApplicable, err
+		}
+		log.Printf("rename: probe final pending-new target %s failed, using remote fallback: %v", newP, err)
+		return pendingRenameRemoteFallback, nil
+	}
+	if targetExists {
+		return pendingRenameRemoteFallback, nil
 	}
 
 	if fs.commitQueue != nil {
 		fs.commitQueue.CancelPathPreserveLocal(oldP)
 		fs.commitQueue.WaitPath(oldP)
-		fs.commitQueue.WaitPath(newP)
 
 		// The cancel may have raced with a successful upload. If so, the old
 		// path now exists remotely and the normal server-side rename is correct.
 		meta, ok = fs.pendingIndex.GetMeta(oldP)
 		if !ok || meta.Kind != PendingNew {
-			return false
+			return pendingRenameRemoteFallback, nil
 		}
 	}
 
 	if fs.shadowStore != nil {
 		if !fs.shadowStore.Rename(oldP, newP) {
-			log.Printf("rename: move pending shadow %s -> %s failed", oldP, newP)
-			return false
+			return pendingRenameHandled, fmt.Errorf("move pending shadow %s -> %s failed", oldP, newP)
 		}
 	}
 	if !fs.pendingIndex.RenamePending(oldP, newP) {
-		log.Printf("rename: move pending index %s -> %s failed", oldP, newP)
-		return false
+		if fs.shadowStore != nil {
+			_ = fs.shadowStore.Rename(newP, oldP)
+		}
+		return pendingRenameHandled, fmt.Errorf("move pending index %s -> %s failed", oldP, newP)
 	}
 
 	fs.finishLocalRename(input, oldP, newP)
@@ -1611,10 +1638,37 @@ func (fs *Dat9FS) renamePendingNewCommit(input *gofuse.RenameIn, oldP, newP stri
 			ShadowSpill: meta.ShadowSpill,
 		}
 		if err := fs.commitQueue.Enqueue(entry); err != nil {
-			log.Printf("rename: enqueue pending-new commit for %s: %v", newP, err)
+			log.Printf("rename: enqueue pending-new commit for %s failed, falling back to sync commit: %v", newP, err)
+			if commitErr := fs.commitQueue.CommitNow(ctx, entry); commitErr != nil {
+				return pendingRenameHandled, fmt.Errorf("sync commit pending-new rename %s: %w", newP, commitErr)
+			}
 		}
 	}
-	return true
+	return pendingRenameHandled, nil
+}
+
+func (fs *Dat9FS) pendingRenameTargetExists(ctx context.Context, p string) (bool, error) {
+	if fs.pendingIndex != nil {
+		if _, ok := fs.pendingIndex.GetMeta(p); ok {
+			return true, nil
+		}
+	}
+	if fs.writeBack != nil {
+		if _, ok := fs.writeBack.GetMeta(p); ok {
+			return true, nil
+		}
+	}
+	if fs.commitQueue != nil && fs.commitQueue.HasPath(p) {
+		return true, nil
+	}
+	_, err := fs.client.StatCtx(ctx, fs.remotePath(p))
+	if err == nil {
+		return true, nil
+	}
+	if isNotFoundErr(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (fs *Dat9FS) finishLocalRename(input *gofuse.RenameIn, oldP, newP string) {
@@ -1648,7 +1702,12 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 		return gofuse.OK
 	}
 
-	if fs.renamePendingNewCommit(input, oldP, newP) {
+	pendingRename, err := fs.renamePendingNewCommit(ctx, input, oldP, newP)
+	if err != nil {
+		log.Printf("rename: pending-new local rename %s -> %s failed: %v", oldP, newP, err)
+		return httpToFuseStatus(err)
+	}
+	if pendingRename == pendingRenameHandled {
 		return gofuse.OK
 	}
 
@@ -1681,8 +1740,15 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 			isPendingNew = true
 		}
 		// Also check pendingIndex for files handed to commitQueue after Release.
-		if !isPendingNew && fs.renamePendingNewCommit(input, oldP, newP) {
-			return gofuse.OK
+		if !isPendingNew {
+			pendingRename, err := fs.renamePendingNewCommit(ctx, input, oldP, newP)
+			if err != nil {
+				log.Printf("rename: pending-new local rename %s -> %s failed: %v", oldP, newP, err)
+				return httpToFuseStatus(err)
+			}
+			if pendingRename == pendingRenameHandled {
+				return gofuse.OK
+			}
 		}
 		if isPendingNew {
 			fs.finishLocalRename(input, oldP, newP)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3469,6 +3469,203 @@ func TestRenamePendingNewCommitQueueCancelsTempUploadAndEnqueuesFinalPath(t *tes
 	}
 }
 
+func TestRenamePendingNewCommitFallsBackWhenFinalTargetExists(t *testing.T) {
+	oldP := "/repo/.git/config.lock"
+	newP := "/repo/.git/config"
+	data := []byte("[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = https://github.com/mem9-ai/drive9.git\n")
+
+	var oldPuts atomic.Int32
+	var finalPuts atomic.Int32
+	var renameCalls atomic.Int32
+	var renameSource string
+	var mu sync.Mutex
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs"+newP:
+			w.Header().Set("Content-Length", "36")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "4")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+oldP:
+			oldPuts.Add(1)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if string(body) != string(data) {
+				http.Error(w, "unexpected temp upload body", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 5})
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+newP:
+			finalPuts.Add(1)
+			http.Error(w, "final path should not be uploaded directly when target exists", http.StatusInternalServerError)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs"+newP && r.URL.RawQuery == "rename":
+			renameCalls.Add(1)
+			mu.Lock()
+			renameSource = r.Header.Get("X-Dat9-Rename-Source")
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	c := client.New(ts.URL, "")
+	fs := NewDat9FS(c, opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 16)
+	defer cq.DrainAll()
+	fs.commitQueue = cq
+
+	if err := shadow.WriteFull(oldP, data, 0); err != nil {
+		t.Fatalf("WriteFull old shadow: %v", err)
+	}
+	if _, err := pending.PutWithBaseRev(oldP, int64(len(data)), PendingNew, 0); err != nil {
+		t.Fatalf("PutWithBaseRev old pending: %v", err)
+	}
+	oldIno := fs.inodes.Lookup(oldP, false, int64(len(data)), time.Now())
+	dirIno := fs.inodes.Lookup("/repo/.git", true, 0, time.Now())
+	fs.inodes.Lookup(newP, false, 36, time.Now())
+
+	if err := cq.Enqueue(&CommitEntry{
+		Path:  oldP,
+		Inode: oldIno,
+		Size:  int64(len(data)),
+		Kind:  PendingNew,
+	}); err != nil {
+		t.Fatalf("enqueue old temp upload: %v", err)
+	}
+
+	st := fs.Rename(nil, &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Newdir:   dirIno,
+	}, "config.lock", "config")
+	if st != gofuse.OK {
+		t.Fatalf("Rename: %v", st)
+	}
+
+	cq.DrainAll()
+	if got := oldPuts.Load(); got != 1 {
+		t.Fatalf("old temp PUTs = %d, want 1", got)
+	}
+	if got := finalPuts.Load(); got != 0 {
+		t.Fatalf("final path PUTs = %d, want 0", got)
+	}
+	if got := renameCalls.Load(); got != 1 {
+		t.Fatalf("remote rename calls = %d, want 1", got)
+	}
+	mu.Lock()
+	gotRenameSource := renameSource
+	mu.Unlock()
+	if gotRenameSource != oldP {
+		t.Fatalf("rename source = %q, want %q", gotRenameSource, oldP)
+	}
+	if pending.HasPending(oldP) {
+		t.Fatal("old temp path still pending")
+	}
+	if shadow.Has(oldP) {
+		t.Fatal("old temp shadow still exists")
+	}
+}
+
+func TestRenamePendingNewCommitSyncCommitsWhenQueueStopped(t *testing.T) {
+	oldP := "/repo/.git/objects/70/tmp_obj_sync"
+	newP := "/repo/.git/objects/70/24234d93f61104585962ac664bc5a7ed1d241d"
+	data := []byte("loose object")
+
+	var finalPuts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+newP:
+			finalPuts.Add(1)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if string(body) != string(data) {
+				http.Error(w, "unexpected final upload body", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 7})
+		case r.Method == http.MethodPost && r.URL.RawQuery == "rename":
+			http.Error(w, "server rename should not be used for absent final target", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	c := client.New(ts.URL, "")
+	fs := NewDat9FS(c, opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 16)
+	cq.DrainAll()
+	fs.commitQueue = cq
+
+	if err := shadow.WriteFull(oldP, data, 0); err != nil {
+		t.Fatalf("WriteFull old shadow: %v", err)
+	}
+	if _, err := pending.PutWithBaseRev(oldP, int64(len(data)), PendingNew, 0); err != nil {
+		t.Fatalf("PutWithBaseRev old pending: %v", err)
+	}
+	oldIno := fs.inodes.Lookup(oldP, false, int64(len(data)), time.Now())
+	dirIno := fs.inodes.Lookup("/repo/.git/objects/70", true, 0, time.Now())
+
+	st := fs.Rename(nil, &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Newdir:   dirIno,
+	}, "tmp_obj_sync", "24234d93f61104585962ac664bc5a7ed1d241d")
+	if st != gofuse.OK {
+		t.Fatalf("Rename: %v", st)
+	}
+	if got := finalPuts.Load(); got != 1 {
+		t.Fatalf("final path PUTs = %d, want 1", got)
+	}
+	if pending.HasPending(newP) {
+		t.Fatal("final path still pending after sync commit")
+	}
+	if shadow.Has(newP) {
+		t.Fatal("final shadow still exists after sync commit")
+	}
+	if _, ok := fs.inodes.GetInode(newP); !ok {
+		t.Fatal("final inode missing after local rename")
+	}
+	if _, ok := fs.inodes.GetEntry(oldIno); !ok {
+		t.Fatal("renamed inode should still exist")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Read detached retry tests
 // ---------------------------------------------------------------------------

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3344,6 +3344,131 @@ func TestFlushLargeFile_InteractiveStagesShadowAndPendingIndex(t *testing.T) {
 	}
 }
 
+func TestRenamePendingNewCommitQueueCancelsTempUploadAndEnqueuesFinalPath(t *testing.T) {
+	oldP := "/repo/.git/objects/70/tmp_obj_test"
+	newP := "/repo/.git/objects/70/24234d93f61104585962ac664bc5a7ed1d241d"
+	data := []byte("loose object data")
+
+	oldPutStarted := make(chan struct{})
+	var oldPutOnce sync.Once
+	var oldPuts atomic.Int32
+	var finalPuts atomic.Int32
+	var renameCalls atomic.Int32
+	var mu sync.Mutex
+	var finalBody []byte
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+oldP:
+			oldPuts.Add(1)
+			oldPutOnce.Do(func() { close(oldPutStarted) })
+			select {
+			case <-r.Context().Done():
+				http.Error(w, "canceled", http.StatusRequestTimeout)
+			case <-time.After(200 * time.Millisecond):
+				http.Error(w, "old temp upload should have been canceled", http.StatusServiceUnavailable)
+			}
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+newP:
+			finalPuts.Add(1)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			finalBody = append([]byte(nil), body...)
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 2})
+		case r.Method == http.MethodPost && r.URL.RawQuery == "rename":
+			renameCalls.Add(1)
+			http.Error(w, "server rename should not be used for pending-new temp files", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	c := client.New(ts.URL, "")
+	fs := NewDat9FS(c, opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 16)
+	defer cq.DrainAll()
+	fs.commitQueue = cq
+
+	if err := shadow.WriteFull(oldP, data, 0); err != nil {
+		t.Fatalf("WriteFull old shadow: %v", err)
+	}
+	if _, err := pending.PutWithBaseRev(oldP, int64(len(data)), PendingNew, 0); err != nil {
+		t.Fatalf("PutWithBaseRev old pending: %v", err)
+	}
+	oldIno := fs.inodes.Lookup(oldP, false, int64(len(data)), time.Now())
+	dirIno := fs.inodes.Lookup("/repo/.git/objects/70", true, 0, time.Now())
+
+	if err := cq.Enqueue(&CommitEntry{
+		Path:  oldP,
+		Inode: oldIno,
+		Size:  int64(len(data)),
+		Kind:  PendingNew,
+	}); err != nil {
+		t.Fatalf("enqueue old temp upload: %v", err)
+	}
+	select {
+	case <-oldPutStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("old temp upload did not start")
+	}
+
+	st := fs.Rename(nil, &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Newdir:   dirIno,
+	}, "tmp_obj_test", "24234d93f61104585962ac664bc5a7ed1d241d")
+	if st != gofuse.OK {
+		t.Fatalf("Rename: %v", st)
+	}
+
+	cq.DrainAll()
+	if got := finalPuts.Load(); got != 1 {
+		t.Fatalf("final path PUTs = %d, want 1", got)
+	}
+	if got := renameCalls.Load(); got != 0 {
+		t.Fatalf("remote rename calls = %d, want 0", got)
+	}
+	mu.Lock()
+	gotBody := string(finalBody)
+	mu.Unlock()
+	if gotBody != string(data) {
+		t.Fatalf("final upload body = %q, want %q", gotBody, string(data))
+	}
+	if pending.HasPending(oldP) {
+		t.Fatal("old temp path still pending")
+	}
+	if pending.HasPending(newP) {
+		t.Fatal("final path still pending after upload")
+	}
+	if shadow.Has(oldP) {
+		t.Fatal("old temp shadow still exists")
+	}
+	if shadow.Has(newP) {
+		t.Fatal("final shadow still exists after upload")
+	}
+	if oldPuts.Load() == 0 {
+		t.Fatal("old temp upload was never exercised")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Read detached retry tests
 // ---------------------------------------------------------------------------

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -173,13 +173,14 @@ func (idx *PendingIndex) RenamePending(oldPath, newPath string) bool {
 	// Copy fields under read lock.
 	gen := idx.nextGen.Add(1)
 	newMeta := &WriteBackMeta{
-		Path:       newPath,
-		Size:       meta.Size,
-		Mtime:      meta.Mtime,
-		CreatedAt:  meta.CreatedAt,
-		Generation: gen,
-		Kind:       meta.Kind,
-		BaseRev:    meta.BaseRev,
+		Path:        newPath,
+		Size:        meta.Size,
+		Mtime:       meta.Mtime,
+		CreatedAt:   meta.CreatedAt,
+		Generation:  gen,
+		Kind:        meta.Kind,
+		BaseRev:     meta.BaseRev,
+		ShadowSpill: meta.ShadowSpill,
 	}
 	idx.mu.RUnlock()
 

--- a/pkg/fuse/pending_index_test.go
+++ b/pkg/fuse/pending_index_test.go
@@ -66,7 +66,7 @@ func TestPendingIndexRenamePending(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = idx.PutWithBaseRev("/old/file.txt", 512, PendingOverwrite, 11)
+	_, err = idx.PutShadowSpill("/old/file.txt", 512, PendingOverwrite, 11)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,6 +88,9 @@ func TestPendingIndexRenamePending(t *testing.T) {
 	}
 	if meta.Size != 512 {
 		t.Errorf("size = %d, want 512", meta.Size)
+	}
+	if !meta.ShadowSpill {
+		t.Error("ShadowSpill = false, want true")
 	}
 	if meta.Kind != PendingOverwrite {
 		t.Errorf("kind = %d, want PendingOverwrite", meta.Kind)


### PR DESCRIPTION
## Summary
- cancel in-flight commit queue uploads for pending-new temp paths without deleting local shadow/index state
- handle pending-new FUSE rename locally before waiting on the old commit path, then enqueue the final path upload
- preserve ShadowSpill metadata across pending index renames

## Tests
- go test ./pkg/fuse -count=1
- go test ./pkg/fuse -run TestRenamePendingNewCommitQueueCancelsTempUploadAndEnqueuesFinalPath -count=20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to cancel pending and in-flight file uploads, with an option to preserve local state
  * Improved rename operations to correctly handle files awaiting upload

* **Tests**
  * Added integration test validating rename behavior for files with pending uploads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->