### PR TITLE
fix(fuse): preserve pending create modes

### DIFF
--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -591,9 +591,9 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 			if err := cq.onCommitSuccess(entry, committedRev); err == nil {
 				return
 			} else {
-				lastErr = err
 				log.Printf("commit queue: post-upload attempt %d/%d failed for %s: %v", attempt+1, maxRetries, entry.Path, err)
-				continue
+				cq.onCommitPostUploadFailure(entry, err)
+				return
 			}
 		}
 		if cq.isEntryCanceled(entry) {
@@ -772,16 +772,21 @@ func (cq *CommitQueue) rebuildQueuedIndexLocked() {
 }
 
 func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) error {
-	if entry.HasMode {
+	if shouldApplyRemoteMode(entry.Kind, entry.HasMode, entry.Mode) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		start := time.Now()
-		err := cq.client.ChmodCtx(ctx, cq.remotePath(entry.Path), entry.Mode&0o777)
+		var err error
+		mode := entry.Mode & 0o777
+		err = retryPostUploadMode(ctx, func() error {
+			start := time.Now()
+			applyErr := cq.client.ChmodCtx(ctx, cq.remotePath(entry.Path), mode)
+			if cq.perf != nil {
+				cq.perf.recordRemoteOp(perfRemoteMutation, applyErr, time.Since(start), 0)
+			}
+			return applyErr
+		})
 		cancel()
-		if cq.perf != nil {
-			cq.perf.recordRemoteOp(perfRemoteMutation, err, time.Since(start), 0)
-		}
 		if err != nil {
-			return fmt.Errorf("%w: chmod %s to %o: %v", errCommitPostUpload, entry.Path, entry.Mode&0o777, err)
+			return fmt.Errorf("%w: chmod %s to %o: %w", errCommitPostUpload, entry.Path, mode, err)
 		}
 	}
 

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -44,6 +44,8 @@ type CommitEntry struct {
 	Size         int64
 	Kind         PendingKind
 	ShadowSpill  bool // true when data is only in shadow file (auto-resolve would OOM)
+	Mode         uint32
+	HasMode      bool
 	canceled     bool
 	cancelCommit context.CancelFunc
 	cancelUpload context.CancelFunc
@@ -269,6 +271,8 @@ func (cq *CommitQueue) RecoverPending() {
 			Size:        meta.Size,
 			Kind:        meta.Kind,
 			ShadowSpill: meta.ShadowSpill,
+			Mode:        meta.Mode,
+			HasMode:     meta.HasMode,
 		}
 		if err := cq.Enqueue(entry); err != nil {
 			log.Printf("commit queue: recover enqueue failed for %s: %v", path, err)
@@ -753,6 +757,19 @@ func (cq *CommitQueue) rebuildQueuedIndexLocked() {
 }
 
 func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) {
+	if entry.HasMode {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		start := time.Now()
+		err := cq.client.ChmodCtx(ctx, cq.remotePath(entry.Path), entry.Mode&0o777)
+		cancel()
+		if cq.perf != nil {
+			cq.perf.recordRemoteOp(perfRemoteMutation, err, time.Since(start), 0)
+		}
+		if err != nil {
+			log.Printf("commit queue: chmod %s to %o failed after upload: %v", entry.Path, entry.Mode&0o777, err)
+		}
+	}
+
 	// Write durable commit record BEFORE cleaning up local state so that
 	// crash recovery never re-uploads an already committed entry.
 	if cq.journal != nil {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -15,6 +15,8 @@ import (
 	"github.com/mem9-ai/dat9/pkg/mountpath"
 )
 
+var errCommitPostUpload = errors.New("commit post-upload step failed")
+
 // directPutThreshold returns the size limit below which commit queue workers
 // use direct PUT (WriteCtxConditionalWithRevision) instead of multipart
 // upload. Must match the server's inline_threshold — the server rejects
@@ -586,9 +588,13 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 		cancel()
 
 		if err == nil {
-			// Success — clean up.
-			cq.onCommitSuccess(entry, committedRev)
-			return
+			if err := cq.onCommitSuccess(entry, committedRev); err == nil {
+				return
+			} else {
+				lastErr = err
+				log.Printf("commit queue: post-upload attempt %d/%d failed for %s: %v", attempt+1, maxRetries, entry.Path, err)
+				continue
+			}
 		}
 		if cq.isEntryCanceled(entry) {
 			cq.removeFromQueue(entry)
@@ -605,6 +611,10 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 	}
 
 	log.Printf("commit queue: giving up on %s after %d retries: %v", entry.Path, maxRetries, lastErr)
+	if errors.Is(lastErr, errCommitPostUpload) {
+		cq.onCommitPostUploadFailure(entry, lastErr)
+		return
+	}
 	cq.onCommitTerminalFailure(entry)
 }
 
@@ -630,7 +640,12 @@ func (cq *CommitQueue) CommitNow(ctx context.Context, entry *CommitEntry) error 
 		}
 		return err
 	}
-	cq.onCommitSuccess(entry, committedRev)
+	if err := cq.onCommitSuccess(entry, committedRev); err != nil {
+		if cq.perf != nil {
+			cq.perf.commitFailure.add(1)
+		}
+		return err
+	}
 	return nil
 }
 
@@ -756,7 +771,7 @@ func (cq *CommitQueue) rebuildQueuedIndexLocked() {
 	}
 }
 
-func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) {
+func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) error {
 	if entry.HasMode {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		start := time.Now()
@@ -766,7 +781,7 @@ func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) {
 			cq.perf.recordRemoteOp(perfRemoteMutation, err, time.Since(start), 0)
 		}
 		if err != nil {
-			log.Printf("commit queue: chmod %s to %o failed after upload: %v", entry.Path, entry.Mode&0o777, err)
+			return fmt.Errorf("%w: chmod %s to %o: %v", errCommitPostUpload, entry.Path, entry.Mode&0o777, err)
 		}
 	}
 
@@ -779,7 +794,7 @@ func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) {
 		}); err != nil {
 			log.Printf("commit queue: journal commit marker failed for %s: %v (keeping local state)", entry.Path, err)
 			cq.removeFromQueue(entry)
-			return
+			return nil
 		}
 	}
 
@@ -808,6 +823,7 @@ func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) {
 		cq.perf.commitSuccess.add(1)
 	}
 	log.Printf("commit queue: successfully uploaded %s (%d bytes, rev=%d)", entry.Path, entry.Size, committedRev)
+	return nil
 }
 
 // tryAutoResolveConflict attempts to resolve a 409 conflict automatically.
@@ -887,7 +903,9 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	// Branch 1: idempotent — content already matches server.
 	if bytes.Equal(localData, serverData) {
 		log.Printf("commit queue: auto-resolved conflict for %s (idempotent, content matches server rev %d)", entry.Path, serverRev)
-		cq.onCommitSuccess(entry, 0)
+		if err := cq.onCommitSuccess(entry, 0); err != nil {
+			cq.onCommitPostUploadFailure(entry, err)
+		}
 		return
 	}
 
@@ -913,7 +931,17 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	}
 
 	log.Printf("commit queue: auto-resolved conflict for %s via LWW (overwrote rev %d → new upload based on rev %d)", entry.Path, entry.BaseRev, serverRev)
-	cq.onCommitSuccess(entry, 0)
+	if err := cq.onCommitSuccess(entry, 0); err != nil {
+		cq.onCommitPostUploadFailure(entry, err)
+	}
+}
+
+func (cq *CommitQueue) onCommitPostUploadFailure(entry *CommitEntry, err error) {
+	if cq.perf != nil {
+		cq.perf.commitFailure.add(1)
+	}
+	cq.removeFromQueue(entry)
+	log.Printf("commit queue: post-upload failure for %s; local pending state preserved for retry: %v", entry.Path, err)
 }
 
 func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry) {

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -72,6 +72,66 @@ func TestCommitQueueConditionalCommitSuccess(t *testing.T) {
 	}
 }
 
+func TestCommitQueueAppliesModeAfterUpload(t *testing.T) {
+	var putCalls atomic.Int32
+	var chmodCalls atomic.Int32
+	var chmodBody []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			putCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","revision":9}`))
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			chmodCalls.Add(1)
+			chmodBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull("/exec.sh", []byte("data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRevAndMode("/exec.sh", 4, PendingNew, 0, 0o755, true); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:    "/exec.sh",
+		Size:    4,
+		Kind:    PendingNew,
+		Mode:    0o755,
+		HasMode: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want 1", got)
+	}
+	if got := chmodCalls.Load(); got != 1 {
+		t.Fatalf("chmod calls = %d, want 1", got)
+	}
+	if !bytes.Contains(chmodBody, []byte("493")) {
+		t.Fatalf("chmod body = %s, want decimal mode 493", chmodBody)
+	}
+}
+
 func TestCommitQueueConflictKeepsPendingState(t *testing.T) {
 	var calls int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -133,6 +133,131 @@ func TestCommitQueueAppliesModeAfterUpload(t *testing.T) {
 	}
 }
 
+func TestCommitQueueSkipsDefaultModeForPendingNew(t *testing.T) {
+	var putCalls atomic.Int32
+	var chmodCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			putCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","revision":9}`))
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			chmodCalls.Add(1)
+			http.Error(w, "unexpected chmod", http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull("/plain.txt", []byte("data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRevAndMode("/plain.txt", 4, PendingNew, 0, defaultRegularFileMode, true); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:    "/plain.txt",
+		Size:    4,
+		Kind:    PendingNew,
+		Mode:    defaultRegularFileMode,
+		HasMode: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want 1", got)
+	}
+	if got := chmodCalls.Load(); got != 0 {
+		t.Fatalf("chmod calls = %d, want 0", got)
+	}
+	if pending.HasPending("/plain.txt") {
+		t.Fatal("pending entry should be removed after successful default-mode commit")
+	}
+	if shadow.Has("/plain.txt") {
+		t.Fatal("shadow should be removed after successful default-mode commit")
+	}
+}
+
+func TestCommitQueueRetriesPostUploadChmodNotFound(t *testing.T) {
+	var putCalls atomic.Int32
+	var chmodCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			putCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","revision":9}`))
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			if chmodCalls.Add(1) == 1 {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull("/exec-retry.sh", []byte("data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRevAndMode("/exec-retry.sh", 4, PendingNew, 0, 0o755, true); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:    "/exec-retry.sh",
+		Size:    4,
+		Kind:    PendingNew,
+		Mode:    0o755,
+		HasMode: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want 1", got)
+	}
+	if got := chmodCalls.Load(); got != 2 {
+		t.Fatalf("chmod calls = %d, want 2", got)
+	}
+	if pending.HasPending("/exec-retry.sh") {
+		t.Fatal("pending entry should be removed after chmod retry succeeds")
+	}
+	if shadow.Has("/exec-retry.sh") {
+		t.Fatal("shadow should be removed after chmod retry succeeds")
+	}
+}
+
 func TestCommitQueueChmodFailureKeepsPendingState(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -2,6 +2,7 @@ package fuse
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -129,6 +130,57 @@ func TestCommitQueueAppliesModeAfterUpload(t *testing.T) {
 	}
 	if !bytes.Contains(chmodBody, []byte("493")) {
 		t.Fatalf("chmod body = %s, want decimal mode 493", chmodBody)
+	}
+}
+
+func TestCommitQueueChmodFailureKeepsPendingState(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","revision":9}`))
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			http.Error(w, "chmod failed", http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull("/exec-fail.sh", []byte("data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRevAndMode("/exec-fail.sh", 4, PendingNew, 0, 0o755, true); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.DrainAll()
+	err = cq.CommitNow(context.Background(), &CommitEntry{
+		Path:    "/exec-fail.sh",
+		Size:    4,
+		Kind:    PendingNew,
+		Mode:    0o755,
+		HasMode: true,
+	})
+	if err == nil {
+		t.Fatal("CommitNow should fail when chmod fails")
+	}
+	if !pending.HasPending("/exec-fail.sh") {
+		t.Fatal("pending entry should be retained when chmod fails")
+	}
+	if !shadow.Has("/exec-fail.sh") {
+		t.Fatal("shadow should be retained when chmod fails")
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -40,6 +40,7 @@ type Dat9FS struct {
 	dirtyMu     sync.Mutex
 	dirtyInodes map[uint64]dirtyInodeState
 	dirtySeq    uint64
+	modeSeq     atomic.Uint64
 	uid         uint32
 	gid         uint32
 	opts        *MountOptions
@@ -632,6 +633,36 @@ func (fs *Dat9FS) modeForPendingHandle(fh *FileHandle) (uint32, bool) {
 	return 0, false
 }
 
+func (fs *Dat9FS) nextPendingModeGen() uint64 {
+	if fs == nil {
+		return 0
+	}
+	return fs.modeSeq.Add(1)
+}
+
+func (fs *Dat9FS) setPendingModeLocked(fh *FileHandle, mode uint32, gen uint64) {
+	if fh == nil {
+		return
+	}
+	if gen == 0 {
+		gen = fs.nextPendingModeGen()
+	}
+	fh.PendingMode = mode & 0o777
+	fh.HasPendingMode = true
+	fh.PendingModeGen = gen
+}
+
+func clearPendingModeLocked(fh *FileHandle) {
+	fh.HasPendingMode = false
+	fh.PendingModeGen = 0
+	fh.HasPreviousMode = false
+	fh.PreviousModeKnown = false
+}
+
+func pendingModeMatchesLocked(fh *FileHandle, mode uint32, gen uint64) bool {
+	return fh != nil && fh.HasPendingMode && fh.PendingModeGen == gen && fh.PendingMode&0o777 == mode&0o777
+}
+
 func (fs *Dat9FS) fileHandlesForInode(ino uint64) []*FileHandle {
 	var handles []*FileHandle
 	fs.fileHandles.ForEach(func(_ uint64, h *FileHandle) {
@@ -666,9 +697,20 @@ func (fs *Dat9FS) clearPendingModeForInodeExcept(ino uint64, skip *FileHandle) {
 			continue
 		}
 		h.Lock()
-		h.HasPendingMode = false
-		h.HasPreviousMode = false
-		h.PreviousModeKnown = false
+		clearPendingModeLocked(h)
+		h.Unlock()
+	}
+}
+
+func (fs *Dat9FS) clearPendingModeForInodeGeneration(ino uint64, skip *FileHandle, mode uint32, gen uint64) {
+	for _, h := range fs.fileHandlesForInode(ino) {
+		if h == skip {
+			continue
+		}
+		h.Lock()
+		if pendingModeMatchesLocked(h, mode, gen) {
+			clearPendingModeLocked(h)
+		}
 		h.Unlock()
 	}
 }
@@ -694,15 +736,16 @@ func (fs *Dat9FS) applyPendingModeForHandleLocked(ctx context.Context, fh *FileH
 	}
 	localPath := fh.Path
 	ino := fh.Ino
+	modeGen := fh.PendingModeGen
 	previousMode := fh.PreviousMode
 	hasPreviousMode := fh.HasPreviousMode
 	previousModeKnown := fh.PreviousModeKnown
 	if !shouldApplyRemoteMode(fs.pendingKindForHandle(fh), hasMode, mode) {
-		fh.HasPendingMode = false
-		fh.HasPreviousMode = false
-		fh.PreviousModeKnown = false
+		if pendingModeMatchesLocked(fh, mode, modeGen) {
+			clearPendingModeLocked(fh)
+		}
 		fh.Unlock()
-		fs.clearPendingModeForInodeExcept(ino, fh)
+		fs.clearPendingModeForInodeGeneration(ino, fh, mode, modeGen)
 		fh.Lock()
 		return nil
 	}
@@ -713,18 +756,30 @@ func (fs *Dat9FS) applyPendingModeForHandleLocked(ctx context.Context, fh *FileH
 	})
 	fh.Lock()
 	if err != nil {
+		if !pendingModeMatchesLocked(fh, mode, modeGen) {
+			return nil
+		}
 		if hasPreviousMode {
 			fs.inodes.SetModeState(ino, previousMode, previousModeKnown)
 		}
 		return err
 	}
-	fh.HasPendingMode = false
-	fh.HasPreviousMode = false
-	fh.PreviousModeKnown = false
+	if !pendingModeMatchesLocked(fh, mode, modeGen) {
+		return nil
+	}
+	fs.inodes.UpdateMode(ino, mode)
+	clearPendingModeLocked(fh)
 	fh.Unlock()
-	fs.clearPendingModeForInodeExcept(ino, fh)
+	fs.clearPendingModeForInodeGeneration(ino, fh, mode, modeGen)
 	fh.Lock()
 	return nil
+}
+
+func (fs *Dat9FS) applyPendingModeWithTimeoutLocked(fh *FileHandle) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	err := fs.applyPendingModeForHandleLocked(ctx, fh)
+	cancel()
+	return err
 }
 
 func expectedRevisionForHandle(fh *FileHandle) int64 {
@@ -872,8 +927,7 @@ func (fs *Dat9FS) loadWritableHandleFromShadowLocked(fh *FileHandle, meta *Write
 	}
 	if meta.HasMode {
 		mode := meta.Mode & 0o777
-		fh.PendingMode = mode
-		fh.HasPendingMode = true
+		fs.setPendingModeLocked(fh, mode, 0)
 		fs.inodes.UpdateMode(fh.Ino, mode)
 	}
 	return nil
@@ -905,8 +959,7 @@ func (fs *Dat9FS) loadWritableHandleFromWriteBackLocked(fh *FileHandle) bool {
 	}
 	if meta.HasMode {
 		mode := meta.Mode & 0o777
-		fh.PendingMode = mode
-		fh.HasPendingMode = true
+		fs.setPendingModeLocked(fh, mode, 0)
 		fs.inodes.UpdateMode(fh.Ino, mode)
 	}
 	fh.DirtySeq = fs.markDirtySize(fh.Ino, int64(len(data)))
@@ -2372,12 +2425,12 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 		// If the file has an open dirty handle, update mode locally without
 		// consulting the remote server. The mode will be synced on Flush.
 		hasDirtyHandle := false
+		modeGen := fs.nextPendingModeGen()
 		for _, h := range fs.fileHandlesForInode(input.NodeId) {
 			h.Lock()
 			if h.Dirty != nil {
 				hasDirtyHandle = true
-				h.PendingMode = mode
-				h.HasPendingMode = true
+				fs.setPendingModeLocked(h, mode, modeGen)
 				if !h.HasPreviousMode {
 					if entry.HasMode {
 						h.PreviousMode = entry.Mode
@@ -3480,8 +3533,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		WritePolicy: fs.writePolicyForOpen(input.Flags),
 	}
 	if hasRemoteMode {
-		fh.PendingMode = mode
-		fh.HasPendingMode = true
+		fs.setPendingModeLocked(fh, mode, 0)
 	}
 
 	if fh.WritePolicy != WritePolicyWriteSync && fs.shadowStore != nil && fs.pendingIndex != nil {
@@ -4318,7 +4370,7 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 		log.Printf("write-sync upload failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}
-	if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+	if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 		log.Printf("write-sync pending chmod failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}
@@ -4372,7 +4424,7 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 			log.Printf("sync handle shadowspill upload failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
-		if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			log.Printf("sync handle shadowspill pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
@@ -4558,7 +4610,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 				log.Printf("flush: ShadowSpill sync upload failed for %s: %v", fh.Path, err)
 				return gofuse.EIO
 			}
-			if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+			if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 				log.Printf("flush: ShadowSpill pending chmod failed for %s: %v", fh.Path, err)
 				return httpToFuseStatus(err)
 			}
@@ -4722,7 +4774,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			log.Printf("fsync: ShadowSpill sync upload failed for %s: %v", fh.Path, err)
 			return gofuse.EIO
 		}
-		if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			log.Printf("fsync: ShadowSpill pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
@@ -4751,11 +4803,11 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		}
 		if fh.HasPendingMode {
 			ino := fh.Ino
-			fh.HasPendingMode = false
-			fh.HasPreviousMode = false
-			fh.PreviousModeKnown = false
+			mode := fh.PendingMode & 0o777
+			modeGen := fh.PendingModeGen
+			clearPendingModeLocked(fh)
 			fh.Unlock()
-			fs.clearPendingModeForInodeExcept(ino, fh)
+			fs.clearPendingModeForInodeGeneration(ino, fh, mode, modeGen)
 			fh.Lock()
 		}
 		// UploadSync already persisted the data to the server. Clear
@@ -4796,6 +4848,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			fh.Lock()
 			hasPendingMode := fh.HasPendingMode
 			pendingMode := fh.PendingMode & 0o777
+			pendingModeGen := fh.PendingModeGen
 			previousMode := fh.PreviousMode
 			hasPreviousMode := fh.HasPreviousMode
 			previousModeKnown := fh.PreviousModeKnown
@@ -4814,21 +4867,40 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				cf()
 				if err != nil {
 					log.Printf("release: pending chmod failed for %s: %v", localPath, err)
-					if hasPreviousMode {
+					fh.Lock()
+					stillCurrent := pendingModeMatchesLocked(fh, pendingMode, pendingModeGen)
+					fh.Unlock()
+					if stillCurrent && hasPreviousMode {
 						fs.inodes.SetModeState(ino, previousMode, previousModeKnown)
 					}
 					return
 				}
-				fs.inodes.UpdateMode(ino, pendingMode)
-				fs.clearPendingModeForInode(ino)
+				fh.Lock()
+				stillCurrent := pendingModeMatchesLocked(fh, pendingMode, pendingModeGen)
+				if stillCurrent {
+					clearPendingModeLocked(fh)
+				}
+				fh.Unlock()
+				if stillCurrent {
+					fs.inodes.UpdateMode(ino, pendingMode)
+					fs.clearPendingModeForInodeGeneration(ino, fh, pendingMode, pendingModeGen)
+				}
 				return
 			}
 
 			// Flush failed — revert the in-memory mode so local GetAttr doesn't lie.
-			if hasPreviousMode {
+			fh.Lock()
+			stillCurrent := pendingModeMatchesLocked(fh, pendingMode, pendingModeGen)
+			if stillCurrent {
+				clearPendingModeLocked(fh)
+			}
+			fh.Unlock()
+			if stillCurrent && hasPreviousMode {
 				fs.inodes.SetModeState(ino, previousMode, previousModeKnown)
 			}
-			fs.clearPendingModeForInode(ino)
+			if stillCurrent {
+				fs.clearPendingModeForInodeGeneration(ino, fh, pendingMode, pendingModeGen)
+			}
 		}()
 
 		// Unpin shadow if this handle pinned it, so deferred removals can proceed.
@@ -5247,7 +5319,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			log.Printf("finish streaming failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
-		if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			log.Printf("finish streaming pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
@@ -5309,7 +5381,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			log.Printf("upload all parts failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
-		if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			log.Printf("upload all pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
@@ -5427,7 +5499,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		log.Printf("flush upload failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}
-	if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+	if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 		log.Printf("flush pending chmod failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -614,6 +614,47 @@ func (fs *Dat9FS) pendingKindForHandle(fh *FileHandle) PendingKind {
 	return PendingOverwrite
 }
 
+func createInputMode(inputMode uint32) (uint32, bool) {
+	mode := inputMode & 0o777
+	if mode == 0 {
+		return 0o644, false
+	}
+	return mode, true
+}
+
+func (fs *Dat9FS) modeForPendingHandle(fh *FileHandle) (uint32, bool) {
+	if fh == nil {
+		return 0, false
+	}
+	if fh.HasPendingMode {
+		return fh.PendingMode & 0o777, true
+	}
+	return 0, false
+}
+
+func (fs *Dat9FS) setPendingMetadataMode(path string, mode uint32) {
+	mode &= 0o777
+	if fs.pendingIndex != nil {
+		if err := fs.pendingIndex.UpdateMode(path, mode); err != nil {
+			log.Printf("pending index mode update failed for %s: %v", path, err)
+		}
+	}
+	if fs.writeBack != nil {
+		if err := fs.writeBack.UpdateMode(path, mode); err != nil {
+			log.Printf("writeback mode update failed for %s: %v", path, err)
+		}
+	}
+}
+
+func (fs *Dat9FS) clearPendingModeForInode(ino uint64) {
+	fs.fileHandles.ForEach(func(_ uint64, h *FileHandle) {
+		if h.Ino == ino {
+			h.HasPendingMode = false
+			h.HasPreviousMode = false
+		}
+	})
+}
+
 func expectedRevisionForHandle(fh *FileHandle) int64 {
 	if fh == nil {
 		return -1
@@ -693,12 +734,13 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 			return err
 		}
 	}
+	mode, hasMode := fs.modeForPendingHandle(fh)
 	if fh.ShadowSpill {
-		if _, err := fs.pendingIndex.PutShadowSpill(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev); err != nil {
+		if _, err := fs.pendingIndex.PutShadowSpillWithMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode); err != nil {
 			log.Printf("pending index put failed for %s: %v", fh.Path, err)
 		}
 	} else {
-		if _, err := fs.pendingIndex.PutWithBaseRev(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev); err != nil {
+		if _, err := fs.pendingIndex.PutWithBaseRevAndMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode); err != nil {
 			log.Printf("pending index put failed for %s: %v", fh.Path, err)
 		}
 	}
@@ -715,12 +757,15 @@ func (fs *Dat9FS) snapshotWriteBackLocked(fh *FileHandle) error {
 	if !fh.ShadowReady && !fh.IsNew && !fh.Dirty.CanMaterializeFull() {
 		return syscall.ENOTSUP
 	}
-	return fs.writeBack.PutWithBaseRev(
+	mode, hasMode := fs.modeForPendingHandle(fh)
+	return fs.writeBack.PutWithBaseRevAndMode(
 		fh.Path,
 		fh.Dirty.bytesView(),
 		fh.Dirty.Size(),
 		fs.pendingKindForHandle(fh),
 		fh.BaseRev,
+		mode,
+		hasMode,
 	)
 }
 
@@ -753,6 +798,12 @@ func (fs *Dat9FS) loadWritableHandleFromShadowLocked(fh *FileHandle, meta *Write
 	} else if rev := fs.shadowStore.BaseRev(fh.Path); rev > 0 {
 		fh.BaseRev = rev
 	}
+	if meta.HasMode {
+		mode := meta.Mode & 0o777
+		fh.PendingMode = mode
+		fh.HasPendingMode = true
+		fs.inodes.UpdateMode(fh.Ino, mode)
+	}
 	return nil
 }
 
@@ -779,6 +830,12 @@ func (fs *Dat9FS) loadWritableHandleFromWriteBackLocked(fh *FileHandle) bool {
 	if meta.BaseRev > 0 {
 		fh.BaseRev = meta.BaseRev
 		fs.inodes.UpdateRevision(fh.Ino, meta.BaseRev)
+	}
+	if meta.HasMode {
+		mode := meta.Mode & 0o777
+		fh.PendingMode = mode
+		fh.HasPendingMode = true
+		fs.inodes.UpdateMode(fh.Ino, mode)
 	}
 	fh.DirtySeq = fs.markDirtySize(fh.Ino, int64(len(data)))
 	fh.WriteBackSeq = fh.DirtySeq
@@ -1796,6 +1853,9 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 				mtime = time.Now()
 			}
 			ino := fs.inodes.Lookup(childP, false, meta.Size, mtime)
+			if meta.HasMode {
+				fs.inodes.UpdateMode(ino, meta.Mode)
+			}
 			entry, ok := fs.inodes.GetEntry(ino)
 			if !ok {
 				return gofuse.EIO
@@ -1810,6 +1870,9 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 				mtime = time.Now()
 			}
 			ino := fs.inodes.Lookup(childP, false, meta.Size, mtime)
+			if meta.HasMode {
+				fs.inodes.UpdateMode(ino, meta.Mode)
+			}
 			entry, ok := fs.inodes.GetEntry(ino)
 			if !ok {
 				return gofuse.EIO
@@ -2108,6 +2171,9 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 				}
 			}
 		})
+		if hasDirtyHandle {
+			fs.setPendingMetadataMode(entry.Path, mode)
+		}
 		if !hasDirtyHandle {
 			ctx, cf := fuseCtx(cancel)
 			defer cf()
@@ -2569,6 +2635,8 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 			Size:        meta.Size,
 			Kind:        meta.Kind,
 			ShadowSpill: meta.ShadowSpill,
+			Mode:        meta.Mode,
+			HasMode:     meta.HasMode,
 		}
 		if isGitLooseObjectFinalPath(newP) {
 			// Git treats a successful tmp_obj_* -> <sha> rename as making the
@@ -2985,10 +3053,13 @@ func (fs *Dat9FS) mergePendingDirEntries(dirPath string, entries []DirEntry) []D
 				mtime = time.Now()
 			}
 			ino := fs.inodes.EnsureInode(meta.Path, false, meta.Size, mtime)
+			if meta.HasMode {
+				fs.inodes.UpdateMode(ino, meta.Mode)
+			}
 			entries = append(entries, DirEntry{
 				Name: name,
 				Ino:  ino,
-				Mode: syscall.S_IFREG,
+				Mode: dirEntryMode(false, meta.HasMode, meta.Mode),
 			})
 			existing[name] = struct{}{}
 		}
@@ -3016,10 +3087,13 @@ func (fs *Dat9FS) mergePendingDirEntries(dirPath string, entries []DirEntry) []D
 				mtime = time.Now()
 			}
 			ino := fs.inodes.EnsureInode(meta.Path, false, meta.Size, mtime)
+			if meta.HasMode {
+				fs.inodes.UpdateMode(ino, meta.Mode)
+			}
 			entries = append(entries, DirEntry{
 				Name: name,
 				Ino:  ino,
-				Mode: syscall.S_IFREG,
+				Mode: dirEntryMode(false, meta.HasMode, meta.Mode),
 			})
 			existing[name] = struct{}{}
 		}
@@ -3075,7 +3149,9 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		return st
 	}
 
+	mode, hasRemoteMode := createInputMode(input.Mode)
 	ino := fs.inodes.Lookup(childP, false, 0, time.Now())
+	fs.inodes.UpdateMode(ino, mode)
 	entry, ok := fs.inodes.GetEntry(ino)
 	if !ok {
 		return gofuse.EIO
@@ -3093,6 +3169,10 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		IsNew:       true,
 		ShadowReady: false,
 		WritePolicy: fs.writePolicyForOpen(input.Flags),
+	}
+	if hasRemoteMode {
+		fh.PendingMode = mode
+		fh.HasPendingMode = true
 	}
 
 	if fh.WritePolicy != WritePolicyWriteSync && fs.shadowStore != nil && fs.pendingIndex != nil {
@@ -4471,6 +4551,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			size := fh.Dirty.Size()
 			fh.DirtySeq = 0
 			fh.ShadowCommitReady = false
+			mode, hasMode := fs.modeForPendingHandle(fh)
 			fh.Unlock()
 
 			entry := &CommitEntry{
@@ -4480,6 +4561,8 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				Size:        size,
 				Kind:        PendingOverwrite,
 				ShadowSpill: true,
+				Mode:        mode,
+				HasMode:     hasMode,
 			}
 			if fh.IsNew {
 				entry.Kind = PendingNew
@@ -4508,6 +4591,8 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 					log.Printf("release: ShadowSpill sync upload failed for %s: %v", fh.Path, uploadErr)
 				}
 				cf()
+			} else if hasMode {
+				fs.clearPendingModeForInode(fh.Ino)
 			}
 
 			fs.invalidateReadCacheAndTargets(fh.Path)
@@ -4542,6 +4627,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			fs.debugf("release writeback check path=%s streamer_active=%t writeback_seq=%d dirty_seq=%d can_use_cache=%t", fh.Path, streamerActive, fh.WriteBackSeq, fh.DirtySeq, canUseCache)
 			if canUseCache {
 				phase = "writeback-cache-release"
+				mode, hasMode := fs.modeForPendingHandle(fh)
 				fh.Dirty.ClearDirty()
 				fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 				fh.DirtySeq = 0
@@ -4557,6 +4643,8 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 						BaseRev: fh.BaseRev,
 						Size:    fh.Dirty.Size(),
 						Kind:    PendingOverwrite,
+						Mode:    mode,
+						HasMode: hasMode,
 					}
 					if fh.IsNew {
 						entry.Kind = PendingNew
@@ -4579,6 +4667,9 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 					// Async upload — the uploader will read from cache and upload.
 					fs.debugf("release uploader submit path=%s", fh.Path)
 					fs.uploader.Submit(fh.Path)
+				}
+				if hasMode {
+					fs.clearPendingModeForInode(fh.Ino)
 				}
 
 				// Invalidate caches so subsequent reads see fresh data.
@@ -5105,12 +5196,18 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 		}
 		fs.inodes.UpdateRevision(entry.Inode, committedRev)
 		fs.inodes.UpdateSize(entry.Inode, entry.Size)
+		if entry.HasMode {
+			fs.inodes.UpdateMode(entry.Inode, entry.Mode&0o777)
+		}
 		fs.cacheFileForPath(entry.Path, entry.Size, time.Now(), committedRev)
 		// Local async commit completion — this is not an external change.
 		// Kernel does not need notify; userspace caches and inode state
 		// are updated above. Kernel will see new attrs on next access.
 	} else {
 		fs.invalidateReadCacheAndTargets(entry.Path)
+		if entry.HasMode && entry.Inode > 0 {
+			fs.inodes.UpdateMode(entry.Inode, entry.Mode&0o777)
+		}
 		fs.cacheFileForPath(entry.Path, entry.Size, time.Now(), 0)
 	}
 }

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -615,7 +615,8 @@ func (fs *Dat9FS) pendingKindForHandle(fh *FileHandle) PendingKind {
 }
 
 func createInputMode(inputMode uint32) (uint32, bool) {
-	return inputMode & 0o777, true
+	mode := inputMode & 0o777
+	return mode, mode != defaultRegularFileMode
 }
 
 // modeForPendingHandle returns the mode that still needs to be committed to
@@ -693,9 +694,19 @@ func (fs *Dat9FS) applyPendingModeForHandleLocked(ctx context.Context, fh *FileH
 	ino := fh.Ino
 	previousMode := fh.PreviousMode
 	hasPreviousMode := fh.HasPreviousMode
+	if !shouldApplyRemoteMode(fs.pendingKindForHandle(fh), hasMode, mode) {
+		fh.HasPendingMode = false
+		fh.HasPreviousMode = false
+		fh.Unlock()
+		fs.clearPendingModeForInodeExcept(ino, fh)
+		fh.Lock()
+		return nil
+	}
 
 	fh.Unlock()
-	err := fs.applyRemoteMode(ctx, localPath, mode)
+	err := retryPostUploadMode(ctx, func() error {
+		return fs.applyRemoteMode(ctx, localPath, mode)
+	})
 	fh.Lock()
 	if err != nil {
 		if hasPreviousMode {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -667,6 +667,7 @@ func (fs *Dat9FS) clearPendingModeForInodeExcept(ino uint64, skip *FileHandle) {
 		h.Lock()
 		h.HasPendingMode = false
 		h.HasPreviousMode = false
+		h.PreviousModeKnown = false
 		h.Unlock()
 	}
 }
@@ -694,9 +695,11 @@ func (fs *Dat9FS) applyPendingModeForHandleLocked(ctx context.Context, fh *FileH
 	ino := fh.Ino
 	previousMode := fh.PreviousMode
 	hasPreviousMode := fh.HasPreviousMode
+	previousModeKnown := fh.PreviousModeKnown
 	if !shouldApplyRemoteMode(fs.pendingKindForHandle(fh), hasMode, mode) {
 		fh.HasPendingMode = false
 		fh.HasPreviousMode = false
+		fh.PreviousModeKnown = false
 		fh.Unlock()
 		fs.clearPendingModeForInodeExcept(ino, fh)
 		fh.Lock()
@@ -710,12 +713,13 @@ func (fs *Dat9FS) applyPendingModeForHandleLocked(ctx context.Context, fh *FileH
 	fh.Lock()
 	if err != nil {
 		if hasPreviousMode {
-			fs.inodes.UpdateMode(ino, previousMode)
+			fs.inodes.SetModeState(ino, previousMode, previousModeKnown)
 		}
 		return err
 	}
 	fh.HasPendingMode = false
 	fh.HasPreviousMode = false
+	fh.PreviousModeKnown = false
 	fh.Unlock()
 	fs.clearPendingModeForInodeExcept(ino, fh)
 	fh.Lock()
@@ -2232,8 +2236,13 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 				h.PendingMode = mode
 				h.HasPendingMode = true
 				if !h.HasPreviousMode {
-					h.PreviousMode = entry.Mode
+					if entry.HasMode {
+						h.PreviousMode = entry.Mode
+					} else {
+						h.PreviousMode = 0
+					}
 					h.HasPreviousMode = true
+					h.PreviousModeKnown = entry.HasMode
 				}
 			}
 			h.Unlock()
@@ -4508,6 +4517,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			ino := fh.Ino
 			fh.HasPendingMode = false
 			fh.HasPreviousMode = false
+			fh.PreviousModeKnown = false
 			fh.Unlock()
 			fs.clearPendingModeForInodeExcept(ino, fh)
 			fh.Lock()
@@ -4552,6 +4562,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			pendingMode := fh.PendingMode & 0o777
 			previousMode := fh.PreviousMode
 			hasPreviousMode := fh.HasPreviousMode
+			previousModeKnown := fh.PreviousModeKnown
 			ino := fh.Ino
 			localPath := fh.Path
 			fh.Unlock()
@@ -4566,7 +4577,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				if err != nil {
 					log.Printf("release: pending chmod failed for %s: %v", localPath, err)
 					if hasPreviousMode {
-						fs.inodes.UpdateMode(ino, previousMode)
+						fs.inodes.SetModeState(ino, previousMode, previousModeKnown)
 					}
 					return
 				}
@@ -4576,7 +4587,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 
 			// Flush failed — revert the in-memory mode so local GetAttr doesn't lie.
 			if hasPreviousMode {
-				fs.inodes.UpdateMode(ino, previousMode)
+				fs.inodes.SetModeState(ino, previousMode, previousModeKnown)
 			}
 			fs.clearPendingModeForInode(ino)
 		}()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -4819,6 +4819,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 					}
 					return
 				}
+				fs.inodes.UpdateMode(ino, pendingMode)
 				fs.clearPendingModeForInode(ino)
 				return
 			}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -615,13 +615,11 @@ func (fs *Dat9FS) pendingKindForHandle(fh *FileHandle) PendingKind {
 }
 
 func createInputMode(inputMode uint32) (uint32, bool) {
-	mode := inputMode & 0o777
-	if mode == 0 {
-		return 0o644, false
-	}
-	return mode, true
+	return inputMode & 0o777, true
 }
 
+// modeForPendingHandle returns the mode that still needs to be committed to
+// the server. Callers must hold fh.mu unless the handle has not been published.
 func (fs *Dat9FS) modeForPendingHandle(fh *FileHandle) (uint32, bool) {
 	if fh == nil {
 		return 0, false
@@ -630,6 +628,16 @@ func (fs *Dat9FS) modeForPendingHandle(fh *FileHandle) (uint32, bool) {
 		return fh.PendingMode & 0o777, true
 	}
 	return 0, false
+}
+
+func (fs *Dat9FS) fileHandlesForInode(ino uint64) []*FileHandle {
+	var handles []*FileHandle
+	fs.fileHandles.ForEach(func(_ uint64, h *FileHandle) {
+		if h.Ino == ino {
+			handles = append(handles, h)
+		}
+	})
+	return handles
 }
 
 func (fs *Dat9FS) setPendingMetadataMode(path string, mode uint32) {
@@ -647,12 +655,60 @@ func (fs *Dat9FS) setPendingMetadataMode(path string, mode uint32) {
 }
 
 func (fs *Dat9FS) clearPendingModeForInode(ino uint64) {
-	fs.fileHandles.ForEach(func(_ uint64, h *FileHandle) {
-		if h.Ino == ino {
-			h.HasPendingMode = false
-			h.HasPreviousMode = false
+	fs.clearPendingModeForInodeExcept(ino, nil)
+}
+
+func (fs *Dat9FS) clearPendingModeForInodeExcept(ino uint64, skip *FileHandle) {
+	for _, h := range fs.fileHandlesForInode(ino) {
+		if h == skip {
+			continue
 		}
-	})
+		h.Lock()
+		h.HasPendingMode = false
+		h.HasPreviousMode = false
+		h.Unlock()
+	}
+}
+
+func (fs *Dat9FS) applyRemoteMode(ctx context.Context, localPath string, mode uint32) error {
+	mode &= 0o777
+	start := fs.perfStart()
+	err := fs.client.ChmodCtx(ctx, fs.remotePath(localPath), mode)
+	fs.perfRecordRemote(perfRemoteMutation, start, err, 0)
+	if err != nil {
+		return fmt.Errorf("chmod %s to %o: %w", localPath, mode, err)
+	}
+	return nil
+}
+
+// applyPendingModeForHandleLocked applies a deferred chmod after the data
+// upload has succeeded. Caller must hold fh.mu; this method drops it around
+// the network request and re-acquires it before returning.
+func (fs *Dat9FS) applyPendingModeForHandleLocked(ctx context.Context, fh *FileHandle) error {
+	mode, hasMode := fs.modeForPendingHandle(fh)
+	if !hasMode {
+		return nil
+	}
+	localPath := fh.Path
+	ino := fh.Ino
+	previousMode := fh.PreviousMode
+	hasPreviousMode := fh.HasPreviousMode
+
+	fh.Unlock()
+	err := fs.applyRemoteMode(ctx, localPath, mode)
+	fh.Lock()
+	if err != nil {
+		if hasPreviousMode {
+			fs.inodes.UpdateMode(ino, previousMode)
+		}
+		return err
+	}
+	fh.HasPendingMode = false
+	fh.HasPreviousMode = false
+	fh.Unlock()
+	fs.clearPendingModeForInodeExcept(ino, fh)
+	fh.Lock()
+	return nil
 }
 
 func expectedRevisionForHandle(fh *FileHandle) int64 {
@@ -2157,11 +2213,10 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 		}
 		// If the file has an open dirty handle, update mode locally without
 		// consulting the remote server. The mode will be synced on Flush.
-		// Use a single ForEach pass to avoid a TOCTOU race between the check
-		// and the mutation.
 		hasDirtyHandle := false
-		fs.fileHandles.ForEach(func(_ uint64, h *FileHandle) {
-			if h.Ino == input.NodeId && h.Dirty != nil {
+		for _, h := range fs.fileHandlesForInode(input.NodeId) {
+			h.Lock()
+			if h.Dirty != nil {
 				hasDirtyHandle = true
 				h.PendingMode = mode
 				h.HasPendingMode = true
@@ -2170,7 +2225,8 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 					h.HasPreviousMode = true
 				}
 			}
-		})
+			h.Unlock()
+		}
 		if hasDirtyHandle {
 			fs.setPendingMetadataMode(entry.Path, mode)
 		}
@@ -4006,6 +4062,10 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 		log.Printf("write-sync upload failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}
+	if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+		log.Printf("write-sync pending chmod failed for %s: %v", fh.Path, err)
+		return httpToFuseStatus(err)
+	}
 
 	fh.Dirty.ClearDirty()
 	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
@@ -4054,6 +4114,10 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		fs.debugDurationf(uploadStart, 0, "sync handle shadowspill upload done path=%s size=%d err=%v", fh.Path, size, err)
 		if err != nil {
 			log.Printf("sync handle shadowspill upload failed for %s: %v", fh.Path, err)
+			return httpToFuseStatus(err)
+		}
+		if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+			log.Printf("sync handle shadowspill pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
 		fh.Dirty.ClearDirty()
@@ -4238,6 +4302,10 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 				log.Printf("flush: ShadowSpill sync upload failed for %s: %v", fh.Path, err)
 				return gofuse.EIO
 			}
+			if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+				log.Printf("flush: ShadowSpill pending chmod failed for %s: %v", fh.Path, err)
+				return httpToFuseStatus(err)
+			}
 			fh.Dirty.ClearDirty()
 			fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 			fh.DirtySeq = 0
@@ -4398,6 +4466,10 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			log.Printf("fsync: ShadowSpill sync upload failed for %s: %v", fh.Path, err)
 			return gofuse.EIO
 		}
+		if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+			log.Printf("fsync: ShadowSpill pending chmod failed for %s: %v", fh.Path, err)
+			return httpToFuseStatus(err)
+		}
 		if fh.Dirty != nil {
 			fh.Dirty.ClearDirty()
 			fs.clearDirtySize(fh.Ino, fh.DirtySeq)
@@ -4420,6 +4492,14 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		if err != nil {
 			log.Printf("fsync writeback upload failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
+		}
+		if fh.HasPendingMode {
+			ino := fh.Ino
+			fh.HasPendingMode = false
+			fh.HasPreviousMode = false
+			fh.Unlock()
+			fs.clearPendingModeForInodeExcept(ino, fh)
+			fh.Lock()
 		}
 		// UploadSync already persisted the data to the server. Clear
 		// the dirty state so the subsequent flushHandleDebounced sees
@@ -4447,41 +4527,47 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 	fh, ok := fs.fileHandles.Get(input.Fh)
 	if ok {
 		flushStatus := gofuse.OK
-		// Apply any deferred chmod after flush completes but before cleanup.
-		defer func() {
-			if fh.HasPendingMode {
-				if flushStatus == gofuse.OK {
-					ctx, cf := context.WithTimeout(context.Background(), 30*time.Second)
-					if err := fs.client.ChmodCtx(ctx, fs.remotePath(fh.Path), fh.PendingMode); err != nil {
-						log.Printf("release: pending chmod failed for %s: %v", fh.Path, err)
-						// Revert in-memory mode so local GetAttr doesn't lie.
-						if fh.HasPreviousMode {
-							fs.inodes.UpdateMode(fh.Ino, fh.PreviousMode)
-						}
-					}
-					cf()
-				} else {
-					// Flush failed — revert the in-memory mode so local GetAttr doesn't lie.
-					if fh.HasPreviousMode {
-						fs.inodes.UpdateMode(fh.Ino, fh.PreviousMode)
-					}
-				}
-				// Clear pending mode on all sibling handles so they don't re-apply
-				// or revert after this handle already decided the outcome.
-				fs.fileHandles.ForEach(func(_ uint64, h *FileHandle) {
-					if h.Ino == fh.Ino {
-						h.HasPendingMode = false
-						h.HasPreviousMode = false
-					}
-				})
-			}
-		}()
 		defer func() {
 			if fh.Prefetch != nil {
 				fh.Prefetch.Close()
 			}
 			fs.deleteFileHandle(input.Fh, fh)
 			fs.cleanupReleasedInode(fh.Ino, fh.Path)
+		}()
+		// Apply any deferred chmod after flush completes but before cleanup.
+		defer func() {
+			fh.Lock()
+			hasPendingMode := fh.HasPendingMode
+			pendingMode := fh.PendingMode & 0o777
+			previousMode := fh.PreviousMode
+			hasPreviousMode := fh.HasPreviousMode
+			ino := fh.Ino
+			localPath := fh.Path
+			fh.Unlock()
+			if !hasPendingMode {
+				return
+			}
+
+			if flushStatus == gofuse.OK {
+				ctx, cf := context.WithTimeout(context.Background(), 30*time.Second)
+				err := fs.applyRemoteMode(ctx, localPath, pendingMode)
+				cf()
+				if err != nil {
+					log.Printf("release: pending chmod failed for %s: %v", localPath, err)
+					if hasPreviousMode {
+						fs.inodes.UpdateMode(ino, previousMode)
+					}
+					return
+				}
+				fs.clearPendingModeForInode(ino)
+				return
+			}
+
+			// Flush failed — revert the in-memory mode so local GetAttr doesn't lie.
+			if hasPreviousMode {
+				fs.inodes.UpdateMode(ino, previousMode)
+			}
+			fs.clearPendingModeForInode(ino)
 		}()
 
 		// Unpin shadow if this handle pinned it, so deferred removals can proceed.
@@ -4764,6 +4850,14 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 			log.Printf("debounced flush failed for %s: %v", filePath, err)
 			return
 		}
+		modeCtx, modeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		modeErr := fs.applyPendingModeForHandleLocked(modeCtx, handle)
+		modeCancel()
+		if modeErr != nil {
+			handle.Unlock()
+			log.Printf("debounced flush pending chmod failed for %s: %v", filePath, modeErr)
+			return
+		}
 		// The handle stays locked across upload + finalize so concurrent writes
 		// cannot advance live state for data outside this committed snapshot.
 		if committedRev > 0 {
@@ -4892,6 +4986,10 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			log.Printf("finish streaming failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
+		if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+			log.Printf("finish streaming pending chmod failed for %s: %v", fh.Path, err)
+			return httpToFuseStatus(err)
+		}
 
 		fh.Dirty.ClearDirty()
 		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
@@ -4948,6 +5046,10 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 
 		if err != nil {
 			log.Printf("upload all parts failed for %s: %v", fh.Path, err)
+			return httpToFuseStatus(err)
+		}
+		if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+			log.Printf("upload all pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
 
@@ -5062,6 +5164,10 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	}
 	if err != nil {
 		log.Printf("flush upload failed for %s: %v", fh.Path, err)
+		return httpToFuseStatus(err)
+	}
+	if err := fs.applyPendingModeForHandleLocked(ctx, fh); err != nil {
+		log.Printf("flush pending chmod failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -4572,7 +4572,9 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 
 			if flushStatus == gofuse.OK {
 				ctx, cf := context.WithTimeout(context.Background(), 30*time.Second)
-				err := fs.applyRemoteMode(ctx, localPath, pendingMode)
+				err := retryPostUploadMode(ctx, func() error {
+					return fs.applyRemoteMode(ctx, localPath, pendingMode)
+				})
 				cf()
 				if err != nil {
 					log.Printf("release: pending chmod failed for %s: %v", localPath, err)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3179,6 +3179,69 @@ func TestCreateDefaultModeDoesNotStageRemoteMode(t *testing.T) {
 	}
 }
 
+func TestDeferredChmodRollbackRestoresUnknownMode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.RawQuery == "chmod" {
+			http.Error(w, "chmod failed", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/rollback.txt", false, 4, time.Now())
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode not found")
+	}
+	if entry.HasMode {
+		t.Fatal("test setup expected unknown mode")
+	}
+
+	wb := NewWriteBuffer("/rollback.txt", maxPreloadSize, 0)
+	if _, err := wb.Write(0, []byte("data")); err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    "/rollback.txt",
+		Dirty:   wb,
+		BaseRev: 3,
+	}
+	fs.fileHandles.Allocate(fh)
+
+	var out gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_MODE,
+			Mode:     0o755,
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+
+	fh.Lock()
+	err := fs.applyPendingModeForHandleLocked(context.Background(), fh)
+	fh.Unlock()
+	if err == nil {
+		t.Fatal("applyPendingModeForHandleLocked should fail")
+	}
+
+	entry, ok = fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode not found after rollback")
+	}
+	if entry.HasMode {
+		t.Fatalf("rollback should restore unknown mode, got mode=%o", entry.Mode)
+	}
+}
+
 func TestLookupPendingIndexPreservesMode(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3106,8 +3106,47 @@ func TestCreatePreservesInputMode(t *testing.T) {
 	if !ok {
 		t.Fatal("created file handle not found")
 	}
+	fh.Lock()
+	defer fh.Unlock()
 	if !fh.HasPendingMode || fh.PendingMode != 0o755 {
 		t.Fatalf("pending mode = %o has=%t, want 0755 true", fh.PendingMode, fh.HasPendingMode)
+	}
+}
+
+func TestCreatePreservesZeroMode(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	var out gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_CREAT),
+		Mode:     0,
+	}, "private.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	if got, want := out.Mode, uint32(syscall.S_IFREG); got != want {
+		t.Fatalf("Create mode = %o, want %o", got, want)
+	}
+
+	entry, ok := fs.inodes.GetEntry(out.NodeId)
+	if !ok {
+		t.Fatal("created inode not found")
+	}
+	if !entry.HasMode || entry.Mode != 0 {
+		t.Fatalf("inode mode = %o has=%t, want 000 true", entry.Mode, entry.HasMode)
+	}
+
+	fh, ok := fs.fileHandles.Get(out.Fh)
+	if !ok {
+		t.Fatal("created file handle not found")
+	}
+	fh.Lock()
+	defer fh.Unlock()
+	if !fh.HasPendingMode || fh.PendingMode != 0 {
+		t.Fatalf("pending mode = %o has=%t, want 000 true", fh.PendingMode, fh.HasPendingMode)
 	}
 }
 
@@ -3808,6 +3847,10 @@ func TestReleaseNewEmptyFileUsesCreateAction(t *testing.T) {
 			if r.URL.Path != "/v1/fs/empty.txt" {
 				recordHandlerErr(fmt.Errorf("path = %s, want /v1/fs/empty.txt", r.URL.Path))
 				http.Error(w, "bad path", http.StatusBadRequest)
+				return
+			}
+			if r.URL.Query().Has("chmod") {
+				w.WriteHeader(http.StatusOK)
 				return
 			}
 			if !r.URL.Query().Has("create") {
@@ -5189,6 +5232,8 @@ func largeFlushStreamingMock(t *testing.T, fileSize int64, completeCh chan<- str
 			etag := fmt.Sprintf(`"etag-%d"`, etagSeq)
 			mu.Unlock()
 			w.Header().Set("ETag", etag)
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Query().Has("chmod"):
 			w.WriteHeader(http.StatusOK)
 		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/up-large/complete":
 			_, _ = io.Copy(io.Discard, r.Body)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3076,6 +3076,123 @@ func TestLockFileCreateDisablesEntryCache(t *testing.T) {
 	}
 }
 
+func TestCreatePreservesInputMode(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	var out gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_CREAT),
+		Mode:     0o755,
+	}, "exec.sh", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	if got, want := out.Mode, uint32(syscall.S_IFREG)|0o755; got != want {
+		t.Fatalf("Create mode = %o, want %o", got, want)
+	}
+
+	entry, ok := fs.inodes.GetEntry(out.NodeId)
+	if !ok {
+		t.Fatal("created inode not found")
+	}
+	if !entry.HasMode || entry.Mode != 0o755 {
+		t.Fatalf("inode mode = %o has=%t, want 0755 true", entry.Mode, entry.HasMode)
+	}
+
+	fh, ok := fs.fileHandles.Get(out.Fh)
+	if !ok {
+		t.Fatal("created file handle not found")
+	}
+	if !fh.HasPendingMode || fh.PendingMode != 0o755 {
+		t.Fatalf("pending mode = %o has=%t, want 0755 true", fh.PendingMode, fh.HasPendingMode)
+	}
+}
+
+func TestLookupPendingIndexPreservesMode(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.pendingIndex = pending
+	if _, err := pending.PutWithBaseRevAndMode("/exec.sh", 3, PendingNew, 0, 0o755, true); err != nil {
+		t.Fatal(err)
+	}
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "exec.sh", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if got, want := out.Mode, uint32(syscall.S_IFREG)|0o755; got != want {
+		t.Fatalf("Lookup mode = %o, want %o", got, want)
+	}
+}
+
+func TestFlushStagesCreateModeInPendingMetadata(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeBack, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.writeBack = writeBack
+
+	var out gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_CREAT),
+		Mode:     0o755,
+	}, "exec.sh", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: out.NodeId},
+		Fh:       out.Fh,
+	}, []byte("echo ok\n")); st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+	st = fs.Flush(nil, &gofuse.FlushIn{Fh: out.Fh})
+	if st != gofuse.OK {
+		t.Fatalf("Flush status = %v, want OK", st)
+	}
+
+	pendingMeta, ok := pending.GetMeta("/exec.sh")
+	if !ok {
+		t.Fatal("pending index entry missing")
+	}
+	if !pendingMeta.HasMode || pendingMeta.Mode != 0o755 {
+		t.Fatalf("pending mode = %o has=%t, want 0755 true", pendingMeta.Mode, pendingMeta.HasMode)
+	}
+	writeBackMeta, ok := writeBack.GetMeta("/exec.sh")
+	if !ok {
+		t.Fatal("writeback entry missing")
+	}
+	if !writeBackMeta.HasMode || writeBackMeta.Mode != 0o755 {
+		t.Fatalf("writeback mode = %o has=%t, want 0755 true", writeBackMeta.Mode, writeBackMeta.HasMode)
+	}
+}
+
 func TestInitStoresServer(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3439,7 +3439,7 @@ func TestReleaseRetriesDeferredChmodNotFound(t *testing.T) {
 	fs := NewDat9FS(newTestClient(ts.URL), opts)
 
 	ino := fs.inodes.Lookup("/release-retry.txt", false, 0, time.Now())
-	fs.inodes.UpdateMode(ino, 0o755)
+	fs.inodes.UpdateMode(ino, 0o644)
 	fh := &FileHandle{
 		Ino:               ino,
 		Path:              "/release-retry.txt",

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3468,6 +3468,191 @@ func TestReleaseRetriesDeferredChmodNotFound(t *testing.T) {
 	}
 }
 
+func TestApplyPendingModeDoesNotClearNewerConcurrentChmod(t *testing.T) {
+	var chmodCalls atomic.Int32
+	chmodStarted := make(chan struct{})
+	allowChmod := make(chan struct{})
+	var startedOnce sync.Once
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			if chmodCalls.Add(1) == 1 {
+				startedOnce.Do(func() { close(chmodStarted) })
+				<-allowChmod
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/chmod-race.txt", false, 4, time.Now())
+	fs.inodes.UpdateMode(ino, 0o644)
+	fh1 := &FileHandle{Ino: ino, Path: "/chmod-race.txt", Dirty: NewWriteBuffer("/chmod-race.txt", maxPreloadSize, 0), BaseRev: 1}
+	fh2 := &FileHandle{Ino: ino, Path: "/chmod-race.txt", Dirty: NewWriteBuffer("/chmod-race.txt", maxPreloadSize, 0), BaseRev: 1}
+	fs.fileHandles.Allocate(fh1)
+	fs.fileHandles.Allocate(fh2)
+
+	var out gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_MODE,
+			Mode:     0o755,
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr 0755 status = %v, want OK", st)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		fh1.Lock()
+		err := fs.applyPendingModeForHandleLocked(context.Background(), fh1)
+		fh1.Unlock()
+		done <- err
+	}()
+
+	select {
+	case <-chmodStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first chmod did not start")
+	}
+
+	st = fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_MODE,
+			Mode:     0o700,
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr 0700 status = %v, want OK", st)
+	}
+	close(allowChmod)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("applyPendingModeForHandleLocked: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pending chmod did not finish")
+	}
+
+	for i, fh := range []*FileHandle{fh1, fh2} {
+		fh.Lock()
+		hasPending := fh.HasPendingMode
+		pendingMode := fh.PendingMode & 0o777
+		fh.Unlock()
+		if !hasPending || pendingMode != 0o700 {
+			t.Fatalf("fh%d pending mode = %o has=%t, want 0700 true", i+1, pendingMode, hasPending)
+		}
+	}
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode not found")
+	}
+	if !entry.HasMode || entry.Mode&0o777 != 0o700 {
+		t.Fatalf("inode mode = %o has=%t, want 0700 true", entry.Mode&0o777, entry.HasMode)
+	}
+}
+
+func TestReleaseDeferredChmodDoesNotClearNewerConcurrentChmod(t *testing.T) {
+	var chmodCalls atomic.Int32
+	chmodStarted := make(chan struct{})
+	allowChmod := make(chan struct{})
+	var startedOnce sync.Once
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			if chmodCalls.Add(1) == 1 {
+				startedOnce.Do(func() { close(chmodStarted) })
+				<-allowChmod
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/release-chmod-race.txt", false, 0, time.Now())
+	fs.inodes.UpdateMode(ino, 0o644)
+	fh1 := &FileHandle{Ino: ino, Path: "/release-chmod-race.txt", Dirty: NewWriteBuffer("/release-chmod-race.txt", maxPreloadSize, 0), BaseRev: 1}
+	fh2 := &FileHandle{Ino: ino, Path: "/release-chmod-race.txt", Dirty: NewWriteBuffer("/release-chmod-race.txt", maxPreloadSize, 0), BaseRev: 1}
+	fh1ID := fs.fileHandles.Allocate(fh1)
+	fs.fileHandles.Allocate(fh2)
+
+	var out gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_MODE,
+			Mode:     0o755,
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr 0755 status = %v, want OK", st)
+	}
+
+	releaseDone := make(chan struct{})
+	go func() {
+		fs.Release(nil, &gofuse.ReleaseIn{Fh: fh1ID})
+		close(releaseDone)
+	}()
+
+	select {
+	case <-chmodStarted:
+	case <-time.After(time.Second):
+		t.Fatal("release chmod did not start")
+	}
+
+	st = fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_MODE,
+			Mode:     0o700,
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr 0700 status = %v, want OK", st)
+	}
+	close(allowChmod)
+
+	select {
+	case <-releaseDone:
+	case <-time.After(time.Second):
+		t.Fatal("Release did not finish")
+	}
+
+	fh2.Lock()
+	hasPending := fh2.HasPendingMode
+	pendingMode := fh2.PendingMode & 0o777
+	fh2.Unlock()
+	if !hasPending || pendingMode != 0o700 {
+		t.Fatalf("sibling pending mode = %o has=%t, want 0700 true", pendingMode, hasPending)
+	}
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode not found")
+	}
+	if !entry.HasMode || entry.Mode&0o777 != 0o700 {
+		t.Fatalf("inode mode = %o has=%t, want 0700 true", entry.Mode&0o777, entry.HasMode)
+	}
+}
+
 func TestLookupPendingIndexPreservesMode(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3150,6 +3150,35 @@ func TestCreatePreservesZeroMode(t *testing.T) {
 	}
 }
 
+func TestCreateDefaultModeDoesNotStageRemoteMode(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	var out gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_CREAT),
+		Mode:     defaultRegularFileMode,
+	}, "plain.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	if got, want := out.Mode, uint32(syscall.S_IFREG)|defaultRegularFileMode; got != want {
+		t.Fatalf("Create mode = %o, want %o", got, want)
+	}
+
+	fh, ok := fs.fileHandles.Get(out.Fh)
+	if !ok {
+		t.Fatal("created file handle not found")
+	}
+	fh.Lock()
+	defer fh.Unlock()
+	if fh.HasPendingMode {
+		t.Fatalf("default create mode should not require remote chmod, got pending %o", fh.PendingMode)
+	}
+}
+
 func TestLookupPendingIndexPreservesMode(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3242,6 +3242,57 @@ func TestDeferredChmodRollbackRestoresUnknownMode(t *testing.T) {
 	}
 }
 
+func TestReleaseRetriesDeferredChmodNotFound(t *testing.T) {
+	var chmodCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			if chmodCalls.Add(1) == 1 {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/release-retry.txt", false, 0, time.Now())
+	fs.inodes.UpdateMode(ino, 0o755)
+	fh := &FileHandle{
+		Ino:               ino,
+		Path:              "/release-retry.txt",
+		PendingMode:       0o755,
+		HasPendingMode:    true,
+		PreviousMode:      0o644,
+		HasPreviousMode:   true,
+		PreviousModeKnown: true,
+	}
+	fhID := fs.fileHandles.Allocate(fh)
+
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: fhID})
+
+	if got := chmodCalls.Load(); got != 2 {
+		t.Fatalf("chmod calls = %d, want 2", got)
+	}
+	if fh.HasPendingMode {
+		t.Fatal("pending mode should be cleared after Release retry succeeds")
+	}
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode not found after Release")
+	}
+	if !entry.HasMode || entry.Mode&0o777 != 0o755 {
+		t.Fatalf("inode mode = %o has=%t, want 0755 true", entry.Mode&0o777, entry.HasMode)
+	}
+}
+
 func TestLookupPendingIndexPreservesMode(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -32,6 +32,7 @@ type FileHandle struct {
 	WritePolicy       WritePolicy // per-handle remote durability policy chosen at open/create
 	PendingMode       uint32      // mode change deferred because a dirty handle was open
 	HasPendingMode    bool        // true when PendingMode should be applied on Release
+	PendingModeGen    uint64      // generation for PendingMode, used to avoid clearing newer chmods
 	PreviousMode      uint32      // mode before PendingMode was set (for rollback on flush failure)
 	HasPreviousMode   bool        // true when previous mode state was snapshotted
 	PreviousModeKnown bool        // true when PreviousMode was authoritative

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -32,7 +32,8 @@ type FileHandle struct {
 	PendingMode       uint32      // mode change deferred because a dirty handle was open
 	HasPendingMode    bool        // true when PendingMode should be applied on Release
 	PreviousMode      uint32      // mode before PendingMode was set (for rollback on flush failure)
-	HasPreviousMode   bool        // true when PreviousMode is valid
+	HasPreviousMode   bool        // true when previous mode state was snapshotted
+	PreviousModeKnown bool        // true when PreviousMode was authoritative
 	mu                sync.Mutex
 }
 

--- a/pkg/fuse/inode.go
+++ b/pkg/fuse/inode.go
@@ -250,12 +250,17 @@ func (m *InodeToPath) UpdateRevision(ino uint64, revision int64) {
 
 // UpdateMode updates the permission bits of the entry identified by ino.
 func (m *InodeToPath) UpdateMode(ino uint64, mode uint32) {
+	m.SetModeState(ino, mode, true)
+}
+
+// SetModeState updates both permission bits and whether they are authoritative.
+func (m *InodeToPath) SetModeState(ino uint64, mode uint32, hasMode bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if entry, ok := m.byInode[ino]; ok {
 		entry.Mode = mode
-		entry.HasMode = true
+		entry.HasMode = hasMode
 	}
 }
 

--- a/pkg/fuse/mode.go
+++ b/pkg/fuse/mode.go
@@ -1,0 +1,47 @@
+package fuse
+
+import (
+	"context"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+const (
+	defaultRegularFileMode     uint32 = 0o644
+	postUploadModeAttempts            = 5
+	postUploadModeInitialDelay        = 10 * time.Millisecond
+)
+
+func shouldApplyRemoteMode(kind PendingKind, hasMode bool, mode uint32) bool {
+	if !hasMode {
+		return false
+	}
+	if kind == PendingNew && mode&0o777 == defaultRegularFileMode {
+		return false
+	}
+	return true
+}
+
+func retryPostUploadMode(ctx context.Context, apply func() error) error {
+	var lastErr error
+	for attempt := 0; attempt < postUploadModeAttempts; attempt++ {
+		lastErr = apply()
+		if lastErr == nil {
+			return nil
+		}
+		if !client.IsNotFound(lastErr) || attempt == postUploadModeAttempts-1 {
+			return lastErr
+		}
+
+		delay := postUploadModeInitialDelay << attempt
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return lastErr
+}

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -79,17 +79,29 @@ func (idx *PendingIndex) Put(remotePath string, size int64, kind PendingKind) (u
 // PutWithBaseRev stores metadata for the given path together with the base
 // revision observed when the local edit session started.
 func (idx *PendingIndex) PutWithBaseRev(remotePath string, size int64, kind PendingKind, baseRev int64) (uint64, error) {
-	return idx.putInternal(remotePath, size, kind, baseRev, false)
+	return idx.PutWithBaseRevAndMode(remotePath, size, kind, baseRev, 0, false)
+}
+
+// PutWithBaseRevAndMode stores metadata for the given path together with the
+// file mode that must be applied after the pending data commits remotely.
+func (idx *PendingIndex) PutWithBaseRevAndMode(remotePath string, size int64, kind PendingKind, baseRev int64, mode uint32, hasMode bool) (uint64, error) {
+	return idx.putInternal(remotePath, size, kind, baseRev, false, mode, hasMode)
 }
 
 // PutShadowSpill is like PutWithBaseRev but marks the entry as ShadowSpill
 // so that crash recovery (RecoverPending) reconstructs it with the correct
 // upload path (streaming from shadow, not full-memory ReadAll).
 func (idx *PendingIndex) PutShadowSpill(remotePath string, size int64, kind PendingKind, baseRev int64) (uint64, error) {
-	return idx.putInternal(remotePath, size, kind, baseRev, true)
+	return idx.PutShadowSpillWithMode(remotePath, size, kind, baseRev, 0, false)
 }
 
-func (idx *PendingIndex) putInternal(remotePath string, size int64, kind PendingKind, baseRev int64, shadowSpill bool) (uint64, error) {
+// PutShadowSpillWithMode is like PutShadowSpill, but also persists file mode
+// metadata for the eventual remote chmod.
+func (idx *PendingIndex) PutShadowSpillWithMode(remotePath string, size int64, kind PendingKind, baseRev int64, mode uint32, hasMode bool) (uint64, error) {
+	return idx.putInternal(remotePath, size, kind, baseRev, true, mode, hasMode)
+}
+
+func (idx *PendingIndex) putInternal(remotePath string, size int64, kind PendingKind, baseRev int64, shadowSpill bool, mode uint32, hasMode bool) (uint64, error) {
 	gen := idx.nextGen.Add(1)
 	meta := &WriteBackMeta{
 		Path:        remotePath,
@@ -100,6 +112,8 @@ func (idx *PendingIndex) putInternal(remotePath string, size int64, kind Pending
 		Kind:        kind,
 		BaseRev:     baseRev,
 		ShadowSpill: shadowSpill,
+		Mode:        mode & 0o777,
+		HasMode:     hasMode,
 	}
 
 	// Write to disk first for durability.
@@ -181,6 +195,8 @@ func (idx *PendingIndex) RenamePending(oldPath, newPath string) bool {
 		Kind:        meta.Kind,
 		BaseRev:     meta.BaseRev,
 		ShadowSpill: meta.ShadowSpill,
+		Mode:        meta.Mode,
+		HasMode:     meta.HasMode,
 	}
 	idx.mu.RUnlock()
 
@@ -242,6 +258,33 @@ func (idx *PendingIndex) UpdateSize(remotePath string, size int64) {
 		meta.Size = size
 		meta.Mtime = time.Now()
 	}
+}
+
+// UpdateMode updates the pending mode metadata for an existing entry.
+func (idx *PendingIndex) UpdateMode(remotePath string, mode uint32) error {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	meta, ok := idx.items[remotePath]
+	if !ok {
+		return nil
+	}
+	updated := *meta
+	updated.Mode = mode & 0o777
+	updated.HasMode = true
+	updated.Generation = idx.nextGen.Add(1)
+
+	metaBytes, err := json.Marshal(&updated)
+	if err != nil {
+		return fmt.Errorf("pending index marshal mode: %w", err)
+	}
+	metaPath := filepath.Join(idx.dir, hashPath(remotePath)+".meta")
+	if err := atomicWrite(metaPath, metaBytes); err != nil {
+		return fmt.Errorf("pending index update mode: %w", err)
+	}
+	cp := updated
+	idx.items[remotePath] = &cp
+	return nil
 }
 
 // MarkConflict marks a pending entry as conflicted so that RecoverPending

--- a/pkg/fuse/pending_index_test.go
+++ b/pkg/fuse/pending_index_test.go
@@ -66,7 +66,7 @@ func TestPendingIndexRenamePending(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = idx.PutShadowSpill("/old/file.txt", 512, PendingOverwrite, 11)
+	_, err = idx.PutShadowSpillWithMode("/old/file.txt", 512, PendingOverwrite, 11, 0o755, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,6 +98,9 @@ func TestPendingIndexRenamePending(t *testing.T) {
 	if meta.BaseRev != 11 {
 		t.Errorf("baseRev = %d, want 11", meta.BaseRev)
 	}
+	if !meta.HasMode || meta.Mode != 0o755 {
+		t.Errorf("mode = %o has=%t, want 0755 true", meta.Mode, meta.HasMode)
+	}
 }
 
 func TestPendingIndexRecoverFromDisk(t *testing.T) {
@@ -108,7 +111,7 @@ func TestPendingIndexRecoverFromDisk(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = idx1.Put("/recover/a.txt", 100, PendingNew)
+	_, err = idx1.PutWithBaseRevAndMode("/recover/a.txt", 100, PendingNew, 0, 0o755, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,6 +135,9 @@ func TestPendingIndexRecoverFromDisk(t *testing.T) {
 	}
 	if meta.Size != 100 {
 		t.Errorf("a.txt size = %d, want 100", meta.Size)
+	}
+	if !meta.HasMode || meta.Mode != 0o755 {
+		t.Errorf("a.txt mode = %o has=%t, want 0755 true", meta.Mode, meta.HasMode)
 	}
 
 	meta, ok = idx2.GetMeta("/recover/b.txt")

--- a/pkg/fuse/writeback.go
+++ b/pkg/fuse/writeback.go
@@ -63,6 +63,8 @@ type WriteBackMeta struct {
 	Kind        PendingKind `json:"kind"`
 	BaseRev     int64       `json:"base_rev,omitempty"`
 	ShadowSpill bool        `json:"shadow_spill,omitempty"`
+	Mode        uint32      `json:"mode,omitempty"`
+	HasMode     bool        `json:"has_mode,omitempty"`
 }
 
 // WriteBackCache manages a local disk cache of pending (not-yet-uploaded)
@@ -175,6 +177,12 @@ func (c *WriteBackCache) Put(remotePath string, data []byte, size int64, kind Pe
 // PutWithBaseRev is like Put, but also persists the remote base revision used
 // for CAS-protected overwrite uploads. baseRev is ignored for PendingNew.
 func (c *WriteBackCache) PutWithBaseRev(remotePath string, data []byte, size int64, kind PendingKind, baseRev int64) error {
+	return c.PutWithBaseRevAndMode(remotePath, data, size, kind, baseRev, 0, false)
+}
+
+// PutWithBaseRevAndMode is like PutWithBaseRev, but also persists the file
+// permission bits that should be applied once the pending data is remote.
+func (c *WriteBackCache) PutWithBaseRevAndMode(remotePath string, data []byte, size int64, kind PendingKind, baseRev int64, mode uint32, hasMode bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -193,6 +201,8 @@ func (c *WriteBackCache) PutWithBaseRev(remotePath string, data []byte, size int
 		Generation: c.nextGen.Add(1),
 		Kind:       kind,
 		BaseRev:    baseRev,
+		Mode:       mode & 0o777,
+		HasMode:    hasMode,
 	}
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {
@@ -328,6 +338,32 @@ func (c *WriteBackCache) Remove(remotePath string) {
 	defer c.mu.Unlock()
 
 	c.pruneEntryLocked(remotePath, true)
+}
+
+// UpdateMode updates the pending mode metadata for an existing cache entry.
+func (c *WriteBackCache) UpdateMode(remotePath string, mode uint32) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	meta, ok := c.metas[remotePath]
+	if !ok {
+		return nil
+	}
+	updated := *meta
+	updated.Mode = mode & 0o777
+	updated.HasMode = true
+	updated.Generation = c.nextGen.Add(1)
+
+	metaBytes, err := json.Marshal(updated)
+	if err != nil {
+		return fmt.Errorf("writeback marshal mode meta: %w", err)
+	}
+	if err := atomicWrite(c.metaFile(remotePath), metaBytes); err != nil {
+		return fmt.Errorf("writeback update mode meta: %w", err)
+	}
+	cp := updated
+	c.metas[remotePath] = &cp
+	return nil
 }
 
 // RenamePending atomically moves a pending cache entry from oldPath to newPath.

--- a/pkg/fuse/writeback.go
+++ b/pkg/fuse/writeback.go
@@ -50,6 +50,9 @@ const (
 	// retries). The local data is preserved for manual recovery but will
 	// not be re-enqueued by RecoverPending.
 	PendingConflict
+	// PendingChmod means file data has already been uploaded remotely, but
+	// the post-upload chmod step still needs to be retried.
+	PendingChmod
 )
 
 // WriteBackMeta stores metadata alongside cached file data so that the
@@ -364,6 +367,34 @@ func (c *WriteBackCache) UpdateMode(remotePath string, mode uint32) error {
 	cp := updated
 	c.metas[remotePath] = &cp
 	return nil
+}
+
+// MarkChmodPending records that data has reached the remote server and only
+// the chmod step remains. The generation guard prevents an old upload from
+// overwriting metadata for a newer local write.
+func (c *WriteBackCache) MarkChmodPending(remotePath string, generation uint64) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	meta, ok := c.metas[remotePath]
+	if !ok || meta.Generation != generation {
+		return false, nil
+	}
+	updated := *meta
+	updated.Kind = PendingChmod
+	updated.BaseRev = 0
+	updated.Generation = c.nextGen.Add(1)
+
+	metaBytes, err := json.Marshal(updated)
+	if err != nil {
+		return false, fmt.Errorf("writeback marshal chmod-pending meta: %w", err)
+	}
+	if err := atomicWrite(c.metaFile(remotePath), metaBytes); err != nil {
+		return false, fmt.Errorf("writeback update chmod-pending meta: %w", err)
+	}
+	cp := updated
+	c.metas[remotePath] = &cp
+	return true, nil
 }
 
 // RenamePending atomically moves a pending cache entry from oldPath to newPath.

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -533,6 +533,62 @@ func TestWriteBackUploader_UploadFailRetainsCache(t *testing.T) {
 	}
 }
 
+func TestWriteBackUploader_ChmodFailureRetainsCache(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			http.Error(w, "chmod failed", http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	cache, _ := NewWriteBackCache(dir)
+	c := newTestClient(ts.URL)
+	uploader := NewWriteBackUploader(c, cache, 1)
+
+	_ = cache.PutWithBaseRevAndMode("/mode-fail.txt", []byte("data"), 4, PendingNew, 0, 0o755, true)
+	uploader.Submit("/mode-fail.txt")
+	uploader.DrainAll()
+
+	if _, ok := cache.Get("/mode-fail.txt"); !ok {
+		t.Fatal("cache entry should be retained after chmod failure")
+	}
+}
+
+func TestWriteBackUploader_UploadSyncChmodFailureReturnsErrorAndRetainsCache(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			http.Error(w, "chmod failed", http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	cache, _ := NewWriteBackCache(dir)
+	c := newTestClient(ts.URL)
+	uploader := NewWriteBackUploader(c, cache, 1)
+
+	_ = cache.PutWithBaseRevAndMode("/mode-sync-fail.txt", []byte("data"), 4, PendingNew, 0, 0o755, true)
+	err := uploader.UploadSync(context.Background(), "/mode-sync-fail.txt")
+	if err == nil {
+		t.Fatal("UploadSync should fail when chmod fails")
+	}
+	if _, ok := cache.Get("/mode-sync-fail.txt"); !ok {
+		t.Fatal("cache entry should be retained after UploadSync chmod failure")
+	}
+	uploader.DrainAll()
+}
+
 func TestWriteBackUploader_PendingNewUsesCreateIfAbsent(t *testing.T) {
 	var gotExpected string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1217,6 +1273,9 @@ func newWriteSyncMultipartRecorder(t *testing.T, wantPath string) *writeSyncMult
 	}
 	rec.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs"+rec.wantPath && r.URL.Query().Has("chmod"):
+			w.WriteHeader(http.StatusOK)
+			return
 		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/initiate":
 			var req struct {
 				Path      string `json:"path"`

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -560,6 +560,43 @@ func TestWriteBackUploader_ChmodFailureRetainsCache(t *testing.T) {
 	}
 }
 
+func TestWriteBackUploaderSkipsDefaultModeForPendingNew(t *testing.T) {
+	var putCalls atomic.Int32
+	var chmodCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			putCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			chmodCalls.Add(1)
+			http.Error(w, "unexpected chmod", http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	cache, _ := NewWriteBackCache(dir)
+	c := newTestClient(ts.URL)
+	uploader := NewWriteBackUploader(c, cache, 1)
+
+	_ = cache.PutWithBaseRevAndMode("/plain.txt", []byte("data"), 4, PendingNew, 0, defaultRegularFileMode, true)
+	uploader.Submit("/plain.txt")
+	uploader.DrainAll()
+
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want 1", got)
+	}
+	if got := chmodCalls.Load(); got != 0 {
+		t.Fatalf("chmod calls = %d, want 0", got)
+	}
+	if _, ok := cache.Get("/plain.txt"); ok {
+		t.Fatal("cache entry should be removed after successful default-mode upload")
+	}
+}
+
 func TestWriteBackUploader_UploadSyncChmodFailureReturnsErrorAndRetainsCache(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -558,6 +558,67 @@ func TestWriteBackUploader_ChmodFailureRetainsCache(t *testing.T) {
 	if _, ok := cache.Get("/mode-fail.txt"); !ok {
 		t.Fatal("cache entry should be retained after chmod failure")
 	}
+	meta, ok := cache.GetMeta("/mode-fail.txt")
+	if !ok {
+		t.Fatal("cache metadata should be retained after chmod failure")
+	}
+	if meta.Kind != PendingChmod {
+		t.Fatalf("meta kind = %v, want PendingChmod", meta.Kind)
+	}
+}
+
+func TestWriteBackUploader_ChmodFailureRetryDoesNotReuploadData(t *testing.T) {
+	var putCalls atomic.Int32
+	var chmodCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			if putCalls.Add(1) > 1 {
+				http.Error(w, "unexpected data reupload", http.StatusConflict)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			if chmodCalls.Add(1) == 1 {
+				http.Error(w, "chmod failed", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	cache, _ := NewWriteBackCache(dir)
+	c := newTestClient(ts.URL)
+	uploader := NewWriteBackUploader(c, cache, 1)
+
+	_ = cache.PutWithBaseRevAndMode("/mode-retry.txt", []byte("data"), 4, PendingNew, 0, 0o755, true)
+	uploader.Submit("/mode-retry.txt")
+	uploader.DrainAll()
+
+	meta, ok := cache.GetMeta("/mode-retry.txt")
+	if !ok {
+		t.Fatal("cache metadata should be retained after first chmod failure")
+	}
+	if meta.Kind != PendingChmod {
+		t.Fatalf("meta kind after first attempt = %v, want PendingChmod", meta.Kind)
+	}
+
+	uploader.Submit("/mode-retry.txt")
+	uploader.DrainAll()
+
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want 1", got)
+	}
+	if got := chmodCalls.Load(); got != 2 {
+		t.Fatalf("chmod calls = %d, want 2", got)
+	}
+	if _, ok := cache.GetMeta("/mode-retry.txt"); ok {
+		t.Fatal("cache metadata should be removed after chmod retry succeeds")
+	}
 }
 
 func TestWriteBackUploaderSkipsDefaultModeForPendingNew(t *testing.T) {

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -684,6 +684,54 @@ func TestWriteBackUploader_UploadSyncChmodFailureReturnsErrorAndRetainsCache(t *
 	if _, ok := cache.Get("/mode-sync-fail.txt"); !ok {
 		t.Fatal("cache entry should be retained after UploadSync chmod failure")
 	}
+	meta, ok := cache.GetMeta("/mode-sync-fail.txt")
+	if !ok {
+		t.Fatal("cache metadata should be retained after UploadSync chmod failure")
+	}
+	if meta.Kind != PendingChmod {
+		t.Fatalf("meta kind = %v, want PendingChmod", meta.Kind)
+	}
+	uploader.DrainAll()
+}
+
+func TestWriteBackUploader_UploadSyncUploadFailureRetainsDataPendingKind(t *testing.T) {
+	var chmodCalled atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			http.Error(w, "upload failed", http.StatusInternalServerError)
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			chmodCalled.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	cache, _ := NewWriteBackCache(dir)
+	c := newTestClient(ts.URL)
+	uploader := NewWriteBackUploader(c, cache, 1)
+
+	_ = cache.PutWithBaseRevAndMode("/sync-upload-fail.txt", []byte("data"), 4, PendingNew, 0, 0o755, true)
+	err := uploader.UploadSync(context.Background(), "/sync-upload-fail.txt")
+	if err == nil {
+		t.Fatal("UploadSync should fail when data upload fails")
+	}
+	if data, ok := cache.Get("/sync-upload-fail.txt"); !ok || string(data) != "data" {
+		t.Fatalf("cache data = %q, %v; want retained data", string(data), ok)
+	}
+	meta, ok := cache.GetMeta("/sync-upload-fail.txt")
+	if !ok {
+		t.Fatal("cache metadata should be retained after upload failure")
+	}
+	if meta.Kind != PendingNew {
+		t.Fatalf("meta kind = %v, want PendingNew", meta.Kind)
+	}
+	if chmodCalled.Load() {
+		t.Fatal("chmod should not be attempted after upload failure")
+	}
 	uploader.DrainAll()
 }
 

--- a/pkg/fuse/writeback_uploader.go
+++ b/pkg/fuse/writeback_uploader.go
@@ -94,16 +94,20 @@ func (u *WriteBackUploader) remotePath(localPath string) string {
 }
 
 func (u *WriteBackUploader) applyMode(ctx context.Context, meta *WriteBackMeta) error {
-	if meta == nil || !meta.HasMode {
+	if meta == nil || !shouldApplyRemoteMode(meta.Kind, meta.HasMode, meta.Mode) {
 		return nil
 	}
-	start := time.Now()
-	err := u.client.ChmodCtx(ctx, u.remotePath(meta.Path), meta.Mode&0o777)
-	if u.perf != nil {
-		u.perf.recordRemoteOp(perfRemoteMutation, err, time.Since(start), 0)
-	}
+	mode := meta.Mode & 0o777
+	err := retryPostUploadMode(ctx, func() error {
+		start := time.Now()
+		applyErr := u.client.ChmodCtx(ctx, u.remotePath(meta.Path), mode)
+		if u.perf != nil {
+			u.perf.recordRemoteOp(perfRemoteMutation, applyErr, time.Since(start), 0)
+		}
+		return applyErr
+	})
 	if err != nil {
-		return fmt.Errorf("writeback upload chmod %s to %o: %w", meta.Path, meta.Mode&0o777, err)
+		return fmt.Errorf("writeback upload chmod %s to %o: %w", meta.Path, mode, err)
 	}
 	return nil
 }

--- a/pkg/fuse/writeback_uploader.go
+++ b/pkg/fuse/writeback_uploader.go
@@ -262,7 +262,7 @@ func (u *WriteBackUploader) uploadOne(localPath string) {
 	gen := meta.Generation
 
 	if meta.Kind == PendingChmod {
-		u.applyPendingChmod(context.Background(), localPath, meta, gen, false)
+		_ = u.applyPendingChmod(context.Background(), localPath, meta, gen, false)
 		return
 	}
 

--- a/pkg/fuse/writeback_uploader.go
+++ b/pkg/fuse/writeback_uploader.go
@@ -93,6 +93,20 @@ func (u *WriteBackUploader) remotePath(localPath string) string {
 	return mountpath.ToRemote(root, localPath)
 }
 
+func (u *WriteBackUploader) applyMode(ctx context.Context, meta *WriteBackMeta) {
+	if meta == nil || !meta.HasMode {
+		return
+	}
+	start := time.Now()
+	err := u.client.ChmodCtx(ctx, u.remotePath(meta.Path), meta.Mode&0o777)
+	if u.perf != nil {
+		u.perf.recordRemoteOp(perfRemoteMutation, err, time.Since(start), 0)
+	}
+	if err != nil {
+		log.Printf("writeback upload chmod %s to %o failed: %v", meta.Path, meta.Mode&0o777, err)
+	}
+}
+
 func (u *WriteBackUploader) SetPerfCounters(perf *fusePerfCounters) {
 	u.perf = perf
 }
@@ -294,6 +308,9 @@ func (u *WriteBackUploader) uploadOne(localPath string) {
 		log.Printf("writeback upload failed for %s after %d attempts: %v (will retry on next mount)", localPath, uploadMaxRetries+1, lastErr)
 		return
 	}
+	chmodCtx, chmodCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	u.applyMode(chmodCtx, meta)
+	chmodCancel()
 
 	// Only remove from cache if the generation hasn't changed. If a newer
 	// Put() happened while we were uploading, the cache now holds fresher
@@ -350,6 +367,9 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) er
 		}
 		return err
 	}
+	chmodCtx, chmodCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	u.applyMode(chmodCtx, meta)
+	chmodCancel()
 
 	// Only remove if generation matches — a concurrent Put() may have written newer data.
 	curMeta, ok := u.cache.GetMeta(localPath)

--- a/pkg/fuse/writeback_uploader.go
+++ b/pkg/fuse/writeback_uploader.go
@@ -93,9 +93,9 @@ func (u *WriteBackUploader) remotePath(localPath string) string {
 	return mountpath.ToRemote(root, localPath)
 }
 
-func (u *WriteBackUploader) applyMode(ctx context.Context, meta *WriteBackMeta) {
+func (u *WriteBackUploader) applyMode(ctx context.Context, meta *WriteBackMeta) error {
 	if meta == nil || !meta.HasMode {
-		return
+		return nil
 	}
 	start := time.Now()
 	err := u.client.ChmodCtx(ctx, u.remotePath(meta.Path), meta.Mode&0o777)
@@ -103,8 +103,9 @@ func (u *WriteBackUploader) applyMode(ctx context.Context, meta *WriteBackMeta) 
 		u.perf.recordRemoteOp(perfRemoteMutation, err, time.Since(start), 0)
 	}
 	if err != nil {
-		log.Printf("writeback upload chmod %s to %o failed: %v", meta.Path, meta.Mode&0o777, err)
+		return fmt.Errorf("writeback upload chmod %s to %o: %w", meta.Path, meta.Mode&0o777, err)
 	}
+	return nil
 }
 
 func (u *WriteBackUploader) SetPerfCounters(perf *fusePerfCounters) {
@@ -309,8 +310,15 @@ func (u *WriteBackUploader) uploadOne(localPath string) {
 		return
 	}
 	chmodCtx, chmodCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	u.applyMode(chmodCtx, meta)
+	modeErr := u.applyMode(chmodCtx, meta)
 	chmodCancel()
+	if modeErr != nil {
+		if u.perf != nil {
+			u.perf.uploaderFailure.add(1)
+		}
+		log.Printf("%v (will retry on next mount)", modeErr)
+		return
+	}
 
 	// Only remove from cache if the generation hasn't changed. If a newer
 	// Put() happened while we were uploading, the cache now holds fresher
@@ -367,9 +375,15 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) er
 		}
 		return err
 	}
-	chmodCtx, chmodCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	u.applyMode(chmodCtx, meta)
+	chmodCtx, chmodCancel := context.WithTimeout(ctx, 30*time.Second)
+	err = u.applyMode(chmodCtx, meta)
 	chmodCancel()
+	if err != nil {
+		if u.perf != nil {
+			u.perf.uploaderFailure.add(1)
+		}
+		return err
+	}
 
 	// Only remove if generation matches — a concurrent Put() may have written newer data.
 	curMeta, ok := u.cache.GetMeta(localPath)

--- a/pkg/fuse/writeback_uploader.go
+++ b/pkg/fuse/writeback_uploader.go
@@ -202,6 +202,9 @@ func expectedRevisionForWriteBack(meta *WriteBackMeta) (int64, error) {
 	if meta == nil {
 		return -1, fmt.Errorf("missing writeback metadata")
 	}
+	if meta.Kind == PendingChmod {
+		return -1, fmt.Errorf("data already uploaded for %s; chmod pending", meta.Path)
+	}
 	if meta.Kind == PendingNew {
 		return 0, nil
 	}
@@ -257,6 +260,11 @@ func (u *WriteBackUploader) uploadOne(localPath string) {
 		return // Already uploaded or removed.
 	}
 	gen := meta.Generation
+
+	if meta.Kind == PendingChmod {
+		u.applyPendingChmod(context.Background(), localPath, meta, gen, false)
+		return
+	}
 
 	data, ok := u.cache.getView(localPath)
 	if !ok {
@@ -320,6 +328,11 @@ func (u *WriteBackUploader) uploadOne(localPath string) {
 		if u.perf != nil {
 			u.perf.uploaderFailure.add(1)
 		}
+		if updated, err := u.cache.MarkChmodPending(localPath, gen); err != nil {
+			log.Printf("writeback upload chmod-pending meta update failed for %s: %v", localPath, err)
+		} else if updated {
+			log.Printf("writeback upload data committed for %s; chmod remains pending", localPath)
+		}
 		log.Printf("%v (will retry on next mount)", modeErr)
 		return
 	}
@@ -350,6 +363,10 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) er
 	}
 	gen := meta.Generation
 
+	if meta.Kind == PendingChmod {
+		return u.applyPendingChmod(ctx, localPath, meta, gen, true)
+	}
+
 	data, ok := u.cache.getView(localPath)
 	if !ok {
 		return nil
@@ -377,6 +394,9 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) er
 		if u.perf != nil {
 			u.perf.uploaderFailure.add(1)
 		}
+		if _, markErr := u.cache.MarkChmodPending(localPath, gen); markErr != nil {
+			return fmt.Errorf("%w; mark chmod pending: %v", err, markErr)
+		}
 		return err
 	}
 	chmodCtx, chmodCancel := context.WithTimeout(ctx, 30*time.Second)
@@ -390,6 +410,31 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) er
 	}
 
 	// Only remove if generation matches — a concurrent Put() may have written newer data.
+	curMeta, ok := u.cache.GetMeta(localPath)
+	if ok && curMeta.Generation == gen {
+		u.cache.Remove(localPath)
+	}
+	if u.perf != nil {
+		u.perf.uploaderSuccess.add(1)
+	}
+	return nil
+}
+
+func (u *WriteBackUploader) applyPendingChmod(ctx context.Context, localPath string, meta *WriteBackMeta, gen uint64, sync bool) error {
+	chmodCtx, chmodCancel := context.WithTimeout(ctx, 30*time.Second)
+	err := u.applyMode(chmodCtx, meta)
+	chmodCancel()
+	if err != nil {
+		if u.perf != nil {
+			u.perf.uploaderFailure.add(1)
+		}
+		if sync {
+			return err
+		}
+		log.Printf("%v (chmod remains pending)", err)
+		return nil
+	}
+
 	curMeta, ok := u.cache.GetMeta(localPath)
 	if ok && curMeta.Generation == gen {
 		u.cache.Remove(localPath)

--- a/pkg/fuse/writeback_uploader.go
+++ b/pkg/fuse/writeback_uploader.go
@@ -394,9 +394,6 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) er
 		if u.perf != nil {
 			u.perf.uploaderFailure.add(1)
 		}
-		if _, markErr := u.cache.MarkChmodPending(localPath, gen); markErr != nil {
-			return fmt.Errorf("%w; mark chmod pending: %v", err, markErr)
-		}
 		return err
 	}
 	chmodCtx, chmodCancel := context.WithTimeout(ctx, 30*time.Second)
@@ -405,6 +402,9 @@ func (u *WriteBackUploader) UploadSync(ctx context.Context, localPath string) er
 	if err != nil {
 		if u.perf != nil {
 			u.perf.uploaderFailure.add(1)
+		}
+		if _, markErr := u.cache.MarkChmodPending(localPath, gen); markErr != nil {
+			return fmt.Errorf("%w; mark chmod pending: %v", err, markErr)
 		}
 		return err
 	}


### PR DESCRIPTION
## Summary
- preserve file mode from FUSE create requests in local inode state and pending writeback metadata
- propagate pending modes through rename/recovery and apply chmod after async commit uploads
- add regression coverage for executable create mode, pending lookup, flush metadata, and commit queue chmod

## Tests
- env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/fuse
- env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9/cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deferred file-mode staging: creation modes are persisted and applied after successful uploads; default-mode creations skip post-upload chmod.
  * Pending-mode metadata is recorded across staging, writeback, release and commit pathways so mode state survives restarts.

* **Bug Fixes**
  * Post-upload chmod failures now surface and halt success-side cleanup; pending state is retained and retries occur without reuploading data.
  * Journal/conflict paths preserve pending mode on post-upload failures.

* **Tests**
  * Expanded tests covering mode propagation, deferred-chmod retry/404 behavior, error retention, and concurrency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->