### PR TITLE
fix(fuse): improve unmount UX on Ctrl+C and re-mount safety

### DIFF
--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -170,6 +170,42 @@ func (cq *CommitQueue) Pending() int {
 	return len(cq.queue)
 }
 
+// PendingStats returns the number of unique pending entries and the sum
+// of their sizes. Used by unmount to display drain progress.
+//
+// Subtleties:
+//  1. In-flight entries remain in cq.queue until the worker calls
+//     removeFromQueue() *after* cleanup (see line 692). The same
+//     *CommitEntry pointer is stored in both cq.queue and cq.inFlight
+//     during that window.
+//  2. Enqueue does NOT dedupe by Path (line 153 just appends). A path
+//     written + closed twice yields two distinct entries with the same
+//     Path string but different pointers.
+//
+// We dedupe by entry pointer: collapses (1) without collapsing (2).
+func (cq *CommitQueue) PendingStats() (count int, bytes int64) {
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	seen := make(map[*CommitEntry]struct{}, len(cq.queue))
+	for _, e := range cq.queue {
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		count++
+		bytes += e.Size
+	}
+	for _, e := range cq.inFlight {
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		count++
+		bytes += e.Size
+	}
+	return
+}
+
 // IsFull reports whether the queue has reached its backpressure limit.
 func (cq *CommitQueue) IsFull() bool {
 	cq.mu.Lock()

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -347,22 +347,100 @@ func Mount(opts *MountOptions) error {
 
 	shutdown := newMountShutdown(sseWatcher.Stop, dat9fs.FlushAll)
 
-	// Signal handling for graceful shutdown
-	sigCh := make(chan os.Signal, 1)
+	// Signal handling for graceful shutdown.
+	//
+	// First SIGINT/SIGTERM:
+	//   1. Start a progress reporter goroutine that prints commit-queue
+	//      depth every 2s so the user knows we're not hung.
+	//   2. Call shutdown() — flushes open fds, drains commit queue.
+	//   3. Retry server.Unmount() up to 5 times (EBUSY is transient).
+	//   4. Fall back to forceUnmount on retry exhaustion.
+	//
+	// Second SIGINT/SIGTERM during step 1-3:
+	//   - Tell the user how much work is being abandoned (count + bytes).
+	//   - Surface where local state is preserved so they can recover or
+	//     inspect it. Do NOT promise automatic resume — recovery is
+	//     best-effort: ShadowSpill (large) files take the terminal-failure
+	//     branch on conflict (commit_queue.go:716-722) to avoid OOMing
+	//     during full-file byte comparison.
+	//   - forceUnmount the mountpoint so re-mount doesn't fail with
+	//     "Permission denied" (the FUSE endpoint must be released).
+	//   - Exit with code 1.
+	//
+	// Buffer size 2: outer goroutine consumes the first signal, inner
+	// goroutine the second. Buffer ≥ 2 ensures signals delivered between
+	// the outer's <-sigCh return and the inner goroutine being scheduled
+	// don't get dropped by signal.Notify.
+	//
+	// Headless/daemon limitation: if shutdown() blocks indefinitely on a
+	// stuck commit-queue worker (no context cancellation), an interactive
+	// user can press Ctrl+C twice; daemon operators must send a second
+	// SIGTERM (e.g. via systemd's TimeoutStopSec) to trigger force-quit.
+	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		<-sigCh
 		fmt.Fprintf(os.Stderr, "\ndrive9: unmounting %s...\n", opts.MountPoint)
 
-		// Second Ctrl+C during unmount exits immediately.
+		// Periodic progress reporter — stops when progressDone is closed.
+		// Distinguishes commit-queue uploads (where we have stats) from
+		// other drain phases (debouncer flush, per-fd flush, write-back
+		// drain) so users don't see "still uploading 0 files" and assume
+		// the process is hung.
+		progressDone := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(2 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-progressDone:
+					return
+				case <-ticker.C:
+					var n int
+					var b int64
+					if dat9fs.commitQueue != nil {
+						n, b = dat9fs.commitQueue.PendingStats()
+					}
+					if n > 0 {
+						fmt.Fprintf(os.Stderr,
+							"drive9: still uploading %d files (%s) — Ctrl+C again to force-quit\n",
+							n, humanizeBytes(b))
+					} else {
+						fmt.Fprintf(os.Stderr,
+							"drive9: still draining — Ctrl+C again to force-quit\n")
+					}
+				}
+			}
+		}()
+
+		// Forced-exit handler for the second signal.
 		go func() {
 			<-sigCh
-			fmt.Fprintf(os.Stderr, "drive9: forced exit\n")
+			n, b := 0, int64(0)
+			if dat9fs.commitQueue != nil {
+				n, b = dat9fs.commitQueue.PendingStats()
+			}
+			if n > 0 {
+				stateLoc := cacheBase
+				if stateLoc == "" {
+					stateLoc = "<cache disabled>"
+				}
+				fmt.Fprintf(os.Stderr,
+					"drive9: force-quit — abandoning %d files (%s); local state preserved in %s, but recovery is best-effort\n",
+					n, humanizeBytes(b), stateLoc)
+			} else {
+				fmt.Fprintf(os.Stderr, "drive9: force-quit\n")
+			}
+			forceUnmount(opts.MountPoint)
+			if pidFile != "" {
+				_ = os.Remove(pidFile)
+			}
 			os.Exit(1)
 		}()
 
 		shutdown()
+		close(progressDone)
 
 		// Retry unmount up to 5 times — EBUSY is transient (Spotlight, Finder).
 		const maxRetries = 5
@@ -400,23 +478,53 @@ func newMountShutdown(stopWatcher func(), flushAll func()) func() {
 }
 
 // forceUnmount shells out to OS-specific tools to force-unmount a FUSE mount.
+// Uses a 5-second timeout so that the forced-exit path can't itself hang
+// on a wedged FUSE endpoint.
 func forceUnmount(mountpoint string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	var cmd *exec.Cmd
 	if runtime.GOOS == "darwin" {
-		cmd = exec.Command("diskutil", "unmount", "force", mountpoint)
+		cmd = exec.CommandContext(ctx, "diskutil", "unmount", "force", mountpoint)
 	} else {
-		// Linux: try fusermount first, fall back to umount -l.
-		if _, err := exec.LookPath("fusermount"); err == nil {
-			cmd = exec.Command("fusermount", "-u", mountpoint)
+		// Linux: prefer fusermount3 (fuse3, default on Ubuntu 22.04+ /
+		// Debian 12+), then fusermount, then umount -l.
+		if _, err := exec.LookPath("fusermount3"); err == nil {
+			cmd = exec.CommandContext(ctx, "fusermount3", "-u", mountpoint)
+		} else if _, err := exec.LookPath("fusermount"); err == nil {
+			cmd = exec.CommandContext(ctx, "fusermount", "-u", mountpoint)
 		} else {
-			cmd = exec.Command("umount", "-l", mountpoint)
+			cmd = exec.CommandContext(ctx, "umount", "-l", mountpoint)
 		}
 	}
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "drive9: force unmount failed: %v\n", err)
+		if ctx.Err() == context.DeadlineExceeded {
+			fmt.Fprintf(os.Stderr, "drive9: force unmount timed out after 5s\n")
+		} else {
+			fmt.Fprintf(os.Stderr, "drive9: force unmount failed: %v\n", err)
+		}
 	}
+}
+
+// humanizeBytes formats a byte count as a human-readable string (e.g. "1.5 MB").
+// Uses 1024-base (matches du -h, df -h, kernel reporting).
+func humanizeBytes(b int64) string {
+	if b < 0 {
+		b = 0
+	}
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
 }
 
 // generateMountID creates a random 16-byte hex ID for this mount instance.


### PR DESCRIPTION
## Problem

Three issues on `drive9 mount` shutdown that compounded into a bad user experience:

1. **First Ctrl+C looked hung.** `shutdown()` drains the commit queue and flushes open fds with no progress output. Users assumed the process was stuck and pressed Ctrl+C again.
2. **Second Ctrl+C corrupted the mountpoint.** The forced-exit path called `os.Exit(1)` without `forceUnmount`, leaving the FUSE endpoint registered with the kernel. Re-mounting the same path returned `fusermount3: failed to access mountpoint: Permission denied`.
3. **`forceUnmount` preferred `fusermount` over `fusermount3`.** On fuse3 systems (Ubuntu 22.04+, Debian 12+) it picked the wrong binary.

## Changes

### `CommitQueue.PendingStats()` (new, read-only)
Returns `(count, bytes)` of pending uploads, deduped by entry pointer. Two subtleties motivate pointer-dedup:
- An in-flight entry stays in `cq.queue` until cleanup runs (`commit_queue.go:692`), so the same `*CommitEntry` lives in both `cq.queue` and `cq.inFlight`.
- `Enqueue` does not dedupe by `Path` (`commit_queue.go:153`), so a path written + closed twice yields two distinct entries with the same Path string.

### Signal handler refactor (`mount.go`)
- `sigCh` buffer 1 → 2 to avoid dropping a second signal that arrives between the outer goroutine's read and the inner goroutine being scheduled.
- Periodic progress reporter prints every 2s during shutdown, distinguishing commit-queue uploads (with file count + bytes) from other drain phases (debouncer flush, per-fd flush, write-back drain). No more silent waits.
- Forced-exit path calls `forceUnmount` and removes the pid file before `os.Exit(1)`, so re-mount of the same path succeeds.
- Forced-exit message surfaces local cache location but **does not promise automatic resume on next mount** — ShadowSpill files take a terminal-failure branch on conflict (`commit_queue.go:716-722`) to avoid OOMing during full-file byte comparison, so recovery is best-effort.
- Comment documents the headless/daemon limitation: `shutdown()` has no context cancellation, so a stuck worker can block indefinitely. Daemon operators must send a second SIGTERM (e.g. via systemd's `TimeoutStopSec`) to trigger force-quit.

### `forceUnmount` hardening
- 5s timeout via `exec.CommandContext` so the forced-exit path can't hang on a wedged FUSE endpoint.
- Linux: prefer `fusermount3` → `fusermount` → `umount -l` (matches `cmd/drive9/cli/mount.go:457` `umountArgv()`).

### `humanizeBytes` helper
Small helper for "1.5 MB" formatting. No existing helper in the repo.

## Sample output

First Ctrl+C, busy commit queue:
```
^C
drive9: unmounting /home/ubuntu/w4...
drive9: still uploading 17 files (43.2 MB) — Ctrl+C again to force-quit
drive9: still uploading 9 files (21.0 MB) — Ctrl+C again to force-quit
drive9: still draining — Ctrl+C again to force-quit
```

Second Ctrl+C while uploads pending:
```
drive9: force-quit — abandoning 9 files (21.0 MB); local state preserved in /home/ubuntu/.cache/drive9, but recovery is best-effort
```

## Non-changes
- No data-path changes
- No public API changes (`PendingStats` is additive)
- No test changes (existing tests still pass)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/fuse/` (full suite, 9.1s)
- [ ] Manual: mount, write 100 × 10 MB files, Ctrl+C once → expect periodic progress every 2s, then clean unmount
- [ ] Manual: same setup, Ctrl+C twice → expect force-quit message naming abandoned files + cache dir; then `drive9 mount` of the same path succeeds without "Permission denied"
- [ ] Manual on fuse3 host (Ubuntu 22.04): verify `fusermount3` is used by `forceUnmount` (check via `strace -e execve` or by removing `fusermount` only)

## Follow-ups (not in this PR)
- Same `buffer=1` signal pattern exists in `vault_mount.go` and `mount_webdav.go` (consistency)
- Per-fd flush phase has no progress output (needs hooks in `Dat9FS.FlushAll`)
- Streamer-fallback memory issue (`OnPartFull` in normal path doesn't evict `wb.parts`) — separate issue, original PR-2 proposal was withdrawn after review identified data-loss bugs in the naive fix
- Headless/daemon: real fix is context cancellation in `CommitQueue.DrainAll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress reporting during graceful shutdown displays upload/drain status
  * Force shutdown now reports remaining work and local state preservation location

* **Bug Fixes**
  * Enhanced unmount handling with timeout protection
  * Improved shutdown signal handling reliability
  * Better byte count display formatting

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/412)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->