### PR TITLE
feat(cli): expose positional reads

### DIFF
--- a/cmd/drive9/cli/cat.go
+++ b/cmd/drive9/cli/cat.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -15,19 +16,57 @@ import (
 //	drive9 fs cat /path/to/file
 //	drive9 fs cat :/path/to/file
 func Cat(c *client.Client, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("usage: drive9 fs cat <path>")
+	return catWithWriter(c, args, os.Stdout)
+}
+
+func catWithWriter(c *client.Client, args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("fs cat", flag.ContinueOnError)
+	offset := fs.Int64("offset", 0, "byte offset for a positional read; requires --length")
+	length := fs.Int64("length", 0, "byte length for a positional read; requires --offset")
+	if err := fs.Parse(args); err != nil {
+		return err
 	}
-	path := args[0]
+	offsetSet := false
+	lengthSet := false
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "offset":
+			offsetSet = true
+		case "length":
+			lengthSet = true
+		}
+	})
+
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: drive9 fs cat [--offset N --length N] <path>")
+	}
+	if offsetSet != lengthSet {
+		return fmt.Errorf("--offset and --length must be provided together")
+	}
+	if *offset < 0 {
+		return fmt.Errorf("--offset must be >= 0")
+	}
+	if *length < 0 {
+		return fmt.Errorf("--length must be >= 0")
+	}
+	path := fs.Arg(0)
 	// Handle ":" prefixed remote paths like cp command
 	if rp, isRemote := ParseRemote(path); isRemote {
 		path = rp.Path
 	}
-	rc, err := c.ReadStream(context.Background(), path)
+	var (
+		rc  io.ReadCloser
+		err error
+	)
+	if offsetSet {
+		rc, err = c.ReadStreamRange(context.Background(), path, *offset, *length)
+	} else {
+		rc, err = c.ReadStream(context.Background(), path)
+	}
 	if err != nil {
 		return err
 	}
 	defer func() { _ = rc.Close() }()
-	_, err = io.Copy(os.Stdout, rc)
+	_, err = io.Copy(out, rc)
 	return err
 }

--- a/cmd/drive9/cli/cat_test.go
+++ b/cmd/drive9/cli/cat_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+func TestCatWritesFullFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/fs/file.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("hello world"))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	if err := catWithWriter(client.New(srv.URL, ""), []string{":/file.txt"}, &out); err != nil {
+		t.Fatalf("Cat: %v", err)
+	}
+	if got := out.String(); got != "hello world" {
+		t.Fatalf("Cat output = %q, want hello world", got)
+	}
+}
+
+func TestCatRangeWritesRequestedBytes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/fs/large.bin":
+			w.Header().Set("Location", fmt.Sprintf("http://%s/s3/presigned", r.Host))
+			w.WriteHeader(http.StatusFound)
+		case "/s3/presigned":
+			if got := r.Header.Get("Range"); got != "bytes=2-5" {
+				http.Error(w, "wrong range: "+got, http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte("2345"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	err := catWithWriter(client.New(srv.URL, ""), []string{"--offset", "2", "--length", "4", ":/large.bin"}, &out)
+	if err != nil {
+		t.Fatalf("Cat range: %v", err)
+	}
+	if got := out.String(); got != "2345" {
+		t.Fatalf("Cat range output = %q, want 2345", got)
+	}
+}
+
+func TestCatRangeRequiresOffsetAndLength(t *testing.T) {
+	c := client.New("http://127.0.0.1", "")
+	if err := catWithWriter(c, []string{"--offset", "2", ":/large.bin"}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "provided together") {
+		t.Fatalf("offset-only error = %v, want paired flag error", err)
+	}
+	if err := catWithWriter(c, []string{"--length", "4", ":/large.bin"}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "provided together") {
+		t.Fatalf("length-only error = %v, want paired flag error", err)
+	}
+}
+
+func TestCatRangeRejectsNegativeInputs(t *testing.T) {
+	c := client.New("http://127.0.0.1", "")
+	if err := catWithWriter(c, []string{"--offset", "-1", "--length", "4", ":/large.bin"}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "--offset") {
+		t.Fatalf("negative offset error = %v, want offset error", err)
+	}
+	if err := catWithWriter(c, []string{"--offset", "0", "--length", "-1", ":/large.bin"}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "--length") {
+		t.Fatalf("negative length error = %v, want length error", err)
+	}
+}

--- a/cmd/drive9/cli/cat_test.go
+++ b/cmd/drive9/cli/cat_test.go
@@ -78,3 +78,24 @@ func TestCatRangeRejectsNegativeInputs(t *testing.T) {
 		t.Fatalf("negative length error = %v, want length error", err)
 	}
 }
+
+func TestCatRangeAllowsZeroLength(t *testing.T) {
+	var hitServer bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitServer = true
+		http.Error(w, "zero-length range should not fetch", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	err := catWithWriter(client.New(srv.URL, ""), []string{"--offset", "10", "--length", "0", ":/large.bin"}, &out)
+	if err != nil {
+		t.Fatalf("Cat zero-length range: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("Cat zero-length output = %q, want empty", out.String())
+	}
+	if hitServer {
+		t.Fatal("zero-length range should not issue a read request")
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -562,6 +562,21 @@ func (c *Client) ReadCtx(ctx context.Context, path string) ([]byte, error) {
 	return io.ReadAll(resp.Body)
 }
 
+// ReadAt downloads at most length bytes starting at offset.
+func (c *Client) ReadAt(path string, offset, length int64) ([]byte, error) {
+	return c.ReadAtCtx(context.Background(), path, offset, length)
+}
+
+// ReadAtCtx downloads at most length bytes starting at offset with context support.
+func (c *Client) ReadAtCtx(ctx context.Context, path string, offset, length int64) ([]byte, error) {
+	rc, err := c.ReadStreamRange(ctx, path, offset, length)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+	return io.ReadAll(rc)
+}
+
 // List returns the entries in a directory.
 func (c *Client) List(path string) ([]FileInfo, error) {
 	return c.ListCtx(context.Background(), path)

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -1269,11 +1269,12 @@ func (c *Client) downloadToFileSequential(ctx context.Context, remotePath string
 	return nil, err
 }
 
-// ReadStreamRange reads a byte range from a remote file. For large files the
-// server returns a 302 redirect to a presigned S3 URL; this method resolves
-// that redirect and issues an HTTP Range request so only the requested bytes
-// are transferred. For small files (no redirect) the full body is returned
-// and the caller should read only what it needs.
+// ReadStreamRange reads at most length bytes from a remote file starting at
+// offset. For large files the server returns a 302 redirect to a presigned S3
+// URL; this method resolves that redirect and issues an HTTP Range request so
+// only the requested bytes are transferred. For inline small files, the server
+// sends the full body and this method returns a reader limited to the requested
+// slice.
 func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, length int64) (io.ReadCloser, error) {
 	if offset < 0 {
 		return nil, fmt.Errorf("offset must be >= 0")

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -1285,6 +1285,9 @@ func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, lengt
 	if length <= 0 {
 		return io.NopCloser(bytes.NewReader(nil)), nil
 	}
+	if offset > (int64(^uint64(0)>>1) - length + 1) {
+		return nil, fmt.Errorf("offset + length overflows int64")
+	}
 
 	resp, err := c.readWithoutRedirect(ctx, path)
 	if err != nil {
@@ -1344,6 +1347,9 @@ func (c *Client) readObjectRangeStrict(ctx context.Context, objectURL string, of
 	}
 	if length <= 0 {
 		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+	if offset > (int64(^uint64(0)>>1) - length + 1) {
+		return nil, fmt.Errorf("offset + length overflows int64")
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, objectURL, nil)

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -1275,6 +1275,12 @@ func (c *Client) downloadToFileSequential(ctx context.Context, remotePath string
 // are transferred. For small files (no redirect) the full body is returned
 // and the caller should read only what it needs.
 func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, length int64) (io.ReadCloser, error) {
+	if offset < 0 {
+		return nil, fmt.Errorf("offset must be >= 0")
+	}
+	if length < 0 {
+		return nil, fmt.Errorf("length must be >= 0")
+	}
 	if length <= 0 {
 		return io.NopCloser(bytes.NewReader(nil)), nil
 	}
@@ -1329,6 +1335,12 @@ func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, lengt
 }
 
 func (c *Client) readObjectRangeStrict(ctx context.Context, objectURL string, offset, length int64) (io.ReadCloser, error) {
+	if offset < 0 {
+		return nil, fmt.Errorf("offset must be >= 0")
+	}
+	if length < 0 {
+		return nil, fmt.Errorf("length must be >= 0")
+	}
 	if length <= 0 {
 		return io.NopCloser(bytes.NewReader(nil)), nil
 	}

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1548,6 +1548,17 @@ func TestReadStreamRangeRejectsNegativeInputs(t *testing.T) {
 	}
 }
 
+func TestReadStreamRangeRejectsOverflow(t *testing.T) {
+	c := New("http://127.0.0.1", "")
+	maxInt64 := int64(^uint64(0) >> 1)
+	if _, err := c.ReadStreamRange(context.Background(), "/file.txt", maxInt64, 2); err == nil || !strings.Contains(err.Error(), "overflows") {
+		t.Fatalf("overflow err = %v, want overflow error", err)
+	}
+	if _, err := c.ReadObjectRange(context.Background(), &ReadTarget{ObjectURL: "http://127.0.0.1/object"}, maxInt64, 2); err == nil || !strings.Contains(err.Error(), "overflows") {
+		t.Fatalf("object overflow err = %v, want overflow error", err)
+	}
+}
+
 func TestResolveReadTargetAndReadObjectRange(t *testing.T) {
 	var readRequests atomic.Int32
 	var objectRequests atomic.Int32

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1474,6 +1474,70 @@ func TestReadAtCtxUsesRangeAndReturnsBytes(t *testing.T) {
 	}
 }
 
+func TestReadAtCtxInlineFileReturnsRequestedSlice(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/fs/small.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("0123456789"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	got, err := c.ReadAtCtx(context.Background(), "/small.txt", 3, 4)
+	if err != nil {
+		t.Fatalf("ReadAtCtx inline: %v", err)
+	}
+	if string(got) != "3456" {
+		t.Fatalf("ReadAtCtx inline = %q, want 3456", got)
+	}
+}
+
+func TestReadAtCtxOffsetPastEOFReturnsEmpty(t *testing.T) {
+	t.Run("inline", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/fs/small.txt" {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write([]byte("small"))
+		}))
+		defer srv.Close()
+
+		got, err := New(srv.URL, "").ReadAtCtx(context.Background(), "/small.txt", 99, 4)
+		if err != nil {
+			t.Fatalf("ReadAtCtx inline EOF: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("ReadAtCtx inline EOF = %q, want empty", got)
+		}
+	})
+
+	t.Run("large", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/v1/fs/large.bin":
+				w.Header().Set("Location", fmt.Sprintf("http://%s/s3/presigned", r.Host))
+				w.WriteHeader(http.StatusFound)
+			case "/s3/presigned":
+				w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer srv.Close()
+
+		got, err := New(srv.URL, "").ReadAtCtx(context.Background(), "/large.bin", 99, 4)
+		if err != nil {
+			t.Fatalf("ReadAtCtx large EOF: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("ReadAtCtx large EOF = %q, want empty", got)
+		}
+	})
+}
+
 func TestReadStreamRangeRejectsNegativeInputs(t *testing.T) {
 	c := New("http://127.0.0.1", "")
 	if _, err := c.ReadStreamRange(context.Background(), "/file.txt", -1, 4); err == nil || !strings.Contains(err.Error(), "offset") {

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1445,6 +1445,45 @@ func TestReadStreamRangeLargeFileTreats416AsEOF(t *testing.T) {
 	}
 }
 
+func TestReadAtCtxUsesRangeAndReturnsBytes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/fs/large.bin":
+			w.Header().Set("Location", fmt.Sprintf("http://%s/s3/presigned", r.Host))
+			w.WriteHeader(http.StatusFound)
+		case "/s3/presigned":
+			if got := r.Header.Get("Range"); got != "bytes=2-5" {
+				http.Error(w, "wrong range: "+got, http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte("2345"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	got, err := c.ReadAtCtx(context.Background(), "/large.bin", 2, 4)
+	if err != nil {
+		t.Fatalf("ReadAtCtx: %v", err)
+	}
+	if string(got) != "2345" {
+		t.Fatalf("ReadAtCtx = %q, want 2345", got)
+	}
+}
+
+func TestReadStreamRangeRejectsNegativeInputs(t *testing.T) {
+	c := New("http://127.0.0.1", "")
+	if _, err := c.ReadStreamRange(context.Background(), "/file.txt", -1, 4); err == nil || !strings.Contains(err.Error(), "offset") {
+		t.Fatalf("negative offset err = %v, want offset error", err)
+	}
+	if _, err := c.ReadStreamRange(context.Background(), "/file.txt", 0, -1); err == nil || !strings.Contains(err.Error(), "length") {
+		t.Fatalf("negative length err = %v, want length error", err)
+	}
+}
+
 func TestResolveReadTargetAndReadObjectRange(t *testing.T) {
 	var readRequests atomic.Int32
 	var objectRequests atomic.Int32


### PR DESCRIPTION
## Summary
- expose positional reads through the Go SDK via `Client.ReadAt` / `ReadAtCtx`
- add `drive9 fs cat --offset N --length N <path>` for byte-range reads without downloading the whole large object
- validate negative offsets/lengths explicitly and require CLI `--offset` + `--length` as a pair

## Scope
This PR uses the existing range-capable read path (`ReadStreamRange`) that already resolves large-file redirects and sends an HTTP `Range` request to the object URL. It does not add positional write, truncate, or a new server-side recursive/read transport.

## Tests
- `go test ./pkg/client ./cmd/drive9/cli -run 'TestReadAtCtx|TestReadStreamRange|TestCat' -count=1`
- `go test ./pkg/client ./cmd/drive9/cli -count=1`
- `go vet ./pkg/client ./cmd/drive9/cli`
- `go build ./cmd/drive9`
- `git diff --check`
