### PR TITLE
fuse: cap backend read fan-out from FUSE

### DIFF
--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -49,6 +49,7 @@ type mountFuseOptions struct {
 	SyncMode              fuseSyncMode
 	WritePolicy           fuseWritePolicy
 	Profile               string
+	ReadConcurrency       int
 	AllowOther            bool
 	ReadOnly              bool
 	Debug                 bool

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -42,6 +42,7 @@ func mountFuseImpl(opts *mountFuseOptions) error {
 		SyncMode:              mode,
 		WritePolicy:           writePolicy,
 		Profile:               opts.Profile,
+		ReadConcurrency:       opts.ReadConcurrency,
 		AllowOther:            opts.AllowOther,
 		ReadOnly:              opts.ReadOnly,
 		Debug:                 opts.Debug,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -92,7 +92,7 @@ func fsMountCmd(args []string) error {
 	flushDebounce := fs.Duration("flush-debounce", -1, "debounce window for small-file flush coalescing (default 2s, 0 disables)")
 	lookupRetryCount := fs.Int("lookup-retry-count", defaultFuseLookupRetryCount, "detached retries after transient Lookup/GetAttr stat failures (set 0 to disable)")
 	lookupRetryTimeout := fs.Duration("lookup-retry-timeout", defaultFuseLookupRetryTimeout, "timeout per detached Lookup/GetAttr stat retry (must be > 0 when set)")
-	readConcurrency := fs.Int("read-concurrency", defaultFuseReadConcurrency, "maximum concurrent remote FUSE reads")
+	readConcurrency := fs.Int("read-concurrency", defaultFuseReadConcurrency, "maximum concurrent backend reads issued by FUSE")
 	legacyDirStatFallback := fs.Bool("legacy-dir-stat-fallback", false, "on Lookup stat 404, list parent to support legacy servers without directory stat")
 	readDirPrefetch := fs.Bool("readdir-prefetch", false, "prefetch small files after directory reads into the read cache")
 	prefetchMaxFiles := fs.Int("readdir-prefetch-max-files", 32, "maximum small files prefetched per directory read")

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -22,6 +22,7 @@ import (
 const (
 	defaultFuseLookupRetryCount   = 3
 	defaultFuseLookupRetryTimeout = 2 * time.Second
+	defaultFuseReadConcurrency    = 24
 )
 
 var (
@@ -91,6 +92,7 @@ func fsMountCmd(args []string) error {
 	flushDebounce := fs.Duration("flush-debounce", -1, "debounce window for small-file flush coalescing (default 2s, 0 disables)")
 	lookupRetryCount := fs.Int("lookup-retry-count", defaultFuseLookupRetryCount, "detached retries after transient Lookup/GetAttr stat failures (set 0 to disable)")
 	lookupRetryTimeout := fs.Duration("lookup-retry-timeout", defaultFuseLookupRetryTimeout, "timeout per detached Lookup/GetAttr stat retry (must be > 0 when set)")
+	readConcurrency := fs.Int("read-concurrency", defaultFuseReadConcurrency, "maximum concurrent remote FUSE reads")
 	legacyDirStatFallback := fs.Bool("legacy-dir-stat-fallback", false, "on Lookup stat 404, list parent to support legacy servers without directory stat")
 	readDirPrefetch := fs.Bool("readdir-prefetch", false, "prefetch small files after directory reads into the read cache")
 	prefetchMaxFiles := fs.Int("readdir-prefetch-max-files", 32, "maximum small files prefetched per directory read")
@@ -149,6 +151,9 @@ func fsMountCmd(args []string) error {
 	lookupRetryTimeoutGiven := flagProvided(fs, "lookup-retry-timeout")
 	if err := validateLookupRetryFlags(*lookupRetryCount, *lookupRetryTimeout, lookupRetryCountGiven, lookupRetryTimeoutGiven); err != nil {
 		return err
+	}
+	if *readConcurrency <= 0 {
+		return fmt.Errorf("drive9 mount: --read-concurrency must be > 0")
 	}
 	if err := validateReadDirPrefetchFlags(*prefetchMaxFiles, *prefetchMaxFileBytes, *prefetchMaxBytes, *prefetchTimeout); err != nil {
 		return err
@@ -245,6 +250,7 @@ func fsMountCmd(args []string) error {
 		SyncMode:              syncModeVal,
 		WritePolicy:           writePolicyVal,
 		Profile:               *profile,
+		ReadConcurrency:       *readConcurrency,
 		AllowOther:            *allowOther,
 		ReadOnly:              *readOnly,
 		Debug:                 *debug,

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -750,6 +750,48 @@ func TestMountCmdPassesReadCacheMaxFileOption(t *testing.T) {
 	}
 }
 
+func TestMountCmdPassesReadConcurrencyOption(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--read-concurrency", "12",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if got.ReadConcurrency != 12 {
+		t.Fatalf("ReadConcurrency = %d, want 12", got.ReadConcurrency)
+	}
+}
+
+func TestMountCmdRejectsInvalidReadConcurrency(t *testing.T) {
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--read-concurrency", "0",
+		t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "--read-concurrency") {
+		t.Fatalf("MountCmd error = %v, want read-concurrency validation error", err)
+	}
+}
+
 func TestMountCmdMapsDurabilityOption(t *testing.T) {
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -35,6 +35,7 @@ type Dat9FS struct {
 	dirHandles  *HandleTable[*DirHandle]
 	readCache   *ReadCache
 	dirCache    *DirCache
+	readSlots   chan struct{}
 	dirtyMu     sync.Mutex
 	dirtyInodes map[uint64]dirtyInodeState
 	dirtySeq    uint64
@@ -176,6 +177,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		dirHandles:    NewHandleTable[*DirHandle](),
 		readCache:     NewReadCacheWithMaxFileSize(opts.CacheSize, 0, opts.ReadCacheMaxFileBytes),
 		dirCache:      NewNamespaceCache(opts.DirTTL, opts.NegativeEntryTTL, defaultNamespaceCacheMaxEntries),
+		readSlots:     make(chan struct{}, readConcurrencyOrDefault(opts.ReadConcurrency)),
 		dirtyInodes:   make(map[uint64]dirtyInodeState),
 		uid:           uint32(os.Getuid()),
 		gid:           uint32(os.Getgid()),
@@ -236,7 +238,33 @@ const (
 	// readTransientRetryTimeout keeps each detached read retry bounded.
 	// Each retry reads at most max_read (1 MiB), so 2s is generous.
 	readTransientRetryTimeout = 2 * time.Second
+
+	// defaultRemoteReadConcurrency leaves headroom under MountOptions'
+	// MaxBackground=32 for writes/flushes while heavy read workloads are active.
+	defaultRemoteReadConcurrency = 24
 )
+
+func readConcurrencyOrDefault(n int) int {
+	if n <= 0 {
+		return defaultRemoteReadConcurrency
+	}
+	return n
+}
+
+func (fs *Dat9FS) acquireRemoteReadSlot(ctx context.Context) (func(), error) {
+	if fs == nil || fs.readSlots == nil {
+		return func() {}, nil
+	}
+	select {
+	case fs.readSlots <- struct{}{}:
+		var once sync.Once
+		return func() {
+			once.Do(func() { <-fs.readSlots })
+		}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
 
 // releaseTimeout computes a generous timeout for synchronous uploads in
 // Release / FlushAll based on file size. The formula is:
@@ -529,6 +557,11 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 
 		lpCtx, lpCf := context.WithTimeout(context.Background(), fuseTimeout)
 		defer lpCf()
+		releaseReadSlot, err := fs.acquireRemoteReadSlot(lpCtx)
+		if err != nil {
+			return nil, err
+		}
+		defer releaseReadSlot()
 
 		loadStart := time.Now()
 		fs.debugf("dirty load part start path=%s part=%d off=%d len=%d", filePath, partNum, offset, length)
@@ -3451,7 +3484,14 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		// Cache miss: read the file and store it. No separate Stat needed —
 		// ReadCtx fetches the data in one round-trip. Uses detached retry
 		// so a single FUSE interrupt doesn't permanently return EAGAIN.
-		data, err := fs.readSmallFileWithRetry(ctx, p)
+		data, err := func() ([]byte, error) {
+			releaseReadSlot, err := fs.acquireRemoteReadSlot(ctx)
+			if err != nil {
+				return nil, err
+			}
+			defer releaseReadSlot()
+			return fs.readSmallFileWithRetry(ctx, p)
+		}()
 		if err != nil {
 			source = "small-read-error"
 			if errors.Is(err, errReadRetriesExhausted) {
@@ -3483,7 +3523,14 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		source = "range-read"
 	}
 	rangeStart := time.Now()
-	data, n, err := fs.readStreamRangeWithRetry(ctx, p, fh, int64(input.Offset), int64(input.Size))
+	data, n, err := func() ([]byte, int, error) {
+		releaseReadSlot, err := fs.acquireRemoteReadSlot(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+		defer releaseReadSlot()
+		return fs.readStreamRangeWithRetry(ctx, p, fh, int64(input.Offset), int64(input.Size))
+	}()
 	if err != nil {
 		fs.debugf("read range error path=%s off=%d req=%d got=%d source=%s dur=%s err=%v", p, input.Offset, input.Size, n, source, time.Since(rangeStart), err)
 		if errors.Is(err, errReadRetriesExhausted) {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -239,8 +239,9 @@ const (
 	// Each retry reads at most max_read (1 MiB), so 2s is generous.
 	readTransientRetryTimeout = 2 * time.Second
 
-	// defaultRemoteReadConcurrency leaves headroom under MountOptions'
-	// MaxBackground=32 for writes/flushes while heavy read workloads are active.
+	// defaultRemoteReadConcurrency bounds backend read fan-out from one FUSE
+	// mount. This protects Drive9/S3/TiDB from read floods; it does not reserve
+	// kernel FUSE MaxBackground slots before go-fuse dispatches a request.
 	defaultRemoteReadConcurrency = 24
 )
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2675,6 +2675,20 @@ func TestMountOptionsLookupRetryDefaultsAndDisableSentinel(t *testing.T) {
 	}
 }
 
+func TestMountOptionsReadConcurrencyDefaults(t *testing.T) {
+	defaults := &MountOptions{}
+	defaults.setDefaults()
+	if defaults.ReadConcurrency != defaultRemoteReadConcurrency {
+		t.Fatalf("default ReadConcurrency = %d, want %d", defaults.ReadConcurrency, defaultRemoteReadConcurrency)
+	}
+
+	explicit := &MountOptions{ReadConcurrency: 7}
+	explicit.setDefaults()
+	if explicit.ReadConcurrency != 7 {
+		t.Fatalf("explicit ReadConcurrency = %d, want 7", explicit.ReadConcurrency)
+	}
+}
+
 func TestLookupReturnsTTLInEntryOut(t *testing.T) {
 	fs, _, cleanup := newTestDat9FS(t, 42, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(make([]byte, 42))
@@ -6398,6 +6412,165 @@ func TestReadSmallFileRetryExhaustedReturnsEIO(t *testing.T) {
 	wantCalls := int32(1 + readTransientRetryCount)
 	if got := getCalls.Load(); got != wantCalls {
 		t.Fatalf("GET calls = %d, want %d", got, wantCalls)
+	}
+}
+
+func TestRemoteReadLimiterCapsConcurrentRangeReads(t *testing.T) {
+	const (
+		readLimit = 2
+		totalRead = 5
+		chunkSize = 4096
+	)
+	var inflight atomic.Int32
+	var maxInflight atomic.Int32
+	started := make(chan struct{}, totalRead)
+	ready := make(chan struct{}, totalRead)
+	startReads := make(chan struct{})
+	releaseServerReads := make(chan struct{})
+	var releaseServerReadsOnce sync.Once
+	releaseAllServerReads := func() {
+		releaseServerReadsOnce.Do(func() { close(releaseServerReads) })
+	}
+	t.Cleanup(releaseAllServerReads)
+	response := bytes.Repeat([]byte("x"), chunkSize)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/fs/large.bin" {
+			http.NotFound(w, r)
+			return
+		}
+		cur := inflight.Add(1)
+		defer inflight.Add(-1)
+		for {
+			max := maxInflight.Load()
+			if cur <= max || maxInflight.CompareAndSwap(max, cur) {
+				break
+			}
+		}
+		started <- struct{}{}
+		<-releaseServerReads
+		w.Header().Set("Content-Length", strconv.Itoa(len(response)))
+		_, _ = w.Write(response)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{ReadConcurrency: readLimit}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	wb := fs.newWriteBuffer("/large.bin", streamingWriteMaxSize, chunkSize)
+	wb.totalSize = int64(totalRead * chunkSize)
+	wb.remoteSize = wb.totalSize
+	fhID := fs.fileHandles.Allocate(&FileHandle{
+		Path:  "/large.bin",
+		Dirty: wb, // skip read-target resolution; exercise the remote range read path only.
+	})
+
+	var wg sync.WaitGroup
+	errs := make(chan string, totalRead)
+	for i := range totalRead {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ready <- struct{}{}
+			<-startReads
+			_, st := fs.Read(nil, &gofuse.ReadIn{
+				Fh:     fhID,
+				Offset: uint64(i * chunkSize),
+				Size:   chunkSize,
+			}, nil)
+			if st != gofuse.OK {
+				errs <- fmt.Sprintf("read %d status = %v, want OK", i, st)
+			}
+		}(i)
+	}
+
+	for i := 0; i < totalRead; i++ {
+		select {
+		case <-ready:
+		case <-time.After(time.Second):
+			t.Fatalf("only %d read goroutines started, want %d", i, totalRead)
+		}
+	}
+	close(startReads)
+
+	for i := 0; i < readLimit; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("only %d remote reads reached server, want %d", i, readLimit)
+		}
+	}
+	select {
+	case <-started:
+		t.Fatal("third remote read reached server before a read slot was released")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseAllServerReads()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if got := maxInflight.Load(); got > readLimit {
+		t.Fatalf("max remote reads in flight = %d, want <= %d", got, readLimit)
+	}
+}
+
+func TestRemoteReadLimiterAcquireHonorsCancellationAndReleases(t *testing.T) {
+	opts := &MountOptions{ReadConcurrency: 1}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://127.0.0.1", ""), opts)
+
+	release, err := fs.acquireRemoteReadSlot(context.Background())
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := fs.acquireRemoteReadSlot(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled acquire err = %v, want context.Canceled", err)
+	}
+
+	release()
+	releaseAgain, err := fs.acquireRemoteReadSlot(context.Background())
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	releaseAgain()
+}
+
+func TestRemoteReadLimiterDoesNotGateWrite(t *testing.T) {
+	opts := &MountOptions{ReadConcurrency: 1}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New("http://127.0.0.1", ""), opts)
+
+	release, err := fs.acquireRemoteReadSlot(context.Background())
+	if err != nil {
+		t.Fatalf("acquire read slot: %v", err)
+	}
+	defer release()
+
+	ino := fs.inodes.Lookup("/out.txt", false, 0, time.Now())
+	fhID := fs.fileHandles.Allocate(&FileHandle{
+		Ino:   ino,
+		Path:  "/out.txt",
+		Dirty: fs.newWriteBuffer("/out.txt", maxPreloadSize, 0),
+	})
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		_, st := fs.Write(nil, &gofuse.WriteIn{Fh: fhID, Offset: 0}, []byte("ok"))
+		done <- st
+	}()
+
+	select {
+	case st := <-done:
+		if st != gofuse.OK {
+			t.Fatalf("Write status = %v, want OK", st)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Write blocked behind the remote read limiter")
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -6541,7 +6541,7 @@ func TestRemoteReadLimiterAcquireHonorsCancellationAndReleases(t *testing.T) {
 	releaseAgain()
 }
 
-func TestRemoteReadLimiterDoesNotGateWrite(t *testing.T) {
+func TestRemoteReadLimiterDoesNotGateWriteHandler(t *testing.T) {
 	opts := &MountOptions{ReadConcurrency: 1}
 	opts.setDefaults()
 	fs := NewDat9FS(client.New("http://127.0.0.1", ""), opts)
@@ -6570,7 +6570,7 @@ func TestRemoteReadLimiterDoesNotGateWrite(t *testing.T) {
 			t.Fatalf("Write status = %v, want OK", st)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("Write blocked behind the remote read limiter")
+		t.Fatal("Write handler blocked behind the remote read limiter")
 	}
 }
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -46,7 +46,7 @@ type MountOptions struct {
 	WritePolicy           WritePolicy   // writeback, close-sync, or write-sync (default writeback)
 	Profile               string        // mount profile: "interactive", "" (default)
 	UploadConcurrency     int           // number of background upload workers (default 4)
-	ReadConcurrency       int           // maximum concurrent remote reads (default 24)
+	ReadConcurrency       int           // maximum concurrent backend reads issued by FUSE (default 24)
 	LookupRetryCount      int           // detached retries after transient Lookup/GetAttr stat failures (default 2)
 	LookupRetryTimeout    time.Duration // timeout per detached stat retry after interrupt/transient errors (default 250ms)
 	LegacyDirStatFallback bool          // on Lookup stat 404, list parent to support legacy servers without directory stat

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -46,6 +46,7 @@ type MountOptions struct {
 	WritePolicy           WritePolicy   // writeback, close-sync, or write-sync (default writeback)
 	Profile               string        // mount profile: "interactive", "" (default)
 	UploadConcurrency     int           // number of background upload workers (default 4)
+	ReadConcurrency       int           // maximum concurrent remote reads (default 24)
 	LookupRetryCount      int           // detached retries after transient Lookup/GetAttr stat failures (default 2)
 	LookupRetryTimeout    time.Duration // timeout per detached stat retry after interrupt/transient errors (default 250ms)
 	LegacyDirStatFallback bool          // on Lookup stat 404, list parent to support legacy servers without directory stat
@@ -90,6 +91,9 @@ func (o *MountOptions) setDefaults() {
 	}
 	if o.UploadConcurrency <= 0 {
 		o.UploadConcurrency = 4
+	}
+	if o.ReadConcurrency <= 0 {
+		o.ReadConcurrency = defaultRemoteReadConcurrency
 	}
 	if o.LookupRetryCount < 0 {
 		// Negative values are CLI-internal sentinels meaning retries were


### PR DESCRIPTION
## Summary
- add a configurable `--read-concurrency` FUSE mount option, defaulting to 24 backend reads
- gate backend READ traffic from FUSE small-file reads, range reads, and lazy dirty-part loads
- preserve cache/local read fast paths and keep FUSE Write/Flush handlers outside the limiter

## Scope correction
This PR is a **backend remote-read fan-out cap**. It protects the Drive9 server/S3/TiDB path from one mount issuing unbounded remote reads.

It does **not** claim to reserve kernel FUSE `MaxBackground` slots for write/flush work. The limiter runs inside `Dat9FS.Read`, after go-fuse has already dispatched the request into userspace, so true FUSE-dispatch fairness remains a separate follow-up.

## Tests
- `go test ./pkg/fuse ./cmd/drive9/cli -count=1`
- `go vet ./pkg/fuse ./cmd/drive9/cli`
- `go build ./cmd/drive9`
- `git diff --check`
