### PR TITLE
Reduce FUSE large-write allocation

### DIFF
--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -228,6 +228,17 @@ func uploadParallelism(partSize int64) int {
 	return min(byMemory, uploadMaxConcurrency)
 }
 
+func boundedUploadParallelism(partSize int64, partCount int) int {
+	parallelism := uploadParallelism(partSize)
+	if partCount > 0 && parallelism > partCount {
+		parallelism = partCount
+	}
+	if parallelism < 1 {
+		return 1
+	}
+	return parallelism
+}
+
 func checksumParallelism(partSize int64, partCount int) int {
 	if partSize <= 0 {
 		partSize = s3client.PartSize
@@ -450,7 +461,7 @@ func (c *Client) writeStreamV1WithSummary(ctx context.Context, path string, ra i
 		summary.PartSizeBytes = stdPartSize
 		summary.TotalParts = len(plan.Parts)
 		summary.UploadedParts = len(plan.Parts)
-		summary.Parallelism = uploadParallelism(stdPartSize)
+		summary.Parallelism = boundedUploadParallelism(stdPartSize, len(plan.Parts))
 	}
 
 	uploadStart := time.Now()
@@ -486,14 +497,14 @@ func (c *Client) writeStreamV2WithSummary(ctx context.Context, path string, ra i
 		summary.PartSizeBytes = plan.PartSize
 		summary.TotalParts = plan.TotalParts
 		summary.UploadedParts = plan.TotalParts
-		summary.Parallelism = uploadParallelism(plan.PartSize)
+		summary.Parallelism = boundedUploadParallelism(plan.PartSize, plan.TotalParts)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// Pipelined presign: feed presigned URLs into a buffered channel.
-	parallelism := uploadParallelism(plan.PartSize)
+	parallelism := boundedUploadParallelism(plan.PartSize, plan.TotalParts)
 	presignCh := make(chan presignedPart, parallelism)
 	presignErrCh := make(chan error, 1)
 	presignRecorder := &uploadDurationRecorder{}
@@ -639,7 +650,7 @@ func (c *Client) uploadPartsOnly(ctx context.Context, plan UploadPlan, ra io.Rea
 	if stdPartSize <= 0 {
 		stdPartSize = s3client.PartSize
 	}
-	maxConcurrency := uploadParallelism(stdPartSize)
+	maxConcurrency := boundedUploadParallelism(stdPartSize, len(plan.Parts))
 	bufferPool := newUploadBufferPool(stdPartSize, maxConcurrency)
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -921,7 +932,7 @@ func (c *Client) presignPipeline(ctx context.Context, plan *uploadPlanV2, batchS
 func (c *Client) uploadPartsV2(ctx context.Context, plan *uploadPlanV2, ra io.ReaderAt,
 	presignCh <-chan presignedPart, presignErrCh <-chan error, recorder *uploadDurationRecorder, progress ProgressFunc) ([]completePart, error) {
 
-	parallelism := uploadParallelism(plan.PartSize)
+	parallelism := boundedUploadParallelism(plan.PartSize, plan.TotalParts)
 	bufferPool := newUploadBufferPool(plan.PartSize, parallelism)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -1650,7 +1661,7 @@ func (c *Client) ResumeUploadWithSummaryAndTags(ctx context.Context, path string
 	summary.PartSizeBytes = plan.PartSize
 	summary.TotalParts = meta.PartsTotal
 	summary.UploadedParts = len(plan.Parts)
-	summary.Parallelism = uploadParallelism(plan.PartSize)
+	summary.Parallelism = boundedUploadParallelism(plan.PartSize, len(plan.Parts))
 
 	if len(plan.Parts) == 0 {
 		// All parts uploaded, just complete
@@ -1792,7 +1803,7 @@ func (c *Client) uploadMissingParts(ctx context.Context, plan UploadPlan, r io.R
 	if stdPartSize <= 0 {
 		stdPartSize = s3client.PartSize
 	}
-	maxConcurrency := uploadParallelism(stdPartSize)
+	maxConcurrency := boundedUploadParallelism(stdPartSize, len(plan.Parts))
 	bufferPool := newUploadBufferPool(stdPartSize, maxConcurrency)
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -133,6 +133,15 @@ func TestUploadBufferPoolGetHonorsContextCancel(t *testing.T) {
 	pool.put(buf)
 }
 
+func TestBoundedUploadParallelismCapsAtPartCount(t *testing.T) {
+	if got := boundedUploadParallelism(s3client.PartSize, 2); got != 2 {
+		t.Fatalf("parallelism = %d, want 2", got)
+	}
+	if got := boundedUploadParallelism(s3client.PartSize, 0); got != uploadParallelism(s3client.PartSize) {
+		t.Fatalf("parallelism for unknown part count = %d, want %d", got, uploadParallelism(s3client.PartSize))
+	}
+}
+
 // TestWriteStreamSmallFile verifies that WriteStream sends a small file via single direct PUT.
 func TestWriteStreamSmallFile(t *testing.T) {
 	var writtenData []byte

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -1,6 +1,7 @@
 package fuse
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -409,6 +410,32 @@ func TestWriteBuffer_GapFill(t *testing.T) {
 		if wb.Bytes()[i] != 0 {
 			t.Fatalf("byte %d = %d, want 0", i, wb.Bytes()[i])
 		}
+	}
+}
+
+func TestWriteBuffer_PartGrowthUsesHeadroom(t *testing.T) {
+	wb := NewWriteBuffer("/test", 0, 8)
+	if _, err := wb.Write(0, []byte{1, 2}); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	first := wb.parts[0]
+	if len(first) != 2 {
+		t.Fatalf("part len after first write = %d, want 2", len(first))
+	}
+	if cap(first) != 8 {
+		t.Fatalf("part cap after first write = %d, want 8", cap(first))
+	}
+
+	if _, err := wb.Write(6, []byte{7}); err != nil {
+		t.Fatalf("gap write: %v", err)
+	}
+	part := wb.parts[0]
+	if cap(part) != cap(first) {
+		t.Fatalf("part cap after gap write = %d, want %d", cap(part), cap(first))
+	}
+	want := []byte{1, 2, 0, 0, 0, 0, 7}
+	if got := wb.PartData(1); !bytes.Equal(got, want) {
+		t.Fatalf("part data = %v, want %v", got, want)
 	}
 }
 

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -10,6 +10,7 @@ const (
 	streamingWriteMaxSize     = 10 << 30 // 10GB — for sequential streaming writes
 	DefaultPartSize           = 8 << 20  // 8MB - default for v1 uploads; v2 may use adaptive sizes
 	maxPreloadSize            = 1 << 30  // 1GB - hard limit for preloading existing files into memory
+	minPartGrowthCapacity     = 64 << 10 // 64KB lower bound for sparse part growth
 )
 
 // LoadPartFunc is called to lazily load part data from the remote server.
@@ -255,10 +256,16 @@ func (wb *WriteBuffer) Write(offset int64, data []byte) (uint32, error) {
 			if neededLen > wb.partSize {
 				neededLen = wb.partSize
 			}
-			grown := make([]byte, neededLen)
-			copy(grown, part)
-			wb.curMemory += neededLen - int64(len(part))
-			part = grown
+			oldLen := int64(len(part))
+			if neededLen <= int64(cap(part)) {
+				part = part[:neededLen]
+				clear(part[oldLen:])
+			} else {
+				grown := make([]byte, neededLen, growPartCapacity(int64(cap(part)), neededLen, wb.partSize))
+				copy(grown, part)
+				part = grown
+			}
+			wb.curMemory += neededLen - oldLen
 			wb.parts[partIdx] = part
 		}
 
@@ -308,6 +315,26 @@ func (wb *WriteBuffer) Write(offset int64, data []byte) (uint32, error) {
 	}
 
 	return uint32(len(data)), nil
+}
+
+func growPartCapacity(currentCap, neededLen, partSize int64) int64 {
+	if partSize > 0 && neededLen > partSize {
+		neededLen = partSize
+	}
+	newCap := currentCap
+	if newCap < minPartGrowthCapacity {
+		newCap = minPartGrowthCapacity
+	}
+	for newCap < neededLen && (partSize <= 0 || newCap < partSize) {
+		newCap *= 2
+	}
+	if partSize > 0 && newCap > partSize {
+		newCap = partSize
+	}
+	if newCap < neededLen {
+		return neededLen
+	}
+	return newCap
 }
 
 // writeSmallFile is the fast-path Write for files that remain below


### PR DESCRIPTION
## Summary
- Grow FUSE WriteBuffer part capacity geometrically instead of reallocating at every exact length.
- Bound multipart upload parallelism and upload-buffer preallocation by actual part count.
- Add focused tests for part growth and bounded upload parallelism.

## Relationship to perf infra PR
Stacked on #446, which adds the perf harness updates, cold-read workload, perf sync endpoint, and the Phase 1 report. This PR only carries the large allocation code change so the review diff stays focused.

## EC2 comparison data
Profile root: perf/mount/profiles-ec2/20260520-065109-current-opt

large-write 32 MiB:
- heap alloc max: 130.8 MiB -> 34.9 MiB
- alloc-space pprof total: 288.47 MiB -> 107.47 MiB
- WriteBuffer.Write alloc-space: 144.81 MiB -> 58.74 MiB
- client.newUploadBufferPool alloc-space: 128.00 MiB -> 32.00 MiB
- wall time: 9.88s -> 10.07s, still remote-write bound

large-read 32 MiB, seeded through FUSE:
- heap alloc max: 130.8 MiB -> 34.9 MiB
- alloc-space pprof total: 329.17 MiB -> 143.04 MiB
- WriteBuffer.Write alloc-space: 144.81 MiB -> 60.78 MiB
- client.newUploadBufferPool alloc-space: 128.00 MiB -> 32.00 MiB

The data shows the allocation optimization is effective, while wall time remains dominated by remote write latency.

## Tests
- env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/fuse
- env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test -c -o /private/tmp/drive9-pkg-client.test ./pkg/client

Note: pkg/client full tests use a package TestMain that starts a MySQL testcontainer; this run used compile-only validation for that package.