### PR TITLE
feat: hardlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ DELETE /v1/fs/{path}              delete
 DELETE /v1/fs/{path}?recursive    recursive delete
 POST   /v1/fs/{path}?append       append
 POST   /v1/fs/{path}?copy         copy (X-Dat9-Copy-Source)
+POST   /v1/fs/{path}?hardlink     hard link (X-Dat9-Hardlink-Source)
 POST   /v1/fs/{path}?rename       rename (X-Dat9-Rename-Source)
 POST   /v1/fs/{path}?mkdir        mkdir
 ```

--- a/cmd/drive9/cli/hardlink.go
+++ b/cmd/drive9/cli/hardlink.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+// Hardlink creates a remote file hard link.
+//
+//	drive9 fs hardlink /target /link
+//	drive9 fs hardlink :/target :/link
+//	drive9 fs hardlink ctx:/target ctx:/link
+func Hardlink(c *client.Client, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("usage: drive9 fs hardlink <target> <link>")
+	}
+	srcPath := args[0]
+	dstPath := args[1]
+	srcRP, srcIsRemote := ParseRemote(srcPath)
+	dstRP, dstIsRemote := ParseRemote(dstPath)
+	if srcIsRemote {
+		srcPath = srcRP.Path
+	}
+	if dstIsRemote {
+		dstPath = dstRP.Path
+	}
+
+	switch {
+	case srcRP.Context == "" && dstRP.Context == "":
+	case srcRP.Context != "" && dstRP.Context != "" && srcRP.Context == dstRP.Context:
+		var err error
+		c, err = newFSClientForContext(srcRP.Context)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("cross-context hardlink not supported: %q -> %q", args[0], args[1])
+	}
+	return c.Hardlink(srcPath, dstPath)
+}

--- a/cmd/drive9/cli/hardlink_test.go
+++ b/cmd/drive9/cli/hardlink_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+func TestHardlink(t *testing.T) {
+	t.Run("creates_link", func(t *testing.T) {
+		var gotMethod string
+		var gotPath string
+		var gotHardlink string
+		var gotSource string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			gotHardlink = r.URL.Query().Get("hardlink")
+			gotSource = r.Header.Get("X-Dat9-Hardlink-Source")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		if err := Hardlink(c, []string{"/target.txt", "/link"}); err != nil {
+			t.Fatalf("Hardlink error = %v", err)
+		}
+		if gotMethod != http.MethodPost {
+			t.Fatalf("method = %q, want POST", gotMethod)
+		}
+		if gotPath != "/v1/fs/link" {
+			t.Fatalf("path = %q, want /v1/fs/link", gotPath)
+		}
+		if gotHardlink != "1" {
+			t.Fatalf("hardlink query = %q, want 1", gotHardlink)
+		}
+		if gotSource != "/target.txt" {
+			t.Fatalf("source = %q, want /target.txt", gotSource)
+		}
+	})
+
+	t.Run("remote_path_prefix", func(t *testing.T) {
+		var gotPath string
+		var gotHardlink string
+		var gotSource string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotHardlink = r.URL.Query().Get("hardlink")
+			gotSource = r.Header.Get("X-Dat9-Hardlink-Source")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := client.New(srv.URL, "")
+		if err := Hardlink(c, []string{":/target.txt", ":/workspace/link"}); err != nil {
+			t.Fatalf("Hardlink(remote) error = %v", err)
+		}
+		if gotPath != "/v1/fs/workspace/link" {
+			t.Fatalf("path = %q, want /v1/fs/workspace/link", gotPath)
+		}
+		if gotHardlink != "1" {
+			t.Fatalf("hardlink query = %q, want 1", gotHardlink)
+		}
+		if gotSource != "/target.txt" {
+			t.Fatalf("source = %q, want /target.txt", gotSource)
+		}
+	})
+}
+
+func TestHardlinkUsageErrors(t *testing.T) {
+	c := client.New("http://example.invalid", "")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"no_args", nil, "usage: drive9 fs hardlink"},
+		{"one_arg", []string{"/target"}, "usage: drive9 fs hardlink"},
+		{"too_many_args", []string{"/target", "/link", "/extra"}, "usage: drive9 fs hardlink"},
+		{"cross_context", []string{"ctx:/target", "other:/link"}, "cross-context hardlink not supported"},
+		{"named_source_without_named_link", []string{"ctx:/target", "/link"}, "cross-context hardlink not supported"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Hardlink(c, tt.args)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/drive9/cli/stat.go
+++ b/cmd/drive9/cli/stat.go
@@ -64,6 +64,9 @@ func Stat(c *client.Client, args []string) error {
 	if m.ResourceID != "" {
 		fmt.Printf("resource_id: %s\n", m.ResourceID)
 	}
+	if m.Nlink > 0 {
+		fmt.Printf("nlink: %d\n", m.Nlink)
+	}
 	fmt.Printf("revision: %d\n", m.Revision)
 	if m.Mtime != nil {
 		fmt.Printf("mtime: %s\n", time.Unix(*m.Mtime, 0).UTC().Format(time.RFC3339))

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -9,7 +9,7 @@
 //	create  provision a new database and owner context
 //	ctx     manage contexts (show, add, import, fork, ls, use, rm)
 //	fs      filesystem operations (cp, cat, ls, stat, mv, rm, mkdir, chmod,
-//	        symlink, sh, grep, find)
+//	        symlink, hardlink, sh, grep, find)
 //	token  issue and revoke workspace-zone scoped filesystem tokens
 //	vault   vault operations (set, get, put, with, ls, rm, grant, revoke, audit)
 //	journal append-only agent/workflow journal operations
@@ -276,6 +276,8 @@ func runFS(args []string) {
 		err = cli.Chmod(c, rest)
 	case "symlink":
 		err = cli.Symlink(c, rest)
+	case "hardlink":
+		err = cli.Hardlink(c, rest)
 	case "sh":
 		err = cli.Sh(c, rest)
 	case "grep":
@@ -367,6 +369,8 @@ commands:
   chmod <mode> <path>  change file permissions (octal, e.g. 644)
   symlink <target> <link>
                        create symbolic link
+  hardlink <target> <link>
+                       create hard link
   rm [-r|--recursive] <path>
                        remove file or directory tree
   sh                  interactive shell

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -145,7 +145,7 @@ use the same value as `DRIVE9_API_KEY` here.
 9. Semantic text recall checks (`GET ?grep=feline%20sofa`, `GET ?grep=canine%20field`) with async polling
 10. Image-associated recall check (`GET ?grep=feline%20face%20icon`) with async polling + image discoverability
 11. SQL sanity check (`POST /v1/sql`)
-12. `copy`, `rename`, `delete`
+12. `copy`, `hardlink`, `rename`, `delete`
 13. Final `list` verifies expected structure after mutations
 14. Large multipart upload (`POST /v1/uploads/initiate` + presigned part uploads + complete + download checksum)
 
@@ -162,7 +162,7 @@ use the same value as `DRIVE9_API_KEY` here.
 1. Provision + readiness polling
 2. Prepare `drive9` CLI binary (build local or download official release)
 3. CLI fork flow (`ctx add`, `ctx fork`, fork readiness polling, fork-context file read/write, fork delete)
-4. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `symlink`, `rm`)
+4. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `symlink`, `hardlink`, `rm`)
 5. CLI `cp` directory-target semantics (local->remote dir, remote->local dir, remote->remote dir all preserve source basename)
 6. CLI batch small-file flow (`cp` many files + dir list count + stat + sample reads)
 7. CLI search flow (`fs grep`, `fs find`)
@@ -193,7 +193,7 @@ script is not a supported Windows validation path.
 2. Prepare `drive9` CLI binary (build local or download official release)
 3. Mount compatibility precheck for root `ls /`
 4. RW mount lifecycle (`drive9 mount`, `drive9 umount`)
-5. File semantics (`create`, `read`, `overwrite`, `append`, `symlink`, `truncate`, `unlink`)
+5. File semantics (`create`, `read`, `overwrite`, `append`, `symlink`, `hardlink`, `truncate`, `unlink`)
 6. Directory semantics (`mkdir`, nested paths, `readdir`, empty/non-empty `rmdir`)
 7. Rename semantics (file + directory rename consistency)
 8. Attribute semantics (`size`, `mtime` monotonicity, remote stat parity)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,10 +13,10 @@ including local single-tenant validation via `drive9-server-local`.
 
 | Script | What it validates |
 |--------|--------------------|
-| `api-smoke-test.sh` | Fresh provisioning, status polling, nested+batch file ops, grep/find checks, semantic text recall, image-associated recall, sql checks, large multipart upload+download |
+| `api-smoke-test.sh` | Fresh provisioning, status polling, nested+batch file ops, hardlink/copy/rename/delete checks, grep/find checks, semantic text recall, image-associated recall, sql checks, large multipart upload+download |
 | `api-smoke-test-existing-key.sh` | Existing API key status/list checks |
-| `cli-smoke-test.sh` | End-to-end CLI workflow including `fs symlink`, `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
-| `fuse-smoke-test.sh` | FUSE mount lifecycle, file/dir/symlink/rename/stat semantics, cross-channel consistency, read-only and error-path checks |
+| `cli-smoke-test.sh` | End-to-end CLI workflow including `fs symlink`, `fs hardlink`, `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
+| `fuse-smoke-test.sh` | FUSE mount lifecycle, file/dir/symlink/hardlink/rename/stat semantics, cross-channel consistency, read-only and error-path checks |
 | `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, and mount-log audit |
 | `git-workspace-smoke-test.sh` | Git workspace fast-blobless clone with coding-agent local overlay, batched tracked-file edits, ignored local-only paths, `git add`/`commit`, `git apply`, and remount restore |
 | `posix-permission-smoke-test.sh` | POSIX permission coverage: API mkdir/chmod mode propagation, CLI `fs chmod`, FUSE `chmod`/`mkdir -m` with remote and local stat parity |

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -13,7 +13,7 @@
 #  9) Semantic text recall checks (`grep` with paraphrase query)
 # 10) Image-associated recall checks (caption text + image file)
 # 11) SQL endpoint sanity query
-# 12) Copy, rename, delete
+# 12) Copy, hardlink, rename, delete
 # 13) Final list verification
 # 14) 100MB multipart upload via POST /v1/uploads/initiate + download checksum
 # 15) Max-upload boundary check (limit allowed, limit+1 rejected)
@@ -119,6 +119,12 @@ curl_body_code() {
 
 http_code() { printf '%s' "$1" | awk -F'__HTTP__' 'NF>1{print $2}' | tr -d '\n'; }
 json_body() { printf '%s' "$1" | sed '/__HTTP__/d'; }
+
+header_value() {
+  local header_file="$1"
+  local header_name="$2"
+  awk -F': *' -v name="$header_name" 'tolower($1)==tolower(name){v=$2} END{gsub(/\r/,"",v); print v}' "$header_file"
+}
 
 json_is_valid() {
   printf '%s' "$1" | jq -e . >/dev/null 2>&1
@@ -532,7 +538,7 @@ check_eq "POST /v1/sql returns 200" "$code" "200"
 sql_n=$(printf '%s' "$body" | jq -r '.[0].n')
 check_eq "SQL query result n=1" "$sql_n" "1"
 
-step "12" "Copy, rename, delete"
+step "12" "Copy, hardlink, rename, delete"
 copy_body="$(mktemp)"
 copy_code=$(curl -sS -o "$copy_body" -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "X-Dat9-Copy-Source: /$ROOT_DIR/README.md" "$BASE/v1/fs/$ROOT_DIR/README-copy.md?copy")
 copy_attempt=1
@@ -544,6 +550,49 @@ while [ "$copy_code" = "429" ] && [ "$copy_attempt" -lt "$REQUEST_MAX_RETRIES" ]
 done
 check_eq "POST ?copy returns 200" "$copy_code" "200"
 rm -f "$copy_body"
+
+hardlink_src="${ROOT_DIR}/hardlink-source.txt"
+hardlink_dst="${ROOT_DIR}/hardlink-link.txt"
+resp=$(curl_body_code PUT "$BASE/v1/fs/$hardlink_src" "$API_KEY" "hardlink-original-${TS}")
+code=$(http_code "$resp")
+check_eq "PUT hardlink source returns 200" "$code" "200"
+
+hardlink_body="$(mktemp)"
+hardlink_code=$(curl -sS -o "$hardlink_body" -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "X-Dat9-Hardlink-Source: /$hardlink_src" "$BASE/v1/fs/$hardlink_dst?hardlink=1")
+hardlink_attempt=1
+while [ "$hardlink_code" = "429" ] && [ "$hardlink_attempt" -lt "$REQUEST_MAX_RETRIES" ]; do
+  info "throttled (429), retrying ${hardlink_attempt}/${REQUEST_MAX_RETRIES}: hardlink"
+  hardlink_attempt=$((hardlink_attempt + 1))
+  sleep "$REQUEST_RETRY_SLEEP_S"
+  hardlink_code=$(curl -sS -o "$hardlink_body" -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "X-Dat9-Hardlink-Source: /$hardlink_src" "$BASE/v1/fs/$hardlink_dst?hardlink=1")
+done
+check_eq "POST ?hardlink returns 200" "$hardlink_code" "200"
+rm -f "$hardlink_body"
+
+hardlink_src_headers="$(mktemp)"
+hardlink_dst_headers="$(mktemp)"
+hardlink_src_head=$(curl -sS -D "$hardlink_src_headers" -o /dev/null -w "%{http_code}" -I -H "Authorization: Bearer $API_KEY" "$BASE/v1/fs/$hardlink_src")
+hardlink_dst_head=$(curl -sS -D "$hardlink_dst_headers" -o /dev/null -w "%{http_code}" -I -H "Authorization: Bearer $API_KEY" "$BASE/v1/fs/$hardlink_dst")
+check_eq "HEAD hardlink source returns 200" "$hardlink_src_head" "200"
+check_eq "HEAD hardlink link returns 200" "$hardlink_dst_head" "200"
+hardlink_src_id=$(header_value "$hardlink_src_headers" "X-Dat9-Resource-ID")
+hardlink_dst_id=$(header_value "$hardlink_dst_headers" "X-Dat9-Resource-ID")
+hardlink_src_nlink=$(header_value "$hardlink_src_headers" "X-Dat9-Nlink")
+hardlink_dst_nlink=$(header_value "$hardlink_dst_headers" "X-Dat9-Nlink")
+rm -f "$hardlink_src_headers" "$hardlink_dst_headers"
+check_cmd "hardlink source resource_id is present" test -n "$hardlink_src_id"
+check_eq "hardlink resource_id matches source" "$hardlink_dst_id" "$hardlink_src_id"
+check_cmd "hardlink source nlink >= 2" bash -c 'test "${1:-0}" -ge 2' -- "$hardlink_src_nlink"
+check_cmd "hardlink link nlink >= 2" bash -c 'test "${1:-0}" -ge 2' -- "$hardlink_dst_nlink"
+
+resp=$(curl_body_code PUT "$BASE/v1/fs/$hardlink_dst" "$API_KEY" "hardlink-updated-${TS}")
+code=$(http_code "$resp")
+check_eq "PUT hardlink link returns 200" "$code" "200"
+resp=$(curl_body_code GET "$BASE/v1/fs/$hardlink_src" "$API_KEY")
+code=$(http_code "$resp")
+body=$(json_body "$resp")
+check_eq "GET hardlink source returns 200" "$code" "200"
+check_eq "writing hardlink updates source content" "$body" "hardlink-updated-${TS}"
 
 rename_body="$(mktemp)"
 rename_code=$(curl -sS -o "$rename_body" -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "X-Dat9-Rename-Source: /$BACKEND_DIR/config.yaml" "$BASE/v1/fs/$BACKEND_DIR/config-renamed.yaml?rename")
@@ -577,9 +626,11 @@ check_eq "GET /v1/fs/$ROOT_DIR?list returns 200" "$code" "200"
 backend_exists=$(printf '%s' "$body" | jq -r 'any(.entries[]; .name=="backend" and .isDir==true)')
 frontend_exists=$(printf '%s' "$body" | jq -r 'any(.entries[]; .name=="frontend" and .isDir==true)')
 copy_exists=$(printf '%s' "$body" | jq -r 'any(.entries[]; .name=="README-copy.md")')
+hardlink_exists=$(printf '%s' "$body" | jq -r 'any(.entries[]; .name=="hardlink-link.txt")')
 check_eq "backend directory still exists" "$backend_exists" "true"
 check_eq "frontend directory still exists" "$frontend_exists" "true"
 check_eq "copied file removed" "$copy_exists" "false"
+check_eq "hardlink file remains visible" "$hardlink_exists" "true"
 
 if [ "$RUN_LARGE_FILE" = "1" ]; then
   step "14" "Large file multipart upload via body initiate (${LARGE_FILE_MB}MB)"

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -477,6 +477,10 @@ check_eq "cat hardlink returns source content" "$hardlink_body" "cli-smoke-${TS}
 
 hardlink_nlink="$(cli_stat_field "$SMALL_HARDLINK" "nlink")"
 check_cmd "hardlink stat reports nlink >= 2" bash -c 'test "${1:-0}" -ge 2' -- "$hardlink_nlink"
+hardlink_source_resource_id="$(cli_stat_field "$SMALL_RENAMED" "resource_id")"
+hardlink_resource_id="$(cli_stat_field "$SMALL_HARDLINK" "resource_id")"
+check_cmd "hardlink source resource_id is non-empty" test -n "$hardlink_source_resource_id"
+check_eq "hardlink and source share resource_id" "$hardlink_resource_id" "$hardlink_source_resource_id"
 
 printf "cli-hardlink-%s" "$TS" > "$HARDLINK_LOCAL"
 drive9_retry fs cp "$HARDLINK_LOCAL" ":$SMALL_HARDLINK" >/dev/null

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -263,6 +263,22 @@ drive9_retry_read() {
   done
 }
 
+cli_stat_field() {
+  local path="$1"
+  local field="$2"
+  local out
+  out="$(drive9_retry fs stat "$path")"
+  python3 - "$out" "$field" <<'PY'
+import sys
+text, field = sys.argv[1], sys.argv[2].lower()
+for line in text.splitlines():
+    if line.strip().lower().startswith(field + ":"):
+        print(line.split(":", 1)[1].strip())
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
 wait_cli_grep_target() {
   local desc="$1"
   local query="$2"
@@ -297,9 +313,11 @@ SMALL_LOCAL="/tmp/drive9-cli-small-${TS}.txt"
 SMALL_REMOTE="/cli-${TS}-small.txt"
 SMALL_RENAMED="/cli-${TS}-small-renamed.txt"
 SMALL_SYMLINK="/cli-${TS}-small-link"
+SMALL_HARDLINK="/cli-${TS}-small-hardlink.txt"
 CP_DIR_REMOTE="/cli-${TS}-cpdir"
 CP_DIR_REMOTE_COPY="/cli-${TS}-cpdir-copy"
 CP_DIR_LOCAL="/tmp/drive9-cli-cpdir-${TS}"
+HARDLINK_LOCAL="/tmp/drive9-cli-hardlink-${TS}.txt"
 TAG_LOCAL="/tmp/drive9-cli-tag-${TS}.txt"
 TAG_REMOTE="/cli-${TS}-tagged.txt"
 IMAGE_LOCAL="/tmp/drive9-cli-image-${TS}.jpg"
@@ -435,6 +453,35 @@ check_eq "symlink appears in ls /" "$symlink_present" "true"
 
 symlink_target="$(drive9_retry_read fs cat "$SMALL_SYMLINK")"
 check_eq "cat symlink returns target payload" "$symlink_target" "$SMALL_RENAMED"
+
+drive9_retry fs hardlink "$SMALL_RENAMED" "$SMALL_HARDLINK" >/dev/null
+hardlink_present="false"
+for _ in $(seq 1 "$CLI_MAX_RETRIES"); do
+  hardlink_ls="$(drive9_retry fs ls /)"
+  hardlink_present=$(python3 - "$hardlink_ls" "$(basename "$SMALL_HARDLINK")" <<'PY'
+import sys
+out=sys.argv[1].splitlines()
+name=sys.argv[2]
+print("true" if any(line.strip()==name for line in out) else "false")
+PY
+)
+  if [[ "$hardlink_present" == "true" ]]; then
+    break
+  fi
+  sleep "$CLI_RETRY_SLEEP_S"
+done
+check_eq "hardlink appears in ls /" "$hardlink_present" "true"
+
+hardlink_body="$(drive9_retry_read fs cat "$SMALL_HARDLINK")"
+check_eq "cat hardlink returns source content" "$hardlink_body" "cli-smoke-${TS}"
+
+hardlink_nlink="$(cli_stat_field "$SMALL_HARDLINK" "nlink")"
+check_cmd "hardlink stat reports nlink >= 2" bash -c 'test "${1:-0}" -ge 2' -- "$hardlink_nlink"
+
+printf "cli-hardlink-%s" "$TS" > "$HARDLINK_LOCAL"
+drive9_retry fs cp "$HARDLINK_LOCAL" ":$SMALL_HARDLINK" >/dev/null
+hardlink_source_after_write="$(drive9_retry_read fs cat "$SMALL_RENAMED")"
+check_eq "writing hardlink updates source content" "$hardlink_source_after_write" "cli-hardlink-${TS}"
 
 echo "[4.1] cli tag/stat metadata checks"
 printf "cli-tag-%s" "$TS" > "$TAG_LOCAL"
@@ -587,6 +634,7 @@ check_eq "downloaded large file sha256 matches" "$sum_dst" "$sum_src"
 
 echo "[8] cleanup via cli"
 drive9_retry fs rm "$SMALL_SYMLINK" >/dev/null
+drive9_retry fs rm "$SMALL_HARDLINK" >/dev/null
 drive9_retry fs rm "$SMALL_RENAMED" >/dev/null
 drive9_retry fs rm "$TAG_REMOTE" >/dev/null
 if [ "$CLI_IMAGE_UPLOADED" = "1" ]; then
@@ -734,7 +782,7 @@ PY
   rm -f "$boundary_over_payload" "$over_file"
 fi
 
-rm -f "$pfile" "$CLI_BIN" "$SMALL_LOCAL" "$IMAGE_LOCAL" "$LARGE_LOCAL" "$LARGE_DOWNLOADED"
+rm -f "$pfile" "$CLI_BIN" "$SMALL_LOCAL" "$HARDLINK_LOCAL" "$IMAGE_LOCAL" "$LARGE_LOCAL" "$LARGE_DOWNLOADED"
 rm -f "$TAG_LOCAL"
 rm -f "$FORK_LOCAL"
 rm -f "/tmp/drive9-cli-sem-target-${TS}.txt" "/tmp/drive9-cli-sem-other-${TS}.txt" "/tmp/drive9-cli-image-caption-${TS}.txt"

--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -782,6 +782,12 @@ if is_mounted "$MOUNT_POINT"; then
   else
     check_eq "remote hardlink nlink is 2" "" "2"
   fi
+  if source_resource_id=$(stat_field "$RW_TEXT_REMOTE" "resource_id") && hardlink_resource_id=$(stat_field "$RW_HARDLINK_REMOTE" "resource_id"); then
+    check_cmd "remote source resource_id is non-empty" test -n "$source_resource_id"
+    check_eq "remote hardlink shares resource_id" "$hardlink_resource_id" "$source_resource_id"
+  else
+    check_eq "remote hardlink resource_id fields are available" "false" "true"
+  fi
   if [ -f "$RW_HARDLINK_MOUNT" ]; then
     printf "hardlink-%s" "$TS" > "$RW_HARDLINK_MOUNT"
     hardlink_source_cat=$(cat "$RW_TEXT_MOUNT")

--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -653,6 +653,9 @@ RW_TEXT_MOUNT="$MOUNT_POINT/$RW_TEXT_REL"
 RW_SYMLINK_REL="${RW_ALPHA_REL}/text-link"
 RW_SYMLINK_REMOTE="/${RW_SYMLINK_REL}"
 RW_SYMLINK_MOUNT="$MOUNT_POINT/$RW_SYMLINK_REL"
+RW_HARDLINK_REL="${RW_ALPHA_REL}/text-hardlink.txt"
+RW_HARDLINK_REMOTE="/${RW_HARDLINK_REL}"
+RW_HARDLINK_MOUNT="$MOUNT_POINT/$RW_HARDLINK_REL"
 RW_TEXT_RENAMED_REL="${RW_ALPHA_REL}/text-renamed.txt"
 RW_TEXT_RENAMED_REMOTE="/${RW_TEXT_RENAMED_REL}"
 RW_TEXT_RENAMED_MOUNT="$MOUNT_POINT/$RW_TEXT_RENAMED_REL"
@@ -761,6 +764,38 @@ if is_mounted "$MOUNT_POINT"; then
   check_eq "readlink returns symlink target" "$link_target" "text.txt"
   check_eq "cat follows mounted symlink" "$symlink_cat" "overwrite-${TS}-append"
   check_eq "remote cat returns symlink payload" "$remote_link_target" "text.txt"
+
+  if ln "$RW_TEXT_MOUNT" "$RW_HARDLINK_MOUNT"; then
+    check_eq "hardlink via mount succeeds" "true" "true"
+  else
+    check_eq "hardlink via mount succeeds" "false" "true"
+  fi
+  check_cmd "hardlink is visible as local file" test -f "$RW_HARDLINK_MOUNT"
+  if [ -f "$RW_HARDLINK_MOUNT" ]; then
+    hardlink_cat=$(cat "$RW_HARDLINK_MOUNT")
+  else
+    hardlink_cat=""
+  fi
+  check_eq "cat hardlink returns source content" "$hardlink_cat" "overwrite-${TS}-append"
+  if hardlink_nlink=$(wait_remote_stat_field_eq "$RW_HARDLINK_REMOTE" "nlink" "2"); then
+    check_eq "remote hardlink nlink is 2" "$hardlink_nlink" "2"
+  else
+    check_eq "remote hardlink nlink is 2" "" "2"
+  fi
+  if [ -f "$RW_HARDLINK_MOUNT" ]; then
+    printf "hardlink-%s" "$TS" > "$RW_HARDLINK_MOUNT"
+    hardlink_source_cat=$(cat "$RW_TEXT_MOUNT")
+    if remote_hardlink_source=$(wait_remote_cat_eq "$RW_TEXT_REMOTE" "hardlink-${TS}"); then
+      :
+    else
+      remote_hardlink_source=""
+    fi
+  else
+    hardlink_source_cat=""
+    remote_hardlink_source=""
+  fi
+  check_eq "writing hardlink updates local source" "$hardlink_source_cat" "hardlink-${TS}"
+  check_eq "writing hardlink updates remote source" "$remote_hardlink_source" "hardlink-${TS}"
 
   if : > "$RW_TEXT_MOUNT"; then
     check_eq "truncate via mount succeeds" "true" "true"

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -1205,20 +1205,16 @@ func (b *Dat9Backend) HardlinkFileCtx(ctx context.Context, srcPath, dstPath stri
 	start := time.Now()
 	defer func() { observeBackend(ctx, "hardlink_file", err, start) }()
 
-	srcPath, err = pathutil.Canonicalize(srcPath)
+	dstPath, err = pathutil.Canonicalize(dstPath)
 	if err != nil {
 		return err
 	}
-	dstPath, err = pathutil.Canonicalize(dstPath)
+	srcPath, srcNode, err := b.resolveNodePath(ctx, srcPath)
 	if err != nil {
 		return err
 	}
 	if srcPath == dstPath {
 		return datastore.ErrPathConflict
-	}
-	srcNode, err := b.store.GetNode(ctx, srcPath)
-	if err != nil {
-		return err
 	}
 	if srcNode.IsDirectory {
 		return ErrInvalidHardlinkTarget

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -824,6 +824,17 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 		return nil, err
 	}
 
+	fileIDs := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.File != nil && e.File.FileID != "" {
+			fileIDs = append(fileIDs, e.File.FileID)
+		}
+	}
+	refCounts, err := b.store.RefCounts(ctx, fileIDs)
+	if err != nil {
+		return nil, err
+	}
+
 	infos = make([]filesystem.FileInfo, 0, len(entries))
 	for _, e := range entries {
 		info := filesystem.FileInfo{
@@ -841,10 +852,7 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 			info.Size = e.File.SizeBytes
 			info.ModTime = fileMtime(e.File)
 			meta["resource_id"] = e.File.FileID
-			count, err := b.store.RefCount(ctx, e.File.FileID)
-			if err != nil {
-				return nil, err
-			}
+			count := refCounts[e.File.FileID]
 			if count <= 0 {
 				count = 1
 			}

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -14,6 +14,7 @@ import (
 	"math/rand"
 	"mime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -828,18 +829,44 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 		info := filesystem.FileInfo{
 			Name: e.Node.Name, IsDir: e.Node.IsDirectory, Mode: 0o644,
 		}
+		meta := make(map[string]string)
 		if e.Node.IsDirectory {
 			info.Mode = 0o755
 		}
 		if e.HasMode {
 			info.Mode = e.Mode
-			info.Meta = filesystem.MetaData{Content: map[string]string{"hasMode": "true"}}
+			meta["hasMode"] = "true"
 		}
 		if e.File != nil {
 			info.Size = e.File.SizeBytes
 			info.ModTime = fileMtime(e.File)
+			meta["resource_id"] = e.File.FileID
+			count, err := b.store.RefCount(ctx, e.File.FileID)
+			if err != nil {
+				return nil, err
+			}
+			if count <= 0 {
+				count = 1
+			}
+			if count > int64(^uint32(0)) {
+				count = int64(^uint32(0))
+			}
+			meta["nlink"] = strconv.FormatInt(count, 10)
 		} else {
 			info.ModTime = e.Node.CreatedAt
+			if e.Node.InodeID != "" {
+				meta["resource_id"] = e.Node.InodeID
+			} else if e.Node.NodeID != "" {
+				meta["resource_id"] = e.Node.NodeID
+			}
+			if e.Node.IsDirectory {
+				meta["nlink"] = "2"
+			} else {
+				meta["nlink"] = "1"
+			}
+		}
+		if len(meta) > 0 {
+			info.Meta = filesystem.MetaData{Content: meta}
 		}
 		infos = append(infos, info)
 	}
@@ -1219,10 +1246,12 @@ func (b *Dat9Backend) HardlinkFileCtx(ctx context.Context, srcPath, dstPath stri
 	if srcNode.IsDirectory {
 		return ErrInvalidHardlinkTarget
 	}
-	if err := b.store.EnsureParentDirs(ctx, dstPath, b.genID); err != nil {
-		return err
-	}
-	err = b.store.LinkFileNode(ctx, srcPath, dstPath, pathutil.ParentPath(dstPath), pathutil.BaseName(dstPath), b.genID(), time.Now())
+	err = b.store.InTx(ctx, func(tx *sql.Tx) error {
+		if err := b.store.EnsureParentDirsTx(tx, dstPath, b.genID); err != nil {
+			return err
+		}
+		return b.store.LinkFileNodeTx(ctx, tx, srcPath, dstPath, pathutil.ParentPath(dstPath), pathutil.BaseName(dstPath), b.genID(), time.Now())
+	})
 	if errors.Is(err, datastore.ErrInvalidLinkTarget) {
 		return ErrInvalidHardlinkTarget
 	}

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -1195,6 +1195,44 @@ func (b *Dat9Backend) CopyFileCtx(ctx context.Context, srcPath, dstPath string) 
 	})
 }
 
+// HardlinkFile creates dstPath as another directory entry for srcPath's file
+// entity. The two paths share content, revision, mode, tags, and storage.
+func (b *Dat9Backend) HardlinkFile(srcPath, dstPath string) error {
+	return b.HardlinkFileCtx(backgroundWithTrace(), srcPath, dstPath)
+}
+
+func (b *Dat9Backend) HardlinkFileCtx(ctx context.Context, srcPath, dstPath string) (err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, "hardlink_file", err, start) }()
+
+	srcPath, err = pathutil.Canonicalize(srcPath)
+	if err != nil {
+		return err
+	}
+	dstPath, err = pathutil.Canonicalize(dstPath)
+	if err != nil {
+		return err
+	}
+	if srcPath == dstPath {
+		return datastore.ErrPathConflict
+	}
+	srcNode, err := b.store.GetNode(ctx, srcPath)
+	if err != nil {
+		return err
+	}
+	if srcNode.IsDirectory {
+		return ErrInvalidHardlinkTarget
+	}
+	if err := b.store.EnsureParentDirs(ctx, dstPath, b.genID); err != nil {
+		return err
+	}
+	err = b.store.LinkFileNode(ctx, srcPath, dstPath, pathutil.ParentPath(dstPath), pathutil.BaseName(dstPath), b.genID(), time.Now())
+	if errors.Is(err, datastore.ErrInvalidLinkTarget) {
+		return ErrInvalidHardlinkTarget
+	}
+	return err
+}
+
 func (b *Dat9Backend) deleteBlobCtx(ctx context.Context, ref string) {
 	if b.s3 != nil && ref != "" {
 		if err := b.s3.DeleteObject(ctx, ref); err != nil {

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -474,6 +474,12 @@ func TestMkdirAndReadDir(t *testing.T) {
 	if entries[0].Name != "a.txt" || entries[1].Name != "b.txt" {
 		t.Errorf("unexpected: %+v", entries)
 	}
+	if got := entries[0].Meta.Content["resource_id"]; got == "" {
+		t.Fatal("ReadDir entry resource_id is empty")
+	}
+	if got := entries[0].Meta.Content["nlink"]; got != "1" {
+		t.Fatalf("ReadDir entry nlink = %q, want 1", got)
+	}
 }
 
 func TestRemove(t *testing.T) {

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -650,6 +650,46 @@ func TestZeroCopyCp(t *testing.T) {
 	}
 }
 
+func TestHardlinkFileSharesContentAndRejectsDirectories(t *testing.T) {
+	b := newTestBackend(t)
+	if _, err := b.Write("/a.txt", []byte("shared"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.HardlinkFile("/a.txt", "/b.txt"); err != nil {
+		t.Fatalf("HardlinkFile: %v", err)
+	}
+	if _, err := b.Write("/b.txt", []byte("updated"), 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatal(err)
+	}
+	dataA, err := b.Read("/a.txt", 0, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(dataA) != "updated" {
+		t.Fatalf("a.txt = %q, want updated", dataA)
+	}
+	nf, err := b.Store().Stat(context.Background(), "/a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err := b.Store().RefCount(context.Background(), nf.File.FileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("refcount = %d, want 2", count)
+	}
+	if err := b.HardlinkFile("/a.txt", "/b.txt"); !errors.Is(err, datastore.ErrPathConflict) {
+		t.Fatalf("duplicate HardlinkFile error = %v, want ErrPathConflict", err)
+	}
+	if err := b.Mkdir("/dir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.HardlinkFile("/dir/", "/dir-link"); !errors.Is(err, ErrInvalidHardlinkTarget) {
+		t.Fatalf("directory HardlinkFile error = %v, want ErrInvalidHardlinkTarget", err)
+	}
+}
+
 func TestAutoCreateParentDirs(t *testing.T) {
 	b := newTestBackend(t)
 	if _, err := b.Write("/a/b/c/file.txt", []byte("deep"), 0, filesystem.WriteFlagCreate); err != nil {
@@ -815,7 +855,6 @@ func TestOpenAndOpenWrite(t *testing.T) {
 		t.Errorf("got %q", readData)
 	}
 }
-
 
 func TestChmod(t *testing.T) {
 	b := newTestBackend(t)

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -685,6 +685,28 @@ func TestHardlinkFileSharesContentAndRejectsDirectories(t *testing.T) {
 	if count != 2 {
 		t.Fatalf("refcount = %d, want 2", count)
 	}
+	entries, err := b.ReadDir("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) < 2 {
+		t.Fatalf("root entries = %d, want at least 2", len(entries))
+	}
+	resourceID := entries[0].Meta.Content["resource_id"]
+	if resourceID == "" {
+		t.Fatal("hardlink ReadDir resource_id is empty")
+	}
+	for _, entry := range entries {
+		if entry.Name != "a.txt" && entry.Name != "b.txt" {
+			continue
+		}
+		if got := entry.Meta.Content["resource_id"]; got != resourceID {
+			t.Fatalf("%s resource_id = %q, want %q", entry.Name, got, resourceID)
+		}
+		if got := entry.Meta.Content["nlink"]; got != "2" {
+			t.Fatalf("%s nlink = %q, want 2", entry.Name, got)
+		}
+	}
 	if err := b.HardlinkFile("/a.txt", "/b.txt"); !errors.Is(err, datastore.ErrPathConflict) {
 		t.Fatalf("duplicate HardlinkFile error = %v, want ErrPathConflict", err)
 	}

--- a/pkg/backend/errors.go
+++ b/pkg/backend/errors.go
@@ -14,3 +14,7 @@ var ErrNotInlineStorage = errors.New("file is not stored inline")
 // ErrInvalidSymlinkTarget reports that a symbolic link target is empty or
 // contains bytes that cannot be represented by the FUSE symlink contract.
 var ErrInvalidSymlinkTarget = errors.New("invalid symlink target")
+
+// ErrInvalidHardlinkTarget reports that a hardlink source cannot be linked,
+// for example because it names a directory.
+var ErrInvalidHardlinkTarget = errors.New("invalid hardlink target")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -185,22 +185,26 @@ func newClient(baseURL, credential string) *Client {
 
 // FileInfo represents a file entry from a directory listing.
 type FileInfo struct {
-	Name    string `json:"name"`
-	Size    int64  `json:"size"`
-	IsDir   bool   `json:"isDir"`
-	Mtime   int64  `json:"mtime,omitempty"` // Unix seconds, 0 means unknown
-	Mode    uint32 `json:"mode,omitempty"`
-	HasMode bool   `json:"hasMode"`
+	Name       string `json:"name"`
+	Size       int64  `json:"size"`
+	IsDir      bool   `json:"isDir"`
+	Mtime      int64  `json:"mtime,omitempty"` // Unix seconds, 0 means unknown
+	Mode       uint32 `json:"mode,omitempty"`
+	HasMode    bool   `json:"hasMode"`
+	ResourceID string `json:"resource_id,omitempty"`
+	Nlink      uint32 `json:"nlink,omitempty"`
 }
 
 // StatResult represents file metadata from HEAD.
 type StatResult struct {
-	Size     int64
-	IsDir    bool
-	Revision int64
-	Mtime    time.Time
-	Mode     uint32
-	HasMode  bool // true when the server returned a mode header (including 0)
+	Size       int64
+	IsDir      bool
+	Revision   int64
+	Mtime      time.Time
+	Mode       uint32
+	HasMode    bool // true when the server returned a mode header (including 0)
+	ResourceID string
+	Nlink      uint32
 }
 
 // MaxBatchStatPaths is the maximum number of paths accepted by BatchStatCtx.
@@ -214,15 +218,17 @@ const MaxBatchReadSmallPaths = 128
 // Status is the HTTP-like per-path status. A missing path returns Status 404
 // in its own result instead of failing the whole batch.
 type BatchStatResult struct {
-	Path     string `json:"path"`
-	Status   int    `json:"status"`
-	Error    string `json:"error,omitempty"`
-	Size     int64  `json:"size,omitempty"`
-	IsDir    bool   `json:"isDir"`
-	Revision int64  `json:"revision,omitempty"`
-	Mtime    int64  `json:"mtime,omitempty"` // Unix seconds, 0 means unknown
-	Mode     uint32 `json:"mode,omitempty"`
-	HasMode  bool   `json:"hasMode"`
+	Path       string `json:"path"`
+	Status     int    `json:"status"`
+	Error      string `json:"error,omitempty"`
+	Size       int64  `json:"size,omitempty"`
+	IsDir      bool   `json:"isDir"`
+	Revision   int64  `json:"revision,omitempty"`
+	Mtime      int64  `json:"mtime,omitempty"` // Unix seconds, 0 means unknown
+	Mode       uint32 `json:"mode,omitempty"`
+	HasMode    bool   `json:"hasMode"`
+	ResourceID string `json:"resource_id,omitempty"`
+	Nlink      uint32 `json:"nlink,omitempty"`
 }
 
 // OK reports whether the per-path batch stat result is successful.
@@ -254,6 +260,7 @@ type StatMetadataResult struct {
 	Size         int64             `json:"size"`
 	IsDir        bool              `json:"isdir"`
 	ResourceID   string            `json:"resource_id,omitempty"`
+	Nlink        uint32            `json:"nlink,omitempty"`
 	Revision     int64             `json:"revision"`
 	Mtime        *int64            `json:"mtime,omitempty"` // Unix seconds when known
 	ContentType  string            `json:"content_type"`
@@ -533,6 +540,29 @@ func (c *Client) SymlinkCtx(ctx context.Context, target, linkPath string) error 
 	return nil
 }
 
+// Hardlink creates a hard link at dstPath pointing at srcPath's file entity.
+func (c *Client) Hardlink(srcPath, dstPath string) error {
+	return c.HardlinkCtx(context.Background(), srcPath, dstPath)
+}
+
+// HardlinkCtx creates a hard link with context support.
+func (c *Client) HardlinkCtx(ctx context.Context, srcPath, dstPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(dstPath)+"?hardlink=1", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Dat9-Hardlink-Source", srcPath)
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return readError(resp)
+	}
+	return nil
+}
+
 func (c *Client) writeCtxConditionalFull(ctx context.Context, path string, data []byte, expectedRevision int64, tags map[string]string, description string) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(path), bytes.NewReader(data))
 	if err != nil {
@@ -771,6 +801,12 @@ func (c *Client) StatCtx(ctx context.Context, path string) (*StatResult, error) 
 			s.Mtime = time.Unix(sec, 0)
 		}
 	}
+	s.ResourceID = resp.Header.Get("X-Dat9-Resource-ID")
+	if nlink := resp.Header.Get("X-Dat9-Nlink"); nlink != "" {
+		if n, err := strconv.ParseUint(nlink, 10, 32); err == nil {
+			s.Nlink = uint32(n)
+		}
+	}
 	return s, nil
 }
 
@@ -840,6 +876,8 @@ func (c *Client) StatMetadataCompatCtx(ctx context.Context, path string) (*StatM
 	return &StatMetadataResult{
 		Size:         statOut.Size,
 		IsDir:        statOut.IsDir,
+		ResourceID:   statOut.ResourceID,
+		Nlink:        statOut.Nlink,
 		Revision:     statOut.Revision,
 		Mtime:        mtime,
 		ContentType:  "",

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -664,6 +664,77 @@ func TestSymlinkCtxPreservesStatusError(t *testing.T) {
 	}
 }
 
+func TestHardlinkCtxPostsHardlinkAction(t *testing.T) {
+	var gotSource string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/fs/link" {
+			t.Errorf("path = %s, want /v1/fs/link", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("hardlink"); got != "1" {
+			t.Errorf("hardlink query = %q, want 1", got)
+		}
+		gotSource = r.Header.Get("X-Dat9-Hardlink-Source")
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	if err := c.HardlinkCtx(context.Background(), "/src.txt", "/link"); err != nil {
+		t.Fatalf("HardlinkCtx error = %v", err)
+	}
+	if gotSource != "/src.txt" {
+		t.Fatalf("source header = %q, want /src.txt", gotSource)
+	}
+}
+
+func TestHardlinkCtxPreservesStatusError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid hardlink target"})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	err := c.HardlinkCtx(context.Background(), "/src", "/link")
+	if err == nil {
+		t.Fatal("HardlinkCtx error = nil, want status error")
+	}
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("HardlinkCtx error type = %T, want *StatusError", err)
+	}
+	if statusErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", statusErr.StatusCode)
+	}
+}
+
+func TestStatCtxParsesResourceIDAndNlink(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Errorf("method = %s, want HEAD", r.Method)
+		}
+		w.Header().Set("Content-Length", "12")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", "7")
+		w.Header().Set("X-Dat9-Resource-ID", "file-1")
+		w.Header().Set("X-Dat9-Nlink", "3")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	stat, err := c.StatCtx(context.Background(), "/file.txt")
+	if err != nil {
+		t.Fatalf("StatCtx error = %v", err)
+	}
+	if stat.Size != 12 || stat.Revision != 7 || stat.ResourceID != "file-1" || stat.Nlink != 3 {
+		t.Fatalf("stat = %+v, want size 12 rev 7 resource file-1 nlink 3", stat)
+	}
+}
+
 func TestWriteCtxConditionalWithTagsRejectsInvalidHeaderTags(t *testing.T) {
 	requests := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/datastore/journal.go
+++ b/pkg/datastore/journal.go
@@ -63,7 +63,8 @@ func (s *Store) CreateJournal(ctx context.Context, tenantID string, req journal.
 	}
 
 	var out *journal.Journal
-	for attempt := 0; attempt < 3; attempt++ {
+	const maxCreateAttempts = 8
+	for attempt := 0; attempt < maxCreateAttempts; attempt++ {
 		out = nil
 		err = s.InTx(ctx, func(tx *sql.Tx) error {
 			existing, existingCreateHash, err := selectJournalTx(ctx, tx, tenantID, req.JournalID, true)
@@ -127,7 +128,7 @@ func (s *Store) CreateJournal(ctx context.Context, tenantID string, req journal.
 		if !isRetryableJournalCreateConflict(err) {
 			break
 		}
-		time.Sleep(time.Duration(attempt+1) * 5 * time.Millisecond)
+		time.Sleep(time.Duration(1<<attempt) * 5 * time.Millisecond)
 	}
 	if err != nil {
 		opErr = err

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -524,9 +524,32 @@ func (s *Store) LinkFileNode(ctx context.Context, srcPath, dstPath, dstParentPat
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if err := s.LinkFileNodeTx(ctx, tx, srcPath, dstPath, dstParentPath, dstName, nodeID, createdAt); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// LinkFileNodeTx creates a hardlink node inside an existing transaction.
+func (s *Store) LinkFileNodeTx(ctx context.Context, db execer, srcPath, dstPath, dstParentPath, dstName, nodeID string, createdAt time.Time) error {
+	if dstParentPath != "/" {
+		var parentIsDir bool
+		err := db.QueryRowContext(ctx, `SELECT is_directory FROM file_nodes WHERE path = ? FOR UPDATE`, dstParentPath).
+			Scan(&parentIsDir)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return err
+		}
+		if !parentIsDir {
+			return ErrNotFound
+		}
+	}
+
 	var fileID, inodeID sql.NullString
 	var isDir bool
-	err = tx.QueryRowContext(ctx, `SELECT file_id, inode_id, is_directory FROM file_nodes WHERE path = ? FOR UPDATE`, srcPath).
+	err := db.QueryRowContext(ctx, `SELECT file_id, inode_id, is_directory FROM file_nodes WHERE path = ? FOR UPDATE`, srcPath).
 		Scan(&fileID, &inodeID, &isDir)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -540,14 +563,14 @@ func (s *Store) LinkFileNode(ctx context.Context, srcPath, dstPath, dstParentPat
 	if !fileID.Valid || fileID.String == "" {
 		return ErrNotFound
 	}
-	if err := s.lockConfirmedFileForAttachTx(tx, fileID.String); err != nil {
+	if err := s.lockConfirmedFileForAttachTx(db, fileID.String); err != nil {
 		return err
 	}
 	linkInodeID := fileID.String
 	if inodeID.Valid && inodeID.String != "" {
 		linkInodeID = inodeID.String
 	}
-	_, err = tx.Exec(`INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, file_id, inode_id, created_at)
+	_, err = db.Exec(`INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, file_id, inode_id, created_at)
 		VALUES (?, ?, ?, ?, 0, ?, ?, ?)`,
 		nodeID, dstPath, dstParentPath, dstName, fileID.String, linkInodeID, createdAt.UTC())
 	if isUniqueViolation(err) {
@@ -556,7 +579,7 @@ func (s *Store) LinkFileNode(ctx context.Context, srcPath, dstPath, dstParentPat
 	if err != nil {
 		return err
 	}
-	return tx.Commit()
+	return nil
 }
 
 func (s *Store) EnsureParentDirs(ctx context.Context, path string, genID func() string) error {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -27,6 +27,7 @@ var (
 	ErrUploadNotActive         = errors.New("upload is not in UPLOADING state")
 	ErrUploadExpired           = errors.New("upload has expired")
 	ErrPathConflict            = errors.New("path already exists")
+	ErrInvalidLinkTarget       = errors.New("invalid link target")
 	ErrUploadConflict          = errors.New("active upload already exists for this path")
 	ErrIdempotencyConflict     = errors.New("duplicate idempotency key")
 	ErrJournalConflict         = errors.New("journal create conflict")
@@ -509,6 +510,53 @@ func (s *Store) RefCount(ctx context.Context, fileID string) (count int64, err e
 
 	err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM file_nodes WHERE file_id = ?`, fileID).Scan(&count)
 	return count, err
+}
+
+// LinkFileNode atomically creates dstPath as another directory entry for the
+// same confirmed file entity referenced by srcPath.
+func (s *Store) LinkFileNode(ctx context.Context, srcPath, dstPath, dstParentPath, dstName, nodeID string, createdAt time.Time) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "link_file_node", start, &err)
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var fileID, inodeID sql.NullString
+	var isDir bool
+	err = tx.QueryRowContext(ctx, `SELECT file_id, inode_id, is_directory FROM file_nodes WHERE path = ? FOR UPDATE`, srcPath).
+		Scan(&fileID, &inodeID, &isDir)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
+	if isDir {
+		return ErrInvalidLinkTarget
+	}
+	if !fileID.Valid || fileID.String == "" {
+		return ErrNotFound
+	}
+	if err := s.lockConfirmedFileForAttachTx(tx, fileID.String); err != nil {
+		return err
+	}
+	linkInodeID := fileID.String
+	if inodeID.Valid && inodeID.String != "" {
+		linkInodeID = inodeID.String
+	}
+	_, err = tx.Exec(`INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, file_id, inode_id, created_at)
+		VALUES (?, ?, ?, ?, 0, ?, ?, ?)`,
+		nodeID, dstPath, dstParentPath, dstName, fileID.String, linkInodeID, createdAt.UTC())
+	if isUniqueViolation(err) {
+		return ErrPathConflict
+	}
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) EnsureParentDirs(ctx context.Context, path string, genID func() string) error {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -512,6 +512,57 @@ func (s *Store) RefCount(ctx context.Context, fileID string) (count int64, err e
 	return count, err
 }
 
+// RefCounts returns path-reference counts for the supplied file IDs.
+func (s *Store) RefCounts(ctx context.Context, fileIDs []string) (counts map[string]int64, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "ref_counts", start, &err)
+
+	counts = make(map[string]int64)
+	seen := make(map[string]struct{}, len(fileIDs))
+	unique := make([]string, 0, len(fileIDs))
+	for _, fileID := range fileIDs {
+		if fileID == "" {
+			continue
+		}
+		if _, ok := seen[fileID]; ok {
+			continue
+		}
+		seen[fileID] = struct{}{}
+		unique = append(unique, fileID)
+	}
+	const batchSize = 500
+	for start := 0; start < len(unique); start += batchSize {
+		end := start + batchSize
+		if end > len(unique) {
+			end = len(unique)
+		}
+		batch := unique[start:end]
+		rows, err := s.db.QueryContext(ctx,
+			`SELECT file_id, COUNT(*) FROM file_nodes WHERE file_id IN (`+questionPlaceholders(len(batch))+`) GROUP BY file_id`,
+			stringsToAny(batch)...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var fileID string
+			var count int64
+			if err := rows.Scan(&fileID, &count); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			counts[fileID] = count
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
+	}
+	return counts, nil
+}
+
 // LinkFileNode atomically creates dstPath as another directory entry for the
 // same confirmed file entity referenced by srcPath.
 func (s *Store) LinkFileNode(ctx context.Context, srcPath, dstPath, dstParentPath, dstName, nodeID string, createdAt time.Time) (err error) {

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -572,6 +572,70 @@ func TestZeroCopyCp(t *testing.T) {
 	}
 }
 
+func TestLinkFileNodeSharesFileAndRefCount(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	if err := s.InsertFile(ctx, &File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		SizeBytes: 50, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(ctx, &FileNode{
+		NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt",
+		FileID: "f1", InodeID: "f1", CreatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.LinkFileNode(ctx, "/a.txt", "/b.txt", "/", "b.txt", "n2", now); err != nil {
+		t.Fatalf("LinkFileNode: %v", err)
+	}
+	dst, err := s.GetNode(ctx, "/b.txt")
+	if err != nil {
+		t.Fatalf("GetNode(dst): %v", err)
+	}
+	if dst.FileID != "f1" || dst.InodeID != "f1" {
+		t.Fatalf("dst identity = file %q inode %q, want f1/f1", dst.FileID, dst.InodeID)
+	}
+	count, err := s.RefCount(ctx, "f1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("refcount = %d, want 2", count)
+	}
+	if err := s.LinkFileNode(ctx, "/a.txt", "/b.txt", "/", "b.txt", "n3", now); !errors.Is(err, ErrPathConflict) {
+		t.Fatalf("duplicate LinkFileNode error = %v, want ErrPathConflict", err)
+	}
+
+	deleted, err := s.DeleteFileWithRefCheck(ctx, "/a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != nil {
+		t.Fatalf("first unlink deleted file record: %+v", deleted)
+	}
+	deleted, err = s.DeleteFileWithRefCheck(ctx, "/b.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted == nil || deleted.Status != StatusDeleted {
+		t.Fatalf("last unlink deleted = %+v, want DELETED file", deleted)
+	}
+}
+
+func TestLinkFileNodeRejectsDirectorySource(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	if err := s.InsertNode(ctx, &FileNode{NodeID: "dir", Path: "/dir/", ParentPath: "/", Name: "dir", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.LinkFileNode(ctx, "/dir/", "/dir-link", "/", "dir-link", "n2", now); !errors.Is(err, ErrInvalidLinkTarget) {
+		t.Fatalf("LinkFileNode directory error = %v, want ErrInvalidLinkTarget", err)
+	}
+}
+
 func TestDeleteWithRefCount(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -636,6 +636,28 @@ func TestLinkFileNodeRejectsDirectorySource(t *testing.T) {
 	}
 }
 
+func TestLinkFileNodeRejectsMissingParent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	if err := s.InsertFile(ctx, &File{FileID: "f1", StorageType: StorageDB9, StorageRef: "/blobs/f1",
+		SizeBytes: 50, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(ctx, &FileNode{
+		NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt",
+		FileID: "f1", InodeID: "f1", CreatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.LinkFileNode(ctx, "/a.txt", "/missing/b.txt", "/missing/", "b.txt", "n2", now); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("LinkFileNode missing parent error = %v, want ErrNotFound", err)
+	}
+	if _, err := s.GetNode(ctx, "/missing/b.txt"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing-parent link created dst: %v", err)
+	}
+}
+
 func TestDeleteWithRefCount(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -604,6 +604,16 @@ func TestLinkFileNodeSharesFileAndRefCount(t *testing.T) {
 	if count != 2 {
 		t.Fatalf("refcount = %d, want 2", count)
 	}
+	counts, err := s.RefCounts(ctx, []string{"f1", "f1", "missing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts["f1"] != 2 {
+		t.Fatalf("batch refcount f1 = %d, want 2", counts["f1"])
+	}
+	if _, ok := counts["missing"]; ok {
+		t.Fatal("batch refcount returned missing file")
+	}
 	if err := s.LinkFileNode(ctx, "/a.txt", "/b.txt", "/", "b.txt", "n3", now); !errors.Is(err, ErrPathConflict) {
 		t.Fatalf("duplicate LinkFileNode error = %v, want ErrPathConflict", err)
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1410,6 +1410,17 @@ func isNotFoundErr(err error) bool {
 	return strings.Contains(msg, "not found") || strings.Contains(msg, "HTTP 404")
 }
 
+func isForbiddenErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var se *client.StatusError
+	if errors.As(err, &se) && se.StatusCode == http.StatusForbidden {
+		return true
+	}
+	return strings.Contains(err.Error(), "HTTP 403")
+}
+
 func isTransientLookupErr(err error) bool {
 	if err == nil {
 		return false
@@ -2001,6 +2012,60 @@ func (fs *Dat9FS) remotePathStatDetached(localPath string) (*client.StatResult, 
 	return stat, err
 }
 
+func (fs *Dat9FS) remoteHardlinkCommittedDetached(srcP, dstP string) bool {
+	dstStat, err := fs.remotePathStatDetached(dstP)
+	if err != nil || dstStat == nil || dstStat.IsDir || dstStat.ResourceID == "" {
+		return false
+	}
+	srcStat, err := fs.remotePathStatDetached(srcP)
+	if err != nil || srcStat == nil || srcStat.IsDir || srcStat.ResourceID == "" {
+		return false
+	}
+	return srcStat.ResourceID == dstStat.ResourceID
+}
+
+func (fs *Dat9FS) hardlinkRemoteWithTransientRecovery(ctx context.Context, srcP, dstP string) error {
+	srcRemote := fs.remotePath(srcP)
+	dstRemote := fs.remotePath(dstP)
+	mutationStart := fs.perfStart()
+	err := fs.client.HardlinkCtx(ctx, srcRemote, dstRemote)
+	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
+	if err == nil || !isTransientLookupErr(err) {
+		return err
+	}
+	if fs.remoteHardlinkCommittedDetached(srcP, dstP) {
+		return nil
+	}
+
+	retryCount := fs.lookupStatRetryCount()
+	if retryCount <= 0 {
+		return err
+	}
+
+	lastErr := err
+	for range retryCount {
+		retryCtx, retryCancel := context.WithTimeout(context.Background(), namespaceMutationRetryTimeout)
+		mutationStart = fs.perfStart()
+		err = fs.client.HardlinkCtx(retryCtx, srcRemote, dstRemote)
+		retryCancel()
+		fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
+		if err == nil {
+			return nil
+		}
+		if isConflictErr(err) && fs.remoteHardlinkCommittedDetached(srcP, dstP) {
+			return nil
+		}
+		if !isTransientLookupErr(err) {
+			return err
+		}
+		if fs.remoteHardlinkCommittedDetached(srcP, dstP) {
+			return nil
+		}
+		lastErr = err
+	}
+	return lastErr
+}
+
 func (fs *Dat9FS) mkdirRemoteWithTransientRetry(cancel <-chan struct{}, localPath string, mode uint32) error {
 	apiPath := fs.remotePath(localPath)
 	ctx, cf := fuseCtx(cancel)
@@ -2150,7 +2215,7 @@ func (fs *Dat9FS) lookupFromDirCache(parentPath, childP, name string, out *gofus
 		if mtime.IsZero() {
 			mtime = time.Now()
 		}
-		ino := fs.inodes.Lookup(childP, item.IsDir, item.Size, mtime)
+		ino := fs.inodes.LookupWithIdentity(childP, item.ResourceID, item.Nlink, item.IsDir, item.Size, mtime)
 		if item.Revision > 0 {
 			fs.inodes.UpdateRevision(ino, item.Revision)
 		}
@@ -2463,6 +2528,51 @@ func (fs *Dat9FS) hasPendingLocalState(p string) bool {
 
 func (fs *Dat9FS) hasQueuedCommit(p string) bool {
 	return fs.commitQueue != nil && fs.commitQueue.HasPath(p)
+}
+
+func (fs *Dat9FS) syncOpenSourceForHardlink(ctx context.Context, ino uint64) gofuse.Status {
+	type candidate struct {
+		fh       *FileHandle
+		dirtySeq uint64
+	}
+
+	var candidates []candidate
+	for _, fh := range fs.openHandles.SnapshotInode(ino) {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		needsSync := fh.Dirty != nil && (fh.IsNew || fh.Dirty.HasDirtyParts())
+		dirtySeq := fh.DirtySeq
+		fh.Unlock()
+		if needsSync {
+			candidates = append(candidates, candidate{fh: fh, dirtySeq: dirtySeq})
+		}
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].dirtySeq < candidates[j].dirtySeq
+	})
+
+	for _, c := range candidates {
+		fh := c.fh
+		fh.Lock()
+		if fh.Dirty == nil || (!fh.IsNew && !fh.Dirty.HasDirtyParts()) {
+			fh.Unlock()
+			continue
+		}
+		size := fh.Dirty.Size()
+		if fs.debouncer != nil {
+			fs.debouncer.Cancel(fh.Path)
+		}
+		syncCtx, cancel := context.WithTimeout(ctx, releaseTimeout(size))
+		st := fs.syncHandleToRemoteLocked(syncCtx, fh)
+		cancel()
+		fh.Unlock()
+		if st != gofuse.OK {
+			return st
+		}
+	}
+	return gofuse.OK
 }
 
 func (fs *Dat9FS) openHandleEntry(p string) (*InodeEntry, bool) {
@@ -3103,6 +3213,12 @@ func (fs *Dat9FS) Link(cancel <-chan struct{}, input *gofuse.LinkIn, name string
 	if _, rel, handled := fs.gitWorkspaceForPath(ctx, dstP); handled && rel != "" {
 		return gofuse.Status(syscall.ENOTSUP)
 	}
+	if fs.openHandles.Has(0, dstP) {
+		return gofuse.Status(syscall.EEXIST)
+	}
+	if st := fs.syncOpenSourceForHardlink(ctx, input.Oldnodeid); st != gofuse.OK {
+		return st
+	}
 	if fs.hasPendingLocalState(dstP) || fs.hasQueuedCommit(dstP) {
 		return gofuse.Status(syscall.EEXIST)
 	}
@@ -3121,15 +3237,12 @@ func (fs *Dat9FS) Link(cancel <-chan struct{}, input *gofuse.LinkIn, name string
 		}
 	}
 
-	mutationStart := fs.perfStart()
-	err := fs.client.HardlinkCtx(ctx, fs.remotePath(srcP), fs.remotePath(dstP))
-	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
-	if err != nil {
+	if err := fs.hardlinkRemoteWithTransientRecovery(ctx, srcP, dstP); err != nil {
 		return httpToFuseStatus(err)
 	}
 
 	stat, err := fs.client.StatCtx(ctx, fs.remotePath(dstP))
-	if err != nil {
+	if err != nil && !isForbiddenErr(err) {
 		return httpToFuseStatus(err)
 	}
 	mtime := time.Now()
@@ -3206,7 +3319,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		if err := overlay.Remove(childP); err != nil {
 			return localErrToFuseStatus(err)
 		}
-		fs.inodes.Remove(childP)
+		fs.inodes.RemoveLink(childP)
 		parentPath, _ := fs.inodes.GetPath(header.NodeId)
 		fs.dirCache.Remove(parentPath, name)
 		fs.cacheNegativePath(childP)
@@ -3306,7 +3419,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		}
 	}
 
-	fs.inodes.Remove(childP)
+	fs.inodes.RemoveLink(childP)
 	fs.invalidateReadCacheAndTargets(childP)
 
 	parentPath, _ := fs.inodes.GetPath(header.NodeId)
@@ -5391,7 +5504,13 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 // Caller must hold fh.mu. The method may temporarily release fh.mu around
 // network I/O, matching flushHandle's locking contract.
 func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) gofuse.Status {
-	if fh == nil || fh.Dirty == nil || !fh.Dirty.HasDirtyParts() {
+	if fh == nil || fh.Dirty == nil {
+		return gofuse.OK
+	}
+	if !fh.Dirty.HasDirtyParts() {
+		if fh.IsNew && fh.Dirty.Size() == 0 {
+			return fs.createEmptyHandleRemoteLocked(ctx, fh)
+		}
 		return gofuse.OK
 	}
 
@@ -5439,6 +5558,54 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 	}
 
 	return fs.flushHandle(ctx, fh)
+}
+
+func (fs *Dat9FS) createEmptyHandleRemoteLocked(ctx context.Context, fh *FileHandle) gofuse.Status {
+	expectedRevision := expectedRevisionForHandle(fh)
+	writeStart := time.Now()
+	fs.debugf("sync empty create start path=%s expected_rev=%d", fh.Path, expectedRevision)
+	committedRev, err := fs.client.CreateFileCtx(ctx, fs.remotePath(fh.Path))
+	if isCreateActionUnsupportedErr(err) {
+		fs.debugf("sync empty create unsupported path=%s fallback=small-write err=%v", fh.Path, err)
+		committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), nil, expectedRevision)
+	}
+	fs.perfRecordRemote(perfRemoteWrite, writeStart, err, 0)
+	fs.debugDurationf(writeStart, 0, "sync empty create done path=%s committed_rev=%d err=%v", fh.Path, committedRev, err)
+	if err != nil {
+		log.Printf("sync empty create failed for %s: %v", fh.Path, err)
+		return httpToFuseStatus(err)
+	}
+	if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
+		log.Printf("sync empty create pending chmod failed for %s: %v", fh.Path, err)
+		return httpToFuseStatus(err)
+	}
+
+	if fh.DirtySeq != 0 {
+		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+		fh.DirtySeq = 0
+	}
+	clearReadTargetForLockedHandle(fh)
+	if committedRev > 0 {
+		fh.IsNew = false
+		fh.BaseRev = committedRev
+		fs.inodes.UpdateRevision(fh.Ino, committedRev)
+		fs.readCache.Put(fh.Path, nil, committedRev)
+	} else {
+		fs.finalizeHandleFlushLocked(fh, expectedRevision)
+		fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
+	}
+	fs.inodes.UpdateSize(fh.Ino, 0)
+	fs.cacheFileForPath(fh.Path, 0, time.Now(), committedRev)
+	if fs.shadowStore != nil {
+		fs.shadowStore.Remove(fh.Path)
+		fh.ShadowReady = false
+		fh.ShadowSpill = false
+		fh.ShadowCommitReady = false
+	}
+	if fs.pendingIndex != nil {
+		fs.pendingIndex.Remove(fh.Path)
+	}
+	return gofuse.OK
 }
 
 func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status gofuse.Status) {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1257,14 +1257,20 @@ func (fs *Dat9FS) fillAttr(entry *InodeEntry, out *gofuse.Attr) {
 			mode = 0o777
 		}
 		out.Mode = uint32(syscall.S_IFLNK) | mode
-		out.Nlink = 1
+		out.Nlink = entry.Nlink
+		if out.Nlink == 0 {
+			out.Nlink = 1
+		}
 	} else {
 		mode := entry.Mode
 		if !entry.HasMode {
 			mode = 0644
 		}
 		out.Mode = syscall.S_IFREG | (mode & 0o777)
-		out.Nlink = 1
+		out.Nlink = entry.Nlink
+		if out.Nlink == 0 {
+			out.Nlink = 1
+		}
 	}
 }
 
@@ -1788,12 +1794,14 @@ func cachedFileInfos(items []client.FileInfo) []CachedFileInfo {
 			mtime = time.Unix(item.Mtime, 0)
 		}
 		cached[i] = CachedFileInfo{
-			Name:    item.Name,
-			Size:    item.Size,
-			IsDir:   item.IsDir,
-			Mtime:   mtime,
-			Mode:    item.Mode,
-			HasMode: item.HasMode,
+			Name:       item.Name,
+			Size:       item.Size,
+			IsDir:      item.IsDir,
+			Mtime:      mtime,
+			Mode:       item.Mode,
+			HasMode:    item.HasMode,
+			ResourceID: item.ResourceID,
+			Nlink:      item.Nlink,
 		}
 	}
 	return cached
@@ -1852,13 +1860,15 @@ func cachedInfoFromEntry(name string, entry *InodeEntry) CachedFileInfo {
 		mtime = time.Now()
 	}
 	return CachedFileInfo{
-		Name:     name,
-		Size:     entry.Size,
-		IsDir:    entry.IsDir,
-		Mtime:    mtime,
-		Revision: entry.Revision,
-		Mode:     entry.Mode,
-		HasMode:  entry.HasMode,
+		Name:       name,
+		Size:       entry.Size,
+		IsDir:      entry.IsDir,
+		Mtime:      mtime,
+		Revision:   entry.Revision,
+		Mode:       entry.Mode,
+		HasMode:    entry.HasMode,
+		ResourceID: entry.ResourceID,
+		Nlink:      entry.Nlink,
 	}
 }
 
@@ -1874,6 +1884,8 @@ func cachedInfoFromStat(name string, stat *client.StatResult) CachedFileInfo {
 		item.Revision = stat.Revision
 		item.HasMode = stat.HasMode
 		item.Mode = stat.Mode
+		item.ResourceID = stat.ResourceID
+		item.Nlink = stat.Nlink
 	}
 	return item
 }
@@ -2368,7 +2380,7 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 				if item.Mtime > 0 {
 					mtime = time.Unix(item.Mtime, 0)
 				}
-				ino := fs.inodes.Lookup(childP, item.IsDir, item.Size, mtime)
+				ino := fs.inodes.LookupWithIdentity(childP, item.ResourceID, item.Nlink, item.IsDir, item.Size, mtime)
 				if item.HasMode {
 					fs.inodes.UpdateMode(ino, item.Mode)
 				}
@@ -2392,7 +2404,7 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	if !stat.Mtime.IsZero() {
 		mtime = stat.Mtime
 	}
-	ino := fs.inodes.Lookup(childP, stat.IsDir, stat.Size, mtime)
+	ino := fs.inodes.LookupWithIdentity(childP, stat.ResourceID, stat.Nlink, stat.IsDir, stat.Size, mtime)
 	// Store server revision for cache validation.
 	if stat.Revision > 0 {
 		fs.inodes.UpdateRevision(ino, stat.Revision)
@@ -2564,6 +2576,11 @@ func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *
 			entry.Size = stat.Size
 			entry.IsDir = stat.IsDir
 			fs.inodes.UpdateSize(input.NodeId, stat.Size)
+			if stat.ResourceID != "" || stat.Nlink > 0 {
+				fs.inodes.SetIdentity(input.NodeId, stat.ResourceID, stat.Nlink)
+				entry.ResourceID = stat.ResourceID
+				entry.Nlink = stat.Nlink
+			}
 			if stat.Revision > 0 {
 				fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
 			}
@@ -2588,6 +2605,11 @@ func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *
 			entry.Size = stat.Size
 			entry.IsDir = stat.IsDir
 			fs.inodes.UpdateSize(input.NodeId, stat.Size)
+			if stat.ResourceID != "" || stat.Nlink > 0 {
+				fs.inodes.SetIdentity(input.NodeId, stat.ResourceID, stat.Nlink)
+				entry.ResourceID = stat.ResourceID
+				entry.Nlink = stat.Nlink
+			}
 			if stat.Revision > 0 {
 				fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
 			}
@@ -2980,6 +3002,9 @@ func (fs *Dat9FS) Symlink(cancel <-chan struct{}, header *gofuse.InHeader, point
 	ino := fs.inodes.Lookup(childP, false, int64(len(pointedTo)), time.Now())
 	fs.inodes.UpdateMode(ino, mode)
 	if stat, err := fs.client.StatCtx(ctx, fs.remotePath(childP)); err == nil && stat != nil {
+		if stat.ResourceID != "" || stat.Nlink > 0 {
+			fs.inodes.SetIdentity(ino, stat.ResourceID, stat.Nlink)
+		}
 		if stat.Revision > 0 {
 			fs.inodes.UpdateRevision(ino, stat.Revision)
 		}
@@ -3000,6 +3025,153 @@ func (fs *Dat9FS) Symlink(cancel <-chan struct{}, header *gofuse.InHeader, point
 	parentPath, _ := fs.inodes.GetPath(header.NodeId)
 	fs.dirCache.Upsert(parentPath, cachedInfoFromEntry(linkName, entry))
 	fs.invalidateReadCacheAndTargets(childP)
+	fs.fillEntryOut(entry, out)
+	return gofuse.OK
+}
+
+func (fs *Dat9FS) Link(cancel <-chan struct{}, input *gofuse.LinkIn, name string, out *gofuse.EntryOut) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseLink, perfStart, status, 0) }()
+	if fs.opts.ReadOnly {
+		return gofuse.EROFS
+	}
+
+	srcEntry, ok := fs.inodes.GetEntry(input.Oldnodeid)
+	if !ok {
+		return gofuse.ENOENT
+	}
+	if srcEntry.IsDir {
+		return gofuse.Status(syscall.EPERM)
+	}
+	srcP := srcEntry.Path
+	if srcP == "" {
+		return gofuse.ENOENT
+	}
+	dstP, st := fs.childPath(input.NodeId, name)
+	if st != gofuse.OK {
+		return st
+	}
+	if srcP == dstP {
+		return gofuse.Status(syscall.EEXIST)
+	}
+
+	ctx, cf := fuseCtx(cancel)
+	defer cf()
+
+	srcLayer := fs.observePathPolicyWithContext(ctx, srcP)
+	dstLayer := fs.observePathPolicyWithContext(ctx, dstP)
+	if srcLayer == PathLayerLocalOnly || dstLayer == PathLayerLocalOnly {
+		if srcLayer != dstLayer {
+			return gofuse.Status(syscall.EXDEV)
+		}
+		if fs.localOverlay == nil {
+			return gofuse.EIO
+		}
+		if err := fs.ensureGitStateForLocalPath(ctx, srcP); err != nil {
+			return httpToFuseStatus(err)
+		}
+		if err := fs.ensureGitStateForLocalPath(ctx, dstP); err != nil {
+			return httpToFuseStatus(err)
+		}
+		if err := fs.localOverlay.Link(srcP, dstP); err != nil {
+			return localErrToFuseStatus(err)
+		}
+		info, err := fs.localOverlay.Lstat(dstP)
+		if err != nil {
+			return localErrToFuseStatus(err)
+		}
+		mode, hasMode, isDir := inodeModeFromFileInfo(info)
+		if isDir {
+			return gofuse.Status(syscall.EPERM)
+		}
+		if !fs.inodes.AddAlias(input.Oldnodeid, dstP, "", srcEntry.Nlink+1, false, info.Size(), info.ModTime()) {
+			return gofuse.EIO
+		}
+		fs.inodes.SetModeState(input.Oldnodeid, mode, hasMode)
+		entry, ok := fs.inodes.GetEntry(input.Oldnodeid)
+		if !ok {
+			return gofuse.EIO
+		}
+		parentPath, _ := fs.inodes.GetPath(input.NodeId)
+		fs.dirCache.Upsert(parentPath, cachedInfoFromEntry(name, entry))
+		fs.fillEntryOut(entry, out)
+		return gofuse.OK
+	}
+	if _, rel, handled := fs.gitWorkspaceForPath(ctx, srcP); handled && rel != "" {
+		return gofuse.Status(syscall.ENOTSUP)
+	}
+	if _, rel, handled := fs.gitWorkspaceForPath(ctx, dstP); handled && rel != "" {
+		return gofuse.Status(syscall.ENOTSUP)
+	}
+	if fs.hasPendingLocalState(dstP) || fs.hasQueuedCommit(dstP) {
+		return gofuse.Status(syscall.EEXIST)
+	}
+	if fs.commitQueue != nil {
+		fs.commitQueue.WaitPath(srcP)
+		fs.commitQueue.WaitPath(dstP)
+	}
+	if fs.writeBack != nil && fs.uploader != nil {
+		fs.uploader.WaitPath(srcP)
+		fs.uploader.WaitPath(dstP)
+		if err := fs.flushPendingWriteBack(ctx, srcP); err != nil {
+			return httpToFuseStatus(err)
+		}
+		if fs.hasPendingLocalState(dstP) {
+			return gofuse.Status(syscall.EEXIST)
+		}
+	}
+
+	mutationStart := fs.perfStart()
+	err := fs.client.HardlinkCtx(ctx, fs.remotePath(srcP), fs.remotePath(dstP))
+	fs.perfRecordRemote(perfRemoteMutation, mutationStart, err, 0)
+	if err != nil {
+		return httpToFuseStatus(err)
+	}
+
+	stat, err := fs.client.StatCtx(ctx, fs.remotePath(dstP))
+	if err != nil {
+		return httpToFuseStatus(err)
+	}
+	mtime := time.Now()
+	if stat != nil && !stat.Mtime.IsZero() {
+		mtime = stat.Mtime
+	}
+	resourceID := srcEntry.ResourceID
+	nlink := srcEntry.Nlink + 1
+	size := srcEntry.Size
+	isDir := false
+	if stat != nil {
+		if stat.ResourceID != "" {
+			resourceID = stat.ResourceID
+		}
+		if stat.Nlink > 0 {
+			nlink = stat.Nlink
+		}
+		size = stat.Size
+		isDir = stat.IsDir
+	}
+	fs.inodes.SetIdentity(input.Oldnodeid, resourceID, nlink)
+	if !fs.inodes.AddAlias(input.Oldnodeid, dstP, resourceID, nlink, isDir, size, mtime) {
+		return gofuse.EIO
+	}
+	if stat != nil {
+		if stat.Revision > 0 {
+			fs.inodes.UpdateRevision(input.Oldnodeid, stat.Revision)
+		}
+		if stat.HasMode {
+			fs.inodes.UpdateMode(input.Oldnodeid, stat.Mode)
+		}
+	}
+	entry, ok := fs.inodes.GetEntry(input.Oldnodeid)
+	if !ok {
+		return gofuse.EIO
+	}
+	parentPath, _ := fs.inodes.GetPath(input.NodeId)
+	fs.dirCache.Upsert(parentPath, cachedInfoFromEntry(name, entry))
+	if srcParent := parentDir(srcP); srcParent != parentPath {
+		fs.dirCache.Invalidate(srcParent)
+	}
+	fs.invalidateReadCacheAndTargets(dstP)
 	fs.fillEntryOut(entry, out)
 	return gofuse.OK
 }
@@ -3749,6 +3921,8 @@ func (fs *Dat9FS) recreateDirEntryInode(dirPath string, e DirEntry) uint64 {
 	var revision int64
 	var mode uint32
 	hasMode := false
+	var resourceID string
+	var nlink uint32
 
 	if e.HasMetadata {
 		isDir = e.IsDir
@@ -3759,6 +3933,8 @@ func (fs *Dat9FS) recreateDirEntryInode(dirPath string, e DirEntry) uint64 {
 		revision = e.Revision
 		mode = e.AttrMode
 		hasMode = e.HasMode
+		resourceID = e.ResourceID
+		nlink = e.Nlink
 	} else if item, ok := fs.dirEntryMetadata(dirPath, childP, e.Name); ok {
 		isDir = item.IsDir
 		size = item.Size
@@ -3768,9 +3944,11 @@ func (fs *Dat9FS) recreateDirEntryInode(dirPath string, e DirEntry) uint64 {
 		revision = item.Revision
 		mode = item.Mode
 		hasMode = item.HasMode
+		resourceID = item.ResourceID
+		nlink = item.Nlink
 	}
 
-	ino := fs.inodes.EnsureInodeNoUpdate(childP, isDir, size, mtime)
+	ino := fs.inodes.EnsureInodeWithIdentity(childP, resourceID, nlink, isDir, size, mtime)
 	if revision > 0 {
 		fs.inodes.UpdateRevision(ino, revision)
 	}
@@ -3811,6 +3989,8 @@ func dirEntryFromCachedInfo(item CachedFileInfo, ino uint64) DirEntry {
 		AttrMode:    item.Mode,
 		HasMode:     item.HasMode,
 		IsDir:       item.IsDir,
+		ResourceID:  item.ResourceID,
+		Nlink:       item.Nlink,
 		HasMetadata: true,
 	}
 }
@@ -3900,6 +4080,8 @@ func (fs *Dat9FS) applyBatchStats(ctx context.Context, dirPath string, items []C
 			item.Revision = result.Revision
 			item.HasMode = result.HasMode
 			item.Mode = result.Mode
+			item.ResourceID = result.ResourceID
+			item.Nlink = result.Nlink
 		}
 	}
 }
@@ -4068,7 +4250,7 @@ func (fs *Dat9FS) cachedToDirEntries(dirPath string, items []CachedFileInfo) []D
 		if mtime.IsZero() {
 			mtime = time.Now()
 		}
-		ino := fs.inodes.EnsureInode(childP, item.IsDir, item.Size, mtime)
+		ino := fs.inodes.EnsureInodeWithIdentity(childP, item.ResourceID, item.Nlink, item.IsDir, item.Size, mtime)
 		if item.Revision > 0 {
 			fs.inodes.UpdateRevision(ino, item.Revision)
 		}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1676,6 +1676,9 @@ func TestLinkCreatesRemoteHardlinkAndCachesAlias(t *testing.T) {
 	if !ok {
 		t.Fatal("source entry missing")
 	}
+	if entry.Path != "/dst.txt" {
+		t.Fatalf("primary path = %q, want /dst.txt", entry.Path)
+	}
 	if _, ok := entry.Paths["/src.txt"]; !ok {
 		t.Fatalf("entry paths missing src alias: %+v", entry.Paths)
 	}
@@ -1684,6 +1687,211 @@ func TestLinkCreatesRemoteHardlinkAndCachesAlias(t *testing.T) {
 	}
 	if cached := fs.dirCache.Lookup("/", "dst.txt"); cached.kind != namespaceLookupPositive || cached.item.Nlink != 2 {
 		t.Fatalf("cached dst = %+v, want positive nlink 2", cached)
+	}
+}
+
+func TestLinkRecoversCommittedHardlinkAfterTransientError(t *testing.T) {
+	var postCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			postCalls.Add(1)
+			w.WriteHeader(statusClientClosedRequest)
+		case http.MethodHead:
+			if r.URL.Path != "/v1/fs/src.txt" && r.URL.Path != "/v1/fs/dst.txt" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Length", "6")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "2")
+			w.Header().Set("X-Dat9-Resource-ID", "file-1")
+			w.Header().Set("X-Dat9-Nlink", "2")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	srcIno := fs.inodes.LookupWithIdentity("/src.txt", "file-1", 1, false, 6, time.Now())
+
+	var out gofuse.EntryOut
+	st := fs.Link(nil, &gofuse.LinkIn{
+		InHeader:  gofuse.InHeader{NodeId: 1},
+		Oldnodeid: srcIno,
+	}, "dst.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Link status = %v, want OK", st)
+	}
+	if got := postCalls.Load(); got != 1 {
+		t.Fatalf("POST calls = %d, want 1 recovery stat without retry", got)
+	}
+	if out.NodeId != srcIno || out.Nlink != 2 {
+		t.Fatalf("entry out = node %d nlink %d, want node %d nlink 2", out.NodeId, out.Nlink, srcIno)
+	}
+}
+
+func TestLinkKeepsDestinationPathWhenDestinationStatForbidden(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodHead:
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	srcIno := fs.inodes.LookupWithIdentity("/src.txt", "file-1", 1, false, 6, time.Now())
+
+	var out gofuse.EntryOut
+	st := fs.Link(nil, &gofuse.LinkIn{
+		InHeader:  gofuse.InHeader{NodeId: 1},
+		Oldnodeid: srcIno,
+	}, "dst.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Link status = %v, want OK", st)
+	}
+	if out.NodeId != srcIno || out.Nlink != 2 {
+		t.Fatalf("entry out = node %d nlink %d, want node %d nlink 2", out.NodeId, out.Nlink, srcIno)
+	}
+	entry, ok := fs.inodes.GetEntry(srcIno)
+	if !ok {
+		t.Fatal("source entry missing")
+	}
+	if entry.Path != "/dst.txt" {
+		t.Fatalf("primary path = %q, want /dst.txt", entry.Path)
+	}
+	if entry.ResourceID != "file-1" {
+		t.Fatalf("resource id = %q, want file-1", entry.ResourceID)
+	}
+}
+
+func TestLinkSyncsDirtyOpenSourceAndRejectsOpenDestination(t *testing.T) {
+	var putCalls atomic.Int32
+	var postCalls atomic.Int32
+	var putBody string
+	var putMu sync.Mutex
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putCalls.Add(1)
+			body, _ := io.ReadAll(r.Body)
+			putMu.Lock()
+			putBody = string(body)
+			putMu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"revision":1}`))
+		case http.MethodPost:
+			postCalls.Add(1)
+			if got := r.Header.Get("X-Dat9-Hardlink-Source"); got != "/src.txt" {
+				t.Errorf("hardlink source header = %q, want /src.txt", got)
+			}
+			w.WriteHeader(http.StatusOK)
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "5")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.Header().Set("X-Dat9-Resource-ID", "file-1")
+			w.Header().Set("X-Dat9-Nlink", "2")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	srcIno := fs.inodes.Lookup("/src.txt", false, 0, time.Now())
+	dirty := fs.newWriteBuffer("/src.txt", 1024, 0)
+	if _, err := dirty.Write(0, []byte("dirty")); err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{Ino: srcIno, Path: "/src.txt", Dirty: dirty, IsNew: true}
+	fh.DirtySeq = fs.markDirtySize(srcIno, dirty.Size())
+	fs.openHandles.Add(fh)
+
+	var out gofuse.EntryOut
+	st := fs.Link(nil, &gofuse.LinkIn{
+		InHeader:  gofuse.InHeader{NodeId: 1},
+		Oldnodeid: srcIno,
+	}, "dst.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("dirty source Link status = %v, want OK", st)
+	}
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want 1 source sync before hardlink", got)
+	}
+	if got := postCalls.Load(); got != 1 {
+		t.Fatalf("POST calls = %d, want 1 hardlink", got)
+	}
+	putMu.Lock()
+	gotBody := putBody
+	putMu.Unlock()
+	if gotBody != "dirty" {
+		t.Fatalf("synced body = %q, want dirty", gotBody)
+	}
+	fh.Lock()
+	if fh.IsNew || fh.DirtySeq != 0 || fh.Dirty.HasDirtyParts() {
+		t.Fatalf("source handle not clean after hardlink sync: isNew=%t dirtySeq=%d dirty=%t", fh.IsNew, fh.DirtySeq, fh.Dirty.HasDirtyParts())
+	}
+	fh.Unlock()
+	fs.openHandles.Remove(fh)
+
+	dstIno := fs.inodes.Lookup("/dst.txt", false, 0, time.Now())
+	dstHandle := &FileHandle{Ino: dstIno, Path: "/dst.txt"}
+	fs.openHandles.Add(dstHandle)
+	st = fs.Link(nil, &gofuse.LinkIn{
+		InHeader:  gofuse.InHeader{NodeId: 1},
+		Oldnodeid: srcIno,
+	}, "dst.txt", &out)
+	if st != gofuse.Status(syscall.EEXIST) {
+		t.Fatalf("open destination Link status = %v, want EEXIST", st)
+	}
+	if got := postCalls.Load(); got != 1 {
+		t.Fatalf("POST calls = %d, want no extra hardlink while destination is open", got)
+	}
+}
+
+func TestLookupFromDirCachePreservesHardlinkIdentity(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	srcIno := fs.inodes.LookupWithIdentity("/src.txt", "file-1", 2, false, 6, time.Now())
+	fs.dirCache.Upsert("/", CachedFileInfo{
+		Name:       "dst.txt",
+		Size:       6,
+		IsDir:      false,
+		Mtime:      time.Now(),
+		ResourceID: "file-1",
+		Nlink:      2,
+	})
+
+	var out gofuse.EntryOut
+	handled, st := fs.lookupFromDirCache("/", "/dst.txt", "dst.txt", &out)
+	if !handled || st != gofuse.OK {
+		t.Fatalf("lookupFromDirCache handled/status = %v/%v, want true/OK", handled, st)
+	}
+	if out.NodeId != srcIno {
+		t.Fatalf("cached hardlink node = %d, want source inode %d", out.NodeId, srcIno)
+	}
+	entry, ok := fs.inodes.GetEntry(srcIno)
+	if !ok {
+		t.Fatal("source entry missing")
+	}
+	if _, ok := entry.Paths["/dst.txt"]; !ok {
+		t.Fatalf("entry paths missing cached dst alias: %+v", entry.Paths)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1613,6 +1613,80 @@ func TestSymlinkCreatesRemoteLinkAndCachesEntry(t *testing.T) {
 	}
 }
 
+func TestLinkCreatesRemoteHardlinkAndCachesAlias(t *testing.T) {
+	var gotSource string
+	var postCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			postCalls.Add(1)
+			if r.URL.Path != "/v1/fs/dst.txt" {
+				t.Errorf("POST path = %s, want /v1/fs/dst.txt", r.URL.Path)
+			}
+			if got := r.URL.Query().Get("hardlink"); got != "1" {
+				t.Errorf("hardlink query = %q, want 1", got)
+			}
+			gotSource = r.Header.Get("X-Dat9-Hardlink-Source")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+		case http.MethodHead:
+			if r.URL.Path != "/v1/fs/dst.txt" {
+				t.Errorf("HEAD path = %s, want /v1/fs/dst.txt", r.URL.Path)
+			}
+			w.Header().Set("Content-Length", "6")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "2")
+			w.Header().Set("X-Dat9-Resource-ID", "file-1")
+			w.Header().Set("X-Dat9-Nlink", "2")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	srcIno := fs.inodes.LookupWithIdentity("/src.txt", "file-1", 1, false, 6, time.Now())
+
+	var out gofuse.EntryOut
+	st := fs.Link(nil, &gofuse.LinkIn{
+		InHeader:  gofuse.InHeader{NodeId: 1},
+		Oldnodeid: srcIno,
+	}, "dst.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Link status = %v, want OK", st)
+	}
+	if gotSource != "/src.txt" {
+		t.Fatalf("posted source = %q, want /src.txt", gotSource)
+	}
+	if got := postCalls.Load(); got != 1 {
+		t.Fatalf("POST calls = %d, want 1", got)
+	}
+	if out.NodeId != srcIno {
+		t.Fatalf("linked node id = %d, want source inode %d", out.NodeId, srcIno)
+	}
+	if out.Nlink != 2 {
+		t.Fatalf("entry nlink = %d, want 2", out.Nlink)
+	}
+	if dstIno, ok := fs.inodes.GetInode("/dst.txt"); !ok || dstIno != srcIno {
+		t.Fatalf("dst inode = %d/%v, want %d/true", dstIno, ok, srcIno)
+	}
+	entry, ok := fs.inodes.GetEntry(srcIno)
+	if !ok {
+		t.Fatal("source entry missing")
+	}
+	if _, ok := entry.Paths["/src.txt"]; !ok {
+		t.Fatalf("entry paths missing src alias: %+v", entry.Paths)
+	}
+	if _, ok := entry.Paths["/dst.txt"]; !ok {
+		t.Fatalf("entry paths missing dst alias: %+v", entry.Paths)
+	}
+	if cached := fs.dirCache.Lookup("/", "dst.txt"); cached.kind != namespaceLookupPositive || cached.item.Nlink != 2 {
+		t.Fatalf("cached dst = %+v, want positive nlink 2", cached)
+	}
+}
+
 func TestSymlinkRecoversWhenInterruptedAfterRemoteCreate(t *testing.T) {
 	const target = "../target"
 	symlinkMode := uint32(syscall.S_IFLNK) | 0o777

--- a/pkg/fuse/dir.go
+++ b/pkg/fuse/dir.go
@@ -14,13 +14,15 @@ const (
 
 // CachedFileInfo matches the client.FileInfo shape but avoids importing client.
 type CachedFileInfo struct {
-	Name     string
-	Size     int64
-	IsDir    bool
-	Mtime    time.Time
-	Revision int64
-	Mode     uint32 // permission bits
-	HasMode  bool   // true when Mode is explicitly known (including 0)
+	Name       string
+	Size       int64
+	IsDir      bool
+	Mtime      time.Time
+	Revision   int64
+	Mode       uint32 // permission bits
+	HasMode    bool   // true when Mode is explicitly known (including 0)
+	ResourceID string
+	Nlink      uint32
 }
 
 type namespaceLookupKind uint8

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -66,15 +66,18 @@ type DirHandle struct {
 
 // DirEntry is a simplified directory entry for FUSE readdir.
 type DirEntry struct {
-	Name        string
-	Ino         uint64
-	Mode        uint32 // S_IFDIR or S_IFREG
-	Size        int64
-	Mtime       time.Time
-	Revision    int64
-	AttrMode    uint32
-	HasMode     bool
-	IsDir       bool
+	Name       string
+	Ino        uint64
+	Mode       uint32 // S_IFDIR or S_IFREG
+	Size       int64
+	Mtime      time.Time
+	Revision   int64
+	AttrMode   uint32
+	HasMode    bool
+	IsDir      bool
+	ResourceID string
+	Nlink      uint32
+
 	HasMetadata bool
 }
 

--- a/pkg/fuse/inode.go
+++ b/pkg/fuse/inode.go
@@ -314,9 +314,10 @@ func (m *InodeToPath) AddAlias(ino uint64, path, resourceID string, nlink uint32
 		return false
 	}
 	if replaced, exists := m.byPath[path]; exists && replaced != ino {
-		m.removePathLocked(path)
+		m.removePathLocked(path, false)
 	}
 	m.addPathLocked(entry, path)
+	entry.Path = path
 	entry.Nlookup++
 	m.updateEntryLocked(entry, path, resourceID, nlink, isDir, size, mtime)
 	return true
@@ -413,7 +414,7 @@ func (m *InodeToPath) Rename(oldPath, newPath string) {
 	// Update the entry itself.
 	delete(m.byPath, oldPath)
 	if replacedIno, ok := m.byPath[newPath]; ok && replacedIno != ino {
-		m.removePathLocked(newPath)
+		m.removePathLocked(newPath, false)
 	}
 	m.byPath[newPath] = ino
 	if entry.Paths == nil {
@@ -478,7 +479,15 @@ func (m *InodeToPath) Remove(path string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.removePathLocked(path)
+	m.removePathLocked(path, false)
+}
+
+// RemoveLink removes one path mapping for a successful unlink-like operation.
+func (m *InodeToPath) RemoveLink(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.removePathLocked(path, true)
 }
 
 func inodeResourceKey(resourceID string, isDir bool) string {
@@ -540,7 +549,7 @@ func (m *InodeToPath) removeEntryLocked(ino uint64, entry *InodeEntry) {
 	delete(m.byInode, ino)
 }
 
-func (m *InodeToPath) removePathLocked(path string) {
+func (m *InodeToPath) removePathLocked(path string, consumeLink bool) {
 	ino, ok := m.byPath[path]
 	if !ok {
 		return
@@ -552,7 +561,7 @@ func (m *InodeToPath) removePathLocked(path string) {
 	}
 	delete(m.byPath, path)
 	delete(entry.Paths, path)
-	if !entry.IsDir && entry.Nlink > 1 {
+	if consumeLink && !entry.IsDir && entry.Nlink > 1 {
 		entry.Nlink--
 	}
 	if entry.Path == path {

--- a/pkg/fuse/inode.go
+++ b/pkg/fuse/inode.go
@@ -8,15 +8,18 @@ import (
 
 // InodeEntry holds metadata for a single inode in the FUSE filesystem.
 type InodeEntry struct {
-	Ino      uint64
-	Path     string
-	IsDir    bool
-	Nlookup  int64 // kernel lookup reference count
-	Size     int64
-	Mtime    time.Time
-	Mode     uint32 // permission bits
-	HasMode  bool   // true when mode is explicitly known (including 0)
-	Revision int64  // server-side revision for cache validation
+	Ino        uint64
+	Path       string
+	Paths      map[string]struct{}
+	ResourceID string
+	Nlink      uint32
+	IsDir      bool
+	Nlookup    int64 // kernel lookup reference count
+	Size       int64
+	Mtime      time.Time
+	Mode       uint32 // permission bits
+	HasMode    bool   // true when mode is explicitly known (including 0)
+	Revision   int64  // server-side revision for cache validation
 }
 
 // InodeToPath provides a bidirectional mapping between inode numbers and
@@ -25,6 +28,7 @@ type InodeToPath struct {
 	mu      sync.RWMutex
 	byInode map[uint64]*InodeEntry
 	byPath  map[string]uint64
+	byID    map[string]uint64
 	nextIno uint64
 }
 
@@ -34,12 +38,15 @@ func NewInodeToPath() *InodeToPath {
 	root := &InodeEntry{
 		Ino:     1,
 		Path:    "/",
+		Paths:   map[string]struct{}{"/": {}},
 		IsDir:   true,
+		Nlink:   2,
 		Nlookup: 1,
 	}
 	return &InodeToPath{
 		byInode: map[uint64]*InodeEntry{1: root},
 		byPath:  map[string]uint64{"/": 1},
+		byID:    make(map[string]uint64),
 		nextIno: 2,
 	}
 }
@@ -48,30 +55,53 @@ func NewInodeToPath() *InodeToPath {
 // Nlookup count is incremented and its size/mtime are updated. If the path
 // does not exist, a new inode is allocated and an entry is created.
 func (m *InodeToPath) Lookup(path string, isDir bool, size int64, mtime time.Time) uint64 {
+	return m.LookupWithIdentity(path, "", 0, isDir, size, mtime)
+}
+
+// LookupWithIdentity is like Lookup, but non-directory entries with a stable
+// resourceID share one FUSE inode across all known hardlink paths.
+func (m *InodeToPath) LookupWithIdentity(path, resourceID string, nlink uint32, isDir bool, size int64, mtime time.Time) uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if ino, ok := m.byPath[path]; ok {
 		entry := m.byInode[ino]
 		entry.Nlookup++
-		entry.Size = size
-		entry.Mtime = mtime
+		m.updateEntryLocked(entry, path, resourceID, nlink, isDir, size, mtime)
 		return ino
+	}
+	if key := inodeResourceKey(resourceID, isDir); key != "" {
+		if ino, ok := m.byID[key]; ok {
+			entry := m.byInode[ino]
+			entry.Nlookup++
+			m.addPathLocked(entry, path)
+			m.updateEntryLocked(entry, path, resourceID, nlink, isDir, size, mtime)
+			return ino
+		}
 	}
 
 	ino := m.nextIno
 	m.nextIno++
 
 	entry := &InodeEntry{
-		Ino:     ino,
-		Path:    path,
-		IsDir:   isDir,
-		Nlookup: 1,
-		Size:    size,
-		Mtime:   mtime,
+		Ino:        ino,
+		Path:       path,
+		Paths:      map[string]struct{}{path: {}},
+		ResourceID: inodeResourceKey(resourceID, isDir),
+		Nlink:      nlink,
+		IsDir:      isDir,
+		Nlookup:    1,
+		Size:       size,
+		Mtime:      mtime,
+	}
+	if entry.Nlink == 0 && !entry.IsDir {
+		entry.Nlink = 1
 	}
 	m.byInode[ino] = entry
 	m.byPath[path] = ino
+	if entry.ResourceID != "" {
+		m.byID[entry.ResourceID] = ino
+	}
 	return ino
 }
 
@@ -79,29 +109,51 @@ func (m *InodeToPath) Lookup(path string, isDir bool, size int64, mtime time.Tim
 // not exist. Unlike Lookup, it does NOT increment the Nlookup counter. Use
 // this for readdir entries where the kernel does not track a lookup reference.
 func (m *InodeToPath) EnsureInode(path string, isDir bool, size int64, mtime time.Time) uint64 {
+	return m.EnsureInodeWithIdentity(path, "", 0, isDir, size, mtime)
+}
+
+// EnsureInodeWithIdentity is like EnsureInode, but preserves hardlink identity
+// for non-directory entries when resourceID is known.
+func (m *InodeToPath) EnsureInodeWithIdentity(path, resourceID string, nlink uint32, isDir bool, size int64, mtime time.Time) uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if ino, ok := m.byPath[path]; ok {
 		entry := m.byInode[ino]
-		entry.Size = size
-		entry.Mtime = mtime
+		m.updateEntryLocked(entry, path, resourceID, nlink, isDir, size, mtime)
 		return ino
+	}
+	if key := inodeResourceKey(resourceID, isDir); key != "" {
+		if ino, ok := m.byID[key]; ok {
+			entry := m.byInode[ino]
+			m.addPathLocked(entry, path)
+			m.updateEntryLocked(entry, path, resourceID, nlink, isDir, size, mtime)
+			return ino
+		}
 	}
 
 	ino := m.nextIno
 	m.nextIno++
 
 	entry := &InodeEntry{
-		Ino:     ino,
-		Path:    path,
-		IsDir:   isDir,
-		Nlookup: 0, // no kernel lookup reference yet
-		Size:    size,
-		Mtime:   mtime,
+		Ino:        ino,
+		Path:       path,
+		Paths:      map[string]struct{}{path: {}},
+		ResourceID: inodeResourceKey(resourceID, isDir),
+		Nlink:      nlink,
+		IsDir:      isDir,
+		Nlookup:    0, // no kernel lookup reference yet
+		Size:       size,
+		Mtime:      mtime,
+	}
+	if entry.Nlink == 0 && !entry.IsDir {
+		entry.Nlink = 1
 	}
 	m.byInode[ino] = entry
 	m.byPath[path] = ino
+	if entry.ResourceID != "" {
+		m.byID[entry.ResourceID] = ino
+	}
 	return ino
 }
 
@@ -122,7 +174,9 @@ func (m *InodeToPath) EnsureInodeNoUpdate(path string, isDir bool, size int64, m
 	entry := &InodeEntry{
 		Ino:     ino,
 		Path:    path,
+		Paths:   map[string]struct{}{path: {}},
 		IsDir:   isDir,
+		Nlink:   1,
 		Nlookup: 0,
 		Size:    size,
 		Mtime:   mtime,
@@ -181,6 +235,12 @@ func (m *InodeToPath) GetEntry(ino uint64) (*InodeEntry, bool) {
 		return nil, false
 	}
 	cp := *entry
+	if entry.Paths != nil {
+		cp.Paths = make(map[string]struct{}, len(entry.Paths))
+		for p := range entry.Paths {
+			cp.Paths[p] = struct{}{}
+		}
+	}
 	return &cp, true
 }
 
@@ -204,8 +264,7 @@ func (m *InodeToPath) Forget(ino uint64, nlookup uint64) {
 			entry.Nlookup = 0
 			return
 		}
-		delete(m.byPath, entry.Path)
-		delete(m.byInode, ino)
+		m.removeEntryLocked(ino, entry)
 	}
 }
 
@@ -240,9 +299,55 @@ func (m *InodeToPath) RemoveFileIfUnreferenced(ino uint64) bool {
 	if ino == 1 || entry.IsDir || entry.Nlookup > 0 {
 		return false
 	}
-	delete(m.byPath, entry.Path)
-	delete(m.byInode, ino)
+	m.removeEntryLocked(ino, entry)
 	return true
+}
+
+// AddAlias maps path to an existing inode and increments its lookup count for
+// the new kernel dentry returned by a successful FUSE Link call.
+func (m *InodeToPath) AddAlias(ino uint64, path, resourceID string, nlink uint32, isDir bool, size int64, mtime time.Time) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.byInode[ino]
+	if !ok {
+		return false
+	}
+	if replaced, exists := m.byPath[path]; exists && replaced != ino {
+		m.removePathLocked(path)
+	}
+	m.addPathLocked(entry, path)
+	entry.Nlookup++
+	m.updateEntryLocked(entry, path, resourceID, nlink, isDir, size, mtime)
+	return true
+}
+
+// SetIdentity records a stable resource identity for an existing inode.
+func (m *InodeToPath) SetIdentity(ino uint64, resourceID string, nlink uint32) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.byInode[ino]
+	if !ok {
+		return
+	}
+	m.setIdentityLocked(entry, resourceID)
+	if nlink > 0 {
+		entry.Nlink = nlink
+	}
+}
+
+// UpdateLinkCount updates the known hardlink count for an inode.
+func (m *InodeToPath) UpdateLinkCount(ino uint64, nlink uint32) {
+	if nlink == 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if entry, ok := m.byInode[ino]; ok {
+		entry.Nlink = nlink
+	}
 }
 
 // UpdateSize updates the size of the entry identified by the given inode.
@@ -308,9 +413,14 @@ func (m *InodeToPath) Rename(oldPath, newPath string) {
 	// Update the entry itself.
 	delete(m.byPath, oldPath)
 	if replacedIno, ok := m.byPath[newPath]; ok && replacedIno != ino {
-		delete(m.byInode, replacedIno)
+		m.removePathLocked(newPath)
 	}
 	m.byPath[newPath] = ino
+	if entry.Paths == nil {
+		entry.Paths = make(map[string]struct{})
+	}
+	delete(entry.Paths, oldPath)
+	entry.Paths[newPath] = struct{}{}
 	entry.Path = newPath
 
 	// If it is a directory, update all children with a matching prefix.
@@ -331,7 +441,13 @@ func (m *InodeToPath) Rename(oldPath, newPath string) {
 			newChildPath := newPath + "/" + strings.TrimPrefix(c.oldChildPath, oldPrefix)
 			delete(m.byPath, c.oldChildPath)
 			m.byPath[newChildPath] = c.childIno
-			m.byInode[c.childIno].Path = newChildPath
+			childEntry := m.byInode[c.childIno]
+			if childEntry.Paths == nil {
+				childEntry.Paths = make(map[string]struct{})
+			}
+			delete(childEntry.Paths, c.oldChildPath)
+			childEntry.Paths[newChildPath] = struct{}{}
+			childEntry.Path = newChildPath
 		}
 	}
 }
@@ -345,7 +461,14 @@ func (m *InodeToPath) Snapshot() []InodeEntry {
 
 	entries := make([]InodeEntry, 0, len(m.byInode))
 	for _, e := range m.byInode {
-		entries = append(entries, *e)
+		cp := *e
+		if e.Paths != nil {
+			cp.Paths = make(map[string]struct{}, len(e.Paths))
+			for p := range e.Paths {
+				cp.Paths[p] = struct{}{}
+			}
+		}
+		entries = append(entries, cp)
 	}
 	return entries
 }
@@ -355,10 +478,91 @@ func (m *InodeToPath) Remove(path string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	m.removePathLocked(path)
+}
+
+func inodeResourceKey(resourceID string, isDir bool) string {
+	if isDir || resourceID == "" {
+		return ""
+	}
+	return resourceID
+}
+
+func (m *InodeToPath) addPathLocked(entry *InodeEntry, path string) {
+	if entry.Paths == nil {
+		entry.Paths = make(map[string]struct{})
+		if entry.Path != "" {
+			entry.Paths[entry.Path] = struct{}{}
+		}
+	}
+	entry.Paths[path] = struct{}{}
+	m.byPath[path] = entry.Ino
+	if entry.Path == "" {
+		entry.Path = path
+	}
+}
+
+func (m *InodeToPath) updateEntryLocked(entry *InodeEntry, path, resourceID string, nlink uint32, isDir bool, size int64, mtime time.Time) {
+	m.addPathLocked(entry, path)
+	entry.IsDir = isDir
+	entry.Size = size
+	entry.Mtime = mtime
+	m.setIdentityLocked(entry, resourceID)
+	if nlink > 0 {
+		entry.Nlink = nlink
+	} else if entry.Nlink == 0 && !isDir {
+		entry.Nlink = 1
+	}
+}
+
+func (m *InodeToPath) setIdentityLocked(entry *InodeEntry, resourceID string) {
+	key := inodeResourceKey(resourceID, entry.IsDir)
+	if key == "" || entry.ResourceID == key {
+		return
+	}
+	if entry.ResourceID != "" && m.byID[entry.ResourceID] == entry.Ino {
+		delete(m.byID, entry.ResourceID)
+	}
+	entry.ResourceID = key
+	m.byID[key] = entry.Ino
+}
+
+func (m *InodeToPath) removeEntryLocked(ino uint64, entry *InodeEntry) {
+	for p := range entry.Paths {
+		delete(m.byPath, p)
+	}
+	if entry.Path != "" {
+		delete(m.byPath, entry.Path)
+	}
+	if entry.ResourceID != "" && m.byID[entry.ResourceID] == ino {
+		delete(m.byID, entry.ResourceID)
+	}
+	delete(m.byInode, ino)
+}
+
+func (m *InodeToPath) removePathLocked(path string) {
 	ino, ok := m.byPath[path]
 	if !ok {
 		return
 	}
+	entry, ok := m.byInode[ino]
+	if !ok {
+		delete(m.byPath, path)
+		return
+	}
 	delete(m.byPath, path)
-	delete(m.byInode, ino)
+	delete(entry.Paths, path)
+	if !entry.IsDir && entry.Nlink > 1 {
+		entry.Nlink--
+	}
+	if entry.Path == path {
+		entry.Path = ""
+		for p := range entry.Paths {
+			entry.Path = p
+			break
+		}
+	}
+	if entry.Path == "" && len(entry.Paths) == 0 {
+		m.removeEntryLocked(ino, entry)
+	}
 }

--- a/pkg/fuse/inode_test.go
+++ b/pkg/fuse/inode_test.go
@@ -29,6 +29,64 @@ func TestUpdateModeUnknownInode(t *testing.T) {
 	m.UpdateMode(999, 0o600)
 }
 
+func TestInodeHardlinkAliasesShareIdentity(t *testing.T) {
+	m := NewInodeToPath()
+	now := time.Now()
+
+	inoA := m.LookupWithIdentity("/a.txt", "file-1", 2, false, 10, now)
+	inoB := m.LookupWithIdentity("/b.txt", "file-1", 2, false, 10, now)
+	if inoA != inoB {
+		t.Fatalf("hardlink aliases got different inodes: %d != %d", inoA, inoB)
+	}
+	entry, ok := m.GetEntry(inoA)
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if entry.Nlink != 2 {
+		t.Fatalf("nlink = %d, want 2", entry.Nlink)
+	}
+	if _, ok := entry.Paths["/a.txt"]; !ok {
+		t.Fatalf("entry paths missing /a.txt: %+v", entry.Paths)
+	}
+	if _, ok := entry.Paths["/b.txt"]; !ok {
+		t.Fatalf("entry paths missing /b.txt: %+v", entry.Paths)
+	}
+
+	m.Remove("/a.txt")
+	if _, ok := m.GetInode("/a.txt"); ok {
+		t.Fatal("/a.txt mapping survived Remove")
+	}
+	if got, ok := m.GetInode("/b.txt"); !ok || got != inoA {
+		t.Fatalf("/b.txt inode = %d/%v, want %d/true", got, ok, inoA)
+	}
+	entry, ok = m.GetEntry(inoA)
+	if !ok {
+		t.Fatal("entry removed while alias still exists")
+	}
+	if entry.Nlink != 1 {
+		t.Fatalf("nlink after removing one alias = %d, want 1", entry.Nlink)
+	}
+}
+
+func TestInodeSetIdentityLetsLaterLookupJoinExistingInode(t *testing.T) {
+	m := NewInodeToPath()
+	now := time.Now()
+
+	inoA := m.Lookup("/a.txt", false, 10, now)
+	m.SetIdentity(inoA, "file-1", 1)
+	inoB := m.LookupWithIdentity("/b.txt", "file-1", 2, false, 10, now)
+	if inoA != inoB {
+		t.Fatalf("lookup with identity allocated new inode: %d != %d", inoB, inoA)
+	}
+	entry, ok := m.GetEntry(inoA)
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if entry.Nlink != 2 {
+		t.Fatalf("nlink = %d, want 2", entry.Nlink)
+	}
+}
+
 func TestFillAttrFileMode(t *testing.T) {
 	fs := &Dat9FS{uid: 1000, gid: 1000}
 
@@ -52,6 +110,16 @@ func TestFillAttrFileMode(t *testing.T) {
 				t.Errorf("mode=%o, want %o", out.Mode, tt.wantMode)
 			}
 		})
+	}
+}
+
+func TestFillAttrFileNlink(t *testing.T) {
+	fs := &Dat9FS{uid: 1000, gid: 1000}
+	entry := &InodeEntry{Ino: 2, Path: "/a.txt", IsDir: false, Size: 42, Nlink: 3}
+	var out gofuse.Attr
+	fs.fillAttr(entry, &out)
+	if out.Nlink != 3 {
+		t.Fatalf("nlink = %d, want 3", out.Nlink)
 	}
 }
 

--- a/pkg/fuse/inode_test.go
+++ b/pkg/fuse/inode_test.go
@@ -52,9 +52,9 @@ func TestInodeHardlinkAliasesShareIdentity(t *testing.T) {
 		t.Fatalf("entry paths missing /b.txt: %+v", entry.Paths)
 	}
 
-	m.Remove("/a.txt")
+	m.RemoveLink("/a.txt")
 	if _, ok := m.GetInode("/a.txt"); ok {
-		t.Fatal("/a.txt mapping survived Remove")
+		t.Fatal("/a.txt mapping survived RemoveLink")
 	}
 	if got, ok := m.GetInode("/b.txt"); !ok || got != inoA {
 		t.Fatalf("/b.txt inode = %d/%v, want %d/true", got, ok, inoA)
@@ -65,6 +65,25 @@ func TestInodeHardlinkAliasesShareIdentity(t *testing.T) {
 	}
 	if entry.Nlink != 1 {
 		t.Fatalf("nlink after removing one alias = %d, want 1", entry.Nlink)
+	}
+}
+
+func TestInodeRemoveMappingDoesNotConsumeLink(t *testing.T) {
+	m := NewInodeToPath()
+	now := time.Now()
+
+	inoA := m.LookupWithIdentity("/a.txt", "file-1", 2, false, 10, now)
+	inoB := m.LookupWithIdentity("/b.txt", "file-1", 2, false, 10, now)
+	if inoA != inoB {
+		t.Fatalf("hardlink aliases got different inodes: %d != %d", inoA, inoB)
+	}
+	m.Remove("/a.txt")
+	entry, ok := m.GetEntry(inoA)
+	if !ok {
+		t.Fatal("entry removed while alias still exists")
+	}
+	if entry.Nlink != 2 {
+		t.Fatalf("nlink after mapping removal = %d, want 2", entry.Nlink)
 	}
 }
 

--- a/pkg/fuse/local_overlay.go
+++ b/pkg/fuse/local_overlay.go
@@ -95,6 +95,21 @@ func (o *LocalOverlay) Symlink(target, localPath string) error {
 	return os.Symlink(target, abs)
 }
 
+func (o *LocalOverlay) Link(oldPath, newPath string) error {
+	oldAbs, err := o.abs(oldPath)
+	if err != nil {
+		return err
+	}
+	newAbs, err := o.abs(newPath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(newAbs), 0o755); err != nil {
+		return err
+	}
+	return os.Link(oldAbs, newAbs)
+}
+
 func (o *LocalOverlay) Readlink(localPath string) (string, error) {
 	abs, err := o.abs(localPath)
 	if err != nil {

--- a/pkg/fuse/open_handles.go
+++ b/pkg/fuse/open_handles.go
@@ -83,6 +83,24 @@ func (idx *OpenHandleIndex) SnapshotPath(p string) []*FileHandle {
 	return out
 }
 
+// SnapshotInode returns a point-in-time copy of handles currently indexed by inode.
+func (idx *OpenHandleIndex) SnapshotInode(ino uint64) []*FileHandle {
+	if idx == nil || ino == 0 {
+		return nil
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	handles := idx.byInode[ino]
+	if len(handles) == 0 {
+		return nil
+	}
+	out := make([]*FileHandle, 0, len(handles))
+	for fh := range handles {
+		out = append(out, fh)
+	}
+	return out
+}
+
 func (idx *OpenHandleIndex) RenamePathPrefix(oldPath, newPath string) map[*FileHandle]string {
 	if idx == nil || oldPath == "" || newPath == "" {
 		return nil

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -33,6 +33,7 @@ const (
 	perfFuseSetAttr
 	perfFuseReadlink
 	perfFuseSymlink
+	perfFuseLink
 	perfFuseOpCount
 )
 
@@ -56,6 +57,7 @@ var perfFuseOpNames = [...]string{
 	perfFuseSetAttr:     "setattr",
 	perfFuseReadlink:    "readlink",
 	perfFuseSymlink:     "symlink",
+	perfFuseLink:        "link",
 }
 
 type perfRemoteOp int

--- a/pkg/server/fs_authorization_test.go
+++ b/pkg/server/fs_authorization_test.go
@@ -189,14 +189,14 @@ func TestIsScopedBusinessRequestAllowed(t *testing.T) {
 			path   string
 			query  string
 		}{
-			{http.MethodPost, "/v1/fs/main.txt", "chmod=1"},           // owner-only forever
-			{http.MethodGet, "/v1/fs:batch-stat", ""},                 // wrong method for this endpoint
-			{http.MethodGet, "/v1/fs:batch-read-small", ""},           // wrong method
-			{http.MethodPost, "/v1/sql", ""},                          // out of scope
-			{http.MethodPost, "/v1/fork", ""},                         // out of scope
-			{http.MethodGet, "/v1/events", ""},                        // out of scope
-			{http.MethodGet, "/v1/journals", ""},                      // out of scope
-			{http.MethodGet, "/v1/vault/secrets", ""},                 // out of scope
+			{http.MethodPost, "/v1/fs/main.txt", "chmod=1"}, // owner-only forever
+			{http.MethodGet, "/v1/fs:batch-stat", ""},       // wrong method for this endpoint
+			{http.MethodGet, "/v1/fs:batch-read-small", ""}, // wrong method
+			{http.MethodPost, "/v1/sql", ""},                // out of scope
+			{http.MethodPost, "/v1/fork", ""},               // out of scope
+			{http.MethodGet, "/v1/events", ""},              // out of scope
+			{http.MethodGet, "/v1/journals", ""},            // out of scope
+			{http.MethodGet, "/v1/vault/secrets", ""},       // out of scope
 		}
 		for _, tc := range cases {
 			r := newScopedRequest(t, tc.method, tc.path, tc.query)
@@ -534,6 +534,46 @@ func TestC2aHandleCopyAllowsBothInZone(t *testing.T) {
 	}
 }
 
+func TestC2aHandleHardlinkAuthorizesSrcViaHeader(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{{
+			Prefix: "/scratch",
+			Ops:    map[FSOp]bool{FSOpRead: true, FSOpWrite: true},
+		}},
+	}
+	r := newScopedRequest(t, http.MethodPost, "/v1/fs/scratch/exfil.env", "hardlink=1")
+	r.Header.Set("X-Dat9-Hardlink-Source", "/secrets/api-key.env")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	(&Server{}).handleHardlink(w, r, "/scratch/exfil.env")
+
+	if got := w.Result().StatusCode; got != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (src in header must be authorized). body=%s",
+			got, http.StatusForbidden, w.Body.String())
+	}
+}
+
+func TestC2aHandleHardlinkAllowsBothInZone(t *testing.T) {
+	scope := &TenantScope{
+		IsScoped: true,
+		FSScopes: []FSScope{
+			{Prefix: "/source", Ops: map[FSOp]bool{FSOpRead: true}},
+			{Prefix: "/dest", Ops: map[FSOp]bool{FSOpWrite: true}},
+		},
+	}
+	r := newScopedRequest(t, http.MethodPost, "/v1/fs/dest/a.txt", "hardlink=1")
+	r.Header.Set("X-Dat9-Hardlink-Source", "/source/a.txt")
+	r = r.WithContext(withScope(r.Context(), scope))
+	w := httptest.NewRecorder()
+	(&Server{}).handleHardlink(w, r, "/dest/a.txt")
+
+	if got := w.Result().StatusCode; got != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d (authorize passed; backend missing). body=%s",
+			got, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
 // TestC2aHandleRenameSrcRequiresDeleteNotWrite pins the banked rename
 // invariant: rename's src op is DELETE (the file disappears), not WRITE.
 // A token with read+write on the source zone but NO delete cannot rename
@@ -603,6 +643,7 @@ func TestC2aDispatcherWriteSideAllowed(t *testing.T) {
 			{http.MethodDelete, "recursive=1&kind=dir"},
 			{http.MethodPost, "append=1"},
 			{http.MethodPost, "copy=1"},
+			{http.MethodPost, "hardlink=1"},
 			{http.MethodPost, "rename=1"},
 			{http.MethodPost, "mkdir=1"},
 			{http.MethodPost, "mkdir=1&mode=755"},
@@ -629,6 +670,8 @@ func TestC2aDispatcherWriteSideAllowed(t *testing.T) {
 		cases := []string{
 			"append=1&copy=1",
 			"copy=1&rename=1",
+			"copy=1&hardlink=1",
+			"hardlink=1&rename=1",
 			"mkdir=1&create=1",
 			"create=1&symlink=1",
 			"copy=1&chmod=1", // chmod combined with anything → deny
@@ -668,6 +711,7 @@ func TestC2aDispatcherWriteSideAllowed(t *testing.T) {
 			why   string
 		}{
 			{"copy=1&mode=755", "mode is a mkdir-arm key, not copy-arm"},
+			{"hardlink=1&mode=755", "mode is a mkdir-arm key, not hardlink-arm"},
 			{"create=1&mode=755", "mode is a mkdir-arm key, not create-arm"},
 			{"append=1&extra=x", "append doesn't consume any filter param"},
 		}
@@ -759,18 +803,18 @@ func TestC2bUploadsAdmittedAtDispatcher(t *testing.T) {
 		method string
 		path   string
 	}{
-		{http.MethodPost, "/v1/uploads"},                          // handleUploadInitiate
-		{http.MethodPost, "/v1/uploads/initiate"},                 // handleUploadInitiate
-		{http.MethodGet, "/v1/uploads"},                           // handleUploads list
-		{http.MethodPost, "/v1/uploads/upload-1/complete"},        // handleUploadComplete
-		{http.MethodPost, "/v1/uploads/upload-1/resume"},          // handleUploadResume
-		{http.MethodGet, "/v1/uploads/upload-1/resume"},           // handleUploadResume (GET form)
-		{http.MethodDelete, "/v1/uploads/upload-1"},               // handleUploadAbort
-		{http.MethodPost, "/v2/uploads/initiate"},                 // handleV2UploadInitiate
-		{http.MethodPost, "/v2/uploads/upload-1/presign"},         // handleV2PresignPart
-		{http.MethodPost, "/v2/uploads/upload-1/presign-batch"},   // handleV2PresignBatch
-		{http.MethodPost, "/v2/uploads/upload-1/complete"},        // handleV2UploadComplete
-		{http.MethodPost, "/v2/uploads/upload-1/abort"},           // handleV2UploadAbort
+		{http.MethodPost, "/v1/uploads"},                        // handleUploadInitiate
+		{http.MethodPost, "/v1/uploads/initiate"},               // handleUploadInitiate
+		{http.MethodGet, "/v1/uploads"},                         // handleUploads list
+		{http.MethodPost, "/v1/uploads/upload-1/complete"},      // handleUploadComplete
+		{http.MethodPost, "/v1/uploads/upload-1/resume"},        // handleUploadResume
+		{http.MethodGet, "/v1/uploads/upload-1/resume"},         // handleUploadResume (GET form)
+		{http.MethodDelete, "/v1/uploads/upload-1"},             // handleUploadAbort
+		{http.MethodPost, "/v2/uploads/initiate"},               // handleV2UploadInitiate
+		{http.MethodPost, "/v2/uploads/upload-1/presign"},       // handleV2PresignPart
+		{http.MethodPost, "/v2/uploads/upload-1/presign-batch"}, // handleV2PresignBatch
+		{http.MethodPost, "/v2/uploads/upload-1/complete"},      // handleV2UploadComplete
+		{http.MethodPost, "/v2/uploads/upload-1/abort"},         // handleV2UploadAbort
 	}
 	for _, tc := range allowed {
 		r := newScopedRequest(t, tc.method, tc.path, "")
@@ -846,8 +890,8 @@ func TestHandlersRejectScopedRequestBeforeBackend(t *testing.T) {
 	}
 
 	cases := []struct {
-		name string
-		op   FSOp
+		name   string
+		op     FSOp
 		invoke func(s *Server, w http.ResponseWriter, r *http.Request)
 	}{
 		{"handleRead", FSOpRead, func(s *Server, w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1108,12 +1108,14 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "list_ok", "path", path, "entries", len(entries))...)
 	type entry struct {
-		Name    string `json:"name"`
-		Size    int64  `json:"size"`
-		IsDir   bool   `json:"isDir"`
-		Mtime   int64  `json:"mtime,omitempty"`
-		Mode    uint32 `json:"mode,omitempty"`
-		HasMode bool   `json:"hasMode"`
+		Name       string `json:"name"`
+		Size       int64  `json:"size"`
+		IsDir      bool   `json:"isDir"`
+		Mtime      int64  `json:"mtime,omitempty"`
+		Mode       uint32 `json:"mode,omitempty"`
+		HasMode    bool   `json:"hasMode"`
+		ResourceID string `json:"resource_id,omitempty"`
+		Nlink      uint32 `json:"nlink,omitempty"`
 	}
 	out := make([]entry, 0, len(entries))
 	for _, e := range entries {
@@ -1122,7 +1124,22 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 			mtime = e.ModTime.Unix()
 		}
 		hasMode := e.Meta.Content["hasMode"] == "true"
-		out = append(out, entry{Name: e.Name, Size: e.Size, IsDir: e.IsDir, Mtime: mtime, Mode: e.Mode, HasMode: hasMode})
+		var nlink uint32
+		if raw := e.Meta.Content["nlink"]; raw != "" {
+			if parsed, err := strconv.ParseUint(raw, 10, 32); err == nil {
+				nlink = uint32(parsed)
+			}
+		}
+		out = append(out, entry{
+			Name:       e.Name,
+			Size:       e.Size,
+			IsDir:      e.IsDir,
+			Mtime:      mtime,
+			Mode:       e.Mode,
+			HasMode:    hasMode,
+			ResourceID: e.Meta.Content["resource_id"],
+			Nlink:      nlink,
+		})
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"entries": out})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -713,7 +713,7 @@ func isScopedFSPostQueryAllowed(q url.Values) bool {
 	// no selector = deny (no handler matches the dispatcher's else branch
 	// for scoped tokens — that's "unknown POST action" which is a 400 for
 	// owner today, and we don't want to silently widen for scoped).
-	selectors := []string{"append", "copy", "rename", "mkdir", "chmod", "create", "symlink"}
+	selectors := []string{"append", "copy", "rename", "mkdir", "chmod", "create", "symlink", "hardlink"}
 	selectorCount := 0
 	var selectorKey string
 	for _, k := range selectors {
@@ -753,6 +753,10 @@ func isScopedFSPostQueryAllowed(q url.Values) bool {
 	case "symlink":
 		// handleSymlink reads only ?symlink; target is in the JSON body.
 		return queryKeysSubsetOf(q, []string{"symlink"})
+	case "hardlink":
+		// handleHardlink reads only ?hardlink; source path is in
+		// X-Dat9-Hardlink-Source.
+		return queryKeysSubsetOf(q, []string{"hardlink"})
 	default:
 		return false
 	}
@@ -989,6 +993,8 @@ func (s *Server) handleFS(w http.ResponseWriter, r *http.Request) {
 			s.handleCreate(w, r, path)
 		} else if r.URL.Query().Has("symlink") {
 			s.handleSymlink(w, r, path)
+		} else if r.URL.Query().Has("hardlink") {
+			s.handleHardlink(w, r, path)
 		} else {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "fs_unknown_post_action", "path", path)...)
 			errJSON(w, http.StatusBadRequest, "unknown POST action")
@@ -1142,6 +1148,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 			Size         int64             `json:"size"`
 			IsDir        bool              `json:"isdir"`
 			ResourceID   string            `json:"resource_id"`
+			Nlink        uint32            `json:"nlink,omitempty"`
 			Revision     int64             `json:"revision"`
 			Mtime        *int64            `json:"mtime,omitempty"`
 			ContentType  string            `json:"content_type"`
@@ -1149,6 +1156,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 			Tags         map[string]string `json:"tags"`
 		}{
 			IsDir: true,
+			Nlink: 2,
 			Mtime: &zero,
 			Tags:  make(map[string]string),
 		})
@@ -1174,6 +1182,12 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 	var contentType string
 	var semanticText string
 	resourceID := nf.Node.NodeID
+	nlink, err := nodeLinkCount(r.Context(), b, nf)
+	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "stat_metadata_refcount_failed", "path", path, "error", err)...)
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	if nf.File != nil {
 		resourceID = nf.File.FileID
 		size = nf.File.SizeBytes
@@ -1206,6 +1220,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 		Size         int64             `json:"size"`
 		IsDir        bool              `json:"isdir"`
 		ResourceID   string            `json:"resource_id"`
+		Nlink        uint32            `json:"nlink,omitempty"`
 		Revision     int64             `json:"revision"`
 		Mtime        *int64            `json:"mtime,omitempty"`
 		ContentType  string            `json:"content_type"`
@@ -1215,6 +1230,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 		Size:         size,
 		IsDir:        nf.Node.IsDirectory,
 		ResourceID:   resourceID,
+		Nlink:        nlink,
 		Revision:     revision,
 		Mtime:        mtime,
 		ContentType:  contentType,
@@ -1592,15 +1608,17 @@ type batchStatResponse struct {
 }
 
 type batchStatResult struct {
-	Path     string `json:"path"`
-	Status   int    `json:"status"`
-	Error    string `json:"error,omitempty"`
-	Size     int64  `json:"size,omitempty"`
-	IsDir    bool   `json:"isDir"`
-	Revision int64  `json:"revision,omitempty"`
-	Mtime    int64  `json:"mtime,omitempty"`
-	Mode     uint32 `json:"mode,omitempty"`
-	HasMode  bool   `json:"hasMode"`
+	Path       string `json:"path"`
+	Status     int    `json:"status"`
+	Error      string `json:"error,omitempty"`
+	Size       int64  `json:"size,omitempty"`
+	IsDir      bool   `json:"isDir"`
+	Revision   int64  `json:"revision,omitempty"`
+	Mtime      int64  `json:"mtime,omitempty"`
+	Mode       uint32 `json:"mode,omitempty"`
+	HasMode    bool   `json:"hasMode"`
+	ResourceID string `json:"resource_id,omitempty"`
+	Nlink      uint32 `json:"nlink,omitempty"`
 }
 
 type batchReadSmallRequest struct {
@@ -1762,6 +1780,7 @@ func (s *Server) batchStatOne(ctx context.Context, b *backend.Dat9Backend, rawPa
 	if path == "/" {
 		result.Status = http.StatusOK
 		result.IsDir = true
+		result.Nlink = 2
 		return result
 	}
 
@@ -1780,6 +1799,14 @@ func (s *Server) batchStatOne(ctx context.Context, b *backend.Dat9Backend, rawPa
 	result.IsDir = nf.Node.IsDirectory
 	result.HasMode = nf.HasMode
 	result.Mode = nf.Mode
+	result.ResourceID = nodeResourceID(nf)
+	nlink, nlinkErr := nodeLinkCount(ctx, b, nf)
+	if nlinkErr != nil {
+		result.Status = http.StatusInternalServerError
+		result.Error = nlinkErr.Error()
+		return result
+	}
+	result.Nlink = nlink
 	if nf.File != nil {
 		result.Size = nf.File.SizeBytes
 		result.Revision = nf.File.Revision
@@ -1801,6 +1828,42 @@ func validateBatchStatPath(rawPath string) error {
 	}
 	_, err := pathutil.Canonicalize(rawPath)
 	return err
+}
+
+func nodeResourceID(nf *datastore.NodeWithFile) string {
+	if nf == nil {
+		return ""
+	}
+	if nf.File != nil {
+		return nf.File.FileID
+	}
+	if nf.Node.InodeID != "" {
+		return nf.Node.InodeID
+	}
+	return nf.Node.NodeID
+}
+
+func nodeLinkCount(ctx context.Context, b *backend.Dat9Backend, nf *datastore.NodeWithFile) (uint32, error) {
+	if nf == nil {
+		return 0, nil
+	}
+	if nf.File == nil || nf.File.FileID == "" {
+		if nf.Node.IsDirectory {
+			return 2, nil
+		}
+		return 1, nil
+	}
+	count, err := b.Store().RefCount(ctx, nf.File.FileID)
+	if err != nil {
+		return 0, err
+	}
+	if count <= 0 {
+		count = 1
+	}
+	if count > int64(^uint32(0)) {
+		return ^uint32(0), nil
+	}
+	return uint32(count), nil
 }
 
 func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string) {
@@ -1826,6 +1889,7 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 		w.Header().Set("Content-Length", "0")
 		w.Header().Set("X-Dat9-IsDir", "true")
 		w.Header().Set("X-Dat9-Mtime", "0")
+		w.Header().Set("X-Dat9-Nlink", "2")
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "stat_ok", "path", path, "is_dir", true)...)
 		w.WriteHeader(http.StatusOK)
 		return
@@ -1854,6 +1918,12 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 	if nf.File != nil {
 		size = nf.File.SizeBytes
 	}
+	nlink, err := nodeLinkCount(r.Context(), b, nf)
+	if err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "stat_refcount_failed", "path", path, "error", err)...)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	logger.InfoBenchTiming(r.Context(), "server_stat_timing",
 		zap.String("path", path),
 		zap.Bool("is_dir", nf.Node.IsDirectory),
@@ -1862,6 +1932,12 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 	w.Header().Set("X-Dat9-IsDir", fmt.Sprintf("%v", nf.Node.IsDirectory))
+	if resourceID := nodeResourceID(nf); resourceID != "" {
+		w.Header().Set("X-Dat9-Resource-ID", resourceID)
+	}
+	if nlink > 0 {
+		w.Header().Set("X-Dat9-Nlink", strconv.FormatUint(uint64(nlink), 10))
+	}
 	if nf.File != nil {
 		w.Header().Set("X-Dat9-Revision", strconv.FormatInt(nf.File.Revision, 10))
 		if nf.File.ConfirmedAt != nil {
@@ -1956,6 +2032,48 @@ func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath stri
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "copy_ok", "src_path", srcPath, "dst_path", dstPath)...)
 	s.publishEvent(r, dstPath, "copy")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleHardlink(w http.ResponseWriter, r *http.Request, dstPath string) {
+	srcPath := r.Header.Get("X-Dat9-Hardlink-Source")
+	if srcPath == "" {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "hardlink_missing_source_header", "dst_path", dstPath)...)
+		errJSON(w, http.StatusBadRequest, "missing X-Dat9-Hardlink-Source header")
+		return
+	}
+	if !authorizeFSPair(w, r, FSOpRead, srcPath, FSOpWrite, dstPath) {
+		return
+	}
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "hardlink_missing_scope", "dst_path", dstPath)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	if err := b.HardlinkFileCtx(r.Context(), srcPath, dstPath); err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "hardlink_not_found", "src_path", srcPath, "dst_path", dstPath)...)
+			errJSON(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if errors.Is(err, datastore.ErrPathConflict) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "hardlink_conflict", "src_path", srcPath, "dst_path", dstPath)...)
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		if errors.Is(err, backend.ErrInvalidHardlinkTarget) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "hardlink_invalid_target", "src_path", srcPath, "dst_path", dstPath, "error", err)...)
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "hardlink_failed", "src_path", srcPath, "dst_path", dstPath, "error", err)...)
+		errJSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "hardlink_ok", "src_path", srcPath, "dst_path", dstPath)...)
+	s.publishEvent(r, srcPath, "hardlink")
+	s.publishEvent(r, dstPath, "hardlink")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1463,6 +1463,81 @@ func TestCopy(t *testing.T) {
 	}
 }
 
+func TestHardlinkRoundTrip(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/src.txt", strings.NewReader("shared"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write src: %d", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/dst.txt?hardlink=1", nil)
+	req.Header.Set("X-Dat9-Hardlink-Source", "/src.txt")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("hardlink: %d", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/src.txt", nil)
+	srcStat, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = srcStat.Body.Close()
+	if srcStat.StatusCode != http.StatusOK {
+		t.Fatalf("stat src: %d", srcStat.StatusCode)
+	}
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/dst.txt", nil)
+	dstStat, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dstStat.Body.Close()
+	if dstStat.StatusCode != http.StatusOK {
+		t.Fatalf("stat dst: %d", dstStat.StatusCode)
+	}
+	if srcStat.Header.Get("X-Dat9-Resource-ID") == "" {
+		t.Fatal("src resource id is empty")
+	}
+	if srcStat.Header.Get("X-Dat9-Resource-ID") != dstStat.Header.Get("X-Dat9-Resource-ID") {
+		t.Fatalf("resource ids differ: src=%q dst=%q",
+			srcStat.Header.Get("X-Dat9-Resource-ID"), dstStat.Header.Get("X-Dat9-Resource-ID"))
+	}
+	if got := dstStat.Header.Get("X-Dat9-Nlink"); got != "2" {
+		t.Fatalf("dst nlink = %q, want 2", got)
+	}
+
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/dst.txt", strings.NewReader("updated"))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write dst: %d", resp.StatusCode)
+	}
+	resp, err = http.Get(ts.URL + "/v1/fs/src.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if string(body) != "updated" {
+		t.Fatalf("src body = %q, want updated", body)
+	}
+}
+
 func TestRename(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -343,8 +343,10 @@ func TestListDir(t *testing.T) {
 
 	var result struct {
 		Entries []struct {
-			Name  string `json:"name"`
-			IsDir bool   `json:"isDir"`
+			Name       string `json:"name"`
+			IsDir      bool   `json:"isDir"`
+			ResourceID string `json:"resource_id"`
+			Nlink      uint32 `json:"nlink"`
 		} `json:"entries"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -352,6 +354,12 @@ func TestListDir(t *testing.T) {
 	}
 	if len(result.Entries) != 2 {
 		t.Fatalf("expected 2 entries, got %d", len(result.Entries))
+	}
+	if result.Entries[0].ResourceID == "" {
+		t.Fatal("list entry resource_id is empty")
+	}
+	if result.Entries[0].Nlink != 1 {
+		t.Fatalf("list entry nlink = %d, want 1", result.Entries[0].Nlink)
 	}
 }
 
@@ -1514,6 +1522,9 @@ func TestHardlinkRoundTrip(t *testing.T) {
 		t.Fatalf("resource ids differ: src=%q dst=%q",
 			srcStat.Header.Get("X-Dat9-Resource-ID"), dstStat.Header.Get("X-Dat9-Resource-ID"))
 	}
+	if got := srcStat.Header.Get("X-Dat9-Nlink"); got != "2" {
+		t.Fatalf("src nlink = %q, want 2", got)
+	}
 	if got := dstStat.Header.Get("X-Dat9-Nlink"); got != "2" {
 		t.Fatalf("dst nlink = %q, want 2", got)
 	}
@@ -1526,6 +1537,28 @@ func TestHardlinkRoundTrip(t *testing.T) {
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("write dst: %d", resp.StatusCode)
+	}
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/src.txt", nil)
+	srcStatAfter, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = srcStatAfter.Body.Close()
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/dst.txt", nil)
+	dstStatAfter, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dstStatAfter.Body.Close()
+	if srcStatAfter.Header.Get("X-Dat9-Resource-ID") != dstStatAfter.Header.Get("X-Dat9-Resource-ID") {
+		t.Fatalf("resource ids differ after overwrite: src=%q dst=%q",
+			srcStatAfter.Header.Get("X-Dat9-Resource-ID"), dstStatAfter.Header.Get("X-Dat9-Resource-ID"))
+	}
+	if got := srcStatAfter.Header.Get("X-Dat9-Nlink"); got != "2" {
+		t.Fatalf("src nlink after overwrite = %q, want 2", got)
+	}
+	if got := dstStatAfter.Header.Get("X-Dat9-Nlink"); got != "2" {
+		t.Fatalf("dst nlink after overwrite = %q, want 2", got)
 	}
 	resp, err = http.Get(ts.URL + "/v1/fs/src.txt")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add first-class file hardlink support across datastore, backend, HTTP API, Go client, CLI, and FUSE.
- Expose stable file identity and link counts through stat metadata so mounted files can present hardlinked paths as the same inode.
- Add live e2e coverage for API, CLI, and FUSE hardlink workflows.

## Implementation Notes
- Introduces Store.LinkFileNode to create another file node for the same confirmed file identity while rejecting directories, missing parents, same-path links, and destination conflicts.
- Adds POST /v1/fs/{path}?hardlink=1 with X-Dat9-Hardlink-Source. Scoped auth requires read access on the source and write access on the destination.
- Adds client.Hardlink, drive9 fs hardlink, and stat resource_id/nlink fields for both JSON and response-header consumers.
- Updates the FUSE layer to implement Link, preserve shared inode identity by resource ID, report nlink, and mirror hardlinks into the local overlay when enabled.

## E2E Coverage
- API smoke creates a hardlink, verifies matching resource IDs, verifies nlink >= 2, and confirms writes through the link update the source.
- CLI smoke covers drive9 fs hardlink, listing visibility, shared content reads, nlink reporting, and shared writes.
- FUSE smoke covers POSIX ln on a mounted file, remote nlink reporting, and shared writes through the mounted hardlink.

## Tests
- bash -n e2e/api-smoke-test.sh
- bash -n e2e/cli-smoke-test.sh
- bash -n e2e/fuse-smoke-test.sh
- env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9/cli ./pkg/fuse
- env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9
- env DRIVE9_TEST_MYSQL_DSN=dummy GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/server -run "TestC2aHandleHardlink|TestC2aDispatcherWriteSideAllowed"
- env DRIVE9_TEST_MYSQL_DSN=dummy GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/client -run "TestHardlinkCtx|TestStatCtxParsesResourceIDAndNlink"
- go test -c for ./pkg/datastore, ./pkg/backend, ./pkg/server, ./pkg/client, and ./pkg/fuse

Note: DB-backed make test was attempted locally, but this machine does not currently have a usable testcontainers runtime available: rootless Docker not found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hardlink support: create hardlinks via CLI (`drive9 fs hardlink <target> <link>`), HTTP API (`POST /v1/fs/{path}?hardlink`), and FUSE.
  * Hardlink reference counts now displayed in `stat` output via `nlink` field.
  * Enhanced e2e test coverage for hardlink operations across API, CLI, and FUSE.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->