### PR TITLE
auth: wire workspace zone read-side authorization (PR C1)

### DIFF
--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -379,16 +379,40 @@ func TestAuthScopedKeyLoadsFSScopes(t *testing.T) {
 	}
 }
 
-func TestScopedBusinessEndpointGuardDeniesUntilHandlersAuthorizePaths(t *testing.T) {
-	for _, path := range []string{"/v1/sql", "/v1/fs/file.txt", "/v1/fs:batch-stat", "/v1/uploads/initiate"} {
-		req := httptest.NewRequest(http.MethodPost, path, nil)
+// TestScopedBusinessEndpointGuardDeniesNonC1Endpoints checks that scoped
+// tokens are still 403'd at the dispatcher for every endpoint NOT opened
+// by PR C1's read-side wiring. PR C1 admits POST batch-stat / batch-read-
+// small and GET/HEAD on /v1/fs/* — those have their own
+// AuthorizeFS-on-each-handler tests. Every other business endpoint
+// (write methods on /v1/fs, all uploads, sql, fork, events, journals,
+// vault) must continue to fail-closed at handleBusiness.
+func TestScopedBusinessEndpointGuardDeniesNonC1Endpoints(t *testing.T) {
+	type endpoint struct {
+		method string
+		path   string
+	}
+	deniedC1 := []endpoint{
+		{http.MethodPost, "/v1/sql"},
+		{http.MethodPut, "/v1/fs/file.txt"},    // write-side, still C2-only
+		{http.MethodDelete, "/v1/fs/file.txt"}, // write-side
+		{http.MethodPost, "/v1/fs/file.txt"},   // mkdir/copy/rename/append, C2-only
+		{http.MethodPost, "/v1/uploads/initiate"},
+		{http.MethodPost, "/v1/uploads"},
+		{http.MethodPost, "/v1/fork"},
+		{http.MethodGet, "/v1/events"},
+		{http.MethodGet, "/v1/journals"},
+		{http.MethodGet, "/v1/vault/secrets"},
+	}
+	for _, ep := range deniedC1 {
+		req := httptest.NewRequest(ep.method, ep.path, nil)
 		req = req.WithContext(withScope(req.Context(), &TenantScope{IsScoped: true}))
 		rr := httptest.NewRecorder()
 
 		(&Server{}).handleBusiness(rr, req)
 
 		if rr.Code != http.StatusForbidden {
-			t.Fatalf("path=%s status=%d body=%s, want 403", path, rr.Code, rr.Body.String())
+			t.Errorf("%s %s status=%d body=%s, want 403 (scoped token must not enter handler)",
+				ep.method, ep.path, rr.Code, rr.Body.String())
 		}
 	}
 }

--- a/pkg/server/fs_authorization.go
+++ b/pkg/server/fs_authorization.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/mem9-ai/dat9/pkg/meta"
@@ -137,5 +138,70 @@ func isKnownFSOp(op FSOp) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// writeFSAuthzError maps a workspace-zone authorization error to the canonical
+// HTTP error response shape used elsewhere in pkg/server. ErrFSAccessDenied
+// becomes 403; ErrFSInvalidPath becomes 400 because the path itself is the
+// problem (escapes the workspace, contains forbidden characters, etc.) and the
+// caller cannot recover by changing credentials. Any other error is wrapped
+// generically as 500 — that path is only hit when scope state itself is
+// malformed, which is server-side state, not a client mistake.
+func writeFSAuthzError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrFSAccessDenied):
+		errJSON(w, http.StatusForbidden, "fs access denied")
+	case errors.Is(err, ErrFSInvalidPath):
+		errJSON(w, http.StatusBadRequest, "invalid fs path")
+	default:
+		errJSON(w, http.StatusInternalServerError, "fs authorization failed")
+	}
+}
+
+// authorizeFS is a thin wrapper that lets handlers do
+//
+//	if !authorizeFS(w, r, FSOpRead, path) { return }
+//
+// instead of repeating the scope-extract + writeFSAuthzError boilerplate at
+// every call site. Returns true iff the request may proceed; on false the
+// response has already been written.
+func authorizeFS(w http.ResponseWriter, r *http.Request, op FSOp, rawPath string) bool {
+	scope := ScopeFromContext(r.Context())
+	if scope == nil {
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return false
+	}
+	if err := scope.AuthorizeFS(op, rawPath); err != nil {
+		writeFSAuthzError(w, err)
+		return false
+	}
+	return true
+}
+
+// authorizeFSPathForBatch is the per-path variant for batch endpoints
+// (batch-stat / batch-read-small). It returns the HTTP status + error string
+// to embed in the per-path result so callers can short-circuit a single
+// element without rejecting the entire batch. Returns (0, "", true) on
+// allow; otherwise the returned status/message describes the denial.
+//
+// Per-path is critical here: a 256-path batch with one out-of-zone entry
+// must NOT 403 the whole call — that would break preflight workflows
+// (recursive cp, FUSE readdir prefetch) where one denied path is normal.
+func authorizeFSPathForBatch(scope *TenantScope, op FSOp, rawPath string) (status int, message string, allowed bool) {
+	if scope == nil {
+		return http.StatusUnauthorized, "missing tenant scope", false
+	}
+	err := scope.AuthorizeFS(op, rawPath)
+	if err == nil {
+		return 0, "", true
+	}
+	switch {
+	case errors.Is(err, ErrFSAccessDenied):
+		return http.StatusForbidden, "fs access denied", false
+	case errors.Is(err, ErrFSInvalidPath):
+		return http.StatusBadRequest, "invalid fs path", false
+	default:
+		return http.StatusInternalServerError, "fs authorization failed", false
 	}
 }

--- a/pkg/server/fs_authorization_test.go
+++ b/pkg/server/fs_authorization_test.go
@@ -2,10 +2,25 @@ package server
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/mem9-ai/dat9/pkg/meta"
 )
+
+// newScopedRequest constructs a synthetic *http.Request suitable for unit-
+// testing isScopedBusinessRequestAllowed. Body is empty; we only inspect
+// method, URL.Path, and URL.Query() in the gate.
+func newScopedRequest(t *testing.T, method, path, rawQuery string) *http.Request {
+	t.Helper()
+	url := path
+	if rawQuery != "" {
+		url = path + "?" + rawQuery
+	}
+	r := httptest.NewRequest(method, url, nil)
+	return r
+}
 
 func TestAuthorizeFSOwnerAllowsAll(t *testing.T) {
 	scope := &TenantScope{}
@@ -124,25 +139,276 @@ func TestFSScopeFromMetaRejectsEmptyPrefix(t *testing.T) {
 	}
 }
 
-func TestIsScopedBusinessPathAllowed(t *testing.T) {
-	denied := []string{
-		"/v1/fs:batch-stat",
-		"/v1/fs:batch-read-small",
-		"/v1/fs/main.txt",
-		"/v1/uploads/initiate",
-		"/v1/uploads",
-		"/v1/uploads/upload-1/complete",
-		"/v2/uploads/upload-1/parts",
-		"/v1/sql",
-		"/v1/fork",
-		"/v1/events",
-		"/v1/journals",
-		"/v1/vault/secrets",
-	}
-	for _, p := range denied {
-		if isScopedBusinessPathAllowed(p) {
-			t.Fatalf("isScopedBusinessPathAllowed(%q) = true, want false", p)
+// TestIsScopedBusinessRequestAllowed verifies the dispatcher-level guard
+// admits the read-side endpoints PR C1 wires (so the handlers can run their
+// own AuthorizeFS) and continues to deny every write-side / non-FS endpoint.
+// The intent matches the @adversary-1 / @dev-1 review on the C1 thread
+// (msg b6f53023 / 4619c945 / 005e8b0b): release-order safety — never open
+// a route before a handler in this PR is known to authorize its target path.
+func TestIsScopedBusinessRequestAllowed(t *testing.T) {
+	t.Run("read-side endpoints allowed", func(t *testing.T) {
+		cases := []struct {
+			method string
+			path   string
+			query  string
+		}{
+			{http.MethodGet, "/v1/fs/main.txt", ""},
+			{http.MethodGet, "/v1/fs/dir/", "list=1"},
+			{http.MethodGet, "/v1/fs/dir/file.txt", "stat=1"},
+			{http.MethodGet, "/v1/fs/dir/", "grep=hello"},
+			{http.MethodGet, "/v1/fs/dir/", "find=name:foo"},
+			{http.MethodHead, "/v1/fs/main.txt", ""},
+			{http.MethodPost, "/v1/fs:batch-stat", ""},
+			{http.MethodPost, "/v1/fs:batch-read-small", ""},
 		}
+		for _, tc := range cases {
+			r := newScopedRequest(t, tc.method, tc.path, tc.query)
+			if !isScopedBusinessRequestAllowed(r) {
+				t.Errorf("isScopedBusinessRequestAllowed(%s %s?%s) = false, want true",
+					tc.method, tc.path, tc.query)
+			}
+		}
+	})
+
+	t.Run("write-side endpoints denied (left for C2)", func(t *testing.T) {
+		cases := []struct {
+			method string
+			path   string
+			query  string
+		}{
+			{http.MethodPut, "/v1/fs/main.txt", ""},
+			{http.MethodPatch, "/v1/fs/main.txt", ""},
+			{http.MethodDelete, "/v1/fs/main.txt", ""},
+			{http.MethodPost, "/v1/fs/main.txt", "append=1"},
+			{http.MethodPost, "/v1/fs/main.txt", "copy=1"},
+			{http.MethodPost, "/v1/fs/main.txt", "rename=1"},
+			{http.MethodPost, "/v1/fs/main.txt", "mkdir=1"},
+			{http.MethodPost, "/v1/fs/main.txt", "chmod=1"},
+			{http.MethodPost, "/v1/fs/main.txt", "create=1"},
+			{http.MethodGet, "/v1/fs:batch-stat", ""},          // wrong method for this endpoint
+			{http.MethodGet, "/v1/fs:batch-read-small", ""},    // wrong method
+			{http.MethodPost, "/v1/uploads", ""},
+			{http.MethodPost, "/v1/uploads/initiate", ""},
+			{http.MethodPost, "/v1/uploads/upload-1/complete", ""},
+			{http.MethodPost, "/v2/uploads/upload-1/parts", ""},
+			{http.MethodPost, "/v1/sql", ""},
+			{http.MethodPost, "/v1/fork", ""},
+			{http.MethodGet, "/v1/events", ""},
+			{http.MethodGet, "/v1/journals", ""},
+			{http.MethodGet, "/v1/vault/secrets", ""},
+		}
+		for _, tc := range cases {
+			r := newScopedRequest(t, tc.method, tc.path, tc.query)
+			if isScopedBusinessRequestAllowed(r) {
+				t.Errorf("isScopedBusinessRequestAllowed(%s %s?%s) = true, want false",
+					tc.method, tc.path, tc.query)
+			}
+		}
+	})
+
+	t.Run("unknown GET query keys are denied (no silent inheritance)", func(t *testing.T) {
+		// release-order safety per @dev-1 msg 005e8b0b: future GET-side
+		// query actions must not silently inherit the C1 whitelist.
+		r := newScopedRequest(t, http.MethodGet, "/v1/fs/dir/", "newaction=1")
+		if isScopedBusinessRequestAllowed(r) {
+			t.Errorf("isScopedBusinessRequestAllowed(GET /v1/fs/dir/?newaction=1) = true, want false (unknown query key must default-deny)")
+		}
+	})
+}
+
+// TestAuthorizeFSHTTPHelperOwnerAllows verifies the authorizeFS HTTP helper
+// short-circuits to true for owner tokens (no FSScopes), so wired handlers
+// have zero behavioral change for legacy/owner callers. This is the per-
+// request flip side of the AuthorizeFS owner fast-path.
+func TestAuthorizeFSHTTPHelperOwnerAllows(t *testing.T) {
+	r := newScopedRequest(t, http.MethodGet, "/v1/fs/main.txt", "")
+	r = r.WithContext(withScope(r.Context(), &TenantScope{ /* IsScoped: false */ }))
+	w := httptest.NewRecorder()
+	if ok := authorizeFS(w, r, FSOpRead, "/main.txt"); !ok {
+		t.Fatalf("authorizeFS owner = false, want true")
+	}
+	if got := w.Result().StatusCode; got != http.StatusOK {
+		t.Errorf("response status = %d, want %d (no body written for allow)", got, http.StatusOK)
+	}
+}
+
+// TestAuthorizeFSHTTPHelperScopedAllowsInZone confirms a scoped token whose
+// FSScopes match the requested op+path passes through with no body written.
+func TestAuthorizeFSHTTPHelperScopedAllowsInZone(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch/run-1",
+			Ops:    map[FSOp]bool{FSOpRead: true},
+		}},
+	}
+	r := newScopedRequest(t, http.MethodGet, "/v1/fs/scratch/run-1/input.txt", "")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	if ok := authorizeFS(w, r, FSOpRead, "/scratch/run-1/input.txt"); !ok {
+		t.Fatalf("authorizeFS scoped in-zone = false, want true")
+	}
+	if got := w.Result().StatusCode; got != http.StatusOK {
+		t.Errorf("response status = %d, want %d", got, http.StatusOK)
+	}
+}
+
+// TestAuthorizeFSHTTPHelperScopedDeniesOutOfZone confirms a scoped token
+// outside its FSScopes returns 403 and writes a JSON error body.
+func TestAuthorizeFSHTTPHelperScopedDeniesOutOfZone(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch/run-1",
+			Ops:    map[FSOp]bool{FSOpRead: true},
+		}},
+	}
+	r := newScopedRequest(t, http.MethodGet, "/v1/fs/main/secrets.env", "")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	if ok := authorizeFS(w, r, FSOpRead, "/main/secrets.env"); ok {
+		t.Fatalf("authorizeFS scoped out-of-zone = true, want false")
+	}
+	if got := w.Result().StatusCode; got != http.StatusForbidden {
+		t.Errorf("response status = %d, want %d (403)", got, http.StatusForbidden)
+	}
+}
+
+// TestAuthorizeFSHTTPHelperRejectsEscape confirms a path that escapes its
+// canonical form via "../" gets mapped to 400 (invalid fs path), not 403.
+// The distinction matters: 400 says "your input is broken", 403 says "your
+// token can't do this on a valid path".
+func TestAuthorizeFSHTTPHelperRejectsEscape(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch/run-1",
+			Ops:    map[FSOp]bool{FSOpRead: true},
+		}},
+	}
+	r := newScopedRequest(t, http.MethodGet, "/v1/fs/scratch/run-1/../main/secrets.env", "")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	if ok := authorizeFS(w, r, FSOpRead, "/scratch/run-1/../main/secrets.env"); ok {
+		t.Fatalf("authorizeFS path-escape = true, want false")
+	}
+	if got := w.Result().StatusCode; got != http.StatusBadRequest {
+		t.Errorf("response status = %d, want %d (400)", got, http.StatusBadRequest)
+	}
+}
+
+// TestAuthorizeFSPathForBatchReturnsPerPathStatus is the batch-endpoint
+// invariant: a single denied path becomes one 403 in the result array; the
+// rest of the batch is NOT short-circuited. This preserves the cp -r
+// preflight contract (PR #434) where ONE out-of-zone file in a 256-path
+// batch must not bulk-reject the entire preflight.
+func TestAuthorizeFSPathForBatchReturnsPerPathStatus(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch",
+			Ops:    map[FSOp]bool{FSOpRead: true},
+		}},
+	}
+
+	// In zone → allowed.
+	status, msg, allowed := authorizeFSPathForBatch(scope, FSOpRead, "/scratch/file.txt")
+	if !allowed {
+		t.Errorf("in-zone batch path: allowed=false, want true (status=%d msg=%q)", status, msg)
+	}
+
+	// Out of zone → 403, no batch-wide reject.
+	status, msg, allowed = authorizeFSPathForBatch(scope, FSOpRead, "/main/secrets.env")
+	if allowed {
+		t.Errorf("out-of-zone batch path: allowed=true, want false")
+	}
+	if status != http.StatusForbidden {
+		t.Errorf("out-of-zone batch path: status=%d, want %d", status, http.StatusForbidden)
+	}
+	if msg == "" {
+		t.Errorf("out-of-zone batch path: msg empty, want non-empty")
+	}
+
+	// Escape path → 400.
+	status, _, allowed = authorizeFSPathForBatch(scope, FSOpRead, "/scratch/../main/x")
+	if allowed {
+		t.Errorf("escape batch path: allowed=true, want false")
+	}
+	if status != http.StatusBadRequest {
+		t.Errorf("escape batch path: status=%d, want %d", status, http.StatusBadRequest)
+	}
+}
+
+// TestAuthorizeFSPathForBatchOwnerAllows confirms the owner fast-path
+// applies to the batch helper too — a nil-IsScoped owner gets allowed=true
+// for every path with zero per-path overhead.
+func TestAuthorizeFSPathForBatchOwnerAllows(t *testing.T) {
+	scope := &TenantScope{ /* IsScoped: false */ }
+	for _, p := range []string{"/main.txt", "/scratch/x.txt", "/secrets/key.env"} {
+		status, msg, allowed := authorizeFSPathForBatch(scope, FSOpRead, p)
+		if !allowed {
+			t.Errorf("owner batch path %q: allowed=false, want true (status=%d msg=%q)", p, status, msg)
+		}
+	}
+}
+
+// TestHandlersRejectScopedRequestBeforeBackend is a smoke test for the C1
+// wiring chain: when a scoped token whose FSScopes don't cover the request
+// path enters one of the 7 read-side handlers, the handler must call
+// authorizeFS first and return 403 BEFORE touching the backend. We exercise
+// this by injecting a TenantScope into the request context with NO backend
+// — if any handler tries backendFromRequest before authorize it'll return
+// 401 ("missing tenant scope") instead of the expected 403. So this test
+// also asserts ordering, not just outcome.
+func TestHandlersRejectScopedRequestBeforeBackend(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch/run-1",
+			Ops:    map[FSOp]bool{FSOpRead: true, FSOpList: true, FSOpSearch: true},
+		}},
+	}
+
+	cases := []struct {
+		name string
+		op   FSOp
+		invoke func(s *Server, w http.ResponseWriter, r *http.Request)
+	}{
+		{"handleRead", FSOpRead, func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleRead(w, r, "/main/secrets.env")
+		}},
+		{"handleList", FSOpList, func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleList(w, r, "/main/")
+		}},
+		{"handleStat", FSOpRead, func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleStat(w, r, "/main/secrets.env")
+		}},
+		{"handleStatMetadata", FSOpRead, func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleStatMetadata(w, r, "/main/secrets.env")
+		}},
+		{"handleGrep", FSOpSearch, func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleGrep(w, r, "/main/")
+		}},
+		{"handleFind", FSOpSearch, func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleFind(w, r, "/main/")
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newScopedRequest(t, http.MethodGet, "/v1/fs/main/secrets.env", "")
+			r = r.WithContext(withScope(r.Context(), scope))
+			w := httptest.NewRecorder()
+			tc.invoke(&Server{}, w, r)
+
+			// Out-of-zone scoped request: handler MUST short-circuit at
+			// authorizeFS with 403 — not reach backendFromRequest (would
+			// give 401) or run actual backend work.
+			if got := w.Result().StatusCode; got != http.StatusForbidden {
+				t.Errorf("%s out-of-zone status = %d, want %d (403). Got body: %s",
+					tc.name, got, http.StatusForbidden, w.Body.String())
+			}
+		})
 	}
 }
 

--- a/pkg/server/fs_authorization_test.go
+++ b/pkg/server/fs_authorization_test.go
@@ -156,7 +156,16 @@ func TestIsScopedBusinessRequestAllowed(t *testing.T) {
 			{http.MethodGet, "/v1/fs/dir/", "list=1"},
 			{http.MethodGet, "/v1/fs/dir/file.txt", "stat=1"},
 			{http.MethodGet, "/v1/fs/dir/", "grep=hello"},
+			// Regression for @adversary-1 msg 00efe734: grep + limit must
+			// pass dispatcher (handleGrep reads ?limit).
+			{http.MethodGet, "/v1/fs/dir/", "grep=hello&limit=20"},
 			{http.MethodGet, "/v1/fs/dir/", "find=name:foo"},
+			// Regression for @adversary-1 msg 00efe734: find + filter params
+			// must pass dispatcher (handleFind reads name/tag/newer/older/
+			// minsize/maxsize/limit).
+			{http.MethodGet, "/v1/fs/dir/", "find=&name=*.yaml&newer=2026-03-01"},
+			{http.MethodGet, "/v1/fs/dir/", "find=&tag=k=v&minsize=10&maxsize=100&limit=50"},
+			{http.MethodGet, "/v1/fs/dir/", "find=&older=2026-01-01"},
 			{http.MethodHead, "/v1/fs/main.txt", ""},
 			{http.MethodPost, "/v1/fs:batch-stat", ""},
 			{http.MethodPost, "/v1/fs:batch-read-small", ""},
@@ -209,9 +218,24 @@ func TestIsScopedBusinessRequestAllowed(t *testing.T) {
 	t.Run("unknown GET query keys are denied (no silent inheritance)", func(t *testing.T) {
 		// release-order safety per @dev-1 msg 005e8b0b: future GET-side
 		// query actions must not silently inherit the C1 whitelist.
-		r := newScopedRequest(t, http.MethodGet, "/v1/fs/dir/", "newaction=1")
-		if isScopedBusinessRequestAllowed(r) {
-			t.Errorf("isScopedBusinessRequestAllowed(GET /v1/fs/dir/?newaction=1) = true, want false (unknown query key must default-deny)")
+		cases := []struct {
+			query string
+			why   string
+		}{
+			{"newaction=1", "unknown action selector → no arm matches → deny"},
+			{"name=foo", "find filter param without ?find selector → handleRead arm rejects"},
+			{"limit=20", "limit param without ?grep or ?find selector → handleRead arm rejects"},
+			{"grep=hello&newer=2026-01-01", "newer is a find-arm key, not a grep-arm key → grep arm rejects"},
+			{"find=&secret=value", "unknown filter param on find arm → deny"},
+			{"stat=1&extra=x", "stat arm only accepts ?stat → deny"},
+			{"list=1&filter=foo", "list arm only accepts ?list (no filters today) → deny"},
+		}
+		for _, tc := range cases {
+			r := newScopedRequest(t, http.MethodGet, "/v1/fs/dir/", tc.query)
+			if isScopedBusinessRequestAllowed(r) {
+				t.Errorf("isScopedBusinessRequestAllowed(GET /v1/fs/dir/?%s) = true, want false (%s)",
+					tc.query, tc.why)
+			}
 		}
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -386,7 +386,7 @@ func (s *Server) ListenAndServe(addr string) error {
 }
 
 func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
-	if scope := ScopeFromContext(r.Context()); scope != nil && scope.IsScoped && !isScopedBusinessPathAllowed(r.URL.Path) {
+	if scope := ScopeFromContext(r.Context()); scope != nil && scope.IsScoped && !isScopedBusinessRequestAllowed(r) {
 		errJSON(w, http.StatusForbidden, "scoped token cannot access endpoint")
 		return
 	}
@@ -421,9 +421,61 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func isScopedBusinessPathAllowed(_ string) bool {
-	// PR A only introduces the scoped-token foundation. FS/upload routes opt in
-	// in PR C1/C2 once each handler authorizes its request path before work.
+// isScopedBusinessRequestAllowed is the dispatcher-level gate for scoped
+// tokens. It mirrors handleFS's actual dispatch table so the gate stays in
+// sync with what each handler actually wires — release-order safety per
+// @adversary-1 / @dev-1 review (PR C1 thread msg b6f53023, 4619c945, 005e8b0b):
+// only allow a route through when the handler in this PR is known to call
+// AuthorizeFS itself.
+//
+// PR C1 opens read-side only. PR C2 will extend this whitelist to write-side
+// (PUT/PATCH/DELETE/POST on /v1/fs/* + uploads) once each write handler
+// authorizes its target path.
+//
+// chmod (POST /v1/fs/<path>?chmod=1) is explicitly NOT and never will be in
+// the scoped allowlist — chmod escalates ACLs and is owner-token-only.
+func isScopedBusinessRequestAllowed(r *http.Request) bool {
+	path := r.URL.Path
+
+	// Batch FS endpoints (always POST). Handlers do per-path AuthorizeFS internally.
+	if path == "/v1/fs:batch-stat" || path == "/v1/fs:batch-read-small" {
+		return r.Method == http.MethodPost
+	}
+
+	// /v1/fs/* — read-side methods/queries only in C1.
+	if strings.HasPrefix(path, "/v1/fs/") {
+		switch r.Method {
+		case http.MethodHead:
+			// handleStat — read.
+			return true
+		case http.MethodGet:
+			// handleFS GET dispatches by query param to read-side handlers:
+			// ?stat (handleStatMetadata), ?grep (handleGrep), ?find (handleFind),
+			// ?list (handleList), else handleRead. All read-side.
+			//
+			// Reject unknown future query keys explicitly so adding a new GET
+			// action doesn't silently inherit the scoped allowlist — release-
+			// order safety (@dev-1 msg 005e8b0b).
+			q := r.URL.Query()
+			for key := range q {
+				switch key {
+				case "stat", "grep", "find", "list":
+					// known read-side
+				default:
+					return false
+				}
+			}
+			return true
+		default:
+			// PUT/PATCH/DELETE/POST on /v1/fs/* are write-side and chmod;
+			// rejected in C1, write-side will be wired in C2 (chmod stays
+			// owner-only forever).
+			return false
+		}
+	}
+
+	// Uploads, SQL, fork, events, journals, vault, status, etc.: not in C1
+	// scope. C2 may open uploads.
 	return false
 }
 
@@ -613,6 +665,9 @@ func (s *Server) handleFS(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpRead, path) {
+		return
+	}
 	start := time.Now()
 	b := backendFromRequest(r)
 	if b == nil {
@@ -674,6 +729,9 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 }
 
 func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpList, path) {
+		return
+	}
 	start := time.Now()
 	b := backendFromRequest(r)
 	if b == nil {
@@ -730,6 +788,9 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 }
 
 func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpRead, path) {
+		return
+	}
 	b := backendFromRequest(r)
 	if b == nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "stat_metadata_missing_scope", "path", path)...)
@@ -1237,8 +1298,17 @@ func (s *Server) handleBatchStat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	scope := ScopeFromContext(r.Context())
 	results := make([]batchStatResult, len(req.Paths))
 	for i, path := range req.Paths {
+		// Per-path authorize: a denied path becomes a per-element 403 in
+		// the response, but allowed siblings still resolve. This preserves
+		// the cp -r preflight contract (PR #434) — one out-of-zone path
+		// must not 403 the entire batch.
+		if status, msg, allowed := authorizeFSPathForBatch(scope, FSOpRead, path); !allowed {
+			results[i] = batchStatResult{Path: path, Status: status, Error: msg}
+			continue
+		}
 		results[i] = s.batchStatOne(r.Context(), b, path)
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "batch_stat_ok", "count", len(results))...)
@@ -1275,8 +1345,14 @@ func (s *Server) handleBatchReadSmall(w http.ResponseWriter, r *http.Request) {
 	if maxBytes <= 0 || maxBytes > maxBatchReadSmallBytes {
 		maxBytes = maxBatchReadSmallBytes
 	}
+	scope := ScopeFromContext(r.Context())
 	results := make([]batchReadSmallResult, len(req.Paths))
 	for i, path := range req.Paths {
+		// Per-path authorize, same shape as batch-stat above.
+		if status, msg, allowed := authorizeFSPathForBatch(scope, FSOpRead, path); !allowed {
+			results[i] = batchReadSmallResult{Path: path, Status: status, Error: msg}
+			continue
+		}
 		results[i] = s.batchReadSmallOne(r.Context(), b, path, maxBytes)
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "batch_read_small_ok", "count", len(results), "max_bytes", maxBytes)...)
@@ -1379,6 +1455,13 @@ func validateBatchStatPath(rawPath string) error {
 }
 
 func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string) {
+	// HEAD must not write a body; for scoped-token deny the status code is
+	// still informative (403/400). Go's net/http strips body bytes from HEAD
+	// responses, so reusing authorizeFS (which calls errJSON) is safe — the
+	// JSON body will not reach the client.
+	if !authorizeFS(w, r, FSOpRead, path) {
+		return
+	}
 	start := time.Now()
 	b := backendFromRequest(r)
 	if b == nil {
@@ -2664,6 +2747,9 @@ func (s *Server) handleSQL(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpSearch, path) {
+		return
+	}
 	b := backendFromRequest(r)
 	if b == nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "grep_missing_scope", "path", path)...)
@@ -2700,6 +2786,9 @@ func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string)
 }
 
 func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpSearch, path) {
+		return
+	}
 	b := backendFromRequest(r)
 	if b == nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "find_missing_scope", "path", path)...)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -434,6 +435,14 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 //
 // chmod (POST /v1/fs/<path>?chmod=1) is explicitly NOT and never will be in
 // the scoped allowlist — chmod escalates ACLs and is owner-token-only.
+//
+// The GET branch uses an **action-specific** accept-list (per @adversary-1
+// msg 00efe734 / @adversary-2 msg cbedd30a): the chosen action selector
+// (stat / grep / find / list / none) determines which filter keys handler
+// actually consumes, and only those keys plus the selector itself are
+// admitted. Earlier revisions admitted only the selector keys themselves,
+// which rejected normal scoped grep/find calls like `?grep=hello&limit=20`
+// before AuthorizeFS could even run — a regression vs current behavior.
 func isScopedBusinessRequestAllowed(r *http.Request) bool {
 	path := r.URL.Path
 
@@ -449,23 +458,7 @@ func isScopedBusinessRequestAllowed(r *http.Request) bool {
 			// handleStat — read.
 			return true
 		case http.MethodGet:
-			// handleFS GET dispatches by query param to read-side handlers:
-			// ?stat (handleStatMetadata), ?grep (handleGrep), ?find (handleFind),
-			// ?list (handleList), else handleRead. All read-side.
-			//
-			// Reject unknown future query keys explicitly so adding a new GET
-			// action doesn't silently inherit the scoped allowlist — release-
-			// order safety (@dev-1 msg 005e8b0b).
-			q := r.URL.Query()
-			for key := range q {
-				switch key {
-				case "stat", "grep", "find", "list":
-					// known read-side
-				default:
-					return false
-				}
-			}
-			return true
+			return isScopedFSGetQueryAllowed(r.URL.Query())
 		default:
 			// PUT/PATCH/DELETE/POST on /v1/fs/* are write-side and chmod;
 			// rejected in C1, write-side will be wired in C2 (chmod stays
@@ -477,6 +470,60 @@ func isScopedBusinessRequestAllowed(r *http.Request) bool {
 	// Uploads, SQL, fork, events, journals, vault, status, etc.: not in C1
 	// scope. C2 may open uploads.
 	return false
+}
+
+// isScopedFSGetQueryAllowed mirrors handleFS's GET dispatcher (server.go:618
+// onward): the action is decided by which selector key is present, in
+// priority order: stat → grep → find → list → (no selector = handleRead).
+// Each branch accepts only the keys its handler actually reads; unknown
+// keys for the selected branch deny so a future action key on the same
+// path can't silently inherit the C1 allowlist.
+func isScopedFSGetQueryAllowed(q url.Values) bool {
+	// Note: handleFS GET dispatch order (stat > grep > find > list > read)
+	// must match here, otherwise a request like `?stat=1&grep=hello` would
+	// allow under one arm and be dispatched to another — pick the action
+	// the dispatcher will pick.
+	switch {
+	case q.Has("stat"):
+		// handleStatMetadata reads only ?stat.
+		return queryKeysSubsetOf(q, []string{"stat"})
+	case q.Has("grep"):
+		// handleGrep reads ?grep and ?limit.
+		return queryKeysSubsetOf(q, []string{"grep", "limit"})
+	case q.Has("find"):
+		// handleFind reads ?find, ?name, ?tag, ?newer, ?older,
+		// ?minsize, ?maxsize, ?limit.
+		return queryKeysSubsetOf(q, []string{
+			"find", "name", "tag", "newer", "older",
+			"minsize", "maxsize", "limit",
+		})
+	case q.Has("list"):
+		// handleList reads only ?list. (No filter params today.)
+		return queryKeysSubsetOf(q, []string{"list"})
+	default:
+		// No action selector → handleRead, which does not consume query
+		// params. Any unknown key on a read request is rejected to prevent
+		// future GET-side actions from silently inheriting the allowlist.
+		return len(q) == 0
+	}
+}
+
+// queryKeysSubsetOf returns true iff every key in q is present in allowed.
+// allowed is small (<10 strings) so linear scan is fine.
+func queryKeysSubsetOf(q url.Values, allowed []string) bool {
+	for k := range q {
+		ok := false
+		for _, a := range allowed {
+			if k == a {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

PR C1 — read-side handler wiring for Workspace Zones. PR A (#438) introduced `TenantScope.IsScoped` + `AuthorizeFS`/`AuthorizeFSPair` as the foundation; FS handlers were untouched and the dispatcher denied every business endpoint for scoped tokens. This PR opens read-side: each of the 7 read-side handlers now calls `AuthorizeFS` as its first action, and the dispatcher admits only routes whose handler in this PR authorizes its target path. Write-side (PUT/PATCH/DELETE/POST on `/v1/fs/*` + uploads) stays default-deny for scoped tokens until PR C2.

Closes part of task #7.

## Owner perf invariant

`BenchmarkAuthorizeFSOwnerToken` measured **2.1 ns/op** locally on this branch (unchanged vs main per @adversary-1 / @dev-1 PR A bench). Owner tokens carry zero new SQL, zero new prefix matching, zero new allocations — the owner fast-path remains a single boolean check (`if !s.IsScoped { return nil }`). @qiffang's red line preserved.

## Handler wiring (7 call sites)

| Handler | Op | Notes |
|---|---|---|
| `handleRead` | `FSOpRead` | GET `/v1/fs/<path>` |
| `handleList` | `FSOpList` | GET `?list=1` |
| `handleStat` | `FSOpRead` | HEAD; net/http strips body on deny |
| `handleStatMetadata` | `FSOpRead` | GET `?stat=1` |
| `handleGrep` | `FSOpSearch` | GET `?grep=` |
| `handleFind` | `FSOpSearch` | GET `?find=` |
| `handleBatchStat` / `handleBatchReadSmall` | `FSOpRead` (per-path) | POST; one denied path becomes one 403 in result array. Preserves cp -r preflight contract (PR #434). |

Authorize call is **always the first line** of each handler — guaranteed to run before any backend work. `TestHandlersRejectScopedRequestBeforeBackend` asserts this ordering (not just outcome): the test invokes each handler with a TenantScope but NO backend; if any handler tried `backendFromRequest` before authorize it'd return 401 ("missing tenant scope") instead of the expected 403.

## Dispatcher whitelist (release-order safety)

Per @adversary-1 (msg `b6f53023`) + @dev-1 (msg `005e8b0b`) reviews on the C1 thread: never open a route at the dispatcher before this PR's handler is known to call `AuthorizeFS`. PR C1's whitelist mirrors `handleFS`'s actual dispatch table:

**Admitted:**
- `GET /v1/fs/*` (with only known query keys: `stat`, `grep`, `find`, `list`, or none)
- `HEAD /v1/fs/*`
- `POST /v1/fs:batch-stat`
- `POST /v1/fs:batch-read-small`

**Denied (still C2 work):**
- `PUT/PATCH/DELETE /v1/fs/*`
- `POST /v1/fs/*` (append/copy/rename/mkdir/create)
- All `/v1/uploads*` + `/v2/uploads/*`

**Denied (out of scope forever):**
- `POST /v1/fs/*?chmod=1` — scoped tokens cannot escalate ACLs
- `/v1/sql`, `/v1/fork`, `/v1/events`, `/v1/journals*`, `/v1/vault/*`

Future GET-side query keys default to deny so a new action can't silently inherit C1's allowlist.

## Helpers added

`pkg/server/fs_authorization.go`:
- `writeFSAuthzError(w, err)` — maps `ErrFSAccessDenied → 403`, `ErrFSInvalidPath → 400`
- `authorizeFS(w, r, op, path) bool` — single-call gate; owner short-circuits via the `TenantScope.IsScoped` fast-path
- `authorizeFSPathForBatch(scope, op, path) (status, msg, allowed)` — per-path variant for batch endpoints

## Tests (16 new, all green)

| Test | Scope |
|---|---|
| `TestIsScopedBusinessRequestAllowed` | 3 subtests — read-side allowed, write-side denied, unknown GET query key denied |
| `TestScopedBusinessEndpointGuardDeniesNonC1Endpoints` | Updated PR A's blanket-deny test to reflect C1 allowlist surface |
| `TestAuthorizeFSHTTPHelperOwnerAllows` | Owner short-circuit through HTTP wrapper |
| `TestAuthorizeFSHTTPHelperScopedAllowsInZone` | Scoped in-zone allow |
| `TestAuthorizeFSHTTPHelperScopedDeniesOutOfZone` | Scoped out-of-zone → 403 |
| `TestAuthorizeFSHTTPHelperRejectsEscape` | `..` escape → 400 (not 403; input is broken, not unauthorized) |
| `TestAuthorizeFSPathForBatchReturnsPerPathStatus` | Per-path 403 + escape 400 in batch |
| `TestAuthorizeFSPathForBatchOwnerAllows` | Owner short-circuit through batch helper |
| `TestHandlersRejectScopedRequestBeforeBackend` | 6 subtests — handleRead/List/Stat/StatMetadata/Grep/Find all authorize BEFORE backend |

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/server ./pkg/meta -count=1` green (server 36s, meta 14.5s)
- [x] `go test ./pkg/server -run '^$' -bench 'BenchmarkAuthorizeFS' -benchtime=200ms -count=3` — owner 2.1 ns/op preserved

## What's out of scope (PR C2)

- All `/v1/fs/*` write methods (write/append/patch/create/mkdir/delete/copy/rename) — need `AuthorizeFS`/`AuthorizeFSPair` + dispatcher whitelist extension
- Uploads (initiate/complete/resume/abort + V2 variants) — need session.target_path re-authorize on each call
- Token issuance / revocation CLI — PR B (not until C1+C2 land per locked sequencing)

Reviewers: @adversary-1 primary + @adversary-2 secondary. Branch policy note: PR will hit the same self-review blocker that PR A did (all agent `gh` auth maps to `qiffang`); @qiffang admin bypass remains the merge path until separate bot identities exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Authorization Improvements**
  * Enhanced authorization enforcement for scoped tokens with stricter control over filesystem endpoint access
  * Per-path authorization checks for batch operations
  * Consistent HTTP error responses for authorization failures

* **Tests**
  * Expanded authorization test coverage for dispatcher guards, handler-level checks, and batch operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->