### PR TITLE
fix(fuse): wait for durable umount shutdown

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -1,17 +1,20 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
+	"syscall"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
 	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
 	"github.com/mem9-ai/dat9/pkg/mountpath"
+	"github.com/mem9-ai/dat9/pkg/mountstate"
 	drive9webdav "github.com/mem9-ai/dat9/pkg/webdav"
 )
 
@@ -264,19 +267,115 @@ func normalizeLookupRetryCount(count int) int {
 
 // UmountCmd handles the "drive9 umount" command.
 func UmountCmd(args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("usage: drive9 umount <mountpoint>")
-	}
-	mountPoint := args[0]
+	return runUmount(args, defaultUmountDeps())
+}
 
-	argv, err := umountArgv(runtime.GOOS, exec.LookPath, mountPoint)
+type umountDeps struct {
+	goos      string
+	lookPath  func(string) (string, error)
+	run       func([]string) error
+	readPID   func(string) (int, string, error)
+	pidAlive  func(int) bool
+	now       func() time.Time
+	sleep     func(time.Duration)
+	printErrf func(string, ...any)
+}
+
+func defaultUmountDeps() umountDeps {
+	return umountDeps{
+		goos:     runtime.GOOS,
+		lookPath: exec.LookPath,
+		run: func(argv []string) error {
+			cmd := exec.Command(argv[0], argv[1:]...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			return cmd.Run()
+		},
+		readPID:   mountstate.ReadPID,
+		pidAlive:  processAlive,
+		now:       time.Now,
+		sleep:     time.Sleep,
+		printErrf: func(format string, args ...any) { fmt.Fprintf(os.Stderr, format, args...) },
+	}
+}
+
+func runUmount(args []string, deps umountDeps) error {
+	fs := flag.NewFlagSet("umount", flag.ContinueOnError)
+	waitTimeout := fs.Duration("timeout", 60*time.Second, "time to wait for the drive9 mount process to exit after unmount; 0 disables waiting")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: drive9 umount [--timeout duration] <mountpoint>\n\nflags:\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return fmt.Errorf("usage: drive9 umount [--timeout duration] <mountpoint>")
+	}
+	mountPoint := fs.Arg(0)
+
+	argv, err := umountArgv(deps.goos, deps.lookPath, mountPoint)
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(argv[0], argv[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if err := deps.run(argv); err != nil {
+		return err
+	}
+	if *waitTimeout == 0 {
+		return nil
+	}
+	pid, path, err := deps.readPID(mountPoint)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if err := waitForPIDExit(pid, *waitTimeout, deps); err != nil {
+		return fmt.Errorf("%w (pid file: %s)", err, path)
+	}
+	return nil
+}
+
+func waitForPIDExit(pid int, timeout time.Duration, deps umountDeps) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid mount process pid %d", pid)
+	}
+	deadline := deps.now().Add(timeout)
+	for {
+		if !deps.pidAlive(pid) {
+			return nil
+		}
+		if !deps.now().Before(deadline) {
+			if deps.printErrf != nil {
+				deps.printErrf("drive9 umount: mount process pid %d still running after %s\n", pid, timeout)
+			}
+			return fmt.Errorf("drive9 umount: mount process pid %d still running after %s", pid, timeout)
+		}
+		deps.sleep(100 * time.Millisecond)
+	}
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+		return false
+	}
+	if errors.Is(err, syscall.EPERM) {
+		return true
+	}
+	return false
 }
 
 // resolveMountCredentials selects the (server, apiKey, token) triple that a

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -77,6 +78,120 @@ func TestUmountArgvNoBinary(t *testing.T) {
 	_, err := umountArgv("linux", fakeLookPath(nil), "/mnt/drive9")
 	if err == nil {
 		t.Fatal("expected error when no unmount binaries are available")
+	}
+}
+
+func TestRunUmountWaitsForMountProcessExit(t *testing.T) {
+	now := time.Unix(100, 0)
+	runCalls := 0
+	aliveCalls := 0
+	deps := umountDeps{
+		goos:     "linux",
+		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
+		run: func(argv []string) error {
+			runCalls++
+			want := []string{"fusermount3", "-u", "/mnt/drive9"}
+			if !reflect.DeepEqual(argv, want) {
+				t.Fatalf("argv = %v, want %v", argv, want)
+			}
+			return nil
+		},
+		readPID: func(mountPoint string) (int, string, error) {
+			if mountPoint != "/mnt/drive9" {
+				t.Fatalf("mountPoint = %q", mountPoint)
+			}
+			return 1234, "/tmp/drive9.pid", nil
+		},
+		pidAlive: func(pid int) bool {
+			if pid != 1234 {
+				t.Fatalf("pid = %d", pid)
+			}
+			aliveCalls++
+			return aliveCalls < 3
+		},
+		now:       func() time.Time { return now },
+		sleep:     func(d time.Duration) { now = now.Add(d) },
+		printErrf: func(string, ...any) {},
+	}
+
+	if err := runUmount([]string{"/mnt/drive9"}, deps); err != nil {
+		t.Fatalf("runUmount: %v", err)
+	}
+	if runCalls != 1 {
+		t.Fatalf("runCalls = %d, want 1", runCalls)
+	}
+	if aliveCalls != 3 {
+		t.Fatalf("aliveCalls = %d, want 3", aliveCalls)
+	}
+}
+
+func TestRunUmountReturnsTimeoutWhenMountProcessStillAlive(t *testing.T) {
+	now := time.Unix(100, 0)
+	deps := umountDeps{
+		goos:     "linux",
+		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
+		run:      func([]string) error { return nil },
+		readPID:  func(string) (int, string, error) { return 1234, "/tmp/drive9.pid", nil },
+		pidAlive: func(int) bool { return true },
+		now:      func() time.Time { return now },
+		sleep:    func(d time.Duration) { now = now.Add(d) },
+		printErrf: func(format string, args ...any) {
+			if !strings.Contains(format, "still running") {
+				t.Fatalf("printErrf format = %q", format)
+			}
+		},
+	}
+
+	err := runUmount([]string{"--timeout", "250ms", "/mnt/drive9"}, deps)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "still running") {
+		t.Fatalf("error = %v, want still running", err)
+	}
+	if !strings.Contains(err.Error(), "/tmp/drive9.pid") {
+		t.Fatalf("error = %v, want pid file path", err)
+	}
+}
+
+func TestRunUmountDoesNotBlockOnStalePID(t *testing.T) {
+	aliveCalls := 0
+	deps := umountDeps{
+		goos:     "linux",
+		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
+		run:      func([]string) error { return nil },
+		readPID:  func(string) (int, string, error) { return 1234, "/tmp/drive9.pid", nil },
+		pidAlive: func(int) bool {
+			aliveCalls++
+			return false
+		},
+		now:       time.Now,
+		sleep:     func(time.Duration) { t.Fatal("sleep should not be called for stale pid") },
+		printErrf: func(string, ...any) {},
+	}
+
+	if err := runUmount([]string{"/mnt/drive9"}, deps); err != nil {
+		t.Fatalf("runUmount: %v", err)
+	}
+	if aliveCalls != 1 {
+		t.Fatalf("aliveCalls = %d, want 1", aliveCalls)
+	}
+}
+
+func TestRunUmountNoPIDFileReturnsSuccess(t *testing.T) {
+	deps := umountDeps{
+		goos:      "linux",
+		lookPath:  fakeLookPath(map[string]bool{"fusermount3": true}),
+		run:       func([]string) error { return nil },
+		readPID:   func(string) (int, string, error) { return 0, "/tmp/drive9.pid", os.ErrNotExist },
+		pidAlive:  func(int) bool { t.Fatal("pidAlive should not be called without pid file"); return false },
+		now:       time.Now,
+		sleep:     func(time.Duration) {},
+		printErrf: func(string, ...any) {},
+	}
+
+	if err := runUmount([]string{"/mnt/drive9"}, deps); err != nil {
+		t.Fatalf("runUmount: %v", err)
 	}
 }
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -10,12 +10,14 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"syscall"
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/mem9-ai/dat9/pkg/client"
 	"github.com/mem9-ai/dat9/pkg/mountpath"
+	"github.com/mem9-ai/dat9/pkg/mountstate"
 )
 
 // MountOptions configures the FUSE mount.
@@ -308,6 +310,20 @@ func Mount(opts *MountOptions) error {
 	if err := server.WaitMount(); err != nil {
 		return fmt.Errorf("fuse wait mount: %w", err)
 	}
+	pidFile, err := mountstate.WritePID(opts.MountPoint, os.Getpid())
+	if err != nil {
+		sseWatcher.Stop()
+		dat9fs.FlushAll()
+		_ = server.Unmount()
+		return fmt.Errorf("write mount pid file: %w", err)
+	}
+	defer func() {
+		if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "dat9: remove mount pid file %s: %v\n", pidFile, err)
+		}
+	}()
+
+	shutdown := newMountShutdown(sseWatcher.Stop, dat9fs.FlushAll)
 
 	// Signal handling for graceful shutdown
 	sigCh := make(chan os.Signal, 1)
@@ -324,8 +340,7 @@ func Mount(opts *MountOptions) error {
 			os.Exit(1)
 		}()
 
-		sseWatcher.Stop()
-		dat9fs.FlushAll()
+		shutdown()
 
 		// Retry unmount up to 5 times — EBUSY is transient (Spotlight, Finder).
 		const maxRetries = 5
@@ -347,8 +362,18 @@ func Mount(opts *MountOptions) error {
 
 	fmt.Fprintf(os.Stderr, "dat9: mounted on %s (server: %s, actor: %s)\n", opts.MountPoint, opts.Server, actorID)
 	server.Wait()
-	sseWatcher.Stop()
+	shutdown()
 	return nil
+}
+
+func newMountShutdown(stopWatcher func(), flushAll func()) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			stopWatcher()
+			flushAll()
+		})
+	}
 }
 
 // forceUnmount shells out to OS-specific tools to force-unmount a FUSE mount.

--- a/pkg/fuse/mount_shutdown_test.go
+++ b/pkg/fuse/mount_shutdown_test.go
@@ -1,0 +1,43 @@
+package fuse
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestMountShutdownRunsOnce(t *testing.T) {
+	var mu sync.Mutex
+	stopCount := 0
+	flushCount := 0
+	shutdown := newMountShutdown(
+		func() {
+			mu.Lock()
+			stopCount++
+			mu.Unlock()
+		},
+		func() {
+			mu.Lock()
+			flushCount++
+			mu.Unlock()
+		},
+	)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			shutdown()
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if stopCount != 1 {
+		t.Fatalf("stopCount = %d, want 1", stopCount)
+	}
+	if flushCount != 1 {
+		t.Fatalf("flushCount = %d, want 1", flushCount)
+	}
+}

--- a/pkg/mountstate/pid.go
+++ b/pkg/mountstate/pid.go
@@ -1,0 +1,55 @@
+package mountstate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func PIDFilePath(mountPoint string) string {
+	canonical := canonicalMountPoint(mountPoint)
+	sum := sha256.Sum256([]byte(canonical))
+	return filepath.Join(os.TempDir(), "drive9-mount-"+hex.EncodeToString(sum[:8])+".pid")
+}
+
+func canonicalMountPoint(mountPoint string) string {
+	canonical := filepath.Clean(mountPoint)
+	if abs, err := filepath.Abs(canonical); err == nil {
+		canonical = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(canonical); err == nil {
+		canonical = resolved
+	}
+	return canonical
+}
+
+func WritePID(mountPoint string, pid int) (string, error) {
+	if pid <= 0 {
+		return "", fmt.Errorf("invalid pid %d", pid)
+	}
+	path := PIDFilePath(mountPoint)
+	if err := os.WriteFile(path, []byte(strconv.Itoa(pid)+"\n"), 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func ReadPID(mountPoint string) (int, string, error) {
+	path := PIDFilePath(mountPoint)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, path, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, path, fmt.Errorf("read pid file %s: %w", path, err)
+	}
+	if pid <= 0 {
+		return 0, path, fmt.Errorf("read pid file %s: invalid pid %d", path, pid)
+	}
+	return pid, path, nil
+}

--- a/pkg/mountstate/pid_test.go
+++ b/pkg/mountstate/pid_test.go
@@ -1,0 +1,76 @@
+package mountstate
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPIDFilePathCanonicalizesMountPoint(t *testing.T) {
+	dir := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldwd); err != nil {
+			t.Fatalf("restore wd: %v", err)
+		}
+	}()
+	if err := os.Mkdir(filepath.Join(dir, "mnt"), 0o755); err != nil {
+		t.Fatalf("mkdir mountpoint: %v", err)
+	}
+
+	relPath := PIDFilePath("mnt/../mnt")
+	absPath := PIDFilePath(filepath.Join(dir, "mnt"))
+	if relPath != absPath {
+		t.Fatalf("PIDFilePath relative = %q, absolute = %q", relPath, absPath)
+	}
+	if !strings.HasPrefix(relPath, os.TempDir()) {
+		t.Fatalf("PIDFilePath = %q, want temp-dir path", relPath)
+	}
+}
+
+func TestWriteReadPID(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "mnt")
+	pid := 12345
+
+	path, err := WritePID(mountPoint, pid)
+	if err != nil {
+		t.Fatalf("WritePID: %v", err)
+	}
+	defer func() { _ = os.Remove(path) }()
+
+	got, gotPath, err := ReadPID(mountPoint)
+	if err != nil {
+		t.Fatalf("ReadPID: %v", err)
+	}
+	if got != pid {
+		t.Fatalf("ReadPID pid = %d, want %d", got, pid)
+	}
+	if gotPath != path {
+		t.Fatalf("ReadPID path = %q, want %q", gotPath, path)
+	}
+}
+
+func TestReadPIDRejectsInvalidFile(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "mnt")
+	path := PIDFilePath(mountPoint)
+	if err := os.WriteFile(path, []byte("not-a-pid\n"), 0o644); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+	defer func() { _ = os.Remove(path) }()
+
+	_, _, err := ReadPID(mountPoint)
+	if err == nil {
+		t.Fatal("expected error for invalid pid file")
+	}
+	if strings.Contains(err.Error(), strconv.Itoa(os.Getpid())) {
+		t.Fatalf("ReadPID error = %v, unexpectedly used current pid", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add mountpoint-scoped PID files for running `drive9 mount` processes.
- Make signal shutdown and external unmount (`server.Wait()` return) share a `sync.Once` shutdown path that stops SSE and runs `dat9fs.FlushAll()`.
- Make `drive9 umount` wait for the corresponding mount process to exit after the OS unmount command, with `--timeout` defaulting to 60s and non-zero error on timeout.
- Cover PID file canonicalization/read/write, umount wait/timeout/stale PID handling, and shutdown idempotency.

## Validation

- `/usr/local/go/bin/go test ./pkg/mountstate -count=1`
- `/usr/local/go/bin/go test ./cmd/drive9/cli -run 'TestRunUmount|TestUmountArgv' -count=1`
- `/usr/local/go/bin/go test ./pkg/fuse -count=1 -timeout=120s`
- `/usr/local/go/bin/go test -c ./cmd/drive9/cli ./pkg/fuse ./pkg/mountstate`
- `git diff --check`

Note: full `/usr/local/go/bin/go test ./cmd/drive9/cli -count=1 -timeout=30s` currently times out in pre-existing WebDAV test `TestFsMountCmd_SingleArgDefaultsToRootRemote`; the new umount tests pass in isolation and the package compile gate passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented improved unmount workflow with configurable timeouts and enhanced error handling
  * Added automatic PID file tracking for active mounts

* **Bug Fixes**
  * Enhanced graceful shutdown handling to properly clean up resources on interrupts and multi-stage Ctrl+C scenarios

* **Tests**
  * Added comprehensive test coverage for unmount operations, shutdown behavior, and mount lifecycle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->