### PR TITLE
Optimize FUSE small-file hot paths

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -463,6 +463,26 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 	return gofuse.OK
 }
 
+func (fs *Dat9FS) preloadWritableHandleFromReadCacheLocked(fh *FileHandle) bool {
+	if fs.readCache == nil || fh == nil || fh.Dirty == nil {
+		return false
+	}
+	if fh.OrigSize <= 0 || fh.OrigSize > smallFileThreshold || fh.BaseRev <= 0 {
+		return false
+	}
+
+	data, ok := fs.readCache.Get(fh.Path, fh.BaseRev)
+	if !ok {
+		return false
+	}
+	if _, err := fh.Dirty.Write(0, data); err != nil {
+		log.Printf("read-cache writable preload failed for %s: %v", fh.Path, err)
+		return false
+	}
+	fh.Dirty.ClearDirty()
+	return true
+}
+
 func (fs *Dat9FS) pendingKindForHandle(fh *FileHandle) PendingKind {
 	if fh.IsNew {
 		return PendingNew
@@ -538,7 +558,7 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 			return err
 		}
 	} else {
-		if err := fs.shadowStore.WriteFull(fh.Path, fh.Dirty.Bytes(), fh.BaseRev); err != nil {
+		if err := fs.shadowStore.WriteFull(fh.Path, fh.Dirty.bytesView(), fh.BaseRev); err != nil {
 			return err
 		}
 		fh.ShadowReady = true
@@ -573,7 +593,7 @@ func (fs *Dat9FS) snapshotWriteBackLocked(fh *FileHandle) error {
 	}
 	return fs.writeBack.PutWithBaseRev(
 		fh.Path,
-		fh.Dirty.Bytes(),
+		fh.Dirty.bytesView(),
 		fh.Dirty.Size(),
 		fs.pendingKindForHandle(fh),
 		fh.BaseRev,
@@ -610,6 +630,34 @@ func (fs *Dat9FS) loadWritableHandleFromShadowLocked(fh *FileHandle, meta *Write
 		fh.BaseRev = rev
 	}
 	return nil
+}
+
+func (fs *Dat9FS) loadWritableHandleFromWriteBackLocked(fh *FileHandle) bool {
+	if fs.writeBack == nil || fh == nil || fh.Dirty == nil {
+		return false
+	}
+
+	meta, ok := fs.writeBack.GetMeta(fh.Path)
+	if !ok {
+		return false
+	}
+	data, ok := fs.writeBack.getView(fh.Path)
+	if !ok {
+		return false
+	}
+	if _, err := fh.Dirty.Write(0, data); err != nil {
+		log.Printf("writeback preload failed for %s: %v", fh.Path, err)
+		return false
+	}
+
+	fh.IsNew = meta.Kind == PendingNew
+	fh.OrigSize = int64(len(data))
+	if meta.BaseRev > 0 {
+		fh.BaseRev = meta.BaseRev
+		fs.inodes.UpdateRevision(fh.Ino, meta.BaseRev)
+	}
+	fh.DirtySeq = fs.markDirtySize(fh.Ino, int64(len(data)))
+	return true
 }
 
 func (fs *Dat9FS) fillAttr(entry *InodeEntry, out *gofuse.Attr) {
@@ -2613,18 +2661,6 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			return gofuse.EROFS
 		}
 
-		// If BaseRev is 0 (e.g. inode came from readdir without revision),
-		// fetch the authoritative revision so CAS uploads work correctly.
-		if fh.BaseRev == 0 && !fh.IsNew {
-			statStart := fs.perfStart()
-			stat, err := fs.client.StatCtx(ctx, fs.remotePath(p))
-			fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
-			if err == nil && stat != nil {
-				fh.BaseRev = stat.Revision
-				fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
-			}
-		}
-
 		fh.Dirty = NewWriteBuffer(p, maxPreloadSize, 0)
 
 		// Preload existing content for non-truncating opens so that
@@ -2642,18 +2678,24 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			}
 			// Prefer write-back cache over remote — handles the case where
 			// a previous close is still uploading asynchronously.
-			if !preloaded && fs.writeBack != nil {
-				if wbData, ok := fs.writeBack.Get(p); ok {
-					if _, err := fh.Dirty.Write(0, wbData); err != nil {
-						return gofuse.Status(syscall.EFBIG)
-					}
-					// Keep dirty parts so Read sees the data. The content hasn't
-					// been persisted to the server yet (pending upload), so
-					// marking it dirty is semantically correct.
-					fh.OrigSize = int64(len(wbData))
-					fh.DirtySeq = fs.markDirtySize(fh.Ino, int64(len(wbData)))
-					preloaded = true
+			if !preloaded && fs.loadWritableHandleFromWriteBackLocked(fh) {
+				preloaded = true
+			}
+
+			// If BaseRev is still 0 (e.g. inode came from readdir without
+			// revision, or a legacy pending overwrite lacks baseRev), fetch the
+			// authoritative revision so CAS uploads work correctly.
+			if fh.BaseRev == 0 && !fh.IsNew {
+				statStart := fs.perfStart()
+				stat, err := fs.client.StatCtx(ctx, fs.remotePath(p))
+				fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
+				if err == nil && stat != nil {
+					fh.BaseRev = stat.Revision
+					fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
 				}
+			}
+			if !preloaded && fs.preloadWritableHandleFromReadCacheLocked(fh) {
+				preloaded = true
 			}
 			if !preloaded {
 				if st := fs.preloadWritableHandle(ctx, fh); st != gofuse.OK {
@@ -2899,7 +2941,8 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		return gofuse.ReadResultData(result), gofuse.OK
 	} else if fh.Dirty != nil && fh.Dirty.Size() > 0 && !fh.Dirty.HasDirtyParts() {
 		// Writable handle with lazy-loaded buffer (no dirty parts yet) —
-		// read directly from the server for unloaded parts.
+		// serve already-loaded ranges from memory and fall back to the server
+		// only when the requested range still has unloaded parts.
 		offset := int64(input.Offset)
 		size := fh.Dirty.Size()
 		if offset >= size {
@@ -2907,6 +2950,28 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 			source = "dirty-clean-eof"
 			bytesRead = 0
 			return gofuse.ReadResultData(nil), gofuse.OK
+		}
+		end := offset + int64(input.Size)
+		if end > size {
+			end = size
+		}
+		ps := fh.Dirty.PartSize()
+		firstPart := int(offset / ps)
+		lastPart := int((end - 1) / ps)
+		fullyLoaded := true
+		for p := firstPart; p <= lastPart; p++ {
+			if !fh.Dirty.IsPartLoaded(p) {
+				fullyLoaded = false
+				break
+			}
+		}
+		if fullyLoaded {
+			result := make([]byte, end-offset)
+			fh.Dirty.ReadAt(offset, result)
+			fh.Unlock()
+			source = "dirty-clean-buffer"
+			bytesRead = len(result)
+			return gofuse.ReadResultData(result), gofuse.OK
 		}
 		source = "dirty-clean-remote"
 		fh.Unlock()
@@ -2967,7 +3032,7 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 	// write-back cache (async upload still in progress), serve reads from
 	// that cached data instead of going to the server (which has stale data).
 	if fh.Dirty == nil && fs.writeBack != nil {
-		if wbData, ok := fs.writeBack.Get(fh.Path); ok {
+		if wbData, ok := fs.writeBack.getView(fh.Path); ok {
 			offset := int64(input.Offset)
 			if offset >= int64(len(wbData)) {
 				source = "writeback-cache-eof"
@@ -3052,7 +3117,7 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 			return nil, httpToFuseStatus(err)
 		}
 		// Store with the revision from the prior Stat/Lookup.
-		fs.readCache.Put(p, data, cacheRev)
+		fs.readCache.PutOwned(p, data, cacheRev)
 		offset := int64(input.Offset)
 		if offset >= int64(len(data)) {
 			source = "small-read-eof"
@@ -3769,8 +3834,9 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 
 	// Small file: schedule a deferred upload.
 	// Snapshot the data so the deferred upload sees a consistent copy.
-	data := make([]byte, len(fh.Dirty.Bytes()))
-	copy(data, fh.Dirty.Bytes())
+	snapshot := fh.Dirty.bytesView()
+	data := make([]byte, len(snapshot))
+	copy(data, snapshot)
 	filePath := fh.Path
 	ino := fh.Ino
 	handle := fh               // capture for goroutine
@@ -3811,7 +3877,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		}
 		handle.Unlock()
 		if committedRev > 0 {
-			fs.readCache.Put(filePath, data, committedRev)
+			fs.readCache.PutOwned(filePath, data, committedRev)
 		} else {
 			fs.readCache.Invalidate(filePath)
 		}
@@ -3999,7 +4065,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	}
 
 	// Path 2: No streaming uploader or small file — materialize all data for upload.
-	data := fh.Dirty.Bytes()
+	data := fh.Dirty.bytesView()
 	expectedRevision := expectedRevisionForHandle(fh)
 	var committedRev int64
 
@@ -4192,7 +4258,7 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 		// Only attempt for files under the readCache size limit.
 		if entry.Size < int64(smallFileThreshold) && fs.shadowStore != nil {
 			if data, err := fs.shadowStore.ReadAll(entry.Path); err == nil {
-				fs.readCache.Put(entry.Path, data, committedRev)
+				fs.readCache.PutOwned(entry.Path, data, committedRev)
 			}
 		}
 		fs.inodes.UpdateRevision(entry.Inode, committedRev)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -657,6 +657,7 @@ func (fs *Dat9FS) loadWritableHandleFromWriteBackLocked(fh *FileHandle) bool {
 		fs.inodes.UpdateRevision(fh.Ino, meta.BaseRev)
 	}
 	fh.DirtySeq = fs.markDirtySize(fh.Ino, int64(len(data)))
+	fh.WriteBackSeq = fh.DirtySeq
 	return true
 }
 
@@ -2954,6 +2955,12 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		end := offset + int64(input.Size)
 		if end > size {
 			end = size
+		}
+		if end <= offset {
+			fh.Unlock()
+			source = "dirty-clean-empty"
+			bytesRead = 0
+			return gofuse.ReadResultData(nil), gofuse.OK
 		}
 		ps := fh.Dirty.PartSize()
 		firstPart := int(offset / ps)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -406,6 +406,68 @@ func TestOpenWritableSmallFileUsesReadCacheFastPath(t *testing.T) {
 	}
 }
 
+func TestReadZeroLengthFromWritableCleanBuffer(t *testing.T) {
+	var headCalls atomic.Int32
+	var getCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			w.Header().Set("Content-Length", "10")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "7")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getCalls.Add(1)
+			_, _ = w.Write([]byte("stale-data"))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	const cachedRev = 7
+	cached := []byte("fresh-data")
+	ino := fs.inodes.Lookup("/file.txt", false, int64(len(cached)), time.Now())
+	fs.inodes.UpdateRevision(ino, cachedRev)
+	fs.readCache.Put("/file.txt", cached, cachedRev)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDWR),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	buf := make([]byte, 8)
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       out.Fh,
+		Offset:   4,
+		Size:     0,
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read status = %v, want OK", st)
+	}
+	data, _ := result.Bytes(buf)
+	if len(data) != 0 {
+		t.Fatalf("Read len = %d, want 0", len(data))
+	}
+	if got := headCalls.Load(); got != 0 {
+		t.Fatalf("HEAD calls = %d, want 0", got)
+	}
+	if got := getCalls.Load(); got != 0 {
+		t.Fatalf("GET calls = %d, want 0", got)
+	}
+}
+
 func TestCreateWriteThroughShadow(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/mem9-ai/dat9/pkg/client"
 )
 
-func newTestDat9FS(t *testing.T, size int64, get func(http.ResponseWriter, *http.Request)) (*Dat9FS, uint64, func()) {
-	t.Helper()
+func newTestDat9FS(tb testing.TB, size int64, get func(http.ResponseWriter, *http.Request)) (*Dat9FS, uint64, func()) {
+	tb.Helper()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -42,6 +42,268 @@ func newTestDat9FS(t *testing.T, size int64, get func(http.ResponseWriter, *http
 	fs := NewDat9FS(client.New(ts.URL, ""), opts)
 	ino := fs.inodes.Lookup("/file.bin", false, size, time.Now())
 	return fs, ino, ts.Close
+}
+
+func BenchmarkDat9FS_SmallFileOpen(b *testing.B) {
+	const (
+		filePath = "/file.bin"
+		fileRev  = 7
+	)
+	data := []byte("fresh-data")
+
+	b.Run("read-cache-hit", func(b *testing.B) {
+		fs, ino, cleanup := newTestDat9FS(b, int64(len(data)), func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("stale-data"))
+		})
+		defer cleanup()
+
+		fs.inodes.UpdateRevision(ino, fileRev)
+		fs.readCache.Put(filePath, data, fileRev)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var out gofuse.OpenOut
+			st := fs.Open(nil, &gofuse.OpenIn{
+				InHeader: gofuse.InHeader{NodeId: ino},
+				Flags:    uint32(syscall.O_RDWR),
+			}, &out)
+			if st != gofuse.OK {
+				b.Fatalf("Open status = %v, want OK", st)
+			}
+			if fh, ok := fs.fileHandles.Get(out.Fh); ok {
+				benchmarkIntSink += int(fh.BaseRev)
+				fs.clearDirtySize(ino, fh.DirtySeq)
+			}
+			fs.fileHandles.Delete(out.Fh)
+		}
+	})
+
+	b.Run("pending-shadow", func(b *testing.B) {
+		fs, ino, cleanup := newTestDat9FS(b, int64(len(data)), func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("stale-data"))
+		})
+		defer cleanup()
+
+		shadow, err := NewShadowStore(b.TempDir())
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer shadow.Close()
+		pending, err := NewPendingIndex(b.TempDir())
+		if err != nil {
+			b.Fatal(err)
+		}
+		fs.shadowStore = shadow
+		fs.pendingIndex = pending
+
+		if err := shadow.WriteFull(filePath, data, 9); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := pending.PutWithBaseRev(filePath, int64(len(data)), PendingOverwrite, 9); err != nil {
+			b.Fatal(err)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var out gofuse.OpenOut
+			st := fs.Open(nil, &gofuse.OpenIn{
+				InHeader: gofuse.InHeader{NodeId: ino},
+				Flags:    uint32(syscall.O_RDWR),
+			}, &out)
+			if st != gofuse.OK {
+				b.Fatalf("Open status = %v, want OK", st)
+			}
+			if fh, ok := fs.fileHandles.Get(out.Fh); ok {
+				benchmarkIntSink += int(fh.BaseRev)
+				fs.clearDirtySize(ino, fh.DirtySeq)
+			}
+			fs.fileHandles.Delete(out.Fh)
+		}
+	})
+
+	b.Run("pending-writeback-overwrite", func(b *testing.B) {
+		fs, ino, cleanup := newTestDat9FS(b, int64(len(data)), func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("stale-data"))
+		})
+		defer cleanup()
+
+		cache, err := NewWriteBackCache(b.TempDir())
+		if err != nil {
+			b.Fatal(err)
+		}
+		fs.SetWriteBack(cache, nil)
+		if err := cache.PutWithBaseRev(filePath, data, int64(len(data)), PendingOverwrite, 11); err != nil {
+			b.Fatal(err)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var out gofuse.OpenOut
+			st := fs.Open(nil, &gofuse.OpenIn{
+				InHeader: gofuse.InHeader{NodeId: ino},
+				Flags:    uint32(syscall.O_RDWR),
+			}, &out)
+			if st != gofuse.OK {
+				b.Fatalf("Open status = %v, want OK", st)
+			}
+			if fh, ok := fs.fileHandles.Get(out.Fh); ok {
+				benchmarkIntSink += int(fh.BaseRev)
+				fs.clearDirtySize(ino, fh.DirtySeq)
+			}
+			fs.fileHandles.Delete(out.Fh)
+		}
+	})
+}
+
+func BenchmarkDat9FS_SmallFileRead(b *testing.B) {
+	const filePath = "/file.bin"
+	data := make([]byte, 32*1024)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	const readSize = 4096
+
+	b.Run("read-cache-hit", func(b *testing.B) {
+		fs, ino, cleanup := newTestDat9FS(b, int64(len(data)), func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(data)
+		})
+		defer cleanup()
+
+		fs.inodes.UpdateRevision(ino, 3)
+		fs.readCache.Put(filePath, data, 3)
+
+		var out gofuse.OpenOut
+		st := fs.Open(nil, &gofuse.OpenIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Flags:    uint32(syscall.O_RDONLY),
+		}, &out)
+		if st != gofuse.OK {
+			b.Fatalf("Open status = %v, want OK", st)
+		}
+		defer fs.fileHandles.Delete(out.Fh)
+
+		buf := make([]byte, readSize)
+		b.ReportAllocs()
+		b.SetBytes(readSize)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			offset := uint64((i % 8) * readSize)
+			result, st := fs.Read(nil, &gofuse.ReadIn{
+				InHeader: gofuse.InHeader{NodeId: ino},
+				Fh:       out.Fh,
+				Offset:   offset,
+				Size:     uint32(readSize),
+			}, buf)
+			if st != gofuse.OK {
+				b.Fatalf("Read status = %v, want OK", st)
+			}
+			data, _ := result.Bytes(buf)
+			benchmarkByteSink ^= data[0]
+		}
+	})
+
+	b.Run("writable-clean-buffer", func(b *testing.B) {
+		fs, ino, cleanup := newTestDat9FS(b, int64(len(data)), func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("stale-data"))
+		})
+		defer cleanup()
+
+		fs.inodes.UpdateRevision(ino, 5)
+		fs.readCache.Put(filePath, data, 5)
+
+		var out gofuse.OpenOut
+		st := fs.Open(nil, &gofuse.OpenIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Flags:    uint32(syscall.O_RDWR),
+		}, &out)
+		if st != gofuse.OK {
+			b.Fatalf("Open status = %v, want OK", st)
+		}
+		defer func() {
+			if fh, ok := fs.fileHandles.Get(out.Fh); ok {
+				fs.clearDirtySize(ino, fh.DirtySeq)
+			}
+			fs.fileHandles.Delete(out.Fh)
+		}()
+
+		buf := make([]byte, readSize)
+		b.ReportAllocs()
+		b.SetBytes(readSize)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			offset := uint64((i % 8) * readSize)
+			result, st := fs.Read(nil, &gofuse.ReadIn{
+				InHeader: gofuse.InHeader{NodeId: ino},
+				Fh:       out.Fh,
+				Offset:   offset,
+				Size:     uint32(readSize),
+			}, buf)
+			if st != gofuse.OK {
+				b.Fatalf("Read status = %v, want OK", st)
+			}
+			data, _ := result.Bytes(buf)
+			benchmarkByteSink ^= data[0]
+		}
+	})
+}
+
+func BenchmarkDat9FS_SmallFileFlush(b *testing.B) {
+	const filePath = "/flush.txt"
+	data := make([]byte, 16*1024)
+	for i := range data {
+		data[i] = byte(i % 253)
+	}
+
+	opts := &MountOptions{FlushDebounce: 0}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	cache, err := NewWriteBackCache(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	fs.SetWriteBack(cache, nil)
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Time{})
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out gofuse.OpenOut
+		st := fs.Open(nil, &gofuse.OpenIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Flags:    uint32(syscall.O_RDWR | syscall.O_TRUNC),
+		}, &out)
+		if st != gofuse.OK {
+			b.Fatalf("Open status = %v, want OK", st)
+		}
+
+		if _, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       out.Fh,
+			Offset:   0,
+		}, data); st != gofuse.OK {
+			b.Fatalf("Write status = %v, want OK", st)
+		}
+
+		st = fs.Flush(nil, &gofuse.FlushIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       out.Fh,
+		})
+		if st != gofuse.OK {
+			b.Fatalf("Flush status = %v, want OK", st)
+		}
+
+		if fh, ok := fs.fileHandles.Get(out.Fh); ok {
+			benchmarkIntSink += int(fh.Dirty.Size())
+			fs.clearDirtySize(ino, fh.DirtySeq)
+		}
+		fs.fileHandles.Delete(out.Fh)
+		cache.Remove(filePath)
+		fs.readCache.Invalidate(filePath)
+	}
 }
 
 func TestOpenWritableSmallFileLazyPreload(t *testing.T) {
@@ -78,6 +340,69 @@ func TestOpenWritableLargeFileLazyPreload(t *testing.T) {
 	}, &out)
 	if st != gofuse.OK {
 		t.Fatalf("Open status = %v, want OK (lazy preload defers loading)", st)
+	}
+}
+
+func TestOpenWritableSmallFileUsesReadCacheFastPath(t *testing.T) {
+	var headCalls atomic.Int32
+	var getCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			w.Header().Set("Content-Length", "10")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "7")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getCalls.Add(1)
+			_, _ = w.Write([]byte("stale-data"))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	const cachedRev = 7
+	cached := []byte("fresh-data")
+	ino := fs.inodes.Lookup("/file.txt", false, int64(len(cached)), time.Now())
+	fs.inodes.UpdateRevision(ino, cachedRev)
+	fs.readCache.Put("/file.txt", cached, cachedRev)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDWR),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	buf := make([]byte, 32)
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       out.Fh,
+		Offset:   0,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read status = %v, want OK", st)
+	}
+
+	data, _ := result.Bytes(buf)
+	if string(data) != string(cached) {
+		t.Fatalf("Read data = %q, want %q", string(data), string(cached))
+	}
+	if got := headCalls.Load(); got != 0 {
+		t.Fatalf("HEAD calls = %d, want 0", got)
+	}
+	if got := getCalls.Load(); got != 0 {
+		t.Fatalf("GET calls = %d, want 0", got)
 	}
 }
 
@@ -328,6 +653,81 @@ func TestOpenWritablePrefersPendingShadowSnapshot(t *testing.T) {
 	data, _ := result.Bytes(buf)
 	if string(data) != "fresh" {
 		t.Fatalf("Read = %q, want fresh", data)
+	}
+}
+
+func TestOpenWritablePendingShadowSkipsRemoteStat(t *testing.T) {
+	var headCalls atomic.Int32
+	var getCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			w.Header().Set("Content-Length", "5")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getCalls.Add(1)
+			_, _ = io.WriteString(w, "stale")
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	ino := fs.inodes.Lookup("/file.bin", false, 5, time.Now())
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	if err := shadow.WriteFull("/file.bin", []byte("fresh"), 9); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/file.bin", 5, PendingOverwrite, 9); err != nil {
+		t.Fatal(err)
+	}
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDWR),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	if got := headCalls.Load(); got != 0 {
+		t.Fatalf("HEAD calls = %d, want 0", got)
+	}
+
+	buf := make([]byte, 16)
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       out.Fh,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read status = %v, want OK", st)
+	}
+	data, _ := result.Bytes(buf)
+	if string(data) != "fresh" {
+		t.Fatalf("Read = %q, want fresh", data)
+	}
+	if got := getCalls.Load(); got != 0 {
+		t.Fatalf("GET calls = %d, want 0", got)
 	}
 }
 

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -240,6 +240,38 @@ func TestReadCache_PutAndGet(t *testing.T) {
 	}
 }
 
+func TestReadCache_PutDefensivelyCopies(t *testing.T) {
+	rc := NewReadCache(1<<20, 10*time.Second)
+	data := []byte("hello world")
+	rc.Put("/test.txt", data, 1)
+	data[0] = 'j'
+
+	got, ok := rc.Get("/test.txt", 1)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if string(got) != "hello world" {
+		t.Fatalf("got %q, want %q", got, "hello world")
+	}
+}
+
+func TestReadCache_PutOwnedReusesSlice(t *testing.T) {
+	rc := NewReadCache(1<<20, 10*time.Second)
+	data := []byte("hello world")
+	rc.PutOwned("/test.txt", data, 1)
+
+	got, ok := rc.Get("/test.txt", 1)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if len(got) == 0 || len(data) == 0 {
+		t.Fatal("expected non-empty cached data")
+	}
+	if &got[0] != &data[0] {
+		t.Fatal("PutOwned should reuse the caller slice")
+	}
+}
+
 func TestReadCache_RevisionMismatch(t *testing.T) {
 	rc := NewReadCache(1<<20, 10*time.Second)
 	rc.Put("/f", []byte("x"), 1)

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -95,6 +95,16 @@ func (rc *ReadCache) Get(path string, currentRevision int64) ([]byte, bool) {
 // the path already exists it is updated in place. After insertion, LRU
 // eviction runs until the total cached size is within maxSize.
 func (rc *ReadCache) Put(path string, data []byte, revision int64) {
+	rc.put(path, data, revision, true)
+}
+
+// PutOwned stores data in the cache without cloning it.
+// Callers must pass a fresh slice that will not be mutated after this call.
+func (rc *ReadCache) PutOwned(path string, data []byte, revision int64) {
+	rc.put(path, data, revision, false)
+}
+
+func (rc *ReadCache) put(path string, data []byte, revision int64, clone bool) {
 	if len(data) > smallFileThreshold {
 		return
 	}
@@ -103,10 +113,11 @@ func (rc *ReadCache) Put(path string, data []byte, revision int64) {
 	defer rc.mu.Unlock()
 
 	dataLen := int64(len(data))
-
-	// Make a defensive copy of the data.
-	stored := make([]byte, dataLen)
-	copy(stored, data)
+	stored := data
+	if clone {
+		stored = make([]byte, dataLen)
+		copy(stored, data)
+	}
 
 	now := time.Now()
 

--- a/pkg/fuse/readdir_prefetch.go
+++ b/pkg/fuse/readdir_prefetch.go
@@ -67,7 +67,7 @@ func (fs *Dat9FS) prefetchReadCacheForDir(ctx context.Context, dirPath string, i
 			if result.Revision > 0 {
 				revision = result.Revision
 			}
-			fs.readCache.Put(candidate.localPath, result.Data, revision)
+			fs.readCache.PutOwned(candidate.localPath, result.Data, revision)
 			if revision > 0 {
 				if ino, ok := fs.inodes.GetInode(candidate.localPath); ok {
 					fs.inodes.UpdateRevision(ino, revision)

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -441,6 +441,20 @@ func (wb *WriteBuffer) smallFileBytes() ([]byte, bool) {
 	return wb.smallFileData, true
 }
 
+// bytesView returns a read-only view of the current buffer contents.
+// For small-file mode this avoids materializing a second full copy.
+// Callers must treat the returned slice as immutable and hold the file-handle
+// lock while using it.
+func (wb *WriteBuffer) bytesView() []byte {
+	if wb.totalSize == 0 {
+		return nil
+	}
+	if data, ok := wb.smallFileBytes(); ok {
+		return data
+	}
+	return wb.Bytes()
+}
+
 func (wb *WriteBuffer) HasDirtyParts() bool {
 	if wb.touched {
 		return true
@@ -604,23 +618,17 @@ func (wb *WriteBuffer) ReadAt(offset int64, buf []byte) int {
 				if partOff < int64(len(part)) {
 					n := copy(buf[copied:], part[partOff:])
 					// Zero-fill the rest
-					for i := copied + n; i < copied+int(canRead); i++ {
-						buf[i] = 0
-					}
+					clear(buf[copied+n : copied+int(canRead)])
 				} else {
 					// Entirely beyond the part — zero-fill
-					for i := copied; i < copied+int(canRead); i++ {
-						buf[i] = 0
-					}
+					clear(buf[copied : copied+int(canRead)])
 				}
 			} else {
 				copy(buf[copied:], part[partOff:partEnd])
 			}
 		} else {
 			// Part not loaded — zero-fill
-			for i := copied; i < copied+int(canRead); i++ {
-				buf[i] = 0
-			}
+			clear(buf[copied : copied+int(canRead)])
 		}
 
 		pos += canRead

--- a/pkg/fuse/writeback.go
+++ b/pkg/fuse/writeback.go
@@ -86,6 +86,19 @@ type WriteBackCache struct {
 	dataMaxBytes int64
 }
 
+func (c *WriteBackCache) pruneScannedEntry(scannedMetaName string) {
+	base := strings.TrimSuffix(scannedMetaName, ".meta")
+	_ = os.Remove(filepath.Join(c.dir, scannedMetaName))
+	_ = os.Remove(filepath.Join(c.dir, base+".dat"))
+}
+
+func (c *WriteBackCache) validateScannedMeta(scannedMetaName string, meta *WriteBackMeta) bool {
+	if meta == nil || meta.Path == "" {
+		return false
+	}
+	return scannedMetaName == hashPath(meta.Path)+".meta"
+}
+
 // NewWriteBackCache creates (or opens) a write-back cache rooted at dir.
 // The directory is created if it does not exist. Existing entries on disk
 // are loaded into the in-memory pending index.
@@ -115,9 +128,11 @@ func NewWriteBackCache(dir string) (*WriteBackCache, error) {
 		}
 		var meta WriteBackMeta
 		if err := json.Unmarshal(raw, &meta); err != nil {
-			base := strings.TrimSuffix(name, ".meta")
-			_ = os.Remove(filepath.Join(dir, name))
-			_ = os.Remove(filepath.Join(dir, base+".dat"))
+			c.pruneScannedEntry(name)
+			continue
+		}
+		if !c.validateScannedMeta(name, &meta) {
+			c.pruneScannedEntry(name)
 			continue
 		}
 		cp := meta
@@ -417,9 +432,11 @@ func (c *WriteBackCache) ListPending() []PendingEntry {
 			}
 			var meta WriteBackMeta
 			if err := json.Unmarshal(raw, &meta); err != nil {
-				base := strings.TrimSuffix(name, ".meta")
-				_ = os.Remove(metaPath)
-				_ = os.Remove(filepath.Join(c.dir, base+".dat"))
+				c.pruneScannedEntry(name)
+				continue
+			}
+			if !c.validateScannedMeta(name, &meta) {
+				c.pruneScannedEntry(name)
 				continue
 			}
 			if _, ok := c.metas[meta.Path]; !ok {

--- a/pkg/fuse/writeback.go
+++ b/pkg/fuse/writeback.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -205,6 +206,15 @@ func (c *WriteBackCache) Get(remotePath string) ([]byte, bool) {
 	return copyData, true
 }
 
+func (c *WriteBackCache) pruneEntryLocked(remotePath string, removeDataFile bool) {
+	if removeDataFile {
+		_ = os.Remove(c.datFile(remotePath))
+	}
+	_ = os.Remove(c.metaFile(remotePath))
+	delete(c.metas, remotePath)
+	c.deleteDataLocked(remotePath)
+}
+
 // getViewLocked returns a read-only payload view for remotePath.
 // The caller must hold c.mu and must not mutate the returned slice.
 func (c *WriteBackCache) getViewLocked(remotePath string) ([]byte, bool) {
@@ -218,6 +228,9 @@ func (c *WriteBackCache) getViewLocked(remotePath string) ([]byte, bool) {
 	}
 	data, err := os.ReadFile(c.datFile(remotePath))
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			c.pruneEntryLocked(remotePath, false)
+		}
 		return nil, false
 	}
 	c.cacheDataLocked(remotePath, data, meta.Size)
@@ -296,10 +309,7 @@ func (c *WriteBackCache) Remove(remotePath string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	_ = os.Remove(c.datFile(remotePath))
-	_ = os.Remove(c.metaFile(remotePath))
-	delete(c.metas, remotePath)
-	c.deleteDataLocked(remotePath)
+	c.pruneEntryLocked(remotePath, true)
 }
 
 // RenamePending atomically moves a pending cache entry from oldPath to newPath.
@@ -428,13 +438,14 @@ func (c *WriteBackCache) ListPending() []PendingEntry {
 
 	result := make([]PendingEntry, 0, len(c.metas))
 	for path, meta := range c.metas {
+		if meta.Kind == PendingConflict {
+			continue
+		}
 		datPath := c.datFile(path)
 		data, err := os.ReadFile(datPath)
 		if err != nil {
 			// Data file missing — remove orphaned metadata.
-			_ = os.Remove(c.metaFile(path))
-			delete(c.metas, path)
-			c.deleteDataLocked(path)
+			c.pruneEntryLocked(path, false)
 			continue
 		}
 

--- a/pkg/fuse/writeback.go
+++ b/pkg/fuse/writeback.go
@@ -1,6 +1,7 @@
 package fuse
 
 import (
+	"container/list"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -17,6 +18,16 @@ import (
 // local write-back cache during Flush. Files larger than this are uploaded
 // directly (streaming or multipart) to avoid filling local disk.
 const writeBackThreshold = 10 << 20 // 10MB
+
+// writeBackInMemoryDataThreshold is the maximum cached write-back payload size
+// retained in memory for hot reopen/read paths. Larger entries stay on disk
+// only to avoid turning write-back into a large in-memory file store.
+const writeBackInMemoryDataThreshold = smallFileThreshold
+
+// defaultWriteBackDataCacheMaxSize bounds the aggregate in-memory footprint of
+// small write-back payloads retained for hot reopen/read/uploader paths.
+// Entries are evicted with an LRU policy once this budget is exceeded.
+const defaultWriteBackDataCacheMaxSize = 32 << 20 // 32MB
 
 // PendingKind distinguishes newly created files from overwrites of existing
 // remote files. This affects Rename behaviour: a pending-new file can be
@@ -59,10 +70,19 @@ type WriteBackCache struct {
 	dir     string // e.g. ~/.cache/drive9/{mount-hash}/pending
 	mu      sync.Mutex
 	nextGen atomic.Uint64
-	// pending is an in-memory index of remote paths with cache entries.
-	// Kept in sync with disk by Put/Remove/RenamePending so that
-	// ListPendingPaths avoids scanning the directory each time.
-	pending map[string]struct{}
+	// metas is the authoritative in-memory metadata index.
+	// Kept in sync with disk by Put/Remove/RenamePending so that GetMeta and
+	// ListPendingPaths avoid local disk I/O and JSON parsing on hot paths.
+	metas map[string]*WriteBackMeta
+	// data keeps small cached payloads in memory so writable reopen/read paths
+	// can avoid re-reading the .dat file from disk.
+	data map[string][]byte
+	// dataOrder tracks recency for the in-memory payload cache.
+	dataOrder *list.List
+	dataElems map[string]*list.Element
+	dataBytes int64
+	// dataMaxBytes is the aggregate memory budget for data.
+	dataMaxBytes int64
 }
 
 // NewWriteBackCache creates (or opens) a write-back cache rooted at dir.
@@ -72,9 +92,17 @@ func NewWriteBackCache(dir string) (*WriteBackCache, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("writeback cache dir: %w", err)
 	}
-	c := &WriteBackCache{dir: dir, pending: make(map[string]struct{})}
+	c := &WriteBackCache{
+		dir:          dir,
+		metas:        make(map[string]*WriteBackMeta),
+		data:         make(map[string][]byte),
+		dataOrder:    list.New(),
+		dataElems:    make(map[string]*list.Element),
+		dataMaxBytes: defaultWriteBackDataCacheMaxSize,
+	}
 	// Populate in-memory index from disk (crash recovery).
 	entries, _ := os.ReadDir(dir)
+	var maxGen uint64
 	for _, e := range entries {
 		name := e.Name()
 		if !strings.HasSuffix(name, ".meta") {
@@ -86,10 +114,18 @@ func NewWriteBackCache(dir string) (*WriteBackCache, error) {
 		}
 		var meta WriteBackMeta
 		if err := json.Unmarshal(raw, &meta); err != nil {
+			base := strings.TrimSuffix(name, ".meta")
+			_ = os.Remove(filepath.Join(dir, name))
+			_ = os.Remove(filepath.Join(dir, base+".dat"))
 			continue
 		}
-		c.pending[meta.Path] = struct{}{}
+		cp := meta
+		c.metas[meta.Path] = &cp
+		if meta.Generation > maxGen {
+			maxGen = meta.Generation
+		}
 	}
+	c.nextGen.Store(maxGen)
 	return c, nil
 }
 
@@ -149,7 +185,9 @@ func (c *WriteBackCache) PutWithBaseRev(remotePath string, data []byte, size int
 		_ = os.Remove(datPath)
 		return fmt.Errorf("writeback put meta: %w", err)
 	}
-	c.pending[remotePath] = struct{}{}
+	cp := meta
+	c.metas[remotePath] = &cp
+	c.cacheDataLocked(remotePath, data, size)
 	return nil
 }
 
@@ -158,11 +196,86 @@ func (c *WriteBackCache) Get(remotePath string) ([]byte, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	data, ok := c.getViewLocked(remotePath)
+	if !ok {
+		return nil, false
+	}
+	copyData := make([]byte, len(data))
+	copy(copyData, data)
+	return copyData, true
+}
+
+// getViewLocked returns a read-only payload view for remotePath.
+// The caller must hold c.mu and must not mutate the returned slice.
+func (c *WriteBackCache) getViewLocked(remotePath string) ([]byte, bool) {
+	if data, ok := c.data[remotePath]; ok {
+		c.touchDataLocked(remotePath)
+		return data, true
+	}
+	meta, ok := c.metas[remotePath]
+	if !ok {
+		return nil, false
+	}
 	data, err := os.ReadFile(c.datFile(remotePath))
 	if err != nil {
 		return nil, false
 	}
+	c.cacheDataLocked(remotePath, data, meta.Size)
+	if cached, ok := c.data[remotePath]; ok {
+		return cached, true
+	}
 	return data, true
+}
+
+// getView returns a read-only payload view for remotePath.
+// Callers must not mutate the returned slice.
+func (c *WriteBackCache) getView(remotePath string) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.getViewLocked(remotePath)
+}
+
+func (c *WriteBackCache) cacheDataLocked(remotePath string, data []byte, size int64) {
+	if size > writeBackInMemoryDataThreshold || len(data) > writeBackInMemoryDataThreshold || c.dataMaxBytes <= 0 {
+		c.deleteDataLocked(remotePath)
+		return
+	}
+	if existing, ok := c.data[remotePath]; ok {
+		c.dataBytes -= int64(len(existing))
+	} else {
+		c.dataElems[remotePath] = c.dataOrder.PushFront(remotePath)
+	}
+	stored := make([]byte, len(data))
+	copy(stored, data)
+	c.data[remotePath] = stored
+	c.dataBytes += int64(len(stored))
+	c.touchDataLocked(remotePath)
+	for c.dataBytes > c.dataMaxBytes && c.dataOrder.Len() > 0 {
+		tail := c.dataOrder.Back()
+		if tail == nil {
+			break
+		}
+		path, _ := tail.Value.(string)
+		c.deleteDataLocked(path)
+	}
+}
+
+func (c *WriteBackCache) touchDataLocked(remotePath string) {
+	if elem, ok := c.dataElems[remotePath]; ok {
+		c.dataOrder.MoveToFront(elem)
+	}
+}
+
+func (c *WriteBackCache) deleteDataLocked(remotePath string) {
+	if data, ok := c.data[remotePath]; ok {
+		c.dataBytes -= int64(len(data))
+		delete(c.data, remotePath)
+	}
+	if elem, ok := c.dataElems[remotePath]; ok {
+		c.dataOrder.Remove(elem)
+		delete(c.dataElems, remotePath)
+	}
 }
 
 // GetMeta reads the metadata for remotePath. Returns nil, false if not cached.
@@ -170,15 +283,12 @@ func (c *WriteBackCache) GetMeta(remotePath string) (*WriteBackMeta, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	raw, err := os.ReadFile(c.metaFile(remotePath))
-	if err != nil {
+	meta, ok := c.metas[remotePath]
+	if !ok {
 		return nil, false
 	}
-	var meta WriteBackMeta
-	if err := json.Unmarshal(raw, &meta); err != nil {
-		return nil, false
-	}
-	return &meta, true
+	cp := *meta
+	return &cp, true
 }
 
 // Remove deletes the cached data and metadata for remotePath.
@@ -188,7 +298,8 @@ func (c *WriteBackCache) Remove(remotePath string) {
 
 	_ = os.Remove(c.datFile(remotePath))
 	_ = os.Remove(c.metaFile(remotePath))
-	delete(c.pending, remotePath)
+	delete(c.metas, remotePath)
+	c.deleteDataLocked(remotePath)
 }
 
 // RenamePending atomically moves a pending cache entry from oldPath to newPath.
@@ -202,15 +313,11 @@ func (c *WriteBackCache) RenamePending(oldPath, newPath string) bool {
 	oldDat := c.datFile(oldPath)
 	oldMeta := c.metaFile(oldPath)
 
-	// Read existing meta.
-	raw, err := os.ReadFile(oldMeta)
-	if err != nil {
+	meta, ok := c.metas[oldPath]
+	if !ok {
 		return false
 	}
-	var meta WriteBackMeta
-	if err := json.Unmarshal(raw, &meta); err != nil {
-		return false
-	}
+	updated := *meta
 
 	// Rename .dat file directly — same directory, no data copy needed.
 	newDat := c.datFile(newPath)
@@ -219,9 +326,9 @@ func (c *WriteBackCache) RenamePending(oldPath, newPath string) bool {
 	}
 
 	// Write new .meta with updated path and fresh generation.
-	meta.Path = newPath
-	meta.Generation = c.nextGen.Add(1)
-	metaBytes, err := json.Marshal(meta)
+	updated.Path = newPath
+	updated.Generation = c.nextGen.Add(1)
+	metaBytes, err := json.Marshal(updated)
 	if err != nil {
 		_ = os.Rename(newDat, oldDat)
 		return false
@@ -235,8 +342,24 @@ func (c *WriteBackCache) RenamePending(oldPath, newPath string) bool {
 
 	// Remove old meta and update index.
 	_ = os.Remove(oldMeta)
-	delete(c.pending, oldPath)
-	c.pending[newPath] = struct{}{}
+	delete(c.metas, oldPath)
+	cp := updated
+	c.metas[newPath] = &cp
+	if data, ok := c.data[oldPath]; ok {
+		c.deleteDataLocked(oldPath)
+		c.deleteDataLocked(newPath)
+		c.data[newPath] = data
+		c.dataBytes += int64(len(data))
+		c.dataElems[newPath] = c.dataOrder.PushFront(newPath)
+		for c.dataBytes > c.dataMaxBytes && c.dataOrder.Len() > 0 {
+			tail := c.dataOrder.Back()
+			if tail == nil {
+				break
+			}
+			path, _ := tail.Value.(string)
+			c.deleteDataLocked(path)
+		}
+	}
 	return true
 }
 
@@ -246,12 +369,12 @@ func (c *WriteBackCache) ListPendingPaths() map[string]struct{} {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if len(c.pending) == 0 {
+	if len(c.metas) == 0 {
 		return nil
 	}
 	// Return a copy so callers can iterate without holding the lock.
-	result := make(map[string]struct{}, len(c.pending))
-	for k := range c.pending {
+	result := make(map[string]struct{}, len(c.metas))
+	for k := range c.metas {
 		result[k] = struct{}{}
 	}
 	return result
@@ -263,46 +386,60 @@ type PendingEntry struct {
 	Data []byte
 }
 
-// ListPending scans the cache directory and returns all pending entries.
-// Entries with missing or corrupt metadata are skipped (and cleaned up).
+// ListPending returns all pending entries using the in-memory metadata index.
+// It also reconciles any on-disk .meta files not yet in memory so crash
+// recovery and corruption cleanup keep the legacy behavior on this cold path.
 func (c *WriteBackCache) ListPending() []PendingEntry {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	entries, err := os.ReadDir(c.dir)
-	if err != nil {
+	if err == nil {
+		for _, e := range entries {
+			name := e.Name()
+			if !strings.HasSuffix(name, ".meta") {
+				continue
+			}
+			metaPath := filepath.Join(c.dir, name)
+			raw, err := os.ReadFile(metaPath)
+			if err != nil {
+				continue
+			}
+			var meta WriteBackMeta
+			if err := json.Unmarshal(raw, &meta); err != nil {
+				base := strings.TrimSuffix(name, ".meta")
+				_ = os.Remove(metaPath)
+				_ = os.Remove(filepath.Join(c.dir, base+".dat"))
+				continue
+			}
+			if _, ok := c.metas[meta.Path]; !ok {
+				cp := meta
+				c.metas[meta.Path] = &cp
+				if meta.Generation > c.nextGen.Load() {
+					c.nextGen.Store(meta.Generation)
+				}
+			}
+		}
+	}
+
+	if len(c.metas) == 0 {
 		return nil
 	}
 
-	var result []PendingEntry
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.HasSuffix(name, ".meta") {
-			continue
-		}
-		metaPath := filepath.Join(c.dir, name)
-		raw, err := os.ReadFile(metaPath)
-		if err != nil {
-			continue
-		}
-		var meta WriteBackMeta
-		if err := json.Unmarshal(raw, &meta); err != nil {
-			// Corrupt meta — remove both files.
-			base := strings.TrimSuffix(name, ".meta")
-			_ = os.Remove(metaPath)
-			_ = os.Remove(filepath.Join(c.dir, base+".dat"))
-			continue
-		}
-
-		datPath := filepath.Join(c.dir, strings.TrimSuffix(name, ".meta")+".dat")
+	result := make([]PendingEntry, 0, len(c.metas))
+	for path, meta := range c.metas {
+		datPath := c.datFile(path)
 		data, err := os.ReadFile(datPath)
 		if err != nil {
-			// Data file missing — remove orphaned meta.
-			_ = os.Remove(metaPath)
+			// Data file missing — remove orphaned metadata.
+			_ = os.Remove(c.metaFile(path))
+			delete(c.metas, path)
+			c.deleteDataLocked(path)
 			continue
 		}
 
-		result = append(result, PendingEntry{Meta: meta, Data: data})
+		c.cacheDataLocked(path, data, meta.Size)
+		result = append(result, PendingEntry{Meta: *meta, Data: data})
 	}
 	return result
 }

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -169,6 +169,36 @@ func TestWriteBackCache_LargeDataNotCachedInMemory(t *testing.T) {
 	}
 }
 
+func TestWriteBackCache_GetViewPrunesMissingLargeData(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := "/large.bin"
+	data := make([]byte, writeBackInMemoryDataThreshold+1)
+	if err := cache.Put(path, data, int64(len(data)), PendingOverwrite); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(cache.datFile(path)); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := cache.getView(path); ok {
+		t.Fatal("expected getView miss after data file removal")
+	}
+	if _, ok := cache.GetMeta(path); ok {
+		t.Fatal("expected missing data to prune in-memory meta")
+	}
+	if _, err := os.Stat(cache.metaFile(path)); !os.IsNotExist(err) {
+		t.Fatal("expected missing data to prune on-disk meta")
+	}
+	if paths := cache.ListPendingPaths(); len(paths) != 0 {
+		t.Fatalf("ListPendingPaths len = %d, want 0", len(paths))
+	}
+}
+
 func TestWriteBackCache_SmallDataCacheBudgetEvictsLRU(t *testing.T) {
 	dir := t.TempDir()
 	cache, err := NewWriteBackCache(dir)
@@ -264,6 +294,29 @@ func TestWriteBackCache_ListPending(t *testing.T) {
 	}
 	if string(byPath["/b.txt"].Data) != "bbb" {
 		t.Fatalf("b.txt data = %q, want %q", byPath["/b.txt"].Data, "bbb")
+	}
+}
+
+func TestWriteBackCache_ListPending_SkipsConflictEntries(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cache.Put("/ok.txt", []byte("ok"), 2, PendingNew); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.PutWithBaseRev("/conflict.txt", []byte("conflict"), 8, PendingConflict, 9); err != nil {
+		t.Fatal(err)
+	}
+
+	pending := cache.ListPending()
+	if len(pending) != 1 {
+		t.Fatalf("ListPending returned %d entries, want 1", len(pending))
+	}
+	if pending[0].Meta.Path != "/ok.txt" {
+		t.Fatalf("pending path = %q, want /ok.txt", pending[0].Meta.Path)
 	}
 }
 
@@ -1562,6 +1615,24 @@ func TestOpenWritable_OverwriteFromWriteBackCacheSkipsRemoteStat(t *testing.T) {
 	}
 	if fh.BaseRev != 11 {
 		t.Fatalf("BaseRev = %d, want 11", fh.BaseRev)
+	}
+	if fh.WriteBackSeq == 0 || fh.WriteBackSeq != fh.DirtySeq {
+		t.Fatalf("WriteBackSeq = %d, DirtySeq = %d, want matching non-zero snapshot seq", fh.WriteBackSeq, fh.DirtySeq)
+	}
+
+	buf := make([]byte, 32)
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       openOut.Fh,
+		Offset:   0,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read: %v", st)
+	}
+	got, _ := result.Bytes(buf)
+	if string(got) != "fresh data" {
+		t.Fatalf("Read = %q, want %q", string(got), "fresh data")
 	}
 	if got := headCalls.Load(); got != 0 {
 		t.Fatalf("HEAD calls = %d, want 0", got)

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -87,6 +87,125 @@ func TestWriteBackCache_PutWithBaseRevPersistsRevision(t *testing.T) {
 	}
 }
 
+func TestWriteBackCache_GetMetaUsesInMemoryIndex(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := "/existing.txt"
+	if err := cache.PutWithBaseRev(path, []byte("hello"), 5, PendingOverwrite, 17); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(cache.metaFile(path)); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, ok := cache.GetMeta(path)
+	if !ok {
+		t.Fatal("expected GetMeta to return true from memory index")
+	}
+	if meta.BaseRev != 17 {
+		t.Fatalf("meta.BaseRev = %d, want 17", meta.BaseRev)
+	}
+	if meta.Kind != PendingOverwrite {
+		t.Fatalf("meta.Kind = %v, want %v", meta.Kind, PendingOverwrite)
+	}
+}
+
+func TestWriteBackCache_GetUsesInMemorySmallDataCache(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := "/small.txt"
+	data := []byte("hello")
+	if err := cache.Put(path, data, int64(len(data)), PendingNew); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(cache.datFile(path)); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := cache.Get(path)
+	if !ok {
+		t.Fatal("expected Get to return true from small data cache")
+	}
+	if string(got) != string(data) {
+		t.Fatalf("Get = %q, want %q", got, data)
+	}
+	view, ok := cache.getView(path)
+	if !ok {
+		t.Fatal("expected getView to return true from small data cache")
+	}
+	if string(view) != string(data) {
+		t.Fatalf("getView = %q, want %q", view, data)
+	}
+}
+
+func TestWriteBackCache_LargeDataNotCachedInMemory(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := "/large.bin"
+	data := make([]byte, writeBackInMemoryDataThreshold+1)
+	if err := cache.Put(path, data, int64(len(data)), PendingNew); err != nil {
+		t.Fatal(err)
+	}
+
+	cache.mu.Lock()
+	_, ok := cache.data[path]
+	cache.mu.Unlock()
+	if ok {
+		t.Fatal("large payload should not be retained in memory cache")
+	}
+}
+
+func TestWriteBackCache_SmallDataCacheBudgetEvictsLRU(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.dataMaxBytes = 10
+
+	if err := cache.Put("/a.txt", []byte("aaaaa"), 5, PendingNew); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Put("/b.txt", []byte("bbbbb"), 5, PendingNew); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.getView("/a.txt"); !ok {
+		t.Fatal("expected /a.txt to be cached")
+	}
+	if err := cache.Put("/c.txt", []byte("ccccc"), 5, PendingNew); err != nil {
+		t.Fatal(err)
+	}
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	if cache.dataBytes > cache.dataMaxBytes {
+		t.Fatalf("dataBytes = %d, want <= %d", cache.dataBytes, cache.dataMaxBytes)
+	}
+	if _, ok := cache.data["/a.txt"]; !ok {
+		t.Fatal("expected /a.txt to remain cached as most-recent entry")
+	}
+	if _, ok := cache.data["/c.txt"]; !ok {
+		t.Fatal("expected /c.txt to remain cached as newest entry")
+	}
+	if _, ok := cache.data["/b.txt"]; ok {
+		t.Fatal("expected /b.txt to be evicted by LRU budget")
+	}
+}
+
 func TestWriteBackCache_AtomicWrite(t *testing.T) {
 	dir := t.TempDir()
 	cache, err := NewWriteBackCache(dir)
@@ -1309,15 +1428,20 @@ func TestLookupFindsPendingWriteBack(t *testing.T) {
 // TestOpenWritable_PreloadsFromWriteBackCache verifies that opening a file
 // for writing preloads data from the write-back cache instead of the remote.
 func TestOpenWritable_PreloadsFromWriteBackCache(t *testing.T) {
+	var headCalls atomic.Int32
+	var getCalls atomic.Int32
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodHead:
+			headCalls.Add(1)
 			// Return stale data size from "server"
 			w.Header().Set("Content-Length", "5")
 			w.Header().Set("X-Dat9-IsDir", "false")
 			w.Header().Set("X-Dat9-Revision", "1")
 			w.WriteHeader(http.StatusOK)
 		case http.MethodGet:
+			getCalls.Add(1)
 			if r.URL.RawQuery == "list=1" {
 				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
 				return
@@ -1372,6 +1496,78 @@ func TestOpenWritable_PreloadsFromWriteBackCache(t *testing.T) {
 	data, _ := result.Bytes(buf)
 	if string(data) != "fresh data" {
 		t.Fatalf("Read = %q, want %q (writable preload used stale data)", string(data), "fresh data")
+	}
+	if got := headCalls.Load(); got != 0 {
+		t.Fatalf("HEAD calls = %d, want 0", got)
+	}
+	if got := getCalls.Load(); got != 0 {
+		t.Fatalf("GET calls = %d, want 0", got)
+	}
+
+	uploader.DrainAll()
+}
+
+func TestOpenWritable_OverwriteFromWriteBackCacheSkipsRemoteStat(t *testing.T) {
+	var headCalls atomic.Int32
+	var getCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			w.Header().Set("Content-Length", "5")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getCalls.Add(1)
+			_, _ = w.Write([]byte("stale"))
+		case http.MethodPut:
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	cache, _ := NewWriteBackCache(dir)
+	c := client.New(ts.URL, "")
+	uploader := NewWriteBackUploader(c, cache, 0)
+
+	opts := &MountOptions{FlushDebounce: 0}
+	opts.setDefaults()
+	fs := NewDat9FS(c, opts)
+	fs.SetWriteBack(cache, uploader)
+
+	if err := cache.PutWithBaseRev("/file.txt", []byte("fresh data"), 10, PendingOverwrite, 11); err != nil {
+		t.Fatal(err)
+	}
+
+	ino := fs.inodes.Lookup("/file.txt", false, 10, time.Time{})
+
+	var openOut gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(os.O_RDWR),
+	}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open: %v", st)
+	}
+
+	fh, ok := fs.fileHandles.Get(openOut.Fh)
+	if !ok {
+		t.Fatal("expected file handle to exist")
+	}
+	if fh.BaseRev != 11 {
+		t.Fatalf("BaseRev = %d, want 11", fh.BaseRev)
+	}
+	if got := headCalls.Load(); got != 0 {
+		t.Fatalf("HEAD calls = %d, want 0", got)
+	}
+	if got := getCalls.Load(); got != 0 {
+		t.Fatalf("GET calls = %d, want 0", got)
 	}
 
 	uploader.DrainAll()
@@ -1501,6 +1697,37 @@ func TestWriteBackCache_Generation(t *testing.T) {
 
 	if meta2.Generation <= meta1.Generation {
 		t.Fatalf("generation did not increase: %d <= %d", meta2.Generation, meta1.Generation)
+	}
+}
+
+func TestWriteBackCache_ReopenPreservesGenerationCounter(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cache.Put("/gen.txt", []byte("v1"), 2, PendingNew); err != nil {
+		t.Fatal(err)
+	}
+	meta1, ok := cache.GetMeta("/gen.txt")
+	if !ok {
+		t.Fatal("expected meta after first Put")
+	}
+
+	cache2, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cache2.Put("/gen.txt", []byte("v2"), 2, PendingNew); err != nil {
+		t.Fatal(err)
+	}
+	meta2, ok := cache2.GetMeta("/gen.txt")
+	if !ok {
+		t.Fatal("expected meta after reopened Put")
+	}
+	if meta2.Generation <= meta1.Generation {
+		t.Fatalf("generation did not increase after reopen: %d <= %d", meta2.Generation, meta1.Generation)
 	}
 }
 

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -352,6 +352,91 @@ func TestWriteBackCache_ListPending_CorruptMeta(t *testing.T) {
 	}
 }
 
+func TestNewWriteBackCache_PrunesMismatchedMetaPath(t *testing.T) {
+	dir := t.TempDir()
+
+	wrongPath := "/wrong.txt"
+	scannedPath := "/actual.txt"
+	scannedHash := hashPath(scannedPath)
+	meta := WriteBackMeta{
+		Path:       wrongPath,
+		Size:       4,
+		Mtime:      time.Now(),
+		CreatedAt:  time.Now(),
+		Generation: 3,
+		Kind:       PendingNew,
+	}
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, scannedHash+".meta"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, scannedHash+".dat"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paths := cache.ListPendingPaths(); len(paths) != 0 {
+		t.Fatalf("ListPendingPaths len = %d, want 0", len(paths))
+	}
+	if _, err := os.Stat(filepath.Join(dir, scannedHash+".meta")); !os.IsNotExist(err) {
+		t.Fatal("mismatched .meta should be removed during cache load")
+	}
+	if _, err := os.Stat(filepath.Join(dir, scannedHash+".dat")); !os.IsNotExist(err) {
+		t.Fatal("mismatched .dat should be removed during cache load")
+	}
+}
+
+func TestWriteBackCache_ListPending_PrunesEmptyMetaPath(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := hashPath("/scanned.txt")
+	meta := WriteBackMeta{
+		Path:       "",
+		Size:       4,
+		Mtime:      time.Now(),
+		CreatedAt:  time.Now(),
+		Generation: 2,
+		Kind:       PendingNew,
+	}
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, hash+".meta"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, hash+".dat"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Put("/valid.txt", []byte("ok"), 2, PendingNew); err != nil {
+		t.Fatal(err)
+	}
+
+	pending := cache.ListPending()
+	if len(pending) != 1 {
+		t.Fatalf("ListPending returned %d entries, want 1", len(pending))
+	}
+	if pending[0].Meta.Path != "/valid.txt" {
+		t.Fatalf("pending path = %q, want /valid.txt", pending[0].Meta.Path)
+	}
+	if _, err := os.Stat(filepath.Join(dir, hash+".meta")); !os.IsNotExist(err) {
+		t.Fatal("empty-path .meta should be removed during reconciliation")
+	}
+	if _, err := os.Stat(filepath.Join(dir, hash+".dat")); !os.IsNotExist(err) {
+		t.Fatal("empty-path .dat should be removed during reconciliation")
+	}
+}
+
 func TestWriteBackUploader_SubmitAndUpload(t *testing.T) {
 	var uploadedPaths sync.Map
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fuse/writeback_uploader.go
+++ b/pkg/fuse/writeback_uploader.go
@@ -239,7 +239,7 @@ func (u *WriteBackUploader) uploadOne(localPath string) {
 	}
 	gen := meta.Generation
 
-	data, ok := u.cache.Get(localPath)
+	data, ok := u.cache.getView(localPath)
 	if !ok {
 		return
 	}
@@ -321,7 +321,7 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) er
 	}
 	gen := meta.Generation
 
-	data, ok := u.cache.Get(localPath)
+	data, ok := u.cache.getView(localPath)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
## Summary
Optimize FUSE small-file hot paths to reduce writable reopen/read overhead and keep pending write-back reopen fast without unbounded memory growth.

## What changed
- preload writable small-file handles from read cache, pending shadow state, and write-back cache before falling back to remote stat/get
- serve clean writable-handle reads from already loaded write buffer ranges instead of always reading remotely
- avoid repeated small-file materialization by adding a read-only write-buffer view and reusing owned slices when populating the read cache
- keep write-back metadata in memory and cache small pending payloads for hot reopen/read/uploader paths
- bound the in-memory write-back payload cache with a 32MB LRU budget to avoid unbounded resident memory growth
- add focused tests and benchmarks covering read-cache hits, pending shadow/write-back reopen, and small-file flush/read paths

## Validation
- go test ./pkg/fuse
- go test ./pkg/fuse -run 'TestWriteBackCache_GetUsesInMemorySmallDataCache|TestWriteBackCache_LargeDataNotCachedInMemory|TestWriteBackCache_SmallDataCacheBudgetEvictsLRU|TestOpenWritable_PreloadsFromWriteBackCache|TestOpenWritable_OverwriteFromWriteBackCacheSkipsRemoteStat|TestWriteBackCache_RenamePending'
- go test ./pkg/fuse -run '^$' -bench 'BenchmarkDat9FS_SmallFileOpen/pending-writeback-overwrite' -benchmem -count 5

## Benchmark note
The pending write-back overwrite reopen benchmark stayed around 9-12 us/op after adding the bounded LRU payload cache, preserving the hot-path win while capping memory use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved file caching and buffer handling for safer, more memory-efficient access
  * Faster small-file opens/reads with new fast-paths that reduce remote stat/read calls
  * Write-back cache revamped to an in-memory metadata index with LRU payload caching for better performance

* **Tests**
  * Added micro-benchmarks for small-file open/read/flush
  * Expanded tests for cache semantics, eviction behavior, preload fast-paths, and write-back persistence
<!-- end of auto-generated comment: release notes by coderabbit.ai -->