### PR TITLE
Optimize FUSE handle hot paths

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -19,6 +19,11 @@ import (
 	drive9webdav "github.com/mem9-ai/dat9/pkg/webdav"
 )
 
+const (
+	defaultFuseLookupRetryCount   = 3
+	defaultFuseLookupRetryTimeout = 2 * time.Second
+)
+
 var (
 	errMountProcessStateStale  = errors.New("drive9 umount: stale mount process state")
 	errMountProcessStateUnsafe = errors.New("drive9 umount: unsafe mount process state")
@@ -83,8 +88,8 @@ func fsMountCmd(args []string) error {
 	attrTTL := fs.Duration("attr-ttl", 10*time.Second, "kernel attr cache TTL")
 	entryTTL := fs.Duration("entry-ttl", 10*time.Second, "kernel entry cache TTL")
 	flushDebounce := fs.Duration("flush-debounce", -1, "debounce window for small-file flush coalescing (default 2s, 0 disables)")
-	lookupRetryCount := fs.Int("lookup-retry-count", 0, "detached retries after transient Lookup/GetAttr stat failures (omit for default, set 0 to disable)")
-	lookupRetryTimeout := fs.Duration("lookup-retry-timeout", 0, "timeout per detached Lookup/GetAttr stat retry (omit for default, must be > 0 when set)")
+	lookupRetryCount := fs.Int("lookup-retry-count", defaultFuseLookupRetryCount, "detached retries after transient Lookup/GetAttr stat failures (set 0 to disable)")
+	lookupRetryTimeout := fs.Duration("lookup-retry-timeout", defaultFuseLookupRetryTimeout, "timeout per detached Lookup/GetAttr stat retry (must be > 0 when set)")
 	legacyDirStatFallback := fs.Bool("legacy-dir-stat-fallback", false, "on Lookup stat 404, list parent to support legacy servers without directory stat")
 	readDirPrefetch := fs.Bool("readdir-prefetch", false, "prefetch small files after directory reads into the read cache")
 	prefetchMaxFiles := fs.Int("readdir-prefetch-max-files", 32, "maximum small files prefetched per directory read")

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -83,8 +83,8 @@ func fsMountCmd(args []string) error {
 	attrTTL := fs.Duration("attr-ttl", 10*time.Second, "kernel attr cache TTL")
 	entryTTL := fs.Duration("entry-ttl", 10*time.Second, "kernel entry cache TTL")
 	flushDebounce := fs.Duration("flush-debounce", -1, "debounce window for small-file flush coalescing (default 2s, 0 disables)")
-	lookupRetryCount := fs.Int("lookup-retry-count", 2, "detached retries after transient Lookup/GetAttr stat failures (default 2, set 0 to disable)")
-	lookupRetryTimeout := fs.Duration("lookup-retry-timeout", 250*time.Millisecond, "timeout per detached Lookup/GetAttr stat retry (default 250ms, must be > 0)")
+	lookupRetryCount := fs.Int("lookup-retry-count", 0, "detached retries after transient Lookup/GetAttr stat failures (omit for default, set 0 to disable)")
+	lookupRetryTimeout := fs.Duration("lookup-retry-timeout", 0, "timeout per detached Lookup/GetAttr stat retry (omit for default, must be > 0 when set)")
 	legacyDirStatFallback := fs.Bool("legacy-dir-stat-fallback", false, "on Lookup stat 404, list parent to support legacy servers without directory stat")
 	readDirPrefetch := fs.Bool("readdir-prefetch", false, "prefetch small files after directory reads into the read cache")
 	prefetchMaxFiles := fs.Int("readdir-prefetch-max-files", 32, "maximum small files prefetched per directory read")
@@ -139,13 +139,19 @@ func fsMountCmd(args []string) error {
 		return err
 	}
 
-	if err := validateLookupRetryFlags(*lookupRetryCount, *lookupRetryTimeout); err != nil {
+	lookupRetryCountGiven := flagProvided(fs, "lookup-retry-count")
+	lookupRetryTimeoutGiven := flagProvided(fs, "lookup-retry-timeout")
+	if err := validateLookupRetryFlags(*lookupRetryCount, *lookupRetryTimeout, lookupRetryCountGiven, lookupRetryTimeoutGiven); err != nil {
 		return err
 	}
 	if err := validateReadDirPrefetchFlags(*prefetchMaxFiles, *prefetchMaxFileBytes, *prefetchMaxBytes, *prefetchTimeout); err != nil {
 		return err
 	}
-	normalizedLookupRetryCount := normalizeLookupRetryCount(*lookupRetryCount)
+	normalizedLookupRetryCount := lookupRetryCountFlagValue(lookupRetryCountGiven, *lookupRetryCount)
+	normalizedLookupRetryTimeout := durationFlagValue(fs, "lookup-retry-timeout", *lookupRetryTimeout)
+	normalizedDirTTL := durationFlagValue(fs, "dir-ttl", *dirTTL)
+	normalizedAttrTTL := durationFlagValue(fs, "attr-ttl", *attrTTL)
+	normalizedEntryTTL := durationFlagValue(fs, "entry-ttl", *entryTTL)
 
 	serverGiven, apiKeyGiven := flagProvided(fs, "server"), flagProvided(fs, "api-key")
 	if err := rejectEmptyFlag("server", *server, serverGiven); err != nil {
@@ -212,12 +218,12 @@ func fsMountCmd(args []string) error {
 		RemoteRoot:            remoteRoot,
 		CacheDir:              *cacheDir,
 		CacheSize:             int64(*cacheSize) << 20,
-		DirTTL:                *dirTTL,
-		AttrTTL:               *attrTTL,
-		EntryTTL:              *entryTTL,
+		DirTTL:                normalizedDirTTL,
+		AttrTTL:               normalizedAttrTTL,
+		EntryTTL:              normalizedEntryTTL,
 		FlushDebounce:         *flushDebounce,
 		LookupRetryCount:      normalizedLookupRetryCount,
-		LookupRetryTimeout:    *lookupRetryTimeout,
+		LookupRetryTimeout:    normalizedLookupRetryTimeout,
 		LegacyDirStatFallback: *legacyDirStatFallback,
 		ReadDirPrefetch:       *readDirPrefetch,
 		PrefetchMaxFiles:      *prefetchMaxFiles,
@@ -281,11 +287,11 @@ func remoteRootError(remoteRoot string, err error) error {
 	return fmt.Errorf("remote root %q: %w", remoteRoot, err)
 }
 
-func validateLookupRetryFlags(count int, timeout time.Duration) error {
-	if count < 0 {
+func validateLookupRetryFlags(count int, timeout time.Duration, countGiven bool, timeoutGiven bool) error {
+	if countGiven && count < 0 {
 		return fmt.Errorf("drive9 mount: --lookup-retry-count must be >= 0")
 	}
-	if timeout <= 0 {
+	if timeoutGiven && timeout <= 0 {
 		return fmt.Errorf("drive9 mount: --lookup-retry-timeout must be > 0")
 	}
 	return nil
@@ -305,6 +311,20 @@ func validateReadDirPrefetchFlags(maxFiles int, maxFileBytes int64, maxBytes int
 		return fmt.Errorf("drive9 mount: --readdir-prefetch-timeout must be > 0")
 	}
 	return nil
+}
+
+func durationFlagValue(fs *flag.FlagSet, name string, value time.Duration) time.Duration {
+	if flagProvided(fs, name) {
+		return value
+	}
+	return 0
+}
+
+func lookupRetryCountFlagValue(given bool, count int) int {
+	if !given {
+		return 0
+	}
+	return normalizeLookupRetryCount(count)
 }
 
 func normalizeLookupRetryCount(count int) int {

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -721,24 +721,97 @@ func TestMountCmdLeavesLegacyDirStatFallbackDisabledByDefault(t *testing.T) {
 	}
 }
 
+func TestMountCmdLeavesDefaultTTLsUnsetForFuseDefaults(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if got.DirTTL != 0 || got.AttrTTL != 0 || got.EntryTTL != 0 {
+		t.Fatalf("default TTLs = dir %v attr %v entry %v, want all unset", got.DirTTL, got.AttrTTL, got.EntryTTL)
+	}
+	if got.LookupRetryCount != 0 || got.LookupRetryTimeout != 0 {
+		t.Fatalf("default lookup retry = count %d timeout %v, want all unset", got.LookupRetryCount, got.LookupRetryTimeout)
+	}
+}
+
+func TestMountCmdPreservesExplicitTTLs(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--profile", "interactive",
+		"--dir-ttl", "5s",
+		"--attr-ttl", "6s",
+		"--entry-ttl", "7s",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if got.DirTTL != 5*time.Second {
+		t.Fatalf("DirTTL = %v, want 5s", got.DirTTL)
+	}
+	if got.AttrTTL != 6*time.Second {
+		t.Fatalf("AttrTTL = %v, want 6s", got.AttrTTL)
+	}
+	if got.EntryTTL != 7*time.Second {
+		t.Fatalf("EntryTTL = %v, want 7s", got.EntryTTL)
+	}
+}
+
 func TestValidateLookupRetryFlags(t *testing.T) {
-	if err := validateLookupRetryFlags(2, 250*time.Millisecond); err != nil {
+	if err := validateLookupRetryFlags(0, 0, false, false); err != nil {
+		t.Fatalf("omitted lookup retry flags should be allowed: %v", err)
+	}
+
+	if err := validateLookupRetryFlags(2, 250*time.Millisecond, true, true); err != nil {
 		t.Fatalf("validateLookupRetryFlags() unexpected error: %v", err)
 	}
 
-	if err := validateLookupRetryFlags(0, 250*time.Millisecond); err != nil {
+	if err := validateLookupRetryFlags(0, 0, true, false); err != nil {
 		t.Fatalf("count=0 should be allowed to disable retries: %v", err)
 	}
 
-	if err := validateLookupRetryFlags(2, 0); err == nil || !strings.Contains(err.Error(), "--lookup-retry-timeout") {
+	if err := validateLookupRetryFlags(2, 0, true, true); err == nil || !strings.Contains(err.Error(), "--lookup-retry-timeout") {
 		t.Fatalf("timeout=0 error = %v, want timeout validation error", err)
 	}
 
-	if err := validateLookupRetryFlags(-1, 250*time.Millisecond); err == nil || !strings.Contains(err.Error(), "--lookup-retry-count") {
+	if err := validateLookupRetryFlags(-1, 250*time.Millisecond, true, true); err == nil || !strings.Contains(err.Error(), "--lookup-retry-count") {
 		t.Fatalf("count=-1 error = %v, want count validation error", err)
 	}
 
-	if err := validateLookupRetryFlags(2, -time.Millisecond); err == nil || !strings.Contains(err.Error(), "--lookup-retry-timeout") {
+	if err := validateLookupRetryFlags(2, -time.Millisecond, true, true); err == nil || !strings.Contains(err.Error(), "--lookup-retry-timeout") {
 		t.Fatalf("timeout<0 error = %v, want timeout validation error", err)
 	}
 }
@@ -763,7 +836,12 @@ func TestValidateReadDirPrefetchFlags(t *testing.T) {
 }
 
 func TestNormalizeLookupRetryCount(t *testing.T) {
-	count := normalizeLookupRetryCount(2)
+	count := lookupRetryCountFlagValue(false, 0)
+	if count != 0 {
+		t.Fatalf("omitted count = %d, want 0 for FUSE default", count)
+	}
+
+	count = normalizeLookupRetryCount(2)
 	if count != 2 {
 		t.Fatalf("normalized positive count = %d, want 2", count)
 	}

--- a/pkg/fuse/context_test.go
+++ b/pkg/fuse/context_test.go
@@ -1,0 +1,41 @@
+package fuse
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestFuseCtxNilCancel(t *testing.T) {
+	ctx, cancel := fuseCtx(nil)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatalf("fuseCtx(nil) was canceled immediately: %v", ctx.Err())
+	default:
+	}
+
+	cancel()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not cancel fuseCtx(nil)")
+	}
+}
+
+func TestFuseCtxCancelChannel(t *testing.T) {
+	ch := make(chan struct{})
+	ctx, cancel := fuseCtx(ch)
+	defer cancel()
+
+	close(ch)
+	select {
+	case <-ctx.Done():
+		if err := ctx.Err(); err != context.Canceled {
+			t.Fatalf("ctx err = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancel channel did not cancel fuseCtx")
+	}
+}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -31,6 +31,7 @@ type Dat9FS struct {
 	client      *client.Client
 	inodes      *InodeToPath
 	fileHandles *HandleTable[*FileHandle]
+	openHandles *OpenHandleIndex
 	dirHandles  *HandleTable[*DirHandle]
 	readCache   *ReadCache
 	dirCache    *DirCache
@@ -171,6 +172,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		client:        c,
 		inodes:        NewInodeToPath(),
 		fileHandles:   NewHandleTable[*FileHandle](),
+		openHandles:   NewOpenHandleIndex(),
 		dirHandles:    NewHandleTable[*DirHandle](),
 		readCache:     NewReadCache(opts.CacheSize, 0),
 		dirCache:      NewNamespaceCache(opts.DirTTL, opts.NegativeEntryTTL, defaultNamespaceCacheMaxEntries),
@@ -264,6 +266,9 @@ func releaseTimeout(size int64) time.Duration {
 // timeout expires. This ensures HTTP calls never block indefinitely.
 func fuseCtx(cancel <-chan struct{}) (context.Context, context.CancelFunc) {
 	ctx, cf := context.WithTimeout(context.Background(), fuseTimeout)
+	if cancel == nil {
+		return ctx, cf
+	}
 	go func() {
 		select {
 		case <-cancel:
@@ -420,8 +425,14 @@ func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64
 	}
 
 	var matching []*FileHandle
-	for _, fh := range fs.fileHandles.Snapshot() {
-		if fh != nil && fh.Path == remotePath && fh.Dirty != nil {
+	for _, fh := range fs.openHandles.SnapshotPath(remotePath) {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		dirty := fh.Dirty != nil
+		fh.Unlock()
+		if dirty {
 			matching = append(matching, fh)
 		}
 	}
@@ -1638,17 +1649,7 @@ func (fs *Dat9FS) shouldPreserveForgottenInode(entry *InodeEntry) bool {
 }
 
 func (fs *Dat9FS) hasOpenHandle(ino uint64, p string) bool {
-	// TODO: if git/package-manager workloads keep many handles open, maintain
-	// path/inode indexes instead of scanning the whole handle table.
-	for _, fh := range fs.fileHandles.Snapshot() {
-		if fh == nil {
-			continue
-		}
-		if fh.Ino == ino || fh.Path == p {
-			return true
-		}
-	}
-	return false
+	return fs.openHandles.Has(ino, p)
 }
 
 func (fs *Dat9FS) hasPendingLocalState(p string) bool {
@@ -1673,11 +1674,15 @@ func (fs *Dat9FS) hasQueuedCommit(p string) bool {
 }
 
 func (fs *Dat9FS) openHandleEntry(p string) (*InodeEntry, bool) {
-	for _, fh := range fs.fileHandles.Snapshot() {
-		if fh == nil || fh.Path != p || fh.Dirty == nil {
+	for _, fh := range fs.openHandles.SnapshotPath(p) {
+		if fh == nil {
 			continue
 		}
 		fh.Lock()
+		if fh.Dirty == nil {
+			fh.Unlock()
+			continue
+		}
 		size := fh.Dirty.Size()
 		fh.Unlock()
 		// This path reconstructs a dentry for an already-open writable file
@@ -2233,6 +2238,27 @@ func (fs *Dat9FS) finishLocalRename(input *gofuse.RenameIn, oldP, newP string) {
 	if oldEntryOK {
 		fs.dirCache.Upsert(newParent, cachedInfoFromEntry(path.Base(newP), oldEntry))
 	}
+	fs.retargetOpenHandlesForRename(oldP, newP)
+}
+
+func (fs *Dat9FS) retargetOpenHandlesForRename(oldP, newP string) {
+	for fh, currentPath := range fs.openHandles.RenamePathPrefix(oldP, newP) {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		fh.Path = currentPath
+		if fh.Dirty != nil {
+			fh.Dirty.path = currentPath
+		}
+		if fh.Streamer != nil {
+			fh.Streamer.SetPath(currentPath, fs.remoteRoot())
+		}
+		if fh.Prefetch != nil {
+			fh.Prefetch.SetPath(fs.remotePath(currentPath))
+		}
+		fh.Unlock()
+	}
 }
 
 func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName string, newName string) (status gofuse.Status) {
@@ -2698,7 +2724,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 	}
 
 	fh.DirtySeq = fs.markDirtySize(ino, 0)
-	out.Fh = fs.fileHandles.Allocate(fh)
+	out.Fh = fs.allocateFileHandle(fh)
 	// Use cached I/O for small/interactive files. Kernel coalesces writes
 	// and serves reads from page cache after first access.
 	// Keep DIRECT_IO for O_TRUNC streaming files.
@@ -2845,7 +2871,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		}
 	}
 
-	out.Fh = fs.fileHandles.Allocate(fh)
+	out.Fh = fs.allocateFileHandle(fh)
 	if fh.Dirty != nil {
 		// Use cached I/O for small/interactive files (< 64MB, no O_TRUNC).
 		// Kernel coalesces writes and serves reads from page cache.
@@ -3698,7 +3724,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			if fh.Prefetch != nil {
 				fh.Prefetch.Close()
 			}
-			fs.fileHandles.Delete(input.Fh)
+			fs.deleteFileHandle(input.Fh, fh)
 			fs.cleanupReleasedInode(fh.Ino, fh.Path)
 		}()
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -501,9 +501,11 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 	// Uses a bounded timeout so a stalled server cannot block the FUSE handler
 	// (and its held fh.mu) indefinitely.
 	c := fs.client
-	filePath := fh.Path
-	remoteFilePath := fs.remotePath(filePath)
 	fh.Dirty.LoadPart = func(partNum int) ([]byte, error) {
+		// WriteBuffer callers hold fh.mu. Resolve the path at load time so an
+		// open handle renamed before lazy loading reads from the new remote path.
+		filePath := fh.Path
+		remoteFilePath := fs.remotePath(filePath)
 		partIdx := partNum - 1
 		offset := int64(partIdx) * partSize
 		length := partSize

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2447,6 +2447,51 @@ func TestOpenWritableLargeFileGetsLazyPreload(t *testing.T) {
 	}
 }
 
+func TestLazyWritablePreloadUsesRenamedPath(t *testing.T) {
+	const size = int64(1024 * 1024)
+	var getPath string
+
+	fs, ino, cleanup := newTestDat9FS(t, size, func(w http.ResponseWriter, r *http.Request) {
+		getPath = r.URL.Path
+		if !strings.HasSuffix(r.URL.Path, "/new.bin") {
+			http.Error(w, "unexpected read path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte("renamed-data"))
+	})
+	defer cleanup()
+
+	oldPath := "/file.bin"
+	newPath := "/new.bin"
+	fh := &FileHandle{Ino: ino, Path: oldPath}
+	if st := fs.preloadWritableHandle(context.Background(), fh); st != gofuse.OK {
+		t.Fatalf("preloadWritableHandle status = %v, want OK", st)
+	}
+	if fh.Dirty == nil || fh.Dirty.LoadPart == nil {
+		t.Fatal("expected lazy dirty buffer")
+	}
+	fhID := fs.allocateFileHandle(fh)
+	defer fs.deleteFileHandle(fhID, fh)
+
+	fs.finishLocalRename(&gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Newdir:   1,
+	}, oldPath, newPath)
+	if fh.Path != newPath {
+		t.Fatalf("file handle path after rename = %q, want %q", fh.Path, newPath)
+	}
+
+	fh.Lock()
+	err := fh.Dirty.EnsureLoaded(0)
+	fh.Unlock()
+	if err != nil {
+		t.Fatalf("EnsureLoaded after rename: %v", err)
+	}
+	if !strings.HasSuffix(getPath, newPath) {
+		t.Fatalf("lazy load GET path = %q, want suffix %q", getPath, newPath)
+	}
+}
+
 func TestDefaultTTLIs10Seconds(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2461,6 +2461,39 @@ func TestDefaultTTLIs10Seconds(t *testing.T) {
 	}
 }
 
+func TestInteractiveProfileAppliesTTLDefaults(t *testing.T) {
+	opts := &MountOptions{Profile: "interactive"}
+	opts.setDefaults()
+	if opts.AttrTTL != time.Second {
+		t.Fatalf("interactive AttrTTL = %v, want 1s", opts.AttrTTL)
+	}
+	if opts.EntryTTL != time.Second {
+		t.Fatalf("interactive EntryTTL = %v, want 1s", opts.EntryTTL)
+	}
+	if opts.DirTTL != 2*time.Second {
+		t.Fatalf("interactive DirTTL = %v, want 2s", opts.DirTTL)
+	}
+}
+
+func TestInteractiveProfileKeepsExplicitTTLs(t *testing.T) {
+	opts := &MountOptions{
+		Profile:  "interactive",
+		AttrTTL:  5 * time.Second,
+		EntryTTL: 6 * time.Second,
+		DirTTL:   7 * time.Second,
+	}
+	opts.setDefaults()
+	if opts.AttrTTL != 5*time.Second {
+		t.Fatalf("explicit AttrTTL = %v, want 5s", opts.AttrTTL)
+	}
+	if opts.EntryTTL != 6*time.Second {
+		t.Fatalf("explicit EntryTTL = %v, want 6s", opts.EntryTTL)
+	}
+	if opts.DirTTL != 7*time.Second {
+		t.Fatalf("explicit DirTTL = %v, want 7s", opts.DirTTL)
+	}
+}
+
 func TestMountOptionsLookupRetryDefaultsAndDisableSentinel(t *testing.T) {
 	defaults := &MountOptions{}
 	defaults.setDefaults()

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -57,7 +57,7 @@ type DirEntry struct {
 // HandleTable is a thread-safe, generic handle allocator and lookup table.
 // Handle IDs start at 1 and are never reused within the lifetime of the table.
 type HandleTable[T any] struct {
-	mu     sync.Mutex
+	mu     sync.RWMutex
 	table  map[uint64]T
 	nextFh uint64 // starts at 1
 }
@@ -85,8 +85,8 @@ func (ht *HandleTable[T]) Allocate(val T) uint64 {
 // Get looks up a value by handle ID. It returns the value and true if found,
 // or the zero value of T and false otherwise.
 func (ht *HandleTable[T]) Get(fh uint64) (T, bool) {
-	ht.mu.Lock()
-	defer ht.mu.Unlock()
+	ht.mu.RLock()
+	defer ht.mu.RUnlock()
 
 	val, ok := ht.table[fh]
 	return val, ok
@@ -116,8 +116,8 @@ func (ht *HandleTable[T]) ForEach(fn func(fh uint64, val T)) {
 // Snapshot returns a copy of the handle values present at the time of call.
 // The returned slice can be iterated without holding the table lock.
 func (ht *HandleTable[T]) Snapshot() []T {
-	ht.mu.Lock()
-	defer ht.mu.Unlock()
+	ht.mu.RLock()
+	defer ht.mu.RUnlock()
 
 	vals := make([]T, 0, len(ht.table))
 	for _, val := range ht.table {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -59,6 +59,11 @@ type MountOptions struct {
 }
 
 func (o *MountOptions) setDefaults() {
+	// Apply profile defaults before generic defaults so profile-specific
+	// zero-value options can take effect while explicit non-zero values win.
+	if o.Profile == "interactive" {
+		ApplyInteractiveProfile(o)
+	}
 	if o.CacheSize <= 0 {
 		o.CacheSize = defaultReadCacheMaxSize
 	}
@@ -102,10 +107,6 @@ func (o *MountOptions) setDefaults() {
 	}
 	if o.PrefetchTimeout <= 0 {
 		o.PrefetchTimeout = defaultReadDirPrefetchTimeout
-	}
-	// Apply interactive profile if requested.
-	if o.Profile == "interactive" {
-		ApplyInteractiveProfile(o)
 	}
 }
 

--- a/pkg/fuse/open_handles.go
+++ b/pkg/fuse/open_handles.go
@@ -51,6 +51,9 @@ func (idx *OpenHandleIndex) Remove(fh *FileHandle) {
 	}
 }
 
+// Has reports whether any open handle matches ino or p.
+// When both are supplied this intentionally uses OR semantics to preserve the
+// old conservative inode/path checks from the pre-index table scan.
 func (idx *OpenHandleIndex) Has(ino uint64, p string) bool {
 	if idx == nil {
 		return false

--- a/pkg/fuse/open_handles.go
+++ b/pkg/fuse/open_handles.go
@@ -1,0 +1,167 @@
+package fuse
+
+import (
+	"strings"
+	"sync"
+)
+
+// OpenHandleIndex keeps O(1) indexes for currently open file handles.
+// It is intentionally separate from HandleTable so FUSE fh lookup remains a
+// simple id table while hot path lifecycle checks can avoid full-table scans.
+type OpenHandleIndex struct {
+	mu           sync.RWMutex
+	byInode      map[uint64]map[*FileHandle]struct{}
+	byPath       map[string]map[*FileHandle]struct{}
+	pathByHandle map[*FileHandle]string
+}
+
+func NewOpenHandleIndex() *OpenHandleIndex {
+	return &OpenHandleIndex{
+		byInode:      make(map[uint64]map[*FileHandle]struct{}),
+		byPath:       make(map[string]map[*FileHandle]struct{}),
+		pathByHandle: make(map[*FileHandle]string),
+	}
+}
+
+func (idx *OpenHandleIndex) Add(fh *FileHandle) {
+	if idx == nil || fh == nil {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	addHandleToSet(idx.byInode, fh.Ino, fh)
+	addHandleToSet(idx.byPath, fh.Path, fh)
+	idx.pathByHandle[fh] = fh.Path
+}
+
+func (idx *OpenHandleIndex) Remove(fh *FileHandle) {
+	if idx == nil || fh == nil {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	removeHandleFromSet(idx.byInode, fh.Ino, fh)
+	if p, ok := idx.pathByHandle[fh]; ok {
+		removeHandleFromSet(idx.byPath, p, fh)
+		delete(idx.pathByHandle, fh)
+	} else {
+		for p := range idx.byPath {
+			removeHandleFromSet(idx.byPath, p, fh)
+		}
+	}
+}
+
+func (idx *OpenHandleIndex) Has(ino uint64, p string) bool {
+	if idx == nil {
+		return false
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	if ino != 0 && len(idx.byInode[ino]) > 0 {
+		return true
+	}
+	return p != "" && len(idx.byPath[p]) > 0
+}
+
+func (idx *OpenHandleIndex) SnapshotPath(p string) []*FileHandle {
+	if idx == nil || p == "" {
+		return nil
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	handles := idx.byPath[p]
+	if len(handles) == 0 {
+		return nil
+	}
+	out := make([]*FileHandle, 0, len(handles))
+	for fh := range handles {
+		out = append(out, fh)
+	}
+	return out
+}
+
+func (idx *OpenHandleIndex) RenamePathPrefix(oldPath, newPath string) map[*FileHandle]string {
+	if idx == nil || oldPath == "" || newPath == "" {
+		return nil
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	oldPrefix := oldPath + "/"
+	type move struct {
+		from string
+		to   string
+	}
+	var moves []move
+	for p := range idx.byPath {
+		switch {
+		case p == oldPath:
+			moves = append(moves, move{from: p, to: newPath})
+		case strings.HasPrefix(p, oldPrefix):
+			moves = append(moves, move{from: p, to: newPath + strings.TrimPrefix(p, oldPath)})
+		}
+	}
+
+	retargeted := make(map[*FileHandle]string)
+	for _, mv := range moves {
+		handles := idx.byPath[mv.from]
+		delete(idx.byPath, mv.from)
+		for fh := range handles {
+			addHandleToSet(idx.byPath, mv.to, fh)
+			idx.pathByHandle[fh] = mv.to
+			retargeted[fh] = mv.to
+		}
+	}
+	if len(retargeted) == 0 {
+		return nil
+	}
+	return retargeted
+}
+
+func (idx *OpenHandleIndex) Path(fh *FileHandle) (string, bool) {
+	if idx == nil || fh == nil {
+		return "", false
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	p, ok := idx.pathByHandle[fh]
+	return p, ok
+}
+
+func addHandleToSet[K comparable](m map[K]map[*FileHandle]struct{}, key K, fh *FileHandle) {
+	handles := m[key]
+	if handles == nil {
+		handles = make(map[*FileHandle]struct{})
+		m[key] = handles
+	}
+	handles[fh] = struct{}{}
+}
+
+func removeHandleFromSet[K comparable](m map[K]map[*FileHandle]struct{}, key K, fh *FileHandle) {
+	handles := m[key]
+	if handles == nil {
+		return
+	}
+	delete(handles, fh)
+	if len(handles) == 0 {
+		delete(m, key)
+	}
+}
+
+func (fs *Dat9FS) allocateFileHandle(fh *FileHandle) uint64 {
+	fhID := fs.fileHandles.Allocate(fh)
+	fs.openHandles.Add(fh)
+	return fhID
+}
+
+func (fs *Dat9FS) deleteFileHandle(fhID uint64, fh *FileHandle) {
+	if fh == nil {
+		var ok bool
+		fh, ok = fs.fileHandles.Get(fhID)
+		if !ok {
+			return
+		}
+	}
+	fs.fileHandles.Delete(fhID)
+	fs.openHandles.Remove(fh)
+}

--- a/pkg/fuse/open_handles_test.go
+++ b/pkg/fuse/open_handles_test.go
@@ -39,6 +39,22 @@ func TestOpenHandleIndexTracksByInodeAndPath(t *testing.T) {
 	}
 }
 
+func TestOpenHandleIndexHasUsesConservativeOR(t *testing.T) {
+	idx := NewOpenHandleIndex()
+	idx.Add(&FileHandle{Ino: 10, Path: "/a.txt"})
+	idx.Add(&FileHandle{Ino: 11, Path: "/b.txt"})
+
+	if !idx.Has(10, "/b.txt") {
+		t.Fatal("Has should match an open inode or an open path")
+	}
+	if !idx.Has(11, "/a.txt") {
+		t.Fatal("Has should preserve OR semantics when both keys are supplied")
+	}
+	if idx.Has(99, "/missing.txt") {
+		t.Fatal("Has matched unrelated inode and path")
+	}
+}
+
 func TestOpenHandleIndexRenamePathPrefix(t *testing.T) {
 	idx := NewOpenHandleIndex()
 	file := &FileHandle{Ino: 10, Path: "/dir/a.txt"}

--- a/pkg/fuse/open_handles_test.go
+++ b/pkg/fuse/open_handles_test.go
@@ -1,0 +1,131 @@
+package fuse
+
+import (
+	"testing"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+)
+
+func TestOpenHandleIndexTracksByInodeAndPath(t *testing.T) {
+	idx := NewOpenHandleIndex()
+	fh1 := &FileHandle{Ino: 10, Path: "/a.txt"}
+	fh2 := &FileHandle{Ino: 11, Path: "/a.txt"}
+
+	idx.Add(fh1)
+	idx.Add(fh2)
+
+	if !idx.Has(10, "") {
+		t.Fatal("index missing inode 10")
+	}
+	if !idx.Has(0, "/a.txt") {
+		t.Fatal("index missing /a.txt")
+	}
+	if got := len(idx.SnapshotPath("/a.txt")); got != 2 {
+		t.Fatalf("SnapshotPath count = %d, want 2", got)
+	}
+
+	idx.Remove(fh1)
+	if idx.Has(10, "") {
+		t.Fatal("inode 10 remained after remove")
+	}
+	if !idx.Has(0, "/a.txt") {
+		t.Fatal("path removed while another handle is still open")
+	}
+
+	idx.Remove(fh2)
+	if idx.Has(11, "/a.txt") {
+		t.Fatal("handle remained after final remove")
+	}
+}
+
+func TestOpenHandleIndexRenamePathPrefix(t *testing.T) {
+	idx := NewOpenHandleIndex()
+	file := &FileHandle{Ino: 10, Path: "/dir/a.txt"}
+	child := &FileHandle{Ino: 11, Path: "/dir/sub/b.txt"}
+	other := &FileHandle{Ino: 12, Path: "/dir-other/c.txt"}
+	idx.Add(file)
+	idx.Add(child)
+	idx.Add(other)
+
+	retargeted := idx.RenamePathPrefix("/dir", "/renamed")
+
+	if idx.Has(0, "/dir/a.txt") || idx.Has(0, "/dir/sub/b.txt") {
+		t.Fatal("old paths remained indexed after rename")
+	}
+	if !idx.Has(0, "/renamed/a.txt") {
+		t.Fatal("renamed file path missing from index")
+	}
+	if !idx.Has(0, "/renamed/sub/b.txt") {
+		t.Fatal("renamed child path missing from index")
+	}
+	if retargeted[file] != "/renamed/a.txt" {
+		t.Fatalf("retargeted file path = %q, want /renamed/a.txt", retargeted[file])
+	}
+	if p, ok := idx.Path(child); !ok || p != "/renamed/sub/b.txt" {
+		t.Fatalf("Path(child) = %q, %t; want /renamed/sub/b.txt, true", p, ok)
+	}
+	if !idx.Has(0, "/dir-other/c.txt") {
+		t.Fatal("unrelated prefix path was changed")
+	}
+}
+
+func TestDat9FSFileHandleIndexLifecycle(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+
+	fh := &FileHandle{Ino: 20, Path: "/b.txt"}
+	fhID := fs.allocateFileHandle(fh)
+	if !fs.hasOpenHandle(20, "/b.txt") {
+		t.Fatal("allocated file handle was not indexed")
+	}
+
+	fs.deleteFileHandle(fhID, fh)
+	if fs.hasOpenHandle(20, "/b.txt") {
+		t.Fatal("deleted file handle remained indexed")
+	}
+	if _, ok := fs.fileHandles.Get(fhID); ok {
+		t.Fatal("deleted file handle remained in handle table")
+	}
+}
+
+func TestDat9FSFinishLocalRenameUpdatesOpenHandleIndex(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+
+	ino := fs.inodes.Lookup("/old.txt", false, 4, time.Now())
+	fh := &FileHandle{Ino: ino, Path: "/old.txt", Dirty: NewWriteBuffer("/old.txt", 0, 0)}
+	fh.Streamer = NewStreamUploader(fs.client, "/old.txt", -1, fs.remoteRoot())
+	fh.Prefetch = NewPrefetcher(fs.client, fs.remotePath("/old.txt"), 4)
+	fhID := fs.allocateFileHandle(fh)
+	defer fs.deleteFileHandle(fhID, fh)
+
+	fs.finishLocalRename(&gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Newdir:   1,
+	}, "/old.txt", "/new.txt")
+
+	if fs.hasOpenHandle(0, "/old.txt") {
+		t.Fatal("old path remained indexed after finishLocalRename")
+	}
+	if !fs.hasOpenHandle(0, "/new.txt") {
+		t.Fatal("new path was not indexed after finishLocalRename")
+	}
+	if fh.Path != "/new.txt" {
+		t.Fatalf("file handle path = %q, want /new.txt", fh.Path)
+	}
+	if fh.Dirty.path != "/new.txt" {
+		t.Fatalf("dirty buffer path = %q, want /new.txt", fh.Dirty.path)
+	}
+	if fh.Streamer.path != "/new.txt" {
+		t.Fatalf("streamer path = %q, want /new.txt", fh.Streamer.path)
+	}
+	if fh.Streamer.remotePath != "/new.txt" {
+		t.Fatalf("streamer remote path = %q, want /new.txt", fh.Streamer.remotePath)
+	}
+	if got := fh.Prefetch.pathString(); got != "/new.txt" {
+		t.Fatalf("prefetch path = %q, want /new.txt", got)
+	}
+}

--- a/pkg/fuse/prefetch.go
+++ b/pkg/fuse/prefetch.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
@@ -49,7 +50,7 @@ type Prefetcher struct {
 	cache      map[int64]*prefetchBlock
 	inflight   map[int64]bool
 	client     *client.Client
-	path       string
+	path       atomic.Value
 	fileSize   int64
 	cancel     context.CancelFunc // cancels all inflight prefetch goroutines
 	ctx        context.Context    // parent context for prefetch goroutines
@@ -65,22 +66,42 @@ func NewPrefetcher(c *client.Client, path string, fileSize int64, debug ...bool)
 	if len(debug) > 0 {
 		debugEnabled = debug[0]
 	}
-	return &Prefetcher{
+	p := &Prefetcher{
 		nextExpect: 0,
 		window:     prefetchMinWindow,
 		cache:      make(map[int64]*prefetchBlock),
 		inflight:   make(map[int64]bool),
 		client:     c,
-		path:       path,
 		fileSize:   fileSize,
 		ctx:        ctx,
 		cancel:     cancel,
 		debug:      debugEnabled,
 	}
+	p.path.Store(path)
+	return p
 }
 
 func (p *Prefetcher) SetPerfCounters(perf *fusePerfCounters) {
 	p.perf = perf
+}
+
+func (p *Prefetcher) SetPath(path string) {
+	if p == nil {
+		return
+	}
+	p.path.Store(path)
+}
+
+func (p *Prefetcher) pathString() string {
+	if p == nil {
+		return ""
+	}
+	if v := p.path.Load(); v != nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
 }
 
 func (p *Prefetcher) debugf(format string, args ...any) {
@@ -96,14 +117,14 @@ func (p *Prefetcher) Get(offset int64, size int) ([]byte, bool) {
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
-		p.debugf("get closed path=%s offset=%d size=%d", p.path, offset, size)
+		p.debugf("get closed path=%s offset=%d size=%d", p.pathString(), offset, size)
 		return nil, false
 	}
 	block, ok := p.cache[offset]
 	p.mu.Unlock()
 
 	if !ok {
-		p.debugf("miss path=%s offset=%d size=%d", p.path, offset, size)
+		p.debugf("miss path=%s offset=%d size=%d", p.pathString(), offset, size)
 		return nil, false
 	}
 
@@ -112,7 +133,7 @@ func (p *Prefetcher) Get(offset int64, size int) ([]byte, bool) {
 	select {
 	case <-block.ready:
 	case <-p.ctx.Done():
-		p.debugf("wait canceled path=%s offset=%d size=%d wait=%s", p.path, offset, size, time.Since(waitStart))
+		p.debugf("wait canceled path=%s offset=%d size=%d wait=%s", p.pathString(), offset, size, time.Since(waitStart))
 		return nil, false
 	}
 	wait := time.Since(waitStart)
@@ -124,7 +145,7 @@ func (p *Prefetcher) Get(offset int64, size int) ([]byte, bool) {
 			delete(p.cache, offset)
 		}
 		p.mu.Unlock()
-		p.debugf("block error path=%s offset=%d size=%d wait=%s err=%v", p.path, offset, size, wait, block.err)
+		p.debugf("block error path=%s offset=%d size=%d wait=%s err=%v", p.pathString(), offset, size, wait, block.err)
 		return nil, false
 	}
 
@@ -138,7 +159,7 @@ func (p *Prefetcher) Get(offset int64, size int) ([]byte, bool) {
 			delete(p.cache, offset)
 		}
 		p.mu.Unlock()
-		p.debugf("short block path=%s offset=%d req=%d got=%d file_size=%d wait=%s", p.path, offset, size, len(data), p.fileSize, wait)
+		p.debugf("short block path=%s offset=%d req=%d got=%d file_size=%d wait=%s", p.pathString(), offset, size, len(data), p.fileSize, wait)
 		return nil, false
 	}
 	if len(data) > size {
@@ -152,7 +173,7 @@ func (p *Prefetcher) Get(offset int64, size int) ([]byte, bool) {
 	}
 	p.mu.Unlock()
 
-	p.debugf("hit path=%s offset=%d req=%d got=%d wait=%s", p.path, offset, size, len(data), wait)
+	p.debugf("hit path=%s offset=%d req=%d got=%d wait=%s", p.pathString(), offset, size, len(data), wait)
 	return data, true
 }
 
@@ -189,7 +210,7 @@ func (p *Prefetcher) OnRead(offset int64, size int) {
 	} else {
 		// Random read — reset
 		if p.nextExpect != 0 || len(p.cache) > 0 || len(p.inflight) > 0 {
-			p.debugf("random reset path=%s offset=%d size=%d next_expect=%d cache=%d inflight=%d", p.path, offset, size, p.nextExpect, len(p.cache), len(p.inflight))
+			p.debugf("random reset path=%s offset=%d size=%d next_expect=%d cache=%d inflight=%d", p.pathString(), offset, size, p.nextExpect, len(p.cache), len(p.inflight))
 		}
 		p.window = prefetchMinWindow
 		// Clear stale cache
@@ -224,7 +245,7 @@ func (p *Prefetcher) Close() {
 	for k := range p.inflight {
 		delete(p.inflight, k)
 	}
-	p.debugf("close path=%s cache=%d inflight=%d", p.path, cacheLen, inflightLen)
+	p.debugf("close path=%s cache=%d inflight=%d", p.pathString(), cacheLen, inflightLen)
 }
 
 // startPrefetch launches a background fetch. Caller must hold p.mu.
@@ -291,7 +312,8 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 	}
 	// Mark the fetch start as inflight (not each chunk — OnRead checks start offset).
 	p.inflight[offset] = true
-	p.debugf("start path=%s offset=%d length=%d chunk_size=%d chunks=%d window=%d", p.path, offset, length, chunkSize, nChunks, p.window)
+	fetchPath := p.pathString()
+	p.debugf("start path=%s offset=%d length=%d chunk_size=%d chunks=%d window=%d", fetchPath, offset, length, chunkSize, nChunks, p.window)
 
 	ctx := p.ctx
 	go func() {
@@ -303,7 +325,7 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 			close(ready)
 		}()
 
-		rc, err := p.client.ReadStreamRange(ctx, p.path, offset, length)
+		rc, err := p.client.ReadStreamRange(ctx, fetchPath, offset, length)
 		if err != nil {
 			if p.perf != nil {
 				p.perf.recordRemoteOp(perfRemoteRead, err, time.Since(start), 0)
@@ -311,7 +333,7 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 			for _, b := range blocks {
 				b.err = err
 			}
-			p.debugf("fetch open error path=%s offset=%d length=%d dur=%s err=%v", p.path, offset, length, time.Since(start), err)
+			p.debugf("fetch open error path=%s offset=%d length=%d dur=%s err=%v", fetchPath, offset, length, time.Since(start), err)
 			return
 		}
 		defer func() { _ = rc.Close() }()
@@ -324,7 +346,7 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 			for _, b := range blocks {
 				b.err = err
 			}
-			p.debugf("fetch read error path=%s offset=%d length=%d got=%d dur=%s err=%v", p.path, offset, length, len(data), time.Since(start), err)
+			p.debugf("fetch read error path=%s offset=%d length=%d got=%d dur=%s err=%v", fetchPath, offset, length, len(data), time.Since(start), err)
 			return
 		}
 
@@ -344,6 +366,6 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 			copy(chunk, data[start:end])
 			b.data = chunk
 		}
-		p.debugf("fetch done path=%s offset=%d length=%d got=%d chunks=%d dur=%s", p.path, offset, length, len(data), nChunks, time.Since(start))
+		p.debugf("fetch done path=%s offset=%d length=%d got=%d chunks=%d dur=%s", fetchPath, offset, length, len(data), nChunks, time.Since(start))
 	}()
 }

--- a/pkg/fuse/readdir_prefetch.go
+++ b/pkg/fuse/readdir_prefetch.go
@@ -127,8 +127,14 @@ func (fs *Dat9FS) hasLocalWriteState(p string) bool {
 			return true
 		}
 	}
-	for _, fh := range fs.fileHandles.Snapshot() {
-		if fh != nil && fh.Path == p && fh.Dirty != nil {
+	for _, fh := range fs.openHandles.SnapshotPath(p) {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		dirty := fh.Dirty != nil
+		fh.Unlock()
+		if dirty {
 			return true
 		}
 	}

--- a/pkg/fuse/stream_upload.go
+++ b/pkg/fuse/stream_upload.go
@@ -89,6 +89,19 @@ func (su *StreamUploader) ExpectedRevision() int64 {
 	return su.expectedRevision
 }
 
+// SetPath retargets future uploads for an open handle that was renamed before
+// its buffered data was committed.
+func (su *StreamUploader) SetPath(path string, remoteRoot ...string) {
+	root := "/"
+	if len(remoteRoot) > 0 && remoteRoot[0] != "" {
+		root = remoteRoot[0]
+	}
+	su.mu.Lock()
+	defer su.mu.Unlock()
+	su.path = path
+	su.remotePath = mountpath.ToRemote(root, path)
+}
+
 // ResetForNextWrite prepares the uploader for another flush cycle after a
 // successful commit on the same open handle.
 func (su *StreamUploader) ResetForNextWrite(revision int64) {
@@ -276,12 +289,13 @@ func (su *StreamUploader) UploadAll(ctx context.Context, totalSize int64, partDa
 func (su *StreamUploader) Abort() {
 	su.mu.Lock()
 	sw := su.writer
+	path := su.path
 	su.pendingParts = make(map[int][]byte) // release buffered data
 	su.mu.Unlock()
 
 	if sw != nil {
 		if err := sw.Abort(context.Background()); err != nil {
-			log.Printf("stream upload abort failed for %s: %v", su.path, err)
+			log.Printf("stream upload abort failed for %s: %v", path, err)
 		}
 	}
 }

--- a/pkg/mountstate/pid.go
+++ b/pkg/mountstate/pid.go
@@ -38,7 +38,7 @@ func WritePID(mountPoint string, pid int) (string, error) {
 		return "", fmt.Errorf("invalid pid %d", pid)
 	}
 	path := PIDFilePath(mountPoint)
-	if err := os.WriteFile(path, []byte(strconv.Itoa(pid)+"\n"), 0o644); err != nil {
+	if err := writeFileAtomic(path, []byte(strconv.Itoa(pid)+"\n"), 0o644); err != nil {
 		return "", err
 	}
 	return path, nil
@@ -53,10 +53,43 @@ func WriteProcessState(mountPoint string, state ProcessState) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal process state: %w", err)
 	}
-	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+	if err := writeFileAtomic(path, append(data, '\n'), 0o644); err != nil {
 		return "", err
 	}
 	return path, nil
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
 }
 
 func ReadPID(mountPoint string) (int, string, error) {

--- a/pkg/mountstate/pid.go
+++ b/pkg/mountstate/pid.go
@@ -1,6 +1,7 @@
 package mountstate
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -62,7 +63,7 @@ func WriteProcessState(mountPoint string, state ProcessState) (string, error) {
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)
-	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	tmp, err := createTempFile(dir, "."+base+".tmp-", perm)
 	if err != nil {
 		return err
 	}
@@ -78,18 +79,34 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 		_ = tmp.Close()
 		return err
 	}
-	if err := tmp.Chmod(perm); err != nil {
-		_ = tmp.Close()
-		return err
-	}
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := replaceFile(tmpPath, path); err != nil {
 		return err
 	}
 	cleanup = false
 	return nil
+}
+
+func createTempFile(dir, prefix string, perm os.FileMode) (*os.File, error) {
+	var lastErr error
+	for range 100 {
+		var suffix [8]byte
+		if _, err := rand.Read(suffix[:]); err != nil {
+			return nil, err
+		}
+		name := filepath.Join(dir, prefix+hex.EncodeToString(suffix[:]))
+		f, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, perm)
+		if err == nil {
+			return f, nil
+		}
+		if !os.IsExist(err) {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("create temporary pid file: %w", lastErr)
 }
 
 func ReadPID(mountPoint string) (int, string, error) {

--- a/pkg/mountstate/pid_test.go
+++ b/pkg/mountstate/pid_test.go
@@ -98,6 +98,37 @@ func TestWriteReadProcessState(t *testing.T) {
 	}
 }
 
+func TestWriteProcessStateReplacesExistingFile(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "mnt")
+
+	path, err := WriteProcessState(mountPoint, ProcessState{PID: 111, CreationTime: 1})
+	if err != nil {
+		t.Fatalf("initial WriteProcessState: %v", err)
+	}
+	defer func() { _ = os.Remove(path) }()
+
+	if _, err := WriteProcessState(mountPoint, ProcessState{PID: 222, CreationTime: 2}); err != nil {
+		t.Fatalf("replacement WriteProcessState: %v", err)
+	}
+	got, gotPath, err := ReadProcessState(mountPoint)
+	if err != nil {
+		t.Fatalf("ReadProcessState: %v", err)
+	}
+	if got != (ProcessState{PID: 222, CreationTime: 2}) {
+		t.Fatalf("ReadProcessState = %#v, want replacement state", got)
+	}
+	if gotPath != path {
+		t.Fatalf("ReadProcessState path = %q, want %q", gotPath, path)
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*"))
+	if err != nil {
+		t.Fatalf("glob temp pid files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("left temporary pid files: %v", matches)
+	}
+}
+
 func TestReadProcessStateSupportsLegacyPIDFile(t *testing.T) {
 	mountPoint := filepath.Join(t.TempDir(), "mnt")
 	path := PIDFilePath(mountPoint)

--- a/pkg/mountstate/pid_umask_test.go
+++ b/pkg/mountstate/pid_umask_test.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package mountstate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWritePIDHonorsUmask(t *testing.T) {
+	mountPoint := filepath.Join(t.TempDir(), "mnt")
+	oldUmask := setUmask(0o077)
+	t.Cleanup(func() { _ = setUmask(oldUmask) })
+
+	path, err := WritePID(mountPoint, 12345)
+	if err != nil {
+		t.Fatalf("WritePID: %v", err)
+	}
+	defer func() { _ = os.Remove(path) }()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat pid file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("pid file mode = %o, want 600 with umask 077", got)
+	}
+}

--- a/pkg/mountstate/replace_unix.go
+++ b/pkg/mountstate/replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package mountstate
+
+import "os"
+
+func replaceFile(oldPath, newPath string) error {
+	return os.Rename(oldPath, newPath)
+}

--- a/pkg/mountstate/replace_windows.go
+++ b/pkg/mountstate/replace_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package mountstate
+
+import "golang.org/x/sys/windows"
+
+func replaceFile(oldPath, newPath string) error {
+	from, err := windows.UTF16PtrFromString(oldPath)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(newPath)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}

--- a/pkg/mountstate/umask_unix_test.go
+++ b/pkg/mountstate/umask_unix_test.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package mountstate
+
+import "syscall"
+
+func setUmask(mask int) int {
+	return syscall.Umask(mask)
+}


### PR DESCRIPTION
## Summary
- fix mount option default handling so interactive profile TTLs and FUSE lookup retry defaults take effect unless explicitly overridden
- add an open-handle index and use it for hot path handle/path checks instead of full handle-table scans
- retarget open FUSE handles, write buffers, stream uploaders, and prefetchers after local rename
- reduce handle table lookup contention with RWMutex and skip the fuseCtx goroutine when cancel is nil

## Tests
- go test ./pkg/fuse ./cmd/drive9/cli
- go test -race ./pkg/fuse -run 'Test(FuseCtx|OpenHandleIndex|Dat9FSFinishLocalRenameUpdatesOpenHandleIndex)'\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mount flags now distinguish omitted vs explicitly provided lookup-retry and TTL values
  * Improved context cancellation and rename handling to keep open-file state consistent
  * PID/process-state files are now written atomically

* **New Features**
  * Track open writable handles in a dedicated index for accurate lookups and retargeting
  * Prefetcher and uploaders can safely update target paths at runtime

* **Performance**
  * Concurrent-read locking for handle tables and faster open-handle lookups

* **Tests**
  * Added tests covering TTL defaults, lookup-retry validation, open-handle index, prefetch/rename, and atomic PID writes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/417)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->