### PR TITLE
feat(cli): add recursive `drive9 fs cp -r` 

### DIFF
--- a/cmd/drive9/cli/cp.go
+++ b/cmd/drive9/cli/cp.go
@@ -18,6 +18,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// recursiveCopyConcurrency caps the per-leaf transfer parallelism for
+// `drive9 fs cp -r`. Mirrors the existing `pkg/client/transfer/`
+// 16-worker convention so we don't introduce a new tuning knob in
+// this PR.
+const recursiveCopyConcurrency = 16
+
 // Cp copies files between local and remote.
 //
 // Remote paths use ":" or "<name>:" prefix:
@@ -32,6 +38,7 @@ import (
 func Cp(c *client.Client, args []string) error {
 	resume := false
 	appendMode := false
+	recursive := false
 	var tags map[string]string
 	var description string
 	filtered := make([]string, 0, len(args))
@@ -42,6 +49,8 @@ func Cp(c *client.Client, args []string) error {
 			resume = true
 		case a == "--append":
 			appendMode = true
+		case a == "-r" || a == "--recursive":
+			recursive = true
 		case a == "--tag":
 			if i+1 >= len(args) {
 				return fmt.Errorf("--tag requires key=value argument")
@@ -75,7 +84,7 @@ func Cp(c *client.Client, args []string) error {
 	}
 
 	if len(args) != 2 {
-		return fmt.Errorf("usage: drive9 fs cp [--resume] [--append] [--tag key=value]... [--description <text>] <src> <dst>")
+		return fmt.Errorf("usage: drive9 fs cp [-r|--recursive] [--resume] [--append] [--tag key=value]... [--description <text>] <src> <dst>")
 	}
 	if resume && appendMode {
 		return fmt.Errorf("--resume and --append cannot be used together")
@@ -88,6 +97,15 @@ func Cp(c *client.Client, args []string) error {
 	}
 	if resume && description != "" {
 		return fmt.Errorf("--resume and --description cannot be used together")
+	}
+	// -r is intentionally orthogonal to the single-file ergonomics
+	// flags. Tree copy doesn't compose with --append (per-file
+	// append semantics ambiguous), --resume (resume is single-file
+	// multipart upload state, not tree-level), or single-file
+	// description/tags (those apply to one upload only). Reject up
+	// front instead of silently picking which file gets the metadata.
+	if recursive && (appendMode || resume || description != "" || len(tags) > 0) {
+		return fmt.Errorf("-r/--recursive cannot be combined with --append, --resume, --tag, or --description")
 	}
 	src, dst := args[0], args[1]
 
@@ -112,6 +130,25 @@ func Cp(c *client.Client, args []string) error {
 	}
 
 	ctx := context.Background()
+
+	// Recursive tree copy. Stdin/stdout sources have no meaningful
+	// recursive semantics; reject up front rather than silently fall
+	// back to the single-file paths below.
+	if recursive {
+		if src == "-" || dst == "-" {
+			return fmt.Errorf("-r/--recursive does not support stdin/stdout endpoints")
+		}
+		switch {
+		case !srcIsRemote && dstIsRemote:
+			return copyTreeLocalToRemote(ctx, c, src, dstRP.Path)
+		case srcIsRemote && !dstIsRemote:
+			return copyTreeRemoteToLocal(ctx, c, srcRP.Path, dst)
+		case srcIsRemote && dstIsRemote:
+			return copyTreeRemoteToRemote(ctx, c, srcRP.Path, dstRP.Path)
+		default:
+			return fmt.Errorf("-r/--recursive requires at least one remote path")
+		}
+	}
 
 	switch {
 	case src == "-" && dstIsRemote:

--- a/cmd/drive9/cli/cp_recursive.go
+++ b/cmd/drive9/cli/cp_recursive.go
@@ -1,0 +1,498 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+// cp_recursive.go implements `drive9 fs cp -r <src> <dst>` (P0 task #58
+// per the db9-drive9 gap analysis). Lives next to cp.go so the
+// single-file ergonomics flags and the tree-copy paths share parsing
+// + error vocabulary.
+//
+// Design (locked in #drive9:72bf030c thread):
+//   - Pure client-side: server primitives stay file-level (handleCopy,
+//     WriteStreamWithSummary, DownloadToFileWithSummary, Mkdir).
+//     Tree walk + concurrency happen on the client.
+//   - Destination semantics: dst is treated as the directory that
+//     receives the source's CONTENTS. If dst doesn't exist it is
+//     created as a directory. Existing file at dst is rejected. No
+//     auto-create-dst/basename(src) variant in this PR (per
+//     @adversary-1 review constraint msg 72d6eb06).
+//   - Symlinks: explicit reject, not silent follow/skip. Per
+//     @adversary-1 msg b8603b41.
+//   - Preflight: BatchStat every destination path (files AND dirs) up
+//     front; if any exists, abort before any transfer. Runtime
+//     failures during transfer surface back as errgroup error;
+//     siblings continue but the overall return is non-nil.
+//   - Path safety: joinRemoteSafe rejects "..", duplicate slashes,
+//     ensures every leaf path stays under the destination root.
+//   - Bounded concurrency: recursiveCopyConcurrency = 16, mirroring
+//     pkg/client/transfer/ existing 16-worker convention.
+
+// copyTreeLocalToRemote uploads a local directory tree to a remote
+// destination. Existing files/dirs at the destination cause preflight
+// failure; symlinks in the source tree cause walk-time failure.
+func copyTreeLocalToRemote(ctx context.Context, c *client.Client, srcLocal, dstRemote string) error {
+	// Source must exist and must be a directory.
+	srcInfo, err := os.Lstat(srcLocal)
+	if err != nil {
+		return fmt.Errorf("stat source %q: %w", srcLocal, err)
+	}
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("recursive copy does not support symlinks yet (source: %s)", srcLocal)
+	}
+	if !srcInfo.IsDir() {
+		return fmt.Errorf("-r/--recursive requires a directory source; %q is a file (use `drive9 fs cp` without -r)", srcLocal)
+	}
+
+	// Walk local tree collecting dirs + files. filepath.Walk uses
+	// Lstat so we detect symlinks here and refuse them, rather than
+	// silently following or skipping (per design lock #2).
+	var (
+		dirs  []string // remote paths to create
+		files []localFileEntry
+	)
+	walkErr := filepath.Walk(srcLocal, func(localPath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			rel, _ := filepath.Rel(srcLocal, localPath)
+			return fmt.Errorf("recursive copy does not support symlinks yet (path: %s)", rel)
+		}
+		rel, relErr := filepath.Rel(srcLocal, localPath)
+		if relErr != nil {
+			return fmt.Errorf("rel %q: %w", localPath, relErr)
+		}
+		// Skip the source root itself; we don't create the root dir
+		// at dst, we treat dst as the root (per destination semantic
+		// lock #1).
+		if rel == "." {
+			return nil
+		}
+		remotePath, joinErr := joinRemoteSafe(dstRemote, rel)
+		if joinErr != nil {
+			return joinErr
+		}
+		if info.IsDir() {
+			dirs = append(dirs, remotePath)
+			return nil
+		}
+		files = append(files, localFileEntry{
+			localPath:  localPath,
+			remotePath: remotePath,
+			size:       info.Size(),
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+
+	// Preflight: batch-stat every destination path (dirs AND files).
+	// If any destination exists, abort before any transfer (per #3
+	// refined by @adversary-1 msg 72d6eb06).
+	allDests := make([]string, 0, len(dirs)+len(files)+1)
+	allDests = append(allDests, dstRemote)
+	allDests = append(allDests, dirs...)
+	for _, f := range files {
+		allDests = append(allDests, f.remotePath)
+	}
+	if err := preflightDestinations(ctx, c, allDests); err != nil {
+		return err
+	}
+
+	// Create dst root + intermediate dirs in path-length ASC order
+	// (parent before child). Empty dirs are preserved via this
+	// explicit Mkdir, per design lock #5.
+	if err := mkdirRemoteTree(ctx, c, dstRemote, dirs); err != nil {
+		return err
+	}
+
+	// Upload files with bounded parallelism. Per-leaf failure surfaces
+	// back via the failure collector; sibling transfers keep going so
+	// "partial failure" semantics match @adversary-1 #3 runtime rule.
+	return parallelTransfer(ctx, files, func(ctx context.Context, e localFileEntry) error {
+		return uploadOneFile(ctx, c, e.localPath, e.remotePath, e.size)
+	})
+}
+
+// copyTreeRemoteToLocal downloads a remote directory tree to a local
+// destination. Mirrors copyTreeLocalToRemote: dst is the directory
+// that will hold src's CONTENTS.
+func copyTreeRemoteToLocal(ctx context.Context, c *client.Client, srcRemote, dstLocal string) error {
+	// Source must exist and be a directory.
+	srcInfo, err := c.StatCtx(ctx, srcRemote)
+	if err != nil {
+		return fmt.Errorf("stat remote source %q: %w", srcRemote, err)
+	}
+	if !srcInfo.IsDir {
+		return fmt.Errorf("-r/--recursive requires a directory source; %q is a file (use `drive9 fs cp` without -r)", srcRemote)
+	}
+
+	// Destination preflight (local side): dst exists as dir → ok;
+	// dst doesn't exist → create; dst exists as file → reject.
+	dstInfo, err := os.Stat(dstLocal)
+	switch {
+	case err == nil && !dstInfo.IsDir():
+		return fmt.Errorf("local destination %q exists and is not a directory", dstLocal)
+	case err == nil && dstInfo.IsDir():
+		// Existing local dir is fine; we'll create children inside.
+		// (Local recursive copy is less strict than remote because
+		// local already-existing dirs are normal Unix behavior.)
+	case errors.Is(err, os.ErrNotExist):
+		if mkErr := os.MkdirAll(dstLocal, 0o755); mkErr != nil {
+			return fmt.Errorf("create local destination %q: %w", dstLocal, mkErr)
+		}
+	default:
+		return fmt.Errorf("stat local destination %q: %w", dstLocal, err)
+	}
+
+	// Walk remote tree via ListCtx BFS, collecting dirs + files.
+	var (
+		dirs  []remoteDirEntry  // relative paths to mkdir locally
+		files []remoteFileEntry // relative paths to download
+	)
+	walkErr := walkRemoteTreeBFS(ctx, c, srcRemote, func(rel string, info client.FileInfo) error {
+		if info.IsDir {
+			dirs = append(dirs, remoteDirEntry{rel: rel})
+			return nil
+		}
+		files = append(files, remoteFileEntry{
+			remotePath: pathpkg.Join(srcRemote, rel),
+			rel:        rel,
+			size:       info.Size,
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+
+	// Create local dirs in parent-before-child order.
+	sort.Slice(dirs, func(i, j int) bool {
+		return len(dirs[i].rel) < len(dirs[j].rel)
+	})
+	for _, d := range dirs {
+		localDir := filepath.Join(dstLocal, filepath.FromSlash(d.rel))
+		if err := os.MkdirAll(localDir, 0o755); err != nil {
+			return fmt.Errorf("mkdir local %q: %w", localDir, err)
+		}
+	}
+
+	return parallelTransfer(ctx, files, func(ctx context.Context, e remoteFileEntry) error {
+		localPath := filepath.Join(dstLocal, filepath.FromSlash(e.rel))
+		return downloadOneFile(ctx, c, e.remotePath, localPath, e.size)
+	})
+}
+
+// copyTreeRemoteToRemote performs a remote→remote tree copy. Each leaf
+// uses server-side zero-copy via Client.Copy (same backend, file_id
+// alias), so we never round-trip file bytes through the client.
+// Directories are recreated via MkdirCtx because server-side Copy is
+// file-level only.
+func copyTreeRemoteToRemote(ctx context.Context, c *client.Client, srcRemote, dstRemote string) error {
+	srcInfo, err := c.StatCtx(ctx, srcRemote)
+	if err != nil {
+		return fmt.Errorf("stat remote source %q: %w", srcRemote, err)
+	}
+	if !srcInfo.IsDir {
+		return fmt.Errorf("-r/--recursive requires a directory source; %q is a file (use `drive9 fs cp` without -r)", srcRemote)
+	}
+
+	var (
+		dirs  []string             // remote dst dirs to create
+		files []remoteCopyPlanItem // src+dst pairs
+	)
+	walkErr := walkRemoteTreeBFS(ctx, c, srcRemote, func(rel string, info client.FileInfo) error {
+		dstPath, joinErr := joinRemoteSafe(dstRemote, rel)
+		if joinErr != nil {
+			return joinErr
+		}
+		if info.IsDir {
+			dirs = append(dirs, dstPath)
+			return nil
+		}
+		files = append(files, remoteCopyPlanItem{
+			srcPath: pathpkg.Join(srcRemote, rel),
+			dstPath: dstPath,
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+
+	// Preflight: dst root + every dir + every file must NOT exist.
+	allDests := make([]string, 0, len(dirs)+len(files)+1)
+	allDests = append(allDests, dstRemote)
+	allDests = append(allDests, dirs...)
+	for _, f := range files {
+		allDests = append(allDests, f.dstPath)
+	}
+	if err := preflightDestinations(ctx, c, allDests); err != nil {
+		return err
+	}
+
+	if err := mkdirRemoteTree(ctx, c, dstRemote, dirs); err != nil {
+		return err
+	}
+
+	return parallelTransfer(ctx, files, func(ctx context.Context, item remoteCopyPlanItem) error {
+		// Client.Copy is metadata-only server-side zero-copy; no
+		// content round-trip. We don't need to pass ctx because the
+		// non-Ctx variant is what's exposed today; if cancellation
+		// support is added later this is the seam.
+		return c.Copy(item.srcPath, item.dstPath)
+	})
+}
+
+// joinRemoteSafe joins a remote base with a slash-or-platform-relative
+// segment, rejecting anything that would escape the base (`..`,
+// absolute segments, duplicate slashes that would let `:/foo` match
+// `:/foobar`-style boundary leaks). Returns a forward-slash remote
+// path suitable for the drive9 server API.
+func joinRemoteSafe(base, rel string) (string, error) {
+	relSlash := filepath.ToSlash(rel)
+	if relSlash == "" || relSlash == "." {
+		return base, nil
+	}
+	// Reject absolute children — relative is required by definition.
+	if strings.HasPrefix(relSlash, "/") {
+		return "", fmt.Errorf("relative segment must not start with /: %q", relSlash)
+	}
+	// Reject `..` anywhere in the relative segments. We can't trust
+	// pathpkg.Clean to eliminate `..` (it would resolve them away,
+	// potentially escaping base if the rel is `../sibling`).
+	for _, seg := range strings.Split(relSlash, "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("relative segment must not contain ..: %q", relSlash)
+		}
+	}
+	// Normalize duplicate slashes / dots via pathpkg.Clean on the
+	// concatenated path; base is already canonical at this point.
+	cleanBase := strings.TrimSuffix(base, "/")
+	joined := pathpkg.Clean(cleanBase + "/" + relSlash)
+	// Final boundary check: result must still be inside the base.
+	// `pathpkg.Clean` cannot escape because we already rejected ".."
+	// above, but be explicit so future refactors don't drift.
+	if cleanBase != "" && !strings.HasPrefix(joined, cleanBase+"/") && joined != cleanBase {
+		return "", fmt.Errorf("computed path %q escapes base %q", joined, base)
+	}
+	return joined, nil
+}
+
+// preflightDestinations stats every destination path in batches of
+// MaxBatchStatPaths (256) and fails if any exists. Catches both
+// file and directory conflicts before any transfer/mkdir.
+func preflightDestinations(ctx context.Context, c *client.Client, paths []string) error {
+	// Dedupe — multiple dirs may share parent paths via Mkdir's
+	// behavior, and the dst root appears once explicitly.
+	seen := make(map[string]struct{}, len(paths))
+	unique := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		unique = append(unique, p)
+	}
+
+	const batchSize = client.MaxBatchStatPaths // 256
+	for start := 0; start < len(unique); start += batchSize {
+		end := start + batchSize
+		if end > len(unique) {
+			end = len(unique)
+		}
+		results, err := c.BatchStatCtx(ctx, unique[start:end])
+		if err != nil {
+			return fmt.Errorf("preflight batch stat: %w", err)
+		}
+		for _, r := range results {
+			// BatchStatResult.Status mirrors the per-path HTTP code:
+			// 200 = exists, 404 = missing. Any 2xx is a conflict for
+			// recursive copy; anything else (5xx, etc.) is surfaced
+			// as a preflight failure so we don't silently proceed.
+			switch {
+			case r.Status == 404:
+				continue
+			case r.Status >= 200 && r.Status < 300:
+				return fmt.Errorf("destination %q already exists; recursive copy refuses to overwrite", r.Path)
+			default:
+				return fmt.Errorf("preflight stat %q failed (status %d): %s", r.Path, r.Status, r.Error)
+			}
+		}
+	}
+	return nil
+}
+
+// mkdirRemoteTree creates the destination root and all intermediate
+// dirs in path-length ASC order so parents land before children. Per
+// design lock #5.
+func mkdirRemoteTree(ctx context.Context, c *client.Client, root string, dirs []string) error {
+	// Build full list including root, dedupe, sort by path length so
+	// parents precede children.
+	all := append([]string{root}, dirs...)
+	seen := make(map[string]struct{}, len(all))
+	unique := make([]string, 0, len(all))
+	for _, d := range all {
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		unique = append(unique, d)
+	}
+	sort.Slice(unique, func(i, j int) bool {
+		return len(unique[i]) < len(unique[j])
+	})
+	for _, d := range unique {
+		if err := c.MkdirCtx(ctx, d, 0o755); err != nil {
+			return fmt.Errorf("mkdir %q: %w", d, err)
+		}
+	}
+	return nil
+}
+
+// walkRemoteTreeBFS walks a remote directory tree breadth-first via
+// Client.ListCtx, invoking visit(rel, info) for every entry (dirs and
+// files) under root. `rel` is the slash-separated path relative to
+// root; root itself is not visited. Per the @adversary-1 lane 2 facts
+// (msg a15bc453) the BFS is fully client-driven because the drive9
+// server has no recursive readdir primitive.
+func walkRemoteTreeBFS(ctx context.Context, c *client.Client, root string, visit func(rel string, info client.FileInfo) error) error {
+	queue := []string{""} // relative paths to expand; "" = root
+	for len(queue) > 0 {
+		rel := queue[0]
+		queue = queue[1:]
+
+		absDir := root
+		if rel != "" {
+			absDir = pathpkg.Join(root, rel)
+		}
+		entries, err := c.ListCtx(ctx, absDir)
+		if err != nil {
+			return fmt.Errorf("list %q: %w", absDir, err)
+		}
+		for _, e := range entries {
+			childRel := e.Name
+			if rel != "" {
+				childRel = rel + "/" + e.Name
+			}
+			if err := visit(childRel, e); err != nil {
+				return err
+			}
+			if e.IsDir {
+				queue = append(queue, childRel)
+			}
+		}
+	}
+	return nil
+}
+
+// uploadOneFile streams a single local file to the remote destination.
+// Wraps WriteStreamWithSummary so per-leaf transfer reuses the
+// existing multipart upload path.
+func uploadOneFile(ctx context.Context, c *client.Client, localPath, remotePath string, size int64) error {
+	f, err := os.Open(localPath)
+	if err != nil {
+		return fmt.Errorf("open %q: %w", localPath, err)
+	}
+	defer func() { _ = f.Close() }()
+	// Recursive copy doesn't pipe per-leaf progress to the CLI
+	// stderr — the bounded parallelism makes the part counters
+	// interleave unreadably. Future ergonomics PR can add a tree
+	// progress bar.
+	_, err = c.WriteStreamWithSummary(ctx, remotePath, f, size, nil)
+	return err
+}
+
+// downloadOneFile fetches a single remote file to the given local
+// path. Wraps DownloadToFileWithSummary for the same reason as
+// uploadOneFile.
+func downloadOneFile(ctx context.Context, c *client.Client, remotePath, localPath string, size int64) error {
+	_, err := c.DownloadToFileWithSummary(ctx, remotePath, localPath, size)
+	return err
+}
+
+// parallelTransfer runs `op(ctx, item)` for every item in `items` with
+// bounded parallelism (recursiveCopyConcurrency). Failures are
+// collected; the first error is returned along with a count summary.
+// Concurrent calls are cancelled when the context is cancelled, but
+// sibling transfers are NOT cancelled when a single leaf fails — this
+// matches the @adversary-1 #3 runtime rule (siblings continue after
+// per-leaf runtime failure).
+func parallelTransfer[T any](ctx context.Context, items []T, op func(context.Context, T) error) error {
+	if len(items) == 0 {
+		return nil
+	}
+	sem := make(chan struct{}, recursiveCopyConcurrency)
+	var (
+		wg         sync.WaitGroup
+		failuresMu sync.Mutex
+		failures   []error
+	)
+	for _, item := range items {
+		// Honor cancellation: stop launching new transfers if ctx
+		// has been cancelled.
+		select {
+		case <-ctx.Done():
+			failuresMu.Lock()
+			failures = append(failures, ctx.Err())
+			failuresMu.Unlock()
+			break
+		default:
+		}
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(item T) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if err := op(ctx, item); err != nil {
+				failuresMu.Lock()
+				failures = append(failures, err)
+				failuresMu.Unlock()
+			}
+		}(item)
+	}
+	wg.Wait()
+	if len(failures) == 0 {
+		return nil
+	}
+	if len(failures) == 1 {
+		return failures[0]
+	}
+	return fmt.Errorf("%d transfers failed (first: %v)", len(failures), failures[0])
+}
+
+// ── plan types ────────────────────────────────────────────────────────
+
+type localFileEntry struct {
+	localPath  string
+	remotePath string
+	size       int64
+}
+
+type remoteFileEntry struct {
+	remotePath string // absolute remote path of the source file
+	rel        string // path relative to source root, slash-separated
+	size       int64
+}
+
+type remoteDirEntry struct {
+	rel string
+}
+
+type remoteCopyPlanItem struct {
+	srcPath string
+	dstPath string
+}

--- a/cmd/drive9/cli/cp_recursive.go
+++ b/cmd/drive9/cli/cp_recursive.go
@@ -99,11 +99,30 @@ func copyTreeLocalToRemote(ctx context.Context, c *client.Client, srcLocal, dstR
 		return walkErr
 	}
 
-	// Preflight: batch-stat every destination path (dirs AND files).
-	// If any destination exists, abort before any transfer (per #3
-	// refined by @adversary-1 msg 72d6eb06).
-	allDests := make([]string, 0, len(dirs)+len(files)+1)
-	allDests = append(allDests, dstRemote)
+	// Destination root semantics (locked in #drive9:72bf030c thread
+	// review msgs 72d6eb06 + 5f25d0a0):
+	//   - dst doesn't exist        → create it, copy contents into dst/
+	//   - dst exists as directory  → accept, copy contents into dst/
+	//   - dst exists as a file     → reject (refuse to overwrite a file
+	//                                with a directory tree)
+	// Only DESCENDANT paths participate in the conflict-preflight; the
+	// dst root itself is handled separately above so the common case
+	// ("agent A wants to drop its scratch tree into an already-created
+	// agent-B workspace dir") works.
+	dstExists, dstIsDir, err := remotePathStatus(ctx, c, dstRemote)
+	if err != nil {
+		return err
+	}
+	if dstExists && !dstIsDir {
+		return fmt.Errorf("remote destination %q exists and is not a directory", dstRemote)
+	}
+
+	// Preflight DESCENDANT destinations only. If dst-exists-as-dir, the
+	// dst root is not in the conflict set (we explicitly allow merging
+	// the source tree into the existing dst dir). Any descendant
+	// conflict still aborts before any transfer, matching @adversary-1
+	// #3 preflight rule.
+	allDests := make([]string, 0, len(dirs)+len(files))
 	allDests = append(allDests, dirs...)
 	for _, f := range files {
 		allDests = append(allDests, f.remotePath)
@@ -112,10 +131,15 @@ func copyTreeLocalToRemote(ctx context.Context, c *client.Client, srcLocal, dstR
 		return err
 	}
 
-	// Create dst root + intermediate dirs in path-length ASC order
-	// (parent before child). Empty dirs are preserved via this
-	// explicit Mkdir, per design lock #5.
-	if err := mkdirRemoteTree(ctx, c, dstRemote, dirs); err != nil {
+	// Create intermediate dirs in path-length ASC order (parent before
+	// child). Empty dirs are preserved via explicit Mkdir per design
+	// lock #5. Skip mkdir on dst root if it already exists; we only
+	// need to ensure descendant dirs are present.
+	mkdirRoots := dirs
+	if !dstExists {
+		mkdirRoots = append([]string{dstRemote}, dirs...)
+	}
+	if err := mkdirRemoteTree(ctx, c, mkdirRoots); err != nil {
 		return err
 	}
 
@@ -130,6 +154,18 @@ func copyTreeLocalToRemote(ctx context.Context, c *client.Client, srcLocal, dstR
 // copyTreeRemoteToLocal downloads a remote directory tree to a local
 // destination. Mirrors copyTreeLocalToRemote: dst is the directory
 // that will hold src's CONTENTS.
+//
+// Destination semantics (locked, identical to local→remote and
+// remote→remote, per @adversary-1 secondary review msg c7eb6852):
+//   - dst doesn't exist       → create it, copy contents into dst/
+//   - dst exists as directory → accept, copy contents into dst/
+//   - dst exists as a file    → reject
+//
+// Descendant preflight: any pre-existing path inside dst/ is a
+// conflict and aborts BEFORE any os.MkdirAll or download (no
+// `-f`/overwrite in P0). This protects against the
+// `os.Create(localPath)` truncation surface that
+// DownloadToFileWithSummary opens up.
 func copyTreeRemoteToLocal(ctx context.Context, c *client.Client, srcRemote, dstLocal string) error {
 	// Source must exist and be a directory.
 	srcInfo, err := c.StatCtx(ctx, srcRemote)
@@ -140,25 +176,9 @@ func copyTreeRemoteToLocal(ctx context.Context, c *client.Client, srcRemote, dst
 		return fmt.Errorf("-r/--recursive requires a directory source; %q is a file (use `drive9 fs cp` without -r)", srcRemote)
 	}
 
-	// Destination preflight (local side): dst exists as dir → ok;
-	// dst doesn't exist → create; dst exists as file → reject.
-	dstInfo, err := os.Stat(dstLocal)
-	switch {
-	case err == nil && !dstInfo.IsDir():
-		return fmt.Errorf("local destination %q exists and is not a directory", dstLocal)
-	case err == nil && dstInfo.IsDir():
-		// Existing local dir is fine; we'll create children inside.
-		// (Local recursive copy is less strict than remote because
-		// local already-existing dirs are normal Unix behavior.)
-	case errors.Is(err, os.ErrNotExist):
-		if mkErr := os.MkdirAll(dstLocal, 0o755); mkErr != nil {
-			return fmt.Errorf("create local destination %q: %w", dstLocal, mkErr)
-		}
-	default:
-		return fmt.Errorf("stat local destination %q: %w", dstLocal, err)
-	}
-
-	// Walk remote tree via ListCtx BFS, collecting dirs + files.
+	// Walk remote tree via ListCtx BFS, collecting dirs + files. The
+	// walk runs BEFORE we touch the local filesystem so a malformed
+	// list response or transport error can't leave a partial dst dir.
 	var (
 		dirs  []remoteDirEntry  // relative paths to mkdir locally
 		files []remoteFileEntry // relative paths to download
@@ -179,20 +199,73 @@ func copyTreeRemoteToLocal(ctx context.Context, c *client.Client, srcRemote, dst
 		return walkErr
 	}
 
-	// Create local dirs in parent-before-child order.
-	sort.Slice(dirs, func(i, j int) bool {
-		return len(dirs[i].rel) < len(dirs[j].rel)
-	})
+	// Pre-resolve every local destination path using joinLocalSafe so
+	// a malicious/malformed remote name (e.g. "../escape.txt") cannot
+	// escape dstLocal. Done as a separate pass so we fail fast before
+	// any filesystem mutation.
+	dstFiles := make([]localDownloadEntry, len(files))
+	for i, f := range files {
+		localPath, joinErr := joinLocalSafe(dstLocal, f.rel)
+		if joinErr != nil {
+			return joinErr
+		}
+		dstFiles[i] = localDownloadEntry{
+			remotePath: f.remotePath,
+			localPath:  localPath,
+			size:       f.size,
+		}
+	}
+	dstDirs := make([]string, 0, len(dirs))
 	for _, d := range dirs {
-		localDir := filepath.Join(dstLocal, filepath.FromSlash(d.rel))
-		if err := os.MkdirAll(localDir, 0o755); err != nil {
-			return fmt.Errorf("mkdir local %q: %w", localDir, err)
+		localDir, joinErr := joinLocalSafe(dstLocal, d.rel)
+		if joinErr != nil {
+			return joinErr
+		}
+		dstDirs = append(dstDirs, localDir)
+	}
+
+	// Destination root preflight (local side).
+	dstInfo, statErr := os.Stat(dstLocal)
+	dstExists := statErr == nil
+	switch {
+	case dstExists && !dstInfo.IsDir():
+		return fmt.Errorf("local destination %q exists and is not a directory", dstLocal)
+	case dstExists && dstInfo.IsDir():
+		// Accept-as-dir; do NOT recreate. Descendant preflight below
+		// catches per-leaf conflicts.
+	case errors.Is(statErr, os.ErrNotExist):
+		// Will create after descendant preflight passes.
+	default:
+		return fmt.Errorf("stat local destination %q: %w", dstLocal, statErr)
+	}
+
+	// Descendant preflight: any pre-existing dir/file under dstLocal
+	// is a conflict. Mirrors remote-dst preflight; descendants of an
+	// accepted dst-as-dir still must not collide.
+	if err := preflightLocalDestinations(append(append([]string{}, dstDirs...), localDownloadPaths(dstFiles)...)); err != nil {
+		return err
+	}
+
+	// Now that preflight passed, create dst root if needed.
+	if !dstExists {
+		if mkErr := os.MkdirAll(dstLocal, 0o755); mkErr != nil {
+			return fmt.Errorf("create local destination %q: %w", dstLocal, mkErr)
 		}
 	}
 
-	return parallelTransfer(ctx, files, func(ctx context.Context, e remoteFileEntry) error {
-		localPath := filepath.Join(dstLocal, filepath.FromSlash(e.rel))
-		return downloadOneFile(ctx, c, e.remotePath, localPath, e.size)
+	// Create descendant dirs in parent-before-child order. Empty dirs
+	// are preserved.
+	sort.Slice(dstDirs, func(i, j int) bool {
+		return len(dstDirs[i]) < len(dstDirs[j])
+	})
+	for _, d := range dstDirs {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			return fmt.Errorf("mkdir local %q: %w", d, err)
+		}
+	}
+
+	return parallelTransfer(ctx, dstFiles, func(ctx context.Context, e localDownloadEntry) error {
+		return downloadOneFile(ctx, c, e.remotePath, e.localPath, e.size)
 	})
 }
 
@@ -233,9 +306,21 @@ func copyTreeRemoteToRemote(ctx context.Context, c *client.Client, srcRemote, ds
 		return walkErr
 	}
 
-	// Preflight: dst root + every dir + every file must NOT exist.
-	allDests := make([]string, 0, len(dirs)+len(files)+1)
-	allDests = append(allDests, dstRemote)
+	// Destination root semantics (same as local→remote path):
+	//   - dst doesn't exist        → create it, copy contents into dst/
+	//   - dst exists as directory  → accept, copy contents into dst/
+	//   - dst exists as a file     → reject
+	dstExists, dstIsDir, err := remotePathStatus(ctx, c, dstRemote)
+	if err != nil {
+		return err
+	}
+	if dstExists && !dstIsDir {
+		return fmt.Errorf("remote destination %q exists and is not a directory", dstRemote)
+	}
+
+	// Preflight descendants only; dst root is allowed to pre-exist
+	// as a directory.
+	allDests := make([]string, 0, len(dirs)+len(files))
 	allDests = append(allDests, dirs...)
 	for _, f := range files {
 		allDests = append(allDests, f.dstPath)
@@ -244,24 +329,29 @@ func copyTreeRemoteToRemote(ctx context.Context, c *client.Client, srcRemote, ds
 		return err
 	}
 
-	if err := mkdirRemoteTree(ctx, c, dstRemote, dirs); err != nil {
+	mkdirRoots := dirs
+	if !dstExists {
+		mkdirRoots = append([]string{dstRemote}, dirs...)
+	}
+	if err := mkdirRemoteTree(ctx, c, mkdirRoots); err != nil {
 		return err
 	}
 
 	return parallelTransfer(ctx, files, func(ctx context.Context, item remoteCopyPlanItem) error {
-		// Client.Copy is metadata-only server-side zero-copy; no
-		// content round-trip. We don't need to pass ctx because the
-		// non-Ctx variant is what's exposed today; if cancellation
-		// support is added later this is the seam.
-		return c.Copy(item.srcPath, item.dstPath)
+		// Client.CopyCtx is metadata-only server-side zero-copy with
+		// context support added in this PR (see pkg/client/client.go),
+		// so r→r honors Ctrl+C just like the local↔remote paths.
+		return c.CopyCtx(ctx, item.srcPath, item.dstPath)
 	})
 }
 
 // joinRemoteSafe joins a remote base with a slash-or-platform-relative
 // segment, rejecting anything that would escape the base (`..`,
-// absolute segments, duplicate slashes that would let `:/foo` match
-// `:/foobar`-style boundary leaks). Returns a forward-slash remote
-// path suitable for the drive9 server API.
+// absolute segments). Duplicate / redundant slashes inside `rel` are
+// normalized by path.Clean rather than rejected — that is intentional;
+// the contract is "result must be inside base", not "rel must be
+// canonical". Returns a forward-slash remote path suitable for the
+// drive9 server API.
 func joinRemoteSafe(base, rel string) (string, error) {
 	relSlash := filepath.ToSlash(rel)
 	if relSlash == "" || relSlash == "." {
@@ -290,6 +380,77 @@ func joinRemoteSafe(base, rel string) (string, error) {
 		return "", fmt.Errorf("computed path %q escapes base %q", joined, base)
 	}
 	return joined, nil
+}
+
+// joinLocalSafe is the local-filesystem counterpart of joinRemoteSafe.
+// It accepts a slash-separated relative path (as produced by the
+// remote BFS) and returns the corresponding absolute local path, but
+// only if that path stays under `base`. Absolute rels, "..", and
+// post-Clean escapes are all rejected.
+//
+// The remote→local copy direction needs this because `rel` originates
+// from server-supplied directory listings: a misbehaving or compromised
+// server could return entry names like "../etc/passwd" and naively
+// `filepath.Join(dstLocal, ...)` would write outside dstLocal.
+func joinLocalSafe(base, rel string) (string, error) {
+	relSlash := filepath.ToSlash(rel)
+	if relSlash == "" || relSlash == "." {
+		return base, nil
+	}
+	if strings.HasPrefix(relSlash, "/") {
+		return "", fmt.Errorf("relative segment must not start with /: %q", relSlash)
+	}
+	for _, seg := range strings.Split(relSlash, "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("relative segment must not contain ..: %q", relSlash)
+		}
+	}
+	// Build the local path using filepath semantics. Resolve to a
+	// canonical form and then verify it still has `base` as a prefix.
+	joined := filepath.Join(base, filepath.FromSlash(relSlash))
+	// Re-canonicalize base the same way Join would so the prefix
+	// comparison is apples-to-apples on platforms that normalize
+	// (e.g. trailing-slash on POSIX is dropped by Clean).
+	cleanBase := filepath.Clean(base)
+	if cleanBase != "" && !strings.HasPrefix(joined, cleanBase+string(filepath.Separator)) && joined != cleanBase {
+		return "", fmt.Errorf("computed path %q escapes base %q", joined, base)
+	}
+	return joined, nil
+}
+
+// preflightLocalDestinations checks every local destination path with
+// os.Lstat (Lstat not Stat, so a pre-existing symlink also counts as
+// a conflict — we don't want to follow a symlink into someone else's
+// directory). Any path that exists aborts the copy before any
+// MkdirAll/download.
+func preflightLocalDestinations(paths []string) error {
+	seen := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		_, err := os.Lstat(p)
+		switch {
+		case err == nil:
+			return fmt.Errorf("local destination %q already exists; recursive copy refuses to overwrite", p)
+		case errors.Is(err, os.ErrNotExist):
+			continue
+		default:
+			return fmt.Errorf("preflight stat local %q: %w", p, err)
+		}
+	}
+	return nil
+}
+
+// localDownloadPaths extracts just the local destination paths from a
+// slice of localDownloadEntry. Convenience for preflight calls.
+func localDownloadPaths(entries []localDownloadEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.localPath
+	}
+	return out
 }
 
 // preflightDestinations stats every destination path in batches of
@@ -336,16 +497,14 @@ func preflightDestinations(ctx context.Context, c *client.Client, paths []string
 	return nil
 }
 
-// mkdirRemoteTree creates the destination root and all intermediate
-// dirs in path-length ASC order so parents land before children. Per
-// design lock #5.
-func mkdirRemoteTree(ctx context.Context, c *client.Client, root string, dirs []string) error {
-	// Build full list including root, dedupe, sort by path length so
-	// parents precede children.
-	all := append([]string{root}, dirs...)
-	seen := make(map[string]struct{}, len(all))
-	unique := make([]string, 0, len(all))
-	for _, d := range all {
+// mkdirRemoteTree creates the supplied dirs in path-length ASC order
+// so parents land before children. Per design lock #5. Callers
+// pre-include the dst root if it needs creating; mkdirRemoteTree
+// itself just sorts + dedupes + issues MkdirCtx per entry.
+func mkdirRemoteTree(ctx context.Context, c *client.Client, dirs []string) error {
+	seen := make(map[string]struct{}, len(dirs))
+	unique := make([]string, 0, len(dirs))
+	for _, d := range dirs {
 		if _, ok := seen[d]; ok {
 			continue
 		}
@@ -361,6 +520,21 @@ func mkdirRemoteTree(ctx context.Context, c *client.Client, root string, dirs []
 		}
 	}
 	return nil
+}
+
+// remotePathStatus returns (exists, isDir, error) for a remote path
+// via StatCtx. A 404 maps to (false, false, nil) so callers can
+// distinguish "missing" from "exists" without parsing the StatusError
+// at the call site. Any other transport/auth error is surfaced.
+func remotePathStatus(ctx context.Context, c *client.Client, path string) (bool, bool, error) {
+	info, err := c.StatCtx(ctx, path)
+	if err == nil {
+		return true, info.IsDir, nil
+	}
+	if client.IsNotFound(err) {
+		return false, false, nil
+	}
+	return false, false, fmt.Errorf("stat %q: %w", path, err)
 }
 
 // walkRemoteTreeBFS walks a remote directory tree breadth-first via
@@ -431,6 +605,14 @@ func downloadOneFile(ctx context.Context, c *client.Client, remotePath, localPat
 // sibling transfers are NOT cancelled when a single leaf fails — this
 // matches the @adversary-1 #3 runtime rule (siblings continue after
 // per-leaf runtime failure).
+//
+// Cancellation correctness (per @adversary-1 secondary review B5):
+//   - There are TWO blocking points where ctx must be honored: the
+//     top-of-loop "have we already been cancelled?" check, AND the
+//     semaphore acquire (which can block arbitrarily long if all
+//     workers are busy). Both use ctx-aware selects.
+//   - `break` inside `select` only exits the select, not the for, so
+//     a labeled break exits the whole loop. (Bug from round-1 PR review.)
 func parallelTransfer[T any](ctx context.Context, items []T, op func(context.Context, T) error) error {
 	if len(items) == 0 {
 		return nil
@@ -441,18 +623,30 @@ func parallelTransfer[T any](ctx context.Context, items []T, op func(context.Con
 		failuresMu sync.Mutex
 		failures   []error
 	)
+	recordCancel := func(err error) {
+		failuresMu.Lock()
+		failures = append(failures, err)
+		failuresMu.Unlock()
+	}
+launch:
 	for _, item := range items {
-		// Honor cancellation: stop launching new transfers if ctx
-		// has been cancelled.
+		// (1) Already-cancelled check. Cheap; lets us bail out before
+		// even waiting for a semaphore slot if ctx is already done.
 		select {
 		case <-ctx.Done():
-			failuresMu.Lock()
-			failures = append(failures, ctx.Err())
-			failuresMu.Unlock()
-			break
+			recordCancel(ctx.Err())
+			break launch
 		default:
 		}
-		sem <- struct{}{}
+		// (2) Semaphore acquire. This can block when the worker pool
+		// is saturated; without the ctx case the launcher would still
+		// wait for a worker to finish even after ctx is cancelled.
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			recordCancel(ctx.Err())
+			break launch
+		}
 		wg.Add(1)
 		go func(item T) {
 			defer wg.Done()
@@ -485,6 +679,15 @@ type localFileEntry struct {
 type remoteFileEntry struct {
 	remotePath string // absolute remote path of the source file
 	rel        string // path relative to source root, slash-separated
+	size       int64
+}
+
+// localDownloadEntry is the resolved (post-joinLocalSafe) form of a
+// remoteFileEntry: the absolute local path has been validated as
+// staying inside the dst root.
+type localDownloadEntry struct {
+	remotePath string
+	localPath  string
 	size       int64
 }
 

--- a/cmd/drive9/cli/cp_recursive_test.go
+++ b/cmd/drive9/cli/cp_recursive_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -122,12 +123,27 @@ func (m *mockTreeServer) httpServer(t *testing.T) *httptest.Server {
 			_ = json.NewEncoder(w).Encode(map[string]any{"entries": out})
 		case r.Method == http.MethodHead && strings.HasPrefix(r.URL.Path, "/v1/fs/"):
 			path := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+			// Prefer the explicit statResults override (used for dst-
+			// exists-as-file and remote-source tests). Fall back to
+			// m.existing so dst-root preflight HEADs see the same
+			// state as BatchStat preflights — without this the dst
+			// root's "exists as dir" flag in m.existing was invisible
+			// to remotePathStatus, which uses StatCtx (HEAD).
 			if s, ok := m.statResults[path]; ok && s.exists {
 				if s.isDir {
 					w.Header().Set("X-Dat9-IsDir", "true")
 				} else {
 					w.Header().Set("X-Dat9-IsDir", "false")
 					w.Header().Set("Content-Length", fmt.Sprintf("%d", s.size))
+				}
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if isDir, exists := m.existing[path]; exists {
+				if isDir {
+					w.Header().Set("X-Dat9-IsDir", "true")
+				} else {
+					w.Header().Set("X-Dat9-IsDir", "false")
 				}
 				w.WriteHeader(http.StatusOK)
 				return
@@ -196,17 +212,76 @@ func TestCpRecursiveLocalToRemote_DstDoesNotExist(t *testing.T) {
 	}
 }
 
-// TestCpRecursiveLocalToRemote_DstExistsAsDir confirms the same
-// locked rule: when dst already exists as a directory, source
-// CONTENTS land at dst/<rel>, NOT at dst/<basename(src)>/<rel>.
+// TestCpRecursiveLocalToRemote_DstExistsAsDir confirms the locked
+// rule from #drive9:72bf030c thread (msgs 72d6eb06 + 5f25d0a0):
+// when dst already exists as a directory, source CONTENTS land at
+// dst/<rel>, NOT at dst/<basename(src)>/<rel>, and the existing
+// dst directory is ACCEPTED (no preflight rejection).
+//
+// Regression note: round-1 of this PR incorrectly rejected dst-
+// exists-as-dir, treating any preexisting destination as a
+// conflict. @adversary-2 caught this in PR review.
 func TestCpRecursiveLocalToRemote_DstExistsAsDir(t *testing.T) {
+	srcDir := t.TempDir()
+	writeTreeFiles(t, srcDir, map[string]string{
+		"a.txt":   "alpha",
+		"b/c.txt": "charlie",
+	})
+
+	mock := newMockTreeServer()
+	// dst pre-exists as a directory. Common case: agent-B already
+	// has its workspace dir; agent-A wants to drop a scratch tree
+	// into it.
+	mock.existing["/dst"] = true
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	if err := Cp(c, []string{"-r", srcDir, ":/dst"}); err != nil {
+		t.Fatalf("Cp(-r) with dst-exists-as-dir must accept, got: %v", err)
+	}
+
+	// Contents landed under dst/, not under dst/<basename(srcDir)>/.
+	wantPuts := map[string]string{
+		"/dst/a.txt":   "alpha",
+		"/dst/b/c.txt": "charlie",
+	}
+	for path, body := range wantPuts {
+		got, ok := mock.recordedPuts[path]
+		if !ok {
+			t.Errorf("expected PUT %q, missing (recorded: %v)", path, sortedKeys(mock.recordedPuts))
+			continue
+		}
+		if string(got) != body {
+			t.Errorf("PUT %q body = %q, want %q", path, got, body)
+		}
+	}
+
+	// The dst root itself MUST NOT be re-mkdir'd (it already exists).
+	// Only descendant dirs (/dst/b) should be created.
+	wantDirs := []string{"/dst/b"}
+	if !equalAsSets(mock.recordedMkdirs, wantDirs) {
+		t.Errorf("MKDIR set = %v, want %v (must not re-mkdir existing dst root)", mock.recordedMkdirs, wantDirs)
+	}
+}
+
+// TestCpRecursiveLocalToRemote_DstExistsAsFileRejects confirms that
+// dst-exists-as-FILE (not dir) is rejected with a clear message —
+// we refuse to overwrite a regular file with a directory tree, since
+// that would be a destructive surprise the user almost certainly
+// didn't intend.
+func TestCpRecursiveLocalToRemote_DstExistsAsFileRejects(t *testing.T) {
 	srcDir := t.TempDir()
 	writeTreeFiles(t, srcDir, map[string]string{"a.txt": "alpha"})
 
 	mock := newMockTreeServer()
-	// dst pre-exists as a directory → preflight must catch this and
-	// abort (we refuse to overwrite per design lock #3).
-	mock.existing["/dst"] = true
+	// dst pre-exists, but it's a FILE (not a dir).
+	mock.statResults["/dst"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: false, size: 5}
 	srv := mock.httpServer(t)
 	defer srv.Close()
 
@@ -214,18 +289,50 @@ func TestCpRecursiveLocalToRemote_DstExistsAsDir(t *testing.T) {
 	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
 	err := Cp(c, []string{"-r", srcDir, ":/dst"})
 	if err == nil {
-		t.Fatalf("expected preflight error when dst exists, got nil; puts=%v mkdirs=%v",
+		t.Fatalf("expected reject when dst exists as file, got nil; puts=%v mkdirs=%v",
 			sortedKeys(mock.recordedPuts), mock.recordedMkdirs)
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("error = %v, want 'not a directory' message", err)
+	}
+	if len(mock.recordedPuts) > 0 {
+		t.Errorf("file-conflict must abort before any PUT, got %v", sortedKeys(mock.recordedPuts))
+	}
+	if len(mock.recordedMkdirs) > 0 {
+		t.Errorf("file-conflict must abort before any MKDIR, got %v", mock.recordedMkdirs)
+	}
+}
+
+// TestCpRecursiveLocalToRemote_DescendantConflictAbortsPreflight
+// confirms preflight rejects when a DESCENDANT path (not dst root)
+// already exists. Even when dst-exists-as-dir is accepted, descendant
+// conflicts still abort before any transfer — locked by @adversary-1
+// design rule #3.
+func TestCpRecursiveLocalToRemote_DescendantConflictAbortsPreflight(t *testing.T) {
+	srcDir := t.TempDir()
+	writeTreeFiles(t, srcDir, map[string]string{
+		"a.txt": "alpha",
+		"b.txt": "bravo",
+	})
+
+	mock := newMockTreeServer()
+	// dst is accepted-as-dir, but one descendant file already exists.
+	mock.existing["/dst"] = true
+	mock.existing["/dst/a.txt"] = false
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	err := Cp(c, []string{"-r", srcDir, ":/dst"})
+	if err == nil {
+		t.Fatalf("expected descendant-conflict preflight error, got nil")
 	}
 	if !strings.Contains(err.Error(), "already exists") {
 		t.Fatalf("error = %v, want 'already exists' message", err)
 	}
-	// Critical: NO PUT/MKDIR happened before the preflight failure.
 	if len(mock.recordedPuts) > 0 {
-		t.Errorf("preflight should have prevented any PUT, but got %v", sortedKeys(mock.recordedPuts))
-	}
-	if len(mock.recordedMkdirs) > 0 {
-		t.Errorf("preflight should have prevented any MKDIR, but got %v", mock.recordedMkdirs)
+		t.Errorf("descendant preflight conflict must abort before any PUT, got %v", sortedKeys(mock.recordedPuts))
 	}
 }
 
@@ -526,6 +633,418 @@ func TestCpRecursiveRemoteToRemote_UsesServerSideCopyPerLeaf(t *testing.T) {
 	if !equalAsSets(mock.recordedMkdirs, wantDirs) {
 		t.Errorf("recorded MKDIR = %v, want %v", mock.recordedMkdirs, wantDirs)
 	}
+}
+
+// ───────────────────────── Remote→Local (B3 + B4) ─────────────────────────
+
+// TestCpRecursiveRemoteToLocal_HappyPath asserts the basic remote→local
+// flow works: a directory tree on the remote lands as a matching local
+// tree under dstLocal. Verifies all leaf files arrive byte-identical.
+//
+// Closes B3 coverage gap from @adversary-1 secondary review msg c7eb6852.
+func TestCpRecursiveRemoteToLocal_HappyPath(t *testing.T) {
+	mock := newMockTreeServer()
+	// Remote tree: /src is a dir; /src/a.txt and /src/sub/b.txt are
+	// files; /src/sub is a subdirectory.
+	mock.statResults["/src"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: true}
+	mock.statResults["/src/a.txt"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: false, size: 5}
+	mock.statResults["/src/sub/b.txt"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: false, size: 7}
+	mock.listEntries["/src"] = []client.FileInfo{
+		{Name: "a.txt", Size: 5, IsDir: false},
+		{Name: "sub", Size: 0, IsDir: true},
+	}
+	mock.listEntries["/src/sub"] = []client.FileInfo{
+		{Name: "b.txt", Size: 7, IsDir: false},
+	}
+	mock.fileBodies["/src/a.txt"] = []byte("alpha")
+	mock.fileBodies["/src/sub/b.txt"] = []byte("bravooo")
+
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	dstLocal := t.TempDir()
+	// Empty dstLocal — must be accepted, and contents land directly
+	// inside it (not inside dstLocal/src/).
+	c := client.New(srv.URL, "")
+	if err := Cp(c, []string{"-r", ":/src", dstLocal}); err != nil {
+		t.Fatalf("Cp(-r remote→local): %v", err)
+	}
+
+	// Verify each leaf landed at the expected local path with the
+	// expected bytes.
+	wantFiles := map[string]string{
+		"a.txt":     "alpha",
+		"sub/b.txt": "bravooo",
+	}
+	for rel, body := range wantFiles {
+		got, err := os.ReadFile(filepath.Join(dstLocal, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Errorf("read %s: %v", rel, err)
+			continue
+		}
+		if string(got) != body {
+			t.Errorf("%s = %q, want %q", rel, got, body)
+		}
+	}
+	// Verify the descendant subdir exists.
+	if info, err := os.Stat(filepath.Join(dstLocal, "sub")); err != nil || !info.IsDir() {
+		t.Errorf("expected dst/sub to exist as dir: err=%v info=%v", err, info)
+	}
+}
+
+// TestCpRecursiveRemoteToLocal_DstExistsAsFileRejects mirrors the
+// local→remote dst-as-file rejection for the remote→local direction.
+func TestCpRecursiveRemoteToLocal_DstExistsAsFileRejects(t *testing.T) {
+	mock := newMockTreeServer()
+	mock.statResults["/src"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: true}
+	mock.listEntries["/src"] = []client.FileInfo{
+		{Name: "a.txt", Size: 5, IsDir: false},
+	}
+	mock.fileBodies["/src/a.txt"] = []byte("alpha")
+
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	// Pre-create dst as a regular file so it should be rejected.
+	tmp := t.TempDir()
+	dstLocal := filepath.Join(tmp, "dst-as-file")
+	if err := os.WriteFile(dstLocal, []byte("preexisting"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	c := client.New(srv.URL, "")
+	err := Cp(c, []string{"-r", ":/src", dstLocal})
+	if err == nil {
+		t.Fatalf("expected reject when local dst exists as file, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("error = %v, want 'not a directory' message", err)
+	}
+	// The original file must NOT have been overwritten.
+	body, _ := os.ReadFile(dstLocal)
+	if string(body) != "preexisting" {
+		t.Errorf("preexisting file content was modified: %q", body)
+	}
+}
+
+// TestCpRecursiveRemoteToLocal_DescendantLeafConflictRejects asserts
+// the remote→local direction also preflights DESCENDANT paths and
+// rejects before any download starts. Without this, DownloadToFile-
+// WithSummary's os.Create would silently truncate a pre-existing
+// local leaf, violating the locked "no overwrite in P0" rule.
+func TestCpRecursiveRemoteToLocal_DescendantLeafConflictRejects(t *testing.T) {
+	mock := newMockTreeServer()
+	mock.statResults["/src"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: true}
+	mock.statResults["/src/a.txt"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: false, size: 5}
+	mock.statResults["/src/b.txt"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: false, size: 5}
+	mock.listEntries["/src"] = []client.FileInfo{
+		{Name: "a.txt", Size: 5, IsDir: false},
+		{Name: "b.txt", Size: 5, IsDir: false},
+	}
+	mock.fileBodies["/src/a.txt"] = []byte("alpha")
+	mock.fileBodies["/src/b.txt"] = []byte("bravo")
+
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	dstLocal := t.TempDir()
+	// dst-as-dir is accepted (mirrors remote semantics), but a
+	// pre-existing descendant leaf MUST cause preflight to abort.
+	preexisting := filepath.Join(dstLocal, "a.txt")
+	if err := os.WriteFile(preexisting, []byte("DO NOT OVERWRITE"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	c := client.New(srv.URL, "")
+	err := Cp(c, []string{"-r", ":/src", dstLocal})
+	if err == nil {
+		t.Fatalf("expected descendant-conflict reject, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %v, want 'already exists' message", err)
+	}
+	// The pre-existing file MUST NOT have been truncated/overwritten.
+	body, _ := os.ReadFile(preexisting)
+	if string(body) != "DO NOT OVERWRITE" {
+		t.Errorf("preexisting descendant was overwritten: %q", body)
+	}
+	// b.txt must NOT have been downloaded either — preflight aborts
+	// the whole batch.
+	if _, err := os.Stat(filepath.Join(dstLocal, "b.txt")); err == nil {
+		t.Errorf("/dst/b.txt was downloaded despite preflight conflict on sibling")
+	}
+}
+
+// TestCpRecursiveRemoteToLocal_EmptyDirPreserved asserts an empty
+// directory in the remote tree results in a corresponding local
+// directory — matches local→remote empty-dir behavior.
+func TestCpRecursiveRemoteToLocal_EmptyDirPreserved(t *testing.T) {
+	mock := newMockTreeServer()
+	mock.statResults["/src"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: true}
+	mock.listEntries["/src"] = []client.FileInfo{
+		{Name: "empty", Size: 0, IsDir: true},
+		{Name: "a.txt", Size: 5, IsDir: false},
+	}
+	mock.listEntries["/src/empty"] = nil // empty subdir
+	mock.statResults["/src/a.txt"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: false, size: 5}
+	mock.fileBodies["/src/a.txt"] = []byte("alpha")
+
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	dstLocal := t.TempDir()
+	c := client.New(srv.URL, "")
+	if err := Cp(c, []string{"-r", ":/src", dstLocal}); err != nil {
+		t.Fatalf("Cp(-r): %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dstLocal, "empty"))
+	if err != nil {
+		t.Fatalf("expected dst/empty to exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("dst/empty should be a directory")
+	}
+}
+
+// TestCpRecursiveRemoteToLocal_RejectsPathEscape asserts that a
+// malformed remote list entry (e.g. "../escape.txt") is rejected
+// before any local file is written. Closes B4 coverage gap from
+// @adversary-1 secondary review msg c7eb6852.
+func TestCpRecursiveRemoteToLocal_RejectsPathEscape(t *testing.T) {
+	mock := newMockTreeServer()
+	mock.statResults["/src"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: true}
+	// Malicious list response: name starts with ".." which would
+	// escape dstLocal if naively joined.
+	mock.listEntries["/src"] = []client.FileInfo{
+		{Name: "..", Size: 0, IsDir: true},
+	}
+	mock.listEntries["/src/.."] = []client.FileInfo{
+		{Name: "escape.txt", Size: 5, IsDir: false},
+	}
+
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	tmpRoot := t.TempDir()
+	// Sentinel file in the PARENT of dstLocal that, if path-escape
+	// worked, would get overwritten by an "escape.txt" leaf.
+	sentinelDir := filepath.Join(tmpRoot, "sibling")
+	if err := os.MkdirAll(sentinelDir, 0o755); err != nil {
+		t.Fatalf("mkdir sentinel: %v", err)
+	}
+	dstLocal := filepath.Join(tmpRoot, "dst")
+	if err := os.MkdirAll(dstLocal, 0o755); err != nil {
+		t.Fatalf("mkdir dst: %v", err)
+	}
+
+	c := client.New(srv.URL, "")
+	err := Cp(c, []string{"-r", ":/src", dstLocal})
+	if err == nil {
+		t.Fatalf("expected path-escape reject, got nil")
+	}
+	if !strings.Contains(err.Error(), "..") {
+		t.Fatalf("error = %v, want '..' rejection", err)
+	}
+	// Most important: nothing was written outside dstLocal.
+	if _, statErr := os.Stat(filepath.Join(tmpRoot, "escape.txt")); statErr == nil {
+		t.Errorf("path escape wrote outside dstLocal: %s", filepath.Join(tmpRoot, "escape.txt"))
+	}
+}
+
+// TestJoinLocalSafe_RejectsTraversal asserts the local path-safety
+// helper rejects `..` traversal segments just like joinRemoteSafe.
+func TestJoinLocalSafe_RejectsTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	cases := []struct {
+		name string
+		rel  string
+	}{
+		{"parent traversal", "../escape.txt"},
+		{"nested traversal", "child/../../escape.txt"},
+		{"deep traversal", "a/b/c/../../../../escape.txt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := joinLocalSafe(tmp, tc.rel)
+			if err == nil {
+				t.Fatalf("expected error for traversal %q (got %q)", tc.rel, got)
+			}
+			if !strings.Contains(err.Error(), "..") {
+				t.Errorf("error = %v, want '..' rejection", err)
+			}
+		})
+	}
+}
+
+// TestJoinLocalSafe_RejectsAbsoluteRel asserts an absolute `rel` is
+// rejected even without `..` segments — a remote-supplied "/etc/passwd"
+// must not be treated as relative to dstLocal and then silently
+// absolute-resolved.
+func TestJoinLocalSafe_RejectsAbsoluteRel(t *testing.T) {
+	tmp := t.TempDir()
+	if _, err := joinLocalSafe(tmp, "/etc/passwd"); err == nil {
+		t.Fatalf("expected reject for absolute rel, got nil")
+	}
+}
+
+// TestJoinLocalSafe_HappyPath asserts the trivial case still resolves
+// to base/rel.
+func TestJoinLocalSafe_HappyPath(t *testing.T) {
+	tmp := t.TempDir()
+	got, err := joinLocalSafe(tmp, "sub/leaf.txt")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := filepath.Join(tmp, "sub", "leaf.txt")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// ───────────────────────── B5: cancellation regressions ─────────────────────────
+
+// TestParallelTransfer_AlreadyCancelledCtxStopsLoop is the "ctx
+// cancelled BEFORE the loop even starts" regression. Verifies the
+// labeled break exits the for loop and no transfer ops are launched.
+func TestParallelTransfer_AlreadyCancelledCtxStopsLoop(t *testing.T) {
+	ctx, cancel := contextWithCancel()
+	cancel() // cancel BEFORE parallelTransfer runs
+
+	var ops atomicCounter
+	items := []int{1, 2, 3, 4, 5}
+	err := parallelTransfer(ctx, items, func(_ context.Context, _ int) error {
+		ops.inc()
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("expected ctx.Err(), got nil")
+	}
+	if ops.get() != 0 {
+		t.Errorf("expected 0 ops when ctx pre-cancelled, got %d", ops.get())
+	}
+}
+
+// TestParallelTransfer_CancelDuringSemaphoreAcquireStopsLoop is the
+// "ctx cancelled while waiting for a semaphore slot" regression. It
+// saturates the worker pool with blocking ops, then cancels, and
+// asserts the launcher stops promptly rather than waiting for a
+// worker to finish.
+//
+// This is the case @adversary-1 flagged in B5: a top-of-loop ctx
+// check alone is not enough — the `sem <- struct{}{}` send must also
+// be ctx-aware.
+func TestParallelTransfer_CancelDuringSemaphoreAcquireStopsLoop(t *testing.T) {
+	// More items than worker slots so the launcher hits the
+	// semaphore-full case for items beyond recursiveCopyConcurrency.
+	const nItems = recursiveCopyConcurrency * 3
+	items := make([]int, nItems)
+	for i := range items {
+		items[i] = i
+	}
+
+	ctx, cancel := contextWithCancel()
+	// release blocks ops in the workers so the pool stays saturated
+	// until we cancel.
+	release := make(chan struct{})
+	var (
+		started atomicCounter
+		opCalls atomicCounter
+	)
+	go func() {
+		// Wait until the worker pool is fully saturated, then cancel.
+		// This forces the launcher to be blocked on `sem <- struct{}{}`
+		// for the (nItems - recursiveCopyConcurrency) remaining items
+		// at the moment ctx is cancelled.
+		for {
+			if started.get() >= recursiveCopyConcurrency {
+				break
+			}
+		}
+		cancel()
+		close(release)
+	}()
+
+	err := parallelTransfer(ctx, items, func(_ context.Context, _ int) error {
+		opCalls.inc()
+		started.inc()
+		<-release // block until cancellation is signalled
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("expected ctx.Err(), got nil")
+	}
+	// At most `recursiveCopyConcurrency` ops should ever start —
+	// the launcher must NOT slip another transfer in after cancel.
+	if got := opCalls.get(); got > recursiveCopyConcurrency {
+		t.Errorf("expected ≤ %d ops to start, got %d (launcher slipped past sem cancel)",
+			recursiveCopyConcurrency, got)
+	}
+}
+
+// contextWithCancel is a tiny shim so test code reads naturally. We
+// keep it local to avoid an import in production code paths.
+func contextWithCancel() (context.Context, context.CancelFunc) {
+	return context.WithCancel(context.Background())
+}
+
+// atomicCounter is a minimal sync.Mutex-protected int used only by
+// the cancellation regression tests above.
+type atomicCounter struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (a *atomicCounter) inc() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.n++
+}
+
+func (a *atomicCounter) get() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.n
 }
 
 // ───────────────────────── Test helpers ─────────────────────────

--- a/cmd/drive9/cli/cp_recursive_test.go
+++ b/cmd/drive9/cli/cp_recursive_test.go
@@ -996,10 +996,7 @@ func TestParallelTransfer_CancelDuringSemaphoreAcquireStopsLoop(t *testing.T) {
 		// This forces the launcher to be blocked on `sem <- struct{}{}`
 		// for the (nItems - recursiveCopyConcurrency) remaining items
 		// at the moment ctx is cancelled.
-		for {
-			if started.get() >= recursiveCopyConcurrency {
-				break
-			}
+		for started.get() < recursiveCopyConcurrency {
 		}
 		cancel()
 		close(release)

--- a/cmd/drive9/cli/cp_recursive_test.go
+++ b/cmd/drive9/cli/cp_recursive_test.go
@@ -1,0 +1,585 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+// mockTreeServer is a small httptest harness that captures the
+// PUT/MKDIR/COPY/LIST/BATCH-STAT side effects of a `drive9 fs cp -r`
+// invocation. Tests can read the captured state to assert the
+// recursive plan executed as expected without re-implementing the
+// full drive9 server contract.
+type mockTreeServer struct {
+	mu sync.Mutex
+	// existing reports paths that pre-exist on the "remote". Used by
+	// BatchStat preflight tests to make the preflight fail. Maps
+	// absolute path → isDir.
+	existing map[string]bool
+	// listEntries supplies the directory listing returned by ListCtx
+	// for each dir path. Test setup populates this for remote-source
+	// trees.
+	listEntries map[string][]client.FileInfo
+	// statResults supplies StatCtx responses for explicit paths
+	// (typically the source root in remote→{local,remote} flows).
+	statResults map[string]struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}
+	// fileBodies stores the bytes a HEAD/GET should return for
+	// remote-source files (remote→local downloads use these).
+	fileBodies map[string][]byte
+	// recordedPuts captures the body of every PUT to /v1/fs/<path>.
+	recordedPuts map[string][]byte
+	// recordedMkdirs captures every successful MKDIR.
+	recordedMkdirs []string
+	// recordedCopies captures every server-side copy as (src, dst).
+	recordedCopies [][2]string
+	// failPutPath, when non-empty, makes that single PUT return 500.
+	// Used to test partial-failure runtime semantics.
+	failPutPath string
+}
+
+func newMockTreeServer() *mockTreeServer {
+	return &mockTreeServer{
+		existing:     map[string]bool{},
+		listEntries:  map[string][]client.FileInfo{},
+		statResults:  map[string]struct{ exists, isDir bool; size int64 }{},
+		fileBodies:   map[string][]byte{},
+		recordedPuts: map[string][]byte{},
+	}
+}
+
+func (m *mockTreeServer) httpServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-stat":
+			var req struct {
+				Paths []string `json:"paths"`
+			}
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &req)
+			results := make([]map[string]any, len(req.Paths))
+			for i, p := range req.Paths {
+				isDir, exists := m.existing[p]
+				if !exists {
+					results[i] = map[string]any{"path": p, "status": 404, "isDir": false, "hasMode": false}
+				} else {
+					results[i] = map[string]any{"path": p, "status": 200, "isDir": isDir, "hasMode": false}
+				}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": results})
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/v1/fs/"):
+			// Per-leaf upload. Optionally fail to test partial-failure.
+			path := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+			if m.failPutPath != "" && path == m.failPutPath {
+				http.Error(w, "injected put failure", http.StatusInternalServerError)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			m.recordedPuts[path] = body
+			// Mark as existing so subsequent BatchStat sees it.
+			m.existing[path] = false
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/fs/") && r.URL.Query().Has("mkdir"):
+			path := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+			m.recordedMkdirs = append(m.recordedMkdirs, path)
+			m.existing[path] = true
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/fs/") && r.URL.Query().Has("copy"):
+			dst := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+			src := r.Header.Get("X-Dat9-Copy-Source")
+			m.recordedCopies = append(m.recordedCopies, [2]string{src, dst})
+			m.existing[dst] = false
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/fs/") && r.URL.Query().Has("list"):
+			path := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+			entries := m.listEntries[path]
+			out := make([]map[string]any, len(entries))
+			for i, e := range entries {
+				out[i] = map[string]any{
+					"name":    e.Name,
+					"size":    e.Size,
+					"isDir":   e.IsDir,
+					"hasMode": false,
+				}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": out})
+		case r.Method == http.MethodHead && strings.HasPrefix(r.URL.Path, "/v1/fs/"):
+			path := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+			if s, ok := m.statResults[path]; ok && s.exists {
+				if s.isDir {
+					w.Header().Set("X-Dat9-IsDir", "true")
+				} else {
+					w.Header().Set("X-Dat9-IsDir", "false")
+					w.Header().Set("Content-Length", fmt.Sprintf("%d", s.size))
+				}
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			http.NotFound(w, r)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/fs/"):
+			path := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+			if body, ok := m.fileBodies[path]; ok {
+				_, _ = w.Write(body)
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// ───────────────────────── Constraint #1: destination semantics ─────────────────────────
+
+// TestCpRecursiveLocalToRemote_DstDoesNotExist asserts the locked
+// destination semantics from @adversary-1 msg 72d6eb06: when dst
+// doesn't exist, copy source CONTENTS into dst/ (not dst/basename(src)/).
+func TestCpRecursiveLocalToRemote_DstDoesNotExist(t *testing.T) {
+	srcDir := t.TempDir()
+	writeTreeFiles(t, srcDir, map[string]string{
+		"a.txt":     "alpha",
+		"b/c.txt":   "charlie",
+		"b/d/e.txt": "echo",
+	})
+
+	mock := newMockTreeServer()
+	// dst does NOT pre-exist anywhere.
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	if err := Cp(c, []string{"-r", srcDir, ":/dst"}); err != nil {
+		t.Fatalf("Cp(-r): %v", err)
+	}
+
+	// All file leaves under SOURCE landed at dst/<relative path>,
+	// NOT at dst/<basename(srcDir)>/<relative path>.
+	wantPuts := map[string]string{
+		"/dst/a.txt":     "alpha",
+		"/dst/b/c.txt":   "charlie",
+		"/dst/b/d/e.txt": "echo",
+	}
+	for path, body := range wantPuts {
+		got, ok := mock.recordedPuts[path]
+		if !ok {
+			t.Errorf("expected PUT %q, missing (recorded: %v)", path, sortedKeys(mock.recordedPuts))
+			continue
+		}
+		if string(got) != body {
+			t.Errorf("PUT %q body = %q, want %q", path, got, body)
+		}
+	}
+
+	// Destination root + intermediate dirs were created in parent-
+	// first order.
+	wantDirs := []string{"/dst", "/dst/b", "/dst/b/d"}
+	if !equalAsSets(mock.recordedMkdirs, wantDirs) {
+		t.Errorf("MKDIR set = %v, want %v", mock.recordedMkdirs, wantDirs)
+	}
+}
+
+// TestCpRecursiveLocalToRemote_DstExistsAsDir confirms the same
+// locked rule: when dst already exists as a directory, source
+// CONTENTS land at dst/<rel>, NOT at dst/<basename(src)>/<rel>.
+func TestCpRecursiveLocalToRemote_DstExistsAsDir(t *testing.T) {
+	srcDir := t.TempDir()
+	writeTreeFiles(t, srcDir, map[string]string{"a.txt": "alpha"})
+
+	mock := newMockTreeServer()
+	// dst pre-exists as a directory → preflight must catch this and
+	// abort (we refuse to overwrite per design lock #3).
+	mock.existing["/dst"] = true
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	err := Cp(c, []string{"-r", srcDir, ":/dst"})
+	if err == nil {
+		t.Fatalf("expected preflight error when dst exists, got nil; puts=%v mkdirs=%v",
+			sortedKeys(mock.recordedPuts), mock.recordedMkdirs)
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %v, want 'already exists' message", err)
+	}
+	// Critical: NO PUT/MKDIR happened before the preflight failure.
+	if len(mock.recordedPuts) > 0 {
+		t.Errorf("preflight should have prevented any PUT, but got %v", sortedKeys(mock.recordedPuts))
+	}
+	if len(mock.recordedMkdirs) > 0 {
+		t.Errorf("preflight should have prevented any MKDIR, but got %v", mock.recordedMkdirs)
+	}
+}
+
+// ───────────────────────── Constraint #2: symlink reject ─────────────────────────
+
+// TestCpRecursiveLocalToRemote_RejectsSymlinkInTree asserts that
+// recursive copy refuses to silently follow OR skip symlinks (per
+// @adversary-1 msg b8603b41).
+func TestCpRecursiveLocalToRemote_RejectsSymlinkInTree(t *testing.T) {
+	srcDir := t.TempDir()
+	writeTreeFiles(t, srcDir, map[string]string{"a.txt": "alpha"})
+	// Add a symlink that would, if followed, copy /etc/passwd or
+	// loop back into the source.
+	if err := os.Symlink("/dev/null", filepath.Join(srcDir, "danger.lnk")); err != nil {
+		t.Fatalf("create symlink fixture: %v", err)
+	}
+
+	mock := newMockTreeServer()
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	err := Cp(c, []string{"-r", srcDir, ":/dst"})
+	if err == nil {
+		t.Fatalf("expected symlink reject error, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error = %v, want 'symlink' message", err)
+	}
+	// No partial transfer should have happened.
+	if len(mock.recordedPuts) > 0 {
+		t.Errorf("expected zero PUT before symlink reject, got %v", sortedKeys(mock.recordedPuts))
+	}
+}
+
+// ───────────────────────── Constraint #3: preflight then runtime semantics ─────────────────────────
+
+// TestCpRecursiveLocalToRemote_RuntimePartialFailureSurfacesError
+// asserts the runtime rule (sibling transfers continue, but the
+// overall return is non-nil if any leaf fails). Distinguished from
+// preflight conflict which would abort BEFORE any transfer.
+func TestCpRecursiveLocalToRemote_RuntimePartialFailureSurfacesError(t *testing.T) {
+	srcDir := t.TempDir()
+	writeTreeFiles(t, srcDir, map[string]string{
+		"a.txt": "alpha",
+		"b.txt": "bravo",
+		"c.txt": "charlie",
+	})
+
+	mock := newMockTreeServer()
+	mock.failPutPath = "/dst/b.txt" // 1 leaf fails at runtime, not at preflight.
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	err := Cp(c, []string{"-r", srcDir, ":/dst"})
+	if err == nil {
+		t.Fatalf("expected runtime failure error, got nil")
+	}
+
+	// Siblings should have still been attempted (and succeeded).
+	if _, ok := mock.recordedPuts["/dst/a.txt"]; !ok {
+		t.Errorf("/dst/a.txt should have been PUT despite sibling failure")
+	}
+	if _, ok := mock.recordedPuts["/dst/c.txt"]; !ok {
+		t.Errorf("/dst/c.txt should have been PUT despite sibling failure")
+	}
+	// The failing leaf should NOT be in recordedPuts.
+	if _, ok := mock.recordedPuts["/dst/b.txt"]; ok {
+		t.Errorf("/dst/b.txt should NOT have been recorded (injected failure)")
+	}
+}
+
+// ───────────────────────── Constraint #4: path safety ─────────────────────────
+
+// TestJoinRemoteSafe_RejectsTraversal asserts the path-safety helper
+// rejects `..` traversal segments that would otherwise let a
+// malicious symlink target (or naive caller) write outside the dst
+// base.
+func TestJoinRemoteSafe_RejectsTraversal(t *testing.T) {
+	cases := []struct {
+		name string
+		base string
+		rel  string
+	}{
+		{"parent traversal", "/dst", "../escape.txt"},
+		{"nested traversal", "/dst", "child/../../escape.txt"},
+		{"deep traversal", "/dst", "a/b/c/../../../../escape.txt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := joinRemoteSafe(tc.base, tc.rel)
+			if err == nil {
+				t.Fatalf("expected error for traversal %q (got %q)", tc.rel, got)
+			}
+			if !strings.Contains(err.Error(), "..") {
+				t.Errorf("error = %v, want '..' rejection", err)
+			}
+		})
+	}
+}
+
+// TestJoinRemoteSafe_BoundaryNotPrefix asserts that joinRemoteSafe
+// won't let a sibling-prefixed path masquerade as a child via
+// boundary confusion (e.g. base "/foo" + something that lands at
+// "/foobar" — Drive9 paths should be segment-anchored).
+func TestJoinRemoteSafe_BoundaryNotPrefix(t *testing.T) {
+	got, err := joinRemoteSafe("/foo", "bar")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "/foo/bar" {
+		t.Errorf("got %q, want /foo/bar (must be segment-anchored, not prefix-anchored)", got)
+	}
+}
+
+// TestJoinRemoteSafe_NormalizesTrailingSlash asserts the base-trailing
+// slash is collapsed so `:/dst` and `:/dst/` produce identical leaf
+// paths.
+func TestJoinRemoteSafe_NormalizesTrailingSlash(t *testing.T) {
+	without, _ := joinRemoteSafe("/dst", "a.txt")
+	with, _ := joinRemoteSafe("/dst/", "a.txt")
+	if without != with {
+		t.Errorf("trailing-slash drift: %q vs %q", without, with)
+	}
+}
+
+// ───────────────────────── Constraint #5: dir creation order + empty dir preservation ─────────────────────────
+
+// TestCpRecursiveLocalToRemote_EmptyDirPreserved asserts that an
+// empty directory in the source tree results in an explicit MKDIR
+// for the corresponding remote path — empty dirs must not silently
+// vanish (per design lock #5).
+func TestCpRecursiveLocalToRemote_EmptyDirPreserved(t *testing.T) {
+	srcDir := t.TempDir()
+	// One file + one empty directory.
+	writeTreeFiles(t, srcDir, map[string]string{"a.txt": "alpha"})
+	if err := os.MkdirAll(filepath.Join(srcDir, "empty"), 0o755); err != nil {
+		t.Fatalf("mkdir empty: %v", err)
+	}
+
+	mock := newMockTreeServer()
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	if err := Cp(c, []string{"-r", srcDir, ":/dst"}); err != nil {
+		t.Fatalf("Cp(-r): %v", err)
+	}
+
+	wantDirs := []string{"/dst", "/dst/empty"}
+	if !equalAsSets(mock.recordedMkdirs, wantDirs) {
+		t.Errorf("MKDIR set = %v, want %v (empty dir must be preserved)", mock.recordedMkdirs, wantDirs)
+	}
+}
+
+// TestCpRecursiveLocalToRemote_MkdirParentBeforeChild asserts the
+// observed MKDIR order is parent-before-child by path length.
+func TestCpRecursiveLocalToRemote_MkdirParentBeforeChild(t *testing.T) {
+	srcDir := t.TempDir()
+	writeTreeFiles(t, srcDir, map[string]string{
+		"deep/nested/leaf.txt": "leaf",
+	})
+
+	mock := newMockTreeServer()
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(client.DefaultSmallFileThreshold)
+	if err := Cp(c, []string{"-r", srcDir, ":/dst"}); err != nil {
+		t.Fatalf("Cp(-r): %v", err)
+	}
+
+	// MKDIR must visit shorter paths before longer ones (parent
+	// before child) so the server can succeed each call.
+	for i := 1; i < len(mock.recordedMkdirs); i++ {
+		if len(mock.recordedMkdirs[i-1]) > len(mock.recordedMkdirs[i]) {
+			t.Errorf("MKDIR order broken at index %d: %q (len %d) before %q (len %d)",
+				i, mock.recordedMkdirs[i-1], len(mock.recordedMkdirs[i-1]),
+				mock.recordedMkdirs[i], len(mock.recordedMkdirs[i]))
+		}
+	}
+}
+
+// ───────────────────────── Flag composition ─────────────────────────
+
+// TestCpRecursive_RejectsIncompatibleFlags ensures -r refuses to
+// compose with single-file ergonomics flags whose semantics don't
+// extend cleanly to trees.
+func TestCpRecursive_RejectsIncompatibleFlags(t *testing.T) {
+	srcDir := t.TempDir()
+	cases := [][]string{
+		{"-r", "--append", srcDir, ":/dst"},
+		{"-r", "--resume", srcDir, ":/dst"},
+		{"-r", "--tag", "k=v", srcDir, ":/dst"},
+		{"-r", "--description", "x", srcDir, ":/dst"},
+	}
+	c := client.New("http://unused", "")
+	for _, args := range cases {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			err := Cp(c, args)
+			if err == nil {
+				t.Fatalf("expected rejection for incompatible flags, got nil")
+			}
+			if !strings.Contains(err.Error(), "-r/--recursive cannot be combined") {
+				t.Fatalf("error = %v, want incompatible-flags message", err)
+			}
+		})
+	}
+}
+
+// TestCpRecursive_RejectsStdinOrStdout ensures -r refuses pipe
+// endpoints (Unix `cp -r` doesn't support pipes as endpoints).
+func TestCpRecursive_RejectsStdinOrStdout(t *testing.T) {
+	c := client.New("http://unused", "")
+	if err := Cp(c, []string{"-r", "-", ":/dst"}); err == nil || !strings.Contains(err.Error(), "stdin/stdout") {
+		t.Fatalf("stdin: err = %v, want stdin/stdout reject", err)
+	}
+	if err := Cp(c, []string{"-r", ":/src", "-"}); err == nil || !strings.Contains(err.Error(), "stdin/stdout") {
+		t.Fatalf("stdout: err = %v, want stdin/stdout reject", err)
+	}
+}
+
+// TestCpRecursive_RequiresAtLeastOneRemote ensures local→local
+// recursive copy is out of scope (Drive9 CLI only handles paths
+// where at least one side is remote).
+func TestCpRecursive_RequiresAtLeastOneRemote(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	c := client.New("http://unused", "")
+	err := Cp(c, []string{"-r", dir1, dir2})
+	if err == nil {
+		t.Fatalf("expected remote-path requirement error, got nil")
+	}
+}
+
+// TestCpRecursive_RejectsFileSource ensures `cp -r <file> ...` fails
+// with a clear message redirecting to the non-recursive form.
+func TestCpRecursive_RejectsFileSource(t *testing.T) {
+	srcFile := filepath.Join(t.TempDir(), "single.txt")
+	if err := os.WriteFile(srcFile, []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	mock := newMockTreeServer()
+	srv := mock.httpServer(t)
+	defer srv.Close()
+	c := client.New(srv.URL, "")
+	err := Cp(c, []string{"-r", srcFile, ":/dst"})
+	if err == nil {
+		t.Fatalf("expected file-source reject, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires a directory source") {
+		t.Fatalf("error = %v, want directory-source guidance", err)
+	}
+}
+
+// ───────────────────────── Remote→Remote (server-side zero-copy) ─────────────────────────
+
+// TestCpRecursiveRemoteToRemote_UsesServerSideCopyPerLeaf asserts the
+// remote→remote tree copy uses Client.Copy (server-side zero-copy)
+// for every leaf — content bytes never cross the client.
+func TestCpRecursiveRemoteToRemote_UsesServerSideCopyPerLeaf(t *testing.T) {
+	mock := newMockTreeServer()
+	// Source tree on the remote: /src is a dir with two files.
+	mock.statResults["/src"] = struct{ exists, isDir bool; size int64 }{exists: true, isDir: true}
+	mock.listEntries["/src"] = []client.FileInfo{
+		{Name: "a.txt", Size: 5, IsDir: false},
+		{Name: "sub", Size: 0, IsDir: true},
+	}
+	mock.listEntries["/src/sub"] = []client.FileInfo{
+		{Name: "b.txt", Size: 7, IsDir: false},
+	}
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	if err := Cp(c, []string{"-r", ":/src", ":/dst"}); err != nil {
+		t.Fatalf("Cp(-r remote→remote): %v", err)
+	}
+
+	// Two leaf files → two COPY calls.
+	wantCopies := [][2]string{
+		{"/src/a.txt", "/dst/a.txt"},
+		{"/src/sub/b.txt", "/dst/sub/b.txt"},
+	}
+	if !equalCopyPairs(mock.recordedCopies, wantCopies) {
+		t.Errorf("recorded copies = %v, want %v", mock.recordedCopies, wantCopies)
+	}
+	// No PUTs — content never round-tripped through the client.
+	if len(mock.recordedPuts) != 0 {
+		t.Errorf("remote→remote must not PUT (content bytes round-trip), got %v", sortedKeys(mock.recordedPuts))
+	}
+	// Dir hierarchy was created.
+	wantDirs := []string{"/dst", "/dst/sub"}
+	if !equalAsSets(mock.recordedMkdirs, wantDirs) {
+		t.Errorf("recorded MKDIR = %v, want %v", mock.recordedMkdirs, wantDirs)
+	}
+}
+
+// ───────────────────────── Test helpers ─────────────────────────
+
+func writeTreeFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, body := range files {
+		fullPath := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(fullPath, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+}
+
+func sortedKeys(m map[string][]byte) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func equalAsSets(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	gotSet := make(map[string]struct{}, len(got))
+	for _, g := range got {
+		gotSet[g] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := gotSet[w]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func equalCopyPairs(got, want [][2]string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	gotSet := make(map[[2]string]struct{}, len(got))
+	for _, g := range got {
+		gotSet[g] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := gotSet[w]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -879,7 +879,15 @@ func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kin
 
 // Copy performs a server-side zero-copy (same file_id, new path).
 func (c *Client) Copy(srcPath, dstPath string) error {
-	req, err := http.NewRequest(http.MethodPost, c.url(dstPath)+"?copy", nil)
+	return c.CopyCtx(context.Background(), srcPath, dstPath)
+}
+
+// CopyCtx performs a server-side zero-copy with context support so
+// callers can cancel mid-flight (e.g., Ctrl+C during a recursive
+// tree copy). The non-Ctx Copy delegates here so both paths share
+// the same request shape.
+func (c *Client) CopyCtx(ctx context.Context, srcPath, dstPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(dstPath)+"?copy", nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Closes P0 #2 from the db9-drive9 gap analysis (#drive9 task #3). Drive9 already had `rm -r` but no `cp -r`; this adds Unix-toolchain parity for the three "at least one side remote" directions:

- **local → remote** — `filepath.Walk` + bounded parallel `WriteStream`
- **remote → local** — BFS via `ListCtx` + bounded parallel `DownloadToFile` (with full descendant preflight + `joinLocalSafe`)
- **remote → remote** — BFS + bounded parallel `Client.CopyCtx` server-side zero-copy (content bytes never round-trip through the client; Ctrl+C cancels in-flight)

## Design lock (per #drive9:72bf030c thread review with @adversary-1 + @adversary-2)

1. **Destination semantics** (locked by msgs `72d6eb06` + `5f25d0a0`; corrected to acceptance in round-2 fixup):
   - dst doesn't exist        → create it, copy contents into dst/
   - dst exists as directory  → **accept**, copy contents into dst/ (no re-mkdir)
   - dst exists as a file     → **reject** ("not a directory")
   - any DESCENDANT path that already exists → preflight abort (no `-f` in P0)
2. **Symlinks**: explicit reject ("recursive copy does not support symlinks yet"). Not silently followed (security risk: out-of-tree escape) and not silently skipped (data loss). Per @adversary-1 msg `b8603b41`.
3. **Preflight vs runtime separation**: `BatchStatCtx` every DESCENDANT destination path up front; any conflict aborts before any transfer. Sibling runtime failures during transfer don't cancel the rest; final return surfaces a multi-failure summary.
4. **Path safety**: `joinRemoteSafe` (remote dst) + `joinLocalSafe` (local dst, for remote→local direction) both reject `..`, absolute rels, and post-Clean escapes. Server-supplied names always pass through joinLocalSafe before any `os.Create`.
5. **Mkdir ordering**: dirs created in path-length ASC order so parents precede children. Empty dirs preserved via explicit `MkdirCtx` / `os.MkdirAll`.
6. **Cancellation correctness**: `parallelTransfer` honors `ctx.Done()` at BOTH the top-of-loop and the `sem <- struct{}{}` send — cancellation during a saturated worker pool stops the launcher promptly. Labeled break exits the whole for loop, not just the select.

## Flag composition

- `-r/--recursive` is incompatible with `--append`, `--resume`, `--tag`, `--description` (single-file ergonomics don't extend cleanly to trees).
- `-r` rejects stdin/stdout endpoints (Unix `cp -r` doesn't support pipes).
- `-r` requires at least one remote path (drive9 CLI scope) and rejects file sources with a clear message redirecting to the non-recursive form.

## Implementation

- `cmd/drive9/cli/cp.go` — `-r/--recursive` flag parsing + new dispatch branch in `Cp`. ~40 lines.
- `cmd/drive9/cli/cp_recursive.go` (new) — 3 tree-copy helpers + utilities (`joinRemoteSafe`, `joinLocalSafe`, `preflightDestinations`, `preflightLocalDestinations`, `remotePathStatus`, `mkdirRemoteTree`, `walkRemoteTreeBFS`, `parallelTransfer` using Go 1.18+ generics). ~700 lines.
- `cmd/drive9/cli/cp_recursive_test.go` (new) — 24 tests covering every locked constraint + happy/edge/failure cases for all three directions + cancellation. ~1000 lines.
- `pkg/client/client.go` — added `CopyCtx(ctx, src, dst)`; `Copy` delegates to it for backward compatibility.

Concurrency: `recursiveCopyConcurrency = 16` mirrors the existing `pkg/client/transfer/` 16-worker convention. No new tuning knob in this PR.

## Out of scope (deferred to later PRs / future ergonomics)

- `-f/--force` to overwrite existing destinations
- Per-leaf progress UI (tree progress bar)
- POSIX UID/GID/ACL preservation (drive9 NEVER per round 12-15)
- Symlink preservation (P2/SKIP per gap analysis)
- Server-side `?recursive=1` for `handleCopy` (this PR is pure client-side; backend interface unchanged)

## Tests

24 tests covering every locked constraint across all three directions:

**Destination semantics + preflight (local→remote)**
- `TestCpRecursiveLocalToRemote_DstDoesNotExist` — contents into dst/
- `TestCpRecursiveLocalToRemote_DstExistsAsDir` — accept dst-as-dir, no re-mkdir
- `TestCpRecursiveLocalToRemote_DstExistsAsFileRejects` — reject "not a directory"
- `TestCpRecursiveLocalToRemote_DescendantConflictAbortsPreflight` — descendant conflict aborts
- `TestCpRecursiveLocalToRemote_RejectsSymlinkInTree`
- `TestCpRecursiveLocalToRemote_RuntimePartialFailureSurfacesError`
- `TestCpRecursiveLocalToRemote_EmptyDirPreserved`
- `TestCpRecursiveLocalToRemote_MkdirParentBeforeChild`

**Destination semantics + preflight (remote→local)**
- `TestCpRecursiveRemoteToLocal_HappyPath`
- `TestCpRecursiveRemoteToLocal_DstExistsAsFileRejects`
- `TestCpRecursiveRemoteToLocal_DescendantLeafConflictRejects` — protects against `os.Create` truncation surface
- `TestCpRecursiveRemoteToLocal_EmptyDirPreserved`
- `TestCpRecursiveRemoteToLocal_RejectsPathEscape` — malformed remote list entry

**remote→remote**
- `TestCpRecursiveRemoteToRemote_UsesServerSideCopyPerLeaf` — uses `Client.CopyCtx` (zero round-trip)

**Path safety helpers**
- `TestJoinRemoteSafe_RejectsTraversal` / `BoundaryNotPrefix` / `NormalizesTrailingSlash`
- `TestJoinLocalSafe_RejectsTraversal` / `RejectsAbsoluteRel` / `HappyPath`

**Cancellation**
- `TestParallelTransfer_AlreadyCancelledCtxStopsLoop` — ctx pre-cancelled
- `TestParallelTransfer_CancelDuringSemaphoreAcquireStopsLoop` — saturated pool + cancel mid-flight

**Flag composition**
- `TestCpRecursive_RejectsIncompatibleFlags` / `RejectsStdinOrStdout` / `RequiresAtLeastOneRemote` / `RejectsFileSource`

## Verification

- [x] `go build ./...` — clean
- [x] `go vet ./cmd/drive9/cli/...` — clean
- [x] `go test ./cmd/drive9/cli/...` — all 24 tests pass
- [x] `go test ./pkg/client/...` — pre-existing tests still pass after `CopyCtx` refactor

## Test plan

- [ ] `go test ./cmd/drive9/cli/...`
- [ ] `go vet ./...`
- [ ] Manual smoke (when running locally): `drive9 fs cp -r ./local-dir :/remote-dir` succeeds, errors clearly when dst exists as file, accepts dst-as-dir, rejects symlinks

Reviewers: @adversary-2 (primary per #drive9:72bf030c msg `b29f785f`) + @adversary-1 (secondary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
