### PR TITLE
auth: add workspace zone token management

### DIFF
--- a/cmd/drive9/cli/client.go
+++ b/cmd/drive9/cli/client.go
@@ -13,17 +13,17 @@ import (
 // extra multipart RTT is preferable to hanging the CLI.
 const fsClientWarmTimeout = 3 * time.Second
 
-// NewFromEnv returns an owner-scoped client for the drive9 fs plane
-// (drive9 fs cp/cat/ls/mv/rm/sh/grep/find/stat). It is the single entry
-// point for runFS in cmd/drive9/main.go.
+// NewFromEnv returns a tenant API-key client for the drive9 fs plane
+// (drive9 fs cp/cat/ls/mv/rm/sh/grep/find/stat). Tenant API keys include
+// legacy owner keys and workspace-zone fs_scoped keys; both travel through
+// DRIVE9_API_KEY / owner contexts and are distinguished server-side.
 //
-// Invariant: the fs plane is owner-only by construction — delegated JWTs
-// are not accepted on fs endpoints server-side. If a delegated credential
-// is the only one resolvable, this returns a client whose API key is
-// empty, and the request will fail with EACCES at the server (Invariant #7).
-// Callers that need to report a clearer error should check Kind themselves
-// before dispatch; retaining the lenient shape keeps parity with the pre-
-// resolver behaviour (which also returned an empty key).
+// Delegated vault capability tokens (DRIVE9_VAULT_TOKEN) are not accepted on
+// fs endpoints. If a vault token is the only resolvable credential, this
+// returns a client whose API key is empty and the request fails server-side.
+// Callers that need a clearer error should check Kind themselves before
+// dispatch; retaining the lenient shape keeps parity with the pre-resolver
+// behaviour (which also returned an empty key).
 //
 // Credential resolution goes through the unified resolver per §14.2
 // (env > config, Unsetenv-after-read).

--- a/cmd/drive9/cli/token.go
+++ b/cmd/drive9/cli/token.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+// Token manages workspace-zone scoped filesystem tokens.
+func Token(args []string) error {
+	if len(args) == 0 {
+		return tokenUsageErr()
+	}
+	switch args[0] {
+	case "issue":
+		return TokenIssue(args[1:])
+	case "revoke":
+		return TokenRevoke(args[1:])
+	case "-h", "-help", "--help", "help":
+		_, _ = fmt.Fprint(os.Stdout, tokenUsage())
+		return nil
+	default:
+		return fmt.Errorf("unknown token command %q\n%s", args[0], tokenUsage())
+	}
+}
+
+func tokenUsage() string {
+	return `usage: drive9 token <command> [arguments]
+
+commands:
+  issue --subject <name> --ttl <duration> --allow <prefix:ops>
+                       issue an fs_scoped token
+  revoke <token_id>   revoke an fs_scoped token
+
+issue flags:
+  --subject <name>    label stored as token key_name
+  --ttl <duration>    required positive duration, e.g. 1h, 24h
+  --allow <prefix:ops>
+                       repeatable; ops are comma-separated read,list,search,write,delete
+  --json              print full JSON response
+  --token-only        print only the bearer token
+`
+}
+
+func tokenUsageErr() error {
+	return fmt.Errorf("%s", tokenUsage())
+}
+
+func TokenIssue(args []string) error {
+	var (
+		subject   string
+		ttlRaw    string
+		asJSON    bool
+		tokenOnly bool
+		scopes    []client.FSScopeGrant
+	)
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--subject":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--subject requires a value")
+			}
+			i++
+			subject = args[i]
+		case "--ttl":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--ttl requires a value")
+			}
+			i++
+			ttlRaw = args[i]
+		case "--allow":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--allow requires a value")
+			}
+			i++
+			scope, err := parseTokenAllow(args[i])
+			if err != nil {
+				return fmt.Errorf("invalid --allow %q: %w", args[i], err)
+			}
+			scopes = append(scopes, scope)
+		case "--json":
+			asJSON = true
+		case "--token-only":
+			tokenOnly = true
+		default:
+			return fmt.Errorf("unknown flag %q", args[i])
+		}
+	}
+	if asJSON && tokenOnly {
+		return fmt.Errorf("--json and --token-only are mutually exclusive")
+	}
+	if strings.TrimSpace(subject) == "" {
+		return fmt.Errorf("--subject is required")
+	}
+	if ttlRaw == "" {
+		return fmt.Errorf("--ttl is required")
+	}
+	ttl, err := time.ParseDuration(ttlRaw)
+	if err != nil {
+		return fmt.Errorf("invalid --ttl %q: %w", ttlRaw, err)
+	}
+	if ttl < time.Second {
+		return fmt.Errorf("--ttl must be at least 1s")
+	}
+	if len(scopes) == 0 {
+		return fmt.Errorf("at least one --allow is required")
+	}
+
+	c, err := newTokenManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	resp, err := c.IssueScopedToken(context.Background(), client.IssueScopedTokenRequest{
+		Subject:    strings.TrimSpace(subject),
+		TTLSeconds: int64(ttl / time.Second),
+		Scopes:     scopes,
+	})
+	if err != nil {
+		return err
+	}
+	switch {
+	case tokenOnly:
+		_, _ = fmt.Fprintln(os.Stdout, resp.Token)
+	case asJSON:
+		return writeJSON(resp)
+	default:
+		_, _ = fmt.Fprintf(os.Stdout, "token=%s\n", resp.Token)
+		_, _ = fmt.Fprintf(os.Stdout, "token_id=%s\n", resp.TokenID)
+		if resp.ExpiresAt != nil {
+			_, _ = fmt.Fprintf(os.Stdout, "expires_at=%s\n", resp.ExpiresAt.Format(time.RFC3339))
+		}
+		for _, scope := range resp.Scopes {
+			_, _ = fmt.Fprintf(os.Stdout, "scope=%s:%s\n", scope.Prefix, strings.Join(scope.Ops, ","))
+		}
+	}
+	return nil
+}
+
+func TokenRevoke(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: drive9 token revoke <token_id>")
+	}
+	tokenID := strings.TrimSpace(args[0])
+	if tokenID == "" {
+		return fmt.Errorf("token_id is required")
+	}
+	c, err := newTokenManagementClientFromEnv()
+	if err != nil {
+		return err
+	}
+	return c.RevokeScopedToken(context.Background(), tokenID)
+}
+
+func parseTokenAllow(raw string) (client.FSScopeGrant, error) {
+	idx := strings.LastIndex(raw, ":")
+	if idx <= 0 || idx == len(raw)-1 {
+		return client.FSScopeGrant{}, fmt.Errorf("expected <prefix>:<ops>")
+	}
+	prefix := strings.TrimSpace(raw[:idx])
+	if prefix == "" {
+		return client.FSScopeGrant{}, fmt.Errorf("prefix is required")
+	}
+	ops, err := parseTokenOps(raw[idx+1:])
+	if err != nil {
+		return client.FSScopeGrant{}, err
+	}
+	return client.FSScopeGrant{Prefix: prefix, Ops: ops}, nil
+}
+
+func parseTokenOps(raw string) ([]string, error) {
+	seen := make(map[string]bool)
+	for _, part := range strings.Split(raw, ",") {
+		op := strings.TrimSpace(part)
+		if op == "" {
+			return nil, fmt.Errorf("empty op")
+		}
+		switch op {
+		case "read", "list", "search", "write", "delete":
+			seen[op] = true
+		default:
+			return nil, fmt.Errorf("unknown op %q", op)
+		}
+	}
+	if len(seen) == 0 {
+		return nil, fmt.Errorf("empty ops")
+	}
+	if seen["search"] && !seen["read"] {
+		return nil, fmt.Errorf("search op requires read")
+	}
+	out := make([]string, 0, len(seen))
+	for _, op := range []string{"read", "list", "search", "write", "delete"} {
+		if seen[op] {
+			out = append(out, op)
+		}
+	}
+	return out, nil
+}
+
+func newTokenManagementClientFromEnv() (*client.Client, error) {
+	r := ResolveCredentials()
+	if r.Kind != CredentialOwner {
+		return nil, fmt.Errorf("missing tenant API key; set %s or run drive9 create", EnvAPIKey)
+	}
+	return client.New(r.Server, r.APIKey), nil
+}

--- a/cmd/drive9/cli/token_test.go
+++ b/cmd/drive9/cli/token_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseTokenAllowUsesLastColonForDrivePaths(t *testing.T) {
+	scope, err := parseTokenAllow(":/scratch/run-123/:write,read,list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.Prefix != ":/scratch/run-123/" {
+		t.Fatalf("prefix = %q", scope.Prefix)
+	}
+	if got := strings.Join(scope.Ops, ","); got != "read,list,write" {
+		t.Fatalf("ops = %q, want read,list,write", got)
+	}
+}
+
+func TestParseTokenAllowRejectsSearchWithoutRead(t *testing.T) {
+	_, err := parseTokenAllow("/scratch:search")
+	if err == nil {
+		t.Fatal("parseTokenAllow error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "search op requires read") {
+		t.Fatalf("error = %q", err)
+	}
+}
+
+func TestTokenIssueSendsScopedTokenRequest(t *testing.T) {
+	var gotAuth string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/tokens" {
+			http.NotFound(w, r)
+			return
+		}
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"dat9_scoped","token_id":"key_123","subject":"vm0-chat","scope_kind":"fs_scoped","expires_at":"2026-05-21T00:00:00Z","scopes":[{"prefix":"/scratch/run-123","ops":["read","list","write"]}]}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(EnvServer, srv.URL)
+	t.Setenv(EnvAPIKey, "owner-key")
+
+	out := captureStdout(t, func() {
+		if err := TokenIssue([]string{"--subject", "vm0-chat", "--ttl", "24h", "--allow", ":/scratch/run-123/:write,read,list"}); err != nil {
+			t.Fatalf("TokenIssue: %v", err)
+		}
+	})
+	if gotAuth != "Bearer owner-key" {
+		t.Fatalf("Authorization = %q, want owner bearer", gotAuth)
+	}
+	if gotBody["subject"] != "vm0-chat" || gotBody["ttl_seconds"] != float64(86400) {
+		t.Fatalf("request body = %#v", gotBody)
+	}
+	scopes, _ := gotBody["scopes"].([]any)
+	if len(scopes) != 1 {
+		t.Fatalf("scopes = %#v", gotBody["scopes"])
+	}
+	if !strings.Contains(out, "token=dat9_scoped") || !strings.Contains(out, "token_id=key_123") || !strings.Contains(out, "scope=/scratch/run-123:read,list,write") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestTokenIssueTokenOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"dat9_scoped","token_id":"key_123","subject":"vm0","scope_kind":"fs_scoped","expires_at":"2026-05-21T00:00:00Z","scopes":[{"prefix":"/scratch","ops":["read"]}]}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(EnvServer, srv.URL)
+	t.Setenv(EnvAPIKey, "owner-key")
+
+	out := captureStdout(t, func() {
+		if err := TokenIssue([]string{"--subject", "vm0", "--ttl", "1h", "--allow", "/scratch:read", "--token-only"}); err != nil {
+			t.Fatalf("TokenIssue: %v", err)
+		}
+	})
+	if out != "dat9_scoped\n" {
+		t.Fatalf("token-only output = %q", out)
+	}
+}
+
+func TestTokenIssueRequiresOwnerAPIKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(EnvVaultToken, "delegated")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	err := TokenIssue([]string{"--subject", "vm0", "--ttl", "1h", "--allow", "/scratch:read"})
+	if err == nil {
+		t.Fatal("TokenIssue error = nil, want missing owner API key")
+	}
+	if !strings.Contains(err.Error(), EnvAPIKey) {
+		t.Fatalf("error = %q, want %s", err, EnvAPIKey)
+	}
+}
+
+func TestTokenRevokeUsesScopedTokenEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(EnvServer, srv.URL)
+	t.Setenv(EnvAPIKey, "owner-key")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	if err := TokenRevoke([]string{"key_123"}); err != nil {
+		t.Fatalf("TokenRevoke: %v", err)
+	}
+	if gotMethod != http.MethodDelete || gotPath != "/v1/tokens/key_123" {
+		t.Fatalf("method/path = %s %s, want DELETE /v1/tokens/key_123", gotMethod, gotPath)
+	}
+}

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -9,6 +9,7 @@
 //	create  provision a new database and owner context
 //	ctx     manage contexts (show, add, import, fork, ls, use, rm)
 //	fs      filesystem operations (cp, cat, ls, stat, mv, rm, sh, grep, find)
+//	token  issue and revoke workspace-zone scoped filesystem tokens
 //	vault   vault operations (set, get, put, with, ls, rm, grant, revoke, audit)
 //	journal append-only agent/workflow journal operations
 //	mount   mount drive9 as a local filesystem, or mount vault secrets
@@ -40,6 +41,7 @@ var exitFunc = os.Exit
 // "handler not reached". Production callers see no change: the default value
 // is the real cli.Secret and nothing else reassigns it outside tests.
 var vaultHandler = cli.Secret
+var tokenHandler = cli.Token
 var doctorHandler = cli.Doctor
 var journalHandler = cli.Journal
 
@@ -123,6 +125,21 @@ func dispatch(cmd string, args []string) {
 				sub = " " + args[0]
 			}
 			fatal("vault"+sub, err)
+		}
+	case "token":
+		if cliLogger != nil {
+			sub := ""
+			if len(args) > 0 {
+				sub = args[0]
+			}
+			logger.Info(context.Background(), "cli_command", zap.String("command", "token"), zap.String("subcommand", sub))
+		}
+		if err := tokenHandler(args); err != nil {
+			sub := ""
+			if len(args) > 0 {
+				sub = " " + args[0]
+			}
+			fatal("token"+sub, err)
 		}
 	case "journal":
 		if cliLogger != nil {
@@ -286,6 +303,7 @@ func usage(code int) {
 			"  ctx use <name>         activate context\n"+
 			"  ctx rm <name>          delete context\n"+
 			"  fs <command>           filesystem operations\n"+
+			"  token <issue|revoke>   issue and revoke workspace-zone scoped tokens\n"+
 			"  vault <set|get|put|with|ls|rm|grant|revoke|audit>\n"+
 			"                         vault operations\n"+
 			"  journal <new|append|cat|find|verify>\n"+

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -82,6 +82,7 @@ func TestDispatchLongHelpFlagShowsUsage(t *testing.T) {
 		"usage: drive9 <command> [arguments]",
 		"ctx show [--json] [--reveal]",
 		"ctx use <name>",
+		"token <issue|revoke>",
 		"journal <new|append|cat|find|verify>",
 		"mount [flags] [:/remote] <mountpoint>",
 		"mount vault [flags] <mountpoint>",
@@ -120,6 +121,39 @@ func TestDispatchVaultVerbReachesHandler(t *testing.T) {
 		t.Fatal("vault handler was not invoked for `drive9 vault ...`")
 	}
 	want := []string{"ls", "--json"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q", i, gotArgs[i], want[i])
+		}
+	}
+}
+
+func TestDispatchTokenVerbReachesHandler(t *testing.T) {
+	origHandler := tokenHandler
+	origExit := exitFunc
+	t.Cleanup(func() {
+		tokenHandler = origHandler
+		exitFunc = origExit
+	})
+	exitFunc = func(int) {}
+
+	var gotArgs []string
+	called := false
+	tokenHandler = func(args []string) error {
+		called = true
+		gotArgs = args
+		return nil
+	}
+
+	dispatch("token", []string{"issue", "--subject", "vm0"})
+
+	if !called {
+		t.Fatal("token handler was not invoked for `drive9 token ...`")
+	}
+	want := []string{"issue", "--subject", "vm0"}
 	if len(gotArgs) != len(want) {
 		t.Fatalf("args = %v, want %v", gotArgs, want)
 	}

--- a/pkg/client/tokens.go
+++ b/pkg/client/tokens.go
@@ -1,0 +1,78 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// FSScopeGrant is one path prefix + operation set for a scoped filesystem token.
+type FSScopeGrant struct {
+	Prefix string   `json:"prefix"`
+	Ops    []string `json:"ops"`
+}
+
+// IssueScopedTokenRequest is the wire payload for POST /v1/tokens.
+type IssueScopedTokenRequest struct {
+	Subject    string         `json:"subject"`
+	TTLSeconds int64          `json:"ttl_seconds"`
+	Scopes     []FSScopeGrant `json:"scopes"`
+}
+
+// IssueScopedTokenResponse is returned by POST /v1/tokens.
+type IssueScopedTokenResponse struct {
+	Token     string         `json:"token"`
+	TokenID   string         `json:"token_id"`
+	Subject   string         `json:"subject"`
+	ScopeKind string         `json:"scope_kind"`
+	ExpiresAt *time.Time     `json:"expires_at,omitempty"`
+	Scopes    []FSScopeGrant `json:"scopes"`
+}
+
+// IssueScopedToken creates an fs_scoped tenant API token. The caller must use
+// an owner API key; scoped tokens are rejected by the server-side dispatcher.
+func (c *Client) IssueScopedToken(ctx context.Context, req IssueScopedTokenRequest) (*IssueScopedTokenResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal scoped token issue request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/tokens", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result IssueScopedTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode scoped token issue response: %w", err)
+	}
+	return &result, nil
+}
+
+// RevokeScopedToken revokes one tenant API token by id.
+func (c *Client) RevokeScopedToken(ctx context.Context, tokenID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/v1/tokens/"+url.PathEscape(tokenID), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return readError(resp)
+	}
+	return nil
+}

--- a/pkg/client/tokens_test.go
+++ b/pkg/client/tokens_test.go
@@ -1,0 +1,78 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIssueScopedTokenSendsRequest(t *testing.T) {
+	var gotAuth, gotSubject string
+	var gotTTL float64
+	var gotScopes []any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/tokens" {
+			t.Fatalf("path = %q, want /v1/tokens", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotSubject, _ = body["subject"].(string)
+		gotTTL, _ = body["ttl_seconds"].(float64)
+		gotScopes, _ = body["scopes"].([]any)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"dat9_scoped","token_id":"key_123","subject":"vm0","scope_kind":"fs_scoped","expires_at":"2026-05-21T00:00:00Z","scopes":[{"prefix":"/scratch","ops":["read","write"]}]}`))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "owner-key")
+	resp, err := c.IssueScopedToken(context.Background(), IssueScopedTokenRequest{
+		Subject:    "vm0",
+		TTLSeconds: 3600,
+		Scopes:     []FSScopeGrant{{Prefix: ":/scratch", Ops: []string{"read", "write"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer owner-key" {
+		t.Fatalf("Authorization = %q, want owner bearer", gotAuth)
+	}
+	if gotSubject != "vm0" || gotTTL != 3600 || len(gotScopes) != 1 {
+		t.Fatalf("request body subject=%q ttl=%v scopes=%v", gotSubject, gotTTL, gotScopes)
+	}
+	if resp.Token != "dat9_scoped" || resp.TokenID != "key_123" || resp.ScopeKind != "fs_scoped" {
+		t.Fatalf("response = %+v", resp)
+	}
+	if resp.ExpiresAt == nil {
+		t.Fatal("ExpiresAt = nil, want timestamp")
+	}
+}
+
+func TestRevokeScopedTokenUsesDELETE(t *testing.T) {
+	var gotPath, gotMethod string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "owner-key")
+	if err := c.RevokeScopedToken(context.Background(), "key_abc"); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Fatalf("method = %q, want DELETE", gotMethod)
+	}
+	if gotPath != "/v1/tokens/key_abc" {
+		t.Fatalf("path = %q, want /v1/tokens/key_abc", gotPath)
+	}
+}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1356,6 +1356,24 @@ func (s *Store) RevokeTenantAPIKeys(ctx context.Context, tenantID string) (err e
 	return err
 }
 
+func (s *Store) RevokeAPIKey(ctx context.Context, tenantID, apiKeyID string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "revoke_api_key", start, &err)
+	now := time.Now().UTC()
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_api_keys
+		SET status = ?, revoked_at = COALESCE(revoked_at, ?), updated_at = ?
+		WHERE tenant_id = ? AND id = ? AND status = ?`,
+		APIKeyRevoked, now, now, tenantID, apiKeyID, APIKeyActive)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) UpsertStorageNamespace(ctx context.Context, ns *StorageNamespace) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "upsert_storage_namespace", start, &err)

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -125,6 +125,23 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 	if err := s.InsertAPIKey(context.Background(), &badKey); err == nil {
 		t.Fatal("InsertAPIKey with unknown scope kind error = nil, want error")
 	}
+
+	if err := s.RevokeAPIKey(context.Background(), tenant.ID, key.ID); err != nil {
+		t.Fatalf("RevokeAPIKey active key error = %v, want nil", err)
+	}
+	revoked, err := s.ResolveByAPIKeyHash(context.Background(), "hash1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revoked.APIKey.Status != APIKeyRevoked || revoked.APIKey.RevokedAt == nil {
+		t.Fatalf("revoked API key = status %s revoked_at %v, want revoked timestamp", revoked.APIKey.Status, revoked.APIKey.RevokedAt)
+	}
+	if err := s.RevokeAPIKey(context.Background(), tenant.ID, key.ID); err != ErrNotFound {
+		t.Fatalf("RevokeAPIKey already revoked error = %v, want ErrNotFound", err)
+	}
+	if err := s.RevokeAPIKey(context.Background(), "wrong-tenant", key.ID); err != ErrNotFound {
+		t.Fatalf("RevokeAPIKey wrong tenant error = %v, want ErrNotFound", err)
+	}
 }
 
 func TestInsertAndListAPIKeyFSScopes(t *testing.T) {

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -394,6 +394,7 @@ func TestScopedBusinessEndpointGuardDeniesEndpointsOutOfWorkspaceZonesScope(t *t
 		{http.MethodPost, "/v1/sql"},
 		{http.MethodPost, "/v1/fs/file.txt"}, // no action selector → ambiguous → deny
 		{http.MethodPost, "/v1/fork"},
+		{http.MethodPost, "/v1/tokens"},
 		{http.MethodGet, "/v1/events"},
 		{http.MethodGet, "/v1/journals"},
 		{http.MethodGet, "/v1/vault/secrets"},

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -136,6 +136,8 @@ func requestRoute(path string) string {
 		return "/v1/provision"
 	case path == "/v1/status":
 		return "/v1/status"
+	case path == "/v1/tokens" || strings.HasPrefix(path, "/v1/tokens/"):
+		return "/v1/tokens/*"
 	case path == "/v1/sql":
 		return "/v1/sql"
 	case path == "/v1/events":

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -16,6 +16,8 @@ func TestRequestRoute(t *testing.T) {
 		{path: "/metrics", want: "/metrics"},
 		{path: "/v1/provision", want: "/v1/provision"},
 		{path: "/v1/status", want: "/v1/status"},
+		{path: "/v1/tokens", want: "/v1/tokens/*"},
+		{path: "/v1/tokens/key1", want: "/v1/tokens/*"},
 		{path: "/v1/sql", want: "/v1/sql"},
 		{path: "/v1/events", want: "/v1/events"},
 		{path: "/v1/fs/doc.txt", want: "/v1/fs/*"},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -177,6 +177,8 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v1/uploads", business)
 	mux.Handle("/v1/uploads/", business)
 	mux.Handle("/v2/uploads/", business)
+	mux.Handle("/v1/tokens", business)
+	mux.Handle("/v1/tokens/", business)
 	mux.Handle("/v1/fork", business)
 	mux.Handle("/v1/sql", business)
 	mux.Handle("/v1/events", business)
@@ -406,6 +408,8 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 		s.handleUploadAction(w, r)
 	case strings.HasPrefix(r.URL.Path, "/v2/uploads/"):
 		s.handleV2Uploads(w, r)
+	case r.URL.Path == "/v1/tokens" || strings.HasPrefix(r.URL.Path, "/v1/tokens/"):
+		s.handleTokens(w, r)
 	case r.URL.Path == "/v1/fork":
 		s.handleFork(w, r)
 	case r.URL.Path == "/v1/sql":

--- a/pkg/server/tokens.go
+++ b/pkg/server/tokens.go
@@ -110,6 +110,11 @@ func (s *Server) handleScopedTokenIssue(w http.ResponseWriter, r *http.Request, 
 		errJSON(w, http.StatusBadRequest, "scopes are required")
 		return
 	}
+	validatedScopes, err := validateScopedTokenScopes(req.Scopes)
+	if err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	tokenVersion, err := newScopedTokenVersion()
 	if err != nil {
@@ -151,18 +156,12 @@ func (s *Server) handleScopedTokenIssue(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	for _, scopeReq := range req.Scopes {
-		ops, err := canonicalScopeOps(scopeReq.Ops)
-		if err != nil {
-			_ = s.meta.RevokeAPIKey(context.Background(), scope.TenantID, apiKeyID)
-			errJSON(w, http.StatusBadRequest, err.Error())
-			return
-		}
+	for _, scopeReq := range validatedScopes {
 		if err := s.meta.InsertAPIKeyFSScope(r.Context(), &meta.APIKeyFSScope{
 			TenantID:  scope.TenantID,
 			APIKeyID:  apiKeyID,
 			Prefix:    scopeReq.Prefix,
-			Ops:       ops,
+			Ops:       scopeReq.Ops,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}); err != nil {
@@ -205,6 +204,41 @@ func (s *Server) handleScopedTokenRevoke(w http.ResponseWriter, r *http.Request,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func validateScopedTokenScopes(reqScopes []fsTokenScopeRequest) ([]meta.APIKeyFSScope, error) {
+	validated := make([]meta.APIKeyFSScope, 0, len(reqScopes))
+	seenPrefix := make(map[string]bool, len(reqScopes))
+	for _, scopeReq := range reqScopes {
+		prefix, err := canonicalScopePrefix(scopeReq.Prefix)
+		if err != nil {
+			return nil, err
+		}
+		if seenPrefix[prefix] {
+			return nil, fmt.Errorf("duplicate fs scope prefix %q", prefix)
+		}
+		seenPrefix[prefix] = true
+		ops, err := canonicalScopeOps(scopeReq.Ops)
+		if err != nil {
+			return nil, err
+		}
+		validated = append(validated, meta.APIKeyFSScope{Prefix: prefix, Ops: ops})
+	}
+	return validated, nil
+}
+
+func canonicalScopePrefix(raw string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return "", fmt.Errorf("fs scope prefix is required")
+	}
+	if strings.TrimSpace(raw) == ":" {
+		return "", fmt.Errorf("fs scope prefix is required")
+	}
+	prefix, err := normalizeFSAuthorizationPath(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid fs scope prefix: %w", err)
+	}
+	return prefix, nil
 }
 
 func canonicalScopeOps(raw []string) (string, error) {

--- a/pkg/server/tokens.go
+++ b/pkg/server/tokens.go
@@ -1,0 +1,258 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
+)
+
+type fsTokenScopeRequest struct {
+	Prefix string   `json:"prefix"`
+	Ops    []string `json:"ops"`
+}
+
+type issueScopedTokenRequest struct {
+	Subject    string                `json:"subject"`
+	TTLSeconds int64                 `json:"ttl_seconds"`
+	Scopes     []fsTokenScopeRequest `json:"scopes"`
+}
+
+type scopedTokenResponse struct {
+	Token     string                `json:"token"`
+	TokenID   string                `json:"token_id"`
+	Subject   string                `json:"subject"`
+	ScopeKind string                `json:"scope_kind"`
+	ExpiresAt *time.Time            `json:"expires_at,omitempty"`
+	Scopes    []fsTokenScopeRequest `json:"scopes"`
+}
+
+const maxScopedTokenTTLSeconds = int64(1<<63-1) / int64(time.Second)
+
+func (s *Server) handleTokens(w http.ResponseWriter, r *http.Request) {
+	if s.meta == nil || s.pool == nil || len(s.tokenSecret) == 0 {
+		errJSON(w, http.StatusNotFound, "token management not enabled")
+		return
+	}
+	scope, ok := ownerScopeFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	if r.URL.Path == "/v1/tokens" {
+		if r.Method != http.MethodPost {
+			errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		s.handleScopedTokenIssue(w, r, scope)
+		return
+	}
+
+	tokenID := strings.TrimPrefix(r.URL.Path, "/v1/tokens/")
+	if tokenID == "" || strings.Contains(tokenID, "/") {
+		errJSON(w, http.StatusNotFound, "token not found or already revoked")
+		return
+	}
+	if r.Method != http.MethodDelete {
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	s.handleScopedTokenRevoke(w, r, scope, tokenID)
+}
+
+func ownerScopeFromRequest(w http.ResponseWriter, r *http.Request) (*TenantScope, bool) {
+	scope := ScopeFromContext(r.Context())
+	if scope == nil {
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return nil, false
+	}
+	if scope.IsScoped || scope.ScopeKind == meta.APIKeyScopeKindFS {
+		errJSON(w, http.StatusForbidden, "scoped token cannot manage tokens")
+		return nil, false
+	}
+	return scope, true
+}
+
+func (s *Server) handleScopedTokenIssue(w http.ResponseWriter, r *http.Request, scope *TenantScope) {
+	var req issueScopedTokenRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		errJSON(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	subject := strings.TrimSpace(req.Subject)
+	if subject == "" {
+		errJSON(w, http.StatusBadRequest, "subject is required")
+		return
+	}
+	if len(subject) > 64 {
+		errJSON(w, http.StatusBadRequest, "subject must be at most 64 bytes")
+		return
+	}
+	if req.TTLSeconds <= 0 {
+		errJSON(w, http.StatusBadRequest, "ttl_seconds must be positive")
+		return
+	}
+	if req.TTLSeconds > maxScopedTokenTTLSeconds {
+		errJSON(w, http.StatusBadRequest, "ttl_seconds is too large")
+		return
+	}
+	if len(req.Scopes) == 0 {
+		errJSON(w, http.StatusBadRequest, "scopes are required")
+		return
+	}
+
+	tokenVersion, err := newScopedTokenVersion()
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to issue token")
+		return
+	}
+	expiresAt := time.Now().UTC().Add(time.Duration(req.TTLSeconds) * time.Second)
+	rawToken, err := token.IssueTokenWithExpiry(s.tokenSecret, scope.TenantID, tokenVersion, expiresAt)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to issue token")
+		return
+	}
+	cipherToken, err := s.pool.Encrypt(r.Context(), []byte(rawToken))
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to encrypt token")
+		return
+	}
+
+	now := time.Now().UTC()
+	apiKeyID := token.NewID()
+	if err := s.meta.InsertAPIKey(r.Context(), &meta.APIKey{
+		ID:            apiKeyID,
+		TenantID:      scope.TenantID,
+		KeyName:       subject,
+		JWTCiphertext: cipherToken,
+		JWTHash:       token.HashToken(rawToken),
+		TokenVersion:  tokenVersion,
+		Status:        meta.APIKeyActive,
+		ScopeKind:     meta.APIKeyScopeKindFS,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		if errors.Is(err, meta.ErrDuplicate) {
+			errJSON(w, http.StatusConflict, "token subject already exists")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to persist token")
+		return
+	}
+
+	for _, scopeReq := range req.Scopes {
+		ops, err := canonicalScopeOps(scopeReq.Ops)
+		if err != nil {
+			_ = s.meta.RevokeAPIKey(context.Background(), scope.TenantID, apiKeyID)
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if err := s.meta.InsertAPIKeyFSScope(r.Context(), &meta.APIKeyFSScope{
+			TenantID:  scope.TenantID,
+			APIKeyID:  apiKeyID,
+			Prefix:    scopeReq.Prefix,
+			Ops:       ops,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}); err != nil {
+			_ = s.meta.RevokeAPIKey(context.Background(), scope.TenantID, apiKeyID)
+			if errors.Is(err, meta.ErrDuplicate) {
+				errJSON(w, http.StatusConflict, "duplicate fs scope")
+				return
+			}
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	rows, err := s.meta.ListAPIKeyFSScopes(r.Context(), scope.TenantID, apiKeyID)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to load token scopes")
+		return
+	}
+	resp := scopedTokenResponse{
+		Token:     rawToken,
+		TokenID:   apiKeyID,
+		Subject:   subject,
+		ScopeKind: string(meta.APIKeyScopeKindFS),
+		ExpiresAt: &expiresAt,
+		Scopes:    fsScopeResponses(rows),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handleScopedTokenRevoke(w http.ResponseWriter, r *http.Request, scope *TenantScope, tokenID string) {
+	if err := s.meta.RevokeAPIKey(r.Context(), scope.TenantID, tokenID); err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "token not found or already revoked")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to revoke token")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func canonicalScopeOps(raw []string) (string, error) {
+	seen := make(map[FSOp]bool)
+	for _, part := range raw {
+		op := FSOp(strings.TrimSpace(part))
+		if op == "" {
+			return "", fmt.Errorf("empty fs scope op")
+		}
+		if !isKnownFSOp(op) {
+			return "", fmt.Errorf("unknown fs scope op %q", op)
+		}
+		seen[op] = true
+	}
+	if len(seen) == 0 {
+		return "", fmt.Errorf("empty fs scope ops")
+	}
+	if seen[FSOpSearch] && !seen[FSOpRead] {
+		return "", fmt.Errorf("search fs scope requires read")
+	}
+	ordered := make([]string, 0, len(seen))
+	for _, op := range []FSOp{FSOpRead, FSOpList, FSOpSearch, FSOpWrite, FSOpDelete} {
+		if seen[op] {
+			ordered = append(ordered, string(op))
+		}
+	}
+	return strings.Join(ordered, ","), nil
+}
+
+func fsScopeResponses(rows []meta.APIKeyFSScope) []fsTokenScopeRequest {
+	out := make([]fsTokenScopeRequest, 0, len(rows))
+	for _, row := range rows {
+		ops := make([]string, 0)
+		for _, op := range strings.Split(row.Ops, ",") {
+			op = strings.TrimSpace(op)
+			if op != "" {
+				ops = append(ops, op)
+			}
+		}
+		out = append(out, fsTokenScopeRequest{Prefix: row.Prefix, Ops: ops})
+	}
+	return out
+}
+
+func newScopedTokenVersion() (int, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt32))
+	if err != nil {
+		return 0, err
+	}
+	return int(n.Int64()) + 1, nil
+}

--- a/pkg/server/tokens_test.go
+++ b/pkg/server/tokens_test.go
@@ -167,6 +167,91 @@ func TestScopedTokenIssueRejectsInvalidPolicy(t *testing.T) {
 	}
 }
 
+func TestScopedTokenIssuePrevalidatesAllScopesBeforeInsert(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	badBody := `{"subject":"retry-subject","ttl_seconds":3600,"scopes":[{"prefix":"/scratch/ok","ops":["read"]},{"prefix":"/scratch/bad","ops":["search"]}]}`
+	badReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", strings.NewReader(badBody))
+	badReq.Header.Set("Authorization", "Bearer "+rt.token)
+	badReq.Header.Set("Content-Type", "application/json")
+	badResp, err := http.DefaultClient.Do(badReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = badResp.Body.Close()
+	if badResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("bad issue status=%d, want 400", badResp.StatusCode)
+	}
+
+	var count int
+	if err := rt.meta.DB().QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND key_name = ?`,
+		rt.tenantID, "retry-subject").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("api key rows after invalid request = %d, want 0", count)
+	}
+
+	goodBody := `{"subject":"retry-subject","ttl_seconds":3600,"scopes":[{"prefix":"/scratch/ok","ops":["read","write"]}]}`
+	goodReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", strings.NewReader(goodBody))
+	goodReq.Header.Set("Authorization", "Bearer "+rt.token)
+	goodReq.Header.Set("Content-Type", "application/json")
+	goodResp, err := http.DefaultClient.Do(goodReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = goodResp.Body.Close() }()
+	if goodResp.StatusCode != http.StatusCreated {
+		t.Fatalf("good issue status=%d, want 201", goodResp.StatusCode)
+	}
+	var issued scopedTokenResponse
+	if err := json.NewDecoder(goodResp.Body).Decode(&issued); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := rt.meta.ListAPIKeyFSScopes(context.Background(), rt.tenantID, issued.TokenID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Prefix != "/scratch/ok" || rows[0].Ops != "read,write" {
+		t.Fatalf("scope rows = %+v, want one intended row", rows)
+	}
+}
+
+func TestScopedTokenIssueRejectsDuplicateNormalizedPrefixesBeforeInsert(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	body := `{"subject":"dup-prefix","ttl_seconds":3600,"scopes":[{"prefix":"/scratch","ops":["read"]},{"prefix":"/scratch/","ops":["write"]}]}`
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
+	}
+	var count int
+	if err := rt.meta.DB().QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND key_name = ?`,
+		rt.tenantID, "dup-prefix").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("api key rows after duplicate normalized prefix = %d, want 0", count)
+	}
+}
+
 func TestScopedTokenRevokeInvalidatesToken(t *testing.T) {
 	rt, cleanup := newAuthRuntime(t)
 	defer cleanup()

--- a/pkg/server/tokens_test.go
+++ b/pkg/server/tokens_test.go
@@ -1,0 +1,226 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
+)
+
+func TestScopedTokenIssueCreatesFSScopeKey(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	body := `{"subject":"vm0-chat-321","ttl_seconds":3600,"scopes":[{"prefix":":/scratch/run-123/","ops":["write","read","list"]}]}`
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var out scopedTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Token == "" || out.TokenID == "" || out.Subject != "vm0-chat-321" || out.ScopeKind != string(meta.APIKeyScopeKindFS) || out.ExpiresAt == nil {
+		t.Fatalf("unexpected response: %+v", out)
+	}
+	if len(out.Scopes) != 1 || out.Scopes[0].Prefix != "/scratch/run-123" || strings.Join(out.Scopes[0].Ops, ",") != "read,list,write" {
+		t.Fatalf("unexpected response scopes: %+v", out.Scopes)
+	}
+
+	resolved, err := rt.meta.ResolveByAPIKeyHash(context.Background(), token.HashToken(out.Token))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.APIKey.ID != out.TokenID || resolved.APIKey.ScopeKind != meta.APIKeyScopeKindFS || resolved.APIKey.KeyName != "vm0-chat-321" {
+		t.Fatalf("resolved key = %+v", resolved.APIKey)
+	}
+	rows, err := rt.meta.ListAPIKeyFSScopes(context.Background(), rt.tenantID, out.TokenID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Prefix != "/scratch/run-123" || rows[0].Ops != "read,list,write" {
+		t.Fatalf("scope rows = %+v", rows)
+	}
+
+	writeReq, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/scratch/run-123/out.txt", strings.NewReader("ok"))
+	writeReq.Header.Set("Authorization", "Bearer "+out.Token)
+	writeResp, err := http.DefaultClient.Do(writeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = writeResp.Body.Close()
+	if writeResp.StatusCode != http.StatusOK {
+		t.Fatalf("in-scope write status=%d, want 200", writeResp.StatusCode)
+	}
+
+	denyReq, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/main/out.txt", strings.NewReader("no"))
+	denyReq.Header.Set("Authorization", "Bearer "+out.Token)
+	denyResp, err := http.DefaultClient.Do(denyReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = denyResp.Body.Close()
+	if denyResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("out-of-scope write status=%d, want 403", denyResp.StatusCode)
+	}
+}
+
+func TestScopedTokenIssueSameTTLDoesNotHashCollide(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	for _, subject := range []string{"vm0-a", "vm0-b"} {
+		body := `{"subject":"` + subject + `","ttl_seconds":3600,"scopes":[{"prefix":"/scratch","ops":["read"]}]}`
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+rt.token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("subject %s status=%d, want 201", subject, resp.StatusCode)
+		}
+	}
+}
+
+func TestScopedTokenCannotManageTokens(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	key := setAuthRuntimeScopeKind(t, rt, meta.APIKeyScopeKindFS)
+	if err := rt.meta.InsertAPIKeyFSScope(context.Background(), &meta.APIKeyFSScope{
+		TenantID: rt.tenantID,
+		APIKeyID: key.ID,
+		Prefix:   "/scratch",
+		Ops:      "read,write",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", strings.NewReader(`{"subject":"x","ttl_seconds":60,"scopes":[{"prefix":"/scratch","ops":["read"]}]}`))
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status=%d, want 403", resp.StatusCode)
+	}
+}
+
+func TestScopedTokenIssueRejectsInvalidPolicy(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "missing subject", body: `{"ttl_seconds":60,"scopes":[{"prefix":"/scratch","ops":["read"]}]}`},
+		{name: "missing ttl", body: `{"subject":"vm0","scopes":[{"prefix":"/scratch","ops":["read"]}]}`},
+		{name: "missing scopes", body: `{"subject":"vm0","ttl_seconds":60}`},
+		{name: "bare colon prefix", body: `{"subject":"vm0-bare-colon","ttl_seconds":60,"scopes":[{"prefix":":","ops":["read"]}]}`},
+		{name: "search without read", body: `{"subject":"vm0-search-only","ttl_seconds":60,"scopes":[{"prefix":"/scratch","ops":["search"]}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", strings.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer "+rt.token)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestScopedTokenRevokeInvalidatesToken(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	issueBody := []byte(`{"subject":"vm0-revoke","ttl_seconds":3600,"scopes":[{"prefix":"/scratch","ops":["read","write"]}]}`)
+	issueReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", bytes.NewReader(issueBody))
+	issueReq.Header.Set("Authorization", "Bearer "+rt.token)
+	issueReq.Header.Set("Content-Type", "application/json")
+	issueResp, err := http.DefaultClient.Do(issueReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var issued scopedTokenResponse
+	if err := json.NewDecoder(issueResp.Body).Decode(&issued); err != nil {
+		t.Fatal(err)
+	}
+	_ = issueResp.Body.Close()
+	if issueResp.StatusCode != http.StatusCreated {
+		t.Fatalf("issue status=%d", issueResp.StatusCode)
+	}
+
+	revokeReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/v1/tokens/"+issued.TokenID, nil)
+	revokeReq.Header.Set("Authorization", "Bearer "+rt.token)
+	revokeResp, err := http.DefaultClient.Do(revokeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = revokeResp.Body.Close()
+	if revokeResp.StatusCode != http.StatusOK {
+		t.Fatalf("revoke status=%d, want 200", revokeResp.StatusCode)
+	}
+
+	readReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/scratch/file.txt", nil)
+	readReq.Header.Set("Authorization", "Bearer "+issued.Token)
+	readResp, err := http.DefaultClient.Do(readReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = readResp.Body.Close()
+	if readResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("revoked token status=%d, want 401", readResp.StatusCode)
+	}
+
+	revokeAgainReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/v1/tokens/"+issued.TokenID, nil)
+	revokeAgainReq.Header.Set("Authorization", "Bearer "+rt.token)
+	revokeAgainResp, err := http.DefaultClient.Do(revokeAgainReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = revokeAgainResp.Body.Close()
+	if revokeAgainResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("second revoke status=%d, want 404", revokeAgainResp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- add owner-only `/v1/tokens` API for issuing and revoking `fs_scoped` tenant API keys
- add client SDK methods plus `drive9 token issue|revoke` CLI
- persist scoped token rows with explicit `scope_kind=fs_scoped` and validated FS scope rows
- keep scoped callers denied from token management at the dispatcher/handler boundary

## Contract
- CLI issue shape: `drive9 token issue --subject <name> --ttl <duration> --allow <prefix:ops>`
- `--ttl` is required; no hidden default token lifetime
- `--allow` is repeatable; ops are `read,list,search,write,delete`; `search` requires `read`
- revoke shape: `drive9 token revoke <token_id>`
- returned token is the existing `dat9_` bearer family and is usable through `DRIVE9_API_KEY`

## Review Notes
- owner/legacy auth hot path is unchanged; `AuthorizeFS` owner benchmark remains ~2.4ns/op
- issue uses a random per-key `token_version` because the existing `dat9_` JWT payload is deterministic for identical tenant/version/iat/exp claims; regression `TestScopedTokenIssueSameTTLDoesNotHashCollide` pins same-second multi-issue behavior
- revoke is scoped by `tenant_id + token_id`; already-revoked or cross-tenant IDs return 404
- invalid policy rows fail closed; if scope insertion fails after key creation, the key is revoked before returning the error

## Validation
- `go test ./pkg/server ./pkg/meta ./pkg/client ./cmd/drive9 ./cmd/drive9/cli -count=1`
- `go test ./pkg/server -run '^$' -bench 'BenchmarkAuthorizeFSOwnerToken' -benchtime=200ms -count=3`
- `go vet ./pkg/server ./pkg/meta ./pkg/client ./cmd/drive9 ./cmd/drive9/cli`
- `go build ./cmd/drive9 ./cmd/drive9-server`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `drive9 token issue` command to create scoped filesystem tokens with customizable permissions (read, list, search, write, delete) and expiration times
  * Added `drive9 token revoke` command to revoke previously issued tokens
  * Support for JSON and token-only output formats for token issuance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->