### PR TITLE
fix: AutoSemanticTaskTypes preserves image/audio tasks when auto-embed disabled

### DIFF
--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -1293,7 +1293,22 @@ func (m *semanticWorkerManager) taskTypesForTarget(b *backend.Dat9Backend) []sem
 	if b.UsesDatabaseAutoEmbedding() {
 		return b.AutoSemanticTaskTypes()
 	}
-	return m.appManagedTaskTypes()
+	// Database auto-embedding is not active for this backend. Image/audio extract
+	// tasks are independent of EMBED_TEXT and should still be claimable when the
+	// runtime is wired. App-managed embed tasks are included if an embedder is
+	// configured.
+	var out []semantic.TaskType
+	if b.SupportsAsyncImageExtract() {
+		out = append(out, semantic.TaskTypeImgExtractText)
+	}
+	if b.SupportsAsyncAudioExtract() {
+		out = append(out, semantic.TaskTypeAudioExtractText)
+	}
+	out = append(out, m.appManagedTaskTypes()...)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func imageExtractTaskSpecFromSemanticTask(task *semantic.Task) backend.ImageExtractTaskSpec {

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -1789,3 +1789,89 @@ func waitForStoreTaskStatusByResource(t *testing.T, store *datastore.Store, reso
 	}
 	t.Fatalf("resource %s version %d status=%q, want %q", resourceID, version, status, want)
 }
+
+// newTestTenantPoolWithDisabledAutoEmbed creates a pool with DisableDatabaseAutoEmbedding=true
+// and optional BackendOptions.
+func newTestTenantPoolWithDisabledAutoEmbed(t *testing.T, opts backend.Options) *tenant.Pool {
+	t.Helper()
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{
+		S3Dir:                        mustTempDir(t),
+		PublicURL:                    "http://localhost",
+		BackendOptions:               opts,
+		DisableDatabaseAutoEmbedding: true,
+	}, enc)
+	t.Cleanup(func() { pool.Close() })
+	return pool
+}
+
+// TestPoolAutoSemanticTaskTypesDisabledAutoEmbed verifies that
+// Pool.AutoSemanticTaskTypes() still returns image/audio task types even when
+// DisableDatabaseAutoEmbedding=true. This is the regression case reported in
+// the startup error: the pool was returning nil, causing ValidateDurableAsync
+// ExtractRequiresSemanticWorker to fail.
+func TestPoolAutoSemanticTaskTypesDisabledAutoEmbed(t *testing.T) {
+	pool := newTestTenantPoolWithDisabledAutoEmbed(t, backend.Options{
+		AsyncImageExtract: backend.AsyncImageExtractOptions{Enabled: true},
+	})
+
+	types := pool.AutoSemanticTaskTypes()
+	if len(types) == 0 {
+		t.Fatal("AutoSemanticTaskTypes() = nil, want [img_extract_text] when image extract is enabled and auto-embed is disabled")
+	}
+	found := false
+	for _, tt := range types {
+		if tt == semantic.TaskTypeImgExtractText {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("AutoSemanticTaskTypes() = %v, want to include TaskTypeImgExtractText", types)
+	}
+	if pool.IsAutoEmbeddingDisabled() != true {
+		t.Fatal("IsAutoEmbeddingDisabled() = false, want true")
+	}
+}
+
+// TestSemanticWorkerTaskTypesForTargetDisabledAutoEmbedWithImageExtract verifies
+// that taskTypesForTarget includes img_extract_text/audio_extract_text for a
+// backend that has SupportsAsyncImageExtract/SupportsAsyncAudioExtract but
+// !UsesDatabaseAutoEmbedding (the DisableDatabaseAutoEmbedding=true case).
+func TestSemanticWorkerTaskTypesForTargetDisabledAutoEmbedWithImageExtract(t *testing.T) {
+	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{
+		AsyncImageExtract: backend.AsyncImageExtractOptions{
+			Enabled:   true,
+			Workers:   1,
+			QueueSize: 1,
+			Extractor: staticServerImageExtractor{text: "extract result"},
+		},
+	})
+
+	if b.UsesDatabaseAutoEmbedding() {
+		t.Skip("backend has database auto-embedding enabled; test targets the disabled path")
+	}
+	if !b.SupportsAsyncImageExtract() {
+		t.Fatal("SupportsAsyncImageExtract() = false; test requires image extract to be wired")
+	}
+
+	m := &semanticWorkerManager{}
+	m.opts.normalize()
+
+	types := m.taskTypesForTarget(b)
+	found := false
+	for _, tt := range types {
+		if tt == semantic.TaskTypeImgExtractText {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("taskTypesForTarget() = %v, want to include TaskTypeImgExtractText when SupportsAsyncImageExtract=true and !UsesDatabaseAutoEmbedding", types)
+	}
+}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -398,12 +398,6 @@ func (p *Pool) AutoSemanticTaskTypes() []semantic.TaskType {
 	if p == nil {
 		return nil
 	}
-	// When database auto-embedding is disabled, TiDB tenants no longer use the
-	// TiDB-auto task path; return nil so the semantic worker falls through to
-	// app-managed task types for those tenants.
-	if p.cfg.DisableDatabaseAutoEmbedding {
-		return nil
-	}
 	var out []semantic.TaskType
 	if backend.AsyncImageExtractWillWireRuntime(p.cfg.BackendOptions.AsyncImageExtract) {
 		out = append(out, semantic.TaskTypeImgExtractText)
@@ -411,6 +405,10 @@ func (p *Pool) AutoSemanticTaskTypes() []semantic.TaskType {
 	if backend.AsyncAudioExtractWillWireRuntime(p.cfg.BackendOptions.AsyncAudioExtract) {
 		out = append(out, semantic.TaskTypeAudioExtractText)
 	}
+	// When database auto-embedding is disabled, image/audio extract tasks are
+	// still valid (they don't depend on EMBED_TEXT). However the semantic worker
+	// routing for TiDB auto-embedding is suppressed, which is handled in
+	// taskTypesForProvider via IsAutoEmbeddingDisabled().
 	if len(out) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Problem

When `DRIVE9_DISABLE_AUTO_EMBEDDING=true` is set alongside async image/audio extract, the server fails at startup with:

```
semantic worker would not start but durable async image/audio extract is enabled;
configure DRIVE9_EMBED_* for app-managed embedding or fix worker/task-type routing
so img_extract_text and audio_extract_text can be claimed
```

## Root Cause

`Pool.AutoSemanticTaskTypes()` was returning `nil` unconditionally when `DisableDatabaseAutoEmbedding=true`. This also stripped `img_extract_text` and `audio_extract_text` from the pool's task types, even though those tasks are completely independent of `EMBED_TEXT` generated columns.

`newSemanticWorkerManager` found no viable task types → returned nil → `ValidateDurableAsyncExtractRequiresSemanticWorker` raised the startup error.

## Fix

Remove the early-return guard from `AutoSemanticTaskTypes`. Image/audio extract task types are always included when their runtime is wired. The TiDB auto-embedding routing suppression is already handled separately in `taskTypesForProvider` via `IsAutoEmbeddingDisabled()`.

Routing matrix after fix:

| Pool config | `disable=true` | TiDB tenant task types |
|---|---|---|
| has image/audio extract | yes | `[img_extract_text, audio_extract_text]` |
| no image/audio extract | yes | nil → fallthrough to `appManagedTaskTypes` |
| has image/audio extract | no | `[img_extract_text, audio_extract_text]` |
| no image/audio extract | no | nil → TiDB tenant skipped (original behavior) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of semantic task selection so asynchronous image/audio text-extraction tasks are correctly considered even when database auto-embedding is disabled, while keeping embedding routing suppression behavior unchanged. This increases consistency and reliability of background media extraction and embedding routing without changing public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->