### PR TITLE
perf: improve FUSE reads and delete paths

### DIFF
--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -18,6 +18,7 @@ type mountFuseOptions struct {
 	RemoteRoot            string
 	CacheDir              string
 	CacheSize             int64
+	ReadCacheMaxFileBytes int64
 	DirTTL                time.Duration
 	AttrTTL               time.Duration
 	EntryTTL              time.Duration

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -30,6 +30,7 @@ func mountFuseImpl(opts *mountFuseOptions) error {
 		RemoteRoot:            opts.RemoteRoot,
 		CacheDir:              opts.CacheDir,
 		CacheSize:             opts.CacheSize,
+		ReadCacheMaxFileBytes: opts.ReadCacheMaxFileBytes,
 		DirTTL:                opts.DirTTL,
 		AttrTTL:               opts.AttrTTL,
 		EntryTTL:              opts.EntryTTL,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -84,6 +84,7 @@ func fsMountCmd(args []string) error {
 	mode := fs.String("mode", "auto", "mount mode: auto, fuse, or webdav")
 	cacheDir := fs.String("cache-dir", "", "write-back cache directory (default ~/.cache/drive9)")
 	cacheSize := fs.Int("cache-size", 128, "read cache size in MB")
+	readCacheMaxFile := fs.Int64("read-cache-max-file-mb", 1, "maximum single file size admitted to read cache in MB")
 	dirTTL := fs.Duration("dir-ttl", 10*time.Second, "directory cache TTL")
 	attrTTL := fs.Duration("attr-ttl", 10*time.Second, "kernel attr cache TTL")
 	entryTTL := fs.Duration("entry-ttl", 10*time.Second, "kernel entry cache TTL")
@@ -151,6 +152,9 @@ func fsMountCmd(args []string) error {
 	}
 	if err := validateReadDirPrefetchFlags(*prefetchMaxFiles, *prefetchMaxFileBytes, *prefetchMaxBytes, *prefetchTimeout); err != nil {
 		return err
+	}
+	if *readCacheMaxFile <= 0 {
+		return fmt.Errorf("drive9 mount: --read-cache-max-file-mb must be > 0")
 	}
 	normalizedLookupRetryCount := lookupRetryCountFlagValue(lookupRetryCountGiven, *lookupRetryCount)
 	normalizedLookupRetryTimeout := durationFlagValue(fs, "lookup-retry-timeout", *lookupRetryTimeout)
@@ -223,6 +227,7 @@ func fsMountCmd(args []string) error {
 		RemoteRoot:            remoteRoot,
 		CacheDir:              *cacheDir,
 		CacheSize:             int64(*cacheSize) << 20,
+		ReadCacheMaxFileBytes: *readCacheMaxFile << 20,
 		DirTTL:                normalizedDirTTL,
 		AttrTTL:               normalizedAttrTTL,
 		EntryTTL:              normalizedEntryTTL,

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -721,6 +721,35 @@ func TestMountCmdLeavesLegacyDirStatFallbackDisabledByDefault(t *testing.T) {
 	}
 }
 
+func TestMountCmdPassesReadCacheMaxFileOption(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--read-cache-max-file-mb", "4",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if got.ReadCacheMaxFileBytes != 4<<20 {
+		t.Fatalf("ReadCacheMaxFileBytes = %d, want %d", got.ReadCacheMaxFileBytes, int64(4<<20))
+	}
+}
+
 func TestMountCmdLeavesDefaultTTLsUnsetForFuseDefaults(t *testing.T) {
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -1120,10 +1120,13 @@ func (b *Dat9Backend) CopyFileCtx(ctx context.Context, srcPath, dstPath string) 
 		return err
 	}
 	return b.store.InTx(ctx, func(tx *sql.Tx) error {
-		return b.store.InsertNodeTx(tx, &datastore.FileNode{
+		if err := b.store.InsertNodeTx(tx, &datastore.FileNode{
 			NodeID: b.genID(), Path: dstPath, ParentPath: pathutil.ParentPath(dstPath),
 			Name: pathutil.BaseName(dstPath), FileID: srcNode.FileID, CreatedAt: time.Now(),
-		})
+		}); err != nil {
+			return fmt.Errorf("insert copied node %q: %w", dstPath, err)
+		}
+		return nil
 	})
 }
 

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -1119,9 +1119,11 @@ func (b *Dat9Backend) CopyFileCtx(ctx context.Context, srcPath, dstPath string) 
 	if err := b.store.EnsureParentDirs(ctx, dstPath, b.genID); err != nil {
 		return err
 	}
-	return b.store.InsertNode(ctx, &datastore.FileNode{
-		NodeID: b.genID(), Path: dstPath, ParentPath: pathutil.ParentPath(dstPath),
-		Name: pathutil.BaseName(dstPath), FileID: srcNode.FileID, CreatedAt: time.Now(),
+	return b.store.InTx(ctx, func(tx *sql.Tx) error {
+		return b.store.InsertNodeTx(tx, &datastore.FileNode{
+			NodeID: b.genID(), Path: dstPath, ParentPath: pathutil.ParentPath(dstPath),
+			Name: pathutil.BaseName(dstPath), FileID: srcNode.FileID, CreatedAt: time.Now(),
+		})
 	})
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -110,18 +110,20 @@ func NewWithToken(baseURL, token string) *Client {
 // decisions server-side.
 func newClient(baseURL, credential string) *Client {
 	// Clone DefaultTransport to preserve Proxy, HTTP/2, dialer, and TLS defaults,
-	// then tune connection pooling for concurrent multipart uploads to S3.
+	// then tune connection pooling for concurrent multipart uploads, prefetch,
+	// and repeated range reads against both drive9 and presigned S3 URLs.
 	// Default MaxIdleConnsPerHost=2 forces new TLS handshakes for every
-	// part beyond 2 in-flight, adding ~50-100ms per part. Setting it to
-	// 16 lets the connection pool cover typical upload parallelism.
+	// request beyond 2 in-flight, adding ~50-100ms per connection in WAN
+	// deployments. Keep headroom above uploadMaxConcurrency so reads and
+	// metadata calls do not evict upload connections.
 	var transport *http.Transport
 	if t, ok := http.DefaultTransport.(*http.Transport); ok {
 		transport = t.Clone()
 	} else {
 		transport = &http.Transport{}
 	}
-	transport.MaxIdleConns = 100
-	transport.MaxIdleConnsPerHost = 16
+	transport.MaxIdleConns = 256
+	transport.MaxIdleConnsPerHost = 64
 
 	// Custom DialContext: fall back to public DNS (8.8.8.8, 1.1.1.1) when the
 	// system resolver fails. Fixes DNS on Termux and minimal containers that

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -179,13 +179,13 @@ type downloadRange struct {
 	length int64
 }
 
-// readTarget captures the presigned object URL resolved from the control
-// plane for one large-file download. The current parallel downloader assumes
-// this URL remains valid for the lifetime of the download; if it expires mid-
-// transfer we fail the download instead of refreshing and retrying in place.
-// Follow-up: #138.
-type readTarget struct {
-	objectURL string
+// ReadTarget captures a resolved object URL for S3-backed reads. Callers that
+// read multiple ranges from the same open file can resolve this once and reuse
+// it until the handle is closed. The current readers assume this URL remains
+// valid for the lifetime of the operation; if it expires mid-transfer, the
+// range read fails instead of refreshing and retrying in place.
+type ReadTarget struct {
+	ObjectURL string
 }
 
 type uploadBufferPool struct {
@@ -1207,7 +1207,14 @@ func (c *Client) readWithoutRedirect(ctx context.Context, path string) (*http.Re
 	return noRedirectClient.Do(req)
 }
 
-func (c *Client) resolveReadTarget(ctx context.Context, path string) (*readTarget, error) {
+// ResolveReadTarget resolves a large S3-backed file path to a reusable object
+// URL. Inline files return errReadTargetNoRedirect because there is no object
+// URL to reuse.
+func (c *Client) ResolveReadTarget(ctx context.Context, path string) (*ReadTarget, error) {
+	return c.resolveReadTarget(ctx, path)
+}
+
+func (c *Client) resolveReadTarget(ctx context.Context, path string) (*ReadTarget, error) {
 	resp, err := c.readWithoutRedirect(ctx, path)
 	if err != nil {
 		return nil, err
@@ -1220,7 +1227,7 @@ func (c *Client) resolveReadTarget(ctx context.Context, path string) (*readTarge
 		if location == "" {
 			return nil, fmt.Errorf("302 without Location header")
 		}
-		return &readTarget{objectURL: location}, nil
+		return &ReadTarget{ObjectURL: location}, nil
 
 	case resp.StatusCode >= 300:
 		return nil, readError(resp)
@@ -1228,6 +1235,14 @@ func (c *Client) resolveReadTarget(ctx context.Context, path string) (*readTarge
 	default:
 		return nil, errReadTargetNoRedirect
 	}
+}
+
+// ReadObjectRange reads a byte range from a previously resolved read target.
+func (c *Client) ReadObjectRange(ctx context.Context, target *ReadTarget, offset, length int64) (io.ReadCloser, error) {
+	if target == nil || target.ObjectURL == "" {
+		return nil, fmt.Errorf("read target is required")
+	}
+	return c.readObjectRangeStrict(ctx, target.ObjectURL, offset, length)
 }
 
 func (c *Client) downloadToFileSequential(ctx context.Context, remotePath string, out *os.File) (*DownloadSummary, error) {
@@ -1402,7 +1417,7 @@ func (c *Client) DownloadToFileWithSummary(ctx context.Context, remotePath, loca
 	return summary, nil
 }
 
-func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, localPath string, out *os.File, size int64, target *readTarget) (*DownloadSummary, error) {
+func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, localPath string, out *os.File, size int64, target *ReadTarget) (*DownloadSummary, error) {
 	// Resolve the presigned object URL once, then reuse it for all range GETs in
 	// this download. This avoids paying one redirect / presign round-trip per
 	// chunk while keeping the existing server contract unchanged.
@@ -1440,7 +1455,7 @@ func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, loca
 					return
 				}
 
-				rc, err := c.readObjectRangeStrict(ctx, target.objectURL, task.offset, task.length)
+				rc, err := c.readObjectRangeStrict(ctx, target.ObjectURL, task.offset, task.length)
 				if err != nil {
 					reportErr(err)
 					return

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -181,9 +181,8 @@ type downloadRange struct {
 
 // ReadTarget captures a resolved object URL for S3-backed reads. Callers that
 // read multiple ranges from the same open file can resolve this once and reuse
-// it until the handle is closed. The current readers assume this URL remains
-// valid for the lifetime of the operation; if it expires mid-transfer, the
-// range read fails instead of refreshing and retrying in place.
+// it. If the presigned URL expires, ReadObjectRange returns an error matched by
+// IsPresignExpired so callers can resolve a fresh target and retry.
 type ReadTarget struct {
 	ObjectURL string
 }
@@ -1035,6 +1034,12 @@ func (c *Client) uploadPartsV2(ctx context.Context, plan *uploadPlanV2, ra io.Re
 // errPresignExpired indicates S3 returned 403, likely due to an expired presigned URL.
 var errPresignExpired = fmt.Errorf("presigned URL expired")
 
+// IsPresignExpired reports whether err indicates a direct S3 presigned URL
+// expired and the caller should resolve a fresh URL before retrying.
+func IsPresignExpired(err error) bool {
+	return errors.Is(err, errPresignExpired)
+}
+
 // uploadOnePartV2 PUTs data to a presigned URL and returns the ETag.
 // Phase 1: no per-part checksum header — checksum negotiation deferred to #113/#114.
 // Returns errPresignExpired on 403 so callers can re-presign and retry.
@@ -1238,6 +1243,8 @@ func (c *Client) resolveReadTarget(ctx context.Context, path string) (*ReadTarge
 }
 
 // ReadObjectRange reads a byte range from a previously resolved read target.
+// If the target's presigned object URL expired, the returned error matches
+// IsPresignExpired so callers can resolve a fresh target and retry.
 func (c *Client) ReadObjectRange(ctx context.Context, target *ReadTarget, offset, length int64) (io.ReadCloser, error) {
 	if target == nil || target.ObjectURL == "" {
 		return nil, fmt.Errorf("read target is required")
@@ -1333,6 +1340,9 @@ func (c *Client) readObjectRangeStrict(ctx context.Context, objectURL string, of
 	switch resp.StatusCode {
 	case http.StatusPartialContent:
 		return resp.Body, nil
+	case http.StatusForbidden:
+		defer func() { _ = resp.Body.Close() }()
+		return nil, errPresignExpired
 	case http.StatusRequestedRangeNotSatisfiable:
 		defer func() { _ = resp.Body.Close() }()
 		return io.NopCloser(bytes.NewReader(nil)), nil

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -135,6 +135,13 @@ const (
 
 var errReadTargetNoRedirect = errors.New("parallel download unavailable without redirect")
 
+// IsReadTargetNoRedirect reports whether err indicates that a read target could
+// not be resolved because the server returned an inline file body instead of a
+// redirect to object storage.
+func IsReadTargetNoRedirect(err error) bool {
+	return errors.Is(err, errReadTargetNoRedirect)
+}
+
 // DownloadSummary exposes the coarse-grained large-file download metrics that
 // the CLI emits as a structured log event when CLI logging is enabled.
 type DownloadSummary struct {
@@ -1213,8 +1220,8 @@ func (c *Client) readWithoutRedirect(ctx context.Context, path string) (*http.Re
 }
 
 // ResolveReadTarget resolves a large S3-backed file path to a reusable object
-// URL. Inline files return errReadTargetNoRedirect because there is no object
-// URL to reuse.
+// URL. Inline files return an error matched by IsReadTargetNoRedirect because
+// there is no object URL to reuse.
 func (c *Client) ResolveReadTarget(ctx context.Context, path string) (*ReadTarget, error) {
 	return c.resolveReadTarget(ctx, path)
 }
@@ -1403,7 +1410,7 @@ func (c *Client) DownloadToFileWithSummary(ctx context.Context, remotePath, loca
 
 	target, err := c.resolveReadTarget(ctx, remotePath)
 	if err != nil {
-		if errors.Is(err, errReadTargetNoRedirect) {
+		if IsReadTargetNoRedirect(err) {
 			// Keep large-file downloads working when the control plane serves the
 			// object inline instead of redirecting to object storage. In that case
 			// the parallel range path is unavailable, so fall back to ReadStream.
@@ -1447,6 +1454,7 @@ func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, loca
 	tasks := make(chan downloadRange, concurrency)
 	errCh := make(chan error, 1)
 	var wg sync.WaitGroup
+	var targetMu sync.RWMutex
 
 	reportErr := func(err error) {
 		select {
@@ -1454,6 +1462,23 @@ func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, loca
 			cancel()
 		default:
 		}
+	}
+
+	objectURL := func() string {
+		targetMu.RLock()
+		defer targetMu.RUnlock()
+		return target.ObjectURL
+	}
+
+	refreshTarget := func(ctx context.Context) error {
+		resolved, err := c.resolveReadTarget(ctx, remotePath)
+		if err != nil {
+			return err
+		}
+		targetMu.Lock()
+		target.ObjectURL = resolved.ObjectURL
+		targetMu.Unlock()
+		return nil
 	}
 
 	for i := 0; i < concurrency; i++ {
@@ -1465,7 +1490,14 @@ func (c *Client) downloadLargeFileParallel(ctx context.Context, remotePath, loca
 					return
 				}
 
-				rc, err := c.readObjectRangeStrict(ctx, target.ObjectURL, task.offset, task.length)
+				rc, err := c.readObjectRangeStrict(ctx, objectURL(), task.offset, task.length)
+				if IsPresignExpired(err) {
+					if refreshErr := refreshTarget(ctx); refreshErr != nil {
+						reportErr(fmt.Errorf("refresh read target for %s: %w", remotePath, refreshErr))
+						return
+					}
+					rc, err = c.readObjectRangeStrict(ctx, objectURL(), task.offset, task.length)
+				}
 				if err != nil {
 					reportErr(err)
 					return

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1445,6 +1445,60 @@ func TestReadStreamRangeLargeFileTreats416AsEOF(t *testing.T) {
 	}
 }
 
+func TestResolveReadTargetAndReadObjectRange(t *testing.T) {
+	var readRequests atomic.Int32
+	var objectRequests atomic.Int32
+	data := []byte("0123456789")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/fs/large.bin":
+			readRequests.Add(1)
+			w.Header().Set("Location", fmt.Sprintf("http://%s/s3/presigned?token=fixed", r.Host))
+			w.WriteHeader(http.StatusFound)
+		case "/s3/presigned":
+			objectRequests.Add(1)
+			if got := r.URL.RawQuery; got != "token=fixed" {
+				http.Error(w, "wrong query: "+got, http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Range"); got != "bytes=2-5" {
+				http.Error(w, "wrong range: "+got, http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(data[2:6])
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	target, err := c.ResolveReadTarget(context.Background(), "/large.bin")
+	if err != nil {
+		t.Fatalf("ResolveReadTarget: %v", err)
+	}
+	rc, err := c.ReadObjectRange(context.Background(), target, 2, 4)
+	if err != nil {
+		t.Fatalf("ReadObjectRange: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "2345" {
+		t.Fatalf("got %q, want 2345", got)
+	}
+	if got := readRequests.Load(); got != 1 {
+		t.Fatalf("read requests = %d, want 1", got)
+	}
+	if got := objectRequests.Load(); got != 1 {
+		t.Fatalf("object requests = %d, want 1", got)
+	}
+}
+
 func TestDownloadToFileWithSummaryReusesPresignedURL(t *testing.T) {
 	data := bytes.Repeat([]byte("ab"), downloadChunkSize/2)
 	data = append(data, []byte("tail")...)

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1513,6 +1513,19 @@ func TestReadObjectRangePresignExpired(t *testing.T) {
 	}
 }
 
+func TestResolveReadTargetInlineFileErrorIsDetectable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("inline"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	_, err := c.ResolveReadTarget(context.Background(), "/small.txt")
+	if !IsReadTargetNoRedirect(err) {
+		t.Fatalf("ResolveReadTarget error = %v, want no-redirect sentinel", err)
+	}
+}
+
 func TestDownloadToFileWithSummaryReusesPresignedURL(t *testing.T) {
 	data := bytes.Repeat([]byte("ab"), downloadChunkSize/2)
 	data = append(data, []byte("tail")...)
@@ -1587,6 +1600,71 @@ func TestDownloadToFileWithSummaryReusesPresignedURL(t *testing.T) {
 		t.Fatalf("summary concurrency = %d, want 2", summary.Concurrency)
 	}
 
+	downloaded, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(downloaded, data) {
+		t.Fatal("downloaded file content mismatch")
+	}
+}
+
+func TestDownloadToFileWithSummaryRefreshesExpiredPresignedURL(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), downloadChunkSize)
+
+	var readRequests atomic.Int32
+	var expiredObjectRequests atomic.Int32
+	var freshObjectRequests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/fs/large.bin":
+			req := readRequests.Add(1)
+			token := "expired"
+			if req > 1 {
+				token = "fresh"
+			}
+			w.Header().Set("Location", fmt.Sprintf("http://%s/s3/presigned?token=%s", r.Host, token))
+			w.WriteHeader(http.StatusFound)
+		case "/s3/presigned":
+			switch r.URL.Query().Get("token") {
+			case "expired":
+				expiredObjectRequests.Add(1)
+				w.WriteHeader(http.StatusForbidden)
+			case "fresh":
+				freshObjectRequests.Add(1)
+				if got := r.Header.Get("Range"); got != fmt.Sprintf("bytes=0-%d", len(data)-1) {
+					http.Error(w, "wrong range: "+got, http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", len(data)-1, len(data)))
+				w.WriteHeader(http.StatusPartialContent)
+				_, _ = w.Write(data)
+			default:
+				http.Error(w, "missing token", http.StatusBadRequest)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	localPath := filepath.Join(t.TempDir(), "large.bin")
+	c := New(srv.URL, "")
+
+	_, err := c.DownloadToFileWithSummary(context.Background(), "/large.bin", localPath, int64(len(data)))
+	if err != nil {
+		t.Fatalf("DownloadToFileWithSummary: %v", err)
+	}
+	if got := readRequests.Load(); got != 2 {
+		t.Fatalf("expected initial resolve plus refresh, got %d /v1/fs requests", got)
+	}
+	if got := expiredObjectRequests.Load(); got != 1 {
+		t.Fatalf("expected one expired object request, got %d", got)
+	}
+	if got := freshObjectRequests.Load(); got != 1 {
+		t.Fatalf("expected one fresh object request, got %d", got)
+	}
 	downloaded, err := os.ReadFile(localPath)
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1499,6 +1499,20 @@ func TestResolveReadTargetAndReadObjectRange(t *testing.T) {
 	}
 }
 
+func TestReadObjectRangePresignExpired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("expired"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	_, err := c.ReadObjectRange(context.Background(), &ReadTarget{ObjectURL: srv.URL}, 0, 4)
+	if !IsPresignExpired(err) {
+		t.Fatalf("ReadObjectRange error = %v, want presign expired", err)
+	}
+}
+
 func TestDownloadToFileWithSummaryReusesPresignedURL(t *testing.T) {
 	data := bytes.Repeat([]byte("ab"), downloadChunkSize/2)
 	data = append(data, []byte("tail")...)

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1072,6 +1072,11 @@ func ensureParentDirsWithExecer(ctx context.Context, db execer, path string, gen
 }
 
 func (s *Store) InsertNodeTx(db execer, n *FileNode) error {
+	if !n.IsDirectory && n.FileID != "" {
+		if err := s.lockConfirmedFileForAttachTx(db, n.FileID); err != nil {
+			return err
+		}
+	}
 	_, err := db.Exec(`INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, file_id, inode_id, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		n.NodeID, n.Path, n.ParentPath, n.Name, n.IsDirectory, nullStr(n.FileID), nullStr(n.InodeID), n.CreatedAt.UTC())
@@ -1079,6 +1084,31 @@ func (s *Store) InsertNodeTx(db execer, n *FileNode) error {
 		return ErrPathConflict
 	}
 	return err
+}
+
+func (s *Store) lockConfirmedFileForAttachTx(db execer, fileID string) error {
+	var status string
+	if s.useLegacyFiles {
+		if err := db.QueryRow(`SELECT status FROM files WHERE file_id = ? FOR UPDATE`, fileID).Scan(&status); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return err
+		}
+		if FileStatus(status) != StatusConfirmed {
+			return ErrNotFound
+		}
+	}
+	if err := db.QueryRow(`SELECT status FROM inodes WHERE inode_id = ? FOR UPDATE`, fileID).Scan(&status); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
+	if FileStatus(status) != StatusConfirmed {
+		return ErrNotFound
+	}
+	return nil
 }
 
 func (s *Store) MarkFileDeleted(ctx context.Context, fileID string) (err error) {
@@ -1520,7 +1550,7 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	candidate, err := s.scanDeleteCandidateTx(tx, path)
+	candidate, err := s.scanDeleteCandidateTx(ctx, tx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -1536,9 +1566,12 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 	if candidate.fileID == "" {
 		return nil, tx.Commit()
 	}
+	if err := s.lockFileIDsForDeleteTx(ctx, tx, []string{candidate.fileID}); err != nil {
+		return nil, err
+	}
 
 	var count int64
-	err = tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE file_id = ? FOR UPDATE`, candidate.fileID).Scan(&count)
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM file_nodes WHERE file_id = ? FOR UPDATE`, candidate.fileID).Scan(&count)
 	if err != nil {
 		return nil, err
 	}
@@ -1551,10 +1584,10 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 		return nil, ErrNotFound
 	}
 
-	if err := s.markFilesDeletedTx(tx, []string{candidate.fileID}); err != nil {
+	if err := s.markFilesDeletedTx(ctx, tx, []string{candidate.fileID}); err != nil {
 		return nil, err
 	}
-	if err := deleteFileTagsByIDsTx(tx, []string{candidate.fileID}); err != nil {
+	if err := deleteFileTagsByIDsTx(ctx, tx, []string{candidate.fileID}); err != nil {
 		return nil, err
 	}
 
@@ -1584,7 +1617,7 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	rows, err := tx.Query(`SELECT DISTINCT file_id FROM file_nodes
+	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT file_id FROM file_nodes
 		WHERE (path = ? OR path LIKE ?) AND file_id IS NOT NULL`, dirPath, dirPath+"%")
 	if err != nil {
 		return nil, err
@@ -1600,12 +1633,16 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 	}
 	_ = rows.Close()
 
-	if _, err := tx.Exec(`DELETE FROM file_nodes WHERE path = ? OR path LIKE ?`,
+	if err := s.lockFileIDsForDeleteTx(ctx, tx, fileIDs); err != nil {
+		return nil, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE path = ? OR path LIKE ?`,
 		dirPath, dirPath+"%"); err != nil {
 		return nil, err
 	}
 
-	orphaned, err := s.scanOrphanedFilesByIDTx(tx, fileIDs)
+	orphaned, err := s.scanOrphanedFilesByIDTx(ctx, tx, fileIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -1613,10 +1650,10 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 	for _, f := range orphaned {
 		orphanIDs = append(orphanIDs, f.FileID)
 	}
-	if err := s.markFilesDeletedTx(tx, orphanIDs); err != nil {
+	if err := s.markFilesDeletedTx(ctx, tx, orphanIDs); err != nil {
 		return nil, err
 	}
-	if err := deleteFileTagsByIDsTx(tx, orphanIDs); err != nil {
+	if err := deleteFileTagsByIDsTx(ctx, tx, orphanIDs); err != nil {
 		return nil, err
 	}
 
@@ -1643,9 +1680,11 @@ type deleteCandidate struct {
 	file   *File
 }
 
-func (s *Store) scanDeleteCandidateTx(tx *sql.Tx, path string) (*deleteCandidate, error) {
+const deleteFileIDBatchSize = 1000
+
+func (s *Store) scanDeleteCandidateTx(ctx context.Context, tx *sql.Tx, path string) (*deleteCandidate, error) {
 	if s.useLegacyFiles {
-		row := tx.QueryRow(`SELECT fn.file_id, fn.is_directory,
+		row := tx.QueryRowContext(ctx, `SELECT fn.file_id, fn.is_directory,
 			f.file_id, f.storage_type, f.storage_ref, f.storage_encryption_mode,
 			f.storage_encryption_key_id, f.content_type, f.size_bytes, f.checksum_sha256,
 			f.revision, f.embedding_revision, f.status, f.source_id, f.created_at, f.confirmed_at, f.expires_at
@@ -1655,7 +1694,7 @@ func (s *Store) scanDeleteCandidateTx(tx *sql.Tx, path string) (*deleteCandidate
 			FOR UPDATE`, path)
 		return scanLegacyDeleteCandidate(row)
 	}
-	row := tx.QueryRow(`SELECT fn.file_id, fn.is_directory,
+	row := tx.QueryRowContext(ctx, `SELECT fn.file_id, fn.is_directory,
 		c.storage_type, c.storage_ref, i.size_bytes, COALESCE(c.content_type, ''),
 		s.embedding_revision
 		FROM file_nodes fn
@@ -1724,76 +1763,159 @@ func scanSplitDeleteCandidate(row *sql.Row) (*deleteCandidate, error) {
 	return c, nil
 }
 
-func (s *Store) scanOrphanedFilesByIDTx(tx *sql.Tx, fileIDs []string) ([]*File, error) {
+func (s *Store) scanOrphanedFilesByIDTx(ctx context.Context, tx *sql.Tx, fileIDs []string) ([]*File, error) {
 	if len(fileIDs) == 0 {
 		return nil, nil
 	}
-	args := stringsToAny(fileIDs)
-	placeholders := questionPlaceholders(len(fileIDs))
-	var query string
-	if s.useLegacyFiles {
-		query = `SELECT f.file_id, f.storage_type, f.storage_ref, f.storage_encryption_mode,
-			f.storage_encryption_key_id, f.content_type, f.size_bytes, f.checksum_sha256,
-			f.revision, f.embedding_revision, f.status, f.source_id, f.created_at, f.confirmed_at, f.expires_at
-			FROM files f
-			WHERE f.file_id IN (` + placeholders + `)
-			  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE fn.file_id = f.file_id)`
-	} else {
-		query = `SELECT i.inode_id, c.storage_type, c.storage_ref, i.size_bytes,
-			COALESCE(c.content_type, ''), s.embedding_revision
-			FROM inodes i
-			JOIN contents c ON c.inode_id = i.inode_id
-			LEFT JOIN semantic s ON s.inode_id = i.inode_id
-			WHERE i.inode_id IN (` + placeholders + `)
-			  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE fn.file_id = i.inode_id)`
-	}
-	rows, err := tx.Query(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
 	var out []*File
-	for rows.Next() {
-		var f *File
-		if s.useLegacyFiles {
-			var fileID, storageType, storageRef, encMode, encKeyID sql.NullString
-			var contentType, checksum, status, sourceID sql.NullString
-			var sizeBytes, revision, embeddingRevision sql.NullInt64
-			var createdAt, confirmedAt, expiresAt sql.NullTime
-			if err := rows.Scan(&fileID, &storageType, &storageRef, &encMode, &encKeyID,
-				&contentType, &sizeBytes, &checksum, &revision, &embeddingRevision,
-				&status, &sourceID, &createdAt, &confirmedAt, &expiresAt); err != nil {
-				return nil, err
-			}
-			f = fileFromLegacyGCScan(fileID.String, storageType, storageRef, encMode, encKeyID,
-				contentType, sizeBytes, checksum, revision, embeddingRevision, status,
-				sourceID, createdAt, confirmedAt, expiresAt)
-			f.Status = StatusDeleted
-		} else {
-			var fileID, storageType, storageRef, contentType sql.NullString
-			var sizeBytes, embeddingRevision sql.NullInt64
-			if err := rows.Scan(&fileID, &storageType, &storageRef, &sizeBytes, &contentType, &embeddingRevision); err != nil {
-				return nil, err
-			}
-			f = &File{
-				FileID:      fileID.String,
-				StorageType: StorageType(storageType.String),
-				StorageRef:  storageRef.String,
-				ContentType: contentType.String,
-				SizeBytes:   sizeBytes.Int64,
-				Status:      StatusDeleted,
-			}
-			if embeddingRevision.Valid {
-				rev := embeddingRevision.Int64
-				f.EmbeddingRevision = &rev
-			}
+	for start := 0; start < len(fileIDs); start += deleteFileIDBatchSize {
+		end := start + deleteFileIDBatchSize
+		if end > len(fileIDs) {
+			end = len(fileIDs)
 		}
-		out = append(out, f)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+		batch := fileIDs[start:end]
+		args := stringsToAny(batch)
+		placeholders := questionPlaceholders(len(batch))
+		var query string
+		if s.useLegacyFiles {
+			query = `SELECT f.file_id, f.storage_type, f.storage_ref, f.storage_encryption_mode,
+				f.storage_encryption_key_id, f.content_type, f.size_bytes, f.checksum_sha256,
+				f.revision, f.embedding_revision, f.status, f.source_id, f.created_at, f.confirmed_at, f.expires_at
+				FROM files f
+				WHERE f.file_id IN (` + placeholders + `)
+				  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE fn.file_id = f.file_id)`
+		} else {
+			query = `SELECT i.inode_id, c.storage_type, c.storage_ref, i.size_bytes,
+				COALESCE(c.content_type, ''), s.embedding_revision
+				FROM inodes i
+				JOIN contents c ON c.inode_id = i.inode_id
+				LEFT JOIN semantic s ON s.inode_id = i.inode_id
+				WHERE i.inode_id IN (` + placeholders + `)
+				  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE fn.file_id = i.inode_id)`
+		}
+		rows, err := tx.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var f *File
+			if s.useLegacyFiles {
+				var fileID, storageType, storageRef, encMode, encKeyID sql.NullString
+				var contentType, checksum, status, sourceID sql.NullString
+				var sizeBytes, revision, embeddingRevision sql.NullInt64
+				var createdAt, confirmedAt, expiresAt sql.NullTime
+				if err := rows.Scan(&fileID, &storageType, &storageRef, &encMode, &encKeyID,
+					&contentType, &sizeBytes, &checksum, &revision, &embeddingRevision,
+					&status, &sourceID, &createdAt, &confirmedAt, &expiresAt); err != nil {
+					_ = rows.Close()
+					return nil, err
+				}
+				f = fileFromLegacyGCScan(fileID.String, storageType, storageRef, encMode, encKeyID,
+					contentType, sizeBytes, checksum, revision, embeddingRevision, status,
+					sourceID, createdAt, confirmedAt, expiresAt)
+				f.Status = StatusDeleted
+			} else {
+				var fileID, storageType, storageRef, contentType sql.NullString
+				var sizeBytes, embeddingRevision sql.NullInt64
+				if err := rows.Scan(&fileID, &storageType, &storageRef, &sizeBytes, &contentType, &embeddingRevision); err != nil {
+					_ = rows.Close()
+					return nil, err
+				}
+				f = &File{
+					FileID:      fileID.String,
+					StorageType: StorageType(storageType.String),
+					StorageRef:  storageRef.String,
+					ContentType: contentType.String,
+					SizeBytes:   sizeBytes.Int64,
+					Status:      StatusDeleted,
+				}
+				if embeddingRevision.Valid {
+					rev := embeddingRevision.Int64
+					f.EmbeddingRevision = &rev
+				}
+			}
+			out = append(out, f)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
 	}
 	return out, nil
+}
+
+func (s *Store) lockFileIDsForDeleteTx(ctx context.Context, tx *sql.Tx, fileIDs []string) error {
+	for start := 0; start < len(fileIDs); start += deleteFileIDBatchSize {
+		end := start + deleteFileIDBatchSize
+		if end > len(fileIDs) {
+			end = len(fileIDs)
+		}
+		batch := fileIDs[start:end]
+		if len(batch) == 0 {
+			continue
+		}
+		args := stringsToAny(batch)
+		placeholders := questionPlaceholders(len(batch))
+		if s.useLegacyFiles {
+			rows, err := tx.QueryContext(ctx, `SELECT file_id FROM files WHERE file_id IN (`+placeholders+`) FOR UPDATE`, args...)
+			if err != nil {
+				return err
+			}
+			if err := closeRowsAfterScan(rows); err != nil {
+				return err
+			}
+		}
+		rows, err := tx.QueryContext(ctx, `SELECT inode_id FROM inodes WHERE inode_id IN (`+placeholders+`) FOR UPDATE`, args...)
+		if err != nil {
+			return err
+		}
+		if err := closeRowsAfterScan(rows); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func closeRowsAfterScan(rows *sql.Rows) error {
+	var discard string
+	for rows.Next() {
+		if err := rows.Scan(&discard); err != nil {
+			_ = rows.Close()
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	return rows.Close()
+}
+
+func (s *Store) markFilesDeletedTx(ctx context.Context, tx *sql.Tx, fileIDs []string) error {
+	for start := 0; start < len(fileIDs); start += deleteFileIDBatchSize {
+		end := start + deleteFileIDBatchSize
+		if end > len(fileIDs) {
+			end = len(fileIDs)
+		}
+		batch := fileIDs[start:end]
+		if len(batch) == 0 {
+			continue
+		}
+		args := stringsToAny(batch)
+		placeholders := questionPlaceholders(len(batch))
+		if s.useLegacyFiles {
+			if _, err := tx.ExecContext(ctx, `UPDATE files SET status = 'DELETED' WHERE file_id IN (`+placeholders+`)`, args...); err != nil {
+				return err
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE inodes SET status = 'DELETED' WHERE inode_id IN (`+placeholders+`)`, args...); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func fileFromLegacyGCScan(fileID string, storageType, storageRef, encMode, encKeyID, contentType sql.NullString, sizeBytes sql.NullInt64, checksum sql.NullString, revision, embeddingRevision sql.NullInt64, status, sourceID sql.NullString, createdAt, confirmedAt, expiresAt sql.NullTime) *File {
@@ -1828,29 +1950,22 @@ func fileFromLegacyGCScan(fileID string, storageType, storageRef, encMode, encKe
 	return f
 }
 
-func (s *Store) markFilesDeletedTx(tx *sql.Tx, fileIDs []string) error {
-	if len(fileIDs) == 0 {
-		return nil
-	}
-	args := stringsToAny(fileIDs)
-	placeholders := questionPlaceholders(len(fileIDs))
-	if s.useLegacyFiles {
-		if _, err := tx.Exec(`UPDATE files SET status = 'DELETED' WHERE file_id IN (`+placeholders+`)`, args...); err != nil {
+func deleteFileTagsByIDsTx(ctx context.Context, tx *sql.Tx, fileIDs []string) error {
+	for start := 0; start < len(fileIDs); start += deleteFileIDBatchSize {
+		end := start + deleteFileIDBatchSize
+		if end > len(fileIDs) {
+			end = len(fileIDs)
+		}
+		batch := fileIDs[start:end]
+		if len(batch) == 0 {
+			continue
+		}
+		_, err := tx.ExecContext(ctx, `DELETE FROM file_tags WHERE file_id IN (`+questionPlaceholders(len(batch))+`)`, stringsToAny(batch)...)
+		if err != nil {
 			return err
 		}
 	}
-	if _, err := tx.Exec(`UPDATE inodes SET status = 'DELETED' WHERE inode_id IN (`+placeholders+`)`, args...); err != nil {
-		return err
-	}
 	return nil
-}
-
-func deleteFileTagsByIDsTx(tx *sql.Tx, fileIDs []string) error {
-	if len(fileIDs) == 0 {
-		return nil
-	}
-	_, err := tx.Exec(`DELETE FROM file_tags WHERE file_id IN (`+questionPlaceholders(len(fileIDs))+`)`, stringsToAny(fileIDs)...)
-	return err
 }
 
 func stringsToAny(values []string) []any {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1520,17 +1520,12 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	var fileID sql.NullString
-	var isDir bool
-	err = tx.QueryRow(`SELECT file_id, is_directory FROM file_nodes WHERE path = ? FOR UPDATE`, path).Scan(&fileID, &isDir)
+	candidate, err := s.scanDeleteCandidateTx(tx, path)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrNotFound
-		}
 		return nil, err
 	}
 
-	if isDir {
+	if candidate.isDir {
 		return nil, ErrNotFound
 	}
 
@@ -1538,12 +1533,12 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 		return nil, err
 	}
 
-	if !fileID.Valid || fileID.String == "" {
+	if candidate.fileID == "" {
 		return nil, tx.Commit()
 	}
 
 	var count int64
-	err = tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE file_id = ? FOR UPDATE`, fileID.String).Scan(&count)
+	err = tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE file_id = ? FOR UPDATE`, candidate.fileID).Scan(&count)
 	if err != nil {
 		return nil, err
 	}
@@ -1552,23 +1547,19 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 		return nil, tx.Commit()
 	}
 
-	if s.useLegacyFiles {
-		if _, err := tx.Exec(`UPDATE files SET status = 'DELETED' WHERE file_id = ?`, fileID.String); err != nil {
-			return nil, err
-		}
+	if candidate.file == nil {
+		return nil, ErrNotFound
 	}
-	if _, err := tx.Exec(`UPDATE inodes SET status = 'DELETED' WHERE inode_id = ?`, fileID.String); err != nil {
+
+	if err := s.markFilesDeletedTx(tx, []string{candidate.fileID}); err != nil {
 		return nil, err
 	}
-	if _, err := tx.Exec(`DELETE FROM file_tags WHERE file_id = ?`, fileID.String); err != nil {
+	if err := deleteFileTagsByIDsTx(tx, []string{candidate.fileID}); err != nil {
 		return nil, err
 	}
 
-	f, err := s.scanFileForGCTx(tx, fileID.String)
-	if err != nil {
-		return nil, err
-	}
-	task, err := NewFileGCTaskFromFile(f, time.Now().UTC())
+	candidate.file.Status = StatusDeleted
+	task, err := NewFileGCTaskFromFile(candidate.file, time.Now().UTC())
 	if err != nil {
 		return nil, err
 	}
@@ -1579,7 +1570,7 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	out = f
+	out = candidate.file
 	return out, nil
 }
 
@@ -1614,30 +1605,22 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 		return nil, err
 	}
 
-	var orphaned []*File
-	for _, fid := range fileIDs {
-		var count int64
-		if err := tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE file_id = ?`, fid).Scan(&count); err != nil {
-			return nil, err
-		}
-		if count > 0 {
-			continue
-		}
-		if s.useLegacyFiles {
-			if _, err := tx.Exec(`UPDATE files SET status = 'DELETED' WHERE file_id = ?`, fid); err != nil {
-				return nil, err
-			}
-		}
-		if _, err := tx.Exec(`UPDATE inodes SET status = 'DELETED' WHERE inode_id = ?`, fid); err != nil {
-			return nil, err
-		}
-		if _, err := tx.Exec(`DELETE FROM file_tags WHERE file_id = ?`, fid); err != nil {
-			return nil, err
-		}
-		f, err := s.scanFileForGCTx(tx, fid)
-		if err != nil {
-			return nil, err
-		}
+	orphaned, err := s.scanOrphanedFilesByIDTx(tx, fileIDs)
+	if err != nil {
+		return nil, err
+	}
+	orphanIDs := make([]string, 0, len(orphaned))
+	for _, f := range orphaned {
+		orphanIDs = append(orphanIDs, f.FileID)
+	}
+	if err := s.markFilesDeletedTx(tx, orphanIDs); err != nil {
+		return nil, err
+	}
+	if err := deleteFileTagsByIDsTx(tx, orphanIDs); err != nil {
+		return nil, err
+	}
+
+	for _, f := range orphaned {
 		task, err := NewFileGCTaskFromFile(f, time.Now().UTC())
 		if err != nil {
 			return nil, err
@@ -1645,7 +1628,6 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 		if _, err := s.EnqueueFileGCTaskTx(tx, task); err != nil {
 			return nil, err
 		}
-		orphaned = append(orphaned, f)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -1653,6 +1635,230 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 	}
 	out = orphaned
 	return out, nil
+}
+
+type deleteCandidate struct {
+	fileID string
+	isDir  bool
+	file   *File
+}
+
+func (s *Store) scanDeleteCandidateTx(tx *sql.Tx, path string) (*deleteCandidate, error) {
+	if s.useLegacyFiles {
+		row := tx.QueryRow(`SELECT fn.file_id, fn.is_directory,
+			f.file_id, f.storage_type, f.storage_ref, f.storage_encryption_mode,
+			f.storage_encryption_key_id, f.content_type, f.size_bytes, f.checksum_sha256,
+			f.revision, f.embedding_revision, f.status, f.source_id, f.created_at, f.confirmed_at, f.expires_at
+			FROM file_nodes fn
+			LEFT JOIN files f ON f.file_id = fn.file_id
+			WHERE fn.path = ?
+			FOR UPDATE`, path)
+		return scanLegacyDeleteCandidate(row)
+	}
+	row := tx.QueryRow(`SELECT fn.file_id, fn.is_directory,
+		c.storage_type, c.storage_ref, i.size_bytes, COALESCE(c.content_type, ''),
+		s.embedding_revision
+		FROM file_nodes fn
+		LEFT JOIN inodes i ON i.inode_id = fn.file_id
+		LEFT JOIN contents c ON c.inode_id = fn.file_id
+		LEFT JOIN semantic s ON s.inode_id = fn.file_id
+		WHERE fn.path = ?
+		FOR UPDATE`, path)
+	return scanSplitDeleteCandidate(row)
+}
+
+func scanLegacyDeleteCandidate(row *sql.Row) (*deleteCandidate, error) {
+	var nodeFileID sql.NullString
+	var isDir bool
+	var fFileID, storageType, storageRef, encMode, encKeyID sql.NullString
+	var contentType, checksum, status, sourceID sql.NullString
+	var sizeBytes, revision, embeddingRevision sql.NullInt64
+	var createdAt, confirmedAt, expiresAt sql.NullTime
+	err := row.Scan(&nodeFileID, &isDir,
+		&fFileID, &storageType, &storageRef, &encMode, &encKeyID,
+		&contentType, &sizeBytes, &checksum, &revision, &embeddingRevision,
+		&status, &sourceID, &createdAt, &confirmedAt, &expiresAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	c := &deleteCandidate{fileID: nodeFileID.String, isDir: isDir}
+	if fFileID.Valid {
+		c.file = fileFromLegacyGCScan(fFileID.String, storageType, storageRef, encMode, encKeyID,
+			contentType, sizeBytes, checksum, revision, embeddingRevision, status,
+			sourceID, createdAt, confirmedAt, expiresAt)
+	}
+	return c, nil
+}
+
+func scanSplitDeleteCandidate(row *sql.Row) (*deleteCandidate, error) {
+	var nodeFileID sql.NullString
+	var isDir bool
+	var storageType, storageRef, contentType sql.NullString
+	var sizeBytes, embeddingRevision sql.NullInt64
+	err := row.Scan(&nodeFileID, &isDir, &storageType, &storageRef, &sizeBytes, &contentType, &embeddingRevision)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	c := &deleteCandidate{fileID: nodeFileID.String, isDir: isDir}
+	if nodeFileID.Valid && storageType.Valid {
+		f := &File{
+			FileID:      nodeFileID.String,
+			StorageType: StorageType(storageType.String),
+			StorageRef:  storageRef.String,
+			ContentType: contentType.String,
+			SizeBytes:   sizeBytes.Int64,
+			Status:      StatusDeleted,
+		}
+		if embeddingRevision.Valid {
+			rev := embeddingRevision.Int64
+			f.EmbeddingRevision = &rev
+		}
+		c.file = f
+	}
+	return c, nil
+}
+
+func (s *Store) scanOrphanedFilesByIDTx(tx *sql.Tx, fileIDs []string) ([]*File, error) {
+	if len(fileIDs) == 0 {
+		return nil, nil
+	}
+	args := stringsToAny(fileIDs)
+	placeholders := questionPlaceholders(len(fileIDs))
+	var query string
+	if s.useLegacyFiles {
+		query = `SELECT f.file_id, f.storage_type, f.storage_ref, f.storage_encryption_mode,
+			f.storage_encryption_key_id, f.content_type, f.size_bytes, f.checksum_sha256,
+			f.revision, f.embedding_revision, f.status, f.source_id, f.created_at, f.confirmed_at, f.expires_at
+			FROM files f
+			WHERE f.file_id IN (` + placeholders + `)
+			  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE fn.file_id = f.file_id)`
+	} else {
+		query = `SELECT i.inode_id, c.storage_type, c.storage_ref, i.size_bytes,
+			COALESCE(c.content_type, ''), s.embedding_revision
+			FROM inodes i
+			JOIN contents c ON c.inode_id = i.inode_id
+			LEFT JOIN semantic s ON s.inode_id = i.inode_id
+			WHERE i.inode_id IN (` + placeholders + `)
+			  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE fn.file_id = i.inode_id)`
+	}
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []*File
+	for rows.Next() {
+		var f *File
+		if s.useLegacyFiles {
+			var fileID, storageType, storageRef, encMode, encKeyID sql.NullString
+			var contentType, checksum, status, sourceID sql.NullString
+			var sizeBytes, revision, embeddingRevision sql.NullInt64
+			var createdAt, confirmedAt, expiresAt sql.NullTime
+			if err := rows.Scan(&fileID, &storageType, &storageRef, &encMode, &encKeyID,
+				&contentType, &sizeBytes, &checksum, &revision, &embeddingRevision,
+				&status, &sourceID, &createdAt, &confirmedAt, &expiresAt); err != nil {
+				return nil, err
+			}
+			f = fileFromLegacyGCScan(fileID.String, storageType, storageRef, encMode, encKeyID,
+				contentType, sizeBytes, checksum, revision, embeddingRevision, status,
+				sourceID, createdAt, confirmedAt, expiresAt)
+			f.Status = StatusDeleted
+		} else {
+			var fileID, storageType, storageRef, contentType sql.NullString
+			var sizeBytes, embeddingRevision sql.NullInt64
+			if err := rows.Scan(&fileID, &storageType, &storageRef, &sizeBytes, &contentType, &embeddingRevision); err != nil {
+				return nil, err
+			}
+			f = &File{
+				FileID:      fileID.String,
+				StorageType: StorageType(storageType.String),
+				StorageRef:  storageRef.String,
+				ContentType: contentType.String,
+				SizeBytes:   sizeBytes.Int64,
+				Status:      StatusDeleted,
+			}
+			if embeddingRevision.Valid {
+				rev := embeddingRevision.Int64
+				f.EmbeddingRevision = &rev
+			}
+		}
+		out = append(out, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func fileFromLegacyGCScan(fileID string, storageType, storageRef, encMode, encKeyID, contentType sql.NullString, sizeBytes sql.NullInt64, checksum sql.NullString, revision, embeddingRevision sql.NullInt64, status, sourceID sql.NullString, createdAt, confirmedAt, expiresAt sql.NullTime) *File {
+	f := &File{
+		FileID:                 fileID,
+		StorageType:            StorageType(storageType.String),
+		StorageRef:             storageRef.String,
+		StorageEncryptionMode:  StorageEncryptionMode(encMode.String),
+		StorageEncryptionKeyID: encKeyID.String,
+		ContentType:            contentType.String,
+		SizeBytes:              sizeBytes.Int64,
+		ChecksumSHA256:         checksum.String,
+		Revision:               revision.Int64,
+		Status:                 FileStatus(status.String),
+		SourceID:               sourceID.String,
+	}
+	if embeddingRevision.Valid {
+		rev := embeddingRevision.Int64
+		f.EmbeddingRevision = &rev
+	}
+	if createdAt.Valid {
+		f.CreatedAt = createdAt.Time.UTC()
+	}
+	if confirmedAt.Valid {
+		t := confirmedAt.Time.UTC()
+		f.ConfirmedAt = &t
+	}
+	if expiresAt.Valid {
+		t := expiresAt.Time.UTC()
+		f.ExpiresAt = &t
+	}
+	return f
+}
+
+func (s *Store) markFilesDeletedTx(tx *sql.Tx, fileIDs []string) error {
+	if len(fileIDs) == 0 {
+		return nil
+	}
+	args := stringsToAny(fileIDs)
+	placeholders := questionPlaceholders(len(fileIDs))
+	if s.useLegacyFiles {
+		if _, err := tx.Exec(`UPDATE files SET status = 'DELETED' WHERE file_id IN (`+placeholders+`)`, args...); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(`UPDATE inodes SET status = 'DELETED' WHERE inode_id IN (`+placeholders+`)`, args...); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deleteFileTagsByIDsTx(tx *sql.Tx, fileIDs []string) error {
+	if len(fileIDs) == 0 {
+		return nil
+	}
+	_, err := tx.Exec(`DELETE FROM file_tags WHERE file_id IN (`+questionPlaceholders(len(fileIDs))+`)`, stringsToAny(fileIDs)...)
+	return err
+}
+
+func stringsToAny(values []string) []any {
+	args := make([]any, len(values))
+	for i, value := range values {
+		args[i] = value
+	}
+	return args
 }
 
 func dirHasChildrenTx(ctx context.Context, tx *sql.Tx, path string) (bool, error) {

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -631,6 +631,26 @@ func TestDeleteFileWithRefCheckRejectsDirectory(t *testing.T) {
 	}
 }
 
+func TestInsertNodeTxRejectsDeletedFile(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	if err := s.InsertFile(ctx, &File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		SizeBytes: 1, Revision: 1, Status: StatusDeleted, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.InsertNodeTx(tx, &FileNode{
+			NodeID: "n1", Path: "/deleted.txt", ParentPath: "/", Name: "deleted.txt",
+			FileID: "f1", CreatedAt: now,
+		})
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("InsertNodeTx error = %v, want %v", err, ErrNotFound)
+	}
+}
+
 func TestDeleteDirRecursive(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -975,7 +975,8 @@ func (fs *Dat9FS) readTargetForHandle(ctx context.Context, fh *FileHandle) *clie
 	}
 	fh.Lock()
 	target := fh.ReadTarget
-	remotePath := fs.remotePath(fh.Path)
+	handlePath := fh.Path
+	remotePath := fs.remotePath(handlePath)
 	fh.Unlock()
 	if target != nil {
 		return target
@@ -989,7 +990,7 @@ func (fs *Dat9FS) readTargetForHandle(ctx context.Context, fh *FileHandle) *clie
 	}
 
 	fh.Lock()
-	if fh.ReadTarget == nil {
+	if fh.Path == handlePath && fh.Dirty == nil && fh.ReadTarget == nil {
 		fh.ReadTarget = resolved
 		if fh.Prefetch != nil {
 			fh.Prefetch.SetReadTarget(resolved)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2379,6 +2379,7 @@ func (fs *Dat9FS) retargetOpenHandlesForRename(oldP, newP string) {
 		}
 		fh.Lock()
 		fh.Path = currentPath
+		fh.ReadTarget = nil
 		if fh.Dirty != nil {
 			fh.Dirty.path = currentPath
 		}
@@ -2387,6 +2388,7 @@ func (fs *Dat9FS) retargetOpenHandlesForRename(oldP, newP string) {
 		}
 		if fh.Prefetch != nil {
 			fh.Prefetch.SetPath(fs.remotePath(currentPath))
+			fh.Prefetch.SetReadTarget(nil)
 		}
 		fh.Unlock()
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1000,14 +1000,86 @@ func (fs *Dat9FS) readTargetForHandle(ctx context.Context, fh *FileHandle) *clie
 	return target
 }
 
+func clearReadTargetForHandle(fh *FileHandle) {
+	if fh == nil {
+		return
+	}
+	fh.Lock()
+	fh.ReadTarget = nil
+	if fh.Prefetch != nil {
+		fh.Prefetch.SetReadTarget(nil)
+	}
+	fh.Unlock()
+}
+
+func (fs *Dat9FS) clearReadTargetsForPath(p string) {
+	fs.clearReadTargetsForPathExcept(p, nil)
+}
+
+func (fs *Dat9FS) clearReadTargetsForPathExcept(p string, skip *FileHandle) {
+	if fs == nil || fs.openHandles == nil || p == "" {
+		return
+	}
+	for _, fh := range fs.openHandles.SnapshotPath(p) {
+		if fh == skip {
+			continue
+		}
+		clearReadTargetForHandle(fh)
+	}
+}
+
+func clearReadTargetForLockedHandle(fh *FileHandle) {
+	if fh == nil {
+		return
+	}
+	fh.ReadTarget = nil
+	if fh.Prefetch != nil {
+		fh.Prefetch.SetReadTarget(nil)
+	}
+}
+
+func (fs *Dat9FS) clearAllReadTargets() {
+	if fs == nil || fs.fileHandles == nil {
+		return
+	}
+	fs.fileHandles.ForEach(func(_ uint64, fh *FileHandle) {
+		clearReadTargetForHandle(fh)
+	})
+}
+
+func (fs *Dat9FS) invalidateReadCacheAndTargets(p string) {
+	fs.invalidateReadCacheAndTargetsExcept(p, nil)
+}
+
+func (fs *Dat9FS) invalidateReadCacheAndTargetsExcept(p string, skip *FileHandle) {
+	if fs == nil {
+		return
+	}
+	if fs.readCache != nil {
+		fs.readCache.Invalidate(p)
+	}
+	fs.clearReadTargetsForPathExcept(p, skip)
+}
+
 // readStreamRangeWithRetry performs a range read with bounded detached retry
 // on transient failures. Wraps both the ReadStreamRange open and io.ReadFull
 // body read as a single retriable unit. On body-stage transient failure, the
 // stream is reopened from scratch on retry.
 // Returns (data, nil) on success. On exhausted retries, the returned error
 // is a wrapped sentinel so the caller can map it to EIO.
-func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, target *client.ReadTarget, offset, size int64) ([]byte, int, error) {
+func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, fh *FileHandle, offset, size int64) ([]byte, int, error) {
+	target := fs.readTargetForHandle(ctx, fh)
 	data, n, err := fs.doRangeRead(ctx, path, target, offset, size)
+	if client.IsPresignExpired(err) {
+		clearReadTargetForHandle(fh)
+		retryCtx, retryCancel := context.WithTimeout(context.Background(), readTransientRetryTimeout)
+		target = fs.readTargetForHandle(retryCtx, fh)
+		data, n, err = fs.doRangeRead(retryCtx, path, target, offset, size)
+		retryCancel()
+		if err == nil && fs.perf != nil {
+			fs.perf.readRetrySuccess.add(1)
+		}
+	}
 	if err == nil || !isTransientReadErr(err) {
 		return data, n, err
 	}
@@ -1019,6 +1091,11 @@ func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, tar
 	for range readTransientRetryCount {
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), readTransientRetryTimeout)
 		data, n, err = fs.doRangeRead(retryCtx, path, target, offset, size)
+		if client.IsPresignExpired(err) {
+			clearReadTargetForHandle(fh)
+			target = fs.readTargetForHandle(retryCtx, fh)
+			data, n, err = fs.doRangeRead(retryCtx, path, target, offset, size)
+		}
 		retryCancel()
 		if err == nil {
 			if fs.perf != nil {
@@ -1988,7 +2065,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 						fs.inodes.UpdateMtime(input.NodeId, stat.Mtime)
 					}
 				}
-				fs.readCache.Invalidate(entry.Path)
+				fs.invalidateReadCacheAndTargets(entry.Path)
 				fs.cacheFileForPath(entry.Path, 0, refreshedMtime, refreshedRevision)
 			} else if newSize != entry.Size {
 				// Arbitrary truncate without an open handle is not
@@ -2123,7 +2200,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	}
 
 	fs.inodes.Remove(childP)
-	fs.readCache.Invalidate(childP)
+	fs.invalidateReadCacheAndTargets(childP)
 
 	parentPath, _ := fs.inodes.GetPath(header.NodeId)
 	fs.dirCache.Remove(parentPath, name)
@@ -2352,8 +2429,8 @@ func (fs *Dat9FS) finishLocalRename(input *gofuse.RenameIn, oldP, newP string) {
 		oldEntry, oldEntryOK = fs.inodes.GetEntry(oldIno)
 	}
 	fs.inodes.Rename(oldP, newP)
-	fs.readCache.Invalidate(oldP)
-	fs.readCache.Invalidate(newP)
+	fs.invalidateReadCacheAndTargets(oldP)
+	fs.invalidateReadCacheAndTargets(newP)
 	fs.readCache.InvalidatePrefix(oldP + "/")
 	fs.readCache.InvalidatePrefix(newP + "/")
 
@@ -3392,8 +3469,7 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		source = "range-read"
 	}
 	rangeStart := time.Now()
-	target := fs.readTargetForHandle(ctx, fh)
-	data, n, err := fs.readStreamRangeWithRetry(ctx, p, target, int64(input.Offset), int64(input.Size))
+	data, n, err := fs.readStreamRangeWithRetry(ctx, p, fh, int64(input.Offset), int64(input.Size))
 	if err != nil {
 		fs.debugf("read range error path=%s off=%d req=%d got=%d source=%s dur=%s err=%v", p, input.Offset, input.Size, n, source, time.Since(rangeStart), err)
 		if errors.Is(err, errReadRetriesExhausted) {
@@ -3979,7 +4055,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				cf()
 			}
 
-			fs.readCache.Invalidate(fh.Path)
+			fs.invalidateReadCacheAndTargets(fh.Path)
 			if flushStatus == gofuse.OK {
 				fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 			} else {
@@ -4051,7 +4127,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				}
 
 				// Invalidate caches so subsequent reads see fresh data.
-				fs.readCache.Invalidate(fh.Path)
+				fs.invalidateReadCacheAndTargets(fh.Path)
 				fs.cacheFileForPath(fh.Path, fh.Dirty.Size(), time.Now(), 0)
 				// Local release — kernel already knows about this close.
 				// No notifyInode needed; userspace caches are invalidated above.
@@ -4159,9 +4235,10 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		}
 		handle.Unlock()
 		if committedRev > 0 {
+			fs.clearReadTargetsForPath(filePath)
 			fs.readCache.PutOwned(filePath, data, committedRev)
 		} else {
-			fs.readCache.Invalidate(filePath)
+			fs.invalidateReadCacheAndTargets(filePath)
 		}
 		fs.inodes.UpdateSize(ino, int64(len(data)))
 		fs.cacheFileForPath(filePath, int64(len(data)), time.Now(), committedRev)
@@ -4273,7 +4350,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fh.Dirty.ClearDirty()
 		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 		fh.DirtySeq = 0
-		fs.readCache.Invalidate(fh.Path)
+		clearReadTargetForLockedHandle(fh)
+		fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
 		fs.inodes.UpdateSize(fh.Ino, size)
 		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 		// Remove stale shadow so subsequent read-only opens don't serve
@@ -4330,7 +4408,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fh.Dirty.ClearDirty()
 		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 		fh.DirtySeq = 0
-		fs.readCache.Invalidate(fh.Path)
+		clearReadTargetForLockedHandle(fh)
+		fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
 		fs.inodes.UpdateSize(fh.Ino, size)
 		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 		// Remove stale shadow (same reason as Path 1a above).
@@ -4444,6 +4523,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 	fh.DirtySeq = 0
 	if committedRev > 0 {
+		clearReadTargetForLockedHandle(fh)
+		fs.clearReadTargetsForPathExcept(fh.Path, fh)
 		fs.readCache.Put(fh.Path, data, committedRev)
 		fh.IsNew = false
 		fh.BaseRev = committedRev
@@ -4452,7 +4533,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			fh.ZeroBase = false
 		}
 	} else {
-		fs.readCache.Invalidate(fh.Path)
+		clearReadTargetForLockedHandle(fh)
+		fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 	}
 	fs.inodes.UpdateSize(fh.Ino, size)
@@ -4558,6 +4640,7 @@ func (fs *Dat9FS) RemoveXAttr(cancel <-chan struct{}, header *gofuse.InHeader, a
 // or invalidates the cache otherwise.
 func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 	if committedRev > 0 && entry.Inode > 0 {
+		fs.clearReadTargetsForPath(entry.Path)
 		// Seed readCache from shadow data before the shadow file is removed.
 		// Only attempt for files under the readCache size limit.
 		if entry.Size <= fs.readCache.MaxFileSize() && fs.shadowStore != nil {
@@ -4572,7 +4655,7 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 		// Kernel does not need notify; userspace caches and inode state
 		// are updated above. Kernel will see new attrs on next access.
 	} else {
-		fs.readCache.Invalidate(entry.Path)
+		fs.invalidateReadCacheAndTargets(entry.Path)
 		fs.cacheFileForPath(entry.Path, entry.Size, time.Now(), 0)
 	}
 }

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -174,7 +174,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		fileHandles:   NewHandleTable[*FileHandle](),
 		openHandles:   NewOpenHandleIndex(),
 		dirHandles:    NewHandleTable[*DirHandle](),
-		readCache:     NewReadCache(opts.CacheSize, 0),
+		readCache:     NewReadCacheWithMaxFileSize(opts.CacheSize, 0, opts.ReadCacheMaxFileBytes),
 		dirCache:      NewNamespaceCache(opts.DirTTL, opts.NegativeEntryTTL, defaultNamespaceCacheMaxEntries),
 		dirtyInodes:   make(map[uint64]dirtyInodeState),
 		uid:           uint32(os.Getuid()),
@@ -546,7 +546,7 @@ func (fs *Dat9FS) preloadWritableHandleFromReadCacheLocked(fh *FileHandle) bool 
 	if fs.readCache == nil || fh == nil || fh.Dirty == nil {
 		return false
 	}
-	if fh.OrigSize <= 0 || fh.OrigSize > defaultReadCacheMaxFileSize || fh.BaseRev <= 0 {
+	if fh.OrigSize <= 0 || fh.OrigSize > fs.readCache.MaxFileSize() || fh.BaseRev <= 0 {
 		return false
 	}
 
@@ -969,14 +969,45 @@ func (fs *Dat9FS) readSmallFileWithRetry(ctx context.Context, path string) ([]by
 	return nil, fmt.Errorf("%w: %s: %v", errReadRetriesExhausted, path, lastErr)
 }
 
+func (fs *Dat9FS) readTargetForHandle(ctx context.Context, fh *FileHandle) *client.ReadTarget {
+	if fs == nil || fs.client == nil || fh == nil || fh.Dirty != nil {
+		return nil
+	}
+	fh.Lock()
+	target := fh.ReadTarget
+	remotePath := fs.remotePath(fh.Path)
+	fh.Unlock()
+	if target != nil {
+		return target
+	}
+
+	resolved, err := fs.client.ResolveReadTarget(ctx, remotePath)
+	if err != nil {
+		// Fall back to the ordinary read path. This preserves inline-file and
+		// transient-error behavior while still optimizing the common S3 case.
+		return nil
+	}
+
+	fh.Lock()
+	if fh.ReadTarget == nil {
+		fh.ReadTarget = resolved
+		if fh.Prefetch != nil {
+			fh.Prefetch.SetReadTarget(resolved)
+		}
+	}
+	target = fh.ReadTarget
+	fh.Unlock()
+	return target
+}
+
 // readStreamRangeWithRetry performs a range read with bounded detached retry
 // on transient failures. Wraps both the ReadStreamRange open and io.ReadFull
 // body read as a single retriable unit. On body-stage transient failure, the
 // stream is reopened from scratch on retry.
 // Returns (data, nil) on success. On exhausted retries, the returned error
 // is a wrapped sentinel so the caller can map it to EIO.
-func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, offset, size int64) ([]byte, int, error) {
-	data, n, err := fs.doRangeRead(ctx, path, offset, size)
+func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, target *client.ReadTarget, offset, size int64) ([]byte, int, error) {
+	data, n, err := fs.doRangeRead(ctx, path, target, offset, size)
 	if err == nil || !isTransientReadErr(err) {
 		return data, n, err
 	}
@@ -987,7 +1018,7 @@ func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, off
 	lastErr := err
 	for range readTransientRetryCount {
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), readTransientRetryTimeout)
-		data, n, err = fs.doRangeRead(retryCtx, path, offset, size)
+		data, n, err = fs.doRangeRead(retryCtx, path, target, offset, size)
 		retryCancel()
 		if err == nil {
 			if fs.perf != nil {
@@ -1009,9 +1040,15 @@ func (fs *Dat9FS) readStreamRangeWithRetry(ctx context.Context, path string, off
 // doRangeRead performs a single range read attempt: open stream + read body.
 // All body read errors (including truncation) are returned as-is so the
 // caller can classify them for retry.
-func (fs *Dat9FS) doRangeRead(ctx context.Context, path string, offset, size int64) ([]byte, int, error) {
+func (fs *Dat9FS) doRangeRead(ctx context.Context, path string, target *client.ReadTarget, offset, size int64) ([]byte, int, error) {
 	readStart := fs.perfStart()
-	rc, err := fs.client.ReadStreamRange(ctx, fs.remotePath(path), offset, size)
+	var rc io.ReadCloser
+	var err error
+	if target != nil {
+		rc, err = fs.client.ReadObjectRange(ctx, target, offset, size)
+	} else {
+		rc, err = fs.client.ReadStreamRange(ctx, fs.remotePath(path), offset, size)
+	}
 	if err != nil {
 		fs.perfRecordRemote(perfRemoteRead, readStart, err, 0)
 		return nil, 0, err
@@ -2956,7 +2993,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 	// Set up read prefetcher for read-only opens on large files.
 	if fh.Dirty == nil {
 		entry, _ := fs.inodes.GetEntry(input.NodeId)
-		if entry != nil && entry.Size > fs.inlineThreshold() {
+		if entry != nil && entry.Size > fs.readCache.MaxFileSize() {
 			fh.Prefetch = NewPrefetcher(fs.client, fs.remotePath(p), entry.Size, fs.debugEnabled())
 			fh.Prefetch.SetPerfCounters(fs.perf)
 		}
@@ -3293,7 +3330,7 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 	// InodeEntry has a stored revision from the last Lookup/GetAttr, pass
 	// it to the cache for validation. Cache hit only if revision matches.
 	entry, _ := fs.inodes.GetEntry(fh.Ino)
-	if entry != nil && entry.Size <= defaultReadCacheMaxFileSize && entry.Size > 0 {
+	if entry != nil && entry.Size <= fs.readCache.MaxFileSize() && entry.Size > 0 {
 		cacheRev := entry.Revision // use revision from last Stat/Lookup
 		// Fast path: serve from cache without any HTTP call.
 		if data, ok := fs.readCache.Get(p, cacheRev); ok {
@@ -3353,7 +3390,8 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		source = "range-read"
 	}
 	rangeStart := time.Now()
-	data, n, err := fs.readStreamRangeWithRetry(ctx, p, int64(input.Offset), int64(input.Size))
+	target := fs.readTargetForHandle(ctx, fh)
+	data, n, err := fs.readStreamRangeWithRetry(ctx, p, target, int64(input.Offset), int64(input.Size))
 	if err != nil {
 		fs.debugf("read range error path=%s off=%d req=%d got=%d source=%s dur=%s err=%v", p, input.Offset, input.Size, n, source, time.Since(rangeStart), err)
 		if errors.Is(err, errReadRetriesExhausted) {
@@ -4520,7 +4558,7 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 	if committedRev > 0 && entry.Inode > 0 {
 		// Seed readCache from shadow data before the shadow file is removed.
 		// Only attempt for files under the readCache size limit.
-		if entry.Size <= int64(defaultReadCacheMaxFileSize) && fs.shadowStore != nil {
+		if entry.Size <= fs.readCache.MaxFileSize() && fs.shadowStore != nil {
 			if data, err := fs.shadowStore.ReadAll(entry.Path); err == nil {
 				fs.readCache.PutOwned(entry.Path, data, committedRev)
 			}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -6489,6 +6489,56 @@ func TestReadStreamRangeWithRetryRefreshesExpiredReadTarget(t *testing.T) {
 	}
 }
 
+func TestReadTargetForHandleDropsResolvedTargetAfterPathChange(t *testing.T) {
+	resolveStarted := make(chan struct{})
+	allowResolve := make(chan struct{})
+	var once sync.Once
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/fs/old.bin" {
+			http.NotFound(w, r)
+			return
+		}
+		once.Do(func() { close(resolveStarted) })
+		<-allowResolve
+		w.Header().Set("Location", fmt.Sprintf("http://%s/s3/old", r.Host))
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fh := &FileHandle{Path: "/old.bin"}
+
+	done := make(chan *client.ReadTarget, 1)
+	go func() {
+		done <- fs.readTargetForHandle(context.Background(), fh)
+	}()
+
+	select {
+	case <-resolveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("resolve did not start")
+	}
+	fh.Lock()
+	fh.Path = "/new.bin"
+	fh.Unlock()
+	close(allowResolve)
+
+	select {
+	case target := <-done:
+		if target != nil {
+			t.Fatalf("target = %+v, want nil after path change", target)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("readTargetForHandle timed out")
+	}
+	if fh.ReadTarget != nil {
+		t.Fatalf("handle cached target = %+v, want nil", fh.ReadTarget)
+	}
+}
+
 // TestDoRangeReadBodyTruncationReturnsError verifies that when a server sends
 // headers successfully but closes the connection mid-body (truncation),
 // doRangeRead surfaces an error instead of silently returning partial data.

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2471,7 +2471,7 @@ func TestIsTransientLookupErr_Treats499AsTransient(t *testing.T) {
 }
 
 func TestOpenReadOnlyLargeFileGetsPrefetcher(t *testing.T) {
-	size := int64(1024 * 1024) // 1MB — above defaultSmallFileThreshold
+	size := int64(2 * 1024 * 1024) // above default read-cache admission limit
 	data := make([]byte, size)
 	for i := range data {
 		data[i] = byte(i % 256)
@@ -2500,6 +2500,30 @@ func TestOpenReadOnlyLargeFileGetsPrefetcher(t *testing.T) {
 	}
 	if out.OpenFlags != gofuse.FOPEN_KEEP_CACHE {
 		t.Fatalf("open flags = %d, want FOPEN_KEEP_CACHE for mmap compatibility", out.OpenFlags)
+	}
+}
+
+func TestOpenReadOnlyCacheableFileSkipsPrefetcher(t *testing.T) {
+	size := int64(defaultReadCacheMaxFileSize)
+	fs, ino, cleanup := newTestDat9FS(t, size, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(make([]byte, int(size)))
+	})
+	defer cleanup()
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	fh, ok := fs.fileHandles.Get(out.Fh)
+	if !ok {
+		t.Fatal("file handle not found")
+	}
+	if fh.Prefetch != nil {
+		t.Fatal("cacheable read-only file should use read cache without prefetcher")
 	}
 }
 
@@ -6397,7 +6421,7 @@ func TestDoRangeReadBodyTimeoutReturnsForRetry(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	_, _, err := fs.doRangeRead(ctx, "/test.bin", 0, 4096)
+	_, _, err := fs.doRangeRead(ctx, "/test.bin", nil, 0, 4096)
 	if err == nil {
 		t.Fatal("expected error from doRangeRead with expired context")
 	}
@@ -6439,7 +6463,7 @@ func TestDoRangeReadBodyTruncationReturnsError(t *testing.T) {
 	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	ctx := context.Background()
-	_, n, err := fs.doRangeRead(ctx, "/truncate.bin", 0, 4096)
+	_, n, err := fs.doRangeRead(ctx, "/truncate.bin", nil, 0, 4096)
 	// doRangeRead must return an error for truncated body, not silent success.
 	// The old code (io.ReadFull + ErrUnexpectedEOF filter) would return nil here.
 	if err == nil {
@@ -6450,7 +6474,7 @@ func TestDoRangeReadBodyTruncationReturnsError(t *testing.T) {
 // TestReadPrefetchNotTriggeredOnFailure verifies that Prefetch.OnRead is NOT
 // called when the remote read fails after a prefetch cache miss.
 func TestReadPrefetchNotTriggeredOnFailure(t *testing.T) {
-	fileSize := int64(1 << 20) // 1 MiB — gets a Prefetcher
+	fileSize := int64(2 << 20) // above default read-cache admission limit
 	var getCalls atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -6509,9 +6533,10 @@ func TestReadPrefetchNotTriggeredOnFailure(t *testing.T) {
 	// those fetches would generate additional GET calls beyond the
 	// Read retry attempts.
 	//
-	// With 1 initial + 2 retries = 3 GET calls from Read itself.
+	// With 1 target resolution attempt plus 1 initial range read and
+	// 2 retries = 4 GET calls from Read itself.
 	// If OnRead fired, the prefetcher would issue additional GETs.
-	wantMaxCalls := int32(1 + readTransientRetryCount)
+	wantMaxCalls := int32(2 + readTransientRetryCount)
 	if got := getCalls.Load(); got > wantMaxCalls {
 		t.Fatalf("GET calls = %d, want <= %d (OnRead should not trigger prefetch on failure)", got, wantMaxCalls)
 	}
@@ -6885,7 +6910,6 @@ func TestSetAttr_NoKernelNotify(t *testing.T) {
 		t.Fatalf("SetAttr produced %d kernel notify calls, want 0", delta)
 	}
 }
-
 
 // TestLookupParsesModeHeader verifies that Lookup reads the X-Dat9-Mode header
 // from the remote stat response and stores it in the inode entry.

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -6433,6 +6433,62 @@ func TestDoRangeReadBodyTimeoutReturnsForRetry(t *testing.T) {
 	}
 }
 
+func TestReadStreamRangeWithRetryRefreshesExpiredReadTarget(t *testing.T) {
+	var resolveCalls atomic.Int32
+	var expiredCalls atomic.Int32
+	var freshCalls atomic.Int32
+	data := []byte("0123456789")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/fs/large.bin":
+			call := resolveCalls.Add(1)
+			token := "expired"
+			if call > 1 {
+				token = "fresh"
+			}
+			w.Header().Set("Location", fmt.Sprintf("http://%s/s3/%s", r.Host, token))
+			w.WriteHeader(http.StatusFound)
+		case "/s3/expired":
+			expiredCalls.Add(1)
+			w.WriteHeader(http.StatusForbidden)
+		case "/s3/fresh":
+			freshCalls.Add(1)
+			if got := r.Header.Get("Range"); got != "bytes=2-5" {
+				http.Error(w, "wrong range: "+got, http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(data[2:6])
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fh := &FileHandle{Path: "/large.bin"}
+
+	got, n, err := fs.readStreamRangeWithRetry(context.Background(), "/large.bin", fh, 2, 4)
+	if err != nil {
+		t.Fatalf("readStreamRangeWithRetry: %v", err)
+	}
+	if n != 4 || string(got) != "2345" {
+		t.Fatalf("range read = %q, %d; want 2345, 4", got, n)
+	}
+	if resolveCalls.Load() != 2 {
+		t.Fatalf("resolve calls = %d, want 2", resolveCalls.Load())
+	}
+	if expiredCalls.Load() != 1 || freshCalls.Load() != 1 {
+		t.Fatalf("expired/fresh calls = %d/%d, want 1/1", expiredCalls.Load(), freshCalls.Load())
+	}
+	if fh.ReadTarget == nil || !strings.Contains(fh.ReadTarget.ObjectURL, "/s3/fresh") {
+		t.Fatalf("read target = %+v, want fresh target", fh.ReadTarget)
+	}
+}
+
 // TestDoRangeReadBodyTruncationReturnsError verifies that when a server sends
 // headers successfully but closes the connection mid-body (truncation),
 // doRangeRead surfaces an error instead of silently returning partial data.

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -299,6 +299,18 @@ func TestReadCache_SkipLargeFiles(t *testing.T) {
 	}
 }
 
+func TestReadCache_CustomMaxFileSize(t *testing.T) {
+	rc := NewReadCacheWithMaxFileSize(1<<20, 10*time.Second, 64<<10)
+	rc.Put("/small", make([]byte, 64<<10), 1)
+	if _, ok := rc.Get("/small", 1); !ok {
+		t.Fatal("file at custom max size should be cached")
+	}
+	rc.Put("/large", make([]byte, (64<<10)+1), 1)
+	if _, ok := rc.Get("/large", 1); ok {
+		t.Fatal("file over custom max size should not be cached")
+	}
+}
+
 func TestReadCache_CachesMediumSmallFiles(t *testing.T) {
 	rc := NewReadCache(1<<20, 10*time.Second)
 	data := make([]byte, defaultSmallFileThreshold+1)

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -1,6 +1,10 @@
 package fuse
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
 
 // FileHandle represents an open file in the FUSE filesystem.
 // WriteBuffer is defined in write.go and supports offset-based writes.
@@ -23,10 +27,11 @@ type FileHandle struct {
 	ShadowGen         uint64          // generation token from Pin/PinIfExists (passed to Unpin)
 	Streamer          *StreamUploader // nil for small files / read-only; manages background part uploads
 	Prefetch          *Prefetcher     // nil for writable handles; sequential read prefetcher
-	PendingMode       uint32          // mode change deferred because a dirty handle was open
-	HasPendingMode    bool            // true when PendingMode should be applied on Release
-	PreviousMode      uint32          // mode before PendingMode was set (for rollback on flush failure)
-	HasPreviousMode   bool            // true when PreviousMode is valid
+	ReadTarget        *client.ReadTarget
+	PendingMode       uint32 // mode change deferred because a dirty handle was open
+	HasPendingMode    bool   // true when PendingMode should be applied on Release
+	PreviousMode      uint32 // mode before PendingMode was set (for rollback on flush failure)
+	HasPreviousMode   bool   // true when PreviousMode is valid
 	mu                sync.Mutex
 }
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -36,6 +36,7 @@ type MountOptions struct {
 	RemoteRoot            string        // remote subtree root (default "/"); set via "drive9 mount :/path /local"
 	CacheDir              string        // write-back cache directory (default ~/.cache/drive9); empty string uses default
 	CacheSize             int64         // ReadCache max size in bytes (default 128MB)
+	ReadCacheMaxFileBytes int64         // largest single file admitted to ReadCache (default 1MiB)
 	DirTTL                time.Duration // DirCache TTL (default 10s)
 	AttrTTL               time.Duration // kernel attr cache TTL (default 60s)
 	EntryTTL              time.Duration // kernel entry cache TTL (default 60s)
@@ -66,6 +67,9 @@ func (o *MountOptions) setDefaults() {
 	}
 	if o.CacheSize <= 0 {
 		o.CacheSize = defaultReadCacheMaxSize
+	}
+	if o.ReadCacheMaxFileBytes <= 0 {
+		o.ReadCacheMaxFileBytes = defaultReadCacheMaxFileSize
 	}
 	if o.DirTTL <= 0 {
 		o.DirTTL = defaultDirCacheTTL

--- a/pkg/fuse/open_handles_test.go
+++ b/pkg/fuse/open_handles_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+
 	"github.com/mem9-ai/dat9/pkg/client"
 )
 
@@ -168,6 +169,8 @@ func TestDat9FSClearReadTargetsForPath(t *testing.T) {
 	fh1.Prefetch = NewPrefetcher(fs.client, fs.remotePath("/file.txt"), 4)
 	fh1.Prefetch.SetReadTarget(target)
 	fh2 := &FileHandle{Ino: 11, Path: "/other.txt", ReadTarget: target}
+	fh2.Prefetch = NewPrefetcher(fs.client, fs.remotePath("/other.txt"), 4)
+	fh2.Prefetch.SetReadTarget(target)
 	fs.allocateFileHandle(fh1)
 	fs.allocateFileHandle(fh2)
 
@@ -184,5 +187,11 @@ func TestDat9FSClearReadTargetsForPath(t *testing.T) {
 	}
 	if fh2.ReadTarget == nil {
 		t.Fatal("non-matching handle read target was cleared")
+	}
+	fh2.Prefetch.mu.Lock()
+	prefetchTarget2 := fh2.Prefetch.target
+	fh2.Prefetch.mu.Unlock()
+	if prefetchTarget2 == nil {
+		t.Fatal("non-matching prefetch read target was cleared")
 	}
 }

--- a/pkg/fuse/open_handles_test.go
+++ b/pkg/fuse/open_handles_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/mem9-ai/dat9/pkg/client"
 )
 
 func TestOpenHandleIndexTracksByInodeAndPath(t *testing.T) {
@@ -115,6 +116,8 @@ func TestDat9FSFinishLocalRenameUpdatesOpenHandleIndex(t *testing.T) {
 	fh := &FileHandle{Ino: ino, Path: "/old.txt", Dirty: NewWriteBuffer("/old.txt", 0, 0)}
 	fh.Streamer = NewStreamUploader(fs.client, "/old.txt", -1, fs.remoteRoot())
 	fh.Prefetch = NewPrefetcher(fs.client, fs.remotePath("/old.txt"), 4)
+	fh.ReadTarget = &client.ReadTarget{ObjectURL: "http://old.example/object"}
+	fh.Prefetch.SetReadTarget(fh.ReadTarget)
 	fhID := fs.allocateFileHandle(fh)
 	defer fs.deleteFileHandle(fhID, fh)
 
@@ -143,5 +146,14 @@ func TestDat9FSFinishLocalRenameUpdatesOpenHandleIndex(t *testing.T) {
 	}
 	if got := fh.Prefetch.pathString(); got != "/new.txt" {
 		t.Fatalf("prefetch path = %q, want /new.txt", got)
+	}
+	if fh.ReadTarget != nil {
+		t.Fatal("file handle read target was not cleared")
+	}
+	fh.Prefetch.mu.Lock()
+	prefetchTarget := fh.Prefetch.target
+	fh.Prefetch.mu.Unlock()
+	if prefetchTarget != nil {
+		t.Fatal("prefetch read target was not cleared")
 	}
 }

--- a/pkg/fuse/open_handles_test.go
+++ b/pkg/fuse/open_handles_test.go
@@ -157,3 +157,32 @@ func TestDat9FSFinishLocalRenameUpdatesOpenHandleIndex(t *testing.T) {
 		t.Fatal("prefetch read target was not cleared")
 	}
 }
+
+func TestDat9FSClearReadTargetsForPath(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+
+	target := &client.ReadTarget{ObjectURL: "http://old.example/object"}
+	fh1 := &FileHandle{Ino: 10, Path: "/file.txt", ReadTarget: target}
+	fh1.Prefetch = NewPrefetcher(fs.client, fs.remotePath("/file.txt"), 4)
+	fh1.Prefetch.SetReadTarget(target)
+	fh2 := &FileHandle{Ino: 11, Path: "/other.txt", ReadTarget: target}
+	fs.allocateFileHandle(fh1)
+	fs.allocateFileHandle(fh2)
+
+	fs.clearReadTargetsForPath("/file.txt")
+
+	if fh1.ReadTarget != nil {
+		t.Fatal("matching handle read target was not cleared")
+	}
+	fh1.Prefetch.mu.Lock()
+	prefetchTarget := fh1.Prefetch.target
+	fh1.Prefetch.mu.Unlock()
+	if prefetchTarget != nil {
+		t.Fatal("matching prefetch read target was not cleared")
+	}
+	if fh2.ReadTarget == nil {
+		t.Fatal("non-matching handle read target was cleared")
+	}
+}

--- a/pkg/fuse/prefetch.go
+++ b/pkg/fuse/prefetch.go
@@ -50,6 +50,7 @@ type Prefetcher struct {
 	cache      map[int64]*prefetchBlock
 	inflight   map[int64]bool
 	client     *client.Client
+	target     *client.ReadTarget
 	path       atomic.Value
 	fileSize   int64
 	cancel     context.CancelFunc // cancels all inflight prefetch goroutines
@@ -83,6 +84,15 @@ func NewPrefetcher(c *client.Client, path string, fileSize int64, debug ...bool)
 
 func (p *Prefetcher) SetPerfCounters(perf *fusePerfCounters) {
 	p.perf = perf
+}
+
+func (p *Prefetcher) SetReadTarget(target *client.ReadTarget) {
+	if p == nil || target == nil {
+		return
+	}
+	p.mu.Lock()
+	p.target = target
+	p.mu.Unlock()
 }
 
 func (p *Prefetcher) SetPath(path string) {
@@ -313,6 +323,7 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 	// Mark the fetch start as inflight (not each chunk — OnRead checks start offset).
 	p.inflight[offset] = true
 	fetchPath := p.pathString()
+	target := p.target
 	p.debugf("start path=%s offset=%d length=%d chunk_size=%d chunks=%d window=%d", fetchPath, offset, length, chunkSize, nChunks, p.window)
 
 	ctx := p.ctx
@@ -325,7 +336,13 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 			close(ready)
 		}()
 
-		rc, err := p.client.ReadStreamRange(ctx, fetchPath, offset, length)
+		var rc io.ReadCloser
+		var err error
+		if target != nil {
+			rc, err = p.client.ReadObjectRange(ctx, target, offset, length)
+		} else {
+			rc, err = p.client.ReadStreamRange(ctx, fetchPath, offset, length)
+		}
 		if err != nil {
 			if p.perf != nil {
 				p.perf.recordRemoteOp(perfRemoteRead, err, time.Since(start), 0)

--- a/pkg/fuse/prefetch.go
+++ b/pkg/fuse/prefetch.go
@@ -87,7 +87,7 @@ func (p *Prefetcher) SetPerfCounters(perf *fusePerfCounters) {
 }
 
 func (p *Prefetcher) SetReadTarget(target *client.ReadTarget) {
-	if p == nil || target == nil {
+	if p == nil {
 		return
 	}
 	p.mu.Lock()

--- a/pkg/fuse/prefetch.go
+++ b/pkg/fuse/prefetch.go
@@ -340,6 +340,10 @@ func (p *Prefetcher) startPrefetch(offset, length int64) {
 		var err error
 		if target != nil {
 			rc, err = p.client.ReadObjectRange(ctx, target, offset, length)
+			if client.IsPresignExpired(err) {
+				p.SetReadTarget(nil)
+				rc, err = p.client.ReadStreamRange(ctx, fetchPath, offset, length)
+			}
 		} else {
 			rc, err = p.client.ReadStreamRange(ctx, fetchPath, offset, length)
 		}

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -18,10 +18,11 @@ const (
 	// /v1/status on the dat9 client and propagated through FS.smallFileMax.
 	defaultSmallFileThreshold = 50_000
 	// defaultReadCacheMaxFileSize is deliberately larger than the inline
-	// fallback so medium-small files do not miss userspace cache solely because
-	// their server inline threshold is higher. The aggregate cache cap still
-	// bounds memory use.
-	defaultReadCacheMaxFileSize = 256 << 10
+	// fallback so medium files do not miss userspace cache solely because
+	// their server inline threshold is lower. The aggregate cache cap still
+	// bounds memory use. Keeping this at 1MiB covers common benchmark and
+	// editor workloads without turning the cache into an unbounded object store.
+	defaultReadCacheMaxFileSize = 1 << 20
 )
 
 // cacheEntry holds a single cached file's data and metadata.
@@ -33,8 +34,8 @@ type cacheEntry struct {
 	elem     *list.Element // position in LRU list
 }
 
-// ReadCache is a thread-safe LRU + TTL read cache for small files.
-// It only caches files whose size does not exceed smallFileThreshold (50KB).
+// ReadCache is a thread-safe LRU + TTL read cache for small and medium files.
+// It only caches files whose size does not exceed the per-cache maxFile limit.
 // Entries are evicted when the total cached size exceeds maxSize or when
 // their TTL expires.
 type ReadCache struct {
@@ -43,6 +44,7 @@ type ReadCache struct {
 	order   *list.List // front = most recently used
 	size    int64      // current total bytes cached
 	maxSize int64
+	maxFile int64
 	ttl     time.Duration
 }
 
@@ -50,18 +52,36 @@ type ReadCache struct {
 // If maxSize <= 0, defaultReadCacheMaxSize (128MB) is used.
 // If ttl <= 0, defaultReadCacheTTL (30s) is used.
 func NewReadCache(maxSize int64, ttl time.Duration) *ReadCache {
+	return NewReadCacheWithMaxFileSize(maxSize, ttl, 0)
+}
+
+// NewReadCacheWithMaxFileSize creates a ReadCache with an explicit per-file
+// admission limit. If maxFileSize <= 0, defaultReadCacheMaxFileSize is used.
+func NewReadCacheWithMaxFileSize(maxSize int64, ttl time.Duration, maxFileSize int64) *ReadCache {
 	if maxSize <= 0 {
 		maxSize = defaultReadCacheMaxSize
 	}
 	if ttl <= 0 {
 		ttl = defaultReadCacheTTL
 	}
+	if maxFileSize <= 0 {
+		maxFileSize = defaultReadCacheMaxFileSize
+	}
 	return &ReadCache{
 		items:   make(map[string]*cacheEntry),
 		order:   list.New(),
 		maxSize: maxSize,
+		maxFile: maxFileSize,
 		ttl:     ttl,
 	}
+}
+
+// MaxFileSize returns the largest payload admitted into this cache.
+func (rc *ReadCache) MaxFileSize() int64 {
+	if rc == nil || rc.maxFile <= 0 {
+		return defaultReadCacheMaxFileSize
+	}
+	return rc.maxFile
 }
 
 // Get returns cached data for the given path if the entry exists, has not
@@ -102,7 +122,7 @@ func (rc *ReadCache) Get(path string, currentRevision int64) ([]byte, bool) {
 }
 
 // Put stores data in the cache for the given path and revision. Only files
-// whose size does not exceed defaultReadCacheMaxFileSize are cached. The cache
+// whose size does not exceed the cache's per-file limit are cached. The cache
 // limit is intentionally a static memory-pressure cap rather than a mirror
 // of the server's inline_threshold; raising the latter should not silently
 // expand FUSE's per-mount RAM footprint. If an entry for the path already
@@ -119,7 +139,7 @@ func (rc *ReadCache) PutOwned(path string, data []byte, revision int64) {
 }
 
 func (rc *ReadCache) put(path string, data []byte, revision int64, clone bool) {
-	if len(data) > defaultReadCacheMaxFileSize {
+	if int64(len(data)) > rc.MaxFileSize() {
 		return
 	}
 

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -84,8 +84,8 @@ func (w *SSEWatcher) handleChange(ce *client.ChangeEvent) {
 
 	fmt.Fprintf(os.Stderr, "drive9: SSE event op=%s path=%s local=%s actor=%s\n", ce.Op, remotePath, p, ce.Actor)
 
-	// Invalidate read cache for the changed file.
-	w.fs.readCache.Invalidate(p)
+	// Invalidate read cache and resolved read targets for the changed file.
+	w.fs.invalidateReadCacheAndTargets(p)
 
 	// Invalidate directory cache for the parent directory.
 	w.fs.dirCache.Invalidate(parentDir(p))
@@ -113,6 +113,7 @@ func (w *SSEWatcher) handleReset(resets ...*client.ResetEvent) {
 
 	// 1. Clear all user-space caches.
 	w.fs.readCache.InvalidateAll()
+	w.fs.clearAllReadTargets()
 	w.fs.dirCache.InvalidateAll()
 
 	// 2. Best-effort kernel cache invalidation for all known inodes.

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -97,10 +97,19 @@ func NewAWS(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
+	var transport *http.Transport
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = t.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+	transport.MaxIdleConns = 512
+	transport.MaxIdleConnsPerHost = 128
 
 	loadOptions := []func(*awsconfig.LoadOptions) error{
 		awsconfig.WithRegion(cfg.Region),
 		awsconfig.WithResponseChecksumValidation(aws.ResponseChecksumValidationWhenRequired),
+		awsconfig.WithHTTPClient(&http.Client{Transport: transport}),
 	}
 
 	provider, ok, err := staticCredentialsProvider(cfg)

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -103,6 +103,10 @@ func NewAWS(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {
 	} else {
 		transport = &http.Transport{}
 	}
+	// S3 data-plane calls fan out more than control-plane API calls:
+	// multipart uploads use uploadMaxConcurrency workers and FUSE reads can
+	// issue direct range/prefetch requests concurrently. Keep this pool 2x
+	// the dat9 client pool so hot S3 paths avoid repeated TLS handshakes.
 	transport.MaxIdleConns = 512
 	transport.MaxIdleConnsPerHost = 128
 


### PR DESCRIPTION
## Summary
- raise and expose FUSE read-cache single-file admission limit to cover 512KB/1MB hot-read workloads
- reuse resolved S3 read targets across FUSE range reads and prefetches
- batch datastore recursive delete orphan handling and tune client/S3 connection pools

## Tests
- `go test ./pkg/client ./pkg/s3client ./pkg/datastore ./pkg/backend ./pkg/fuse ./cmd/drive9/cli`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New mount flag to cap per-file read-cache size (default 1 MB).
  * Read-cache now configurable per-file; prefetch and read paths use this limit.
  * Client exposes read-target/resolution and helpers to detect expired presigned URLs for robust large-file downloads and automatic refresh on failure.

* **Improvements**
  * Improved HTTP connection pooling for concurrent transfers.
  * Read-target memoization and cache invalidation tightened to avoid stale targets.

* **Tests**
  * Added/updated tests for mount flag, read-target handling, presign expiry refresh, cache limits, and deletion flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/428)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->