### PR TITLE
docs: fix Drive9 copy and rename headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,10 @@ notify storms.
 
 ## HTTP API
 
+Authenticate HTTP API calls with `Authorization: Bearer $DRIVE9_API_KEY`.
+`X-API-Key: $DRIVE9_API_KEY` is accepted for compatibility. Query modifiers are
+presence-based, so `?list` and `?list=1` are equivalent.
+
 Core filesystem endpoints:
 
 ```text
@@ -321,8 +325,8 @@ PATCH  /v1/fs/{path}              patch large file parts
 DELETE /v1/fs/{path}              delete
 DELETE /v1/fs/{path}?recursive    recursive delete
 POST   /v1/fs/{path}?append       append
-POST   /v1/fs/{path}?copy         copy (X-Drive9-Copy-Source)
-POST   /v1/fs/{path}?rename       rename (X-Drive9-Rename-Source)
+POST   /v1/fs/{path}?copy         copy (X-Dat9-Copy-Source)
+POST   /v1/fs/{path}?rename       rename (X-Dat9-Rename-Source)
 POST   /v1/fs/{path}?mkdir        mkdir
 ```
 

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -513,7 +513,7 @@ HEAD   /v1/fs/{path}          Stat  (standard HTTP semantics)
 GET    /v1/fs/{path}?list     List directory
 
 POST   /v1/fs/{path}?copy     Server-side link (zero-copy, same file_id)
-  Header: X-Drive9-Copy-Source: /source/path
+  Header: X-Dat9-Copy-Source: /source/path
 
 POST   /v1/search             Semantic search (vector + FTS + hybrid)
 POST   /v1/query              Metadata query (tags, status, source_id)


### PR DESCRIPTION
## Summary
- document the actual Drive9 copy/rename headers as `X-Dat9-Copy-Source` and `X-Dat9-Rename-Source`
- add the HTTP API auth forms accepted by the server (`Authorization: Bearer` and `X-API-Key`)
- clarify that query modifiers are presence-based (`?list` and `?list=1` are equivalent)

## Verification
- `rg -n "X-Drive9-(Copy|Rename)-Source" README.md docs/design-overview.md docs` returns no stale copy/rename header hits
- `go test ./pkg/server -run 'Test.*(Copy|Rename|Auth|Batch|Revision|Tag|Description)' -count=1`\n\n## Source of truth\n- `pkg/server/server.go` reads `X-Dat9-Copy-Source` in `handleCopy` and `X-Dat9-Rename-Source` in `handleRename`\n- `pkg/server/auth.go` reads `Authorization: Bearer` first, then `X-API-Key` as fallback\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API authentication to use `Authorization: Bearer $DRIVE9_API_KEY` with `X-API-Key` as an alternative option.
  * Clarified list query modifier behavior (presence-based parameters).
  * Updated custom request header names for copy and rename operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->