### PR TITLE
cli: support display tenant_id in drive9 ctx for tracing log

### DIFF
--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -66,6 +67,7 @@ type ctxShowEntry struct {
 	Name      string     `json:"name"`
 	Type      string     `json:"type"`
 	Server    string     `json:"server,omitempty"`
+	TenantID  string     `json:"tenant_id,omitempty"`
 	APIKey    string     `json:"api_key,omitempty"`
 	Token     string     `json:"token,omitempty"`
 	Agent     string     `json:"agent,omitempty"`
@@ -109,10 +111,11 @@ func buildCtxShowEntry(cfg *Config, reveal bool) *ctxShowEntry {
 	}
 
 	entry := &ctxShowEntry{
-		Name:   cfg.CurrentContext,
-		Type:   string(current.Type),
-		Server: cfg.ResolveServer(),
-		Source: configPath(),
+		Name:     cfg.CurrentContext,
+		Type:     string(current.Type),
+		Server:   cfg.ResolveServer(),
+		TenantID: tenantIDFromContext(current),
+		Source:   configPath(),
 	}
 
 	switch current.Type {
@@ -164,6 +167,12 @@ func writeCtxShowText(entry *ctxShowEntry) error {
 		{label: "name", value: entry.Name},
 		{label: "type", value: entry.Type},
 		{label: "server", value: entry.Server},
+	}
+	if entry.TenantID != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "tenant_id", value: entry.TenantID})
 	}
 	if entry.APIKey != "" {
 		fields = append(fields, struct {
@@ -231,6 +240,41 @@ func writeCtxShowText(entry *ctxShowEntry) error {
 		_, _ = fmt.Fprintf(w, "%s:\t%s\n", field.label, field.value)
 	}
 	return w.Flush()
+}
+
+const drive9APIKeyJWTWrapperPrefix = "dat9_"
+
+func tenantIDFromContext(ctx *Context) string {
+	if ctx == nil {
+		return ""
+	}
+	var claims *jwtClaims
+	var err error
+	switch ctx.Type {
+	case PrincipalOwner, PrincipalFSScoped:
+		claims, err = decodeDrive9APIKeyPayload(ctx.APIKey)
+	case PrincipalDelegated:
+		claims, err = decodeJWTPayload(ctx.Token)
+	default:
+		return ""
+	}
+	if err != nil || claims == nil {
+		return ""
+	}
+	return claims.TenantID
+}
+
+func decodeDrive9APIKeyPayload(apiKey string) (*jwtClaims, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if !strings.HasPrefix(apiKey, drive9APIKeyJWTWrapperPrefix) {
+		return nil, fmt.Errorf("invalid drive9 api key format")
+	}
+	wrapped := strings.TrimPrefix(apiKey, drive9APIKeyJWTWrapperPrefix)
+	rawJWT, err := base64.RawURLEncoding.DecodeString(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("decode api key wrapper: %w", err)
+	}
+	return decodeJWTPayload(string(rawJWT))
 }
 
 func formatSecretForDisplay(secret string, reveal bool) string {
@@ -742,6 +786,7 @@ type ctxListEntry struct {
 	Current   bool      `json:"current"`
 	Type      string    `json:"type"`
 	Server    string    `json:"server,omitempty"`
+	TenantID  string    `json:"tenant_id,omitempty"`
 	Scope     []string  `json:"scope,omitempty"`
 	Perm      string    `json:"perm,omitempty"`
 	ExpiresAt time.Time `json:"expires_at,omitempty"`
@@ -774,7 +819,7 @@ func writeCtxListTable(cfg *Config, longForm bool, typeFilter string) error {
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	// tabwriter.Writer buffers internally; errors surface at Flush().
-	_, _ = fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS")
+	_, _ = fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tTENANT_ID\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS")
 	for _, e := range entries {
 		cur := " "
 		if e.Current {
@@ -785,10 +830,11 @@ func writeCtxListTable(cfg *Config, longForm bool, typeFilter string) error {
 		if e.Type == string(PrincipalOwner) {
 			perm = "rw"
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			cur,
 			e.Name,
 			e.Type,
+			e.TenantID,
 			scope,
 			perm,
 			formatExpiresAt(e.ExpiresAt),
@@ -816,6 +862,7 @@ func buildCtxListEntries(cfg *Config) []ctxListEntry {
 			Current:   n == cfg.CurrentContext,
 			Type:      string(c.Type),
 			Server:    c.Server,
+			TenantID:  tenantIDFromContext(c),
 			Scope:     c.Scope,
 			Perm:      string(c.Perm),
 			ExpiresAt: c.ExpiresAt,

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -29,6 +29,11 @@ func makeJWT(t *testing.T, claims map[string]any) string {
 	return header + "." + payload + "." + sig
 }
 
+func makeDrive9APIKey(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	return "dat9_" + base64.RawURLEncoding.EncodeToString([]byte(makeJWT(t, claims)))
+}
+
 func TestCtxForkCreatesOwnerContextWithoutSwitching(t *testing.T) {
 	withIsolatedHome(t)
 	var sawName string
@@ -414,6 +419,48 @@ func TestCtxShowOwnerRevealJSON(t *testing.T) {
 	}
 }
 
+func TestCtxShowOwnerDisplaysTenantID(t *testing.T) {
+	_ = withIsolatedHome(t)
+	cfg := loadConfig()
+	_, err := ctxAdd(cfg, "prod", &Context{
+		Type: PrincipalOwner,
+		APIKey: makeDrive9APIKey(t, map[string]any{
+			"tenant_id":     "tenant-owner-1",
+			"token_version": 1,
+			"iat":           time.Now().Unix(),
+		}),
+		Server: "https://api.drive9.ai",
+	})
+	if err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"show"}) })
+	if err != nil {
+		t.Fatalf("ctx show: %v", err)
+	}
+	if !strings.Contains(out, "tenant_id:") || !strings.Contains(out, "tenant-owner-1") {
+		t.Fatalf("ctx show output = %q, want tenant_id", out)
+	}
+
+	out, err = captureStdoutE(t, func() error { return Ctx([]string{"show", "--json"}) })
+	if err != nil {
+		t.Fatalf("ctx show --json: %v", err)
+	}
+	var got struct {
+		TenantID string `json:"tenant_id"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v\nout=%q", err, out)
+	}
+	if got.TenantID != "tenant-owner-1" {
+		t.Fatalf("tenant_id = %q, want tenant-owner-1", got.TenantID)
+	}
+}
+
 func TestCtxShowDelegatedJSON(t *testing.T) {
 	_ = withIsolatedHome(t)
 	expiresAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
@@ -483,6 +530,42 @@ func TestCtxShowDelegatedJSON(t *testing.T) {
 	}
 	if got.LabelHint != "alice-prod-db" {
 		t.Fatalf("label_hint = %q, want alice-prod-db", got.LabelHint)
+	}
+}
+
+func TestCtxShowDelegatedDisplaysTenantID(t *testing.T) {
+	_ = withIsolatedHome(t)
+	cfg := loadConfig()
+	_, err := ctxAdd(cfg, "alice-prod-db", &Context{
+		Type:   PrincipalDelegated,
+		Server: "https://api.drive9.ai",
+		Token: makeJWT(t, map[string]any{
+			"tenant_id":      "tenant-delegated-1",
+			"principal_type": "delegated",
+			"grant_id":       "grt_1",
+			"agent":          "alice",
+			"scope":          []string{"/n/vault/prod-db/DB_URL"},
+			"perm":           "read",
+			"exp":            time.Now().Add(time.Hour).Unix(),
+		}),
+		Agent:   "alice",
+		Scope:   []string{"/n/vault/prod-db/DB_URL"},
+		Perm:    PermRead,
+		GrantID: "grt_1",
+	})
+	if err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"show"}) })
+	if err != nil {
+		t.Fatalf("ctx show: %v", err)
+	}
+	if !strings.Contains(out, "tenant_id:") || !strings.Contains(out, "tenant-delegated-1") {
+		t.Fatalf("ctx show output = %q, want tenant_id", out)
 	}
 }
 
@@ -711,6 +794,80 @@ func TestF16_CtxListUsesCurrentColumn(t *testing.T) {
 	}
 	if stars != 1 {
 		t.Errorf("expected exactly one row with * in CURRENT column; got %d", stars)
+	}
+}
+
+func TestCtxListDisplaysTenantID(t *testing.T) {
+	_ = withIsolatedHome(t)
+	cfg := loadConfig()
+	_, err := ctxAdd(cfg, "owner-prod", &Context{
+		Type: PrincipalOwner,
+		APIKey: makeDrive9APIKey(t, map[string]any{
+			"tenant_id":     "tenant-owner-1",
+			"token_version": 1,
+			"iat":           time.Now().Unix(),
+		}),
+		Server: "https://s",
+	})
+	if err != nil {
+		t.Fatalf("ctxAdd owner: %v", err)
+	}
+	_, err = ctxAdd(cfg, "alice", &Context{
+		Type:   PrincipalDelegated,
+		Server: "https://s",
+		Token: makeJWT(t, map[string]any{
+			"tenant_id":      "tenant-delegated-1",
+			"principal_type": "delegated",
+			"grant_id":       "grt_1",
+			"agent":          "alice",
+			"scope":          []string{"/n/vault/prod-db/DB_URL"},
+			"perm":           "read",
+			"exp":            time.Now().Add(time.Hour).Unix(),
+		}),
+		Agent:   "alice",
+		Scope:   []string{"/n/vault/prod-db/DB_URL"},
+		Perm:    PermRead,
+		GrantID: "grt_1",
+	})
+	if err != nil {
+		t.Fatalf("ctxAdd delegated: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"ls"}) })
+	if err != nil {
+		t.Fatalf("ctx ls: %v", err)
+	}
+	for _, want := range []string{"TENANT_ID", "tenant-owner-1", "tenant-delegated-1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("ctx ls output = %q, want substring %q", out, want)
+		}
+	}
+
+	out, err = captureStdoutE(t, func() error { return Ctx([]string{"ls", "--json"}) })
+	if err != nil {
+		t.Fatalf("ctx ls --json: %v", err)
+	}
+	var got struct {
+		Contexts []struct {
+			Name     string `json:"name"`
+			TenantID string `json:"tenant_id"`
+		} `json:"contexts"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v\nout=%q", err, out)
+	}
+	tenantIDs := map[string]string{}
+	for _, entry := range got.Contexts {
+		tenantIDs[entry.Name] = entry.TenantID
+	}
+	if tenantIDs["owner-prod"] != "tenant-owner-1" {
+		t.Fatalf("owner tenant_id = %q, want tenant-owner-1", tenantIDs["owner-prod"])
+	}
+	if tenantIDs["alice"] != "tenant-delegated-1" {
+		t.Fatalf("delegated tenant_id = %q, want tenant-delegated-1", tenantIDs["alice"])
 	}
 }
 

--- a/cmd/drive9/cli/jwt.go
+++ b/cmd/drive9/cli/jwt.go
@@ -16,6 +16,7 @@ import (
 // MUST re-validate signature, TTL, and revocation on every request.
 type jwtClaims struct {
 	Iss           string   `json:"iss"`
+	TenantID      string   `json:"tenant_id"`
 	GrantID       string   `json:"grant_id"`
 	PrincipalType string   `json:"principal_type"`
 	Agent         string   `json:"agent"`

--- a/scripts/decode_drive9_config.py
+++ b/scripts/decode_drive9_config.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """Decode tenant_id from ~/.drive9/config without revealing credentials.
 
+This script is intended for drive9 CLI versions where ``drive9 ctx`` does not
+yet display ``tenant_id``. When your ``drive9 ctx show`` or ``drive9 ctx ls``
+output already includes ``tenant_id``, prefer those commands instead of this
+script.
+
 Owner and fs_scoped contexts store a drive9 API key shaped as:
 
     dat9_<base64url(jwt)>

--- a/scripts/decode_drive9_config.py
+++ b/scripts/decode_drive9_config.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Decode tenant_id from ~/.drive9/config without revealing credentials.
+
+Owner and fs_scoped contexts store a drive9 API key shaped as:
+
+    dat9_<base64url(jwt)>
+
+The JWT payload contains tenant_id. This script unwraps that local encoding and
+decodes the JWT payload. Delegated contexts store a JWT directly; the script
+also decodes that payload when present. It does not verify signatures, TTL, or
+revocation, so use the output only for local inspection/debugging.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_CONFIG_PATH = Path.home() / ".drive9" / "config"
+DRIVE9_API_KEY_PREFIX = "dat9_"
+
+
+def b64url_decode(raw: str) -> bytes:
+    raw = raw.strip()
+    padding = "=" * (-len(raw) % 4)
+    return base64.urlsafe_b64decode((raw + padding).encode("ascii"))
+
+
+def decode_jwt_payload(raw_jwt: str) -> dict[str, Any]:
+    parts = raw_jwt.strip().split(".")
+    if len(parts) != 3:
+        raise ValueError(f"expected 3 JWT segments, got {len(parts)}")
+    payload = b64url_decode(parts[1])
+    return json.loads(payload.decode("utf-8"))
+
+
+def unwrap_drive9_api_key(api_key: str) -> str:
+    api_key = api_key.strip()
+    if not api_key.startswith(DRIVE9_API_KEY_PREFIX):
+        raise ValueError(f"expected {DRIVE9_API_KEY_PREFIX!r} API key prefix")
+    wrapped = api_key.removeprefix(DRIVE9_API_KEY_PREFIX)
+    return b64url_decode(wrapped).decode("utf-8")
+
+
+def decode_context(name: str, ctx: dict[str, Any], current: bool, server: str) -> dict[str, Any]:
+    ctx_type = ctx.get("type") or "owner"
+    result: dict[str, Any] = {
+        "name": name,
+        "current": current,
+        "type": ctx_type,
+        "server": ctx.get("server") or server,
+        "tenant_id": None,
+        "token_version": None,
+        "iat": None,
+        "exp": None,
+        "grant_id": ctx.get("grant_id") or None,
+        "agent": ctx.get("agent") or None,
+        "decode_error": None,
+    }
+
+    try:
+        if ctx_type in ("owner", "fs_scoped"):
+            api_key = ctx.get("api_key") or ""
+            raw_jwt = unwrap_drive9_api_key(api_key)
+            claims = decode_jwt_payload(raw_jwt)
+        elif ctx_type == "delegated":
+            token = ctx.get("token") or ""
+            claims = decode_jwt_payload(token)
+        else:
+            raise ValueError(f"unsupported context type {ctx_type!r}")
+    except Exception as exc:  # Keep script useful across partially migrated configs.
+        result["decode_error"] = str(exc)
+        return result
+
+    result["tenant_id"] = claims.get("tenant_id")
+    result["token_version"] = claims.get("token_version")
+    result["iat"] = claims.get("iat")
+    result["exp"] = claims.get("exp")
+    result["grant_id"] = result["grant_id"] or claims.get("grant_id")
+    result["agent"] = result["agent"] or claims.get("agent")
+    return result
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def print_text(rows: list[dict[str, Any]]) -> None:
+    for row in rows:
+        marker = "*" if row["current"] else " "
+        print(f"{marker} context: {row['name']}")
+        print(f"  type:      {row['type']}")
+        print(f"  server:    {row['server']}")
+        print(f"  tenant_id: {row['tenant_id'] or '-'}")
+        if row["token_version"] is not None:
+            print(f"  version:   {row['token_version']}")
+        if row["iat"] is not None:
+            print(f"  iat:       {row['iat']}")
+        if row["exp"] is not None:
+            print(f"  exp:       {row['exp']}")
+        if row["grant_id"]:
+            print(f"  grant_id:  {row['grant_id']}")
+        if row["agent"]:
+            print(f"  agent:     {row['agent']}")
+        if row["decode_error"]:
+            print(f"  error:     {row['decode_error']}")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Decode tenant_id from drive9 CLI config contexts."
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help=f"config path (default: {DEFAULT_CONFIG_PATH})",
+    )
+    parser.add_argument(
+        "--context",
+        help="context name to decode (default: current context)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="decode all contexts instead of only the current context",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print machine-readable JSON",
+    )
+    args = parser.parse_args(argv)
+
+    cfg = load_config(args.config)
+    contexts = cfg.get("contexts") or {}
+    current = cfg.get("current_context") or ""
+    server = cfg.get("server") or "https://api.drive9.ai"
+
+    if args.all:
+        names = sorted(contexts)
+    else:
+        name = args.context or current
+        if not name:
+            raise SystemExit("no current context; pass --context <name> or --all")
+        if name not in contexts:
+            raise SystemExit(f"context {name!r} not found in {args.config}")
+        names = [name]
+
+    rows = [
+        decode_context(name, contexts[name] or {}, name == current, server)
+        for name in names
+    ]
+
+    if args.json:
+        json.dump(rows[0] if len(rows) == 1 else rows, sys.stdout, indent=2)
+        print()
+    else:
+        print_text(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- Show `tenant_id` in `drive9 ctx show` / `drive9 ctx ls` output so operators can correlate local context with server-side tracing logs.
- Decode tenant ID from JWT claims when present, and add CLI tests plus a helper script for inspecting encoded drive9 config.
- `scripts/decode_drive9_config.py` is for drive9 CLI versions where `drive9 ctx` does not yet display `tenant_id`. If your client already supports it, prefer `drive9 ctx show` or `drive9 ctx ls` to view `tenant_id`.

## Test plan

- [x] `go test ./cmd/drive9/cli/... -run TestCtx`
- [x] `drive9 ctx show` and `drive9 ctx ls -l` display `tenant_id` for owner/delegated contexts that carry it
- [x] Verify tracing/log correlation against a live deployment when applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant ID now displays in context show and list operations
  * Added standalone utility script for decoding Drive9 configuration and extracting tenant ID information

* **Tests**
  * Added comprehensive test coverage for tenant ID display across context commands

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->