### PR TITLE
Fix CLI help success path

### DIFF
--- a/cmd/drive9/cli/cli_consolidation_test.go
+++ b/cmd/drive9/cli/cli_consolidation_test.go
@@ -219,6 +219,58 @@ func TestCtxRmFSScopedEmitsServerNotRevokedWarning(t *testing.T) {
 	}
 }
 
+func TestCtxRmRemovesDashPrefixedContextNames(t *testing.T) {
+	seedThreeContexts(t)
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "-foo", &Context{Type: PrincipalFSScoped, Server: "https://s", APIKey: "dat9_scoped", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatalf("ctxAdd -foo: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error {
+		return Ctx([]string{"rm", "-foo"})
+	})
+	if err != nil {
+		t.Fatalf("ctx rm -foo: %v", err)
+	}
+	if !strings.Contains(out, "removed local context") {
+		t.Fatalf("missing success line, got: %s", out)
+	}
+	if _, ok := loadConfig().Contexts["-foo"]; ok {
+		t.Fatal("local -foo context still present after rm")
+	}
+}
+
+func TestCtxRmRemovesHelpAliasContextNames(t *testing.T) {
+	for _, name := range []string{"help", "-h", "-help", "--help"} {
+		t.Run(name, func(t *testing.T) {
+			seedThreeContexts(t)
+			cfg := loadConfig()
+			if _, err := ctxAdd(cfg, name, &Context{Type: PrincipalFSScoped, Server: "https://s", APIKey: "dat9_scoped", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+				t.Fatalf("ctxAdd %q: %v", name, err)
+			}
+			if err := saveConfig(cfg); err != nil {
+				t.Fatalf("saveConfig: %v", err)
+			}
+
+			out, err := captureStdoutE(t, func() error {
+				return Ctx([]string{"rm", name})
+			})
+			if err != nil {
+				t.Fatalf("ctx rm %q: %v", name, err)
+			}
+			if !strings.Contains(out, "removed local context") {
+				t.Fatalf("missing success line, got: %s", out)
+			}
+			if _, ok := loadConfig().Contexts[name]; ok {
+				t.Fatalf("local %q context still present after rm", name)
+			}
+		})
+	}
+}
+
 // TestCtxRmOwnerRequiresConfirmation verifies the [y/N] prompt on
 // owner-context removal. A "no" answer (empty line) MUST abort the
 // removal so owner key loss is never accidental.

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -24,6 +24,10 @@ func Ctx(args []string) error {
 	if len(args) == 0 {
 		return ctxShowCmd(nil)
 	}
+	if IsHelpArg(args[0]) {
+		_, _ = fmt.Fprintln(os.Stdout, ctxUsage())
+		return nil
+	}
 	switch args[0] {
 	case "show":
 		return ctxShowCmd(args[1:])
@@ -39,8 +43,6 @@ func Ctx(args []string) error {
 		return ctxUseCmd(args[1:])
 	case "rm":
 		return ctxRmCmd(args[1:])
-	case "-h", "--help", "help":
-		return ctxUsageErr()
 	default:
 		return fmt.Errorf("unknown ctx command %q\n%s", args[0], ctxUsage())
 	}
@@ -57,10 +59,6 @@ func ctxUsage() string {
   ls [-l|--json] [--type <kind>|--scoped]             list contexts (filter by type: owner|delegated|fs_scoped)
   use <name>                                          activate a context
   rm <name>                                           remove a local context name (does NOT revoke server-side credential)`
-}
-
-func ctxUsageErr() error {
-	return fmt.Errorf("%s", ctxUsage())
 }
 
 type ctxShowEntry struct {
@@ -1008,7 +1006,11 @@ func ctxUseDescriptor(c *Context) string {
 //
 // Acceptance from #drive9:67e75a87 task #11 thread.
 func ctxRmCmd(args []string) error {
-	if len(args) != 1 || strings.HasPrefix(args[0], "--") {
+	if len(args) == 1 && IsHelpArg(args[0]) {
+		_, _ = fmt.Fprintln(os.Stdout, ctxRmUsage())
+		return nil
+	}
+	if len(args) != 1 || strings.HasPrefix(args[0], "-") {
 		return fmt.Errorf("%s", ctxRmUsage())
 	}
 	name := args[0]

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -1006,17 +1006,17 @@ func ctxUseDescriptor(c *Context) string {
 //
 // Acceptance from #drive9:67e75a87 task #11 thread.
 func ctxRmCmd(args []string) error {
-	if len(args) == 1 && IsHelpArg(args[0]) {
-		_, _ = fmt.Fprintln(os.Stdout, ctxRmUsage())
-		return nil
-	}
-	if len(args) != 1 || strings.HasPrefix(args[0], "-") {
+	if len(args) != 1 {
 		return fmt.Errorf("%s", ctxRmUsage())
 	}
 	name := args[0]
 	cfg := loadConfig()
 	target, ok := cfg.Contexts[name]
 	if !ok || target == nil {
+		if IsHelpArg(name) {
+			_, _ = fmt.Fprintln(os.Stdout, ctxRmUsage())
+			return nil
+		}
 		return fmt.Errorf("context %q not found", name)
 	}
 	if cfg.CurrentContext == name {

--- a/cmd/drive9/cli/doctor.go
+++ b/cmd/drive9/cli/doctor.go
@@ -98,12 +98,13 @@ func runDoctor(args []string, deps doctorDeps) error {
 	if len(args) == 0 {
 		return errors.New(doctorUsage())
 	}
+	if IsHelpArg(args[0]) {
+		_, _ = fmt.Fprint(deps.stdout, doctorUsage())
+		return nil
+	}
 	switch args[0] {
 	case "fuse":
 		return runDoctorFuse(args[1:], deps)
-	case "-h", "-help", "--help", "help":
-		_, _ = fmt.Fprint(deps.stdout, doctorUsage())
-		return nil
 	default:
 		return fmt.Errorf("unknown doctor command %q\n%s", args[0], doctorUsage())
 	}

--- a/cmd/drive9/cli/help.go
+++ b/cmd/drive9/cli/help.go
@@ -1,0 +1,11 @@
+package cli
+
+// IsHelpArg reports whether arg is one of the accepted CLI help spellings.
+func IsHelpArg(arg string) bool {
+	switch arg {
+	case "-h", "-help", "--help", "help":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/drive9/cli/journal.go
+++ b/cmd/drive9/cli/journal.go
@@ -28,7 +28,11 @@ func (r *repeatStrings) Set(value string) error {
 
 func Journal(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: drive9 journal <new|append|cat|find|verify>")
+		return fmt.Errorf("%s", journalUsage())
+	}
+	if IsHelpArg(args[0]) {
+		_, _ = fmt.Fprintln(os.Stdout, journalUsage())
+		return nil
 	}
 	switch args[0] {
 	case "new":
@@ -43,11 +47,13 @@ func Journal(args []string) error {
 		return JournalVerify(args[1:])
 	case "seal":
 		return fmt.Errorf("journal seal is not implemented in the Phase 1 journal backend")
-	case "-h", "--help", "help":
-		return fmt.Errorf("usage: drive9 journal <new|append|cat|find|verify>")
 	default:
 		return fmt.Errorf("unknown journal command %q", args[0])
 	}
+}
+
+func journalUsage() string {
+	return "usage: drive9 journal <new|append|cat|find|verify>"
 }
 
 func JournalNew(args []string) error {

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -31,7 +31,11 @@ const (
 // rationale on fail-loud > silent-drop.
 func Secret(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage drive9 vault <set|get|put|with|ls|rm|grant|revoke|audit>")
+		return fmt.Errorf("%s", vaultUsage())
+	}
+	if IsHelpArg(args[0]) {
+		_, _ = fmt.Fprintln(os.Stdout, vaultUsage())
+		return nil
 	}
 	switch args[0] {
 	case "set":
@@ -52,11 +56,13 @@ func Secret(args []string) error {
 		return SecretRevoke(args[1:])
 	case "audit":
 		return SecretAudit(args[1:])
-	case "-h", "--help", "help":
-		return fmt.Errorf("usage drive9 vault <set|get|put|with|ls|rm|grant|revoke|audit>")
 	default:
 		return fmt.Errorf("unknown vault command %q", args[0])
 	}
+}
+
+func vaultUsage() string {
+	return "usage drive9 vault <set|get|put|with|ls|rm|grant|revoke|audit>"
 }
 
 // SecretSet creates a new secret. It deliberately does NOT update in place on

--- a/cmd/drive9/cli/token.go
+++ b/cmd/drive9/cli/token.go
@@ -18,6 +18,7 @@ import (
 // Per task #11 / Plan B consensus (#drive9:f2a8e33e):
 //   - `drive9 token issue`  — issue a scoped capability (server)
 //   - `drive9 token revoke` — revoke a scoped capability (server)
+//
 // are the canonical token namespace operations.
 //
 // `drive9 token list` / `drive9 token forget` are kept as hidden
@@ -28,6 +29,10 @@ import (
 func Token(args []string) error {
 	if len(args) == 0 {
 		return tokenUsageErr()
+	}
+	if IsHelpArg(args[0]) {
+		_, _ = fmt.Fprint(os.Stdout, tokenUsage())
+		return nil
 	}
 	switch args[0] {
 	case "issue":
@@ -47,9 +52,6 @@ func Token(args []string) error {
 		fmt.Fprintln(os.Stderr, "WARNING: `drive9 token forget` is deprecated; use `drive9 ctx rm <name>` instead.")
 		fmt.Fprintln(os.Stderr, "         This command will be removed in a future release.")
 		return Ctx(append([]string{"rm"}, args[1:]...))
-	case "-h", "-help", "--help", "help":
-		_, _ = fmt.Fprint(os.Stdout, tokenUsage())
-		return nil
 	default:
 		return fmt.Errorf("unknown token command %q\n%s", args[0], tokenUsage())
 	}

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -128,6 +128,8 @@ func TestDispatchSubcommandHelpShowsUsageWithoutFatalPrefix(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+
 			origExit := exitFunc
 			origStdout := os.Stdout
 			origStderr := os.Stderr
@@ -175,13 +177,13 @@ func TestDispatchSubcommandHelpShowsUsageWithoutFatalPrefix(t *testing.T) {
 			stderr := <-stderrDone
 
 			if len(exitCodes) != 0 {
-				t.Fatalf("exit codes = %v, want no fatal/usage exit", exitCodes)
+				t.Errorf("exit codes = %v, want no fatal/usage exit", exitCodes)
 			}
 			if !strings.HasPrefix(stdout, tc.firstLine) {
-				t.Fatalf("stdout = %q, want first line %q", stdout, tc.firstLine)
+				t.Errorf("stdout = %q, want first line %q", stdout, tc.firstLine)
 			}
 			if stderr != "" {
-				t.Fatalf("stderr = %q, want empty stderr for explicit help", stderr)
+				t.Errorf("stderr = %q, want empty stderr for explicit help", stderr)
 			}
 		})
 	}

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -95,6 +95,98 @@ func TestDispatchLongHelpFlagShowsUsage(t *testing.T) {
 	}
 }
 
+func TestDispatchSubcommandHelpShowsUsageWithoutFatalPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		cmd       string
+		args      []string
+		firstLine string
+	}{
+		{
+			name:      "ctx",
+			cmd:       "ctx",
+			args:      []string{"--help"},
+			firstLine: "usage: drive9 ctx <show|add|import|fork|ls|use|rm>",
+		},
+		{
+			name:      "ctx rm",
+			cmd:       "ctx",
+			args:      []string{"rm", "--help"},
+			firstLine: "usage: drive9 ctx rm <name>",
+		},
+		{
+			name:      "journal",
+			cmd:       "journal",
+			args:      []string{"--help"},
+			firstLine: "usage: drive9 journal <new|append|cat|find|verify>",
+		},
+		{
+			name:      "vault",
+			cmd:       "vault",
+			args:      []string{"--help"},
+			firstLine: "usage drive9 vault <set|get|put|with|ls|rm|grant|revoke|audit>",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			origExit := exitFunc
+			origStdout := os.Stdout
+			origStderr := os.Stderr
+			origStop := cpuProfileStop
+			t.Cleanup(func() {
+				exitFunc = origExit
+				os.Stdout = origStdout
+				os.Stderr = origStderr
+				cpuProfileStop = origStop
+			})
+			cpuProfileStop = func() {}
+
+			var exitCodes []int
+			exitFunc = func(code int) { exitCodes = append(exitCodes, code) }
+
+			stdoutR, stdoutW, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("stdout pipe: %v", err)
+			}
+			stderrR, stderrW, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("stderr pipe: %v", err)
+			}
+			os.Stdout = stdoutW
+			os.Stderr = stderrW
+
+			stdoutDone := make(chan string, 1)
+			stderrDone := make(chan string, 1)
+			go func() {
+				var buf bytes.Buffer
+				_, _ = io.Copy(&buf, stdoutR)
+				stdoutDone <- buf.String()
+			}()
+			go func() {
+				var buf bytes.Buffer
+				_, _ = io.Copy(&buf, stderrR)
+				stderrDone <- buf.String()
+			}()
+
+			dispatch(tc.cmd, tc.args)
+
+			_ = stdoutW.Close()
+			_ = stderrW.Close()
+			stdout := <-stdoutDone
+			stderr := <-stderrDone
+
+			if len(exitCodes) != 0 {
+				t.Fatalf("exit codes = %v, want no fatal/usage exit", exitCodes)
+			}
+			if !strings.HasPrefix(stdout, tc.firstLine) {
+				t.Fatalf("stdout = %q, want first line %q", stdout, tc.firstLine)
+			}
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty stderr for explicit help", stderr)
+			}
+		})
+	}
+}
+
 // V2b: `drive9 vault <sub>` MUST route to the vault handler with args forwarded
 // verbatim (no shell parsing, no arg mangling). This is the positive half of
 // the hard-cut contract: the new verb name is live.


### PR DESCRIPTION
## Summary
- Treat explicit CLI help args as success paths for ctx, ctx rm, journal, and vault.
- Add shared help-arg detection and dispatch-level regression coverage.

Fixes #456

## Tests
- go test ./cmd/drive9 ./cmd/drive9/cli
- make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent immediate help handling across CLI commands so requesting help prints usage text (no errors).
  * Improved behavior for context removal: names that look like flags (e.g., -foo, --help, help) are handled correctly and can be removed; clearer unknown-subcommand messages.

* **Tests**
  * Added tests ensuring help displays usage without fatal errors and ctx rm handles dash- and help-like names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->