### PR TITLE
Add batch stat API for FUSE listings

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -185,6 +185,28 @@ type StatResult struct {
 	Mtime    time.Time
 }
 
+// MaxBatchStatPaths is the maximum number of paths accepted by BatchStatCtx.
+const MaxBatchStatPaths = 256
+
+// BatchStatResult is one per-path result from BatchStatCtx.
+//
+// Status is the HTTP-like per-path status. A missing path returns Status 404
+// in its own result instead of failing the whole batch.
+type BatchStatResult struct {
+	Path     string `json:"path"`
+	Status   int    `json:"status"`
+	Error    string `json:"error,omitempty"`
+	Size     int64  `json:"size,omitempty"`
+	IsDir    bool   `json:"isDir"`
+	Revision int64  `json:"revision,omitempty"`
+	Mtime    int64  `json:"mtime,omitempty"` // Unix seconds, 0 means unknown
+}
+
+// OK reports whether the per-path batch stat result is successful.
+func (r BatchStatResult) OK() bool {
+	return r.Status >= 200 && r.Status < 300 && r.Error == ""
+}
+
 // StatMetadataResult represents enriched metadata from GET /v1/fs/{path}?stat=1.
 type StatMetadataResult struct {
 	Size         int64             `json:"size"`
@@ -414,6 +436,49 @@ func (c *Client) ListCtx(ctx context.Context, path string) ([]FileInfo, error) {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
 	return result.Entries, nil
+}
+
+// BatchStatCtx returns lightweight metadata for up to MaxBatchStatPaths paths.
+//
+// Transport/request errors fail the method. Per-path stat errors are returned
+// inside the corresponding BatchStatResult so one missing path does not fail
+// the whole batch.
+func (c *Client) BatchStatCtx(ctx context.Context, paths []string) ([]BatchStatResult, error) {
+	if len(paths) == 0 {
+		return []BatchStatResult{}, nil
+	}
+	if len(paths) > MaxBatchStatPaths {
+		return nil, fmt.Errorf("batch stat: %d paths exceeds limit of %d", len(paths), MaxBatchStatPaths)
+	}
+	body, err := json.Marshal(struct {
+		Paths []string `json:"paths"`
+	}{Paths: paths})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/fs:batch-stat", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var out struct {
+		Results []BatchStatResult `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	if len(out.Results) != len(paths) {
+		return nil, fmt.Errorf("batch stat: got %d results for %d paths", len(out.Results), len(paths))
+	}
+	return out.Results, nil
 }
 
 // Stat returns metadata for a path.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
@@ -96,6 +97,70 @@ func TestListDir(t *testing.T) {
 	}
 	if len(entries) != 2 {
 		t.Fatalf("expected 2, got %d", len(entries))
+	}
+}
+
+func TestBatchStatCtxPreservesPerPathErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/fs:batch-stat" {
+			t.Fatalf("path = %q, want /v1/fs:batch-stat", r.URL.Path)
+		}
+		var req struct {
+			Paths []string `json:"paths"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got, want := strings.Join(req.Paths, ","), "/ok.txt,/missing.txt,/ok.txt"; got != want {
+			t.Fatalf("paths = %q, want %q", got, want)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"path": "/ok.txt", "status": 200, "size": 7, "isDir": false, "revision": 3, "mtime": 11},
+				{"path": "/missing.txt", "status": 404, "error": "not found"},
+				{"path": "/ok.txt", "status": 200, "size": 7, "isDir": false, "revision": 3, "mtime": 11},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	results, err := c.BatchStatCtx(context.Background(), []string{"/ok.txt", "/missing.txt", "/ok.txt"})
+	if err != nil {
+		t.Fatalf("BatchStatCtx error = %v, want nil", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results len = %d, want 3", len(results))
+	}
+	if !results[0].OK() || results[0].Revision != 3 || results[0].Size != 7 || results[0].Mtime != 11 {
+		t.Fatalf("first result = %+v, want ok rev=3 size=7 mtime=11", results[0])
+	}
+	if results[1].OK() || results[1].Status != http.StatusNotFound {
+		t.Fatalf("second result = %+v, want per-path 404", results[1])
+	}
+	if !results[2].OK() || results[2].Path != "/ok.txt" {
+		t.Fatalf("third result = %+v, want duplicate ok path", results[2])
+	}
+}
+
+func TestBatchStatCtxRejectsTooManyPathsBeforeRequest(t *testing.T) {
+	var called bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer ts.Close()
+
+	paths := make([]string, MaxBatchStatPaths+1)
+	c := New(ts.URL, "")
+	_, err := c.BatchStatCtx(context.Background(), paths)
+	if err == nil {
+		t.Fatal("BatchStatCtx error = nil, want too-large error")
+	}
+	if called {
+		t.Fatal("server was called despite client-side batch limit")
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2035,10 +2035,44 @@ func (fs *Dat9FS) listDir(ctx context.Context, dirPath string) ([]DirEntry, erro
 			Mtime: mtime,
 		}
 	}
+	fs.applyBatchStats(ctx, dirPath, cached)
 	fs.dirCache.Put(dirPath, cached)
 
 	entries := fs.cachedToDirEntries(dirPath, cached)
 	return fs.mergePendingDirEntries(dirPath, entries), nil
+}
+
+func (fs *Dat9FS) applyBatchStats(ctx context.Context, dirPath string, items []CachedFileInfo) {
+	if len(items) == 0 {
+		return
+	}
+	for start := 0; start < len(items); start += client.MaxBatchStatPaths {
+		end := start + client.MaxBatchStatPaths
+		if end > len(items) {
+			end = len(items)
+		}
+		paths := make([]string, end-start)
+		for i := start; i < end; i++ {
+			paths[i-start] = fs.remotePath(dirEntryChildPath(dirPath, items[i].Name))
+		}
+		results, err := fs.client.BatchStatCtx(ctx, paths)
+		if err != nil {
+			log.Printf("batch stat failed for %s entries %d-%d: %v", dirPath, start, end, err)
+			return
+		}
+		for i, result := range results {
+			if !result.OK() {
+				continue
+			}
+			item := &items[start+i]
+			item.Size = result.Size
+			item.IsDir = result.IsDir
+			if result.Mtime > 0 {
+				item.Mtime = time.Unix(result.Mtime, 0)
+			}
+			item.Revision = result.Revision
+		}
+	}
 }
 
 // mergePendingDirEntries overlays pending write-back entries onto a directory
@@ -2117,18 +2151,16 @@ func (fs *Dat9FS) mergePendingDirEntries(dirPath string, entries []DirEntry) []D
 func (fs *Dat9FS) cachedToDirEntries(dirPath string, items []CachedFileInfo) []DirEntry {
 	entries := make([]DirEntry, 0, len(items))
 	for _, item := range items {
-		var childP string
-		if dirPath == "/" {
-			childP = "/" + item.Name
-		} else {
-			childP = dirPath + "/" + item.Name
-		}
+		childP := dirEntryChildPath(dirPath, item.Name)
 
 		mtime := item.Mtime
 		if mtime.IsZero() {
 			mtime = time.Now()
 		}
 		ino := fs.inodes.EnsureInode(childP, item.IsDir, item.Size, mtime)
+		if item.Revision > 0 {
+			fs.inodes.UpdateRevision(ino, item.Revision)
+		}
 
 		var mode uint32
 		if item.IsDir {
@@ -2143,6 +2175,13 @@ func (fs *Dat9FS) cachedToDirEntries(dirPath string, items []CachedFileInfo) []D
 		})
 	}
 	return entries
+}
+
+func dirEntryChildPath(dirPath, name string) string {
+	if dirPath == "/" {
+		return "/" + name
+	}
+	return dirPath + "/" + name
 }
 
 // --- File operations ---------------------------------------------------------

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -773,22 +774,44 @@ func TestLookupUsesRemoteRootMapping(t *testing.T) {
 }
 
 func TestListDirUsesRemoteRootMapping(t *testing.T) {
-	var gotPath string
-	var gotQuery string
+	var gotListPath string
+	var gotListQuery string
+	var gotBatchPath string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		gotQuery = r.URL.RawQuery
-		if r.Method != http.MethodGet {
-			t.Fatalf("method = %s, want GET", r.Method)
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			gotListPath = r.URL.Path
+			gotListQuery = r.URL.RawQuery
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []map[string]any{{
+					"name":  "nested.txt",
+					"isDir": false,
+					"size":  7,
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-stat":
+			gotBatchPath = r.URL.Path
+			var req struct {
+				Paths []string `json:"paths"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batch request: %v", err)
+			}
+			if got, want := strings.Join(req.Paths, ","), "/remote/subdir/nested.txt"; got != want {
+				t.Fatalf("batch stat paths = %q, want %q", got, want)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{{
+					"path":     "/remote/subdir/nested.txt",
+					"status":   200,
+					"isDir":    false,
+					"size":     7,
+					"revision": 3,
+				}},
+			})
+		default:
+			t.Fatalf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"entries": []map[string]any{{
-				"name":     "nested.txt",
-				"isDir":    false,
-				"size":     7,
-				"revision": 3,
-			}},
-		})
 	}))
 	defer ts.Close()
 
@@ -800,11 +823,105 @@ func TestListDirUsesRemoteRootMapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listDir error = %v, want nil", err)
 	}
-	if gotPath != "/v1/fs/remote/subdir" || gotQuery != "list=1" {
-		t.Fatalf("listDir request = %q?%s, want /v1/fs/remote/subdir?list=1", gotPath, gotQuery)
+	if gotListPath != "/v1/fs/remote/subdir" || gotListQuery != "list=1" {
+		t.Fatalf("listDir request = %q?%s, want /v1/fs/remote/subdir?list=1", gotListPath, gotListQuery)
+	}
+	if gotBatchPath != "/v1/fs:batch-stat" {
+		t.Fatalf("batch stat path = %q, want /v1/fs:batch-stat", gotBatchPath)
 	}
 	if len(entries) != 1 || entries[0].Name != "nested.txt" {
 		t.Fatalf("listDir entries = %+v, want nested.txt", entries)
+	}
+	entry, ok := fs.inodes.GetEntry(entries[0].Ino)
+	if !ok {
+		t.Fatal("listDir entry inode not found")
+	}
+	if entry.Revision != 3 {
+		t.Fatalf("entry revision = %d, want 3 from batch stat", entry.Revision)
+	}
+}
+
+func TestListDirIgnoresBatchStatPerPathFailure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []map[string]any{{
+					"name":  "listed.txt",
+					"isDir": false,
+					"size":  9,
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-stat":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{{
+					"path":   "/listed.txt",
+					"status": 404,
+					"error":  "not found",
+				}},
+			})
+		default:
+			t.Fatalf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	entries, err := fs.listDir(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("listDir error = %v, want nil", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "listed.txt" {
+		t.Fatalf("listDir entries = %+v, want listed.txt despite batch 404", entries)
+	}
+	entry, ok := fs.inodes.GetEntry(entries[0].Ino)
+	if !ok {
+		t.Fatal("listDir entry inode not found")
+	}
+	if entry.Size != 9 || entry.Revision != 0 {
+		t.Fatalf("entry = %+v, want list metadata preserved with no revision", entry)
+	}
+}
+
+func TestListDirIgnoresBatchStatTransportFailure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []map[string]any{{
+					"name":  "listed.txt",
+					"isDir": false,
+					"size":  9,
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-stat":
+			http.Error(w, "batch stat unavailable", http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	entries, err := fs.listDir(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("listDir error = %v, want nil", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "listed.txt" {
+		t.Fatalf("listDir entries = %+v, want listed.txt despite batch transport failure", entries)
+	}
+	entry, ok := fs.inodes.GetEntry(entries[0].Ino)
+	if !ok {
+		t.Fatal("listDir entry inode not found")
+	}
+	if entry.Size != 9 || entry.Revision != 0 {
+		t.Fatalf("entry = %+v, want list metadata preserved with no revision", entry)
 	}
 }
 

--- a/pkg/fuse/dir.go
+++ b/pkg/fuse/dir.go
@@ -11,10 +11,11 @@ const (
 
 // CachedFileInfo matches the client.FileInfo shape but avoids importing client.
 type CachedFileInfo struct {
-	Name  string
-	Size  int64
-	IsDir bool
-	Mtime time.Time
+	Name     string
+	Size     int64
+	IsDir    bool
+	Mtime    time.Time
+	Revision int64
 }
 
 type dirCacheEntry struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/embedding"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/tagutil"
 	"github.com/mem9-ai/dat9/pkg/tenant"
@@ -83,6 +84,8 @@ type TenantStatusResponse struct {
 	MaxUploadBytes int64  `json:"max_upload_bytes"`
 }
 
+const maxBatchStatPaths = 256
+
 func New(b *backend.Dat9Backend) *Server {
 	return NewWithConfig(Config{Backend: b})
 }
@@ -126,6 +129,7 @@ func NewWithConfig(cfg Config) *Server {
 	} else if cfg.Backend != nil {
 		business = injectFallbackBackend(cfg.Backend, business)
 	}
+	mux.Handle("/v1/fs:batch-stat", business)
 	mux.Handle("/v1/fs/", business)
 	mux.Handle("/v1/uploads", business)
 	mux.Handle("/v1/uploads/", business)
@@ -293,6 +297,8 @@ func (s *Server) ListenAndServe(addr string) error {
 
 func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 	switch {
+	case r.URL.Path == "/v1/fs:batch-stat":
+		s.handleBatchStat(w, r)
 	case strings.HasPrefix(r.URL.Path, "/v1/fs/"):
 		s.handleFS(w, r)
 	case r.URL.Path == "/v1/uploads/initiate":
@@ -1039,6 +1045,111 @@ func (s *Server) handleAppend(w http.ResponseWriter, r *http.Request, path strin
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(plan)
+}
+
+type batchStatRequest struct {
+	Paths []string `json:"paths"`
+}
+
+type batchStatResponse struct {
+	Results []batchStatResult `json:"results"`
+}
+
+type batchStatResult struct {
+	Path     string `json:"path"`
+	Status   int    `json:"status"`
+	Error    string `json:"error,omitempty"`
+	Size     int64  `json:"size,omitempty"`
+	IsDir    bool   `json:"isDir"`
+	Revision int64  `json:"revision,omitempty"`
+	Mtime    int64  `json:"mtime,omitempty"`
+}
+
+func (s *Server) handleBatchStat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_stat_method_not_allowed", "method", r.Method)...)
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_stat_missing_scope")...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+
+	var req batchStatRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_stat_decode_failed", "error", err)...)
+		errJSON(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if len(req.Paths) > maxBatchStatPaths {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_stat_too_large", "count", len(req.Paths), "limit", maxBatchStatPaths)...)
+		errJSON(w, http.StatusBadRequest, fmt.Sprintf("too many paths: %d exceeds limit %d", len(req.Paths), maxBatchStatPaths))
+		return
+	}
+
+	results := make([]batchStatResult, len(req.Paths))
+	for i, path := range req.Paths {
+		results[i] = s.batchStatOne(r.Context(), b, path)
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "batch_stat_ok", "count", len(results))...)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(batchStatResponse{Results: results})
+}
+
+func (s *Server) batchStatOne(ctx context.Context, b *backend.Dat9Backend, rawPath string) batchStatResult {
+	result := batchStatResult{Path: rawPath}
+	path := rawPath
+	if path == "" {
+		path = "/"
+	}
+	if err := validateBatchStatPath(path); err != nil {
+		result.Status = http.StatusBadRequest
+		result.Error = err.Error()
+		return result
+	}
+	if path == "/" {
+		result.Status = http.StatusOK
+		result.IsDir = true
+		return result
+	}
+
+	nf, err := b.StatNodeLiteCtx(ctx, path)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			result.Status = http.StatusNotFound
+			result.Error = err.Error()
+			return result
+		}
+		result.Status = http.StatusInternalServerError
+		result.Error = err.Error()
+		return result
+	}
+	result.Status = http.StatusOK
+	result.IsDir = nf.Node.IsDirectory
+	if nf.File != nil {
+		result.Size = nf.File.SizeBytes
+		result.Revision = nf.File.Revision
+		if nf.File.ConfirmedAt != nil {
+			result.Mtime = nf.File.ConfirmedAt.Unix()
+		} else {
+			result.Mtime = nf.File.CreatedAt.Unix()
+		}
+	} else {
+		result.Mtime = nf.Node.CreatedAt.Unix()
+	}
+	return result
+}
+
+func validateBatchStatPath(rawPath string) error {
+	if pathutil.IsDir(rawPath) {
+		_, err := pathutil.CanonicalizeDir(rawPath)
+		return err
+	}
+	_, err := pathutil.Canonicalize(rawPath)
+	return err
 }
 
 func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -271,6 +271,120 @@ func TestStat(t *testing.T) {
 	}
 }
 
+func TestBatchStatReturnsPerPathResults(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/data/a.txt", strings.NewReader("data"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write: %d", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/data/dir?mkdir", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mkdir: %d", resp.StatusCode)
+	}
+
+	body := `{"paths":["/data/a.txt","/data/dir","/missing.txt","/data/a.txt","/bad\\path"]}`
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs:batch-stat", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		response, _ := io.ReadAll(resp.Body)
+		t.Fatalf("batch stat status = %d, body %s", resp.StatusCode, response)
+	}
+	var out struct {
+		Results []struct {
+			Path     string `json:"path"`
+			Status   int    `json:"status"`
+			Error    string `json:"error"`
+			Size     int64  `json:"size"`
+			IsDir    bool   `json:"isDir"`
+			Revision int64  `json:"revision"`
+			Mtime    int64  `json:"mtime"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Results) != 5 {
+		t.Fatalf("results len = %d, want 5", len(out.Results))
+	}
+	if out.Results[0].Status != http.StatusOK || out.Results[0].Size != 4 || out.Results[0].IsDir || out.Results[0].Revision != 1 || out.Results[0].Mtime == 0 {
+		t.Fatalf("file result = %+v, want ok file metadata", out.Results[0])
+	}
+	if out.Results[1].Status != http.StatusOK || !out.Results[1].IsDir {
+		t.Fatalf("dir result = %+v, want ok directory metadata", out.Results[1])
+	}
+	if out.Results[2].Status != http.StatusNotFound || out.Results[2].Error == "" {
+		t.Fatalf("missing result = %+v, want per-path 404", out.Results[2])
+	}
+	if out.Results[3].Status != http.StatusOK || out.Results[3].Path != "/data/a.txt" {
+		t.Fatalf("duplicate result = %+v, want duplicate preserved", out.Results[3])
+	}
+	if out.Results[4].Status != http.StatusBadRequest || out.Results[4].Error == "" {
+		t.Fatalf("invalid path result = %+v, want per-path 400", out.Results[4])
+	}
+}
+
+func TestBatchStatEmptyAndTooLargeInputs(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs:batch-stat", strings.NewReader(`{"paths":[]}`))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var empty struct {
+		Results []struct{} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&empty); err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("empty status = %d, want 200", resp.StatusCode)
+	}
+	if len(empty.Results) != 0 {
+		t.Fatalf("empty results len = %d, want 0", len(empty.Results))
+	}
+
+	paths := make([]string, maxBatchStatPaths+1)
+	for i := range paths {
+		paths[i] = "/x.txt"
+	}
+	payload, err := json.Marshal(map[string][]string{"paths": paths})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs:batch-stat", strings.NewReader(string(payload)))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("too-large status = %d, want 400", resp.StatusCode)
+	}
+}
+
 func TestStatMetadataIncludesTagsAndSemanticText(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary
- add POST /v1/fs:batch-stat with explicit per-path status/error results and a 256-path limit
- add client BatchStatCtx preserving duplicate order and partial failures
- use batch stat after FUSE directory listing to seed inode revision/attrs without changing list semantics

## Semantics
- empty batch returns an empty result set
- oversized batch returns 400 before per-path processing
- missing/invalid paths are per-path 404/400 results and do not fail the whole batch
- FUSE treats batch stat as best-effort; listDir still succeeds on batch transport or per-path failure

## Validation
- /usr/local/go/bin/go test ./pkg/fuse -run 'TestListDirUsesRemoteRootMapping|TestListDirIgnoresBatchStatPerPathFailure' -count=1
- /usr/local/go/bin/go test ./pkg/fuse -count=1
- /usr/local/go/bin/go test -c ./pkg/client ./pkg/server ./pkg/fuse
- /usr/local/go/bin/go test -c ./pkg/... ./cmd/...
- git diff --check origin/main...HEAD

Note: running package tests for ./pkg/client and ./pkg/server locally is blocked by pre-existing testcontainers setup on this Mac (rootless Docker not found); compile gates pass and CI is the runtime DB gate.