### PR TITLE
Add tenant API key management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ drive9 create --name dev --server https://api.drive9.ai
 drive9 ctx use dev
 ```
 
+### Tenant API Key Commands
+
+The provisioned `default` API key can manage additional tenant API keys:
+
+```bash
+drive9 api-key ls
+
+drive9 api-key create worker --json
+drive9 api-key get worker
+drive9 api-key rm worker
+```
+
 ### Filesystem Commands
 
 ```bash

--- a/cmd/drive9/cli/api_keys.go
+++ b/cmd/drive9/cli/api_keys.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+const defaultManagedAPIKeyName = "default"
+
+// APIKeyCmd dispatches tenant API key management subcommands.
+func APIKeyCmd(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage drive9 api-key <ls|create|get|rm>")
+	}
+	switch args[0] {
+	case "ls":
+		return apiKeyList(args[1:])
+	case "create":
+		return apiKeyCreate(args[1:])
+	case "get":
+		return apiKeyGet(args[1:])
+	case "rm":
+		return apiKeyDelete(args[1:])
+	case "-h", "--help", "help":
+		return fmt.Errorf("usage drive9 api-key <ls|create|get|rm>")
+	default:
+		return fmt.Errorf("unknown api-key command %q", args[0])
+	}
+}
+
+func apiKeyList(args []string) error {
+	asJSON := false
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+			asJSON = true
+		default:
+			return fmt.Errorf("usage drive9 api-key ls [--json]")
+		}
+	}
+	c, err := newVaultManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	keys, err := c.ListTenantAPIKeys(context.Background())
+	if err != nil {
+		return err
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].KeyName < keys[j].KeyName
+	})
+	if asJSON {
+		return writeJSON(map[string]any{"keys": keys})
+	}
+	printTenantAPIKeyTable(keys)
+	return nil
+}
+
+func apiKeyCreate(args []string) error {
+	name, asJSON, err := parseAPIKeyNameAndJSONFlag(args, "usage drive9 api-key create <name> [--json]")
+	if err != nil {
+		return err
+	}
+	if err := validateTenantAPIKeyNameForCreate(name); err != nil {
+		return err
+	}
+	c, err := newVaultManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	key, err := c.CreateTenantAPIKey(context.Background(), name)
+	if err != nil {
+		return err
+	}
+	if asJSON {
+		return writeJSON(key)
+	}
+	printTenantAPIKey(key)
+	return nil
+}
+
+func apiKeyGet(args []string) error {
+	name, asJSON, err := parseAPIKeyNameAndJSONFlag(args, "usage drive9 api-key get <name> [--json]")
+	if err != nil {
+		return err
+	}
+	if err := validateTenantAPIKeyName(name); err != nil {
+		return err
+	}
+	c, err := newVaultManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	key, err := c.GetTenantAPIKey(context.Background(), name)
+	if err != nil {
+		return err
+	}
+	if asJSON {
+		return writeJSON(key)
+	}
+	printTenantAPIKey(key)
+	return nil
+}
+
+func apiKeyDelete(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage drive9 api-key rm <name>")
+	}
+	if err := validateTenantAPIKeyName(args[0]); err != nil {
+		return err
+	}
+	c, err := newVaultManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	return c.DeleteTenantAPIKey(context.Background(), args[0])
+}
+
+func parseAPIKeyNameAndJSONFlag(args []string, usage string) (string, bool, error) {
+	var (
+		name   string
+		asJSON bool
+	)
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+			asJSON = true
+		default:
+			if strings.HasPrefix(arg, "--") {
+				return "", false, fmt.Errorf("unknown flag %q", arg)
+			}
+			if name != "" {
+				return "", false, fmt.Errorf("%s", usage)
+			}
+			name = arg
+		}
+	}
+	if name == "" {
+		return "", false, fmt.Errorf("%s", usage)
+	}
+	return name, asJSON, nil
+}
+
+func validateTenantAPIKeyName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("api key name is required")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("api key name must be <= 64 characters")
+	}
+	if strings.Contains(name, "/") {
+		return fmt.Errorf("api key name must not contain /")
+	}
+	return nil
+}
+
+func validateTenantAPIKeyNameForCreate(name string) error {
+	if err := validateTenantAPIKeyName(name); err != nil {
+		return err
+	}
+	if name == defaultManagedAPIKeyName {
+		return fmt.Errorf("api key name %q is reserved", defaultManagedAPIKeyName)
+	}
+	return nil
+}
+
+func printTenantAPIKeyTable(keys []client.TenantAPIKeySummary) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "NAME\tSTATUS\tISSUED_AT\tREVOKED_AT")
+	for _, key := range keys {
+		revokedAt := ""
+		if key.RevokedAt != nil {
+			revokedAt = key.RevokedAt.Format(time.RFC3339)
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			key.KeyName,
+			key.Status,
+			key.IssuedAt.Format(time.RFC3339),
+			revokedAt,
+		)
+	}
+	_ = w.Flush()
+}
+
+func printTenantAPIKey(key *client.TenantAPIKey) {
+	_, _ = fmt.Fprintf(os.Stdout, "api_key=%s\n", key.APIKey)
+	_, _ = fmt.Fprintf(os.Stdout, "key_id=%s\n", key.KeyID)
+	_, _ = fmt.Fprintf(os.Stdout, "key_name=%s\n", key.KeyName)
+	_, _ = fmt.Fprintf(os.Stdout, "status=%s\n", key.Status)
+	if !key.IssuedAt.IsZero() {
+		_, _ = fmt.Fprintf(os.Stdout, "issued_at=%s\n", key.IssuedAt.Format(time.RFC3339))
+	}
+	if key.RevokedAt != nil {
+		_, _ = fmt.Fprintf(os.Stdout, "revoked_at=%s\n", key.RevokedAt.Format(time.RFC3339))
+	}
+}

--- a/cmd/drive9/cli/api_keys_test.go
+++ b/cmd/drive9/cli/api_keys_test.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAPIKeyListJSON(t *testing.T) {
+	home := withIsolatedHome(t)
+	_ = home
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+	issuedAt := time.Date(2026, time.May, 7, 12, 0, 0, 0, time.UTC)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/tenants/keys" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-owner" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{{
+				"key_id":    "k_default",
+				"key_name":  "default",
+				"status":    "active",
+				"issued_at": issuedAt.Format(time.RFC3339),
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv(EnvServer, srv.URL)
+	t.Setenv(EnvAPIKey, "sk-owner")
+	out, err := captureStdoutE(t, func() error { return APIKeyCmd([]string{"ls", "--json"}) })
+	if err != nil {
+		t.Fatalf("APIKeyCmd ls: %v", err)
+	}
+	if !strings.Contains(out, `"key_name": "default"`) {
+		t.Fatalf("output = %q, want default key json", out)
+	}
+}
+
+func TestAPIKeyCreatePrintsKeyValueLines(t *testing.T) {
+	home := withIsolatedHome(t)
+	_ = home
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/tenants/keys" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var req map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		if req["key_name"] != "worker" {
+			t.Fatalf("key_name = %q, want worker", req["key_name"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"api_key":  "sk_worker",
+			"key_id":   "k_worker",
+			"key_name": "worker",
+			"status":   "active",
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv(EnvServer, srv.URL)
+	t.Setenv(EnvAPIKey, "sk-owner")
+	out, err := captureStdoutE(t, func() error { return APIKeyCmd([]string{"create", "worker"}) })
+	if err != nil {
+		t.Fatalf("APIKeyCmd create: %v", err)
+	}
+	for _, want := range []string{"api_key=sk_worker", "key_id=k_worker", "key_name=worker", "status=active"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output = %q, want %q", out, want)
+		}
+	}
+}
+
+func TestAPIKeyGetJSON(t *testing.T) {
+	home := withIsolatedHome(t)
+	_ = home
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+	issuedAt := time.Date(2026, time.May, 7, 12, 30, 0, 0, time.UTC)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/tenants/keys/worker" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"api_key":   "sk_worker",
+			"key_id":    "k_worker",
+			"key_name":  "worker",
+			"status":    "active",
+			"issued_at": issuedAt.Format(time.RFC3339),
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv(EnvServer, srv.URL)
+	t.Setenv(EnvAPIKey, "sk-owner")
+	out, err := captureStdoutE(t, func() error { return APIKeyCmd([]string{"get", "worker", "--json"}) })
+	if err != nil {
+		t.Fatalf("APIKeyCmd get: %v", err)
+	}
+	if !strings.Contains(out, `"api_key": "sk_worker"`) || !strings.Contains(out, `"issued_at": "2026-05-07T12:30:00Z"`) {
+		t.Fatalf("output = %q, want api key json", out)
+	}
+}
+
+func TestAPIKeyDeleteCallsEndpoint(t *testing.T) {
+	home := withIsolatedHome(t)
+	_ = home
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/tenants/keys/worker" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv(EnvServer, srv.URL)
+	t.Setenv(EnvAPIKey, "sk-owner")
+	out, err := captureStdoutE(t, func() error { return APIKeyCmd([]string{"rm", "worker"}) })
+	if err != nil {
+		t.Fatalf("APIKeyCmd rm: %v", err)
+	}
+	if !called {
+		t.Fatal("delete endpoint was not called")
+	}
+	if out != "" {
+		t.Fatalf("stdout = %q, want empty", out)
+	}
+}

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -7,6 +7,7 @@
 // Commands:
 //
 //	create  provision a new database and owner context
+//	api-key tenant API key operations (ls, create, get, rm)
 //	ctx     manage contexts (add, import, ls, use, rm)
 //	fs      filesystem operations (cp, cat, ls, stat, mv, rm, sh, grep, find)
 //	vault   vault operations (set, get, put, with, ls, rm, grant, revoke, audit)
@@ -37,6 +38,10 @@ var exitFunc = os.Exit
 // "handler not reached". Production callers see no change: the default value
 // is the real cli.Secret and nothing else reassigns it outside tests.
 var vaultHandler = cli.Secret
+
+// apiKeyHandler is the `drive9 api-key` command entry point, indirected so
+// dispatch tests can assert routing without invoking the concrete handler.
+var apiKeyHandler = cli.APIKeyCmd
 
 func main() {
 	if logger.CLIEnabled() {
@@ -87,6 +92,21 @@ func dispatch(cmd string, args []string) {
 		}
 		if err := cli.Create(args); err != nil {
 			fatal("create", err)
+		}
+	case "api-key":
+		if cliLogger != nil {
+			sub := ""
+			if len(args) > 0 {
+				sub = args[0]
+			}
+			logger.Info(context.Background(), "cli_command", zap.String("command", "api-key"), zap.String("subcommand", sub))
+		}
+		if err := apiKeyHandler(args); err != nil {
+			sub := ""
+			if len(args) > 0 {
+				sub = " " + args[0]
+			}
+			fatal("api-key"+sub, err)
 		}
 	case "ctx":
 		if cliLogger != nil {
@@ -229,6 +249,8 @@ func usage(code int) {
 commands:
   create [--name NAME] [--server URL]
                          provision a new database and owner context
+	api-key <ls|create|get|rm>
+												 manage tenant API keys
   ctx                    show current context
   ctx add --api-key <key> [--name NAME] [--server URL]
                          add owner context

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -80,6 +80,7 @@ func TestDispatchLongHelpFlagShowsUsage(t *testing.T) {
 	}
 	for _, want := range []string{
 		"usage: drive9 <command> [arguments]",
+		"api-key <ls|create|get|rm>",
 		"ctx use <name>",
 		"mount [flags] [:/remote] <mountpoint>",
 		"mount vault [flags] <mountpoint>",
@@ -87,6 +88,39 @@ func TestDispatchLongHelpFlagShowsUsage(t *testing.T) {
 	} {
 		if !strings.Contains(stderr, want) {
 			t.Fatalf("stderr = %q, want it to contain %q", stderr, want)
+		}
+	}
+}
+
+func TestDispatchAPIKeyVerbReachesHandler(t *testing.T) {
+	origHandler := apiKeyHandler
+	origExit := exitFunc
+	t.Cleanup(func() {
+		apiKeyHandler = origHandler
+		exitFunc = origExit
+	})
+	exitFunc = func(int) {}
+
+	var gotArgs []string
+	called := false
+	apiKeyHandler = func(args []string) error {
+		called = true
+		gotArgs = args
+		return nil
+	}
+
+	dispatch("api-key", []string{"ls", "--json"})
+
+	if !called {
+		t.Fatal("api-key handler was not invoked for `drive9 api-key ...`")
+	}
+	want := []string{"ls", "--json"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q", i, gotArgs[i], want[i])
 		}
 	}
 }

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -148,13 +148,14 @@ use the same value as `DRIVE9_API_KEY` here.
 
 1. Provision + readiness polling
 2. Prepare `drive9` CLI binary (build local or download official release)
-3. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `rm`)
-4. CLI batch small-file flow (`cp` many files + dir list count + stat + sample reads)
-5. CLI search flow (`fs grep`, `fs find`)
-6. CLI semantic and image-associated recall flow (`fs grep` paraphrase + image caption recall) with async polling
-7. CLI image flow (`fs cp` jpg + `fs find -name "*.jpg"`)
-8. CLI large-file flow (`cp` upload multipart + `cp` download + checksum verification)
-9. CLI upload-limit boundary (`10GiB` initiate accepted, `10GiB+1` rejected)
+3. CLI tenant API key flow (`api-key ls/create/get/rm` + revoked-key rejection)
+4. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `rm`)
+5. CLI batch small-file flow (`cp` many files + dir list count + stat + sample reads)
+6. CLI search flow (`fs grep`, `fs find`)
+7. CLI semantic and image-associated recall flow (`fs grep` paraphrase + image caption recall) with async polling
+8. CLI image flow (`fs cp` jpg + `fs find -name "*.jpg"`)
+9. CLI large-file flow (`cp` upload multipart + `cp` download + checksum verification)
+10. CLI upload-limit boundary (`10GiB` initiate accepted, `10GiB+1` rejected)
 
 ### `fuse-smoke-test.sh`
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,7 +15,7 @@ including local single-tenant validation via `drive9-server-local`.
 |--------|--------------------|
 | `api-smoke-test.sh` | Fresh provisioning, status polling, nested+batch file ops, grep/find checks, semantic text recall, image-associated recall, sql checks, large multipart upload+download |
 | `api-smoke-test-existing-key.sh` | Existing API key status/list checks |
-| `cli-smoke-test.sh` | End-to-end CLI workflow including `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
+| `cli-smoke-test.sh` | End-to-end CLI workflow including tenant `api-key` management, `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
 | `fuse-smoke-test.sh` | FUSE mount lifecycle, file/dir/rename/stat semantics, cross-channel consistency, read-only and error-path checks |
 | `smoke-all.sh` | Runs API + CLI + FUSE smoke scripts in sequence with aggregated pass/fail |
 

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -244,6 +244,7 @@ PY
 }
 
 TS="$(date +%s)"
+MANAGED_KEY_NAME="cli-worker-${TS}"
 SMALL_LOCAL="/tmp/drive9-cli-small-${TS}.txt"
 SMALL_REMOTE="/cli-${TS}-small.txt"
 SMALL_RENAMED="/cli-${TS}-small-renamed.txt"
@@ -261,6 +262,43 @@ LARGE_REMOTE="/cli-${TS}-large-${CLI_LARGE_FILE_MB}m.bin"
 LARGE_DOWNLOADED="/tmp/drive9-cli-large-${TS}.download.bin"
 LARGE_BYTES=$((CLI_LARGE_FILE_MB * 1024 * 1024))
 CLI_IMAGE_UPLOADED=0
+
+echo "[3.1] tenant api key management via cli"
+api_key_ls_json="$(drive9_retry api-key ls --json)"
+default_key_present="$(jq -r '[.keys[]? | select(.key_name=="default")] | length' <<<"$api_key_ls_json")"
+check_eq "api-key ls includes default key" "$default_key_present" "1"
+
+created_key_json="$(drive9_retry api-key create "$MANAGED_KEY_NAME" --json)"
+MANAGED_API_KEY="$(jq -r '.api_key // empty' <<<"$created_key_json")"
+check_cmd "api-key create returns plaintext api_key" test -n "$MANAGED_API_KEY"
+
+created_key_name="$(jq -r '.key_name // empty' <<<"$created_key_json")"
+check_eq "api-key create returns requested key name" "$created_key_name" "$MANAGED_KEY_NAME"
+
+managed_key_present="$(jq -r --arg key "$MANAGED_KEY_NAME" '[.keys[]? | select(.key_name==$key)] | length' <<<"$(drive9_retry api-key ls --json)")"
+check_eq "api-key ls includes managed key" "$managed_key_present" "1"
+
+managed_get_json="$(drive9_retry api-key get "$MANAGED_KEY_NAME" --json)"
+managed_get_api_key="$(jq -r '.api_key // empty' <<<"$managed_get_json")"
+check_eq "api-key get returns created plaintext key" "$managed_get_api_key" "$MANAGED_API_KEY"
+
+worker_ls_out="$(DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$MANAGED_API_KEY" "$CLI_BIN" fs ls / 2>&1)"
+worker_ls_rc=$?
+check_eq "created managed key can access fs ls /" "$worker_ls_rc" "0"
+
+drive9_retry api-key rm "$MANAGED_KEY_NAME" >/dev/null
+revoked_get_json="$(drive9_retry api-key get "$MANAGED_KEY_NAME" --json)"
+revoked_status="$(jq -r '.status // empty' <<<"$revoked_get_json")"
+check_eq "api-key rm marks key revoked" "$revoked_status" "revoked"
+
+TOTAL=$((TOTAL+1))
+if DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$MANAGED_API_KEY" "$CLI_BIN" fs ls / >/dev/null 2>&1; then
+  echo "FAIL revoked managed key is rejected"
+  FAIL=$((FAIL+1))
+else
+  echo "PASS revoked managed key is rejected"
+  PASS=$((PASS+1))
+fi
 
 echo "[4] small file ops via cli"
 printf "cli-smoke-%s" "$TS" > "$SMALL_LOCAL"

--- a/pkg/client/api_keys.go
+++ b/pkg/client/api_keys.go
@@ -1,0 +1,131 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// TenantAPIKeySummary holds metadata returned by the tenant API key list API.
+type TenantAPIKeySummary struct {
+	KeyID     string     `json:"key_id"`
+	KeyName   string     `json:"key_name"`
+	Status    string     `json:"status"`
+	IssuedAt  time.Time  `json:"issued_at"`
+	RevokedAt *time.Time `json:"revoked_at,omitempty"`
+}
+
+// TenantAPIKey holds a tenant API key response that includes plaintext key material.
+type TenantAPIKey struct {
+	APIKey    string     `json:"api_key"`
+	KeyID     string     `json:"key_id"`
+	KeyName   string     `json:"key_name"`
+	Status    string     `json:"status"`
+	IssuedAt  time.Time  `json:"issued_at,omitempty"`
+	RevokedAt *time.Time `json:"revoked_at,omitempty"`
+}
+
+func (c *Client) tenantAPIKeysURL(path string) string {
+	if path == "" {
+		return c.baseURL + "/v1/tenants/keys"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return c.baseURL + "/v1/tenants/keys" + path
+}
+
+// ListTenantAPIKeys lists tenant API key metadata.
+func (c *Client) ListTenantAPIKeys(ctx context.Context) ([]TenantAPIKeySummary, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.tenantAPIKeysURL(""), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result struct {
+		Keys []TenantAPIKeySummary `json:"keys"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode tenant api key list response: %w", err)
+	}
+	if result.Keys == nil {
+		result.Keys = []TenantAPIKeySummary{}
+	}
+	return result.Keys, nil
+}
+
+// CreateTenantAPIKey creates a named tenant API key.
+func (c *Client) CreateTenantAPIKey(ctx context.Context, keyName string) (*TenantAPIKey, error) {
+	body, err := json.Marshal(map[string]string{"key_name": keyName})
+	if err != nil {
+		return nil, fmt.Errorf("marshal tenant api key create request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.tenantAPIKeysURL(""), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result TenantAPIKey
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode tenant api key create response: %w", err)
+	}
+	return &result, nil
+}
+
+// GetTenantAPIKey fetches a named tenant API key including plaintext key material.
+func (c *Client) GetTenantAPIKey(ctx context.Context, keyName string) (*TenantAPIKey, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.tenantAPIKeysURL("/"+url.PathEscape(keyName)), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result TenantAPIKey
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode tenant api key get response: %w", err)
+	}
+	return &result, nil
+}
+
+// DeleteTenantAPIKey revokes a named tenant API key.
+func (c *Client) DeleteTenantAPIKey(ctx context.Context, keyName string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.tenantAPIKeysURL("/"+url.PathEscape(keyName)), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return readError(resp)
+	}
+	return nil
+}

--- a/pkg/client/api_keys_test.go
+++ b/pkg/client/api_keys_test.go
@@ -1,0 +1,149 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestListTenantAPIKeysDecodesResponse(t *testing.T) {
+	t.Parallel()
+
+	issuedAt := time.Date(2026, time.May, 7, 8, 0, 0, 0, time.UTC)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/tenants/keys" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tenant-key" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{{
+				"key_id":    "k_default",
+				"key_name":  "default",
+				"status":    "active",
+				"issued_at": issuedAt.Format(time.RFC3339),
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tenant-key")
+	keys, err := c.ListTenantAPIKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListTenantAPIKeys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("len(keys) = %d, want 1", len(keys))
+	}
+	if keys[0].KeyName != "default" || keys[0].KeyID != "k_default" {
+		t.Fatalf("unexpected key: %+v", keys[0])
+	}
+}
+
+func TestCreateTenantAPIKeySendsPayloadAndDecodesResponse(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/tenants/keys" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tenant-key" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		var req map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		if req["key_name"] != "worker" {
+			t.Fatalf("key_name = %q, want worker", req["key_name"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"api_key":  "sk_worker",
+			"key_id":   "k_worker",
+			"key_name": "worker",
+			"status":   "active",
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tenant-key")
+	key, err := c.CreateTenantAPIKey(context.Background(), "worker")
+	if err != nil {
+		t.Fatalf("CreateTenantAPIKey: %v", err)
+	}
+	if key.APIKey != "sk_worker" || key.KeyName != "worker" || key.KeyID != "k_worker" {
+		t.Fatalf("unexpected key: %+v", key)
+	}
+}
+
+func TestGetTenantAPIKeyDecodesResponse(t *testing.T) {
+	t.Parallel()
+
+	issuedAt := time.Date(2026, time.May, 7, 8, 30, 0, 0, time.UTC)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/tenants/keys/worker" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"api_key":   "sk_worker",
+			"key_id":    "k_worker",
+			"key_name":  "worker",
+			"status":    "active",
+			"issued_at": issuedAt.Format(time.RFC3339),
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tenant-key")
+	key, err := c.GetTenantAPIKey(context.Background(), "worker")
+	if err != nil {
+		t.Fatalf("GetTenantAPIKey: %v", err)
+	}
+	if key.APIKey != "sk_worker" || !key.IssuedAt.Equal(issuedAt) {
+		t.Fatalf("unexpected key: %+v", key)
+	}
+}
+
+func TestDeleteTenantAPIKeyPropagatesStatusError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/v1/tenants/keys/worker" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"api key not found or already revoked"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tenant-key")
+	err := c.DeleteTenantAPIKey(context.Background(), "worker")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusNotFound {
+		t.Fatalf("statusErr = %#v", statusErr)
+	}
+}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -899,7 +899,7 @@ func (s *Store) GetAPIKeyByName(ctx context.Context, tenantID, keyName string) (
 func (s *Store) ListAPIKeysByTenant(ctx context.Context, tenantID string) (out []APIKey, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "list_api_keys_by_tenant", start, &err)
-	rows, err := s.db.QueryContext(ctx, `SELECT id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, issued_at,
+	rows, err := s.db.QueryContext(ctx, `SELECT id, tenant_id, key_name, token_version, status, issued_at,
 		revoked_at, created_at, updated_at
 		FROM tenant_api_keys
 		WHERE tenant_id = ?
@@ -911,7 +911,7 @@ func (s *Store) ListAPIKeysByTenant(ctx context.Context, tenantID string) (out [
 
 	out = make([]APIKey, 0)
 	for rows.Next() {
-		rec, err := scanAPIKeyRows(rows)
+		rec, err := scanAPIKeyMetadataRow(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -1151,6 +1151,29 @@ type apiKeyRowScanner interface {
 
 func scanAPIKeyRow(row apiKeyRowScanner) (*APIKey, error) {
 	return scanAPIKeyRows(row)
+}
+
+func scanAPIKeyMetadataRow(row apiKeyRowScanner) (*APIKey, error) {
+	var rec APIKey
+	var revokedAt sql.NullTime
+	if err := row.Scan(
+		&rec.ID,
+		&rec.TenantID,
+		&rec.KeyName,
+		&rec.TokenVersion,
+		&rec.Status,
+		&rec.IssuedAt,
+		&revokedAt,
+		&rec.CreatedAt,
+		&rec.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if revokedAt.Valid {
+		t := revokedAt.Time.UTC()
+		rec.RevokedAt = &t
+	}
+	return &rec, nil
 }
 
 func scanAPIKeyRows(row apiKeyRowScanner) (*APIKey, error) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -859,6 +859,70 @@ func (s *Store) InsertAPIKey(ctx context.Context, k *APIKey) (err error) {
 	return err
 }
 
+func (s *Store) RevokeAPIKeyByName(ctx context.Context, tenantID, keyName string, revokedAt time.Time) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "revoke_api_key_by_name", start, &err)
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_api_keys
+		SET status = ?, revoked_at = ?, updated_at = ?
+		WHERE tenant_id = ? AND key_name = ? AND status = ?`,
+		APIKeyRevoked, revokedAt.UTC(), revokedAt.UTC(), tenantID, keyName, APIKeyActive)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) GetAPIKeyByName(ctx context.Context, tenantID, keyName string) (out *APIKey, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "get_api_key_by_name", start, &err)
+	row := s.db.QueryRowContext(ctx, `SELECT id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, issued_at,
+		revoked_at, created_at, updated_at
+		FROM tenant_api_keys
+		WHERE tenant_id = ? AND key_name = ?`, tenantID, keyName)
+	rec, err := scanAPIKeyRow(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return rec, nil
+}
+
+func (s *Store) ListAPIKeysByTenant(ctx context.Context, tenantID string) (out []APIKey, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_api_keys_by_tenant", start, &err)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, issued_at,
+		revoked_at, created_at, updated_at
+		FROM tenant_api_keys
+		WHERE tenant_id = ?
+		ORDER BY created_at ASC, key_name ASC`, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out = make([]APIKey, 0)
+	for rows.Next() {
+		rec, err := scanAPIKeyRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *TenantWithAPIKey, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "resolve_api_key_hash", start, &err)
@@ -1079,6 +1143,39 @@ func nullStr(v string) any {
 		return nil
 	}
 	return v
+}
+
+type apiKeyRowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAPIKeyRow(row apiKeyRowScanner) (*APIKey, error) {
+	return scanAPIKeyRows(row)
+}
+
+func scanAPIKeyRows(row apiKeyRowScanner) (*APIKey, error) {
+	var rec APIKey
+	var revokedAt sql.NullTime
+	if err := row.Scan(
+		&rec.ID,
+		&rec.TenantID,
+		&rec.KeyName,
+		&rec.JWTCiphertext,
+		&rec.JWTHash,
+		&rec.TokenVersion,
+		&rec.Status,
+		&rec.IssuedAt,
+		&revokedAt,
+		&rec.CreatedAt,
+		&rec.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if revokedAt.Valid {
+		t := revokedAt.Time.UTC()
+		rec.RevokedAt = &t
+	}
+	return &rec, nil
 }
 
 func isDuplicateEntry(err error) bool {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -160,7 +160,7 @@ func TestRevokeAPIKeyByName(t *testing.T) {
 	if got.APIKey.Status != APIKeyRevoked {
 		t.Fatalf("key status = %s, want %s", got.APIKey.Status, APIKeyRevoked)
 	}
-	if got.APIKey.RevokedAt == nil || !got.APIKey.RevokedAt.Equal(revokedAt.Truncate(time.Millisecond)) {
+	if got.APIKey.RevokedAt == nil || !got.APIKey.RevokedAt.Equal(revokedAt.Round(time.Millisecond)) {
 		t.Fatalf("revoked_at = %v, want %v", got.APIKey.RevokedAt, revokedAt)
 	}
 

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -2,6 +2,7 @@ package meta
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -164,10 +165,10 @@ func TestRevokeAPIKeyByName(t *testing.T) {
 		t.Fatalf("revoked_at = %v, want %v", got.APIKey.RevokedAt, revokedAt)
 	}
 
-	if err := s.RevokeAPIKeyByName(context.Background(), "tenant-revoke-key", "worker", revokedAt.Add(time.Minute)); err != ErrNotFound {
+	if err := s.RevokeAPIKeyByName(context.Background(), "tenant-revoke-key", "worker", revokedAt.Add(time.Minute)); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("second revoke err = %v, want %v", err, ErrNotFound)
 	}
-	if err := s.RevokeAPIKeyByName(context.Background(), "tenant-revoke-key", "missing", revokedAt); err != ErrNotFound {
+	if err := s.RevokeAPIKeyByName(context.Background(), "tenant-revoke-key", "missing", revokedAt); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("missing revoke err = %v, want %v", err, ErrNotFound)
 	}
 }
@@ -233,6 +234,12 @@ func TestListAndGetAPIKeysByTenant(t *testing.T) {
 	if gotKeys[0].KeyName != "default" || gotKeys[1].KeyName != "worker" {
 		t.Fatalf("unexpected key order: %q, %q", gotKeys[0].KeyName, gotKeys[1].KeyName)
 	}
+	if len(gotKeys[0].JWTCiphertext) != 0 || gotKeys[0].JWTHash != "" {
+		t.Fatalf("list returned secret material for %q", gotKeys[0].KeyName)
+	}
+	if len(gotKeys[1].JWTCiphertext) != 0 || gotKeys[1].JWTHash != "" {
+		t.Fatalf("list returned secret material for %q", gotKeys[1].KeyName)
+	}
 
 	gotKey, err := s.GetAPIKeyByName(context.Background(), "tenant-list-keys", "worker")
 	if err != nil {
@@ -241,7 +248,10 @@ func TestListAndGetAPIKeysByTenant(t *testing.T) {
 	if gotKey.ID != "k-worker" || gotKey.KeyName != "worker" {
 		t.Fatalf("unexpected key: %#v", gotKey)
 	}
-	if _, err := s.GetAPIKeyByName(context.Background(), "tenant-list-keys", "missing"); err != ErrNotFound {
+	if len(gotKey.JWTCiphertext) == 0 || gotKey.JWTHash == "" {
+		t.Fatal("get did not return secret material")
+	}
+	if _, err := s.GetAPIKeyByName(context.Background(), "tenant-list-keys", "missing"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("missing key err = %v, want %v", err, ErrNotFound)
 	}
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -114,6 +114,138 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 	}
 }
 
+func TestRevokeAPIKeyByName(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertTenant(context.Background(), &Tenant{
+		ID:               "tenant-revoke-key",
+		Status:           TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_revoke_key_db",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertAPIKey(context.Background(), &APIKey{
+		ID:            "k-revoke",
+		TenantID:      "tenant-revoke-key",
+		KeyName:       "worker",
+		JWTCiphertext: []byte("jwt-cipher"),
+		JWTHash:       "hash-revoke",
+		TokenVersion:  1,
+		Status:        APIKeyActive,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	revokedAt := now.Add(time.Minute)
+	if err := s.RevokeAPIKeyByName(context.Background(), "tenant-revoke-key", "worker", revokedAt); err != nil {
+		t.Fatalf("RevokeAPIKeyByName: %v", err)
+	}
+
+	got, err := s.ResolveByAPIKeyHash(context.Background(), "hash-revoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.APIKey.Status != APIKeyRevoked {
+		t.Fatalf("key status = %s, want %s", got.APIKey.Status, APIKeyRevoked)
+	}
+	if got.APIKey.RevokedAt == nil || !got.APIKey.RevokedAt.Equal(revokedAt.Truncate(time.Millisecond)) {
+		t.Fatalf("revoked_at = %v, want %v", got.APIKey.RevokedAt, revokedAt)
+	}
+
+	if err := s.RevokeAPIKeyByName(context.Background(), "tenant-revoke-key", "worker", revokedAt.Add(time.Minute)); err != ErrNotFound {
+		t.Fatalf("second revoke err = %v, want %v", err, ErrNotFound)
+	}
+	if err := s.RevokeAPIKeyByName(context.Background(), "tenant-revoke-key", "missing", revokedAt); err != ErrNotFound {
+		t.Fatalf("missing revoke err = %v, want %v", err, ErrNotFound)
+	}
+}
+
+func TestListAndGetAPIKeysByTenant(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertTenant(context.Background(), &Tenant{
+		ID:               "tenant-list-keys",
+		Status:           TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_list_keys_db",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	keys := []*APIKey{
+		{
+			ID:            "k-default",
+			TenantID:      "tenant-list-keys",
+			KeyName:       "default",
+			JWTCiphertext: []byte("jwt-default"),
+			JWTHash:       "hash-default",
+			TokenVersion:  1,
+			Status:        APIKeyActive,
+			IssuedAt:      now,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		},
+		{
+			ID:            "k-worker",
+			TenantID:      "tenant-list-keys",
+			KeyName:       "worker",
+			JWTCiphertext: []byte("jwt-worker"),
+			JWTHash:       "hash-worker",
+			TokenVersion:  2,
+			Status:        APIKeyActive,
+			IssuedAt:      now.Add(time.Second),
+			CreatedAt:     now.Add(time.Second),
+			UpdatedAt:     now.Add(time.Second),
+		},
+	}
+	for _, key := range keys {
+		if err := s.InsertAPIKey(context.Background(), key); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	gotKeys, err := s.ListAPIKeysByTenant(context.Background(), "tenant-list-keys")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gotKeys) != 2 {
+		t.Fatalf("len(keys)=%d, want 2", len(gotKeys))
+	}
+	if gotKeys[0].KeyName != "default" || gotKeys[1].KeyName != "worker" {
+		t.Fatalf("unexpected key order: %q, %q", gotKeys[0].KeyName, gotKeys[1].KeyName)
+	}
+
+	gotKey, err := s.GetAPIKeyByName(context.Background(), "tenant-list-keys", "worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotKey.ID != "k-worker" || gotKey.KeyName != "worker" {
+		t.Fatalf("unexpected key: %#v", gotKey)
+	}
+	if _, err := s.GetAPIKeyByName(context.Background(), "tenant-list-keys", "missing"); err != ErrNotFound {
+		t.Fatalf("missing key err = %v, want %v", err, ErrNotFound)
+	}
+}
+
 func TestGetTenantReadsS3EncryptionPolicy(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC()

--- a/pkg/server/api_keys.go
+++ b/pkg/server/api_keys.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -94,7 +93,12 @@ func (s *Server) handleAPIKeyCreate(w http.ResponseWriter, r *http.Request, scop
 	var req struct {
 		KeyName string `json:"key_name"`
 	}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			errJSON(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		errJSON(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
@@ -143,6 +147,15 @@ func (s *Server) handleAPIKeyCreate(w http.ResponseWriter, r *http.Request, scop
 	})
 	if err != nil {
 		if errors.Is(err, meta.ErrDuplicate) {
+			existing, getErr := s.meta.GetAPIKeyByName(r.Context(), scope.TenantID, keyName)
+			if getErr == nil {
+				if existing.Status == meta.APIKeyRevoked {
+					errJSON(w, http.StatusConflict, "api key name has been revoked and cannot be reused")
+					return
+				}
+				errJSON(w, http.StatusConflict, "api key name already exists")
+				return
+			}
 			errJSON(w, http.StatusConflict, "api key conflict")
 			return
 		}

--- a/pkg/server/api_keys.go
+++ b/pkg/server/api_keys.go
@@ -1,0 +1,210 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
+)
+
+const defaultTenantAPIKeyName = "default"
+const tenantAPIKeysPath = "/v1/tenants/keys"
+
+func (s *Server) handleAPIKeys(w http.ResponseWriter, r *http.Request) {
+	if s.meta == nil || s.pool == nil || len(s.tokenSecret) == 0 {
+		errJSON(w, http.StatusNotFound, "api key management not enabled")
+		return
+	}
+	scope := ScopeFromContext(r.Context())
+	if scope == nil {
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	if scope.APIKeyName != defaultTenantAPIKeyName {
+		errJSON(w, http.StatusForbidden, "only default API key may manage API keys")
+		return
+	}
+
+	sub := strings.TrimPrefix(r.URL.Path, tenantAPIKeysPath)
+	if sub == "" || sub == "/" {
+		if r.Method == http.MethodGet {
+			s.handleAPIKeyList(w, r, scope)
+			return
+		}
+		if r.Method == http.MethodPost {
+			s.handleAPIKeyCreate(w, r, scope)
+			return
+		}
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	keyName, err := url.PathUnescape(strings.TrimPrefix(sub, "/"))
+	if err != nil || keyName == "" || strings.Contains(keyName, "/") {
+		errJSON(w, http.StatusBadRequest, "invalid key name")
+		return
+	}
+	if r.Method == http.MethodGet {
+		s.handleAPIKeyGet(w, r, scope, keyName)
+		return
+	}
+	if r.Method == http.MethodDelete {
+		s.handleAPIKeyDelete(w, r, scope, keyName)
+		return
+	}
+	errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+}
+
+func (s *Server) handleAPIKeyList(w http.ResponseWriter, r *http.Request, scope *TenantScope) {
+	keys, err := s.meta.ListAPIKeysByTenant(r.Context(), scope.TenantID)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to list api keys")
+		return
+	}
+	type apiKeySummary struct {
+		KeyID     string     `json:"key_id"`
+		KeyName   string     `json:"key_name"`
+		Status    string     `json:"status"`
+		IssuedAt  time.Time  `json:"issued_at"`
+		RevokedAt *time.Time `json:"revoked_at,omitempty"`
+	}
+	items := make([]apiKeySummary, 0, len(keys))
+	for _, key := range keys {
+		items = append(items, apiKeySummary{
+			KeyID:     key.ID,
+			KeyName:   key.KeyName,
+			Status:    string(key.Status),
+			IssuedAt:  key.IssuedAt,
+			RevokedAt: key.RevokedAt,
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"keys": items})
+}
+
+func (s *Server) handleAPIKeyCreate(w http.ResponseWriter, r *http.Request, scope *TenantScope) {
+	var req struct {
+		KeyName string `json:"key_name"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		errJSON(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	keyName := strings.TrimSpace(req.KeyName)
+	if keyName == "" {
+		errJSON(w, http.StatusBadRequest, "key_name is required")
+		return
+	}
+	if len(keyName) > 64 {
+		errJSON(w, http.StatusBadRequest, "key_name must be <= 64 characters")
+		return
+	}
+	if keyName == defaultTenantAPIKeyName {
+		errJSON(w, http.StatusBadRequest, "key_name default is reserved")
+		return
+	}
+
+	tokenVersion := managedAPITokenVersion()
+	apiToken, err := token.IssueToken(s.tokenSecret, scope.TenantID, tokenVersion)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to issue token")
+		return
+	}
+	cipherToken, err := s.pool.Encrypt(r.Context(), []byte(apiToken))
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to encrypt api key")
+		return
+	}
+	now := time.Now().UTC()
+	apiKeyID := token.NewID()
+	err = s.meta.InsertAPIKey(r.Context(), &meta.APIKey{
+		ID:            apiKeyID,
+		TenantID:      scope.TenantID,
+		KeyName:       keyName,
+		JWTCiphertext: cipherToken,
+		JWTHash:       token.HashToken(apiToken),
+		TokenVersion:  tokenVersion,
+		Status:        meta.APIKeyActive,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+	if err != nil {
+		if errors.Is(err, meta.ErrDuplicate) {
+			errJSON(w, http.StatusConflict, "api key name already exists")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to persist api key")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"api_key":  apiToken,
+		"key_id":   apiKeyID,
+		"key_name": keyName,
+		"status":   string(meta.APIKeyActive),
+	})
+}
+
+func (s *Server) handleAPIKeyDelete(w http.ResponseWriter, r *http.Request, scope *TenantScope, keyName string) {
+	if keyName == defaultTenantAPIKeyName {
+		errJSON(w, http.StatusBadRequest, "default API key cannot be deleted")
+		return
+	}
+	err := s.meta.RevokeAPIKeyByName(r.Context(), scope.TenantID, keyName, time.Now().UTC())
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "api key not found or already revoked")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to revoke api key")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"key_name": keyName,
+	})
+}
+
+func (s *Server) handleAPIKeyGet(w http.ResponseWriter, r *http.Request, scope *TenantScope, keyName string) {
+	key, err := s.meta.GetAPIKeyByName(r.Context(), scope.TenantID, keyName)
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "api key not found")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to get api key")
+		return
+	}
+	plain, err := s.pool.Decrypt(r.Context(), key.JWTCiphertext)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to decrypt api key")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"api_key":    string(plain),
+		"key_id":     key.ID,
+		"key_name":   key.KeyName,
+		"status":     string(key.Status),
+		"issued_at":  key.IssuedAt,
+		"revoked_at": key.RevokedAt,
+	})
+}
+
+func managedAPITokenVersion() int {
+	version := int(time.Now().UnixNano() % 2147483647)
+	if version <= 1 {
+		return 2
+	}
+	return version
+}

--- a/pkg/server/api_keys.go
+++ b/pkg/server/api_keys.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"io"
@@ -109,6 +111,10 @@ func (s *Server) handleAPIKeyCreate(w http.ResponseWriter, r *http.Request, scop
 		errJSON(w, http.StatusBadRequest, "key_name default is reserved")
 		return
 	}
+	if strings.Contains(keyName, "/") {
+		errJSON(w, http.StatusBadRequest, "key_name must not contain /")
+		return
+	}
 
 	tokenVersion := managedAPITokenVersion()
 	apiToken, err := token.IssueToken(s.tokenSecret, scope.TenantID, tokenVersion)
@@ -137,13 +143,14 @@ func (s *Server) handleAPIKeyCreate(w http.ResponseWriter, r *http.Request, scop
 	})
 	if err != nil {
 		if errors.Is(err, meta.ErrDuplicate) {
-			errJSON(w, http.StatusConflict, "api key name already exists")
+			errJSON(w, http.StatusConflict, "api key conflict")
 			return
 		}
 		errJSON(w, http.StatusInternalServerError, "failed to persist api key")
 		return
 	}
 
+	setNoStoreHeaders(w)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(map[string]any{
@@ -190,6 +197,7 @@ func (s *Server) handleAPIKeyGet(w http.ResponseWriter, r *http.Request, scope *
 		errJSON(w, http.StatusInternalServerError, "failed to decrypt api key")
 		return
 	}
+	setNoStoreHeaders(w)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"api_key":    string(plain),
@@ -201,10 +209,16 @@ func (s *Server) handleAPIKeyGet(w http.ResponseWriter, r *http.Request, scope *
 	})
 }
 
+func setNoStoreHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+}
+
 func managedAPITokenVersion() int {
-	version := int(time.Now().UnixNano() % 2147483647)
-	if version <= 1 {
-		return 2
+	var seed [4]byte
+	if _, err := rand.Read(seed[:]); err == nil {
+		const maxManagedTokenVersion = uint32(1<<31 - 2)
+		return int(binary.BigEndian.Uint32(seed[:])%maxManagedTokenVersion) + 2
 	}
-	return version
+	return int(time.Now().UnixNano()%2147483645) + 2
 }

--- a/pkg/server/api_keys_test.go
+++ b/pkg/server/api_keys_test.go
@@ -1,0 +1,258 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
+)
+
+func createManagedAPIKey(t *testing.T, baseURL, ownerToken, keyName string) string {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"key_name": keyName})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+tenantAPIKeysPath, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create api key status=%d", resp.StatusCode)
+	}
+	var out map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out["key_name"] != keyName {
+		t.Fatalf("key_name=%q, want %q", out["key_name"], keyName)
+	}
+	if out["api_key"] == "" {
+		t.Fatal("empty api_key")
+	}
+	return out["api_key"]
+}
+
+func doJSONRequest(t *testing.T, method, url, bearer string, body io.Reader) (*http.Response, map[string]any) {
+	t.Helper()
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	return resp, out
+}
+
+func TestDefaultAPIKeyCanCreateAndDeleteOtherKeys(t *testing.T) {
+	srv, ownerToken, cleanup := newAuthServer(t)
+	defer cleanup()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	workerToken := createManagedAPIKey(t, ts.URL, ownerToken, "worker")
+
+	statusReq, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusReq.Header.Set("Authorization", "Bearer "+workerToken)
+	statusResp, err := http.DefaultClient.Do(statusReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = statusResp.Body.Close() }()
+	if statusResp.StatusCode != http.StatusOK {
+		t.Fatalf("worker status=%d, want %d", statusResp.StatusCode, http.StatusOK)
+	}
+
+	deleteReq, err := http.NewRequest(http.MethodDelete, ts.URL+tenantAPIKeysPath+"/worker", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deleteReq.Header.Set("Authorization", "Bearer "+ownerToken)
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("delete status=%d, want %d", deleteResp.StatusCode, http.StatusOK)
+	}
+
+	revokedReq, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revokedReq.Header.Set("Authorization", "Bearer "+workerToken)
+	revokedResp, err := http.DefaultClient.Do(revokedReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = revokedResp.Body.Close() }()
+	if revokedResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("revoked key status=%d, want %d", revokedResp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestDefaultAPIKeyCanListAndGetKeys(t *testing.T) {
+	srv, ownerToken, cleanup := newAuthServer(t)
+	defer cleanup()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	workerToken := createManagedAPIKey(t, ts.URL, ownerToken, "worker")
+
+	listResp, listBody := doJSONRequest(t, http.MethodGet, ts.URL+tenantAPIKeysPath, ownerToken, nil)
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("list status=%d, want %d", listResp.StatusCode, http.StatusOK)
+	}
+	rawKeys, ok := listBody["keys"].([]any)
+	if !ok {
+		t.Fatalf("keys type=%T, want []any", listBody["keys"])
+	}
+	if len(rawKeys) != 2 {
+		t.Fatalf("len(keys)=%d, want 2", len(rawKeys))
+	}
+	names := make([]string, 0, len(rawKeys))
+	for _, raw := range rawKeys {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("item type=%T, want map[string]any", raw)
+		}
+		name, _ := item["key_name"].(string)
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if names[0] != "default" || names[1] != "worker" {
+		t.Fatalf("unexpected key names: %#v", names)
+	}
+
+	getResp, getBody := doJSONRequest(t, http.MethodGet, ts.URL+tenantAPIKeysPath+"/worker", ownerToken, nil)
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("get status=%d, want %d", getResp.StatusCode, http.StatusOK)
+	}
+	if got := getBody["key_name"]; got != "worker" {
+		t.Fatalf("key_name=%v, want worker", got)
+	}
+	if got := getBody["api_key"]; got != workerToken {
+		t.Fatalf("api_key=%v, want worker token", got)
+	}
+}
+
+func TestNonDefaultAPIKeyCannotManageAPIKeys(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	workerToken := createManagedAPIKey(t, ts.URL, rt.token, "worker")
+	body := []byte(`{"key_name":"worker-2"}`)
+	createReq, err := http.NewRequest(http.MethodPost, ts.URL+tenantAPIKeysPath, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	createReq.Header.Set("Authorization", "Bearer "+workerToken)
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("create status=%d, want %d", createResp.StatusCode, http.StatusForbidden)
+	}
+
+	deleteReq, err := http.NewRequest(http.MethodDelete, ts.URL+tenantAPIKeysPath+"/default", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deleteReq.Header.Set("Authorization", "Bearer "+workerToken)
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("delete status=%d, want %d", deleteResp.StatusCode, http.StatusForbidden)
+	}
+
+	listResp, _ := doJSONRequest(t, http.MethodGet, ts.URL+tenantAPIKeysPath, workerToken, nil)
+	if listResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("list status=%d, want %d", listResp.StatusCode, http.StatusForbidden)
+	}
+
+	getResp, _ := doJSONRequest(t, http.MethodGet, ts.URL+tenantAPIKeysPath+"/default", workerToken, nil)
+	if getResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("get status=%d, want %d", getResp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestDefaultAPIKeyCannotDeleteItself(t *testing.T) {
+	srv, ownerToken, cleanup := newAuthServer(t)
+	defer cleanup()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+tenantAPIKeysPath+"/default", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestCreatedAPIKeyIsPersistedForTenant(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	workerToken := createManagedAPIKey(t, ts.URL, rt.token, "worker")
+	resolved, err := rt.meta.ResolveByAPIKeyHash(context.Background(), token.HashToken(workerToken))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.APIKey.KeyName != "worker" {
+		t.Fatalf("key_name=%q, want worker", resolved.APIKey.KeyName)
+	}
+	if resolved.APIKey.Status != meta.APIKeyActive {
+		t.Fatalf("status=%s, want %s", resolved.APIKey.Status, meta.APIKeyActive)
+	}
+}

--- a/pkg/server/api_keys_test.go
+++ b/pkg/server/api_keys_test.go
@@ -159,11 +159,48 @@ func TestDefaultAPIKeyCanListAndGetKeys(t *testing.T) {
 	if getResp.StatusCode != http.StatusOK {
 		t.Fatalf("get status=%d, want %d", getResp.StatusCode, http.StatusOK)
 	}
+	if cacheControl := getResp.Header.Get("Cache-Control"); cacheControl != "no-store" {
+		t.Fatalf("Cache-Control=%q, want no-store", cacheControl)
+	}
+	if pragma := getResp.Header.Get("Pragma"); pragma != "no-cache" {
+		t.Fatalf("Pragma=%q, want no-cache", pragma)
+	}
 	if got := getBody["key_name"]; got != "worker" {
 		t.Fatalf("key_name=%v, want worker", got)
 	}
 	if got := getBody["api_key"]; got != workerToken {
 		t.Fatalf("api_key=%v, want worker token", got)
+	}
+}
+
+func TestCreateAPIKeyRejectsSlashAndDisablesCaching(t *testing.T) {
+	srv, ownerToken, cleanup := newAuthServer(t)
+	defer cleanup()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	body := bytes.NewReader([]byte(`{"key_name":"worker/blue"}`))
+	badResp, badBody := doJSONRequest(t, http.MethodPost, ts.URL+tenantAPIKeysPath, ownerToken, body)
+	if badResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("bad create status=%d, want %d", badResp.StatusCode, http.StatusBadRequest)
+	}
+	if got := badBody["error"]; got != "key_name must not contain /" {
+		t.Fatalf("error=%v, want key_name must not contain /", got)
+	}
+
+	goodBody := bytes.NewReader([]byte(`{"key_name":"worker-blue"}`))
+	goodResp, goodOut := doJSONRequest(t, http.MethodPost, ts.URL+tenantAPIKeysPath, ownerToken, goodBody)
+	if goodResp.StatusCode != http.StatusCreated {
+		t.Fatalf("good create status=%d, want %d", goodResp.StatusCode, http.StatusCreated)
+	}
+	if cacheControl := goodResp.Header.Get("Cache-Control"); cacheControl != "no-store" {
+		t.Fatalf("Cache-Control=%q, want no-store", cacheControl)
+	}
+	if pragma := goodResp.Header.Get("Pragma"); pragma != "no-cache" {
+		t.Fatalf("Pragma=%q, want no-cache", pragma)
+	}
+	if got := goodOut["key_name"]; got != "worker-blue" {
+		t.Fatalf("key_name=%v, want worker-blue", got)
 	}
 }
 

--- a/pkg/server/api_keys_test.go
+++ b/pkg/server/api_keys_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/mem9-ai/dat9/pkg/meta"
@@ -201,6 +202,48 @@ func TestCreateAPIKeyRejectsSlashAndDisablesCaching(t *testing.T) {
 	}
 	if got := goodOut["key_name"]; got != "worker-blue" {
 		t.Fatalf("key_name=%v, want worker-blue", got)
+	}
+}
+
+func TestCreateAPIKeyRejectsOversizeBody(t *testing.T) {
+	srv, ownerToken, cleanup := newAuthServer(t)
+	defer cleanup()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	largePadding := strings.Repeat("x", 1<<20)
+	body := bytes.NewReader([]byte(`{"key_name":"worker-big","padding":"` + largePadding + `"}`))
+	resp, out := doJSONRequest(t, http.MethodPost, ts.URL+tenantAPIKeysPath, ownerToken, body)
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize create status=%d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+	if got := out["error"]; got != "request body too large" {
+		t.Fatalf("error=%v, want request body too large", got)
+	}
+}
+
+func TestRevokedAPIKeyNameCannotBeReused(t *testing.T) {
+	srv, ownerToken, cleanup := newAuthServer(t)
+	defer cleanup()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	createManagedAPIKey(t, ts.URL, ownerToken, "worker")
+	deleteResp, deleteBody := doJSONRequest(t, http.MethodDelete, ts.URL+tenantAPIKeysPath+"/worker", ownerToken, nil)
+	if deleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("delete status=%d, want %d", deleteResp.StatusCode, http.StatusOK)
+	}
+	if got := deleteBody["status"]; got != "ok" {
+		t.Fatalf("delete status body=%v, want ok", got)
+	}
+
+	recreateBody := bytes.NewReader([]byte(`{"key_name":"worker"}`))
+	recreateResp, recreateOut := doJSONRequest(t, http.MethodPost, ts.URL+tenantAPIKeysPath, ownerToken, recreateBody)
+	if recreateResp.StatusCode != http.StatusConflict {
+		t.Fatalf("recreate status=%d, want %d", recreateResp.StatusCode, http.StatusConflict)
+	}
+	if got := recreateOut["error"]; got != "api key name has been revoked and cannot be reused" {
+		t.Fatalf("error=%v, want revoked-name conflict", got)
 	}
 }
 

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -25,6 +25,7 @@ const tenantScopeKey scopeKey = iota
 type TenantScope struct {
 	TenantID     string
 	APIKeyID     string
+	APIKeyName   string
 	TokenVersion int
 	Provider     string
 	Backend      *backend.Dat9Backend
@@ -198,7 +199,7 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			zap.Float64("total_ms", authPhaseMs(authStart)),
 		)
 
-		scope := &TenantScope{TenantID: resolved.Tenant.ID, APIKeyID: resolved.APIKey.ID, TokenVersion: resolved.APIKey.TokenVersion, Provider: resolved.Tenant.Provider, Backend: b}
+		scope := &TenantScope{TenantID: resolved.Tenant.ID, APIKeyID: resolved.APIKey.ID, APIKeyName: resolved.APIKey.KeyName, TokenVersion: resolved.APIKey.TokenVersion, Provider: resolved.Tenant.Provider, Backend: b}
 		next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))
 	})
 }

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -232,6 +232,8 @@ func requestRoute(path string) string {
 		return "/v1/provision"
 	case path == "/v1/status":
 		return "/v1/status"
+	case path == tenantAPIKeysPath || strings.HasPrefix(path, tenantAPIKeysPath+"/"):
+		return tenantAPIKeysPath + "/*"
 	case path == "/v1/sql":
 		return "/v1/sql"
 	case path == "/v1/events":

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -16,6 +16,8 @@ func TestRequestRoute(t *testing.T) {
 		{path: "/metrics", want: "/metrics"},
 		{path: "/v1/provision", want: "/v1/provision"},
 		{path: "/v1/status", want: "/v1/status"},
+		{path: "/v1/tenants/keys", want: "/v1/tenants/keys/*"},
+		{path: "/v1/tenants/keys/worker", want: "/v1/tenants/keys/*"},
 		{path: "/v1/sql", want: "/v1/sql"},
 		{path: "/v1/events", want: "/v1/events"},
 		{path: "/v1/fs/doc.txt", want: "/v1/fs/*"},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -130,6 +130,8 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v1/uploads", business)
 	mux.Handle("/v1/uploads/", business)
 	mux.Handle("/v2/uploads/", business)
+	mux.Handle(tenantAPIKeysPath, business)
+	mux.Handle(tenantAPIKeysPath+"/", business)
 	mux.Handle("/v1/sql", business)
 	mux.Handle("/v1/events", business)
 	// Vault management API goes through tenant auth.
@@ -277,7 +279,7 @@ func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled 
 
 func injectFallbackBackend(b *backend.Dat9Backend, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		scope := &TenantScope{TenantID: "local", APIKeyID: "local", TokenVersion: 1, Backend: b}
+		scope := &TenantScope{TenantID: "local", APIKeyID: "local", APIKeyName: defaultTenantAPIKeyName, TokenVersion: 1, Backend: b}
 		next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))
 	})
 }
@@ -303,6 +305,8 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 		s.handleUploadAction(w, r)
 	case strings.HasPrefix(r.URL.Path, "/v2/uploads/"):
 		s.handleV2Uploads(w, r)
+	case r.URL.Path == tenantAPIKeysPath, strings.HasPrefix(r.URL.Path, tenantAPIKeysPath+"/"):
+		s.handleAPIKeys(w, r)
 	case r.URL.Path == "/v1/sql":
 		s.handleSQL(w, r)
 	case r.URL.Path == "/v1/events":


### PR DESCRIPTION
## Summary
Add tenant API key management endpoints under /v1/tenants/keys.

This PR introduces tenant-scoped key management so the default/root API key can manage additional tenant API keys.

## Changes
- add /v1/tenants/keys endpoints for:
  - GET list keys
  - POST create key
  - GET key by name
  - DELETE key by name
- restrict key management to the default key only
- carry API key name through tenant auth scope
- add meta store helpers for get/list/revoke by key name
- add request route instrumentation for the new endpoint
- add focused meta/server tests for create, list, get, delete, and authorization

## Notes
- default key is reserved and cannot be deleted
- non-default keys receive distinct token versions so newly issued keys do not collide with the provisioned default key hash
- list returns metadata only; get returns the plaintext key for the named key

## Validation
- go test ./pkg/meta ./pkg/server -run 'Test(ListAndGetAPIKeysByTenant|DefaultAPIKeyCanCreateAndDeleteOtherKeys|DefaultAPIKeyCanListAndGetKeys|NonDefaultAPIKeyCannotManageAPIKeys|DefaultAPIKeyCannotDeleteItself|CreatedAPIKeyIsPersistedForTenant)$'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant API key management endpoints: create, list, retrieve, revoke (tenant-scoped).
  * Token responses disable caching; key name validation (non-empty, ≤64 chars, no '/'); reserved default name is protected.
  * Revocation by name updates status and records revoke timestamp; repeated or missing revocations return not-found.

* **Tests**
  * Expanded tests for creation, validation (name chars, oversized bodies), caching headers, persistence, and revoke behavior.

* **Instrumentation**
  * Tenant-keys paths normalized to a single canonical route for metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->