### PR TITLE
fix(fuse): infer revisions after async commits

### DIFF
--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -720,6 +720,16 @@ func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEnt
 	return nil
 }
 
+func committedRevisionForExpectedRevision(expectedRevision, committedRev int64) int64 {
+	if committedRev > 0 {
+		return committedRev
+	}
+	if revision, ok := committedRevisionFromExpectedRevision(expectedRevision); ok {
+		return revision
+	}
+	return 0
+}
+
 // uploadEntry uploads entry data to the server. Returns (committedRev, error).
 // committedRev > 0 only when the server-returned revision is available
 // (direct PUT). Multipart/streaming uploads return 0 because the current
@@ -844,6 +854,8 @@ func (cq *CommitQueue) rebuildQueuedIndexLocked() {
 }
 
 func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) error {
+	committedRev = committedRevisionForExpectedRevision(entry.BaseRev, committedRev)
+
 	if shouldApplyRemoteMode(entry.Kind, entry.HasMode, entry.Mode) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		var err error

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -648,7 +648,7 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 		cancel()
 
 		if err == nil {
-			if err := cq.onCommitSuccess(entry, committedRev); err == nil {
+			if err := cq.onCommitSuccess(entry, entry.BaseRev, committedRev); err == nil {
 				unlockPath()
 				return
 			} else {
@@ -711,7 +711,7 @@ func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEnt
 		}
 		return err
 	}
-	if err := cq.onCommitSuccess(entry, committedRev); err != nil {
+	if err := cq.onCommitSuccess(entry, entry.BaseRev, committedRev); err != nil {
 		if cq.perf != nil {
 			cq.perf.commitFailure.add(1)
 		}
@@ -853,8 +853,8 @@ func (cq *CommitQueue) rebuildQueuedIndexLocked() {
 	}
 }
 
-func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, committedRev int64) error {
-	committedRev = committedRevisionForExpectedRevision(entry.BaseRev, committedRev)
+func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, expectedRevision, committedRev int64) error {
+	committedRev = committedRevisionForExpectedRevision(expectedRevision, committedRev)
 
 	if shouldApplyRemoteMode(entry.Kind, entry.HasMode, entry.Mode) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -992,7 +992,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	// Branch 1: idempotent — content already matches server.
 	if bytes.Equal(localData, serverData) {
 		log.Printf("commit queue: auto-resolved conflict for %s (idempotent, content matches server rev %d)", entry.Path, serverRev)
-		if err := cq.onCommitSuccess(entry, 0); err != nil {
+		if err := cq.onCommitSuccess(entry, serverRev, serverRev); err != nil {
 			cq.onCommitPostUploadFailure(entry, err)
 		}
 		return
@@ -1020,7 +1020,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 	}
 
 	log.Printf("commit queue: auto-resolved conflict for %s via LWW (overwrote rev %d → new upload based on rev %d)", entry.Path, entry.BaseRev, serverRev)
-	if err := cq.onCommitSuccess(entry, 0); err != nil {
+	if err := cq.onCommitSuccess(entry, serverRev, 0); err != nil {
 		cq.onCommitPostUploadFailure(entry, err)
 	}
 }

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -1159,14 +1159,142 @@ func TestCommitQueueShadowSpillUpload(t *testing.T) {
 	if statCalls.Load() != 0 {
 		t.Fatalf("stat calls = %d, want 0", statCalls.Load())
 	}
-	if successRev != 0 {
-		t.Fatalf("OnSuccess committedRev = %d, want 0 for multipart stream", successRev)
+	if successRev != 13 {
+		t.Fatalf("OnSuccess committedRev = %d, want 13 from CAS base revision", successRev)
 	}
 	if pending.HasPending("/big.bin") {
 		t.Fatal("pending entry should be removed after successful ShadowSpill commit")
 	}
 	if shadow.Has("/big.bin") {
 		t.Fatal("shadow should be removed after successful ShadowSpill commit")
+	}
+}
+
+func TestCommitQueueMultipartCreateInfersRevisionForOpenHandle(t *testing.T) {
+	data := bytes.Repeat([]byte("d"), 1024)
+	const path = "/workload.db"
+	var gotExpected int64 = -1
+	var gotBody []byte
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/initiate":
+			var req struct {
+				Path             string `json:"path"`
+				TotalSize        int64  `json:"total_size"`
+				ExpectedRevision *int64 `json:"expected_revision"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode initiate request: %v", err)
+			}
+			if req.Path != path {
+				t.Fatalf("initiate path = %q, want %q", req.Path, path)
+			}
+			if req.TotalSize != int64(len(data)) {
+				t.Fatalf("initiate total_size = %d, want %d", req.TotalSize, len(data))
+			}
+			if req.ExpectedRevision == nil {
+				t.Fatal("initiate expected_revision missing")
+			}
+			gotExpected = *req.ExpectedRevision
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"upload_id":   "u1",
+				"key":         "object-key",
+				"part_size":   int64(len(data)),
+				"total_parts": 1,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/u1/presign-batch":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"parts": []map[string]any{{
+					"number": 1,
+					"url":    ts.URL + "/s3/u1/1",
+					"size":   int64(len(data)),
+				}},
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/s3/u1/1":
+			var err error
+			gotBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read part body: %v", err)
+			}
+			w.Header().Set("ETag", "etag-1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/u1/complete":
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.PathLock = fs.lockRemoteCommitPath
+	cq.OnSuccess = fs.onCommitQueueSuccess
+	cq.OnCleanup = fs.onCommitQueueCleanup
+	fs.commitQueue = cq
+
+	if err := shadow.WriteFull(path, data, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutShadowSpill(path, int64(len(data)), PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+	ino := fs.inodes.Lookup(path, false, int64(len(data)), time.Now())
+	fh := &FileHandle{
+		Ino:         ino,
+		Path:        path,
+		Dirty:       fs.newWriteBuffer(path, maxPreloadSize, 0),
+		IsNew:       true,
+		ShadowReady: true,
+		ShadowSpill: true,
+	}
+	fhID := fs.allocateFileHandle(fh)
+	defer fs.deleteFileHandle(fhID, fh)
+
+	if err := cq.Enqueue(&CommitEntry{
+		Path:        path,
+		Inode:       ino,
+		BaseRev:     0,
+		Size:        int64(len(data)),
+		Kind:        PendingNew,
+		ShadowSpill: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if gotExpected != 0 {
+		t.Fatalf("expected revision = %d, want create-if-absent 0", gotExpected)
+	}
+	if !bytes.Equal(gotBody, data) {
+		t.Fatalf("server received %d bytes, want %d", len(gotBody), len(data))
+	}
+	if fh.IsNew {
+		t.Fatal("open handle remained PendingNew after successful multipart create")
+	}
+	if fh.BaseRev != 1 {
+		t.Fatalf("open handle BaseRev = %d, want inferred committed revision 1", fh.BaseRev)
+	}
+	if pending.HasPending(path) {
+		t.Fatal("pending entry should be removed after commit")
+	}
+	if shadow.Has(path) {
+		t.Fatal("shadow should be removed after commit")
 	}
 }
 
@@ -1353,8 +1481,8 @@ func TestCommitQueueRecoverPendingShadowSpill(t *testing.T) {
 	if statCalls.Load() != 0 {
 		t.Fatalf("stat calls = %d, want 0", statCalls.Load())
 	}
-	if successRev != 0 {
-		t.Fatalf("OnSuccess committedRev = %d, want 0 for multipart stream", successRev)
+	if successRev != 9 {
+		t.Fatalf("OnSuccess committedRev = %d, want 9 from recovered CAS base revision", successRev)
 	}
 	if pending2.HasPending("/recover.bin") {
 		t.Fatal("pending entry should be removed after successful recovery upload")

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -758,6 +758,7 @@ func TestCommitQueueDirectPutRouting(t *testing.T) {
 // Test axis 1: 409 → fetch → LWW re-upload succeeds.
 func TestCommitQueueAutoResolveLWW(t *testing.T) {
 	var uploadCalls, statCalls, readCalls int
+	var successRev int64
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodHead:
@@ -808,6 +809,12 @@ func TestCommitQueueAutoResolveLWW(t *testing.T) {
 	}
 
 	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.OnSuccess = func(entry *CommitEntry, committedRev int64) {
+		if entry.Path != "/lww.txt" {
+			t.Fatalf("OnSuccess path = %q, want /lww.txt", entry.Path)
+		}
+		successRev = committedRev
+	}
 	if err := cq.Enqueue(&CommitEntry{
 		Path:    "/lww.txt",
 		BaseRev: 5,
@@ -827,6 +834,9 @@ func TestCommitQueueAutoResolveLWW(t *testing.T) {
 	if readCalls != 1 {
 		t.Fatalf("read calls = %d, want 1", readCalls)
 	}
+	if successRev != 11 {
+		t.Fatalf("OnSuccess committedRev = %d, want 11 from resolved server revision", successRev)
+	}
 	// Success: shadow and pending should be cleaned up.
 	if pending.HasPending("/lww.txt") {
 		t.Fatal("pending entry should be removed after successful LWW")
@@ -839,6 +849,7 @@ func TestCommitQueueAutoResolveLWW(t *testing.T) {
 // Test axis 2: 409 → fetch → content matches → idempotent success.
 func TestCommitQueueAutoResolveIdempotent(t *testing.T) {
 	var uploadCalls int
+	var successRev int64
 	sameContent := []byte("identical!")
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -875,6 +886,12 @@ func TestCommitQueueAutoResolveIdempotent(t *testing.T) {
 	}
 
 	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.OnSuccess = func(entry *CommitEntry, committedRev int64) {
+		if entry.Path != "/idem.txt" {
+			t.Fatalf("OnSuccess path = %q, want /idem.txt", entry.Path)
+		}
+		successRev = committedRev
+	}
 	if err := cq.Enqueue(&CommitEntry{
 		Path:    "/idem.txt",
 		BaseRev: 5,
@@ -889,6 +906,9 @@ func TestCommitQueueAutoResolveIdempotent(t *testing.T) {
 	// No LWW re-upload because content matched.
 	if uploadCalls != 1 {
 		t.Fatalf("upload calls = %d, want 1 (initial 409 only, no LWW re-upload)", uploadCalls)
+	}
+	if successRev != 8 {
+		t.Fatalf("OnSuccess committedRev = %d, want matching server revision", successRev)
 	}
 	// Idempotent: should be cleaned up without a second upload.
 	if pending.HasPending("/idem.txt") {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1696,10 +1696,11 @@ func (fs *Dat9FS) enqueueStagedShadowCommitLocked(fh *FileHandle) error {
 	}
 	size := fh.Dirty.Size()
 	mode, hasMode := fs.modeForPendingHandle(fh)
+	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 	entry := &CommitEntry{
 		Path:        fh.Path,
 		Inode:       fh.Ino,
-		BaseRev:     fh.BaseRev,
+		BaseRev:     expectedRevision,
 		Size:        size,
 		Kind:        fs.pendingKindForHandle(fh),
 		ShadowSpill: fh.ShadowSpill,
@@ -8389,7 +8390,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			entry := &CommitEntry{
 				Path:        fh.Path,
 				Inode:       fh.Ino,
-				BaseRev:     fh.BaseRev,
+				BaseRev:     expectedRevision,
 				Size:        size,
 				Kind:        PendingOverwrite,
 				ShadowSpill: true,
@@ -8498,6 +8499,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			if canUseCache {
 				phase = "writeback-cache-release"
 				mode, hasMode := fs.modeForPendingHandle(fh)
+				expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 				fh.Dirty.ClearDirty()
 				fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 				fh.DirtySeq = 0
@@ -8515,7 +8517,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 					entry := &CommitEntry{
 						Path:    fh.Path,
 						Inode:   fh.Ino,
-						BaseRev: fh.BaseRev,
+						BaseRev: expectedRevision,
 						Size:    fh.Dirty.Size(),
 						Kind:    PendingOverwrite,
 						Mode:    mode,

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -788,7 +788,7 @@ func TestWriteBackUploader_PendingOverwriteUsesBaseRevision(t *testing.T) {
 	}
 }
 
-func TestWriteBackUploader_OnSuccessReceivesUnknownStreamRevision(t *testing.T) {
+func TestWriteBackUploader_OnSuccessInfersStreamRevision(t *testing.T) {
 	var gotExpected string
 	data := []byte("edit")
 	var ts *httptest.Server
@@ -871,8 +871,8 @@ func TestWriteBackUploader_OnSuccessReceivesUnknownStreamRevision(t *testing.T) 
 	if successMeta.Path != "/existing.txt" {
 		t.Fatalf("OnSuccess path = %q, want /existing.txt", successMeta.Path)
 	}
-	if successRev != 0 {
-		t.Fatalf("OnSuccess committedRev = %d, want 0 for stream upload", successRev)
+	if successRev != 24 {
+		t.Fatalf("OnSuccess committedRev = %d, want 24 from CAS base revision", successRev)
 	}
 }
 
@@ -932,8 +932,12 @@ func TestWriteBackUploader_UploadSyncLegacyOverwriteFallsBackToUnconditional(t *
 	uploader := NewWriteBackUploader(c, cache, 1)
 
 	_ = cache.Put("/legacy-sync.txt", []byte("edit"), 4, PendingOverwrite)
-	if err := uploader.UploadSync(context.Background(), "/legacy-sync.txt"); err != nil {
-		t.Fatalf("UploadSync: %v", err)
+	committedRev, err := uploader.UploadSyncWithRevision(context.Background(), "/legacy-sync.txt")
+	if err != nil {
+		t.Fatalf("UploadSyncWithRevision: %v", err)
+	}
+	if committedRev != 0 {
+		t.Fatalf("UploadSyncWithRevision committedRev = %d, want 0 for unconditional legacy fallback", committedRev)
 	}
 
 	if putCalls.Load() != 1 {

--- a/pkg/fuse/writeback_uploader.go
+++ b/pkg/fuse/writeback_uploader.go
@@ -334,6 +334,7 @@ func (u *WriteBackUploader) uploadOne(localPath string) {
 		log.Printf("writeback upload failed for %s after %d attempts: %v (will retry on next mount)", localPath, uploadMaxRetries+1, lastErr)
 		return
 	}
+	committedRev = committedRevisionForExpectedRevision(expectedRevision, committedRev)
 	chmodCtx, chmodCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	modeErr := u.applyMode(chmodCtx, meta)
 	chmodCancel()
@@ -424,6 +425,7 @@ func (u *WriteBackUploader) UploadSyncWithRevision(ctx context.Context, localPat
 		}
 		return 0, err
 	}
+	committedRev = committedRevisionForExpectedRevision(expectedRevision, committedRev)
 	chmodCtx, chmodCancel := context.WithTimeout(ctx, 30*time.Second)
 	err = u.applyMode(chmodCtx, meta)
 	chmodCancel()


### PR DESCRIPTION
## Summary
- infer committed revisions after successful CAS-protected async commit queue and writeback uploads when multipart/stream completion does not return a revision
- enqueue staged shadow/writeback commits with the resolved expected revision so open handles can advance from create-if-absent to overwrite safely
- add regression coverage for multipart create commits refreshing open handle base revisions, shadow spill recovery, writeback stream revisions, and legacy unconditional fallback remaining unknown

## Tests
- `go test -count=1 ./pkg/fuse -run "TestCommitQueue(ShadowSpillUpload|MultipartCreateInfersRevisionForOpenHandle|RecoverPendingShadowSpill)|TestWriteBackUploader_(OnSuccessInfersStreamRevision|PendingOverwriteUsesBaseRevision|PendingOverwriteWithoutBaseRevRetainsCache|UploadSyncLegacyOverwriteFallsBackToUnconditional)"`
- `go test -count=1 ./pkg/fuse`
- Remote SQLite FUSE e2e against `http://k8s-dat9-dat9serv-83b19cd008-1851198124.us-east-1.elb.amazonaws.com` using the fixed linux/amd64 CLI on `ubuntu@47.129.127.73`:
  - `DRIVE9_BASE=... CLI_SOURCE=official CLI_RELEASE_BASE_URL=file:///tmp FUSE_STRICT_PREREQS=1 RUN_FUSE_SQLITE_WAL=1 RUN_FUSE_SQLITE_CHURN=1 RUN_FUSE_SQLITE_CONCURRENCY=1 bash e2e/fuse-sqlite-correctness.sh`
  - result: `19/19 passed, 0 failed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed revision tracking for multipart and streaming file uploads to ensure accurate metadata is propagated through post-commit operations and callbacks.

* **Tests**
  * Enhanced test coverage for revision tracking behavior in commit queue operations.
  * Added new test validating revision inference during multipart file creation.
  * Updated write-back uploader tests to verify correct revision handling in upload completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->