### PR TITLE
Ignore FileGC worker cancellation on shutdown

### DIFF
--- a/pkg/backend/file_gc_worker.go
+++ b/pkg/backend/file_gc_worker.go
@@ -103,20 +103,36 @@ func (w *FileGCWorker) run(ctx context.Context) {
 }
 
 func (w *FileGCWorker) processAvailable(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
 	now := time.Now().UTC()
 	if _, err := w.backend.store.RecoverExpiredFileGCTasks(ctx, now, w.opts.RecoverLimit); err != nil {
+		if isContextDone(err) {
+			return
+		}
 		logger.Warn(ctx, "file_gc_recover_expired_failed", zap.Error(err))
 		metrics.RecordOperation("file_gc", "recover_expired", "error", 0)
 	}
 	for i := 0; i < w.opts.BatchSize; i++ {
+		if ctx.Err() != nil {
+			return
+		}
 		processed, err := w.backend.processOneFileGCTask(ctx, w.opts)
 		if err != nil {
+			if isContextDone(err) {
+				return
+			}
 			logger.Warn(ctx, "file_gc_task_process_failed", zap.Error(err))
 		}
 		if !processed {
 			return
 		}
 	}
+}
+
+func isContextDone(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 // ProcessOneFileGCTask processes at most one queued cleanup task. It is exposed


### PR DESCRIPTION
## Summary
- stop FileGC recovery/claim loops when the worker context is already canceled
- suppress warning logs for context cancellation/deadline errors during shutdown

## Tests
- env GOCACHE=/tmp/drive9-go-build go test ./pkg/backend -count=1
- env GOCACHE=/tmp/drive9-go-build GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-lint make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File garbage collection process now exits cleanly during context cancellation with fewer unnecessary warning messages and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->