### PR TITLE
ux: make scoped token names local

### DIFF
--- a/cmd/drive9/cli/client.go
+++ b/cmd/drive9/cli/client.go
@@ -36,7 +36,7 @@ const fsClientWarmTimeout = 3 * time.Second
 func NewFromEnv() *client.Client {
 	r := ResolveCredentials()
 	apiKey := ""
-	if r.Kind == CredentialOwner {
+	if r.Kind == CredentialOwner || r.Kind == CredentialFSScoped {
 		apiKey = r.APIKey
 	}
 	return client.New(r.Server, apiKey)

--- a/cmd/drive9/cli/config.go
+++ b/cmd/drive9/cli/config.go
@@ -16,6 +16,7 @@ type PrincipalType string
 const (
 	PrincipalOwner     PrincipalType = "owner"
 	PrincipalDelegated PrincipalType = "delegated"
+	PrincipalFSScoped  PrincipalType = "fs_scoped"
 )
 
 // Perm is the scope permission carried by a delegated context's JWT. Spec §6
@@ -31,8 +32,9 @@ const (
 // Type per spec §13.1:
 //
 //   - owner:     APIKey, Server
+//   - fs_scoped: APIKey, Server, Scope[], ExpiresAt
 //   - delegated: Token, Server (from iss), Agent, Scope[], Perm, ExpiresAt,
-//                GrantID, optional LabelHint
+//     GrantID, optional LabelHint
 //
 // The delegated fields are populated by locally decoding the JWT payload at
 // `ctx import` time. This is UX-only — authorization remains server-side
@@ -121,7 +123,7 @@ func saveConfig(cfg *Config) error {
 // active context is delegated or absent.
 func (c *Config) CurrentAPIKey() string {
 	ctx := c.currentContextEntry()
-	if ctx == nil || ctx.Type != PrincipalOwner {
+	if ctx == nil || (ctx.Type != PrincipalOwner && ctx.Type != PrincipalFSScoped) {
 		return ""
 	}
 	return ctx.APIKey

--- a/cmd/drive9/cli/credentials.go
+++ b/cmd/drive9/cli/credentials.go
@@ -34,6 +34,7 @@ type CredentialKind int
 const (
 	CredentialNone CredentialKind = iota
 	CredentialOwner
+	CredentialFSScoped
 	CredentialDelegated
 )
 
@@ -46,7 +47,7 @@ const (
 type ResolvedCredentials struct {
 	Kind         CredentialKind
 	Server       string
-	APIKey       string // set when Kind == CredentialOwner
+	APIKey       string // set when Kind == CredentialOwner or CredentialFSScoped
 	Token        string // set when Kind == CredentialDelegated
 	CredSource   string // "env:DRIVE9_VAULT_TOKEN", "env:DRIVE9_API_KEY", "config:<ctx-name>", ""
 	ServerSource string // "env:DRIVE9_SERVER", "config:<ctx-name>", "default"
@@ -129,6 +130,12 @@ func resolveCredentialsWithConfig(cfg *Config) ResolvedCredentials {
 			case PrincipalOwner:
 				if ctx.APIKey != "" {
 					r.Kind = CredentialOwner
+					r.APIKey = ctx.APIKey
+					r.CredSource = "config:" + ctxName
+				}
+			case PrincipalFSScoped:
+				if ctx.APIKey != "" {
+					r.Kind = CredentialFSScoped
 					r.APIKey = ctx.APIKey
 					r.CredSource = "config:" + ctxName
 				}

--- a/cmd/drive9/cli/credentials_test.go
+++ b/cmd/drive9/cli/credentials_test.go
@@ -141,6 +141,28 @@ func TestResolveCredentials_ConfigDelegatedContext(t *testing.T) {
 	}
 }
 
+func TestResolveCredentials_ConfigFSScopedContext(t *testing.T) {
+	setResolverEnv(t, nil)
+	cfg := &Config{
+		CurrentContext: "smoke",
+		Contexts: map[string]*Context{
+			"smoke": {Type: PrincipalFSScoped, Server: "https://config.example", APIKey: "dat9_scoped"},
+		},
+	}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.Kind != CredentialFSScoped {
+		t.Fatalf("Kind = %d, want CredentialFSScoped", r.Kind)
+	}
+	if r.APIKey != "dat9_scoped" {
+		t.Fatalf("APIKey = %q", r.APIKey)
+	}
+	if r.Server != "https://config.example" {
+		t.Fatalf("Server = %q", r.Server)
+	}
+}
+
 func TestResolveCredentials_EmptyWhenNothingAvailable(t *testing.T) {
 	setResolverEnv(t, nil)
 	cfg := &Config{}

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -118,6 +118,14 @@ func buildCtxShowEntry(cfg *Config, reveal bool) *ctxShowEntry {
 	switch current.Type {
 	case PrincipalOwner:
 		entry.APIKey = formatSecretForDisplay(current.APIKey, reveal)
+	case PrincipalFSScoped:
+		entry.APIKey = formatSecretForDisplay(current.APIKey, reveal)
+		entry.Scope = append([]string(nil), current.Scope...)
+		if !current.ExpiresAt.IsZero() {
+			expiresAt := current.ExpiresAt
+			entry.ExpiresAt = &expiresAt
+		}
+		entry.Status = ctxStatus(current, time.Now())
 	case PrincipalDelegated:
 		entry.Token = formatSecretForDisplay(current.Token, reveal)
 		entry.Agent = current.Agent
@@ -784,7 +792,7 @@ func buildCtxListEntries(cfg *Config) []ctxListEntry {
 }
 
 func ctxStatus(c *Context, now time.Time) string {
-	if c.Type == PrincipalDelegated && !c.ExpiresAt.IsZero() && !c.ExpiresAt.After(now) {
+	if (c.Type == PrincipalDelegated || c.Type == PrincipalFSScoped) && !c.ExpiresAt.IsZero() && !c.ExpiresAt.After(now) {
 		return "expired"
 	}
 	return "active"
@@ -834,7 +842,7 @@ func ctxUseCmd(args []string) error {
 	if !ok {
 		return fmt.Errorf("context %q not found; run: drive9 ctx ls", name)
 	}
-	if c.Type == PrincipalDelegated && !c.ExpiresAt.IsZero() && !c.ExpiresAt.After(time.Now()) {
+	if (c.Type == PrincipalDelegated || c.Type == PrincipalFSScoped) && !c.ExpiresAt.IsZero() && !c.ExpiresAt.After(time.Now()) {
 		return fmt.Errorf("context %q expired at %s; request a new grant and re-import", name, c.ExpiresAt.Format(time.RFC3339))
 	}
 	if cfg.CurrentContext == name {
@@ -855,6 +863,15 @@ func ctxUseDescriptor(c *Context) string {
 	switch c.Type {
 	case PrincipalOwner:
 		return fmt.Sprintf("  owner credentials, server %s", c.Server)
+	case PrincipalFSScoped:
+		scope := "—"
+		if len(c.Scope) > 0 {
+			scope = c.Scope[0]
+			if len(c.Scope) > 1 {
+				scope = fmt.Sprintf("%s +%d", scope, len(c.Scope)-1)
+			}
+		}
+		return fmt.Sprintf("  fs_scoped: scope %s, expires %s", scope, formatExpiresAt(c.ExpiresAt))
 	case PrincipalDelegated:
 		scope := "—"
 		if len(c.Scope) > 0 {

--- a/cmd/drive9/cli/doctor.go
+++ b/cmd/drive9/cli/doctor.go
@@ -377,6 +377,8 @@ func doctorCredentialsCheck(creds ResolvedCredentials) doctorCheck {
 	switch creds.Kind {
 	case CredentialOwner:
 		return doctorCheck{name: "credentials", status: doctorPass, detail: "owner credential from " + creds.CredSource}
+	case CredentialFSScoped:
+		return doctorCheck{name: "credentials", status: doctorPass, detail: "fs_scoped credential from " + creds.CredSource}
 	case CredentialDelegated:
 		return doctorCheck{name: "credentials", status: doctorPass, detail: "delegated credential from " + creds.CredSource}
 	default:

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -586,7 +586,7 @@ func resolveMountCredentials(r ResolvedCredentials, flagServer, flagAPIKey strin
 	apiKey = flagAPIKey
 	if apiKey == "" {
 		switch r.Kind {
-		case CredentialOwner:
+		case CredentialOwner, CredentialFSScoped:
 			apiKey = r.APIKey
 		case CredentialDelegated:
 			token = r.Token

--- a/cmd/drive9/cli/token.go
+++ b/cmd/drive9/cli/token.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
+	"sort"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
@@ -18,6 +21,10 @@ func Token(args []string) error {
 	switch args[0] {
 	case "issue":
 		return TokenIssue(args[1:])
+	case "list", "ls":
+		return TokenList(args[1:])
+	case "forget":
+		return TokenForget(args[1:])
 	case "revoke":
 		return TokenRevoke(args[1:])
 	case "-h", "-help", "--help", "help":
@@ -32,17 +39,25 @@ func tokenUsage() string {
 	return `usage: drive9 token <command> [arguments]
 
 commands:
-  issue --subject <name> --ttl <duration> --allow <prefix:ops>
-                       issue an fs_scoped token
-  revoke <token_id>   revoke an fs_scoped token
+  issue [name] --ttl <duration> --allow <prefix:ops>
+                       issue an fs_scoped token; name is local only when set
+  list                 list locally saved fs_scoped token names
+  forget <name>        remove a local token name without revoking the token
+  revoke <name>        revoke a locally named fs_scoped token
+  revoke -             read a token from stdin and revoke it
 
 issue flags:
-  --subject <name>    label stored as token key_name
+  --subject <name>    optional server-side audit label; not a revoke key
   --ttl <duration>    required positive duration, e.g. 1h, 24h
   --allow <prefix:ops>
                        repeatable; ops are comma-separated read,list,search,write,delete
   --json              print full JSON response
-  --token-only        print only the bearer token
+  --print             print only the bearer token
+  --token-only        alias for --print
+
+revoke flags:
+  --api-key-file <path>
+                       read the target token from a file instead of a local name
 `
 }
 
@@ -57,6 +72,7 @@ func TokenIssue(args []string) error {
 		asJSON    bool
 		tokenOnly bool
 		scopes    []client.FSScopeGrant
+		name      string
 	)
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -84,17 +100,27 @@ func TokenIssue(args []string) error {
 			scopes = append(scopes, scope)
 		case "--json":
 			asJSON = true
-		case "--token-only":
+		case "--print", "--token-only":
 			tokenOnly = true
 		default:
-			return fmt.Errorf("unknown flag %q", args[i])
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag %q", args[i])
+			}
+			if name != "" {
+				return fmt.Errorf("unexpected argument %q", args[i])
+			}
+			name = args[i]
 		}
 	}
 	if asJSON && tokenOnly {
 		return fmt.Errorf("--json and --token-only are mutually exclusive")
 	}
-	if strings.TrimSpace(subject) == "" {
-		return fmt.Errorf("--subject is required")
+	name = strings.TrimSpace(name)
+	if name != "" {
+		cfg := loadConfig()
+		if _, exists := cfg.Contexts[name]; exists {
+			return fmt.Errorf("context %q already exists; use a different name or run: drive9 token forget %s", name, name)
+		}
 	}
 	if ttlRaw == "" {
 		return fmt.Errorf("--ttl is required")
@@ -110,7 +136,8 @@ func TokenIssue(args []string) error {
 		return fmt.Errorf("at least one --allow is required")
 	}
 
-	c, err := newTokenManagementClientFromEnv()
+	r := ResolveCredentials()
+	c, err := newTokenManagementClientFromResolved(r)
 	if err != nil {
 		return err
 	}
@@ -122,14 +149,21 @@ func TokenIssue(args []string) error {
 	if err != nil {
 		return err
 	}
+	if name != "" {
+		if err := saveScopedTokenContext(name, r.Server, resp); err != nil {
+			return rollbackIssuedTokenAfterSaveFailure(c, resp.Token, err)
+		}
+	}
 	switch {
 	case tokenOnly:
 		_, _ = fmt.Fprintln(os.Stdout, resp.Token)
 	case asJSON:
 		return writeJSON(resp)
 	default:
+		if name != "" {
+			_, _ = fmt.Fprintf(os.Stdout, "name=%s\n", name)
+		}
 		_, _ = fmt.Fprintf(os.Stdout, "token=%s\n", resp.Token)
-		_, _ = fmt.Fprintf(os.Stdout, "token_id=%s\n", resp.TokenID)
 		if resp.ExpiresAt != nil {
 			_, _ = fmt.Fprintf(os.Stdout, "expires_at=%s\n", resp.ExpiresAt.Format(time.RFC3339))
 		}
@@ -140,19 +174,213 @@ func TokenIssue(args []string) error {
 	return nil
 }
 
-func TokenRevoke(args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("usage: drive9 token revoke <token_id>")
+func rollbackIssuedTokenAfterSaveFailure(c *client.Client, apiKey string, saveErr error) error {
+	if strings.TrimSpace(apiKey) == "" {
+		return fmt.Errorf("issued token but failed to save local context; no token returned for rollback: %w", saveErr)
 	}
-	tokenID := strings.TrimSpace(args[0])
-	if tokenID == "" {
-		return fmt.Errorf("token_id is required")
+	if err := c.RevokeScopedTokenByAPIKey(context.Background(), apiKey); err != nil {
+		return fmt.Errorf("issued token but failed to save local context and rollback revoke failed; token=%s; save error: %w; revoke error: %v", apiKey, saveErr, err)
+	}
+	return fmt.Errorf("failed to save local token context; issued token was revoked: %w", saveErr)
+}
+
+func TokenList(args []string) error {
+	if len(args) != 0 {
+		return fmt.Errorf("usage: drive9 token list")
+	}
+	cfg := loadConfig()
+	names := make([]string, 0, len(cfg.Contexts))
+	for name, ctx := range cfg.Contexts {
+		if ctx != nil && ctx.Type == PrincipalFSScoped {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		fmt.Println("no local fs_scoped tokens")
+		return nil
+	}
+	sort.Strings(names)
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tSCOPE\tEXPIRES_AT\tSTATUS")
+	now := time.Now()
+	for _, name := range names {
+		ctx := cfg.Contexts[name]
+		cur := " "
+		if name == cfg.CurrentContext {
+			cur = "*"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			cur, name, ctx.Type, renderScope(ctx.Scope, string(ctx.Type), false),
+			formatExpiresAt(ctx.ExpiresAt), ctxStatus(ctx, now))
+	}
+	return w.Flush()
+}
+
+func TokenForget(args []string) error {
+	if len(args) != 1 || strings.HasPrefix(args[0], "-") {
+		return fmt.Errorf("usage: drive9 token forget <name>")
+	}
+	name := strings.TrimSpace(args[0])
+	cfg := loadConfig()
+	ctx, ok := cfg.Contexts[name]
+	if !ok || ctx == nil || ctx.Type != PrincipalFSScoped {
+		return fmt.Errorf("fs_scoped token context %q not found", name)
+	}
+	delete(cfg.Contexts, name)
+	if cfg.CurrentContext == name {
+		cfg.CurrentContext = ""
+	}
+	if err := saveConfig(cfg); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	fmt.Printf("forgot local token %q\n", name)
+	return nil
+}
+
+func TokenRevoke(args []string) error {
+	var apiKeyFile string
+	pos := make([]string, 0, 1)
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--api-key-file":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--api-key-file requires a value")
+			}
+			i++
+			apiKeyFile = args[i]
+		default:
+			pos = append(pos, args[i])
+		}
+	}
+	if apiKeyFile != "" && len(pos) > 0 {
+		return fmt.Errorf("--api-key-file cannot be combined with a token name or id")
+	}
+	if apiKeyFile == "" && len(pos) != 1 {
+		return fmt.Errorf("usage: drive9 token revoke <name|->")
+	}
+
+	var (
+		targetAPIKey string
+		localName    string
+		legacyID     string
+		err          error
+	)
+	switch {
+	case apiKeyFile != "":
+		targetAPIKey, err = readTokenAPIKeyFile(apiKeyFile)
+	case pos[0] == "-":
+		targetAPIKey, err = readTokenAPIKeyStdin()
+	default:
+		target := strings.TrimSpace(pos[0])
+		if target == "" {
+			return fmt.Errorf("token name is required")
+		}
+		if strings.HasPrefix(target, "dat9_") {
+			return fmt.Errorf("refusing token secret in argv; pipe it with: drive9 token revoke -")
+		}
+		cfg := loadConfig()
+		if ctx := cfg.Contexts[target]; ctx != nil && ctx.Type == PrincipalFSScoped && ctx.APIKey != "" {
+			targetAPIKey = ctx.APIKey
+			localName = target
+		} else {
+			legacyID = target
+		}
+	}
+	if err != nil {
+		return err
 	}
 	c, err := newTokenManagementClientFromEnv()
 	if err != nil {
 		return err
 	}
-	return c.RevokeScopedToken(context.Background(), tokenID)
+	if targetAPIKey != "" {
+		if err := c.RevokeScopedTokenByAPIKey(context.Background(), targetAPIKey); err != nil {
+			return err
+		}
+		if localName != "" {
+			if err := forgetLocalScopedTokenContext(localName); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return c.RevokeScopedToken(context.Background(), legacyID)
+}
+
+func saveScopedTokenContext(name, server string, resp *client.IssueScopedTokenResponse) error {
+	cfg := loadConfig()
+	if _, exists := cfg.Contexts[name]; exists {
+		return fmt.Errorf("context %q already exists; use a different name or run: drive9 token forget %s", name, name)
+	}
+	if server == "" {
+		server = cfg.ResolveServer()
+	}
+	ctx := &Context{
+		Type:      PrincipalFSScoped,
+		Server:    server,
+		APIKey:    resp.Token,
+		Scope:     tokenScopeStrings(resp.Scopes),
+		ExpiresAt: timeValue(resp.ExpiresAt),
+	}
+	if _, err := ctxAdd(cfg, name, ctx); err != nil {
+		return err
+	}
+	if err := saveConfig(cfg); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	return nil
+}
+
+func forgetLocalScopedTokenContext(name string) error {
+	cfg := loadConfig()
+	ctx := cfg.Contexts[name]
+	if ctx == nil || ctx.Type != PrincipalFSScoped {
+		return nil
+	}
+	delete(cfg.Contexts, name)
+	if cfg.CurrentContext == name {
+		cfg.CurrentContext = ""
+	}
+	return saveConfig(cfg)
+}
+
+func tokenScopeStrings(scopes []client.FSScopeGrant) []string {
+	out := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		out = append(out, fmt.Sprintf("%s:%s", scope.Prefix, strings.Join(scope.Ops, ",")))
+	}
+	return out
+}
+
+func timeValue(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+func readTokenAPIKeyStdin() (string, error) {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("read token from stdin: %w", err)
+	}
+	apiKey := strings.TrimSpace(string(data))
+	if apiKey == "" {
+		return "", fmt.Errorf("api_key is required")
+	}
+	return apiKey, nil
+}
+
+func readTokenAPIKeyFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read token file: %w", err)
+	}
+	apiKey := strings.TrimSpace(string(data))
+	if apiKey == "" {
+		return "", fmt.Errorf("api_key is required")
+	}
+	return apiKey, nil
 }
 
 func parseTokenAllow(raw string) (client.FSScopeGrant, error) {
@@ -201,7 +429,10 @@ func parseTokenOps(raw string) ([]string, error) {
 }
 
 func newTokenManagementClientFromEnv() (*client.Client, error) {
-	r := ResolveCredentials()
+	return newTokenManagementClientFromResolved(ResolveCredentials())
+}
+
+func newTokenManagementClientFromResolved(r ResolvedCredentials) (*client.Client, error) {
 	if r.Kind != CredentialOwner {
 		return nil, fmt.Errorf("missing tenant API key; set %s or run drive9 create", EnvAPIKey)
 	}

--- a/cmd/drive9/cli/token_test.go
+++ b/cmd/drive9/cli/token_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -32,6 +33,8 @@ func TestParseTokenAllowRejectsSearchWithoutRead(t *testing.T) {
 }
 
 func TestTokenIssueSendsScopedTokenRequest(t *testing.T) {
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
 	var gotAuth string
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -54,26 +57,36 @@ func TestTokenIssueSendsScopedTokenRequest(t *testing.T) {
 	t.Setenv(EnvAPIKey, "owner-key")
 
 	out := captureStdout(t, func() {
-		if err := TokenIssue([]string{"--subject", "vm0-chat", "--ttl", "24h", "--allow", ":/scratch/run-123/:write,read,list"}); err != nil {
+		if err := TokenIssue([]string{"vm0-chat", "--ttl", "24h", "--allow", ":/scratch/run-123/:write,read,list"}); err != nil {
 			t.Fatalf("TokenIssue: %v", err)
 		}
 	})
 	if gotAuth != "Bearer owner-key" {
 		t.Fatalf("Authorization = %q, want owner bearer", gotAuth)
 	}
-	if gotBody["subject"] != "vm0-chat" || gotBody["ttl_seconds"] != float64(86400) {
+	if _, ok := gotBody["subject"]; ok {
+		t.Fatalf("request body includes server-visible subject: %#v", gotBody)
+	}
+	if gotBody["ttl_seconds"] != float64(86400) {
 		t.Fatalf("request body = %#v", gotBody)
 	}
 	scopes, _ := gotBody["scopes"].([]any)
 	if len(scopes) != 1 {
 		t.Fatalf("scopes = %#v", gotBody["scopes"])
 	}
-	if !strings.Contains(out, "token=dat9_scoped") || !strings.Contains(out, "token_id=key_123") || !strings.Contains(out, "scope=/scratch/run-123:read,list,write") {
+	if !strings.Contains(out, "name=vm0-chat") || !strings.Contains(out, "token=dat9_scoped") || strings.Contains(out, "token_id=") || !strings.Contains(out, "scope=/scratch/run-123:read,list,write") {
 		t.Fatalf("output = %q", out)
+	}
+	cfg := loadConfig()
+	ctx := cfg.Contexts["vm0-chat"]
+	if ctx == nil || ctx.Type != PrincipalFSScoped || ctx.APIKey != "dat9_scoped" || len(ctx.Scope) != 1 || ctx.Scope[0] != "/scratch/run-123:read,list,write" {
+		t.Fatalf("saved context = %+v", ctx)
 	}
 }
 
 func TestTokenIssueTokenOnly(t *testing.T) {
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -86,12 +99,104 @@ func TestTokenIssueTokenOnly(t *testing.T) {
 	t.Setenv(EnvAPIKey, "owner-key")
 
 	out := captureStdout(t, func() {
-		if err := TokenIssue([]string{"--subject", "vm0", "--ttl", "1h", "--allow", "/scratch:read", "--token-only"}); err != nil {
+		if err := TokenIssue([]string{"--ttl", "1h", "--allow", "/scratch:read", "--print"}); err != nil {
 			t.Fatalf("TokenIssue: %v", err)
 		}
 	})
 	if out != "dat9_scoped\n" {
 		t.Fatalf("token-only output = %q", out)
+	}
+}
+
+func TestTokenIssueNamedRollsBackWhenLocalSaveFails(t *testing.T) {
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+	var issueCalls, revokeCalls int
+	var revokedAPIKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/tokens":
+			issueCalls++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"dat9_scoped","scope_kind":"fs_scoped","expires_at":"2026-05-21T00:00:00Z","scopes":[{"prefix":"/scratch","ops":["read"]}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/tokens/revoke":
+			revokeCalls++
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode revoke request: %v", err)
+			}
+			revokedAPIKey = body["api_key"]
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	home := t.TempDir()
+	if err := os.WriteFile(home+"/.drive9", []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv(EnvServer, srv.URL)
+	t.Setenv(EnvAPIKey, "owner-key")
+
+	err := TokenIssue([]string{"smoke", "--ttl", "1h", "--allow", "/scratch:read"})
+	if err == nil {
+		t.Fatal("TokenIssue error = nil, want local save failure")
+	}
+	if !strings.Contains(err.Error(), "issued token was revoked") {
+		t.Fatalf("error = %q", err)
+	}
+	if issueCalls != 1 || revokeCalls != 1 {
+		t.Fatalf("issue/revoke calls = %d/%d, want 1/1", issueCalls, revokeCalls)
+	}
+	if revokedAPIKey != "dat9_scoped" {
+		t.Fatalf("revoked api_key = %q, want dat9_scoped", revokedAPIKey)
+	}
+}
+
+func TestTokenIssueNamedReportsRollbackFailure(t *testing.T) {
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+	var revokeCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/tokens":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"dat9_scoped","scope_kind":"fs_scoped","expires_at":"2026-05-21T00:00:00Z","scopes":[{"prefix":"/scratch","ops":["read"]}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/tokens/revoke":
+			revokeCalls++
+			http.Error(w, `{"error":"rollback failed"}`, http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	home := t.TempDir()
+	if err := os.WriteFile(home+"/.drive9", []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv(EnvServer, srv.URL)
+	t.Setenv(EnvAPIKey, "owner-key")
+
+	err := TokenIssue([]string{"smoke", "--ttl", "1h", "--allow", "/scratch:read"})
+	if err == nil {
+		t.Fatal("TokenIssue error = nil, want rollback failure")
+	}
+	if !strings.Contains(err.Error(), "issued token but failed to save local context and rollback revoke failed") {
+		t.Fatalf("error = %q", err)
+	}
+	if !strings.Contains(err.Error(), "token=dat9_scoped") {
+		t.Fatalf("error missing recovery token handle: %q", err)
+	}
+	if revokeCalls != 1 {
+		t.Fatalf("revoke calls = %d, want 1", revokeCalls)
 	}
 }
 
@@ -131,5 +236,118 @@ func TestTokenRevokeUsesScopedTokenEndpoint(t *testing.T) {
 	}
 	if gotMethod != http.MethodDelete || gotPath != "/v1/tokens/key_123" {
 		t.Fatalf("method/path = %s %s, want DELETE /v1/tokens/key_123", gotMethod, gotPath)
+	}
+}
+
+func TestTokenRevokeLocalNameUsesAPIKeyAndForgetsContext(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	cfg := &Config{Server: srv.URL, Contexts: map[string]*Context{}}
+	if _, err := ctxAdd(cfg, "owner", &Context{Type: PrincipalOwner, Server: srv.URL, APIKey: "owner-key"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ctxAdd(cfg, "smoke", &Context{Type: PrincipalFSScoped, Server: srv.URL, APIKey: "dat9_scoped", Scope: []string{"/scratch:read"}}); err != nil {
+		t.Fatal(err)
+	}
+	cfg.CurrentContext = "owner"
+	if err := saveConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	if err := TokenRevoke([]string{"smoke"}); err != nil {
+		t.Fatalf("TokenRevoke: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/tokens/revoke" {
+		t.Fatalf("method/path = %s %s, want POST /v1/tokens/revoke", gotMethod, gotPath)
+	}
+	if gotBody["api_key"] != "dat9_scoped" {
+		t.Fatalf("request body = %#v", gotBody)
+	}
+	if _, ok := loadConfig().Contexts["smoke"]; ok {
+		t.Fatal("local scoped token context still present after revoke")
+	}
+}
+
+func TestTokenRevokeRejectsAPIKeyInArgv(t *testing.T) {
+	err := TokenRevoke([]string{"dat9_secret"})
+	if err == nil {
+		t.Fatal("TokenRevoke error = nil, want argv secret rejection")
+	}
+	if !strings.Contains(err.Error(), "pipe it") {
+		t.Fatalf("error = %q", err)
+	}
+}
+
+func TestTokenForgetRemovesOnlyLocalContext(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg := &Config{Contexts: map[string]*Context{}}
+	if _, err := ctxAdd(cfg, "smoke", &Context{Type: PrincipalFSScoped, Server: "https://s", APIKey: "dat9_scoped"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := TokenForget([]string{"smoke"}); err != nil {
+			t.Fatalf("TokenForget: %v", err)
+		}
+	})
+	if !strings.Contains(out, `forgot local token "smoke"`) {
+		t.Fatalf("output = %q", out)
+	}
+	if _, ok := loadConfig().Contexts["smoke"]; ok {
+		t.Fatal("local scoped token context still present after forget")
+	}
+}
+
+func TestTokenRevokeStdinUsesAPIKeyEndpoint(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/tokens/revoke" {
+			t.Fatalf("method/path = %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(EnvServer, srv.URL)
+	t.Setenv(EnvAPIKey, "owner-key")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = oldStdin })
+	_, _ = w.WriteString("dat9_from_stdin\n")
+	_ = w.Close()
+
+	if err := TokenRevoke([]string{"-"}); err != nil {
+		t.Fatalf("TokenRevoke: %v", err)
+	}
+	if gotBody["api_key"] != "dat9_from_stdin" {
+		t.Fatalf("request body = %#v", gotBody)
 	}
 }

--- a/pkg/client/tokens.go
+++ b/pkg/client/tokens.go
@@ -18,7 +18,7 @@ type FSScopeGrant struct {
 
 // IssueScopedTokenRequest is the wire payload for POST /v1/tokens.
 type IssueScopedTokenRequest struct {
-	Subject    string         `json:"subject"`
+	Subject    string         `json:"subject,omitempty"`
 	TTLSeconds int64          `json:"ttl_seconds"`
 	Scopes     []FSScopeGrant `json:"scopes"`
 }
@@ -26,11 +26,16 @@ type IssueScopedTokenRequest struct {
 // IssueScopedTokenResponse is returned by POST /v1/tokens.
 type IssueScopedTokenResponse struct {
 	Token     string         `json:"token"`
-	TokenID   string         `json:"token_id"`
-	Subject   string         `json:"subject"`
+	TokenID   string         `json:"token_id,omitempty"`
+	Subject   string         `json:"subject,omitempty"`
 	ScopeKind string         `json:"scope_kind"`
 	ExpiresAt *time.Time     `json:"expires_at,omitempty"`
 	Scopes    []FSScopeGrant `json:"scopes"`
+}
+
+// RevokeScopedTokenByAPIKeyRequest is the wire payload for POST /v1/tokens/revoke.
+type RevokeScopedTokenByAPIKeyRequest struct {
+	APIKey string `json:"api_key"`
 }
 
 // IssueScopedToken creates an fs_scoped tenant API token. The caller must use
@@ -66,6 +71,31 @@ func (c *Client) RevokeScopedToken(ctx context.Context, tokenID string) error {
 	if err != nil {
 		return err
 	}
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return readError(resp)
+	}
+	return nil
+}
+
+// RevokeScopedTokenByAPIKey revokes one fs_scoped tenant API token by presenting
+// the target bearer as request data. The caller must authenticate separately as
+// the tenant owner; the server hashes APIKey and revokes only a matching active
+// fs_scoped token in the same tenant.
+func (c *Client) RevokeScopedTokenByAPIKey(ctx context.Context, apiKey string) error {
+	body, err := json.Marshal(RevokeScopedTokenByAPIKeyRequest{APIKey: apiKey})
+	if err != nil {
+		return fmt.Errorf("marshal scoped token revoke request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/tokens/revoke", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.do(req)
 	if err != nil {
 		return err

--- a/pkg/client/tokens_test.go
+++ b/pkg/client/tokens_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestIssueScopedTokenSendsRequest(t *testing.T) {
-	var gotAuth, gotSubject string
+	var gotAuth string
+	var gotSubject any
 	var gotTTL float64
 	var gotScopes []any
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +25,7 @@ func TestIssueScopedTokenSendsRequest(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		gotSubject, _ = body["subject"].(string)
+		gotSubject = body["subject"]
 		gotTTL, _ = body["ttl_seconds"].(float64)
 		gotScopes, _ = body["scopes"].([]any)
 		w.Header().Set("Content-Type", "application/json")
@@ -35,7 +36,6 @@ func TestIssueScopedTokenSendsRequest(t *testing.T) {
 
 	c := New(ts.URL, "owner-key")
 	resp, err := c.IssueScopedToken(context.Background(), IssueScopedTokenRequest{
-		Subject:    "vm0",
 		TTLSeconds: 3600,
 		Scopes:     []FSScopeGrant{{Prefix: ":/scratch", Ops: []string{"read", "write"}}},
 	})
@@ -45,7 +45,7 @@ func TestIssueScopedTokenSendsRequest(t *testing.T) {
 	if gotAuth != "Bearer owner-key" {
 		t.Fatalf("Authorization = %q, want owner bearer", gotAuth)
 	}
-	if gotSubject != "vm0" || gotTTL != 3600 || len(gotScopes) != 1 {
+	if gotSubject != nil || gotTTL != 3600 || len(gotScopes) != 1 {
 		t.Fatalf("request body subject=%q ttl=%v scopes=%v", gotSubject, gotTTL, gotScopes)
 	}
 	if resp.Token != "dat9_scoped" || resp.TokenID != "key_123" || resp.ScopeKind != "fs_scoped" {
@@ -53,6 +53,34 @@ func TestIssueScopedTokenSendsRequest(t *testing.T) {
 	}
 	if resp.ExpiresAt == nil {
 		t.Fatal("ExpiresAt = nil, want timestamp")
+	}
+}
+
+func TestRevokeScopedTokenByAPIKeyUsesPOSTBody(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "owner-key")
+	if err := c.RevokeScopedTokenByAPIKey(context.Background(), "dat9_scoped"); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/v1/tokens/revoke" {
+		t.Fatalf("path = %q, want /v1/tokens/revoke", gotPath)
+	}
+	if gotBody["api_key"] != "dat9_scoped" {
+		t.Fatalf("body = %#v", gotBody)
 	}
 }
 

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -208,6 +208,9 @@ func (s *Store) migrate() (err error) {
 	if err != nil {
 		return fmt.Errorf("parse meta schema statements: %w", err)
 	}
+	if err := dropObsoleteMetaIndexes(ctx, s.db); err != nil {
+		return err
+	}
 	diffs, err := diffMetaSchema(ctx, s.db, spec)
 	if err != nil {
 		return fmt.Errorf("diff meta schema: %w", err)
@@ -408,8 +411,7 @@ func metaInitSchemaStatements() []string {
 			created_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			UNIQUE INDEX idx_api_keys_hash (jwt_hash),
-			INDEX idx_api_keys_tenant (tenant_id, status),
-			UNIQUE INDEX idx_api_keys_tenant_name (tenant_id, key_name)
+			INDEX idx_api_keys_tenant (tenant_id, status)
 		)`,
 		`CREATE TABLE IF NOT EXISTS tenant_api_key_fs_scopes (
 			tenant_id   VARCHAR(64) NOT NULL,
@@ -501,6 +503,28 @@ func metaInitSchemaStatements() []string {
 			INDEX idx_tenant_order (tenant_id, id)
 		)`,
 	}
+}
+
+func dropObsoleteMetaIndexes(ctx context.Context, db *sql.DB) error {
+	if err := dropMetaIndexIfExists(ctx, db, "tenant_api_keys", "idx_api_keys_tenant_name"); err != nil {
+		return fmt.Errorf("drop obsolete meta index idx_api_keys_tenant_name: %w", err)
+	}
+	return nil
+}
+
+func dropMetaIndexIfExists(ctx context.Context, db *sql.DB, tableName, indexName string) error {
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM information_schema.statistics
+		WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?`,
+		tableName, indexName).Scan(&count); err != nil {
+		return err
+	}
+	if count == 0 {
+		return nil
+	}
+	_, err := db.ExecContext(ctx, fmt.Sprintf("DROP INDEX %s ON %s", indexName, tableName))
+	return err
 }
 
 func metaSchemaSpecFromStatements(stmts []string) (metaSchemaSpec, error) {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -144,6 +144,44 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 	}
 }
 
+func TestInsertAPIKeyAllowsRepeatedKeyName(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC()
+	tenant := &Tenant{
+		ID:               "repeat-key-name-tenant",
+		Status:           TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_db",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := s.InsertTenant(context.Background(), tenant); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"k-repeat-a", "k-repeat-b"} {
+		if err := s.InsertAPIKey(context.Background(), &APIKey{
+			ID:            id,
+			TenantID:      tenant.ID,
+			KeyName:       "same-audit-label",
+			JWTCiphertext: []byte("jwt-cipher-" + id),
+			JWTHash:       "hash-" + id,
+			TokenVersion:  1,
+			Status:        APIKeyActive,
+			IssuedAt:      now,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}); err != nil {
+			t.Fatalf("InsertAPIKey %s: %v", id, err)
+		}
+	}
+}
+
 func TestInsertAndListAPIKeyFSScopes(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC()
@@ -554,6 +592,9 @@ func TestMetaSchemaSpecIncludesForkStorageNamespaceColumns(t *testing.T) {
 func TestMetaSchemaSpecIncludesAPIKeyScopeTables(t *testing.T) {
 	spec := mustMetaSpec(t)
 	apiKeys := mustMetaTableSpec(t, spec, "tenant_api_keys")
+	if _, ok := apiKeys.indexes["idx_api_keys_tenant_name"]; ok {
+		t.Fatal("tenant_api_keys schema must not require key_name uniqueness")
+	}
 	scopeKind, ok := apiKeys.columns["scope_kind"]
 	if !ok {
 		t.Fatal("tenant_api_keys schema missing scope_kind")

--- a/pkg/server/tokens.go
+++ b/pkg/server/tokens.go
@@ -23,18 +23,22 @@ type fsTokenScopeRequest struct {
 }
 
 type issueScopedTokenRequest struct {
-	Subject    string                `json:"subject"`
+	Subject    string                `json:"subject,omitempty"`
 	TTLSeconds int64                 `json:"ttl_seconds"`
 	Scopes     []fsTokenScopeRequest `json:"scopes"`
 }
 
 type scopedTokenResponse struct {
 	Token     string                `json:"token"`
-	TokenID   string                `json:"token_id"`
-	Subject   string                `json:"subject"`
+	TokenID   string                `json:"token_id,omitempty"`
+	Subject   string                `json:"subject,omitempty"`
 	ScopeKind string                `json:"scope_kind"`
 	ExpiresAt *time.Time            `json:"expires_at,omitempty"`
 	Scopes    []fsTokenScopeRequest `json:"scopes"`
+}
+
+type revokeScopedTokenByAPIKeyRequest struct {
+	APIKey string `json:"api_key"`
 }
 
 const maxScopedTokenTTLSeconds = int64(1<<63-1) / int64(time.Second)
@@ -55,6 +59,14 @@ func (s *Server) handleTokens(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleScopedTokenIssue(w, r, scope)
+		return
+	}
+	if r.URL.Path == "/v1/tokens/revoke" {
+		if r.Method != http.MethodPost {
+			errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		s.handleScopedTokenRevokeByAPIKey(w, r, scope)
 		return
 	}
 
@@ -90,10 +102,6 @@ func (s *Server) handleScopedTokenIssue(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	subject := strings.TrimSpace(req.Subject)
-	if subject == "" {
-		errJSON(w, http.StatusBadRequest, "subject is required")
-		return
-	}
 	if len(subject) > 64 {
 		errJSON(w, http.StatusBadRequest, "subject must be at most 64 bytes")
 		return
@@ -149,7 +157,7 @@ func (s *Server) handleScopedTokenIssue(w http.ResponseWriter, r *http.Request, 
 		UpdatedAt:     now,
 	}); err != nil {
 		if errors.Is(err, meta.ErrDuplicate) {
-			errJSON(w, http.StatusConflict, "token subject already exists")
+			errJSON(w, http.StatusConflict, "token already exists")
 			return
 		}
 		errJSON(w, http.StatusInternalServerError, "failed to persist token")
@@ -195,6 +203,42 @@ func (s *Server) handleScopedTokenIssue(w http.ResponseWriter, r *http.Request, 
 
 func (s *Server) handleScopedTokenRevoke(w http.ResponseWriter, r *http.Request, scope *TenantScope, tokenID string) {
 	if err := s.meta.RevokeAPIKey(r.Context(), scope.TenantID, tokenID); err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "token not found or already revoked")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to revoke token")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleScopedTokenRevokeByAPIKey(w http.ResponseWriter, r *http.Request, scope *TenantScope) {
+	var req revokeScopedTokenByAPIKeyRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		errJSON(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	apiKey := strings.TrimSpace(req.APIKey)
+	if apiKey == "" {
+		errJSON(w, http.StatusBadRequest, "api_key is required")
+		return
+	}
+	resolved, err := s.meta.ResolveByAPIKeyHash(r.Context(), token.HashToken(apiKey))
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "token not found or already revoked")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to revoke token")
+		return
+	}
+	if resolved.APIKey.TenantID != scope.TenantID || resolved.APIKey.ScopeKind != meta.APIKeyScopeKindFS {
+		errJSON(w, http.StatusNotFound, "token not found or already revoked")
+		return
+	}
+	if err := s.meta.RevokeAPIKey(r.Context(), scope.TenantID, resolved.APIKey.ID); err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "token not found or already revoked")
 			return

--- a/pkg/server/tokens_test.go
+++ b/pkg/server/tokens_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
@@ -20,7 +21,7 @@ func TestScopedTokenIssueCreatesFSScopeKey(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	body := `{"subject":"vm0-chat-321","ttl_seconds":3600,"scopes":[{"prefix":":/scratch/run-123/","ops":["write","read","list"]}]}`
+	body := `{"ttl_seconds":3600,"scopes":[{"prefix":":/scratch/run-123/","ops":["write","read","list"]}]}`
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+rt.token)
 	req.Header.Set("Content-Type", "application/json")
@@ -36,7 +37,7 @@ func TestScopedTokenIssueCreatesFSScopeKey(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if out.Token == "" || out.TokenID == "" || out.Subject != "vm0-chat-321" || out.ScopeKind != string(meta.APIKeyScopeKindFS) || out.ExpiresAt == nil {
+	if out.Token == "" || out.TokenID == "" || out.Subject != "" || out.ScopeKind != string(meta.APIKeyScopeKindFS) || out.ExpiresAt == nil {
 		t.Fatalf("unexpected response: %+v", out)
 	}
 	if len(out.Scopes) != 1 || out.Scopes[0].Prefix != "/scratch/run-123" || strings.Join(out.Scopes[0].Ops, ",") != "read,list,write" {
@@ -47,7 +48,7 @@ func TestScopedTokenIssueCreatesFSScopeKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resolved.APIKey.ID != out.TokenID || resolved.APIKey.ScopeKind != meta.APIKeyScopeKindFS || resolved.APIKey.KeyName != "vm0-chat-321" {
+	if resolved.APIKey.ID != out.TokenID || resolved.APIKey.ScopeKind != meta.APIKeyScopeKindFS || resolved.APIKey.KeyName != "" {
 		t.Fatalf("resolved key = %+v", resolved.APIKey)
 	}
 	rows, err := rt.meta.ListAPIKeyFSScopes(context.Background(), rt.tenantID, out.TokenID)
@@ -104,6 +105,29 @@ func TestScopedTokenIssueSameTTLDoesNotHashCollide(t *testing.T) {
 	}
 }
 
+func TestScopedTokenIssueAllowsRepeatedSubject(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	for i := 0; i < 2; i++ {
+		body := `{"subject":"same-audit-label","ttl_seconds":3600,"scopes":[{"prefix":"/scratch/` + string(rune('a'+i)) + `","ops":["read"]}]}`
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+rt.token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("issue %d status=%d, want 201", i, resp.StatusCode)
+		}
+	}
+}
+
 func TestScopedTokenCannotManageTokens(t *testing.T) {
 	rt, cleanup := newAuthRuntime(t)
 	defer cleanup()
@@ -131,6 +155,18 @@ func TestScopedTokenCannotManageTokens(t *testing.T) {
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status=%d, want 403", resp.StatusCode)
 	}
+
+	revokeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens/revoke", strings.NewReader(`{"api_key":"dat9_target"}`))
+	revokeReq.Header.Set("Authorization", "Bearer "+rt.token)
+	revokeReq.Header.Set("Content-Type", "application/json")
+	revokeResp, err := http.DefaultClient.Do(revokeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = revokeResp.Body.Close()
+	if revokeResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("revoke status=%d, want 403", revokeResp.StatusCode)
+	}
 }
 
 func TestScopedTokenIssueRejectsInvalidPolicy(t *testing.T) {
@@ -144,7 +180,6 @@ func TestScopedTokenIssueRejectsInvalidPolicy(t *testing.T) {
 		name string
 		body string
 	}{
-		{name: "missing subject", body: `{"ttl_seconds":60,"scopes":[{"prefix":"/scratch","ops":["read"]}]}`},
 		{name: "missing ttl", body: `{"subject":"vm0","scopes":[{"prefix":"/scratch","ops":["read"]}]}`},
 		{name: "missing scopes", body: `{"subject":"vm0","ttl_seconds":60}`},
 		{name: "bare colon prefix", body: `{"subject":"vm0-bare-colon","ttl_seconds":60,"scopes":[{"prefix":":","ops":["read"]}]}`},
@@ -308,4 +343,169 @@ func TestScopedTokenRevokeInvalidatesToken(t *testing.T) {
 	if revokeAgainResp.StatusCode != http.StatusNotFound {
 		t.Fatalf("second revoke status=%d, want 404", revokeAgainResp.StatusCode)
 	}
+}
+
+func TestScopedTokenRevokeByAPIKeyInvalidatesToken(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	issueBody := []byte(`{"ttl_seconds":3600,"scopes":[{"prefix":"/scratch","ops":["read","write"]}]}`)
+	issueReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", bytes.NewReader(issueBody))
+	issueReq.Header.Set("Authorization", "Bearer "+rt.token)
+	issueReq.Header.Set("Content-Type", "application/json")
+	issueResp, err := http.DefaultClient.Do(issueReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var issued scopedTokenResponse
+	if err := json.NewDecoder(issueResp.Body).Decode(&issued); err != nil {
+		t.Fatal(err)
+	}
+	_ = issueResp.Body.Close()
+	if issueResp.StatusCode != http.StatusCreated {
+		t.Fatalf("issue status=%d", issueResp.StatusCode)
+	}
+
+	revokeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens/revoke", strings.NewReader(`{"api_key":"`+issued.Token+`"}`))
+	revokeReq.Header.Set("Authorization", "Bearer "+rt.token)
+	revokeReq.Header.Set("Content-Type", "application/json")
+	revokeResp, err := http.DefaultClient.Do(revokeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = revokeResp.Body.Close()
+	if revokeResp.StatusCode != http.StatusOK {
+		t.Fatalf("revoke status=%d, want 200", revokeResp.StatusCode)
+	}
+
+	readReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/scratch/file.txt", nil)
+	readReq.Header.Set("Authorization", "Bearer "+issued.Token)
+	readResp, err := http.DefaultClient.Do(readReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = readResp.Body.Close()
+	if readResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("revoked token status=%d, want 401", readResp.StatusCode)
+	}
+}
+
+func TestScopedTokenRevokeByAPIKeyCannotRevokeOwnerKey(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens/revoke", strings.NewReader(`{"api_key":"`+rt.token+`"}`))
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestScopedTokenRevokeByAPIKeyCannotCrossTenant(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	otherToken := insertAuthRuntimeOwnerToken(t, rt, token.NewID())
+	srv := NewWithConfig(Config{Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	issueBody := []byte(`{"ttl_seconds":3600,"scopes":[{"prefix":"/scratch","ops":["read"]}]}`)
+	issueReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens", bytes.NewReader(issueBody))
+	issueReq.Header.Set("Authorization", "Bearer "+rt.token)
+	issueReq.Header.Set("Content-Type", "application/json")
+	issueResp, err := http.DefaultClient.Do(issueReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var issued scopedTokenResponse
+	if err := json.NewDecoder(issueResp.Body).Decode(&issued); err != nil {
+		t.Fatal(err)
+	}
+	_ = issueResp.Body.Close()
+	if issueResp.StatusCode != http.StatusCreated {
+		t.Fatalf("issue status=%d", issueResp.StatusCode)
+	}
+
+	revokeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/tokens/revoke", strings.NewReader(`{"api_key":"`+issued.Token+`"}`))
+	revokeReq.Header.Set("Authorization", "Bearer "+otherToken)
+	revokeReq.Header.Set("Content-Type", "application/json")
+	revokeResp, err := http.DefaultClient.Do(revokeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = revokeResp.Body.Close()
+	if revokeResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("cross-tenant revoke status=%d, want 404", revokeResp.StatusCode)
+	}
+
+	readReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/fs/scratch/file.txt", nil)
+	readReq.Header.Set("Authorization", "Bearer "+issued.Token)
+	readResp, err := http.DefaultClient.Do(readReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = readResp.Body.Close()
+	if readResp.StatusCode == http.StatusUnauthorized {
+		t.Fatal("target token was revoked by cross-tenant owner")
+	}
+}
+
+func insertAuthRuntimeOwnerToken(t *testing.T, rt *authTestRuntime, tenantID string) string {
+	t.Helper()
+	now := time.Now().UTC()
+	source, err := rt.meta.ResolveByAPIKeyHash(context.Background(), token.HashToken(rt.token))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           source.Tenant.DBHost,
+		DBPort:           source.Tenant.DBPort,
+		DBUser:           source.Tenant.DBUser,
+		DBPasswordCipher: source.Tenant.DBPasswordCipher,
+		DBName:           source.Tenant.DBName,
+		DBTLS:            source.Tenant.DBTLS,
+		Provider:         source.Tenant.Provider,
+		SchemaVersion:    source.Tenant.SchemaVersion,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rawToken, err := token.IssueToken(rt.tokenSecret, tenantID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cipherToken, err := rt.pool.Encrypt(context.Background(), []byte(rawToken))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.InsertAPIKey(context.Background(), &meta.APIKey{
+		ID:            token.NewID(),
+		TenantID:      tenantID,
+		KeyName:       "default",
+		JWTCiphertext: cipherToken,
+		JWTHash:       token.HashToken(rawToken),
+		TokenVersion:  1,
+		Status:        meta.APIKeyActive,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return rawToken
 }


### PR DESCRIPTION
## Summary

Implements the task #10 scoped-token UX correction from qiffang's Unix/Plan9 framing:

- `drive9 token issue [name]` now treats `name` as a local config/context alias only.
- `--subject` is optional audit metadata and no longer required or unique.
- Default human output no longer prints `token_id`.
- Adds local `fs_scoped` contexts usable by fs/mount commands.
- Adds `drive9 token list`, `drive9 token forget <name>`, `drive9 token revoke <name>`, and safe secret input via `drive9 token revoke -` / `--api-key-file`.
- Adds owner-authenticated revoke-by-capability (`POST /v1/tokens/revoke`) by hashing the presented target API key and revoking the matching active fs_scoped key in the same tenant.
- Keeps legacy `DELETE /v1/tokens/{id}` for backcompat/internal use.
- Drops the obsolete `(tenant_id, key_name)` unique index so repeated audit subjects are valid.

## Design Notes

The invariant is: `dat9_...` is the capability; local `name` is only client namespace. The server does not authorize or revoke by local name.

Security boundary for revoke-by-capability:

- Caller must authenticate as owner for the tenant.
- Target api key is request data, hashed server-side.
- Server only revokes matching active `fs_scoped` keys in the same tenant.
- Owner keys are not revoked through the new capability path.
- CLI rejects raw `dat9_...` positional argv and asks users to pipe it to stdin instead.

## Tests

Passed:

- `go test ./cmd/drive9/cli ./pkg/client ./pkg/server ./pkg/meta -count=1`
- `go test ./cmd/drive9 -count=1`
- `go vet ./cmd/drive9 ./cmd/drive9/cli ./pkg/client ./pkg/server ./pkg/meta`
- `go build ./cmd/drive9`
- `git diff --check`

Also tried:

- `go test ./... -count=1`

That broader run failed because multiple package test suites attempted to start MySQL containers and timed out waiting for `port: 3306  MySQL Community Server`; the targeted MySQL-backed `pkg/server` and `pkg/meta` package tests passed immediately before this broader run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `token list` command to view locally saved filesystem-scoped token contexts.
* Added `token forget` command to remove saved token contexts locally.
* Enhanced `token revoke` command to revoke tokens by local name, token ID, or via file input.
* Introduced filesystem-scoped credentials as a new credential type alongside owner credentials.
* Added `/v1/tokens/revoke` endpoint for revoking scoped tokens by API key.

## Bug Fixes
* Made subject field optional when issuing scoped tokens.

## Tests
* Added comprehensive test coverage for new token management commands and credential types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->