### PR TITLE
Polish fork provisioning UX and extend CLI smoke coverage

### DIFF
--- a/cmd/drive9/cli/cp.go
+++ b/cmd/drive9/cli/cp.go
@@ -182,7 +182,7 @@ func resolveRemoteCopyTarget(ctx context.Context, c *client.Client, remotePath, 
 		}
 		return pathpkg.Join(remotePath, sourceBase), nil
 	}
-	info, err := c.Stat(remotePath)
+	info, err := c.StatCtx(ctx, remotePath)
 	if err == nil && info.IsDir {
 		if sourceBase == "" {
 			return "", fmt.Errorf("destination %q requires a file name", remotePath)
@@ -196,7 +196,7 @@ func resolveRemoteCopyTarget(ctx context.Context, c *client.Client, remotePath, 
 }
 
 func resolveLocalCopyTarget(localPath, sourceBase string) (string, error) {
-	if strings.HasSuffix(localPath, string(os.PathSeparator)) {
+	if strings.HasSuffix(localPath, string(os.PathSeparator)) || strings.HasSuffix(localPath, "/") {
 		if sourceBase == "" {
 			return "", fmt.Errorf("destination %q requires a file name", localPath)
 		}

--- a/cmd/drive9/cli/cp.go
+++ b/cmd/drive9/cli/cp.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	pathpkg "path"
+	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
@@ -113,12 +115,16 @@ func Cp(c *client.Client, args []string) error {
 
 	switch {
 	case src == "-" && dstIsRemote:
+		resolvedDst, err := resolveRemoteCopyTarget(ctx, c, dstRP.Path, "")
+		if err != nil {
+			return err
+		}
 		data, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("read stdin: %w", err)
 		}
 		if appendMode {
-			return c.AppendStream(ctx, dstRP.Path, bytes.NewReader(data), int64(len(data)), printProgress)
+			return c.AppendStream(ctx, resolvedDst, bytes.NewReader(data), int64(len(data)), printProgress)
 		}
 		var opts []client.WriteOption
 		if tags != nil {
@@ -127,7 +133,7 @@ func Cp(c *client.Client, args []string) error {
 		if description != "" {
 			opts = append(opts, client.WithDescription(description))
 		}
-		summary, err := c.WriteStreamWithSummary(ctx, dstRP.Path, bytes.NewReader(data), int64(len(data)), printProgress, opts...)
+		summary, err := c.WriteStreamWithSummary(ctx, resolvedDst, bytes.NewReader(data), int64(len(data)), printProgress, opts...)
 		if err != nil {
 			return err
 		}
@@ -138,23 +144,75 @@ func Cp(c *client.Client, args []string) error {
 		return streamToStdout(ctx, c, srcRP.Path)
 
 	case !srcIsRemote && dstIsRemote:
+		resolvedDst, err := resolveRemoteCopyTarget(ctx, c, dstRP.Path, filepath.Base(src))
+		if err != nil {
+			return err
+		}
 		if appendMode {
-			return appendFile(ctx, c, src, dstRP.Path)
+			return appendFile(ctx, c, src, resolvedDst)
 		}
 		if resume {
-			return resumeUploadWithTags(ctx, c, src, dstRP.Path, tags)
+			return resumeUploadWithTags(ctx, c, src, resolvedDst, tags)
 		}
-		return uploadFileWithTagsAndDescription(ctx, c, src, dstRP.Path, tags, description)
+		return uploadFileWithTagsAndDescription(ctx, c, src, resolvedDst, tags, description)
 
 	case srcIsRemote && !dstIsRemote:
-		return downloadFile(ctx, c, srcRP.Path, dst)
+		resolvedDst, err := resolveLocalCopyTarget(dst, pathpkg.Base(srcRP.Path))
+		if err != nil {
+			return err
+		}
+		return downloadFile(ctx, c, srcRP.Path, resolvedDst)
 
 	case srcIsRemote && dstIsRemote:
-		return c.Copy(srcRP.Path, dstRP.Path)
+		resolvedDst, err := resolveRemoteCopyTarget(ctx, c, dstRP.Path, pathpkg.Base(srcRP.Path))
+		if err != nil {
+			return err
+		}
+		return c.Copy(srcRP.Path, resolvedDst)
 
 	default:
 		return fmt.Errorf("at least one path must be remote (e.g. :/path or mydb:/path)")
 	}
+}
+
+func resolveRemoteCopyTarget(ctx context.Context, c *client.Client, remotePath, sourceBase string) (string, error) {
+	if strings.HasSuffix(remotePath, "/") {
+		if sourceBase == "" {
+			return "", fmt.Errorf("destination %q requires a file name", remotePath)
+		}
+		return pathpkg.Join(remotePath, sourceBase), nil
+	}
+	info, err := c.Stat(remotePath)
+	if err == nil && info.IsDir {
+		if sourceBase == "" {
+			return "", fmt.Errorf("destination %q requires a file name", remotePath)
+		}
+		return pathpkg.Join(remotePath, sourceBase), nil
+	}
+	if err != nil && !client.IsNotFound(err) {
+		return "", err
+	}
+	return remotePath, nil
+}
+
+func resolveLocalCopyTarget(localPath, sourceBase string) (string, error) {
+	if strings.HasSuffix(localPath, string(os.PathSeparator)) {
+		if sourceBase == "" {
+			return "", fmt.Errorf("destination %q requires a file name", localPath)
+		}
+		return filepath.Join(localPath, sourceBase), nil
+	}
+	info, err := os.Stat(localPath)
+	if err == nil && info.IsDir() {
+		if sourceBase == "" {
+			return "", fmt.Errorf("destination %q requires a file name", localPath)
+		}
+		return filepath.Join(localPath, sourceBase), nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat %s: %w", localPath, err)
+	}
+	return localPath, nil
 }
 
 func uploadFile(ctx context.Context, c *client.Client, localPath, remotePath string, description string) error {

--- a/cmd/drive9/cli/cp_test.go
+++ b/cmd/drive9/cli/cp_test.go
@@ -460,6 +460,108 @@ func TestCpUploadWithTagsSendsHeaders(t *testing.T) {
 	}
 }
 
+func TestCpUploadToRemoteDirectoryKeepsSourceName(t *testing.T) {
+	localPath := filepath.Join(t.TempDir(), "upload.txt")
+	if err := os.WriteFile(localPath, []byte("hello dir"), 0o644); err != nil {
+		t.Fatalf("WriteFile(local): %v", err)
+	}
+
+	var gotPath string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "HEAD /v1/fs/dir":
+			w.Header().Set("X-Dat9-IsDir", "true")
+			w.WriteHeader(http.StatusOK)
+		case "PUT /v1/fs/dir/upload.txt":
+			gotPath = r.URL.Path
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			gotBody = append([]byte(nil), body...)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	if err := Cp(c, []string{localPath, ":/dir"}); err != nil {
+		t.Fatalf("Cp(upload to dir): %v", err)
+	}
+	if gotPath != "/v1/fs/dir/upload.txt" {
+		t.Fatalf("PUT path = %q, want %q", gotPath, "/v1/fs/dir/upload.txt")
+	}
+	if got := string(gotBody); got != "hello dir" {
+		t.Fatalf("uploaded body = %q, want %q", got, "hello dir")
+	}
+}
+
+func TestCpDownloadToLocalDirectoryKeepsSourceName(t *testing.T) {
+	dstDir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "HEAD /v1/fs/src.txt":
+			w.Header().Set("Content-Length", "11")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.WriteHeader(http.StatusOK)
+		case "GET /v1/fs/src.txt":
+			_, _ = io.WriteString(w, "hello local")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	if err := Cp(c, []string{":/src.txt", dstDir}); err != nil {
+		t.Fatalf("Cp(download to dir): %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dstDir, "src.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile(downloaded): %v", err)
+	}
+	if string(got) != "hello local" {
+		t.Fatalf("downloaded body = %q, want %q", string(got), "hello local")
+	}
+}
+
+func TestCpRemoteToRemoteDirectoryKeepsSourceName(t *testing.T) {
+	var gotPath string
+	var gotSource string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "HEAD /v1/fs/dstdir":
+			w.Header().Set("X-Dat9-IsDir", "true")
+			w.WriteHeader(http.StatusOK)
+		case "POST /v1/fs/dstdir/src.txt":
+			if !r.URL.Query().Has("copy") {
+				t.Fatalf("expected ?copy on %s", r.URL.String())
+			}
+			gotPath = r.URL.Path
+			gotSource = r.Header.Get("X-Dat9-Copy-Source")
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	if err := Cp(c, []string{":/src.txt", ":/dstdir"}); err != nil {
+		t.Fatalf("Cp(remote to remote dir): %v", err)
+	}
+	if gotPath != "/v1/fs/dstdir/src.txt" || gotSource != "/src.txt" {
+		t.Fatalf("copy request path=%q source=%q, want path=%q source=%q", gotPath, gotSource, "/v1/fs/dstdir/src.txt", "/src.txt")
+	}
+}
+
 func TestCpRejectsTagForDownloadDirection(t *testing.T) {
 	localPath := filepath.Join(t.TempDir(), "out.txt")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/drive9/cli/cp_test.go
+++ b/cmd/drive9/cli/cp_test.go
@@ -531,6 +531,17 @@ func TestCpDownloadToLocalDirectoryKeepsSourceName(t *testing.T) {
 	}
 }
 
+func TestResolveLocalCopyTargetTreatsSlashSuffixAsDirectoryHint(t *testing.T) {
+	got, err := resolveLocalCopyTarget("C:/tmp/dir/", "file.txt")
+	if err != nil {
+		t.Fatalf("resolveLocalCopyTarget: %v", err)
+	}
+	want := filepath.Join("C:/tmp/dir/", "file.txt")
+	if got != want {
+		t.Fatalf("resolved path = %q, want %q", got, want)
+	}
+}
+
 func TestCpRemoteToRemoteDirectoryKeepsSourceName(t *testing.T) {
 	var gotPath string
 	var gotSource string

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -430,8 +430,17 @@ func ctxForkCmd(args []string) error {
 	}
 	fmt.Printf("Forked %s -> %s\n", fromName, newName)
 	fmt.Println("Mode: copy-on-write")
+	if result.Status != "" {
+		fmt.Printf("Status: %s\n", result.Status)
+	}
+	if result.Message != "" {
+		fmt.Printf("Message: %s\n", result.Message)
+	}
 	if useNew || cfg.CurrentContext == newName {
 		fmt.Printf("Now using ctx %s\n", newName)
+	}
+	if result.Status == "provisioning" {
+		fmt.Println("The fork is still provisioning. Wait for `drive9 status` to report `active` before running `fs` commands.")
 	}
 	return nil
 }

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -440,7 +440,7 @@ func ctxForkCmd(args []string) error {
 		fmt.Printf("Now using ctx %s\n", newName)
 	}
 	if result.Status == "provisioning" {
-		fmt.Println("The fork is still provisioning. Wait for `drive9 status` to report `active` before running `fs` commands.")
+		fmt.Println("The fork is still provisioning. Wait a moment, then retry a command like `drive9 fs ls /`; `fs` commands may fail until the tenant becomes active.")
 	}
 	return nil
 }

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -52,7 +52,7 @@ func ctxUsage() string {
   import --from-file <path>                           add delegated context from file (must be mode 0600)
   import --from-file -                                add delegated context from stdin explicitly
   import                                              add delegated context from stdin (default when stdin is a pipe)
-  fork [<new>] [--from <ctx>] [--use] [--json]        create a copy-on-write fork context
+  fork [<new>] [--from <ctx>] [--json]                create a copy-on-write fork context
   ls [-l|--json]                                      list contexts
   use <name>                                          activate a context
   rm <name>                                           delete a context`
@@ -336,7 +336,6 @@ func ctxAdd(cfg *Config, name string, ctx *Context) (*Context, error) {
 func ctxForkCmd(args []string) error {
 	newName := ""
 	fromName := ""
-	useNew := false
 	jsonOut := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -346,16 +345,14 @@ func ctxForkCmd(args []string) error {
 			}
 			i++
 			fromName = args[i]
-		case "--use":
-			useNew = true
 		case "--json":
 			jsonOut = true
 		default:
 			if strings.HasPrefix(args[i], "-") {
-				return fmt.Errorf("unknown flag %q\nusage: drive9 ctx fork [<new>] [--from <ctx>] [--use] [--json]", args[i])
+				return fmt.Errorf("unknown flag %q\nusage: drive9 ctx fork [<new>] [--from <ctx>] [--json]", args[i])
 			}
 			if newName != "" {
-				return fmt.Errorf("unexpected argument %q\nusage: drive9 ctx fork [<new>] [--from <ctx>] [--use] [--json]", args[i])
+				return fmt.Errorf("unexpected argument %q\nusage: drive9 ctx fork [<new>] [--from <ctx>] [--json]", args[i])
 			}
 			newName = args[i]
 		}
@@ -419,9 +416,6 @@ func ctxForkCmd(args []string) error {
 	}); err != nil {
 		return err
 	}
-	if useNew {
-		cfg.CurrentContext = newName
-	}
 	if err := saveConfig(cfg); err != nil {
 		return fmt.Errorf("save config: %w", err)
 	}
@@ -436,9 +430,7 @@ func ctxForkCmd(args []string) error {
 	if result.Message != "" {
 		fmt.Printf("Message: %s\n", result.Message)
 	}
-	if useNew || cfg.CurrentContext == newName {
-		fmt.Printf("Now using ctx %s\n", newName)
-	}
+	fmt.Printf("Use `drive9 ctx use %s` to switch when you're ready.\n", newName)
 	if result.Status == "provisioning" {
 		fmt.Println("The fork is still provisioning. Wait a moment, then retry a command like `drive9 fs ls /`; `fs` commands may fail until the tenant becomes active.")
 	}

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -72,7 +72,10 @@ func TestCtxForkCreatesOwnerContextAndSwitchesWhenRequested(t *testing.T) {
 	if sawName != "exp" {
 		t.Fatalf("request name = %q, want exp", sawName)
 	}
-	if !strings.Contains(out, "Forked prod -> exp") || !strings.Contains(out, "Now using ctx exp") {
+	if !strings.Contains(out, "Forked prod -> exp") ||
+		!strings.Contains(out, "Status: provisioning") ||
+		!strings.Contains(out, "Now using ctx exp") ||
+		!strings.Contains(out, "Wait for `drive9 status` to report `active` before running `fs` commands.") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 	got := loadConfig()
@@ -124,7 +127,10 @@ func TestCtxForkGeneratesNameWhenOmitted(t *testing.T) {
 	if sawName == "" || sawName == "prod" {
 		t.Errorf("generated request name = %q", sawName)
 	}
-	if !strings.Contains(out, "Forked prod -> "+sawName) || !strings.Contains(out, "Now using ctx "+sawName) {
+	if !strings.Contains(out, "Forked prod -> "+sawName) ||
+		!strings.Contains(out, "Status: provisioning") ||
+		!strings.Contains(out, "Now using ctx "+sawName) ||
+		!strings.Contains(out, "Wait for `drive9 status` to report `active` before running `fs` commands.") {
 		t.Errorf("unexpected output: %q", out)
 	}
 	got := loadConfig()

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -29,7 +29,7 @@ func makeJWT(t *testing.T, claims map[string]any) string {
 	return header + "." + payload + "." + sig
 }
 
-func TestCtxForkCreatesOwnerContextAndSwitchesWhenRequested(t *testing.T) {
+func TestCtxForkCreatesOwnerContextWithoutSwitching(t *testing.T) {
 	withIsolatedHome(t)
 	var sawName string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -65,7 +65,7 @@ func TestCtxForkCreatesOwnerContextAndSwitchesWhenRequested(t *testing.T) {
 		t.Fatalf("save config: %v", err)
 	}
 
-	out, err := captureStdoutE(t, func() error { return Ctx([]string{"fork", "exp", "--use"}) })
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"fork", "exp"}) })
 	if err != nil {
 		t.Fatalf("ctx fork: %v", err)
 	}
@@ -74,13 +74,13 @@ func TestCtxForkCreatesOwnerContextAndSwitchesWhenRequested(t *testing.T) {
 	}
 	if !strings.Contains(out, "Forked prod -> exp") ||
 		!strings.Contains(out, "Status: provisioning") ||
-		!strings.Contains(out, "Now using ctx exp") ||
+		!strings.Contains(out, "Use `drive9 ctx use exp` to switch when you're ready.") ||
 		!strings.Contains(out, "Wait a moment, then retry a command like `drive9 fs ls /`; `fs` commands may fail until the tenant becomes active.") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 	got := loadConfig()
-	if got.CurrentContext != "exp" {
-		t.Fatalf("current context = %q, want exp", got.CurrentContext)
+	if got.CurrentContext != "prod" {
+		t.Fatalf("current context = %q, want prod", got.CurrentContext)
 	}
 	if got.Contexts["exp"] == nil || got.Contexts["exp"].APIKey != "fork-key" || got.Contexts["exp"].Server != ts.URL {
 		t.Fatalf("fork context not persisted correctly: %#v", got.Contexts["exp"])
@@ -120,7 +120,7 @@ func TestCtxForkGeneratesNameWhenOmitted(t *testing.T) {
 		t.Fatalf("save config: %v", err)
 	}
 
-	out, err := captureStdoutE(t, func() error { return Ctx([]string{"fork", "--use"}) })
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"fork"}) })
 	if err != nil {
 		t.Fatalf("ctx fork: %v", err)
 	}
@@ -129,13 +129,13 @@ func TestCtxForkGeneratesNameWhenOmitted(t *testing.T) {
 	}
 	if !strings.Contains(out, "Forked prod -> "+sawName) ||
 		!strings.Contains(out, "Status: provisioning") ||
-		!strings.Contains(out, "Now using ctx "+sawName) ||
+		!strings.Contains(out, "Use `drive9 ctx use "+sawName+"` to switch when you're ready.") ||
 		!strings.Contains(out, "Wait a moment, then retry a command like `drive9 fs ls /`; `fs` commands may fail until the tenant becomes active.") {
 		t.Errorf("unexpected output: %q", out)
 	}
 	got := loadConfig()
-	if got.CurrentContext != sawName {
-		t.Errorf("current context = %q, want %q", got.CurrentContext, sawName)
+	if got.CurrentContext != "prod" {
+		t.Errorf("current context = %q, want %q", got.CurrentContext, "prod")
 	}
 	if got.Contexts[sawName] == nil || got.Contexts[sawName].APIKey != "fork-key" || got.Contexts[sawName].Server != ts.URL {
 		t.Errorf("generated fork context not persisted correctly: %#v", got.Contexts[sawName])

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -75,7 +75,7 @@ func TestCtxForkCreatesOwnerContextAndSwitchesWhenRequested(t *testing.T) {
 	if !strings.Contains(out, "Forked prod -> exp") ||
 		!strings.Contains(out, "Status: provisioning") ||
 		!strings.Contains(out, "Now using ctx exp") ||
-		!strings.Contains(out, "Wait for `drive9 status` to report `active` before running `fs` commands.") {
+		!strings.Contains(out, "Wait a moment, then retry a command like `drive9 fs ls /`; `fs` commands may fail until the tenant becomes active.") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 	got := loadConfig()
@@ -130,7 +130,7 @@ func TestCtxForkGeneratesNameWhenOmitted(t *testing.T) {
 	if !strings.Contains(out, "Forked prod -> "+sawName) ||
 		!strings.Contains(out, "Status: provisioning") ||
 		!strings.Contains(out, "Now using ctx "+sawName) ||
-		!strings.Contains(out, "Wait for `drive9 status` to report `active` before running `fs` commands.") {
+		!strings.Contains(out, "Wait a moment, then retry a command like `drive9 fs ls /`; `fs` commands may fail until the tenant becomes active.") {
 		t.Errorf("unexpected output: %q", out)
 	}
 	got := loadConfig()

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -7,7 +7,7 @@
 // Commands:
 //
 //	create  provision a new database and owner context
-//	ctx     manage contexts (add, import, ls, use, rm)
+//	ctx     manage contexts (show, add, import, fork, ls, use, rm)
 //	fs      filesystem operations (cp, cat, ls, stat, mv, rm, sh, grep, find)
 //	vault   vault operations (set, get, put, with, ls, rm, grant, revoke, audit)
 //	journal append-only agent/workflow journal operations
@@ -280,7 +280,7 @@ func usage(code int) {
 			"                         add owner context\n"+
 			"  ctx import [--from-file <path|->] [--name NAME]\n"+
 			"                         add delegated context\n"+
-			"  ctx fork [<new>] [--from <ctx>] [--use] [--json]\n"+
+			"  ctx fork [<new>] [--from <ctx>] [--json]\n"+
 			"                         create a copy-on-write fork context\n"+
 			"  ctx ls [-l|--json]     list contexts\n"+
 			"  ctx use <name>         activate context\n"+

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -124,7 +124,7 @@ use the same value as `DRIVE9_API_KEY` here.
 
 ### `api-smoke-test.sh`
 
-1. `POST /v1/provision` returns `202` with only `api_key` + `status`
+1. `POST /v1/provision` returns `202` with `tenant_id`, `api_key`, and `status`
 2. `GET /v1/status` polled until `active`
 3. `GET /v1/fs/?list` returns `entries[]`
 4. Nested `mkdir` (`/team/...`) across multi-level paths

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -151,13 +151,15 @@ use the same value as `DRIVE9_API_KEY` here.
 
 1. Provision + readiness polling
 2. Prepare `drive9` CLI binary (build local or download official release)
-3. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `rm`)
-4. CLI batch small-file flow (`cp` many files + dir list count + stat + sample reads)
-5. CLI search flow (`fs grep`, `fs find`)
-6. CLI semantic and image-associated recall flow (`fs grep` paraphrase + image caption recall) with async polling
-7. CLI image flow (`fs cp` jpg + `fs find -name "*.jpg"`)
-8. CLI large-file flow (`cp` upload multipart + `cp` download + checksum verification)
-9. CLI upload-limit boundary (`10GiB` initiate accepted, `10GiB+1` rejected)
+3. CLI fork flow (`ctx add`, `ctx fork`, fork readiness polling, fork-context file read/write, fork delete)
+4. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `rm`)
+5. CLI `cp` directory-target semantics (local->remote dir, remote->local dir, remote->remote dir all preserve source basename)
+6. CLI batch small-file flow (`cp` many files + dir list count + stat + sample reads)
+7. CLI search flow (`fs grep`, `fs find`)
+8. CLI semantic and image-associated recall flow (`fs grep` paraphrase + image caption recall) with async polling
+9. CLI image flow (`fs cp` jpg + `fs find -name "*.jpg"`)
+10. CLI large-file flow (`cp` upload multipart + `cp` download + checksum verification)
+11. CLI upload-limit boundary (`10GiB` initiate accepted, `10GiB+1` rejected)
 
 ### `journal-smoke-test.sh`
 
@@ -238,6 +240,7 @@ Notes:
 | `RUN_CLI_UPLOAD_LIMIT_BOUNDARY` | `1` | `cli-smoke-test.sh` |
 | `CLI_UPLOAD_LIMIT_BYTES` | `10737418240` | `cli-smoke-test.sh` |
 | `RUN_CLI_SEMANTIC_CHECKS` | `1` | `cli-smoke-test.sh` |
+| `RUN_CLI_FORK_CHECKS` | `1` | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_TIMEOUT_S` | `90` | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_INTERVAL_S` | `3` | `cli-smoke-test.sh` |
 | `CLI_SOURCE` | `build` (`build` or `official`) | `cli-smoke-test.sh`, `fuse-smoke-test.sh` |

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -240,7 +240,7 @@ Notes:
 | `RUN_CLI_UPLOAD_LIMIT_BOUNDARY` | `1` | `cli-smoke-test.sh` |
 | `CLI_UPLOAD_LIMIT_BYTES` | `10737418240` | `cli-smoke-test.sh` |
 | `RUN_CLI_SEMANTIC_CHECKS` | `1` | `cli-smoke-test.sh` |
-| `RUN_CLI_FORK_CHECKS` | `1` | `cli-smoke-test.sh` |
+| `RUN_CLI_FORK_CHECKS` | `1` (auto-skip when `/v1/fork` is unavailable) | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_TIMEOUT_S` | `90` | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_INTERVAL_S` | `3` | `cli-smoke-test.sh` |
 | `CLI_SOURCE` | `build` (`build` or `official`) | `cli-smoke-test.sh`, `fuse-smoke-test.sh` |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -161,7 +161,7 @@ CLI_SOURCE=official bash e2e/fuse-release-gate.sh
 
 ## Notes
 
-- `api-smoke-test.sh` expects `POST /v1/provision` to return only `api_key` and `status`.
+- `api-smoke-test.sh` expects `POST /v1/provision` to return `tenant_id`, `api_key`, and `status`.
 - Tenant readiness is checked through `GET /v1/status`.
 - File operations use `/v1/fs/*` and include nested directory coverage.
 - Semantic recall polling knobs for API smoke are `SEMANTIC_TIMEOUT_S` and `SEMANTIC_INTERVAL_S`.

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -2,7 +2,7 @@
 # drive9 API smoke test against a live drive9-server deployment.
 #
 # Coverage:
-#  1) Provision tenant (expect 202, api_key + status only)
+#  1) Provision tenant (expect 202, tenant_id + api_key + status)
 #  2) Poll tenant status via GET /v1/status until active
 #  3) Root list
 #  4) Nested mkdir (multi-level directories)
@@ -233,11 +233,13 @@ body=$(json_body "$resp")
 check_eq "POST /v1/provision returns 202" "$code" "202"
 
 API_KEY=$(printf '%s' "$body" | jq -r '.api_key // empty')
+TENANT_ID=$(printf '%s' "$body" | jq -r '.tenant_id // empty')
 INIT_STATUS=$(printf '%s' "$body" | jq -r '.status // empty')
+check_cmd "response contains tenant_id" test -n "$TENANT_ID"
 check_cmd "response contains api_key" test -n "$API_KEY"
 check_eq "provision response status is provisioning" "$INIT_STATUS" "provisioning"
 keys=$(printf '%s' "$body" | jq -r 'keys_unsorted | sort | join(",")')
-check_eq "provision response only has api_key+status" "$keys" "api_key,status"
+check_eq "provision response only has api_key+status+tenant_id" "$keys" "api_key,status,tenant_id"
 
 step "2" "Poll tenant status via /v1/status"
 deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -20,6 +20,7 @@ CLI_UPLOAD_LIMIT_BYTES="${CLI_UPLOAD_LIMIT_BYTES:-10737418240}"
 CLI_SEMANTIC_TIMEOUT_S="${CLI_SEMANTIC_TIMEOUT_S:-90}"
 CLI_SEMANTIC_INTERVAL_S="${CLI_SEMANTIC_INTERVAL_S:-3}"
 RUN_CLI_SEMANTIC_CHECKS="${RUN_CLI_SEMANTIC_CHECKS:-1}"
+RUN_CLI_FORK_CHECKS="${RUN_CLI_FORK_CHECKS:-1}"
 
 PASS=0
 FAIL=0
@@ -162,6 +163,10 @@ drive9() {
   DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$API_KEY" "$CLI_BIN" "$@"
 }
 
+drive9_ctx() {
+  env -u DRIVE9_SERVER -u DRIVE9_API_KEY -u DRIVE9_VAULT_TOKEN HOME="$CLI_CTX_HOME" "$CLI_BIN" "$@"
+}
+
 drive9_retry() {
   local attempt=1
   local out rc
@@ -176,6 +181,29 @@ drive9_retry() {
     fi
     if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* ]]; then
       echo "retry $attempt/$CLI_MAX_RETRIES for drive9 $* (throttled)" >&2
+      attempt=$((attempt + 1))
+      sleep "$CLI_RETRY_SLEEP_S"
+      continue
+    fi
+    printf '%s\n' "$out" >&2
+    return "$rc"
+  done
+}
+
+drive9_ctx_retry() {
+  local attempt=1
+  local out rc
+  while :; do
+    set +e
+    out=$(drive9_ctx "$@" 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+      printf '%s' "$out"
+      return 0
+    fi
+    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"not found"* ]]; then
+      echo "retry $attempt/$CLI_MAX_RETRIES for drive9(ctx) $* " >&2
       attempt=$((attempt + 1))
       sleep "$CLI_RETRY_SLEEP_S"
       continue
@@ -244,9 +272,13 @@ PY
 }
 
 TS="$(date +%s)"
+CLI_CTX_HOME="$(mktemp -d)"
 SMALL_LOCAL="/tmp/drive9-cli-small-${TS}.txt"
 SMALL_REMOTE="/cli-${TS}-small.txt"
 SMALL_RENAMED="/cli-${TS}-small-renamed.txt"
+CP_DIR_REMOTE="/cli-${TS}-cpdir"
+CP_DIR_REMOTE_COPY="/cli-${TS}-cpdir-copy"
+CP_DIR_LOCAL="/tmp/drive9-cli-cpdir-${TS}"
 TAG_LOCAL="/tmp/drive9-cli-tag-${TS}.txt"
 TAG_REMOTE="/cli-${TS}-tagged.txt"
 IMAGE_LOCAL="/tmp/drive9-cli-image-${TS}.jpg"
@@ -261,6 +293,57 @@ LARGE_REMOTE="/cli-${TS}-large-${CLI_LARGE_FILE_MB}m.bin"
 LARGE_DOWNLOADED="/tmp/drive9-cli-large-${TS}.download.bin"
 LARGE_BYTES=$((CLI_LARGE_FILE_MB * 1024 * 1024))
 CLI_IMAGE_UPLOADED=0
+FORK_CTX_NAME="fork-${TS}"
+FORK_REMOTE="/cli-${TS}-fork-smoke.txt"
+FORK_LOCAL="/tmp/drive9-cli-fork-${TS}.txt"
+
+echo "[3.1] ctx fork smoke"
+if [ "$RUN_CLI_FORK_CHECKS" = "1" ]; then
+  drive9_ctx ctx add --name owner --server "$BASE" --api-key "$API_KEY" >/dev/null
+  fork_json="$(drive9_ctx ctx fork "$FORK_CTX_NAME" --from owner --json)"
+  fork_api_key="$(jq -r '.api_key // empty' <<<"$fork_json")"
+  fork_tenant_id="$(jq -r '.tenant_id // empty' <<<"$fork_json")"
+  fork_status="$(jq -r '.status // empty' <<<"$fork_json")"
+  check_cmd "ctx fork returns api_key" test -n "$fork_api_key"
+  check_cmd "ctx fork returns tenant_id" test -n "$fork_tenant_id"
+  check_eq "ctx fork initial status is provisioning" "$fork_status" "provisioning"
+
+  fork_deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+  fork_state=""
+  while :; do
+    fork_status_file="$(mktemp)"
+    fork_status_code=$(curl -sS -o "$fork_status_file" -w "%{http_code}" -H "Authorization: Bearer $fork_api_key" "$BASE/v1/status")
+    fork_state=$(jq -r '.status // empty' "$fork_status_file")
+    rm -f "$fork_status_file"
+    echo "fork-status=${fork_status_code}:${fork_state}"
+    if [ "$fork_status_code" = "200" ] && [ "$fork_state" = "active" ]; then
+      break
+    fi
+    if [ "$(date +%s)" -ge "$fork_deadline" ]; then
+      break
+    fi
+    sleep "$POLL_INTERVAL_S"
+  done
+  check_eq "fork tenant becomes active" "$fork_state" "active"
+
+  printf "fork-smoke-%s" "$TS" > "$FORK_LOCAL"
+  drive9_ctx ctx use "$FORK_CTX_NAME" >/dev/null
+  drive9_ctx_retry fs cp "$FORK_LOCAL" ":$FORK_REMOTE" >/dev/null
+  fork_cat="$(drive9_ctx_retry fs cat "$FORK_REMOTE")"
+  check_eq "fork context can read written file" "$fork_cat" "fork-smoke-${TS}"
+
+  fork_delete_body="$(mktemp)"
+  fork_delete_code=$(curl -sS -o "$fork_delete_body" -w "%{http_code}" -X DELETE -H "Authorization: Bearer $fork_api_key" "$BASE/v1/fork")
+  check_eq "DELETE /v1/fork returns 202" "$fork_delete_code" "202"
+  rm -f "$fork_delete_body"
+else
+  skip_check "ctx fork returns api_key"
+  skip_check "ctx fork returns tenant_id"
+  skip_check "ctx fork initial status is provisioning"
+  skip_check "fork tenant becomes active"
+  skip_check "fork context can read written file"
+  skip_check "DELETE /v1/fork returns 202"
+fi
 
 echo "[4] small file ops via cli"
 printf "cli-smoke-%s" "$TS" > "$SMALL_LOCAL"
@@ -278,6 +361,27 @@ check_eq "uploaded small file appears in ls /" "$small_present" "true"
 
 cat_out="$(drive9_retry_read fs cat "$SMALL_REMOTE")"
 check_eq "cat returns expected small file content" "$cat_out" "cli-smoke-${TS}"
+
+echo "[4.0] cp directory target semantics"
+mkdir -p "$CP_DIR_LOCAL"
+drive9_retry fs mkdir "$CP_DIR_REMOTE" >/dev/null
+drive9_retry fs mkdir "$CP_DIR_REMOTE_COPY" >/dev/null
+
+cp_dir_base="$(basename "$SMALL_LOCAL")"
+cp_dir_remote_path="$CP_DIR_REMOTE/$cp_dir_base"
+cp_dir_remote_copy_path="$CP_DIR_REMOTE_COPY/$cp_dir_base"
+
+drive9_retry fs cp "$SMALL_LOCAL" ":$CP_DIR_REMOTE" >/dev/null
+cp_dir_remote_body="$(drive9_retry_read fs cat "$cp_dir_remote_path")"
+check_eq "cp local->remote dir keeps source name" "$cp_dir_remote_body" "cli-smoke-${TS}"
+
+drive9_retry fs cp ":$cp_dir_remote_path" "$CP_DIR_LOCAL" >/dev/null
+cp_dir_local_body="$(cat "$CP_DIR_LOCAL/$cp_dir_base")"
+check_eq "cp remote->local dir keeps source name" "$cp_dir_local_body" "cli-smoke-${TS}"
+
+drive9_retry fs cp ":$cp_dir_remote_path" ":$CP_DIR_REMOTE_COPY" >/dev/null
+cp_dir_remote_copy_body="$(drive9_retry_read fs cat "$cp_dir_remote_copy_path")"
+check_eq "cp remote->remote dir keeps source name" "$cp_dir_remote_copy_body" "cli-smoke-${TS}"
 
 drive9_retry fs mv "$SMALL_REMOTE" "$SMALL_RENAMED" >/dev/null
 renamed_out="$(drive9_retry fs ls /)"
@@ -446,6 +550,10 @@ if [ "$CLI_IMAGE_UPLOADED" = "1" ]; then
   drive9_retry fs rm "$IMAGE_REMOTE" >/dev/null
 fi
 drive9_retry fs rm "$LARGE_REMOTE" >/dev/null
+drive9_retry fs rm "$cp_dir_remote_path" >/dev/null
+drive9_retry fs rm "$cp_dir_remote_copy_path" >/dev/null
+drive9_retry fs rm -r "$CP_DIR_REMOTE" >/dev/null
+drive9_retry fs rm -r "$CP_DIR_REMOTE_COPY" >/dev/null
 for i in $(seq 1 "$CLI_BATCH_SMALL_FILE_COUNT"); do
   drive9_retry fs rm "$BATCH_REMOTE_DIR/file-${i}.txt" >/dev/null
 done
@@ -585,8 +693,9 @@ fi
 
 rm -f "$pfile" "$CLI_BIN" "$SMALL_LOCAL" "$IMAGE_LOCAL" "$LARGE_LOCAL" "$LARGE_DOWNLOADED"
 rm -f "$TAG_LOCAL"
+rm -f "$FORK_LOCAL"
 rm -f "/tmp/drive9-cli-sem-target-${TS}.txt" "/tmp/drive9-cli-sem-other-${TS}.txt" "/tmp/drive9-cli-image-caption-${TS}.txt"
-rm -rf "$BATCH_LOCAL_DIR"
+rm -rf "$BATCH_LOCAL_DIR" "$CP_DIR_LOCAL" "$CLI_CTX_HOME"
 
 echo "RESULT: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total"
 exit "$FAIL"

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -225,9 +225,6 @@ fork_checks_enabled() {
   local probe_code
   probe_code=$(curl -sS -o /dev/null -w "%{http_code}" \
     -X POST \
-    -H "Authorization: Bearer $API_KEY" \
-    -H "Content-Type: application/json" \
-    --data '{' \
     "$BASE/v1/fork" || true)
   if [ "$probe_code" = "404" ]; then
     echo "fork checks skipped: server does not expose /v1/fork" >&2

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -213,6 +213,24 @@ drive9_ctx_retry() {
   done
 }
 
+fork_checks_enabled() {
+  if [ "$RUN_CLI_FORK_CHECKS" != "1" ]; then
+    return 1
+  fi
+  local probe_code
+  probe_code=$(curl -sS -o /dev/null -w "%{http_code}" \
+    -X POST \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    --data '{' \
+    "$BASE/v1/fork" || true)
+  if [ "$probe_code" = "404" ]; then
+    echo "fork checks skipped: server does not expose /v1/fork" >&2
+    return 1
+  fi
+  return 0
+}
+
 # Some read-after-write paths can be eventually consistent right after upload.
 drive9_retry_read() {
   local attempt=1
@@ -298,7 +316,7 @@ FORK_REMOTE="/cli-${TS}-fork-smoke.txt"
 FORK_LOCAL="/tmp/drive9-cli-fork-${TS}.txt"
 
 echo "[3.1] ctx fork smoke"
-if [ "$RUN_CLI_FORK_CHECKS" = "1" ]; then
+if fork_checks_enabled; then
   drive9_ctx ctx add --name owner --server "$BASE" --api-key "$API_KEY" >/dev/null
   fork_json="$(drive9_ctx ctx fork "$FORK_CTX_NAME" --from owner --json)"
   fork_api_key="$(jq -r '.api_key // empty' <<<"$fork_json")"

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -202,6 +202,11 @@ drive9_ctx_retry() {
       printf '%s' "$out"
       return 0
     fi
+    # Fork-context smoke can race eventual consistency while the saved context
+    # becomes usable. Treat "not found" as retryable here only, with bounded
+    # retries/sleeps via CLI_MAX_RETRIES and CLI_RETRY_SLEEP_S. The match is
+    # intentionally broad and should be revisited if stricter ctx semantics are
+    # needed for other callers.
     if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"not found"* ]]; then
       echo "retry $attempt/$CLI_MAX_RETRIES for drive9(ctx) $* " >&2
       attempt=$((attempt + 1))
@@ -380,7 +385,7 @@ check_eq "uploaded small file appears in ls /" "$small_present" "true"
 cat_out="$(drive9_retry_read fs cat "$SMALL_REMOTE")"
 check_eq "cat returns expected small file content" "$cat_out" "cli-smoke-${TS}"
 
-echo "[4.0] cp directory target semantics"
+echo "[4.1] cp directory target semantics"
 mkdir -p "$CP_DIR_LOCAL"
 drive9_retry fs mkdir "$CP_DIR_REMOTE" >/dev/null
 drive9_retry fs mkdir "$CP_DIR_REMOTE_COPY" >/dev/null

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -452,7 +452,7 @@ func TestTenantStatusReturnsProvisioningState(t *testing.T) {
 	}
 }
 
-func TestTenantStatusReturnsForkProvisioningMessage(t *testing.T) {
+func TestTenantStatusForkProvisioningWithoutReadyBranchOmitsMessage(t *testing.T) {
 	rt, cleanup := newAuthRuntime(t)
 	defer cleanup()
 	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
@@ -480,7 +480,42 @@ func TestTenantStatusReturnsForkProvisioningMessage(t *testing.T) {
 	if out.Status != string(meta.TenantProvisioning) {
 		t.Fatalf("status = %q, want provisioning", out.Status)
 	}
-	if !strings.Contains(out.Message, "Creating the database branch") {
+	if out.Message != "" {
+		t.Fatalf("message = %q, want empty", out.Message)
+	}
+}
+
+func TestTenantStatusForkProvisioningBranchShowsMigrationMessage(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	if _, err := srv.meta.DB().Exec(`UPDATE tenants
+		SET status = ?, kind = ?, parent_tenant_id = ?, branch_id = ?, db_host = ?, db_port = ?, db_user = ?
+		WHERE id = ?`,
+		string(meta.TenantProvisioning), string(meta.TenantKindFork), "source", "branch-a", "", 0, "", rt.tenantID); err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var out TenantStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != string(meta.TenantProvisioning) {
+		t.Fatalf("status = %q, want provisioning", out.Status)
+	}
+	if !strings.Contains(out.Message, "Migrating fork data") {
 		t.Fatalf("message = %q", out.Message)
 	}
 }

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -136,12 +136,9 @@ func forkErr(code int, msg string) error {
 
 func forkProvisioningMessage(t *meta.Tenant) string {
 	if t == nil || t.BranchID == "" {
-		return "Creating the database branch. This usually takes 30 seconds to a few minutes."
+		return ""
 	}
-	if t.DBHost == "" || t.DBPort == 0 || t.DBUser == "" {
-		return "Waiting for the database branch to become ready. This usually takes 30 seconds to a few minutes."
-	}
-	return "Preparing fork metadata and quota counters. Large tenants may take a few minutes."
+	return "Migrating fork data. Large tenants may take a few minutes."
 }
 
 type forkFatalProvisionError struct {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -221,6 +221,8 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		s.markForkFailed(ctx, forkID)
 		return nil, forkErr(http.StatusBadGateway, "starter branch response missing required metadata")
 	}
+	forkRoot.ClusterID = cluster.ClusterID
+	forkRoot.BranchID = cluster.BranchID
 	if err := s.meta.UpdateTenantConnection(ctx, forkID, &meta.Tenant{
 		DBHost:           cluster.Host,
 		DBPort:           cluster.Port,

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -238,6 +238,9 @@ func TestCreateForkPartialBranchProvisionErrorPersistsBranchAndKeepsRoot(t *test
 	if resp.Status != string(meta.TenantProvisioning) || resp.APIKey == "" {
 		t.Fatalf("unexpected fork response: %+v", resp)
 	}
+	if resp.Message != "Migrating fork data. Large tenants may take a few minutes." {
+		t.Fatalf("message = %q", resp.Message)
+	}
 	waitForCondition(t, func() bool {
 		return len(rt.prov.deletedBranches()) >= 1
 	})
@@ -270,6 +273,9 @@ func TestCreateForkTenantPersistsGeneratedBranchPassword(t *testing.T) {
 	resp, err := rt.server.createForkTenant(context.Background(), "source", "fork")
 	if err != nil {
 		t.Fatalf("createForkTenant: %v", err)
+	}
+	if resp.Message != "Migrating fork data. Large tenants may take a few minutes." {
+		t.Fatalf("message = %q", resp.Message)
 	}
 
 	forkTenant, err := rt.meta.GetTenant(context.Background(), resp.TenantID)

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -110,6 +110,9 @@ func TestProvisionMarksTenantFailedWhenInitKeepsFailing(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
+	if out["tenant_id"] == "" {
+		t.Fatalf("unexpected provision response: %+v", out)
+	}
 	apiKey := out["api_key"]
 	if apiKey == "" {
 		t.Fatal("empty api_key")
@@ -211,7 +214,7 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if out["api_key"] == "" {
+	if out["tenant_id"] == "" || out["api_key"] == "" {
 		t.Fatalf("unexpected provision response: %+v", out)
 	}
 	claims, err := token.ParseAndVerifyToken(tokenSecret, out["api_key"])

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2523,6 +2523,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_accepted", "tenant_id", tenantID, "provider", provider)...)
 	metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "accepted")
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]string{
 		"tenant_id": tenantID,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2525,8 +2525,9 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]string{
-		"api_key": apiToken,
-		"status":  string(meta.TenantProvisioning),
+		"tenant_id": tenantID,
+		"api_key":   apiToken,
+		"status":    string(meta.TenantProvisioning),
 	})
 }
 
@@ -2539,8 +2540,9 @@ func (s *Server) handleLocalTenantProvision(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]string{
-		"api_key": s.localTenantAPIKey,
-		"status":  "provisioning",
+		"tenant_id": "local",
+		"api_key":   s.localTenantAPIKey,
+		"status":    "provisioning",
 	})
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1170,11 +1170,14 @@ func TestLocalTenantShimProvisionAndStatus(t *testing.T) {
 	if got := provisionBody["api_key"]; got != "local-dev-key" {
 		t.Fatalf("api_key = %q, want local-dev-key", got)
 	}
+	if got := provisionBody["tenant_id"]; got != "local" {
+		t.Fatalf("tenant_id = %q, want local", got)
+	}
 	if got := provisionBody["status"]; got != "provisioning" {
 		t.Fatalf("status = %q, want provisioning", got)
 	}
-	if len(provisionBody) != 2 {
-		t.Fatalf("provision body keys = %v, want only api_key/status", provisionBody)
+	if len(provisionBody) != 3 {
+		t.Fatalf("provision body keys = %v, want only tenant_id/api_key/status", provisionBody)
 	}
 
 	statusReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)


### PR DESCRIPTION
## Summary
- align fork provisioning status messaging with create until a branch exists, then show a single migration message
- return `tenant_id` from `/v1/provision` and local shim provision responses so CLI output stays populated
- make `drive9 fs cp` treat directory destinations like shell `cp` and add CLI tests for all three copy directions
- extend `e2e/cli-smoke-test.sh` with live fork coverage and directory-target cp checks

## Validation
- `go test ./pkg/server ./cmd/drive9/cli`
- `bash -n e2e/cli-smoke-test.sh`
- `DRIVE9_BASE=http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com RUN_CLI_SEMANTIC_CHECKS=0 RUN_CLI_UPLOAD_LIMIT_BOUNDARY=0 CLI_LARGE_FILE_MB=1 CLI_BATCH_SMALL_FILE_COUNT=2 bash e2e/cli-smoke-test.sh`

## Self-review
- reviewed the final diff for copy-target resolution, fork status messaging, and provision response shape
- live smoke passed end to end with the new fork and cp directory checks enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy command resolves directory-style destinations and preserves source filenames.
  * Provision API now includes tenant_id in provision responses.

* **Improvements**
  * Fork/ctx workflow: forking no longer auto-switches contexts; guidance added to CLI output and help text updated.
  * CLI smoke tests gain optional fork-context coverage and more robust retry/cleanup behavior.

* **Documentation**
  * Updated CLI smoke-test docs and README to reflect provisioning response and fork workflow.

* **Tests**
  * Added/expanded tests for copy destination semantics and fork/provision behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/426)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->