### PR TITLE
feat: make inline storage threshold server-configurable

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -578,6 +578,15 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 		return backend.Options{}, fmt.Errorf("DRIVE9_MAX_TENANT_STORAGE_BYTES must be a positive integer")
 	}
 
+	opts.InlineThreshold = envInt64("DRIVE9_INLINE_THRESHOLD", backend.DefaultInlineThreshold)
+	if opts.InlineThreshold <= 0 {
+		return backend.Options{}, fmt.Errorf("DRIVE9_INLINE_THRESHOLD must be a positive integer")
+	}
+	opts.TextExtractMaxBytes = envInt64("DRIVE9_TEXT_EXTRACT_MAX_BYTES", backend.DefaultTextExtractMaxBytes)
+	if opts.TextExtractMaxBytes <= 0 {
+		return backend.Options{}, fmt.Errorf("DRIVE9_TEXT_EXTRACT_MAX_BYTES must be a positive integer")
+	}
+
 	// Quota enforcement source: "tenant" (default) or "server" (central server DB).
 	switch qs := strings.ToLower(strings.TrimSpace(os.Getenv("DRIVE9_QUOTA_SOURCE"))); qs {
 	case "", "tenant":

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -249,6 +249,7 @@ func main() {
 			VaultMasterKey:   vaultMasterKey,
 			S3Dir:            s3cfg.Dir,
 			MaxUploadBytes:   maxUploadBytes,
+			InlineThreshold:  backendOptions.InlineThreshold,
 			Logger:           srvLogger,
 			SemanticEmbedder: semanticEmbedder,
 			SemanticWorkers:  semanticWorkerOpts,
@@ -266,6 +267,7 @@ func main() {
 		VaultIssuerURL:   vaultIssuerURL(addr),
 		S3Dir:            s3cfg.Dir,
 		MaxUploadBytes:   maxUploadBytes,
+		InlineThreshold:  backendOptions.InlineThreshold,
 		Logger:           srvLogger,
 		SemanticEmbedder: semanticEmbedder,
 		SemanticWorkers:  semanticWorkerOpts,
@@ -477,6 +479,15 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 	opts.MaxTenantStorageBytes = envInt64("DRIVE9_MAX_TENANT_STORAGE_BYTES", 50*(1<<30))
 	if opts.MaxTenantStorageBytes <= 0 {
 		return backend.Options{}, fmt.Errorf("DRIVE9_MAX_TENANT_STORAGE_BYTES must be a positive integer")
+	}
+
+	opts.InlineThreshold = envInt64("DRIVE9_INLINE_THRESHOLD", backend.DefaultInlineThreshold)
+	if opts.InlineThreshold <= 0 {
+		return backend.Options{}, fmt.Errorf("DRIVE9_INLINE_THRESHOLD must be a positive integer")
+	}
+	opts.TextExtractMaxBytes = envInt64("DRIVE9_TEXT_EXTRACT_MAX_BYTES", backend.DefaultTextExtractMaxBytes)
+	if opts.TextExtractMaxBytes <= 0 {
+		return backend.Options{}, fmt.Errorf("DRIVE9_TEXT_EXTRACT_MAX_BYTES must be a positive integer")
 	}
 
 	// Quota enforcement source: "tenant" (default, per-tenant DB) or "server" (central server DB).

--- a/cmd/drive9/cli/client.go
+++ b/cmd/drive9/cli/client.go
@@ -1,8 +1,17 @@
 package cli
 
 import (
+	"context"
+	"time"
+
 	"github.com/mem9-ai/dat9/pkg/client"
 )
+
+// fsClientWarmTimeout caps the synchronous /v1/status fetch issued by
+// upload-bearing commands so a slow or unreachable server can't stall the
+// CLI. On timeout the client just falls back to compiled defaults; one
+// extra multipart RTT is preferable to hanging the CLI.
+const fsClientWarmTimeout = 3 * time.Second
 
 // NewFromEnv returns an owner-scoped client for the drive9 fs plane
 // (drive9 fs cp/cat/ls/mv/rm/sh/grep/find/stat). It is the single entry
@@ -18,6 +27,12 @@ import (
 //
 // Credential resolution goes through the unified resolver per §14.2
 // (env > config, Unsetenv-after-read).
+//
+// NewFromEnv intentionally does NOT warm the /v1/status cache: read-only
+// commands (ls/cat/stat/rm/grep/find) don't need the upload threshold and
+// shouldn't pay an extra RTT (or wait on a slow server) before issuing
+// their actual request. Upload-bearing commands should call
+// NewFromEnvWithWarm.
 func NewFromEnv() *client.Client {
 	r := ResolveCredentials()
 	apiKey := ""
@@ -25,4 +40,21 @@ func NewFromEnv() *client.Client {
 		apiKey = r.APIKey
 	}
 	return client.New(r.Server, apiKey)
+}
+
+// NewFromEnvWithWarm is NewFromEnv plus a synchronous /v1/status warm,
+// bounded by fsClientWarmTimeout. Use this from commands that perform
+// uploads (cp, secret put, anything that may hit the simple-PUT vs V2
+// multipart split) so the very first upload picks up the server's
+// configured inline_threshold instead of the local fallback.
+//
+// A failed warm leaves the client unflagged: subsequent client methods
+// that themselves call Warm/MaxUploadBytes/SmallFileThreshold will retry,
+// rather than caching the failure forever.
+func NewFromEnvWithWarm() *client.Client {
+	c := NewFromEnv()
+	ctx, cancel := context.WithTimeout(context.Background(), fsClientWarmTimeout)
+	defer cancel()
+	c.Warm(ctx)
+	return c
 }

--- a/cmd/drive9/cli/cp_test.go
+++ b/cmd/drive9/cli/cp_test.go
@@ -108,6 +108,7 @@ func TestDownloadFileEmitsDownloadSummaryToCLILogForLargeFile(t *testing.T) {
 
 	localPath := filepath.Join(t.TempDir(), "large.bin")
 	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 
 	if err := downloadFile(context.Background(), c, "/large.bin", localPath); err != nil {
 		t.Fatalf("downloadFile: %v", err)
@@ -159,6 +160,7 @@ func TestDownloadFileSkipsDownloadSummaryWhenCLILogDisabled(t *testing.T) {
 
 	localPath := filepath.Join(t.TempDir(), "small.txt")
 	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 
 	if err := downloadFile(context.Background(), c, "/small.txt", localPath); err != nil {
 		t.Fatalf("downloadFile: %v", err)
@@ -217,6 +219,7 @@ func TestUploadFileEmitsUploadSummaryToCLILog(t *testing.T) {
 	}
 
 	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 	if err := uploadFile(context.Background(), c, localPath, "/upload.txt", ""); err != nil {
 		t.Fatalf("uploadFile: %v", err)
 	}
@@ -328,6 +331,7 @@ func TestCpAppendUploadsToRemote(t *testing.T) {
 	defer srv.Close()
 
 	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 	if err := Cp(c, []string{"--append", localPath, ":/dest.txt"}); err != nil {
 		t.Fatalf("Cp(--append): %v", err)
 	}
@@ -347,6 +351,7 @@ func TestCpAppendRejectsRemoteToLocal(t *testing.T) {
 	defer srv.Close()
 
 	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 	err := Cp(c, []string{"--append", ":/src.txt", localPath})
 	if err == nil {
 		t.Fatal("expected error for remote -> local append")
@@ -363,6 +368,7 @@ func TestCpAppendRejectsRemoteToRemote(t *testing.T) {
 	defer srv.Close()
 
 	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 	err := Cp(c, []string{"--append", ":/src.txt", ":/dst.txt"})
 	if err == nil {
 		t.Fatal("expected error for remote -> remote append")
@@ -379,6 +385,7 @@ func TestCpAppendRejectsStdinSource(t *testing.T) {
 	defer srv.Close()
 
 	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 	err := Cp(c, []string{"--append", "-", ":/dst.txt"})
 	if err == nil {
 		t.Fatal("expected error for stdin append")
@@ -400,6 +407,7 @@ func TestCpAppendRejectsTags(t *testing.T) {
 	defer srv.Close()
 
 	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 	err := Cp(c, []string{"--append", "--tag", "owner=alice", localPath, ":/dst.txt"})
 	if err == nil {
 		t.Fatal("expected error for append with tags")
@@ -435,6 +443,7 @@ func TestCpUploadWithTagsSendsHeaders(t *testing.T) {
 	defer srv.Close()
 
 	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 	err := Cp(c, []string{"--tag", "topic=cat", "--tag=owner=alice", localPath, ":/tagged.txt"})
 	if err != nil {
 		t.Fatalf("Cp(upload with tags): %v", err)
@@ -459,6 +468,7 @@ func TestCpRejectsTagForDownloadDirection(t *testing.T) {
 	defer srv.Close()
 
 	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 	err := Cp(c, []string{"--tag", "owner=alice", ":/src.txt", localPath})
 	if err == nil {
 		t.Fatal("expected direction validation error")

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -175,6 +176,9 @@ func fsMountCmd(args []string) error {
 		} else {
 			c = client.New(*server, *apiKey)
 		}
+		warmCtx, warmCancel := context.WithTimeout(context.Background(), fsClientWarmTimeout)
+		c.Warm(warmCtx)
+		warmCancel()
 
 		// Validate remote root exists and is a directory.
 		if err := validateRemoteRoot(c, remoteRoot); err != nil {

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/mem9-ai/dat9/cmd/drive9/cli"
 	"github.com/mem9-ai/dat9/pkg/buildinfo"
+	"github.com/mem9-ai/dat9/pkg/client"
 	"github.com/mem9-ai/dat9/pkg/logger"
 )
 
@@ -189,7 +190,19 @@ func runFS(args []string) {
 	}
 	sub := args[0]
 	rest := args[1:]
-	c := cli.NewFromEnv()
+
+	// Only commands that may upload pay the /v1/status warm RTT. Read-only
+	// commands (cat/ls/stat/rm/grep/find) and namespace-only writes (mv,
+	// mkdir) do not consult the upload threshold and can skip the warm —
+	// keeps cold-start latency unchanged for the common case and avoids
+	// hanging an `ls` behind a slow status endpoint.
+	var c *client.Client
+	switch sub {
+	case "cp", "sh":
+		c = cli.NewFromEnvWithWarm()
+	default:
+		c = cli.NewFromEnv()
+	}
 
 	var err error
 	switch sub {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -33,11 +33,31 @@ import (
 )
 
 const (
-	smallFileThreshold = 50_000 // 50,000 bytes; controls DB-inline storage.
-	// TiDB auto embedding currently rejects inputs over 8192 tokens. Use a
-	// conservative byte cap for synchronous text extraction so text-heavy small
-	// files do not fail the whole write through the generated embedding column.
-	textExtractMaxBytes = 8_192
+	// DefaultInlineThreshold is the default cutoff between DB-inline and S3
+	// storage. Operators can override via Options.InlineThreshold; the value
+	// is also exposed to clients via /v1/status so they pick a matching
+	// upload strategy.
+	//
+	// This single threshold deliberately governs both decisions:
+	//   1. Server-side: store inline in TiDB content_blob vs spill to S3.
+	//   2. Client-side: simple PUT to /v1/fs/{path} vs V2 multipart presign.
+	//
+	// Splitting the two (e.g. "client direct PUT up to 1MB but only inline
+	// in TiDB up to 50KB") is tempting for performance but reintroduces the
+	// server as a data-plane proxy: the simple-PUT body would have to flow
+	// through the server process and PutObject to S3 itself, exactly what
+	// the V2 multipart protocol is designed to avoid. Until the simple-PUT
+	// path streams into S3 without buffering in server RAM, keep the two
+	// decisions tied so raising the threshold has predictable cost
+	// (TiDB blob column growth, not server bandwidth + memory).
+	DefaultInlineThreshold int64 = 50_000
+	// DefaultTextExtractMaxBytes is the default cap for synchronous text
+	// extraction. TiDB auto embedding currently rejects inputs over 8192
+	// tokens; this byte cap keeps text-heavy small files from failing the
+	// whole write through the generated embedding column. Independent of
+	// InlineThreshold: extraction can be tightened or relaxed without
+	// changing the storage-class boundary.
+	DefaultTextExtractMaxBytes int64 = 8_192
 )
 
 // Dat9Backend implements filesystem.FileSystem with the inode model.
@@ -53,6 +73,11 @@ type Dat9Backend struct {
 	maxUploadBytes        int64
 	maxTenantStorageBytes int64
 	maxMediaLLMFiles      int64
+	// inlineThreshold controls the DB-inline vs S3 storage cutoff and (when
+	// surfaced to clients) the simple-PUT vs multipart upload boundary.
+	inlineThreshold int64
+	// textExtractMaxBytes caps synchronous text extraction input size.
+	textExtractMaxBytes int64
 	mu                    sync.Mutex
 	entropy               io.Reader
 
@@ -93,10 +118,12 @@ type Dat9Backend struct {
 
 func newBaseBackend(store *datastore.Store) *Dat9Backend {
 	return &Dat9Backend{
-		store:         store,
-		smallInDB:     true,
-		queryEmbedder: embedding.NopClient{},
-		entropy:       ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0),
+		store:               store,
+		smallInDB:           true,
+		queryEmbedder:       embedding.NopClient{},
+		entropy:             ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0),
+		inlineThreshold:     DefaultInlineThreshold,
+		textExtractMaxBytes: DefaultTextExtractMaxBytes,
 	}
 }
 
@@ -415,7 +442,7 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 
 	contentType := detectContentType(path, data)
 	checksum := sha256sum(data)
-	contentText := extractText(data, contentType)
+	contentText := extractText(data, contentType, b.textExtractMaxBytes)
 
 	storageType := datastore.StorageDB9
 	storageRef := "inline"
@@ -532,7 +559,7 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 	}
 	contentType := detectContentType(nf.Node.Path, finalData)
 	checksum := sha256sum(finalData)
-	contentText := extractText(finalData, contentType)
+	contentText := extractText(finalData, contentType, b.textExtractMaxBytes)
 	storageType := datastore.StorageDB9
 	storageRef := "inline"
 	storageEncryptionMode := datastore.StorageEncryptionNone
@@ -1054,8 +1081,19 @@ func (b *Dat9Backend) readFileDataCtx(ctx context.Context, f *datastore.File) ([
 	return nil, fmt.Errorf("unsupported storage type for direct read: %s", f.StorageType)
 }
 
+// InlineThreshold returns the configured DB-inline vs S3 storage cutoff.
+func (b *Dat9Backend) InlineThreshold() int64 {
+	return b.inlineThreshold
+}
+
+// TextExtractMaxBytes returns the configured cap for synchronous text
+// extraction inputs.
+func (b *Dat9Backend) TextExtractMaxBytes() int64 {
+	return b.textExtractMaxBytes
+}
+
 func (b *Dat9Backend) shouldStoreInDB(size int64) bool {
-	return b.smallInDB && size < smallFileThreshold
+	return b.smallInDB && size < b.inlineThreshold
 }
 
 // --- writeCloser ---
@@ -1167,14 +1205,17 @@ func isTextualContentType(contentType string) bool {
 		contentType == "application/yaml"
 }
 
-func extractText(data []byte, contentType string) string {
+func extractText(data []byte, contentType string, maxBytes int64) string {
 	if !isTextualContentType(contentType) {
 		return ""
 	}
 	if !isTextContent(data) {
 		return ""
 	}
-	if len(data) > textExtractMaxBytes {
+	if maxBytes <= 0 {
+		maxBytes = DefaultTextExtractMaxBytes
+	}
+	if int64(len(data)) > maxBytes {
 		return ""
 	}
 	return string(data)

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -190,26 +190,103 @@ func TestDat9BackendAutoSemanticTaskTypes(t *testing.T) {
 }
 
 func TestExtractTextUsesEmbeddingSafeLimit(t *testing.T) {
-	if textExtractMaxBytes >= smallFileThreshold {
-		t.Fatalf("textExtractMaxBytes=%d must stay below smallFileThreshold=%d", textExtractMaxBytes, smallFileThreshold)
+	if DefaultTextExtractMaxBytes >= DefaultInlineThreshold {
+		t.Fatalf("DefaultTextExtractMaxBytes=%d must stay below DefaultInlineThreshold=%d", DefaultTextExtractMaxBytes, DefaultInlineThreshold)
 	}
-	exact := make([]byte, textExtractMaxBytes)
+	exact := make([]byte, DefaultTextExtractMaxBytes)
 	for i := range exact {
 		exact[i] = 'a'
 	}
-	if got := extractText(exact, "application/json"); len(got) != textExtractMaxBytes {
-		t.Fatalf("exact limit extracted length=%d, want %d", len(got), textExtractMaxBytes)
+	if got := extractText(exact, "application/json", DefaultTextExtractMaxBytes); int64(len(got)) != DefaultTextExtractMaxBytes {
+		t.Fatalf("exact limit extracted length=%d, want %d", len(got), DefaultTextExtractMaxBytes)
 	}
 	oversized := append(exact, 'a')
-	if got := extractText(oversized, "application/json"); got != "" {
+	if got := extractText(oversized, "application/json", DefaultTextExtractMaxBytes); got != "" {
 		t.Fatalf("oversized text should not be extracted, got length %d", len(got))
 	}
-	if got := extractText([]byte("hello"), "text/plain"); got != "hello" {
+	if got := extractText([]byte("hello"), "text/plain", DefaultTextExtractMaxBytes); got != "hello" {
 		t.Fatalf("small text extracted as %q, want hello", got)
 	}
-	if got := extractText([]byte{0x66, 0x6f, 0x80}, "text/plain"); got != "" {
+	if got := extractText([]byte{0x66, 0x6f, 0x80}, "text/plain", DefaultTextExtractMaxBytes); got != "" {
 		t.Fatalf("invalid UTF-8 text should not be extracted, got %q", got)
 	}
+}
+
+func TestConfigurableInlineThreshold(t *testing.T) {
+	t.Run("defaults applied when options omit thresholds", func(t *testing.T) {
+		b := newTestBackend(t)
+		if got := b.InlineThreshold(); got != DefaultInlineThreshold {
+			t.Fatalf("InlineThreshold = %d, want %d", got, DefaultInlineThreshold)
+		}
+		if got := b.TextExtractMaxBytes(); got != DefaultTextExtractMaxBytes {
+			t.Fatalf("TextExtractMaxBytes = %d, want %d", got, DefaultTextExtractMaxBytes)
+		}
+		// shouldStoreInDB and IsLargeFile must agree on the default cutoff so
+		// a file at exactly the threshold flips storage class.
+		if !b.shouldStoreInDB(DefaultInlineThreshold - 1) {
+			t.Fatal("shouldStoreInDB should be true at threshold-1")
+		}
+		if b.shouldStoreInDB(DefaultInlineThreshold) {
+			t.Fatal("shouldStoreInDB should be false at threshold")
+		}
+		if b.IsLargeFile(DefaultInlineThreshold - 1) {
+			t.Fatal("IsLargeFile should be false at threshold-1")
+		}
+		if !b.IsLargeFile(DefaultInlineThreshold) {
+			t.Fatal("IsLargeFile should be true at threshold")
+		}
+	})
+
+	t.Run("custom inline threshold overrides default", func(t *testing.T) {
+		const custom = int64(256_000)
+		b := newTestBackendWithOptions(t, Options{InlineThreshold: custom})
+		if got := b.InlineThreshold(); got != custom {
+			t.Fatalf("InlineThreshold = %d, want %d", got, custom)
+		}
+		if !b.shouldStoreInDB(custom - 1) {
+			t.Fatal("file below custom threshold must store inline")
+		}
+		if b.shouldStoreInDB(custom) {
+			t.Fatal("file at custom threshold must spill to S3")
+		}
+		if b.IsLargeFile(custom - 1) {
+			t.Fatal("IsLargeFile must be false at custom-1")
+		}
+		if !b.IsLargeFile(custom) {
+			t.Fatal("IsLargeFile must be true at custom")
+		}
+	})
+
+	t.Run("custom text extract max overrides default", func(t *testing.T) {
+		const custom = int64(64_000)
+		b := newTestBackendWithOptions(t, Options{TextExtractMaxBytes: custom})
+		if got := b.TextExtractMaxBytes(); got != custom {
+			t.Fatalf("TextExtractMaxBytes = %d, want %d", got, custom)
+		}
+		// Right at the cap is still extractable.
+		atCap := make([]byte, custom)
+		for i := range atCap {
+			atCap[i] = 'a'
+		}
+		if got := extractText(atCap, "text/plain", b.TextExtractMaxBytes()); int64(len(got)) != custom {
+			t.Fatalf("extracted len = %d, want %d", len(got), custom)
+		}
+		// Just over the cap must drop the text entirely (not truncate).
+		over := append(atCap, 'a')
+		if got := extractText(over, "text/plain", b.TextExtractMaxBytes()); got != "" {
+			t.Fatalf("extracted len = %d, want 0 (dropped over cap)", len(got))
+		}
+	})
+
+	t.Run("zero or negative options fall back to defaults", func(t *testing.T) {
+		b := newTestBackendWithOptions(t, Options{InlineThreshold: 0, TextExtractMaxBytes: -1})
+		if got := b.InlineThreshold(); got != DefaultInlineThreshold {
+			t.Fatalf("zero InlineThreshold did not fall back: got %d", got)
+		}
+		if got := b.TextExtractMaxBytes(); got != DefaultTextExtractMaxBytes {
+			t.Fatalf("negative TextExtractMaxBytes did not fall back: got %d", got)
+		}
+	})
 }
 
 func TestDetectContentTypeRequiresValidUTF8ForText(t *testing.T) {

--- a/pkg/backend/file_gc_worker_test.go
+++ b/pkg/backend/file_gc_worker_test.go
@@ -132,7 +132,7 @@ func TestFileGCTaskReleasesCentralQuotaBeforeBlobRetry(t *testing.T) {
 	b.s3 = &failingDeleteS3Client{S3Client: b.s3, err: deleteErr}
 
 	ctx := context.Background()
-	payload := bytes.Repeat([]byte("x"), smallFileThreshold)
+	payload := bytes.Repeat([]byte("x"), int(DefaultInlineThreshold))
 	if _, err := b.Write("/img.png", payload, 0, filesystem.WriteFlagCreate); err != nil {
 		t.Fatalf("create image: %v", err)
 	}

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -86,6 +86,13 @@ type Options struct {
 	// S3EncryptionPolicy is the already-resolved policy for this backend.
 	// The zero value is normalized to the global default of explicit no encryption.
 	S3EncryptionPolicy meta.ResolvedS3EncryptionPolicy
+	// InlineThreshold overrides the DB-inline vs S3 storage cutoff. When 0,
+	// DefaultInlineThreshold is used. The same value is surfaced via
+	// /v1/status so clients can pick a matching upload strategy.
+	InlineThreshold int64
+	// TextExtractMaxBytes overrides the synchronous text extraction cap. When
+	// 0, DefaultTextExtractMaxBytes is used. Independent of InlineThreshold.
+	TextExtractMaxBytes int64
 }
 
 // LLMCostBudgetOptions configures the monthly LLM cost budget.
@@ -191,6 +198,16 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		b.maxTenantStorageBytes = opts.MaxTenantStorageBytes
 	} else {
 		b.maxTenantStorageBytes = defaultMaxTenantStorageBytes
+	}
+	if opts.InlineThreshold > 0 {
+		b.inlineThreshold = opts.InlineThreshold
+	} else {
+		b.inlineThreshold = DefaultInlineThreshold
+	}
+	if opts.TextExtractMaxBytes > 0 {
+		b.textExtractMaxBytes = opts.TextExtractMaxBytes
+	} else {
+		b.textExtractMaxBytes = DefaultTextExtractMaxBytes
 	}
 
 	cb := opts.LLMCostBudget

--- a/pkg/backend/s3_encryption_test.go
+++ b/pkg/backend/s3_encryption_test.go
@@ -402,7 +402,7 @@ func TestReadPlanDoesNotUseEncryptionHeaders(t *testing.T) {
 	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(
 		context.Background(),
 		"/read.bin",
-		bytes.Repeat([]byte("x"), smallFileThreshold),
+		bytes.Repeat([]byte("x"), int(DefaultInlineThreshold)),
 		0,
 		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate,
 		-1,

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -198,7 +198,7 @@ func (b *Dat9Backend) cleanupFailedFinalizeUpload(ctx context.Context, upload *d
 // IsLargeFile returns true if the given size exceeds the small file threshold
 // and S3 is configured.
 func (b *Dat9Backend) IsLargeFile(size int64) bool {
-	return b.s3 != nil && size >= smallFileThreshold
+	return b.s3 != nil && size >= b.inlineThreshold
 }
 
 // InitiateUpload creates a multipart upload for a large file.

--- a/pkg/client/append_test.go
+++ b/pkg/client/append_test.go
@@ -38,6 +38,7 @@ func TestAppendStreamCreatesMissingFile(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "")
+	c.smallFileThreshold = DefaultSmallFileThreshold
 	if err := c.AppendStream(context.Background(), "/new.txt", strings.NewReader("hello"), 5, nil); err != nil {
 		t.Fatalf("AppendStream: %v", err)
 	}
@@ -123,6 +124,7 @@ func TestAppendStreamFallsBackToRewriteForSmallExistingFile(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "")
+	c.smallFileThreshold = DefaultSmallFileThreshold
 	if err := c.AppendStream(context.Background(), "/small.txt", strings.NewReader(" world"), 6, nil); err != nil {
 		t.Fatalf("AppendStream: %v", err)
 	}
@@ -278,6 +280,7 @@ func TestAppendStreamFallsBackToRewriteWhenAppendActionUnsupported(t *testing.T)
 	defer srv.Close()
 
 	c := New(srv.URL, "")
+	c.smallFileThreshold = DefaultSmallFileThreshold
 	if err := c.AppendStream(context.Background(), "/legacy.txt", strings.NewReader(" world"), 6, nil); err != nil {
 		t.Fatalf("AppendStream: %v", err)
 	}
@@ -326,6 +329,7 @@ func TestAppendStreamFallsBackToRewriteWhenS3NotConfigured(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "")
+	c.smallFileThreshold = DefaultSmallFileThreshold
 	if err := c.AppendStream(context.Background(), "/db-only.txt", strings.NewReader(" world"), 6, nil); err != nil {
 		t.Fatalf("AppendStream: %v", err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/tagutil"
@@ -29,16 +30,27 @@ type Client struct {
 	httpClient         *http.Client
 	smallFileThreshold int64 // 0 means use DefaultSmallFileThreshold
 
-	statusOnce sync.Once
-	statusMax  int64 // tenant max_upload_bytes from /v1/status, 0 if unavailable
+	// statusFetchMu serializes /v1/status fetches across concurrent callers
+	// so a transient warm failure can be retried but two callers never
+	// double-fetch. Set statusFetched only on a successful HTTP 200, so a
+	// timeout/5xx during warm never permanently caches "unknown" — the
+	// next caller will retry.
+	statusFetchMu sync.Mutex
+	statusFetched atomic.Bool
+	// statusMax / statusInline are atomic so warmup goroutines and hot-path
+	// readers (commit queue, FUSE write decisions) coordinate without a
+	// mutex. Race detector previously caught this when FUSE's async warm
+	// raced with concurrent uploads.
+	statusMax    atomic.Int64 // tenant max_upload_bytes from /v1/status; 0 if unavailable
+	statusInline atomic.Int64 // server inline_threshold from /v1/status; 0 if unavailable
 }
 
 // tenantStatusResponse mirrors the server's TenantStatusResponse JSON shape.
-// We only consume max_upload_bytes today, but keep the full shape so the
-// decoder ignores forward-compatible additions cleanly.
+// Forward-compatible: unknown fields decode-and-ignore cleanly.
 type tenantStatusResponse struct {
-	Status         string `json:"status"`
-	MaxUploadBytes int64  `json:"max_upload_bytes"`
+	Status          string `json:"status"`
+	MaxUploadBytes  int64  `json:"max_upload_bytes"`
+	InlineThreshold int64  `json:"inline_threshold,omitempty"`
 }
 
 // ErrConflict reports an HTTP 409 write conflict from the server.
@@ -282,33 +294,112 @@ func (c *Client) APIKey() string {
 // not include the field, or if the lookup fails — callers should treat 0 as
 // "unknown" and fall back to a conservative local default.
 func (c *Client) MaxUploadBytes(ctx context.Context) int64 {
-	c.statusOnce.Do(func() {
-		c.statusMax = c.fetchTenantMaxUploadBytes(ctx)
-	})
-	return c.statusMax
+	c.ensureTenantStatus(ctx)
+	return c.statusMax.Load()
 }
 
-func (c *Client) fetchTenantMaxUploadBytes(ctx context.Context) int64 {
+// Warm proactively populates the /v1/status cache so subsequent hot-path
+// reads (CachedSmallFileThreshold, uploadThreshold) see the server-
+// advertised values instead of falling back to compiled-in defaults.
+// Failures are silent — the cache simply stays at zero and callers fall
+// back. Idempotent; safe to call once at CLI/FUSE startup.
+func (c *Client) Warm(ctx context.Context) {
+	c.ensureTenantStatus(ctx)
+}
+
+// SetSmallFileThresholdForTests pins the client's small-file cutoff
+// without consulting the server. Hot paths (uploadThreshold,
+// CachedSmallFileThreshold) treat this override as authoritative and
+// skip the network fetch entirely.
+//
+// Production code must NOT call this — the server is the threshold
+// authority and clients are supposed to negotiate via /v1/status. The
+// helper exists for unit tests that build fake HTTP servers without a
+// /v1/status route and would otherwise force every upload through V2
+// multipart (the safe-default when no server value is observable).
+func (c *Client) SetSmallFileThresholdForTests(threshold int64) {
+	c.smallFileThreshold = threshold
+}
+
+// SmallFileThreshold returns the server's DB-inline vs S3 storage cutoff as
+// reported by GET /v1/status. The result is cached for the lifetime of the
+// client. Returns 0 when the server omits the field (older builds) or when
+// the lookup fails; callers should fall back to DefaultSmallFileThreshold.
+//
+// An explicit per-Client override set via testing or configuration takes
+// precedence: when c.smallFileThreshold > 0 it short-circuits the network
+// fetch and is returned as-is. This keeps unit tests deterministic and lets
+// operators pin a threshold when needed.
+func (c *Client) SmallFileThreshold(ctx context.Context) int64 {
+	if c.smallFileThreshold > 0 {
+		return c.smallFileThreshold
+	}
+	c.ensureTenantStatus(ctx)
+	return c.statusInline.Load()
+}
+
+// CachedSmallFileThreshold returns the server-advertised threshold without
+// triggering a network fetch. Returns 0 when no value has been negotiated
+// yet. Use this on hot paths (commit queue, FUSE write decisions) to avoid
+// surprising side-effect requests; defer the initial fetch to a single
+// SmallFileThreshold call from a startup or warmup site.
+func (c *Client) CachedSmallFileThreshold() int64 {
+	if c.smallFileThreshold > 0 {
+		return c.smallFileThreshold
+	}
+	return c.statusInline.Load()
+}
+
+// ensureTenantStatus fetches and caches /v1/status fields once per Client.
+// Failures cache as zero so callers fall back to local defaults instead of
+// retrying every request.
+func (c *Client) ensureTenantStatus(ctx context.Context) {
+	if c.statusFetched.Load() {
+		return
+	}
+	c.statusFetchMu.Lock()
+	defer c.statusFetchMu.Unlock()
+	if c.statusFetched.Load() {
+		return
+	}
+	body, ok := c.fetchTenantStatus(ctx)
+	if !ok {
+		// Transient failure (timeout, 5xx, network). Don't mark fetched —
+		// a future Warm/MaxUploadBytes/SmallFileThreshold call will retry.
+		// Hot-path reads continue to fall back to compiled defaults until
+		// then.
+		return
+	}
+	if body.MaxUploadBytes > 0 {
+		c.statusMax.Store(body.MaxUploadBytes)
+	}
+	if body.InlineThreshold > 0 {
+		c.statusInline.Store(body.InlineThreshold)
+	}
+	// Mark fetched even when the server omits inline_threshold (older
+	// build): that's an authoritative "no value", retrying won't help and
+	// hot paths should stop attempting status fetches every call.
+	c.statusFetched.Store(true)
+}
+
+func (c *Client) fetchTenantStatus(ctx context.Context) (tenantStatusResponse, bool) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/status", nil)
 	if err != nil {
-		return 0
+		return tenantStatusResponse{}, false
 	}
 	resp, err := c.do(req)
 	if err != nil {
-		return 0
+		return tenantStatusResponse{}, false
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return 0
+		return tenantStatusResponse{}, false
 	}
 	var body tenantStatusResponse
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return 0
+		return tenantStatusResponse{}, false
 	}
-	if body.MaxUploadBytes < 0 {
-		return 0
-	}
-	return body.MaxUploadBytes
+	return body, true
 }
 
 func (c *Client) do(req *http.Request) (*http.Response, error) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -781,7 +782,10 @@ func TestSmallFileThresholdCachesFromServer(t *testing.T) {
 
 func TestSmallFileThresholdFallsBackWhenServerOmits(t *testing.T) {
 	// Older servers don't include inline_threshold. Client should leave
-	// statusInline = 0 and let callers fall back to DefaultSmallFileThreshold.
+	// statusInline = 0 so uploadThreshold returns 0 ("force multipart") —
+	// this is the safe choice when the operator may have configured the
+	// threshold below the historical 50KB. MaxUploadBytes still echoes
+	// the field that was present.
 	body := []byte(`{"status":"active","max_upload_bytes":1048576}`)
 	fake := newStatusFakeServer(t, body)
 	c := New(fake.srv.URL, "")
@@ -789,8 +793,8 @@ func TestSmallFileThresholdFallsBackWhenServerOmits(t *testing.T) {
 	if got := c.SmallFileThreshold(context.Background()); got != 0 {
 		t.Fatalf("SmallFileThreshold without server field = %d, want 0", got)
 	}
-	if got := c.uploadThreshold(context.Background()); got != DefaultSmallFileThreshold {
-		t.Fatalf("uploadThreshold fallback = %d, want %d", got, DefaultSmallFileThreshold)
+	if got := c.uploadThreshold(context.Background()); got != 0 {
+		t.Fatalf("uploadThreshold without server field = %d, want 0 (force multipart)", got)
 	}
 	if got := c.MaxUploadBytes(context.Background()); got != 1048576 {
 		t.Fatalf("MaxUploadBytes = %d", got)
@@ -822,8 +826,8 @@ func TestSmallFileThresholdLookupFailureCachesZero(t *testing.T) {
 	if got := c.SmallFileThreshold(context.Background()); got != 0 {
 		t.Fatalf("SmallFileThreshold on 500 = %d, want 0", got)
 	}
-	if got := c.uploadThreshold(context.Background()); got != DefaultSmallFileThreshold {
-		t.Fatalf("uploadThreshold during failure = %d, want %d", got, DefaultSmallFileThreshold)
+	if got := c.uploadThreshold(context.Background()); got != 0 {
+		t.Fatalf("uploadThreshold during failure = %d, want 0 (force multipart)", got)
 	}
 
 	// Server recovers; a subsequent call must retry, not stay cached at 0.
@@ -900,6 +904,110 @@ func TestSmallFileThresholdConcurrentReadersAreRaceFree(t *testing.T) {
 		_ = c.CachedSmallFileThreshold()
 	}
 	close(done)
+}
+
+func TestUploadThresholdReturnsZeroBeforeWarm(t *testing.T) {
+	// uploadThreshold must NOT fall back to DefaultSmallFileThreshold
+	// before /v1/status warmup. If the operator configured the server
+	// below 50KB, falling back to 50KB would direct-PUT files the server
+	// then rejects with `missing X-Dat9-Part-Checksums`. Returning 0 is
+	// the documented "force multipart" signal that callers honor.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"inline_threshold":30000}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := New(srv.URL, "")
+
+	if got := c.uploadThreshold(context.Background()); got != 0 {
+		t.Fatalf("pre-warm uploadThreshold = %d, want 0 (force multipart)", got)
+	}
+	// After warmup, returns the negotiated value.
+	c.Warm(context.Background())
+	if got := c.uploadThreshold(context.Background()); got != 30000 {
+		t.Fatalf("post-warm uploadThreshold = %d, want 30000", got)
+	}
+}
+
+func TestUploadThresholdHonoursLoweredServerThreshold(t *testing.T) {
+	// End-to-end: when the server is configured at 30KB and the client
+	// has warmed, a 40KB upload must NOT go direct PUT — the server's
+	// IsLargeFile gate would reject it. The fake server enforces this
+	// by failing any direct PUT that lands here.
+	const serverThreshold = int64(30000)
+	const fileSize = 40000
+	directPUTs := 0
+	multipartInits := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"inline_threshold":30000}`))
+	})
+	mux.HandleFunc("/v1/fs/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		// Server-side: any PUT >= threshold without X-Dat9-Part-Checksums
+		// is rejected. Mirrors the production gate at server.go:776.
+		cl := r.ContentLength
+		if cl >= serverThreshold && r.Header.Get("X-Dat9-Part-Checksums") == "" {
+			directPUTs++
+			http.Error(w, "missing X-Dat9-Part-Checksums header", http.StatusBadRequest)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"revision":1}`))
+	})
+	mux.HandleFunc("/v2/uploads/initiate", func(w http.ResponseWriter, r *http.Request) {
+		multipartInits++
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"upload_id":"u1","key":"k1","part_size":8388608,"total_parts":1}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	c.Warm(context.Background())
+
+	// Stream through writeStreamConditionalWithSummary; size > threshold
+	// must take the multipart path. We use the WriteStream entry point
+	// since direct PUT for small files is the path under test.
+	body := bytes.NewReader(make([]byte, fileSize))
+	_, err := c.writeStreamConditionalWithSummary(context.Background(), "/test.bin", body, fileSize, nil, -1, nil, "")
+	// Expected: initiate, then presign/parts/complete that aren't routed
+	// in this minimal fake — call returns error past initiate. We only
+	// assert routing went through initiate and not direct PUT.
+	if err == nil {
+		// fine — not all paths in the fake are wired, but we don't care
+	}
+	if directPUTs > 0 {
+		t.Fatalf("client issued %d direct PUTs for %dB above %dB threshold; multipart was required", directPUTs, fileSize, serverThreshold)
+	}
+	if multipartInits == 0 {
+		t.Fatalf("client never issued multipart initiate; routing missed the lowered threshold")
+	}
+}
+
+func TestUploadThresholdWarmFailureForcesMultipart(t *testing.T) {
+	// /v1/status fails (5xx); the client must fall back to "force
+	// multipart" rather than the historical 50KB. Otherwise an operator
+	// who lowered the server threshold below 50KB would see direct PUTs
+	// rejected after every transient warm failure.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := New(srv.URL, "")
+	c.Warm(context.Background())
+
+	if got := c.uploadThreshold(context.Background()); got != 0 {
+		t.Fatalf("uploadThreshold after warm failure = %d, want 0 (force multipart)", got)
+	}
 }
 
 func TestSmallFileThresholdOverrideShortCircuits(t *testing.T) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -976,13 +976,12 @@ func TestUploadThresholdHonoursLoweredServerThreshold(t *testing.T) {
 	// must take the multipart path. We use the WriteStream entry point
 	// since direct PUT for small files is the path under test.
 	body := bytes.NewReader(make([]byte, fileSize))
-	_, err := c.writeStreamConditionalWithSummary(context.Background(), "/test.bin", body, fileSize, nil, -1, nil, "")
-	// Expected: initiate, then presign/parts/complete that aren't routed
-	// in this minimal fake — call returns error past initiate. We only
-	// assert routing went through initiate and not direct PUT.
-	if err == nil {
-		// fine — not all paths in the fake are wired, but we don't care
-	}
+	// The fake server only wires initiate and direct PUT — presign /
+	// parts / complete intentionally aren't implemented because we only
+	// need to observe routing. The call is therefore expected to fail
+	// past initiate; what matters is which endpoint the client hit
+	// before failing. The unused-error discard is deliberate.
+	_, _ = c.writeStreamConditionalWithSummary(context.Background(), "/test.bin", body, fileSize, nil, -1, nil, "")
 	if directPUTs > 0 {
 		t.Fatalf("client issued %d direct PUTs for %dB above %dB threshold; multipart was required", directPUTs, fileSize, serverThreshold)
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -813,7 +813,7 @@ func TestSmallFileThresholdLookupFailureCachesZero(t *testing.T) {
 			http.Error(w, "boom", http.StatusInternalServerError)
 			return
 		}
-		w.Write([]byte(`{"inline_threshold":262144}`))
+		_, _ = w.Write([]byte(`{"inline_threshold":262144}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -849,7 +849,7 @@ func TestCachedSmallFileThresholdDoesNotFetch(t *testing.T) {
 	hits := 0
 	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
 		hits++
-		w.Write([]byte(`{"inline_threshold":131072}`))
+		_, _ = w.Write([]byte(`{"inline_threshold":131072}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -907,7 +907,7 @@ func TestSmallFileThresholdOverrideShortCircuits(t *testing.T) {
 	hits := 0
 	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
 		hits++
-		w.Write([]byte(`{"inline_threshold":999999}`))
+		_, _ = w.Write([]byte(`{"inline_threshold":999999}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/mem9-ai/dat9/internal/testmysql"
@@ -734,5 +735,192 @@ func TestMkdir(t *testing.T) {
 	}
 	if !info.IsDir {
 		t.Error("expected directory")
+	}
+}
+
+// statusFakeServer returns an httptest server that responds to GET /v1/status
+// with the given JSON body and counts the number of times it was called.
+type statusFakeServer struct {
+	srv  *httptest.Server
+	hits *int
+}
+
+func newStatusFakeServer(t *testing.T, body []byte) *statusFakeServer {
+	t.Helper()
+	hits := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return &statusFakeServer{srv: srv, hits: &hits}
+}
+
+func TestSmallFileThresholdCachesFromServer(t *testing.T) {
+	body := []byte(`{"status":"active","max_upload_bytes":1048576,"inline_threshold":262144}`)
+	fake := newStatusFakeServer(t, body)
+	c := New(fake.srv.URL, "")
+
+	if got := c.SmallFileThreshold(context.Background()); got != 262144 {
+		t.Fatalf("SmallFileThreshold = %d, want 262144", got)
+	}
+	if got := c.MaxUploadBytes(context.Background()); got != 1048576 {
+		t.Fatalf("MaxUploadBytes = %d, want 1048576", got)
+	}
+	// Subsequent calls must hit the in-memory cache, not the server.
+	if got := c.SmallFileThreshold(context.Background()); got != 262144 {
+		t.Fatalf("second SmallFileThreshold = %d", got)
+	}
+	if *fake.hits != 1 {
+		t.Fatalf("expected 1 status fetch, got %d", *fake.hits)
+	}
+}
+
+func TestSmallFileThresholdFallsBackWhenServerOmits(t *testing.T) {
+	// Older servers don't include inline_threshold. Client should leave
+	// statusInline = 0 and let callers fall back to DefaultSmallFileThreshold.
+	body := []byte(`{"status":"active","max_upload_bytes":1048576}`)
+	fake := newStatusFakeServer(t, body)
+	c := New(fake.srv.URL, "")
+
+	if got := c.SmallFileThreshold(context.Background()); got != 0 {
+		t.Fatalf("SmallFileThreshold without server field = %d, want 0", got)
+	}
+	if got := c.uploadThreshold(context.Background()); got != DefaultSmallFileThreshold {
+		t.Fatalf("uploadThreshold fallback = %d, want %d", got, DefaultSmallFileThreshold)
+	}
+	if got := c.MaxUploadBytes(context.Background()); got != 1048576 {
+		t.Fatalf("MaxUploadBytes = %d", got)
+	}
+}
+
+func TestSmallFileThresholdLookupFailureCachesZero(t *testing.T) {
+	// Transient warm failure must NOT consume the once-style guard: a later
+	// successful Warm/SmallFileThreshold call should refetch and pick up
+	// the server-advertised value. This guards against the failure mode
+	// where FUSE Init's bounded warm misses (5s timeout, 5xx, network)
+	// and the client is then permanently stuck on the local fallback.
+	var failing atomic.Bool
+	failing.Store(true)
+	hits := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if failing.Load() {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(`{"inline_threshold":262144}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := New(srv.URL, "")
+
+	if got := c.SmallFileThreshold(context.Background()); got != 0 {
+		t.Fatalf("SmallFileThreshold on 500 = %d, want 0", got)
+	}
+	if got := c.uploadThreshold(context.Background()); got != DefaultSmallFileThreshold {
+		t.Fatalf("uploadThreshold during failure = %d, want %d", got, DefaultSmallFileThreshold)
+	}
+
+	// Server recovers; a subsequent call must retry, not stay cached at 0.
+	failing.Store(false)
+	if got := c.SmallFileThreshold(context.Background()); got != 262144 {
+		t.Fatalf("SmallFileThreshold after recovery = %d, want 262144 (failures must not consume the once-guard)", got)
+	}
+	if hits < 2 {
+		t.Fatalf("expected refetch after transient failure; total hits=%d", hits)
+	}
+
+	// Once we have a successful response, we must not fetch again.
+	prev := hits
+	_ = c.SmallFileThreshold(context.Background())
+	_ = c.SmallFileThreshold(context.Background())
+	if hits != prev {
+		t.Fatalf("post-success calls fetched again: hits %d -> %d", prev, hits)
+	}
+}
+
+func TestCachedSmallFileThresholdDoesNotFetch(t *testing.T) {
+	mux := http.NewServeMux()
+	hits := 0
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Write([]byte(`{"inline_threshold":131072}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := New(srv.URL, "")
+
+	// CachedSmallFileThreshold must never trigger /v1/status.
+	if got := c.CachedSmallFileThreshold(); got != 0 {
+		t.Fatalf("cached pre-warm = %d, want 0", got)
+	}
+	if hits != 0 {
+		t.Fatalf("CachedSmallFileThreshold triggered %d fetches; must be 0", hits)
+	}
+	// After warm-up via SmallFileThreshold, cache returns server value.
+	_ = c.SmallFileThreshold(context.Background())
+	if got := c.CachedSmallFileThreshold(); got != 131072 {
+		t.Fatalf("cached post-warm = %d, want 131072", got)
+	}
+}
+
+func TestSmallFileThresholdConcurrentReadersAreRaceFree(t *testing.T) {
+	body := []byte(`{"status":"active","max_upload_bytes":1048576,"inline_threshold":262144}`)
+	fake := newStatusFakeServer(t, body)
+	c := New(fake.srv.URL, "")
+
+	// Mix one warmup goroutine (calls SmallFileThreshold which writes the
+	// atomic) with many CachedSmallFileThreshold readers. Run with -race;
+	// pre-fix this race tripped the detector.
+	const readers = 32
+	done := make(chan struct{})
+	for i := 0; i < readers; i++ {
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = c.CachedSmallFileThreshold()
+					_ = c.statusInline.Load()
+				}
+			}
+		}()
+	}
+	// Warmup goroutine.
+	go c.SmallFileThreshold(context.Background())
+
+	// Run for a brief period and stop.
+	for i := 0; i < 10000; i++ {
+		_ = c.CachedSmallFileThreshold()
+	}
+	close(done)
+}
+
+func TestSmallFileThresholdOverrideShortCircuits(t *testing.T) {
+	mux := http.NewServeMux()
+	hits := 0
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Write([]byte(`{"inline_threshold":999999}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := New(srv.URL, "")
+	c.smallFileThreshold = 7 // explicit per-Client override
+
+	if got := c.SmallFileThreshold(context.Background()); got != 7 {
+		t.Fatalf("override = %d, want 7", got)
+	}
+	if got := c.CachedSmallFileThreshold(); got != 7 {
+		t.Fatalf("override cached = %d, want 7", got)
+	}
+	if hits != 0 {
+		t.Fatalf("override should short-circuit network; saw %d hits", hits)
 	}
 }

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -77,8 +77,35 @@ type completePart struct {
 // partNumber is 1-based, totalParts is the total count.
 type ProgressFunc func(partNumber, totalParts int, bytesUploaded int64)
 
-// DefaultSmallFileThreshold matches the server's threshold for direct PUT vs multipart.
-const DefaultSmallFileThreshold = 50_000 // 50,000 bytes — matches embedding model max input characters
+// DefaultSmallFileThreshold is the conservative fallback used when the server
+// does not advertise an inline_threshold via /v1/status (e.g. older builds) or
+// the lookup fails. New code should consume the value via Client.uploadThreshold
+// so server-side overrides propagate without client redeploys.
+const DefaultSmallFileThreshold = 50_000
+
+// uploadThreshold returns the cutoff between direct PUT and V2 multipart
+// upload. Resolution order:
+//  1. Per-Client override (c.smallFileThreshold > 0): used as-is. Tests pin
+//     this; operators can also force a value when the server cannot be
+//     reached at construction.
+//  2. Server-advertised inline_threshold cached from a prior /v1/status
+//     fetch. Treated as the source of truth in production.
+//  3. DefaultSmallFileThreshold fallback: when neither override nor cached
+//     server value is available.
+//
+// This deliberately reads only the cached value rather than triggering a
+// fresh /v1/status fetch on the upload hot path: callers wanting the
+// server-advertised threshold should warm the cache once at startup via
+// SmallFileThreshold or MaxUploadBytes. Hot-path fetches caused unrelated
+// test fakes to flag GET /v1/status as an unexpected request and added a
+// blocking RTT to every first upload before warmup.
+func (c *Client) uploadThreshold(ctx context.Context) int64 {
+	_ = ctx
+	if t := c.CachedSmallFileThreshold(); t > 0 {
+		return t
+	}
+	return DefaultSmallFileThreshold
+}
 
 // Upload concurrency limits, modeled after db9's memory-bounded approach:
 //
@@ -307,10 +334,7 @@ func (c *Client) writeStreamConditionalWithSummary(ctx context.Context, path str
 	if err := validateTags(tags); err != nil {
 		return nil, err
 	}
-	threshold := int64(DefaultSmallFileThreshold)
-	if c.smallFileThreshold > 0 {
-		threshold = c.smallFileThreshold
-	}
+	threshold := c.uploadThreshold(ctx)
 	summary := &UploadSummary{
 		Type:       "upload_summary",
 		StartedAt:  time.Now(),

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -77,10 +77,14 @@ type completePart struct {
 // partNumber is 1-based, totalParts is the total count.
 type ProgressFunc func(partNumber, totalParts int, bytesUploaded int64)
 
-// DefaultSmallFileThreshold is the conservative fallback used when the server
-// does not advertise an inline_threshold via /v1/status (e.g. older builds) or
-// the lookup fails. New code should consume the value via Client.uploadThreshold
-// so server-side overrides propagate without client redeploys.
+// DefaultSmallFileThreshold names the historical 50KB cutoff. It is kept
+// for tests and for callers that want to size buffers around the typical
+// small-file boundary. Do NOT use it as a fallback for the simple-PUT vs
+// V2-multipart upload decision: when the server is configured below 50KB
+// (DRIVE9_INLINE_THRESHOLD < 50000), a 50KB fallback would direct-PUT
+// files the server then rejects with `missing X-Dat9-Part-Checksums`.
+// Use Client.uploadThreshold which fails safe by forcing multipart when
+// no server value has been negotiated.
 const DefaultSmallFileThreshold = 50_000
 
 // uploadThreshold returns the cutoff between direct PUT and V2 multipart
@@ -90,8 +94,17 @@ const DefaultSmallFileThreshold = 50_000
 //     reached at construction.
 //  2. Server-advertised inline_threshold cached from a prior /v1/status
 //     fetch. Treated as the source of truth in production.
-//  3. DefaultSmallFileThreshold fallback: when neither override nor cached
-//     server value is available.
+//  3. Otherwise return 0, which forces every upload through V2 multipart.
+//
+// Returning 0 (rather than the historical 50KB fallback) is intentional:
+// multipart is always accepted by the server regardless of its configured
+// inline_threshold, while a fixed 50KB fallback breaks correctness when
+// operators lower the server threshold below 50KB (the server then rejects
+// the simple PUT with `missing X-Dat9-Part-Checksums`). The cost is that
+// uploads issued before /v1/status warmup is observable spend extra RTTs
+// going through initiate/presign/complete; once Warm or
+// SmallFileThreshold has populated the cache, hot paths return the
+// negotiated value and the optimization kicks in.
 //
 // This deliberately reads only the cached value rather than triggering a
 // fresh /v1/status fetch on the upload hot path: callers wanting the
@@ -101,10 +114,7 @@ const DefaultSmallFileThreshold = 50_000
 // blocking RTT to every first upload before warmup.
 func (c *Client) uploadThreshold(ctx context.Context) int64 {
 	_ = ctx
-	if t := c.CachedSmallFileThreshold(); t > 0 {
-		return t
-	}
-	return DefaultSmallFileThreshold
+	return c.CachedSmallFileThreshold()
 }
 
 // Upload concurrency limits, modeled after db9's memory-bounded approach:
@@ -341,7 +351,15 @@ func (c *Client) writeStreamConditionalWithSummary(ctx context.Context, path str
 		RemotePath: path,
 		TotalBytes: size,
 	}
-	if size < threshold {
+	// useDirectPUT picks the simple-PUT path. When threshold == 0 (no server
+	// value negotiated yet) we must NOT direct-PUT non-empty files, since
+	// the server may be configured below the historical 50KB default and
+	// would reject the simple PUT with `missing X-Dat9-Part-Checksums`.
+	// Multipart is always accepted, so we route any non-zero-size upload
+	// through it until /v1/status warmup populates the cache. Zero-byte
+	// files keep using simple PUT because V2 initiate rejects total_size=0.
+	useDirectPUT := size == 0 || (threshold > 0 && size < threshold)
+	if useDirectPUT {
 		summary.Mode = "direct_put"
 		summary.PartSizeBytes = size
 		summary.TotalParts = 1

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -147,6 +147,7 @@ func TestWriteStreamSmallFile(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "")
+	c.smallFileThreshold = DefaultSmallFileThreshold
 	data := []byte("hello small")
 	err := c.WriteStream(context.Background(), "/small.txt", bytes.NewReader(data), int64(len(data)), nil)
 	if err != nil {
@@ -171,6 +172,7 @@ func TestWriteStreamWithSummarySmallFile(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "")
+	c.smallFileThreshold = DefaultSmallFileThreshold
 	data := []byte("summary me")
 	summary, err := c.WriteStreamWithSummary(context.Background(), "/small-summary.txt", bytes.NewReader(data), int64(len(data)), nil)
 	if err != nil {
@@ -218,6 +220,7 @@ func TestWriteStreamWithSummaryAndTagsSmallFileSetsTagHeaders(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "")
+	c.smallFileThreshold = DefaultSmallFileThreshold
 	data := []byte("hello")
 	_, err := c.WriteStreamWithSummaryAndTags(context.Background(), "/tagged-small.txt", bytes.NewReader(data), int64(len(data)), nil, map[string]string{
 		"topic": "cat",

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -15,12 +15,23 @@ import (
 	"github.com/mem9-ai/dat9/pkg/mountpath"
 )
 
-// commitQueueDirectPutThreshold is the size limit below which commit queue
-// workers use direct PUT (WriteCtxConditionalWithRevision) instead of
-// multipart upload. Must match the server's smallFileThreshold — the server
-// rejects simple PUTs for files >= 50KB on S3-configured backends by requiring
-// X-Dat9-Part-Checksums (multipart protocol).
-const commitQueueDirectPutThreshold = client.DefaultSmallFileThreshold
+// directPutThreshold returns the size limit below which commit queue workers
+// use direct PUT (WriteCtxConditionalWithRevision) instead of multipart
+// upload. Must match the server's inline_threshold — the server rejects
+// simple PUTs for files at or above the threshold on S3-configured backends
+// by requiring X-Dat9-Part-Checksums (multipart protocol). Read from the
+// client's cached value to avoid surprise GET /v1/status calls in the hot
+// commit path; the FS layer is expected to have warmed the cache via the
+// startup inlineThreshold() call. Falls back to DefaultSmallFileThreshold
+// when no value has been negotiated.
+func (cq *CommitQueue) directPutThreshold() int64 {
+	if cq.client != nil {
+		if t := cq.client.CachedSmallFileThreshold(); t > 0 {
+			return t
+		}
+	}
+	return client.DefaultSmallFileThreshold
+}
 
 // CommitEntry represents a pending remote commit.
 type CommitEntry struct {
@@ -605,9 +616,9 @@ func (cq *CommitQueue) uploadEntry(ctx context.Context, entry *CommitEntry) (int
 	}
 
 	// Route based on entry.Size (metadata at enqueue time), NOT len(data).
-	// Files under commitQueueDirectPutThreshold use direct PUT to skip the
-	// multipart initiate/presign/complete/finalize overhead (~440ms).
-	if entry.Size < commitQueueDirectPutThreshold {
+	// Files under directPutThreshold() use direct PUT to skip the multipart
+	// initiate/presign/complete/finalize overhead (~440ms).
+	if entry.Size < cq.directPutThreshold() {
 		start := time.Now()
 		committedRev, err := cq.client.WriteCtxConditionalWithRevision(ctx, apiPath, data, expectedRevision)
 		if cq.perf != nil {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -22,15 +22,18 @@ import (
 // by requiring X-Dat9-Part-Checksums (multipart protocol). Read from the
 // client's cached value to avoid surprise GET /v1/status calls in the hot
 // commit path; the FS layer is expected to have warmed the cache via the
-// startup inlineThreshold() call. Falls back to DefaultSmallFileThreshold
-// when no value has been negotiated.
+// startup inlineThreshold() call.
+//
+// Returns 0 when no server value has been negotiated yet. Callers that
+// route on the result must treat 0 as "force multipart": the server may
+// be configured below the historical 50KB default, and a fixed fallback
+// would direct-PUT files the server then rejects. Multipart is always
+// accepted.
 func (cq *CommitQueue) directPutThreshold() int64 {
 	if cq.client != nil {
-		if t := cq.client.CachedSmallFileThreshold(); t > 0 {
-			return t
-		}
+		return cq.client.CachedSmallFileThreshold()
 	}
-	return client.DefaultSmallFileThreshold
+	return 0
 }
 
 // CommitEntry represents a pending remote commit.
@@ -617,8 +620,14 @@ func (cq *CommitQueue) uploadEntry(ctx context.Context, entry *CommitEntry) (int
 
 	// Route based on entry.Size (metadata at enqueue time), NOT len(data).
 	// Files under directPutThreshold() use direct PUT to skip the multipart
-	// initiate/presign/complete/finalize overhead (~440ms).
-	if entry.Size < cq.directPutThreshold() {
+	// initiate/presign/complete/finalize overhead (~440ms). When threshold
+	// is 0 (no server value cached) we deliberately do not direct-PUT
+	// non-empty files: the server may be configured below 50KB and would
+	// reject the simple PUT. Zero-byte files keep direct PUT because V2
+	// initiate rejects total_size=0.
+	threshold := cq.directPutThreshold()
+	useDirectPUT := entry.Size == 0 || (threshold > 0 && entry.Size < threshold)
+	if useDirectPUT {
 		start := time.Now()
 		committedRev, err := cq.client.WriteCtxConditionalWithRevision(ctx, apiPath, data, expectedRevision)
 		if cq.perf != nil {

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/mem9-ai/dat9/pkg/client"
 )
 
 func TestCommitQueueConditionalCommitSuccess(t *testing.T) {
@@ -42,7 +40,7 @@ func TestCommitQueueConditionalCommitSuccess(t *testing.T) {
 	var successPath string
 	var successRev int64
 
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	cq.OnSuccess = func(entry *CommitEntry, committedRev int64) {
 		successPath = entry.Path
 		successRev = committedRev
@@ -99,7 +97,7 @@ func TestCommitQueueConflictKeepsPendingState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	if err := cq.Enqueue(&CommitEntry{
 		Path:    "/conflict.txt",
 		BaseRev: 3,
@@ -167,7 +165,7 @@ func TestCommitQueueCancelPathDoesNotPoisonFutureSamePath(t *testing.T) {
 
 	oldEntry := &CommitEntry{Path: path, Size: 3, Kind: PendingNew}
 	cq := &CommitQueue{
-		client:     client.New(ts.URL, ""),
+		client:     newTestClient(ts.URL),
 		shadows:    shadow,
 		index:      pending,
 		inFlight:   make(map[string]*CommitEntry),
@@ -248,7 +246,7 @@ func TestCommitQueueCancelPathCancelsRetryBackoff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	defer cq.DrainAll()
 	if err := cq.Enqueue(&CommitEntry{Path: path, Size: 4, Kind: PendingNew}); err != nil {
 		t.Fatal(err)
@@ -319,7 +317,7 @@ func TestCommitQueueDirectPutRouting(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+		cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 		if err := cq.Enqueue(&CommitEntry{
 			Path:    "/small.bin",
 			BaseRev: 5,
@@ -393,7 +391,7 @@ func TestCommitQueueAutoResolveLWW(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	if err := cq.Enqueue(&CommitEntry{
 		Path:    "/lww.txt",
 		BaseRev: 5,
@@ -460,7 +458,7 @@ func TestCommitQueueAutoResolveIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	if err := cq.Enqueue(&CommitEntry{
 		Path:    "/idem.txt",
 		BaseRev: 5,
@@ -520,7 +518,7 @@ func TestCommitQueueAutoResolveLWWSecond409Fallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	if err := cq.Enqueue(&CommitEntry{
 		Path:    "/double409.txt",
 		BaseRev: 5,
@@ -570,7 +568,7 @@ func TestCommitQueueNonConflictErrorUnchanged(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	if err := cq.Enqueue(&CommitEntry{
 		Path:    "/500.txt",
 		BaseRev: 5,
@@ -620,7 +618,7 @@ func TestCommitQueueRecoverPendingSkipsLegacyOverwriteWithoutBaseRev(t *testing.
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	cq.RecoverPending()
 	cq.DrainAll()
 
@@ -670,7 +668,7 @@ func TestCommitQueueShadowSpillUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	if err := cq.Enqueue(&CommitEntry{
 		Path:        "/big.bin",
 		BaseRev:     12,
@@ -723,7 +721,7 @@ func TestCommitQueueShadowSpillConflictTerminal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	if err := cq.Enqueue(&CommitEntry{
 		Path:        "/big-conflict.bin",
 		BaseRev:     5,
@@ -813,7 +811,7 @@ func TestCommitQueueRecoverPendingShadowSpill(t *testing.T) {
 
 	// RecoverPending should reconstruct CommitEntry with ShadowSpill=true,
 	// causing uploadEntry to use streaming (uploadFromShadow) not ReadAll.
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow2, pending2, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow2, pending2, nil, 1, 8)
 	cq.RecoverPending()
 	cq.DrainAll()
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -106,13 +106,34 @@ func (fs *Dat9FS) newWriteBuffer(path string, maxSize, partSize int64) *WriteBuf
 	return wb
 }
 
-// inlineThreshold returns the cutoff between simple PUT and V2 multipart
-// upload, mirroring the server-side IsLargeFile gate. It is read from the
-// FS's cached server-advertised value populated by warmInlineThreshold;
-// callers on hot paths (Read, Write, Flush, commit queue) must NOT trigger
-// network fetches here. Falls back to defaultSmallFileThreshold when no
-// value has been negotiated (e.g. unit tests that don't run Init).
+// inlineThreshold returns a small-file cutoff suitable for performance
+// heuristics (read-cache prefetch sizing, debounce flush timing, write-
+// buffer fast-path bounds). It mirrors the server's inline_threshold once
+// /v1/status is observed, and falls back to defaultSmallFileThreshold so
+// the heuristics still work in unit tests and pre-warm.
+//
+// Do NOT use this for the simple-PUT vs V2-multipart upload decision —
+// callers there must use negotiatedInlineThreshold() so a missing server
+// value forces multipart instead of guessing 50KB (which would break when
+// the server is configured below 50KB).
 func (fs *Dat9FS) inlineThreshold() int64 {
+	if v := fs.negotiatedInlineThreshold(); v > 0 {
+		return v
+	}
+	return defaultSmallFileThreshold
+}
+
+// negotiatedInlineThreshold returns the server-advertised inline_threshold
+// or 0 when no value has been observed yet. Hot-path readers must not
+// trigger network I/O; warmInlineThreshold is responsible for populating
+// the cache before first use.
+//
+// Returns 0 means "unknown — caller must fall back to a multipart-safe
+// behavior". The historical 50KB fallback is unsafe here: when the server
+// is configured with DRIVE9_INLINE_THRESHOLD < 50000, files in
+// [server_threshold, 50000) would be direct-PUT and rejected at the
+// server's IsLargeFile gate with `missing X-Dat9-Part-Checksums`.
+func (fs *Dat9FS) negotiatedInlineThreshold() int64 {
 	if v := fs.smallFileMax.Load(); v > 0 {
 		return v
 	}
@@ -122,7 +143,7 @@ func (fs *Dat9FS) inlineThreshold() int64 {
 			return t
 		}
 	}
-	return defaultSmallFileThreshold
+	return 0
 }
 
 // warmInlineThreshold triggers a one-shot /v1/status fetch via the client
@@ -4135,8 +4156,16 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	expectedRevision := expectedRevisionForHandle(fh)
 	var committedRev int64
 
-	threshold := fs.inlineThreshold()
-	if size < threshold {
+	// Use the negotiated server threshold (not the heuristic-only inline
+	// fallback): when /v1/status hasn't been observed we must force
+	// multipart for non-empty writes. The server's IsLargeFile gate would
+	// otherwise reject a direct PUT with `missing X-Dat9-Part-Checksums`
+	// whenever the server is configured below the historical 50KB
+	// default. Zero-byte files keep direct PUT because V2 initiate
+	// rejects total_size=0.
+	threshold := fs.negotiatedInlineThreshold()
+	useDirectPUT := size == 0 || (threshold > 0 && size < threshold)
+	if useDirectPUT {
 		// Small file: direct PUT with revision return for freshness seeding.
 		phase = "small-write"
 		writeStart := time.Now()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -91,6 +91,51 @@ type Dat9FS struct {
 
 	// perf contains optional mount-level counters. Nil when disabled.
 	perf *fusePerfCounters
+
+	// smallFileMax mirrors the server's inline_threshold (fetched lazily via
+	// the dat9 client). When 0, defaultSmallFileThreshold is used. Use the
+	// inlineThreshold() accessor; do not read directly.
+	smallFileMax atomic.Int64
+}
+
+// newWriteBuffer constructs a WriteBuffer with the small-file fast-path
+// cutoff aligned to the negotiated server inline_threshold.
+func (fs *Dat9FS) newWriteBuffer(path string, maxSize, partSize int64) *WriteBuffer {
+	wb := NewWriteBuffer(path, maxSize, partSize)
+	wb.SetSmallFileMax(fs.inlineThreshold())
+	return wb
+}
+
+// inlineThreshold returns the cutoff between simple PUT and V2 multipart
+// upload, mirroring the server-side IsLargeFile gate. It is read from the
+// FS's cached server-advertised value populated by warmInlineThreshold;
+// callers on hot paths (Read, Write, Flush, commit queue) must NOT trigger
+// network fetches here. Falls back to defaultSmallFileThreshold when no
+// value has been negotiated (e.g. unit tests that don't run Init).
+func (fs *Dat9FS) inlineThreshold() int64 {
+	if v := fs.smallFileMax.Load(); v > 0 {
+		return v
+	}
+	if fs.client != nil {
+		if t := fs.client.CachedSmallFileThreshold(); t > 0 {
+			fs.smallFileMax.Store(t)
+			return t
+		}
+	}
+	return defaultSmallFileThreshold
+}
+
+// warmInlineThreshold triggers a one-shot /v1/status fetch via the client
+// to populate the cached server inline_threshold. Idempotent and safe to
+// call from FUSE startup; failures (e.g. older server) cache as zero so
+// subsequent reads fall back to defaultSmallFileThreshold without retrying.
+func (fs *Dat9FS) warmInlineThreshold(ctx context.Context) {
+	if fs.client == nil {
+		return
+	}
+	if t := fs.client.SmallFileThreshold(ctx); t > 0 {
+		fs.smallFileMax.Store(t)
+	}
 }
 
 type dirtyInodeState struct {
@@ -410,7 +455,7 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 	if bufMax < maxPreloadSize {
 		bufMax = maxPreloadSize
 	}
-	fh.Dirty = NewWriteBuffer(fh.Path, bufMax, partSize)
+	fh.Dirty = fs.newWriteBuffer(fh.Path, bufMax, partSize)
 
 	// Lazy preload for all sizes — only Stat() now, load parts on demand.
 	// Set totalSize so the buffer knows the file extent, but don't load data.
@@ -467,7 +512,7 @@ func (fs *Dat9FS) preloadWritableHandleFromReadCacheLocked(fh *FileHandle) bool 
 	if fs.readCache == nil || fh == nil || fh.Dirty == nil {
 		return false
 	}
-	if fh.OrigSize <= 0 || fh.OrigSize > smallFileThreshold || fh.BaseRev <= 0 {
+	if fh.OrigSize <= 0 || fh.OrigSize > defaultSmallFileThreshold || fh.BaseRev <= 0 {
 		return false
 	}
 
@@ -610,7 +655,7 @@ func (fs *Dat9FS) loadWritableHandleFromShadowLocked(fh *FileHandle, meta *Write
 		return err
 	}
 
-	wb := NewWriteBuffer(fh.Path, maxPreloadSize, 0)
+	wb := fs.newWriteBuffer(fh.Path, maxPreloadSize, 0)
 	if len(data) > 0 {
 		if _, err := wb.Write(0, data); err != nil {
 			return err
@@ -1384,7 +1429,21 @@ func (fs *Dat9FS) lookupFromDirCache(parentPath, childP, name string, out *gofus
 
 func (fs *Dat9FS) Init(server *gofuse.Server) {
 	fs.server = server
+	// Synchronously warm the server-advertised inline_threshold so the very
+	// first Create/Write/Flush/commit-queue decision after mount sees the
+	// negotiated value. Bound by a short timeout so an unreachable server
+	// can't stall mount; on timeout/failure we fall back to
+	// defaultSmallFileThreshold (50KB), matching old-server behavior.
+	ctx, cancel := context.WithTimeout(context.Background(), inlineThresholdWarmTimeout)
+	defer cancel()
+	fs.warmInlineThreshold(ctx)
 }
+
+// inlineThresholdWarmTimeout caps the synchronous status fetch on Init.
+// 5s leaves margin for cold TLS handshake + cross-region RTT while staying
+// under typical mount-readiness expectations. Declared as a var so tests
+// can shrink it; production callers must not mutate.
+var inlineThresholdWarmTimeout = 5 * time.Second
 
 // notifyEntry tells the kernel to invalidate a directory entry cache.
 // Safe to call even if the server is not yet initialized (e.g., during tests).
@@ -2577,7 +2636,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		return gofuse.EIO
 	}
 
-	wb := NewWriteBuffer(childP, streamingWriteMaxSize, 0)
+	wb := fs.newWriteBuffer(childP, streamingWriteMaxSize, 0)
 	wb.touched = true
 	wb.sequential = true
 	wb.uploadedParts = make(map[int]bool)
@@ -2662,7 +2721,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			return gofuse.EROFS
 		}
 
-		fh.Dirty = NewWriteBuffer(p, maxPreloadSize, 0)
+		fh.Dirty = fs.newWriteBuffer(p, maxPreloadSize, 0)
 
 		// Preload existing content for non-truncating opens so that
 		// random writes don't discard the original file data.
@@ -2750,7 +2809,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 	// Set up read prefetcher for read-only opens on large files.
 	if fh.Dirty == nil {
 		entry, _ := fs.inodes.GetEntry(input.NodeId)
-		if entry != nil && entry.Size > smallFileThreshold {
+		if entry != nil && entry.Size > fs.inlineThreshold() {
 			fh.Prefetch = NewPrefetcher(fs.client, fs.remotePath(p), entry.Size, fs.debugEnabled())
 			fh.Prefetch.SetPerfCounters(fs.perf)
 		}
@@ -3087,7 +3146,7 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 	// InodeEntry has a stored revision from the last Lookup/GetAttr, pass
 	// it to the cache for validation. Cache hit only if revision matches.
 	entry, _ := fs.inodes.GetEntry(fh.Ino)
-	if entry != nil && entry.Size <= smallFileThreshold && entry.Size > 0 {
+	if entry != nil && entry.Size <= defaultSmallFileThreshold && entry.Size > 0 {
 		cacheRev := entry.Revision // use revision from last Stat/Lookup
 		// Fast path: serve from cache without any HTTP call.
 		if data, ok := fs.readCache.Get(p, cacheRev); ok {
@@ -3203,7 +3262,7 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 
 	if fh.Dirty == nil {
 		source = "new-dirty-buffer"
-		fh.Dirty = NewWriteBuffer(fh.Path, 0, 0)
+		fh.Dirty = fs.newWriteBuffer(fh.Path, 0, 0)
 	}
 
 	// ShadowSpill: write shadow FIRST, before Dirty. If shadow fails, return
@@ -3835,7 +3894,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 	}
 
 	size := fh.Dirty.Size()
-	if size >= smallFileThreshold || fs.debouncer.delay <= 0 {
+	if size >= fs.inlineThreshold() || fs.debouncer.delay <= 0 {
 		return fs.flushHandle(ctx, fh)
 	}
 
@@ -4017,7 +4076,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 
 	// Path 1b: Large new file with streaming uploader but no streaming parts
 	// (non-sequential writes) — upload all parts in parallel at flush time.
-	if fh.Streamer != nil && size >= smallFileThreshold {
+	if fh.Streamer != nil && size >= fs.inlineThreshold() {
 		phase = "upload-all"
 		expectedRevision := fh.Streamer.ExpectedRevision()
 		numParts := int((size + fh.Dirty.PartSize() - 1) / fh.Dirty.PartSize())
@@ -4076,7 +4135,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	expectedRevision := expectedRevisionForHandle(fh)
 	var committedRev int64
 
-	if size < smallFileThreshold {
+	threshold := fs.inlineThreshold()
+	if size < threshold {
 		// Small file: direct PUT with revision return for freshness seeding.
 		phase = "small-write"
 		writeStart := time.Now()
@@ -4084,7 +4144,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), data, expectedRevision)
 		fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
 		fs.debugDurationf(writeStart, 0, "flushHandle small write done path=%s size=%d committed_rev=%d err=%v", fh.Path, size, committedRev, err)
-	} else if fh.OrigSize >= smallFileThreshold {
+	} else if fh.OrigSize >= threshold {
 		phase = "patch-file"
 		dirtyParts := fh.Dirty.DirtyPartNumbers()
 		if len(dirtyParts) > 0 {
@@ -4263,7 +4323,7 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 	if committedRev > 0 && entry.Inode > 0 {
 		// Seed readCache from shadow data before the shadow file is removed.
 		// Only attempt for files under the readCache size limit.
-		if entry.Size < int64(smallFileThreshold) && fs.shadowStore != nil {
+		if entry.Size < int64(defaultSmallFileThreshold) && fs.shadowStore != nil {
 			if data, err := fs.shadowStore.ReadAll(entry.Path); err == nil {
 				fs.readCache.PutOwned(entry.Path, data, committedRev)
 			}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -39,7 +39,7 @@ func newTestDat9FS(tb testing.TB, size int64, get func(http.ResponseWriter, *htt
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	ino := fs.inodes.Lookup("/file.bin", false, size, time.Now())
 	return fs, ino, ts.Close
 }
@@ -106,6 +106,31 @@ func TestInitWarmTimeoutFallsBackToDefault(t *testing.T) {
 	}
 	if got := fs.inlineThreshold(); got != defaultSmallFileThreshold {
 		t.Fatalf("inlineThreshold after timeout = %d, want %d", got, defaultSmallFileThreshold)
+	}
+	// negotiatedInlineThreshold returns 0 since /v1/status never succeeded;
+	// hot-path callers must use this to force multipart for non-empty
+	// uploads instead of the heuristic-only inlineThreshold().
+	if got := fs.negotiatedInlineThreshold(); got != 0 {
+		t.Fatalf("negotiatedInlineThreshold after timeout = %d, want 0", got)
+	}
+}
+
+func TestNegotiatedInlineThresholdSeparatesProtocolFromHeuristic(t *testing.T) {
+	// inlineThreshold() is the heuristic value (falls back to 50KB) used
+	// for things like read prefetch sizing where 50KB is harmless.
+	// negotiatedInlineThreshold() returns 0 until /v1/status succeeds —
+	// flushHandle and commit_queue use the latter so a missing server
+	// value forces multipart instead of risking a server-side reject when
+	// the operator configured the inline threshold below 50KB.
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://127.0.0.1:1", ""), opts) // unreachable server
+
+	if got := fs.negotiatedInlineThreshold(); got != 0 {
+		t.Fatalf("pre-warm negotiatedInlineThreshold = %d, want 0", got)
+	}
+	if got := fs.inlineThreshold(); got != defaultSmallFileThreshold {
+		t.Fatalf("pre-warm inlineThreshold = %d, want %d (heuristic fallback)", got, defaultSmallFileThreshold)
 	}
 }
 
@@ -541,7 +566,7 @@ func TestCreateWriteThroughShadow(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	shadow, err := NewShadowStore(t.TempDir())
 	if err != nil {
@@ -665,7 +690,7 @@ func TestFlushSkipsAsyncShadowForPartialExistingSnapshot(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	ino := fs.inodes.Lookup("/file.bin", false, size, time.Now())
 
 	writeBack, err := NewWriteBackCache(t.TempDir())
@@ -917,7 +942,7 @@ func TestFlushLargeOverwritePatchCarriesExpectedRevision(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	ino := fs.inodes.Lookup("/file.bin", false, fileSize, time.Now())
 	wb := NewWriteBuffer("/file.bin", 0, partSize)
@@ -1026,7 +1051,7 @@ func TestFlushNewLargeWriteStreamCarriesCreateIfAbsentRevision(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	ino := fs.inodes.Lookup("/new.bin", false, 0, time.Now())
 	wb := NewWriteBuffer("/new.bin", 0, 0)
@@ -1161,7 +1186,7 @@ func TestGetAttrDirectoryDoesNotRequireRemoteStat(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
 
 	var out gofuse.AttrOut
@@ -1198,7 +1223,7 @@ func TestGetAttrRetriesTransientCanceledStat(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	ino := fs.inodes.Lookup("/retry-getattr.bin", false, 0, time.Now())
 
 	cancel := make(chan struct{})
@@ -1253,7 +1278,7 @@ func TestLookupStatNotFoundReturnsENOENTWithoutParentListByDefault(t *testing.T)
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	var out gofuse.EntryOut
 	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "missing", &out)
@@ -1298,7 +1323,7 @@ func TestLookupLegacyDirStatFallbackListsParentWhenEnabled(t *testing.T) {
 
 	opts := &MountOptions{LegacyDirStatFallback: true}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	var out gofuse.EntryOut
 	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "dir", &out)
@@ -1323,7 +1348,7 @@ func TestLookupUsesDirCachePositiveEntryWithoutRemoteStat(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	mtime := time.Unix(123, 0)
 	fs.dirCache.Put("/", []CachedFileInfo{{
 		Name:     "cached.txt",
@@ -1363,7 +1388,7 @@ func TestLookupUsesDirCacheNegativeEntryWithoutRemoteStat(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	fs.dirCache.Put("/", []CachedFileInfo{{Name: "other.txt", Size: 1}})
 
 	var out gofuse.EntryOut
@@ -1394,7 +1419,7 @@ func TestLookupPartialNamespaceMissFallsThroughToRemoteStat(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	fs.dirCache.Upsert("/", CachedFileInfo{Name: "known.txt", Size: 1})
 
 	var out gofuse.EntryOut
@@ -1423,7 +1448,7 @@ func TestLookupStatNotFoundSeedsShortNegativeNamespaceCache(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	for range 2 {
 		var out gofuse.EntryOut
@@ -1450,7 +1475,7 @@ func TestLookupLockFileStatNotFoundDoesNotSeedNamespaceNegative(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	for range 2 {
 		var out gofuse.EntryOut
@@ -1477,7 +1502,7 @@ func TestLookupLockFileIgnoresCompleteNamespaceMiss(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	fs.dirCache.Put("/", []CachedFileInfo{{Name: "config"}})
 
 	var out gofuse.EntryOut
@@ -1507,7 +1532,7 @@ func TestLookupSessionCreatedDirMissAvoidsRemoteStat(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	var mkdirOut gofuse.EntryOut
 	st := fs.Mkdir(nil, &gofuse.MkdirIn{
@@ -1542,7 +1567,7 @@ func TestLookupSSEForeignCreateInvalidatesSessionCreatedMiss(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
 	fs.dirCache.MarkSessionCreatedDir("/dir")
 
@@ -1577,7 +1602,7 @@ func TestLookupSSEForeignDeleteInvalidatesPositiveNamespaceHit(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	fs.inodes.Lookup("/dir", true, 0, time.Now())
 	fs.dirCache.Upsert("/dir", CachedFileInfo{Name: "stale.txt", Size: 9})
 
@@ -1610,7 +1635,7 @@ func TestNamespaceCacheCrossDirRenameUpdatesBothParents(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	srcIno := fs.inodes.Lookup("/src", true, 0, time.Now())
 	dstIno := fs.inodes.Lookup("/dst", true, 0, time.Now())
@@ -1671,7 +1696,7 @@ func TestLookupLegacyListFallbackPopulatesDirCacheForLaterMisses(t *testing.T) {
 
 	opts := &MountOptions{LegacyDirStatFallback: true}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	var first gofuse.EntryOut
 	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "first-missing.txt", &first)
@@ -1709,7 +1734,7 @@ func TestLookupUsesRemoteRootMapping(t *testing.T) {
 
 	opts := &MountOptions{RemoteRoot: "/remote"}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	var out gofuse.EntryOut
 	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "file.txt", &out)
@@ -1768,7 +1793,7 @@ func TestListDirUsesRemoteRootMapping(t *testing.T) {
 
 	opts := &MountOptions{RemoteRoot: "/remote"}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	entries, err := fs.listDir(context.Background(), "/subdir")
 	if err != nil {
@@ -1819,7 +1844,7 @@ func TestListDirIgnoresBatchStatPerPathFailure(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	entries, err := fs.listDir(context.Background(), "/")
 	if err != nil {
@@ -1858,7 +1883,7 @@ func TestListDirIgnoresBatchStatTransportFailure(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	entries, err := fs.listDir(context.Background(), "/")
 	if err != nil {
@@ -1934,7 +1959,7 @@ func TestListDirPrefetchesSmallFilesIntoReadCache(t *testing.T) {
 		PrefetchTimeout:      time.Second,
 	}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	entries, err := fs.listDir(context.Background(), "/")
 	if err != nil {
@@ -1983,7 +2008,7 @@ func TestListDirPrefetchIgnoresBatchReadTransportFailure(t *testing.T) {
 
 	opts := &MountOptions{ReadDirPrefetch: true}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	entries, err := fs.listDir(context.Background(), "/")
 	if err != nil {
@@ -2028,7 +2053,7 @@ func TestListDirPrefetchSkipsPendingFile(t *testing.T) {
 
 	opts := &MountOptions{ReadDirPrefetch: true}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	pending, err := NewPendingIndex(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -2099,7 +2124,7 @@ func TestListDirPrefetchRespectsBudgets(t *testing.T) {
 		PrefetchTimeout:      time.Second,
 	}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	_, err := fs.listDir(context.Background(), "/")
 	if err != nil {
@@ -2140,7 +2165,7 @@ func TestLookupRetriesTransientCanceledStat(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	cancel := make(chan struct{})
 	var out gofuse.EntryOut
@@ -2203,7 +2228,7 @@ func TestLookupReturnsENOENTAfterTransientCanceledStat(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	cancel := make(chan struct{})
 	var out gofuse.EntryOut
@@ -2257,7 +2282,7 @@ func TestLookupTransientRetryExhaustedReturnsEAGAIN(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	cancel := make(chan struct{})
 	var out gofuse.EntryOut
@@ -2508,7 +2533,7 @@ func TestLockFileLookupDisablesEntryCache(t *testing.T) {
 func TestLockFileCreateDisablesEntryCache(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	var lockOut gofuse.CreateOut
 	st := fs.Create(nil, &gofuse.CreateIn{
@@ -2538,7 +2563,7 @@ func TestLockFileCreateDisablesEntryCache(t *testing.T) {
 func TestInitStoresServer(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 	if fs.server != nil {
 		t.Fatal("server should be nil before Init")
 	}
@@ -2568,7 +2593,7 @@ func TestCreateFileGetsStreamUploader(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	// First we need to list root so inodes are populated
 	_, _ = fs.client.List("/")
@@ -2613,7 +2638,7 @@ func TestMkdirRetriesDetachedAfterTransientInterrupt(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	var out gofuse.EntryOut
 	st := fs.Mkdir(nil, &gofuse.MkdirIn{
@@ -2661,7 +2686,7 @@ func TestMkdirRetryTreatsRemoteDirectoryAsSuccessAfterAmbiguousCreate(t *testing
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	var out gofuse.EntryOut
 	st := fs.Mkdir(nil, &gofuse.MkdirIn{
@@ -2688,7 +2713,7 @@ func TestLookupOpenCreatedFileAfterForgetSupportsGitChmodLock(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	var createOut gofuse.CreateOut
 	st := fs.Create(nil, &gofuse.CreateIn{
@@ -2740,7 +2765,7 @@ func TestLookupOpenCreatedFileAfterForgetSupportsGitChmodLock(t *testing.T) {
 func TestCommitQueueCleanupRemovesForgottenPendingInode(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	shadow, err := NewShadowStore(t.TempDir())
 	if err != nil {
@@ -2779,7 +2804,7 @@ func TestCommitQueueCleanupRemovesForgottenPendingInode(t *testing.T) {
 func TestForgetPreservesQueuedCommitInodeUntilCleanup(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	const p = "/config.lock"
 	ino := fs.inodes.Lookup(p, false, 7, time.Now())
@@ -2803,7 +2828,7 @@ func TestForgetPreservesQueuedCommitInodeUntilCleanup(t *testing.T) {
 func TestReleaseCleansForgottenInodeWithoutLocalState(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	const p = "/config.lock"
 	ino := fs.inodes.Lookup(p, false, 7, time.Now())
@@ -2835,7 +2860,7 @@ func TestReleaseCleansForgottenInodeWithoutLocalState(t *testing.T) {
 func TestStatFs_ReportsVirtualCapacity(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	var out gofuse.StatfsOut
 	st := fs.StatFs(nil, &gofuse.InHeader{NodeId: 1}, &out)
@@ -2864,7 +2889,7 @@ func TestStatFs_ReportsVirtualCapacity(t *testing.T) {
 func TestXAttr_GetReturnsENOATTR(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	_, st := fs.GetXAttr(nil, &gofuse.InHeader{NodeId: 1}, "user.test", nil)
 	if st != gofuse.ENOATTR {
@@ -2875,7 +2900,7 @@ func TestXAttr_GetReturnsENOATTR(t *testing.T) {
 func TestXAttr_ListReturnsEmpty(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	n, st := fs.ListXAttr(nil, &gofuse.InHeader{NodeId: 1}, nil)
 	if st != gofuse.OK {
@@ -2889,7 +2914,7 @@ func TestXAttr_ListReturnsEmpty(t *testing.T) {
 func TestXAttr_SetDiscardsSilently(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	st := fs.SetXAttr(nil, &gofuse.SetXAttrIn{}, "user.test", []byte("val"))
 	if st != gofuse.OK {
@@ -2900,7 +2925,7 @@ func TestXAttr_SetDiscardsSilently(t *testing.T) {
 func TestXAttr_RemoveReturnsENOATTR(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	st := fs.RemoveXAttr(nil, &gofuse.InHeader{NodeId: 1}, "user.test")
 	if st != gofuse.ENOATTR {
@@ -3005,7 +3030,7 @@ func TestSetAttr_TruncateWithoutHandleRefreshesRevision(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	ino := fs.inodes.Lookup("/file.bin", false, 42, time.Now())
 	fs.inodes.UpdateRevision(ino, 1)
 
@@ -3084,7 +3109,7 @@ func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	ino := fs.inodes.Lookup("/flush.bin", false, 4, time.Now())
 	fs.inodes.UpdateRevision(ino, 7)
 
@@ -3169,7 +3194,7 @@ func TestFlushHandle_SmallFile_SeedsReadCache(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	ino := fs.inodes.Lookup("/fresh.txt", false, int64(len(content)), time.Now())
 	fs.inodes.UpdateRevision(ino, 1)
@@ -3232,7 +3257,7 @@ func TestFlushHandle_SmallFile_SeedsReadCache(t *testing.T) {
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 	ino := fs.inodes.Lookup("/stream.bin", false, 0, time.Now())
 
 	fh := &FileHandle{
@@ -3321,7 +3346,7 @@ func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	ino := fs.inodes.Lookup("/file.bin", false, int64(len(content)), time.Now())
 	fs.inodes.UpdateRevision(ino, revision)
 	fs.inodes.UpdateSize(ino, int64(len(content)))
@@ -3454,7 +3479,7 @@ func TestSetAttr_PathTruncateSingleCallerWriterAdoptsZeroBase(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	ino := fs.inodes.Lookup("/file.bin", false, int64(len(content)), time.Now())
 	fs.inodes.UpdateRevision(ino, revision)
 	fs.inodes.UpdateSize(ino, int64(len(content)))
@@ -3589,7 +3614,7 @@ func TestSetAttr_PathTruncateDoesNotRefreshStaleWriterHandle(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	ino := fs.inodes.Lookup("/file.bin", false, int64(len(content)), time.Now())
 	fs.inodes.UpdateRevision(ino, revision)
 	fs.inodes.UpdateSize(ino, int64(len(content)))
@@ -3733,7 +3758,7 @@ func TestSetAttr_PathTruncateSingleStaleWriterHandleKeepsOriginalRevision(t *tes
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	ino := fs.inodes.Lookup("/file.bin", false, int64(len(content)), time.Now())
 	fs.inodes.UpdateRevision(ino, revision)
 	fs.inodes.UpdateSize(ino, int64(len(content)))
@@ -3814,7 +3839,7 @@ func TestLookup_UsesMtimeFromStat(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	var out gofuse.EntryOut
 	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "file.txt", &out)
@@ -3868,7 +3893,7 @@ func TestCreateWriteFlushRelease_SmallFile(t *testing.T) {
 
 	opts := &MountOptions{FlushDebounce: 0} // disable debounce for determinism
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	done := make(chan struct{})
 	go func() {
@@ -3960,7 +3985,7 @@ func TestConcurrentGetAttrDuringWrite(t *testing.T) {
 
 	opts := &MountOptions{FlushDebounce: 0}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	// Create a file
 	var createOut gofuse.CreateOut
@@ -4011,7 +4036,7 @@ func TestConcurrentGetAttrDuringWrite(t *testing.T) {
 func TestNotifyEntry_NonBlocking(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	// Set a non-nil server so notifyEntry/notifyInode actually enter the
 	// async goroutine path (a zero-value Server returns ENOSYS immediately
@@ -4074,7 +4099,7 @@ func TestMutationHandlers_CompleteWithinTimeout(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	// Pre-populate some inodes for mutation tests
 	fs.inodes.Lookup("/existing.txt", false, 100, time.Now())
@@ -4168,7 +4193,7 @@ func TestParallelCreateAndGetAttr(t *testing.T) {
 
 	opts := &MountOptions{FlushDebounce: 0}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	const N = 20
 	var wg sync.WaitGroup
@@ -4256,7 +4281,7 @@ func TestFlushHandle_SmallFile_ServerUnreachable(t *testing.T) {
 
 	opts := &MountOptions{FlushDebounce: 0}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(serverURL, ""), opts)
+	fs := NewDat9FS(newTestClient(serverURL), opts)
 
 	// Manually create a file handle (server is dead, can't do real Create)
 	ino := fs.inodes.Lookup("/slow.txt", false, 0, time.Now())
@@ -4323,7 +4348,7 @@ func TestDebounce_ReleaseAfterFlush_NoDataLoss(t *testing.T) {
 
 	opts := &MountOptions{FlushDebounce: 10 * time.Second} // long debounce — won't fire naturally
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	// Create a file
 	var createOut gofuse.CreateOut
@@ -4485,7 +4510,7 @@ func TestFlushLargeFile_StrictUploadsBeforeReturning(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	fs.syncMode = SyncStrict
 
 	var createOut gofuse.CreateOut
@@ -4572,7 +4597,7 @@ func TestFlushLargeFile_InteractiveStagesShadowAndPendingIndex(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	fs := NewDat9FS(c, opts)
 	fs.syncMode = SyncInteractive
 
@@ -4701,7 +4726,7 @@ func TestRenamePendingNewCommitSyncCommitsGitLooseObjectFinalPath(t *testing.T) 
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	fs := NewDat9FS(c, opts)
 
 	shadow, err := NewShadowStore(t.TempDir())
@@ -4804,7 +4829,7 @@ func TestRenamePendingNewCommitGitLooseObjectSyncFailureKeepsRecoverableShadow(t
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	fs := NewDat9FS(c, opts)
 
 	shadowDir := t.TempDir()
@@ -4952,7 +4977,7 @@ func TestRenamePendingNewCommitFallsBackWhenFinalTargetExists(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	fs := NewDat9FS(c, opts)
 
 	shadow, err := NewShadowStore(t.TempDir())
@@ -5088,7 +5113,7 @@ func TestRenamePendingNewCommitUsesRemoteRenameWhenCanceledUploadBecameVisible(t
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	fs := NewDat9FS(c, opts)
 
 	shadow, err := NewShadowStore(t.TempDir())
@@ -5197,7 +5222,7 @@ func TestRenamePendingNewCommitSyncCommitsWhenQueueStopped(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	fs := NewDat9FS(c, opts)
 
 	shadow, err := NewShadowStore(t.TempDir())
@@ -5285,7 +5310,7 @@ func TestUnlinkRemoteDeleteDoesNotRetryRecreatedPathAfterInterrupt(t *testing.T)
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	parentIno := fs.inodes.Lookup("/repo/.github/workflows", true, 0, time.Now())
 	fs.inodes.Lookup(path, false, 6172, time.Now())
@@ -5359,7 +5384,7 @@ func TestUnlinkRemoteDeleteAcceptsGoneAfterInterrupt(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	parentIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
 	fs.inodes.Lookup(path, false, 10011, time.Now())
@@ -5433,7 +5458,7 @@ func TestRmdirRemoteDeleteDoesNotRetryRecreatedPathAfterInterrupt(t *testing.T) 
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	parentIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
 	fs.inodes.Lookup(path, true, 0, time.Now())
@@ -5499,7 +5524,7 @@ func TestRenameRemoteWithTransientRetryRetriesAfterInterrupt(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	dirIno := fs.inodes.Lookup("/repo/.git/objects/e6", true, 0, time.Now())
 	fs.inodes.Lookup(oldP, false, 849, time.Now())
@@ -5574,7 +5599,7 @@ func TestRenameRemoteWithTransientRetryAcceptsTargetVisibleAfterInterrupt(t *tes
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	dirIno := fs.inodes.Lookup("/repo/.git/objects/e6", true, 0, time.Now())
 	fs.inodes.Lookup(oldP, false, 849, time.Now())
@@ -5657,7 +5682,7 @@ func TestRenameRemoteWithTransientRetryDoesNotAcceptPreexistingTarget(t *testing
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	dirIno := fs.inodes.Lookup("/repo/.git", true, 0, time.Now())
 	fs.inodes.Lookup(oldP, false, 54, time.Now())
@@ -5729,7 +5754,7 @@ func TestRenamePendingNewCommitFallsBackWhenCanceledUploadReachedRemote(t *testi
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	fs := NewDat9FS(c, opts)
 
 	shadowDir := t.TempDir()
@@ -5823,7 +5848,7 @@ func TestRenamePendingNewCommitOldVisibilityProbeIgnoresFuseCancel(t *testing.T)
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	fs := NewDat9FS(c, opts)
 
 	shadow, err := NewShadowStore(t.TempDir())
@@ -5933,7 +5958,7 @@ func TestReadSmallFileRetryOnTransient(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	// Register root inode and do a lookup to populate inode entry
 	cancel := make(chan struct{})
@@ -5988,7 +6013,7 @@ func TestReadRangeRetryExhaustedReturnsEIO(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	cancel := make(chan struct{})
 	var entryOut2 gofuse.EntryOut
@@ -6039,7 +6064,7 @@ func TestReadSmallFileRetryExhaustedReturnsEIO(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	cancel := make(chan struct{})
 	var entryOut2 gofuse.EntryOut
@@ -6080,7 +6105,7 @@ func TestDoRangeReadBodyTimeoutReturnsForRetry(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -6124,7 +6149,7 @@ func TestDoRangeReadBodyTruncationReturnsError(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	ctx := context.Background()
 	_, n, err := fs.doRangeRead(ctx, "/truncate.bin", 0, 4096)
@@ -6159,7 +6184,7 @@ func TestReadPrefetchNotTriggeredOnFailure(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	cancel := make(chan struct{})
 	var entryOut2 gofuse.EntryOut
@@ -6259,7 +6284,7 @@ func TestLocalMutations_NotifyBudget(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	// Pre-populate inodes for mutation targets.
 	fs.inodes.Lookup("/existing.txt", false, 100, time.Now())
@@ -6336,7 +6361,7 @@ func TestCreateWriteFlushRelease_NoKernelNotify(t *testing.T) {
 
 	opts := &MountOptions{FlushDebounce: 0}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	before := fs.notifyCount.Load()
 
@@ -6416,7 +6441,7 @@ func TestCreateWriteFlushRelease_NoKernelNotify(t *testing.T) {
 func TestOnCommitQueueSuccess_NoKernelNotify_SeedsReadCache(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	// Set up shadowStore with test data (simulates what Flush stages).
 	shadowDir := t.TempDir()
@@ -6479,7 +6504,7 @@ func TestOnCommitQueueSuccess_NoKernelNotify_SeedsReadCache(t *testing.T) {
 func TestSSEForeignChange_StillNotifiesKernel(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	// Pre-populate an inode so SSE invalidation has something to notify.
 	fs.inodes.Lookup("/remote-file.txt", false, 100, time.Now())
@@ -6540,7 +6565,7 @@ func TestSSEForeignChange_StillNotifiesKernel(t *testing.T) {
 func TestSetAttr_NoKernelNotify(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://localhost", ""), opts)
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
 	ino := fs.inodes.Lookup("/trunc.txt", false, 100, time.Now())
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -44,6 +44,71 @@ func newTestDat9FS(tb testing.TB, size int64, get func(http.ResponseWriter, *htt
 	return fs, ino, ts.Close
 }
 
+func TestInitSynchronouslyWarmsInlineThreshold(t *testing.T) {
+	// Pre-fix this was a goroutine, so the very first FUSE Create/Flush
+	// after mount could see the 50KB fallback even when the server
+	// advertised something larger. Init must block on the warm fetch.
+	const advertised = int64(262144)
+	statusHits := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/status" {
+			statusHits++
+			_, _ = w.Write([]byte(`{"status":"active","inline_threshold":262144}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	// Use the raw client (no test pin) so Init's warm actually hits the
+	// fake /v1/status — newTestClient pins a static threshold and would
+	// short-circuit the fetch.
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs.Init(nil)
+
+	if statusHits != 1 {
+		t.Fatalf("Init issued %d status fetches, want 1", statusHits)
+	}
+	if got := fs.inlineThreshold(); got != advertised {
+		t.Fatalf("inlineThreshold after Init = %d, want %d", got, advertised)
+	}
+}
+
+func TestInitWarmTimeoutFallsBackToDefault(t *testing.T) {
+	// Server is unreachable / hung; Init must not block longer than the
+	// warm timeout and must fall back to the local default so mount stays
+	// usable. The handler waits on the request context so the server can
+	// shut down cleanly when the client cancels.
+	prev := inlineThresholdWarmTimeout
+	inlineThresholdWarmTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { inlineThresholdWarmTimeout = prev })
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	// Raw client so Init actually issues the warm fetch and we observe the
+	// timeout-fallback path; newTestClient would short-circuit via the
+	// pinned threshold.
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	start := time.Now()
+	fs.Init(nil)
+	elapsed := time.Since(start)
+	// Allow a generous slack for slow CI: ~5x the configured timeout.
+	if elapsed > 5*inlineThresholdWarmTimeout {
+		t.Fatalf("Init took %v, want <= %v", elapsed, 5*inlineThresholdWarmTimeout)
+	}
+	if got := fs.inlineThreshold(); got != defaultSmallFileThreshold {
+		t.Fatalf("inlineThreshold after timeout = %d, want %d", got, defaultSmallFileThreshold)
+	}
+}
+
 func BenchmarkDat9FS_SmallFileOpen(b *testing.B) {
 	const (
 		filePath = "/file.bin"
@@ -328,7 +393,7 @@ func TestOpenWritableSmallFileLazyPreload(t *testing.T) {
 func TestOpenWritableLargeFileLazyPreload(t *testing.T) {
 	// With lazy preload, Open() succeeds for large files even if the server
 	// would fail on GET — the actual data loading is deferred to Write time.
-	fs, ino, cleanup := newTestDat9FS(t, smallFileThreshold+1, func(w http.ResponseWriter, r *http.Request) {
+	fs, ino, cleanup := newTestDat9FS(t, defaultSmallFileThreshold+1, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)
 	})
 	defer cleanup()
@@ -795,7 +860,7 @@ func TestOpenWritablePendingShadowSkipsRemoteStat(t *testing.T) {
 
 func TestFlushLargeOverwritePatchCarriesExpectedRevision(t *testing.T) {
 	const (
-		fileSize = smallFileThreshold + 1024
+		fileSize = defaultSmallFileThreshold + 1024
 		partSize = 5 << 20
 	)
 
@@ -889,7 +954,7 @@ func TestFlushLargeOverwritePatchCarriesExpectedRevision(t *testing.T) {
 }
 
 func TestFlushNewLargeWriteStreamCarriesCreateIfAbsentRevision(t *testing.T) {
-	const fileSize = smallFileThreshold + 2048
+	const fileSize = defaultSmallFileThreshold + 2048
 
 	var gotExpected atomic.Int64
 	gotExpected.Store(-1)
@@ -2289,7 +2354,7 @@ func TestIsTransientLookupErr_Treats499AsTransient(t *testing.T) {
 }
 
 func TestOpenReadOnlyLargeFileGetsPrefetcher(t *testing.T) {
-	size := int64(1024 * 1024) // 1MB — above smallFileThreshold
+	size := int64(1024 * 1024) // 1MB — above defaultSmallFileThreshold
 	data := make([]byte, size)
 	for i := range data {
 		data[i] = byte(i % 256)
@@ -2322,7 +2387,7 @@ func TestOpenReadOnlyLargeFileGetsPrefetcher(t *testing.T) {
 }
 
 func TestOpenWritableLargeFileGetsLazyPreload(t *testing.T) {
-	size := int64(1024 * 1024) // 1MB — above smallFileThreshold
+	size := int64(1024 * 1024) // 1MB — above defaultSmallFileThreshold
 	getCalled := false
 
 	fs, ino, cleanup := newTestDat9FS(t, size, func(w http.ResponseWriter, r *http.Request) {
@@ -4278,7 +4343,7 @@ func TestDebounce_ReleaseAfterFlush_NoDataLoss(t *testing.T) {
 		t.Fatalf("Write status = %v, want OK", st)
 	}
 
-	// Flush (will debounce since file < smallFileThreshold and debounce > 0)
+	// Flush (will debounce since file < defaultSmallFileThreshold and debounce > 0)
 	st = fs.Flush(nil, &gofuse.FlushIn{
 		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
 		Fh:       createOut.Fh,
@@ -5903,7 +5968,7 @@ func TestReadSmallFileRetryOnTransient(t *testing.T) {
 // are exhausted, the Read returns EIO instead of EAGAIN.
 func TestReadRangeRetryExhaustedReturnsEIO(t *testing.T) {
 	var getCalls atomic.Int32
-	fileSize := int64(1 << 20) // 1 MiB — above smallFileThreshold
+	fileSize := int64(1 << 20) // 1 MiB — above defaultSmallFileThreshold
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/mem9-ai/dat9/pkg/client"
 )
 
 var (
@@ -1226,7 +1224,7 @@ func TestPrefetcher_SubBlockReads(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	p := NewPrefetcher(c, "/bigfile.bin", int64(len(fileData)))
 	defer p.Close()
 
@@ -1310,7 +1308,7 @@ func TestPrefetcher_LargeReadSizeDoesNotReturnShortPrefetch(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	p := NewPrefetcher(c, "/bigfile.bin", int64(len(fileData)))
 	defer p.Close()
 
@@ -1359,7 +1357,7 @@ func TestPrefetcher_ChunkCapBound(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	p := NewPrefetcher(c, "/test.bin", fileSize)
 	defer p.Close()
 
@@ -1657,7 +1655,7 @@ func TestStreamUploader_FinishStreamingRestoresPendingOnFailure(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	su := NewStreamUploader(c, "/retry-test.bin", -1)
 
 	// Submit 2 parts.

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -293,7 +293,7 @@ func TestReadCache_TTLExpiry(t *testing.T) {
 
 func TestReadCache_SkipLargeFiles(t *testing.T) {
 	rc := NewReadCache(1<<20, 10*time.Second)
-	bigData := make([]byte, smallFileThreshold+1)
+	bigData := make([]byte, defaultSmallFileThreshold+1)
 	rc.Put("/big", bigData, 1)
 	_, ok := rc.Get("/big", 1)
 	if ok {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -94,8 +94,8 @@ func (o *MountOptions) setDefaults() {
 	if o.PrefetchMaxFiles <= 0 {
 		o.PrefetchMaxFiles = defaultReadDirPrefetchMaxFiles
 	}
-	if o.PrefetchMaxFileBytes <= 0 || o.PrefetchMaxFileBytes > smallFileThreshold {
-		o.PrefetchMaxFileBytes = smallFileThreshold
+	if o.PrefetchMaxFileBytes <= 0 || o.PrefetchMaxFileBytes > defaultSmallFileThreshold {
+		o.PrefetchMaxFileBytes = defaultSmallFileThreshold
 	}
 	if o.PrefetchMaxBytes <= 0 {
 		o.PrefetchMaxBytes = defaultReadDirPrefetchMaxBytes

--- a/pkg/fuse/perf_test.go
+++ b/pkg/fuse/perf_test.go
@@ -67,7 +67,7 @@ func TestFusePerfDisabledByDefault(t *testing.T) {
 		DirTTL:    time.Second,
 	}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://127.0.0.1", ""), opts)
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
 	if fs.perf != nil {
 		t.Fatal("perf counters should be nil when disabled")
 	}
@@ -82,7 +82,7 @@ func TestFusePerfCountsNotifyAndSSE(t *testing.T) {
 		PerfCounters: true,
 	}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New("http://127.0.0.1", ""), opts)
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
 	fs.inodes.Lookup("/file.txt", false, 4, time.Now())
 
 	watcher := &SSEWatcher{fs: fs, actor: "actor-a"}
@@ -130,7 +130,7 @@ func TestCommitQueuePerfCounters(t *testing.T) {
 	}
 
 	perf := newFusePerfCounters(true)
-	cq := NewCommitQueue(client.New(ts.URL, ""), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	cq.SetPerfCounters(perf)
 	if err := cq.Enqueue(&CommitEntry{
 		Path:    "/ok.txt",

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -10,7 +10,10 @@ import (
 const (
 	defaultReadCacheMaxSize = 128 << 20        // 128MB
 	defaultReadCacheTTL     = 30 * time.Second // 30s
-	smallFileThreshold      = 50_000           // 50,000 bytes — matches embedding model max input characters
+	// defaultSmallFileThreshold is the local fallback used when no server
+	// value has been negotiated yet. The authoritative value is fetched from
+	// /v1/status on the dat9 client and propagated through FS.smallFileMax.
+	defaultSmallFileThreshold = 50_000
 )
 
 // cacheEntry holds a single cached file's data and metadata.
@@ -91,9 +94,12 @@ func (rc *ReadCache) Get(path string, currentRevision int64) ([]byte, bool) {
 }
 
 // Put stores data in the cache for the given path and revision. Only files
-// whose size does not exceed smallFileThreshold are cached. If an entry for
-// the path already exists it is updated in place. After insertion, LRU
-// eviction runs until the total cached size is within maxSize.
+// whose size does not exceed defaultSmallFileThreshold are cached. The cache
+// limit is intentionally a static memory-pressure cap rather than a mirror
+// of the server's inline_threshold; raising the latter should not silently
+// expand FUSE's per-mount RAM footprint. If an entry for the path already
+// exists it is updated in place. After insertion, LRU eviction runs until
+// the total cached size is within maxSize.
 func (rc *ReadCache) Put(path string, data []byte, revision int64) {
 	rc.put(path, data, revision, true)
 }
@@ -105,7 +111,7 @@ func (rc *ReadCache) PutOwned(path string, data []byte, revision int64) {
 }
 
 func (rc *ReadCache) put(path string, data []byte, revision int64, clone bool) {
-	if len(data) > smallFileThreshold {
+	if len(data) > defaultSmallFileThreshold {
 		return
 	}
 

--- a/pkg/fuse/remote_upload_test.go
+++ b/pkg/fuse/remote_upload_test.go
@@ -161,7 +161,7 @@ func newMultipartUploadRecorder(t *testing.T, wantPath string, wantSize int64, w
 }
 
 func (rec *multipartUploadRecorder) client() *client.Client {
-	return client.New(rec.server.URL, "")
+	return newTestClient(rec.server.URL)
 }
 
 func TestCommitQueueLargeOverwriteUsesMultipartUpload(t *testing.T) {

--- a/pkg/fuse/test_clienthelper_test.go
+++ b/pkg/fuse/test_clienthelper_test.go
@@ -1,0 +1,19 @@
+package fuse
+
+import "github.com/mem9-ai/dat9/pkg/client"
+
+// newTestClient is the standard test-only client constructor for fuse
+// tests. It pins the small-file threshold to the historical 50KB so
+// fake HTTP servers without a /v1/status route still see the legacy
+// direct-PUT vs V2-multipart split. Production code negotiates this
+// value via /v1/status; the helper exists purely so each test fixture
+// doesn't have to either stub out /v1/status or rewrite every server
+// handler to expect multipart for small writes.
+//
+// Tests that specifically exercise the multipart path (force large)
+// continue to set c.smallFileThreshold = 1 directly after construction.
+func newTestClient(baseURL string) *client.Client {
+	c := client.New(baseURL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	return c
+}

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -21,9 +21,10 @@ type LoadPartFunc func(partNum int) ([]byte, error)
 // explicitly loaded are held in memory. This enables lazy preloading
 // (load parts on demand) and streaming uploads (notify when parts are full).
 //
-// For files that remain below smallFileThreshold, a fast path uses a single
-// contiguous allocation instead of the sparse part map, avoiding map lookups
-// and per-part allocations for the common case of editing small files.
+// For files that remain below the per-buffer smallFileMax, a fast path uses
+// a single contiguous allocation instead of the sparse part map, avoiding
+// map lookups and per-part allocations for the common case of editing small
+// files.
 //
 // It tracks which parts have been modified so that on flush,
 // only dirty parts need to be uploaded (unchanged parts are copied
@@ -34,9 +35,14 @@ type WriteBuffer struct {
 	totalSize  int64 // current logical file size
 	maxSize    int64
 	partSize   int64
-	parts      map[int][]byte // 0-based part index → part data
-	dirtyParts map[int]bool   // 0-based part index → dirty flag
-	touched    bool
+	// smallFileMax is the cutoff for the single-buffer fast path; equals the
+	// server-advertised inline_threshold when known, otherwise the local
+	// default. Stored per-buffer so per-mount values (server overrides,
+	// tests) work without a global.
+	smallFileMax int64
+	parts        map[int][]byte // 0-based part index → part data
+	dirtyParts   map[int]bool   // 0-based part index → dirty flag
+	touched      bool
 
 	// Callback (optional)
 	LoadPart LoadPartFunc // called to lazily load part data
@@ -72,6 +78,9 @@ type WriteBuffer struct {
 // NewWriteBuffer creates a new WriteBuffer for the given path.
 // If maxSize <= 0, defaultWriteBufferMaxSize (64MB) is used.
 // If partSize <= 0, DefaultPartSize (8MB) is used.
+// The small-file fast path uses defaultSmallFileThreshold; production callers
+// should immediately call SetSmallFileMax to track the server-advertised
+// inline_threshold. Tests rely on the default and need not call it.
 func NewWriteBuffer(path string, maxSize int64, partSize int64) *WriteBuffer {
 	if maxSize <= 0 {
 		maxSize = defaultWriteBufferMaxSize
@@ -80,12 +89,22 @@ func NewWriteBuffer(path string, maxSize int64, partSize int64) *WriteBuffer {
 		partSize = DefaultPartSize
 	}
 	return &WriteBuffer{
-		path:       path,
-		maxSize:    maxSize,
-		partSize:   partSize,
-		parts:      make(map[int][]byte),
-		dirtyParts: make(map[int]bool),
+		path:         path,
+		maxSize:      maxSize,
+		partSize:     partSize,
+		smallFileMax: defaultSmallFileThreshold,
+		parts:        make(map[int][]byte),
+		dirtyParts:   make(map[int]bool),
 	}
+}
+
+// SetSmallFileMax overrides the small-file fast-path cutoff. Must be called
+// before any Write/Truncate; ignored when threshold <= 0.
+func (wb *WriteBuffer) SetSmallFileMax(threshold int64) {
+	if threshold <= 0 {
+		return
+	}
+	wb.smallFileMax = threshold
 }
 
 // Write writes data at the given offset into the buffer.
@@ -104,7 +123,7 @@ func (wb *WriteBuffer) Write(offset int64, data []byte) (uint32, error) {
 	// fragmentation for the common case.
 	// Do NOT use the fast path when lazy loading is configured (LoadPart != nil)
 	// because we may need to load existing remote data.
-	if wb.smallFileData != nil || (wb.partSize >= smallFileThreshold && len(wb.parts) == 0 && wb.LoadPart == nil && end <= smallFileThreshold && wb.totalSize <= smallFileThreshold) {
+	if wb.smallFileData != nil || (wb.partSize >= wb.smallFileMax && len(wb.parts) == 0 && wb.LoadPart == nil && end <= wb.smallFileMax && wb.totalSize <= wb.smallFileMax) {
 		return wb.writeSmallFile(offset, data)
 	}
 
@@ -203,7 +222,7 @@ func (wb *WriteBuffer) writeSmallFile(offset int64, data []byte) (uint32, error)
 	if end > wb.maxSize {
 		return 0, syscall.EFBIG
 	}
-	if end > smallFileThreshold {
+	if end > wb.smallFileMax {
 		// Migrate to part mode and retry
 		wb.migrateToPartMode()
 		return wb.Write(offset, data)
@@ -225,8 +244,8 @@ func (wb *WriteBuffer) writeSmallFile(offset int64, data []byte) (uint32, error)
 		if newCap < 2*cap(wb.smallFileData) {
 			newCap = 2 * cap(wb.smallFileData)
 		}
-		if newCap > smallFileThreshold {
-			newCap = smallFileThreshold
+		if int64(newCap) > wb.smallFileMax {
+			newCap = int(wb.smallFileMax)
 		}
 		grown := make([]byte, newCap)
 		copy(grown, wb.smallFileData)
@@ -387,7 +406,7 @@ func (wb *WriteBuffer) Truncate(size int64) error {
 
 	case size > cur:
 		if wb.smallFileData != nil {
-			if size <= smallFileThreshold {
+			if size <= wb.smallFileMax {
 				if int(size) > cap(wb.smallFileData) {
 					newCap := int(size)
 					if newCap < 1024 {

--- a/pkg/fuse/writeback.go
+++ b/pkg/fuse/writeback.go
@@ -22,8 +22,11 @@ const writeBackThreshold = 10 << 20 // 10MB
 
 // writeBackInMemoryDataThreshold is the maximum cached write-back payload size
 // retained in memory for hot reopen/read paths. Larger entries stay on disk
-// only to avoid turning write-back into a large in-memory file store.
-const writeBackInMemoryDataThreshold = smallFileThreshold
+// only to avoid turning write-back into a large in-memory file store. Tied
+// to the static defaultSmallFileThreshold rather than the server-advertised
+// inline_threshold so raising the latter doesn't silently expand FUSE's
+// per-mount RAM footprint.
+const writeBackInMemoryDataThreshold = defaultSmallFileThreshold
 
 // defaultWriteBackDataCacheMaxSize bounds the aggregate in-memory footprint of
 // small write-back payloads retained for hot reopen/read/uploader paths.

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -1671,7 +1671,7 @@ func TestOpenWritable_OverwriteFromWriteBackCacheSkipsRemoteStat(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 0)
 
 	opts := &MountOptions{FlushDebounce: 0}

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/mem9-ai/dat9/pkg/client"
 )
 
 func TestWriteBackCache_PutGetRemove(t *testing.T) {
@@ -452,7 +451,7 @@ func TestWriteBackUploader_SubmitAndUpload(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	// Put data in cache and submit for upload.
@@ -489,7 +488,7 @@ func TestWriteBackUploader_RecoverPending(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 
 	// Simulate entries from a previous session.
 	_ = cache.Put("/recover1.txt", []byte("data1"), 5, PendingNew)
@@ -516,7 +515,7 @@ func TestWriteBackUploader_UploadFailRetainsCache(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 1)
 
 	_ = cache.Put("/fail.txt", []byte("fail data"), 9, PendingNew)
@@ -543,7 +542,7 @@ func TestWriteBackUploader_PendingNewUsesCreateIfAbsent(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 1)
 
 	_ = cache.Put("/new.txt", []byte("new"), 3, PendingNew)
@@ -569,7 +568,7 @@ func TestWriteBackUploader_PendingOverwriteUsesBaseRevision(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 1)
 
 	_ = cache.PutWithBaseRev("/existing.txt", []byte("edit"), 4, PendingOverwrite, 23)
@@ -593,7 +592,7 @@ func TestWriteBackUploader_PendingOverwriteWithoutBaseRevRetainsCache(t *testing
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 1)
 
 	_ = cache.Put("/legacy-overwrite.txt", []byte("edit"), 4, PendingOverwrite)
@@ -633,7 +632,7 @@ func TestWriteBackUploader_UploadSyncLegacyOverwriteFallsBackToUnconditional(t *
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 1)
 
 	_ = cache.Put("/legacy-sync.txt", []byte("edit"), 4, PendingOverwrite)
@@ -694,7 +693,7 @@ func TestFlush_WriteBack_SmallFile(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -793,7 +792,7 @@ func TestFlush_WriteBack_Lifecycle(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -887,7 +886,7 @@ func TestFlush_WriteBack_MultipleFiles(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 4)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -983,7 +982,7 @@ func TestFlush_WriteBack_WriteBetweenFlushAndRelease(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -1083,7 +1082,7 @@ func TestFlush_WriteBack_NoWriteBack_LargeFile(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -1173,7 +1172,7 @@ func TestRenameFlushesWriteBack(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -1233,7 +1232,7 @@ func TestRenameInvalidatesDestinationReadCache(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	fs.inodes.Lookup("/config.lock", false, 54, time.Now())
 	fs.inodes.Lookup("/config", false, 36, time.Now())
 	fs.readCache.Put("/config.lock", []byte("new config"), 1)
@@ -1277,7 +1276,7 @@ func TestUnlinkClearsPendingWriteBack(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -1338,7 +1337,7 @@ func TestReopenAfterClose_ReadsPendingCache(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	// Don't start workers so the upload stays pending.
 	uploader := NewWriteBackUploader(c, cache, 0)
 
@@ -1410,7 +1409,7 @@ func TestFsync_NoDuplicateUpload(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -1493,7 +1492,7 @@ func TestSamePathConsecutiveSaves(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	// Put "version1" — simulates first save.
@@ -1543,7 +1542,7 @@ func TestLookupFindsPendingWriteBack(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 
 	opts := &MountOptions{FlushDebounce: 0}
 	opts.setDefaults()
@@ -1597,7 +1596,7 @@ func TestOpenWritable_PreloadsFromWriteBackCache(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 0) // no workers — keep data pending
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -1750,7 +1749,7 @@ func TestUploader_WaitPath(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 1)
 
 	_ = cache.Put("/inflight.txt", []byte("data"), 4, PendingNew)
@@ -1929,7 +1928,7 @@ func TestRename_PendingOverwrite_UsesSlowPath(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -2051,7 +2050,7 @@ func TestUnlink_PendingNew_SkipsRemoteDelete(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -2123,7 +2122,7 @@ func TestUnlink_PendingNewCommitQueueUploadedDeletesRemote(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
 	defer cq.DrainAll()
 
@@ -2208,7 +2207,7 @@ func TestUnlink_PendingNewCommitQueueNotEnqueuedSkipsRemoteDelete(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
 	defer cq.DrainAll()
 
@@ -2252,7 +2251,7 @@ func TestUnlink_PendingOverwrite_DeletesRemote(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -2310,7 +2309,7 @@ func TestPreload_LazyLoad_SmallFile(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 
 	opts := &MountOptions{FlushDebounce: 0}
 	opts.setDefaults()
@@ -2382,7 +2381,7 @@ func TestRmdir_CleansPendingDescendants(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -2458,7 +2457,7 @@ func TestRename_Directory_MigratesPendingDescendants(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	uploader := NewWriteBackUploader(c, cache, 2)
 
 	opts := &MountOptions{FlushDebounce: 0}
@@ -2549,7 +2548,7 @@ func TestFlush_SkipsRedundantCacheWrite(t *testing.T) {
 
 	dir := t.TempDir()
 	cache, _ := NewWriteBackCache(dir)
-	c := client.New(ts.URL, "")
+	c := newTestClient(ts.URL)
 	// No workers — uploads stay pending so we can inspect cache writes.
 	uploader := NewWriteBackUploader(c, cache, 0)
 

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -291,6 +291,38 @@ func TestTenantStatusWithValidKey(t *testing.T) {
 	}
 }
 
+func TestTenantStatusReturnsInlineThreshold(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	const customThreshold = int64(256_000)
+	srv := NewWithConfig(Config{
+		Meta:            rt.meta,
+		Pool:            rt.pool,
+		TokenSecret:     rt.tokenSecret,
+		InlineThreshold: customThreshold,
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var out TenantStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.InlineThreshold != customThreshold {
+		t.Fatalf("inline_threshold = %d, want %d", out.InlineThreshold, customThreshold)
+	}
+}
+
 func TestTenantStatusReturnsProvisioningState(t *testing.T) {
 	srv, tok, cleanup := newAuthServer(t)
 	defer cleanup()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -42,9 +42,13 @@ type Config struct {
 	LocalS3           *s3client.LocalS3Client
 	S3Dir             string
 	MaxUploadBytes    int64
-	Logger            *zap.Logger
-	SemanticEmbedder  embedding.Client
-	SemanticWorkers   SemanticWorkerOptions
+	// InlineThreshold is the server-wide DB-inline vs S3 cutoff surfaced to
+	// clients via /v1/status. When 0, the value is inferred from
+	// cfg.Backend.InlineThreshold() (or omitted in responses if no backend).
+	InlineThreshold  int64
+	Logger           *zap.Logger
+	SemanticEmbedder embedding.Client
+	SemanticWorkers  SemanticWorkerOptions
 }
 
 type Server struct {
@@ -57,6 +61,7 @@ type Server struct {
 	vaultMK           *vault.MasterKey
 	vaultIssuerURL    string
 	maxUploadBytes    int64
+	inlineThreshold   int64
 	metrics           *serverMetrics
 	logger            *zap.Logger
 	mux               *http.ServeMux
@@ -82,6 +87,11 @@ const DefaultMaxUploadBytes int64 = 10 * (1 << 30) // 10 GiB
 type TenantStatusResponse struct {
 	Status         string `json:"status"`
 	MaxUploadBytes int64  `json:"max_upload_bytes"`
+	// InlineThreshold is the server's DB-inline vs S3 storage cutoff. Clients
+	// use it to choose simple PUT vs V2 multipart upload so they stay
+	// consistent with server-side IsLargeFile gating. Omitted (zero) by old
+	// servers; clients fall back to their compiled-in default.
+	InlineThreshold int64 `json:"inline_threshold,omitempty"`
 }
 
 const (
@@ -112,6 +122,13 @@ func NewWithConfig(cfg Config) *Server {
 			logger.Warn("vault master key invalid, vault disabled", zap.Error(err))
 		}
 	}
+	inlineThreshold := cfg.InlineThreshold
+	if inlineThreshold <= 0 && cfg.Backend != nil {
+		inlineThreshold = cfg.Backend.InlineThreshold()
+	}
+	if inlineThreshold <= 0 {
+		inlineThreshold = backend.DefaultInlineThreshold
+	}
 	s := &Server{
 		fallback:          cfg.Backend,
 		meta:              cfg.Meta,
@@ -122,6 +139,7 @@ func NewWithConfig(cfg Config) *Server {
 		vaultIssuerURL:    strings.TrimSpace(cfg.VaultIssuerURL),
 		provisioner:       cfg.Provisioner,
 		maxUploadBytes:    maxUpload,
+		inlineThreshold:   inlineThreshold,
 		metrics:           newServerMetrics(),
 		logger:            logger,
 		events:            newEventBuses(),
@@ -406,8 +424,9 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_ok", "tenant_id", resolved.Tenant.ID, "status", resolved.Tenant.Status)...)
 	_ = json.NewEncoder(w).Encode(TenantStatusResponse{
-		Status:         string(resolved.Tenant.Status),
-		MaxUploadBytes: s.maxUploadBytes,
+		Status:          string(resolved.Tenant.Status),
+		MaxUploadBytes:  s.maxUploadBytes,
+		InlineThreshold: s.inlineThreshold,
 	})
 }
 
@@ -441,8 +460,9 @@ func (s *Server) handleLocalTenantStatus(w http.ResponseWriter, r *http.Request)
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_ok", "tenant_id", "local", "status", "active")...)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(TenantStatusResponse{
-		Status:         "active",
-		MaxUploadBytes: s.maxUploadBytes,
+		Status:          "active",
+		MaxUploadBytes:  s.maxUploadBytes,
+		InlineThreshold: s.inlineThreshold,
 	})
 }
 


### PR DESCRIPTION
## Summary

- Make the DB-inline vs S3 storage cutoff (`smallFileThreshold`) and the synchronous text-extraction cap (`textExtractMaxBytes`) configurable on the server via env vars `DRIVE9_INLINE_THRESHOLD` / `DRIVE9_TEXT_EXTRACT_MAX_BYTES` (defaults unchanged: 50KB / 8KB).
- Server is the single source of truth: it advertises `inline_threshold` via `GET /v1/status`. Clients fetch lazily, cache via `atomic.Int64`, and only consume the once-guard on a successful response so transient warm failures retry rather than getting stuck on the local fallback.
- FUSE `Dat9FS.Init` synchronously warms with a bounded timeout (`inlineThresholdWarmTimeout = 5s`, var-overridable for tests) so the very first Create/Write/Flush/commit-queue decision sees the negotiated value. Hot paths use `CachedSmallFileThreshold()` and never trigger network I/O.
- CLI: `NewFromEnv` stays cold; only `cp` / `sh` use `NewFromEnvWithWarm` so read-only commands (ls/cat/stat/rm/grep/find) don't pay an extra RTT.

## Why one threshold, not two

Splitting into `DBInlineThreshold` (DB vs S3) and `DirectPutThreshold` (simple PUT vs V2 multipart) is tempting for performance, but with the current simple-PUT path it would re-introduce the server as a data-plane proxy: bodies above the inline cutoff would have to flow through the server process and `PutObject` to S3. The V2 multipart protocol exists specifically to avoid that. Keeping the two decisions tied means raising the threshold has predictable cost (TiDB blob column growth, not server bandwidth + memory). Documented inline at `pkg/backend/dat9.go`.

## Backwards compatibility

- **Reads**: completely unaffected. `ReadPlanCtx` consults persisted `StorageType` metadata, never the threshold. Files written under any threshold remain readable by any client.
- **Old client + new (higher) server threshold**: ✓ — old client still writes >50KB via V2 multipart; server accepts and stores in S3. No correctness issue, just foregoes some perf.
- **New client + old server (no `inline_threshold` field)**: ✓ — client falls back to compiled `DefaultSmallFileThreshold = 50_000`.
- **Transient warm failure (5xx, timeout)**: ✓ — failure doesn't consume the once-guard; next call (e.g. when server recovers) refetches.

## Test plan

- [x] `go test ./pkg/backend/ ./pkg/server/ ./pkg/client/ ./pkg/fuse/ -count=1`
- [x] `go test ./pkg/client/ ./pkg/fuse/ -count=1 -race` (atomic cache, no goroutine race)
- [x] New tests:
  - `TestConfigurableInlineThreshold` — backend `Options.InlineThreshold` / `TextExtractMaxBytes` propagation across `shouldStoreInDB` / `IsLargeFile` / `extractText`, including 0/negative fallback.
  - `TestTenantStatusReturnsInlineThreshold` — `/v1/status` echoes configured value.
  - `TestSmallFileThresholdCachesFromServer` / `FallsBackWhenServerOmits` / `LookupFailureCachesZero` / `CachedSmallFileThresholdDoesNotFetch` / `OverrideShortCircuits` / `ConcurrentReadersAreRaceFree` — client cache semantics.
  - `TestInitSynchronouslyWarmsInlineThreshold` / `TestInitWarmTimeoutFallsBackToDefault` — FUSE Init blocks on warm with bounded timeout, falls back cleanly on stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server exposes a configurable inline-threshold via status; clients can warm and cache it.
  * New environment variables to configure inline threshold and text-extract max bytes.
  * Filesystem mount path performs an optional warmup to adopt server upload behavior.

* **Improvements**
  * Upload/read/write decisions now honor negotiated thresholds with sensible fallbacks for safer direct PUT vs multipart.

* **Tests**
  * Extensive tests added for negotiation, caching, warmup, thresholds, and boundary behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->