### PR TITLE
fuse: expose sync-read mount option

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ drive9 mount [flags] [:/remote] <mountpoint>
   -flush-debounce duration       small-file flush debounce (default: 2s)
   -lookup-retry-count int        detached stat retries after transient lookup errors
   -lookup-retry-timeout duration timeout per detached lookup retry
+  -read-concurrency int          concurrent backend reads issued by FUSE (default: 24)
+  -fuse-sync-read                disable kernel async read dispatch per file handle
   -allow-other                   allow other users to access mount
   -read-only                     mount read-only
   -debug                         enable FUSE debug logging

--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -50,6 +50,7 @@ type mountFuseOptions struct {
 	WritePolicy           fuseWritePolicy
 	Profile               string
 	ReadConcurrency       int
+	SyncRead              bool
 	AllowOther            bool
 	ReadOnly              bool
 	Debug                 bool

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -43,6 +43,7 @@ func mountFuseImpl(opts *mountFuseOptions) error {
 		WritePolicy:           writePolicy,
 		Profile:               opts.Profile,
 		ReadConcurrency:       opts.ReadConcurrency,
+		SyncRead:              opts.SyncRead,
 		AllowOther:            opts.AllowOther,
 		ReadOnly:              opts.ReadOnly,
 		Debug:                 opts.Debug,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -93,6 +93,7 @@ func fsMountCmd(args []string) error {
 	lookupRetryCount := fs.Int("lookup-retry-count", defaultFuseLookupRetryCount, "detached retries after transient Lookup/GetAttr stat failures (set 0 to disable)")
 	lookupRetryTimeout := fs.Duration("lookup-retry-timeout", defaultFuseLookupRetryTimeout, "timeout per detached Lookup/GetAttr stat retry (must be > 0 when set)")
 	readConcurrency := fs.Int("read-concurrency", defaultFuseReadConcurrency, "maximum concurrent backend reads issued by FUSE")
+	syncRead := fs.Bool("fuse-sync-read", false, "disable kernel async read dispatch; at most one read in flight per file handle")
 	legacyDirStatFallback := fs.Bool("legacy-dir-stat-fallback", false, "on Lookup stat 404, list parent to support legacy servers without directory stat")
 	readDirPrefetch := fs.Bool("readdir-prefetch", false, "prefetch small files after directory reads into the read cache")
 	prefetchMaxFiles := fs.Int("readdir-prefetch-max-files", 32, "maximum small files prefetched per directory read")
@@ -251,6 +252,7 @@ func fsMountCmd(args []string) error {
 		WritePolicy:           writePolicyVal,
 		Profile:               *profile,
 		ReadConcurrency:       *readConcurrency,
+		SyncRead:              *syncRead,
 		AllowOther:            *allowOther,
 		ReadOnly:              *readOnly,
 		Debug:                 *debug,

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -792,6 +792,35 @@ func TestMountCmdRejectsInvalidReadConcurrency(t *testing.T) {
 	}
 }
 
+func TestMountCmdPassesFuseSyncReadOption(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--fuse-sync-read",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if !got.SyncRead {
+		t.Fatal("SyncRead = false, want true")
+	}
+}
+
 func TestMountCmdMapsDurabilityOption(t *testing.T) {
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2689,6 +2689,35 @@ func TestMountOptionsReadConcurrencyDefaults(t *testing.T) {
 	}
 }
 
+func TestMountOptionsSyncReadDefaultsToAsyncReads(t *testing.T) {
+	defaults := &MountOptions{}
+	defaults.setDefaults()
+	if defaults.SyncRead {
+		t.Fatal("default SyncRead = true, want false")
+	}
+
+	explicit := &MountOptions{SyncRead: true}
+	explicit.setDefaults()
+	if !explicit.SyncRead {
+		t.Fatal("explicit SyncRead = false, want true")
+	}
+}
+
+func TestGoFuseMountOptionsMapsSyncRead(t *testing.T) {
+	defaults := newGoFuseMountOptions(&MountOptions{})
+	if defaults.SyncRead {
+		t.Fatal("default go-fuse SyncRead = true, want false")
+	}
+
+	explicit := newGoFuseMountOptions(&MountOptions{SyncRead: true})
+	if !explicit.SyncRead {
+		t.Fatal("explicit go-fuse SyncRead = false, want true")
+	}
+	if explicit.MaxBackground != 32 {
+		t.Fatalf("MaxBackground = %d, want 32", explicit.MaxBackground)
+	}
+}
+
 func TestLookupReturnsTTLInEntryOut(t *testing.T) {
 	fs, _, cleanup := newTestDat9FS(t, 42, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(make([]byte, 42))

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -47,6 +47,7 @@ type MountOptions struct {
 	Profile               string        // mount profile: "interactive", "" (default)
 	UploadConcurrency     int           // number of background upload workers (default 4)
 	ReadConcurrency       int           // maximum concurrent backend reads issued by FUSE (default 24)
+	SyncRead              bool          // disable kernel async read dispatch; at most one read in flight per file handle
 	LookupRetryCount      int           // detached retries after transient Lookup/GetAttr stat failures (default 2)
 	LookupRetryTimeout    time.Duration // timeout per detached stat retry after interrupt/transient errors (default 250ms)
 	LegacyDirStatFallback bool          // on Lookup stat 404, list parent to support legacy servers without directory stat
@@ -293,29 +294,7 @@ func Mount(opts *MountOptions) error {
 	}
 
 	// Configure FUSE mount options
-	fuseOpts := &gofuse.MountOptions{
-		FsName:        "drive9",
-		Name:          "drive9",
-		MaxReadAhead:  8 * 1024 * 1024, // 8MB — larger readahead reduces FUSE kernel↔userspace switches
-		MaxWrite:      128 * 1024,      // 128KB per write request (default 64KB)
-		MaxBackground: 32,              // concurrent background FUSE requests (default 12)
-		Debug:         opts.Debug,
-		AllowOther:    opts.AllowOther,
-	}
-	if runtime.GOOS == "linux" {
-		fuseOpts.MaxWrite = 1024 * 1024 // 1MiB — Linux FUSE supports this natively
-	}
-	if runtime.GOOS == "darwin" {
-		// macFUSE can reject open/readdir before requests reach the daemon if
-		// it performs local permission checks or treats the volume as a
-		// privacy-gated network volume. drive9 authorization is remote, so
-		// defer permission decisions to the filesystem handlers and present the
-		// mount as local to ordinary CLI tools.
-		fuseOpts.Options = append(fuseOpts.Options, "defer_permissions", "local")
-	}
-	if opts.ReadOnly {
-		fuseOpts.Options = append(fuseOpts.Options, "ro")
-	}
+	fuseOpts := newGoFuseMountOptions(opts)
 
 	// Create FUSE server
 	server, err := gofuse.NewServer(dat9fs, opts.MountPoint, fuseOpts)
@@ -475,6 +454,34 @@ func Mount(opts *MountOptions) error {
 	server.Wait()
 	shutdown()
 	return nil
+}
+
+func newGoFuseMountOptions(opts *MountOptions) *gofuse.MountOptions {
+	fuseOpts := &gofuse.MountOptions{
+		FsName:        "drive9",
+		Name:          "drive9",
+		MaxReadAhead:  8 * 1024 * 1024, // 8MB — larger readahead reduces FUSE kernel↔userspace switches
+		MaxWrite:      128 * 1024,      // 128KB per write request (default 64KB)
+		MaxBackground: 32,              // concurrent background FUSE requests (default 12)
+		SyncRead:      opts.SyncRead,   // disables FUSE_CAP_ASYNC_READ; one read in flight per file handle
+		Debug:         opts.Debug,
+		AllowOther:    opts.AllowOther,
+	}
+	if runtime.GOOS == "linux" {
+		fuseOpts.MaxWrite = 1024 * 1024 // 1MiB — Linux FUSE supports this natively
+	}
+	if runtime.GOOS == "darwin" {
+		// macFUSE can reject open/readdir before requests reach the daemon if
+		// it performs local permission checks or treats the volume as a
+		// privacy-gated network volume. drive9 authorization is remote, so
+		// defer permission decisions to the filesystem handlers and present the
+		// mount as local to ordinary CLI tools.
+		fuseOpts.Options = append(fuseOpts.Options, "defer_permissions", "local")
+	}
+	if opts.ReadOnly {
+		fuseOpts.Options = append(fuseOpts.Options, "ro")
+	}
+	return fuseOpts
 }
 
 func newMountShutdown(stopWatcher func(), flushAll func()) func() {


### PR DESCRIPTION
## Summary

Adds an explicit `drive9 mount --fuse-sync-read` option and `MountOptions.SyncRead` plumbing. When enabled, Drive9 passes go-fuse `MountOptions.SyncRead=true`, which clears `FUSE_CAP_ASYNC_READ` during FUSE init.

Effect, per go-fuse: the kernel sends only one read request at a time per file handle, ordered by offset. This limits kernel async read fan-out at the FUSE dispatch boundary for a single hot file handle.

## Scope / non-claims

This is deliberately opt-in and conservative. It does **not** claim absolute write/flush fairness for every read flood:

- It does not reserve global `MaxBackground` slots by operation type.
- It does not stop many independent file handles from issuing one read each.
- It may reduce sequential read throughput, so the default remains unchanged.

This PR gives operators a safe FUSE-level lever beyond the backend read fan-out cap from #435. A stronger default fairness policy still needs Linux FUSE e2e evidence before we enable it by default.

## Tests

- `TestMountCmdPassesFuseSyncReadOption`
- `TestMountOptionsSyncReadDefaultsToAsyncReads`
- `TestGoFuseMountOptionsMapsSyncRead`

Local verification:

- `go test ./pkg/fuse ./cmd/drive9/cli -count=1`
- `go vet ./pkg/fuse ./cmd/drive9/cli`
- `go build ./cmd/drive9`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--fuse-sync-read` CLI flag to control kernel async read dispatch, limiting to one read in flight per file handle.
  * Documented `-read-concurrency` flag for configuring concurrent backend reads.

* **Tests**
  * Added tests validating the new sync read option behavior and defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->