### PR TITLE
fix: increase Lookup retry timeout to prevent EAGAIN on git checkout

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -141,11 +141,16 @@ const fuseTimeout = 30 * time.Second
 const (
 	// lookupTransientRetryCount is the number of detached retries after the
 	// initial Lookup StatCtx attempt fails with a transient error.
-	lookupTransientRetryCount = 2
+	// Raised from 2 to 3 to tolerate E2B/high-latency environments where
+	// concurrent git checkout triggers kernel FUSE interrupts on Lookup.
+	lookupTransientRetryCount = 3
 
-	// lookupTransientRetryTimeout keeps each detached retry short so interrupted
-	// lookups do not block the caller for long.
-	lookupTransientRetryTimeout = 250 * time.Millisecond
+	// lookupTransientRetryTimeout is the timeout per detached retry. Set to
+	// 2s (up from 250ms) so that retries can complete a full HTTP round-trip
+	// in high-latency environments (E2B sandbox → drive9 server can be
+	// 100-200ms RTT). The previous 250ms was barely above one RTT, leaving
+	// almost no margin for server processing or network jitter.
+	lookupTransientRetryTimeout = 2 * time.Second
 
 	// lookupRetrySuccessLogEvery controls how often successful retry recovery is
 	// logged, to avoid noisy logs on hot lookup paths.

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1328,7 +1328,7 @@ func TestLookupTransientRetryExhaustedReturnsEAGAIN(t *testing.T) {
 		if st != want {
 			t.Fatalf("Lookup status = %v, want %v", st, want)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(time.Duration(lookupTransientRetryCount+1) * lookupTransientRetryTimeout * 2):
 		t.Fatal("Lookup timed out")
 	}
 


### PR DESCRIPTION
## Summary

- Increases `lookupTransientRetryCount` from 2 → 3 and `lookupTransientRetryTimeout` from 250ms → 2s
- Fixes EAGAIN returned to git during `checkout` when cloning directly into a drive9 FUSE mount in high-latency environments (E2B sandboxes)

## Root Cause

When git clones into a FUSE mount, each file creation triggers a `Lookup` → `StatCtx` (HTTP HEAD). If the kernel sends a FUSE interrupt during the stat, the context is canceled and the detached retry must complete within the retry timeout. The previous 250ms timeout was barely above one RTT for E2B→server connections (~100-200ms), causing retries to timeout and return EAGAIN to git.

Git interprets EAGAIN on `open(O_CREAT)` as "unable to create file: Resource temporarily unavailable" and aborts checkout.

## Changes

- `lookupTransientRetryCount`: 2 → 3 (one more retry attempt)
- `lookupTransientRetryTimeout`: 250ms → 2s (enough for full HTTP round-trip with margin)
- Test timeout updated to scale with new retry config

The retry mechanism already uses `context.Background()` (detached from FUSE cancel), so this only changes the retry budget, not interrupt semantics.

## Test plan

- [x] All existing Lookup/retry tests pass locally
- [ ] CI passes
- [ ] Validate with E2B demo: `git clone --depth 1` directly into FUSE mount under `DRIVE9_SYNC_MODE=interactive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted the filesystem lookup retry mechanism to use increased retry attempts (3 instead of 2) and extended timeout duration (2s instead of 250ms) per retry, enhancing transient failure handling during lookup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->