### PR TITLE
test: cover FUSE tier transitions and object GC

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -204,7 +204,7 @@ script is not a supported Windows validation path.
 7. Rename semantics (file + directory rename consistency)
 8. Attribute semantics (`size`, `mtime` monotonicity, remote stat parity)
 9. Cross-channel consistency (CLI write visible in mount; mount write visible via CLI)
-10. Mounted large file boundary check (8MB write + remote checksum parity)
+10. Mounted large file boundary check (8MB write + remote checksum parity) and tier-transition parity (10KiB → 8MiB → 10KiB size/checksum/remount)
 11. Read-only mount behavior (`--read-only` blocks writes/deletes, allows reads)
 12. Error semantics (missing path reads/deletes and duplicate mkdir failures)
 13. Linux prerequisite guardrails (`fusermount`, `/dev/fuse`) with skip behavior when unavailable

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,7 +16,7 @@ including local single-tenant validation via `drive9-server-local`.
 | `api-smoke-test.sh` | Fresh provisioning, status polling, nested+batch file ops, hardlink/copy/rename/delete checks, grep/find checks, semantic text recall, image-associated recall, sql checks, large multipart upload+download |
 | `api-smoke-test-existing-key.sh` | Existing API key status/list checks |
 | `cli-smoke-test.sh` | End-to-end CLI workflow including `fs symlink`, `fs hardlink`, `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
-| `fuse-smoke-test.sh` | FUSE mount lifecycle, file/dir/symlink/hardlink/rename/stat semantics, cross-channel consistency, read-only and error-path checks |
+| `fuse-smoke-test.sh` | FUSE mount lifecycle, file/dir/symlink/hardlink/rename/stat semantics, cross-channel consistency, mounted 10KiB→8MiB→10KiB tier-transition parity, read-only and error-path checks |
 | `fuse-correctness-workload.sh` | Real read-only FUSE workload over a manifest fixture: `find`, `grep`, `stat`, `cat`, `sha256`, symlink, hardlink, unicode/space paths, empty files, binary files, and 8MiB+ files |
 | `fuse-concurrency-stress.sh` | Real writable FUSE concurrency workload with parallel writers/readers, atomic rename, unlink churn, open-handle rename reads, and deterministic final manifest checks |
 | `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, mount-log audit, and manifest-based FUSE correctness workload; set `RUN_FUSE_CONCURRENCY_STRESS=1` to add bounded concurrency stress |

--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -309,6 +309,30 @@ print(h.hexdigest())
 PY
 }
 
+write_pattern_file() {
+  local file_path="$1"
+  local size="$2"
+  local seed="$3"
+  python3 - "$file_path" "$size" "$seed" <<'PY'
+import sys
+
+path = sys.argv[1]
+size = int(sys.argv[2])
+seed = int(sys.argv[3])
+chunk = bytearray(1024 * 1024)
+remaining = size
+offset = 0
+with open(path, "wb") as handle:
+    while remaining > 0:
+        n = min(len(chunk), remaining)
+        for idx in range(n):
+            chunk[idx] = (offset + idx * 31 + seed) % 251
+        handle.write(chunk[:n])
+        offset += n
+        remaining -= n
+PY
+}
+
 wait_mount_state() {
   local expect="$1"
   local deadline=$(( $(date +%s) + MOUNT_READY_TIMEOUT_S ))
@@ -631,6 +655,7 @@ MOUNT_POINT="$ROOT_MOUNT"
 MOUNT_LOG="$FUSE_MOUNT_ROOT/drive9-fuse-smoke-${TS}.log"
 SEED_LOCAL="$FUSE_MOUNT_ROOT/drive9-fuse-seed-${TS}.txt"
 LARGE_DOWNLOADED="$FUSE_MOUNT_ROOT/drive9-fuse-large-down-${TS}.bin"
+TIER_DOWNLOADED="$FUSE_MOUNT_ROOT/drive9-fuse-tier-down-${TS}.bin"
 
 set +e
 ls_out=$(drive9 fs ls / 2>&1)
@@ -674,6 +699,9 @@ MOUNT_TO_CLI_MOUNT="$MOUNT_POINT/$MOUNT_TO_CLI_REL"
 LARGE_REL="${RW_ALPHA_RENAMED_REL}/large-8m.bin"
 LARGE_REMOTE="/${LARGE_REL}"
 LARGE_MOUNT="$MOUNT_POINT/$LARGE_REL"
+TIER_REL="${RW_ALPHA_RENAMED_REL}/tier-transition.bin"
+TIER_REMOTE="/${TIER_REL}"
+TIER_MOUNT="$MOUNT_POINT/$TIER_REL"
 GIT_PROBE_REL="${ROOT_REL}/git-config-probe"
 GIT_PROBE_MOUNT="$MOUNT_POINT/$GIT_PROBE_REL"
 GIT_PROBE_ORIGIN="https://github.com/mem9-ai/drive9.git"
@@ -694,7 +722,7 @@ printf "seed-%s" "$TS" > "$SEED_LOCAL"
 MOUNT_PID=""
 cleanup() {
   stop_mount
-  rm -f "$SEED_LOCAL" "$LARGE_DOWNLOADED" "$CLI_BIN"
+  rm -f "$SEED_LOCAL" "$LARGE_DOWNLOADED" "$TIER_DOWNLOADED" "$CLI_BIN"
   rm -rf "${MOUNT_POINT:?}" || true
 }
 on_exit() {
@@ -977,6 +1005,64 @@ PY
     large_src_hash=$(sha256_file "$LARGE_MOUNT")
     large_dst_hash=$(sha256_file "$LARGE_DOWNLOADED")
     check_eq "large file checksum matches" "$large_dst_hash" "$large_src_hash"
+
+    echo "[10.1] mounted tier-transition parity"
+    write_pattern_file "$TIER_MOUNT" 10240 17
+    tier_small_initial_size=$(wait_remote_stat_field_eq "$TIER_REMOTE" "size" "10240")
+    check_eq "tier transition initial 10KiB size matches remote stat" "$tier_small_initial_size" "10240"
+    rm -f "$TIER_DOWNLOADED"
+    drive9_retry fs cp ":$TIER_REMOTE" "$TIER_DOWNLOADED" >/dev/null
+    tier_small_initial_hash=$(sha256_file "$TIER_MOUNT")
+    tier_small_initial_remote_hash=$(sha256_file "$TIER_DOWNLOADED")
+    check_eq "tier transition initial 10KiB checksum matches" "$tier_small_initial_remote_hash" "$tier_small_initial_hash"
+
+    write_pattern_file "$TIER_MOUNT" 8388608 43
+    tier_large_size=$(wait_remote_stat_field_eq "$TIER_REMOTE" "size" "8388608" "$LARGE_FILE_VISIBILITY_TIMEOUT_S" "$LARGE_FILE_VISIBILITY_INTERVAL_S")
+    check_eq "tier transition 8MiB A size matches remote stat" "$tier_large_size" "8388608"
+    rm -f "$TIER_DOWNLOADED"
+    drive9_retry fs cp ":$TIER_REMOTE" "$TIER_DOWNLOADED" >/dev/null
+    tier_large_hash=$(sha256_file "$TIER_MOUNT")
+    tier_large_remote_hash=$(sha256_file "$TIER_DOWNLOADED")
+    check_eq "tier transition 8MiB A checksum matches" "$tier_large_remote_hash" "$tier_large_hash"
+
+    write_pattern_file "$TIER_MOUNT" 8388608 67
+    tier_large_second_size=$(wait_remote_stat_field_eq "$TIER_REMOTE" "size" "8388608" "$LARGE_FILE_VISIBILITY_TIMEOUT_S" "$LARGE_FILE_VISIBILITY_INTERVAL_S")
+    check_eq "tier transition 8MiB B size matches remote stat" "$tier_large_second_size" "8388608"
+    rm -f "$TIER_DOWNLOADED"
+    drive9_retry fs cp ":$TIER_REMOTE" "$TIER_DOWNLOADED" >/dev/null
+    tier_large_second_hash=$(sha256_file "$TIER_MOUNT")
+    tier_large_second_remote_hash=$(sha256_file "$TIER_DOWNLOADED")
+    check_eq "tier transition 8MiB B checksum matches" "$tier_large_second_remote_hash" "$tier_large_second_hash"
+
+    write_pattern_file "$TIER_MOUNT" 10240 89
+    tier_small_final_size=$(wait_remote_stat_field_eq "$TIER_REMOTE" "size" "10240")
+    check_eq "tier transition final 10KiB size matches remote stat" "$tier_small_final_size" "10240"
+    rm -f "$TIER_DOWNLOADED"
+    drive9_retry fs cp ":$TIER_REMOTE" "$TIER_DOWNLOADED" >/dev/null
+    tier_small_final_hash=$(sha256_file "$TIER_MOUNT")
+    tier_small_final_remote_hash=$(sha256_file "$TIER_DOWNLOADED")
+    check_eq "tier transition final 10KiB checksum matches" "$tier_small_final_remote_hash" "$tier_small_final_hash"
+
+    if unmount_mount; then
+      check_eq "rw mount unmounted after tier transition" "true" "true"
+    else
+      check_eq "rw mount unmounted after tier transition" "false" "true"
+      stop_mount
+    fi
+    if start_mount rw; then
+      check_eq "rw mount remounted after tier transition" "true" "true"
+    else
+      check_eq "rw mount remounted after tier transition" "false" "true"
+    fi
+    if is_mounted "$MOUNT_POINT"; then
+      check_cmd "tier transition file visible after remount" wait_path_exists "$TIER_MOUNT"
+      if [ -f "$TIER_MOUNT" ]; then
+        tier_remount_hash=$(sha256_file "$TIER_MOUNT")
+      else
+        tier_remount_hash=""
+      fi
+      check_eq "tier transition final checksum survives remount" "$tier_remount_hash" "$tier_small_final_hash"
+    fi
   else
     echo "SKIP large-file boundary after mount directory rename failure (tracked in issue #248)"
   fi

--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -309,6 +309,53 @@ print(h.hexdigest())
 PY
 }
 
+wait_remote_file_hash_eq() {
+  local remote_path="$1"
+  local want_hash="$2"
+  local local_path="$3"
+  local timeout_s="${4:-$REMOTE_VISIBILITY_TIMEOUT_S}"
+  local interval_s="${5:-$REMOTE_VISIBILITY_INTERVAL_S}"
+  local deadline
+  local out rc got_hash
+  deadline=$(python3 - "$timeout_s" <<'PY'
+import sys
+import time
+print(time.time() + float(sys.argv[1]))
+PY
+)
+
+  while :; do
+    rm -f "$local_path"
+    set +e
+    out=$(drive9 fs cp ":$remote_path" "$local_path" 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ] && [ -f "$local_path" ]; then
+      got_hash=$(sha256_file "$local_path")
+      if [ "$got_hash" = "$want_hash" ]; then
+        printf '%s' "$got_hash"
+        return 0
+      fi
+    elif [[ "$out" != *"not found"* && "$out" != *"Too Many Requests"* && "$out" != *"HTTP 429"* && "$out" != *"HTTP 403"* && "$out" != *"403 Forbidden"* ]]; then
+      printf '%s\n' "$out" >&2
+      return 1
+    fi
+
+    if python3 - "$deadline" <<'PY'
+import sys
+import time
+raise SystemExit(0 if time.time() >= float(sys.argv[1]) else 1)
+PY
+    then
+      printf 'wait_remote_file_hash_eq: timeout path=%s want_hash=%s last_hash=%s\n' \
+        "$remote_path" "$want_hash" "${got_hash:-<none>}" >&2
+      return 1
+    fi
+
+    sleep "$interval_s"
+  done
+}
+
 write_pattern_file() {
   local file_path="$1"
   local size="$2"
@@ -1008,41 +1055,50 @@ PY
 
     echo "[10.1] mounted tier-transition parity"
     write_pattern_file "$TIER_MOUNT" 10240 17
+    tier_small_initial_hash=$(sha256_file "$TIER_MOUNT")
     tier_small_initial_size=$(wait_remote_stat_field_eq "$TIER_REMOTE" "size" "10240")
     check_eq "tier transition initial 10KiB size matches remote stat" "$tier_small_initial_size" "10240"
-    rm -f "$TIER_DOWNLOADED"
-    drive9_retry fs cp ":$TIER_REMOTE" "$TIER_DOWNLOADED" >/dev/null
-    tier_small_initial_hash=$(sha256_file "$TIER_MOUNT")
-    tier_small_initial_remote_hash=$(sha256_file "$TIER_DOWNLOADED")
+    if tier_small_initial_remote_hash=$(wait_remote_file_hash_eq "$TIER_REMOTE" "$tier_small_initial_hash" "$TIER_DOWNLOADED"); then
+      :
+    else
+      tier_small_initial_remote_hash=""
+    fi
     check_eq "tier transition initial 10KiB checksum matches" "$tier_small_initial_remote_hash" "$tier_small_initial_hash"
 
     write_pattern_file "$TIER_MOUNT" 8388608 43
+    tier_large_hash=$(sha256_file "$TIER_MOUNT")
     tier_large_size=$(wait_remote_stat_field_eq "$TIER_REMOTE" "size" "8388608" "$LARGE_FILE_VISIBILITY_TIMEOUT_S" "$LARGE_FILE_VISIBILITY_INTERVAL_S")
     check_eq "tier transition 8MiB A size matches remote stat" "$tier_large_size" "8388608"
-    rm -f "$TIER_DOWNLOADED"
-    drive9_retry fs cp ":$TIER_REMOTE" "$TIER_DOWNLOADED" >/dev/null
-    tier_large_hash=$(sha256_file "$TIER_MOUNT")
-    tier_large_remote_hash=$(sha256_file "$TIER_DOWNLOADED")
+    if tier_large_remote_hash=$(wait_remote_file_hash_eq "$TIER_REMOTE" "$tier_large_hash" "$TIER_DOWNLOADED" "$LARGE_FILE_VISIBILITY_TIMEOUT_S" "$LARGE_FILE_VISIBILITY_INTERVAL_S"); then
+      :
+    else
+      tier_large_remote_hash=""
+    fi
     check_eq "tier transition 8MiB A checksum matches" "$tier_large_remote_hash" "$tier_large_hash"
 
     write_pattern_file "$TIER_MOUNT" 8388608 67
+    tier_large_second_hash=$(sha256_file "$TIER_MOUNT")
     tier_large_second_size=$(wait_remote_stat_field_eq "$TIER_REMOTE" "size" "8388608" "$LARGE_FILE_VISIBILITY_TIMEOUT_S" "$LARGE_FILE_VISIBILITY_INTERVAL_S")
     check_eq "tier transition 8MiB B size matches remote stat" "$tier_large_second_size" "8388608"
-    rm -f "$TIER_DOWNLOADED"
-    drive9_retry fs cp ":$TIER_REMOTE" "$TIER_DOWNLOADED" >/dev/null
-    tier_large_second_hash=$(sha256_file "$TIER_MOUNT")
-    tier_large_second_remote_hash=$(sha256_file "$TIER_DOWNLOADED")
+    if tier_large_second_remote_hash=$(wait_remote_file_hash_eq "$TIER_REMOTE" "$tier_large_second_hash" "$TIER_DOWNLOADED" "$LARGE_FILE_VISIBILITY_TIMEOUT_S" "$LARGE_FILE_VISIBILITY_INTERVAL_S"); then
+      :
+    else
+      tier_large_second_remote_hash=""
+    fi
     check_eq "tier transition 8MiB B checksum matches" "$tier_large_second_remote_hash" "$tier_large_second_hash"
 
     write_pattern_file "$TIER_MOUNT" 10240 89
+    tier_small_final_hash=$(sha256_file "$TIER_MOUNT")
     tier_small_final_size=$(wait_remote_stat_field_eq "$TIER_REMOTE" "size" "10240")
     check_eq "tier transition final 10KiB size matches remote stat" "$tier_small_final_size" "10240"
-    rm -f "$TIER_DOWNLOADED"
-    drive9_retry fs cp ":$TIER_REMOTE" "$TIER_DOWNLOADED" >/dev/null
-    tier_small_final_hash=$(sha256_file "$TIER_MOUNT")
-    tier_small_final_remote_hash=$(sha256_file "$TIER_DOWNLOADED")
+    if tier_small_final_remote_hash=$(wait_remote_file_hash_eq "$TIER_REMOTE" "$tier_small_final_hash" "$TIER_DOWNLOADED"); then
+      :
+    else
+      tier_small_final_remote_hash=""
+    fi
     check_eq "tier transition final 10KiB checksum matches" "$tier_small_final_remote_hash" "$tier_small_final_hash"
 
+    rw_mount_available=true
     if unmount_mount; then
       check_eq "rw mount unmounted after tier transition" "true" "true"
     else
@@ -1053,8 +1109,9 @@ PY
       check_eq "rw mount remounted after tier transition" "true" "true"
     else
       check_eq "rw mount remounted after tier transition" "false" "true"
+      rw_mount_available=false
     fi
-    if is_mounted "$MOUNT_POINT"; then
+    if [ "$rw_mount_available" = "true" ] && is_mounted "$MOUNT_POINT"; then
       check_cmd "tier transition file visible after remount" wait_path_exists "$TIER_MOUNT"
       if [ -f "$TIER_MOUNT" ]; then
         tier_remount_hash=$(sha256_file "$TIER_MOUNT")
@@ -1062,11 +1119,15 @@ PY
         tier_remount_hash=""
       fi
       check_eq "tier transition final checksum survives remount" "$tier_remount_hash" "$tier_small_final_hash"
+    else
+      echo "SKIP tier transition remount content checks because rw mount is unavailable"
+      rw_mount_available=false
     fi
   else
     echo "SKIP large-file boundary after mount directory rename failure (tracked in issue #248)"
   fi
 
+  if [ "${rw_mount_available:-true}" = "true" ] && is_mounted "$MOUNT_POINT"; then
   echo "[11] error semantics"
   check_cmd_fail "cat missing file via mount fails" cat "$MOUNT_POINT/${ROOT_REL}/no-such-file.txt"
 
@@ -1150,6 +1211,11 @@ PY
     check_eq "final mount unmounted" "true" "true"
   else
     check_eq "final mount unmounted" "false" "true"
+    stop_mount
+  fi
+  else
+    echo "SKIP remaining mounted checks because rw mount is unavailable after tier transition remount"
+    drive9_retry fs rm -r "$ROOT_REMOTE" >/dev/null 2>&1 || true
     stop_mount
   fi
   # End of the writable-alpha branch opened after the nested mkdir checks.

--- a/pkg/backend/tier_transition_test.go
+++ b/pkg/backend/tier_transition_test.go
@@ -67,6 +67,57 @@ func TestBackendTierTransitionInlineToS3ToInlineCleansStorage(t *testing.T) {
 	assertOverwriteGCCandidate(t, fake, "ns-tier-transition", large.storageRef)
 }
 
+func TestBackendTierTransitionMultipleS3OverwritesQueueAllObsoleteRefs(t *testing.T) {
+	backendFS, fake := newCentralQuotaBackend(t)
+	backendFS.storageNamespaceID = "ns-tier-transition-multi"
+
+	ctx := context.Background()
+	path := "/tier-transition-multi.bin"
+	initialInline := deterministicTierPayload(10*1024, 0x13)
+	largeA := deterministicTierPayload(8*1024*1024, 0x24)
+	largeB := deterministicTierPayload(8*1024*1024, 0x35)
+	finalInline := deterministicTierPayload(10*1024, 0x46)
+
+	if _, err := backendFS.Write(path, initialInline, 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatalf("create inline file: %v", err)
+	}
+	if _, err := backendFS.Write(path, largeA, 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatalf("overwrite inline -> s3 A: %v", err)
+	}
+	stateA := loadBackendTierState(t, backendFS, path)
+	assertS3TierState(t, stateA, largeA)
+	assertS3ObjectBytes(t, backendFS, stateA.storageRef, largeA)
+
+	if _, err := backendFS.Write(path, largeB, 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatalf("overwrite s3 A -> s3 B: %v", err)
+	}
+	stateB := loadBackendTierState(t, backendFS, path)
+	assertS3TierState(t, stateB, largeB)
+	assertS3ObjectBytes(t, backendFS, stateB.storageRef, largeB)
+	if stateB.storageRef == stateA.storageRef {
+		t.Fatalf("s3 overwrite reused storage ref %q", stateB.storageRef)
+	}
+
+	if _, err := backendFS.Write(path, finalInline, 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatalf("overwrite s3 B -> inline: %v", err)
+	}
+	finalState := loadBackendTierState(t, backendFS, path)
+	assertInlineTierState(t, finalState, finalInline)
+	assertBackendVisibleBytes(t, backendFS, path, finalInline)
+
+	for _, obsoleteRef := range []string{stateA.storageRef, stateB.storageRef} {
+		stillReferenced, err := backendFS.Store().HasConfirmedS3StorageRef(ctx, datastore.StorageRefHash(obsoleteRef), obsoleteRef)
+		if err != nil {
+			t.Fatalf("check obsolete s3 reference %q: %v", obsoleteRef, err)
+		}
+		if stillReferenced {
+			t.Fatalf("obsolete s3 ref %q is still referenced by confirmed content", obsoleteRef)
+		}
+		assertOverwriteGCCandidate(t, fake, "ns-tier-transition-multi", obsoleteRef)
+	}
+	assertOverwriteGCCandidateCount(t, fake, "ns-tier-transition-multi", []string{stateA.storageRef, stateB.storageRef})
+}
+
 type backendTierState struct {
 	fileID            string
 	storageType       datastore.StorageType
@@ -242,6 +293,32 @@ func assertOverwriteGCCandidate(t *testing.T, fake *fakeMetaQuotaStore, namespac
 		}
 	}
 	t.Fatalf("missing overwrite gc candidate for %q in namespace %q: %+v", storageRef, namespaceID, fake.objectGCCandidates)
+}
+
+func assertOverwriteGCCandidateCount(t *testing.T, fake *fakeMetaQuotaStore, namespaceID string, storageRefs []string) {
+	t.Helper()
+
+	want := make(map[string]int, len(storageRefs))
+	for _, storageRef := range storageRefs {
+		want[storageRef]++
+	}
+	got := make(map[string]int, len(storageRefs))
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	for _, candidate := range fake.objectGCCandidates {
+		if candidate.NamespaceID == namespaceID && candidate.Reason == meta.ObjectGCReasonOverwrite {
+			got[candidate.StorageRef]++
+		}
+	}
+	for storageRef, count := range want {
+		if got[storageRef] != count {
+			t.Fatalf("overwrite gc candidate count for %q = %d, want %d; all=%+v",
+				storageRef, got[storageRef], count, fake.objectGCCandidates)
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("overwrite gc candidate refs = %+v, want exactly %+v", got, want)
+	}
 }
 
 func deterministicTierPayload(size int, seed byte) []byte {

--- a/pkg/server/object_gc_worker_test.go
+++ b/pkg/server/object_gc_worker_test.go
@@ -1,15 +1,19 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"database/sql"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/go-sql-driver/mysql"
+	backendpkg "github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/encrypt"
 	"github.com/mem9-ai/dat9/pkg/meta"
@@ -193,4 +197,193 @@ func TestObjectGCDeletesUnreachableBlob(t *testing.T) {
 	if state != meta.ObjectGCCandidateDeleted || lastError != "" {
 		t.Fatalf("candidate state=%s last_error=%q", state, lastError)
 	}
+}
+
+func TestObjectGCPostponesReachableBlob(t *testing.T) {
+	rt := newObjectGCTestRuntime(t)
+	ctx := context.Background()
+	namespaceID := "ns-reachable"
+	ownerID := "owner-reachable"
+	path := "/reachable.bin"
+	payload := deterministicObjectGCPayload(8*1024*1024, 0x61)
+
+	rt.upsertNamespace(t, namespaceID, ownerID)
+	rt.insertTenant(t, ownerID, meta.TenantActive, meta.TenantKindLive, namespaceID)
+	owner := objectGCTenant(t, rt, ownerID)
+	ownerBackend, release, err := rt.pool.Acquire(ctx, owner)
+	if err != nil {
+		t.Fatalf("acquire owner backend: %v", err)
+	}
+	if _, err := ownerBackend.Write(path, payload, 0, filesystem.WriteFlagCreate); err != nil {
+		release()
+		t.Fatalf("create s3 file: %v", err)
+	}
+	storageRef := objectGCFileStorageRef(t, ownerBackend, path)
+	assertObjectGCS3ObjectBytes(t, ownerBackend, storageRef, payload)
+	release()
+
+	candidate := rt.enqueueCandidate(t, namespaceID, storageRef)
+	worker := &objectGCWorker{meta: rt.meta, pool: rt.pool}
+	if err := worker.processCandidate(ctx, candidate); err != nil {
+		t.Fatal(err)
+	}
+
+	state, lastError := objectGCCandidateRow(t, rt.meta.DB(), namespaceID, storageRef)
+	if state != meta.ObjectGCCandidatePending || lastError != "storage ref still reachable" {
+		t.Fatalf("candidate state=%s last_error=%q", state, lastError)
+	}
+	ownerBackend, release, err = rt.pool.Acquire(ctx, owner)
+	if err != nil {
+		t.Fatalf("reacquire owner backend: %v", err)
+	}
+	defer release()
+	assertObjectGCS3ObjectBytes(t, ownerBackend, storageRef, payload)
+	assertObjectGCBackendVisibleBytes(t, ownerBackend, path, payload)
+}
+
+func TestObjectGCSweepsTierTransitionObsoleteBlobKeepsCurrentContent(t *testing.T) {
+	rt := newObjectGCTestRuntime(t)
+	ctx := context.Background()
+	namespaceID := "ns-tier-sweep"
+	ownerID := "owner-tier-sweep"
+	path := "/tier-sweep.bin"
+	initialInline := deterministicObjectGCPayload(10*1024, 0x12)
+	largeS3 := deterministicObjectGCPayload(8*1024*1024, 0x34)
+	finalInline := deterministicObjectGCPayload(10*1024, 0x56)
+
+	rt.upsertNamespace(t, namespaceID, ownerID)
+	rt.insertTenant(t, ownerID, meta.TenantActive, meta.TenantKindLive, namespaceID)
+	owner := objectGCTenant(t, rt, ownerID)
+	ownerBackend, release, err := rt.pool.Acquire(ctx, owner)
+	if err != nil {
+		t.Fatalf("acquire owner backend: %v", err)
+	}
+	if _, err := ownerBackend.Write(path, initialInline, 0, filesystem.WriteFlagCreate); err != nil {
+		release()
+		t.Fatalf("create inline file: %v", err)
+	}
+	if _, err := ownerBackend.Write(path, largeS3, 0, filesystem.WriteFlagTruncate); err != nil {
+		release()
+		t.Fatalf("overwrite inline -> s3: %v", err)
+	}
+	obsoleteRef := objectGCFileStorageRef(t, ownerBackend, path)
+	assertObjectGCS3ObjectBytes(t, ownerBackend, obsoleteRef, largeS3)
+	if _, err := ownerBackend.Write(path, finalInline, 0, filesystem.WriteFlagTruncate); err != nil {
+		release()
+		t.Fatalf("overwrite s3 -> inline: %v", err)
+	}
+	assertObjectGCBackendVisibleBytes(t, ownerBackend, path, finalInline)
+	if reachable, err := ownerBackend.HasConfirmedS3StorageRef(ctx, datastore.StorageRefHash(obsoleteRef), obsoleteRef); err != nil {
+		release()
+		t.Fatalf("check obsolete ref reachability: %v", err)
+	} else if reachable {
+		release()
+		t.Fatalf("obsolete ref %q is still confirmed after inline overwrite", obsoleteRef)
+	}
+	release()
+
+	candidates, err := rt.meta.ListDueObjectGCCandidates(ctx, time.Now().UTC().Add(8*24*time.Hour), 10)
+	if err != nil {
+		t.Fatalf("list due object gc candidates: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("candidate count = %d, want 1: %+v", len(candidates), candidates)
+	}
+	candidate := candidates[0]
+	if candidate.NamespaceID != namespaceID || candidate.StorageRef != obsoleteRef || candidate.Reason != meta.ObjectGCReasonOverwrite {
+		t.Fatalf("candidate = %+v, want namespace=%q ref=%q reason=%q", candidate, namespaceID, obsoleteRef, meta.ObjectGCReasonOverwrite)
+	}
+
+	worker := &objectGCWorker{meta: rt.meta, pool: rt.pool}
+	if err := worker.processCandidate(ctx, candidate); err != nil {
+		t.Fatal(err)
+	}
+
+	state, lastError := objectGCCandidateRow(t, rt.meta.DB(), namespaceID, obsoleteRef)
+	if state != meta.ObjectGCCandidateDeleted || lastError != "" {
+		t.Fatalf("candidate state=%s last_error=%q", state, lastError)
+	}
+	ownerBackend, release, err = rt.pool.Acquire(ctx, owner)
+	if err != nil {
+		t.Fatalf("reacquire owner backend: %v", err)
+	}
+	defer release()
+	assertObjectGCS3ObjectMissing(t, ownerBackend, obsoleteRef)
+	assertObjectGCBackendVisibleBytes(t, ownerBackend, path, finalInline)
+	currentRef := objectGCFileStorageRef(t, ownerBackend, path)
+	if currentRef != "inline" {
+		t.Fatalf("current storage ref = %q, want inline", currentRef)
+	}
+}
+
+func objectGCTenant(t *testing.T, rt *objectGCTestRuntime, tenantID string) *meta.Tenant {
+	t.Helper()
+	tenant, err := rt.meta.GetTenant(context.Background(), tenantID)
+	if err != nil {
+		t.Fatalf("get tenant %s: %v", tenantID, err)
+	}
+	return tenant
+}
+
+func objectGCFileStorageRef(t *testing.T, backendFS *backendpkg.Dat9Backend, path string) string {
+	t.Helper()
+	node, err := backendFS.Store().Stat(context.Background(), path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if node.File == nil {
+		t.Fatalf("stat %s returned no file", path)
+	}
+	return node.File.StorageRef
+}
+
+func assertObjectGCBackendVisibleBytes(t *testing.T, backendFS *backendpkg.Dat9Backend, path string, want []byte) {
+	t.Helper()
+	info, err := backendFS.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if info.Size != int64(len(want)) {
+		t.Fatalf("visible size for %s = %d, want %d", path, info.Size, len(want))
+	}
+	got, err := backendFS.Read(path, 0, int64(len(want)+1))
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("visible bytes for %s mismatch: got %d bytes want %d bytes", path, len(got), len(want))
+	}
+}
+
+func assertObjectGCS3ObjectBytes(t *testing.T, backendFS *backendpkg.Dat9Backend, storageRef string, want []byte) {
+	t.Helper()
+	reader, err := backendFS.S3().GetObject(context.Background(), storageRef)
+	if err != nil {
+		t.Fatalf("get s3 object %q: %v", storageRef, err)
+	}
+	defer func() { _ = reader.Close() }()
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read s3 object %q: %v", storageRef, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("s3 object %q mismatch: got %d bytes want %d bytes", storageRef, len(got), len(want))
+	}
+}
+
+func assertObjectGCS3ObjectMissing(t *testing.T, backendFS *backendpkg.Dat9Backend, storageRef string) {
+	t.Helper()
+	reader, err := backendFS.S3().GetObject(context.Background(), storageRef)
+	if err == nil {
+		_ = reader.Close()
+		t.Fatalf("s3 object %q still exists after object gc", storageRef)
+	}
+}
+
+func deterministicObjectGCPayload(size int, seed byte) []byte {
+	out := make([]byte, size)
+	for idx := range out {
+		out[idx] = byte((idx*29 + int(seed)) % 251)
+	}
+	return out
 }


### PR DESCRIPTION
## Summary
- add mounted FUSE tier-transition parity to `e2e/fuse-smoke-test.sh`: 10KiB -> 8MiB A -> 8MiB B -> 10KiB, with remote stat/download checksum checks and remount checksum parity
- add backend multi-overwrite tier-transition regression: 10KiB -> 8MiB A -> 8MiB B -> 10KiB queues both obsolete S3 refs exactly once and keeps current inline content readable
- add server object GC worker regressions: reachable S3 ref is postponed and preserved; obsolete tier-transition S3 ref is swept while current content remains readable

## Validation
- `bash -n e2e/fuse-smoke-test.sh`
- `/usr/local/go/bin/go test -c -o /tmp/drive9-backend-tier-gc.test ./pkg/backend`
- `/usr/local/go/bin/go test -c -o /tmp/drive9-server-tier-gc.test ./pkg/server`
- `/usr/local/go/bin/go test -c ./pkg/... ./cmd/...`
- `git diff --check`

## Local runtime caveat
- Focused DB-backed `go test ./pkg/backend -run TestBackendTierTransition -count=1` is blocked on this Mac by testcontainers startup: `panic: rootless Docker not found`. CI/local-e2e host should execute runtime tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end smoke tests for mounts and tier transitions, including multi-size boundary checks and checksum parity across remounts
  * Added coverage for multiple overwrites, ensuring final tier state and GC candidate behavior
  * New GC tests validating reachable objects and cleanup of obsolete tier-transition objects

* **Documentation**
  * Expanded test docs to describe the extended smoke-test validations and lifecycle checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->