### PR TITLE
fix(fuse): enforce UTF-8 text detection and fix git pack mmap compatibility

### DIFF
--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -183,6 +183,7 @@ func TestF_ImportStoresDelegatedContext(t *testing.T) {
 	got := cfg.Contexts["alice-prod-db"]
 	if got == nil {
 		t.Fatalf("context %q missing", "alice-prod-db")
+		return
 	}
 	if got.Type != PrincipalDelegated {
 		t.Errorf("type = %q, want delegated", got.Type)

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mem9-ai/dat9/pkg/buildinfo"
 	"github.com/mem9-ai/dat9/pkg/client"
 	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
 	"github.com/mem9-ai/dat9/pkg/mountpath"
@@ -40,6 +41,7 @@ var mountFuse = drive9fuse.Mount
 // a positional-arity error rather than by pre-reserving backend-shaped
 // words that do not exist yet.
 func MountCmd(args []string) error {
+	fmt.Fprint(os.Stderr, buildinfo.String("drive9 mount"))
 	if len(args) > 0 {
 		if args[0] == "vault" {
 			return VaultMountCmd(args[1:])
@@ -152,7 +154,7 @@ func fsMountCmd(args []string) error {
 
 	// Resolve auto mode to a concrete backend.
 	resolved := ResolveMountMode(mountMode, runtime.GOOS, exec.LookPath)
-	fmt.Fprintf(os.Stderr, "dat9: mount mode: %s\n", resolved)
+	fmt.Fprintf(os.Stderr, "drive9: mount mode: %s\n", resolved)
 
 	if resolved == MountModeWebDAV && *readOnly {
 		return fmt.Errorf("drive9 mount: --read-only is not supported with WebDAV mode")
@@ -231,7 +233,7 @@ func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 	if remoteRoot == "/" {
 		// Root always exists; verify server connectivity via List.
 		if _, err := c.List("/"); err != nil {
-			return fmt.Errorf("cannot reach dat9 server: %w", err)
+			return fmt.Errorf("cannot reach drive9 server: %w", err)
 		}
 		return nil
 	}

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -172,7 +172,7 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 		return explainMountError(deps.goos, mountPoint, err)
 	}
 
-	fmt.Fprintf(os.Stderr, "drive9: mounted on %s via WebDAV (%s)\n", mountPoint, serverURL)
+	fmt.Fprintf(os.Stderr, "drive9: mounted on %s via WebDAV (server: %s)\n", mountPoint, serverURL)
 
 	// Signal handling for graceful shutdown.
 	go func() {

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -172,17 +172,17 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 		return explainMountError(deps.goos, mountPoint, err)
 	}
 
-	fmt.Fprintf(os.Stderr, "dat9: mounted on %s via WebDAV (%s)\n", mountPoint, serverURL)
+	fmt.Fprintf(os.Stderr, "drive9: mounted on %s via WebDAV (%s)\n", mountPoint, serverURL)
 
 	// Signal handling for graceful shutdown.
 	go func() {
 		<-deps.signals
-		fmt.Fprintf(os.Stderr, "\ndat9: unmounting %s...\n", mountPoint)
+		fmt.Fprintf(os.Stderr, "\ndrive9: unmounting %s...\n", mountPoint)
 
 		// Second signal forces exit.
 		go func() {
 			<-deps.signals
-			fmt.Fprintf(os.Stderr, "dat9: forced exit\n")
+			fmt.Fprintf(os.Stderr, "drive9: forced exit\n")
 			deps.exit(1)
 		}()
 
@@ -326,6 +326,6 @@ func webdavUnmount(goos, mountPoint string) {
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "dat9: webdav unmount failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "drive9: webdav unmount failed: %v\n", err)
 	}
 }

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -446,6 +446,7 @@ func init() {
 // ---------------------------------------------------------------------------
 
 func TestFsMountCmd_RemoteSourceParsing(t *testing.T) {
+	isolateMountCredentialsForTest(t)
 	// 2-arg with valid remote source should parse (will fail at credential
 	// resolution, but that proves parsing succeeded).
 	err := fsMountCmd([]string{":/foo/bar", "/tmp/drive9-remote-test"})
@@ -479,6 +480,7 @@ func TestFsMountCmd_RejectsContextScopedRemote(t *testing.T) {
 }
 
 func TestFsMountCmd_SingleArgDefaultsToRootRemote(t *testing.T) {
+	isolateMountCredentialsForTest(t)
 	// Single arg should work (fail at credentials, not at parsing).
 	err := fsMountCmd([]string{"/tmp/drive9-single-arg-test"})
 	if err == nil {
@@ -488,6 +490,20 @@ func TestFsMountCmd_SingleArgDefaultsToRootRemote(t *testing.T) {
 	if strings.Contains(err.Error(), "remote source") {
 		t.Fatalf("single arg should not trigger remote-source error: %v", err)
 	}
+}
+
+// isolateMountCredentialsForTest keeps parsing-only mount tests from reading
+// the developer machine's DRIVE9_* env vars or active drive9 context. Without
+// this, a test that expects credential resolution to fail can reach the real
+// WebDAV mount path and block waiting for an unmount signal.
+func isolateMountCredentialsForTest(t *testing.T) {
+	t.Helper()
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(EnvServer, "")
+	t.Setenv(EnvAPIKey, "")
+	t.Setenv(EnvVaultToken, "")
 }
 
 func newWebDAVLifecycleClient(t *testing.T) *client.Client {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/mem9-ai/dat9/pkg/datastore"
@@ -1155,6 +1156,9 @@ func detectContentType(path string, data []byte) string {
 	ext := pathutil.Ext(path)
 	if ext != "" {
 		if ct := mime.TypeByExtension(ext); ct != "" {
+			if isTextualContentType(ct) && !isTextContent(data) {
+				return "application/octet-stream"
+			}
 			return ct
 		}
 	}
@@ -1170,14 +1174,21 @@ func isTextContent(data []byte) bool {
 			return false
 		}
 	}
-	return true
+	return utf8.Valid(data)
+}
+
+func isTextualContentType(contentType string) bool {
+	return strings.HasPrefix(contentType, "text/") ||
+		contentType == "application/json" ||
+		contentType == "application/xml" ||
+		contentType == "application/yaml"
 }
 
 func extractText(data []byte, contentType string) string {
-	if !strings.HasPrefix(contentType, "text/") &&
-		contentType != "application/json" &&
-		contentType != "application/xml" &&
-		contentType != "application/yaml" {
+	if !isTextualContentType(contentType) {
+		return ""
+	}
+	if !isTextContent(data) {
 		return ""
 	}
 	if len(data) > textExtractMaxBytes {

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -207,6 +207,20 @@ func TestExtractTextUsesEmbeddingSafeLimit(t *testing.T) {
 	if got := extractText([]byte("hello"), "text/plain"); got != "hello" {
 		t.Fatalf("small text extracted as %q, want hello", got)
 	}
+	if got := extractText([]byte{0x66, 0x6f, 0x80}, "text/plain"); got != "" {
+		t.Fatalf("invalid UTF-8 text should not be extracted, got %q", got)
+	}
+}
+
+func TestDetectContentTypeRequiresValidUTF8ForText(t *testing.T) {
+	data := []byte{0x78, 0x01, 0x95, 0x90, 0xbd, 0x6a}
+	if got := detectContentType("/objects/61/31ee8937c5f0aff1268064d5f2218d7d240056", data); got != "application/octet-stream" {
+		t.Fatalf("content type=%q, want application/octet-stream", got)
+	}
+	gbkCSV := []byte{0xb0, 0xa1, ',', 'x', '\n'}
+	if got := detectContentType("/data/gbk.csv", gbkCSV); got != "application/octet-stream" {
+		t.Fatalf("content type=%q, want application/octet-stream for invalid UTF-8 text extension", got)
+	}
 }
 
 func TestWriteAndRead(t *testing.T) {

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -221,6 +221,9 @@ func TestDetectContentTypeRequiresValidUTF8ForText(t *testing.T) {
 	if got := detectContentType("/data/gbk.csv", gbkCSV); got != "application/octet-stream" {
 		t.Fatalf("content type=%q, want application/octet-stream for invalid UTF-8 text extension", got)
 	}
+	if got := detectContentType("/config.json", gbkCSV); got != "application/octet-stream" {
+		t.Fatalf("content type=%q, want application/octet-stream for invalid UTF-8 JSON extension", got)
+	}
 }
 
 func TestWriteAndRead(t *testing.T) {

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -178,6 +178,7 @@ func TestWriteStreamWithSummarySmallFile(t *testing.T) {
 	}
 	if summary == nil {
 		t.Fatal("summary is nil")
+		return
 	}
 	if summary.Type != "upload_summary" {
 		t.Fatalf("summary.Type = %q, want upload_summary", summary.Type)
@@ -1494,6 +1495,7 @@ func TestDownloadToFileWithSummaryReusesPresignedURL(t *testing.T) {
 	}
 	if summary == nil {
 		t.Fatal("expected download summary for large-file path")
+		return
 	}
 	if got := readRequests.Load(); got != 1 {
 		t.Fatalf("expected one /v1/fs request, got %d", got)

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -41,6 +41,7 @@ func requireEmbeddingRevision(t *testing.T, got *int64, want int64) {
 	t.Helper()
 	if got == nil {
 		t.Fatalf("embedding_revision=nil, want %d", want)
+		return
 	}
 	if *got != want {
 		t.Fatalf("embedding_revision=%d, want %d", *got, want)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1888,6 +1888,21 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 
 		// The cancel may have raced with a successful upload. If so, the old
 		// path now exists remotely and the normal server-side rename is correct.
+		oldRemoteExists, err := fs.remotePathExists(ctx, oldP)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return pendingRenameNotApplicable, err
+			}
+			log.Printf("rename: probe old pending-new source %s failed, using remote fallback: %v", oldP, err)
+			return pendingRenameRemoteFallback, nil
+		}
+		if oldRemoteExists {
+			if fs.shadowStore != nil {
+				fs.shadowStore.Remove(oldP)
+			}
+			fs.pendingIndex.Remove(oldP)
+			return pendingRenameRemoteFallback, nil
+		}
 		meta, ok = fs.pendingIndex.GetMeta(oldP)
 		if !ok || meta.Kind != PendingNew {
 			return pendingRenameRemoteFallback, nil
@@ -1964,6 +1979,19 @@ func (fs *Dat9FS) pendingRenameTargetExists(ctx context.Context, p string) (bool
 	if fs.commitQueue != nil && fs.commitQueue.HasPath(p) {
 		return true, nil
 	}
+	statStart := fs.perfStart()
+	_, err := fs.client.StatCtx(ctx, fs.remotePath(p))
+	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
+	if err == nil {
+		return true, nil
+	}
+	if isNotFoundErr(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (fs *Dat9FS) remotePathExists(ctx context.Context, p string) (bool, error) {
 	statStart := fs.perfStart()
 	_, err := fs.client.StatCtx(ctx, fs.remotePath(p))
 	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
@@ -2610,10 +2638,10 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			out.OpenFlags = gofuse.FOPEN_KEEP_CACHE
 		}
 	} else if fh.Prefetch != nil {
-		// Large read-only files with prefetcher: use DIRECT_IO so every
-		// read goes through our Read handler (no kernel page cache).
-		// The prefetcher provides its own caching layer.
-		out.OpenFlags = gofuse.FOPEN_DIRECT_IO
+		// Large read-only files still need kernel caching so mmap-based
+		// readers (notably git pack access) do not SIGBUS on macFUSE.
+		// Reads still populate the userspace prefetcher on cache misses.
+		out.OpenFlags = gofuse.FOPEN_KEEP_CACHE
 	} else {
 		out.OpenFlags = gofuse.FOPEN_KEEP_CACHE
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1888,9 +1888,7 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 
 		// The cancel may have raced with a successful upload. If so, the old
 		// path now exists remotely and the normal server-side rename is correct.
-		probeCtx, probeCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
-		oldRemoteExists, err := fs.remotePathExists(probeCtx, oldP)
-		probeCancel()
+		oldRemoteExists, err := fs.remotePathExistsDetached(oldP)
 		if err != nil {
 			log.Printf("rename: probe old pending-new source %s failed, using remote fallback: %v", oldP, err)
 			return pendingRenameRemoteFallback, nil

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2643,12 +2643,10 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		} else {
 			out.OpenFlags = gofuse.FOPEN_KEEP_CACHE
 		}
-	} else if fh.Prefetch != nil {
-		// Large read-only files still need kernel caching so mmap-based
-		// readers (notably git pack access) do not SIGBUS on macFUSE.
-		// Reads still populate the userspace prefetcher on cache misses.
-		out.OpenFlags = gofuse.FOPEN_KEEP_CACHE
 	} else {
+		// Read-only opens need kernel caching so mmap-based readers (notably
+		// git pack access) do not SIGBUS on macFUSE. Prefetch-backed reads
+		// still populate the userspace prefetcher on cache misses.
 		out.OpenFlags = gofuse.FOPEN_KEEP_CACHE
 	}
 	fs.debugf("open path=%s fh=%d ino=%d flags=0x%x open_flags=%d dirty=%t prefetch=%t orig_size=%d base_rev=%d shadow_ready=%t shadow_spill=%t", p, out.Fh, fh.Ino, input.Flags, out.OpenFlags, fh.Dirty != nil, fh.Prefetch != nil, fh.OrigSize, fh.BaseRev, fh.ShadowReady, fh.ShadowSpill)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1987,19 +1987,6 @@ func (fs *Dat9FS) pendingRenameTargetExists(ctx context.Context, p string) (bool
 	return false, err
 }
 
-func (fs *Dat9FS) remotePathExists(ctx context.Context, p string) (bool, error) {
-	statStart := fs.perfStart()
-	_, err := fs.client.StatCtx(ctx, fs.remotePath(p))
-	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
-	if err == nil {
-		return true, nil
-	}
-	if isNotFoundErr(err) {
-		return false, nil
-	}
-	return false, err
-}
-
 func (fs *Dat9FS) finishLocalRename(input *gofuse.RenameIn, oldP, newP string) {
 	fs.inodes.Rename(oldP, newP)
 	fs.readCache.Invalidate(oldP)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1870,11 +1870,10 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 	if fs.commitQueue != nil {
 		fs.commitQueue.WaitPath(newP)
 	}
-	targetExists, err := fs.pendingRenameTargetExists(ctx, newP)
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+	targetExists, err := fs.pendingRenameTargetExists(probeCtx, newP)
+	probeCancel()
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return pendingRenameNotApplicable, err
-		}
 		log.Printf("rename: probe final pending-new target %s failed, using remote fallback: %v", newP, err)
 		return pendingRenameRemoteFallback, nil
 	}
@@ -1888,11 +1887,10 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 
 		// The cancel may have raced with a successful upload. If so, the old
 		// path now exists remotely and the normal server-side rename is correct.
-		oldRemoteExists, err := fs.remotePathExists(ctx, oldP)
+		probeCtx, probeCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+		oldRemoteExists, err := fs.remotePathExists(probeCtx, oldP)
+		probeCancel()
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return pendingRenameNotApplicable, err
-			}
 			log.Printf("rename: probe old pending-new source %s failed, using remote fallback: %v", oldP, err)
 			return pendingRenameRemoteFallback, nil
 		}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1851,6 +1851,7 @@ type pendingRenameResult int
 const (
 	pendingRenameNotApplicable pendingRenameResult = iota
 	pendingRenameRemoteFallback
+	pendingRenameRemoteFallbackCleanupOld
 	pendingRenameHandled
 )
 
@@ -1895,11 +1896,10 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 			return pendingRenameRemoteFallback, nil
 		}
 		if oldRemoteExists {
-			if fs.shadowStore != nil {
-				fs.shadowStore.Remove(oldP)
-			}
-			fs.pendingIndex.Remove(oldP)
-			return pendingRenameRemoteFallback, nil
+			// The caller still needs to execute the remote rename. Keep local
+			// state until that succeeds so a remote rename failure can be
+			// retried from the preserved shadow/pending entry.
+			return pendingRenameRemoteFallbackCleanupOld, nil
 		}
 		meta, ok = fs.pendingIndex.GetMeta(oldP)
 		if !ok || meta.Kind != PendingNew {
@@ -2106,6 +2106,14 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 
 	if err := fs.renameRemoteWithTransientRetry(ctx, oldP, newP); err != nil {
 		return httpToFuseStatus(err)
+	}
+	if pendingRename == pendingRenameRemoteFallbackCleanupOld {
+		if fs.shadowStore != nil {
+			fs.shadowStore.Remove(oldP)
+		}
+		if fs.pendingIndex != nil {
+			fs.pendingIndex.Remove(oldP)
+		}
 	}
 
 	// After server-side rename, migrate pending descendants.

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -4992,6 +4992,121 @@ func TestRenamePendingNewCommitFallsBackWhenCanceledUploadReachedRemote(t *testi
 	}
 }
 
+func TestRenamePendingNewCommitOldVisibilityProbeIgnoresFuseCancel(t *testing.T) {
+	oldP := "/repo/.git/config.lock"
+	newP := "/repo/.git/config"
+
+	oldHeadStarted := make(chan struct{})
+	oldHeadCanceled := make(chan struct{})
+	allowOldHead := make(chan struct{})
+	var oldHeadOnce sync.Once
+	var oldHeadCanceledOnce sync.Once
+	var renameCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs"+newP:
+			http.NotFound(w, r)
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs"+oldP:
+			oldHeadOnce.Do(func() { close(oldHeadStarted) })
+			select {
+			case <-allowOldHead:
+			case <-r.Context().Done():
+				oldHeadCanceledOnce.Do(func() { close(oldHeadCanceled) })
+				return
+			}
+			w.Header().Set("Content-Length", "36")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs"+newP && r.URL.RawQuery == "rename":
+			if r.Header.Get("X-Dat9-Rename-Source") != oldP {
+				t.Errorf("rename source = %q, want %q", r.Header.Get("X-Dat9-Rename-Source"), oldP)
+			}
+			renameCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	c := client.New(ts.URL, "")
+	fs := NewDat9FS(c, opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = NewCommitQueue(c, shadow, pending, nil, 1, 16)
+	defer fs.commitQueue.DrainAll()
+
+	data := []byte("[core]\n\tfilemode = false\n")
+	if err := shadow.WriteFull(oldP, data, 0); err != nil {
+		t.Fatalf("WriteFull old shadow: %v", err)
+	}
+	if _, err := pending.PutWithBaseRev(oldP, int64(len(data)), PendingNew, 0); err != nil {
+		t.Fatalf("PutWithBaseRev old pending: %v", err)
+	}
+	dirIno := fs.inodes.Lookup("/repo/.git", true, 0, time.Now())
+	fs.inodes.Lookup(oldP, false, int64(len(data)), time.Now())
+
+	cancel := make(chan struct{})
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		done <- fs.Rename(cancel, &gofuse.RenameIn{
+			InHeader: gofuse.InHeader{NodeId: dirIno},
+			Newdir:   dirIno,
+		}, "config.lock", "config")
+	}()
+
+	select {
+	case <-oldHeadStarted:
+		close(cancel)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for old-path visibility probe")
+	}
+	select {
+	case <-oldHeadCanceled:
+		t.Fatal("old-path visibility probe used the canceled FUSE request context")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(allowOldHead)
+
+	select {
+	case st := <-done:
+		if st != gofuse.OK {
+			t.Fatalf("Rename status = %v, want OK", st)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Rename timed out")
+	}
+	if got := renameCalls.Load(); got != 1 {
+		t.Fatalf("remote rename calls = %d, want 1", got)
+	}
+	if pending.HasPending(oldP) {
+		t.Fatal("old lock path should not remain pending after remote fallback")
+	}
+	if shadow.Has(oldP) {
+		t.Fatal("old lock shadow should be removed after remote fallback")
+	}
+	if _, ok := fs.inodes.GetInode(oldP); ok {
+		t.Fatal("old lock inode should not remain mapped after rename")
+	}
+	if _, ok := fs.inodes.GetInode(newP); !ok {
+		t.Fatal("new config inode should be mapped after rename")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Read detached retry tests
 // ---------------------------------------------------------------------------

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1591,6 +1591,9 @@ func TestOpenReadOnlyLargeFileGetsPrefetcher(t *testing.T) {
 	if fh.Prefetch == nil {
 		t.Fatal("expected Prefetcher to be set for large read-only file")
 	}
+	if out.OpenFlags != gofuse.FOPEN_KEEP_CACHE {
+		t.Fatalf("open flags = %d, want FOPEN_KEEP_CACHE for mmap compatibility", out.OpenFlags)
+	}
 }
 
 func TestOpenWritableLargeFileGetsLazyPreload(t *testing.T) {
@@ -4905,6 +4908,87 @@ func TestRenameRemoteWithTransientRetryDoesNotAcceptPreexistingTarget(t *testing
 	}
 	if sourceExists.Load() {
 		t.Fatal("retry did not commit the overwrite rename")
+	}
+}
+
+func TestRenamePendingNewCommitFallsBackWhenCanceledUploadReachedRemote(t *testing.T) {
+	oldP := "/repo/.git/config.lock"
+	newP := "/repo/.git/config"
+
+	var renameCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs"+newP:
+			http.NotFound(w, r)
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs"+oldP:
+			w.Header().Set("Content-Length", "36")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs"+newP && r.URL.RawQuery == "rename":
+			if r.Header.Get("X-Dat9-Rename-Source") != oldP {
+				t.Errorf("rename source = %q, want %q", r.Header.Get("X-Dat9-Rename-Source"), oldP)
+			}
+			renameCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	c := client.New(ts.URL, "")
+	fs := NewDat9FS(c, opts)
+
+	shadowDir := t.TempDir()
+	pendingDir := t.TempDir()
+	shadow, err := NewShadowStore(shadowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(pendingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = NewCommitQueue(c, shadow, pending, nil, 1, 16)
+	defer fs.commitQueue.DrainAll()
+
+	data := []byte("[core]\n\tfilemode = false\n")
+	if err := shadow.WriteFull(oldP, data, 0); err != nil {
+		t.Fatalf("WriteFull old shadow: %v", err)
+	}
+	if _, err := pending.PutWithBaseRev(oldP, int64(len(data)), PendingNew, 0); err != nil {
+		t.Fatalf("PutWithBaseRev old pending: %v", err)
+	}
+	dirIno := fs.inodes.Lookup("/repo/.git", true, 0, time.Now())
+	fs.inodes.Lookup(oldP, false, int64(len(data)), time.Now())
+
+	st := fs.Rename(nil, &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Newdir:   dirIno,
+	}, "config.lock", "config")
+	if st != gofuse.OK {
+		t.Fatalf("Rename status = %v, want OK", st)
+	}
+	if got := renameCalls.Load(); got != 1 {
+		t.Fatalf("remote rename calls = %d, want 1", got)
+	}
+	if pending.HasPending(oldP) {
+		t.Fatal("old lock path should not remain pending after remote fallback")
+	}
+	if shadow.Has(oldP) {
+		t.Fatal("old lock shadow should be removed after remote fallback")
+	}
+	if _, ok := fs.inodes.GetInode(oldP); ok {
+		t.Fatal("old lock inode should not remain mapped after rename")
+	}
+	if _, ok := fs.inodes.GetInode(newP); !ok {
+		t.Fatal("new config inode should be mapped after rename")
 	}
 }
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -184,8 +184,9 @@ func Mount(opts *MountOptions) error {
 	fmt.Fprintf(os.Stderr, "drive9: sync mode: %s\n", resolved)
 
 	// Initialize write-back cache, shadow store, and pending index.
+	var cacheBase, shadowDir string
 	if !opts.ReadOnly {
-		cacheBase := opts.CacheDir
+		cacheBase = opts.CacheDir
 		if cacheBase == "" {
 			home, err := os.UserHomeDir()
 			if err == nil {
@@ -195,7 +196,7 @@ func Mount(opts *MountOptions) error {
 		if cacheBase != "" {
 			mh := MountHash(opts.Server, opts.MountPoint, opts.RemoteRoot)
 			pendingDir := filepath.Join(cacheBase, mh, "pending")
-			shadowDir := filepath.Join(cacheBase, mh, "shadow")
+			shadowDir = filepath.Join(cacheBase, mh, "shadow")
 
 			// Initialize PendingIndex (in-memory authoritative metadata).
 			pendingIdx, err := NewPendingIndex(pendingDir)
@@ -381,7 +382,12 @@ func Mount(opts *MountOptions) error {
 		forceUnmount(opts.MountPoint)
 	}()
 
-	fmt.Fprintf(os.Stderr, "drive9: mounted on %s (server: %s, actor: %s)\n", opts.MountPoint, opts.Server, actorID)
+	if shadowDir != "" {
+		fmt.Fprintf(os.Stderr, "drive9: mounted on %s (server: %s, actor: %s, cache: %s, shadow: %s)\n",
+			opts.MountPoint, opts.Server, actorID, cacheBase, shadowDir)
+	} else {
+		fmt.Fprintf(os.Stderr, "drive9: mounted on %s (server: %s, actor: %s)\n", opts.MountPoint, opts.Server, actorID)
+	}
 	server.Wait()
 	shutdown()
 	return nil

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -29,7 +29,7 @@ import (
 // its entire lifetime (Invariant #3). To change credentials, umount and
 // remount; there is no in-process rebind.
 type MountOptions struct {
-	Server                string        // dat9 server URL
+	Server                string        // drive9 server URL
 	APIKey                string        // owner API key (mutually exclusive with Token)
 	Token                 string        // delegated capability JWT (mutually exclusive with APIKey)
 	MountPoint            string        // local mount point
@@ -152,7 +152,7 @@ func Mount(opts *MountOptions) error {
 	opts.RemoteRoot = remoteRoot
 	if remoteRoot == "/" {
 		if _, err := c.List("/"); err != nil {
-			return fmt.Errorf("cannot reach dat9 server: %w", err)
+			return fmt.Errorf("cannot reach drive9 server: %w", err)
 		}
 	} else {
 		stat, err := c.Stat(remoteRoot)
@@ -284,8 +284,8 @@ func Mount(opts *MountOptions) error {
 
 	// Configure FUSE mount options
 	fuseOpts := &gofuse.MountOptions{
-		FsName:        "dat9",
-		Name:          "dat9",
+		FsName:        "drive9",
+		Name:          "drive9",
 		MaxReadAhead:  8 * 1024 * 1024, // 8MB — larger readahead reduces FUSE kernel↔userspace switches
 		MaxWrite:      128 * 1024,      // 128KB per write request (default 64KB)
 		MaxBackground: 32,              // concurrent background FUSE requests (default 12)
@@ -382,12 +382,8 @@ func Mount(opts *MountOptions) error {
 		forceUnmount(opts.MountPoint)
 	}()
 
-	if shadowDir != "" {
-		fmt.Fprintf(os.Stderr, "drive9: mounted on %s (server: %s, actor: %s, cache: %s, shadow: %s)\n",
-			opts.MountPoint, opts.Server, actorID, cacheBase, shadowDir)
-	} else {
-		fmt.Fprintf(os.Stderr, "drive9: mounted on %s (server: %s, actor: %s)\n", opts.MountPoint, opts.Server, actorID)
-	}
+	fmt.Fprintf(os.Stderr, "drive9: mounted on %s (server: %s, actor: %s, readonly: %v, cache: %s, shadow: %s)\n",
+		opts.MountPoint, opts.Server, actorID, opts.ReadOnly, cacheBase, shadowDir)
 	server.Wait()
 	shutdown()
 	return nil

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -181,7 +181,7 @@ func Mount(opts *MountOptions) error {
 	// Resolve sync mode (auto-detect RTT if needed).
 	resolved := ResolveMode(context.Background(), opts.SyncMode, opts.Server)
 	dat9fs.syncMode = resolved
-	fmt.Fprintf(os.Stderr, "dat9: sync mode: %s\n", resolved)
+	fmt.Fprintf(os.Stderr, "drive9: sync mode: %s\n", resolved)
 
 	// Initialize write-back cache, shadow store, and pending index.
 	if !opts.ReadOnly {
@@ -200,10 +200,10 @@ func Mount(opts *MountOptions) error {
 			// Initialize PendingIndex (in-memory authoritative metadata).
 			pendingIdx, err := NewPendingIndex(pendingDir)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "dat9: pending index init failed: %v (continuing without)\n", err)
+				fmt.Fprintf(os.Stderr, "drive9: pending index init failed: %v (continuing without)\n", err)
 			} else {
 				if err := pendingIdx.RecoverFromDisk(); err != nil {
-					fmt.Fprintf(os.Stderr, "dat9: pending index recovery: %v\n", err)
+					fmt.Fprintf(os.Stderr, "drive9: pending index recovery: %v\n", err)
 				}
 				dat9fs.pendingIndex = pendingIdx
 			}
@@ -211,7 +211,7 @@ func Mount(opts *MountOptions) error {
 			// Initialize ShadowStore.
 			shadowStore, err := NewShadowStore(shadowDir)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "dat9: shadow store init failed: %v (continuing without)\n", err)
+				fmt.Fprintf(os.Stderr, "drive9: shadow store init failed: %v (continuing without)\n", err)
 			} else {
 				dat9fs.shadowStore = shadowStore
 			}
@@ -220,7 +220,7 @@ func Mount(opts *MountOptions) error {
 			journalPath := filepath.Join(cacheBase, mh, "journal.wal")
 			journal, err := NewJournal(journalPath)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "dat9: journal init failed: %v (continuing without)\n", err)
+				fmt.Fprintf(os.Stderr, "drive9: journal init failed: %v (continuing without)\n", err)
 			} else {
 				dat9fs.journal = journal
 				// Replay journal for crash recovery. Preserve the original kind
@@ -243,7 +243,7 @@ func Mount(opts *MountOptions) error {
 			// RecoverPending would prune them as orphans (shadow missing).
 			wbCache, err := NewWriteBackCache(pendingDir)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "dat9: write-back cache init failed: %v (continuing without)\n", err)
+				fmt.Fprintf(os.Stderr, "drive9: write-back cache init failed: %v (continuing without)\n", err)
 			}
 
 			// Migrate legacy writeBack entries to shadow store so
@@ -252,7 +252,7 @@ func Mount(opts *MountOptions) error {
 				for _, pe := range wbCache.ListPending() {
 					if !shadowStore.Has(pe.Meta.Path) {
 						if err := shadowStore.WriteFull(pe.Meta.Path, pe.Data, pe.Meta.BaseRev); err != nil {
-							fmt.Fprintf(os.Stderr, "dat9: migrate legacy entry %s to shadow: %v\n", pe.Meta.Path, err)
+							fmt.Fprintf(os.Stderr, "drive9: migrate legacy entry %s to shadow: %v\n", pe.Meta.Path, err)
 						}
 					}
 				}
@@ -340,7 +340,7 @@ func Mount(opts *MountOptions) error {
 	}
 	defer func() {
 		if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "dat9: remove mount pid file %s: %v\n", pidFile, err)
+			fmt.Fprintf(os.Stderr, "drive9: remove mount pid file %s: %v\n", pidFile, err)
 		}
 	}()
 
@@ -352,12 +352,12 @@ func Mount(opts *MountOptions) error {
 
 	go func() {
 		<-sigCh
-		fmt.Fprintf(os.Stderr, "\ndat9: unmounting %s...\n", opts.MountPoint)
+		fmt.Fprintf(os.Stderr, "\ndrive9: unmounting %s...\n", opts.MountPoint)
 
 		// Second Ctrl+C during unmount exits immediately.
 		go func() {
 			<-sigCh
-			fmt.Fprintf(os.Stderr, "dat9: forced exit\n")
+			fmt.Fprintf(os.Stderr, "drive9: forced exit\n")
 			os.Exit(1)
 		}()
 
@@ -370,18 +370,18 @@ func Mount(opts *MountOptions) error {
 			if unmountErr = server.Unmount(); unmountErr == nil {
 				return
 			}
-			fmt.Fprintf(os.Stderr, "dat9: unmount attempt %d/%d failed: %v\n", i+1, maxRetries, unmountErr)
+			fmt.Fprintf(os.Stderr, "drive9: unmount attempt %d/%d failed: %v\n", i+1, maxRetries, unmountErr)
 			if i < maxRetries-1 {
 				time.Sleep(500 * time.Millisecond)
 			}
 		}
 
 		// All retries exhausted — force unmount via OS tool.
-		fmt.Fprintf(os.Stderr, "dat9: retries exhausted, force-unmounting %s\n", opts.MountPoint)
+		fmt.Fprintf(os.Stderr, "drive9: retries exhausted, force-unmounting %s\n", opts.MountPoint)
 		forceUnmount(opts.MountPoint)
 	}()
 
-	fmt.Fprintf(os.Stderr, "dat9: mounted on %s (server: %s, actor: %s)\n", opts.MountPoint, opts.Server, actorID)
+	fmt.Fprintf(os.Stderr, "drive9: mounted on %s (server: %s, actor: %s)\n", opts.MountPoint, opts.Server, actorID)
 	server.Wait()
 	shutdown()
 	return nil
@@ -413,7 +413,7 @@ func forceUnmount(mountpoint string) {
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "dat9: force unmount failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "drive9: force unmount failed: %v\n", err)
 	}
 }
 

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -250,25 +250,25 @@ func (p *fusePerfCounters) printSummary(w io.Writer) {
 		return
 	}
 	snap := p.snapshot()
-	writePerfLine(w, "dat9: FUSE perf summary uptime=%s\n", snap.Uptime.Truncate(time.Millisecond))
+	writePerfLine(w, "drive9: FUSE perf summary uptime=%s\n", snap.Uptime.Truncate(time.Millisecond))
 	writePerfOps(w, "fuse", perfFuseOpNames[:], snap.FuseOps)
 	writePerfOps(w, "remote", perfRemoteOpNames[:], snap.RemoteOps)
-	writePerfLine(w, "dat9: perf cache read_hit=%d read_miss=%d dir_hit=%d dir_miss=%d prefetch_hit=%d prefetch_miss=%d\n",
+	writePerfLine(w, "drive9: perf cache read_hit=%d read_miss=%d dir_hit=%d dir_miss=%d prefetch_hit=%d prefetch_miss=%d\n",
 		snap.Counters["read_cache_hit"], snap.Counters["read_cache_miss"],
 		snap.Counters["dir_cache_hit"], snap.Counters["dir_cache_miss"],
 		snap.Counters["prefetch_hit"], snap.Counters["prefetch_miss"])
-	writePerfLine(w, "dat9: perf retries lookup_total=%d lookup_success=%d lookup_exhausted=%d read_total=%d read_success=%d read_exhausted=%d\n",
+	writePerfLine(w, "drive9: perf retries lookup_total=%d lookup_success=%d lookup_exhausted=%d read_total=%d read_success=%d read_exhausted=%d\n",
 		snap.Counters["lookup_retry_total"], snap.Counters["lookup_retry_success"], snap.Counters["lookup_retry_exhausted"],
 		snap.Counters["read_retry_total"], snap.Counters["read_retry_success"], snap.Counters["read_retry_exhausted"])
-	writePerfLine(w, "dat9: perf commit enqueue=%d enqueue_errors=%d retries=%d success=%d failure=%d drain_count=%d drain_total=%s\n",
+	writePerfLine(w, "drive9: perf commit enqueue=%d enqueue_errors=%d retries=%d success=%d failure=%d drain_count=%d drain_total=%s\n",
 		snap.Counters["commit_enqueue"], snap.Counters["commit_enqueue_error"], snap.Counters["commit_retry"],
 		snap.Counters["commit_success"], snap.Counters["commit_failure"],
 		snap.Counters["commit_drain_count"], time.Duration(snap.Counters["commit_drain_total_ns"]).Truncate(time.Millisecond))
-	writePerfLine(w, "dat9: perf uploader submit=%d sync_fallback=%d success=%d failure=%d drain_count=%d drain_total=%s\n",
+	writePerfLine(w, "drive9: perf uploader submit=%d sync_fallback=%d success=%d failure=%d drain_count=%d drain_total=%s\n",
 		snap.Counters["uploader_submit"], snap.Counters["uploader_sync_fallback"],
 		snap.Counters["uploader_success"], snap.Counters["uploader_failure"],
 		snap.Counters["uploader_drain_count"], time.Duration(snap.Counters["uploader_drain_total_ns"]).Truncate(time.Millisecond))
-	writePerfLine(w, "dat9: perf sse change=%d reset=%d self_filtered=%d notify_entry=%d notify_inode=%d\n",
+	writePerfLine(w, "drive9: perf sse change=%d reset=%d self_filtered=%d notify_entry=%d notify_inode=%d\n",
 		snap.Counters["sse_change"], snap.Counters["sse_reset"], snap.Counters["sse_self_filtered"],
 		snap.Counters["notify_entry"], snap.Counters["notify_inode"])
 }
@@ -283,7 +283,7 @@ func writePerfOps(w io.Writer, group string, names []string, stats map[string]pe
 		if st.count > 0 && st.totalNS > 0 {
 			avg = time.Duration(st.totalNS / st.count)
 		}
-		writePerfLine(w, "dat9: perf %s %s count=%d errors=%d bytes=%d avg=%s\n",
+		writePerfLine(w, "drive9: perf %s %s count=%d errors=%d bytes=%d avg=%s\n",
 			group, name, st.count, st.errors, st.bytes, avg.Truncate(time.Microsecond))
 	}
 }

--- a/pkg/fuse/perf_test.go
+++ b/pkg/fuse/perf_test.go
@@ -45,7 +45,7 @@ func TestFusePerfCountersSummary(t *testing.T) {
 	perf.printSummary(&out)
 	text := out.String()
 	for _, want := range []string{
-		"dat9: FUSE perf summary",
+		"drive9: FUSE perf summary",
 		"perf fuse lookup count=1",
 		"perf fuse read count=1 errors=1 bytes=128",
 		"perf remote read count=1",

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -82,7 +82,7 @@ func (w *SSEWatcher) handleChange(ce *client.ChangeEvent) {
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "dat9: SSE event op=%s path=%s local=%s actor=%s\n", ce.Op, remotePath, p, ce.Actor)
+	fmt.Fprintf(os.Stderr, "drive9: SSE event op=%s path=%s local=%s actor=%s\n", ce.Op, remotePath, p, ce.Actor)
 
 	// Invalidate read cache for the changed file.
 	w.fs.readCache.Invalidate(p)
@@ -107,7 +107,7 @@ func (w *SSEWatcher) handleReset(resets ...*client.ResetEvent) {
 		seq = resets[0].Seq
 		reason = resets[0].Reason
 	}
-	fmt.Fprintf(os.Stderr, "dat9: SSE reset — invalidating all caches\n")
+	fmt.Fprintf(os.Stderr, "drive9: SSE reset — invalidating all caches\n")
 	w.fs.debugf("sse reset start seq=%d reason=%s", seq, reason)
 
 	// 1. Clear all user-space caches.

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -2049,6 +2049,10 @@ func TestRmdir_CleansPendingDescendants(t *testing.T) {
 // and that migrated descendants are actually uploaded to the new paths.
 func TestRename_Directory_MigratesPendingDescendants(t *testing.T) {
 	var uploadedPaths sync.Map
+	allowUploadResponses := make(chan struct{})
+	var allowUploadResponsesOnce sync.Once
+	defer allowUploadResponsesOnce.Do(func() { close(allowUploadResponses) })
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodHead:
@@ -2061,6 +2065,7 @@ func TestRename_Directory_MigratesPendingDescendants(t *testing.T) {
 		case http.MethodPut:
 			_, _ = io.ReadAll(r.Body)
 			uploadedPaths.Store(r.URL.Path, true)
+			<-allowUploadResponses
 			w.WriteHeader(http.StatusOK)
 		default:
 			w.WriteHeader(http.StatusOK)
@@ -2121,6 +2126,7 @@ func TestRename_Directory_MigratesPendingDescendants(t *testing.T) {
 	}
 
 	// Drain uploader — migrated descendants should be uploaded to NEW paths.
+	allowUploadResponsesOnce.Do(func() { close(allowUploadResponses) })
 	uploader.DrainAll()
 
 	// Verify uploads happened at new paths, not old paths.

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -432,6 +432,7 @@ func TestColumnTypeMismatchSchemaVersionPlansRepair(t *testing.T) {
 	}
 	if typeDiff == nil {
 		t.Fatal("expected a column_type_mismatch diff for schema_version, got none")
+		return
 	}
 	if typeDiff.repairSQL == "" {
 		t.Fatal("expected repairSQL to be set for schema_version type mismatch")


### PR DESCRIPTION
## Summary

Fixes git clone failures on FUSE mounts by addressing two root causes:

1. **UTF-8 enforcement for text detection** — Binary data (e.g. git pack objects) was incorrectly classified as `text/*` via extension-based content type detection, causing `Incorrect string value` errors in the TiDB text content column.
2. **Git pack mmap compatibility** — Changed large prefetched file open flags from `FOPEN_DIRECT_IO` to `FOPEN_KEEP_CACHE` so mmap-based readers (git pack verification) don't SIGBUS on macFUSE.
3. **Config.lock rename race** — Added `remotePathExists` fallback in `renamePendingNewCommit` to handle canceled uploads that already reached the remote, preventing persistent stale config.lock entries.

## Changes

| File | Description |
|------|-------------|
| `pkg/backend/dat9.go` | Refactored `isTextContent` → `utf8.Valid()`; new `isTextualContentType()` helper; extension-inferred text types now require valid UTF-8 |
| `pkg/backend/dat9_test.go` | Added tests for invalid UTF-8 rejection and gbk CSV edge case |
| `pkg/fuse/dat9fs.go` | `FOPEN_DIRECT_IO` → `FOPEN_KEEP_CACHE` for prefetched files; `remotePathExists` helper; pending rename falls back to remote rename when upload-cancel-race detected |
| `pkg/fuse/dat9fs_test.go` | Test for `renamePendingNewCommit` remote fallback path |

## Verification

- `git clone --no-hardlinks` of the full tidb repo onto FUSE mount completes successfully
- `git status`, `git fsck --full`, `git verify-pack` all pass
- No more `Incorrect string value`, `SIGBUS`, or `could not lock config` errors in logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text extraction to require valid UTF-8 before treating content as text.
  * Fixed read-only file caching to avoid mmap SIGBUS and enable prefetching.
  * Enhanced pending-file rename handling to correctly fall back when remote state changes.

* **Chores**
  * Standardized user-facing branding and logging/messages to "drive9" across mounts, WebDAV, perf summaries, and SSE output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->