### PR TITLE
feat: add symlink support

### DIFF
--- a/cmd/drive9/cli/cp_recursive.go
+++ b/cmd/drive9/cli/cp_recursive.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/mem9-ai/dat9/pkg/client"
 )
@@ -184,6 +185,9 @@ func copyTreeRemoteToLocal(ctx context.Context, c *client.Client, srcRemote, dst
 		files []remoteFileEntry // relative paths to download
 	)
 	walkErr := walkRemoteTreeBFS(ctx, c, srcRemote, func(rel string, info client.FileInfo) error {
+		if remoteInfoIsSymlink(info) {
+			return fmt.Errorf("recursive copy does not support symlinks yet (path: %s)", rel)
+		}
 		if info.IsDir {
 			dirs = append(dirs, remoteDirEntry{rel: rel})
 			return nil
@@ -288,6 +292,9 @@ func copyTreeRemoteToRemote(ctx context.Context, c *client.Client, srcRemote, ds
 		files []remoteCopyPlanItem // src+dst pairs
 	)
 	walkErr := walkRemoteTreeBFS(ctx, c, srcRemote, func(rel string, info client.FileInfo) error {
+		if remoteInfoIsSymlink(info) {
+			return fmt.Errorf("recursive copy does not support symlinks yet (path: %s)", rel)
+		}
 		dstPath, joinErr := joinRemoteSafe(dstRemote, rel)
 		if joinErr != nil {
 			return joinErr
@@ -571,6 +578,10 @@ func walkRemoteTreeBFS(ctx context.Context, c *client.Client, root string, visit
 		}
 	}
 	return nil
+}
+
+func remoteInfoIsSymlink(info client.FileInfo) bool {
+	return info.HasMode && info.Mode&uint32(syscall.S_IFMT) == uint32(syscall.S_IFLNK)
 }
 
 // uploadOneFile streams a single local file to the remote destination.

--- a/cmd/drive9/cli/cp_recursive_test.go
+++ b/cmd/drive9/cli/cp_recursive_test.go
@@ -394,13 +394,16 @@ func TestCpRecursiveRemoteToLocal_RejectsSymlinkInTree(t *testing.T) {
 	c := client.New(srv.URL, "")
 	err := Cp(c, []string{"-r", ":/src", dstLocal})
 	if err == nil {
-		t.Fatal("expected remote symlink reject error, got nil")
+		t.Error("expected remote symlink reject error, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "symlink") {
-		t.Fatalf("error = %v, want 'symlink' message", err)
+		t.Errorf("error = %v, want 'symlink' message", err)
+		return
 	}
 	if _, statErr := os.Lstat(dstLocal); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("local destination should not be created after symlink reject, stat err=%v", statErr)
+		t.Errorf("local destination should not be created after symlink reject, stat err=%v", statErr)
+		return
 	}
 }
 
@@ -421,16 +424,20 @@ func TestCpRecursiveRemoteToRemote_RejectsSymlinkInTree(t *testing.T) {
 	c := client.New(srv.URL, "")
 	err := Cp(c, []string{"-r", ":/src", ":/dst"})
 	if err == nil {
-		t.Fatal("expected remote symlink reject error, got nil")
+		t.Error("expected remote symlink reject error, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "symlink") {
-		t.Fatalf("error = %v, want 'symlink' message", err)
+		t.Errorf("error = %v, want 'symlink' message", err)
+		return
 	}
 	if len(mock.recordedCopies) > 0 {
-		t.Fatalf("expected no remote copies before symlink reject, got %v", mock.recordedCopies)
+		t.Errorf("expected no remote copies before symlink reject, got %v", mock.recordedCopies)
+		return
 	}
 	if len(mock.recordedMkdirs) > 0 {
-		t.Fatalf("expected no remote mkdirs before symlink reject, got %v", mock.recordedMkdirs)
+		t.Errorf("expected no remote mkdirs before symlink reject, got %v", mock.recordedMkdirs)
+		return
 	}
 }
 

--- a/cmd/drive9/cli/cp_recursive_test.go
+++ b/cmd/drive9/cli/cp_recursive_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/mem9-ai/dat9/pkg/client"
@@ -55,9 +57,12 @@ type mockTreeServer struct {
 
 func newMockTreeServer() *mockTreeServer {
 	return &mockTreeServer{
-		existing:     map[string]bool{},
-		listEntries:  map[string][]client.FileInfo{},
-		statResults:  map[string]struct{ exists, isDir bool; size int64 }{},
+		existing:    map[string]bool{},
+		listEntries: map[string][]client.FileInfo{},
+		statResults: map[string]struct {
+			exists, isDir bool
+			size          int64
+		}{},
 		fileBodies:   map[string][]byte{},
 		recordedPuts: map[string][]byte{},
 	}
@@ -117,7 +122,8 @@ func (m *mockTreeServer) httpServer(t *testing.T) *httptest.Server {
 					"name":    e.Name,
 					"size":    e.Size,
 					"isDir":   e.IsDir,
-					"hasMode": false,
+					"mode":    e.Mode,
+					"hasMode": e.HasMode,
 				}
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"entries": out})
@@ -368,6 +374,66 @@ func TestCpRecursiveLocalToRemote_RejectsSymlinkInTree(t *testing.T) {
 	}
 }
 
+func TestCpRecursiveRemoteToLocal_RejectsSymlinkInTree(t *testing.T) {
+	mock := newMockTreeServer()
+	mock.statResults["/src"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: true}
+	mock.listEntries["/src"] = []client.FileInfo{
+		{Name: "target.txt", Size: 5, IsDir: false},
+		{Name: "link", Size: 10, IsDir: false, HasMode: true, Mode: uint32(syscall.S_IFLNK) | 0o777},
+	}
+	mock.fileBodies["/src/target.txt"] = []byte("alpha")
+
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	dstLocal := filepath.Join(t.TempDir(), "dst")
+	c := client.New(srv.URL, "")
+	err := Cp(c, []string{"-r", ":/src", dstLocal})
+	if err == nil {
+		t.Fatal("expected remote symlink reject error, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error = %v, want 'symlink' message", err)
+	}
+	if _, statErr := os.Lstat(dstLocal); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("local destination should not be created after symlink reject, stat err=%v", statErr)
+	}
+}
+
+func TestCpRecursiveRemoteToRemote_RejectsSymlinkInTree(t *testing.T) {
+	mock := newMockTreeServer()
+	mock.statResults["/src"] = struct {
+		exists bool
+		isDir  bool
+		size   int64
+	}{exists: true, isDir: true}
+	mock.listEntries["/src"] = []client.FileInfo{
+		{Name: "link", Size: 10, IsDir: false, HasMode: true, Mode: uint32(syscall.S_IFLNK) | 0o777},
+	}
+
+	srv := mock.httpServer(t)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	err := Cp(c, []string{"-r", ":/src", ":/dst"})
+	if err == nil {
+		t.Fatal("expected remote symlink reject error, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error = %v, want 'symlink' message", err)
+	}
+	if len(mock.recordedCopies) > 0 {
+		t.Fatalf("expected no remote copies before symlink reject, got %v", mock.recordedCopies)
+	}
+	if len(mock.recordedMkdirs) > 0 {
+		t.Fatalf("expected no remote mkdirs before symlink reject, got %v", mock.recordedMkdirs)
+	}
+}
+
 // ───────────────────────── Constraint #3: preflight then runtime semantics ─────────────────────────
 
 // TestCpRecursiveLocalToRemote_RuntimePartialFailureSurfacesError
@@ -600,7 +666,10 @@ func TestCpRecursive_RejectsFileSource(t *testing.T) {
 func TestCpRecursiveRemoteToRemote_UsesServerSideCopyPerLeaf(t *testing.T) {
 	mock := newMockTreeServer()
 	// Source tree on the remote: /src is a dir with two files.
-	mock.statResults["/src"] = struct{ exists, isDir bool; size int64 }{exists: true, isDir: true}
+	mock.statResults["/src"] = struct {
+		exists, isDir bool
+		size          int64
+	}{exists: true, isDir: true}
 	mock.listEntries["/src"] = []client.FileInfo{
 		{Name: "a.txt", Size: 5, IsDir: false},
 		{Name: "sub", Size: 0, IsDir: true},

--- a/cmd/drive9/cli/symlink.go
+++ b/cmd/drive9/cli/symlink.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+// Symlink creates a remote symbolic link.
+//
+//	drive9 fs symlink ../target link
+//	drive9 fs symlink /target :/link
+//	drive9 fs symlink ctx:/target ctx:/link
+func Symlink(c *client.Client, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("usage: drive9 fs symlink <target> <link>")
+	}
+	target := args[0]
+	linkPath := args[1]
+	linkRP, linkIsRemote := ParseRemote(linkPath)
+
+	target, err := symlinkTargetForCLI(target, linkRP, linkIsRemote)
+	if err != nil {
+		return err
+	}
+	c, linkPath, _, _, err = fsClientForRemoteArg(c, linkPath)
+	if err != nil {
+		return err
+	}
+	return c.Symlink(target, linkPath)
+}
+
+func symlinkTargetForCLI(target string, linkRP RemotePath, linkIsRemote bool) (string, error) {
+	targetRP, targetIsRemote := ParseRemote(target)
+	if !targetIsRemote {
+		return target, nil
+	}
+	if targetRP.Context == "" {
+		return targetRP.Path, nil
+	}
+	if !linkIsRemote || linkRP.Context == "" {
+		return "", fmt.Errorf("symlink target context %q requires link path to use the same context prefix", targetRP.Context)
+	}
+	if linkRP.Context != targetRP.Context {
+		return "", fmt.Errorf("cross-context symlink not supported: target context %q, link context %q", targetRP.Context, linkRP.Context)
+	}
+	return targetRP.Path, nil
+}

--- a/cmd/drive9/cli/symlink_test.go
+++ b/cmd/drive9/cli/symlink_test.go
@@ -1,0 +1,169 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+func TestSymlink(t *testing.T) {
+	t.Run("creates_link", func(t *testing.T) {
+		var gotMethod string
+		var gotPath string
+		var gotSymlink bool
+		var gotTarget string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			gotSymlink = r.URL.Query().Has("symlink")
+			var req struct {
+				Target string `json:"target"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode request body: %v", err)
+			}
+			gotTarget = req.Target
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		if err := Symlink(c, []string{"../target.txt", "/link"}); err != nil {
+			t.Fatalf("Symlink error = %v", err)
+		}
+		if gotMethod != http.MethodPost {
+			t.Fatalf("method = %q, want POST", gotMethod)
+		}
+		if gotPath != "/v1/fs/link" {
+			t.Fatalf("path = %q, want /v1/fs/link", gotPath)
+		}
+		if !gotSymlink {
+			t.Fatal("missing ?symlink query parameter")
+		}
+		if gotTarget != "../target.txt" {
+			t.Fatalf("target = %q, want ../target.txt", gotTarget)
+		}
+	})
+
+	t.Run("remote_path_prefix", func(t *testing.T) {
+		var gotPath string
+		var gotTarget string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			var req struct {
+				Target string `json:"target"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode request body: %v", err)
+			}
+			gotTarget = req.Target
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		if err := Symlink(c, []string{":/target.txt", ":/workspace/link"}); err != nil {
+			t.Fatalf("Symlink(remote) error = %v", err)
+		}
+		if gotPath != "/v1/fs/workspace/link" {
+			t.Fatalf("path = %q, want /v1/fs/workspace/link", gotPath)
+		}
+		if gotTarget != "/target.txt" {
+			t.Fatalf("target = %q, want /target.txt", gotTarget)
+		}
+	})
+}
+
+func TestSymlinkTargetForCLI(t *testing.T) {
+	tests := []struct {
+		name       string
+		target     string
+		linkRP     RemotePath
+		linkRemote bool
+		want       string
+		wantErr    string
+	}{
+		{
+			name:   "relative_literal",
+			target: "../target",
+			want:   "../target",
+		},
+		{
+			name:       "current_context_remote_shorthand",
+			target:     ":/target",
+			linkRemote: true,
+			linkRP:     RemotePath{Path: "/link"},
+			want:       "/target",
+		},
+		{
+			name:       "same_named_context",
+			target:     "ctx:/target",
+			linkRemote: true,
+			linkRP:     RemotePath{Context: "ctx", Path: "/link"},
+			want:       "/target",
+		},
+		{
+			name:       "cross_named_context",
+			target:     "other:/target",
+			linkRemote: true,
+			linkRP:     RemotePath{Context: "ctx", Path: "/link"},
+			wantErr:    "cross-context symlink not supported",
+		},
+		{
+			name:    "named_target_without_named_link",
+			target:  "ctx:/target",
+			wantErr: "requires link path to use the same context prefix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := symlinkTargetForCLI(tt.target, tt.linkRP, tt.linkRemote)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("target = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSymlinkUsageErrors(t *testing.T) {
+	c := client.New("http://example.invalid", "")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"no_args", nil},
+		{"one_arg", []string{"/target"}},
+		{"too_many_args", []string{"/target", "/link", "/extra"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Symlink(c, tt.args)
+			if err == nil {
+				t.Fatal("expected usage error")
+			}
+			if !strings.Contains(err.Error(), "usage: drive9 fs symlink") {
+				t.Fatalf("error = %q, want usage message", err.Error())
+			}
+		})
+	}
+}

--- a/cmd/drive9/cli/symlink_test.go
+++ b/cmd/drive9/cli/symlink_test.go
@@ -14,13 +14,13 @@ func TestSymlink(t *testing.T) {
 	t.Run("creates_link", func(t *testing.T) {
 		var gotMethod string
 		var gotPath string
-		var gotSymlink bool
+		var gotSymlink string
 		var gotTarget string
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotMethod = r.Method
 			gotPath = r.URL.Path
-			gotSymlink = r.URL.Query().Has("symlink")
+			gotSymlink = r.URL.Query().Get("symlink")
 			var req struct {
 				Target string `json:"target"`
 			}
@@ -42,8 +42,8 @@ func TestSymlink(t *testing.T) {
 		if gotPath != "/v1/fs/link" {
 			t.Fatalf("path = %q, want /v1/fs/link", gotPath)
 		}
-		if !gotSymlink {
-			t.Fatal("missing ?symlink query parameter")
+		if gotSymlink != "1" {
+			t.Fatalf("symlink query = %q, want 1", gotSymlink)
 		}
 		if gotTarget != "../target.txt" {
 			t.Fatalf("target = %q, want ../target.txt", gotTarget)
@@ -52,10 +52,12 @@ func TestSymlink(t *testing.T) {
 
 	t.Run("remote_path_prefix", func(t *testing.T) {
 		var gotPath string
+		var gotSymlink string
 		var gotTarget string
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotPath = r.URL.Path
+			gotSymlink = r.URL.Query().Get("symlink")
 			var req struct {
 				Target string `json:"target"`
 			}
@@ -73,6 +75,9 @@ func TestSymlink(t *testing.T) {
 		}
 		if gotPath != "/v1/fs/workspace/link" {
 			t.Fatalf("path = %q, want /v1/fs/workspace/link", gotPath)
+		}
+		if gotSymlink != "1" {
+			t.Fatalf("symlink query = %q, want 1", gotSymlink)
 		}
 		if gotTarget != "/target.txt" {
 			t.Fatalf("target = %q, want /target.txt", gotTarget)

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -8,7 +8,8 @@
 //
 //	create  provision a new database and owner context
 //	ctx     manage contexts (show, add, import, fork, ls, use, rm)
-//	fs      filesystem operations (cp, cat, ls, stat, mv, rm, sh, grep, find)
+//	fs      filesystem operations (cp, cat, ls, stat, mv, rm, mkdir, chmod,
+//	        symlink, sh, grep, find)
 //	token  issue and revoke workspace-zone scoped filesystem tokens
 //	vault   vault operations (set, get, put, with, ls, rm, grant, revoke, audit)
 //	journal append-only agent/workflow journal operations
@@ -256,6 +257,8 @@ func runFS(args []string) {
 		err = cli.Mkdir(c, rest)
 	case "chmod":
 		err = cli.Chmod(c, rest)
+	case "symlink":
+		err = cli.Symlink(c, rest)
 	case "sh":
 		err = cli.Sh(c, rest)
 	case "grep":
@@ -343,6 +346,8 @@ commands:
   mv <old> <new>      rename/move
   mkdir <path>        create directory (parents auto-created)
   chmod <mode> <path>  change file permissions (octal, e.g. 644)
+  symlink <target> <link>
+                       create symbolic link
   rm [-r|--recursive] <path>
                        remove file or directory tree
   sh                  interactive shell

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -155,7 +155,7 @@ use the same value as `DRIVE9_API_KEY` here.
 1. Provision + readiness polling
 2. Prepare `drive9` CLI binary (build local or download official release)
 3. CLI fork flow (`ctx add`, `ctx fork`, fork readiness polling, fork-context file read/write, fork delete)
-4. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `rm`)
+4. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `symlink`, `rm`)
 5. CLI `cp` directory-target semantics (local->remote dir, remote->local dir, remote->remote dir all preserve source basename)
 6. CLI batch small-file flow (`cp` many files + dir list count + stat + sample reads)
 7. CLI search flow (`fs grep`, `fs find`)
@@ -186,7 +186,7 @@ script is not a supported Windows validation path.
 2. Prepare `drive9` CLI binary (build local or download official release)
 3. Mount compatibility precheck for root `ls /`
 4. RW mount lifecycle (`drive9 mount`, `drive9 umount`)
-5. File semantics (`create`, `read`, `overwrite`, `append`, `truncate`, `unlink`)
+5. File semantics (`create`, `read`, `overwrite`, `append`, `symlink`, `truncate`, `unlink`)
 6. Directory semantics (`mkdir`, nested paths, `readdir`, empty/non-empty `rmdir`)
 7. Rename semantics (file + directory rename consistency)
 8. Attribute semantics (`size`, `mtime` monotonicity, remote stat parity)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,8 +15,8 @@ including local single-tenant validation via `drive9-server-local`.
 |--------|--------------------|
 | `api-smoke-test.sh` | Fresh provisioning, status polling, nested+batch file ops, grep/find checks, semantic text recall, image-associated recall, sql checks, large multipart upload+download |
 | `api-smoke-test-existing-key.sh` | Existing API key status/list checks |
-| `cli-smoke-test.sh` | End-to-end CLI workflow including `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
-| `fuse-smoke-test.sh` | FUSE mount lifecycle, file/dir/rename/stat semantics, cross-channel consistency, read-only and error-path checks |
+| `cli-smoke-test.sh` | End-to-end CLI workflow including `fs symlink`, `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
+| `fuse-smoke-test.sh` | FUSE mount lifecycle, file/dir/symlink/rename/stat semantics, cross-channel consistency, read-only and error-path checks |
 | `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, and mount-log audit |
 | `posix-permission-smoke-test.sh` | POSIX permission coverage: API mkdir/chmod mode propagation, CLI `fs chmod`, FUSE `chmod`/`mkdir -m` with remote and local stat parity |
 | `smoke-all.sh` | Runs API + CLI + FUSE + POSIX permission smoke scripts in sequence with aggregated pass/fail |

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -416,14 +416,21 @@ PY
 check_eq "mv renames remote file" "$renamed_present" "true"
 
 drive9_retry fs symlink ":$SMALL_RENAMED" ":$SMALL_SYMLINK" >/dev/null
-symlink_ls="$(drive9_retry fs ls /)"
-symlink_present=$(python3 - "$symlink_ls" "$(basename "$SMALL_SYMLINK")" <<'PY'
+symlink_present="false"
+for _ in $(seq 1 "$CLI_MAX_RETRIES"); do
+  symlink_ls="$(drive9_retry fs ls /)"
+  symlink_present=$(python3 - "$symlink_ls" "$(basename "$SMALL_SYMLINK")" <<'PY'
 import sys
 out=sys.argv[1].splitlines()
 name=sys.argv[2]
 print("true" if any(line.strip()==name for line in out) else "false")
 PY
 )
+  if [[ "$symlink_present" == "true" ]]; then
+    break
+  fi
+  sleep "$CLI_RETRY_SLEEP_S"
+done
 check_eq "symlink appears in ls /" "$symlink_present" "true"
 
 symlink_target="$(drive9_retry_read fs cat "$SMALL_SYMLINK")"

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -296,6 +296,7 @@ CLI_CTX_HOME="$(mktemp -d)"
 SMALL_LOCAL="/tmp/drive9-cli-small-${TS}.txt"
 SMALL_REMOTE="/cli-${TS}-small.txt"
 SMALL_RENAMED="/cli-${TS}-small-renamed.txt"
+SMALL_SYMLINK="/cli-${TS}-small-link"
 CP_DIR_REMOTE="/cli-${TS}-cpdir"
 CP_DIR_REMOTE_COPY="/cli-${TS}-cpdir-copy"
 CP_DIR_LOCAL="/tmp/drive9-cli-cpdir-${TS}"
@@ -413,6 +414,20 @@ print("true" if any(line.strip()==name for line in out) else "false")
 PY
 )
 check_eq "mv renames remote file" "$renamed_present" "true"
+
+drive9_retry fs symlink ":$SMALL_RENAMED" ":$SMALL_SYMLINK" >/dev/null
+symlink_ls="$(drive9_retry fs ls /)"
+symlink_present=$(python3 - "$symlink_ls" "$(basename "$SMALL_SYMLINK")" <<'PY'
+import sys
+out=sys.argv[1].splitlines()
+name=sys.argv[2]
+print("true" if any(line.strip()==name for line in out) else "false")
+PY
+)
+check_eq "symlink appears in ls /" "$symlink_present" "true"
+
+symlink_target="$(drive9_retry_read fs cat "$SMALL_SYMLINK")"
+check_eq "cat symlink returns target payload" "$symlink_target" "$SMALL_RENAMED"
 
 echo "[4.1] cli tag/stat metadata checks"
 printf "cli-tag-%s" "$TS" > "$TAG_LOCAL"
@@ -564,6 +579,7 @@ sum_dst=$(sha256sum "$LARGE_DOWNLOADED" | cut -d' ' -f1)
 check_eq "downloaded large file sha256 matches" "$sum_dst" "$sum_src"
 
 echo "[8] cleanup via cli"
+drive9_retry fs rm "$SMALL_SYMLINK" >/dev/null
 drive9_retry fs rm "$SMALL_RENAMED" >/dev/null
 drive9_retry fs rm "$TAG_REMOTE" >/dev/null
 if [ "$CLI_IMAGE_UPLOADED" = "1" ]; then

--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -650,6 +650,9 @@ RW_BETA_MOUNT="$RW_ALPHA_MOUNT/beta"
 RW_TEXT_REL="${RW_ALPHA_REL}/text.txt"
 RW_TEXT_REMOTE="/${RW_TEXT_REL}"
 RW_TEXT_MOUNT="$MOUNT_POINT/$RW_TEXT_REL"
+RW_SYMLINK_REL="${RW_ALPHA_REL}/text-link"
+RW_SYMLINK_REMOTE="/${RW_SYMLINK_REL}"
+RW_SYMLINK_MOUNT="$MOUNT_POINT/$RW_SYMLINK_REL"
 RW_TEXT_RENAMED_REL="${RW_ALPHA_REL}/text-renamed.txt"
 RW_TEXT_RENAMED_REMOTE="/${RW_TEXT_RENAMED_REL}"
 RW_TEXT_RENAMED_MOUNT="$MOUNT_POINT/$RW_TEXT_RENAMED_REL"
@@ -739,6 +742,25 @@ if is_mounted "$MOUNT_POINT"; then
   printf -- "-append" >> "$RW_TEXT_MOUNT"
   remote_append=$(wait_remote_cat_eq "$RW_TEXT_REMOTE" "overwrite-${TS}-append")
   check_eq "append visible via remote cat" "$remote_append" "overwrite-${TS}-append"
+
+  if ln -s "text.txt" "$RW_SYMLINK_MOUNT"; then
+    check_eq "symlink via mount succeeds" "true" "true"
+  else
+    check_eq "symlink via mount succeeds" "false" "true"
+  fi
+  check_cmd "symlink is visible as local link" test -L "$RW_SYMLINK_MOUNT"
+  if [ -L "$RW_SYMLINK_MOUNT" ]; then
+    link_target=$(readlink "$RW_SYMLINK_MOUNT")
+    symlink_cat=$(cat "$RW_SYMLINK_MOUNT")
+    remote_link_target=$(wait_remote_cat_eq "$RW_SYMLINK_REMOTE" "text.txt")
+  else
+    link_target=""
+    symlink_cat=""
+    remote_link_target=""
+  fi
+  check_eq "readlink returns symlink target" "$link_target" "text.txt"
+  check_eq "cat follows mounted symlink" "$symlink_cat" "overwrite-${TS}-append"
+  check_eq "remote cat returns symlink payload" "$remote_link_target" "text.txt"
 
   if : > "$RW_TEXT_MOUNT"; then
     check_eq "truncate via mount succeeds" "true" "true"

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -58,6 +58,9 @@ const (
 	// InlineThreshold: extraction can be tightened or relaxed without
 	// changing the storage-class boundary.
 	DefaultTextExtractMaxBytes int64 = 8_192
+
+	symlinkMode        uint32 = 0o120000 | 0o777
+	symlinkContentType        = "application/x-symlink"
 )
 
 // Dat9Backend implements filesystem.FileSystem with the inode model.
@@ -242,6 +245,64 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 		return err
 	}
 	b.syncCentralFileCreate(ctx, fileID, 0, "")
+	return nil
+}
+
+// CreateSymlinkCtx creates a symbolic link whose target is stored as the file
+// payload and whose inode mode carries the POSIX symlink file type bits.
+func (b *Dat9Backend) CreateSymlinkCtx(ctx context.Context, linkPath, target string) (err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "create_symlink", err, start) }()
+
+	if target == "" || strings.ContainsRune(target, 0) {
+		return ErrInvalidSymlinkTarget
+	}
+	linkPath, err = pathutil.Canonicalize(linkPath)
+	if err != nil {
+		return err
+	}
+
+	data := []byte(target)
+	if err := b.ensureUploadSizeAllowed(int64(len(data))); err != nil {
+		return err
+	}
+	fileID := b.genID()
+	now := time.Now()
+	checksum := sha256sum(data)
+
+	err = b.store.InTx(ctx, func(tx *sql.Tx) error {
+		if err := b.ensureStorageQuota(ctx, tx, linkPath, int64(len(data))); err != nil {
+			return err
+		}
+		if err := b.store.InsertFileTx(tx, &datastore.File{
+			FileID:                fileID,
+			StorageType:           datastore.StorageDB9,
+			StorageRef:            "inline",
+			StorageEncryptionMode: datastore.StorageEncryptionNone,
+			ContentBlob:           append([]byte(nil), data...),
+			ContentType:           symlinkContentType,
+			SizeBytes:             int64(len(data)),
+			ChecksumSHA256:        checksum,
+			Revision:              1,
+			Mode:                  symlinkMode,
+			Status:                datastore.StatusConfirmed,
+			CreatedAt:             now,
+			ConfirmedAt:           &now,
+		}); err != nil {
+			return err
+		}
+		if err := b.store.EnsureParentDirsTx(tx, linkPath, b.genID); err != nil {
+			return err
+		}
+		return b.store.InsertNodeTx(tx, &datastore.FileNode{
+			NodeID: b.genID(), Path: linkPath, ParentPath: pathutil.ParentPath(linkPath),
+			Name: pathutil.BaseName(linkPath), FileID: fileID, CreatedAt: now,
+		})
+	})
+	if err != nil {
+		return err
+	}
+	b.syncCentralFileCreate(ctx, fileID, int64(len(data)), symlinkContentType)
 	return nil
 }
 

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -59,6 +59,10 @@ const (
 	// changing the storage-class boundary.
 	DefaultTextExtractMaxBytes int64 = 8_192
 
+	// MaxSymlinkTargetBytes bounds symbolic link targets to a path-sized inline
+	// payload instead of allowing generic upload-sized blobs.
+	MaxSymlinkTargetBytes = 4 << 10
+
 	symlinkMode        uint32 = 0o120000 | 0o777
 	symlinkContentType        = "application/x-symlink"
 )
@@ -254,7 +258,8 @@ func (b *Dat9Backend) CreateSymlinkCtx(ctx context.Context, linkPath, target str
 	start := time.Now()
 	defer func() { observeBackend(ctx, "create_symlink", err, start) }()
 
-	if target == "" || strings.ContainsRune(target, 0) {
+	data := []byte(target)
+	if target == "" || strings.ContainsRune(target, 0) || len(data) > MaxSymlinkTargetBytes {
 		return ErrInvalidSymlinkTarget
 	}
 	linkPath, err = pathutil.Canonicalize(linkPath)
@@ -262,7 +267,6 @@ func (b *Dat9Backend) CreateSymlinkCtx(ctx context.Context, linkPath, target str
 		return err
 	}
 
-	data := []byte(target)
 	if err := b.ensureUploadSizeAllowed(int64(len(data))); err != nil {
 		return err
 	}

--- a/pkg/backend/errors.go
+++ b/pkg/backend/errors.go
@@ -10,3 +10,7 @@ var ErrS3NotConfigured = errors.New("S3 not configured")
 
 // ErrNotInlineStorage reports that an operation requires db9-inline file data.
 var ErrNotInlineStorage = errors.New("file is not stored inline")
+
+// ErrInvalidSymlinkTarget reports that a symbolic link target is empty or
+// contains bytes that cannot be represented by the FUSE symlink contract.
+var ErrInvalidSymlinkTarget = errors.New("invalid symlink target")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -506,6 +506,33 @@ func (c *Client) CreateFileCtx(ctx context.Context, path string) (int64, error) 
 	return result.Revision, nil
 }
 
+// Symlink creates a symbolic link at linkPath pointing to target.
+func (c *Client) Symlink(target, linkPath string) error {
+	return c.SymlinkCtx(context.Background(), target, linkPath)
+}
+
+// SymlinkCtx creates a symbolic link with context support.
+func (c *Client) SymlinkCtx(ctx context.Context, target, linkPath string) error {
+	body, err := json.Marshal(map[string]string{"target": target})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(linkPath)+"?symlink=1", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return readError(resp)
+	}
+	return nil
+}
+
 func (c *Client) writeCtxConditionalFull(ctx context.Context, path string, data []byte, expectedRevision int64, tags map[string]string, description string) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(path), bytes.NewReader(data))
 	if err != nil {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -610,6 +610,60 @@ func TestCreateFileCtxReturnsMalformedJSONError(t *testing.T) {
 	}
 }
 
+func TestSymlinkCtxPostsSymlinkAction(t *testing.T) {
+	var gotTarget string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/fs/link" {
+			t.Errorf("path = %s, want /v1/fs/link", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("symlink"); got != "1" {
+			t.Errorf("symlink query = %q, want 1", got)
+		}
+		var req struct {
+			Target string `json:"target"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		gotTarget = req.Target
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	if err := c.SymlinkCtx(context.Background(), "../target", "/link"); err != nil {
+		t.Fatalf("SymlinkCtx error = %v", err)
+	}
+	if gotTarget != "../target" {
+		t.Fatalf("target = %q, want ../target", gotTarget)
+	}
+}
+
+func TestSymlinkCtxPreservesStatusError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		errJSON := map[string]string{"error": "already exists"}
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(errJSON)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	err := c.SymlinkCtx(context.Background(), "target", "/link")
+	if err == nil {
+		t.Fatal("SymlinkCtx error = nil, want conflict")
+	}
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("SymlinkCtx error type = %T, want *StatusError", err)
+	}
+	if statusErr.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", statusErr.StatusCode)
+	}
+}
+
 func TestWriteCtxConditionalWithTagsRejectsInvalidHeaderTags(t *testing.T) {
 	requests := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1099,7 +1153,6 @@ func TestSmallFileThresholdOverrideShortCircuits(t *testing.T) {
 		t.Fatalf("override should short-circuit network; saw %d hits", hits)
 	}
 }
-
 
 func TestChmod(t *testing.T) {
 	c, cleanup := newTestClient(t)

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -44,6 +44,8 @@ const (
 	StorageS3  StorageType = "s3"
 )
 
+const fileTypeModeMask uint32 = 0o170000
+
 type StorageEncryptionMode string
 
 const (
@@ -974,7 +976,14 @@ func (s *Store) Chmod(ctx context.Context, path string, mode uint32) (err error)
 		return ErrNotFound
 	}
 
-	mode = mode & 0o777
+	var currentMode uint32
+	if err := s.db.QueryRowContext(ctx, `SELECT mode FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED'`, inodeID).Scan(&currentMode); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
+	mode = (mode & 0o777) | (currentMode & fileTypeModeMask)
 	res, err := s.db.ExecContext(ctx, `UPDATE inodes SET mode = ? WHERE inode_id = ? AND status = 'CONFIRMED'`, mode, inodeID)
 	if err != nil {
 		return err

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -1162,6 +1162,41 @@ func TestChmod(t *testing.T) {
 	}
 }
 
+func TestChmodPreservesFileTypeBits(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	if err := s.InsertFile(ctx, &File{
+		FileID:      "f1",
+		StorageType: StorageDB9,
+		StorageRef:  "/blobs/f1",
+		SizeBytes:   6,
+		Revision:    1,
+		Mode:        0o120777,
+		Status:      StatusConfirmed,
+		CreatedAt:   now,
+		ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(ctx, &FileNode{NodeID: "n1", Path: "/link", ParentPath: "/", Name: "link", FileID: "f1", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Chmod(ctx, "/link", 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetFile(ctx, "f1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Mode != 0o120600 {
+		t.Errorf("mode=%o, want 0o120600", got.Mode)
+	}
+}
+
 func TestChmodNotFound(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -803,16 +803,53 @@ func (fs *Dat9FS) fillAttr(entry *InodeEntry, out *gofuse.Attr) {
 		if !entry.HasMode {
 			mode = 0755
 		}
-		out.Mode = syscall.S_IFDIR | mode
+		out.Mode = syscall.S_IFDIR | (mode & 0o777)
 		out.Nlink = 2
+	} else if entryIsSymlink(entry) {
+		mode := entry.Mode & 0o777
+		if !entry.HasMode {
+			mode = 0o777
+		}
+		out.Mode = uint32(syscall.S_IFLNK) | mode
+		out.Nlink = 1
 	} else {
 		mode := entry.Mode
 		if !entry.HasMode {
 			mode = 0644
 		}
-		out.Mode = syscall.S_IFREG | mode
+		out.Mode = syscall.S_IFREG | (mode & 0o777)
 		out.Nlink = 1
 	}
+}
+
+func isSymlinkMode(mode uint32) bool {
+	return mode&uint32(syscall.S_IFMT) == uint32(syscall.S_IFLNK)
+}
+
+func entryIsSymlink(entry *InodeEntry) bool {
+	return entry != nil && !entry.IsDir && entry.HasMode && isSymlinkMode(entry.Mode)
+}
+
+func dirEntryMode(isDir, hasMode bool, mode uint32) uint32 {
+	if isDir {
+		perm := uint32(0o755)
+		if hasMode {
+			perm = mode & 0o777
+		}
+		return uint32(syscall.S_IFDIR) | perm
+	}
+	perm := uint32(0o644)
+	if hasMode {
+		perm = mode & 0o777
+	}
+	if hasMode && isSymlinkMode(mode) {
+		return uint32(syscall.S_IFLNK) | perm
+	}
+	return uint32(syscall.S_IFREG) | perm
+}
+
+func symlinkMode() uint32 {
+	return uint32(syscall.S_IFLNK) | 0o777
 }
 
 func (fs *Dat9FS) fillEntryOut(entry *InodeEntry, out *gofuse.EntryOut) {
@@ -1984,6 +2021,11 @@ func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *
 			if stat.Revision > 0 {
 				fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
 			}
+			if stat.HasMode {
+				entry.Mode = stat.Mode
+				entry.HasMode = true
+				fs.inodes.UpdateMode(input.NodeId, stat.Mode)
+			}
 			if !stat.Mtime.IsZero() {
 				entry.Mtime = stat.Mtime
 				fs.inodes.UpdateMtime(input.NodeId, stat.Mtime)
@@ -2002,6 +2044,11 @@ func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *
 			fs.inodes.UpdateSize(input.NodeId, stat.Size)
 			if stat.Revision > 0 {
 				fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
+			}
+			if stat.HasMode {
+				entry.Mode = stat.Mode
+				entry.HasMode = true
+				fs.inodes.UpdateMode(input.NodeId, stat.Mode)
 			}
 			if !stat.Mtime.IsZero() {
 				entry.Mtime = stat.Mtime
@@ -2032,6 +2079,10 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 	// Handle mode (chmod)
 	if input.Valid&gofuse.FATTR_MODE != 0 {
 		mode := input.Mode & 0777
+		entryMode := mode
+		if entryIsSymlink(entry) {
+			entryMode |= uint32(syscall.S_IFLNK)
+		}
 		// If the file has an open dirty handle, update mode locally without
 		// consulting the remote server. The mode will be synced on Flush.
 		// Use a single ForEach pass to avoid a TOCTOU race between the check
@@ -2055,8 +2106,8 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 				return httpToFuseStatus(err)
 			}
 		}
-		entry.Mode = mode
-		fs.inodes.UpdateMode(input.NodeId, mode)
+		entry.Mode = entryMode
+		fs.inodes.UpdateMode(input.NodeId, entryMode)
 	}
 
 	// Handle truncate
@@ -2130,6 +2181,29 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 	return gofuse.OK
 }
 
+func (fs *Dat9FS) Readlink(cancel <-chan struct{}, header *gofuse.InHeader) (out []byte, status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseReadlink, perfStart, status, uint64(len(out))) }()
+
+	entry, ok := fs.inodes.GetEntry(header.NodeId)
+	if !ok {
+		return nil, gofuse.ENOENT
+	}
+	if !entryIsSymlink(entry) {
+		return nil, gofuse.Status(syscall.EINVAL)
+	}
+
+	ctx, cf := fuseCtx(cancel)
+	defer cf()
+	readStart := fs.perfStart()
+	target, err := fs.client.ReadCtx(ctx, fs.remotePath(entry.Path))
+	fs.perfRecordRemote(perfRemoteRead, readStart, err, uint64(len(target)))
+	if err != nil {
+		return nil, httpToFuseStatus(err)
+	}
+	return target, gofuse.OK
+}
+
 // --- Directory operations ----------------------------------------------------
 
 func (fs *Dat9FS) Mkdir(cancel <-chan struct{}, input *gofuse.MkdirIn, name string, out *gofuse.EntryOut) (status gofuse.Status) {
@@ -2158,6 +2232,55 @@ func (fs *Dat9FS) Mkdir(cancel <-chan struct{}, input *gofuse.MkdirIn, name stri
 	// Kernel already receives the new entry via the Mkdir reply —
 	// no need for notifyEntry/notifyInode here.
 
+	fs.fillEntryOut(entry, out)
+	return gofuse.OK
+}
+
+func (fs *Dat9FS) Symlink(cancel <-chan struct{}, header *gofuse.InHeader, pointedTo string, linkName string, out *gofuse.EntryOut) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseSymlink, perfStart, status, 0) }()
+	if fs.opts.ReadOnly {
+		return gofuse.EROFS
+	}
+
+	childP, st := fs.childPath(header.NodeId, linkName)
+	if st != gofuse.OK {
+		return st
+	}
+
+	ctx, cf := fuseCtx(cancel)
+	defer cf()
+	mutationStart := fs.perfStart()
+	err := fs.client.SymlinkCtx(ctx, pointedTo, fs.remotePath(childP))
+	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
+	if err != nil {
+		return httpToFuseStatus(err)
+	}
+
+	mode := symlinkMode()
+	ino := fs.inodes.Lookup(childP, false, int64(len(pointedTo)), time.Now())
+	fs.inodes.UpdateMode(ino, mode)
+	if stat, err := fs.client.StatCtx(ctx, fs.remotePath(childP)); err == nil && stat != nil {
+		if stat.Revision > 0 {
+			fs.inodes.UpdateRevision(ino, stat.Revision)
+		}
+		if !stat.Mtime.IsZero() {
+			fs.inodes.UpdateMtime(ino, stat.Mtime)
+		}
+		if stat.HasMode {
+			fs.inodes.UpdateMode(ino, stat.Mode)
+		}
+	} else if err != nil && !isNotFoundErr(err) {
+		log.Printf("post-symlink stat refresh failed for %s: %v", childP, err)
+	}
+
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		return gofuse.EIO
+	}
+	parentPath, _ := fs.inodes.GetPath(header.NodeId)
+	fs.dirCache.Upsert(parentPath, cachedInfoFromEntry(linkName, entry))
+	fs.invalidateReadCacheAndTargets(childP)
 	fs.fillEntryOut(entry, out)
 	return gofuse.OK
 }
@@ -2900,19 +3023,10 @@ func (fs *Dat9FS) cachedToDirEntries(dirPath string, items []CachedFileInfo) []D
 			fs.inodes.UpdateMode(ino, item.Mode)
 		}
 
-		var mode uint32
-		if item.IsDir {
-			mode = syscall.S_IFDIR
-		} else {
-			mode = syscall.S_IFREG
-		}
-		if item.HasMode {
-			mode |= item.Mode & 0o777
-		}
 		entries = append(entries, DirEntry{
 			Name: item.Name,
 			Ino:  ino,
-			Mode: mode,
+			Mode: dirEntryMode(item.IsDir, item.HasMode, item.Mode),
 		})
 	}
 	return entries
@@ -3021,6 +3135,9 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 	}
 	entry, _ := fs.inodes.GetEntry(input.NodeId)
 	if entry != nil {
+		if entryIsSymlink(entry) {
+			return gofuse.Status(syscall.ELOOP)
+		}
 		fh.OrigSize = entry.Size
 		fh.BaseRev = entry.Revision
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2195,10 +2195,11 @@ func (fs *Dat9FS) Readlink(cancel <-chan struct{}, header *gofuse.InHeader) (out
 
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
-	readStart := fs.perfStart()
-	target, err := fs.client.ReadCtx(ctx, fs.remotePath(entry.Path))
-	fs.perfRecordRemote(perfRemoteRead, readStart, err, uint64(len(target)))
+	target, err := fs.readSmallFileWithRetry(ctx, entry.Path)
 	if err != nil {
+		if errors.Is(err, errReadRetriesExhausted) {
+			return nil, gofuse.EIO
+		}
 		return nil, httpToFuseStatus(err)
 	}
 	return target, gofuse.OK
@@ -2253,6 +2254,15 @@ func (fs *Dat9FS) Symlink(cancel <-chan struct{}, header *gofuse.InHeader, point
 	mutationStart := fs.perfStart()
 	err := fs.client.SymlinkCtx(ctx, pointedTo, fs.remotePath(childP))
 	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
+	if err != nil {
+		if isTransientLookupErr(err) {
+			if exists, probeErr := fs.remotePathExistsDetached(childP); probeErr == nil && exists {
+				err = nil
+			} else if probeErr != nil {
+				log.Printf("symlink: probe created path %s failed: %v", childP, probeErr)
+			}
+		}
+	}
 	if err != nil {
 		return httpToFuseStatus(err)
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1515,6 +1515,15 @@ func (fs *Dat9FS) remotePathExistsDetached(localPath string) (bool, error) {
 	return false, err
 }
 
+func (fs *Dat9FS) remotePathStatDetached(localPath string) (*client.StatResult, error) {
+	retryCtx, retryCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+	defer retryCancel()
+	statStart := fs.perfStart()
+	stat, err := fs.client.StatCtx(retryCtx, fs.remotePath(localPath))
+	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
+	return stat, err
+}
+
 func (fs *Dat9FS) mkdirRemoteWithTransientRetry(cancel <-chan struct{}, localPath string, mode uint32) error {
 	apiPath := fs.remotePath(localPath)
 	ctx, cf := fuseCtx(cancel)
@@ -2256,10 +2265,13 @@ func (fs *Dat9FS) Symlink(cancel <-chan struct{}, header *gofuse.InHeader, point
 	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
 	if err != nil {
 		if isTransientLookupErr(err) {
-			if exists, probeErr := fs.remotePathExistsDetached(childP); probeErr == nil && exists {
+			stat, probeErr := fs.remotePathStatDetached(childP)
+			if probeErr == nil && stat != nil && stat.HasMode && isSymlinkMode(stat.Mode) {
 				err = nil
 			} else if probeErr != nil {
 				log.Printf("symlink: probe created path %s failed: %v", childP, probeErr)
+			} else if stat != nil {
+				log.Printf("symlink: recovered path %s is not a symlink (hasMode=%t mode=%o)", childP, stat.HasMode, stat.Mode)
 			}
 		}
 	}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1494,6 +1494,52 @@ func TestLookupRecognizesRemoteSymlinkMode(t *testing.T) {
 	}
 }
 
+func TestReadlinkRetriesTransientRead(t *testing.T) {
+	target := []byte("../target")
+	symlinkMode := uint32(syscall.S_IFLNK) | 0o777
+	var getCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(target)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Mode", strconv.FormatUint(uint64(symlinkMode), 10))
+			w.Header().Set("X-Dat9-Revision", "11")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if getCalls.Add(1) == 1 {
+				http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = w.Write(target)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "link", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+
+	got, st := fs.Readlink(nil, &gofuse.InHeader{NodeId: out.NodeId})
+	if st != gofuse.OK {
+		t.Fatalf("Readlink status = %v, want OK", st)
+	}
+	if string(got) != string(target) {
+		t.Fatalf("Readlink target = %q, want %q", got, target)
+	}
+	if calls := getCalls.Load(); calls < 2 {
+		t.Fatalf("GET calls = %d, want retry", calls)
+	}
+}
+
 func TestSymlinkCreatesRemoteLinkAndCachesEntry(t *testing.T) {
 	const target = "../target"
 	symlinkMode := uint32(syscall.S_IFLNK) | 0o777
@@ -1559,6 +1605,50 @@ func TestSymlinkCreatesRemoteLinkAndCachesEntry(t *testing.T) {
 	}
 	if string(got) != target {
 		t.Fatalf("Readlink target = %q, want %q", got, target)
+	}
+}
+
+func TestSymlinkRecoversWhenInterruptedAfterRemoteCreate(t *testing.T) {
+	const target = "../target"
+	symlinkMode := uint32(syscall.S_IFLNK) | 0o777
+	var postCalls atomic.Int32
+	var headCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs/link" && r.URL.RawQuery == "symlink=1":
+			postCalls.Add(1)
+			w.WriteHeader(statusClientClosedRequest)
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs/link":
+			headCalls.Add(1)
+			w.Header().Set("Content-Length", strconv.Itoa(len(target)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Mode", strconv.FormatUint(uint64(symlinkMode), 10))
+			w.Header().Set("X-Dat9-Revision", "12")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var out gofuse.EntryOut
+	st := fs.Symlink(nil, &gofuse.InHeader{NodeId: 1}, target, "link", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Symlink status = %v, want OK", st)
+	}
+	if got := postCalls.Load(); got != 1 {
+		t.Fatalf("POST calls = %d, want 1", got)
+	}
+	if got := headCalls.Load(); got == 0 {
+		t.Fatal("symlink retry did not probe created path")
+	}
+	if got := out.Mode & uint32(syscall.S_IFMT); got != uint32(syscall.S_IFLNK) {
+		t.Fatalf("Symlink mode type = %o, want symlink", got)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1445,6 +1445,123 @@ func TestLookupUsesDirCachePositiveEntryWithoutRemoteStat(t *testing.T) {
 	}
 }
 
+func TestLookupRecognizesRemoteSymlinkMode(t *testing.T) {
+	target := []byte("../target")
+	symlinkMode := uint32(syscall.S_IFLNK) | 0o777
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			w.Header().Set("Content-Length", strconv.Itoa(len(target)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Mode", strconv.FormatUint(uint64(symlinkMode), 10))
+			w.Header().Set("X-Dat9-Revision", "11")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			_, _ = w.Write(target)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "link", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if got := out.Mode & uint32(syscall.S_IFMT); got != uint32(syscall.S_IFLNK) {
+		t.Fatalf("Lookup mode type = %o, want symlink", got)
+	}
+	if got := out.Size; got != uint64(len(target)) {
+		t.Fatalf("Lookup size = %d, want %d", got, len(target))
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+
+	got, st := fs.Readlink(nil, &gofuse.InHeader{NodeId: out.NodeId})
+	if st != gofuse.OK {
+		t.Fatalf("Readlink status = %v, want OK", st)
+	}
+	if string(got) != string(target) {
+		t.Fatalf("Readlink target = %q, want %q", got, target)
+	}
+}
+
+func TestSymlinkCreatesRemoteLinkAndCachesEntry(t *testing.T) {
+	const target = "../target"
+	symlinkMode := uint32(syscall.S_IFLNK) | 0o777
+	var gotTarget string
+	var postCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			postCalls.Add(1)
+			if r.URL.Path != "/v1/fs/link" {
+				t.Errorf("POST path = %s, want /v1/fs/link", r.URL.Path)
+			}
+			if got := r.URL.Query().Get("symlink"); got != "1" {
+				t.Errorf("symlink query = %q, want 1", got)
+			}
+			var req struct {
+				Target string `json:"target"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			gotTarget = req.Target
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(target)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Mode", strconv.FormatUint(uint64(symlinkMode), 10))
+			w.Header().Set("X-Dat9-Revision", "12")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			_, _ = w.Write([]byte(target))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var out gofuse.EntryOut
+	st := fs.Symlink(nil, &gofuse.InHeader{NodeId: 1}, target, "link", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Symlink status = %v, want OK", st)
+	}
+	if gotTarget != target {
+		t.Fatalf("posted target = %q, want %q", gotTarget, target)
+	}
+	if got := postCalls.Load(); got != 1 {
+		t.Fatalf("POST calls = %d, want 1", got)
+	}
+	if got := out.Mode & uint32(syscall.S_IFMT); got != uint32(syscall.S_IFLNK) {
+		t.Fatalf("Symlink mode type = %o, want symlink", got)
+	}
+	if got := out.Size; got != uint64(len(target)) {
+		t.Fatalf("Symlink size = %d, want %d", got, len(target))
+	}
+
+	got, st := fs.Readlink(nil, &gofuse.InHeader{NodeId: out.NodeId})
+	if st != gofuse.OK {
+		t.Fatalf("Readlink status = %v, want OK", st)
+	}
+	if string(got) != target {
+		t.Fatalf("Readlink target = %q, want %q", got, target)
+	}
+}
+
 func TestLookupUsesDirCacheNegativeEntryWithoutRemoteStat(t *testing.T) {
 	var remoteCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4461,6 +4578,13 @@ func TestMutationHandlers_CompleteWithinTimeout(t *testing.T) {
 				return fs.Mkdir(nil, &gofuse.MkdirIn{
 					InHeader: gofuse.InHeader{NodeId: 1},
 				}, "newdir", &out)
+			},
+		},
+		{
+			name: "Symlink",
+			fn: func() gofuse.Status {
+				var out gofuse.EntryOut
+				return fs.Symlink(nil, &gofuse.InHeader{NodeId: 1}, "target.txt", "newlink", &out)
 			},
 		},
 		{

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1525,18 +1525,22 @@ func TestReadlinkRetriesTransientRead(t *testing.T) {
 	var out gofuse.EntryOut
 	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "link", &out)
 	if st != gofuse.OK {
-		t.Fatalf("Lookup status = %v, want OK", st)
+		t.Errorf("Lookup status = %v, want OK", st)
+		return
 	}
 
 	got, st := fs.Readlink(nil, &gofuse.InHeader{NodeId: out.NodeId})
 	if st != gofuse.OK {
-		t.Fatalf("Readlink status = %v, want OK", st)
+		t.Errorf("Readlink status = %v, want OK", st)
+		return
 	}
 	if string(got) != string(target) {
-		t.Fatalf("Readlink target = %q, want %q", got, target)
+		t.Errorf("Readlink target = %q, want %q", got, target)
+		return
 	}
 	if calls := getCalls.Load(); calls < 2 {
-		t.Fatalf("GET calls = %d, want retry", calls)
+		t.Errorf("GET calls = %d, want retry", calls)
+		return
 	}
 }
 
@@ -1639,16 +1643,63 @@ func TestSymlinkRecoversWhenInterruptedAfterRemoteCreate(t *testing.T) {
 	var out gofuse.EntryOut
 	st := fs.Symlink(nil, &gofuse.InHeader{NodeId: 1}, target, "link", &out)
 	if st != gofuse.OK {
-		t.Fatalf("Symlink status = %v, want OK", st)
+		t.Errorf("Symlink status = %v, want OK", st)
+		return
 	}
 	if got := postCalls.Load(); got != 1 {
-		t.Fatalf("POST calls = %d, want 1", got)
+		t.Errorf("POST calls = %d, want 1", got)
+		return
 	}
 	if got := headCalls.Load(); got == 0 {
-		t.Fatal("symlink retry did not probe created path")
+		t.Error("symlink retry did not probe created path")
+		return
 	}
 	if got := out.Mode & uint32(syscall.S_IFMT); got != uint32(syscall.S_IFLNK) {
-		t.Fatalf("Symlink mode type = %o, want symlink", got)
+		t.Errorf("Symlink mode type = %o, want symlink", got)
+		return
+	}
+}
+
+func TestSymlinkRecoveryRejectsNonSymlinkProbe(t *testing.T) {
+	const target = "../target"
+	var postCalls atomic.Int32
+	var headCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs/link" && r.URL.RawQuery == "symlink=1":
+			postCalls.Add(1)
+			w.WriteHeader(statusClientClosedRequest)
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs/link":
+			headCalls.Add(1)
+			w.Header().Set("Content-Length", "4")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Mode", strconv.FormatUint(uint64(uint32(syscall.S_IFREG)|0o644), 10))
+			w.Header().Set("X-Dat9-Revision", "12")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var out gofuse.EntryOut
+	st := fs.Symlink(nil, &gofuse.InHeader{NodeId: 1}, target, "link", &out)
+	if st != gofuse.Status(syscall.EAGAIN) {
+		t.Errorf("Symlink status = %v, want EAGAIN", st)
+		return
+	}
+	if got := postCalls.Load(); got != 1 {
+		t.Errorf("POST calls = %d, want 1", got)
+		return
+	}
+	if got := headCalls.Load(); got == 0 {
+		t.Error("symlink recovery did not stat created path")
+		return
 	}
 }
 

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -31,6 +31,8 @@ const (
 	perfFuseRmdir
 	perfFuseRename
 	perfFuseSetAttr
+	perfFuseReadlink
+	perfFuseSymlink
 	perfFuseOpCount
 )
 
@@ -52,6 +54,8 @@ var perfFuseOpNames = [...]string{
 	perfFuseRmdir:       "rmdir",
 	perfFuseRename:      "rename",
 	perfFuseSetAttr:     "setattr",
+	perfFuseReadlink:    "readlink",
+	perfFuseSymlink:     "symlink",
 }
 
 type perfRemoteOp int

--- a/pkg/server/fs_authorization_test.go
+++ b/pkg/server/fs_authorization_test.go
@@ -398,6 +398,9 @@ func TestC2aWriteHandlersRejectScopedRequestBeforeBackend(t *testing.T) {
 		{"handleCreate", func(s *Server, w http.ResponseWriter, r *http.Request) {
 			s.handleCreate(w, r, "/main/secrets.env")
 		}},
+		{"handleSymlink", func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.handleSymlink(w, r, "/main/secrets.env")
+		}},
 		{"handleMkdir", func(s *Server, w http.ResponseWriter, r *http.Request) {
 			s.handleMkdir(w, r, "/main/newdir")
 		}},

--- a/pkg/server/fs_authorization_test.go
+++ b/pkg/server/fs_authorization_test.go
@@ -604,6 +604,7 @@ func TestC2aDispatcherWriteSideAllowed(t *testing.T) {
 			{http.MethodPost, "mkdir=1"},
 			{http.MethodPost, "mkdir=1&mode=755"},
 			{http.MethodPost, "create=1"},
+			{http.MethodPost, "symlink=1"},
 		}
 		for _, tc := range cases {
 			r := newScopedRequest(t, tc.method, "/v1/fs/main.txt", tc.query)
@@ -626,6 +627,7 @@ func TestC2aDispatcherWriteSideAllowed(t *testing.T) {
 			"append=1&copy=1",
 			"copy=1&rename=1",
 			"mkdir=1&create=1",
+			"create=1&symlink=1",
 			"copy=1&chmod=1", // chmod combined with anything → deny
 			"append=1&mkdir=1&create=1",
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1983,7 +1983,9 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request, path strin
 	_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(1)})
 }
 
-const maxSymlinkBodyBytes = backend.MaxSymlinkTargetBytes + 1024
+// Worst-case JSON escaping can expand one target byte to six bytes (\u00XX),
+// plus fixed wrapper overhead for {"target":...}.
+const maxSymlinkBodyBytes = backend.MaxSymlinkTargetBytes*6 + 64
 
 func (s *Server) handleSymlink(w http.ResponseWriter, r *http.Request, path string) {
 	if !authorizeFS(w, r, FSOpWrite, path) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1983,6 +1983,8 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request, path strin
 	_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(1)})
 }
 
+const maxSymlinkBodyBytes = backend.MaxSymlinkTargetBytes + 1024
+
 func (s *Server) handleSymlink(w http.ResponseWriter, r *http.Request, path string) {
 	if !authorizeFS(w, r, FSOpWrite, path) {
 		return
@@ -1996,7 +1998,13 @@ func (s *Server) handleSymlink(w http.ResponseWriter, r *http.Request, path stri
 	var req struct {
 		Target string `json:"target"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxSymlinkBodyBytes)).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_body_too_large", "path", path, "max", maxSymlinkBodyBytes)...)
+			errJSON(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_bad_body", "path", path, "error", err)...)
 		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 		return
@@ -2005,6 +2013,16 @@ func (s *Server) handleSymlink(w http.ResponseWriter, r *http.Request, path stri
 		if errors.Is(err, backend.ErrInvalidSymlinkTarget) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_invalid_target", "path", path, "error", err)...)
 			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if errors.Is(err, backend.ErrUploadTooLarge) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_upload_too_large", "path", path, "error", err)...)
+			errJSON(w, http.StatusRequestEntityTooLarge, err.Error())
+			return
+		}
+		if errors.Is(err, backend.ErrStorageQuotaExceeded) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_storage_quota_exceeded", "path", path, "error", err)...)
+			errJSON(w, http.StatusInsufficientStorage, err.Error())
 			return
 		}
 		if errors.Is(err, datastore.ErrPathConflict) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -602,7 +602,7 @@ func isScopedFSPostQueryAllowed(q url.Values) bool {
 	// no selector = deny (no handler matches the dispatcher's else branch
 	// for scoped tokens — that's "unknown POST action" which is a 400 for
 	// owner today, and we don't want to silently widen for scoped).
-	selectors := []string{"append", "copy", "rename", "mkdir", "chmod", "create"}
+	selectors := []string{"append", "copy", "rename", "mkdir", "chmod", "create", "symlink"}
 	selectorCount := 0
 	var selectorKey string
 	for _, k := range selectors {
@@ -639,6 +639,9 @@ func isScopedFSPostQueryAllowed(q url.Values) bool {
 	case "create":
 		// handleCreate reads only ?create.
 		return queryKeysSubsetOf(q, []string{"create"})
+	case "symlink":
+		// handleSymlink reads only ?symlink; target is in the JSON body.
+		return queryKeysSubsetOf(q, []string{"symlink"})
 	default:
 		return false
 	}
@@ -873,6 +876,8 @@ func (s *Server) handleFS(w http.ResponseWriter, r *http.Request) {
 			s.handleChmod(w, r, path)
 		} else if r.URL.Query().Has("create") {
 			s.handleCreate(w, r, path)
+		} else if r.URL.Query().Has("symlink") {
+			s.handleSymlink(w, r, path)
 		} else {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "fs_unknown_post_action", "path", path)...)
 			errJSON(w, http.StatusBadRequest, "unknown POST action")
@@ -1974,6 +1979,45 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request, path strin
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "create_ok", "path", path)...)
 	s.publishEvent(r, path, "create")
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(1)})
+}
+
+func (s *Server) handleSymlink(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpWrite, path) {
+		return
+	}
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_missing_scope", "path", path)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	var req struct {
+		Target string `json:"target"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_bad_body", "path", path, "error", err)...)
+		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if err := b.CreateSymlinkCtx(r.Context(), path, req.Target); err != nil {
+		if errors.Is(err, backend.ErrInvalidSymlinkTarget) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_invalid_target", "path", path, "error", err)...)
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if errors.Is(err, datastore.ErrPathConflict) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_conflict", "path", path, "error", err)...)
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "symlink_failed", "path", path, "error", err)...)
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "symlink_ok", "path", path)...)
+	s.publishEvent(r, path, "symlink")
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(1)})
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -895,6 +896,57 @@ func TestStatDirectoryReturnsMode(t *testing.T) {
 	}
 	if modeHdr != "448" { // 0o700 = 448 decimal
 		t.Errorf("expected X-Dat9-Mode 448, got %s", modeHdr)
+	}
+}
+
+func TestSymlinkRoundTrip(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	reqBody := strings.NewReader(`{"target":"../target.txt"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/link?symlink=1", reqBody)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("symlink: %d", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/link", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stat link: %d", resp.StatusCode)
+	}
+	wantMode := strconv.FormatUint(uint64(uint32(syscall.S_IFLNK)|0o777), 10)
+	if got := resp.Header.Get("X-Dat9-Mode"); got != wantMode {
+		t.Fatalf("X-Dat9-Mode = %s, want %s", got, wantMode)
+	}
+	if got := resp.Header.Get("Content-Length"); got != strconv.Itoa(len("../target.txt")) {
+		t.Fatalf("Content-Length = %s, want %d", got, len("../target.txt"))
+	}
+
+	resp, err = http.Get(ts.URL + "/v1/fs/link")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("read link payload: %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "../target.txt" {
+		t.Fatalf("read link payload = %q, want ../target.txt", body)
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -950,6 +950,72 @@ func TestSymlinkRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSymlinkRejectsOversizeTarget(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	target := strings.Repeat("x", backend.MaxSymlinkTargetBytes+1)
+	reqBody := strings.NewReader(`{"target":"` + target + `"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/too-long-link?symlink=1", reqBody)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("symlink oversize target status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/too-long-link", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("oversize symlink should not be inserted; stat status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestSymlinkRejectsOversizeBody(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	reqBody := strings.NewReader(`{"target":"` + strings.Repeat("x", maxSymlinkBodyBytes) + `"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/body-too-large-link?symlink=1", reqBody)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("symlink oversize body status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestSymlinkReturns507WhenTenantStorageQuotaExceeded(t *testing.T) {
+	s, _ := newTestServerWithS3Config(t, backend.Options{MaxTenantStorageBytes: 10}, SemanticWorkerOptions{})
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	reqBody := strings.NewReader(`{"target":"12345678901"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/quota-link?symlink=1", reqBody)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInsufficientStorage {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("symlink quota status = %d, want %d: %s", resp.StatusCode, http.StatusInsufficientStorage, body)
+	}
+}
+
 func TestStatDirectoryWithoutTrailingSlashDoesNotLogDatastoreError(t *testing.T) {
 	core, recorded := observer.New(zap.ErrorLevel)
 	restoreLogger := logger.L()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -997,6 +997,32 @@ func TestSymlinkRejectsOversizeBody(t *testing.T) {
 	}
 }
 
+func TestSymlinkAllowsMaxTargetWithWorstCaseJSONEscaping(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	target := strings.Repeat("\x01", backend.MaxSymlinkTargetBytes)
+	body, err := json.Marshal(map[string]string{"target": target})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) > maxSymlinkBodyBytes {
+		t.Fatalf("test body length = %d exceeds symlink body cap %d", len(body), maxSymlinkBodyBytes)
+	}
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/escaped-max-link?symlink=1", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("symlink escaped max target status = %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
+	}
+}
+
 func TestSymlinkReturns507WhenTenantStorageQuotaExceeded(t *testing.T) {
 	s, _ := newTestServerWithS3Config(t, backend.Options{MaxTenantStorageBytes: 10}, SemanticWorkerOptions{})
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary
- Add backend/server/client support for symbolic links stored as inline target payloads with POSIX symlink mode bits.
- Implement FUSE Symlink/Readlink handling and CLI `drive9 fs symlink`.
- Add unit coverage plus CLI/FUSE smoke-test symlink cases.

## Tests
- `env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9 ./cmd/drive9/cli ./pkg/fuse`
- `bash -n e2e/cli-smoke-test.sh`
- `bash -n e2e/fuse-smoke-test.sh`
- `git diff --check`

Live e2e scripts were updated but not run locally because they require a live drive9 server/FUSE mount environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added symbolic link support end-to-end: CLI command to create symlinks, server/backend handling, client API, and filesystem-level create/readlink/resolve behavior.

* **Bug Fixes**
  * Chmod now preserves file-type bits when updating permissions.

* **Tests**
  * Added extensive unit and integration tests covering symlink creation, readlink behavior, error cases, authorization, and recursive-copy rejection of symlinks.

* **Documentation / E2E**
  * Updated smoke tests and E2E docs to include symlink scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->