### PR TITLE
fix: allow auto-repair of primary key changes during schema validation

### DIFF
--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -1435,12 +1435,22 @@ func diffTiDBTableMetaWithObservedIndexes(table tidbTableSpec, meta tidbTableMet
 	if len(table.primaryKey.columns) > 0 {
 		actualPrimaryKey, ok := parsePrimaryKeyColumnsFromCreateStatement(createStmt)
 		if !ok {
-			diffs = append(diffs, tidbSchemaDiff{
-				kind:      tidbSchemaDiffTableContract,
-				tableName: table.name,
-				detail:    fmt.Sprintf("%s schema contract: missing primary key constraint", table.name),
-				repairSQL: table.primaryKey.repairSQL(table.name, false),
-			})
+			// Distinguish "unable to parse CREATE statement" from "parsed OK but no PK found".
+			// Only attempt repair when we successfully parsed the statement and confirmed the PK is missing.
+			if _, _, parseOk, parseErr := parseCreateTableStatement(createStmt); parseErr != nil || !parseOk {
+				diffs = append(diffs, tidbSchemaDiff{
+					kind:      tidbSchemaDiffTableContract,
+					tableName: table.name,
+					detail:    fmt.Sprintf("%s schema contract: unable to inspect primary key", table.name),
+				})
+			} else {
+				diffs = append(diffs, tidbSchemaDiff{
+					kind:      tidbSchemaDiffTableContract,
+					tableName: table.name,
+					detail:    fmt.Sprintf("%s schema contract: missing primary key constraint", table.name),
+					repairSQL: table.primaryKey.repairSQL(table.name, false),
+				})
+			}
 		} else if !equalStringSlices(actualPrimaryKey, table.primaryKey.columns) {
 			diffs = append(diffs, tidbSchemaDiff{
 				kind:      tidbSchemaDiffTableContract,
@@ -1657,7 +1667,28 @@ func isSafeTiDBRepairDiff(diff tidbSchemaDiff) bool {
 
 func isSafePrimaryKeyRepairSQL(sqlText string) bool {
 	normalized := normalizeSQLFragment(sqlText)
-	return strings.HasPrefix(normalized, "alter table ") && strings.Contains(normalized, "primary key")
+	if !strings.HasPrefix(normalized, "alter table ") {
+		return false
+	}
+	// Disallow statement chaining in safety gate.
+	if strings.Contains(normalized, ";") {
+		return false
+	}
+	// Reject statements that contain other ALTER actions besides PK changes.
+	disallowed := []string{
+		" add column ", " drop column ", " modify ", " change ", " rename ",
+		" drop index ", " add index ", " add unique ", " add constraint ",
+		" add key ", " drop key ", " add fulltext ", " add vector ",
+	}
+	for _, token := range disallowed {
+		if strings.Contains(normalized, token) {
+			return false
+		}
+	}
+	// Allow only the two exact shapes we generate.
+	hasAdd := strings.Contains(normalized, " add primary key (")
+	hasDropAdd := strings.Contains(normalized, " drop primary key, add primary key (")
+	return hasAdd || hasDropAdd
 }
 
 func isSafeAddColumnRepairSQL(sqlText string) bool {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -127,6 +127,14 @@ type tidbPrimaryKeySpec struct {
 	columns []string
 }
 
+func (pk tidbPrimaryKeySpec) repairSQL(tableName string, needsDrop bool) string {
+	cols := strings.Join(pk.columns, ", ")
+	if needsDrop {
+		return fmt.Sprintf("ALTER TABLE %s DROP PRIMARY KEY, ADD PRIMARY KEY (%s)", tableName, cols)
+	}
+	return fmt.Sprintf("ALTER TABLE %s ADD PRIMARY KEY (%s)", tableName, cols)
+}
+
 type tidbUniqueIndexRepair struct {
 	tableName string
 	indexName string
@@ -1431,12 +1439,14 @@ func diffTiDBTableMetaWithObservedIndexes(table tidbTableSpec, meta tidbTableMet
 				kind:      tidbSchemaDiffTableContract,
 				tableName: table.name,
 				detail:    fmt.Sprintf("%s schema contract: missing primary key constraint", table.name),
+				repairSQL: table.primaryKey.repairSQL(table.name, false),
 			})
 		} else if !equalStringSlices(actualPrimaryKey, table.primaryKey.columns) {
 			diffs = append(diffs, tidbSchemaDiff{
 				kind:      tidbSchemaDiffTableContract,
 				tableName: table.name,
 				detail:    fmt.Sprintf("%s schema contract: primary key columns = (%s), want (%s)", table.name, strings.Join(actualPrimaryKey, ", "), strings.Join(table.primaryKey.columns, ", ")),
+				repairSQL: table.primaryKey.repairSQL(table.name, true),
 			})
 		}
 	}
@@ -1638,9 +1648,16 @@ func isSafeTiDBRepairDiff(diff tidbSchemaDiff) bool {
 		return isSafeAddColumnRepairSQL(diff.repairSQL)
 	case tidbSchemaDiffMissingIndex:
 		return isSafeAddIndexRepairSQL(diff.repairSQL)
+	case tidbSchemaDiffTableContract:
+		return diff.repairSQL != "" && isSafePrimaryKeyRepairSQL(diff.repairSQL)
 	default:
 		return false
 	}
+}
+
+func isSafePrimaryKeyRepairSQL(sqlText string) bool {
+	normalized := normalizeSQLFragment(sqlText)
+	return strings.HasPrefix(normalized, "alter table ") && strings.Contains(normalized, "primary key")
 }
 
 func isSafeAddColumnRepairSQL(sqlText string) bool {

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -612,6 +612,143 @@ func TestDiffTiDBTableMetaReportsPrimaryKeyColumnMismatch(t *testing.T) {
 	}
 }
 
+func TestDiffTiDBTableMetaMissingPrimaryKeyGeneratesRepairSQL(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "file_tags")
+	meta := tidbTableMeta{
+		tableName: "file_tags",
+		columns: map[string]tidbColumnMeta{
+			"file_id":   {columnType: "varchar(64)"},
+			"tag_key":   {columnType: "varchar(255)"},
+			"tag_value": {columnType: "varchar(255)"},
+		},
+	}
+	createStmt := `CREATE TABLE file_tags (
+		file_id VARCHAR(64) NOT NULL,
+		tag_key VARCHAR(255) NOT NULL,
+		tag_value VARCHAR(255),
+		KEY idx_kv (tag_key, tag_value)
+	)`
+
+	diffs := diffTiDBTableMeta(spec, meta, createStmt)
+	var pkDiff *tidbSchemaDiff
+	for i := range diffs {
+		if diffs[i].kind == tidbSchemaDiffTableContract && strings.Contains(diffs[i].detail, "missing primary key") {
+			pkDiff = &diffs[i]
+			break
+		}
+	}
+	if pkDiff == nil {
+		t.Fatalf("expected missing primary key diff, got %#v", diffs)
+	}
+	wantRepair := "ALTER TABLE file_tags ADD PRIMARY KEY (file_id, tag_key)"
+	if pkDiff.repairSQL != wantRepair {
+		t.Fatalf("missing PK repairSQL=%q, want %q", pkDiff.repairSQL, wantRepair)
+	}
+}
+
+func TestDiffTiDBTableMetaPrimaryKeyMismatchGeneratesRepairSQL(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "file_tags")
+	meta := tidbTableMeta{
+		tableName: "file_tags",
+		columns: map[string]tidbColumnMeta{
+			"file_id":   {columnType: "varchar(64)"},
+			"tag_key":   {columnType: "varchar(255)"},
+			"tag_value": {columnType: "varchar(255)"},
+		},
+	}
+	createStmt := `CREATE TABLE file_tags (
+		file_id VARCHAR(64) NOT NULL,
+		tag_key VARCHAR(255) NOT NULL,
+		tag_value VARCHAR(255),
+		PRIMARY KEY (tag_key, file_id),
+		KEY idx_kv (tag_key, tag_value)
+	)`
+
+	diffs := diffTiDBTableMeta(spec, meta, createStmt)
+	var pkDiff *tidbSchemaDiff
+	for i := range diffs {
+		if diffs[i].kind == tidbSchemaDiffTableContract && strings.Contains(diffs[i].detail, "primary key columns") {
+			pkDiff = &diffs[i]
+			break
+		}
+	}
+	if pkDiff == nil {
+		t.Fatalf("expected primary key mismatch diff, got %#v", diffs)
+	}
+	wantRepair := "ALTER TABLE file_tags DROP PRIMARY KEY, ADD PRIMARY KEY (file_id, tag_key)"
+	if pkDiff.repairSQL != wantRepair {
+		t.Fatalf("PK mismatch repairSQL=%q, want %q", pkDiff.repairSQL, wantRepair)
+	}
+}
+
+func TestDiffTiDBTableMetaUnparseableCreateStmtSkipsPKRepair(t *testing.T) {
+	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "file_tags")
+	meta := tidbTableMeta{
+		tableName: "file_tags",
+		columns: map[string]tidbColumnMeta{
+			"file_id":   {columnType: "varchar(64)"},
+			"tag_key":   {columnType: "varchar(255)"},
+			"tag_value": {columnType: "varchar(255)"},
+		},
+	}
+	// Malformed CREATE statement — parsing should fail.
+	createStmt := `NOT A CREATE TABLE STATEMENT`
+
+	diffs := diffTiDBTableMeta(spec, meta, createStmt)
+	var pkDiff *tidbSchemaDiff
+	for i := range diffs {
+		if diffs[i].kind == tidbSchemaDiffTableContract && strings.Contains(diffs[i].detail, "primary key") {
+			pkDiff = &diffs[i]
+			break
+		}
+	}
+	if pkDiff == nil {
+		t.Fatalf("expected primary key inspection diff, got %#v", diffs)
+	}
+	if pkDiff.repairSQL != "" {
+		t.Fatalf("unparseable CREATE stmt should not produce repairSQL, got %q", pkDiff.repairSQL)
+	}
+}
+
+func TestIsSafePrimaryKeyRepairSQLAcceptsExactForms(t *testing.T) {
+	tests := []struct {
+		sql  string
+		want bool
+	}{
+		{"ALTER TABLE t ADD PRIMARY KEY (a)", true},
+		{"ALTER TABLE t DROP PRIMARY KEY, ADD PRIMARY KEY (a, b)", true},
+		{"ALTER TABLE t ADD PRIMARY KEY (a); DROP TABLE x", false},
+		{"ALTER TABLE t ADD COLUMN x INT, ADD PRIMARY KEY (a)", false},
+		{"ALTER TABLE t DROP PRIMARY KEY", false},
+		{"CREATE TABLE t (a INT PRIMARY KEY)", false},
+		{"SELECT 1", false},
+	}
+	for _, tt := range tests {
+		got := isSafePrimaryKeyRepairSQL(tt.sql)
+		if got != tt.want {
+			t.Fatalf("isSafePrimaryKeyRepairSQL(%q) = %v, want %v", tt.sql, got, tt.want)
+		}
+	}
+}
+
+func TestPlannedTiDBSchemaRepairsIncludesPrimaryKeyChanges(t *testing.T) {
+	diffs := []tidbSchemaDiff{
+		{kind: tidbSchemaDiffTableContract, tableName: "t", detail: "missing pk", repairSQL: "ALTER TABLE t ADD PRIMARY KEY (a)"},
+		{kind: tidbSchemaDiffTableContract, tableName: "t", detail: "pk mismatch", repairSQL: "ALTER TABLE t DROP PRIMARY KEY, ADD PRIMARY KEY (b)"},
+		{kind: tidbSchemaDiffTableContract, tableName: "t", detail: "unparseable", repairSQL: ""},
+	}
+	got := plannedTiDBSchemaRepairs(diffs)
+	if len(got) != 2 {
+		t.Fatalf("plannedTiDBSchemaRepairs() len=%d, want 2 (%#v)", len(got), got)
+	}
+	if got[0] != "ALTER TABLE t ADD PRIMARY KEY (a)" {
+		t.Fatalf("unexpected first repair: %q", got[0])
+	}
+	if got[1] != "ALTER TABLE t DROP PRIMARY KEY, ADD PRIMARY KEY (b)" {
+		t.Fatalf("unexpected second repair: %q", got[1])
+	}
+}
+
 func TestDiffTiDBTableMetaTreatsBooleanAndTinyIntAsEquivalent(t *testing.T) {
 	spec := mustTiDBTableSpecByName(t, TiDBEmbeddingModeAuto, "file_nodes")
 	meta := tidbTableMeta{


### PR DESCRIPTION
## Problem

When tenant tables undergo primary key migrations (e.g., adding `path_hash` column and changing PK from `(workspace_id, commit_sha, path)` to `(workspace_id, commit_sha, path_hash)`), the schema validation detects the mismatch as `tidbSchemaDiffTableContract` but does not generate or execute any repair SQL. This causes all existing tenants with the old schema to fail on startup with:

```
backend_load_failed: tidb schema contract mismatch... primary key columns = (workspace_id, commit_sha, path), want (workspace_id, commit_sha, path_hash)
```

## Solution

1. **Generate repair SQL for primary key changes**: Added `repairSQL()` method to `tidbPrimaryKeySpec` that generates `ALTER TABLE ... DROP PRIMARY KEY, ADD PRIMARY KEY (...)` for mismatches and `ALTER TABLE ... ADD PRIMARY KEY (...)` for missing PKs.

2. **Allow PK repairs in safety check**: Extended `isSafeTiDBRepairDiff()` to accept `tidbSchemaDiffTableContract` diffs when they carry a primary-key-related `ALTER TABLE` statement.

## Changes

- `pkg/tenant/schema/tidb_auto.go`: Added `tidbPrimaryKeySpec.repairSQL()`, populated `repairSQL` in primary key diffs, added `isSafePrimaryKeyRepairSQL()` check.

## Testing

- `make lint` passes
- `go build ./pkg/tenant/schema/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved primary key constraint repair validation and safety checks during schema maintenance.
  * Enhanced automatic repair detection to properly recognize primary key-related alteration statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->