### PR TITLE
Allow manual dev deploys from custom refs

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -12,6 +12,11 @@ on:
       - 'Makefile'
       - '.github/workflows/dev-cd.yml'
   workflow_dispatch:
+    inputs:
+      deploy_ref:
+        description: "Branch, tag, or SHA to deploy"
+        required: true
+        default: "main"
 
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -33,6 +38,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_ref || github.ref }}
+
+      - name: Resolve image tag
+        run: |
+          REF_NAME="${{ github.event_name == 'workflow_dispatch' && inputs.deploy_ref || github.ref_name }}"
+          REF_NAME=${REF_NAME#refs/heads/}
+          REF_NAME=${REF_NAME#refs/tags/}
+          REF_NAME=${REF_NAME//\//-}
+          REF_NAME=$(printf '%s' "$REF_NAME" | tr -c '[:alnum:]_.-' '-')
+          TAG="${REF_NAME}-$(git rev-parse --short=7 HEAD)"
+          echo "IMAGE_TAG=$TAG" >> "$GITHUB_ENV"
 
       - name: Checkout agfs dependency
         run: |
@@ -55,12 +72,8 @@ jobs:
 
       - name: Build and push image
         run: |
-          REF_NAME=${{ github.ref_name }}
-          REF_NAME=${REF_NAME/\//-}
-          TAG="${REF_NAME}-${GITHUB_SHA::7}"
-          make docker-build IMAGE_REPO=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }} IMAGE_TAG=$TAG
-          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:$TAG
-          echo "IMAGE_TAG=$TAG" >> "$GITHUB_ENV"
+          make docker-build IMAGE_REPO=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }} IMAGE_TAG=${{ env.IMAGE_TAG }}
+          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
 
       - name: Update kubeconfig
         run: |


### PR DESCRIPTION
## Summary
- Add a deploy_ref input for manual dev deploys.
- Checkout the requested ref while keeping push deploys limited to main.
- Tag images from the deployed ref name and checked-out commit SHA.

## Validation
- git diff --check -- .github/workflows/dev-cd.yml
- Parsed .github/workflows/dev-cd.yml with Ruby YAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled manual deployments with customizable branch, tag, or commit selection (defaults to main).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->