### PR TITLE
feat: add drive9 doctor fuse

### DIFF
--- a/cmd/drive9/cli/doctor.go
+++ b/cmd/drive9/cli/doctor.go
@@ -1,0 +1,432 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type doctorStatus string
+
+const (
+	doctorPass doctorStatus = "PASS"
+	doctorFail doctorStatus = "FAIL"
+)
+
+type doctorCheck struct {
+	name   string
+	status doctorStatus
+	detail string
+	fix    string
+}
+
+type doctorFailure struct {
+	failed int
+}
+
+func (e doctorFailure) Error() string {
+	if e.failed == 1 {
+		return "doctor fuse found 1 failing check"
+	}
+	return fmt.Sprintf("doctor fuse found %d failing checks", e.failed)
+}
+
+func (e doctorFailure) ExitCode() int { return 1 }
+
+type doctorDeps struct {
+	goos               string
+	goarch             string
+	stdout             io.Writer
+	lookupPath         func(string) (string, error)
+	stat               func(string) (os.FileInfo, error)
+	readFile           func(string) ([]byte, error)
+	mkdirAll           func(string, os.FileMode) error
+	writeFile          func(string, []byte, os.FileMode) error
+	remove             func(string) error
+	access             func(string, uint32) error
+	currentUser        func() (*user.User, error)
+	getgroups          func() ([]int, error)
+	commandOutput      func(context.Context, string, ...string) ([]byte, error)
+	resolveCredentials func() ResolvedCredentials
+	httpGet            func(context.Context, string, string) (int, error)
+	isMountpoint       func(string) (bool, error)
+}
+
+func defaultDoctorDeps() doctorDeps {
+	return doctorDeps{
+		goos:        runtime.GOOS,
+		goarch:      runtime.GOARCH,
+		stdout:      os.Stdout,
+		lookupPath:  exec.LookPath,
+		stat:        os.Stat,
+		readFile:    os.ReadFile,
+		mkdirAll:    os.MkdirAll,
+		writeFile:   os.WriteFile,
+		remove:      os.Remove,
+		access:      syscall.Access,
+		currentUser: user.Current,
+		getgroups:   os.Getgroups,
+		commandOutput: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return exec.CommandContext(ctx, name, args...).CombinedOutput()
+		},
+		resolveCredentials: ResolveCredentials,
+		httpGet:            doctorHTTPGet,
+		isMountpoint:       isMountpoint,
+	}
+}
+
+// Doctor handles the `drive9 doctor` command.
+func Doctor(args []string) error {
+	return runDoctor(args, defaultDoctorDeps())
+}
+
+func runDoctor(args []string, deps doctorDeps) error {
+	if deps.stdout == nil {
+		deps.stdout = io.Discard
+	}
+	if len(args) == 0 {
+		return errors.New(doctorUsage())
+	}
+	switch args[0] {
+	case "fuse":
+		return runDoctorFuse(args[1:], deps)
+	case "-h", "-help", "--help", "help":
+		_, _ = fmt.Fprint(deps.stdout, doctorUsage())
+		return nil
+	default:
+		return fmt.Errorf("unknown doctor command %q\n%s", args[0], doctorUsage())
+	}
+}
+
+func doctorUsage() string {
+	return `usage: drive9 doctor <fuse>
+
+commands:
+  fuse    diagnose local FUSE prerequisites for drive9 mount
+`
+}
+
+func runDoctorFuse(args []string, deps doctorDeps) error {
+	if deps.stdout == nil {
+		deps.stdout = io.Discard
+	}
+
+	fs := flag.NewFlagSet("doctor fuse", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	mountpoint := fs.String("mountpoint", "/mnt/drive9", "mountpoint path to inspect")
+	cacheDir := fs.String("cache-dir", defaultDoctorCacheDir(), "cache directory to inspect")
+	server := fs.String("server", "", "drive9 server URL to check")
+	timeout := fs.Duration("timeout", 3*time.Second, "server connectivity timeout")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("usage: drive9 doctor fuse [--mountpoint path] [--cache-dir path] [--server url] [--timeout duration]")
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("usage: drive9 doctor fuse [--mountpoint path] [--cache-dir path] [--server url] [--timeout duration]")
+	}
+	if *timeout <= 0 {
+		return fmt.Errorf("doctor fuse: --timeout must be > 0")
+	}
+
+	creds := deps.resolveCredentials()
+	if strings.TrimSpace(*server) != "" {
+		creds.Server = strings.TrimSpace(*server)
+		creds.ServerSource = "flag:--server"
+	}
+
+	checks := []doctorCheck{
+		doctorOSKernelCheck(context.Background(), deps),
+		doctorEnvironmentCheck(deps),
+		doctorCurrentUserCheck(deps),
+		doctorFuseDeviceCheck(deps),
+		doctorFuseBinaryCheck(deps),
+		doctorUnmountHelperCheck(deps, *mountpoint),
+		doctorFuseConfCheck(deps),
+		doctorMountpointCheck(deps, *mountpoint),
+		doctorCacheDirCheck(deps, *cacheDir),
+		doctorCredentialsCheck(creds),
+		doctorServerCheck(context.Background(), deps, creds, *timeout),
+	}
+
+	_, _ = fmt.Fprintln(deps.stdout, "drive9 doctor fuse")
+	failures := 0
+	for _, check := range checks {
+		_, _ = fmt.Fprintf(deps.stdout, "%s %s: %s\n", check.status, check.name, check.detail)
+		if check.status == doctorFail {
+			failures++
+			if strings.TrimSpace(check.fix) != "" {
+				_, _ = fmt.Fprintf(deps.stdout, "  fix: %s\n", check.fix)
+			}
+		}
+	}
+	if failures > 0 {
+		return doctorFailure{failed: failures}
+	}
+	return nil
+}
+
+func defaultDoctorCacheDir() string {
+	if dir, err := os.UserCacheDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "drive9")
+	}
+	return filepath.Join(os.TempDir(), "drive9-cache")
+}
+
+func doctorOSKernelCheck(ctx context.Context, deps doctorDeps) doctorCheck {
+	detail := deps.goos + "/" + deps.goarch
+	if deps.commandOutput != nil {
+		if out, err := deps.commandOutput(ctx, "uname", "-a"); err == nil {
+			if s := strings.TrimSpace(string(out)); s != "" {
+				detail += " " + s
+			}
+		}
+	}
+	return doctorCheck{name: "os/kernel", status: doctorPass, detail: detail}
+}
+
+func doctorEnvironmentCheck(deps doctorDeps) doctorCheck {
+	var detected []string
+	if deps.stat != nil {
+		if _, err := deps.stat("/.dockerenv"); err == nil {
+			detected = append(detected, "docker")
+		}
+		if _, err := deps.stat("/run/.containerenv"); err == nil {
+			detected = append(detected, "container")
+		}
+	}
+	if deps.readFile != nil {
+		if b, err := deps.readFile("/proc/1/cgroup"); err == nil {
+			s := strings.ToLower(string(b))
+			for _, marker := range []string{"docker", "kubepods", "containerd"} {
+				if strings.Contains(s, marker) {
+					detected = appendIfMissing(detected, marker)
+				}
+			}
+		}
+	}
+	for _, key := range []string{"E2B_SANDBOX_ID", "E2B_API_KEY"} {
+		if os.Getenv(key) != "" {
+			detected = appendIfMissing(detected, "e2b")
+		}
+	}
+	if len(detected) == 0 {
+		return doctorCheck{name: "environment", status: doctorPass, detail: "no container or E2B marker detected"}
+	}
+	return doctorCheck{name: "environment", status: doctorPass, detail: strings.Join(detected, ", ") + " detected"}
+}
+
+func doctorCurrentUserCheck(deps doctorDeps) doctorCheck {
+	if deps.currentUser == nil {
+		return doctorCheck{name: "current user", status: doctorPass, detail: "not inspected"}
+	}
+	u, err := deps.currentUser()
+	if err != nil {
+		return doctorCheck{name: "current user", status: doctorFail, detail: err.Error(), fix: "ensure the current user exists in passwd/NSS"}
+	}
+	detail := u.Username
+	if u.Uid != "" {
+		detail += " uid=" + u.Uid
+	}
+	if deps.getgroups != nil {
+		if groups, err := deps.getgroups(); err == nil {
+			detail += " groups=" + strconv.Itoa(len(groups))
+		}
+	}
+	return doctorCheck{name: "current user", status: doctorPass, detail: detail}
+}
+
+func doctorFuseDeviceCheck(deps doctorDeps) doctorCheck {
+	if deps.goos != "linux" {
+		return doctorCheck{name: "/dev/fuse", status: doctorPass, detail: "not required on " + deps.goos}
+	}
+	info, err := deps.stat("/dev/fuse")
+	if err != nil {
+		return doctorCheck{name: "/dev/fuse", status: doctorFail, detail: err.Error(), fix: "run in an environment with /dev/fuse exposed, or enable FUSE device access for the container/sandbox"}
+	}
+	if info.Mode()&os.ModeCharDevice == 0 {
+		return doctorCheck{name: "/dev/fuse", status: doctorFail, detail: "exists but is not a character device", fix: "recreate /dev/fuse using the host FUSE device"}
+	}
+	if deps.access != nil {
+		if err := deps.access("/dev/fuse", 0x6); err != nil {
+			return doctorCheck{name: "/dev/fuse", status: doctorFail, detail: "current user cannot read/write /dev/fuse: " + err.Error(), fix: "add the user to the fuse group, adjust /dev/fuse permissions, or run the sandbox with FUSE privileges"}
+		}
+	}
+	return doctorCheck{name: "/dev/fuse", status: doctorPass, detail: "character device is present and accessible"}
+}
+
+func doctorFuseBinaryCheck(deps doctorDeps) doctorCheck {
+	switch deps.goos {
+	case "linux":
+		for _, name := range []string{"fusermount3", "fusermount"} {
+			if path, err := deps.lookupPath(name); err == nil {
+				return doctorCheck{name: "fusermount", status: doctorPass, detail: name + " at " + path}
+			}
+		}
+		return doctorCheck{name: "fusermount", status: doctorFail, detail: "fusermount3 not found in PATH", fix: "install fuse3 (for example: apt-get install -y fuse3)"}
+	case "darwin":
+		for _, name := range []string{"mount_macfuse", "mount_fusefs"} {
+			if path, err := deps.lookupPath(name); err == nil {
+				return doctorCheck{name: "fuse binary", status: doctorPass, detail: name + " at " + path}
+			}
+		}
+		return doctorCheck{name: "fuse binary", status: doctorFail, detail: "macFUSE mount helper not found in PATH", fix: "install macFUSE and ensure its mount helper is available"}
+	default:
+		return doctorCheck{name: "fuse binary", status: doctorFail, detail: "unsupported OS " + deps.goos, fix: "run drive9 mount on Linux or macOS with FUSE installed"}
+	}
+}
+
+func doctorUnmountHelperCheck(deps doctorDeps, mountpoint string) doctorCheck {
+	argv, err := umountArgv(deps.goos, deps.lookupPath, mountpoint)
+	if err != nil {
+		return doctorCheck{name: "unmount helper", status: doctorFail, detail: err.Error(), fix: "install fuse3 or ensure umount is available in PATH"}
+	}
+	return doctorCheck{name: "unmount helper", status: doctorPass, detail: strings.Join(argv, " ")}
+}
+
+func doctorFuseConfCheck(deps doctorDeps) doctorCheck {
+	if deps.goos != "linux" {
+		return doctorCheck{name: "/etc/fuse.conf user_allow_other", status: doctorPass, detail: "not required on " + deps.goos}
+	}
+	b, err := deps.readFile("/etc/fuse.conf")
+	if err != nil {
+		return doctorCheck{name: "/etc/fuse.conf user_allow_other", status: doctorFail, detail: err.Error(), fix: "create /etc/fuse.conf with a line containing user_allow_other if you need --allow-other mounts"}
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "user_allow_other" {
+			return doctorCheck{name: "/etc/fuse.conf user_allow_other", status: doctorPass, detail: "enabled"}
+		}
+	}
+	return doctorCheck{name: "/etc/fuse.conf user_allow_other", status: doctorFail, detail: "user_allow_other is not enabled", fix: "add `user_allow_other` to /etc/fuse.conf before using drive9 mount --allow-other"}
+}
+
+func doctorMountpointCheck(deps doctorDeps, mountpoint string) doctorCheck {
+	mountpoint = strings.TrimSpace(mountpoint)
+	if mountpoint == "" {
+		return doctorCheck{name: "mountpoint", status: doctorFail, detail: "empty path", fix: "pass --mountpoint <path>"}
+	}
+	info, err := deps.stat(mountpoint)
+	if err != nil {
+		return doctorCheck{name: "mountpoint", status: doctorFail, detail: err.Error(), fix: "create the mountpoint directory: mkdir -p " + mountpoint}
+	}
+	if !info.IsDir() {
+		return doctorCheck{name: "mountpoint", status: doctorFail, detail: "path is not a directory", fix: "choose or create an empty directory for the mountpoint"}
+	}
+	if deps.isMountpoint != nil {
+		mounted, err := deps.isMountpoint(mountpoint)
+		if err != nil {
+			return doctorCheck{name: "mountpoint", status: doctorFail, detail: err.Error(), fix: "check mountpoint permissions and parent directory state"}
+		}
+		if mounted {
+			return doctorCheck{name: "mountpoint", status: doctorPass, detail: mountpoint + " is already mounted"}
+		}
+	}
+	return doctorCheck{name: "mountpoint", status: doctorPass, detail: mountpoint + " is an available directory"}
+}
+
+func doctorCacheDirCheck(deps doctorDeps, dir string) doctorCheck {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return doctorCheck{name: "cache dir", status: doctorFail, detail: "empty path", fix: "pass --cache-dir <path>"}
+	}
+	if err := deps.mkdirAll(dir, 0o700); err != nil {
+		return doctorCheck{name: "cache dir", status: doctorFail, detail: err.Error(), fix: "choose a writable cache directory or fix permissions"}
+	}
+	probe := filepath.Join(dir, ".drive9-doctor-write-test")
+	if err := deps.writeFile(probe, []byte("ok\n"), 0o600); err != nil {
+		return doctorCheck{name: "cache dir", status: doctorFail, detail: err.Error(), fix: "choose a writable cache directory or fix permissions"}
+	}
+	if err := deps.remove(probe); err != nil {
+		return doctorCheck{name: "cache dir", status: doctorFail, detail: err.Error(), fix: "remove stale files or fix cache directory permissions"}
+	}
+	return doctorCheck{name: "cache dir", status: doctorPass, detail: dir + " is writable"}
+}
+
+func doctorCredentialsCheck(creds ResolvedCredentials) doctorCheck {
+	switch creds.Kind {
+	case CredentialOwner:
+		return doctorCheck{name: "credentials", status: doctorPass, detail: "owner credential from " + creds.CredSource}
+	case CredentialDelegated:
+		return doctorCheck{name: "credentials", status: doctorPass, detail: "delegated credential from " + creds.CredSource}
+	default:
+		return doctorCheck{name: "credentials", status: doctorFail, detail: "no drive9 credential resolved", fix: "set DRIVE9_API_KEY or DRIVE9_VAULT_TOKEN, or configure a context with drive9 ctx add/import/use"}
+	}
+}
+
+func doctorServerCheck(ctx context.Context, deps doctorDeps, creds ResolvedCredentials, timeout time.Duration) doctorCheck {
+	server := strings.TrimSpace(creds.Server)
+	if server == "" {
+		return doctorCheck{name: "server connectivity", status: doctorFail, detail: "empty server URL", fix: "set DRIVE9_SERVER or pass --server <url>"}
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	status, err := deps.httpGet(ctx, strings.TrimRight(server, "/")+"/healthz", "")
+	if err != nil {
+		return doctorCheck{name: "server connectivity", status: doctorFail, detail: err.Error(), fix: "check DRIVE9_SERVER, DNS, TLS, and network access"}
+	}
+	if status < 200 || status >= 300 {
+		return doctorCheck{name: "server connectivity", status: doctorFail, detail: fmt.Sprintf("%s /healthz returned HTTP %d", server, status), fix: "check that the drive9 server is running and reachable"}
+	}
+	return doctorCheck{name: "server connectivity", status: doctorPass, detail: fmt.Sprintf("%s /healthz returned HTTP %d (%s)", server, status, creds.ServerSource)}
+}
+
+func doctorHTTPGet(ctx context.Context, url string, bearer string) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode, nil
+}
+
+func appendIfMissing(items []string, item string) []string {
+	for _, existing := range items {
+		if existing == item {
+			return items
+		}
+	}
+	return append(items, item)
+}
+
+func isMountpoint(path string) (bool, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return false, err
+	}
+	parent := filepath.Dir(abs)
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		return false, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, nil
+	}
+	parentStat, ok := parentInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, nil
+	}
+	return stat.Dev != parentStat.Dev || stat.Ino == parentStat.Ino, nil
+}

--- a/cmd/drive9/cli/doctor_test.go
+++ b/cmd/drive9/cli/doctor_test.go
@@ -1,0 +1,221 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/user"
+	"strings"
+	"testing"
+	"time"
+)
+
+type doctorFakeInfo struct {
+	name string
+	mode os.FileMode
+}
+
+func (i doctorFakeInfo) Name() string       { return i.name }
+func (i doctorFakeInfo) Size() int64        { return 0 }
+func (i doctorFakeInfo) Mode() os.FileMode  { return i.mode }
+func (i doctorFakeInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (i doctorFakeInfo) IsDir() bool        { return i.mode.IsDir() }
+func (i doctorFakeInfo) Sys() any           { return nil }
+
+func doctorTestDeps(out *bytes.Buffer) doctorDeps {
+	return doctorDeps{
+		goos:   "linux",
+		goarch: "amd64",
+		stdout: out,
+		lookupPath: func(name string) (string, error) {
+			if name == "fusermount3" {
+				return "/usr/bin/fusermount3", nil
+			}
+			return "", os.ErrNotExist
+		},
+		stat: func(path string) (os.FileInfo, error) {
+			switch path {
+			case "/dev/fuse":
+				return doctorFakeInfo{name: "fuse", mode: os.ModeCharDevice | 0o666}, nil
+			case "/mnt/drive9":
+				return doctorFakeInfo{name: "drive9", mode: os.ModeDir | 0o755}, nil
+			case "/.dockerenv", "/run/.containerenv":
+				return nil, os.ErrNotExist
+			default:
+				return nil, os.ErrNotExist
+			}
+		},
+		readFile: func(path string) ([]byte, error) {
+			switch path {
+			case "/etc/fuse.conf":
+				return []byte("# comment\nuser_allow_other\n"), nil
+			case "/proc/1/cgroup":
+				return []byte("0::/user.slice\n"), nil
+			default:
+				return nil, os.ErrNotExist
+			}
+		},
+		mkdirAll: func(string, os.FileMode) error { return nil },
+		writeFile: func(string, []byte, os.FileMode) error {
+			return nil
+		},
+		remove: func(string) error { return nil },
+		access: func(string, uint32) error { return nil },
+		currentUser: func() (*user.User, error) {
+			return &user.User{Username: "tester", Uid: "1000"}, nil
+		},
+		getgroups: func() ([]int, error) { return []int{20, 1000}, nil },
+		commandOutput: func(context.Context, string, ...string) ([]byte, error) {
+			return []byte("Linux test 6.0\n"), nil
+		},
+		resolveCredentials: func() ResolvedCredentials {
+			return ResolvedCredentials{
+				Kind:         CredentialOwner,
+				Server:       "https://api.test",
+				APIKey:       "d9_test",
+				CredSource:   "env:DRIVE9_API_KEY",
+				ServerSource: "env:DRIVE9_SERVER",
+			}
+		},
+		httpGet: func(context.Context, string, string) (int, error) {
+			return 200, nil
+		},
+		isMountpoint: func(string) (bool, error) { return false, nil },
+	}
+}
+
+func TestRunDoctorFuseAllPass(t *testing.T) {
+	var out bytes.Buffer
+	err := runDoctor([]string{"fuse"}, doctorTestDeps(&out))
+	if err != nil {
+		t.Fatalf("runDoctor: %v\n%s", err, out.String())
+	}
+	for _, want := range []string{
+		"drive9 doctor fuse",
+		"PASS os/kernel:",
+		"PASS /dev/fuse:",
+		"PASS fusermount:",
+		"PASS unmount helper:",
+		"PASS /etc/fuse.conf user_allow_other:",
+		"PASS mountpoint:",
+		"PASS cache dir:",
+		"PASS credentials:",
+		"PASS server connectivity:",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunDoctorFuseMissingDeviceFailsWithFix(t *testing.T) {
+	var out bytes.Buffer
+	deps := doctorTestDeps(&out)
+	deps.stat = func(path string) (os.FileInfo, error) {
+		switch path {
+		case "/dev/fuse":
+			return nil, os.ErrNotExist
+		case "/mnt/drive9":
+			return doctorFakeInfo{name: "drive9", mode: os.ModeDir | 0o755}, nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+	err := runDoctor([]string{"fuse"}, deps)
+	if err == nil {
+		t.Fatal("expected missing /dev/fuse to fail")
+	}
+	var failure doctorFailure
+	if !errors.As(err, &failure) || failure.failed != 1 {
+		t.Fatalf("err = %#v, want one doctorFailure", err)
+	}
+	if !strings.Contains(out.String(), "FAIL /dev/fuse:") || !strings.Contains(out.String(), "fix: run in an environment with /dev/fuse exposed") {
+		t.Fatalf("output missing /dev/fuse failure and fix:\n%s", out.String())
+	}
+}
+
+func TestRunDoctorFuseMissingCredentialsFails(t *testing.T) {
+	var out bytes.Buffer
+	deps := doctorTestDeps(&out)
+	deps.resolveCredentials = func() ResolvedCredentials {
+		return ResolvedCredentials{Kind: CredentialNone, Server: "https://api.test", ServerSource: "default"}
+	}
+	err := runDoctor([]string{"fuse"}, deps)
+	if err == nil {
+		t.Fatal("expected missing credentials to fail")
+	}
+	if !strings.Contains(out.String(), "FAIL credentials: no drive9 credential resolved") {
+		t.Fatalf("output missing credentials failure:\n%s", out.String())
+	}
+}
+
+func TestRunDoctorFuseServerFailureFails(t *testing.T) {
+	var out bytes.Buffer
+	deps := doctorTestDeps(&out)
+	deps.httpGet = func(context.Context, string, string) (int, error) {
+		return 503, nil
+	}
+	err := runDoctor([]string{"fuse"}, deps)
+	if err == nil {
+		t.Fatal("expected server failure to fail")
+	}
+	if !strings.Contains(out.String(), "FAIL server connectivity:") || !strings.Contains(out.String(), "HTTP 503") {
+		t.Fatalf("output missing server failure:\n%s", out.String())
+	}
+}
+
+func TestRunDoctorFuseMountpointFileFails(t *testing.T) {
+	var out bytes.Buffer
+	deps := doctorTestDeps(&out)
+	deps.stat = func(path string) (os.FileInfo, error) {
+		switch path {
+		case "/dev/fuse":
+			return doctorFakeInfo{name: "fuse", mode: os.ModeCharDevice | 0o666}, nil
+		case "/mnt/drive9":
+			return doctorFakeInfo{name: "drive9", mode: 0o644}, nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+	err := runDoctor([]string{"fuse"}, deps)
+	if err == nil {
+		t.Fatal("expected file mountpoint to fail")
+	}
+	if !strings.Contains(out.String(), "FAIL mountpoint: path is not a directory") {
+		t.Fatalf("output missing mountpoint failure:\n%s", out.String())
+	}
+}
+
+func TestRunDoctorFuseDarwinDoesNotRequireLinuxFuseConf(t *testing.T) {
+	var out bytes.Buffer
+	deps := doctorTestDeps(&out)
+	deps.goos = "darwin"
+	deps.lookupPath = func(name string) (string, error) {
+		if name == "mount_macfuse" {
+			return "/usr/local/bin/mount_macfuse", nil
+		}
+		return "", os.ErrNotExist
+	}
+	err := runDoctor([]string{"fuse"}, deps)
+	if err != nil {
+		t.Fatalf("runDoctor: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "PASS /etc/fuse.conf user_allow_other: not required on darwin") {
+		t.Fatalf("output missing darwin fuse.conf pass:\n%s", out.String())
+	}
+}
+
+func TestRunDoctorUsageErrors(t *testing.T) {
+	for _, args := range [][]string{
+		nil,
+		{"unknown"},
+		{"fuse", "extra"},
+		{"fuse", "--timeout", "0s"},
+	} {
+		var out bytes.Buffer
+		if err := runDoctor(args, doctorTestDeps(&out)); err == nil {
+			t.Fatalf("runDoctor(%v) = nil, want error", args)
+		}
+	}
+}

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -12,6 +12,7 @@
 //	vault   vault operations (set, get, put, with, ls, rm, grant, revoke, audit)
 //	mount   mount drive9 as a local filesystem, or mount vault secrets
 //	umount  unmount a drive9 local mount
+//	doctor  diagnose local drive9 runtime prerequisites
 package main
 
 import (
@@ -37,6 +38,7 @@ var exitFunc = os.Exit
 // "handler not reached". Production callers see no change: the default value
 // is the real cli.Secret and nothing else reassigns it outside tests.
 var vaultHandler = cli.Secret
+var doctorHandler = cli.Doctor
 
 func main() {
 	if logger.CLIEnabled() {
@@ -132,6 +134,17 @@ func dispatch(cmd string, args []string) {
 		}
 		if err := cli.UmountCmd(args); err != nil {
 			fatal("umount", err)
+		}
+	case "doctor":
+		if cliLogger != nil {
+			sub := ""
+			if len(args) > 0 {
+				sub = args[0]
+			}
+			logger.Info(context.Background(), "cli_command", zap.String("command", "doctor"), zap.String("subcommand", sub))
+		}
+		if err := doctorHandler(args); err != nil {
+			fatal("doctor", err)
 		}
 	default:
 		if cliLogger != nil {
@@ -245,6 +258,7 @@ commands:
   mount vault [flags] <mountpoint>
                          mount vault secrets read-only
   umount <mountpoint>    unmount a drive9 mount
+  doctor fuse            diagnose local FUSE prerequisites
 
 global:
   -h, --help, help       show this help

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -83,6 +83,7 @@ func TestDispatchLongHelpFlagShowsUsage(t *testing.T) {
 		"ctx use <name>",
 		"mount [flags] [:/remote] <mountpoint>",
 		"mount vault [flags] <mountpoint>",
+		"doctor fuse",
 		"-h, --help, help",
 	} {
 		if !strings.Contains(stderr, want) {
@@ -117,6 +118,39 @@ func TestDispatchVaultVerbReachesHandler(t *testing.T) {
 		t.Fatal("vault handler was not invoked for `drive9 vault ...`")
 	}
 	want := []string{"ls", "--json"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q", i, gotArgs[i], want[i])
+		}
+	}
+}
+
+func TestDispatchDoctorVerbReachesHandler(t *testing.T) {
+	origHandler := doctorHandler
+	origExit := exitFunc
+	t.Cleanup(func() {
+		doctorHandler = origHandler
+		exitFunc = origExit
+	})
+	exitFunc = func(int) {}
+
+	var gotArgs []string
+	called := false
+	doctorHandler = func(args []string) error {
+		called = true
+		gotArgs = args
+		return nil
+	}
+
+	dispatch("doctor", []string{"fuse", "--mountpoint", "/mnt/drive9"})
+
+	if !called {
+		t.Fatal("doctor handler was not invoked for `drive9 doctor ...`")
+	}
+	want := []string{"fuse", "--mountpoint", "/mnt/drive9"}
 	if len(gotArgs) != len(want) {
 		t.Fatalf("args = %v, want %v", gotArgs, want)
 	}


### PR DESCRIPTION
## Summary
- add `drive9 doctor fuse` CLI diagnostics for FUSE runtime prerequisites
- check OS/kernel, environment markers, current user, /dev/fuse access, FUSE helpers, allow_other config, mountpoint, cache dir, credentials, and server /healthz
- add unit tests for pass, device failure, missing credentials, server failure, mountpoint failure, darwin behavior, usage, and top-level dispatch

## Validation
- `/usr/local/go/bin/go test ./cmd/drive9/cli -run 'TestRunDoctor|TestDoctor' -count=1`
- `/usr/local/go/bin/go test ./cmd/drive9 -run 'TestDispatchDoctor|TestDispatchLongHelpFlagShowsUsage' -count=1`
- `/usr/local/go/bin/go test -c ./cmd/drive9 ./cmd/drive9/cli`
- `PATH=/usr/local/go/bin:$PATH bin/golangci-lint run --timeout 10m --new-from-rev=origin/main ./cmd/drive9/...`
- `git diff --check`

Note: full local `bin/golangci-lint run ./cmd/drive9/...` still reports pre-existing staticcheck warnings in `cmd/drive9/cli/ctx_test.go`; no new lint issues under `--new-from-rev=origin/main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `doctor` diagnostic command to inspect system configuration and health
  * Performs comprehensive checks including OS/kernel compatibility, FUSE driver availability, server connectivity, credentials, cache configuration, and environment variables
  * Includes configurable flags for custom mountpoint, cache directory, server endpoint, and timeout values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->