### PR TITLE
Add FUSE all-workloads e2e flag

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -55,6 +55,9 @@ bash e2e/fuse-concurrency-stress.sh
 # Opt-in FUSE performance baseline metrics workload
 bash e2e/fuse-performance-baseline.sh
 
+# Strict FUSE release gate plus all optional FUSE workloads
+RUN_FUSE_ALL_WORKLOADS=1 bash e2e/fuse-release-gate.sh
+
 # Git workspace smoke (fast-blobless clone + common agent Git workloads)
 bash e2e/git-workspace-smoke-test.sh
 
@@ -117,6 +120,7 @@ DRIVE9_API_KEY='local-dev-key' bash e2e/api-smoke-test-existing-key.sh
 bash e2e/cli-smoke-test.sh
 bash e2e/fuse-smoke-test.sh
 bash e2e/git-workspace-smoke-test.sh
+RUN_FUSE_ALL_WORKLOADS=1 bash e2e/fuse-release-gate.sh
 bash e2e/smoke-all.sh
 ```
 
@@ -383,8 +387,13 @@ the layout captured by that run.
    host-specific FUSE failures
 7. Runs bounded concurrency stress workload only when
    `RUN_FUSE_CONCURRENCY_STRESS=1`
-8. Runs threshold-free FUSE performance baseline metrics only when
+8. Runs POSIX/fsx workload only when `RUN_FUSE_POSIX_FSX=1`
+9. Runs threshold-free FUSE performance baseline metrics only when
    `RUN_FUSE_PERFORMANCE_BASELINE=1`
+
+Set `RUN_FUSE_ALL_WORKLOADS=1` to default the optional concurrency,
+POSIX/fsx, and performance workloads to enabled in one release-gate command.
+Explicit per-workload env vars still take precedence.
 
 `local-e2e.yml` runs the warning-only performance compare before archiving the
 current metrics so a run cannot compare against itself. It runs concurrency
@@ -443,6 +452,7 @@ enabled.
 | `FUSE_UMOUNT_TIMEOUT` | `60s` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
 | `FUSE_CORRECTNESS_LARGE_MB` | `9` | `fuse-correctness-workload.sh` |
 | `FUSE_CORRECTNESS_KEEP_ARTIFACTS` | `0` | `fuse-correctness-workload.sh` |
+| `RUN_FUSE_ALL_WORKLOADS` | `0` | `fuse-release-gate.sh` |
 | `RUN_FUSE_SQLITE_CORRECTNESS` | `1` | `fuse-release-gate.sh` |
 | `FUSE_SQLITE_ROWS` | `64` | `fuse-sqlite-correctness.sh` |
 | `FUSE_SQLITE_CHURN_ROUNDS` | `4` | `fuse-sqlite-correctness.sh` |
@@ -459,6 +469,8 @@ enabled.
 | `FUSE_CONCURRENCY_PAYLOAD_KB` | `32` | `fuse-concurrency-stress.sh` |
 | `FUSE_CONCURRENCY_TIMEOUT_S` | `120` | `fuse-concurrency-stress.sh` |
 | `FUSE_CONCURRENCY_KEEP_ARTIFACTS` | `0` | `fuse-concurrency-stress.sh` |
+| `RUN_FUSE_CONCURRENCY_STRESS` | `0` | `fuse-release-gate.sh` |
+| `RUN_FUSE_POSIX_FSX` | `0` | `fuse-release-gate.sh` |
 | `RUN_FUSE_PERFORMANCE_BASELINE` | `0` | `fuse-release-gate.sh` |
 | `ARCHIVE_FUSE_PERFORMANCE_METRICS` | `0` (`1` in the scheduled daily heavy `local-e2e` run) | `local-e2e.yml` |
 | `COMPARE_FUSE_PERFORMANCE_METRICS` | `0` (`1` in the scheduled daily heavy `local-e2e` run) | `local-e2e.yml` |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -22,7 +22,7 @@ including local single-tenant validation via `drive9-server-local`.
 | `fuse-concurrency-stress.sh` | Real writable FUSE concurrency workload with parallel writers/readers, atomic rename, unlink churn, open-handle rename reads, and deterministic final manifest checks |
 | `fuse-posix-fsx-gate.sh` | Opt-in JuiceFS-style POSIX/fsx subset over real writable FUSE: deterministic random write/read/truncate, atomic rename replacement, unlink-open reads, directory fsync, final model hash, unmount, and remote snapshot parity |
 | `fuse-performance-baseline.sh` | Opt-in real writable FUSE baseline that records small-file, large-file, repeated large-read, and SQLite transaction/read metrics as JSON artifacts without hardcoded throughput thresholds; SQLite reads verify stored row payload bytes against row checksums |
-| `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, mount-log audit, manifest-based FUSE correctness workload, and SQLite rollback-journal correctness; set `RUN_FUSE_SQLITE_CORRECTNESS=0` to skip SQLite temporarily, `RUN_FUSE_CONCURRENCY_STRESS=1` to add bounded concurrency stress, `RUN_FUSE_POSIX_FSX=1` to add the POSIX/fsx subset, and `RUN_FUSE_PERFORMANCE_BASELINE=1` to add performance metrics |
+| `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, mount-log audit, manifest-based FUSE correctness workload, and SQLite rollback-journal correctness; set `RUN_FUSE_ALL_WORKLOADS=1` to add all optional release-gate workloads, `RUN_FUSE_SQLITE_CORRECTNESS=0` to skip SQLite temporarily, `RUN_FUSE_CONCURRENCY_STRESS=1` to add bounded concurrency stress, `RUN_FUSE_POSIX_FSX=1` to add the POSIX/fsx subset, and `RUN_FUSE_PERFORMANCE_BASELINE=1` to add performance metrics |
 | `git-workspace-smoke-test.sh` | Git workspace fast-blobless clone with coding-agent local overlay, batched tracked-file edits, ignored local-only paths, `git add`/`commit`, `git apply`, and remount restore |
 | `posix-permission-smoke-test.sh` | POSIX permission coverage: API mkdir/chmod mode propagation, CLI `fs chmod`, FUSE `chmod`/`mkdir -m` with remote and local stat parity |
 | `smoke-all.sh` | Runs API + CLI + FUSE + POSIX permission smoke scripts in sequence with aggregated pass/fail; set `RUN_GIT_WORKSPACE_SMOKE=1` to include Git workspace coverage |
@@ -79,6 +79,9 @@ bash e2e/git-workspace-smoke-test.sh
 
 # Strict FUSE release gate used by CI
 bash e2e/fuse-release-gate.sh
+
+# Strict FUSE release gate plus all optional FUSE workloads.
+RUN_FUSE_ALL_WORKLOADS=1 bash e2e/fuse-release-gate.sh
 
 # Add the concurrency stress workload to the strict FUSE release gate.
 RUN_FUSE_CONCURRENCY_STRESS=1 bash e2e/fuse-release-gate.sh
@@ -219,6 +222,10 @@ bash e2e/fuse-performance-baseline.sh
 # Strict FUSE release gate using the repo build.
 bash e2e/fuse-release-gate.sh
 
+# Strict FUSE release gate plus correctness, SQLite, concurrency, POSIX/fsx,
+# and performance workloads.
+RUN_FUSE_ALL_WORKLOADS=1 bash e2e/fuse-release-gate.sh
+
 # Strict FUSE release gate plus bounded concurrency stress.
 RUN_FUSE_CONCURRENCY_STRESS=1 bash e2e/fuse-release-gate.sh
 
@@ -293,7 +300,7 @@ CLI_SOURCE=official bash e2e/git-workspace-smoke-test.sh
 - `local-e2e.yml` does not run the performance baseline or heavy FUSE detectors on ordinary PR triggers. Use manual `workflow_dispatch` inputs `run_fuse_concurrency_stress=1`, `run_fuse_posix_fsx=1`, `run_fuse_sqlite_wal=1`, `run_fuse_sqlite_churn=1`, `run_fuse_sqlite_concurrency=1`, `run_fuse_performance_baseline=1`, and `compare_fuse_performance_metrics=1` to enable them on demand. The scheduled daily run enables all of these flags; concurrency stress and POSIX/fsx run as separate hard-fail steps after the release gate and metrics archive, and both are attempted so one failure does not hide the other workload's result.
 - Set `archive_fuse_performance_metrics=1` on manual `local-e2e` runs, or use the daily scheduled run, to copy `performance-metrics-*.json`, `performance-compare-*.json`, `performance-compare-*.md`, mount logs, and an archive manifest to the Drive9 CI workspace under `/benchmarks/fuse-performance/<YYYY>/<MM>/<DD>/<branch>/<sha>/<run_id>-<attempt>/`. The same files are still uploaded as the GitHub artifact `fuse-performance-baseline`.
 - Set `compare_fuse_performance_metrics=1` on manual `local-e2e` runs, or use the daily scheduled run, to compare current metrics against the latest Drive9 archive before archiving the current run. The compare is warning-only for regressions, missing historical baselines, and legacy baselines missing newly added workloads; it fails closed for invalid current metrics, broken Drive9 compare configuration, malformed archived manifests, and structurally invalid baseline metrics.
-- FUSE release-gate knobs are `FUSE_STRICT_PREREQS`, `RUN_FUSE_GIT_CLONE`, `FUSE_GIT_CLONE_URL`, `FUSE_GIT_CLONE_TIMEOUT_S`, `RUN_FUSE_UMOUNT_DURABLE`, `FUSE_UMOUNT_TIMEOUT`, `RUN_FUSE_LOG_AUDIT`, `RUN_FUSE_SQLITE_CORRECTNESS`, `RUN_FUSE_CONCURRENCY_STRESS`, `RUN_FUSE_POSIX_FSX`, `RUN_FUSE_PERFORMANCE_BASELINE`, and the FUSE correctness/SQLite/concurrency/POSIX/fsx/performance workload knobs. `local-e2e.yml` intentionally overrides `RUN_FUSE_CONCURRENCY_STRESS=0` and `RUN_FUSE_POSIX_FSX=0` for its release-gate step, then runs `fuse-concurrency-stress.sh` and `fuse-posix-fsx-gate.sh` separately after metrics artifact/archive steps.
+- FUSE release-gate knobs are `FUSE_STRICT_PREREQS`, `RUN_FUSE_GIT_CLONE`, `FUSE_GIT_CLONE_URL`, `FUSE_GIT_CLONE_TIMEOUT_S`, `RUN_FUSE_UMOUNT_DURABLE`, `FUSE_UMOUNT_TIMEOUT`, `RUN_FUSE_LOG_AUDIT`, `RUN_FUSE_ALL_WORKLOADS`, `RUN_FUSE_SQLITE_CORRECTNESS`, `RUN_FUSE_CONCURRENCY_STRESS`, `RUN_FUSE_POSIX_FSX`, `RUN_FUSE_PERFORMANCE_BASELINE`, and the FUSE correctness/SQLite/concurrency/POSIX/fsx/performance workload knobs. Set `RUN_FUSE_ALL_WORKLOADS=1` to default concurrency stress, POSIX/fsx, and performance baseline to enabled in one release-gate command; explicit per-workload env vars still take precedence. `local-e2e.yml` intentionally overrides `RUN_FUSE_CONCURRENCY_STRESS=0` and `RUN_FUSE_POSIX_FSX=0` for its release-gate step, then runs `fuse-concurrency-stress.sh` and `fuse-posix-fsx-gate.sh` separately after metrics artifact/archive steps.
 - Git workspace smoke defaults to `drive9`, `kimi-cli`, and `kimi-code`. Override with `GIT_WORKSPACE_REPOS='slug=https://example/repo.git,...'`.
 - Git workspace scenarios default to `agent_edit_add_commit,agent_patch_apply,sandbox_restore`; tune with `GIT_WORKSPACE_SCENARIOS`.
 - Git workspace file-count knobs are `GIT_WORKSPACE_EXISTING_FILES`, `GIT_WORKSPACE_NEW_FILES`, and `GIT_WORKSPACE_PATCH_FILES`.
@@ -305,4 +312,4 @@ CLI_SOURCE=official bash e2e/git-workspace-smoke-test.sh
 - CLI upload-limit boundary check is enabled by default via `RUN_CLI_UPLOAD_LIMIT_BOUNDARY=1`.
 - `CLI_UPLOAD_LIMIT_BYTES` controls the boundary value checked by CLI e2e (default `10737418240`).
 - `fuse-smoke-test.sh` will `SKIP` when host prerequisites are missing (for example no `/dev/fuse`) unless `FUSE_STRICT_PREREQS=1`.
-- `fuse-release-gate.sh` is the strict CI/release entry point and enables git clone/status/log, durable `umount --timeout` remount checks, mount-log audit, manifest read correctness, and SQLite rollback-journal correctness. Set `RUN_FUSE_SQLITE_CORRECTNESS=0` to skip SQLite temporarily while diagnosing host-specific FUSE failures, `RUN_FUSE_CONCURRENCY_STRESS=1` to add bounded concurrency stress, `RUN_FUSE_POSIX_FSX=1` to add fsx-style POSIX coverage, or `RUN_FUSE_PERFORMANCE_BASELINE=1` to add threshold-free performance metrics.
+- `fuse-release-gate.sh` is the strict CI/release entry point and enables git clone/status/log, durable `umount --timeout` remount checks, mount-log audit, manifest read correctness, and SQLite rollback-journal correctness. Set `RUN_FUSE_ALL_WORKLOADS=1` to add concurrency stress, fsx-style POSIX coverage, and threshold-free performance metrics in one command. Set `RUN_FUSE_SQLITE_CORRECTNESS=0` to skip SQLite temporarily while diagnosing host-specific FUSE failures, `RUN_FUSE_CONCURRENCY_STRESS=1` to add bounded concurrency stress, `RUN_FUSE_POSIX_FSX=1` to add fsx-style POSIX coverage, or `RUN_FUSE_PERFORMANCE_BASELINE=1` to add threshold-free performance metrics.

--- a/e2e/fuse-release-gate.sh
+++ b/e2e/fuse-release-gate.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Strict FUSE release gate. Unlike the general smoke script, this fails when
 # host FUSE prerequisites are unavailable and enables git/remount/log checks.
+# Set RUN_FUSE_ALL_WORKLOADS=1 to enable all optional release-gate FUSE
+# workloads in one command.
 
 set -euo pipefail
 
@@ -10,10 +12,20 @@ export FUSE_STRICT_PREREQS="${FUSE_STRICT_PREREQS:-1}"
 export RUN_FUSE_GIT_CLONE="${RUN_FUSE_GIT_CLONE:-1}"
 export RUN_FUSE_UMOUNT_DURABLE="${RUN_FUSE_UMOUNT_DURABLE:-1}"
 export RUN_FUSE_LOG_AUDIT="${RUN_FUSE_LOG_AUDIT:-1}"
-export RUN_FUSE_CONCURRENCY_STRESS="${RUN_FUSE_CONCURRENCY_STRESS:-0}"
-export RUN_FUSE_POSIX_FSX="${RUN_FUSE_POSIX_FSX:-0}"
+export RUN_FUSE_ALL_WORKLOADS="${RUN_FUSE_ALL_WORKLOADS:-0}"
+if [[ "$RUN_FUSE_ALL_WORKLOADS" = "1" ]]; then
+  : "${RUN_FUSE_CONCURRENCY_STRESS:=1}"
+  : "${RUN_FUSE_POSIX_FSX:=1}"
+  : "${RUN_FUSE_PERFORMANCE_BASELINE:=1}"
+else
+  : "${RUN_FUSE_CONCURRENCY_STRESS:=0}"
+  : "${RUN_FUSE_POSIX_FSX:=0}"
+  : "${RUN_FUSE_PERFORMANCE_BASELINE:=0}"
+fi
+export RUN_FUSE_CONCURRENCY_STRESS
+export RUN_FUSE_POSIX_FSX
 export RUN_FUSE_SQLITE_CORRECTNESS="${RUN_FUSE_SQLITE_CORRECTNESS:-1}"
-export RUN_FUSE_PERFORMANCE_BASELINE="${RUN_FUSE_PERFORMANCE_BASELINE:-0}"
+export RUN_FUSE_PERFORMANCE_BASELINE
 export FUSE_GIT_CLONE_URL="${FUSE_GIT_CLONE_URL:-https://github.com/octocat/Hello-World.git}"
 export FUSE_GIT_CLONE_TIMEOUT_S="${FUSE_GIT_CLONE_TIMEOUT_S:-180}"
 export FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-60s}"


### PR DESCRIPTION
## Summary
- add `RUN_FUSE_ALL_WORKLOADS=1` to `e2e/fuse-release-gate.sh`
- use the flag to enable concurrency stress, POSIX/fsx, and performance baseline workloads in one release-gate command
- update e2e README and AGENTS guidance with the new command and flag semantics

## Verification
- `bash -n e2e/fuse-release-gate.sh e2e/smoke-all.sh`
- `git diff --check -- e2e/fuse-release-gate.sh e2e/README.md e2e/AGENTS.md`

Note: did not run the full FUSE e2e workload locally because it requires a running local server and real FUSE environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `RUN_FUSE_ALL_WORKLOADS` environment variable flag enabling all optional test workloads in a single setting.

* **Documentation**
  * Updated release-gate workflow documentation with clearer instructions for running comprehensive test suites.
  * Added environment variable reference guide documenting concurrency stress, POSIX compatibility, and performance baseline options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->