### PR TITLE
Make fork provisioning asynchronous

### DIFF
--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -52,7 +52,7 @@ func ctxUsage() string {
   import --from-file <path>                           add delegated context from file (must be mode 0600)
   import --from-file -                                add delegated context from stdin explicitly
   import                                              add delegated context from stdin (default when stdin is a pipe)
-  fork <new> [--from <ctx>] [--use] [--json]          create a copy-on-write fork context
+  fork [<new>] [--from <ctx>] [--use] [--json]        create a copy-on-write fork context
   ls [-l|--json]                                      list contexts
   use <name>                                          activate a context
   rm <name>                                           delete a context`
@@ -334,9 +334,6 @@ func ctxAdd(cfg *Config, name string, ctx *Context) (*Context, error) {
 }
 
 func ctxForkCmd(args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("usage: drive9 ctx fork <new> [--from <ctx>] [--use] [--json]")
-	}
 	newName := ""
 	fromName := ""
 	useNew := false
@@ -355,20 +352,20 @@ func ctxForkCmd(args []string) error {
 			jsonOut = true
 		default:
 			if strings.HasPrefix(args[i], "-") {
-				return fmt.Errorf("unknown flag %q\nusage: drive9 ctx fork <new> [--from <ctx>] [--use] [--json]", args[i])
+				return fmt.Errorf("unknown flag %q\nusage: drive9 ctx fork [<new>] [--from <ctx>] [--use] [--json]", args[i])
 			}
 			if newName != "" {
-				return fmt.Errorf("unexpected argument %q\nusage: drive9 ctx fork <new> [--from <ctx>] [--use] [--json]", args[i])
+				return fmt.Errorf("unexpected argument %q\nusage: drive9 ctx fork [<new>] [--from <ctx>] [--use] [--json]", args[i])
 			}
 			newName = args[i]
 		}
 	}
-	if newName == "" {
-		return fmt.Errorf("usage: drive9 ctx fork <new> [--from <ctx>] [--use] [--json]")
-	}
 	cfg := loadConfig()
 	if cfg.Contexts == nil {
 		cfg.Contexts = map[string]*Context{}
+	}
+	if newName == "" {
+		newName = randomName()
 	}
 	if _, exists := cfg.Contexts[newName]; exists {
 		return fmt.Errorf("context %q already exists; use a different name", newName)
@@ -396,13 +393,13 @@ func ctxForkCmd(args []string) error {
 
 	body, _ := json.Marshal(map[string]string{"name": newName})
 	c := client.New(server, source.APIKey)
-	resp, err := c.RawPost("/v1/ctx/fork", strings.NewReader(string(body)))
+	resp, err := c.RawPost("/v1/fork", strings.NewReader(string(body)))
 	if err != nil {
 		return fmt.Errorf("ctx fork failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	var result forkCtxResult
-	if resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
 		var errResp struct {
 			Error string `json:"error"`
 		}
@@ -443,6 +440,7 @@ type forkCtxResult struct {
 	TenantID       string `json:"tenant_id"`
 	APIKey         string `json:"api_key"`
 	Status         string `json:"status"`
+	Message        string `json:"message,omitempty"`
 	ParentTenantID string `json:"parent_tenant_id"`
 	Storage        string `json:"storage"`
 }

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -122,17 +122,17 @@ func TestCtxForkGeneratesNameWhenOmitted(t *testing.T) {
 		t.Fatalf("ctx fork: %v", err)
 	}
 	if sawName == "" || sawName == "prod" {
-		t.Fatalf("generated request name = %q", sawName)
+		t.Errorf("generated request name = %q", sawName)
 	}
 	if !strings.Contains(out, "Forked prod -> "+sawName) || !strings.Contains(out, "Now using ctx "+sawName) {
-		t.Fatalf("unexpected output: %q", out)
+		t.Errorf("unexpected output: %q", out)
 	}
 	got := loadConfig()
 	if got.CurrentContext != sawName {
-		t.Fatalf("current context = %q, want %q", got.CurrentContext, sawName)
+		t.Errorf("current context = %q, want %q", got.CurrentContext, sawName)
 	}
 	if got.Contexts[sawName] == nil || got.Contexts[sawName].APIKey != "fork-key" || got.Contexts[sawName].Server != ts.URL {
-		t.Fatalf("generated fork context not persisted correctly: %#v", got.Contexts[sawName])
+		t.Errorf("generated fork context not persisted correctly: %#v", got.Contexts[sawName])
 	}
 }
 

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -33,7 +33,7 @@ func TestCtxForkCreatesOwnerContextAndSwitchesWhenRequested(t *testing.T) {
 	withIsolatedHome(t)
 	var sawName string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/v1/ctx/fork" {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/fork" {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer source-key" {
@@ -46,11 +46,11 @@ func TestCtxForkCreatesOwnerContextAndSwitchesWhenRequested(t *testing.T) {
 			t.Fatalf("decode request: %v", err)
 		}
 		sawName = body.Name
-		w.WriteHeader(http.StatusCreated)
+		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"tenant_id":        "fork-tenant",
 			"api_key":          "fork-key",
-			"status":           "active",
+			"status":           "provisioning",
 			"parent_tenant_id": "source-tenant",
 			"storage":          "shared",
 		})
@@ -81,6 +81,58 @@ func TestCtxForkCreatesOwnerContextAndSwitchesWhenRequested(t *testing.T) {
 	}
 	if got.Contexts["exp"] == nil || got.Contexts["exp"].APIKey != "fork-key" || got.Contexts["exp"].Server != ts.URL {
 		t.Fatalf("fork context not persisted correctly: %#v", got.Contexts["exp"])
+	}
+}
+
+func TestCtxForkGeneratesNameWhenOmitted(t *testing.T) {
+	withIsolatedHome(t)
+	var sawName string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/fork" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var body struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		sawName = body.Name
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"tenant_id":        "fork-tenant",
+			"api_key":          "fork-key",
+			"status":           "provisioning",
+			"parent_tenant_id": "source-tenant",
+			"storage":          "shared",
+		})
+	}))
+	defer ts.Close()
+
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "prod", &Context{Type: PrincipalOwner, APIKey: "source-key", Server: ts.URL}); err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"fork", "--use"}) })
+	if err != nil {
+		t.Fatalf("ctx fork: %v", err)
+	}
+	if sawName == "" || sawName == "prod" {
+		t.Fatalf("generated request name = %q", sawName)
+	}
+	if !strings.Contains(out, "Forked prod -> "+sawName) || !strings.Contains(out, "Now using ctx "+sawName) {
+		t.Fatalf("unexpected output: %q", out)
+	}
+	got := loadConfig()
+	if got.CurrentContext != sawName {
+		t.Fatalf("current context = %q, want %q", got.CurrentContext, sawName)
+	}
+	if got.Contexts[sawName] == nil || got.Contexts[sawName].APIKey != "fork-key" || got.Contexts[sawName].Server != ts.URL {
+		t.Fatalf("generated fork context not persisted correctly: %#v", got.Contexts[sawName])
 	}
 }
 

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -280,7 +280,7 @@ func usage(code int) {
 			"                         add owner context\n"+
 			"  ctx import [--from-file <path|->] [--name NAME]\n"+
 			"                         add delegated context\n"+
-			"  ctx fork <new> [--from <ctx>] [--use] [--json]\n"+
+			"  ctx fork [<new>] [--from <ctx>] [--use] [--json]\n"+
 			"                         create a copy-on-write fork context\n"+
 			"  ctx ls [-l|--json]     list contexts\n"+
 			"  ctx use <name>         activate context\n"+

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -453,17 +453,18 @@ func TestTenantStatusReturnsProvisioningState(t *testing.T) {
 }
 
 func TestTenantStatusReturnsForkProvisioningMessage(t *testing.T) {
-	srv, tok, cleanup := newAuthServer(t)
+	rt, cleanup := newAuthRuntime(t)
 	defer cleanup()
-	if _, err := srv.meta.DB().Exec("UPDATE tenants SET status = ?, kind = ?, parent_tenant_id = ?, branch_id = ?",
-		string(meta.TenantProvisioning), string(meta.TenantKindFork), "source", ""); err != nil {
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	if _, err := srv.meta.DB().Exec("UPDATE tenants SET status = ?, kind = ?, parent_tenant_id = ?, branch_id = ? WHERE id = ?",
+		string(meta.TenantProvisioning), string(meta.TenantKindFork), "source", "", rt.tenantID); err != nil {
 		t.Fatal(err)
 	}
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
-	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Authorization", "Bearer "+rt.token)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -451,3 +451,35 @@ func TestTenantStatusReturnsProvisioningState(t *testing.T) {
 		t.Fatalf("expected provisioning status, got %+v", out)
 	}
 }
+
+func TestTenantStatusReturnsForkProvisioningMessage(t *testing.T) {
+	srv, tok, cleanup := newAuthServer(t)
+	defer cleanup()
+	if _, err := srv.meta.DB().Exec("UPDATE tenants SET status = ?, kind = ?, parent_tenant_id = ?, branch_id = ?",
+		string(meta.TenantProvisioning), string(meta.TenantKindFork), "source", ""); err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var out TenantStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != string(meta.TenantProvisioning) {
+		t.Fatalf("status = %q, want provisioning", out.Status)
+	}
+	if !strings.Contains(out.Message, "Creating the database branch") {
+		t.Fatalf("message = %q", out.Message)
+	}
+}

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -39,6 +39,39 @@ var (
 	forkProvisionMaxBackoff     = 30 * time.Second
 )
 
+func (s *Server) startForkProvision(ctx context.Context, forkID string) {
+	s.startForkWorker(ctx, func(workerCtx context.Context) {
+		s.provisionForkTenantAsync(workerCtx, forkID)
+	})
+}
+
+func (s *Server) startForkCleanup(ctx context.Context, forkID string) {
+	s.startForkWorker(ctx, func(workerCtx context.Context) {
+		s.cleanupForkTenant(workerCtx, forkID)
+	})
+}
+
+func (s *Server) startForkWorker(ctx context.Context, fn func(context.Context)) {
+	workerCtx := backgroundWithTrace(ctx)
+	if s.forkWorkerCtx != nil {
+		workerCtx = contextWithTrace(s.forkWorkerCtx, ctx)
+	}
+
+	s.forkWorkerMu.Lock()
+	if s.forkWorkerClosed {
+		s.forkWorkerMu.Unlock()
+		logger.Warn(workerCtx, "fork_worker_start_after_close")
+		return
+	}
+	s.forkWorkerWG.Add(1)
+	s.forkWorkerMu.Unlock()
+
+	go func() {
+		defer s.forkWorkerWG.Done()
+		fn(workerCtx)
+	}()
+}
+
 func (s *Server) handleFork(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPost:
@@ -229,7 +262,7 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		return nil, err
 	}
 
-	go s.provisionForkTenantAsync(backgroundWithTrace(ctx), forkID)
+	s.startForkProvision(ctx, forkID)
 
 	return &forkResponse{
 		TenantID:       forkID,
@@ -243,16 +276,26 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 }
 
 func (s *Server) provisionForkTenantAsync(ctx context.Context, forkID string) {
-	ctx = backgroundWithTrace(ctx)
+	ctx = ensureTrace(ctx)
 	logger.Info(ctx, "fork_provision_started", zap.String("tenant_id", forkID))
 	deadline := time.Now().Add(forkProvisionRetryWindow)
 	backoff := forkProvisionInitialBackoff
 	attempt := 1
 	for {
+		select {
+		case <-ctx.Done():
+			logger.Info(ctx, "fork_provision_stopped", zap.String("tenant_id", forkID), zap.Error(ctx.Err()))
+			return
+		default:
+		}
 		if err := s.provisionForkTenantOnce(ctx, forkID); err == nil {
 			logger.Info(ctx, "fork_provision_ok", zap.String("tenant_id", forkID), zap.Int("attempt", attempt))
 			return
 		} else {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				logger.Info(ctx, "fork_provision_stopped", zap.String("tenant_id", forkID), zap.Int("attempt", attempt), zap.Error(err))
+				return
+			}
 			var fatal *forkFatalProvisionError
 			if errors.As(err, &fatal) || time.Now().After(deadline) {
 				logger.Error(ctx, "fork_provision_failed",
@@ -276,7 +319,19 @@ func (s *Server) provisionForkTenantAsync(ctx context.Context, forkID string) {
 			sleepFor = time.Until(deadline)
 		}
 		if sleepFor > 0 {
-			time.Sleep(sleepFor)
+			timer := time.NewTimer(sleepFor)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				logger.Info(ctx, "fork_provision_stopped", zap.String("tenant_id", forkID), zap.Error(ctx.Err()))
+				return
+			case <-timer.C:
+			}
 		}
 		backoff *= 2
 		attempt++
@@ -459,7 +514,7 @@ func (s *Server) markForkFailed(ctx context.Context, forkID string) {
 
 func (s *Server) markForkFailedAndCleanup(ctx context.Context, forkID string) {
 	s.markForkFailed(ctx, forkID)
-	go s.cleanupForkTenant(backgroundWithTrace(ctx), forkID)
+	s.startForkCleanup(ctx, forkID)
 }
 
 func clusterInfoFromTenant(t *meta.Tenant) *tenant.ClusterInfo {
@@ -561,13 +616,13 @@ func (s *Server) handleForkDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
-	go s.cleanupForkTenant(backgroundWithTrace(r.Context()), t.ID)
+	s.startForkCleanup(r.Context(), t.ID)
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": string(meta.TenantDeleting)})
 }
 
 func (s *Server) cleanupForkTenant(ctx context.Context, tenantID string) {
-	ctx = backgroundWithTrace(ctx)
+	ctx = ensureTrace(ctx)
 	t, err := s.meta.GetTenant(ctx, tenantID)
 	if err != nil {
 		logger.Error(ctx, "fork_cleanup_get_tenant_failed", zap.String("tenant_id", tenantID), zap.Error(err))

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -103,7 +103,10 @@ func forkProvisioningMessage(t *meta.Tenant) string {
 	if t == nil || t.BranchID == "" {
 		return "Creating the database branch. This usually takes 30 seconds to a few minutes."
 	}
-	return "Database branch is ready; preparing fork metadata and quota counters. Large tenants may take a few minutes."
+	if t.DBHost == "" || t.DBPort == 0 || t.DBUser == "" {
+		return "Waiting for the database branch to become ready. This usually takes 30 seconds to a few minutes."
+	}
+	return "Preparing fork metadata and quota counters. Large tenants may take a few minutes."
 }
 
 type forkFatalProvisionError struct {
@@ -174,6 +177,7 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		cluster.Provider = source.Provider
 	}
 	if err != nil {
+		s.deleteForkBranchOrPersist(ctx, forkID, branchProvisioner, cluster)
 		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
@@ -194,19 +198,19 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		ClaimURL:         cluster.ClaimURL,
 		ClaimExpiresAt:   cluster.ClaimExpiresAt,
 	}); err != nil {
-		_ = branchProvisioner.DeleteBranch(ctx, cluster.ClusterID, cluster.BranchID)
+		s.deleteForkBranchOrPersist(ctx, forkID, branchProvisioner, cluster)
 		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
 
 	apiToken, err := token.IssueToken(s.tokenSecret, forkID, 1)
 	if err != nil {
-		s.markForkFailed(ctx, forkID)
+		s.markForkFailedAndCleanup(ctx, forkID)
 		return nil, err
 	}
 	cipherToken, err := s.pool.Encrypt(ctx, []byte(apiToken))
 	if err != nil {
-		s.markForkFailed(ctx, forkID)
+		s.markForkFailedAndCleanup(ctx, forkID)
 		return nil, err
 	}
 	if err := s.meta.InsertAPIKey(ctx, &meta.APIKey{
@@ -221,7 +225,7 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		CreatedAt:     time.Now().UTC(),
 		UpdatedAt:     time.Now().UTC(),
 	}); err != nil {
-		s.markForkFailed(ctx, forkID)
+		s.markForkFailedAndCleanup(ctx, forkID)
 		return nil, err
 	}
 
@@ -331,7 +335,7 @@ func (s *Server) provisionForkTenantOnce(ctx context.Context, forkID string) err
 	if active, err := store.HasActiveUploads(ctx); err != nil {
 		return err
 	} else if active {
-		return forkErr(http.StatusConflict, "source snapshot contains active uploads")
+		return &forkFatalProvisionError{err: forkErr(http.StatusConflict, "source snapshot contains active uploads")}
 	}
 	if err := store.SanitizeForkRuntimeState(ctx); err != nil {
 		return err
@@ -386,41 +390,28 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		return tenantDSN(cluster.Username, string(plain), cluster.Host, cluster.Port, cluster.DBName, true), nil
 	}
 
-	cluster, err := branchProvisioner.CreateBranch(ctx, forkTenant.ID, clusterInfoFromTenant(source))
+	sourcePassword, err := s.pool.Decrypt(ctx, source.DBPasswordCipher)
+	if err != nil {
+		return "", err
+	}
+	sourceCluster := clusterInfoFromTenant(source)
+	sourceCluster.Password = string(sourcePassword)
+	cluster, err := branchProvisioner.CreateBranch(ctx, forkTenant.ID, sourceCluster)
 	if cluster != nil {
 		cluster.Provider = source.Provider
 	}
 	if err != nil {
-		if cluster != nil && cluster.ClusterID != "" && cluster.BranchID != "" {
-			if derr := branchProvisioner.DeleteBranch(ctx, cluster.ClusterID, cluster.BranchID); derr != nil {
-				if perr := s.meta.UpdateTenantBranch(ctx, forkTenant.ID, &meta.Tenant{
-					Provider:       cluster.Provider,
-					ClusterID:      cluster.ClusterID,
-					BranchID:       cluster.BranchID,
-					ClaimURL:       cluster.ClaimURL,
-					ClaimExpiresAt: cluster.ClaimExpiresAt,
-				}); perr != nil {
-					logger.Error(ctx, "fork_persist_branch_after_delete_failure_failed",
-						zap.String("tenant_id", forkTenant.ID),
-						zap.String("cluster_id", cluster.ClusterID),
-						zap.String("branch_id", cluster.BranchID),
-						zap.Error(perr))
-				}
-				return "", &forkFatalProvisionError{err: derr}
-			}
-		}
+		s.deleteForkBranchOrPersist(ctx, forkTenant.ID, branchProvisioner, cluster)
 		return "", err
 	}
-	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
-	if err != nil {
-		_ = branchProvisioner.DeleteBranch(ctx, cluster.ClusterID, cluster.BranchID)
-		return "", err
+	if cluster == nil || cluster.ClusterID == "" || cluster.BranchID == "" {
+		return "", forkErr(http.StatusBadGateway, "starter branch response missing required metadata")
 	}
 	if err := s.meta.UpdateTenantConnection(ctx, forkTenant.ID, &meta.Tenant{
 		DBHost:           cluster.Host,
 		DBPort:           cluster.Port,
 		DBUser:           cluster.Username,
-		DBPasswordCipher: cipherPass,
+		DBPasswordCipher: source.DBPasswordCipher,
 		DBName:           cluster.DBName,
 		DBTLS:            true,
 		Provider:         cluster.Provider,
@@ -429,13 +420,35 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		ClaimURL:         cluster.ClaimURL,
 		ClaimExpiresAt:   cluster.ClaimExpiresAt,
 	}); err != nil {
-		_ = branchProvisioner.DeleteBranch(ctx, cluster.ClusterID, cluster.BranchID)
+		s.deleteForkBranchOrPersist(ctx, forkTenant.ID, branchProvisioner, cluster)
 		return "", err
 	}
 	if cluster.Host == "" || cluster.Port == 0 || cluster.Username == "" {
 		return "", forkErr(http.StatusServiceUnavailable, "database branch is not active yet")
 	}
-	return tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true), nil
+	return tenantDSN(cluster.Username, string(sourcePassword), cluster.Host, cluster.Port, cluster.DBName, true), nil
+}
+
+func (s *Server) deleteForkBranchOrPersist(ctx context.Context, forkID string, branchProvisioner tenant.BranchProvisioner, cluster *tenant.ClusterInfo) {
+	if cluster == nil || cluster.ClusterID == "" || cluster.BranchID == "" {
+		return
+	}
+	if err := branchProvisioner.DeleteBranch(ctx, cluster.ClusterID, cluster.BranchID); err == nil {
+		return
+	}
+	if perr := s.meta.UpdateTenantBranch(ctx, forkID, &meta.Tenant{
+		Provider:       cluster.Provider,
+		ClusterID:      cluster.ClusterID,
+		BranchID:       cluster.BranchID,
+		ClaimURL:       cluster.ClaimURL,
+		ClaimExpiresAt: cluster.ClaimExpiresAt,
+	}); perr != nil {
+		logger.Error(ctx, "fork_persist_branch_after_delete_failure_failed",
+			zap.String("tenant_id", forkID),
+			zap.String("cluster_id", cluster.ClusterID),
+			zap.String("branch_id", cluster.BranchID),
+			zap.Error(perr))
+	}
 }
 
 func (s *Server) markForkFailed(ctx context.Context, forkID string) {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -19,26 +19,40 @@ import (
 	"go.uber.org/zap"
 )
 
-type forkContextRequest struct {
+type forkRequest struct {
 	Name string `json:"name"`
 }
 
-type forkContextResponse struct {
+type forkResponse struct {
 	TenantID       string `json:"tenant_id"`
 	Name           string `json:"name"`
 	APIKey         string `json:"api_key"`
 	Status         string `json:"status"`
+	Message        string `json:"message,omitempty"`
 	ParentTenantID string `json:"parent_tenant_id"`
 	Storage        string `json:"storage"`
 }
 
-func (s *Server) handleCtxFork(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
+var (
+	forkProvisionRetryWindow    = 30 * time.Minute
+	forkProvisionInitialBackoff = 2 * time.Second
+	forkProvisionMaxBackoff     = 30 * time.Second
+)
+
+func (s *Server) handleFork(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		s.handleForkCreate(w, r)
+	case http.MethodDelete:
+		s.handleForkDelete(w, r)
+	default:
 		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
-		return
 	}
+}
+
+func (s *Server) handleForkCreate(w http.ResponseWriter, r *http.Request) {
 	if s.meta == nil || s.pool == nil || s.provisioner == nil || len(s.tokenSecret) == 0 {
-		errJSON(w, http.StatusNotFound, "ctx fork not enabled")
+		errJSON(w, http.StatusNotFound, "fork not enabled")
 		return
 	}
 	scope := ScopeFromContext(r.Context())
@@ -46,7 +60,7 @@ func (s *Server) handleCtxFork(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
-	var req forkContextRequest
+	var req forkRequest
 	if r.Body != nil {
 		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			errJSON(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
@@ -70,7 +84,7 @@ func (s *Server) handleCtxFork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
+	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
@@ -85,7 +99,22 @@ func forkErr(code int, msg string) error {
 	return &forkStatusError{code: code, msg: msg}
 }
 
-func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayName string) (*forkContextResponse, error) {
+func forkProvisioningMessage(t *meta.Tenant) string {
+	if t == nil || t.BranchID == "" {
+		return "Creating the database branch. This usually takes 30 seconds to a few minutes."
+	}
+	return "Database branch is ready; preparing fork metadata and quota counters. Large tenants may take a few minutes."
+}
+
+type forkFatalProvisionError struct {
+	err error
+}
+
+func (e *forkFatalProvisionError) Error() string { return e.err.Error() }
+
+func (e *forkFatalProvisionError) Unwrap() error { return e.err }
+
+func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayName string) (*forkResponse, error) {
 	// The CLI stores the user-facing ctx name locally; MetaDB tenants currently
 	// have no display-name column. We echo the name back in the response so the
 	// CLI can confirm the server received it.
@@ -97,19 +126,23 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		return nil, forkErr(http.StatusConflict, "source tenant is not active")
 	}
 	if source.Provider != tenant.ProviderTiDBCloudStarter {
-		return nil, forkErr(http.StatusConflict, "ctx fork requires TiDB Cloud Starter provider")
+		return nil, forkErr(http.StatusConflict, "fork requires TiDB Cloud Starter provider")
 	}
 	if source.StorageNamespaceID == "" {
 		return nil, forkErr(http.StatusConflict, "source tenant storage namespace is not initialized")
 	}
-	branchProvisioner, ok := s.provisioner.(tenant.BranchProvisioner)
+	branchProvisioner, ok := s.provisioner.(tenant.AsyncBranchProvisioner)
 	if !ok {
-		return nil, forkErr(http.StatusConflict, "ctx fork requires branch-capable provisioner")
+		return nil, forkErr(http.StatusConflict, "fork requires branch-capable provisioner")
 	}
 	if hasReservations, err := s.sourceHasActiveUploadReservations(ctx, source.ID); err != nil {
 		return nil, err
 	} else if hasReservations {
 		return nil, forkErr(http.StatusConflict, "source tenant has active upload reservations")
+	}
+	sourcePassword, err := s.pool.Decrypt(ctx, source.DBPasswordCipher)
+	if err != nil {
+		return nil, err
 	}
 
 	forkID := token.NewID()
@@ -134,34 +167,25 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		return nil, err
 	}
 
-	cluster, err := branchProvisioner.ProvisionBranch(ctx, forkID, clusterInfoFromTenant(source))
+	sourceCluster := clusterInfoFromTenant(source)
+	sourceCluster.Password = string(sourcePassword)
+	cluster, err := branchProvisioner.CreateBranch(ctx, forkID, sourceCluster)
 	if cluster != nil {
 		cluster.Provider = source.Provider
 	}
 	if err != nil {
-		s.handleForkBranchProvisionError(ctx, forkID, branchProvisioner, cluster)
+		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
-	if err := s.meta.UpdateTenantBranch(ctx, forkID, &meta.Tenant{
-		Provider:       cluster.Provider,
-		ClusterID:      cluster.ClusterID,
-		BranchID:       cluster.BranchID,
-		ClaimURL:       cluster.ClaimURL,
-		ClaimExpiresAt: cluster.ClaimExpiresAt,
-	}); err != nil {
-		s.deleteUnpersistedForkBranch(ctx, forkID, branchProvisioner, cluster)
-		return nil, err
-	}
-	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
-	if err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return nil, err
+	if cluster == nil || cluster.ClusterID == "" || cluster.BranchID == "" {
+		s.markForkFailed(ctx, forkID)
+		return nil, forkErr(http.StatusBadGateway, "starter branch response missing required metadata")
 	}
 	if err := s.meta.UpdateTenantConnection(ctx, forkID, &meta.Tenant{
 		DBHost:           cluster.Host,
 		DBPort:           cluster.Port,
 		DBUser:           cluster.Username,
-		DBPasswordCipher: cipherPass,
+		DBPasswordCipher: forkRoot.DBPasswordCipher,
 		DBName:           cluster.DBName,
 		DBTLS:            true,
 		Provider:         cluster.Provider,
@@ -170,57 +194,19 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		ClaimURL:         cluster.ClaimURL,
 		ClaimExpiresAt:   cluster.ClaimExpiresAt,
 	}); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
+		_ = branchProvisioner.DeleteBranch(ctx, cluster.ClusterID, cluster.BranchID)
+		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
 
-	dsn := tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true)
-	if err := s.provisioner.InitSchema(ctx, dsn); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return nil, err
-	}
-	store, err := datastore.Open(dsn)
-	if err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return nil, err
-	}
-	defer func() { _ = store.Close() }()
-
-	if active, err := store.HasActiveUploads(ctx); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return nil, err
-	} else if active {
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return nil, forkErr(http.StatusConflict, "source snapshot contains active uploads")
-	}
-	if err := store.SanitizeForkRuntimeState(ctx); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return nil, err
-	}
-	if err := s.meta.CopyQuotaConfig(ctx, source.ID, forkID); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return nil, err
-	}
-	if err := s.backfillForkQuota(ctx, forkID, store); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return nil, err
-	}
-	if err := s.meta.UpdateTenantSchemaVersion(ctx, forkID, schema.CurrentTiDBTenantSchemaVersion); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return nil, err
-	}
-	if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantActive); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return nil, err
-	}
 	apiToken, err := token.IssueToken(s.tokenSecret, forkID, 1)
 	if err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
+		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
 	cipherToken, err := s.pool.Encrypt(ctx, []byte(apiToken))
 	if err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
+		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
 	if err := s.meta.InsertAPIKey(ctx, &meta.APIKey{
@@ -235,17 +221,221 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		CreatedAt:     time.Now().UTC(),
 		UpdatedAt:     time.Now().UTC(),
 	}); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
+		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
-	return &forkContextResponse{
+
+	go s.provisionForkTenantAsync(backgroundWithTrace(ctx), forkID)
+
+	return &forkResponse{
 		TenantID:       forkID,
 		Name:           displayName,
 		APIKey:         apiToken,
-		Status:         string(meta.TenantActive),
+		Status:         string(meta.TenantProvisioning),
+		Message:        forkProvisioningMessage(&forkRoot),
 		ParentTenantID: source.ID,
 		Storage:        "shared",
 	}, nil
+}
+
+func (s *Server) provisionForkTenantAsync(ctx context.Context, forkID string) {
+	ctx = backgroundWithTrace(ctx)
+	logger.Info(ctx, "fork_provision_started", zap.String("tenant_id", forkID))
+	deadline := time.Now().Add(forkProvisionRetryWindow)
+	backoff := forkProvisionInitialBackoff
+	attempt := 1
+	for {
+		if err := s.provisionForkTenantOnce(ctx, forkID); err == nil {
+			logger.Info(ctx, "fork_provision_ok", zap.String("tenant_id", forkID), zap.Int("attempt", attempt))
+			return
+		} else {
+			var fatal *forkFatalProvisionError
+			if errors.As(err, &fatal) || time.Now().After(deadline) {
+				logger.Error(ctx, "fork_provision_failed",
+					zap.String("tenant_id", forkID),
+					zap.Int("attempt", attempt),
+					zap.Error(err))
+				s.markForkFailedAndCleanup(ctx, forkID)
+				return
+			}
+			logger.Warn(ctx, "fork_provision_retry",
+				zap.String("tenant_id", forkID),
+				zap.Int("attempt", attempt),
+				zap.Duration("backoff", backoff),
+				zap.Error(err))
+		}
+		sleepFor := backoff
+		if sleepFor > forkProvisionMaxBackoff {
+			sleepFor = forkProvisionMaxBackoff
+		}
+		if time.Now().Add(sleepFor).After(deadline) {
+			sleepFor = time.Until(deadline)
+		}
+		if sleepFor > 0 {
+			time.Sleep(sleepFor)
+		}
+		backoff *= 2
+		attempt++
+	}
+}
+
+func (s *Server) provisionForkTenantOnce(ctx context.Context, forkID string) error {
+	forkTenant, err := s.meta.GetTenant(ctx, forkID)
+	if err != nil {
+		return err
+	}
+	if forkTenant.Kind != meta.TenantKindFork {
+		return &forkFatalProvisionError{err: forkErr(http.StatusConflict, "tenant is not a fork")}
+	}
+	switch forkTenant.Status {
+	case meta.TenantActive, meta.TenantDeleting, meta.TenantDeleted:
+		return nil
+	case meta.TenantProvisioning:
+	default:
+		return &forkFatalProvisionError{err: forkErr(http.StatusConflict, "fork tenant is not provisioning")}
+	}
+
+	source, err := s.meta.GetTenant(ctx, forkTenant.ParentTenantID)
+	if err != nil {
+		return err
+	}
+	if source.Status != meta.TenantActive {
+		return forkErr(http.StatusConflict, "source tenant is not active")
+	}
+	if source.Provider != tenant.ProviderTiDBCloudStarter {
+		return &forkFatalProvisionError{err: forkErr(http.StatusConflict, "fork requires TiDB Cloud Starter provider")}
+	}
+	branchProvisioner, ok := s.provisioner.(tenant.AsyncBranchProvisioner)
+	if !ok {
+		return &forkFatalProvisionError{err: forkErr(http.StatusConflict, "fork requires branch-capable provisioner")}
+	}
+	if hasReservations, err := s.sourceHasActiveUploadReservations(ctx, source.ID); err != nil {
+		return err
+	} else if hasReservations {
+		return forkErr(http.StatusConflict, "source tenant has active upload reservations")
+	}
+
+	dsn, err := s.ensureForkBranchConnection(ctx, forkTenant, source, branchProvisioner)
+	if err != nil {
+		return err
+	}
+	if err := s.provisioner.InitSchema(ctx, dsn); err != nil {
+		return err
+	}
+	store, err := datastore.Open(dsn)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = store.Close() }()
+
+	if active, err := store.HasActiveUploads(ctx); err != nil {
+		return err
+	} else if active {
+		return forkErr(http.StatusConflict, "source snapshot contains active uploads")
+	}
+	if err := store.SanitizeForkRuntimeState(ctx); err != nil {
+		return err
+	}
+	if err := s.meta.CopyQuotaConfig(ctx, source.ID, forkID); err != nil {
+		return err
+	}
+	if err := s.backfillForkQuota(ctx, forkID, store); err != nil {
+		return err
+	}
+	if err := s.meta.UpdateTenantSchemaVersion(ctx, forkID, schema.CurrentTiDBTenantSchemaVersion); err != nil {
+		return err
+	}
+	return s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantActive)
+}
+
+func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, source *meta.Tenant, branchProvisioner tenant.AsyncBranchProvisioner) (string, error) {
+	if forkTenant.BranchID != "" {
+		plain, err := s.pool.Decrypt(ctx, forkTenant.DBPasswordCipher)
+		if err != nil {
+			return "", err
+		}
+		if forkTenant.DBHost != "" && forkTenant.DBPort != 0 && forkTenant.DBUser != "" {
+			return tenantDSN(forkTenant.DBUser, string(plain), forkTenant.DBHost, forkTenant.DBPort, forkTenant.DBName, forkTenant.DBTLS), nil
+		}
+		cluster, err := branchProvisioner.WaitForBranchActive(ctx, &tenant.ClusterInfo{
+			TenantID:  forkTenant.ID,
+			ClusterID: forkTenant.ClusterID,
+			BranchID:  forkTenant.BranchID,
+			Password:  string(plain),
+			DBName:    forkTenant.DBName,
+			Provider:  forkTenant.Provider,
+		})
+		if err != nil {
+			return "", err
+		}
+		if err := s.meta.UpdateTenantConnection(ctx, forkTenant.ID, &meta.Tenant{
+			DBHost:           cluster.Host,
+			DBPort:           cluster.Port,
+			DBUser:           cluster.Username,
+			DBPasswordCipher: forkTenant.DBPasswordCipher,
+			DBName:           cluster.DBName,
+			DBTLS:            true,
+			Provider:         cluster.Provider,
+			ClusterID:        cluster.ClusterID,
+			BranchID:         cluster.BranchID,
+			ClaimURL:         cluster.ClaimURL,
+			ClaimExpiresAt:   cluster.ClaimExpiresAt,
+		}); err != nil {
+			return "", err
+		}
+		return tenantDSN(cluster.Username, string(plain), cluster.Host, cluster.Port, cluster.DBName, true), nil
+	}
+
+	cluster, err := branchProvisioner.CreateBranch(ctx, forkTenant.ID, clusterInfoFromTenant(source))
+	if cluster != nil {
+		cluster.Provider = source.Provider
+	}
+	if err != nil {
+		if cluster != nil && cluster.ClusterID != "" && cluster.BranchID != "" {
+			if derr := branchProvisioner.DeleteBranch(ctx, cluster.ClusterID, cluster.BranchID); derr != nil {
+				if perr := s.meta.UpdateTenantBranch(ctx, forkTenant.ID, &meta.Tenant{
+					Provider:       cluster.Provider,
+					ClusterID:      cluster.ClusterID,
+					BranchID:       cluster.BranchID,
+					ClaimURL:       cluster.ClaimURL,
+					ClaimExpiresAt: cluster.ClaimExpiresAt,
+				}); perr != nil {
+					logger.Error(ctx, "fork_persist_branch_after_delete_failure_failed",
+						zap.String("tenant_id", forkTenant.ID),
+						zap.String("cluster_id", cluster.ClusterID),
+						zap.String("branch_id", cluster.BranchID),
+						zap.Error(perr))
+				}
+				return "", &forkFatalProvisionError{err: derr}
+			}
+		}
+		return "", err
+	}
+	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
+	if err != nil {
+		_ = branchProvisioner.DeleteBranch(ctx, cluster.ClusterID, cluster.BranchID)
+		return "", err
+	}
+	if err := s.meta.UpdateTenantConnection(ctx, forkTenant.ID, &meta.Tenant{
+		DBHost:           cluster.Host,
+		DBPort:           cluster.Port,
+		DBUser:           cluster.Username,
+		DBPasswordCipher: cipherPass,
+		DBName:           cluster.DBName,
+		DBTLS:            true,
+		Provider:         cluster.Provider,
+		ClusterID:        cluster.ClusterID,
+		BranchID:         cluster.BranchID,
+		ClaimURL:         cluster.ClaimURL,
+		ClaimExpiresAt:   cluster.ClaimExpiresAt,
+	}); err != nil {
+		_ = branchProvisioner.DeleteBranch(ctx, cluster.ClusterID, cluster.BranchID)
+		return "", err
+	}
+	if cluster.Host == "" || cluster.Port == 0 || cluster.Username == "" {
+		return "", forkErr(http.StatusServiceUnavailable, "database branch is not active yet")
+	}
+	return tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true), nil
 }
 
 func (s *Server) markForkFailed(ctx context.Context, forkID string) {
@@ -257,60 +447,6 @@ func (s *Server) markForkFailed(ctx context.Context, forkID string) {
 func (s *Server) markForkFailedAndCleanup(ctx context.Context, forkID string) {
 	s.markForkFailed(ctx, forkID)
 	go s.cleanupForkTenant(backgroundWithTrace(ctx), forkID)
-}
-
-func (s *Server) handleForkBranchProvisionError(ctx context.Context, forkID string, branchProvisioner tenant.BranchProvisioner, cluster *tenant.ClusterInfo) {
-	if cluster != nil && cluster.ClusterID != "" && cluster.BranchID != "" {
-		if err := s.meta.UpdateTenantBranch(ctx, forkID, &meta.Tenant{
-			Provider:       cluster.Provider,
-			ClusterID:      cluster.ClusterID,
-			BranchID:       cluster.BranchID,
-			ClaimURL:       cluster.ClaimURL,
-			ClaimExpiresAt: cluster.ClaimExpiresAt,
-		}); err != nil {
-			s.deleteUnpersistedForkBranch(ctx, forkID, branchProvisioner, cluster)
-			return
-		}
-		s.markForkFailedAndCleanup(ctx, forkID)
-		return
-	}
-	s.markForkFailed(ctx, forkID)
-}
-
-func (s *Server) deleteUnpersistedForkBranch(ctx context.Context, forkID string, branchProvisioner tenant.BranchProvisioner, cluster *tenant.ClusterInfo) {
-	if cluster != nil && cluster.ClusterID != "" && cluster.BranchID != "" {
-		if err := branchProvisioner.DeleteBranch(ctx, cluster.ClusterID, cluster.BranchID); err != nil {
-			logger.Error(ctx, "fork_delete_unpersisted_branch_failed",
-				zap.String("tenant_id", forkID),
-				zap.String("cluster_id", cluster.ClusterID),
-				zap.String("branch_id", cluster.BranchID),
-				zap.Error(err))
-			if perr := s.meta.UpdateTenantBranch(ctx, forkID, &meta.Tenant{
-				Provider:       cluster.Provider,
-				ClusterID:      cluster.ClusterID,
-				BranchID:       cluster.BranchID,
-				ClaimURL:       cluster.ClaimURL,
-				ClaimExpiresAt: cluster.ClaimExpiresAt,
-			}); perr != nil {
-				logger.Error(ctx, "fork_persist_branch_after_delete_failure_failed",
-					zap.String("tenant_id", forkID),
-					zap.String("cluster_id", cluster.ClusterID),
-					zap.String("branch_id", cluster.BranchID),
-					zap.Error(perr))
-				s.markForkFailed(ctx, forkID)
-				return
-			}
-			s.markForkFailedAndCleanup(ctx, forkID)
-			return
-		}
-	}
-	if cluster == nil || cluster.ClusterID == "" || cluster.BranchID == "" {
-		s.markForkFailed(ctx, forkID)
-		return
-	}
-	if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantDeleted); err != nil {
-		logger.Error(ctx, "fork_mark_deleted_after_unpersisted_branch_failed", zap.String("tenant_id", forkID), zap.Error(err))
-	}
 }
 
 func clusterInfoFromTenant(t *meta.Tenant) *tenant.ClusterInfo {
@@ -369,13 +505,9 @@ func forkQuotaMediaContentType(contentType string) bool {
 	return strings.HasPrefix(contentType, "image/") || strings.HasPrefix(contentType, "audio/")
 }
 
-func (s *Server) handleCtxDelete(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodDelete {
-		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
-		return
-	}
+func (s *Server) handleForkDelete(w http.ResponseWriter, r *http.Request) {
 	if s.meta == nil || s.pool == nil {
-		errJSON(w, http.StatusNotFound, "ctx delete not enabled")
+		errJSON(w, http.StatusNotFound, "fork delete not enabled")
 		return
 	}
 	scope := ScopeFromContext(r.Context())
@@ -393,7 +525,7 @@ func (s *Server) handleCtxDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if t.Kind != meta.TenantKindFork {
-		errJSON(w, http.StatusConflict, "only fork tenants can be deleted through ctx delete")
+		errJSON(w, http.StatusConflict, "only fork tenants can be deleted through fork delete")
 		return
 	}
 	if t.Status == meta.TenantDeleted {
@@ -552,7 +684,7 @@ func (s *Server) enqueueForkConfirmedRefs(ctx context.Context, t *meta.Tenant, s
 
 func (s *Server) resumeDeletingForkTenants() {
 	ctx := backgroundWithTrace(context.Background())
-	for _, status := range []meta.TenantStatus{meta.TenantDeleting, meta.TenantFailed, meta.TenantProvisioning} {
+	for _, status := range []meta.TenantStatus{meta.TenantDeleting, meta.TenantFailed} {
 		tenants, err := s.meta.ListTenantsByStatus(ctx, status, 1000)
 		if err != nil {
 			logger.Error(ctx, "resume_fork_cleanup_list_failed", zap.String("status", string(status)), zap.Error(err))

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -30,12 +30,35 @@ func (f *fakeBranchProvisioner) Provision(context.Context, string) (*tenant.Clus
 }
 
 func (f *fakeBranchProvisioner) ProvisionBranch(_ context.Context, forkTenantID string, _ *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
+	return f.CreateBranch(context.Background(), forkTenantID, nil)
+}
+
+func (f *fakeBranchProvisioner) CreateBranch(_ context.Context, forkTenantID string, _ *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
 	if f.cluster == nil {
 		return nil, errors.New("missing cluster")
 	}
 	out := *f.cluster
 	out.TenantID = forkTenantID
-	return &out, f.provisionErr
+	out.Host = ""
+	out.Port = 0
+	out.Username = ""
+	return &out, nil
+}
+
+func (f *fakeBranchProvisioner) WaitForBranchActive(_ context.Context, branch *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
+	if f.provisionErr != nil {
+		return branch, f.provisionErr
+	}
+	if f.cluster == nil {
+		return nil, errors.New("missing cluster")
+	}
+	out := *f.cluster
+	out.TenantID = branch.TenantID
+	out.Password = branch.Password
+	if out.DBName == "" {
+		out.DBName = branch.DBName
+	}
+	return &out, nil
 }
 
 func (f *fakeBranchProvisioner) DeleteBranch(_ context.Context, clusterID, branchID string) error {
@@ -163,18 +186,35 @@ func waitForCondition(t *testing.T, fn func() bool) {
 }
 
 func TestCreateForkPartialBranchProvisionErrorPersistsBranchAndKeepsRoot(t *testing.T) {
+	origWindow, origInitialBackoff, origMaxBackoff := forkProvisionRetryWindow, forkProvisionInitialBackoff, forkProvisionMaxBackoff
+	forkProvisionRetryWindow = 50 * time.Millisecond
+	forkProvisionInitialBackoff = 5 * time.Millisecond
+	forkProvisionMaxBackoff = 5 * time.Millisecond
+	t.Cleanup(func() {
+		forkProvisionRetryWindow = origWindow
+		forkProvisionInitialBackoff = origInitialBackoff
+		forkProvisionMaxBackoff = origMaxBackoff
+	})
+
 	rt := newForkCleanupTestRuntime(t)
 	rt.insertLiveTenant(t, "source")
 	rt.prov.cluster = &tenant.ClusterInfo{ClusterID: "cluster-a", BranchID: "branch-created"}
 	rt.prov.provisionErr = errors.New("starter branch not active before timeout")
 	rt.prov.deleteErr = errors.New("delete branch failed")
 
-	_, err := rt.server.createForkTenant(context.Background(), "source", "fork")
-	if err == nil {
-		t.Fatal("expected createForkTenant error")
+	resp, err := rt.server.createForkTenant(context.Background(), "source", "fork")
+	if err != nil {
+		t.Fatalf("createForkTenant: %v", err)
+	}
+	if resp.Status != string(meta.TenantProvisioning) || resp.APIKey == "" {
+		t.Fatalf("unexpected fork response: %+v", resp)
 	}
 	waitForCondition(t, func() bool {
-		return len(rt.prov.deletedBranches()) == 1
+		return len(rt.prov.deletedBranches()) >= 1
+	})
+	waitForCondition(t, func() bool {
+		failed, err := rt.meta.ListTenantsByStatus(context.Background(), meta.TenantFailed, 10)
+		return err == nil && len(failed) == 1
 	})
 
 	failed, err := rt.meta.ListTenantsByStatus(context.Background(), meta.TenantFailed, 10)
@@ -187,7 +227,7 @@ func TestCreateForkPartialBranchProvisionErrorPersistsBranchAndKeepsRoot(t *test
 	if failed[0].BranchID != "branch-created" || failed[0].ClusterID != "cluster-a" {
 		t.Fatalf("failed fork branch metadata = cluster:%q branch:%q", failed[0].ClusterID, failed[0].BranchID)
 	}
-	if deleted := rt.prov.deletedBranches(); deleted[0] != "cluster-a/branch-created" {
+	if deleted := rt.prov.deletedBranches(); len(deleted) == 0 || deleted[0] != "cluster-a/branch-created" {
 		t.Fatalf("deleted branches = %#v", deleted)
 	}
 }
@@ -209,6 +249,27 @@ func TestCleanupFailedForkDoesNotMarkDeletedWhenBranchDeleteFails(t *testing.T) 
 	if deleted := rt.prov.deletedBranches(); len(deleted) != 1 || deleted[0] != "cluster-a/branch-a" {
 		t.Fatalf("deleted branches = %#v", deleted)
 	}
+}
+
+func TestResumeProvisioningForkActivatesBranchBackedTenant(t *testing.T) {
+	rt := newForkCleanupTestRuntime(t)
+	rt.prov.cluster = &tenant.ClusterInfo{
+		ClusterID: "cluster-a",
+		BranchID:  "branch-a",
+		Host:      rt.dbHost,
+		Port:      rt.dbPort,
+		Username:  rt.dbUser,
+		DBName:    rt.dbName,
+	}
+	rt.insertLiveTenant(t, "parent")
+	rt.insertForkTenant(t, "fork-provisioning", meta.TenantProvisioning, "branch-a")
+
+	rt.server.resumeProvisioningTenants()
+
+	waitForCondition(t, func() bool {
+		got, err := rt.meta.GetTenant(context.Background(), "fork-provisioning")
+		return err == nil && got.Status == meta.TenantActive
+	})
 }
 
 func TestCleanupDeletingForkEnqueuesFileGCTaskRefsBeforeSanitize(t *testing.T) {

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -29,11 +29,16 @@ func (f *fakeBranchProvisioner) Provision(context.Context, string) (*tenant.Clus
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (f *fakeBranchProvisioner) ProvisionBranch(_ context.Context, forkTenantID string, _ *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
-	return f.CreateBranch(context.Background(), forkTenantID, nil)
+func (f *fakeBranchProvisioner) ProvisionBranch(ctx context.Context, forkTenantID string, _ *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
+	return f.CreateBranch(ctx, forkTenantID, nil)
 }
 
-func (f *fakeBranchProvisioner) CreateBranch(_ context.Context, forkTenantID string, _ *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
+func (f *fakeBranchProvisioner) CreateBranch(ctx context.Context, forkTenantID string, _ *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 	if f.cluster == nil {
 		return nil, errors.New("missing cluster")
 	}
@@ -45,7 +50,12 @@ func (f *fakeBranchProvisioner) CreateBranch(_ context.Context, forkTenantID str
 	return &out, nil
 }
 
-func (f *fakeBranchProvisioner) WaitForBranchActive(_ context.Context, branch *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
+func (f *fakeBranchProvisioner) WaitForBranchActive(ctx context.Context, branch *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 	if f.provisionErr != nil {
 		return branch, f.provisionErr
 	}
@@ -187,7 +197,7 @@ func waitForCondition(t *testing.T, fn func() bool) {
 
 func TestCreateForkPartialBranchProvisionErrorPersistsBranchAndKeepsRoot(t *testing.T) {
 	origWindow, origInitialBackoff, origMaxBackoff := forkProvisionRetryWindow, forkProvisionInitialBackoff, forkProvisionMaxBackoff
-	forkProvisionRetryWindow = 50 * time.Millisecond
+	forkProvisionRetryWindow = 500 * time.Millisecond
 	forkProvisionInitialBackoff = 5 * time.Millisecond
 	forkProvisionMaxBackoff = 5 * time.Millisecond
 	t.Cleanup(func() {

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -140,8 +140,8 @@ func requestRoute(path string) string {
 		return "/v1/sql"
 	case path == "/v1/events":
 		return "/v1/events"
-	case path == "/v1/ctx" || path == "/v1/ctx/fork":
-		return "/v1/ctx/*"
+	case path == "/v1/fork":
+		return "/v1/fork"
 	case strings.HasPrefix(path, "/v1/fs/"):
 		return "/v1/fs/*"
 	case path == "/v1/uploads":

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -88,8 +88,10 @@ const DefaultMaxUploadBytes int64 = 10 * (1 << 30) // 10 GiB
 // shape is per-tenant so future tenant-scoped quotas plug in without a
 // protocol change.
 type TenantStatusResponse struct {
-	Status         string `json:"status"`
-	MaxUploadBytes int64  `json:"max_upload_bytes"`
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+
+	MaxUploadBytes int64 `json:"max_upload_bytes"`
 	// InlineThreshold is the server's DB-inline vs S3 storage cutoff. Clients
 	// use it to choose simple PUT vs V2 multipart upload so they stay
 	// consistent with server-side IsLargeFile gating. Omitted (zero) by old
@@ -165,8 +167,7 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v1/uploads", business)
 	mux.Handle("/v1/uploads/", business)
 	mux.Handle("/v2/uploads/", business)
-	mux.Handle("/v1/ctx/fork", business)
-	mux.Handle("/v1/ctx", business)
+	mux.Handle("/v1/fork", business)
 	mux.Handle("/v1/sql", business)
 	mux.Handle("/v1/events", business)
 	mux.Handle("/v1/journals", business)
@@ -296,9 +297,10 @@ func (s *Server) resumeProvisioningTenants() {
 	for i := range tenants {
 		t := tenants[i]
 		if t.Kind == meta.TenantKindFork {
-			logger.Warn(ctx, "resume_provisioning_fork_skipped",
+			logger.Info(ctx, "resume_provisioning_fork",
 				zap.String("tenant_id", t.ID),
 				zap.String("parent_tenant_id", t.ParentTenantID))
+			go s.provisionForkTenantAsync(ctx, t.ID)
 			continue
 		}
 		go s.resumeTenantSchemaInit(t)
@@ -370,10 +372,8 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 		s.handleUploadAction(w, r)
 	case strings.HasPrefix(r.URL.Path, "/v2/uploads/"):
 		s.handleV2Uploads(w, r)
-	case r.URL.Path == "/v1/ctx/fork":
-		s.handleCtxFork(w, r)
-	case r.URL.Path == "/v1/ctx":
-		s.handleCtxDelete(w, r)
+	case r.URL.Path == "/v1/fork":
+		s.handleFork(w, r)
 	case r.URL.Path == "/v1/sql":
 		s.handleSQL(w, r)
 	case r.URL.Path == "/v1/events":
@@ -466,9 +466,20 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_ok", "tenant_id", resolved.Tenant.ID, "status", resolved.Tenant.Status)...)
 	_ = json.NewEncoder(w).Encode(TenantStatusResponse{
 		Status:          string(resolved.Tenant.Status),
+		Message:         tenantStatusMessage(&resolved.Tenant),
 		MaxUploadBytes:  s.maxUploadBytes,
 		InlineThreshold: s.inlineThreshold,
 	})
+}
+
+func tenantStatusMessage(t *meta.Tenant) string {
+	if t == nil {
+		return ""
+	}
+	if t.Kind == meta.TenantKindFork && t.Status == meta.TenantProvisioning {
+		return forkProvisioningMessage(t)
+	}
+	return ""
 }
 
 func backendFromRequest(r *http.Request) *backend.Dat9Backend {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -70,6 +71,11 @@ type Server struct {
 	semanticWorker      *semanticWorkerManager
 	journalCursorSecret []byte
 	objectGCWorker      *objectGCWorker
+	forkWorkerCtx       context.Context
+	forkWorkerCancel    context.CancelFunc
+	forkWorkerWG        sync.WaitGroup
+	forkWorkerMu        sync.Mutex
+	forkWorkerClosed    bool
 }
 
 var (
@@ -137,6 +143,7 @@ func NewWithConfig(cfg Config) *Server {
 	if inlineThreshold <= 0 {
 		inlineThreshold = backend.DefaultInlineThreshold
 	}
+	forkWorkerCtx, forkWorkerCancel := context.WithCancel(context.Background())
 	s := &Server{
 		fallback:            cfg.Backend,
 		meta:                cfg.Meta,
@@ -152,6 +159,8 @@ func NewWithConfig(cfg Config) *Server {
 		logger:              logger,
 		events:              newEventBuses(),
 		journalCursorSecret: newJournalCursorSecret(cfg.TokenSecret),
+		forkWorkerCtx:       forkWorkerCtx,
+		forkWorkerCancel:    forkWorkerCancel,
 	}
 	mux := http.NewServeMux()
 
@@ -279,6 +288,15 @@ func NewWithConfig(cfg Config) *Server {
 }
 
 func (s *Server) Close() {
+	s.forkWorkerMu.Lock()
+	if !s.forkWorkerClosed {
+		s.forkWorkerClosed = true
+		if s.forkWorkerCancel != nil {
+			s.forkWorkerCancel()
+		}
+	}
+	s.forkWorkerMu.Unlock()
+	s.forkWorkerWG.Wait()
 	if s.semanticWorker != nil {
 		s.semanticWorker.Stop()
 	}
@@ -300,7 +318,7 @@ func (s *Server) resumeProvisioningTenants() {
 			logger.Info(ctx, "resume_provisioning_fork",
 				zap.String("tenant_id", t.ID),
 				zap.String("parent_tenant_id", t.ParentTenantID))
-			go s.provisionForkTenantAsync(ctx, t.ID)
+			s.startForkProvision(ctx, t.ID)
 			continue
 		}
 		go s.resumeTenantSchemaInit(t)
@@ -319,11 +337,22 @@ func (s *Server) resumeTenantSchemaInit(t meta.Tenant) {
 }
 
 func backgroundWithTrace(ctx context.Context) context.Context {
-	traceID := traceid.FromContext(ctx)
+	return contextWithTrace(context.Background(), ctx)
+}
+
+func ensureTrace(ctx context.Context) context.Context {
+	if traceid.FromContext(ctx) != "" {
+		return ctx
+	}
+	return traceid.With(ctx, traceid.Generate())
+}
+
+func contextWithTrace(parent, traceSource context.Context) context.Context {
+	traceID := traceid.FromContext(traceSource)
 	if traceID == "" {
 		traceID = traceid.Generate()
 	}
-	return traceid.With(context.Background(), traceID)
+	return traceid.With(parent, traceID)
 }
 
 func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled bool) string {

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -32,6 +32,12 @@ type BranchProvisioner interface {
 	DeleteBranch(ctx context.Context, clusterID, branchID string) error
 }
 
+type AsyncBranchProvisioner interface {
+	BranchProvisioner
+	CreateBranch(ctx context.Context, forkTenantID string, source *ClusterInfo) (*ClusterInfo, error)
+	WaitForBranchActive(ctx context.Context, branch *ClusterInfo) (*ClusterInfo, error)
+}
+
 func RequireProvisioner(provider string, provisioners map[string]Provisioner) (Provisioner, error) {
 	p, ok := provisioners[provider]
 	if !ok || p == nil {

--- a/pkg/tenant/starter/provisioner.go
+++ b/pkg/tenant/starter/provisioner.go
@@ -106,6 +106,17 @@ func (p *Provisioner) Provision(ctx context.Context, tenantID string) (*tenant.C
 }
 
 func (p *Provisioner) ProvisionBranch(ctx context.Context, forkTenantID string, source *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
+	out, err := p.CreateBranch(ctx, forkTenantID, source)
+	if err != nil {
+		return out, err
+	}
+	if out.Host != "" && out.Port != 0 && out.Username != "" {
+		return out, nil
+	}
+	return p.WaitForBranchActive(ctx, out)
+}
+
+func (p *Provisioner) CreateBranch(ctx context.Context, forkTenantID string, source *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
 	if source == nil {
 		return nil, fmt.Errorf("source cluster info is required")
 	}
@@ -116,14 +127,9 @@ func (p *Provisioner) ProvisionBranch(ctx context.Context, forkTenantID string, 
 	if source.ClusterID == "" || parentID == "" {
 		return nil, fmt.Errorf("source cluster id is required")
 	}
-	password, err := generateRandomPassword(24)
-	if err != nil {
-		return nil, err
-	}
 	body, _ := json.Marshal(map[string]string{
-		"displayName":  forkTenantID,
-		"parentId":     parentID,
-		"rootPassword": password,
+		"displayName": forkTenantID,
+		"parentId":    parentID,
 	})
 	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s/branches", p.apiURL, source.ClusterID)
 	resp, err := p.doDigestAuthRequest(ctx, http.MethodPost, endpoint, body)
@@ -151,26 +157,50 @@ func (p *Provisioner) ProvisionBranch(ctx context.Context, forkTenantID string, 
 		TenantID:  forkTenantID,
 		ClusterID: source.ClusterID,
 		BranchID:  branch.BranchID,
-		Password:  password,
+		Password:  source.Password,
 		DBName:    dbName,
 		Provider:  tenant.ProviderTiDBCloudStarter,
 	}
 	if branch.State != "" && branch.State != "ACTIVE" {
-		branch, err = p.waitForBranchActive(ctx, source.ClusterID, branch.BranchID)
-		if err != nil {
+		return out, nil
+	}
+	if branch.State == "ACTIVE" || branch.Endpoints.Public.Host != "" || branch.UserPrefix != "" {
+		if err := fillBranchEndpoint(out, branch); err != nil {
 			return out, err
 		}
 	}
+	return out, nil
+}
+
+func (p *Provisioner) WaitForBranchActive(ctx context.Context, branch *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
+	if branch == nil {
+		return nil, fmt.Errorf("branch cluster info is required")
+	}
+	if branch.ClusterID == "" || branch.BranchID == "" {
+		return nil, fmt.Errorf("cluster id and branch id are required")
+	}
+	out := *branch
+	info, err := p.waitForBranchActive(ctx, branch.ClusterID, branch.BranchID)
+	if err != nil {
+		return &out, err
+	}
+	if err := fillBranchEndpoint(&out, info); err != nil {
+		return &out, err
+	}
+	return &out, nil
+}
+
+func fillBranchEndpoint(out *tenant.ClusterInfo, branch *starterBranchInfo) error {
 	if branch.Endpoints.Public.Host == "" || branch.Endpoints.Public.Port == 0 {
-		return out, fmt.Errorf("starter branch response missing endpoint")
+		return fmt.Errorf("starter branch response missing endpoint")
 	}
 	if branch.UserPrefix == "" {
-		return out, fmt.Errorf("starter branch response missing user prefix")
+		return fmt.Errorf("starter branch response missing user prefix")
 	}
 	out.Host = branch.Endpoints.Public.Host
 	out.Port = branch.Endpoints.Public.Port
 	out.Username = branch.UserPrefix + ".root"
-	return out, nil
+	return nil
 }
 
 func (p *Provisioner) DeleteBranch(ctx context.Context, clusterID, branchID string) error {

--- a/pkg/tenant/starter/provisioner_test.go
+++ b/pkg/tenant/starter/provisioner_test.go
@@ -29,18 +29,14 @@ func TestProvisionBranchCreatesBranchFromSourceBranch(t *testing.T) {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		var body struct {
-			DisplayName  string `json:"displayName"`
-			ParentID     string `json:"parentId"`
-			RootPassword string `json:"rootPassword"`
+			DisplayName string `json:"displayName"`
+			ParentID    string `json:"parentId"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
 		if body.DisplayName != "fork-tenant" {
 			t.Fatalf("displayName = %q", body.DisplayName)
-		}
-		if body.RootPassword == "" {
-			t.Fatal("rootPassword is empty")
 		}
 		gotParentID = body.ParentID
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -58,6 +54,7 @@ func TestProvisionBranchCreatesBranchFromSourceBranch(t *testing.T) {
 	out, err := p.ProvisionBranch(context.Background(), "fork-tenant", &tenant.ClusterInfo{
 		ClusterID: "c1",
 		BranchID:  "b1",
+		Password:  "source-pass",
 		DBName:    "test",
 	})
 	if err != nil {
@@ -67,6 +64,45 @@ func TestProvisionBranchCreatesBranchFromSourceBranch(t *testing.T) {
 		t.Fatalf("parentId = %q, want b1", gotParentID)
 	}
 	if out.ClusterID != "c1" || out.BranchID != "b2" || out.Username != "u2.root" || out.Host != "db.example" || out.Port != 4000 {
+		t.Fatalf("unexpected cluster info: %#v", out)
+	}
+	if out.Password != "source-pass" {
+		t.Fatalf("password = %q, want source-pass", out.Password)
+	}
+}
+
+func TestCreateBranchDoesNotWaitForActive(t *testing.T) {
+	var gotGet bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1beta1/clusters/c1/branches":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"branchId": "b-pending",
+				"state":    "CREATING",
+			})
+		case r.Method == http.MethodGet:
+			gotGet = true
+			t.Fatalf("CreateBranch must not poll branch status")
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{apiURL: ts.URL, client: ts.Client()}
+	out, err := p.CreateBranch(context.Background(), "fork-tenant", &tenant.ClusterInfo{
+		ClusterID: "c1",
+		BranchID:  "b1",
+		Password:  "source-pass",
+		DBName:    "test",
+	})
+	if err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if gotGet {
+		t.Fatal("CreateBranch polled branch status")
+	}
+	if out.ClusterID != "c1" || out.BranchID != "b-pending" || out.Host != "" || out.Username != "" || out.Password != "source-pass" {
 		t.Fatalf("unexpected cluster info: %#v", out)
 	}
 }


### PR DESCRIPTION
## Summary
- move fork API to /v1/fork and rename ctx_fork server files to fork
- make fork creation return 202 after creating the TiDB branch, then wait for ACTIVE and prepare metadata/quota asynchronously
- resume provisioning fork tenants on startup and surface user-facing provisioning messages from /v1/status
- allow CLI fork names to be omitted and accept 202 responses

## Tests
- go test ./pkg/tenant/starter
- go test ./cmd/drive9/cli
- go test ./pkg/server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context fork command now auto-generates a name when omitted, eliminating the need to specify one manually
  * Fork operations return asynchronously with provisioning status and progress messages

* **Improvements**
  * Enhanced status feedback during fork provisioning with descriptive messages
  * Status endpoint now includes messages indicating fork preparation and branch creation progress

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/424)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->