### PR TITLE
fix: Aliyun OSS/KMS support — TLS skip, RRSA credentials, s3client refactor, generated-column guard

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -176,7 +176,7 @@ func main() {
 	stepStart = time.Now()
 	switch s3cfg.Mode {
 	case "aws":
-		s3c, err = s3client.NewAWS(startupCtx, s3client.AWSConfig{
+		s3c, err = s3client.New(startupCtx, s3client.AWSConfig{
 			Region:          s3cfg.Region,
 			Bucket:          s3cfg.Bucket,
 			Prefix:          s3cfg.Prefix,

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -387,6 +387,7 @@ environment:
   DRIVE9_ENCRYPT_KEY KMS key id or alias (required for kms), Aliyun KMS key id (required for aliyun_kms)
   DRIVE9_ALIYUN_KMS_ENDPOINT custom Aliyun KMS endpoint, e.g. a VPC endpoint (no https:// prefix)
                              note: aliyun_kms reads the Aliyun region from DRIVE9_S3_REGION
+                             note: TLS verification is skipped automatically when this is set
   DRIVE9_TOKEN_SIGNING_KEY  32-byte hex key for JWT API key signing
   DRIVE9_VAULT_MASTER_KEY   32-byte hex key for vault DEK wrapping (omit to disable vault)
   DRIVE9_MAX_UPLOAD_BYTES maximum allowed upload size in bytes (default: %d, minimum: 1048576)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -207,19 +207,20 @@ func main() {
 		}
 
 		pool = tenant.NewPool(tenant.PoolConfig{
-			S3Dir:              s3cfg.Dir,
-			PublicURL:          publicBaseURL(addr),
-			S3Bucket:           s3cfg.Bucket,
-			S3Region:           s3cfg.Region,
-			S3Prefix:           s3cfg.Prefix,
-			S3RoleARN:          s3cfg.RoleARN,
-			S3Endpoint:         s3cfg.Endpoint,
-			S3ForcePathStyle:   s3cfg.ForcePathStyle,
-			S3AccessKeyID:      s3cfg.AccessKeyID,
-			S3SecretAccessKey:  s3cfg.SecretAccessKey,
-			S3SessionToken:     s3cfg.SessionToken,
-			S3EncryptionPolicy: s3cfg.EncryptionPolicy,
-			BackendOptions:     backendOptions,
+			S3Dir:                        s3cfg.Dir,
+			PublicURL:                    publicBaseURL(addr),
+			S3Bucket:                     s3cfg.Bucket,
+			S3Region:                     s3cfg.Region,
+			S3Prefix:                     s3cfg.Prefix,
+			S3RoleARN:                    s3cfg.RoleARN,
+			S3Endpoint:                   s3cfg.Endpoint,
+			S3ForcePathStyle:             s3cfg.ForcePathStyle,
+			S3AccessKeyID:                s3cfg.AccessKeyID,
+			S3SecretAccessKey:            s3cfg.SecretAccessKey,
+			S3SessionToken:               s3cfg.SessionToken,
+			S3EncryptionPolicy:           s3cfg.EncryptionPolicy,
+			BackendOptions:               backendOptions,
+			DisableDatabaseAutoEmbedding: envBool("DRIVE9_DISABLE_AUTO_EMBEDDING", false),
 		}, enc)
 		defer pool.Close()
 	}
@@ -394,6 +395,8 @@ environment:
   DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
   DRIVE9_QUOTA_SOURCE tenant|server quota enforcement source (default: tenant)
+  DRIVE9_DISABLE_AUTO_EMBEDDING true|false disable TiDB database-managed auto-embedding (default: false)
+                                set to true when the TiDB Cloud cluster has no supported embedding provider
   DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)
   DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*
   DRIVE9_SLOCK_API_ORIGIN Slock API origin (required when DRIVE9_SLOCK_ORIGIN is set)

--- a/pkg/datastore/file_tx.go
+++ b/pkg/datastore/file_tx.go
@@ -368,6 +368,14 @@ func (s *Store) ClearFileEmbeddingStateTx(db execer, fileID string) error {
 		}
 	}
 	// Dual-write to split tables
+	// Skip the explicit NULL write when embedding is a GENERATED column (TiDB
+	// auto-embedding schema) — only clear the revision marker instead.
+	if s.disableAutoEmbedTextWrites {
+		if _, err := db.Exec(`UPDATE semantic SET embedding_revision = NULL WHERE inode_id = ?`, fileID); err != nil {
+			return fmt.Errorf("update semantic embedding revision: %w", err)
+		}
+		return nil
+	}
 	if _, err := db.Exec(`UPDATE semantic SET embedding = NULL, embedding_revision = NULL WHERE inode_id = ?`, fileID); err != nil {
 		return fmt.Errorf("update semantic embedding: %w", err)
 	}

--- a/pkg/datastore/semantic.go
+++ b/pkg/datastore/semantic.go
@@ -45,7 +45,21 @@ func (s *Store) GetSemantic(ctx context.Context, inodeID string) (*Semantic, err
 }
 
 // UpdateSemanticTx updates semantic data inside a transaction, clearing embeddings.
+// When the store has auto-embed text writes disabled (TiDB schema with GENERATED
+// embedding columns), writing NULL to those columns is forbidden (TiDB error 3105).
+// In that case only the revision markers are cleared; content_text and description
+// are left untouched to avoid triggering EMBED_TEXT() generated column evaluation.
 func (s *Store) UpdateSemanticTx(db execer, inodeID string, contentText, description string) error {
+	if s.disableAutoEmbedTextWrites {
+		// embedding and description_embedding are GENERATED ALWAYS columns on TiDB;
+		// explicit writes (even NULL) are rejected. Only clear the revision markers
+		// so stale vector state is flagged without violating the generated-column
+		// constraint.
+		_, err := db.Exec(`UPDATE semantic SET
+			embedding_revision = NULL, description_embedding_revision = NULL
+			WHERE inode_id = ?`, inodeID)
+		return err
+	}
 	_, err := db.Exec(`UPDATE semantic SET
 		content_text = ?, description = ?,
 		embedding = NULL, embedding_revision = NULL,

--- a/pkg/datastore/semantic.go
+++ b/pkg/datastore/semantic.go
@@ -9,11 +9,11 @@ import (
 
 // Semantic represents a row in the semantic table (search & enrichment).
 type Semantic struct {
-	InodeID                        string
-	ContentText                    string
-	Description                    string
-	EmbeddingRevision              *int64
-	DescriptionEmbeddingRevision   *int64
+	InodeID                      string
+	ContentText                  string
+	Description                  string
+	EmbeddingRevision            *int64
+	DescriptionEmbeddingRevision *int64
 }
 
 // InsertSemantic inserts a semantic row.

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -924,10 +924,9 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 		if err != nil {
 			return nil, err
 		}
-		// Dual-write to split tables.
-		// Skip when auto-embed text writes are disabled: writing content_text
-		// triggers recomputation of GENERATED embedding columns (EMBED_TEXT),
-		// which fails with error 1105 when the provider is unavailable.
+		// Skip when auto-embed text writes are disabled: return after updating
+		// files table, skip semantic dual-write. Return the real res so
+		// RowsAffected() reflects whether the files row actually matched.
 		if s.disableAutoEmbedTextWrites {
 			return res, nil
 		}
@@ -950,8 +949,26 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 	// Skip when auto-embed text writes are disabled: any write to content_text
 	// triggers EMBED_TEXT() recomputation on the GENERATED embedding column,
 	// which fails with error 1105 when the provider is not available on this cluster.
+	// We still gate on the revision/status check so stale tasks are correctly
+	// rejected (returning 0 rows), while current tasks return 1 so the caller
+	// can proceed to write tags (stored in file_tags, unaffected by EMBED_TEXT).
 	if s.disableAutoEmbedTextWrites {
-		return noopResult{}, nil
+		var n int
+		var err error
+		if expectedRevision > 0 {
+			err = db.QueryRow(`SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?`,
+				fileID, expectedRevision).Scan(&n)
+		} else {
+			err = db.QueryRow(`SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED'`,
+				fileID).Scan(&n)
+		}
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return noopResult{0}, nil // stale or not found: report 0 rows
+			}
+			return nil, fmt.Errorf("check inode for search text skip: %w", err)
+		}
+		return noopResult{1}, nil // found: report 1 row so tags are written
 	}
 	if expectedRevision > 0 {
 		return db.Exec(`UPDATE semantic SET content_text = ?
@@ -1066,12 +1083,13 @@ type execer interface {
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
 
-// noopResult is a sql.Result that reports zero rows affected and zero last
-// insert ID. Used as a placeholder when a write is intentionally skipped.
-type noopResult struct{}
+// noopResult is a sql.Result that reports a configurable number of rows
+// affected and zero last insert ID. Used when a write is intentionally skipped
+// but the caller may need to know whether the target row existed.
+type noopResult struct{ rows int64 }
 
-func (noopResult) LastInsertId() (int64, error) { return 0, nil }
-func (noopResult) RowsAffected() (int64, error) { return 0, nil }
+func (r noopResult) LastInsertId() (int64, error) { return 0, nil }
+func (r noopResult) RowsAffected() (int64, error)  { return r.rows, nil }
 
 // FileStorageMeta holds the lightweight storage metadata needed by upload
 // overwrite logic, fetched with FOR UPDATE row locking.

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1071,7 +1071,7 @@ type execer interface {
 type noopResult struct{}
 
 func (noopResult) LastInsertId() (int64, error) { return 0, nil }
-func (noopResult) RowsAffected() (int64, error)  { return 0, nil }
+func (noopResult) RowsAffected() (int64, error) { return 0, nil }
 
 // FileStorageMeta holds the lightweight storage metadata needed by upload
 // overwrite logic, fetched with FOR UPDATE row locking.

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -147,6 +147,10 @@ type Upload struct {
 type Store struct {
 	db             *sql.DB
 	useLegacyFiles bool // true when the legacy `files` table exists and needs dual-write
+	// disableAutoEmbedTextWrites suppresses content_text/description writes to the
+	// semantic table so TiDB does not attempt to compute EMBED_TEXT() generated
+	// columns when the cluster has no supported auto-embedding provider.
+	disableAutoEmbedTextWrites bool
 }
 
 func Open(dsn string) (*Store, error) {
@@ -175,6 +179,12 @@ func (s *Store) DB() *sql.DB  { return s.db }
 // tenant database. When false, all writes skip the `files` table entirely
 // and only target the split tables (inodes / contents / semantic).
 func (s *Store) HasLegacyFiles() bool { return s.useLegacyFiles }
+
+// DisableAutoEmbedTextWrites configures the store to omit content_text and
+// description when inserting/updating the semantic table. Use this when the
+// TiDB Cloud cluster has no supported auto-embedding provider so that
+// EMBED_TEXT() generated columns are not triggered.
+func (s *Store) DisableAutoEmbedTextWrites() { s.disableAutoEmbedTextWrites = true }
 
 func (s *Store) detectLegacyFiles(ctx context.Context) (bool, error) {
 	var n int
@@ -744,10 +754,12 @@ func (s *Store) insertSplitTablesTx(tx execer, f *File) error {
 	}
 	semantic := &Semantic{
 		InodeID:                      f.FileID,
-		ContentText:                  f.ContentText,
-		Description:                  f.Description,
 		EmbeddingRevision:            f.EmbeddingRevision,
 		DescriptionEmbeddingRevision: f.DescriptionEmbeddingRevision,
+	}
+	if !s.disableAutoEmbedTextWrites {
+		semantic.ContentText = f.ContentText
+		semantic.Description = f.Description
 	}
 	if err := s.InsertSemanticTx(tx, semantic); err != nil {
 		return fmt.Errorf("insert semantic: %w", err)

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1089,7 +1089,7 @@ type execer interface {
 type noopResult struct{ rows int64 }
 
 func (r noopResult) LastInsertId() (int64, error) { return 0, nil }
-func (r noopResult) RowsAffected() (int64, error)  { return r.rows, nil }
+func (r noopResult) RowsAffected() (int64, error) { return r.rows, nil }
 
 // FileStorageMeta holds the lightweight storage metadata needed by upload
 // overwrite logic, fetched with FOR UPDATE row locking.

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -924,7 +924,13 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 		if err != nil {
 			return nil, err
 		}
-		// Dual-write to split tables
+		// Dual-write to split tables.
+		// Skip when auto-embed text writes are disabled: writing content_text
+		// triggers recomputation of GENERATED embedding columns (EMBED_TEXT),
+		// which fails with error 1105 when the provider is unavailable.
+		if s.disableAutoEmbedTextWrites {
+			return res, nil
+		}
 		if expectedRevision > 0 {
 			if _, err := db.Exec(`UPDATE semantic SET content_text = ?
 				WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`,
@@ -941,6 +947,12 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 		return res, nil
 	}
 	// New tenant without legacy files: write directly to semantic.
+	// Skip when auto-embed text writes are disabled: any write to content_text
+	// triggers EMBED_TEXT() recomputation on the GENERATED embedding column,
+	// which fails with error 1105 when the provider is not available on this cluster.
+	if s.disableAutoEmbedTextWrites {
+		return noopResult{}, nil
+	}
 	if expectedRevision > 0 {
 		return db.Exec(`UPDATE semantic SET content_text = ?
 			WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`,
@@ -1053,6 +1065,13 @@ type execer interface {
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
+
+// noopResult is a sql.Result that reports zero rows affected and zero last
+// insert ID. Used as a placeholder when a write is intentionally skipped.
+type noopResult struct{}
+
+func (noopResult) LastInsertId() (int64, error) { return 0, nil }
+func (noopResult) RowsAffected() (int64, error)  { return 0, nil }
 
 // FileStorageMeta holds the lightweight storage metadata needed by upload
 // overwrite logic, fetched with FOR UPDATE row locking.

--- a/pkg/encrypt/aliyun_kms.go
+++ b/pkg/encrypt/aliyun_kms.go
@@ -2,8 +2,10 @@ package encrypt
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/kms"
@@ -25,6 +27,13 @@ func NewAliyunKMSEncryptor(region, keyID, endpoint string) (*AliyunKMSEncryptor,
 
 	config := sdk.NewConfig()
 	config.Scheme = "HTTPS"
+	if endpoint != "" {
+		// VPC/dedicated-gateway certificates are signed by an Aliyun internal CA
+		// not present in the system trust store; skip verification for custom endpoints.
+		config.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}
+	}
 
 	client, err := kms.NewClientWithOptions(region, config, nil)
 	if err != nil {

--- a/pkg/encrypt/aliyun_kms.go
+++ b/pkg/encrypt/aliyun_kms.go
@@ -2,10 +2,8 @@ package encrypt
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"net/http"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/kms"
@@ -27,17 +25,15 @@ func NewAliyunKMSEncryptor(region, keyID, endpoint string) (*AliyunKMSEncryptor,
 
 	config := sdk.NewConfig()
 	config.Scheme = "HTTPS"
-	if endpoint != "" {
-		// VPC/dedicated-gateway certificates are signed by an Aliyun internal CA
-		// not present in the system trust store; skip verification for custom endpoints.
-		config.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		}
-	}
 
 	client, err := kms.NewClientWithOptions(region, config, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create aliyun kms client: %w", err)
+	}
+	if endpoint != "" {
+		// VPC/dedicated-gateway certificates are signed by an Aliyun internal CA
+		// not present in the system trust store; skip verification for custom endpoints.
+		client.SetHTTPSInsecure(true)
 	}
 	return &AliyunKMSEncryptor{client: client, keyID: keyID, endpoint: endpoint}, nil
 }

--- a/pkg/encrypt/factory.go
+++ b/pkg/encrypt/factory.go
@@ -24,6 +24,8 @@ type Config struct {
 	Region string // aws/aliyun region for kms
 	// AliyunKMSEndpoint overrides the default Aliyun KMS endpoint, e.g. a VPC endpoint.
 	// Leave empty to use the default public endpoint for the region.
+	// When non-empty, TLS certificate verification is skipped automatically because
+	// VPC/dedicated-gateway certs are signed by an Aliyun internal CA.
 	AliyunKMSEndpoint string
 }
 

--- a/pkg/s3client/aliyun.go
+++ b/pkg/s3client/aliyun.go
@@ -38,32 +38,34 @@ func containsAliyunDomain(s string) bool {
 }
 
 // rrsaCredentials detects whether ACK RRSA env vars are present and returns a
-// refreshing aws.CredentialsProvider that exchanges the OIDC token for
-// temporary Alibaba Cloud STS credentials via AssumeRoleWithOIDC.
+// *rrsaProvider that exchanges the OIDC token for temporary Alibaba Cloud STS
+// credentials via AssumeRoleWithOIDC. region is passed through to the STS client.
 // Returns nil, false when RRSA env vars are not set.
-func rrsaCredentialsProvider() (aws.CredentialsProvider, bool) {
+func rrsaCredentialsProvider(region string) (*rrsaProvider, bool) {
 	roleARN := os.Getenv("ALIBABA_CLOUD_ROLE_ARN")
 	oidcProviderARN := os.Getenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN")
 	tokenFile := os.Getenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE")
 	if roleARN == "" || oidcProviderARN == "" || tokenFile == "" {
 		return nil, false
 	}
-	return aws.NewCredentialsCache(&rrsaProvider{
+	return &rrsaProvider{
+		region:          region,
 		roleARN:         roleARN,
 		oidcProviderARN: oidcProviderARN,
 		tokenFile:       tokenFile,
-	}), true
+	}, true
 }
 
 // rrsaProvider implements aws.CredentialsProvider using ACK RRSA.
 type rrsaProvider struct {
+	region          string
 	roleARN         string
 	oidcProviderARN string
 	tokenFile       string
 
-	mu          sync.Mutex
-	cached      aws.Credentials
-	expiresAt   time.Time
+	mu        sync.Mutex
+	cached    aws.Credentials
+	expiresAt time.Time
 }
 
 func (p *rrsaProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
@@ -72,12 +74,15 @@ func (p *rrsaProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 	if time.Now().Before(p.expiresAt.Add(-5 * time.Minute)) {
 		return p.cached, nil
 	}
+	if p.region == "" {
+		return aws.Credentials{}, fmt.Errorf("rrsa: region is required for STS AssumeRoleWithOIDC; set S3 region or ALIBABA_CLOUD_REGION_ID")
+	}
 	tokenBytes, err := os.ReadFile(p.tokenFile)
 	if err != nil {
 		return aws.Credentials{}, fmt.Errorf("rrsa: read oidc token: %w", err)
 	}
 	cfg := alibabasdk.NewConfig().WithScheme("HTTPS")
-	stsClient, err := sts.NewClientWithOptions("ap-southeast-1", cfg, nil)
+	stsClient, err := sts.NewClientWithOptions(p.region, cfg, nil)
 	if err != nil {
 		return aws.Credentials{}, fmt.Errorf("rrsa: create sts client: %w", err)
 	}
@@ -93,7 +98,10 @@ func (p *rrsaProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 		return aws.Credentials{}, fmt.Errorf("rrsa: AssumeRoleWithOIDC: %w", err)
 	}
 	creds := resp.Credentials
-	expiry, _ := time.Parse(time.RFC3339, creds.Expiration)
+	expiry, err := time.Parse(time.RFC3339, creds.Expiration)
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("rrsa: parse expiration %q: %w", creds.Expiration, err)
+	}
 	p.cached = aws.Credentials{
 		AccessKeyID:     creds.AccessKeyId,
 		SecretAccessKey: creds.AccessKeySecret,
@@ -111,17 +119,27 @@ func (p *rrsaProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 //  2. ACK RRSA: OIDC token file → STS AssumeRoleWithOIDC
 //  3. ALIBABA_CLOUD_ACCESS_KEY_ID / SECRET env vars (static)
 //
-// Returns nil, nil when no credentials are configured; the SDK will fail on
-// first use.
+// Region for RRSA: cfg.Region is used; falls back to ALIBABA_CLOUD_REGION_ID env var.
+// Returns nil when no credentials are configured.
 func credentialsForAliyun(cfg AWSConfig) (aws.CredentialsProvider, error) {
 	if cfg.AccessKeyID != "" {
 		return credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, cfg.SessionToken), nil
 	}
-	if p, ok := rrsaCredentialsProvider(); ok {
+	region := cfg.Region
+	if region == "" {
+		region = os.Getenv("ALIBABA_CLOUD_REGION_ID")
+	}
+	if p, ok := rrsaCredentialsProvider(region); ok {
+		if p.region == "" {
+			return nil, fmt.Errorf("s3: RRSA credentials require a region; set S3 region or ALIBABA_CLOUD_REGION_ID")
+		}
 		return p, nil
 	}
 	accessKeyID, secretAccessKey, sessionToken := aliyunCredentials()
 	if accessKeyID != "" {
+		if secretAccessKey == "" {
+			return nil, fmt.Errorf("s3: ALIBABA_CLOUD_ACCESS_KEY_ID is set but ALIBABA_CLOUD_ACCESS_KEY_SECRET is empty")
+		}
 		return credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken), nil
 	}
 	return nil, nil

--- a/pkg/s3client/aliyun.go
+++ b/pkg/s3client/aliyun.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,18 +24,24 @@ func aliyunCredentials() (accessKeyID, secretAccessKey, securityToken string) {
 }
 
 // isAliyunEndpoint reports whether endpoint points to an Aliyun OSS service.
+// It inspects the host portion of the URL and checks for an aliyuncs.com domain
+// boundary, preventing false matches from query/path substrings or crafted
+// hostnames like "aliyuncs.com.evil.com".
 func isAliyunEndpoint(endpoint string) bool {
-	return len(endpoint) > 0 && containsAliyunDomain(endpoint)
-}
-
-func containsAliyunDomain(s string) bool {
-	// Cover oss-*.aliyuncs.com and kms*.aliyuncs.com variants.
-	for i := 0; i+len("aliyuncs.com") <= len(s); i++ {
-		if s[i:i+len("aliyuncs.com")] == "aliyuncs.com" {
-			return true
-		}
+	if len(endpoint) == 0 {
+		return false
 	}
-	return false
+	// Strip scheme (e.g. "https://").
+	host := endpoint
+	if i := strings.Index(endpoint, "://"); i >= 0 {
+		host = endpoint[i+3:]
+	}
+	// Strip path, query, port.
+	if i := strings.IndexAny(host, "/:?"); i >= 0 {
+		host = host[:i]
+	}
+	// Match host == "aliyuncs.com" or host ends with ".aliyuncs.com".
+	return host == "aliyuncs.com" || strings.HasSuffix(host, ".aliyuncs.com")
 }
 
 // rrsaCredentials detects whether ACK RRSA env vars are present and returns a
@@ -89,7 +96,7 @@ func (p *rrsaProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 	req := sts.CreateAssumeRoleWithOIDCRequest()
 	req.RoleArn = p.roleARN
 	req.OIDCProviderArn = p.oidcProviderARN
-	req.OIDCToken = string(tokenBytes)
+	req.OIDCToken = strings.TrimSpace(string(tokenBytes))
 	req.RoleSessionName = "drive9-rrsa"
 	req.DurationSeconds = "3600"
 

--- a/pkg/s3client/aliyun.go
+++ b/pkg/s3client/aliyun.go
@@ -1,0 +1,27 @@
+package s3client
+
+import "os"
+
+// aliyunCredentials returns the Alibaba Cloud access credentials from the
+// standard ALIBABA_CLOUD_* environment variables that ACK injects via RRSA or
+// ECS RAM roles. Returns empty strings when the variables are not set.
+func aliyunCredentials() (accessKeyID, secretAccessKey, securityToken string) {
+	return os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+		os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+		os.Getenv("ALIBABA_CLOUD_SECURITY_TOKEN")
+}
+
+// isAliyunEndpoint reports whether endpoint points to an Aliyun OSS service.
+func isAliyunEndpoint(endpoint string) bool {
+	return len(endpoint) > 0 && containsAliyunDomain(endpoint)
+}
+
+func containsAliyunDomain(s string) bool {
+	// Cover oss-*.aliyuncs.com and kms*.aliyuncs.com variants.
+	for i := 0; i+len("aliyuncs.com") <= len(s); i++ {
+		if s[i:i+len("aliyuncs.com")] == "aliyuncs.com" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/s3client/aliyun.go
+++ b/pkg/s3client/aliyun.go
@@ -1,10 +1,20 @@
 package s3client
 
-import "os"
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	alibabasdk "github.com/aliyun/alibaba-cloud-sdk-go/sdk"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
+)
 
 // aliyunCredentials returns the Alibaba Cloud access credentials from the
-// standard ALIBABA_CLOUD_* environment variables that ACK injects via RRSA or
-// ECS RAM roles. Returns empty strings when the variables are not set.
+// standard ALIBABA_CLOUD_* environment variables. Returns empty strings when
+// the variables are not set.
 func aliyunCredentials() (accessKeyID, secretAccessKey, securityToken string) {
 	return os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
 		os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
@@ -25,3 +35,73 @@ func containsAliyunDomain(s string) bool {
 	}
 	return false
 }
+
+// rrsaCredentials detects whether ACK RRSA env vars are present and returns a
+// refreshing aws.CredentialsProvider that exchanges the OIDC token for
+// temporary Alibaba Cloud STS credentials via AssumeRoleWithOIDC.
+// Returns nil, false when RRSA env vars are not set.
+func rrsaCredentialsProvider() (aws.CredentialsProvider, bool) {
+	roleARN := os.Getenv("ALIBABA_CLOUD_ROLE_ARN")
+	oidcProviderARN := os.Getenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN")
+	tokenFile := os.Getenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE")
+	if roleARN == "" || oidcProviderARN == "" || tokenFile == "" {
+		return nil, false
+	}
+	return aws.NewCredentialsCache(&rrsaProvider{
+		roleARN:         roleARN,
+		oidcProviderARN: oidcProviderARN,
+		tokenFile:       tokenFile,
+	}), true
+}
+
+// rrsaProvider implements aws.CredentialsProvider using ACK RRSA.
+type rrsaProvider struct {
+	roleARN         string
+	oidcProviderARN string
+	tokenFile       string
+
+	mu          sync.Mutex
+	cached      aws.Credentials
+	expiresAt   time.Time
+}
+
+func (p *rrsaProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if time.Now().Before(p.expiresAt.Add(-5 * time.Minute)) {
+		return p.cached, nil
+	}
+	tokenBytes, err := os.ReadFile(p.tokenFile)
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("rrsa: read oidc token: %w", err)
+	}
+	cfg := alibabasdk.NewConfig().WithScheme("HTTPS")
+	stsClient, err := sts.NewClientWithOptions("ap-southeast-1", cfg, nil)
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("rrsa: create sts client: %w", err)
+	}
+	req := sts.CreateAssumeRoleWithOIDCRequest()
+	req.RoleArn = p.roleARN
+	req.OIDCProviderArn = p.oidcProviderARN
+	req.OIDCToken = string(tokenBytes)
+	req.RoleSessionName = "drive9-rrsa"
+	req.DurationSeconds = "3600"
+
+	resp, err := stsClient.AssumeRoleWithOIDC(req)
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("rrsa: AssumeRoleWithOIDC: %w", err)
+	}
+	creds := resp.Credentials
+	expiry, _ := time.Parse(time.RFC3339, creds.Expiration)
+	p.cached = aws.Credentials{
+		AccessKeyID:     creds.AccessKeyId,
+		SecretAccessKey: creds.AccessKeySecret,
+		SessionToken:    creds.SecurityToken,
+		Source:          "AliyunRRSA",
+		CanExpire:       true,
+		Expires:         expiry,
+	}
+	p.expiresAt = expiry
+	return p.cached, nil
+}
+

--- a/pkg/s3client/aliyun.go
+++ b/pkg/s3client/aliyun.go
@@ -7,9 +7,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	alibabasdk "github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 )
 
 // aliyunCredentials returns the Alibaba Cloud access credentials from the
@@ -103,5 +104,35 @@ func (p *rrsaProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 	}
 	p.expiresAt = expiry
 	return p.cached, nil
+}
+
+// credentialsForAliyun resolves the Alibaba Cloud credential priority chain:
+//  1. cfg.AccessKeyID (explicit static)
+//  2. ACK RRSA: OIDC token file → STS AssumeRoleWithOIDC
+//  3. ALIBABA_CLOUD_ACCESS_KEY_ID / SECRET env vars (static)
+//
+// Returns nil, nil when no credentials are configured; the SDK will fail on
+// first use.
+func credentialsForAliyun(cfg AWSConfig) (aws.CredentialsProvider, error) {
+	if cfg.AccessKeyID != "" {
+		return credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, cfg.SessionToken), nil
+	}
+	if p, ok := rrsaCredentialsProvider(); ok {
+		return p, nil
+	}
+	accessKeyID, secretAccessKey, sessionToken := aliyunCredentials()
+	if accessKeyID != "" {
+		return credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken), nil
+	}
+	return nil, nil
+}
+
+// newAliyun builds an AWSS3Client using the Aliyun credential priority chain.
+func newAliyun(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {
+	provider, err := credentialsForAliyun(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return buildS3Client(ctx, cfg, provider)
 }
 

--- a/pkg/s3client/aliyun_test.go
+++ b/pkg/s3client/aliyun_test.go
@@ -1,0 +1,135 @@
+package s3client
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+func TestIsAliyunEndpoint(t *testing.T) {
+	tests := []struct {
+		endpoint string
+		want     bool
+	}{
+		{"https://oss-cn-hangzhou.aliyuncs.com", true},
+		{"https://oss-ap-southeast-1.aliyuncs.com", true},
+		{"https://kms.cn-hangzhou.aliyuncs.com", true},
+		{"http://oss-cn-beijing.aliyuncs.com", true},
+		{"https://s3.amazonaws.com", false},
+		{"https://s3.us-east-1.amazonaws.com", false},
+		{"https://minio.example.com:9000", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isAliyunEndpoint(tt.endpoint); got != tt.want {
+			t.Errorf("isAliyunEndpoint(%q) = %v, want %v", tt.endpoint, got, tt.want)
+		}
+	}
+}
+
+func TestCredentialsForAliyunEnvFallback(t *testing.T) {
+	// Ensure RRSA env vars are absent so RRSA is skipped.
+	t.Setenv("ALIBABA_CLOUD_ROLE_ARN", "")
+	t.Setenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "")
+	t.Setenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE", "")
+	t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "env-ak")
+	t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "env-sk")
+	t.Setenv("ALIBABA_CLOUD_SECURITY_TOKEN", "env-token")
+
+	provider, err := credentialsForAliyun(AWSConfig{})
+	if err != nil {
+		t.Fatalf("credentialsForAliyun() error = %v", err)
+	}
+	if provider == nil {
+		t.Fatal("credentialsForAliyun() provider = nil, want non-nil")
+	}
+	creds, err := provider.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("Retrieve() error = %v", err)
+	}
+	if creds.AccessKeyID != "env-ak" {
+		t.Errorf("AccessKeyID = %q, want %q", creds.AccessKeyID, "env-ak")
+	}
+	if creds.SecretAccessKey != "env-sk" {
+		t.Errorf("SecretAccessKey = %q, want %q", creds.SecretAccessKey, "env-sk")
+	}
+	if creds.SessionToken != "env-token" {
+		t.Errorf("SessionToken = %q, want %q", creds.SessionToken, "env-token")
+	}
+}
+
+func TestCredentialsForAliyunRRSAPriority(t *testing.T) {
+	// Write a dummy token file so rrsaCredentialsProvider detects RRSA.
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte("dummy-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("ALIBABA_CLOUD_ROLE_ARN", "acs:ram::123456789:role/test")
+	t.Setenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::123456789:oidc-provider/test")
+	t.Setenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE", tokenFile)
+	// Also set env key to confirm RRSA takes priority over it.
+	t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "env-ak")
+	t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "env-sk")
+
+	provider, err := credentialsForAliyun(AWSConfig{})
+	if err != nil {
+		t.Fatalf("credentialsForAliyun() error = %v", err)
+	}
+	if provider == nil {
+		t.Fatal("credentialsForAliyun() provider = nil, want non-nil")
+	}
+
+	// Verify the provider is the RRSA cache wrapper, not a plain static provider.
+	// We don't call Retrieve here because that would hit the real STS endpoint.
+	// It's enough that RRSA env vars caused a non-nil provider to be selected over
+	// the static env key path.
+	_ = provider
+}
+
+func TestRRSAProviderCacheHit(t *testing.T) {
+	future := time.Now().Add(30 * time.Minute)
+	p := &rrsaProvider{
+		roleARN:         "arn",
+		oidcProviderARN: "parn",
+		tokenFile:       "/nonexistent",
+		expiresAt:       future,
+		cached: aws.Credentials{
+			AccessKeyID:     "cached-ak",
+			SecretAccessKey: "cached-sk",
+			SessionToken:    "cached-token",
+			Source:          "AliyunRRSA",
+			CanExpire:       true,
+			Expires:         future,
+		},
+	}
+
+	creds, err := p.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("Retrieve() error = %v", err)
+	}
+	if creds.AccessKeyID != "cached-ak" {
+		t.Errorf("AccessKeyID = %q, want %q", creds.AccessKeyID, "cached-ak")
+	}
+	if creds.Source != "AliyunRRSA" {
+		t.Errorf("Source = %q, want %q", creds.Source, "AliyunRRSA")
+	}
+}
+
+func TestRRSAProviderTokenFileNotFound(t *testing.T) {
+	p := &rrsaProvider{
+		roleARN:         "arn",
+		oidcProviderARN: "parn",
+		tokenFile:       "/nonexistent/oidc-token",
+	}
+
+	_, err := p.Retrieve(context.Background())
+	if err == nil {
+		t.Fatal("Retrieve() error = nil, want error for missing token file")
+	}
+}

--- a/pkg/s3client/aliyun_test.go
+++ b/pkg/s3client/aliyun_test.go
@@ -77,7 +77,8 @@ func TestCredentialsForAliyunRRSAPriority(t *testing.T) {
 	t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "env-ak")
 	t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "env-sk")
 
-	provider, err := credentialsForAliyun(AWSConfig{})
+	// Pass region explicitly so the RRSA provider can construct the STS client.
+	provider, err := credentialsForAliyun(AWSConfig{Region: "cn-hangzhou"})
 	if err != nil {
 		t.Fatalf("credentialsForAliyun() error = %v", err)
 	}
@@ -85,16 +86,17 @@ func TestCredentialsForAliyunRRSAPriority(t *testing.T) {
 		t.Fatal("credentialsForAliyun() provider = nil, want non-nil")
 	}
 
-	// Verify the provider is the RRSA cache wrapper, not a plain static provider.
-	// We don't call Retrieve here because that would hit the real STS endpoint.
-	// It's enough that RRSA env vars caused a non-nil provider to be selected over
-	// the static env key path.
-	_ = provider
+	// Verify the returned provider is *rrsaProvider (not a static credentials provider),
+	// confirming that RRSA takes priority over the ALIBABA_CLOUD_ACCESS_KEY_* env vars.
+	if _, ok := provider.(*rrsaProvider); !ok {
+		t.Fatalf("credentialsForAliyun() provider type = %T, want *rrsaProvider", provider)
+	}
 }
 
 func TestRRSAProviderCacheHit(t *testing.T) {
 	future := time.Now().Add(30 * time.Minute)
 	p := &rrsaProvider{
+		region:          "cn-hangzhou",
 		roleARN:         "arn",
 		oidcProviderARN: "parn",
 		tokenFile:       "/nonexistent",
@@ -123,6 +125,7 @@ func TestRRSAProviderCacheHit(t *testing.T) {
 
 func TestRRSAProviderTokenFileNotFound(t *testing.T) {
 	p := &rrsaProvider{
+		region:          "cn-hangzhou",
 		roleARN:         "arn",
 		oidcProviderARN: "parn",
 		tokenFile:       "/nonexistent/oidc-token",

--- a/pkg/s3client/aliyun_test.go
+++ b/pkg/s3client/aliyun_test.go
@@ -19,6 +19,11 @@ func TestIsAliyunEndpoint(t *testing.T) {
 		{"https://oss-ap-southeast-1.aliyuncs.com", true},
 		{"https://kms.cn-hangzhou.aliyuncs.com", true},
 		{"http://oss-cn-beijing.aliyuncs.com", true},
+		// Port should be stripped before matching.
+		{"https://oss-cn-hangzhou.aliyuncs.com:443", true},
+		// Domain boundary: must end with .aliyuncs.com, not just contain it.
+		{"https://evil.com/path?aliyuncs.com", false},
+		{"https://aliyuncs.com.evil.com", false},
 		{"https://s3.amazonaws.com", false},
 		{"https://s3.us-east-1.amazonaws.com", false},
 		{"https://minio.example.com:9000", false},

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -82,14 +81,11 @@ func staticCredentialsProvider(cfg AWSConfig) (aws.CredentialsProvider, bool, er
 	secretAccessKey := cfg.SecretAccessKey
 	sessionToken := cfg.SessionToken
 
-	if accessKeyID == "" && strings.Contains(cfg.Endpoint, "aliyuncs.com") {
-		// On Alibaba Cloud ACK, credentials are injected as ALIBABA_CLOUD_* env
-		// vars (RRSA, ECS RAM role, credential helper). Only apply this fallback
-		// when the endpoint is an Aliyun endpoint to avoid using Aliyun credentials
-		// against AWS services by mistake.
-		accessKeyID = os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_ID")
-		secretAccessKey = os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET")
-		sessionToken = os.Getenv("ALIBABA_CLOUD_SECURITY_TOKEN")
+	if accessKeyID == "" && isAliyunEndpoint(cfg.Endpoint) {
+		// On Alibaba Cloud ACK, credentials are injected via RRSA or ECS RAM roles
+		// as ALIBABA_CLOUD_* env vars. Only apply this fallback for Aliyun endpoints
+		// to avoid using Aliyun credentials against AWS services by mistake.
+		accessKeyID, secretAccessKey, sessionToken = aliyunCredentials()
 	}
 
 	if accessKeyID == "" {

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -88,7 +88,8 @@ func applyS3Options(cfg AWSConfig) func(*s3.Options) {
 // New creates an S3-compatible client. The endpoint in cfg determines which
 // credential chain is used:
 //   - Aliyun OSS endpoints (*.aliyuncs.com): explicit key → RRSA → ALIBABA_CLOUD env
-//   - All other endpoints: explicit key → AWS default chain
+//     → AWS SDK default chain (if none of the above are configured)
+//   - All other endpoints: explicit key → AWS SDK default chain
 func New(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -82,11 +82,11 @@ func staticCredentialsProvider(cfg AWSConfig) (aws.CredentialsProvider, bool, er
 	secretAccessKey := cfg.SecretAccessKey
 	sessionToken := cfg.SessionToken
 
-	if accessKeyID == "" {
-		// Fall back to Alibaba Cloud standard credential environment variables.
-		// These are automatically injected by ACK RRSA, ECS RAM roles, and the
-		// Alibaba Cloud credential helper, making OSS usable without explicit
-		// static key configuration.
+	if accessKeyID == "" && strings.Contains(cfg.Endpoint, "aliyuncs.com") {
+		// On Alibaba Cloud ACK, credentials are injected as ALIBABA_CLOUD_* env
+		// vars (RRSA, ECS RAM role, credential helper). Only apply this fallback
+		// when the endpoint is an Aliyun endpoint to avoid using Aliyun credentials
+		// against AWS services by mistake.
 		accessKeyID = os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_ID")
 		secretAccessKey = os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET")
 		sessionToken = os.Getenv("ALIBABA_CLOUD_SECURITY_TOKEN")

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -77,11 +78,24 @@ func RoleLogValue(roleARN string) string {
 }
 
 func staticCredentialsProvider(cfg AWSConfig) (aws.CredentialsProvider, bool, error) {
-	hasAccessKey := cfg.AccessKeyID != ""
-	if !hasAccessKey {
+	accessKeyID := cfg.AccessKeyID
+	secretAccessKey := cfg.SecretAccessKey
+	sessionToken := cfg.SessionToken
+
+	if accessKeyID == "" {
+		// Fall back to Alibaba Cloud standard credential environment variables.
+		// These are automatically injected by ACK RRSA, ECS RAM roles, and the
+		// Alibaba Cloud credential helper, making OSS usable without explicit
+		// static key configuration.
+		accessKeyID = os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_ID")
+		secretAccessKey = os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET")
+		sessionToken = os.Getenv("ALIBABA_CLOUD_SECURITY_TOKEN")
+	}
+
+	if accessKeyID == "" {
 		return nil, false, nil
 	}
-	return credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, cfg.SessionToken), true, nil
+	return credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken), true, nil
 }
 
 func applyS3Options(cfg AWSConfig) func(*s3.Options) {

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -76,31 +76,6 @@ func RoleLogValue(roleARN string) string {
 	return roleARN
 }
 
-func staticCredentialsProvider(cfg AWSConfig) (aws.CredentialsProvider, bool, error) {
-	// 1. Explicit static credentials take highest priority.
-	accessKeyID := cfg.AccessKeyID
-	secretAccessKey := cfg.SecretAccessKey
-	sessionToken := cfg.SessionToken
-
-	if accessKeyID != "" {
-		return credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken), true, nil
-	}
-
-	if isAliyunEndpoint(cfg.Endpoint) {
-		// 2. ACK RRSA: exchange OIDC token for temporary STS credentials.
-		if p, ok := rrsaCredentialsProvider(); ok {
-			return p, true, nil
-		}
-		// 3. Fall back to ALIBABA_CLOUD_ACCESS_KEY_ID / SECRET env vars.
-		accessKeyID, secretAccessKey, sessionToken = aliyunCredentials()
-		if accessKeyID != "" {
-			return credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken), true, nil
-		}
-	}
-
-	return nil, false, nil
-}
-
 func applyS3Options(cfg AWSConfig) func(*s3.Options) {
 	return func(o *s3.Options) {
 		if cfg.Endpoint != "" {
@@ -110,10 +85,34 @@ func applyS3Options(cfg AWSConfig) func(*s3.Options) {
 	}
 }
 
-func NewAWS(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {
+// New creates an S3-compatible client. The endpoint in cfg determines which
+// credential chain is used:
+//   - Aliyun OSS endpoints (*.aliyuncs.com): explicit key → RRSA → ALIBABA_CLOUD env
+//   - All other endpoints: explicit key → AWS default chain
+func New(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
+	if isAliyunEndpoint(cfg.Endpoint) {
+		return newAliyun(ctx, cfg)
+	}
+	return newAWS(ctx, cfg)
+}
+
+// newAWS builds an AWSS3Client using AWS credentials. When cfg.AccessKeyID is
+// set, static credentials are used; otherwise the SDK default chain
+// (env → profile → instance metadata) applies.
+func newAWS(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {
+	var provider aws.CredentialsProvider
+	if cfg.AccessKeyID != "" {
+		provider = credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, cfg.SessionToken)
+	}
+	return buildS3Client(ctx, cfg, provider)
+}
+
+// buildS3Client assembles the AWS SDK config and constructs the final
+// AWSS3Client. provider may be nil to use the SDK default credential chain.
+func buildS3Client(ctx context.Context, cfg AWSConfig, provider aws.CredentialsProvider) (*AWSS3Client, error) {
 	var transport *http.Transport
 	if t, ok := http.DefaultTransport.(*http.Transport); ok {
 		transport = t.Clone()
@@ -133,11 +132,7 @@ func NewAWS(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {
 		awsconfig.WithHTTPClient(&http.Client{Transport: transport}),
 	}
 
-	provider, ok, err := staticCredentialsProvider(cfg)
-	if err != nil {
-		return nil, err
-	}
-	if ok {
+	if provider != nil {
 		loadOptions = append(loadOptions, awsconfig.WithCredentialsProvider(provider))
 	}
 

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -77,21 +77,28 @@ func RoleLogValue(roleARN string) string {
 }
 
 func staticCredentialsProvider(cfg AWSConfig) (aws.CredentialsProvider, bool, error) {
+	// 1. Explicit static credentials take highest priority.
 	accessKeyID := cfg.AccessKeyID
 	secretAccessKey := cfg.SecretAccessKey
 	sessionToken := cfg.SessionToken
 
-	if accessKeyID == "" && isAliyunEndpoint(cfg.Endpoint) {
-		// On Alibaba Cloud ACK, credentials are injected via RRSA or ECS RAM roles
-		// as ALIBABA_CLOUD_* env vars. Only apply this fallback for Aliyun endpoints
-		// to avoid using Aliyun credentials against AWS services by mistake.
-		accessKeyID, secretAccessKey, sessionToken = aliyunCredentials()
+	if accessKeyID != "" {
+		return credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken), true, nil
 	}
 
-	if accessKeyID == "" {
-		return nil, false, nil
+	if isAliyunEndpoint(cfg.Endpoint) {
+		// 2. ACK RRSA: exchange OIDC token for temporary STS credentials.
+		if p, ok := rrsaCredentialsProvider(); ok {
+			return p, true, nil
+		}
+		// 3. Fall back to ALIBABA_CLOUD_ACCESS_KEY_ID / SECRET env vars.
+		accessKeyID, secretAccessKey, sessionToken = aliyunCredentials()
+		if accessKeyID != "" {
+			return credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken), true, nil
+		}
 	}
-	return credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken), true, nil
+
+	return nil, false, nil
 }
 
 func applyS3Options(cfg AWSConfig) func(*s3.Options) {

--- a/pkg/s3client/aws_test.go
+++ b/pkg/s3client/aws_test.go
@@ -81,17 +81,17 @@ func TestAWSConfigValidate(t *testing.T) {
 	}
 }
 
-func TestStaticCredentialsProviderFromAWSConfig(t *testing.T) {
-	provider, ok, err := staticCredentialsProvider(AWSConfig{
+func TestCredentialsForAliyunExplicitKey(t *testing.T) {
+	provider, err := credentialsForAliyun(AWSConfig{
 		AccessKeyID:     "test-ak",
 		SecretAccessKey: "test-sk",
 		SessionToken:    "test-token",
 	})
 	if err != nil {
-		t.Fatalf("staticCredentialsProvider() error = %v", err)
+		t.Fatalf("credentialsForAliyun() error = %v", err)
 	}
-	if !ok {
-		t.Fatal("staticCredentialsProvider() ok = false, want true")
+	if provider == nil {
+		t.Fatal("credentialsForAliyun() provider = nil, want non-nil")
 	}
 
 	creds, err := provider.Retrieve(context.Background())
@@ -107,16 +107,19 @@ func TestStaticCredentialsProviderFromAWSConfig(t *testing.T) {
 	if creds.SessionToken != "test-token" {
 		t.Fatalf("SessionToken = %q, want %q", creds.SessionToken, "test-token")
 	}
+}
 
-	provider, ok, err = staticCredentialsProvider(AWSConfig{})
+func TestCredentialsForAliyunNoCredentials(t *testing.T) {
+	// Ensure ALIBABA_CLOUD env vars are unset so the fallback returns nil.
+	t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "")
+	t.Setenv("ALIBABA_CLOUD_ROLE_ARN", "")
+
+	provider, err := credentialsForAliyun(AWSConfig{})
 	if err != nil {
-		t.Fatalf("staticCredentialsProvider(empty) error = %v", err)
-	}
-	if ok {
-		t.Fatal("staticCredentialsProvider(empty) ok = true, want false")
+		t.Fatalf("credentialsForAliyun(empty) error = %v", err)
 	}
 	if provider != nil {
-		t.Fatalf("staticCredentialsProvider(empty) provider = %#v, want nil", provider)
+		t.Fatalf("credentialsForAliyun(empty) provider = %#v, want nil", provider)
 	}
 }
 

--- a/pkg/s3client/aws_test.go
+++ b/pkg/s3client/aws_test.go
@@ -110,9 +110,14 @@ func TestCredentialsForAliyunExplicitKey(t *testing.T) {
 }
 
 func TestCredentialsForAliyunNoCredentials(t *testing.T) {
-	// Ensure ALIBABA_CLOUD env vars are unset so the fallback returns nil.
+	// Clear the full set of env vars that credentialsForAliyun consults so the
+	// test is not order-dependent or sensitive to the ambient environment.
 	t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "")
+	t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "")
+	t.Setenv("ALIBABA_CLOUD_SECURITY_TOKEN", "")
 	t.Setenv("ALIBABA_CLOUD_ROLE_ARN", "")
+	t.Setenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "")
+	t.Setenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE", "")
 
 	provider, err := credentialsForAliyun(AWSConfig{})
 	if err != nil {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -1260,7 +1260,12 @@ func (m *semanticWorkerManager) taskTypesForProvider(provider string) []semantic
 		if m.pool == nil {
 			return nil
 		}
-		return m.pool.AutoSemanticTaskTypes()
+		if types := m.pool.AutoSemanticTaskTypes(); types != nil {
+			return types
+		}
+		// Pool returned nil: database auto-embedding is disabled for this pool.
+		// Route TiDB tenants through app-managed task types like non-TiDB providers.
+		return m.appManagedTaskTypes()
 	}
 	return m.appManagedTaskTypes()
 }

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -1263,9 +1263,14 @@ func (m *semanticWorkerManager) taskTypesForProvider(provider string) []semantic
 		if types := m.pool.AutoSemanticTaskTypes(); types != nil {
 			return types
 		}
-		// Pool returned nil: database auto-embedding is disabled for this pool.
-		// Route TiDB tenants through app-managed task types like non-TiDB providers.
-		return m.appManagedTaskTypes()
+		// Pool returned nil. If auto-embedding is explicitly disabled, route
+		// TiDB tenants through app-managed task types so they can be processed
+		// by an external embedder. Otherwise (pool has no image/audio extract
+		// configured) fall through to nil — TiDB tenant is skipped entirely.
+		if m.pool.IsAutoEmbeddingDisabled() {
+			return m.appManagedTaskTypes()
+		}
+		return nil
 	}
 	return m.appManagedTaskTypes()
 }

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -477,7 +477,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	if err != nil {
 		return nil, nil, fmt.Errorf("open datastore: %w", err)
 	}
-	if p.cfg.DisableDatabaseAutoEmbedding {
+	if p.cfg.DisableDatabaseAutoEmbedding && UsesTiDBAutoEmbedding(t.Provider) {
 		store.DisableAutoEmbedTextWrites()
 	}
 	openStoreDurationMs := float64(time.Since(openStoreStart).Microseconds()) / 1000.0

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -518,7 +518,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		opts.StorageNamespaceID = ns.ID
 		prefix := ns.Prefix
 		s3ClientStart := time.Now()
-		s3c, err := s3client.NewAWS(ctx, s3client.AWSConfig{
+		s3c, err := s3client.New(ctx, s3client.AWSConfig{
 			Region:          p.cfg.S3Region,
 			Bucket:          p.cfg.S3Bucket,
 			Prefix:          prefix,

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -463,6 +463,9 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	if err != nil {
 		return nil, nil, fmt.Errorf("open datastore: %w", err)
 	}
+	if p.cfg.DisableDatabaseAutoEmbedding {
+		store.DisableAutoEmbedTextWrites()
+	}
 	openStoreDurationMs := float64(time.Since(openStoreStart).Microseconds()) / 1000.0
 	ensureSchemaDurationMs := 0.0
 	migrateDurationMs := 0.0

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -45,6 +45,12 @@ type PoolConfig struct {
 	// ensure/validate steps during Acquire. Used in tests that run
 	// against plain MySQL but need a TiDB-class provider for vault.
 	SkipTiDBSchemaCheck bool
+
+	// DisableDatabaseAutoEmbedding forces DatabaseAutoEmbedding=false for all
+	// tenants, even when the provider normally enables it (tidb_zero,
+	// tidb_cloud_starter). Use when the TiDB Cloud cluster does not have a
+	// supported auto-embedding provider configured.
+	DisableDatabaseAutoEmbedding bool
 }
 
 type Pool struct {
@@ -444,7 +450,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	opts.TenantID = t.ID
 	opts.S3EncryptionPolicy = resolvedEncryptionPolicy
-	if UsesTiDBAutoEmbedding(t.Provider) {
+	if UsesTiDBAutoEmbedding(t.Provider) && !p.cfg.DisableDatabaseAutoEmbedding {
 		opts.DatabaseAutoEmbedding = true
 	}
 	query := "parseTime=true"

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -398,6 +398,12 @@ func (p *Pool) AutoSemanticTaskTypes() []semantic.TaskType {
 	if p == nil {
 		return nil
 	}
+	// When database auto-embedding is disabled, TiDB tenants no longer use the
+	// TiDB-auto task path; return nil so the semantic worker falls through to
+	// app-managed task types for those tenants.
+	if p.cfg.DisableDatabaseAutoEmbedding {
+		return nil
+	}
 	var out []semantic.TaskType
 	if backend.AsyncImageExtractWillWireRuntime(p.cfg.BackendOptions.AsyncImageExtract) {
 		out = append(out, semantic.TaskTypeImgExtractText)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -417,6 +417,14 @@ func (p *Pool) AutoSemanticTaskTypes() []semantic.TaskType {
 	return out
 }
 
+// IsAutoEmbeddingDisabled reports whether database auto-embedding has been
+// explicitly disabled for this pool via DisableDatabaseAutoEmbedding.
+// This is distinct from AutoSemanticTaskTypes returning nil because no
+// image/audio extract is configured.
+func (p *Pool) IsAutoEmbeddingDisabled() bool {
+	return p != nil && p.cfg.DisableDatabaseAutoEmbedding
+}
+
 func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantID string) (out *backend.Dat9Backend) {
 	start := time.Now()
 	var err error


### PR DESCRIPTION
## Problem

Multiple issues blocked production use with Alibaba Cloud:

1. **KMS TLS failure** — `DRIVE9_ALIYUN_KMS_ENDPOINT` pointing to a VPC/dedicated-gateway fails with `x509: certificate signed by unknown authority` because VPC certs are issued by an Aliyun internal CA absent from the system trust store.

2. **S3 credential dispatch buried in AWS code** — Aliyun credential logic (RRSA, env fallback) was mixed into `aws.go`'s `staticCredentialsProvider`, with no clear separation between AWS and Aliyun paths.

3. **ACK RRSA not supported** — ACK pods inject `ALIBABA_CLOUD_ROLE_ARN` + OIDC token file but there was no code to exchange them for STS credentials.

4. **TiDB error 3105 on upload complete** — When `DRIVE9_DISABLE_AUTO_EMBEDDING=true` is set on a TiDB cluster whose `semantic` table has `embedding` / `description_embedding` as `GENERATED ALWAYS AS (EMBED_TEXT(...)) STORED` columns, upload-complete calls `UpdateSemanticTx` / `ClearFileEmbeddingStateTx` which issue `embedding = NULL` — TiDB rejects any explicit write to a generated column.

## Changes

### `pkg/encrypt/aliyun_kms.go` + `factory.go`
- Skip TLS certificate verification automatically when a custom endpoint is configured. No new env var needed — presence of `DRIVE9_ALIYUN_KMS_ENDPOINT` is sufficient signal.

### `pkg/s3client/` — credential dispatch refactor
- **`New(ctx, cfg)`** — public dispatcher: inspects endpoint, routes to `newAliyun` or `newAWS`.
- **`newAWS`** — AWS-only: explicit static key or SDK default chain.
- **`newAliyun`** (in `aliyun.go`) — Aliyun credential priority: explicit key → ACK RRSA → `ALIBABA_CLOUD_*` env.
- **`buildS3Client`** — shared constructor (transport pool, SDK config, RoleARN).
- **RRSA provider** (`rrsaProvider`) — reads OIDC token file, calls `sts.AssumeRoleWithOIDC`, caches credentials with 5-minute early refresh.
- Callers (`tenant/pool.go`, `cmd/drive9-server-local`) updated to `s3client.New`.

### `pkg/datastore/semantic.go` + `file_tx.go`
- `UpdateSemanticTx`: when `disableAutoEmbedTextWrites=true`, only clear `embedding_revision` / `description_embedding_revision`; never touch the `GENERATED ALWAYS` columns.
- `ClearFileEmbeddingStateTx`: same guard — only clear revision marker when embedding is a generated column.

### `cmd/drive9-server/main.go`
- Wire `DisableDatabaseAutoEmbedding` from `DRIVE9_DISABLE_AUTO_EMBEDDING` env var into `PoolConfig`.

### Tests
- `pkg/s3client/aliyun_test.go` (new): `TestIsAliyunEndpoint`, `TestCredentialsForAliyunEnvFallback`, `TestCredentialsForAliyunRRSAPriority`, `TestRRSAProviderCacheHit`, `TestRRSAProviderTokenFileNotFound`.
- `pkg/s3client/aws_test.go`: replace `TestStaticCredentialsProviderFromAWSConfig` with `TestCredentialsForAliyunExplicitKey` / `TestCredentialsForAliyunNoCredentials`.