### PR TITLE
Fix CLI context server precedence

### DIFF
--- a/cmd/drive9/cli/cat.go
+++ b/cmd/drive9/cli/cat.go
@@ -50,13 +50,13 @@ func catWithWriter(c *client.Client, args []string, out io.Writer) error {
 		return fmt.Errorf("--length must be >= 0")
 	}
 	path := fs.Arg(0)
-	// Handle ":" prefixed remote paths like cp command
-	if rp, isRemote := ParseRemote(path); isRemote {
-		path = rp.Path
+	var err error
+	c, path, _, _, err = fsClientForRemoteArg(c, path)
+	if err != nil {
+		return err
 	}
 	var (
-		rc  io.ReadCloser
-		err error
+		rc io.ReadCloser
 	)
 	if offsetSet {
 		rc, err = c.ReadStreamRange(context.Background(), path, *offset, *length)

--- a/cmd/drive9/cli/chmod.go
+++ b/cmd/drive9/cli/chmod.go
@@ -17,5 +17,9 @@ func Chmod(c *client.Client, args []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid mode %q: %w", modeStr, err)
 	}
+	c, path, _, _, err = fsClientForRemoteArg(c, path)
+	if err != nil {
+		return err
+	}
 	return c.Chmod(path, uint32(mode64))
 }

--- a/cmd/drive9/cli/client.go
+++ b/cmd/drive9/cli/client.go
@@ -70,7 +70,11 @@ func newFSClientForContext(name string) (*client.Client, error) {
 
 	server := ctx.Server
 	if server == "" {
-		server = cfg.ResolveServer()
+		if cfg.Server != "" {
+			server = cfg.Server
+		} else {
+			server = defaultServerURL
+		}
 	}
 
 	switch ctx.Type {

--- a/cmd/drive9/cli/client.go
+++ b/cmd/drive9/cli/client.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
@@ -25,8 +26,9 @@ const fsClientWarmTimeout = 3 * time.Second
 // dispatch; retaining the lenient shape keeps parity with the pre-resolver
 // behaviour (which also returned an empty key).
 //
-// Credential resolution goes through the unified resolver per §14.2
-// (env > config, Unsetenv-after-read).
+// Credential resolution goes through the unified resolver: env credentials
+// override config credentials, while the active context's server URL wins
+// over DRIVE9_SERVER. Resolver reads still use Unsetenv-after-read.
 //
 // NewFromEnv intentionally does NOT warm the /v1/status cache: read-only
 // commands (ls/cat/stat/rm/grep/find) don't need the upload threshold and
@@ -57,4 +59,45 @@ func NewFromEnvWithWarm() *client.Client {
 	defer cancel()
 	c.Warm(ctx)
 	return c
+}
+
+func newFSClientForContext(name string) (*client.Client, error) {
+	cfg := loadConfig()
+	ctx := cfg.Contexts[name]
+	if ctx == nil {
+		return nil, fmt.Errorf("context %q not found; run: drive9 ctx ls", name)
+	}
+
+	server := ctx.Server
+	if server == "" {
+		server = cfg.ResolveServer()
+	}
+
+	switch ctx.Type {
+	case PrincipalOwner, PrincipalFSScoped:
+		if ctx.APIKey == "" {
+			return nil, fmt.Errorf("context %q has no API key", name)
+		}
+		return client.New(server, ctx.APIKey), nil
+	case PrincipalDelegated:
+		return nil, fmt.Errorf("context %q is delegated; fs commands require an owner or fs_scoped context", name)
+	default:
+		return nil, fmt.Errorf("context %q has unsupported type %q", name, ctx.Type)
+	}
+}
+
+func fsClientForRemoteArg(defaultClient *client.Client, raw string) (*client.Client, string, string, bool, error) {
+	rp, isRemote := ParseRemote(raw)
+	if !isRemote {
+		return defaultClient, raw, "", false, nil
+	}
+	if rp.Context == "" {
+		return defaultClient, rp.Path, "", true, nil
+	}
+
+	c, err := newFSClientForContext(rp.Context)
+	if err != nil {
+		return nil, "", "", true, err
+	}
+	return c, rp.Path, rp.Context, true, nil
 }

--- a/cmd/drive9/cli/client.go
+++ b/cmd/drive9/cli/client.go
@@ -62,7 +62,8 @@ func NewFromEnvWithWarm() *client.Client {
 }
 
 func newFSClientForContext(name string) (*client.Client, error) {
-	cfg := loadConfig()
+	r := ResolveCredentials()
+	cfg := loadCredentialConfigSnapshot()
 	ctx := cfg.Contexts[name]
 	if ctx == nil {
 		return nil, fmt.Errorf("context %q not found; run: drive9 ctx ls", name)
@@ -70,7 +71,9 @@ func newFSClientForContext(name string) (*client.Client, error) {
 
 	server := ctx.Server
 	if server == "" {
-		if cfg.Server != "" {
+		if r.envServer != "" {
+			server = r.envServer
+		} else if cfg.Server != "" {
 			server = cfg.Server
 		} else {
 			server = defaultServerURL

--- a/cmd/drive9/cli/cp.go
+++ b/cmd/drive9/cli/cp.go
@@ -111,6 +111,22 @@ func Cp(c *client.Client, args []string) error {
 
 	srcRP, srcIsRemote := ParseRemote(src)
 	dstRP, dstIsRemote := ParseRemote(dst)
+	switch {
+	case srcIsRemote && dstIsRemote && srcRP.Context != "" && dstRP.Context != "" && srcRP.Context != dstRP.Context:
+		return fmt.Errorf("cross-context copy not supported: %s -> %s", srcRP.Context, dstRP.Context)
+	case srcIsRemote && srcRP.Context != "":
+		var err error
+		c, err = newFSClientForContext(srcRP.Context)
+		if err != nil {
+			return err
+		}
+	case dstIsRemote && dstRP.Context != "":
+		var err error
+		c, err = newFSClientForContext(dstRP.Context)
+		if err != nil {
+			return err
+		}
+	}
 	if description != "" {
 		descriptionSupported := dstIsRemote && !appendMode && !resume && (src == "-" || !srcIsRemote)
 		if !descriptionSupported {

--- a/cmd/drive9/cli/cp.go
+++ b/cmd/drive9/cli/cp.go
@@ -111,22 +111,6 @@ func Cp(c *client.Client, args []string) error {
 
 	srcRP, srcIsRemote := ParseRemote(src)
 	dstRP, dstIsRemote := ParseRemote(dst)
-	switch {
-	case srcIsRemote && dstIsRemote && srcRP.Context != "" && dstRP.Context != "" && srcRP.Context != dstRP.Context:
-		return fmt.Errorf("cross-context copy not supported: %s -> %s", srcRP.Context, dstRP.Context)
-	case srcIsRemote && srcRP.Context != "":
-		var err error
-		c, err = newFSClientForContext(srcRP.Context)
-		if err != nil {
-			return err
-		}
-	case dstIsRemote && dstRP.Context != "":
-		var err error
-		c, err = newFSClientForContext(dstRP.Context)
-		if err != nil {
-			return err
-		}
-	}
 	if description != "" {
 		descriptionSupported := dstIsRemote && !appendMode && !resume && (src == "-" || !srcIsRemote)
 		if !descriptionSupported {
@@ -168,6 +152,13 @@ func Cp(c *client.Client, args []string) error {
 
 	switch {
 	case src == "-" && dstIsRemote:
+		if dstRP.Context != "" {
+			var err error
+			c, err = newFSClientForContext(dstRP.Context)
+			if err != nil {
+				return err
+			}
+		}
 		resolvedDst, err := resolveRemoteCopyTarget(ctx, c, dstRP.Path, "")
 		if err != nil {
 			return err
@@ -194,9 +185,23 @@ func Cp(c *client.Client, args []string) error {
 		return nil
 
 	case srcIsRemote && dst == "-":
+		if srcRP.Context != "" {
+			var err error
+			c, err = newFSClientForContext(srcRP.Context)
+			if err != nil {
+				return err
+			}
+		}
 		return streamToStdout(ctx, c, srcRP.Path)
 
 	case !srcIsRemote && dstIsRemote:
+		if dstRP.Context != "" {
+			var err error
+			c, err = newFSClientForContext(dstRP.Context)
+			if err != nil {
+				return err
+			}
+		}
 		resolvedDst, err := resolveRemoteCopyTarget(ctx, c, dstRP.Path, filepath.Base(src))
 		if err != nil {
 			return err
@@ -210,6 +215,13 @@ func Cp(c *client.Client, args []string) error {
 		return uploadFileWithTagsAndDescription(ctx, c, src, resolvedDst, tags, description)
 
 	case srcIsRemote && !dstIsRemote:
+		if srcRP.Context != "" {
+			var err error
+			c, err = newFSClientForContext(srcRP.Context)
+			if err != nil {
+				return err
+			}
+		}
 		resolvedDst, err := resolveLocalCopyTarget(dst, pathpkg.Base(srcRP.Path))
 		if err != nil {
 			return err
@@ -217,6 +229,17 @@ func Cp(c *client.Client, args []string) error {
 		return downloadFile(ctx, c, srcRP.Path, resolvedDst)
 
 	case srcIsRemote && dstIsRemote:
+		switch {
+		case srcRP.Context == "" && dstRP.Context == "":
+		case srcRP.Context != "" && dstRP.Context != "" && srcRP.Context == dstRP.Context:
+			var err error
+			c, err = newFSClientForContext(srcRP.Context)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("cross-context copy not supported: %q -> %q", src, dst)
+		}
 		resolvedDst, err := resolveRemoteCopyTarget(ctx, c, dstRP.Path, pathpkg.Base(srcRP.Path))
 		if err != nil {
 			return err

--- a/cmd/drive9/cli/cp.go
+++ b/cmd/drive9/cli/cp.go
@@ -140,10 +140,35 @@ func Cp(c *client.Client, args []string) error {
 		}
 		switch {
 		case !srcIsRemote && dstIsRemote:
+			if dstRP.Context != "" {
+				var err error
+				c, err = newFSClientForContext(dstRP.Context)
+				if err != nil {
+					return err
+				}
+			}
 			return copyTreeLocalToRemote(ctx, c, src, dstRP.Path)
 		case srcIsRemote && !dstIsRemote:
+			if srcRP.Context != "" {
+				var err error
+				c, err = newFSClientForContext(srcRP.Context)
+				if err != nil {
+					return err
+				}
+			}
 			return copyTreeRemoteToLocal(ctx, c, srcRP.Path, dst)
 		case srcIsRemote && dstIsRemote:
+			switch {
+			case srcRP.Context == "" && dstRP.Context == "":
+			case srcRP.Context != "" && dstRP.Context != "" && srcRP.Context == dstRP.Context:
+				var err error
+				c, err = newFSClientForContext(srcRP.Context)
+				if err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("cross-context copy not supported: %q -> %q", src, dst)
+			}
 			return copyTreeRemoteToRemote(ctx, c, srcRP.Path, dstRP.Path)
 		default:
 			return fmt.Errorf("-r/--recursive requires at least one remote path")

--- a/cmd/drive9/cli/credentials.go
+++ b/cmd/drive9/cli/credentials.go
@@ -100,6 +100,11 @@ func resetCredentialCacheForTest() {
 
 func resolveCredentialsWithConfig(cfg *Config) ResolvedCredentials {
 	var r ResolvedCredentials
+	var activeCtx *Context
+	ctxName := cfg.CurrentContext
+	if ctxName != "" {
+		activeCtx = cfg.Contexts[ctxName]
+	}
 
 	// Consume all three credential-bearing env vars up-front so the Unsetenv
 	// mitigation fires regardless of which one "wins" priority. Otherwise a
@@ -108,6 +113,11 @@ func resolveCredentialsWithConfig(cfg *Config) ResolvedCredentials {
 	envServer := consumeEnv(EnvServer)
 	envToken := consumeEnv(EnvVaultToken)
 	envAPIKey := consumeEnv(EnvAPIKey)
+
+	if activeCtx != nil && activeCtx.Server != "" {
+		r.Server = activeCtx.Server
+		r.ServerSource = "config:" + ctxName
+	}
 
 	// Credential resolution: VAULT_TOKEN > API_KEY > active context.
 	if envToken != "" {
@@ -118,31 +128,25 @@ func resolveCredentialsWithConfig(cfg *Config) ResolvedCredentials {
 		r.Kind = CredentialOwner
 		r.APIKey = envAPIKey
 		r.CredSource = "env:" + EnvAPIKey
-	} else if ctxName := cfg.CurrentContext; ctxName != "" {
-		if ctx := cfg.Contexts[ctxName]; ctx != nil {
-			switch ctx.Type {
-			case PrincipalOwner:
-				if ctx.APIKey != "" {
-					r.Kind = CredentialOwner
-					r.APIKey = ctx.APIKey
-					r.CredSource = "config:" + ctxName
-				}
-			case PrincipalFSScoped:
-				if ctx.APIKey != "" {
-					r.Kind = CredentialFSScoped
-					r.APIKey = ctx.APIKey
-					r.CredSource = "config:" + ctxName
-				}
-			case PrincipalDelegated:
-				if ctx.Token != "" {
-					r.Kind = CredentialDelegated
-					r.Token = ctx.Token
-					r.CredSource = "config:" + ctxName
-				}
+	} else if activeCtx != nil {
+		switch activeCtx.Type {
+		case PrincipalOwner:
+			if activeCtx.APIKey != "" {
+				r.Kind = CredentialOwner
+				r.APIKey = activeCtx.APIKey
+				r.CredSource = "config:" + ctxName
 			}
-			if ctx.Server != "" {
-				r.Server = ctx.Server
-				r.ServerSource = "config:" + ctxName
+		case PrincipalFSScoped:
+			if activeCtx.APIKey != "" {
+				r.Kind = CredentialFSScoped
+				r.APIKey = activeCtx.APIKey
+				r.CredSource = "config:" + ctxName
+			}
+		case PrincipalDelegated:
+			if activeCtx.Token != "" {
+				r.Kind = CredentialDelegated
+				r.Token = activeCtx.Token
+				r.CredSource = "config:" + ctxName
 			}
 		}
 	}

--- a/cmd/drive9/cli/credentials.go
+++ b/cmd/drive9/cli/credentials.go
@@ -54,10 +54,10 @@ type ResolvedCredentials struct {
 }
 
 // ResolveCredentials is the single source of truth for (credential, server)
-// resolution across all drive9 CLI call sites. Priority matches spec §14.2:
+// resolution across all drive9 CLI call sites.
 //
 //	Credential: DRIVE9_VAULT_TOKEN > DRIVE9_API_KEY > active context
-//	Server:     DRIVE9_SERVER      > active-context.server > compiled-in default
+//	Server:     active-context.server > DRIVE9_SERVER > config.server > compiled-in default
 //
 // "First match wins" applies to *presence*, not validity. A set-but-malformed
 // env var yields a distinct error at validation time; it must never silently
@@ -109,12 +109,6 @@ func resolveCredentialsWithConfig(cfg *Config) ResolvedCredentials {
 	envToken := consumeEnv(EnvVaultToken)
 	envAPIKey := consumeEnv(EnvAPIKey)
 
-	// Server resolution is orthogonal to credential resolution (§14.2).
-	if envServer != "" {
-		r.Server = envServer
-		r.ServerSource = "env:" + EnvServer
-	}
-
 	// Credential resolution: VAULT_TOKEN > API_KEY > active context.
 	if envToken != "" {
 		r.Kind = CredentialDelegated
@@ -146,7 +140,7 @@ func resolveCredentialsWithConfig(cfg *Config) ResolvedCredentials {
 					r.CredSource = "config:" + ctxName
 				}
 			}
-			if r.Server == "" && ctx.Server != "" {
+			if ctx.Server != "" {
 				r.Server = ctx.Server
 				r.ServerSource = "config:" + ctxName
 			}
@@ -154,7 +148,10 @@ func resolveCredentialsWithConfig(cfg *Config) ResolvedCredentials {
 	}
 
 	if r.Server == "" {
-		if cfg.Server != "" {
+		if envServer != "" {
+			r.Server = envServer
+			r.ServerSource = "env:" + EnvServer
+		} else if cfg.Server != "" {
 			r.Server = cfg.Server
 			r.ServerSource = "config:server"
 		} else {

--- a/cmd/drive9/cli/credentials.go
+++ b/cmd/drive9/cli/credentials.go
@@ -51,6 +51,7 @@ type ResolvedCredentials struct {
 	Token        string // set when Kind == CredentialDelegated
 	CredSource   string // "env:DRIVE9_VAULT_TOKEN", "env:DRIVE9_API_KEY", "config:<ctx-name>", ""
 	ServerSource string // "env:DRIVE9_SERVER", "config:<ctx-name>", "default"
+	envServer    string
 }
 
 // ResolveCredentials is the single source of truth for (credential, server)
@@ -81,21 +82,32 @@ type ResolvedCredentials struct {
 // whitespace to match file-based ingress (`ctx import`) behaviour.
 func ResolveCredentials() ResolvedCredentials {
 	credentialOnce.Do(func() {
-		cachedCredentials = resolveCredentialsWithConfig(loadConfig())
+		cachedCredentials = resolveCredentialsWithConfig(loadCredentialConfigSnapshot())
 	})
 	return cachedCredentials
 }
 
 var (
-	credentialOnce    sync.Once
-	cachedCredentials ResolvedCredentials
+	credentialOnce       sync.Once
+	cachedCredentials    ResolvedCredentials
+	configSnapshotOnce   sync.Once
+	cachedConfigSnapshot *Config
 )
+
+func loadCredentialConfigSnapshot() *Config {
+	configSnapshotOnce.Do(func() {
+		cachedConfigSnapshot = loadConfig()
+	})
+	return cachedConfigSnapshot
+}
 
 // resetCredentialCacheForTest clears the per-process resolver cache. Test-
 // only; callers in production would see an env-read-after-unset race.
 func resetCredentialCacheForTest() {
 	credentialOnce = sync.Once{}
 	cachedCredentials = ResolvedCredentials{}
+	configSnapshotOnce = sync.Once{}
+	cachedConfigSnapshot = nil
 }
 
 func resolveCredentialsWithConfig(cfg *Config) ResolvedCredentials {
@@ -113,6 +125,7 @@ func resolveCredentialsWithConfig(cfg *Config) ResolvedCredentials {
 	envServer := consumeEnv(EnvServer)
 	envToken := consumeEnv(EnvVaultToken)
 	envAPIKey := consumeEnv(EnvAPIKey)
+	r.envServer = envServer
 
 	if activeCtx != nil && activeCtx.Server != "" {
 		r.Server = activeCtx.Server

--- a/cmd/drive9/cli/credentials_test.go
+++ b/cmd/drive9/cli/credentials_test.go
@@ -183,7 +183,7 @@ func TestResolveCredentials_EmptyWhenNothingAvailable(t *testing.T) {
 	}
 }
 
-func TestResolveCredentials_ServerEnvOverridesContextServer(t *testing.T) {
+func TestResolveCredentials_ContextServerBeatsEnvServer(t *testing.T) {
 	setResolverEnv(t, map[string]string{
 		EnvServer: "https://env.override",
 	})
@@ -196,12 +196,33 @@ func TestResolveCredentials_ServerEnvOverridesContextServer(t *testing.T) {
 
 	r := resolveCredentialsWithConfig(cfg)
 
-	if r.Server != "https://env.override" {
-		t.Fatalf("Server = %q, want env override", r.Server)
+	if r.Server != "https://config.example" {
+		t.Fatalf("Server = %q, want context server", r.Server)
 	}
 	// Credential still from config.
 	if r.APIKey != "sk-config-owner" {
 		t.Fatalf("APIKey = %q, want config", r.APIKey)
+	}
+	if r.ServerSource != "config:prod" {
+		t.Fatalf("ServerSource = %q", r.ServerSource)
+	}
+}
+
+func TestResolveCredentials_ServerEnvUsedWhenContextServerEmpty(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvServer: "https://env.override",
+	})
+	cfg := &Config{
+		CurrentContext: "prod",
+		Contexts: map[string]*Context{
+			"prod": {Type: PrincipalOwner, APIKey: "sk-config-owner"},
+		},
+	}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.Server != "https://env.override" {
+		t.Fatalf("Server = %q, want env override", r.Server)
 	}
 	if r.ServerSource != "env:"+EnvServer {
 		t.Fatalf("ServerSource = %q", r.ServerSource)

--- a/cmd/drive9/cli/credentials_test.go
+++ b/cmd/drive9/cli/credentials_test.go
@@ -229,6 +229,56 @@ func TestResolveCredentials_ServerEnvUsedWhenContextServerEmpty(t *testing.T) {
 	}
 }
 
+func TestResolveCredentials_ContextServerBeatsEnvServerWhenCredentialFromEnvAPIKey(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvAPIKey: "sk-env-owner",
+		EnvServer: "https://env.override",
+	})
+	cfg := &Config{
+		CurrentContext: "prod",
+		Contexts: map[string]*Context{
+			"prod": {Type: PrincipalOwner, Server: "https://config.example", APIKey: "sk-config-owner"},
+		},
+	}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.APIKey != "sk-env-owner" {
+		t.Fatalf("APIKey = %q, want env API key", r.APIKey)
+	}
+	if r.Server != "https://config.example" {
+		t.Fatalf("Server = %q, want context server", r.Server)
+	}
+	if r.ServerSource != "config:prod" {
+		t.Fatalf("ServerSource = %q", r.ServerSource)
+	}
+}
+
+func TestResolveCredentials_ContextServerBeatsEnvServerWhenCredentialFromEnvVaultToken(t *testing.T) {
+	setResolverEnv(t, map[string]string{
+		EnvVaultToken: "jwt-eyAAA",
+		EnvServer:     "https://env.override",
+	})
+	cfg := &Config{
+		CurrentContext: "prod",
+		Contexts: map[string]*Context{
+			"prod": {Type: PrincipalOwner, Server: "https://config.example", APIKey: "sk-config-owner"},
+		},
+	}
+
+	r := resolveCredentialsWithConfig(cfg)
+
+	if r.Token != "jwt-eyAAA" {
+		t.Fatalf("Token = %q, want env vault token", r.Token)
+	}
+	if r.Server != "https://config.example" {
+		t.Fatalf("Server = %q, want context server", r.Server)
+	}
+	if r.ServerSource != "config:prod" {
+		t.Fatalf("ServerSource = %q", r.ServerSource)
+	}
+}
+
 func TestResolveCredentials_UnsetsEnvAfterRead(t *testing.T) {
 	setResolverEnv(t, map[string]string{
 		EnvVaultToken: "jwt-eyAAA",

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -166,6 +166,8 @@ func TestCtxForkRejectsDelegatedSource(t *testing.T) {
 // duration of the test. Returns the tmp dir path.
 func withIsolatedHome(t *testing.T) string {
 	t.Helper()
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	// Some macOS Go versions cache UserHomeDir via getenv; t.Setenv is

--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -44,10 +44,11 @@ func Create(args []string) error {
 		return err
 	}
 
-	// Precedence per §14.2: explicit --server flag > DRIVE9_SERVER env > config.
-	// ResolveCredentials consumes the env var (Unsetenv mitigation), so even when
-	// the flag wins we still sink the env to keep downstream forks from inheriting
-	// it. Credential resolution is not used here — provisioning is unauthenticated.
+	// Precedence here is: explicit --server flag > active context.server >
+	// DRIVE9_SERVER env > config.server/default. ResolveCredentials consumes the
+	// env var (Unsetenv mitigation), so even when the flag wins we still sink the
+	// env to keep downstream forks from inheriting it. Credential resolution is
+	// not used here — provisioning is unauthenticated.
 	r := ResolveCredentials()
 	server := serverFlag
 	if server == "" {

--- a/cmd/drive9/cli/find.go
+++ b/cmd/drive9/cli/find.go
@@ -62,9 +62,10 @@ func Find(c *client.Client, args []string) error {
 		}
 	}
 
-	// Handle ":" prefixed remote paths like cp command
-	if rp, isRemote := ParseRemote(path); isRemote {
-		path = rp.Path
+	var err error
+	c, path, _, _, err = fsClientForRemoteArg(c, path)
+	if err != nil {
+		return err
 	}
 
 	results, err := c.Find(path, params)

--- a/cmd/drive9/cli/fs_context_test.go
+++ b/cmd/drive9/cli/fs_context_test.go
@@ -119,6 +119,109 @@ func TestExplicitContextUsesConfigServerFallbackInsteadOfActiveContextServer(t *
 	}
 }
 
+func TestExplicitContextUsesEnvServerFallback(t *testing.T) {
+	withIsolatedHome(t)
+
+	configServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("config server should not be used: %s %s", r.Method, r.URL.Path)
+	}))
+	defer configServer.Close()
+
+	envServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/fs/" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer fork-key" {
+			t.Fatalf("Authorization = %q, want Bearer fork-key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"entries": []map[string]any{
+				{"name": "env-docs", "isDir": true},
+			},
+		})
+	}))
+	defer envServer.Close()
+
+	cfg := loadConfig()
+	cfg.Server = configServer.URL
+	cfg.Contexts = map[string]*Context{
+		"fork": {Type: PrincipalOwner, APIKey: "fork-key"},
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	t.Setenv(EnvServer, envServer.URL)
+
+	out, err := captureStdoutE(t, func() error {
+		return Ls(client.New(configServer.URL, "unused"), []string{"fork:/"})
+	})
+	if err != nil {
+		t.Fatalf("Ls: %v", err)
+	}
+	if !strings.Contains(out, "env-docs/") {
+		t.Fatalf("Ls output = %q, want env-docs/", out)
+	}
+}
+
+func TestExplicitContextUsesResolverConfigSnapshot(t *testing.T) {
+	withIsolatedHome(t)
+
+	initial := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/fs/" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer fork-key" {
+			t.Fatalf("Authorization = %q, want Bearer fork-key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"entries": []map[string]any{
+				{"name": "snapshot-docs", "isDir": true},
+			},
+		})
+	}))
+	defer initial.Close()
+
+	later := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("later config server should not be observed: %s %s", r.Method, r.URL.Path)
+	}))
+	defer later.Close()
+
+	cfg := loadConfig()
+	cfg.CurrentContext = "current"
+	cfg.Contexts = map[string]*Context{
+		"current": {Type: PrincipalOwner, APIKey: "current-key", Server: initial.URL},
+		"fork":    {Type: PrincipalOwner, APIKey: "fork-key", Server: initial.URL},
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	_ = ResolveCredentials()
+
+	mutated := &Config{
+		CurrentContext: "current",
+		Contexts: map[string]*Context{
+			"current": {Type: PrincipalOwner, APIKey: "current-key", Server: later.URL},
+			"fork":    {Type: PrincipalOwner, APIKey: "fork-key", Server: later.URL},
+		},
+	}
+	if err := saveConfig(mutated); err != nil {
+		t.Fatalf("save mutated config: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error {
+		return Ls(client.New(initial.URL, "current-key"), []string{"fork:/"})
+	})
+	if err != nil {
+		t.Fatalf("Ls: %v", err)
+	}
+	if !strings.Contains(out, "snapshot-docs/") {
+		t.Fatalf("Ls output = %q, want snapshot-docs/", out)
+	}
+}
+
 func TestCpRejectsMixedExplicitAndCurrentRemoteContexts(t *testing.T) {
 	withIsolatedHome(t)
 

--- a/cmd/drive9/cli/fs_context_test.go
+++ b/cmd/drive9/cli/fs_context_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+func TestLsUsesExplicitRemoteContext(t *testing.T) {
+	withIsolatedHome(t)
+
+	current := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("current context should not be used: %s %s", r.Method, r.URL.Path)
+	}))
+	defer current.Close()
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/fs/" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer fork-key" {
+			t.Fatalf("Authorization = %q, want Bearer fork-key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"entries": []map[string]any{
+				{"name": "docs", "isDir": true},
+			},
+		})
+	}))
+	defer target.Close()
+
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "current", &Context{Type: PrincipalOwner, APIKey: "current-key", Server: current.URL}); err != nil {
+		t.Fatalf("ctxAdd current: %v", err)
+	}
+	if _, err := ctxAdd(cfg, "fork", &Context{Type: PrincipalOwner, APIKey: "fork-key", Server: target.URL}); err != nil {
+		t.Fatalf("ctxAdd fork: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error {
+		return Ls(client.New(current.URL, "current-key"), []string{"fork:/"})
+	})
+	if err != nil {
+		t.Fatalf("Ls: %v", err)
+	}
+	if !strings.Contains(out, "docs/") {
+		t.Fatalf("Ls output = %q, want docs/", out)
+	}
+}
+
+func TestLsRejectsDelegatedExplicitRemoteContext(t *testing.T) {
+	withIsolatedHome(t)
+
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "delegated", &Context{Type: PrincipalDelegated, Token: "tok", Server: "https://drive9.example"}); err != nil {
+		t.Fatalf("ctxAdd delegated: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	err := Ls(client.New("https://unused.example", "unused"), []string{"delegated:/"})
+	if err == nil || !strings.Contains(err.Error(), "require an owner or fs_scoped context") {
+		t.Fatalf("Ls error = %v, want explicit delegated-context error", err)
+	}
+}

--- a/cmd/drive9/cli/fs_context_test.go
+++ b/cmd/drive9/cli/fs_context_test.go
@@ -139,6 +139,26 @@ func TestCpRejectsMixedExplicitAndCurrentRemoteContexts(t *testing.T) {
 	}
 }
 
+func TestCpRecursiveRejectsMixedExplicitAndCurrentRemoteContexts(t *testing.T) {
+	withIsolatedHome(t)
+
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "current", &Context{Type: PrincipalOwner, APIKey: "current-key", Server: "https://current.example"}); err != nil {
+		t.Fatalf("ctxAdd current: %v", err)
+	}
+	if _, err := ctxAdd(cfg, "prod", &Context{Type: PrincipalOwner, APIKey: "prod-key", Server: "https://prod.example"}); err != nil {
+		t.Fatalf("ctxAdd prod: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	err := Cp(client.New("https://current.example", "current-key"), []string{"-r", "prod:/dir", ":/dir"})
+	if err == nil || !strings.Contains(err.Error(), "cross-context copy not supported") {
+		t.Fatalf("Cp recursive error = %v, want cross-context rejection", err)
+	}
+}
+
 func TestMvRejectsMixedExplicitAndCurrentRemoteContexts(t *testing.T) {
 	withIsolatedHome(t)
 

--- a/cmd/drive9/cli/fs_context_test.go
+++ b/cmd/drive9/cli/fs_context_test.go
@@ -72,3 +72,89 @@ func TestLsRejectsDelegatedExplicitRemoteContext(t *testing.T) {
 		t.Fatalf("Ls error = %v, want explicit delegated-context error", err)
 	}
 }
+
+func TestExplicitContextUsesConfigServerFallbackInsteadOfActiveContextServer(t *testing.T) {
+	withIsolatedHome(t)
+
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("active context server should not be used: %s %s", r.Method, r.URL.Path)
+	}))
+	defer active.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/fs/" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer fork-key" {
+			t.Fatalf("Authorization = %q, want Bearer fork-key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"entries": []map[string]any{
+				{"name": "docs", "isDir": true},
+			},
+		})
+	}))
+	defer fallback.Close()
+
+	cfg := loadConfig()
+	cfg.Server = fallback.URL
+	cfg.CurrentContext = "current"
+	cfg.Contexts = map[string]*Context{
+		"current": {Type: PrincipalOwner, APIKey: "current-key", Server: active.URL},
+		"fork":    {Type: PrincipalOwner, APIKey: "fork-key"},
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error {
+		return Ls(client.New(active.URL, "current-key"), []string{"fork:/"})
+	})
+	if err != nil {
+		t.Fatalf("Ls: %v", err)
+	}
+	if !strings.Contains(out, "docs/") {
+		t.Fatalf("Ls output = %q, want docs/", out)
+	}
+}
+
+func TestCpRejectsMixedExplicitAndCurrentRemoteContexts(t *testing.T) {
+	withIsolatedHome(t)
+
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "current", &Context{Type: PrincipalOwner, APIKey: "current-key", Server: "https://current.example"}); err != nil {
+		t.Fatalf("ctxAdd current: %v", err)
+	}
+	if _, err := ctxAdd(cfg, "prod", &Context{Type: PrincipalOwner, APIKey: "prod-key", Server: "https://prod.example"}); err != nil {
+		t.Fatalf("ctxAdd prod: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	err := Cp(client.New("https://current.example", "current-key"), []string{"prod:/a", ":/b"})
+	if err == nil || !strings.Contains(err.Error(), "cross-context copy not supported") {
+		t.Fatalf("Cp error = %v, want cross-context rejection", err)
+	}
+}
+
+func TestMvRejectsMixedExplicitAndCurrentRemoteContexts(t *testing.T) {
+	withIsolatedHome(t)
+
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "current", &Context{Type: PrincipalOwner, APIKey: "current-key", Server: "https://current.example"}); err != nil {
+		t.Fatalf("ctxAdd current: %v", err)
+	}
+	if _, err := ctxAdd(cfg, "prod", &Context{Type: PrincipalOwner, APIKey: "prod-key", Server: "https://prod.example"}); err != nil {
+		t.Fatalf("ctxAdd prod: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	err := Mv(client.New("https://current.example", "current-key"), []string{":/old", "prod:/new"})
+	if err == nil || !strings.Contains(err.Error(), "cross-context rename not supported") {
+		t.Fatalf("Mv error = %v, want cross-context rejection", err)
+	}
+}

--- a/cmd/drive9/cli/grep.go
+++ b/cmd/drive9/cli/grep.go
@@ -18,9 +18,10 @@ func Grep(c *client.Client, args []string) error {
 		path = args[1]
 	}
 
-	// Handle ":" prefixed remote paths like cp command
-	if rp, isRemote := ParseRemote(path); isRemote {
-		path = rp.Path
+	var err error
+	c, path, _, _, err = fsClientForRemoteArg(c, path)
+	if err != nil {
+		return err
 	}
 
 	results, err := c.Grep(query, path, 20)
@@ -50,9 +51,10 @@ func GrepJSON(c *client.Client, args []string) error {
 		path = args[1]
 	}
 
-	// Handle ":" prefixed remote paths like cp command
-	if rp, isRemote := ParseRemote(path); isRemote {
-		path = rp.Path
+	var err error
+	c, path, _, _, err = fsClientForRemoteArg(c, path)
+	if err != nil {
+		return err
 	}
 
 	results, err := c.Grep(query, path, 20)

--- a/cmd/drive9/cli/ls.go
+++ b/cmd/drive9/cli/ls.go
@@ -27,9 +27,10 @@ func Ls(c *client.Client, args []string) error {
 		}
 	}
 
-	// Handle ":" prefixed remote paths like cp command
-	if rp, isRemote := ParseRemote(path); isRemote {
-		path = rp.Path
+	var err error
+	c, path, _, _, err = fsClientForRemoteArg(c, path)
+	if err != nil {
+		return err
 	}
 
 	entries, err := c.List(path)

--- a/cmd/drive9/cli/mkdir.go
+++ b/cmd/drive9/cli/mkdir.go
@@ -16,8 +16,10 @@ func Mkdir(c *client.Client, args []string) error {
 		return fmt.Errorf("usage: drive9 fs mkdir <path>")
 	}
 	path := args[0]
-	if rp, isRemote := ParseRemote(path); isRemote {
-		path = rp.Path
+	var err error
+	c, path, _, _, err = fsClientForRemoteArg(c, path)
+	if err != nil {
+		return err
 	}
 	if err := c.Mkdir(path); err != nil {
 		return err

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -61,10 +61,11 @@ func MountCmd(args []string) error {
 
 // fsMountCmd is the pre-V2e writable fs mount entry point.
 //
-// Credential precedence matches spec section 14.2: explicit --server / --api-key flag
-// > DRIVE9_SERVER / DRIVE9_API_KEY / DRIVE9_VAULT_TOKEN env > active config
-// context. The flag defaults are empty strings so we can distinguish "unset"
-// from "explicit empty"; the latter is rejected (see rejectEmptyFlag).
+// Credential precedence matches the unified resolver: explicit --server /
+// --api-key flag overrides all resolver sources; env credentials still beat
+// config credentials, but the active context's server beats DRIVE9_SERVER.
+// The flag defaults are empty strings so we can distinguish "unset" from
+// "explicit empty"; the latter is rejected (see rejectEmptyFlag).
 //
 // A mount is bound to exactly one principal at mount time (Invariant #3).
 // If the resolver returns a delegated credential (owner JWT / `ctx use <alice>`),

--- a/cmd/drive9/cli/mv.go
+++ b/cmd/drive9/cli/mv.go
@@ -16,12 +16,25 @@ func Mv(c *client.Client, args []string) error {
 	}
 	oldPath := args[0]
 	newPath := args[1]
-	// Handle ":" prefixed remote paths like cp command
-	if rp, isRemote := ParseRemote(oldPath); isRemote {
-		oldPath = rp.Path
+	var (
+		oldCtx string
+		newCtx string
+		err    error
+	)
+	c, oldPath, oldCtx, _, err = fsClientForRemoteArg(c, oldPath)
+	if err != nil {
+		return err
 	}
-	if rp, isRemote := ParseRemote(newPath); isRemote {
-		newPath = rp.Path
+	newClient := c
+	newClient, newPath, newCtx, _, err = fsClientForRemoteArg(newClient, newPath)
+	if err != nil {
+		return err
+	}
+	if oldCtx != "" && newCtx != "" && oldCtx != newCtx {
+		return fmt.Errorf("cross-context rename not supported: %s -> %s", oldCtx, newCtx)
+	}
+	if oldCtx == "" && newCtx != "" {
+		c = newClient
 	}
 	return c.Rename(oldPath, newPath)
 }

--- a/cmd/drive9/cli/mv.go
+++ b/cmd/drive9/cli/mv.go
@@ -16,25 +16,25 @@ func Mv(c *client.Client, args []string) error {
 	}
 	oldPath := args[0]
 	newPath := args[1]
-	var (
-		oldCtx string
-		newCtx string
-		err    error
-	)
-	c, oldPath, oldCtx, _, err = fsClientForRemoteArg(c, oldPath)
-	if err != nil {
-		return err
+	oldRP, oldIsRemote := ParseRemote(oldPath)
+	newRP, newIsRemote := ParseRemote(newPath)
+	if oldIsRemote {
+		oldPath = oldRP.Path
 	}
-	newClient := c
-	newClient, newPath, newCtx, _, err = fsClientForRemoteArg(newClient, newPath)
-	if err != nil {
-		return err
+	if newIsRemote {
+		newPath = newRP.Path
 	}
-	if oldCtx != "" && newCtx != "" && oldCtx != newCtx {
-		return fmt.Errorf("cross-context rename not supported: %s -> %s", oldCtx, newCtx)
-	}
-	if oldCtx == "" && newCtx != "" {
-		c = newClient
+
+	switch {
+	case oldRP.Context == "" && newRP.Context == "":
+	case oldRP.Context != "" && newRP.Context != "" && oldRP.Context == newRP.Context:
+		var err error
+		c, err = newFSClientForContext(oldRP.Context)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("cross-context rename not supported: %q -> %q", args[0], args[1])
 	}
 	return c.Rename(oldPath, newPath)
 }

--- a/cmd/drive9/cli/rm.go
+++ b/cmd/drive9/cli/rm.go
@@ -42,9 +42,10 @@ func Rm(c *client.Client, args []string) error {
 		return fmt.Errorf("usage: drive9 fs rm [-r|--recursive] <path>")
 	}
 
-	// Handle ":" prefixed remote paths like cp command
-	if rp, isRemote := ParseRemote(path); isRemote {
-		path = rp.Path
+	var err error
+	c, path, _, _, err = fsClientForRemoteArg(c, path)
+	if err != nil {
+		return err
 	}
 	if recursive {
 		return c.RemoveAll(path)

--- a/cmd/drive9/cli/stat.go
+++ b/cmd/drive9/cli/stat.go
@@ -44,9 +44,10 @@ func Stat(c *client.Client, args []string) error {
 	if path == "" {
 		return fmt.Errorf("usage: drive9 fs stat [-o text|json] <path>")
 	}
-	// Handle ":" prefixed remote paths like cp command
-	if rp, isRemote := ParseRemote(path); isRemote {
-		path = rp.Path
+	var err error
+	c, path, _, _, err = fsClientForRemoteArg(c, path)
+	if err != nil {
+		return err
 	}
 	m, err := c.StatMetadataCompat(path)
 	if err != nil {

--- a/docs/guides/vault-quickstart.md
+++ b/docs/guides/vault-quickstart.md
@@ -258,7 +258,9 @@ Credential priority (first match wins):
 
 An explicitly-empty flag (`--api-key=""`) is rejected at parse time — it is not treated as "unset and fall through." Pass a non-empty value or omit the flag entirely.
 
-`DRIVE9_SERVER` is resolved independently: if set, it overrides the active context's `server` field even when credentials come from the active context.
+Server routing is resolved independently from credential selection, but an active context's `server` field wins over `DRIVE9_SERVER`. This prevents a stale shell export from silently sending the active context's credential to the wrong drive9 server after `drive9 ctx use`. The effective server order is: explicit `--server` flag, active context `server`, `DRIVE9_SERVER`, top-level config `server`, compiled default.
+
+Migration note: if an existing CI job or one-off shell relied on `DRIVE9_SERVER` to override an active context with its own `server`, switch to a context pointed at the desired endpoint, clear/replace the active context for that invocation, or pass an explicit `--server` flag on commands that support it.
 
 "First match wins" applies to **presence**, not to validity. A set-but-invalid `DRIVE9_VAULT_TOKEN` (malformed, expired, revoked, or issued by an unknown server) fails as `Permission denied` — it does not silently fall through to `DRIVE9_API_KEY` or the active context. To use the owner credential, unset `DRIVE9_VAULT_TOKEN`.
 

--- a/docs/specs/vault-interaction-end-state.md
+++ b/docs/specs/vault-interaction-end-state.md
@@ -484,10 +484,16 @@ The unified credential resolver (`ResolveCredentials()`) is the **sole source-of
 Server URL resolution is **orthogonal** to credential resolution:
 
 1. Explicit `--server` flag
-2. `DRIVE9_SERVER`
-3. The `server` field of the active context
+2. The `server` field of the active context
+3. `DRIVE9_SERVER`
+4. Top-level `server` in `~/.drive9/config`
+5. Compiled-in default
 
-`ctx use` does **not** lock server and credential together: if `DRIVE9_SERVER` is set, it overrides the context's `server` field even when the active context is used for credentials. If the resulting (server, credential) pair is mismatched (e.g. a JWT signed by a different issuer), the server rejects the request with `EACCES` via the standard stale-auth path (§11). No new error model is introduced.
+`ctx use` intentionally binds the active context's server before the process environment's `DRIVE9_SERVER`. This prevents a stale shell export from silently routing an active context's credential to the wrong drive9 server after switching contexts. Environment credentials still override context credentials; only server routing prefers the active context's explicit `server` field.
+
+For explicit filesystem context paths (`<ctx>:/path`), the named context's `server` field has the same priority as the active context's server. If the named context omits `server`, fallback is `DRIVE9_SERVER`, then top-level config `server`, then the compiled default.
+
+Migration note: CI jobs, containers, and one-off scripts that previously relied on `DRIVE9_SERVER` to override an active context with its own `server` must either switch to a context whose `server` points at the desired endpoint, clear/replace the active context before invoking drive9, or pass an explicit `--server` flag on commands that support it. If the resulting (server, credential) pair is mismatched (e.g. a JWT signed by a different issuer), the server rejects the request with `EACCES` via the standard stale-auth path (§11). No new error model is introduced.
 
 ### 14.3 Activation mechanics
 


### PR DESCRIPTION
## Summary
- make active context server override DRIVE9_SERVER during credential resolution
- honor explicit `<ctx>:/path` contexts for CLI fs commands that accept remote path prefixes (`ls`, `cp`, `mv`, `rm`, `mkdir`, `cat`, `grep`, `stat`, `chmod`, `find`)
- reject mixed explicit/current-context server-side copy and rename operations that could target the wrong tenant
- add regression coverage for remote-context selection and server precedence

## Testing
- go test ./cmd/drive9/cli
- go build -o bin/drive9 ./cmd/drive9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified remote-context resolution applied across filesystem commands with consistent handling and early error returns.
  * Explicit rejection of cross-context operations with clearer error messages.

* **Bug Fixes**
  * Credential/server resolution precedence refined: active-context server now beats DRIVE9_SERVER; env still overrides config when context server is absent.

* **Tests**
  * Expanded tests for explicit/delegated remote contexts and cross-context command behavior.

* **Documentation**
  * Updated docs/specs and quickstart guidance to reflect new server-selection precedence and migration notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->