### PR TITLE
e2e: add FUSE read correctness workload

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -349,8 +349,8 @@ the layout captured by that run.
 | `RUN_LARGE_FILE` | `1` | `api-smoke-test.sh` |
 | `LARGE_FILE_MB` | `100` | `api-smoke-test.sh` |
 | `BATCH_SMALL_FILE_COUNT` | `10` | `api-smoke-test.sh` |
-| `REQUEST_MAX_RETRIES` | `8` | `api-smoke-test.sh` |
-| `REQUEST_RETRY_SLEEP_S` | `2` | `api-smoke-test.sh` |
+| `REQUEST_MAX_RETRIES` | `8` | `api-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `REQUEST_RETRY_SLEEP_S` | `2` | `api-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
 | `RUN_UPLOAD_LIMIT_BOUNDARY` | `1` | `api-smoke-test.sh` |
 | `UPLOAD_LIMIT_BYTES` | `10737418240` | `api-smoke-test.sh` |
 | `RUN_SEMANTIC_CHECKS` | `1` | `api-smoke-test.sh` |
@@ -372,8 +372,8 @@ the layout captured by that run.
 | `MOUNT_READY_TIMEOUT_S` | `20` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
 | `MOUNT_READY_INTERVAL_S` | `1` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
 | `FUSE_MOUNT_ROOT` | `/tmp` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
-| `CLI_MAX_RETRIES` | `8` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
-| `CLI_RETRY_SLEEP_S` | `2` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `CLI_MAX_RETRIES` | `8` | `fuse-smoke-test.sh` |
+| `CLI_RETRY_SLEEP_S` | `2` | `fuse-smoke-test.sh` |
 | `FUSE_STRICT_PREREQS` | `0` (`1` in release gate) | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
 | `FUSE_UMOUNT_TIMEOUT` | `60s` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
 | `FUSE_CORRECTNESS_LARGE_MB` | `9` | `fuse-correctness-workload.sh` |

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -46,6 +46,9 @@ bash e2e/journal-smoke-test.sh
 # FUSE smoke (mount + bidirectional filesystem checks)
 bash e2e/fuse-smoke-test.sh
 
+# Manifest-based FUSE read correctness workload
+bash e2e/fuse-correctness-workload.sh
+
 # Git workspace smoke (fast-blobless clone + common agent Git workloads)
 bash e2e/git-workspace-smoke-test.sh
 
@@ -208,6 +211,27 @@ Notes:
 - Optional release-gate knobs add small-repo git clone/status/log checks,
   durable `drive9 umount --timeout` remount visibility checks, and mount-log audit.
 
+### `fuse-correctness-workload.sh`
+
+Host support: Linux and macOS only. This script needs real FUSE support and is
+deterministic read-correctness coverage, not a write/concurrency/Git workload.
+
+1. Provision tenant unless `DRIVE9_API_KEY` is already set
+2. Prepare `drive9` CLI binary (build local or download official release)
+3. Create a remote fixture tree through CLI writes, including empty files,
+   text files, binary files, an 8MiB+ file, multi-level directories, filenames
+   with spaces, unicode filenames, a symlink, and a hardlink
+4. Mount the fixture subtree read-only through real FUSE
+5. Verify `find -type f`, `find -type d`, and `find -type l` exactly match
+   the fixture manifest
+6. Verify `cat` + SHA-256 and `stat` size parity for every manifest file
+7. Verify hardlink `nlink` and checksum parity, and symlink `readlink` plus
+   target checksum parity
+8. Verify `grep` finds expected markers across normal, space-containing,
+   unicode, nested, hardlink, and symlink paths, and that no-match grep fails
+9. Verify the read-only mount rejects writes
+10. Preserve run root, fixture root, and mount log on failure
+
 ### `git-workspace-smoke-test.sh`
 
 Host support: Linux and macOS only. This script needs real FUSE support and
@@ -317,16 +341,18 @@ the layout captured by that run.
 | `RUN_CLI_FORK_CHECKS` | `1` (auto-skip when `/v1/fork` is unavailable) | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_TIMEOUT_S` | `90` | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_INTERVAL_S` | `3` | `cli-smoke-test.sh` |
-| `CLI_SOURCE` | `build` (`build` or `official`) | `cli-smoke-test.sh`, `fuse-smoke-test.sh` |
-| `CLI_RELEASE_BASE_URL` | `https://drive9.ai/releases` | `cli-smoke-test.sh`, `fuse-smoke-test.sh` |
-| `CLI_RELEASE_VERSION` | *(latest)* | `cli-smoke-test.sh`, `fuse-smoke-test.sh` |
-| `MOUNT_READY_TIMEOUT_S` | `20` | `fuse-smoke-test.sh` |
-| `MOUNT_READY_INTERVAL_S` | `1` | `fuse-smoke-test.sh` |
-| `FUSE_MOUNT_ROOT` | `/tmp` | `fuse-smoke-test.sh` |
-| `CLI_MAX_RETRIES` | `8` | `fuse-smoke-test.sh` |
-| `CLI_RETRY_SLEEP_S` | `2` | `fuse-smoke-test.sh` |
-| `FUSE_STRICT_PREREQS` | `0` (`1` in release gate) | `fuse-smoke-test.sh` |
-| `FUSE_UMOUNT_TIMEOUT` | `60s` | `fuse-smoke-test.sh` |
+| `CLI_SOURCE` | `build` (`build` or `official`) | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `CLI_RELEASE_BASE_URL` | `https://drive9.ai/releases` | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `CLI_RELEASE_VERSION` | *(latest)* | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `MOUNT_READY_TIMEOUT_S` | `20` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `MOUNT_READY_INTERVAL_S` | `1` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `FUSE_MOUNT_ROOT` | `/tmp` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `CLI_MAX_RETRIES` | `8` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `CLI_RETRY_SLEEP_S` | `2` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `FUSE_STRICT_PREREQS` | `0` (`1` in release gate) | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `FUSE_UMOUNT_TIMEOUT` | `60s` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `FUSE_CORRECTNESS_LARGE_MB` | `9` | `fuse-correctness-workload.sh` |
+| `FUSE_CORRECTNESS_KEEP_ARTIFACTS` | `0` | `fuse-correctness-workload.sh` |
 | `RUN_FUSE_GIT_CLONE` | `0` (`1` in release gate) | `fuse-smoke-test.sh` |
 | `FUSE_GIT_CLONE_URL` | `https://github.com/octocat/Hello-World.git` | `fuse-smoke-test.sh` |
 | `FUSE_GIT_CLONE_TIMEOUT_S` | `180` | `fuse-smoke-test.sh` |

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -49,6 +49,9 @@ bash e2e/fuse-smoke-test.sh
 # Manifest-based FUSE read correctness workload
 bash e2e/fuse-correctness-workload.sh
 
+# Bounded FUSE concurrency stress workload
+bash e2e/fuse-concurrency-stress.sh
+
 # Git workspace smoke (fast-blobless clone + common agent Git workloads)
 bash e2e/git-workspace-smoke-test.sh
 
@@ -232,6 +235,25 @@ deterministic read-correctness coverage, not a write/concurrency/Git workload.
 9. Verify the read-only mount rejects writes
 10. Preserve run root, fixture root, and mount log on failure
 
+### `fuse-concurrency-stress.sh`
+
+Host support: Linux and macOS only. This script needs real FUSE support and is
+deterministic writable concurrency coverage, not a Git or cross-mount workload.
+
+1. Provision tenant unless `DRIVE9_API_KEY` is already set
+2. Prepare `drive9` CLI binary (build local or download official release)
+3. Mount a fresh writable namespace through real FUSE
+4. Run parallel writer threads that create files via temp-write/fsync/atomic
+   rename, append per-worker logs, churn create/unlink temp files, rename
+   directories into final locations, and verify open-handle reads across rename
+5. Run concurrent reader threads that continuously walk/read the mounted tree
+   and reject mixed, short, or corrupted reads of atomically published files
+6. Verify the final mounted tree exactly matches a deterministic manifest
+7. Unmount, copy the remote tree back through the CLI, and verify the remote
+   snapshot matches the same manifest
+8. Preserve run root, mount log, expected/actual manifests, and reader error log
+   on failure
+
 ### `git-workspace-smoke-test.sh`
 
 Host support: Linux and macOS only. This script needs real FUSE support and
@@ -301,6 +323,9 @@ the layout captured by that run.
 2. Enables small-repo git clone/status/log coverage
 3. Enables durable `umount --timeout` followed by remount visibility checks
 4. Enables mount-log audit and dumps mount logs on failure
+5. Runs manifest read correctness workload
+6. Runs bounded concurrency stress workload only when
+   `RUN_FUSE_CONCURRENCY_STRESS=1`
 
 ### `smoke-all.sh`
 
@@ -341,18 +366,24 @@ the layout captured by that run.
 | `RUN_CLI_FORK_CHECKS` | `1` (auto-skip when `/v1/fork` is unavailable) | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_TIMEOUT_S` | `90` | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_INTERVAL_S` | `3` | `cli-smoke-test.sh` |
-| `CLI_SOURCE` | `build` (`build` or `official`) | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
-| `CLI_RELEASE_BASE_URL` | `https://drive9.ai/releases` | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
-| `CLI_RELEASE_VERSION` | *(latest)* | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
-| `MOUNT_READY_TIMEOUT_S` | `20` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
-| `MOUNT_READY_INTERVAL_S` | `1` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
-| `FUSE_MOUNT_ROOT` | `/tmp` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
-| `CLI_MAX_RETRIES` | `8` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
-| `CLI_RETRY_SLEEP_S` | `2` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
-| `FUSE_STRICT_PREREQS` | `0` (`1` in release gate) | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
-| `FUSE_UMOUNT_TIMEOUT` | `60s` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh` |
+| `CLI_SOURCE` | `build` (`build` or `official`) | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `CLI_RELEASE_BASE_URL` | `https://drive9.ai/releases` | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `CLI_RELEASE_VERSION` | *(latest)* | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `MOUNT_READY_TIMEOUT_S` | `20` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `MOUNT_READY_INTERVAL_S` | `1` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `FUSE_MOUNT_ROOT` | `/tmp` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `CLI_MAX_RETRIES` | `8` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `CLI_RETRY_SLEEP_S` | `2` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `FUSE_STRICT_PREREQS` | `0` (`1` in release gate) | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
+| `FUSE_UMOUNT_TIMEOUT` | `60s` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-concurrency-stress.sh` |
 | `FUSE_CORRECTNESS_LARGE_MB` | `9` | `fuse-correctness-workload.sh` |
 | `FUSE_CORRECTNESS_KEEP_ARTIFACTS` | `0` | `fuse-correctness-workload.sh` |
+| `FUSE_CONCURRENCY_WORKERS` | `4` | `fuse-concurrency-stress.sh` |
+| `FUSE_CONCURRENCY_FILES_PER_WORKER` | `8` | `fuse-concurrency-stress.sh` |
+| `FUSE_CONCURRENCY_READER_WORKERS` | `2` | `fuse-concurrency-stress.sh` |
+| `FUSE_CONCURRENCY_PAYLOAD_KB` | `32` | `fuse-concurrency-stress.sh` |
+| `FUSE_CONCURRENCY_TIMEOUT_S` | `120` | `fuse-concurrency-stress.sh` |
+| `FUSE_CONCURRENCY_KEEP_ARTIFACTS` | `0` | `fuse-concurrency-stress.sh` |
 | `RUN_FUSE_GIT_CLONE` | `0` (`1` in release gate) | `fuse-smoke-test.sh` |
 | `FUSE_GIT_CLONE_URL` | `https://github.com/octocat/Hello-World.git` | `fuse-smoke-test.sh` |
 | `FUSE_GIT_CLONE_TIMEOUT_S` | `180` | `fuse-smoke-test.sh` |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -17,7 +17,8 @@ including local single-tenant validation via `drive9-server-local`.
 | `api-smoke-test-existing-key.sh` | Existing API key status/list checks |
 | `cli-smoke-test.sh` | End-to-end CLI workflow including `fs symlink`, `fs hardlink`, `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
 | `fuse-smoke-test.sh` | FUSE mount lifecycle, file/dir/symlink/hardlink/rename/stat semantics, cross-channel consistency, read-only and error-path checks |
-| `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, and mount-log audit |
+| `fuse-correctness-workload.sh` | Real read-only FUSE workload over a manifest fixture: `find`, `grep`, `stat`, `cat`, `sha256`, symlink, hardlink, unicode/space paths, empty files, binary files, and 8MiB+ files |
+| `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, mount-log audit, and manifest-based FUSE correctness workload |
 | `git-workspace-smoke-test.sh` | Git workspace fast-blobless clone with coding-agent local overlay, batched tracked-file edits, ignored local-only paths, `git add`/`commit`, `git apply`, and remount restore |
 | `posix-permission-smoke-test.sh` | POSIX permission coverage: API mkdir/chmod mode propagation, CLI `fs chmod`, FUSE `chmod`/`mkdir -m` with remote and local stat parity |
 | `smoke-all.sh` | Runs API + CLI + FUSE + POSIX permission smoke scripts in sequence with aggregated pass/fail; set `RUN_GIT_WORKSPACE_SMOKE=1` to include Git workspace coverage |
@@ -53,6 +54,9 @@ CLI_SOURCE=official bash e2e/cli-smoke-test.sh
 
 bash e2e/fuse-smoke-test.sh
 
+# Manifest-based read correctness workload on a real read-only FUSE mount.
+bash e2e/fuse-correctness-workload.sh
+
 # Fast-blobless Git workspace smoke. This is intentionally opt-in for broad
 # smoke runs because it clones real repositories and needs FUSE support.
 bash e2e/git-workspace-smoke-test.sh
@@ -62,6 +66,7 @@ bash e2e/fuse-release-gate.sh
 
 # Use official released drive9 CLI for FUSE smoke
 CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
+CLI_SOURCE=official bash e2e/fuse-correctness-workload.sh
 CLI_SOURCE=official bash e2e/fuse-release-gate.sh
 CLI_SOURCE=official bash e2e/posix-permission-smoke-test.sh
 
@@ -161,6 +166,9 @@ bash e2e/cli-smoke-test.sh
 # FUSE smoke using the repo build.
 bash e2e/fuse-smoke-test.sh
 
+# Deterministic read correctness workload using grep/find/stat/cat/checksum.
+bash e2e/fuse-correctness-workload.sh
+
 # Strict FUSE release gate using the repo build.
 bash e2e/fuse-release-gate.sh
 
@@ -182,6 +190,7 @@ use the same value as `DRIVE9_API_KEY` here.
 ```bash
 CLI_SOURCE=official bash e2e/cli-smoke-test.sh
 CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
+CLI_SOURCE=official bash e2e/fuse-correctness-workload.sh
 CLI_SOURCE=official bash e2e/fuse-release-gate.sh
 CLI_SOURCE=official bash e2e/git-workspace-smoke-test.sh
 ```
@@ -217,6 +226,7 @@ CLI_SOURCE=official bash e2e/git-workspace-smoke-test.sh
 - API retry knobs for throttling are `REQUEST_MAX_RETRIES` and `REQUEST_RETRY_SLEEP_S`.
 - CLI retry knobs for throttling are `CLI_MAX_RETRIES` and `CLI_RETRY_SLEEP_S`.
 - FUSE mount readiness knobs are `MOUNT_READY_TIMEOUT_S`, `MOUNT_READY_INTERVAL_S`, and `FUSE_MOUNT_ROOT`.
+- FUSE correctness workload knobs are `FUSE_CORRECTNESS_LARGE_MB` and `FUSE_CORRECTNESS_KEEP_ARTIFACTS`.
 - FUSE release-gate knobs are `FUSE_STRICT_PREREQS`, `RUN_FUSE_GIT_CLONE`, `FUSE_GIT_CLONE_URL`, `FUSE_GIT_CLONE_TIMEOUT_S`, `RUN_FUSE_UMOUNT_DURABLE`, `FUSE_UMOUNT_TIMEOUT`, and `RUN_FUSE_LOG_AUDIT`.
 - Git workspace smoke defaults to `drive9`, `kimi-cli`, and `kimi-code`. Override with `GIT_WORKSPACE_REPOS='slug=https://example/repo.git,...'`.
 - Git workspace scenarios default to `agent_edit_add_commit,agent_patch_apply,sandbox_restore`; tune with `GIT_WORKSPACE_SCENARIOS`.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -18,7 +18,8 @@ including local single-tenant validation via `drive9-server-local`.
 | `cli-smoke-test.sh` | End-to-end CLI workflow including `fs symlink`, `fs hardlink`, `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
 | `fuse-smoke-test.sh` | FUSE mount lifecycle, file/dir/symlink/hardlink/rename/stat semantics, cross-channel consistency, read-only and error-path checks |
 | `fuse-correctness-workload.sh` | Real read-only FUSE workload over a manifest fixture: `find`, `grep`, `stat`, `cat`, `sha256`, symlink, hardlink, unicode/space paths, empty files, binary files, and 8MiB+ files |
-| `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, mount-log audit, and manifest-based FUSE correctness workload |
+| `fuse-concurrency-stress.sh` | Real writable FUSE concurrency workload with parallel writers/readers, atomic rename, unlink churn, open-handle rename reads, and deterministic final manifest checks |
+| `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, mount-log audit, and manifest-based FUSE correctness workload; set `RUN_FUSE_CONCURRENCY_STRESS=1` to add bounded concurrency stress |
 | `git-workspace-smoke-test.sh` | Git workspace fast-blobless clone with coding-agent local overlay, batched tracked-file edits, ignored local-only paths, `git add`/`commit`, `git apply`, and remount restore |
 | `posix-permission-smoke-test.sh` | POSIX permission coverage: API mkdir/chmod mode propagation, CLI `fs chmod`, FUSE `chmod`/`mkdir -m` with remote and local stat parity |
 | `smoke-all.sh` | Runs API + CLI + FUSE + POSIX permission smoke scripts in sequence with aggregated pass/fail; set `RUN_GIT_WORKSPACE_SMOKE=1` to include Git workspace coverage |
@@ -57,6 +58,9 @@ bash e2e/fuse-smoke-test.sh
 # Manifest-based read correctness workload on a real read-only FUSE mount.
 bash e2e/fuse-correctness-workload.sh
 
+# Bounded concurrency stress on a real writable FUSE mount.
+bash e2e/fuse-concurrency-stress.sh
+
 # Fast-blobless Git workspace smoke. This is intentionally opt-in for broad
 # smoke runs because it clones real repositories and needs FUSE support.
 bash e2e/git-workspace-smoke-test.sh
@@ -64,9 +68,13 @@ bash e2e/git-workspace-smoke-test.sh
 # Strict FUSE release gate used by CI
 bash e2e/fuse-release-gate.sh
 
+# Add the concurrency stress workload to the strict FUSE release gate.
+RUN_FUSE_CONCURRENCY_STRESS=1 bash e2e/fuse-release-gate.sh
+
 # Use official released drive9 CLI for FUSE smoke
 CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
 CLI_SOURCE=official bash e2e/fuse-correctness-workload.sh
+CLI_SOURCE=official bash e2e/fuse-concurrency-stress.sh
 CLI_SOURCE=official bash e2e/fuse-release-gate.sh
 CLI_SOURCE=official bash e2e/posix-permission-smoke-test.sh
 
@@ -169,8 +177,14 @@ bash e2e/fuse-smoke-test.sh
 # Deterministic read correctness workload using grep/find/stat/cat/checksum.
 bash e2e/fuse-correctness-workload.sh
 
+# Deterministic concurrency workload using parallel reads/writes/rename/unlink.
+bash e2e/fuse-concurrency-stress.sh
+
 # Strict FUSE release gate using the repo build.
 bash e2e/fuse-release-gate.sh
+
+# Strict FUSE release gate plus bounded concurrency stress.
+RUN_FUSE_CONCURRENCY_STRESS=1 bash e2e/fuse-release-gate.sh
 
 # POSIX permission smoke (API + CLI + FUSE).
 bash e2e/posix-permission-smoke-test.sh
@@ -191,6 +205,7 @@ use the same value as `DRIVE9_API_KEY` here.
 CLI_SOURCE=official bash e2e/cli-smoke-test.sh
 CLI_SOURCE=official bash e2e/fuse-smoke-test.sh
 CLI_SOURCE=official bash e2e/fuse-correctness-workload.sh
+CLI_SOURCE=official bash e2e/fuse-concurrency-stress.sh
 CLI_SOURCE=official bash e2e/fuse-release-gate.sh
 CLI_SOURCE=official bash e2e/git-workspace-smoke-test.sh
 ```
@@ -227,7 +242,8 @@ CLI_SOURCE=official bash e2e/git-workspace-smoke-test.sh
 - CLI retry knobs for throttling are `CLI_MAX_RETRIES` and `CLI_RETRY_SLEEP_S`.
 - FUSE mount readiness knobs are `MOUNT_READY_TIMEOUT_S`, `MOUNT_READY_INTERVAL_S`, and `FUSE_MOUNT_ROOT`.
 - FUSE correctness workload knobs are `FUSE_CORRECTNESS_LARGE_MB` and `FUSE_CORRECTNESS_KEEP_ARTIFACTS`.
-- FUSE release-gate knobs are `FUSE_STRICT_PREREQS`, `RUN_FUSE_GIT_CLONE`, `FUSE_GIT_CLONE_URL`, `FUSE_GIT_CLONE_TIMEOUT_S`, `RUN_FUSE_UMOUNT_DURABLE`, `FUSE_UMOUNT_TIMEOUT`, and `RUN_FUSE_LOG_AUDIT`.
+- FUSE concurrency workload knobs are `FUSE_CONCURRENCY_WORKERS`, `FUSE_CONCURRENCY_FILES_PER_WORKER`, `FUSE_CONCURRENCY_READER_WORKERS`, `FUSE_CONCURRENCY_PAYLOAD_KB`, `FUSE_CONCURRENCY_TIMEOUT_S`, and `FUSE_CONCURRENCY_KEEP_ARTIFACTS`.
+- FUSE release-gate knobs are `FUSE_STRICT_PREREQS`, `RUN_FUSE_GIT_CLONE`, `FUSE_GIT_CLONE_URL`, `FUSE_GIT_CLONE_TIMEOUT_S`, `RUN_FUSE_UMOUNT_DURABLE`, `FUSE_UMOUNT_TIMEOUT`, `RUN_FUSE_LOG_AUDIT`, `RUN_FUSE_CONCURRENCY_STRESS`, and the FUSE correctness/concurrency workload knobs.
 - Git workspace smoke defaults to `drive9`, `kimi-cli`, and `kimi-code`. Override with `GIT_WORKSPACE_REPOS='slug=https://example/repo.git,...'`.
 - Git workspace scenarios default to `agent_edit_add_commit,agent_patch_apply,sandbox_restore`; tune with `GIT_WORKSPACE_SCENARIOS`.
 - Git workspace file-count knobs are `GIT_WORKSPACE_EXISTING_FILES`, `GIT_WORKSPACE_NEW_FILES`, and `GIT_WORKSPACE_PATCH_FILES`.
@@ -239,4 +255,4 @@ CLI_SOURCE=official bash e2e/git-workspace-smoke-test.sh
 - CLI upload-limit boundary check is enabled by default via `RUN_CLI_UPLOAD_LIMIT_BOUNDARY=1`.
 - `CLI_UPLOAD_LIMIT_BYTES` controls the boundary value checked by CLI e2e (default `10737418240`).
 - `fuse-smoke-test.sh` will `SKIP` when host prerequisites are missing (for example no `/dev/fuse`) unless `FUSE_STRICT_PREREQS=1`.
-- `fuse-release-gate.sh` is the strict CI/release entry point and enables git clone/status/log, durable `umount --timeout` remount checks, and mount-log audit.
+- `fuse-release-gate.sh` is the strict CI/release entry point and enables git clone/status/log, durable `umount --timeout` remount checks, mount-log audit, and manifest read correctness. Set `RUN_FUSE_CONCURRENCY_STRESS=1` to add bounded concurrency stress.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -238,8 +238,8 @@ CLI_SOURCE=official bash e2e/git-workspace-smoke-test.sh
 - CLI smoke large-file size can be tuned with `CLI_LARGE_FILE_MB` (default `100`).
 - API batch small-file coverage can be tuned with `BATCH_SMALL_FILE_COUNT` (default `10`).
 - CLI batch small-file coverage can be tuned with `CLI_BATCH_SMALL_FILE_COUNT` (default `10`).
-- API retry knobs for throttling are `REQUEST_MAX_RETRIES` and `REQUEST_RETRY_SLEEP_S`.
-- CLI retry knobs for throttling are `CLI_MAX_RETRIES` and `CLI_RETRY_SLEEP_S`.
+- API retry knobs for throttling are `REQUEST_MAX_RETRIES` and `REQUEST_RETRY_SLEEP_S`; the FUSE correctness/concurrency workloads use these for provisioning/status and CLI retry loops.
+- CLI retry knobs for `cli-smoke-test.sh` and `fuse-smoke-test.sh` throttling are `CLI_MAX_RETRIES` and `CLI_RETRY_SLEEP_S`.
 - FUSE mount readiness knobs are `MOUNT_READY_TIMEOUT_S`, `MOUNT_READY_INTERVAL_S`, and `FUSE_MOUNT_ROOT`.
 - FUSE correctness workload knobs are `FUSE_CORRECTNESS_LARGE_MB` and `FUSE_CORRECTNESS_KEEP_ARTIFACTS`.
 - FUSE concurrency workload knobs are `FUSE_CONCURRENCY_WORKERS`, `FUSE_CONCURRENCY_FILES_PER_WORKER`, `FUSE_CONCURRENCY_READER_WORKERS`, `FUSE_CONCURRENCY_PAYLOAD_KB`, `FUSE_CONCURRENCY_TIMEOUT_S`, and `FUSE_CONCURRENCY_KEEP_ARTIFACTS`.

--- a/e2e/fuse-concurrency-stress.sh
+++ b/e2e/fuse-concurrency-stress.sh
@@ -1,0 +1,730 @@
+#!/usr/bin/env bash
+# Deterministic Drive9 FUSE concurrency stress workload.
+#
+# This script mounts a fresh writable namespace through real FUSE, then runs
+# concurrent readers and writers against ordinary filesystem operations. Final
+# correctness is judged by deterministic manifests, not command exit status.
+# It intentionally avoids Git and cross-mount checks; those are separate gates.
+
+set -euo pipefail
+
+BASE="${DRIVE9_BASE:-http://127.0.0.1:9009}"
+DRIVE9_API_KEY="${DRIVE9_API_KEY:-}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-120}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+MOUNT_READY_TIMEOUT_S="${MOUNT_READY_TIMEOUT_S:-20}"
+MOUNT_READY_INTERVAL_S="${MOUNT_READY_INTERVAL_S:-1}"
+FUSE_MOUNT_ROOT="${FUSE_MOUNT_ROOT:-/tmp}"
+FUSE_STRICT_PREREQS="${FUSE_STRICT_PREREQS:-0}"
+FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-60s}"
+FUSE_CONCURRENCY_KEEP_ARTIFACTS="${FUSE_CONCURRENCY_KEEP_ARTIFACTS:-0}"
+FUSE_CONCURRENCY_WORKERS="${FUSE_CONCURRENCY_WORKERS:-4}"
+FUSE_CONCURRENCY_FILES_PER_WORKER="${FUSE_CONCURRENCY_FILES_PER_WORKER:-8}"
+FUSE_CONCURRENCY_READER_WORKERS="${FUSE_CONCURRENCY_READER_WORKERS:-2}"
+FUSE_CONCURRENCY_PAYLOAD_KB="${FUSE_CONCURRENCY_PAYLOAD_KB:-32}"
+FUSE_CONCURRENCY_TIMEOUT_S="${FUSE_CONCURRENCY_TIMEOUT_S:-120}"
+CLI_SOURCE="${CLI_SOURCE:-build}"
+CLI_RELEASE_BASE_URL="${CLI_RELEASE_BASE_URL:-https://drive9.ai/releases}"
+CLI_RELEASE_VERSION="${CLI_RELEASE_VERSION:-}"
+CLI_MAX_RETRIES="${CLI_MAX_RETRIES:-8}"
+CLI_RETRY_SLEEP_S="${CLI_RETRY_SLEEP_S:-2}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+check_eq() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL + 1))
+  if [ "$got" = "$want" ]; then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    echo "  want: $want"
+    echo "  got:  $got"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@"; then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+skip() {
+  echo "SKIP $*"
+  exit 0
+}
+
+skip_or_fail() {
+  if [ "$FUSE_STRICT_PREREQS" = "1" ]; then
+    echo "FAIL $*" >&2
+    exit 1
+  fi
+  skip "$@"
+}
+
+detect_release_target() {
+  case "$(uname -s)" in
+    Linux) CLI_RELEASE_OS="linux" ;;
+    Darwin) CLI_RELEASE_OS="darwin" ;;
+    *)
+      echo "unsupported OS for official CLI download: $(uname -s)" >&2
+      return 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64) CLI_RELEASE_ARCH="amd64" ;;
+    aarch64|arm64) CLI_RELEASE_ARCH="arm64" ;;
+    *)
+      echo "unsupported architecture for official CLI download: $(uname -m)" >&2
+      return 1
+      ;;
+  esac
+}
+
+download_official_cli() {
+  local target_version="$CLI_RELEASE_VERSION"
+  detect_release_target || return 1
+  if [ -z "$target_version" ]; then
+    target_version=$(curl -fsSL "$CLI_RELEASE_BASE_URL/version" | tr -d '[:space:]')
+  fi
+  if [ -z "$target_version" ]; then
+    echo "failed to resolve release version from $CLI_RELEASE_BASE_URL/version" >&2
+    return 1
+  fi
+  curl -fsSL "$CLI_RELEASE_BASE_URL/drive9-$CLI_RELEASE_OS-$CLI_RELEASE_ARCH" -o "$CLI_BIN"
+  chmod +x "$CLI_BIN"
+  local actual_version
+  actual_version="$($CLI_BIN --version 2>/dev/null | awk '{print $2}')"
+  if [ -n "$CLI_RELEASE_VERSION" ] && [ "$actual_version" != "$CLI_RELEASE_VERSION" ]; then
+    echo "downloaded version mismatch: expected=$CLI_RELEASE_VERSION actual=$actual_version" >&2
+    return 1
+  fi
+  echo "downloaded official drive9 $actual_version for $CLI_RELEASE_OS/$CLI_RELEASE_ARCH" >&2
+}
+
+prepare_cli_binary() {
+  CLI_BIN="$(mktemp)"
+  case "$CLI_SOURCE" in
+    build)
+      make build-cli CLI_BIN="$CLI_BIN"
+      ;;
+    official)
+      download_official_cli
+      ;;
+    *)
+      echo "invalid CLI_SOURCE: $CLI_SOURCE (expected build|official)" >&2
+      return 1
+      ;;
+  esac
+}
+
+is_mounted() {
+  local mount_point="$1"
+  local physical_mount_point
+  physical_mount_point="$(cd "$(dirname "$mount_point")" 2>/dev/null && pwd -P)/$(basename "$mount_point")"
+  if command -v mountpoint >/dev/null 2>&1; then
+    mountpoint -q "$mount_point"
+    return
+  fi
+  mount | awk -v mp="$mount_point" -v pmp="$physical_mount_point" '{for(i=1;i<=NF;i++) if($i=="on" && ($(i+1)==mp || $(i+1)==pmp)) found=1} END{exit !found}'
+}
+
+wait_mount_state() {
+  local expect="$1"
+  local deadline=$(( $(date +%s) + MOUNT_READY_TIMEOUT_S ))
+  while :; do
+    if [ "$expect" = "mounted" ] && is_mounted "$MOUNT_POINT"; then
+      return 0
+    fi
+    if [ "$expect" = "unmounted" ] && ! is_mounted "$MOUNT_POINT"; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep "$MOUNT_READY_INTERVAL_S"
+  done
+}
+
+start_mount() {
+  {
+    echo "=== drive9 concurrency mount start time=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
+    echo "root_remote=$ROOT_REMOTE"
+  } >>"$MOUNT_LOG"
+  drive9 mount "$MOUNT_POINT" >>"$MOUNT_LOG" 2>&1 &
+  MOUNT_PID="$!"
+
+  if wait_mount_state mounted; then
+    return 0
+  fi
+  cat "$MOUNT_LOG" >&2 || true
+  return 1
+}
+
+stop_mount() {
+  set +e
+  if [ -n "${MOUNT_POINT:-}" ] && is_mounted "$MOUNT_POINT"; then
+    drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT" >/dev/null 2>&1 || true
+    wait_mount_state unmounted >/dev/null 2>&1 || true
+  fi
+  if [ -n "${MOUNT_PID:-}" ] && kill -0 "$MOUNT_PID" >/dev/null 2>&1; then
+    kill "$MOUNT_PID" >/dev/null 2>&1 || true
+    wait "$MOUNT_PID" >/dev/null 2>&1 || true
+  fi
+  MOUNT_PID=""
+  set -e
+}
+
+unmount_mount() {
+  if is_mounted "$MOUNT_POINT"; then
+    drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT"
+  fi
+  wait_mount_state unmounted
+  if [ -n "${MOUNT_PID:-}" ]; then
+    set +e
+    wait "$MOUNT_PID" >/dev/null 2>&1
+    MOUNT_PID=""
+    set -e
+  fi
+}
+
+curl_body_code() {
+  local method="$1"
+  local url="$2"
+  local auth="${3:-}"
+
+  local attempt=1
+  while :; do
+    local body_file
+    body_file="$(mktemp)"
+    local code
+    if [ -n "$auth" ]; then
+      code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $auth" "$url")
+    else
+      code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" "$url")
+    fi
+
+    if { [ "$code" != "429" ] && [ "$code" != "403" ]; } || [ "$attempt" -ge "$CLI_MAX_RETRIES" ]; then
+      cat "$body_file"
+      echo
+      echo "__HTTP__${code}"
+      rm -f "$body_file"
+      return
+    fi
+
+    rm -f "$body_file"
+    attempt=$((attempt + 1))
+    sleep "$CLI_RETRY_SLEEP_S"
+  done
+}
+
+http_code() { printf '%s' "$1" | awk -F'__HTTP__' 'NF>1{print $2}' | tr -d '\n'; }
+json_body() { printf '%s' "$1" | sed '/__HTTP__/d'; }
+
+drive9_retry() {
+  local attempt=1
+  local out rc
+  while :; do
+    set +e
+    out=$(drive9 "$@" 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+      printf '%s' "$out"
+      return 0
+    fi
+    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"HTTP 403"* || "$out" == *"403 Forbidden"* ]]; then
+      attempt=$((attempt + 1))
+      sleep "$CLI_RETRY_SLEEP_S"
+      continue
+    fi
+    printf '%s\n' "$out" >&2
+    return "$rc"
+  done
+}
+
+run_fuse_concurrency_workload() {
+  python3 - "$WORK_MOUNT" "$EXPECTED_MANIFEST" "$ACTUAL_MANIFEST" "$READER_ERRORS" "$FUSE_CONCURRENCY_WORKERS" "$FUSE_CONCURRENCY_FILES_PER_WORKER" "$FUSE_CONCURRENCY_READER_WORKERS" "$FUSE_CONCURRENCY_PAYLOAD_KB" "$FUSE_CONCURRENCY_TIMEOUT_S" <<'PY'
+import hashlib
+import json
+import os
+import shutil
+import sys
+import threading
+import time
+import traceback
+
+root = os.path.abspath(sys.argv[1])
+expected_manifest = sys.argv[2]
+actual_manifest = sys.argv[3]
+reader_errors_path = sys.argv[4]
+workers = int(sys.argv[5])
+files_per_worker = int(sys.argv[6])
+reader_workers = int(sys.argv[7])
+payload_kb = int(sys.argv[8])
+timeout_s = float(sys.argv[9])
+
+errors = []
+reader_errors = []
+errors_lock = threading.Lock()
+stop_readers = threading.Event()
+expected = {}
+
+
+def record_error(message):
+    with errors_lock:
+        errors.append(message)
+
+
+def record_reader_error(message):
+    with errors_lock:
+        reader_errors.append(message)
+
+
+def payload(worker, index, kind):
+    header = f"drive9-concurrency kind={kind} worker={worker} index={index}\n".encode()
+    seed = hashlib.sha256(header).digest()
+    body = bytearray()
+    target = payload_kb * 1024
+    counter = 0
+    while len(body) < target:
+        body.extend(hashlib.sha256(seed + counter.to_bytes(8, "big")).digest())
+        counter += 1
+    return header + bytes(body[:target]) + b"\nEND\n"
+
+
+def expected_final_file(worker, index):
+    return f"final/w{worker}/file-{index:03d}.txt"
+
+
+def expected_append_file(worker):
+    return f"append/w{worker}.log"
+
+
+def expected_handle_file(worker):
+    return f"handles/w{worker}.renamed.txt"
+
+
+def expected_renamed_dir_file(worker, index):
+    return f"renamed-dirs/w{worker}/dst-{index:03d}/payload.txt"
+
+
+def add_expected(rel, data):
+    expected[rel] = {
+        "size": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+
+
+def is_transient_path(rel):
+    parts = rel.split(os.sep)
+    if rel == ".go-fuse-epoll-hack" or rel.endswith("/.go-fuse-epoll-hack"):
+        return True
+    if rel.startswith("churn/"):
+        return True
+    return any(part.startswith(".") or ".tmp." in part or part.endswith(".tmp") for part in parts)
+
+
+def fsync_parent(path):
+    parent = os.path.dirname(path)
+    if not parent:
+        return
+    try:
+        fd = os.open(parent, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def atomic_write(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = f"{path}.tmp.{os.getpid()}.{threading.get_ident()}"
+    with open(tmp, "wb") as f:
+        f.write(data)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+    fsync_parent(path)
+
+
+def append_line(path, line):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "ab") as f:
+        f.write(line)
+        f.flush()
+        os.fsync(f.fileno())
+
+
+def writer(worker):
+    try:
+        append_data = bytearray()
+        for index in range(files_per_worker):
+            final_rel = expected_final_file(worker, index)
+            final_path = os.path.join(root, final_rel)
+            data = payload(worker, index, "final")
+            atomic_write(final_path, data)
+            append_line_data = f"worker={worker} index={index} append-ok\n".encode()
+            append_line(os.path.join(root, expected_append_file(worker)), append_line_data)
+            append_data.extend(append_line_data)
+
+            churn_dir = os.path.join(root, "churn", f"w{worker}")
+            os.makedirs(churn_dir, exist_ok=True)
+            churn_tmp = os.path.join(churn_dir, f"delete-{index:03d}.tmp")
+            with open(churn_tmp, "wb") as f:
+                f.write(payload(worker, index, "delete"))
+                f.flush()
+                os.fsync(f.fileno())
+            os.unlink(churn_tmp)
+
+            src_dir = os.path.join(root, "renamed-dirs", f"w{worker}", f"src-{index:03d}")
+            dst_dir = os.path.join(root, "renamed-dirs", f"w{worker}", f"dst-{index:03d}")
+            os.makedirs(src_dir, exist_ok=True)
+            dir_data = payload(worker, index, "renamed-dir")
+            atomic_write(os.path.join(src_dir, "payload.txt"), dir_data)
+            os.replace(src_dir, dst_dir)
+            fsync_parent(dst_dir)
+
+            handle_initial = os.path.join(root, "handles", f"w{worker}.txt")
+            handle_final = os.path.join(root, expected_handle_file(worker))
+            handle_data = payload(worker, index, "handle")
+            atomic_write(handle_initial, handle_data)
+            with open(handle_initial, "rb") as open_handle:
+                os.replace(handle_initial, handle_final)
+                fsync_parent(handle_final)
+                seen = open_handle.read()
+            if seen != handle_data:
+                raise AssertionError(f"open handle content mismatch worker={worker} index={index}")
+    except Exception:
+        record_error(traceback.format_exc())
+
+
+def reader(reader_id):
+    while not stop_readers.is_set():
+        try:
+            for current_root, _, files in os.walk(root):
+                for name in files:
+                    path = os.path.join(current_root, name)
+                    rel = os.path.relpath(path, root)
+                    if is_transient_path(rel):
+                        continue
+                    try:
+                        with open(path, "rb") as f:
+                            data = f.read()
+                    except FileNotFoundError:
+                        continue
+                    except IsADirectoryError:
+                        continue
+                    if rel.startswith("final/"):
+                        parts = rel.split("/")
+                        try:
+                            worker = int(parts[1][1:])
+                            index = int(parts[2].split("-")[1].split(".")[0])
+                        except Exception:
+                            record_reader_error(f"reader={reader_id} unexpected final path {rel}")
+                            continue
+                        want = payload(worker, index, "final")
+                        if data != want:
+                            record_reader_error(f"reader={reader_id} mixed/short final read {rel}: got={len(data)} want={len(want)}")
+        except Exception:
+            record_reader_error(traceback.format_exc())
+        time.sleep(0.01)
+
+
+def build_expected():
+    for worker in range(workers):
+        append_data = bytearray()
+        for index in range(files_per_worker):
+            add_expected(expected_final_file(worker, index), payload(worker, index, "final"))
+            add_expected(expected_renamed_dir_file(worker, index), payload(worker, index, "renamed-dir"))
+            append_data.extend(f"worker={worker} index={index} append-ok\n".encode())
+        add_expected(expected_append_file(worker), bytes(append_data))
+        add_expected(expected_handle_file(worker), payload(worker, files_per_worker - 1, "handle"))
+
+
+def build_actual():
+    actual = {}
+    for current_root, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d != ".go-fuse-epoll-hack"]
+        for name in files:
+            path = os.path.join(current_root, name)
+            rel = os.path.relpath(path, root)
+            if is_transient_path(rel):
+                continue
+            with open(path, "rb") as f:
+                data = f.read()
+            actual[rel] = {
+                "size": len(data),
+                "sha256": hashlib.sha256(data).hexdigest(),
+            }
+    return actual
+
+
+shutil.rmtree(root, ignore_errors=True)
+os.makedirs(root, exist_ok=True)
+build_expected()
+
+reader_threads = [threading.Thread(target=reader, args=(i,), daemon=True) for i in range(reader_workers)]
+writer_threads = [threading.Thread(target=writer, args=(i,), daemon=True) for i in range(workers)]
+
+for thread in reader_threads + writer_threads:
+    thread.start()
+
+deadline = time.monotonic() + timeout_s
+for thread in writer_threads:
+    remaining = deadline - time.monotonic()
+    thread.join(max(0.1, remaining))
+    if thread.is_alive():
+        record_error(f"writer thread timed out: {thread.name}")
+
+stop_readers.set()
+for thread in reader_threads:
+    thread.join(5)
+
+actual = build_actual()
+with open(expected_manifest, "w", encoding="utf-8") as f:
+    json.dump(expected, f, indent=2, sort_keys=True)
+    f.write("\n")
+with open(actual_manifest, "w", encoding="utf-8") as f:
+    json.dump(actual, f, indent=2, sort_keys=True)
+    f.write("\n")
+with open(reader_errors_path, "w", encoding="utf-8") as f:
+    for error in reader_errors:
+        f.write(error)
+        if not error.endswith("\n"):
+            f.write("\n")
+
+missing = sorted(set(expected) - set(actual))
+extra = sorted(set(actual) - set(expected))
+mismatched = sorted(rel for rel in set(expected) & set(actual) if expected[rel] != actual[rel])
+
+if missing:
+    record_error("missing files: " + ", ".join(missing[:20]))
+if extra:
+    record_error("extra files: " + ", ".join(extra[:20]))
+if mismatched:
+    record_error("mismatched files: " + ", ".join(mismatched[:20]))
+if reader_errors:
+    record_error(f"reader observed {len(reader_errors)} inconsistent reads; see {reader_errors_path}")
+
+if errors:
+    for error in errors:
+        sys.stderr.write(error)
+        if not error.endswith("\n"):
+            sys.stderr.write("\n")
+    raise SystemExit(1)
+PY
+}
+
+verify_manifest_dir() {
+  local desc="$1"
+  local root="$2"
+  local actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if python3 - "$root" "$EXPECTED_MANIFEST" "$actual" <<'PY'
+import hashlib
+import json
+import os
+import sys
+root = os.path.abspath(sys.argv[1])
+expected_path = sys.argv[2]
+actual_path = sys.argv[3]
+with open(expected_path, encoding="utf-8") as f:
+    expected = json.load(f)
+actual = {}
+for current_root, dirs, files in os.walk(root):
+    dirs[:] = [d for d in dirs if d != ".go-fuse-epoll-hack"]
+    for name in files:
+        path = os.path.join(current_root, name)
+        rel = os.path.relpath(path, root)
+        if rel == ".go-fuse-epoll-hack" or rel.endswith("/.go-fuse-epoll-hack"):
+            continue
+        with open(path, "rb") as f:
+            data = f.read()
+        actual[rel] = {"size": len(data), "sha256": hashlib.sha256(data).hexdigest()}
+with open(actual_path, "w", encoding="utf-8") as f:
+    json.dump(actual, f, indent=2, sort_keys=True)
+    f.write("\n")
+if actual != expected:
+    print("manifest mismatch", file=sys.stderr)
+    print("missing:", sorted(set(expected) - set(actual))[:20], file=sys.stderr)
+    print("extra:", sorted(set(actual) - set(expected))[:20], file=sys.stderr)
+    mismatched = sorted(rel for rel in set(expected) & set(actual) if expected[rel] != actual[rel])
+    print("mismatched:", mismatched[:20], file=sys.stderr)
+    raise SystemExit(1)
+PY
+  then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== drive9 FUSE concurrency stress ==="
+echo "BASE=$BASE"
+echo "CLI_SOURCE=$CLI_SOURCE"
+echo "FUSE_STRICT_PREREQS=$FUSE_STRICT_PREREQS"
+echo "FUSE_CONCURRENCY_WORKERS=$FUSE_CONCURRENCY_WORKERS"
+echo "FUSE_CONCURRENCY_FILES_PER_WORKER=$FUSE_CONCURRENCY_FILES_PER_WORKER"
+echo "FUSE_CONCURRENCY_READER_WORKERS=$FUSE_CONCURRENCY_READER_WORKERS"
+echo "FUSE_CONCURRENCY_PAYLOAD_KB=$FUSE_CONCURRENCY_PAYLOAD_KB"
+echo "FUSE_CONCURRENCY_TIMEOUT_S=$FUSE_CONCURRENCY_TIMEOUT_S"
+
+check_cmd "jq is available" bash -c 'command -v jq >/dev/null'
+check_cmd "python3 is available" bash -c 'command -v python3 >/dev/null'
+if [ "$CLI_SOURCE" = "build" ]; then
+  check_cmd "go is available" bash -c 'command -v go >/dev/null'
+else
+  check_cmd "curl is available" bash -c 'command -v curl >/dev/null'
+fi
+
+if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
+  skip_or_fail "unsupported OS for this workload"
+fi
+
+if [ "$(uname -s)" = "Linux" ]; then
+  if ! command -v fusermount >/dev/null 2>&1 && ! command -v fusermount3 >/dev/null 2>&1; then
+    skip_or_fail "fusermount/fusermount3 is required for Linux FUSE unmount"
+  fi
+  if [ ! -e /dev/fuse ]; then
+    skip_or_fail "/dev/fuse not available"
+  fi
+fi
+
+if [ "$FUSE_CONCURRENCY_WORKERS" -lt 1 ] || [ "$FUSE_CONCURRENCY_FILES_PER_WORKER" -lt 1 ] || [ "$FUSE_CONCURRENCY_READER_WORKERS" -lt 1 ]; then
+  echo "invalid concurrency settings: workers/files/readers must be >= 1" >&2
+  exit 1
+fi
+
+if [ "$FUSE_CONCURRENCY_PAYLOAD_KB" -lt 1 ]; then
+  echo "invalid FUSE_CONCURRENCY_PAYLOAD_KB: must be >= 1" >&2
+  exit 1
+fi
+
+echo "[1] provision tenant"
+if [ -n "$DRIVE9_API_KEY" ]; then
+  API_KEY="$DRIVE9_API_KEY"
+  check_eq "use provided DRIVE9_API_KEY" "true" "true"
+else
+  resp=$(curl_body_code POST "$BASE/v1/provision")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  check_eq "POST /v1/provision returns 202" "$code" "202"
+  API_KEY=$(printf '%s' "$body" | jq -r '.api_key // empty')
+  check_cmd "provision returns api_key" test -n "$API_KEY"
+fi
+
+echo "[2] wait tenant active"
+deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+state=""
+while :; do
+  sresp=$(curl_body_code GET "$BASE/v1/status" "$API_KEY")
+  scode=$(http_code "$sresp")
+  sbody=$(json_body "$sresp")
+  state=$(printf '%s' "$sbody" | jq -r '.status // empty')
+  echo "status=${scode}:${state}"
+  if [ "$scode" = "200" ] && [ "$state" = "active" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    break
+  fi
+  sleep "$POLL_INTERVAL_S"
+done
+check_eq "tenant becomes active" "$state" "active"
+
+echo "[3] prepare drive9 cli"
+prepare_cli_binary
+check_cmd "drive9 binary ready" test -x "$CLI_BIN"
+
+drive9() {
+  DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$API_KEY" "$CLI_BIN" "$@"
+}
+
+TS="$(date +%s)"
+RUN_ROOT="$(mktemp -d "$FUSE_MOUNT_ROOT/drive9-fuse-concurrency-${TS}.XXXXXX")"
+MOUNT_POINT="$RUN_ROOT/mount"
+MOUNT_LOG="$RUN_ROOT/mount.log"
+REMOTE_SNAPSHOT="$RUN_ROOT/remote-snapshot"
+EXPECTED_MANIFEST="$RUN_ROOT/expected-manifest.json"
+ACTUAL_MANIFEST="$RUN_ROOT/actual-mounted-manifest.json"
+REMOTE_MANIFEST="$RUN_ROOT/actual-remote-manifest.json"
+READER_ERRORS="$RUN_ROOT/reader-errors.log"
+ROOT_REL="fuse-concurrency-${TS}"
+ROOT_REMOTE="/$ROOT_REL"
+WORK_MOUNT="$MOUNT_POINT/$ROOT_REL/work"
+WORK_REMOTE="$ROOT_REMOTE/work"
+MOUNT_PID=""
+
+mkdir -p "$MOUNT_POINT"
+: > "$MOUNT_LOG"
+
+cleanup() {
+  local rc=$?
+  stop_mount
+  if [ -n "${CLI_BIN:-}" ]; then
+    rm -f "$CLI_BIN"
+  fi
+  if [ "$rc" -eq 0 ] && [ "$FAIL" -eq 0 ] && [ "$FUSE_CONCURRENCY_KEEP_ARTIFACTS" != "1" ]; then
+    rm -rf "$RUN_ROOT"
+  else
+    echo "Artifacts preserved at $RUN_ROOT"
+    echo "Mount log: $MOUNT_LOG"
+    echo "Expected manifest: $EXPECTED_MANIFEST"
+    echo "Actual mount manifest: $ACTUAL_MANIFEST"
+    echo "Remote manifest: $REMOTE_MANIFEST"
+    echo "Reader errors: $READER_ERRORS"
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+echo "[4] create remote root"
+drive9_retry fs mkdir "$ROOT_REMOTE" >/dev/null
+check_eq "remote concurrency root" "$ROOT_REMOTE" "$ROOT_REMOTE"
+
+echo "[5] mount writable namespace"
+if start_mount; then
+  check_eq "concurrency mount is mounted" "true" "true"
+else
+  check_eq "concurrency mount is mounted" "false" "true"
+fi
+
+if is_mounted "$MOUNT_POINT"; then
+  echo "[6] run concurrent writers/readers/rename/unlink/open-handle workload"
+  check_cmd "concurrent mounted workload reaches deterministic final manifest" run_fuse_concurrency_workload
+
+  echo "[7] unmount and verify remote persistence"
+  check_cmd "unmount concurrency mount" unmount_mount
+  MOUNT_PID=""
+  mkdir -p "$REMOTE_SNAPSHOT"
+  drive9_retry fs cp ":$WORK_REMOTE" "$REMOTE_SNAPSHOT" >/dev/null
+  if [ -d "$REMOTE_SNAPSHOT/work" ]; then
+    REMOTE_WORK_SNAPSHOT="$REMOTE_SNAPSHOT/work"
+  else
+    REMOTE_WORK_SNAPSHOT="$REMOTE_SNAPSHOT"
+  fi
+  verify_manifest_dir "remote snapshot manifest matches mounted final manifest" "$REMOTE_WORK_SNAPSHOT" "$REMOTE_MANIFEST"
+fi
+
+echo "[8] cleanup remote fixture"
+drive9_retry fs rm -r "$ROOT_REMOTE" >/dev/null || true
+
+echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"
+exit "$FAIL"

--- a/e2e/fuse-concurrency-stress.sh
+++ b/e2e/fuse-concurrency-stress.sh
@@ -26,8 +26,8 @@ FUSE_CONCURRENCY_TIMEOUT_S="${FUSE_CONCURRENCY_TIMEOUT_S:-120}"
 CLI_SOURCE="${CLI_SOURCE:-build}"
 CLI_RELEASE_BASE_URL="${CLI_RELEASE_BASE_URL:-https://drive9.ai/releases}"
 CLI_RELEASE_VERSION="${CLI_RELEASE_VERSION:-}"
-CLI_MAX_RETRIES="${CLI_MAX_RETRIES:-8}"
-CLI_RETRY_SLEEP_S="${CLI_RETRY_SLEEP_S:-2}"
+REQUEST_MAX_RETRIES="${REQUEST_MAX_RETRIES:-8}"
+REQUEST_RETRY_SLEEP_S="${REQUEST_RETRY_SLEEP_S:-2}"
 
 PASS=0
 FAIL=0
@@ -58,6 +58,19 @@ check_cmd() {
     echo "FAIL $desc"
     FAIL=$((FAIL + 1))
   fi
+}
+
+require_cmd() {
+  local name="$1"
+  TOTAL=$((TOTAL + 1))
+  if command -v "$name" >/dev/null 2>&1; then
+    echo "PASS $name is available"
+    PASS=$((PASS + 1))
+    return 0
+  fi
+  echo "FAIL $name is available" >&2
+  FAIL=$((FAIL + 1))
+  exit 1
 }
 
 skip() {
@@ -95,15 +108,20 @@ detect_release_target() {
 
 download_official_cli() {
   local target_version="$CLI_RELEASE_VERSION"
+  local unversioned_url versioned_url download_url
   detect_release_target || return 1
+  unversioned_url="$CLI_RELEASE_BASE_URL/drive9-$CLI_RELEASE_OS-$CLI_RELEASE_ARCH"
   if [ -z "$target_version" ]; then
-    target_version=$(curl -fsSL "$CLI_RELEASE_BASE_URL/version" | tr -d '[:space:]')
+    target_version=$(curl -fsSL "$CLI_RELEASE_BASE_URL/version" 2>/dev/null | tr -d '[:space:]' || true)
   fi
-  if [ -z "$target_version" ]; then
-    echo "failed to resolve release version from $CLI_RELEASE_BASE_URL/version" >&2
-    return 1
+  download_url="$unversioned_url"
+  if [ -n "$target_version" ]; then
+    versioned_url="$CLI_RELEASE_BASE_URL/drive9-$target_version-$CLI_RELEASE_OS-$CLI_RELEASE_ARCH"
+    if curl -fsI "$versioned_url" >/dev/null 2>&1; then
+      download_url="$versioned_url"
+    fi
   fi
-  curl -fsSL "$CLI_RELEASE_BASE_URL/drive9-$CLI_RELEASE_OS-$CLI_RELEASE_ARCH" -o "$CLI_BIN"
+  curl -fsSL "$download_url" -o "$CLI_BIN"
   chmod +x "$CLI_BIN"
   local actual_version
   actual_version="$($CLI_BIN --version 2>/dev/null | awk '{print $2}')"
@@ -207,26 +225,32 @@ curl_body_code() {
 
   local attempt=1
   while :; do
-    local body_file
+    local body_file code rc
     body_file="$(mktemp)"
-    local code
+    set +e
     if [ -n "$auth" ]; then
       code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $auth" "$url")
+      rc=$?
     else
       code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" "$url")
+      rc=$?
+    fi
+    set -e
+    if [ "$rc" -ne 0 ]; then
+      code="000"
     fi
 
-    if { [ "$code" != "429" ] && [ "$code" != "403" ]; } || [ "$attempt" -ge "$CLI_MAX_RETRIES" ]; then
+    if { [ "$rc" -eq 0 ] && [ "$code" != "429" ] && [ "$code" != "403" ]; } || [ "$attempt" -ge "$REQUEST_MAX_RETRIES" ]; then
       cat "$body_file"
       echo
       echo "__HTTP__${code}"
       rm -f "$body_file"
-      return
+      return "$rc"
     fi
 
     rm -f "$body_file"
     attempt=$((attempt + 1))
-    sleep "$CLI_RETRY_SLEEP_S"
+    sleep "$REQUEST_RETRY_SLEEP_S"
   done
 }
 
@@ -245,9 +269,9 @@ drive9_retry() {
       printf '%s' "$out"
       return 0
     fi
-    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"HTTP 403"* || "$out" == *"403 Forbidden"* ]]; then
+    if [ "$attempt" -lt "$REQUEST_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"HTTP 403"* || "$out" == *"403 Forbidden"* ]]; then
       attempt=$((attempt + 1))
-      sleep "$CLI_RETRY_SLEEP_S"
+      sleep "$REQUEST_RETRY_SLEEP_S"
       continue
     fi
     printf '%s\n' "$out" >&2
@@ -586,12 +610,11 @@ echo "FUSE_CONCURRENCY_READER_WORKERS=$FUSE_CONCURRENCY_READER_WORKERS"
 echo "FUSE_CONCURRENCY_PAYLOAD_KB=$FUSE_CONCURRENCY_PAYLOAD_KB"
 echo "FUSE_CONCURRENCY_TIMEOUT_S=$FUSE_CONCURRENCY_TIMEOUT_S"
 
-check_cmd "jq is available" bash -c 'command -v jq >/dev/null'
-check_cmd "python3 is available" bash -c 'command -v python3 >/dev/null'
+require_cmd curl
+require_cmd jq
+require_cmd python3
 if [ "$CLI_SOURCE" = "build" ]; then
-  check_cmd "go is available" bash -c 'command -v go >/dev/null'
-else
-  check_cmd "curl is available" bash -c 'command -v curl >/dev/null'
+  require_cmd go
 fi
 
 if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
@@ -659,6 +682,7 @@ drive9() {
 
 TS="$(date +%s)"
 RUN_ROOT="$(mktemp -d "$FUSE_MOUNT_ROOT/drive9-fuse-concurrency-${TS}.XXXXXX")"
+RUN_ID="$(basename "$RUN_ROOT")"
 MOUNT_POINT="$RUN_ROOT/mount"
 MOUNT_LOG="$RUN_ROOT/mount.log"
 REMOTE_SNAPSHOT="$RUN_ROOT/remote-snapshot"
@@ -666,7 +690,7 @@ EXPECTED_MANIFEST="$RUN_ROOT/expected-manifest.json"
 ACTUAL_MANIFEST="$RUN_ROOT/actual-mounted-manifest.json"
 REMOTE_MANIFEST="$RUN_ROOT/actual-remote-manifest.json"
 READER_ERRORS="$RUN_ROOT/reader-errors.log"
-ROOT_REL="fuse-concurrency-${TS}"
+ROOT_REL="$RUN_ID"
 ROOT_REMOTE="/$ROOT_REL"
 WORK_MOUNT="$MOUNT_POINT/$ROOT_REL/work"
 WORK_REMOTE="$ROOT_REMOTE/work"

--- a/e2e/fuse-correctness-workload.sh
+++ b/e2e/fuse-correctness-workload.sh
@@ -1,0 +1,610 @@
+#!/usr/bin/env bash
+# Deterministic Drive9 FUSE correctness workload.
+#
+# This script builds a remote fixture tree through the CLI, mounts that tree
+# read-only through real FUSE, then verifies ordinary Unix read workloads
+# against a manifest. It intentionally avoids concurrent writes, Git, and
+# cross-mount checks; those are separate workload classes.
+
+set -euo pipefail
+
+BASE="${DRIVE9_BASE:-http://127.0.0.1:9009}"
+DRIVE9_API_KEY="${DRIVE9_API_KEY:-}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-120}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+MOUNT_READY_TIMEOUT_S="${MOUNT_READY_TIMEOUT_S:-20}"
+MOUNT_READY_INTERVAL_S="${MOUNT_READY_INTERVAL_S:-1}"
+FUSE_MOUNT_ROOT="${FUSE_MOUNT_ROOT:-/tmp}"
+FUSE_STRICT_PREREQS="${FUSE_STRICT_PREREQS:-0}"
+FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-60s}"
+FUSE_CORRECTNESS_KEEP_ARTIFACTS="${FUSE_CORRECTNESS_KEEP_ARTIFACTS:-0}"
+FUSE_CORRECTNESS_LARGE_MB="${FUSE_CORRECTNESS_LARGE_MB:-9}"
+CLI_SOURCE="${CLI_SOURCE:-build}"
+CLI_RELEASE_BASE_URL="${CLI_RELEASE_BASE_URL:-https://drive9.ai/releases}"
+CLI_RELEASE_VERSION="${CLI_RELEASE_VERSION:-}"
+CLI_MAX_RETRIES="${CLI_MAX_RETRIES:-8}"
+CLI_RETRY_SLEEP_S="${CLI_RETRY_SLEEP_S:-2}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+check_eq() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL + 1))
+  if [ "$got" = "$want" ]; then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    echo "  want: $want"
+    echo "  got:  $got"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@"; then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+skip() {
+  echo "SKIP $*"
+  exit 0
+}
+
+skip_or_fail() {
+  if [ "$FUSE_STRICT_PREREQS" = "1" ]; then
+    echo "FAIL $*" >&2
+    exit 1
+  fi
+  skip "$@"
+}
+
+detect_release_target() {
+  case "$(uname -s)" in
+    Linux) CLI_RELEASE_OS="linux" ;;
+    Darwin) CLI_RELEASE_OS="darwin" ;;
+    *)
+      echo "unsupported OS for official CLI download: $(uname -s)" >&2
+      return 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64) CLI_RELEASE_ARCH="amd64" ;;
+    aarch64|arm64) CLI_RELEASE_ARCH="arm64" ;;
+    *)
+      echo "unsupported architecture for official CLI download: $(uname -m)" >&2
+      return 1
+      ;;
+  esac
+}
+
+download_official_cli() {
+  local target_version="$CLI_RELEASE_VERSION"
+  detect_release_target || return 1
+  if [ -z "$target_version" ]; then
+    target_version=$(curl -fsSL "$CLI_RELEASE_BASE_URL/version" | tr -d '[:space:]')
+  fi
+  if [ -z "$target_version" ]; then
+    echo "failed to resolve release version from $CLI_RELEASE_BASE_URL/version" >&2
+    return 1
+  fi
+  curl -fsSL "$CLI_RELEASE_BASE_URL/drive9-$CLI_RELEASE_OS-$CLI_RELEASE_ARCH" -o "$CLI_BIN"
+  chmod +x "$CLI_BIN"
+  local actual_version
+  actual_version="$($CLI_BIN --version 2>/dev/null | awk '{print $2}')"
+  if [ -n "$CLI_RELEASE_VERSION" ] && [ "$actual_version" != "$CLI_RELEASE_VERSION" ]; then
+    echo "downloaded version mismatch: expected=$CLI_RELEASE_VERSION actual=$actual_version" >&2
+    return 1
+  fi
+  echo "downloaded official drive9 $actual_version for $CLI_RELEASE_OS/$CLI_RELEASE_ARCH" >&2
+}
+
+prepare_cli_binary() {
+  CLI_BIN="$(mktemp)"
+  case "$CLI_SOURCE" in
+    build)
+      make build-cli CLI_BIN="$CLI_BIN"
+      ;;
+    official)
+      download_official_cli
+      ;;
+    *)
+      echo "invalid CLI_SOURCE: $CLI_SOURCE (expected build|official)" >&2
+      return 1
+      ;;
+  esac
+}
+
+is_mounted() {
+  local mount_point="$1"
+  local physical_mount_point
+  physical_mount_point="$(cd "$(dirname "$mount_point")" 2>/dev/null && pwd -P)/$(basename "$mount_point")"
+  if command -v mountpoint >/dev/null 2>&1; then
+    mountpoint -q "$mount_point"
+    return
+  fi
+  mount | awk -v mp="$mount_point" -v pmp="$physical_mount_point" '{for(i=1;i<=NF;i++) if($i=="on" && ($(i+1)==mp || $(i+1)==pmp)) found=1} END{exit !found}'
+}
+
+wait_mount_state() {
+  local expect="$1"
+  local deadline=$(( $(date +%s) + MOUNT_READY_TIMEOUT_S ))
+  while :; do
+    if [ "$expect" = "mounted" ] && is_mounted "$MOUNT_POINT"; then
+      return 0
+    fi
+    if [ "$expect" = "unmounted" ] && ! is_mounted "$MOUNT_POINT"; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep "$MOUNT_READY_INTERVAL_S"
+  done
+}
+
+start_mount() {
+  {
+    echo "=== drive9 correctness mount start time=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
+    echo "remote_root=$ROOT_REMOTE"
+  } >>"$MOUNT_LOG"
+  drive9 mount --read-only ":$ROOT_REMOTE" "$MOUNT_POINT" >>"$MOUNT_LOG" 2>&1 &
+  MOUNT_PID="$!"
+
+  if wait_mount_state mounted; then
+    return 0
+  fi
+  cat "$MOUNT_LOG" >&2 || true
+  return 1
+}
+
+stop_mount() {
+  set +e
+  if [ -n "${MOUNT_POINT:-}" ] && is_mounted "$MOUNT_POINT"; then
+    drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT" >/dev/null 2>&1 || true
+    wait_mount_state unmounted >/dev/null 2>&1 || true
+  fi
+  if [ -n "${MOUNT_PID:-}" ] && kill -0 "$MOUNT_PID" >/dev/null 2>&1; then
+    kill "$MOUNT_PID" >/dev/null 2>&1 || true
+    wait "$MOUNT_PID" >/dev/null 2>&1 || true
+  fi
+  MOUNT_PID=""
+  set -e
+}
+
+curl_body_code() {
+  local method="$1"
+  local url="$2"
+  local auth="${3:-}"
+  local body_file code
+  body_file="$(mktemp)"
+  if [ -n "$auth" ]; then
+    code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $auth" "$url")
+  else
+    code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" "$url")
+  fi
+  cat "$body_file"
+  echo
+  echo "__HTTP__${code}"
+  rm -f "$body_file"
+}
+
+http_code() { printf '%s' "$1" | awk -F'__HTTP__' 'NF>1{print $2}' | tr -d '\n'; }
+json_body() { printf '%s' "$1" | sed '/__HTTP__/d'; }
+
+sha256_file() {
+  local file_path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file_path" | cut -d' ' -f1
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file_path" | cut -d' ' -f1
+    return
+  fi
+  python3 - "$file_path" <<'PY'
+import hashlib
+import sys
+h = hashlib.sha256()
+with open(sys.argv[1], "rb") as f:
+    for chunk in iter(lambda: f.read(1024 * 1024), b""):
+        h.update(chunk)
+print(h.hexdigest())
+PY
+}
+
+stat_size() {
+  local file_path="$1"
+  case "$(uname -s)" in
+    Darwin) stat -f %z "$file_path" ;;
+    *) stat -c %s "$file_path" ;;
+  esac
+}
+
+stat_nlink() {
+  local file_path="$1"
+  case "$(uname -s)" in
+    Darwin) stat -f %l "$file_path" ;;
+    *) stat -c %h "$file_path" ;;
+  esac
+}
+
+relative_sorted_find() {
+  local root="$1"
+  local type_flag="$2"
+  find "$root" -type "$type_flag" -print | python3 - "$root" <<'PY'
+import os
+import sys
+root = os.path.abspath(sys.argv[1])
+items = []
+for line in sys.stdin:
+    path = os.path.abspath(line.rstrip("\n"))
+    rel = os.path.relpath(path, root)
+    if rel == ".":
+        rel = "."
+    if rel == ".go-fuse-epoll-hack" or rel.endswith("/.go-fuse-epoll-hack"):
+        continue
+    items.append(rel)
+for item in sorted(items):
+    print(item)
+PY
+}
+
+grep_relative_matches() {
+  local pattern="$1"
+  shift
+  { grep -R -l -- "$pattern" "$@" || true; } | python3 - "$MOUNT_POINT" <<'PY'
+import os
+import sys
+root = os.path.abspath(sys.argv[1])
+items = []
+for line in sys.stdin:
+    path = os.path.abspath(line.rstrip("\n"))
+    items.append(os.path.relpath(path, root))
+for item in sorted(items):
+    print(item)
+PY
+}
+
+create_fixture_tree() {
+  mkdir -p "$FIXTURE_DIR/text" "$FIXTURE_DIR/nested/deep" "$FIXTURE_DIR/binary" "$FIXTURE_DIR/large" "$FIXTURE_DIR/links"
+
+  : > "$FIXTURE_DIR/empty.txt"
+  cat > "$FIXTURE_DIR/text/alpha.txt" <<EOF
+alpha line
+DRIVE9_NEEDLE_ALPHA common-read-correctness
+unicode 你好 café
+EOF
+  cat > "$FIXTURE_DIR/text/space name.txt" <<EOF
+space path line
+DRIVE9_NEEDLE_SPACE common-read-correctness
+EOF
+  cat > "$FIXTURE_DIR/text/中文-文件.txt" <<EOF
+中文路径
+DRIVE9_NEEDLE_UNICODE
+EOF
+  cat > "$FIXTURE_DIR/nested/deep/story.md" <<EOF
+# Story
+
+This nested file carries DRIVE9_NEEDLE_NESTED and common-read-correctness.
+EOF
+  python3 - "$FIXTURE_DIR/binary/small.bin" "$FIXTURE_DIR/large/large-${FUSE_CORRECTNESS_LARGE_MB}mb.bin" "$FUSE_CORRECTNESS_LARGE_MB" <<'PY'
+import pathlib
+import sys
+small = pathlib.Path(sys.argv[1])
+large = pathlib.Path(sys.argv[2])
+large_mb = int(sys.argv[3])
+small.write_bytes(bytes(range(256)) * 17 + b"\x00drive9-binary-tail\xff")
+chunk = bytearray((i * 31 + 7) % 256 for i in range(1024 * 1024))
+with large.open("wb") as f:
+    for i in range(large_mb):
+        chunk[0] = i % 256
+        f.write(chunk)
+    f.write(b"drive9-large-tail")
+PY
+}
+
+write_expected_manifests() {
+  cat > "$EXPECTED_FILES" <<EOF
+binary/small.bin
+empty.txt
+large/large-${FUSE_CORRECTNESS_LARGE_MB}mb.bin
+links/alpha-hardlink.txt
+nested/deep/story.md
+text/alpha.txt
+text/space name.txt
+text/中文-文件.txt
+EOF
+  cat > "$EXPECTED_DIRS" <<'EOF'
+.
+binary
+empty-dir
+large
+links
+nested
+nested/deep
+text
+EOF
+  cat > "$EXPECTED_LINKS" <<'EOF'
+links/alpha-link
+EOF
+}
+
+upload_fixture_tree() {
+  for dir in "" "text" "nested" "nested/deep" "binary" "large" "links" "empty-dir"; do
+    drive9_retry fs mkdir "$ROOT_REMOTE${dir:+/$dir}" >/dev/null
+  done
+
+  while IFS= read -r rel; do
+    case "$rel" in
+      links/alpha-hardlink.txt)
+        continue
+        ;;
+    esac
+    drive9_retry fs cp "$FIXTURE_DIR/$rel" ":$ROOT_REMOTE/$rel" >/dev/null
+  done < "$EXPECTED_FILES"
+
+  drive9_retry fs symlink "../text/alpha.txt" ":$ROOT_REMOTE/links/alpha-link" >/dev/null
+  drive9_retry fs hardlink "$ROOT_REMOTE/text/alpha.txt" "$ROOT_REMOTE/links/alpha-hardlink.txt" >/dev/null
+}
+
+assert_manifest_files() {
+  local actual_files actual_dirs actual_links
+  actual_files="$RUN_ROOT/actual-files.txt"
+  actual_dirs="$RUN_ROOT/actual-dirs.txt"
+  actual_links="$RUN_ROOT/actual-links.txt"
+
+  relative_sorted_find "$MOUNT_POINT" f > "$actual_files"
+  relative_sorted_find "$MOUNT_POINT" d > "$actual_dirs"
+  relative_sorted_find "$MOUNT_POINT" l > "$actual_links"
+
+  check_cmd "find -type f matches manifest" diff -u "$EXPECTED_FILES" "$actual_files"
+  check_cmd "find -type d matches manifest" diff -u "$EXPECTED_DIRS" "$actual_dirs"
+  check_cmd "find -type l matches manifest" diff -u "$EXPECTED_LINKS" "$actual_links"
+}
+
+assert_cat_stat_checksum() {
+  local rel expected_path mounted_path expected_hash mounted_hash expected_size mounted_size
+  while IFS= read -r rel; do
+    mounted_path="$MOUNT_POINT/$rel"
+    if [ "$rel" = "links/alpha-hardlink.txt" ]; then
+      expected_path="$FIXTURE_DIR/text/alpha.txt"
+    else
+      expected_path="$FIXTURE_DIR/$rel"
+    fi
+    expected_hash="$(sha256_file "$expected_path")"
+    mounted_hash="$(cat "$mounted_path" | sha256_file /dev/stdin)"
+    check_eq "cat+sha256 $rel" "$mounted_hash" "$expected_hash"
+
+    expected_size="$(stat_size "$expected_path")"
+    mounted_size="$(stat_size "$mounted_path")"
+    check_eq "stat size $rel" "$mounted_size" "$expected_size"
+  done < "$EXPECTED_FILES"
+
+  local source_nlink hardlink_nlink source_hash hardlink_hash
+  source_nlink="$(stat_nlink "$MOUNT_POINT/text/alpha.txt")"
+  hardlink_nlink="$(stat_nlink "$MOUNT_POINT/links/alpha-hardlink.txt")"
+  check_eq "stat nlink source hardlink" "$source_nlink" "2"
+  check_eq "stat nlink hardlink" "$hardlink_nlink" "2"
+  source_hash="$(sha256_file "$MOUNT_POINT/text/alpha.txt")"
+  hardlink_hash="$(sha256_file "$MOUNT_POINT/links/alpha-hardlink.txt")"
+  check_eq "hardlink checksum matches source" "$hardlink_hash" "$source_hash"
+
+  local link_target link_hash
+  link_target="$(readlink "$MOUNT_POINT/links/alpha-link")"
+  check_eq "readlink symlink target" "$link_target" "../text/alpha.txt"
+  link_hash="$(sha256_file "$MOUNT_POINT/links/alpha-link")"
+  check_eq "symlink target checksum matches source" "$link_hash" "$source_hash"
+}
+
+assert_grep_workload() {
+  local actual expected
+  actual="$RUN_ROOT/grep-common.txt"
+  expected="$RUN_ROOT/grep-common-expected.txt"
+  grep_relative_matches "common-read-correctness" \
+    "$MOUNT_POINT/text" "$MOUNT_POINT/nested" "$MOUNT_POINT/links/alpha-hardlink.txt" > "$actual"
+  cat > "$expected" <<'EOF'
+links/alpha-hardlink.txt
+nested/deep/story.md
+text/alpha.txt
+text/space name.txt
+EOF
+  check_cmd "grep common marker matches expected files" diff -u "$expected" "$actual"
+
+  actual="$RUN_ROOT/grep-space.txt"
+  expected="$RUN_ROOT/grep-space-expected.txt"
+  grep_relative_matches "DRIVE9_NEEDLE_SPACE" "$MOUNT_POINT/text" > "$actual"
+  cat > "$expected" <<'EOF'
+text/space name.txt
+EOF
+  check_cmd "grep handles filename with spaces" diff -u "$expected" "$actual"
+
+  actual="$RUN_ROOT/grep-unicode.txt"
+  expected="$RUN_ROOT/grep-unicode-expected.txt"
+  grep_relative_matches "DRIVE9_NEEDLE_UNICODE" "$MOUNT_POINT/text" > "$actual"
+  cat > "$expected" <<'EOF'
+text/中文-文件.txt
+EOF
+  check_cmd "grep handles unicode filename" diff -u "$expected" "$actual"
+
+  check_cmd "grep through symlink follows target content" grep -q "DRIVE9_NEEDLE_ALPHA" "$MOUNT_POINT/links/alpha-link"
+  check_cmd "grep no-match exits non-zero" bash -c 'if grep -R -q -- "DRIVE9_NEEDLE_ABSENT" "$1"; then exit 1; fi' _ "$MOUNT_POINT"
+}
+
+drive9_retry() {
+  local attempt=1
+  local out rc
+  while :; do
+    set +e
+    out=$(drive9 "$@" 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+      printf '%s' "$out"
+      return 0
+    fi
+    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"HTTP 403"* || "$out" == *"403 Forbidden"* ]]; then
+      attempt=$((attempt + 1))
+      sleep "$CLI_RETRY_SLEEP_S"
+      continue
+    fi
+    printf '%s\n' "$out" >&2
+    return "$rc"
+  done
+}
+
+echo "=== drive9 FUSE correctness workload ==="
+echo "BASE=$BASE"
+echo "CLI_SOURCE=$CLI_SOURCE"
+echo "FUSE_STRICT_PREREQS=$FUSE_STRICT_PREREQS"
+echo "FUSE_CORRECTNESS_LARGE_MB=$FUSE_CORRECTNESS_LARGE_MB"
+
+check_cmd "jq is available" bash -c 'command -v jq >/dev/null'
+check_cmd "python3 is available" bash -c 'command -v python3 >/dev/null'
+check_cmd "grep is available" bash -c 'command -v grep >/dev/null'
+check_cmd "find is available" bash -c 'command -v find >/dev/null'
+check_cmd "stat is available" bash -c 'command -v stat >/dev/null'
+check_cmd "readlink is available" bash -c 'command -v readlink >/dev/null'
+if [ "$CLI_SOURCE" = "build" ]; then
+  check_cmd "go is available" bash -c 'command -v go >/dev/null'
+else
+  check_cmd "curl is available" bash -c 'command -v curl >/dev/null'
+fi
+
+if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
+  skip_or_fail "unsupported OS for this workload"
+fi
+
+if [ "$(uname -s)" = "Linux" ]; then
+  if ! command -v fusermount >/dev/null 2>&1 && ! command -v fusermount3 >/dev/null 2>&1; then
+    skip_or_fail "fusermount/fusermount3 is required for Linux FUSE unmount"
+  fi
+  if [ ! -e /dev/fuse ]; then
+    skip_or_fail "/dev/fuse not available"
+  fi
+fi
+
+echo "[1] provision tenant"
+if [ -n "$DRIVE9_API_KEY" ]; then
+  API_KEY="$DRIVE9_API_KEY"
+  check_eq "use provided DRIVE9_API_KEY" "true" "true"
+else
+  resp=$(curl_body_code POST "$BASE/v1/provision")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  check_eq "POST /v1/provision returns 202" "$code" "202"
+  API_KEY=$(printf '%s' "$body" | jq -r '.api_key // empty')
+  check_cmd "provision returns api_key" test -n "$API_KEY"
+fi
+
+echo "[2] wait tenant active"
+deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+state=""
+while :; do
+  sresp=$(curl_body_code GET "$BASE/v1/status" "$API_KEY")
+  scode=$(http_code "$sresp")
+  sbody=$(json_body "$sresp")
+  state=$(printf '%s' "$sbody" | jq -r '.status // empty')
+  echo "status=${scode}:${state}"
+  if [ "$scode" = "200" ] && [ "$state" = "active" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    break
+  fi
+  sleep "$POLL_INTERVAL_S"
+done
+check_eq "tenant becomes active" "$state" "active"
+
+echo "[3] prepare drive9 cli"
+prepare_cli_binary
+check_cmd "drive9 binary ready" test -x "$CLI_BIN"
+
+drive9() {
+  DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$API_KEY" "$CLI_BIN" "$@"
+}
+
+TS="$(date +%s)"
+RUN_ROOT="$(mktemp -d "$FUSE_MOUNT_ROOT/drive9-fuse-correctness-${TS}.XXXXXX")"
+FIXTURE_DIR="$RUN_ROOT/fixture"
+MOUNT_POINT="$RUN_ROOT/mount"
+MOUNT_LOG="$RUN_ROOT/mount.log"
+EXPECTED_FILES="$RUN_ROOT/expected-files.txt"
+EXPECTED_DIRS="$RUN_ROOT/expected-dirs.txt"
+EXPECTED_LINKS="$RUN_ROOT/expected-links.txt"
+ROOT_REMOTE="/fuse-correctness-${TS}"
+MOUNT_PID=""
+
+mkdir -p "$FIXTURE_DIR" "$MOUNT_POINT"
+: > "$MOUNT_LOG"
+
+cleanup() {
+  local rc=$?
+  stop_mount
+  if [ -n "${CLI_BIN:-}" ]; then
+    rm -f "$CLI_BIN"
+  fi
+  if [ "$rc" -eq 0 ] && [ "$FAIL" -eq 0 ] && [ "$FUSE_CORRECTNESS_KEEP_ARTIFACTS" != "1" ]; then
+    rm -rf "$RUN_ROOT"
+  else
+    echo "Artifacts preserved at $RUN_ROOT"
+    echo "Mount log: $MOUNT_LOG"
+    echo "Fixture root: $FIXTURE_DIR"
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+echo "[4] create fixture manifest"
+create_fixture_tree
+write_expected_manifests
+check_cmd "fixture file manifest generated" test -s "$EXPECTED_FILES"
+check_cmd "fixture dir manifest generated" test -s "$EXPECTED_DIRS"
+check_cmd "fixture symlink manifest generated" test -s "$EXPECTED_LINKS"
+
+echo "[5] upload fixture through CLI"
+upload_fixture_tree
+check_eq "remote fixture root" "$ROOT_REMOTE" "$ROOT_REMOTE"
+
+echo "[6] mount fixture read-only"
+if start_mount; then
+  check_eq "fixture mount is mounted" "true" "true"
+else
+  check_eq "fixture mount is mounted" "false" "true"
+fi
+
+if is_mounted "$MOUNT_POINT"; then
+  echo "[7] find manifest parity"
+  assert_manifest_files
+
+  echo "[8] cat/stat/checksum parity"
+  assert_cat_stat_checksum
+
+  echo "[9] grep workload"
+  assert_grep_workload
+
+  echo "[10] read-only guardrail"
+  check_cmd "read-only mount rejects writes" bash -c 'if printf x > "$1/should-not-write.txt" 2>/dev/null; then exit 1; fi' _ "$MOUNT_POINT"
+fi
+
+echo "[11] cleanup remote fixture"
+if is_mounted "$MOUNT_POINT"; then
+  check_cmd "unmount correctness mount" drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT"
+  wait_mount_state unmounted || true
+  MOUNT_PID=""
+fi
+drive9_retry fs rm -r "$ROOT_REMOTE" >/dev/null || true
+
+echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"
+exit "$FAIL"

--- a/e2e/fuse-correctness-workload.sh
+++ b/e2e/fuse-correctness-workload.sh
@@ -22,8 +22,8 @@ FUSE_CORRECTNESS_LARGE_MB="${FUSE_CORRECTNESS_LARGE_MB:-9}"
 CLI_SOURCE="${CLI_SOURCE:-build}"
 CLI_RELEASE_BASE_URL="${CLI_RELEASE_BASE_URL:-https://drive9.ai/releases}"
 CLI_RELEASE_VERSION="${CLI_RELEASE_VERSION:-}"
-CLI_MAX_RETRIES="${CLI_MAX_RETRIES:-8}"
-CLI_RETRY_SLEEP_S="${CLI_RETRY_SLEEP_S:-2}"
+REQUEST_MAX_RETRIES="${REQUEST_MAX_RETRIES:-8}"
+REQUEST_RETRY_SLEEP_S="${REQUEST_RETRY_SLEEP_S:-2}"
 
 PASS=0
 FAIL=0
@@ -54,6 +54,19 @@ check_cmd() {
     echo "FAIL $desc"
     FAIL=$((FAIL + 1))
   fi
+}
+
+require_cmd() {
+  local name="$1"
+  TOTAL=$((TOTAL + 1))
+  if command -v "$name" >/dev/null 2>&1; then
+    echo "PASS $name is available"
+    PASS=$((PASS + 1))
+    return 0
+  fi
+  echo "FAIL $name is available" >&2
+  FAIL=$((FAIL + 1))
+  exit 1
 }
 
 skip() {
@@ -91,15 +104,20 @@ detect_release_target() {
 
 download_official_cli() {
   local target_version="$CLI_RELEASE_VERSION"
+  local unversioned_url versioned_url download_url
   detect_release_target || return 1
+  unversioned_url="$CLI_RELEASE_BASE_URL/drive9-$CLI_RELEASE_OS-$CLI_RELEASE_ARCH"
   if [ -z "$target_version" ]; then
-    target_version=$(curl -fsSL "$CLI_RELEASE_BASE_URL/version" | tr -d '[:space:]')
+    target_version=$(curl -fsSL "$CLI_RELEASE_BASE_URL/version" 2>/dev/null | tr -d '[:space:]' || true)
   fi
-  if [ -z "$target_version" ]; then
-    echo "failed to resolve release version from $CLI_RELEASE_BASE_URL/version" >&2
-    return 1
+  download_url="$unversioned_url"
+  if [ -n "$target_version" ]; then
+    versioned_url="$CLI_RELEASE_BASE_URL/drive9-$target_version-$CLI_RELEASE_OS-$CLI_RELEASE_ARCH"
+    if curl -fsI "$versioned_url" >/dev/null 2>&1; then
+      download_url="$versioned_url"
+    fi
   fi
-  curl -fsSL "$CLI_RELEASE_BASE_URL/drive9-$CLI_RELEASE_OS-$CLI_RELEASE_ARCH" -o "$CLI_BIN"
+  curl -fsSL "$download_url" -o "$CLI_BIN"
   chmod +x "$CLI_BIN"
   local actual_version
   actual_version="$($CLI_BIN --version 2>/dev/null | awk '{print $2}')"
@@ -187,17 +205,36 @@ curl_body_code() {
   local method="$1"
   local url="$2"
   local auth="${3:-}"
-  local body_file code
-  body_file="$(mktemp)"
-  if [ -n "$auth" ]; then
-    code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $auth" "$url")
-  else
-    code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" "$url")
-  fi
-  cat "$body_file"
-  echo
-  echo "__HTTP__${code}"
-  rm -f "$body_file"
+
+  local attempt=1
+  while :; do
+    local body_file code rc
+    body_file="$(mktemp)"
+    set +e
+    if [ -n "$auth" ]; then
+      code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $auth" "$url")
+      rc=$?
+    else
+      code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" "$url")
+      rc=$?
+    fi
+    set -e
+    if [ "$rc" -ne 0 ]; then
+      code="000"
+    fi
+
+    if { [ "$rc" -eq 0 ] && [ "$code" != "429" ] && [ "$code" != "403" ]; } || [ "$attempt" -ge "$REQUEST_MAX_RETRIES" ]; then
+      cat "$body_file"
+      echo
+      echo "__HTTP__${code}"
+      rm -f "$body_file"
+      return "$rc"
+    fi
+
+    rm -f "$body_file"
+    attempt=$((attempt + 1))
+    sleep "$REQUEST_RETRY_SLEEP_S"
+  done
 }
 
 http_code() { printf '%s' "$1" | awk -F'__HTTP__' 'NF>1{print $2}' | tr -d '\n'; }
@@ -454,9 +491,9 @@ drive9_retry() {
       printf '%s' "$out"
       return 0
     fi
-    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"HTTP 403"* || "$out" == *"403 Forbidden"* ]]; then
+    if [ "$attempt" -lt "$REQUEST_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"HTTP 403"* || "$out" == *"403 Forbidden"* ]]; then
       attempt=$((attempt + 1))
-      sleep "$CLI_RETRY_SLEEP_S"
+      sleep "$REQUEST_RETRY_SLEEP_S"
       continue
     fi
     printf '%s\n' "$out" >&2
@@ -470,16 +507,15 @@ echo "CLI_SOURCE=$CLI_SOURCE"
 echo "FUSE_STRICT_PREREQS=$FUSE_STRICT_PREREQS"
 echo "FUSE_CORRECTNESS_LARGE_MB=$FUSE_CORRECTNESS_LARGE_MB"
 
-check_cmd "jq is available" bash -c 'command -v jq >/dev/null'
-check_cmd "python3 is available" bash -c 'command -v python3 >/dev/null'
-check_cmd "grep is available" bash -c 'command -v grep >/dev/null'
-check_cmd "find is available" bash -c 'command -v find >/dev/null'
-check_cmd "stat is available" bash -c 'command -v stat >/dev/null'
-check_cmd "readlink is available" bash -c 'command -v readlink >/dev/null'
+require_cmd curl
+require_cmd jq
+require_cmd python3
+require_cmd grep
+require_cmd find
+require_cmd stat
+require_cmd readlink
 if [ "$CLI_SOURCE" = "build" ]; then
-  check_cmd "go is available" bash -c 'command -v go >/dev/null'
-else
-  check_cmd "curl is available" bash -c 'command -v curl >/dev/null'
+  require_cmd go
 fi
 
 if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then

--- a/e2e/fuse-correctness-workload.sh
+++ b/e2e/fuse-correctness-workload.sh
@@ -243,7 +243,7 @@ stat_nlink() {
 relative_sorted_find() {
   local root="$1"
   local type_flag="$2"
-  find "$root" -type "$type_flag" -print | python3 - "$root" <<'PY'
+  find "$root" -type "$type_flag" -print | python3 -c '
 import os
 import sys
 root = os.path.abspath(sys.argv[1])
@@ -258,13 +258,13 @@ for line in sys.stdin:
     items.append(rel)
 for item in sorted(items):
     print(item)
-PY
+' "$root"
 }
 
 grep_relative_matches() {
   local pattern="$1"
   shift
-  { grep -R -l -- "$pattern" "$@" || true; } | python3 - "$MOUNT_POINT" <<'PY'
+  { grep -R -l -- "$pattern" "$@" || true; } | python3 -c '
 import os
 import sys
 root = os.path.abspath(sys.argv[1])
@@ -274,7 +274,7 @@ for line in sys.stdin:
     items.append(os.path.relpath(path, root))
 for item in sorted(items):
     print(item)
-PY
+' "$MOUNT_POINT"
 }
 
 create_fixture_tree() {

--- a/e2e/fuse-release-gate.sh
+++ b/e2e/fuse-release-gate.sh
@@ -10,9 +10,13 @@ export FUSE_STRICT_PREREQS="${FUSE_STRICT_PREREQS:-1}"
 export RUN_FUSE_GIT_CLONE="${RUN_FUSE_GIT_CLONE:-1}"
 export RUN_FUSE_UMOUNT_DURABLE="${RUN_FUSE_UMOUNT_DURABLE:-1}"
 export RUN_FUSE_LOG_AUDIT="${RUN_FUSE_LOG_AUDIT:-1}"
+export RUN_FUSE_CONCURRENCY_STRESS="${RUN_FUSE_CONCURRENCY_STRESS:-0}"
 export FUSE_GIT_CLONE_URL="${FUSE_GIT_CLONE_URL:-https://github.com/octocat/Hello-World.git}"
 export FUSE_GIT_CLONE_TIMEOUT_S="${FUSE_GIT_CLONE_TIMEOUT_S:-180}"
 export FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-60s}"
 
 bash "$SCRIPT_DIR/fuse-smoke-test.sh"
 bash "$SCRIPT_DIR/fuse-correctness-workload.sh"
+if [ "$RUN_FUSE_CONCURRENCY_STRESS" = "1" ]; then
+  bash "$SCRIPT_DIR/fuse-concurrency-stress.sh"
+fi

--- a/e2e/fuse-release-gate.sh
+++ b/e2e/fuse-release-gate.sh
@@ -14,4 +14,5 @@ export FUSE_GIT_CLONE_URL="${FUSE_GIT_CLONE_URL:-https://github.com/octocat/Hell
 export FUSE_GIT_CLONE_TIMEOUT_S="${FUSE_GIT_CLONE_TIMEOUT_S:-180}"
 export FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-60s}"
 
-exec bash "$SCRIPT_DIR/fuse-smoke-test.sh"
+bash "$SCRIPT_DIR/fuse-smoke-test.sh"
+bash "$SCRIPT_DIR/fuse-correctness-workload.sh"


### PR DESCRIPTION
## Summary

Adds a deterministic real-mount FUSE read correctness workload for task #5.

The new `e2e/fuse-correctness-workload.sh`:
- creates a remote fixture tree through the Drive9 CLI;
- includes empty files, text files, binary files, an 8MiB+ file, multi-level directories, filenames with spaces, unicode filenames, a symlink, and a hardlink;
- mounts the fixture subtree read-only through real FUSE;
- verifies `find -type f/d/l` against manifest files;
- verifies `cat` + SHA-256 and `stat` size parity for every manifest file;
- verifies hardlink `nlink` and checksum parity;
- verifies symlink `readlink` and target checksum parity;
- verifies `grep` over normal, space-containing, unicode, nested, hardlink, and symlink paths;
- preserves run root, fixture root, and mount log on failure.

Also wires the workload into `e2e/fuse-release-gate.sh` and documents the new script in `e2e/README.md` and `e2e/AGENTS.md`.

## Validation

Local static/build validation:

```bash
bash -n e2e/fuse-correctness-workload.sh e2e/fuse-release-gate.sh
git diff --check --cached
PATH=/usr/local/go/bin:$PATH make build-cli CLI_BIN=/tmp/drive9-fuse-correctness-cli
```

Not run locally: real FUSE workload execution, because it requires a live Drive9 endpoint plus host FUSE support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a FUSE read-correctness workload that validates directory/tree structure, file contents/hashes, hardlink/symlink semantics, grep coverage, and enforces read-only behavior; preserves artifacts on failure.
  * Added an optional FUSE concurrency stress workload exercising concurrent writers/readers with final-manifest verification and preserved logs; enabled via a new env flag.

* **Documentation**
  * Expanded E2E docs and run flows to include both workloads, host prerequisites, verification criteria, and new tuning knobs for large files, concurrency, retries, and artifact retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->