### PR TITLE
feat: fast git worktree

### DIFF
--- a/cmd/drive9/cli/git.go
+++ b/cmd/drive9/cli/git.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	pathpkg "path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -47,6 +48,8 @@ func Git(args []string) error {
 		return gitClone(args[1:])
 	case "hydrate":
 		return gitHydrate(args[1:])
+	case "worktree":
+		return gitWorktree(args[1:])
 	case "-h", "-help", "--help", "help":
 		gitUsage()
 		return nil
@@ -62,6 +65,10 @@ func gitUsage() {
 commands:
   clone --fast [--blobless] [--hydrate=background|sync|off] <repo-url> <mounted-path>
                        create a local .git and register the HEAD tree
+  worktree add --fast [-b <branch>] [--detach] [--blobless] [--hydrate=auto|background|sync|off] <base-repo-path> <worktree-path> [<commit-ish>]
+                       add a linked worktree without checking out file contents
+  worktree remove --fast <worktree-path>
+                       remove a fast linked worktree without per-file whiteouts
   hydrate <mounted-path>
                        materialize a blobless clean tree into local cache
 
@@ -166,31 +173,13 @@ func gitClone(args []string) error {
 		return fmt.Errorf("register git tree manifest: %w", err)
 	}
 	cancel()
-	gitDir := filepath.Join(target, ".git")
-	if resolved.LocalGitDir != "" {
-		if info, statErr := os.Stat(resolved.LocalGitDir); statErr == nil && info.IsDir() {
-			gitDir = resolved.LocalGitDir
-		} else if statErr != nil && !os.IsNotExist(statErr) {
-			return fmt.Errorf("stat local .git checkpoint path: %w", statErr)
-		}
-	}
-	gitState, err := archiveGitStateDir(cmdCtx, gitDir)
+	gitDir, err := mainGitStateDirForTarget(target, resolved)
 	if err != nil {
-		return fmt.Errorf("checkpoint .git: %w", err)
+		return err
 	}
-	sum := sha256.Sum256(gitState)
-	ctx, cancel = context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
-	if _, err := c.UpsertGitState(ctx, ws.WorkspaceID, client.GitStateRequest{
-		CheckpointCommit: head,
-		StorageType:      gitStateStorageTarGzNoObjects,
-		ChecksumSHA256:   hex.EncodeToString(sum[:]),
-		SizeBytes:        int64(len(gitState)),
-		Content:          gitState,
-	}); err != nil {
-		cancel()
-		return fmt.Errorf("upload .git checkpoint: %w", err)
+	if err := uploadGitStateCheckpoint(cmdCtx, c, ws.WorkspaceID, head, gitDir); err != nil {
+		return err
 	}
-	cancel()
 
 	fmt.Fprintf(os.Stderr, "drive9: registered git workspace %s at :%s (%d tree entries)\n", ws.WorkspaceID, resolved.RemotePath, len(nodes))
 	if *blobless {
@@ -210,6 +199,296 @@ func gitClone(args []string) error {
 			}
 		}
 	}
+	return nil
+}
+
+func gitWorktree(args []string) error {
+	if len(args) == 0 {
+		gitWorktreeUsage()
+		return fmt.Errorf("usage: drive9 git worktree <add|remove> [arguments]")
+	}
+	switch args[0] {
+	case "add":
+		return gitWorktreeAdd(args[1:])
+	case "remove":
+		return gitWorktreeRemove(args[1:])
+	case "-h", "-help", "--help", "help":
+		gitWorktreeUsage()
+		return nil
+	default:
+		gitWorktreeUsage()
+		return fmt.Errorf("drive9 git worktree: unknown command %q", args[0])
+	}
+}
+
+func gitWorktreeUsage() {
+	fmt.Fprintf(os.Stderr, `usage: drive9 git worktree <command> [arguments]
+
+commands:
+  add --fast [-b <branch>] [--detach] [--blobless] [--hydrate=auto|background|sync|off] <base-repo-path> <worktree-path> [<commit-ish>]
+  remove --fast <worktree-path>
+`)
+}
+
+func gitWorktreeAdd(args []string) error {
+	fs := flag.NewFlagSet("git worktree add", flag.ContinueOnError)
+	fast := fs.Bool("fast", false, "use drive9 git fast worktree add")
+	branch := fs.String("b", "", "create a new branch for the worktree")
+	detach := fs.Bool("detach", false, "detach HEAD in the new worktree")
+	blobless := fs.Bool("blobless", false, "require a blobless base workspace")
+	hydrate := fs.String("hydrate", "auto", "blobless clean tree hydrate strategy: auto, background, sync, or off")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: drive9 git worktree add --fast [-b <branch>] [--detach] [--blobless] [--hydrate=auto|background|sync|off] <base-repo-path> <worktree-path> [<commit-ish>]\n\nflags:\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if !*fast {
+		return fmt.Errorf("drive9 git worktree add currently requires --fast")
+	}
+	if *branch != "" && *detach {
+		return fmt.Errorf("-b and --detach are mutually exclusive")
+	}
+	if fs.NArg() < 2 || fs.NArg() > 3 {
+		fs.Usage()
+		return fmt.Errorf("drive9 git worktree add --fast requires <base-repo-path> <worktree-path> [<commit-ish>]")
+	}
+	basePath := fs.Arg(0)
+	worktreePath := fs.Arg(1)
+	commitish := "HEAD"
+	if fs.NArg() == 3 {
+		commitish = fs.Arg(2)
+	}
+	cmdCtx := context.Background()
+
+	baseResolved, err := resolveMountedGitTarget(basePath)
+	if err != nil {
+		return err
+	}
+	worktreeResolved, err := resolveMountedGitTarget(worktreePath)
+	if err != nil {
+		return err
+	}
+	if !sameDrive9Mount(baseResolved, worktreeResolved) {
+		return fmt.Errorf("base repo and worktree path must be inside the same drive9 mount")
+	}
+
+	c := NewFromEnv()
+	ctx, cancel := context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
+	baseWS, err := c.GetGitWorkspaceByRoot(ctx, baseResolved.RemotePath)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("lookup base git workspace :%s: %w", baseResolved.RemotePath, err)
+	}
+	if baseWS.WorkspaceKind != "" && baseWS.WorkspaceKind != "main" {
+		return fmt.Errorf("base repo must be a main fast workspace, got workspace_kind=%q", baseWS.WorkspaceKind)
+	}
+	linkedBlobless := baseWS.Mode == "fast-blobless"
+	if *blobless && !linkedBlobless {
+		return fmt.Errorf("--blobless requires the base workspace to be fast-blobless")
+	}
+	hydrateMode, err := resolveGitHydrateMode(*hydrate, linkedBlobless)
+	if err != nil {
+		return err
+	}
+	resolvedCommit, err := gitOutput(cmdCtx, basePath, "rev-parse", "--verify", commitish+"^{commit}")
+	if err != nil {
+		return fmt.Errorf("resolve commit %q: %w", commitish, err)
+	}
+
+	worktreeArgs := gitFastWorktreeAddArgs(basePath, worktreePath, *branch, *detach || *branch == "", resolvedCommit)
+	if err := runGitStreaming(cmdCtx, worktreeArgs...); err != nil {
+		return fmt.Errorf("git worktree add failed: %w", err)
+	}
+	if err := initializeFastCloneIndex(cmdCtx, worktreePath, resolvedCommit); err != nil {
+		return err
+	}
+	configureFastCloneGitOptimizations(cmdCtx, worktreePath)
+
+	head, err := gitOutput(cmdCtx, worktreePath, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("git rev-parse HEAD in worktree: %w", err)
+	}
+	branchName, branchErr := gitOutput(cmdCtx, worktreePath, "symbolic-ref", "--short", "-q", "HEAD")
+	if branchErr != nil {
+		branchName = ""
+	}
+	nodes, err := gitListTree(cmdCtx, worktreePath, head)
+	if err != nil {
+		return err
+	}
+	treeSHA, treeErr := gitOutput(cmdCtx, worktreePath, "rev-parse", head+"^{tree}")
+	if treeErr != nil {
+		return fmt.Errorf("git rev-parse HEAD^{tree}: %w", treeErr)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), githubTreeAPITimeout)
+	enriched, enrichErr := enrichGitTreeSizesFromGitHub(ctx, baseWS.RepoURL, treeSHA, nodes)
+	cancel()
+	if enrichErr != nil {
+		fmt.Fprintf(os.Stderr, "drive9: warning: could not enrich GitHub tree sizes: %v\n", enrichErr)
+		if unknown := unknownGitTreeFileSizeCount(nodes); unknown > 0 {
+			fmt.Fprintf(os.Stderr, "drive9: warning: %d git file sizes remain unknown; git status may need to read those blobs lazily\n", unknown)
+		}
+	} else {
+		nodes = enriched
+	}
+
+	linkedGitDir, worktreeName, gitDirRel, err := linkedWorktreeGitDirMetadata(worktreeResolved.LocalGitDir, baseResolved.LocalGitDir)
+	if err != nil {
+		return err
+	}
+	mode := "fast"
+	if linkedBlobless {
+		mode = "fast-blobless"
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
+	ws, err := c.UpsertGitWorkspace(ctx, client.GitWorkspaceRequest{
+		RootPath:          worktreeResolved.RemotePath,
+		RepoURL:           baseWS.RepoURL,
+		RemoteName:        baseWS.RemoteName,
+		BranchName:        branchName,
+		BaseCommit:        head,
+		HeadCommit:        head,
+		Mode:              mode,
+		WorkspaceKind:     "linked",
+		CommonWorkspaceID: baseWS.WorkspaceID,
+		WorktreeName:      worktreeName,
+		GitDirRel:         gitDirRel,
+	})
+	cancel()
+	if err != nil {
+		return fmt.Errorf("register linked git workspace: %w", err)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
+	if err := c.ReplaceGitTree(ctx, ws.WorkspaceID, client.GitTreeReplaceRequest{
+		CommitSHA: head,
+		Nodes:     nodes,
+	}); err != nil {
+		cancel()
+		return fmt.Errorf("register linked git tree manifest: %w", err)
+	}
+	cancel()
+	if err := uploadGitStateCheckpoint(cmdCtx, c, ws.WorkspaceID, head, linkedGitDir); err != nil {
+		return err
+	}
+	baseGitDir, err := mainGitStateDirForTarget(basePath, baseResolved)
+	if err != nil {
+		return err
+	}
+	if err := uploadGitStateCheckpoint(cmdCtx, c, baseWS.WorkspaceID, baseWS.HeadCommit, baseGitDir); err != nil {
+		return fmt.Errorf("checkpoint base .git after worktree add: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "drive9: registered linked git workspace %s at :%s (%d tree entries)\n", ws.WorkspaceID, worktreeResolved.RemotePath, len(nodes))
+	if linkedBlobless {
+		switch hydrateMode {
+		case gitHydrateModeSync:
+			ctx, cancel := context.WithTimeout(context.Background(), gitHydrateTimeout)
+			result, err := hydrateMountedGitTarget(ctx, baseWS.RepoURL, worktreeResolved, ws, nodes)
+			cancel()
+			if err != nil {
+				return fmt.Errorf("hydrate linked clean tree: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "drive9: hydrated linked clean tree provider=%s files=%d bytes=%d objects=%d object_bytes=%d duration=%s\n",
+				result.Provider, result.Files, result.Bytes, result.Objects, result.ObjectBytes, result.Duration.Truncate(time.Millisecond))
+		case gitHydrateModeBackground:
+			if err := startGitHydrateBackground(cmdCtx, worktreePath, worktreeResolved, ws); err != nil {
+				fmt.Fprintf(os.Stderr, "drive9: warning: could not start background hydrate: %v\n", err)
+			}
+		}
+	}
+	return nil
+}
+
+func gitFastWorktreeAddArgs(basePath, worktreePath, branch string, detach bool, commit string) []string {
+	args := []string{"-C", basePath, "worktree", "add", "--no-checkout"}
+	if branch != "" {
+		args = append(args, "-b", branch)
+	} else if detach {
+		args = append(args, "--detach")
+	}
+	args = append(args, worktreePath)
+	if commit != "" {
+		args = append(args, commit)
+	}
+	return args
+}
+
+func gitWorktreeRemove(args []string) error {
+	fs := flag.NewFlagSet("git worktree remove", flag.ContinueOnError)
+	fast := fs.Bool("fast", false, "use drive9 git fast worktree remove")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: drive9 git worktree remove --fast <worktree-path>\n\nflags:\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if !*fast {
+		return fmt.Errorf("drive9 git worktree remove currently requires --fast")
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return fmt.Errorf("drive9 git worktree remove --fast requires <worktree-path>")
+	}
+	target := fs.Arg(0)
+	cmdCtx := context.Background()
+	resolved, err := resolveMountedGitTarget(target)
+	if err != nil {
+		return err
+	}
+	c := NewFromEnv()
+	ctx, cancel := context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
+	ws, err := c.GetGitWorkspaceByRoot(ctx, resolved.RemotePath)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("lookup linked git workspace :%s: %w", resolved.RemotePath, err)
+	}
+	if ws.WorkspaceKind != "linked" {
+		return fmt.Errorf("git workspace :%s is not a linked worktree", resolved.RemotePath)
+	}
+	if strings.TrimSpace(ws.CommonWorkspaceID) == "" {
+		return fmt.Errorf("linked git workspace %s has no common_workspace_id", ws.WorkspaceID)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
+	commonWS, err := c.GetGitWorkspace(ctx, ws.CommonWorkspaceID)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("lookup common git workspace %s: %w", ws.CommonWorkspaceID, err)
+	}
+	commonLocalPath, err := localPathForRemoteInMount(resolved, commonWS.RootPath)
+	if err != nil {
+		return err
+	}
+	commonResolved, err := resolveMountedGitTarget(commonLocalPath)
+	if err != nil {
+		return err
+	}
+	if commonResolved.LocalGitDir != "" && strings.TrimSpace(ws.WorktreeName) != "" {
+		if err := os.RemoveAll(filepath.Join(commonResolved.LocalGitDir, "worktrees", ws.WorktreeName)); err != nil {
+			return fmt.Errorf("remove common worktree gitdir: %w", err)
+		}
+		_ = gitRun(cmdCtx, commonLocalPath, "worktree", "prune")
+		if err := uploadGitStateCheckpoint(cmdCtx, c, commonWS.WorkspaceID, commonWS.HeadCommit, commonResolved.LocalGitDir); err != nil {
+			return fmt.Errorf("checkpoint common .git after worktree remove: %w", err)
+		}
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
+	if err := c.DeleteGitWorkspace(ctx, ws.WorkspaceID); err != nil {
+		cancel()
+		return fmt.Errorf("delete linked git workspace: %w", err)
+	}
+	cancel()
+	if overlayRoot, err := localOverlayRootForMountedTarget(resolved); err == nil && overlayRoot != "" {
+		if err := os.RemoveAll(overlayRoot); err != nil {
+			return fmt.Errorf("remove linked local overlay root: %w", err)
+		}
+	}
+	if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "drive9: warning: could not remove empty worktree root %s: %v\n", target, err)
+	}
+	fmt.Fprintf(os.Stderr, "drive9: removed linked git workspace %s at :%s\n", ws.WorkspaceID, resolved.RemotePath)
 	return nil
 }
 
@@ -292,12 +571,16 @@ func hydrateMountedGitTarget(ctx context.Context, repoURL string, resolved mount
 	if repoURL == "" {
 		repoURL = ws.RepoURL
 	}
+	gitDir := resolved.LocalGitDir
+	if parsed, err := gitDirFromMountedGitPath(resolved.LocalGitDir); err == nil && parsed != "" {
+		gitDir = parsed
+	}
 	return gitcache.Hydrate(ctx, gitcache.HydrateOptions{
 		LocalRoot:   resolved.LocalRoot,
 		WorkspaceID: ws.WorkspaceID,
 		Commit:      ws.HeadCommit,
 		RepoURL:     repoURL,
-		GitDir:      resolved.LocalGitDir,
+		GitDir:      gitDir,
 		Token:       githubTokenForRepoURL(repoURL),
 		TreeEntries: gitcacheEntriesFromClient(nodes),
 	})
@@ -377,6 +660,7 @@ func gitcacheEntriesFromClient(nodes []client.GitTreeNode) []gitcache.HydrateTre
 
 type mountedGitTarget struct {
 	MountPoint  string
+	MountRel    string
 	RemoteRoot  string
 	RemotePath  string
 	Profile     string
@@ -424,6 +708,7 @@ func resolveMountedGitTarget(target string) (mountedGitTarget, error) {
 			}
 			return mountedGitTarget{
 				MountPoint:  absMount,
+				MountRel:    rel,
 				RemoteRoot:  state.RemoteRoot,
 				RemotePath:  remotePath,
 				Profile:     state.Profile,
@@ -453,6 +738,164 @@ func localGitDirForMountedTarget(localRoot, rel string) (string, error) {
 		localPath = filepath.Join(localPath, rel)
 	}
 	return filepath.Join(localPath, ".git"), nil
+}
+
+func localOverlayRootForMountedTarget(resolved mountedGitTarget) (string, error) {
+	localRoot := strings.TrimSpace(resolved.LocalRoot)
+	if localRoot == "" {
+		return "", nil
+	}
+	if !filepath.IsAbs(localRoot) {
+		return "", fmt.Errorf("drive9 mount metadata local_root must be absolute, got %q", localRoot)
+	}
+	localPath := filepath.Join(localRoot, "overlay")
+	if resolved.MountRel != "" && resolved.MountRel != "." {
+		localPath = filepath.Join(localPath, resolved.MountRel)
+	}
+	return localPath, nil
+}
+
+func sameDrive9Mount(a, b mountedGitTarget) bool {
+	return filepath.Clean(a.MountPoint) == filepath.Clean(b.MountPoint) &&
+		strings.TrimRight(a.RemoteRoot, "/") == strings.TrimRight(b.RemoteRoot, "/") &&
+		filepath.Clean(a.LocalRoot) == filepath.Clean(b.LocalRoot)
+}
+
+func localPathForRemoteInMount(anchor mountedGitTarget, remotePath string) (string, error) {
+	remote, err := pathutil.CanonicalizeDir(remotePath)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize remote path: %w", err)
+	}
+	root, err := pathutil.CanonicalizeDir(anchor.RemoteRoot)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize mount remote root: %w", err)
+	}
+	cleanRemote := pathpkg.Clean(remote)
+	cleanRoot := pathpkg.Clean(root)
+	rel := ""
+	if cleanRoot == "/" {
+		rel = strings.TrimPrefix(cleanRemote, "/")
+	} else {
+		if cleanRemote != cleanRoot && !strings.HasPrefix(cleanRemote, cleanRoot+"/") {
+			return "", fmt.Errorf("remote path %s is outside mounted remote root %s", remote, root)
+		}
+		rel = strings.TrimPrefix(cleanRemote, cleanRoot)
+		rel = strings.TrimPrefix(rel, "/")
+	}
+	if rel == "" {
+		return anchor.MountPoint, nil
+	}
+	return filepath.Join(anchor.MountPoint, filepath.FromSlash(rel)), nil
+}
+
+func mainGitStateDirForTarget(target string, resolved mountedGitTarget) (string, error) {
+	gitDir := filepath.Join(target, ".git")
+	if resolved.LocalGitDir == "" {
+		return gitDir, nil
+	}
+	info, err := os.Stat(resolved.LocalGitDir)
+	if err == nil {
+		if !info.IsDir() {
+			return "", fmt.Errorf("local .git checkpoint path %s is not a directory", resolved.LocalGitDir)
+		}
+		return resolved.LocalGitDir, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat local .git checkpoint path: %w", err)
+	}
+	return gitDir, nil
+}
+
+func uploadGitStateCheckpoint(ctx context.Context, c *client.Client, workspaceID, checkpointCommit, gitDir string) error {
+	gitState, err := archiveGitStateDir(ctx, gitDir)
+	if err != nil {
+		return fmt.Errorf("checkpoint .git: %w", err)
+	}
+	sum := sha256.Sum256(gitState)
+	apiCtx, cancel := context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
+	defer cancel()
+	if _, err := c.UpsertGitState(apiCtx, workspaceID, client.GitStateRequest{
+		CheckpointCommit: checkpointCommit,
+		StorageType:      gitStateStorageTarGzNoObjects,
+		ChecksumSHA256:   hex.EncodeToString(sum[:]),
+		SizeBytes:        int64(len(gitState)),
+		Content:          gitState,
+	}); err != nil {
+		return fmt.Errorf("upload .git checkpoint: %w", err)
+	}
+	return nil
+}
+
+func linkedWorktreeGitDirMetadata(gitFile, commonGitDir string) (gitDir string, worktreeName string, gitDirRel string, err error) {
+	if strings.TrimSpace(gitFile) == "" {
+		return "", "", "", fmt.Errorf("linked worktree .git file path is unavailable")
+	}
+	data, err := os.ReadFile(gitFile)
+	if err != nil {
+		return "", "", "", fmt.Errorf("read linked worktree .git file: %w", err)
+	}
+	gitDir, err = parseGitDirFile(data, filepath.Dir(gitFile))
+	if err != nil {
+		return "", "", "", err
+	}
+	info, err := os.Stat(gitDir)
+	if err != nil {
+		return "", "", "", fmt.Errorf("stat linked worktree gitdir: %w", err)
+	}
+	if !info.IsDir() {
+		return "", "", "", fmt.Errorf("linked worktree gitdir %s is not a directory", gitDir)
+	}
+	worktreeName = filepath.Base(gitDir)
+	if worktreeName == "." || worktreeName == string(filepath.Separator) || worktreeName == "" {
+		return "", "", "", fmt.Errorf("could not derive linked worktree name from gitdir %s", gitDir)
+	}
+	gitDirRel = filepath.ToSlash(filepath.Join("worktrees", worktreeName))
+	if commonGitDir != "" {
+		if rel, relErr := filepath.Rel(commonGitDir, gitDir); relErr == nil && rel != "." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." {
+			gitDirRel = filepath.ToSlash(rel)
+		}
+	}
+	return gitDir, worktreeName, gitDirRel, nil
+}
+
+func gitDirFromMountedGitPath(gitPath string) (string, error) {
+	if strings.TrimSpace(gitPath) == "" {
+		return "", nil
+	}
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return gitPath, nil
+	}
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", err
+	}
+	return parseGitDirFile(data, filepath.Dir(gitPath))
+}
+
+func parseGitDirFile(data []byte, baseDir string) (string, error) {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		gitDir, ok := strings.CutPrefix(line, "gitdir:")
+		if !ok {
+			continue
+		}
+		gitDir = strings.TrimSpace(gitDir)
+		if gitDir == "" {
+			return "", fmt.Errorf("linked worktree .git file has empty gitdir")
+		}
+		if !filepath.IsAbs(gitDir) {
+			gitDir = filepath.Join(baseDir, gitDir)
+		}
+		return filepath.Clean(gitDir), nil
+	}
+	return "", fmt.Errorf("linked worktree .git file does not contain gitdir")
 }
 
 func relToMountedTarget(absTarget, mountPoint string) (absMount string, rel string, ok bool, err error) {

--- a/cmd/drive9/cli/git.go
+++ b/cmd/drive9/cli/git.go
@@ -256,7 +256,7 @@ func gitWorktreeAdd(args []string) error {
 	}
 	basePath := fs.Arg(0)
 	worktreePath := fs.Arg(1)
-	commitish := "HEAD"
+	commitish := ""
 	if fs.NArg() == 3 {
 		commitish = fs.Arg(2)
 	}
@@ -292,9 +292,12 @@ func gitWorktreeAdd(args []string) error {
 	if err != nil {
 		return err
 	}
-	resolvedCommit, err := gitOutput(cmdCtx, basePath, "rev-parse", "--verify", commitish+"^{commit}")
-	if err != nil {
-		return fmt.Errorf("resolve commit %q: %w", commitish, err)
+	resolvedCommit := ""
+	if commitish != "" {
+		resolvedCommit, err = gitOutput(cmdCtx, basePath, "rev-parse", "--verify", commitish+"^{commit}")
+		if err != nil {
+			return fmt.Errorf("resolve commit %q: %w", commitish, err)
+		}
 	}
 
 	worktreeCommit := gitFastWorktreeAddCommit(*branch, *detach, commitish, resolvedCommit)
@@ -302,15 +305,15 @@ func gitWorktreeAdd(args []string) error {
 	if err := runGitStreaming(cmdCtx, worktreeArgs...); err != nil {
 		return fmt.Errorf("git worktree add failed: %w", err)
 	}
-	if err := initializeFastCloneIndex(cmdCtx, worktreePath, resolvedCommit); err != nil {
-		return err
-	}
-	configureFastCloneGitOptimizations(cmdCtx, worktreePath)
-
 	head, err := gitOutput(cmdCtx, worktreePath, "rev-parse", "HEAD")
 	if err != nil {
 		return fmt.Errorf("git rev-parse HEAD in worktree: %w", err)
 	}
+	if err := initializeFastCloneIndex(cmdCtx, worktreePath, head); err != nil {
+		return err
+	}
+	configureFastCloneGitOptimizations(cmdCtx, worktreePath)
+
 	branchName, branchErr := gitOutput(cmdCtx, worktreePath, "symbolic-ref", "--short", "-q", "HEAD")
 	if branchErr != nil {
 		branchName = ""
@@ -417,6 +420,9 @@ func gitFastWorktreeAddArgs(basePath, worktreePath, branch string, detach bool, 
 }
 
 func gitFastWorktreeAddCommit(branch string, detach bool, commitish, resolvedCommit string) string {
+	if commitish == "" {
+		return ""
+	}
 	if branch != "" || detach {
 		return resolvedCommit
 	}

--- a/cmd/drive9/cli/git.go
+++ b/cmd/drive9/cli/git.go
@@ -67,7 +67,7 @@ commands:
                        create a local .git and register the HEAD tree
   worktree add --fast [-b <branch>] [--detach] [--blobless] [--hydrate=auto|background|sync|off] <base-repo-path> <worktree-path> [<commit-ish>]
                        add a linked worktree without checking out file contents
-  worktree remove --fast <worktree-path>
+  worktree remove --fast [--force] <worktree-path>
                        remove a fast linked worktree without per-file whiteouts
   hydrate <mounted-path>
                        materialize a blobless clean tree into local cache
@@ -226,7 +226,7 @@ func gitWorktreeUsage() {
 
 commands:
   add --fast [-b <branch>] [--detach] [--blobless] [--hydrate=auto|background|sync|off] <base-repo-path> <worktree-path> [<commit-ish>]
-  remove --fast <worktree-path>
+  remove --fast [--force] <worktree-path>
 `)
 }
 
@@ -297,7 +297,8 @@ func gitWorktreeAdd(args []string) error {
 		return fmt.Errorf("resolve commit %q: %w", commitish, err)
 	}
 
-	worktreeArgs := gitFastWorktreeAddArgs(basePath, worktreePath, *branch, *detach || *branch == "", resolvedCommit)
+	worktreeCommit := gitFastWorktreeAddCommit(*branch, *detach, commitish, resolvedCommit)
+	worktreeArgs := gitFastWorktreeAddArgs(basePath, worktreePath, *branch, *detach, worktreeCommit)
 	if err := runGitStreaming(cmdCtx, worktreeArgs...); err != nil {
 		return fmt.Errorf("git worktree add failed: %w", err)
 	}
@@ -415,11 +416,19 @@ func gitFastWorktreeAddArgs(basePath, worktreePath, branch string, detach bool, 
 	return args
 }
 
+func gitFastWorktreeAddCommit(branch string, detach bool, commitish, resolvedCommit string) string {
+	if branch != "" || detach {
+		return resolvedCommit
+	}
+	return commitish
+}
+
 func gitWorktreeRemove(args []string) error {
 	fs := flag.NewFlagSet("git worktree remove", flag.ContinueOnError)
 	fast := fs.Bool("fast", false, "use drive9 git fast worktree remove")
+	force := fs.Bool("force", false, "remove even when the linked worktree has local changes")
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "usage: drive9 git worktree remove --fast <worktree-path>\n\nflags:\n")
+		fmt.Fprintf(os.Stderr, "usage: drive9 git worktree remove --fast [--force] <worktree-path>\n\nflags:\n")
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
@@ -465,6 +474,15 @@ func gitWorktreeRemove(args []string) error {
 	if err != nil {
 		return err
 	}
+	if !*force {
+		clean, status, err := gitWorktreeStatusClean(cmdCtx, target)
+		if err != nil {
+			return fmt.Errorf("check linked worktree status before remove: %w", err)
+		}
+		if !clean {
+			return fmt.Errorf("linked worktree %s has local changes; commit/stash them or rerun with --force\n%s", target, status)
+		}
+	}
 	if commonResolved.LocalGitDir != "" && strings.TrimSpace(ws.WorktreeName) != "" {
 		if err := os.RemoveAll(filepath.Join(commonResolved.LocalGitDir, "worktrees", ws.WorktreeName)); err != nil {
 			return fmt.Errorf("remove common worktree gitdir: %w", err)
@@ -490,6 +508,15 @@ func gitWorktreeRemove(args []string) error {
 	}
 	fmt.Fprintf(os.Stderr, "drive9: removed linked git workspace %s at :%s\n", ws.WorkspaceID, resolved.RemotePath)
 	return nil
+}
+
+func gitWorktreeStatusClean(ctx context.Context, worktreePath string) (bool, string, error) {
+	status, err := gitOutput(ctx, worktreePath, "status", "--porcelain=v1", "--untracked-files=all")
+	if err != nil {
+		return false, "", err
+	}
+	status = strings.TrimSpace(status)
+	return status == "", status, nil
 }
 
 type gitHydrateMode string

--- a/cmd/drive9/cli/git_test.go
+++ b/cmd/drive9/cli/git_test.go
@@ -116,6 +116,17 @@ func TestGitFastCloneArgs(t *testing.T) {
 	}
 }
 
+func TestGitFastWorktreeAddArgs(t *testing.T) {
+	args := gitFastWorktreeAddArgs("/mnt/base", "/mnt/wt", "feature", false, "abc123")
+	if got, want := strings.Join(args, " "), "-C /mnt/base worktree add --no-checkout -b feature /mnt/wt abc123"; got != want {
+		t.Fatalf("branch worktree args = %q, want %q", got, want)
+	}
+	args = gitFastWorktreeAddArgs("/mnt/base", "/mnt/wt", "", true, "abc123")
+	if got, want := strings.Join(args, " "), "-C /mnt/base worktree add --no-checkout --detach /mnt/wt abc123"; got != want {
+		t.Fatalf("detached worktree args = %q, want %q", got, want)
+	}
+}
+
 func TestResolveGitHydrateMode(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -276,6 +287,18 @@ func TestArchiveGitStateDirSkipsObjectDatabases(t *testing.T) {
 	}
 }
 
+func TestParseGitDirFileResolvesRelativeGitDir(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "worktree")
+	got, err := parseGitDirFile([]byte("gitdir: ../repo/.git/worktrees/wt\n"), base)
+	if err != nil {
+		t.Fatalf("parseGitDirFile: %v", err)
+	}
+	want := filepath.Clean(filepath.Join(base, "../repo/.git/worktrees/wt"))
+	if got != want {
+		t.Fatalf("gitdir = %q, want %q", got, want)
+	}
+}
+
 func TestResolveMountedGitTargetUsesMountMetadata(t *testing.T) {
 	mountPoint := t.TempDir()
 	localRoot := t.TempDir()
@@ -305,6 +328,25 @@ func TestResolveMountedGitTargetUsesMountMetadata(t *testing.T) {
 	wantLocalGitDir := filepath.Join(localRoot, "overlay", "repos", "drive9", ".git")
 	if resolved.LocalGitDir != wantLocalGitDir {
 		t.Fatalf("LocalGitDir = %q, want %q", resolved.LocalGitDir, wantLocalGitDir)
+	}
+}
+
+func TestLocalPathForRemoteInMount(t *testing.T) {
+	mountPoint := t.TempDir()
+	resolved := mountedGitTarget{
+		MountPoint: mountPoint,
+		RemoteRoot: "/remote/root/",
+	}
+	got, err := localPathForRemoteInMount(resolved, "/remote/root/repos/wt/")
+	if err != nil {
+		t.Fatalf("localPathForRemoteInMount: %v", err)
+	}
+	want := filepath.Join(mountPoint, "repos", "wt")
+	if got != want {
+		t.Fatalf("local path = %q, want %q", got, want)
+	}
+	if _, err := localPathForRemoteInMount(resolved, "/other/repos/wt/"); err == nil {
+		t.Fatalf("localPathForRemoteInMount outside root err = nil, want error")
 	}
 }
 

--- a/cmd/drive9/cli/git_test.go
+++ b/cmd/drive9/cli/git_test.go
@@ -125,6 +125,55 @@ func TestGitFastWorktreeAddArgs(t *testing.T) {
 	if got, want := strings.Join(args, " "), "-C /mnt/base worktree add --no-checkout --detach /mnt/wt abc123"; got != want {
 		t.Fatalf("detached worktree args = %q, want %q", got, want)
 	}
+	args = gitFastWorktreeAddArgs("/mnt/base", "/mnt/wt", "", false, "feature")
+	if got, want := strings.Join(args, " "), "-C /mnt/base worktree add --no-checkout /mnt/wt feature"; got != want {
+		t.Fatalf("existing branch worktree args = %q, want %q", got, want)
+	}
+}
+
+func TestGitFastWorktreeAddCommitPreservesExistingBranchish(t *testing.T) {
+	if got := gitFastWorktreeAddCommit("", false, "feature", "abc123"); got != "feature" {
+		t.Fatalf("commit arg = %q, want original branchish", got)
+	}
+	if got := gitFastWorktreeAddCommit("new-feature", false, "feature", "abc123"); got != "abc123" {
+		t.Fatalf("new branch commit arg = %q, want resolved commit", got)
+	}
+	if got := gitFastWorktreeAddCommit("", true, "feature", "abc123"); got != "abc123" {
+		t.Fatalf("detached commit arg = %q, want resolved commit", got)
+	}
+}
+
+func TestGitWorktreeStatusClean(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	repo := t.TempDir()
+	runTestGit(t, "", "init", "-b", "main", repo)
+	runTestGit(t, repo, "config", "user.email", "drive9-test@example.invalid")
+	runTestGit(t, repo, "config", "user.name", "Drive9 Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runTestGit(t, repo, "add", ".")
+	runTestGit(t, repo, "commit", "-m", "initial")
+
+	clean, status, err := gitWorktreeStatusClean(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("gitWorktreeStatusClean clean repo: %v", err)
+	}
+	if !clean || status != "" {
+		t.Fatalf("clean=%t status=%q, want clean empty status", clean, status)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	clean, status, err = gitWorktreeStatusClean(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("gitWorktreeStatusClean dirty repo: %v", err)
+	}
+	if clean || !strings.Contains(status, "dirty.txt") {
+		t.Fatalf("clean=%t status=%q, want dirty status", clean, status)
+	}
 }
 
 func TestResolveGitHydrateMode(t *testing.T) {

--- a/cmd/drive9/cli/git_test.go
+++ b/cmd/drive9/cli/git_test.go
@@ -129,9 +129,16 @@ func TestGitFastWorktreeAddArgs(t *testing.T) {
 	if got, want := strings.Join(args, " "), "-C /mnt/base worktree add --no-checkout /mnt/wt feature"; got != want {
 		t.Fatalf("existing branch worktree args = %q, want %q", got, want)
 	}
+	args = gitFastWorktreeAddArgs("/mnt/base", "/mnt/wt", "", false, "")
+	if got, want := strings.Join(args, " "), "-C /mnt/base worktree add --no-checkout /mnt/wt"; got != want {
+		t.Fatalf("omitted commitish worktree args = %q, want %q", got, want)
+	}
 }
 
 func TestGitFastWorktreeAddCommitPreservesExistingBranchish(t *testing.T) {
+	if got := gitFastWorktreeAddCommit("", false, "", "abc123"); got != "" {
+		t.Fatalf("omitted commit arg = %q, want empty", got)
+	}
 	if got := gitFastWorktreeAddCommit("", false, "feature", "abc123"); got != "feature" {
 		t.Fatalf("commit arg = %q, want original branchish", got)
 	}
@@ -140,6 +147,30 @@ func TestGitFastWorktreeAddCommitPreservesExistingBranchish(t *testing.T) {
 	}
 	if got := gitFastWorktreeAddCommit("", true, "feature", "abc123"); got != "abc123" {
 		t.Fatalf("detached commit arg = %q, want resolved commit", got)
+	}
+}
+
+func TestGitWorktreeAddNoCommitishCreatesAttachedBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	worktree := filepath.Join(root, "topic")
+	runTestGit(t, "", "init", "-b", "main", base)
+	runTestGit(t, base, "config", "user.email", "drive9-test@example.invalid")
+	runTestGit(t, base, "config", "user.name", "Drive9 Test")
+	if err := os.WriteFile(filepath.Join(base, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runTestGit(t, base, "add", ".")
+	runTestGit(t, base, "commit", "-m", "initial")
+
+	args := gitFastWorktreeAddArgs(base, worktree, "", false, gitFastWorktreeAddCommit("", false, "", ""))
+	runTestGit(t, "", args...)
+	branch := gitOutputForTest(t, worktree, "symbolic-ref", "--short", "HEAD")
+	if branch != "topic" {
+		t.Fatalf("branch = %q, want topic", branch)
 	}
 }
 

--- a/docs/design/git-fast-clone-workspace.md
+++ b/docs/design/git-fast-clone-workspace.md
@@ -18,6 +18,8 @@ This is therefore not a pure generic filesystem optimization. It is a Git-aware 
 - Working tree changes such as edit/create/delete/chmod/symlink are persisted to the Drive9 backend overlay.
 - `.git` keeps local disk read/write performance while lightweight state and small local-only Git objects are checkpointed to Drive9 for cross-sandbox recovery.
 - `git add`, `git commit`, and `git push` should remain as close as possible to the native Git workflow, without introducing a separate push API.
+- `drive9 git worktree add --fast` should create linked worktrees without native checkout writes into FUSE.
+- `drive9 git worktree remove --fast` should remove a linked fast workspace without recursively unlinking every virtual clean file.
 
 ## Non-Goals
 
@@ -37,6 +39,10 @@ This is therefore not a pure generic filesystem optimization. It is a Git-aware 
 - Key fields: `workspace_id`, `root_path`, `repo_url`, `remote_name`, `branch_name`, `base_commit`, `head_commit`, `mode`, and `status=active`.
 - `mode=fast` is the default full-object local clone; `mode=fast-blobless` is the opt-in blobless local clone.
 - `root_path` is unique and maps to the repo root directory inside the mounted tree.
+- `workspace_kind=main` is a primary fast clone. `workspace_kind=linked` is a Git linked worktree with its own clean tree manifest and dirty overlay.
+- `common_workspace_id` points from a linked worktree to the main/common workspace that owns the shared Git common dir.
+- `worktree_name` is the stable name under the common Git dir's `worktrees/` directory.
+- `gitdir_rel` stores the linked gitdir path relative to the common `.git` directory, normally `worktrees/<worktree_name>`.
 
 `git_workspace_tree_nodes`
 
@@ -95,6 +101,7 @@ Coding-agent local overlay policy
 - These local-only paths are still merged into FUSE directory listings with tracked Git workspace entries, so generated directories under a tracked source directory remain visible to local build tools without being uploaded to Drive9.
 - Local-only dependency and generated-output files are a rebuildable performance layer. Their ordinary FUSE `Flush` path does not force `fsync`; it refreshes local inode metadata only. Explicit `Fsync` still syncs the local file.
 - Lightweight `.git` state is checkpointed asynchronously and coalesced per workspace. Foreground `Flush`, `Fsync`, `Release`, `Rename`, and `Unlink` on local `.git` files only perform the necessary local filesystem operation and schedule a checkpoint; `FlushAll`/unmount drains pending checkpoints.
+- Linked worktree `.git` is a file, not a directory. It is local-only too. On restore, Drive9 rewrites it with a relative `gitdir:` target that points through the mounted path back to the common workspace's `.git/worktrees/<name>` directory, so later Git metadata writes still pass through FUSE and can be checkpointed.
 - Transient Git lock files such as `.git/index.lock`, `.git/packed-refs.lock`, `.git/HEAD.lock`, and `refs/**/*.lock` are never checkpointed. The durable state is captured after Git atomically renames the lock file to its final destination.
 - `.git/objects` remains a local object database/cache and is not checkpointed directly.
 
@@ -154,6 +161,56 @@ Coding-agent local overlay policy
 8. After FUSE rediscovers the workspace, directory listings come from the synthetic view of `git_workspace_tree_nodes` plus `git_workspace_overlay`. FUSE also best-effort starts hydrate for `mode=fast-blobless` workspaces so replacement sandboxes still warm their local cache.
 
 9. In the coding-agent mount profile, FUSE treats repository-ignored generated paths as local-only. The policy first applies explicit local/remote patterns; for otherwise remote-default paths inside a Git workspace, it runs cached `git check-ignore` against the hidden hydrated clean tree and the local `.git` state. Paths that Git would ignore are routed to the local overlay, while tracked clean files and durable Git overlay entries keep their normal Git workspace semantics.
+
+## Fast Worktree Flow
+
+V1 uses explicit Drive9 commands and does not transparently intercept native `git worktree add/remove`:
+
+```bash
+drive9 git worktree add --fast [-b <branch>] [--detach] [--blobless] [--hydrate=auto|background|sync|off] <base-repo-path> <worktree-path> [<commit-ish>]
+drive9 git worktree remove --fast <worktree-path>
+```
+
+`drive9 git worktree add --fast`:
+
+1. Resolves both paths through Drive9 mount metadata and requires them to be in the same mount.
+2. Looks up `<base-repo-path>` as an active `workspace_kind=main` fast workspace.
+3. Runs native Git only for linked worktree metadata:
+
+   ```bash
+   git -C <base-repo-path> worktree add --no-checkout [-b <branch>|--detach] <worktree-path> <resolved-commit>
+   git -C <worktree-path> read-tree --reset <resolved-commit>
+   ```
+
+   The command intentionally avoids a checkout. It creates only the worktree root, the linked `.git` file, the common `.git/worktrees/<name>` metadata, and the Git index.
+
+4. Generates a clean tree manifest with `git ls-tree -r -t -z <commit>`, enriches sizes through the GitHub Trees API when possible, and registers a new `git_workspaces` row with `workspace_kind=linked`.
+5. Stores linked `.git` state as a separate `git_workspace_git_state` row and also checkpoints the common workspace `.git`, because Git updated common metadata such as `worktrees/<name>` and refs.
+6. Uses the same hydrate behavior as fast clone. A linked workspace inherits blobless behavior from a blobless common workspace; `--blobless` is a validation flag rather than a way to convert a full common object database into a partial one.
+
+`drive9 git worktree remove --fast`:
+
+1. Resolves `<worktree-path>` to a linked fast workspace.
+2. Removes the common `.git/worktrees/<name>` metadata from the local overlay and runs `git worktree prune` as best-effort local cleanup.
+3. Checkpoints the common workspace `.git`.
+4. Marks the linked `git_workspaces` row deleted and removes the linked local overlay root.
+5. Best-effort removes the empty mounted worktree root. It does not generate clean-tree whiteouts and does not recursively unlink virtual manifest files.
+
+Linked worktree restore:
+
+1. FUSE matches workspaces by longest `root_path`, so the main repo and each linked worktree get independent runtimes.
+2. Access to a linked worktree `.git` file, or to the common path `.git/worktrees/<name>/...`, triggers linked restore.
+3. FUSE restores the common workspace `.git` first from `repo_url`, common object packs, and the common Git state checkpoint.
+4. FUSE recreates the linked `.git` file, restores the linked gitdir under the common `.git/worktrees/<name>` directory, unpacks linked local-only object packs into the common object database, and extracts the linked lightweight Git state.
+5. Dirty working tree files restore from the linked workspace's own `git_workspace_overlay`, isolated from the common workspace and other linked worktrees.
+
+Performance coverage for issue #476:
+
+- `git worktree add --fast` avoids checkout writes for every clean source file.
+- `git worktree remove --fast` avoids recursive unlink/rmdir over virtual clean tree entries.
+- `git status` and `git add` read tracked metadata from the manifest and overlay instead of round-tripping to generic remote `file_nodes`.
+- `.git` probes, lock files, linked gitdir files, and common worktree metadata stay on local overlay hot paths with coalesced checkpoints.
+- The expected perf-counter movement is lower aggregate `remote stat`, `remote mutation`, `remote write`, and FUSE unlink time for worktree smoke workflows.
 
 ## Read/Edit/Add/Commit/Push Flow
 
@@ -218,6 +275,8 @@ Edit a file:
 7. FUSE downloads and unpacks local-only object packs, then extracts the lightweight `.git` checkpoint over the local clone.
 8. B sees working tree = clean tree manifest + durable overlay; `git status`, `git log`, and file content are restored to A's last persisted state, subject to the explicit oversized staged/local-ref downgrade rules.
 
+For linked worktrees, B restores the common workspace first, then each linked gitdir on demand. Edited files come from the linked workspace overlay, staged state comes from the linked `.git` checkpoint plus small object packs, and local commits/refs are recovered through the common and linked checkpoints together.
+
 ## Local State and SQLite
 
 The current implementation does not introduce SQLite.
@@ -278,4 +337,4 @@ Backend table checks:
 - Branch switching, merge, rebase, conflicts, submodules, and LFS need deeper semantic validation.
 - V1 hydrate does not optimize LFS or submodule object fetching. Non-GitHub repositories use a Git checkout-index fallback, which can be slower than GitHub codeload but still keeps the work out of FUSE read calls.
 - Object database hydrate is a performance layer, not authoritative storage. If a sandbox loses its local root, replacement sandboxes rebuild clean objects from the remote or hidden tree hydrate and restore local-only objects through the existing object-pack checkpoint path.
-- The fast clone E2E should be turned into a repeatable script instead of relying on manual commands.
+- The repeatable live smoke path is `e2e/git-workspace-smoke-test.sh`. It covers fast clone, agent edit/add/commit, sandbox replacement, and fast linked worktree add/edit/stage/commit/remount/remove. Release gates still need to decide when to enable this heavier FUSE workflow by default.

--- a/docs/design/git-fast-clone-workspace.md
+++ b/docs/design/git-fast-clone-workspace.md
@@ -168,7 +168,7 @@ V1 uses explicit Drive9 commands and does not transparently intercept native `gi
 
 ```bash
 drive9 git worktree add --fast [-b <branch>] [--detach] [--blobless] [--hydrate=auto|background|sync|off] <base-repo-path> <worktree-path> [<commit-ish>]
-drive9 git worktree remove --fast <worktree-path>
+drive9 git worktree remove --fast [--force] <worktree-path>
 ```
 
 `drive9 git worktree add --fast`:
@@ -191,10 +191,11 @@ drive9 git worktree remove --fast <worktree-path>
 `drive9 git worktree remove --fast`:
 
 1. Resolves `<worktree-path>` to a linked fast workspace.
-2. Removes the common `.git/worktrees/<name>` metadata from the local overlay and runs `git worktree prune` as best-effort local cleanup.
-3. Checkpoints the common workspace `.git`.
-4. Marks the linked `git_workspaces` row deleted and removes the linked local overlay root.
-5. Best-effort removes the empty mounted worktree root. It does not generate clean-tree whiteouts and does not recursively unlink virtual manifest files.
+2. Refuses removal when `git status --porcelain` reports staged, unstaged, or untracked changes, unless the caller passes `--force`.
+3. Removes the common `.git/worktrees/<name>` metadata from the local overlay and runs `git worktree prune` as best-effort local cleanup.
+4. Checkpoints the common workspace `.git`.
+5. Marks the linked `git_workspaces` row deleted and removes the linked local overlay root.
+6. Best-effort removes the empty mounted worktree root. It does not generate clean-tree whiteouts and does not recursively unlink virtual manifest files.
 
 Linked worktree restore:
 

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -226,7 +226,12 @@ developer machines or EC2-style validation rather than the default smoke path.
    `git add`/`commit`
 7. Sandbox restore scenario: stage tracked and generated edits, unmount, remount
    with a fresh local root, and verify `.git` plus dirty status survive restore
-8. Audit mount logs for fatal FUSE/Git workspace patterns such as short reads
+8. Fast worktree scenario: clone a base workspace, run
+   `drive9 git worktree add --fast --blobless`, commit in the linked worktree,
+   leave another staged edit and unstaged file, unmount, remount with a fresh
+   local root, verify `git worktree list`/`status`/`log`, then remove the
+   linked workspace with `drive9 git worktree remove --fast`
+9. Audit mount logs for fatal FUSE/Git workspace patterns such as short reads
 
 ### `posix-permission-smoke-test.sh`
 
@@ -302,7 +307,7 @@ developer machines or EC2-style validation rather than the default smoke path.
 | `RUN_FUSE_LOG_AUDIT` | `0` (`1` in release gate) | `fuse-smoke-test.sh` |
 | `RUN_GIT_WORKSPACE_SMOKE` | `0` | `smoke-all.sh` |
 | `GIT_WORKSPACE_REPOS` | `drive9=...,kimi-cli=...,kimi-code=...` | `git-workspace-smoke-test.sh` |
-| `GIT_WORKSPACE_SCENARIOS` | `agent_edit_add_commit,agent_patch_apply,sandbox_restore` | `git-workspace-smoke-test.sh` |
+| `GIT_WORKSPACE_SCENARIOS` | `agent_edit_add_commit,agent_patch_apply,sandbox_restore,fast_worktree` | `git-workspace-smoke-test.sh` |
 | `GIT_WORKSPACE_EXISTING_FILES` | `20` | `git-workspace-smoke-test.sh` |
 | `GIT_WORKSPACE_NEW_FILES` | `20` | `git-workspace-smoke-test.sh` |
 | `GIT_WORKSPACE_PATCH_FILES` | `20` | `git-workspace-smoke-test.sh` |

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -229,8 +229,8 @@ developer machines or EC2-style validation rather than the default smoke path.
 8. Fast worktree scenario: clone a base workspace, run
    `drive9 git worktree add --fast --blobless`, commit in the linked worktree,
    leave another staged edit and unstaged file, unmount, remount with a fresh
-   local root, verify `git worktree list`/`status`/`log`, then remove the
-   linked workspace with `drive9 git worktree remove --fast`
+   local root, verify `git worktree list`/`status`/`log`, then force-remove the
+   intentionally dirty linked workspace with `drive9 git worktree remove --fast --force`
 9. Audit mount logs for fatal FUSE/Git workspace patterns such as short reads
 
 ### `posix-permission-smoke-test.sh`

--- a/e2e/git-workspace-smoke-test.sh
+++ b/e2e/git-workspace-smoke-test.sh
@@ -18,7 +18,7 @@ CLI_RELEASE_VERSION="${CLI_RELEASE_VERSION:-}"
 CLI_MAX_RETRIES="${CLI_MAX_RETRIES:-8}"
 CLI_RETRY_SLEEP_S="${CLI_RETRY_SLEEP_S:-2}"
 GIT_WORKSPACE_REPOS="${GIT_WORKSPACE_REPOS:-drive9=https://github.com/mem9-ai/drive9.git,kimi-cli=https://github.com/MoonshotAI/kimi-cli.git,kimi-code=https://github.com/MoonshotAI/kimi-code.git}"
-GIT_WORKSPACE_SCENARIOS="${GIT_WORKSPACE_SCENARIOS:-agent_edit_add_commit,agent_patch_apply,sandbox_restore}"
+GIT_WORKSPACE_SCENARIOS="${GIT_WORKSPACE_SCENARIOS:-agent_edit_add_commit,agent_patch_apply,sandbox_restore,fast_worktree}"
 GIT_WORKSPACE_EXISTING_FILES="${GIT_WORKSPACE_EXISTING_FILES:-20}"
 GIT_WORKSPACE_NEW_FILES="${GIT_WORKSPACE_NEW_FILES:-20}"
 GIT_WORKSPACE_PATCH_FILES="${GIT_WORKSPACE_PATCH_FILES:-20}"
@@ -304,6 +304,15 @@ clone_fast_blobless() {
     drive9 git clone --fast --blobless "--hydrate=$GIT_WORKSPACE_HYDRATE" "$repo_url" "$target"
 }
 
+fast_worktree_add() {
+  local base_repo="$1"
+  local worktree="$2"
+  local branch="$3"
+  local commitish="$4"
+  run_with_timeout "$GIT_WORKSPACE_CLONE_TIMEOUT_S" \
+    drive9 git worktree add --fast --blobless "--hydrate=$GIT_WORKSPACE_HYDRATE" -b "$branch" "$base_repo" "$worktree" "$commitish"
+}
+
 configure_git_identity() {
   local repo="$1"
   git_cmd -C "$repo" config user.email "drive9-e2e@example.test" || return
@@ -389,7 +398,7 @@ assert_clean_status() {
 
 assert_repo_ready() {
   local repo="$1"
-  test -d "$repo/.git" || return
+  test -e "$repo/.git" || return
   git_cmd -C "$repo" rev-parse --is-inside-work-tree >/dev/null || return
   git_cmd -C "$repo" log --oneline -1 >/dev/null || return
   git_cmd -C "$repo" status --porcelain=v1 >/dev/null
@@ -506,12 +515,81 @@ run_sandbox_restore() {
   stop_mount
 }
 
+run_fast_worktree() {
+  local slug="$1" repo_url="$2"
+  local scenario="fast_worktree"
+  local marker="${slug}-${scenario}-$(date +%s)"
+  local case_root="$RUN_ROOT/$slug-$scenario"
+  local mount_point="$case_root/mount"
+  local local_root_a="$case_root/local-root-a"
+  local local_root_b="$case_root/local-root-b"
+  local log_a="$case_root/mount-a.log"
+  local log_b="$case_root/mount-b.log"
+  local base_repo="$mount_point/$slug-$scenario-base"
+  local worktree="$mount_point/$slug-$scenario-linked"
+  local branch="drive9-e2e-${slug}-${scenario}-$(date +%s)"
+  local selected_commit="$case_root/selected-commit.txt"
+  local selected_staged="$case_root/selected-staged.txt"
+  local status_before="$case_root/status-before.txt"
+  local status_after="$case_root/status-after.txt"
+  local cached_before="$case_root/cached-before.txt"
+  local cached_after="$case_root/cached-after.txt"
+  local commit_subject="drive9 e2e $scenario committed $marker"
+  local staged_rel
+  mkdir -p "$case_root"
+
+  echo "[repo=$slug scenario=$scenario] initial mount + fast linked worktree"
+  check_cmd "$slug $scenario first mount starts" start_mount "$mount_point" "$local_root_a" "$log_a"
+  check_cmd "$slug $scenario fast blobless clone base" clone_fast_blobless "$repo_url" "$base_repo"
+  check_cmd "$slug $scenario base repo ready" assert_repo_ready "$base_repo"
+  configure_git_identity "$base_repo"
+  check_cmd "$slug $scenario fast worktree add" fast_worktree_add "$base_repo" "$worktree" "$branch" "HEAD"
+  check_cmd "$slug $scenario linked worktree ready" assert_repo_ready "$worktree"
+  configure_git_identity "$worktree"
+  check_cmd "$slug $scenario base lists linked worktree" bash -c 'git -C "$1" worktree list --porcelain | grep -q "^worktree $2$"' _ "$base_repo" "$worktree"
+
+  check_cmd "$slug $scenario append commit files" select_and_append_existing "$worktree" "$GIT_WORKSPACE_EXISTING_FILES" "$marker-commit" "$selected_commit"
+  check_cmd "$slug $scenario write commit files" write_new_files "$worktree" "$GIT_WORKSPACE_NEW_FILES" "$marker-commit"
+  check_cmd "$slug $scenario linked worktree commit" commit_all "$worktree" "$commit_subject"
+  check_eq "$slug $scenario commit subject before remount" "$(git -C "$worktree" log -1 --pretty=%s)" "$commit_subject"
+
+  check_cmd "$slug $scenario append staged file" select_and_append_existing "$worktree" 1 "$marker-staged" "$selected_staged"
+  staged_rel="$(head -n 1 "$selected_staged")"
+  check_cmd "$slug $scenario git add staged file" git_cmd -C "$worktree" add -- "$staged_rel"
+  mkdir -p "$worktree/agent-bench/worktree"
+  printf 'unstaged linked worktree marker=%s\n' "$marker" > "$worktree/agent-bench/worktree/unstaged.txt"
+  git_cmd -C "$worktree" diff --cached --name-only > "$cached_before"
+  git_cmd -C "$worktree" status --porcelain=v1 > "$status_before"
+  check_cmd "$slug $scenario cached diff before remount" grep -Fxq "$staged_rel" "$cached_before"
+  check_cmd "$slug $scenario dirty status before remount" test -s "$status_before"
+  check_cmd "$slug $scenario first mount log audit" audit_mount_log "$log_a"
+  stop_mount
+
+  echo "[repo=$slug scenario=$scenario] remount with fresh local root"
+  check_cmd "$slug $scenario second mount starts" start_mount "$mount_point" "$local_root_b" "$log_b"
+  check_cmd "$slug $scenario linked .git restored as file" test -f "$worktree/.git"
+  check_cmd "$slug $scenario base .git restored" test -d "$base_repo/.git"
+  check_cmd "$slug $scenario base worktree list restored" bash -c 'git -C "$1" worktree list --porcelain | grep -q "^worktree $2$"' _ "$base_repo" "$worktree"
+  check_cmd "$slug $scenario linked worktree ready after remount" assert_repo_ready "$worktree"
+  check_eq "$slug $scenario commit subject after remount" "$(git -C "$worktree" log -1 --pretty=%s)" "$commit_subject"
+  git_cmd -C "$worktree" diff --cached --name-only > "$cached_after"
+  git_cmd -C "$worktree" status --porcelain=v1 > "$status_after"
+  check_cmd "$slug $scenario cached diff restored" cmp -s "$cached_before" "$cached_after"
+  check_cmd "$slug $scenario status restored" cmp -s "$status_before" "$status_after"
+  check_cmd "$slug $scenario unstaged file restored" grep -q "$marker" "$worktree/agent-bench/worktree/unstaged.txt"
+  check_cmd "$slug $scenario fast worktree remove" drive9 git worktree remove --fast "$worktree"
+  check_cmd "$slug $scenario linked worktree removed from git metadata" bash -c 'out=$(git -C "$1" worktree list --porcelain) && ! printf "%s\n" "$out" | grep -q "^worktree $2$"' _ "$base_repo" "$worktree"
+  check_cmd "$slug $scenario second mount log audit" audit_mount_log "$log_b"
+  stop_mount
+}
+
 run_repo_scenario() {
   local slug="$1" repo_url="$2" scenario="$3"
   case "$scenario" in
     agent_edit_add_commit) run_agent_edit_add_commit "$slug" "$repo_url" ;;
     agent_patch_apply) run_agent_patch_apply "$slug" "$repo_url" ;;
     sandbox_restore) run_sandbox_restore "$slug" "$repo_url" ;;
+    fast_worktree) run_fast_worktree "$slug" "$repo_url" ;;
     *)
       echo "unknown GIT_WORKSPACE_SCENARIOS entry: $scenario" >&2
       FAIL=$((FAIL + 1))

--- a/e2e/git-workspace-smoke-test.sh
+++ b/e2e/git-workspace-smoke-test.sh
@@ -577,7 +577,7 @@ run_fast_worktree() {
   check_cmd "$slug $scenario cached diff restored" cmp -s "$cached_before" "$cached_after"
   check_cmd "$slug $scenario status restored" cmp -s "$status_before" "$status_after"
   check_cmd "$slug $scenario unstaged file restored" grep -q "$marker" "$worktree/agent-bench/worktree/unstaged.txt"
-  check_cmd "$slug $scenario fast worktree remove" drive9 git worktree remove --fast "$worktree"
+  check_cmd "$slug $scenario fast worktree remove" drive9 git worktree remove --fast --force "$worktree"
   check_cmd "$slug $scenario linked worktree removed from git metadata" bash -c 'out=$(git -C "$1" worktree list --porcelain) && ! printf "%s\n" "$out" | grep -q "^worktree $2$"' _ "$base_repo" "$worktree"
   check_cmd "$slug $scenario second mount log audit" audit_mount_log "$log_b"
   stop_mount

--- a/pkg/client/git_workspace.go
+++ b/pkg/client/git_workspace.go
@@ -12,27 +12,35 @@ import (
 )
 
 type GitWorkspaceRequest struct {
-	RootPath   string `json:"root_path"`
-	RepoURL    string `json:"repo_url"`
-	RemoteName string `json:"remote_name,omitempty"`
-	BranchName string `json:"branch_name,omitempty"`
-	BaseCommit string `json:"base_commit,omitempty"`
-	HeadCommit string `json:"head_commit,omitempty"`
-	Mode       string `json:"mode,omitempty"`
+	RootPath          string `json:"root_path"`
+	RepoURL           string `json:"repo_url"`
+	RemoteName        string `json:"remote_name,omitempty"`
+	BranchName        string `json:"branch_name,omitempty"`
+	BaseCommit        string `json:"base_commit,omitempty"`
+	HeadCommit        string `json:"head_commit,omitempty"`
+	Mode              string `json:"mode,omitempty"`
+	WorkspaceKind     string `json:"workspace_kind,omitempty"`
+	CommonWorkspaceID string `json:"common_workspace_id,omitempty"`
+	WorktreeName      string `json:"worktree_name,omitempty"`
+	GitDirRel         string `json:"gitdir_rel,omitempty"`
 }
 
 type GitWorkspace struct {
-	WorkspaceID string    `json:"workspace_id"`
-	RootPath    string    `json:"root_path"`
-	RepoURL     string    `json:"repo_url"`
-	RemoteName  string    `json:"remote_name"`
-	BranchName  string    `json:"branch_name"`
-	BaseCommit  string    `json:"base_commit"`
-	HeadCommit  string    `json:"head_commit"`
-	Mode        string    `json:"mode"`
-	Status      string    `json:"status"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	WorkspaceID       string    `json:"workspace_id"`
+	RootPath          string    `json:"root_path"`
+	RepoURL           string    `json:"repo_url"`
+	RemoteName        string    `json:"remote_name"`
+	BranchName        string    `json:"branch_name"`
+	BaseCommit        string    `json:"base_commit"`
+	HeadCommit        string    `json:"head_commit"`
+	Mode              string    `json:"mode"`
+	WorkspaceKind     string    `json:"workspace_kind"`
+	CommonWorkspaceID string    `json:"common_workspace_id"`
+	WorktreeName      string    `json:"worktree_name"`
+	GitDirRel         string    `json:"gitdir_rel"`
+	Status            string    `json:"status"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
 }
 
 type GitTreeReplaceRequest struct {
@@ -150,6 +158,30 @@ func (c *Client) GetGitWorkspaceByRoot(ctx context.Context, rootPath string) (*G
 		return nil, fmt.Errorf("rootPath must not be empty")
 	}
 	u := c.baseURL + "/v1/git-workspaces?root_path=" + url.QueryEscape(rootPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var out GitWorkspace
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode git workspace: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) GetGitWorkspace(ctx context.Context, workspaceID string) (*GitWorkspace, error) {
+	if strings.TrimSpace(workspaceID) == "" {
+		return nil, fmt.Errorf("workspaceID must not be empty")
+	}
+	u := c.baseURL + "/v1/git-workspaces/" + url.PathEscape(workspaceID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/datastore/git_workspace.go
+++ b/pkg/datastore/git_workspace.go
@@ -12,6 +12,7 @@ import (
 )
 
 type GitWorkspaceMode string
+type GitWorkspaceKind string
 type GitWorkspaceStatus string
 type GitTreeNodeKind string
 type GitOverlayOp string
@@ -20,6 +21,8 @@ type GitOverlayKind string
 const (
 	GitWorkspaceModeFast         GitWorkspaceMode   = "fast"
 	GitWorkspaceModeFastBlobless GitWorkspaceMode   = "fast-blobless"
+	GitWorkspaceKindMain         GitWorkspaceKind   = "main"
+	GitWorkspaceKindLinked       GitWorkspaceKind   = "linked"
 	GitWorkspaceStatusLive       GitWorkspaceStatus = "active"
 	GitWorkspaceStatusDeleted    GitWorkspaceStatus = "deleted"
 
@@ -42,17 +45,21 @@ const (
 // GitWorkspace is the authoritative drive9 record for a git-backed worktree.
 // Clean files are represented by git object metadata rather than file_nodes.
 type GitWorkspace struct {
-	WorkspaceID string
-	RootPath    string
-	RepoURL     string
-	RemoteName  string
-	BranchName  string
-	BaseCommit  string
-	HeadCommit  string
-	Mode        GitWorkspaceMode
-	Status      GitWorkspaceStatus
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	WorkspaceID  string
+	RootPath     string
+	RepoURL      string
+	RemoteName   string
+	BranchName   string
+	BaseCommit   string
+	HeadCommit   string
+	Mode         GitWorkspaceMode
+	Kind         GitWorkspaceKind
+	CommonID     string
+	WorktreeName string
+	GitDirRel    string
+	Status       GitWorkspaceStatus
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 // GitTreeNode describes one entry from a commit tree relative to a workspace
@@ -136,14 +143,18 @@ func (s *Store) UpsertGitWorkspace(ctx context.Context, ws GitWorkspace) error {
 	if ws.Mode == "" {
 		ws.Mode = GitWorkspaceModeFast
 	}
+	if ws.Kind == "" {
+		ws.Kind = GitWorkspaceKindMain
+	}
 	if ws.Status == "" {
 		ws.Status = GitWorkspaceStatusLive
 	}
 	_, err = s.db.ExecContext(ctx, `
 INSERT INTO git_workspaces (
 	workspace_id, root_path, repo_url, remote_name, branch_name,
-	base_commit, head_commit, mode, status, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3))
+	base_commit, head_commit, mode, workspace_kind, common_workspace_id,
+	worktree_name, gitdir_rel, status, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3))
 ON DUPLICATE KEY UPDATE
 	repo_url = VALUES(repo_url),
 	remote_name = VALUES(remote_name),
@@ -151,10 +162,15 @@ ON DUPLICATE KEY UPDATE
 	base_commit = VALUES(base_commit),
 	head_commit = VALUES(head_commit),
 	mode = VALUES(mode),
+	workspace_kind = VALUES(workspace_kind),
+	common_workspace_id = VALUES(common_workspace_id),
+	worktree_name = VALUES(worktree_name),
+	gitdir_rel = VALUES(gitdir_rel),
 	status = VALUES(status),
 	updated_at = UTC_TIMESTAMP(3)`,
 		ws.WorkspaceID, ws.RootPath, ws.RepoURL, ws.RemoteName, ws.BranchName,
-		ws.BaseCommit, ws.HeadCommit, string(ws.Mode), string(ws.Status))
+		ws.BaseCommit, ws.HeadCommit, string(ws.Mode), string(ws.Kind), ws.CommonID,
+		ws.WorktreeName, ws.GitDirRel, string(ws.Status))
 	if err != nil {
 		return fmt.Errorf("upsert git workspace %s: %w", ws.WorkspaceID, err)
 	}
@@ -164,7 +180,8 @@ ON DUPLICATE KEY UPDATE
 func (s *Store) GetGitWorkspace(ctx context.Context, workspaceID string) (*GitWorkspace, error) {
 	row := s.db.QueryRowContext(ctx, `
 SELECT workspace_id, root_path, repo_url, remote_name, branch_name,
-	base_commit, head_commit, mode, status, created_at, updated_at
+	base_commit, head_commit, mode, workspace_kind, common_workspace_id,
+	worktree_name, gitdir_rel, status, created_at, updated_at
 FROM git_workspaces
 WHERE workspace_id = ?`, workspaceID)
 	return scanGitWorkspace(row)
@@ -177,7 +194,8 @@ func (s *Store) GetGitWorkspaceByRoot(ctx context.Context, rootPath string) (*Gi
 	}
 	row := s.db.QueryRowContext(ctx, `
 	SELECT workspace_id, root_path, repo_url, remote_name, branch_name,
-		base_commit, head_commit, mode, status, created_at, updated_at
+		base_commit, head_commit, mode, workspace_kind, common_workspace_id,
+		worktree_name, gitdir_rel, status, created_at, updated_at
 	FROM git_workspaces
 	WHERE root_path = ?`, root)
 	return scanGitWorkspace(row)
@@ -186,7 +204,8 @@ func (s *Store) GetGitWorkspaceByRoot(ctx context.Context, rootPath string) (*Gi
 func (s *Store) ListGitWorkspaces(ctx context.Context) ([]GitWorkspace, error) {
 	rows, err := s.db.QueryContext(ctx, `
 SELECT workspace_id, root_path, repo_url, remote_name, branch_name,
-	base_commit, head_commit, mode, status, created_at, updated_at
+	base_commit, head_commit, mode, workspace_kind, common_workspace_id,
+	worktree_name, gitdir_rel, status, created_at, updated_at
 FROM git_workspaces
 WHERE status = ?
 	ORDER BY root_path`, string(GitWorkspaceStatusLive))
@@ -267,10 +286,11 @@ type gitWorkspaceScanner interface {
 
 func scanGitWorkspace(row gitWorkspaceScanner) (*GitWorkspace, error) {
 	var ws GitWorkspace
-	var mode, status string
+	var mode, kind, status string
 	if err := row.Scan(
 		&ws.WorkspaceID, &ws.RootPath, &ws.RepoURL, &ws.RemoteName, &ws.BranchName,
-		&ws.BaseCommit, &ws.HeadCommit, &mode, &status, &ws.CreatedAt, &ws.UpdatedAt,
+		&ws.BaseCommit, &ws.HeadCommit, &mode, &kind, &ws.CommonID,
+		&ws.WorktreeName, &ws.GitDirRel, &status, &ws.CreatedAt, &ws.UpdatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -278,6 +298,7 @@ func scanGitWorkspace(row gitWorkspaceScanner) (*GitWorkspace, error) {
 		return nil, err
 	}
 	ws.Mode = GitWorkspaceMode(mode)
+	ws.Kind = GitWorkspaceKind(kind)
 	ws.Status = GitWorkspaceStatus(status)
 	return &ws, nil
 }

--- a/pkg/datastore/git_workspace_test.go
+++ b/pkg/datastore/git_workspace_test.go
@@ -5,7 +5,53 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
+
+func TestGitWorkspaceLinkedMetadataRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	initGitWorkspaceTestSchema(t, s)
+	ctx := context.Background()
+	main := GitWorkspace{
+		WorkspaceID: "base",
+		RootPath:    "/repo/",
+		RepoURL:     "https://github.com/example/repo.git",
+		RemoteName:  "origin",
+		BranchName:  "main",
+		BaseCommit:  strings.Repeat("1", 40),
+		HeadCommit:  strings.Repeat("1", 40),
+		Mode:        GitWorkspaceModeFast,
+		Kind:        GitWorkspaceKindMain,
+	}
+	if err := s.UpsertGitWorkspace(ctx, main); err != nil {
+		t.Fatalf("UpsertGitWorkspace main: %v", err)
+	}
+	linked := GitWorkspace{
+		WorkspaceID:  "wt",
+		RootPath:     "/repo-wt/",
+		RepoURL:      main.RepoURL,
+		RemoteName:   "origin",
+		BranchName:   "feature",
+		BaseCommit:   strings.Repeat("2", 40),
+		HeadCommit:   strings.Repeat("2", 40),
+		Mode:         GitWorkspaceModeFastBlobless,
+		Kind:         GitWorkspaceKindLinked,
+		CommonID:     main.WorkspaceID,
+		WorktreeName: "wt",
+		GitDirRel:    "worktrees/wt",
+	}
+	if err := s.UpsertGitWorkspace(ctx, linked); err != nil {
+		t.Fatalf("UpsertGitWorkspace linked: %v", err)
+	}
+	got, err := s.GetGitWorkspaceByRoot(ctx, "/repo-wt")
+	if err != nil {
+		t.Fatalf("GetGitWorkspaceByRoot linked: %v", err)
+	}
+	if got.Kind != GitWorkspaceKindLinked || got.CommonID != "base" || got.WorktreeName != "wt" || got.GitDirRel != "worktrees/wt" {
+		t.Fatalf("linked metadata = %+v", got)
+	}
+}
 
 func TestGitObjectPackRoundTrip(t *testing.T) {
 	s := newTestStore(t)
@@ -38,6 +84,19 @@ func TestGitObjectPackRoundTrip(t *testing.T) {
 	}
 	if len(packs) != 1 || packs[0].PackID != "pack1" || len(packs[0].ContentBlob) != 0 {
 		t.Fatalf("listed packs = %+v, want metadata only", packs)
+	}
+}
+
+func initGitWorkspaceTestSchema(t *testing.T, s *Store) {
+	t.Helper()
+	for _, stmt := range schema.GitWorkspaceTiDBSchemaStatements() {
+		if _, err := s.DB().Exec(stmt); err != nil {
+			msg := strings.ToLower(err.Error())
+			if strings.Contains(msg, "duplicate key name") || strings.Contains(msg, "duplicate column") || strings.Contains(msg, "already exist") {
+				continue
+			}
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -1197,7 +1197,7 @@ func (fs *Dat9FS) ensureLinkedGitStateRestored(ctx context.Context, rt *gitWorks
 	if err != nil {
 		return err
 	}
-	if gitDirLooksUsable(ctx, linkedGitDir) {
+	if _, err := os.Lstat(linkedGitFile); err == nil && gitDirLooksUsable(ctx, linkedGitDir) {
 		if err := fs.writeLinkedGitFile(rt, commonRT, linkedGitFile); err != nil {
 			return err
 		}
@@ -1205,6 +1205,8 @@ func (fs *Dat9FS) ensureLinkedGitStateRestored(ctx context.Context, rt *gitWorks
 		rt.restored = true
 		rt.mu.Unlock()
 		return nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
 	}
 	state, err := fs.client.GetGitState(ctx, rt.workspace.WorkspaceID)
 	if err != nil {

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -306,6 +306,17 @@ func (fs *Dat9FS) linkedGitDir(rt, commonRT *gitWorkspaceRuntime) (string, error
 	if err != nil {
 		return "", err
 	}
+	rel, err := linkedGitDirRel(rt)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(commonGitDir, filepath.FromSlash(rel)), nil
+}
+
+func linkedGitDirRel(rt *gitWorkspaceRuntime) (string, error) {
+	if rt == nil {
+		return "", fmt.Errorf("git workspace runtime is nil")
+	}
 	rel := strings.Trim(strings.TrimSpace(rt.workspace.GitDirRel), "/")
 	if rel == "" {
 		name := strings.TrimSpace(rt.workspace.WorktreeName)
@@ -314,10 +325,15 @@ func (fs *Dat9FS) linkedGitDir(rt, commonRT *gitWorkspaceRuntime) (string, error
 		}
 		rel = path.Join("worktrees", name)
 	}
-	if strings.ContainsRune(rel, '\x00') || strings.HasPrefix(rel, "../") || strings.Contains(rel, "/../") || rel == ".." {
+	if strings.ContainsRune(rel, '\x00') || strings.ContainsRune(rel, '\\') {
 		return "", fmt.Errorf("linked git workspace %s has unsafe gitdir_rel %q", rt.workspace.WorkspaceID, rt.workspace.GitDirRel)
 	}
-	return filepath.Join(commonGitDir, filepath.FromSlash(rel)), nil
+	for _, part := range strings.Split(rel, "/") {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("linked git workspace %s has unsafe gitdir_rel %q", rt.workspace.WorkspaceID, rt.workspace.GitDirRel)
+		}
+	}
+	return path.Clean(rel), nil
 }
 
 func (fs *Dat9FS) writeLinkedGitFile(rt, commonRT *gitWorkspaceRuntime, gitFile string) error {
@@ -327,16 +343,29 @@ func (fs *Dat9FS) writeLinkedGitFile(rt, commonRT *gitWorkspaceRuntime, gitFile 
 	if err := os.MkdirAll(filepath.Dir(gitFile), 0o755); err != nil {
 		return err
 	}
-	name := strings.TrimSpace(rt.workspace.WorktreeName)
-	if name == "" {
-		return fmt.Errorf("linked git workspace %s has no worktree name", rt.workspace.WorkspaceID)
+	relGitDir, err := linkedGitDirRel(rt)
+	if err != nil {
+		return err
 	}
-	target := path.Join(commonRT.localRoot, ".git", "worktrees", name)
+	target := path.Join(commonRT.localRoot, ".git", relGitDir)
 	rel, err := filepath.Rel(filepath.FromSlash(rt.localRoot), filepath.FromSlash(target))
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(gitFile, []byte("gitdir: "+filepath.ToSlash(rel)+"\n"), 0o644)
+}
+
+func (fs *Dat9FS) mountedGitFileForRuntime(rt *gitWorkspaceRuntime, fallback string) string {
+	if rt == nil {
+		return fallback
+	}
+	localGitFile := path.Join(rt.localRoot, ".git")
+	if fs != nil && fs.opts != nil {
+		if mountPoint := strings.TrimSpace(fs.opts.MountPoint); mountPoint != "" {
+			return filepath.Join(mountPoint, filepath.FromSlash(strings.TrimPrefix(localGitFile, "/")))
+		}
+	}
+	return filepath.FromSlash(localGitFile)
 }
 
 func (fs *Dat9FS) gitWorkspaceOwnsPath(ctx context.Context, localPath string) bool {
@@ -1267,13 +1296,22 @@ func (fs *Dat9FS) restoreLinkedGitStateAtomically(ctx context.Context, rt, commo
 	if err := extractGitArchive(state.Content, tmpGitDir); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(tmpGitDir, "commondir"), []byte("../..\n"), 0o644); err != nil {
+	commonGitDir, err := fs.gitDirForRuntime(commonRT)
+	if err != nil {
+		return err
+	}
+	commonDirRel, err := filepath.Rel(linkedGitDir, commonGitDir)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(tmpGitDir, "commondir"), []byte(filepath.ToSlash(commonDirRel)+"\n"), 0o644); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(filepath.Dir(linkedGitFile), 0o755); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(tmpGitDir, "gitdir"), []byte(linkedGitFile+"\n"), 0o644); err != nil {
+	mountedGitFile := fs.mountedGitFileForRuntime(rt, linkedGitFile)
+	if err := os.WriteFile(filepath.Join(tmpGitDir, "gitdir"), []byte(mountedGitFile+"\n"), 0o644); err != nil {
 		return err
 	}
 	if err := os.RemoveAll(linkedGitDir); err != nil {

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -61,6 +61,10 @@ type gitWorkspaceRuntime struct {
 	restored  bool
 }
 
+func (rt *gitWorkspaceRuntime) isLinked() bool {
+	return rt != nil && rt.workspace.WorkspaceKind == "linked"
+}
+
 type gitMaterializeCall struct {
 	done chan struct{}
 	data []byte
@@ -213,6 +217,128 @@ func (fs *Dat9FS) loadedGitWorkspaceForPath(localPath string) (*gitWorkspaceRunt
 	return nil, "", false
 }
 
+func (fs *Dat9FS) loadedGitWorkspaceForGitStatePath(localPath string) (*gitWorkspaceRuntime, string, bool) {
+	rt, rel, ok := fs.loadedGitWorkspaceForPath(localPath)
+	if !ok {
+		return nil, "", false
+	}
+	if linked, linkedRel, linkedOK := fs.linkedWorkspaceForCommonGitStatePath(rt, rel); linkedOK {
+		return linked, linkedRel, true
+	}
+	return rt, rel, true
+}
+
+func (fs *Dat9FS) linkedWorkspaceForCommonGitStatePath(commonRT *gitWorkspaceRuntime, rel string) (*gitWorkspaceRuntime, string, bool) {
+	if fs == nil || fs.git == nil || commonRT == nil || commonRT.isLinked() {
+		return nil, "", false
+	}
+	rel = strings.TrimPrefix(path.Clean("/"+rel), "/")
+	const prefix = ".git/worktrees/"
+	if !strings.HasPrefix(rel, prefix) {
+		return nil, "", false
+	}
+	tail := strings.TrimPrefix(rel, prefix)
+	name, rest, _ := strings.Cut(tail, "/")
+	if name == "" {
+		return nil, "", false
+	}
+	fs.git.mu.Lock()
+	defer fs.git.mu.Unlock()
+	for _, candidate := range fs.git.workspaces {
+		if candidate.workspace.CommonWorkspaceID == commonRT.workspace.WorkspaceID && candidate.workspace.WorktreeName == name {
+			if rest == "" {
+				return candidate, ".git", true
+			}
+			return candidate, ".git/" + rest, true
+		}
+	}
+	return nil, "", false
+}
+
+func (fs *Dat9FS) gitWorkspaceRuntimeByID(workspaceID string) (*gitWorkspaceRuntime, bool) {
+	if fs == nil || fs.git == nil || strings.TrimSpace(workspaceID) == "" {
+		return nil, false
+	}
+	fs.git.mu.Lock()
+	defer fs.git.mu.Unlock()
+	for _, rt := range fs.git.workspaces {
+		if rt.workspace.WorkspaceID == workspaceID {
+			return rt, true
+		}
+	}
+	return nil, false
+}
+
+func (fs *Dat9FS) commonRuntimeForLinked(rt *gitWorkspaceRuntime) (*gitWorkspaceRuntime, error) {
+	if rt == nil {
+		return nil, fmt.Errorf("git workspace runtime is nil")
+	}
+	commonID := strings.TrimSpace(rt.workspace.CommonWorkspaceID)
+	if commonID == "" {
+		return nil, fmt.Errorf("linked git workspace %s has no common workspace id", rt.workspace.WorkspaceID)
+	}
+	commonRT, ok := fs.gitWorkspaceRuntimeByID(commonID)
+	if !ok {
+		return nil, fmt.Errorf("linked git workspace %s common workspace %s is not loaded", rt.workspace.WorkspaceID, commonID)
+	}
+	return commonRT, nil
+}
+
+func (fs *Dat9FS) gitDirForRuntime(rt *gitWorkspaceRuntime) (string, error) {
+	if fs == nil || fs.localOverlay == nil || rt == nil {
+		return "", syscall.EIO
+	}
+	if !rt.isLinked() {
+		return fs.localOverlay.abs(path.Join(rt.localRoot, ".git"))
+	}
+	commonRT, err := fs.commonRuntimeForLinked(rt)
+	if err != nil {
+		return "", err
+	}
+	return fs.linkedGitDir(rt, commonRT)
+}
+
+func (fs *Dat9FS) linkedGitDir(rt, commonRT *gitWorkspaceRuntime) (string, error) {
+	if fs == nil || fs.localOverlay == nil || rt == nil || commonRT == nil {
+		return "", syscall.EIO
+	}
+	commonGitDir, err := fs.localOverlay.abs(path.Join(commonRT.localRoot, ".git"))
+	if err != nil {
+		return "", err
+	}
+	rel := strings.Trim(strings.TrimSpace(rt.workspace.GitDirRel), "/")
+	if rel == "" {
+		name := strings.TrimSpace(rt.workspace.WorktreeName)
+		if name == "" {
+			return "", fmt.Errorf("linked git workspace %s has no worktree name", rt.workspace.WorkspaceID)
+		}
+		rel = path.Join("worktrees", name)
+	}
+	if strings.ContainsRune(rel, '\x00') || strings.HasPrefix(rel, "../") || strings.Contains(rel, "/../") || rel == ".." {
+		return "", fmt.Errorf("linked git workspace %s has unsafe gitdir_rel %q", rt.workspace.WorkspaceID, rt.workspace.GitDirRel)
+	}
+	return filepath.Join(commonGitDir, filepath.FromSlash(rel)), nil
+}
+
+func (fs *Dat9FS) writeLinkedGitFile(rt, commonRT *gitWorkspaceRuntime, gitFile string) error {
+	if rt == nil || commonRT == nil {
+		return fmt.Errorf("linked git runtime is incomplete")
+	}
+	if err := os.MkdirAll(filepath.Dir(gitFile), 0o755); err != nil {
+		return err
+	}
+	name := strings.TrimSpace(rt.workspace.WorktreeName)
+	if name == "" {
+		return fmt.Errorf("linked git workspace %s has no worktree name", rt.workspace.WorkspaceID)
+	}
+	target := path.Join(commonRT.localRoot, ".git", "worktrees", name)
+	rel, err := filepath.Rel(filepath.FromSlash(rt.localRoot), filepath.FromSlash(target))
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(gitFile, []byte("gitdir: "+filepath.ToSlash(rel)+"\n"), 0o644)
+}
+
 func (fs *Dat9FS) gitWorkspaceOwnsPath(ctx context.Context, localPath string) bool {
 	rt, rel, ok := fs.gitWorkspaceForPath(ctx, localPath)
 	if !ok || rel == "" {
@@ -296,7 +422,7 @@ func (fs *Dat9FS) gitCheckIgnoredPath(ctx context.Context, rt *gitWorkspaceRunti
 	if err := fs.ensureGitStateRestored(ctx, rt); err != nil {
 		return false, false
 	}
-	gitDir, err := fs.localOverlay.abs(path.Join(rt.localRoot, ".git"))
+	gitDir, err := fs.gitDirForRuntime(rt)
 	if err != nil {
 		return false, false
 	}
@@ -907,10 +1033,7 @@ func (fs *Dat9FS) gitCatFileBlob(ctx context.Context, rt *gitWorkspaceRuntime, o
 	if err := fs.ensureGitStateRestored(ctx, rt); err != nil {
 		return nil, err
 	}
-	if fs.localOverlay == nil {
-		return nil, syscall.EIO
-	}
-	gitDir, err := fs.localOverlay.abs(path.Join(rt.localRoot, ".git"))
+	gitDir, err := fs.gitDirForRuntime(rt)
 	if err != nil {
 		return nil, err
 	}
@@ -965,6 +1088,9 @@ func (fs *Dat9FS) ensureGitStateRestored(ctx context.Context, rt *gitWorkspaceRu
 	if rt == nil || fs.localOverlay == nil {
 		return nil
 	}
+	if rt.isLinked() {
+		return fs.ensureLinkedGitStateRestored(ctx, rt)
+	}
 	rt.mu.RLock()
 	if rt.restored {
 		rt.mu.RUnlock()
@@ -981,7 +1107,7 @@ func (fs *Dat9FS) ensureGitStateRestored(ctx context.Context, rt *gitWorkspaceRu
 	}
 	rt.mu.RUnlock()
 
-	gitDir, err := fs.localOverlay.abs(path.Join(rt.localRoot, ".git"))
+	gitDir, err := fs.gitDirForRuntime(rt)
 	if err != nil {
 		return err
 	}
@@ -1003,6 +1129,73 @@ func (fs *Dat9FS) ensureGitStateRestored(ctx context.Context, rt *gitWorkspaceRu
 	}
 	if !gitDirLooksUsable(ctx, gitDir) {
 		return fmt.Errorf("git workspace %s restored unusable .git state", rt.workspace.WorkspaceID)
+	}
+	rt.mu.Lock()
+	rt.restored = true
+	rt.mu.Unlock()
+	return nil
+}
+
+func (fs *Dat9FS) ensureLinkedGitStateRestored(ctx context.Context, rt *gitWorkspaceRuntime) error {
+	rt.mu.RLock()
+	if rt.restored {
+		rt.mu.RUnlock()
+		return nil
+	}
+	rt.mu.RUnlock()
+
+	rt.restoreMu.Lock()
+	defer rt.restoreMu.Unlock()
+	rt.mu.RLock()
+	if rt.restored {
+		rt.mu.RUnlock()
+		return nil
+	}
+	rt.mu.RUnlock()
+
+	commonRT, err := fs.commonRuntimeForLinked(rt)
+	if err != nil {
+		return err
+	}
+	if err := fs.ensureGitStateRestored(ctx, commonRT); err != nil {
+		return err
+	}
+	linkedGitDir, err := fs.linkedGitDir(rt, commonRT)
+	if err != nil {
+		return err
+	}
+	linkedGitFile, err := fs.localOverlay.abs(path.Join(rt.localRoot, ".git"))
+	if err != nil {
+		return err
+	}
+	if gitDirLooksUsable(ctx, linkedGitDir) {
+		if err := fs.writeLinkedGitFile(rt, commonRT, linkedGitFile); err != nil {
+			return err
+		}
+		rt.mu.Lock()
+		rt.restored = true
+		rt.mu.Unlock()
+		return nil
+	}
+	state, err := fs.client.GetGitState(ctx, rt.workspace.WorkspaceID)
+	if err != nil {
+		return err
+	}
+	if len(state.Content) == 0 {
+		return fmt.Errorf("git workspace %s has no .git checkpoint", rt.workspace.WorkspaceID)
+	}
+	commonGitDir, err := fs.gitDirForRuntime(commonRT)
+	if err != nil {
+		return err
+	}
+	if err := fs.restoreGitObjectPacks(ctx, rt, commonGitDir); err != nil {
+		return err
+	}
+	if err := fs.restoreLinkedGitStateAtomically(ctx, rt, commonRT, linkedGitDir, linkedGitFile, state); err != nil {
+		return err
+	}
+	if !gitDirLooksUsable(ctx, linkedGitDir) {
+		return fmt.Errorf("git workspace %s restored unusable linked .git state", rt.workspace.WorkspaceID)
 	}
 	rt.mu.Lock()
 	rt.restored = true
@@ -1058,6 +1251,38 @@ func (fs *Dat9FS) restoreGitStateAtomically(ctx context.Context, rt *gitWorkspac
 		return err
 	}
 	return nil
+}
+
+func (fs *Dat9FS) restoreLinkedGitStateAtomically(ctx context.Context, rt, commonRT *gitWorkspaceRuntime, linkedGitDir, linkedGitFile string, state *client.GitState) error {
+	parent := filepath.Dir(linkedGitDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return err
+	}
+	tmpRoot, err := os.MkdirTemp(parent, ".drive9-linked-git-state-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(tmpRoot) }()
+	tmpGitDir := filepath.Join(tmpRoot, rt.workspace.WorktreeName)
+	if err := extractGitArchive(state.Content, tmpGitDir); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(tmpGitDir, "commondir"), []byte("../..\n"), 0o644); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(linkedGitFile), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(tmpGitDir, "gitdir"), []byte(linkedGitFile+"\n"), 0o644); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(linkedGitDir); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpGitDir, linkedGitDir); err != nil {
+		return err
+	}
+	return fs.writeLinkedGitFile(rt, commonRT, linkedGitFile)
 }
 
 func (fs *Dat9FS) restoreGitObjectsFromRemote(ctx context.Context, rt *gitWorkspaceRuntime, gitDir string) error {
@@ -1146,7 +1371,18 @@ func (fs *Dat9FS) restoreGitObjectPacks(ctx context.Context, rt *gitWorkspaceRun
 }
 
 func (fs *Dat9FS) ensureGitStateForLocalPath(ctx context.Context, localPath string) error {
-	rt, rel, ok := fs.gitWorkspaceForPath(ctx, localPath)
+	if fs == nil || fs.git == nil || fs.opts == nil || !fs.opts.EnableGitWorkspaces {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+	refreshCtx, cancel := context.WithTimeout(ctx, fuseTimeout)
+	if err := fs.ensureGitWorkspaces(refreshCtx); err != nil {
+		log.Printf("git workspace refresh failed for %s: %v", localPath, err)
+	}
+	cancel()
+	rt, rel, ok := fs.loadedGitWorkspaceForGitStatePath(localPath)
 	if !ok {
 		return nil
 	}
@@ -1192,18 +1428,16 @@ func (fs *Dat9FS) runGitWorkspaceHydrate(rt *gitWorkspaceRuntime) {
 		fs.perf.gitHydrateStart.add(1)
 	}
 
-	gitDir := ""
-	if fs.localOverlay != nil {
-		if p, err := fs.localOverlay.abs(path.Join(rt.localRoot, ".git")); err == nil {
-			gitDir = p
-		}
-	}
 	if err := fs.ensureGitStateRestored(ctx, rt); err != nil {
 		if fs.perfEnabled() {
 			fs.perf.gitHydrateFailure.add(1)
 		}
 		log.Printf("git workspace hydrate restore failed for %s: %v", rt.workspace.RootPath, err)
 		return
+	}
+	gitDir := ""
+	if p, err := fs.gitDirForRuntime(rt); err == nil {
+		gitDir = p
 	}
 	result, err := gitcache.Hydrate(ctx, gitcache.HydrateOptions{
 		LocalRoot:   fs.opts.LocalRoot,
@@ -1392,7 +1626,7 @@ func (fs *Dat9FS) scheduleGitStateCheckpoint(localPath string) {
 	if fs == nil || fs.gitCheckpoints == nil || !localPathShouldCheckpointGitState(localPath) {
 		return
 	}
-	rt, rel, ok := fs.loadedGitWorkspaceForPath(localPath)
+	rt, rel, ok := fs.loadedGitWorkspaceForGitStatePath(localPath)
 	if !ok || (rel != ".git" && !strings.HasPrefix(rel, ".git/")) {
 		return
 	}
@@ -1410,7 +1644,7 @@ func (fs *Dat9FS) checkpointGitStateForPath(ctx context.Context, localPath strin
 	if fs == nil || !localPathShouldCheckpointGitState(localPath) {
 		return nil
 	}
-	rt, rel, ok := fs.loadedGitWorkspaceForPath(localPath)
+	rt, rel, ok := fs.loadedGitWorkspaceForGitStatePath(localPath)
 	if !ok || (rel != ".git" && !strings.HasPrefix(rel, ".git/")) {
 		return nil
 	}
@@ -1439,7 +1673,7 @@ func (fs *Dat9FS) checkpointGitStateForRuntime(ctx context.Context, rt *gitWorks
 	if fs == nil || fs.git == nil || fs.client == nil || fs.localOverlay == nil || rt == nil {
 		return nil
 	}
-	gitDir, err := fs.localOverlay.abs(path.Join(rt.localRoot, ".git"))
+	gitDir, err := fs.gitDirForRuntime(rt)
 	if err != nil {
 		return err
 	}
@@ -1538,7 +1772,7 @@ func buildLocalGitObjectPack(ctx context.Context, gitDir string, rt *gitWorkspac
 }
 
 func collectLocalRefObjects(ctx context.Context, gitDir string, rt *gitWorkspaceRuntime) (map[string]struct{}, bool, error) {
-	tips, err := collectLocalRefTips(gitDir)
+	tips, err := collectLocalRefTips(ctx, gitDir)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1640,7 +1874,7 @@ func collectStagedLocalObjects(ctx context.Context, gitDir string, rt *gitWorksp
 	return objects, allRestores, restores, nil
 }
 
-func collectLocalRefTips(gitDir string) ([]string, error) {
+func collectLocalRefTips(ctx context.Context, gitDir string) ([]string, error) {
 	seen := make(map[string]struct{})
 	add := func(raw string) {
 		fields := strings.Fields(raw)
@@ -1653,56 +1887,20 @@ func collectLocalRefTips(gitDir string) ([]string, error) {
 		}
 		seen[oid] = struct{}{}
 	}
-	if head, err := os.ReadFile(filepath.Join(gitDir, "HEAD")); err == nil {
-		text := strings.TrimSpace(string(head))
-		if !strings.HasPrefix(text, "ref: ") {
-			add(text)
-		}
-	} else if !os.IsNotExist(err) {
+	if head, err := gitCommandOutputNoLazy(ctx, "--git-dir", gitDir, "rev-parse", "--verify", "HEAD"); err == nil {
+		add(string(head))
+	} else if !isMissingGitObjectError(err) {
 		return nil, err
 	}
-	headsDir := filepath.Join(gitDir, "refs", "heads")
-	if err := filepath.WalkDir(headsDir, func(p string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			if os.IsNotExist(walkErr) {
-				return nil
-			}
-			return walkErr
+	out, err := gitCommandOutputNoLazy(ctx, "--git-dir", gitDir, "for-each-ref", "--format=%(objectname)", "refs/heads", "refs/stash")
+	if err != nil {
+		if !isMissingGitObjectError(err) {
+			return nil, err
 		}
-		if d.IsDir() {
-			return nil
+	} else {
+		for _, line := range strings.Split(string(out), "\n") {
+			add(line)
 		}
-		content, err := os.ReadFile(p)
-		if err != nil {
-			return err
-		}
-		add(string(content))
-		return nil
-	}); err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-	if stash, err := os.ReadFile(filepath.Join(gitDir, "refs", "stash")); err == nil {
-		add(string(stash))
-	} else if err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-	if packed, err := os.ReadFile(filepath.Join(gitDir, "packed-refs")); err == nil {
-		for _, line := range strings.Split(string(packed), "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "^") {
-				continue
-			}
-			fields := strings.Fields(line)
-			if len(fields) < 2 {
-				continue
-			}
-			ref := fields[1]
-			if strings.HasPrefix(ref, "refs/heads/") || ref == "refs/stash" {
-				add(fields[0])
-			}
-		}
-	} else if err != nil && !os.IsNotExist(err) {
-		return nil, err
 	}
 	tips := mapKeys(seen)
 	sort.Strings(tips)

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1223,6 +1223,62 @@ func TestLinkedGitWorkspaceRestoresGitStateWithCommonRuntime(t *testing.T) {
 	}
 }
 
+func TestLinkedGitWorkspaceRestoreIgnoresStaleCommonGitdir(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	linkedRepo := createLinkedGitWorktreeForTest(t)
+	commonState, err := archiveLocalGitDir(linkedRepo.commonGitDir)
+	if err != nil {
+		t.Fatalf("archive common git state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(linkedRepo.linkedWorktree, "README.md"), []byte("staged linked worktree content\n"), 0o644); err != nil {
+		t.Fatalf("write linked readme: %v", err)
+	}
+	runFuseTestGit(t, linkedRepo.linkedWorktree, "add", "README.md")
+	stagedIndex := fuseGitOutputForTest(t, "", "--git-dir", linkedRepo.linkedGitDir, "ls-files", "-s", "--", "README.md")
+	linkedState, err := archiveLocalGitDir(linkedRepo.linkedGitDir)
+	if err != nil {
+		t.Fatalf("archive linked git state: %v", err)
+	}
+
+	localRoot := t.TempDir()
+	overlay := NewLocalOverlay(localRoot)
+	if err := overlay.EnsureRoot(); err != nil {
+		t.Fatalf("EnsureRoot: %v", err)
+	}
+	commonGitDir, err := overlay.abs("/repo/.git")
+	if err != nil {
+		t.Fatalf("common git dir: %v", err)
+	}
+	if err := extractGitArchive(commonState, commonGitDir); err != nil {
+		t.Fatalf("extract common git state: %v", err)
+	}
+
+	fixture := newGitStateOnlyFixture(t)
+	fixture.states["linked"] = client.GitState{
+		WorkspaceID:      "linked",
+		CheckpointCommit: linkedRepo.headCommit,
+		StorageType:      gitStateStorageTarGzNoObjects,
+		SizeBytes:        int64(len(linkedState)),
+		Content:          linkedState,
+	}
+	fs, commonRT, linkedRT := newLinkedGitWorkspaceTestFS(localRoot, overlay, fixture.client(), linkedRepo)
+	commonRT.restored = true
+
+	if err := fs.ensureGitStateRestored(context.Background(), linkedRT); err != nil {
+		t.Fatalf("ensure linked git state restored: %v", err)
+	}
+	restoredLinkedGitDir, err := fs.linkedGitDir(linkedRT, commonRT)
+	if err != nil {
+		t.Fatalf("linked gitdir: %v", err)
+	}
+	restoredIndex := fuseGitOutputForTest(t, "", "--git-dir", restoredLinkedGitDir, "ls-files", "-s", "--", "README.md")
+	if restoredIndex != stagedIndex {
+		t.Fatalf("restored linked index = %q, want %q", restoredIndex, stagedIndex)
+	}
+}
+
 func TestLinkedGitWorkspaceCheckpointUsesLinkedGitdir(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1104,6 +1104,43 @@ func TestWriteLinkedGitFileUsesRelativeMountPath(t *testing.T) {
 	}
 }
 
+func TestWriteLinkedGitFileUsesGitDirRel(t *testing.T) {
+	localRoot := t.TempDir()
+	overlay := NewLocalOverlay(localRoot)
+	if err := overlay.EnsureRoot(); err != nil {
+		t.Fatalf("EnsureRoot: %v", err)
+	}
+	fs := &Dat9FS{localOverlay: overlay}
+	common := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{WorkspaceID: "base", WorkspaceKind: "main"},
+		localRoot: "/repo",
+	}
+	linked := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID:       "wt",
+			WorkspaceKind:     "linked",
+			CommonWorkspaceID: "base",
+			WorktreeName:      "wt",
+			GitDirRel:         "custom/worktrees/wt",
+		},
+		localRoot: "/repo-wt",
+	}
+	gitFile, err := overlay.abs("/repo-wt/.git")
+	if err != nil {
+		t.Fatalf("overlay abs: %v", err)
+	}
+	if err := fs.writeLinkedGitFile(linked, common, gitFile); err != nil {
+		t.Fatalf("writeLinkedGitFile: %v", err)
+	}
+	got, err := os.ReadFile(gitFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "gitdir: ../repo/.git/custom/worktrees/wt\n" {
+		t.Fatalf(".git file = %q", got)
+	}
+}
+
 func TestLinkedGitWorkspaceRestoresGitStateWithCommonRuntime(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")
@@ -1144,6 +1181,7 @@ func TestLinkedGitWorkspaceRestoresGitStateWithCommonRuntime(t *testing.T) {
 	}
 	fs, commonRT, linkedRT := newLinkedGitWorkspaceTestFS(localRoot, overlay, fixture.client(), linkedRepo)
 	commonRT.restored = true
+	linkedRT.workspace.GitDirRel = "custom/worktrees/" + linkedRepo.worktreeName
 
 	if err := fs.ensureGitStateRestored(context.Background(), linkedRT); err != nil {
 		t.Fatalf("ensure linked git state restored: %v", err)
@@ -1153,7 +1191,7 @@ func TestLinkedGitWorkspaceRestoresGitStateWithCommonRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read linked .git file: %v", err)
 	}
-	wantGitFile := "gitdir: ../repo/.git/worktrees/" + linkedRepo.worktreeName + "\n"
+	wantGitFile := "gitdir: ../repo/.git/custom/worktrees/" + linkedRepo.worktreeName + "\n"
 	if string(got) != wantGitFile {
 		t.Fatalf("linked .git file = %q, want %q", got, wantGitFile)
 	}
@@ -1163,6 +1201,21 @@ func TestLinkedGitWorkspaceRestoresGitStateWithCommonRuntime(t *testing.T) {
 	}
 	if !gitDirLooksUsable(context.Background(), restoredLinkedGitDir) {
 		t.Fatalf("restored linked gitdir is not usable: %s", restoredLinkedGitDir)
+	}
+	gitDirFile, err := os.ReadFile(filepath.Join(restoredLinkedGitDir, "gitdir"))
+	if err != nil {
+		t.Fatalf("read restored linked gitdir file: %v", err)
+	}
+	wantMountedGitFile := filepath.Join(fs.opts.MountPoint, "repo-wt", ".git") + "\n"
+	if string(gitDirFile) != wantMountedGitFile {
+		t.Fatalf("restored gitdir file = %q, want %q", gitDirFile, wantMountedGitFile)
+	}
+	commonDir, err := os.ReadFile(filepath.Join(restoredLinkedGitDir, "commondir"))
+	if err != nil {
+		t.Fatalf("read restored commondir: %v", err)
+	}
+	if string(commonDir) != "../../..\n" {
+		t.Fatalf("restored commondir = %q, want ../../..", commonDir)
 	}
 	gotHead := fuseGitOutputForTest(t, "", "--git-dir", restoredLinkedGitDir, "rev-parse", "HEAD")
 	if gotHead != linkedRepo.headCommit {
@@ -1210,14 +1263,14 @@ func TestLinkedGitWorkspaceCheckpointUsesLinkedGitdir(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(linkedGitFile), 0o755); err != nil {
 		t.Fatalf("mkdir linked worktree: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(linkedGitDir, "gitdir"), []byte(linkedGitFile+"\n"), 0o644); err != nil {
-		t.Fatalf("rewrite linked gitdir file: %v", err)
-	}
 
 	fixture := newGitStateOnlyFixture(t)
 	fs, commonRT, linkedRT := newLinkedGitWorkspaceTestFS(localRoot, overlay, fixture.client(), linkedRepo)
 	commonRT.restored = true
 	linkedRT.restored = true
+	if err := os.WriteFile(filepath.Join(linkedGitDir, "gitdir"), []byte(fs.mountedGitFileForRuntime(linkedRT, linkedGitFile)+"\n"), 0o644); err != nil {
+		t.Fatalf("rewrite linked gitdir file: %v", err)
+	}
 	if err := fs.writeLinkedGitFile(linkedRT, commonRT, linkedGitFile); err != nil {
 		t.Fatalf("write linked .git file: %v", err)
 	}
@@ -2690,7 +2743,7 @@ func newLinkedGitWorkspaceTestFS(localRoot string, overlay *LocalOverlay, c *cli
 	}
 	fs := &Dat9FS{
 		client:       c,
-		opts:         &MountOptions{LocalRoot: localRoot, EnableGitWorkspaces: true},
+		opts:         &MountOptions{MountPoint: filepath.Join(localRoot, "mount"), LocalRoot: localRoot, EnableGitWorkspaces: true},
 		git:          newGitWorkspaceLayer(),
 		localOverlay: overlay,
 	}

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -46,6 +47,137 @@ type gitWorkspaceFixture struct {
 	readmeSize      int64
 	failTree        bool
 	failOverlay     bool
+}
+
+type gitStateOnlyFixture struct {
+	mu            sync.Mutex
+	states        map[string]client.GitState
+	statePuts     map[string]int
+	objectPacks   map[string]map[string]client.GitObjectPack
+	objectPackPut map[string]int
+	server        *httptest.Server
+}
+
+func newGitStateOnlyFixture(t *testing.T) *gitStateOnlyFixture {
+	t.Helper()
+	f := &gitStateOnlyFixture{
+		states:        make(map[string]client.GitState),
+		statePuts:     make(map[string]int),
+		objectPacks:   make(map[string]map[string]client.GitObjectPack),
+		objectPackPut: make(map[string]int),
+	}
+	f.server = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *gitStateOnlyFixture) client() *client.Client {
+	return newTestClient(f.server.URL)
+}
+
+func (f *gitStateOnlyFixture) handle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) < 3 || parts[0] != "v1" || parts[1] != "git-workspaces" {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+		return
+	}
+	workspaceID := parts[2]
+	switch {
+	case len(parts) == 4 && parts[3] == "git-state":
+		f.handleGitState(workspaceID, w, r)
+	case len(parts) >= 4 && parts[3] == "object-packs":
+		f.handleObjectPacks(workspaceID, parts[4:], w, r)
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+	}
+}
+
+func (f *gitStateOnlyFixture) handleGitState(workspaceID string, w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	switch r.Method {
+	case http.MethodGet:
+		state, ok := f.states[workspaceID]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(state)
+	case http.MethodPost:
+		var req client.GitStateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		state := client.GitState{
+			WorkspaceID:      workspaceID,
+			CheckpointCommit: req.CheckpointCommit,
+			StorageType:      req.StorageType,
+			ChecksumSHA256:   req.ChecksumSHA256,
+			SizeBytes:        int64(len(req.Content)),
+			Content:          append([]byte(nil), req.Content...),
+			CreatedAt:        time.Now(),
+			UpdatedAt:        time.Now(),
+		}
+		f.states[workspaceID] = state
+		f.statePuts[workspaceID]++
+		_ = json.NewEncoder(w).Encode(state)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (f *gitStateOnlyFixture) handleObjectPacks(workspaceID string, tail []string, w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	packs := f.objectPacks[workspaceID]
+	if packs == nil {
+		packs = make(map[string]client.GitObjectPack)
+		f.objectPacks[workspaceID] = packs
+	}
+	switch {
+	case r.Method == http.MethodGet && len(tail) == 0:
+		out := make([]client.GitObjectPack, 0, len(packs))
+		for _, pack := range packs {
+			pack.Content = nil
+			out = append(out, pack)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"packs": out})
+	case r.Method == http.MethodGet && len(tail) == 1:
+		pack, ok := packs[tail[0]]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(pack)
+	case r.Method == http.MethodPost && len(tail) == 0:
+		var req client.GitObjectPackRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		sum := sha256.Sum256(req.Content)
+		packID := hex.EncodeToString(sum[:])
+		pack := client.GitObjectPack{
+			WorkspaceID:    workspaceID,
+			PackID:         packID,
+			ChecksumSHA256: packID,
+			SizeBytes:      int64(len(req.Content)),
+			Content:        append([]byte(nil), req.Content...),
+			CreatedAt:      time.Now(),
+		}
+		packs[packID] = pack
+		f.objectPackPut[workspaceID]++
+		pack.Content = nil
+		_ = json.NewEncoder(w).Encode(pack)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
 }
 
 func newGitWorkspaceFixture(t *testing.T) *gitWorkspaceFixture {
@@ -901,6 +1033,215 @@ func TestGitWorkspaceRestoresLocalGitStateOnLookup(t *testing.T) {
 	}
 	if !strings.Contains(string(got), "repositoryformatversion") {
 		t.Fatalf("restored config = %q, want git config", got)
+	}
+}
+
+func TestLinkedGitStatePathMapsToLinkedRuntime(t *testing.T) {
+	fs := &Dat9FS{
+		opts: &MountOptions{EnableGitWorkspaces: true},
+		git:  newGitWorkspaceLayer(),
+	}
+	common := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{WorkspaceID: "base", WorkspaceKind: "main"},
+		localRoot: "/repo",
+	}
+	linked := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID:       "wt",
+			WorkspaceKind:     "linked",
+			CommonWorkspaceID: "base",
+			WorktreeName:      "wt",
+		},
+		localRoot: "/repo-wt",
+	}
+	fs.git.workspaces = []*gitWorkspaceRuntime{linked, common}
+
+	got, rel, ok := fs.loadedGitWorkspaceForGitStatePath("/repo/.git/worktrees/wt/index")
+	if !ok {
+		t.Fatalf("linked git state path was not resolved")
+	}
+	if got != linked {
+		t.Fatalf("runtime = %s, want linked", got.workspace.WorkspaceID)
+	}
+	if rel != ".git/index" {
+		t.Fatalf("rel = %q, want .git/index", rel)
+	}
+}
+
+func TestWriteLinkedGitFileUsesRelativeMountPath(t *testing.T) {
+	localRoot := t.TempDir()
+	overlay := NewLocalOverlay(localRoot)
+	if err := overlay.EnsureRoot(); err != nil {
+		t.Fatalf("EnsureRoot: %v", err)
+	}
+	fs := &Dat9FS{localOverlay: overlay}
+	common := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{WorkspaceID: "base", WorkspaceKind: "main"},
+		localRoot: "/repo",
+	}
+	linked := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID:       "wt",
+			WorkspaceKind:     "linked",
+			CommonWorkspaceID: "base",
+			WorktreeName:      "wt",
+		},
+		localRoot: "/repo-wt",
+	}
+	gitFile, err := overlay.abs("/repo-wt/.git")
+	if err != nil {
+		t.Fatalf("overlay abs: %v", err)
+	}
+	if err := fs.writeLinkedGitFile(linked, common, gitFile); err != nil {
+		t.Fatalf("writeLinkedGitFile: %v", err)
+	}
+	got, err := os.ReadFile(gitFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "gitdir: ../repo/.git/worktrees/wt\n" {
+		t.Fatalf(".git file = %q", got)
+	}
+}
+
+func TestLinkedGitWorkspaceRestoresGitStateWithCommonRuntime(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	linkedRepo := createLinkedGitWorktreeForTest(t)
+	commonState, err := archiveLocalGitDir(linkedRepo.commonGitDir)
+	if err != nil {
+		t.Fatalf("archive common git state: %v", err)
+	}
+	linkedState, err := archiveLocalGitDir(linkedRepo.linkedGitDir)
+	if err != nil {
+		t.Fatalf("archive linked git state: %v", err)
+	}
+
+	localRoot := t.TempDir()
+	overlay := NewLocalOverlay(localRoot)
+	if err := overlay.EnsureRoot(); err != nil {
+		t.Fatalf("EnsureRoot: %v", err)
+	}
+	commonGitDir, err := overlay.abs("/repo/.git")
+	if err != nil {
+		t.Fatalf("common git dir: %v", err)
+	}
+	if err := extractGitArchive(commonState, commonGitDir); err != nil {
+		t.Fatalf("extract common git state: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(commonGitDir, "worktrees", linkedRepo.worktreeName)); err != nil {
+		t.Fatalf("remove preexisting linked gitdir: %v", err)
+	}
+
+	fixture := newGitStateOnlyFixture(t)
+	fixture.states["linked"] = client.GitState{
+		WorkspaceID:      "linked",
+		CheckpointCommit: linkedRepo.headCommit,
+		StorageType:      gitStateStorageTarGzNoObjects,
+		SizeBytes:        int64(len(linkedState)),
+		Content:          linkedState,
+	}
+	fs, commonRT, linkedRT := newLinkedGitWorkspaceTestFS(localRoot, overlay, fixture.client(), linkedRepo)
+	commonRT.restored = true
+
+	if err := fs.ensureGitStateRestored(context.Background(), linkedRT); err != nil {
+		t.Fatalf("ensure linked git state restored: %v", err)
+	}
+	linkedGitFile := filepath.Join(localRoot, "overlay", "repo-wt", ".git")
+	got, err := os.ReadFile(linkedGitFile)
+	if err != nil {
+		t.Fatalf("read linked .git file: %v", err)
+	}
+	wantGitFile := "gitdir: ../repo/.git/worktrees/" + linkedRepo.worktreeName + "\n"
+	if string(got) != wantGitFile {
+		t.Fatalf("linked .git file = %q, want %q", got, wantGitFile)
+	}
+	restoredLinkedGitDir, err := fs.linkedGitDir(linkedRT, commonRT)
+	if err != nil {
+		t.Fatalf("linked gitdir: %v", err)
+	}
+	if !gitDirLooksUsable(context.Background(), restoredLinkedGitDir) {
+		t.Fatalf("restored linked gitdir is not usable: %s", restoredLinkedGitDir)
+	}
+	gotHead := fuseGitOutputForTest(t, "", "--git-dir", restoredLinkedGitDir, "rev-parse", "HEAD")
+	if gotHead != linkedRepo.headCommit {
+		t.Fatalf("linked HEAD = %s, want %s", gotHead, linkedRepo.headCommit)
+	}
+}
+
+func TestLinkedGitWorkspaceCheckpointUsesLinkedGitdir(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	linkedRepo := createLinkedGitWorktreeForTest(t)
+	commonState, err := archiveLocalGitDir(linkedRepo.commonGitDir)
+	if err != nil {
+		t.Fatalf("archive common git state: %v", err)
+	}
+	linkedState, err := archiveLocalGitDir(linkedRepo.linkedGitDir)
+	if err != nil {
+		t.Fatalf("archive linked git state: %v", err)
+	}
+
+	localRoot := t.TempDir()
+	overlay := NewLocalOverlay(localRoot)
+	if err := overlay.EnsureRoot(); err != nil {
+		t.Fatalf("EnsureRoot: %v", err)
+	}
+	commonGitDir, err := overlay.abs("/repo/.git")
+	if err != nil {
+		t.Fatalf("common git dir: %v", err)
+	}
+	if err := extractGitArchive(commonState, commonGitDir); err != nil {
+		t.Fatalf("extract common git state: %v", err)
+	}
+	linkedGitDir := filepath.Join(commonGitDir, "worktrees", linkedRepo.worktreeName)
+	if err := os.RemoveAll(linkedGitDir); err != nil {
+		t.Fatalf("clear linked gitdir: %v", err)
+	}
+	if err := extractGitArchive(linkedState, linkedGitDir); err != nil {
+		t.Fatalf("extract linked git state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(linkedGitDir, "commondir"), []byte("../..\n"), 0o644); err != nil {
+		t.Fatalf("rewrite commondir: %v", err)
+	}
+	linkedGitFile := filepath.Join(localRoot, "overlay", "repo-wt", ".git")
+	if err := os.MkdirAll(filepath.Dir(linkedGitFile), 0o755); err != nil {
+		t.Fatalf("mkdir linked worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(linkedGitDir, "gitdir"), []byte(linkedGitFile+"\n"), 0o644); err != nil {
+		t.Fatalf("rewrite linked gitdir file: %v", err)
+	}
+
+	fixture := newGitStateOnlyFixture(t)
+	fs, commonRT, linkedRT := newLinkedGitWorkspaceTestFS(localRoot, overlay, fixture.client(), linkedRepo)
+	commonRT.restored = true
+	linkedRT.restored = true
+	if err := fs.writeLinkedGitFile(linkedRT, commonRT, linkedGitFile); err != nil {
+		t.Fatalf("write linked .git file: %v", err)
+	}
+
+	checkpointPath := "/repo/.git/worktrees/" + linkedRepo.worktreeName + "/index"
+	if err := fs.checkpointGitStateForPath(context.Background(), checkpointPath); err != nil {
+		t.Fatalf("checkpoint linked git state: %v", err)
+	}
+	fixture.mu.Lock()
+	linkedPuts := fixture.statePuts["linked"]
+	commonPuts := fixture.statePuts["base"]
+	state := fixture.states["linked"]
+	fixture.mu.Unlock()
+	if linkedPuts != 1 {
+		t.Fatalf("linked state PUTs = %d, want 1", linkedPuts)
+	}
+	if commonPuts != 0 {
+		t.Fatalf("common state PUTs = %d, want 0", commonPuts)
+	}
+	if state.StorageType != gitStateStorageTarGzNoObjects {
+		t.Fatalf("linked state storage = %q, want %q", state.StorageType, gitStateStorageTarGzNoObjects)
+	}
+	if len(state.Content) == 0 {
+		t.Fatal("linked checkpoint content is empty")
 	}
 }
 
@@ -2259,6 +2600,102 @@ func gitRuntimeForRepo(t *testing.T, repo string) *gitWorkspaceRuntime {
 			},
 		},
 	}
+}
+
+type linkedGitWorktreeForTest struct {
+	sourceRepo     string
+	baseWorktree   string
+	linkedWorktree string
+	commonGitDir   string
+	linkedGitDir   string
+	worktreeName   string
+	headCommit     string
+}
+
+func createLinkedGitWorktreeForTest(t *testing.T) linkedGitWorktreeForTest {
+	t.Helper()
+	sourceRepo := createGitRepoWithReadme(t, []byte("hello base\n"))
+	root := t.TempDir()
+	baseWorktree := filepath.Join(root, "base")
+	linkedWorktree := filepath.Join(root, "linked")
+	runFuseTestGit(t, "", "clone", "--no-checkout", sourceRepo, baseWorktree)
+	headCommit := fuseGitOutputForTest(t, baseWorktree, "rev-parse", "HEAD")
+	runFuseTestGit(t, baseWorktree, "worktree", "add", "--no-checkout", "--detach", linkedWorktree, headCommit)
+	runFuseTestGit(t, linkedWorktree, "read-tree", "--reset", headCommit)
+	linkedGitDir := parseFuseTestGitDirFile(t, filepath.Join(linkedWorktree, ".git"))
+	return linkedGitWorktreeForTest{
+		sourceRepo:     sourceRepo,
+		baseWorktree:   baseWorktree,
+		linkedWorktree: linkedWorktree,
+		commonGitDir:   filepath.Join(baseWorktree, ".git"),
+		linkedGitDir:   linkedGitDir,
+		worktreeName:   filepath.Base(linkedGitDir),
+		headCommit:     headCommit,
+	}
+}
+
+func parseFuseTestGitDirFile(t *testing.T, gitFile string) string {
+	t.Helper()
+	data, err := os.ReadFile(gitFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", gitFile, err)
+	}
+	text := strings.TrimSpace(string(data))
+	const prefix = "gitdir:"
+	if !strings.HasPrefix(text, prefix) {
+		t.Fatalf("%s = %q, want gitdir file", gitFile, text)
+	}
+	target := strings.TrimSpace(strings.TrimPrefix(text, prefix))
+	if target == "" {
+		t.Fatalf("%s has empty gitdir target", gitFile)
+	}
+	if filepath.IsAbs(target) {
+		return filepath.Clean(target)
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(gitFile), filepath.FromSlash(target)))
+}
+
+func newLinkedGitWorkspaceTestFS(localRoot string, overlay *LocalOverlay, c *client.Client, repo linkedGitWorktreeForTest) (*Dat9FS, *gitWorkspaceRuntime, *gitWorkspaceRuntime) {
+	common := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID:   "base",
+			RootPath:      "/repo/",
+			RepoURL:       repo.sourceRepo,
+			RemoteName:    "origin",
+			BranchName:    "main",
+			BaseCommit:    repo.headCommit,
+			HeadCommit:    repo.headCommit,
+			Mode:          "fast-blobless",
+			WorkspaceKind: "main",
+			Status:        "active",
+		},
+		localRoot: "/repo",
+	}
+	linked := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID:       "linked",
+			RootPath:          "/repo-wt/",
+			RepoURL:           repo.sourceRepo,
+			RemoteName:        "origin",
+			BaseCommit:        repo.headCommit,
+			HeadCommit:        repo.headCommit,
+			Mode:              "fast-blobless",
+			WorkspaceKind:     "linked",
+			CommonWorkspaceID: "base",
+			WorktreeName:      repo.worktreeName,
+			GitDirRel:         path.Join("worktrees", repo.worktreeName),
+			Status:            "active",
+		},
+		localRoot: "/repo-wt",
+	}
+	fs := &Dat9FS{
+		client:       c,
+		opts:         &MountOptions{LocalRoot: localRoot, EnableGitWorkspaces: true},
+		git:          newGitWorkspaceLayer(),
+		localOverlay: overlay,
+	}
+	fs.git.workspaces = []*gitWorkspaceRuntime{linked, common}
+	return fs, common, linked
 }
 
 func unpackGitPackForTest(t *testing.T, gitDir string, pack []byte) {

--- a/pkg/server/git_workspace.go
+++ b/pkg/server/git_workspace.go
@@ -26,27 +26,35 @@ const (
 )
 
 type gitWorkspaceRequest struct {
-	RootPath   string `json:"root_path"`
-	RepoURL    string `json:"repo_url"`
-	RemoteName string `json:"remote_name,omitempty"`
-	BranchName string `json:"branch_name,omitempty"`
-	BaseCommit string `json:"base_commit,omitempty"`
-	HeadCommit string `json:"head_commit,omitempty"`
-	Mode       string `json:"mode,omitempty"`
+	RootPath          string `json:"root_path"`
+	RepoURL           string `json:"repo_url"`
+	RemoteName        string `json:"remote_name,omitempty"`
+	BranchName        string `json:"branch_name,omitempty"`
+	BaseCommit        string `json:"base_commit,omitempty"`
+	HeadCommit        string `json:"head_commit,omitempty"`
+	Mode              string `json:"mode,omitempty"`
+	WorkspaceKind     string `json:"workspace_kind,omitempty"`
+	CommonWorkspaceID string `json:"common_workspace_id,omitempty"`
+	WorktreeName      string `json:"worktree_name,omitempty"`
+	GitDirRel         string `json:"gitdir_rel,omitempty"`
 }
 
 type gitWorkspaceResponse struct {
-	WorkspaceID string    `json:"workspace_id"`
-	RootPath    string    `json:"root_path"`
-	RepoURL     string    `json:"repo_url"`
-	RemoteName  string    `json:"remote_name"`
-	BranchName  string    `json:"branch_name"`
-	BaseCommit  string    `json:"base_commit"`
-	HeadCommit  string    `json:"head_commit"`
-	Mode        string    `json:"mode"`
-	Status      string    `json:"status"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	WorkspaceID       string    `json:"workspace_id"`
+	RootPath          string    `json:"root_path"`
+	RepoURL           string    `json:"repo_url"`
+	RemoteName        string    `json:"remote_name"`
+	BranchName        string    `json:"branch_name"`
+	BaseCommit        string    `json:"base_commit"`
+	HeadCommit        string    `json:"head_commit"`
+	Mode              string    `json:"mode"`
+	WorkspaceKind     string    `json:"workspace_kind"`
+	CommonWorkspaceID string    `json:"common_workspace_id"`
+	WorktreeName      string    `json:"worktree_name"`
+	GitDirRel         string    `json:"gitdir_rel"`
+	Status            string    `json:"status"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
 }
 
 type gitTreeReplaceRequest struct {
@@ -194,6 +202,56 @@ func (s *Server) handleGitWorkspaceUpsert(w http.ResponseWriter, r *http.Request
 	if req.BaseCommit == "" {
 		req.BaseCommit = req.HeadCommit
 	}
+	workspaceKind := datastore.GitWorkspaceKind(strings.TrimSpace(req.WorkspaceKind))
+	if workspaceKind == "" {
+		workspaceKind = datastore.GitWorkspaceKindMain
+	}
+	switch workspaceKind {
+	case datastore.GitWorkspaceKindMain, datastore.GitWorkspaceKindLinked:
+	default:
+		errJSON(w, http.StatusBadRequest, "invalid workspace_kind")
+		return
+	}
+	commonWorkspaceID := strings.TrimSpace(req.CommonWorkspaceID)
+	worktreeName := strings.TrimSpace(req.WorktreeName)
+	gitDirRel := strings.TrimSpace(req.GitDirRel)
+	if workspaceKind == datastore.GitWorkspaceKindLinked {
+		if commonWorkspaceID == "" {
+			errJSON(w, http.StatusBadRequest, "common_workspace_id is required for linked git workspaces")
+			return
+		}
+		if worktreeName == "" {
+			errJSON(w, http.StatusBadRequest, "worktree_name is required for linked git workspaces")
+			return
+		}
+		if err := validateGitWorktreeName(worktreeName); err != nil {
+			errJSON(w, http.StatusBadRequest, "invalid worktree_name: "+err.Error())
+			return
+		}
+		if gitDirRel != "" {
+			if err := validateGitMetadataRelativePath(gitDirRel); err != nil {
+				errJSON(w, http.StatusBadRequest, "invalid gitdir_rel: "+err.Error())
+				return
+			}
+		}
+		common, err := store.GetGitWorkspace(r.Context(), commonWorkspaceID)
+		if err != nil {
+			if errors.Is(err, datastore.ErrNotFound) {
+				errJSON(w, http.StatusBadRequest, "common_workspace_id does not reference an active workspace")
+				return
+			}
+			writeGitWorkspaceStoreError(w, err)
+			return
+		}
+		if common.Status != datastore.GitWorkspaceStatusLive || common.Kind == datastore.GitWorkspaceKindLinked {
+			errJSON(w, http.StatusBadRequest, "common_workspace_id does not reference an active main workspace")
+			return
+		}
+	} else {
+		commonWorkspaceID = ""
+		worktreeName = ""
+		gitDirRel = ""
+	}
 
 	workspaceID := token.NewID()
 	existing, err := store.GetGitWorkspaceByRoot(r.Context(), root)
@@ -204,15 +262,19 @@ func (s *Server) handleGitWorkspaceUpsert(w http.ResponseWriter, r *http.Request
 		return
 	}
 	ws := datastore.GitWorkspace{
-		WorkspaceID: workspaceID,
-		RootPath:    root,
-		RepoURL:     repoURL,
-		RemoteName:  strings.TrimSpace(req.RemoteName),
-		BranchName:  strings.TrimSpace(req.BranchName),
-		BaseCommit:  strings.TrimSpace(req.BaseCommit),
-		HeadCommit:  strings.TrimSpace(req.HeadCommit),
-		Mode:        datastore.GitWorkspaceMode(strings.TrimSpace(req.Mode)),
-		Status:      datastore.GitWorkspaceStatusLive,
+		WorkspaceID:  workspaceID,
+		RootPath:     root,
+		RepoURL:      repoURL,
+		RemoteName:   strings.TrimSpace(req.RemoteName),
+		BranchName:   strings.TrimSpace(req.BranchName),
+		BaseCommit:   strings.TrimSpace(req.BaseCommit),
+		HeadCommit:   strings.TrimSpace(req.HeadCommit),
+		Mode:         datastore.GitWorkspaceMode(strings.TrimSpace(req.Mode)),
+		Kind:         workspaceKind,
+		CommonID:     commonWorkspaceID,
+		WorktreeName: worktreeName,
+		GitDirRel:    gitDirRel,
+		Status:       datastore.GitWorkspaceStatusLive,
 	}
 	if ws.RemoteName == "" {
 		ws.RemoteName = "origin"
@@ -721,6 +783,46 @@ func validateInlineContentMetadata(content []byte, sizeBytes int64, checksumSHA2
 	return nil
 }
 
+func validateGitWorktreeName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if len(name) > 255 {
+		return fmt.Errorf("name exceeds 255 bytes")
+	}
+	if strings.ContainsRune(name, '\x00') {
+		return fmt.Errorf("name contains NUL")
+	}
+	if strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
+		return fmt.Errorf("name must be a single safe path segment")
+	}
+	return nil
+}
+
+func validateGitMetadataRelativePath(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	if len(raw) > 1024 {
+		return fmt.Errorf("path exceeds 1024 bytes")
+	}
+	if strings.HasPrefix(raw, "/") {
+		return fmt.Errorf("path must be relative")
+	}
+	if strings.ContainsRune(raw, '\x00') || strings.ContainsRune(raw, '\\') {
+		return fmt.Errorf("path contains invalid character")
+	}
+	for _, part := range strings.Split(raw, "/") {
+		if part == "" || part == "." || part == ".." {
+			return fmt.Errorf("path contains invalid segment %q", part)
+		}
+		if len(part) > 255 {
+			return fmt.Errorf("path segment exceeds 255 bytes")
+		}
+	}
+	return nil
+}
+
 func writeGitWorkspaceStoreError(w http.ResponseWriter, err error) {
 	if errors.Is(err, datastore.ErrNotFound) {
 		errJSON(w, http.StatusNotFound, "not found")
@@ -731,17 +833,21 @@ func writeGitWorkspaceStoreError(w http.ResponseWriter, err error) {
 
 func toGitWorkspaceResponse(ws *datastore.GitWorkspace) gitWorkspaceResponse {
 	return gitWorkspaceResponse{
-		WorkspaceID: ws.WorkspaceID,
-		RootPath:    ws.RootPath,
-		RepoURL:     ws.RepoURL,
-		RemoteName:  ws.RemoteName,
-		BranchName:  ws.BranchName,
-		BaseCommit:  ws.BaseCommit,
-		HeadCommit:  ws.HeadCommit,
-		Mode:        string(ws.Mode),
-		Status:      string(ws.Status),
-		CreatedAt:   ws.CreatedAt,
-		UpdatedAt:   ws.UpdatedAt,
+		WorkspaceID:       ws.WorkspaceID,
+		RootPath:          ws.RootPath,
+		RepoURL:           ws.RepoURL,
+		RemoteName:        ws.RemoteName,
+		BranchName:        ws.BranchName,
+		BaseCommit:        ws.BaseCommit,
+		HeadCommit:        ws.HeadCommit,
+		Mode:              string(ws.Mode),
+		WorkspaceKind:     string(ws.Kind),
+		CommonWorkspaceID: ws.CommonID,
+		WorktreeName:      ws.WorktreeName,
+		GitDirRel:         ws.GitDirRel,
+		Status:            string(ws.Status),
+		CreatedAt:         ws.CreatedAt,
+		UpdatedAt:         ws.UpdatedAt,
 	}
 }
 

--- a/pkg/server/git_workspace.go
+++ b/pkg/server/git_workspace.go
@@ -256,6 +256,10 @@ func (s *Server) handleGitWorkspaceUpsert(w http.ResponseWriter, r *http.Request
 	workspaceID := token.NewID()
 	existing, err := store.GetGitWorkspaceByRoot(r.Context(), root)
 	if err == nil {
+		if workspaceKind == datastore.GitWorkspaceKindLinked && commonWorkspaceID == existing.WorkspaceID {
+			errJSON(w, http.StatusBadRequest, "linked git workspace cannot reference itself as common_workspace_id")
+			return
+		}
 		workspaceID = existing.WorkspaceID
 	} else if !errors.Is(err, datastore.ErrNotFound) {
 		writeGitWorkspaceStoreError(w, err)

--- a/pkg/server/git_workspace_test.go
+++ b/pkg/server/git_workspace_test.go
@@ -57,7 +57,10 @@ func TestGitWorkspaceUpsertRejectsSelfLinkedWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	gotBody, _ := io.ReadAll(resp.Body)
+	gotBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400, body=%s", resp.StatusCode, gotBody)
 	}

--- a/pkg/server/git_workspace_test.go
+++ b/pkg/server/git_workspace_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
+)
+
+func TestGitWorkspaceUpsertRejectsSelfLinkedWorkspace(t *testing.T) {
+	s := newTestServer(t)
+	for _, stmt := range schema.GitWorkspaceTiDBSchemaStatements() {
+		if _, err := s.fallback.Store().DB().Exec(stmt); err != nil {
+			msg := strings.ToLower(err.Error())
+			if strings.Contains(msg, "duplicate key name") || strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate column") {
+				continue
+			}
+			t.Fatal(err)
+		}
+	}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	c := client.New(ts.URL, "")
+	mainWS, err := c.UpsertGitWorkspace(context.Background(), client.GitWorkspaceRequest{
+		RootPath:   "/repo/",
+		RepoURL:    "https://example.test/repo.git",
+		RemoteName: "origin",
+		HeadCommit: "1111111111111111111111111111111111111111",
+	})
+	if err != nil {
+		t.Fatalf("UpsertGitWorkspace main: %v", err)
+	}
+
+	body, err := json.Marshal(client.GitWorkspaceRequest{
+		RootPath:          "/repo/",
+		RepoURL:           "https://example.test/repo.git",
+		RemoteName:        "origin",
+		HeadCommit:        "1111111111111111111111111111111111111111",
+		WorkspaceKind:     "linked",
+		CommonWorkspaceID: mainWS.WorkspaceID,
+		WorktreeName:      "repo-wt",
+		GitDirRel:         "worktrees/repo-wt",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(ts.URL+"/v1/git-workspaces", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	gotBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", resp.StatusCode, gotBody)
+	}
+	if !strings.Contains(string(gotBody), "cannot reference itself") {
+		t.Fatalf("body = %s, want self-link error", gotBody)
+	}
+}

--- a/pkg/tenant/schema/git_workspace.go
+++ b/pkg/tenant/schema/git_workspace.go
@@ -23,6 +23,9 @@ func GitWorkspaceTiDBSchemaStatements() []string {
 			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
 		)`,
+		// Repair existing git_workspaces tables created before linked worktree
+		// metadata existed. ExecSchemaStatementsContext tolerates duplicate
+		// column errors for fresh schemas.
 		`ALTER TABLE git_workspaces ADD COLUMN workspace_kind VARCHAR(16) NOT NULL DEFAULT 'main'`,
 		`ALTER TABLE git_workspaces ADD COLUMN common_workspace_id VARCHAR(64) NOT NULL DEFAULT ''`,
 		`ALTER TABLE git_workspaces ADD COLUMN worktree_name VARCHAR(255) NOT NULL DEFAULT ''`,
@@ -116,6 +119,9 @@ func GitWorkspaceDB9SchemaStatements() []string {
 			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
+		// Repair existing git_workspaces tables created before linked worktree
+		// metadata existed. ExecSchemaStatementsContext tolerates duplicate
+		// column errors for fresh schemas.
 		`ALTER TABLE git_workspaces ADD COLUMN workspace_kind VARCHAR(16) NOT NULL DEFAULT 'main'`,
 		`ALTER TABLE git_workspaces ADD COLUMN common_workspace_id VARCHAR(64) NOT NULL DEFAULT ''`,
 		`ALTER TABLE git_workspaces ADD COLUMN worktree_name VARCHAR(255) NOT NULL DEFAULT ''`,

--- a/pkg/tenant/schema/git_workspace.go
+++ b/pkg/tenant/schema/git_workspace.go
@@ -15,12 +15,21 @@ func GitWorkspaceTiDBSchemaStatements() []string {
 			base_commit  VARCHAR(64) NOT NULL DEFAULT '',
 			head_commit  VARCHAR(64) NOT NULL DEFAULT '',
 			mode         VARCHAR(32) NOT NULL DEFAULT 'fast',
+			workspace_kind VARCHAR(16) NOT NULL DEFAULT 'main',
+			common_workspace_id VARCHAR(64) NOT NULL DEFAULT '',
+			worktree_name VARCHAR(255) NOT NULL DEFAULT '',
+			gitdir_rel VARCHAR(1024) NOT NULL DEFAULT '',
 			status       VARCHAR(32) NOT NULL DEFAULT 'active',
 			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
 		)`,
+		`ALTER TABLE git_workspaces ADD COLUMN workspace_kind VARCHAR(16) NOT NULL DEFAULT 'main'`,
+		`ALTER TABLE git_workspaces ADD COLUMN common_workspace_id VARCHAR(64) NOT NULL DEFAULT ''`,
+		`ALTER TABLE git_workspaces ADD COLUMN worktree_name VARCHAR(255) NOT NULL DEFAULT ''`,
+		`ALTER TABLE git_workspaces ADD COLUMN gitdir_rel VARCHAR(1024) NOT NULL DEFAULT ''`,
 		`CREATE UNIQUE INDEX uk_git_workspaces_root ON git_workspaces(root_path)`,
 		`CREATE INDEX idx_git_workspaces_status ON git_workspaces(status, updated_at)`,
+		`CREATE INDEX idx_git_workspaces_common ON git_workspaces(common_workspace_id, status)`,
 
 		`CREATE TABLE IF NOT EXISTS git_workspace_tree_nodes (
 			workspace_id VARCHAR(64) NOT NULL,
@@ -99,12 +108,21 @@ func GitWorkspaceDB9SchemaStatements() []string {
 			base_commit  VARCHAR(64) NOT NULL DEFAULT '',
 			head_commit  VARCHAR(64) NOT NULL DEFAULT '',
 			mode         VARCHAR(32) NOT NULL DEFAULT 'fast',
+			workspace_kind VARCHAR(16) NOT NULL DEFAULT 'main',
+			common_workspace_id VARCHAR(64) NOT NULL DEFAULT '',
+			worktree_name VARCHAR(255) NOT NULL DEFAULT '',
+			gitdir_rel VARCHAR(1024) NOT NULL DEFAULT '',
 			status       VARCHAR(32) NOT NULL DEFAULT 'active',
 			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
+		`ALTER TABLE git_workspaces ADD COLUMN workspace_kind VARCHAR(16) NOT NULL DEFAULT 'main'`,
+		`ALTER TABLE git_workspaces ADD COLUMN common_workspace_id VARCHAR(64) NOT NULL DEFAULT ''`,
+		`ALTER TABLE git_workspaces ADD COLUMN worktree_name VARCHAR(255) NOT NULL DEFAULT ''`,
+		`ALTER TABLE git_workspaces ADD COLUMN gitdir_rel VARCHAR(1024) NOT NULL DEFAULT ''`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS uk_git_workspaces_root ON git_workspaces(root_path)`,
 		`CREATE INDEX IF NOT EXISTS idx_git_workspaces_status ON git_workspaces(status, updated_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_git_workspaces_common ON git_workspaces(common_workspace_id, status)`,
 
 		`CREATE TABLE IF NOT EXISTS git_workspace_tree_nodes (
 			workspace_id VARCHAR(64) NOT NULL,


### PR DESCRIPTION
## Summary

This PR adds an explicit fast Git worktree workflow on top of the existing Drive9 fast clone / Git workspace implementation:

```bash
drive9 git worktree add --fast [-b <branch>] [--detach] [--blobless] [--hydrate=auto|background|sync|off] <base-repo-path> <worktree-path> [<commit-ish>]
drive9 git worktree remove --fast <worktree-path>
```

The goal is to make linked worktrees fast in Drive9-mounted coding-agent directories without transparently intercepting native `git worktree add/remove`. Native Git still works, but the optimized path is explicit and avoids the metadata and mutation amplification described in #476.

## Design

The implementation keeps Git semantics, but avoids checking out every clean file through FUSE:

- `worktree add --fast` runs native Git with `worktree add --no-checkout`, then initializes the linked worktree index with `git read-tree --reset <commit>`.
- Each linked worktree is registered as its own `git_workspace` row with `workspace_kind=linked`, `common_workspace_id`, `worktree_name`, and `gitdir_rel`.
- The linked worktree gets its own clean tree manifest and dirty overlay, isolated from the base workspace and other linked worktrees.
- The common `.git` directory remains in the local overlay, while linked worktree-specific state is checkpointed separately.
- Restore is on demand: Drive9 restores the common workspace `.git` first, then recreates the linked `.git` file and linked gitdir under `.git/worktrees/<name>`.
- Small local-only Git objects continue to use inline object packs; clean remote blobs stay out of Drive9 backend storage.

This preserves the existing blobless/full fast-clone behavior. `--blobless` on worktree add is a validation flag: it requires the base workspace to be blobless rather than converting an existing full-object common object database.

## Implementation Details

### CLI

- Adds `drive9 git worktree add --fast` and `drive9 git worktree remove --fast`.
- Validates base and linked worktree paths are inside the same Drive9 mount.
- Requires the base repository to already be an active main fast workspace.
- Registers linked workspace metadata and tree manifest after `--no-checkout` worktree creation.
- Checkpoints both linked gitdir state and common `.git` state after add/remove.
- Removes linked worktrees without recursively unlinking every virtual clean-tree file.

### Backend/API/Schema

- Extends `git_workspaces` with linked-worktree metadata:
  - `workspace_kind`
  - `common_workspace_id`
  - `worktree_name`
  - `gitdir_rel`
- Adds validation for linked workspace registration.
- Keeps tree nodes, dirty overlay, Git state checkpoints, and object packs isolated per workspace id.
- Adds schema repair ALTER statements so existing tenant schemas can pick up the new columns/indexes.

### FUSE

- Matches Git workspaces by longest root prefix, so base repositories and linked worktrees can coexist under the same mount.
- Maps common `.git/worktrees/<name>/...` paths back to the owning linked workspace runtime.
- Restores linked worktrees by first restoring the common runtime, then writing the linked `.git` file and extracting linked gitdir state.
- Uses `gitDirForRuntime` for linked checkpoint/check-ignore paths so linked worktrees use `.git/worktrees/<name>` rather than the `.git` file as a directory.
- Collects local refs through Git commands, which works for linked gitdirs that share common refs.

### E2E Smoke Coverage

`e2e/git-workspace-smoke-test.sh` now includes a default `fast_worktree` scenario. It covers:

- fast blobless clone of the base repository
- `drive9 git worktree add --fast --blobless`
- commit from the linked worktree
- staged edit plus unstaged dirty file
- unmount/remount with a fresh local root to simulate sandbox replacement
- restored `git worktree list`, `git status`, and `git log`
- `drive9 git worktree remove --fast`

## Issue #476 Coverage

This PR addresses the issue by providing an explicit optimized path for Git worktree operations:

- add avoids checkout writes for every clean source file
- remove avoids recursive unlink/rmdir over virtual clean tree entries
- status/add/commit hot paths use the Git workspace manifest, local overlay, and local `.git` state instead of generic remote `file_nodes` operations
- linked gitdir probes and lock files stay on local overlay paths with coalesced checkpoints

## Tests

Ran locally:

```bash
bash -n e2e/git-workspace-smoke-test.sh
go test ./pkg/fuse -run 'TestLinkedGitWorkspace|TestLinkedGitStatePath|TestWriteLinkedGitFile'
go test ./pkg/fuse
go test ./cmd/drive9/cli
go test ./cmd/drive9 ./cmd/drive9/cli ./pkg/fuse
git diff --check
```

Note: I added the repeatable live FUSE smoke scenario, but did not run it against a live dev deployment in this local PR creation step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added linked "fast" worktree support and CLI: `drive9 git worktree add/remove --fast` with blobless/hydration options; server & client now accept and return linked-workspace metadata and validate worktree inputs.

* **Tests**
  * Added extensive unit, integration, and e2e coverage including a `fast_worktree` smoke scenario for add/commit/remount/remove and checkpoint/restore behavior.

* **Documentation**
  * Updated design doc and e2e docs/scripts to describe fast linked worktree flows and test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->