### PR TITLE
feat(cli): consolidate ctx/token UX (drop token list, add ctx list --type, fold forget into ctx rm) [task #11]

### DIFF
--- a/cmd/drive9/cli/cli_consolidation_test.go
+++ b/cmd/drive9/cli/cli_consolidation_test.go
@@ -382,6 +382,48 @@ func TestTokenForgetEmitsDeprecationWarningAndDispatchesToCtxRm(t *testing.T) {
 	}
 }
 
+// TestTokenIssueDuplicateNameDoesNotRecommendDeprecatedForget is the
+// @adversary-1 msg `b07b633a` primary-review blocker fix: when
+// `drive9 token issue <name>` finds an existing local context with
+// that name, the error must NOT steer the user to the deprecated
+// `drive9 token forget`. It must point at the canonical
+// `drive9 ctx rm <name>` cleanup path so the user keeps a single
+// mental model (Plan B lock).
+//
+// Two code sites are affected (token.go lines 146 + 337 — both
+// `TokenIssue` pre-check and `saveScopedTokenContext` write-time
+// duplicate-name guard). The test exercises the pre-check site
+// directly via TokenIssue.
+func TestTokenIssueDuplicateNameDoesNotRecommendDeprecatedForget(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg := &Config{Contexts: map[string]*Context{}}
+	if _, err := ctxAdd(cfg, "smoke", &Context{Type: PrincipalFSScoped, Server: "https://s", APIKey: "dat9_existing"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvServer, "https://s")
+	t.Setenv(EnvAPIKey, "owner-key")
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+
+	err := TokenIssue([]string{"smoke", "--ttl", "1h", "--allow", "/scratch/smoke:read"})
+	if err == nil {
+		t.Fatal("expected duplicate-name error, got nil")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "drive9 token forget") {
+		t.Fatalf("duplicate-name error must NOT recommend deprecated `drive9 token forget`, got: %s", msg)
+	}
+	if !strings.Contains(msg, "drive9 ctx rm") {
+		t.Fatalf("duplicate-name error must point at canonical `drive9 ctx rm`, got: %s", msg)
+	}
+	if !strings.Contains(msg, "smoke") {
+		t.Fatalf("error must include the conflicting name 'smoke', got: %s", msg)
+	}
+}
+
 // TestTokenUsageHidesListAndForget verifies the canonical
 // `drive9 token --help` no longer advertises `list` or `forget`
 // as subcommands. They remain reachable as hidden aliases but the

--- a/cmd/drive9/cli/cli_consolidation_test.go
+++ b/cmd/drive9/cli/cli_consolidation_test.go
@@ -1,0 +1,413 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureStderrE runs fn with os.Stderr redirected to a pipe and
+// returns whatever fn wrote to stderr. Mirrors captureStdoutE.
+func captureStderrE(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	done := make(chan []byte, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.Bytes()
+	}()
+	fnErr := fn()
+	_ = w.Close()
+	return string(<-done), fnErr
+}
+
+// seedThreeContexts writes one owner + one delegated + one fs_scoped
+// context to local config under an isolated $HOME for use by the
+// ctx list / ctx rm / token deprecation alias tests in this file.
+func seedThreeContexts(t *testing.T) {
+	t.Helper()
+	withIsolatedHome(t)
+	cfg := &Config{Contexts: map[string]*Context{}}
+	if _, err := ctxAdd(cfg, "owner-ctx", &Context{Type: PrincipalOwner, Server: "https://s", APIKey: "dat9_owner"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ctxAdd(cfg, "delegated-ctx", &Context{Type: PrincipalDelegated, Server: "https://s", Token: "delegated-jwt", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ctxAdd(cfg, "smoke", &Context{Type: PrincipalFSScoped, Server: "https://s", APIKey: "dat9_scoped", Scope: []string{"/scratch/smoke:read,write,list"}, ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	cfg.CurrentContext = "owner-ctx"
+	if err := saveConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCtxListFiltersByTypeFlag verifies `drive9 ctx list --type fs_scoped`
+// returns only fs_scoped contexts. Covers task #11 acceptance criterion
+// from @dev-1 msg `17ccf84e`.
+func TestCtxListFiltersByTypeFlag(t *testing.T) {
+	seedThreeContexts(t)
+
+	out, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"list", "--type", "fs_scoped"})
+	})
+	if err != nil {
+		t.Fatalf("ctx list --type fs_scoped: %v", err)
+	}
+	if !strings.Contains(out, "smoke") {
+		t.Fatalf("expected fs_scoped 'smoke' in output, got: %s", out)
+	}
+	if strings.Contains(out, "owner-ctx") || strings.Contains(out, "delegated-ctx") {
+		t.Fatalf("expected only fs_scoped rows, got: %s", out)
+	}
+}
+
+// TestCtxListScopedShortcutMatchesTypeFilter verifies the `--scoped`
+// shorthand behaves identically to `--type fs_scoped`. This is the
+// user-friendly alias from @gtm-1 msg `2eb962dd` ("--scoped shortcut").
+func TestCtxListScopedShortcutMatchesTypeFilter(t *testing.T) {
+	seedThreeContexts(t)
+
+	withType, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"list", "--type", "fs_scoped"})
+	})
+	if err != nil {
+		t.Fatalf("--type form: %v", err)
+	}
+	withScoped, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"list", "--scoped"})
+	})
+	if err != nil {
+		t.Fatalf("--scoped form: %v", err)
+	}
+	if withType != withScoped {
+		t.Fatalf("--scoped output diverged from --type fs_scoped\n--type:\n%s\n--scoped:\n%s", withType, withScoped)
+	}
+}
+
+// TestCtxListTypeFilterEqualsForm verifies `--type=fs_scoped` works
+// the same as `--type fs_scoped`. Standard Go flag-parsing parity.
+func TestCtxListTypeFilterEqualsForm(t *testing.T) {
+	seedThreeContexts(t)
+
+	out, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"list", "--type=fs_scoped"})
+	})
+	if err != nil {
+		t.Fatalf("--type=fs_scoped: %v", err)
+	}
+	if !strings.Contains(out, "smoke") {
+		t.Fatalf("expected smoke row, got: %s", out)
+	}
+}
+
+// TestCtxListRejectsUnknownType verifies the filter validates the
+// principal-type literal up front, so a typo like `--type scoped`
+// gets a clear error instead of silently returning all rows.
+func TestCtxListRejectsUnknownType(t *testing.T) {
+	seedThreeContexts(t)
+
+	_, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"list", "--type", "scoped"}) // not a valid value
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown --type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown --type") {
+		t.Fatalf("expected 'unknown --type' error, got: %v", err)
+	}
+}
+
+// TestCtxListJSONFilterRespectsType verifies the --json output path
+// also applies the filter. Otherwise scripts would silently get an
+// unfiltered list when combining --json with --type.
+func TestCtxListJSONFilterRespectsType(t *testing.T) {
+	seedThreeContexts(t)
+
+	out, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"list", "--json", "--type", "fs_scoped"})
+	})
+	if err != nil {
+		t.Fatalf("ctx list --json --type: %v", err)
+	}
+	var payload struct {
+		Contexts []map[string]any `json:"contexts"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("decode json: %v\noutput: %s", err, out)
+	}
+	if len(payload.Contexts) != 1 {
+		t.Fatalf("expected 1 fs_scoped row in JSON, got %d: %s", len(payload.Contexts), out)
+	}
+	if payload.Contexts[0]["type"] != string(PrincipalFSScoped) {
+		t.Fatalf("expected type=fs_scoped, got: %v", payload.Contexts[0])
+	}
+}
+
+// TestCtxRmRefusesCurrentContext is the @adversary-1 msg `7c8dc13c`
+// safety guard: removing the active context would leave a dangling
+// CurrentContext pointer. The user must `ctx use <other>` first.
+func TestCtxRmRefusesCurrentContext(t *testing.T) {
+	seedThreeContexts(t)
+
+	// Fixture has owner-ctx as current.
+	err := Ctx([]string{"rm", "owner-ctx"})
+	if err == nil {
+		t.Fatal("expected error refusing to remove current context, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to remove current context") {
+		t.Fatalf("error must explain refusal, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "ctx use") {
+		t.Fatalf("error must point user to `ctx use`, got: %v", err)
+	}
+
+	// Config must be unchanged.
+	cfg := loadConfig()
+	if _, ok := cfg.Contexts["owner-ctx"]; !ok {
+		t.Fatal("owner-ctx removed despite refusal")
+	}
+	if cfg.CurrentContext != "owner-ctx" {
+		t.Fatalf("CurrentContext changed to %q", cfg.CurrentContext)
+	}
+}
+
+// TestCtxRmFSScopedEmitsServerNotRevokedWarning is the @qiffang msg
+// `7472f701` safety usage requirement: removing a fs_scoped context
+// must explicitly tell the user that the server-side token remains
+// valid, and direct them to `drive9 token revoke -` for revocation.
+func TestCtxRmFSScopedEmitsServerNotRevokedWarning(t *testing.T) {
+	seedThreeContexts(t)
+
+	// Switch off owner-ctx so we can rm smoke (it's not current).
+	if err := Ctx([]string{"use", "delegated-ctx"}); err != nil {
+		t.Fatalf("ctx use delegated-ctx: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"rm", "smoke"})
+	})
+	if err != nil {
+		t.Fatalf("ctx rm smoke: %v", err)
+	}
+	if !strings.Contains(out, "removed local context") {
+		t.Fatalf("missing success line, got: %s", out)
+	}
+	if !strings.Contains(out, "NOT revoked") {
+		t.Fatalf("fs_scoped removal MUST warn the server token is NOT revoked, got: %s", out)
+	}
+	if !strings.Contains(out, "drive9 token revoke -") {
+		t.Fatalf("must point user to `drive9 token revoke -` for revocation, got: %s", out)
+	}
+
+	// Verify the local entry is actually gone.
+	if _, ok := loadConfig().Contexts["smoke"]; ok {
+		t.Fatal("local smoke context still present after rm")
+	}
+}
+
+// TestCtxRmOwnerRequiresConfirmation verifies the [y/N] prompt on
+// owner-context removal. A "no" answer (empty line) MUST abort the
+// removal so owner key loss is never accidental.
+func TestCtxRmOwnerRequiresConfirmation(t *testing.T) {
+	seedThreeContexts(t)
+	if err := Ctx([]string{"use", "delegated-ctx"}); err != nil {
+		t.Fatalf("ctx use: %v", err)
+	}
+
+	// Simulate user pressing Enter (empty answer = refusal).
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.WriteString("\n")
+	_ = w.Close()
+	oldStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	out, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"rm", "owner-ctx"})
+	})
+	if err != nil {
+		t.Fatalf("ctx rm: %v", err)
+	}
+	if !strings.Contains(out, "aborted") {
+		t.Fatalf("empty answer should produce 'aborted', got: %s", out)
+	}
+	if _, ok := loadConfig().Contexts["owner-ctx"]; !ok {
+		t.Fatal("owner-ctx removed despite [y/N] refusal — safety guard failed")
+	}
+}
+
+// TestCtxRmOwnerAcceptsYesConfirmation verifies the [y/N] prompt
+// accepts "y" and proceeds with the removal.
+func TestCtxRmOwnerAcceptsYesConfirmation(t *testing.T) {
+	seedThreeContexts(t)
+	if err := Ctx([]string{"use", "delegated-ctx"}); err != nil {
+		t.Fatalf("ctx use: %v", err)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.WriteString("y\n")
+	_ = w.Close()
+	oldStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	if err := Ctx([]string{"rm", "owner-ctx"}); err != nil {
+		t.Fatalf("ctx rm with 'y' confirmation: %v", err)
+	}
+	if _, ok := loadConfig().Contexts["owner-ctx"]; ok {
+		t.Fatal("owner-ctx still present after confirmed removal")
+	}
+}
+
+// TestCtxRmHelpLeadsWithSafetyWarning is the @gtm-1 msg `30bf6704`
+// "scan-first" requirement: the first screen of `drive9 ctx rm --help`
+// must lead with the WARNING line, NOT bury it below detail blocks.
+func TestCtxRmHelpLeadsWithSafetyWarning(t *testing.T) {
+	help := ctxRmUsage()
+	lines := strings.Split(help, "\n")
+	if len(lines) < 4 {
+		t.Fatalf("usage too short: %s", help)
+	}
+	// Line 0: "usage: drive9 ctx rm <name>"
+	// Line 1: blank
+	// Lines 2-3: WARNING block (the scan-first lock)
+	combinedTop := strings.Join(lines[:5], "\n")
+	if !strings.Contains(combinedTop, "WARNING:") {
+		t.Fatalf("WARNING line must appear in the first 5 lines (scan-first), got:\n%s", combinedTop)
+	}
+	if !strings.Contains(combinedTop, "Does NOT revoke") {
+		t.Fatalf("first screen must explicitly say 'Does NOT revoke', got:\n%s", combinedTop)
+	}
+	if !strings.Contains(combinedTop, "drive9 token revoke") {
+		t.Fatalf("first screen must point to `drive9 token revoke` for actual revocation, got:\n%s", combinedTop)
+	}
+	// English-only per @qiffang msg `405e0ae9`. Spot-check for CJK
+	// codepoints anywhere in the usage block.
+	for _, r := range help {
+		if r >= 0x4E00 && r <= 0x9FFF {
+			t.Fatalf("ctx rm usage contains CJK character %q; CLI surface must be English-only", r)
+		}
+	}
+}
+
+// TestTokenListEmitsDeprecationWarningAndDispatchesToCtxList covers
+// the @dev-1 msg `17ccf84e` deprecation contract: `drive9 token list`
+// must (a) warn on stderr that it's deprecated, (b) point users to
+// the canonical `drive9 ctx list --type fs_scoped`, and (c) still
+// produce equivalent output by dispatching through the new path.
+func TestTokenListEmitsDeprecationWarningAndDispatchesToCtxList(t *testing.T) {
+	seedThreeContexts(t)
+
+	var (
+		stdout string
+		stderr string
+	)
+	// Capture both streams: stderr for the deprecation warning,
+	// stdout for the dispatched output.
+	stderr, err := captureStderrE(t, func() error {
+		out, runErr := captureStdoutE(t, func() error {
+			return Token([]string{"list"})
+		})
+		stdout = out
+		return runErr
+	})
+	if err != nil {
+		t.Fatalf("Token list: %v", err)
+	}
+
+	if !strings.Contains(stderr, "deprecated") {
+		t.Fatalf("stderr must contain 'deprecated' warning, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "drive9 ctx list --type fs_scoped") {
+		t.Fatalf("stderr must point to canonical command, got: %s", stderr)
+	}
+	// Stdout should match what `ctx list --type fs_scoped` produces.
+	if !strings.Contains(stdout, "smoke") {
+		t.Fatalf("stdout should still list smoke (dispatched), got: %s", stdout)
+	}
+	if strings.Contains(stdout, "owner-ctx") {
+		t.Fatalf("stdout should NOT include owner-ctx (filtered), got: %s", stdout)
+	}
+}
+
+// TestTokenForgetEmitsDeprecationWarningAndDispatchesToCtxRm covers
+// the parallel deprecation contract for `drive9 token forget`. Must
+// warn on stderr and route through `drive9 ctx rm`.
+func TestTokenForgetEmitsDeprecationWarningAndDispatchesToCtxRm(t *testing.T) {
+	seedThreeContexts(t)
+	// Switch off owner-ctx so smoke isn't blocked by "current"
+	// refusal when dispatched.
+	if err := Ctx([]string{"use", "delegated-ctx"}); err != nil {
+		t.Fatalf("ctx use: %v", err)
+	}
+
+	stderr, err := captureStderrE(t, func() error {
+		_, runErr := captureStdoutE(t, func() error {
+			return Token([]string{"forget", "smoke"})
+		})
+		return runErr
+	})
+	if err != nil {
+		t.Fatalf("Token forget: %v", err)
+	}
+
+	if !strings.Contains(stderr, "deprecated") {
+		t.Fatalf("stderr must warn deprecated, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "drive9 ctx rm") {
+		t.Fatalf("stderr must point to `drive9 ctx rm`, got: %s", stderr)
+	}
+	if _, ok := loadConfig().Contexts["smoke"]; ok {
+		t.Fatal("smoke still present after token forget dispatched to ctx rm")
+	}
+}
+
+// TestTokenUsageHidesListAndForget verifies the canonical
+// `drive9 token --help` no longer advertises `list` or `forget`
+// as subcommands. They remain reachable as hidden aliases but the
+// help text steers users toward `ctx list` / `ctx rm`.
+func TestTokenUsageHidesListAndForget(t *testing.T) {
+	usage := tokenUsage()
+	// `list` and `forget` must not appear as advertised subcommands.
+	// (They may appear in cross-references like "To list local
+	// contexts ... drive9 ctx list", which is intentional.)
+	for _, line := range strings.Split(usage, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Match the pattern "list   ..." or "forget   ..." at the
+		// start of a help row.
+		if strings.HasPrefix(trimmed, "list ") || trimmed == "list" {
+			t.Fatalf("token usage still lists 'list' subcommand: %s", line)
+		}
+		if strings.HasPrefix(trimmed, "forget ") || trimmed == "forget" {
+			t.Fatalf("token usage still lists 'forget' subcommand: %s", line)
+		}
+	}
+	// And the cross-reference to the canonical ctx commands MUST
+	// be present so users can find the replacement.
+	if !strings.Contains(usage, "drive9 ctx list") {
+		t.Fatalf("token usage must point users to `drive9 ctx list` for listing, got:\n%s", usage)
+	}
+	if !strings.Contains(usage, "drive9 ctx rm") {
+		t.Fatalf("token usage must point users to `drive9 ctx rm` for local removal, got:\n%s", usage)
+	}
+}

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -53,9 +53,9 @@ func ctxUsage() string {
   import --from-file -                                add delegated context from stdin explicitly
   import                                              add delegated context from stdin (default when stdin is a pipe)
   fork [<new>] [--from <ctx>] [--json]                create a copy-on-write fork context
-  ls [-l|--json]                                      list contexts
+  ls [-l|--json] [--type <kind>|--scoped]             list contexts (filter by type: owner|delegated|fs_scoped)
   use <name>                                          activate a context
-  rm <name>                                           delete a context`
+  rm <name>                                           remove a local context name (does NOT revoke server-side credential)`
 }
 
 func ctxUsageErr() error {
@@ -685,24 +685,56 @@ func scopeRootSegment(scope string) string {
 func ctxListCmd(args []string) error {
 	longForm := false
 	asJSON := false
-	for _, arg := range args {
-		switch arg {
+	typeFilter := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
 		case "-l", "--long":
 			longForm = true
 		case "--json":
 			asJSON = true
+		case "--scoped":
+			// Shorthand for --type fs_scoped. The user mental model
+			// is "show me the scoped tokens" — accept the shortcut
+			// so they don't have to remember the type literal.
+			typeFilter = string(PrincipalFSScoped)
+		case "--type":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--type requires a value (owner|delegated|fs_scoped)")
+			}
+			i++
+			typeFilter = args[i]
 		default:
-			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx ls [-l|--json]", arg)
+			if strings.HasPrefix(args[i], "--type=") {
+				typeFilter = strings.TrimPrefix(args[i], "--type=")
+				continue
+			}
+			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx ls [-l|--json] [--type <kind>|--scoped]", args[i])
 		}
 	}
 	if longForm && asJSON {
 		return fmt.Errorf("-l/--long and --json are mutually exclusive")
 	}
+	if typeFilter != "" {
+		if !isKnownPrincipalType(typeFilter) {
+			return fmt.Errorf("unknown --type %q; valid: owner, delegated, fs_scoped", typeFilter)
+		}
+	}
 	cfg := loadConfig()
 	if asJSON {
-		return writeCtxListJSON(cfg)
+		return writeCtxListJSON(cfg, typeFilter)
 	}
-	return writeCtxListTable(cfg, longForm)
+	return writeCtxListTable(cfg, longForm, typeFilter)
+}
+
+// isKnownPrincipalType validates a --type filter value against the set
+// of principal types stored in local contexts. Keep this in sync with
+// PrincipalOwner / PrincipalDelegated / PrincipalFSScoped in config.go.
+func isKnownPrincipalType(value string) bool {
+	switch PrincipalType(value) {
+	case PrincipalOwner, PrincipalDelegated, PrincipalFSScoped:
+		return true
+	}
+	return false
 }
 
 type ctxListEntry struct {
@@ -718,8 +750,8 @@ type ctxListEntry struct {
 	GrantID   string    `json:"grant_id,omitempty"`
 }
 
-func writeCtxListJSON(cfg *Config) error {
-	entries := buildCtxListEntries(cfg)
+func writeCtxListJSON(cfg *Config, typeFilter string) error {
+	entries := filterCtxListEntries(buildCtxListEntries(cfg), typeFilter)
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(map[string]any{
@@ -728,9 +760,13 @@ func writeCtxListJSON(cfg *Config) error {
 	})
 }
 
-func writeCtxListTable(cfg *Config, longForm bool) error {
-	entries := buildCtxListEntries(cfg)
+func writeCtxListTable(cfg *Config, longForm bool, typeFilter string) error {
+	entries := filterCtxListEntries(buildCtxListEntries(cfg), typeFilter)
 	if len(entries) == 0 {
+		if typeFilter != "" {
+			fmt.Printf("no contexts of type %q configured\n", typeFilter)
+			return nil
+		}
 		fmt.Println("no contexts configured")
 		fmt.Println("run: drive9 ctx add --api-key <key>  (owner)")
 		fmt.Println("     drive9 ctx import --from-file <path>  (delegated)")
@@ -789,6 +825,22 @@ func buildCtxListEntries(cfg *Config) []ctxListEntry {
 		})
 	}
 	return entries
+}
+
+// filterCtxListEntries returns the subset of entries whose Type matches
+// the supplied filter. An empty filter returns the slice unchanged.
+// Used by `drive9 ctx list --type <kind>` / `--scoped`.
+func filterCtxListEntries(entries []ctxListEntry, typeFilter string) []ctxListEntry {
+	if typeFilter == "" {
+		return entries
+	}
+	out := entries[:0:0]
+	for _, e := range entries {
+		if e.Type == typeFilter {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 func ctxStatus(c *Context, now time.Time) string {
@@ -887,25 +939,110 @@ func ctxUseDescriptor(c *Context) string {
 }
 
 // ctxRmCmd implements `drive9 ctx rm <name>` per spec §13.2.
+// ctxRmCmd implements `drive9 ctx rm <name>`.
+//
+// SAFETY CONTRACT (per task #11 / msg `7472f701` from qiffang):
+// This is a LOCAL cleanup operation. It does NOT contact the server and
+// does NOT revoke any server-side credential. Three safety layers:
+//
+//  1. Help text (ctxRmUsage) leads with a WARNING line so the
+//     scanning user reads "Local cleanup only. Does NOT revoke
+//     server-side credentials." in the first screen.
+//  2. Runtime: removing an owner context is unrecoverable on this
+//     machine (the api_key is erased from local config; the server
+//     key remains valid), so we require interactive [y/N]
+//     confirmation. fs_scoped contexts do not require confirmation
+//     but the post-rm output explicitly states the server token
+//     remains valid until TTL or explicit revoke.
+//  3. Removing the current active context is refused (per
+//     @adversary-1 msg `7c8dc13c`) to prevent leaving a dangling
+//     CurrentContext pointer in saved config. The user is told to
+//     `ctx use <other>` first.
+//
+// Acceptance from #drive9:67e75a87 task #11 thread.
 func ctxRmCmd(args []string) error {
 	if len(args) != 1 || strings.HasPrefix(args[0], "--") {
-		return fmt.Errorf("usage: drive9 ctx rm <name>")
+		return fmt.Errorf("%s", ctxRmUsage())
 	}
 	name := args[0]
 	cfg := loadConfig()
-	if _, ok := cfg.Contexts[name]; !ok {
+	target, ok := cfg.Contexts[name]
+	if !ok || target == nil {
 		return fmt.Errorf("context %q not found", name)
 	}
-	delete(cfg.Contexts, name)
 	if cfg.CurrentContext == name {
-		cfg.CurrentContext = ""
+		return fmt.Errorf("refusing to remove current context %q; switch first with `drive9 ctx use <other>` then retry", name)
 	}
+	if target.Type == PrincipalOwner {
+		if !confirmCtxRmOwner(name) {
+			fmt.Printf("aborted; %q was not removed\n", name)
+			return nil
+		}
+	}
+	delete(cfg.Contexts, name)
 	if err := saveConfig(cfg); err != nil {
 		return fmt.Errorf("save config: %w", err)
 	}
-	fmt.Printf("removed context %q\n", name)
-	if cfg.CurrentContext == "" {
-		fmt.Println("no current context; run `drive9 ctx use <name>` to activate one")
-	}
+	emitCtxRmSuccess(name, target)
 	return nil
+}
+
+// ctxRmUsage returns the user-facing help text for `drive9 ctx rm`.
+// Written English-only (per qiffang msg `405e0ae9` directive: no
+// Chinese in CLI surface). The first screen leads with a WARNING line
+// + a redirect to the correct revoke path, per @gtm-1's scan-first
+// observation (msg `30bf6704`).
+func ctxRmUsage() string {
+	return `usage: drive9 ctx rm <name>
+
+  WARNING: Local cleanup only. Does NOT revoke server-side credentials.
+  To revoke a scoped token: drive9 token revoke <name>
+
+  Removes the named context from local config (~/.drive9/config).
+  - fs_scoped: the dat9_... token remains valid on the server until TTL
+    expiry or explicit revoke.
+  - owner: the api_key is erased from local config. The server key
+    remains valid. You'll need it saved elsewhere to log back in.
+
+  Removing the current active context is refused; switch with
+  ` + "`drive9 ctx use <other>`" + ` first.
+
+example:
+  drive9 ctx rm smoke`
+}
+
+// confirmCtxRmOwner prompts the operator for a yes/no answer before
+// removing an owner context. Returns true only if the operator types
+// "y" or "yes" (case-insensitive). Any other input — including an
+// empty line, "n", EOF, or read error — is treated as a refusal.
+func confirmCtxRmOwner(name string) bool {
+	fmt.Fprintf(os.Stderr, "WARNING: %q is an owner context. Removing it erases the owner api_key\n", name)
+	fmt.Fprintf(os.Stderr, "from local config; the server key remains valid (you may lose access from this\n")
+	fmt.Fprintf(os.Stderr, "machine unless the key is saved elsewhere).\n")
+	fmt.Fprint(os.Stderr, "Continue? [y/N]: ")
+	var answer string
+	if _, err := fmt.Fscanln(os.Stdin, &answer); err != nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+		return true
+	}
+	return false
+}
+
+// emitCtxRmSuccess writes the success message after a context is
+// removed. For fs_scoped contexts it includes an explicit reminder
+// that the server-side token is still valid, with a one-line pointer
+// to the correct revoke command (per the @qiffang msg `7472f701`
+// usage clarity directive).
+func emitCtxRmSuccess(name string, removed *Context) {
+	fmt.Printf("removed local context %q (type=%s)\n", name, removed.Type)
+	if removed.Type == PrincipalFSScoped {
+		fmt.Println("note: the scoped token on the server is NOT revoked.")
+		fmt.Printf("      to revoke, run: drive9 token revoke -   (paste the saved api_key on stdin)\n")
+		if !removed.ExpiresAt.IsZero() {
+			fmt.Printf("      otherwise the token remains valid until %s\n", removed.ExpiresAt.UTC().Format(time.RFC3339))
+		}
+	}
 }

--- a/cmd/drive9/cli/token.go
+++ b/cmd/drive9/cli/token.go
@@ -143,7 +143,7 @@ func TokenIssue(args []string) error {
 	if name != "" {
 		cfg := loadConfig()
 		if _, exists := cfg.Contexts[name]; exists {
-			return fmt.Errorf("context %q already exists; use a different name or run: drive9 token forget %s", name, name)
+			return fmt.Errorf("context %q already exists; use a different name or remove the local context with: drive9 ctx rm %s", name, name)
 		}
 	}
 	if ttlRaw == "" {
@@ -334,7 +334,7 @@ func TokenRevoke(args []string) error {
 func saveScopedTokenContext(name, server string, resp *client.IssueScopedTokenResponse) error {
 	cfg := loadConfig()
 	if _, exists := cfg.Contexts[name]; exists {
-		return fmt.Errorf("context %q already exists; use a different name or run: drive9 token forget %s", name, name)
+		return fmt.Errorf("context %q already exists; use a different name or remove the local context with: drive9 ctx rm %s", name, name)
 	}
 	if server == "" {
 		server = cfg.ResolveServer()

--- a/cmd/drive9/cli/token.go
+++ b/cmd/drive9/cli/token.go
@@ -14,6 +14,17 @@ import (
 )
 
 // Token manages workspace-zone scoped filesystem tokens.
+//
+// Per task #11 / Plan B consensus (#drive9:f2a8e33e):
+//   - `drive9 token issue`  — issue a scoped capability (server)
+//   - `drive9 token revoke` — revoke a scoped capability (server)
+// are the canonical token namespace operations.
+//
+// `drive9 token list` / `drive9 token forget` are kept as hidden
+// deprecation-warning aliases that point users to the canonical
+// `drive9 ctx list --type fs_scoped` / `drive9 ctx rm` paths. They
+// are NOT advertised in `drive9 token --help`. One release cycle
+// later they should be deleted entirely.
 func Token(args []string) error {
 	if len(args) == 0 {
 		return tokenUsageErr()
@@ -21,12 +32,21 @@ func Token(args []string) error {
 	switch args[0] {
 	case "issue":
 		return TokenIssue(args[1:])
-	case "list", "ls":
-		return TokenList(args[1:])
-	case "forget":
-		return TokenForget(args[1:])
 	case "revoke":
 		return TokenRevoke(args[1:])
+	case "list", "ls":
+		// Deprecated alias; warn on stderr then dispatch through
+		// the canonical ctx-list filter path. Keeps existing
+		// scripts working for one release.
+		fmt.Fprintln(os.Stderr, "WARNING: `drive9 token list` is deprecated; use `drive9 ctx list --type fs_scoped` instead.")
+		fmt.Fprintln(os.Stderr, "         This command will be removed in a future release.")
+		return Ctx([]string{"list", "--type", "fs_scoped"})
+	case "forget":
+		// Deprecated alias; warn on stderr then dispatch through
+		// `drive9 ctx rm <name>` which owns local namespace cleanup.
+		fmt.Fprintln(os.Stderr, "WARNING: `drive9 token forget` is deprecated; use `drive9 ctx rm <name>` instead.")
+		fmt.Fprintln(os.Stderr, "         This command will be removed in a future release.")
+		return Ctx(append([]string{"rm"}, args[1:]...))
 	case "-h", "-help", "--help", "help":
 		_, _ = fmt.Fprint(os.Stdout, tokenUsage())
 		return nil
@@ -41,10 +61,10 @@ func tokenUsage() string {
 commands:
   issue [name] --ttl <duration> --allow <prefix:ops>
                        issue an fs_scoped token; name is local only when set
-  list                 list locally saved fs_scoped token names
-  forget <name>        remove a local token name without revoking the token
-  revoke <name>        revoke a locally named fs_scoped token
+  revoke <name>        revoke a locally named fs_scoped token (deletes local name on success)
   revoke -             read a token from stdin and revoke it
+  revoke --api-key-file <path>
+                       read the target token from a file and revoke it
 
 issue flags:
   --subject <name>    optional server-side audit label; not a revoke key
@@ -55,9 +75,13 @@ issue flags:
   --print             print only the bearer token
   --token-only        alias for --print
 
-revoke flags:
-  --api-key-file <path>
-                       read the target token from a file instead of a local name
+To list local contexts (including fs_scoped tokens):
+  drive9 ctx list                     all local contexts
+  drive9 ctx list --type fs_scoped    only scoped tokens
+  drive9 ctx list --scoped            shorthand for --type fs_scoped
+
+To remove a local context name without revoking the server credential:
+  drive9 ctx rm <name>
 `
 }
 


### PR DESCRIPTION
## Summary

Per @qiffang msg `7472f701` + 8-agent consensus in #drive9:f2a8e33e, this PR collapses the duplicated `ctx list` vs `token list` listing surface into a single canonical inventory and folds `token forget` into the existing `ctx rm`, while keeping `token issue/revoke` (the buyer-recognized capability verbs per @gtm-1 GTM tax argument).

The split-by-noun mental model:
- **`ctx`** = local namespace (list / use / rm)
- **`token`** = server capability (issue / revoke)

## Final CLI shape

```bash
# Local namespace (single canonical inventory)
drive9 ctx list                          # all local contexts
drive9 ctx list --type fs_scoped         # filtered view
drive9 ctx list --scoped                 # shorthand alias
drive9 ctx use smoke                     # activate
drive9 ctx rm smoke                      # local cleanup (does NOT revoke server)

# Server capability lifecycle
drive9 token issue smoke --ttl 10m --allow /scratch/smoke:read,write,list
drive9 token revoke smoke                # revoke + delete local entry
drive9 token revoke -                    # stdin secret
drive9 token revoke --api-key-file ./key.txt

# Hidden deprecated aliases (one release cycle, then delete)
drive9 token list   → "WARNING: deprecated; use `drive9 ctx list --type fs_scoped`"
drive9 token forget → "WARNING: deprecated; use `drive9 ctx rm`"
```

## Safety guards on `ctx rm` (per @qiffang msg `7472f701`)

The user explicitly flagged `ctx rm` as a footgun — users running it thinking they're revoking the token would leave a live server-side capability. Three safety layers:

1. **Help text (scan-first lock)** per @gtm-1 msg `30bf6704`: first 5 lines lead with `WARNING:` + redirect to `drive9 token revoke <name>`. No emoji (`WARNING:` prefix for terminal/CI/grep compatibility per @strategy-2 msg `36c20d45`). English-only per @qiffang msg `405e0ae9`.

2. **Refuse-current-context guard** per @adversary-1 msg `7c8dc13c`: `ctx rm <current>` returns error `"refusing to remove current context; switch first with drive9 ctx use <other> then retry"`. Prevents dangling `CurrentContext` pointer.

3. **Owner-context [y/N] confirmation**: removing an owner context is unrecoverable on this machine (api_key erased from local config, server key stays valid → user may be locked out). Interactive confirmation required. fs_scoped contexts don't require confirmation but the success output explicitly states the server token remains valid + points to `drive9 token revoke -`.

## Deprecation behavior

- `drive9 token list`: writes deprecation warning to stderr, dispatches via `Ctx(["list", "--type", "fs_scoped"])`. Output is identical to the canonical command.
- `drive9 token forget`: writes deprecation warning to stderr, dispatches via `Ctx(["rm", name])`. Inherits all the safety guards above.
- Both commands removed from `drive9 token --help` output. Cross-references added: "To list local contexts ... drive9 ctx list" and "To remove a local context name ... drive9 ctx rm".
- Public Go funcs `TokenList`/`TokenForget` retained (existing tests call them directly).

## Tests (12 new, all green)

`cmd/drive9/cli/cli_consolidation_test.go`:

| Test | Asserts |
|---|---|
| `TestCtxListFiltersByTypeFlag` | `ctx list --type fs_scoped` returns only fs_scoped |
| `TestCtxListScopedShortcutMatchesTypeFilter` | `--scoped` produces identical output to `--type fs_scoped` |
| `TestCtxListTypeFilterEqualsForm` | `--type=fs_scoped` works same as `--type fs_scoped` |
| `TestCtxListRejectsUnknownType` | typo like `--type scoped` → clear error |
| `TestCtxListJSONFilterRespectsType` | `--json --type` correctly filters |
| `TestCtxRmRefusesCurrentContext` | safety guard #2 |
| `TestCtxRmFSScopedEmitsServerNotRevokedWarning` | post-rm warning + revoke pointer |
| `TestCtxRmOwnerRequiresConfirmation` | empty answer (Enter) = refusal |
| `TestCtxRmOwnerAcceptsYesConfirmation` | "y" answer proceeds |
| `TestCtxRmHelpLeadsWithSafetyWarning` | WARNING in first 5 lines + no CJK (English-only enforcement) |
| `TestTokenListEmitsDeprecationWarningAndDispatchesToCtxList` | stderr warning + correct dispatch |
| `TestTokenForgetEmitsDeprecationWarningAndDispatchesToCtxRm` | stderr warning + correct dispatch |
| `TestTokenUsageHidesListAndForget` | list/forget removed from help + cross-refs added |

## Verification

```
go test ./cmd/drive9/cli -count=1     → ok 0.926s (full cli suite, no regressions)
go vet ./...                          → clean
go build ./...                        → clean
```

## What's NOT in this PR

- **No docs/README changes**: PR #443 (task #10) didn't ship doc examples for `drive9 token list/forget`. Task thread acceptance noted "update docs (English only)" but the sweep turned up nothing to change.
- **Deletion of the deprecated aliases** is deferred one release cycle (separate follow-up task when that release happens).

## Diff stat

3 files, +603/-29:
- `cmd/drive9/cli/ctx.go` — add `--type`/`--scoped` filter; rewrite `ctxRmCmd` with safety guards; add `ctxRmUsage` / `confirmCtxRmOwner` / `emitCtxRmSuccess` / `filterCtxListEntries` / `isKnownPrincipalType` helpers
- `cmd/drive9/cli/token.go` — `token list`/`token forget` deprecation dispatch; `tokenUsage` removes those entries + adds cross-refs to ctx commands
- `cmd/drive9/cli/cli_consolidation_test.go` (new) — 12 acceptance tests

## Reviewers

- @adversary-1 primary (msg `c85a0411` already laid out review gates)
- @dev-1 final (msg `17ccf84e` laid out acceptance criteria; English-only blocker per `788ccf02`)
- Optional: @gtm-1 / @strategy-2 spot-check the `ctx rm` help-text first-screen layout matches their scan-first lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--type` and `--scoped` filtering options to `drive9 ctx list` for refined context browsing.

* **Improvements**
  * `drive9 ctx rm` now prevents accidental removal of the current active context and requires confirmation for owner-context deletion.
  * Enhanced help text with safety warnings for context removal.

* **Deprecations**
  * `drive9 token list` and `drive9 token forget` are deprecated; use `drive9 ctx list --type fs_scoped` and `drive9 ctx rm` respectively.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->