### PR TITLE
auth: add workspace zone scope foundation

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -3,7 +3,9 @@ package meta
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sort"
@@ -14,6 +16,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/mysqlutil"
+	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"go.uber.org/zap"
 )
 
@@ -47,6 +50,13 @@ type APIKeyStatus string
 const (
 	APIKeyActive  APIKeyStatus = "active"
 	APIKeyRevoked APIKeyStatus = "revoked"
+)
+
+type APIKeyScopeKind string
+
+const (
+	APIKeyScopeKindOwner APIKeyScopeKind = "owner"
+	APIKeyScopeKindFS    APIKeyScopeKind = "fs_scoped"
 )
 
 type Tenant struct {
@@ -133,10 +143,21 @@ type APIKey struct {
 	JWTHash       string
 	TokenVersion  int
 	Status        APIKeyStatus
+	ScopeKind     APIKeyScopeKind
 	IssuedAt      time.Time
 	RevokedAt     *time.Time
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
+}
+
+type APIKeyFSScope struct {
+	TenantID   string
+	APIKeyID   string
+	Prefix     string
+	PrefixHash string
+	Ops        string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
 }
 
 type TenantWithAPIKey struct {
@@ -381,6 +402,7 @@ func metaInitSchemaStatements() []string {
 			jwt_hash       VARCHAR(128) NOT NULL,
 			token_version  INT NOT NULL DEFAULT 1,
 			status         VARCHAR(20) NOT NULL DEFAULT 'active',
+			scope_kind     VARCHAR(32) NOT NULL DEFAULT 'owner',
 			issued_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			revoked_at     DATETIME(3) NULL,
 			created_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
@@ -388,6 +410,18 @@ func metaInitSchemaStatements() []string {
 			UNIQUE INDEX idx_api_keys_hash (jwt_hash),
 			INDEX idx_api_keys_tenant (tenant_id, status),
 			UNIQUE INDEX idx_api_keys_tenant_name (tenant_id, key_name)
+		)`,
+		`CREATE TABLE IF NOT EXISTS tenant_api_key_fs_scopes (
+			tenant_id   VARCHAR(64) NOT NULL,
+			api_key_id  VARCHAR(64) NOT NULL,
+			prefix      TEXT NOT NULL,
+			prefix_hash VARCHAR(64) NOT NULL,
+			ops         VARCHAR(255) NOT NULL,
+			created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (tenant_id, api_key_id, prefix_hash),
+			INDEX idx_fs_scopes_api_key (api_key_id),
+			INDEX idx_fs_scopes_tenant_key (tenant_id, api_key_id)
 		)`,
 		`CREATE TABLE IF NOT EXISTS llm_usage (
 			id              BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -933,10 +967,14 @@ func (s *Store) InsertTenant(ctx context.Context, t *Tenant) (err error) {
 func (s *Store) InsertAPIKey(ctx context.Context, k *APIKey) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "insert_api_key", start, &err)
+	scopeKind, err := apiKeyScopeKindForInsert(k)
+	if err != nil {
+		return err
+	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_api_keys
-		(id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, issued_at, revoked_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		k.ID, k.TenantID, k.KeyName, k.JWTCiphertext, k.JWTHash, k.TokenVersion, k.Status,
+		(id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, scope_kind, issued_at, revoked_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		k.ID, k.TenantID, k.KeyName, k.JWTCiphertext, k.JWTHash, k.TokenVersion, k.Status, scopeKind,
 		k.IssuedAt.UTC(), k.RevokedAt, k.CreatedAt.UTC(), k.UpdatedAt.UTC())
 	if isDuplicateEntry(err) {
 		return ErrDuplicate
@@ -952,7 +990,7 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name, t.db_tls,
 			t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
 			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
-			k.id, k.tenant_id, k.key_name, k.jwt_ciphertext, k.jwt_hash, k.token_version, k.status, k.issued_at,
+			k.id, k.tenant_id, k.key_name, k.jwt_ciphertext, k.jwt_hash, k.token_version, k.status, k.scope_kind, k.issued_at,
 			k.revoked_at, k.created_at, k.updated_at
 		FROM tenant_api_keys k
 		JOIN tenants t ON t.id = k.tenant_id
@@ -974,7 +1012,7 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 		&rec.Tenant.BranchID, &claimURL, &claimExp, &rec.Tenant.SchemaVersion, &rec.Tenant.S3EncryptionMode,
 		&rec.Tenant.S3KMSKeyID, &s3BucketKeyEnabled, &rec.Tenant.CreatedAt, &rec.Tenant.UpdatedAt,
 		&rec.APIKey.ID, &rec.APIKey.TenantID, &rec.APIKey.KeyName, &rec.APIKey.JWTCiphertext,
-		&rec.APIKey.JWTHash, &rec.APIKey.TokenVersion, &rec.APIKey.Status, &rec.APIKey.IssuedAt,
+		&rec.APIKey.JWTHash, &rec.APIKey.TokenVersion, &rec.APIKey.Status, &rec.APIKey.ScopeKind, &rec.APIKey.IssuedAt,
 		&revokedAt, &rec.APIKey.CreatedAt, &rec.APIKey.UpdatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1007,6 +1045,128 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 	}
 	out = &rec
 	return out, nil
+}
+
+func (s *Store) InsertAPIKeyFSScope(ctx context.Context, scope *APIKeyFSScope) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "insert_api_key_fs_scope", start, &err)
+	if scope == nil {
+		return fmt.Errorf("fs scope is required")
+	}
+	prefix, err := canonicalFSScopePrefix(scope.Prefix)
+	if err != nil {
+		return err
+	}
+	if err := validateFSScopeOps(scope.Ops); err != nil {
+		return err
+	}
+	if strings.TrimSpace(prefix) == "" {
+		return fmt.Errorf("fs scope prefix is required")
+	}
+	prefixHash := fsScopePrefixHash(prefix)
+	createdAt := scope.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	updatedAt := scope.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = createdAt
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_api_key_fs_scopes
+		(tenant_id, api_key_id, prefix, prefix_hash, ops, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		scope.TenantID, scope.APIKeyID, prefix, prefixHash, scope.Ops,
+		createdAt.UTC(), updatedAt.UTC())
+	if isDuplicateEntry(err) {
+		return ErrDuplicate
+	}
+	return err
+}
+
+func (s *Store) ListAPIKeyFSScopes(ctx context.Context, tenantID, apiKeyID string) (out []APIKeyFSScope, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_api_key_fs_scopes", start, &err)
+	rows, err := s.db.QueryContext(ctx, `SELECT tenant_id, api_key_id, prefix, prefix_hash, ops, created_at, updated_at
+		FROM tenant_api_key_fs_scopes
+		WHERE tenant_id = ? AND api_key_id = ?
+		ORDER BY prefix`, tenantID, apiKeyID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var scope APIKeyFSScope
+		if err := rows.Scan(&scope.TenantID, &scope.APIKeyID, &scope.Prefix, &scope.PrefixHash, &scope.Ops, &scope.CreatedAt, &scope.UpdatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, scope)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func apiKeyScopeKindForInsert(k *APIKey) (APIKeyScopeKind, error) {
+	if k == nil || k.ScopeKind == "" {
+		return APIKeyScopeKindOwner, nil
+	}
+	if !isValidAPIKeyScopeKind(k.ScopeKind) {
+		return "", fmt.Errorf("unsupported api key scope kind %q", k.ScopeKind)
+	}
+	return k.ScopeKind, nil
+}
+
+func isValidAPIKeyScopeKind(kind APIKeyScopeKind) bool {
+	switch kind {
+	case APIKeyScopeKindOwner, APIKeyScopeKindFS:
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalFSScopePrefix(raw string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return "", fmt.Errorf("fs scope prefix is required")
+	}
+	if strings.TrimSpace(raw) == ":" {
+		return "", fmt.Errorf("fs scope prefix is required")
+	}
+	raw = strings.TrimPrefix(raw, ":")
+	prefix, err := pathutil.Canonicalize(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid fs scope prefix: %w", err)
+	}
+	return prefix, nil
+}
+
+func validateFSScopeOps(raw string) error {
+	ops := make(map[string]bool)
+	for _, part := range strings.Split(raw, ",") {
+		op := strings.TrimSpace(part)
+		if op == "" {
+			continue
+		}
+		switch op {
+		case "read", "list", "search", "write", "delete":
+			ops[op] = true
+		default:
+			return fmt.Errorf("unknown fs scope op %q", op)
+		}
+	}
+	if len(ops) == 0 {
+		return fmt.Errorf("empty fs scope ops")
+	}
+	if ops["search"] && !ops["read"] {
+		return fmt.Errorf("search fs scope requires read")
+	}
+	return nil
+}
+
+func fsScopePrefixHash(prefix string) string {
+	sum := sha256.Sum256([]byte(prefix))
+	return hex.EncodeToString(sum[:])
 }
 
 func (s *Store) GetTenant(ctx context.Context, id string) (out *Tenant, err error) {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -17,6 +17,7 @@ func newControlStore(t *testing.T) *Store {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
+	_, _ = s.DB().Exec("DELETE FROM tenant_api_key_fs_scopes")
 	_, _ = s.DB().Exec("DELETE FROM tenant_api_keys")
 	_, _ = s.DB().Exec("DELETE FROM tenants")
 	_, _ = s.DB().Exec("DELETE FROM llm_usage")
@@ -111,6 +112,176 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 	}
 	if got.APIKey.Status != APIKeyActive {
 		t.Fatalf("unexpected key status: %s", got.APIKey.Status)
+	}
+	if got.APIKey.ScopeKind != APIKeyScopeKindOwner {
+		t.Fatalf("unexpected key scope kind: %s", got.APIKey.ScopeKind)
+	}
+
+	badKey := *key
+	badKey.ID = "bad-scope-kind"
+	badKey.KeyName = "bad-scope-kind"
+	badKey.JWTHash = "bad-scope-kind-hash"
+	badKey.ScopeKind = APIKeyScopeKind("unknown")
+	if err := s.InsertAPIKey(context.Background(), &badKey); err == nil {
+		t.Fatal("InsertAPIKey with unknown scope kind error = nil, want error")
+	}
+}
+
+func TestInsertAndListAPIKeyFSScopes(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertTenant(context.Background(), &Tenant{
+		ID:               "scope-tenant",
+		Status:           TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_db_scopes",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertTenant(context.Background(), &Tenant{
+		ID:               "other-tenant",
+		Status:           TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_db_other_scopes",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertAPIKey(context.Background(), &APIKey{
+		ID:            "scope-key",
+		TenantID:      "scope-tenant",
+		KeyName:       "scoped",
+		JWTCiphertext: []byte("jwt-cipher"),
+		JWTHash:       "scope-hash",
+		TokenVersion:  1,
+		Status:        APIKeyActive,
+		ScopeKind:     APIKeyScopeKindFS,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := s.ResolveByAPIKeyHash(context.Background(), "scope-hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.APIKey.ScopeKind != APIKeyScopeKindFS {
+		t.Fatalf("resolved scope kind = %s, want %s", resolved.APIKey.ScopeKind, APIKeyScopeKindFS)
+	}
+	if err := s.InsertAPIKey(context.Background(), &APIKey{
+		ID:            "other-key",
+		TenantID:      "scope-tenant",
+		KeyName:       "other-scoped",
+		JWTCiphertext: []byte("jwt-cipher"),
+		JWTHash:       "other-scope-hash",
+		TokenVersion:  1,
+		Status:        APIKeyActive,
+		ScopeKind:     APIKeyScopeKindFS,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertAPIKey(context.Background(), &APIKey{
+		ID:            "other-tenant-key",
+		TenantID:      "other-tenant",
+		KeyName:       "scoped",
+		JWTCiphertext: []byte("jwt-cipher"),
+		JWTHash:       "other-tenant-scope-hash",
+		TokenVersion:  1,
+		Status:        APIKeyActive,
+		ScopeKind:     APIKeyScopeKindFS,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.InsertAPIKeyFSScope(context.Background(), &APIKeyFSScope{
+		TenantID: "scope-tenant",
+		APIKeyID: "scope-key",
+		Prefix:   "/scratch/run-1",
+		Ops:      "read,list",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertAPIKeyFSScope(context.Background(), &APIKeyFSScope{
+		TenantID: "scope-tenant",
+		APIKeyID: "other-key",
+		Prefix:   "/wrong-key",
+		Ops:      "read",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertAPIKeyFSScope(context.Background(), &APIKeyFSScope{
+		TenantID: "other-tenant",
+		APIKeyID: "scope-key",
+		Prefix:   "/wrong-tenant",
+		Ops:      "read",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.ListAPIKeyFSScopes(context.Background(), "scope-tenant", "scope-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("scope count = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].TenantID != "scope-tenant" || got[0].APIKeyID != "scope-key" || got[0].Prefix != "/scratch/run-1" || got[0].Ops != "read,list" {
+		t.Fatalf("unexpected scope row: %#v", got[0])
+	}
+
+	if err := s.InsertAPIKeyFSScope(context.Background(), &APIKeyFSScope{
+		TenantID: "scope-tenant",
+		APIKeyID: "scope-key",
+		Prefix:   "",
+		Ops:      "read",
+	}); err == nil {
+		t.Fatal("InsertAPIKeyFSScope with empty prefix error = nil, want error")
+	}
+	if err := s.InsertAPIKeyFSScope(context.Background(), &APIKeyFSScope{
+		TenantID: "scope-tenant",
+		APIKeyID: "scope-key",
+		Prefix:   ":",
+		Ops:      "read",
+	}); err == nil {
+		t.Fatal("InsertAPIKeyFSScope with bare colon prefix error = nil, want error")
+	}
+	if err := s.InsertAPIKeyFSScope(context.Background(), &APIKeyFSScope{
+		TenantID: "scope-tenant",
+		APIKeyID: "scope-key",
+		Prefix:   ":/",
+		Ops:      "read",
+	}); err != nil {
+		t.Fatalf("InsertAPIKeyFSScope with explicit root prefix error = %v, want nil", err)
+	}
+	if err := s.InsertAPIKeyFSScope(context.Background(), &APIKeyFSScope{
+		TenantID: "scope-tenant",
+		APIKeyID: "scope-key",
+		Prefix:   "/bad-search",
+		Ops:      "search",
+	}); err == nil {
+		t.Fatal("InsertAPIKeyFSScope with search-only ops error = nil, want error")
 	}
 }
 
@@ -361,6 +532,30 @@ func TestMetaSchemaSpecIncludesForkStorageNamespaceColumns(t *testing.T) {
 	}
 	_ = mustMetaTableSpec(t, mustMetaSpec(t), "storage_namespaces")
 	_ = mustMetaTableSpec(t, mustMetaSpec(t), "object_gc_candidates")
+}
+
+func TestMetaSchemaSpecIncludesAPIKeyScopeTables(t *testing.T) {
+	spec := mustMetaSpec(t)
+	apiKeys := mustMetaTableSpec(t, spec, "tenant_api_keys")
+	scopeKind, ok := apiKeys.columns["scope_kind"]
+	if !ok {
+		t.Fatal("tenant_api_keys schema missing scope_kind")
+	}
+	if scopeKind.addSQL != "ALTER TABLE tenant_api_keys ADD COLUMN scope_kind VARCHAR(32) NOT NULL DEFAULT 'owner'" {
+		t.Fatalf("scope_kind addSQL = %q", scopeKind.addSQL)
+	}
+
+	scopes := mustMetaTableSpec(t, spec, "tenant_api_key_fs_scopes")
+	for _, column := range []string{"tenant_id", "api_key_id", "prefix", "prefix_hash", "ops"} {
+		if _, ok := scopes.columns[column]; !ok {
+			t.Fatalf("tenant_api_key_fs_scopes schema missing %s", column)
+		}
+	}
+	for _, index := range []string{"primary", "idx_fs_scopes_api_key", "idx_fs_scopes_tenant_key"} {
+		if _, ok := scopes.indexes[index]; !ok {
+			t.Fatalf("tenant_api_key_fs_scopes schema missing index %s", index)
+		}
+	}
 }
 
 func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -29,6 +29,9 @@ type TenantScope struct {
 	Provider           string
 	Backend            *backend.Dat9Backend
 	JournalPermissions map[string]bool
+	ScopeKind          meta.APIKeyScopeKind
+	IsScoped           bool
+	FSScopes           []FSScope
 }
 
 const (
@@ -134,6 +137,14 @@ func writeClientCanceled(w http.ResponseWriter) {
 }
 
 func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret []byte, next http.Handler) http.Handler {
+	return tenantAuthMiddlewareWithFSScopeLoader(metaStore, pool, tokenSecret, metaStore, next)
+}
+
+type tenantFSScopeLoader interface {
+	ListAPIKeyFSScopes(ctx context.Context, tenantID, apiKeyID string) ([]meta.APIKeyFSScope, error)
+}
+
+func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.Pool, tokenSecret []byte, fsScopeLoader tenantFSScopeLoader, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authStart := time.Now()
 		tok := bearerToken(r)
@@ -241,6 +252,42 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			return
 		}
 
+		scopeKind := resolved.APIKey.ScopeKind
+		if scopeKind == "" {
+			scopeKind = meta.APIKeyScopeKindOwner
+		}
+		isScoped := false
+		var fsScopes []FSScope
+		switch scopeKind {
+		case meta.APIKeyScopeKindOwner:
+		case meta.APIKeyScopeKindFS:
+			isScoped = true
+			rows, err := fsScopeLoader.ListAPIKeyFSScopes(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID)
+			if err != nil {
+				if isClientCanceled(r.Context(), err) {
+					logAuthClientCanceled(r.Context(), "auth_fs_scope_load_client_canceled", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)
+					writeClientCanceled(w)
+					return
+				}
+				logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_fs_scope_load_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
+				metricEvent(r.Context(), "auth", "result", "fs_scope_load_failed")
+				errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
+				return
+			}
+			fsScopes, err = fsScopesFromMeta(rows)
+			if err != nil {
+				logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_fs_scope_invalid", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
+				metricEvent(r.Context(), "auth", "result", "fs_scope_invalid")
+				errJSON(w, http.StatusInternalServerError, "invalid API key scope policy")
+				return
+			}
+		default:
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_scope_kind_unsupported", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "scope_kind", scopeKind)...)
+			metricEvent(r.Context(), "auth", "result", "scope_kind_unsupported")
+			errJSON(w, http.StatusForbidden, "unsupported API key scope kind")
+			return
+		}
+
 		acquireStart := time.Now()
 		b, release, err := pool.Acquire(r.Context(), &resolved.Tenant)
 		acquireDurationMs := authPhaseMs(acquireStart)
@@ -276,6 +323,9 @@ func tenantAuthMiddleware(metaStore *meta.Store, pool *tenant.Pool, tokenSecret 
 			Provider:           resolved.Tenant.Provider,
 			Backend:            b,
 			JournalPermissions: journalPermissionsFromClaims(claims),
+			ScopeKind:          scopeKind,
+			IsScoped:           isScoped,
+			FSScopes:           fsScopes,
 		}
 		next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))
 	})

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -41,6 +41,7 @@ func newAuthRuntime(t *testing.T) (*authTestRuntime, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_key_fs_scopes")
 	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
 	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
 
@@ -121,6 +122,7 @@ func newAuthRuntime(t *testing.T) (*authTestRuntime, func()) {
 	}
 	cleanup := func() {
 		pool.Close()
+		_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_key_fs_scopes")
 		_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
 		_, _ = metaStore.DB().Exec("DELETE FROM tenants")
 		_ = metaStore.Close()
@@ -155,6 +157,44 @@ func replaceAuthRuntimeToken(t *testing.T, rt *authTestRuntime, tok string) {
 	if n != 1 {
 		t.Fatalf("updated %d api keys, want 1", n)
 	}
+}
+
+func setAuthRuntimeScopeKind(t *testing.T, rt *authTestRuntime, kind meta.APIKeyScopeKind) meta.APIKey {
+	t.Helper()
+	ctx := context.Background()
+	res, err := rt.meta.DB().ExecContext(ctx, `UPDATE tenant_api_keys
+		SET scope_kind = ?, updated_at = ?
+		WHERE tenant_id = ?`, kind, time.Now().UTC(), rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("updated %d api keys, want 1", n)
+	}
+	resolved, err := rt.meta.ResolveByAPIKeyHash(ctx, token.HashToken(rt.token))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved.APIKey
+}
+
+type recordingFSScopeLoader struct {
+	calls    int
+	tenantID string
+	apiKeyID string
+	rows     []meta.APIKeyFSScope
+	err      error
+}
+
+func (l *recordingFSScopeLoader) ListAPIKeyFSScopes(ctx context.Context, tenantID, apiKeyID string) ([]meta.APIKeyFSScope, error) {
+	l.calls++
+	l.tenantID = tenantID
+	l.apiKeyID = apiKeyID
+	return l.rows, l.err
 }
 
 func mustTempDir(t *testing.T) string {
@@ -259,6 +299,97 @@ func TestAuthLegacyTokenKeepsOwnerJournalPermissions(t *testing.T) {
 	h.ServeHTTP(rr, req)
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAuthOwnerKeyDoesNotLoadFSScopes(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	loader := &recordingFSScopeLoader{}
+
+	h := tenantAuthMiddlewareWithFSScopeLoader(rt.meta, rt.pool, rt.tokenSecret, loader, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scope := ScopeFromContext(r.Context())
+		if scope == nil {
+			http.Error(w, "missing scope", http.StatusInternalServerError)
+			return
+		}
+		if scope.IsScoped {
+			http.Error(w, "owner key should not be scoped", http.StatusInternalServerError)
+			return
+		}
+		if len(scope.FSScopes) != 0 {
+			http.Error(w, "owner key should not carry fs scopes", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/owner", nil)
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if loader.calls != 0 {
+		t.Fatalf("FS scope loader calls = %d, want 0", loader.calls)
+	}
+}
+
+func TestAuthScopedKeyLoadsFSScopes(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	key := setAuthRuntimeScopeKind(t, rt, meta.APIKeyScopeKindFS)
+	loader := &recordingFSScopeLoader{rows: []meta.APIKeyFSScope{{
+		TenantID: rt.tenantID,
+		APIKeyID: key.ID,
+		Prefix:   "/scratch/run-1/",
+		Ops:      "read,list",
+	}}}
+
+	h := tenantAuthMiddlewareWithFSScopeLoader(rt.meta, rt.pool, rt.tokenSecret, loader, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scope := ScopeFromContext(r.Context())
+		if scope == nil {
+			http.Error(w, "missing scope", http.StatusInternalServerError)
+			return
+		}
+		if !scope.IsScoped {
+			http.Error(w, "scoped key was not marked scoped", http.StatusInternalServerError)
+			return
+		}
+		if len(scope.FSScopes) != 1 || scope.FSScopes[0].Prefix != "/scratch/run-1" || !scope.FSScopes[0].Ops[FSOpRead] || !scope.FSScopes[0].Ops[FSOpList] {
+			http.Error(w, fmt.Sprintf("unexpected fs scopes: %#v", scope.FSScopes), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/scoped", nil)
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if loader.calls != 1 {
+		t.Fatalf("FS scope loader calls = %d, want 1", loader.calls)
+	}
+	if loader.tenantID != rt.tenantID || loader.apiKeyID != key.ID {
+		t.Fatalf("loader args tenant=%q key=%q, want tenant=%q key=%q", loader.tenantID, loader.apiKeyID, rt.tenantID, key.ID)
+	}
+}
+
+func TestScopedBusinessEndpointGuardDeniesUntilHandlersAuthorizePaths(t *testing.T) {
+	for _, path := range []string{"/v1/sql", "/v1/fs/file.txt", "/v1/fs:batch-stat", "/v1/uploads/initiate"} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		req = req.WithContext(withScope(req.Context(), &TenantScope{IsScoped: true}))
+		rr := httptest.NewRecorder()
+
+		(&Server{}).handleBusiness(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("path=%s status=%d body=%s, want 403", path, rr.Code, rr.Body.String())
+		}
 	}
 }
 

--- a/pkg/server/fs_authorization.go
+++ b/pkg/server/fs_authorization.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/pathutil"
+)
+
+type FSOp string
+
+const (
+	FSOpRead   FSOp = "read"
+	FSOpList   FSOp = "list"
+	FSOpSearch FSOp = "search"
+	FSOpWrite  FSOp = "write"
+	FSOpDelete FSOp = "delete"
+)
+
+var (
+	ErrFSAccessDenied = errors.New("fs access denied")
+	ErrFSInvalidPath  = errors.New("invalid fs path")
+)
+
+type FSScope struct {
+	Prefix string
+	Ops    map[FSOp]bool
+}
+
+func (s *TenantScope) AuthorizeFS(op FSOp, rawPath string) error {
+	if s == nil {
+		return ErrFSAccessDenied
+	}
+	if !s.IsScoped {
+		return nil
+	}
+	if !isKnownFSOp(op) {
+		return ErrFSAccessDenied
+	}
+	p, err := normalizeFSAuthorizationPath(rawPath)
+	if err != nil {
+		return err
+	}
+	for _, scope := range s.FSScopes {
+		if !scopeAllows(scope, op, p) {
+			continue
+		}
+		return nil
+	}
+	return ErrFSAccessDenied
+}
+
+func (s *TenantScope) AuthorizeFSPair(srcOp FSOp, srcPath string, dstOp FSOp, dstPath string) error {
+	if err := s.AuthorizeFS(srcOp, srcPath); err != nil {
+		return err
+	}
+	return s.AuthorizeFS(dstOp, dstPath)
+}
+
+func fsScopesFromMeta(rows []meta.APIKeyFSScope) ([]FSScope, error) {
+	scopes := make([]FSScope, 0, len(rows))
+	for _, row := range rows {
+		if strings.TrimSpace(row.Prefix) == "" {
+			return nil, errors.New("empty fs scope prefix")
+		}
+		if strings.TrimSpace(row.Prefix) == ":" {
+			return nil, errors.New("empty fs scope prefix")
+		}
+		prefix, err := normalizeFSAuthorizationPath(row.Prefix)
+		if err != nil {
+			return nil, fmt.Errorf("normalize prefix %q: %w", row.Prefix, err)
+		}
+		ops, err := parseFSScopeOps(row.Ops)
+		if err != nil {
+			return nil, err
+		}
+		scopes = append(scopes, FSScope{Prefix: prefix, Ops: ops})
+	}
+	return scopes, nil
+}
+
+func parseFSScopeOps(raw string) (map[FSOp]bool, error) {
+	ops := make(map[FSOp]bool)
+	for _, part := range strings.Split(raw, ",") {
+		op := FSOp(strings.TrimSpace(part))
+		if op == "" {
+			continue
+		}
+		if !isKnownFSOp(op) {
+			return nil, fmt.Errorf("unknown fs scope op %q", op)
+		}
+		ops[op] = true
+	}
+	if len(ops) == 0 {
+		return nil, errors.New("empty fs scope ops")
+	}
+	if ops[FSOpSearch] && !ops[FSOpRead] {
+		return nil, errors.New("search fs scope requires read")
+	}
+	return ops, nil
+}
+
+func scopeAllows(scope FSScope, op FSOp, p string) bool {
+	if op == FSOpSearch && !scope.Ops[FSOpRead] {
+		return false
+	}
+	if !scope.Ops[op] {
+		return false
+	}
+	return pathMatchesScope(scope.Prefix, p)
+}
+
+func pathMatchesScope(prefix, p string) bool {
+	if prefix == "/" {
+		return true
+	}
+	if p == prefix {
+		return true
+	}
+	return strings.HasPrefix(p, prefix+"/")
+}
+
+func normalizeFSAuthorizationPath(raw string) (string, error) {
+	raw = strings.TrimPrefix(raw, ":")
+	p, err := pathutil.Canonicalize(raw)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrFSInvalidPath, err)
+	}
+	return p, nil
+}
+
+func isKnownFSOp(op FSOp) bool {
+	switch op {
+	case FSOpRead, FSOpList, FSOpSearch, FSOpWrite, FSOpDelete:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/server/fs_authorization_test.go
+++ b/pkg/server/fs_authorization_test.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/meta"
+)
+
+func TestAuthorizeFSOwnerAllowsAll(t *testing.T) {
+	scope := &TenantScope{}
+	if err := scope.AuthorizeFS(FSOpDelete, "/main/secrets.txt"); err != nil {
+		t.Fatalf("owner AuthorizeFS error = %v, want nil", err)
+	}
+}
+
+func TestAuthorizeFSScopedAllowsMatchingOpAndPrefix(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch/run-1",
+			Ops:    map[FSOp]bool{FSOpRead: true, FSOpList: true, FSOpWrite: true},
+		}},
+	}
+
+	if err := scope.AuthorizeFS(FSOpRead, "/scratch/run-1/input.txt"); err != nil {
+		t.Fatalf("AuthorizeFS allowed path error = %v, want nil", err)
+	}
+	if err := scope.AuthorizeFS(FSOpWrite, ":/scratch/run-1/out.txt"); err != nil {
+		t.Fatalf("AuthorizeFS drive-style path error = %v, want nil", err)
+	}
+}
+
+func TestAuthorizeFSDeniesOutsidePrefix(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch/run-1",
+			Ops:    map[FSOp]bool{FSOpRead: true},
+		}},
+	}
+
+	err := scope.AuthorizeFS(FSOpRead, "/scratch/run-2/input.txt")
+	if !errors.Is(err, ErrFSAccessDenied) {
+		t.Fatalf("AuthorizeFS error = %v, want ErrFSAccessDenied", err)
+	}
+}
+
+func TestAuthorizeFSUsesSegmentBoundary(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/foo",
+			Ops:    map[FSOp]bool{FSOpRead: true},
+		}},
+	}
+
+	if err := scope.AuthorizeFS(FSOpRead, "/foo/bar.txt"); err != nil {
+		t.Fatalf("AuthorizeFS /foo/bar.txt error = %v, want nil", err)
+	}
+	err := scope.AuthorizeFS(FSOpRead, "/foobar/secrets.txt")
+	if !errors.Is(err, ErrFSAccessDenied) {
+		t.Fatalf("AuthorizeFS /foobar error = %v, want ErrFSAccessDenied", err)
+	}
+}
+
+func TestAuthorizeFSRejectsEscapingPathBeforeMatching(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch/run-1",
+			Ops:    map[FSOp]bool{FSOpRead: true},
+		}},
+	}
+
+	err := scope.AuthorizeFS(FSOpRead, "/scratch/run-1/../main/secrets.txt")
+	if !errors.Is(err, ErrFSInvalidPath) {
+		t.Fatalf("AuthorizeFS escaped path error = %v, want ErrFSInvalidPath", err)
+	}
+}
+
+func TestAuthorizeFSPairRequiresBothPaths(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{
+			{Prefix: "/source", Ops: map[FSOp]bool{FSOpRead: true}},
+			{Prefix: "/dest", Ops: map[FSOp]bool{FSOpWrite: true}},
+		},
+	}
+
+	if err := scope.AuthorizeFSPair(FSOpRead, "/source/a.txt", FSOpWrite, "/dest/a.txt"); err != nil {
+		t.Fatalf("AuthorizeFSPair allowed paths error = %v, want nil", err)
+	}
+	err := scope.AuthorizeFSPair(FSOpRead, "/source/a.txt", FSOpWrite, "/other/a.txt")
+	if !errors.Is(err, ErrFSAccessDenied) {
+		t.Fatalf("AuthorizeFSPair dst error = %v, want ErrFSAccessDenied", err)
+	}
+}
+
+func TestParseFSScopeOpsRejectsSearchWithoutRead(t *testing.T) {
+	if _, err := parseFSScopeOps("search"); err == nil {
+		t.Fatal("parseFSScopeOps(search) error = nil, want error")
+	}
+	if _, err := parseFSScopeOps("read,search"); err != nil {
+		t.Fatalf("parseFSScopeOps(read,search) error = %v, want nil", err)
+	}
+}
+
+func TestFSScopeFromMetaRejectsEmptyPrefix(t *testing.T) {
+	if _, err := fsScopesFromMeta(nil); err != nil {
+		t.Fatalf("fsScopesFromMeta(nil) error = %v, want nil", err)
+	}
+	if _, err := fsScopesFromMeta([]meta.APIKeyFSScope{{Prefix: "", Ops: "read"}}); err == nil {
+		t.Fatal("fsScopesFromMeta(empty prefix) error = nil, want error")
+	}
+	if _, err := fsScopesFromMeta([]meta.APIKeyFSScope{{Prefix: "   ", Ops: "read"}}); err == nil {
+		t.Fatal("fsScopesFromMeta(blank prefix) error = nil, want error")
+	}
+	if _, err := fsScopesFromMeta([]meta.APIKeyFSScope{{Prefix: ":", Ops: "read"}}); err == nil {
+		t.Fatal("fsScopesFromMeta(bare colon prefix) error = nil, want error")
+	}
+	if _, err := fsScopesFromMeta([]meta.APIKeyFSScope{{Prefix: ":/", Ops: "read"}}); err != nil {
+		t.Fatalf("fsScopesFromMeta(explicit root prefix) error = %v, want nil", err)
+	}
+}
+
+func TestIsScopedBusinessPathAllowed(t *testing.T) {
+	denied := []string{
+		"/v1/fs:batch-stat",
+		"/v1/fs:batch-read-small",
+		"/v1/fs/main.txt",
+		"/v1/uploads/initiate",
+		"/v1/uploads",
+		"/v1/uploads/upload-1/complete",
+		"/v2/uploads/upload-1/parts",
+		"/v1/sql",
+		"/v1/fork",
+		"/v1/events",
+		"/v1/journals",
+		"/v1/vault/secrets",
+	}
+	for _, p := range denied {
+		if isScopedBusinessPathAllowed(p) {
+			t.Fatalf("isScopedBusinessPathAllowed(%q) = true, want false", p)
+		}
+	}
+}
+
+func BenchmarkAuthorizeFSOwnerToken(b *testing.B) {
+	scope := &TenantScope{}
+	for i := 0; i < b.N; i++ {
+		if err := scope.AuthorizeFS(FSOpRead, "/main/file.txt"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAuthorizeFSSingleZone(b *testing.B) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch/run-1",
+			Ops:    map[FSOp]bool{FSOpRead: true},
+		}},
+	}
+	for i := 0; i < b.N; i++ {
+		if err := scope.AuthorizeFS(FSOpRead, "/scratch/run-1/file.txt"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAuthorizeFSTenZones(b *testing.B) {
+	scope := &TenantScope{IsScoped: true}
+	for _, prefix := range []string{"/zone0", "/zone1", "/zone2", "/zone3", "/zone4", "/zone5", "/zone6", "/zone7", "/zone8", "/zone9"} {
+		scope.FSScopes = append(scope.FSScopes, FSScope{
+			Prefix: prefix,
+			Ops:    map[FSOp]bool{FSOpRead: true},
+		})
+	}
+	for i := 0; i < b.N; i++ {
+		if err := scope.AuthorizeFS(FSOpRead, "/zone9/file.txt"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -386,6 +386,10 @@ func (s *Server) ListenAndServe(addr string) error {
 }
 
 func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
+	if scope := ScopeFromContext(r.Context()); scope != nil && scope.IsScoped && !isScopedBusinessPathAllowed(r.URL.Path) {
+		errJSON(w, http.StatusForbidden, "scoped token cannot access endpoint")
+		return
+	}
 	switch {
 	case r.URL.Path == "/v1/fs:batch-stat":
 		s.handleBatchStat(w, r)
@@ -415,6 +419,12 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "business_route_not_found", "path", r.URL.Path, "method", r.Method)...)
 		errJSON(w, http.StatusNotFound, "not found")
 	}
+}
+
+func isScopedBusinessPathAllowed(_ string) bool {
+	// PR A only introduces the scoped-token foundation. FS/upload routes opt in
+	// in PR C1/C2 once each handler authorizes its request path before work.
+	return false
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Add additive meta schema for workspace-zone scoped API keys: `tenant_api_keys.scope_kind` defaults to `owner`, plus `tenant_api_key_fs_scopes` for per-key FS prefix/op rows.
- Load FS scope rows only when the resolved API key has `scope_kind = 'fs_scoped'`; legacy/owner keys do not query the new scope table.
- Add request-local `TenantScope` fields, pure in-memory `AuthorizeFS` / `AuthorizeFSPair`, scoped endpoint default-deny guard, and tests for owner compatibility, scope loading, prefix boundaries, path normalization, op semantics, and tenant-scoped row lookup.

## Scope / Non-Claims
- This is PR A foundation only. It does not expose scoped token CLI/API yet and does not wire every FS handler path check; those are split into PR B/C1/C2.
- No audit/log surface is added.
- Owner/legacy keys remain full-access and keep the hot `AuthorizeFS` fast path.

## Owner Performance Guard
- `scope_kind` is read with the existing API key row.
- Owner/legacy keys skip `ListAPIKeyFSScopes`; `TestAuthOwnerKeyDoesNotLoadFSScopes` uses a fake loader to pin this.
- `AuthorizeFS` never queries DB; it reads request-local `TenantScope` only.

Benchmark on local darwin/arm64, `go test ./pkg/server -run '^$' -bench 'BenchmarkAuthorizeFS' -benchtime=200ms -count=3`:

```text
BenchmarkAuthorizeFSOwnerToken-10    ~2.6 ns/op
BenchmarkAuthorizeFSSingleZone-10    ~150-162 ns/op
BenchmarkAuthorizeFSTenZones-10      ~446-562 ns/op
```

## Verification
- `go test ./pkg/server ./pkg/meta -count=1`
- `go test ./pkg/server -run '^$' -bench 'BenchmarkAuthorizeFS' -benchtime=200ms -count=3`
- `go vet ./pkg/server ./pkg/meta`
- `go build ./cmd/drive9`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys can now be scoped to specific filesystem paths and operations
  * Filesystem-scoped API keys enforce granular access controls with configurable operations (read, write, delete, search, list)
  * Scoped API keys are denied access to protected business paths

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->