### PR TITLE
Make drive9 mount run in the background by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,15 @@ drive9 fs rm -r :/old-dir
 
 ```bash
 mkdir -p ~/drive9
-drive9 mount :/ ~/drive9 --debug
+drive9 mount --debug :/ ~/drive9
 
-# In another shell:
 git clone https://github.com/mem9-ai/drive9.git ~/drive9/drive9
 
 drive9 umount ~/drive9
 ```
+
+`drive9 mount` starts in the background by default. Use `--foreground` to keep
+the mount process attached to the current terminal until it is unmounted.
 
 The mount command accepts an optional remote root:
 

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -30,12 +30,23 @@ const (
 	defaultFuseReadConcurrency         = 24
 	defaultFuseParallelReadConcurrency = 4
 	defaultFuseParallelReadBlockSizeMB = 1
+	defaultMountBackgroundReadyTimeout = 30 * time.Second
 )
 
 var (
 	errMountProcessStateStale  = errors.New("drive9 umount: stale mount process state")
 	errMountProcessStateUnsafe = errors.New("drive9 umount: unsafe mount process state")
 )
+
+type mountBackgroundRequest struct {
+	Args       []string
+	MountPoint string
+	Server     string
+	APIKey     string
+	Token      string
+}
+
+var startMountBackground = startMountBackgroundImpl
 
 // MountCmd handles the "drive9 mount" command.
 //
@@ -60,10 +71,10 @@ func MountCmd(args []string) error {
 	fmt.Fprint(os.Stderr, buildinfo.String("drive9 mount"))
 	if len(args) > 0 {
 		if args[0] == "vault" {
-			return VaultMountCmd(args[1:])
+			return vaultMountCmd(args[1:], true)
 		}
 	}
-	return fsMountCmd(args)
+	return fsMountCmdWithBackground(args, true)
 }
 
 // fsMountCmd is the pre-V2e writable fs mount entry point.
@@ -83,14 +94,21 @@ func MountCmd(args []string) error {
 // `vault reauth` is not part of M1; see docs/specs/vault-interaction-end-state.md
 // section 17.
 //
-// drive9fuse.Mount runs in-process (no fork/exec); credentials flow through
-// MountOptions{Server, APIKey, Token}, not through the child's environment.
-// This makes the resolver's Unsetenv-after-read mitigation safe for mount.
+// In foreground mode, drive9fuse.Mount runs in-process and credentials flow
+// through MountOptions{Server, APIKey, Token}. In default background mode,
+// this command starts a fresh `drive9 mount --foreground` child and passes the
+// resolved credential snapshot through that child's environment; the child
+// consumes and unsets those env vars through the normal resolver path.
 func fsMountCmd(args []string) error {
+	return fsMountCmdWithBackground(args, false)
+}
+
+func fsMountCmdWithBackground(args []string, background bool) error {
 	fs := flag.NewFlagSet("mount", flag.ExitOnError)
 	server := fs.String("server", "", "drive9 server URL (overrides $DRIVE9_SERVER and config)")
 	apiKey := fs.String("api-key", "", "owner API key (overrides $DRIVE9_API_KEY and config)")
 	mode := fs.String("mode", "auto", "mount mode: auto, fuse, or webdav")
+	foreground := fs.Bool("foreground", false, "run in the foreground and block until unmounted")
 	cacheDir := fs.String("cache-dir", "", "write-back cache directory (default ~/.cache/drive9)")
 	cacheSize := fs.Int("cache-size", 128, "read cache size in MB")
 	readCacheMaxFile := fs.Int64("read-cache-max-file-mb", 1, "maximum single file size admitted to read cache in MB")
@@ -291,6 +309,16 @@ func fsMountCmd(args []string) error {
 		})
 	}
 
+	if background && !*foreground {
+		return startMountBackground(mountBackgroundRequest{
+			Args:       append([]string(nil), args...),
+			MountPoint: mountPoint,
+			Server:     serverVal,
+			APIKey:     apiKeyVal,
+			Token:      tokenVal,
+		})
+	}
+
 	// WebDAV path: create client, start local WebDAV server, invoke mount_webdav.
 	if resolved == MountModeWebDAV {
 		var c *client.Client
@@ -402,6 +430,225 @@ func fsMountCmd(args []string) error {
 	}
 
 	return mountFuse(opts)
+}
+
+func startMountBackgroundImpl(req mountBackgroundRequest) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("drive9 mount: locate executable: %w", err)
+	}
+	logPath, logFile, err := openMountBackgroundLog(req.MountPoint)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = logFile.Close() }()
+
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		return fmt.Errorf("drive9 mount: open %s: %w", os.DevNull, err)
+	}
+	defer func() { _ = devNull.Close() }()
+
+	cmd := exec.Command(exe, foregroundMountCommandArgs(req.Args)...)
+	cmd.Env = mountBackgroundEnv(os.Environ(), req)
+	cmd.Stdin = devNull
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	configureMountBackgroundCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("drive9 mount: start background mount: %w", err)
+	}
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	if err := waitForBackgroundMountReady(req.MountPoint, cmd.Process.Pid, waitCh, logPath, defaultMountBackgroundReadyTimeout); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "drive9: mount running in background (pid: %d, log: %s)\n", cmd.Process.Pid, logPath)
+	fmt.Fprintf(os.Stderr, "drive9: unmount with `drive9 umount %s`\n", req.MountPoint)
+	return nil
+}
+
+func foregroundMountCommandArgs(args []string) []string {
+	out := []string{"mount"}
+	if len(args) > 0 && args[0] == "vault" {
+		out = append(out, "vault", "--foreground")
+		out = append(out, stripBackgroundOnlyCredentialArgs(args[1:])...)
+		return out
+	}
+	out = append(out, "--foreground")
+	out = append(out, stripBackgroundOnlyCredentialArgs(args)...)
+	return out
+}
+
+func stripBackgroundOnlyCredentialArgs(args []string) []string {
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--api-key" {
+			if i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(arg, "--api-key=") {
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
+}
+
+func mountBackgroundEnv(environ []string, req mountBackgroundRequest) []string {
+	out := make([]string, 0, len(environ)+2)
+	for _, kv := range environ {
+		if strings.HasPrefix(kv, EnvServer+"=") ||
+			strings.HasPrefix(kv, EnvAPIKey+"=") ||
+			strings.HasPrefix(kv, EnvVaultToken+"=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	if req.Server != "" {
+		out = append(out, EnvServer+"="+req.Server)
+	}
+	if req.Token != "" {
+		out = append(out, EnvVaultToken+"="+req.Token)
+	} else if req.APIKey != "" {
+		out = append(out, EnvAPIKey+"="+req.APIKey)
+	}
+	return out
+}
+
+func openMountBackgroundLog(mountPoint string) (string, *os.File, error) {
+	path, err := mountBackgroundLogPath(mountPoint)
+	if err != nil {
+		return "", nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", nil, fmt.Errorf("drive9 mount: open background log %s: %w", path, err)
+	}
+	_, _ = fmt.Fprintf(f, "\n--- drive9 mount background start %s ---\n", time.Now().Format(time.RFC3339))
+	return path, f, nil
+}
+
+func mountBackgroundLogPath(mountPoint string) (string, error) {
+	cacheRoot, err := os.UserCacheDir()
+	if err != nil || strings.TrimSpace(cacheRoot) == "" {
+		cacheRoot = os.TempDir()
+	}
+	dir := filepath.Join(cacheRoot, "drive9", "mount-logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("drive9 mount: create background log directory: %w", err)
+	}
+	canonical := filepath.Clean(mountPoint)
+	if abs, err := filepath.Abs(canonical); err == nil {
+		canonical = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(canonical); err == nil {
+		canonical = resolved
+	}
+	sum := sha256.Sum256([]byte(canonical))
+	return filepath.Join(dir, "mount-"+hex.EncodeToString(sum[:8])+".log"), nil
+}
+
+func waitForBackgroundMountReady(mountPoint string, pid int, waitCh <-chan error, logPath string, timeout time.Duration) error {
+	return waitForBackgroundMountReadyWithDeps(mountPoint, pid, waitCh, logPath, timeout, backgroundMountReadyDeps{
+		readProcessState: mountstate.ReadProcessState,
+		terminate:        terminateProcess,
+		now:              time.Now,
+		sleep:            time.Sleep,
+	})
+}
+
+type backgroundMountReadyDeps struct {
+	readProcessState func(string) (mountstate.ProcessState, string, error)
+	terminate        func(int, time.Duration) error
+	now              func() time.Time
+	sleep            func(time.Duration)
+}
+
+func waitForBackgroundMountReadyWithDeps(mountPoint string, pid int, waitCh <-chan error, logPath string, timeout time.Duration, deps backgroundMountReadyDeps) error {
+	if deps.readProcessState == nil {
+		deps.readProcessState = mountstate.ReadProcessState
+	}
+	if deps.terminate == nil {
+		deps.terminate = terminateProcess
+	}
+	if deps.now == nil {
+		deps.now = time.Now
+	}
+	if deps.sleep == nil {
+		deps.sleep = time.Sleep
+	}
+	stateMountPoint := backgroundMountStatePoint(mountPoint)
+	deadline := deps.now().Add(timeout)
+	for {
+		select {
+		case err := <-waitCh:
+			if err != nil {
+				return fmt.Errorf("drive9 mount: background mount exited before becoming ready: %w (log: %s)", err, logPath)
+			}
+			return fmt.Errorf("drive9 mount: background mount exited before becoming ready (log: %s)", logPath)
+		default:
+		}
+
+		state, _, err := deps.readProcessState(stateMountPoint)
+		if err == nil {
+			if state.PID == pid {
+				return nil
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			if stopErr := stopBackgroundMountProcess(pid, waitCh, deps, 5*time.Second); stopErr != nil {
+				return fmt.Errorf("drive9 mount: read mount process state: %w; failed to stop background mount pid %d: %v", err, pid, stopErr)
+			}
+			return fmt.Errorf("drive9 mount: read mount process state: %w", err)
+		}
+
+		if !deps.now().Before(deadline) {
+			_ = stopBackgroundMountProcess(pid, waitCh, deps, 5*time.Second)
+			return fmt.Errorf("drive9 mount: timed out waiting for background mount to become ready after %s (log: %s)", timeout, logPath)
+		}
+		deps.sleep(50 * time.Millisecond)
+	}
+}
+
+func stopBackgroundMountProcess(pid int, waitCh <-chan error, deps backgroundMountReadyDeps, timeout time.Duration) error {
+	var stopErr error
+	if deps.terminate != nil {
+		stopErr = deps.terminate(pid, timeout)
+	}
+	if waitCh == nil {
+		return stopErr
+	}
+	deadline := deps.now().Add(timeout)
+	for {
+		select {
+		case <-waitCh:
+			return stopErr
+		default:
+		}
+		if timeout <= 0 || !deps.now().Before(deadline) {
+			if stopErr != nil {
+				return stopErr
+			}
+			return fmt.Errorf("background mount pid %d did not exit after stop request", pid)
+		}
+		deps.sleep(10 * time.Millisecond)
+	}
+}
+
+func backgroundMountStatePoint(mountPoint string) string {
+	if runtime.GOOS == "windows" {
+		if stateMountPoint, err := webdavMountStatePoint(runtime.GOOS, mountPoint); err == nil {
+			return stateMountPoint
+		}
+	}
+	return mountPoint
 }
 
 // newWebDAVHandler creates an http.Handler that serves drive9 content over WebDAV.
@@ -730,12 +977,6 @@ func runUmount(args []string, deps umountDeps) error {
 		return err
 	}
 	runErr := deps.run(argv)
-	if deps.goos != "windows" && runErr != nil {
-		return runErr
-	}
-	if deps.goos != "windows" && *waitTimeout == 0 {
-		return runPackAfterUnmountIfRequested(deps, packState, packArchiveArgs, packPaths)
-	}
 	if deps.goos == "windows" {
 		var (
 			state mountstate.ProcessState
@@ -805,28 +1046,87 @@ func runUmount(args []string, deps umountDeps) error {
 		return runErr
 	}
 
-	pid, path, err := deps.readPID(stateMountPoint)
+	state, path, stateOK, err := readUnmountProcessState(deps, stateMountPoint)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			if runErr == nil {
-				if err := runPackAfterUnmountIfRequested(deps, packState, packArchiveArgs, packPaths); err != nil {
-					return err
-				}
-			}
-			return runErr
-		}
 		if runErr != nil {
 			return runErr
 		}
 		return err
 	}
+	if stateOK && state.MountKind == mountstate.MountKindWebDAV {
+		if deps.terminateState != nil {
+			err = deps.terminateState(state, *waitTimeout)
+		} else if deps.terminate != nil {
+			err = deps.terminate(state.PID, *waitTimeout)
+		} else {
+			err = fmt.Errorf("drive9 umount: no process terminator configured for WebDAV mount")
+		}
+		if err != nil {
+			if errors.Is(err, errMountProcessStateStale) || errors.Is(err, errMountProcessStateUnsafe) {
+				if path != "" && deps.remove != nil {
+					if removeErr := deps.remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) && runErr == nil {
+						return fmt.Errorf("drive9 umount: remove mount pid file %s: %w", path, removeErr)
+					}
+				}
+				if errors.Is(err, errMountProcessStateStale) {
+					if deps.printErrf != nil {
+						deps.printErrf("drive9 umount: removed stale mount pid file %s without terminating any process\n", path)
+					}
+					return runErr
+				}
+			}
+			if runErr != nil {
+				return runErr
+			}
+			return fmt.Errorf("%w (pid file: %s)", err, path)
+		}
+		if path != "" && deps.remove != nil {
+			if err := deps.remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				if runErr != nil {
+					return runErr
+				}
+				return fmt.Errorf("drive9 umount: remove mount pid file %s: %w", path, err)
+			}
+		}
+		if runErr != nil {
+			return runErr
+		}
+		return runPackAfterUnmountIfRequested(deps, packState, packArchiveArgs, packPaths)
+	}
+	if runErr != nil {
+		return runErr
+	}
 	if *waitTimeout == 0 {
 		return runPackAfterUnmountIfRequested(deps, packState, packArchiveArgs, packPaths)
 	}
-	if err := waitForPIDExit(pid, *waitTimeout, deps); err != nil {
+	if !stateOK {
+		return runPackAfterUnmountIfRequested(deps, packState, packArchiveArgs, packPaths)
+	}
+	if err := waitForPIDExit(state.PID, *waitTimeout, deps); err != nil {
 		return fmt.Errorf("%w (pid file: %s)", err, path)
 	}
 	return runPackAfterUnmountIfRequested(deps, packState, packArchiveArgs, packPaths)
+}
+
+func readUnmountProcessState(deps umountDeps, mountPoint string) (mountstate.ProcessState, string, bool, error) {
+	if deps.readProcessState != nil {
+		state, path, err := deps.readProcessState(mountPoint)
+		if err == nil {
+			return state, path, true, nil
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			return mountstate.ProcessState{}, path, false, nil
+		}
+		return mountstate.ProcessState{}, path, false, err
+	}
+	pid, path, err := deps.readPID(mountPoint)
+	if err == nil {
+		return mountstate.ProcessState{PID: pid}, path, true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return mountstate.ProcessState{}, path, false, nil
+	}
+	return mountstate.ProcessState{}, path, false, err
 }
 
 func validateUmountPackState(state mountstate.ProcessState) error {

--- a/cmd/drive9/cli/mount_background_unix.go
+++ b/cmd/drive9/cli/mount_background_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureMountBackgroundCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/cmd/drive9/cli/mount_background_windows.go
+++ b/cmd/drive9/cli/mount_background_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package cli
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const (
+	windowsDetachedProcess       = 0x00000008
+	windowsCreateNewProcessGroup = 0x00000200
+)
+
+func configureMountBackgroundCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windowsDetachedProcess | windowsCreateNewProcessGroup,
+		HideWindow:    true,
+	}
+}

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -26,6 +26,15 @@ func fakeLookPath(binMap map[string]bool) func(string) (string, error) {
 	}
 }
 
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
 func TestUmountArgvDarwin(t *testing.T) {
 	got, err := umountArgv("darwin", fakeLookPath(nil), "/mnt/drive9")
 	if err != nil {
@@ -186,9 +195,12 @@ func TestRunUmountDoesNotBlockOnStalePID(t *testing.T) {
 		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
 		run:      func([]string) error { return nil },
 		readProcessState: func(string) (mountstate.ProcessState, string, error) {
-			return mountstate.ProcessState{}, "", errors.New("readProcessState should not be called on non-Windows")
+			return mountstate.ProcessState{PID: 1234}, "/tmp/drive9.pid", nil
 		},
-		readPID: func(string) (int, string, error) { return 1234, "/tmp/drive9.pid", nil },
+		readPID: func(string) (int, string, error) {
+			t.Fatal("readPID should not be called when process state is available")
+			return 0, "", nil
+		},
 		pidAlive: func(int) bool {
 			aliveCalls++
 			return false
@@ -212,9 +224,12 @@ func TestRunUmountNoPIDFileReturnsSuccess(t *testing.T) {
 		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
 		run:      func([]string) error { return nil },
 		readProcessState: func(string) (mountstate.ProcessState, string, error) {
-			return mountstate.ProcessState{}, "", errors.New("readProcessState should not be called on non-Windows")
+			return mountstate.ProcessState{}, "/tmp/drive9.pid", os.ErrNotExist
 		},
-		readPID:   func(string) (int, string, error) { return 0, "/tmp/drive9.pid", os.ErrNotExist },
+		readPID: func(string) (int, string, error) {
+			t.Fatal("readPID should not be called when process state reader reports no file")
+			return 0, "", nil
+		},
 		terminate: func(int, time.Duration) error { t.Fatal("terminate should not be called without pid file"); return nil },
 		remove:    func(string) error { t.Fatal("remove should not be called without pid file"); return nil },
 		pidAlive:  func(int) bool { t.Fatal("pidAlive should not be called without pid file"); return false },
@@ -228,16 +243,16 @@ func TestRunUmountNoPIDFileReturnsSuccess(t *testing.T) {
 	}
 }
 
-func TestRunUmountNonWindowsTimeoutZeroSkipsPIDRead(t *testing.T) {
+func TestRunUmountNonWindowsTimeoutZeroSkipsPIDWait(t *testing.T) {
 	deps := umountDeps{
 		goos:     "linux",
 		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
 		run:      func([]string) error { return nil },
 		readProcessState: func(string) (mountstate.ProcessState, string, error) {
-			return mountstate.ProcessState{}, "", errors.New("readProcessState should not be called on non-Windows")
+			return mountstate.ProcessState{}, "/tmp/drive9.pid", os.ErrNotExist
 		},
 		readPID: func(string) (int, string, error) {
-			t.Fatal("readPID should not be called when timeout is zero on non-Windows")
+			t.Fatal("readPID should not be called when timeout is zero on non-Windows FUSE path")
 			return 0, "", nil
 		},
 		terminate: func(int, time.Duration) error {
@@ -259,6 +274,137 @@ func TestRunUmountNonWindowsTimeoutZeroSkipsPIDRead(t *testing.T) {
 
 	if err := runUmount([]string{"--timeout", "0", "/mnt/drive9"}, deps); err != nil {
 		t.Fatalf("runUmount: %v", err)
+	}
+}
+
+func TestRunUmountTerminatesNonWindowsWebDAVBridge(t *testing.T) {
+	runCalls := 0
+	stateReads := 0
+	terminateCalls := 0
+	removeCalls := 0
+	deps := umountDeps{
+		goos:     "linux",
+		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
+		run: func(argv []string) error {
+			runCalls++
+			want := []string{"fusermount3", "-u", "/mnt/drive9"}
+			if !reflect.DeepEqual(argv, want) {
+				t.Fatalf("argv = %v, want %v", argv, want)
+			}
+			return nil
+		},
+		readProcessState: func(mountPoint string) (mountstate.ProcessState, string, error) {
+			stateReads++
+			if mountPoint != "/mnt/drive9" {
+				t.Fatalf("mountPoint = %q", mountPoint)
+			}
+			return mountstate.ProcessState{PID: 1234, MountKind: mountstate.MountKindWebDAV}, "/tmp/drive9-webdav.pid", nil
+		},
+		readPID: func(string) (int, string, error) {
+			t.Fatal("readPID should not be called when process state is available")
+			return 0, "", nil
+		},
+		terminateState: func(state mountstate.ProcessState, waitTimeout time.Duration) error {
+			terminateCalls++
+			if state.PID != 1234 {
+				t.Fatalf("pid = %d, want 1234", state.PID)
+			}
+			if waitTimeout != 250*time.Millisecond {
+				t.Fatalf("waitTimeout = %s, want 250ms", waitTimeout)
+			}
+			return nil
+		},
+		remove: func(path string) error {
+			removeCalls++
+			if path != "/tmp/drive9-webdav.pid" {
+				t.Fatalf("path = %q, want /tmp/drive9-webdav.pid", path)
+			}
+			return nil
+		},
+		pidAlive:  func(int) bool { t.Fatal("pidAlive should not be called for WebDAV bridge termination"); return false },
+		now:       time.Now,
+		sleep:     func(time.Duration) {},
+		printErrf: func(string, ...any) {},
+	}
+
+	if err := runUmount([]string{"--timeout", "250ms", "/mnt/drive9"}, deps); err != nil {
+		t.Fatalf("runUmount: %v", err)
+	}
+	if runCalls != 1 {
+		t.Fatalf("runCalls = %d, want 1", runCalls)
+	}
+	if stateReads < 1 {
+		t.Fatal("readProcessState was not called")
+	}
+	if terminateCalls != 1 {
+		t.Fatalf("terminateCalls = %d, want 1", terminateCalls)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("removeCalls = %d, want 1", removeCalls)
+	}
+}
+
+func TestRunUmountNonWindowsWebDAVStillCleansUpAfterUnmountFailure(t *testing.T) {
+	runErr := errors.New("fusermount failed")
+	runCalls := 0
+	terminateCalls := 0
+	removeCalls := 0
+	deps := umountDeps{
+		goos:     "linux",
+		lookPath: fakeLookPath(map[string]bool{"fusermount3": true}),
+		run: func(argv []string) error {
+			runCalls++
+			want := []string{"fusermount3", "-u", "/mnt/drive9"}
+			if !reflect.DeepEqual(argv, want) {
+				t.Fatalf("argv = %v, want %v", argv, want)
+			}
+			return runErr
+		},
+		readProcessState: func(mountPoint string) (mountstate.ProcessState, string, error) {
+			if mountPoint != "/mnt/drive9" {
+				t.Fatalf("mountPoint = %q", mountPoint)
+			}
+			return mountstate.ProcessState{
+				PID:          1234,
+				CreationTime: 99,
+				MountKind:    mountstate.MountKindWebDAV,
+			}, "/tmp/drive9-webdav.pid", nil
+		},
+		terminateState: func(state mountstate.ProcessState, waitTimeout time.Duration) error {
+			terminateCalls++
+			if state.PID != 1234 {
+				t.Fatalf("pid = %d, want 1234", state.PID)
+			}
+			if waitTimeout != 250*time.Millisecond {
+				t.Fatalf("waitTimeout = %s, want 250ms", waitTimeout)
+			}
+			return nil
+		},
+		remove: func(path string) error {
+			removeCalls++
+			if path != "/tmp/drive9-webdav.pid" {
+				t.Fatalf("path = %q, want /tmp/drive9-webdav.pid", path)
+			}
+			return nil
+		},
+		pidAlive:  func(int) bool { t.Fatal("pidAlive should not be called for WebDAV bridge termination"); return false },
+		now:       time.Now,
+		sleep:     func(time.Duration) {},
+		printErrf: func(string, ...any) {},
+	}
+
+	err := runUmount([]string{"--timeout", "250ms", "/mnt/drive9"}, deps)
+	if !errors.Is(err, runErr) {
+		t.Fatalf("err = %v, want %v", err, runErr)
+	}
+	if runCalls != 1 {
+		t.Fatalf("runCalls = %d, want 1", runCalls)
+	}
+	if terminateCalls != 1 {
+		t.Fatalf("terminateCalls = %d, want 1", terminateCalls)
+	}
+	if removeCalls != 1 {
+		t.Fatalf("removeCalls = %d, want 1", removeCalls)
 	}
 }
 
@@ -426,6 +572,31 @@ func TestTerminateProcessWaitsAfterSuccessfulKill(t *testing.T) {
 		t.Fatal("waitForProcessExit was not called after successful kill")
 	}
 	_, _ = cmd.Process.Wait()
+}
+
+func TestTerminateMountProcessRejectsUnsafeWebDAVState(t *testing.T) {
+	err := terminateMountProcess(mountstate.ProcessState{
+		PID:       os.Getpid(),
+		MountKind: mountstate.MountKindWebDAV,
+	}, time.Millisecond)
+	if !errors.Is(err, errMountProcessStateUnsafe) {
+		t.Fatalf("err = %v, want unsafe mount process state", err)
+	}
+}
+
+func TestTerminateMountProcessRejectsStaleWebDAVState(t *testing.T) {
+	creationTime, err := processCreationTimeByPID(os.Getpid())
+	if err != nil {
+		t.Fatalf("processCreationTimeByPID: %v", err)
+	}
+	err = terminateMountProcess(mountstate.ProcessState{
+		PID:          os.Getpid(),
+		CreationTime: creationTime + 1,
+		MountKind:    mountstate.MountKindWebDAV,
+	}, time.Millisecond)
+	if !errors.Is(err, errMountProcessStateStale) {
+		t.Fatalf("err = %v, want stale mount process state", err)
+	}
 }
 
 func TestRunUmountWindowsStalePIDFileDoesNotTerminateProcess(t *testing.T) {
@@ -660,6 +831,190 @@ func TestResolveMountCredentials_MissingServer(t *testing.T) {
 	}
 }
 
+func TestMountCmdStartsBackgroundByDefault(t *testing.T) {
+	oldStartMountBackground := startMountBackground
+	oldMountFuse := mountFuse
+	t.Cleanup(func() {
+		startMountBackground = oldStartMountBackground
+		mountFuse = oldMountFuse
+	})
+
+	var got mountBackgroundRequest
+	startMountBackground = func(req mountBackgroundRequest) error {
+		got = req
+		return nil
+	}
+	mountFuse = func(*mountFuseOptions) error {
+		t.Fatal("mountFuse should not run in-process for default background mount")
+		return nil
+	}
+
+	mountPoint := t.TempDir()
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--profile", "interactive",
+		mountPoint,
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got.MountPoint != mountPoint {
+		t.Fatalf("MountPoint = %q, want %q", got.MountPoint, mountPoint)
+	}
+	if got.Server != "https://drive9.example" || got.APIKey != "sk-test" || got.Token != "" {
+		t.Fatalf("background credentials = server %q api %q token %q", got.Server, got.APIKey, got.Token)
+	}
+	if containsString(got.Args, "--foreground") {
+		t.Fatalf("background request args = %v, should preserve original user args", got.Args)
+	}
+}
+
+func TestMountCmdVaultStartsBackgroundByDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("vault FUSE mounts are unsupported on Windows")
+	}
+	oldStartMountBackground := startMountBackground
+	oldMountVault := mountVault
+	t.Cleanup(func() {
+		startMountBackground = oldStartMountBackground
+		mountVault = oldMountVault
+	})
+
+	var got mountBackgroundRequest
+	startMountBackground = func(req mountBackgroundRequest) error {
+		got = req
+		return nil
+	}
+	mountVault = func(*vaultMountOptions) error {
+		t.Fatal("mountVault should not run in-process for default background vault mount")
+		return nil
+	}
+
+	mountPoint := t.TempDir()
+	err := MountCmd([]string{
+		"vault",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		mountPoint,
+	})
+	if err != nil {
+		t.Fatalf("MountCmd vault: %v", err)
+	}
+	if got.MountPoint != mountPoint {
+		t.Fatalf("MountPoint = %q, want %q", got.MountPoint, mountPoint)
+	}
+	wantArgs := []string{"vault", "--server", "https://drive9.example", "--api-key", "sk-test", mountPoint}
+	if !reflect.DeepEqual(got.Args, wantArgs) {
+		t.Fatalf("Args = %v, want %v", got.Args, wantArgs)
+	}
+}
+
+func TestForegroundMountCommandArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "fs",
+			in:   []string{"--mode", "fuse", "/mnt/drive9"},
+			want: []string{"mount", "--foreground", "--mode", "fuse", "/mnt/drive9"},
+		},
+		{
+			name: "vault",
+			in:   []string{"vault", "--dir-ttl", "1s", "/mnt/vault"},
+			want: []string{"mount", "vault", "--foreground", "--dir-ttl", "1s", "/mnt/vault"},
+		},
+		{
+			name: "fs strip split api key",
+			in:   []string{"--mode", "fuse", "--api-key", "sk-secret", "--server", "https://drive9.example", "/mnt/drive9"},
+			want: []string{"mount", "--foreground", "--mode", "fuse", "--server", "https://drive9.example", "/mnt/drive9"},
+		},
+		{
+			name: "fs strip equals api key",
+			in:   []string{"--api-key=sk-secret", "--debug", "/mnt/drive9"},
+			want: []string{"mount", "--foreground", "--debug", "/mnt/drive9"},
+		},
+		{
+			name: "vault strip api key",
+			in:   []string{"vault", "--api-key", "sk-secret", "--dir-ttl", "1s", "/mnt/vault"},
+			want: []string{"mount", "vault", "--foreground", "--dir-ttl", "1s", "/mnt/vault"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := foregroundMountCommandArgs(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("foregroundMountCommandArgs(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaitForBackgroundMountReadyStopsChildOnStateReadError(t *testing.T) {
+	readErr := errors.New("invalid mount state")
+	mountPoint := t.TempDir()
+	stateMountPoint := backgroundMountStatePoint(mountPoint)
+	waitCh := make(chan error, 1)
+	now := time.Unix(100, 0)
+	terminateCalls := 0
+	deps := backgroundMountReadyDeps{
+		readProcessState: func(gotMountPoint string) (mountstate.ProcessState, string, error) {
+			if gotMountPoint != stateMountPoint {
+				t.Fatalf("mountPoint = %q, want %q", gotMountPoint, stateMountPoint)
+			}
+			return mountstate.ProcessState{}, "", readErr
+		},
+		terminate: func(pid int, waitTimeout time.Duration) error {
+			terminateCalls++
+			if pid != 1234 {
+				t.Fatalf("pid = %d, want 1234", pid)
+			}
+			if waitTimeout != 5*time.Second {
+				t.Fatalf("waitTimeout = %s, want 5s", waitTimeout)
+			}
+			waitCh <- errors.New("signal: terminated")
+			return nil
+		},
+		now:   func() time.Time { return now },
+		sleep: func(d time.Duration) { now = now.Add(d) },
+	}
+
+	err := waitForBackgroundMountReadyWithDeps(mountPoint, 1234, waitCh, "/tmp/drive9.log", time.Second, deps)
+	if !errors.Is(err, readErr) {
+		t.Fatalf("err = %v, want %v", err, readErr)
+	}
+	if terminateCalls != 1 {
+		t.Fatalf("terminateCalls = %d, want 1", terminateCalls)
+	}
+	select {
+	case leftover := <-waitCh:
+		t.Fatalf("waitCh was not drained after termination: %v", leftover)
+	default:
+	}
+}
+
+func TestMountBackgroundEnvSnapshotsCredentials(t *testing.T) {
+	got := mountBackgroundEnv([]string{
+		"PATH=/bin",
+		EnvServer + "=https://old.example",
+		EnvAPIKey + "=old-key",
+		EnvVaultToken + "=old-token",
+	}, mountBackgroundRequest{
+		Server: "https://drive9.example",
+		Token:  "jwt-token",
+	})
+	want := []string{
+		"PATH=/bin",
+		EnvServer + "=https://drive9.example",
+		EnvVaultToken + "=jwt-token",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("env = %v, want %v", got, want)
+	}
+}
+
 func TestMountCmdPassesLegacyDirStatFallbackOption(t *testing.T) {
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
@@ -672,6 +1027,7 @@ func TestMountCmdPassesLegacyDirStatFallbackOption(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -705,6 +1061,7 @@ func TestMountCmdLeavesLegacyDirStatFallbackDisabledByDefault(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -733,6 +1090,7 @@ func TestMountCmdPassesTrustLocalEventsOption(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -762,6 +1120,7 @@ func TestMountCmdLeavesTrustLocalEventsDisabledByDefault(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -803,6 +1162,7 @@ func TestMountCmdPassesReadCacheMaxFileOption(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -822,6 +1182,7 @@ func TestMountCmdPassesReadCacheMaxFileOption(t *testing.T) {
 
 func TestMountCmdRejectsZeroDiskReadCacheFreeRatio(t *testing.T) {
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -845,6 +1206,7 @@ func TestMountCmdPassesReadConcurrencyOption(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -874,6 +1236,7 @@ func TestMountCmdPassesParallelReadOptions(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -907,6 +1270,7 @@ func TestMountCmdPassesUploadConcurrencyOption(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -926,6 +1290,7 @@ func TestMountCmdPassesUploadConcurrencyOption(t *testing.T) {
 
 func TestMountCmdRejectsInvalidReadConcurrency(t *testing.T) {
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -939,6 +1304,7 @@ func TestMountCmdRejectsInvalidReadConcurrency(t *testing.T) {
 
 func TestMountCmdRejectsInvalidParallelReadConcurrency(t *testing.T) {
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -952,6 +1318,7 @@ func TestMountCmdRejectsInvalidParallelReadConcurrency(t *testing.T) {
 
 func TestMountCmdRejectsInvalidParallelReadBlockSize(t *testing.T) {
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -965,6 +1332,7 @@ func TestMountCmdRejectsInvalidParallelReadBlockSize(t *testing.T) {
 
 func TestMountCmdRejectsInvalidUploadConcurrency(t *testing.T) {
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -988,6 +1356,7 @@ func TestMountCmdPassesFuseSyncReadOption(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -1056,6 +1425,7 @@ func TestMountCmdMapsDurabilityOption(t *testing.T) {
 			}
 
 			args := []string{
+				"--foreground",
 				"--mode", "fuse",
 				"--server", "https://drive9.example",
 				"--api-key", "sk-test",
@@ -1088,6 +1458,7 @@ func TestMountCmdLeavesDefaultTTLsUnsetForFuseDefaults(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -1119,6 +1490,7 @@ func TestMountCmdPreservesExplicitTTLs(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -1158,6 +1530,7 @@ func TestMountCmdCodingAgentProfilePassesPolicyOptions(t *testing.T) {
 
 	localRoot := t.TempDir()
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
@@ -1202,6 +1575,7 @@ func TestMountCmdCodingAgentProfileGeneratesDefaultLocalRoot(t *testing.T) {
 	}
 
 	err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",

--- a/cmd/drive9/cli/mount_vault.go
+++ b/cmd/drive9/cli/mount_vault.go
@@ -24,9 +24,14 @@ import (
 // vault_mount.go for the per-row anchors. This file owns only the CLI
 // surface (flag parsing + cred resolution + handing off to MountVault).
 func VaultMountCmd(args []string) error {
+	return vaultMountCmd(args, false)
+}
+
+func vaultMountCmd(args []string, background bool) error {
 	fs := flag.NewFlagSet("mount vault", flag.ExitOnError)
 	server := fs.String("server", "", "drive9 server URL (overrides $DRIVE9_SERVER and config)")
 	apiKey := fs.String("api-key", "", "owner API key (overrides $DRIVE9_API_KEY and config)")
+	foreground := fs.Bool("foreground", false, "run in the foreground and block until unmounted")
 	dirTTL := fs.Duration("dir-ttl", 5*time.Second, "vault list / field cache TTL")
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
 	debug := fs.Bool("debug", false, "enable FUSE debug logging")
@@ -67,6 +72,16 @@ func VaultMountCmd(args []string) error {
 	serverVal, apiKeyVal, tokenVal, err := resolveMountCredentials(ResolveCredentials(), *server, *apiKey)
 	if err != nil {
 		return err
+	}
+
+	if background && !*foreground {
+		return startMountBackground(mountBackgroundRequest{
+			Args:       append([]string{"vault"}, args...),
+			MountPoint: mountPoint,
+			Server:     serverVal,
+			APIKey:     apiKeyVal,
+			Token:      tokenVal,
+		})
 	}
 
 	opts := &vaultMountOptions{

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -183,38 +183,41 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 		return explainMountError(deps.goos, mountPoint, err)
 	}
 
-	if deps.goos == "windows" {
-		stateMountPoint, err := webdavMountStatePoint(deps.goos, mountPoint)
-		if err != nil {
-			deps.unmount(deps.goos, mountPoint)
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			_ = srv.Shutdown(ctx)
-			return err
-		}
-		processState := mountstate.ProcessState{PID: os.Getpid()}
-		processState.CreationTime, err = processCreationTimeByPID(processState.PID)
-		if err != nil {
-			deps.unmount(deps.goos, mountPoint)
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			_ = srv.Shutdown(ctx)
-			return fmt.Errorf("webdav: inspect mount process state: %w", err)
-		}
-		pidFile, err := mountstate.WriteProcessState(stateMountPoint, processState)
-		if err != nil {
-			deps.unmount(deps.goos, mountPoint)
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			_ = srv.Shutdown(ctx)
-			return fmt.Errorf("webdav: write mount pid file: %w", err)
-		}
-		defer func() {
-			if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
-				fmt.Fprintf(os.Stderr, "drive9: remove mount pid file %s: %v\n", pidFile, err)
-			}
-		}()
+	stateMountPoint, err := webdavMountStatePoint(deps.goos, mountPoint)
+	if err != nil {
+		deps.unmount(deps.goos, mountPoint)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+		return err
 	}
+	processState := mountstate.ProcessState{
+		PID:        os.Getpid(),
+		MountKind:  mountstate.MountKindWebDAV,
+		MountPoint: stateMountPoint,
+		RemoteRoot: remoteRoot,
+	}
+	processState.CreationTime, err = processCreationTimeByPID(processState.PID)
+	if err != nil {
+		deps.unmount(deps.goos, mountPoint)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+		return fmt.Errorf("webdav: inspect mount process state: %w", err)
+	}
+	pidFile, err := mountstate.WriteProcessState(stateMountPoint, processState)
+	if err != nil {
+		deps.unmount(deps.goos, mountPoint)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+		return fmt.Errorf("webdav: write mount pid file: %w", err)
+	}
+	defer func() {
+		if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "drive9: remove mount pid file %s: %v\n", pidFile, err)
+		}
+	}()
 
 	fmt.Fprintf(os.Stderr, "drive9: mounted on %s via WebDAV (server: %s)\n", mountPoint, serverURL)
 

--- a/cmd/drive9/cli/mount_webdav_test.go
+++ b/cmd/drive9/cli/mount_webdav_test.go
@@ -343,12 +343,33 @@ func TestWebDAVMountLifecycle(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("mount command was not invoked")
 	}
-	_, _, err := mountstate.ReadPID(mountPoint)
-	if !errors.Is(err, os.ErrNotExist) {
-		if err == nil {
-			t.Fatalf("expected no pid file for non-Windows WebDAV mount at %q", mountPoint)
+	var (
+		state   mountstate.ProcessState
+		pidFile string
+		err     error
+	)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		state, pidFile, err = mountstate.ReadProcessState(mountPoint)
+		if err == nil && state.PID == os.Getpid() {
+			break
 		}
-		t.Fatalf("ReadPID(%q): %v", mountPoint, err)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("ReadPID(%q): %v", mountPoint, err)
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("ReadPID(%q): timed out waiting for current pid file", mountPoint)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if state.PID != os.Getpid() {
+		t.Fatalf("pid = %d, want %d", state.PID, os.Getpid())
+	}
+	if state.MountKind != mountstate.MountKindWebDAV {
+		t.Fatalf("MountKind = %q, want %q", state.MountKind, mountstate.MountKindWebDAV)
+	}
+	if state.CreationTime == 0 {
+		t.Fatal("CreationTime = 0, want process ownership metadata")
 	}
 
 	signals <- os.Interrupt
@@ -363,6 +384,13 @@ func TestWebDAVMountLifecycle(t *testing.T) {
 	}
 	if !unmounted.Load() {
 		t.Fatal("unmount callback was not called")
+	}
+	_, _, err = mountstate.ReadPID(mountPoint)
+	if !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			t.Fatalf("expected pid file %q to be removed", pidFile)
+		}
+		t.Fatalf("pid file %q not removed cleanly: %v", pidFile, err)
 	}
 }
 
@@ -422,19 +450,25 @@ func TestWebDAVMountLifecycleWindowsNormalizesDriveLetter(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		state, pidFile, err = mountstate.ReadProcessState(stateMountPoint)
-		if err == nil {
+		if err == nil && state.PID == os.Getpid() {
 			break
 		}
-		if !errors.Is(err, os.ErrNotExist) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("ReadPID(%q): %v", stateMountPoint, err)
 		}
 		if !time.Now().Before(deadline) {
-			t.Fatalf("ReadPID(%q): timed out waiting for pid file", stateMountPoint)
+			t.Fatalf("ReadPID(%q): timed out waiting for current pid file", stateMountPoint)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 	if state.PID != os.Getpid() {
 		t.Fatalf("pid = %d, want %d", state.PID, os.Getpid())
+	}
+	if state.MountKind != mountstate.MountKindWebDAV {
+		t.Fatalf("MountKind = %q, want %q", state.MountKind, mountstate.MountKindWebDAV)
+	}
+	if state.CreationTime == 0 {
+		t.Fatal("CreationTime = 0, want process ownership metadata")
 	}
 
 	signals <- os.Interrupt

--- a/cmd/drive9/cli/pack_test.go
+++ b/cmd/drive9/cli/pack_test.go
@@ -886,6 +886,7 @@ func TestMountCmdUnpacksBeforeFuseMount(t *testing.T) {
 	}
 
 	if err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", srv.URL,
 		"--api-key", "sk-test",
@@ -936,6 +937,7 @@ func TestMountCmdAutoUnpacksCodingAgentPackBeforeFuseMount(t *testing.T) {
 	mountFuse = func(opts *mountFuseOptions) error { return nil }
 
 	if err := MountCmd([]string{
+		"--foreground",
 		"--mode", "fuse",
 		"--server", srv.URL,
 		"--api-key", "sk-test",

--- a/cmd/drive9/cli/process_creation_darwin.go
+++ b/cmd/drive9/cli/process_creation_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func processCreationTimeByPID(pid int) (uint64, error) {
+	if pid <= 0 {
+		return 0, fmt.Errorf("invalid mount process pid %d", pid)
+	}
+	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return 0, err
+	}
+	if kp == nil || int(kp.Proc.P_pid) != pid {
+		return 0, os.ErrNotExist
+	}
+	start := kp.Proc.P_starttime
+	if start.Sec < 0 || start.Usec < 0 {
+		return 0, fmt.Errorf("invalid process start time for pid %d", pid)
+	}
+	return uint64(start.Sec)*1_000_000_000 + uint64(start.Usec)*1_000, nil
+}

--- a/cmd/drive9/cli/process_creation_linux.go
+++ b/cmd/drive9/cli/process_creation_linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func processCreationTimeByPID(pid int) (uint64, error) {
+	if pid <= 0 {
+		return 0, fmt.Errorf("invalid mount process pid %d", pid)
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, err
+	}
+	stat := string(data)
+	commEnd := strings.LastIndex(stat, ")")
+	if commEnd < 0 || commEnd+2 >= len(stat) {
+		return 0, fmt.Errorf("inspect mount process pid %d: malformed /proc stat", pid)
+	}
+	fields := strings.Fields(stat[commEnd+2:])
+	if len(fields) <= 19 {
+		return 0, fmt.Errorf("inspect mount process pid %d: short /proc stat", pid)
+	}
+	startTime, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("inspect mount process pid %d start time: %w", pid, err)
+	}
+	return startTime, nil
+}

--- a/cmd/drive9/cli/process_creation_other_unix.go
+++ b/cmd/drive9/cli/process_creation_other_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows && !darwin && !linux
+
+package cli
+
+import "fmt"
+
+func processCreationTimeByPID(pid int) (uint64, error) {
+	if pid <= 0 {
+		return 0, fmt.Errorf("invalid mount process pid %d", pid)
+	}
+	return 0, fmt.Errorf("process creation time inspection is unsupported on this platform")
+}

--- a/cmd/drive9/cli/process_wait_unix.go
+++ b/cmd/drive9/cli/process_wait_unix.go
@@ -46,11 +46,27 @@ func waitForProcessExitByPID(pid int, timeout time.Duration) error {
 	}
 }
 
-func processCreationTimeByPID(pid int) (uint64, error) {
-	_ = pid
-	return 0, nil
-}
-
 func terminateMountProcess(state mountstate.ProcessState, waitTimeout time.Duration) error {
+	if state.PID <= 0 {
+		return fmt.Errorf("invalid mount process pid %d", state.PID)
+	}
+	if state.MountKind == mountstate.MountKindWebDAV {
+		if state.CreationTime == 0 {
+			return fmt.Errorf("%w: mount pid file for pid %d is missing ownership metadata", errMountProcessStateUnsafe, state.PID)
+		}
+		actualCreationTime, err := processCreationTimeByPID(state.PID)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ESRCH) {
+				return fmt.Errorf("%w: mount process pid %d is no longer running", errMountProcessStateStale, state.PID)
+			}
+			return fmt.Errorf("drive9 umount: inspect mount process pid %d: %w", state.PID, err)
+		}
+		if actualCreationTime == 0 {
+			return fmt.Errorf("%w: mount process pid %d has no ownership metadata", errMountProcessStateUnsafe, state.PID)
+		}
+		if actualCreationTime != state.CreationTime {
+			return fmt.Errorf("%w: mount process pid %d no longer matches recorded ownership", errMountProcessStateStale, state.PID)
+		}
+	}
 	return terminateProcess(state.PID, waitTimeout)
 }

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -51,6 +51,7 @@ var gitHandler = cli.Git
 var packHandler = cli.PackCommand
 var unpackHandler = cli.UnpackCommand
 var profileHandler = cli.Profile
+var umountHandler = cli.UmountCmd
 
 func main() {
 	if logger.CLIEnabled() {
@@ -214,7 +215,7 @@ func dispatch(cmd string, args []string) {
 		if cliLogger != nil {
 			logger.Info(context.Background(), "cli_command", zap.String("command", "umount"))
 		}
-		if err := cli.UmountCmd(args); err != nil {
+		if err := umountHandler(args); err != nil {
 			fatal("umount", err)
 		}
 	case "doctor":

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -87,6 +87,7 @@ func TestDispatchLongHelpFlagShowsUsage(t *testing.T) {
 		"profile show [profile]",
 		"mount [flags] [:/remote] <mountpoint>",
 		"mount vault [flags] <mountpoint>",
+		"umount <mountpoint>",
 		"doctor fuse",
 		"-h, --help, help",
 	} {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -401,6 +401,7 @@ func Mount(opts *MountOptions) error {
 	}
 	pidFile, err := mountstate.WriteProcessState(opts.MountPoint, mountstate.ProcessState{
 		PID:            os.Getpid(),
+		MountKind:      mountstate.MountKindFUSE,
 		MountPoint:     stateMountPoint,
 		RemoteRoot:     opts.RemoteRoot,
 		Profile:        opts.Profile,

--- a/pkg/fuse/vault_mount.go
+++ b/pkg/fuse/vault_mount.go
@@ -6,12 +6,14 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"syscall"
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/mountstate"
 )
 
 // VaultMountOptions configures a `drive9 mount vault <path>` mount.
@@ -122,6 +124,28 @@ func MountVault(opts *VaultMountOptions) error {
 	if err := server.WaitMount(); err != nil {
 		return fmt.Errorf("fuse wait mount (vault): %w", err)
 	}
+
+	stateMountPoint := opts.MountPoint
+	if absMountPoint, absErr := filepath.Abs(stateMountPoint); absErr == nil {
+		stateMountPoint = absMountPoint
+	}
+	if resolvedMountPoint, resolveErr := filepath.EvalSymlinks(stateMountPoint); resolveErr == nil {
+		stateMountPoint = resolvedMountPoint
+	}
+	pidFile, err := mountstate.WriteProcessState(opts.MountPoint, mountstate.ProcessState{
+		PID:        os.Getpid(),
+		MountKind:  mountstate.MountKindVault,
+		MountPoint: stateMountPoint,
+	})
+	if err != nil {
+		_ = server.Unmount()
+		return fmt.Errorf("write vault mount pid file: %w", err)
+	}
+	defer func() {
+		if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "drive9: remove mount pid file %s: %v\n", pidFile, err)
+		}
+	}()
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)

--- a/pkg/mountstate/pid.go
+++ b/pkg/mountstate/pid.go
@@ -15,6 +15,7 @@ import (
 type ProcessState struct {
 	PID            int      `json:"pid"`
 	CreationTime   uint64   `json:"creation_time,omitempty"`
+	MountKind      string   `json:"mount_kind,omitempty"`
 	MountPoint     string   `json:"mount_point,omitempty"`
 	RemoteRoot     string   `json:"remote_root,omitempty"`
 	Profile        string   `json:"profile,omitempty"`
@@ -29,6 +30,10 @@ type ProcessState struct {
 const (
 	CredentialKindAPIKey = "api_key"
 	CredentialKindToken  = "token"
+
+	MountKindFUSE   = "fuse"
+	MountKindVault  = "vault"
+	MountKindWebDAV = "webdav"
 )
 
 func PIDFilePath(mountPoint string) string {


### PR DESCRIPTION
## Summary

This PR changes `drive9 mount` to start mounts as background workers by default, while preserving the previous blocking behavior behind the explicit `--foreground` flag.

Key user-facing changes:

- `drive9 mount ...` now returns after the mount worker is ready instead of blocking the current terminal.
- `drive9 mount --foreground ...` keeps the existing blocking behavior until the filesystem is unmounted.
- `drive9 umount <mountpoint>` remains the lifecycle command for stopping a mount.
- No `--block` flag or `drive9 unmount` alias is introduced; `--foreground` and `umount` are the only public lifecycle controls added/kept here.

## Implementation Details

The default background mode is implemented in the CLI layer rather than by changing the core FUSE mount loop. The parent `drive9 mount` process validates local arguments, credentials, mount mode, profile constraints, and overlay/local-root settings, then starts a detached child process by re-executing the current binary as `drive9 mount --foreground ...`.

This keeps the existing FUSE and WebDAV lifecycle code intact:

- The foreground child still owns the real mount server lifecycle.
- Existing signal handling, flush/drain behavior, write-back cleanup, and PID/state removal remain in the mount worker.
- The parent waits for the child to write mount process state before returning, so a successful command means the mount worker has reached the ready point.
- Child stdout/stderr are appended to a per-mount log file under the user cache directory.
- The parent passes a resolved credential snapshot to the child via `DRIVE9_SERVER`, `DRIVE9_API_KEY`, or `DRIVE9_VAULT_TOKEN`, after stripping stale drive9 credential variables from the inherited environment.
- The child argv is sanitized before exec: `--api-key value` and `--api-key=value` are removed so long-lived background mounts do not expose secrets through process listings.
- Platform-specific child detachment is handled through small Unix and Windows helpers.

Mount process state now includes a `mount_kind` field:

- `fuse` for normal drive9 FUSE mounts.
- `vault` for vault FUSE mounts.
- `webdav` for WebDAV bridge mounts.

This lets `drive9 umount` distinguish a WebDAV bridge process from an ordinary FUSE mount process. WebDAV mounts now write process state on all platforms, not only Windows, so non-Windows background WebDAV workers can be stopped cleanly after the OS-level umount completes.

Review-driven hardening added in the latest revision:

- If readiness polling hits a non-`os.ErrNotExist` mount-state read error, the parent now terminates the spawned child and waits for it to be reaped before returning the read error.
- Non-Windows WebDAV cleanup now still reads mount state and terminates/removes the bridge process state even when the OS unmount helper returns an error, mirroring the Windows cleanup behavior.
- WebDAV process state now records process creation time on Darwin, Linux, and Windows. `drive9 umount` verifies this ownership metadata before terminating a WebDAV bridge and treats missing/mismatched metadata as unsafe or stale instead of blindly killing a reused PID.
- Vault mount process state no longer persists server credentials; it only records the PID, mount kind, and resolved mount point needed for lifecycle handling.

## Behavior Notes

This PR intentionally does not introduce a system daemon or service manager. A self-managed background worker is a smaller change that fits the existing mount process model and keeps `drive9 umount` as the lifecycle boundary.

The old interactive workflow is still available when needed:

```bash
drive9 mount --foreground :/ ~/drive9
```

The recommended default workflow is now:

```bash
drive9 mount :/ ~/drive9
# use the mounted filesystem
drive9 umount ~/drive9
```

## Documentation

The README mount quickstart now reflects the background default and continues to use `drive9 umount` as the stop command.

## Validation

Ran:

```bash
git diff --check
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9/cli ./cmd/drive9 ./pkg/fuse ./pkg/mountstate -timeout=180s
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go vet ./cmd/drive9/cli ./cmd/drive9 ./pkg/fuse ./pkg/mountstate
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache GOOS=linux go test -c ./cmd/drive9/cli -o /private/tmp/drive9-cli-linux.test
```

The Go test command was run outside the sandbox because `httptest` needs to bind local ports for the CLI tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mounts default to background for FUSE and Vault; add --foreground to keep them attached.
  * Mount kind and related mount state are now persisted for better lifecycle handling.

* **Bug Fixes**
  * More reliable start/stop and unmount across platforms with improved readiness checks and cleanup.

* **Documentation**
  * Quick Start mount example updated and note added about background-default behavior and --foreground.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->