### PR TITLE
feat: add ctx show and unify bare ctx output

### DIFF
--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -13,16 +13,16 @@ import (
 
 // Ctx dispatches drive9 ctx subcommands per spec §13.2.
 //
-// The 5 normative verbs are: add / import / ls / use / rm.
+// The user-facing verbs are: show / add / import / ls / use / rm.
 //
-// Bare `drive9 ctx` (no verb) is retained as a non-spec compatibility
-// convenience that prints the current context name. See migration call-out
-// #7 in the impl PR body.
+// Bare `drive9 ctx` is the shorthand form of `drive9 ctx show`.
 func Ctx(args []string) error {
 	if len(args) == 0 {
-		return ctxShow()
+		return ctxShowCmd(nil)
 	}
 	switch args[0] {
+	case "show":
+		return ctxShowCmd(args[1:])
 	case "add":
 		return ctxAddCmd(args[1:])
 	case "import":
@@ -41,7 +41,8 @@ func Ctx(args []string) error {
 }
 
 func ctxUsage() string {
-	return `usage: drive9 ctx <add|import|ls|use|rm>
+	return `usage: drive9 ctx <show|add|import|ls|use|rm>
+  show [--json] [--reveal]                            show current context
   add --api-key <key> [--name <n>] [--server <url>]   add owner context
   import --from-file <path>                           add delegated context from file (must be mode 0600)
   import --from-file -                                add delegated context from stdin explicitly
@@ -55,14 +56,179 @@ func ctxUsageErr() error {
 	return fmt.Errorf("%s", ctxUsage())
 }
 
-func ctxShow() error {
-	cfg := loadConfig()
-	if cfg.CurrentContext == "" {
+type ctxShowEntry struct {
+	Name      string    `json:"name"`
+	Type      string    `json:"type"`
+	Server    string    `json:"server,omitempty"`
+	APIKey    string    `json:"api_key,omitempty"`
+	Token     string    `json:"token,omitempty"`
+	Agent     string    `json:"agent,omitempty"`
+	Scope     []string  `json:"scope,omitempty"`
+	Perm      string    `json:"perm,omitempty"`
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	Status    string    `json:"status,omitempty"`
+	GrantID   string    `json:"grant_id,omitempty"`
+	LabelHint string    `json:"label_hint,omitempty"`
+	Source    string    `json:"source,omitempty"`
+}
+
+func ctxShowCmd(args []string) error {
+	asJSON := false
+	reveal := false
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+			asJSON = true
+		case "--reveal":
+			reveal = true
+		default:
+			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx show [--json] [--reveal]", arg)
+		}
+	}
+
+	entry := buildCtxShowEntry(loadConfig(), reveal)
+	if asJSON {
+		return writeCtxShowJSON(entry)
+	}
+	return writeCtxShowText(entry)
+}
+
+func buildCtxShowEntry(cfg *Config, reveal bool) *ctxShowEntry {
+	current := cfg.currentContextEntry()
+	if current == nil || cfg.CurrentContext == "" {
+		return nil
+	}
+
+	entry := &ctxShowEntry{
+		Name:   cfg.CurrentContext,
+		Type:   string(current.Type),
+		Server: cfg.ResolveServer(),
+		Source: configPath(),
+	}
+
+	switch current.Type {
+	case PrincipalOwner:
+		entry.APIKey = formatSecretForDisplay(current.APIKey, reveal)
+	case PrincipalDelegated:
+		entry.Token = formatSecretForDisplay(current.Token, reveal)
+		entry.Agent = current.Agent
+		entry.Scope = append([]string(nil), current.Scope...)
+		entry.Perm = string(current.Perm)
+		entry.ExpiresAt = current.ExpiresAt
+		entry.Status = ctxStatus(current, time.Now())
+		entry.GrantID = current.GrantID
+		entry.LabelHint = current.LabelHint
+	}
+
+	return entry
+}
+
+func writeCtxShowJSON(entry *ctxShowEntry) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	// Keep the zero-current-context JSON contract explicit for scripts.
+	// A missing active context serializes as JSON null rather than an error.
+	return enc.Encode(entry)
+}
+
+func writeCtxShowText(entry *ctxShowEntry) error {
+	if entry == nil {
 		fmt.Println("no current context")
 		return nil
 	}
-	fmt.Println(cfg.CurrentContext)
-	return nil
+
+	fields := []struct {
+		label string
+		value string
+	}{
+		{label: "name", value: entry.Name},
+		{label: "type", value: entry.Type},
+		{label: "server", value: entry.Server},
+	}
+	if entry.APIKey != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "api_key", value: entry.APIKey})
+	}
+	if entry.Token != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "token", value: entry.Token})
+	}
+	if entry.Agent != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "agent", value: entry.Agent})
+	}
+	if len(entry.Scope) > 0 {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "scope", value: strings.Join(entry.Scope, ", ")})
+	}
+	if entry.Perm != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "perm", value: entry.Perm})
+	}
+	if !entry.ExpiresAt.IsZero() {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "expires_at", value: formatExpiresAt(entry.ExpiresAt)})
+	}
+	if entry.Status != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "status", value: entry.Status})
+	}
+	if entry.GrantID != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "grant_id", value: entry.GrantID})
+	}
+	if entry.LabelHint != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "label_hint", value: entry.LabelHint})
+	}
+	if entry.Source != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "source", value: entry.Source})
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	for _, field := range fields {
+		_, _ = fmt.Fprintf(w, "%s:\t%s\n", field.label, field.value)
+	}
+	return w.Flush()
+}
+
+func formatSecretForDisplay(secret string, reveal bool) string {
+	if reveal || secret == "" {
+		return secret
+	}
+
+	if strings.HasPrefix(secret, "drive9_") && len(secret) > len("drive9_")+8 {
+		return secret[:len("drive9_")+4] + "..." + secret[len(secret)-4:]
+	}
+
+	if len(secret) <= 8 {
+		return strings.Repeat("x", len(secret))
+	}
+	if len(secret) <= 12 {
+		return secret[:2] + "..." + secret[len(secret)-2:]
+	}
+	return secret[:8] + "..." + secret[len(secret)-4:]
 }
 
 // ctxAddCmd is the user-facing `drive9 ctx add` verb. Internally it delegates
@@ -157,9 +323,10 @@ func ctxAdd(cfg *Config, name string, ctx *Context) (*Context, error) {
 
 // ctxImportCmd implements `drive9 ctx import` per spec §13.2/§13.3. Input
 // modes:
-//   --from-file <path>   read JWT from file (file MUST be mode 0600)
-//   --from-file -        read JWT from stdin explicitly
-//   (no args, stdin piped) read JWT from stdin (auto-detected when !isatty)
+//
+//	--from-file <path>   read JWT from file (file MUST be mode 0600)
+//	--from-file -        read JWT from stdin explicitly
+//	(no args, stdin piped) read JWT from stdin (auto-detected when !isatty)
 //
 // Per §13.3, the JWT MUST NOT be passed as a positional argument — the
 // positional form was removed because a runtime warning cannot unexpose a
@@ -331,6 +498,7 @@ func checkImportFilePerm(path string) error {
 // defaultImportName derives the default context name from (in order):
 //  1. JWT label_hint (if set and not already taken),
 //  2. agent-<first-scope-root>,
+//
 // with a numeric suffix appended on collision.
 func defaultImportName(cfg *Config, claims *jwtClaims) string {
 	base := claims.LabelHint

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -82,7 +82,10 @@ func ctxShowCmd(args []string) error {
 		case "--reveal":
 			reveal = true
 		default:
-			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx show [--json] [--reveal]", arg)
+			if strings.HasPrefix(arg, "-") {
+				return fmt.Errorf("unknown flag %q\nusage: drive9 ctx show [--json] [--reveal]", arg)
+			}
+			return fmt.Errorf("unexpected argument %q\nusage: drive9 ctx show [--json] [--reveal]", arg)
 		}
 	}
 

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -57,19 +57,19 @@ func ctxUsageErr() error {
 }
 
 type ctxShowEntry struct {
-	Name      string    `json:"name"`
-	Type      string    `json:"type"`
-	Server    string    `json:"server,omitempty"`
-	APIKey    string    `json:"api_key,omitempty"`
-	Token     string    `json:"token,omitempty"`
-	Agent     string    `json:"agent,omitempty"`
-	Scope     []string  `json:"scope,omitempty"`
-	Perm      string    `json:"perm,omitempty"`
-	ExpiresAt time.Time `json:"expires_at,omitempty"`
-	Status    string    `json:"status,omitempty"`
-	GrantID   string    `json:"grant_id,omitempty"`
-	LabelHint string    `json:"label_hint,omitempty"`
-	Source    string    `json:"source,omitempty"`
+	Name      string     `json:"name"`
+	Type      string     `json:"type"`
+	Server    string     `json:"server,omitempty"`
+	APIKey    string     `json:"api_key,omitempty"`
+	Token     string     `json:"token,omitempty"`
+	Agent     string     `json:"agent,omitempty"`
+	Scope     []string   `json:"scope,omitempty"`
+	Perm      string     `json:"perm,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Status    string     `json:"status,omitempty"`
+	GrantID   string     `json:"grant_id,omitempty"`
+	LabelHint string     `json:"label_hint,omitempty"`
+	Source    string     `json:"source,omitempty"`
 }
 
 func ctxShowCmd(args []string) error {
@@ -117,7 +117,10 @@ func buildCtxShowEntry(cfg *Config, reveal bool) *ctxShowEntry {
 		entry.Agent = current.Agent
 		entry.Scope = append([]string(nil), current.Scope...)
 		entry.Perm = string(current.Perm)
-		entry.ExpiresAt = current.ExpiresAt
+		if !current.ExpiresAt.IsZero() {
+			expiresAt := current.ExpiresAt
+			entry.ExpiresAt = &expiresAt
+		}
 		entry.Status = ctxStatus(current, time.Now())
 		entry.GrantID = current.GrantID
 		entry.LabelHint = current.LabelHint
@@ -178,11 +181,11 @@ func writeCtxShowText(entry *ctxShowEntry) error {
 			value string
 		}{label: "perm", value: entry.Perm})
 	}
-	if !entry.ExpiresAt.IsZero() {
+	if entry.ExpiresAt != nil {
 		fields = append(fields, struct {
 			label string
 			value string
-		}{label: "expires_at", value: formatExpiresAt(entry.ExpiresAt)})
+		}{label: "expires_at", value: formatExpiresAt(*entry.ExpiresAt)})
 	}
 	if entry.Status != "" {
 		fields = append(fields, struct {

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -199,6 +199,249 @@ func TestF_ImportStoresDelegatedContext(t *testing.T) {
 	}
 }
 
+func TestCtxShowOwnerMaskedText(t *testing.T) {
+	home := withIsolatedHome(t)
+	cfg := loadConfig()
+	_, err := ctxAdd(cfg, "prod", &Context{
+		Type:   PrincipalOwner,
+		APIKey: "drive9_abcdxxxxxxxxwxyz",
+		Server: "https://api.drive9.ai",
+	})
+	if err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"show"}) })
+	if err != nil {
+		t.Fatalf("ctx show: %v", err)
+	}
+	for _, want := range []string{
+		"name:",
+		"prod",
+		"type:",
+		"owner",
+		"server:",
+		"https://api.drive9.ai",
+		"api_key:",
+		"drive9_abcd...wxyz",
+		filepath.Join(home, ".drive9", "config"),
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("ctx show output = %q, want substring %q", out, want)
+		}
+	}
+	if strings.Contains(out, "drive9_abcdxxxxxxxxwxyz") {
+		t.Fatalf("ctx show should mask api key by default: %q", out)
+	}
+}
+
+func TestCtxShowOwnerRevealJSON(t *testing.T) {
+	home := withIsolatedHome(t)
+	cfg := loadConfig()
+	cfg.Server = "https://api.drive9.ai"
+	_, err := ctxAdd(cfg, "prod", &Context{
+		Type:   PrincipalOwner,
+		APIKey: "drive9_abcdxxxxxxxxwxyz",
+	})
+	if err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"show", "--json", "--reveal"})
+	})
+	if err != nil {
+		t.Fatalf("ctx show --json --reveal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v\nout=%q", err, out)
+	}
+	if got["name"] != "prod" {
+		t.Fatalf("name = %v, want prod", got["name"])
+	}
+	if got["type"] != "owner" {
+		t.Fatalf("type = %v, want owner", got["type"])
+	}
+	if got["server"] != "https://api.drive9.ai" {
+		t.Fatalf("server = %v, want https://api.drive9.ai", got["server"])
+	}
+	if got["api_key"] != "drive9_abcdxxxxxxxxwxyz" {
+		t.Fatalf("api_key = %v, want full key", got["api_key"])
+	}
+	if got["source"] != filepath.Join(home, ".drive9", "config") {
+		t.Fatalf("source = %v, want config path", got["source"])
+	}
+}
+
+func TestCtxShowDelegatedJSON(t *testing.T) {
+	_ = withIsolatedHome(t)
+	expiresAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	cfg := loadConfig()
+	_, err := ctxAdd(cfg, "alice-prod-db", &Context{
+		Type:      PrincipalDelegated,
+		Server:    "https://api.drive9.ai",
+		Token:     "eyJhbGciOiJIUzI1NiJ9.eyJncmFudF9pZCI6ImdydF8xIn0.signature",
+		Agent:     "alice",
+		Scope:     []string{"/n/vault/prod-db/DB_URL", "/n/vault/prod-db/PASSWORD"},
+		Perm:      PermRead,
+		ExpiresAt: expiresAt,
+		GrantID:   "grt_1",
+		LabelHint: "alice-prod-db",
+	})
+	if err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"show", "--json"}) })
+	if err != nil {
+		t.Fatalf("ctx show --json: %v", err)
+	}
+
+	var got struct {
+		Name      string    `json:"name"`
+		Type      string    `json:"type"`
+		Server    string    `json:"server"`
+		Token     string    `json:"token"`
+		Agent     string    `json:"agent"`
+		Scope     []string  `json:"scope"`
+		Perm      string    `json:"perm"`
+		ExpiresAt time.Time `json:"expires_at"`
+		Status    string    `json:"status"`
+		GrantID   string    `json:"grant_id"`
+		LabelHint string    `json:"label_hint"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v\nout=%q", err, out)
+	}
+	if got.Name != "alice-prod-db" || got.Type != "delegated" {
+		t.Fatalf("unexpected identity fields: %+v", got)
+	}
+	if got.Token == "eyJhbGciOiJIUzI1NiJ9.eyJncmFudF9pZCI6ImdydF8xIn0.signature" {
+		t.Fatalf("token should be masked by default: %+v", got)
+	}
+	if got.Agent != "alice" {
+		t.Fatalf("agent = %q, want alice", got.Agent)
+	}
+	if len(got.Scope) != 2 {
+		t.Fatalf("scope = %v, want 2 entries", got.Scope)
+	}
+	if got.Perm != "read" {
+		t.Fatalf("perm = %q, want read", got.Perm)
+	}
+	if !got.ExpiresAt.Equal(expiresAt) {
+		t.Fatalf("expires_at = %s, want %s", got.ExpiresAt, expiresAt)
+	}
+	if got.Status != "active" {
+		t.Fatalf("status = %q, want active", got.Status)
+	}
+	if got.GrantID != "grt_1" {
+		t.Fatalf("grant_id = %q, want grt_1", got.GrantID)
+	}
+	if got.LabelHint != "alice-prod-db" {
+		t.Fatalf("label_hint = %q, want alice-prod-db", got.LabelHint)
+	}
+}
+
+func TestCtxShowDelegatedRevealJSON(t *testing.T) {
+	_ = withIsolatedHome(t)
+	expiresAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	fullToken := "eyJhbGciOiJIUzI1NiJ9.eyJncmFudF9pZCI6ImdydF8xIn0.signature"
+	cfg := loadConfig()
+	_, err := ctxAdd(cfg, "alice-prod-db", &Context{
+		Type:      PrincipalDelegated,
+		Server:    "https://api.drive9.ai",
+		Token:     fullToken,
+		Agent:     "alice",
+		Scope:     []string{"/n/vault/prod-db/DB_URL"},
+		Perm:      PermRead,
+		ExpiresAt: expiresAt,
+		GrantID:   "grt_1",
+		LabelHint: "alice-prod-db",
+	})
+	if err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"show", "--json", "--reveal"}) })
+	if err != nil {
+		t.Fatalf("ctx show --json --reveal: %v", err)
+	}
+
+	var got struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v\nout=%q", err, out)
+	}
+	if got.Token != fullToken {
+		t.Fatalf("token = %q, want full token", got.Token)
+	}
+}
+
+func TestCtxShowJSONNoCurrentContext(t *testing.T) {
+	_ = withIsolatedHome(t)
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"show", "--json"}) })
+	if err != nil {
+		t.Fatalf("ctx show --json: %v", err)
+	}
+	if strings.TrimSpace(out) != "null" {
+		t.Fatalf("ctx show --json without current context = %q, want null", out)
+	}
+}
+
+func TestCtxBareMatchesShowText(t *testing.T) {
+	_ = withIsolatedHome(t)
+	cfg := loadConfig()
+	_, err := ctxAdd(cfg, "prod", &Context{Type: PrincipalOwner, APIKey: "k", Server: "https://api.drive9.ai"})
+	if err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	bareOut, err := captureStdoutE(t, func() error { return Ctx(nil) })
+	if err != nil {
+		t.Fatalf("bare ctx: %v", err)
+	}
+	showOut, err := captureStdoutE(t, func() error { return Ctx([]string{"show"}) })
+	if err != nil {
+		t.Fatalf("ctx show: %v", err)
+	}
+	if bareOut != showOut {
+		t.Fatalf("bare ctx output = %q, want same as ctx show %q", bareOut, showOut)
+	}
+}
+
+func TestCtxBareNoCurrentContextMatchesShow(t *testing.T) {
+	_ = withIsolatedHome(t)
+	bareOut, err := captureStdoutE(t, func() error { return Ctx(nil) })
+	if err != nil {
+		t.Fatalf("bare ctx: %v", err)
+	}
+	showOut, err := captureStdoutE(t, func() error { return Ctx([]string{"show"}) })
+	if err != nil {
+		t.Fatalf("ctx show: %v", err)
+	}
+	if bareOut != showOut {
+		t.Fatalf("bare ctx output = %q, want same as ctx show %q", bareOut, showOut)
+	}
+}
+
 // TestF15_CtxUseIsExplicitVerb — spec §13.2 / F15: `ctx use` must be an
 // explicit verb. The positional-switch form `drive9 ctx <name>` is retired.
 func TestF15_CtxUseIsExplicitVerb(t *testing.T) {

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -403,6 +403,17 @@ func TestCtxShowJSONNoCurrentContext(t *testing.T) {
 	}
 }
 
+func TestCtxShowRejectsUnexpectedPositionalArgument(t *testing.T) {
+	_ = withIsolatedHome(t)
+	err := Ctx([]string{"show", "prod"})
+	if err == nil {
+		t.Fatal("expected error for unexpected positional argument")
+	}
+	if !strings.Contains(err.Error(), "unexpected argument \"prod\"") {
+		t.Fatalf("error = %q, want unexpected argument message", err)
+	}
+}
+
 func TestCtxBareMatchesShowText(t *testing.T) {
 	_ = withIsolatedHome(t)
 	cfg := loadConfig()

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -276,6 +276,9 @@ func TestCtxShowOwnerRevealJSON(t *testing.T) {
 	if got["api_key"] != "drive9_abcdxxxxxxxxwxyz" {
 		t.Fatalf("api_key = %v, want full key", got["api_key"])
 	}
+	if _, ok := got["expires_at"]; ok {
+		t.Fatalf("expires_at should be omitted for owner contexts: %+v", got)
+	}
 	if got["source"] != filepath.Join(home, ".drive9", "config") {
 		t.Fatalf("source = %v, want config path", got["source"])
 	}

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -250,33 +250,33 @@ func fatal(cmd string, err error) {
 }
 
 func usage(code int) {
-	fmt.Fprintf(os.Stderr, `usage: drive9 <command> [arguments]
-
-commands:
-  create [--name NAME] [--server URL]
-                         provision a new database and owner context
-  ctx                    show current context
-  ctx add --api-key <key> [--name NAME] [--server URL]
-                         add owner context
-  ctx import [--from-file <path|->] [--name NAME]
-                         add delegated context
-  ctx ls [-l|--json]     list contexts
-  ctx use <name>         activate context
-  ctx rm <name>          delete context
-  fs <command>           filesystem operations
-  vault <set|get|put|with|ls|rm|grant|revoke|audit>
-                         vault operations
-  mount [flags] [:/remote] <mountpoint>
-                         mount drive9 filesystem
-  mount vault [flags] <mountpoint>
-                         mount vault secrets read-only
-  umount <mountpoint>    unmount a drive9 mount
-  doctor fuse            diagnose local FUSE prerequisites
-
-global:
-  -h, --help, help       show this help
-  -v, --version, version print version information
-`)
+	fmt.Fprint(os.Stderr,
+		"usage: drive9 <command> [arguments]\n\n"+
+			"commands:\n"+
+			"  create [--name NAME] [--server URL]\n"+
+			"                         provision a new database and owner context\n"+
+			"  ctx show [--json] [--reveal]\n"+
+			"                         show current context\n"+
+			"  ctx add --api-key <key> [--name NAME] [--server URL]\n"+
+			"                         add owner context\n"+
+			"  ctx import [--from-file <path|->] [--name NAME]\n"+
+			"                         add delegated context\n"+
+			"  ctx ls [-l|--json]     list contexts\n"+
+			"  ctx use <name>         activate context\n"+
+			"  ctx rm <name>          delete context\n"+
+			"  fs <command>           filesystem operations\n"+
+			"  vault <set|get|put|with|ls|rm|grant|revoke|audit>\n"+
+			"                         vault operations\n"+
+			"  mount [flags] [:/remote] <mountpoint>\n"+
+			"                         mount drive9 filesystem\n"+
+			"  mount vault [flags] <mountpoint>\n"+
+			"                         mount vault secrets read-only\n"+
+			"  umount <mountpoint>    unmount a drive9 mount\n"+
+			"  doctor fuse            diagnose local FUSE prerequisites\n\n"+
+			"global:\n"+
+			"  -h, --help, help       show this help\n"+
+			"  -v, --version, version print version information\n",
+	)
 	exitWithCode(code)
 }
 

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -80,6 +80,7 @@ func TestDispatchLongHelpFlagShowsUsage(t *testing.T) {
 	}
 	for _, want := range []string{
 		"usage: drive9 <command> [arguments]",
+		"ctx show [--json] [--reveal]",
 		"ctx use <name>",
 		"mount [flags] [:/remote] <mountpoint>",
 		"mount vault [flags] <mountpoint>",

--- a/docs/specs/pr-b-ctx-implementation.md
+++ b/docs/specs/pr-b-ctx-implementation.md
@@ -30,7 +30,7 @@ PR-B is the **CLI side** of the grant → context flow: the verbs that take a JW
 ### Non-goals
 
 - No change to any server endpoint, DB schema, or audit event written by PR-A.
-- No new CLI verb outside the five locked in §13.2. The `drive9 ctx` bare form (no verb) remains a non-spec compatibility convenience that prints the current context name; it is not load-bearing.
+- The user-facing ctx verb set is `show / add / import / ls / use / rm`. Bare `drive9 ctx` is accepted as shorthand for `drive9 ctx show` and carries the same default text output contract.
 - No auto-mint, auto-refresh, auto-rotate, or auto-anything at `ctx` layer. A context that expires is refused on `ctx use`; the user must re-import.
 
 ---
@@ -407,7 +407,7 @@ Wordlist sizing:
 
 ### 4.5 `drive9 ctx` bare form (compatibility)
 
-Current pre-PR-B implementation: `drive9 ctx` (no verb) prints the current context name. This is a non-spec convenience not listed in §13.2. Keep it as-is for backwards compat; the dispatcher routes `args == []` to `ctxShow()`. **Flag this in PR-B body as a known non-spec carry-over**; removal would be a separate UX-cleanup PR, not a bundle into PR-B.
+Current implementation converges both entry points onto one contract: `drive9 ctx show` renders the current context details (text or JSON, masked by default, `--reveal` to unmask; `--json` emits the active-context object or `null` when none is active), and bare `drive9 ctx` is a shorthand alias for the default text form of `ctx show`.
 
 ---
 

--- a/docs/specs/pr-b-review-checklist.md
+++ b/docs/specs/pr-b-review-checklist.md
@@ -12,7 +12,7 @@ Per `feedback_review_gate_axis_enumeration.md`: before sign-off, walk every numb
 
 ## A. Spec conformance (§13.1 / §13.2 / §13.3 / §14 / §15)
 
-- [ ] **[spec+code]** Verb set is exactly `{add, import, ls, use, rm}` plus the bare `ctx` (no-verb) carry-over whose contract is "print the current context name, or 'no current context'; no side effects; not listed in §13.2". No `create`, no `sh`, no `login`, no other aliases beyond the `ls` / `list` synonym already in merged §13.2. The bare form is a documented non-spec compat (impl §4.5), not a silent sixth verb.
+- [ ] **[spec+code]** User-facing ctx verb set is exactly `{show, add, import, ls, use, rm}`. If bare `drive9 ctx` is accepted, it is only as shorthand for `drive9 ctx show` and MUST produce the same default text output; there is no separate name-only contract. No `create`, no `sh`, no `login`, no other aliases beyond the `ls` / `list` synonym already in merged §13.2.
 - [ ] **[spec]** §13.2 verb table in `vault-interaction-end-state.md` has positional-JWT row removed; `ctx import` rows show `--from-file <path>` and `--from-file -` only.
 - [ ] **[spec]** §13.3 "Input modes" bullet list contains exactly three bullets: `--from-file <path>`, `--from-file -`, and no-arg (pipe default).
 - [ ] **[spec]** §13.3 includes the literal TTY-detection error string:

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -379,7 +379,7 @@ The delegated fields are populated by locally decoding the JWT payload (see §16
 
 ```bash
 drive9 ctx add --api-key <key> [--name <n>] [--server <url>]      # add owner context
-drive9 ctx show [--json] [--reveal]                               # show the active context (masked by default)
+drive9 ctx show [--json] [--reveal]                               # show the active context (masked by default in text and JSON)
 drive9 ctx import --from-file <path>                              # add delegated context from a file
 drive9 ctx import [--from-file -]                                 # add delegated context from stdin (default when stdin is a pipe)
 drive9 ctx ls [-l|--json]                                         # list contexts (offline — reads only local config)
@@ -389,7 +389,7 @@ drive9 ctx rm <name>                                              # delete a con
 
 Both `ctx import` forms are equivalent in effect. Stdin is read by default when stdin is a pipe (`isatty(0) == false`); the explicit `--from-file -` form is accepted for scripts that want the intent to be unambiguous. When stdin is a TTY and no `--from-file` is supplied, `ctx import` exits with `EINVAL` and prints a one-line help pointing at the two canonical forms (see §13.3).
 
-`ctx show` renders the active context only. Human output is masked by default; `--reveal` disables masking for the credential field. `ctx show --json` emits a single JSON value: the active-context object when one exists, or JSON `null` when no context is active. Bare `drive9 ctx` is shorthand for the default text form of `drive9 ctx show`.
+`ctx show` renders the active context only. Text and JSON output are both masked by default; `--reveal` disables masking for the credential field in either form. `ctx show --json` emits a single JSON value: the active-context object when one exists, or JSON `null` when no context is active. Bare `drive9 ctx` is shorthand for the default text form of `drive9 ctx show`.
 
 **Canonical pipe handoff.** The default human output of `drive9 vault grant` (see §6) is *not* pipe-safe — it prints `grant_id` and `expires_at` lines in addition to the JWT. To pipe grant output directly into `ctx import`, use `drive9 vault grant ... --token-only`, which prints only the bare JWT. The end-to-end canonical pipeline is:
 

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -379,6 +379,7 @@ The delegated fields are populated by locally decoding the JWT payload (see §16
 
 ```bash
 drive9 ctx add --api-key <key> [--name <n>] [--server <url>]      # add owner context
+drive9 ctx show [--json] [--reveal]                               # show the active context (masked by default)
 drive9 ctx import --from-file <path>                              # add delegated context from a file
 drive9 ctx import [--from-file -]                                 # add delegated context from stdin (default when stdin is a pipe)
 drive9 ctx ls [-l|--json]                                         # list contexts (offline — reads only local config)
@@ -387,6 +388,8 @@ drive9 ctx rm <name>                                              # delete a con
 ```
 
 Both `ctx import` forms are equivalent in effect. Stdin is read by default when stdin is a pipe (`isatty(0) == false`); the explicit `--from-file -` form is accepted for scripts that want the intent to be unambiguous. When stdin is a TTY and no `--from-file` is supplied, `ctx import` exits with `EINVAL` and prints a one-line help pointing at the two canonical forms (see §13.3).
+
+`ctx show` renders the active context only. Human output is masked by default; `--reveal` disables masking for the credential field. `ctx show --json` emits a single JSON value: the active-context object when one exists, or JSON `null` when no context is active. Bare `drive9 ctx` is shorthand for the default text form of `drive9 ctx show`.
 
 **Canonical pipe handoff.** The default human output of `drive9 vault grant` (see §6) is *not* pipe-safe — it prints `grant_id` and `expires_at` lines in addition to the JWT. To pipe grant output directly into `ctx import`, use `drive9 vault grant ... --token-only`, which prints only the bare JWT. The end-to-end canonical pipeline is:
 
@@ -718,7 +721,7 @@ Legend:
 | `drive9 umount <path>` | implemented | pre-M1 |
 | `drive9 ctx add --api-key` | implemented | #284 (PR-B) |
 | `drive9 ctx import --from-file` | implemented | #284 (PR-B) |
-| `drive9 ctx ls` / `use` / `rm` | implemented | #284 (PR-B) |
+| `drive9 ctx show` / `ls` / `use` / `rm` | implemented | #284 (PR-B) |
 | `drive9 vault put <path> --from <dir>` | implemented | V2d (#307) |
 | `drive9 vault grant <scope>... --agent --perm --ttl` | implemented | Appendix-A alignment PR track |
 | `drive9 vault revoke <grant-id>` | implemented | Appendix-A alignment PR track |
@@ -738,7 +741,7 @@ Appendix A — Command surface at a glance:
 | `drive9 ctx add --api-key <k>` | Register an owner context. |
 | `drive9 ctx import --from-file <path>` | Register a delegated context from a grant JWT file (primary UX). |
 | `drive9 ctx import [--from-file -]` | Same, reading the JWT from stdin (default when stdin is a pipe). |
-| `drive9 ctx ls / use / rm` | Manage contexts (offline). |
+| `drive9 ctx show / ls / use / rm` | Inspect and manage contexts (offline). |
 | `drive9 vault put <path> --from <dir>` | Atomic wholesale-replace batch write (§2). |
 | `drive9 vault grant <scope>... --agent --perm --ttl` | Issue a scoped JWT. |
 | `drive9 vault revoke <grant-id>` | Revoke a grant. |


### PR DESCRIPTION
## Summary
- add `drive9 ctx show` with masked-by-default text output plus `--json` and `--reveal`
- make bare `drive9 ctx` use the same default text output as `drive9 ctx show`
- update help text, tests, and ctx/vault interaction spec to match the converged CLI contract

## Testing
- `go test ./cmd/drive9/cli ./cmd/drive9`