### PR TITLE
auth: wire workspace zone write-side authorization (PR C2a)

### DIFF
--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -379,23 +379,21 @@ func TestAuthScopedKeyLoadsFSScopes(t *testing.T) {
 	}
 }
 
-// TestScopedBusinessEndpointGuardDeniesNonC1Endpoints checks that scoped
-// tokens are still 403'd at the dispatcher for every endpoint NOT opened
-// by PR C1's read-side wiring. PR C1 admits POST batch-stat / batch-read-
-// small and GET/HEAD on /v1/fs/* — those have their own
-// AuthorizeFS-on-each-handler tests. Every other business endpoint
-// (write methods on /v1/fs, all uploads, sql, fork, events, journals,
-// vault) must continue to fail-closed at handleBusiness.
-func TestScopedBusinessEndpointGuardDeniesNonC1Endpoints(t *testing.T) {
+// TestScopedBusinessEndpointGuardDeniesEndpointsOutOfC1C2aScope checks
+// that scoped tokens are still 403'd at the dispatcher for every endpoint
+// NOT opened by PR C1 (read-side) or PR C2a (write-side except chmod).
+// Uploads remain dispatcher-denied until C2b wires their handlers +
+// session re-authorize. SQL/fork/events/journals/vault are permanently
+// out of scope. chmod stays owner-only forever. A bare POST /v1/fs/*
+// without an action selector also denies (ambiguous request).
+func TestScopedBusinessEndpointGuardDeniesEndpointsOutOfC1C2aScope(t *testing.T) {
 	type endpoint struct {
 		method string
 		path   string
 	}
 	deniedC1 := []endpoint{
 		{http.MethodPost, "/v1/sql"},
-		{http.MethodPut, "/v1/fs/file.txt"},    // write-side, still C2-only
-		{http.MethodDelete, "/v1/fs/file.txt"}, // write-side
-		{http.MethodPost, "/v1/fs/file.txt"},   // mkdir/copy/rename/append, C2-only
+		{http.MethodPost, "/v1/fs/file.txt"}, // no action selector → ambiguous → deny
 		{http.MethodPost, "/v1/uploads/initiate"},
 		{http.MethodPost, "/v1/uploads"},
 		{http.MethodPost, "/v1/fork"},

--- a/pkg/server/fs_authorization.go
+++ b/pkg/server/fs_authorization.go
@@ -179,6 +179,27 @@ func authorizeFS(w http.ResponseWriter, r *http.Request, op FSOp, rawPath string
 	return true
 }
 
+// authorizeFSPair is the dual-path variant for copy / rename handlers,
+// where one operation needs different op semantics on src vs dst.
+//
+//	copy:   src=read,   dst=write   (read the source, write the dest)
+//	rename: src=delete, dst=write   (the source disappears = delete; dest = write)
+//
+// Owner short-circuit (IsScoped=false) inside AuthorizeFS still applies for
+// both sides — same per-arm fast-path as single-path authorize.
+func authorizeFSPair(w http.ResponseWriter, r *http.Request, srcOp FSOp, srcPath string, dstOp FSOp, dstPath string) bool {
+	scope := ScopeFromContext(r.Context())
+	if scope == nil {
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return false
+	}
+	if err := scope.AuthorizeFSPair(srcOp, srcPath, dstOp, dstPath); err != nil {
+		writeFSAuthzError(w, err)
+		return false
+	}
+	return true
+}
+
 // authorizeFSPathForBatch is the per-path variant for batch endpoints
 // (batch-stat / batch-read-small). It returns the HTTP status + error string
 // to embed in the per-path result so callers can short-circuit a single

--- a/pkg/server/fs_authorization_test.go
+++ b/pkg/server/fs_authorization_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/mem9-ai/dat9/pkg/meta"
@@ -179,32 +180,27 @@ func TestIsScopedBusinessRequestAllowed(t *testing.T) {
 		}
 	})
 
-	t.Run("write-side endpoints denied (left for C2)", func(t *testing.T) {
+	t.Run("non-FS endpoints still denied after C2a (uploads/sql/fork/events/journals/vault)", func(t *testing.T) {
+		// PR C2a admits write-side on /v1/fs/* but uploads remain denied
+		// until C2b wires their handlers + session re-authorize. chmod
+		// stays owner-only forever.
 		cases := []struct {
 			method string
 			path   string
 			query  string
 		}{
-			{http.MethodPut, "/v1/fs/main.txt", ""},
-			{http.MethodPatch, "/v1/fs/main.txt", ""},
-			{http.MethodDelete, "/v1/fs/main.txt", ""},
-			{http.MethodPost, "/v1/fs/main.txt", "append=1"},
-			{http.MethodPost, "/v1/fs/main.txt", "copy=1"},
-			{http.MethodPost, "/v1/fs/main.txt", "rename=1"},
-			{http.MethodPost, "/v1/fs/main.txt", "mkdir=1"},
-			{http.MethodPost, "/v1/fs/main.txt", "chmod=1"},
-			{http.MethodPost, "/v1/fs/main.txt", "create=1"},
-			{http.MethodGet, "/v1/fs:batch-stat", ""},          // wrong method for this endpoint
-			{http.MethodGet, "/v1/fs:batch-read-small", ""},    // wrong method
-			{http.MethodPost, "/v1/uploads", ""},
-			{http.MethodPost, "/v1/uploads/initiate", ""},
-			{http.MethodPost, "/v1/uploads/upload-1/complete", ""},
-			{http.MethodPost, "/v2/uploads/upload-1/parts", ""},
-			{http.MethodPost, "/v1/sql", ""},
-			{http.MethodPost, "/v1/fork", ""},
-			{http.MethodGet, "/v1/events", ""},
-			{http.MethodGet, "/v1/journals", ""},
-			{http.MethodGet, "/v1/vault/secrets", ""},
+			{http.MethodPost, "/v1/fs/main.txt", "chmod=1"},           // owner-only forever
+			{http.MethodGet, "/v1/fs:batch-stat", ""},                 // wrong method for this endpoint
+			{http.MethodGet, "/v1/fs:batch-read-small", ""},           // wrong method
+			{http.MethodPost, "/v1/uploads", ""},                      // C2b
+			{http.MethodPost, "/v1/uploads/initiate", ""},             // C2b
+			{http.MethodPost, "/v1/uploads/upload-1/complete", ""},    // C2b
+			{http.MethodPost, "/v2/uploads/upload-1/parts", ""},       // C2b
+			{http.MethodPost, "/v1/sql", ""},                          // out of scope
+			{http.MethodPost, "/v1/fork", ""},                         // out of scope
+			{http.MethodGet, "/v1/events", ""},                        // out of scope
+			{http.MethodGet, "/v1/journals", ""},                      // out of scope
+			{http.MethodGet, "/v1/vault/secrets", ""},                 // out of scope
 		}
 		for _, tc := range cases {
 			r := newScopedRequest(t, tc.method, tc.path, tc.query)
@@ -372,6 +368,339 @@ func TestAuthorizeFSPathForBatchOwnerAllows(t *testing.T) {
 		status, msg, allowed := authorizeFSPathForBatch(scope, FSOpRead, p)
 		if !allowed {
 			t.Errorf("owner batch path %q: allowed=false, want true (status=%d msg=%q)", p, status, msg)
+		}
+	}
+}
+
+// TestC2aWriteHandlersRejectScopedRequestBeforeBackend mirrors the C1
+// ordering proof for the new write-side handlers wired in C2a. Same
+// zero-value `&Server{}` trick: handler MUST call authorizeFS / authorizeFSPair
+// before touching backendFromRequest, otherwise the response would be
+// 401 "missing tenant scope" instead of 403 "fs access denied".
+func TestC2aWriteHandlersRejectScopedRequestBeforeBackend(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch/run-1",
+			Ops:    map[FSOp]bool{FSOpRead: true, FSOpList: true, FSOpWrite: true, FSOpDelete: true},
+		}},
+	}
+
+	cases := []struct {
+		name   string
+		invoke func(s *Server, w http.ResponseWriter, r *http.Request)
+	}{
+		{"handleWrite", func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleWrite(w, r, "/main/secrets.env")
+		}},
+		{"handlePatch", func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handlePatch(w, r, "/main/secrets.env")
+		}},
+		{"handleAppend", func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleAppend(w, r, "/main/secrets.env")
+		}},
+		{"handleCreate", func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleCreate(w, r, "/main/secrets.env")
+		}},
+		{"handleMkdir", func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleMkdir(w, r, "/main/newdir")
+		}},
+		{"handleDelete", func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleDelete(w, r, "/main/secrets.env")
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newScopedRequest(t, http.MethodPost, "/v1/fs/main/secrets.env", "")
+			r = r.WithContext(withScope(r.Context(), scope))
+			w := httptest.NewRecorder()
+			tc.invoke(&Server{}, w, r)
+			if got := w.Result().StatusCode; got != http.StatusForbidden {
+				t.Errorf("%s out-of-zone status = %d, want %d (must authorize before backend). body=%s",
+					tc.name, got, http.StatusForbidden, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestC2aHandleAppendAuthorizesBeforePlan asserts the banked
+// plan-timing invariant: handleAppend authorizes BEFORE generating the
+// upload plan. Otherwise the plan response would leak "this prefix is
+// writable" even if the subsequent PUT is denied.
+//
+// Method: a scoped token out-of-zone calling append should get 403 with
+// the canonical "fs access denied" JSON body, NOT a plan response.
+func TestC2aHandleAppendAuthorizesBeforePlan(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch",
+			Ops:    map[FSOp]bool{FSOpWrite: true},
+		}},
+	}
+	r := newScopedRequest(t, http.MethodPost, "/v1/fs/main/log.txt", "append=1")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	(&Server{}).handleAppend(w, r, "/main/log.txt")
+
+	if got := w.Result().StatusCode; got != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", got, http.StatusForbidden)
+	}
+	// The 403 body must NOT look like an upload plan (which has fields like
+	// upload_id, part_size, max_parts). Look for the canonical authz error.
+	if !strings.Contains(w.Body.String(), "fs access denied") {
+		t.Errorf("body = %q, want canonical 'fs access denied' (not a plan response)", w.Body.String())
+	}
+}
+
+// TestC2aHandleChmodRejectsScopedToken pins the chmod-is-owner-only
+// invariant at the handler level (defense in depth — dispatcher already
+// rejects scoped tokens on ?chmod=1, but the handler MUST also reject
+// in case the dispatcher gate ever drifts).
+func TestC2aHandleChmodRejectsScopedToken(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		// Give the scoped token write+delete on EVERY zone — it still
+		// must not be able to chmod, because chmod isn't in the op set.
+		FSScopes: []FSScope{{
+			Prefix: "/",
+			Ops: map[FSOp]bool{
+				FSOpRead: true, FSOpList: true, FSOpSearch: true,
+				FSOpWrite: true, FSOpDelete: true,
+			},
+		}},
+	}
+	r := newScopedRequest(t, http.MethodPost, "/v1/fs/main/file.txt", "chmod=1")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	(&Server{}).handleChmod(w, r, "/main/file.txt")
+
+	if got := w.Result().StatusCode; got != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (chmod is owner-only)", got, http.StatusForbidden)
+	}
+}
+
+// TestC2aHandleCopyAuthorizesSrcViaHeader is the critical regression for
+// the copy dual-path invariant (banked from cp -r PR #434 work): copy's
+// source path comes from X-Dat9-Copy-Source HEADER, not the URL. A scoped
+// token allowed write on dst but NOT read on src must STILL get 403,
+// not 200 just because the URL path looks fine to a careless dispatcher.
+func TestC2aHandleCopyAuthorizesSrcViaHeader(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			// Allow read+write on /scratch but NOT on /secrets.
+			Prefix: "/scratch",
+			Ops:    map[FSOp]bool{FSOpRead: true, FSOpWrite: true},
+		}},
+	}
+	// URL = dst = /scratch/exfil.env (in zone, write allowed).
+	// Header = src = /secrets/api-key.env (out of zone, read denied).
+	r := newScopedRequest(t, http.MethodPost, "/v1/fs/scratch/exfil.env", "copy=1")
+	r.Header.Set("X-Dat9-Copy-Source", "/secrets/api-key.env")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	(&Server{}).handleCopy(w, r, "/scratch/exfil.env")
+
+	if got := w.Result().StatusCode; got != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (src in header must be authorized, not just URL dst). body=%s",
+			got, http.StatusForbidden, w.Body.String())
+	}
+}
+
+// TestC2aHandleCopyAllowsBothInZone confirms the happy path: scoped token
+// with read on src zone AND write on dst zone allows copy. Negative tests
+// verify each missing capability denies.
+func TestC2aHandleCopyAllowsBothInZone(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{
+			{Prefix: "/source", Ops: map[FSOp]bool{FSOpRead: true}},
+			{Prefix: "/dest", Ops: map[FSOp]bool{FSOpWrite: true}},
+		},
+	}
+	r := newScopedRequest(t, http.MethodPost, "/v1/fs/dest/a.txt", "copy=1")
+	r.Header.Set("X-Dat9-Copy-Source", "/source/a.txt")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	(&Server{}).handleCopy(w, r, "/dest/a.txt")
+
+	// Authorize-pass path reaches backendFromRequest (nil here) → 401.
+	// We're proving the pair authorize PASSED for both endpoints; the
+	// nil-backend 401 is the post-authorize signal.
+	if got := w.Result().StatusCode; got != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d (authorize passed; backend missing). body=%s",
+			got, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+// TestC2aHandleRenameSrcRequiresDeleteNotWrite pins the banked rename
+// invariant: rename's src op is DELETE (the file disappears), not WRITE.
+// A token with read+write on the source zone but NO delete cannot rename
+// — even though they could copy + (try to) delete original.
+func TestC2aHandleRenameSrcRequiresDeleteNotWrite(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			// Read+Write on /scratch but NO delete.
+			Prefix: "/scratch",
+			Ops:    map[FSOp]bool{FSOpRead: true, FSOpWrite: true},
+		}},
+	}
+	r := newScopedRequest(t, http.MethodPost, "/v1/fs/scratch/new.txt", "rename=1")
+	r.Header.Set("X-Dat9-Rename-Source", "/scratch/old.txt")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	(&Server{}).handleRename(w, r, "/scratch/new.txt")
+
+	if got := w.Result().StatusCode; got != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (rename src requires delete, not write)",
+			got, http.StatusForbidden)
+	}
+}
+
+// TestC2aHandleRenameAllowsDeletePlusWrite confirms rename works with
+// the correct ops: delete on src + write on dst.
+func TestC2aHandleRenameAllowsDeletePlusWrite(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			// Single zone with full ops.
+			Prefix: "/scratch",
+			Ops: map[FSOp]bool{
+				FSOpRead: true, FSOpWrite: true, FSOpDelete: true,
+			},
+		}},
+	}
+	r := newScopedRequest(t, http.MethodPost, "/v1/fs/scratch/new.txt", "rename=1")
+	r.Header.Set("X-Dat9-Rename-Source", "/scratch/old.txt")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	(&Server{}).handleRename(w, r, "/scratch/new.txt")
+
+	// Pair authorize passes; missing backend → 401.
+	if got := w.Result().StatusCode; got != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d (authorize passed; backend missing). body=%s",
+			got, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+// TestC2aDispatcherWriteSideAllowed verifies the dispatcher whitelist
+// extension for write-side methods admits the right requests and denies
+// chmod, mixed selectors, and unknown query keys per @adversary-1's
+// "no silent first-wins" invariant.
+func TestC2aDispatcherWriteSideAllowed(t *testing.T) {
+	t.Run("write-side allowed", func(t *testing.T) {
+		cases := []struct {
+			method string
+			query  string
+		}{
+			{http.MethodPut, ""},
+			{http.MethodPatch, ""},
+			{http.MethodDelete, ""},
+			{http.MethodDelete, "recursive=1"},
+			{http.MethodDelete, "kind=dir"},
+			{http.MethodDelete, "recursive=1&kind=dir"},
+			{http.MethodPost, "append=1"},
+			{http.MethodPost, "copy=1"},
+			{http.MethodPost, "rename=1"},
+			{http.MethodPost, "mkdir=1"},
+			{http.MethodPost, "mkdir=1&mode=755"},
+			{http.MethodPost, "create=1"},
+		}
+		for _, tc := range cases {
+			r := newScopedRequest(t, tc.method, "/v1/fs/main.txt", tc.query)
+			if !isScopedBusinessRequestAllowed(r) {
+				t.Errorf("isScopedBusinessRequestAllowed(%s /v1/fs/main.txt?%s) = false, want true",
+					tc.method, tc.query)
+			}
+		}
+	})
+
+	t.Run("chmod always denied for scoped", func(t *testing.T) {
+		r := newScopedRequest(t, http.MethodPost, "/v1/fs/main.txt", "chmod=1")
+		if isScopedBusinessRequestAllowed(r) {
+			t.Errorf("chmod must be denied for scoped tokens at dispatcher")
+		}
+	})
+
+	t.Run("mixed POST selectors denied as ambiguous", func(t *testing.T) {
+		cases := []string{
+			"append=1&copy=1",
+			"copy=1&rename=1",
+			"mkdir=1&create=1",
+			"copy=1&chmod=1", // chmod combined with anything → deny
+			"append=1&mkdir=1&create=1",
+		}
+		for _, q := range cases {
+			r := newScopedRequest(t, http.MethodPost, "/v1/fs/main.txt", q)
+			if isScopedBusinessRequestAllowed(r) {
+				t.Errorf("isScopedBusinessRequestAllowed(POST /v1/fs/main.txt?%s) = true, want false (ambiguous mixed selectors must deny)", q)
+			}
+		}
+	})
+
+	t.Run("POST without selector denied", func(t *testing.T) {
+		r := newScopedRequest(t, http.MethodPost, "/v1/fs/main.txt", "")
+		if isScopedBusinessRequestAllowed(r) {
+			t.Errorf("POST without action selector must deny (no handler matches)")
+		}
+	})
+
+	t.Run("PUT/PATCH reject unknown query keys", func(t *testing.T) {
+		// handleWrite and handlePatch don't consume any query params; any
+		// extra key would be a sign of caller confusion or future drift.
+		for _, m := range []string{http.MethodPut, http.MethodPatch} {
+			r := newScopedRequest(t, m, "/v1/fs/main.txt", "extra=1")
+			if isScopedBusinessRequestAllowed(r) {
+				t.Errorf("%s with unknown query key must deny", m)
+			}
+		}
+	})
+
+	t.Run("POST action arms reject cross-arm filter keys", func(t *testing.T) {
+		// `mkdir` allows ?mode; `mkdir&mode` is fine.
+		// But `copy&mode` is cross-arm: mode is a mkdir filter, not copy.
+		cases := []struct {
+			query string
+			why   string
+		}{
+			{"copy=1&mode=755", "mode is a mkdir-arm key, not copy-arm"},
+			{"create=1&mode=755", "mode is a mkdir-arm key, not create-arm"},
+			{"append=1&extra=x", "append doesn't consume any filter param"},
+		}
+		for _, tc := range cases {
+			r := newScopedRequest(t, http.MethodPost, "/v1/fs/main.txt", tc.query)
+			if isScopedBusinessRequestAllowed(r) {
+				t.Errorf("POST /v1/fs/main.txt?%s = true, want false (%s)", tc.query, tc.why)
+			}
+		}
+	})
+}
+
+// TestC2aUploadsStillDeniedForScopedTokens pins the C2b boundary:
+// uploads are still dispatcher-denied for scoped tokens after C2a. This
+// regression catches the case where C2b's whitelist extension might
+// accidentally land before its handlers are wired.
+func TestC2aUploadsStillDeniedForScopedTokens(t *testing.T) {
+	cases := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/v1/uploads"},
+		{http.MethodPost, "/v1/uploads/initiate"},
+		{http.MethodPost, "/v1/uploads/upload-1/complete"},
+		{http.MethodPost, "/v1/uploads/upload-1/resume"},
+		{http.MethodPost, "/v1/uploads/upload-1/abort"},
+		{http.MethodPost, "/v2/uploads/upload-1/parts"},
+		{http.MethodPost, "/v2/uploads/upload-1/complete"},
+		{http.MethodPost, "/v2/uploads/upload-1/abort"},
+	}
+	for _, tc := range cases {
+		r := newScopedRequest(t, tc.method, tc.path, "")
+		if isScopedBusinessRequestAllowed(r) {
+			t.Errorf("%s %s = allowed; uploads must remain dispatcher-denied until C2b", tc.method, tc.path)
 		}
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -429,20 +429,23 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 // only allow a route through when the handler in this PR is known to call
 // AuthorizeFS itself.
 //
-// PR C1 opens read-side only. PR C2 will extend this whitelist to write-side
-// (PUT/PATCH/DELETE/POST on /v1/fs/* + uploads) once each write handler
-// authorizes its target path.
+// PR C1 opened read-side. PR C2 extends the whitelist to write-side
+// (PUT/PATCH/DELETE/POST on /v1/fs/* except chmod) now that each write
+// handler authorizes its target path. Uploads are still default-deny —
+// they will be wired in a follow-up PR with session re-authorize semantics.
 //
 // chmod (POST /v1/fs/<path>?chmod=1) is explicitly NOT and never will be in
 // the scoped allowlist — chmod escalates ACLs and is owner-token-only.
 //
 // The GET branch uses an **action-specific** accept-list (per @adversary-1
 // msg 00efe734 / @adversary-2 msg cbedd30a): the chosen action selector
-// (stat / grep / find / list / none) determines which filter keys handler
-// actually consumes, and only those keys plus the selector itself are
-// admitted. Earlier revisions admitted only the selector keys themselves,
-// which rejected normal scoped grep/find calls like `?grep=hello&limit=20`
-// before AuthorizeFS could even run — a regression vs current behavior.
+// determines which filter keys the handler actually consumes, and only
+// those keys plus the selector itself are admitted.
+//
+// The POST branch also uses an action-specific accept-list (per @adversary-1
+// msg 6e17765f): mixed selectors like `?append=1&copy=1` deny as ambiguous
+// rather than silently first-wins. Each action arm allows only the keys
+// the corresponding handler reads.
 func isScopedBusinessRequestAllowed(r *http.Request) bool {
 	path := r.URL.Path
 
@@ -451,7 +454,7 @@ func isScopedBusinessRequestAllowed(r *http.Request) bool {
 		return r.Method == http.MethodPost
 	}
 
-	// /v1/fs/* — read-side methods/queries only in C1.
+	// /v1/fs/* — read + write methods admitted in C2; uploads still deny.
 	if strings.HasPrefix(path, "/v1/fs/") {
 		switch r.Method {
 		case http.MethodHead:
@@ -459,17 +462,77 @@ func isScopedBusinessRequestAllowed(r *http.Request) bool {
 			return true
 		case http.MethodGet:
 			return isScopedFSGetQueryAllowed(r.URL.Query())
+		case http.MethodPut:
+			// handleWrite — write. No query params consumed.
+			return len(r.URL.Query()) == 0
+		case http.MethodPatch:
+			// handlePatch — write. No query params consumed.
+			return len(r.URL.Query()) == 0
+		case http.MethodDelete:
+			// handleDelete — delete. Consumes ?recursive and ?kind.
+			return queryKeysSubsetOf(r.URL.Query(), []string{"recursive", "kind"})
+		case http.MethodPost:
+			return isScopedFSPostQueryAllowed(r.URL.Query())
 		default:
-			// PUT/PATCH/DELETE/POST on /v1/fs/* are write-side and chmod;
-			// rejected in C1, write-side will be wired in C2 (chmod stays
-			// owner-only forever).
 			return false
 		}
 	}
 
-	// Uploads, SQL, fork, events, journals, vault, status, etc.: not in C1
-	// scope. C2 may open uploads.
+	// Uploads, SQL, fork, events, journals, vault, status: still default-
+	// deny for scoped tokens. Uploads will be wired in a follow-up PR.
 	return false
+}
+
+// isScopedFSPostQueryAllowed mirrors handleFS's POST dispatcher (server.go
+// :691 onward), but rejects mixed selectors as ambiguous (per @adversary-1
+// msg 6e17765f) rather than silently first-wins. Each action arm allows
+// only the keys the corresponding handler reads. chmod is never allowed
+// for scoped tokens.
+func isScopedFSPostQueryAllowed(q url.Values) bool {
+	// Count how many action selectors are set. Multiple selectors = deny;
+	// no selector = deny (no handler matches the dispatcher's else branch
+	// for scoped tokens — that's "unknown POST action" which is a 400 for
+	// owner today, and we don't want to silently widen for scoped).
+	selectors := []string{"append", "copy", "rename", "mkdir", "chmod", "create"}
+	selectorCount := 0
+	var selectorKey string
+	for _, k := range selectors {
+		if q.Has(k) {
+			selectorCount++
+			selectorKey = k
+		}
+	}
+	if selectorCount != 1 {
+		return false
+	}
+
+	switch selectorKey {
+	case "append":
+		// handleAppend reads only ?append.
+		return queryKeysSubsetOf(q, []string{"append"})
+	case "copy":
+		// handleCopy reads only ?copy (source path is in
+		// X-Dat9-Copy-Source header, not query).
+		return queryKeysSubsetOf(q, []string{"copy"})
+	case "rename":
+		// handleRename reads only ?rename (source path is in
+		// X-Dat9-Rename-Source header, not query).
+		return queryKeysSubsetOf(q, []string{"rename"})
+	case "mkdir":
+		// handleMkdir reads ?mkdir and ?mode.
+		return queryKeysSubsetOf(q, []string{"mkdir", "mode"})
+	case "chmod":
+		// chmod is owner-only; scoped tokens MUST NEVER reach this arm.
+		// Defense in depth — the handler also rejects scoped tokens, but
+		// the dispatcher gate makes the policy decision explicit at the
+		// allowlist boundary.
+		return false
+	case "create":
+		// handleCreate reads only ?create.
+		return queryKeysSubsetOf(q, []string{"create"})
+	default:
+		return false
+	}
 }
 
 // isScopedFSGetQueryAllowed mirrors handleFS's GET dispatcher (server.go:618
@@ -936,6 +999,9 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 }
 
 func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpWrite, path) {
+		return
+	}
 	b := backendFromRequest(r)
 	if b == nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_missing_scope", "path", path)...)
@@ -1100,6 +1166,9 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 }
 
 func (s *Server) handlePatch(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpWrite, path) {
+		return
+	}
 	b := backendFromRequest(r)
 	if b == nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "patch_missing_scope", "path", path)...)
@@ -1196,6 +1265,14 @@ func (s *Server) handlePatch(w http.ResponseWriter, r *http.Request, path string
 }
 
 func (s *Server) handleAppend(w http.ResponseWriter, r *http.Request, path string) {
+	// Authorize BEFORE generating the upload plan (per @adversary-1 review
+	// banked invariant): a plan response leaks "this prefix is writable" to
+	// any caller who can hit the endpoint, even if the subsequent PUT is
+	// later denied. Putting authorize first ensures denied scoped tokens
+	// receive a 403 with no plan-shaped JSON body.
+	if !authorizeFS(w, r, FSOpWrite, path) {
+		return
+	}
 	b := backendFromRequest(r)
 	if b == nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "append_missing_scope", "path", path)...)
@@ -1578,6 +1655,9 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 }
 
 func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpDelete, path) {
+		return
+	}
 	b := backendFromRequest(r)
 	if b == nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "delete_missing_scope", "path", path)...)
@@ -1618,16 +1698,25 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path strin
 }
 
 func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath string) {
-	b := backendFromRequest(r)
-	if b == nil {
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "copy_missing_scope", "dst_path", dstPath)...)
-		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
-		return
-	}
+	// Copy semantics: src needs read, dst needs write. The source path is
+	// in the X-Dat9-Copy-Source HEADER (not the URL) — banked invariant
+	// from the cp -r work (PR #434): missing this means the dispatcher
+	// could authorize ONLY the dst from the URL and let a scoped token
+	// exfiltrate from any zone it doesn't have read on, as long as its dst
+	// zone is writable. Both ends MUST authorize.
 	srcPath := r.Header.Get("X-Dat9-Copy-Source")
 	if srcPath == "" {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "copy_missing_source_header", "dst_path", dstPath)...)
 		errJSON(w, http.StatusBadRequest, "missing X-Dat9-Copy-Source header")
+		return
+	}
+	if !authorizeFSPair(w, r, FSOpRead, srcPath, FSOpWrite, dstPath) {
+		return
+	}
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "copy_missing_scope", "dst_path", dstPath)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	if err := b.CopyFileCtx(r.Context(), srcPath, dstPath); err != nil {
@@ -1646,16 +1735,23 @@ func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath stri
 }
 
 func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath string) {
-	b := backendFromRequest(r)
-	if b == nil {
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "rename_missing_scope", "new_path", newPath)...)
-		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
-		return
-	}
+	// Rename semantics: src disappears (= delete), dst is the new location
+	// (= write). Subtle but important — a scoped token with read+write on
+	// the source zone but no delete CAN read & copy the file but must NOT
+	// rename it away. See banked invariant.
 	oldPath := r.Header.Get("X-Dat9-Rename-Source")
 	if oldPath == "" {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "rename_missing_source_header", "new_path", newPath)...)
 		errJSON(w, http.StatusBadRequest, "missing X-Dat9-Rename-Source header")
+		return
+	}
+	if !authorizeFSPair(w, r, FSOpDelete, oldPath, FSOpWrite, newPath) {
+		return
+	}
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "rename_missing_scope", "new_path", newPath)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
 	if err := b.RenameCtx(r.Context(), oldPath, newPath); err != nil {
@@ -1679,6 +1775,9 @@ func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath st
 }
 
 func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpWrite, path) {
+		return
+	}
 	b := backendFromRequest(r)
 	if b == nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "mkdir_missing_scope", "path", path)...)
@@ -1707,6 +1806,14 @@ func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string
 }
 
 func (s *Server) handleChmod(w http.ResponseWriter, r *http.Request, path string) {
+	// chmod escalates ACLs; scoped tokens MUST NEVER be allowed to chmod,
+	// regardless of zone. The dispatcher already denies scoped tokens on
+	// POST /v1/fs/*?chmod, so reaching this handler with a scoped token
+	// indicates a defense-in-depth gap somewhere upstream — fail closed.
+	if scope := ScopeFromContext(r.Context()); scope != nil && scope.IsScoped {
+		errJSON(w, http.StatusForbidden, "chmod is owner-only")
+		return
+	}
 	b := backendFromRequest(r)
 	if b == nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "chmod_missing_scope", "path", path)...)
@@ -1737,6 +1844,9 @@ func (s *Server) handleChmod(w http.ResponseWriter, r *http.Request, path string
 }
 
 func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpWrite, path) {
+		return
+	}
 	b := backendFromRequest(r)
 	if b == nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "create_missing_scope", "path", path)...)


### PR DESCRIPTION
## Summary

PR C2a — write-side handler wiring for Workspace Zones. PR C1 (#439) opened the read-side; this PR opens single-path write handlers (`handleWrite`, `handlePatch`, `handleAppend`, `handleCreate`, `handleMkdir`, `handleDelete`), dual-path handlers (`handleCopy`, `handleRename`), and unconditional scoped-token denial in `handleChmod`. The dispatcher whitelist is extended with action-specific allowlists for PUT/PATCH/DELETE/POST methods.

**Uploads (`/v1/uploads*`, `/v2/uploads/*`) remain dispatcher-denied for scoped tokens until PR C2b** wires their handlers + session re-authorize semantics. Per @adversary-1 + @dev-1 (msgs `08848b1a`, `32d3019f`): release-order safety — only open routes whose handlers in this PR authorize their target path.

Partial completion of task #8 (task stays open as umbrella; C2b finishes it).

## Owner perf invariant

`BenchmarkAuthorizeFSOwnerToken` = **2.08 ns/op** (unchanged from PR A's 2.7 ns/op). Owner tokens carry zero new dispatcher work — the C2a allowlist additions are scoped behind `scope.IsScoped` at `handleBusiness`, never run for owner tokens. @qiffang's red line preserved.

## Handler wiring

| Handler | Op(s) | Notes |
|---|---|---|
| `handleWrite` | `FSOpWrite` | PUT `/v1/fs/<path>` |
| `handlePatch` | `FSOpWrite` | PATCH `/v1/fs/<path>` |
| `handleAppend` | `FSOpWrite` | POST `?append=1` — **authorize BEFORE plan generation** (banked invariant: plan response leaks "this prefix is writable" even on later denial) |
| `handleCreate` | `FSOpWrite` | POST `?create=1` |
| `handleMkdir` | `FSOpWrite` | POST `?mkdir=1` |
| `handleDelete` | `FSOpDelete` | DELETE `/v1/fs/<path>` |
| `handleCopy` | `read` on src + `write` on dst | POST `?copy=1`. **Src in `X-Dat9-Copy-Source` HEADER, NOT URL** — banked invariant from cp -r PR #434. URL-only authorize would let a scoped token exfiltrate from any unreadable zone. |
| `handleRename` | `delete` on src + `write` on dst | POST `?rename=1`. **Rename src op is `delete` not `write`** — file disappears. read+write-only token must NOT be able to rename. |
| `handleChmod` | (unconditional 403 for scoped) | chmod escalates ACLs; owner-only forever. Defense-in-depth: dispatcher already denies POST `?chmod=1` for scoped tokens, but the handler also rejects in case dispatcher gate drifts. |

New helper `authorizeFSPair(w, r, srcOp, srcPath, dstOp, dstPath) bool` — per-handler wrapper around `TenantScope.AuthorizeFSPair` for copy/rename. Symmetric with C1's `authorizeFS`.

## Dispatcher whitelist (extended for C2a)

PR C2a admits:
- All C1 read-side (HEAD/GET on `/v1/fs/*`, POST batch-stat / batch-read-small) — unchanged
- `PUT /v1/fs/*` (no query keys)
- `PATCH /v1/fs/*` (no query keys)
- `DELETE /v1/fs/*` (query subset of `{recursive, kind}`)
- `POST /v1/fs/*` with **exactly one** action selector from `{append, copy, rename, mkdir, create}` + per-arm filter allowlist

PR C2a explicitly denies:
- All `/v1/uploads*` + `/v2/uploads/*` — wait for C2b
- `POST /v1/fs/*?chmod=1` — owner-only forever
- `POST /v1/fs/*` with mixed selectors (`?append=1&copy=1`) — per @adversary-1 msg `6e17765f`: ambiguous = deny, not silent first-wins
- `POST /v1/fs/*` without an action selector
- `PUT`/`PATCH` with any query keys (handlers don't consume them)

The POST allowlist follows the same action-arm pattern as C1's GET allowlist: pick the dispatched action by selector key, then the accept-list is what that handler reads.

## Tests (16 new, all green)

| Test | Scope |
|---|---|
| `TestC2aWriteHandlersRejectScopedRequestBeforeBackend` | 6 subtests proving ordering: handleWrite/Patch/Append/Create/Mkdir/Delete all authorize before `backendFromRequest` (zero-value `&Server{}` trick from C1) |
| `TestC2aHandleAppendAuthorizesBeforePlan` | Plan-response leak invariant: 403 body is canonical "fs access denied", NOT plan JSON |
| `TestC2aHandleChmodRejectsScopedToken` | Scoped 403 even with `/` full-ops zone (chmod not in op set) |
| `TestC2aHandleCopyAuthorizesSrcViaHeader` | Banked PR #434 invariant: src in header — denied src must 403 even when URL dst is writable |
| `TestC2aHandleCopyAllowsBothInZone` | Happy path: src read + dst write in separate zones |
| `TestC2aHandleRenameSrcRequiresDeleteNotWrite` | Banked invariant: read+write on src zone NOT enough — need delete |
| `TestC2aHandleRenameAllowsDeletePlusWrite` | Happy path |
| `TestC2aDispatcherWriteSideAllowed` | 5 subtests covering write-side allow, chmod deny, mixed-selectors deny, no-selector deny, unknown-query-key deny, cross-arm filter-key deny |
| `TestC2aUploadsStillDeniedForScopedTokens` | C2b boundary regression: all uploads still 403 at dispatcher |

Test updates (3): renamed `TestIsScopedBusinessRequestAllowed.write-side-denied` → `non-FS-endpoints-still-denied`; renamed `TestScopedBusinessEndpointGuardDeniesNonC1Endpoints` → `...EndpointsOutOfC1C2aScope`; both reflect the new allowlist surface.

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/server ./pkg/meta -count=1` green (server 34.7s, meta 13.5s)
- [x] `BenchmarkAuthorizeFSOwnerToken` 2.08 ns/op (owner perf preserved)

## Out of scope (PR C2b)

- `handleUploadInitiate` + `handleV2UploadInitiate` — authorize target path on initiate (request body has path)
- `handleUploadComplete` / `handleUploadResume` / `handleUploadAbort` + V2 variants — **re-read session.target_path and re-authorize against CURRENT request scope**, NOT trust the original session creator (token can be revoked / scope changed between initiate and complete)
- Dispatcher whitelist extension to admit `/v1/uploads*` and `/v2/uploads/*` for scoped tokens

Reviewers: @adversary-1 primary + @adversary-2 secondary per the C2 thread. Same admin-bypass merge path as PR A / C1 given the shared `qiffang` GitHub auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
