### PR TITLE
cd: merge us-east-1 into prod-cd workflow

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
 
     steps:
-      - name: Configure AWS credentials for dev (ap-southeast-1)
+      - name: Configure AWS credentials (ap-southeast-1)
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ARN_PROD }}
@@ -67,8 +67,10 @@ jobs:
           printf '%s=%s\n' "IMAGE" "$IMAGE" >> "$GITHUB_ENV"
 
       - name: Deploy to ap-southeast-1
+        id: deploy-sg
         if: inputs.region == 'all' || inputs.region == 'ap-southeast-1'
         run: |
+          echo "sg-deploy=1" >> "$GITHUB_ENV"
           aws eks update-kubeconfig \
             --name prod-dat9 \
             --region ap-southeast-1 \
@@ -81,12 +83,12 @@ jobs:
             --timeout=180s
 
       - name: Rollback ap-southeast-1 on failure
-        if: failure() && (inputs.region == 'all' || inputs.region == 'ap-southeast-1')
+        if: failure() && steps.deploy-sg.outcome == 'failure'
         run: |
           kubectl --context prod -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
 
-      - name: Configure AWS credentials for us-east-1
+      - name: Configure AWS credentials (us-east-1)
         if: inputs.region == 'all' || inputs.region == 'us-east-1'
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -94,8 +96,10 @@ jobs:
           aws-region: us-east-1
 
       - name: Deploy to us-east-1
+        id: deploy-us
         if: inputs.region == 'all' || inputs.region == 'us-east-1'
         run: |
+          echo "us-deploy=1" >> "$GITHUB_ENV"
           aws eks update-kubeconfig \
             --name prod-dat9-us \
             --region us-east-1 \
@@ -108,7 +112,7 @@ jobs:
             --timeout=180s
 
       - name: Rollback us-east-1 on failure
-        if: failure() && (inputs.region == 'all' || inputs.region == 'us-east-1')
+        if: failure() && steps.deploy-us.outcome == 'failure'
         run: |
           kubectl --context us -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -3,10 +3,11 @@ on:
   workflow_dispatch:
     inputs:
       region:
-        description: "Target region (empty = all regions)"
-        required: false
+        description: "Target region"
+        required: true
         type: choice
         options:
+          - all
           - ap-southeast-1
           - us-east-1
       image_tag:
@@ -22,7 +23,7 @@ env:
 
 jobs:
   deploy:
-    name: Deploy${{ inputs.region && format(' to {0}', inputs.region) || ' all regions' }}
+    name: Deploy to ${{ inputs.region }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -66,7 +67,7 @@ jobs:
           printf '%s=%s\n' "IMAGE" "$IMAGE" >> "$GITHUB_ENV"
 
       - name: Deploy to ap-southeast-1
-        if: inputs.region == '' || inputs.region == 'ap-southeast-1'
+        if: inputs.region == 'all' || inputs.region == 'ap-southeast-1'
         run: |
           aws eks update-kubeconfig \
             --name prod-dat9 \
@@ -79,22 +80,35 @@ jobs:
             rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
             --timeout=180s
 
+      - name: Rollback ap-southeast-1 on failure
+        if: failure() && (inputs.region == 'all' || inputs.region == 'ap-southeast-1')
+        run: |
+          kubectl --context prod -n "${{ env.DEPLOY_NAMESPACE }}" \
+            rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
+
       - name: Configure AWS credentials for us-east-1
-        if: inputs.region == '' || inputs.region == 'us-east-1'
+        if: inputs.region == 'all' || inputs.region == 'us-east-1'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ARN_US }}
           aws-region: us-east-1
 
       - name: Deploy to us-east-1
-        if: inputs.region == '' || inputs.region == 'us-east-1'
+        if: inputs.region == 'all' || inputs.region == 'us-east-1'
         run: |
           aws eks update-kubeconfig \
             --name prod-dat9-us \
-            --region us-east-1
-          kubectl -n "${{ env.DEPLOY_NAMESPACE }}" \
+            --region us-east-1 \
+            --alias us
+          kubectl --context us -n "${{ env.DEPLOY_NAMESPACE }}" \
             set image "deployment/${{ env.K8S_DEPLOYMENT }}" \
             "${{ env.K8S_DEPLOYMENT }}=$IMAGE"
-          kubectl -n "${{ env.DEPLOY_NAMESPACE }}" \
+          kubectl --context us -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
             --timeout=180s
+
+      - name: Rollback us-east-1 on failure
+        if: failure() && (inputs.region == 'all' || inputs.region == 'us-east-1')
+        run: |
+          kubectl --context us -n "${{ env.DEPLOY_NAMESPACE }}" \
+            rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -1,48 +1,46 @@
 name: Deploy server to prod
-
 on:
   workflow_dispatch:
     inputs:
+      region:
+        description: "Target region (empty = all regions)"
+        required: false
+        type: choice
+        options:
+          - ap-southeast-1
+          - us-east-1
       image_tag:
-        description: "Optional image tag override (default: use current dev deployment image)"
+        description: "Image tag override (default: resolve from dev deployment)"
         required: false
         type: string
 
 env:
-  AWS_REGION: ${{ secrets.AWS_REGION }}
   ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-  AWS_ASSUME_ARN_PROD: ${{ secrets.AWS_ASSUME_ARN_PROD }}
   ECR_REPOSITORY: dat9-server
-  EKS_DEV_CLUSTER: dev-dat9
-  EKS_PROD_CLUSTER: prod-dat9
   DEPLOY_NAMESPACE: dat9
   K8S_DEPLOYMENT: dat9-server
 
 jobs:
   deploy:
-    name: Promote dev image to prod
+    name: Deploy${{ inputs.region && format(' to {0}', inputs.region) || ' all regions' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
 
     steps:
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials for dev (ap-southeast-1)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.AWS_ASSUME_ARN_PROD }}
-          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ASSUME_ARN_PROD }}
+          aws-region: ap-southeast-1
 
-      - name: Update kubeconfig for dev and prod
+      - name: Update kubeconfig for dev
         run: |
           aws eks update-kubeconfig \
-            --name ${{ env.EKS_DEV_CLUSTER }} \
-            --region ${{ env.AWS_REGION }} \
+            --name dev-dat9 \
+            --region ap-southeast-1 \
             --alias dev
-          aws eks update-kubeconfig \
-            --name ${{ env.EKS_PROD_CLUSTER }} \
-            --region ${{ env.AWS_REGION }} \
-            --alias prod
 
       - name: Resolve image from dev
         run: |
@@ -54,17 +52,20 @@ jobs:
               get deployment/${{ env.K8S_DEPLOYMENT }} \
               -o jsonpath='{.spec.template.spec.containers[?(@.name=="dat9-server")].image}')
           fi
-
           if [ -z "$IMAGE" ]; then
             echo "Failed to resolve image" >&2
             exit 1
           fi
-
           echo "Promoting image: $IMAGE"
           echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
 
-      - name: Deploy to prod
+      - name: Deploy to ap-southeast-1
+        if: inputs.region == '' || inputs.region == 'ap-southeast-1'
         run: |
+          aws eks update-kubeconfig \
+            --name prod-dat9 \
+            --region ap-southeast-1 \
+            --alias prod
           kubectl --context prod -n ${{ env.DEPLOY_NAMESPACE }} \
             set image deployment/${{ env.K8S_DEPLOYMENT }} \
             ${{ env.K8S_DEPLOYMENT }}=${{ env.IMAGE }}
@@ -72,8 +73,22 @@ jobs:
             rollout status deployment/${{ env.K8S_DEPLOYMENT }} \
             --timeout=180s
 
-      - name: Rollback on failed deploy
-        if: failure()
+      - name: Configure AWS credentials for us-east-1
+        if: inputs.region == '' || inputs.region == 'us-east-1'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ARN_US }}
+          aws-region: us-east-1
+
+      - name: Deploy to us-east-1
+        if: inputs.region == '' || inputs.region == 'us-east-1'
         run: |
-          kubectl --context prod -n ${{ env.DEPLOY_NAMESPACE }} \
-            rollout undo deployment/${{ env.K8S_DEPLOYMENT }}
+          aws eks update-kubeconfig \
+            --name prod-dat9-us \
+            --region us-east-1
+          kubectl -n ${{ env.DEPLOY_NAMESPACE }} \
+            set image deployment/${{ env.K8S_DEPLOYMENT }} \
+            ${{ env.K8S_DEPLOYMENT }}=${{ env.IMAGE }}
+          kubectl -n ${{ env.DEPLOY_NAMESPACE }} \
+            rollout status deployment/${{ env.K8S_DEPLOYMENT }} \
+            --timeout=180s

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -46,18 +46,24 @@ jobs:
         run: |
           INPUT_TAG='${{ inputs.image_tag }}'
           if [ -n "$INPUT_TAG" ]; then
+            case "$INPUT_TAG" in
+              *[![:alnum:]_.-]*)
+                echo "Invalid image tag override" >&2
+                exit 1
+                ;;
+            esac
             IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:$INPUT_TAG"
           else
-            IMAGE=$(kubectl --context dev -n ${{ env.DEPLOY_NAMESPACE }} \
-              get deployment/${{ env.K8S_DEPLOYMENT }} \
-              -o jsonpath='{.spec.template.spec.containers[?(@.name=="dat9-server")].image}')
+            IMAGE=$(kubectl --context dev -n "${{ env.DEPLOY_NAMESPACE }}" \
+              get "deployment/${{ env.K8S_DEPLOYMENT }}" \
+              -o 'jsonpath={.spec.template.spec.containers[?(@.name=="dat9-server")].image}')
           fi
           if [ -z "$IMAGE" ]; then
             echo "Failed to resolve image" >&2
             exit 1
           fi
           echo "Promoting image: $IMAGE"
-          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+          printf '%s=%s\n' "IMAGE" "$IMAGE" >> "$GITHUB_ENV"
 
       - name: Deploy to ap-southeast-1
         if: inputs.region == '' || inputs.region == 'ap-southeast-1'
@@ -66,11 +72,11 @@ jobs:
             --name prod-dat9 \
             --region ap-southeast-1 \
             --alias prod
-          kubectl --context prod -n ${{ env.DEPLOY_NAMESPACE }} \
-            set image deployment/${{ env.K8S_DEPLOYMENT }} \
-            ${{ env.K8S_DEPLOYMENT }}=${{ env.IMAGE }}
-          kubectl --context prod -n ${{ env.DEPLOY_NAMESPACE }} \
-            rollout status deployment/${{ env.K8S_DEPLOYMENT }} \
+          kubectl --context prod -n "${{ env.DEPLOY_NAMESPACE }}" \
+            set image "deployment/${{ env.K8S_DEPLOYMENT }}" \
+            "${{ env.K8S_DEPLOYMENT }}=$IMAGE"
+          kubectl --context prod -n "${{ env.DEPLOY_NAMESPACE }}" \
+            rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
             --timeout=180s
 
       - name: Configure AWS credentials for us-east-1
@@ -86,9 +92,9 @@ jobs:
           aws eks update-kubeconfig \
             --name prod-dat9-us \
             --region us-east-1
-          kubectl -n ${{ env.DEPLOY_NAMESPACE }} \
-            set image deployment/${{ env.K8S_DEPLOYMENT }} \
-            ${{ env.K8S_DEPLOYMENT }}=${{ env.IMAGE }}
-          kubectl -n ${{ env.DEPLOY_NAMESPACE }} \
-            rollout status deployment/${{ env.K8S_DEPLOYMENT }} \
+          kubectl -n "${{ env.DEPLOY_NAMESPACE }}" \
+            set image "deployment/${{ env.K8S_DEPLOYMENT }}" \
+            "${{ env.K8S_DEPLOYMENT }}=$IMAGE"
+          kubectl -n "${{ env.DEPLOY_NAMESPACE }}" \
+            rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
             --timeout=180s


### PR DESCRIPTION
## Summary
- Merge us-east-1 deployment into prod-cd.yml
- Add region choice input (ap-southeast-1 / us-east-1 / all)
- Both regions resolve image from dev deployment
- Deploy all regions when no region selected

## Changes
- Update `.github/workflows/prod-cd.yml` to support multi-region deploy
- Remove standalone `us-east-1-cd.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Production deployment workflow now supports region selection (ap-southeast-1/us-east-1 or all) and deploys conditionally per region with region-specific credential and cluster setup.
  * Resolved image is exported to the environment for downstream steps and job display names reflect the selected region.
* **Bug Fixes**
  * Improved image-tag validation and explicit failure when no image is resolved; rollout waits added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->