### PR TITLE
feat: enrich Slock callback JSON response and add PublicURL config

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -276,6 +276,7 @@ func main() {
 		TokenSecret:      tokenSecret,
 		VaultMasterKey:   vaultMasterKey,
 		VaultIssuerURL:   vaultIssuerURL(addr),
+		PublicURL:        publicBaseURL(addr),
 		S3Dir:            s3cfg.Dir,
 		MaxUploadBytes:   maxUploadBytes,
 		InlineThreshold:  backendOptions.InlineThreshold,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -42,6 +42,7 @@ type Config struct {
 	LocalTenantAPIKey string
 	VaultMasterKey    []byte // 32-byte AES key for vault DEK wrapping; nil disables vault
 	VaultIssuerURL    string // canonical server URL placed in grant `iss` claim; empty = server hostname unknown, grants disabled
+	PublicURL         string // externally reachable base URL for client responses (e.g., slock callback server_url)
 	Backend           *backend.Dat9Backend
 	LocalS3           *s3client.LocalS3Client
 	S3Dir             string
@@ -71,6 +72,7 @@ type Server struct {
 	localTenantAPIKey   string
 	vaultMK             *vault.MasterKey
 	vaultIssuerURL      string
+	publicURL           string
 	maxUploadBytes      int64
 	inlineThreshold     int64
 	metrics             *serverMetrics
@@ -164,6 +166,7 @@ func NewWithConfig(cfg Config) *Server {
 		localTenantAPIKey:   strings.TrimSpace(cfg.LocalTenantAPIKey),
 		vaultMK:             vaultMK,
 		vaultIssuerURL:      strings.TrimSpace(cfg.VaultIssuerURL),
+		publicURL:           strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
 		provisioner:         cfg.Provisioner,
 		maxUploadBytes:      maxUpload,
 		inlineThreshold:     inlineThreshold,

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -468,15 +468,20 @@ func (s *Server) handleSlockCallback(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprint(w, "<!doctype html><html><body style='font-family:sans-serif;padding:40px;text-align:center;background:#0a0908;color:#ede8e0'><h1>Provisioning Error</h1><p style='color:#c75050'>slock tenant provision failed</p></body></html>")
 		return
 	}
-	resp.ServerURL = s.vaultIssuerURL
-	resp.Message = fmt.Sprintf("Welcome to drive9! Your tenant is ready. Visit https://drive9.ai/ for documentation. Read https://drive9.ai/skill.md and follow the instructions to install and configure drive9. Use the API key below with the CLI: drive9 ctx add --api-key %s --server %s", resp.APIKey, s.vaultIssuerURL)
+	resp.ServerURL = s.publicURL
+	resp.Message = fmt.Sprintf(
+		"Drive9 login successful. "+
+			"Documentation: https://drive9.ai/ | Skill setup: https://drive9.ai/skill.md\n"+
+			"Configure CLI: drive9 ctx add --api-key <API_KEY> --server %s",
+		s.publicURL,
+	)
 	if wantsJSON(r) {
 		setSlockCallbackNoStoreHeaders(w)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 		return
 	}
-	writeSlockHTML(w, resp, s.vaultIssuerURL)
+	writeSlockHTML(w, resp, s.publicURL)
 }
 
 func (s *Server) ensureSlockProvisioningEnabled() error {

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -391,6 +391,8 @@ type slockCallbackResponse struct {
 	APIKey    string         `json:"api_key"`
 	Status    string         `json:"status"`
 	Principal slockPrincipal `json:"principal"`
+	ServerURL string         `json:"server_url"`
+	Message   string         `json:"message"`
 }
 
 func (s *Server) handleSlockLogin(w http.ResponseWriter, r *http.Request) {
@@ -466,6 +468,8 @@ func (s *Server) handleSlockCallback(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprint(w, "<!doctype html><html><body style='font-family:sans-serif;padding:40px;text-align:center;background:#0a0908;color:#ede8e0'><h1>Provisioning Error</h1><p style='color:#c75050'>slock tenant provision failed</p></body></html>")
 		return
 	}
+	resp.ServerURL = s.vaultIssuerURL
+	resp.Message = fmt.Sprintf("Welcome to drive9! Your tenant is ready. Visit https://drive9.ai/ for documentation. Read https://drive9.ai/skill.md and follow the instructions to install and configure drive9. Use the API key below with the CLI: drive9 ctx add --api-key %s --server %s", resp.APIKey, s.vaultIssuerURL)
 	if wantsJSON(r) {
 		setSlockCallbackNoStoreHeaders(w)
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/slock_test.go
+++ b/pkg/server/slock_test.go
@@ -54,6 +54,7 @@ func newSlockTestServer(t *testing.T, info slockoauth.UserInfo) (*Server, *meta.
 		Pool:        dbi.Pool,
 		Provisioner: prov,
 		TokenSecret: tokenSecret,
+		PublicURL:   "http://localhost:9009",
 		SlockOAuth:  &fakeSlockOAuth{info: info},
 	})
 	t.Cleanup(srv.Close)
@@ -133,6 +134,12 @@ func TestSlockCallbackCreatesTenantBindingAndOwnerKey(t *testing.T) {
 	}
 	if _, err := token.ParseAndVerifyToken(tokenSecret, out.APIKey); err != nil {
 		t.Fatalf("ParseAndVerifyToken: %v", err)
+	}
+	if out.ServerURL == "" {
+		t.Fatal("server_url should not be empty")
+	}
+	if out.Message == "" {
+		t.Fatal("message should not be empty")
 	}
 	wantSubjectKey := slockSubjectKey(info)
 	binding, err := metaStore.GetExternalBinding(context.Background(), "slock", wantSubjectKey)


### PR DESCRIPTION
## Summary
Improve Slock OAuth callback JSON response with additional context and add explicit PublicURL configuration.

## Changes
- Add `PublicURL` field to `Server.Config` separate from `VaultIssuerURL`
- Enrich JSON response with:
  - `server_url`: The public server endpoint
  - `message`: Usage instructions with docs link and CLI setup command
- Use `<API_KEY>` placeholder in CLI command to avoid bloated output
- Keep HTML response unchanged with drive9.ai styling

## Example Response
```json
{
  "tenant_id": "...",
  "api_key": "dat9_...",
  "status": "active",
  "principal": {...},
  "server_url": "https://drive9.example.com",
  "message": "Drive9 login successful. Documentation: https://drive9.ai/ | Skill setup: https://drive9.ai/skill.md\nConfigure CLI: drive9 ctx add --api-key <API_KEY> --server https://drive9.example.com"
}
```

## Dev Environment Updates
- `DRIVE9_PUBLIC_URL` is now explicitly set as `PublicURL` in server config

## Testing
- All slock tests pass ✅
- Lint passes ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server now explicitly configured with its publicly accessible base URL
  * Provisioning responses now include the server URL and helpful guidance message with documentation links and CLI command template for adding context

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mem9-ai/drive9/pull/472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->