### PR TITLE
Tune FUSE upload concurrency

### DIFF
--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -49,6 +49,7 @@ type mountFuseOptions struct {
 	SyncMode              fuseSyncMode
 	WritePolicy           fuseWritePolicy
 	Profile               string
+	UploadConcurrency     int
 	ReadConcurrency       int
 	SyncRead              bool
 	AllowOther            bool

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -42,6 +42,7 @@ func mountFuseImpl(opts *mountFuseOptions) error {
 		SyncMode:              mode,
 		WritePolicy:           writePolicy,
 		Profile:               opts.Profile,
+		UploadConcurrency:     opts.UploadConcurrency,
 		ReadConcurrency:       opts.ReadConcurrency,
 		SyncRead:              opts.SyncRead,
 		AllowOther:            opts.AllowOther,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -102,6 +102,7 @@ func fsMountCmd(args []string) error {
 	prefetchTimeout := fs.Duration("readdir-prefetch-timeout", time.Second, "timeout for one readdir prefetch batch")
 	durability := fs.String("durability", string(fuseDurabilityAuto), "write durability: auto, interactive, fsync, close-sync, or write-sync")
 	profile := fs.String("profile", "", "mount profile: interactive (empty for default)")
+	uploadConcurrency := fs.Int("upload-concurrency", 16, "maximum concurrent background uploads issued by FUSE")
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
 	readOnly := fs.Bool("read-only", false, "mount as read-only")
 	debug := fs.Bool("debug", false, "enable FUSE debug logging")
@@ -155,6 +156,9 @@ func fsMountCmd(args []string) error {
 	}
 	if *readConcurrency <= 0 {
 		return fmt.Errorf("drive9 mount: --read-concurrency must be > 0")
+	}
+	if *uploadConcurrency <= 0 {
+		return fmt.Errorf("drive9 mount: --upload-concurrency must be > 0")
 	}
 	if err := validateReadDirPrefetchFlags(*prefetchMaxFiles, *prefetchMaxFileBytes, *prefetchMaxBytes, *prefetchTimeout); err != nil {
 		return err
@@ -251,6 +255,7 @@ func fsMountCmd(args []string) error {
 		SyncMode:              syncModeVal,
 		WritePolicy:           writePolicyVal,
 		Profile:               *profile,
+		UploadConcurrency:     *uploadConcurrency,
 		ReadConcurrency:       *readConcurrency,
 		SyncRead:              *syncRead,
 		AllowOther:            *allowOther,

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -779,6 +779,35 @@ func TestMountCmdPassesReadConcurrencyOption(t *testing.T) {
 	}
 }
 
+func TestMountCmdPassesUploadConcurrencyOption(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--upload-concurrency", "16",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if got.UploadConcurrency != 16 {
+		t.Fatalf("UploadConcurrency = %d, want 16", got.UploadConcurrency)
+	}
+}
+
 func TestMountCmdRejectsInvalidReadConcurrency(t *testing.T) {
 	err := MountCmd([]string{
 		"--mode", "fuse",
@@ -789,6 +818,19 @@ func TestMountCmdRejectsInvalidReadConcurrency(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "--read-concurrency") {
 		t.Fatalf("MountCmd error = %v, want read-concurrency validation error", err)
+	}
+}
+
+func TestMountCmdRejectsInvalidUploadConcurrency(t *testing.T) {
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--upload-concurrency", "0",
+		t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "--upload-concurrency") {
+		t.Fatalf("MountCmd error = %v, want upload-concurrency validation error", err)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2689,6 +2689,26 @@ func TestMountOptionsReadConcurrencyDefaults(t *testing.T) {
 	}
 }
 
+func TestMountOptionsUploadConcurrencyDefaults(t *testing.T) {
+	defaults := &MountOptions{}
+	defaults.setDefaults()
+	if defaults.UploadConcurrency != defaultUploadConcurrency {
+		t.Fatalf("default UploadConcurrency = %d, want %d", defaults.UploadConcurrency, defaultUploadConcurrency)
+	}
+
+	explicit := &MountOptions{UploadConcurrency: 7}
+	explicit.setDefaults()
+	if explicit.UploadConcurrency != 7 {
+		t.Fatalf("explicit UploadConcurrency = %d, want 7", explicit.UploadConcurrency)
+	}
+
+	profileExplicit := &MountOptions{Profile: "interactive", UploadConcurrency: 9}
+	profileExplicit.setDefaults()
+	if profileExplicit.UploadConcurrency != 9 {
+		t.Fatalf("interactive profile explicit UploadConcurrency = %d, want 9", profileExplicit.UploadConcurrency)
+	}
+}
+
 func TestMountOptionsSyncReadDefaultsToAsyncReads(t *testing.T) {
 	defaults := &MountOptions{}
 	defaults.setDefaults()

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -62,6 +62,8 @@ type MountOptions struct {
 	PerfCounters          bool          // print low-overhead FUSE perf counter summary on shutdown
 }
 
+const defaultUploadConcurrency = 16
+
 func (o *MountOptions) setDefaults() {
 	// Apply profile defaults before generic defaults so profile-specific
 	// zero-value options can take effect while explicit non-zero values win.
@@ -91,7 +93,7 @@ func (o *MountOptions) setDefaults() {
 		o.FlushDebounce = defaultFlushDebounce
 	}
 	if o.UploadConcurrency <= 0 {
-		o.UploadConcurrency = 4
+		o.UploadConcurrency = defaultUploadConcurrency
 	}
 	if o.ReadConcurrency <= 0 {
 		o.ReadConcurrency = defaultRemoteReadConcurrency

--- a/pkg/fuse/mount_profile.go
+++ b/pkg/fuse/mount_profile.go
@@ -150,5 +150,7 @@ func ApplyInteractiveProfile(opts *MountOptions) {
 	}
 	// Disable debounce — replaced by shadow writes.
 	opts.FlushDebounce = 0
-	opts.UploadConcurrency = 4
+	if opts.UploadConcurrency <= 0 {
+		opts.UploadConcurrency = defaultUploadConcurrency
+	}
 }


### PR DESCRIPTION
## Summary

- expose `drive9 mount --upload-concurrency` and pass it through to `pkg/fuse.MountOptions`
- raise the FUSE background upload worker default from 4 to 16 based on EC2 small-file data
- preserve explicit `UploadConcurrency` when `Profile: interactive` is used

## EC2 perf data

Environment: `ec2-18-142-137-189.ap-southeast-1.compute.amazonaws.com` in `ap-southeast-1`, live drive9 server `https://api.drive9.ai`, FUSE mount, 50 files x 93 B, `--durability interactive`, `--perf-counters`.

Upload concurrency matrix, same binary before changing the default:

| upload workers | wall time | commit drain | remote write avg | failures/retries |
| --- | ---: | ---: | ---: | ---: |
| 1 | ~281.7s uptime / drain 4m38.694s | 4m38.694s | 5.573807s | 0 / 0 |
| 2 | 138.164s | 2m15.181s | 5.398893s | 0 / 0 |
| 4 | 73.575s | 1m10.539s | 5.446409s | 0 / 0 |
| 8 | 40.772s | 37.737s | 5.538946s | 0 / 0 |
| 16 | 24.497s | 21.524s | 5.837514s | 0 / 0 |

Verification after raising the default to 16 and omitting `--upload-concurrency`:

| case | wall time | commit drain | remote write avg | failures/retries |
| --- | ---: | ---: | ---: | ---: |
| small-files default | 24.998s | 21.997s | 5.820756s | 0 / 0 |

This moves the default small-file case from the old 4-worker baseline (`73.575s`) to the 16-worker result (`24.998s`), about 2.9x faster for this workload.

## Tests

- `env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9/cli`
- `env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/fuse`
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /private/tmp/drive9-track3-linux-amd64 ./cmd/drive9`

Related performance infrastructure PR: #446. Related large-write allocation PR: #448.