### PR TITLE
test: add FUSE release gate

### DIFF
--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -135,10 +135,9 @@ jobs:
         continue-on-error: true
         run: bash e2e/cli-smoke-test.sh
 
-      - name: Run FUSE smoke
+      - name: Run FUSE release gate
         id: fuse-smoke
-        continue-on-error: true
-        run: bash e2e/fuse-smoke-test.sh
+        run: bash e2e/fuse-release-gate.sh
 
       - name: Publish local e2e summary
         if: always()
@@ -151,7 +150,7 @@ jobs:
             echo "| API smoke | ${{ steps.api-smoke.outcome || 'skipped' }} |"
             echo "| Existing-key smoke | ${{ steps.existing-key-smoke.outcome || 'skipped' }} |"
             echo "| CLI smoke | ${{ steps.cli-smoke.outcome || 'skipped' }} |"
-            echo "| FUSE smoke | ${{ steps.fuse-smoke.outcome || 'skipped' }} |"
+            echo "| FUSE release gate | ${{ steps.fuse-smoke.outcome || 'skipped' }} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dump TiDB playground logs
@@ -201,6 +200,6 @@ jobs:
           check_required "API smoke" "${{ steps.api-smoke.outcome }}"
           check_required "Existing-key smoke" "${{ steps.existing-key-smoke.outcome }}"
           check_required "CLI smoke" "${{ steps.cli-smoke.outcome }}"
-          check_required "FUSE smoke" "${{ steps.fuse-smoke.outcome }}"
+          check_required "FUSE release gate" "${{ steps.fuse-smoke.outcome }}"
 
           exit "$failed"

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -174,6 +174,15 @@ use the same value as `DRIVE9_API_KEY` here.
 
 Notes:
 - The script prechecks root `ls /` reachability before mount behavior checks.
+- Optional release-gate knobs add small-repo git clone/status/log checks,
+  durable `drive9 umount --timeout` remount visibility checks, and mount-log audit.
+
+### `fuse-release-gate.sh`
+
+1. Runs `fuse-smoke-test.sh` with `FUSE_STRICT_PREREQS=1`
+2. Enables small-repo git clone/status/log coverage
+3. Enables durable `umount --timeout` followed by remount visibility checks
+4. Enables mount-log audit and dumps mount logs on failure
 
 ### `smoke-all.sh`
 
@@ -219,6 +228,13 @@ Notes:
 | `FUSE_MOUNT_ROOT` | `/tmp` | `fuse-smoke-test.sh` |
 | `CLI_MAX_RETRIES` | `8` | `fuse-smoke-test.sh` |
 | `CLI_RETRY_SLEEP_S` | `2` | `fuse-smoke-test.sh` |
+| `FUSE_STRICT_PREREQS` | `0` (`1` in release gate) | `fuse-smoke-test.sh` |
+| `FUSE_UMOUNT_TIMEOUT` | `60s` | `fuse-smoke-test.sh` |
+| `RUN_FUSE_GIT_CLONE` | `0` (`1` in release gate) | `fuse-smoke-test.sh` |
+| `FUSE_GIT_CLONE_URL` | `https://github.com/octocat/Hello-World.git` | `fuse-smoke-test.sh` |
+| `FUSE_GIT_CLONE_TIMEOUT_S` | `180` | `fuse-smoke-test.sh` |
+| `RUN_FUSE_UMOUNT_DURABLE` | `0` (`1` in release gate) | `fuse-smoke-test.sh` |
+| `RUN_FUSE_LOG_AUDIT` | `0` (`1` in release gate) | `fuse-smoke-test.sh` |
 
 ## Conventions
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -17,6 +17,7 @@ including local single-tenant validation via `drive9-server-local`.
 | `api-smoke-test-existing-key.sh` | Existing API key status/list checks |
 | `cli-smoke-test.sh` | End-to-end CLI workflow including `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
 | `fuse-smoke-test.sh` | FUSE mount lifecycle, file/dir/rename/stat semantics, cross-channel consistency, read-only and error-path checks |
+| `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, and mount-log audit |
 | `smoke-all.sh` | Runs API + CLI + FUSE smoke scripts in sequence with aggregated pass/fail |
 
 ## Run
@@ -50,8 +51,12 @@ CLI_SOURCE=official bash e2e/cli-smoke-test.sh
 
 bash e2e/fuse-smoke-test.sh
 
+# Strict FUSE release gate used by CI
+bash e2e/fuse-release-gate.sh
+
 # Use official released drive9 CLI for FUSE smoke
 CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
+CLI_SOURCE=official bash e2e/fuse-release-gate.sh
 
 bash e2e/smoke-all.sh
 ```
@@ -123,6 +128,9 @@ bash e2e/cli-smoke-test.sh
 # FUSE smoke using the repo build.
 bash e2e/fuse-smoke-test.sh
 
+# Strict FUSE release gate using the repo build.
+bash e2e/fuse-release-gate.sh
+
 # Run API + CLI + FUSE in sequence.
 bash e2e/smoke-all.sh
 ```
@@ -135,6 +143,7 @@ use the same value as `DRIVE9_API_KEY` here.
 ```bash
 CLI_SOURCE=official bash e2e/cli-smoke-test.sh
 CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
+CLI_SOURCE=official bash e2e/fuse-release-gate.sh
 ```
 
 #### `drive9-server-local` notes
@@ -168,9 +177,11 @@ CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
 - API retry knobs for throttling are `REQUEST_MAX_RETRIES` and `REQUEST_RETRY_SLEEP_S`.
 - CLI retry knobs for throttling are `CLI_MAX_RETRIES` and `CLI_RETRY_SLEEP_S`.
 - FUSE mount readiness knobs are `MOUNT_READY_TIMEOUT_S`, `MOUNT_READY_INTERVAL_S`, and `FUSE_MOUNT_ROOT`.
+- FUSE release-gate knobs are `FUSE_STRICT_PREREQS`, `RUN_FUSE_GIT_CLONE`, `FUSE_GIT_CLONE_URL`, `FUSE_GIT_CLONE_TIMEOUT_S`, `RUN_FUSE_UMOUNT_DURABLE`, `FUSE_UMOUNT_TIMEOUT`, and `RUN_FUSE_LOG_AUDIT`.
 - CLI source knobs are `CLI_SOURCE` (`build` or `official`), `CLI_RELEASE_BASE_URL`, and optional `CLI_RELEASE_VERSION`.
 - API upload-limit boundary check is enabled by default via `RUN_UPLOAD_LIMIT_BOUNDARY=1`.
 - `UPLOAD_LIMIT_BYTES` controls the boundary value checked by API e2e (default `10737418240`).
 - CLI upload-limit boundary check is enabled by default via `RUN_CLI_UPLOAD_LIMIT_BOUNDARY=1`.
 - `CLI_UPLOAD_LIMIT_BYTES` controls the boundary value checked by CLI e2e (default `10737418240`).
-- `fuse-smoke-test.sh` will `SKIP` when host prerequisites are missing (for example no `/dev/fuse`) or when the server does not support mount precheck `ls /`.
+- `fuse-smoke-test.sh` will `SKIP` when host prerequisites are missing (for example no `/dev/fuse`) unless `FUSE_STRICT_PREREQS=1`.
+- `fuse-release-gate.sh` is the strict CI/release entry point and enables git clone/status/log, durable `umount --timeout` remount checks, and mount-log audit.

--- a/e2e/fuse-release-gate.sh
+++ b/e2e/fuse-release-gate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Strict FUSE release gate. Unlike the general smoke script, this fails when
+# host FUSE prerequisites are unavailable and enables git/remount/log checks.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export FUSE_STRICT_PREREQS="${FUSE_STRICT_PREREQS:-1}"
+export RUN_FUSE_GIT_CLONE="${RUN_FUSE_GIT_CLONE:-1}"
+export RUN_FUSE_UMOUNT_DURABLE="${RUN_FUSE_UMOUNT_DURABLE:-1}"
+export RUN_FUSE_LOG_AUDIT="${RUN_FUSE_LOG_AUDIT:-1}"
+export FUSE_GIT_CLONE_URL="${FUSE_GIT_CLONE_URL:-https://github.com/octocat/Hello-World.git}"
+export FUSE_GIT_CLONE_TIMEOUT_S="${FUSE_GIT_CLONE_TIMEOUT_S:-180}"
+export FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-60s}"
+
+exec bash "$SCRIPT_DIR/fuse-smoke-test.sh"

--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # drive9 FUSE smoke test against a live deployment.
+# shellcheck disable=SC2317,SC2016
 
 set -euo pipefail
 
@@ -19,6 +20,14 @@ CLI_RELEASE_BASE_URL="${CLI_RELEASE_BASE_URL:-https://drive9.ai/releases}"
 CLI_RELEASE_VERSION="${CLI_RELEASE_VERSION:-}"
 CLI_MAX_RETRIES="${CLI_MAX_RETRIES:-8}"
 CLI_RETRY_SLEEP_S="${CLI_RETRY_SLEEP_S:-2}"
+FUSE_STRICT_PREREQS="${FUSE_STRICT_PREREQS:-0}"
+FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-60s}"
+RUN_FUSE_GIT_CLONE="${RUN_FUSE_GIT_CLONE:-0}"
+RUN_FUSE_UMOUNT_DURABLE="${RUN_FUSE_UMOUNT_DURABLE:-0}"
+RUN_FUSE_LOG_AUDIT="${RUN_FUSE_LOG_AUDIT:-0}"
+FUSE_GIT_CLONE_URL="${FUSE_GIT_CLONE_URL:-https://github.com/octocat/Hello-World.git}"
+FUSE_GIT_CLONE_TIMEOUT_S="${FUSE_GIT_CLONE_TIMEOUT_S:-180}"
+FUSE_LOG_AUDIT_PATTERN="${FUSE_LOG_AUDIT_PATTERN:-panic|fatal error|Resource temporarily unavailable}"
 
 PASS=0
 FAIL=0
@@ -122,6 +131,14 @@ prepare_cli_binary() {
 skip() {
   echo "SKIP $*"
   exit 0
+}
+
+skip_or_fail() {
+  if [ "$FUSE_STRICT_PREREQS" = "1" ]; then
+    echo "FAIL $*" >&2
+    exit 1
+  fi
+  skip "$@"
 }
 
 is_mounted() {
@@ -414,11 +431,13 @@ PY
 
 start_mount() {
   local mode="$1"
-  : >"$MOUNT_LOG"
+  {
+    echo "=== drive9 mount start mode=$mode time=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
+  } >>"$MOUNT_LOG"
   if [ "$mode" = "ro" ]; then
-    drive9 mount --read-only "$MOUNT_POINT" >"$MOUNT_LOG" 2>&1 &
+    drive9 mount --read-only "$MOUNT_POINT" >>"$MOUNT_LOG" 2>&1 &
   else
-    drive9 mount "$MOUNT_POINT" >"$MOUNT_LOG" 2>&1 &
+    drive9 mount "$MOUNT_POINT" >>"$MOUNT_LOG" 2>&1 &
   fi
   MOUNT_PID="$!"
 
@@ -435,7 +454,7 @@ start_mount() {
 stop_mount() {
   set +e
   if is_mounted "$MOUNT_POINT"; then
-    drive9 umount "$MOUNT_POINT" >/dev/null 2>&1 || true
+    drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT" >/dev/null 2>&1 || true
     wait_mount_state unmounted >/dev/null 2>&1 || true
   fi
   if [ -n "${MOUNT_PID:-}" ] && kill -0 "$MOUNT_PID" >/dev/null 2>&1; then
@@ -446,9 +465,52 @@ stop_mount() {
   set -e
 }
 
+unmount_mount() {
+  if is_mounted "$MOUNT_POINT"; then
+    if ! drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT"; then
+      return 1
+    fi
+  fi
+  if ! wait_mount_state unmounted; then
+    return 1
+  fi
+  if [ -n "${MOUNT_PID:-}" ]; then
+    set +e
+    wait "$MOUNT_PID" >/dev/null 2>&1
+    MOUNT_PID=""
+    set -e
+  fi
+  return 0
+}
+
+dump_mount_log() {
+  if [ -n "${MOUNT_LOG:-}" ] && [ -f "$MOUNT_LOG" ]; then
+    echo "=== drive9 mount log: $MOUNT_LOG ==="
+    cat "$MOUNT_LOG"
+  fi
+}
+
+audit_mount_log() {
+  if [ ! -f "$MOUNT_LOG" ]; then
+    echo "mount log missing: $MOUNT_LOG" >&2
+    return 1
+  fi
+  if grep -Eina "$FUSE_LOG_AUDIT_PATTERN" "$MOUNT_LOG"; then
+    echo "mount log contains release-gate failure pattern" >&2
+    return 1
+  fi
+  return 0
+}
+
 echo "=== drive9 FUSE smoke test ==="
 echo "BASE=$BASE"
 echo "CLI_SOURCE=$CLI_SOURCE"
+echo "FUSE_STRICT_PREREQS=$FUSE_STRICT_PREREQS"
+echo "RUN_FUSE_GIT_CLONE=$RUN_FUSE_GIT_CLONE"
+echo "FUSE_GIT_CLONE_TIMEOUT_S=$FUSE_GIT_CLONE_TIMEOUT_S"
+echo "RUN_FUSE_UMOUNT_DURABLE=$RUN_FUSE_UMOUNT_DURABLE"
+echo "RUN_FUSE_LOG_AUDIT=$RUN_FUSE_LOG_AUDIT"
+echo "FUSE_LOG_AUDIT_PATTERN=$FUSE_LOG_AUDIT_PATTERN"
 
 check_cmd "jq is available" bash -c 'command -v jq >/dev/null'
 if [ "$CLI_SOURCE" = "build" ]; then
@@ -458,17 +520,23 @@ else
 fi
 check_cmd "python3 is available" bash -c 'command -v python3 >/dev/null'
 check_cmd "git is available" bash -c 'command -v git >/dev/null'
+if [ "$FUSE_STRICT_PREREQS" = "1" ] && [ "$RUN_FUSE_GIT_CLONE" = "1" ]; then
+  if ! command -v timeout >/dev/null 2>&1; then
+    skip_or_fail "timeout is required for strict FUSE git clone timeout"
+  fi
+  check_eq "timeout is available" "true" "true"
+fi
 
 if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
-  skip "unsupported OS for this smoke script"
+  skip_or_fail "unsupported OS for this smoke script"
 fi
 
 if [ "$(uname -s)" = "Linux" ]; then
   if ! command -v fusermount >/dev/null 2>&1 && ! command -v fusermount3 >/dev/null 2>&1; then
-    skip "fusermount/fusermount3 is required for Linux FUSE unmount"
+    skip_or_fail "fusermount/fusermount3 is required for Linux FUSE unmount"
   fi
   if [ ! -e /dev/fuse ]; then
-    skip "/dev/fuse not available"
+    skip_or_fail "/dev/fuse not available"
   fi
 fi
 
@@ -583,21 +651,35 @@ LARGE_MOUNT="$MOUNT_POINT/$LARGE_REL"
 GIT_PROBE_REL="${ROOT_REL}/git-config-probe"
 GIT_PROBE_MOUNT="$MOUNT_POINT/$GIT_PROBE_REL"
 GIT_PROBE_ORIGIN="https://github.com/mem9-ai/drive9.git"
+GIT_CLONE_REL="${ROOT_REL}/hello-world"
+GIT_CLONE_MOUNT="$MOUNT_POINT/$GIT_CLONE_REL"
+DURABLE_REL="${ROOT_REL}/umount-durable.txt"
+DURABLE_REMOTE="/${DURABLE_REL}"
+DURABLE_MOUNT="$MOUNT_POINT/$DURABLE_REL"
 RO_SEED_REL="${ROOT_REL}/ro-seed.txt"
 RO_SEED_REMOTE="/${RO_SEED_REL}"
 RO_SEED_MOUNT="$MOUNT_POINT/$RO_SEED_REL"
 RO_WRITE_MOUNT="$MOUNT_POINT/${ROOT_REL}/ro-write.txt"
 
 mkdir -p "$MOUNT_POINT"
+: >"$MOUNT_LOG"
 printf "seed-%s" "$TS" > "$SEED_LOCAL"
 
 MOUNT_PID=""
 cleanup() {
   stop_mount
   rm -f "$SEED_LOCAL" "$LARGE_DOWNLOADED" "$CLI_BIN"
-  rm -rf "$MOUNT_POINT" || true
+  rm -rf "${MOUNT_POINT:?}" || true
 }
-trap cleanup EXIT
+on_exit() {
+  local rc=$?
+  if [ "$rc" -ne 0 ] || [ "${FAIL:-0}" -ne 0 ]; then
+    dump_mount_log
+  fi
+  cleanup
+  exit "$rc"
+}
+trap on_exit EXIT
 
 echo "[4] mount rw"
 if start_mount rw; then
@@ -753,6 +835,29 @@ PY
   check_eq "git config remote origin is readable" "$git_origin_rc" "0"
   check_eq "git config remote origin survives lockfile reuse" "$git_origin" "$GIT_PROBE_ORIGIN"
 
+  if [ "$RUN_FUSE_GIT_CLONE" = "1" ]; then
+    echo "[8.2] git clone small repo"
+    rm -rf "$GIT_CLONE_MOUNT"
+    git_clone_ok=true
+    date -u '+git clone start: %Y-%m-%dT%H:%M:%SZ'
+    if command -v timeout >/dev/null 2>&1; then
+      if ! GIT_PROGRESS_DELAY=0 timeout "$FUSE_GIT_CLONE_TIMEOUT_S" git clone --progress --depth 1 "$FUSE_GIT_CLONE_URL" "$GIT_CLONE_MOUNT"; then
+        git_clone_ok=false
+      fi
+    elif ! GIT_PROGRESS_DELAY=0 git clone --progress --depth 1 "$FUSE_GIT_CLONE_URL" "$GIT_CLONE_MOUNT"; then
+      git_clone_ok=false
+    fi
+    date -u '+git clone done:  %Y-%m-%dT%H:%M:%SZ'
+    check_eq "git clone small repo succeeds" "$git_clone_ok" "true"
+    if [ "$git_clone_ok" = "true" ]; then
+      git_status=$(git -C "$GIT_CLONE_MOUNT" status --short)
+      check_eq "git status clean after clone" "$git_status" ""
+      check_cmd "git log reads latest commit" git -C "$GIT_CLONE_MOUNT" log --oneline -1
+      check_cmd "git clone directory visible via remote list" wait_remote_ls_has_name "$ROOT_REMOTE" "hello-world"
+      check_cmd "git config lockfile absent after clone" test ! -e "$GIT_CLONE_MOUNT/.git/config.lock"
+    fi
+  fi
+
   echo "[9] cross-channel consistency"
   if [ "$rename_dir_ready" = "true" ]; then
     drive9_retry fs cp "$SEED_LOCAL" ":$CLI_TO_MOUNT_REMOTE" >/dev/null
@@ -806,8 +911,39 @@ PY
 
   check_cmd_fail "rm missing file fails" rm "$MOUNT_POINT/${ROOT_REL}/missing.txt"
 
-  echo "[12] cleanup writable tree"
-  rm -rf "$MOUNT_POINT/$ROOT_REL"
+  if [ "$RUN_FUSE_UMOUNT_DURABLE" = "1" ]; then
+    echo "[12] umount durable remount"
+    printf "durable-%s" "$TS" > "$DURABLE_MOUNT"
+    if unmount_mount; then
+      check_eq "rw mount unmounted after durable write" "true" "true"
+    else
+      check_eq "rw mount unmounted after durable write" "false" "true"
+      stop_mount
+    fi
+    if start_mount rw; then
+      check_eq "rw mount remounted after durable write" "true" "true"
+    else
+      check_eq "rw mount remounted after durable write" "false" "true"
+    fi
+    if is_mounted "$MOUNT_POINT"; then
+      if wait_path_exists "$DURABLE_MOUNT"; then
+        check_eq "durable file visible after remount" "true" "true"
+        durable_mounted=$(cat "$DURABLE_MOUNT")
+        durable_remote=$(drive9_retry fs cat "$DURABLE_REMOTE")
+        check_eq "durable file content survives remount" "$durable_mounted" "durable-${TS}"
+        check_eq "durable file remote content survives umount" "$durable_remote" "durable-${TS}"
+      else
+        check_eq "durable file visible after remount" "false" "true"
+      fi
+      if [ "$RUN_FUSE_GIT_CLONE" = "1" ]; then
+        check_cmd "git clone directory survives remount" test -d "$GIT_CLONE_MOUNT/.git"
+        check_cmd "git log works after remount" git -C "$GIT_CLONE_MOUNT" log --oneline -1
+      fi
+    fi
+  fi
+
+  echo "[12.1] cleanup writable tree"
+  rm -rf "${MOUNT_POINT:?}/${ROOT_REL:?}"
   check_cmd "remote root removed from ls after mounted rm -rf" wait_remote_ls_missing_name "/" "$ROOT_REL"
 
   echo "[13] remount read-only semantics"
@@ -834,10 +970,20 @@ PY
     check_cmd_fail "delete fails on read-only mount" rm "$RO_SEED_MOUNT"
   fi
 
-    echo "[14] unmount"
+  echo "[14] unmount"
+  if unmount_mount; then
+    check_eq "final mount unmounted" "true" "true"
+  else
+    check_eq "final mount unmounted" "false" "true"
     stop_mount
-    check_cmd "final mount unmounted" wait_mount_state unmounted
   fi
+  # End of the writable-alpha branch opened after the nested mkdir checks.
+  fi
+fi # End of the mounted-rw branch.
+
+if [ "$RUN_FUSE_LOG_AUDIT" = "1" ]; then
+  echo "[15] mount log audit"
+  check_cmd "mount log has no release-gate failure patterns" audit_mount_log
 fi
 
 echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- add strict FUSE release gate wrapper that hard-fails missing FUSE prerequisites
- extend FUSE smoke with optional git clone/status/log, durable umount/remount, and mount-log audit checks
- wire local-e2e CI to run the FUSE release gate without continue-on-error

## Validation
- bash -n e2e/fuse-smoke-test.sh e2e/fuse-release-gate.sh e2e/smoke-all.sh
- git diff --check
- shellcheck not installed on this host
- live FUSE gate not run locally on this Darwin host