### PR TITLE
feat(fuse): add perf counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ drive9 mount [flags] [:/remote] <mountpoint>
   -allow-other                   allow other users to access mount
   -read-only                     mount read-only
   -debug                         enable FUSE debug logging
+  -perf-counters                 print FUSE perf counter summary on unmount
 ```
 
 ## Server Configuration

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -83,6 +83,7 @@ func fsMountCmd(args []string) error {
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
 	readOnly := fs.Bool("read-only", false, "mount as read-only")
 	debug := fs.Bool("debug", false, "enable FUSE debug logging")
+	perfCounters := fs.Bool("perf-counters", false, "print FUSE perf counter summary on unmount")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: drive9 mount [flags] [:/remote] <mountpoint>\n\nflags:\n")
@@ -195,6 +196,7 @@ func fsMountCmd(args []string) error {
 		AllowOther:         *allowOther,
 		ReadOnly:           *readOnly,
 		Debug:              *debug,
+		PerfCounters:       *perfCounters,
 	}
 
 	return drive9fuse.Mount(opts)

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -69,6 +69,8 @@ type CommitQueue struct {
 	// workCh dispatches entries to upload workers. The buffer is always
 	// larger than maxPending so Enqueue never blocks.
 	workCh chan *CommitEntry
+
+	perf *fusePerfCounters
 }
 
 // NewCommitQueue creates a CommitQueue with background workers.
@@ -105,6 +107,10 @@ func NewCommitQueue(c *client.Client, shadows *ShadowStore, index *PendingIndex,
 	return cq
 }
 
+func (cq *CommitQueue) SetPerfCounters(perf *fusePerfCounters) {
+	cq.perf = perf
+}
+
 func (cq *CommitQueue) remotePath(localPath string) string {
 	root := "/"
 	if cq != nil && cq.remoteRoot != "" {
@@ -119,12 +125,21 @@ func (cq *CommitQueue) Enqueue(entry *CommitEntry) error {
 	cq.mu.Lock()
 	defer cq.mu.Unlock()
 	if cq.stopped {
+		if cq.perf != nil {
+			cq.perf.commitEnqueueError.add(1)
+		}
 		return fmt.Errorf("commit queue stopped")
 	}
 	if len(cq.queue) >= cq.maxPending {
+		if cq.perf != nil {
+			cq.perf.commitEnqueueError.add(1)
+		}
 		return fmt.Errorf("commit queue full (%d pending)", cq.maxPending)
 	}
 	cq.queue = append(cq.queue, entry)
+	if cq.perf != nil {
+		cq.perf.commitEnqueue.add(1)
+	}
 
 	// Send to workers while holding the lock. The channel buffer is always
 	// > maxPending, so this will not block as long as the backpressure
@@ -150,6 +165,13 @@ func (cq *CommitQueue) IsFull() bool {
 
 // DrainAll stops accepting new entries and waits for all workers to finish.
 func (cq *CommitQueue) DrainAll() {
+	start := time.Now()
+	defer func() {
+		if cq.perf != nil {
+			cq.perf.commitDrainCount.add(1)
+			cq.perf.commitDrainTotalNS.add(uint64(time.Since(start)))
+		}
+	}()
 	cq.mu.Lock()
 	if cq.stopped {
 		cq.mu.Unlock()
@@ -462,6 +484,9 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 		}
 
 		if attempt > 0 {
+			if cq.perf != nil {
+				cq.perf.commitRetry.add(1)
+			}
 			delay := time.Duration(float64(baseDelay) * math.Pow(2, float64(attempt-1)))
 			if delay > maxDelay {
 				delay = maxDelay
@@ -535,6 +560,9 @@ func sleepWithCancel(ctx context.Context, delay time.Duration) bool {
 func (cq *CommitQueue) CommitNow(ctx context.Context, entry *CommitEntry) error {
 	committedRev, err := cq.uploadEntry(ctx, entry)
 	if err != nil {
+		if cq.perf != nil {
+			cq.perf.commitFailure.add(1)
+		}
 		return err
 	}
 	cq.onCommitSuccess(entry, committedRev)
@@ -558,7 +586,16 @@ func (cq *CommitQueue) uploadEntry(ctx context.Context, entry *CommitEntry) (int
 	// ShadowSpill entries: stream directly from shadow file to avoid loading
 	// multi-GiB files into memory. Uses io.SectionReader over the shadow fd.
 	if entry.ShadowSpill {
-		return 0, uploadFromShadowRemote(ctx, cq.client, cq.shadows, entry.Path, apiPath, expectedRevision)
+		start := time.Now()
+		err := uploadFromShadowRemote(ctx, cq.client, cq.shadows, entry.Path, apiPath, expectedRevision)
+		if cq.perf != nil {
+			var bytes uint64
+			if entry.Size > 0 {
+				bytes = uint64(entry.Size)
+			}
+			cq.perf.recordRemoteOp(perfRemoteWrite, err, time.Since(start), bytes)
+		}
+		return 0, err
 	}
 
 	// Non-ShadowSpill: read full content into memory.
@@ -571,12 +608,21 @@ func (cq *CommitQueue) uploadEntry(ctx context.Context, entry *CommitEntry) (int
 	// Files under commitQueueDirectPutThreshold use direct PUT to skip the
 	// multipart initiate/presign/complete/finalize overhead (~440ms).
 	if entry.Size < commitQueueDirectPutThreshold {
+		start := time.Now()
 		committedRev, err := cq.client.WriteCtxConditionalWithRevision(ctx, apiPath, data, expectedRevision)
+		if cq.perf != nil {
+			cq.perf.recordRemoteOp(perfRemoteWrite, err, time.Since(start), uint64(len(data)))
+		}
 		return committedRev, err
 	}
 
 	// Larger non-ShadowSpill files: multipart upload.
-	return 0, uploadBufferedRemoteFile(ctx, cq.client, apiPath, data, expectedRevision)
+	start := time.Now()
+	err = uploadBufferedRemoteFile(ctx, cq.client, apiPath, data, expectedRevision)
+	if cq.perf != nil {
+		cq.perf.recordRemoteOp(perfRemoteWrite, err, time.Since(start), uint64(len(data)))
+	}
+	return 0, err
 }
 
 func (cq *CommitQueue) removeFromQueue(entry *CommitEntry) {
@@ -625,6 +671,9 @@ func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) {
 	// until bookkeeping is complete.
 	cq.removeFromQueue(entry)
 
+	if cq.perf != nil {
+		cq.perf.commitSuccess.add(1)
+	}
 	log.Printf("commit queue: successfully uploaded %s (%d bytes, rev=%d)", entry.Path, entry.Size, committedRev)
 }
 
@@ -676,8 +725,12 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	// Fetch server's current state: revision + content.
 	// Use per-RPC timeouts so that a slow Read doesn't starve the Upload budget.
 	statCtx, statCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	statStart := time.Now()
 	stat, err := cq.client.StatCtx(statCtx, apiPath)
 	statCancel()
+	if cq.perf != nil {
+		cq.perf.recordRemoteOp(perfRemoteStat, err, time.Since(statStart), 0)
+	}
 	if err != nil {
 		log.Printf("commit queue: auto-resolve failed for %s: stat: %v", entry.Path, err)
 		cq.onCommitTerminalFailure(entry)
@@ -686,8 +739,12 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	serverRev := stat.Revision
 
 	readCtx, readCancel := context.WithTimeout(context.Background(), uploadTimeout)
+	readStart := time.Now()
 	serverData, err := cq.client.ReadCtx(readCtx, apiPath)
 	readCancel()
+	if cq.perf != nil {
+		cq.perf.recordRemoteOp(perfRemoteRead, err, time.Since(readStart), uint64(len(serverData)))
+	}
 	if err != nil {
 		log.Printf("commit queue: auto-resolve failed for %s: read server: %v", entry.Path, err)
 		cq.onCommitTerminalFailure(entry)
@@ -710,8 +767,12 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	}
 	log.Printf("commit queue: auto-resolving conflict for %s via LWW (base rev %d → server rev %d)", entry.Path, entry.BaseRev, serverRev)
 	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), releaseTimeout(int64(len(localData))))
+	uploadStart := time.Now()
 	err = uploadBufferedRemoteFile(uploadCtx, cq.client, apiPath, localData, serverRev)
 	uploadCancel()
+	if cq.perf != nil {
+		cq.perf.recordRemoteOp(perfRemoteWrite, err, time.Since(uploadStart), uint64(len(localData)))
+	}
 	if err != nil {
 		log.Printf("commit queue: auto-resolve LWW re-upload failed for %s: %v", entry.Path, err)
 		cq.onCommitTerminalFailure(entry)
@@ -723,6 +784,9 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 }
 
 func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry) {
+	if cq.perf != nil {
+		cq.perf.commitFailure.add(1)
+	}
 	// Mark the entry as conflicted in the pending index so that crash
 	// recovery (RecoverPending) skips it instead of retrying forever.
 	// Preserve both the shadow file and the pending metadata so the user

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -88,6 +88,9 @@ type Dat9FS struct {
 	lookupStatRetryTotal     atomic.Uint64
 	lookupStatRetrySuccess   atomic.Uint64
 	lookupStatRetryExhausted atomic.Uint64
+
+	// perf contains optional mount-level counters. Nil when disabled.
+	perf *fusePerfCounters
 }
 
 type dirtyInodeState struct {
@@ -110,6 +113,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		gid:           uint32(os.Getgid()),
 		opts:          opts,
 		debouncer:     newFlushDebouncer(opts.FlushDebounce),
+		perf:          newFusePerfCounters(opts.PerfCounters),
 	}
 }
 
@@ -382,7 +386,9 @@ func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64
 }
 
 func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gofuse.Status {
+	statStart := fs.perfStart()
 	stat, err := fs.client.StatCtx(ctx, fs.remotePath(fh.Path))
+	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
 	if err != nil {
 		return httpToFuseStatus(err)
 	}
@@ -433,12 +439,14 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 		fs.debugf("dirty load part start path=%s part=%d off=%d len=%d", filePath, partNum, offset, length)
 		rc, err := c.ReadStreamRange(lpCtx, remoteFilePath, offset, length)
 		if err != nil {
+			fs.perfRecordRemote(perfRemoteRead, loadStart, err, 0)
 			fs.debugDurationf(loadStart, 0, "dirty load part open failed path=%s part=%d off=%d len=%d err=%v", filePath, partNum, offset, length, err)
 			return nil, err
 		}
 		defer func() { _ = rc.Close() }()
 
 		data, err := io.ReadAll(rc)
+		fs.perfRecordRemote(perfRemoteRead, loadStart, err, uint64(len(data)))
 		if err != nil {
 			fs.debugDurationf(loadStart, 0, "dirty load part read failed path=%s part=%d off=%d len=%d got=%d err=%v", filePath, partNum, offset, length, len(data), err)
 			return nil, err
@@ -771,23 +779,36 @@ func isTransientReadErr(err error) bool {
 // Returns EIO (never EAGAIN) when all retries are exhausted.
 func (fs *Dat9FS) readSmallFileWithRetry(ctx context.Context, path string) ([]byte, error) {
 	remotePath := fs.remotePath(path)
+	readStart := fs.perfStart()
 	data, err := fs.client.ReadCtx(ctx, remotePath)
+	fs.perfRecordRemote(perfRemoteRead, readStart, err, uint64(len(data)))
 	if err == nil || !isTransientReadErr(err) {
 		return data, err
 	}
 
+	if fs.perf != nil {
+		fs.perf.readRetryTotal.add(1)
+	}
 	lastErr := err
 	for range readTransientRetryCount {
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), readTransientRetryTimeout)
+		readStart = fs.perfStart()
 		data, err = fs.client.ReadCtx(retryCtx, remotePath)
 		retryCancel()
+		fs.perfRecordRemote(perfRemoteRead, readStart, err, uint64(len(data)))
 		if err == nil {
+			if fs.perf != nil {
+				fs.perf.readRetrySuccess.add(1)
+			}
 			return data, nil
 		}
 		if !isTransientReadErr(err) {
 			return nil, err
 		}
 		lastErr = err
+	}
+	if fs.perf != nil {
+		fs.perf.readRetryExhausted.add(1)
 	}
 	return nil, fmt.Errorf("%w: %s: %v", errReadRetriesExhausted, path, lastErr)
 }
@@ -804,18 +825,27 @@ func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, off
 		return data, n, err
 	}
 
+	if fs.perf != nil {
+		fs.perf.readRetryTotal.add(1)
+	}
 	lastErr := err
 	for range readTransientRetryCount {
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), readTransientRetryTimeout)
 		data, n, err = fs.doRangeRead(retryCtx, path, offset, size)
 		retryCancel()
 		if err == nil {
+			if fs.perf != nil {
+				fs.perf.readRetrySuccess.add(1)
+			}
 			return data, n, nil
 		}
 		if !isTransientReadErr(err) {
 			return nil, 0, err
 		}
 		lastErr = err
+	}
+	if fs.perf != nil {
+		fs.perf.readRetryExhausted.add(1)
 	}
 	return nil, 0, fmt.Errorf("%w: %s: %v", errReadRetriesExhausted, path, lastErr)
 }
@@ -824,8 +854,10 @@ func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, off
 // All body read errors (including truncation) are returned as-is so the
 // caller can classify them for retry.
 func (fs *Dat9FS) doRangeRead(ctx context.Context, path string, offset, size int64) ([]byte, int, error) {
+	readStart := fs.perfStart()
 	rc, err := fs.client.ReadStreamRange(ctx, fs.remotePath(path), offset, size)
 	if err != nil {
+		fs.perfRecordRemote(perfRemoteRead, readStart, err, 0)
 		return nil, 0, err
 	}
 	defer func() { _ = rc.Close() }()
@@ -837,6 +869,7 @@ func (fs *Dat9FS) doRangeRead(ctx context.Context, path string, offset, size int
 	// io.ReadFull swallows io.ErrUnexpectedEOF, hiding truncation.
 	lr := io.LimitReader(rc, size)
 	data, err := io.ReadAll(lr)
+	fs.perfRecordRemote(perfRemoteRead, readStart, err, uint64(len(data)))
 	if err != nil {
 		return nil, len(data), err
 	}
@@ -874,8 +907,10 @@ func (fs *Dat9FS) lookupRetryStats() (total, success, exhausted uint64) {
 func (fs *Dat9FS) statWithTransientRetry(cancel <-chan struct{}, localPath string, trackLookupMetrics bool) (*client.StatResult, error) {
 	apiPath := fs.remotePath(localPath)
 	ctx, cf := fuseCtx(cancel)
+	statStart := fs.perfStart()
 	stat, err := fs.client.StatCtx(ctx, apiPath)
 	cf()
+	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
 	if err == nil || isNotFoundErr(err) || !isTransientLookupErr(err) {
 		return stat, err
 	}
@@ -890,6 +925,9 @@ func (fs *Dat9FS) statWithTransientRetry(cancel <-chan struct{}, localPath strin
 	}
 	if trackLookupMetrics {
 		fs.lookupStatRetryTotal.Add(1)
+		if fs.perf != nil {
+			fs.perf.lookupRetryTotal.add(1)
+		}
 	}
 
 	lastErr := err
@@ -901,11 +939,16 @@ func (fs *Dat9FS) statWithTransientRetry(cancel <-chan struct{}, localPath strin
 		// transient failures. Keep this detached+bounded behavior unless retry
 		// semantics are redesigned.
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), fs.lookupStatRetryTimeout())
+		statStart = fs.perfStart()
 		stat, err = fs.client.StatCtx(retryCtx, apiPath)
 		retryCancel()
+		fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
 		if err == nil {
 			if trackLookupMetrics {
 				successCount := fs.lookupStatRetrySuccess.Add(1)
+				if fs.perf != nil {
+					fs.perf.lookupRetrySuccess.add(1)
+				}
 				if successCount <= 3 || successCount%lookupRetrySuccessLogEvery == 0 {
 					log.Printf("lookup stat retry recovered for %s (success_count=%d)", localPath, successCount)
 				}
@@ -920,6 +963,9 @@ func (fs *Dat9FS) statWithTransientRetry(cancel <-chan struct{}, localPath strin
 
 	if trackLookupMetrics {
 		fs.lookupStatRetryExhausted.Add(1)
+		if fs.perf != nil {
+			fs.perf.lookupRetryExhausted.add(1)
+		}
 		log.Printf("lookup stat retries exhausted for %s: %v", localPath, lastErr)
 	}
 	return nil, lastErr
@@ -940,8 +986,10 @@ func (fs *Dat9FS) lookupListWithRetry(cancel <-chan struct{}, parentPath string)
 	// those counters remain scoped to the primary Lookup->Stat path.
 	ctx, cf := fuseCtx(cancel)
 	apiPath := fs.remotePath(parentPath)
+	listStart := fs.perfStart()
 	items, err := fs.client.ListCtx(ctx, apiPath)
 	cf()
+	fs.perfRecordRemote(perfRemoteList, listStart, err, 0)
 	if err == nil || !isTransientLookupErr(err) {
 		return items, err
 	}
@@ -957,8 +1005,10 @@ func (fs *Dat9FS) lookupListWithRetry(cancel <-chan struct{}, parentPath string)
 		// said "not found", and cancel-coupled retries would collapse to the
 		// original transient failure immediately.
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), fs.lookupStatRetryTimeout())
+		listStart = fs.perfStart()
 		items, err = fs.client.ListCtx(retryCtx, apiPath)
 		retryCancel()
+		fs.perfRecordRemote(perfRemoteList, listStart, err, 0)
 		if err == nil || !isTransientLookupErr(err) {
 			return items, err
 		}
@@ -970,36 +1020,46 @@ func (fs *Dat9FS) lookupListWithRetry(cancel <-chan struct{}, parentPath string)
 func (fs *Dat9FS) remoteDirExistsDetached(localPath string) bool {
 	retryCtx, retryCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
 	defer retryCancel()
+	statStart := fs.perfStart()
 	stat, err := fs.client.StatCtx(retryCtx, fs.remotePath(localPath))
+	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
 	return err == nil && stat.IsDir
 }
 
 func (fs *Dat9FS) remoteRenameCommittedDetached(oldP, newP string) bool {
 	targetCtx, targetCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+	statStart := fs.perfStart()
 	_, targetErr := fs.client.StatCtx(targetCtx, fs.remotePath(newP))
 	targetCancel()
+	fs.perfRecordRemote(perfRemoteStat, statStart, targetErr, 0)
 	if targetErr != nil {
 		return false
 	}
 
 	sourceCtx, sourceCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+	statStart = fs.perfStart()
 	_, sourceErr := fs.client.StatCtx(sourceCtx, fs.remotePath(oldP))
 	sourceCancel()
+	fs.perfRecordRemote(perfRemoteStat, statStart, sourceErr, 0)
 	return isNotFoundErr(sourceErr)
 }
 
 func (fs *Dat9FS) remotePathGoneDetached(localPath string) bool {
 	retryCtx, retryCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
 	defer retryCancel()
+	statStart := fs.perfStart()
 	_, err := fs.client.StatCtx(retryCtx, fs.remotePath(localPath))
+	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
 	return isNotFoundErr(err)
 }
 
 func (fs *Dat9FS) mkdirRemoteWithTransientRetry(cancel <-chan struct{}, localPath string) error {
 	apiPath := fs.remotePath(localPath)
 	ctx, cf := fuseCtx(cancel)
+	mutationStart := fs.perfStart()
 	err := fs.client.MkdirCtx(ctx, apiPath)
 	cf()
+	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
 	if err == nil || !isTransientLookupErr(err) {
 		return err
 	}
@@ -1019,8 +1079,10 @@ func (fs *Dat9FS) mkdirRemoteWithTransientRetry(cancel <-chan struct{}, localPat
 	lastErr := err
 	for range retryCount {
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+		mutationStart = fs.perfStart()
 		err = fs.client.MkdirCtx(retryCtx, apiPath)
 		retryCancel()
+		fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
 		if err == nil {
 			return nil
 		}
@@ -1039,7 +1101,9 @@ func (fs *Dat9FS) mkdirRemoteWithTransientRetry(cancel <-chan struct{}, localPat
 }
 
 func (fs *Dat9FS) deleteRemoteWithInterruptRecovery(ctx context.Context, localPath string) error {
+	mutationStart := fs.perfStart()
 	err := fs.client.DeleteCtx(ctx, fs.remotePath(localPath))
+	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
 	if err == nil || !isTransientLookupErr(err) {
 		return err
 	}
@@ -1057,7 +1121,9 @@ func (fs *Dat9FS) deleteRemoteWithInterruptRecovery(ctx context.Context, localPa
 func (fs *Dat9FS) renameRemoteWithTransientRetry(ctx context.Context, oldP, newP string) error {
 	oldRemote := fs.remotePath(oldP)
 	newRemote := fs.remotePath(newP)
+	mutationStart := fs.perfStart()
 	err := fs.client.RenameCtx(ctx, oldRemote, newRemote)
+	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
 	if err == nil || !isTransientLookupErr(err) {
 		return err
 	}
@@ -1078,8 +1144,10 @@ func (fs *Dat9FS) renameRemoteWithTransientRetry(ctx context.Context, oldP, newP
 	lastErr := err
 	for range retryCount {
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+		mutationStart = fs.perfStart()
 		err = fs.client.RenameCtx(retryCtx, oldRemote, newRemote)
 		retryCancel()
+		fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
 		if err == nil {
 			return nil
 		}
@@ -1107,6 +1175,9 @@ func (fs *Dat9FS) Init(server *gofuse.Server) {
 // Safe to call even if the server is not yet initialized (e.g., during tests).
 func (fs *Dat9FS) notifyEntry(parentIno uint64, name string) {
 	fs.notifyCount.Add(1)
+	if fs.perf != nil {
+		fs.perf.notifyEntry.add(1)
+	}
 	if fs.server == nil {
 		return
 	}
@@ -1125,6 +1196,9 @@ func (fs *Dat9FS) notifyEntry(parentIno uint64, name string) {
 // for an inode. off=0, sz=0 means invalidate all cached data.
 func (fs *Dat9FS) notifyInode(ino uint64) {
 	fs.notifyCount.Add(1)
+	if fs.perf != nil {
+		fs.perf.notifyInode.add(1)
+	}
 	if fs.server == nil {
 		return
 	}
@@ -1135,7 +1209,9 @@ func (fs *Dat9FS) notifyInode(ino uint64) {
 	}()
 }
 
-func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name string, out *gofuse.EntryOut) gofuse.Status {
+func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name string, out *gofuse.EntryOut) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseLookup, perfStart, status, 0) }()
 	childP, st := fs.childPath(header.NodeId, name)
 	if st != gofuse.OK {
 		return st
@@ -1332,7 +1408,9 @@ func (fs *Dat9FS) cleanupCommittedInode(ino uint64, p string) {
 	fs.inodes.RemoveFileIfUnreferenced(ino)
 }
 
-func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *gofuse.AttrOut) gofuse.Status {
+func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *gofuse.AttrOut) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseGetAttr, perfStart, status, 0) }()
 	entry, ok := fs.inodes.GetEntry(input.NodeId)
 	if !ok {
 		return gofuse.ENOENT
@@ -1405,7 +1483,9 @@ func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *
 	return gofuse.OK
 }
 
-func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *gofuse.AttrOut) gofuse.Status {
+func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *gofuse.AttrOut) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseSetAttr, perfStart, status, 0) }()
 	entry, ok := fs.inodes.GetEntry(input.NodeId)
 	if !ok {
 		return gofuse.ENOENT
@@ -1440,13 +1520,18 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 				ctx, cf := fuseCtx(cancel)
 				defer cf()
 				apiPath := fs.remotePath(entry.Path)
-				if err := fs.client.WriteCtx(ctx, apiPath, nil); err != nil {
+				writeStart := fs.perfStart()
+				err := fs.client.WriteCtx(ctx, apiPath, nil)
+				fs.perfRecordRemote(perfRemoteWrite, writeStart, err, 0)
+				if err != nil {
 					return httpToFuseStatus(err)
 				}
 				// Refresh the inode revision after the server-side truncate so a
 				// subsequent writable open does not reuse the stale pre-truncate
 				// base revision and conflict with its own zero-byte write.
+				statStart := fs.perfStart()
 				stat, statErr := fs.client.StatCtx(ctx, apiPath)
+				fs.perfRecordRemote(perfRemoteStat, statStart, statErr, 0)
 				if statErr != nil {
 					log.Printf("post-truncate stat refresh failed for %s (inode=%d): %v (revision may be stale)", entry.Path, input.NodeId, statErr)
 				} else if stat != nil {
@@ -1481,7 +1566,9 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 
 // --- Directory operations ----------------------------------------------------
 
-func (fs *Dat9FS) Mkdir(cancel <-chan struct{}, input *gofuse.MkdirIn, name string, out *gofuse.EntryOut) gofuse.Status {
+func (fs *Dat9FS) Mkdir(cancel <-chan struct{}, input *gofuse.MkdirIn, name string, out *gofuse.EntryOut) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseMkdir, perfStart, status, 0) }()
 	childP, st := fs.childPath(input.NodeId, name)
 	if st != gofuse.OK {
 		return st
@@ -1506,13 +1593,15 @@ func (fs *Dat9FS) Mkdir(cancel <-chan struct{}, input *gofuse.MkdirIn, name stri
 	return gofuse.OK
 }
 
-func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name string) gofuse.Status {
+func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name string) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseUnlink, perfStart, status, 0) }()
 	childP, st := fs.childPath(header.NodeId, name)
 	if st != gofuse.OK {
 		return st
 	}
 	start := time.Now()
-	status := gofuse.OK
+	status = gofuse.OK
 	fs.debugf("unlink start path=%s parent_ino=%d name=%s", childP, header.NodeId, name)
 	defer func() {
 		fs.debugf("unlink done path=%s status=%d dur=%s", childP, status, time.Since(start))
@@ -1597,7 +1686,9 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	return gofuse.OK
 }
 
-func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name string) gofuse.Status {
+func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name string) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseRmdir, perfStart, status, 0) }()
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
 
@@ -1606,7 +1697,7 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 		return st
 	}
 	start := time.Now()
-	status := gofuse.OK
+	status = gofuse.OK
 	fs.debugf("rmdir start path=%s parent_ino=%d name=%s", childP, header.NodeId, name)
 	defer func() {
 		fs.debugf("rmdir done path=%s status=%d dur=%s", childP, status, time.Since(start))
@@ -1770,7 +1861,9 @@ func (fs *Dat9FS) pendingRenameTargetExists(ctx context.Context, p string) (bool
 	if fs.commitQueue != nil && fs.commitQueue.HasPath(p) {
 		return true, nil
 	}
+	statStart := fs.perfStart()
 	_, err := fs.client.StatCtx(ctx, fs.remotePath(p))
+	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
 	if err == nil {
 		return true, nil
 	}
@@ -1795,7 +1888,9 @@ func (fs *Dat9FS) finishLocalRename(input *gofuse.RenameIn, oldP, newP string) {
 	}
 }
 
-func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName string, newName string) gofuse.Status {
+func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName string, newName string) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseRename, perfStart, status, 0) }()
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
 
@@ -1917,7 +2012,9 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 	return gofuse.OK
 }
 
-func (fs *Dat9FS) OpenDir(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse.OpenOut) gofuse.Status {
+func (fs *Dat9FS) OpenDir(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse.OpenOut) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseOpenDir, perfStart, status, 0) }()
 	p, ok := fs.inodes.GetPath(input.NodeId)
 	if !ok {
 		return gofuse.ENOENT
@@ -1932,7 +2029,9 @@ func (fs *Dat9FS) OpenDir(cancel <-chan struct{}, input *gofuse.OpenIn, out *gof
 	return gofuse.OK
 }
 
-func (fs *Dat9FS) ReadDir(cancel <-chan struct{}, input *gofuse.ReadIn, out *gofuse.DirEntryList) gofuse.Status {
+func (fs *Dat9FS) ReadDir(cancel <-chan struct{}, input *gofuse.ReadIn, out *gofuse.DirEntryList) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseReadDir, perfStart, status, 0) }()
 	dh, ok := fs.dirHandles.Get(input.Fh)
 	if !ok {
 		return gofuse.ENOENT
@@ -1964,7 +2063,9 @@ func (fs *Dat9FS) ReadDir(cancel <-chan struct{}, input *gofuse.ReadIn, out *gof
 	return gofuse.OK
 }
 
-func (fs *Dat9FS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out *gofuse.DirEntryList) gofuse.Status {
+func (fs *Dat9FS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out *gofuse.DirEntryList) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseReadDirPlus, perfStart, status, 0) }()
 	dh, ok := fs.dirHandles.Get(input.Fh)
 	if !ok {
 		return gofuse.ENOENT
@@ -2012,11 +2113,19 @@ func (fs *Dat9FS) ReleaseDir(input *gofuse.ReleaseIn) {
 func (fs *Dat9FS) listDir(ctx context.Context, dirPath string) ([]DirEntry, error) {
 	// Check dir cache first
 	if cached, ok := fs.dirCache.Get(dirPath); ok {
+		if fs.perf != nil {
+			fs.perf.dirCacheHit.add(1)
+		}
 		entries := fs.cachedToDirEntries(dirPath, cached)
 		return fs.mergePendingDirEntries(dirPath, entries), nil
 	}
+	if fs.perf != nil {
+		fs.perf.dirCacheMiss.add(1)
+	}
 
+	listStart := fs.perfStart()
 	items, err := fs.client.ListCtx(ctx, fs.remotePath(dirPath))
+	fs.perfRecordRemote(perfRemoteList, listStart, err, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -2147,7 +2256,9 @@ func (fs *Dat9FS) cachedToDirEntries(dirPath string, items []CachedFileInfo) []D
 
 // --- File operations ---------------------------------------------------------
 
-func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name string, out *gofuse.CreateOut) gofuse.Status {
+func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name string, out *gofuse.CreateOut) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseCreate, perfStart, status, 0) }()
 	if fs.opts.ReadOnly {
 		return gofuse.EROFS
 	}
@@ -2218,7 +2329,9 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 	return gofuse.OK
 }
 
-func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse.OpenOut) gofuse.Status {
+func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse.OpenOut) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseOpen, perfStart, status, 0) }()
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
 
@@ -2249,7 +2362,10 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		// If BaseRev is 0 (e.g. inode came from readdir without revision),
 		// fetch the authoritative revision so CAS uploads work correctly.
 		if fh.BaseRev == 0 && !fh.IsNew {
-			if stat, err := fs.client.StatCtx(ctx, fs.remotePath(p)); err == nil && stat != nil {
+			statStart := fs.perfStart()
+			stat, err := fs.client.StatCtx(ctx, fs.remotePath(p))
+			fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
+			if err == nil && stat != nil {
 				fh.BaseRev = stat.Revision
 				fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
 			}
@@ -2339,6 +2455,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		entry, _ := fs.inodes.GetEntry(input.NodeId)
 		if entry != nil && entry.Size > smallFileThreshold {
 			fh.Prefetch = NewPrefetcher(fs.client, fs.remotePath(p), entry.Size, fs.debugEnabled())
+			fh.Prefetch.SetPerfCounters(fs.perf)
 		}
 		// Atomically pin shadow for read-only opens so commit queue cleanup
 		// doesn't delete the shadow file while this handle is reading from it.
@@ -2380,6 +2497,11 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 	source := "unknown"
 	bytesRead := -1
 	defer func() {
+		var perfBytes uint64
+		if bytesRead > 0 {
+			perfBytes = uint64(bytesRead)
+		}
+		fs.perfRecordFuse(perfFuseRead, start, status, perfBytes)
 		if !fs.debugEnabled() {
 			return
 		}
@@ -2620,11 +2742,17 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		offset := int64(input.Offset)
 		size := int(input.Size)
 		if data, ok := fh.Prefetch.Get(offset, size); ok {
+			if fs.perf != nil {
+				fs.perf.prefetchHit.add(1)
+			}
 			// Trigger next prefetch
 			fh.Prefetch.OnRead(offset, len(data))
 			source = "prefetch-hit"
 			bytesRead = len(data)
 			return gofuse.ReadResultData(data), gofuse.OK
+		}
+		if fs.perf != nil {
+			fs.perf.prefetchMiss.add(1)
 		}
 		// Cache miss — fall through to direct read. Prefetch is triggered
 		// only after a successful read (see below), not unconditionally.
@@ -2639,6 +2767,9 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		cacheRev := entry.Revision // use revision from last Stat/Lookup
 		// Fast path: serve from cache without any HTTP call.
 		if data, ok := fs.readCache.Get(p, cacheRev); ok {
+			if fs.perf != nil {
+				fs.perf.readCacheHit.add(1)
+			}
 			offset := int64(input.Offset)
 			if offset >= int64(len(data)) {
 				source = "read-cache-eof"
@@ -2652,6 +2783,9 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 			source = "read-cache-hit"
 			bytesRead = int(end - offset)
 			return gofuse.ReadResultData(data[offset:end]), gofuse.OK
+		}
+		if fs.perf != nil {
+			fs.perf.readCacheMiss.add(1)
 		}
 
 		// Cache miss: read the file and store it. No separate Stat needed —
@@ -2713,6 +2847,7 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 	var logIno uint64
 	source := "start"
 	defer func() {
+		fs.perfRecordFuse(perfFuseWrite, start, status, uint64(written))
 		if !fs.debugEnabled() {
 			return
 		}
@@ -2799,6 +2934,8 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 }
 
 func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseFlush, perfStart, status, 0) }()
 	fh, ok := fs.fileHandles.Get(input.Fh)
 	if !ok {
 		return gofuse.OK
@@ -2935,6 +3072,11 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			fh.Unlock()
 			err := uploadFromShadowRemote(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevisionForHandle(fh))
 			fh.Lock()
+			var uploadBytes uint64
+			if size > 0 {
+				uploadBytes = uint64(size)
+			}
+			fs.perfRecordRemote(perfRemoteWrite, uploadStart, err, uploadBytes)
 			fs.debugDurationf(uploadStart, 0, "flush shadowspill upload done path=%s size=%d err=%v", fh.Path, size, err)
 			if err != nil {
 				log.Printf("flush: ShadowSpill sync upload failed for %s: %v", fh.Path, err)
@@ -2995,6 +3137,8 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 }
 
 func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseFsync, perfStart, status, 0) }()
 	fh, ok := fs.fileHandles.Get(input.Fh)
 	if !ok {
 		return gofuse.OK
@@ -3088,6 +3232,11 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		fh.Unlock()
 		err := uploadFromShadowRemote(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevisionForHandle(fh))
 		fh.Lock()
+		var uploadBytes uint64
+		if size > 0 {
+			uploadBytes = uint64(size)
+		}
+		fs.perfRecordRemote(perfRemoteWrite, uploadStart, err, uploadBytes)
 		fs.debugDurationf(uploadStart, 0, "fsync shadowspill upload done path=%s size=%d err=%v", fh.Path, size, err)
 		if err != nil {
 			log.Printf("fsync: ShadowSpill sync upload failed for %s: %v", fh.Path, err)
@@ -3136,6 +3285,9 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 }
 
 func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
+	perfStart := fs.perfStart()
+	releaseStatus := gofuse.OK
+	defer func() { fs.perfRecordFuse(perfFuseRelease, perfStart, releaseStatus, 0) }()
 	fh, ok := fs.fileHandles.Get(input.Fh)
 	if ok {
 		defer func() {
@@ -3154,6 +3306,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 		start := time.Now()
 		phase := "start"
 		flushStatus := gofuse.OK
+		defer func() { releaseStatus = flushStatus }()
 		fs.debugf("release start path=%s fh=%d ino=%d", fh.Path, input.Fh, fh.Ino)
 		defer func() {
 			if !fs.debugEnabled() {
@@ -3214,6 +3367,11 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				uploadStart := time.Now()
 				fs.debugf("release shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 				uploadErr := uploadFromShadowRemote(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevisionForHandle(fh))
+				var uploadBytes uint64
+				if size > 0 {
+					uploadBytes = uint64(size)
+				}
+				fs.perfRecordRemote(perfRemoteWrite, uploadStart, uploadErr, uploadBytes)
 				fs.debugDurationf(uploadStart, 0, "release shadowspill upload done path=%s size=%d err=%v", fh.Path, size, uploadErr)
 				if uploadErr != nil {
 					flushStatus = gofuse.EIO
@@ -3371,8 +3529,10 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		}
 
 		dCtx, dCf := context.WithTimeout(context.Background(), fuseTimeout)
+		writeStart := fs.perfStart()
 		committedRev, err := fs.client.WriteCtxConditionalWithRevision(dCtx, fs.remotePath(filePath), data, expectedRevision)
 		dCf()
+		fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
 		if err != nil {
 			handle.Unlock()
 			log.Printf("debounced flush failed for %s: %v", filePath, err)
@@ -3490,9 +3650,15 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		uploadStart := time.Now()
 		fs.debugf("flushHandle finish streaming start path=%s size=%d part_size=%d parts=%d dirty_parts=%d expected_rev=%d", fh.Path, size, partSize, numParts, len(dirtyParts), expectedRevision)
 		fh.Unlock()
+		perfUploadStart := fs.perfStart()
 		err = streamer.FinishStreaming(ctx, size,
 			lastPartNum, lastCp, dirtyParts)
 		fh.Lock()
+		var perfUploadBytes uint64
+		if size > 0 {
+			perfUploadBytes = uint64(size)
+		}
+		fs.perfRecordRemote(perfRemoteWrite, perfUploadStart, err, perfUploadBytes)
 		fs.debugDurationf(uploadStart, 0, "flushHandle finish streaming done path=%s size=%d err=%v", fh.Path, size, err)
 
 		if err != nil {
@@ -3542,8 +3708,14 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		uploadStart := time.Now()
 		fs.debugf("flushHandle upload all start path=%s size=%d parts=%d expected_rev=%d", fh.Path, size, len(partSnapshots), expectedRevision)
 		fh.Unlock()
+		perfUploadStart := fs.perfStart()
 		err = streamer.UploadAll(ctx, size, partSnapshots)
 		fh.Lock()
+		var perfUploadBytes uint64
+		if size > 0 {
+			perfUploadBytes = uint64(size)
+		}
+		fs.perfRecordRemote(perfRemoteWrite, perfUploadStart, err, perfUploadBytes)
 		fs.debugDurationf(uploadStart, 0, "flushHandle upload all done path=%s size=%d parts=%d err=%v", fh.Path, size, len(partSnapshots), err)
 
 		if err != nil {
@@ -3581,6 +3753,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		writeStart := time.Now()
 		fs.debugf("flushHandle small write start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
 		committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), data, expectedRevision)
+		fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
 		fs.debugDurationf(writeStart, 0, "flushHandle small write done path=%s size=%d committed_rev=%d err=%v", fh.Path, size, committedRev, err)
 	} else if fh.OrigSize >= smallFileThreshold {
 		phase = "patch-file"
@@ -3612,6 +3785,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 				client.WithPartSize(fh.Dirty.PartSize()),
 				client.WithExpectedRevision(expectedRevision),
 			)
+			var patchBytes uint64
+			if size > 0 {
+				patchBytes = uint64(size)
+			}
+			fs.perfRecordRemote(perfRemoteWrite, patchStart, err, patchBytes)
 			fs.debugDurationf(patchStart, 0, "flushHandle patch done path=%s size=%d dirty_parts=%d err=%v", fh.Path, size, len(dirtyParts), err)
 		}
 		// If no dirty parts, nothing changed — skip upload.
@@ -3628,6 +3806,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			nil,
 			expectedRevision,
 		)
+		fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
 		fs.debugDurationf(writeStart, 0, "flushHandle write stream done path=%s size=%d err=%v", fh.Path, size, err)
 	}
 	if err != nil {
@@ -3710,6 +3889,10 @@ func (fs *Dat9FS) FlushAll() {
 
 	// Wait for any inflight async kernel notifications to complete.
 	fs.notifyWg.Wait()
+
+	if fs.perf != nil {
+		fs.perf.printSummary(os.Stderr)
+	}
 }
 
 // StatFs reports a generous virtual capacity so that apps (Obsidian, Finder)

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -49,6 +49,7 @@ type MountOptions struct {
 	AllowOther         bool          // allow other users to access mount
 	ReadOnly           bool          // mount as read-only
 	Debug              bool          // enable FUSE debug logging
+	PerfCounters       bool          // print low-overhead FUSE perf counter summary on shutdown
 }
 
 func (o *MountOptions) setDefaults() {
@@ -242,6 +243,7 @@ func Mount(opts *MountOptions) error {
 			// Initialize CommitQueue for background remote commits.
 			if shadowStore != nil && pendingIdx != nil {
 				cq := NewCommitQueue(c, shadowStore, pendingIdx, journal, opts.UploadConcurrency, maxCommitQueuePending, opts.RemoteRoot)
+				cq.SetPerfCounters(dat9fs.perf)
 				cq.OnSuccess = dat9fs.onCommitQueueSuccess
 				cq.OnCleanup = dat9fs.onCommitQueueCleanup
 				cq.RecoverPending()
@@ -250,6 +252,7 @@ func Mount(opts *MountOptions) error {
 
 			if wbCache != nil {
 				uploader := NewWriteBackUploader(c, wbCache, opts.UploadConcurrency, opts.RemoteRoot)
+				uploader.SetPerfCounters(dat9fs.perf)
 				dat9fs.SetWriteBack(wbCache, uploader)
 				// Recover pending uploads only when the newer commit queue is
 				// unavailable. Otherwise commitQueue owns shadow-backed recovery.

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -1,0 +1,318 @@
+package fuse
+
+import (
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+)
+
+type perfFuseOp int
+
+const (
+	perfFuseLookup perfFuseOp = iota
+	perfFuseGetAttr
+	perfFuseOpenDir
+	perfFuseReadDir
+	perfFuseReadDirPlus
+	perfFuseOpen
+	perfFuseRead
+	perfFuseWrite
+	perfFuseFlush
+	perfFuseFsync
+	perfFuseRelease
+	perfFuseCreate
+	perfFuseMkdir
+	perfFuseUnlink
+	perfFuseRmdir
+	perfFuseRename
+	perfFuseSetAttr
+	perfFuseOpCount
+)
+
+var perfFuseOpNames = [...]string{
+	perfFuseLookup:      "lookup",
+	perfFuseGetAttr:     "getattr",
+	perfFuseOpenDir:     "opendir",
+	perfFuseReadDir:     "readdir",
+	perfFuseReadDirPlus: "readdirplus",
+	perfFuseOpen:        "open",
+	perfFuseRead:        "read",
+	perfFuseWrite:       "write",
+	perfFuseFlush:       "flush",
+	perfFuseFsync:       "fsync",
+	perfFuseRelease:     "release",
+	perfFuseCreate:      "create",
+	perfFuseMkdir:       "mkdir",
+	perfFuseUnlink:      "unlink",
+	perfFuseRmdir:       "rmdir",
+	perfFuseRename:      "rename",
+	perfFuseSetAttr:     "setattr",
+}
+
+type perfRemoteOp int
+
+const (
+	perfRemoteStat perfRemoteOp = iota
+	perfRemoteList
+	perfRemoteRead
+	perfRemoteWrite
+	perfRemoteMutation
+	perfRemoteOpCount
+)
+
+var perfRemoteOpNames = [...]string{
+	perfRemoteStat:     "stat",
+	perfRemoteList:     "list",
+	perfRemoteRead:     "read",
+	perfRemoteWrite:    "write",
+	perfRemoteMutation: "mutation",
+}
+
+type perfOpStats struct {
+	count   uint64
+	errors  uint64
+	bytes   uint64
+	totalNS uint64
+}
+
+type fusePerfCounters struct {
+	enabled bool
+	start   time.Time
+
+	fuseOps   [perfFuseOpCount]perfAtomicStats
+	remoteOps [perfRemoteOpCount]perfAtomicStats
+
+	readCacheHit  atomicUint64
+	readCacheMiss atomicUint64
+	dirCacheHit   atomicUint64
+	dirCacheMiss  atomicUint64
+	prefetchHit   atomicUint64
+	prefetchMiss  atomicUint64
+
+	lookupRetryTotal     atomicUint64
+	lookupRetrySuccess   atomicUint64
+	lookupRetryExhausted atomicUint64
+	readRetryTotal       atomicUint64
+	readRetrySuccess     atomicUint64
+	readRetryExhausted   atomicUint64
+
+	commitEnqueue      atomicUint64
+	commitEnqueueError atomicUint64
+	commitRetry        atomicUint64
+	commitSuccess      atomicUint64
+	commitFailure      atomicUint64
+
+	uploaderSubmit       atomicUint64
+	uploaderSyncFallback atomicUint64
+	uploaderSuccess      atomicUint64
+	uploaderFailure      atomicUint64
+
+	commitDrainCount   atomicUint64
+	commitDrainTotalNS atomicUint64
+	uploaderDrainCount atomicUint64
+	uploaderDrainTotal atomicUint64
+
+	sseChange       atomicUint64
+	sseReset        atomicUint64
+	sseSelfFiltered atomicUint64
+
+	notifyEntry atomicUint64
+	notifyInode atomicUint64
+}
+
+// atomicUint64 is a small wrapper around sync/atomic.Uint64. Keeping it local
+// keeps tests compact and avoids map allocations on FUSE hot paths.
+type atomicUint64 struct {
+	v uint64
+}
+
+func (a *atomicUint64) add(n uint64) { atomic.AddUint64(&a.v, n) }
+func (a *atomicUint64) load() uint64 { return atomic.LoadUint64(&a.v) }
+
+type perfAtomicStats struct {
+	count   atomicUint64
+	errors  atomicUint64
+	bytes   atomicUint64
+	totalNS atomicUint64
+}
+
+func newFusePerfCounters(enabled bool) *fusePerfCounters {
+	if !enabled {
+		return nil
+	}
+	return &fusePerfCounters{
+		enabled: true,
+		start:   time.Now(),
+	}
+}
+
+func (p *fusePerfCounters) isEnabled() bool {
+	return p != nil && p.enabled
+}
+
+func (p *fusePerfCounters) recordFuseOp(op perfFuseOp, status gofuse.Status, dur time.Duration, bytes uint64) {
+	if !p.isEnabled() || op < 0 || op >= perfFuseOpCount {
+		return
+	}
+	p.fuseOps[op].record(status != gofuse.OK, dur, bytes)
+}
+
+func (p *fusePerfCounters) recordRemoteOp(op perfRemoteOp, err error, dur time.Duration, bytes uint64) {
+	if !p.isEnabled() || op < 0 || op >= perfRemoteOpCount {
+		return
+	}
+	p.remoteOps[op].record(err != nil, dur, bytes)
+}
+
+func (s *perfAtomicStats) record(failed bool, dur time.Duration, bytes uint64) {
+	s.count.add(1)
+	if failed {
+		s.errors.add(1)
+	}
+	if bytes > 0 {
+		s.bytes.add(bytes)
+	}
+	if dur > 0 {
+		s.totalNS.add(uint64(dur))
+	}
+}
+
+func (s *perfAtomicStats) snapshot() perfOpStats {
+	return perfOpStats{
+		count:   s.count.load(),
+		errors:  s.errors.load(),
+		bytes:   s.bytes.load(),
+		totalNS: s.totalNS.load(),
+	}
+}
+
+type fusePerfSnapshot struct {
+	Uptime    time.Duration
+	FuseOps   map[string]perfOpStats
+	RemoteOps map[string]perfOpStats
+	Counters  map[string]uint64
+}
+
+func (p *fusePerfCounters) snapshot() fusePerfSnapshot {
+	if !p.isEnabled() {
+		return fusePerfSnapshot{}
+	}
+	snap := fusePerfSnapshot{
+		Uptime:    time.Since(p.start),
+		FuseOps:   make(map[string]perfOpStats, len(p.fuseOps)),
+		RemoteOps: make(map[string]perfOpStats, len(p.remoteOps)),
+		Counters:  make(map[string]uint64, 32),
+	}
+	for i, stats := range p.fuseOps {
+		snap.FuseOps[perfFuseOpNames[i]] = stats.snapshot()
+	}
+	for i, stats := range p.remoteOps {
+		snap.RemoteOps[perfRemoteOpNames[i]] = stats.snapshot()
+	}
+	snap.Counters["read_cache_hit"] = p.readCacheHit.load()
+	snap.Counters["read_cache_miss"] = p.readCacheMiss.load()
+	snap.Counters["dir_cache_hit"] = p.dirCacheHit.load()
+	snap.Counters["dir_cache_miss"] = p.dirCacheMiss.load()
+	snap.Counters["prefetch_hit"] = p.prefetchHit.load()
+	snap.Counters["prefetch_miss"] = p.prefetchMiss.load()
+	snap.Counters["lookup_retry_total"] = p.lookupRetryTotal.load()
+	snap.Counters["lookup_retry_success"] = p.lookupRetrySuccess.load()
+	snap.Counters["lookup_retry_exhausted"] = p.lookupRetryExhausted.load()
+	snap.Counters["read_retry_total"] = p.readRetryTotal.load()
+	snap.Counters["read_retry_success"] = p.readRetrySuccess.load()
+	snap.Counters["read_retry_exhausted"] = p.readRetryExhausted.load()
+	snap.Counters["commit_enqueue"] = p.commitEnqueue.load()
+	snap.Counters["commit_enqueue_error"] = p.commitEnqueueError.load()
+	snap.Counters["commit_retry"] = p.commitRetry.load()
+	snap.Counters["commit_success"] = p.commitSuccess.load()
+	snap.Counters["commit_failure"] = p.commitFailure.load()
+	snap.Counters["uploader_submit"] = p.uploaderSubmit.load()
+	snap.Counters["uploader_sync_fallback"] = p.uploaderSyncFallback.load()
+	snap.Counters["uploader_success"] = p.uploaderSuccess.load()
+	snap.Counters["uploader_failure"] = p.uploaderFailure.load()
+	snap.Counters["commit_drain_count"] = p.commitDrainCount.load()
+	snap.Counters["commit_drain_total_ns"] = p.commitDrainTotalNS.load()
+	snap.Counters["uploader_drain_count"] = p.uploaderDrainCount.load()
+	snap.Counters["uploader_drain_total_ns"] = p.uploaderDrainTotal.load()
+	snap.Counters["sse_change"] = p.sseChange.load()
+	snap.Counters["sse_reset"] = p.sseReset.load()
+	snap.Counters["sse_self_filtered"] = p.sseSelfFiltered.load()
+	snap.Counters["notify_entry"] = p.notifyEntry.load()
+	snap.Counters["notify_inode"] = p.notifyInode.load()
+	return snap
+}
+
+func (p *fusePerfCounters) printSummary(w io.Writer) {
+	if !p.isEnabled() || w == nil {
+		return
+	}
+	snap := p.snapshot()
+	writePerfLine(w, "dat9: FUSE perf summary uptime=%s\n", snap.Uptime.Truncate(time.Millisecond))
+	writePerfOps(w, "fuse", perfFuseOpNames[:], snap.FuseOps)
+	writePerfOps(w, "remote", perfRemoteOpNames[:], snap.RemoteOps)
+	writePerfLine(w, "dat9: perf cache read_hit=%d read_miss=%d dir_hit=%d dir_miss=%d prefetch_hit=%d prefetch_miss=%d\n",
+		snap.Counters["read_cache_hit"], snap.Counters["read_cache_miss"],
+		snap.Counters["dir_cache_hit"], snap.Counters["dir_cache_miss"],
+		snap.Counters["prefetch_hit"], snap.Counters["prefetch_miss"])
+	writePerfLine(w, "dat9: perf retries lookup_total=%d lookup_success=%d lookup_exhausted=%d read_total=%d read_success=%d read_exhausted=%d\n",
+		snap.Counters["lookup_retry_total"], snap.Counters["lookup_retry_success"], snap.Counters["lookup_retry_exhausted"],
+		snap.Counters["read_retry_total"], snap.Counters["read_retry_success"], snap.Counters["read_retry_exhausted"])
+	writePerfLine(w, "dat9: perf commit enqueue=%d enqueue_errors=%d retries=%d success=%d failure=%d drain_count=%d drain_total=%s\n",
+		snap.Counters["commit_enqueue"], snap.Counters["commit_enqueue_error"], snap.Counters["commit_retry"],
+		snap.Counters["commit_success"], snap.Counters["commit_failure"],
+		snap.Counters["commit_drain_count"], time.Duration(snap.Counters["commit_drain_total_ns"]).Truncate(time.Millisecond))
+	writePerfLine(w, "dat9: perf uploader submit=%d sync_fallback=%d success=%d failure=%d drain_count=%d drain_total=%s\n",
+		snap.Counters["uploader_submit"], snap.Counters["uploader_sync_fallback"],
+		snap.Counters["uploader_success"], snap.Counters["uploader_failure"],
+		snap.Counters["uploader_drain_count"], time.Duration(snap.Counters["uploader_drain_total_ns"]).Truncate(time.Millisecond))
+	writePerfLine(w, "dat9: perf sse change=%d reset=%d self_filtered=%d notify_entry=%d notify_inode=%d\n",
+		snap.Counters["sse_change"], snap.Counters["sse_reset"], snap.Counters["sse_self_filtered"],
+		snap.Counters["notify_entry"], snap.Counters["notify_inode"])
+}
+
+func writePerfOps(w io.Writer, group string, names []string, stats map[string]perfOpStats) {
+	for _, name := range names {
+		st := stats[name]
+		if st.count == 0 {
+			continue
+		}
+		avg := time.Duration(0)
+		if st.count > 0 && st.totalNS > 0 {
+			avg = time.Duration(st.totalNS / st.count)
+		}
+		writePerfLine(w, "dat9: perf %s %s count=%d errors=%d bytes=%d avg=%s\n",
+			group, name, st.count, st.errors, st.bytes, avg.Truncate(time.Microsecond))
+	}
+}
+
+func writePerfLine(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...)
+}
+
+func (fs *Dat9FS) perfEnabled() bool {
+	return fs != nil && fs.perf != nil && fs.perf.enabled
+}
+
+func (fs *Dat9FS) perfStart() time.Time {
+	if !fs.perfEnabled() {
+		return time.Time{}
+	}
+	return time.Now()
+}
+
+func (fs *Dat9FS) perfRecordFuse(op perfFuseOp, start time.Time, status gofuse.Status, bytes uint64) {
+	if !fs.perfEnabled() || start.IsZero() {
+		return
+	}
+	fs.perf.recordFuseOp(op, status, time.Since(start), bytes)
+}
+
+func (fs *Dat9FS) perfRecordRemote(op perfRemoteOp, start time.Time, err error, bytes uint64) {
+	if !fs.perfEnabled() || start.IsZero() {
+		return
+	}
+	fs.perf.recordRemoteOp(op, err, time.Since(start), bytes)
+}

--- a/pkg/fuse/perf_test.go
+++ b/pkg/fuse/perf_test.go
@@ -1,0 +1,158 @@
+package fuse
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+func TestFusePerfCountersSummary(t *testing.T) {
+	perf := newFusePerfCounters(true)
+	perf.recordFuseOp(perfFuseLookup, gofuse.OK, 10*time.Millisecond, 0)
+	perf.recordFuseOp(perfFuseRead, gofuse.EIO, 20*time.Millisecond, 128)
+	perf.recordRemoteOp(perfRemoteRead, nil, 5*time.Millisecond, 128)
+	perf.readCacheHit.add(2)
+	perf.readCacheMiss.add(1)
+	perf.lookupRetryTotal.add(1)
+	perf.lookupRetrySuccess.add(1)
+	perf.commitEnqueue.add(1)
+	perf.commitSuccess.add(1)
+	perf.uploaderSubmit.add(1)
+	perf.sseChange.add(1)
+	perf.notifyEntry.add(1)
+
+	snap := perf.snapshot()
+	if got := snap.FuseOps["lookup"].count; got != 1 {
+		t.Fatalf("lookup count = %d, want 1", got)
+	}
+	if got := snap.FuseOps["read"].errors; got != 1 {
+		t.Fatalf("read errors = %d, want 1", got)
+	}
+	if got := snap.RemoteOps["read"].bytes; got != 128 {
+		t.Fatalf("remote read bytes = %d, want 128", got)
+	}
+	if got := snap.Counters["read_cache_hit"]; got != 2 {
+		t.Fatalf("read cache hits = %d, want 2", got)
+	}
+
+	var out bytes.Buffer
+	perf.printSummary(&out)
+	text := out.String()
+	for _, want := range []string{
+		"dat9: FUSE perf summary",
+		"perf fuse lookup count=1",
+		"perf fuse read count=1 errors=1 bytes=128",
+		"perf remote read count=1",
+		"perf cache read_hit=2 read_miss=1",
+		"perf retries lookup_total=1 lookup_success=1",
+		"perf commit enqueue=1",
+		"perf uploader submit=1",
+		"perf sse change=1",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("summary missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestFusePerfDisabledByDefault(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    time.Second,
+	}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://127.0.0.1", ""), opts)
+	if fs.perf != nil {
+		t.Fatal("perf counters should be nil when disabled")
+	}
+	fs.notifyEntry(1, "x")
+	fs.notifyInode(1)
+}
+
+func TestFusePerfCountsNotifyAndSSE(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize:    1 << 20,
+		DirTTL:       time.Second,
+		PerfCounters: true,
+	}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://127.0.0.1", ""), opts)
+	fs.inodes.Lookup("/file.txt", false, 4, time.Now())
+
+	watcher := &SSEWatcher{fs: fs, actor: "actor-a"}
+	watcher.handleEvent(&client.ChangeEvent{Path: "/file.txt", Actor: "actor-a"}, nil)
+	watcher.handleEvent(&client.ChangeEvent{Path: "/file.txt", Actor: "actor-b"}, nil)
+	watcher.handleEvent(nil, &client.ResetEvent{Reason: "structural_change", Actor: "actor-a"})
+	watcher.handleEvent(nil, &client.ResetEvent{Reason: "structural_change", Actor: "actor-b"})
+
+	snap := fs.perf.snapshot()
+	if got := snap.Counters["sse_self_filtered"]; got != 2 {
+		t.Fatalf("sse self-filtered = %d, want 2", got)
+	}
+	if got := snap.Counters["sse_change"]; got != 1 {
+		t.Fatalf("sse change = %d, want 1", got)
+	}
+	if got := snap.Counters["sse_reset"]; got != 1 {
+		t.Fatalf("sse reset = %d, want 1", got)
+	}
+	if got := snap.Counters["notify_inode"]; got == 0 {
+		t.Fatal("notify inode counter should be incremented by change/reset")
+	}
+}
+
+func TestCommitQueuePerfCounters(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":9}`))
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull("/ok.txt", []byte("data"), 8); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/ok.txt", 4, PendingOverwrite, 8); err != nil {
+		t.Fatal(err)
+	}
+
+	perf := newFusePerfCounters(true)
+	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq.SetPerfCounters(perf)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:    "/ok.txt",
+		BaseRev: 8,
+		Size:    4,
+		Kind:    PendingOverwrite,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	snap := perf.snapshot()
+	if got := snap.Counters["commit_enqueue"]; got != 1 {
+		t.Fatalf("commit enqueue = %d, want 1", got)
+	}
+	if got := snap.Counters["commit_success"]; got != 1 {
+		t.Fatalf("commit success = %d, want 1", got)
+	}
+	if got := snap.RemoteOps["write"].count; got != 1 {
+		t.Fatalf("remote write count = %d, want 1", got)
+	}
+	if got := snap.Counters["commit_drain_count"]; got != 1 {
+		t.Fatalf("commit drain count = %d, want 1", got)
+	}
+}

--- a/pkg/fuse/prefetch.go
+++ b/pkg/fuse/prefetch.go
@@ -55,6 +55,7 @@ type Prefetcher struct {
 	ctx        context.Context    // parent context for prefetch goroutines
 	closed     bool
 	debug      bool
+	perf       *fusePerfCounters
 }
 
 // NewPrefetcher creates a Prefetcher for the given file.
@@ -76,6 +77,10 @@ func NewPrefetcher(c *client.Client, path string, fileSize int64, debug ...bool)
 		cancel:     cancel,
 		debug:      debugEnabled,
 	}
+}
+
+func (p *Prefetcher) SetPerfCounters(perf *fusePerfCounters) {
+	p.perf = perf
 }
 
 func (p *Prefetcher) debugf(format string, args ...any) {
@@ -300,6 +305,9 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 
 		rc, err := p.client.ReadStreamRange(ctx, p.path, offset, length)
 		if err != nil {
+			if p.perf != nil {
+				p.perf.recordRemoteOp(perfRemoteRead, err, time.Since(start), 0)
+			}
 			for _, b := range blocks {
 				b.err = err
 			}
@@ -309,6 +317,9 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 		defer func() { _ = rc.Close() }()
 
 		data, err := io.ReadAll(rc)
+		if p.perf != nil {
+			p.perf.recordRemoteOp(perfRemoteRead, err, time.Since(start), uint64(len(data)))
+		}
 		if err != nil {
 			for _, b := range blocks {
 				b.err = err

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -46,14 +46,26 @@ func (w *SSEWatcher) handleEvent(change *client.ChangeEvent, reset *client.Reset
 	if change != nil {
 		// Skip events from our own mount.
 		if w.actor != "" && change.Actor == w.actor {
+			if w.fs != nil && w.fs.perf != nil {
+				w.fs.perf.sseSelfFiltered.add(1)
+			}
 			return
+		}
+		if w.fs != nil && w.fs.perf != nil {
+			w.fs.perf.sseChange.add(1)
 		}
 		w.handleChange(change)
 		return
 	}
 	if reset != nil && reset.Reason != "" {
 		if w.actor != "" && reset.Reason == "structural_change" && reset.Actor == w.actor {
+			if w.fs != nil && w.fs.perf != nil {
+				w.fs.perf.sseSelfFiltered.add(1)
+			}
 			return
+		}
+		if w.fs != nil && w.fs.perf != nil {
+			w.fs.perf.sseReset.add(1)
 		}
 		// Only handle resets with an explicit reason (not heartbeats).
 		w.handleReset(reset)

--- a/pkg/fuse/writeback_uploader.go
+++ b/pkg/fuse/writeback_uploader.go
@@ -56,6 +56,8 @@ type WriteBackUploader struct {
 	// Per-path in-flight tracking.
 	inflightMu sync.Mutex
 	inflight   map[string]*pathState
+
+	perf *fusePerfCounters
 }
 
 // NewWriteBackUploader creates and starts a background uploader with
@@ -91,12 +93,22 @@ func (u *WriteBackUploader) remotePath(localPath string) string {
 	return mountpath.ToRemote(root, localPath)
 }
 
+func (u *WriteBackUploader) SetPerfCounters(perf *fusePerfCounters) {
+	u.perf = perf
+}
+
 // Submit enqueues a local namespace path for background upload. Blocks up to 5s if the
 // channel is full; on timeout, falls back to synchronous upload in the current
 // goroutine so data is never silently dropped.
 func (u *WriteBackUploader) Submit(localPath string) {
+	if u.perf != nil {
+		u.perf.uploaderSubmit.add(1)
+	}
 	if u.stopped.Load() {
 		log.Printf("writeback uploader: already stopped, uploading synchronously for %s", localPath)
+		if u.perf != nil {
+			u.perf.uploaderSyncFallback.add(1)
+		}
 		u.uploadOne(localPath)
 		return
 	}
@@ -110,6 +122,9 @@ func (u *WriteBackUploader) Submit(localPath string) {
 		case u.uploadCh <- localPath:
 		case <-timer.C:
 			log.Printf("writeback uploader: channel full after %v, uploading synchronously for %s", submitTimeout, localPath)
+			if u.perf != nil {
+				u.perf.uploaderSyncFallback.add(1)
+			}
 			u.uploadOne(localPath)
 		}
 	}
@@ -131,6 +146,13 @@ func (u *WriteBackUploader) WaitPath(localPath string) {
 // DrainAll closes the upload channel and waits for all inflight uploads to
 // complete. Called during graceful shutdown.
 func (u *WriteBackUploader) DrainAll() {
+	start := time.Now()
+	defer func() {
+		if u.perf != nil {
+			u.perf.uploaderDrainCount.add(1)
+			u.perf.uploaderDrainTotal.add(uint64(time.Since(start)))
+		}
+	}()
 	u.stopOnce.Do(func() {
 		u.stopped.Store(true)
 		close(u.uploadCh)
@@ -243,8 +265,12 @@ func (u *WriteBackUploader) uploadOne(localPath string) {
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), uploadTimeout)
+		uploadStart := time.Now()
 		lastErr = uploadBufferedRemoteFile(ctx, u.client, u.remotePath(localPath), data, expectedRevision)
 		cancel()
+		if u.perf != nil {
+			u.perf.recordRemoteOp(perfRemoteWrite, lastErr, time.Since(uploadStart), uint64(len(data)))
+		}
 
 		if lastErr == nil {
 			break
@@ -256,6 +282,9 @@ func (u *WriteBackUploader) uploadOne(localPath string) {
 	}
 
 	if lastErr != nil {
+		if u.perf != nil {
+			u.perf.uploaderFailure.add(1)
+		}
 		if errors.Is(lastErr, client.ErrConflict) {
 			// TODO: persist a conflict marker or resolution flow so these
 			// entries do not remain pending forever across mounts.
@@ -272,6 +301,9 @@ func (u *WriteBackUploader) uploadOne(localPath string) {
 	curMeta, ok := u.cache.GetMeta(localPath)
 	if ok && curMeta.Generation == gen {
 		u.cache.Remove(localPath)
+	}
+	if u.perf != nil {
+		u.perf.uploaderSuccess.add(1)
 	}
 }
 
@@ -307,7 +339,15 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) er
 		}
 	}
 
-	if err := uploadBufferedRemoteFile(ctx, u.client, u.remotePath(localPath), data, expectedRevision); err != nil {
+	uploadStart := time.Now()
+	err = uploadBufferedRemoteFile(ctx, u.client, u.remotePath(localPath), data, expectedRevision)
+	if u.perf != nil {
+		u.perf.recordRemoteOp(perfRemoteWrite, err, time.Since(uploadStart), uint64(len(data)))
+	}
+	if err != nil {
+		if u.perf != nil {
+			u.perf.uploaderFailure.add(1)
+		}
 		return err
 	}
 
@@ -315,6 +355,9 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) er
 	curMeta, ok := u.cache.GetMeta(localPath)
 	if ok && curMeta.Generation == gen {
 		u.cache.Remove(localPath)
+	}
+	if u.perf != nil {
+		u.perf.uploaderSuccess.add(1)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- add optional mount-level FUSE perf counters behind `drive9 mount --perf-counters`
- summarize FUSE ops, remote ops, cache hit/miss, retries, commit queue, uploader, SSE, and notify counters on shutdown
- wire counters into commit queue, writeback uploader, prefetch, SSE, and key FUSE paths

## Validation
- `/usr/local/go/bin/go test ./pkg/fuse -count=1`
- `/usr/local/go/bin/go test ./cmd/drive9/cli -run 'TestResolveMountCredentials|TestUmountArgv|TestRunUmount|TestParseMountMode|TestValidateRemoteRoot' -count=1`
- `/usr/local/go/bin/go test -c ./pkg/... ./cmd/...`
- `PATH=/usr/local/go/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/qiffang/.codex/tmp/arg0/codex-arg0CjlbdM:/Users/qiffang/.slock/agents/27e7bfef-4ef8-4cd6-ba5f-057142b2827e/.slock:/Users/qiffang/.npm/_npx/277f35d2ed0078b9/node_modules/.bin:/Users/qiffang/node_modules/.bin:/Users/node_modules/.bin:/node_modules/.bin:/opt/homebrew/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/node-gyp-bin:/Users/qiffang/.local/bin bin/golangci-lint run --timeout 10m --new-from-rev=origin/main ./pkg/fuse ./cmd/drive9/...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `-perf-counters` command-line flag to mount operations that prints a FUSE performance counter summary on unmount, providing low-overhead insights into file system operation performance and metrics.

* **Tests**
  * Added comprehensive test coverage for performance counter functionality, including unit and integration tests validating counter recording and event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->