### PR TITLE
Add FUSE write durability policies

### DIFF
--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -3,11 +3,16 @@ package cli
 import "time"
 
 type fuseSyncMode string
+type fuseWritePolicy string
 
 const (
 	fuseSyncModeAuto        fuseSyncMode = "auto"
 	fuseSyncModeInteractive fuseSyncMode = "interactive"
 	fuseSyncModeStrict      fuseSyncMode = "strict"
+
+	fuseWritePolicyWriteBack fuseWritePolicy = "writeback"
+	fuseWritePolicyCloseSync fuseWritePolicy = "close-sync"
+	fuseWritePolicyWriteSync fuseWritePolicy = "write-sync"
 )
 
 type mountFuseOptions struct {
@@ -32,6 +37,7 @@ type mountFuseOptions struct {
 	PrefetchMaxBytes      int64
 	PrefetchTimeout       time.Duration
 	SyncMode              fuseSyncMode
+	WritePolicy           fuseWritePolicy
 	Profile               string
 	AllowOther            bool
 	ReadOnly              bool
@@ -55,4 +61,8 @@ var mountVault = mountVaultImpl
 
 func parseFuseSyncMode(s string) (fuseSyncMode, error) {
 	return parseFuseSyncModeImpl(s)
+}
+
+func parseFuseWritePolicy(s string) (fuseWritePolicy, error) {
+	return parseFuseWritePolicyImpl(s)
 }

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -16,8 +16,20 @@ func parseFuseSyncModeImpl(s string) (fuseSyncMode, error) {
 	return fromDrive9FuseSyncMode(mode), nil
 }
 
+func parseFuseWritePolicyImpl(s string) (fuseWritePolicy, error) {
+	policy, err := drive9fuse.ParseWritePolicy(s)
+	if err != nil {
+		return "", err
+	}
+	return fromDrive9FuseWritePolicy(policy), nil
+}
+
 func mountFuseImpl(opts *mountFuseOptions) error {
 	mode, err := toDrive9FuseSyncMode(opts.SyncMode)
+	if err != nil {
+		return err
+	}
+	writePolicy, err := toDrive9FuseWritePolicy(opts.WritePolicy)
 	if err != nil {
 		return err
 	}
@@ -44,6 +56,7 @@ func mountFuseImpl(opts *mountFuseOptions) error {
 		PrefetchMaxBytes:      opts.PrefetchMaxBytes,
 		PrefetchTimeout:       opts.PrefetchTimeout,
 		SyncMode:              mode,
+		WritePolicy:           writePolicy,
 		Profile:               opts.Profile,
 		AllowOther:            opts.AllowOther,
 		ReadOnly:              opts.ReadOnly,
@@ -75,6 +88,17 @@ func fromDrive9FuseSyncMode(mode drive9fuse.SyncMode) fuseSyncMode {
 	}
 }
 
+func fromDrive9FuseWritePolicy(policy drive9fuse.WritePolicy) fuseWritePolicy {
+	switch policy {
+	case drive9fuse.WritePolicyCloseSync:
+		return fuseWritePolicyCloseSync
+	case drive9fuse.WritePolicyWriteSync:
+		return fuseWritePolicyWriteSync
+	default:
+		return fuseWritePolicyWriteBack
+	}
+}
+
 func toDrive9FuseSyncMode(mode fuseSyncMode) (drive9fuse.SyncMode, error) {
 	switch mode {
 	case fuseSyncModeAuto:
@@ -85,5 +109,18 @@ func toDrive9FuseSyncMode(mode fuseSyncMode) (drive9fuse.SyncMode, error) {
 		return drive9fuse.SyncStrict, nil
 	default:
 		return drive9fuse.SyncAuto, fmt.Errorf("unknown sync mode %q", mode)
+	}
+}
+
+func toDrive9FuseWritePolicy(policy fuseWritePolicy) (drive9fuse.WritePolicy, error) {
+	switch policy {
+	case fuseWritePolicyWriteBack:
+		return drive9fuse.WritePolicyWriteBack, nil
+	case fuseWritePolicyCloseSync:
+		return drive9fuse.WritePolicyCloseSync, nil
+	case fuseWritePolicyWriteSync:
+		return drive9fuse.WritePolicyWriteSync, nil
+	default:
+		return drive9fuse.WritePolicyWriteBack, fmt.Errorf("unknown write policy %q", policy)
 	}
 }

--- a/cmd/drive9/cli/fuse_bridge_windows.go
+++ b/cmd/drive9/cli/fuse_bridge_windows.go
@@ -17,6 +17,19 @@ func parseFuseSyncModeImpl(s string) (fuseSyncMode, error) {
 	}
 }
 
+func parseFuseWritePolicyImpl(s string) (fuseWritePolicy, error) {
+	switch s {
+	case "", string(fuseWritePolicyWriteBack):
+		return fuseWritePolicyWriteBack, nil
+	case string(fuseWritePolicyCloseSync):
+		return fuseWritePolicyCloseSync, nil
+	case string(fuseWritePolicyWriteSync):
+		return fuseWritePolicyWriteSync, nil
+	default:
+		return "", fmt.Errorf("unknown write policy %q (valid: writeback, close-sync, write-sync)", s)
+	}
+}
+
 func mountFuseImpl(opts *mountFuseOptions) error {
 	_ = opts
 	return fmt.Errorf("drive9 mount: FUSE mounts are not supported on Windows; use `drive9 mount` without `--mode=fuse` on Windows (the default path uses WebDAV), or run drive9 mount on Linux or macOS")

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -194,8 +194,16 @@ func fsMountCmd(args []string) error {
 	*server, *apiKey = serverVal, apiKeyVal
 	token := tokenVal
 
+	writePolicyVal, err := parseFuseWritePolicy(*writePolicy)
+	if err != nil {
+		return err
+	}
+
 	// WebDAV path: create client, start local WebDAV server, invoke mount_webdav.
 	if resolved == MountModeWebDAV {
+		if writePolicyVal != fuseWritePolicyWriteBack {
+			return fmt.Errorf("--write-policy is only supported with --mode=fuse; WebDAV mounts always use their native write behavior")
+		}
 		var c *client.Client
 		if token != "" {
 			c = client.NewWithToken(*server, token)
@@ -216,10 +224,6 @@ func fsMountCmd(args []string) error {
 
 	// FUSE path (existing behavior).
 	syncModeVal, err := parseFuseSyncMode(*syncMode)
-	if err != nil {
-		return err
-	}
-	writePolicyVal, err := parseFuseWritePolicy(*writePolicy)
 	if err != nil {
 		return err
 	}

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -98,6 +98,7 @@ func fsMountCmd(args []string) error {
 	prefetchMaxBytes := fs.Int64("readdir-prefetch-max-bytes", 1<<20, "maximum aggregate bytes prefetched per directory read")
 	prefetchTimeout := fs.Duration("readdir-prefetch-timeout", time.Second, "timeout for one readdir prefetch batch")
 	syncMode := fs.String("sync-mode", "auto", "sync mode: auto, interactive, or strict")
+	writePolicy := fs.String("write-policy", "writeback", "write durability policy: writeback, close-sync, or write-sync")
 	profile := fs.String("profile", "", "mount profile: interactive (empty for default)")
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
 	readOnly := fs.Bool("read-only", false, "mount as read-only")
@@ -218,6 +219,10 @@ func fsMountCmd(args []string) error {
 	if err != nil {
 		return err
 	}
+	writePolicyVal, err := parseFuseWritePolicy(*writePolicy)
+	if err != nil {
+		return err
+	}
 
 	opts := &mountFuseOptions{
 		Server:                *server,
@@ -241,6 +246,7 @@ func fsMountCmd(args []string) error {
 		PrefetchMaxBytes:      *prefetchMaxBytes,
 		PrefetchTimeout:       *prefetchTimeout,
 		SyncMode:              syncModeVal,
+		WritePolicy:           writePolicyVal,
 		Profile:               *profile,
 		AllowOther:            *allowOther,
 		ReadOnly:              *readOnly,

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -651,6 +651,22 @@ func TestFsMountCmd_SingleArgDefaultsToRootRemote(t *testing.T) {
 	}
 }
 
+func TestFsMountCmdRejectsWritePolicyForWebDAV(t *testing.T) {
+	err := fsMountCmd([]string{
+		"--mode=webdav",
+		"--server=https://drive9.example",
+		"--api-key=sk-test",
+		"--write-policy=close-sync",
+		t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected WebDAV write-policy rejection")
+	}
+	if !strings.Contains(err.Error(), "--write-policy is only supported with --mode=fuse") {
+		t.Fatalf("error = %v, want write-policy WebDAV rejection", err)
+	}
+}
+
 // isolateMountCredentialsForTest keeps parsing-only mount tests from reading
 // the developer machine's DRIVE9_* env vars or active drive9 context. Without
 // this, a test that expects credential resolution to fail can reach the real

--- a/docs/design/fuse-write-policy.md
+++ b/docs/design/fuse-write-policy.md
@@ -36,6 +36,10 @@ Valid values:
 
 Default is `writeback` to preserve existing behavior.
 
+The flag applies only to FUSE mounts. WebDAV mounts use their native write
+behavior; passing a non-default `--write-policy` with a WebDAV-resolved mount is
+rejected instead of silently ignored.
+
 ## Relationship To Existing Sync Mode
 
 `--sync-mode=auto|interactive|strict` already exists and controls explicit
@@ -55,9 +59,11 @@ Precedence:
 The mount-level policy is copied into `FileHandle.WritePolicy` at `Create` or
 `Open` time. The policy does not change for that handle.
 
-When the mount default is `writeback`, a writable open with `O_SYNC` is
-promoted to `write-sync`. This mirrors the operating system model where sync
-behavior is chosen when the descriptor is opened.
+When a writable handle is opened with `O_SYNC` or `O_DSYNC`, it is promoted to
+`write-sync` regardless of the mount default. This includes `close-sync` mounts:
+the per-descriptor sync request is stronger than close-time durability. This
+mirrors the operating system model where sync behavior is chosen when the
+descriptor is opened.
 
 ## FUSE Placement
 
@@ -79,14 +85,22 @@ Therefore:
 
 Remote synchronization reuses the existing upload machinery:
 
-- Shadow-spill handles stream from `ShadowStore` with `uploadFromShadowRemote`.
-- Non-shadow handles use `flushHandle`, preserving the existing direct PUT,
-  patch, stream upload, and multipart decisions.
+- `close-sync` handles reuse the flush-time direct PUT, patch, stream upload,
+  multipart, and shadow-spill paths. After a successful shadow-spill upload, the
+  local shadow is retired so later read-only opens do not pin stale local data.
+- `write-sync` handles do not use the streaming uploader. Each write is treated
+  as a serialized write-and-commit transaction for that file handle. This avoids
+  reusing flush-time multipart state across multiple per-write commits.
+- `write-sync` direct/small writes upload the current full handle contents.
+  Existing large-file edits use the patch path when possible.
 - Timeouts use `releaseTimeout(size)` so large files are not limited by the
   generic FUSE operation timeout.
 - On success, dirty state is cleared and inode/read cache metadata is updated.
-- On failure, local shadow/pending state is preserved where possible so data is
-  not silently discarded.
+- On `write-sync` failure, the write reports failure and the handle rolls back to
+  its pre-write dirty-buffer snapshot so data the kernel believes was not
+  written is not uploaded later by close or flush.
+- On `close-sync` failure, dirty state remains retryable because the write
+  syscall already succeeded and `Flush` is the failing operation.
 
 ## Expected Tradeoffs
 
@@ -96,3 +110,8 @@ latency include network, server, database, and S3/db9 latency.
 `write-sync` can be dramatically slower for normal buffered writers because a
 single logical file copy may be split into many FUSE write requests. It is
 intended for explicit durability-sensitive workloads, not as the default.
+
+For append-heavy workloads, `write-sync` may repeatedly upload or validate an
+ever-growing file snapshot. A sequence of many small writes to a large file can
+therefore have O(n²) byte-transfer amplification. Use `close-sync` when the
+required durability boundary is file close rather than every individual write.

--- a/docs/design/fuse-write-policy.md
+++ b/docs/design/fuse-write-policy.md
@@ -1,0 +1,98 @@
+# FUSE Write Policy
+
+## Context
+
+The drive9 FUSE mount currently optimizes for interactive latency. A close
+usually stages data into the local shadow/write-back state and then hands the
+remote upload to the commit queue or write-back uploader. This preserves local
+read-after-close behavior, but close returning successfully does not mean the
+cloud backend has accepted the write.
+
+Some workloads want stronger semantics:
+
+- close should not return until the cloud write has succeeded;
+- every write should be remote-durable before the write syscall returns.
+
+This document defines a mount-level write policy that is captured on each
+writable file handle when it is opened.
+
+## CLI
+
+Add a mount flag:
+
+```bash
+drive9 mount --write-policy=writeback   :/ /mnt/drive9
+drive9 mount --write-policy=close-sync  :/ /mnt/drive9
+drive9 mount --write-policy=write-sync  :/ /mnt/drive9
+```
+
+Valid values:
+
+| Policy | Write syscall | Close syscall | Use case |
+| --- | --- | --- | --- |
+| `writeback` | Writes local buffer/shadow state. | Existing behavior: remote commit may be async. | Lowest latency, current default. |
+| `close-sync` | Writes local buffer/shadow state. | Waits for remote commit before close can succeed. | JuiceFS-like close-to-cloud semantics. |
+| `write-sync` | Waits for remote commit before each write succeeds. | Usually clean; close is a final no-op/verification. | Strong durability, tests, low-frequency writes. |
+
+Default is `writeback` to preserve existing behavior.
+
+## Relationship To Existing Sync Mode
+
+`--sync-mode=auto|interactive|strict` already exists and controls explicit
+`fsync` durability semantics. The new `--write-policy` controls ordinary write
+and close behavior.
+
+Precedence:
+
+- `writeback`: keep the existing `Flush`, `Release`, and `Fsync` behavior.
+- `close-sync`: ordinary close is remote durable. Explicit `fsync` still follows
+  `--sync-mode`, but close is stronger than the default interactive path.
+- `write-sync`: each write is remote durable. `fsync` and close are normally
+  clean unless a prior write failed or another path dirtied the handle.
+
+## Per-Handle Decision
+
+The mount-level policy is copied into `FileHandle.WritePolicy` at `Create` or
+`Open` time. The policy does not change for that handle.
+
+When the mount default is `writeback`, a writable open with `O_SYNC` is
+promoted to `write-sync`. This mirrors the operating system model where sync
+behavior is chosen when the descriptor is opened.
+
+## FUSE Placement
+
+go-fuse `Release` has no status return, so it cannot reliably report cloud
+upload failure to the application that called `close(2)`. The close error path
+is `Flush`, which returns a FUSE status.
+
+Therefore:
+
+- `close-sync` is enforced in `Flush` by bypassing write-back staging,
+  debouncing, and commit-queue enqueue. It uploads to the cloud before
+  returning.
+- `Release` still handles cleanup and remains a fallback for unusual flows, but
+  it is not the primary close-sync error propagation point.
+- `write-sync` is enforced at the end of `Write` by uploading the current
+  handle contents before returning success.
+
+## Upload Strategy
+
+Remote synchronization reuses the existing upload machinery:
+
+- Shadow-spill handles stream from `ShadowStore` with `uploadFromShadowRemote`.
+- Non-shadow handles use `flushHandle`, preserving the existing direct PUT,
+  patch, stream upload, and multipart decisions.
+- Timeouts use `releaseTimeout(size)` so large files are not limited by the
+  generic FUSE operation timeout.
+- On success, dirty state is cleared and inode/read cache metadata is updated.
+- On failure, local shadow/pending state is preserved where possible so data is
+  not silently discarded.
+
+## Expected Tradeoffs
+
+`close-sync` improves cross-client/cloud visibility after close but makes close
+latency include network, server, database, and S3/db9 latency.
+
+`write-sync` can be dramatically slower for normal buffered writers because a
+single logical file copy may be split into many FUSE write requests. It is
+intended for explicit durability-sensitive workloads, not as the default.

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -316,7 +316,7 @@ func (fs *Dat9FS) writePolicyForOpen(flags uint32) WritePolicy {
 	if fs != nil && fs.opts != nil {
 		policy = fs.opts.WritePolicy
 	}
-	if policy == WritePolicyWriteBack && flags&uint32(syscall.O_SYNC) != 0 {
+	if hasSyncOpenFlag(flags) {
 		return WritePolicyWriteSync
 	}
 	return policy
@@ -410,7 +410,7 @@ func (fs *Dat9FS) truncateWritableHandleLocked(fh *FileHandle, newSize int64) er
 	if err := fh.Dirty.Truncate(newSize); err != nil {
 		return err
 	}
-	if fs.shadowStore != nil && fs.pendingIndex != nil {
+	if fh.WritePolicy != WritePolicyWriteSync && fs.shadowStore != nil && fs.pendingIndex != nil {
 		if fh.ShadowReady || fh.IsNew || newSize == 0 {
 			if err := fs.shadowStore.Truncate(fh.Path, newSize, fh.BaseRev); err != nil {
 				log.Printf("shadow truncate failed for %s: %v", fh.Path, err)
@@ -2940,7 +2940,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		wb.OnPartFull = func(partIdx int, data []byte) {
 			wb.EvictPart(partIdx)
 		}
-	} else {
+	} else if fh.WritePolicy != WritePolicyWriteSync {
 		// Normal mode: attach streaming uploader for sequential write streaming.
 		fh.Streamer = NewStreamUploader(fs.client, childP, expectedRevisionForHandle(fh), fs.remoteRoot())
 		streamer := fh.Streamer
@@ -3049,7 +3049,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			fh.ZeroBase = true
 			fh.DirtySeq = fs.markDirtySize(fh.Ino, 0)
 			fs.inodes.UpdateSize(fh.Ino, 0)
-			if fs.shadowStore != nil && fs.pendingIndex != nil {
+			if fh.WritePolicy != WritePolicyWriteSync && fs.shadowStore != nil && fs.pendingIndex != nil {
 				if err := fs.shadowStore.Ensure(p, 0, fh.BaseRev); err != nil {
 					log.Printf("shadow ensure failed for truncate-open %s: %v", p, err)
 				} else {
@@ -3068,7 +3068,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 				wb.OnPartFull = func(partIdx int, data []byte) {
 					wb.EvictPart(partIdx)
 				}
-			} else {
+			} else if fh.WritePolicy != WritePolicyWriteSync {
 				// Normal mode: attach streaming uploader with OnPartFull wiring.
 				fh.Streamer = NewStreamUploader(fs.client, p, expectedRevisionForHandle(fh), fs.remoteRoot())
 				streamer := fh.Streamer
@@ -3541,6 +3541,10 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 		source = "new-dirty-buffer"
 		fh.Dirty = fs.newWriteBuffer(fh.Path, 0, 0)
 	}
+	writeSyncSnapshot := (*writeBufferSnapshot)(nil)
+	if fh.WritePolicy == WritePolicyWriteSync {
+		writeSyncSnapshot = fh.Dirty.snapshot()
+	}
 
 	// ShadowSpill: write shadow FIRST, before Dirty. If shadow fails, return
 	// EIO without touching Dirty — OnPartFull may evict the part, so writing
@@ -3595,12 +3599,168 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 		ctx, cf := context.WithTimeout(context.Background(), releaseTimeout(size))
 		defer cf()
 		source = "write-sync"
-		st := fs.syncHandleToRemoteLocked(ctx, fh)
+		st := fs.syncWriteHandleToRemoteLocked(ctx, fh)
 		if st != gofuse.OK {
+			fs.restoreFailedWriteSyncLocked(fh, writeSyncSnapshot)
 			return 0, st
 		}
 	}
 	return n, gofuse.OK
+}
+
+func (fs *Dat9FS) restoreFailedWriteSyncLocked(fh *FileHandle, snapshot *writeBufferSnapshot) {
+	if fh == nil {
+		return
+	}
+	if fh.DirtySeq != 0 {
+		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+		fh.DirtySeq = 0
+	}
+	if snapshot == nil {
+		fh.Dirty = nil
+	} else {
+		if fh.Dirty == nil {
+			fh.Dirty = fs.newWriteBuffer(fh.Path, snapshot.maxSize, snapshot.partSize)
+		}
+		fh.Dirty.restore(snapshot)
+		if fh.Dirty.HasDirtyParts() {
+			fh.DirtySeq = fs.markDirtySize(fh.Ino, fh.Dirty.Size())
+		}
+		fs.inodes.UpdateSize(fh.Ino, fh.Dirty.Size())
+	}
+	fh.WriteBackSeq = 0
+	clearReadTargetForLockedHandle(fh)
+	if fs.shadowStore != nil && fh.ShadowReady {
+		fs.shadowStore.Remove(fh.Path)
+		fh.ShadowReady = false
+		fh.ShadowSpill = false
+		fh.ShadowCommitReady = false
+	}
+}
+
+// syncWriteHandleToRemoteLocked makes the current handle contents
+// remote-durable for a write-sync Write call. Caller must hold fh.mu and this
+// method keeps it held for the whole upload so no same-handle write can mutate
+// the dirty buffer before the syscall returns.
+func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHandle) gofuse.Status {
+	if fh == nil || fh.Dirty == nil || !fh.Dirty.HasDirtyParts() {
+		return gofuse.OK
+	}
+
+	size := fh.Dirty.Size()
+	expectedRevision := expectedRevisionForHandle(fh)
+	var (
+		data         []byte
+		committedRev int64
+		err          error
+	)
+
+	threshold := fs.negotiatedInlineThreshold()
+	useDirectPUT := size == 0 || (threshold > 0 && size < threshold)
+	if useDirectPUT || fh.OrigSize < threshold {
+		data = fh.Dirty.bytesView()
+	}
+
+	if useDirectPUT {
+		writeStart := time.Now()
+		if size == 0 && fh.IsNew {
+			fs.debugf("write-sync empty create start path=%s expected_rev=%d", fh.Path, expectedRevision)
+			committedRev, err = fs.client.CreateFileCtx(ctx, fs.remotePath(fh.Path))
+			if isCreateActionUnsupportedErr(err) {
+				fs.debugf("write-sync empty create unsupported path=%s fallback=small-write err=%v", fh.Path, err)
+				committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), data, expectedRevision)
+			}
+			fs.perfRecordRemote(perfRemoteWrite, writeStart, err, 0)
+			fs.debugDurationf(writeStart, 0, "write-sync empty create done path=%s committed_rev=%d err=%v", fh.Path, committedRev, err)
+		} else {
+			fs.debugf("write-sync small write start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
+			committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), data, expectedRevision)
+			fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
+			fs.debugDurationf(writeStart, 0, "write-sync small write done path=%s size=%d committed_rev=%d err=%v", fh.Path, size, committedRev, err)
+		}
+	} else if fh.OrigSize >= threshold {
+		dirtyParts := fh.Dirty.DirtyPartNumbers()
+		if len(dirtyParts) > 0 {
+			partSnapshots := make(map[int][]byte, len(dirtyParts))
+			for _, pn := range dirtyParts {
+				src := fh.Dirty.PartData(pn)
+				if src != nil {
+					cp := make([]byte, len(src))
+					copy(cp, src)
+					partSnapshots[pn] = cp
+				}
+			}
+			patchStart := time.Now()
+			fs.debugf("write-sync patch start path=%s size=%d dirty_parts=%d expected_rev=%d", fh.Path, size, len(dirtyParts), expectedRevision)
+			err = fs.client.PatchFile(
+				ctx,
+				fs.remotePath(fh.Path),
+				size,
+				dirtyParts,
+				func(partNumber int, partSize int64, origData []byte) ([]byte, error) {
+					if d, ok := partSnapshots[partNumber]; ok {
+						return d, nil
+					}
+					return origData, nil
+				},
+				nil,
+				client.WithPartSize(fh.Dirty.PartSize()),
+				client.WithExpectedRevision(expectedRevision),
+			)
+			var patchBytes uint64
+			if size > 0 {
+				patchBytes = uint64(size)
+			}
+			fs.perfRecordRemote(perfRemoteWrite, patchStart, err, patchBytes)
+			fs.debugDurationf(patchStart, 0, "write-sync patch done path=%s size=%d dirty_parts=%d err=%v", fh.Path, size, len(dirtyParts), err)
+		}
+	} else {
+		if data == nil && !fh.Dirty.CanMaterializeFull() {
+			log.Printf("write-sync cannot materialize full file for %s", fh.Path)
+			return gofuse.EIO
+		}
+		if data == nil {
+			data = fh.Dirty.bytesView()
+		}
+		writeStart := time.Now()
+		fs.debugf("write-sync stream start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
+		err = fs.client.WriteStreamConditional(
+			ctx,
+			fs.remotePath(fh.Path),
+			bytes.NewReader(data),
+			size,
+			nil,
+			expectedRevision,
+		)
+		fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
+		fs.debugDurationf(writeStart, 0, "write-sync stream done path=%s size=%d err=%v", fh.Path, size, err)
+	}
+	if err != nil {
+		log.Printf("write-sync upload failed for %s: %v", fh.Path, err)
+		return httpToFuseStatus(err)
+	}
+
+	fh.Dirty.ClearDirty()
+	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+	fh.DirtySeq = 0
+	if committedRev > 0 {
+		clearReadTargetForLockedHandle(fh)
+		fs.clearReadTargetsForPathExcept(fh.Path, fh)
+		fs.readCache.Put(fh.Path, data, committedRev)
+		fh.IsNew = false
+		fh.BaseRev = committedRev
+		fs.inodes.UpdateRevision(fh.Ino, committedRev)
+		if fh.ZeroBase && fh.Dirty != nil && fh.Dirty.Size() > 0 {
+			fh.ZeroBase = false
+		}
+	} else {
+		clearReadTargetForLockedHandle(fh)
+		fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
+		fs.finalizeHandleFlushLocked(fh, expectedRevision)
+	}
+	fs.inodes.UpdateSize(fh.Ino, size)
+	fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
+	return gofuse.OK
 }
 
 // syncHandleToRemoteLocked makes the current dirty handle remote-durable.
@@ -3638,6 +3798,12 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		fs.inodes.UpdateSize(fh.Ino, size)
 		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
+		if fs.shadowStore != nil {
+			fs.shadowStore.Remove(fh.Path)
+			fh.ShadowReady = false
+			fh.ShadowSpill = false
+			fh.ShadowCommitReady = false
+		}
 		if fs.pendingIndex != nil {
 			fs.pendingIndex.Remove(fh.Path)
 		}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -311,6 +311,17 @@ func (fs *Dat9FS) remotePath(localPath string) string {
 	return mountpath.ToRemote(fs.remoteRoot(), localPath)
 }
 
+func (fs *Dat9FS) writePolicyForOpen(flags uint32) WritePolicy {
+	policy := WritePolicyWriteBack
+	if fs != nil && fs.opts != nil {
+		policy = fs.opts.WritePolicy
+	}
+	if policy == WritePolicyWriteBack && flags&uint32(syscall.O_SYNC) != 0 {
+		return WritePolicyWriteSync
+	}
+	return policy
+}
+
 func isGitLooseObjectFinalPath(p string) bool {
 	const marker = "/.git/objects/"
 
@@ -2911,6 +2922,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		Dirty:       wb,
 		IsNew:       true,
 		ShadowReady: false,
+		WritePolicy: fs.writePolicyForOpen(input.Flags),
 	}
 
 	if fs.shadowStore != nil && fs.pendingIndex != nil {
@@ -2967,10 +2979,11 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 	}
 
 	fh := &FileHandle{
-		Ino:     input.NodeId,
-		Path:    p,
-		Flags:   input.Flags,
-		OpenPID: input.Pid,
+		Ino:         input.NodeId,
+		Path:        p,
+		Flags:       input.Flags,
+		OpenPID:     input.Pid,
+		WritePolicy: fs.writePolicyForOpen(input.Flags),
 	}
 	entry, _ := fs.inodes.GetEntry(input.NodeId)
 	if entry != nil {
@@ -3104,7 +3117,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		// still populate the userspace prefetcher on cache misses.
 		out.OpenFlags = gofuse.FOPEN_KEEP_CACHE
 	}
-	fs.debugf("open path=%s fh=%d ino=%d flags=0x%x open_flags=%d dirty=%t prefetch=%t orig_size=%d base_rev=%d shadow_ready=%t shadow_spill=%t", p, out.Fh, fh.Ino, input.Flags, out.OpenFlags, fh.Dirty != nil, fh.Prefetch != nil, fh.OrigSize, fh.BaseRev, fh.ShadowReady, fh.ShadowSpill)
+	fs.debugf("open path=%s fh=%d ino=%d flags=0x%x open_flags=%d dirty=%t prefetch=%t orig_size=%d base_rev=%d shadow_ready=%t shadow_spill=%t write_policy=%s", p, out.Fh, fh.Ino, input.Flags, out.OpenFlags, fh.Dirty != nil, fh.Prefetch != nil, fh.OrigSize, fh.BaseRev, fh.ShadowReady, fh.ShadowSpill, fh.WritePolicy)
 	return gofuse.OK
 }
 
@@ -3577,7 +3590,61 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 	}
 	fh.DirtySeq = fs.markDirtySize(fh.Ino, fh.Dirty.Size())
 	fs.inodes.UpdateSize(fh.Ino, fh.Dirty.Size())
+	if fh.WritePolicy == WritePolicyWriteSync {
+		size := fh.Dirty.Size()
+		ctx, cf := context.WithTimeout(context.Background(), releaseTimeout(size))
+		defer cf()
+		source = "write-sync"
+		st := fs.syncHandleToRemoteLocked(ctx, fh)
+		if st != gofuse.OK {
+			return 0, st
+		}
+	}
 	return n, gofuse.OK
+}
+
+// syncHandleToRemoteLocked makes the current dirty handle remote-durable.
+// Caller must hold fh.mu. The method may temporarily release fh.mu around
+// network I/O, matching flushHandle's locking contract.
+func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) gofuse.Status {
+	if fh == nil || fh.Dirty == nil || !fh.Dirty.HasDirtyParts() {
+		return gofuse.OK
+	}
+
+	size := fh.Dirty.Size()
+	if fh.ShadowSpill && fs.shadowStore != nil {
+		expectedRevision := expectedRevisionForHandle(fh)
+		uploadStart := time.Now()
+		fs.debugf("sync handle shadowspill upload start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
+		fh.Unlock()
+		err := uploadFromShadowRemote(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevision)
+		fh.Lock()
+		var uploadBytes uint64
+		if size > 0 {
+			uploadBytes = uint64(size)
+		}
+		fs.perfRecordRemote(perfRemoteWrite, uploadStart, err, uploadBytes)
+		fs.debugDurationf(uploadStart, 0, "sync handle shadowspill upload done path=%s size=%d err=%v", fh.Path, size, err)
+		if err != nil {
+			log.Printf("sync handle shadowspill upload failed for %s: %v", fh.Path, err)
+			return httpToFuseStatus(err)
+		}
+		fh.Dirty.ClearDirty()
+		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+		fh.DirtySeq = 0
+		fh.ShadowCommitReady = false
+		clearReadTargetForLockedHandle(fh)
+		fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
+		fs.inodes.UpdateSize(fh.Ino, size)
+		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
+		fs.finalizeHandleFlushLocked(fh, expectedRevision)
+		if fs.pendingIndex != nil {
+			fs.pendingIndex.Remove(fh.Path)
+		}
+		return gofuse.OK
+	}
+
+	return fs.flushHandle(ctx, fh)
 }
 
 func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status gofuse.Status) {
@@ -3613,6 +3680,15 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 		}
 		fs.debugf("flush done path=%s fh=%d ino=%d phase=%s size=%d dirty=%t shadow_ready=%t shadow_spill=%t status=%d dur=%s", fh.Path, input.Fh, fh.Ino, phase, size, dirty, fh.ShadowReady, fh.ShadowSpill, status, d)
 	}()
+
+	if fh.Dirty != nil && fh.Dirty.HasDirtyParts() &&
+		(fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync) {
+		size := fh.Dirty.Size()
+		ctx, cf := context.WithTimeout(context.Background(), releaseTimeout(size))
+		defer cf()
+		phase = fh.WritePolicy.String()
+		return fs.syncHandleToRemoteLocked(ctx, fh)
+	}
 
 	// Write-back path: small dirty files are persisted to local disk
 	// and return immediately. The actual HTTP upload happens in Release
@@ -4003,6 +4079,31 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 		// Cancel any pending debounce for this path — Release always flushes immediately.
 		phase = "cancel-debounce"
 		fs.debouncer.Cancel(fh.Path)
+
+		// close-sync is primarily enforced in Flush so close(2) can receive
+		// remote upload errors. Keep Release as a best-effort fallback for
+		// unusual flows where dirty staged state reaches Release directly.
+		if fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync {
+			phase = "release-write-policy-sync"
+			lockStart := time.Now()
+			fh.Lock()
+			if lockWait := time.Since(lockStart); fs.debugEnabled() && lockWait >= fuseDebugSlowOpThreshold {
+				fs.debugf("release lock wait path=%s fh=%d ino=%d phase=%s wait=%s", fh.Path, input.Fh, fh.Ino, phase, lockWait)
+			}
+			if fh.Dirty != nil && fh.Dirty.HasDirtyParts() {
+				size := fh.Dirty.Size()
+				ctx, cf := context.WithTimeout(context.Background(), releaseTimeout(size))
+				flushStart := time.Now()
+				fs.debugf("release write policy sync start path=%s size=%d policy=%s timeout=%s", fh.Path, size, fh.WritePolicy, releaseTimeout(size))
+				flushStatus = fs.syncHandleToRemoteLocked(ctx, fh)
+				fs.debugDurationf(flushStart, 0, "release write policy sync done path=%s size=%d status=%d", fh.Path, size, flushStatus)
+				cf()
+			}
+			fh.Unlock()
+			if flushStatus != gofuse.OK {
+				return
+			}
+		}
 
 		// ShadowSpill Release: CommitQueue streaming from shadow, no writeBack.
 		if fh.ShadowSpill && fh.ShadowCommitReady && fs.commitQueue != nil && fs.shadowStore != nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2925,7 +2925,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		WritePolicy: fs.writePolicyForOpen(input.Flags),
 	}
 
-	if fs.shadowStore != nil && fs.pendingIndex != nil {
+	if fh.WritePolicy != WritePolicyWriteSync && fs.shadowStore != nil && fs.pendingIndex != nil {
 		if err := fs.shadowStore.Ensure(childP, 0, 0); err != nil {
 			log.Printf("shadow ensure failed for create %s: %v", childP, err)
 		} else {

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -28,10 +28,11 @@ type FileHandle struct {
 	Streamer          *StreamUploader // nil for small files / read-only; manages background part uploads
 	Prefetch          *Prefetcher     // nil for writable handles; sequential read prefetcher
 	ReadTarget        *client.ReadTarget
-	PendingMode       uint32 // mode change deferred because a dirty handle was open
-	HasPendingMode    bool   // true when PendingMode should be applied on Release
-	PreviousMode      uint32 // mode before PendingMode was set (for rollback on flush failure)
-	HasPreviousMode   bool   // true when PreviousMode is valid
+	WritePolicy       WritePolicy // per-handle remote durability policy chosen at open/create
+	PendingMode       uint32      // mode change deferred because a dirty handle was open
+	HasPendingMode    bool        // true when PendingMode should be applied on Release
+	PreviousMode      uint32      // mode before PendingMode was set (for rollback on flush failure)
+	HasPreviousMode   bool        // true when PreviousMode is valid
 	mu                sync.Mutex
 }
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -43,6 +43,7 @@ type MountOptions struct {
 	NegativeEntryTTL      time.Duration // kernel negative entry cache TTL (default 10s)
 	FlushDebounce         time.Duration // debounce window for small-file flush coalescing (default 2s, 0 disables); set to -1 to use default
 	SyncMode              SyncMode      // interactive, strict, or auto (default auto)
+	WritePolicy           WritePolicy   // writeback, close-sync, or write-sync (default writeback)
 	Profile               string        // mount profile: "interactive", "" (default)
 	UploadConcurrency     int           // number of background upload workers (default 4)
 	LookupRetryCount      int           // detached retries after transient Lookup/GetAttr stat failures (default 2)
@@ -465,8 +466,8 @@ func Mount(opts *MountOptions) error {
 		forceUnmount(opts.MountPoint)
 	}()
 
-	fmt.Fprintf(os.Stderr, "drive9: mounted on %s (server: %s, actor: %s, readonly: %v, cache: %s, shadow: %s)\n",
-		opts.MountPoint, opts.Server, actorID, opts.ReadOnly, cacheBase, shadowDir)
+	fmt.Fprintf(os.Stderr, "drive9: mounted on %s (server: %s, actor: %s, readonly: %v, write_policy: %s, cache: %s, shadow: %s)\n",
+		opts.MountPoint, opts.Server, actorID, opts.ReadOnly, opts.WritePolicy, cacheBase, shadowDir)
 	server.Wait()
 	shutdown()
 	return nil

--- a/pkg/fuse/mount_profile.go
+++ b/pkg/fuse/mount_profile.go
@@ -20,18 +20,18 @@ const (
 )
 
 // WritePolicy controls when ordinary writes become remote-durable.
-type WritePolicy int
+type WritePolicy string
 
 const (
 	// WritePolicyWriteBack preserves the existing behavior: writes are staged
 	// locally and remote upload may happen asynchronously after close.
-	WritePolicyWriteBack WritePolicy = iota
+	WritePolicyWriteBack WritePolicy = "writeback"
 	// WritePolicyCloseSync makes close remote-durable by forcing cloud upload
 	// from Flush, the FUSE operation whose status propagates to close(2).
-	WritePolicyCloseSync
+	WritePolicyCloseSync WritePolicy = "close-sync"
 	// WritePolicyWriteSync makes each Write operation remote-durable before
 	// returning success. This is intentionally expensive.
-	WritePolicyWriteSync
+	WritePolicyWriteSync WritePolicy = "write-sync"
 )
 
 // String returns the write policy name for CLI/logging.
@@ -44,7 +44,7 @@ func (p WritePolicy) String() string {
 	case WritePolicyWriteSync:
 		return "write-sync"
 	default:
-		return "unknown"
+		return fmt.Sprintf("unknown(%s)", string(p))
 	}
 }
 

--- a/pkg/fuse/mount_profile.go
+++ b/pkg/fuse/mount_profile.go
@@ -19,6 +19,49 @@ const (
 	SyncStrict
 )
 
+// WritePolicy controls when ordinary writes become remote-durable.
+type WritePolicy int
+
+const (
+	// WritePolicyWriteBack preserves the existing behavior: writes are staged
+	// locally and remote upload may happen asynchronously after close.
+	WritePolicyWriteBack WritePolicy = iota
+	// WritePolicyCloseSync makes close remote-durable by forcing cloud upload
+	// from Flush, the FUSE operation whose status propagates to close(2).
+	WritePolicyCloseSync
+	// WritePolicyWriteSync makes each Write operation remote-durable before
+	// returning success. This is intentionally expensive.
+	WritePolicyWriteSync
+)
+
+// String returns the write policy name for CLI/logging.
+func (p WritePolicy) String() string {
+	switch p {
+	case WritePolicyWriteBack:
+		return "writeback"
+	case WritePolicyCloseSync:
+		return "close-sync"
+	case WritePolicyWriteSync:
+		return "write-sync"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseWritePolicy converts a CLI string to a WritePolicy.
+func ParseWritePolicy(s string) (WritePolicy, error) {
+	switch s {
+	case "", "writeback":
+		return WritePolicyWriteBack, nil
+	case "close-sync":
+		return WritePolicyCloseSync, nil
+	case "write-sync":
+		return WritePolicyWriteSync, nil
+	default:
+		return WritePolicyWriteBack, fmt.Errorf("unknown write policy %q (valid: writeback, close-sync, write-sync)", s)
+	}
+}
+
 // String returns the sync mode name for CLI/logging.
 func (m SyncMode) String() string {
 	switch m {

--- a/pkg/fuse/sync_flags_unix.go
+++ b/pkg/fuse/sync_flags_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package fuse
+
+import "syscall"
+
+func hasSyncOpenFlag(flags uint32) bool {
+	syncFlags := uint32(syscall.O_SYNC | syscall.O_DSYNC)
+	return flags&syncFlags != 0
+}

--- a/pkg/fuse/sync_flags_windows.go
+++ b/pkg/fuse/sync_flags_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package fuse
+
+func hasSyncOpenFlag(uint32) bool {
+	return false
+}

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -31,10 +31,10 @@ type LoadPartFunc func(partNum int) ([]byte, error)
 // server-side via S3 UploadPartCopy).
 // It is NOT thread-safe; callers must hold the FileHandle mutex.
 type WriteBuffer struct {
-	path       string
-	totalSize  int64 // current logical file size
-	maxSize    int64
-	partSize   int64
+	path      string
+	totalSize int64 // current logical file size
+	maxSize   int64
+	partSize  int64
 	// smallFileMax is the cutoff for the single-buffer fast path; equals the
 	// server-advertised inline_threshold when known, otherwise the local
 	// default. Stored per-buffer so per-mount values (server overrides,
@@ -73,6 +73,102 @@ type WriteBuffer struct {
 	// When a write would exceed the threshold, the data is migrated to the
 	// regular part map and this field is set to nil.
 	smallFileData []byte
+}
+
+type writeBufferSnapshot struct {
+	path          string
+	totalSize     int64
+	maxSize       int64
+	partSize      int64
+	smallFileMax  int64
+	parts         map[int][]byte
+	dirtyParts    map[int]bool
+	touched       bool
+	LoadPart      LoadPartFunc
+	remoteSize    int64
+	curMemory     int64
+	appendCursor  int64
+	sequential    bool
+	uploadedParts map[int]bool
+	OnPartFull    func(partIdx int, data []byte)
+	smallFileData []byte
+}
+
+func (wb *WriteBuffer) snapshot() *writeBufferSnapshot {
+	if wb == nil {
+		return nil
+	}
+	return &writeBufferSnapshot{
+		path:          wb.path,
+		totalSize:     wb.totalSize,
+		maxSize:       wb.maxSize,
+		partSize:      wb.partSize,
+		smallFileMax:  wb.smallFileMax,
+		parts:         cloneByteMap(wb.parts),
+		dirtyParts:    cloneBoolMap(wb.dirtyParts),
+		touched:       wb.touched,
+		LoadPart:      wb.LoadPart,
+		remoteSize:    wb.remoteSize,
+		curMemory:     wb.curMemory,
+		appendCursor:  wb.appendCursor,
+		sequential:    wb.sequential,
+		uploadedParts: cloneBoolMap(wb.uploadedParts),
+		OnPartFull:    wb.OnPartFull,
+		smallFileData: cloneBytes(wb.smallFileData),
+	}
+}
+
+func (wb *WriteBuffer) restore(snapshot *writeBufferSnapshot) {
+	if wb == nil || snapshot == nil {
+		return
+	}
+	wb.path = snapshot.path
+	wb.totalSize = snapshot.totalSize
+	wb.maxSize = snapshot.maxSize
+	wb.partSize = snapshot.partSize
+	wb.smallFileMax = snapshot.smallFileMax
+	wb.parts = cloneByteMap(snapshot.parts)
+	wb.dirtyParts = cloneBoolMap(snapshot.dirtyParts)
+	wb.touched = snapshot.touched
+	wb.LoadPart = snapshot.LoadPart
+	wb.remoteSize = snapshot.remoteSize
+	wb.curMemory = snapshot.curMemory
+	wb.appendCursor = snapshot.appendCursor
+	wb.sequential = snapshot.sequential
+	wb.uploadedParts = cloneBoolMap(snapshot.uploadedParts)
+	wb.OnPartFull = snapshot.OnPartFull
+	wb.smallFileData = cloneBytes(snapshot.smallFileData)
+}
+
+func cloneByteMap(src map[int][]byte) map[int][]byte {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[int][]byte, len(src))
+	for k, v := range src {
+		dst[k] = cloneBytes(v)
+	}
+	return dst
+}
+
+func cloneBoolMap(src map[int]bool) map[int]bool {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[int]bool, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func cloneBytes(src []byte) []byte {
+	if src == nil {
+		return nil
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
 }
 
 // NewWriteBuffer creates a new WriteBuffer for the given path.

--- a/pkg/fuse/writeback_syncflags_unix_test.go
+++ b/pkg/fuse/writeback_syncflags_unix_test.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package fuse
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestODSyncOpenPromotesCloseSyncToWriteSync(t *testing.T) {
+	opts := &MountOptions{WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+
+	if got := fs.writePolicyForOpen(uint32(syscall.O_DSYNC)); got != WritePolicyWriteSync {
+		t.Errorf("O_DSYNC policy = %v, want write-sync", got)
+	}
+}

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -16,6 +18,8 @@ import (
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/s3client"
 )
 
 func TestWriteBackCache_PutGetRemove(t *testing.T) {
@@ -811,16 +815,16 @@ func TestFlush_CloseSyncUploadsBeforeReturning(t *testing.T) {
 		Fh:       createOut.Fh,
 	})
 	if st != gofuse.OK {
-		t.Fatalf("Flush: %v", st)
+		t.Errorf("Flush: %v", st)
 	}
 	if putCalls.Load() != 1 {
-		t.Fatalf("PUT calls after Flush = %d, want 1", putCalls.Load())
+		t.Errorf("PUT calls after Flush = %d, want 1", putCalls.Load())
 	}
 	if string(uploaded) != "close-sync data" {
-		t.Fatalf("uploaded = %q, want %q", uploaded, "close-sync data")
+		t.Errorf("uploaded = %q, want %q", uploaded, "close-sync data")
 	}
 	if _, ok := cache.Get("/close_sync.txt"); ok {
-		t.Fatal("close-sync Flush should not leave a write-back cache entry")
+		t.Error("close-sync Flush should not leave a write-back cache entry")
 	}
 
 	fs.Release(nil, &gofuse.ReleaseIn{
@@ -829,7 +833,7 @@ func TestFlush_CloseSyncUploadsBeforeReturning(t *testing.T) {
 	})
 	uploader.DrainAll()
 	if putCalls.Load() != 1 {
-		t.Fatalf("PUT calls after Release = %d, want still 1", putCalls.Load())
+		t.Errorf("PUT calls after Release = %d, want still 1", putCalls.Load())
 	}
 }
 
@@ -866,16 +870,16 @@ func TestWriteSyncUploadsBeforeWriteReturns(t *testing.T) {
 		Fh:       createOut.Fh,
 	}, []byte("write-sync data"))
 	if st != gofuse.OK {
-		t.Fatalf("Write: %v", st)
+		t.Errorf("Write: %v", st)
 	}
 	if written != uint32(len("write-sync data")) {
-		t.Fatalf("written = %d, want %d", written, len("write-sync data"))
+		t.Errorf("written = %d, want %d", written, len("write-sync data"))
 	}
 	if putCalls.Load() != 1 {
-		t.Fatalf("PUT calls after Write = %d, want 1", putCalls.Load())
+		t.Errorf("PUT calls after Write = %d, want 1", putCalls.Load())
 	}
 	if string(uploaded) != "write-sync data" {
-		t.Fatalf("uploaded = %q, want %q", uploaded, "write-sync data")
+		t.Errorf("uploaded = %q, want %q", uploaded, "write-sync data")
 	}
 
 	st = fs.Flush(nil, &gofuse.FlushIn{
@@ -883,10 +887,140 @@ func TestWriteSyncUploadsBeforeWriteReturns(t *testing.T) {
 		Fh:       createOut.Fh,
 	})
 	if st != gofuse.OK {
-		t.Fatalf("Flush: %v", st)
+		t.Errorf("Flush: %v", st)
 	}
 	if putCalls.Load() != 1 {
-		t.Fatalf("PUT calls after clean Flush = %d, want still 1", putCalls.Load())
+		t.Errorf("PUT calls after clean Flush = %d, want still 1", putCalls.Load())
+	}
+}
+
+func TestWriteSyncFailureRollsBackDirtyState(t *testing.T) {
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putCalls.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0, WritePolicy: WritePolicyWriteSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "write_sync_fail.txt", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	written, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}, []byte("failed data"))
+	if st == gofuse.OK {
+		t.Fatal("Write status = OK, want remote failure")
+	}
+	if written != 0 {
+		t.Errorf("written = %d, want 0 on write-sync failure", written)
+	}
+
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("created handle not found")
+	}
+	fh.Lock()
+	size := int64(0)
+	if fh.Dirty != nil {
+		size = fh.Dirty.Size()
+	}
+	fh.Unlock()
+	if size != 0 {
+		t.Errorf("dirty buffer size after failed write-sync = %d, want 0", size)
+	}
+
+	st = fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+	if st != gofuse.OK {
+		t.Errorf("Flush after failed write-sync: %v", st)
+	}
+	if putCalls.Load() != 1 {
+		t.Errorf("PUT calls after failed Write + Flush = %d, want 1", putCalls.Load())
+	}
+}
+
+func TestFlushCloseSyncRemoteFailureKeepsDirtyForRetry(t *testing.T) {
+	var putCalls atomic.Int32
+	var fail atomic.Bool
+	fail.Store(true)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putCalls.Add(1)
+			if fail.Load() {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"revision":2}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0, WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "close_sync_retry.txt", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	if _, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}, []byte("retry data")); st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+
+	st = fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+	if st == gofuse.OK {
+		t.Fatal("first Flush status = OK, want remote failure")
+	}
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("created handle not found")
+	}
+	fh.Lock()
+	dirty := fh.Dirty != nil && fh.Dirty.HasDirtyParts()
+	fh.Unlock()
+	if !dirty {
+		t.Fatal("failed close-sync Flush cleared dirty data; want retryable dirty state")
+	}
+
+	fail.Store(false)
+	st = fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+	if st != gofuse.OK {
+		t.Fatalf("second Flush: %v", st)
+	}
+	if putCalls.Load() != 2 {
+		t.Errorf("PUT calls = %d, want 2", putCalls.Load())
 	}
 }
 
@@ -922,7 +1056,7 @@ func TestOSyncOpenPromotesWriteBackToWriteSync(t *testing.T) {
 		t.Fatal("created handle not found")
 	}
 	if fh.WritePolicy != WritePolicyWriteSync {
-		t.Fatalf("handle write policy = %v, want write-sync", fh.WritePolicy)
+		t.Errorf("handle write policy = %v, want write-sync", fh.WritePolicy)
 	}
 	_, st = fs.Write(nil, &gofuse.WriteIn{
 		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
@@ -932,8 +1066,206 @@ func TestOSyncOpenPromotesWriteBackToWriteSync(t *testing.T) {
 		t.Fatalf("Write: %v", st)
 	}
 	if putCalls.Load() != 1 {
-		t.Fatalf("PUT calls after O_SYNC Write = %d, want 1", putCalls.Load())
+		t.Errorf("PUT calls after O_SYNC Write = %d, want 1", putCalls.Load())
 	}
+}
+
+func TestSyncOpenFlagsPromoteCloseSyncToWriteSync(t *testing.T) {
+	opts := &MountOptions{WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+
+	if got := fs.writePolicyForOpen(uint32(syscall.O_SYNC)); got != WritePolicyWriteSync {
+		t.Errorf("O_SYNC policy = %v, want write-sync", got)
+	}
+	if got := fs.writePolicyForOpen(uint32(syscall.O_DSYNC)); got != WritePolicyWriteSync {
+		t.Errorf("O_DSYNC policy = %v, want write-sync", got)
+	}
+}
+
+func TestWriteSyncDisablesStreamingUploaderForLargeSequentialWrites(t *testing.T) {
+	rec := newWriteSyncMultipartRecorder(t, "/stream_sync.bin")
+	opts := &MountOptions{FlushDebounce: 0, WritePolicy: WritePolicyWriteSync}
+	opts.setDefaults()
+	fs := NewDat9FS(rec.client(), opts)
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "stream_sync.bin", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("created handle not found")
+	}
+	if fh.Streamer != nil {
+		t.Fatal("write-sync handle should not attach StreamUploader")
+	}
+
+	chunk := bytesOf('a', int(s3client.PartSize))
+	written, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Offset:   0,
+	}, chunk)
+	if st != gofuse.OK {
+		t.Fatalf("first Write: %v", st)
+	}
+	if written != uint32(len(chunk)) {
+		t.Fatalf("first written = %d, want %d", written, len(chunk))
+	}
+	chunk = bytesOf('b', int(s3client.PartSize))
+	written, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Offset:   uint64(s3client.PartSize),
+	}, chunk)
+	if st != gofuse.OK {
+		t.Fatalf("second Write: %v", st)
+	}
+	if written != uint32(len(chunk)) {
+		t.Fatalf("second written = %d, want %d", written, len(chunk))
+	}
+
+	if got := rec.initiateSizes(); len(got) != 2 || got[0] != int64(s3client.PartSize) || got[1] != 2*int64(s3client.PartSize) {
+		t.Fatalf("initiate sizes = %v, want [%d %d]", got, s3client.PartSize, 2*s3client.PartSize)
+	}
+	if got := rec.completePartCounts(); len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("complete part counts = %v, want [1 2]", got)
+	}
+}
+
+type writeSyncMultipartRecorder struct {
+	t            *testing.T
+	server       *httptest.Server
+	wantPath     string
+	mu           sync.Mutex
+	initiateByID map[string]int64
+	sizes        []int64
+	completes    []int
+}
+
+func newWriteSyncMultipartRecorder(t *testing.T, wantPath string) *writeSyncMultipartRecorder {
+	t.Helper()
+	rec := &writeSyncMultipartRecorder{
+		t:            t,
+		wantPath:     wantPath,
+		initiateByID: make(map[string]int64),
+	}
+	rec.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/initiate":
+			var req struct {
+				Path      string `json:"path"`
+				TotalSize int64  `json:"total_size"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode initiate request: %v", err)
+			}
+			if req.Path != rec.wantPath {
+				t.Fatalf("initiate path = %q, want %q", req.Path, rec.wantPath)
+			}
+			rec.mu.Lock()
+			id := "upload-" + strconv.Itoa(len(rec.sizes)+1)
+			rec.sizes = append(rec.sizes, req.TotalSize)
+			rec.initiateByID[id] = req.TotalSize
+			rec.mu.Unlock()
+			totalParts := int((req.TotalSize + int64(s3client.PartSize) - 1) / int64(s3client.PartSize))
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"upload_id":   id,
+				"key":         "object-key",
+				"part_size":   int64(s3client.PartSize),
+				"total_parts": totalParts,
+			})
+			return
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/uploads/") && strings.HasSuffix(r.URL.Path, "/presign-batch"):
+			id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v2/uploads/"), "/presign-batch")
+			rec.mu.Lock()
+			size := rec.initiateByID[id]
+			rec.mu.Unlock()
+			totalParts := int((size + int64(s3client.PartSize) - 1) / int64(s3client.PartSize))
+			parts := make([]map[string]any, 0, totalParts)
+			for pn := 1; pn <= totalParts; pn++ {
+				partSize := int64(s3client.PartSize)
+				if pn == totalParts && size%int64(s3client.PartSize) != 0 {
+					partSize = size % int64(s3client.PartSize)
+				}
+				parts = append(parts, map[string]any{
+					"number": pn,
+					"url":    rec.server.URL + "/s3/" + id + "/" + strconv.Itoa(pn),
+					"size":   partSize,
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"parts": parts})
+			return
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/uploads/") && strings.HasSuffix(r.URL.Path, "/presign"):
+			id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v2/uploads/"), "/presign")
+			var req struct {
+				PartNumber int `json:"part_number"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode presign request: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number": req.PartNumber,
+				"url":    rec.server.URL + "/s3/" + id + "/" + strconv.Itoa(req.PartNumber),
+				"size":   int64(s3client.PartSize),
+			})
+			return
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/s3/"):
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Fatalf("read s3 body: %v", err)
+			}
+			w.Header().Set("ETag", "etag-1")
+			w.WriteHeader(http.StatusOK)
+			return
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/uploads/") && strings.HasSuffix(r.URL.Path, "/complete"):
+			var req struct {
+				Parts []struct {
+					Number int    `json:"number"`
+					ETag   string `json:"etag"`
+				} `json:"parts"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode complete request: %v", err)
+			}
+			rec.mu.Lock()
+			rec.completes = append(rec.completes, len(req.Parts))
+			rec.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+	}))
+	t.Cleanup(rec.server.Close)
+	return rec
+}
+
+func (rec *writeSyncMultipartRecorder) client() *client.Client {
+	return newTestClient(rec.server.URL)
+}
+
+func (rec *writeSyncMultipartRecorder) initiateSizes() []int64 {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	return append([]int64(nil), rec.sizes...)
+}
+
+func (rec *writeSyncMultipartRecorder) completePartCounts() []int {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	return append([]int(nil), rec.completes...)
+}
+
+func bytesOf(b byte, n int) []byte {
+	data := make([]byte, n)
+	for i := range data {
+		data[i] = b
+	}
+	return data
 }
 
 // TestFlush_WriteBack_Lifecycle tests the full echo "xxx" > file lifecycle

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -760,6 +761,178 @@ func TestFlush_WriteBack_SmallFile(t *testing.T) {
 	// Cache should be cleaned up after successful upload.
 	if _, ok := cache.Get("/wb_test.txt"); ok {
 		t.Fatal("cache entry should be removed after successful upload")
+	}
+}
+
+func TestFlush_CloseSyncUploadsBeforeReturning(t *testing.T) {
+	var putCalls atomic.Int32
+	var uploaded []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putCalls.Add(1)
+			body, _ := io.ReadAll(r.Body)
+			uploaded = append(uploaded[:0], body...)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"revision":1}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	cache, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	uploader := NewWriteBackUploader(newTestClient(ts.URL), cache, 2)
+	opts := &MountOptions{FlushDebounce: 0, WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.SetWriteBack(cache, uploader)
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "close_sync.txt", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	_, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}, []byte("close-sync data"))
+	if st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+
+	st = fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+	if st != gofuse.OK {
+		t.Fatalf("Flush: %v", st)
+	}
+	if putCalls.Load() != 1 {
+		t.Fatalf("PUT calls after Flush = %d, want 1", putCalls.Load())
+	}
+	if string(uploaded) != "close-sync data" {
+		t.Fatalf("uploaded = %q, want %q", uploaded, "close-sync data")
+	}
+	if _, ok := cache.Get("/close_sync.txt"); ok {
+		t.Fatal("close-sync Flush should not leave a write-back cache entry")
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+	uploader.DrainAll()
+	if putCalls.Load() != 1 {
+		t.Fatalf("PUT calls after Release = %d, want still 1", putCalls.Load())
+	}
+}
+
+func TestWriteSyncUploadsBeforeWriteReturns(t *testing.T) {
+	var putCalls atomic.Int32
+	var uploaded []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putCalls.Add(1)
+			body, _ := io.ReadAll(r.Body)
+			uploaded = append(uploaded[:0], body...)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"revision":1}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0, WritePolicy: WritePolicyWriteSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "write_sync.txt", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	written, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}, []byte("write-sync data"))
+	if st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+	if written != uint32(len("write-sync data")) {
+		t.Fatalf("written = %d, want %d", written, len("write-sync data"))
+	}
+	if putCalls.Load() != 1 {
+		t.Fatalf("PUT calls after Write = %d, want 1", putCalls.Load())
+	}
+	if string(uploaded) != "write-sync data" {
+		t.Fatalf("uploaded = %q, want %q", uploaded, "write-sync data")
+	}
+
+	st = fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+	if st != gofuse.OK {
+		t.Fatalf("Flush: %v", st)
+	}
+	if putCalls.Load() != 1 {
+		t.Fatalf("PUT calls after clean Flush = %d, want still 1", putCalls.Load())
+	}
+}
+
+func TestOSyncOpenPromotesWriteBackToWriteSync(t *testing.T) {
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putCalls.Add(1)
+			_, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"revision":1}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_SYNC),
+	}, "osync.txt", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("created handle not found")
+	}
+	if fh.WritePolicy != WritePolicyWriteSync {
+		t.Fatalf("handle write policy = %v, want write-sync", fh.WritePolicy)
+	}
+	_, st = fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}, []byte("osync data"))
+	if st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+	if putCalls.Load() != 1 {
+		t.Fatalf("PUT calls after O_SYNC Write = %d, want 1", putCalls.Load())
 	}
 }
 

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -1134,6 +1134,68 @@ func TestWriteSyncDisablesStreamingUploaderForLargeSequentialWrites(t *testing.T
 	}
 }
 
+func TestWriteSyncCreateWithShadowStoreUploadsWrittenBytes(t *testing.T) {
+	rec := newWriteSyncMultipartRecorder(t, "/shadow_sync.bin")
+	rec.captureParts = true
+
+	opts := &MountOptions{FlushDebounce: 0, WritePolicy: WritePolicyWriteSync}
+	opts.setDefaults()
+	fs := NewDat9FS(rec.client(), opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+	}, "shadow_sync.bin", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("created handle not found")
+	}
+	if fh.ShadowSpill {
+		t.Fatal("write-sync create should not enable ShadowSpill")
+	}
+
+	data := bytesOf('x', int(s3client.PartSize))
+	written, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Offset:   0,
+	}, data)
+	if st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+	if written != uint32(len(data)) {
+		t.Fatalf("written = %d, want %d", written, len(data))
+	}
+
+	bodies := rec.capturedPartBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("captured S3 part bodies = %d, want 1", len(bodies))
+	}
+	if len(bodies[0]) != len(data) {
+		t.Fatalf("captured body len = %d, want %d", len(bodies[0]), len(data))
+	}
+	for i, b := range bodies[0] {
+		if b != 'x' {
+			t.Fatalf("captured body byte %d = %q, want 'x'", i, b)
+		}
+	}
+}
+
 type writeSyncMultipartRecorder struct {
 	t            *testing.T
 	server       *httptest.Server
@@ -1142,6 +1204,8 @@ type writeSyncMultipartRecorder struct {
 	initiateByID map[string]int64
 	sizes        []int64
 	completes    []int
+	captureParts bool
+	partBodies   [][]byte
 }
 
 func newWriteSyncMultipartRecorder(t *testing.T, wantPath string) *writeSyncMultipartRecorder {
@@ -1213,8 +1277,18 @@ func newWriteSyncMultipartRecorder(t *testing.T, wantPath string) *writeSyncMult
 			})
 			return
 		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/s3/"):
-			if _, err := io.Copy(io.Discard, r.Body); err != nil {
-				t.Fatalf("read s3 body: %v", err)
+			if rec.captureParts {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("read s3 body: %v", err)
+				}
+				rec.mu.Lock()
+				rec.partBodies = append(rec.partBodies, body)
+				rec.mu.Unlock()
+			} else {
+				if _, err := io.Copy(io.Discard, r.Body); err != nil {
+					t.Fatalf("read s3 body: %v", err)
+				}
 			}
 			w.Header().Set("ETag", "etag-1")
 			w.WriteHeader(http.StatusOK)
@@ -1255,6 +1329,16 @@ func (rec *writeSyncMultipartRecorder) completePartCounts() []int {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 	return append([]int(nil), rec.completes...)
+}
+
+func (rec *writeSyncMultipartRecorder) capturedPartBodies() [][]byte {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	out := make([][]byte, len(rec.partBodies))
+	for i, body := range rec.partBodies {
+		out[i] = append([]byte(nil), body...)
+	}
+	return out
 }
 
 func bytesOf(b byte, n int) []byte {

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -1078,9 +1078,6 @@ func TestSyncOpenFlagsPromoteCloseSyncToWriteSync(t *testing.T) {
 	if got := fs.writePolicyForOpen(uint32(syscall.O_SYNC)); got != WritePolicyWriteSync {
 		t.Errorf("O_SYNC policy = %v, want write-sync", got)
 	}
-	if got := fs.writePolicyForOpen(uint32(syscall.O_DSYNC)); got != WritePolicyWriteSync {
-		t.Errorf("O_DSYNC policy = %v, want write-sync", got)
-	}
 }
 
 func TestWriteSyncDisablesStreamingUploaderForLargeSequentialWrites(t *testing.T) {


### PR DESCRIPTION
## Summary
- add --write-policy=writeback|close-sync|write-sync for FUSE mounts
- capture the policy per writable handle, including O_SYNC promotion to write-sync
- enforce close-sync through Flush and write-sync through Write while preserving shadow/stream upload paths
- document the design in docs/design/fuse-write-policy.md

## Tests
- go test ./pkg/fuse -run 'TestFlush_CloseSyncUploadsBeforeReturning|TestWriteSyncUploadsBeforeWriteReturns|TestOSyncOpenPromotesWriteBackToWriteSync|TestFlush_WriteBack_SmallFile'
- go test ./pkg/fuse
- go test ./cmd/drive9/cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --write-policy for mounts: writeback (default), close-sync, write-sync.
  * Per-handle write policy: write-sync forces uploads during Write; close-sync forces uploads on Flush/close.
  * Opening with O_SYNC/O_DSYNC promotes a handle to write-sync.
  * WebDAV mounts reject --write-policy (supported only for FUSE).
  * Mount startup now logs the selected write policy.

* **Documentation**
  * Added design doc describing write-policy semantics and tradeoffs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->