### PR TITLE
Fix git workspace restore regressions

### DIFF
--- a/cmd/drive9/cli/git.go
+++ b/cmd/drive9/cli/git.go
@@ -143,7 +143,6 @@ func gitClone(args []string) error {
 	if err := initializeFastCloneIndex(cmdCtx, target, head); err != nil {
 		return err
 	}
-	configureFastCloneGitOptimizations(cmdCtx, target)
 
 	mode := "fast"
 	if *blobless {
@@ -173,6 +172,7 @@ func gitClone(args []string) error {
 		return fmt.Errorf("register git tree manifest: %w", err)
 	}
 	cancel()
+	configureFastCloneGitOptimizations(cmdCtx, target)
 	gitDir, err := mainGitStateDirForTarget(target, resolved)
 	if err != nil {
 		return err
@@ -312,7 +312,6 @@ func gitWorktreeAdd(args []string) error {
 	if err := initializeFastCloneIndex(cmdCtx, worktreePath, head); err != nil {
 		return err
 	}
-	configureFastCloneGitOptimizations(cmdCtx, worktreePath)
 
 	branchName, branchErr := gitOutput(cmdCtx, worktreePath, "symbolic-ref", "--short", "-q", "HEAD")
 	if branchErr != nil {
@@ -373,6 +372,7 @@ func gitWorktreeAdd(args []string) error {
 		return fmt.Errorf("register linked git tree manifest: %w", err)
 	}
 	cancel()
+	configureFastCloneGitOptimizations(cmdCtx, worktreePath)
 	if err := uploadGitStateCheckpoint(cmdCtx, c, ws.WorkspaceID, head, linkedGitDir); err != nil {
 		return err
 	}

--- a/e2e/_feature-matrix-runner.sh
+++ b/e2e/_feature-matrix-runner.sh
@@ -1099,7 +1099,7 @@ run_restore_suite() {
     python3 - "$restore_repo/oversized-staged.bin" <<'PY'
 import sys
 from pathlib import Path
-Path(sys.argv[1]).write_bytes(b"D9" * (3 * 1024 * 1024 + 1))
+Path(sys.argv[1]).write_bytes(b"D" * (5 * 1024 * 1024 + 1))
 PY
     git_cmd_record "$restore_repo" "Drive9 Git Workspace Behavior" "stage oversized object before remount" add oversized-staged.bin
   else

--- a/e2e/_feature-matrix-runner.sh
+++ b/e2e/_feature-matrix-runner.sh
@@ -1099,7 +1099,7 @@ run_restore_suite() {
     python3 - "$restore_repo/oversized-staged.bin" <<'PY'
 import sys
 from pathlib import Path
-Path(sys.argv[1]).write_bytes(b"D9" * (3 * 1024 * 1024))
+Path(sys.argv[1]).write_bytes(b"D9" * (3 * 1024 * 1024 + 1))
 PY
     git_cmd_record "$restore_repo" "Drive9 Git Workspace Behavior" "stage oversized object before remount" add oversized-staged.bin
   else

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -9049,14 +9049,16 @@ func (fs *Dat9FS) FlushAll() {
 		cf()
 	}
 
-	// Drain coalesced .git checkpoints before shutdown so replacement
-	// sandboxes can restore the latest lightweight Git state.
-	fs.drainGitStateCheckpoints()
-
 	// Drain git workspace overlay commits queued by interactive writeback.
 	// These include both file payloads and metadata entries such as chmod,
 	// mkdir, symlink, and whiteout.
 	fs.drainGitOverlayWrites()
+
+	// Drain coalesced .git checkpoints and then checkpoint every loaded git
+	// workspace once more. The final pass covers Git ref/index updates that
+	// arrived through lock-file rename sequences without a pending debounce.
+	fs.drainGitStateCheckpoints()
+	fs.checkpointAllGitWorkspaces()
 
 	// Drain all pending write-back uploads before shutting down.
 	if fs.uploader != nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -9050,14 +9050,16 @@ func (fs *Dat9FS) FlushAll() {
 		cf()
 	}
 
-	// Git workspace dirty mirrors are the local durable copy-on-write cache.
-	// Sweep them once during graceful shutdown so a missed handle flush cannot
-	// lose working-tree content across sandbox replacement.
-	fs.syncGitDirtyMirrors()
-
 	// Drain git workspace overlay commits queued by interactive writeback.
 	// These include both file payloads and metadata entries such as chmod,
-	// mkdir, symlink, and whiteout.
+	// mkdir, symlink, and whiteout. Do this before sweeping dirty mirrors so
+	// older queued overlay writes cannot overwrite newer mirror content.
+	fs.drainGitOverlayWrites()
+
+	// Git workspace dirty mirrors are the local durable copy-on-write cache.
+	// Sweep them during graceful shutdown so a missed handle flush cannot lose
+	// working-tree content across sandbox replacement.
+	fs.syncGitDirtyMirrors()
 	fs.drainGitOverlayWrites()
 
 	// Drain coalesced .git checkpoints and then checkpoint every loaded git

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7232,6 +7232,7 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 			fh.DirtySeq = fs.markDirtySize(fh.Ino, info.Size())
 			fs.inodes.UpdateSize(fh.Ino, info.Size())
 			fs.inodes.UpdateMtime(fh.Ino, info.ModTime())
+			fs.applyGitOverlayMirrorEntry(fh, info.Size())
 		}
 		if fh.WritePolicy == WritePolicyWriteSync {
 			source = "git-local-write-sync"

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -9050,6 +9050,11 @@ func (fs *Dat9FS) FlushAll() {
 		cf()
 	}
 
+	// Git workspace dirty mirrors are the local durable copy-on-write cache.
+	// Sweep them once during graceful shutdown so a missed handle flush cannot
+	// lose working-tree content across sandbox replacement.
+	fs.syncGitDirtyMirrors()
+
 	// Drain git workspace overlay commits queued by interactive writeback.
 	// These include both file payloads and metadata entries such as chmod,
 	// mkdir, symlink, and whiteout.

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -541,10 +541,10 @@ func (fs *Dat9FS) gitEntry(ctx context.Context, localPath string, incrementLooku
 		if e.Op == "whiteout" {
 			return nil, true
 		}
-		return fs.gitOverlayInode(rt, rel, e, incrementLookup), true
+		return fs.gitOverlayInode(ctx, rt, rel, e, incrementLookup), true
 	}
 	if n, ok := rt.cleanNode(rel); ok {
-		return fs.gitTreeInode(localPath, n, incrementLookup), true
+		return fs.gitTreeInode(ctx, rt, localPath, rel, n, incrementLookup), true
 	}
 	if rt.hasImpliedDir(rel) {
 		return fs.gitInode(localPath, true, 0, 0o755, true, incrementLookup), true
@@ -570,23 +570,25 @@ func (rt *gitWorkspaceRuntime) hasImpliedDir(rel string) bool {
 	return false
 }
 
-func (fs *Dat9FS) gitTreeInode(localPath string, n client.GitTreeNode, incrementLookup bool) *InodeEntry {
+func (fs *Dat9FS) gitTreeInode(ctx context.Context, rt *gitWorkspaceRuntime, localPath, rel string, n client.GitTreeNode, incrementLookup bool) *InodeEntry {
 	mode, hasMode, isDir := gitNodeMode(n)
 	size := n.SizeBytes
 	if isDir {
 		size = 0
+	} else if size < 0 {
+		size = fs.resolveGitCleanNodeSize(ctx, rt, rel, n)
 	}
 	return fs.gitInode(localPath, isDir, size, mode, hasMode, incrementLookup)
 }
 
-func (fs *Dat9FS) gitOverlayInode(rt *gitWorkspaceRuntime, rel string, e client.GitOverlayEntry, incrementLookup bool) *InodeEntry {
+func (fs *Dat9FS) gitOverlayInode(ctx context.Context, rt *gitWorkspaceRuntime, rel string, e client.GitOverlayEntry, incrementLookup bool) *InodeEntry {
 	localPath := path.Join(rt.localRoot, rel)
 	if rt.localRoot == "/" {
 		localPath = "/" + rel
 	}
 	if e.Op == "chmod" {
 		if n, ok := rt.cleanNode(rel); ok {
-			base := fs.gitTreeInode(localPath, n, incrementLookup)
+			base := fs.gitTreeInode(ctx, rt, localPath, rel, n, incrementLookup)
 			if parsed, ok := parseGitMode(e.Mode); ok && base != nil {
 				fs.inodes.SetModeState(base.Ino, parsed, true)
 				base.Mode = parsed
@@ -691,7 +693,7 @@ func (fs *Dat9FS) listGitDir(ctx context.Context, dirPath string) ([]DirEntry, b
 		if rt.localRoot == "/" {
 			localPath = "/" + n.Path
 		}
-		entry := fs.gitTreeInode(localPath, n, false)
+		entry := fs.gitTreeInode(ctx, rt, localPath, n.Path, n, false)
 		if entry == nil {
 			continue
 		}
@@ -725,7 +727,7 @@ func (fs *Dat9FS) listGitDir(ctx context.Context, dirPath string) ([]DirEntry, b
 			delete(entriesByName, childRel)
 			continue
 		}
-		entry := fs.gitOverlayInode(rt, p, e, false)
+		entry := fs.gitOverlayInode(ctx, rt, p, e, false)
 		entriesByName[childRel] = DirEntry{
 			Name:        childRel,
 			Ino:         entry.Ino,
@@ -805,7 +807,7 @@ func gitWorkspaceOpenFlags(rt *gitWorkspaceRuntime, rel string, flags uint32) ui
 	return gofuse.FOPEN_KEEP_CACHE
 }
 
-func (fs *Dat9FS) gitWorkspaceCurrentSize(rt *gitWorkspaceRuntime, rel string) (int64, bool) {
+func (fs *Dat9FS) gitWorkspaceCurrentSize(ctx context.Context, rt *gitWorkspaceRuntime, rel string) (int64, bool) {
 	if rt == nil || rel == "" {
 		return 0, false
 	}
@@ -826,6 +828,9 @@ func (fs *Dat9FS) gitWorkspaceCurrentSize(rt *gitWorkspaceRuntime, rel string) (
 	if n, ok := rt.cleanNode(rel); ok {
 		if n.Kind == "dir" || n.Kind == "submodule" {
 			return 0, false
+		}
+		if n.SizeBytes < 0 {
+			return fs.resolveGitCleanNodeSize(ctx, rt, rel, n), true
 		}
 		return n.SizeBytes, true
 	}
@@ -983,6 +988,35 @@ func (fs *Dat9FS) updateGitKnownSize(rt *gitWorkspaceRuntime, localPath, rel str
 	rt.updateCleanNodeSize(rel, size)
 }
 
+func (fs *Dat9FS) resolveGitCleanNodeSize(ctx context.Context, rt *gitWorkspaceRuntime, rel string, n client.GitTreeNode) int64 {
+	if n.SizeBytes >= 0 || n.Kind == "dir" || n.Kind == "submodule" {
+		if n.Kind == "dir" {
+			return 0
+		}
+		return n.SizeBytes
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if localRoot := strings.TrimSpace(fs.opts.LocalRoot); localRoot != "" {
+		if size, hit, err := gitcache.StatTreeFile(ctx, localRoot, rt.workspace.WorkspaceID, rt.workspace.HeadCommit, rel); err == nil && hit {
+			rt.updateCleanNodeSize(rel, size)
+			return size
+		}
+		if size, hit, err := gitcache.StatBlob(ctx, localRoot, rt.workspace.WorkspaceID, rt.workspace.HeadCommit, n.ObjectSHA); err == nil && hit {
+			rt.updateCleanNodeSize(rel, size)
+			return size
+		}
+	}
+	if n.ObjectSHA != "" {
+		if size, err := fs.gitCatFileBlobSize(ctx, rt, n.ObjectSHA); err == nil {
+			rt.updateCleanNodeSize(rel, size)
+			return size
+		}
+	}
+	return n.SizeBytes
+}
+
 func (rt *gitWorkspaceRuntime) updateCleanNodeSize(rel string, size int64) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
@@ -1056,6 +1090,43 @@ func (fs *Dat9FS) materializeGitBlobOnce(ctx context.Context, rt *gitWorkspaceRu
 		}
 	}
 	return data, nil
+}
+
+func (fs *Dat9FS) gitCatFileBlobSize(ctx context.Context, rt *gitWorkspaceRuntime, objectSHA string) (int64, error) {
+	if err := fs.ensureGitStateRestored(ctx, rt); err != nil {
+		return 0, err
+	}
+	gitDir, err := fs.gitDirForRuntime(rt)
+	if err != nil {
+		return 0, err
+	}
+	start := time.Now()
+	if fs.perfEnabled() {
+		fs.perf.gitCatFileCount.add(1)
+	}
+	cmd := exec.CommandContext(ctx, "git", "--git-dir", gitDir, "cat-file", "-s", objectSHA)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	dur := time.Since(start)
+	if fs.perfEnabled() {
+		fs.perf.gitCatFileTotalNS.add(uint64(dur))
+		if dur >= 50*time.Millisecond {
+			fs.perf.gitCatFileSlowCount.add(1)
+		}
+	}
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return 0, fmt.Errorf("git cat-file -s %s: %w: %s", objectSHA, err, msg)
+		}
+		return 0, err
+	}
+	size, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse git cat-file -s %s output %q: %w", objectSHA, strings.TrimSpace(string(out)), err)
+	}
+	return size, nil
 }
 
 func (fs *Dat9FS) gitCatFileBlob(ctx context.Context, rt *gitWorkspaceRuntime, objectSHA string) ([]byte, error) {
@@ -3024,7 +3095,7 @@ func (fs *Dat9FS) prepareGitOpenHandle(ctx context.Context, fh *FileHandle, flag
 	}
 
 	size := fh.OrigSize
-	if currentSize, ok := fs.gitWorkspaceCurrentSize(rt, rel); ok {
+	if currentSize, ok := fs.gitWorkspaceCurrentSize(ctx, rt, rel); ok {
 		size = currentSize
 		fh.OrigSize = currentSize
 		fs.inodes.UpdateSize(fh.Ino, currentSize)

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -212,6 +212,11 @@ func (fs *Dat9FS) hasLocalGitStateHint(localPath string) bool {
 	if clean == "." || clean == "/" {
 		return false
 	}
+	for _, part := range strings.Split(strings.Trim(clean, "/"), "/") {
+		if part == ".git" {
+			return false
+		}
+	}
 	for cur := clean; cur != "." && cur != "/"; cur = path.Dir(cur) {
 		if _, err := fs.localOverlay.Lstat(path.Join(cur, ".git")); err == nil {
 			return true

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -3096,6 +3096,116 @@ func (fs *Dat9FS) drainGitOverlayWrites() {
 	}
 }
 
+func (fs *Dat9FS) syncGitDirtyMirrors() {
+	if fs == nil || fs.git == nil || fs.opts == nil || strings.TrimSpace(fs.opts.LocalRoot) == "" {
+		return
+	}
+	localRoot := strings.TrimSpace(fs.opts.LocalRoot)
+	workspaceRoot := filepath.Join(localRoot, "git-workspaces")
+	fs.git.mu.Lock()
+	runtimes := make(map[string]*gitWorkspaceRuntime, len(fs.git.workspaces))
+	for _, rt := range fs.git.workspaces {
+		if rt != nil && rt.workspace.WorkspaceID != "" {
+			runtimes[rt.workspace.WorkspaceID] = rt
+		}
+	}
+	fs.git.mu.Unlock()
+
+	workspaceDirs, err := os.ReadDir(workspaceRoot)
+	if err != nil {
+		return
+	}
+	for _, workspaceDir := range workspaceDirs {
+		if !workspaceDir.IsDir() {
+			continue
+		}
+		workspaceID := workspaceDir.Name()
+		if strings.TrimSpace(workspaceID) == "" {
+			continue
+		}
+		commitDirs, err := os.ReadDir(filepath.Join(workspaceRoot, workspaceID))
+		if err != nil {
+			continue
+		}
+		rt := runtimes[workspaceID]
+		for _, commitDir := range commitDirs {
+			if !commitDir.IsDir() {
+				continue
+			}
+			dirtyRoot := filepath.Join(workspaceRoot, workspaceID, commitDir.Name(), "dirty")
+			fs.syncGitDirtyMirrorRoot(workspaceID, rt, dirtyRoot)
+		}
+	}
+}
+
+func (fs *Dat9FS) syncGitDirtyMirrorForRuntime(rt *gitWorkspaceRuntime) {
+	if fs == nil || rt == nil || rt.workspace.WorkspaceID == "" || rt.workspace.HeadCommit == "" {
+		return
+	}
+	dirtyRoot := filepath.Join(strings.TrimSpace(fs.opts.LocalRoot), "git-workspaces", rt.workspace.WorkspaceID, rt.workspace.HeadCommit, "dirty")
+	fs.syncGitDirtyMirrorRoot(rt.workspace.WorkspaceID, rt, dirtyRoot)
+}
+
+func (fs *Dat9FS) syncGitDirtyMirrorRoot(workspaceID string, rt *gitWorkspaceRuntime, dirtyRoot string) {
+	if fs == nil || workspaceID == "" || dirtyRoot == "" {
+		return
+	}
+	info, err := os.Stat(dirtyRoot)
+	if err != nil || !info.IsDir() {
+		return
+	}
+	_ = filepath.WalkDir(dirtyRoot, func(p string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dirtyRoot, p)
+		if err != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "." || rel == "" {
+			return nil
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil
+		}
+		mode := "100644"
+		kind := "file"
+		base := ""
+		if e, ok := rt.overlayEntry(rel); ok {
+			if e.Op == "whiteout" {
+				return nil
+			}
+			if e.Mode != "" {
+				mode = e.Mode
+			}
+			if e.Kind != "" {
+				kind = e.Kind
+			}
+			base = e.BaseObjectSHA
+		}
+		if stat, err := d.Info(); err == nil && mode == "100644" && stat.Mode()&0o111 != 0 {
+			mode = "100755"
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), releaseTimeout(int64(len(data))))
+		_, err = fs.putGitOverlayWithPolicy(ctx, workspaceID, client.GitOverlayEntryRequest{
+			Path:          rel,
+			Op:            "upsert",
+			Kind:          kind,
+			Mode:          mode,
+			BaseObjectSHA: base,
+			Content:       data,
+			SizeBytes:     int64(len(data)),
+		}, WritePolicyWriteSync, true)
+		cancel()
+		if err != nil {
+			log.Printf("git workspace dirty mirror sync failed workspace=%s root=%s path=%s: %v", workspaceID, dirtyRoot, rel, err)
+		}
+		return nil
+	})
+}
+
 func (fs *Dat9FS) flushGitHandleLocked(ctx context.Context, fh *FileHandle) gofuse.Status {
 	return fs.flushGitHandleLockedWithPolicy(ctx, fh, false)
 }

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -90,11 +90,19 @@ func newGitWorkspaceLayer() *gitWorkspaceLayer {
 }
 
 func (fs *Dat9FS) ensureGitWorkspaces(ctx context.Context) error {
+	return fs.ensureGitWorkspacesWithRefresh(ctx, false)
+}
+
+func (fs *Dat9FS) forceRefreshGitWorkspaces(ctx context.Context) error {
+	return fs.ensureGitWorkspacesWithRefresh(ctx, true)
+}
+
+func (fs *Dat9FS) ensureGitWorkspacesWithRefresh(ctx context.Context, force bool) error {
 	if fs == nil || fs.git == nil || fs.client == nil {
 		return nil
 	}
 	fs.git.mu.Lock()
-	if fs.git.loaded && time.Since(fs.git.loadedAt) < gitWorkspaceRefreshInterval {
+	if !force && fs.git.loaded && time.Since(fs.git.loadedAt) < gitWorkspaceRefreshInterval {
 		fs.git.mu.Unlock()
 		return nil
 	}
@@ -173,30 +181,43 @@ func (fs *Dat9FS) gitWorkspaceForPath(ctx context.Context, localPath string) (*g
 	if ctx == nil {
 		ctx = context.TODO()
 	}
-	ctx, cancel := context.WithTimeout(ctx, fuseTimeout)
-	if err := fs.ensureGitWorkspaces(ctx); err != nil {
+	baseCtx := ctx
+	ensureCtx, cancel := context.WithTimeout(baseCtx, fuseTimeout)
+	if err := fs.ensureGitWorkspaces(ensureCtx); err != nil {
 		log.Printf("git workspace refresh failed for %s: %v", localPath, err)
 	}
 	cancel()
 
-	clean := path.Clean(localPath)
-	fs.git.mu.Lock()
-	defer fs.git.mu.Unlock()
-	for _, rt := range fs.git.workspaces {
-		root := rt.localRoot
-		if root == "/" {
-			rel := strings.TrimPrefix(clean, "/")
+	if rt, rel, ok := fs.loadedGitWorkspaceForPath(localPath); ok {
+		return rt, rel, true
+	}
+	if fs.hasLocalGitStateHint(localPath) {
+		refreshCtx, refreshCancel := context.WithTimeout(baseCtx, fuseTimeout)
+		if err := fs.forceRefreshGitWorkspaces(refreshCtx); err != nil {
+			log.Printf("git workspace forced refresh failed for %s: %v", localPath, err)
+		}
+		refreshCancel()
+		if rt, rel, ok := fs.loadedGitWorkspaceForPath(localPath); ok {
 			return rt, rel, true
-		}
-		if clean == root {
-			return rt, "", true
-		}
-		prefix := root + "/"
-		if strings.HasPrefix(clean, prefix) {
-			return rt, strings.TrimPrefix(clean, prefix), true
 		}
 	}
 	return nil, "", false
+}
+
+func (fs *Dat9FS) hasLocalGitStateHint(localPath string) bool {
+	if fs == nil || fs.localOverlay == nil {
+		return false
+	}
+	clean := path.Clean(localPath)
+	if clean == "." || clean == "/" {
+		return false
+	}
+	for cur := clean; cur != "." && cur != "/"; cur = path.Dir(cur) {
+		if _, err := fs.localOverlay.Lstat(path.Join(cur, ".git")); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (fs *Dat9FS) loadedGitWorkspaceForPath(localPath string) (*gitWorkspaceRuntime, string, bool) {

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -2882,6 +2882,23 @@ func (fs *Dat9FS) applyGitOverlayEntry(workspaceID string, entry client.GitOverl
 	}
 }
 
+func (fs *Dat9FS) applyGitOverlayMirrorEntry(fh *FileHandle, size int64) {
+	if fs == nil || fh == nil || fh.Layer != PathLayerGitWorkspace || fh.GitWorkspaceID == "" || fh.GitRelPath == "" {
+		return
+	}
+	fs.applyGitOverlayEntry(fh.GitWorkspaceID, client.GitOverlayEntry{
+		WorkspaceID:    fh.GitWorkspaceID,
+		Path:           fh.GitRelPath,
+		Op:             "upsert",
+		Kind:           fh.GitKind,
+		Mode:           gitModeForHandle(fh),
+		SizeBytes:      size,
+		BaseObjectSHA:  fh.GitBaseObjectSHA,
+		ChecksumSHA256: "",
+		UpdatedAt:      time.Now(),
+	})
+}
+
 func (fs *Dat9FS) rememberPendingGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) uint64 {
 	if fs == nil {
 		return 0
@@ -3293,6 +3310,7 @@ func (fs *Dat9FS) gitCreateHandle(ctx context.Context, localPath string, flags u
 	}
 	if file, ok := fs.openGitDirtyMirrorFile(rt, rel, flags|uint32(syscall.O_TRUNC), nil); ok {
 		fh.LocalFile = file
+		fs.applyGitOverlayMirrorEntry(fh, 0)
 	}
 	fh.DirtySeq = fs.markDirtySize(ino, 0)
 	return fh, entry, gofuse.OK
@@ -3338,6 +3356,7 @@ func (fs *Dat9FS) prepareGitOpenHandle(ctx context.Context, fh *FileHandle, flag
 		fs.inodes.UpdateSize(fh.Ino, 0)
 		if file, ok := fs.openGitDirtyMirrorFile(rt, rel, flags, nil); ok {
 			fh.LocalFile = file
+			fs.applyGitOverlayMirrorEntry(fh, 0)
 			return gofuse.OK
 		}
 		return gofuse.OK

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -3138,14 +3138,6 @@ func (fs *Dat9FS) syncGitDirtyMirrors() {
 	}
 }
 
-func (fs *Dat9FS) syncGitDirtyMirrorForRuntime(rt *gitWorkspaceRuntime) {
-	if fs == nil || rt == nil || rt.workspace.WorkspaceID == "" || rt.workspace.HeadCommit == "" {
-		return
-	}
-	dirtyRoot := filepath.Join(strings.TrimSpace(fs.opts.LocalRoot), "git-workspaces", rt.workspace.WorkspaceID, rt.workspace.HeadCommit, "dirty")
-	fs.syncGitDirtyMirrorRoot(rt.workspace.WorkspaceID, rt, dirtyRoot)
-}
-
 func (fs *Dat9FS) syncGitDirtyMirrorRoot(workspaceID string, rt *gitWorkspaceRuntime, dirtyRoot string) {
 	if fs == nil || workspaceID == "" || dirtyRoot == "" {
 		return

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -59,6 +59,11 @@ type gitWorkspaceRuntime struct {
 	children  map[string][]client.GitTreeNode
 	overlay   map[string]client.GitOverlayEntry
 	restored  bool
+
+	localTreeCommit   string
+	localNodes        map[string]client.GitTreeNode
+	localChildren     map[string][]client.GitTreeNode
+	localTreeLoadedAt time.Time
 }
 
 func (rt *gitWorkspaceRuntime) isLinked() bool {
@@ -376,6 +381,12 @@ func (fs *Dat9FS) gitWorkspaceOwnsPath(ctx context.Context, localPath string) bo
 	if _, ok := rt.overlayEntry(rel); ok {
 		return true
 	}
+	if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
+		if _, ok := rt.localHeadNode(rel); ok {
+			return true
+		}
+		return rt.hasLocalHeadImpliedDir(rel)
+	}
 	if _, ok := rt.cleanNode(rel); ok {
 		return true
 	}
@@ -400,6 +411,14 @@ func (fs *Dat9FS) gitIgnoredPathLocalOnly(ctx context.Context, localPath string,
 	}
 	if _, ok := rt.overlayEntry(rel); ok {
 		return false
+	}
+	if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
+		if _, ok := rt.localHeadNode(rel); ok {
+			return false
+		}
+		if rt.hasLocalHeadImpliedDir(rel) {
+			return false
+		}
 	}
 	if _, ok := rt.cleanNode(rel); ok {
 		return false
@@ -499,6 +518,16 @@ func (rt *gitWorkspaceRuntime) cleanNode(rel string) (client.GitTreeNode, bool) 
 	return n, ok
 }
 
+func (rt *gitWorkspaceRuntime) localHeadNode(rel string) (client.GitTreeNode, bool) {
+	if rt == nil {
+		return client.GitTreeNode{}, false
+	}
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+	n, ok := rt.localNodes[rel]
+	return n, ok
+}
+
 type gitOverlaySnapshot struct {
 	path  string
 	entry client.GitOverlayEntry
@@ -511,6 +540,18 @@ func (rt *gitWorkspaceRuntime) childrenFor(rel string) []client.GitTreeNode {
 	rt.mu.RLock()
 	defer rt.mu.RUnlock()
 	children := rt.children[rel]
+	out := make([]client.GitTreeNode, len(children))
+	copy(out, children)
+	return out
+}
+
+func (rt *gitWorkspaceRuntime) localHeadChildrenFor(rel string) []client.GitTreeNode {
+	if rt == nil {
+		return nil
+	}
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+	children := rt.localChildren[rel]
 	out := make([]client.GitTreeNode, len(children))
 	copy(out, children)
 	return out
@@ -543,6 +584,15 @@ func (fs *Dat9FS) gitEntry(ctx context.Context, localPath string, incrementLooku
 		}
 		return fs.gitOverlayInode(ctx, rt, rel, e, incrementLookup), true
 	}
+	if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
+		if n, ok := rt.localHeadNode(rel); ok {
+			return fs.gitTreeInode(ctx, rt, localPath, rel, n, incrementLookup), true
+		}
+		if rt.hasLocalHeadImpliedDir(rel) {
+			return fs.gitInode(localPath, true, 0, 0o755, true, incrementLookup), true
+		}
+		return nil, true
+	}
 	if n, ok := rt.cleanNode(rel); ok {
 		return fs.gitTreeInode(ctx, rt, localPath, rel, n, incrementLookup), true
 	}
@@ -550,6 +600,123 @@ func (fs *Dat9FS) gitEntry(ctx context.Context, localPath string, incrementLooku
 		return fs.gitInode(localPath, true, 0, 0o755, true, incrementLookup), true
 	}
 	return nil, true
+}
+
+func (fs *Dat9FS) ensureGitLocalHeadTree(ctx context.Context, rt *gitWorkspaceRuntime) (bool, error) {
+	if fs == nil || rt == nil {
+		return false, nil
+	}
+	rt.mu.RLock()
+	if rt.localTreeCommit != "" {
+		active := rt.localNodes != nil
+		rt.mu.RUnlock()
+		return active, nil
+	}
+	rt.mu.RUnlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := fs.ensureGitStateRestored(ctx, rt); err != nil {
+		return false, err
+	}
+	gitDir, err := fs.gitDirForRuntime(rt)
+	if err != nil {
+		return false, err
+	}
+	headOut, err := gitCommandOutputNoLazy(ctx, "--git-dir", gitDir, "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		return false, err
+	}
+	head := strings.ToLower(strings.TrimSpace(string(headOut)))
+	if !isGitObjectID(head) || strings.EqualFold(head, rt.workspace.HeadCommit) {
+		rt.mu.Lock()
+		rt.localTreeCommit = head
+		rt.localNodes = nil
+		rt.localChildren = nil
+		rt.localTreeLoadedAt = time.Time{}
+		rt.mu.Unlock()
+		return false, nil
+	}
+
+	treeOut, err := gitCommandOutputNoLazy(ctx, "--git-dir", gitDir, "ls-tree", "-r", "-t", "-z", head)
+	if err != nil {
+		return false, err
+	}
+	nodes, children := parseLocalGitTree(rt.workspace.WorkspaceID, head, treeOut)
+	rt.mu.Lock()
+	rt.localTreeCommit = head
+	rt.localNodes = nodes
+	rt.localChildren = children
+	rt.localTreeLoadedAt = time.Now()
+	rt.mu.Unlock()
+	return true, nil
+}
+
+func (rt *gitWorkspaceRuntime) clearLocalHeadTree() {
+	if rt == nil {
+		return
+	}
+	rt.mu.Lock()
+	rt.localTreeCommit = ""
+	rt.localNodes = nil
+	rt.localChildren = nil
+	rt.localTreeLoadedAt = time.Time{}
+	rt.mu.Unlock()
+}
+
+func parseLocalGitTree(workspaceID, commit string, raw []byte) (map[string]client.GitTreeNode, map[string][]client.GitTreeNode) {
+	nodes := make(map[string]client.GitTreeNode)
+	children := make(map[string][]client.GitTreeNode)
+	for _, rec := range bytes.Split(raw, []byte{0}) {
+		if len(rec) == 0 {
+			continue
+		}
+		tab := bytes.IndexByte(rec, '\t')
+		if tab < 0 {
+			continue
+		}
+		meta := strings.Fields(string(rec[:tab]))
+		if len(meta) < 3 {
+			continue
+		}
+		mode, typ, objectSHA := meta[0], meta[1], meta[2]
+		rel := strings.TrimPrefix(path.Clean("/"+string(rec[tab+1:])), "/")
+		if rel == "" || rel == "." {
+			continue
+		}
+		kind := "file"
+		switch typ {
+		case "tree":
+			kind = "dir"
+		case "commit":
+			kind = "submodule"
+		case "blob":
+			if mode == "120000" {
+				kind = "symlink"
+			}
+		}
+		parent := path.Dir(rel)
+		if parent == "." {
+			parent = ""
+		}
+		node := client.GitTreeNode{
+			WorkspaceID: workspaceID,
+			CommitSHA:   commit,
+			Path:        rel,
+			ParentPath:  parent,
+			Name:        path.Base(rel),
+			Kind:        kind,
+			Mode:        mode,
+			ObjectSHA:   objectSHA,
+			SizeBytes:   -1,
+		}
+		nodes[rel] = node
+		children[parent] = append(children[parent], node)
+	}
+	for parent := range children {
+		sort.Slice(children[parent], func(i, j int) bool { return children[parent][i].Name < children[parent][j].Name })
+	}
+	return nodes, children
 }
 
 func (rt *gitWorkspaceRuntime) hasImpliedDir(rel string) bool {
@@ -566,6 +733,18 @@ func (rt *gitWorkspaceRuntime) hasImpliedDir(rel string) bool {
 		if e.Op != "whiteout" && strings.HasPrefix(p, prefix) {
 			return true
 		}
+	}
+	return false
+}
+
+func (rt *gitWorkspaceRuntime) hasLocalHeadImpliedDir(rel string) bool {
+	if rel == "" {
+		return true
+	}
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+	if _, ok := rt.localChildren[rel]; ok {
+		return true
 	}
 	return false
 }
@@ -587,7 +766,11 @@ func (fs *Dat9FS) gitOverlayInode(ctx context.Context, rt *gitWorkspaceRuntime, 
 		localPath = "/" + rel
 	}
 	if e.Op == "chmod" {
-		if n, ok := rt.cleanNode(rel); ok {
+		n, ok := rt.cleanNode(rel)
+		if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
+			n, ok = rt.localHeadNode(rel)
+		}
+		if ok {
 			base := fs.gitTreeInode(ctx, rt, localPath, rel, n, incrementLookup)
 			if parsed, ok := parseGitMode(e.Mode); ok && base != nil {
 				fs.inodes.SetModeState(base.Ino, parsed, true)
@@ -669,6 +852,7 @@ func (fs *Dat9FS) listGitDir(ctx context.Context, dirPath string) ([]DirEntry, b
 	if !ok {
 		return nil, false, nil
 	}
+	localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt)
 	if rel != "" {
 		if e, ok := rt.overlayEntry(rel); ok {
 			if e.Op == "whiteout" {
@@ -676,6 +860,14 @@ func (fs *Dat9FS) listGitDir(ctx context.Context, dirPath string) ([]DirEntry, b
 			}
 			if e.Kind != "dir" {
 				return nil, true, syscall.ENOTDIR
+			}
+		} else if localTree {
+			if n, ok := rt.localHeadNode(rel); ok {
+				if n.Kind != "dir" {
+					return nil, true, syscall.ENOTDIR
+				}
+			} else if !rt.hasLocalHeadImpliedDir(rel) {
+				return nil, true, os.ErrNotExist
 			}
 		} else if n, ok := rt.cleanNode(rel); ok {
 			if n.Kind != "dir" {
@@ -688,7 +880,11 @@ func (fs *Dat9FS) listGitDir(ctx context.Context, dirPath string) ([]DirEntry, b
 	entriesByName := make(map[string]DirEntry)
 	whiteouts := make(map[string]struct{})
 	overlays := rt.overlaySnapshot()
-	for _, n := range rt.childrenFor(rel) {
+	children := rt.childrenFor(rel)
+	if localTree {
+		children = rt.localHeadChildrenFor(rel)
+	}
+	for _, n := range children {
 		localPath := path.Join(rt.localRoot, n.Path)
 		if rt.localRoot == "/" {
 			localPath = "/" + n.Path
@@ -787,6 +983,9 @@ func (fs *Dat9FS) readGitFile(ctx context.Context, localPath string, offset, siz
 		}
 	}
 	n, ok := rt.cleanNode(rel)
+	if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
+		n, ok = rt.localHeadNode(rel)
+	}
 	if !ok {
 		return nil, os.ErrNotExist
 	}
@@ -825,7 +1024,17 @@ func (fs *Dat9FS) gitWorkspaceCurrentSize(ctx context.Context, rt *gitWorkspaceR
 			return e.SizeBytes, true
 		}
 	}
-	if n, ok := rt.cleanNode(rel); ok {
+	if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
+		if n, ok := rt.localHeadNode(rel); ok {
+			if n.Kind == "dir" || n.Kind == "submodule" {
+				return 0, false
+			}
+			if n.SizeBytes < 0 {
+				return fs.resolveGitCleanNodeSize(ctx, rt, rel, n), true
+			}
+			return n.SizeBytes, true
+		}
+	} else if n, ok := rt.cleanNode(rel); ok {
 		if n.Kind == "dir" || n.Kind == "submodule" {
 			return 0, false
 		}
@@ -1021,17 +1230,29 @@ func (rt *gitWorkspaceRuntime) updateCleanNodeSize(rel string, size int64) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	n, ok := rt.nodes[rel]
-	if !ok || n.SizeBytes >= 0 {
-		return
+	if ok && n.SizeBytes < 0 {
+		n.SizeBytes = size
+		rt.nodes[rel] = n
+		children := rt.children[n.ParentPath]
+		for i := range children {
+			if children[i].Path == rel {
+				children[i].SizeBytes = size
+				rt.children[n.ParentPath] = children
+				break
+			}
+		}
 	}
-	n.SizeBytes = size
-	rt.nodes[rel] = n
-	children := rt.children[n.ParentPath]
-	for i := range children {
-		if children[i].Path == rel {
-			children[i].SizeBytes = size
-			rt.children[n.ParentPath] = children
-			return
+	n, ok = rt.localNodes[rel]
+	if ok && n.SizeBytes < 0 {
+		n.SizeBytes = size
+		rt.localNodes[rel] = n
+		children := rt.localChildren[n.ParentPath]
+		for i := range children {
+			if children[i].Path == rel {
+				children[i].SizeBytes = size
+				rt.localChildren[n.ParentPath] = children
+				break
+			}
 		}
 	}
 }
@@ -1741,6 +1962,7 @@ func (fs *Dat9FS) scheduleGitStateCheckpoint(localPath string) {
 	if !ok || (rel != ".git" && !strings.HasPrefix(rel, ".git/")) {
 		return
 	}
+	rt.clearLocalHeadTree()
 	key := gitWorkspaceCacheKey(rt)
 	fs.gitCheckpoints.Schedule(key, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), gitCheckpointTimeout)
@@ -1759,6 +1981,7 @@ func (fs *Dat9FS) checkpointGitStateForPath(ctx context.Context, localPath strin
 	if !ok || (rel != ".git" && !strings.HasPrefix(rel, ".git/")) {
 		return nil
 	}
+	rt.clearLocalHeadTree()
 	if fs.gitCheckpoints != nil {
 		fs.gitCheckpoints.Cancel(gitWorkspaceCacheKey(rt))
 	}
@@ -1778,6 +2001,26 @@ func (fs *Dat9FS) drainGitStateCheckpoints() {
 		return
 	}
 	fs.gitCheckpoints.FlushAll()
+}
+
+func (fs *Dat9FS) checkpointAllGitWorkspaces() {
+	if fs == nil || fs.git == nil {
+		return
+	}
+	fs.git.mu.Lock()
+	workspaces := make([]*gitWorkspaceRuntime, len(fs.git.workspaces))
+	copy(workspaces, fs.git.workspaces)
+	fs.git.mu.Unlock()
+	if len(workspaces) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), gitCheckpointTimeout)
+	defer cancel()
+	for _, rt := range workspaces {
+		if err := fs.checkpointGitStateForRuntime(ctx, rt); err != nil {
+			log.Printf("git state final checkpoint failed for workspace %s root %s: %v", rt.workspace.WorkspaceID, rt.workspace.RootPath, err)
+		}
+	}
 }
 
 func (fs *Dat9FS) checkpointGitStateForRuntime(ctx context.Context, rt *gitWorkspaceRuntime) error {
@@ -3068,6 +3311,12 @@ func (fs *Dat9FS) prepareGitOpenHandle(ctx context.Context, fh *FileHandle, flag
 		fh.GitKind = e.Kind
 		fh.GitMode = e.Mode
 		fh.GitBaseObjectSHA = e.BaseObjectSHA
+	} else if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
+		if n, ok := rt.localHeadNode(rel); ok {
+			fh.GitKind = n.Kind
+			fh.GitMode = n.Mode
+			fh.GitBaseObjectSHA = n.ObjectSHA
+		}
 	} else if n, ok := rt.cleanNode(rel); ok {
 		fh.GitKind = n.Kind
 		fh.GitMode = n.Mode
@@ -3220,7 +3469,7 @@ func (fs *Dat9FS) setGitAttr(ctx context.Context, input *gofuse.SetAttrIn, entry
 				Op:            "chmod",
 				Kind:          gitOverlayKindForEntry(entry),
 				Mode:          gitFileModeString(entryMode, entry.IsDir),
-				BaseObjectSHA: gitBaseObjectSHA(rt, rel),
+				BaseObjectSHA: fs.gitBaseObjectSHA(ctx, rt, rel),
 			}
 			if _, err := fs.putGitOverlay(ctx, rt.workspace.WorkspaceID, req); err != nil {
 				return httpToFuseStatus(err)
@@ -3271,7 +3520,7 @@ func (fs *Dat9FS) setGitAttr(ctx context.Context, input *gofuse.SetAttrIn, entry
 				Op:            "upsert",
 				Kind:          "file",
 				Mode:          gitFileModeString(entry.Mode, false),
-				BaseObjectSHA: gitBaseObjectSHA(rt, rel),
+				BaseObjectSHA: fs.gitBaseObjectSHA(ctx, rt, rel),
 				Content:       data,
 				SizeBytes:     int64(len(data)),
 			}
@@ -3290,12 +3539,17 @@ func (fs *Dat9FS) setGitAttr(ctx context.Context, input *gofuse.SetAttrIn, entry
 	return gofuse.OK
 }
 
-func gitBaseObjectSHA(rt *gitWorkspaceRuntime, rel string) string {
+func (fs *Dat9FS) gitBaseObjectSHA(ctx context.Context, rt *gitWorkspaceRuntime, rel string) string {
 	if rt == nil {
 		return ""
 	}
 	if e, ok := rt.overlayEntry(rel); ok && e.BaseObjectSHA != "" {
 		return e.BaseObjectSHA
+	}
+	if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
+		if n, ok := rt.localHeadNode(rel); ok {
+			return n.ObjectSHA
+		}
 	}
 	if n, ok := rt.cleanNode(rel); ok {
 		return n.ObjectSHA
@@ -3400,7 +3654,7 @@ func (fs *Dat9FS) copyGitFileOverlay(ctx context.Context, rt *gitWorkspaceRuntim
 	size := int64(0)
 	mode := "100644"
 	kind := "file"
-	base := gitBaseObjectSHA(rt, oldRel)
+	base := fs.gitBaseObjectSHA(ctx, rt, oldRel)
 	if e, ok := rt.overlayEntry(oldRel); ok {
 		size = e.SizeBytes
 		mode = e.Mode

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -1107,6 +1107,17 @@ func (fs *Dat9FS) removeGitDirtyMirror(rt *gitWorkspaceRuntime, rel string) {
 	_ = os.Remove(mirrorPath)
 }
 
+func (fs *Dat9FS) replaceGitDirtyMirror(rt *gitWorkspaceRuntime, rel string, data []byte) {
+	mirrorPath, ok := fs.gitWorkspaceDirtyMirrorPath(rt, rel)
+	if !ok {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(mirrorPath), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(mirrorPath, data, 0o644)
+}
+
 func (fs *Dat9FS) readGitDirtyMirror(rt *gitWorkspaceRuntime, rel string, offset, size int64) ([]byte, bool, error) {
 	mirrorPath, ok := fs.gitWorkspaceDirtyMirrorPath(rt, rel)
 	if !ok {
@@ -3582,6 +3593,7 @@ func (fs *Dat9FS) setGitAttr(ctx context.Context, input *gofuse.SetAttrIn, entry
 			if _, err := fs.putGitOverlay(ctx, rt.workspace.WorkspaceID, req); err != nil {
 				return httpToFuseStatus(err)
 			}
+			fs.replaceGitDirtyMirror(rt, rel, data)
 		}
 		entry.Size = newSize
 		fs.inodes.UpdateSize(input.NodeId, newSize)

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -3443,6 +3443,16 @@ func (fs *Dat9FS) openGitDirtyMirrorFile(rt *gitWorkspaceRuntime, rel string, fl
 	if err != nil {
 		return nil, false
 	}
+	if flags&uint32(syscall.O_TRUNC) != 0 {
+		if err := file.Truncate(0); err != nil {
+			_ = file.Close()
+			return nil, false
+		}
+		if _, err := file.Seek(0, 0); err != nil {
+			_ = file.Close()
+			return nil, false
+		}
+	}
 	return file, true
 }
 

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -209,7 +209,7 @@ func (fs *Dat9FS) hasLocalGitStateHint(localPath string) bool {
 		return false
 	}
 	clean := path.Clean(localPath)
-	if clean == "." || clean == "/" {
+	if clean == "." {
 		return false
 	}
 	for _, part := range strings.Split(strings.Trim(clean, "/"), "/") {
@@ -217,9 +217,12 @@ func (fs *Dat9FS) hasLocalGitStateHint(localPath string) bool {
 			return false
 		}
 	}
-	for cur := clean; cur != "." && cur != "/"; cur = path.Dir(cur) {
+	for cur := clean; cur != "."; cur = path.Dir(cur) {
 		if _, err := fs.localOverlay.Lstat(path.Join(cur, ".git")); err == nil {
 			return true
+		}
+		if cur == "/" {
+			break
 		}
 	}
 	return false
@@ -1185,8 +1188,9 @@ func (fs *Dat9FS) readGitCleanFile(ctx context.Context, rt *gitWorkspaceRuntime,
 	if fs.perfEnabled() {
 		fs.perf.gitCleanReadCount.add(1)
 	}
+	nodeCommit := gitNodeCommit(rt, n)
 	if localRoot := strings.TrimSpace(fs.opts.LocalRoot); localRoot != "" {
-		data, hit, err := gitcache.ReadTreeFile(ctx, localRoot, rt.workspace.WorkspaceID, rt.workspace.HeadCommit, rel, offset, size)
+		data, hit, err := gitcache.ReadTreeFile(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, rel, offset, size)
 		if err != nil {
 			return nil, err
 		}
@@ -1199,7 +1203,7 @@ func (fs *Dat9FS) readGitCleanFile(ctx context.Context, rt *gitWorkspaceRuntime,
 			}
 			return data, nil
 		}
-		data, hit, err = gitcache.ReadBlob(ctx, localRoot, rt.workspace.WorkspaceID, rt.workspace.HeadCommit, n.ObjectSHA, offset, size)
+		data, hit, err = gitcache.ReadBlob(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, n.ObjectSHA, offset, size)
 		if err != nil {
 			return nil, err
 		}
@@ -1216,7 +1220,7 @@ func (fs *Dat9FS) readGitCleanFile(ctx context.Context, rt *gitWorkspaceRuntime,
 	if fs.perfEnabled() {
 		fs.perf.gitCleanCacheMiss.add(1)
 	}
-	data, err := fs.materializeGitBlob(ctx, rt, n.ObjectSHA)
+	data, err := fs.materializeGitBlob(ctx, rt, nodeCommit, n.ObjectSHA)
 	if err != nil {
 		return nil, err
 	}
@@ -1231,7 +1235,7 @@ func (fs *Dat9FS) updateGitKnownSize(rt *gitWorkspaceRuntime, localPath, rel str
 	if ino, ok := fs.inodes.GetInode(localPath); ok {
 		fs.inodes.UpdateSize(ino, size)
 	}
-	rt.updateCleanNodeSize(rel, size)
+	rt.updateCleanNodeSize(rel, gitNodeCommit(rt, n), size)
 }
 
 func (fs *Dat9FS) resolveGitCleanNodeSize(ctx context.Context, rt *gitWorkspaceRuntime, rel string, n client.GitTreeNode) int64 {
@@ -1244,30 +1248,55 @@ func (fs *Dat9FS) resolveGitCleanNodeSize(ctx context.Context, rt *gitWorkspaceR
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	nodeCommit := gitNodeCommit(rt, n)
 	if localRoot := strings.TrimSpace(fs.opts.LocalRoot); localRoot != "" {
-		if size, hit, err := gitcache.StatTreeFile(ctx, localRoot, rt.workspace.WorkspaceID, rt.workspace.HeadCommit, rel); err == nil && hit {
-			rt.updateCleanNodeSize(rel, size)
+		if size, hit, err := gitcache.StatTreeFile(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, rel); err == nil && hit {
+			rt.updateCleanNodeSize(rel, nodeCommit, size)
 			return size
 		}
-		if size, hit, err := gitcache.StatBlob(ctx, localRoot, rt.workspace.WorkspaceID, rt.workspace.HeadCommit, n.ObjectSHA); err == nil && hit {
-			rt.updateCleanNodeSize(rel, size)
+		if size, hit, err := gitcache.StatBlob(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, n.ObjectSHA); err == nil && hit {
+			rt.updateCleanNodeSize(rel, nodeCommit, size)
 			return size
 		}
 	}
 	if n.ObjectSHA != "" {
 		if size, err := fs.gitCatFileBlobSize(ctx, rt, n.ObjectSHA); err == nil {
-			rt.updateCleanNodeSize(rel, size)
+			rt.updateCleanNodeSize(rel, nodeCommit, size)
 			return size
 		}
 	}
 	return n.SizeBytes
 }
 
-func (rt *gitWorkspaceRuntime) updateCleanNodeSize(rel string, size int64) {
+func gitNodeCommit(rt *gitWorkspaceRuntime, n client.GitTreeNode) string {
+	if commit := strings.TrimSpace(n.CommitSHA); commit != "" {
+		return commit
+	}
+	if rt == nil {
+		return ""
+	}
+	return rt.workspace.HeadCommit
+}
+
+func (rt *gitWorkspaceRuntime) updateCleanNodeSize(rel, commit string, size int64) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
+	commit = strings.TrimSpace(commit)
+	shouldUpdate := func(n client.GitTreeNode, expectedCommit string) bool {
+		if n.SizeBytes >= 0 {
+			return false
+		}
+		if commit == "" {
+			return true
+		}
+		if nodeCommit := strings.TrimSpace(n.CommitSHA); nodeCommit != "" {
+			return strings.EqualFold(nodeCommit, commit)
+		}
+		expectedCommit = strings.TrimSpace(expectedCommit)
+		return expectedCommit == "" || strings.EqualFold(expectedCommit, commit)
+	}
 	n, ok := rt.nodes[rel]
-	if ok && n.SizeBytes < 0 {
+	if ok && shouldUpdate(n, rt.workspace.HeadCommit) {
 		n.SizeBytes = size
 		rt.nodes[rel] = n
 		children := rt.children[n.ParentPath]
@@ -1280,7 +1309,7 @@ func (rt *gitWorkspaceRuntime) updateCleanNodeSize(rel string, size int64) {
 		}
 	}
 	n, ok = rt.localNodes[rel]
-	if ok && n.SizeBytes < 0 {
+	if ok && shouldUpdate(n, rt.localTreeCommit) {
 		n.SizeBytes = size
 		rt.localNodes[rel] = n
 		children := rt.localChildren[n.ParentPath]
@@ -1294,11 +1323,15 @@ func (rt *gitWorkspaceRuntime) updateCleanNodeSize(rel string, size int64) {
 	}
 }
 
-func (fs *Dat9FS) materializeGitBlob(ctx context.Context, rt *gitWorkspaceRuntime, objectSHA string) ([]byte, error) {
+func (fs *Dat9FS) materializeGitBlob(ctx context.Context, rt *gitWorkspaceRuntime, commit, objectSHA string) ([]byte, error) {
 	if fs == nil || fs.git == nil || rt == nil {
 		return nil, os.ErrNotExist
 	}
-	key := rt.workspace.WorkspaceID + ":" + rt.workspace.HeadCommit + ":" + objectSHA
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		commit = rt.workspace.HeadCommit
+	}
+	key := rt.workspace.WorkspaceID + ":" + commit + ":" + objectSHA
 	fs.git.mu.Lock()
 	if fs.git.materialize == nil {
 		fs.git.materialize = make(map[string]*gitMaterializeCall)
@@ -1316,7 +1349,7 @@ func (fs *Dat9FS) materializeGitBlob(ctx context.Context, rt *gitWorkspaceRuntim
 	fs.git.materialize[key] = call
 	fs.git.mu.Unlock()
 
-	call.data, call.err = fs.materializeGitBlobOnce(ctx, rt, objectSHA)
+	call.data, call.err = fs.materializeGitBlobOnce(ctx, rt, commit, objectSHA)
 	close(call.done)
 
 	fs.git.mu.Lock()
@@ -1325,9 +1358,9 @@ func (fs *Dat9FS) materializeGitBlob(ctx context.Context, rt *gitWorkspaceRuntim
 	return call.data, call.err
 }
 
-func (fs *Dat9FS) materializeGitBlobOnce(ctx context.Context, rt *gitWorkspaceRuntime, objectSHA string) ([]byte, error) {
+func (fs *Dat9FS) materializeGitBlobOnce(ctx context.Context, rt *gitWorkspaceRuntime, commit, objectSHA string) ([]byte, error) {
 	if localRoot := strings.TrimSpace(fs.opts.LocalRoot); localRoot != "" {
-		data, hit, err := gitcache.ReadBlob(ctx, localRoot, rt.workspace.WorkspaceID, rt.workspace.HeadCommit, objectSHA, 0, -1)
+		data, hit, err := gitcache.ReadBlob(ctx, localRoot, rt.workspace.WorkspaceID, commit, objectSHA, 0, -1)
 		if err != nil {
 			return nil, err
 		}
@@ -1343,7 +1376,7 @@ func (fs *Dat9FS) materializeGitBlobOnce(ctx context.Context, rt *gitWorkspaceRu
 		return nil, err
 	}
 	if localRoot := strings.TrimSpace(fs.opts.LocalRoot); localRoot != "" {
-		if err := gitcache.WriteBlob(ctx, localRoot, rt.workspace.WorkspaceID, rt.workspace.HeadCommit, objectSHA, data); err != nil {
+		if err := gitcache.WriteBlob(ctx, localRoot, rt.workspace.WorkspaceID, commit, objectSHA, data); err != nil {
 			return nil, err
 		}
 	}
@@ -2923,7 +2956,7 @@ func (fs *Dat9FS) applyGitOverlayMirrorEntry(fh *FileHandle, size int64) {
 	if fs == nil || fh == nil || fh.Layer != PathLayerGitWorkspace || fh.GitWorkspaceID == "" || fh.GitRelPath == "" {
 		return
 	}
-	fs.applyGitOverlayEntry(fh.GitWorkspaceID, client.GitOverlayEntry{
+	entry := client.GitOverlayEntry{
 		WorkspaceID:    fh.GitWorkspaceID,
 		Path:           fh.GitRelPath,
 		Op:             "upsert",
@@ -2933,7 +2966,9 @@ func (fs *Dat9FS) applyGitOverlayMirrorEntry(fh *FileHandle, size int64) {
 		BaseObjectSHA:  fh.GitBaseObjectSHA,
 		ChecksumSHA256: "",
 		UpdatedAt:      time.Now(),
-	})
+	}
+	fs.rememberPendingGitOverlayEntry(fh.GitWorkspaceID, entry)
+	fs.applyGitOverlayEntry(fh.GitWorkspaceID, entry)
 }
 
 func (fs *Dat9FS) rememberPendingGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) uint64 {
@@ -3831,10 +3866,24 @@ func (fs *Dat9FS) copyGitFileOverlay(ctx context.Context, rt *gitWorkspaceRuntim
 		if e.BaseObjectSHA != "" {
 			base = e.BaseObjectSHA
 		}
-	} else if n, ok := rt.cleanNode(oldRel); ok {
-		size = n.SizeBytes
-		mode = n.Mode
-		kind = n.Kind
+	} else {
+		var (
+			n  client.GitTreeNode
+			ok bool
+		)
+		if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
+			n, ok = rt.localHeadNode(oldRel)
+		} else {
+			n, ok = rt.cleanNode(oldRel)
+		}
+		if ok {
+			size = n.SizeBytes
+			if size < 0 {
+				size = fs.resolveGitCleanNodeSize(ctx, rt, oldRel, n)
+			}
+			mode = n.Mode
+			kind = n.Kind
+		}
 	}
 	data, err := fs.readGitFile(ctx, oldLocal, 0, size)
 	if err != nil {

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -503,6 +503,48 @@ func TestEnsureGitWorkspacesKeepsPreviousSnapshotOnLoadFailure(t *testing.T) {
 	}
 }
 
+func TestGitWorkspaceForPathForceRefreshesAfterLocalGitAppears(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	fixture.deleted = true
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.localOverlay.EnsureRoot(); err != nil {
+		t.Fatalf("EnsureRoot: %v", err)
+	}
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("initial ensureGitWorkspaces: %v", err)
+	}
+	fs.git.mu.Lock()
+	initialLoadedAt := fs.git.loadedAt
+	initialCount := len(fs.git.workspaces)
+	fs.git.mu.Unlock()
+	if initialCount != 0 {
+		t.Fatalf("initial workspace count = %d, want 0", initialCount)
+	}
+	if err := fs.localOverlay.Mkdir("/repo/.git", 0o755); err != nil {
+		t.Fatalf("create local .git hint: %v", err)
+	}
+	fixture.mu.Lock()
+	fixture.deleted = false
+	fixture.mu.Unlock()
+
+	entry, handled := fs.gitEntry(context.Background(), "/repo/README.md", false)
+	if !handled || entry == nil {
+		t.Fatalf("gitEntry handled=%t entry=%v, want forced refresh to load README", handled, entry)
+	}
+	fs.git.mu.Lock()
+	loadedAt := fs.git.loadedAt
+	count := len(fs.git.workspaces)
+	fs.git.mu.Unlock()
+	if count != 1 {
+		t.Fatalf("workspace count after forced refresh = %d, want 1", count)
+	}
+	if !loadedAt.After(initialLoadedAt) {
+		t.Fatalf("loadedAt did not advance after forced refresh")
+	}
+}
+
 func TestGitWorkspaceWriteSyncWritesOverlay(t *testing.T) {
 	fixture := newGitWorkspaceFixture(t)
 	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1535,6 +1535,39 @@ func TestGitWorkspaceCleanReadUsesMaterializedTreeCache(t *testing.T) {
 	}
 }
 
+func TestGitWorkspaceUnknownSizeLookupUsesMaterializedTreeCacheSize(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	fixture.readmeSize = -1
+	localRoot := t.TempDir()
+	content := []byte("cached base\n")
+	treePath := filepath.Join(gitcache.TreeRoot(localRoot, "ws1", fixtureHeadCommit), "README.md")
+	if err := os.MkdirAll(filepath.Dir(treePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(treePath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &MountOptions{LocalRoot: localRoot, EnableGitWorkspaces: true, PerfCounters: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "README.md", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if got := lookupOut.Size; got != uint64(len(content)) {
+		t.Fatalf("Lookup size = %d, want %d", got, len(content))
+	}
+	if entry, ok := fs.inodes.GetEntry(lookupOut.NodeId); !ok || entry.Size != int64(len(content)) {
+		t.Fatalf("inode size = entry %v ok %t, want %d", entry, ok, len(content))
+	}
+	snap := fs.perf.snapshot()
+	if got := snap.Counters["git_cat_file_count"]; got != 0 {
+		t.Fatalf("git_cat_file_count = %d, want 0", got)
+	}
+}
+
 func TestGitObjectDatabasePathsSkipDirectCheckpoint(t *testing.T) {
 	if !localPathMayBeGitState("/repo/.git/index") {
 		t.Fatal(".git/index should be git state")
@@ -1577,6 +1610,35 @@ func TestGitWorkspaceCleanReadUsesBlobCache(t *testing.T) {
 	if got := snap.Counters["git_clean_blob_cache_hit"]; got != 1 {
 		t.Fatalf("git_clean_blob_cache_hit = %d, want 1", got)
 	}
+	if got := snap.Counters["git_cat_file_count"]; got != 0 {
+		t.Fatalf("git_cat_file_count = %d, want 0", got)
+	}
+}
+
+func TestGitWorkspaceUnknownSizeLookupUsesBlobCacheSize(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	fixture.readmeSize = -1
+	localRoot := t.TempDir()
+	content := []byte("cached blob\n")
+	if err := gitcache.WriteBlob(context.Background(), localRoot, "ws1", fixtureHeadCommit, fixture.readmeObjectSHA, content); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &MountOptions{LocalRoot: localRoot, EnableGitWorkspaces: true, PerfCounters: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "README.md", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if got := lookupOut.Size; got != uint64(len(content)) {
+		t.Fatalf("Lookup size = %d, want %d", got, len(content))
+	}
+	if entry, ok := fs.inodes.GetEntry(lookupOut.NodeId); !ok || entry.Size != int64(len(content)) {
+		t.Fatalf("inode size = entry %v ok %t, want %d", entry, ok, len(content))
+	}
+	snap := fs.perf.snapshot()
 	if got := snap.Counters["git_cat_file_count"]; got != 0 {
 		t.Fatalf("git_cat_file_count = %d, want 0", got)
 	}
@@ -2406,8 +2468,8 @@ func TestGitWorkspaceUnknownSizeWritableOpenPreservesBaseContent(t *testing.T) {
 	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "README.md", &lookupOut); st != gofuse.OK {
 		t.Fatalf("Lookup status = %v, want OK", st)
 	}
-	if got := lookupOut.Size; got != 0 {
-		t.Fatalf("Lookup size = %d, want 0 attr fallback for unknown size", got)
+	if got := lookupOut.Size; got != uint64(len(content)) {
+		t.Fatalf("Lookup size = %d, want %d from git object size fallback", got, len(content))
 	}
 
 	var openOut gofuse.OpenOut

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1884,6 +1884,7 @@ func TestGitWorkspaceCleanReadSingleflightsCatFile(t *testing.T) {
 	fixture := newGitWorkspaceFixture(t)
 	content := []byte("hello base\n")
 	repo := createGitRepoWithReadme(t, content)
+	fixture.headCommit = fuseGitOutputForTest(t, repo, "rev-parse", "HEAD")
 	state, err := archiveLocalGitDir(filepath.Join(repo, ".git"))
 	if err != nil {
 		t.Fatalf("archiveLocalGitDir: %v", err)

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1897,6 +1897,13 @@ func TestGitWorkspaceCleanReadSingleflightsCatFile(t *testing.T) {
 	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true, PerfCounters: true}
 	opts.setDefaults()
 	fs := NewDat9FS(fixture.client(), opts)
+	rt, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/README.md")
+	if !ok {
+		t.Fatal("git workspace not loaded")
+	}
+	if err := fs.ensureGitStateRestored(context.Background(), rt); err != nil {
+		t.Fatalf("ensureGitStateRestored: %v", err)
+	}
 	const readers = 20
 	var wg sync.WaitGroup
 	errs := make(chan error, readers)

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -2846,6 +2846,67 @@ func TestGitWorkspaceCreatePublishesDirtyMirrorBeforeFlush(t *testing.T) {
 	fs.Release(nil, &gofuse.ReleaseIn{Fh: createOut.Fh})
 }
 
+func TestGitWorkspaceDirtyMirrorSweepUploadsContent(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	rt, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/README.md")
+	if !ok {
+		t.Fatal("git workspace not loaded")
+	}
+	content := []byte("mirror only\n")
+	fs.replaceGitDirtyMirror(rt, "mirror-only.txt", content)
+	fs.applyGitOverlayEntry("ws1", client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "mirror-only.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+		SizeBytes:   int64(len(content)),
+	})
+
+	fs.syncGitDirtyMirrors()
+
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["mirror-only.txt"]
+	fixture.mu.Unlock()
+	if !ok {
+		t.Fatal("mirror-only.txt overlay missing after dirty mirror sweep")
+	}
+	if !bytes.Equal(entry.Content, content) {
+		t.Fatalf("overlay content = %q, want %q", entry.Content, content)
+	}
+}
+
+func TestGitWorkspaceDirtyMirrorSweepUploadsUnloadedRuntime(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	localRoot := t.TempDir()
+	opts := &MountOptions{LocalRoot: localRoot, EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	content := []byte("unloaded runtime mirror\n")
+	dirtyPath := filepath.Join(localRoot, "git-workspaces", "ws1", "local-head", "dirty", "nested", "mirror-only.txt")
+	if err := os.MkdirAll(filepath.Dir(dirtyPath), 0o755); err != nil {
+		t.Fatalf("mkdir dirty mirror: %v", err)
+	}
+	if err := os.WriteFile(dirtyPath, content, 0o644); err != nil {
+		t.Fatalf("write dirty mirror: %v", err)
+	}
+
+	fs.syncGitDirtyMirrors()
+
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["nested/mirror-only.txt"]
+	fixture.mu.Unlock()
+	if !ok {
+		t.Fatal("nested/mirror-only.txt overlay missing after dirty mirror sweep")
+	}
+	if !bytes.Equal(entry.Content, content) {
+		t.Fatalf("overlay content = %q, want %q", entry.Content, content)
+	}
+}
+
 func TestGitWorkspaceUnlinkCreateRefreshesDirtyMirror(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -2731,6 +2731,41 @@ func TestGitWorkspaceLocalHeadTreeProvidesCommittedFiles(t *testing.T) {
 	}
 }
 
+func TestGitWorkspaceCreatePublishesDirtyMirrorBeforeFlush(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_CREAT | syscall.O_TRUNC),
+		Mode:     0o644,
+	}, "stash-new.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	content := []byte("stash untracked\n")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Offset:   0,
+		Size:     uint32(len(content)),
+	}, content); st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+
+	got, err := fs.readGitFile(context.Background(), "/repo/stash-new.txt", 0, -1)
+	if err != nil {
+		t.Fatalf("readGitFile before flush: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("readGitFile before flush = %q, want %q", got, content)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: createOut.Fh})
+}
+
 func TestGitWorkspaceUnlinkCreateRefreshesDirtyMirror(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -2675,10 +2675,20 @@ func TestGitWorkspaceTruncateOpenRefreshesDirtyMirror(t *testing.T) {
 		t.Fatalf("appended readGitFile = %q, want %q", got, appended)
 	}
 
+	var truncateAttr gofuse.AttrOut
+	if st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &truncateAttr); st != gofuse.OK {
+		t.Fatalf("truncate SetAttr status = %v, want OK", st)
+	}
 	var truncateOpen gofuse.OpenOut
 	if st := fs.Open(nil, &gofuse.OpenIn{
 		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
-		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+		Flags:    uint32(syscall.O_WRONLY),
 	}, &truncateOpen); st != gofuse.OK {
 		t.Fatalf("truncate Open status = %v, want OK", st)
 	}

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -2675,6 +2675,34 @@ func TestGitWorkspaceTruncateOpenRefreshesDirtyMirror(t *testing.T) {
 		t.Fatalf("appended readGitFile = %q, want %q", got, appended)
 	}
 
+	var truncateOpen gofuse.OpenOut
+	if st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	}, &truncateOpen); st != gofuse.OK {
+		t.Fatalf("truncate Open status = %v, want OK", st)
+	}
+	shortContent := []byte("short\n")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Fh:       truncateOpen.Fh,
+		Offset:   0,
+		Size:     uint32(len(shortContent)),
+	}, shortContent); st != gofuse.OK {
+		t.Fatalf("truncate Write status = %v, want OK", st)
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{Fh: truncateOpen.Fh}); st != gofuse.OK {
+		t.Fatalf("truncate Flush status = %v, want OK", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: truncateOpen.Fh})
+	got, err = fs.readGitFile(context.Background(), "/repo/README.md", 0, -1)
+	if err != nil {
+		t.Fatalf("read truncated git file: %v", err)
+	}
+	if !bytes.Equal(got, shortContent) {
+		t.Fatalf("truncated readGitFile = %q, want %q", got, shortContent)
+	}
+
 	var restoreOpen gofuse.OpenOut
 	if st := fs.Open(nil, &gofuse.OpenIn{
 		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1078,6 +1078,23 @@ func TestGitWorkspaceRestoresLocalGitStateOnLookup(t *testing.T) {
 	}
 }
 
+func TestGitWorkspaceLocalStateHintChecksMountRootGitDir(t *testing.T) {
+	localRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(localRoot, "overlay", ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	opts := &MountOptions{LocalRoot: localRoot, EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+
+	if !fs.hasLocalGitStateHint("/README.md") {
+		t.Fatal("hasLocalGitStateHint missed mount-root .git")
+	}
+	if fs.hasLocalGitStateHint("/.git/config") {
+		t.Fatal("hasLocalGitStateHint should ignore paths inside .git")
+	}
+}
+
 func TestLinkedGitStatePathMapsToLinkedRuntime(t *testing.T) {
 	fs := &Dat9FS{
 		opts: &MountOptions{EnableGitWorkspaces: true},
@@ -2811,6 +2828,110 @@ func TestGitWorkspaceLocalHeadTreeProvidesCommittedFiles(t *testing.T) {
 	}
 }
 
+func TestGitWorkspaceLocalHeadReadUsesSelectedCommitCache(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	baseContent := []byte("base\n")
+	localContent := []byte("committed local README\n")
+	repo := createGitRepoWithReadme(t, baseContent)
+	baseCommit := fuseGitOutputForTest(t, repo, "rev-parse", "HEAD")
+	baseSHA := fuseGitOutputForTest(t, repo, "hash-object", "README.md")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), localContent, 0o644); err != nil {
+		t.Fatalf("write local README: %v", err)
+	}
+	runFuseTestGit(t, repo, "add", "README.md")
+	runFuseTestGit(t, repo, "commit", "-m", "local README")
+	state, err := archiveLocalGitDir(filepath.Join(repo, ".git"))
+	if err != nil {
+		t.Fatalf("archiveLocalGitDir: %v", err)
+	}
+
+	fixture := newGitWorkspaceFixture(t)
+	fixture.headCommit = baseCommit
+	fixture.state = state
+	fixture.readmeObjectSHA = baseSHA
+	fixture.readmeSize = -1
+
+	localRoot := t.TempDir()
+	treePath := filepath.Join(gitcache.TreeRoot(localRoot, "ws1", baseCommit), "README.md")
+	if err := os.MkdirAll(filepath.Dir(treePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(treePath, baseContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &MountOptions{LocalRoot: localRoot, EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "README.md", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup README status = %v, want OK", st)
+	}
+	if got := lookupOut.Size; got != uint64(len(localContent)) {
+		t.Fatalf("Lookup README size = %d, want %d", got, len(localContent))
+	}
+
+	got, err := fs.readGitFile(context.Background(), "/repo/README.md", 0, -1)
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if !bytes.Equal(got, localContent) {
+		t.Fatalf("README content = %q, want %q", got, localContent)
+	}
+}
+
+func TestGitWorkspaceRenameLocalHeadOnlyFilePreservesContent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	baseContent := []byte("hello base\n")
+	localContent := []byte("committed local file\n")
+	repo := createGitRepoWithReadme(t, baseContent)
+	baseCommit := fuseGitOutputForTest(t, repo, "rev-parse", "HEAD")
+	baseSHA := fuseGitOutputForTest(t, repo, "hash-object", "README.md")
+	if err := os.WriteFile(filepath.Join(repo, "committed-local.txt"), localContent, 0o644); err != nil {
+		t.Fatalf("write committed-local: %v", err)
+	}
+	runFuseTestGit(t, repo, "add", "committed-local.txt")
+	runFuseTestGit(t, repo, "commit", "-m", "local file")
+	state, err := archiveLocalGitDir(filepath.Join(repo, ".git"))
+	if err != nil {
+		t.Fatalf("archiveLocalGitDir: %v", err)
+	}
+
+	fixture := newGitWorkspaceFixture(t)
+	fixture.headCommit = baseCommit
+	fixture.state = state
+	fixture.readmeObjectSHA = baseSHA
+	fixture.readmeSize = int64(len(baseContent))
+
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	st := fs.Rename(nil, &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Newdir:   repoIno,
+	}, "committed-local.txt", "renamed-local.txt")
+	if st != gofuse.OK {
+		t.Fatalf("Rename status = %v, want OK", st)
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["renamed-local.txt"]
+	fixture.mu.Unlock()
+	if !ok {
+		t.Fatal("renamed-local overlay entry missing")
+	}
+	if !bytes.Equal(entry.Content, localContent) {
+		t.Fatalf("renamed-local content = %q, want %q", entry.Content, localContent)
+	}
+}
+
 func TestGitWorkspaceCreatePublishesDirtyMirrorBeforeFlush(t *testing.T) {
 	fixture := newGitWorkspaceFixture(t)
 	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
@@ -2842,6 +2963,16 @@ func TestGitWorkspaceCreatePublishesDirtyMirrorBeforeFlush(t *testing.T) {
 	}
 	if !bytes.Equal(got, content) {
 		t.Fatalf("readGitFile before flush = %q, want %q", got, content)
+	}
+	if err := fs.forceRefreshGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("forceRefreshGitWorkspaces: %v", err)
+	}
+	got, err = fs.readGitFile(context.Background(), "/repo/stash-new.txt", 0, -1)
+	if err != nil {
+		t.Fatalf("readGitFile after refresh before flush: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("readGitFile after refresh before flush = %q, want %q", got, content)
 	}
 	fs.Release(nil, &gofuse.ReleaseIn{Fh: createOut.Fh})
 }

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -2672,6 +2672,65 @@ func TestGitWorkspaceTruncateOpenRefreshesDirtyMirror(t *testing.T) {
 	}
 }
 
+func TestGitWorkspaceLocalHeadTreeProvidesCommittedFiles(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	baseContent := []byte("hello base\n")
+	localContent := []byte("committed local\n")
+	repo := createGitRepoWithReadme(t, baseContent)
+	if err := os.WriteFile(filepath.Join(repo, "committed-local.txt"), localContent, 0o644); err != nil {
+		t.Fatalf("write committed-local: %v", err)
+	}
+	runFuseTestGit(t, repo, "add", "committed-local.txt")
+	runFuseTestGit(t, repo, "commit", "-m", "local commit")
+	state, err := archiveLocalGitDir(filepath.Join(repo, ".git"))
+	if err != nil {
+		t.Fatalf("archiveLocalGitDir: %v", err)
+	}
+
+	fixture := newGitWorkspaceFixture(t)
+	fixture.state = state
+	fixture.readmeObjectSHA = fuseGitOutputForTest(t, repo, "rev-parse", "HEAD~1:README.md")
+	fixture.readmeSize = int64(len(baseContent))
+
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "committed-local.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup committed-local status = %v, want OK", st)
+	}
+	if got := lookupOut.Size; got != uint64(len(localContent)) {
+		t.Fatalf("Lookup committed-local size = %d, want %d", got, len(localContent))
+	}
+	got, err := fs.readGitFile(context.Background(), "/repo/committed-local.txt", 0, -1)
+	if err != nil {
+		t.Fatalf("read committed-local: %v", err)
+	}
+	if !bytes.Equal(got, localContent) {
+		t.Fatalf("committed-local content = %q, want %q", got, localContent)
+	}
+	entries, handled, err := fs.listGitDir(context.Background(), "/repo")
+	if err != nil {
+		t.Fatalf("listGitDir: %v", err)
+	}
+	if !handled {
+		t.Fatal("listGitDir handled = false, want true")
+	}
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		seen[entry.Name] = true
+	}
+	for _, name := range []string{"README.md", "committed-local.txt"} {
+		if !seen[name] {
+			t.Fatalf("listGitDir missing %s; entries=%v", name, seen)
+		}
+	}
+}
+
 func TestGitWorkspaceUnlinkCreateRefreshesDirtyMirror(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")

--- a/pkg/gitcache/cache.go
+++ b/pkg/gitcache/cache.go
@@ -131,6 +131,29 @@ func ReadTreeFile(ctx context.Context, localRoot, workspaceID, commit, rel strin
 	return readFileRange(f, info.Size(), offset, size)
 }
 
+// StatTreeFile returns the size of a materialized clean tree file or symlink.
+// The boolean is false when the materialized path is absent or not file-like.
+func StatTreeFile(ctx context.Context, localRoot, workspaceID, commit, rel string) (int64, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, false, err
+	}
+	p, err := treeFilePath(localRoot, workspaceID, commit, rel)
+	if err != nil {
+		return 0, false, err
+	}
+	info, err := os.Lstat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if info.IsDir() {
+		return 0, false, nil
+	}
+	return info.Size(), true, nil
+}
+
 // ReadBlob reads a cached blob.
 func ReadBlob(ctx context.Context, localRoot, workspaceID, commit, objectSHA string, offset, size int64) ([]byte, bool, error) {
 	if err := ctx.Err(); err != nil {
@@ -156,6 +179,29 @@ func ReadBlob(ctx context.Context, localRoot, workspaceID, commit, objectSHA str
 	}
 	defer func() { _ = f.Close() }()
 	return readFileRange(f, info.Size(), offset, size)
+}
+
+// StatBlob returns the size of a cached blob. The boolean is false when the
+// blob is absent or not a regular file.
+func StatBlob(ctx context.Context, localRoot, workspaceID, commit, objectSHA string) (int64, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, false, err
+	}
+	p, err := BlobPath(localRoot, workspaceID, commit, objectSHA)
+	if err != nil {
+		return 0, false, err
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if !info.Mode().IsRegular() {
+		return 0, false, nil
+	}
+	return info.Size(), true, nil
 }
 
 // WriteBlob writes a blob cache entry atomically. Existing entries are kept.

--- a/pkg/gitcache/cache_test.go
+++ b/pkg/gitcache/cache_test.go
@@ -189,6 +189,69 @@ func TestReadTreeFileReadsSymlinkTarget(t *testing.T) {
 	}
 }
 
+func TestStatTreeFileReturnsRegularAndSymlinkSizes(t *testing.T) {
+	localRoot := t.TempDir()
+	root := TreeRoot(localRoot, "ws1", "commit1")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("README.md", filepath.Join(root, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	size, hit, err := StatTreeFile(context.Background(), localRoot, "ws1", "commit1", "README.md")
+	if err != nil {
+		t.Fatalf("StatTreeFile regular: %v", err)
+	}
+	if !hit || size != int64(len("hello\n")) {
+		t.Fatalf("StatTreeFile regular = size %d hit %t, want %d true", size, hit, len("hello\n"))
+	}
+
+	size, hit, err = StatTreeFile(context.Background(), localRoot, "ws1", "commit1", "link")
+	if err != nil {
+		t.Fatalf("StatTreeFile symlink: %v", err)
+	}
+	if !hit || size != int64(len("README.md")) {
+		t.Fatalf("StatTreeFile symlink = size %d hit %t, want %d true", size, hit, len("README.md"))
+	}
+
+	size, hit, err = StatTreeFile(context.Background(), localRoot, "ws1", "commit1", "missing")
+	if err != nil {
+		t.Fatalf("StatTreeFile missing: %v", err)
+	}
+	if hit || size != 0 {
+		t.Fatalf("StatTreeFile missing = size %d hit %t, want 0 false", size, hit)
+	}
+}
+
+func TestStatBlobReturnsCachedBlobSize(t *testing.T) {
+	localRoot := t.TempDir()
+	data := []byte("cached blob\n")
+	sha := gitBlobSHA(data)
+	if err := WriteBlob(context.Background(), localRoot, "ws1", "commit1", sha, data); err != nil {
+		t.Fatal(err)
+	}
+
+	size, hit, err := StatBlob(context.Background(), localRoot, "ws1", "commit1", sha)
+	if err != nil {
+		t.Fatalf("StatBlob: %v", err)
+	}
+	if !hit || size != int64(len(data)) {
+		t.Fatalf("StatBlob = size %d hit %t, want %d true", size, hit, len(data))
+	}
+
+	size, hit, err = StatBlob(context.Background(), localRoot, "ws1", "commit1", "2222222222222222222222222222222222222222")
+	if err != nil {
+		t.Fatalf("StatBlob missing: %v", err)
+	}
+	if hit || size != 0 {
+		t.Fatalf("StatBlob missing = size %d hit %t, want 0 false", size, hit)
+	}
+}
+
 func TestHydrateWritesCleanTreeObjectsToGitObjectDB(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")


### PR DESCRIPTION
## Summary

This PR fixes the git workspace regressions reproduced by the live git feature matrix on `main`, especially sandbox replacement after fast git workflows.

The failures came from several related gaps in the fast git workspace path:

- clean git tree entries could have unknown sizes after blobless/fast registration, so FUSE stat/read paths needed to resolve sizes from the local git cache or object database instead of surfacing unstable metadata;
- after a local commit, the workspace runtime still used the backend registered `head_commit` tree only, so paths that existed only in the sandbox-local HEAD could appear missing after restore;
- dirty mirror writes were durable locally, but the in-memory overlay was not always published early enough for immediate reads/status;
- fast clone configured split-index/untracked-cache before backend workspace registration, leaving a race where the mount could observe local `.git` before the git workspace row/tree existed;
- shell-style truncation could leave stale bytes in the local dirty mirror;
- shutdown could miss dirty mirror content that had not been flushed through a live handle, which broke the oversized staged-object downgrade path.

## Changes

- Resolve unknown clean file sizes from `gitcache` tree/blob cache or local git objects before returning FUSE metadata.
- Add local-HEAD tree support so committed local files remain visible when the local `.git` HEAD differs from the backend registered head.
- Publish dirty mirror placeholder entries immediately on create/truncate/write so same-sandbox reads and git status can observe pending content.
- Force refresh git workspace metadata when a non-`.git` path has local git-state hints but no matching runtime, while avoiding the refresh shortcut for native `.git` writes.
- Move fast clone/worktree optimization config until after backend workspace and tree registration.
- Fix `O_TRUNC` and `SetAttr(size=0)` dirty mirror handling so truncation does not preserve stale tails.
- Add a final shutdown dirty mirror sweep. It now scans all local `git-workspaces/*/*/dirty` directories, not just currently loaded runtimes, and uploads any remaining working-tree content synchronously before the final `.git` checkpoint.
- Adjust the oversized staged-object e2e fixture to use exactly `5 MiB + 1 byte`, matching the current local-only object-pack threshold while avoiding an unrelated larger inline-overlay payload.

## Validation

Local tests:

```bash
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9/cli -count=1
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/fuse -run 'TestGitWorkspaceDirtyMirrorSweepUploadsContent|TestGitWorkspaceDirtyMirrorSweepUploadsUnloadedRuntime|TestGitWorkspaceAppendOpenUsesCurrentBufferEnd' -count=1
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/gitcache ./pkg/fuse -count=1
bash -n e2e/_feature-matrix-runner.sh e2e/git-feature-matrix.sh
```

Live EC2/dev e2e:

```bash
DRIVE9_BASE=http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com \
FEATURE_MATRIX_REPORT_DIR=/home/ubuntu/drive9-git-e2e-results-fix-git-codex-20260608-9 \
CLI_SOURCE=build \
bash e2e/git-feature-matrix.sh
```

Result:

- Report: `/home/ubuntu/drive9-git-e2e-results-fix-git-codex-20260608-9/git-feature-report-20260608-123421.md`
- Summary: `PASS 110`, `FAIL 0`, `TOTAL 110`
- Verified sandbox A/B restore, staged files, local commits, stash, merge/rebase flows, dirty overlay restore, whiteout/chmod/symlink restore, ignored generated files, and oversized staged-object downgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lightweight checks for cached git content size/availability
  * Improved local-head caching to resolve sizes and listings without remote queries

* **Bug Fixes**
  * Moved optimization steps to run after workspace registration to improve reliability
  * Improved overlay mirror consistency, write/truncate behavior, and stronger shutdown sync sequencing

* **Tests**
  * Expanded tests for local-head snapshots, mirror uploads, size resolution, forced refresh and refresh-on-local-git appearance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->