### PR TITLE
P1b: add readdir small-file prefetch

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -78,6 +78,11 @@ func fsMountCmd(args []string) error {
 	flushDebounce := fs.Duration("flush-debounce", -1, "debounce window for small-file flush coalescing (default 2s, 0 disables)")
 	lookupRetryCount := fs.Int("lookup-retry-count", 2, "detached retries after transient Lookup/GetAttr stat failures (default 2, set 0 to disable)")
 	lookupRetryTimeout := fs.Duration("lookup-retry-timeout", 250*time.Millisecond, "timeout per detached Lookup/GetAttr stat retry (default 250ms, must be > 0)")
+	readDirPrefetch := fs.Bool("readdir-prefetch", false, "prefetch small files after directory reads into the read cache")
+	prefetchMaxFiles := fs.Int("readdir-prefetch-max-files", 32, "maximum small files prefetched per directory read")
+	prefetchMaxFileBytes := fs.Int64("readdir-prefetch-max-file-bytes", 50_000, "maximum individual file size prefetched by readdir prefetch")
+	prefetchMaxBytes := fs.Int64("readdir-prefetch-max-bytes", 1<<20, "maximum aggregate bytes prefetched per directory read")
+	prefetchTimeout := fs.Duration("readdir-prefetch-timeout", time.Second, "timeout for one readdir prefetch batch")
 	syncMode := fs.String("sync-mode", "auto", "sync mode: auto, interactive, or strict")
 	profile := fs.String("profile", "", "mount profile: interactive (empty for default)")
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
@@ -129,6 +134,9 @@ func fsMountCmd(args []string) error {
 	if err := validateLookupRetryFlags(*lookupRetryCount, *lookupRetryTimeout); err != nil {
 		return err
 	}
+	if err := validateReadDirPrefetchFlags(*prefetchMaxFiles, *prefetchMaxFileBytes, *prefetchMaxBytes, *prefetchTimeout); err != nil {
+		return err
+	}
 	normalizedLookupRetryCount := normalizeLookupRetryCount(*lookupRetryCount)
 
 	serverGiven, apiKeyGiven := flagProvided(fs, "server"), flagProvided(fs, "api-key")
@@ -178,25 +186,30 @@ func fsMountCmd(args []string) error {
 	}
 
 	opts := &drive9fuse.MountOptions{
-		Server:             *server,
-		APIKey:             *apiKey,
-		Token:              token,
-		MountPoint:         mountPoint,
-		RemoteRoot:         remoteRoot,
-		CacheDir:           *cacheDir,
-		CacheSize:          int64(*cacheSize) << 20,
-		DirTTL:             *dirTTL,
-		AttrTTL:            *attrTTL,
-		EntryTTL:           *entryTTL,
-		FlushDebounce:      *flushDebounce,
-		LookupRetryCount:   normalizedLookupRetryCount,
-		LookupRetryTimeout: *lookupRetryTimeout,
-		SyncMode:           syncModeVal,
-		Profile:            *profile,
-		AllowOther:         *allowOther,
-		ReadOnly:           *readOnly,
-		Debug:              *debug,
-		PerfCounters:       *perfCounters,
+		Server:               *server,
+		APIKey:               *apiKey,
+		Token:                token,
+		MountPoint:           mountPoint,
+		RemoteRoot:           remoteRoot,
+		CacheDir:             *cacheDir,
+		CacheSize:            int64(*cacheSize) << 20,
+		DirTTL:               *dirTTL,
+		AttrTTL:              *attrTTL,
+		EntryTTL:             *entryTTL,
+		FlushDebounce:        *flushDebounce,
+		LookupRetryCount:     normalizedLookupRetryCount,
+		LookupRetryTimeout:   *lookupRetryTimeout,
+		ReadDirPrefetch:      *readDirPrefetch,
+		PrefetchMaxFiles:     *prefetchMaxFiles,
+		PrefetchMaxFileBytes: *prefetchMaxFileBytes,
+		PrefetchMaxBytes:     *prefetchMaxBytes,
+		PrefetchTimeout:      *prefetchTimeout,
+		SyncMode:             syncModeVal,
+		Profile:              *profile,
+		AllowOther:           *allowOther,
+		ReadOnly:             *readOnly,
+		Debug:                *debug,
+		PerfCounters:         *perfCounters,
 	}
 
 	return drive9fuse.Mount(opts)
@@ -254,6 +267,22 @@ func validateLookupRetryFlags(count int, timeout time.Duration) error {
 	}
 	if timeout <= 0 {
 		return fmt.Errorf("drive9 mount: --lookup-retry-timeout must be > 0")
+	}
+	return nil
+}
+
+func validateReadDirPrefetchFlags(maxFiles int, maxFileBytes int64, maxBytes int64, timeout time.Duration) error {
+	if maxFiles <= 0 {
+		return fmt.Errorf("drive9 mount: --readdir-prefetch-max-files must be > 0")
+	}
+	if maxFileBytes <= 0 {
+		return fmt.Errorf("drive9 mount: --readdir-prefetch-max-file-bytes must be > 0")
+	}
+	if maxBytes <= 0 {
+		return fmt.Errorf("drive9 mount: --readdir-prefetch-max-bytes must be > 0")
+	}
+	if timeout <= 0 {
+		return fmt.Errorf("drive9 mount: --readdir-prefetch-timeout must be > 0")
 	}
 	return nil
 }

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -343,6 +343,25 @@ func TestValidateLookupRetryFlags(t *testing.T) {
 	}
 }
 
+func TestValidateReadDirPrefetchFlags(t *testing.T) {
+	if err := validateReadDirPrefetchFlags(32, 50_000, 1<<20, time.Second); err != nil {
+		t.Fatalf("validateReadDirPrefetchFlags() unexpected error: %v", err)
+	}
+
+	if err := validateReadDirPrefetchFlags(0, 50_000, 1<<20, time.Second); err == nil || !strings.Contains(err.Error(), "--readdir-prefetch-max-files") {
+		t.Fatalf("max-files=0 error = %v, want max-files validation error", err)
+	}
+	if err := validateReadDirPrefetchFlags(32, 0, 1<<20, time.Second); err == nil || !strings.Contains(err.Error(), "--readdir-prefetch-max-file-bytes") {
+		t.Fatalf("max-file-bytes=0 error = %v, want max-file-bytes validation error", err)
+	}
+	if err := validateReadDirPrefetchFlags(32, 50_000, 0, time.Second); err == nil || !strings.Contains(err.Error(), "--readdir-prefetch-max-bytes") {
+		t.Fatalf("max-bytes=0 error = %v, want max-bytes validation error", err)
+	}
+	if err := validateReadDirPrefetchFlags(32, 50_000, 1<<20, 0); err == nil || !strings.Contains(err.Error(), "--readdir-prefetch-timeout") {
+		t.Fatalf("timeout=0 error = %v, want timeout validation error", err)
+	}
+}
+
 func TestNormalizeLookupRetryCount(t *testing.T) {
 	count := normalizeLookupRetryCount(2)
 	if count != 2 {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -682,11 +682,7 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 		}
 		if e.File != nil {
 			info.Size = e.File.SizeBytes
-			if e.File.ConfirmedAt != nil {
-				info.ModTime = *e.File.ConfirmedAt
-			} else {
-				info.ModTime = e.File.CreatedAt
-			}
+			info.ModTime = fileMtime(e.File)
 		} else {
 			info.ModTime = e.Node.CreatedAt
 		}
@@ -783,6 +779,10 @@ type ReadPlan struct {
 	PresignURL string
 	// Size is the file size in bytes.
 	Size int64
+	// Revision is the file revision observed by the same metadata query.
+	Revision int64
+	// Mtime is the confirmed timestamp when available, otherwise file creation time.
+	Mtime time.Time
 }
 
 // ReadPlanCtx resolves a file path into a ReadPlan with a single metadata query.
@@ -843,6 +843,8 @@ func (b *Dat9Backend) ReadPlanCtx(ctx context.Context, path string) (plan *ReadP
 		return &ReadPlan{
 			InlineData: nf.File.ContentBlob,
 			Size:       nf.File.SizeBytes,
+			Revision:   nf.File.Revision,
+			Mtime:      fileMtime(nf.File),
 		}, nil
 	case datastore.StorageS3:
 		if b.s3 == nil {
@@ -860,10 +862,51 @@ func (b *Dat9Backend) ReadPlanCtx(ctx context.Context, path string) (plan *ReadP
 		return &ReadPlan{
 			PresignURL: url,
 			Size:       nf.File.SizeBytes,
+			Revision:   nf.File.Revision,
+			Mtime:      fileMtime(nf.File),
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported storage type for read plan: %s", nf.File.StorageType)
 	}
+}
+
+// ReadInlinePlanCtx resolves a file path to inline db9 data without presigning
+// S3 objects. Batch read-small uses this to reject S3-backed files cheaply
+// without reading or presigning object storage data.
+func (b *Dat9Backend) ReadInlinePlanCtx(ctx context.Context, path string) (plan *ReadPlan, err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "read_inline_plan", err, start) }()
+
+	resolvedPath, err := pathutil.Canonicalize(path)
+	if err != nil {
+		return nil, err
+	}
+	nf, err := b.store.StatForRead(ctx, resolvedPath)
+	if err != nil {
+		return nil, err
+	}
+	if nf.Node.IsDirectory || nf.File == nil {
+		return nil, datastore.ErrNotFound
+	}
+	if nf.File.StorageType != datastore.StorageDB9 {
+		return nil, ErrNotInlineStorage
+	}
+	return &ReadPlan{
+		InlineData: nf.File.ContentBlob,
+		Size:       nf.File.SizeBytes,
+		Revision:   nf.File.Revision,
+		Mtime:      fileMtime(nf.File),
+	}, nil
+}
+
+func fileMtime(f *datastore.File) time.Time {
+	if f == nil {
+		return time.Time{}
+	}
+	if f.ConfirmedAt != nil {
+		return *f.ConfirmedAt
+	}
+	return f.CreatedAt
 }
 
 func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {
@@ -880,11 +923,7 @@ func (b *Dat9Backend) Stat(path string) (*filesystem.FileInfo, error) {
 	}
 	if nf.File != nil {
 		info.Size = nf.File.SizeBytes
-		if nf.File.ConfirmedAt != nil {
-			info.ModTime = *nf.File.ConfirmedAt
-		} else {
-			info.ModTime = nf.File.CreatedAt
-		}
+		info.ModTime = fileMtime(nf.File)
 	} else {
 		info.ModTime = nf.Node.CreatedAt
 	}

--- a/pkg/backend/errors.go
+++ b/pkg/backend/errors.go
@@ -7,3 +7,6 @@ var ErrNotS3Stored = errors.New("file is not S3-stored")
 
 // ErrS3NotConfigured reports that the backend cannot serve S3-backed flows.
 var ErrS3NotConfigured = errors.New("S3 not configured")
+
+// ErrNotInlineStorage reports that an operation requires db9-inline file data.
+var ErrNotInlineStorage = errors.New("file is not stored inline")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -188,6 +188,9 @@ type StatResult struct {
 // MaxBatchStatPaths is the maximum number of paths accepted by BatchStatCtx.
 const MaxBatchStatPaths = 256
 
+// MaxBatchReadSmallPaths is the maximum number of paths accepted by BatchReadSmallCtx.
+const MaxBatchReadSmallPaths = 128
+
 // BatchStatResult is one per-path result from BatchStatCtx.
 //
 // Status is the HTTP-like per-path status. A missing path returns Status 404
@@ -204,6 +207,25 @@ type BatchStatResult struct {
 
 // OK reports whether the per-path batch stat result is successful.
 func (r BatchStatResult) OK() bool {
+	return r.Status >= 200 && r.Status < 300 && r.Error == ""
+}
+
+// BatchReadSmallResult is one per-path result from BatchReadSmallCtx.
+//
+// Data is JSON base64-encoded on the wire. Missing, invalid, directory, and
+// too-large paths are reported as per-path errors.
+type BatchReadSmallResult struct {
+	Path     string `json:"path"`
+	Status   int    `json:"status"`
+	Error    string `json:"error,omitempty"`
+	Data     []byte `json:"data,omitempty"`
+	Size     int64  `json:"size,omitempty"`
+	Revision int64  `json:"revision,omitempty"`
+	Mtime    int64  `json:"mtime,omitempty"` // Unix seconds, 0 means unknown
+}
+
+// OK reports whether the per-path batch read-small result is successful.
+func (r BatchReadSmallResult) OK() bool {
 	return r.Status >= 200 && r.Status < 300 && r.Error == ""
 }
 
@@ -477,6 +499,55 @@ func (c *Client) BatchStatCtx(ctx context.Context, paths []string) ([]BatchStatR
 	}
 	if len(out.Results) != len(paths) {
 		return nil, fmt.Errorf("batch stat: got %d results for %d paths", len(out.Results), len(paths))
+	}
+	return out.Results, nil
+}
+
+// BatchReadSmallCtx reads up to MaxBatchReadSmallPaths small inline files.
+//
+// Transport/request errors fail the method. Per-path read errors are returned
+// inside the corresponding BatchReadSmallResult so one missing or too-large
+// path does not fail the whole batch.
+func (c *Client) BatchReadSmallCtx(ctx context.Context, paths []string, maxBytes int64) ([]BatchReadSmallResult, error) {
+	if len(paths) == 0 {
+		return []BatchReadSmallResult{}, nil
+	}
+	if len(paths) > MaxBatchReadSmallPaths {
+		return nil, fmt.Errorf("batch read-small: %d paths exceeds limit of %d", len(paths), MaxBatchReadSmallPaths)
+	}
+	body, err := json.Marshal(struct {
+		Paths    []string `json:"paths"`
+		MaxBytes int64    `json:"max_bytes,omitempty"`
+	}{Paths: paths, MaxBytes: maxBytes})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/fs:batch-read-small", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var out struct {
+		Results []BatchReadSmallResult `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	if len(out.Results) != len(paths) {
+		return nil, fmt.Errorf("batch read-small: got %d results for %d paths", len(out.Results), len(paths))
+	}
+	for i := range out.Results {
+		if out.Results[i].Path != paths[i] {
+			return nil, fmt.Errorf("batch read-small: result[%d] path = %q, want %q", i, out.Results[i].Path, paths[i])
+		}
 	}
 	return out.Results, nil
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -164,6 +164,94 @@ func TestBatchStatCtxRejectsTooManyPathsBeforeRequest(t *testing.T) {
 	}
 }
 
+func TestBatchReadSmallCtxPreservesPerPathErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/fs:batch-read-small" {
+			t.Fatalf("path = %q, want /v1/fs:batch-read-small", r.URL.Path)
+		}
+		var req struct {
+			Paths    []string `json:"paths"`
+			MaxBytes int64    `json:"max_bytes"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got, want := strings.Join(req.Paths, ","), "/ok.txt,/missing.txt,/ok.txt"; got != want {
+			t.Fatalf("paths = %q, want %q", got, want)
+		}
+		if req.MaxBytes != 16 {
+			t.Fatalf("max_bytes = %d, want 16", req.MaxBytes)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"path": "/ok.txt", "status": 200, "data": []byte("hello"), "size": 5, "revision": 3, "mtime": 11},
+				{"path": "/missing.txt", "status": 404, "error": "not found"},
+				{"path": "/ok.txt", "status": 200, "data": []byte("hello"), "size": 5, "revision": 3, "mtime": 11},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	results, err := c.BatchReadSmallCtx(context.Background(), []string{"/ok.txt", "/missing.txt", "/ok.txt"}, 16)
+	if err != nil {
+		t.Fatalf("BatchReadSmallCtx error = %v, want nil", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results len = %d, want 3", len(results))
+	}
+	if !results[0].OK() || string(results[0].Data) != "hello" || results[0].Revision != 3 || results[0].Size != 5 || results[0].Mtime != 11 {
+		t.Fatalf("first result = %+v, want ok data/rev/size/mtime", results[0])
+	}
+	if results[1].OK() || results[1].Status != http.StatusNotFound {
+		t.Fatalf("second result = %+v, want per-path 404", results[1])
+	}
+	if !results[2].OK() || results[2].Path != "/ok.txt" || string(results[2].Data) != "hello" {
+		t.Fatalf("third result = %+v, want duplicate ok path", results[2])
+	}
+}
+
+func TestBatchReadSmallCtxRejectsTooManyPathsBeforeRequest(t *testing.T) {
+	var called bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer ts.Close()
+
+	paths := make([]string, MaxBatchReadSmallPaths+1)
+	c := New(ts.URL, "")
+	_, err := c.BatchReadSmallCtx(context.Background(), paths, 1024)
+	if err == nil {
+		t.Fatal("BatchReadSmallCtx error = nil, want too-large error")
+	}
+	if called {
+		t.Fatal("server was called despite client-side batch limit")
+	}
+}
+
+func TestBatchReadSmallCtxRejectsPathMismatch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"path": "/b.txt", "status": 200, "data": []byte("wrong")},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	_, err := c.BatchReadSmallCtx(context.Background(), []string{"/a.txt"}, 16)
+	if err == nil {
+		t.Fatal("BatchReadSmallCtx error = nil, want path mismatch error")
+	}
+	if !strings.Contains(err.Error(), `result[0] path = "/b.txt", want "/a.txt"`) {
+		t.Fatalf("BatchReadSmallCtx error = %v, want path mismatch", err)
+	}
+}
+
 func TestStat(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2146,6 +2146,7 @@ func (fs *Dat9FS) listDir(ctx context.Context, dirPath string) ([]DirEntry, erro
 	}
 	fs.applyBatchStats(ctx, dirPath, cached)
 	fs.dirCache.Put(dirPath, cached)
+	fs.prefetchReadCacheForDir(ctx, dirPath, cached)
 
 	entries := fs.cachedToDirEntries(dirPath, cached)
 	return fs.mergePendingDirEntries(dirPath, entries), nil

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -925,6 +925,246 @@ func TestListDirIgnoresBatchStatTransportFailure(t *testing.T) {
 	}
 }
 
+func TestListDirPrefetchesSmallFilesIntoReadCache(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []map[string]any{{
+					"name":  "prefetch.txt",
+					"isDir": false,
+					"size":  5,
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-stat":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{{
+					"path":     "/prefetch.txt",
+					"status":   200,
+					"isDir":    false,
+					"size":     5,
+					"revision": 7,
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-read-small":
+			var req struct {
+				Paths    []string `json:"paths"`
+				MaxBytes int64    `json:"max_bytes"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batch read-small request: %v", err)
+			}
+			if got, want := strings.Join(req.Paths, ","), "/prefetch.txt"; got != want {
+				t.Fatalf("batch read-small paths = %q, want %q", got, want)
+			}
+			if req.MaxBytes != 16 {
+				t.Fatalf("batch read-small max_bytes = %d, want 16", req.MaxBytes)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{{
+					"path":     "/prefetch.txt",
+					"status":   200,
+					"data":     []byte("hello"),
+					"size":     5,
+					"revision": 7,
+				}},
+			})
+		default:
+			t.Fatalf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{
+		ReadDirPrefetch:      true,
+		PrefetchMaxFiles:     8,
+		PrefetchMaxFileBytes: 16,
+		PrefetchMaxBytes:     64,
+		PrefetchTimeout:      time.Second,
+	}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	entries, err := fs.listDir(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("listDir error = %v, want nil", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "prefetch.txt" {
+		t.Fatalf("listDir entries = %+v, want prefetch.txt", entries)
+	}
+	data, ok := fs.readCache.Get("/prefetch.txt", 7)
+	if !ok {
+		t.Fatal("readCache miss after readdir prefetch")
+	}
+	if string(data) != "hello" {
+		t.Fatalf("readCache data = %q, want hello", data)
+	}
+}
+
+func TestListDirPrefetchIgnoresBatchReadTransportFailure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []map[string]any{{
+					"name":  "listed.txt",
+					"isDir": false,
+					"size":  9,
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-stat":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{{
+					"path":     "/listed.txt",
+					"status":   200,
+					"isDir":    false,
+					"size":     9,
+					"revision": 4,
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-read-small":
+			http.Error(w, "batch read unavailable", http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{ReadDirPrefetch: true}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	entries, err := fs.listDir(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("listDir error = %v, want nil", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "listed.txt" {
+		t.Fatalf("listDir entries = %+v, want listed.txt despite batch read transport failure", entries)
+	}
+	if _, ok := fs.readCache.Get("/listed.txt", 4); ok {
+		t.Fatal("readCache hit after failed batch read-small, want miss")
+	}
+}
+
+func TestListDirPrefetchSkipsPendingFile(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []map[string]any{{
+					"name":  "dirty.txt",
+					"isDir": false,
+					"size":  6,
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-stat":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{{
+					"path":     "/dirty.txt",
+					"status":   200,
+					"isDir":    false,
+					"size":     6,
+					"revision": 5,
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-read-small":
+			t.Fatalf("batch read-small should not be called for pending local file")
+		default:
+			t.Fatalf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{ReadDirPrefetch: true}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/dirty.txt", 6, PendingOverwrite, 4); err != nil {
+		t.Fatal(err)
+	}
+	fs.pendingIndex = pending
+
+	entries, err := fs.listDir(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("listDir error = %v, want nil", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "dirty.txt" {
+		t.Fatalf("listDir entries = %+v, want dirty.txt", entries)
+	}
+	if _, ok := fs.readCache.Get("/dirty.txt", 5); ok {
+		t.Fatal("readCache hit for pending local file, want miss")
+	}
+}
+
+func TestListDirPrefetchRespectsBudgets(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []map[string]any{
+					{"name": "a.txt", "isDir": false, "size": 4},
+					{"name": "b.txt", "isDir": false, "size": 5},
+					{"name": "c.txt", "isDir": false, "size": 4},
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-stat":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{
+					{"path": "/a.txt", "status": 200, "isDir": false, "size": 4, "revision": 1},
+					{"path": "/b.txt", "status": 200, "isDir": false, "size": 5, "revision": 2},
+					{"path": "/c.txt", "status": 200, "isDir": false, "size": 4, "revision": 3},
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-read-small":
+			var req struct {
+				Paths []string `json:"paths"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batch read-small request: %v", err)
+			}
+			if got, want := strings.Join(req.Paths, ","), "/a.txt,/b.txt"; got != want {
+				t.Fatalf("batch read-small paths = %q, want %q", got, want)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{
+					{"path": "/a.txt", "status": 200, "data": []byte("aaaa"), "size": 4, "revision": 1},
+					{"path": "/b.txt", "status": 200, "data": []byte("bbbbb"), "size": 5, "revision": 2},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{
+		ReadDirPrefetch:      true,
+		PrefetchMaxFiles:     2,
+		PrefetchMaxFileBytes: 16,
+		PrefetchMaxBytes:     9,
+		PrefetchTimeout:      time.Second,
+	}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	_, err := fs.listDir(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("listDir error = %v, want nil", err)
+	}
+	if data, ok := fs.readCache.Get("/a.txt", 1); !ok || string(data) != "aaaa" {
+		t.Fatalf("readCache a.txt = %q, %v; want aaaa hit", data, ok)
+	}
+	if data, ok := fs.readCache.Get("/b.txt", 2); !ok || string(data) != "bbbbb" {
+		t.Fatalf("readCache b.txt = %q, %v; want bbbbb hit", data, ok)
+	}
+	if _, ok := fs.readCache.Get("/c.txt", 3); ok {
+		t.Fatal("readCache c.txt hit despite max-files budget, want miss")
+	}
+}
+
 func TestLookupRetriesTransientCanceledStat(t *testing.T) {
 	var headCalls atomic.Int32
 	firstHeadStarted := make(chan struct{}, 1)

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -29,27 +29,32 @@ import (
 // its entire lifetime (Invariant #3). To change credentials, umount and
 // remount; there is no in-process rebind.
 type MountOptions struct {
-	Server             string        // dat9 server URL
-	APIKey             string        // owner API key (mutually exclusive with Token)
-	Token              string        // delegated capability JWT (mutually exclusive with APIKey)
-	MountPoint         string        // local mount point
-	RemoteRoot         string        // remote subtree root (default "/"); set via "drive9 mount :/path /local"
-	CacheDir           string        // write-back cache directory (default ~/.cache/drive9); empty string uses default
-	CacheSize          int64         // ReadCache max size in bytes (default 128MB)
-	DirTTL             time.Duration // DirCache TTL (default 10s)
-	AttrTTL            time.Duration // kernel attr cache TTL (default 10s)
-	EntryTTL           time.Duration // kernel entry cache TTL (default 10s)
-	NegativeEntryTTL   time.Duration // kernel negative entry cache TTL (default 10s)
-	FlushDebounce      time.Duration // debounce window for small-file flush coalescing (default 2s, 0 disables); set to -1 to use default
-	SyncMode           SyncMode      // interactive, strict, or auto (default auto)
-	Profile            string        // mount profile: "interactive", "" (default)
-	UploadConcurrency  int           // number of background upload workers (default 4)
-	LookupRetryCount   int           // detached retries after transient Lookup/GetAttr stat failures (default 2)
-	LookupRetryTimeout time.Duration // timeout per detached stat retry after interrupt/transient errors (default 250ms)
-	AllowOther         bool          // allow other users to access mount
-	ReadOnly           bool          // mount as read-only
-	Debug              bool          // enable FUSE debug logging
-	PerfCounters       bool          // print low-overhead FUSE perf counter summary on shutdown
+	Server               string        // dat9 server URL
+	APIKey               string        // owner API key (mutually exclusive with Token)
+	Token                string        // delegated capability JWT (mutually exclusive with APIKey)
+	MountPoint           string        // local mount point
+	RemoteRoot           string        // remote subtree root (default "/"); set via "drive9 mount :/path /local"
+	CacheDir             string        // write-back cache directory (default ~/.cache/drive9); empty string uses default
+	CacheSize            int64         // ReadCache max size in bytes (default 128MB)
+	DirTTL               time.Duration // DirCache TTL (default 10s)
+	AttrTTL              time.Duration // kernel attr cache TTL (default 10s)
+	EntryTTL             time.Duration // kernel entry cache TTL (default 10s)
+	NegativeEntryTTL     time.Duration // kernel negative entry cache TTL (default 10s)
+	FlushDebounce        time.Duration // debounce window for small-file flush coalescing (default 2s, 0 disables); set to -1 to use default
+	SyncMode             SyncMode      // interactive, strict, or auto (default auto)
+	Profile              string        // mount profile: "interactive", "" (default)
+	UploadConcurrency    int           // number of background upload workers (default 4)
+	LookupRetryCount     int           // detached retries after transient Lookup/GetAttr stat failures (default 2)
+	LookupRetryTimeout   time.Duration // timeout per detached stat retry after interrupt/transient errors (default 250ms)
+	ReadDirPrefetch      bool          // prefetch small files after readdir into ReadCache (default false)
+	PrefetchMaxFiles     int           // maximum files prefetched per directory read (default 32 when enabled)
+	PrefetchMaxFileBytes int64         // maximum individual file size prefetched (default 50KB)
+	PrefetchMaxBytes     int64         // maximum aggregate bytes prefetched per directory read (default 1MB)
+	PrefetchTimeout      time.Duration // timeout for one readdir prefetch batch (default 1s)
+	AllowOther           bool          // allow other users to access mount
+	ReadOnly             bool          // mount as read-only
+	Debug                bool          // enable FUSE debug logging
+	PerfCounters         bool          // print low-overhead FUSE perf counter summary on shutdown
 }
 
 func (o *MountOptions) setDefaults() {
@@ -84,6 +89,18 @@ func (o *MountOptions) setDefaults() {
 	}
 	if o.LookupRetryTimeout <= 0 {
 		o.LookupRetryTimeout = lookupTransientRetryTimeout
+	}
+	if o.PrefetchMaxFiles <= 0 {
+		o.PrefetchMaxFiles = defaultReadDirPrefetchMaxFiles
+	}
+	if o.PrefetchMaxFileBytes <= 0 || o.PrefetchMaxFileBytes > smallFileThreshold {
+		o.PrefetchMaxFileBytes = smallFileThreshold
+	}
+	if o.PrefetchMaxBytes <= 0 {
+		o.PrefetchMaxBytes = defaultReadDirPrefetchMaxBytes
+	}
+	if o.PrefetchTimeout <= 0 {
+		o.PrefetchTimeout = defaultReadDirPrefetchTimeout
 	}
 	// Apply interactive profile if requested.
 	if o.Profile == "interactive" {

--- a/pkg/fuse/readdir_prefetch.go
+++ b/pkg/fuse/readdir_prefetch.go
@@ -1,0 +1,136 @@
+package fuse
+
+import (
+	"context"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultReadDirPrefetchMaxFiles = 32
+	defaultReadDirPrefetchMaxBytes = 1 << 20
+	defaultReadDirPrefetchTimeout  = time.Second
+)
+
+type readDirPrefetchCandidate struct {
+	localPath  string
+	remotePath string
+	revision   int64
+}
+
+func (fs *Dat9FS) prefetchReadCacheForDir(ctx context.Context, dirPath string, items []CachedFileInfo) {
+	if fs == nil || fs.opts == nil || !fs.opts.ReadDirPrefetch || len(items) == 0 {
+		return
+	}
+	candidates := fs.readDirPrefetchCandidates(dirPath, items)
+	if len(candidates) == 0 {
+		return
+	}
+
+	for start := 0; start < len(candidates); start += client.MaxBatchReadSmallPaths {
+		end := start + client.MaxBatchReadSmallPaths
+		if end > len(candidates) {
+			end = len(candidates)
+		}
+		chunk := candidates[start:end]
+		paths := make([]string, len(chunk))
+		for i, candidate := range chunk {
+			paths[i] = candidate.remotePath
+		}
+
+		prefetchCtx, cancel := context.WithTimeout(ctx, fs.opts.PrefetchTimeout)
+		results, err := fs.client.BatchReadSmallCtx(prefetchCtx, paths, fs.opts.PrefetchMaxFileBytes)
+		cancel()
+		if err != nil {
+			logger.Warn(ctx, "fuse_batch_read_small_prefetch_failed",
+				zap.String("dir", dirPath),
+				zap.Int("start", start),
+				zap.Int("end", end),
+				zap.Error(err))
+			return
+		}
+		for i, result := range results {
+			if !result.OK() {
+				continue
+			}
+			candidate := chunk[i]
+			if int64(len(result.Data)) > fs.opts.PrefetchMaxFileBytes {
+				continue
+			}
+			if fs.hasLocalWriteState(candidate.localPath) {
+				continue
+			}
+			revision := candidate.revision
+			if result.Revision > 0 {
+				revision = result.Revision
+			}
+			fs.readCache.Put(candidate.localPath, result.Data, revision)
+			if revision > 0 {
+				if ino, ok := fs.inodes.GetInode(candidate.localPath); ok {
+					fs.inodes.UpdateRevision(ino, revision)
+				}
+			}
+		}
+	}
+}
+
+func (fs *Dat9FS) readDirPrefetchCandidates(dirPath string, items []CachedFileInfo) []readDirPrefetchCandidate {
+	maxFiles := fs.opts.PrefetchMaxFiles
+	maxFileBytes := fs.opts.PrefetchMaxFileBytes
+	maxBytes := fs.opts.PrefetchMaxBytes
+	if maxFiles <= 0 || maxFileBytes <= 0 || maxBytes <= 0 {
+		return nil
+	}
+
+	candidates := make([]readDirPrefetchCandidate, 0, maxFiles)
+	var totalBytes int64
+	for _, item := range items {
+		if len(candidates) >= maxFiles {
+			break
+		}
+		if item.IsDir || item.Size <= 0 || item.Size > maxFileBytes {
+			continue
+		}
+		localPath := dirEntryChildPath(dirPath, item.Name)
+		if isLockFilePath(localPath) || fs.hasLocalWriteState(localPath) {
+			continue
+		}
+		if _, hit := fs.readCache.Get(localPath, item.Revision); hit {
+			continue
+		}
+		if totalBytes+item.Size > maxBytes {
+			// Keep scanning so later smaller files can still fit the aggregate budget.
+			continue
+		}
+		candidates = append(candidates, readDirPrefetchCandidate{
+			localPath:  localPath,
+			remotePath: fs.remotePath(localPath),
+			revision:   item.Revision,
+		})
+		totalBytes += item.Size
+	}
+	return candidates
+}
+
+func (fs *Dat9FS) hasLocalWriteState(p string) bool {
+	if fs.hasPendingLocalState(p) || fs.hasQueuedCommit(p) {
+		return true
+	}
+	if ino, ok := fs.inodes.GetInode(p); ok {
+		if fs.hasOpenHandle(ino, p) {
+			return true
+		}
+		if _, dirty := fs.dirtyHandleSize(ino); dirty {
+			return true
+		}
+	}
+	for _, fh := range fs.fileHandles.Snapshot() {
+		if fh != nil && fh.Path == p && fh.Dirty != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -84,7 +84,12 @@ type TenantStatusResponse struct {
 	MaxUploadBytes int64  `json:"max_upload_bytes"`
 }
 
-const maxBatchStatPaths = 256
+const (
+	maxBatchStatPaths       = 256
+	maxBatchReadSmallPaths  = 128
+	maxBatchReadSmallBytes  = 50_000
+	defaultBatchReadMaxBody = 1 << 20
+)
 
 func New(b *backend.Dat9Backend) *Server {
 	return NewWithConfig(Config{Backend: b})
@@ -130,6 +135,7 @@ func NewWithConfig(cfg Config) *Server {
 		business = injectFallbackBackend(cfg.Backend, business)
 	}
 	mux.Handle("/v1/fs:batch-stat", business)
+	mux.Handle("/v1/fs:batch-read-small", business)
 	mux.Handle("/v1/fs/", business)
 	mux.Handle("/v1/uploads", business)
 	mux.Handle("/v1/uploads/", business)
@@ -299,6 +305,8 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.URL.Path == "/v1/fs:batch-stat":
 		s.handleBatchStat(w, r)
+	case r.URL.Path == "/v1/fs:batch-read-small":
+		s.handleBatchReadSmall(w, r)
 	case strings.HasPrefix(r.URL.Path, "/v1/fs/"):
 		s.handleFS(w, r)
 	case r.URL.Path == "/v1/uploads/initiate":
@@ -1065,6 +1073,25 @@ type batchStatResult struct {
 	Mtime    int64  `json:"mtime,omitempty"`
 }
 
+type batchReadSmallRequest struct {
+	Paths    []string `json:"paths"`
+	MaxBytes int64    `json:"max_bytes,omitempty"`
+}
+
+type batchReadSmallResponse struct {
+	Results []batchReadSmallResult `json:"results"`
+}
+
+type batchReadSmallResult struct {
+	Path     string `json:"path"`
+	Status   int    `json:"status"`
+	Error    string `json:"error,omitempty"`
+	Data     []byte `json:"data,omitempty"`
+	Size     int64  `json:"size,omitempty"`
+	Revision int64  `json:"revision,omitempty"`
+	Mtime    int64  `json:"mtime,omitempty"`
+}
+
 func (s *Server) handleBatchStat(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_stat_method_not_allowed", "method", r.Method)...)
@@ -1097,6 +1124,83 @@ func (s *Server) handleBatchStat(w http.ResponseWriter, r *http.Request) {
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "batch_stat_ok", "count", len(results))...)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(batchStatResponse{Results: results})
+}
+
+func (s *Server) handleBatchReadSmall(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_read_small_method_not_allowed", "method", r.Method)...)
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_read_small_missing_scope")...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+
+	var req batchReadSmallRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, defaultBatchReadMaxBody)).Decode(&req); err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_read_small_decode_failed", "error", err)...)
+		errJSON(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if len(req.Paths) > maxBatchReadSmallPaths {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_read_small_too_large", "count", len(req.Paths), "limit", maxBatchReadSmallPaths)...)
+		errJSON(w, http.StatusBadRequest, fmt.Sprintf("too many paths: %d exceeds limit %d", len(req.Paths), maxBatchReadSmallPaths))
+		return
+	}
+
+	maxBytes := req.MaxBytes
+	if maxBytes <= 0 || maxBytes > maxBatchReadSmallBytes {
+		maxBytes = maxBatchReadSmallBytes
+	}
+	results := make([]batchReadSmallResult, len(req.Paths))
+	for i, path := range req.Paths {
+		results[i] = s.batchReadSmallOne(r.Context(), b, path, maxBytes)
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "batch_read_small_ok", "count", len(results), "max_bytes", maxBytes)...)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(batchReadSmallResponse{Results: results})
+}
+
+func (s *Server) batchReadSmallOne(ctx context.Context, b *backend.Dat9Backend, rawPath string, maxBytes int64) batchReadSmallResult {
+	result := batchReadSmallResult{Path: rawPath}
+	if err := validateBatchStatPath(rawPath); err != nil {
+		result.Status = http.StatusBadRequest
+		result.Error = err.Error()
+		return result
+	}
+
+	plan, err := b.ReadInlinePlanCtx(ctx, rawPath)
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			result.Status = http.StatusNotFound
+			result.Error = err.Error()
+			return result
+		}
+		if errors.Is(err, backend.ErrNotInlineStorage) {
+			result.Status = http.StatusRequestEntityTooLarge
+			result.Error = "file is not available for inline read"
+			return result
+		}
+		result.Status = http.StatusInternalServerError
+		result.Error = err.Error()
+		return result
+	}
+	if plan.Size > maxBytes || int64(len(plan.InlineData)) > maxBytes {
+		result.Status = http.StatusRequestEntityTooLarge
+		result.Error = fmt.Sprintf("file exceeds batch read-small limit %d bytes", maxBytes)
+		return result
+	}
+	result.Status = http.StatusOK
+	result.Data = plan.InlineData
+	result.Size = plan.Size
+	result.Revision = plan.Revision
+	if !plan.Mtime.IsZero() {
+		result.Mtime = plan.Mtime.Unix()
+	}
+	return result
 }
 
 func (s *Server) batchStatOne(ctx context.Context, b *backend.Dat9Backend, rawPath string) batchStatResult {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -9,11 +10,13 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -45,6 +48,39 @@ func newTestServer(t *testing.T) *Server {
 		t.Fatal(err)
 	}
 	return New(b)
+}
+
+func insertTestS3File(t *testing.T, s *Server, p string, size int64) {
+	t.Helper()
+	now := time.Now().UTC()
+	fileID := "test-s3-" + strings.Trim(pathutil.BaseName(p), ".")
+	store := s.fallback.Store()
+	if err := store.InsertFile(context.Background(), &datastore.File{
+		FileID:                fileID,
+		StorageType:           datastore.StorageS3,
+		StorageRef:            "blobs/" + fileID,
+		StorageEncryptionMode: datastore.StorageEncryptionLegacy,
+		SizeBytes:             size,
+		Revision:              1,
+		Status:                datastore.StatusConfirmed,
+		CreatedAt:             now,
+		ConfirmedAt:           &now,
+	}); err != nil {
+		t.Fatalf("insert s3 file: %v", err)
+	}
+	if err := store.EnsureParentDirs(context.Background(), p, func() string { return "node-parent-" + fileID }); err != nil {
+		t.Fatalf("ensure parent dirs: %v", err)
+	}
+	if err := store.InsertNode(context.Background(), &datastore.FileNode{
+		NodeID:     "node-" + fileID,
+		Path:       p,
+		ParentPath: pathutil.ParentPath(p),
+		Name:       pathutil.BaseName(p),
+		FileID:     fileID,
+		CreatedAt:  now,
+	}); err != nil {
+		t.Fatalf("insert s3 node: %v", err)
+	}
 }
 
 func newLocalTenantShimServer(t *testing.T, apiKey string) *Server {
@@ -375,6 +411,176 @@ func TestBatchStatEmptyAndTooLargeInputs(t *testing.T) {
 		t.Fatal(err)
 	}
 	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs:batch-stat", strings.NewReader(string(payload)))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("too-large status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestBatchReadSmallReturnsPerPathResults(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/data/a.txt", strings.NewReader("hello"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write: %d", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/data/dir?mkdir", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mkdir: %d", resp.StatusCode)
+	}
+
+	body := `{"paths":["/data/a.txt","/missing.txt","/bad\\path","/data/dir","/data/a.txt"],"max_bytes":16}`
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs:batch-read-small", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		response, _ := io.ReadAll(resp.Body)
+		t.Fatalf("batch read-small status = %d, body %s", resp.StatusCode, response)
+	}
+	var out struct {
+		Results []struct {
+			Path     string `json:"path"`
+			Status   int    `json:"status"`
+			Error    string `json:"error"`
+			Data     []byte `json:"data"`
+			Size     int64  `json:"size"`
+			Revision int64  `json:"revision"`
+			Mtime    int64  `json:"mtime"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Results) != 5 {
+		t.Fatalf("results len = %d, want 5", len(out.Results))
+	}
+	if out.Results[0].Status != http.StatusOK || string(out.Results[0].Data) != "hello" || out.Results[0].Size != 5 || out.Results[0].Revision != 1 || out.Results[0].Mtime == 0 {
+		t.Fatalf("file result = %+v, want ok file data", out.Results[0])
+	}
+	if out.Results[1].Status != http.StatusNotFound || out.Results[1].Error == "" {
+		t.Fatalf("missing result = %+v, want per-path 404", out.Results[1])
+	}
+	if out.Results[2].Status != http.StatusBadRequest || out.Results[2].Error == "" {
+		t.Fatalf("invalid path result = %+v, want per-path 400", out.Results[2])
+	}
+	if out.Results[3].Status != http.StatusNotFound || out.Results[3].Error == "" {
+		t.Fatalf("directory result = %+v, want per-path 404 matching GET semantics", out.Results[3])
+	}
+	if out.Results[4].Status != http.StatusOK || out.Results[4].Path != "/data/a.txt" || string(out.Results[4].Data) != "hello" {
+		t.Fatalf("duplicate result = %+v, want duplicate preserved", out.Results[4])
+	}
+}
+
+func TestBatchReadSmallEmptyTooLargeAndFileTooLarge(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs:batch-read-small", strings.NewReader(`{"paths":[]}`))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var empty struct {
+		Results []struct{} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&empty); err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("empty status = %d, want 200", resp.StatusCode)
+	}
+	if len(empty.Results) != 0 {
+		t.Fatalf("empty results len = %d, want 0", len(empty.Results))
+	}
+
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/data/large.txt", strings.NewReader("hello"))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write large candidate: %d", resp.StatusCode)
+	}
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs:batch-read-small", strings.NewReader(`{"paths":["/data/large.txt"],"max_bytes":4}`))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tooLargeFile struct {
+		Results []struct {
+			Status int    `json:"status"`
+			Error  string `json:"error"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tooLargeFile); err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("file-too-large batch status = %d, want 200", resp.StatusCode)
+	}
+	if len(tooLargeFile.Results) != 1 || tooLargeFile.Results[0].Status != http.StatusRequestEntityTooLarge || tooLargeFile.Results[0].Error == "" {
+		t.Fatalf("file-too-large result = %+v, want per-path 413", tooLargeFile.Results)
+	}
+
+	insertTestS3File(t, s, "/data/s3.txt", 1)
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs:batch-read-small", strings.NewReader(`{"paths":["/data/s3.txt"],"max_bytes":50000}`))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nonInlineFile struct {
+		Results []struct {
+			Status int    `json:"status"`
+			Error  string `json:"error"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&nonInlineFile); err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("non-inline batch status = %d, want 200", resp.StatusCode)
+	}
+	if len(nonInlineFile.Results) != 1 ||
+		nonInlineFile.Results[0].Status != http.StatusRequestEntityTooLarge ||
+		nonInlineFile.Results[0].Error != "file is not available for inline read" {
+		t.Fatalf("non-inline result = %+v, want per-path 413 inline-storage error", nonInlineFile.Results)
+	}
+
+	paths := make([]string, maxBatchReadSmallPaths+1)
+	for i := range paths {
+		paths[i] = "/x.txt"
+	}
+	payload, err := json.Marshal(map[string][]string{"paths": paths})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs:batch-read-small", strings.NewReader(string(payload)))
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- add batch read-small server/client API with per-path results and explicit limits
- add opt-in FUSE readdir small-file prefetch into read cache with count/size/timeout budgets
- skip lockfiles and local pending/dirty/open paths so remote prefetch never overwrites local state

## Validation
- /usr/local/go/bin/go test ./pkg/fuse -run 'TestListDirPrefetch|TestListDirIgnoresBatchStat' -count=1
- /usr/local/go/bin/go test ./pkg/fuse -count=1
- /usr/local/go/bin/go test ./cmd/drive9/cli -run 'TestValidateReadDirPrefetchFlags|TestValidateLookupRetryFlags|TestNormalizeLookupRetryCount' -count=1
- /usr/local/go/bin/go test -c ./pkg/... ./cmd/...
- PATH=/usr/local/go/bin:/Users/qiffang/.codex/tmp/arg0/codex-arg0CjlbdM:/Users/qiffang/.slock/agents/27e7bfef-4ef8-4cd6-ba5f-057142b2827e/.slock:/Users/qiffang/.npm/_npx/277f35d2ed0078b9/node_modules/.bin:/Users/qiffang/node_modules/.bin:/Users/node_modules/.bin:/node_modules/.bin:/opt/homebrew/lib/node_modules/npm/node_modules/@npmcli/run-script/lib/node-gyp-bin:/Users/qiffang/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin bin/golangci-lint run --timeout 10m --new-from-rev=origin/main ./pkg/fuse ./pkg/client ./pkg/server ./cmd/drive9/cli
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Directory read prefetch: automatically prefetches small files when listing directories to improve performance
  * Batch read API: new endpoint enables efficient reading of multiple small files in a single request
  * Added CLI flags to configure prefetch behavior including limits on files, bytes, and timeouts
  * Enhanced file metadata now includes revision and modification time information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->