### PR TITLE
perf(fuse): skip lookup list fallback by default

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -18,6 +18,8 @@ import (
 	drive9webdav "github.com/mem9-ai/dat9/pkg/webdav"
 )
 
+var mountFuse = drive9fuse.Mount
+
 // MountCmd handles the "drive9 mount" command.
 //
 // Dispatch fork (Row A, V2e): the first positional argument selects the
@@ -78,6 +80,7 @@ func fsMountCmd(args []string) error {
 	flushDebounce := fs.Duration("flush-debounce", -1, "debounce window for small-file flush coalescing (default 2s, 0 disables)")
 	lookupRetryCount := fs.Int("lookup-retry-count", 2, "detached retries after transient Lookup/GetAttr stat failures (default 2, set 0 to disable)")
 	lookupRetryTimeout := fs.Duration("lookup-retry-timeout", 250*time.Millisecond, "timeout per detached Lookup/GetAttr stat retry (default 250ms, must be > 0)")
+	legacyDirStatFallback := fs.Bool("legacy-dir-stat-fallback", false, "on Lookup stat 404, list parent to support legacy servers without directory stat")
 	readDirPrefetch := fs.Bool("readdir-prefetch", false, "prefetch small files after directory reads into the read cache")
 	prefetchMaxFiles := fs.Int("readdir-prefetch-max-files", 32, "maximum small files prefetched per directory read")
 	prefetchMaxFileBytes := fs.Int64("readdir-prefetch-max-file-bytes", 50_000, "maximum individual file size prefetched by readdir prefetch")
@@ -186,33 +189,34 @@ func fsMountCmd(args []string) error {
 	}
 
 	opts := &drive9fuse.MountOptions{
-		Server:               *server,
-		APIKey:               *apiKey,
-		Token:                token,
-		MountPoint:           mountPoint,
-		RemoteRoot:           remoteRoot,
-		CacheDir:             *cacheDir,
-		CacheSize:            int64(*cacheSize) << 20,
-		DirTTL:               *dirTTL,
-		AttrTTL:              *attrTTL,
-		EntryTTL:             *entryTTL,
-		FlushDebounce:        *flushDebounce,
-		LookupRetryCount:     normalizedLookupRetryCount,
-		LookupRetryTimeout:   *lookupRetryTimeout,
-		ReadDirPrefetch:      *readDirPrefetch,
-		PrefetchMaxFiles:     *prefetchMaxFiles,
-		PrefetchMaxFileBytes: *prefetchMaxFileBytes,
-		PrefetchMaxBytes:     *prefetchMaxBytes,
-		PrefetchTimeout:      *prefetchTimeout,
-		SyncMode:             syncModeVal,
-		Profile:              *profile,
-		AllowOther:           *allowOther,
-		ReadOnly:             *readOnly,
-		Debug:                *debug,
-		PerfCounters:         *perfCounters,
+		Server:                *server,
+		APIKey:                *apiKey,
+		Token:                 token,
+		MountPoint:            mountPoint,
+		RemoteRoot:            remoteRoot,
+		CacheDir:              *cacheDir,
+		CacheSize:             int64(*cacheSize) << 20,
+		DirTTL:                *dirTTL,
+		AttrTTL:               *attrTTL,
+		EntryTTL:              *entryTTL,
+		FlushDebounce:         *flushDebounce,
+		LookupRetryCount:      normalizedLookupRetryCount,
+		LookupRetryTimeout:    *lookupRetryTimeout,
+		LegacyDirStatFallback: *legacyDirStatFallback,
+		ReadDirPrefetch:       *readDirPrefetch,
+		PrefetchMaxFiles:      *prefetchMaxFiles,
+		PrefetchMaxFileBytes:  *prefetchMaxFileBytes,
+		PrefetchMaxBytes:      *prefetchMaxBytes,
+		PrefetchTimeout:       *prefetchTimeout,
+		SyncMode:              syncModeVal,
+		Profile:               *profile,
+		AllowOther:            *allowOther,
+		ReadOnly:              *readOnly,
+		Debug:                 *debug,
+		PerfCounters:          *perfCounters,
 	}
 
-	return drive9fuse.Mount(opts)
+	return mountFuse(opts)
 }
 
 // newWebDAVHandler creates an http.Handler that serves drive9 content over WebDAV.

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
 )
 
 func fakeLookPath(binMap map[string]bool) func(string) (string, error) {
@@ -318,6 +319,67 @@ func TestResolveMountCredentials_MissingServer(t *testing.T) {
 	_, _, _, err := resolveMountCredentials(r, "", "")
 	if err == nil {
 		t.Fatal("expected error when no server URL is available")
+	}
+}
+
+func TestMountCmdPassesLegacyDirStatFallbackOption(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *drive9fuse.MountOptions
+	mountFuse = func(opts *drive9fuse.MountOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--legacy-dir-stat-fallback",
+		":/repo",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if !got.LegacyDirStatFallback {
+		t.Fatal("LegacyDirStatFallback = false, want true")
+	}
+	if got.RemoteRoot != "/repo" {
+		t.Fatalf("RemoteRoot = %q, want /repo", got.RemoteRoot)
+	}
+}
+
+func TestMountCmdLeavesLegacyDirStatFallbackDisabledByDefault(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *drive9fuse.MountOptions
+	mountFuse = func(opts *drive9fuse.MountOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if got.LegacyDirStatFallback {
+		t.Fatal("LegacyDirStatFallback = true, want false")
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1350,27 +1350,29 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 			return httpToFuseStatus(err)
 		}
 
-		// Some deployments do not support stat/HEAD on directories.
-		// Fall back to listing the parent and matching by name.
-		items, listErr := fs.lookupListWithRetry(cancel, parentPath)
-		if listErr != nil {
-			return httpToFuseStatus(listErr)
-		}
-		for _, item := range items {
-			if item.Name != name {
-				continue
+		if fs.opts.LegacyDirStatFallback {
+			// Compatibility path for private legacy servers that do not support
+			// stat/HEAD on directories: list the parent and match by name.
+			items, listErr := fs.lookupListWithRetry(cancel, parentPath)
+			if listErr != nil {
+				return httpToFuseStatus(listErr)
 			}
-			mtime := time.Now()
-			if item.Mtime > 0 {
-				mtime = time.Unix(item.Mtime, 0)
+			for _, item := range items {
+				if item.Name != name {
+					continue
+				}
+				mtime := time.Now()
+				if item.Mtime > 0 {
+					mtime = time.Unix(item.Mtime, 0)
+				}
+				ino := fs.inodes.Lookup(childP, item.IsDir, item.Size, mtime)
+				entry, ok := fs.inodes.GetEntry(ino)
+				if !ok {
+					return gofuse.EIO
+				}
+				fs.fillEntryOut(entry, out)
+				return gofuse.OK
 			}
-			ino := fs.inodes.Lookup(childP, item.IsDir, item.Size, mtime)
-			entry, ok := fs.inodes.GetEntry(ino)
-			if !ok {
-				return gofuse.EIO
-			}
-			fs.fillEntryOut(entry, out)
-			return gofuse.OK
 		}
 		// Cache negative lookup: tell kernel this entry doesn't exist
 		// for NegativeEntryTTL so it doesn't re-ask immediately.

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -705,13 +705,54 @@ func TestGetAttrRetriesTransientCanceledStat(t *testing.T) {
 	}
 }
 
-func TestLookupFallsBackToParentListWhenDirStatUnsupported(t *testing.T) {
+func TestLookupStatNotFoundReturnsENOENTWithoutParentListByDefault(t *testing.T) {
+	var headCalls atomic.Int32
+	var listCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			http.Error(w, "not found", http.StatusNotFound)
+		case http.MethodGet:
+			if r.URL.Query().Get("list") == "1" {
+				listCalls.Add(1)
+			}
+			http.Error(w, "unexpected list fallback", http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "missing", &out)
+	if st != gofuse.ENOENT {
+		t.Fatalf("Lookup status = %v, want ENOENT", st)
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+	if got := listCalls.Load(); got != 0 {
+		t.Fatalf("list calls = %d, want 0", got)
+	}
+	if out.NodeId != 0 {
+		t.Fatalf("negative lookup NodeId = %d, want 0", out.NodeId)
+	}
+}
+
+func TestLookupLegacyDirStatFallbackListsParentWhenEnabled(t *testing.T) {
+	var listCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodHead:
 			http.Error(w, "not found", http.StatusNotFound)
 		case http.MethodGet:
 			if r.URL.Path == "/v1/fs/" && r.URL.RawQuery == "list=1" {
+				listCalls.Add(1)
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"entries": []map[string]any{{
 						"name":  "dir",
@@ -728,7 +769,7 @@ func TestLookupFallsBackToParentListWhenDirStatUnsupported(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	opts := &MountOptions{}
+	opts := &MountOptions{LegacyDirStatFallback: true}
 	opts.setDefaults()
 	fs := NewDat9FS(client.New(ts.URL, ""), opts)
 
@@ -739,6 +780,9 @@ func TestLookupFallsBackToParentListWhenDirStatUnsupported(t *testing.T) {
 	}
 	if out.Mode&syscall.S_IFDIR == 0 {
 		t.Fatalf("Lookup mode = %o, want directory mode", out.Mode)
+	}
+	if got := listCalls.Load(); got != 1 {
+		t.Fatalf("list calls = %d, want 1", got)
 	}
 }
 
@@ -808,7 +852,7 @@ func TestLookupUsesDirCacheNegativeEntryWithoutRemoteStat(t *testing.T) {
 	}
 }
 
-func TestLookupListFallbackPopulatesDirCacheForLaterMisses(t *testing.T) {
+func TestLookupLegacyListFallbackPopulatesDirCacheForLaterMisses(t *testing.T) {
 	var headCalls atomic.Int32
 	var listCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -835,7 +879,7 @@ func TestLookupListFallbackPopulatesDirCacheForLaterMisses(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	opts := &MountOptions{}
+	opts := &MountOptions{LegacyDirStatFallback: true}
 	opts.setDefaults()
 	fs := NewDat9FS(client.New(ts.URL, ""), opts)
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -29,32 +29,33 @@ import (
 // its entire lifetime (Invariant #3). To change credentials, umount and
 // remount; there is no in-process rebind.
 type MountOptions struct {
-	Server               string        // dat9 server URL
-	APIKey               string        // owner API key (mutually exclusive with Token)
-	Token                string        // delegated capability JWT (mutually exclusive with APIKey)
-	MountPoint           string        // local mount point
-	RemoteRoot           string        // remote subtree root (default "/"); set via "drive9 mount :/path /local"
-	CacheDir             string        // write-back cache directory (default ~/.cache/drive9); empty string uses default
-	CacheSize            int64         // ReadCache max size in bytes (default 128MB)
-	DirTTL               time.Duration // DirCache TTL (default 10s)
-	AttrTTL              time.Duration // kernel attr cache TTL (default 10s)
-	EntryTTL             time.Duration // kernel entry cache TTL (default 10s)
-	NegativeEntryTTL     time.Duration // kernel negative entry cache TTL (default 10s)
-	FlushDebounce        time.Duration // debounce window for small-file flush coalescing (default 2s, 0 disables); set to -1 to use default
-	SyncMode             SyncMode      // interactive, strict, or auto (default auto)
-	Profile              string        // mount profile: "interactive", "" (default)
-	UploadConcurrency    int           // number of background upload workers (default 4)
-	LookupRetryCount     int           // detached retries after transient Lookup/GetAttr stat failures (default 2)
-	LookupRetryTimeout   time.Duration // timeout per detached stat retry after interrupt/transient errors (default 250ms)
-	ReadDirPrefetch      bool          // prefetch small files after readdir into ReadCache (default false)
-	PrefetchMaxFiles     int           // maximum files prefetched per directory read (default 32 when enabled)
-	PrefetchMaxFileBytes int64         // maximum individual file size prefetched (default 50KB)
-	PrefetchMaxBytes     int64         // maximum aggregate bytes prefetched per directory read (default 1MB)
-	PrefetchTimeout      time.Duration // timeout for one readdir prefetch batch (default 1s)
-	AllowOther           bool          // allow other users to access mount
-	ReadOnly             bool          // mount as read-only
-	Debug                bool          // enable FUSE debug logging
-	PerfCounters         bool          // print low-overhead FUSE perf counter summary on shutdown
+	Server                string        // dat9 server URL
+	APIKey                string        // owner API key (mutually exclusive with Token)
+	Token                 string        // delegated capability JWT (mutually exclusive with APIKey)
+	MountPoint            string        // local mount point
+	RemoteRoot            string        // remote subtree root (default "/"); set via "drive9 mount :/path /local"
+	CacheDir              string        // write-back cache directory (default ~/.cache/drive9); empty string uses default
+	CacheSize             int64         // ReadCache max size in bytes (default 128MB)
+	DirTTL                time.Duration // DirCache TTL (default 10s)
+	AttrTTL               time.Duration // kernel attr cache TTL (default 10s)
+	EntryTTL              time.Duration // kernel entry cache TTL (default 10s)
+	NegativeEntryTTL      time.Duration // kernel negative entry cache TTL (default 10s)
+	FlushDebounce         time.Duration // debounce window for small-file flush coalescing (default 2s, 0 disables); set to -1 to use default
+	SyncMode              SyncMode      // interactive, strict, or auto (default auto)
+	Profile               string        // mount profile: "interactive", "" (default)
+	UploadConcurrency     int           // number of background upload workers (default 4)
+	LookupRetryCount      int           // detached retries after transient Lookup/GetAttr stat failures (default 2)
+	LookupRetryTimeout    time.Duration // timeout per detached stat retry after interrupt/transient errors (default 250ms)
+	LegacyDirStatFallback bool          // on Lookup stat 404, list parent to support legacy servers without directory stat
+	ReadDirPrefetch       bool          // prefetch small files after readdir into ReadCache (default false)
+	PrefetchMaxFiles      int           // maximum files prefetched per directory read (default 32 when enabled)
+	PrefetchMaxFileBytes  int64         // maximum individual file size prefetched (default 50KB)
+	PrefetchMaxBytes      int64         // maximum aggregate bytes prefetched per directory read (default 1MB)
+	PrefetchTimeout       time.Duration // timeout for one readdir prefetch batch (default 1s)
+	AllowOther            bool          // allow other users to access mount
+	ReadOnly              bool          // mount as read-only
+	Debug                 bool          // enable FUSE debug logging
+	PerfCounters          bool          // print low-overhead FUSE perf counter summary on shutdown
 }
 
 func (o *MountOptions) setDefaults() {


### PR DESCRIPTION
## Summary
- return ENOENT directly when FUSE Lookup stat returns 404 on modern servers
- add hidden rollback flag `--legacy-dir-stat-fallback` / `MountOptions.LegacyDirStatFallback` for old private servers
- keep legacy list fallback tests behind the explicit option and add default zero-list regression coverage

## Validation
- `/usr/local/go/bin/go test ./pkg/fuse -run 'TestLookup(StatNotFound|Legacy|UsesDirCache|UsesRemoteRootMapping)|TestMountOptionsLookupRetry' -count=1`\n- `/usr/local/go/bin/go test ./cmd/drive9/cli -run 'TestMountCmd(PassesLegacyDirStatFallbackOption|LeavesLegacyDirStatFallbackDisabledByDefault)|TestValidateLookupRetryFlags|TestValidateReadDirPrefetchFlags|TestNormalizeLookupRetryCount' -count=1`\n- `/usr/local/go/bin/go test ./pkg/fuse -count=1`\n- `/usr/local/go/bin/go test ./cmd/drive9/cli -run 'TestMount|TestRunMount|TestUmount|TestDoctor|TestFuse|TestValidateLookupRetryFlags|TestValidateReadDirPrefetchFlags|TestNormalizeLookupRetryCount' -count=1`\n- `/usr/local/go/bin/go test -c ./pkg/fuse ./cmd/drive9 ./cmd/drive9/cli ./pkg/client ./pkg/server`\n- `git diff --check`