### PR TITLE
server: rotate semantic tenant scans

### DIFF
--- a/internal/testmysql/testmysql.go
+++ b/internal/testmysql/testmysql.go
@@ -78,6 +78,21 @@ func ResetDB(t *testing.T, db *sql.DB) {
 	}
 }
 
+// ResetMetaDB clears control-plane tenant metadata tables for meta store tests.
+func ResetMetaDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+	queries := []string{
+		"DELETE FROM tenant_api_key_fs_scopes",
+		"DELETE FROM tenant_api_keys",
+		"DELETE FROM tenants",
+	}
+	for _, q := range queries {
+		if _, err := db.Exec(q); err != nil {
+			t.Fatalf("reset meta test db: %v", err)
+		}
+	}
+}
+
 // ResetDBWithoutFiles is like ResetDB but for tests that intentionally drop
 // the legacy files table to exercise the no-legacy-table code path.
 func ResetDBWithoutFiles(t *testing.T, db *sql.DB) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1251,13 +1251,51 @@ func (s *Store) ListTenantsByStatus(ctx context.Context, status TenantStatus, li
 		db_host, db_port, db_user, db_password, db_name,
 		db_tls, provider, cluster_id, branch_id, claim_url, claim_expires_at, schema_version,
 		s3_encryption_mode, s3_kms_key_id, s3_bucket_key_enabled, created_at, updated_at
-		FROM tenants WHERE status = ? ORDER BY created_at ASC LIMIT ?`, status, limit)
+		FROM tenants WHERE status = ? ORDER BY created_at ASC, id ASC LIMIT ?`, status, limit)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 
-	out = make([]Tenant, 0)
+	return scanTenantRows(rows)
+}
+
+// ListTenantsByStatusAfter returns one keyset page of tenants after
+// (afterCreatedAt, afterID), ordered by (created_at, id). Pass a zero
+// afterCreatedAt and empty afterID to scan from the beginning.
+func (s *Store) ListTenantsByStatusAfter(ctx context.Context, status TenantStatus, afterCreatedAt time.Time, afterID string, limit int) (out []Tenant, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_tenants_by_status_after", start, &err)
+	if limit <= 0 {
+		limit = 100
+	}
+
+	var rows *sql.Rows
+	if afterCreatedAt.IsZero() && afterID == "" {
+		rows, err = s.db.QueryContext(ctx, `SELECT id, status, kind, parent_tenant_id, storage_namespace_id,
+			db_host, db_port, db_user, db_password, db_name,
+			db_tls, provider, cluster_id, branch_id, claim_url, claim_expires_at, schema_version,
+			s3_encryption_mode, s3_kms_key_id, s3_bucket_key_enabled, created_at, updated_at
+			FROM tenants WHERE status = ? ORDER BY created_at ASC, id ASC LIMIT ?`, status, limit)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `SELECT id, status, kind, parent_tenant_id, storage_namespace_id,
+			db_host, db_port, db_user, db_password, db_name,
+			db_tls, provider, cluster_id, branch_id, claim_url, claim_expires_at, schema_version,
+			s3_encryption_mode, s3_kms_key_id, s3_bucket_key_enabled, created_at, updated_at
+			FROM tenants
+			WHERE status = ? AND (created_at > ? OR (created_at = ? AND id > ?))
+			ORDER BY created_at ASC, id ASC LIMIT ?`, status, afterCreatedAt.UTC(), afterCreatedAt.UTC(), afterID, limit)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	return scanTenantRows(rows)
+}
+
+func scanTenantRows(rows *sql.Rows) ([]Tenant, error) {
+	out := make([]Tenant, 0)
 	for rows.Next() {
 		var t Tenant
 		var dbTLS int

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -363,6 +363,7 @@ func metaInitSchemaStatements() []string {
 			updated_at       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			deleted_at       DATETIME(3) NULL,
 			INDEX idx_tenant_status (status),
+			INDEX idx_tenant_status_created_id (status, created_at, id),
 			INDEX idx_tenant_provider (provider),
 			INDEX idx_tenant_namespace (storage_namespace_id, kind, status),
 			INDEX idx_tenant_parent (parent_tenant_id)

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -653,6 +653,51 @@ func TestMetaSchemaSpecIncludesForkStorageNamespaceColumns(t *testing.T) {
 	_ = mustMetaTableSpec(t, mustMetaSpec(t), "object_gc_candidates")
 }
 
+func TestMetaSchemaSpecIncludesTenantStatusCreatedIDIndex(t *testing.T) {
+	table := mustMetaTableSpec(t, mustMetaSpec(t), "tenants")
+	idx, ok := table.indexes["idx_tenant_status_created_id"]
+	if !ok {
+		t.Fatal("tenants schema missing idx_tenant_status_created_id")
+	}
+	wantCreateSQL := "CREATE INDEX idx_tenant_status_created_id ON tenants(status, created_at, id)"
+	if idx.createSQL != wantCreateSQL {
+		t.Fatalf("idx_tenant_status_created_id createSQL = %q, want %q", idx.createSQL, wantCreateSQL)
+	}
+
+	observed := metaTableMeta{
+		tableName: "tenants",
+		columns: map[string]metaColumnMeta{
+			"id":         {columnType: "varchar(64)"},
+			"status":     {columnType: "varchar(20)"},
+			"created_at": {columnType: "datetime(3)"},
+		},
+	}
+	observedIndexes := map[string]struct{}{
+		"primary":           {},
+		"idx_tenant_status": {},
+	}
+	diffs := diffMetaTableMetaWithObservedIndexes(table, observed, "", observedIndexes)
+	if !hasMetaDiff(diffs, metaSchemaDiffMissingIndex, "idx_tenant_status_created_id") {
+		t.Fatalf("expected missing idx_tenant_status_created_id diff, got %#v", diffs)
+	}
+
+	var indexDiff metaSchemaDiff
+	for _, diff := range diffs {
+		if diff.indexName == "idx_tenant_status_created_id" {
+			indexDiff = diff
+			break
+		}
+	}
+	if indexDiff.repairSQL != wantCreateSQL {
+		t.Fatalf("idx_tenant_status_created_id repairSQL = %q, want %q", indexDiff.repairSQL, wantCreateSQL)
+	}
+
+	plans := plannedMetaSchemaRepairs([]metaSchemaDiff{indexDiff})
+	if len(plans) != 1 || plans[0] != wantCreateSQL {
+		t.Fatalf("repair plans = %#v, want [%q]", plans, wantCreateSQL)
+	}
+}
+
 func TestMetaSchemaSpecIncludesAPIKeyScopeTables(t *testing.T) {
 	spec := mustMetaSpec(t)
 	apiKeys := mustMetaTableSpec(t, spec, "tenant_api_keys")

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -484,6 +484,70 @@ func TestListTenantsByStatus(t *testing.T) {
 	}
 }
 
+func TestListTenantsByStatusAfterKeyset(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	for _, tc := range []struct {
+		id        string
+		status    TenantStatus
+		createdAt time.Time
+	}{
+		{id: "active-a", status: TenantActive, createdAt: now},
+		{id: "active-b", status: TenantActive, createdAt: now},
+		{id: "active-c", status: TenantActive, createdAt: now.Add(time.Second)},
+		{id: "provisioning-a", status: TenantProvisioning, createdAt: now},
+	} {
+		if err := s.InsertTenant(context.Background(), &Tenant{
+			ID:               tc.id,
+			Status:           tc.status,
+			DBHost:           "127.0.0.1",
+			DBPort:           4000,
+			DBUser:           "root",
+			DBPasswordCipher: []byte("cipher"),
+			DBName:           "tenant_db",
+			DBTLS:            true,
+			Provider:         "tidb_zero",
+			SchemaVersion:    1,
+			CreatedAt:        tc.createdAt,
+			UpdatedAt:        tc.createdAt,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	first, err := s.ListTenantsByStatusAfter(context.Background(), TenantActive, time.Time{}, "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 2 || first[0].ID != "active-a" || first[1].ID != "active-b" {
+		t.Fatalf("first page ids = %v, want active-a, active-b", tenantIDs(first))
+	}
+
+	second, err := s.ListTenantsByStatusAfter(context.Background(), TenantActive, first[1].CreatedAt, first[1].ID, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 1 || second[0].ID != "active-c" {
+		t.Fatalf("second page ids = %v, want active-c", tenantIDs(second))
+	}
+
+	empty, err := s.ListTenantsByStatusAfter(context.Background(), TenantActive, second[0].CreatedAt, second[0].ID, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("tail page ids = %v, want empty", tenantIDs(empty))
+	}
+}
+
+func tenantIDs(tenants []Tenant) []string {
+	ids := make([]string, 0, len(tenants))
+	for _, t := range tenants {
+		ids = append(ids, t.ID)
+	}
+	return ids
+}
+
 func TestMetaSchemaSpecFromStatementsParsesNewTable(t *testing.T) {
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS tenant_custom_events (

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -661,7 +661,7 @@ func TestMetaSchemaSpecIncludesTenantStatusCreatedIDIndex(t *testing.T) {
 	}
 	wantCreateSQL := "CREATE INDEX idx_tenant_status_created_id ON tenants(status, created_at, id)"
 	if idx.createSQL != wantCreateSQL {
-		t.Fatalf("idx_tenant_status_created_id createSQL = %q, want %q", idx.createSQL, wantCreateSQL)
+		t.Errorf("idx_tenant_status_created_id createSQL = %q, want %q", idx.createSQL, wantCreateSQL)
 	}
 
 	observed := metaTableMeta{
@@ -678,7 +678,7 @@ func TestMetaSchemaSpecIncludesTenantStatusCreatedIDIndex(t *testing.T) {
 	}
 	diffs := diffMetaTableMetaWithObservedIndexes(table, observed, "", observedIndexes)
 	if !hasMetaDiff(diffs, metaSchemaDiffMissingIndex, "idx_tenant_status_created_id") {
-		t.Fatalf("expected missing idx_tenant_status_created_id diff, got %#v", diffs)
+		t.Errorf("expected missing idx_tenant_status_created_id diff, got %#v", diffs)
 	}
 
 	var indexDiff metaSchemaDiff
@@ -689,12 +689,12 @@ func TestMetaSchemaSpecIncludesTenantStatusCreatedIDIndex(t *testing.T) {
 		}
 	}
 	if indexDiff.repairSQL != wantCreateSQL {
-		t.Fatalf("idx_tenant_status_created_id repairSQL = %q, want %q", indexDiff.repairSQL, wantCreateSQL)
+		t.Errorf("idx_tenant_status_created_id repairSQL = %q, want %q", indexDiff.repairSQL, wantCreateSQL)
 	}
 
 	plans := plannedMetaSchemaRepairs([]metaSchemaDiff{indexDiff})
 	if len(plans) != 1 || plans[0] != wantCreateSQL {
-		t.Fatalf("repair plans = %#v, want [%q]", plans, wantCreateSQL)
+		t.Errorf("repair plans = %#v, want [%q]", plans, wantCreateSQL)
 	}
 }
 

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -142,6 +142,8 @@ type semanticWorkerManager struct {
 	tenantScanCursorSet       bool
 	tenantScanCursorCreatedAt time.Time
 	tenantScanCursorID        string
+	tenantScanRoundRawTenants int
+	tenantScanRoundIncluded   int
 	lastTenantScan            semanticTenantScanSnapshot
 	tenantScanMu              sync.Mutex
 
@@ -638,7 +640,7 @@ func (m *semanticWorkerManager) listTenantRefs(ctx context.Context) ([]semanticT
 			}
 			refs = append(refs, semanticTenantRef{id: t.ID, tenant: &t})
 		}
-		m.recordTenantScan(tenants, len(refs), wrapped)
+		m.recordTenantScan(ctx, tenants, len(refs), wrapped)
 		return refs, nil
 	}
 	if m.shouldIncludeFallback() {
@@ -647,15 +649,30 @@ func (m *semanticWorkerManager) listTenantRefs(ctx context.Context) ([]semanticT
 	return nil, nil
 }
 
+// nextTenantScanPage returns the next raw page of active tenants for round-robin
+// scheduling. It reads the current scan cursor, fetches up to TenantScanLimit rows
+// after that cursor in (created_at, id) order, and wraps to the first page when the
+// cursor is already at the end of the active-tenant sequence.
+//
+// Outward behavior for callers (typically listTenantRefs under tenantScanMu):
+//   - Returns DB rows only; provider/task-type filtering happens after this call.
+//   - Does not advance the scan cursor; the caller must call recordTenantScan with
+//     the returned page and wrapped flag.
+//   - wrapped is true only when the first query after the cursor returned no rows
+//     and a second query restarted from the beginning of the active-tenant order.
+//   - On the first scan (no cursor yet), an empty page means there are no active
+//     tenants; wrapped stays false.
 func (m *semanticWorkerManager) nextTenantScanPage(ctx context.Context) ([]meta.Tenant, bool, error) {
 	createdAt, id, ok := m.tenantScanCursor()
 	tenants, err := m.meta.ListTenantsByStatusAfter(ctx, meta.TenantActive, createdAt, id, m.opts.TenantScanLimit)
 	if err != nil {
 		return nil, false, err
 	}
+	// Non-empty page, or the initial scan before any cursor exists: return as-is.
 	if len(tenants) > 0 || !ok {
 		return tenants, false, nil
 	}
+	// Cursor was set but nothing remains after it; wrap to the head of the order.
 	tenants, err = m.meta.ListTenantsByStatusAfter(ctx, meta.TenantActive, time.Time{}, "", m.opts.TenantScanLimit)
 	if err != nil {
 		return nil, true, err
@@ -672,9 +689,19 @@ func (m *semanticWorkerManager) tenantScanCursor() (time.Time, string, bool) {
 	return m.tenantScanCursorCreatedAt, m.tenantScanCursorID, true
 }
 
-func (m *semanticWorkerManager) recordTenantScan(tenants []meta.Tenant, included int, wrapped bool) {
+func (m *semanticWorkerManager) recordTenantScan(ctx context.Context, tenants []meta.Tenant, included int, wrapped bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if wrapped {
+		logger.Info(ctx, "semantic_worker_tenant_scan_wrapped",
+			zap.Int("tenant_scan_round_raw_tenants", m.tenantScanRoundRawTenants),
+			zap.Int("tenant_scan_round_included_tenants", m.tenantScanRoundIncluded),
+		)
+		m.tenantScanRoundRawTenants = 0
+		m.tenantScanRoundIncluded = 0
+	}
+	m.tenantScanRoundRawTenants += len(tenants)
+	m.tenantScanRoundIncluded += included
 	if len(tenants) > 0 {
 		last := tenants[len(tenants)-1]
 		m.tenantScanCursorSet = true

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -139,6 +139,12 @@ type semanticWorkerManager struct {
 	processing int
 	rr         int
 
+	tenantScanCursorSet       bool
+	tenantScanCursorCreatedAt time.Time
+	tenantScanCursorID        string
+	lastTenantScan            semanticTenantScanSnapshot
+	tenantScanMu              sync.Mutex
+
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 }
@@ -162,6 +168,17 @@ type semanticObservationSnapshot struct {
 	deadLettered    int
 	queueLagSeconds float64
 	inflight        int
+	tenantScan      semanticTenantScanSnapshot
+}
+
+type semanticTenantScanSnapshot struct {
+	limit           int
+	cursorSet       bool
+	cursorCreatedAt time.Time
+	cursorID        string
+	rawTenants      int
+	includedTenants int
+	wrapped         bool
 }
 
 type semanticTaskAction string
@@ -264,11 +281,14 @@ func (m *semanticWorkerManager) Start(ctx context.Context) {
 	}
 	m.wg.Add(1)
 	go m.recoverLoop(workerCtx)
-	logger.Info(workerCtx, "semantic_worker_manager_started",
+	fields := []zap.Field{
 		zap.Int("workers", m.opts.Workers),
 		zap.Duration("poll_interval", m.opts.PollInterval),
 		zap.Duration("lease_duration", m.opts.LeaseDuration),
-		zap.Duration("recover_interval", m.opts.RecoverInterval))
+		zap.Duration("recover_interval", m.opts.RecoverInterval),
+	}
+	fields = append(fields, m.tenantScanLogFields()...)
+	logger.Info(workerCtx, "semantic_worker_manager_started", fields...)
 }
 
 func (m *semanticWorkerManager) Stop() {
@@ -599,7 +619,15 @@ func (m *semanticWorkerManager) releaseTenantSlot(tenantID string) {
 
 func (m *semanticWorkerManager) listTenantRefs(ctx context.Context) ([]semanticTenantRef, error) {
 	if m.meta != nil && m.pool != nil {
-		tenants, err := m.meta.ListTenantsByStatus(ctx, meta.TenantActive, m.opts.TenantScanLimit)
+		// Multi-tenant workers scan active tenants with a keyset cursor rather than
+		// repeatedly reading the oldest TenantScanLimit rows. The cursor advances to
+		// the last raw active tenant in each page, even when provider filtering drops
+		// every tenant from that page, so unsupported providers cannot pin the scan.
+		// When the page after the cursor is empty, the next scan wraps to the start
+		// of the active-tenant order and continues round-robin pagination.
+		m.tenantScanMu.Lock()
+		defer m.tenantScanMu.Unlock()
+		tenants, wrapped, err := m.nextTenantScanPage(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -611,12 +639,62 @@ func (m *semanticWorkerManager) listTenantRefs(ctx context.Context) ([]semanticT
 			}
 			refs = append(refs, semanticTenantRef{id: t.ID, tenant: &t})
 		}
+		m.recordTenantScan(tenants, len(refs), wrapped)
 		return refs, nil
 	}
 	if m.shouldIncludeFallback() {
 		return []semanticTenantRef{{id: semanticLocalTenantID}}, nil
 	}
 	return nil, nil
+}
+
+func (m *semanticWorkerManager) nextTenantScanPage(ctx context.Context) ([]meta.Tenant, bool, error) {
+	createdAt, id, ok := m.tenantScanCursor()
+	tenants, err := m.meta.ListTenantsByStatusAfter(ctx, meta.TenantActive, createdAt, id, m.opts.TenantScanLimit)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(tenants) > 0 || !ok {
+		return tenants, false, nil
+	}
+	tenants, err = m.meta.ListTenantsByStatusAfter(ctx, meta.TenantActive, time.Time{}, "", m.opts.TenantScanLimit)
+	if err != nil {
+		return nil, true, err
+	}
+	return tenants, true, nil
+}
+
+func (m *semanticWorkerManager) tenantScanCursor() (time.Time, string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.tenantScanCursorSet {
+		return time.Time{}, "", false
+	}
+	return m.tenantScanCursorCreatedAt, m.tenantScanCursorID, true
+}
+
+func (m *semanticWorkerManager) recordTenantScan(tenants []meta.Tenant, included int, wrapped bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(tenants) > 0 {
+		last := tenants[len(tenants)-1]
+		m.tenantScanCursorSet = true
+		m.tenantScanCursorCreatedAt = last.CreatedAt.UTC()
+		m.tenantScanCursorID = last.ID
+	} else if wrapped || !m.tenantScanCursorSet {
+		m.tenantScanCursorSet = false
+		m.tenantScanCursorCreatedAt = time.Time{}
+		m.tenantScanCursorID = ""
+	}
+	m.lastTenantScan = semanticTenantScanSnapshot{
+		limit:           m.opts.TenantScanLimit,
+		cursorSet:       m.tenantScanCursorSet,
+		cursorCreatedAt: m.tenantScanCursorCreatedAt,
+		cursorID:        m.tenantScanCursorID,
+		rawTenants:      len(tenants),
+		includedTenants: included,
+		wrapped:         wrapped,
+	}
 }
 
 // TODO(JaySon-Huang): DB9/Postgres tenants are not yet supported in the semantic
@@ -1043,6 +1121,38 @@ func (m *semanticWorkerManager) snapshotProcessing() int {
 	return m.processing
 }
 
+func (m *semanticWorkerManager) tenantScanSnapshot() semanticTenantScanSnapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := m.lastTenantScan
+	if s.limit == 0 {
+		s.limit = m.opts.TenantScanLimit
+		s.cursorSet = m.tenantScanCursorSet
+		s.cursorCreatedAt = m.tenantScanCursorCreatedAt
+		s.cursorID = m.tenantScanCursorID
+	}
+	return s
+}
+
+func (m *semanticWorkerManager) tenantScanLogFields() []zap.Field {
+	return semanticTenantScanLogFields(m.tenantScanSnapshot())
+}
+
+func semanticTenantScanLogFields(s semanticTenantScanSnapshot) []zap.Field {
+	fields := []zap.Field{
+		zap.Int("tenant_scan_limit", s.limit),
+		zap.Bool("tenant_scan_cursor_set", s.cursorSet),
+		zap.String("tenant_scan_cursor_id", s.cursorID),
+		zap.Int("tenant_scan_raw_tenants", s.rawTenants),
+		zap.Int("tenant_scan_included_tenants", s.includedTenants),
+		zap.Bool("tenant_scan_wrapped", s.wrapped),
+	}
+	if s.cursorSet {
+		fields = append(fields, zap.Time("tenant_scan_cursor_created_at", s.cursorCreatedAt.UTC()))
+	}
+	return fields
+}
+
 func (m *semanticWorkerManager) observeOnce(ctx context.Context, now time.Time) {
 	snapshot := m.collectObservation(ctx, now)
 	metrics.RecordGauge("semantic_worker", "inflight", float64(snapshot.inflight))
@@ -1050,6 +1160,15 @@ func (m *semanticWorkerManager) observeOnce(ctx context.Context, now time.Time) 
 	metrics.RecordGauge("semantic_worker", "processing", float64(snapshot.processing))
 	metrics.RecordGauge("semantic_worker", "dead_lettered", float64(snapshot.deadLettered))
 	metrics.RecordGauge("semantic_worker", "queue_lag_seconds", snapshot.queueLagSeconds)
+	fields := []zap.Field{
+		zap.Int("queued", snapshot.queued),
+		zap.Int("processing", snapshot.processing),
+		zap.Int("dead_lettered", snapshot.deadLettered),
+		zap.Float64("queue_lag_seconds", snapshot.queueLagSeconds),
+		zap.Int("inflight", snapshot.inflight),
+	}
+	fields = append(fields, semanticTenantScanLogFields(snapshot.tenantScan)...)
+	logger.Info(ctx, "semantic_worker_observe", fields...)
 }
 
 func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time.Time) semanticObservationSnapshot {
@@ -1064,6 +1183,7 @@ func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time
 		logger.Warn(ctx, "semantic_worker_list_tenants_for_observation_failed", zap.Error(err))
 		return snapshot
 	}
+	snapshot.tenantScan = m.tenantScanSnapshot()
 
 	var oldest *time.Time
 	for _, ref := range refs {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -168,7 +168,6 @@ type semanticObservationSnapshot struct {
 	deadLettered    int
 	queueLagSeconds float64
 	inflight        int
-	tenantScan      semanticTenantScanSnapshot
 }
 
 type semanticTenantScanSnapshot struct {
@@ -1160,15 +1159,6 @@ func (m *semanticWorkerManager) observeOnce(ctx context.Context, now time.Time) 
 	metrics.RecordGauge("semantic_worker", "processing", float64(snapshot.processing))
 	metrics.RecordGauge("semantic_worker", "dead_lettered", float64(snapshot.deadLettered))
 	metrics.RecordGauge("semantic_worker", "queue_lag_seconds", snapshot.queueLagSeconds)
-	fields := []zap.Field{
-		zap.Int("queued", snapshot.queued),
-		zap.Int("processing", snapshot.processing),
-		zap.Int("dead_lettered", snapshot.deadLettered),
-		zap.Float64("queue_lag_seconds", snapshot.queueLagSeconds),
-		zap.Int("inflight", snapshot.inflight),
-	}
-	fields = append(fields, semanticTenantScanLogFields(snapshot.tenantScan)...)
-	logger.Info(ctx, "semantic_worker_observe", fields...)
 }
 
 func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time.Time) semanticObservationSnapshot {
@@ -1183,7 +1173,6 @@ func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time
 		logger.Warn(ctx, "semantic_worker_list_tenants_for_observation_failed", zap.Error(err))
 		return snapshot
 	}
-	snapshot.tenantScan = m.tenantScanSnapshot()
 
 	var oldest *time.Time
 	for _, ref := range refs {

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -1031,8 +1031,7 @@ func TestSemanticWorkerListTenantRefsRotatesAcrossActiveTenantPages(t *testing.T
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPoolWithBackendOptions(t, backend.Options{
 		AsyncImageExtract: backend.AsyncImageExtractOptions{Enabled: true},

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -1025,6 +1025,95 @@ func TestSemanticWorkerListTenantRefsImageOnlyIncludesAutoProviders(t *testing.T
 	}
 }
 
+func TestSemanticWorkerListTenantRefsRotatesAcrossActiveTenantPages(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	pool := newTestTenantPoolWithBackendOptions(t, backend.Options{
+		AsyncImageExtract: backend.AsyncImageExtractOptions{Enabled: true},
+	})
+	passCipher, err := pool.Encrypt(context.Background(), []byte("pw"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	for _, tc := range []struct {
+		id        string
+		provider  string
+		createdAt time.Time
+	}{
+		{id: "tenant-db9", provider: tenant.ProviderDB9, createdAt: base},
+		{id: "tenant-auto-1", provider: tenant.ProviderTiDBZero, createdAt: base.Add(time.Second)},
+		{id: "tenant-auto-2", provider: tenant.ProviderTiDBZero, createdAt: base.Add(2 * time.Second)},
+	} {
+		if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+			ID:               tc.id,
+			Status:           meta.TenantActive,
+			DBHost:           "127.0.0.1",
+			DBPort:           4000,
+			DBUser:           "root",
+			DBPasswordCipher: passCipher,
+			DBName:           "app",
+			DBTLS:            false,
+			Provider:         tc.provider,
+			SchemaVersion:    1,
+			CreatedAt:        tc.createdAt,
+			UpdatedAt:        tc.createdAt,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	orig := semanticWorkerUsesTiDBAutoEmbedding
+	semanticWorkerUsesTiDBAutoEmbedding = func(provider string) bool {
+		return provider == tenant.ProviderTiDBZero
+	}
+	defer func() {
+		semanticWorkerUsesTiDBAutoEmbedding = orig
+	}()
+
+	m := newSemanticWorkerManager(nil, metaStore, pool, nil, SemanticWorkerOptions{TenantScanLimit: 1})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	assertRefs := func(want ...string) {
+		t.Helper()
+		refs, err := m.listTenantRefs(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := make([]string, 0, len(refs))
+		for _, ref := range refs {
+			got = append(got, ref.id)
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("refs = %v, want %v", got, want)
+		}
+	}
+
+	assertRefs()
+	assertRefs("tenant-auto-1")
+	assertRefs("tenant-auto-2")
+	assertRefs()
+	assertRefs("tenant-auto-1")
+
+	scan := m.tenantScanSnapshot()
+	if scan.limit != 1 {
+		t.Fatalf("tenant scan limit = %d, want 1", scan.limit)
+	}
+	if scan.rawTenants != 1 || scan.includedTenants != 1 {
+		t.Fatalf("tenant scan raw/included = %d/%d, want 1/1", scan.rawTenants, scan.includedTenants)
+	}
+	if !scan.cursorSet || scan.cursorID != "tenant-auto-1" {
+		t.Fatalf("tenant scan cursor = set:%v id:%q, want tenant-auto-1", scan.cursorSet, scan.cursorID)
+	}
+}
+
 func TestSemanticWorkerListTenantRefsEmbedOnlySkipsAutoProviders(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -257,7 +257,7 @@ func NewWithConfig(cfg Config) *Server {
 		poolAutoTaskTypes = semanticWorkerLogTaskTypesFromTypes(cfg.Pool.AutoSemanticTaskTypes())
 	}
 	if s.semanticWorker != nil {
-		logger.Info("server_semantic_workers_enabled",
+		fields := []zap.Field{
 			zap.Int("workers", s.semanticWorker.opts.Workers),
 			zap.Duration("poll_interval", s.semanticWorker.opts.PollInterval),
 			zap.Duration("lease_duration", s.semanticWorker.opts.LeaseDuration),
@@ -267,7 +267,10 @@ func NewWithConfig(cfg Config) *Server {
 			zap.Strings("fallback_task_types", fallbackTaskTypes),
 			zap.Strings("pool_auto_task_types", poolAutoTaskTypes),
 			zap.Bool("fallback_image_extract_enabled", cfg.Backend != nil && cfg.Backend.SupportsAsyncImageExtract()),
-			zap.Bool("pool_image_extract_enabled", cfg.Pool != nil && cfg.Pool.SupportsAsyncImageExtract()))
+			zap.Bool("pool_image_extract_enabled", cfg.Pool != nil && cfg.Pool.SupportsAsyncImageExtract()),
+		}
+		fields = append(fields, s.semanticWorker.tenantScanLogFields()...)
+		logger.Info("server_semantic_workers_enabled", fields...)
 		s.semanticWorker.Start(backgroundWithTrace(context.Background()))
 	} else {
 		logger.Info("server_semantic_workers_disabled",


### PR DESCRIPTION
## Summary

- Rotate semantic worker tenant scans with a keyset cursor so each scheduling pass advances through active tenants instead of always scanning the same prefix.
- Add cursor state to worker metrics/logging and extend meta tenant listing to support paginated keyset queries.

## Test plan

- [x] `make test TEST_PKGS='./pkg/meta/... ./pkg/server/...' TEST_P=1`
- [x] `make test TEST_P=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyset pagination for tenant queries with deterministic ordering and cursor-based navigation; new composite index ensures stable tenant listing.

* **Improvements**
  * Multi-tenant scheduling now scans active tenants via a keyset cursor for efficient, rotating pagination.
  * Semantic worker startup logging includes tenant-scan metadata.

* **Tests**
  * Added tests for keyset pagination, tenant-scan rotation, and schema/index detection; new test helper to reset meta DB state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->