### PR TITLE
fix(fuse): keep local writes visible during reopens

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -785,6 +785,72 @@ func (fs *Dat9FS) loadWritableHandleFromWriteBackLocked(fh *FileHandle) bool {
 	return true
 }
 
+func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
+	if fs.openHandles == nil || fh == nil || fh.Dirty == nil {
+		return false
+	}
+
+	for _, src := range fs.openHandles.SnapshotPath(fh.Path) {
+		if src == nil || src == fh {
+			continue
+		}
+
+		src.Lock()
+		if src.Dirty == nil {
+			src.Unlock()
+			continue
+		}
+		size := src.Dirty.Size()
+		baseRev := src.BaseRev
+		isNew := src.IsNew
+		zeroBase := src.ZeroBase
+		shadowSource := fs.shadowStore != nil && (src.ShadowReady || src.ShadowSpill)
+
+		var data []byte
+		haveData := size == 0
+		if !haveData && src.Dirty.CanMaterializeFull() {
+			data = src.Dirty.Bytes()
+			haveData = true
+		}
+		src.Unlock()
+
+		if !haveData && shadowSource {
+			var err error
+			data, err = fs.shadowStore.ReadAll(fh.Path)
+			if err != nil {
+				log.Printf("open-handle preload shadow read failed for %s: %v", fh.Path, err)
+				continue
+			}
+			size = int64(len(data))
+			haveData = true
+		}
+		if !haveData {
+			continue
+		}
+
+		if len(data) > 0 {
+			if _, err := fh.Dirty.Write(0, data); err != nil {
+				log.Printf("open-handle preload failed for %s: %v", fh.Path, err)
+				continue
+			}
+		} else if err := fh.Dirty.Truncate(size); err != nil {
+			log.Printf("open-handle preload truncate failed for %s: %v", fh.Path, err)
+			continue
+		}
+		fh.Dirty.ClearDirty()
+		fh.IsNew = isNew
+		fh.ZeroBase = zeroBase || (isNew && baseRev == 0)
+		fh.BaseRev = baseRev
+		fh.OrigSize = size
+		fs.inodes.UpdateSize(fh.Ino, size)
+		if baseRev > 0 {
+			fs.inodes.UpdateRevision(fh.Ino, baseRev)
+		}
+		return true
+	}
+	return false
+}
+
 func (fs *Dat9FS) fillAttr(entry *InodeEntry, out *gofuse.Attr) {
 	out.Ino = entry.Ino
 	out.Size = uint64(entry.Size)
@@ -2864,6 +2930,12 @@ func (fs *Dat9FS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out 
 
 	for i := int(input.Offset); i < len(dh.Entries); i++ {
 		e := dh.Entries[i]
+		if _, ok := fs.inodes.GetEntry(e.Ino); !ok {
+			childP := dirEntryChildPath(dh.Path, e.Name)
+			isDir := e.Mode&uint32(syscall.S_IFMT) == uint32(syscall.S_IFDIR)
+			e.Ino = fs.inodes.EnsureInode(childP, isDir, 0, time.Now())
+			dh.Entries[i].Ino = e.Ino
+		}
 		entryOut := out.AddDirLookupEntry(gofuse.DirEntry{
 			Name: e.Name,
 			Ino:  e.Ino,
@@ -3177,6 +3249,9 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		// random writes don't discard the original file data.
 		if input.Flags&syscall.O_TRUNC == 0 {
 			preloaded := false
+			if fs.loadWritableHandleFromOpenHandleLocked(fh) {
+				preloaded = true
+			}
 			if fs.pendingIndex != nil && fs.shadowStore != nil {
 				if meta, ok := fs.pendingIndex.GetMeta(p); ok && fs.shadowStore.Has(p) {
 					if err := fs.loadWritableHandleFromShadowLocked(fh, meta); err == nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3044,7 +3044,16 @@ func (fs *Dat9FS) recreateDirEntryInode(dirPath string, e DirEntry) uint64 {
 	var mode uint32
 	hasMode := false
 
-	if item, ok := fs.dirEntryMetadata(dirPath, childP, e.Name); ok {
+	if e.HasMetadata {
+		isDir = e.IsDir
+		size = e.Size
+		if !e.Mtime.IsZero() {
+			mtime = e.Mtime
+		}
+		revision = e.Revision
+		mode = e.AttrMode
+		hasMode = e.HasMode
+	} else if item, ok := fs.dirEntryMetadata(dirPath, childP, e.Name); ok {
 		isDir = item.IsDir
 		size = item.Size
 		if !item.Mtime.IsZero() {
@@ -3083,6 +3092,21 @@ func (fs *Dat9FS) dirEntryMetadata(dirPath, childP, name string) (CachedFileInfo
 		}
 	}
 	return CachedFileInfo{}, false
+}
+
+func dirEntryFromCachedInfo(item CachedFileInfo, ino uint64) DirEntry {
+	return DirEntry{
+		Name:        item.Name,
+		Ino:         ino,
+		Mode:        dirEntryMode(item.IsDir, item.HasMode, item.Mode),
+		Size:        item.Size,
+		Mtime:       item.Mtime,
+		Revision:    item.Revision,
+		AttrMode:    item.Mode,
+		HasMode:     item.HasMode,
+		IsDir:       item.IsDir,
+		HasMetadata: true,
+	}
 }
 
 func (fs *Dat9FS) ReleaseDir(input *gofuse.ReleaseIn) {
@@ -3185,9 +3209,13 @@ func (fs *Dat9FS) mergePendingDirEntries(dirPath string, entries []DirEntry) []D
 			}
 			ino := fs.inodes.EnsureInode(meta.Path, false, meta.Size, mtime)
 			entries = append(entries, DirEntry{
-				Name: name,
-				Ino:  ino,
-				Mode: syscall.S_IFREG,
+				Name:        name,
+				Ino:         ino,
+				Mode:        syscall.S_IFREG,
+				Size:        meta.Size,
+				Mtime:       mtime,
+				IsDir:       false,
+				HasMetadata: true,
 			})
 			existing[name] = struct{}{}
 		}
@@ -3216,9 +3244,13 @@ func (fs *Dat9FS) mergePendingDirEntries(dirPath string, entries []DirEntry) []D
 			}
 			ino := fs.inodes.EnsureInode(meta.Path, false, meta.Size, mtime)
 			entries = append(entries, DirEntry{
-				Name: name,
-				Ino:  ino,
-				Mode: syscall.S_IFREG,
+				Name:        name,
+				Ino:         ino,
+				Mode:        syscall.S_IFREG,
+				Size:        meta.Size,
+				Mtime:       mtime,
+				IsDir:       false,
+				HasMetadata: true,
 			})
 			existing[name] = struct{}{}
 		}
@@ -3244,11 +3276,7 @@ func (fs *Dat9FS) cachedToDirEntries(dirPath string, items []CachedFileInfo) []D
 			fs.inodes.UpdateMode(ino, item.Mode)
 		}
 
-		entries = append(entries, DirEntry{
-			Name: item.Name,
-			Ino:  ino,
-			Mode: dirEntryMode(item.IsDir, item.HasMode, item.Mode),
-		})
+		entries = append(entries, dirEntryFromCachedInfo(item, ino))
 	}
 	return entries
 }

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -790,6 +791,19 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 		return false
 	}
 
+	type candidate struct {
+		src          *FileHandle
+		size         int64
+		origSize     int64
+		baseRev      int64
+		dirtySeq     uint64
+		isNew        bool
+		zeroBase     bool
+		shadowSource bool
+		canMemory    bool
+	}
+
+	var candidates []candidate
 	for _, src := range fs.openHandles.SnapshotPath(fh.Path) {
 		if src == nil || src == fh {
 			continue
@@ -800,30 +814,70 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 			src.Unlock()
 			continue
 		}
-		size := src.Dirty.Size()
-		baseRev := src.BaseRev
-		isNew := src.IsNew
-		zeroBase := src.ZeroBase
-		shadowSource := fs.shadowStore != nil && (src.ShadowReady || src.ShadowSpill)
-
-		var data []byte
-		haveData := size == 0
-		if !haveData && src.Dirty.CanMaterializeFull() {
-			data = src.Dirty.Bytes()
-			haveData = true
+		c := candidate{
+			src:          src,
+			size:         src.Dirty.Size(),
+			origSize:     src.OrigSize,
+			baseRev:      src.BaseRev,
+			dirtySeq:     src.DirtySeq,
+			isNew:        src.IsNew,
+			zeroBase:     src.ZeroBase,
+			shadowSource: fs.shadowStore != nil && (src.ShadowReady || src.ShadowSpill),
+			canMemory:    src.Dirty.CanMaterializeFull(),
 		}
 		src.Unlock()
+		candidates = append(candidates, c)
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		a, b := candidates[i], candidates[j]
+		if a.dirtySeq != b.dirtySeq {
+			return a.dirtySeq > b.dirtySeq
+		}
+		if a.shadowSource != b.shadowSource {
+			return a.shadowSource
+		}
+		if a.size != b.size {
+			return a.size > b.size
+		}
+		return a.baseRev > b.baseRev
+	})
 
-		if !haveData && shadowSource {
+	for _, c := range candidates {
+		var data []byte
+		size := c.size
+		haveData := size == 0
+
+		// Shadow-backed handles are authoritative in the shadow store. Their
+		// dirty buffer may have evicted parts and would materialize zeros.
+		if !haveData && c.shadowSource {
 			var err error
 			data, err = fs.shadowStore.ReadAll(fh.Path)
 			if err != nil {
 				log.Printf("open-handle preload shadow read failed for %s: %v", fh.Path, err)
-				continue
+			} else {
+				size = int64(len(data))
+				haveData = true
 			}
-			size = int64(len(data))
-			haveData = true
 		}
+
+		if !haveData && c.canMemory {
+			c.src.Lock()
+			if c.src.Dirty != nil {
+				size = c.src.Dirty.Size()
+				c.origSize = c.src.OrigSize
+				c.baseRev = c.src.BaseRev
+				c.isNew = c.src.IsNew
+				c.zeroBase = c.src.ZeroBase
+				if size == 0 {
+					haveData = true
+				} else if c.src.Dirty.CanMaterializeFull() {
+					data = c.src.Dirty.Bytes()
+					haveData = true
+				}
+			}
+			c.src.Unlock()
+		}
+
 		if !haveData {
 			continue
 		}
@@ -838,13 +892,17 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 			continue
 		}
 		fh.Dirty.ClearDirty()
-		fh.IsNew = isNew
-		fh.ZeroBase = zeroBase || (isNew && baseRev == 0)
-		fh.BaseRev = baseRev
-		fh.OrigSize = size
+		fh.IsNew = c.isNew
+		fh.ZeroBase = c.zeroBase || (c.isNew && c.baseRev == 0)
+		fh.BaseRev = c.baseRev
+		if c.isNew {
+			fh.OrigSize = 0
+		} else {
+			fh.OrigSize = c.origSize
+		}
 		fs.inodes.UpdateSize(fh.Ino, size)
-		if baseRev > 0 {
-			fs.inodes.UpdateRevision(fh.Ino, baseRev)
+		if c.baseRev > 0 {
+			fs.inodes.UpdateRevision(fh.Ino, c.baseRev)
 		}
 		return true
 	}
@@ -1496,6 +1554,23 @@ func cachedInfoFromStat(name string, stat *client.StatResult) CachedFileInfo {
 		item.Mode = stat.Mode
 	}
 	return item
+}
+
+func cachedInfoFromWriteBackMeta(name string, meta *WriteBackMeta) CachedFileInfo {
+	if meta == nil {
+		return CachedFileInfo{Name: name}
+	}
+	mtime := meta.Mtime
+	if mtime.IsZero() {
+		mtime = time.Now()
+	}
+	return CachedFileInfo{
+		Name:     name,
+		Size:     meta.Size,
+		IsDir:    false,
+		Mtime:    mtime,
+		Revision: meta.BaseRev,
+	}
 }
 
 func (fs *Dat9FS) cacheFileForPath(p string, size int64, mtime time.Time, revision int64) {
@@ -2931,9 +3006,7 @@ func (fs *Dat9FS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out 
 	for i := int(input.Offset); i < len(dh.Entries); i++ {
 		e := dh.Entries[i]
 		if _, ok := fs.inodes.GetEntry(e.Ino); !ok {
-			childP := dirEntryChildPath(dh.Path, e.Name)
-			isDir := e.Mode&uint32(syscall.S_IFMT) == uint32(syscall.S_IFDIR)
-			e.Ino = fs.inodes.EnsureInode(childP, isDir, 0, time.Now())
+			e.Ino = fs.recreateDirEntryInode(dh.Path, e)
 			dh.Entries[i].Ino = e.Ino
 		}
 		entryOut := out.AddDirLookupEntry(gofuse.DirEntry{
@@ -2956,6 +3029,60 @@ func (fs *Dat9FS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out 
 		}
 	}
 	return gofuse.OK
+}
+
+func (fs *Dat9FS) recreateDirEntryInode(dirPath string, e DirEntry) uint64 {
+	childP := dirEntryChildPath(dirPath, e.Name)
+	if ino, ok := fs.inodes.GetInode(childP); ok {
+		return ino
+	}
+
+	isDir := e.Mode&uint32(syscall.S_IFMT) == uint32(syscall.S_IFDIR)
+	size := int64(0)
+	mtime := time.Now()
+	var revision int64
+	var mode uint32
+	hasMode := false
+
+	if item, ok := fs.dirEntryMetadata(dirPath, childP, e.Name); ok {
+		isDir = item.IsDir
+		size = item.Size
+		if !item.Mtime.IsZero() {
+			mtime = item.Mtime
+		}
+		revision = item.Revision
+		mode = item.Mode
+		hasMode = item.HasMode
+	}
+
+	ino := fs.inodes.EnsureInodeNoUpdate(childP, isDir, size, mtime)
+	if revision > 0 {
+		fs.inodes.UpdateRevision(ino, revision)
+	}
+	if hasMode {
+		fs.inodes.UpdateMode(ino, mode)
+	}
+	return ino
+}
+
+func (fs *Dat9FS) dirEntryMetadata(dirPath, childP, name string) (CachedFileInfo, bool) {
+	if fs.writeBack != nil {
+		if meta, ok := fs.writeBack.GetMeta(childP); ok {
+			return cachedInfoFromWriteBackMeta(name, meta), true
+		}
+	}
+	if fs.pendingIndex != nil {
+		if meta, ok := fs.pendingIndex.GetMeta(childP); ok {
+			return cachedInfoFromWriteBackMeta(name, meta), true
+		}
+	}
+	if fs.dirCache != nil {
+		result := fs.dirCache.Lookup(dirPath, name)
+		if result.kind == namespaceLookupPositive {
+			return result.item, true
+		}
+	}
+	return CachedFileInfo{}, false
 }
 
 func (fs *Dat9FS) ReleaseDir(input *gofuse.ReleaseIn) {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1919,12 +1919,19 @@ func TestReadDirPlusRecreatesStaleSnapshotInode(t *testing.T) {
 	opts.setDefaults()
 	fs := NewDat9FS(newTestClient("http://localhost"), opts)
 
+	mtime := time.Now().Add(-time.Minute)
 	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
 	fileIno := fs.inodes.Lookup("/dir/file.txt", false, 1, time.Now())
 	fs.inodes.Forget(fileIno, 1)
 	if _, ok := fs.inodes.GetEntry(fileIno); ok {
 		t.Fatalf("stale file inode %d is still mapped", fileIno)
 	}
+	fs.dirCache.Upsert("/dir", CachedFileInfo{
+		Name:     "file.txt",
+		Size:     9,
+		Mtime:    mtime,
+		Revision: 12,
+	})
 
 	dh := &DirHandle{
 		Ino:  dirIno,
@@ -1962,6 +1969,57 @@ func TestReadDirPlusRecreatesStaleSnapshotInode(t *testing.T) {
 	}
 	if entry.Nlookup != 1 {
 		t.Fatalf("replacement inode lookup refs = %d, want 1", entry.Nlookup)
+	}
+	if entry.Size != 9 {
+		t.Fatalf("replacement inode size = %d, want cached size 9", entry.Size)
+	}
+	if entry.Revision != 12 {
+		t.Fatalf("replacement inode revision = %d, want cached revision 12", entry.Revision)
+	}
+}
+
+func TestReadDirPlusStaleSnapshotDoesNotZeroLiveInode(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+	staleIno := fs.inodes.Lookup("/dir/file.txt", false, 1, time.Now())
+	fs.inodes.Forget(staleIno, 1)
+	if _, ok := fs.inodes.GetEntry(staleIno); ok {
+		t.Fatalf("stale file inode %d is still mapped", staleIno)
+	}
+	liveIno := fs.inodes.Lookup("/dir/file.txt", false, 17, time.Now())
+
+	dh := &DirHandle{
+		Ino:  dirIno,
+		Path: "/dir",
+		Entries: []DirEntry{{
+			Name: "file.txt",
+			Ino:  staleIno,
+			Mode: uint32(syscall.S_IFREG) | 0o644,
+		}},
+	}
+	fh := fs.dirHandles.Allocate(dh)
+	out := gofuse.NewDirEntryList(make([]byte, 4096), 0)
+	st := fs.ReadDirPlus(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Fh:       fh,
+		Size:     4096,
+	}, out)
+	if st != gofuse.OK {
+		t.Fatalf("ReadDirPlus status = %v, want OK", st)
+	}
+
+	if dh.Entries[0].Ino != liveIno {
+		t.Fatalf("snapshot inode = %d, want existing live inode %d", dh.Entries[0].Ino, liveIno)
+	}
+	entry, ok := fs.inodes.GetEntry(liveIno)
+	if !ok {
+		t.Fatalf("live inode %d is not mapped", liveIno)
+	}
+	if entry.Size != 17 {
+		t.Fatalf("live inode size = %d, want preserved size 17", entry.Size)
 	}
 }
 
@@ -3368,6 +3426,194 @@ func TestOpenWritableCreatedFileUsesOpenLocalHandle(t *testing.T) {
 		Offset:   0,
 	}, []byte("#!/bin/sh\n")); st != gofuse.OK {
 		t.Fatalf("Write through reopened handle status = %v, want OK", st)
+	}
+}
+
+func TestOpenWritablePreloadChoosesNewestOpenHandle(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	ino := fs.inodes.Lookup("/script.tmp", false, 0, time.Now())
+	stale := &FileHandle{
+		Ino:   ino,
+		Path:  "/script.tmp",
+		Dirty: fs.newWriteBuffer("/script.tmp", maxPreloadSize, 0),
+		IsNew: true,
+	}
+	if err := stale.Dirty.Truncate(0); err != nil {
+		t.Fatal(err)
+	}
+	stale.DirtySeq = fs.markDirtySize(ino, 0)
+	fs.openHandles.Add(stale)
+
+	fresh := &FileHandle{
+		Ino:   ino,
+		Path:  "/script.tmp",
+		Dirty: fs.newWriteBuffer("/script.tmp", maxPreloadSize, 0),
+		IsNew: true,
+	}
+	want := []byte("fresh local bytes")
+	if _, err := fresh.Dirty.Write(0, want); err != nil {
+		t.Fatal(err)
+	}
+	fresh.DirtySeq = fs.markDirtySize(ino, int64(len(want)))
+	fs.openHandles.Add(fresh)
+
+	target := &FileHandle{
+		Ino:   ino,
+		Path:  "/script.tmp",
+		Dirty: fs.newWriteBuffer("/script.tmp", maxPreloadSize, 0),
+	}
+	if !fs.loadWritableHandleFromOpenHandleLocked(target) {
+		t.Fatal("preload from open handle returned false")
+	}
+	if got := target.Dirty.Bytes(); !bytes.Equal(got, want) {
+		t.Fatalf("preloaded bytes = %q, want %q", got, want)
+	}
+	if target.OrigSize != 0 {
+		t.Fatalf("target OrigSize = %d, want 0 for pending new file", target.OrigSize)
+	}
+}
+
+func TestOpenWritablePreloadReadsShadowBeforeEvictedBuffer(t *testing.T) {
+	var remoteCalls atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "remote should not be consulted for shadow-backed open handle", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT | syscall.O_EXCL),
+	}, "large.tmp", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+
+	want := bytes.Repeat([]byte{0x5a}, DefaultPartSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Offset:   0,
+	}, want); st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+	src, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("created handle not found")
+	}
+	src.Lock()
+	partLoaded := src.Dirty.IsPartLoaded(0)
+	src.Unlock()
+	if partLoaded {
+		t.Fatal("test setup expected ShadowSpill to evict the first part")
+	}
+
+	var openOut gofuse.OpenOut
+	st = fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Flags:    uint32(syscall.O_WRONLY),
+	}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote calls = %d, want 0", got)
+	}
+	reopened, ok := fs.fileHandles.Get(openOut.Fh)
+	if !ok {
+		t.Fatal("reopened handle not found")
+	}
+	reopened.Lock()
+	got := reopened.Dirty.Bytes()
+	origSize := reopened.OrigSize
+	isNew := reopened.IsNew
+	reopened.Unlock()
+	if !bytes.Equal(got, want) {
+		t.Fatal("reopened handle did not preload the authoritative shadow bytes")
+	}
+	if !isNew {
+		t.Fatal("reopened handle should preserve pending-new state")
+	}
+	if origSize != 0 {
+		t.Fatalf("reopened OrigSize = %d, want 0 for pending new file", origSize)
+	}
+}
+
+func TestOpenWritablePreloadPreservesExistingOrigSize(t *testing.T) {
+	var remoteCalls atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "remote should not be consulted for cached existing file", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup("/grow.bin", false, 1, time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+	fs.readCache.Put("/grow.bin", []byte("a"), 7)
+
+	var firstOut gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDWR),
+	}, &firstOut)
+	if st != gofuse.OK {
+		t.Fatalf("first Open status = %v, want OK", st)
+	}
+	want := bytes.Repeat([]byte("x"), defaultSmallFileThreshold+1024)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       firstOut.Fh,
+		Offset:   0,
+	}, want); st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+
+	var secondOut gofuse.OpenOut
+	st = fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_WRONLY),
+	}, &secondOut)
+	if st != gofuse.OK {
+		t.Fatalf("second Open status = %v, want OK", st)
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote calls = %d, want 0", got)
+	}
+	reopened, ok := fs.fileHandles.Get(secondOut.Fh)
+	if !ok {
+		t.Fatal("reopened handle not found")
+	}
+	reopened.Lock()
+	origSize := reopened.OrigSize
+	got := reopened.Dirty.Bytes()
+	reopened.Unlock()
+	if origSize != 1 {
+		t.Fatalf("reopened OrigSize = %d, want original remote size 1", origSize)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("reopened handle did not preload local grown bytes")
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1914,6 +1914,57 @@ func TestLookupSSEForeignCreateInvalidatesSessionCreatedMiss(t *testing.T) {
 	}
 }
 
+func TestReadDirPlusRecreatesStaleSnapshotInode(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+	fileIno := fs.inodes.Lookup("/dir/file.txt", false, 1, time.Now())
+	fs.inodes.Forget(fileIno, 1)
+	if _, ok := fs.inodes.GetEntry(fileIno); ok {
+		t.Fatalf("stale file inode %d is still mapped", fileIno)
+	}
+
+	dh := &DirHandle{
+		Ino:  dirIno,
+		Path: "/dir",
+		Entries: []DirEntry{{
+			Name: "file.txt",
+			Ino:  fileIno,
+			Mode: uint32(syscall.S_IFREG) | 0o644,
+		}},
+	}
+	fh := fs.dirHandles.Allocate(dh)
+	out := gofuse.NewDirEntryList(make([]byte, 4096), 0)
+	st := fs.ReadDirPlus(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Fh:       fh,
+		Size:     4096,
+	}, out)
+	if st != gofuse.OK {
+		t.Fatalf("ReadDirPlus status = %v, want OK", st)
+	}
+
+	newIno, ok := fs.inodes.GetInode("/dir/file.txt")
+	if !ok {
+		t.Fatal("file path was not remapped")
+	}
+	if newIno == fileIno {
+		t.Fatalf("file inode = %d, want a replacement for stale inode", newIno)
+	}
+	if dh.Entries[0].Ino != newIno {
+		t.Fatalf("snapshot inode = %d, want remapped inode %d", dh.Entries[0].Ino, newIno)
+	}
+	entry, ok := fs.inodes.GetEntry(newIno)
+	if !ok {
+		t.Fatalf("replacement inode %d is not mapped", newIno)
+	}
+	if entry.Nlookup != 1 {
+		t.Fatalf("replacement inode lookup refs = %d, want 1", entry.Nlookup)
+	}
+}
+
 func TestLookupSSEForeignDeleteInvalidatesPositiveNamespaceHit(t *testing.T) {
 	var headCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3275,6 +3326,48 @@ func TestLookupOpenCreatedFileAfterForgetSupportsGitChmodLock(t *testing.T) {
 	}
 	if got := remoteCalls.Load(); got != 0 {
 		t.Fatalf("remote calls = %d, want 0 for open-created lookup", got)
+	}
+}
+
+func TestOpenWritableCreatedFileUsesOpenLocalHandle(t *testing.T) {
+	var remoteCalls atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "remote should not be consulted for open-created file", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT | syscall.O_EXCL),
+	}, "script.tmp", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+
+	var openOut gofuse.OpenOut
+	st = fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Flags:    uint32(syscall.O_WRONLY),
+	}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote calls = %d, want 0 for open-created file", got)
+	}
+
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       openOut.Fh,
+		Offset:   0,
+	}, []byte("#!/bin/sh\n")); st != gofuse.OK {
+		t.Fatalf("Write through reopened handle status = %v, want OK", st)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -2023,6 +2023,72 @@ func TestReadDirPlusStaleSnapshotDoesNotZeroLiveInode(t *testing.T) {
 	}
 }
 
+func TestReadDirPlusStaleSnapshotUsesStoredEntryMetadataAfterDirCacheInvalidated(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+	mtime := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+	entries := fs.cachedToDirEntries("/dir", []CachedFileInfo{{
+		Name:     "file.txt",
+		Size:     23,
+		Mtime:    mtime,
+		Revision: 44,
+		Mode:     0o600,
+		HasMode:  true,
+	}})
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	staleIno := entries[0].Ino
+	fs.inodes.Forget(staleIno, 1)
+	if _, ok := fs.inodes.GetEntry(staleIno); ok {
+		t.Fatalf("stale file inode %d is still mapped", staleIno)
+	}
+	fs.dirCache.Invalidate("/dir")
+
+	dh := &DirHandle{
+		Ino:     dirIno,
+		Path:    "/dir",
+		Entries: entries,
+	}
+	fh := fs.dirHandles.Allocate(dh)
+	out := gofuse.NewDirEntryList(make([]byte, 4096), 0)
+	st := fs.ReadDirPlus(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Fh:       fh,
+		Size:     4096,
+	}, out)
+	if st != gofuse.OK {
+		t.Fatalf("ReadDirPlus status = %v, want OK", st)
+	}
+
+	newIno, ok := fs.inodes.GetInode("/dir/file.txt")
+	if !ok {
+		t.Fatal("file path was not remapped")
+	}
+	if newIno == staleIno {
+		t.Fatalf("file inode = %d, want a replacement for stale inode", newIno)
+	}
+	entry, ok := fs.inodes.GetEntry(newIno)
+	if !ok {
+		t.Fatalf("replacement inode %d is not mapped", newIno)
+	}
+	if entry.Size != 23 {
+		t.Fatalf("replacement inode size = %d, want stored size 23", entry.Size)
+	}
+	if entry.Revision != 44 {
+		t.Fatalf("replacement inode revision = %d, want stored revision 44", entry.Revision)
+	}
+	if !entry.HasMode || entry.Mode != 0o600 {
+		t.Fatalf("replacement inode mode = %o has=%t, want 0600 true", entry.Mode, entry.HasMode)
+	}
+	if !entry.Mtime.Equal(mtime) {
+		t.Fatalf("replacement inode mtime = %s, want %s", entry.Mtime, mtime)
+	}
+}
+
 func TestLookupSSEForeignDeleteInvalidatesPositiveNamespaceHit(t *testing.T) {
 	var headCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -2,6 +2,7 @@ package fuse
 
 import (
 	"sync"
+	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
 )
@@ -55,9 +56,16 @@ type DirHandle struct {
 
 // DirEntry is a simplified directory entry for FUSE readdir.
 type DirEntry struct {
-	Name string
-	Ino  uint64
-	Mode uint32 // S_IFDIR or S_IFREG
+	Name        string
+	Ino         uint64
+	Mode        uint32 // S_IFDIR or S_IFREG
+	Size        int64
+	Mtime       time.Time
+	Revision    int64
+	AttrMode    uint32
+	HasMode     bool
+	IsDir       bool
+	HasMetadata bool
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/fuse/inode.go
+++ b/pkg/fuse/inode.go
@@ -105,6 +105,33 @@ func (m *InodeToPath) EnsureInode(path string, isDir bool, size int64, mtime tim
 	return ino
 }
 
+// EnsureInodeNoUpdate returns the inode for path, allocating one if needed.
+// Unlike EnsureInode, an existing mapping is returned without mutating its
+// cached metadata. Use this when recovering stale snapshot references.
+func (m *InodeToPath) EnsureInodeNoUpdate(path string, isDir bool, size int64, mtime time.Time) uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if ino, ok := m.byPath[path]; ok {
+		return ino
+	}
+
+	ino := m.nextIno
+	m.nextIno++
+
+	entry := &InodeEntry{
+		Ino:     ino,
+		Path:    path,
+		IsDir:   isDir,
+		Nlookup: 0,
+		Size:    size,
+		Mtime:   mtime,
+	}
+	m.byInode[ino] = entry
+	m.byPath[path] = ino
+	return ino
+}
+
 // IncrementLookup adds one kernel lookup reference to an existing inode.
 // Returns false if the inode does not exist.
 func (m *InodeToPath) IncrementLookup(ino uint64) bool {


### PR DESCRIPTION
## Summary
- Recreate stale directory snapshot inodes in ReadDirPlus instead of surfacing EIO.
- Preload writable opens from an already-open local dirty handle so create-then-open paths stay visible before remote commit.
- Add focused regressions for stale ReadDirPlus snapshots and create/open local visibility.

## Verification
- `env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/fuse`
- EC2 synthetic visibility probe: 8x200 create/rename/stat/list completed with 0 probe errors and `readdirplus errors=0`.
- EC2 fresh kimi-cli run: clone/checkout succeeded; `uv sync` reached 30m timeout without the prior failed-to-create-file ENOENT. FUSE summary showed `open/create/write/flush/readdirplus errors=0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of stale directory snapshots to correctly remap outdated file references.
  * Improved concurrent file write handling to properly preload data from existing open file handles.

* **Tests**
  * Added tests for directory snapshot integrity and concurrent file creation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->