### PR TITLE
Add follow-up Grafana dashboard coverage

### DIFF
--- a/docs/grafana/drive9-api-surface-dashboard.json
+++ b/docs/grafana/drive9-api-surface-dashboard.json
@@ -55,7 +55,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# API Surface Performance\n\nCategory: request-path drill-down.\n\nUse this after an overview dashboard shows an HTTP-facing problem outside the FS and upload paths. This dashboard is intentionally scoped to control, vault, SQL, events, and auxiliary HTTP routes so it does not duplicate the dedicated FS and upload dashboards. It answers which routes are hot, which are slow, and whether latency coincides with inflight buildup or error spikes.",
+        "content": "# API Surface Performance\n\nCategory: request-path drill-down.\n\nUse this after an overview dashboard shows an HTTP-facing problem outside the FS and upload paths. This dashboard is intentionally scoped to control, vault, SQL, events, and auxiliary HTTP routes so it does not duplicate the dedicated FS and upload dashboards. It answers which routes are hot, which are slow, whether latency coincides with inflight buildup or error spikes, and whether tenant lifecycle control-plane events are failing.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -668,6 +668,100 @@
         }
       ],
       "title": "Error Routes And Inflight",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"tenant_provision|tenant_schema_init\"}[$__rate_interval]))",
+          "legendFormat": "{{event}} {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tenant Lifecycle Event Mix",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"tenant_provision|tenant_schema_init\",result!~\"ok|accepted\"}[$__rate_interval]))",
+          "legendFormat": "{{event}} {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tenant Lifecycle Failures",
       "type": "timeseries"
     }
   ],

--- a/docs/grafana/drive9-async-fuse-dashboard.json
+++ b/docs/grafana/drive9-async-fuse-dashboard.json
@@ -66,7 +66,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Drive9 Async And FUSE\n\nCategory: overview.\n\nUse this when the incident is not on the front-door HTTP path but in delayed work or the mount path. The first row is intentionally alarm-biased: semantic backlog, dead letters, FUSE remote error ratio, and FUSE remote latency. The second row is organized as two narrowing paths: worker state on the left and per-operation FUSE latency on the right. The media rows are for extraction runtime and outcomes: image runtime capacity, image failure and saturation, then audio extract process results and tail latency. If the issue reduces to a specific FUSE or upload path, continue into the request-path drill-down dashboards.",
+        "content": "# Drive9 Async And FUSE\n\nCategory: overview.\n\nUse this when the incident is not on the front-door HTTP path but in delayed work or the mount path. The first row is intentionally alarm-biased: semantic backlog, dead letters, FUSE remote error ratio, and FUSE remote latency. The second row is organized as two narrowing paths: worker state on the left and per-operation FUSE latency on the right. The media rows are for extraction runtime and outcomes: image runtime capacity first, then audio extract process results and tail latency, followed by image failure and saturation. If the issue reduces to a specific FUSE or upload path, continue into the request-path drill-down dashboards.",
         "mode": "markdown"
       },
       "title": "Guide",

--- a/docs/grafana/drive9-async-fuse-dashboard.json
+++ b/docs/grafana/drive9-async-fuse-dashboard.json
@@ -66,7 +66,7 @@
       },
       "id": 100,
       "options": {
-        "content": "# Drive9 Async And FUSE\n\nCategory: overview.\n\nUse this when the incident is not on the front-door HTTP path but in delayed work or the mount path. The first row is intentionally alarm-biased: semantic backlog, dead letters, FUSE remote error ratio, and FUSE remote latency. The second row is organized as two narrowing paths: worker state on the left and per-operation FUSE latency on the right. The bottom row is for media extraction: image runtime capacity first, then audio extract process results and tail latency. If the issue reduces to a specific FUSE or upload path, continue into the request-path drill-down dashboards.",
+        "content": "# Drive9 Async And FUSE\n\nCategory: overview.\n\nUse this when the incident is not on the front-door HTTP path but in delayed work or the mount path. The first row is intentionally alarm-biased: semantic backlog, dead letters, FUSE remote error ratio, and FUSE remote latency. The second row is organized as two narrowing paths: worker state on the left and per-operation FUSE latency on the right. The media rows are for extraction runtime and outcomes: image runtime capacity, image failure and saturation, then audio extract process results and tail latency. If the issue reduces to a specific FUSE or upload path, continue into the request-path drill-down dashboards.",
         "mode": "markdown"
       },
       "title": "Guide",
@@ -677,6 +677,100 @@
         }
       ],
       "title": "Audio Extract Tail Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(dat9_service_operations_total{component=\"image_extract\",operation=\"process\"}[$__rate_interval]))",
+          "legendFormat": "image_extract {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Image Extract Process Results",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dat9_service_gauge{component=\"image_extract\",name=\"queue_depth\"} / clamp_min(dat9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"}, 1)",
+          "legendFormat": "image_extract queue_saturation",
+          "refId": "A"
+        }
+      ],
+      "title": "Image Extract Queue Saturation",
       "type": "timeseries"
     }
   ],


### PR DESCRIPTION
## Summary
- add image_extract process result and queue saturation panels to the async/fuse overview dashboard
- add tenant lifecycle event mix and failure panels to the API surface dashboard
- update dashboard guide text so the new panels are discoverable during incident response

## Context
These dashboard additions were left in the local working tree after the earlier observability PR was merged. This PR carries the missing Grafana follow-up on top of current main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dashboard guides with troubleshooting details for tenant lifecycle events and improved image extraction metrics descriptions.

* **New Features**
  * Added monitoring panels for tenant lifecycle event breakdown by type and result status.
  * Added monitoring panels for tenant lifecycle failure tracking.
  * Added monitoring panels for image extraction process results and queue saturation metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/414)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->