### PR TITLE
perf(fuse): cache lookup list fallback results

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -981,6 +981,23 @@ func (fs *Dat9FS) getAttrStatWithRetry(cancel <-chan struct{}, remotePath string
 	return fs.statWithTransientRetry(cancel, remotePath, false)
 }
 
+func cachedFileInfos(items []client.FileInfo) []CachedFileInfo {
+	cached := make([]CachedFileInfo, len(items))
+	for i, item := range items {
+		var mtime time.Time
+		if item.Mtime > 0 {
+			mtime = time.Unix(item.Mtime, 0)
+		}
+		cached[i] = CachedFileInfo{
+			Name:  item.Name,
+			Size:  item.Size,
+			IsDir: item.IsDir,
+			Mtime: mtime,
+		}
+	}
+	return cached
+}
+
 func (fs *Dat9FS) lookupListWithRetry(cancel <-chan struct{}, parentPath string) ([]client.FileInfo, error) {
 	// list-fallback retries are intentionally not counted in lookupStatRetry*;
 	// those counters remain scoped to the primary Lookup->Stat path.
@@ -990,7 +1007,11 @@ func (fs *Dat9FS) lookupListWithRetry(cancel <-chan struct{}, parentPath string)
 	items, err := fs.client.ListCtx(ctx, apiPath)
 	cf()
 	fs.perfRecordRemote(perfRemoteList, listStart, err, 0)
-	if err == nil || !isTransientLookupErr(err) {
+	if err == nil {
+		fs.dirCache.Put(parentPath, cachedFileInfos(items))
+		return items, nil
+	}
+	if !isTransientLookupErr(err) {
 		return items, err
 	}
 	retryCount := fs.lookupStatRetryCount()
@@ -1009,7 +1030,11 @@ func (fs *Dat9FS) lookupListWithRetry(cancel <-chan struct{}, parentPath string)
 		items, err = fs.client.ListCtx(retryCtx, apiPath)
 		retryCancel()
 		fs.perfRecordRemote(perfRemoteList, listStart, err, 0)
-		if err == nil || !isTransientLookupErr(err) {
+		if err == nil {
+			fs.dirCache.Put(parentPath, cachedFileInfos(items))
+			return items, nil
+		}
+		if !isTransientLookupErr(err) {
 			return items, err
 		}
 		lastErr = err
@@ -1051,6 +1076,21 @@ func (fs *Dat9FS) remotePathGoneDetached(localPath string) bool {
 	_, err := fs.client.StatCtx(retryCtx, fs.remotePath(localPath))
 	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
 	return isNotFoundErr(err)
+}
+
+func (fs *Dat9FS) remotePathExistsDetached(localPath string) (bool, error) {
+	retryCtx, retryCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+	defer retryCancel()
+	statStart := fs.perfStart()
+	_, err := fs.client.StatCtx(retryCtx, fs.remotePath(localPath))
+	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
+	if err == nil {
+		return true, nil
+	}
+	if isNotFoundErr(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (fs *Dat9FS) mkdirRemoteWithTransientRetry(cancel <-chan struct{}, localPath string) error {
@@ -1165,6 +1205,43 @@ func (fs *Dat9FS) renameRemoteWithTransientRetry(ctx context.Context, oldP, newP
 	return lastErr
 }
 
+func (fs *Dat9FS) lookupFromDirCache(parentPath, childP, name string, out *gofuse.EntryOut) (bool, gofuse.Status) {
+	cached, ok := fs.dirCache.Get(parentPath)
+	if !ok {
+		if fs.perf != nil {
+			fs.perf.dirCacheMiss.add(1)
+		}
+		return false, gofuse.OK
+	}
+	if fs.perf != nil {
+		fs.perf.dirCacheHit.add(1)
+	}
+
+	for _, item := range cached {
+		if item.Name != name {
+			continue
+		}
+		mtime := item.Mtime
+		if mtime.IsZero() {
+			mtime = time.Now()
+		}
+		ino := fs.inodes.Lookup(childP, item.IsDir, item.Size, mtime)
+		if item.Revision > 0 {
+			fs.inodes.UpdateRevision(ino, item.Revision)
+		}
+		entry, ok := fs.inodes.GetEntry(ino)
+		if !ok {
+			return true, gofuse.EIO
+		}
+		fs.fillEntryOut(entry, out)
+		return true, gofuse.OK
+	}
+
+	out.NodeId = 0
+	out.SetEntryTimeout(fs.opts.NegativeEntryTTL)
+	return true, gofuse.ENOENT
+}
+
 // --- RawFileSystem methods ---------------------------------------------------
 
 func (fs *Dat9FS) Init(server *gofuse.Server) {
@@ -1259,6 +1336,14 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		return gofuse.OK
 	}
 
+	parentPath, ok := fs.inodes.GetPath(header.NodeId)
+	if !ok {
+		return gofuse.ENOENT
+	}
+	if handled, cacheStatus := fs.lookupFromDirCache(parentPath, childP, name, out); handled {
+		return cacheStatus
+	}
+
 	stat, err := fs.lookupStatWithRetry(cancel, childP)
 	if err != nil {
 		if !isNotFoundErr(err) {
@@ -1267,10 +1352,6 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 
 		// Some deployments do not support stat/HEAD on directories.
 		// Fall back to listing the parent and matching by name.
-		parentPath, ok := fs.inodes.GetPath(header.NodeId)
-		if !ok {
-			return gofuse.ENOENT
-		}
 		items, listErr := fs.lookupListWithRetry(cancel, parentPath)
 		if listErr != nil {
 			return httpToFuseStatus(listErr)
@@ -1804,6 +1885,21 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 		if !ok || meta.Kind != PendingNew {
 			return pendingRenameRemoteFallback, nil
 		}
+		oldExistsRemote, oldExistsErr := fs.remotePathExistsDetached(oldP)
+		if oldExistsErr != nil {
+			return pendingRenameHandled, oldExistsErr
+		}
+		if oldExistsRemote {
+			if err := fs.renameRemoteWithTransientRetry(ctx, oldP, newP); err != nil {
+				return pendingRenameHandled, err
+			}
+			if fs.shadowStore != nil {
+				fs.shadowStore.Remove(oldP)
+			}
+			fs.pendingIndex.Remove(oldP)
+			fs.finishLocalRename(input, oldP, newP)
+			return pendingRenameHandled, nil
+		}
 	}
 
 	if fs.shadowStore != nil {
@@ -2131,19 +2227,7 @@ func (fs *Dat9FS) listDir(ctx context.Context, dirPath string) ([]DirEntry, erro
 	}
 
 	// Store in dir cache
-	cached := make([]CachedFileInfo, len(items))
-	for i, item := range items {
-		var mtime time.Time
-		if item.Mtime > 0 {
-			mtime = time.Unix(item.Mtime, 0)
-		}
-		cached[i] = CachedFileInfo{
-			Name:  item.Name,
-			Size:  item.Size,
-			IsDir: item.IsDir,
-			Mtime: mtime,
-		}
-	}
+	cached := cachedFileInfos(items)
 	fs.applyBatchStats(ctx, dirPath, cached)
 	fs.dirCache.Put(dirPath, cached)
 	fs.prefetchReadCacheForDir(ctx, dirPath, cached)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -742,6 +742,123 @@ func TestLookupFallsBackToParentListWhenDirStatUnsupported(t *testing.T) {
 	}
 }
 
+func TestLookupUsesDirCachePositiveEntryWithoutRemoteStat(t *testing.T) {
+	var remoteCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "unexpected remote call", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	mtime := time.Unix(123, 0)
+	fs.dirCache.Put("/", []CachedFileInfo{{
+		Name:     "cached.txt",
+		Size:     12,
+		IsDir:    false,
+		Mtime:    mtime,
+		Revision: 7,
+	}})
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "cached.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote calls = %d, want 0", got)
+	}
+	if got, want := out.Size, uint64(12); got != want {
+		t.Fatalf("Lookup size = %d, want %d", got, want)
+	}
+	entry, ok := fs.inodes.GetEntry(out.NodeId)
+	if !ok {
+		t.Fatal("lookup inode entry not found")
+	}
+	if entry.Revision != 7 {
+		t.Fatalf("inode revision = %d, want 7", entry.Revision)
+	}
+}
+
+func TestLookupUsesDirCacheNegativeEntryWithoutRemoteStat(t *testing.T) {
+	var remoteCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "unexpected remote call", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs.dirCache.Put("/", []CachedFileInfo{{Name: "other.txt", Size: 1}})
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "missing.txt", &out)
+	if st != gofuse.ENOENT {
+		t.Fatalf("Lookup status = %v, want ENOENT", st)
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote calls = %d, want 0", got)
+	}
+	if out.NodeId != 0 {
+		t.Fatalf("negative lookup NodeId = %d, want 0", out.NodeId)
+	}
+}
+
+func TestLookupListFallbackPopulatesDirCacheForLaterMisses(t *testing.T) {
+	var headCalls atomic.Int32
+	var listCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			http.Error(w, "not found", http.StatusNotFound)
+		case http.MethodGet:
+			if r.URL.Path == "/v1/fs/" && r.URL.Query().Get("list") == "1" {
+				listCalls.Add(1)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"entries": []map[string]any{{
+						"name":  "listed.txt",
+						"isDir": false,
+						"size":  3,
+					}},
+				})
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	var first gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "first-missing.txt", &first)
+	if st != gofuse.ENOENT {
+		t.Fatalf("first Lookup status = %v, want ENOENT", st)
+	}
+
+	var second gofuse.EntryOut
+	st = fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "second-missing.txt", &second)
+	if st != gofuse.ENOENT {
+		t.Fatalf("second Lookup status = %v, want ENOENT", st)
+	}
+
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+	if got := listCalls.Load(); got != 1 {
+		t.Fatalf("list calls = %d, want 1", got)
+	}
+}
+
 func TestLookupUsesRemoteRootMapping(t *testing.T) {
 	var gotPath string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4064,6 +4181,152 @@ func TestRenamePendingNewCommitFallsBackWhenFinalTargetExists(t *testing.T) {
 	}
 	if shadow.Has(oldP) {
 		t.Fatal("old temp shadow still exists")
+	}
+}
+
+func TestRenamePendingNewCommitUsesRemoteRenameWhenCanceledUploadBecameVisible(t *testing.T) {
+	oldP := "/repo/.git/config.lock"
+	newP := "/repo/.git/config"
+	data := []byte("[core]\n\trepositoryformatversion = 0\n")
+
+	oldPutStarted := make(chan struct{})
+	var oldPutOnce sync.Once
+	var oldPuts atomic.Int32
+	var finalPuts atomic.Int32
+	var renameCalls atomic.Int32
+	var oldRemoteExists atomic.Bool
+	var newRemoteExists atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs"+newP:
+			if newRemoteExists.Load() {
+				w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "2")
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			http.NotFound(w, r)
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs"+oldP:
+			if oldRemoteExists.Load() {
+				w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "1")
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			http.NotFound(w, r)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+oldP:
+			oldPuts.Add(1)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if string(body) != string(data) {
+				http.Error(w, "unexpected temp upload body", http.StatusBadRequest)
+				return
+			}
+			oldRemoteExists.Store(true)
+			oldPutOnce.Do(func() { close(oldPutStarted) })
+			<-r.Context().Done()
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+newP:
+			finalPuts.Add(1)
+			http.Error(w, "final path should not be uploaded directly when old temp is already remote-visible", http.StatusInternalServerError)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs"+newP && r.URL.RawQuery == "rename":
+			if got := r.Header.Get("X-Dat9-Rename-Source"); got != oldP {
+				http.Error(w, "unexpected rename source "+got, http.StatusBadRequest)
+				return
+			}
+			renameCalls.Add(1)
+			oldRemoteExists.Store(false)
+			newRemoteExists.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	c := client.New(ts.URL, "")
+	fs := NewDat9FS(c, opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 16)
+	defer cq.DrainAll()
+	fs.commitQueue = cq
+
+	if err := shadow.WriteFull(oldP, data, 0); err != nil {
+		t.Fatalf("WriteFull old shadow: %v", err)
+	}
+	if _, err := pending.PutWithBaseRev(oldP, int64(len(data)), PendingNew, 0); err != nil {
+		t.Fatalf("PutWithBaseRev old pending: %v", err)
+	}
+	oldIno := fs.inodes.Lookup(oldP, false, int64(len(data)), time.Now())
+	dirIno := fs.inodes.Lookup("/repo/.git", true, 0, time.Now())
+
+	if err := cq.Enqueue(&CommitEntry{
+		Path:  oldP,
+		Inode: oldIno,
+		Size:  int64(len(data)),
+		Kind:  PendingNew,
+	}); err != nil {
+		t.Fatalf("enqueue old temp upload: %v", err)
+	}
+
+	select {
+	case <-oldPutStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for old temp upload to start")
+	}
+
+	st := fs.Rename(nil, &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Newdir:   dirIno,
+	}, "config.lock", "config")
+	if st != gofuse.OK {
+		t.Fatalf("Rename: %v", st)
+	}
+
+	if got := oldPuts.Load(); got != 1 {
+		t.Fatalf("old temp PUTs = %d, want 1", got)
+	}
+	if got := finalPuts.Load(); got != 0 {
+		t.Fatalf("final path PUTs = %d, want 0", got)
+	}
+	if got := renameCalls.Load(); got != 1 {
+		t.Fatalf("remote rename calls = %d, want 1", got)
+	}
+	if oldRemoteExists.Load() {
+		t.Fatal("old temp path still exists remotely")
+	}
+	if !newRemoteExists.Load() {
+		t.Fatal("final path was not made visible by remote rename")
+	}
+	if pending.HasPending(oldP) {
+		t.Fatal("old temp path still pending")
+	}
+	if shadow.Has(oldP) {
+		t.Fatal("old temp shadow still exists")
+	}
+	if _, ok := fs.inodes.GetInode(oldP); ok {
+		t.Fatal("old temp inode still exists after rename")
+	}
+	if _, ok := fs.inodes.GetInode(newP); !ok {
+		t.Fatal("final inode missing after rename")
 	}
 }
 


### PR DESCRIPTION
## Summary
- use cached parent directory listings to answer FUSE Lookup positive and negative entries before remote stat
- cache successful Lookup list-fallback results so repeated same-directory misses avoid remote list/stat amplification
- recover pending-new rename when a canceled temp upload already became visible remotely, preventing stale git lockfiles

## Validation
- go test ./pkg/fuse -run 'TestLookupUsesDirCache|TestLookupListFallbackPopulatesDirCache|TestLookupFallsBackToParentListWhenDirStatUnsupported|TestRenamePendingNewCommitUsesRemoteRenameWhenCanceledUploadBecameVisible' -count=1
- go test ./pkg/fuse -count=1
- go test -c ./pkg/fuse ./cmd/drive9
- git diff --check -- pkg/fuse/dat9fs.go pkg/fuse/dat9fs_test.go

## EC2 smoke
- shallow clone on drive9 mount with this branch: 93.65s, down from about 175s on latest main in the same environment
- remote stat count: 2905 -> 995
- remote list count: 2378 -> 701
- FUSE lookup avg: 60ms -> 24ms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved directory lookup performance through in-memory caching of directory entries.

* **Bug Fixes**
  * Enhanced rename operation handling for edge cases involving interrupted uploads becoming remotely visible.
  * Improved retry and caching behavior for filesystem operations.

* **Tests**
  * Added tests validating directory cache functionality and avoiding unnecessary remote calls.
  * Added regression test for rename operations with interrupted uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->