### PR TITLE
feat: singleflight dedup for concurrent reads (#488)

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -4819,8 +4819,13 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		// Use a detached context for the shared HTTP fetch so that
 		// cancellation of the owner's FUSE request does not fail
 		// piggybacking readers. The shared work must be independent
-		// of any single caller's lifecycle.
-		fetchCtx := context.WithoutCancel(ctx)
+		// of any single caller's lifecycle. We apply a fresh
+		// fuseTimeout so the fetch is still bounded even though the
+		// caller cancel is detached.
+		fetchCtx, fetchCancel := context.WithTimeout(
+			context.WithoutCancel(ctx), fuseTimeout,
+		)
+		defer fetchCancel()
 		data, err, _ := fs.readFlight.Do(ctx, sfKey, func() ([]byte, error) {
 			releaseReadSlot, slotErr := fs.acquireRemoteReadSlot(fetchCtx)
 			if slotErr != nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -101,6 +101,9 @@ type Dat9FS struct {
 	// simultaneously, only one HTTP request is made; the others share the
 	// result. See cache invalidation spec §9.8 T24.
 	readFlight *SingleFlight
+	// remoteReadTimeout bounds detached shared read fetches. Defaults to
+	// fuseTimeout; tests may shorten it to exercise timeout paths.
+	remoteReadTimeout time.Duration
 
 	// localPolicy classifies coding-agent paths that should be routed to
 	// local-only storage instead of the Drive9 remote backend.
@@ -217,6 +220,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		gitCheckpoints:    newFlushDebouncer(gitCheckpointDebounce),
 		gitOverlayPending: make(map[string]map[string]pendingGitOverlayEntry),
 		readFlight:        NewSingleFlight(),
+		remoteReadTimeout: fuseTimeout,
 	}
 }
 
@@ -343,6 +347,13 @@ func fuseCtxWithTimeout(cancel <-chan struct{}, timeout time.Duration) (context.
 		}
 	}()
 	return ctx, cf
+}
+
+func detachedSharedReadCtx(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		timeout = fuseTimeout
+	}
+	return context.WithTimeout(context.WithoutCancel(parent), timeout)
 }
 
 // --- helpers -----------------------------------------------------------------
@@ -4816,17 +4827,13 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		// the observed revision so that concurrent reads after a revision
 		// change do not share stale in-flight results.
 		sfKey := fmt.Sprintf("%s@%d", p, cacheRev)
-		// Use a detached context for the shared HTTP fetch so that
-		// cancellation of the owner's FUSE request does not fail
-		// piggybacking readers. The shared work must be independent
-		// of any single caller's lifecycle. We apply a fresh
-		// fuseTimeout so the fetch is still bounded even though the
-		// caller cancel is detached.
-		fetchCtx, fetchCancel := context.WithTimeout(
-			context.WithoutCancel(ctx), fuseTimeout,
-		)
-		defer fetchCancel()
 		data, err, _ := fs.readFlight.Do(ctx, sfKey, func() ([]byte, error) {
+			// Use a detached context for the shared HTTP fetch so that
+			// cancellation of the owner's FUSE request does not fail
+			// piggybacking readers. Apply a fresh bounded timeout so the
+			// shared in-flight key and read slot cannot hang forever.
+			fetchCtx, fetchCancel := detachedSharedReadCtx(ctx, fs.remoteReadTimeout)
+			defer fetchCancel()
 			releaseReadSlot, slotErr := fs.acquireRemoteReadSlot(fetchCtx)
 			if slotErr != nil {
 				return nil, slotErr

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -4816,25 +4816,32 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		// the observed revision so that concurrent reads after a revision
 		// change do not share stale in-flight results.
 		sfKey := fmt.Sprintf("%s@%d", p, cacheRev)
-		data, err, isOwner := fs.readFlight.Do(sfKey, func() ([]byte, error) {
-			releaseReadSlot, err := fs.acquireRemoteReadSlot(ctx)
-			if err != nil {
-				return nil, err
+		data, err, _ := fs.readFlight.Do(ctx, sfKey, func() ([]byte, error) {
+			releaseReadSlot, slotErr := fs.acquireRemoteReadSlot(ctx)
+			if slotErr != nil {
+				return nil, slotErr
 			}
 			defer releaseReadSlot()
-			return fs.readSmallFileWithRetry(ctx, p)
+			fetchData, fetchErr := fs.readSmallFileWithRetry(ctx, p)
+			if fetchErr != nil {
+				return nil, fetchErr
+			}
+			// Populate cache inside the flight callback so the entry
+			// is visible before the flight key is released. This closes
+			// the window where a concurrent reader could miss both the
+			// cache and the in-flight dedup.
+			fs.readCache.PutOwned(p, fetchData, cacheRev)
+			return fetchData, nil
 		})
 		if err != nil {
 			source = "small-read-error"
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, gofuse.EINTR
+			}
 			if errors.Is(err, errReadRetriesExhausted) {
 				return nil, gofuse.EIO
 			}
 			return nil, httpToFuseStatus(err)
-		}
-		// Only the owner stores into the cache — piggybackers use
-		// the shared result directly to avoid redundant cache churn.
-		if isOwner {
-			fs.readCache.PutOwned(p, data, cacheRev)
 		}
 		offset := int64(input.Offset)
 		if offset >= int64(len(data)) {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -4816,13 +4816,18 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		// the observed revision so that concurrent reads after a revision
 		// change do not share stale in-flight results.
 		sfKey := fmt.Sprintf("%s@%d", p, cacheRev)
+		// Use a detached context for the shared HTTP fetch so that
+		// cancellation of the owner's FUSE request does not fail
+		// piggybacking readers. The shared work must be independent
+		// of any single caller's lifecycle.
+		fetchCtx := context.WithoutCancel(ctx)
 		data, err, _ := fs.readFlight.Do(ctx, sfKey, func() ([]byte, error) {
-			releaseReadSlot, slotErr := fs.acquireRemoteReadSlot(ctx)
+			releaseReadSlot, slotErr := fs.acquireRemoteReadSlot(fetchCtx)
 			if slotErr != nil {
 				return nil, slotErr
 			}
 			defer releaseReadSlot()
-			fetchData, fetchErr := fs.readSmallFileWithRetry(ctx, p)
+			fetchData, fetchErr := fs.readSmallFileWithRetry(fetchCtx, p)
 			if fetchErr != nil {
 				return nil, fetchErr
 			}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -96,6 +96,12 @@ type Dat9FS struct {
 	// perf contains optional mount-level counters. Nil when disabled.
 	perf *fusePerfCounters
 
+	// readFlight deduplicates concurrent HTTP reads for the same file path.
+	// When multiple FUSE goroutines read the same uncached small file
+	// simultaneously, only one HTTP request is made; the others share the
+	// result. See cache invalidation spec §9.8 T24.
+	readFlight *SingleFlight
+
 	// localPolicy classifies coding-agent paths that should be routed to
 	// local-only storage instead of the Drive9 remote backend.
 	localPolicy *LocalPolicy
@@ -210,6 +216,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		git:               newGitWorkspaceLayer(),
 		gitCheckpoints:    newFlushDebouncer(gitCheckpointDebounce),
 		gitOverlayPending: make(map[string]map[string]pendingGitOverlayEntry),
+		readFlight:        NewSingleFlight(),
 	}
 }
 
@@ -4803,17 +4810,17 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 			fs.perf.readCacheMiss.add(1)
 		}
 
-		// Cache miss: read the file and store it. No separate Stat needed —
-		// ReadCtx fetches the data in one round-trip. Uses detached retry
-		// so a single FUSE interrupt doesn't permanently return EAGAIN.
-		data, err := func() ([]byte, error) {
+		// Cache miss: read the file and store it. Singleflight ensures
+		// only one HTTP request per path when multiple goroutines miss
+		// the cache simultaneously (spec §9.8 T24).
+		data, err, isOwner := fs.readFlight.Do(p, func() ([]byte, error) {
 			releaseReadSlot, err := fs.acquireRemoteReadSlot(ctx)
 			if err != nil {
 				return nil, err
 			}
 			defer releaseReadSlot()
 			return fs.readSmallFileWithRetry(ctx, p)
-		}()
+		})
 		if err != nil {
 			source = "small-read-error"
 			if errors.Is(err, errReadRetriesExhausted) {
@@ -4821,8 +4828,11 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 			}
 			return nil, httpToFuseStatus(err)
 		}
-		// Store with the revision from the prior Stat/Lookup.
-		fs.readCache.PutOwned(p, data, cacheRev)
+		// Only the owner stores into the cache — piggybackers use
+		// the shared result directly to avoid redundant cache churn.
+		if isOwner {
+			fs.readCache.PutOwned(p, data, cacheRev)
+		}
 		offset := int64(input.Offset)
 		if offset >= int64(len(data)) {
 			source = "small-read-eof"

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -4811,9 +4811,12 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		}
 
 		// Cache miss: read the file and store it. Singleflight ensures
-		// only one HTTP request per path when multiple goroutines miss
-		// the cache simultaneously (spec §9.8 T24).
-		data, err, isOwner := fs.readFlight.Do(p, func() ([]byte, error) {
+		// only one HTTP request per path+revision when multiple goroutines
+		// miss the cache simultaneously (spec §9.8 T24). The key includes
+		// the observed revision so that concurrent reads after a revision
+		// change do not share stale in-flight results.
+		sfKey := fmt.Sprintf("%s@%d", p, cacheRev)
+		data, err, isOwner := fs.readFlight.Do(sfKey, func() ([]byte, error) {
 			releaseReadSlot, err := fs.acquireRemoteReadSlot(ctx)
 			if err != nil {
 				return nil, err

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1104,6 +1104,125 @@ func TestDat9FSReadSingleFlightOwnerCancelDoesNotFailPiggybacker(t *testing.T) {
 	}
 }
 
+func TestDat9FSReadSingleFlightUnresponsiveFetchIsBounded(t *testing.T) {
+	const (
+		path = "/file.bin"
+		rev  = int64(9)
+	)
+	data := []byte("hung-read-data")
+	started := make(chan struct{}, 1)
+	firstCtxDone := make(chan struct{}, 1)
+	var getCalls atomic.Int32
+	var (
+		handlerMu  sync.Mutex
+		handlerErr error
+	)
+	recordHandlerErr := func(err error) {
+		handlerMu.Lock()
+		defer handlerMu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.Path != "/v1/fs/file.bin" {
+				recordHandlerErr(fmt.Errorf("GET path = %q, want /v1/fs/file.bin", r.URL.Path))
+				http.NotFound(w, r)
+				return
+			}
+			call := getCalls.Add(1)
+			if call == 1 {
+				started <- struct{}{}
+				<-r.Context().Done()
+				firstCtxDone <- struct{}{}
+				return
+			}
+			http.Error(w, "retry should not hang", http.StatusBadRequest)
+		default:
+			recordHandlerErr(fmt.Errorf("unexpected method %s", r.Method))
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.remoteReadTimeout = 30 * time.Millisecond
+	fs.readSlots = make(chan struct{}, 1)
+	ino := fs.inodes.Lookup(path, false, int64(len(data)), time.Now())
+	fs.inodes.UpdateRevision(ino, rev)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	readDone := make(chan gofuse.Status, 1)
+	go func() {
+		_, st, err := readDat9FSTestBytes(fs, ino, out.Fh, len(data))
+		if err != nil {
+			readDone <- gofuse.EIO
+			return
+		}
+		readDone <- st
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("backend GET did not start")
+	}
+
+	select {
+	case <-firstCtxDone:
+	case <-time.After(time.Second):
+		t.Fatal("unresponsive backend GET was not cancelled by bounded shared context")
+	}
+
+	select {
+	case st := <-readDone:
+		if st == gofuse.OK {
+			t.Fatal("Read status = OK, want failure for hung backend")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Read did not return after bounded shared context expired")
+	}
+
+	if got := fs.readFlight.Inflight(); got != 0 {
+		t.Fatalf("readFlight.Inflight() = %d, want 0 after bounded failure", got)
+	}
+	slotCtx, slotCancel := context.WithTimeout(context.Background(), time.Second)
+	releaseSlot, err := fs.acquireRemoteReadSlot(slotCtx)
+	slotCancel()
+	if err != nil {
+		t.Fatalf("acquireRemoteReadSlot after bounded failure: %v", err)
+	}
+	releaseSlot()
+
+	if got := getCalls.Load(); got < 1 {
+		t.Fatalf("GET calls = %d, want at least 1", got)
+	}
+	handlerMu.Lock()
+	handlerError := handlerErr
+	handlerMu.Unlock()
+	if handlerError != nil {
+		t.Fatal(handlerError)
+	}
+}
+
 func TestCreateWriteThroughShadow(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -626,6 +626,315 @@ func TestReadCacheCachesMediumSmallFileAfterFirstRead(t *testing.T) {
 	}
 }
 
+func readDat9FSTestBytes(fs *Dat9FS, ino, fh uint64, size int) ([]byte, gofuse.Status, error) {
+	buf := make([]byte, size)
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       fh,
+		Offset:   0,
+		Size:     uint32(size),
+	}, buf)
+	if st != gofuse.OK {
+		return nil, st, nil
+	}
+	if result == nil {
+		return nil, st, errors.New("nil read result")
+	}
+	data, _ := result.Bytes(buf)
+	return append([]byte(nil), data...), st, nil
+}
+
+func TestDat9FSReadSingleFlightSameRevisionDedupsBackendRead(t *testing.T) {
+	const (
+		path    = "/file.bin"
+		rev     = int64(7)
+		readers = 3
+	)
+	data := []byte("same-revision-data")
+	started := make(chan struct{}, readers)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseReads := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	t.Cleanup(releaseReads)
+	var getCalls atomic.Int32
+	var (
+		handlerMu  sync.Mutex
+		handlerErr error
+	)
+	recordHandlerErr := func(err error) {
+		handlerMu.Lock()
+		defer handlerMu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.Path != "/v1/fs/file.bin" {
+				recordHandlerErr(fmt.Errorf("GET path = %q, want /v1/fs/file.bin", r.URL.Path))
+				http.NotFound(w, r)
+				return
+			}
+			getCalls.Add(1)
+			started <- struct{}{}
+			<-release
+			w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+			_, _ = w.Write(data)
+		default:
+			recordHandlerErr(fmt.Errorf("unexpected method %s", r.Method))
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup(path, false, int64(len(data)), time.Now())
+	fs.inodes.UpdateRevision(ino, rev)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, readers)
+	results := make(chan []byte, readers)
+	startReaders := make(chan struct{})
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-startReaders
+			got, st, err := readDat9FSTestBytes(fs, ino, out.Fh, len(data))
+			if err != nil {
+				errs <- err
+				return
+			}
+			if st != gofuse.OK {
+				errs <- fmt.Errorf("Read status = %v, want OK", st)
+				return
+			}
+			results <- got
+		}()
+	}
+	close(startReaders)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		releaseReads()
+		t.Fatal("backend GET did not start")
+	}
+	waitForWaiters(t, fs.readFlight, fmt.Sprintf("%s@%d", path, rev), readers-1)
+	releaseReads()
+	wg.Wait()
+	close(errs)
+	close(results)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	for got := range results {
+		if !bytes.Equal(got, data) {
+			t.Fatalf("Read data = %q, want %q", got, data)
+		}
+	}
+	if got := getCalls.Load(); got != 1 {
+		t.Fatalf("GET calls = %d, want 1", got)
+	}
+	if cached, ok := fs.readCache.Get(path, rev); !ok || !bytes.Equal(cached, data) {
+		t.Fatalf("readCache.Get(%q, %d) = %q, %v; want cached data", path, rev, cached, ok)
+	}
+	handlerMu.Lock()
+	err := handlerErr
+	handlerMu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDat9FSReadSingleFlightDifferentRevisionNotShared(t *testing.T) {
+	const path = "/file.bin"
+	rev1Data := []byte("revision-one")
+	rev2Data := []byte("revision-two")
+	started := make(chan int32, 3)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseReads := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	t.Cleanup(releaseReads)
+	var getCalls atomic.Int32
+	var (
+		handlerMu  sync.Mutex
+		handlerErr error
+	)
+	recordHandlerErr := func(err error) {
+		handlerMu.Lock()
+		defer handlerMu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(rev2Data)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "2")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.Path != "/v1/fs/file.bin" {
+				recordHandlerErr(fmt.Errorf("GET path = %q, want /v1/fs/file.bin", r.URL.Path))
+				http.NotFound(w, r)
+				return
+			}
+			call := getCalls.Add(1)
+			started <- call
+			<-release
+			switch call {
+			case 1:
+				w.Header().Set("Content-Length", strconv.Itoa(len(rev1Data)))
+				_, _ = w.Write(rev1Data)
+			case 2:
+				w.Header().Set("Content-Length", strconv.Itoa(len(rev2Data)))
+				_, _ = w.Write(rev2Data)
+			default:
+				recordHandlerErr(fmt.Errorf("GET call count = %d, want <= 2", call))
+				http.Error(w, "unexpected extra read", http.StatusInternalServerError)
+			}
+		default:
+			recordHandlerErr(fmt.Errorf("unexpected method %s", r.Method))
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup(path, false, int64(len(rev2Data)), time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	firstDone := make(chan []byte, 1)
+	firstErr := make(chan error, 1)
+	go func() {
+		got, st, err := readDat9FSTestBytes(fs, ino, out.Fh, len(rev2Data))
+		if err != nil {
+			firstErr <- err
+			return
+		}
+		if st != gofuse.OK {
+			firstErr <- fmt.Errorf("first Read status = %v, want OK", st)
+			return
+		}
+		firstDone <- got
+	}()
+
+	select {
+	case call := <-started:
+		if call != 1 {
+			releaseReads()
+			t.Fatalf("first started GET call = %d, want 1", call)
+		}
+	case <-time.After(time.Second):
+		releaseReads()
+		t.Fatal("first backend GET did not start")
+	}
+
+	// Simulate a revalidated lookup/invalidation advancing the observed
+	// revision while the old revision read is still in flight.
+	fs.inodes.UpdateRevision(ino, 2)
+
+	secondDone := make(chan []byte, 1)
+	secondErr := make(chan error, 1)
+	go func() {
+		got, st, err := readDat9FSTestBytes(fs, ino, out.Fh, len(rev2Data))
+		if err != nil {
+			secondErr <- err
+			return
+		}
+		if st != gofuse.OK {
+			secondErr <- fmt.Errorf("second Read status = %v, want OK", st)
+			return
+		}
+		secondDone <- got
+	}()
+
+	select {
+	case call := <-started:
+		if call != 2 {
+			releaseReads()
+			t.Fatalf("second started GET call = %d, want 2", call)
+		}
+	case <-time.After(time.Second):
+		releaseReads()
+		t.Fatal("second backend GET did not start; reads for different revisions were likely shared")
+	}
+
+	releaseReads()
+
+	var first []byte
+	select {
+	case err := <-firstErr:
+		t.Fatal(err)
+	case first = <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("first Read did not finish")
+	}
+	var second []byte
+	select {
+	case err := <-secondErr:
+		t.Fatal(err)
+	case second = <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("second Read did not finish")
+	}
+
+	if !bytes.Equal(first, rev1Data) {
+		t.Fatalf("first Read data = %q, want %q", first, rev1Data)
+	}
+	if !bytes.Equal(second, rev2Data) {
+		t.Fatalf("second Read data = %q, want %q", second, rev2Data)
+	}
+	if got := getCalls.Load(); got != 2 {
+		t.Fatalf("GET calls = %d, want 2", got)
+	}
+	handlerMu.Lock()
+	err := handlerErr
+	handlerMu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCreateWriteThroughShadow(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -935,6 +935,175 @@ func TestDat9FSReadSingleFlightDifferentRevisionNotShared(t *testing.T) {
 	}
 }
 
+// TestDat9FSReadSingleFlightOwnerCancelDoesNotFailPiggybacker verifies that
+// cancelling the owner's FUSE request context does not fail piggybacking
+// readers. The shared HTTP fetch uses a detached context so it runs to
+// completion regardless of the owner's cancellation.
+func TestDat9FSReadSingleFlightOwnerCancelDoesNotFailPiggybacker(t *testing.T) {
+	const (
+		path = "/file.bin"
+		rev  = int64(3)
+	)
+	data := []byte("owner-cancel-data")
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseReads := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	t.Cleanup(releaseReads)
+	var getCalls atomic.Int32
+	var (
+		handlerMu  sync.Mutex
+		handlerErr error
+	)
+	recordHandlerErr := func(err error) {
+		handlerMu.Lock()
+		defer handlerMu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.Path != "/v1/fs/file.bin" {
+				recordHandlerErr(fmt.Errorf("GET path = %q, want /v1/fs/file.bin", r.URL.Path))
+				http.NotFound(w, r)
+				return
+			}
+			getCalls.Add(1)
+			started <- struct{}{}
+			<-release
+			w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+			_, _ = w.Write(data)
+		default:
+			recordHandlerErr(fmt.Errorf("unexpected method %s", r.Method))
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup(path, false, int64(len(data)), time.Now())
+	fs.inodes.UpdateRevision(ino, rev)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	sfKey := fmt.Sprintf("%s@%d", path, rev)
+
+	// Owner read with a cancel channel we control.
+	ownerCancel := make(chan struct{})
+	ownerDone := make(chan struct{})
+	var ownerResult []byte
+	var ownerSt gofuse.Status
+	go func() {
+		defer close(ownerDone)
+		buf := make([]byte, len(data))
+		var result gofuse.ReadResult
+		result, ownerSt = fs.Read(ownerCancel, &gofuse.ReadIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       out.Fh,
+			Offset:   0,
+			Size:     uint32(len(data)),
+		}, buf)
+		if result != nil {
+			ownerResult, _ = result.Bytes(buf)
+			ownerResult = append([]byte(nil), ownerResult...)
+		}
+	}()
+
+	// Wait for the backend GET to start (owner is in the flight callback).
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		releaseReads()
+		t.Fatal("backend GET did not start")
+	}
+
+	// Start a piggybacker reader (no cancel).
+	piggyDone := make(chan []byte, 1)
+	piggyErr := make(chan error, 1)
+	go func() {
+		got, st, err := readDat9FSTestBytes(fs, ino, out.Fh, len(data))
+		if err != nil {
+			piggyErr <- err
+			return
+		}
+		if st != gofuse.OK {
+			piggyErr <- fmt.Errorf("piggy Read status = %v, want OK", st)
+			return
+		}
+		piggyDone <- got
+	}()
+
+	// Wait for the piggybacker to attach to the in-flight entry.
+	waitForWaiters(t, fs.readFlight, sfKey, 1)
+
+	// Cancel the owner's FUSE context while the HTTP fetch is in-flight.
+	// Because the singleflight callback uses a detached context
+	// (context.WithoutCancel), this cancel does NOT fail the shared HTTP
+	// fetch. The owner is executing fn() directly so it blocks until the
+	// fetch completes — the cancel only affects piggybackers' select.
+	close(ownerCancel)
+
+	// Release the HTTP fetch — the detached context is still valid despite
+	// the owner cancel.
+	releaseReads()
+
+	// Owner should complete with OK (detached fetch succeeded).
+	select {
+	case <-ownerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("owner Read did not return")
+	}
+	if ownerSt != gofuse.OK {
+		t.Fatalf("owner status = %v, want OK (detached fetch should succeed)", ownerSt)
+	}
+	if !bytes.Equal(ownerResult, data) {
+		t.Fatalf("owner data = %q, want %q", ownerResult, data)
+	}
+
+	// Piggybacker must also succeed with correct data.
+	select {
+	case err := <-piggyErr:
+		t.Fatalf("piggybacker failed: %v", err)
+	case got := <-piggyDone:
+		if !bytes.Equal(got, data) {
+			t.Fatalf("piggybacker data = %q, want %q", got, data)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("piggybacker Read did not finish")
+	}
+
+	// Only one GET should have been made.
+	if got := getCalls.Load(); got != 1 {
+		t.Fatalf("GET calls = %d, want 1", got)
+	}
+
+	handlerMu.Lock()
+	err := handlerErr
+	handlerMu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCreateWriteThroughShadow(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/pkg/fuse/singleflight.go
+++ b/pkg/fuse/singleflight.go
@@ -2,6 +2,7 @@ package fuse
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 )
@@ -63,8 +64,17 @@ func (sf *SingleFlight) Do(ctx context.Context, key string, fn func() ([]byte, e
 	sf.calls[key] = c
 	sf.mu.Unlock()
 
-	// Execute the function.
-	c.val, c.err = fn()
+	// Execute the function. Recover from panics so that the in-flight
+	// entry is always cleaned up — otherwise a panic would leave
+	// sf.calls[key] stuck and all future waiters would hang.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.err = fmt.Errorf("singleflight: fn panicked: %v", r)
+			}
+		}()
+		c.val, c.err = fn()
+	}()
 
 	// Remove from map and wake waiters.
 	sf.mu.Lock()

--- a/pkg/fuse/singleflight.go
+++ b/pkg/fuse/singleflight.go
@@ -3,13 +3,15 @@ package fuse
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 )
 
 // singleflightCall represents an in-progress or completed call.
 type singleflightCall struct {
-	done chan struct{} // closed when the call completes
-	val  []byte
-	err  error
+	done    chan struct{} // closed when the call completes
+	waiters atomic.Int32 // number of piggybackers currently in select
+	val     []byte
+	err     error
 }
 
 // SingleFlight deduplicates concurrent calls for the same key.
@@ -45,6 +47,8 @@ func (sf *SingleFlight) Do(ctx context.Context, key string, fn func() ([]byte, e
 	if c, ok := sf.calls[key]; ok {
 		// Another goroutine is already fetching this key.
 		sf.mu.Unlock()
+		c.waiters.Add(1)
+		defer c.waiters.Add(-1)
 		select {
 		case <-c.done:
 			return c.val, c.err, false
@@ -78,4 +82,18 @@ func (sf *SingleFlight) Inflight() int {
 	sf.mu.Lock()
 	defer sf.mu.Unlock()
 	return len(sf.calls)
+}
+
+// Waiters returns the number of piggybackers currently waiting for the
+// given key. Returns 0 if the key is not in-flight. This is intended
+// for testing only — it allows deterministic synchronization without
+// time.Sleep.
+func (sf *SingleFlight) Waiters(key string) int {
+	sf.mu.Lock()
+	c, ok := sf.calls[key]
+	sf.mu.Unlock()
+	if !ok {
+		return 0
+	}
+	return int(c.waiters.Load())
 }

--- a/pkg/fuse/singleflight.go
+++ b/pkg/fuse/singleflight.go
@@ -1,18 +1,15 @@
 package fuse
 
-import "sync"
-
-// singleflightResult holds the result of a singleflight call.
-type singleflightResult struct {
-	data []byte
-	err  error
-}
+import (
+	"context"
+	"sync"
+)
 
 // singleflightCall represents an in-progress or completed call.
 type singleflightCall struct {
-	wg  sync.WaitGroup
-	val []byte
-	err error
+	done chan struct{} // closed when the call completes
+	val  []byte
+	err  error
 }
 
 // SingleFlight deduplicates concurrent calls for the same key.
@@ -34,22 +31,31 @@ func NewSingleFlight() *SingleFlight {
 
 // Do executes fn once for the given key, deduplicating concurrent calls.
 // If a call for key is already in progress, Do blocks until it completes
-// and returns the same result. The returned data slice is shared among
+// or the context is cancelled. The returned data slice is shared among
 // all callers for the same key — callers MUST NOT mutate it.
 //
 // The boolean return value is true if the caller was the one that
 // executed fn (the "owner"), false if it piggybacked on another call.
-func (sf *SingleFlight) Do(key string, fn func() ([]byte, error)) ([]byte, error, bool) {
+//
+// When a piggybacker's context is cancelled before the owner finishes,
+// Do returns ctx.Err(). The owner call is NOT cancelled — it runs to
+// completion so that other waiters (and the cache) still get the result.
+func (sf *SingleFlight) Do(ctx context.Context, key string, fn func() ([]byte, error)) ([]byte, error, bool) {
 	sf.mu.Lock()
 	if c, ok := sf.calls[key]; ok {
 		// Another goroutine is already fetching this key.
 		sf.mu.Unlock()
-		c.wg.Wait()
-		return c.val, c.err, false
+		select {
+		case <-c.done:
+			return c.val, c.err, false
+		case <-ctx.Done():
+			return nil, ctx.Err(), false
+		}
 	}
 
-	c := &singleflightCall{}
-	c.wg.Add(1)
+	c := &singleflightCall{
+		done: make(chan struct{}),
+	}
 	sf.calls[key] = c
 	sf.mu.Unlock()
 
@@ -61,7 +67,7 @@ func (sf *SingleFlight) Do(key string, fn func() ([]byte, error)) ([]byte, error
 	delete(sf.calls, key)
 	sf.mu.Unlock()
 
-	c.wg.Done()
+	close(c.done)
 
 	return c.val, c.err, true
 }

--- a/pkg/fuse/singleflight.go
+++ b/pkg/fuse/singleflight.go
@@ -1,0 +1,75 @@
+package fuse
+
+import "sync"
+
+// singleflightResult holds the result of a singleflight call.
+type singleflightResult struct {
+	data []byte
+	err  error
+}
+
+// singleflightCall represents an in-progress or completed call.
+type singleflightCall struct {
+	wg  sync.WaitGroup
+	val []byte
+	err error
+}
+
+// SingleFlight deduplicates concurrent calls for the same key.
+// When multiple goroutines call Do with the same key concurrently,
+// only one executes the function; the others wait and receive
+// the same result. This prevents thundering-herd HTTP requests
+// when multiple FUSE reads hit the same uncached file simultaneously.
+type SingleFlight struct {
+	mu    sync.Mutex
+	calls map[string]*singleflightCall
+}
+
+// NewSingleFlight creates a new SingleFlight instance.
+func NewSingleFlight() *SingleFlight {
+	return &SingleFlight{
+		calls: make(map[string]*singleflightCall),
+	}
+}
+
+// Do executes fn once for the given key, deduplicating concurrent calls.
+// If a call for key is already in progress, Do blocks until it completes
+// and returns the same result. The returned data slice is shared among
+// all callers for the same key — callers MUST NOT mutate it.
+//
+// The boolean return value is true if the caller was the one that
+// executed fn (the "owner"), false if it piggybacked on another call.
+func (sf *SingleFlight) Do(key string, fn func() ([]byte, error)) ([]byte, error, bool) {
+	sf.mu.Lock()
+	if c, ok := sf.calls[key]; ok {
+		// Another goroutine is already fetching this key.
+		sf.mu.Unlock()
+		c.wg.Wait()
+		return c.val, c.err, false
+	}
+
+	c := &singleflightCall{}
+	c.wg.Add(1)
+	sf.calls[key] = c
+	sf.mu.Unlock()
+
+	// Execute the function.
+	c.val, c.err = fn()
+
+	// Remove from map and wake waiters.
+	sf.mu.Lock()
+	delete(sf.calls, key)
+	sf.mu.Unlock()
+
+	c.wg.Done()
+
+	return c.val, c.err, true
+}
+
+// Inflight returns the number of keys currently being fetched.
+// This is intended for testing and metrics only.
+func (sf *SingleFlight) Inflight() int {
+	sf.mu.Lock()
+	defer sf.mu.Unlock()
+	return len(sf.calls)
+}

--- a/pkg/fuse/singleflight_test.go
+++ b/pkg/fuse/singleflight_test.go
@@ -9,6 +9,23 @@ import (
 	"time"
 )
 
+// waitForWaiters polls sf.Waiters(key) until it reaches wantN or the
+// timeout fires. This replaces non-deterministic time.Sleep in tests
+// that need to prove piggybackers have entered the select inside Do.
+func waitForWaiters(t *testing.T, sf *SingleFlight, key string, wantN int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for sf.Waiters(key) < wantN {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d waiters on key %q (got %d)",
+				wantN, key, sf.Waiters(key))
+		default:
+			time.Sleep(1 * time.Millisecond)
+		}
+	}
+}
+
 func TestSingleFlightBasicDedup(t *testing.T) {
 	sf := NewSingleFlight()
 
@@ -367,8 +384,9 @@ func TestSingleFlightContextCancelPiggybacker(t *testing.T) {
 		close(piggyDone)
 	}()
 
-	// Give the piggybacker time to enter Do and block on the owner.
-	time.Sleep(10 * time.Millisecond)
+	// Deterministically wait until the piggybacker has entered the select
+	// inside Do (proven by Waiters count reaching 1).
+	waitForWaiters(t, sf, "cancel-key", 1)
 
 	// Cancel the piggybacker's context.
 	cancel()
@@ -445,8 +463,9 @@ func TestSingleFlightContextCancelOwnerNotAffected(t *testing.T) {
 		}()
 	}
 
-	// Give piggybackers time to block.
-	time.Sleep(10 * time.Millisecond)
+	// Deterministically wait until all piggybackers have entered the select
+	// inside Do (proven by Waiters count reaching nPiggy).
+	waitForWaiters(t, sf, "owner-key", nPiggy)
 
 	// Cancel all piggybackers.
 	for _, cancel := range piggyCtxs {

--- a/pkg/fuse/singleflight_test.go
+++ b/pkg/fuse/singleflight_test.go
@@ -1,0 +1,232 @@
+package fuse
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleFlightBasicDedup(t *testing.T) {
+	sf := NewSingleFlight()
+
+	var calls atomic.Int32
+	var wg sync.WaitGroup
+	const n = 10
+
+	// All goroutines request the same key concurrently.
+	results := make([][]byte, n)
+	errs := make([]error, n)
+	owners := make([]bool, n)
+
+	// Use a channel to ensure all goroutines are launched before any proceeds.
+	ready := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-ready
+			results[idx], errs[idx], owners[idx] = sf.Do("key1", func() ([]byte, error) {
+				calls.Add(1)
+				time.Sleep(50 * time.Millisecond) // simulate slow fetch
+				return []byte("hello"), nil
+			})
+		}(i)
+	}
+	close(ready) // release all goroutines
+	wg.Wait()
+
+	// The function should have been called exactly once.
+	require.Equal(t, int32(1), calls.Load(), "fn should be called exactly once")
+
+	// Exactly one goroutine should be the owner.
+	ownerCount := 0
+	for _, o := range owners {
+		if o {
+			ownerCount++
+		}
+	}
+	require.Equal(t, 1, ownerCount, "exactly one goroutine should be the owner")
+
+	// All goroutines should get the same result.
+	for i := 0; i < n; i++ {
+		require.Equal(t, []byte("hello"), results[i])
+		require.NoError(t, errs[i])
+	}
+
+	// No inflight calls remaining.
+	require.Equal(t, 0, sf.Inflight())
+}
+
+func TestSingleFlightErrorPropagated(t *testing.T) {
+	sf := NewSingleFlight()
+	testErr := errors.New("fetch failed")
+
+	var calls atomic.Int32
+	var wg sync.WaitGroup
+	const n = 5
+
+	ready := make(chan struct{})
+	results := make([][]byte, n)
+	errs := make([]error, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-ready
+			results[idx], errs[idx], _ = sf.Do("err-key", func() ([]byte, error) {
+				calls.Add(1)
+				time.Sleep(20 * time.Millisecond)
+				return nil, testErr
+			})
+		}(i)
+	}
+	close(ready)
+	wg.Wait()
+
+	require.Equal(t, int32(1), calls.Load())
+	for i := 0; i < n; i++ {
+		require.Nil(t, results[i])
+		require.ErrorIs(t, errs[i], testErr)
+	}
+}
+
+func TestSingleFlightDifferentKeysParallel(t *testing.T) {
+	sf := NewSingleFlight()
+	var callsA, callsB atomic.Int32
+
+	var wg sync.WaitGroup
+	ready := make(chan struct{})
+
+	// 5 goroutines for key A, 5 for key B.
+	for i := 0; i < 5; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-ready
+			sf.Do("A", func() ([]byte, error) {
+				callsA.Add(1)
+				time.Sleep(30 * time.Millisecond)
+				return []byte("a"), nil
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			<-ready
+			sf.Do("B", func() ([]byte, error) {
+				callsB.Add(1)
+				time.Sleep(30 * time.Millisecond)
+				return []byte("b"), nil
+			})
+		}()
+	}
+	close(ready)
+	wg.Wait()
+
+	// Each key should have exactly one call.
+	require.Equal(t, int32(1), callsA.Load(), "key A fn called once")
+	require.Equal(t, int32(1), callsB.Load(), "key B fn called once")
+}
+
+func TestSingleFlightSequentialCallsSameKey(t *testing.T) {
+	sf := NewSingleFlight()
+	var calls atomic.Int32
+
+	// First call.
+	data1, err1, owner1 := sf.Do("k", func() ([]byte, error) {
+		calls.Add(1)
+		return []byte("v1"), nil
+	})
+	require.NoError(t, err1)
+	require.Equal(t, []byte("v1"), data1)
+	require.True(t, owner1)
+
+	// Second sequential call — should execute fn again (no dedup for non-concurrent calls).
+	data2, err2, owner2 := sf.Do("k", func() ([]byte, error) {
+		calls.Add(1)
+		return []byte("v2"), nil
+	})
+	require.NoError(t, err2)
+	require.Equal(t, []byte("v2"), data2)
+	require.True(t, owner2)
+
+	require.Equal(t, int32(2), calls.Load(), "sequential calls should both execute")
+}
+
+func TestSingleFlightInflight(t *testing.T) {
+	sf := NewSingleFlight()
+	require.Equal(t, 0, sf.Inflight())
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	go func() {
+		sf.Do("inflight-key", func() ([]byte, error) {
+			close(started)
+			<-release
+			return []byte("done"), nil
+		})
+	}()
+
+	<-started
+	require.Equal(t, 1, sf.Inflight())
+	close(release)
+
+	// Wait for completion.
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, 0, sf.Inflight())
+}
+
+func TestSingleFlightNilData(t *testing.T) {
+	sf := NewSingleFlight()
+
+	data, err, owner := sf.Do("nil-key", func() ([]byte, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+	require.Nil(t, data)
+	require.True(t, owner)
+}
+
+func TestSingleFlightConcurrentDifferentKeysDoNotBlock(t *testing.T) {
+	sf := NewSingleFlight()
+
+	// Key A blocks indefinitely. Key B should complete independently.
+	blockA := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		sf.Do("block-A", func() ([]byte, error) {
+			<-blockA
+			return []byte("a"), nil
+		})
+	}()
+
+	// Give goroutine A time to start.
+	time.Sleep(10 * time.Millisecond)
+
+	// Key B should not be blocked by key A.
+	done := make(chan struct{})
+	go func() {
+		sf.Do("free-B", func() ([]byte, error) {
+			return []byte("b"), nil
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success — B completed while A is still blocked
+	case <-time.After(1 * time.Second):
+		t.Fatal("key B should not be blocked by key A")
+	}
+
+	close(blockA)
+	wg.Wait()
+}

--- a/pkg/fuse/singleflight_test.go
+++ b/pkg/fuse/singleflight_test.go
@@ -199,7 +199,7 @@ func TestSingleFlightInflight(t *testing.T) {
 	release := make(chan struct{})
 
 	go func() {
-		sf.Do(context.Background(), "inflight-key", func() ([]byte, error) {
+		_, _, _ = sf.Do(context.Background(), "inflight-key", func() ([]byte, error) {
 			close(started)
 			<-release
 			return []byte("done"), nil
@@ -212,12 +212,9 @@ func TestSingleFlightInflight(t *testing.T) {
 	}
 	close(release)
 
-	// Wait for completion using a channel-based poll instead of time.Sleep.
+	// Wait for completion using a bounded poll instead of time.Sleep.
 	deadline := time.After(2 * time.Second)
-	for {
-		if sf.Inflight() == 0 {
-			break
-		}
+	for sf.Inflight() != 0 {
 		select {
 		case <-deadline:
 			t.Fatal("timed out waiting for inflight to reach 0")
@@ -255,7 +252,7 @@ func TestSingleFlightConcurrentDifferentKeysDoNotBlock(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		sf.Do(context.Background(), "block-A", func() ([]byte, error) {
+		_, _, _ = sf.Do(context.Background(), "block-A", func() ([]byte, error) {
 			close(startedA)
 			<-blockA
 			return []byte("a"), nil
@@ -268,7 +265,7 @@ func TestSingleFlightConcurrentDifferentKeysDoNotBlock(t *testing.T) {
 	// Key B should not be blocked by key A.
 	done := make(chan struct{})
 	go func() {
-		sf.Do(context.Background(), "free-B", func() ([]byte, error) {
+		_, _, _ = sf.Do(context.Background(), "free-B", func() ([]byte, error) {
 			return []byte("b"), nil
 		})
 		close(done)
@@ -422,7 +419,7 @@ func TestSingleFlightContextCancelOwnerNotAffected(t *testing.T) {
 	// Owner goroutine.
 	go func() {
 		defer wg.Done()
-		sf.Do(context.Background(), "owner-key", func() ([]byte, error) {
+		_, _, _ = sf.Do(context.Background(), "owner-key", func() ([]byte, error) {
 			calls.Add(1)
 			close(ownerStarted)
 			<-ownerRelease
@@ -440,7 +437,7 @@ func TestSingleFlightContextCancelOwnerNotAffected(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		piggyCtxs[i] = cancel
 		go func() {
-			sf.Do(ctx, "owner-key", func() ([]byte, error) {
+			_, _, _ = sf.Do(ctx, "owner-key", func() ([]byte, error) {
 				t.Error("piggybacker fn should not be called")
 				return nil, nil
 			})

--- a/pkg/fuse/singleflight_test.go
+++ b/pkg/fuse/singleflight_test.go
@@ -1,13 +1,12 @@
 package fuse
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestSingleFlightBasicDedup(t *testing.T) {
@@ -17,7 +16,6 @@ func TestSingleFlightBasicDedup(t *testing.T) {
 	var wg sync.WaitGroup
 	const n = 10
 
-	// All goroutines request the same key concurrently.
 	results := make([][]byte, n)
 	errs := make([]error, n)
 	owners := make([]bool, n)
@@ -29,7 +27,7 @@ func TestSingleFlightBasicDedup(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 			<-ready
-			results[idx], errs[idx], owners[idx] = sf.Do("key1", func() ([]byte, error) {
+			results[idx], errs[idx], owners[idx] = sf.Do(context.Background(), "key1", func() ([]byte, error) {
 				calls.Add(1)
 				time.Sleep(50 * time.Millisecond) // simulate slow fetch
 				return []byte("hello"), nil
@@ -40,7 +38,9 @@ func TestSingleFlightBasicDedup(t *testing.T) {
 	wg.Wait()
 
 	// The function should have been called exactly once.
-	require.Equal(t, int32(1), calls.Load(), "fn should be called exactly once")
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fn called %d times, want 1", got)
+	}
 
 	// Exactly one goroutine should be the owner.
 	ownerCount := 0
@@ -49,16 +49,24 @@ func TestSingleFlightBasicDedup(t *testing.T) {
 			ownerCount++
 		}
 	}
-	require.Equal(t, 1, ownerCount, "exactly one goroutine should be the owner")
+	if ownerCount != 1 {
+		t.Fatalf("owner count = %d, want 1", ownerCount)
+	}
 
 	// All goroutines should get the same result.
 	for i := 0; i < n; i++ {
-		require.Equal(t, []byte("hello"), results[i])
-		require.NoError(t, errs[i])
+		if string(results[i]) != "hello" {
+			t.Errorf("result[%d] = %q, want %q", i, results[i], "hello")
+		}
+		if errs[i] != nil {
+			t.Errorf("err[%d] = %v, want nil", i, errs[i])
+		}
 	}
 
 	// No inflight calls remaining.
-	require.Equal(t, 0, sf.Inflight())
+	if got := sf.Inflight(); got != 0 {
+		t.Fatalf("inflight = %d, want 0", got)
+	}
 }
 
 func TestSingleFlightErrorPropagated(t *testing.T) {
@@ -78,7 +86,7 @@ func TestSingleFlightErrorPropagated(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 			<-ready
-			results[idx], errs[idx], _ = sf.Do("err-key", func() ([]byte, error) {
+			results[idx], errs[idx], _ = sf.Do(context.Background(), "err-key", func() ([]byte, error) {
 				calls.Add(1)
 				time.Sleep(20 * time.Millisecond)
 				return nil, testErr
@@ -88,10 +96,16 @@ func TestSingleFlightErrorPropagated(t *testing.T) {
 	close(ready)
 	wg.Wait()
 
-	require.Equal(t, int32(1), calls.Load())
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fn called %d times, want 1", got)
+	}
 	for i := 0; i < n; i++ {
-		require.Nil(t, results[i])
-		require.ErrorIs(t, errs[i], testErr)
+		if results[i] != nil {
+			t.Errorf("result[%d] = %v, want nil", i, results[i])
+		}
+		if !errors.Is(errs[i], testErr) {
+			t.Errorf("err[%d] = %v, want %v", i, errs[i], testErr)
+		}
 	}
 }
 
@@ -108,7 +122,7 @@ func TestSingleFlightDifferentKeysParallel(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-ready
-			sf.Do("A", func() ([]byte, error) {
+			_, _, _ = sf.Do(context.Background(), "A", func() ([]byte, error) {
 				callsA.Add(1)
 				time.Sleep(30 * time.Millisecond)
 				return []byte("a"), nil
@@ -117,7 +131,7 @@ func TestSingleFlightDifferentKeysParallel(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-ready
-			sf.Do("B", func() ([]byte, error) {
+			_, _, _ = sf.Do(context.Background(), "B", func() ([]byte, error) {
 				callsB.Add(1)
 				time.Sleep(30 * time.Millisecond)
 				return []byte("b"), nil
@@ -128,8 +142,12 @@ func TestSingleFlightDifferentKeysParallel(t *testing.T) {
 	wg.Wait()
 
 	// Each key should have exactly one call.
-	require.Equal(t, int32(1), callsA.Load(), "key A fn called once")
-	require.Equal(t, int32(1), callsB.Load(), "key B fn called once")
+	if got := callsA.Load(); got != 1 {
+		t.Fatalf("key A fn called %d times, want 1", got)
+	}
+	if got := callsB.Load(); got != 1 {
+		t.Fatalf("key B fn called %d times, want 1", got)
+	}
 }
 
 func TestSingleFlightSequentialCallsSameKey(t *testing.T) {
@@ -137,35 +155,51 @@ func TestSingleFlightSequentialCallsSameKey(t *testing.T) {
 	var calls atomic.Int32
 
 	// First call.
-	data1, err1, owner1 := sf.Do("k", func() ([]byte, error) {
+	data1, err1, owner1 := sf.Do(context.Background(), "k", func() ([]byte, error) {
 		calls.Add(1)
 		return []byte("v1"), nil
 	})
-	require.NoError(t, err1)
-	require.Equal(t, []byte("v1"), data1)
-	require.True(t, owner1)
+	if err1 != nil {
+		t.Fatalf("call 1 err = %v, want nil", err1)
+	}
+	if string(data1) != "v1" {
+		t.Fatalf("call 1 data = %q, want %q", data1, "v1")
+	}
+	if !owner1 {
+		t.Fatalf("call 1 owner = false, want true")
+	}
 
 	// Second sequential call — should execute fn again (no dedup for non-concurrent calls).
-	data2, err2, owner2 := sf.Do("k", func() ([]byte, error) {
+	data2, err2, owner2 := sf.Do(context.Background(), "k", func() ([]byte, error) {
 		calls.Add(1)
 		return []byte("v2"), nil
 	})
-	require.NoError(t, err2)
-	require.Equal(t, []byte("v2"), data2)
-	require.True(t, owner2)
+	if err2 != nil {
+		t.Fatalf("call 2 err = %v, want nil", err2)
+	}
+	if string(data2) != "v2" {
+		t.Fatalf("call 2 data = %q, want %q", data2, "v2")
+	}
+	if !owner2 {
+		t.Fatalf("call 2 owner = false, want true")
+	}
 
-	require.Equal(t, int32(2), calls.Load(), "sequential calls should both execute")
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("fn called %d times, want 2 (sequential calls should both execute)", got)
+	}
 }
 
 func TestSingleFlightInflight(t *testing.T) {
 	sf := NewSingleFlight()
-	require.Equal(t, 0, sf.Inflight())
+	if got := sf.Inflight(); got != 0 {
+		t.Fatalf("inflight = %d, want 0", got)
+	}
 
 	started := make(chan struct{})
 	release := make(chan struct{})
 
 	go func() {
-		sf.Do("inflight-key", func() ([]byte, error) {
+		sf.Do(context.Background(), "inflight-key", func() ([]byte, error) {
 			close(started)
 			<-release
 			return []byte("done"), nil
@@ -173,23 +207,41 @@ func TestSingleFlightInflight(t *testing.T) {
 	}()
 
 	<-started
-	require.Equal(t, 1, sf.Inflight())
+	if got := sf.Inflight(); got != 1 {
+		t.Fatalf("inflight = %d, want 1", got)
+	}
 	close(release)
 
-	// Wait for completion.
-	time.Sleep(20 * time.Millisecond)
-	require.Equal(t, 0, sf.Inflight())
+	// Wait for completion using a channel-based poll instead of time.Sleep.
+	deadline := time.After(2 * time.Second)
+	for {
+		if sf.Inflight() == 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for inflight to reach 0")
+		default:
+			time.Sleep(1 * time.Millisecond)
+		}
+	}
 }
 
 func TestSingleFlightNilData(t *testing.T) {
 	sf := NewSingleFlight()
 
-	data, err, owner := sf.Do("nil-key", func() ([]byte, error) {
+	data, err, owner := sf.Do(context.Background(), "nil-key", func() ([]byte, error) {
 		return nil, nil
 	})
-	require.NoError(t, err)
-	require.Nil(t, data)
-	require.True(t, owner)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if data != nil {
+		t.Fatalf("data = %v, want nil", data)
+	}
+	if !owner {
+		t.Fatalf("owner = false, want true")
+	}
 }
 
 func TestSingleFlightConcurrentDifferentKeysDoNotBlock(t *testing.T) {
@@ -197,24 +249,26 @@ func TestSingleFlightConcurrentDifferentKeysDoNotBlock(t *testing.T) {
 
 	// Key A blocks indefinitely. Key B should complete independently.
 	blockA := make(chan struct{})
+	startedA := make(chan struct{})
 	var wg sync.WaitGroup
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		sf.Do("block-A", func() ([]byte, error) {
+		sf.Do(context.Background(), "block-A", func() ([]byte, error) {
+			close(startedA)
 			<-blockA
 			return []byte("a"), nil
 		})
 	}()
 
-	// Give goroutine A time to start.
-	time.Sleep(10 * time.Millisecond)
+	// Wait for goroutine A to actually start its fn.
+	<-startedA
 
 	// Key B should not be blocked by key A.
 	done := make(chan struct{})
 	go func() {
-		sf.Do("free-B", func() ([]byte, error) {
+		sf.Do(context.Background(), "free-B", func() ([]byte, error) {
 			return []byte("b"), nil
 		})
 		close(done)
@@ -248,7 +302,7 @@ func TestSingleFlightSamePathDifferentRevisionNotShared(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-ready
-			sf.Do("file.txt@1", func() ([]byte, error) {
+			_, _, _ = sf.Do(context.Background(), "file.txt@1", func() ([]byte, error) {
 				callsR1.Add(1)
 				time.Sleep(30 * time.Millisecond)
 				return []byte("data-rev1"), nil
@@ -257,7 +311,7 @@ func TestSingleFlightSamePathDifferentRevisionNotShared(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-ready
-			sf.Do("file.txt@2", func() ([]byte, error) {
+			_, _, _ = sf.Do(context.Background(), "file.txt@2", func() ([]byte, error) {
 				callsR2.Add(1)
 				time.Sleep(30 * time.Millisecond)
 				return []byte("data-rev2"), nil
@@ -268,6 +322,160 @@ func TestSingleFlightSamePathDifferentRevisionNotShared(t *testing.T) {
 	wg.Wait()
 
 	// Each revision should trigger exactly one fetch.
-	require.Equal(t, int32(1), callsR1.Load(), "rev1 fn called once")
-	require.Equal(t, int32(1), callsR2.Load(), "rev2 fn called once")
+	if got := callsR1.Load(); got != 1 {
+		t.Fatalf("rev1 fn called %d times, want 1", got)
+	}
+	if got := callsR2.Load(); got != 1 {
+		t.Fatalf("rev2 fn called %d times, want 1", got)
+	}
+}
+
+func TestSingleFlightContextCancelPiggybacker(t *testing.T) {
+	// When a piggybacker's context is cancelled before the owner finishes,
+	// the piggybacker should return ctx.Err() immediately. The owner
+	// should still complete successfully.
+	sf := NewSingleFlight()
+
+	ownerStarted := make(chan struct{})
+	ownerRelease := make(chan struct{})
+
+	// Start owner goroutine with a long-running fn.
+	var ownerData []byte
+	var ownerErr error
+	var ownerIsOwner bool
+	var ownerWg sync.WaitGroup
+	ownerWg.Add(1)
+	go func() {
+		defer ownerWg.Done()
+		ownerData, ownerErr, ownerIsOwner = sf.Do(context.Background(), "cancel-key", func() ([]byte, error) {
+			close(ownerStarted)
+			<-ownerRelease
+			return []byte("result"), nil
+		})
+	}()
+
+	<-ownerStarted
+
+	// Start piggybacker with a cancellable context.
+	ctx, cancel := context.WithCancel(context.Background())
+	piggyDone := make(chan struct{})
+	var piggyData []byte
+	var piggyErr error
+	var piggyIsOwner bool
+	go func() {
+		piggyData, piggyErr, piggyIsOwner = sf.Do(ctx, "cancel-key", func() ([]byte, error) {
+			t.Error("piggybacker fn should not be called")
+			return nil, nil
+		})
+		close(piggyDone)
+	}()
+
+	// Give the piggybacker time to enter Do and block on the owner.
+	time.Sleep(10 * time.Millisecond)
+
+	// Cancel the piggybacker's context.
+	cancel()
+
+	select {
+	case <-piggyDone:
+		// Piggybacker returned.
+	case <-time.After(1 * time.Second):
+		t.Fatal("piggybacker did not return after context cancellation")
+	}
+
+	if piggyIsOwner {
+		t.Error("piggybacker should not be owner")
+	}
+	if !errors.Is(piggyErr, context.Canceled) {
+		t.Errorf("piggybacker err = %v, want context.Canceled", piggyErr)
+	}
+	if piggyData != nil {
+		t.Errorf("piggybacker data = %v, want nil", piggyData)
+	}
+
+	// Let owner finish.
+	close(ownerRelease)
+	ownerWg.Wait()
+
+	if !ownerIsOwner {
+		t.Error("owner should be owner")
+	}
+	if ownerErr != nil {
+		t.Errorf("owner err = %v, want nil", ownerErr)
+	}
+	if string(ownerData) != "result" {
+		t.Errorf("owner data = %q, want %q", ownerData, "result")
+	}
+}
+
+func TestSingleFlightContextCancelOwnerNotAffected(t *testing.T) {
+	// Even if all piggybackers cancel, the owner call runs to completion.
+	sf := NewSingleFlight()
+
+	ownerStarted := make(chan struct{})
+	ownerRelease := make(chan struct{})
+	var calls atomic.Int32
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Owner goroutine.
+	go func() {
+		defer wg.Done()
+		sf.Do(context.Background(), "owner-key", func() ([]byte, error) {
+			calls.Add(1)
+			close(ownerStarted)
+			<-ownerRelease
+			return []byte("done"), nil
+		})
+	}()
+
+	<-ownerStarted
+
+	// Launch 3 piggybackers, all with contexts that will be cancelled.
+	const nPiggy = 3
+	piggyCtxs := make([]context.CancelFunc, nPiggy)
+	piggyDone := make(chan struct{}, nPiggy)
+	for i := 0; i < nPiggy; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		piggyCtxs[i] = cancel
+		go func() {
+			sf.Do(ctx, "owner-key", func() ([]byte, error) {
+				t.Error("piggybacker fn should not be called")
+				return nil, nil
+			})
+			piggyDone <- struct{}{}
+		}()
+	}
+
+	// Give piggybackers time to block.
+	time.Sleep(10 * time.Millisecond)
+
+	// Cancel all piggybackers.
+	for _, cancel := range piggyCtxs {
+		cancel()
+	}
+
+	// Wait for all piggybackers to return.
+	for i := 0; i < nPiggy; i++ {
+		select {
+		case <-piggyDone:
+		case <-time.After(1 * time.Second):
+			t.Fatal("piggybacker did not return after context cancellation")
+		}
+	}
+
+	// Owner should still be inflight.
+	if got := sf.Inflight(); got != 1 {
+		t.Fatalf("inflight = %d, want 1 (owner should still be running)", got)
+	}
+
+	// Release owner.
+	close(ownerRelease)
+	wg.Wait()
+
+	// fn called exactly once — owner ran to completion despite piggy cancels.
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fn called %d times, want 1", got)
+	}
 }

--- a/pkg/fuse/singleflight_test.go
+++ b/pkg/fuse/singleflight_test.go
@@ -230,3 +230,44 @@ func TestSingleFlightConcurrentDifferentKeysDoNotBlock(t *testing.T) {
 	close(blockA)
 	wg.Wait()
 }
+
+func TestSingleFlightSamePathDifferentRevisionNotShared(t *testing.T) {
+	// Regression: when a file's revision changes, concurrent reads for the
+	// same path but different revisions must NOT share results. The
+	// singleflight key in Dat9FS.Read includes the revision, so
+	// "file.txt@1" and "file.txt@2" are independent keys.
+	sf := NewSingleFlight()
+
+	var callsR1, callsR2 atomic.Int32
+	var wg sync.WaitGroup
+	ready := make(chan struct{})
+
+	// 3 goroutines for path@rev1, 3 for path@rev2.
+	for i := 0; i < 3; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-ready
+			sf.Do("file.txt@1", func() ([]byte, error) {
+				callsR1.Add(1)
+				time.Sleep(30 * time.Millisecond)
+				return []byte("data-rev1"), nil
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			<-ready
+			sf.Do("file.txt@2", func() ([]byte, error) {
+				callsR2.Add(1)
+				time.Sleep(30 * time.Millisecond)
+				return []byte("data-rev2"), nil
+			})
+		}()
+	}
+	close(ready)
+	wg.Wait()
+
+	// Each revision should trigger exactly one fetch.
+	require.Equal(t, int32(1), callsR1.Load(), "rev1 fn called once")
+	require.Equal(t, int32(1), callsR2.Load(), "rev2 fn called once")
+}

--- a/pkg/fuse/singleflight_test.go
+++ b/pkg/fuse/singleflight_test.go
@@ -3,6 +3,7 @@ package fuse
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -341,6 +342,101 @@ func TestSingleFlightSamePathDifferentRevisionNotShared(t *testing.T) {
 	}
 	if got := callsR2.Load(); got != 1 {
 		t.Fatalf("rev2 fn called %d times, want 1", got)
+	}
+}
+
+func TestSingleFlightPanicRecovery(t *testing.T) {
+	// When fn panics, the in-flight entry must still be cleaned up so that
+	// subsequent calls for the same key do not hang forever.
+	sf := NewSingleFlight()
+
+	// First call panics — should be recovered and returned as an error.
+	data, err, owner := sf.Do(context.Background(), "panic-key", func() ([]byte, error) {
+		panic("boom")
+	})
+	if data != nil {
+		t.Fatalf("data = %v, want nil after panic", data)
+	}
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("err = %v, want error containing 'boom'", err)
+	}
+	if !owner {
+		t.Fatalf("owner = false, want true")
+	}
+	if got := sf.Inflight(); got != 0 {
+		t.Fatalf("inflight = %d, want 0 after panic recovery", got)
+	}
+
+	// Verify a subsequent call for the same key works normally.
+	data2, err2, owner2 := sf.Do(context.Background(), "panic-key", func() ([]byte, error) {
+		return []byte("ok"), nil
+	})
+	if err2 != nil {
+		t.Fatalf("post-panic err = %v, want nil", err2)
+	}
+	if string(data2) != "ok" {
+		t.Fatalf("post-panic data = %q, want %q", data2, "ok")
+	}
+	if !owner2 {
+		t.Fatalf("post-panic owner = false, want true")
+	}
+}
+
+func TestSingleFlightPanicRecoveryWithWaiters(t *testing.T) {
+	// When the owner panics while piggybackers are waiting, all waiters
+	// should receive the panic-converted error.
+	sf := NewSingleFlight()
+
+	ownerStarted := make(chan struct{})
+	const nPiggy = 3
+
+	var wg sync.WaitGroup
+	errs := make([]error, nPiggy)
+
+	// Start owner.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _, _ = sf.Do(context.Background(), "panic-wait-key", func() ([]byte, error) {
+			close(ownerStarted)
+			// Wait for waiters to attach before panicking.
+			deadline := time.After(2 * time.Second)
+			for sf.Waiters("panic-wait-key") < nPiggy {
+				select {
+				case <-deadline:
+					t.Error("timed out waiting for piggybackers")
+					return nil, nil
+				default:
+					time.Sleep(1 * time.Millisecond)
+				}
+			}
+			panic("owner-panic")
+		})
+	}()
+
+	<-ownerStarted
+
+	// Start piggybackers.
+	for i := 0; i < nPiggy; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, errs[idx], _ = sf.Do(context.Background(), "panic-wait-key", func() ([]byte, error) {
+				t.Error("piggybacker fn should not be called")
+				return nil, nil
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		if err == nil || !strings.Contains(err.Error(), "owner-panic") {
+			t.Errorf("piggy[%d] err = %v, want error containing 'owner-panic'", i, err)
+		}
+	}
+	if got := sf.Inflight(); got != 0 {
+		t.Fatalf("inflight = %d, want 0 after panic", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `SingleFlight` to deduplicate concurrent HTTP reads for the same file path
- When multiple FUSE goroutines read the same uncached small file simultaneously, only one HTTP request is made; others share the result
- Integrated into `Dat9FS.Read` small-file cache-miss path
- Only the owner goroutine stores into `ReadCache` (avoids redundant cache churn)
- Different keys execute in parallel (no head-of-line blocking)

## Implementation

- `pkg/fuse/singleflight.go`: 75-line generic key-based dedup using `sync.WaitGroup`
- `pkg/fuse/dat9fs.go`: `readFlight` field added to `Dat9FS`, wired into small-file read miss path
- No changes to write path, dir cache, or SSE handling

## Test plan

- [x] 7 unit test scenarios (all pass with `-race`):
  - BasicDedup: 10 concurrent goroutines → 1 HTTP call
  - ErrorPropagated: errors shared to all waiters
  - DifferentKeysParallel: independent keys don't block each other
  - SequentialCallsSameKey: non-concurrent calls both execute
  - Inflight: correct count tracking
  - NilData: nil result handled correctly
  - ConcurrentDifferentKeysDoNotBlock: blocked key A doesn't block key B
- [x] Existing `TestDat9FS*` and `TestReadCache*` tests pass
- [x] Race detector clean

References cache invalidation spec §9.8 T24.

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deduplicated concurrent uncached reads so a single backend fetch is shared and cached for all waiters.
  * Added a concurrency utility to coordinate in-flight operations and expose inflight/waiter visibility.

* **Bug Fixes**
  * Better mapping of cancellation/timeouts and retry exhaustion to appropriate error statuses; owner cancellation doesn't break piggybackers.

* **Tests**
  * Extensive coverage for deduplication, revision isolation, panic recovery, and cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->