### PR TITLE
Optimize delete performance

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -215,29 +215,33 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 		}
 	}
 
-	err = b.store.InsertFile(ctx, &datastore.File{
-		FileID: fileID, StorageType: storageType, StorageRef: storageRef,
-		StorageEncryptionMode:  storageEncryptionMode,
-		StorageEncryptionKeyID: storageEncryptionKeyID,
-		ContentBlob:            contentBlob,
-		SizeBytes:              0, Revision: 1, Status: datastore.StatusConfirmed,
-		CreatedAt: now, ConfirmedAt: &now,
+	err = b.store.InTx(ctx, func(tx *sql.Tx) error {
+		if err := b.store.InsertFileTx(tx, &datastore.File{
+			FileID: fileID, StorageType: storageType, StorageRef: storageRef,
+			StorageEncryptionMode:  storageEncryptionMode,
+			StorageEncryptionKeyID: storageEncryptionKeyID,
+			ContentBlob:            contentBlob,
+			SizeBytes:              0, Revision: 1, Status: datastore.StatusConfirmed,
+			CreatedAt: now, ConfirmedAt: &now,
+		}); err != nil {
+			return err
+		}
+		if err := b.store.EnsureParentDirsTx(tx, path, b.genID); err != nil {
+			return err
+		}
+		return b.store.InsertNodeTx(tx, &datastore.FileNode{
+			NodeID: b.genID(), Path: path, ParentPath: pathutil.ParentPath(path),
+			Name: pathutil.BaseName(path), FileID: fileID, CreatedAt: now,
+		})
 	})
 	if err != nil {
+		if storageType == datastore.StorageS3 {
+			b.deleteBlobCtx(ctx, storageRef)
+		}
 		return err
 	}
-	err = b.store.EnsureParentDirs(ctx, path, b.genID)
-	if err != nil {
-		return err
-	}
-	err = b.store.InsertNode(ctx, &datastore.FileNode{
-		NodeID: b.genID(), Path: path, ParentPath: pathutil.ParentPath(path),
-		Name: pathutil.BaseName(path), FileID: fileID, CreatedAt: now,
-	})
-	if err == nil {
-		b.syncCentralFileCreate(ctx, fileID, 0, "")
-	}
-	return err
+	b.syncCentralFileCreate(ctx, fileID, 0, "")
+	return nil
 }
 
 func (b *Dat9Backend) Mkdir(path string, perm uint32) error {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -78,8 +78,8 @@ type Dat9Backend struct {
 	inlineThreshold int64
 	// textExtractMaxBytes caps synchronous text extraction input size.
 	textExtractMaxBytes int64
-	mu                    sync.Mutex
-	entropy               io.Reader
+	mu                  sync.Mutex
+	entropy             io.Reader
 
 	// Central quota enforcement (Rev 4 migration).
 	tenantID    string
@@ -105,7 +105,7 @@ type Dat9Backend struct {
 	audioExtractMaxSize      int64
 	maxAudioExtractTextBytes int
 
-	fileGCWorker *FileGCWorker
+	fileGCWorker     *FileGCWorker
 	runtimeMetricsID uint64
 
 	// Monthly LLM cost budget (P1).
@@ -282,6 +282,29 @@ func (b *Dat9Backend) RemoveCtx(ctx context.Context, path string) (err error) {
 	return err
 }
 
+func (b *Dat9Backend) RemoveFileCtx(ctx context.Context, path string) (err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "remove_file", err, start) }()
+
+	path, err = pathutil.Canonicalize(path)
+	if err != nil {
+		return err
+	}
+	_, err = b.store.DeleteFileWithRefCheck(ctx, path)
+	return err
+}
+
+func (b *Dat9Backend) RemoveDirCtx(ctx context.Context, path string) (err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "remove_dir", err, start) }()
+
+	path, err = pathutil.CanonicalizeDir(path)
+	if err != nil {
+		return err
+	}
+	return b.store.DeleteEmptyDir(ctx, path)
+}
+
 func (b *Dat9Backend) RemoveAll(path string) error {
 	return b.RemoveAllCtx(backgroundWithTrace(), path)
 }
@@ -295,7 +318,8 @@ func (b *Dat9Backend) RemoveAllCtx(ctx context.Context, path string) (err error)
 		return err
 	}
 	if !node.IsDirectory {
-		return b.RemoveCtx(ctx, path)
+		_, err = b.store.DeleteFileWithRefCheck(ctx, path)
+		return err
 	}
 	_, err = b.store.DeleteDirRecursive(ctx, path)
 	return err

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
@@ -60,6 +61,76 @@ func TestCreateAndStat(t *testing.T) {
 	}
 	if info.Name != "hello.txt" || info.IsDir || info.Size != 0 {
 		t.Errorf("unexpected: %+v", info)
+	}
+}
+
+func TestCreateDuplicateDoesNotLeaveOrphanFileOrObject(t *testing.T) {
+	ctx := context.Background()
+	s3Dir, err := os.MkdirTemp("", "dat9-s3-create-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
+
+	initBackendSchema(t, testDSN)
+	store, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetDB(t, store.DB())
+	t.Cleanup(func() { _ = store.Close() })
+
+	s3c, err := s3client.NewLocal(s3Dir, "/s3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := NewWithS3Mode(store, s3c, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { b.Close() })
+
+	if err := b.CreateCtx(ctx, "/empty.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.CreateCtx(ctx, "/empty.txt"); !errors.Is(err, datastore.ErrPathConflict) {
+		t.Fatalf("duplicate CreateCtx error = %v, want ErrPathConflict", err)
+	}
+
+	var files int
+	if err := store.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM files`).Scan(&files); err != nil {
+		t.Fatal(err)
+	}
+	if files != 1 {
+		t.Fatalf("files rows = %d, want 1", files)
+	}
+	var orphans int
+	if err := store.DB().QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM files f
+		LEFT JOIN file_nodes fn ON fn.file_id = f.file_id
+		WHERE fn.file_id IS NULL`).Scan(&orphans); err != nil {
+		t.Fatal(err)
+	}
+	if orphans != 0 {
+		t.Fatalf("orphan files = %d, want 0", orphans)
+	}
+
+	objectCount := 0
+	objectsRoot := filepath.Join(s3Dir, "objects")
+	err = filepath.WalkDir(objectsRoot, func(_ string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.Type().IsRegular() {
+			objectCount++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if objectCount != 1 {
+		t.Fatalf("s3 object count = %d, want 1", objectCount)
 	}
 }
 

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -419,6 +419,37 @@ func TestRemove(t *testing.T) {
 	}
 }
 
+func TestRemoveFileAndDirCtxUseTypedPaths(t *testing.T) {
+	b := newTestBackend(t)
+	ctx := context.Background()
+
+	if _, err := b.Write("/f.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Mkdir("/empty", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Mkdir("/dir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/g.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.RemoveFileCtx(ctx, "/dir/"); err != datastore.ErrNotFound {
+		t.Fatalf("RemoveFileCtx dir error = %v, want ErrNotFound", err)
+	}
+	if err := b.RemoveDirCtx(ctx, "/g.txt"); err != datastore.ErrNotFound {
+		t.Fatalf("RemoveDirCtx file error = %v, want ErrNotFound", err)
+	}
+	if err := b.RemoveFileCtx(ctx, "/f.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.RemoveDirCtx(ctx, "/empty"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRemoveAll(t *testing.T) {
 	b := newTestBackend(t)
 	if err := b.Mkdir("/data", 0o755); err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -779,7 +779,17 @@ func (c *Client) Delete(path string) error {
 
 // DeleteCtx removes a file or directory with context support.
 func (c *Client) DeleteCtx(ctx context.Context, path string) error {
-	return c.deleteCtx(ctx, path, false)
+	return c.deleteCtx(ctx, path, false, "")
+}
+
+// DeleteFileCtx removes a file with a server-side type hint.
+func (c *Client) DeleteFileCtx(ctx context.Context, path string) error {
+	return c.deleteCtx(ctx, path, false, "file")
+}
+
+// DeleteDirCtx removes an empty directory with a server-side type hint.
+func (c *Client) DeleteDirCtx(ctx context.Context, path string) error {
+	return c.deleteCtx(ctx, path, false, "dir")
 }
 
 // RemoveAll removes a file or directory tree recursively.
@@ -794,14 +804,16 @@ func (c *Client) RemoveAll(path string) error {
 // It forwards to deleteCtx with recursive=true, so regular files use Delete
 // semantics and missing paths return the same 404 *StatusError as RemoveAll.
 func (c *Client) RemoveAllCtx(ctx context.Context, path string) error {
-	return c.deleteCtx(ctx, path, true)
+	return c.deleteCtx(ctx, path, true, "")
 }
 
-func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool) error {
+func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kind string) error {
 	requestURL := c.url(path)
 	if recursive {
 		// Use an explicit value to avoid intermediaries dropping bare "?recursive".
 		requestURL += "?recursive=1"
+	} else if kind != "" {
+		requestURL += "?kind=" + url.QueryEscape(kind)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -490,7 +490,10 @@ func (c *Client) CreateFileCtx(ctx context.Context, path string) (int64, error) 
 		Revision int64 `json:"revision"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return 0, nil
+		if errors.Is(err, io.EOF) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("decode create file response: %w", err)
 	}
 	return result.Revision, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -474,7 +474,7 @@ func (c *Client) CreateFile(path string) (int64, error) {
 // CreateFileCtx creates an empty file with context support and returns the
 // committed file revision when the server reports it.
 func (c *Client) CreateFileCtx(ctx context.Context, path string) (int64, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path)+"?create", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path)+"?create=1", nil)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -466,6 +466,35 @@ func (c *Client) WriteCtxConditionalWithRevision(ctx context.Context, path strin
 	return c.writeCtxConditionalFull(ctx, path, data, expectedRevision, nil, "")
 }
 
+// CreateFile creates an empty file.
+func (c *Client) CreateFile(path string) (int64, error) {
+	return c.CreateFileCtx(context.Background(), path)
+}
+
+// CreateFileCtx creates an empty file with context support and returns the
+// committed file revision when the server reports it.
+func (c *Client) CreateFileCtx(ctx context.Context, path string) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path)+"?create", nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return 0, readError(resp)
+	}
+	var result struct {
+		Revision int64 `json:"revision"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, nil
+	}
+	return result.Revision, nil
+}
+
 func (c *Client) writeCtxConditionalFull(ctx context.Context, path string, data []byte, expectedRevision int64, tags map[string]string, description string) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(path), bytes.NewReader(data))
 	if err != nil {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -644,6 +644,33 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestDeleteKindHints(t *testing.T) {
+	var got []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, r.URL.RawQuery)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	if err := c.DeleteFileCtx(context.Background(), "/file.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.DeleteDirCtx(context.Background(), "/dir/"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("requests = %d, want 2", len(got))
+	}
+	if got[0] != "kind=file" {
+		t.Fatalf("file delete query = %q, want kind=file", got[0])
+	}
+	if got[1] != "kind=dir" {
+		t.Fatalf("dir delete query = %q, want kind=dir", got[1])
+	}
+}
+
 func TestRemoveAll(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -569,6 +569,31 @@ func TestStatCtxPreservesStatusErrorOnNotFound(t *testing.T) {
 	}
 }
 
+func TestCreateFileCtxPostsCreateActionAndReturnsRevision(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/fs/empty.txt" {
+			t.Errorf("path = %s, want /v1/fs/empty.txt", r.URL.Path)
+		}
+		if !r.URL.Query().Has("create") {
+			t.Errorf("query = %q, want create action", r.URL.RawQuery)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(1)})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	rev, err := c.CreateFileCtx(context.Background(), "/empty.txt")
+	if err != nil {
+		t.Fatalf("CreateFileCtx error = %v", err)
+	}
+	if rev != 1 {
+		t.Fatalf("revision = %d, want 1", rev)
+	}
+}
+
 func TestWriteCtxConditionalWithTagsRejectsInvalidHeaderTags(t *testing.T) {
 	requests := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -577,8 +577,8 @@ func TestCreateFileCtxPostsCreateActionAndReturnsRevision(t *testing.T) {
 		if r.URL.Path != "/v1/fs/empty.txt" {
 			t.Errorf("path = %s, want /v1/fs/empty.txt", r.URL.Path)
 		}
-		if !r.URL.Query().Has("create") {
-			t.Errorf("query = %q, want create action", r.URL.RawQuery)
+		if got := r.URL.Query().Get("create"); got != "1" {
+			t.Errorf("create query = %q, want 1", got)
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(1)})
 	}))

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -594,6 +594,22 @@ func TestCreateFileCtxPostsCreateActionAndReturnsRevision(t *testing.T) {
 	}
 }
 
+func TestCreateFileCtxReturnsMalformedJSONError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("{"))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	_, err := c.CreateFileCtx(context.Background(), "/empty.txt")
+	if err == nil {
+		t.Fatal("CreateFileCtx error = nil, want decode error")
+	}
+	if !strings.Contains(err.Error(), "decode create file response:") {
+		t.Fatalf("error = %v, want decode create file response error", err)
+	}
+}
+
 func TestWriteCtxConditionalWithTagsRejectsInvalidHeaderTags(t *testing.T) {
 	requests := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -256,11 +256,11 @@ func (s *Store) DeleteEmptyDir(ctx context.Context, path string) (err error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	var count int64
-	if err := tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE parent_path = ?`, path).Scan(&count); err != nil {
+	hasChildren, err := dirHasChildrenTx(tx, path)
+	if err != nil {
 		return err
 	}
-	if count > 0 {
+	if hasChildren {
 		return fmt.Errorf("directory not empty: %s", path)
 	}
 	res, err := tx.Exec(`DELETE FROM file_nodes WHERE path = ? AND is_directory = 1`, path)
@@ -279,8 +279,8 @@ func (s *Store) DeleteNodesByPrefix(ctx context.Context, prefix string) (n int64
 	start := time.Now()
 	defer observeStoreOp(ctx, "delete_nodes_by_prefix", start, &err)
 
-	res, err := s.db.ExecContext(ctx, `DELETE FROM file_nodes WHERE path = ? OR path LIKE ?`,
-		prefix, prefix+"%")
+	where, args := pathPrefixPredicate("path", prefix)
+	res, err := s.db.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+where, args...)
 	if err != nil {
 		return 0, err
 	}
@@ -1056,22 +1056,23 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 		}
 		return nil, err
 	}
+	if isDir {
+		return nil, ErrNotFound
+	}
 
 	if _, err := tx.Exec(`DELETE FROM file_nodes WHERE path = ?`, path); err != nil {
 		return nil, err
 	}
 
-	if isDir || !fileID.Valid || fileID.String == "" {
+	if !fileID.Valid || fileID.String == "" {
 		return nil, tx.Commit()
 	}
 
-	var count int64
-	err = tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE file_id = ? FOR UPDATE`, fileID.String).Scan(&count)
+	stillReferenced, err := fileIDExistsTx(tx, fileID.String)
 	if err != nil {
 		return nil, err
 	}
-
-	if count > 0 {
+	if stillReferenced {
 		return nil, tx.Commit()
 	}
 
@@ -1115,58 +1116,26 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	rows, err := tx.Query(`SELECT DISTINCT file_id FROM file_nodes
-		WHERE (path = ? OR path LIKE ?) AND file_id IS NOT NULL`, dirPath, dirPath+"%")
+	orphaned, err := orphanedFilesByPathPrefixTx(tx, dirPath)
 	if err != nil {
 		return nil, err
 	}
-	var fileIDs []string
-	for rows.Next() {
-		var fid string
-		if err := rows.Scan(&fid); err != nil {
-			_ = rows.Close()
-			return nil, err
-		}
-		fileIDs = append(fileIDs, fid)
-	}
-	_ = rows.Close()
 
-	if _, err := tx.Exec(`DELETE FROM file_nodes WHERE path = ? OR path LIKE ?`,
-		dirPath, dirPath+"%"); err != nil {
+	deleteWhere, deleteArgs := pathPrefixPredicate("path", dirPath)
+	if _, err := tx.Exec(`DELETE FROM file_nodes WHERE `+deleteWhere, deleteArgs...); err != nil {
 		return nil, err
 	}
 
-	var orphaned []*File
-	for _, fid := range fileIDs {
-		var count int64
-		if err := tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE file_id = ?`, fid).Scan(&count); err != nil {
+	if len(orphaned) > 0 {
+		if err := markFilesDeletedTx(tx, orphaned); err != nil {
 			return nil, err
 		}
-		if count > 0 {
-			continue
-		}
-		if _, err := tx.Exec(`UPDATE files SET status = 'DELETED' WHERE file_id = ?`, fid); err != nil {
+		if err := deleteFileTagsTx(tx, orphaned); err != nil {
 			return nil, err
 		}
-		if _, err := tx.Exec(`DELETE FROM file_tags WHERE file_id = ?`, fid); err != nil {
+		if err := enqueueFileGCTasksTx(tx, orphaned, time.Now().UTC()); err != nil {
 			return nil, err
 		}
-		row := tx.QueryRow(`SELECT file_id, storage_type, storage_ref, storage_encryption_mode,
-			storage_encryption_key_id, content_type, size_bytes, checksum_sha256,
-			revision, embedding_revision, status, source_id, created_at, confirmed_at, expires_at
-			FROM files WHERE file_id = ?`, fid)
-		f, err := scanFileForGC(row)
-		if err != nil {
-			return nil, err
-		}
-		task, err := NewFileGCTaskFromFile(f, time.Now().UTC())
-		if err != nil {
-			return nil, err
-		}
-		if _, err := s.EnqueueFileGCTaskTx(tx, task); err != nil {
-			return nil, err
-		}
-		orphaned = append(orphaned, f)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -1174,6 +1143,173 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 	}
 	out = orphaned
 	return out, nil
+}
+
+const deleteBatchSize = 500
+
+func fileIDExistsTx(tx *sql.Tx, fileID string) (bool, error) {
+	var one int
+	err := tx.QueryRow(`SELECT 1 FROM file_nodes WHERE file_id = ? LIMIT 1 FOR UPDATE`, fileID).Scan(&one)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, err
+}
+
+func dirHasChildrenTx(tx *sql.Tx, path string) (bool, error) {
+	var one int
+	err := tx.QueryRow(`SELECT 1 FROM file_nodes WHERE parent_path = ? LIMIT 1 FOR UPDATE`, path).Scan(&one)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, err
+}
+
+func orphanedFilesByPathPrefixTx(tx *sql.Tx, dirPath string) ([]*File, error) {
+	subtreeWhere, subtreeArgs := pathPrefixPredicate("fn.path", dirPath)
+	outsideWhere, outsideArgs := pathPrefixPredicate("live.path", dirPath)
+	args := make([]any, 0, len(subtreeArgs)+len(outsideArgs))
+	args = append(args, subtreeArgs...)
+	args = append(args, outsideArgs...)
+
+	rows, err := tx.Query(`SELECT DISTINCT f.file_id, f.storage_type, f.storage_ref, f.storage_encryption_mode,
+			f.storage_encryption_key_id, f.content_type, f.size_bytes, f.checksum_sha256,
+			f.revision, f.embedding_revision, f.status, f.source_id, f.created_at, f.confirmed_at, f.expires_at
+		FROM file_nodes fn
+		JOIN files f ON f.file_id = fn.file_id
+		WHERE (`+subtreeWhere+`)
+			AND fn.file_id IS NOT NULL
+			AND NOT EXISTS (
+				SELECT 1 FROM file_nodes live
+				WHERE live.file_id = fn.file_id
+					AND NOT (`+outsideWhere+`)
+				LIMIT 1
+			)
+		FOR UPDATE`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*File
+	for rows.Next() {
+		f, err := scanFileForGC(rows)
+		if err != nil {
+			return nil, err
+		}
+		f.Status = StatusDeleted
+		out = append(out, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func markFilesDeletedTx(tx *sql.Tx, files []*File) error {
+	return forEachFileBatch(files, func(batch []*File) error {
+		query, args := fileIDInQuery(`UPDATE files SET status = ? WHERE file_id IN `, StatusDeleted, batch)
+		_, err := tx.Exec(query, args...)
+		return err
+	})
+}
+
+func deleteFileTagsTx(tx *sql.Tx, files []*File) error {
+	return forEachFileBatch(files, func(batch []*File) error {
+		query, args := fileIDInQuery(`DELETE FROM file_tags WHERE file_id IN `, nil, batch)
+		_, err := tx.Exec(query, args...)
+		return err
+	})
+}
+
+func enqueueFileGCTasksTx(tx *sql.Tx, files []*File, now time.Time) error {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	return forEachFileBatch(files, func(batch []*File) error {
+		var b strings.Builder
+		b.WriteString(`INSERT IGNORE INTO file_gc_tasks
+			(task_id, file_id, storage_type, storage_ref, size_bytes, content_type,
+			 status, attempt_count, max_attempts, receipt, leased_at, lease_until,
+			 available_at, last_error, created_at, updated_at, completed_at)
+			VALUES `)
+		args := make([]any, 0, len(batch)*17)
+		for i, f := range batch {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+			args = append(args,
+				f.FileID, f.FileID, f.StorageType, f.StorageRef, f.SizeBytes, nullStr(f.ContentType),
+				FileGCTaskQueued, 0, defaultFileGCMaxAttempts, nil, nil, nil,
+				now, nil, now, now, nil,
+			)
+		}
+		_, err := tx.Exec(b.String(), args...)
+		return err
+	})
+}
+
+func forEachFileBatch(files []*File, fn func([]*File) error) error {
+	for start := 0; start < len(files); start += deleteBatchSize {
+		end := start + deleteBatchSize
+		if end > len(files) {
+			end = len(files)
+		}
+		if err := fn(files[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func fileIDInQuery(prefix string, firstArg any, files []*File) (string, []any) {
+	var b strings.Builder
+	b.WriteString(prefix)
+	b.WriteString("(")
+	args := make([]any, 0, len(files)+1)
+	if firstArg != nil {
+		args = append(args, firstArg)
+	}
+	for i, f := range files {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString("?")
+		args = append(args, f.FileID)
+	}
+	b.WriteString(")")
+	return b.String(), args
+}
+
+func pathPrefixPredicate(column, prefix string) (string, []any) {
+	upper, ok := nextPathPrefix(prefix)
+	if !ok {
+		return column + " = ? OR " + column + " >= ?", []any{prefix, prefix}
+	}
+	return column + " = ? OR (" + column + " >= ? AND " + column + " < ?)", []any{prefix, prefix, upper}
+}
+
+func nextPathPrefix(prefix string) (string, bool) {
+	if prefix == "" {
+		return "", false
+	}
+	b := []byte(prefix)
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] != 0xff {
+			b[i]++
+			return string(b[:i+1]), true
+		}
+	}
+	return "", false
 }
 
 // --- uploads operations ---

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1275,25 +1275,7 @@ func fileIDInQuery(prefix string, firstArg any, files []*File) (string, []any) {
 }
 
 func pathPrefixPredicate(column, prefix string) (string, []any) {
-	upper, ok := nextPathPrefix(prefix)
-	if !ok {
-		return column + " = ? OR " + column + " >= ?", []any{prefix, prefix}
-	}
-	return column + " = ? OR (" + column + " >= ? AND " + column + " < ?)", []any{prefix, prefix, upper}
-}
-
-func nextPathPrefix(prefix string) (string, bool) {
-	if prefix == "" {
-		return "", false
-	}
-	b := []byte(prefix)
-	for i := len(b) - 1; i >= 0; i-- {
-		if b[i] != 0xff {
-			b[i]++
-			return string(b[:i+1]), true
-		}
-	}
-	return "", false
+	return "BINARY " + column + " LIKE BINARY ? ESCAPE '\\\\'", []any{likeLiteralPrefixPattern(prefix)}
 }
 
 // --- uploads operations ---

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -256,14 +256,14 @@ func (s *Store) DeleteEmptyDir(ctx context.Context, path string) (err error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	hasChildren, err := dirHasChildrenTx(tx, path)
+	hasChildren, err := dirHasChildrenTx(ctx, tx, path)
 	if err != nil {
 		return err
 	}
 	if hasChildren {
 		return fmt.Errorf("directory not empty: %s", path)
 	}
-	res, err := tx.Exec(`DELETE FROM file_nodes WHERE path = ? AND is_directory = 1`, path)
+	res, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE path = ? AND is_directory = 1`, path)
 	if err != nil {
 		return err
 	}
@@ -1047,28 +1047,23 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	var fileID sql.NullString
-	var isDir bool
-	err = tx.QueryRow(`SELECT file_id, is_directory FROM file_nodes WHERE path = ? FOR UPDATE`, path).Scan(&fileID, &isDir)
+	row := tx.QueryRowContext(ctx, `SELECT f.file_id, f.storage_type, f.storage_ref, f.storage_encryption_mode,
+		f.storage_encryption_key_id, f.content_type, f.size_bytes, f.checksum_sha256,
+		f.revision, f.embedding_revision, f.status, f.source_id, f.created_at, f.confirmed_at, f.expires_at
+		FROM file_nodes fn
+		JOIN files f ON f.file_id = fn.file_id
+		WHERE fn.path = ? AND fn.is_directory = 0
+		FOR UPDATE`, path)
+	f, err := scanFileForGC(row)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, err
-	}
-	if isDir {
-		return nil, ErrNotFound
-	}
-
-	if _, err := tx.Exec(`DELETE FROM file_nodes WHERE path = ?`, path); err != nil {
 		return nil, err
 	}
 
-	if !fileID.Valid || fileID.String == "" {
-		return nil, tx.Commit()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE path = ?`, path); err != nil {
+		return nil, err
 	}
 
-	stillReferenced, err := fileIDExistsTx(tx, fileID.String)
+	stillReferenced, err := fileIDExistsTx(ctx, tx, f.FileID)
 	if err != nil {
 		return nil, err
 	}
@@ -1076,26 +1071,14 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 		return nil, tx.Commit()
 	}
 
-	if _, err := tx.Exec(`UPDATE files SET status = 'DELETED' WHERE file_id = ?`, fileID.String); err != nil {
+	if _, err := tx.ExecContext(ctx, `UPDATE files SET status = 'DELETED' WHERE file_id = ?`, f.FileID); err != nil {
 		return nil, err
 	}
-	if _, err := tx.Exec(`DELETE FROM file_tags WHERE file_id = ?`, fileID.String); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM file_tags WHERE file_id = ?`, f.FileID); err != nil {
 		return nil, err
 	}
-
-	row := tx.QueryRow(`SELECT file_id, storage_type, storage_ref, storage_encryption_mode,
-		storage_encryption_key_id, content_type, size_bytes, checksum_sha256,
-		revision, embedding_revision, status, source_id, created_at, confirmed_at, expires_at
-		FROM files WHERE file_id = ?`, fileID.String)
-	f, err := scanFileForGC(row)
-	if err != nil {
-		return nil, err
-	}
-	task, err := NewFileGCTaskFromFile(f, time.Now().UTC())
-	if err != nil {
-		return nil, err
-	}
-	if _, err := s.EnqueueFileGCTaskTx(tx, task); err != nil {
+	f.Status = StatusDeleted
+	if err := enqueueFileGCTasksTx(ctx, tx, []*File{f}, time.Now().UTC()); err != nil {
 		return nil, err
 	}
 
@@ -1116,24 +1099,24 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	orphaned, err := orphanedFilesByPathPrefixTx(tx, dirPath)
+	orphaned, err := orphanedFilesByPathPrefixTx(ctx, tx, dirPath)
 	if err != nil {
 		return nil, err
 	}
 
 	deleteWhere, deleteArgs := pathPrefixPredicate("path", dirPath)
-	if _, err := tx.Exec(`DELETE FROM file_nodes WHERE `+deleteWhere, deleteArgs...); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+deleteWhere, deleteArgs...); err != nil {
 		return nil, err
 	}
 
 	if len(orphaned) > 0 {
-		if err := markFilesDeletedTx(tx, orphaned); err != nil {
+		if err := markFilesDeletedTx(ctx, tx, orphaned); err != nil {
 			return nil, err
 		}
-		if err := deleteFileTagsTx(tx, orphaned); err != nil {
+		if err := deleteFileTagsTx(ctx, tx, orphaned); err != nil {
 			return nil, err
 		}
-		if err := enqueueFileGCTasksTx(tx, orphaned, time.Now().UTC()); err != nil {
+		if err := enqueueFileGCTasksTx(ctx, tx, orphaned, time.Now().UTC()); err != nil {
 			return nil, err
 		}
 	}
@@ -1147,9 +1130,9 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 
 const deleteBatchSize = 500
 
-func fileIDExistsTx(tx *sql.Tx, fileID string) (bool, error) {
+func fileIDExistsTx(ctx context.Context, tx *sql.Tx, fileID string) (bool, error) {
 	var one int
-	err := tx.QueryRow(`SELECT 1 FROM file_nodes WHERE file_id = ? LIMIT 1 FOR UPDATE`, fileID).Scan(&one)
+	err := tx.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE file_id = ? LIMIT 1 FOR UPDATE`, fileID).Scan(&one)
 	if err == nil {
 		return true, nil
 	}
@@ -1159,9 +1142,9 @@ func fileIDExistsTx(tx *sql.Tx, fileID string) (bool, error) {
 	return false, err
 }
 
-func dirHasChildrenTx(tx *sql.Tx, path string) (bool, error) {
+func dirHasChildrenTx(ctx context.Context, tx *sql.Tx, path string) (bool, error) {
 	var one int
-	err := tx.QueryRow(`SELECT 1 FROM file_nodes WHERE parent_path = ? LIMIT 1 FOR UPDATE`, path).Scan(&one)
+	err := tx.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE parent_path = ? LIMIT 1 FOR UPDATE`, path).Scan(&one)
 	if err == nil {
 		return true, nil
 	}
@@ -1171,14 +1154,14 @@ func dirHasChildrenTx(tx *sql.Tx, path string) (bool, error) {
 	return false, err
 }
 
-func orphanedFilesByPathPrefixTx(tx *sql.Tx, dirPath string) ([]*File, error) {
+func orphanedFilesByPathPrefixTx(ctx context.Context, tx *sql.Tx, dirPath string) ([]*File, error) {
 	subtreeWhere, subtreeArgs := pathPrefixPredicate("fn.path", dirPath)
 	outsideWhere, outsideArgs := pathPrefixPredicate("live.path", dirPath)
 	args := make([]any, 0, len(subtreeArgs)+len(outsideArgs))
 	args = append(args, subtreeArgs...)
 	args = append(args, outsideArgs...)
 
-	rows, err := tx.Query(`SELECT DISTINCT f.file_id, f.storage_type, f.storage_ref, f.storage_encryption_mode,
+	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT f.file_id, f.storage_type, f.storage_ref, f.storage_encryption_mode,
 			f.storage_encryption_key_id, f.content_type, f.size_bytes, f.checksum_sha256,
 			f.revision, f.embedding_revision, f.status, f.source_id, f.created_at, f.confirmed_at, f.expires_at
 		FROM file_nodes fn
@@ -1212,23 +1195,23 @@ func orphanedFilesByPathPrefixTx(tx *sql.Tx, dirPath string) ([]*File, error) {
 	return out, nil
 }
 
-func markFilesDeletedTx(tx *sql.Tx, files []*File) error {
+func markFilesDeletedTx(ctx context.Context, tx *sql.Tx, files []*File) error {
 	return forEachFileBatch(files, func(batch []*File) error {
 		query, args := fileIDInQuery(`UPDATE files SET status = ? WHERE file_id IN `, StatusDeleted, batch)
-		_, err := tx.Exec(query, args...)
+		_, err := tx.ExecContext(ctx, query, args...)
 		return err
 	})
 }
 
-func deleteFileTagsTx(tx *sql.Tx, files []*File) error {
+func deleteFileTagsTx(ctx context.Context, tx *sql.Tx, files []*File) error {
 	return forEachFileBatch(files, func(batch []*File) error {
 		query, args := fileIDInQuery(`DELETE FROM file_tags WHERE file_id IN `, nil, batch)
-		_, err := tx.Exec(query, args...)
+		_, err := tx.ExecContext(ctx, query, args...)
 		return err
 	})
 }
 
-func enqueueFileGCTasksTx(tx *sql.Tx, files []*File, now time.Time) error {
+func enqueueFileGCTasksTx(ctx context.Context, tx *sql.Tx, files []*File, now time.Time) error {
 	if now.IsZero() {
 		now = time.Now().UTC()
 	} else {
@@ -1236,7 +1219,7 @@ func enqueueFileGCTasksTx(tx *sql.Tx, files []*File, now time.Time) error {
 	}
 	return forEachFileBatch(files, func(batch []*File) error {
 		var b strings.Builder
-		b.WriteString(`INSERT IGNORE INTO file_gc_tasks
+		b.WriteString(`INSERT INTO file_gc_tasks
 			(task_id, file_id, storage_type, storage_ref, size_bytes, content_type,
 			 status, attempt_count, max_attempts, receipt, leased_at, lease_until,
 			 available_at, last_error, created_at, updated_at, completed_at)
@@ -1253,7 +1236,8 @@ func enqueueFileGCTasksTx(tx *sql.Tx, files []*File, now time.Time) error {
 				now, nil, now, now, nil,
 			)
 		}
-		_, err := tx.Exec(b.String(), args...)
+		b.WriteString(` ON DUPLICATE KEY UPDATE task_id = task_id`)
+		_, err := tx.ExecContext(ctx, b.String(), args...)
 		return err
 	})
 }

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -575,6 +575,22 @@ func TestDeleteWithRefCount(t *testing.T) {
 	}
 }
 
+func TestDeleteFileWithRefCheckRejectsDirectory(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	if err := s.InsertNode(ctx, &FileNode{NodeID: "dir", Path: "/dir/", ParentPath: "/", Name: "dir", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DeleteFileWithRefCheck(ctx, "/dir/"); err != ErrNotFound {
+		t.Fatalf("DeleteFileWithRefCheck dir error = %v, want ErrNotFound", err)
+	}
+	if _, err := s.GetNode(ctx, "/dir/"); err != nil {
+		t.Fatalf("directory should remain after rejected file delete: %v", err)
+	}
+}
+
 func TestDeleteDirRecursive(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
@@ -627,6 +643,48 @@ func TestDeleteDirRecursive(t *testing.T) {
 	_, err = s.GetNode(context.Background(), "/shared.txt")
 	if err != nil {
 		t.Error("expected /shared.txt to survive")
+	}
+}
+
+func TestDeleteDirRecursiveDoesNotDeleteSiblingPrefix(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now()
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "d1", Path: "/data/", ParentPath: "/", Name: "data", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "d2", Path: "/data-other/", ParentPath: "/", Name: "data-other", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertFile(context.Background(), &File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		SizeBytes: 10, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertFile(context.Background(), &File{FileID: "f2", StorageType: StorageDB9, StorageRef: "/blobs/f2",
+		SizeBytes: 20, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n1", Path: "/data/a.txt", ParentPath: "/data/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "n2", Path: "/data-other/b.txt", ParentPath: "/data-other/", Name: "b.txt", FileID: "f2", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	orphaned, err := s.DeleteDirRecursive(context.Background(), "/data/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(orphaned) != 1 || orphaned[0].FileID != "f1" {
+		t.Fatalf("orphaned = %+v, want only f1", orphaned)
+	}
+	if _, err := s.GetNode(context.Background(), "/data-other/"); err != nil {
+		t.Fatalf("sibling directory should survive: %v", err)
+	}
+	if _, err := s.GetNode(context.Background(), "/data-other/b.txt"); err != nil {
+		t.Fatalf("sibling file should survive: %v", err)
+	}
+	if _, err := s.GetFileGCTaskByFileID(context.Background(), "f2"); err != ErrNotFound {
+		t.Fatalf("expected no gc task for sibling f2, got %v", err)
 	}
 }
 

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -61,17 +61,18 @@ type CommitCleanupFunc func(entry *CommitEntry)
 // CommitQueue manages ordered background remote commits with baseRev tracking.
 // It provides backpressure when the queue exceeds maxPending items.
 type CommitQueue struct {
-	mu         sync.Mutex
-	queue      []*CommitEntry
-	inFlight   map[string]*CommitEntry // paths currently being processed by workers
-	maxPending int
-	client     *client.Client
-	remoteRoot string
-	shadows    *ShadowStore
-	index      *PendingIndex
-	journal    *Journal
-	wg         sync.WaitGroup
-	stopped    bool
+	mu           sync.Mutex
+	queue        []*CommitEntry
+	queuedByPath map[string]map[*CommitEntry]struct{}
+	inFlight     map[string]*CommitEntry // paths currently being processed by workers
+	maxPending   int
+	client       *client.Client
+	remoteRoot   string
+	shadows      *ShadowStore
+	index        *PendingIndex
+	journal      *Journal
+	wg           sync.WaitGroup
+	stopped      bool
 
 	// OnSuccess is called after successful upload with the committed
 	// revision. Used by dat9fs to seed readCache and update inode revision.
@@ -105,14 +106,15 @@ func NewCommitQueue(c *client.Client, shadows *ShadowStore, index *PendingIndex,
 		bufSize = 256
 	}
 	cq := &CommitQueue{
-		maxPending: maxPending,
-		client:     c,
-		remoteRoot: root,
-		shadows:    shadows,
-		index:      index,
-		journal:    journal,
-		inFlight:   make(map[string]*CommitEntry),
-		workCh:     make(chan *CommitEntry, bufSize),
+		maxPending:   maxPending,
+		client:       c,
+		remoteRoot:   root,
+		shadows:      shadows,
+		index:        index,
+		journal:      journal,
+		inFlight:     make(map[string]*CommitEntry),
+		queuedByPath: make(map[string]map[*CommitEntry]struct{}),
+		workCh:       make(chan *CommitEntry, bufSize),
 	}
 	for i := 0; i < numWorkers; i++ {
 		cq.wg.Add(1)
@@ -151,6 +153,7 @@ func (cq *CommitQueue) Enqueue(entry *CommitEntry) error {
 		return fmt.Errorf("commit queue full (%d pending)", cq.maxPending)
 	}
 	cq.queue = append(cq.queue, entry)
+	cq.addQueuedLocked(entry)
 	if cq.perf != nil {
 		cq.perf.commitEnqueue.add(1)
 	}
@@ -280,13 +283,7 @@ func (cq *CommitQueue) WaitPath(path string) {
 	for {
 		cq.mu.Lock()
 		_, inflight := cq.inFlight[path]
-		queued := false
-		for _, e := range cq.queue {
-			if e.Path == path {
-				queued = true
-				break
-			}
-		}
+		queued := cq.hasQueuedPathLocked(path)
 		cq.mu.Unlock()
 		if !inflight && !queued {
 			return
@@ -305,12 +302,7 @@ func (cq *CommitQueue) HasPath(path string) bool {
 	if _, inflight := cq.inFlight[path]; inflight {
 		return true
 	}
-	for _, e := range cq.queue {
-		if e.Path == path {
-			return true
-		}
-	}
-	return false
+	return cq.hasQueuedPathLocked(path)
 }
 
 // WaitPrefix blocks until all in-flight or queued commits under the given
@@ -381,15 +373,31 @@ func (cq *CommitQueue) cancelPath(path string, preserveLocal bool) {
 	if e, ok := cq.inFlight[path]; ok {
 		markCanceled(e)
 	}
-	remaining := cq.queue[:0]
-	for _, e := range cq.queue {
-		if e.Path == path {
+	if cq.queuedByPath != nil {
+		for e := range cq.queuedByPath[path] {
 			markCanceled(e)
-			continue
 		}
-		remaining = append(remaining, e)
 	}
-	cq.queue = remaining
+	if cq.queuedByPath == nil {
+		remaining := cq.queue[:0]
+		for _, e := range cq.queue {
+			if e.Path == path {
+				markCanceled(e)
+				continue
+			}
+			remaining = append(remaining, e)
+		}
+		cq.queue = remaining
+	} else if len(cq.queuedByPath[path]) > 0 {
+		remaining := cq.queue[:0]
+		for _, e := range cq.queue {
+			if e.Path != path {
+				remaining = append(remaining, e)
+			}
+		}
+		cq.queue = remaining
+		delete(cq.queuedByPath, path)
+	}
 	cq.mu.Unlock()
 
 	for _, cancel := range cancels {
@@ -446,6 +454,9 @@ func (cq *CommitQueue) CancelPrefix(prefix string) {
 		}
 	}
 	cq.queue = remaining
+	if cq.queuedByPath != nil {
+		cq.rebuildQueuedIndexLocked()
+	}
 	cq.mu.Unlock()
 
 	for _, cancel := range cancels {
@@ -687,8 +698,57 @@ func (cq *CommitQueue) removeFromQueue(entry *CommitEntry) {
 	for i, e := range cq.queue {
 		if e == entry {
 			cq.queue = append(cq.queue[:i], cq.queue[i+1:]...)
+			cq.removeQueuedLocked(entry)
 			return
 		}
+	}
+}
+
+func (cq *CommitQueue) addQueuedLocked(entry *CommitEntry) {
+	if cq.queuedByPath == nil || entry == nil {
+		return
+	}
+	entries := cq.queuedByPath[entry.Path]
+	if entries == nil {
+		entries = make(map[*CommitEntry]struct{})
+		cq.queuedByPath[entry.Path] = entries
+	}
+	entries[entry] = struct{}{}
+}
+
+func (cq *CommitQueue) removeQueuedLocked(entry *CommitEntry) {
+	if cq.queuedByPath == nil || entry == nil {
+		return
+	}
+	entries := cq.queuedByPath[entry.Path]
+	if entries == nil {
+		return
+	}
+	delete(entries, entry)
+	if len(entries) == 0 {
+		delete(cq.queuedByPath, entry.Path)
+	}
+}
+
+func (cq *CommitQueue) hasQueuedPathLocked(path string) bool {
+	if cq.queuedByPath != nil {
+		return len(cq.queuedByPath[path]) > 0
+	}
+	for _, e := range cq.queue {
+		if e.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func (cq *CommitQueue) rebuildQueuedIndexLocked() {
+	if cq.queuedByPath == nil {
+		return
+	}
+	cq.queuedByPath = make(map[string]map[*CommitEntry]struct{}, len(cq.queue))
+	for _, e := range cq.queue {
+		cq.addQueuedLocked(e)
 	}
 }
 

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -277,6 +277,41 @@ func TestCommitQueueCancelPathCancelsRetryBackoff(t *testing.T) {
 	}
 }
 
+func TestCommitQueueQueuedPathIndexTracksCancelAndRemove(t *testing.T) {
+	path := "/repo/file.txt"
+	otherPath := "/repo/other.txt"
+	e1 := &CommitEntry{Path: path}
+	e2 := &CommitEntry{Path: path}
+	other := &CommitEntry{Path: otherPath}
+	cq := &CommitQueue{
+		queue:        []*CommitEntry{e1, other, e2},
+		queuedByPath: make(map[string]map[*CommitEntry]struct{}),
+		inFlight:     make(map[string]*CommitEntry),
+	}
+	cq.addQueuedLocked(e1)
+	cq.addQueuedLocked(other)
+	cq.addQueuedLocked(e2)
+
+	if !cq.HasPath(path) {
+		t.Fatal("HasPath should find queued entries through index")
+	}
+	cq.CancelPath(path)
+	if cq.HasPath(path) {
+		t.Fatal("CancelPath should remove all queued entries for path from index")
+	}
+	if !cq.isEntryCanceled(e1) || !cq.isEntryCanceled(e2) {
+		t.Fatal("CancelPath should cancel all queued entries for path")
+	}
+	if !cq.HasPath(otherPath) {
+		t.Fatal("CancelPath should preserve unrelated queued paths")
+	}
+
+	cq.removeFromQueue(other)
+	if cq.HasPath(otherPath) {
+		t.Fatal("removeFromQueue should remove queued path index entry")
+	}
+}
+
 // TestCommitQueueDirectPutRouting verifies that files under
 // commitQueueDirectPutThreshold use direct PUT (WriteCtxConditionalWithRevision)
 // which sends raw body, while files at or above the threshold use multipart

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -546,7 +546,7 @@ func (fs *Dat9FS) preloadWritableHandleFromReadCacheLocked(fh *FileHandle) bool 
 	if fs.readCache == nil || fh == nil || fh.Dirty == nil {
 		return false
 	}
-	if fh.OrigSize <= 0 || fh.OrigSize > defaultSmallFileThreshold || fh.BaseRev <= 0 {
+	if fh.OrigSize <= 0 || fh.OrigSize > defaultReadCacheMaxFileSize || fh.BaseRev <= 0 {
 		return false
 	}
 
@@ -3208,7 +3208,7 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 	// InodeEntry has a stored revision from the last Lookup/GetAttr, pass
 	// it to the cache for validation. Cache hit only if revision matches.
 	entry, _ := fs.inodes.GetEntry(fh.Ino)
-	if entry != nil && entry.Size <= defaultSmallFileThreshold && entry.Size > 0 {
+	if entry != nil && entry.Size <= defaultReadCacheMaxFileSize && entry.Size > 0 {
 		cacheRev := entry.Revision // use revision from last Stat/Lookup
 		// Fast path: serve from cache without any HTTP call.
 		if data, ok := fs.readCache.Get(p, cacheRev); ok {
@@ -4393,7 +4393,7 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 	if committedRev > 0 && entry.Inode > 0 {
 		// Seed readCache from shadow data before the shadow file is removed.
 		// Only attempt for files under the readCache size limit.
-		if entry.Size < int64(defaultSmallFileThreshold) && fs.shadowStore != nil {
+		if entry.Size <= int64(defaultReadCacheMaxFileSize) && fs.shadowStore != nil {
 			if data, err := fs.shadowStore.ReadAll(entry.Path); err == nil {
 				fs.readCache.PutOwned(entry.Path, data, committedRev)
 			}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -899,7 +899,10 @@ func isCreateActionUnsupportedErr(err error) bool {
 	if !errors.As(err, &se) {
 		return false
 	}
-	if se.StatusCode != http.StatusBadRequest && se.StatusCode != http.StatusMethodNotAllowed && se.StatusCode != http.StatusNotFound {
+	if se.StatusCode == http.StatusNotFound {
+		return true
+	}
+	if se.StatusCode != http.StatusBadRequest && se.StatusCode != http.StatusMethodNotAllowed {
 		return false
 	}
 	msg := strings.ToLower(se.Message)
@@ -1373,7 +1376,7 @@ func (fs *Dat9FS) deleteRemotePathWithInterruptRecovery(ctx context.Context, loc
 	case deleteKindDir:
 		err = fs.client.DeleteDirCtx(ctx, remotePath)
 	default:
-		err = fs.client.DeleteCtx(ctx, remotePath)
+		err = fmt.Errorf("unsupported delete kind %q", kind)
 	}
 	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
 	if err == nil || !isTransientLookupErr(err) {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1348,22 +1348,29 @@ func (fs *Dat9FS) mkdirRemoteWithTransientRetry(cancel <-chan struct{}, localPat
 	return lastErr
 }
 
+type deleteKind string
+
+const (
+	deleteKindFile deleteKind = "file"
+	deleteKindDir  deleteKind = "dir"
+)
+
 func (fs *Dat9FS) deleteRemoteFileWithInterruptRecovery(ctx context.Context, localPath string) error {
-	return fs.deleteRemotePathWithInterruptRecovery(ctx, localPath, "file")
+	return fs.deleteRemotePathWithInterruptRecovery(ctx, localPath, deleteKindFile)
 }
 
 func (fs *Dat9FS) deleteRemoteDirWithInterruptRecovery(ctx context.Context, localPath string) error {
-	return fs.deleteRemotePathWithInterruptRecovery(ctx, localPath, "dir")
+	return fs.deleteRemotePathWithInterruptRecovery(ctx, localPath, deleteKindDir)
 }
 
-func (fs *Dat9FS) deleteRemotePathWithInterruptRecovery(ctx context.Context, localPath, kind string) error {
+func (fs *Dat9FS) deleteRemotePathWithInterruptRecovery(ctx context.Context, localPath string, kind deleteKind) error {
 	mutationStart := fs.perfStart()
 	remotePath := fs.remotePath(localPath)
 	var err error
 	switch kind {
-	case "file":
+	case deleteKindFile:
 		err = fs.client.DeleteFileCtx(ctx, remotePath)
-	case "dir":
+	case deleteKindDir:
 		err = fs.client.DeleteDirCtx(ctx, remotePath)
 	default:
 		err = fs.client.DeleteCtx(ctx, remotePath)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1336,9 +1336,26 @@ func (fs *Dat9FS) mkdirRemoteWithTransientRetry(cancel <-chan struct{}, localPat
 	return lastErr
 }
 
-func (fs *Dat9FS) deleteRemoteWithInterruptRecovery(ctx context.Context, localPath string) error {
+func (fs *Dat9FS) deleteRemoteFileWithInterruptRecovery(ctx context.Context, localPath string) error {
+	return fs.deleteRemotePathWithInterruptRecovery(ctx, localPath, "file")
+}
+
+func (fs *Dat9FS) deleteRemoteDirWithInterruptRecovery(ctx context.Context, localPath string) error {
+	return fs.deleteRemotePathWithInterruptRecovery(ctx, localPath, "dir")
+}
+
+func (fs *Dat9FS) deleteRemotePathWithInterruptRecovery(ctx context.Context, localPath, kind string) error {
 	mutationStart := fs.perfStart()
-	err := fs.client.DeleteCtx(ctx, fs.remotePath(localPath))
+	remotePath := fs.remotePath(localPath)
+	var err error
+	switch kind {
+	case "file":
+		err = fs.client.DeleteFileCtx(ctx, remotePath)
+	case "dir":
+		err = fs.client.DeleteDirCtx(ctx, remotePath)
+	default:
+		err = fs.client.DeleteCtx(ctx, remotePath)
+	}
 	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
 	if err == nil || !isTransientLookupErr(err) {
 		return err
@@ -1981,7 +1998,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// Tolerate 404 in case it was already deleted.
 		deleteStart := time.Now()
 		fs.debugf("unlink remote delete start path=%s", childP)
-		err := fs.deleteRemoteWithInterruptRecovery(ctx, childP)
+		err := fs.deleteRemoteFileWithInterruptRecovery(ctx, childP)
 		fs.debugDurationf(deleteStart, 0, "unlink remote delete done path=%s err=%v", childP, err)
 		if err != nil {
 			if !isNotFoundErr(err) {
@@ -2021,7 +2038,7 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 
 	deleteStart := time.Now()
 	fs.debugf("rmdir remote delete start path=%s", childP)
-	err := fs.deleteRemoteWithInterruptRecovery(ctx, childP)
+	err := fs.deleteRemoteDirWithInterruptRecovery(ctx, childP)
 	fs.debugDurationf(deleteStart, 0, "rmdir remote delete done path=%s err=%v", childP, err)
 	if err != nil {
 		status = httpToFuseStatus(err)
@@ -2032,16 +2049,14 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 	// Without this, the uploader would try to PUT to paths under a deleted dir.
 	prefix := childP + "/"
 	if fs.writeBack != nil {
-		for p := range fs.writeBack.ListPendingPaths() {
-			if strings.HasPrefix(p, prefix) {
-				if fs.uploader != nil {
-					waitStart := time.Now()
-					fs.debugf("rmdir wait writeback start path=%s child=%s", childP, p)
-					fs.uploader.WaitPath(p)
-					fs.debugDurationf(waitStart, 0, "rmdir wait writeback done path=%s child=%s", childP, p)
-				}
-				fs.writeBack.Remove(p)
+		for _, meta := range fs.writeBack.ListByPrefix(prefix) {
+			if fs.uploader != nil {
+				waitStart := time.Now()
+				fs.debugf("rmdir wait writeback start path=%s child=%s", childP, meta.Path)
+				fs.uploader.WaitPath(meta.Path)
+				fs.debugDurationf(waitStart, 0, "rmdir wait writeback done path=%s child=%s", childP, meta.Path)
 			}
+			fs.writeBack.Remove(meta.Path)
 		}
 	}
 	// Cancel commitQueue entries for the subtree so background commits
@@ -2367,16 +2382,14 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 	// re-keyed to newP+"/". Without this the uploader would PUT to stale paths.
 	prefix := oldP + "/"
 	if fs.writeBack != nil {
-		for p := range fs.writeBack.ListPendingPaths() {
-			if strings.HasPrefix(p, prefix) {
-				newChild := newP + p[len(oldP):]
-				if fs.uploader != nil {
-					fs.uploader.WaitPath(p)
-				}
-				fs.writeBack.RenamePending(p, newChild)
-				if fs.uploader != nil {
-					fs.uploader.Submit(newChild)
-				}
+		for _, meta := range fs.writeBack.ListByPrefix(prefix) {
+			newChild := newP + meta.Path[len(oldP):]
+			if fs.uploader != nil {
+				fs.uploader.WaitPath(meta.Path)
+			}
+			fs.writeBack.RenamePending(meta.Path, newChild)
+			if fs.uploader != nil {
+				fs.uploader.Submit(newChild)
 			}
 		}
 	}
@@ -2569,23 +2582,23 @@ func (fs *Dat9FS) mergePendingDirEntries(dirPath string, entries []DirEntry) []D
 
 	// Overlay write-back cache entries.
 	if fs.writeBack != nil {
-		for p := range fs.writeBack.ListPendingPaths() {
-			if parentDir(p) != dirPath {
+		prefix := dirPath
+		if prefix != "/" {
+			prefix += "/"
+		}
+		for _, meta := range fs.writeBack.ListByPrefix(prefix) {
+			if parentDir(meta.Path) != dirPath {
 				continue
 			}
-			name := path.Base(p)
+			name := path.Base(meta.Path)
 			if _, ok := existing[name]; ok {
-				continue
-			}
-			meta, ok := fs.writeBack.GetMeta(p)
-			if !ok {
 				continue
 			}
 			mtime := meta.Mtime
 			if mtime.IsZero() {
 				mtime = time.Now()
 			}
-			ino := fs.inodes.EnsureInode(p, false, meta.Size, mtime)
+			ino := fs.inodes.EnsureInode(meta.Path, false, meta.Size, mtime)
 			entries = append(entries, DirEntry{
 				Name: name,
 				Ino:  ino,

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -894,6 +894,18 @@ func isConflictErr(err error) bool {
 	return errors.As(err, &se) && se.StatusCode == http.StatusConflict
 }
 
+func isCreateActionUnsupportedErr(err error) bool {
+	var se *client.StatusError
+	if !errors.As(err, &se) {
+		return false
+	}
+	if se.StatusCode != http.StatusBadRequest && se.StatusCode != http.StatusMethodNotAllowed && se.StatusCode != http.StatusNotFound {
+		return false
+	}
+	msg := strings.ToLower(se.Message)
+	return strings.Contains(msg, "unknown post action") || strings.Contains(msg, "method not allowed")
+}
+
 // errReadRetriesExhausted is a sentinel indicating all detached read retries
 // failed with transient errors. Callers should map this to EIO.
 var errReadRetriesExhausted = errors.New("read retries exhausted")
@@ -4207,13 +4219,26 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	threshold := fs.negotiatedInlineThreshold()
 	useDirectPUT := size == 0 || (threshold > 0 && size < threshold)
 	if useDirectPUT {
-		// Small file: direct PUT with revision return for freshness seeding.
-		phase = "small-write"
-		writeStart := time.Now()
-		fs.debugf("flushHandle small write start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
-		committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), data, expectedRevision)
-		fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
-		fs.debugDurationf(writeStart, 0, "flushHandle small write done path=%s size=%d committed_rev=%d err=%v", fh.Path, size, committedRev, err)
+		if size == 0 && fh.IsNew {
+			phase = "empty-create"
+			writeStart := time.Now()
+			fs.debugf("flushHandle empty create start path=%s expected_rev=%d", fh.Path, expectedRevision)
+			committedRev, err = fs.client.CreateFileCtx(ctx, fs.remotePath(fh.Path))
+			if isCreateActionUnsupportedErr(err) {
+				fs.debugf("flushHandle empty create unsupported path=%s fallback=small-write err=%v", fh.Path, err)
+				committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), data, expectedRevision)
+			}
+			fs.perfRecordRemote(perfRemoteWrite, writeStart, err, 0)
+			fs.debugDurationf(writeStart, 0, "flushHandle empty create done path=%s committed_rev=%d err=%v", fh.Path, committedRev, err)
+		} else {
+			// Small file: direct PUT with revision return for freshness seeding.
+			phase = "small-write"
+			writeStart := time.Now()
+			fs.debugf("flushHandle small write start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
+			committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), data, expectedRevision)
+			fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
+			fs.debugDurationf(writeStart, 0, "flushHandle small write done path=%s size=%d committed_rev=%d err=%v", fh.Path, size, committedRev, err)
+		}
 	} else if fh.OrigSize >= threshold {
 		phase = "patch-file"
 		dirtyParts := fh.Dirty.DirtyPartNumbers()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2420,6 +2420,15 @@ func TestHTTPToFuseStatus_PreservesRevisionConflictAsEIO(t *testing.T) {
 	}
 }
 
+func TestIsCreateActionUnsupportedErr(t *testing.T) {
+	if !isCreateActionUnsupportedErr(&client.StatusError{StatusCode: http.StatusBadRequest, Message: "unknown POST action"}) {
+		t.Fatal("unknown POST action should be treated as unsupported create action")
+	}
+	if isCreateActionUnsupportedErr(&client.StatusError{StatusCode: http.StatusBadRequest, Message: "invalid path"}) {
+		t.Fatal("plain bad request should not be treated as unsupported create action")
+	}
+}
+
 // TestHTTPToFuseStatus_MapsClientClosedRequestToEAGAIN locks the contract
 // between the server's tenantAuthMiddleware (which writes 499 when a request
 // is canceled mid-auth) and the FUSE client. Without this mapping, a canceled
@@ -3297,6 +3306,83 @@ func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
 	}
 	if entry.Revision != 8 {
 		t.Fatalf("inode revision = %d, want 8", entry.Revision)
+	}
+}
+
+func TestReleaseNewEmptyFileUsesCreateAction(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		handlerErr  error
+		createCalls atomic.Int32
+		putCalls    atomic.Int32
+	)
+	recordHandlerErr := func(err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			if r.URL.Path != "/v1/fs/empty.txt" {
+				recordHandlerErr(fmt.Errorf("path = %s, want /v1/fs/empty.txt", r.URL.Path))
+				http.Error(w, "bad path", http.StatusBadRequest)
+				return
+			}
+			if !r.URL.Query().Has("create") {
+				recordHandlerErr(fmt.Errorf("query = %q, want create action", r.URL.RawQuery))
+				http.Error(w, "bad query", http.StatusBadRequest)
+				return
+			}
+			createCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(1)})
+		case http.MethodPut:
+			putCalls.Add(1)
+			http.Error(w, "unexpected PUT", http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var out gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "empty.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: out.Fh})
+
+	mu.Lock()
+	err := handlerErr
+	mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := createCalls.Load(); got != 1 {
+		t.Fatalf("create calls = %d, want 1", got)
+	}
+	if got := putCalls.Load(); got != 0 {
+		t.Fatalf("PUT calls = %d, want 0", got)
+	}
+	entry, ok := fs.inodes.GetEntry(out.NodeId)
+	if !ok {
+		t.Fatal("created inode entry not found")
+	}
+	if entry.Size != 0 {
+		t.Fatalf("entry size = %d, want 0", entry.Size)
+	}
+	if entry.Revision != 1 {
+		t.Fatalf("entry revision = %d, want 1", entry.Revision)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2424,8 +2424,24 @@ func TestIsCreateActionUnsupportedErr(t *testing.T) {
 	if !isCreateActionUnsupportedErr(&client.StatusError{StatusCode: http.StatusBadRequest, Message: "unknown POST action"}) {
 		t.Fatal("unknown POST action should be treated as unsupported create action")
 	}
+	if !isCreateActionUnsupportedErr(&client.StatusError{StatusCode: http.StatusNotFound, Message: ""}) {
+		t.Fatal("plain 404 should be treated as unsupported create action")
+	}
 	if isCreateActionUnsupportedErr(&client.StatusError{StatusCode: http.StatusBadRequest, Message: "invalid path"}) {
 		t.Fatal("plain bad request should not be treated as unsupported create action")
+	}
+}
+
+func TestDeleteRemotePathRejectsInvalidKind(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	err := fs.deleteRemotePathWithInterruptRecovery(context.Background(), "/file.txt", deleteKind(""))
+	if err == nil {
+		t.Fatal("deleteRemotePathWithInterruptRecovery error = nil, want invalid kind error")
+	}
+	if !strings.Contains(err.Error(), "unsupported delete kind") {
+		t.Fatalf("error = %v, want unsupported delete kind", err)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -5499,6 +5499,45 @@ func TestUnlinkRemoteDeleteAcceptsGoneAfterInterrupt(t *testing.T) {
 	}
 }
 
+func TestUnlinkAndRmdirUseDeleteKindHints(t *testing.T) {
+	var fileQuery atomic.Value
+	var dirQuery atomic.Value
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/fs/file.txt":
+			fileQuery.Store(r.URL.RawQuery)
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/fs/dir":
+			dirQuery.Store(r.URL.RawQuery)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.inodes.Lookup("/file.txt", false, 4, time.Now())
+	fs.inodes.Lookup("/dir", true, 0, time.Now())
+
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, "file.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+	if st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir"); st != gofuse.OK {
+		t.Fatalf("Rmdir: %v", st)
+	}
+
+	if got, _ := fileQuery.Load().(string); got != "kind=file" {
+		t.Fatalf("file delete query = %q, want kind=file", got)
+	}
+	if got, _ := dirQuery.Load().(string); got != "kind=dir" {
+		t.Fatalf("dir delete query = %q, want kind=dir", got)
+	}
+}
+
 func TestRmdirRemoteDeleteDoesNotRetryRecreatedPathAfterInterrupt(t *testing.T) {
 	path := "/repo/emptydir"
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1,6 +1,7 @@
 package fuse
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -555,6 +556,72 @@ func TestReadZeroLengthFromWritableCleanBuffer(t *testing.T) {
 	}
 	if got := getCalls.Load(); got != 0 {
 		t.Fatalf("GET calls = %d, want 0", got)
+	}
+}
+
+func TestReadCacheCachesMediumSmallFileAfterFirstRead(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), defaultSmallFileThreshold+1024)
+	var getCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			getCalls.Add(1)
+			w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+			_, _ = w.Write(data)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	const rev = 11
+	ino := fs.inodes.Lookup("/medium.bin", false, int64(len(data)), time.Now())
+	fs.inodes.UpdateRevision(ino, rev)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	buf := make([]byte, 64)
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       out.Fh,
+		Offset:   0,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("first Read status = %v, want OK", st)
+	}
+	first, _ := result.Bytes(buf)
+	if string(first) != string(data[:len(buf)]) {
+		t.Fatalf("first Read = %q, want prefix", string(first))
+	}
+
+	result, st = fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       out.Fh,
+		Offset:   128,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("second Read status = %v, want OK", st)
+	}
+	second, _ := result.Bytes(buf)
+	if string(second) != string(data[128:128+len(buf)]) {
+		t.Fatalf("second Read = %q, want prefix", string(second))
+	}
+	if got := getCalls.Load(); got != 1 {
+		t.Fatalf("GET calls = %d, want 1", got)
 	}
 }
 
@@ -2492,14 +2559,14 @@ func TestLazyWritablePreloadUsesRenamedPath(t *testing.T) {
 	}
 }
 
-func TestDefaultTTLIs10Seconds(t *testing.T) {
+func TestDefaultTTLIs60Seconds(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
-	if opts.AttrTTL != 10*time.Second {
-		t.Fatalf("default AttrTTL = %v, want 10s", opts.AttrTTL)
+	if opts.AttrTTL != defaultPositiveKernelCacheTTL {
+		t.Fatalf("default AttrTTL = %v, want %v", opts.AttrTTL, defaultPositiveKernelCacheTTL)
 	}
-	if opts.EntryTTL != 10*time.Second {
-		t.Fatalf("default EntryTTL = %v, want 10s", opts.EntryTTL)
+	if opts.EntryTTL != defaultPositiveKernelCacheTTL {
+		t.Fatalf("default EntryTTL = %v, want %v", opts.EntryTTL, defaultPositiveKernelCacheTTL)
 	}
 	if opts.NegativeEntryTTL != 10*time.Second {
 		t.Fatalf("default NegativeEntryTTL = %v, want 10s", opts.NegativeEntryTTL)
@@ -2570,13 +2637,14 @@ func TestLookupReturnsTTLInEntryOut(t *testing.T) {
 	if st != gofuse.OK {
 		t.Fatalf("Lookup status = %v, want OK", st)
 	}
-	// The entry timeout should match the configured TTL (10s default).
+	// The entry timeout should match the configured default TTL.
 	// go-fuse stores timeouts in seconds + nanoseconds.
-	if out.EntryValid < 10 || out.EntryValid > 11 {
-		t.Fatalf("EntryValid = %d, want ~10 (10s TTL)", out.EntryValid)
+	wantSeconds := uint64(defaultPositiveKernelCacheTTL / time.Second)
+	if out.EntryValid < wantSeconds || out.EntryValid > wantSeconds+1 {
+		t.Fatalf("EntryValid = %d, want ~%d", out.EntryValid, wantSeconds)
 	}
-	if out.AttrValid < 10 || out.AttrValid > 11 {
-		t.Fatalf("AttrValid = %d, want ~10 (10s TTL)", out.AttrValid)
+	if out.AttrValid < wantSeconds || out.AttrValid > wantSeconds+1 {
+		t.Fatalf("AttrValid = %d, want ~%d", out.AttrValid, wantSeconds)
 	}
 }
 

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -291,11 +291,20 @@ func TestReadCache_TTLExpiry(t *testing.T) {
 
 func TestReadCache_SkipLargeFiles(t *testing.T) {
 	rc := NewReadCache(1<<20, 10*time.Second)
-	bigData := make([]byte, defaultSmallFileThreshold+1)
+	bigData := make([]byte, defaultReadCacheMaxFileSize+1)
 	rc.Put("/big", bigData, 1)
 	_, ok := rc.Get("/big", 1)
 	if ok {
 		t.Fatal("large file should not be cached")
+	}
+}
+
+func TestReadCache_CachesMediumSmallFiles(t *testing.T) {
+	rc := NewReadCache(1<<20, 10*time.Second)
+	data := make([]byte, defaultSmallFileThreshold+1)
+	rc.Put("/medium", data, 1)
+	if _, ok := rc.Get("/medium", 1); !ok {
+		t.Fatal("medium-small file should be cached")
 	}
 }
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -37,8 +37,8 @@ type MountOptions struct {
 	CacheDir              string        // write-back cache directory (default ~/.cache/drive9); empty string uses default
 	CacheSize             int64         // ReadCache max size in bytes (default 128MB)
 	DirTTL                time.Duration // DirCache TTL (default 10s)
-	AttrTTL               time.Duration // kernel attr cache TTL (default 10s)
-	EntryTTL              time.Duration // kernel entry cache TTL (default 10s)
+	AttrTTL               time.Duration // kernel attr cache TTL (default 60s)
+	EntryTTL              time.Duration // kernel entry cache TTL (default 60s)
 	NegativeEntryTTL      time.Duration // kernel negative entry cache TTL (default 10s)
 	FlushDebounce         time.Duration // debounce window for small-file flush coalescing (default 2s, 0 disables); set to -1 to use default
 	SyncMode              SyncMode      // interactive, strict, or auto (default auto)
@@ -71,10 +71,10 @@ func (o *MountOptions) setDefaults() {
 		o.DirTTL = defaultDirCacheTTL
 	}
 	if o.AttrTTL <= 0 {
-		o.AttrTTL = 10 * time.Second
+		o.AttrTTL = defaultPositiveKernelCacheTTL
 	}
 	if o.EntryTTL <= 0 {
-		o.EntryTTL = 10 * time.Second
+		o.EntryTTL = defaultPositiveKernelCacheTTL
 	}
 	if o.NegativeEntryTTL <= 0 {
 		o.NegativeEntryTTL = 10 * time.Second

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -10,10 +10,18 @@ import (
 const (
 	defaultReadCacheMaxSize = 128 << 20        // 128MB
 	defaultReadCacheTTL     = 30 * time.Second // 30s
+	// defaultPositiveKernelCacheTTL keeps positive path metadata hot across
+	// repeated scans while SSE/self-invalidation still handles namespace changes.
+	defaultPositiveKernelCacheTTL = 60 * time.Second
 	// defaultSmallFileThreshold is the local fallback used when no server
 	// value has been negotiated yet. The authoritative value is fetched from
 	// /v1/status on the dat9 client and propagated through FS.smallFileMax.
 	defaultSmallFileThreshold = 50_000
+	// defaultReadCacheMaxFileSize is deliberately larger than the inline
+	// fallback so medium-small files do not miss userspace cache solely because
+	// their server inline threshold is higher. The aggregate cache cap still
+	// bounds memory use.
+	defaultReadCacheMaxFileSize = 256 << 10
 )
 
 // cacheEntry holds a single cached file's data and metadata.
@@ -94,7 +102,7 @@ func (rc *ReadCache) Get(path string, currentRevision int64) ([]byte, bool) {
 }
 
 // Put stores data in the cache for the given path and revision. Only files
-// whose size does not exceed defaultSmallFileThreshold are cached. The cache
+// whose size does not exceed defaultReadCacheMaxFileSize are cached. The cache
 // limit is intentionally a static memory-pressure cap rather than a mirror
 // of the server's inline_threshold; raising the latter should not silently
 // expand FUSE's per-mount RAM footprint. If an entry for the path already
@@ -111,7 +119,7 @@ func (rc *ReadCache) PutOwned(path string, data []byte, revision int64) {
 }
 
 func (rc *ReadCache) put(path string, data []byte, revision int64, clone bool) {
-	if len(data) > defaultSmallFileThreshold {
+	if len(data) > defaultReadCacheMaxFileSize {
 		return
 	}
 

--- a/pkg/fuse/writeback.go
+++ b/pkg/fuse/writeback.go
@@ -408,6 +408,21 @@ func (c *WriteBackCache) ListPendingPaths() map[string]struct{} {
 	return result
 }
 
+// ListByPrefix returns metadata for pending entries under prefix.
+func (c *WriteBackCache) ListByPrefix(prefix string) []*WriteBackMeta {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var result []*WriteBackMeta
+	for p, meta := range c.metas {
+		if strings.HasPrefix(p, prefix) {
+			cp := *meta
+			result = append(result, &cp)
+		}
+	}
+	return result
+}
+
 // PendingEntry represents one file waiting to be uploaded.
 type PendingEntry struct {
 	Meta WriteBackMeta

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -2033,6 +2033,36 @@ func TestWriteBackCache_PendingIndex(t *testing.T) {
 	}
 }
 
+func TestWriteBackCacheListByPrefix(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewWriteBackCache(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = cache.Put("/dir/a.txt", []byte("a"), 1, PendingNew)
+	_ = cache.Put("/dir/sub/b.txt", []byte("b"), 1, PendingNew)
+	_ = cache.Put("/dir-other/c.txt", []byte("c"), 1, PendingNew)
+
+	entries := cache.ListByPrefix("/dir/")
+	if len(entries) != 2 {
+		t.Fatalf("ListByPrefix len = %d, want 2", len(entries))
+	}
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		seen[entry.Path] = struct{}{}
+	}
+	if _, ok := seen["/dir/a.txt"]; !ok {
+		t.Fatal("missing /dir/a.txt")
+	}
+	if _, ok := seen["/dir/sub/b.txt"]; !ok {
+		t.Fatal("missing /dir/sub/b.txt")
+	}
+	if _, ok := seen["/dir-other/c.txt"]; ok {
+		t.Fatal("/dir-other/c.txt should not match /dir/")
+	}
+}
+
 // TestUnlink_PendingNew_SkipsRemoteDelete verifies that Unlink skips the
 // remote DELETE for PendingNew files (never uploaded), avoiding a wasted RTT.
 func TestUnlink_PendingNew_SkipsRemoteDelete(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -511,6 +511,8 @@ func (s *Server) handleFS(w http.ResponseWriter, r *http.Request) {
 			s.handleRename(w, r, path)
 		} else if r.URL.Query().Has("mkdir") {
 			s.handleMkdir(w, r, path)
+		} else if r.URL.Query().Has("create") {
+			s.handleCreate(w, r, path)
 		} else {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "fs_unknown_post_action", "path", path)...)
 			errJSON(w, http.StatusBadRequest, "unknown POST action")
@@ -1467,6 +1469,28 @@ func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "mkdir_ok", "path", path)...)
 	s.publishEvent(r, path, "mkdir")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request, path string) {
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "create_missing_scope", "path", path)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	if err := b.CreateCtx(r.Context(), path); err != nil {
+		if errors.Is(err, datastore.ErrPathConflict) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "create_conflict", "path", path, "error", err)...)
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "create_failed", "path", path, "error", err)...)
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "create_ok", "path", path)...)
+	s.publishEvent(r, path, "create")
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(1)})
 }
 
 func (s *Server) handleUploads(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1354,23 +1354,34 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path strin
 		return
 	}
 	recursive := r.URL.Query().Has("recursive")
+	kind := r.URL.Query().Get("kind")
 	var err error
 	if recursive {
 		err = b.RemoveAllCtx(r.Context(), path)
 	} else {
-		err = b.RemoveCtx(r.Context(), path)
+		switch kind {
+		case "":
+			err = b.RemoveCtx(r.Context(), path)
+		case "file":
+			err = b.RemoveFileCtx(r.Context(), path)
+		case "dir":
+			err = b.RemoveDirCtx(r.Context(), path)
+		default:
+			errJSON(w, http.StatusBadRequest, "invalid delete kind")
+			return
+		}
 	}
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "delete_not_found", "path", path, "recursive", recursive)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "delete_not_found", "path", path, "recursive", recursive, "kind", kind)...)
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
-		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "delete_failed", "path", path, "recursive", recursive, "error", err)...)
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "delete_failed", "path", path, "recursive", recursive, "kind", kind, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "delete_ok", "path", path, "recursive", recursive)...)
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "delete_ok", "path", path, "recursive", recursive, "kind", kind)...)
 	s.publishEvent(r, path, "delete")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1490,6 +1490,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request, path strin
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "create_ok", "path", path)...)
 	s.publishEvent(r, path, "create")
+	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(1)})
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1048,6 +1048,48 @@ func TestDeleteKindHint(t *testing.T) {
 	}
 }
 
+func TestCreateFileActionCreatesEmptyFileAndConflicts(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/empty.txt?create", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create status = %d, want 200", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/empty.txt", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Header.Get("Content-Length") != "0" {
+		t.Fatalf("Content-Length = %q, want 0", resp.Header.Get("Content-Length"))
+	}
+	if resp.Header.Get("X-Dat9-Revision") != "1" {
+		t.Fatalf("X-Dat9-Revision = %q, want 1", resp.Header.Get("X-Dat9-Revision"))
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stat status = %d, want 200", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/empty.txt?create", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("duplicate create status = %d, want 409", resp.StatusCode)
+	}
+}
+
 func TestLocalTenantShimProvisionAndStatus(t *testing.T) {
 	s := newLocalTenantShimServer(t, "local-dev-key")
 	ts := httptest.NewServer(s)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1062,6 +1062,9 @@ func TestCreateFileActionCreatesEmptyFileAndConflicts(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("create status = %d, want 200", resp.StatusCode)
 	}
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Fatalf("create Content-Type = %q, want application/json", got)
+	}
 
 	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/empty.txt", nil)
 	resp, err = http.DefaultClient.Do(req)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1088,6 +1088,24 @@ func TestCreateFileActionCreatesEmptyFileAndConflicts(t *testing.T) {
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("duplicate create status = %d, want 409", resp.StatusCode)
 	}
+
+	var fileRows int
+	if err := s.fallback.Store().DB().QueryRow(`SELECT COUNT(*) FROM files`).Scan(&fileRows); err != nil {
+		t.Fatal(err)
+	}
+	if fileRows != 1 {
+		t.Fatalf("files rows after duplicate create = %d, want 1", fileRows)
+	}
+	var orphanRows int
+	if err := s.fallback.Store().DB().QueryRow(`SELECT COUNT(*)
+		FROM files f
+		LEFT JOIN file_nodes fn ON fn.file_id = f.file_id
+		WHERE fn.file_id IS NULL`).Scan(&orphanRows); err != nil {
+		t.Fatal(err)
+	}
+	if orphanRows != 0 {
+		t.Fatalf("orphan files after duplicate create = %d, want 0", orphanRows)
+	}
 }
 
 func TestLocalTenantShimProvisionAndStatus(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -992,6 +992,62 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestDeleteKindHint(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/typed.txt", strings.NewReader("data"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write status = %d, want 200", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/typed-dir?mkdir", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mkdir status = %d, want 200", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/v1/fs/typed.txt?kind=file", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("file delete status = %d, want 200", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/v1/fs/typed-dir?kind=dir", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("dir delete status = %d, want 200", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/v1/fs/missing?kind=bogus", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid kind status = %d, want 400", resp.StatusCode)
+	}
+}
+
 func TestLocalTenantShimProvisionAndStatus(t *testing.T) {
 	s := newLocalTenantShimServer(t, "local-dev-key")
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary
- batch recursive directory delete cleanup in datastore and avoid sibling-prefix matches
- add typed DELETE hints for FUSE unlink/rmdir to skip server-side resolve where the caller already knows the node type
- add path/prefix indexes for FUSE pending cleanup paths to reduce hot-path scans

## Validation
- go test ./pkg/client ./pkg/server ./pkg/backend ./pkg/datastore ./pkg/fuse
- make lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client/server create action with revision response; explicit file-vs-dir create and delete helpers; write-back listing by prefix.

* **Bug Fixes**
  * Prevent orphaned storage objects/DB rows on duplicate create; enforce typed delete semantics; more direct file deletion in bulk removes.

* **Chores**
  * Raise kernel cache TTLs and unify read-cache size limits; add path-indexing to commit queue; improve flush/create fallback handling.

* **Tests**
  * Expanded coverage for create/delete hints, cache behavior, write-back listing, orphan cleanup, and path-indexing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/420)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->