### PR TITLE
Add Windows CLI support

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -42,7 +42,12 @@ jobs:
 
       - name: Build CLI for all platforms
         run: |
-          make build-cli-release DIST_DIR=dist VERSION="${{ env.VERSION }}"
+          make build-cli-release DIST_DIR=dist VERSION="${{ env.VERSION }}" CLI_TARGETS="linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64"
+
+      - name: Verify Windows artifacts
+        run: |
+          test -f dist/drive9-windows-amd64.exe
+          test -f dist/drive9-windows-arm64.exe
 
       - name: Ensure version file
         run: |

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ GIT_HASH ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
 BUILD_TIME ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 
-CLI_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
+CLI_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
 GOLANGCI_LINT_BIN ?= $(BIN_DIR)/golangci-lint
@@ -126,7 +126,11 @@ build-cli-release:
 	for target in $(CLI_TARGETS); do \
 		os="$${target%/*}"; \
 		arch="$${target#*/}"; \
-		out="$(DIST_DIR)/$(CLI_NAME)-$${os}-$${arch}"; \
+		ext=""; \
+		if [ "$$os" = "windows" ]; then \
+			ext=".exe"; \
+		fi; \
+		out="$(DIST_DIR)/$(CLI_NAME)-$${os}-$${arch}$$ext"; \
 		echo "Building $$(basename "$$out")..."; \
 		$(MAKE) --no-print-directory build-cli GOOS="$$os" GOARCH="$$arch" CLI_BIN="$$out" VERSION="$(VERSION)"; \
 	done; \

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ The mount command accepts an optional remote root:
 drive9 mount :/projects/my-agent ./work
 ```
 
+Windows note: `drive9 mount` uses the built-in WebDAV redirector and maps to a
+drive letter, not a directory mountpoint:
+
+```powershell
+drive9 mount :/ X:
+drive9 umount X:
+```
+
+This requires the Windows WebClient service. `drive9 mount vault` still requires
+Linux or macOS because the vault mount is FUSE-only. On Windows, use the
+`drive9 vault ...` commands or the vault API instead of `drive9 mount vault`.
+
 ### Tag Filter Semantics
 
 `drive9 fs find -tag` uses exact matching:
@@ -125,6 +137,8 @@ drive9 mount :/projects/my-agent ./work
 - Prefix, contains, and regex matching are not supported for `-tag`.
 
 ## FUSE Prerequisites
+
+Windows is not supported for drive9 FUSE mounts.
 
 **macOS**: install macFUSE.
 

--- a/cmd/drive9/cli/doctor.go
+++ b/cmd/drive9/cli/doctor.go
@@ -14,7 +14,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -75,7 +74,7 @@ func defaultDoctorDeps() doctorDeps {
 		mkdirAll:    os.MkdirAll,
 		writeFile:   os.WriteFile,
 		remove:      os.Remove,
-		access:      syscall.Access,
+		access:      doctorAccess,
 		currentUser: user.Current,
 		getgroups:   os.Getgroups,
 		commandOutput: func(ctx context.Context, name string, args ...string) ([]byte, error) {
@@ -137,6 +136,27 @@ func runDoctorFuse(args []string, deps doctorDeps) error {
 	}
 	if *timeout <= 0 {
 		return fmt.Errorf("doctor fuse: --timeout must be > 0")
+	}
+
+	if deps.goos == "windows" {
+		checks := []doctorCheck{
+			doctorOSKernelCheck(context.Background(), deps),
+			{
+				name:   "fuse support",
+				status: doctorFail,
+				detail: "drive9 FUSE mounts are not supported on windows",
+				fix:    "use `drive9 mount` without `--mode=fuse` on Windows (the default path uses WebDAV), or use Linux/macOS for FUSE mounts",
+			},
+		}
+
+		_, _ = fmt.Fprintln(deps.stdout, "drive9 doctor fuse")
+		for _, check := range checks {
+			_, _ = fmt.Fprintf(deps.stdout, "%s %s: %s\n", check.status, check.name, check.detail)
+			if strings.TrimSpace(check.fix) != "" {
+				_, _ = fmt.Fprintf(deps.stdout, "  fix: %s\n", check.fix)
+			}
+		}
+		return doctorFailure{failed: 1}
 	}
 
 	creds := deps.resolveCredentials()
@@ -404,29 +424,4 @@ func appendIfMissing(items []string, item string) []string {
 		}
 	}
 	return append(items, item)
-}
-
-func isMountpoint(path string) (bool, error) {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return false, err
-	}
-	info, err := os.Stat(abs)
-	if err != nil {
-		return false, err
-	}
-	parent := filepath.Dir(abs)
-	parentInfo, err := os.Stat(parent)
-	if err != nil {
-		return false, err
-	}
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false, nil
-	}
-	parentStat, ok := parentInfo.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false, nil
-	}
-	return stat.Dev != parentStat.Dev || stat.Ino == parentStat.Ino, nil
 }

--- a/cmd/drive9/cli/doctor.go
+++ b/cmd/drive9/cli/doctor.go
@@ -144,7 +144,7 @@ func runDoctorFuse(args []string, deps doctorDeps) error {
 			{
 				name:   "fuse support",
 				status: doctorFail,
-				detail: "drive9 FUSE mounts are not supported on windows",
+				detail: "drive9 FUSE mounts are not supported on Windows",
 				fix:    "use `drive9 mount` without `--mode=fuse` on Windows (the default path uses WebDAV), or use Linux/macOS for FUSE mounts",
 			},
 		}

--- a/cmd/drive9/cli/doctor_platform_unix.go
+++ b/cmd/drive9/cli/doctor_platform_unix.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func doctorAccess(path string, mode uint32) error {
+	return syscall.Access(path, mode)
+}
+
+func isMountpoint(path string) (bool, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return false, err
+	}
+	parent := filepath.Dir(abs)
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		return false, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, nil
+	}
+	parentStat, ok := parentInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, nil
+	}
+	return stat.Dev != parentStat.Dev || stat.Ino == parentStat.Ino, nil
+}

--- a/cmd/drive9/cli/doctor_platform_windows.go
+++ b/cmd/drive9/cli/doctor_platform_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package cli
+
+func doctorAccess(path string, mode uint32) error {
+	_ = path
+	_ = mode
+	return nil
+}
+
+func isMountpoint(path string) (bool, error) {
+	_ = path
+	return false, nil
+}

--- a/cmd/drive9/cli/doctor_test.go
+++ b/cmd/drive9/cli/doctor_test.go
@@ -214,7 +214,7 @@ func TestRunDoctorFuseWindowsReportsUnsupported(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected windows doctor fuse to fail")
 	}
-	if !strings.Contains(out.String(), "FAIL fuse support: drive9 FUSE mounts are not supported on windows") {
+	if !strings.Contains(out.String(), "FAIL fuse support: drive9 FUSE mounts are not supported on Windows") {
 		t.Fatalf("output missing windows unsupported message:\n%s", out.String())
 	}
 	if !strings.Contains(out.String(), "use `drive9 mount` without `--mode=fuse` on Windows") {

--- a/cmd/drive9/cli/doctor_test.go
+++ b/cmd/drive9/cli/doctor_test.go
@@ -206,6 +206,22 @@ func TestRunDoctorFuseDarwinDoesNotRequireLinuxFuseConf(t *testing.T) {
 	}
 }
 
+func TestRunDoctorFuseWindowsReportsUnsupported(t *testing.T) {
+	var out bytes.Buffer
+	deps := doctorTestDeps(&out)
+	deps.goos = "windows"
+	err := runDoctor([]string{"fuse"}, deps)
+	if err == nil {
+		t.Fatal("expected windows doctor fuse to fail")
+	}
+	if !strings.Contains(out.String(), "FAIL fuse support: drive9 FUSE mounts are not supported on windows") {
+		t.Fatalf("output missing windows unsupported message:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "use `drive9 mount` without `--mode=fuse` on Windows") {
+		t.Fatalf("output missing windows fix guidance:\n%s", out.String())
+	}
+}
+
 func TestRunDoctorUsageErrors(t *testing.T) {
 	for _, args := range [][]string{
 		nil,

--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -1,0 +1,57 @@
+package cli
+
+import "time"
+
+type fuseSyncMode string
+
+const (
+	fuseSyncModeAuto        fuseSyncMode = "auto"
+	fuseSyncModeInteractive fuseSyncMode = "interactive"
+	fuseSyncModeStrict      fuseSyncMode = "strict"
+)
+
+type mountFuseOptions struct {
+	Server                string
+	APIKey                string
+	Token                 string
+	MountPoint            string
+	RemoteRoot            string
+	CacheDir              string
+	CacheSize             int64
+	DirTTL                time.Duration
+	AttrTTL               time.Duration
+	EntryTTL              time.Duration
+	FlushDebounce         time.Duration
+	LookupRetryCount      int
+	LookupRetryTimeout    time.Duration
+	LegacyDirStatFallback bool
+	ReadDirPrefetch       bool
+	PrefetchMaxFiles      int
+	PrefetchMaxFileBytes  int64
+	PrefetchMaxBytes      int64
+	PrefetchTimeout       time.Duration
+	SyncMode              fuseSyncMode
+	Profile               string
+	AllowOther            bool
+	ReadOnly              bool
+	Debug                 bool
+	PerfCounters          bool
+}
+
+type vaultMountOptions struct {
+	Server     string
+	APIKey     string
+	Token      string
+	MountPoint string
+	DirTTL     time.Duration
+	AllowOther bool
+	Debug      bool
+}
+
+var mountFuse = mountFuseImpl
+
+var mountVault = mountVaultImpl
+
+func parseFuseSyncMode(s string) (fuseSyncMode, error) {
+	return parseFuseSyncModeImpl(s)
+}

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -1,0 +1,88 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+
+	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
+)
+
+func parseFuseSyncModeImpl(s string) (fuseSyncMode, error) {
+	mode, err := drive9fuse.ParseSyncMode(s)
+	if err != nil {
+		return "", err
+	}
+	return fromDrive9FuseSyncMode(mode), nil
+}
+
+func mountFuseImpl(opts *mountFuseOptions) error {
+	mode, err := toDrive9FuseSyncMode(opts.SyncMode)
+	if err != nil {
+		return err
+	}
+
+	return drive9fuse.Mount(&drive9fuse.MountOptions{
+		Server:                opts.Server,
+		APIKey:                opts.APIKey,
+		Token:                 opts.Token,
+		MountPoint:            opts.MountPoint,
+		RemoteRoot:            opts.RemoteRoot,
+		CacheDir:              opts.CacheDir,
+		CacheSize:             opts.CacheSize,
+		DirTTL:                opts.DirTTL,
+		AttrTTL:               opts.AttrTTL,
+		EntryTTL:              opts.EntryTTL,
+		FlushDebounce:         opts.FlushDebounce,
+		LookupRetryCount:      opts.LookupRetryCount,
+		LookupRetryTimeout:    opts.LookupRetryTimeout,
+		LegacyDirStatFallback: opts.LegacyDirStatFallback,
+		ReadDirPrefetch:       opts.ReadDirPrefetch,
+		PrefetchMaxFiles:      opts.PrefetchMaxFiles,
+		PrefetchMaxFileBytes:  opts.PrefetchMaxFileBytes,
+		PrefetchMaxBytes:      opts.PrefetchMaxBytes,
+		PrefetchTimeout:       opts.PrefetchTimeout,
+		SyncMode:              mode,
+		Profile:               opts.Profile,
+		AllowOther:            opts.AllowOther,
+		ReadOnly:              opts.ReadOnly,
+		Debug:                 opts.Debug,
+		PerfCounters:          opts.PerfCounters,
+	})
+}
+
+func mountVaultImpl(opts *vaultMountOptions) error {
+	return drive9fuse.MountVault(&drive9fuse.VaultMountOptions{
+		Server:     opts.Server,
+		APIKey:     opts.APIKey,
+		Token:      opts.Token,
+		MountPoint: opts.MountPoint,
+		DirTTL:     opts.DirTTL,
+		AllowOther: opts.AllowOther,
+		Debug:      opts.Debug,
+	})
+}
+
+func fromDrive9FuseSyncMode(mode drive9fuse.SyncMode) fuseSyncMode {
+	switch mode {
+	case drive9fuse.SyncInteractive:
+		return fuseSyncModeInteractive
+	case drive9fuse.SyncStrict:
+		return fuseSyncModeStrict
+	default:
+		return fuseSyncModeAuto
+	}
+}
+
+func toDrive9FuseSyncMode(mode fuseSyncMode) (drive9fuse.SyncMode, error) {
+	switch mode {
+	case fuseSyncModeAuto:
+		return drive9fuse.SyncAuto, nil
+	case fuseSyncModeInteractive:
+		return drive9fuse.SyncInteractive, nil
+	case fuseSyncModeStrict:
+		return drive9fuse.SyncStrict, nil
+	default:
+		return drive9fuse.SyncAuto, fmt.Errorf("unknown sync mode %q", mode)
+	}
+}

--- a/cmd/drive9/cli/fuse_bridge_windows.go
+++ b/cmd/drive9/cli/fuse_bridge_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package cli
+
+import "fmt"
+
+func parseFuseSyncModeImpl(s string) (fuseSyncMode, error) {
+	switch s {
+	case "", string(fuseSyncModeAuto):
+		return fuseSyncModeAuto, nil
+	case string(fuseSyncModeInteractive):
+		return fuseSyncModeInteractive, nil
+	case string(fuseSyncModeStrict):
+		return fuseSyncModeStrict, nil
+	default:
+		return "", fmt.Errorf("unknown sync mode %q (valid: auto, interactive, strict)", s)
+	}
+}
+
+func mountFuseImpl(opts *mountFuseOptions) error {
+	_ = opts
+	return fmt.Errorf("drive9 mount: FUSE mounts are not supported on Windows; use `drive9 mount` without `--mode=fuse` on Windows (the default path uses WebDAV), or run drive9 mount on Linux or macOS")
+}
+
+func mountVaultImpl(opts *vaultMountOptions) error {
+	_ = opts
+	return fmt.Errorf("drive9 mount vault: FUSE mounts are not supported on Windows; use drive9 vault commands or the vault API on Windows, or use a Linux or macOS host for vault mounts")
+}

--- a/cmd/drive9/cli/fuse_bridge_windows_test.go
+++ b/cmd/drive9/cli/fuse_bridge_windows_test.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMountVaultImplWindowsReportsCLIAlternative(t *testing.T) {
+	err := mountVaultImpl(&vaultMountOptions{})
+	if err == nil {
+		t.Fatal("expected windows vault mount to be unsupported")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "drive9 vault commands") {
+		t.Fatalf("error = %q, want drive9 vault command guidance", got)
+	}
+	if !strings.Contains(got, "vault API") {
+		t.Fatalf("error = %q, want vault API guidance", got)
+	}
+}
+
+func TestMountFuseImplWindowsReportsWebDAVAlternative(t *testing.T) {
+	err := mountFuseImpl(&mountFuseOptions{})
+	if err == nil {
+		t.Fatal("expected windows fuse mount to be unsupported")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "drive9 mount") || !strings.Contains(got, "--mode=fuse") {
+		t.Fatalf("error = %q, want explicit WebDAV mount guidance", got)
+	}
+	if !strings.Contains(got, "WebDAV") {
+		t.Fatalf("error = %q, want WebDAV guidance", got)
+	}
+}

--- a/cmd/drive9/cli/fuse_bridge_windows_test.go
+++ b/cmd/drive9/cli/fuse_bridge_windows_test.go
@@ -7,6 +7,76 @@ import (
 	"testing"
 )
 
+func TestFsMountCmdWindowsFuseReportsUnsupportedBeforeCredentialResolution(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	err := fsMountCmd([]string{"--mode=fuse", `X:\\drive9`})
+	if err == nil {
+		t.Fatal("expected windows fuse mount to be unsupported")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "WebDAV") || !strings.Contains(got, "--mode=fuse") {
+		t.Fatalf("error = %q, want explicit Windows WebDAV guidance", got)
+	}
+	if strings.Contains(got, "owner API key or delegated token required") {
+		t.Fatalf("error = %q, should not surface credential resolution failure", got)
+	}
+	if strings.Contains(got, "drive9 server URL required") {
+		t.Fatalf("error = %q, should not surface server resolution failure", got)
+	}
+}
+
+func TestFsMountCmdWindowsFuseStillRejectsExplicitEmptyAPIKey(t *testing.T) {
+	err := fsMountCmd([]string{"--mode=fuse", "--api-key=", `X:\\drive9`})
+	if err == nil {
+		t.Fatal("expected explicit empty api-key to fail")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "--api-key was given an empty value") {
+		t.Fatalf("error = %q, want empty api-key validation", got)
+	}
+	if strings.Contains(got, "WebDAV") {
+		t.Fatalf("error = %q, want empty-flag validation before Windows unsupported guidance", got)
+	}
+}
+
+func TestVaultMountCmdWindowsReportsUnsupportedBeforeCredentialResolution(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	err := VaultMountCmd([]string{`X:\\drive9-vault`})
+	if err == nil {
+		t.Fatal("expected windows vault mount to be unsupported")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "drive9 vault commands") || !strings.Contains(got, "vault API") {
+		t.Fatalf("error = %q, want Windows vault guidance", got)
+	}
+	if strings.Contains(got, "owner API key or delegated token required") {
+		t.Fatalf("error = %q, should not surface credential resolution failure", got)
+	}
+	if strings.Contains(got, "drive9 server URL required") {
+		t.Fatalf("error = %q, should not surface server resolution failure", got)
+	}
+}
+
+func TestVaultMountCmdWindowsStillRejectsExplicitEmptyAPIKey(t *testing.T) {
+	err := VaultMountCmd([]string{"--api-key=", `X:\\drive9-vault`})
+	if err == nil {
+		t.Fatal("expected explicit empty api-key to fail")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "--api-key was given an empty value") {
+		t.Fatalf("error = %q, want empty api-key validation", got)
+	}
+	if strings.Contains(got, "vault API") {
+		t.Fatalf("error = %q, want empty-flag validation before Windows unsupported guidance", got)
+	}
+}
+
 func TestMountVaultImplWindowsReportsCLIAlternative(t *testing.T) {
 	err := mountVaultImpl(&vaultMountOptions{})
 	if err == nil {

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -162,6 +162,14 @@ func fsMountCmd(args []string) error {
 	if resolved == MountModeWebDAV && *readOnly {
 		return fmt.Errorf("drive9 mount: --read-only is not supported with WebDAV mode")
 	}
+	if runtime.GOOS == "windows" && resolved == MountModeFUSE {
+		return mountFuse(&mountFuseOptions{
+			MountPoint: mountPoint,
+			RemoteRoot: remoteRoot,
+			ReadOnly:   *readOnly,
+			Debug:      *debug,
+		})
+	}
 
 	serverVal, apiKeyVal, tokenVal, err := resolveMountCredentials(ResolveCredentials(), *server, *apiKey)
 	if err != nil {

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -313,7 +313,7 @@ type umountDeps struct {
 	lookPath  func(string) (string, error)
 	run       func([]string) error
 	readPID   func(string) (int, string, error)
-	terminate func(int) error
+	terminate func(int, time.Duration) error
 	pidAlive  func(int) bool
 	now       func() time.Time
 	sleep     func(time.Duration)
@@ -384,9 +384,10 @@ func runUmount(args []string, deps umountDeps) error {
 		if deps.terminate == nil {
 			return fmt.Errorf("drive9 umount: no process terminator configured for Windows WebDAV mount")
 		}
-		if err := deps.terminate(pid); err != nil {
-			return fmt.Errorf("drive9 umount: terminate mount process pid %d: %w", pid, err)
+		if err := deps.terminate(pid, *waitTimeout); err != nil {
+			return fmt.Errorf("%w (pid file: %s)", err, path)
 		}
+		return nil
 	}
 	if *waitTimeout == 0 {
 		return nil
@@ -417,27 +418,10 @@ func waitForPIDExit(pid int, timeout time.Duration, deps umountDeps) error {
 }
 
 func processAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	err = process.Signal(syscall.Signal(0))
-	if err == nil {
-		return true
-	}
-	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
-		return false
-	}
-	if errors.Is(err, syscall.EPERM) {
-		return true
-	}
-	return false
+	return processAliveImpl(pid)
 }
 
-func terminateProcess(pid int) error {
+func terminateProcess(pid int, waitTimeout time.Duration) error {
 	if pid <= 0 {
 		return fmt.Errorf("invalid mount process pid %d", pid)
 	}
@@ -452,7 +436,13 @@ func terminateProcess(pid int) error {
 	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
 		return nil
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	if waitTimeout > 0 {
+		return waitForProcessExitByPID(pid, waitTimeout)
+	}
+	return nil
 }
 
 // resolveMountCredentials selects the (server, apiKey, token) triple that a

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -369,8 +369,9 @@ func runUmount(args []string, deps umountDeps) error {
 	if err != nil {
 		return err
 	}
-	if err := deps.run(argv); err != nil {
-		return err
+	runErr := deps.run(argv)
+	if deps.goos != "windows" && runErr != nil {
+		return runErr
 	}
 	// Windows WebDAV mounts run a local bridge in the mount process. Even when
 	// the caller opts out of waiting, still request process shutdown before
@@ -378,23 +379,35 @@ func runUmount(args []string, deps umountDeps) error {
 	pid, path, err := deps.readPID(stateMountPoint)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil
+			return runErr
+		}
+		if runErr != nil {
+			return runErr
 		}
 		return err
 	}
 	if deps.goos == "windows" {
 		if deps.terminate == nil {
+			if runErr != nil {
+				return runErr
+			}
 			return fmt.Errorf("drive9 umount: no process terminator configured for Windows WebDAV mount")
 		}
 		if err := deps.terminate(pid, *waitTimeout); err != nil {
+			if runErr != nil {
+				return runErr
+			}
 			return fmt.Errorf("%w (pid file: %s)", err, path)
 		}
 		if path != "" && deps.remove != nil {
 			if err := deps.remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				if runErr != nil {
+					return runErr
+				}
 				return fmt.Errorf("drive9 umount: remove mount pid file %s: %w", path, err)
 			}
 		}
-		return nil
+		return runErr
 	}
 	if *waitTimeout == 0 {
 		return nil

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -314,6 +314,7 @@ type umountDeps struct {
 	run       func([]string) error
 	readPID   func(string) (int, string, error)
 	terminate func(int, time.Duration) error
+	remove    func(string) error
 	pidAlive  func(int) bool
 	now       func() time.Time
 	sleep     func(time.Duration)
@@ -332,6 +333,7 @@ func defaultUmountDeps() umountDeps {
 		},
 		readPID:   mountstate.ReadPID,
 		terminate: terminateProcess,
+		remove:    os.Remove,
 		pidAlive:  processAlive,
 		now:       time.Now,
 		sleep:     time.Sleep,
@@ -387,6 +389,11 @@ func runUmount(args []string, deps umountDeps) error {
 		if err := deps.terminate(pid, *waitTimeout); err != nil {
 			return fmt.Errorf("%w (pid file: %s)", err, path)
 		}
+		if path != "" && deps.remove != nil {
+			if err := deps.remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("drive9 umount: remove mount pid file %s: %w", path, err)
+			}
+		}
 		return nil
 	}
 	if *waitTimeout == 0 {
@@ -421,6 +428,8 @@ func processAlive(pid int) bool {
 	return processAliveImpl(pid)
 }
 
+var waitForProcessExit = waitForProcessExitByPID
+
 func terminateProcess(pid int, waitTimeout time.Duration) error {
 	if pid <= 0 {
 		return fmt.Errorf("invalid mount process pid %d", pid)
@@ -430,17 +439,18 @@ func terminateProcess(pid int, waitTimeout time.Duration) error {
 		return err
 	}
 	err = process.Kill()
-	if err == nil {
-		return nil
+	if err != nil {
+		if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+			err = nil
+		} else {
+			return err
+		}
 	}
-	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
-		return nil
+	if waitTimeout > 0 {
+		return waitForProcessExit(pid, waitTimeout)
 	}
 	if err != nil {
 		return err
-	}
-	if waitTimeout > 0 {
-		return waitForProcessExitByPID(pid, waitTimeout)
 	}
 	return nil
 }

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -313,6 +313,7 @@ type umountDeps struct {
 	lookPath  func(string) (string, error)
 	run       func([]string) error
 	readPID   func(string) (int, string, error)
+	terminate func(int) error
 	pidAlive  func(int) bool
 	now       func() time.Time
 	sleep     func(time.Duration)
@@ -330,6 +331,7 @@ func defaultUmountDeps() umountDeps {
 			return cmd.Run()
 		},
 		readPID:   mountstate.ReadPID,
+		terminate: terminateProcess,
 		pidAlive:  processAlive,
 		now:       time.Now,
 		sleep:     time.Sleep,
@@ -352,6 +354,14 @@ func runUmount(args []string, deps umountDeps) error {
 		return fmt.Errorf("usage: drive9 umount [--timeout duration] <mountpoint>")
 	}
 	mountPoint := fs.Arg(0)
+	stateMountPoint := mountPoint
+	var err error
+	if deps.goos == "windows" {
+		stateMountPoint, err = webdavMountStatePoint(deps.goos, mountPoint)
+		if err != nil {
+			return err
+		}
+	}
 
 	argv, err := umountArgv(deps.goos, deps.lookPath, mountPoint)
 	if err != nil {
@@ -361,14 +371,26 @@ func runUmount(args []string, deps umountDeps) error {
 		return err
 	}
 	if *waitTimeout == 0 {
-		return nil
+		// Windows WebDAV mounts run a local bridge in the mount process. Even
+		// when the caller opts out of waiting, still request process shutdown.
 	}
-	pid, path, err := deps.readPID(mountPoint)
+	pid, path, err := deps.readPID(stateMountPoint)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return err
+	}
+	if deps.goos == "windows" {
+		if deps.terminate == nil {
+			return fmt.Errorf("drive9 umount: no process terminator configured for Windows WebDAV mount")
+		}
+		if err := deps.terminate(pid); err != nil {
+			return fmt.Errorf("drive9 umount: terminate mount process pid %d: %w", pid, err)
+		}
+	}
+	if *waitTimeout == 0 {
+		return nil
 	}
 	if err := waitForPIDExit(pid, *waitTimeout, deps); err != nil {
 		return fmt.Errorf("%w (pid file: %s)", err, path)
@@ -414,6 +436,24 @@ func processAlive(pid int) bool {
 		return true
 	}
 	return false
+}
+
+func terminateProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid mount process pid %d", pid)
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	err = process.Kill()
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
 }
 
 // resolveMountCredentials selects the (server, apiKey, token) triple that a

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -24,13 +24,13 @@ import (
 // Dispatch fork (Row A, V2e): the first positional argument selects the
 // mount flavour.
 //
-//   - `drive9 mount vault <path>`   → read-only vault FUSE filesystem
-//   - `drive9 mount [flags] <path>` → legacy writable fs mount (no
+//   - `drive9 mount vault <path>`   鈫?read-only vault FUSE filesystem
+//   - `drive9 mount [flags] <path>` 鈫?legacy writable fs mount (no
 //     subcommand keyword; first positional is the mount point)
 //
 // We MUST peek at the first arg before flag.Parse because the vault flag
 // set is smaller (no cache-size / write-path knobs), and a single flag
-// set would quietly accept write-path flags for a vault mount — that
+// set would quietly accept write-path flags for a vault mount 鈥?that
 // would violate Row C (read-only) in a subtle, mount-time-visible way.
 //
 // Only the CURRENT supported backend keyword ("vault") is reserved here.
@@ -50,7 +50,7 @@ func MountCmd(args []string) error {
 
 // fsMountCmd is the pre-V2e writable fs mount entry point.
 //
-// Credential precedence matches spec §14.2: explicit --server / --api-key flag
+// Credential precedence matches spec 搂14.2: explicit --server / --api-key flag
 // > DRIVE9_SERVER / DRIVE9_API_KEY / DRIVE9_VAULT_TOKEN env > active config
 // context. The flag defaults are empty strings so we can distinguish "unset"
 // from "explicit empty"; the latter is rejected (see rejectEmptyFlag).
@@ -59,10 +59,10 @@ func MountCmd(args []string) error {
 // If the resolver returns a delegated credential (owner JWT / `ctx use <alice>`),
 // Mount is created via client.NewWithToken and bound to that capability for
 // the mount's lifetime. If the active principal changes later (`ctx use` to
-// another context), the running mount keeps its original binding — changing
+// another context), the running mount keeps its original binding 鈥?changing
 // a running mount's credential requires umount + remount (Invariant #6).
 // `vault reauth` is not part of M1; see docs/specs/vault-interaction-end-state.md
-// §17.
+// 搂17.
 //
 // drive9fuse.Mount runs in-process (no fork/exec); credentials flow through
 // MountOptions{Server, APIKey, Token}, not through the child's environment.
@@ -228,7 +228,7 @@ func newWebDAVHandler(c *client.Client, prefix string, remoteRoot string) (http.
 }
 
 // validateRemoteRoot checks that the remote root path exists and is a directory.
-// Mirrors the FUSE path's Stat→List fallback so both mount modes behave
+// Mirrors the FUSE path's Stat鈫扡ist fallback so both mount modes behave
 // identically on backends where directory stat is unsupported.
 func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 	if remoteRoot == "/" {
@@ -240,7 +240,7 @@ func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 	}
 	stat, err := c.Stat(remoteRoot)
 	if err != nil {
-		// If Stat explicitly says "not found", trust it — don't fall back
+		// If Stat explicitly says "not found", trust it 鈥?don't fall back
 		// to List which may return empty success for non-existent paths.
 		if client.IsNotFound(err) {
 			return remoteRootError(remoteRoot, err)
@@ -370,10 +370,9 @@ func runUmount(args []string, deps umountDeps) error {
 	if err := deps.run(argv); err != nil {
 		return err
 	}
-	if *waitTimeout == 0 {
-		// Windows WebDAV mounts run a local bridge in the mount process. Even
-		// when the caller opts out of waiting, still request process shutdown.
-	}
+	// Windows WebDAV mounts run a local bridge in the mount process. Even when
+	// the caller opts out of waiting, still request process shutdown before
+	// returning.
 	pid, path, err := deps.readPID(stateMountPoint)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -458,7 +457,7 @@ func terminateProcess(pid int) error {
 
 // resolveMountCredentials selects the (server, apiKey, token) triple that a
 // fresh mount will be bound to. It locks the principal kind at mount time
-// per Invariant #3 — once this function returns, the chosen credential is
+// per Invariant #3 鈥?once this function returns, the chosen credential is
 // fixed for the mount's lifetime. An explicit --api-key flag always means
 // owner; delegated JWTs only reach this layer through the active context
 // or DRIVE9_VAULT_TOKEN (resolver output).

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -14,13 +14,10 @@ import (
 
 	"github.com/mem9-ai/dat9/pkg/buildinfo"
 	"github.com/mem9-ai/dat9/pkg/client"
-	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
 	"github.com/mem9-ai/dat9/pkg/mountpath"
 	"github.com/mem9-ai/dat9/pkg/mountstate"
 	drive9webdav "github.com/mem9-ai/dat9/pkg/webdav"
 )
-
-var mountFuse = drive9fuse.Mount
 
 // MountCmd handles the "drive9 mount" command.
 //
@@ -189,12 +186,12 @@ func fsMountCmd(args []string) error {
 	}
 
 	// FUSE path (existing behavior).
-	syncModeVal, err := drive9fuse.ParseSyncMode(*syncMode)
+	syncModeVal, err := parseFuseSyncMode(*syncMode)
 	if err != nil {
 		return err
 	}
 
-	opts := &drive9fuse.MountOptions{
+	opts := &mountFuseOptions{
 		Server:                *server,
 		APIKey:                *apiKey,
 		Token:                 token,
@@ -455,6 +452,13 @@ func resolveMountCredentials(r ResolvedCredentials, flagServer, flagAPIKey strin
 }
 
 func umountArgv(goos string, lookPath func(string) (string, error), mountPoint string) ([]string, error) {
+	if goos == "windows" {
+		normalizedMountPoint, err := normalizeWebDAVMountPoint(goos, mountPoint)
+		if err != nil {
+			return nil, err
+		}
+		return []string{"net", "use", normalizedMountPoint, "/delete", "/y"}, nil
+	}
 	if goos == "darwin" {
 		return []string{"umount", mountPoint}, nil
 	}

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -19,6 +19,11 @@ import (
 	drive9webdav "github.com/mem9-ai/dat9/pkg/webdav"
 )
 
+var (
+	errMountProcessStateStale  = errors.New("drive9 umount: stale mount process state")
+	errMountProcessStateUnsafe = errors.New("drive9 umount: unsafe mount process state")
+)
+
 // MountCmd handles the "drive9 mount" command.
 //
 // Dispatch fork (Row A, V2e): the first positional argument selects the
@@ -309,16 +314,18 @@ func UmountCmd(args []string) error {
 }
 
 type umountDeps struct {
-	goos      string
-	lookPath  func(string) (string, error)
-	run       func([]string) error
-	readPID   func(string) (int, string, error)
-	terminate func(int, time.Duration) error
-	remove    func(string) error
-	pidAlive  func(int) bool
-	now       func() time.Time
-	sleep     func(time.Duration)
-	printErrf func(string, ...any)
+	goos             string
+	lookPath         func(string) (string, error)
+	run              func([]string) error
+	readPID          func(string) (int, string, error)
+	readProcessState func(string) (mountstate.ProcessState, string, error)
+	terminate        func(int, time.Duration) error
+	terminateState   func(mountstate.ProcessState, time.Duration) error
+	remove           func(string) error
+	pidAlive         func(int) bool
+	now              func() time.Time
+	sleep            func(time.Duration)
+	printErrf        func(string, ...any)
 }
 
 func defaultUmountDeps() umountDeps {
@@ -331,13 +338,15 @@ func defaultUmountDeps() umountDeps {
 			cmd.Stderr = os.Stderr
 			return cmd.Run()
 		},
-		readPID:   mountstate.ReadPID,
-		terminate: terminateProcess,
-		remove:    os.Remove,
-		pidAlive:  processAlive,
-		now:       time.Now,
-		sleep:     time.Sleep,
-		printErrf: func(format string, args ...any) { fmt.Fprintf(os.Stderr, format, args...) },
+		readPID:          mountstate.ReadPID,
+		readProcessState: mountstate.ReadProcessState,
+		terminate:        terminateProcess,
+		terminateState:   terminateMountProcess,
+		remove:           os.Remove,
+		pidAlive:         processAlive,
+		now:              time.Now,
+		sleep:            time.Sleep,
+		printErrf:        func(format string, args ...any) { fmt.Fprintf(os.Stderr, format, args...) },
 	}
 }
 
@@ -376,27 +385,54 @@ func runUmount(args []string, deps umountDeps) error {
 	if deps.goos != "windows" && *waitTimeout == 0 {
 		return nil
 	}
-	// Windows WebDAV mounts run a local bridge in the mount process. Even when
-	// the caller opts out of waiting, still request process shutdown before
-	// returning.
-	pid, path, err := deps.readPID(stateMountPoint)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return runErr
-		}
-		if runErr != nil {
-			return runErr
-		}
-		return err
-	}
 	if deps.goos == "windows" {
-		if deps.terminate == nil {
+		var (
+			state mountstate.ProcessState
+			path  string
+		)
+		if deps.readProcessState != nil {
+			state, path, err = deps.readProcessState(stateMountPoint)
+		} else {
+			var pid int
+			pid, path, err = deps.readPID(stateMountPoint)
+			state = mountstate.ProcessState{PID: pid}
+		}
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return runErr
+			}
+			if runErr != nil {
+				return runErr
+			}
+			return err
+		}
+
+		if deps.terminateState == nil && deps.terminate == nil {
 			if runErr != nil {
 				return runErr
 			}
 			return fmt.Errorf("drive9 umount: no process terminator configured for Windows WebDAV mount")
 		}
-		if err := deps.terminate(pid, *waitTimeout); err != nil {
+
+		if deps.terminateState != nil {
+			err = deps.terminateState(state, *waitTimeout)
+		} else {
+			err = deps.terminate(state.PID, *waitTimeout)
+		}
+		if err != nil {
+			if errors.Is(err, errMountProcessStateStale) || errors.Is(err, errMountProcessStateUnsafe) {
+				if path != "" && deps.remove != nil {
+					if removeErr := deps.remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) && runErr == nil {
+						return fmt.Errorf("drive9 umount: remove mount pid file %s: %w", path, removeErr)
+					}
+				}
+				if errors.Is(err, errMountProcessStateStale) {
+					if deps.printErrf != nil {
+						deps.printErrf("drive9 umount: removed stale mount pid file %s without terminating any process\n", path)
+					}
+					return runErr
+				}
+			}
 			if runErr != nil {
 				return runErr
 			}
@@ -411,6 +447,17 @@ func runUmount(args []string, deps umountDeps) error {
 			}
 		}
 		return runErr
+	}
+
+	pid, path, err := deps.readPID(stateMountPoint)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return runErr
+		}
+		if runErr != nil {
+			return runErr
+		}
+		return err
 	}
 	if *waitTimeout == 0 {
 		return nil

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -24,13 +24,13 @@ import (
 // Dispatch fork (Row A, V2e): the first positional argument selects the
 // mount flavour.
 //
-//   - `drive9 mount vault <path>`   鈫?read-only vault FUSE filesystem
-//   - `drive9 mount [flags] <path>` 鈫?legacy writable fs mount (no
+//   - `drive9 mount vault <path>`   -> read-only vault FUSE filesystem
+//   - `drive9 mount [flags] <path>` -> legacy writable fs mount (no
 //     subcommand keyword; first positional is the mount point)
 //
 // We MUST peek at the first arg before flag.Parse because the vault flag
 // set is smaller (no cache-size / write-path knobs), and a single flag
-// set would quietly accept write-path flags for a vault mount 鈥?that
+// set would quietly accept write-path flags for a vault mount - that
 // would violate Row C (read-only) in a subtle, mount-time-visible way.
 //
 // Only the CURRENT supported backend keyword ("vault") is reserved here.
@@ -50,7 +50,7 @@ func MountCmd(args []string) error {
 
 // fsMountCmd is the pre-V2e writable fs mount entry point.
 //
-// Credential precedence matches spec 搂14.2: explicit --server / --api-key flag
+// Credential precedence matches spec section 14.2: explicit --server / --api-key flag
 // > DRIVE9_SERVER / DRIVE9_API_KEY / DRIVE9_VAULT_TOKEN env > active config
 // context. The flag defaults are empty strings so we can distinguish "unset"
 // from "explicit empty"; the latter is rejected (see rejectEmptyFlag).
@@ -59,10 +59,10 @@ func MountCmd(args []string) error {
 // If the resolver returns a delegated credential (owner JWT / `ctx use <alice>`),
 // Mount is created via client.NewWithToken and bound to that capability for
 // the mount's lifetime. If the active principal changes later (`ctx use` to
-// another context), the running mount keeps its original binding 鈥?changing
+// another context), the running mount keeps its original binding - changing
 // a running mount's credential requires umount + remount (Invariant #6).
 // `vault reauth` is not part of M1; see docs/specs/vault-interaction-end-state.md
-// 搂17.
+// section 17.
 //
 // drive9fuse.Mount runs in-process (no fork/exec); credentials flow through
 // MountOptions{Server, APIKey, Token}, not through the child's environment.
@@ -228,7 +228,7 @@ func newWebDAVHandler(c *client.Client, prefix string, remoteRoot string) (http.
 }
 
 // validateRemoteRoot checks that the remote root path exists and is a directory.
-// Mirrors the FUSE path's Stat鈫扡ist fallback so both mount modes behave
+// Mirrors the FUSE path's Stat->List fallback so both mount modes behave
 // identically on backends where directory stat is unsupported.
 func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 	if remoteRoot == "/" {
@@ -240,7 +240,7 @@ func validateRemoteRoot(c *client.Client, remoteRoot string) error {
 	}
 	stat, err := c.Stat(remoteRoot)
 	if err != nil {
-		// If Stat explicitly says "not found", trust it 鈥?don't fall back
+		// If Stat explicitly says "not found", trust it - don't fall back
 		// to List which may return empty success for non-existent paths.
 		if client.IsNotFound(err) {
 			return remoteRootError(remoteRoot, err)
@@ -373,6 +373,9 @@ func runUmount(args []string, deps umountDeps) error {
 	if deps.goos != "windows" && runErr != nil {
 		return runErr
 	}
+	if deps.goos != "windows" && *waitTimeout == 0 {
+		return nil
+	}
 	// Windows WebDAV mounts run a local bridge in the mount process. Even when
 	// the caller opts out of waiting, still request process shutdown before
 	// returning.
@@ -470,7 +473,7 @@ func terminateProcess(pid int, waitTimeout time.Duration) error {
 
 // resolveMountCredentials selects the (server, apiKey, token) triple that a
 // fresh mount will be bound to. It locks the principal kind at mount time
-// per Invariant #3 鈥?once this function returns, the chosen credential is
+// per Invariant #3 - once this function returns, the chosen credential is
 // fixed for the mount's lifetime. An explicit --api-key flag always means
 // owner; delegated JWTs only reach this layer through the active context
 // or DRIVE9_VAULT_TOKEN (resolver output).

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -370,10 +370,9 @@ func runUmount(args []string, deps umountDeps) error {
 	if err := deps.run(argv); err != nil {
 		return err
 	}
-	if *waitTimeout == 0 {
-		// Windows WebDAV mounts run a local bridge in the mount process. Even
-		// when the caller opts out of waiting, still request process shutdown.
-	}
+	// Windows WebDAV mounts run a local bridge in the mount process. Even when
+	// the caller opts out of waiting, still request process shutdown before
+	// returning.
 	pid, path, err := deps.readPID(stateMountPoint)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -282,6 +282,67 @@ func TestRunUmountWindowsTerminatesMountProcess(t *testing.T) {
 	}
 }
 
+func TestRunUmountWindowsStillCleansUpAfterUnmountFailure(t *testing.T) {
+	now := time.Unix(100, 0)
+	runErr := errors.New("net use failed")
+	runCalls := 0
+	terminateCalls := 0
+	removeCalls := 0
+	deps := umountDeps{
+		goos:     "windows",
+		lookPath: fakeLookPath(nil),
+		run: func(argv []string) error {
+			runCalls++
+			want := []string{"net", "use", "X:", "/delete", "/y"}
+			if !reflect.DeepEqual(argv, want) {
+				t.Fatalf("argv = %v, want %v", argv, want)
+			}
+			return runErr
+		},
+		readPID: func(mountPoint string) (int, string, error) {
+			if mountPoint != "X:\\" {
+				t.Fatalf("mountPoint = %q, want %q", mountPoint, "X:\\")
+			}
+			return 4321, "C:/tmp/drive9-webdav.pid", nil
+		},
+		terminate: func(pid int, waitTimeout time.Duration) error {
+			terminateCalls++
+			if pid != 4321 {
+				t.Fatalf("pid = %d, want 4321", pid)
+			}
+			if waitTimeout != 60*time.Second {
+				t.Fatalf("waitTimeout = %s, want %s", waitTimeout, 60*time.Second)
+			}
+			return nil
+		},
+		remove: func(path string) error {
+			removeCalls++
+			if path != "C:/tmp/drive9-webdav.pid" {
+				t.Fatalf("path = %q, want %q", path, "C:/tmp/drive9-webdav.pid")
+			}
+			return nil
+		},
+		pidAlive:  func(int) bool { t.Fatal("pidAlive should not be called on Windows"); return false },
+		now:       func() time.Time { return now },
+		sleep:     func(d time.Duration) { now = now.Add(d) },
+		printErrf: func(string, ...any) {},
+	}
+
+	err := runUmount([]string{"x:\\"}, deps)
+	if !errors.Is(err, runErr) {
+		t.Fatalf("err = %v, want %v", err, runErr)
+	}
+	if runCalls != 1 {
+		t.Fatalf("runCalls = %d, want 1", runCalls)
+	}
+	if terminateCalls != 1 {
+		t.Fatalf("terminateCalls = %d, want 1", terminateCalls)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("removeCalls = %d, want 1", removeCalls)
+	}
+}
+
 func TestTerminateProcessWaitsAfterSuccessfulKill(t *testing.T) {
 	oldWaitForProcessExit := waitForProcessExit
 	t.Cleanup(func() { waitForProcessExit = oldWaitForProcessExit })

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -205,7 +205,7 @@ func TestRunUmountNoPIDFileReturnsSuccess(t *testing.T) {
 		lookPath:  fakeLookPath(map[string]bool{"fusermount3": true}),
 		run:       func([]string) error { return nil },
 		readPID:   func(string) (int, string, error) { return 0, "/tmp/drive9.pid", os.ErrNotExist },
-		terminate: func(int) error { t.Fatal("terminate should not be called without pid file"); return nil },
+		terminate: func(int, time.Duration) error { t.Fatal("terminate should not be called without pid file"); return nil },
 		pidAlive:  func(int) bool { t.Fatal("pidAlive should not be called without pid file"); return false },
 		now:       time.Now,
 		sleep:     func(time.Duration) {},
@@ -221,7 +221,6 @@ func TestRunUmountWindowsTerminatesMountProcess(t *testing.T) {
 	now := time.Unix(100, 0)
 	runCalls := 0
 	terminateCalls := 0
-	aliveCalls := 0
 	deps := umountDeps{
 		goos:     "windows",
 		lookPath: fakeLookPath(nil),
@@ -239,19 +238,19 @@ func TestRunUmountWindowsTerminatesMountProcess(t *testing.T) {
 			}
 			return 4321, "C:/tmp/drive9-webdav.pid", nil
 		},
-		terminate: func(pid int) error {
+		terminate: func(pid int, waitTimeout time.Duration) error {
 			terminateCalls++
 			if pid != 4321 {
 				t.Fatalf("pid = %d, want 4321", pid)
 			}
+			if waitTimeout != 60*time.Second {
+				t.Fatalf("waitTimeout = %s, want %s", waitTimeout, 60*time.Second)
+			}
 			return nil
 		},
 		pidAlive: func(pid int) bool {
-			aliveCalls++
-			if pid != 4321 {
-				t.Fatalf("pid = %d, want 4321", pid)
-			}
-			return aliveCalls < 2
+			t.Fatalf("pidAlive should not be called on Windows; terminate handles the wait path")
+			return false
 		},
 		now:       func() time.Time { return now },
 		sleep:     func(d time.Duration) { now = now.Add(d) },
@@ -266,9 +265,6 @@ func TestRunUmountWindowsTerminatesMountProcess(t *testing.T) {
 	}
 	if terminateCalls != 1 {
 		t.Fatalf("terminateCalls = %d, want 1", terminateCalls)
-	}
-	if aliveCalls != 2 {
-		t.Fatalf("aliveCalls = %d, want 2", aliveCalls)
 	}
 }
 

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/mountstate"
 )
 
 func fakeLookPath(binMap map[string]bool) func(string) (string, error) {
@@ -183,7 +185,10 @@ func TestRunUmountDoesNotBlockOnStalePID(t *testing.T) {
 		goos:     "linux",
 		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
 		run:      func([]string) error { return nil },
-		readPID:  func(string) (int, string, error) { return 1234, "/tmp/drive9.pid", nil },
+		readProcessState: func(string) (mountstate.ProcessState, string, error) {
+			return mountstate.ProcessState{}, "", errors.New("readProcessState should not be called on non-Windows")
+		},
+		readPID: func(string) (int, string, error) { return 1234, "/tmp/drive9.pid", nil },
 		pidAlive: func(int) bool {
 			aliveCalls++
 			return false
@@ -203,9 +208,12 @@ func TestRunUmountDoesNotBlockOnStalePID(t *testing.T) {
 
 func TestRunUmountNoPIDFileReturnsSuccess(t *testing.T) {
 	deps := umountDeps{
-		goos:      "linux",
-		lookPath:  fakeLookPath(map[string]bool{"fusermount3": true}),
-		run:       func([]string) error { return nil },
+		goos:     "linux",
+		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
+		run:      func([]string) error { return nil },
+		readProcessState: func(string) (mountstate.ProcessState, string, error) {
+			return mountstate.ProcessState{}, "", errors.New("readProcessState should not be called on non-Windows")
+		},
 		readPID:   func(string) (int, string, error) { return 0, "/tmp/drive9.pid", os.ErrNotExist },
 		terminate: func(int, time.Duration) error { t.Fatal("terminate should not be called without pid file"); return nil },
 		remove:    func(string) error { t.Fatal("remove should not be called without pid file"); return nil },
@@ -225,6 +233,9 @@ func TestRunUmountNonWindowsTimeoutZeroSkipsPIDRead(t *testing.T) {
 		goos:     "linux",
 		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
 		run:      func([]string) error { return nil },
+		readProcessState: func(string) (mountstate.ProcessState, string, error) {
+			return mountstate.ProcessState{}, "", errors.New("readProcessState should not be called on non-Windows")
+		},
 		readPID: func(string) (int, string, error) {
 			t.Fatal("readPID should not be called when timeout is zero on non-Windows")
 			return 0, "", nil
@@ -267,16 +278,19 @@ func TestRunUmountWindowsTerminatesMountProcess(t *testing.T) {
 			}
 			return nil
 		},
-		readPID: func(mountPoint string) (int, string, error) {
+		readProcessState: func(mountPoint string) (mountstate.ProcessState, string, error) {
 			if mountPoint != "X:\\" {
 				t.Fatalf("mountPoint = %q, want %q", mountPoint, "X:\\")
 			}
-			return 4321, "C:/tmp/drive9-webdav.pid", nil
+			return mountstate.ProcessState{PID: 4321, CreationTime: 99}, "C:/tmp/drive9-webdav.pid", nil
 		},
-		terminate: func(pid int, waitTimeout time.Duration) error {
+		terminateState: func(state mountstate.ProcessState, waitTimeout time.Duration) error {
 			terminateCalls++
-			if pid != 4321 {
-				t.Fatalf("pid = %d, want 4321", pid)
+			if state.PID != 4321 {
+				t.Fatalf("pid = %d, want 4321", state.PID)
+			}
+			if state.CreationTime != 99 {
+				t.Fatalf("creationTime = %d, want 99", state.CreationTime)
 			}
 			if waitTimeout != 60*time.Second {
 				t.Fatalf("waitTimeout = %s, want %s", waitTimeout, 60*time.Second)
@@ -330,16 +344,19 @@ func TestRunUmountWindowsStillCleansUpAfterUnmountFailure(t *testing.T) {
 			}
 			return runErr
 		},
-		readPID: func(mountPoint string) (int, string, error) {
+		readProcessState: func(mountPoint string) (mountstate.ProcessState, string, error) {
 			if mountPoint != "X:\\" {
 				t.Fatalf("mountPoint = %q, want %q", mountPoint, "X:\\")
 			}
-			return 4321, "C:/tmp/drive9-webdav.pid", nil
+			return mountstate.ProcessState{PID: 4321, CreationTime: 99}, "C:/tmp/drive9-webdav.pid", nil
 		},
-		terminate: func(pid int, waitTimeout time.Duration) error {
+		terminateState: func(state mountstate.ProcessState, waitTimeout time.Duration) error {
 			terminateCalls++
-			if pid != 4321 {
-				t.Fatalf("pid = %d, want 4321", pid)
+			if state.PID != 4321 {
+				t.Fatalf("pid = %d, want 4321", state.PID)
+			}
+			if state.CreationTime != 99 {
+				t.Fatalf("creationTime = %d, want 99", state.CreationTime)
 			}
 			if waitTimeout != 60*time.Second {
 				t.Fatalf("waitTimeout = %s, want %s", waitTimeout, 60*time.Second)
@@ -409,6 +426,55 @@ func TestTerminateProcessWaitsAfterSuccessfulKill(t *testing.T) {
 		t.Fatal("waitForProcessExit was not called after successful kill")
 	}
 	_, _ = cmd.Process.Wait()
+}
+
+func TestRunUmountWindowsStalePIDFileDoesNotTerminateProcess(t *testing.T) {
+	runCalls := 0
+	removeCalls := 0
+	deps := umountDeps{
+		goos:     "windows",
+		lookPath: fakeLookPath(nil),
+		run: func(argv []string) error {
+			runCalls++
+			want := []string{"net", "use", "X:", "/delete", "/y"}
+			if !reflect.DeepEqual(argv, want) {
+				t.Fatalf("argv = %v, want %v", argv, want)
+			}
+			return nil
+		},
+		readProcessState: func(mountPoint string) (mountstate.ProcessState, string, error) {
+			if mountPoint != "X:\\" {
+				t.Fatalf("mountPoint = %q, want %q", mountPoint, "X:\\")
+			}
+			return mountstate.ProcessState{PID: 9999, CreationTime: 123}, "C:/tmp/drive9-webdav.pid", nil
+		},
+		terminateState: func(state mountstate.ProcessState, waitTimeout time.Duration) error {
+			if state.PID != 9999 {
+				t.Fatalf("pid = %d, want 9999", state.PID)
+			}
+			return fmt.Errorf("%w: pid reused", errMountProcessStateStale)
+		},
+		remove: func(path string) error {
+			removeCalls++
+			if path != "C:/tmp/drive9-webdav.pid" {
+				t.Fatalf("path = %q, want %q", path, "C:/tmp/drive9-webdav.pid")
+			}
+			return nil
+		},
+		now:       time.Now,
+		sleep:     func(time.Duration) {},
+		printErrf: func(string, ...any) {},
+	}
+
+	if err := runUmount([]string{"x:\\"}, deps); err != nil {
+		t.Fatalf("runUmount: %v", err)
+	}
+	if runCalls != 1 {
+		t.Fatalf("runCalls = %d, want 1", runCalls)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("removeCalls = %d, want 1", removeCalls)
+	}
 }
 
 // TestResolveMountCredentials_OwnerFromResolver binds a mount to an owner

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -97,7 +97,7 @@ func TestUmountArgvWindowsRejectsNonDriveLetter(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid Windows mountpoint to fail")
 	}
-	if !strings.Contains(err.Error(), "drive letter like X:") {
+	if !strings.Contains(err.Error(), "drive letter like \"X:\"") {
 		t.Fatalf("error = %v, want drive-letter guidance", err)
 	}
 }

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -205,6 +205,7 @@ func TestRunUmountNoPIDFileReturnsSuccess(t *testing.T) {
 		lookPath:  fakeLookPath(map[string]bool{"fusermount3": true}),
 		run:       func([]string) error { return nil },
 		readPID:   func(string) (int, string, error) { return 0, "/tmp/drive9.pid", os.ErrNotExist },
+		terminate: func(int) error { t.Fatal("terminate should not be called without pid file"); return nil },
 		pidAlive:  func(int) bool { t.Fatal("pidAlive should not be called without pid file"); return false },
 		now:       time.Now,
 		sleep:     func(time.Duration) {},
@@ -213,6 +214,61 @@ func TestRunUmountNoPIDFileReturnsSuccess(t *testing.T) {
 
 	if err := runUmount([]string{"/mnt/drive9"}, deps); err != nil {
 		t.Fatalf("runUmount: %v", err)
+	}
+}
+
+func TestRunUmountWindowsTerminatesMountProcess(t *testing.T) {
+	now := time.Unix(100, 0)
+	runCalls := 0
+	terminateCalls := 0
+	aliveCalls := 0
+	deps := umountDeps{
+		goos:     "windows",
+		lookPath: fakeLookPath(nil),
+		run: func(argv []string) error {
+			runCalls++
+			want := []string{"net", "use", "X:", "/delete", "/y"}
+			if !reflect.DeepEqual(argv, want) {
+				t.Fatalf("argv = %v, want %v", argv, want)
+			}
+			return nil
+		},
+		readPID: func(mountPoint string) (int, string, error) {
+			if mountPoint != "X:\\" {
+				t.Fatalf("mountPoint = %q, want %q", mountPoint, "X:\\")
+			}
+			return 4321, "C:/tmp/drive9-webdav.pid", nil
+		},
+		terminate: func(pid int) error {
+			terminateCalls++
+			if pid != 4321 {
+				t.Fatalf("pid = %d, want 4321", pid)
+			}
+			return nil
+		},
+		pidAlive: func(pid int) bool {
+			aliveCalls++
+			if pid != 4321 {
+				t.Fatalf("pid = %d, want 4321", pid)
+			}
+			return aliveCalls < 2
+		},
+		now:       func() time.Time { return now },
+		sleep:     func(d time.Duration) { now = now.Add(d) },
+		printErrf: func(string, ...any) {},
+	}
+
+	if err := runUmount([]string{"x:\\"}, deps); err != nil {
+		t.Fatalf("runUmount: %v", err)
+	}
+	if runCalls != 1 {
+		t.Fatalf("runCalls = %d, want 1", runCalls)
+	}
+	if terminateCalls != 1 {
+		t.Fatalf("terminateCalls = %d, want 1", terminateCalls)
+	}
+	if aliveCalls != 2 {
+		t.Fatalf("aliveCalls = %d, want 2", aliveCalls)
 	}
 }
 

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -220,6 +220,37 @@ func TestRunUmountNoPIDFileReturnsSuccess(t *testing.T) {
 	}
 }
 
+func TestRunUmountNonWindowsTimeoutZeroSkipsPIDRead(t *testing.T) {
+	deps := umountDeps{
+		goos:     "linux",
+		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
+		run:      func([]string) error { return nil },
+		readPID: func(string) (int, string, error) {
+			t.Fatal("readPID should not be called when timeout is zero on non-Windows")
+			return 0, "", nil
+		},
+		terminate: func(int, time.Duration) error {
+			t.Fatal("terminate should not be called on non-Windows timeout-zero path")
+			return nil
+		},
+		remove: func(string) error {
+			t.Fatal("remove should not be called on non-Windows timeout-zero path")
+			return nil
+		},
+		pidAlive: func(int) bool {
+			t.Fatal("pidAlive should not be called on non-Windows timeout-zero path")
+			return false
+		},
+		now:       time.Now,
+		sleep:     func(time.Duration) {},
+		printErrf: func(string, ...any) {},
+	}
+
+	if err := runUmount([]string{"--timeout", "0", "/mnt/drive9"}, deps); err != nil {
+		t.Fatalf("runUmount: %v", err)
+	}
+}
+
 func TestRunUmountWindowsTerminatesMountProcess(t *testing.T) {
 	now := time.Unix(100, 0)
 	runCalls := 0

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -97,7 +97,7 @@ func TestUmountArgvWindowsRejectsNonDriveLetter(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid Windows mountpoint to fail")
 	}
-	if !strings.Contains(err.Error(), "drive letter like X:") {
+	if !strings.Contains(err.Error(), "drive letter like \"X:\"") {
 		t.Fatalf("error = %v, want drive-letter guidance", err)
 	}
 }
@@ -283,7 +283,7 @@ func TestResolveMountCredentials_Invariant6Snapshot(t *testing.T) {
 
 	// Simulate `ctx use other-context` happening between two mount
 	// attempts. Since the helper is pure, the second call cannot affect
-	// the first's result — the first mount's binding is already frozen
+	// the first's result - the first mount's binding is already frozen
 	// into its returned triple.
 	second := ResolvedCredentials{Kind: CredentialOwner, Server: "https://s.example", APIKey: "sk-rotated"}
 	_, api2, tok2, err := resolveMountCredentials(second, "", "")
@@ -457,7 +457,7 @@ func TestNormalizeLookupRetryCount(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Row A — only the CURRENT backend keyword ("vault") is special. All other
+// Row A - only the CURRENT backend keyword ("vault") is special. All other
 // bare-word first positionals (not :/path remote sources) are rejected when
 // two args are given, since the 2-arg form requires a remote source prefix.
 // ---------------------------------------------------------------------------
@@ -556,7 +556,7 @@ func TestValidateRemoteRoot_BothFailWith404(t *testing.T) {
 }
 
 func TestValidateRemoteRoot_Stat404TrustedOverList(t *testing.T) {
-	// Stat (HEAD) returns 404 — we trust it immediately and show the hint,
+	// Stat (HEAD) returns 404 - we trust it immediately and show the hint,
 	// even if List would succeed (server returns empty entries for
 	// non-existent paths).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
-	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
 )
 
 func fakeLookPath(binMap map[string]bool) func(string) (string, error) {
@@ -79,6 +78,27 @@ func TestUmountArgvNoBinary(t *testing.T) {
 	_, err := umountArgv("linux", fakeLookPath(nil), "/mnt/drive9")
 	if err == nil {
 		t.Fatal("expected error when no unmount binaries are available")
+	}
+}
+
+func TestUmountArgvWindows(t *testing.T) {
+	got, err := umountArgv("windows", fakeLookPath(nil), "x:\\")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"net", "use", "X:", "/delete", "/y"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("argv = %v, want %v", got, want)
+	}
+}
+
+func TestUmountArgvWindowsRejectsNonDriveLetter(t *testing.T) {
+	_, err := umountArgv("windows", fakeLookPath(nil), "C:\\temp\\drive9")
+	if err == nil {
+		t.Fatal("expected invalid Windows mountpoint to fail")
+	}
+	if !strings.Contains(err.Error(), "drive letter like X:") {
+		t.Fatalf("error = %v, want drive-letter guidance", err)
 	}
 }
 
@@ -326,8 +346,8 @@ func TestMountCmdPassesLegacyDirStatFallbackOption(t *testing.T) {
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
-	var got *drive9fuse.MountOptions
-	mountFuse = func(opts *drive9fuse.MountOptions) error {
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
 		copied := *opts
 		got = &copied
 		return nil
@@ -359,8 +379,8 @@ func TestMountCmdLeavesLegacyDirStatFallbackDisabledByDefault(t *testing.T) {
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
-	var got *drive9fuse.MountOptions
-	mountFuse = func(opts *drive9fuse.MountOptions) error {
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
 		copied := *opts
 		got = &copied
 		return nil

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -206,6 +208,7 @@ func TestRunUmountNoPIDFileReturnsSuccess(t *testing.T) {
 		run:       func([]string) error { return nil },
 		readPID:   func(string) (int, string, error) { return 0, "/tmp/drive9.pid", os.ErrNotExist },
 		terminate: func(int, time.Duration) error { t.Fatal("terminate should not be called without pid file"); return nil },
+		remove:    func(string) error { t.Fatal("remove should not be called without pid file"); return nil },
 		pidAlive:  func(int) bool { t.Fatal("pidAlive should not be called without pid file"); return false },
 		now:       time.Now,
 		sleep:     func(time.Duration) {},
@@ -221,6 +224,7 @@ func TestRunUmountWindowsTerminatesMountProcess(t *testing.T) {
 	now := time.Unix(100, 0)
 	runCalls := 0
 	terminateCalls := 0
+	removeCalls := 0
 	deps := umountDeps{
 		goos:     "windows",
 		lookPath: fakeLookPath(nil),
@@ -248,6 +252,13 @@ func TestRunUmountWindowsTerminatesMountProcess(t *testing.T) {
 			}
 			return nil
 		},
+		remove: func(path string) error {
+			removeCalls++
+			if path != "C:/tmp/drive9-webdav.pid" {
+				t.Fatalf("path = %q, want %q", path, "C:/tmp/drive9-webdav.pid")
+			}
+			return nil
+		},
 		pidAlive: func(pid int) bool {
 			t.Fatalf("pidAlive should not be called on Windows; terminate handles the wait path")
 			return false
@@ -266,6 +277,46 @@ func TestRunUmountWindowsTerminatesMountProcess(t *testing.T) {
 	if terminateCalls != 1 {
 		t.Fatalf("terminateCalls = %d, want 1", terminateCalls)
 	}
+	if removeCalls != 1 {
+		t.Fatalf("removeCalls = %d, want 1", removeCalls)
+	}
+}
+
+func TestTerminateProcessWaitsAfterSuccessfulKill(t *testing.T) {
+	oldWaitForProcessExit := waitForProcessExit
+	t.Cleanup(func() { waitForProcessExit = oldWaitForProcessExit })
+
+	called := false
+	waitForProcessExit = func(pid int, timeout time.Duration) error {
+		called = true
+		if pid <= 0 {
+			t.Fatalf("pid = %d, want > 0", pid)
+		}
+		if timeout != 50*time.Millisecond {
+			t.Fatalf("timeout = %s, want %s", timeout, 50*time.Millisecond)
+		}
+		return nil
+	}
+
+	cmd := exec.Command("cmd", "/c", "pause")
+	if runtime.GOOS != "windows" {
+		cmd = exec.Command("sh", "-c", "sleep 30")
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	if err := terminateProcess(cmd.Process.Pid, 50*time.Millisecond); err != nil {
+		t.Fatalf("terminateProcess: %v", err)
+	}
+	if !called {
+		t.Fatal("waitForProcessExit was not called after successful kill")
+	}
+	_, _ = cmd.Process.Wait()
 }
 
 // TestResolveMountCredentials_OwnerFromResolver binds a mount to an owner

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -477,6 +477,63 @@ func TestRunUmountWindowsStalePIDFileDoesNotTerminateProcess(t *testing.T) {
 	}
 }
 
+func TestRunUmountWindowsPermissionErrorKeepsPIDFile(t *testing.T) {
+	runCalls := 0
+	removeCalls := 0
+	inspectErr := errors.New("access is denied")
+	deps := umountDeps{
+		goos:     "windows",
+		lookPath: fakeLookPath(nil),
+		run: func(argv []string) error {
+			runCalls++
+			want := []string{"net", "use", "X:", "/delete", "/y"}
+			if !reflect.DeepEqual(argv, want) {
+				t.Fatalf("argv = %v, want %v", argv, want)
+			}
+			return nil
+		},
+		readProcessState: func(mountPoint string) (mountstate.ProcessState, string, error) {
+			if mountPoint != "X:\\" {
+				t.Fatalf("mountPoint = %q, want %q", mountPoint, "X:\\")
+			}
+			return mountstate.ProcessState{PID: 4321, CreationTime: 99}, "C:/tmp/drive9-webdav.pid", nil
+		},
+		terminateState: func(state mountstate.ProcessState, waitTimeout time.Duration) error {
+			if state.PID != 4321 {
+				t.Fatalf("pid = %d, want 4321", state.PID)
+			}
+			if state.CreationTime != 99 {
+				t.Fatalf("creationTime = %d, want 99", state.CreationTime)
+			}
+			return inspectErr
+		},
+		remove: func(path string) error {
+			removeCalls++
+			if path != "C:/tmp/drive9-webdav.pid" {
+				t.Fatalf("path = %q, want %q", path, "C:/tmp/drive9-webdav.pid")
+			}
+			return nil
+		},
+		now:       time.Now,
+		sleep:     func(time.Duration) {},
+		printErrf: func(string, ...any) {},
+	}
+
+	err := runUmount([]string{"x:\\"}, deps)
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	if !errors.Is(err, inspectErr) {
+		t.Fatalf("err = %v, want wrapped %v", err, inspectErr)
+	}
+	if runCalls != 1 {
+		t.Fatalf("runCalls = %d, want 1", runCalls)
+	}
+	if removeCalls != 0 {
+		t.Fatalf("removeCalls = %d, want 0", removeCalls)
+	}
+}
+
 // TestResolveMountCredentials_OwnerFromResolver binds a mount to an owner
 // API key sourced from the resolver (no --api-key flag). Asserts that
 // apiKey routes through MountOptions.APIKey and token stays empty, which

--- a/cmd/drive9/cli/mount_vault.go
+++ b/cmd/drive9/cli/mount_vault.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 )
 
@@ -53,6 +54,14 @@ func VaultMountCmd(args []string) error {
 	}
 	if err := rejectEmptyFlag("api-key", *apiKey, apiKeyGiven); err != nil {
 		return err
+	}
+	if runtime.GOOS == "windows" {
+		return mountVault(&vaultMountOptions{
+			MountPoint: mountPoint,
+			DirTTL:     *dirTTL,
+			AllowOther: *allowOther,
+			Debug:      *debug,
+		})
 	}
 
 	serverVal, apiKeyVal, tokenVal, err := resolveMountCredentials(ResolveCredentials(), *server, *apiKey)

--- a/cmd/drive9/cli/mount_vault.go
+++ b/cmd/drive9/cli/mount_vault.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"time"
-
-	drive9fuse "github.com/mem9-ai/dat9/pkg/fuse"
 )
 
 // VaultMountCmd handles `drive9 mount vault [flags] <mountpoint>`.
@@ -62,7 +60,7 @@ func VaultMountCmd(args []string) error {
 		return err
 	}
 
-	opts := &drive9fuse.VaultMountOptions{
+	opts := &vaultMountOptions{
 		Server:     serverVal,
 		APIKey:     apiKeyVal,
 		Token:      tokenVal,
@@ -71,5 +69,5 @@ func VaultMountCmd(args []string) error {
 		AllowOther: *allowOther,
 		Debug:      *debug,
 	}
-	return drive9fuse.MountVault(opts)
+	return mountVault(opts)
 }

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -192,7 +192,16 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 			_ = srv.Shutdown(ctx)
 			return err
 		}
-		pidFile, err := mountstate.WritePID(stateMountPoint, os.Getpid())
+		processState := mountstate.ProcessState{PID: os.Getpid()}
+		processState.CreationTime, err = processCreationTimeByPID(processState.PID)
+		if err != nil {
+			deps.unmount(deps.goos, mountPoint)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = srv.Shutdown(ctx)
+			return fmt.Errorf("webdav: inspect mount process state: %w", err)
+		}
+		pidFile, err := mountstate.WriteProcessState(stateMountPoint, processState)
 		if err != nil {
 			deps.unmount(deps.goos, mountPoint)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -183,27 +183,29 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 		return explainMountError(deps.goos, mountPoint, err)
 	}
 
-	stateMountPoint, err := webdavMountStatePoint(deps.goos, mountPoint)
-	if err != nil {
-		deps.unmount(deps.goos, mountPoint)
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = srv.Shutdown(ctx)
-		return err
-	}
-	pidFile, err := mountstate.WritePID(stateMountPoint, os.Getpid())
-	if err != nil {
-		deps.unmount(deps.goos, mountPoint)
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = srv.Shutdown(ctx)
-		return fmt.Errorf("webdav: write mount pid file: %w", err)
-	}
-	defer func() {
-		if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "drive9: remove mount pid file %s: %v\n", pidFile, err)
+	if deps.goos == "windows" {
+		stateMountPoint, err := webdavMountStatePoint(deps.goos, mountPoint)
+		if err != nil {
+			deps.unmount(deps.goos, mountPoint)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = srv.Shutdown(ctx)
+			return err
 		}
-	}()
+		pidFile, err := mountstate.WritePID(stateMountPoint, os.Getpid())
+		if err != nil {
+			deps.unmount(deps.goos, mountPoint)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = srv.Shutdown(ctx)
+			return fmt.Errorf("webdav: write mount pid file: %w", err)
+		}
+		defer func() {
+			if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "drive9: remove mount pid file %s: %v\n", pidFile, err)
+			}
+		}()
+	}
 
 	fmt.Fprintf(os.Stderr, "drive9: mounted on %s via WebDAV (server: %s)\n", mountPoint, serverURL)
 

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/mountstate"
 )
 
 // MountMode selects the filesystem mount backend.
@@ -40,8 +41,8 @@ func ParseMountMode(s string) (MountMode, error) {
 }
 
 // ResolveMountMode picks the concrete mode from "auto".
-// On macOS auto always uses WebDAV for zero-install onboarding; FUSE is only
-// selected there when explicitly requested with --mode=fuse.
+// On macOS and Windows, auto always uses WebDAV for zero-install onboarding.
+// Linux and other platforms still default to FUSE.
 func ResolveMountMode(mode MountMode, goos string, lookPath func(string) (string, error)) MountMode {
 	_ = lookPath
 	if mode != MountModeAuto {
@@ -176,11 +177,33 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 		}
 	}
 
-	// Invoke mount_webdav.
+	// Invoke the OS-specific WebDAV mount helper.
 	if err := deps.runMount(deps.goos, serverURL, mountPoint); err != nil {
 		_ = srv.Close()
 		return explainMountError(deps.goos, mountPoint, err)
 	}
+
+	stateMountPoint, err := webdavMountStatePoint(deps.goos, mountPoint)
+	if err != nil {
+		deps.unmount(deps.goos, mountPoint)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+		return err
+	}
+	pidFile, err := mountstate.WritePID(stateMountPoint, os.Getpid())
+	if err != nil {
+		deps.unmount(deps.goos, mountPoint)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+		return fmt.Errorf("webdav: write mount pid file: %w", err)
+	}
+	defer func() {
+		if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "drive9: remove mount pid file %s: %v\n", pidFile, err)
+		}
+	}()
 
 	fmt.Fprintf(os.Stderr, "drive9: mounted on %s via WebDAV (server: %s)\n", mountPoint, serverURL)
 
@@ -335,6 +358,17 @@ func normalizeWebDAVMountPoint(goos, mountPoint string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("webdav: Windows mount point must be a drive letter like \"X:\"")
+}
+
+func webdavMountStatePoint(goos, mountPoint string) (string, error) {
+	normalizedMountPoint, err := normalizeWebDAVMountPoint(goos, mountPoint)
+	if err != nil {
+		return "", err
+	}
+	if goos == "windows" {
+		return normalizedMountPoint + `\`, nil
+	}
+	return normalizedMountPoint, nil
 }
 
 func newWebDAVNoncePrefix() (string, error) {

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -269,7 +269,7 @@ func mountErrorHint(goos, mountPoint string, err error) string {
 	case 2: // ENOENT
 		return fmt.Sprintf("mount point %q does not exist or is not accessible.", mountPoint)
 	case 16: // EBUSY
-		return fmt.Sprintf("mount point %q is busy — a filesystem may already be mounted there. Run `mount | grep %q` and `drive9 umount %s` to clean up.", mountPoint, mountPoint, mountPoint)
+		return fmt.Sprintf("mount point %q is busy - a filesystem may already be mounted there. Run `mount | grep %q` and `drive9 umount %s` to clean up.", mountPoint, mountPoint, mountPoint)
 	case 19: // ENODEV
 		return fmt.Sprintf("the kernel rejected the WebDAV mount at %q (ENODEV). Common causes: a stale mount still attached at this path (try `mount | grep %q` then `drive9 umount %s`); the local WebDAV bridge was unreachable; or the mount point is on a filesystem that does not support WebDAV mounts (e.g. some network volumes). Try a fresh path under your home directory.", mountPoint, mountPoint, mountPoint)
 	case 77: // ECANCELED
@@ -320,7 +320,7 @@ func normalizeWebDAVMountPoint(goos, mountPoint string) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("webdav: Windows mount point must be a drive letter like X:")
+	return "", fmt.Errorf("webdav: Windows mount point must be a drive letter like \"X:\"")
 }
 
 func newWebDAVNoncePrefix() (string, error) {

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -227,23 +227,26 @@ func runWebDAVMountCmd(goos, serverURL, mountPoint string) error {
 	return mountCmd.Run()
 }
 
-// explainMountError turns the opaque "exit status N" from mount_webdav into
-// an actionable message. The underlying error is preserved via %w so callers
+// explainMountError turns the opaque mount helper exit status into an
+// actionable message. The underlying error is preserved via %w so callers
 // (and tests) can still match on it.
 func explainMountError(goos, mountPoint string, err error) error {
+	helper := webdavMountHelperName(goos)
 	hint := mountErrorHint(goos, mountPoint, err)
 	if hint == "" {
-		return fmt.Errorf("webdav: mount_webdav failed: %w", err)
+		return fmt.Errorf("webdav: %s failed: %w", helper, err)
 	}
-	return fmt.Errorf("webdav: mount_webdav failed: %w\n  %s", err, hint)
+	return fmt.Errorf("webdav: %s failed: %w\n  %s", helper, err, hint)
 }
 
-// mountErrorHint returns a human-readable explanation for known mount_webdav
-// exit codes on macOS. Returns "" when no specific hint applies.
+// mountErrorHint returns a human-readable explanation for known WebDAV mount
+// helper exit codes on macOS and Windows. Returns "" when no specific hint
+// applies.
 //
-// Codes follow mount_webdav(8) DIAGNOSTICS: ENOENT (invalid node path),
-// ENODEV (server not WebDAV-enabled, missing, or inaccessible), ECANCELED
-// (auth canceled). EBUSY surfaces when a mount already covers the point.
+// On macOS, codes follow mount_webdav(8) DIAGNOSTICS: ENOENT (invalid node
+// path), ENODEV (server not WebDAV-enabled, missing, or inaccessible),
+// ECANCELED (auth canceled). EBUSY surfaces when a mount already covers the
+// point.
 func mountErrorHint(goos, mountPoint string, err error) string {
 	var ee *exec.ExitError
 	if !errors.As(err, &ee) {
@@ -276,6 +279,17 @@ func mountErrorHint(goos, mountPoint string, err error) string {
 		return "authentication was canceled by mount_webdav. Re-run the command and ensure credentials are configured (`drive9 ctx`)."
 	}
 	return ""
+}
+
+func webdavMountHelperName(goos string) string {
+	switch goos {
+	case "windows":
+		return "net use"
+	case "linux":
+		return "mount.davfs"
+	default:
+		return "mount_webdav"
+	}
 }
 
 // webdavMountCmd builds the OS command to mount a WebDAV URL at mountPoint.

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -46,7 +47,7 @@ func ResolveMountMode(mode MountMode, goos string, lookPath func(string) (string
 	if mode != MountModeAuto {
 		return mode
 	}
-	if goos == "darwin" {
+	if goos == "darwin" || goos == "windows" {
 		return MountModeWebDAV
 	}
 	// Linux and others: FUSE is the default.
@@ -71,8 +72,9 @@ type WebDAVMountHandler interface {
 	http.Handler
 }
 
-// webdavMount starts a local WebDAV server bound to 127.0.0.1, invokes
-// mount_webdav to attach it to mountPoint, and blocks until SIGINT/SIGTERM.
+// webdavMount starts a local WebDAV server bound to 127.0.0.1, invokes the
+// OS-specific WebDAV mount helper to attach it to mountPoint, and blocks until
+// SIGINT/SIGTERM. On Windows, mountPoint must be a drive letter like X:.
 func webdavMount(c *client.Client, mountPoint string, remoteRoot string) error {
 	return webdavMountWithDeps(c, mountPoint, webdavMountDeps{
 		goos:       runtime.GOOS,
@@ -114,6 +116,12 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 	if deps.newPrefix == nil {
 		deps.newPrefix = newWebDAVNoncePrefix
 	}
+
+	normalizedMountPoint, err := normalizeWebDAVMountPoint(deps.goos, mountPoint)
+	if err != nil {
+		return err
+	}
+	mountPoint = normalizedMountPoint
 
 	// Bind to a random available port on loopback.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -160,10 +168,12 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 	}
 	readyCancel()
 
-	// Ensure mount point exists.
-	if err := os.MkdirAll(mountPoint, 0o755); err != nil {
-		_ = srv.Close()
-		return fmt.Errorf("webdav: create mount point: %w", err)
+	// Ensure mount point exists where the platform expects a directory mount.
+	if deps.goos != "windows" {
+		if err := os.MkdirAll(mountPoint, 0o755); err != nil {
+			_ = srv.Close()
+			return fmt.Errorf("webdav: create mount point: %w", err)
+		}
 	}
 
 	// Invoke mount_webdav.
@@ -235,11 +245,24 @@ func explainMountError(goos, mountPoint string, err error) error {
 // ENODEV (server not WebDAV-enabled, missing, or inaccessible), ECANCELED
 // (auth canceled). EBUSY surfaces when a mount already covers the point.
 func mountErrorHint(goos, mountPoint string, err error) string {
-	if goos != "darwin" {
-		return ""
-	}
 	var ee *exec.ExitError
 	if !errors.As(err, &ee) {
+		return ""
+	}
+	if goos == "windows" {
+		switch ee.ExitCode() {
+		case 5:
+			return fmt.Sprintf("Windows denied access while mounting %q. If this drive letter is already in use, unmap it first. Otherwise ensure the WebClient service is running and the current user can create network drives.", mountPoint)
+		case 67:
+			return "Windows WebDAV redirector could not find the WebDAV endpoint. Ensure the WebClient service is running and the local drive9 WebDAV bridge is reachable."
+		case 1244:
+			return "Windows WebDAV redirector could not authenticate to the WebDAV endpoint. Re-run the command after ensuring the WebClient service is running and no stale credentials are cached."
+		case 224:
+			return "Windows WebDAV redirector blocked the site as untrusted. Add the drive9 WebDAV URL to Trusted Sites or use a host the WebClient service trusts."
+		}
+		return ""
+	}
+	if goos != "darwin" {
 		return ""
 	}
 	switch ee.ExitCode() {
@@ -257,6 +280,12 @@ func mountErrorHint(goos, mountPoint string, err error) string {
 
 // webdavMountCmd builds the OS command to mount a WebDAV URL at mountPoint.
 func webdavMountCmd(goos, serverURL, mountPoint string) (*exec.Cmd, error) {
+	normalizedMountPoint, err := normalizeWebDAVMountPoint(goos, mountPoint)
+	if err != nil {
+		return nil, err
+	}
+	mountPoint = normalizedMountPoint
+
 	switch goos {
 	case "darwin":
 		// -S suppresses auth UI dialogs and auto-unmounts on disconnect.
@@ -267,9 +296,31 @@ func webdavMountCmd(goos, serverURL, mountPoint string) (*exec.Cmd, error) {
 			return exec.Command("mount.davfs", serverURL, mountPoint), nil
 		}
 		return nil, fmt.Errorf("webdav: no WebDAV mount utility found on Linux (install davfs2)")
+	case "windows":
+		return exec.Command("net", "use", mountPoint, strings.TrimRight(serverURL, "/"), "/persistent:no"), nil
 	default:
 		return nil, fmt.Errorf("webdav: unsupported OS %q", goos)
 	}
+}
+
+func normalizeWebDAVMountPoint(goos, mountPoint string) (string, error) {
+	mountPoint = strings.TrimSpace(mountPoint)
+	if mountPoint == "" {
+		return "", fmt.Errorf("webdav: mount point is required")
+	}
+	if goos != "windows" {
+		return mountPoint, nil
+	}
+	if len(mountPoint) >= 2 {
+		drive := mountPoint[0]
+		rest := mountPoint[2:]
+		if ((drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')) && mountPoint[1] == ':' {
+			if rest == "" || rest == "\\" || rest == "/" {
+				return strings.ToUpper(mountPoint[:1]) + ":", nil
+			}
+		}
+	}
+	return "", fmt.Errorf("webdav: Windows mount point must be a drive letter like X:")
 }
 
 func newWebDAVNoncePrefix() (string, error) {
@@ -314,14 +365,29 @@ func waitForWebDAVReady(ctx context.Context, serverURL string) error {
 	}
 }
 
-// webdavUnmount detaches the WebDAV mount.
-func webdavUnmount(goos, mountPoint string) {
-	var cmd *exec.Cmd
+func webdavUnmountCmd(goos, mountPoint string) (*exec.Cmd, error) {
+	normalizedMountPoint, err := normalizeWebDAVMountPoint(goos, mountPoint)
+	if err != nil {
+		return nil, err
+	}
+	mountPoint = normalizedMountPoint
+
 	switch goos {
 	case "darwin":
-		cmd = exec.Command("umount", mountPoint)
+		return exec.Command("umount", mountPoint), nil
+	case "windows":
+		return exec.Command("net", "use", mountPoint, "/delete", "/y"), nil
 	default:
-		cmd = exec.Command("umount", mountPoint)
+		return exec.Command("umount", mountPoint), nil
+	}
+}
+
+// webdavUnmount detaches the WebDAV mount.
+func webdavUnmount(goos, mountPoint string) {
+	cmd, err := webdavUnmountCmd(goos, mountPoint)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "drive9: webdav unmount failed: %v\n", err)
+		return
 	}
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -320,7 +320,7 @@ func normalizeWebDAVMountPoint(goos, mountPoint string) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("webdav: Windows mount point must be a drive letter like X:")
+	return "", fmt.Errorf("webdav: Windows mount point must be a drive letter like \"X:\"")
 }
 
 func newWebDAVNoncePrefix() (string, error) {

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -68,6 +69,14 @@ func TestResolveMountMode_Linux(t *testing.T) {
 	}
 }
 
+func TestResolveMountMode_Windows(t *testing.T) {
+	lp := fakeLookPath(nil)
+	got := ResolveMountMode(MountModeAuto, "windows", lp)
+	if got != MountModeWebDAV {
+		t.Fatalf("windows auto: got %q, want webdav", got)
+	}
+}
+
 func TestResolveMountMode_ExplicitOverridesAuto(t *testing.T) {
 	lp := fakeLookPath(nil)
 	got := ResolveMountMode(MountModeFUSE, "darwin", lp)
@@ -109,6 +118,27 @@ func TestWebdavMountCmd_UnsupportedOS(t *testing.T) {
 	_, err := webdavMountCmd("freebsd", "http://127.0.0.1:8080", "/mnt/drive9")
 	if err == nil {
 		t.Fatal("expected error for unsupported OS")
+	}
+}
+
+func TestWebdavMountCmd_Windows(t *testing.T) {
+	cmd, err := webdavMountCmd("windows", "http://127.0.0.1:8080/_drive9_test/", "x:\\")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args := cmd.Args
+	if len(args) != 5 || args[0] != "net" || args[1] != "use" || args[2] != "X:" || args[3] != "http://127.0.0.1:8080/_drive9_test" || args[4] != "/persistent:no" {
+		t.Fatalf("windows mount cmd args = %v", args)
+	}
+}
+
+func TestWebdavMountCmd_WindowsRejectsNonDriveLetter(t *testing.T) {
+	_, err := webdavMountCmd("windows", "http://127.0.0.1:8080", "C:\\temp\\drive9")
+	if err == nil {
+		t.Fatal("expected invalid Windows mountpoint to fail")
+	}
+	if !strings.Contains(err.Error(), "drive letter like X:") {
+		t.Fatalf("error = %v, want drive-letter guidance", err)
 	}
 }
 
@@ -279,6 +309,66 @@ func TestWebDAVMountLifecycle(t *testing.T) {
 	}
 }
 
+func TestWebDAVMountLifecycleWindowsNormalizesDriveLetter(t *testing.T) {
+	c := newWebDAVLifecycleClient(t)
+	signals := make(chan os.Signal, 2)
+	mounted := make(chan string, 1)
+	done := make(chan error, 1)
+	var unmounted atomic.Bool
+
+	go func() {
+		done <- webdavMountWithDeps(c, "x:\\", webdavMountDeps{
+			goos:    "windows",
+			signals: signals,
+			runMount: func(goos, serverURL, gotMountPoint string) error {
+				if goos != "windows" {
+					t.Errorf("goos = %q, want windows", goos)
+				}
+				if gotMountPoint != "X:" {
+					t.Errorf("mountPoint = %q, want X:", gotMountPoint)
+				}
+				mounted <- serverURL
+				return nil
+			},
+			unmount: func(goos, gotMountPoint string) {
+				if goos != "windows" {
+					t.Errorf("unmount goos = %q, want windows", goos)
+				}
+				if gotMountPoint != "X:" {
+					t.Errorf("unmount mountPoint = %q, want X:", gotMountPoint)
+				}
+				unmounted.Store(true)
+			},
+			exit: func(code int) {
+				t.Errorf("unexpected forced exit code %d", code)
+			},
+			newPrefix: func() (string, error) {
+				return "/_drive9_test", nil
+			},
+		})
+	}()
+
+	select {
+	case <-mounted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("mount command was not invoked")
+	}
+
+	signals <- os.Interrupt
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("webdavMountWithDeps returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("webdavMountWithDeps did not shut down after signal")
+	}
+	if !unmounted.Load() {
+		t.Fatal("unmount callback was not called")
+	}
+}
+
 func TestWebDAVMountReturnsMountFailure(t *testing.T) {
 	c := newWebDAVLifecycleClient(t)
 	mountErr := errors.New("mount failed")
@@ -362,6 +452,13 @@ func TestMountErrorHint(t *testing.T) {
 			err:      exitErrorWithCode(t, 19),
 			wantHint: false,
 		},
+		{
+			name:     "windows system error 67",
+			goos:     "windows",
+			err:      exitErrorWithCode(t, 67),
+			wantSubs: []string{"WebDAV redirector", "WebClient service"},
+			wantHint: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -407,6 +504,22 @@ func TestExplainMountError(t *testing.T) {
 	if strings.Contains(wrapped2.Error(), "ENODEV") {
 		t.Errorf("plain error should not get an ENODEV hint; got %q", wrapped2.Error())
 	}
+
+	wrapped3 := explainMountError("windows", "X:", exitErrorWithCode(t, 67))
+	if !strings.Contains(wrapped3.Error(), "WebClient service") {
+		t.Errorf("windows hint missing; got %q", wrapped3.Error())
+	}
+}
+
+func TestWebdavUnmountCmdWindows(t *testing.T) {
+	cmd, err := webdavUnmountCmd("windows", "x:\\")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args := cmd.Args
+	if len(args) != 5 || args[0] != "net" || args[1] != "use" || args[2] != "X:" || args[3] != "/delete" || args[4] != "/y" {
+		t.Fatalf("windows unmount cmd args = %v", args)
+	}
 }
 
 // exitErrorWithCode runs a tiny shell command that exits with the given code
@@ -414,7 +527,12 @@ func TestExplainMountError(t *testing.T) {
 // to construct one — its internal fields are unexported.
 func exitErrorWithCode(t *testing.T, code int) error {
 	t.Helper()
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code))
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", fmt.Sprintf("exit %d", code))
+	} else {
+		cmd = exec.Command("sh", "-c", fmt.Sprintf("exit %d", code))
+	}
 	err := cmd.Run()
 	if err == nil {
 		t.Fatalf("expected non-zero exit, got nil")

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/mountstate"
 )
 
 func TestParseMountMode(t *testing.T) {
@@ -315,6 +316,10 @@ func TestWebDAVMountLifecycleWindowsNormalizesDriveLetter(t *testing.T) {
 	mounted := make(chan string, 1)
 	done := make(chan error, 1)
 	var unmounted atomic.Bool
+	stateMountPoint, err := webdavMountStatePoint("windows", "x:\\")
+	if err != nil {
+		t.Fatalf("webdavMountStatePoint: %v", err)
+	}
 
 	go func() {
 		done <- webdavMountWithDeps(c, "x:\\", webdavMountDeps{
@@ -354,6 +359,28 @@ func TestWebDAVMountLifecycleWindowsNormalizesDriveLetter(t *testing.T) {
 		t.Fatal("mount command was not invoked")
 	}
 
+	var (
+		pid     int
+		pidFile string
+	)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		pid, pidFile, err = mountstate.ReadPID(stateMountPoint)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("ReadPID(%q): %v", stateMountPoint, err)
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("ReadPID(%q): timed out waiting for pid file", stateMountPoint)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if pid != os.Getpid() {
+		t.Fatalf("pid = %d, want %d", pid, os.Getpid())
+	}
+
 	signals <- os.Interrupt
 
 	select {
@@ -366,6 +393,13 @@ func TestWebDAVMountLifecycleWindowsNormalizesDriveLetter(t *testing.T) {
 	}
 	if !unmounted.Load() {
 		t.Fatal("unmount callback was not called")
+	}
+	_, _, err = mountstate.ReadPID(stateMountPoint)
+	if !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			t.Fatalf("expected pid file %q to be removed", pidFile)
+		}
+		t.Fatalf("pid file %q not removed cleanly: %v", pidFile, err)
 	}
 }
 

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -137,7 +137,7 @@ func TestWebdavMountCmd_WindowsRejectsNonDriveLetter(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid Windows mountpoint to fail")
 	}
-	if !strings.Contains(err.Error(), "drive letter like X:") {
+	if !strings.Contains(err.Error(), "drive letter like \"X:\"") {
 		t.Fatalf("error = %v, want drive-letter guidance", err)
 	}
 }

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -367,12 +367,12 @@ func TestWebDAVMountLifecycleWindowsNormalizesDriveLetter(t *testing.T) {
 	}
 
 	var (
-		pid     int
+		state   mountstate.ProcessState
 		pidFile string
 	)
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		pid, pidFile, err = mountstate.ReadPID(stateMountPoint)
+		state, pidFile, err = mountstate.ReadProcessState(stateMountPoint)
 		if err == nil {
 			break
 		}
@@ -384,8 +384,8 @@ func TestWebDAVMountLifecycleWindowsNormalizesDriveLetter(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if pid != os.Getpid() {
-		t.Fatalf("pid = %d, want %d", pid, os.Getpid())
+	if state.PID != os.Getpid() {
+		t.Fatalf("pid = %d, want %d", state.PID, os.Getpid())
 	}
 
 	signals <- os.Interrupt

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -137,7 +137,7 @@ func TestWebdavMountCmd_WindowsRejectsNonDriveLetter(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid Windows mountpoint to fail")
 	}
-	if !strings.Contains(err.Error(), "drive letter like X:") {
+	if !strings.Contains(err.Error(), "drive letter like \"X:\"") {
 		t.Fatalf("error = %v, want drive-letter guidance", err)
 	}
 }
@@ -524,7 +524,7 @@ func TestWebdavUnmountCmdWindows(t *testing.T) {
 
 // exitErrorWithCode runs a tiny shell command that exits with the given code
 // and returns the resulting *exec.ExitError. This is the only portable way
-// to construct one — its internal fields are unexported.
+// to construct one - its internal fields are unexported.
 func exitErrorWithCode(t *testing.T, code int) error {
 	t.Helper()
 	var cmd *exec.Cmd
@@ -571,7 +571,7 @@ func TestFsMountCmd_RemoteSourceParsing(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected credential error, not nil")
 	}
-	// Should NOT contain "must be a remote source" — that means parsing worked.
+	// Should NOT contain "must be a remote source" - that means parsing worked.
 	if strings.Contains(err.Error(), "must be a remote source") {
 		t.Fatalf("error = %v, should have parsed remote source successfully", err)
 	}

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -294,6 +294,13 @@ func TestWebDAVMountLifecycle(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("mount command was not invoked")
 	}
+	_, _, err := mountstate.ReadPID(mountPoint)
+	if !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			t.Fatalf("expected no pid file for non-Windows WebDAV mount at %q", mountPoint)
+		}
+		t.Fatalf("ReadPID(%q): %v", mountPoint, err)
+	}
 
 	signals <- os.Interrupt
 

--- a/cmd/drive9/cli/process_wait_unix.go
+++ b/cmd/drive9/cli/process_wait_unix.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+func processAliveImpl(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+		return false
+	}
+	if errors.Is(err, syscall.EPERM) {
+		return true
+	}
+	return false
+}
+
+func waitForProcessExitByPID(pid int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if !processAliveImpl(pid) {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("drive9 umount: mount process pid %d still running after %s", pid, timeout)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/cmd/drive9/cli/process_wait_unix.go
+++ b/cmd/drive9/cli/process_wait_unix.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/mem9-ai/dat9/pkg/mountstate"
 )
 
 func processAliveImpl(pid int) bool {
@@ -42,4 +44,13 @@ func waitForProcessExitByPID(pid int, timeout time.Duration) error {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+}
+
+func processCreationTimeByPID(pid int) (uint64, error) {
+	_ = pid
+	return 0, nil
+}
+
+func terminateMountProcess(state mountstate.ProcessState, waitTimeout time.Duration) error {
+	return terminateProcess(state.PID, waitTimeout)
 }

--- a/cmd/drive9/cli/process_wait_windows.go
+++ b/cmd/drive9/cli/process_wait_windows.go
@@ -3,59 +3,154 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"math"
-	"syscall"
 	"time"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/mem9-ai/dat9/pkg/mountstate"
 )
+
+const processQueryLimitedInformation = 0x1000
 
 func processAliveImpl(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
-	handle, err := syscall.OpenProcess(syscall.SYNCHRONIZE, false, uint32(pid))
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|processQueryLimitedInformation, false, uint32(pid))
 	if err != nil {
 		return false
 	}
-	defer syscall.CloseHandle(handle)
-	status, err := syscall.WaitForSingleObject(handle, 0)
+	defer windows.CloseHandle(handle)
+	status, err := windows.WaitForSingleObject(handle, 0)
 	if err != nil {
 		return false
 	}
-	return status == syscall.WAIT_TIMEOUT
+	return status == uint32(windows.WAIT_TIMEOUT)
 }
 
 func waitForProcessExitByPID(pid int, timeout time.Duration) error {
 	if pid <= 0 {
 		return fmt.Errorf("invalid mount process pid %d", pid)
 	}
-	handle, err := syscall.OpenProcess(syscall.SYNCHRONIZE, false, uint32(pid))
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|processQueryLimitedInformation, false, uint32(pid))
 	if err != nil {
 		return nil
 	}
-	defer syscall.CloseHandle(handle)
+	defer windows.CloseHandle(handle)
 
-	waitMillis := uint32(syscall.INFINITE)
+	waitMillis := uint32(windows.INFINITE)
 	if timeout > 0 {
 		millis := timeout / time.Millisecond
 		if millis <= 0 {
 			millis = 1
 		}
 		if millis > time.Duration(math.MaxUint32) {
-			waitMillis = syscall.INFINITE
+			waitMillis = windows.INFINITE
 		} else {
 			waitMillis = uint32(millis)
 		}
 	}
 
-	status, err := syscall.WaitForSingleObject(handle, waitMillis)
+	status, err := windows.WaitForSingleObject(handle, waitMillis)
 	if err != nil {
 		return fmt.Errorf("drive9 umount: wait for mount process pid %d exit: %w", pid, err)
 	}
 	switch status {
-	case syscall.WAIT_OBJECT_0:
+	case windows.WAIT_OBJECT_0:
 		return nil
-	case syscall.WAIT_TIMEOUT:
+	case uint32(windows.WAIT_TIMEOUT):
+		return fmt.Errorf("drive9 umount: mount process pid %d still running after %s", pid, timeout)
+	default:
+		return fmt.Errorf("drive9 umount: wait for mount process pid %d exit returned status %d", pid, status)
+	}
+}
+
+func processCreationTimeByPID(pid int) (uint64, error) {
+	if pid <= 0 {
+		return 0, fmt.Errorf("invalid mount process pid %d", pid)
+	}
+	handle, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return 0, err
+	}
+	defer windows.CloseHandle(handle)
+
+	var creationTime, exitTime, kernelTime, userTime windows.Filetime
+	if err := windows.GetProcessTimes(handle, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
+		return 0, err
+	}
+	return uint64(creationTime.HighDateTime)<<32 | uint64(creationTime.LowDateTime), nil
+}
+
+func terminateMountProcess(state mountstate.ProcessState, waitTimeout time.Duration) error {
+	if state.PID <= 0 {
+		return fmt.Errorf("invalid mount process pid %d", state.PID)
+	}
+	if state.CreationTime == 0 {
+		return fmt.Errorf("%w: mount pid file for pid %d is missing ownership metadata", errMountProcessStateUnsafe, state.PID)
+	}
+
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_TERMINATE|processQueryLimitedInformation, false, uint32(state.PID))
+	if err != nil {
+		return fmt.Errorf("%w: mount process pid %d is no longer running", errMountProcessStateStale, state.PID)
+	}
+	defer windows.CloseHandle(handle)
+
+	var creationTime, exitTime, kernelTime, userTime windows.Filetime
+	if err := windows.GetProcessTimes(handle, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
+		return fmt.Errorf("drive9 umount: inspect mount process pid %d: %w", state.PID, err)
+	}
+	actualCreationTime := uint64(creationTime.HighDateTime)<<32 | uint64(creationTime.LowDateTime)
+	if actualCreationTime != state.CreationTime {
+		return fmt.Errorf("%w: mount process pid %d no longer matches recorded ownership", errMountProcessStateStale, state.PID)
+	}
+
+	status, err := windows.WaitForSingleObject(handle, 0)
+	if err == nil && status == uint32(windows.WAIT_OBJECT_0) {
+		return nil
+	}
+
+	err = windows.TerminateProcess(handle, 1)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+			status, waitErr := windows.WaitForSingleObject(handle, 0)
+			if waitErr == nil && status == uint32(windows.WAIT_OBJECT_0) {
+				return nil
+			}
+		}
+		return fmt.Errorf("drive9 umount: terminate mount process pid %d: %w", state.PID, err)
+	}
+	if waitTimeout > 0 {
+		return waitForProcessExitHandle(handle, state.PID, waitTimeout)
+	}
+	return nil
+}
+
+func waitForProcessExitHandle(handle windows.Handle, pid int, timeout time.Duration) error {
+	waitMillis := uint32(windows.INFINITE)
+	if timeout > 0 {
+		millis := timeout / time.Millisecond
+		if millis <= 0 {
+			millis = 1
+		}
+		if millis > time.Duration(math.MaxUint32) {
+			waitMillis = windows.INFINITE
+		} else {
+			waitMillis = uint32(millis)
+		}
+	}
+
+	status, err := windows.WaitForSingleObject(handle, waitMillis)
+	if err != nil {
+		return fmt.Errorf("drive9 umount: wait for mount process pid %d exit: %w", pid, err)
+	}
+	switch status {
+	case windows.WAIT_OBJECT_0:
+		return nil
+	case uint32(windows.WAIT_TIMEOUT):
 		return fmt.Errorf("drive9 umount: mount process pid %d still running after %s", pid, timeout)
 	default:
 		return fmt.Errorf("drive9 umount: wait for mount process pid %d exit returned status %d", pid, status)

--- a/cmd/drive9/cli/process_wait_windows.go
+++ b/cmd/drive9/cli/process_wait_windows.go
@@ -13,17 +13,15 @@ import (
 	"github.com/mem9-ai/dat9/pkg/mountstate"
 )
 
-const processQueryLimitedInformation = 0x1000
-
 func processAliveImpl(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
-	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|processQueryLimitedInformation, false, uint32(pid))
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
-		return false
+		return !errors.Is(err, windows.ERROR_INVALID_PARAMETER)
 	}
-	defer windows.CloseHandle(handle)
+	defer func() { _ = windows.CloseHandle(handle) }()
 	status, err := windows.WaitForSingleObject(handle, 0)
 	if err != nil {
 		return false
@@ -35,11 +33,14 @@ func waitForProcessExitByPID(pid int, timeout time.Duration) error {
 	if pid <= 0 {
 		return fmt.Errorf("invalid mount process pid %d", pid)
 	}
-	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|processQueryLimitedInformation, false, uint32(pid))
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
-		return nil
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return nil
+		}
+		return fmt.Errorf("drive9 umount: inspect mount process pid %d: %w", pid, err)
 	}
-	defer windows.CloseHandle(handle)
+	defer func() { _ = windows.CloseHandle(handle) }()
 
 	waitMillis := uint32(windows.INFINITE)
 	if timeout > 0 {
@@ -72,11 +73,11 @@ func processCreationTimeByPID(pid int) (uint64, error) {
 	if pid <= 0 {
 		return 0, fmt.Errorf("invalid mount process pid %d", pid)
 	}
-	handle, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
 		return 0, err
 	}
-	defer windows.CloseHandle(handle)
+	defer func() { _ = windows.CloseHandle(handle) }()
 
 	var creationTime, exitTime, kernelTime, userTime windows.Filetime
 	if err := windows.GetProcessTimes(handle, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
@@ -93,11 +94,11 @@ func terminateMountProcess(state mountstate.ProcessState, waitTimeout time.Durat
 		return fmt.Errorf("%w: mount pid file for pid %d is missing ownership metadata", errMountProcessStateUnsafe, state.PID)
 	}
 
-	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_TERMINATE|processQueryLimitedInformation, false, uint32(state.PID))
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_TERMINATE|windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(state.PID))
 	if err != nil {
 		return fmt.Errorf("%w: mount process pid %d is no longer running", errMountProcessStateStale, state.PID)
 	}
-	defer windows.CloseHandle(handle)
+	defer func() { _ = windows.CloseHandle(handle) }()
 
 	var creationTime, exitTime, kernelTime, userTime windows.Filetime
 	if err := windows.GetProcessTimes(handle, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {

--- a/cmd/drive9/cli/process_wait_windows.go
+++ b/cmd/drive9/cli/process_wait_windows.go
@@ -96,7 +96,10 @@ func terminateMountProcess(state mountstate.ProcessState, waitTimeout time.Durat
 
 	handle, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_TERMINATE|windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(state.PID))
 	if err != nil {
-		return fmt.Errorf("%w: mount process pid %d is no longer running", errMountProcessStateStale, state.PID)
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return fmt.Errorf("%w: mount process pid %d is no longer running", errMountProcessStateStale, state.PID)
+		}
+		return fmt.Errorf("drive9 umount: inspect mount process pid %d: %w", state.PID, err)
 	}
 	defer func() { _ = windows.CloseHandle(handle) }()
 

--- a/cmd/drive9/cli/process_wait_windows.go
+++ b/cmd/drive9/cli/process_wait_windows.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+package cli
+
+import (
+	"fmt"
+	"math"
+	"syscall"
+	"time"
+)
+
+func processAliveImpl(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	handle, err := syscall.OpenProcess(syscall.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(handle)
+	status, err := syscall.WaitForSingleObject(handle, 0)
+	if err != nil {
+		return false
+	}
+	return status == syscall.WAIT_TIMEOUT
+}
+
+func waitForProcessExitByPID(pid int, timeout time.Duration) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid mount process pid %d", pid)
+	}
+	handle, err := syscall.OpenProcess(syscall.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return nil
+	}
+	defer syscall.CloseHandle(handle)
+
+	waitMillis := uint32(syscall.INFINITE)
+	if timeout > 0 {
+		millis := timeout / time.Millisecond
+		if millis <= 0 {
+			millis = 1
+		}
+		if millis > time.Duration(math.MaxUint32) {
+			waitMillis = syscall.INFINITE
+		} else {
+			waitMillis = uint32(millis)
+		}
+	}
+
+	status, err := syscall.WaitForSingleObject(handle, waitMillis)
+	if err != nil {
+		return fmt.Errorf("drive9 umount: wait for mount process pid %d exit: %w", pid, err)
+	}
+	switch status {
+	case syscall.WAIT_OBJECT_0:
+		return nil
+	case syscall.WAIT_TIMEOUT:
+		return fmt.Errorf("drive9 umount: mount process pid %d still running after %s", pid, timeout)
+	default:
+		return fmt.Errorf("drive9 umount: wait for mount process pid %d exit returned status %d", pid, status)
+	}
+}

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -158,6 +158,11 @@ use the same value as `DRIVE9_API_KEY` here.
 
 ### `fuse-smoke-test.sh`
 
+Host support: Linux and macOS only. Windows is currently limited to non-mount
+CLI workflows for FUSE validation; Windows mounts use the built-in WebDAV
+redirector with drive letters instead of the FUSE path, so the FUSE smoke
+script is not a supported Windows validation path.
+
 1. Provision + readiness polling
 2. Prepare `drive9` CLI binary (build local or download official release)
 3. Mount compatibility precheck for root `ls /`

--- a/pkg/mountstate/pid.go
+++ b/pkg/mountstate/pid.go
@@ -3,12 +3,18 @@ package mountstate
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 )
+
+type ProcessState struct {
+	PID          int    `json:"pid"`
+	CreationTime uint64 `json:"creation_time,omitempty"`
+}
 
 func PIDFilePath(mountPoint string) string {
 	canonical := canonicalMountPoint(mountPoint)
@@ -38,18 +44,55 @@ func WritePID(mountPoint string, pid int) (string, error) {
 	return path, nil
 }
 
-func ReadPID(mountPoint string) (int, string, error) {
+func WriteProcessState(mountPoint string, state ProcessState) (string, error) {
+	if state.PID <= 0 {
+		return "", fmt.Errorf("invalid pid %d", state.PID)
+	}
 	path := PIDFilePath(mountPoint)
-	data, err := os.ReadFile(path)
+	data, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("marshal process state: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func ReadPID(mountPoint string) (int, string, error) {
+	state, path, err := ReadProcessState(mountPoint)
 	if err != nil {
 		return 0, path, err
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	return state.PID, path, nil
+}
+
+func ReadProcessState(mountPoint string) (ProcessState, string, error) {
+	path := PIDFilePath(mountPoint)
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return 0, path, fmt.Errorf("read pid file %s: %w", path, err)
+		return ProcessState{}, path, err
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return ProcessState{}, path, fmt.Errorf("read pid file %s: empty file", path)
+	}
+	if strings.HasPrefix(trimmed, "{") {
+		var state ProcessState
+		if err := json.Unmarshal([]byte(trimmed), &state); err != nil {
+			return ProcessState{}, path, fmt.Errorf("read pid file %s: %w", path, err)
+		}
+		if state.PID <= 0 {
+			return ProcessState{}, path, fmt.Errorf("read pid file %s: invalid pid %d", path, state.PID)
+		}
+		return state, path, nil
+	}
+	pid, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return ProcessState{}, path, fmt.Errorf("read pid file %s: %w", path, err)
 	}
 	if pid <= 0 {
-		return 0, path, fmt.Errorf("read pid file %s: invalid pid %d", path, pid)
+		return ProcessState{}, path, fmt.Errorf("read pid file %s: invalid pid %d", path, pid)
 	}
-	return pid, path, nil
+	return ProcessState{PID: pid}, path, nil
 }

--- a/pkg/mountstate/pid_test.go
+++ b/pkg/mountstate/pid_test.go
@@ -1,6 +1,7 @@
 package mountstate
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -72,5 +73,68 @@ func TestReadPIDRejectsInvalidFile(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), strconv.Itoa(os.Getpid())) {
 		t.Fatalf("ReadPID error = %v, unexpectedly used current pid", err)
+	}
+}
+
+func TestWriteReadProcessState(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "mnt")
+	want := ProcessState{PID: 12345, CreationTime: 67890}
+
+	path, err := WriteProcessState(mountPoint, want)
+	if err != nil {
+		t.Fatalf("WriteProcessState: %v", err)
+	}
+	defer func() { _ = os.Remove(path) }()
+
+	got, gotPath, err := ReadProcessState(mountPoint)
+	if err != nil {
+		t.Fatalf("ReadProcessState: %v", err)
+	}
+	if got != want {
+		t.Fatalf("ReadProcessState = %#v, want %#v", got, want)
+	}
+	if gotPath != path {
+		t.Fatalf("ReadProcessState path = %q, want %q", gotPath, path)
+	}
+}
+
+func TestReadProcessStateSupportsLegacyPIDFile(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "mnt")
+	path := PIDFilePath(mountPoint)
+	if err := os.WriteFile(path, []byte("12345\n"), 0o644); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+	defer func() { _ = os.Remove(path) }()
+
+	got, gotPath, err := ReadProcessState(mountPoint)
+	if err != nil {
+		t.Fatalf("ReadProcessState: %v", err)
+	}
+	if got.PID != 12345 {
+		t.Fatalf("ReadProcessState pid = %d, want 12345", got.PID)
+	}
+	if got.CreationTime != 0 {
+		t.Fatalf("ReadProcessState creation time = %d, want 0", got.CreationTime)
+	}
+	if gotPath != path {
+		t.Fatalf("ReadProcessState path = %q, want %q", gotPath, path)
+	}
+}
+
+func TestReadProcessStateRejectsInvalidJSON(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "mnt")
+	path := PIDFilePath(mountPoint)
+	data, err := json.Marshal(map[string]string{"pid": "oops"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+	defer func() { _ = os.Remove(path) }()
+
+	_, _, err = ReadProcessState(mountPoint)
+	if err == nil {
+		t.Fatal("expected error for invalid process state file")
 	}
 }


### PR DESCRIPTION
## Summary
- add Windows CLI support for the default WebDAV mount flow, including drive-letter normalization and `net use` mount/unmount handling
- keep FUSE and vault mount unsupported on Windows, but guide users to the supported Windows paths: default WebDAV mount for filesystems and `drive9 vault` or the vault API for vault access
- split doctor platform helpers, update docs, and add Windows-focused tests for mount behavior, unsupported-mode messaging, and release packaging
- include Windows CLI binaries in release builds and publish `.exe` artifacts for `windows/amd64` and `windows/arm64`

## Validation
- `go test ./cmd/drive9/cli -run "TestRunDoctorFuseWindowsReportsUnsupported|TestMountFuseImplWindowsReportsWebDAVAlternative|TestMountVaultImplWindowsReportsCLIAlternative|TestResolveMountMode_Windows|TestWebdavMountCmd_Windows|TestWebdavUnmountCmdWindows|TestUmountArgvWindows" -count=1`
- `go build -o dist-pr-check/drive9-windows-amd64.exe ./cmd/drive9`
- `go build -o dist-pr-check/drive9-windows-arm64.exe ./cmd/drive9`
- real Windows validation against `https://api.drive9.ai` for `drive9 mount :/ X:` lifecycle, CLI-to-mount visibility, mount-to-CLI visibility, and unmount cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds Windows WebDAV mount with drive-letter mapping and Windows-friendly mount/unmount flows; releases now include Windows CLI binaries.

* **Improvements**
  * Better Windows error hints and guidance for mount/unmount failures; improved unmount behavior and PID/process cleanup across platforms.
  * Mount state now records richer process metadata for more robust lifecycle handling while remaining backward compatible.

* **Documentation**
  * README and docs updated with Windows mount guidance and FUSE platform notes.

* **Tests**
  * Added Windows-focused tests for mounting, unmounting and diagnostics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/415)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->