### PR TITLE
Use revision-bound dir cache for GetAttr

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,14 @@ SSE events from `/v1/events` invalidate caches for foreign changes. Local
 same-mount mutations update userspace caches directly and avoid redundant kernel
 notify storms.
 
+Revision-bound `GetAttr` hits from the directory cache are disabled by default
+because the current SSE event stream is process-local. Enable
+`drive9 mount --trust-process-local-events` only when tenant mutations and
+`/v1/events` are guaranteed to use the same server process through
+single-server/sticky routing, or when the deployment provides a cluster-wide
+durable event stream. Without that explicit trust boundary, regular-file
+`GetAttr` falls back to remote HEAD revalidation.
+
 ## HTTP API
 
 Authenticate HTTP API calls with `Authorization: Bearer $DRIVE9_API_KEY`.

--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -46,6 +46,7 @@ type mountFuseOptions struct {
 	PrefetchMaxFileBytes  int64
 	PrefetchMaxBytes      int64
 	PrefetchTimeout       time.Duration
+	TrustLocalEvents      bool
 	SyncMode              fuseSyncMode
 	WritePolicy           fuseWritePolicy
 	Profile               string

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -39,6 +39,7 @@ func mountFuseImpl(opts *mountFuseOptions) error {
 		PrefetchMaxFileBytes:  opts.PrefetchMaxFileBytes,
 		PrefetchMaxBytes:      opts.PrefetchMaxBytes,
 		PrefetchTimeout:       opts.PrefetchTimeout,
+		TrustLocalEvents:      opts.TrustLocalEvents,
 		SyncMode:              mode,
 		WritePolicy:           writePolicy,
 		Profile:               opts.Profile,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -104,6 +104,7 @@ func fsMountCmd(args []string) error {
 	prefetchMaxFileBytes := fs.Int64("readdir-prefetch-max-file-bytes", 50_000, "maximum individual file size prefetched by readdir prefetch")
 	prefetchMaxBytes := fs.Int64("readdir-prefetch-max-bytes", 1<<20, "maximum aggregate bytes prefetched per directory read")
 	prefetchTimeout := fs.Duration("readdir-prefetch-timeout", time.Second, "timeout for one readdir prefetch batch")
+	trustProcessLocalEvents := fs.Bool("trust-process-local-events", false, "allow revision-bound GetAttr dir-cache hits using process-local SSE freshness; only safe for single-server/sticky routing or cluster-wide event streams")
 	durability := fs.String("durability", string(fuseDurabilityAuto), "write durability: auto, interactive, fsync, close-sync, or write-sync")
 	profile := fs.String("profile", "", "mount profile: interactive, coding-agent (empty for default)")
 	localRoot := fs.String("local-root", "", "local-only overlay storage root for --profile=coding-agent")
@@ -160,6 +161,7 @@ func fsMountCmd(args []string) error {
 
 	lookupRetryCountGiven := flagProvided(fs, "lookup-retry-count")
 	lookupRetryTimeoutGiven := flagProvided(fs, "lookup-retry-timeout")
+	trustProcessLocalEventsGiven := flagProvided(fs, "trust-process-local-events")
 	if err := validateLookupRetryFlags(*lookupRetryCount, *lookupRetryTimeout, lookupRetryCountGiven, lookupRetryTimeoutGiven); err != nil {
 		return err
 	}
@@ -206,6 +208,9 @@ func fsMountCmd(args []string) error {
 
 	if resolved == MountModeWebDAV && *readOnly {
 		return fmt.Errorf("drive9 mount: --read-only is not supported with WebDAV mode")
+	}
+	if resolved == MountModeWebDAV && trustProcessLocalEventsGiven {
+		return fmt.Errorf("drive9 mount: --trust-process-local-events is only supported with --mode=fuse")
 	}
 	if runtime.GOOS == "windows" && resolved == MountModeFUSE {
 		return mountFuse(&mountFuseOptions{
@@ -272,6 +277,7 @@ func fsMountCmd(args []string) error {
 		PrefetchMaxFileBytes:  *prefetchMaxFileBytes,
 		PrefetchMaxBytes:      *prefetchMaxBytes,
 		PrefetchTimeout:       *prefetchTimeout,
+		TrustLocalEvents:      *trustProcessLocalEvents,
 		SyncMode:              syncModeVal,
 		WritePolicy:           writePolicyVal,
 		Profile:               *profile,

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -721,6 +721,76 @@ func TestMountCmdLeavesLegacyDirStatFallbackDisabledByDefault(t *testing.T) {
 	}
 }
 
+func TestMountCmdPassesTrustLocalEventsOption(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--trust-process-local-events",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if !got.TrustLocalEvents {
+		t.Fatal("TrustLocalEvents = false, want true")
+	}
+}
+
+func TestMountCmdLeavesTrustLocalEventsDisabledByDefault(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if got.TrustLocalEvents {
+		t.Fatal("TrustLocalEvents = true, want false")
+	}
+}
+
+func TestMountCmdRejectsTrustLocalEventsWithWebDAV(t *testing.T) {
+	err := MountCmd([]string{
+		"--mode", "webdav",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--trust-process-local-events",
+		t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "--trust-process-local-events") {
+		t.Fatalf("MountCmd error = %v, want trust-process-local-events validation error", err)
+	}
+}
+
 func TestMountCmdPassesReadCacheMaxFileOption(t *testing.T) {
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })

--- a/docs/specs/cache-invalidation.md
+++ b/docs/specs/cache-invalidation.md
@@ -37,7 +37,8 @@ This spec describes the **target architecture** for P1 cache implementation. The
 ## 2. Definitions
 
 - **revision**: A monotonically increasing integer assigned by the server to each file mutation. Every write produces a new revision. Note: chmod does NOT currently increment revision or emit SSE (see §1.1 prerequisites).
-- **SSE**: Server-Sent Events stream from `/v1/events`. Delivers `ChangeEvent` (per-path, for write/upload_complete/create/symlink ops) and `ResetEvent` (full invalidation, including for structural ops like rename/delete/mkdir/copy).
+- **SSE**: Server-Sent Events stream from `/v1/events`. Delivers `ChangeEvent` (per-path, for write/upload_complete/create/symlink ops), `ResetEvent` (full invalidation, including for structural ops like rename/delete/mkdir/copy), and heartbeat/current markers after replay/reset catch-up.
+- **trusted event stream**: An SSE stream that is safe to use as a freshness guarantee for revision-bound stat-cache hits. The current server event bus is process-local, so the stream is trusted only for single-server/sticky-routing deployments, or for future deployments with a cluster-wide durable event stream. Mounts must fail closed unless the operator explicitly enables this trust boundary.
 - **stale**: Cache entry whose revision is older than the server's current revision for that path.
 - **orphan**: Cache entry for a path/file that no longer exists on the server.
 - **structural op**: An operation that affects paths beyond the single target (rename, delete, mkdir, copy). The server converts these to `ResetEvent` because targeted single-path invalidation cannot reliably cover old paths, subtrees, and parent directory caches.
@@ -186,8 +187,10 @@ When the SSE connection drops:
    - For **directories**: Directory revision is not exposed by the current API (see §1.1). During SSE disconnect, directory cache entries fall back to TTL-only validity. After TTL expires, the next readdir fetches from server.
 4. When SSE reconnects:
    - The client reconnects with its last seen sequence number (`WatchEvents` in `pkg/client/events.go:50`).
-   - If the server's ring buffer can replay events since that sequence: server replays missed events. Each replayed event triggers normal invalidation (§4.1/§4.2). "Unverified" flag is cleared for entries that survive replay without invalidation.
-   - If the server cannot replay (sequence too old, server restart): server sends a `ResetEvent`. All caches are fully invalidated. "Unverified" flag is moot (everything is cleared).
+   - If the server's ring buffer can replay events since that sequence: server replays missed events. Each replayed event triggers normal invalidation (§4.1/§4.2). The server then emits a heartbeat/current marker. Only that marker can clear the "unverified" flag for entries that survive replay without invalidation.
+   - If the server cannot replay (sequence too old, server restart): server sends a `ResetEvent`, then a heartbeat/current marker. All caches are fully invalidated before the stream is considered verified.
+
+Revision-bound stat-cache hits may use the verified state only when the mount is configured to trust the SSE deployment boundary. With the current process-local event bus, default mounts do not trust SSE for regular-file `GetAttr` freshness and must fall back to remote HEAD revalidation.
 
 **Rationale**: Option A (block reads) would make the mount unusable during network hiccups. Option B (bounded stale) is complex to tune. Option C is pragmatic: reads continue with lazy revalidation, and missed events are replayed or full invalidation happens on reconnect.
 

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -29,9 +29,21 @@ type ResetEvent struct {
 	Actor  string `json:"actor,omitempty"`
 }
 
+// HeartbeatEvent is a server stream-current marker. Seq is the latest server
+// event sequence flushed before this heartbeat.
+type HeartbeatEvent struct {
+	Seq uint64 `json:"seq"`
+}
+
 // EventHandler receives SSE events. Exactly one of the pointer arguments is
 // non-nil per call.
 type EventHandler func(change *ChangeEvent, reset *ResetEvent)
+
+// EventLifecycle receives SSE stream lifecycle notifications.
+type EventLifecycle struct {
+	OnDisconnected func(error)
+	OnCurrent      func(seq uint64)
+}
 
 const (
 	sseInitialBackoff = 1 * time.Second
@@ -43,6 +55,11 @@ const (
 // The caller should cancel ctx to stop watching.
 // actor is the per-mount identifier used for self-event filtering.
 func (c *Client) WatchEvents(ctx context.Context, actor string, handler EventHandler) {
+	c.WatchEventsWithLifecycle(ctx, actor, handler, EventLifecycle{})
+}
+
+// WatchEventsWithLifecycle is WatchEvents with optional lifecycle callbacks.
+func (c *Client) WatchEventsWithLifecycle(ctx context.Context, actor string, handler EventHandler, lifecycle EventLifecycle) {
 	var lastSeq uint64
 	backoff := sseInitialBackoff
 
@@ -55,12 +72,22 @@ func (c *Client) WatchEvents(ctx context.Context, actor string, handler EventHan
 				lastSeq = reset.Seq
 			}
 			handler(change, reset)
+		}, func(seq uint64) {
+			if seq > lastSeq {
+				lastSeq = seq
+			}
+			if lifecycle.OnCurrent != nil {
+				lifecycle.OnCurrent(seq)
+			}
 		})
 
 		select {
 		case <-ctx.Done():
 			return
 		default:
+		}
+		if lifecycle.OnDisconnected != nil {
+			lifecycle.OnDisconnected(err)
 		}
 
 		// Always backoff on disconnect (err or clean EOF).
@@ -80,7 +107,7 @@ func (c *Client) WatchEvents(ctx context.Context, actor string, handler EventHan
 	}
 }
 
-func (c *Client) streamEvents(ctx context.Context, since uint64, actor string, handler EventHandler) error {
+func (c *Client) streamEvents(ctx context.Context, since uint64, actor string, handler EventHandler, onCurrent func(seq uint64)) error {
 	url := fmt.Sprintf("%s/v1/events?since=%d", c.baseURL, since)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -114,7 +141,7 @@ func (c *Client) streamEvents(ctx context.Context, since uint64, actor string, h
 		if line == "" {
 			// End of event.
 			if dataLine != "" {
-				parseAndDispatch(eventType, dataLine, handler)
+				parseAndDispatch(eventType, dataLine, handler, onCurrent)
 			}
 			eventType = ""
 			dataLine = ""
@@ -130,7 +157,7 @@ func (c *Client) streamEvents(ctx context.Context, since uint64, actor string, h
 	return scanner.Err()
 }
 
-func parseAndDispatch(eventType, data string, handler EventHandler) {
+func parseAndDispatch(eventType, data string, handler EventHandler, onCurrent func(seq uint64)) {
 	switch eventType {
 	case "file_changed":
 		var ev ChangeEvent
@@ -145,6 +172,12 @@ func parseAndDispatch(eventType, data string, handler EventHandler) {
 		}
 		handler(nil, &ev)
 	case "heartbeat":
-		// Heartbeats are connection-liveness signals only; do not dispatch.
+		var ev HeartbeatEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			return
+		}
+		if onCurrent != nil {
+			onCurrent(ev.Seq)
+		}
 	}
 }

--- a/pkg/client/events_test.go
+++ b/pkg/client/events_test.go
@@ -11,7 +11,7 @@ func TestParseAndDispatchResetIncludesStructuralFields(t *testing.T) {
 			t.Fatalf("change=%+v, want nil", change)
 		}
 		got = reset
-	})
+	}, nil)
 
 	if got == nil {
 		t.Fatal("reset event was not dispatched")
@@ -30,5 +30,23 @@ func TestParseAndDispatchResetIncludesStructuralFields(t *testing.T) {
 	}
 	if got.Actor != "actor1" {
 		t.Errorf("Actor=%q, want actor1", got.Actor)
+	}
+}
+
+func TestParseAndDispatchHeartbeatMarksStreamCurrent(t *testing.T) {
+	var gotSeq uint64
+	var handlerCalled bool
+
+	parseAndDispatch("heartbeat", `{"seq":42}`, func(*ChangeEvent, *ResetEvent) {
+		handlerCalled = true
+	}, func(seq uint64) {
+		gotSeq = seq
+	})
+
+	if handlerCalled {
+		t.Fatal("heartbeat should not dispatch a filesystem event")
+	}
+	if gotSeq != 42 {
+		t.Fatalf("current seq = %d, want 42", gotSeq)
 	}
 }

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -36,15 +36,19 @@ type Dat9FS struct {
 	dirHandles  *HandleTable[*DirHandle]
 	readCache   *ReadCache
 	dirCache    *DirCache
-	readSlots   chan struct{}
-	dirtyMu     sync.Mutex
-	dirtyInodes map[uint64]dirtyInodeState
-	dirtySeq    uint64
-	modeSeq     atomic.Uint64
-	uid         uint32
-	gid         uint32
-	opts        *MountOptions
-	debouncer   *flushDebouncer
+	// statCacheUnverified is true while the SSE stream is not known-current.
+	// In that state, file stat cache hits embedded in DirCache must fall back
+	// to HEAD revalidation instead of serving TTL-only attrs.
+	statCacheUnverified atomic.Bool
+	readSlots           chan struct{}
+	dirtyMu             sync.Mutex
+	dirtyInodes         map[uint64]dirtyInodeState
+	dirtySeq            uint64
+	modeSeq             atomic.Uint64
+	uid                 uint32
+	gid                 uint32
+	opts                *MountOptions
+	debouncer           *flushDebouncer
 
 	// Write-back cache: Flush writes small files to local disk, Release
 	// triggers async upload. Nil when CacheDir is not configured.
@@ -1914,6 +1918,30 @@ func (fs *Dat9FS) cacheFileForPath(p string, size int64, mtime time.Time, revisi
 	})
 }
 
+func (fs *Dat9FS) cacheEntryForPath(p string, entry *InodeEntry) {
+	if fs == nil || fs.dirCache == nil || p == "/" || entry == nil {
+		return
+	}
+	parentPath, name := cacheParentName(p)
+	fs.dirCache.Upsert(parentPath, cachedInfoFromEntry(name, entry))
+}
+
+func (fs *Dat9FS) markStatCacheUnverified() {
+	if fs != nil {
+		fs.statCacheUnverified.Store(true)
+	}
+}
+
+func (fs *Dat9FS) markStatCacheVerified() {
+	if fs != nil {
+		fs.statCacheUnverified.Store(false)
+	}
+}
+
+func (fs *Dat9FS) statCacheVerified() bool {
+	return fs == nil || !fs.statCacheUnverified.Load()
+}
+
 func (fs *Dat9FS) cacheNegativePath(p string) {
 	if fs == nil || fs.dirCache == nil || p == "/" || isLockFilePath(p) {
 		return
@@ -2129,6 +2157,12 @@ func (fs *Dat9FS) lookupFromDirCache(parentPath, childP, name string, out *gofus
 	result := fs.dirCache.Lookup(parentPath, name)
 	switch result.kind {
 	case namespaceLookupPositive:
+		if isLockFilePath(childP) {
+			if fs.perf != nil {
+				fs.perf.dirCacheMiss.add(1)
+			}
+			return false, gofuse.OK
+		}
 		if fs.perf != nil {
 			fs.perf.dirCacheHit.add(1)
 			fs.perf.namespacePositiveHit.add(1)
@@ -2184,6 +2218,50 @@ func (fs *Dat9FS) lookupFromDirCache(parentPath, childP, name string, out *gofus
 		}
 		return false, gofuse.OK
 	}
+}
+
+func (fs *Dat9FS) cachedAttrEntry(entry *InodeEntry) (*InodeEntry, bool) {
+	if fs == nil || fs.dirCache == nil || entry == nil || entry.Path == "/" || entry.IsDir || isLockFilePath(entry.Path) || !fs.statCacheVerified() {
+		return nil, false
+	}
+	parentPath, name := cacheParentName(entry.Path)
+	result := fs.dirCache.Lookup(parentPath, name)
+	if result.kind != namespaceLookupPositive {
+		return nil, false
+	}
+	item := result.item
+	if item.IsDir != entry.IsDir {
+		return nil, false
+	}
+	if item.Revision <= 0 && !item.IsDir {
+		return nil, false
+	}
+	if entry.Revision > 0 && item.Revision > 0 && item.Revision < entry.Revision {
+		return nil, false
+	}
+	mtime := item.Mtime
+	if mtime.IsZero() {
+		mtime = entry.Mtime
+	}
+	if mtime.IsZero() {
+		mtime = time.Now()
+	}
+	cached := *entry
+	cached.Size = item.Size
+	cached.IsDir = item.IsDir
+	cached.Mtime = mtime
+	if item.Revision > 0 {
+		cached.Revision = item.Revision
+		fs.inodes.UpdateRevision(entry.Ino, item.Revision)
+	}
+	fs.inodes.UpdateSize(entry.Ino, item.Size)
+	fs.inodes.UpdateMtime(entry.Ino, mtime)
+	if item.HasMode {
+		cached.Mode = item.Mode
+		cached.HasMode = true
+		fs.inodes.UpdateMode(entry.Ino, item.Mode)
+	}
+	return &cached, true
 }
 
 // --- RawFileSystem methods ---------------------------------------------------
@@ -2556,6 +2634,12 @@ func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *
 				pendingFound = true
 			}
 		}
+		if !pendingFound {
+			if cachedEntry, ok := fs.cachedAttrEntry(entry); ok {
+				entry = cachedEntry
+				pendingFound = true
+			}
+		}
 		if !pendingFound && input.NodeId != 1 {
 			stat, err := fs.getAttrStatWithRetry(cancel, entry.Path)
 			if err != nil {
@@ -2580,7 +2664,9 @@ func (fs *Dat9FS) GetAttr(cancel <-chan struct{}, input *gofuse.GetAttrIn, out *
 	} else if input.NodeId != 1 {
 		// Some deployments do not support HEAD/stat on directories.
 		// Keep directory attrs from inode map and only refresh regular files.
-		if !entry.IsDir {
+		if cachedEntry, ok := fs.cachedAttrEntry(entry); ok {
+			entry = cachedEntry
+		} else if !entry.IsDir {
 			stat, err := fs.getAttrStatWithRetry(cancel, entry.Path)
 			if err != nil {
 				return httpToFuseStatus(err)
@@ -2624,6 +2710,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 		if st != gofuse.OK {
 			return st
 		}
+		metadataChanged := false
 		restoreErr := fs.ensureGitStateForLocalPath(ctx, entry.Path)
 		if restoreErr != nil {
 			return httpToFuseStatus(restoreErr)
@@ -2634,6 +2721,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 			}
 			entry.Mtime = mtime
 			fs.inodes.UpdateMtime(input.NodeId, mtime)
+			metadataChanged = true
 		}
 		if input.Valid&gofuse.FATTR_MODE != 0 {
 			mode := input.Mode & 0o777
@@ -2646,6 +2734,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 			}
 			entry.Mode = entryMode
 			fs.inodes.UpdateMode(input.NodeId, entryMode)
+			metadataChanged = true
 		}
 		if input.Valid&gofuse.FATTR_SIZE != 0 {
 			if entry.IsDir {
@@ -2663,6 +2752,9 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 				entry = refreshed
 			}
 		}
+		if metadataChanged {
+			fs.cacheEntryForPath(entry.Path, entry)
+		}
 		fs.fillAttr(entry, &out.Attr)
 		out.SetTimeout(fs.opts.AttrTTL)
 		return gofuse.OK
@@ -2673,10 +2765,13 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 		return fs.setGitAttr(ctx, input, entry, out)
 	}
 
+	metadataChanged := false
+
 	// Handle mtime updates
 	if mtime, ok := input.GetMTime(); ok {
 		entry.Mtime = mtime
 		fs.inodes.UpdateMtime(input.NodeId, mtime)
+		metadataChanged = true
 	}
 
 	// Handle mode (chmod)
@@ -2719,6 +2814,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 		}
 		entry.Mode = entryMode
 		fs.inodes.UpdateMode(input.NodeId, entryMode)
+		metadataChanged = true
 	}
 
 	// Handle truncate
@@ -2787,6 +2883,9 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 		// no need for an explicit notifyInode here.
 	}
 
+	if metadataChanged {
+		fs.cacheEntryForPath(entry.Path, entry)
+	}
 	fs.fillAttr(entry, &out.Attr)
 	out.SetTimeout(fs.opts.AttrTTL)
 	return gofuse.OK

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -38,7 +38,10 @@ type Dat9FS struct {
 	dirCache    *DirCache
 	// statCacheUnverified is true while the SSE stream is not known-current.
 	// In that state, file stat cache hits embedded in DirCache must fall back
-	// to HEAD revalidation instead of serving TTL-only attrs.
+	// to HEAD revalidation instead of serving TTL-only attrs. Even when the
+	// stream is current, revision-bound file stat hits are enabled only when
+	// MountOptions.TrustLocalEvents explicitly allows process-local SSE
+	// freshness for this deployment.
 	statCacheUnverified atomic.Bool
 	readSlots           chan struct{}
 	dirtyMu             sync.Mutex
@@ -1942,6 +1945,13 @@ func (fs *Dat9FS) statCacheVerified() bool {
 	return fs == nil || !fs.statCacheUnverified.Load()
 }
 
+func (fs *Dat9FS) statCacheTrustedAndVerified() bool {
+	if fs == nil || fs.opts == nil || !fs.opts.TrustLocalEvents {
+		return false
+	}
+	return fs.statCacheVerified()
+}
+
 func (fs *Dat9FS) cacheNegativePath(p string) {
 	if fs == nil || fs.dirCache == nil || p == "/" || isLockFilePath(p) {
 		return
@@ -2221,7 +2231,7 @@ func (fs *Dat9FS) lookupFromDirCache(parentPath, childP, name string, out *gofus
 }
 
 func (fs *Dat9FS) cachedAttrEntry(entry *InodeEntry) (*InodeEntry, bool) {
-	if fs == nil || fs.dirCache == nil || entry == nil || entry.Path == "/" || entry.IsDir || isLockFilePath(entry.Path) || !fs.statCacheVerified() {
+	if fs == nil || fs.dirCache == nil || entry == nil || entry.Path == "/" || entry.IsDir || isLockFilePath(entry.Path) || !fs.statCacheTrustedAndVerified() {
 		return nil, false
 	}
 	parentPath, name := cacheParentName(entry.Path)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -44,6 +44,12 @@ func (r *testErrorRecorder) Check(t *testing.T) {
 	}
 }
 
+func trustedProcessLocalEventsOptions() *MountOptions {
+	opts := &MountOptions{TrustLocalEvents: true}
+	opts.setDefaults()
+	return opts
+}
+
 func newTestDat9FS(tb testing.TB, size int64, get func(http.ResponseWriter, *http.Request)) (*Dat9FS, uint64, func()) {
 	tb.Helper()
 
@@ -301,9 +307,7 @@ func BenchmarkDat9FS_GetAttr(b *testing.B) {
 		}))
 		defer ts.Close()
 
-		opts := &MountOptions{}
-		opts.setDefaults()
-		fs := NewDat9FS(newTestClient(ts.URL), opts)
+		fs := NewDat9FS(newTestClient(ts.URL), trustedProcessLocalEventsOptions())
 		ino := fs.inodes.Lookup(filePath, false, 1, time.Unix(1, 0))
 		fs.dirCache.Upsert("/", CachedFileInfo{
 			Name:     "cached.txt",
@@ -1357,9 +1361,7 @@ func TestGetAttrUsesRevisionBoundDirCacheStatWithoutRemoteHead(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	opts := &MountOptions{}
-	opts.setDefaults()
-	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), trustedProcessLocalEventsOptions())
 	ino := fs.inodes.Lookup("/cached.txt", false, 1, time.Unix(1, 0))
 	mtime := time.Unix(123, 0)
 	fs.dirCache.Upsert("/", CachedFileInfo{
@@ -1398,6 +1400,48 @@ func TestGetAttrUsesRevisionBoundDirCacheStatWithoutRemoteHead(t *testing.T) {
 	}
 }
 
+func TestGetAttrDoesNotTrustLocalEventsByDefault(t *testing.T) {
+	var headCalls atomic.Int32
+	var handlerErrors testErrorRecorder
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			handlerErrors.Recordf("method = %s, want HEAD", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		headCalls.Add(1)
+		w.Header().Set("Content-Length", "33")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", "8")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup("/cached.txt", false, 1, time.Unix(1, 0))
+	fs.dirCache.Upsert("/", CachedFileInfo{
+		Name:     "cached.txt",
+		Size:     12,
+		IsDir:    false,
+		Revision: 7,
+	})
+
+	var out gofuse.AttrOut
+	st := fs.GetAttr(nil, &gofuse.GetAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("GetAttr status = %v, want OK", st)
+	}
+	handlerErrors.Check(t)
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+	if got, want := out.Size, uint64(33); got != want {
+		t.Fatalf("GetAttr size = %d, want %d", got, want)
+	}
+}
+
 func TestGetAttrIgnoresOlderDirCacheRevision(t *testing.T) {
 	var headCalls atomic.Int32
 	var handlerErrors testErrorRecorder
@@ -1415,9 +1459,7 @@ func TestGetAttrIgnoresOlderDirCacheRevision(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	opts := &MountOptions{}
-	opts.setDefaults()
-	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), trustedProcessLocalEventsOptions())
 	ino := fs.inodes.Lookup("/cached.txt", false, 1, time.Unix(1, 0))
 	fs.inodes.UpdateRevision(ino, 9)
 	fs.dirCache.Upsert("/", CachedFileInfo{
@@ -1465,9 +1507,7 @@ func TestGetAttrSSEChangeInvalidatesCachedStat(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	opts := &MountOptions{}
-	opts.setDefaults()
-	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), trustedProcessLocalEventsOptions())
 	ino := fs.inodes.Lookup("/docs/readme.md", false, 12, time.Unix(1, 0))
 	fs.inodes.UpdateRevision(ino, 7)
 	fs.dirCache.Upsert("/docs", CachedFileInfo{
@@ -1523,9 +1563,7 @@ func TestSetAttrRefreshesDirCacheStatMetadata(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	opts := &MountOptions{}
-	opts.setDefaults()
-	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), trustedProcessLocalEventsOptions())
 	oldMtime := time.Unix(10, 0)
 	newMtime := time.Unix(123, 0)
 	ino := fs.inodes.Lookup("/cached.txt", false, 12, oldMtime)
@@ -1589,9 +1627,7 @@ func TestGetAttrRevalidatesDirCacheStatWhenSSEUnverified(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	opts := &MountOptions{}
-	opts.setDefaults()
-	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), trustedProcessLocalEventsOptions())
 	ino := fs.inodes.Lookup("/cached.txt", false, 12, time.Unix(1, 0))
 	fs.inodes.UpdateRevision(ino, 7)
 	fs.dirCache.Upsert("/", CachedFileInfo{
@@ -2246,9 +2282,7 @@ func TestGetAttrLockFileIgnoresPositiveDirCache(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	opts := &MountOptions{}
-	opts.setDefaults()
-	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), trustedProcessLocalEventsOptions())
 	fs.dirCache.Put("/repo/.git", []CachedFileInfo{{
 		Name:     "config.lock",
 		Size:     251,

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -22,6 +22,28 @@ import (
 	"github.com/mem9-ai/dat9/pkg/client"
 )
 
+type testErrorRecorder struct {
+	mu  sync.Mutex
+	err error
+}
+
+func (r *testErrorRecorder) Recordf(format string, args ...interface{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err == nil {
+		r.err = fmt.Errorf(format, args...)
+	}
+}
+
+func (r *testErrorRecorder) Check(t *testing.T) {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		t.Fatal(r.err)
+	}
+}
+
 func newTestDat9FS(tb testing.TB, size int64, get func(http.ResponseWriter, *http.Request)) (*Dat9FS, uint64, func()) {
 	tb.Helper()
 
@@ -246,6 +268,66 @@ func BenchmarkDat9FS_SmallFileOpen(b *testing.B) {
 				fs.clearDirtySize(ino, fh.DirtySeq)
 			}
 			fs.fileHandles.Delete(out.Fh)
+		}
+	})
+}
+
+func BenchmarkDat9FS_GetAttr(b *testing.B) {
+	const filePath = "/cached.txt"
+
+	b.Run("remote-head", func(b *testing.B) {
+		fs, ino, cleanup := newTestDat9FS(b, 12, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("data"))
+		})
+		defer cleanup()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var out gofuse.AttrOut
+			st := fs.GetAttr(nil, &gofuse.GetAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, &out)
+			if st != gofuse.OK {
+				b.Fatalf("GetAttr status = %v, want OK", st)
+			}
+			benchmarkIntSink += int(out.Size)
+		}
+	})
+
+	b.Run("dir-cache-hit", func(b *testing.B) {
+		var remoteCalls atomic.Int32
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			remoteCalls.Add(1)
+			http.Error(w, "unexpected remote call", http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		opts := &MountOptions{}
+		opts.setDefaults()
+		fs := NewDat9FS(newTestClient(ts.URL), opts)
+		ino := fs.inodes.Lookup(filePath, false, 1, time.Unix(1, 0))
+		fs.dirCache.Upsert("/", CachedFileInfo{
+			Name:     "cached.txt",
+			Size:     12,
+			IsDir:    false,
+			Mtime:    time.Unix(123, 0),
+			Revision: 7,
+			Mode:     0o600,
+			HasMode:  true,
+		})
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var out gofuse.AttrOut
+			st := fs.GetAttr(nil, &gofuse.GetAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, &out)
+			if st != gofuse.OK {
+				b.Fatalf("GetAttr status = %v, want OK", st)
+			}
+			benchmarkIntSink += int(out.Size)
+		}
+		b.StopTimer()
+		if got := remoteCalls.Load(); got != 0 {
+			b.Fatalf("remote calls = %d, want 0", got)
 		}
 	})
 }
@@ -1267,6 +1349,280 @@ func TestGetAttrDirectoryDoesNotRequireRemoteStat(t *testing.T) {
 	}
 }
 
+func TestGetAttrUsesRevisionBoundDirCacheStatWithoutRemoteHead(t *testing.T) {
+	var remoteCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "unexpected remote call", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup("/cached.txt", false, 1, time.Unix(1, 0))
+	mtime := time.Unix(123, 0)
+	fs.dirCache.Upsert("/", CachedFileInfo{
+		Name:     "cached.txt",
+		Size:     12,
+		IsDir:    false,
+		Mtime:    mtime,
+		Revision: 7,
+		Mode:     0o600,
+		HasMode:  true,
+	})
+
+	var out gofuse.AttrOut
+	st := fs.GetAttr(nil, &gofuse.GetAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("GetAttr status = %v, want OK", st)
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote calls = %d, want 0", got)
+	}
+	if got, want := out.Size, uint64(12); got != want {
+		t.Fatalf("GetAttr size = %d, want %d", got, want)
+	}
+	if got, want := out.Mode&0o777, uint32(0o600); got != want {
+		t.Fatalf("GetAttr mode = %o, want %o", got, want)
+	}
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode entry not found")
+	}
+	if entry.Revision != 7 {
+		t.Fatalf("inode revision = %d, want 7", entry.Revision)
+	}
+	if !entry.Mtime.Equal(mtime) {
+		t.Fatalf("inode mtime = %s, want %s", entry.Mtime, mtime)
+	}
+}
+
+func TestGetAttrIgnoresOlderDirCacheRevision(t *testing.T) {
+	var headCalls atomic.Int32
+	var handlerErrors testErrorRecorder
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			handlerErrors.Recordf("method = %s, want HEAD", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		headCalls.Add(1)
+		w.Header().Set("Content-Length", "33")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", "10")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup("/cached.txt", false, 1, time.Unix(1, 0))
+	fs.inodes.UpdateRevision(ino, 9)
+	fs.dirCache.Upsert("/", CachedFileInfo{
+		Name:     "cached.txt",
+		Size:     12,
+		IsDir:    false,
+		Revision: 7,
+	})
+
+	var out gofuse.AttrOut
+	st := fs.GetAttr(nil, &gofuse.GetAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("GetAttr status = %v, want OK", st)
+	}
+	handlerErrors.Check(t)
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+	if got, want := out.Size, uint64(33); got != want {
+		t.Fatalf("GetAttr size = %d, want %d", got, want)
+	}
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode entry not found")
+	}
+	if entry.Revision != 10 {
+		t.Fatalf("inode revision = %d, want 10", entry.Revision)
+	}
+}
+
+func TestGetAttrSSEChangeInvalidatesCachedStat(t *testing.T) {
+	var headCalls atomic.Int32
+	var handlerErrors testErrorRecorder
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			handlerErrors.Recordf("method = %s, want HEAD", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		headCalls.Add(1)
+		w.Header().Set("Content-Length", "44")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", "8")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup("/docs/readme.md", false, 12, time.Unix(1, 0))
+	fs.inodes.UpdateRevision(ino, 7)
+	fs.dirCache.Upsert("/docs", CachedFileInfo{
+		Name:     "readme.md",
+		Size:     12,
+		IsDir:    false,
+		Revision: 7,
+	})
+
+	w := &SSEWatcher{fs: fs, actor: "mount-b"}
+	w.handleChange(&client.ChangeEvent{
+		Seq:   1,
+		Path:  "/docs/readme.md",
+		Op:    "write",
+		Actor: "mount-a",
+	})
+
+	var out gofuse.AttrOut
+	st := fs.GetAttr(nil, &gofuse.GetAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("GetAttr status = %v, want OK", st)
+	}
+	handlerErrors.Check(t)
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+	if got, want := out.Size, uint64(44); got != want {
+		t.Fatalf("GetAttr size = %d, want %d", got, want)
+	}
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode entry not found")
+	}
+	if entry.Revision != 8 {
+		t.Fatalf("inode revision = %d, want 8", entry.Revision)
+	}
+}
+
+func TestSetAttrRefreshesDirCacheStatMetadata(t *testing.T) {
+	var chmodCalls atomic.Int32
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Query().Has("chmod"):
+			chmodCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodHead:
+			headCalls.Add(1)
+			http.Error(w, "unexpected stale-cache revalidation", http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	oldMtime := time.Unix(10, 0)
+	newMtime := time.Unix(123, 0)
+	ino := fs.inodes.Lookup("/cached.txt", false, 12, oldMtime)
+	fs.inodes.UpdateRevision(ino, 7)
+	fs.dirCache.Upsert("/", CachedFileInfo{
+		Name:     "cached.txt",
+		Size:     12,
+		IsDir:    false,
+		Mtime:    oldMtime,
+		Revision: 7,
+		Mode:     0o644,
+		HasMode:  true,
+	})
+
+	var setOut gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_MODE | gofuse.FATTR_MTIME,
+			Mode:     0o600,
+			Mtime:    uint64(newMtime.Unix()),
+		},
+	}, &setOut)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+	if got := chmodCalls.Load(); got != 1 {
+		t.Fatalf("chmod calls = %d, want 1", got)
+	}
+
+	var out gofuse.AttrOut
+	st = fs.GetAttr(nil, &gofuse.GetAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("GetAttr status = %v, want OK", st)
+	}
+	if got := headCalls.Load(); got != 0 {
+		t.Fatalf("HEAD calls = %d, want 0", got)
+	}
+	if got, want := out.Mode&0o777, uint32(0o600); got != want {
+		t.Fatalf("GetAttr mode = %o, want %o", got, want)
+	}
+	if got, want := out.Mtime, uint64(newMtime.Unix()); got != want {
+		t.Fatalf("GetAttr mtime = %d, want %d", got, want)
+	}
+}
+
+func TestGetAttrRevalidatesDirCacheStatWhenSSEUnverified(t *testing.T) {
+	var headCalls atomic.Int32
+	var handlerErrors testErrorRecorder
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			handlerErrors.Recordf("method = %s, want HEAD", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		headCalls.Add(1)
+		w.Header().Set("Content-Length", "44")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", "8")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup("/cached.txt", false, 12, time.Unix(1, 0))
+	fs.inodes.UpdateRevision(ino, 7)
+	fs.dirCache.Upsert("/", CachedFileInfo{
+		Name:     "cached.txt",
+		Size:     12,
+		IsDir:    false,
+		Revision: 7,
+	})
+	fs.markStatCacheUnverified()
+
+	var out gofuse.AttrOut
+	st := fs.GetAttr(nil, &gofuse.GetAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("GetAttr status = %v, want OK", st)
+	}
+	handlerErrors.Check(t)
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+	if got, want := out.Size, uint64(44); got != want {
+		t.Fatalf("GetAttr size = %d, want %d", got, want)
+	}
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode entry not found")
+	}
+	if entry.Revision != 8 {
+		t.Fatalf("inode revision = %d, want 8", entry.Revision)
+	}
+}
+
 func TestGetAttrRetriesTransientCanceledStat(t *testing.T) {
 	var headCalls atomic.Int32
 	firstHeadStarted := make(chan struct{}, 1)
@@ -1839,6 +2195,79 @@ func TestLookupLockFileIgnoresCompleteNamespaceMiss(t *testing.T) {
 	if got := headCalls.Load(); got != 1 {
 		t.Fatalf("HEAD calls = %d, want 1", got)
 	}
+}
+
+func TestLookupLockFileIgnoresPositiveDirCache(t *testing.T) {
+	var handlerErrors testErrorRecorder
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			handlerErrors.Recordf("method = %s, want HEAD", r.Method)
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		headCalls.Add(1)
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.dirCache.Put("/repo/.git", []CachedFileInfo{{
+		Name:     "config.lock",
+		Size:     251,
+		Revision: 7,
+	}})
+	gitIno := fs.inodes.Lookup("/repo/.git", true, 0, time.Now())
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: gitIno}, "config.lock", &out)
+	if st != gofuse.ENOENT {
+		t.Fatalf("Lookup status = %v, want ENOENT", st)
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+	handlerErrors.Check(t)
+}
+
+func TestGetAttrLockFileIgnoresPositiveDirCache(t *testing.T) {
+	var handlerErrors testErrorRecorder
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			handlerErrors.Recordf("method = %s, want HEAD", r.Method)
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		headCalls.Add(1)
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.dirCache.Put("/repo/.git", []CachedFileInfo{{
+		Name:     "config.lock",
+		Size:     251,
+		Revision: 7,
+	}})
+	lockIno := fs.inodes.Lookup("/repo/.git/config.lock", false, 251, time.Now())
+	fs.inodes.UpdateRevision(lockIno, 7)
+
+	var out gofuse.AttrOut
+	st := fs.GetAttr(nil, &gofuse.GetAttrIn{
+		InHeader: gofuse.InHeader{NodeId: lockIno},
+	}, &out)
+	if st != gofuse.ENOENT {
+		t.Fatalf("GetAttr status = %v, want ENOENT", st)
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+	handlerErrors.Check(t)
 }
 
 func TestLookupSessionCreatedDirMissAvoidsRemoteStat(t *testing.T) {
@@ -3051,8 +3480,8 @@ func TestDefaultTTLIs60Seconds(t *testing.T) {
 	if opts.EntryTTL != defaultPositiveKernelCacheTTL {
 		t.Fatalf("default EntryTTL = %v, want %v", opts.EntryTTL, defaultPositiveKernelCacheTTL)
 	}
-	if opts.NegativeEntryTTL != 10*time.Second {
-		t.Fatalf("default NegativeEntryTTL = %v, want 10s", opts.NegativeEntryTTL)
+	if opts.NegativeEntryTTL != time.Second {
+		t.Fatalf("default NegativeEntryTTL = %v, want 1s", opts.NegativeEntryTTL)
 	}
 }
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -41,7 +41,7 @@ type MountOptions struct {
 	DirTTL                time.Duration // DirCache TTL (default 10s)
 	AttrTTL               time.Duration // kernel attr cache TTL (default 60s)
 	EntryTTL              time.Duration // kernel entry cache TTL (default 60s)
-	NegativeEntryTTL      time.Duration // kernel negative entry cache TTL (default 10s)
+	NegativeEntryTTL      time.Duration // kernel negative entry cache TTL (default 1s)
 	FlushDebounce         time.Duration // debounce window for small-file flush coalescing (default 2s, 0 disables); set to -1 to use default
 	SyncMode              SyncMode      // interactive, strict, or auto (default auto)
 	WritePolicy           WritePolicy   // writeback, close-sync, or write-sync (default writeback)
@@ -91,7 +91,7 @@ func (o *MountOptions) setDefaults() {
 		o.EntryTTL = defaultPositiveKernelCacheTTL
 	}
 	if o.NegativeEntryTTL <= 0 {
-		o.NegativeEntryTTL = 10 * time.Second
+		o.NegativeEntryTTL = time.Second
 	}
 	// FlushDebounce: 0 means disabled, negative means unset (use default).
 	if o.FlushDebounce < 0 {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -60,6 +60,7 @@ type MountOptions struct {
 	PrefetchMaxFileBytes  int64         // maximum individual file size prefetched (default 50KB)
 	PrefetchMaxBytes      int64         // maximum aggregate bytes prefetched per directory read (default 1MB)
 	PrefetchTimeout       time.Duration // timeout for one readdir prefetch batch (default 1s)
+	TrustLocalEvents      bool          // allow revision-bound GetAttr hits from DirCache using process-local SSE freshness; safe only for single-server/sticky or cluster-wide event streams
 	AllowOther            bool          // allow other users to access mount
 	ReadOnly              bool          // mount as read-only
 	Debug                 bool          // enable FUSE debug logging

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -22,6 +22,9 @@ type SSEWatcher struct {
 // StartSSEWatcher starts a background goroutine that connects to the
 // server's /v1/events SSE endpoint and invalidates local caches.
 func StartSSEWatcher(fs *Dat9FS, c *client.Client, actor string) *SSEWatcher {
+	if fs != nil {
+		fs.markStatCacheUnverified()
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	w := &SSEWatcher{
 		fs:     fs,
@@ -31,7 +34,14 @@ func StartSSEWatcher(fs *Dat9FS, c *client.Client, actor string) *SSEWatcher {
 	}
 	go func() {
 		defer close(w.doneCh)
-		c.WatchEvents(ctx, actor, w.handleEvent)
+		c.WatchEventsWithLifecycle(ctx, actor, w.handleEvent, client.EventLifecycle{
+			OnDisconnected: func(error) {
+				if w.fs != nil {
+					w.fs.markStatCacheUnverified()
+				}
+			},
+			OnCurrent: w.handleStreamCurrent,
+		})
 	}()
 	return w
 }
@@ -40,6 +50,12 @@ func StartSSEWatcher(fs *Dat9FS, c *client.Client, actor string) *SSEWatcher {
 func (w *SSEWatcher) Stop() {
 	w.cancel()
 	<-w.doneCh
+}
+
+func (w *SSEWatcher) handleStreamCurrent(uint64) {
+	if w.fs != nil {
+		w.fs.markStatCacheVerified()
+	}
 }
 
 func (w *SSEWatcher) handleEvent(change *client.ChangeEvent, reset *client.ResetEvent) {
@@ -69,6 +85,9 @@ func (w *SSEWatcher) handleEvent(change *client.ChangeEvent, reset *client.Reset
 		}
 		// Only handle resets with an explicit reason (not heartbeats).
 		w.handleReset(reset)
+		if w.fs != nil {
+			w.fs.markStatCacheVerified()
+		}
 	}
 }
 

--- a/pkg/fuse/sse_test.go
+++ b/pkg/fuse/sse_test.go
@@ -161,6 +161,61 @@ func TestSSEWatcherHandleChangeInvalidatesChildDirNamespace(t *testing.T) {
 	}
 }
 
+func TestSSEWatcherHandleEventChangeInvalidatesButKeepsStatCacheUnverified(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+	fs.markStatCacheUnverified()
+	fs.readCache.Put("/docs/readme.md", []byte("old content"), 1)
+	fs.dirCache.Put("/docs", []CachedFileInfo{{Name: "readme.md", Size: 50}})
+
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+	w.handleEvent(&client.ChangeEvent{
+		Seq:   1,
+		Path:  "/docs/readme.md",
+		Op:    "write",
+		Actor: "other-actor",
+	}, nil)
+
+	if _, ok := fs.readCache.Get("/docs/readme.md", 1); ok {
+		t.Error("readCache entry should be invalidated after handled change")
+	}
+	if _, ok := fs.dirCache.Get("/docs"); ok {
+		t.Error("dirCache entry should be invalidated after handled change")
+	}
+	if fs.statCacheVerified() {
+		t.Error("stat cache should remain unverified after handled change without replay-complete marker")
+	}
+}
+
+func TestSSEWatcherStreamCurrentVerifiesStatCache(t *testing.T) {
+	opts := &MountOptions{
+		CacheSize: 1 << 20,
+		DirTTL:    5 * time.Second,
+	}
+	opts.setDefaults()
+	fs := &Dat9FS{
+		inodes:    NewInodeToPath(),
+		readCache: NewReadCache(opts.CacheSize, 0),
+		dirCache:  NewDirCache(opts.DirTTL),
+	}
+	fs.markStatCacheUnverified()
+
+	w := &SSEWatcher{fs: fs, actor: "my-actor"}
+	w.handleStreamCurrent(42)
+
+	if !fs.statCacheVerified() {
+		t.Error("stream-current callback should verify stat cache")
+	}
+}
+
 func TestSSEWatcherHandleChangeFiltersAndRebasesRemoteRoot(t *testing.T) {
 	opts := &MountOptions{
 		CacheSize:  1 << 20,
@@ -292,6 +347,7 @@ func TestSSEWatcherHandleEventReset(t *testing.T) {
 
 	fs.readCache.Put("/test.txt", []byte("data"), 1)
 	fs.dirCache.Put("/", []CachedFileInfo{{Name: "test.txt", Size: 4}})
+	fs.markStatCacheUnverified()
 
 	w := &SSEWatcher{fs: fs, actor: "my-actor"}
 
@@ -303,6 +359,9 @@ func TestSSEWatcherHandleEventReset(t *testing.T) {
 	}
 	if _, ok := fs.dirCache.Get("/"); ok {
 		t.Error("dirCache should be cleared after reset")
+	}
+	if !fs.statCacheVerified() {
+		t.Error("stat cache should be verified after handled reset invalidation")
 	}
 }
 

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -213,8 +213,13 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			lastSeen = ev.Seq
 		}
 	}
+	// End the initial replay/reset phase with an immediate heartbeat so
+	// clients have an explicit stream-current marker. This lets caches that
+	// were marked unverified on disconnect become verified without waiting
+	// for the periodic heartbeat.
+	sendSSEHeartbeat(bw, lastSeen)
 	// Flush initial replay/reset immediately so the client receives the
-	// cursor position without waiting for the first heartbeat.
+	// cursor position without waiting for the periodic heartbeat.
 	if err := bw.Flush(); err != nil {
 		return
 	}

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -502,6 +502,17 @@ func TestSSEBurstFlush(t *testing.T) {
 
 	scanner := bufio.NewScanner(resp.Body)
 
+	// Initial replay is empty for since=1, but the server must still emit a
+	// current heartbeat immediately so clients can clear reconnect-unverified
+	// cache state without waiting for the periodic heartbeat.
+	ev, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected initial current heartbeat")
+	}
+	if ev.Event != "heartbeat" {
+		t.Fatalf("expected initial heartbeat, got %q", ev.Event)
+	}
+
 	// Publish a burst of 3 events concurrently.
 	go func() {
 		time.Sleep(50 * time.Millisecond)
@@ -512,8 +523,6 @@ func TestSSEBurstFlush(t *testing.T) {
 
 	// Read first event with a timeout well under heartbeat (30s).
 	done := make(chan struct{})
-	var ev sseEvent
-	var ok bool
 	go func() {
 		ev, ok = readSSEEvent(scanner)
 		close(done)

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -174,13 +174,18 @@ func TestSSEEndpointLiveEvent(t *testing.T) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Publish a new event after connection is established.
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		bus.Publish("/new.txt", "write", "remote-actor")
-	}()
-
 	scanner := bufio.NewScanner(resp.Body)
+
+	current, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected initial stream-current heartbeat")
+	}
+	if current.Event != "heartbeat" {
+		t.Fatalf("initial event=%q, want heartbeat", current.Event)
+	}
+
+	bus.Publish("/new.txt", "write", "remote-actor")
+
 	ev, ok := readSSEEvent(scanner)
 	if !ok {
 		t.Fatal("expected live event")
@@ -325,13 +330,18 @@ func TestSSEStructuralOpLiveEmitsReset(t *testing.T) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Publish a structural op live.
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		bus.Publish("/old", "rename", "remote-actor")
-	}()
-
 	scanner := bufio.NewScanner(resp.Body)
+
+	current, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected initial stream-current heartbeat")
+	}
+	if current.Event != "heartbeat" {
+		t.Fatalf("initial event=%q, want heartbeat", current.Event)
+	}
+
+	bus.Publish("/old", "rename", "remote-actor")
+
 	ev, ok := readSSEEvent(scanner)
 	if !ok {
 		t.Fatal("expected live event")


### PR DESCRIPTION
## Summary

Implements the read-only stat-cache portion of #487 using the existing directory cache and the merged cache invalidation spec.

Changes:
- `GetAttr` can now use a positive `DirCache` entry as a revision-bound stat cache hit.
- File stat cache hits require a positive revision and reject cache entries older than the current inode revision.
- Dirty/writeback/pending local metadata still wins over cached remote metadata.
- Existing SSE change/reset invalidation now has a regression proving a remote change invalidates cached stat data and forces a fresh HEAD.
- Negative cache default is aligned with `docs/specs/cache-invalidation.md`: 1s.

This does not change writeback, commit batching, disk read cache, singleflight, parallel read, or server APIs.

## Scope notes

The merged spec states directory revision is not yet exposed by the server API, so directory cache validity remains TTL + SSE-driven for now. This PR does not invent a directory revision protocol; it uses the current API safely and keeps file stat hits revision-bound.

## Tests

```bash
/usr/local/go/bin/go test ./pkg/fuse -count=1
/usr/local/go/bin/go test ./cmd/drive9 ./pkg/fuse -count=1
git diff --check
```

Added regressions:
- `TestGetAttrUsesRevisionBoundDirCacheStatWithoutRemoteHead`
- `TestGetAttrIgnoresOlderDirCacheRevision`
- `TestGetAttrSSEChangeInvalidatesCachedStat`
- updated `TestDefaultTTLIs60Seconds` for the 1s negative-cache default

## Benchmark

Command:

```bash
/usr/local/go/bin/go test ./pkg/fuse -run '^$' -bench '^BenchmarkDat9FS_GetAttr$' -benchmem -count=5 -json > /tmp/drive9-issue487-getattr-bench.json
```

Observed local Go benchmark:

```text
BenchmarkDat9FS_GetAttr/remote-head-8      ~32.8–33.7 µs/op   ~6392 B/op   82 allocs/op
BenchmarkDat9FS_GetAttr/dir-cache-hit-8    ~564.8–569.7 ns/op    464 B/op    6 allocs/op
```

This is a focused unit benchmark for the changed `GetAttr` path. Full mount-level benchmark harness data should be collected after #487/#488 land together because user-visible `stat` workloads also interact with lookup/readdir and singleflight behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event-stream lifecycle callbacks: disconnection and stream-current notifications to drive cache verification.

* **Refactor**
  * Stronger attribute cache handling with verifiable stat-cache state, conditional cache writes, and lock-file cache misses.
  * Reduced default FUSE negative entry TTL from 10s to 1s.

* **Tests**
  * New unit tests and a benchmark covering attribute caching, SSE/watch behavior, and heartbeat/current handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->