### PR TITLE
Set root password for fork branches

### DIFF
--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"io"
@@ -176,7 +177,11 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 	} else if hasReservations {
 		return nil, forkErr(http.StatusConflict, "source tenant has active upload reservations")
 	}
-	sourcePassword, err := s.pool.Decrypt(ctx, source.DBPasswordCipher)
+	forkPassword, err := generateForkDBPassword(24)
+	if err != nil {
+		return nil, err
+	}
+	forkPasswordCipher, err := s.pool.Encrypt(ctx, []byte(forkPassword))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +195,7 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 	forkRoot.ParentTenantID = source.ID
 	forkRoot.StorageNamespaceID = source.StorageNamespaceID
 	forkRoot.BranchID = ""
-	forkRoot.DBPasswordCipher = append([]byte(nil), source.DBPasswordCipher...)
+	forkRoot.DBPasswordCipher = forkPasswordCipher
 	if source.S3BucketKeyEnabled != nil {
 		v := *source.S3BucketKeyEnabled
 		forkRoot.S3BucketKeyEnabled = &v
@@ -204,7 +209,7 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 	}
 
 	sourceCluster := clusterInfoFromTenant(source)
-	sourceCluster.Password = string(sourcePassword)
+	sourceCluster.Password = forkPassword
 	cluster, err := branchProvisioner.CreateBranch(ctx, forkID, sourceCluster)
 	if cluster != nil {
 		cluster.Provider = source.Provider
@@ -445,12 +450,12 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		return tenantDSN(cluster.Username, string(plain), cluster.Host, cluster.Port, cluster.DBName, true), nil
 	}
 
-	sourcePassword, err := s.pool.Decrypt(ctx, source.DBPasswordCipher)
+	branchPassword, err := s.pool.Decrypt(ctx, forkTenant.DBPasswordCipher)
 	if err != nil {
 		return "", err
 	}
 	sourceCluster := clusterInfoFromTenant(source)
-	sourceCluster.Password = string(sourcePassword)
+	sourceCluster.Password = string(branchPassword)
 	cluster, err := branchProvisioner.CreateBranch(ctx, forkTenant.ID, sourceCluster)
 	if cluster != nil {
 		cluster.Provider = source.Provider
@@ -466,7 +471,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		DBHost:           cluster.Host,
 		DBPort:           cluster.Port,
 		DBUser:           cluster.Username,
-		DBPasswordCipher: source.DBPasswordCipher,
+		DBPasswordCipher: forkTenant.DBPasswordCipher,
 		DBName:           cluster.DBName,
 		DBTLS:            true,
 		Provider:         cluster.Provider,
@@ -481,7 +486,19 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 	if cluster.Host == "" || cluster.Port == 0 || cluster.Username == "" {
 		return "", forkErr(http.StatusServiceUnavailable, "database branch is not active yet")
 	}
-	return tenantDSN(cluster.Username, string(sourcePassword), cluster.Host, cluster.Port, cluster.DBName, true), nil
+	return tenantDSN(cluster.Username, string(branchPassword), cluster.Host, cluster.Port, cluster.DBName, true), nil
+}
+
+func generateForkDBPassword(length int) (string, error) {
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	for i := range b {
+		b[i] = chars[int(b[i])%len(chars)]
+	}
+	return string(b), nil
 }
 
 func (s *Server) deleteForkBranchOrPersist(ctx context.Context, forkID string, branchProvisioner tenant.BranchProvisioner, cluster *tenant.ClusterInfo) {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math/big"
 	"net/http"
 	"strings"
 	"sync"
@@ -492,11 +493,13 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 func generateForkDBPassword(length int) (string, error) {
 	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	b := make([]byte, length)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
+	max := big.NewInt(int64(len(chars)))
 	for i := range b {
-		b[i] = chars[int(b[i])%len(chars)]
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		b[i] = chars[n.Int64()]
 	}
 	return string(b), nil
 }

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -17,8 +17,9 @@ type fakeBranchProvisioner struct {
 	provisionErr error
 	deleteErr    error
 
-	mu      sync.Mutex
-	deleted []string
+	mu                 sync.Mutex
+	deleted            []string
+	createBranchInputs []*tenant.ClusterInfo
 }
 
 func (f *fakeBranchProvisioner) ProviderType() string { return tenant.ProviderTiDBCloudStarter }
@@ -33,12 +34,20 @@ func (f *fakeBranchProvisioner) ProvisionBranch(ctx context.Context, forkTenantI
 	return f.CreateBranch(ctx, forkTenantID, nil)
 }
 
-func (f *fakeBranchProvisioner) CreateBranch(ctx context.Context, forkTenantID string, _ *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
+func (f *fakeBranchProvisioner) CreateBranch(ctx context.Context, forkTenantID string, source *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
 	}
+	f.mu.Lock()
+	if source != nil {
+		copySource := *source
+		f.createBranchInputs = append(f.createBranchInputs, &copySource)
+	} else {
+		f.createBranchInputs = append(f.createBranchInputs, nil)
+	}
+	f.mu.Unlock()
 	if f.cluster == nil {
 		return nil, errors.New("missing cluster")
 	}
@@ -82,6 +91,16 @@ func (f *fakeBranchProvisioner) deletedBranches() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.deleted...)
+}
+
+func (f *fakeBranchProvisioner) createBranchInput(i int) *tenant.ClusterInfo {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if i < 0 || i >= len(f.createBranchInputs) || f.createBranchInputs[i] == nil {
+		return nil
+	}
+	out := *f.createBranchInputs[i]
+	return &out
 }
 
 type nonBranchOnlyProvisioner struct{}
@@ -239,6 +258,41 @@ func TestCreateForkPartialBranchProvisionErrorPersistsBranchAndKeepsRoot(t *test
 	}
 	if deleted := rt.prov.deletedBranches(); len(deleted) == 0 || deleted[0] != "cluster-a/branch-created" {
 		t.Fatalf("deleted branches = %#v", deleted)
+	}
+}
+
+func TestCreateForkTenantPersistsGeneratedBranchPassword(t *testing.T) {
+	rt := newForkCleanupTestRuntime(t)
+	rt.insertLiveTenant(t, "source")
+	rt.prov.cluster = &tenant.ClusterInfo{ClusterID: "cluster-a", BranchID: "branch-created"}
+	rt.prov.provisionErr = context.Canceled
+
+	resp, err := rt.server.createForkTenant(context.Background(), "source", "fork")
+	if err != nil {
+		t.Fatalf("createForkTenant: %v", err)
+	}
+
+	forkTenant, err := rt.meta.GetTenant(context.Background(), resp.TenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if forkTenant.DBPasswordCipher == nil {
+		t.Fatal("fork DB password cipher is nil")
+	}
+	gotPassword, err := rt.pool.Decrypt(context.Background(), forkTenant.DBPasswordCipher)
+	if err != nil {
+		t.Fatalf("decrypt fork password: %v", err)
+	}
+	if string(gotPassword) == rt.dbPass {
+		t.Fatal("fork password unexpectedly matches source password")
+	}
+
+	createInput := rt.prov.createBranchInput(0)
+	if createInput == nil {
+		t.Fatal("CreateBranch was not called with source cluster info")
+	}
+	if createInput.Password != string(gotPassword) {
+		t.Fatalf("CreateBranch password = %q, want persisted fork password", createInput.Password)
 	}
 }
 

--- a/pkg/server/schema_test_helper.go
+++ b/pkg/server/schema_test_helper.go
@@ -47,7 +47,8 @@ func initServerTenantSchema(t *testing.T, dsn string) {
 		`CREATE UNIQUE INDEX uk_file_gc_file_id ON file_gc_tasks(file_id)`,
 		`CREATE UNIQUE INDEX uk_file_gc_inode_id ON file_gc_tasks(inode_id)`,
 		`CREATE INDEX idx_file_gc_claim ON file_gc_tasks(status, available_at, lease_until, created_at)`,
-		`CREATE TABLE IF NOT EXISTS llm_usage (id BIGINT AUTO_INCREMENT PRIMARY KEY, task_type VARCHAR(32) NOT NULL, task_id VARCHAR(64) NOT NULL, cost_millicents BIGINT NOT NULL DEFAULT 0, raw_units BIGINT NOT NULL DEFAULT 0, raw_unit_type VARCHAR(16) NOT NULL, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
+		`CREATE TABLE IF NOT EXISTS llm_usage (id BIGINT AUTO_INCREMENT PRIMARY KEY, tenant_id VARCHAR(64) NOT NULL, task_type VARCHAR(64) NOT NULL, task_id VARCHAR(255) NOT NULL, cost_millicents BIGINT NOT NULL DEFAULT 0, raw_units BIGINT NOT NULL DEFAULT 0, raw_unit_type VARCHAR(32) NOT NULL DEFAULT '', created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
+		`CREATE INDEX idx_llm_usage_tenant_created ON llm_usage(tenant_id, created_at)`,
 		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
 	}
 	stmts = append(stmts, schema.JournalTiDBSchemaStatements()...)

--- a/pkg/tenant/starter/provisioner.go
+++ b/pkg/tenant/starter/provisioner.go
@@ -127,10 +127,14 @@ func (p *Provisioner) CreateBranch(ctx context.Context, forkTenantID string, sou
 	if source.ClusterID == "" || parentID == "" {
 		return nil, fmt.Errorf("source cluster id is required")
 	}
-	body, _ := json.Marshal(map[string]string{
+	reqBody := map[string]string{
 		"displayName": forkTenantID,
 		"parentId":    parentID,
-	})
+	}
+	if source.Password != "" {
+		reqBody["rootPassword"] = source.Password
+	}
+	body, _ := json.Marshal(reqBody)
 	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s/branches", p.apiURL, source.ClusterID)
 	resp, err := p.doDigestAuthRequest(ctx, http.MethodPost, endpoint, body)
 	if err != nil {

--- a/pkg/tenant/starter/provisioner.go
+++ b/pkg/tenant/starter/provisioner.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"os"
@@ -64,7 +65,10 @@ func (p *Provisioner) Provision(ctx context.Context, tenantID string) (*tenant.C
 	if err != nil {
 		return nil, err
 	}
-	body, _ := json.Marshal(map[string]string{"pool_id": p.poolID, "root_password": password})
+	body, err := json.Marshal(map[string]string{"pool_id": p.poolID, "root_password": password})
+	if err != nil {
+		return nil, err
+	}
 	endpoint := p.apiURL + "/v1beta1/clusters:takeoverFromPool"
 	resp, err := p.doDigestAuthRequest(ctx, http.MethodPost, endpoint, body)
 	if err != nil {
@@ -134,7 +138,10 @@ func (p *Provisioner) CreateBranch(ctx context.Context, forkTenantID string, sou
 	if source.Password != "" {
 		reqBody["rootPassword"] = source.Password
 	}
-	body, _ := json.Marshal(reqBody)
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
 	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s/branches", p.apiURL, source.ClusterID)
 	resp, err := p.doDigestAuthRequest(ctx, http.MethodPost, endpoint, body)
 	if err != nil {
@@ -360,11 +367,13 @@ func generateNonce() (string, error) {
 func generateRandomPassword(length int) (string, error) {
 	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	b := make([]byte, length)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
+	max := big.NewInt(int64(len(chars)))
 	for i := range b {
-		b[i] = chars[int(b[i])%len(chars)]
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		b[i] = chars[n.Int64()]
 	}
 	return string(b), nil
 }

--- a/pkg/tenant/starter/provisioner_test.go
+++ b/pkg/tenant/starter/provisioner_test.go
@@ -29,14 +29,18 @@ func TestProvisionBranchCreatesBranchFromSourceBranch(t *testing.T) {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		var body struct {
-			DisplayName string `json:"displayName"`
-			ParentID    string `json:"parentId"`
+			DisplayName  string `json:"displayName"`
+			ParentID     string `json:"parentId"`
+			RootPassword string `json:"rootPassword"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
 		if body.DisplayName != "fork-tenant" {
 			t.Fatalf("displayName = %q", body.DisplayName)
+		}
+		if body.RootPassword != "branch-pass" {
+			t.Fatalf("rootPassword = %q, want branch-pass", body.RootPassword)
 		}
 		gotParentID = body.ParentID
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -54,7 +58,7 @@ func TestProvisionBranchCreatesBranchFromSourceBranch(t *testing.T) {
 	out, err := p.ProvisionBranch(context.Background(), "fork-tenant", &tenant.ClusterInfo{
 		ClusterID: "c1",
 		BranchID:  "b1",
-		Password:  "source-pass",
+		Password:  "branch-pass",
 		DBName:    "test",
 	})
 	if err != nil {
@@ -66,16 +70,24 @@ func TestProvisionBranchCreatesBranchFromSourceBranch(t *testing.T) {
 	if out.ClusterID != "c1" || out.BranchID != "b2" || out.Username != "u2.root" || out.Host != "db.example" || out.Port != 4000 {
 		t.Fatalf("unexpected cluster info: %#v", out)
 	}
-	if out.Password != "source-pass" {
-		t.Fatalf("password = %q, want source-pass", out.Password)
+	if out.Password != "branch-pass" {
+		t.Fatalf("password = %q, want branch-pass", out.Password)
 	}
 }
 
 func TestCreateBranchDoesNotWaitForActive(t *testing.T) {
 	var gotGet bool
+	var gotRootPassword string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1beta1/clusters/c1/branches":
+			var body struct {
+				RootPassword string `json:"rootPassword"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			gotRootPassword = body.RootPassword
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"branchId": "b-pending",
 				"state":    "CREATING",
@@ -93,7 +105,7 @@ func TestCreateBranchDoesNotWaitForActive(t *testing.T) {
 	out, err := p.CreateBranch(context.Background(), "fork-tenant", &tenant.ClusterInfo{
 		ClusterID: "c1",
 		BranchID:  "b1",
-		Password:  "source-pass",
+		Password:  "branch-pass",
 		DBName:    "test",
 	})
 	if err != nil {
@@ -102,7 +114,10 @@ func TestCreateBranchDoesNotWaitForActive(t *testing.T) {
 	if gotGet {
 		t.Fatal("CreateBranch polled branch status")
 	}
-	if out.ClusterID != "c1" || out.BranchID != "b-pending" || out.Host != "" || out.Username != "" || out.Password != "source-pass" {
+	if gotRootPassword != "branch-pass" {
+		t.Fatalf("rootPassword = %q, want branch-pass", gotRootPassword)
+	}
+	if out.ClusterID != "c1" || out.BranchID != "b-pending" || out.Host != "" || out.Username != "" || out.Password != "branch-pass" {
 		t.Fatalf("unexpected cluster info: %#v", out)
 	}
 }


### PR DESCRIPTION
## Summary
- generate a fresh DB root password for each fork tenant
- send that password as `rootPassword` when creating the TiDB Cloud branch
- persist the fork password cipher and reuse it when async provisioning resumes

## Validation
- dev verification showed Branch API returned `userPrefix` but `annotations.tidb.cloud/has-set-password=false`; async provisioning then failed with TiDB access denied for `<branch-user>.root`
- go test ./pkg/tenant/starter ./pkg/server ./cmd/drive9/cli
- make build-cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Forked database instances now generate and use unique database passwords instead of reusing source instance credentials, improving security isolation between forks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/425)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->