### PR TITLE
feat: add FUSE namespace lookup cache

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -107,7 +107,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		fileHandles:   NewHandleTable[*FileHandle](),
 		dirHandles:    NewHandleTable[*DirHandle](),
 		readCache:     NewReadCache(opts.CacheSize, 0),
-		dirCache:      NewDirCache(opts.DirTTL),
+		dirCache:      NewNamespaceCache(opts.DirTTL, opts.NegativeEntryTTL, defaultNamespaceCacheMaxEntries),
 		dirtyInodes:   make(map[uint64]dirtyInodeState),
 		uid:           uint32(os.Getuid()),
 		gid:           uint32(os.Getgid()),
@@ -1047,6 +1047,69 @@ func (fs *Dat9FS) lookupListWithRetry(cancel <-chan struct{}, parentPath string)
 	return nil, lastErr
 }
 
+func cachedInfoFromEntry(name string, entry *InodeEntry) CachedFileInfo {
+	if entry == nil {
+		return CachedFileInfo{Name: name}
+	}
+	mtime := entry.Mtime
+	if mtime.IsZero() {
+		mtime = time.Now()
+	}
+	return CachedFileInfo{
+		Name:     name,
+		Size:     entry.Size,
+		IsDir:    entry.IsDir,
+		Mtime:    mtime,
+		Revision: entry.Revision,
+	}
+}
+
+func cachedInfoFromStat(name string, stat *client.StatResult) CachedFileInfo {
+	mtime := time.Now()
+	if stat != nil && !stat.Mtime.IsZero() {
+		mtime = stat.Mtime
+	}
+	item := CachedFileInfo{Name: name, Mtime: mtime}
+	if stat != nil {
+		item.Size = stat.Size
+		item.IsDir = stat.IsDir
+		item.Revision = stat.Revision
+	}
+	return item
+}
+
+func (fs *Dat9FS) cacheFileForPath(p string, size int64, mtime time.Time, revision int64) {
+	if fs == nil || fs.dirCache == nil || p == "/" {
+		return
+	}
+	if mtime.IsZero() {
+		mtime = time.Now()
+	}
+	parentPath, name := cacheParentName(p)
+	fs.dirCache.Upsert(parentPath, CachedFileInfo{
+		Name:     name,
+		Size:     size,
+		IsDir:    false,
+		Mtime:    mtime,
+		Revision: revision,
+	})
+}
+
+func (fs *Dat9FS) cacheNegativePath(p string) {
+	if fs == nil || fs.dirCache == nil || p == "/" || isLockFilePath(p) {
+		return
+	}
+	parentPath, name := cacheParentName(p)
+	fs.dirCache.MarkNegative(parentPath, name)
+}
+
+func (fs *Dat9FS) negativeEntryTTL(p string) time.Duration {
+	if isLockFilePath(p) {
+		return 0
+	}
+	return fs.opts.NegativeEntryTTL
+}
+
 func (fs *Dat9FS) remoteDirExistsDetached(localPath string) bool {
 	retryCtx, retryCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
 	defer retryCancel()
@@ -1211,21 +1274,14 @@ func (fs *Dat9FS) renameRemoteWithTransientRetry(ctx context.Context, oldP, newP
 }
 
 func (fs *Dat9FS) lookupFromDirCache(parentPath, childP, name string, out *gofuse.EntryOut) (bool, gofuse.Status) {
-	cached, ok := fs.dirCache.Get(parentPath)
-	if !ok {
+	result := fs.dirCache.Lookup(parentPath, name)
+	switch result.kind {
+	case namespaceLookupPositive:
 		if fs.perf != nil {
-			fs.perf.dirCacheMiss.add(1)
+			fs.perf.dirCacheHit.add(1)
+			fs.perf.namespacePositiveHit.add(1)
 		}
-		return false, gofuse.OK
-	}
-	if fs.perf != nil {
-		fs.perf.dirCacheHit.add(1)
-	}
-
-	for _, item := range cached {
-		if item.Name != name {
-			continue
-		}
+		item := result.item
 		mtime := item.Mtime
 		if mtime.IsZero() {
 			mtime = time.Now()
@@ -1240,11 +1296,39 @@ func (fs *Dat9FS) lookupFromDirCache(parentPath, childP, name string, out *gofus
 		}
 		fs.fillEntryOut(entry, out)
 		return true, gofuse.OK
+	case namespaceLookupNegative, namespaceLookupCompleteMiss, namespaceLookupSessionMiss:
+		if isLockFilePath(childP) {
+			if fs.perf != nil {
+				fs.perf.dirCacheMiss.add(1)
+			}
+			return false, gofuse.OK
+		}
+		if fs.perf != nil {
+			fs.perf.dirCacheHit.add(1)
+			switch result.kind {
+			case namespaceLookupNegative:
+				fs.perf.namespaceNegativeHit.add(1)
+			case namespaceLookupCompleteMiss:
+				fs.perf.namespaceCompleteMiss.add(1)
+			case namespaceLookupSessionMiss:
+				fs.perf.namespaceSessionMiss.add(1)
+			}
+		}
+		out.NodeId = 0
+		out.SetEntryTimeout(fs.negativeEntryTTL(childP))
+		return true, gofuse.ENOENT
+	case namespaceLookupPartialMiss:
+		if fs.perf != nil {
+			fs.perf.dirCacheMiss.add(1)
+			fs.perf.namespacePartialMiss.add(1)
+		}
+		return false, gofuse.OK
+	default:
+		if fs.perf != nil {
+			fs.perf.dirCacheMiss.add(1)
+		}
+		return false, gofuse.OK
 	}
-
-	out.NodeId = 0
-	out.SetEntryTimeout(fs.opts.NegativeEntryTTL)
-	return true, gofuse.ENOENT
 }
 
 // --- RawFileSystem methods ---------------------------------------------------
@@ -1381,8 +1465,9 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		}
 		// Cache negative lookup: tell kernel this entry doesn't exist
 		// for NegativeEntryTTL so it doesn't re-ask immediately.
+		fs.cacheNegativePath(childP)
 		out.NodeId = 0
-		out.SetEntryTimeout(fs.opts.NegativeEntryTTL)
+		out.SetEntryTimeout(fs.negativeEntryTTL(childP))
 		return gofuse.ENOENT
 	}
 
@@ -1395,6 +1480,7 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	if stat.Revision > 0 {
 		fs.inodes.UpdateRevision(ino, stat.Revision)
 	}
+	fs.dirCache.Upsert(parentPath, cachedInfoFromStat(name, stat))
 	entry, ok := fs.inodes.GetEntry(ino)
 	if !ok {
 		return gofuse.EIO
@@ -1617,6 +1703,8 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 				// Refresh the inode revision after the server-side truncate so a
 				// subsequent writable open does not reuse the stale pre-truncate
 				// base revision and conflict with its own zero-byte write.
+				var refreshedRevision int64
+				var refreshedMtime time.Time
 				statStart := fs.perfStart()
 				stat, statErr := fs.client.StatCtx(ctx, apiPath)
 				fs.perfRecordRemote(perfRemoteStat, statStart, statErr, 0)
@@ -1624,17 +1712,19 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 					log.Printf("post-truncate stat refresh failed for %s (inode=%d): %v (revision may be stale)", entry.Path, input.NodeId, statErr)
 				} else if stat != nil {
 					if stat.Revision > 0 {
+						refreshedRevision = stat.Revision
 						entry.Revision = stat.Revision
 						fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
 						fs.updateOpenHandleBaseRevision(entry.Path, stat.Revision, input.Pid)
 					}
 					if !stat.Mtime.IsZero() {
+						refreshedMtime = stat.Mtime
 						entry.Mtime = stat.Mtime
 						fs.inodes.UpdateMtime(input.NodeId, stat.Mtime)
 					}
 				}
 				fs.readCache.Invalidate(entry.Path)
-				fs.dirCache.Invalidate(parentDir(entry.Path))
+				fs.cacheFileForPath(entry.Path, 0, refreshedMtime, refreshedRevision)
 			} else if newSize != entry.Size {
 				// Arbitrary truncate without an open handle is not
 				// supported — dat9 has no server-side truncate API.
@@ -1673,7 +1763,8 @@ func (fs *Dat9FS) Mkdir(cancel <-chan struct{}, input *gofuse.MkdirIn, name stri
 	}
 
 	parentPath, _ := fs.inodes.GetPath(input.NodeId)
-	fs.dirCache.Invalidate(parentPath)
+	fs.dirCache.Upsert(parentPath, cachedInfoFromEntry(name, entry))
+	fs.dirCache.MarkSessionCreatedDir(childP)
 	// Kernel already receives the new entry via the Mkdir reply —
 	// no need for notifyEntry/notifyInode here.
 
@@ -1768,7 +1859,8 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	fs.readCache.Invalidate(childP)
 
 	parentPath, _ := fs.inodes.GetPath(header.NodeId)
-	fs.dirCache.Invalidate(parentPath)
+	fs.dirCache.Remove(parentPath, name)
+	fs.cacheNegativePath(childP)
 	// Kernel initiated the unlink and receives OK — it already
 	// removes the dentry. No notifyEntry/notifyInode needed.
 	return gofuse.OK
@@ -1836,11 +1928,12 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 	}
 
 	fs.inodes.Remove(childP)
-	fs.dirCache.Invalidate(childP)
+	fs.dirCache.InvalidatePrefix(childP)
 	fs.readCache.InvalidatePrefix(childP + "/")
 
 	parentPath, _ := fs.inodes.GetPath(header.NodeId)
-	fs.dirCache.Invalidate(parentPath)
+	fs.dirCache.Remove(parentPath, name)
+	fs.cacheNegativePath(childP)
 	// Kernel initiated the rmdir and receives OK — it already
 	// removes the dentry. No notifyEntry/notifyInode needed.
 	return gofuse.OK
@@ -1988,6 +2081,11 @@ func (fs *Dat9FS) pendingRenameTargetExists(ctx context.Context, p string) (bool
 }
 
 func (fs *Dat9FS) finishLocalRename(input *gofuse.RenameIn, oldP, newP string) {
+	var oldEntry *InodeEntry
+	oldEntryOK := false
+	if oldIno, ok := fs.inodes.GetInode(oldP); ok {
+		oldEntry, oldEntryOK = fs.inodes.GetEntry(oldIno)
+	}
 	fs.inodes.Rename(oldP, newP)
 	fs.readCache.Invalidate(oldP)
 	fs.readCache.Invalidate(newP)
@@ -1995,10 +2093,16 @@ func (fs *Dat9FS) finishLocalRename(input *gofuse.RenameIn, oldP, newP string) {
 	fs.readCache.InvalidatePrefix(newP + "/")
 
 	oldParent, _ := fs.inodes.GetPath(input.NodeId)
-	fs.dirCache.Invalidate(oldParent)
+	fs.dirCache.Remove(oldParent, path.Base(oldP))
+	fs.cacheNegativePath(oldP)
+	fs.dirCache.InvalidatePrefix(oldP)
+	fs.dirCache.InvalidatePrefix(newP)
+	newParent := oldParent
 	if input.Newdir != input.NodeId {
-		newParent, _ := fs.inodes.GetPath(input.Newdir)
-		fs.dirCache.Invalidate(newParent)
+		newParent, _ = fs.inodes.GetPath(input.Newdir)
+	}
+	if oldEntryOK {
+		fs.dirCache.Upsert(newParent, cachedInfoFromEntry(path.Base(newP), oldEntry))
 	}
 }
 
@@ -2473,7 +2577,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 	fs.fillEntryOut(entry, &out.EntryOut)
 
 	parentPath, _ := fs.inodes.GetPath(input.NodeId)
-	fs.dirCache.Invalidate(parentPath)
+	fs.dirCache.Upsert(parentPath, cachedInfoFromEntry(name, entry))
 	// Kernel initiated the create and receives the new entry via reply —
 	// no need for notifyEntry/notifyInode here.
 	return gofuse.OK
@@ -3529,7 +3633,11 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			}
 
 			fs.readCache.Invalidate(fh.Path)
-			fs.dirCache.Invalidate(parentDir(fh.Path))
+			if flushStatus == gofuse.OK {
+				fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
+			} else {
+				fs.dirCache.Invalidate(parentDir(fh.Path))
+			}
 			// Local release — kernel already knows about this close.
 			// No notifyInode needed; userspace caches are invalidated above.
 			return
@@ -3597,7 +3705,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 
 				// Invalidate caches so subsequent reads see fresh data.
 				fs.readCache.Invalidate(fh.Path)
-				fs.dirCache.Invalidate(parentDir(fh.Path))
+				fs.cacheFileForPath(fh.Path, fh.Dirty.Size(), time.Now(), 0)
 				// Local release — kernel already knows about this close.
 				// No notifyInode needed; userspace caches are invalidated above.
 				return
@@ -3707,8 +3815,8 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		} else {
 			fs.readCache.Invalidate(filePath)
 		}
-		fs.dirCache.Invalidate(parentDir(filePath))
 		fs.inodes.UpdateSize(ino, int64(len(data)))
+		fs.cacheFileForPath(filePath, int64(len(data)), time.Now(), committedRev)
 		// Local debounced flush — kernel is not aware of this async
 		// operation and does not need notify. Userspace caches are
 		// updated above; kernel will pick up new attrs on next getattr.
@@ -3818,8 +3926,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 		fh.DirtySeq = 0
 		fs.readCache.Invalidate(fh.Path)
-		fs.dirCache.Invalidate(parentDir(fh.Path))
 		fs.inodes.UpdateSize(fh.Ino, size)
+		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 		// Remove stale shadow so subsequent read-only opens don't serve
 		// the empty placeholder created at Create/Open time.
 		if fs.shadowStore != nil {
@@ -3875,8 +3983,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 		fh.DirtySeq = 0
 		fs.readCache.Invalidate(fh.Path)
-		fs.dirCache.Invalidate(parentDir(fh.Path))
 		fs.inodes.UpdateSize(fh.Ino, size)
+		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 		// Remove stale shadow (same reason as Path 1a above).
 		if fs.shadowStore != nil {
 			fs.shadowStore.Remove(fh.Path)
@@ -3977,8 +4085,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.readCache.Invalidate(fh.Path)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 	}
-	fs.dirCache.Invalidate(parentDir(fh.Path))
 	fs.inodes.UpdateSize(fh.Ino, size)
+	fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
 	// Local flush — kernel receives the Flush reply with status.
 	// No notifyInode/notifyEntry needed; userspace caches are updated
 	// above and kernel will refresh attrs on next getattr/lookup.
@@ -4089,13 +4197,13 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 		}
 		fs.inodes.UpdateRevision(entry.Inode, committedRev)
 		fs.inodes.UpdateSize(entry.Inode, entry.Size)
-		fs.dirCache.Invalidate(parentDir(entry.Path))
+		fs.cacheFileForPath(entry.Path, entry.Size, time.Now(), committedRev)
 		// Local async commit completion — this is not an external change.
 		// Kernel does not need notify; userspace caches and inode state
 		// are updated above. Kernel will see new attrs on next access.
 	} else {
 		fs.readCache.Invalidate(entry.Path)
-		fs.dirCache.Invalidate(parentDir(entry.Path))
+		fs.cacheFileForPath(entry.Path, entry.Size, time.Now(), 0)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -852,6 +852,269 @@ func TestLookupUsesDirCacheNegativeEntryWithoutRemoteStat(t *testing.T) {
 	}
 }
 
+func TestLookupPartialNamespaceMissFallsThroughToRemoteStat(t *testing.T) {
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Fatalf("method = %s, want HEAD", r.Method)
+		}
+		headCalls.Add(1)
+		w.Header().Set("Content-Length", "9")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs.dirCache.Upsert("/", CachedFileInfo{Name: "known.txt", Size: 1})
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "remote.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+	if got, want := out.Size, uint64(9); got != want {
+		t.Fatalf("Lookup size = %d, want %d", got, want)
+	}
+}
+
+func TestLookupStatNotFoundSeedsShortNegativeNamespaceCache(t *testing.T) {
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Fatalf("method = %s, want HEAD", r.Method)
+		}
+		headCalls.Add(1)
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	for range 2 {
+		var out gofuse.EntryOut
+		st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "missing.txt", &out)
+		if st != gofuse.ENOENT {
+			t.Fatalf("Lookup status = %v, want ENOENT", st)
+		}
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+}
+
+func TestLookupLockFileStatNotFoundDoesNotSeedNamespaceNegative(t *testing.T) {
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Fatalf("method = %s, want HEAD", r.Method)
+		}
+		headCalls.Add(1)
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	for range 2 {
+		var out gofuse.EntryOut
+		st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "config.lock", &out)
+		if st != gofuse.ENOENT {
+			t.Fatalf("Lookup status = %v, want ENOENT", st)
+		}
+	}
+	if got := headCalls.Load(); got != 2 {
+		t.Fatalf("HEAD calls = %d, want 2", got)
+	}
+}
+
+func TestLookupLockFileIgnoresCompleteNamespaceMiss(t *testing.T) {
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Fatalf("method = %s, want HEAD", r.Method)
+		}
+		headCalls.Add(1)
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs.dirCache.Put("/", []CachedFileInfo{{Name: "config"}})
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "config.lock", &out)
+	if st != gofuse.ENOENT {
+		t.Fatalf("Lookup status = %v, want ENOENT", st)
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+}
+
+func TestLookupSessionCreatedDirMissAvoidsRemoteStat(t *testing.T) {
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.RawQuery == "mkdir":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead:
+			headCalls.Add(1)
+			http.Error(w, "unexpected remote stat", http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	var mkdirOut gofuse.EntryOut
+	st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "dir", &mkdirOut)
+	if st != gofuse.OK {
+		t.Fatalf("Mkdir status = %v, want OK", st)
+	}
+
+	var lookupOut gofuse.EntryOut
+	st = fs.Lookup(nil, &gofuse.InHeader{NodeId: mkdirOut.NodeId}, "missing.txt", &lookupOut)
+	if st != gofuse.ENOENT {
+		t.Fatalf("Lookup status = %v, want ENOENT", st)
+	}
+	if got := headCalls.Load(); got != 0 {
+		t.Fatalf("HEAD calls = %d, want 0", got)
+	}
+}
+
+func TestLookupSSEForeignCreateInvalidatesSessionCreatedMiss(t *testing.T) {
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Fatalf("method = %s, want HEAD", r.Method)
+		}
+		headCalls.Add(1)
+		w.Header().Set("Content-Length", "4")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+	fs.dirCache.MarkSessionCreatedDir("/dir")
+
+	w := &SSEWatcher{fs: fs, actor: "mine"}
+	w.handleChange(&client.ChangeEvent{
+		Seq:   1,
+		Path:  "/dir/remote.txt",
+		Op:    "write",
+		Actor: "other",
+	})
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: dirIno}, "remote.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+}
+
+func TestLookupSSEForeignDeleteInvalidatesPositiveNamespaceHit(t *testing.T) {
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Fatalf("method = %s, want HEAD", r.Method)
+		}
+		headCalls.Add(1)
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs.inodes.Lookup("/dir", true, 0, time.Now())
+	fs.dirCache.Upsert("/dir", CachedFileInfo{Name: "stale.txt", Size: 9})
+
+	w := &SSEWatcher{fs: fs, actor: "mine"}
+	w.handleChange(&client.ChangeEvent{
+		Seq:   1,
+		Path:  "/dir/stale.txt",
+		Op:    "delete",
+		Actor: "other",
+	})
+
+	dirIno, _ := fs.inodes.GetInode("/dir")
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: dirIno}, "stale.txt", &out)
+	if st != gofuse.ENOENT {
+		t.Fatalf("Lookup status = %v, want ENOENT", st)
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+}
+
+func TestNamespaceCacheCrossDirRenameUpdatesBothParents(t *testing.T) {
+	var remoteCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "unexpected remote call", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	srcIno := fs.inodes.Lookup("/src", true, 0, time.Now())
+	dstIno := fs.inodes.Lookup("/dst", true, 0, time.Now())
+	fs.inodes.Lookup("/src/file.txt", false, 5, time.Unix(10, 0))
+	fs.dirCache.Put("/src", []CachedFileInfo{{Name: "file.txt", Size: 5}})
+	fs.dirCache.Put("/dst", []CachedFileInfo{{Name: "other.txt", Size: 1}})
+
+	fs.finishLocalRename(&gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: srcIno},
+		Newdir:   dstIno,
+	}, "/src/file.txt", "/dst/file.txt")
+
+	var oldOut gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: srcIno}, "file.txt", &oldOut)
+	if st != gofuse.ENOENT {
+		t.Fatalf("old parent Lookup status = %v, want ENOENT", st)
+	}
+
+	var newOut gofuse.EntryOut
+	st = fs.Lookup(nil, &gofuse.InHeader{NodeId: dstIno}, "file.txt", &newOut)
+	if st != gofuse.OK {
+		t.Fatalf("new parent Lookup status = %v, want OK", st)
+	}
+	if got, want := newOut.Size, uint64(5); got != want {
+		t.Fatalf("renamed entry size = %d, want %d", got, want)
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote calls = %d, want 0", got)
+	}
+}
+
 func TestLookupLegacyListFallbackPopulatesDirCacheForLaterMisses(t *testing.T) {
 	var headCalls atomic.Int32
 	var listCalls atomic.Int32

--- a/pkg/fuse/dir.go
+++ b/pkg/fuse/dir.go
@@ -1,12 +1,15 @@
 package fuse
 
 import (
+	"path"
+	"strings"
 	"sync"
 	"time"
 )
 
 const (
-	defaultDirCacheTTL = 10 * time.Second
+	defaultDirCacheTTL              = 10 * time.Second
+	defaultNamespaceCacheMaxEntries = 2000
 )
 
 // CachedFileInfo matches the client.FileInfo shape but avoids importing client.
@@ -18,66 +21,230 @@ type CachedFileInfo struct {
 	Revision int64
 }
 
-type dirCacheEntry struct {
-	items   []CachedFileInfo
-	expires time.Time
+type namespaceLookupKind uint8
+
+const (
+	namespaceLookupNone namespaceLookupKind = iota
+	namespaceLookupPositive
+	namespaceLookupNegative
+	namespaceLookupCompleteMiss
+	namespaceLookupSessionMiss
+	namespaceLookupPartialMiss
+)
+
+type namespaceLookupResult struct {
+	kind namespaceLookupKind
+	item CachedFileInfo
 }
 
-// DirCache is a thread-safe, TTL-based cache for directory listings.
+type dirCacheEntry struct {
+	items           map[string]CachedFileInfo
+	order           []string
+	expires         time.Time // positive entries and cached ReadDir listing TTL
+	complete        bool
+	completeExpires time.Time // safe ENOENT-on-miss TTL for a complete listing
+	sessionExpires  time.Time // safe ENOENT-on-miss TTL for a session-created dir
+	negatives       map[string]time.Time
+}
+
+// DirCache is a thread-safe, TTL-based namespace cache.
+//
+// It stores positive entries, explicit negative lookups, complete directory
+// listings, and mount-local session-created directories. Misses are only safe
+// to answer locally when they come from a complete listing, an explicit
+// negative marker, or a session-created directory. Partial parents still miss
+// through to remote stat.
 type DirCache struct {
-	mu      sync.Mutex
-	entries map[string]*dirCacheEntry // keyed by directory path
-	ttl     time.Duration
+	mu          sync.Mutex
+	entries     map[string]*dirCacheEntry // keyed by directory path
+	ttl         time.Duration
+	negativeTTL time.Duration
+	maxEntries  int
 }
 
 // NewDirCache creates a new DirCache with the given TTL.
 // If ttl <= 0, defaultDirCacheTTL is used.
 func NewDirCache(ttl time.Duration) *DirCache {
+	return NewNamespaceCache(ttl, ttl, defaultNamespaceCacheMaxEntries)
+}
+
+// NewNamespaceCache creates a namespace-aware directory cache.
+func NewNamespaceCache(ttl, negativeTTL time.Duration, maxEntries int) *DirCache {
 	if ttl <= 0 {
 		ttl = defaultDirCacheTTL
 	}
+	if negativeTTL <= 0 || negativeTTL > ttl {
+		negativeTTL = ttl
+	}
+	if maxEntries <= 0 {
+		maxEntries = defaultNamespaceCacheMaxEntries
+	}
 	return &DirCache{
-		entries: make(map[string]*dirCacheEntry),
-		ttl:     ttl,
+		entries:     make(map[string]*dirCacheEntry),
+		ttl:         ttl,
+		negativeTTL: negativeTTL,
+		maxEntries:  maxEntries,
 	}
 }
 
 // Get returns cached directory entries if they exist and have not expired.
 // If the entry has expired, it is deleted and (nil, false) is returned.
-func (dc *DirCache) Get(path string) ([]CachedFileInfo, bool) {
+func (dc *DirCache) Get(dirPath string) ([]CachedFileInfo, bool) {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 
-	entry, ok := dc.entries[path]
-	if !ok {
+	now := time.Now()
+	entry, ok := dc.getEntryLocked(dirPath, now)
+	if !ok || !entry.completeListValid(now) {
 		return nil, false
 	}
 
-	if time.Now().After(entry.expires) {
-		delete(dc.entries, path)
-		return nil, false
+	items := make([]CachedFileInfo, 0, len(entry.order))
+	for _, name := range entry.order {
+		item, ok := entry.items[name]
+		if ok {
+			items = append(items, item)
+		}
 	}
-
-	return entry.items, true
+	return items, true
 }
 
 // Put stores directory entries in the cache with an expiration of now + ttl.
-func (dc *DirCache) Put(path string, items []CachedFileInfo) {
+func (dc *DirCache) Put(dirPath string, items []CachedFileInfo) {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 
-	dc.entries[path] = &dirCacheEntry{
-		items:   items,
-		expires: time.Now().Add(dc.ttl),
+	now := time.Now()
+	entry := newDirCacheEntry()
+	entry.expires = now.Add(dc.ttl)
+	limit := len(items)
+	if limit > dc.maxEntries {
+		limit = dc.maxEntries
+	}
+	for i := 0; i < limit; i++ {
+		entry.upsert(items[i], dc.maxEntries)
+	}
+	if len(items) <= dc.maxEntries {
+		entry.complete = true
+		entry.completeExpires = now.Add(dc.negativeTTL)
+	}
+	dc.entries[dirPath] = entry
+}
+
+// Lookup returns the namespace-cache state for parent/name.
+func (dc *DirCache) Lookup(parentPath, name string) namespaceLookupResult {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	now := time.Now()
+	entry, ok := dc.getEntryLocked(parentPath, now)
+	if !ok {
+		return namespaceLookupResult{}
+	}
+	if item, ok := entry.items[name]; ok && entry.positiveValid(now) {
+		return namespaceLookupResult{kind: namespaceLookupPositive, item: item}
+	}
+	if entry.negativeValid(name, now) {
+		return namespaceLookupResult{kind: namespaceLookupNegative}
+	}
+	if entry.sessionValid(now) {
+		return namespaceLookupResult{kind: namespaceLookupSessionMiss}
+	}
+	if entry.completeValid(now) {
+		return namespaceLookupResult{kind: namespaceLookupCompleteMiss}
+	}
+	if entry.hasState() {
+		return namespaceLookupResult{kind: namespaceLookupPartialMiss}
+	}
+	return namespaceLookupResult{}
+}
+
+// Upsert records or refreshes a known child entry for a parent.
+func (dc *DirCache) Upsert(parentPath string, item CachedFileInfo) {
+	if item.Name == "" {
+		return
+	}
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	now := time.Now()
+	entry := dc.ensureEntryLocked(parentPath)
+	entry.expires = now.Add(dc.ttl)
+	entry.upsert(item, dc.maxEntries)
+	delete(entry.negatives, item.Name)
+}
+
+// Remove deletes a known child entry from a parent without implying the parent
+// namespace is complete.
+func (dc *DirCache) Remove(parentPath, name string) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	entry, ok := dc.entries[parentPath]
+	if !ok {
+		return
+	}
+	entry.remove(name)
+	if !entry.hasState() {
+		delete(dc.entries, parentPath)
+	}
+}
+
+// MarkNegative records a short-lived ENOENT marker for parent/name.
+func (dc *DirCache) MarkNegative(parentPath, name string) {
+	if name == "" || dc.negativeTTL <= 0 {
+		return
+	}
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	entry := dc.ensureEntryLocked(parentPath)
+	entry.remove(name)
+	if entry.negatives == nil {
+		entry.negatives = make(map[string]time.Time)
+	}
+	entry.negatives[name] = time.Now().Add(dc.negativeTTL)
+}
+
+// MarkSessionCreatedDir records a directory created by this mount as having a
+// locally managed empty namespace for a short TTL.
+func (dc *DirCache) MarkSessionCreatedDir(dirPath string) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	now := time.Now()
+	entry := dc.ensureEntryLocked(dirPath)
+	entry.expires = now.Add(dc.ttl)
+	entry.complete = true
+	entry.completeExpires = now.Add(dc.negativeTTL)
+	entry.sessionExpires = now.Add(dc.negativeTTL)
+	entry.negatives = make(map[string]time.Time)
+}
+
+// InvalidatePrefix removes cached namespace state for dirPath and descendants.
+func (dc *DirCache) InvalidatePrefix(dirPath string) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	if dirPath == "/" {
+		dc.entries = make(map[string]*dirCacheEntry)
+		return
+	}
+	prefix := dirPath
+	prefix += "/"
+	for p := range dc.entries {
+		if p == dirPath || strings.HasPrefix(p, prefix) {
+			delete(dc.entries, p)
+		}
 	}
 }
 
 // Invalidate removes a specific directory entry from the cache.
-func (dc *DirCache) Invalidate(path string) {
+func (dc *DirCache) Invalidate(dirPath string) {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 
-	delete(dc.entries, path)
+	delete(dc.entries, dirPath)
 }
 
 // InvalidateAll clears all cache entries.
@@ -86,4 +253,128 @@ func (dc *DirCache) InvalidateAll() {
 	defer dc.mu.Unlock()
 
 	dc.entries = make(map[string]*dirCacheEntry)
+}
+
+func newDirCacheEntry() *dirCacheEntry {
+	return &dirCacheEntry{
+		items:     make(map[string]CachedFileInfo),
+		negatives: make(map[string]time.Time),
+	}
+}
+
+func (dc *DirCache) ensureEntryLocked(dirPath string) *dirCacheEntry {
+	entry, ok := dc.entries[dirPath]
+	if !ok {
+		entry = newDirCacheEntry()
+		dc.entries[dirPath] = entry
+	}
+	if entry.items == nil {
+		entry.items = make(map[string]CachedFileInfo)
+	}
+	if entry.negatives == nil {
+		entry.negatives = make(map[string]time.Time)
+	}
+	return entry
+}
+
+func (dc *DirCache) getEntryLocked(dirPath string, now time.Time) (*dirCacheEntry, bool) {
+	entry, ok := dc.entries[dirPath]
+	if !ok {
+		return nil, false
+	}
+	entry.prune(now)
+	if !entry.hasState() {
+		delete(dc.entries, dirPath)
+		return nil, false
+	}
+	return entry, true
+}
+
+func (e *dirCacheEntry) upsert(item CachedFileInfo, maxEntries int) {
+	if item.Name == "" {
+		return
+	}
+	if e.items == nil {
+		e.items = make(map[string]CachedFileInfo)
+	}
+	if _, exists := e.items[item.Name]; !exists {
+		if maxEntries > 0 && len(e.items) >= maxEntries {
+			if len(e.order) == 0 {
+				return
+			}
+			evict := e.order[0]
+			e.order = e.order[1:]
+			delete(e.items, evict)
+			delete(e.negatives, evict)
+			e.complete = false
+			e.completeExpires = time.Time{}
+			e.sessionExpires = time.Time{}
+		}
+		e.order = append(e.order, item.Name)
+	}
+	e.items[item.Name] = item
+}
+
+func (e *dirCacheEntry) remove(name string) {
+	delete(e.items, name)
+	delete(e.negatives, name)
+	for i, existing := range e.order {
+		if existing == name {
+			e.order = append(e.order[:i], e.order[i+1:]...)
+			return
+		}
+	}
+}
+
+func (e *dirCacheEntry) prune(now time.Time) {
+	if !e.expires.IsZero() && now.After(e.expires) {
+		e.items = make(map[string]CachedFileInfo)
+		e.order = nil
+		e.expires = time.Time{}
+		e.complete = false
+	}
+	if !e.completeExpires.IsZero() && now.After(e.completeExpires) {
+		e.completeExpires = time.Time{}
+	}
+	if !e.sessionExpires.IsZero() && now.After(e.sessionExpires) {
+		e.sessionExpires = time.Time{}
+	}
+	for name, expires := range e.negatives {
+		if now.After(expires) {
+			delete(e.negatives, name)
+		}
+	}
+}
+
+func (e *dirCacheEntry) positiveValid(now time.Time) bool {
+	return e.expires.IsZero() || !now.After(e.expires)
+}
+
+func (e *dirCacheEntry) completeListValid(now time.Time) bool {
+	return e.complete && e.positiveValid(now)
+}
+
+func (e *dirCacheEntry) completeValid(now time.Time) bool {
+	return e.complete && !e.completeExpires.IsZero() && !now.After(e.completeExpires)
+}
+
+func (e *dirCacheEntry) sessionValid(now time.Time) bool {
+	return !e.sessionExpires.IsZero() && !now.After(e.sessionExpires)
+}
+
+func (e *dirCacheEntry) negativeValid(name string, now time.Time) bool {
+	expires, ok := e.negatives[name]
+	return ok && !now.After(expires)
+}
+
+func (e *dirCacheEntry) hasState() bool {
+	return len(e.items) > 0 || len(e.negatives) > 0 || e.complete || !e.completeExpires.IsZero() || !e.sessionExpires.IsZero()
+}
+
+func cacheParentName(p string) (string, string) {
+	dir := path.Dir(p)
+	if dir == "." {
+		dir = "/"
+	}
+	return dir, path.Base(p)
 }

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -626,6 +626,116 @@ func TestDirCache_InvalidateAll(t *testing.T) {
 	}
 }
 
+func TestNamespaceCache_PositiveHit(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, 10*time.Second, 10)
+	dc.Upsert("/repo", CachedFileInfo{Name: "README.md", Size: 12, Revision: 7})
+
+	got := dc.Lookup("/repo", "README.md")
+	if got.kind != namespaceLookupPositive {
+		t.Fatalf("lookup kind = %v, want positive", got.kind)
+	}
+	if got.item.Size != 12 || got.item.Revision != 7 {
+		t.Fatalf("lookup item = %+v, want size=12 revision=7", got.item)
+	}
+}
+
+func TestNamespaceCache_CompleteMissIsSafeNegative(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, 10*time.Second, 10)
+	dc.Put("/repo", []CachedFileInfo{{Name: "README.md"}})
+
+	got := dc.Lookup("/repo", "missing.txt")
+	if got.kind != namespaceLookupCompleteMiss {
+		t.Fatalf("lookup kind = %v, want complete miss", got.kind)
+	}
+}
+
+func TestNamespaceCache_PartialMissFallsThrough(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, 10*time.Second, 10)
+	dc.Upsert("/repo", CachedFileInfo{Name: "known.txt"})
+
+	got := dc.Lookup("/repo", "missing.txt")
+	if got.kind != namespaceLookupPartialMiss {
+		t.Fatalf("lookup kind = %v, want partial miss", got.kind)
+	}
+}
+
+func TestNamespaceCache_SessionCreatedMissIsSafeNegative(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, 10*time.Second, 10)
+	dc.MarkSessionCreatedDir("/repo/.git/objects/ab")
+
+	got := dc.Lookup("/repo/.git/objects/ab", "missing")
+	if got.kind != namespaceLookupSessionMiss {
+		t.Fatalf("lookup kind = %v, want session miss", got.kind)
+	}
+	if gotItems, ok := dc.Get("/repo/.git/objects/ab"); !ok || len(gotItems) != 0 {
+		t.Fatalf("Get session-created dir = len %d ok %t, want empty complete hit", len(gotItems), ok)
+	}
+}
+
+func TestNamespaceCache_NegativeExpires(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, time.Millisecond, 10)
+	dc.MarkNegative("/repo", "missing.txt")
+	if got := dc.Lookup("/repo", "missing.txt"); got.kind != namespaceLookupNegative {
+		t.Fatalf("lookup kind before expiry = %v, want negative", got.kind)
+	}
+	time.Sleep(5 * time.Millisecond)
+	if got := dc.Lookup("/repo", "missing.txt"); got.kind != namespaceLookupNone {
+		t.Fatalf("lookup kind after expiry = %v, want none", got.kind)
+	}
+}
+
+func TestNamespaceCache_CompleteMissExpiresBeforePositiveList(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, time.Millisecond, 10)
+	dc.Put("/repo", []CachedFileInfo{{Name: "known.txt"}})
+	time.Sleep(5 * time.Millisecond)
+
+	if got := dc.Lookup("/repo", "missing.txt"); got.kind != namespaceLookupPartialMiss {
+		t.Fatalf("lookup kind after negative TTL = %v, want partial miss", got.kind)
+	}
+	items, ok := dc.Get("/repo")
+	if !ok || len(items) != 1 || items[0].Name != "known.txt" {
+		t.Fatalf("Get after negative TTL = %+v ok %t, want complete positive list", items, ok)
+	}
+}
+
+func TestNamespaceCache_LargeDirGuardDoesNotMarkComplete(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, 10*time.Second, 2)
+	dc.Put("/repo", []CachedFileInfo{
+		{Name: "a.txt"},
+		{Name: "b.txt"},
+		{Name: "c.txt"},
+	})
+
+	if _, ok := dc.Get("/repo"); ok {
+		t.Fatal("large dir should not be returned as a complete listing")
+	}
+	if got := dc.Lookup("/repo", "a.txt"); got.kind != namespaceLookupPositive {
+		t.Fatalf("lookup existing kind = %v, want positive", got.kind)
+	}
+	if got := dc.Lookup("/repo", "c.txt"); got.kind != namespaceLookupPartialMiss {
+		t.Fatalf("lookup overflow/missing kind = %v, want partial miss", got.kind)
+	}
+}
+
+func TestNamespaceCache_InvalidatePrefix(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, 10*time.Second, 10)
+	dc.Put("/repo", []CachedFileInfo{{Name: ".git", IsDir: true}})
+	dc.Put("/repo/.git", []CachedFileInfo{{Name: "config"}})
+	dc.Put("/repo2", []CachedFileInfo{{Name: "keep"}})
+
+	dc.InvalidatePrefix("/repo")
+
+	if _, ok := dc.Get("/repo"); ok {
+		t.Fatal("/repo should be invalidated")
+	}
+	if _, ok := dc.Get("/repo/.git"); ok {
+		t.Fatal("/repo/.git should be invalidated")
+	}
+	if _, ok := dc.Get("/repo2"); !ok {
+		t.Fatal("/repo2 should be preserved")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Sparse WriteBuffer with LoadPart (lazy loading) tests
 // ---------------------------------------------------------------------------

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -92,6 +92,12 @@ type fusePerfCounters struct {
 	prefetchHit   atomicUint64
 	prefetchMiss  atomicUint64
 
+	namespacePositiveHit  atomicUint64
+	namespaceNegativeHit  atomicUint64
+	namespaceCompleteMiss atomicUint64
+	namespaceSessionMiss  atomicUint64
+	namespacePartialMiss  atomicUint64
+
 	lookupRetryTotal     atomicUint64
 	lookupRetrySuccess   atomicUint64
 	lookupRetryExhausted atomicUint64
@@ -218,6 +224,11 @@ func (p *fusePerfCounters) snapshot() fusePerfSnapshot {
 	snap.Counters["dir_cache_miss"] = p.dirCacheMiss.load()
 	snap.Counters["prefetch_hit"] = p.prefetchHit.load()
 	snap.Counters["prefetch_miss"] = p.prefetchMiss.load()
+	snap.Counters["namespace_positive_hit"] = p.namespacePositiveHit.load()
+	snap.Counters["namespace_negative_hit"] = p.namespaceNegativeHit.load()
+	snap.Counters["namespace_complete_miss"] = p.namespaceCompleteMiss.load()
+	snap.Counters["namespace_session_miss"] = p.namespaceSessionMiss.load()
+	snap.Counters["namespace_partial_miss"] = p.namespacePartialMiss.load()
 	snap.Counters["lookup_retry_total"] = p.lookupRetryTotal.load()
 	snap.Counters["lookup_retry_success"] = p.lookupRetrySuccess.load()
 	snap.Counters["lookup_retry_exhausted"] = p.lookupRetryExhausted.load()
@@ -257,6 +268,10 @@ func (p *fusePerfCounters) printSummary(w io.Writer) {
 		snap.Counters["read_cache_hit"], snap.Counters["read_cache_miss"],
 		snap.Counters["dir_cache_hit"], snap.Counters["dir_cache_miss"],
 		snap.Counters["prefetch_hit"], snap.Counters["prefetch_miss"])
+	writePerfLine(w, "drive9: perf namespace positive_hit=%d negative_hit=%d complete_miss=%d session_miss=%d partial_miss=%d\n",
+		snap.Counters["namespace_positive_hit"], snap.Counters["namespace_negative_hit"],
+		snap.Counters["namespace_complete_miss"], snap.Counters["namespace_session_miss"],
+		snap.Counters["namespace_partial_miss"])
 	writePerfLine(w, "drive9: perf retries lookup_total=%d lookup_success=%d lookup_exhausted=%d read_total=%d read_success=%d read_exhausted=%d\n",
 		snap.Counters["lookup_retry_total"], snap.Counters["lookup_retry_success"], snap.Counters["lookup_retry_exhausted"],
 		snap.Counters["read_retry_total"], snap.Counters["read_retry_success"], snap.Counters["read_retry_exhausted"])

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -89,6 +89,7 @@ func (w *SSEWatcher) handleChange(ce *client.ChangeEvent) {
 
 	// Invalidate directory cache for the parent directory.
 	w.fs.dirCache.Invalidate(parentDir(p))
+	w.fs.dirCache.InvalidatePrefix(p)
 
 	// Notify kernel about the change.
 	if ino, ok := w.fs.inodes.GetInode(p); ok {

--- a/pkg/fuse/sse_test.go
+++ b/pkg/fuse/sse_test.go
@@ -134,6 +134,33 @@ func TestSSEWatcherHandleChangeInvalidatesCache(t *testing.T) {
 	}
 }
 
+func TestSSEWatcherHandleChangeInvalidatesChildDirNamespace(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+
+	fs.dirCache.Put("/docs/subdir", []CachedFileInfo{{Name: "stale.txt", Size: 50}})
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+
+	w.handleChange(&client.ChangeEvent{
+		Seq:   1,
+		Path:  "/docs/subdir",
+		Op:    "delete",
+		Actor: "other-actor",
+	})
+
+	if _, ok := fs.dirCache.Get("/docs/subdir"); ok {
+		t.Error("child dir namespace should be invalidated after directory change")
+	}
+}
+
 func TestSSEWatcherHandleChangeFiltersAndRebasesRemoteRoot(t *testing.T) {
 	opts := &MountOptions{
 		CacheSize:  1 << 20,


### PR DESCRIPTION
## Summary\n- upgrade FUSE directory cache into a namespace-aware cache with positive, negative, complete-list, and session-created states\n- use safe namespace hits in Lookup while partial misses still fall through to remote stat\n- update local mutation/SSE paths and perf counters for namespace cache sources\n\n## Tests\n- /usr/local/go/bin/go test ./pkg/fuse -count=1\n- /usr/local/go/bin/go test -c ./pkg/... ./cmd/...\n- git diff --check