### PR TITLE
perf(fuse): optimize small file read/write performance

### DIFF
--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -375,6 +375,34 @@ func TestWriteBuffer_Truncate(t *testing.T) {
 	}
 }
 
+func TestWriteBuffer_TruncateSmallFileSparseWriteZeroFillsGap(t *testing.T) {
+	wb := NewWriteBuffer("/test", 0, 0)
+	_, _ = wb.Write(0, []byte("hello world"))
+
+	if err := wb.Truncate(5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wb.Write(10, []byte("X")); err != nil {
+		t.Fatal(err)
+	}
+
+	got := wb.Bytes()
+	if len(got) != 11 {
+		t.Fatalf("Bytes() len = %d, want 11", len(got))
+	}
+	if string(got[:5]) != "hello" {
+		t.Fatalf("prefix = %q, want %q", got[:5], "hello")
+	}
+	for i := 5; i < 10; i++ {
+		if got[i] != 0 {
+			t.Fatalf("gap byte %d = %d, want 0", i, got[i])
+		}
+	}
+	if got[10] != 'X' {
+		t.Fatalf("tail byte = %q, want %q", got[10], byte('X'))
+	}
+}
+
 func TestWriteBuffer_EFBIG(t *testing.T) {
 	wb := NewWriteBuffer("/test", 100, 0)
 	_, err := wb.Write(0, make([]byte, 101))
@@ -986,6 +1014,28 @@ func TestWriteBuffer_ReadAt_Basic(t *testing.T) {
 	}
 	if string(buf[20:30]) != "CCCCCCCCCC" {
 		t.Fatalf("part 3: got %q", buf[20:30])
+	}
+}
+
+func TestWriteBuffer_SmallFileFastPathRequiresSinglePart(t *testing.T) {
+	wb := NewWriteBuffer("/test", 0, 10)
+	data := []byte("0123456789012345678901234")
+	if _, err := wb.Write(0, data); err != nil {
+		t.Fatal(err)
+	}
+
+	dirty := wb.DirtyPartNumbers()
+	if len(dirty) != 3 {
+		t.Fatalf("dirty parts = %v, want 3 parts", dirty)
+	}
+	if got := string(wb.PartData(1)); got != "0123456789" {
+		t.Fatalf("part 1 = %q, want %q", got, "0123456789")
+	}
+	if got := string(wb.PartData(2)); got != "0123456789" {
+		t.Fatalf("part 2 = %q, want %q", got, "0123456789")
+	}
+	if got := string(wb.PartData(3)); got != "01234" {
+		t.Fatalf("part 3 = %q, want %q", got, "01234")
 	}
 }
 

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/mem9-ai/dat9/pkg/client"
 )
 
+var (
+	benchmarkBytesSink []byte
+	benchmarkByteSink  byte
+	benchmarkIntSink   int
+)
+
 // ---------------------------------------------------------------------------
 // InodeToPath tests
 // ---------------------------------------------------------------------------
@@ -2100,7 +2106,7 @@ func BenchmarkWriteBuffer_SmallFile_WriteAndRead(b *testing.B) {
 		wb := NewWriteBuffer("/test.txt", 0, 0)
 		_, _ = wb.Write(0, data)
 		_, _ = wb.Write(6, []byte("EARTH"))
-		_ = wb.Bytes()
+		benchmarkBytesSink = wb.Bytes()
 	}
 }
 
@@ -2114,7 +2120,8 @@ func BenchmarkWriteBuffer_SmallFile_ReadAt(b *testing.B) {
 	buf := make([]byte, 4096)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = wb.ReadAt(int64(i%36)*1024, buf)
+		benchmarkIntSink = wb.ReadAt(int64(i%36)*1024, buf)
+		benchmarkByteSink ^= buf[0]
 	}
 }
 
@@ -2141,6 +2148,6 @@ func BenchmarkReadCache_GetPut(b *testing.B) {
 	rc.Put("/test.txt", data, 1)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = rc.Get("/test.txt", 1)
+		benchmarkBytesSink, _ = rc.Get("/test.txt", 1)
 	}
 }

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -1103,6 +1103,25 @@ func TestWriteBuffer_ReadAt_BeyondEnd(t *testing.T) {
 	}
 }
 
+func TestWriteBuffer_ReadAt_SmallFileClampsToLogicalSize(t *testing.T) {
+	wb := NewWriteBuffer("/test", 0, 0)
+	if _, err := wb.Write(0, []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := []byte{'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x'}
+	n := wb.ReadAt(3, buf)
+	if n != 2 {
+		t.Fatalf("ReadAt returned %d, want 2", n)
+	}
+	if string(buf[:2]) != "lo" {
+		t.Fatalf("ReadAt data = %q, want %q", buf[:2], "lo")
+	}
+	if string(buf[2:]) != "xxxxxx" {
+		t.Fatalf("ReadAt wrote past logical end: got %q", buf[2:])
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Prefetcher Close test
 // ---------------------------------------------------------------------------

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2038,3 +2038,59 @@ func TestShadowSpill_WriteBackSeqStaysZero(t *testing.T) {
 		t.Fatal("Fsync UploadSync condition must never be true for ShadowSpill handles")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+func BenchmarkWriteBuffer_SmallFile_WriteAndRead(b *testing.B) {
+	data := []byte("hello world, this is a small file content for testing!")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		wb := NewWriteBuffer("/test.txt", 0, 0)
+		_, _ = wb.Write(0, data)
+		_, _ = wb.Write(6, []byte("EARTH"))
+		_ = wb.Bytes()
+	}
+}
+
+func BenchmarkWriteBuffer_SmallFile_ReadAt(b *testing.B) {
+	data := make([]byte, 40*1024) // 40KB small file
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	wb := NewWriteBuffer("/test.txt", 0, 0)
+	_, _ = wb.Write(0, data)
+	buf := make([]byte, 4096)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = wb.ReadAt(int64(i%36)*1024, buf)
+	}
+}
+
+func BenchmarkWriteBuffer_SmallFile_Truncate(b *testing.B) {
+	data := make([]byte, 40*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		wb := NewWriteBuffer("/test.txt", 0, 0)
+		_, _ = wb.Write(0, data)
+		_ = wb.Truncate(20 * 1024)
+		_ = wb.Truncate(40 * 1024)
+	}
+}
+
+func BenchmarkReadCache_GetPut(b *testing.B) {
+	rc := NewReadCache(128<<20, 30*time.Second)
+	data := make([]byte, 40*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	rc.Put("/test.txt", data, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = rc.Get("/test.txt", 1)
+	}
+}

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -409,6 +409,38 @@ func TestWriteBuffer_TruncateSmallFileSparseWriteZeroFillsGap(t *testing.T) {
 	}
 }
 
+func TestWriteBuffer_TruncateExtendThenSmallWritePreservesLogicalSize(t *testing.T) {
+	wb := NewWriteBuffer("/test", 0, 8<<20)
+
+	if err := wb.Truncate(100); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wb.Write(0, []byte("X")); err != nil {
+		t.Fatal(err)
+	}
+	if wb.Size() != 100 {
+		t.Fatalf("Size() = %d, want 100", wb.Size())
+	}
+
+	buf := make([]byte, 10)
+	n := wb.ReadAt(50, buf)
+	if n != 10 {
+		t.Fatalf("ReadAt returned %d, want 10", n)
+	}
+	for i, b := range buf {
+		if b != 0 {
+			t.Fatalf("buf[%d] = %d, want 0", i, b)
+		}
+	}
+
+	if err := wb.Truncate(50); err != nil {
+		t.Fatal(err)
+	}
+	if wb.Size() != 50 {
+		t.Fatalf("Size() after shrink = %d, want 50", wb.Size())
+	}
+}
+
 func TestWriteBuffer_EFBIG(t *testing.T) {
 	wb := NewWriteBuffer("/test", 100, 0)
 	_, err := wb.Write(0, make([]byte, 101))

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -8,16 +8,16 @@ import (
 )
 
 const (
-	defaultReadCacheMaxSize = 128 << 20          // 128MB
-	defaultReadCacheTTL     = 30 * time.Second   // 30s
-	smallFileThreshold      = 50_000             // 50,000 bytes — matches embedding model max input characters
+	defaultReadCacheMaxSize = 128 << 20        // 128MB
+	defaultReadCacheTTL     = 30 * time.Second // 30s
+	smallFileThreshold      = 50_000           // 50,000 bytes — matches embedding model max input characters
 )
 
 // cacheEntry holds a single cached file's data and metadata.
 type cacheEntry struct {
 	path     string
 	data     []byte
-	revision int64         // dat9 file revision for invalidation
+	revision int64 // dat9 file revision for invalidation
 	expires  time.Time
 	elem     *list.Element // position in LRU list
 }
@@ -82,10 +82,10 @@ func (rc *ReadCache) Get(path string, currentRevision int64) ([]byte, bool) {
 	// Cache hit — promote to front of LRU.
 	rc.order.MoveToFront(entry.elem)
 
-	// Return a copy so the caller cannot mutate cached data.
-	out := make([]byte, len(entry.data))
-	copy(out, entry.data)
-	return out, true
+	// Return the cached data directly. The caller (FUSE Read) treats this
+	// as read-only and copies it into the kernel response buffer via
+	// gofuse.ReadResultData, so the cached data is never mutated.
+	return entry.data, true
 }
 
 // Put stores data in the cache for the given path and revision. Only files

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -84,7 +84,9 @@ func (rc *ReadCache) Get(path string, currentRevision int64) ([]byte, bool) {
 
 	// Return the cached data directly. The caller (FUSE Read) treats this
 	// as read-only and copies it into the kernel response buffer via
-	// gofuse.ReadResultData, so the cached data is never mutated.
+	// gofuse.ReadResultData, so the cached data is never mutated. If the
+	// entry is evicted after this returns, the slice remains valid because
+	// the returned slice still keeps the backing array reachable for the GC.
 	return entry.data, true
 }
 

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -23,7 +23,7 @@ type cacheEntry struct {
 }
 
 // ReadCache is a thread-safe LRU + TTL read cache for small files.
-// It only caches files whose size does not exceed smallFileThreshold (1MB).
+// It only caches files whose size does not exceed smallFileThreshold (50KB).
 // Entries are evicted when the total cached size exceeds maxSize or when
 // their TTL expires.
 type ReadCache struct {

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -269,11 +269,7 @@ func (s *ShadowStore) WriteExtents(remotePath string, wb *WriteBuffer, baseRev i
 
 	// Small-file fast path: if the buffer is using a contiguous allocation,
 	// write the entire content in one shot instead of iterating parts.
-	if wb.smallFileData != nil {
-		data := wb.smallFileData
-		if wb.totalSize < int64(len(data)) {
-			data = data[:wb.totalSize]
-		}
+	if data, ok := wb.smallFileBytes(); ok {
 		if len(data) > 0 {
 			n, err := sf.fd.WriteAt(data, 0)
 			if err != nil {

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -266,20 +266,37 @@ func (s *ShadowStore) WriteExtents(remotePath string, wb *WriteBuffer, baseRev i
 	// Write each dirty part at its correct offset.
 	var extents []DirtyExtent
 	partSize := wb.PartSize()
-	for idx, dirty := range wb.dirtyParts {
-		if !dirty {
-			continue
+
+	// Small-file fast path: if the buffer is using a contiguous allocation,
+	// write the entire content in one shot instead of iterating parts.
+	if wb.smallFileData != nil {
+		data := wb.smallFileData
+		if wb.totalSize < int64(len(data)) {
+			data = data[:wb.totalSize]
 		}
-		data := wb.PartData(idx + 1) // PartData is 1-based
-		if data == nil {
-			continue
+		if len(data) > 0 {
+			n, err := sf.fd.WriteAt(data, 0)
+			if err != nil {
+				return fmt.Errorf("shadow pwrite at 0: %w", err)
+			}
+			extents = append(extents, DirtyExtent{Offset: 0, Length: int64(n)})
 		}
-		offset := int64(idx) * partSize
-		n, err := sf.fd.WriteAt(data, offset)
-		if err != nil {
-			return fmt.Errorf("shadow pwrite at %d: %w", offset, err)
+	} else {
+		for idx, dirty := range wb.dirtyParts {
+			if !dirty {
+				continue
+			}
+			data := wb.PartData(idx + 1) // PartData is 1-based
+			if data == nil {
+				continue
+			}
+			offset := int64(idx) * partSize
+			n, err := sf.fd.WriteAt(data, offset)
+			if err != nil {
+				return fmt.Errorf("shadow pwrite at %d: %w", offset, err)
+			}
+			extents = append(extents, DirtyExtent{Offset: offset, Length: int64(n)})
 		}
-		extents = append(extents, DirtyExtent{Offset: offset, Length: int64(n)})
 	}
 
 	// Update shadow file metadata.

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -99,11 +99,12 @@ func (wb *WriteBuffer) Write(offset int64, data []byte) (uint32, error) {
 	}
 
 	// Small-file fast path: use a single contiguous allocation for files
-	// that remain below the small-file threshold. This avoids map lookups,
-	// per-part allocations, and fragmentation for the common case.
+	// that remain below the small-file threshold and still fit in a single
+	// logical part. This avoids map lookups, per-part allocations, and
+	// fragmentation for the common case.
 	// Do NOT use the fast path when lazy loading is configured (LoadPart != nil)
 	// because we may need to load existing remote data.
-	if wb.smallFileData != nil || (len(wb.parts) == 0 && wb.LoadPart == nil && end <= smallFileThreshold) {
+	if wb.smallFileData != nil || (wb.partSize >= smallFileThreshold && len(wb.parts) == 0 && wb.LoadPart == nil && end <= smallFileThreshold) {
 		return wb.writeSmallFile(offset, data)
 	}
 
@@ -208,6 +209,8 @@ func (wb *WriteBuffer) writeSmallFile(offset int64, data []byte) (uint32, error)
 		return wb.Write(offset, data)
 	}
 
+	oldLen := len(wb.smallFileData)
+
 	// Ensure capacity (grow with headroom to reduce reallocations)
 	if int(end) > cap(wb.smallFileData) {
 		newCap := int(end)
@@ -226,6 +229,9 @@ func (wb *WriteBuffer) writeSmallFile(offset int64, data []byte) (uint32, error)
 		wb.smallFileData = grown[:end]
 	} else if int(end) > len(wb.smallFileData) {
 		wb.smallFileData = wb.smallFileData[:end]
+	}
+	if oldLen < len(wb.smallFileData) {
+		clear(wb.smallFileData[oldLen:])
 	}
 
 	copy(wb.smallFileData[offset:], data)

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -21,6 +21,10 @@ type LoadPartFunc func(partNum int) ([]byte, error)
 // explicitly loaded are held in memory. This enables lazy preloading
 // (load parts on demand) and streaming uploads (notify when parts are full).
 //
+// For files that remain below smallFileThreshold, a fast path uses a single
+// contiguous allocation instead of the sparse part map, avoiding map lookups
+// and per-part allocations for the common case of editing small files.
+//
 // It tracks which parts have been modified so that on flush,
 // only dirty parts need to be uploaded (unchanged parts are copied
 // server-side via S3 UploadPartCopy).
@@ -56,6 +60,13 @@ type WriteBuffer struct {
 	// partIdx is 0-based, data is the full part data (partSize bytes).
 	// The callback should copy data if it needs to outlive the call.
 	OnPartFull func(partIdx int, data []byte)
+
+	// Small-file fast path: a single contiguous buffer used when the file
+	// remains below smallFileThreshold. Avoids map lookups and per-part
+	// allocations for the common case of editing small files (< 50KB).
+	// When a write would exceed the threshold, the data is migrated to the
+	// regular part map and this field is set to nil.
+	smallFileData []byte
 }
 
 // NewWriteBuffer creates a new WriteBuffer for the given path.
@@ -85,6 +96,15 @@ func (wb *WriteBuffer) Write(offset int64, data []byte) (uint32, error) {
 	end := offset + int64(len(data))
 	if end > wb.maxSize {
 		return 0, syscall.EFBIG
+	}
+
+	// Small-file fast path: use a single contiguous allocation for files
+	// that remain below the small-file threshold. This avoids map lookups,
+	// per-part allocations, and fragmentation for the common case.
+	// Do NOT use the fast path when lazy loading is configured (LoadPart != nil)
+	// because we may need to load existing remote data.
+	if wb.smallFileData != nil || (len(wb.parts) == 0 && wb.LoadPart == nil && end <= smallFileThreshold) {
+		return wb.writeSmallFile(offset, data)
 	}
 
 	// Update totalSize
@@ -174,10 +194,82 @@ func (wb *WriteBuffer) Write(offset int64, data []byte) (uint32, error) {
 	return uint32(len(data)), nil
 }
 
+// writeSmallFile is the fast-path Write for files that remain below
+// smallFileThreshold. It uses a single contiguous []byte instead of the
+// sparse part map.
+func (wb *WriteBuffer) writeSmallFile(offset int64, data []byte) (uint32, error) {
+	end := offset + int64(len(data))
+	if end > wb.maxSize {
+		return 0, syscall.EFBIG
+	}
+	if end > smallFileThreshold {
+		// Migrate to part mode and retry
+		wb.migrateToPartMode()
+		return wb.Write(offset, data)
+	}
+
+	// Ensure capacity (grow with headroom to reduce reallocations)
+	if int(end) > cap(wb.smallFileData) {
+		newCap := int(end)
+		if newCap < 1024 {
+			newCap = 1024
+		}
+		// Double the capacity to amortize reallocation cost
+		if newCap < 2*cap(wb.smallFileData) {
+			newCap = 2 * cap(wb.smallFileData)
+		}
+		if newCap > smallFileThreshold {
+			newCap = smallFileThreshold
+		}
+		grown := make([]byte, newCap)
+		copy(grown, wb.smallFileData)
+		wb.smallFileData = grown[:end]
+	} else if int(end) > len(wb.smallFileData) {
+		wb.smallFileData = wb.smallFileData[:end]
+	}
+
+	copy(wb.smallFileData[offset:], data)
+	if end > wb.totalSize {
+		wb.totalSize = end
+	}
+	wb.touched = true
+	wb.dirtyParts[0] = true // small files map to a single logical part
+
+	// Sequential write detection
+	if offset == wb.appendCursor {
+		wb.appendCursor = end
+	} else if offset > wb.appendCursor {
+		wb.appendCursor = end
+	} else {
+		wb.sequential = false
+	}
+
+	return uint32(len(data)), nil
+}
+
+// migrateToPartMode transfers smallFileData into the sparse part map and
+// clears smallFileData. Called when a write exceeds smallFileThreshold.
+func (wb *WriteBuffer) migrateToPartMode() {
+	if len(wb.smallFileData) == 0 {
+		wb.smallFileData = nil
+		return
+	}
+	// Transfer data to part 0
+	wb.parts[0] = make([]byte, len(wb.smallFileData))
+	copy(wb.parts[0], wb.smallFileData)
+	wb.curMemory = int64(len(wb.smallFileData))
+	wb.smallFileData = nil
+}
+
 // ensurePart makes sure a part exists in the map. If it doesn't exist
 // and LoadPart is set, tries to load from remote. Otherwise creates a
 // nil entry that will be grown as needed by Write.
 func (wb *WriteBuffer) ensurePart(partIdx int) error {
+	if wb.smallFileData != nil {
+		// Small-file mode: all data is in smallFileData, no parts needed
+		return nil
+	}
+
 	if _, ok := wb.parts[partIdx]; ok {
 		return nil
 	}
@@ -241,6 +333,14 @@ func (wb *WriteBuffer) Truncate(size int64) error {
 	cur := wb.totalSize
 	switch {
 	case size < cur:
+		if wb.smallFileData != nil {
+			wb.smallFileData = wb.smallFileData[:size]
+			wb.totalSize = size
+			wb.touched = true
+			wb.dirtyParts[0] = true
+			return nil
+		}
+
 		// Mark affected parts as dirty
 		if size > 0 {
 			wb.markDirty(size, cur)
@@ -276,6 +376,32 @@ func (wb *WriteBuffer) Truncate(size int64) error {
 		wb.totalSize = size
 
 	case size > cur:
+		if wb.smallFileData != nil {
+			if size <= smallFileThreshold {
+				if int(size) > cap(wb.smallFileData) {
+					newCap := int(size)
+					if newCap < 1024 {
+						newCap = 1024
+					}
+					grown := make([]byte, newCap)
+					copy(grown, wb.smallFileData)
+					wb.smallFileData = grown[:size]
+				} else {
+					oldLen := len(wb.smallFileData)
+					wb.smallFileData = wb.smallFileData[:size]
+					for i := oldLen; i < int(size); i++ {
+						wb.smallFileData[i] = 0
+					}
+				}
+				wb.totalSize = size
+				wb.touched = true
+				wb.dirtyParts[0] = true
+				return nil
+			}
+			// Migrate to part mode for larger size
+			wb.migrateToPartMode()
+			return wb.Truncate(size)
+		}
 		// Mark the extended region as dirty
 		wb.markDirty(cur, size)
 		// Ensure parts exist for the extended region (zero-filled on access)
@@ -313,6 +439,11 @@ func (wb *WriteBuffer) Bytes() []byte {
 	if wb.totalSize == 0 {
 		return nil
 	}
+	if wb.smallFileData != nil {
+		buf := make([]byte, wb.totalSize)
+		copy(buf, wb.smallFileData)
+		return buf
+	}
 	buf := make([]byte, wb.totalSize)
 	numParts := int((wb.totalSize + wb.partSize - 1) / wb.partSize)
 	for i := 0; i < numParts; i++ {
@@ -340,6 +471,11 @@ func (wb *WriteBuffer) DirtyPartNumbers() []int {
 // MarkAllDirty marks every part in the current buffer as dirty.
 // Used when the entire file content is loaded (e.g., new file or full rewrite).
 func (wb *WriteBuffer) MarkAllDirty() {
+	if wb.smallFileData != nil {
+		wb.dirtyParts = map[int]bool{0: true}
+		wb.touched = true
+		return
+	}
 	n := int((wb.totalSize + wb.partSize - 1) / wb.partSize)
 	wb.dirtyParts = make(map[int]bool, n)
 	for i := 0; i < n; i++ {
@@ -355,6 +491,25 @@ func (wb *WriteBuffer) PartData(partNum int) []byte {
 	start := int64(partIdx) * wb.partSize
 	if start >= wb.totalSize {
 		return nil
+	}
+
+	if wb.smallFileData != nil {
+		// Small-file mode: the entire file is logically part 1
+		if partNum != 1 {
+			return nil
+		}
+		end := wb.partSize
+		if end > wb.totalSize {
+			end = wb.totalSize
+		}
+		if int64(len(wb.smallFileData)) < end {
+			extended := make([]byte, end)
+			copy(extended, wb.smallFileData)
+			return extended
+		}
+		buf := make([]byte, end)
+		copy(buf, wb.smallFileData)
+		return buf
 	}
 
 	part, ok := wb.parts[partIdx]
@@ -397,6 +552,11 @@ func (wb *WriteBuffer) ReadAt(offset int64, buf []byte) int {
 	total := int(end - offset)
 	if total <= 0 {
 		return 0
+	}
+
+	if wb.smallFileData != nil {
+		n := copy(buf, wb.smallFileData[offset:])
+		return n
 	}
 
 	pos := offset
@@ -448,6 +608,9 @@ func (wb *WriteBuffer) ReadAt(offset int64, buf []byte) int {
 
 // IsPartLoaded reports whether the 0-based part index is in memory.
 func (wb *WriteBuffer) IsPartLoaded(partIdx int) bool {
+	if wb.smallFileData != nil {
+		return partIdx == 0
+	}
 	_, ok := wb.parts[partIdx]
 	return ok
 }
@@ -457,6 +620,9 @@ func (wb *WriteBuffer) IsPartLoaded(partIdx int) bool {
 // This is true for new files (remoteSize == 0) and for existing files whose
 // entire retained remote prefix has been loaded into memory.
 func (wb *WriteBuffer) CanMaterializeFull() bool {
+	if wb.smallFileData != nil {
+		return true
+	}
 	covered := wb.remoteSize
 	if wb.totalSize < covered {
 		covered = wb.totalSize
@@ -480,11 +646,15 @@ func (wb *WriteBuffer) Reset() {
 	wb.dirtyParts = make(map[int]bool)
 	wb.totalSize = 0
 	wb.curMemory = 0
+	wb.smallFileData = nil
 }
 
 func (wb *WriteBuffer) ClearDirty() {
 	wb.dirtyParts = make(map[int]bool)
 	wb.touched = false
+	// Note: we intentionally do NOT clear smallFileData here.
+	// ClearDirty is called after successful flush/upload; the data remains
+	// valid for reads until the handle is released or Reset is called.
 }
 
 // EnsureLoaded loads a part from the server if it's not already in memory.
@@ -520,6 +690,11 @@ func (wb *WriteBuffer) EvictPart(partIdx int) {
 		wb.uploadedParts = make(map[int]bool)
 	}
 	wb.uploadedParts[partIdx] = true
+
+	if wb.smallFileData != nil {
+		// Migrate to part mode before evicting
+		wb.migrateToPartMode()
+	}
 
 	if part, ok := wb.parts[partIdx]; ok {
 		wb.curMemory -= int64(len(part))

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -104,7 +104,7 @@ func (wb *WriteBuffer) Write(offset int64, data []byte) (uint32, error) {
 	// fragmentation for the common case.
 	// Do NOT use the fast path when lazy loading is configured (LoadPart != nil)
 	// because we may need to load existing remote data.
-	if wb.smallFileData != nil || (wb.partSize >= smallFileThreshold && len(wb.parts) == 0 && wb.LoadPart == nil && end <= smallFileThreshold) {
+	if wb.smallFileData != nil || (wb.partSize >= smallFileThreshold && len(wb.parts) == 0 && wb.LoadPart == nil && end <= smallFileThreshold && wb.totalSize <= smallFileThreshold) {
 		return wb.writeSmallFile(offset, data)
 	}
 
@@ -210,10 +210,14 @@ func (wb *WriteBuffer) writeSmallFile(offset int64, data []byte) (uint32, error)
 	}
 
 	oldLen := len(wb.smallFileData)
+	needLen := end
+	if wb.totalSize > needLen {
+		needLen = wb.totalSize
+	}
 
 	// Ensure capacity (grow with headroom to reduce reallocations)
-	if int(end) > cap(wb.smallFileData) {
-		newCap := int(end)
+	if int(needLen) > cap(wb.smallFileData) {
+		newCap := int(needLen)
 		if newCap < 1024 {
 			newCap = 1024
 		}
@@ -226,9 +230,9 @@ func (wb *WriteBuffer) writeSmallFile(offset int64, data []byte) (uint32, error)
 		}
 		grown := make([]byte, newCap)
 		copy(grown, wb.smallFileData)
-		wb.smallFileData = grown[:end]
-	} else if int(end) > len(wb.smallFileData) {
-		wb.smallFileData = wb.smallFileData[:end]
+		wb.smallFileData = grown[:needLen]
+	} else if int(needLen) > len(wb.smallFileData) {
+		wb.smallFileData = wb.smallFileData[:needLen]
 	}
 	if oldLen < len(wb.smallFileData) {
 		clear(wb.smallFileData[oldLen:])
@@ -395,9 +399,7 @@ func (wb *WriteBuffer) Truncate(size int64) error {
 				} else {
 					oldLen := len(wb.smallFileData)
 					wb.smallFileData = wb.smallFileData[:size]
-					for i := oldLen; i < int(size); i++ {
-						wb.smallFileData[i] = 0
-					}
+					clear(wb.smallFileData[oldLen:])
 				}
 				wb.totalSize = size
 				wb.touched = true

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -428,6 +428,19 @@ func (wb *WriteBuffer) PartSize() int64 {
 	return wb.partSize
 }
 
+// smallFileBytes returns a read-only view of the contiguous small-file buffer.
+// The returned slice is clamped to totalSize so callers do not depend on the
+// internal len(smallFileData) == totalSize invariant.
+func (wb *WriteBuffer) smallFileBytes() ([]byte, bool) {
+	if wb.smallFileData == nil {
+		return nil, false
+	}
+	if wb.totalSize < int64(len(wb.smallFileData)) {
+		return wb.smallFileData[:wb.totalSize], true
+	}
+	return wb.smallFileData, true
+}
+
 func (wb *WriteBuffer) HasDirtyParts() bool {
 	if wb.touched {
 		return true
@@ -447,9 +460,9 @@ func (wb *WriteBuffer) Bytes() []byte {
 	if wb.totalSize == 0 {
 		return nil
 	}
-	if wb.smallFileData != nil {
+	if data, ok := wb.smallFileBytes(); ok {
 		buf := make([]byte, wb.totalSize)
-		copy(buf, wb.smallFileData)
+		copy(buf, data)
 		return buf
 	}
 	buf := make([]byte, wb.totalSize)
@@ -501,7 +514,7 @@ func (wb *WriteBuffer) PartData(partNum int) []byte {
 		return nil
 	}
 
-	if wb.smallFileData != nil {
+	if data, ok := wb.smallFileBytes(); ok {
 		// Small-file mode: the entire file is logically part 1
 		if partNum != 1 {
 			return nil
@@ -510,13 +523,13 @@ func (wb *WriteBuffer) PartData(partNum int) []byte {
 		if end > wb.totalSize {
 			end = wb.totalSize
 		}
-		if int64(len(wb.smallFileData)) < end {
+		if int64(len(data)) < end {
 			extended := make([]byte, end)
-			copy(extended, wb.smallFileData)
+			copy(extended, data)
 			return extended
 		}
 		buf := make([]byte, end)
-		copy(buf, wb.smallFileData)
+		copy(buf, data)
 		return buf
 	}
 
@@ -562,8 +575,10 @@ func (wb *WriteBuffer) ReadAt(offset int64, buf []byte) int {
 		return 0
 	}
 
-	if wb.smallFileData != nil {
-		n := copy(buf, wb.smallFileData[offset:])
+	if data, ok := wb.smallFileBytes(); ok {
+		start := int(offset)
+		limit := start + total
+		n := copy(buf[:total], data[start:limit])
 		return n
 	}
 


### PR DESCRIPTION
## Summary

This PR optimizes FUSE small file (< 50KB) read/write performance through two key changes:

### 1. WriteBuffer small-file fast path
- Uses a single contiguous `[]byte` allocation for files below `smallFileThreshold` (50KB)
- Avoids sparse part map lookups, per-part allocations, and memory fragmentation
- Automatically migrates to standard part mode when writes exceed the threshold
- Updated `ShadowStore.WriteExtents` to leverage the contiguous data path

### 2. ReadCache zero-copy reads
- Removed defensive copy (`make` + `copy`) from `ReadCache.Get()`
- FUSE `Read` treats cached data as read-only; the kernel copies it via `ReadResultData`
- Eliminates one full data copy per cache hit

### Benchmarks

```
BenchmarkWriteBuffer_SmallFile_ReadAt-12     34113346    34.33 ns/op    0 B/op    0 allocs/op
BenchmarkReadCache_GetPut-12                   489373  2434 ns/op      0 B/op    0 allocs/op
```

- `ReadCache_GetPut`: **0 allocations** (was copying 50KB per get)
- `WriteBuffer_SmallFile_ReadAt`: **0 allocations**, ~34ns per call

### Files changed
- `pkg/fuse/write.go` — small-file fast path in WriteBuffer
- `pkg/fuse/read.go` — zero-copy ReadCache.Get()
- `pkg/fuse/shadow.go` — fast path in WriteExtents
- `pkg/fuse/fuse_test.go` — benchmarks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Fast-path handling for small-file writes/reads/truncates for faster small-file operations.
  * Read-cache returns cached data without extra copying to reduce allocations and improve read efficiency.

* **Bug Fixes**
  * Sparse-write/truncate correctness: gaps after truncation are zero-filled while preserving existing prefix and new tail data.

* **Tests**
  * Added correctness tests for small-file/sparse behaviors and multiple benchmarks measuring small-file and cache performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->