### PR TITLE
Refactor metrics instrumentation and observability dashboards

### DIFF
--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -1,0 +1,32 @@
+# Drive9 Grafana Dashboards
+
+This directory uses a three-bucket layout instead of a single mega dashboard.
+
+## 1. Overview dashboards
+
+- `drive9-service-health-dashboard.json`: first-stop dashboard for service incidents, module availability, HTTP health, service error ratio, and coarse DB pressure.
+- `drive9-async-fuse-dashboard.json`: first-stop dashboard for delayed background work and mount-path incidents, especially semantic worker backlog, image/audio extraction runtime, audio extract failures, and FUSE remote behavior.
+
+## 2. Request-path drill-down dashboards
+
+- `drive9-api-surface-dashboard.json`: non-FS and non-upload API request-path analysis for control, vault, SQL, events, and auxiliary HTTP surfaces.
+- `drive9-filesystem-path-dashboard.json`: filesystem-path analysis that owns `/v1/fs/*`, correlates HTTP traffic with `fs_*` backend work, and now includes explicit WebDAV behavior.
+- `drive9-upload-path-dashboard.json`: upload-path analysis that owns upload flows and correlates upload HTTP traffic, backend upload operations, and upload-related events.
+- `drive9-upload-s3-path-dashboard.json`: upload plus raw object-store analysis for incidents that have narrowed from upload symptoms into `s3client` throughput, errors, or latency.
+
+## 3. Data-store drill-down dashboards
+
+- `drive9-metadata-db-dashboard.json`: metadata/control-plane DB analysis that owns `role="meta"`.
+- `drive9-tenant-data-db-dashboard.json`: tenant data-path DB analysis that owns `role="user"`.
+
+## Operating rule
+
+Start from an overview dashboard. Only move into drill-down dashboards after the incident shape is clear.
+
+Dashboard links are embedded in the overview and drill-down dashboards so the normal workflow is clickable inside Grafana rather than document-only.
+
+We intentionally do not keep a single all-in-one observability dashboard anymore. The split is:
+
+- Overview dashboards answer `is the system healthy and where is the blast radius?`
+- Request-path dashboards answer `which API or business path is slow or failing?`
+- Data-store dashboards answer `is the database the limiting factor?`

--- a/docs/grafana/drive9-api-surface-dashboard.json
+++ b/docs/grafana/drive9-api-surface-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Data-store drill-down dashboard that owns database role=user, focused on Drive9 tenant-serving query behavior.",
+  "description": "Request-path drill-down dashboard for non-FS and non-upload Drive9 APIs, focused on control, vault, SQL, events, and auxiliary HTTP surfaces.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -31,6 +31,17 @@
       "title": "Service Health Overview",
       "type": "link",
       "url": "/d/drive9-service-health"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Async And FUSE Overview",
+      "type": "link",
+      "url": "/d/drive9-async-fuse"
     }
   ],
   "liveNow": false,
@@ -44,7 +55,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Tenant Data DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure on tenant-serving queries rather than control-plane metadata traffic. This dashboard owns database role=`user` and should be preferred whenever the bottleneck looks data-path rather than control-plane. Operation latency and throughput panels can be filtered by `tenant_id`. Pool panels remain shared because they come from the process-wide `sql.DB` pool rather than tenant-scoped accounting.",
+        "content": "# API Surface Performance\n\nCategory: request-path drill-down.\n\nUse this after an overview dashboard shows an HTTP-facing problem outside the FS and upload paths. This dashboard is intentionally scoped to control, vault, SQL, events, and auxiliary HTTP routes so it does not duplicate the dedicated FS and upload dashboards. It answers which routes are hot, which are slow, and whether latency coincides with inflight buildup or error spikes.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -71,15 +82,15 @@
               },
               {
                 "color": "orange",
-                "value": 0.05
+                "value": 100
               },
               {
                 "color": "red",
-                "value": 0.25
+                "value": 300
               }
             ]
           },
-          "unit": "s"
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -110,12 +121,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p95",
+          "expr": "sum(rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval]))",
+          "legendFormat": "http_rps",
           "refId": "A"
         }
       ],
-      "title": "User DB P95",
+      "title": "HTTP RPS",
       "type": "stat"
     },
     {
@@ -177,12 +188,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p99",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval])))",
+          "legendFormat": "http_p95",
           "refId": "A"
         }
       ],
-      "title": "User DB P99",
+      "title": "HTTP P95",
       "type": "stat"
     },
     {
@@ -205,15 +216,15 @@
               },
               {
                 "color": "orange",
-                "value": 1
+                "value": 0.5
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 2
               }
             ]
           },
-          "unit": "ops"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -244,12 +255,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "user_waits",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval])))",
+          "legendFormat": "http_p99",
           "refId": "A"
         }
       ],
-      "title": "User Waits /s",
+      "title": "HTTP P99",
       "type": "stat"
     },
     {
@@ -272,15 +283,15 @@
               },
               {
                 "color": "orange",
-                "value": 0.7
+                "value": 20
               },
               {
                 "color": "red",
-                "value": 0.9
+                "value": 100
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -311,12 +322,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"user\",state=\"max_open\"}), 1)",
-          "legendFormat": "user_utilization",
+          "expr": "dat9_http_inflight_requests",
+          "legendFormat": "inflight",
           "refId": "A"
         }
       ],
-      "title": "User Utilization",
+      "title": "Inflight Requests",
       "type": "stat"
     },
     {
@@ -339,15 +350,15 @@
               },
               {
                 "color": "orange",
-                "value": 1
+                "value": 0.01
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 0.05
               }
             ]
           },
-          "unit": "short"
+          "unit": "percentunit"
         },
         "overrides": []
       },
@@ -378,12 +389,79 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"open\"})",
-          "legendFormat": "user_open",
+          "expr": "sum(rate(dat9_http_requests_total{route=~\"$route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "http_5xx_ratio",
           "refId": "A"
         }
       ],
-      "title": "Open Connections",
+      "title": "HTTP 5xx Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dat9_http_requests_total{route=~\"$route\",status=~\"4..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "http_4xx_ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP 4xx Ratio",
       "type": "stat"
     },
     {
@@ -402,7 +480,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 0,
         "y": 8
@@ -425,12 +503,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
-          "legendFormat": "{{operation}} / {{result}}",
+          "expr": "topk(12, sum by (route) (rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval])))",
+          "legendFormat": "{{route}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Operation Throughput",
+      "title": "Top Routes By Throughput",
       "type": "timeseries"
     },
     {
@@ -449,7 +527,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 12,
         "y": 8
@@ -472,8 +550,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p95",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval]))))",
+          "legendFormat": "{{route}} p95",
           "refId": "A"
         },
         {
@@ -481,12 +559,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p99",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval]))))",
+          "legendFormat": "{{route}} p99",
           "refId": "B"
         }
       ],
-      "title": "User DB Tail Latency",
+      "title": "Route Latency P95 / P99",
       "type": "timeseries"
     },
     {
@@ -500,21 +578,21 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "short"
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 18
       },
       "id": 13,
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "list",
+          "displayMode": "table",
           "placement": "bottom"
         },
         "tooltip": {
@@ -528,12 +606,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (state) (dat9_db_pool_connections{role=\"user\"})",
-          "legendFormat": "{{state}}",
+          "expr": "sum by (status) (rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval]))",
+          "legendFormat": "status={{status}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Pool Connections",
+      "title": "HTTP Status Mix",
       "type": "timeseries"
     },
     {
@@ -547,40 +625,15 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "short"
+          "unit": "ops"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "wait_seconds_rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "wait_count_rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ops"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 18
       },
       "id": 14,
       "options": {
@@ -600,8 +653,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"user\"}[$__rate_interval])",
-          "legendFormat": "wait_seconds_rate",
+          "expr": "topk(12, sum by (route, status) (rate(dat9_http_requests_total{route=~\"$route\",status!~\"2..|3..\"}[$__rate_interval])))",
+          "legendFormat": "{{route}} / {{status}}",
           "refId": "A"
         },
         {
@@ -609,153 +662,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval])",
-          "legendFormat": "wait_count_rate",
+          "expr": "dat9_http_inflight_requests",
+          "legendFormat": "inflight",
           "refId": "B"
         }
       ],
-      "title": "User DB Wait Pressure",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "{{reason}}",
-          "refId": "A"
-        }
-      ],
-      "title": "User DB Pool Close Reasons",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 32
-      },
-      "id": 16,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} qps",
-          "refId": "A"
-        }
-      ],
-      "title": "Top Tenants By User DB QPS",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 32
-      },
-      "id": 17,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
-          "legendFormat": "{{tenant_id}} p95",
-          "refId": "A"
-        }
-      ],
-      "title": "Top Tenants By User DB P95",
+      "title": "Error Routes And Inflight",
       "type": "timeseries"
     }
   ],
@@ -763,8 +675,8 @@
   "schemaVersion": 41,
   "tags": [
     "drive9",
-    "data-store",
-    "user-db",
+    "api",
+    "control-plane",
     "performance",
     "grafana",
     "prometheus"
@@ -789,7 +701,7 @@
         "type": "datasource"
       },
       {
-        "allValue": ".*",
+        "allValue": "/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*",
         "current": {
           "selected": true,
           "text": "All",
@@ -799,38 +711,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "definition": "label_values(dat9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
         "hide": 0,
         "includeAll": true,
-        "label": "DB Operation",
+        "label": "API Route",
         "multi": true,
-        "name": "db_operation",
+        "name": "route",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Tenant ID",
-        "multi": true,
-        "name": "tenant_id",
-        "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
+        "query": "label_values(dat9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -844,8 +732,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 Tenant Data DB Performance",
-  "uid": "drive9-user-db-performance",
+  "title": "Drive9 API Surface Performance",
+  "uid": "drive9-api-surface",
   "version": 1,
   "weekStart": ""
 }

--- a/docs/grafana/drive9-api-surface-dashboard.json
+++ b/docs/grafana/drive9-api-surface-dashboard.json
@@ -322,7 +322,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_http_inflight_requests",
+          "expr": "sum(dat9_http_inflight_requests{route=~\"$route\"})",
           "legendFormat": "inflight",
           "refId": "A"
         }
@@ -662,7 +662,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_http_inflight_requests",
+          "expr": "sum(dat9_http_inflight_requests{route=~\"$route\"})",
           "legendFormat": "inflight",
           "refId": "B"
         }

--- a/docs/grafana/drive9-async-fuse-dashboard.json
+++ b/docs/grafana/drive9-async-fuse-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Data-store drill-down dashboard that owns database role=user, focused on Drive9 tenant-serving query behavior.",
+  "description": "Overview dashboard: first stop for Drive9 delayed-work and mount-path incidents, with an alarm-biased first screen for backlog, dead letters, remote errors, and remote latency.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -31,6 +31,28 @@
       "title": "Service Health Overview",
       "type": "link",
       "url": "/d/drive9-service-health"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Upload Path Drill-Down",
+      "type": "link",
+      "url": "/d/drive9-upload-path"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Filesystem Path Drill-Down",
+      "type": "link",
+      "url": "/d/drive9-filesystem-path"
     }
   ],
   "liveNow": false,
@@ -44,7 +66,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Tenant Data DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure on tenant-serving queries rather than control-plane metadata traffic. This dashboard owns database role=`user` and should be preferred whenever the bottleneck looks data-path rather than control-plane. Operation latency and throughput panels can be filtered by `tenant_id`. Pool panels remain shared because they come from the process-wide `sql.DB` pool rather than tenant-scoped accounting.",
+        "content": "# Drive9 Async And FUSE\n\nCategory: overview.\n\nUse this when the incident is not on the front-door HTTP path but in delayed work or the mount path. The first row is intentionally alarm-biased: semantic backlog, dead letters, FUSE remote error ratio, and FUSE remote latency. The second row is organized as two narrowing paths: worker state on the left and per-operation FUSE latency on the right. The bottom row is for media extraction: image runtime capacity first, then audio extract process results and tail latency. If the issue reduces to a specific FUSE or upload path, continue into the request-path drill-down dashboards.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -71,11 +93,11 @@
               },
               {
                 "color": "orange",
-                "value": 0.05
+                "value": 60
               },
               {
                 "color": "red",
-                "value": 0.25
+                "value": 300
               }
             ]
           },
@@ -85,7 +107,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
+        "w": 6,
         "x": 0,
         "y": 4
       },
@@ -110,12 +132,146 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p95",
+          "expr": "dat9_service_gauge{component=\"semantic_worker\",name=\"queue_lag_seconds\"}",
+          "legendFormat": "queue_lag_seconds",
           "refId": "A"
         }
       ],
-      "title": "User DB P95",
+      "title": "Semantic Queue Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 4
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dat9_service_gauge{component=\"semantic_worker\",name=\"dead_lettered\"}",
+          "legendFormat": "dead_lettered",
+          "refId": "A"
+        }
+      ],
+      "title": "Semantic Dead Lettered",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dat9_fuse_remote_operations_total{result=\"error\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_fuse_remote_operations_total[$__rate_interval])), 0.000001)",
+          "legendFormat": "fuse_remote_error_ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "FUSE Remote Error Ratio",
       "type": "stat"
     },
     {
@@ -152,142 +308,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 4,
-        "y": 4
-      },
-      "id": 2,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p99",
-          "refId": "A"
-        }
-      ],
-      "title": "User DB P99",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 8,
-        "y": 4
-      },
-      "id": 3,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "user_waits",
-          "refId": "A"
-        }
-      ],
-      "title": "User Waits /s",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0.7
-              },
-              {
-                "color": "red",
-                "value": 0.9
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 12,
+        "w": 6,
+        "x": 18,
         "y": 4
       },
       "id": 4,
@@ -311,12 +333,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"user\",state=\"max_open\"}), 1)",
-          "legendFormat": "user_utilization",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_fuse_remote_operation_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "fuse_remote_p95",
           "refId": "A"
         }
       ],
-      "title": "User Utilization",
+      "title": "FUSE Remote P95",
       "type": "stat"
     },
     {
@@ -327,50 +349,30 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
           "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 4
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
       },
       "id": 5,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
         },
-        "textMode": "auto"
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -378,13 +380,78 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"open\"})",
-          "legendFormat": "user_open",
+          "expr": "dat9_service_gauge{component=\"semantic_worker\",name=~\"inflight|queued|processing|dead_lettered\"}",
+          "legendFormat": "semantic_worker {{name}}",
           "refId": "A"
         }
       ],
-      "title": "Open Connections",
-      "type": "stat"
+      "title": "Semantic Worker State",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dat9_service_gauge{component=\"semantic_worker\",name=\"queue_lag_seconds\"}",
+          "legendFormat": "semantic_worker queue_lag_seconds",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dat9_service_gauge{component=\"image_extract\",name=~\"workers|queue_capacity|queue_depth\"}",
+          "legendFormat": "image_extract {{name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dat9_service_gauge{component=\"audio_extract\",name=~\"task_timeout_seconds|max_audio_bytes|max_extract_text_bytes\"}",
+          "legendFormat": "audio_extract {{name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Media Extract Runtime",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -405,9 +472,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 16
       },
-      "id": 11,
+      "id": 7,
       "options": {
         "legend": {
           "calcs": [],
@@ -425,12 +492,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
-          "legendFormat": "{{operation}} / {{result}}",
+          "expr": "sum by (operation, result) (rate(dat9_fuse_remote_operations_total[$__rate_interval]))",
+          "legendFormat": "{{operation}} {{result}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Operation Throughput",
+      "title": "FUSE Remote Operations",
       "type": "timeseries"
     },
     {
@@ -454,7 +521,7 @@
         "x": 12,
         "y": 8
       },
-      "id": 12,
+      "id": 8,
       "options": {
         "legend": {
           "calcs": [],
@@ -472,149 +539,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p95",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p99",
-          "refId": "B"
-        }
-      ],
-      "title": "User DB Tail Latency",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
-      "id": 13,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum by (state) (dat9_db_pool_connections{role=\"user\"})",
-          "legendFormat": "{{state}}",
+          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(dat9_fuse_remote_operation_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{operation}} remote_p95",
           "refId": "A"
         }
       ],
-      "title": "User DB Pool Connections",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "wait_seconds_rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "wait_count_rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ops"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"user\"}[$__rate_interval])",
-          "legendFormat": "wait_seconds_rate",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval])",
-          "legendFormat": "wait_count_rate",
-          "refId": "B"
-        }
-      ],
-      "title": "User DB Wait Pressure",
+      "title": "FUSE Remote P95 By Operation",
       "type": "timeseries"
     },
     {
@@ -634,11 +564,11 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 24
       },
-      "id": 15,
+      "id": 9,
       "options": {
         "legend": {
           "calcs": [],
@@ -656,59 +586,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "{{reason}}",
+          "expr": "sum by (result) (rate(dat9_service_operations_total{component=\"audio_extract\",operation=\"process\"}[$__rate_interval]))",
+          "legendFormat": "audio_extract {{result}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Pool Close Reasons",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 32
-      },
-      "id": 16,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} qps",
-          "refId": "A"
-        }
-      ],
-      "title": "Top Tenants By User DB QPS",
+      "title": "Audio Extract Process Results",
       "type": "timeseries"
     },
     {
@@ -730,9 +613,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 24
       },
-      "id": 17,
+      "id": 10,
       "options": {
         "legend": {
           "calcs": [],
@@ -750,12 +633,21 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
-          "legendFormat": "{{tenant_id}} p95",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{component=\"audio_extract\",operation=\"process\"}[$__rate_interval])))",
+          "legendFormat": "audio_extract p95",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{component=\"audio_extract\",operation=\"process\"}[$__rate_interval])))",
+          "legendFormat": "audio_extract p99",
+          "refId": "B"
         }
       ],
-      "title": "Top Tenants By User DB P95",
+      "title": "Audio Extract Tail Latency",
       "type": "timeseries"
     }
   ],
@@ -763,9 +655,9 @@
   "schemaVersion": 41,
   "tags": [
     "drive9",
-    "data-store",
-    "user-db",
-    "performance",
+    "async",
+    "fuse",
+    "observability",
     "grafana",
     "prometheus"
   ],
@@ -787,54 +679,6 @@
         "refresh": 1,
         "regex": "",
         "type": "datasource"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "DB Operation",
-        "multi": true,
-        "name": "db_operation",
-        "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Tenant ID",
-        "multi": true,
-        "name": "tenant_id",
-        "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "type": "query"
       }
     ]
   },
@@ -844,8 +688,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 Tenant Data DB Performance",
-  "uid": "drive9-user-db-performance",
+  "title": "Drive9 Async And FUSE",
+  "uid": "drive9-async-fuse",
   "version": 1,
   "weekStart": ""
 }

--- a/docs/grafana/drive9-async-fuse-dashboard.json
+++ b/docs/grafana/drive9-async-fuse-dashboard.json
@@ -354,7 +354,36 @@
           "mappings": [],
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "audio_extract (max_audio_bytes|max_extract_text_bytes)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "(semantic_worker queue_lag_seconds|audio_extract task_timeout_seconds)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,

--- a/docs/grafana/drive9-filesystem-path-dashboard.json
+++ b/docs/grafana/drive9-filesystem-path-dashboard.json
@@ -322,7 +322,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 1)",
+          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "fs_5xx_ratio",
           "refId": "A"
         }

--- a/docs/grafana/drive9-filesystem-path-dashboard.json
+++ b/docs/grafana/drive9-filesystem-path-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Data-store drill-down dashboard that owns database role=user, focused on Drive9 tenant-serving query behavior.",
+  "description": "Request-path drill-down dashboard for the Drive9 filesystem path, correlating /v1/fs HTTP requests with backend fs_* work.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -31,6 +31,17 @@
       "title": "Service Health Overview",
       "type": "link",
       "url": "/d/drive9-service-health"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Async And FUSE Overview",
+      "type": "link",
+      "url": "/d/drive9-async-fuse"
     }
   ],
   "liveNow": false,
@@ -44,7 +55,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Tenant Data DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure on tenant-serving queries rather than control-plane metadata traffic. This dashboard owns database role=`user` and should be preferred whenever the bottleneck looks data-path rather than control-plane. Operation latency and throughput panels can be filtered by `tenant_id`. Pool panels remain shared because they come from the process-wide `sql.DB` pool rather than tenant-scoped accounting.",
+        "content": "# Filesystem Path Performance\n\nCategory: request-path drill-down.\n\nUse this when the incident is clearly on the filesystem path. This dashboard owns the `/v1/fs/*` path and should be preferred over the generic API surface dashboard for filesystem symptoms. It combines HTTP `/v1/fs/*` traffic with backend `fs_*` service operations so you can separate front-door symptoms from internal work.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -71,15 +82,15 @@
               },
               {
                 "color": "orange",
-                "value": 0.05
+                "value": 20
               },
               {
                 "color": "red",
-                "value": 0.25
+                "value": 100
               }
             ]
           },
-          "unit": "s"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -110,12 +121,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p95",
+          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "legendFormat": "fs_rps",
           "refId": "A"
         }
       ],
-      "title": "User DB P95",
+      "title": "FS HTTP RPS",
       "type": "stat"
     },
     {
@@ -177,12 +188,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p99",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
+          "legendFormat": "http_p95",
           "refId": "A"
         }
       ],
-      "title": "User DB P99",
+      "title": "FS HTTP P95",
       "type": "stat"
     },
     {
@@ -205,15 +216,15 @@
               },
               {
                 "color": "orange",
-                "value": 1
+                "value": 0.1
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 0.5
               }
             ]
           },
-          "unit": "ops"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -244,12 +255,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "user_waits",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval])))",
+          "legendFormat": "svc_p95",
           "refId": "A"
         }
       ],
-      "title": "User Waits /s",
+      "title": "FS Service P95",
       "type": "stat"
     },
     {
@@ -272,11 +283,11 @@
               },
               {
                 "color": "orange",
-                "value": 0.7
+                "value": 0.01
               },
               {
                 "color": "red",
-                "value": 0.9
+                "value": 0.05
               }
             ]
           },
@@ -311,12 +322,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"user\",state=\"max_open\"}), 1)",
-          "legendFormat": "user_utilization",
+          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 1)",
+          "legendFormat": "fs_5xx_ratio",
           "refId": "A"
         }
       ],
-      "title": "User Utilization",
+      "title": "FS 5xx Ratio",
       "type": "stat"
     },
     {
@@ -339,11 +350,11 @@
               },
               {
                 "color": "orange",
-                "value": 1
+                "value": 20
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 100
               }
             ]
           },
@@ -378,12 +389,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"open\"})",
-          "legendFormat": "user_open",
+          "expr": "sum(dat9_http_inflight_requests{route=~\"$http_route\"})",
+          "legendFormat": "fs_inflight",
           "refId": "A"
         }
       ],
-      "title": "Open Connections",
+      "title": "FS HTTP Inflight",
       "type": "stat"
     },
     {
@@ -397,7 +408,7 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "ops"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -425,12 +436,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
-          "legendFormat": "{{operation}} / {{result}}",
+          "expr": "sum by (route, method) (rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "legendFormat": "{{method}} {{route}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Operation Throughput",
+      "title": "FS Route Throughput",
       "type": "timeseries"
     },
     {
@@ -472,8 +483,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p95",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route, method) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
+          "legendFormat": "{{method}} {{route}} p95",
           "refId": "A"
         },
         {
@@ -481,12 +492,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p99",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route, method) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
+          "legendFormat": "{{method}} {{route}} p99",
           "refId": "B"
         }
       ],
-      "title": "User DB Tail Latency",
+      "title": "FS Route Tail Latency",
       "type": "timeseries"
     },
     {
@@ -500,7 +511,7 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "short"
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -528,12 +539,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (state) (dat9_db_pool_connections{role=\"user\"})",
-          "legendFormat": "{{state}}",
+          "expr": "sum by (operation, result) (rate(dat9_service_operations_total{operation=~\"$service_operation\"}[$__rate_interval]))",
+          "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Pool Connections",
+      "title": "FS Service Throughput",
       "type": "timeseries"
     },
     {
@@ -547,34 +558,9 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "short"
+          "unit": "s"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "wait_seconds_rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "wait_count_rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ops"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -600,8 +586,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"user\"}[$__rate_interval])",
-          "legendFormat": "wait_seconds_rate",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
+          "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
         {
@@ -609,12 +595,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval])",
-          "legendFormat": "wait_count_rate",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
+          "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
       ],
-      "title": "User DB Wait Pressure",
+      "title": "FS Service Tail Latency",
       "type": "timeseries"
     },
     {
@@ -628,7 +614,7 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "ops"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -656,12 +642,21 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "{{reason}}",
+          "expr": "sum by (status) (rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dat9_http_inflight_requests{route=~\"$http_route\"})",
+          "legendFormat": "inflight",
+          "refId": "B"
         }
       ],
-      "title": "User DB Pool Close Reasons",
+      "title": "FS HTTP Status Mix And Inflight",
       "type": "timeseries"
     },
     {
@@ -703,12 +698,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} qps",
+          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"fs_read|fs_write|fs_patch|fs_append\"}[$__rate_interval]))",
+          "legendFormat": "{{event}} / {{result}}",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By User DB QPS",
+      "title": "FS Outcome Events",
       "type": "timeseries"
     },
     {
@@ -722,7 +717,7 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "s"
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -750,12 +745,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
-          "legendFormat": "{{tenant_id}} p95",
+          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"fs_read|fs_write|fs_patch|fs_append\",result!~\"ok|accepted\"}[$__rate_interval]))",
+          "legendFormat": "{{event}} / {{result}}",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By User DB P95",
+      "title": "FS Conflict And Error Events",
       "type": "timeseries"
     }
   ],
@@ -763,8 +758,8 @@
   "schemaVersion": 41,
   "tags": [
     "drive9",
-    "data-store",
-    "user-db",
+    "filesystem",
+    "request-path",
     "performance",
     "grafana",
     "prometheus"
@@ -789,7 +784,7 @@
         "type": "datasource"
       },
       {
-        "allValue": ".*",
+        "allValue": "/v1/fs/.*",
         "current": {
           "selected": true,
           "text": "All",
@@ -799,21 +794,21 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "definition": "label_values(dat9_http_requests_total{route=~\"/v1/fs.*\"}, route)",
         "hide": 0,
         "includeAll": true,
-        "label": "DB Operation",
+        "label": "HTTP Route",
         "multi": true,
-        "name": "db_operation",
+        "name": "http_route",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "query": "label_values(dat9_http_requests_total{route=~\"/v1/fs.*\"}, route)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
         "type": "query"
       },
       {
-        "allValue": ".*",
+        "allValue": "fs_.*",
         "current": {
           "selected": true,
           "text": "All",
@@ -823,14 +818,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
+        "definition": "label_values(dat9_service_operations_total{operation=~\"fs_.*\"}, operation)",
         "hide": 0,
         "includeAll": true,
-        "label": "Tenant ID",
+        "label": "Service Operation",
         "multi": true,
-        "name": "tenant_id",
+        "name": "service_operation",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
+        "query": "label_values(dat9_service_operations_total{operation=~\"fs_.*\"}, operation)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -844,8 +839,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 Tenant Data DB Performance",
-  "uid": "drive9-user-db-performance",
+  "title": "Drive9 Filesystem Path Performance",
+  "uid": "drive9-filesystem-path",
   "version": 1,
   "weekStart": ""
 }

--- a/docs/grafana/drive9-fs-operations-dashboard.json
+++ b/docs/grafana/drive9-fs-operations-dashboard.json
@@ -15,12 +15,35 @@
       }
     ]
   },
-  "description": "Filesystem operation dashboard for Drive9 request-path and backend work latency.",
+  "description": "Request-path drill-down dashboard for the Drive9 filesystem path, correlating /v1/fs HTTP requests with backend fs_* work.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Service Health Overview",
+      "type": "link",
+      "url": "/d/drive9-service-health"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Async And FUSE Overview",
+      "type": "link",
+      "url": "/d/drive9-async-fuse"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {
@@ -32,7 +55,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# FS Operations\n\nThis dashboard follows file-system request paths. It combines HTTP `/v1/fs/*` traffic with backend `fs_*` service operations to separate front-door symptoms from internal work.",
+        "content": "# Filesystem Path Performance\n\nCategory: request-path drill-down.\n\nUse this when the incident is clearly on the filesystem path. This dashboard owns the `/v1/fs/*` path and should be preferred over the generic API surface dashboard for filesystem symptoms. It combines HTTP `/v1/fs/*` traffic with backend `fs_*` service operations so you can separate front-door symptoms from internal work. The bottom row adds explicit WebDAV behavior, which is useful when filesystem symptoms only reproduce through DAV mounts or clients.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -729,13 +752,117 @@
       ],
       "title": "FS Conflict And Error Events",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (operation, result) (rate(dat9_service_operations_total{component=\"webdav\"}[$__rate_interval]))",
+          "legendFormat": "{{operation}} / {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "WebDAV Operations By Result",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{component=\"webdav\"}[$__rate_interval])))",
+          "legendFormat": "webdav p95",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{component=\"webdav\"}[$__rate_interval])))",
+          "legendFormat": "webdav p99",
+          "refId": "B"
+        }
+      ],
+      "title": "WebDAV Tail Latency",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
   "schemaVersion": 41,
   "tags": [
     "drive9",
-    "fs",
+    "filesystem",
+    "request-path",
     "performance",
     "grafana",
     "prometheus"
@@ -815,7 +942,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 FS Operations Performance",
+  "title": "Drive9 Filesystem Path Performance",
   "uid": "drive9-fs-operations-performance",
   "version": 1,
   "weekStart": ""

--- a/docs/grafana/drive9-http-performance-dashboard.json
+++ b/docs/grafana/drive9-http-performance-dashboard.json
@@ -322,7 +322,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_http_inflight_requests",
+          "expr": "sum(dat9_http_inflight_requests{route=~\"$route\"})",
           "legendFormat": "inflight",
           "refId": "A"
         }
@@ -662,7 +662,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_http_inflight_requests",
+          "expr": "sum(dat9_http_inflight_requests{route=~\"$route\"})",
           "legendFormat": "inflight",
           "refId": "B"
         }
@@ -732,7 +732,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 API Surface Performance",
+  "title": "Drive9 API Surface (HTTP) Performance",
   "uid": "drive9-http-performance",
   "version": 1,
   "weekStart": ""

--- a/docs/grafana/drive9-http-performance-dashboard.json
+++ b/docs/grafana/drive9-http-performance-dashboard.json
@@ -15,12 +15,35 @@
       }
     ]
   },
-  "description": "Detailed HTTP performance dashboard for Drive9. Use this when route throughput, request latency, or API error mix is the main problem.",
+  "description": "Request-path drill-down dashboard for non-FS and non-upload Drive9 APIs, focused on control, vault, SQL, events, and auxiliary HTTP surfaces.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Service Health Overview",
+      "type": "link",
+      "url": "/d/drive9-service-health"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Async And FUSE Overview",
+      "type": "link",
+      "url": "/d/drive9-async-fuse"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {
@@ -32,7 +55,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# HTTP Performance\n\nThis dashboard is intentionally large-format for request-path analysis. It answers: which routes are hot, which are slow, and whether latency coincides with inflight buildup or error spikes.",
+        "content": "# API Surface Performance\n\nCategory: request-path drill-down.\n\nUse this after an overview dashboard shows an HTTP-facing problem outside the FS and upload paths. This dashboard is intentionally scoped to control, vault, SQL, events, and auxiliary HTTP routes so it does not duplicate the dedicated FS and upload dashboards. It answers which routes are hot, which are slow, and whether latency coincides with inflight buildup or error spikes.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -652,7 +675,8 @@
   "schemaVersion": 41,
   "tags": [
     "drive9",
-    "http",
+    "api",
+    "control-plane",
     "performance",
     "grafana",
     "prometheus"
@@ -677,7 +701,7 @@
         "type": "datasource"
       },
       {
-        "allValue": "/v1/.*|/v2/.*|/s3/.*",
+        "allValue": "/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*",
         "current": {
           "selected": true,
           "text": "All",
@@ -687,14 +711,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_http_requests_total{route!~\"/healthz|/metrics|other\"}, route)",
+        "definition": "label_values(dat9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
         "hide": 0,
         "includeAll": true,
-        "label": "Route",
+        "label": "API Route",
         "multi": true,
         "name": "route",
         "options": [],
-        "query": "label_values(dat9_http_requests_total{route!~\"/healthz|/metrics|other\"}, route)",
+        "query": "label_values(dat9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -708,7 +732,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 HTTP Performance",
+  "title": "Drive9 API Surface Performance",
   "uid": "drive9-http-performance",
   "version": 1,
   "weekStart": ""

--- a/docs/grafana/drive9-meta-db-performance-dashboard.json
+++ b/docs/grafana/drive9-meta-db-performance-dashboard.json
@@ -15,12 +15,24 @@
       }
     ]
   },
-  "description": "Meta DB performance dashboard for Drive9 control-plane queries and pool pressure.",
+  "description": "Data-store drill-down dashboard that owns database role=meta, focused on Drive9 control-plane and metadata query behavior.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Service Health Overview",
+      "type": "link",
+      "url": "/d/drive9-service-health"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {
@@ -32,7 +44,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Meta DB Performance\n\nThis dashboard is scoped to role=`meta`. Operation latency and throughput panels can be filtered by `tenant_id` to spot hot tenants in control-plane traffic. Pool panels remain global because they come from the shared process-wide `sql.DB` pool.",
+        "content": "# Metadata DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure and the problem appears to sit in metadata or control-plane queries. This dashboard owns database role=`meta` and should be preferred whenever the bottleneck looks control-plane rather than tenant-serving. Operation latency and throughput panels can be filtered by `tenant_id` to spot hot tenants in control-plane traffic. Pool panels remain global because they come from the shared process-wide `sql.DB` pool.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -751,6 +763,7 @@
   "schemaVersion": 41,
   "tags": [
     "drive9",
+    "data-store",
     "meta-db",
     "performance",
     "grafana",
@@ -831,7 +844,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 Meta DB Performance",
+  "title": "Drive9 Metadata DB Performance",
   "uid": "drive9-meta-db-performance",
   "version": 1,
   "weekStart": ""

--- a/docs/grafana/drive9-meta-db-performance-dashboard.json
+++ b/docs/grafana/drive9-meta-db-performance-dashboard.json
@@ -44,7 +44,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Metadata DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure and the problem appears to sit in metadata or control-plane queries. This dashboard owns database role=`meta` and should be preferred whenever the bottleneck looks control-plane rather than tenant-serving. Operation latency and throughput panels can be filtered by `tenant_id` to spot hot tenants in control-plane traffic. Pool panels remain global because they come from the shared process-wide `sql.DB` pool.",
+        "content": "# Metadata DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure and the problem appears to sit in metadata or control-plane queries. This dashboard owns database role=`meta` and should be preferred whenever the bottleneck looks control-plane rather than tenant-serving. Operation panels stay grouped by operation and result only because exported DB metrics intentionally avoid tenant-scoped labels. Pool panels remain global because they come from the shared process-wide `sql.DB` pool.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -110,7 +110,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "meta_p95",
           "refId": "A"
         }
@@ -177,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "meta_p99",
           "refId": "A"
         }
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -481,7 +481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -703,12 +703,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} qps",
+          "expr": "topk(10, sum by (operation) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "legendFormat": "{{operation}} qps",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By Meta DB QPS",
+      "title": "Top Meta DB Operations By QPS",
       "type": "timeseries"
     },
     {
@@ -750,12 +750,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
-          "legendFormat": "{{tenant_id}} p95",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "legendFormat": "{{operation}} p95",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By Meta DB P95",
+      "title": "Slowest Meta DB Operations By P95",
       "type": "timeseries"
     }
   ],
@@ -812,30 +812,7 @@
         "sort": 1,
         "type": "query"
       },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(dat9_db_operations_total{role=\"meta\",tenant_id!=\"\"}, tenant_id)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Tenant ID",
-        "multi": true,
-        "name": "tenant_id",
-        "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"meta\",tenant_id!=\"\"}, tenant_id)",
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "type": "query"
-      }
+
     ]
   },
   "time": {

--- a/docs/grafana/drive9-metadata-db-dashboard.json
+++ b/docs/grafana/drive9-metadata-db-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Data-store drill-down dashboard that owns database role=user, focused on Drive9 tenant-serving query behavior.",
+  "description": "Data-store drill-down dashboard that owns database role=meta, focused on Drive9 control-plane and metadata query behavior.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -44,7 +44,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Tenant Data DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure on tenant-serving queries rather than control-plane metadata traffic. This dashboard owns database role=`user` and should be preferred whenever the bottleneck looks data-path rather than control-plane. Operation latency and throughput panels can be filtered by `tenant_id`. Pool panels remain shared because they come from the process-wide `sql.DB` pool rather than tenant-scoped accounting.",
+        "content": "# Metadata DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure and the problem appears to sit in metadata or control-plane queries. This dashboard owns database role=`meta` and should be preferred whenever the bottleneck looks control-plane rather than tenant-serving. Operation latency and throughput panels can be filtered by `tenant_id` to spot hot tenants in control-plane traffic. Pool panels remain global because they come from the shared process-wide `sql.DB` pool.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -110,12 +110,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p95",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
+          "legendFormat": "meta_p95",
           "refId": "A"
         }
       ],
-      "title": "User DB P95",
+      "title": "Meta DB P95",
       "type": "stat"
     },
     {
@@ -177,12 +177,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p99",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
+          "legendFormat": "meta_p99",
           "refId": "A"
         }
       ],
-      "title": "User DB P99",
+      "title": "Meta DB P99",
       "type": "stat"
     },
     {
@@ -244,12 +244,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "user_waits",
+          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"meta\"}[$__rate_interval]))",
+          "legendFormat": "meta_waits",
           "refId": "A"
         }
       ],
-      "title": "User Waits /s",
+      "title": "Meta Waits /s",
       "type": "stat"
     },
     {
@@ -311,12 +311,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"user\",state=\"max_open\"}), 1)",
-          "legendFormat": "user_utilization",
+          "expr": "sum(dat9_db_pool_connections{role=\"meta\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"meta\",state=\"max_open\"}), 1)",
+          "legendFormat": "meta_utilization",
           "refId": "A"
         }
       ],
-      "title": "User Utilization",
+      "title": "Meta Utilization",
       "type": "stat"
     },
     {
@@ -378,8 +378,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"open\"})",
-          "legendFormat": "user_open",
+          "expr": "sum(dat9_db_pool_connections{role=\"meta\",state=\"open\"})",
+          "legendFormat": "meta_open",
           "refId": "A"
         }
       ],
@@ -425,12 +425,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Operation Throughput",
+      "title": "Meta DB Operation Throughput",
       "type": "timeseries"
     },
     {
@@ -472,7 +472,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -481,12 +481,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
       ],
-      "title": "User DB Tail Latency",
+      "title": "Meta DB Tail Latency",
       "type": "timeseries"
     },
     {
@@ -528,12 +528,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (state) (dat9_db_pool_connections{role=\"user\"})",
+          "expr": "sum by (state) (dat9_db_pool_connections{role=\"meta\"})",
           "legendFormat": "{{state}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Pool Connections",
+      "title": "Meta DB Pool Connections",
       "type": "timeseries"
     },
     {
@@ -600,7 +600,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"user\"}[$__rate_interval])",
+          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"meta\"}[$__rate_interval])",
           "legendFormat": "wait_seconds_rate",
           "refId": "A"
         },
@@ -609,12 +609,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval])",
+          "expr": "rate(dat9_db_pool_wait_count_total{role=\"meta\"}[$__rate_interval])",
           "legendFormat": "wait_count_rate",
           "refId": "B"
         }
       ],
-      "title": "User DB Wait Pressure",
+      "title": "Meta DB Wait Pressure",
       "type": "timeseries"
     },
     {
@@ -656,12 +656,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"user\"}[$__rate_interval]))",
+          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"meta\"}[$__rate_interval]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Pool Close Reasons",
+      "title": "Meta DB Pool Close Reasons",
       "type": "timeseries"
     },
     {
@@ -703,12 +703,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
+          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
           "legendFormat": "{{tenant_id}} qps",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By User DB QPS",
+      "title": "Top Tenants By Meta DB QPS",
       "type": "timeseries"
     },
     {
@@ -750,12 +750,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
           "legendFormat": "{{tenant_id}} p95",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By User DB P95",
+      "title": "Top Tenants By Meta DB P95",
       "type": "timeseries"
     }
   ],
@@ -764,7 +764,7 @@
   "tags": [
     "drive9",
     "data-store",
-    "user-db",
+    "meta-db",
     "performance",
     "grafana",
     "prometheus"
@@ -799,14 +799,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "definition": "label_values(dat9_db_operations_total{role=\"meta\"}, operation)",
         "hide": 0,
         "includeAll": true,
         "label": "DB Operation",
         "multi": true,
         "name": "db_operation",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "query": "label_values(dat9_db_operations_total{role=\"meta\"}, operation)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -823,14 +823,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
+        "definition": "label_values(dat9_db_operations_total{role=\"meta\",tenant_id!=\"\"}, tenant_id)",
         "hide": 0,
         "includeAll": true,
         "label": "Tenant ID",
         "multi": true,
         "name": "tenant_id",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
+        "query": "label_values(dat9_db_operations_total{role=\"meta\",tenant_id!=\"\"}, tenant_id)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -844,8 +844,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 Tenant Data DB Performance",
-  "uid": "drive9-user-db-performance",
+  "title": "Drive9 Metadata DB Performance",
+  "uid": "drive9-metadata-db",
   "version": 1,
   "weekStart": ""
 }

--- a/docs/grafana/drive9-metadata-db-dashboard.json
+++ b/docs/grafana/drive9-metadata-db-dashboard.json
@@ -44,7 +44,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Metadata DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure and the problem appears to sit in metadata or control-plane queries. This dashboard owns database role=`meta` and should be preferred whenever the bottleneck looks control-plane rather than tenant-serving. Operation latency and throughput panels can be filtered by `tenant_id` to spot hot tenants in control-plane traffic. Pool panels remain global because they come from the shared process-wide `sql.DB` pool.",
+        "content": "# Metadata DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure and the problem appears to sit in metadata or control-plane queries. This dashboard owns database role=`meta` and should be preferred whenever the bottleneck looks control-plane rather than tenant-serving. Operation panels stay grouped by operation and result only because exported DB metrics intentionally avoid tenant-scoped labels. Pool panels remain global because they come from the shared process-wide `sql.DB` pool.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -110,7 +110,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "meta_p95",
           "refId": "A"
         }
@@ -177,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "meta_p99",
           "refId": "A"
         }
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -481,7 +481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -703,12 +703,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} qps",
+          "expr": "topk(10, sum by (operation) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "legendFormat": "{{operation}} qps",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By Meta DB QPS",
+      "title": "Top Meta DB Operations By QPS",
       "type": "timeseries"
     },
     {
@@ -750,12 +750,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
-          "legendFormat": "{{tenant_id}} p95",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "legendFormat": "{{operation}} p95",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By Meta DB P95",
+      "title": "Slowest Meta DB Operations By P95",
       "type": "timeseries"
     }
   ],
@@ -812,30 +812,7 @@
         "sort": 1,
         "type": "query"
       },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(dat9_db_operations_total{role=\"meta\",tenant_id!=\"\"}, tenant_id)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Tenant ID",
-        "multi": true,
-        "name": "tenant_id",
-        "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"meta\",tenant_id!=\"\"}, tenant_id)",
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "type": "query"
-      }
+
     ]
   },
   "time": {

--- a/docs/grafana/drive9-service-health-dashboard.json
+++ b/docs/grafana/drive9-service-health-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Data-store drill-down dashboard that owns database role=user, focused on Drive9 tenant-serving query behavior.",
+  "description": "Overview dashboard: first stop for Drive9 service incidents, with an alarm-biased first screen for module failures, HTTP symptoms, and coarse DB pressure.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -28,9 +28,64 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "Service Health Overview",
+      "title": "API Surface Drill-Down",
       "type": "link",
-      "url": "/d/drive9-service-health"
+      "url": "/d/drive9-api-surface"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Filesystem Path Drill-Down",
+      "type": "link",
+      "url": "/d/drive9-filesystem-path"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Upload Path Drill-Down",
+      "type": "link",
+      "url": "/d/drive9-upload-path"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Metadata DB Drill-Down",
+      "type": "link",
+      "url": "/d/drive9-metadata-db"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Tenant Data DB Drill-Down",
+      "type": "link",
+      "url": "/d/drive9-tenant-data-db"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Async And FUSE Overview",
+      "type": "link",
+      "url": "/d/drive9-async-fuse"
     }
   ],
   "liveNow": false,
@@ -44,7 +99,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Tenant Data DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure on tenant-serving queries rather than control-plane metadata traffic. This dashboard owns database role=`user` and should be preferred whenever the bottleneck looks data-path rather than control-plane. Operation latency and throughput panels can be filtered by `tenant_id`. Pool panels remain shared because they come from the process-wide `sql.DB` pool rather than tenant-scoped accounting.",
+        "content": "# Drive9 Service Health\n\nCategory: overview.\n\nUse this as the primary incident entrypoint for front-door symptoms. The first row is intentionally alarm-biased: down modules, DB waits, HTTP traffic, HTTP errors, tail latency, and inflight pressure. The second row is organized for rapid narrowing: failing routes first, then noisy components, then hot latency outliers. If the issue narrows to a specific API path, move to the request-path drill-down dashboards. If the issue narrows to async work or mount behavior, move to the async and FUSE overview.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -71,22 +126,22 @@
               },
               {
                 "color": "orange",
-                "value": 0.05
+                "value": 0.5
               },
               {
                 "color": "red",
-                "value": 0.25
+                "value": 5
               }
             ]
           },
-          "unit": "s"
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 0,
+        "x": 4,
         "y": 4
       },
       "id": 1,
@@ -110,12 +165,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p95",
+          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=~\"$db_role\"}[$__rate_interval]))",
+          "legendFormat": "db_waits_per_second",
           "refId": "A"
         }
       ],
-      "title": "User DB P95",
+      "title": "DB Waits /s",
       "type": "stat"
     },
     {
@@ -138,22 +193,22 @@
               },
               {
                 "color": "orange",
-                "value": 0.2
+                "value": 1
               },
               {
                 "color": "red",
-                "value": 1
+                "value": 2
               }
             ]
           },
-          "unit": "s"
+          "unit": "none"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 4,
+        "x": 0,
         "y": 4
       },
       "id": 2,
@@ -177,12 +232,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p99",
+          "expr": "sum(1 - dat9_module_up{module=~\"$module\"})",
+          "legendFormat": "down_modules",
           "refId": "A"
         }
       ],
-      "title": "User DB P99",
+      "title": "Down Modules",
       "type": "stat"
     },
     {
@@ -205,15 +260,15 @@
               },
               {
                 "color": "orange",
-                "value": 1
+                "value": 20
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 100
               }
             ]
           },
-          "unit": "ops"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -244,12 +299,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "user_waits",
+          "expr": "sum(rate(dat9_http_requests_total{route!~\"/healthz|/metrics|other\"}[$__rate_interval]))",
+          "legendFormat": "http_rps",
           "refId": "A"
         }
       ],
-      "title": "User Waits /s",
+      "title": "HTTP RPS",
       "type": "stat"
     },
     {
@@ -272,11 +327,11 @@
               },
               {
                 "color": "orange",
-                "value": 0.7
+                "value": 0.02
               },
               {
                 "color": "red",
-                "value": 0.9
+                "value": 0.05
               }
             ]
           },
@@ -311,12 +366,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"user\",state=\"max_open\"}), 1)",
-          "legendFormat": "user_utilization",
+          "expr": "sum(rate(dat9_http_requests_total{route!~\"/healthz|/metrics|other\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route!~\"/healthz|/metrics|other\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "http_5xx_ratio",
           "refId": "A"
         }
       ],
-      "title": "User Utilization",
+      "title": "HTTP 5xx Ratio",
       "type": "stat"
     },
     {
@@ -343,11 +398,11 @@
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 3
               }
             ]
           },
-          "unit": "short"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -378,12 +433,79 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"open\"})",
-          "legendFormat": "user_open",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route!~\"/healthz|/metrics|other\"}[$__rate_interval])))",
+          "legendFormat": "http_p99",
           "refId": "A"
         }
       ],
-      "title": "Open Connections",
+      "title": "HTTP P99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 25
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dat9_http_inflight_requests",
+          "legendFormat": "http_inflight",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Inflight",
       "type": "stat"
     },
     {
@@ -397,15 +519,203 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "ops"
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dat9_module_up{module=~\"$module\"}",
+          "legendFormat": "{{module}} up",
+          "refId": "A"
+        }
+      ],
+      "title": "Module Availability History",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(8, histogram_quantile(0.95, sum by (le, route) (rate(dat9_http_request_duration_seconds_bucket{route!~\"/healthz|/metrics|other\"}[$__rate_interval]))))",
+          "legendFormat": "{{route}} p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Routes By HTTP P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
         "x": 0,
         "y": 8
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(12, sum by (route, status) (rate(dat9_http_requests_total{route!~\"/healthz|/metrics|other\",status!~\"2..|3..\"}[$__rate_interval])))",
+          "legendFormat": "{{route}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Non-2xx/3xx Routes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (component) (rate(dat9_service_operations_total{component=~\"$component\",result=~\"error|deadline_exceeded|canceled|bad_conn\"}[$__rate_interval])) / clamp_min(sum by (component) (rate(dat9_service_operations_total{component=~\"$component\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "{{component}} error_ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Service Error Ratio By Component",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
       },
       "id": 11,
       "options": {
@@ -425,12 +735,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
-          "legendFormat": "{{operation}} / {{result}}",
+          "expr": "sum by (role, state) (dat9_db_pool_connections{role=~\"$db_role\"})",
+          "legendFormat": "{{role}} {{state}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Operation Throughput",
+      "title": "DB Pool Connections",
       "type": "timeseries"
     },
     {
@@ -450,9 +760,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
+        "w": 8,
+        "x": 16,
+        "y": 16
       },
       "id": 12,
       "options": {
@@ -472,243 +782,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p95",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p99",
-          "refId": "B"
-        }
-      ],
-      "title": "User DB Tail Latency",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
-      "id": 13,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum by (state) (dat9_db_pool_connections{role=\"user\"})",
-          "legendFormat": "{{state}}",
+          "expr": "histogram_quantile(0.95, sum by (le, role) (rate(dat9_db_operation_duration_seconds_bucket{role=~\"$db_role\"}[$__rate_interval])))",
+          "legendFormat": "{{role}} db_p95",
           "refId": "A"
         }
       ],
-      "title": "User DB Pool Connections",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "wait_seconds_rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "wait_count_rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ops"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"user\"}[$__rate_interval])",
-          "legendFormat": "wait_seconds_rate",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval])",
-          "legendFormat": "wait_count_rate",
-          "refId": "B"
-        }
-      ],
-      "title": "User DB Wait Pressure",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "{{reason}}",
-          "refId": "A"
-        }
-      ],
-      "title": "User DB Pool Close Reasons",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 32
-      },
-      "id": 16,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} qps",
-          "refId": "A"
-        }
-      ],
-      "title": "Top Tenants By User DB QPS",
+      "title": "DB Operation P95 By Role",
       "type": "timeseries"
     },
     {
@@ -728,11 +807,11 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 32
+        "w": 24,
+        "x": 0,
+        "y": 24
       },
-      "id": 17,
+      "id": 13,
       "options": {
         "legend": {
           "calcs": [],
@@ -750,12 +829,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
-          "legendFormat": "{{tenant_id}} p95",
+          "expr": "dat9_module_uptime_seconds{module=~\"$module\"}",
+          "legendFormat": "{{module}} uptime",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By User DB P95",
+      "title": "Module Uptime",
       "type": "timeseries"
     }
   ],
@@ -763,9 +842,8 @@
   "schemaVersion": 41,
   "tags": [
     "drive9",
-    "data-store",
-    "user-db",
-    "performance",
+    "service-health",
+    "observability",
     "grafana",
     "prometheus"
   ],
@@ -799,14 +877,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "definition": "label_values(dat9_module_up, module)",
         "hide": 0,
         "includeAll": true,
-        "label": "DB Operation",
+        "label": "Module",
         "multi": true,
-        "name": "db_operation",
+        "name": "module",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "query": "label_values(dat9_module_up, module)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -823,14 +901,38 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
+        "definition": "label_values(dat9_service_operations_total, component)",
         "hide": 0,
         "includeAll": true,
-        "label": "Tenant ID",
+        "label": "Component",
         "multi": true,
-        "name": "tenant_id",
+        "name": "component",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
+        "query": "label_values(dat9_service_operations_total, component)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(dat9_db_pool_registered, role)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "DB Role",
+        "multi": true,
+        "name": "db_role",
+        "options": [],
+        "query": "label_values(dat9_db_pool_registered, role)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -844,8 +946,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 Tenant Data DB Performance",
-  "uid": "drive9-user-db-performance",
+  "title": "Drive9 Service Health",
+  "uid": "drive9-service-health",
   "version": 1,
   "weekStart": ""
 }

--- a/docs/grafana/drive9-tenant-data-db-dashboard.json
+++ b/docs/grafana/drive9-tenant-data-db-dashboard.json
@@ -845,7 +845,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Drive9 Tenant Data DB Performance",
-  "uid": "drive9-user-db-performance",
+  "uid": "drive9-tenant-data-db",
   "version": 1,
   "weekStart": ""
 }

--- a/docs/grafana/drive9-tenant-data-db-dashboard.json
+++ b/docs/grafana/drive9-tenant-data-db-dashboard.json
@@ -44,7 +44,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Tenant Data DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure on tenant-serving queries rather than control-plane metadata traffic. This dashboard owns database role=`user` and should be preferred whenever the bottleneck looks data-path rather than control-plane. Operation latency and throughput panels can be filtered by `tenant_id`. Pool panels remain shared because they come from the process-wide `sql.DB` pool rather than tenant-scoped accounting.",
+        "content": "# Tenant Data DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure on tenant-serving queries rather than control-plane metadata traffic. This dashboard owns database role=`user` and should be preferred whenever the bottleneck looks data-path rather than control-plane. Operation panels stay grouped by operation and result only because exported DB metrics intentionally avoid tenant-scoped labels. Pool panels remain shared because they come from the process-wide `sql.DB` pool rather than tenant-scoped accounting.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -110,7 +110,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "user_p95",
           "refId": "A"
         }
@@ -177,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "user_p99",
           "refId": "A"
         }
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -481,7 +481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -703,12 +703,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} qps",
+          "expr": "topk(10, sum by (operation) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "legendFormat": "{{operation}} qps",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By User DB QPS",
+      "title": "Top User DB Operations By QPS",
       "type": "timeseries"
     },
     {
@@ -750,12 +750,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
-          "legendFormat": "{{tenant_id}} p95",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "legendFormat": "{{operation}} p95",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By User DB P95",
+      "title": "Slowest User DB Operations By P95",
       "type": "timeseries"
     }
   ],
@@ -812,30 +812,7 @@
         "sort": 1,
         "type": "query"
       },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Tenant ID",
-        "multi": true,
-        "name": "tenant_id",
-        "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "type": "query"
-      }
+
     ]
   },
   "time": {

--- a/docs/grafana/drive9-upload-path-dashboard.json
+++ b/docs/grafana/drive9-upload-path-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Data-store drill-down dashboard that owns database role=user, focused on Drive9 tenant-serving query behavior.",
+  "description": "Request-path drill-down dashboard for the Drive9 upload path, correlating upload HTTP traffic, backend upload operations, and upload-related events.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -31,6 +31,17 @@
       "title": "Service Health Overview",
       "type": "link",
       "url": "/d/drive9-service-health"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Async And FUSE Overview",
+      "type": "link",
+      "url": "/d/drive9-async-fuse"
     }
   ],
   "liveNow": false,
@@ -44,7 +55,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Tenant Data DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure on tenant-serving queries rather than control-plane metadata traffic. This dashboard owns database role=`user` and should be preferred whenever the bottleneck looks data-path rather than control-plane. Operation latency and throughput panels can be filtered by `tenant_id`. Pool panels remain shared because they come from the process-wide `sql.DB` pool rather than tenant-scoped accounting.",
+        "content": "# Upload Path Performance\n\nCategory: request-path drill-down.\n\nUse this when the issue is clearly on initiate, presign, confirm, finalize, resume, or abort upload flows. This dashboard owns the upload path and should be preferred over the generic API surface dashboard for upload symptoms. Start with HTTP throughput and tail latency, then compare service-operation latency, and finally check conflict, expired, and error event pressure. It does not show raw S3 SDK timings because those metrics do not exist yet, so the scope is the upload path rather than raw S3 internals.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -71,15 +82,15 @@
               },
               {
                 "color": "orange",
-                "value": 0.05
+                "value": 10
               },
               {
                 "color": "red",
-                "value": 0.25
+                "value": 50
               }
             ]
           },
-          "unit": "s"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -110,12 +121,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p95",
+          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "legendFormat": "upload_rps",
           "refId": "A"
         }
       ],
-      "title": "User DB P95",
+      "title": "Upload HTTP RPS",
       "type": "stat"
     },
     {
@@ -177,12 +188,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
-          "legendFormat": "user_p99",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
+          "legendFormat": "upload_http_p95",
           "refId": "A"
         }
       ],
-      "title": "User DB P99",
+      "title": "Upload HTTP P95",
       "type": "stat"
     },
     {
@@ -205,15 +216,15 @@
               },
               {
                 "color": "orange",
-                "value": 1
+                "value": 0.5
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 2
               }
             ]
           },
-          "unit": "ops"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -221,6 +232,73 @@
         "h": 4,
         "w": 4,
         "x": 8,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
+          "legendFormat": "upload_http_p99",
+          "refId": "A"
+        }
+      ],
+      "title": "Upload HTTP P99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
         "y": 4
       },
       "id": 3,
@@ -244,12 +322,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "user_waits",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval])))",
+          "legendFormat": "upload_service_p95",
           "refId": "A"
         }
       ],
-      "title": "User Waits /s",
+      "title": "Upload Service P95",
       "type": "stat"
     },
     {
@@ -272,11 +350,11 @@
               },
               {
                 "color": "orange",
-                "value": 0.7
+                "value": 0.01
               },
               {
                 "color": "red",
-                "value": 0.9
+                "value": 0.05
               }
             ]
           },
@@ -287,7 +365,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 12,
+        "x": 16,
         "y": 4
       },
       "id": 4,
@@ -311,12 +389,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"user\",state=\"max_open\"}), 1)",
-          "legendFormat": "user_utilization",
+          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 1)",
+          "legendFormat": "upload_5xx_ratio",
           "refId": "A"
         }
       ],
-      "title": "User Utilization",
+      "title": "Upload 5xx Ratio",
       "type": "stat"
     },
     {
@@ -339,11 +417,11 @@
               },
               {
                 "color": "orange",
-                "value": 1
+                "value": 5
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 20
               }
             ]
           },
@@ -354,7 +432,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 16,
+        "x": 20,
         "y": 4
       },
       "id": 5,
@@ -378,12 +456,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"open\"})",
-          "legendFormat": "user_open",
+          "expr": "sum(dat9_http_inflight_requests{route=~\"$http_route\"})",
+          "legendFormat": "upload_inflight",
           "refId": "A"
         }
       ],
-      "title": "Open Connections",
+      "title": "Upload HTTP Inflight",
       "type": "stat"
     },
     {
@@ -397,7 +475,7 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "ops"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -425,12 +503,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
-          "legendFormat": "{{operation}} / {{result}}",
+          "expr": "sum by (route, method) (rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "legendFormat": "{{method}} {{route}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Operation Throughput",
+      "title": "Hot Upload Routes By Throughput",
       "type": "timeseries"
     },
     {
@@ -472,8 +550,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p95",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route, method) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
+          "legendFormat": "{{method}} {{route}} p95",
           "refId": "A"
         },
         {
@@ -481,12 +559,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p99",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route, method) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
+          "legendFormat": "{{method}} {{route}} p99",
           "refId": "B"
         }
       ],
-      "title": "User DB Tail Latency",
+      "title": "Upload HTTP Tail Latency",
       "type": "timeseries"
     },
     {
@@ -500,7 +578,7 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "short"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -528,12 +606,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (state) (dat9_db_pool_connections{role=\"user\"})",
-          "legendFormat": "{{state}}",
+          "expr": "sum by (status) (rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}",
           "refId": "A"
         }
       ],
-      "title": "User DB Pool Connections",
+      "title": "Upload HTTP Status Mix",
       "type": "timeseries"
     },
     {
@@ -547,34 +625,9 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "short"
+          "unit": "ops"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "wait_seconds_rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "wait_count_rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ops"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -600,21 +653,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"user\"}[$__rate_interval])",
-          "legendFormat": "wait_seconds_rate",
+          "expr": "sum by (operation, result) (rate(dat9_service_operations_total{operation=~\"$service_operation\"}[$__rate_interval]))",
+          "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval])",
-          "legendFormat": "wait_count_rate",
-          "refId": "B"
         }
       ],
-      "title": "User DB Wait Pressure",
+      "title": "Upload Service Throughput By Result",
       "type": "timeseries"
     },
     {
@@ -628,13 +672,13 @@
             "mode": "palette-classic"
           },
           "mappings": [],
-          "unit": "ops"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 24
       },
@@ -656,12 +700,21 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"user\"}[$__rate_interval]))",
-          "legendFormat": "{{reason}}",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
+          "legendFormat": "{{operation}} p95",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
+          "legendFormat": "{{operation}} p99",
+          "refId": "B"
         }
       ],
-      "title": "User DB Pool Close Reasons",
+      "title": "Upload Service Tail Latency",
       "type": "timeseries"
     },
     {
@@ -682,8 +735,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 32
+        "x": 12,
+        "y": 24
       },
       "id": 16,
       "options": {
@@ -703,59 +756,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} qps",
+          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"$event\"}[$__rate_interval]))",
+          "legendFormat": "{{event}} / {{result}}",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By User DB QPS",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 32
-      },
-      "id": 17,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
-          "legendFormat": "{{tenant_id}} p95",
-          "refId": "A"
-        }
-      ],
-      "title": "Top Tenants By User DB P95",
+      "title": "Upload Outcome Events",
       "type": "timeseries"
     }
   ],
@@ -763,8 +769,8 @@
   "schemaVersion": 41,
   "tags": [
     "drive9",
-    "data-store",
-    "user-db",
+    "upload",
+    "request-path",
     "performance",
     "grafana",
     "prometheus"
@@ -789,7 +795,7 @@
         "type": "datasource"
       },
       {
-        "allValue": ".*",
+        "allValue": "/v1/uploads.*|/v2/uploads.*",
         "current": {
           "selected": true,
           "text": "All",
@@ -799,14 +805,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "definition": "label_values(dat9_http_requests_total{route=~\"/v1/uploads.*|/v2/uploads.*\"}, route)",
         "hide": 0,
         "includeAll": true,
-        "label": "DB Operation",
+        "label": "HTTP Route",
         "multi": true,
-        "name": "db_operation",
+        "name": "http_route",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "query": "label_values(dat9_http_requests_total{route=~\"/v1/uploads.*|/v2/uploads.*\"}, route)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -823,14 +829,38 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
+        "definition": "label_values(dat9_service_operations_total{operation=~\"upload_.*|v2_upload_.*|v2_presign_.*|complete_upload|resume_upload|abort_upload\"}, operation)",
         "hide": 0,
         "includeAll": true,
-        "label": "Tenant ID",
+        "label": "Service Operation",
         "multi": true,
-        "name": "tenant_id",
+        "name": "service_operation",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
+        "query": "label_values(dat9_service_operations_total{operation=~\"upload_.*|v2_upload_.*|v2_presign_.*|complete_upload|resume_upload|abort_upload\"}, operation)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(dat9_tenant_events_total{event=~\"upload_.*|v2_upload_.*|v2_presign_.*\"}, event)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Tenant Event",
+        "multi": true,
+        "name": "event",
+        "options": [],
+        "query": "label_values(dat9_tenant_events_total{event=~\"upload_.*|v2_upload_.*|v2_presign_.*\"}, event)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -844,8 +874,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 Tenant Data DB Performance",
-  "uid": "drive9-user-db-performance",
+  "title": "Drive9 Upload Path Performance",
+  "uid": "drive9-upload-path",
   "version": 1,
   "weekStart": ""
 }

--- a/docs/grafana/drive9-upload-path-dashboard.json
+++ b/docs/grafana/drive9-upload-path-dashboard.json
@@ -55,7 +55,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Upload Path Performance\n\nCategory: request-path drill-down.\n\nUse this when the issue is clearly on initiate, presign, confirm, finalize, resume, or abort upload flows. This dashboard owns the upload path and should be preferred over the generic API surface dashboard for upload symptoms. Start with HTTP throughput and tail latency, then compare service-operation latency, and finally check conflict, expired, and error event pressure. It does not show raw S3 SDK timings because those metrics do not exist yet, so the scope is the upload path rather than raw S3 internals.",
+        "content": "# Upload Path Performance\n\nCategory: request-path drill-down.\n\nUse this when the issue is clearly on initiate, presign, confirm, finalize, resume, or abort upload flows. This dashboard owns the upload path and should be preferred over the generic API surface dashboard for upload symptoms. Start with HTTP throughput and tail latency, then compare service-operation latency, and finally check conflict, expired, and error event pressure. If the symptom narrows past the upload control path into raw object-store behavior, continue into the upload plus S3 drill-down dashboard for s3client throughput and latency.",
         "mode": "markdown"
       },
       "title": "Guide",

--- a/docs/grafana/drive9-upload-s3-path-dashboard.json
+++ b/docs/grafana/drive9-upload-s3-path-dashboard.json
@@ -15,12 +15,35 @@
       }
     ]
   },
-  "description": "Upload and S3-path dashboard for Drive9. This uses upload-related HTTP, service, and event metrics rather than raw S3 SDK instrumentation.",
+  "description": "Request-path drill-down dashboard for the Drive9 upload and object-store path, correlating upload HTTP traffic, backend upload operations, upload events, and raw s3client timings/results.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Service Health Overview",
+      "type": "link",
+      "url": "/d/drive9-service-health"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Async And FUSE Overview",
+      "type": "link",
+      "url": "/d/drive9-async-fuse"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {
@@ -32,7 +55,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Upload And S3 Path\n\nThis dashboard is tuned for performance triage on the upload path. Start with HTTP throughput and tail latency, then compare service-operation latency, and finally check conflict/error/expired event pressure. It still does not show raw S3 SDK timings because those metrics do not exist yet.",
+        "content": "# Upload And S3 Path Performance\n\nCategory: request-path drill-down.\n\nUse this when the issue is clearly on initiate, presign, confirm, finalize, resume, or abort upload flows, or when the suspicion has narrowed to raw object-store behavior. This dashboard owns the upload path and should be preferred over the generic API surface dashboard for upload symptoms. Start with HTTP throughput and tail latency, then compare service-operation latency and outcome events, and finally use the bottom row to inspect raw s3client operation rate and latency.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -740,6 +763,109 @@
       ],
       "title": "Upload Outcome Events",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (operation, result) (rate(dat9_service_operations_total{component=\"s3client\"}[$__rate_interval]))",
+          "legendFormat": "{{operation}} / {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "S3 Client Throughput By Result",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{component=\"s3client\"}[$__rate_interval]))))",
+          "legendFormat": "{{operation}} p95",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{component=\"s3client\"}[$__rate_interval]))))",
+          "legendFormat": "{{operation}} p99",
+          "refId": "B"
+        }
+      ],
+      "title": "S3 Client Tail Latency",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -747,7 +873,7 @@
   "tags": [
     "drive9",
     "upload",
-    "s3-path",
+    "request-path",
     "performance",
     "grafana",
     "prometheus"

--- a/docs/grafana/drive9-user-db-performance-dashboard.json
+++ b/docs/grafana/drive9-user-db-performance-dashboard.json
@@ -44,7 +44,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Tenant Data DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure on tenant-serving queries rather than control-plane metadata traffic. This dashboard owns database role=`user` and should be preferred whenever the bottleneck looks data-path rather than control-plane. Operation latency and throughput panels can be filtered by `tenant_id`. Pool panels remain shared because they come from the process-wide `sql.DB` pool rather than tenant-scoped accounting.",
+        "content": "# Tenant Data DB Performance\n\nCategory: data-store drill-down.\n\nUse this when overview dashboards suggest DB pressure on tenant-serving queries rather than control-plane metadata traffic. This dashboard owns database role=`user` and should be preferred whenever the bottleneck looks data-path rather than control-plane. Operation panels stay grouped by operation and result only because exported DB metrics intentionally avoid tenant-scoped labels. Pool panels remain shared because they come from the process-wide `sql.DB` pool rather than tenant-scoped accounting.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -110,7 +110,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "user_p95",
           "refId": "A"
         }
@@ -177,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "user_p99",
           "refId": "A"
         }
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -481,7 +481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -703,12 +703,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (tenant_id) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} qps",
+          "expr": "topk(10, sum by (operation) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "legendFormat": "{{operation}} qps",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By User DB QPS",
+      "title": "Top User DB Operations By QPS",
       "type": "timeseries"
     },
     {
@@ -750,12 +750,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, tenant_id) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\",tenant_id=~\"$tenant_id\",tenant_id!=\"\"}[$__rate_interval]))))",
-          "legendFormat": "{{tenant_id}} p95",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "legendFormat": "{{operation}} p95",
           "refId": "A"
         }
       ],
-      "title": "Top Tenants By User DB P95",
+      "title": "Slowest User DB Operations By P95",
       "type": "timeseries"
     }
   ],
@@ -812,30 +812,7 @@
         "sort": 1,
         "type": "query"
       },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Tenant ID",
-        "multi": true,
-        "name": "tenant_id",
-        "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\",tenant_id!=\"\"}, tenant_id)",
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "type": "query"
-      }
+
     ]
   },
   "time": {

--- a/pkg/backend/audio_extract.go
+++ b/pkg/backend/audio_extract.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/pingcap/failpoint"
 
@@ -280,30 +281,43 @@ func resolvedAudioExtractContentType(storedContentType, payloadContentType, reso
 // audio_extract_text task. Terminal business outcomes return a nil error; runtime
 // misconfiguration and transient failures return a retryable error.
 func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExtractTaskSpec) (AudioExtractResult, error) {
+	start := time.Now()
+	var result AudioExtractResult
+	defer func() {
+		metrics.RecordOperation("audio_extract", "process", legacyAudioExtractMetricResult(result), time.Since(start))
+	}()
+
 	if !b.SupportsAsyncAudioExtract() {
-		return AudioExtractResultRuntimeNotConfigured, fmt.Errorf("async audio extract runtime not configured")
+		result = AudioExtractResultRuntimeNotConfigured
+		return result, fmt.Errorf("async audio extract runtime not configured")
 	}
 	if b.monthlyLLMCostExceededCheck(ctx) {
 		metrics.RecordOperation("llm_cost_budget", "process_skip", "budget_exhausted", 0)
-		return AudioExtractResultBudgetExhausted, nil
+		result = AudioExtractResultBudgetExhausted
+		return result, nil
 	}
 
 	f, err := b.store.GetFile(ctx, task.FileID)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
-			return AudioExtractResultFileNotFound, nil
+			result = AudioExtractResultFileNotFound
+			return result, nil
 		}
-		return AudioExtractResultGetFileError, fmt.Errorf("get file: %w", err)
+		result = AudioExtractResultGetFileError
+		return result, fmt.Errorf("get file: %w", err)
 	}
 	if f.Status != datastore.StatusConfirmed {
-		return AudioExtractResultNotConfirmed, nil
+		result = AudioExtractResultNotConfirmed
+		return result, nil
 	}
 	if task.Revision > 0 && f.Revision != task.Revision {
-		return AudioExtractResultStale, nil
+		result = AudioExtractResultStale
+		return result, nil
 	}
 	resolvedMIME := resolvedAudioMIMEForHandler(task.Path, f.ContentType, task.ContentType)
 	if resolvedMIME == "" {
-		return AudioExtractResultNotAudio, nil
+		result = AudioExtractResultNotAudio
+		return result, nil
 	}
 	extractorContentType := resolvedAudioExtractContentType(f.ContentType, task.ContentType, resolvedMIME)
 	if extractorContentType == "" {
@@ -313,9 +327,11 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 	data, err := b.loadAudioBytesForExtract(ctx, f)
 	if err != nil {
 		if errors.Is(err, errAudioExtractSourceTooLarge) {
-			return AudioExtractResultTooLarge, nil
+			result = AudioExtractResultTooLarge
+			return result, nil
 		}
-		return AudioExtractResultLoadError, fmt.Errorf("load audio bytes: %w", err)
+		result = AudioExtractResultLoadError
+		return result, fmt.Errorf("load audio bytes: %w", err)
 	}
 
 	taskCtx, cancel := context.WithTimeout(ctx, b.audioExtractTimeout)
@@ -327,12 +343,14 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 	})
 	cancel()
 	if err != nil {
-		return AudioExtractResultExtractError, fmt.Errorf("extract audio text: %w", err)
+		result = AudioExtractResultExtractError
+		return result, fmt.Errorf("extract audio text: %w", err)
 	}
 	b.recordAudioExtractUsage(task.FileID, audioUsage)
 	text = sanitizeExtractedText(text, b.maxAudioExtractTextBytes)
 	if text == "" {
-		return AudioExtractResultEmptyText, nil
+		result = AudioExtractResultEmptyText
+		return result, nil
 	}
 
 	// Always revision-gate writeback: UpdateFileSearchTextTx treats expectedRevision<=0
@@ -352,12 +370,28 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 		return txErr
 	})
 	if err != nil {
-		return AudioExtractResultUpdateError, fmt.Errorf("update file search text: %w", err)
+		result = AudioExtractResultUpdateError
+		return result, fmt.Errorf("update file search text: %w", err)
 	}
 	if !updated {
-		return AudioExtractResultStale, nil
+		result = AudioExtractResultStale
+		return result, nil
 	}
-	return AudioExtractResultWritten, nil
+	result = AudioExtractResultWritten
+	return result, nil
+}
+
+func legacyAudioExtractMetricResult(result AudioExtractResult) string {
+	switch result {
+	case AudioExtractResultFileNotFound, AudioExtractResultGetFileError:
+		return "get_file_error"
+	case AudioExtractResultTooLarge:
+		return "skip_too_large"
+	case AudioExtractResultWritten:
+		return "ok"
+	default:
+		return string(result)
+	}
 }
 
 func injectedAudioExtractWritebackError(name string) error {

--- a/pkg/backend/audio_extract_test.go
+++ b/pkg/backend/audio_extract_test.go
@@ -2,11 +2,13 @@ package backend
 
 import (
 	"context"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 )
 
 type staticAudioExtractor struct {
@@ -35,6 +37,12 @@ func (e *recordingAudioExtractor) ExtractAudioText(ctx context.Context, req Audi
 	return e.text, AudioExtractUsage{}, nil
 }
 
+func readBackendMetrics() string {
+	recorder := httptest.NewRecorder()
+	metrics.WritePrometheus(recorder)
+	return recorder.Body.String()
+}
+
 func TestProcessAudioExtractTaskWritesContentText(t *testing.T) {
 	b := newTestBackendWithOptions(t, Options{
 		DatabaseAutoEmbedding: true,
@@ -59,6 +67,46 @@ func TestProcessAudioExtractTaskWritesContentText(t *testing.T) {
 	got := waitForContentText(t, b, "/rec/clip.mp3", time.Second)
 	if !strings.Contains(got, "keyword") {
 		t.Fatalf("unexpected content_text: %q", got)
+	}
+}
+
+func TestAsyncAudioExtractMetricsExposed(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{
+		DatabaseAutoEmbedding: true,
+		AsyncAudioExtract: AsyncAudioExtractOptions{
+			Enabled:             true,
+			MaxAudioBytes:       4096,
+			TaskTimeout:         3 * time.Second,
+			MaxExtractTextBytes: 777,
+			Extractor:           &staticAudioExtractor{text: "spoken keyword in transcript"},
+		},
+	})
+	fileID := insertImageFileForExtractTest(t, b, "/rec/metrics.mp3", "audio/mpeg", []byte{0xff, 0xf3, 0x80})
+	result, err := b.ProcessAudioExtractTask(context.Background(), AudioExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/rec/metrics.mp3",
+		ContentType: "audio/mpeg",
+		Revision:    1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != AudioExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, AudioExtractResultWritten)
+	}
+
+	metricsText := readBackendMetrics()
+	if !strings.Contains(metricsText, "dat9_module_up{module=\"audio_extract\"} 1") {
+		t.Fatalf("metrics missing audio_extract module availability: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 4096") {
+		t.Fatalf("metrics missing audio_extract runtime gauge: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_operations_total{component=\"audio_extract\",operation=\"process\",result=\"ok\"}") {
+		t.Fatalf("metrics missing audio_extract process counter: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_operation_duration_seconds_count{component=\"audio_extract\",operation=\"process\",result=\"ok\"}") {
+		t.Fatalf("metrics missing audio_extract duration histogram: %s", metricsText)
 	}
 }
 

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -106,6 +106,7 @@ type Dat9Backend struct {
 	maxAudioExtractTextBytes int
 
 	fileGCWorker *FileGCWorker
+	runtimeMetricsID uint64
 
 	// Monthly LLM cost budget (P1).
 	maxMonthlyLLMCostMillicents     int64
@@ -124,6 +125,7 @@ func newBaseBackend(store *datastore.Store) *Dat9Backend {
 		entropy:             ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0),
 		inlineThreshold:     DefaultInlineThreshold,
 		textExtractMaxBytes: DefaultTextExtractMaxBytes,
+		runtimeMetricsID:    globalBackendRuntimeMetrics.allocateID(),
 	}
 }
 

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -110,10 +110,10 @@ func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revi
 	select {
 	case b.imageExtractQueue <- task:
 		metrics.RecordOperation("image_extract", "enqueue", "ok", 0)
-		metrics.RecordGauge("image_extract", "queue_depth", float64(len(b.imageExtractQueue)))
+		globalBackendRuntimeMetrics.setImageQueueDepth(b.runtimeMetricsID, len(b.imageExtractQueue))
 	default:
 		metrics.RecordOperation("image_extract", "enqueue", "queue_full", 0)
-		metrics.RecordGauge("image_extract", "queue_depth", float64(len(b.imageExtractQueue)))
+		globalBackendRuntimeMetrics.setImageQueueDepth(b.runtimeMetricsID, len(b.imageExtractQueue))
 		logger.Warn(backgroundWithTrace(), "backend_image_extract_queue_full_drop",
 			zap.String("file_id", fileID),
 			zap.String("path", path),
@@ -170,7 +170,7 @@ func (b *Dat9Backend) runImageExtractWorker(ctx context.Context, workerID int) {
 			logger.Info(ctx, "backend_image_extract_worker_stopped", zap.Int("worker_id", workerID), zap.String("reason", "context_canceled"))
 			return
 		case task := <-b.imageExtractQueue:
-			metrics.RecordGauge("image_extract", "queue_depth", float64(len(b.imageExtractQueue)))
+			globalBackendRuntimeMetrics.setImageQueueDepth(b.runtimeMetricsID, len(b.imageExtractQueue))
 			b.processQueuedImageExtractTask(ctx, task)
 		}
 	}

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mem9-ai/dat9/pkg/embedding"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
-	"github.com/mem9-ai/dat9/pkg/metrics"
 	"go.uber.org/zap"
 )
 
@@ -258,10 +257,7 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		b.imageExtractMaxSize = cfg.MaxImageBytes
 		b.maxExtractTextBytes = cfg.MaxExtractTextBytes
 		b.imageExtractQueue = make(chan ImageExtractTaskSpec, cfg.QueueSize)
-		metrics.SetModuleAvailability("image_extract", true)
-		metrics.RecordGauge("image_extract", "queue_capacity", float64(cfg.QueueSize))
-		metrics.RecordGauge("image_extract", "workers", float64(cfg.Workers))
-		metrics.RecordGauge("image_extract", "queue_depth", 0)
+		globalBackendRuntimeMetrics.activateImage(b.runtimeMetricsID, cfg.QueueSize, cfg.Workers)
 
 		ctx, cancel := context.WithCancel(backgroundWithTrace())
 		b.imageExtractCancel = cancel
@@ -294,10 +290,7 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		b.audioExtractTimeout = a.TaskTimeout
 		b.audioExtractMaxSize = a.MaxAudioBytes
 		b.maxAudioExtractTextBytes = a.MaxExtractTextBytes
-		metrics.SetModuleAvailability("audio_extract", true)
-		metrics.RecordGauge("audio_extract", "max_audio_bytes", float64(a.MaxAudioBytes))
-		metrics.RecordGauge("audio_extract", "max_extract_text_bytes", float64(a.MaxExtractTextBytes))
-		metrics.RecordGauge("audio_extract", "task_timeout_seconds", a.TaskTimeout.Seconds())
+		globalBackendRuntimeMetrics.activateAudio(b.runtimeMetricsID, a.MaxAudioBytes, a.MaxExtractTextBytes, a.TaskTimeout)
 		logger.Info(backgroundWithTrace(), "backend_audio_extract_runtime_configured",
 			zap.Duration("task_timeout", a.TaskTimeout),
 			zap.Int64("max_audio_bytes", a.MaxAudioBytes),
@@ -313,17 +306,14 @@ func (b *Dat9Backend) Close() {
 		b.imageExtractCancel()
 		b.imageExtractWG.Wait()
 		b.imageExtractCancel = nil
-		metrics.SetModuleAvailability("image_extract", false)
-		metrics.RecordGauge("image_extract", "workers", 0)
-		metrics.RecordGauge("image_extract", "queue_depth", 0)
+		globalBackendRuntimeMetrics.deactivateImage(b.runtimeMetricsID)
+		b.imageExtractEnabled = false
 		logger.Info(backgroundWithTrace(), "backend_image_extract_workers_stopped",
 			zap.Int("queue_depth", len(b.imageExtractQueue)),
 			zap.Int("queue_size", cap(b.imageExtractQueue)))
 	}
 	if b.audioExtractEnabled {
-		metrics.SetModuleAvailability("audio_extract", false)
-		metrics.RecordGauge("audio_extract", "max_audio_bytes", 0)
-		metrics.RecordGauge("audio_extract", "max_extract_text_bytes", 0)
-		metrics.RecordGauge("audio_extract", "task_timeout_seconds", 0)
+		globalBackendRuntimeMetrics.deactivateAudio(b.runtimeMetricsID)
+		b.audioExtractEnabled = false
 	}
 }

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -258,6 +258,7 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		b.imageExtractMaxSize = cfg.MaxImageBytes
 		b.maxExtractTextBytes = cfg.MaxExtractTextBytes
 		b.imageExtractQueue = make(chan ImageExtractTaskSpec, cfg.QueueSize)
+		metrics.SetModuleAvailability("image_extract", true)
 		metrics.RecordGauge("image_extract", "queue_capacity", float64(cfg.QueueSize))
 		metrics.RecordGauge("image_extract", "workers", float64(cfg.Workers))
 		metrics.RecordGauge("image_extract", "queue_depth", 0)
@@ -293,6 +294,10 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		b.audioExtractTimeout = a.TaskTimeout
 		b.audioExtractMaxSize = a.MaxAudioBytes
 		b.maxAudioExtractTextBytes = a.MaxExtractTextBytes
+		metrics.SetModuleAvailability("audio_extract", true)
+		metrics.RecordGauge("audio_extract", "max_audio_bytes", float64(a.MaxAudioBytes))
+		metrics.RecordGauge("audio_extract", "max_extract_text_bytes", float64(a.MaxExtractTextBytes))
+		metrics.RecordGauge("audio_extract", "task_timeout_seconds", a.TaskTimeout.Seconds())
 		logger.Info(backgroundWithTrace(), "backend_audio_extract_runtime_configured",
 			zap.Duration("task_timeout", a.TaskTimeout),
 			zap.Int64("max_audio_bytes", a.MaxAudioBytes),
@@ -304,15 +309,21 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 // Close stops background workers owned by this backend instance.
 func (b *Dat9Backend) Close() {
 	b.stopFileGCWorker()
-	if b.imageExtractCancel == nil {
-		return
+	if b.imageExtractCancel != nil {
+		b.imageExtractCancel()
+		b.imageExtractWG.Wait()
+		b.imageExtractCancel = nil
+		metrics.SetModuleAvailability("image_extract", false)
+		metrics.RecordGauge("image_extract", "workers", 0)
+		metrics.RecordGauge("image_extract", "queue_depth", 0)
+		logger.Info(backgroundWithTrace(), "backend_image_extract_workers_stopped",
+			zap.Int("queue_depth", len(b.imageExtractQueue)),
+			zap.Int("queue_size", cap(b.imageExtractQueue)))
 	}
-	b.imageExtractCancel()
-	b.imageExtractWG.Wait()
-	b.imageExtractCancel = nil
-	metrics.RecordGauge("image_extract", "workers", 0)
-	metrics.RecordGauge("image_extract", "queue_depth", 0)
-	logger.Info(backgroundWithTrace(), "backend_image_extract_workers_stopped",
-		zap.Int("queue_depth", len(b.imageExtractQueue)),
-		zap.Int("queue_size", cap(b.imageExtractQueue)))
+	if b.audioExtractEnabled {
+		metrics.SetModuleAvailability("audio_extract", false)
+		metrics.RecordGauge("audio_extract", "max_audio_bytes", 0)
+		metrics.RecordGauge("audio_extract", "max_extract_text_bytes", 0)
+		metrics.RecordGauge("audio_extract", "task_timeout_seconds", 0)
+	}
 }

--- a/pkg/backend/runtime_metrics.go
+++ b/pkg/backend/runtime_metrics.go
@@ -1,0 +1,158 @@
+package backend
+
+import (
+	"sync"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/metrics"
+)
+
+type backendRuntimeMetrics struct {
+	mu     sync.Mutex
+	nextID uint64
+	image  map[uint64]imageRuntimeState
+	audio  map[uint64]audioRuntimeState
+}
+
+type imageRuntimeState struct {
+	queueCapacity int
+	workers       int
+	queueDepth    int
+}
+
+type audioRuntimeState struct {
+	maxAudioBytes       int64
+	maxExtractTextBytes int
+	taskTimeoutSeconds  float64
+}
+
+type imageRuntimeSummary struct {
+	active        bool
+	queueCapacity float64
+	workers       float64
+	queueDepth    float64
+}
+
+type audioRuntimeSummary struct {
+	active              bool
+	maxAudioBytes       float64
+	maxExtractTextBytes float64
+	taskTimeoutSeconds  float64
+}
+
+var globalBackendRuntimeMetrics = newBackendRuntimeMetrics()
+
+func newBackendRuntimeMetrics() *backendRuntimeMetrics {
+	return &backendRuntimeMetrics{
+		image: make(map[uint64]imageRuntimeState),
+		audio: make(map[uint64]audioRuntimeState),
+	}
+}
+
+func (m *backendRuntimeMetrics) allocateID() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextID++
+	return m.nextID
+}
+
+func (m *backendRuntimeMetrics) activateImage(id uint64, queueCapacity, workers int) {
+	m.mu.Lock()
+	m.image[id] = imageRuntimeState{
+		queueCapacity: queueCapacity,
+		workers:       workers,
+	}
+	summary := m.imageSummaryLocked()
+	m.mu.Unlock()
+	publishImageRuntimeSummary(summary)
+}
+
+func (m *backendRuntimeMetrics) setImageQueueDepth(id uint64, queueDepth int) {
+	m.mu.Lock()
+	state, ok := m.image[id]
+	if !ok {
+		m.mu.Unlock()
+		return
+	}
+	state.queueDepth = queueDepth
+	m.image[id] = state
+	summary := m.imageSummaryLocked()
+	m.mu.Unlock()
+	publishImageRuntimeSummary(summary)
+}
+
+func (m *backendRuntimeMetrics) deactivateImage(id uint64) {
+	m.mu.Lock()
+	delete(m.image, id)
+	summary := m.imageSummaryLocked()
+	m.mu.Unlock()
+	publishImageRuntimeSummary(summary)
+}
+
+func (m *backendRuntimeMetrics) activateAudio(id uint64, maxAudioBytes int64, maxExtractTextBytes int, taskTimeout time.Duration) {
+	m.mu.Lock()
+	m.audio[id] = audioRuntimeState{
+		maxAudioBytes:       maxAudioBytes,
+		maxExtractTextBytes: maxExtractTextBytes,
+		taskTimeoutSeconds:  taskTimeout.Seconds(),
+	}
+	summary := m.audioSummaryLocked()
+	m.mu.Unlock()
+	publishAudioRuntimeSummary(summary)
+}
+
+func (m *backendRuntimeMetrics) deactivateAudio(id uint64) {
+	m.mu.Lock()
+	delete(m.audio, id)
+	summary := m.audioSummaryLocked()
+	m.mu.Unlock()
+	publishAudioRuntimeSummary(summary)
+}
+
+func (m *backendRuntimeMetrics) imageSummaryLocked() imageRuntimeSummary {
+	var summary imageRuntimeSummary
+	if len(m.image) == 0 {
+		return summary
+	}
+	summary.active = true
+	for _, state := range m.image {
+		summary.queueCapacity += float64(state.queueCapacity)
+		summary.workers += float64(state.workers)
+		summary.queueDepth += float64(state.queueDepth)
+	}
+	return summary
+}
+
+func (m *backendRuntimeMetrics) audioSummaryLocked() audioRuntimeSummary {
+	var summary audioRuntimeSummary
+	if len(m.audio) == 0 {
+		return summary
+	}
+	summary.active = true
+	for _, state := range m.audio {
+		if value := float64(state.maxAudioBytes); value > summary.maxAudioBytes {
+			summary.maxAudioBytes = value
+		}
+		if value := float64(state.maxExtractTextBytes); value > summary.maxExtractTextBytes {
+			summary.maxExtractTextBytes = value
+		}
+		if state.taskTimeoutSeconds > summary.taskTimeoutSeconds {
+			summary.taskTimeoutSeconds = state.taskTimeoutSeconds
+		}
+	}
+	return summary
+}
+
+func publishImageRuntimeSummary(summary imageRuntimeSummary) {
+	metrics.SetModuleAvailability("image_extract", summary.active)
+	metrics.RecordGauge("image_extract", "queue_capacity", summary.queueCapacity)
+	metrics.RecordGauge("image_extract", "workers", summary.workers)
+	metrics.RecordGauge("image_extract", "queue_depth", summary.queueDepth)
+}
+
+func publishAudioRuntimeSummary(summary audioRuntimeSummary) {
+	metrics.SetModuleAvailability("audio_extract", summary.active)
+	metrics.RecordGauge("audio_extract", "max_audio_bytes", summary.maxAudioBytes)
+	metrics.RecordGauge("audio_extract", "max_extract_text_bytes", summary.maxExtractTextBytes)
+	metrics.RecordGauge("audio_extract", "task_timeout_seconds", summary.taskTimeoutSeconds)
+}

--- a/pkg/backend/runtime_metrics_test.go
+++ b/pkg/backend/runtime_metrics_test.go
@@ -1,0 +1,89 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
+	b1 := newTestBackendWithOptions(t, Options{
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   2,
+			QueueSize: 5,
+			Extractor: &staticImageExtractor{text: "one"},
+		},
+		AsyncAudioExtract: AsyncAudioExtractOptions{
+			Enabled:             true,
+			MaxAudioBytes:       4096,
+			TaskTimeout:         3 * time.Second,
+			MaxExtractTextBytes: 777,
+			Extractor:           &staticAudioExtractor{text: "one"},
+		},
+	})
+	b2 := newTestBackendWithOptions(t, Options{
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 3,
+			Extractor: &staticImageExtractor{text: "two"},
+		},
+		AsyncAudioExtract: AsyncAudioExtractOptions{
+			Enabled:             true,
+			MaxAudioBytes:       2048,
+			TaskTimeout:         2 * time.Second,
+			MaxExtractTextBytes: 555,
+			Extractor:           &staticAudioExtractor{text: "two"},
+		},
+	})
+
+	metricsText := readBackendMetrics()
+	if !strings.Contains(metricsText, "dat9_module_up{module=\"image_extract\"} 1") {
+		t.Fatalf("metrics missing aggregated image_extract availability: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 8") {
+		t.Fatalf("metrics missing aggregated image queue capacity: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"image_extract\",name=\"workers\"} 3") {
+		t.Fatalf("metrics missing aggregated image workers: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 4096") {
+		t.Fatalf("metrics missing aggregated audio max bytes: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\"} 3") {
+		t.Fatalf("metrics missing aggregated audio timeout: %s", metricsText)
+	}
+
+	b1.Close()
+
+	metricsText = readBackendMetrics()
+	if !strings.Contains(metricsText, "dat9_module_up{module=\"image_extract\"} 1") {
+		t.Fatalf("metrics should keep image_extract available while one backend remains: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 3") {
+		t.Fatalf("metrics should retain remaining image queue capacity: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"image_extract\",name=\"workers\"} 1") {
+		t.Fatalf("metrics should retain remaining image workers: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 2048") {
+		t.Fatalf("metrics should retain remaining audio max bytes: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"max_extract_text_bytes\"} 555") {
+		t.Fatalf("metrics should retain remaining audio text limit: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\"} 2") {
+		t.Fatalf("metrics should retain remaining audio timeout: %s", metricsText)
+	}
+
+	b2.Close()
+
+	metricsText = readBackendMetrics()
+	if !strings.Contains(metricsText, "dat9_module_up{module=\"image_extract\"} 0") {
+		t.Fatalf("metrics should mark image_extract unavailable once all backends close: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_module_up{module=\"audio_extract\"} 0") {
+		t.Fatalf("metrics should mark audio_extract unavailable once all backends close: %s", metricsText)
+	}
+}

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+
+	"github.com/mem9-ai/dat9/pkg/metrics"
 )
 
 type perfFuseOp int
@@ -149,6 +151,7 @@ func newFusePerfCounters(enabled bool) *fusePerfCounters {
 	if !enabled {
 		return nil
 	}
+	metrics.SetModuleAvailability("fuse", true)
 	return &fusePerfCounters{
 		enabled: true,
 		start:   time.Now(),
@@ -322,12 +325,28 @@ func (fs *Dat9FS) perfRecordFuse(op perfFuseOp, start time.Time, status gofuse.S
 	if !fs.perfEnabled() || start.IsZero() {
 		return
 	}
-	fs.perf.recordFuseOp(op, status, time.Since(start), bytes)
+	dur := time.Since(start)
+	fs.perf.recordFuseOp(op, status, dur, bytes)
+	result := "ok"
+	if status != gofuse.OK {
+		result = "error"
+	}
+	if op >= 0 && op < perfFuseOpCount {
+		metrics.RecordFuseOperation(perfFuseOpNames[op], result, dur, bytes)
+	}
 }
 
 func (fs *Dat9FS) perfRecordRemote(op perfRemoteOp, start time.Time, err error, bytes uint64) {
 	if !fs.perfEnabled() || start.IsZero() {
 		return
 	}
-	fs.perf.recordRemoteOp(op, err, time.Since(start), bytes)
+	dur := time.Since(start)
+	fs.perf.recordRemoteOp(op, err, dur, bytes)
+	result := "ok"
+	if err != nil {
+		result = "error"
+	}
+	if op >= 0 && op < perfRemoteOpCount {
+		metrics.RecordFuseRemoteOperation(perfRemoteOpNames[op], result, dur, bytes)
+	}
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -46,7 +46,7 @@ func TestMetaDBMetrics(t *testing.T) {
 	rec := httptest.NewRecorder()
 	metrics.WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `dat9_db_operations_total{role="meta"`) {
+	if !strings.Contains(text, `dat9_db_operations_total{operation="`) || !strings.Contains(text, `role="meta"`) {
 		t.Fatalf("expected meta db operation metric in response: %s", text)
 	}
 	if !strings.Contains(text, `dat9_db_pool_registered{role="meta"}`) {

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -9,12 +9,8 @@ import (
 )
 
 type dbMetrics struct {
-	mu             sync.RWMutex
-	counts         map[string]int64
-	durationCount  map[string]int64
-	durationSum    map[string]float64
-	durationBucket map[string][]int64
-	dbs            map[*sql.DB]string
+	mu  sync.RWMutex
+	dbs map[*sql.DB]string
 }
 
 type dbPoolTotals struct {
@@ -33,37 +29,30 @@ type dbPoolTotals struct {
 var dbOperationDurationBounds = []float64{0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
 
 var globalDB = &dbMetrics{
-	counts:         map[string]int64{},
-	durationCount:  map[string]int64{},
-	durationSum:    map[string]float64{},
-	durationBucket: map[string][]int64{},
-	dbs:            map[*sql.DB]string{},
+	dbs: map[*sql.DB]string{},
 }
 
+var dbMeter = globalMeterProvider.Meter("db")
+var dbOperationsTotal = dbMeter.Int64Counter("dat9_db_operations_total", "Database operations by role/operation/result/tenant_id")
+var dbOperationDuration = dbMeter.Float64Histogram("dat9_db_operation_duration_seconds", "Database operation duration histogram", dbOperationDurationBounds)
+
 func RecordDBOperation(role, operation, result, tenantID string, d time.Duration) {
-	key := dbLabels(role, operation, result, tenantID)
-	globalDB.mu.Lock()
-	globalDB.counts[key]++
-	globalDB.durationCount[key]++
-	globalDB.durationSum[key] += d.Seconds()
-	buckets := globalDB.durationBucket[key]
-	if buckets == nil {
-		buckets = make([]int64, len(dbOperationDurationBounds))
-		globalDB.durationBucket[key] = buckets
+	RegisterModule("db")
+	attrs := []Attribute{
+		Attr("role", cleanMetricValue(role, "unknown")),
+		Attr("operation", cleanMetricValue(operation, "unknown")),
+		Attr("result", cleanMetricValue(result, "unknown")),
+		Attr("tenant_id", tenantID),
 	}
-	seconds := d.Seconds()
-	for i, bound := range dbOperationDurationBounds {
-		if seconds <= bound {
-			buckets[i]++
-		}
-	}
-	globalDB.mu.Unlock()
+	dbOperationsTotal.Add(1, attrs...)
+	dbOperationDuration.Observe(d.Seconds(), attrs...)
 }
 
 func RegisterDB(role string, db *sql.DB) {
 	if db == nil {
 		return
 	}
+	RegisterModule("db")
 	globalDB.mu.Lock()
 	globalDB.dbs[db] = role
 	globalDB.mu.Unlock()
@@ -80,44 +69,11 @@ func UnregisterDB(db *sql.DB) {
 
 func writeDBPrometheus(w http.ResponseWriter) {
 	globalDB.mu.RLock()
-	countKeys := SortedKeys(globalDB.counts)
-	counts := CloneIntMap(globalDB.counts)
-	durationCount := CloneIntMap(globalDB.durationCount)
-	durationSum := CloneFloatMap(globalDB.durationSum)
-	durationBucket := CloneBucketMap(globalDB.durationBucket)
 	dbByRole := make(map[*sql.DB]string, len(globalDB.dbs))
 	for db, role := range globalDB.dbs {
 		dbByRole[db] = role
 	}
 	globalDB.mu.RUnlock()
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_db_operations_total Database operations by role/operation/result/tenant_id")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_operations_total counter")
-	for _, k := range countKeys {
-		_, _ = fmt.Fprintf(w, "dat9_db_operations_total{%s} %d\n", k, counts[k])
-	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_db_operation_duration_seconds Database operation duration histogram")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_operation_duration_seconds histogram")
-	for _, k := range countKeys {
-		buckets := durationBucket[k]
-		for i, bound := range dbOperationDurationBounds {
-			_, _ = fmt.Fprintf(w, "dat9_db_operation_duration_seconds_bucket{%s,le=\"%s\"} %d\n", k, FormatPromBound(bound), buckets[i])
-		}
-		_, _ = fmt.Fprintf(w, "dat9_db_operation_duration_seconds_bucket{%s,le=\"+Inf\"} %d\n", k, durationCount[k])
-	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_db_operation_duration_seconds_count Database operation duration count")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_operation_duration_seconds_count counter")
-	for _, k := range countKeys {
-		_, _ = fmt.Fprintf(w, "dat9_db_operation_duration_seconds_count{%s} %d\n", k, durationCount[k])
-	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_db_operation_duration_seconds_sum Database operation duration sum in seconds")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_operation_duration_seconds_sum counter")
-	for _, k := range countKeys {
-		_, _ = fmt.Fprintf(w, "dat9_db_operation_duration_seconds_sum{%s} %.6f\n", k, durationSum[k])
-	}
 
 	poolTotals := make(map[string]dbPoolTotals)
 	for db, role := range dbByRole {
@@ -175,8 +131,4 @@ func writeDBPrometheus(w http.ResponseWriter) {
 		_, _ = fmt.Fprintf(w, "dat9_db_pool_closes_total{role=\"%s\",reason=\"max_idle_time\"} %d\n", escapedRole, totals.maxIdleTimeClosed)
 		_, _ = fmt.Fprintf(w, "dat9_db_pool_closes_total{role=\"%s\",reason=\"max_lifetime\"} %d\n", escapedRole, totals.maxLifetimeClosed)
 	}
-}
-
-func dbLabels(role, operation, result, tenantID string) string {
-	return "role=\"" + EscapePromLabel(role) + "\",operation=\"" + EscapePromLabel(operation) + "\",result=\"" + EscapePromLabel(result) + "\",tenant_id=\"" + EscapePromLabel(tenantID) + "\""
 }

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -33,16 +33,15 @@ var globalDB = &dbMetrics{
 }
 
 var dbMeter = globalMeterProvider.Meter("db")
-var dbOperationsTotal = dbMeter.Int64Counter("dat9_db_operations_total", "Database operations by role/operation/result/tenant_id")
+var dbOperationsTotal = dbMeter.Int64Counter("dat9_db_operations_total", "Database operations by role/operation/result")
 var dbOperationDuration = dbMeter.Float64Histogram("dat9_db_operation_duration_seconds", "Database operation duration histogram", dbOperationDurationBounds)
 
-func RecordDBOperation(role, operation, result, tenantID string, d time.Duration) {
+func RecordDBOperation(role, operation, result string, d time.Duration) {
 	RegisterModule("db")
 	attrs := []Attribute{
 		Attr("role", cleanMetricValue(role, "unknown")),
 		Attr("operation", cleanMetricValue(operation, "unknown")),
 		Attr("result", cleanMetricValue(result, "unknown")),
-		Attr("tenant_id", tenantID),
 	}
 	dbOperationsTotal.Add(1, attrs...)
 	dbOperationDuration.Observe(d.Seconds(), attrs...)

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -84,6 +84,11 @@ func RecordHTTPInFlight(value float64) {
 	httpInflight.Set(value)
 }
 
+func RecordHTTPInFlightRoute(route string, value float64) {
+	RegisterModule("server")
+	httpInflight.Set(value, Attr("route", cleanMetricValue(route, "other")))
+}
+
 func RecordEvent(event string, labels ...string) {
 	RegisterModule("server")
 	attrs := make([]Attribute, 0, len(labels)/2+1)

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -1,111 +1,138 @@
-// Package metrics provides process-wide service operation metrics.
+// Package metrics provides process-wide metrics with an OpenTelemetry-like
+// meter/instrument/attribute model and a Prometheus text exporter.
 package metrics
 
 import (
-	"fmt"
 	"net/http"
-	"sync"
+	"strconv"
+	"strings"
 	"time"
 )
 
-type opMetrics struct {
-	mu             sync.RWMutex
-	counts         map[string]int64
-	durationCount  map[string]int64
-	durationSum    map[string]float64
-	durationBucket map[string][]int64
-	gauges         map[string]float64
+var operationDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
+var httpDurationBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+var globalRegistry = NewRegistry()
+var globalMeterProvider = NewMeterProvider(globalRegistry)
+
+var serviceMeter = globalMeterProvider.Meter("service")
+var httpMeter = globalMeterProvider.Meter("http")
+var eventMeter = globalMeterProvider.Meter("event")
+var fuseMeter = globalMeterProvider.Meter("fuse")
+
+var serviceOperationsTotal = serviceMeter.Int64Counter("dat9_service_operations_total", "Service operations by component/operation/result")
+var serviceOperationDuration = serviceMeter.Float64Histogram("dat9_service_operation_duration_seconds", "Service operation duration histogram", operationDurationBounds)
+var serviceGauge = serviceMeter.Float64Gauge("dat9_service_gauge", "Service gauges by component/name")
+
+var httpRequestsTotal = httpMeter.Int64Counter("dat9_http_requests_total", "Total HTTP requests by method/route/status")
+var httpRequestDuration = httpMeter.Float64Histogram("dat9_http_request_duration_seconds", "HTTP request duration histogram by method/route", httpDurationBounds)
+var httpInflight = httpMeter.Float64Gauge("dat9_http_inflight_requests", "Current in-flight HTTP requests")
+
+var tenantEventsTotal = eventMeter.Int64Counter("dat9_tenant_events_total", "Tenant/business lifecycle events")
+
+var fuseOperationsTotal = fuseMeter.Int64Counter("dat9_fuse_operations_total", "FUSE operations by operation/result")
+var fuseOperationDuration = fuseMeter.Float64Histogram("dat9_fuse_operation_duration_seconds", "FUSE operation duration histogram", operationDurationBounds)
+var fuseOperationBytes = fuseMeter.Int64Counter("dat9_fuse_operation_bytes_total", "Bytes processed by FUSE operation/result")
+var fuseRemoteOperationsTotal = fuseMeter.Int64Counter("dat9_fuse_remote_operations_total", "Remote FUSE operations by operation/result")
+var fuseRemoteOperationDuration = fuseMeter.Float64Histogram("dat9_fuse_remote_operation_duration_seconds", "Remote FUSE operation duration histogram", operationDurationBounds)
+var fuseRemoteOperationBytes = fuseMeter.Int64Counter("dat9_fuse_remote_operation_bytes_total", "Bytes processed by remote FUSE operation/result")
+
+func RegisterModule(module string) {
+	globalRegistry.RegisterModule(module)
 }
 
-var operationDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
-
-var globalOps = &opMetrics{
-	counts:         map[string]int64{},
-	durationCount:  map[string]int64{},
-	durationSum:    map[string]float64{},
-	durationBucket: map[string][]int64{},
-	gauges:         map[string]float64{},
+func SetModuleAvailability(module string, up bool) {
+	globalRegistry.SetModuleAvailability(module, up)
 }
 
 func RecordOperation(component, operation, result string, d time.Duration) {
-	key := labels(component, operation, result)
-	globalOps.mu.Lock()
-	globalOps.counts[key]++
-	globalOps.durationCount[key]++
-	globalOps.durationSum[key] += d.Seconds()
-	buckets := globalOps.durationBucket[key]
-	if buckets == nil {
-		buckets = make([]int64, len(operationDurationBounds))
-		globalOps.durationBucket[key] = buckets
+	component = cleanMetricValue(component, "unknown")
+	operation = cleanMetricValue(operation, "unknown")
+	result = cleanMetricValue(result, "unknown")
+	RegisterModule(component)
+	attrs := []Attribute{
+		Attr("component", component),
+		Attr("operation", operation),
+		Attr("result", result),
 	}
-	seconds := d.Seconds()
-	for i, bound := range operationDurationBounds {
-		if seconds <= bound {
-			buckets[i]++
-		}
-	}
-	globalOps.mu.Unlock()
+	serviceOperationsTotal.Add(1, attrs...)
+	serviceOperationDuration.Observe(d.Seconds(), attrs...)
 }
 
 func RecordGauge(component, name string, value float64) {
-	key := gaugeLabels(component, name)
-	globalOps.mu.Lock()
-	globalOps.gauges[key] = value
-	globalOps.mu.Unlock()
+	component = cleanMetricValue(component, "unknown")
+	name = cleanMetricValue(name, "unknown")
+	RegisterModule(component)
+	serviceGauge.Set(value, Attr("component", component), Attr("name", name))
+}
+
+func RecordHTTPRequest(method, route string, status int, d time.Duration) {
+	RegisterModule("server")
+	httpRequestsTotal.Add(1,
+		Attr("method", cleanMetricValue(method, "UNKNOWN")),
+		Attr("route", cleanMetricValue(route, "other")),
+		Attr("status", strconv.Itoa(status)),
+	)
+	httpRequestDuration.Observe(d.Seconds(),
+		Attr("method", cleanMetricValue(method, "UNKNOWN")),
+		Attr("route", cleanMetricValue(route, "other")),
+	)
+}
+
+func RecordHTTPInFlight(value float64) {
+	RegisterModule("server")
+	httpInflight.Set(value)
+}
+
+func RecordEvent(event string, labels ...string) {
+	RegisterModule("server")
+	attrs := make([]Attribute, 0, len(labels)/2+1)
+	attrs = append(attrs, Attr("event", cleanMetricValue(event, "unknown")))
+	for i := 0; i+1 < len(labels); i += 2 {
+		attrs = append(attrs, Attr(labels[i], labels[i+1]))
+	}
+	tenantEventsTotal.Add(1, attrs...)
+}
+
+func RecordFuseOperation(operation, result string, d time.Duration, bytes uint64) {
+	RegisterModule("fuse")
+	attrs := []Attribute{
+		Attr("operation", cleanMetricValue(operation, "unknown")),
+		Attr("result", cleanMetricValue(result, "unknown")),
+	}
+	fuseOperationsTotal.Add(1, attrs...)
+	fuseOperationDuration.Observe(d.Seconds(), attrs...)
+	if bytes > 0 {
+		fuseOperationBytes.Add(int64(bytes), attrs...)
+	}
+}
+
+func RecordFuseRemoteOperation(operation, result string, d time.Duration, bytes uint64) {
+	RegisterModule("fuse")
+	attrs := []Attribute{
+		Attr("operation", cleanMetricValue(operation, "unknown")),
+		Attr("result", cleanMetricValue(result, "unknown")),
+	}
+	fuseRemoteOperationsTotal.Add(1, attrs...)
+	fuseRemoteOperationDuration.Observe(d.Seconds(), attrs...)
+	if bytes > 0 {
+		fuseRemoteOperationBytes.Add(int64(bytes), attrs...)
+	}
 }
 
 func WritePrometheus(w http.ResponseWriter) {
-	globalOps.mu.RLock()
-	countKeys := SortedKeys(globalOps.counts)
-	counts := CloneIntMap(globalOps.counts)
-	durationCount := CloneIntMap(globalOps.durationCount)
-	durationSum := CloneFloatMap(globalOps.durationSum)
-	durationBucket := CloneBucketMap(globalOps.durationBucket)
-	gaugeKeys := SortedKeys(globalOps.gauges)
-	gauges := CloneFloatMap(globalOps.gauges)
-	globalOps.mu.RUnlock()
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operations_total Service operations by component/operation/result")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_operations_total counter")
-	for _, k := range countKeys {
-		_, _ = fmt.Fprintf(w, "dat9_service_operations_total{%s} %d\n", k, counts[k])
+	if w == nil {
+		return
 	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operation_duration_seconds Service operation duration histogram")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_operation_duration_seconds histogram")
-	for _, k := range countKeys {
-		buckets := durationBucket[k]
-		for i, bound := range operationDurationBounds {
-			_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_bucket{%s,le=\"%s\"} %d\n", k, FormatPromBound(bound), buckets[i])
-		}
-		_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_bucket{%s,le=\"+Inf\"} %d\n", k, durationCount[k])
-	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operation_duration_seconds_count Service operation duration count")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_operation_duration_seconds_count counter")
-	for _, k := range countKeys {
-		_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_count{%s} %d\n", k, durationCount[k])
-	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_service_operation_duration_seconds_sum Service operation duration sum in seconds")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_operation_duration_seconds_sum counter")
-	for _, k := range countKeys {
-		_, _ = fmt.Fprintf(w, "dat9_service_operation_duration_seconds_sum{%s} %.6f\n", k, durationSum[k])
-	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_service_gauge Service gauges by component/name")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_service_gauge gauge")
-	for _, k := range gaugeKeys {
-		_, _ = fmt.Fprintf(w, "dat9_service_gauge{%s} %.6f\n", k, gauges[k])
-	}
-
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+	globalRegistry.WritePrometheus(w)
 	writeDBPrometheus(w)
 }
 
-func labels(component, operation, result string) string {
-	return "component=\"" + EscapePromLabel(component) + "\",operation=\"" + EscapePromLabel(operation) + "\",result=\"" + EscapePromLabel(result) + "\""
-}
-
-func gaugeLabels(component, name string) string {
-	return "component=\"" + EscapePromLabel(component) + "\",name=\"" + EscapePromLabel(name) + "\""
+func cleanMetricValue(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
 }

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -1,0 +1,471 @@
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Attribute struct {
+	Key   string
+	Value string
+}
+
+func Attr(key, value string) Attribute {
+	return Attribute{Key: key, Value: value}
+}
+
+type instrumentKind string
+
+const (
+	instrumentCounter   instrumentKind = "counter"
+	instrumentGauge     instrumentKind = "gauge"
+	instrumentHistogram instrumentKind = "histogram"
+)
+
+type descriptor struct {
+	name   string
+	help   string
+	scope  string
+	kind   instrumentKind
+	bounds []float64
+}
+
+type counterInstrument struct {
+	desc   descriptor
+	values map[string]int64
+}
+
+type gaugeInstrument struct {
+	desc   descriptor
+	values map[string]float64
+}
+
+type histogramSample struct {
+	count   int64
+	sum     float64
+	buckets []int64
+}
+
+type histogramInstrument struct {
+	desc    descriptor
+	values  map[string]*histogramSample
+	bounds  []float64
+	boundsS []string
+}
+
+type moduleState struct {
+	registeredAt time.Time
+	up           float64
+}
+
+type Registry struct {
+	mu sync.RWMutex
+
+	counters   map[string]*counterInstrument
+	gauges     map[string]*gaugeInstrument
+	histograms map[string]*histogramInstrument
+	modules    map[string]moduleState
+}
+
+type MeterProvider struct {
+	registry *Registry
+}
+
+type Meter struct {
+	scope    string
+	registry *Registry
+}
+
+type Int64Counter struct {
+	registry *Registry
+	name     string
+}
+
+type Float64Gauge struct {
+	registry *Registry
+	name     string
+}
+
+type Float64Histogram struct {
+	registry *Registry
+	name     string
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		counters:   map[string]*counterInstrument{},
+		gauges:     map[string]*gaugeInstrument{},
+		histograms: map[string]*histogramInstrument{},
+		modules:    map[string]moduleState{},
+	}
+}
+
+func NewMeterProvider(registry *Registry) *MeterProvider {
+	if registry == nil {
+		registry = NewRegistry()
+	}
+	return &MeterProvider{registry: registry}
+}
+
+func (p *MeterProvider) Meter(scope string) *Meter {
+	return &Meter{scope: strings.TrimSpace(scope), registry: p.registry}
+}
+
+func (m *Meter) Int64Counter(name, help string) *Int64Counter {
+	m.registry.ensureCounter(name, help, m.scope)
+	return &Int64Counter{registry: m.registry, name: name}
+}
+
+func (m *Meter) Float64Gauge(name, help string) *Float64Gauge {
+	m.registry.ensureGauge(name, help, m.scope)
+	return &Float64Gauge{registry: m.registry, name: name}
+}
+
+func (m *Meter) Float64Histogram(name, help string, bounds []float64) *Float64Histogram {
+	m.registry.ensureHistogram(name, help, m.scope, bounds)
+	return &Float64Histogram{registry: m.registry, name: name}
+}
+
+func (c *Int64Counter) Add(value int64, attrs ...Attribute) {
+	if c == nil || c.registry == nil || value == 0 {
+		return
+	}
+	c.registry.addCounter(c.name, labelsKey(attrs), value)
+}
+
+func (g *Float64Gauge) Set(value float64, attrs ...Attribute) {
+	if g == nil || g.registry == nil {
+		return
+	}
+	g.registry.setGauge(g.name, labelsKey(attrs), value)
+}
+
+func (h *Float64Histogram) Observe(value float64, attrs ...Attribute) {
+	if h == nil || h.registry == nil {
+		return
+	}
+	h.registry.observeHistogram(h.name, labelsKey(attrs), value)
+}
+
+func (r *Registry) RegisterModule(module string) {
+	module = strings.TrimSpace(module)
+	if module == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.modules[module]; ok {
+		return
+	}
+	r.modules[module] = moduleState{registeredAt: time.Now(), up: 1}
+}
+
+func (r *Registry) SetModuleAvailability(module string, up bool) {
+	module = strings.TrimSpace(module)
+	if module == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	state := r.modules[module]
+	if state.registeredAt.IsZero() {
+		state.registeredAt = time.Now()
+	}
+	if up {
+		state.up = 1
+	} else {
+		state.up = 0
+	}
+	r.modules[module] = state
+}
+
+func (r *Registry) ensureCounter(name, help, scope string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if inst, ok := r.counters[name]; ok {
+		if inst.desc.kind != instrumentCounter {
+			panic(fmt.Sprintf("metrics: %s already registered with kind %s", name, inst.desc.kind))
+		}
+		return
+	}
+	r.counters[name] = &counterInstrument{
+		desc:   descriptor{name: name, help: help, scope: scope, kind: instrumentCounter},
+		values: map[string]int64{},
+	}
+}
+
+func (r *Registry) ensureGauge(name, help, scope string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if inst, ok := r.gauges[name]; ok {
+		if inst.desc.kind != instrumentGauge {
+			panic(fmt.Sprintf("metrics: %s already registered with kind %s", name, inst.desc.kind))
+		}
+		return
+	}
+	r.gauges[name] = &gaugeInstrument{
+		desc:   descriptor{name: name, help: help, scope: scope, kind: instrumentGauge},
+		values: map[string]float64{},
+	}
+}
+
+func (r *Registry) ensureHistogram(name, help, scope string, bounds []float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if inst, ok := r.histograms[name]; ok {
+		if inst.desc.kind != instrumentHistogram {
+			panic(fmt.Sprintf("metrics: %s already registered with kind %s", name, inst.desc.kind))
+		}
+		return
+	}
+	cleanBounds := make([]float64, len(bounds))
+	copy(cleanBounds, bounds)
+	sort.Float64s(cleanBounds)
+	boundStrings := make([]string, len(cleanBounds))
+	for i, bound := range cleanBounds {
+		boundStrings[i] = FormatPromBound(bound)
+	}
+	r.histograms[name] = &histogramInstrument{
+		desc:    descriptor{name: name, help: help, scope: scope, kind: instrumentHistogram, bounds: cleanBounds},
+		values:  map[string]*histogramSample{},
+		bounds:  cleanBounds,
+		boundsS: boundStrings,
+	}
+}
+
+func (r *Registry) addCounter(name, labels string, value int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inst := r.counters[name]
+	if inst == nil {
+		panic(fmt.Sprintf("metrics: counter %s not registered", name))
+	}
+	inst.values[labels] += value
+}
+
+func (r *Registry) setGauge(name, labels string, value float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inst := r.gauges[name]
+	if inst == nil {
+		panic(fmt.Sprintf("metrics: gauge %s not registered", name))
+	}
+	inst.values[labels] = value
+}
+
+func (r *Registry) observeHistogram(name, labels string, value float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inst := r.histograms[name]
+	if inst == nil {
+		panic(fmt.Sprintf("metrics: histogram %s not registered", name))
+	}
+	sample := inst.values[labels]
+	if sample == nil {
+		sample = &histogramSample{buckets: make([]int64, len(inst.bounds))}
+		inst.values[labels] = sample
+	}
+	sample.count++
+	sample.sum += value
+	for i, bound := range inst.bounds {
+		if value <= bound {
+			sample.buckets[i]++
+		}
+	}
+}
+
+func (r *Registry) WritePrometheus(w io.Writer) {
+	if r == nil || w == nil {
+		return
+	}
+	r.writeModules(w)
+	r.writeCounters(w)
+	r.writeHistograms(w)
+	r.writeGauges(w)
+}
+
+func (r *Registry) writeModules(w io.Writer) {
+	r.mu.RLock()
+	modules := make(map[string]moduleState, len(r.modules))
+	for module, state := range r.modules {
+		modules[module] = state
+	}
+	r.mu.RUnlock()
+
+	now := time.Now()
+	names := make([]string, 0, len(modules))
+	for module := range modules {
+		names = append(names, module)
+	}
+	sort.Strings(names)
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_module_up Module availability state")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_module_up gauge")
+	for _, module := range names {
+		writeMetricLine(w, "dat9_module_up", labelsKey([]Attribute{Attr("module", module)}), formatFloat(modules[module].up))
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP dat9_module_uptime_seconds Module uptime in seconds since first registration")
+	_, _ = fmt.Fprintln(w, "# TYPE dat9_module_uptime_seconds gauge")
+	for _, module := range names {
+		state := modules[module]
+		uptime := 0.0
+		if !state.registeredAt.IsZero() {
+			uptime = now.Sub(state.registeredAt).Seconds()
+		}
+		writeMetricLine(w, "dat9_module_uptime_seconds", labelsKey([]Attribute{Attr("module", module)}), formatFloat(uptime))
+	}
+}
+
+func (r *Registry) writeCounters(w io.Writer) {
+	r.mu.RLock()
+	names := make([]string, 0, len(r.counters))
+	for name := range r.counters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		inst := r.counters[name]
+		labels := SortedKeys(inst.values)
+		values := CloneIntMap(inst.values)
+		_, _ = fmt.Fprintf(w, "# HELP %s %s\n", inst.desc.name, inst.desc.help)
+		_, _ = fmt.Fprintf(w, "# TYPE %s counter\n", inst.desc.name)
+		for _, labelSet := range labels {
+			writeMetricLine(w, inst.desc.name, labelSet, fmt.Sprintf("%d", values[labelSet]))
+		}
+	}
+	r.mu.RUnlock()
+}
+
+func (r *Registry) writeHistograms(w io.Writer) {
+	r.mu.RLock()
+	names := make([]string, 0, len(r.histograms))
+	for name := range r.histograms {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		inst := r.histograms[name]
+		labels := make([]string, 0, len(inst.values))
+		samples := make(map[string]histogramSample, len(inst.values))
+		for labelSet, sample := range inst.values {
+			labels = append(labels, labelSet)
+			copied := histogramSample{count: sample.count, sum: sample.sum, buckets: make([]int64, len(sample.buckets))}
+			copy(copied.buckets, sample.buckets)
+			samples[labelSet] = copied
+		}
+		sort.Strings(labels)
+		_, _ = fmt.Fprintf(w, "# HELP %s %s\n", inst.desc.name, inst.desc.help)
+		_, _ = fmt.Fprintf(w, "# TYPE %s histogram\n", inst.desc.name)
+		for _, labelSet := range labels {
+			sample := samples[labelSet]
+			for i, bound := range inst.boundsS {
+				writeMetricLine(w, inst.desc.name+"_bucket", appendBound(labelSet, bound), fmt.Sprintf("%d", sample.buckets[i]))
+			}
+			writeMetricLine(w, inst.desc.name+"_bucket", appendBound(labelSet, "+Inf"), fmt.Sprintf("%d", sample.count))
+			writeMetricLine(w, inst.desc.name+"_count", labelSet, fmt.Sprintf("%d", sample.count))
+			writeMetricLine(w, inst.desc.name+"_sum", labelSet, formatFloat(sample.sum))
+		}
+	}
+	r.mu.RUnlock()
+}
+
+func (r *Registry) writeGauges(w io.Writer) {
+	r.mu.RLock()
+	names := make([]string, 0, len(r.gauges))
+	for name := range r.gauges {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		inst := r.gauges[name]
+		labels := SortedKeys(inst.values)
+		values := CloneFloatMap(inst.values)
+		_, _ = fmt.Fprintf(w, "# HELP %s %s\n", inst.desc.name, inst.desc.help)
+		_, _ = fmt.Fprintf(w, "# TYPE %s gauge\n", inst.desc.name)
+		for _, labelSet := range labels {
+			writeMetricLine(w, inst.desc.name, labelSet, formatFloat(values[labelSet]))
+		}
+	}
+	r.mu.RUnlock()
+}
+
+func labelsKey(attrs []Attribute) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+	labels := make(map[string]string, len(attrs))
+	keys := make([]string, 0, len(attrs))
+	seen := make(map[string]struct{}, len(attrs))
+	for _, attr := range attrs {
+		key := normalizeLabelKey(attr.Key)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; !ok {
+			keys = append(keys, key)
+			seen[key] = struct{}{}
+		}
+		labels[key] = attr.Value
+	}
+	if len(labels) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, key := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(key)
+		b.WriteString(`="`)
+		b.WriteString(EscapePromLabel(labels[key]))
+		b.WriteString(`"`)
+	}
+	return b.String()
+}
+
+func normalizeLabelKey(key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+func appendBound(labels, bound string) string {
+	if labels == "" {
+		return `le="` + bound + `"`
+	}
+	return labels + `,le="` + bound + `"`
+}
+
+func writeMetricLine(w io.Writer, name, labels, value string) {
+	if labels == "" {
+		_, _ = fmt.Fprintf(w, "%s %s\n", name, value)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "%s{%s} %s\n", name, labels, value)
+}
+
+func formatFloat(value float64) string {
+	return fmt.Sprintf("%.6f", value)
+}

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -57,6 +57,25 @@ type histogramInstrument struct {
 	boundsS []string
 }
 
+type counterSnapshot struct {
+	desc   descriptor
+	labels []string
+	values map[string]int64
+}
+
+type gaugeSnapshot struct {
+	desc   descriptor
+	labels []string
+	values map[string]float64
+}
+
+type histogramSnapshot struct {
+	desc    descriptor
+	labels  []string
+	samples map[string]histogramSample
+	boundsS []string
+}
+
 type moduleState struct {
 	registeredAt time.Time
 	up           float64
@@ -328,17 +347,23 @@ func (r *Registry) writeCounters(w io.Writer) {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	snapshots := make([]counterSnapshot, 0, len(names))
 	for _, name := range names {
 		inst := r.counters[name]
-		labels := SortedKeys(inst.values)
-		values := CloneIntMap(inst.values)
-		_, _ = fmt.Fprintf(w, "# HELP %s %s\n", inst.desc.name, inst.desc.help)
-		_, _ = fmt.Fprintf(w, "# TYPE %s counter\n", inst.desc.name)
-		for _, labelSet := range labels {
-			writeMetricLine(w, inst.desc.name, labelSet, fmt.Sprintf("%d", values[labelSet]))
-		}
+		snapshots = append(snapshots, counterSnapshot{
+			desc:   inst.desc,
+			labels: SortedKeys(inst.values),
+			values: CloneIntMap(inst.values),
+		})
 	}
 	r.mu.RUnlock()
+	for _, snapshot := range snapshots {
+		_, _ = fmt.Fprintf(w, "# HELP %s %s\n", snapshot.desc.name, snapshot.desc.help)
+		_, _ = fmt.Fprintf(w, "# TYPE %s counter\n", snapshot.desc.name)
+		for _, labelSet := range snapshot.labels {
+			writeMetricLine(w, snapshot.desc.name, labelSet, fmt.Sprintf("%d", snapshot.values[labelSet]))
+		}
+	}
 }
 
 func (r *Registry) writeHistograms(w io.Writer) {
@@ -348,6 +373,7 @@ func (r *Registry) writeHistograms(w io.Writer) {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	snapshots := make([]histogramSnapshot, 0, len(names))
 	for _, name := range names {
 		inst := r.histograms[name]
 		labels := make([]string, 0, len(inst.values))
@@ -359,19 +385,27 @@ func (r *Registry) writeHistograms(w io.Writer) {
 			samples[labelSet] = copied
 		}
 		sort.Strings(labels)
-		_, _ = fmt.Fprintf(w, "# HELP %s %s\n", inst.desc.name, inst.desc.help)
-		_, _ = fmt.Fprintf(w, "# TYPE %s histogram\n", inst.desc.name)
-		for _, labelSet := range labels {
-			sample := samples[labelSet]
-			for i, bound := range inst.boundsS {
-				writeMetricLine(w, inst.desc.name+"_bucket", appendBound(labelSet, bound), fmt.Sprintf("%d", sample.buckets[i]))
-			}
-			writeMetricLine(w, inst.desc.name+"_bucket", appendBound(labelSet, "+Inf"), fmt.Sprintf("%d", sample.count))
-			writeMetricLine(w, inst.desc.name+"_count", labelSet, fmt.Sprintf("%d", sample.count))
-			writeMetricLine(w, inst.desc.name+"_sum", labelSet, formatFloat(sample.sum))
-		}
+		snapshots = append(snapshots, histogramSnapshot{
+			desc:    inst.desc,
+			labels:  labels,
+			samples: samples,
+			boundsS: append([]string(nil), inst.boundsS...),
+		})
 	}
 	r.mu.RUnlock()
+	for _, snapshot := range snapshots {
+		_, _ = fmt.Fprintf(w, "# HELP %s %s\n", snapshot.desc.name, snapshot.desc.help)
+		_, _ = fmt.Fprintf(w, "# TYPE %s histogram\n", snapshot.desc.name)
+		for _, labelSet := range snapshot.labels {
+			sample := snapshot.samples[labelSet]
+			for i, bound := range snapshot.boundsS {
+				writeMetricLine(w, snapshot.desc.name+"_bucket", appendBound(labelSet, bound), fmt.Sprintf("%d", sample.buckets[i]))
+			}
+			writeMetricLine(w, snapshot.desc.name+"_bucket", appendBound(labelSet, "+Inf"), fmt.Sprintf("%d", sample.count))
+			writeMetricLine(w, snapshot.desc.name+"_count", labelSet, fmt.Sprintf("%d", sample.count))
+			writeMetricLine(w, snapshot.desc.name+"_sum", labelSet, formatFloat(sample.sum))
+		}
+	}
 }
 
 func (r *Registry) writeGauges(w io.Writer) {
@@ -381,17 +415,23 @@ func (r *Registry) writeGauges(w io.Writer) {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	snapshots := make([]gaugeSnapshot, 0, len(names))
 	for _, name := range names {
 		inst := r.gauges[name]
-		labels := SortedKeys(inst.values)
-		values := CloneFloatMap(inst.values)
-		_, _ = fmt.Fprintf(w, "# HELP %s %s\n", inst.desc.name, inst.desc.help)
-		_, _ = fmt.Fprintf(w, "# TYPE %s gauge\n", inst.desc.name)
-		for _, labelSet := range labels {
-			writeMetricLine(w, inst.desc.name, labelSet, formatFloat(values[labelSet]))
-		}
+		snapshots = append(snapshots, gaugeSnapshot{
+			desc:   inst.desc,
+			labels: SortedKeys(inst.values),
+			values: CloneFloatMap(inst.values),
+		})
 	}
 	r.mu.RUnlock()
+	for _, snapshot := range snapshots {
+		_, _ = fmt.Fprintf(w, "# HELP %s %s\n", snapshot.desc.name, snapshot.desc.help)
+		_, _ = fmt.Fprintf(w, "# TYPE %s gauge\n", snapshot.desc.name)
+		for _, labelSet := range snapshot.labels {
+			writeMetricLine(w, snapshot.desc.name, labelSet, formatFloat(snapshot.values[labelSet]))
+		}
+	}
 }
 
 func labelsKey(attrs []Attribute) string {
@@ -415,6 +455,7 @@ func labelsKey(attrs []Attribute) string {
 	if len(labels) == 0 {
 		return ""
 	}
+	sort.Strings(keys)
 	var b strings.Builder
 	for i, key := range keys {
 		if i > 0 {

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -11,7 +11,6 @@ import (
 	mysql "github.com/go-sql-driver/mysql"
 
 	"github.com/mem9-ai/dat9/pkg/metrics"
-	"github.com/mem9-ai/dat9/pkg/tenantctx"
 )
 
 const (
@@ -115,7 +114,7 @@ func (c instrumentedConn) PrepareContext(ctx context.Context, query string) (dri
 	if err != nil {
 		return nil, err
 	}
-	return instrumentedStmt{base: stmt, role: c.role, tenantID: tenantctx.TenantIDFromContext(ctx)}, nil
+	return instrumentedStmt{base: stmt, role: c.role}, nil
 }
 
 func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
@@ -128,7 +127,7 @@ func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (d
 		if err != nil {
 			return nil, err
 		}
-		return instrumentedTx{base: tx, role: c.role, tenantID: tenantctx.TenantIDFromContext(ctx)}, nil
+		return instrumentedTx{base: tx, role: c.role}, nil
 	}
 	if opts.Isolation != driver.IsolationLevel(0) || opts.ReadOnly {
 		return nil, fmt.Errorf("driver does not support non-default transaction options")
@@ -189,7 +188,6 @@ func (c instrumentedConn) CheckNamedValue(nv *driver.NamedValue) error {
 type instrumentedStmt struct {
 	base driver.Stmt
 	role string
-	tenantID string
 }
 
 func (s instrumentedStmt) Close() error {
@@ -216,7 +214,7 @@ func (s instrumentedStmt) ExecContext(ctx context.Context, args []driver.NamedVa
 	start := time.Now()
 	res, err := execer.ExecContext(ctx, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(withTenantID(ctx, s.tenantID), s.role, "exec", start, err)
+		observeDBOperation(ctx, s.role, "exec", start, err)
 	}
 	return res, err
 }
@@ -229,7 +227,7 @@ func (s instrumentedStmt) QueryContext(ctx context.Context, args []driver.NamedV
 	start := time.Now()
 	rows, err := queryer.QueryContext(ctx, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(withTenantID(ctx, s.tenantID), s.role, "query", start, err)
+		observeDBOperation(ctx, s.role, "query", start, err)
 	}
 	return rows, err
 }
@@ -245,14 +243,13 @@ func (s instrumentedStmt) CheckNamedValue(nv *driver.NamedValue) error {
 type instrumentedTx struct {
 	base driver.Tx
 	role string
-	tenantID string
 }
 
 func (tx instrumentedTx) Commit() error {
 	start := time.Now()
 	err := tx.base.Commit()
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(withTenantID(context.Background(), tx.tenantID), tx.role, "commit", start, err)
+		observeDBOperation(context.Background(), tx.role, "commit", start, err)
 	}
 	return err
 }
@@ -261,20 +258,13 @@ func (tx instrumentedTx) Rollback() error {
 	start := time.Now()
 	err := tx.base.Rollback()
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(withTenantID(context.Background(), tx.tenantID), tx.role, "rollback", start, err)
+		observeDBOperation(context.Background(), tx.role, "rollback", start, err)
 	}
 	return err
 }
 
 func observeDBOperation(ctx context.Context, role, operation string, start time.Time, err error) {
-	metrics.RecordDBOperation(role, operation, dbResult(err), tenantctx.TenantIDFromContext(ctx), time.Since(start))
-}
-
-func withTenantID(ctx context.Context, tenantID string) context.Context {
-	if tenantctx.TenantIDFromContext(ctx) != "" {
-		return ctx
-	}
-	return tenantctx.WithTenantID(ctx, tenantID)
+	metrics.RecordDBOperation(role, operation, dbResult(err), time.Since(start))
 }
 
 func dbResult(err error) string {

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -128,6 +128,7 @@ func NewAWS(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {
 	}
 
 	client := s3.NewFromConfig(awsCfg, applyS3Options(cfg))
+	markS3ClientAvailable()
 	return &AWSS3Client{
 		client:  client,
 		presign: s3.NewPresignClient(client),
@@ -155,15 +156,21 @@ func (c *AWSS3Client) fullKey(key string) string {
 }
 
 func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo, encOpts EncryptionOpts) (*MultipartUpload, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("create_multipart_upload", result, start) }()
+
 	in := &s3.CreateMultipartUploadInput{
 		Bucket: &c.bucket,
 		Key:    aws.String(c.fullKey(key)),
 	}
 	if err := applyEncryptionToCreateMultipartUploadInput(in, encOpts); err != nil {
+		result = "error"
 		return nil, err
 	}
 	awsAlgo, ok, err := checksumAlgorithmForAWS(algo)
 	if err != nil {
+		result = "error"
 		return nil, err
 	}
 	if ok {
@@ -171,6 +178,7 @@ func (c *AWSS3Client) CreateMultipartUpload(ctx context.Context, key string, alg
 	}
 	out, err := c.client.CreateMultipartUpload(ctx, in)
 	if err != nil {
+		result = "error"
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 	return &MultipartUpload{
@@ -193,6 +201,10 @@ func checksumAlgorithmForAWS(algo ChecksumAlgo) (types.ChecksumAlgorithm, bool, 
 }
 
 func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, algo ChecksumAlgo, checksumValue string, ttl time.Duration) (*UploadPartURL, error) {
+	start := time.Now()
+	metricResult := "ok"
+	defer func() { recordS3Operation("presign_upload_part", metricResult, start) }()
+
 	if ttl > UploadTTL {
 		ttl = UploadTTL
 	}
@@ -223,13 +235,14 @@ func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID strin
 		func(o *s3.PresignOptions) { o.Presigner = partPresigner },
 	)
 	if err != nil {
+		metricResult = "error"
 		return nil, fmt.Errorf("presign upload part: %w", err)
 	}
 	headers := flattenSignedHeaders(out.SignedHeader)
 	if checksumValue != "" {
 		headers[headerKey] = checksumValue
 	}
-	result := &UploadPartURL{
+	urlResult := &UploadPartURL{
 		Number:    partNumber,
 		URL:       out.URL,
 		Size:      partSize,
@@ -238,11 +251,11 @@ func (c *AWSS3Client) PresignUploadPart(ctx context.Context, key, uploadID strin
 	}
 	switch algo {
 	case ChecksumAlgoCRC32C:
-		result.ChecksumCRC32C = checksumValue
+		urlResult.ChecksumCRC32C = checksumValue
 	default:
-		result.ChecksumSHA256 = checksumValue
+		urlResult.ChecksumSHA256 = checksumValue
 	}
-	return result, nil
+	return urlResult, nil
 }
 
 func flattenSignedHeaders(h http.Header) map[string]string {
@@ -266,6 +279,10 @@ func flattenSignedHeaders(h http.Header) map[string]string {
 }
 
 func (c *AWSS3Client) CompleteMultipartUpload(ctx context.Context, key, uploadID string, parts []Part) error {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("complete_multipart_upload", result, start) }()
+
 	completed := make([]types.CompletedPart, len(parts))
 	for i, p := range parts {
 		cp := types.CompletedPart{
@@ -288,24 +305,34 @@ func (c *AWSS3Client) CompleteMultipartUpload(ctx context.Context, key, uploadID
 		},
 	})
 	if err != nil {
+		result = "error"
 		return fmt.Errorf("complete multipart upload: %w", err)
 	}
 	return nil
 }
 
 func (c *AWSS3Client) AbortMultipartUpload(ctx context.Context, key, uploadID string) error {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("abort_multipart_upload", result, start) }()
+
 	_, err := c.client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
 		Bucket:   &c.bucket,
 		Key:      aws.String(c.fullKey(key)),
 		UploadId: &uploadID,
 	})
 	if err != nil {
+		result = "error"
 		return fmt.Errorf("abort multipart upload: %w", err)
 	}
 	return nil
 }
 
 func (c *AWSS3Client) ListParts(ctx context.Context, key, uploadID string) ([]Part, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("list_parts", result, start) }()
+
 	var parts []Part
 	var partMarker *string
 
@@ -317,6 +344,7 @@ func (c *AWSS3Client) ListParts(ctx context.Context, key, uploadID string) ([]Pa
 			PartNumberMarker: partMarker,
 		})
 		if err != nil {
+			result = "error"
 			return nil, fmt.Errorf("list parts: %w", err)
 		}
 		for _, p := range out.Parts {
@@ -337,6 +365,10 @@ func (c *AWSS3Client) ListParts(ctx context.Context, key, uploadID string) ([]Pa
 }
 
 func (c *AWSS3Client) PresignGetObject(ctx context.Context, key string, ttl time.Duration) (string, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("presign_get_object", result, start) }()
+
 	if ttl > DownloadTTL {
 		ttl = DownloadTTL
 	}
@@ -345,12 +377,17 @@ func (c *AWSS3Client) PresignGetObject(ctx context.Context, key string, ttl time
 		Key:    aws.String(c.fullKey(key)),
 	}, s3.WithPresignExpires(ttl))
 	if err != nil {
+		result = "error"
 		return "", fmt.Errorf("presign get object: %w", err)
 	}
 	return out.URL, nil
 }
 
 func (c *AWSS3Client) PutObject(ctx context.Context, key string, body io.Reader, size int64, encOpts EncryptionOpts) error {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("put_object", result, start) }()
+
 	in := &s3.PutObjectInput{
 		Bucket:        &c.bucket,
 		Key:           aws.String(c.fullKey(key)),
@@ -358,10 +395,12 @@ func (c *AWSS3Client) PutObject(ctx context.Context, key string, body io.Reader,
 		ContentLength: aws.Int64(size),
 	}
 	if err := applyEncryptionToPutObjectInput(in, encOpts); err != nil {
+		result = "error"
 		return err
 	}
 	_, err := c.client.PutObject(ctx, in)
 	if err != nil {
+		result = "error"
 		return fmt.Errorf("put object: %w", err)
 	}
 	return nil
@@ -477,28 +516,42 @@ func encodeKMSEncryptionContext(contextMap map[string]string) (*string, error) {
 }
 
 func (c *AWSS3Client) GetObject(ctx context.Context, key string) (io.ReadCloser, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("get_object", result, start) }()
+
 	out, err := c.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &c.bucket,
 		Key:    aws.String(c.fullKey(key)),
 	})
 	if err != nil {
+		result = "error"
 		return nil, fmt.Errorf("get object: %w", err)
 	}
 	return out.Body, nil
 }
 
 func (c *AWSS3Client) DeleteObject(ctx context.Context, key string) error {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("delete_object", result, start) }()
+
 	_, err := c.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: &c.bucket,
 		Key:    aws.String(c.fullKey(key)),
 	})
 	if err != nil {
+		result = "error"
 		return fmt.Errorf("delete object: %w", err)
 	}
 	return nil
 }
 
 func (c *AWSS3Client) UploadPartCopy(ctx context.Context, destKey, uploadID string, partNumber int, sourceKey string, startByte, endByte int64) (string, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("upload_part_copy", result, start) }()
+
 	copySource := fmt.Sprintf("%s/%s", c.bucket, c.fullKey(sourceKey))
 	copyRange := fmt.Sprintf("bytes=%d-%d", startByte, endByte)
 
@@ -511,12 +564,17 @@ func (c *AWSS3Client) UploadPartCopy(ctx context.Context, destKey, uploadID stri
 		CopySourceRange: aws.String(copyRange),
 	})
 	if err != nil {
+		result = "error"
 		return "", fmt.Errorf("upload part copy: %w", err)
 	}
 	return aws.ToString(out.CopyPartResult.ETag), nil
 }
 
 func (c *AWSS3Client) PresignGetObjectRange(ctx context.Context, key string, startByte, endByte int64, ttl time.Duration) (string, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("presign_get_object_range", result, start) }()
+
 	if ttl > DownloadTTL {
 		ttl = DownloadTTL
 	}
@@ -527,6 +585,7 @@ func (c *AWSS3Client) PresignGetObjectRange(ctx context.Context, key string, sta
 		Range:  aws.String(rangeHeader),
 	}, s3.WithPresignExpires(ttl))
 	if err != nil {
+		result = "error"
 		return "", fmt.Errorf("presign get object range: %w", err)
 	}
 	return out.URL, nil

--- a/pkg/s3client/local.go
+++ b/pkg/s3client/local.go
@@ -38,6 +38,7 @@ func NewLocal(rootDir, baseURL string) (*LocalS3Client, error) {
 	if err := os.MkdirAll(rootDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create s3 root: %w", err)
 	}
+	markS3ClientAvailable()
 	return &LocalS3Client{
 		rootDir: rootDir,
 		baseURL: baseURL,
@@ -54,10 +55,15 @@ func (c *LocalS3Client) partPath(key, uploadID string, partNumber int) string {
 }
 
 func (c *LocalS3Client) CreateMultipartUpload(ctx context.Context, key string, algo ChecksumAlgo, encOpts EncryptionOpts) (*MultipartUpload, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("create_multipart_upload", result, start) }()
+
 	uploadID := fmt.Sprintf("upload-%x", sha256.Sum256([]byte(key+time.Now().String())))[:24]
 
 	partsDir := filepath.Join(c.rootDir, "parts", uploadID)
 	if err := os.MkdirAll(partsDir, 0o755); err != nil {
+		result = "error"
 		return nil, fmt.Errorf("create parts dir: %w", err)
 	}
 
@@ -69,6 +75,10 @@ func (c *LocalS3Client) CreateMultipartUpload(ctx context.Context, key string, a
 }
 
 func (c *LocalS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, algo ChecksumAlgo, checksumValue string, ttl time.Duration) (*UploadPartURL, error) {
+	start := time.Now()
+	metricResult := "ok"
+	defer func() { recordS3Operation("presign_upload_part", metricResult, start) }()
+
 	url := fmt.Sprintf("%s/upload/%s/%d", c.baseURL, uploadID, partNumber)
 	var headers map[string]string
 	if checksumValue != "" {
@@ -79,7 +89,7 @@ func (c *LocalS3Client) PresignUploadPart(ctx context.Context, key, uploadID str
 			headers = map[string]string{"x-amz-checksum-sha256": checksumValue}
 		}
 	}
-	result := &UploadPartURL{
+	urlResult := &UploadPartURL{
 		Number:    partNumber,
 		URL:       url,
 		Size:      partSize,
@@ -88,32 +98,40 @@ func (c *LocalS3Client) PresignUploadPart(ctx context.Context, key, uploadID str
 	}
 	switch algo {
 	case ChecksumAlgoCRC32C:
-		result.ChecksumCRC32C = checksumValue
+		urlResult.ChecksumCRC32C = checksumValue
 	default:
-		result.ChecksumSHA256 = checksumValue
+		urlResult.ChecksumSHA256 = checksumValue
 	}
-	return result, nil
+	return urlResult, nil
 }
 
 // UploadPart directly writes a part (used by the local presigned URL handler).
 func (c *LocalS3Client) UploadPart(ctx context.Context, uploadID string, partNumber int, body io.Reader) (string, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("upload_part", result, start) }()
+
 	c.mu.Lock()
 	upload, ok := c.uploads[uploadID]
 	c.mu.Unlock()
 	if !ok {
+		result = "not_found"
 		return "", fmt.Errorf("upload not found: %s", uploadID)
 	}
 
 	data, err := io.ReadAll(body)
 	if err != nil {
+		result = "error"
 		return "", fmt.Errorf("read part body: %w", err)
 	}
 
 	path := c.partPath(upload.key, uploadID, partNumber)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		result = "error"
 		return "", err
 	}
 	if err := os.WriteFile(path, data, 0o644); err != nil {
+		result = "error"
 		return "", err
 	}
 
@@ -128,10 +146,15 @@ func (c *LocalS3Client) UploadPart(ctx context.Context, uploadID string, partNum
 }
 
 func (c *LocalS3Client) CompleteMultipartUpload(ctx context.Context, key, uploadID string, parts []Part) error {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("complete_multipart_upload", result, start) }()
+
 	c.mu.Lock()
 	upload, ok := c.uploads[uploadID]
 	c.mu.Unlock()
 	if !ok {
+		result = "not_found"
 		return fmt.Errorf("upload not found: %s", uploadID)
 	}
 
@@ -143,10 +166,12 @@ func (c *LocalS3Client) CompleteMultipartUpload(ctx context.Context, key, upload
 	// Assemble final object from parts
 	objPath := c.objectPath(key)
 	if err := os.MkdirAll(filepath.Dir(objPath), 0o755); err != nil {
+		result = "error"
 		return err
 	}
 	f, err := os.Create(objPath)
 	if err != nil {
+		result = "error"
 		return err
 	}
 	defer func() { _ = f.Close() }()
@@ -155,9 +180,11 @@ func (c *LocalS3Client) CompleteMultipartUpload(ctx context.Context, key, upload
 		partFile := c.partPath(upload.key, uploadID, p.Number)
 		data, err := os.ReadFile(partFile)
 		if err != nil {
+			result = "error"
 			return fmt.Errorf("read part %d: %w", p.Number, err)
 		}
 		if _, err := f.Write(data); err != nil {
+			result = "error"
 			return err
 		}
 	}
@@ -174,6 +201,9 @@ func (c *LocalS3Client) CompleteMultipartUpload(ctx context.Context, key, upload
 }
 
 func (c *LocalS3Client) AbortMultipartUpload(ctx context.Context, key, uploadID string) error {
+	start := time.Now()
+	defer func() { recordS3Operation("abort_multipart_upload", "ok", start) }()
+
 	partsDir := filepath.Join(c.rootDir, "parts", uploadID)
 	_ = os.RemoveAll(partsDir)
 
@@ -185,11 +215,16 @@ func (c *LocalS3Client) AbortMultipartUpload(ctx context.Context, key, uploadID 
 }
 
 func (c *LocalS3Client) ListParts(ctx context.Context, key, uploadID string) ([]Part, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("list_parts", result, start) }()
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	upload, ok := c.uploads[uploadID]
 	if !ok {
+		result = "not_found"
 		return nil, fmt.Errorf("upload not found: %s", uploadID)
 	}
 
@@ -202,35 +237,79 @@ func (c *LocalS3Client) ListParts(ctx context.Context, key, uploadID string) ([]
 }
 
 func (c *LocalS3Client) PresignGetObject(ctx context.Context, key string, ttl time.Duration) (string, error) {
+	start := time.Now()
+	defer func() { recordS3Operation("presign_get_object", "ok", start) }()
+
 	url := fmt.Sprintf("%s/objects/%s", c.baseURL, key)
 	return url, nil
 }
 
 func (c *LocalS3Client) PutObject(ctx context.Context, key string, body io.Reader, size int64, encOpts EncryptionOpts) error {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("put_object", result, start) }()
+
 	objPath := c.objectPath(key)
 	if err := os.MkdirAll(filepath.Dir(objPath), 0o755); err != nil {
+		result = "error"
 		return err
 	}
 	data, err := io.ReadAll(body)
 	if err != nil {
+		result = "error"
 		return err
 	}
-	return os.WriteFile(objPath, data, 0o644)
+	if err := os.WriteFile(objPath, data, 0o644); err != nil {
+		result = "error"
+		return err
+	}
+	return nil
 }
 
 func (c *LocalS3Client) GetObject(ctx context.Context, key string) (io.ReadCloser, error) {
-	return os.Open(c.objectPath(key))
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("get_object", result, start) }()
+
+	rc, err := os.Open(c.objectPath(key))
+	if err != nil {
+		if os.IsNotExist(err) {
+			result = "not_found"
+		} else {
+			result = "error"
+		}
+		return nil, err
+	}
+	return rc, nil
 }
 
 func (c *LocalS3Client) DeleteObject(ctx context.Context, key string) error {
-	return os.Remove(c.objectPath(key))
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("delete_object", result, start) }()
+
+	err := os.Remove(c.objectPath(key))
+	if err != nil {
+		if os.IsNotExist(err) {
+			result = "not_found"
+		} else {
+			result = "error"
+		}
+		return err
+	}
+	return nil
 }
 
 func (c *LocalS3Client) UploadPartCopy(ctx context.Context, destKey, uploadID string, partNumber int, sourceKey string, startByte, endByte int64) (string, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("upload_part_copy", result, start) }()
+
 	c.mu.Lock()
 	upload, ok := c.uploads[uploadID]
 	c.mu.Unlock()
 	if !ok {
+		result = "not_found"
 		return "", fmt.Errorf("upload not found: %s", uploadID)
 	}
 
@@ -238,6 +317,11 @@ func (c *LocalS3Client) UploadPartCopy(ctx context.Context, destKey, uploadID st
 	srcPath := c.objectPath(sourceKey)
 	f, err := os.Open(srcPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			result = "not_found"
+		} else {
+			result = "error"
+		}
 		return "", fmt.Errorf("open source object: %w", err)
 	}
 	defer func() { _ = f.Close() }()
@@ -246,6 +330,7 @@ func (c *LocalS3Client) UploadPartCopy(ctx context.Context, destKey, uploadID st
 	data := make([]byte, size)
 	n, err := f.ReadAt(data, startByte)
 	if err != nil && err != io.EOF {
+		result = "error"
 		return "", fmt.Errorf("read source range: %w", err)
 	}
 	data = data[:n]
@@ -253,9 +338,11 @@ func (c *LocalS3Client) UploadPartCopy(ctx context.Context, destKey, uploadID st
 	// Write as a part file
 	path := c.partPath(upload.key, uploadID, partNumber)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		result = "error"
 		return "", err
 	}
 	if err := os.WriteFile(path, data, 0o644); err != nil {
+		result = "error"
 		return "", err
 	}
 
@@ -270,6 +357,9 @@ func (c *LocalS3Client) UploadPartCopy(ctx context.Context, destKey, uploadID st
 }
 
 func (c *LocalS3Client) PresignGetObjectRange(ctx context.Context, key string, startByte, endByte int64, ttl time.Duration) (string, error) {
+	start := time.Now()
+	defer func() { recordS3Operation("presign_get_object_range", "ok", start) }()
+
 	url := fmt.Sprintf("%s/objects/%s?range=%d-%d", c.baseURL, key, startByte, endByte)
 	return url, nil
 }

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -7,7 +7,19 @@ import (
 	"context"
 	"io"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/metrics"
 )
+
+const metricsComponent = "s3client"
+
+func markS3ClientAvailable() {
+	metrics.SetModuleAvailability(metricsComponent, true)
+}
+
+func recordS3Operation(operation, result string, start time.Time) {
+	metrics.RecordOperation(metricsComponent, operation, result, time.Since(start))
+}
 
 // EncryptionMode identifies the storage encryption mode used for an object.
 type EncryptionMode string

--- a/pkg/s3client/s3client_test.go
+++ b/pkg/s3client/s3client_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/metrics"
 )
 
 func newTestClient(t *testing.T) *LocalS3Client {
@@ -22,6 +25,12 @@ func newTestClient(t *testing.T) *LocalS3Client {
 		t.Fatal(err)
 	}
 	return c
+}
+
+func readS3Metrics() string {
+	recorder := httptest.NewRecorder()
+	metrics.WritePrometheus(recorder)
+	return recorder.Body.String()
 }
 
 func TestCalcParts(t *testing.T) {
@@ -88,6 +97,38 @@ func TestDeleteObject(t *testing.T) {
 	_, err := c.GetObject(ctx, "blobs/del")
 	if err == nil {
 		t.Error("expected error after delete")
+	}
+}
+
+func TestS3MetricsExposed(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	data := []byte("hello metrics")
+	if err := c.PutObject(ctx, "blobs/metrics", bytes.NewReader(data), int64(len(data)), EncryptionOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	rc, err := c.GetObject(ctx, "blobs/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rc.Close() }()
+	if _, err := io.ReadAll(rc); err != nil {
+		t.Fatal(err)
+	}
+
+	metricsText := readS3Metrics()
+	if !strings.Contains(metricsText, "dat9_module_up{module=\"s3client\"} 1") {
+		t.Fatalf("metrics missing s3client module availability: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_operations_total{component=\"s3client\",operation=\"put_object\",result=\"ok\"}") {
+		t.Fatalf("metrics missing s3client put_object counter: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_operations_total{component=\"s3client\",operation=\"get_object\",result=\"ok\"}") {
+		t.Fatalf("metrics missing s3client get_object counter: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_operation_duration_seconds_count{component=\"s3client\",operation=\"get_object\",result=\"ok\"}") {
+		t.Fatalf("metrics missing s3client duration histogram: %s", metricsText)
 	}
 }
 

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -58,12 +59,14 @@ func metricEvent(ctx context.Context, event string, labels ...string) {
 
 type serverMetrics struct {
 	inFlight atomic.Int64
+	routeMu  sync.Mutex
+	routes   map[string]int64
 }
 
 func newServerMetrics() *serverMetrics {
 	metrics.SetModuleAvailability("server", true)
 	metrics.RecordHTTPInFlight(0)
-	return &serverMetrics{}
+	return &serverMetrics{routes: map[string]int64{}}
 }
 
 func (m *serverMetrics) record(method, route string, status int, d time.Duration) {
@@ -76,6 +79,22 @@ func (m *serverMetrics) recordEvent(event string, labels ...string) {
 
 func (m *serverMetrics) writePrometheus(w http.ResponseWriter) {
 	metrics.WritePrometheus(w)
+}
+
+func (m *serverMetrics) adjustRouteInFlight(route string, delta int64) int64 {
+	route = strings.TrimSpace(route)
+	if route == "" {
+		route = "other"
+	}
+	m.routeMu.Lock()
+	defer m.routeMu.Unlock()
+	next := m.routes[route] + delta
+	if next <= 0 {
+		delete(m.routes, route)
+		return 0
+	}
+	m.routes[route] = next
+	return next
 }
 
 type observedResponseWriter struct {
@@ -160,14 +179,17 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	w.Header().Set("X-Trace-ID", traceID)
 
 	start := time.Now()
+	route := requestRoute(r.URL.Path)
 	ow := &observedResponseWriter{ResponseWriter: w}
 	rw := http.ResponseWriter(ow)
 	if f, ok := w.(http.Flusher); ok {
 		rw = &flusherResponseWriter{observedResponseWriter: ow, flusher: f}
 	}
 	metrics.RecordHTTPInFlight(float64(s.metrics.inFlight.Add(1)))
+	metrics.RecordHTTPInFlightRoute(route, float64(s.metrics.adjustRouteInFlight(route, 1)))
 	defer func() {
 		metrics.RecordHTTPInFlight(float64(s.metrics.inFlight.Add(-1)))
+		metrics.RecordHTTPInFlightRoute(route, float64(s.metrics.adjustRouteInFlight(route, -1)))
 	}()
 
 	next.ServeHTTP(rw, r)
@@ -176,7 +198,6 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	}
 
 	dur := time.Since(start)
-	route := requestRoute(r.URL.Path)
 	s.metrics.record(r.Method, route, ow.status, dur)
 
 	tenantID := ""

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -60,137 +58,24 @@ func metricEvent(ctx context.Context, event string, labels ...string) {
 
 type serverMetrics struct {
 	inFlight atomic.Int64
-
-	mu             sync.RWMutex
-	requests       map[string]int64
-	durationCount  map[string]int64
-	durationSecond map[string]float64
-	durationBucket map[string][]int64
-	events         map[string]int64
 }
 
-var httpDurationBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
-
 func newServerMetrics() *serverMetrics {
-	return &serverMetrics{
-		requests:       make(map[string]int64),
-		durationCount:  make(map[string]int64),
-		durationSecond: make(map[string]float64),
-		durationBucket: make(map[string][]int64),
-		events:         make(map[string]int64),
-	}
+	metrics.SetModuleAvailability("server", true)
+	metrics.RecordHTTPInFlight(0)
+	return &serverMetrics{}
 }
 
 func (m *serverMetrics) record(method, route string, status int, d time.Duration) {
-	statusKey := metricLabels(method, route, strconv.Itoa(status))
-	durationKey := metricLabels(method, route)
-
-	m.mu.Lock()
-	m.requests[statusKey]++
-	m.durationCount[durationKey]++
-	m.durationSecond[durationKey] += d.Seconds()
-	buckets := m.durationBucket[durationKey]
-	if buckets == nil {
-		buckets = make([]int64, len(httpDurationBounds))
-		m.durationBucket[durationKey] = buckets
-	}
-	seconds := d.Seconds()
-	for i, bound := range httpDurationBounds {
-		if seconds <= bound {
-			buckets[i]++
-		}
-	}
-	m.mu.Unlock()
+	metrics.RecordHTTPRequest(method, route, status, d)
 }
 
 func (m *serverMetrics) recordEvent(event string, labels ...string) {
-	key := metricEventLabels(event, labels...)
-	m.mu.Lock()
-	m.events[key]++
-	m.mu.Unlock()
+	metrics.RecordEvent(event, labels...)
 }
 
 func (m *serverMetrics) writePrometheus(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_http_inflight_requests Current in-flight HTTP requests")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_inflight_requests gauge")
-	_, _ = fmt.Fprintf(w, "dat9_http_inflight_requests %d\n", m.inFlight.Load())
-
-	m.mu.RLock()
-	requestKeys := metrics.SortedKeys(m.requests)
-	durationKeys := metrics.SortedKeys(m.durationCount)
-	eventKeys := metrics.SortedKeys(m.events)
-	requests := metrics.CloneIntMap(m.requests)
-	durationCount := metrics.CloneIntMap(m.durationCount)
-	durationSecond := metrics.CloneFloatMap(m.durationSecond)
-	durationBucket := metrics.CloneBucketMap(m.durationBucket)
-	events := metrics.CloneIntMap(m.events)
-	m.mu.RUnlock()
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_http_requests_total Total HTTP requests by method/route/status")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_requests_total counter")
-	for _, k := range requestKeys {
-		_, _ = fmt.Fprintf(w, "dat9_http_requests_total{%s} %d\n", k, requests[k])
-	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_http_request_duration_seconds HTTP request duration histogram by method/route")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_request_duration_seconds histogram")
-	for _, k := range durationKeys {
-		buckets := durationBucket[k]
-		for i, bound := range httpDurationBounds {
-			_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_bucket{%s,le=\"%s\"} %d\n", k, metrics.FormatPromBound(bound), buckets[i])
-		}
-		_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_bucket{%s,le=\"+Inf\"} %d\n", k, durationCount[k])
-	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_http_request_duration_seconds_count HTTP request duration count by method/route")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_request_duration_seconds_count counter")
-	for _, k := range durationKeys {
-		_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_count{%s} %d\n", k, durationCount[k])
-	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_http_request_duration_seconds_sum HTTP request duration sum in seconds by method/route")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_http_request_duration_seconds_sum counter")
-	for _, k := range durationKeys {
-		_, _ = fmt.Fprintf(w, "dat9_http_request_duration_seconds_sum{%s} %.6f\n", k, durationSecond[k])
-	}
-
-	_, _ = fmt.Fprintln(w, "# HELP dat9_tenant_events_total Tenant/business lifecycle events")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_tenant_events_total counter")
-	for _, k := range eventKeys {
-		_, _ = fmt.Fprintf(w, "dat9_tenant_events_total{%s} %d\n", k, events[k])
-	}
-}
-
-func metricLabels(method, route string, status ...string) string {
-	b := strings.Builder{}
-	b.WriteString(`method="`)
-	b.WriteString(metrics.EscapePromLabel(method))
-	b.WriteString(`",route="`)
-	b.WriteString(metrics.EscapePromLabel(route))
-	b.WriteString(`"`)
-	if len(status) > 0 {
-		b.WriteString(`,status="`)
-		b.WriteString(metrics.EscapePromLabel(status[0]))
-		b.WriteString(`"`)
-	}
-	return b.String()
-}
-
-func metricEventLabels(event string, labels ...string) string {
-	b := strings.Builder{}
-	b.WriteString(`event="`)
-	b.WriteString(metrics.EscapePromLabel(event))
-	b.WriteString(`"`)
-	for i := 0; i+1 < len(labels); i += 2 {
-		b.WriteString(",")
-		b.WriteString(metrics.EscapePromLabel(labels[i]))
-		b.WriteString(`="`)
-		b.WriteString(metrics.EscapePromLabel(labels[i+1]))
-		b.WriteString(`"`)
-	}
-	return b.String()
+	metrics.WritePrometheus(w)
 }
 
 type observedResponseWriter struct {
@@ -280,8 +165,10 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	if f, ok := w.(http.Flusher); ok {
 		rw = &flusherResponseWriter{observedResponseWriter: ow, flusher: f}
 	}
-	s.metrics.inFlight.Add(1)
-	defer s.metrics.inFlight.Add(-1)
+	metrics.RecordHTTPInFlight(float64(s.metrics.inFlight.Add(1)))
+	defer func() {
+		metrics.RecordHTTPInFlight(float64(s.metrics.inFlight.Add(-1)))
+	}()
 
 	next.ServeHTTP(rw, r)
 	if ow.status == 0 {
@@ -327,5 +214,4 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.metrics.writePrometheus(w)
-	metrics.WritePrometheus(w)
 }

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -251,6 +251,7 @@ func (m *semanticWorkerManager) Start(ctx context.Context) {
 	}
 	workerCtx, cancel := context.WithCancel(backgroundWithTrace(ctx))
 	m.cancel = cancel
+	metrics.SetModuleAvailability("semantic_worker", true)
 	metrics.RecordGauge("semantic_worker", "workers", float64(m.opts.Workers))
 	metrics.RecordGauge("semantic_worker", "inflight", 0)
 	metrics.RecordGauge("semantic_worker", "queued", 0)
@@ -280,6 +281,7 @@ func (m *semanticWorkerManager) Stop() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.processing = 0
+	metrics.SetModuleAvailability("semantic_worker", false)
 	metrics.RecordGauge("semantic_worker", "workers", 0)
 	metrics.RecordGauge("semantic_worker", "inflight", 0)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -115,6 +115,7 @@ func NewWithConfig(cfg Config) *Server {
 	if logger == nil {
 		logger, _ = zap.NewProduction()
 	}
+	metrics.SetModuleAvailability("vault", false)
 	var vaultMK *vault.MasterKey
 	if len(cfg.VaultMasterKey) > 0 {
 		var err error

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/embedding"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/tagutil"
@@ -120,6 +121,8 @@ func NewWithConfig(cfg Config) *Server {
 		vaultMK, err = vault.NewMasterKey(cfg.VaultMasterKey)
 		if err != nil {
 			logger.Warn("vault master key invalid, vault disabled", zap.Error(err))
+		} else {
+			metrics.SetModuleAvailability("vault", true)
 		}
 	}
 	inlineThreshold := cfg.InlineThreshold

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1425,6 +1425,9 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, "dat9_http_inflight_requests") {
 		t.Fatalf("expected inflight metric in response: %s", text)
 	}
+	if !strings.Contains(text, `dat9_http_inflight_requests{route="/v1/fs/*"} 0.000000`) {
+		t.Fatalf("expected route-scoped inflight metric in response: %s", text)
+	}
 	if !strings.Contains(text, `dat9_service_operations_total{component="backend",operation="exec_sql",result="ok"}`) {
 		t.Fatalf("expected backend service metric in response: %s", text)
 	}
@@ -1434,7 +1437,7 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `dat9_service_operation_duration_seconds_bucket{component="backend",operation="exec_sql",result="ok",le="0.01"}`) {
 		t.Fatalf("expected service operation histogram bucket in response: %s", text)
 	}
-	if !strings.Contains(text, `dat9_db_operations_total{role="user"`) {
+	if !strings.Contains(text, `dat9_db_operations_total{operation="`) || !strings.Contains(text, `role="user"`) {
 		t.Fatalf("expected user db operation metric in response: %s", text)
 	}
 	if !strings.Contains(text, `tenant_id="local"`) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1440,8 +1440,8 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `dat9_db_operations_total{operation="`) || !strings.Contains(text, `role="user"`) {
 		t.Fatalf("expected user db operation metric in response: %s", text)
 	}
-	if !strings.Contains(text, `tenant_id="local"`) {
-		t.Fatalf("expected tenant_id label on db operation metric in response: %s", text)
+	if strings.Contains(text, `tenant_id="`) {
+		t.Fatalf("expected db operation metrics to avoid tenant_id labels: %s", text)
 	}
 	if !strings.Contains(text, `dat9_db_pool_registered{role="user"}`) {
 		t.Fatalf("expected user db pool metric in response: %s", text)

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -283,12 +283,12 @@ func (s *Server) handleVaultSecretReadValue(w http.ResponseWriter, r *http.Reque
 			_, _ = fmt.Fprintf(w, "%s=%s\n", strings.ToUpper(k), string(v))
 		}
 	case "json", "":
-		result := make(map[string]string, len(fields))
+		payload := make(map[string]string, len(fields))
 		for k, v := range fields {
-			result[k] = string(v)
+			payload[k] = string(v)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(result)
+		_ = json.NewEncoder(w).Encode(payload)
 	default:
 		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "unsupported format")
@@ -991,12 +991,12 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 			_, _ = fmt.Fprintf(w, "%s=%s\n", strings.ToUpper(k), string(v))
 		}
 	case "json", "":
-		result := make(map[string]string, len(fields))
+		payload := make(map[string]string, len(fields))
 		for k, v := range fields {
-			result[k] = string(v)
+			payload[k] = string(v)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(result)
+		_ = json.NewEncoder(w).Encode(payload)
 	default:
 		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "unsupported format")

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/vault"
 )
@@ -56,6 +57,10 @@ func (s *Server) handleVault(w http.ResponseWriter, r *http.Request) {
 }
 
 var errVaultUnsupported = errors.New("vault is not supported for this provider")
+
+func recordVaultOperation(op string, start time.Time, result string) {
+	metrics.RecordOperation("vault", op, result, time.Since(start))
+}
 
 // vaultStore returns the vault store for the current tenant.
 // Vault is only supported on TiDB providers; db9 tenants get a clear error.
@@ -138,6 +143,10 @@ func (s *Server) handleVaultSecrets(w http.ResponseWriter, r *http.Request, sub 
 }
 
 func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("secret_create", start, result) }()
+
 	var req struct {
 		Name       string            `json:"name"`
 		SecretType string            `json:"secret_type"`
@@ -145,14 +154,17 @@ func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request,
 		CreatedBy  string            `json:"created_by"`
 	}
 	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if req.Name == "" {
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "name is required")
 		return
 	}
 	if len(req.Fields) == 0 {
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "fields are required")
 		return
 	}
@@ -172,9 +184,11 @@ func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request,
 	sec, err := vs.CreateSecret(r.Context(), tenantID, req.Name, req.CreatedBy, secretType, fields)
 	if err != nil {
 		if isVaultDuplicateEntryErr(err) {
+			result = "already_exists"
 			errJSON(w, http.StatusConflict, "secret already exists")
 			return
 		}
+		result = "error"
 		logger.Error(r.Context(), "vault_secret_create_failed",
 			eventFields(r.Context(), "vault_secret_create_failed",
 				"tenant_id", tenantID,
@@ -196,8 +210,13 @@ func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request,
 }
 
 func (s *Server) handleVaultSecretList(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("secret_list", start, result) }()
+
 	secrets, err := vs.ListSecrets(r.Context(), tenantID)
 	if err != nil {
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to list secrets")
 		return
 	}
@@ -209,12 +228,18 @@ func (s *Server) handleVaultSecretList(w http.ResponseWriter, r *http.Request, v
 }
 
 func (s *Server) handleVaultSecretGet(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("secret_get", start, result) }()
+
 	sec, err := vs.GetSecret(r.Context(), tenantID, name)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
+			result = "not_found"
 			errJSON(w, http.StatusNotFound, "secret not found")
 			return
 		}
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to get secret")
 		return
 	}
@@ -225,12 +250,18 @@ func (s *Server) handleVaultSecretGet(w http.ResponseWriter, r *http.Request, vs
 // handleVaultSecretReadValue returns all decrypted fields for a secret (owner-read path).
 // Response shape matches handleVaultReadSecret (Invariant #9: response schema parity).
 func (s *Server) handleVaultSecretReadValue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, secretName string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("secret_read_value", start, result) }()
+
 	fields, err := vs.ReadSecretFields(r.Context(), tenantID, secretName)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
+			result = "not_found"
 			errJSON(w, http.StatusNotFound, "not found")
 			return
 		}
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to read secret")
 		return
 	}
@@ -259,6 +290,7 @@ func (s *Server) handleVaultSecretReadValue(w http.ResponseWriter, r *http.Reque
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(result)
 	default:
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "unsupported format")
 	}
 }
@@ -266,12 +298,18 @@ func (s *Server) handleVaultSecretReadValue(w http.ResponseWriter, r *http.Reque
 // handleVaultSecretReadField returns a single decrypted field (owner-read path).
 // Response shape matches handleVaultReadField (Invariant #9: response schema parity).
 func (s *Server) handleVaultSecretReadField(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, secretName, fieldName string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("secret_read_field", start, result) }()
+
 	plaintext, err := vs.ReadSecretField(r.Context(), tenantID, secretName, fieldName)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) || errors.Is(err, vault.ErrFieldNotFound) {
+			result = "not_found"
 			errJSON(w, http.StatusNotFound, "not found")
 			return
 		}
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to read field")
 		return
 	}
@@ -291,15 +329,21 @@ func (s *Server) handleVaultSecretReadField(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("secret_update", start, result) }()
+
 	var req struct {
 		Fields    map[string]string `json:"fields"`
 		UpdatedBy string            `json:"updated_by"`
 	}
 	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if len(req.Fields) == 0 {
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "fields are required")
 		return
 	}
@@ -315,9 +359,11 @@ func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request,
 	sec, err := vs.UpdateSecret(r.Context(), tenantID, name, req.UpdatedBy, fields)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
+			result = "not_found"
 			errJSON(w, http.StatusNotFound, "secret not found")
 			return
 		}
+		result = "error"
 		logger.Error(r.Context(), "vault_secret_update_failed",
 			eventFields(r.Context(), "vault_secret_update_failed",
 				"tenant_id", tenantID,
@@ -338,12 +384,18 @@ func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request,
 }
 
 func (s *Server) handleVaultSecretDelete(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("secret_delete", start, result) }()
+
 	err := vs.DeleteSecret(r.Context(), tenantID, name)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
+			result = "not_found"
 			errJSON(w, http.StatusNotFound, "secret not found")
 			return
 		}
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to delete secret")
 		return
 	}
@@ -392,6 +444,10 @@ func (s *Server) handleVaultTokens(w http.ResponseWriter, r *http.Request, sub s
 }
 
 func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("token_issue", start, result) }()
+
 	var req struct {
 		AgentID string   `json:"agent_id"`
 		TaskID  string   `json:"task_id"`
@@ -399,18 +455,22 @@ func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, v
 		TTLSecs int      `json:"ttl_seconds"`
 	}
 	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if req.AgentID == "" {
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "agent_id is required")
 		return
 	}
 	if len(req.Scope) == 0 {
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "scope is required")
 		return
 	}
 	if err := vault.ValidateScope(req.Scope); err != nil {
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -421,6 +481,7 @@ func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, v
 
 	tokenStr, capToken, err := vs.IssueCapToken(r.Context(), tenantID, req.AgentID, req.TaskID, req.Scope, ttl)
 	if err != nil {
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to issue token")
 		return
 	}
@@ -443,6 +504,10 @@ func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, v
 }
 
 func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, tokenID string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("token_revoke", start, result) }()
+
 	var req struct {
 		RevokedBy string `json:"revoked_by"`
 		Reason    string `json:"reason"`
@@ -456,9 +521,11 @@ func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, 
 	err := vs.RevokeCapToken(r.Context(), tenantID, tokenID, req.RevokedBy, req.Reason)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
+			result = "not_found"
 			errJSON(w, http.StatusNotFound, "token not found or already revoked")
 			return
 		}
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to revoke token")
 		return
 	}
@@ -517,10 +584,15 @@ func (s *Server) handleVaultGrants(w http.ResponseWriter, r *http.Request, sub s
 }
 
 func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("grant_issue", start, result) }()
+
 	// Grants require a canonical server URL for the `iss` claim. If the
 	// operator hasn't configured one, we cannot mint non-forgeable tokens:
 	// fail closed rather than emit a grant without issuer binding.
 	if s.vaultIssuerURL == "" {
+		result = "unavailable"
 		errJSON(w, http.StatusServiceUnavailable, "vault issuer URL not configured")
 		return
 	}
@@ -532,6 +604,7 @@ func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, v
 		LabelHint string   `json:"label_hint"`
 	}
 	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
@@ -544,6 +617,7 @@ func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, v
 	principal := vault.PrincipalDelegated
 	perm := vault.GrantPerm(req.Perm)
 	if req.TTLSecs <= 0 {
+		result = "invalid_argument"
 		// Spec §6 "--ttl is required". Silent defaulting at the handler
 		// would emit a grant the caller didn't ask for — audit/debug trap
 		// (adv-1 Block 4, adv-2 Block B context).
@@ -561,9 +635,11 @@ func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, v
 		// enum / agent / issuer); map them to 400. Internal DB errors
 		// surface the same way but prefixed "insert grant:" — map to 500.
 		if strings.HasPrefix(err.Error(), "insert grant") {
+			result = "error"
 			errJSON(w, http.StatusInternalServerError, "failed to issue grant")
 			return
 		}
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -597,6 +673,10 @@ func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, v
 }
 
 func (s *Server) handleVaultGrantRevoke(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, grantID string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("grant_revoke", start, result) }()
+
 	var req struct {
 		RevokedBy string `json:"revoked_by"`
 		Reason    string `json:"reason"`
@@ -609,9 +689,11 @@ func (s *Server) handleVaultGrantRevoke(w http.ResponseWriter, r *http.Request, 
 	err := vs.RevokeGrant(r.Context(), tenantID, grantID, req.RevokedBy, req.Reason)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
+			result = "not_found"
 			errJSON(w, http.StatusNotFound, "grant not found or already revoked")
 			return
 		}
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to revoke grant")
 		return
 	}
@@ -638,16 +720,23 @@ func (s *Server) handleVaultGrantRevoke(w http.ResponseWriter, r *http.Request, 
 // ---- Management API: /v1/vault/audit ----
 
 func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("audit_query", start, result) }()
+
 	if r.Method != http.MethodGet {
+		result = "invalid_argument"
 		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 	vs, err := s.vaultStore(r)
 	if err != nil {
 		if errors.Is(err, errVaultUnsupported) {
+			result = "unsupported"
 			errJSON(w, http.StatusNotImplemented, err.Error())
 			return
 		}
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -663,6 +752,7 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 
 	events, err := vs.QueryAuditLog(r.Context(), scope.TenantID, secretName, limit)
 	if err != nil {
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to query audit log")
 		return
 	}
@@ -806,6 +896,10 @@ func (s *Server) verifyGrantReadToken(r *http.Request, vs *vault.Store, tenantID
 }
 
 func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("read_enumerate", start, result) }()
+
 	scopedNames := vault.ScopedSecretNames(p.Scope)
 	// Filter to secrets that actually exist.
 	var available []string
@@ -833,9 +927,14 @@ func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal, secretName string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("read_secret", start, result) }()
+
 	// Scope check.
 	allFields, allowedFields := vault.AllowedFields(p.Scope, secretName)
 	if !allFields && len(allowedFields) == 0 {
+		result = "out_of_scope"
 		_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 			TenantID:   p.TenantID,
 			EventType:  "secret.denied",
@@ -852,9 +951,11 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 	fields, err := vs.ReadSecretFields(r.Context(), p.TenantID, secretName)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) {
+			result = "not_found"
 			errJSON(w, http.StatusNotFound, "not found")
 			return
 		}
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to read secret")
 		return
 	}
@@ -897,13 +998,19 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(result)
 	default:
+		result = "invalid_argument"
 		errJSON(w, http.StatusBadRequest, "unsupported format")
 	}
 }
 
 func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal, secretName, fieldName string) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordVaultOperation("read_field", start, result) }()
+
 	// Scope check.
 	if !vault.CheckScope(p.Scope, secretName, fieldName) {
+		result = "out_of_scope"
 		_ = vs.WriteAuditEvent(r.Context(), &vault.AuditEvent{
 			TenantID:   p.TenantID,
 			EventType:  "secret.denied",
@@ -920,9 +1027,11 @@ func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs
 	plaintext, err := vs.ReadSecretField(r.Context(), p.TenantID, secretName, fieldName)
 	if err != nil {
 		if errors.Is(err, vault.ErrNotFound) || errors.Is(err, vault.ErrFieldNotFound) {
+			result = "not_found"
 			errJSON(w, http.StatusNotFound, "not found")
 			return
 		}
+		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to read field")
 		return
 	}

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -196,6 +196,24 @@ func doVaultGrantRead(t *testing.T, srv *Server, token, path string) (*http.Resp
 	return resp, body
 }
 
+func readServerMetrics(t *testing.T, srv *Server) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	resp := rec.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("metrics status=%d body=%s", resp.StatusCode, body)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read metrics body: %v", err)
+	}
+	return string(body)
+}
+
 func tamperGrantTenantID(t *testing.T, raw, tenantID string) string {
 	t.Helper()
 	if !strings.HasPrefix(raw, "vt_") {
@@ -328,5 +346,28 @@ func TestVaultGrantReadRejectsWritePermAfterVerify(t *testing.T) {
 	resp, body := doVaultGrantRead(t, rt.server, tok, "/v1/vault/read/test3/k1")
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("status=%d body=%s, want 401", resp.StatusCode, body)
+	}
+}
+
+func TestVaultMetricsExposed(t *testing.T) {
+	rt := newVaultGrantReadRuntime(t)
+	defer rt.cleanup()
+	rt.createSecret(t)
+	tok, _ := rt.issueGrant(t, []string{"test3"}, vault.GrantPermRead)
+
+	resp, body := doVaultGrantRead(t, rt.server, tok, "/v1/vault/read/test3?format=json")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s, want 200", resp.StatusCode, body)
+	}
+
+	metricsText := readServerMetrics(t, rt.server)
+	if !strings.Contains(metricsText, "dat9_module_up{module=\"vault\"} 1") {
+		t.Fatalf("metrics missing vault module availability: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_operations_total{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
+		t.Fatalf("metrics missing vault service operation counter: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
+		t.Fatalf("metrics missing vault service duration histogram: %s", metricsText)
 	}
 }

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -202,7 +202,7 @@ func readServerMetrics(t *testing.T, srv *Server) string {
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	resp := rec.Result()
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("metrics status=%d body=%s", resp.StatusCode, body)

--- a/pkg/webdav/fs_test.go
+++ b/pkg/webdav/fs_test.go
@@ -13,7 +13,14 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 )
+
+func readWebDAVMetrics() string {
+	recorder := httptest.NewRecorder()
+	metrics.WritePrometheus(recorder)
+	return recorder.Body.String()
+}
 
 func TestNormPath(t *testing.T) {
 	tests := []struct {
@@ -209,6 +216,29 @@ func TestHandlerPutMissingParentReturnsConflict(t *testing.T) {
 
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("PUT missing parent status = %d, want %d: %s", rr.Code, http.StatusConflict, rr.Body.String())
+	}
+}
+
+func TestHandlerMetricsExposed(t *testing.T) {
+	c := newWriteOnlyTestClient(t, nil)
+	handler := NewHandler(c, Options{})
+
+	req := httptest.NewRequest(http.MethodPut, "/missing/file.txt", strings.NewReader("payload"))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("PUT missing parent status = %d, want %d: %s", rr.Code, http.StatusConflict, rr.Body.String())
+	}
+
+	metricsText := readWebDAVMetrics()
+	if !strings.Contains(metricsText, "dat9_module_up{module=\"webdav\"} 1") {
+		t.Fatalf("metrics missing webdav module availability: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_operations_total{component=\"webdav\",operation=\"put\",result=\"conflict\"}") {
+		t.Fatalf("metrics missing webdav service counter: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "dat9_service_operation_duration_seconds_count{component=\"webdav\",operation=\"put\",result=\"conflict\"}") {
+		t.Fatalf("metrics missing webdav duration histogram: %s", metricsText)
 	}
 }
 

--- a/pkg/webdav/handler.go
+++ b/pkg/webdav/handler.go
@@ -63,6 +63,16 @@ func (w *statusCapturingResponseWriter) Write(p []byte) (int, error) {
 	return w.ResponseWriter.Write(p)
 }
 
+func (w *statusCapturingResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (w *statusCapturingResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 func (w *statusCapturingResponseWriter) statusCode() int {
 	if w.status == 0 {
 		return http.StatusOK

--- a/pkg/webdav/handler.go
+++ b/pkg/webdav/handler.go
@@ -6,8 +6,12 @@ package webdav
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 	"golang.org/x/net/webdav"
 )
 
@@ -28,9 +32,69 @@ func NewHandler(c *client.Client, opts Options) http.Handler {
 	if remoteRoot == "" {
 		remoteRoot = "/"
 	}
-	return &webdav.Handler{
+	metrics.SetModuleAvailability("webdav", true)
+	next := &webdav.Handler{
 		Prefix:     opts.Prefix,
 		FileSystem: &fileSystem{client: c, remoteRoot: remoteRoot, props: newDeadPropStore()},
 		LockSystem: webdav.NewMemLS(),
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		recorder := &statusCapturingResponseWriter{ResponseWriter: w}
+		next.ServeHTTP(recorder, r)
+		metrics.RecordOperation("webdav", webdavMetricOperation(r.Method), webdavMetricResult(recorder.statusCode()), time.Since(start))
+	})
+}
+
+type statusCapturingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusCapturingResponseWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *statusCapturingResponseWriter) Write(p []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *statusCapturingResponseWriter) statusCode() int {
+	if w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
+}
+
+func webdavMetricOperation(method string) string {
+	method = strings.TrimSpace(strings.ToUpper(method))
+	if method == "" {
+		return "unknown"
+	}
+	return strings.ToLower(method)
+}
+
+func webdavMetricResult(status int) string {
+	switch {
+	case status == http.StatusMultiStatus:
+		return "multi_status"
+	case status >= 200 && status < 300:
+		return "ok"
+	case status == http.StatusConflict:
+		return "conflict"
+	case status == http.StatusNotFound:
+		return "not_found"
+	case status == http.StatusMethodNotAllowed:
+		return "method_not_allowed"
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		return "permission_denied"
+	case status >= 500:
+		return "error"
+	default:
+		return strconv.Itoa(status)
 	}
 }


### PR DESCRIPTION
## Summary
Refactor the metrics stack around a unified registry and OpenTelemetry-style instrument model, then finish the remaining observability coverage in the runtime modules and Grafana dashboards.

## What changed
- replace the ad hoc process-wide metrics aggregation with a shared registry, meter, counter, gauge, and histogram model while keeping Prometheus text exposition
- migrate service, HTTP, DB, FUSE, and event metrics onto the unified API and add explicit module availability and uptime tracking
- add missing runtime metrics coverage for vault, audio_extract, s3client, and webdav, including tests that assert the new metrics are exposed
- expand and reorganize Grafana dashboards so request-path, async/FUSE, and data-store drill-downs match the new observability layout

## Validation
- go test ./pkg/server
- go test ./pkg/backend
- go test ./pkg/s3client
- go test ./pkg/webdav
- dashboard JSON syntax validation

## Notes
- The external runbooks alert file edited during the broader observability work lives outside this repository, so it is not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Grafana monitoring architecture with overview and drill-down dashboards for request-path and data-store performance analysis.
  * Added eleven new Grafana dashboards covering service health, API surface, filesystem operations, uploads, async processing, and database performance.

* **New Features**
  * Enhanced system observability with expanded metrics collection across audio extraction, S3 operations, WebDAV, Vault, FUSE, and database subsystems.
  * Implemented module availability signaling for better visibility into system component health.

* **Tests**
  * Added metrics validation tests for core system components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/413)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->