### PR TITLE
feat: add Slock callback tenant provisioning

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/s3client"
 	"github.com/mem9-ai/dat9/pkg/server"
+	"github.com/mem9-ai/dat9/pkg/slockoauth"
 	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/tenant/db9"
 	"github.com/mem9-ai/dat9/pkg/tenant/starter"
@@ -258,6 +259,16 @@ func main() {
 		}
 	}
 
+	slockOAuth, err := slockOAuthFromEnv()
+	if err != nil {
+		die(err)
+	}
+	if slockOAuth != nil {
+		logger.Info(context.Background(), "slock_oauth_enabled")
+	} else {
+		logger.Info(context.Background(), "slock_oauth_disabled")
+	}
+
 	die(server.NewWithConfig(server.Config{
 		Meta:             store,
 		Pool:             pool,
@@ -271,6 +282,7 @@ func main() {
 		Logger:           srvLogger,
 		SemanticEmbedder: semanticEmbedder,
 		SemanticWorkers:  semanticWorkerOpts,
+		SlockOAuth:       slockOAuth,
 	}).ListenAndServe(addr))
 }
 
@@ -279,6 +291,24 @@ func envOr(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func slockOAuthFromEnv() (*slockoauth.Client, error) {
+	origin := strings.TrimSpace(os.Getenv("DRIVE9_SLOCK_ORIGIN"))
+	if origin == "" {
+		return nil, nil
+	}
+	cfg := slockoauth.Config{
+		Origin:       origin,
+		APIOrigin:    strings.TrimSpace(os.Getenv("DRIVE9_SLOCK_API_ORIGIN")),
+		ClientID:     strings.TrimSpace(os.Getenv("DRIVE9_SLOCK_CLIENT_ID")),
+		ClientSecret: strings.TrimSpace(os.Getenv("DRIVE9_SLOCK_CLIENT_SECRET")),
+		PublicURL:    strings.TrimSpace(os.Getenv("DRIVE9_PUBLIC_URL")),
+	}
+	if cfg.APIOrigin == "" || cfg.ClientID == "" || cfg.ClientSecret == "" || cfg.PublicURL == "" {
+		return nil, fmt.Errorf("DRIVE9_SLOCK_ORIGIN enables Slock OAuth; DRIVE9_SLOCK_API_ORIGIN, DRIVE9_SLOCK_CLIENT_ID, DRIVE9_SLOCK_CLIENT_SECRET, and DRIVE9_PUBLIC_URL must also be set")
+	}
+	return slockoauth.New(cfg)
 }
 
 func s3ConfigFromEnv() s3Config {
@@ -359,6 +389,10 @@ environment:
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
   DRIVE9_QUOTA_SOURCE tenant|server quota enforcement source (default: tenant)
   DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)
+  DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*
+  DRIVE9_SLOCK_API_ORIGIN Slock API origin (required when DRIVE9_SLOCK_ORIGIN is set)
+  DRIVE9_SLOCK_CLIENT_ID Slock connected-app client id (required when DRIVE9_SLOCK_ORIGIN is set)
+  DRIVE9_SLOCK_CLIENT_SECRET Slock connected-app client secret (required when DRIVE9_SLOCK_ORIGIN is set)
 
   S3 storage (set DRIVE9_S3_BUCKET to enable AWS S3, otherwise local mock):
   DRIVE9_S3_BUCKET   S3 bucket name (enables AWS S3 mode)

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -16,6 +16,71 @@ func TestVersionTextUsesDrive9ServerComponent(t *testing.T) {
 	}
 }
 
+func TestSlockOAuthFromEnvDisabledByDefault(t *testing.T) {
+	keys := []string{
+		"DRIVE9_SLOCK_ORIGIN",
+		"DRIVE9_SLOCK_API_ORIGIN",
+		"DRIVE9_SLOCK_CLIENT_ID",
+		"DRIVE9_SLOCK_CLIENT_SECRET",
+		"DRIVE9_PUBLIC_URL",
+	}
+	restore := snapshotEnv(t, keys)
+	t.Cleanup(func() { restoreEnv(t, restore) })
+	unsetEnv(t, keys)
+
+	c, err := slockOAuthFromEnv()
+	if err != nil {
+		t.Fatalf("slockOAuthFromEnv: %v", err)
+	}
+	if c != nil {
+		t.Fatal("expected nil Slock client when DRIVE9_SLOCK_ORIGIN is unset")
+	}
+}
+
+func TestSlockOAuthFromEnvRequiresCompanionVars(t *testing.T) {
+	keys := []string{
+		"DRIVE9_SLOCK_ORIGIN",
+		"DRIVE9_SLOCK_API_ORIGIN",
+		"DRIVE9_SLOCK_CLIENT_ID",
+		"DRIVE9_SLOCK_CLIENT_SECRET",
+		"DRIVE9_PUBLIC_URL",
+	}
+	restore := snapshotEnv(t, keys)
+	t.Cleanup(func() { restoreEnv(t, restore) })
+	unsetEnv(t, keys)
+	setEnv(t, "DRIVE9_SLOCK_ORIGIN", "https://app.slock.ai")
+
+	if _, err := slockOAuthFromEnv(); err == nil {
+		t.Fatal("expected partial Slock config to fail")
+	}
+}
+
+func TestSlockOAuthFromEnvEnabled(t *testing.T) {
+	keys := []string{
+		"DRIVE9_SLOCK_ORIGIN",
+		"DRIVE9_SLOCK_API_ORIGIN",
+		"DRIVE9_SLOCK_CLIENT_ID",
+		"DRIVE9_SLOCK_CLIENT_SECRET",
+		"DRIVE9_PUBLIC_URL",
+	}
+	restore := snapshotEnv(t, keys)
+	t.Cleanup(func() { restoreEnv(t, restore) })
+	unsetEnv(t, keys)
+	setEnv(t, "DRIVE9_SLOCK_ORIGIN", "https://app.slock.ai")
+	setEnv(t, "DRIVE9_SLOCK_API_ORIGIN", "https://api.slock.ai")
+	setEnv(t, "DRIVE9_SLOCK_CLIENT_ID", "drive9")
+	setEnv(t, "DRIVE9_SLOCK_CLIENT_SECRET", "secret")
+	setEnv(t, "DRIVE9_PUBLIC_URL", "https://drive9.example.com")
+
+	c, err := slockOAuthFromEnv()
+	if err != nil {
+		t.Fatalf("slockOAuthFromEnv: %v", err)
+	}
+	if c == nil || !strings.Contains(c.LoginURL(), "client_id=drive9") {
+		t.Fatalf("unexpected Slock client: %#v", c)
+	}
+}
+
 func TestBuildBackendOptionsFromEnvAudioDisabled(t *testing.T) {
 	keys := []string{
 		"DRIVE9_QUERY_EMBED_API_BASE",

--- a/internal/testmysql/testmysql.go
+++ b/internal/testmysql/testmysql.go
@@ -84,6 +84,7 @@ func ResetMetaDB(t *testing.T, db *sql.DB) {
 	queries := []string{
 		"DELETE FROM tenant_api_key_fs_scopes",
 		"DELETE FROM tenant_api_keys",
+		"DELETE FROM tenant_external_bindings",
 		"DELETE FROM tenants",
 	}
 	for _, q := range queries {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -30,6 +30,7 @@ var (
 type TenantStatus string
 
 const (
+	TenantPending      TenantStatus = "pending"
 	TenantProvisioning TenantStatus = "provisioning"
 	TenantActive       TenantStatus = "active"
 	TenantFailed       TenantStatus = "failed"

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -136,18 +136,21 @@ func (t Tenant) S3BucketKeyEnabledValue() bool {
 }
 
 type APIKey struct {
-	ID            string
-	TenantID      string
-	KeyName       string
-	JWTCiphertext []byte
-	JWTHash       string
-	TokenVersion  int
-	Status        APIKeyStatus
-	ScopeKind     APIKeyScopeKind
-	IssuedAt      time.Time
-	RevokedAt     *time.Time
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	ID                   string
+	TenantID             string
+	KeyName              string
+	JWTCiphertext        []byte
+	JWTHash              string
+	TokenVersion         int
+	Status               APIKeyStatus
+	ScopeKind            APIKeyScopeKind
+	IssuedByProvider     string
+	IssuedBySubjectKey   string
+	IssuedByMetadataJSON []byte
+	IssuedAt             time.Time
+	RevokedAt            *time.Time
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
 }
 
 type APIKeyFSScope struct {
@@ -163,6 +166,15 @@ type APIKeyFSScope struct {
 type TenantWithAPIKey struct {
 	Tenant Tenant
 	APIKey APIKey
+}
+
+type ExternalBinding struct {
+	Provider     string
+	SubjectKey   string
+	TenantID     string
+	MetadataJSON []byte
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 type Store struct {
@@ -190,6 +202,7 @@ func (s *Store) DB() *sql.DB  { return s.db }
 
 const metaSchemaMigrateLockNamePrefix = "dat9_meta_schema_migrate:"
 const metaSchemaMigrateLockTimeoutSeconds = 30
+const externalBindingLockTimeoutSeconds = 30
 
 func (s *Store) migrate() (err error) {
 	ctx := context.Background()
@@ -407,12 +420,25 @@ func metaInitSchemaStatements() []string {
 			token_version  INT NOT NULL DEFAULT 1,
 			status         VARCHAR(20) NOT NULL DEFAULT 'active',
 			scope_kind     VARCHAR(32) NOT NULL DEFAULT 'owner',
+			issued_by_provider VARCHAR(64) NOT NULL DEFAULT '',
+			issued_by_subject_key VARCHAR(512) NOT NULL DEFAULT '',
+			issued_by_metadata_json JSON NULL,
 			issued_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			revoked_at     DATETIME(3) NULL,
 			created_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			UNIQUE INDEX idx_api_keys_hash (jwt_hash),
 			INDEX idx_api_keys_tenant (tenant_id, status)
+		)`,
+		`CREATE TABLE IF NOT EXISTS tenant_external_bindings (
+			provider      VARCHAR(64) NOT NULL,
+			subject_key   VARCHAR(512) NOT NULL,
+			tenant_id     VARCHAR(64) NOT NULL,
+			metadata_json JSON NULL,
+			created_at    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			UNIQUE INDEX uk_external_binding_subject (provider, subject_key),
+			INDEX idx_external_binding_tenant (tenant_id)
 		)`,
 		`CREATE TABLE IF NOT EXISTS tenant_api_key_fs_scopes (
 			tenant_id   VARCHAR(64) NOT NULL,
@@ -997,14 +1023,99 @@ func (s *Store) InsertAPIKey(ctx context.Context, k *APIKey) (err error) {
 		return err
 	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_api_keys
-		(id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, scope_kind, issued_at, revoked_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		(id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, scope_kind,
+		 issued_by_provider, issued_by_subject_key, issued_by_metadata_json,
+		 issued_at, revoked_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		k.ID, k.TenantID, k.KeyName, k.JWTCiphertext, k.JWTHash, k.TokenVersion, k.Status, scopeKind,
+		k.IssuedByProvider, k.IssuedBySubjectKey, nullableBytes(k.IssuedByMetadataJSON),
 		k.IssuedAt.UTC(), k.RevokedAt, k.CreatedAt.UTC(), k.UpdatedAt.UTC())
 	if isDuplicateEntry(err) {
 		return ErrDuplicate
 	}
 	return err
+}
+
+func (s *Store) GetExternalBinding(ctx context.Context, provider, subjectKey string) (out *ExternalBinding, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "get_external_binding", start, &err)
+	row := s.db.QueryRowContext(ctx, `SELECT provider, subject_key, tenant_id, metadata_json, created_at, updated_at
+		FROM tenant_external_bindings
+		WHERE provider = ? AND subject_key = ?`, provider, subjectKey)
+	var rec ExternalBinding
+	var metadata []byte
+	if err = row.Scan(&rec.Provider, &rec.SubjectKey, &rec.TenantID, &metadata, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			err = ErrNotFound
+			return nil, err
+		}
+		return nil, err
+	}
+	rec.MetadataJSON = metadata
+	return &rec, nil
+}
+
+func (s *Store) InsertExternalBinding(ctx context.Context, b *ExternalBinding) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "insert_external_binding", start, &err)
+	if b == nil {
+		return fmt.Errorf("external binding is required")
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_external_bindings
+		(provider, subject_key, tenant_id, metadata_json, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		b.Provider, b.SubjectKey, b.TenantID, nullableBytes(b.MetadataJSON), b.CreatedAt.UTC(), b.UpdatedAt.UTC())
+	if isDuplicateEntry(err) {
+		return ErrDuplicate
+	}
+	return err
+}
+
+func (s *Store) WithExternalBindingLock(ctx context.Context, provider, subjectKey string, fn func(context.Context) error) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "external_binding_lock", start, &err)
+	if fn == nil {
+		return fmt.Errorf("external binding lock callback is required")
+	}
+	lockName := externalBindingLockName(provider, subjectKey)
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	var got sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, externalBindingLockTimeoutSeconds).Scan(&got); err != nil {
+		return err
+	}
+	if !got.Valid {
+		return fmt.Errorf("external binding named lock returned NULL")
+	}
+	if got.Int64 != 1 {
+		return fmt.Errorf("timed out waiting for external binding named lock")
+	}
+	defer func() {
+		var released sql.NullInt64
+		releaseErr := conn.QueryRowContext(context.Background(), "SELECT RELEASE_LOCK(?)", lockName).Scan(&released)
+		if releaseErr != nil {
+			err = errors.Join(err, releaseErr)
+			return
+		}
+		if !released.Valid {
+			err = errors.Join(err, fmt.Errorf("external binding named lock release returned NULL"))
+			return
+		}
+		if released.Int64 != 1 {
+			err = errors.Join(err, fmt.Errorf("external binding named lock was not held by current connection"))
+		}
+	}()
+
+	return fn(ctx)
+}
+
+func externalBindingLockName(provider, subjectKey string) string {
+	sum := sha256.Sum256([]byte(provider + "\x00" + subjectKey))
+	return "d9_extbind:" + hex.EncodeToString(sum[:26])
 }
 
 func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *TenantWithAPIKey, err error) {
@@ -1015,7 +1126,8 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name, t.db_tls,
 			t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
 			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
-			k.id, k.tenant_id, k.key_name, k.jwt_ciphertext, k.jwt_hash, k.token_version, k.status, k.scope_kind, k.issued_at,
+			k.id, k.tenant_id, k.key_name, k.jwt_ciphertext, k.jwt_hash, k.token_version, k.status, k.scope_kind,
+			k.issued_by_provider, k.issued_by_subject_key, k.issued_by_metadata_json, k.issued_at,
 			k.revoked_at, k.created_at, k.updated_at
 		FROM tenant_api_keys k
 		JOIN tenants t ON t.id = k.tenant_id
@@ -1030,6 +1142,9 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 	var storageNamespaceID sql.NullString
 	var revokedAt sql.NullTime
 	var s3BucketKeyEnabled int
+	var issuedByProvider sql.NullString
+	var issuedBySubjectKey sql.NullString
+	var issuedByMetadataJSON []byte
 	if err = row.Scan(
 		&rec.Tenant.ID, &rec.Tenant.Status, &rec.Tenant.Kind, &parentTenantID, &storageNamespaceID,
 		&rec.Tenant.DBHost, &rec.Tenant.DBPort, &rec.Tenant.DBUser,
@@ -1037,7 +1152,8 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 		&rec.Tenant.BranchID, &claimURL, &claimExp, &rec.Tenant.SchemaVersion, &rec.Tenant.S3EncryptionMode,
 		&rec.Tenant.S3KMSKeyID, &s3BucketKeyEnabled, &rec.Tenant.CreatedAt, &rec.Tenant.UpdatedAt,
 		&rec.APIKey.ID, &rec.APIKey.TenantID, &rec.APIKey.KeyName, &rec.APIKey.JWTCiphertext,
-		&rec.APIKey.JWTHash, &rec.APIKey.TokenVersion, &rec.APIKey.Status, &rec.APIKey.ScopeKind, &rec.APIKey.IssuedAt,
+		&rec.APIKey.JWTHash, &rec.APIKey.TokenVersion, &rec.APIKey.Status, &rec.APIKey.ScopeKind,
+		&issuedByProvider, &issuedBySubjectKey, &issuedByMetadataJSON, &rec.APIKey.IssuedAt,
 		&revokedAt, &rec.APIKey.CreatedAt, &rec.APIKey.UpdatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1068,6 +1184,13 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 		t := revokedAt.Time.UTC()
 		rec.APIKey.RevokedAt = &t
 	}
+	if issuedByProvider.Valid {
+		rec.APIKey.IssuedByProvider = issuedByProvider.String
+	}
+	if issuedBySubjectKey.Valid {
+		rec.APIKey.IssuedBySubjectKey = issuedBySubjectKey.String
+	}
+	rec.APIKey.IssuedByMetadataJSON = issuedByMetadataJSON
 	out = &rec
 	return out, nil
 }
@@ -1765,6 +1888,13 @@ func boolPtr(v bool) *bool {
 
 func nullStr(v string) any {
 	if v == "" {
+		return nil
+	}
+	return v
+}
+
+func nullableBytes(v []byte) any {
+	if len(v) == 0 {
 		return nil
 	}
 	return v

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1578,6 +1578,18 @@ func (s *Store) RevokeAPIKey(ctx context.Context, tenantID, apiKeyID string) (er
 	return nil
 }
 
+func (s *Store) RevokeAPIKeysByIssuer(ctx context.Context, tenantID, provider, subjectKey, exceptAPIKeyID string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "revoke_api_keys_by_issuer", start, &err)
+	now := time.Now().UTC()
+	_, err = s.db.ExecContext(ctx, `UPDATE tenant_api_keys
+		SET status = ?, revoked_at = COALESCE(revoked_at, ?), updated_at = ?
+		WHERE tenant_id = ? AND issued_by_provider = ? AND issued_by_subject_key = ? AND status = ?
+			AND (? = '' OR id <> ?)`,
+		APIKeyRevoked, now, now, tenantID, provider, subjectKey, APIKeyActive, exceptAPIKeyID, exceptAPIKeyID)
+	return err
+}
+
 func (s *Store) UpsertStorageNamespace(ctx context.Context, ns *StorageNamespace) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "upsert_storage_namespace", start, &err)

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -204,6 +204,7 @@ func (s *Store) DB() *sql.DB  { return s.db }
 const metaSchemaMigrateLockNamePrefix = "dat9_meta_schema_migrate:"
 const metaSchemaMigrateLockTimeoutSeconds = 30
 const externalBindingLockTimeoutSeconds = 30
+const externalBindingReleaseLockTimeout = 5 * time.Second
 
 func (s *Store) migrate() (err error) {
 	ctx := context.Background()
@@ -1100,7 +1101,7 @@ func (s *Store) WithExternalBindingLock(ctx context.Context, provider, subjectKe
 	defer func() { _ = conn.Close() }()
 
 	var got sql.NullInt64
-	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, externalBindingLockTimeoutSeconds).Scan(&got); err != nil {
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(CONCAT(?, DATABASE()), ?)", lockName, externalBindingLockTimeoutSeconds).Scan(&got); err != nil {
 		return err
 	}
 	if !got.Valid {
@@ -1110,8 +1111,10 @@ func (s *Store) WithExternalBindingLock(ctx context.Context, provider, subjectKe
 		return fmt.Errorf("timed out waiting for external binding named lock")
 	}
 	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), externalBindingReleaseLockTimeout)
+		defer cancel()
 		var released sql.NullInt64
-		releaseErr := conn.QueryRowContext(context.Background(), "SELECT RELEASE_LOCK(?)", lockName).Scan(&released)
+		releaseErr := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(CONCAT(?, DATABASE()))", lockName).Scan(&released)
 		if releaseErr != nil {
 			err = errors.Join(err, releaseErr)
 			return
@@ -1130,7 +1133,7 @@ func (s *Store) WithExternalBindingLock(ctx context.Context, provider, subjectKe
 
 func externalBindingLockName(provider, subjectKey string) string {
 	sum := sha256.Sum256([]byte(provider + "\x00" + subjectKey))
-	return "d9_extbind:" + hex.EncodeToString(sum[:26])
+	return "d9_extbind:" + hex.EncodeToString(sum[:20])
 }
 
 func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *TenantWithAPIKey, err error) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -203,7 +203,7 @@ func (s *Store) DB() *sql.DB  { return s.db }
 
 const metaSchemaMigrateLockNamePrefix = "dat9_meta_schema_migrate:"
 const metaSchemaMigrateLockTimeoutSeconds = 30
-const externalBindingLockTimeoutSeconds = 30
+const externalBindingLockTimeoutSeconds = 90
 const externalBindingReleaseLockTimeout = 5 * time.Second
 
 func (s *Store) migrate() (err error) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1071,6 +1071,20 @@ func (s *Store) InsertExternalBinding(ctx context.Context, b *ExternalBinding) (
 	return err
 }
 
+func (s *Store) DeleteExternalBinding(ctx context.Context, provider, subjectKey string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_external_binding", start, &err)
+	res, err := s.db.ExecContext(ctx, `DELETE FROM tenant_external_bindings WHERE provider = ? AND subject_key = ?`, provider, subjectKey)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) WithExternalBindingLock(ctx context.Context, provider, subjectKey string, fn func(context.Context) error) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "external_binding_lock", start, &err)

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -2,8 +2,11 @@ package meta
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +22,7 @@ func newControlStore(t *testing.T) *Store {
 	t.Cleanup(func() { _ = s.Close() })
 	_, _ = s.DB().Exec("DELETE FROM tenant_api_key_fs_scopes")
 	_, _ = s.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = s.DB().Exec("DELETE FROM tenant_external_bindings")
 	_, _ = s.DB().Exec("DELETE FROM tenants")
 	_, _ = s.DB().Exec("DELETE FROM llm_usage")
 	return s
@@ -141,6 +145,133 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 	}
 	if err := s.RevokeAPIKey(context.Background(), "wrong-tenant", key.ID); err != ErrNotFound {
 		t.Fatalf("RevokeAPIKey wrong tenant error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestInsertAndGetExternalBinding(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertTenant(context.Background(), &Tenant{
+		ID:               "binding-tenant",
+		Status:           TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_db_binding",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"server_id":"srv","sub":"sub"}`)
+	if err := s.InsertExternalBinding(context.Background(), &ExternalBinding{
+		Provider:     "slock",
+		SubjectKey:   "srv:sub",
+		TenantID:     "binding-tenant",
+		MetadataJSON: metadata,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}); err != nil {
+		t.Fatalf("InsertExternalBinding: %v", err)
+	}
+	got, err := s.GetExternalBinding(context.Background(), "slock", "srv:sub")
+	if err != nil {
+		t.Fatalf("GetExternalBinding: %v", err)
+	}
+	if got.Provider != "slock" || got.SubjectKey != "srv:sub" || got.TenantID != "binding-tenant" ||
+		!strings.Contains(string(got.MetadataJSON), `"server_id": "srv"`) ||
+		!strings.Contains(string(got.MetadataJSON), `"sub": "sub"`) {
+		t.Fatalf("binding = %+v metadata=%s", got, string(got.MetadataJSON))
+	}
+	if err := s.InsertExternalBinding(context.Background(), got); !errors.Is(err, ErrDuplicate) {
+		t.Fatalf("duplicate InsertExternalBinding error = %v, want ErrDuplicate", err)
+	}
+	if _, err := s.GetExternalBinding(context.Background(), "slock", "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing GetExternalBinding error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestInsertAPIKeyStoresIssuedByMetadata(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC()
+	tenant := &Tenant{
+		ID:               "issued-by-tenant",
+		Status:           TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_db_issued_by",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := s.InsertTenant(context.Background(), tenant); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertAPIKey(context.Background(), &APIKey{
+		ID:                   "issued-key",
+		TenantID:             tenant.ID,
+		KeyName:              "slock",
+		JWTCiphertext:        []byte("cipher"),
+		JWTHash:              "hash-issued",
+		TokenVersion:         1,
+		Status:               APIKeyActive,
+		ScopeKind:            APIKeyScopeKindOwner,
+		IssuedByProvider:     "slock",
+		IssuedBySubjectKey:   "srv:sub",
+		IssuedByMetadataJSON: []byte(`{"type":"agent"}`),
+		IssuedAt:             now,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}); err != nil {
+		t.Fatalf("InsertAPIKey: %v", err)
+	}
+	got, err := s.ResolveByAPIKeyHash(context.Background(), "hash-issued")
+	if err != nil {
+		t.Fatalf("ResolveByAPIKeyHash: %v", err)
+	}
+	if got.APIKey.IssuedByProvider != "slock" || got.APIKey.IssuedBySubjectKey != "srv:sub" ||
+		!strings.Contains(string(got.APIKey.IssuedByMetadataJSON), `"type": "agent"`) {
+		t.Fatalf("issued-by metadata not round-tripped: %+v metadata=%s", got.APIKey, string(got.APIKey.IssuedByMetadataJSON))
+	}
+}
+
+func TestWithExternalBindingLockSerializesCallbacks(t *testing.T) {
+	s := newControlStore(t)
+	var running int32
+	var maxRunning int32
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := s.WithExternalBindingLock(context.Background(), "slock", "srv:sub", func(context.Context) error {
+				n := atomic.AddInt32(&running, 1)
+				for {
+					max := atomic.LoadInt32(&maxRunning)
+					if n <= max || atomic.CompareAndSwapInt32(&maxRunning, max, n) {
+						break
+					}
+				}
+				time.Sleep(20 * time.Millisecond)
+				atomic.AddInt32(&running, -1)
+				return nil
+			})
+			if err != nil {
+				t.Errorf("WithExternalBindingLock: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if maxRunning != 1 {
+		t.Fatalf("max concurrent lock holders = %d, want 1", maxRunning)
 	}
 }
 
@@ -711,6 +842,19 @@ func TestMetaSchemaSpecIncludesAPIKeyScopeTables(t *testing.T) {
 	if scopeKind.addSQL != "ALTER TABLE tenant_api_keys ADD COLUMN scope_kind VARCHAR(32) NOT NULL DEFAULT 'owner'" {
 		t.Fatalf("scope_kind addSQL = %q", scopeKind.addSQL)
 	}
+	for column, wantAddSQL := range map[string]string{
+		"issued_by_provider":      "ALTER TABLE tenant_api_keys ADD COLUMN issued_by_provider VARCHAR(64) NOT NULL DEFAULT ''",
+		"issued_by_subject_key":   "ALTER TABLE tenant_api_keys ADD COLUMN issued_by_subject_key VARCHAR(512) NOT NULL DEFAULT ''",
+		"issued_by_metadata_json": "ALTER TABLE tenant_api_keys ADD COLUMN issued_by_metadata_json JSON NULL",
+	} {
+		spec, ok := apiKeys.columns[column]
+		if !ok {
+			t.Fatalf("tenant_api_keys schema missing %s", column)
+		}
+		if spec.addSQL != wantAddSQL {
+			t.Fatalf("%s addSQL = %q, want %q", column, spec.addSQL, wantAddSQL)
+		}
+	}
 
 	scopes := mustMetaTableSpec(t, spec, "tenant_api_key_fs_scopes")
 	for _, column := range []string{"tenant_id", "api_key_id", "prefix", "prefix_hash", "ops"} {
@@ -721,6 +865,20 @@ func TestMetaSchemaSpecIncludesAPIKeyScopeTables(t *testing.T) {
 	for _, index := range []string{"primary", "idx_fs_scopes_api_key", "idx_fs_scopes_tenant_key"} {
 		if _, ok := scopes.indexes[index]; !ok {
 			t.Fatalf("tenant_api_key_fs_scopes schema missing index %s", index)
+		}
+	}
+}
+
+func TestMetaSchemaSpecIncludesExternalBindings(t *testing.T) {
+	table := mustMetaTableSpec(t, mustMetaSpec(t), "tenant_external_bindings")
+	for _, column := range []string{"provider", "subject_key", "tenant_id", "metadata_json", "created_at", "updated_at"} {
+		if _, ok := table.columns[column]; !ok {
+			t.Fatalf("tenant_external_bindings schema missing %s", column)
+		}
+	}
+	for _, index := range []string{"uk_external_binding_subject", "idx_external_binding_tenant"} {
+		if _, ok := table.indexes[index]; !ok {
+			t.Fatalf("tenant_external_bindings schema missing index %s", index)
 		}
 	}
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/metrics"
 )
 
@@ -20,10 +21,7 @@ func newControlStore(t *testing.T) *Store {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
-	_, _ = s.DB().Exec("DELETE FROM tenant_api_key_fs_scopes")
-	_, _ = s.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = s.DB().Exec("DELETE FROM tenant_external_bindings")
-	_, _ = s.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, s.DB())
 	_, _ = s.DB().Exec("DELETE FROM llm_usage")
 	return s
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -144,6 +144,49 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 	if err := s.RevokeAPIKey(context.Background(), "wrong-tenant", key.ID); err != ErrNotFound {
 		t.Fatalf("RevokeAPIKey wrong tenant error = %v, want ErrNotFound", err)
 	}
+
+	key2 := &APIKey{
+		ID:                 "k2",
+		TenantID:           tenant.ID,
+		KeyName:            "k2",
+		JWTCiphertext:      []byte("jwt2"),
+		JWTHash:            "hash2",
+		TokenVersion:       2,
+		Status:             APIKeyActive,
+		ScopeKind:          APIKeyScopeKindOwner,
+		IssuedByProvider:   "slock",
+		IssuedBySubjectKey: "subject-1",
+		IssuedAt:           now,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if err := s.InsertAPIKey(context.Background(), key2); err != nil {
+		t.Fatal(err)
+	}
+	key3 := *key2
+	key3.ID = "k3"
+	key3.KeyName = "k3"
+	key3.JWTHash = "hash3"
+	if err := s.InsertAPIKey(context.Background(), &key3); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RevokeAPIKeysByIssuer(context.Background(), tenant.ID, "slock", "subject-1", key3.ID); err != nil {
+		t.Fatalf("RevokeAPIKeysByIssuer error = %v, want nil", err)
+	}
+	issuerRevoked, err := s.ResolveByAPIKeyHash(context.Background(), "hash2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issuerRevoked.APIKey.Status != APIKeyRevoked {
+		t.Fatalf("issuer revoked key status = %s, want %s", issuerRevoked.APIKey.Status, APIKeyRevoked)
+	}
+	issuerKept, err := s.ResolveByAPIKeyHash(context.Background(), "hash3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issuerKept.APIKey.Status != APIKeyActive {
+		t.Fatalf("issuer kept key status = %s, want %s", issuerKept.APIKey.Status, APIKeyActive)
+	}
 }
 
 func TestInsertAndGetExternalBinding(t *testing.T) {

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -229,6 +229,11 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 
 		switch resolved.Tenant.Status {
 		case meta.TenantActive:
+		case meta.TenantPending:
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_pending", "tenant_id", resolved.Tenant.ID)...)
+			metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantPending))
+			errJSON(w, http.StatusServiceUnavailable, "tenant provisioning is pending")
+			return
 		case meta.TenantProvisioning:
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_provisioning", "tenant_id", resolved.Tenant.ID)...)
 			metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantProvisioning))

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -20,9 +20,10 @@ import (
 )
 
 type fakeProvisioner struct {
-	provider string
-	cluster  *tenant.ClusterInfo
-	initErr  error
+	provider     string
+	cluster      *tenant.ClusterInfo
+	initErr      error
+	provisionErr error
 }
 
 func (f *fakeProvisioner) ProviderType() string { return f.provider }
@@ -35,6 +36,9 @@ func (f *fakeProvisioner) InitSchema(_ context.Context, dsn string) error {
 }
 
 func (f *fakeProvisioner) Provision(_ context.Context, tenantID string) (*tenant.ClusterInfo, error) {
+	if f.provisionErr != nil {
+		return nil, f.provisionErr
+	}
 	out := *f.cluster
 	out.TenantID = tenantID
 	out.Provider = f.provider
@@ -260,6 +264,78 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	}
 }
 
+func TestProvisionPersistsTenantBeforeProvisionFailure(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+
+	prov := &fakeProvisioner{
+		provider:     tenant.ProviderTiDBZero,
+		cluster:      &tenant.ClusterInfo{},
+		provisionErr: fmt.Errorf("boom"),
+	}
+
+	srv := NewWithConfig(Config{
+		Meta:        metaStore,
+		Pool:        pool,
+		Provisioner: prov,
+		TokenSecret: tokenSecret,
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	body, _ := json.Marshal(map[string]any{"provider": tenant.ProviderTiDBZero})
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status=%d, want %d", resp.StatusCode, http.StatusBadGateway)
+	}
+
+	var tenantID, status string
+	if err := metaStore.DB().QueryRow("SELECT id, status FROM tenants LIMIT 1").Scan(&tenantID, &status); err != nil {
+		t.Fatalf("QueryRow tenant: %v", err)
+	}
+	if tenantID == "" {
+		t.Fatal("expected tenant row to be persisted")
+	}
+	if status != string(meta.TenantFailed) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
+	}
+	var keyCount int
+	if err := metaStore.DB().QueryRow("SELECT COUNT(*) FROM tenant_api_keys").Scan(&keyCount); err != nil {
+		t.Fatal(err)
+	}
+	if keyCount != 0 {
+		t.Fatalf("api key count = %d, want 0", keyCount)
+	}
+}
+
 func TestStartupResumesProvisioningTenantInit(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -332,6 +408,65 @@ func TestStartupResumesProvisioningTenantInit(t *testing.T) {
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("tenant did not become active after restart resume, status=%s", status)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestStartupMarksPendingTenantFailed(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tenantID := token.NewID()
+	now := time.Now().UTC()
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantPending,
+		DBHost:           "",
+		DBPort:           0,
+		DBUser:           "",
+		DBPasswordCipher: []byte{},
+		DBName:           "",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBZero,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBZero, cluster: &tenant.ClusterInfo{}}
+	_ = NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov, TokenSecret: []byte("abc")})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		row := metaStore.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", tenantID)
+		var status string
+		if err := row.Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status == string(meta.TenantFailed) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pending tenant did not become failed after startup resume, status=%s", status)
 		}
 		time.Sleep(20 * time.Millisecond)
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -528,7 +528,8 @@ func TestStartupKeepsFreshPendingTenant(t *testing.T) {
 	}
 
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBZero, cluster: &tenant.ClusterInfo{}}
-	_ = NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov, TokenSecret: []byte("abc")})
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov, TokenSecret: []byte("abc")})
+	t.Cleanup(srv.Close)
 
 	time.Sleep(100 * time.Millisecond)
 	row := metaStore.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", tenantID)

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -584,3 +584,46 @@ func TestReconcilePendingTenantDoesNotOverwriteChangedStatus(t *testing.T) {
 		t.Fatalf("status after reconcile = %s, want %s", status, meta.TenantProvisioning)
 	}
 }
+
+func TestServerCloseCancelsSchemaInitRetryWorker(t *testing.T) {
+	origWindow, origInitBackoff, origMaxBackoff := schemaInitRetryWindow, schemaInitInitialBackoff, schemaInitMaxBackoff
+	schemaInitRetryWindow = time.Minute
+	schemaInitInitialBackoff = 5 * time.Second
+	schemaInitMaxBackoff = 5 * time.Second
+	defer func() {
+		schemaInitRetryWindow = origWindow
+		schemaInitInitialBackoff = origInitBackoff
+		schemaInitMaxBackoff = origMaxBackoff
+	}()
+
+	prov := &fakeProvisioner{
+		provider: tenant.ProviderTiDBZero,
+		cluster:  &tenant.ClusterInfo{},
+		initErr:  fmt.Errorf("boom"),
+	}
+	srv := NewWithConfig(Config{
+		Provisioner: prov,
+		TokenSecret: []byte("abc"),
+	})
+
+	srv.startProvisionedTenantSchemaInit(context.Background(), &provisionTenantResult{
+		TenantID:  "tenant-close-test",
+		TenantDSN: "user:pass@tcp(localhost:3306)/db?parseTime=true",
+		Provider:  tenant.ProviderTiDBZero,
+	})
+
+	// Let the worker enter the retry backoff path before closing the server.
+	time.Sleep(50 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		srv.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Server.Close did not cancel schema init retry worker promptly")
+	}
+}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,10 +22,11 @@ import (
 )
 
 type fakeProvisioner struct {
-	provider     string
-	cluster      *tenant.ClusterInfo
-	initErr      error
-	provisionErr error
+	provider       string
+	cluster        *tenant.ClusterInfo
+	initErr        error
+	provisionErr   error
+	provisionCalls atomic.Int32
 }
 
 func (f *fakeProvisioner) ProviderType() string { return f.provider }
@@ -37,6 +39,7 @@ func (f *fakeProvisioner) InitSchema(_ context.Context, dsn string) error {
 }
 
 func (f *fakeProvisioner) Provision(_ context.Context, tenantID string) (*tenant.ClusterInfo, error) {
+	f.provisionCalls.Add(1)
 	if f.provisionErr != nil {
 		return nil, f.provisionErr
 	}
@@ -44,6 +47,10 @@ func (f *fakeProvisioner) Provision(_ context.Context, tenantID string) (*tenant
 	out.TenantID = tenantID
 	out.Provider = f.provider
 	return &out, nil
+}
+
+func (f *fakeProvisioner) ProvisionCallCount() int {
+	return int(f.provisionCalls.Load())
 }
 
 func TestProvisionMarksTenantFailedWhenInitKeepsFailing(t *testing.T) {
@@ -430,7 +437,14 @@ func TestStartupMarksPendingTenantFailed(t *testing.T) {
 	defer pool.Close()
 
 	tenantID := token.NewID()
-	now := time.Now().UTC()
+	now := time.Now().UTC().Add(-2 * time.Minute)
+	origStaleAfter, origSweepEvery := pendingTenantStaleAfter, pendingTenantSweepEvery
+	pendingTenantStaleAfter = time.Minute
+	pendingTenantSweepEvery = time.Hour
+	defer func() {
+		pendingTenantStaleAfter = origStaleAfter
+		pendingTenantSweepEvery = origSweepEvery
+	}()
 	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
 		ID:               tenantID,
 		Status:           meta.TenantPending,
@@ -465,5 +479,107 @@ func TestStartupMarksPendingTenantFailed(t *testing.T) {
 			t.Fatalf("pending tenant did not become failed after startup resume, status=%s", status)
 		}
 		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestStartupKeepsFreshPendingTenant(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tenantID := token.NewID()
+	now := time.Now().UTC()
+	origStaleAfter, origSweepEvery := pendingTenantStaleAfter, pendingTenantSweepEvery
+	pendingTenantStaleAfter = time.Minute
+	pendingTenantSweepEvery = time.Hour
+	defer func() {
+		pendingTenantStaleAfter = origStaleAfter
+		pendingTenantSweepEvery = origSweepEvery
+	}()
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantPending,
+		DBHost:           "",
+		DBPort:           0,
+		DBUser:           "",
+		DBPasswordCipher: []byte{},
+		DBName:           "",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBZero,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBZero, cluster: &tenant.ClusterInfo{}}
+	_ = NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov, TokenSecret: []byte("abc")})
+
+	time.Sleep(100 * time.Millisecond)
+	row := metaStore.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", tenantID)
+	var status string
+	if err := row.Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantPending) {
+		t.Fatalf("fresh pending tenant status = %s, want %s", status, meta.TenantPending)
+	}
+}
+
+func TestReconcilePendingTenantDoesNotOverwriteChangedStatus(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	tenantID := token.NewID()
+	now := time.Now().UTC().Add(-2 * time.Minute)
+	origStaleAfter := pendingTenantStaleAfter
+	pendingTenantStaleAfter = time.Minute
+	defer func() { pendingTenantStaleAfter = origStaleAfter }()
+	pendingTenant := meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantPending,
+		DBPasswordCipher: []byte{},
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBZero,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := metaStore.InsertTenant(context.Background(), &pendingTenant); err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.UpdateTenantStatus(context.Background(), tenantID, meta.TenantProvisioning); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{meta: metaStore}
+	srv.reconcilePendingTenant(context.Background(), pendingTenant)
+
+	row := metaStore.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", tenantID)
+	var status string
+	if err := row.Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantProvisioning) {
+		t.Fatalf("status after reconcile = %s, want %s", status, meta.TenantProvisioning)
 	}
 }

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
@@ -51,8 +52,7 @@ func TestProvisionMarksTenantFailedWhenInitKeepsFailing(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	master := make([]byte, 32)
 	if _, err := rand.Read(master); err != nil {
@@ -150,8 +150,7 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	master := make([]byte, 32)
 	if _, err := rand.Read(master); err != nil {
@@ -270,8 +269,7 @@ func TestProvisionPersistsTenantBeforeProvisionFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	master := make([]byte, 32)
 	if _, err := rand.Read(master); err != nil {
@@ -342,8 +340,7 @@ func TestStartupResumesProvisioningTenantInit(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	master := make([]byte, 32)
 	if _, err := rand.Read(master); err != nil {
@@ -419,8 +416,7 @@ func TestStartupMarksPendingTenantFailed(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	master := make([]byte, 32)
 	if _, err := rand.Read(master); err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/metrics"
 	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/s3client"
+	"github.com/mem9-ai/dat9/pkg/slockoauth"
 	"github.com/mem9-ai/dat9/pkg/tagutil"
 	"github.com/mem9-ai/dat9/pkg/tenant"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
@@ -52,6 +53,13 @@ type Config struct {
 	Logger           *zap.Logger
 	SemanticEmbedder embedding.Client
 	SemanticWorkers  SemanticWorkerOptions
+	SlockOAuth       SlockOAuthClient
+}
+
+type SlockOAuthClient interface {
+	LoginURL() string
+	ExchangeCode(ctx context.Context, code string) (slockoauth.Token, error)
+	Userinfo(ctx context.Context, accessToken string) (slockoauth.UserInfo, error)
 }
 
 type Server struct {
@@ -72,6 +80,7 @@ type Server struct {
 	semanticWorker      *semanticWorkerManager
 	journalCursorSecret []byte
 	objectGCWorker      *objectGCWorker
+	slockOAuth          SlockOAuthClient
 	forkWorkerCtx       context.Context
 	forkWorkerCancel    context.CancelFunc
 	forkWorkerWG        sync.WaitGroup
@@ -159,6 +168,7 @@ func NewWithConfig(cfg Config) *Server {
 		metrics:             newServerMetrics(),
 		logger:              logger,
 		events:              newEventBuses(),
+		slockOAuth:          cfg.SlockOAuth,
 		journalCursorSecret: newJournalCursorSecret(cfg.TokenSecret),
 		forkWorkerCtx:       forkWorkerCtx,
 		forkWorkerCancel:    forkWorkerCancel,
@@ -208,6 +218,8 @@ func NewWithConfig(cfg Config) *Server {
 	}
 	mux.HandleFunc("/v1/status", s.handleTenantStatus)
 	mux.HandleFunc("/v1/provision", s.handleProvision)
+	mux.HandleFunc("/v1/auth/slock/login", s.handleSlockLogin)
+	mux.HandleFunc("/v1/auth/slock/callback", s.handleSlockCallback)
 	mux.HandleFunc("/healthz", s.handleHealthz)
 	mux.HandleFunc("/metrics", s.handleMetrics)
 
@@ -2938,44 +2950,99 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	tenantID := token.NewID()
-	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_requested", "tenant_id", tenantID, "provider", provider)...)
-	keyName := "default"
-
-	apiToken, err := token.IssueTokenWithJournalPermissions(s.tokenSecret, tenantID, 1, time.Time{}, ownerJournalPermissionList())
+	res, err := s.provisionTenant(r.Context(), provisionTenantOptions{
+		KeyName:      "default",
+		TokenVersion: 1,
+	})
 	if err != nil {
-		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_issue_token_failed", "tenant_id", tenantID, "error", err)...)
-		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
-		errJSON(w, http.StatusInternalServerError, "failed to issue token")
+		var pe *provisionTenantError
+		if errors.As(err, &pe) {
+			errJSON(w, pe.status, pe.message)
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to provision tenant")
 		return
 	}
-	hash := token.HashToken(apiToken)
-	now := time.Now().UTC()
-	cluster, err := s.provisioner.Provision(r.Context(), tenantID)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"tenant_id": res.TenantID,
+		"api_key":   res.APIKey,
+		"status":    string(res.Status),
+	})
+}
+
+type apiKeyIssueSource struct {
+	Provider     string
+	SubjectKey   string
+	MetadataJSON []byte
+}
+
+type provisionTenantOptions struct {
+	KeyName      string
+	TokenVersion int
+	APIKeySource apiKeyIssueSource
+}
+
+type provisionTenantResult struct {
+	TenantID string
+	APIKey   string
+	APIKeyID string
+	Status   meta.TenantStatus
+	Provider string
+}
+
+type provisionTenantError struct {
+	status  int
+	message string
+	err     error
+}
+
+func (e *provisionTenantError) Error() string {
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return e.message
+}
+
+func (e *provisionTenantError) Unwrap() error { return e.err }
+
+func newProvisionTenantError(status int, message string, err error) *provisionTenantError {
+	return &provisionTenantError{status: status, message: message, err: err}
+}
+
+func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOptions) (*provisionTenantResult, error) {
+	provider := s.provisioner.ProviderType()
+	provider, err := tenant.NormalizeProvider(provider)
 	if err != nil {
-		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
-		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "cluster_error")
-		errJSON(w, http.StatusBadGateway, fmt.Sprintf("provision tenant cluster failed: %v", err))
-		return
+		logger.Warn(ctx, "server_event", eventFields(ctx, "provision_provider_invalid", "provider", provider, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
+		return nil, newProvisionTenantError(http.StatusBadRequest, err.Error(), err)
+	}
+	tenantID := token.NewID()
+	logger.Info(ctx, "server_event", eventFields(ctx, "provision_requested", "tenant_id", tenantID, "provider", provider)...)
+
+	keyName := strings.TrimSpace(opts.KeyName)
+	if keyName == "" {
+		keyName = "default"
+	}
+	now := time.Now().UTC()
+	cluster, err := s.provisioner.Provision(ctx, tenantID)
+	if err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "cluster_error")
+		return nil, newProvisionTenantError(http.StatusBadGateway, fmt.Sprintf("provision tenant cluster failed: %v", err), err)
 	}
 	cluster.Provider = provider
 
-	cipherPass, err := s.pool.Encrypt(r.Context(), []byte(cluster.Password))
+	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
 	if err != nil {
-		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_encrypt_db_password_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
-		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
-		errJSON(w, http.StatusInternalServerError, "failed to encrypt db password")
-		return
+		logger.Error(ctx, "server_event", eventFields(ctx, "provision_encrypt_db_password_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encrypt db password", err)
 	}
-	cipherToken, err := s.pool.Encrypt(r.Context(), []byte(apiToken))
-	if err != nil {
-		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_encrypt_api_key_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
-		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
-		errJSON(w, http.StatusInternalServerError, "failed to encrypt api key")
-		return
-	}
-
-	if err := s.meta.InsertTenant(r.Context(), &meta.Tenant{
+	if err := s.meta.InsertTenant(ctx, &meta.Tenant{
 		ID:               tenantID,
 		Status:           meta.TenantProvisioning,
 		DBHost:           cluster.Host,
@@ -2992,48 +3059,74 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		CreatedAt:        now,
 		UpdatedAt:        now,
 	}); err != nil {
-		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_insert_tenant_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
-		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
-		metricEvent(r.Context(), "metadb_query", "api", "insert_tenant", "result", "error")
-		errJSON(w, http.StatusInternalServerError, "failed to persist tenant")
-		return
+		logger.Error(ctx, "server_event", eventFields(ctx, "provision_insert_tenant_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
+		metricEvent(ctx, "metadb_query", "api", "insert_tenant", "result", "error")
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist tenant", err)
 	}
-	metricEvent(r.Context(), "metadb_query", "api", "insert_tenant", "result", "ok")
-	apiKeyID := token.NewID()
-	if err := s.meta.InsertAPIKey(r.Context(), &meta.APIKey{
-		ID:            apiKeyID,
-		TenantID:      tenantID,
-		KeyName:       keyName,
-		JWTCiphertext: cipherToken,
-		JWTHash:       hash,
-		TokenVersion:  1,
-		Status:        meta.APIKeyActive,
-		IssuedAt:      now,
-		CreatedAt:     now,
-		UpdatedAt:     now,
-	}); err != nil {
-		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_insert_api_key_failed", "tenant_id", tenantID, "api_key_id", apiKeyID, "error", err)...)
-		metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
-		metricEvent(r.Context(), "metadb_query", "api", "insert_api_key", "result", "error")
-		_ = s.meta.UpdateTenantStatus(r.Context(), tenantID, meta.TenantDeleted)
-		errJSON(w, http.StatusInternalServerError, "failed to persist api key")
-		return
+	metricEvent(ctx, "metadb_query", "api", "insert_tenant", "result", "ok")
+
+	apiToken, apiKeyID, err := s.issueOwnerAPIKey(ctx, tenantID, keyName, opts.TokenVersion, opts.APIKeySource)
+	if err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "provision_insert_api_key_failed", "tenant_id", tenantID, "api_key_id", apiKeyID, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
+		metricEvent(ctx, "metadb_query", "api", "insert_api_key", "result", "error")
+		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantDeleted)
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist api key", err)
 	}
-	metricEvent(r.Context(), "metadb_query", "api", "insert_api_key", "result", "ok")
 
 	// Initialize tenant schema asynchronously; tenant remains in provisioning state until success.
 	dsn := tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true)
-	go s.initTenantSchemaAsync(backgroundWithTrace(r.Context()), tenantID, dsn, provider, s.provisioner.InitSchema)
-	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_accepted", "tenant_id", tenantID, "provider", provider)...)
-	metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "accepted")
+	go s.initTenantSchemaAsync(backgroundWithTrace(ctx), tenantID, dsn, provider, s.provisioner.InitSchema)
+	logger.Info(ctx, "server_event", eventFields(ctx, "provision_accepted", "tenant_id", tenantID, "provider", provider)...)
+	metricEvent(ctx, "tenant_provision", "provider", provider, "result", "accepted")
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
-	_ = json.NewEncoder(w).Encode(map[string]string{
-		"tenant_id": tenantID,
-		"api_key":   apiToken,
-		"status":    string(meta.TenantProvisioning),
-	})
+	return &provisionTenantResult{
+		TenantID: tenantID,
+		APIKey:   apiToken,
+		APIKeyID: apiKeyID,
+		Status:   meta.TenantProvisioning,
+		Provider: provider,
+	}, nil
+}
+
+func (s *Server) issueOwnerAPIKey(ctx context.Context, tenantID, keyName string, tokenVersion int, source apiKeyIssueSource) (rawToken, apiKeyID string, err error) {
+	if tokenVersion <= 0 {
+		tokenVersion, err = newScopedTokenVersion()
+		if err != nil {
+			return "", "", err
+		}
+	}
+	rawToken, err = token.IssueTokenWithJournalPermissions(s.tokenSecret, tenantID, tokenVersion, time.Time{}, ownerJournalPermissionList())
+	if err != nil {
+		return "", "", err
+	}
+	cipherToken, err := s.pool.Encrypt(ctx, []byte(rawToken))
+	if err != nil {
+		return "", "", err
+	}
+	now := time.Now().UTC()
+	apiKeyID = token.NewID()
+	if err := s.meta.InsertAPIKey(ctx, &meta.APIKey{
+		ID:                   apiKeyID,
+		TenantID:             tenantID,
+		KeyName:              keyName,
+		JWTCiphertext:        cipherToken,
+		JWTHash:              token.HashToken(rawToken),
+		TokenVersion:         tokenVersion,
+		Status:               meta.APIKeyActive,
+		ScopeKind:            meta.APIKeyScopeKindOwner,
+		IssuedByProvider:     source.Provider,
+		IssuedBySubjectKey:   source.SubjectKey,
+		IssuedByMetadataJSON: source.MetadataJSON,
+		IssuedAt:             now,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}); err != nil {
+		return "", "", err
+	}
+	metricEvent(ctx, "metadb_query", "api", "insert_api_key", "result", "ok")
+	return rawToken, apiKeyID, nil
 }
 
 // handleLocalTenantProvision serves drive9-server-local's single-tenant

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -359,17 +359,6 @@ func (s *Server) resumePendingTenants() {
 	}
 }
 
-func (s *Server) resumeTenantSchemaInit(t meta.Tenant) {
-	ctx := backgroundWithTrace(context.Background())
-	plain, err := s.pool.Decrypt(ctx, t.DBPasswordCipher)
-	if err != nil {
-		logger.Warn(ctx, "resume_schema_init_skipped", zap.String("tenant_id", t.ID), zap.Error(err))
-		return
-	}
-	dsn := tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS)
-	s.initTenantSchemaAsync(ctx, t.ID, dsn, t.Provider, s.provisioner.InitSchema)
-}
-
 func (s *Server) startTenantSchemaInitResume(ctx context.Context, t meta.Tenant) {
 	s.startServerWorker(ctx, func(workerCtx context.Context) {
 		plain, err := s.pool.Decrypt(workerCtx, t.DBPasswordCipher)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3278,12 +3278,21 @@ func (s *Server) handleLocalTenantProvision(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN, provider string, schemaInit func(context.Context, string) error) {
-	ctx = backgroundWithTrace(ctx)
+	ctx = ensureTrace(ctx)
 	logger.Info(ctx, "server_event", eventFields(ctx, "schema_init_started", "tenant_id", tenantID, "provider", provider)...)
 	deadline := time.Now().Add(schemaInitRetryWindow)
 	backoff := schemaInitInitialBackoff
 	attempt := 1
 	for {
+		select {
+		case <-ctx.Done():
+			logger.Info(ctx, "schema_init_stopped",
+				zap.String("tenant_id", tenantID),
+				zap.String("provider", provider),
+				zap.Error(ctx.Err()))
+			return
+		default:
+		}
 		if err := schemaInit(ctx, tenantDSN); err == nil {
 			logger.Info(ctx, "server_event", eventFields(ctx, "schema_init_ok", "tenant_id", tenantID, "provider", provider, "attempt", attempt)...)
 			if s.metrics != nil {
@@ -3333,7 +3342,19 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			sleepFor = time.Until(deadline)
 		}
 		if sleepFor > 0 {
-			time.Sleep(sleepFor)
+			timer := time.NewTimer(sleepFor)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				logger.Info(ctx, "schema_init_stopped",
+					zap.String("tenant_id", tenantID),
+					zap.String("provider", provider),
+					zap.Error(ctx.Err()))
+				return
+			case <-timer.C:
+			}
 		}
 		backoff *= 2
 		attempt++

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -343,7 +343,7 @@ func (s *Server) resumeProvisioningTenants() {
 			s.startForkProvision(ctx, t.ID)
 			continue
 		}
-		go s.resumeTenantSchemaInit(t)
+		s.startTenantSchemaInitResume(ctx, t)
 	}
 }
 
@@ -368,6 +368,18 @@ func (s *Server) resumeTenantSchemaInit(t meta.Tenant) {
 	}
 	dsn := tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS)
 	s.initTenantSchemaAsync(ctx, t.ID, dsn, t.Provider, s.provisioner.InitSchema)
+}
+
+func (s *Server) startTenantSchemaInitResume(ctx context.Context, t meta.Tenant) {
+	s.startServerWorker(ctx, func(workerCtx context.Context) {
+		plain, err := s.pool.Decrypt(workerCtx, t.DBPasswordCipher)
+		if err != nil {
+			logger.Warn(workerCtx, "resume_schema_init_skipped", zap.String("tenant_id", t.ID), zap.Error(err))
+			return
+		}
+		dsn := tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS)
+		s.initTenantSchemaAsync(workerCtx, t.ID, dsn, t.Provider, s.provisioner.InitSchema)
+	})
 }
 
 func (s *Server) startPendingTenantReconciler() {
@@ -426,6 +438,27 @@ func isStalePendingTenant(now time.Time, t meta.Tenant) bool {
 
 func backgroundWithTrace(ctx context.Context) context.Context {
 	return contextWithTrace(context.Background(), ctx)
+}
+
+func (s *Server) startServerWorker(ctx context.Context, fn func(context.Context)) {
+	workerCtx := backgroundWithTrace(ctx)
+	if s.forkWorkerCtx != nil {
+		workerCtx = contextWithTrace(s.forkWorkerCtx, ctx)
+	}
+
+	s.forkWorkerMu.Lock()
+	if s.forkWorkerClosed {
+		s.forkWorkerMu.Unlock()
+		logger.Warn(workerCtx, "server_worker_start_after_close")
+		return
+	}
+	s.forkWorkerWG.Add(1)
+	s.forkWorkerMu.Unlock()
+
+	go func() {
+		defer s.forkWorkerWG.Done()
+		fn(workerCtx)
+	}()
 }
 
 func ensureTrace(ctx context.Context) context.Context {
@@ -3196,7 +3229,9 @@ func (s *Server) startProvisionedTenantSchemaInit(ctx context.Context, res *prov
 		return
 	}
 	// Tenant remains in provisioning state until schema initialization succeeds.
-	go s.initTenantSchemaAsync(backgroundWithTrace(ctx), res.TenantID, res.TenantDSN, res.Provider, s.provisioner.InitSchema)
+	s.startServerWorker(ctx, func(workerCtx context.Context) {
+		s.initTenantSchemaAsync(workerCtx, res.TenantID, res.TenantDSN, res.Provider, s.provisioner.InitSchema)
+	})
 }
 
 func (s *Server) issueOwnerAPIKey(ctx context.Context, tenantID, keyName string, tokenVersion int, source apiKeyIssueSource) (rawToken, apiKeyID string, err error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3013,11 +3013,11 @@ func newProvisionTenantError(status int, message string, err error) *provisionTe
 }
 
 func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOptions) (*provisionTenantResult, error) {
-	provider := s.provisioner.ProviderType()
-	provider, err := tenant.NormalizeProvider(provider)
+	rawProvider := s.provisioner.ProviderType()
+	provider, err := tenant.NormalizeProvider(rawProvider)
 	if err != nil {
-		logger.Warn(ctx, "server_event", eventFields(ctx, "provision_provider_invalid", "provider", provider, "error", err)...)
-		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
+		logger.Warn(ctx, "server_event", eventFields(ctx, "provision_provider_invalid", "provider", rawProvider, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", rawProvider, "result", "error")
 		return nil, newProvisionTenantError(http.StatusBadRequest, err.Error(), err)
 	}
 	tenantID := token.NewID()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -92,6 +92,8 @@ var (
 	schemaInitRetryWindow    = 10 * time.Minute
 	schemaInitInitialBackoff = 2 * time.Second
 	schemaInitMaxBackoff     = 30 * time.Second
+	pendingTenantStaleAfter  = 10 * time.Minute
+	pendingTenantSweepEvery  = time.Minute
 )
 
 // DefaultMaxUploadBytes is the server-wide fallback upload size limit.
@@ -257,6 +259,7 @@ func NewWithConfig(cfg Config) *Server {
 	s.mux = mux
 	if s.meta != nil && s.pool != nil && s.provisioner != nil {
 		s.resumePendingTenants()
+		s.startPendingTenantReconciler()
 		s.resumeProvisioningTenants()
 		s.resumeDeletingForkTenants()
 	}
@@ -352,16 +355,7 @@ func (s *Server) resumePendingTenants() {
 		return
 	}
 	for i := range tenants {
-		t := tenants[i]
-		logger.Warn(ctx, "resume_pending_mark_failed",
-			zap.String("tenant_id", t.ID),
-			zap.String("kind", string(t.Kind)),
-			zap.String("provider", t.Provider))
-		if err := s.meta.UpdateTenantStatus(ctx, t.ID, meta.TenantFailed); err != nil {
-			logger.Error(ctx, "resume_pending_mark_failed_update_error",
-				zap.String("tenant_id", t.ID),
-				zap.Error(err))
-		}
+		s.reconcilePendingTenant(ctx, tenants[i])
 	}
 }
 
@@ -374,6 +368,60 @@ func (s *Server) resumeTenantSchemaInit(t meta.Tenant) {
 	}
 	dsn := tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS)
 	s.initTenantSchemaAsync(ctx, t.ID, dsn, t.Provider, s.provisioner.InitSchema)
+}
+
+func (s *Server) startPendingTenantReconciler() {
+	if s.forkWorkerCtx == nil || pendingTenantSweepEvery <= 0 {
+		return
+	}
+	s.forkWorkerWG.Add(1)
+	go func() {
+		defer s.forkWorkerWG.Done()
+		ticker := time.NewTicker(pendingTenantSweepEvery)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-s.forkWorkerCtx.Done():
+				return
+			case <-ticker.C:
+				s.resumePendingTenants()
+			}
+		}
+	}()
+}
+
+func (s *Server) reconcilePendingTenant(ctx context.Context, t meta.Tenant) {
+	if !isStalePendingTenant(time.Now().UTC(), t) {
+		return
+	}
+	logger.Warn(ctx, "resume_pending_mark_failed",
+		zap.String("tenant_id", t.ID),
+		zap.String("kind", string(t.Kind)),
+		zap.String("provider", t.Provider),
+		zap.Time("updated_at", t.UpdatedAt))
+	updated, err := s.meta.UpdateTenantStatusIf(ctx, t.ID, meta.TenantPending, meta.TenantFailed)
+	if err != nil {
+		logger.Error(ctx, "resume_pending_mark_failed_update_error",
+			zap.String("tenant_id", t.ID),
+			zap.Error(err))
+		return
+	}
+	if !updated {
+		logger.Info(ctx, "resume_pending_mark_failed_skipped",
+			zap.String("tenant_id", t.ID),
+			zap.String("reason", "status_changed"))
+	}
+}
+
+func isStalePendingTenant(now time.Time, t meta.Tenant) bool {
+	if pendingTenantStaleAfter <= 0 {
+		return true
+	}
+	lastTouched := t.UpdatedAt
+	if lastTouched.IsZero() || t.CreatedAt.After(lastTouched) {
+		lastTouched = t.CreatedAt
+	}
+	return !lastTouched.IsZero() && now.Sub(lastTouched) >= pendingTenantStaleAfter
 }
 
 func backgroundWithTrace(ctx context.Context) context.Context {
@@ -3217,8 +3265,14 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			if s.metrics != nil {
 				s.metrics.recordEvent("tenant_schema_init", "provider", provider, "result", "ok")
 			}
-			if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantActive); err != nil {
+			updated, err := s.meta.UpdateTenantStatusIf(ctx, tenantID, meta.TenantProvisioning, meta.TenantActive)
+			if err != nil {
 				logger.Error(ctx, "schema_init_activate_failed", zap.String("tenant_id", tenantID), zap.Error(err))
+			} else if !updated {
+				logger.Warn(ctx, "schema_init_activate_skipped",
+					zap.String("tenant_id", tenantID),
+					zap.String("provider", provider),
+					zap.String("reason", "status_changed"))
 			}
 			return
 		} else {
@@ -3228,8 +3282,13 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			}
 			remaining := time.Until(deadline)
 			if remaining <= 0 {
-				if uerr := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantFailed); uerr != nil {
+				if updated, uerr := s.meta.UpdateTenantStatusIf(ctx, tenantID, meta.TenantProvisioning, meta.TenantFailed); uerr != nil {
 					logger.Error(ctx, "schema_init_mark_failed_update_error", zap.String("tenant_id", tenantID), zap.Error(uerr))
+				} else if !updated {
+					logger.Warn(ctx, "schema_init_mark_failed_skipped",
+						zap.String("tenant_id", tenantID),
+						zap.String("provider", provider),
+						zap.String("reason", "status_changed"))
 				}
 				logger.Error(ctx, "schema_init_retry_exhausted", zap.String("tenant_id", tenantID), zap.Error(err))
 				return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2985,6 +2985,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusInternalServerError, "failed to provision tenant")
 		return
 	}
+	s.startProvisionedTenantSchemaInit(r.Context(), res)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
@@ -3008,11 +3009,12 @@ type provisionTenantOptions struct {
 }
 
 type provisionTenantResult struct {
-	TenantID string
-	APIKey   string
-	APIKeyID string
-	Status   meta.TenantStatus
-	Provider string
+	TenantID  string
+	APIKey    string
+	APIKeyID  string
+	Status    meta.TenantStatus
+	Provider  string
+	TenantDSN string
 }
 
 type provisionTenantError struct {
@@ -3128,19 +3130,25 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist api key", err)
 	}
 
-	// Initialize tenant schema asynchronously; tenant remains in provisioning state until success.
-	dsn := tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true)
-	go s.initTenantSchemaAsync(backgroundWithTrace(ctx), tenantID, dsn, provider, s.provisioner.InitSchema)
 	logger.Info(ctx, "server_event", eventFields(ctx, "provision_accepted", "tenant_id", tenantID, "provider", provider)...)
 	metricEvent(ctx, "tenant_provision", "provider", provider, "result", "accepted")
 
 	return &provisionTenantResult{
-		TenantID: tenantID,
-		APIKey:   apiToken,
-		APIKeyID: apiKeyID,
-		Status:   meta.TenantProvisioning,
-		Provider: provider,
+		TenantID:  tenantID,
+		APIKey:    apiToken,
+		APIKeyID:  apiKeyID,
+		Status:    meta.TenantProvisioning,
+		Provider:  provider,
+		TenantDSN: tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true),
 	}, nil
+}
+
+func (s *Server) startProvisionedTenantSchemaInit(ctx context.Context, res *provisionTenantResult) {
+	if res == nil || res.TenantID == "" || res.TenantDSN == "" || s.provisioner == nil {
+		return
+	}
+	// Tenant remains in provisioning state until schema initialization succeeds.
+	go s.initTenantSchemaAsync(backgroundWithTrace(ctx), res.TenantID, res.TenantDSN, res.Provider, s.provisioner.InitSchema)
 }
 
 func (s *Server) issueOwnerAPIKey(ctx context.Context, tenantID, keyName string, tokenVersion int, source apiKeyIssueSource) (rawToken, apiKeyID string, err error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -256,6 +256,7 @@ func NewWithConfig(cfg Config) *Server {
 
 	s.mux = mux
 	if s.meta != nil && s.pool != nil && s.provisioner != nil {
+		s.resumePendingTenants()
 		s.resumeProvisioningTenants()
 		s.resumeDeletingForkTenants()
 	}
@@ -340,6 +341,27 @@ func (s *Server) resumeProvisioningTenants() {
 			continue
 		}
 		go s.resumeTenantSchemaInit(t)
+	}
+}
+
+func (s *Server) resumePendingTenants() {
+	ctx := backgroundWithTrace(context.Background())
+	tenants, err := s.meta.ListTenantsByStatus(ctx, meta.TenantPending, 1000)
+	if err != nil {
+		logger.Error(ctx, "resume_pending_list_failed", zap.Error(err))
+		return
+	}
+	for i := range tenants {
+		t := tenants[i]
+		logger.Warn(ctx, "resume_pending_mark_failed",
+			zap.String("tenant_id", t.ID),
+			zap.String("kind", string(t.Kind)),
+			zap.String("provider", t.Provider))
+		if err := s.meta.UpdateTenantStatus(ctx, t.ID, meta.TenantFailed); err != nil {
+			logger.Error(ctx, "resume_pending_mark_failed_update_error",
+				zap.String("tenant_id", t.ID),
+				zap.Error(err))
+		}
 	}
 }
 
@@ -3028,33 +3050,16 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		keyName = "default"
 	}
 	now := time.Now().UTC()
-	cluster, err := s.provisioner.Provision(ctx, tenantID)
-	if err != nil {
-		logger.Error(ctx, "server_event", eventFields(ctx, "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
-		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "cluster_error")
-		return nil, newProvisionTenantError(http.StatusBadGateway, fmt.Sprintf("provision tenant cluster failed: %v", err), err)
-	}
-	cluster.Provider = provider
-
-	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
-	if err != nil {
-		logger.Error(ctx, "server_event", eventFields(ctx, "provision_encrypt_db_password_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
-		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
-		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encrypt db password", err)
-	}
 	if err := s.meta.InsertTenant(ctx, &meta.Tenant{
 		ID:               tenantID,
-		Status:           meta.TenantProvisioning,
-		DBHost:           cluster.Host,
-		DBPort:           cluster.Port,
-		DBUser:           cluster.Username,
-		DBPasswordCipher: cipherPass,
-		DBName:           cluster.DBName,
+		Status:           meta.TenantPending,
+		DBHost:           "",
+		DBPort:           0,
+		DBUser:           "",
+		DBPasswordCipher: []byte{},
+		DBName:           "",
 		DBTLS:            true,
 		Provider:         provider,
-		ClusterID:        cluster.ClusterID,
-		ClaimURL:         cluster.ClaimURL,
-		ClaimExpiresAt:   cluster.ClaimExpiresAt,
 		SchemaVersion:    1,
 		CreatedAt:        now,
 		UpdatedAt:        now,
@@ -3066,12 +3071,60 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	}
 	metricEvent(ctx, "metadb_query", "api", "insert_tenant", "result", "ok")
 
+	cluster, err := s.provisioner.Provision(ctx, tenantID)
+	if err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "cluster_error")
+		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
+			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
+		}
+		return nil, newProvisionTenantError(http.StatusBadGateway, fmt.Sprintf("provision tenant cluster failed: %v", err), err)
+	}
+	cluster.Provider = provider
+
+	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
+	if err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "provision_encrypt_db_password_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
+		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
+			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
+		}
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encrypt db password", err)
+	}
+	if err := s.meta.UpdateTenantConnection(ctx, tenantID, &meta.Tenant{
+		DBHost:           cluster.Host,
+		DBPort:           cluster.Port,
+		DBUser:           cluster.Username,
+		DBPasswordCipher: cipherPass,
+		DBName:           cluster.DBName,
+		DBTLS:            true,
+		Provider:         provider,
+		ClusterID:        cluster.ClusterID,
+		ClaimURL:         cluster.ClaimURL,
+		ClaimExpiresAt:   cluster.ClaimExpiresAt,
+	}); err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "provision_update_tenant_connection_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
+		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
+			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
+		}
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist tenant connection", err)
+	}
+	if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantProvisioning); err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "provision_update_tenant_status_failed", "tenant_id", tenantID, "provider", provider, "status", meta.TenantProvisioning, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
+		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
+			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
+		}
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to update tenant status", err)
+	}
+
 	apiToken, apiKeyID, err := s.issueOwnerAPIKey(ctx, tenantID, keyName, opts.TokenVersion, opts.APIKeySource)
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_insert_api_key_failed", "tenant_id", tenantID, "api_key_id", apiKeyID, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
 		metricEvent(ctx, "metadb_query", "api", "insert_api_key", "result", "error")
-		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantDeleted)
+		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist api key", err)
 	}
 

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -267,6 +267,7 @@ func (s *Server) rotateIssuedOwnerAPIKey(ctx context.Context, tenantID, keyName 
 		return "", "", err
 	}
 	if err := s.meta.RevokeAPIKeysByIssuer(ctx, tenantID, source.Provider, source.SubjectKey, apiKeyID); err != nil {
+		_ = s.meta.RevokeAPIKey(ctx, tenantID, apiKeyID)
 		return "", "", err
 	}
 	return rawToken, apiKeyID, nil

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -261,7 +261,7 @@ func wantsJSON(r *http.Request) bool {
 	if strings.EqualFold(r.URL.Query().Get("format"), "json") {
 		return true
 	}
-	return strings.Contains(r.Header.Get("Accept"), "application/json")
+	return strings.Contains(strings.ToLower(r.Header.Get("Accept")), "application/json")
 }
 
 func writeSlockHTML(w http.ResponseWriter, resp *slockCallbackResponse) {

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -132,9 +133,14 @@ func (s *Server) slockProvisionForUserInfo(ctx context.Context, info slockoauth.
 
 	binding, err := s.meta.GetExternalBinding(ctx, slockProvider, subjectKey)
 	if err == nil {
-		return s.slockIssueForBinding(ctx, binding, source, principal)
-	}
-	if !errors.Is(err, meta.ErrNotFound) {
+		resp, reprovision, err := s.slockIssueForBinding(ctx, binding, source, principal)
+		if err == nil && !reprovision {
+			return resp, nil
+		}
+		if !reprovision {
+			return nil, err
+		}
+	} else if !errors.Is(err, meta.ErrNotFound) {
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to load external binding", err)
 	}
 
@@ -142,14 +148,20 @@ func (s *Server) slockProvisionForUserInfo(ctx context.Context, info slockoauth.
 	err = s.meta.WithExternalBindingLock(ctx, slockProvider, subjectKey, func(lockCtx context.Context) error {
 		binding, err := s.meta.GetExternalBinding(lockCtx, slockProvider, subjectKey)
 		if err == nil {
-			resp, issueErr := s.slockIssueForBinding(lockCtx, binding, source, principal)
-			if issueErr != nil {
+			resp, reprovision, issueErr := s.slockIssueForBinding(lockCtx, binding, source, principal)
+			if issueErr == nil && !reprovision {
+				out = resp
+				return nil
+			}
+			if !reprovision {
 				return issueErr
 			}
-			out = resp
-			return nil
-		}
-		if !errors.Is(err, meta.ErrNotFound) {
+			if err := s.meta.DeleteExternalBinding(lockCtx, slockProvider, subjectKey); err != nil && !errors.Is(err, meta.ErrNotFound) {
+				return newProvisionTenantError(http.StatusInternalServerError, "failed to delete stale external binding", err)
+			}
+			logger.Info(lockCtx, "server_event", eventFields(lockCtx, "slock_external_binding_deleted",
+				"subject_key", subjectKey, "tenant_id", binding.TenantID)...)
+		} else if !errors.Is(err, meta.ErrNotFound) {
 			return newProvisionTenantError(http.StatusInternalServerError, "failed to load external binding", err)
 		}
 
@@ -189,23 +201,25 @@ func (s *Server) slockProvisionForUserInfo(ctx context.Context, info slockoauth.
 	return out, nil
 }
 
-func (s *Server) slockIssueForBinding(ctx context.Context, binding *meta.ExternalBinding, source apiKeyIssueSource, principal slockPrincipal) (*slockCallbackResponse, error) {
+func (s *Server) slockIssueForBinding(ctx context.Context, binding *meta.ExternalBinding, source apiKeyIssueSource, principal slockPrincipal) (*slockCallbackResponse, bool, error) {
 	t, err := s.meta.GetTenant(ctx, binding.TenantID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
-			return nil, newProvisionTenantError(http.StatusNotFound, "bound tenant not found", err)
+			return nil, true, nil
 		}
-		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to load bound tenant", err)
+		return nil, false, newProvisionTenantError(http.StatusInternalServerError, "failed to load bound tenant", err)
 	}
 	switch t.Status {
 	case meta.TenantActive, meta.TenantProvisioning:
+	case meta.TenantFailed, meta.TenantDeleted:
+		return nil, true, nil
 	default:
-		return nil, newProvisionTenantError(http.StatusForbidden, "bound tenant is unavailable", fmt.Errorf("tenant status %s", t.Status))
+		return nil, false, newProvisionTenantError(http.StatusForbidden, "bound tenant is unavailable", fmt.Errorf("tenant status %s", t.Status))
 	}
 	apiKey, _, err := s.issueOwnerAPIKey(ctx, t.ID, "slock", 0, source)
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "slock_api_key_issue_failed", "tenant_id", t.ID, "error", err)...)
-		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to issue api key", err)
+		return nil, false, newProvisionTenantError(http.StatusInternalServerError, "failed to issue api key", err)
 	}
 	logger.Info(ctx, "server_event", eventFields(ctx, "slock_external_binding_resolved",
 		"tenant_id", t.ID, "subject_key", binding.SubjectKey, "status", string(t.Status))...)
@@ -214,11 +228,12 @@ func (s *Server) slockIssueForBinding(ctx context.Context, binding *meta.Externa
 		APIKey:    apiKey,
 		Status:    string(t.Status),
 		Principal: principal,
-	}, nil
+	}, false, nil
 }
 
 func slockSubjectKey(info slockoauth.UserInfo) string {
-	return info.ServerID + ":" + info.Sub
+	return base64.RawURLEncoding.EncodeToString([]byte(info.ServerID)) + "." +
+		base64.RawURLEncoding.EncodeToString([]byte(info.Sub))
 }
 
 func slockMetadataJSON(info slockoauth.UserInfo) ([]byte, error) {

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -1,0 +1,255 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/slockoauth"
+	"go.uber.org/zap"
+)
+
+const slockProvider = "slock"
+
+type slockPrincipal struct {
+	Provider string `json:"provider"`
+	Type     string `json:"type"`
+	ServerID string `json:"server_id"`
+	Sub      string `json:"sub"`
+}
+
+type slockCallbackResponse struct {
+	TenantID  string         `json:"tenant_id"`
+	APIKey    string         `json:"api_key"`
+	Status    string         `json:"status"`
+	Principal slockPrincipal `json:"principal"`
+}
+
+func (s *Server) handleSlockLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if s.slockOAuth == nil {
+		errJSON(w, http.StatusNotImplemented, "login with slock is not configured")
+		return
+	}
+	http.Redirect(w, r, s.slockOAuth.LoginURL(), http.StatusFound)
+}
+
+func (s *Server) handleSlockCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if s.slockOAuth == nil {
+		errJSON(w, http.StatusNotImplemented, "login with slock is not configured")
+		return
+	}
+	if errMsg := strings.TrimSpace(r.URL.Query().Get("error")); errMsg != "" {
+		errJSON(w, http.StatusBadRequest, "slock oauth error: "+errMsg)
+		return
+	}
+	code := strings.TrimSpace(r.URL.Query().Get("code"))
+	if code == "" {
+		errJSON(w, http.StatusBadRequest, "code is required")
+		return
+	}
+	if err := s.ensureSlockProvisioningEnabled(); err != nil {
+		errJSON(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	tok, err := s.slockOAuth.ExchangeCode(r.Context(), code)
+	if err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "slock_token_exchange_failed", "error", err)...)
+		writeSlockOAuthError(w, err)
+		return
+	}
+	info, err := s.slockOAuth.Userinfo(r.Context(), tok.AccessToken)
+	if err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "slock_userinfo_failed", "error", err)...)
+		writeSlockOAuthError(w, err)
+		return
+	}
+
+	resp, err := s.slockProvisionForUserInfo(r.Context(), info)
+	if err != nil {
+		var pe *provisionTenantError
+		if errors.As(err, &pe) {
+			errJSON(w, pe.status, pe.message)
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "slock tenant provision failed")
+		return
+	}
+	if wantsJSON(r) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+		return
+	}
+	writeSlockHTML(w, resp)
+}
+
+func (s *Server) ensureSlockProvisioningEnabled() error {
+	if s.meta == nil || s.pool == nil || len(s.tokenSecret) == 0 {
+		return fmt.Errorf("provisioning not enabled")
+	}
+	if s.provisioner == nil {
+		return fmt.Errorf("provisioner not configured")
+	}
+	return nil
+}
+
+func (s *Server) slockProvisionForUserInfo(ctx context.Context, info slockoauth.UserInfo) (*slockCallbackResponse, error) {
+	subjectKey := slockSubjectKey(info)
+	metadata, err := slockMetadataJSON(info)
+	if err != nil {
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encode slock metadata", err)
+	}
+	source := apiKeyIssueSource{Provider: slockProvider, SubjectKey: subjectKey, MetadataJSON: metadata}
+	principal := slockPrincipal{Provider: slockProvider, Type: info.Type, ServerID: info.ServerID, Sub: info.Sub}
+
+	binding, err := s.meta.GetExternalBinding(ctx, slockProvider, subjectKey)
+	if err == nil {
+		return s.slockIssueForBinding(ctx, binding, source, principal)
+	}
+	if !errors.Is(err, meta.ErrNotFound) {
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to load external binding", err)
+	}
+
+	var out *slockCallbackResponse
+	err = s.meta.WithExternalBindingLock(ctx, slockProvider, subjectKey, func(lockCtx context.Context) error {
+		binding, err := s.meta.GetExternalBinding(lockCtx, slockProvider, subjectKey)
+		if err == nil {
+			resp, issueErr := s.slockIssueForBinding(lockCtx, binding, source, principal)
+			if issueErr != nil {
+				return issueErr
+			}
+			out = resp
+			return nil
+		}
+		if !errors.Is(err, meta.ErrNotFound) {
+			return newProvisionTenantError(http.StatusInternalServerError, "failed to load external binding", err)
+		}
+
+		res, err := s.provisionTenant(lockCtx, provisionTenantOptions{
+			KeyName:      "slock",
+			TokenVersion: 1,
+			APIKeySource: source,
+		})
+		if err != nil {
+			return err
+		}
+		now := time.Now().UTC()
+		if err := s.meta.InsertExternalBinding(lockCtx, &meta.ExternalBinding{
+			Provider:     slockProvider,
+			SubjectKey:   subjectKey,
+			TenantID:     res.TenantID,
+			MetadataJSON: metadata,
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		}); err != nil {
+			_ = s.meta.UpdateTenantStatus(context.Background(), res.TenantID, meta.TenantDeleted)
+			return newProvisionTenantError(http.StatusInternalServerError, "failed to persist external binding", err)
+		}
+		logger.Info(lockCtx, "server_event", eventFields(lockCtx, "slock_external_binding_created",
+			"tenant_id", res.TenantID, "subject_key", subjectKey)...)
+		out = &slockCallbackResponse{
+			TenantID:  res.TenantID,
+			APIKey:    res.APIKey,
+			Status:    string(res.Status),
+			Principal: principal,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *Server) slockIssueForBinding(ctx context.Context, binding *meta.ExternalBinding, source apiKeyIssueSource, principal slockPrincipal) (*slockCallbackResponse, error) {
+	t, err := s.meta.GetTenant(ctx, binding.TenantID)
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			return nil, newProvisionTenantError(http.StatusNotFound, "bound tenant not found", err)
+		}
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to load bound tenant", err)
+	}
+	switch t.Status {
+	case meta.TenantActive, meta.TenantProvisioning:
+	default:
+		return nil, newProvisionTenantError(http.StatusForbidden, "bound tenant is unavailable", fmt.Errorf("tenant status %s", t.Status))
+	}
+	apiKey, _, err := s.issueOwnerAPIKey(ctx, t.ID, "slock", 0, source)
+	if err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "slock_api_key_issue_failed", "tenant_id", t.ID, "error", err)...)
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to issue api key", err)
+	}
+	logger.Info(ctx, "server_event", eventFields(ctx, "slock_external_binding_resolved",
+		"tenant_id", t.ID, "subject_key", binding.SubjectKey, "status", string(t.Status))...)
+	return &slockCallbackResponse{
+		TenantID:  t.ID,
+		APIKey:    apiKey,
+		Status:    string(t.Status),
+		Principal: principal,
+	}, nil
+}
+
+func slockSubjectKey(info slockoauth.UserInfo) string {
+	return info.ServerID + ":" + info.Sub
+}
+
+func slockMetadataJSON(info slockoauth.UserInfo) ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"server_id":          info.ServerID,
+		"sub":                info.Sub,
+		"principal_type":     info.Type,
+		"server_slug":        info.ServerSlug,
+		"preferred_username": info.PreferredUsername,
+		"name":               info.Name,
+		"client_id":          info.ClientID,
+	})
+}
+
+func writeSlockOAuthError(w http.ResponseWriter, err error) {
+	var oe slockoauth.OAuthError
+	if errors.As(err, &oe) {
+		errJSON(w, http.StatusBadGateway, oe.Error())
+		return
+	}
+	errJSON(w, http.StatusBadGateway, "slock oauth request failed")
+}
+
+func wantsJSON(r *http.Request) bool {
+	if strings.EqualFold(r.URL.Query().Get("format"), "json") {
+		return true
+	}
+	return strings.Contains(r.Header.Get("Accept"), "application/json")
+}
+
+func writeSlockHTML(w http.ResponseWriter, resp *slockCallbackResponse) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	tmpl := template.Must(template.New("slock").Parse(`<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Drive9 Slock Login</title></head>
+<body>
+<h1>Drive9 tenant ready</h1>
+<p>Tenant: <code>{{.TenantID}}</code></p>
+<p>Status: <code>{{.Status}}</code></p>
+<p>API key:</p>
+<pre>{{.APIKey}}</pre>
+</body>
+</html>`))
+	if err := tmpl.Execute(w, resp); err != nil {
+		logger.Warn(context.Background(), "slock_html_render_failed", zap.Error(err))
+	}
+}

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -19,6 +19,11 @@ import (
 
 const slockProvider = "slock"
 
+const (
+	maxExternalSubjectKeyBytes = 512
+	maxExternalMetadataBytes   = 16 << 10
+)
+
 var slockHTMLTemplate = template.Must(template.New("slock").Parse(`<!doctype html>
 <html>
 <head><meta charset="utf-8"><title>Drive9 Slock Login</title></head>
@@ -26,8 +31,7 @@ var slockHTMLTemplate = template.Must(template.New("slock").Parse(`<!doctype htm
 <h1>Drive9 tenant ready</h1>
 <p>Tenant: <code>{{.TenantID}}</code></p>
 <p>Status: <code>{{.Status}}</code></p>
-<p>API key:</p>
-<pre>{{.APIKey}}</pre>
+<p>API key is only returned from the JSON callback response.</p>
 </body>
 </html>`))
 
@@ -128,21 +132,11 @@ func (s *Server) slockProvisionForUserInfo(ctx context.Context, info slockoauth.
 	if err != nil {
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encode slock metadata", err)
 	}
+	if err := validateExternalIdentityPayload(subjectKey, metadata); err != nil {
+		return nil, err
+	}
 	source := apiKeyIssueSource{Provider: slockProvider, SubjectKey: subjectKey, MetadataJSON: metadata}
 	principal := slockPrincipal{Provider: slockProvider, Type: info.Type, ServerID: info.ServerID, Sub: info.Sub}
-
-	binding, err := s.meta.GetExternalBinding(ctx, slockProvider, subjectKey)
-	if err == nil {
-		resp, reprovision, err := s.slockIssueForBinding(ctx, binding, source, principal)
-		if err == nil && !reprovision {
-			return resp, nil
-		}
-		if !reprovision {
-			return nil, err
-		}
-	} else if !errors.Is(err, meta.ErrNotFound) {
-		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to load external binding", err)
-	}
 
 	var out *slockCallbackResponse
 	err = s.meta.WithExternalBindingLock(ctx, slockProvider, subjectKey, func(lockCtx context.Context) error {
@@ -214,10 +208,15 @@ func (s *Server) slockIssueForBinding(ctx context.Context, binding *meta.Externa
 	case meta.TenantActive, meta.TenantProvisioning:
 	case meta.TenantFailed, meta.TenantDeleted:
 		return nil, true, nil
+	case meta.TenantPending:
+		if isStalePendingTenant(time.Now().UTC(), *t) {
+			return nil, true, nil
+		}
+		return nil, false, newProvisionTenantError(http.StatusConflict, "bound tenant is still pending", fmt.Errorf("tenant status %s", t.Status))
 	default:
 		return nil, false, newProvisionTenantError(http.StatusForbidden, "bound tenant is unavailable", fmt.Errorf("tenant status %s", t.Status))
 	}
-	apiKey, _, err := s.issueOwnerAPIKey(ctx, t.ID, "slock", 0, source)
+	apiKey, _, err := s.rotateIssuedOwnerAPIKey(ctx, t.ID, "slock", source)
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "slock_api_key_issue_failed", "tenant_id", t.ID, "error", err)...)
 		return nil, false, newProvisionTenantError(http.StatusInternalServerError, "failed to issue api key", err)
@@ -247,6 +246,30 @@ func slockMetadataJSON(info slockoauth.UserInfo) ([]byte, error) {
 		"name":               info.Name,
 		"client_id":          info.ClientID,
 	})
+}
+
+func validateExternalIdentityPayload(subjectKey string, metadata []byte) *provisionTenantError {
+	switch {
+	case len(subjectKey) == 0:
+		return newProvisionTenantError(http.StatusBadRequest, "external subject key is required", nil)
+	case len(subjectKey) > maxExternalSubjectKeyBytes:
+		return newProvisionTenantError(http.StatusBadRequest, "external subject key is too large", nil)
+	case len(metadata) > maxExternalMetadataBytes:
+		return newProvisionTenantError(http.StatusBadRequest, "external metadata is too large", nil)
+	default:
+		return nil
+	}
+}
+
+func (s *Server) rotateIssuedOwnerAPIKey(ctx context.Context, tenantID, keyName string, source apiKeyIssueSource) (rawToken, apiKeyID string, err error) {
+	rawToken, apiKeyID, err = s.issueOwnerAPIKey(ctx, tenantID, keyName, 0, source)
+	if err != nil {
+		return "", "", err
+	}
+	if err := s.meta.RevokeAPIKeysByIssuer(ctx, tenantID, source.Provider, source.SubjectKey, apiKeyID); err != nil {
+		return "", "", err
+	}
+	return rawToken, apiKeyID, nil
 }
 
 func writeSlockOAuthError(w http.ResponseWriter, err error) {

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -18,6 +18,18 @@ import (
 
 const slockProvider = "slock"
 
+var slockHTMLTemplate = template.Must(template.New("slock").Parse(`<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Drive9 Slock Login</title></head>
+<body>
+<h1>Drive9 tenant ready</h1>
+<p>Tenant: <code>{{.TenantID}}</code></p>
+<p>Status: <code>{{.Status}}</code></p>
+<p>API key:</p>
+<pre>{{.APIKey}}</pre>
+</body>
+</html>`))
+
 type slockPrincipal struct {
 	Provider string `json:"provider"`
 	Type     string `json:"type"`
@@ -91,6 +103,7 @@ func (s *Server) handleSlockCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if wantsJSON(r) {
+		setSlockCallbackNoStoreHeaders(w)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 		return
@@ -237,19 +250,14 @@ func wantsJSON(r *http.Request) bool {
 }
 
 func writeSlockHTML(w http.ResponseWriter, resp *slockCallbackResponse) {
+	setSlockCallbackNoStoreHeaders(w)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	tmpl := template.Must(template.New("slock").Parse(`<!doctype html>
-<html>
-<head><meta charset="utf-8"><title>Drive9 Slock Login</title></head>
-<body>
-<h1>Drive9 tenant ready</h1>
-<p>Tenant: <code>{{.TenantID}}</code></p>
-<p>Status: <code>{{.Status}}</code></p>
-<p>API key:</p>
-<pre>{{.APIKey}}</pre>
-</body>
-</html>`))
-	if err := tmpl.Execute(w, resp); err != nil {
+	if err := slockHTMLTemplate.Execute(w, resp); err != nil {
 		logger.Warn(context.Background(), "slock_html_render_failed", zap.Error(err))
 	}
+}
+
+func setSlockCallbackNoStoreHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 }

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -185,6 +185,7 @@ func (s *Server) slockProvisionForUserInfo(ctx context.Context, info slockoauth.
 			_ = s.meta.UpdateTenantStatus(context.Background(), res.TenantID, meta.TenantDeleted)
 			return newProvisionTenantError(http.StatusInternalServerError, "failed to persist external binding", err)
 		}
+		s.startProvisionedTenantSchemaInit(lockCtx, res)
 		logger.Info(lockCtx, "server_event", eventFields(lockCtx, "slock_external_binding_created",
 			"tenant_id", res.TenantID, "subject_key", subjectKey)...)
 		out = &slockCallbackResponse{

--- a/pkg/server/slock_test.go
+++ b/pkg/server/slock_test.go
@@ -239,3 +239,11 @@ func TestSlockSubjectKeyIsUnambiguous(t *testing.T) {
 		t.Fatalf("slockSubjectKey collision: %q", a)
 	}
 }
+
+func TestWantsJSONAcceptHeaderCaseInsensitive(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/slock/callback", nil)
+	req.Header.Set("Accept", "Application/JSON")
+	if !wantsJSON(req) {
+		t.Fatal("wantsJSON = false, want true")
+	}
+}

--- a/pkg/server/slock_test.go
+++ b/pkg/server/slock_test.go
@@ -377,20 +377,18 @@ func TestSlockHTMLDoesNotRenderAPIKey(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	var out slockCallbackResponse
-	jsonResp, err := http.Get(ts.URL + "/v1/auth/slock/callback?code=json&format=json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = jsonResp.Body.Close() }()
-	if err := json.NewDecoder(jsonResp.Body).Decode(&out); err != nil {
-		t.Fatal(err)
-	}
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(bodyBytes), out.APIKey) {
-		t.Fatal("html response should not render api key")
+	body := string(bodyBytes)
+	if strings.Contains(body, "<pre>") {
+		t.Fatal("html response should not render preformatted api key output")
+	}
+	if strings.Contains(strings.ToLower(body), "api_key") {
+		t.Fatal("html response should not render api_key field")
+	}
+	if strings.Contains(body, "eyJ") {
+		t.Fatal("html response should not render token-like content")
 	}
 }

--- a/pkg/server/slock_test.go
+++ b/pkg/server/slock_test.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
+	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/slockoauth"
 	"github.com/mem9-ai/dat9/pkg/tenant"
@@ -34,10 +34,7 @@ func (f *fakeSlockOAuth) Userinfo(_ context.Context, _ string) (slockoauth.UserI
 func newSlockTestServer(t *testing.T, info slockoauth.UserInfo) (*Server, *meta.Store, []byte) {
 	t.Helper()
 	dbi := newTestDBInfo(t)
-	_, _ = dbi.Meta.DB().Exec("DELETE FROM tenant_api_key_fs_scopes")
-	_, _ = dbi.Meta.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = dbi.Meta.DB().Exec("DELETE FROM tenant_external_bindings")
-	_, _ = dbi.Meta.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, dbi.Meta.DB())
 	tokenSecret := make([]byte, 32)
 	if _, err := rand.Read(tokenSecret); err != nil {
 		t.Fatal(err)
@@ -57,6 +54,7 @@ func newSlockTestServer(t *testing.T, info slockoauth.UserInfo) (*Server, *meta.
 		TokenSecret: tokenSecret,
 		SlockOAuth:  &fakeSlockOAuth{info: info},
 	})
+	t.Cleanup(srv.Close)
 	return srv, dbi.Meta, tokenSecret
 }
 
@@ -134,18 +132,23 @@ func TestSlockCallbackCreatesTenantBindingAndOwnerKey(t *testing.T) {
 	if _, err := token.ParseAndVerifyToken(tokenSecret, out.APIKey); err != nil {
 		t.Fatalf("ParseAndVerifyToken: %v", err)
 	}
-	binding, err := metaStore.GetExternalBinding(context.Background(), "slock", "server-1:sub-1")
+	wantSubjectKey := slockSubjectKey(info)
+	binding, err := metaStore.GetExternalBinding(context.Background(), "slock", wantSubjectKey)
 	if err != nil {
 		t.Fatalf("GetExternalBinding: %v", err)
 	}
-	if binding.TenantID != out.TenantID || !strings.Contains(string(binding.MetadataJSON), `"principal_type": "agent"`) {
+	var bindingMeta map[string]any
+	if err := json.Unmarshal(binding.MetadataJSON, &bindingMeta); err != nil {
+		t.Fatalf("Unmarshal(binding.MetadataJSON): %v", err)
+	}
+	if binding.TenantID != out.TenantID || bindingMeta["principal_type"] != "agent" {
 		t.Fatalf("unexpected binding: %+v metadata=%s", binding, string(binding.MetadataJSON))
 	}
 	resolved, err := metaStore.ResolveByAPIKeyHash(context.Background(), token.HashToken(out.APIKey))
 	if err != nil {
 		t.Fatalf("ResolveByAPIKeyHash: %v", err)
 	}
-	if resolved.APIKey.IssuedByProvider != "slock" || resolved.APIKey.IssuedBySubjectKey != "server-1:sub-1" {
+	if resolved.APIKey.IssuedByProvider != "slock" || resolved.APIKey.IssuedBySubjectKey != wantSubjectKey {
 		t.Fatalf("issued-by metadata not set: %+v", resolved.APIKey)
 	}
 }
@@ -186,5 +189,53 @@ func TestSlockCallbackReusesExistingBinding(t *testing.T) {
 	}
 	if tenantCount != 1 {
 		t.Fatalf("tenant count = %d, want 1", tenantCount)
+	}
+}
+
+func TestSlockCallbackReprovisionsFailedBinding(t *testing.T) {
+	info := slockoauth.UserInfo{Sub: "sub-1", Type: "agent", ClientID: "drive9", ServerID: "server-1"}
+	srv, metaStore, _ := newSlockTestServer(t, info)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	call := func(code string) slockCallbackResponse {
+		t.Helper()
+		resp, err := http.Get(ts.URL + "/v1/auth/slock/callback?code=" + code + "&format=json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		var out slockCallbackResponse
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatal(err)
+		}
+		return out
+	}
+
+	first := call("first")
+	if err := metaStore.UpdateTenantStatus(context.Background(), first.TenantID, meta.TenantFailed); err != nil {
+		t.Fatalf("UpdateTenantStatus: %v", err)
+	}
+	second := call("second")
+	if second.TenantID == first.TenantID {
+		t.Fatalf("second tenant = %s, want new tenant after failed binding", second.TenantID)
+	}
+	binding, err := metaStore.GetExternalBinding(context.Background(), "slock", slockSubjectKey(info))
+	if err != nil {
+		t.Fatalf("GetExternalBinding: %v", err)
+	}
+	if binding.TenantID != second.TenantID {
+		t.Fatalf("binding tenant = %s, want %s", binding.TenantID, second.TenantID)
+	}
+}
+
+func TestSlockSubjectKeyIsUnambiguous(t *testing.T) {
+	a := slockSubjectKey(slockoauth.UserInfo{ServerID: "a:b", Sub: "c"})
+	b := slockSubjectKey(slockoauth.UserInfo{ServerID: "a", Sub: "b:c"})
+	if a == b {
+		t.Fatalf("slockSubjectKey collision: %q", a)
 	}
 }

--- a/pkg/server/slock_test.go
+++ b/pkg/server/slock_test.go
@@ -1,0 +1,184 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/slockoauth"
+	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
+)
+
+type fakeSlockOAuth struct {
+	info slockoauth.UserInfo
+}
+
+func (f *fakeSlockOAuth) LoginURL() string {
+	return "https://slock.example/login-with-slock/setup?client_id=drive9"
+}
+
+func (f *fakeSlockOAuth) ExchangeCode(_ context.Context, code string) (slockoauth.Token, error) {
+	return slockoauth.Token{AccessToken: "tok-" + code}, nil
+}
+
+func (f *fakeSlockOAuth) Userinfo(_ context.Context, _ string) (slockoauth.UserInfo, error) {
+	return f.info, nil
+}
+
+func newSlockTestServer(t *testing.T, info slockoauth.UserInfo) (*Server, *meta.Store, []byte) {
+	t.Helper()
+	dbi := newTestDBInfo(t)
+	_, _ = dbi.Meta.DB().Exec("DELETE FROM tenant_api_key_fs_scopes")
+	_, _ = dbi.Meta.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = dbi.Meta.DB().Exec("DELETE FROM tenant_external_bindings")
+	_, _ = dbi.Meta.DB().Exec("DELETE FROM tenants")
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBZero, cluster: &tenant.ClusterInfo{
+		ClusterID: "slock-cluster",
+		Host:      dbi.DBHost,
+		Port:      dbi.DBPort,
+		Username:  dbi.DBUser,
+		Password:  dbi.DBPass,
+		DBName:    dbi.DBName,
+	}}
+	srv := NewWithConfig(Config{
+		Meta:        dbi.Meta,
+		Pool:        dbi.Pool,
+		Provisioner: prov,
+		TokenSecret: tokenSecret,
+		SlockOAuth:  &fakeSlockOAuth{info: info},
+	})
+	return srv, dbi.Meta, tokenSecret
+}
+
+func TestSlockRoutesNotConfigured(t *testing.T) {
+	srv := NewWithConfig(Config{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/auth/slock/login")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", resp.StatusCode)
+	}
+}
+
+func TestSlockCallbackRequiresCode(t *testing.T) {
+	info := slockoauth.UserInfo{Sub: "sub-1", Type: "agent", ClientID: "drive9", ServerID: "server-1"}
+	srv, _, _ := newSlockTestServer(t, info)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/auth/slock/callback?format=json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestSlockCallbackCreatesTenantBindingAndOwnerKey(t *testing.T) {
+	info := slockoauth.UserInfo{
+		Sub:               "sub-1",
+		Type:              "agent",
+		ClientID:          "drive9",
+		ServerID:          "server-1",
+		ServerSlug:        "dev",
+		PreferredUsername: "assistant",
+		Name:              "Assistant",
+	}
+	srv, metaStore, tokenSecret := newSlockTestServer(t, info)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/auth/slock/callback?code=abc&format=json", nil)
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var out slockCallbackResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.TenantID == "" || out.APIKey == "" || out.Status != string(meta.TenantProvisioning) {
+		t.Fatalf("unexpected response: %+v", out)
+	}
+	if out.Principal.Provider != "slock" || out.Principal.ServerID != "server-1" || out.Principal.Sub != "sub-1" {
+		t.Fatalf("unexpected principal: %+v", out.Principal)
+	}
+	if _, err := token.ParseAndVerifyToken(tokenSecret, out.APIKey); err != nil {
+		t.Fatalf("ParseAndVerifyToken: %v", err)
+	}
+	binding, err := metaStore.GetExternalBinding(context.Background(), "slock", "server-1:sub-1")
+	if err != nil {
+		t.Fatalf("GetExternalBinding: %v", err)
+	}
+	if binding.TenantID != out.TenantID || !strings.Contains(string(binding.MetadataJSON), `"principal_type": "agent"`) {
+		t.Fatalf("unexpected binding: %+v metadata=%s", binding, string(binding.MetadataJSON))
+	}
+	resolved, err := metaStore.ResolveByAPIKeyHash(context.Background(), token.HashToken(out.APIKey))
+	if err != nil {
+		t.Fatalf("ResolveByAPIKeyHash: %v", err)
+	}
+	if resolved.APIKey.IssuedByProvider != "slock" || resolved.APIKey.IssuedBySubjectKey != "server-1:sub-1" {
+		t.Fatalf("issued-by metadata not set: %+v", resolved.APIKey)
+	}
+}
+
+func TestSlockCallbackReusesExistingBinding(t *testing.T) {
+	info := slockoauth.UserInfo{Sub: "sub-1", Type: "agent", ClientID: "drive9", ServerID: "server-1"}
+	srv, metaStore, _ := newSlockTestServer(t, info)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	call := func(code string) slockCallbackResponse {
+		t.Helper()
+		resp, err := http.Get(ts.URL + "/v1/auth/slock/callback?code=" + code + "&format=json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		var out slockCallbackResponse
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatal(err)
+		}
+		return out
+	}
+	first := call("first")
+	second := call("second")
+	if second.TenantID != first.TenantID {
+		t.Fatalf("second tenant = %s, want %s", second.TenantID, first.TenantID)
+	}
+	if second.APIKey == first.APIKey {
+		t.Fatal("repeat callback should issue a fresh api key")
+	}
+	var tenantCount int
+	if err := metaStore.DB().QueryRow("SELECT COUNT(*) FROM tenants").Scan(&tenantCount); err != nil {
+		t.Fatal(err)
+	}
+	if tenantCount != 1 {
+		t.Fatalf("tenant count = %d, want 1", tenantCount)
+	}
+}

--- a/pkg/server/slock_test.go
+++ b/pkg/server/slock_test.go
@@ -115,6 +115,12 @@ func TestSlockCallbackCreatesTenantBindingAndOwnerKey(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	if got := resp.Header.Get("Pragma"); got != "no-cache" {
+		t.Fatalf("Pragma = %q, want no-cache", got)
+	}
 	var out slockCallbackResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)

--- a/pkg/server/slock_test.go
+++ b/pkg/server/slock_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/mem9-ai/dat9/internal/testmysql"
@@ -183,12 +185,33 @@ func TestSlockCallbackReusesExistingBinding(t *testing.T) {
 	if second.APIKey == first.APIKey {
 		t.Fatal("repeat callback should issue a fresh api key")
 	}
+	firstResolved, err := metaStore.ResolveByAPIKeyHash(context.Background(), token.HashToken(first.APIKey))
+	if err != nil {
+		t.Fatalf("ResolveByAPIKeyHash(first): %v", err)
+	}
+	if firstResolved.APIKey.Status != meta.APIKeyRevoked {
+		t.Fatalf("first api key status = %s, want %s", firstResolved.APIKey.Status, meta.APIKeyRevoked)
+	}
+	secondResolved, err := metaStore.ResolveByAPIKeyHash(context.Background(), token.HashToken(second.APIKey))
+	if err != nil {
+		t.Fatalf("ResolveByAPIKeyHash(second): %v", err)
+	}
+	if secondResolved.APIKey.Status != meta.APIKeyActive {
+		t.Fatalf("second api key status = %s, want %s", secondResolved.APIKey.Status, meta.APIKeyActive)
+	}
 	var tenantCount int
 	if err := metaStore.DB().QueryRow("SELECT COUNT(*) FROM tenants").Scan(&tenantCount); err != nil {
 		t.Fatal(err)
 	}
 	if tenantCount != 1 {
 		t.Fatalf("tenant count = %d, want 1", tenantCount)
+	}
+	var activeKeyCount int
+	if err := metaStore.DB().QueryRow("SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND status = ?", first.TenantID, meta.APIKeyActive).Scan(&activeKeyCount); err != nil {
+		t.Fatal(err)
+	}
+	if activeKeyCount != 1 {
+		t.Fatalf("active api key count = %d, want 1", activeKeyCount)
 	}
 }
 
@@ -245,5 +268,129 @@ func TestWantsJSONAcceptHeaderCaseInsensitive(t *testing.T) {
 	req.Header.Set("Accept", "Application/JSON")
 	if !wantsJSON(req) {
 		t.Fatal("wantsJSON = false, want true")
+	}
+}
+
+func TestSlockCallbackRejectsOversizedSubjectBeforeProvision(t *testing.T) {
+	dbi := newTestDBInfo(t)
+	testmysql.ResetMetaDB(t, dbi.Meta.DB())
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBZero, cluster: &tenant.ClusterInfo{
+		ClusterID: "slock-cluster",
+		Host:      dbi.DBHost,
+		Port:      dbi.DBPort,
+		Username:  dbi.DBUser,
+		Password:  dbi.DBPass,
+		DBName:    dbi.DBName,
+	}}
+	info := slockoauth.UserInfo{
+		Sub:      strings.Repeat("sub", 160),
+		Type:     "agent",
+		ClientID: "drive9",
+		ServerID: strings.Repeat("server", 80),
+	}
+	srv := NewWithConfig(Config{
+		Meta:        dbi.Meta,
+		Pool:        dbi.Pool,
+		Provisioner: prov,
+		TokenSecret: tokenSecret,
+		SlockOAuth:  &fakeSlockOAuth{info: info},
+	})
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/auth/slock/callback?code=oversized&format=json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if prov.ProvisionCallCount() != 0 {
+		t.Fatalf("ProvisionCallCount = %d, want 0", prov.ProvisionCallCount())
+	}
+}
+
+func TestSlockCallbackRejectsOversizedMetadataBeforeProvision(t *testing.T) {
+	dbi := newTestDBInfo(t)
+	testmysql.ResetMetaDB(t, dbi.Meta.DB())
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBZero, cluster: &tenant.ClusterInfo{
+		ClusterID: "slock-cluster",
+		Host:      dbi.DBHost,
+		Port:      dbi.DBPort,
+		Username:  dbi.DBUser,
+		Password:  dbi.DBPass,
+		DBName:    dbi.DBName,
+	}}
+	info := slockoauth.UserInfo{
+		Sub:               "sub-1",
+		Type:              "agent",
+		ClientID:          "drive9",
+		ServerID:          "server-1",
+		Name:              strings.Repeat("n", maxExternalMetadataBytes),
+		PreferredUsername: "assistant",
+	}
+	srv := NewWithConfig(Config{
+		Meta:        dbi.Meta,
+		Pool:        dbi.Pool,
+		Provisioner: prov,
+		TokenSecret: tokenSecret,
+		SlockOAuth:  &fakeSlockOAuth{info: info},
+	})
+	t.Cleanup(srv.Close)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/auth/slock/callback?code=oversized-metadata&format=json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if prov.ProvisionCallCount() != 0 {
+		t.Fatalf("ProvisionCallCount = %d, want 0", prov.ProvisionCallCount())
+	}
+}
+
+func TestSlockHTMLDoesNotRenderAPIKey(t *testing.T) {
+	info := slockoauth.UserInfo{Sub: "sub-1", Type: "agent", ClientID: "drive9", ServerID: "server-1"}
+	srv, _, _ := newSlockTestServer(t, info)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/auth/slock/callback?code=html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var out slockCallbackResponse
+	jsonResp, err := http.Get(ts.URL + "/v1/auth/slock/callback?code=json&format=json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = jsonResp.Body.Close() }()
+	if err := json.NewDecoder(jsonResp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(bodyBytes), out.APIKey) {
+		t.Fatal("html response should not render api key")
 	}
 }

--- a/pkg/slockoauth/client.go
+++ b/pkg/slockoauth/client.go
@@ -3,6 +3,7 @@
 package slockoauth
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -64,6 +65,7 @@ func New(cfg Config) (*Client, error) {
 	cfg.APIOrigin = strings.TrimRight(strings.TrimSpace(cfg.APIOrigin), "/")
 	cfg.PublicURL = strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/")
 	cfg.ClientID = strings.TrimSpace(cfg.ClientID)
+	cfg.ClientSecret = strings.TrimSpace(cfg.ClientSecret)
 	return &Client{cfg: cfg, http: httpClient}, nil
 }
 
@@ -122,11 +124,14 @@ func (c *Client) ExchangeCode(ctx context.Context, code string) (Token, error) {
 	if code == "" {
 		return Token{}, errors.New("slockoauth: code is required")
 	}
-	rawBody, _ := json.Marshal(map[string]string{
+	rawBody, err := json.Marshal(map[string]string{
 		"grant_type": "authorization_code",
 		"code":       code,
 	})
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.APIOrigin+"/api/oauth/token", strings.NewReader(string(rawBody)))
+	if err != nil {
+		return Token{}, fmt.Errorf("slockoauth: encode token request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.APIOrigin+"/api/oauth/token", bytes.NewReader(rawBody))
 	if err != nil {
 		return Token{}, fmt.Errorf("slockoauth: build token request: %w", err)
 	}

--- a/pkg/slockoauth/client.go
+++ b/pkg/slockoauth/client.go
@@ -1,0 +1,216 @@
+// Package slockoauth implements the Login-with-Slock OAuth-like flow used by
+// Drive9 to bind a Slock principal to a tenant.
+package slockoauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	Origin       string
+	APIOrigin    string
+	ClientID     string
+	ClientSecret string
+	PublicURL    string
+	HTTPClient   *http.Client
+}
+
+func (c Config) Validate() error {
+	var missing []string
+	if strings.TrimSpace(c.Origin) == "" {
+		missing = append(missing, "Origin")
+	}
+	if strings.TrimSpace(c.APIOrigin) == "" {
+		missing = append(missing, "APIOrigin")
+	}
+	if strings.TrimSpace(c.ClientID) == "" {
+		missing = append(missing, "ClientID")
+	}
+	if strings.TrimSpace(c.ClientSecret) == "" {
+		missing = append(missing, "ClientSecret")
+	}
+	if strings.TrimSpace(c.PublicURL) == "" {
+		missing = append(missing, "PublicURL")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("slockoauth: missing config: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+type Client struct {
+	cfg  Config
+	http *http.Client
+}
+
+func New(cfg Config) (*Client, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	cfg.Origin = strings.TrimRight(strings.TrimSpace(cfg.Origin), "/")
+	cfg.APIOrigin = strings.TrimRight(strings.TrimSpace(cfg.APIOrigin), "/")
+	cfg.PublicURL = strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/")
+	cfg.ClientID = strings.TrimSpace(cfg.ClientID)
+	return &Client{cfg: cfg, http: httpClient}, nil
+}
+
+func (c *Client) ClientID() string { return c.cfg.ClientID }
+
+func (c *Client) CallbackURL() string {
+	return c.cfg.PublicURL + "/v1/auth/slock/callback"
+}
+
+func (c *Client) LoginURL() string {
+	q := url.Values{}
+	q.Set("client_id", c.cfg.ClientID)
+	q.Set("return_to", c.CallbackURL())
+	return c.cfg.Origin + "/login-with-slock/setup?" + q.Encode()
+}
+
+type Token struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope"`
+}
+
+type UserInfo struct {
+	Sub               string  `json:"sub"`
+	Type              string  `json:"type"`
+	Scope             string  `json:"scope"`
+	ClientID          string  `json:"client_id"`
+	ClientName        string  `json:"client_name"`
+	ServerID          string  `json:"server_id"`
+	ServerSlug        string  `json:"server_slug"`
+	PreferredUsername string  `json:"preferred_username"`
+	Name              string  `json:"name"`
+	AvatarURL         *string `json:"avatar_url"`
+	Description       *string `json:"description"`
+}
+
+type OAuthError struct {
+	Code        string `json:"error"`
+	Description string `json:"error_description,omitempty"`
+	Status      int    `json:"-"`
+}
+
+func (e OAuthError) Error() string {
+	if e.Description != "" {
+		return fmt.Sprintf("slock oauth error %q: %s", e.Code, e.Description)
+	}
+	if e.Code != "" {
+		return "slock oauth error: " + e.Code
+	}
+	return fmt.Sprintf("slock oauth http %d", e.Status)
+}
+
+func (c *Client) ExchangeCode(ctx context.Context, code string) (Token, error) {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return Token{}, errors.New("slockoauth: code is required")
+	}
+	rawBody, _ := json.Marshal(map[string]string{
+		"grant_type": "authorization_code",
+		"code":       code,
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.APIOrigin+"/api/oauth/token", strings.NewReader(string(rawBody)))
+	if err != nil {
+		return Token{}, fmt.Errorf("slockoauth: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	basic := base64.StdEncoding.EncodeToString([]byte(c.cfg.ClientID + ":" + c.cfg.ClientSecret))
+	req.Header.Set("Authorization", "Basic "+basic)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return Token{}, fmt.Errorf("slockoauth: token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return Token{}, fmt.Errorf("slockoauth: read token response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Token{}, parseOAuthError(resp.StatusCode, raw)
+	}
+	var tok Token
+	if err := json.Unmarshal(raw, &tok); err != nil {
+		return Token{}, fmt.Errorf("slockoauth: decode token response: %w", err)
+	}
+	if strings.TrimSpace(tok.AccessToken) == "" {
+		return Token{}, errors.New("slockoauth: token response missing access_token")
+	}
+	return tok, nil
+}
+
+func (c *Client) Userinfo(ctx context.Context, accessToken string) (UserInfo, error) {
+	accessToken = strings.TrimSpace(accessToken)
+	if accessToken == "" {
+		return UserInfo{}, errors.New("slockoauth: access token is required")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.cfg.APIOrigin+"/api/oauth/userinfo", nil)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("slockoauth: build userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("slockoauth: userinfo request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("slockoauth: read userinfo response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return UserInfo{}, parseOAuthError(resp.StatusCode, raw)
+	}
+	var info UserInfo
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return UserInfo{}, fmt.Errorf("slockoauth: decode userinfo response: %w", err)
+	}
+	if err := c.validateUserInfo(info); err != nil {
+		return UserInfo{}, err
+	}
+	return info, nil
+}
+
+func (c *Client) validateUserInfo(info UserInfo) error {
+	if strings.TrimSpace(info.Sub) == "" {
+		return errors.New("slockoauth: userinfo missing sub")
+	}
+	if strings.TrimSpace(info.ServerID) == "" {
+		return errors.New("slockoauth: userinfo missing server_id")
+	}
+	switch info.Type {
+	case "human", "agent":
+	default:
+		return fmt.Errorf("slockoauth: unsupported userinfo type %q", info.Type)
+	}
+	if info.ClientID != c.cfg.ClientID {
+		return fmt.Errorf("slockoauth: userinfo client_id %q does not match configured client_id", info.ClientID)
+	}
+	return nil
+}
+
+func parseOAuthError(status int, raw []byte) error {
+	var oe OAuthError
+	if err := json.Unmarshal(raw, &oe); err == nil && (oe.Code != "" || oe.Description != "") {
+		oe.Status = status
+		return oe
+	}
+	return OAuthError{Status: status}
+}

--- a/pkg/slockoauth/client_test.go
+++ b/pkg/slockoauth/client_test.go
@@ -2,6 +2,7 @@ package slockoauth
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -47,6 +48,31 @@ func TestLoginURL(t *testing.T) {
 	}
 	if !strings.Contains(got, "return_to=https%3A%2F%2Fdrive9.example.com%2Fv1%2Fauth%2Fslock%2Fcallback") {
 		t.Fatalf("LoginURL missing callback: %q", got)
+	}
+}
+
+func TestNewTrimsClientSecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("drive9:secret"))
+		if r.Header.Get("Authorization") != want {
+			t.Fatalf("Authorization = %q, want %q", r.Header.Get("Authorization"), want)
+		}
+		_, _ = w.Write([]byte(`{"access_token":"tok"}`))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := New(Config{
+		Origin:       "https://app.slock.ai",
+		APIOrigin:    srv.URL,
+		ClientID:     "drive9",
+		ClientSecret: " secret ",
+		PublicURL:    "https://drive9.example.com",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := c.ExchangeCode(context.Background(), "abc"); err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
 	}
 }
 

--- a/pkg/slockoauth/client_test.go
+++ b/pkg/slockoauth/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -52,11 +53,14 @@ func TestLoginURL(t *testing.T) {
 }
 
 func TestNewTrimsClientSecret(t *testing.T) {
+	reqErr := make(chan error, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("drive9:secret"))
 		if r.Header.Get("Authorization") != want {
-			t.Fatalf("Authorization = %q, want %q", r.Header.Get("Authorization"), want)
+			reqErr <- fmt.Errorf("Authorization = %q, want %q", r.Header.Get("Authorization"), want)
+			return
 		}
+		reqErr <- nil
 		_, _ = w.Write([]byte(`{"access_token":"tok"}`))
 	}))
 	t.Cleanup(srv.Close)
@@ -74,29 +78,41 @@ func TestNewTrimsClientSecret(t *testing.T) {
 	if _, err := c.ExchangeCode(context.Background(), "abc"); err != nil {
 		t.Fatalf("ExchangeCode: %v", err)
 	}
+	if err := <-reqErr; err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestExchangeCodeSuccess(t *testing.T) {
+	reqErr := make(chan error, 1)
 	c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/oauth/token" || r.Method != http.MethodPost {
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			reqErr <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			return
 		}
 		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
-			t.Fatalf("missing basic auth")
+			reqErr <- fmt.Errorf("missing basic auth")
+			return
 		}
 		var body map[string]string
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode body: %v", err)
+			reqErr <- fmt.Errorf("decode body: %v", err)
+			return
 		}
 		if body["grant_type"] != "authorization_code" || body["code"] != "abc" {
-			t.Fatalf("unexpected body: %#v", body)
+			reqErr <- fmt.Errorf("unexpected body: %#v", body)
+			return
 		}
+		reqErr <- nil
 		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600,"scope":"identity openid profile"}`))
 	}))
 
 	tok, err := c.ExchangeCode(context.Background(), "abc")
 	if err != nil {
 		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if err := <-reqErr; err != nil {
+		t.Fatal(err)
 	}
 	if tok.AccessToken != "tok" {
 		t.Fatalf("AccessToken = %q", tok.AccessToken)
@@ -132,19 +148,26 @@ func TestExchangeCodeFailures(t *testing.T) {
 }
 
 func TestUserinfoSuccess(t *testing.T) {
+	reqErr := make(chan error, 1)
 	c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/oauth/userinfo" || r.Method != http.MethodGet {
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			reqErr <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			return
 		}
 		if r.Header.Get("Authorization") != "Bearer tok" {
-			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+			reqErr <- fmt.Errorf("Authorization = %q", r.Header.Get("Authorization"))
+			return
 		}
+		reqErr <- nil
 		_, _ = w.Write([]byte(`{"sub":"sub-1","type":"agent","client_id":"drive9","server_id":"server-1","server_slug":"dev","preferred_username":"assistant","name":"Assistant"}`))
 	}))
 
 	info, err := c.Userinfo(context.Background(), "tok")
 	if err != nil {
 		t.Fatalf("Userinfo: %v", err)
+	}
+	if err := <-reqErr; err != nil {
+		t.Fatal(err)
 	}
 	if info.Sub != "sub-1" || info.ServerID != "server-1" || info.Type != "agent" {
 		t.Fatalf("unexpected info: %+v", info)

--- a/pkg/slockoauth/client_test.go
+++ b/pkg/slockoauth/client_test.go
@@ -1,0 +1,161 @@
+package slockoauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestClient(t *testing.T, h http.Handler) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	c, err := New(Config{
+		Origin:       "https://app.slock.ai",
+		APIOrigin:    srv.URL,
+		ClientID:     "drive9",
+		ClientSecret: "secret",
+		PublicURL:    "https://drive9.example.com",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c, srv
+}
+
+func TestLoginURL(t *testing.T) {
+	c, err := New(Config{
+		Origin:       "https://app.slock.ai/",
+		APIOrigin:    "https://api.slock.ai/",
+		ClientID:     "drive9",
+		ClientSecret: "secret",
+		PublicURL:    "https://drive9.example.com/",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := c.LoginURL()
+	if !strings.HasPrefix(got, "https://app.slock.ai/login-with-slock/setup?") {
+		t.Fatalf("LoginURL = %q", got)
+	}
+	if !strings.Contains(got, "client_id=drive9") {
+		t.Fatalf("LoginURL missing client_id: %q", got)
+	}
+	if !strings.Contains(got, "return_to=https%3A%2F%2Fdrive9.example.com%2Fv1%2Fauth%2Fslock%2Fcallback") {
+		t.Fatalf("LoginURL missing callback: %q", got)
+	}
+}
+
+func TestExchangeCodeSuccess(t *testing.T) {
+	c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/oauth/token" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			t.Fatalf("missing basic auth")
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["grant_type"] != "authorization_code" || body["code"] != "abc" {
+			t.Fatalf("unexpected body: %#v", body)
+		}
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600,"scope":"identity openid profile"}`))
+	}))
+
+	tok, err := c.ExchangeCode(context.Background(), "abc")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if tok.AccessToken != "tok" {
+		t.Fatalf("AccessToken = %q", tok.AccessToken)
+	}
+}
+
+func TestExchangeCodeFailures(t *testing.T) {
+	t.Run("empty code", func(t *testing.T) {
+		c, _ := New(Config{Origin: "http://slock", APIOrigin: "http://api", ClientID: "drive9", ClientSecret: "secret", PublicURL: "http://drive9"})
+		if _, err := c.ExchangeCode(context.Background(), " "); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+	t.Run("oauth error body", func(t *testing.T) {
+		c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_client","error_description":"bad secret"}`))
+		}))
+		_, err := c.ExchangeCode(context.Background(), "abc")
+		var oe OAuthError
+		if !errors.As(err, &oe) || oe.Code != "invalid_client" || oe.Status != http.StatusUnauthorized {
+			t.Fatalf("error = %#v, want OAuthError invalid_client", err)
+		}
+	})
+	t.Run("bad json", func(t *testing.T) {
+		c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{`))
+		}))
+		if _, err := c.ExchangeCode(context.Background(), "abc"); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestUserinfoSuccess(t *testing.T) {
+	c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/oauth/userinfo" || r.Method != http.MethodGet {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer tok" {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"sub":"sub-1","type":"agent","client_id":"drive9","server_id":"server-1","server_slug":"dev","preferred_username":"assistant","name":"Assistant"}`))
+	}))
+
+	info, err := c.Userinfo(context.Background(), "tok")
+	if err != nil {
+		t.Fatalf("Userinfo: %v", err)
+	}
+	if info.Sub != "sub-1" || info.ServerID != "server-1" || info.Type != "agent" {
+		t.Fatalf("unexpected info: %+v", info)
+	}
+}
+
+func TestUserinfoValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing sub", body: `{"type":"agent","client_id":"drive9","server_id":"server-1"}`},
+		{name: "missing server", body: `{"sub":"sub-1","type":"agent","client_id":"drive9"}`},
+		{name: "bad type", body: `{"sub":"sub-1","type":"bot","client_id":"drive9","server_id":"server-1"}`},
+		{name: "bad client", body: `{"sub":"sub-1","type":"agent","client_id":"other","server_id":"server-1"}`},
+		{name: "bad json", body: `{`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			if _, err := c.Userinfo(context.Background(), "tok"); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestUserinfoHTTPError(t *testing.T) {
+	c, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	_, err := c.Userinfo(context.Background(), "tok")
+	var oe OAuthError
+	if !errors.As(err, &oe) || oe.Status != http.StatusBadGateway {
+		t.Fatalf("error = %#v, want OAuthError", err)
+	}
+}

--- a/pkg/slockoauth/client_test.go
+++ b/pkg/slockoauth/client_test.go
@@ -79,7 +79,8 @@ func TestNewTrimsClientSecret(t *testing.T) {
 		t.Fatalf("ExchangeCode: %v", err)
 	}
 	if err := <-reqErr; err != nil {
-		t.Fatal(err)
+		t.Errorf("unexpected error: %v", err)
+		return
 	}
 }
 
@@ -112,7 +113,8 @@ func TestExchangeCodeSuccess(t *testing.T) {
 		t.Fatalf("ExchangeCode: %v", err)
 	}
 	if err := <-reqErr; err != nil {
-		t.Fatal(err)
+		t.Errorf("unexpected error: %v", err)
+		return
 	}
 	if tok.AccessToken != "tok" {
 		t.Fatalf("AccessToken = %q", tok.AccessToken)
@@ -167,7 +169,8 @@ func TestUserinfoSuccess(t *testing.T) {
 		t.Fatalf("Userinfo: %v", err)
 	}
 	if err := <-reqErr; err != nil {
-		t.Fatal(err)
+		t.Errorf("unexpected error: %v", err)
+		return
 	}
 	if info.Sub != "sub-1" || info.ServerID != "server-1" || info.Type != "agent" {
 		t.Fatalf("unexpected info: %+v", info)


### PR DESCRIPTION
## Summary
- add Slock OAuth client and public login/callback routes
- add generic external subject bindings and API key issuance audit metadata
- refactor tenant provisioning so anonymous provision and Slock callback share the tenant creation path

## Tests
- go test ./pkg/slockoauth ./cmd/drive9-server ./pkg/meta ./pkg/server

## Self-review
- no blocking issues found in local review
- binding insert failure marks the newly provisioned tenant deleted; any already-created key remains blocked by tenant status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Slock OAuth login & callback (HTML/JSON) with no-store caching; CLI env vars documented.
  * External identity bindings and "issued-by" provenance persisted for API keys; revoke-by-issuer support.

* **Bug Fixes / Behavior**
  * Startup and periodic reconciler now handle pending tenants and safer reprovisioning; provisioning flow has clearer status transitions.
  * Login endpoint returns 501 when OAuth is not configured; HTML responses omit API key rendering.

* **Tests**
  * Extensive coverage for OAuth flows, OAuth client behavior, bindings, schema, concurrency, and provisioning edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->