### PR TITLE
fix(schema): strip ADD_COLUMNAR_REPLICA_ON_DEMAND from FULLTEXT/VECTOR index repair SQL

### DIFF
--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -1526,20 +1526,35 @@ func diffTiDBTable(ctx context.Context, db *sql.DB, table tidbTableSpec) ([]tidb
 }
 
 func loadObservedTiDBIndexes(ctx context.Context, db *sql.DB, tableName, createStmt string) (map[string]struct{}, bool) {
-	indexNames, err := loadTiDBIndexNames(ctx, db, tableName)
-	if err == nil {
-		return indexNames, true
+	indexNames, statErr := loadTiDBIndexNames(ctx, db, tableName)
+	if statErr != nil {
+		logger.Warn(ctx, "tenant_tidb_schema_load_index_metadata_failed",
+			zap.String("table", tableName),
+			zap.Error(statErr))
 	}
-	logger.Warn(ctx, "tenant_tidb_schema_load_index_metadata_failed",
-		zap.String("table", tableName),
-		zap.Error(err))
-	observedIndexes, ok := parseObservedTiDBIndexes(createStmt)
-	if ok {
-		return observedIndexes, true
+
+	merged := make(map[string]struct{})
+	if statErr == nil {
+		for name := range indexNames {
+			merged[name] = struct{}{}
+		}
 	}
-	logger.Warn(ctx, "tenant_tidb_schema_parse_show_create_indexes_failed",
-		zap.String("table", tableName))
-	return nil, false
+
+	if observedIndexes, ok := parseObservedTiDBIndexes(createStmt); ok {
+		for name := range observedIndexes {
+			if _, exists := merged[name]; !exists {
+				merged[name] = struct{}{}
+			}
+		}
+	} else if statErr != nil {
+		logger.Warn(ctx, "tenant_tidb_schema_parse_show_create_indexes_failed",
+			zap.String("table", tableName))
+	}
+
+	if len(merged) == 0 && statErr != nil {
+		return nil, false
+	}
+	return merged, true
 }
 
 func tidbSchemaSpecForMode(mode TiDBEmbeddingMode) (tidbSchemaSpec, error) {
@@ -2232,6 +2247,14 @@ func parseObservedTiDBIndexes(createStmt string) (map[string]struct{}, bool) {
 			if name, _ := parseIndexNameAndColumns(def, "VECTOR INDEX"); name != "" {
 				observed[name] = struct{}{}
 			}
+		case strings.HasPrefix(normalized, "spatial index "):
+			if name, _ := parseIndexNameAndColumns(def, "SPATIAL INDEX"); name != "" {
+				observed[name] = struct{}{}
+			}
+		case strings.HasPrefix(normalized, "spatial key "):
+			if name, _ := parseIndexNameAndColumns(def, "SPATIAL KEY"); name != "" {
+				observed[name] = struct{}{}
+			}
 		case strings.HasPrefix(normalized, "index "):
 			if name, _ := parseIndexNameAndColumns(def, "INDEX"); name != "" {
 				observed[name] = struct{}{}
@@ -2393,10 +2416,11 @@ func isSafeAddColumnRepairSQL(sqlText string) bool {
 
 func isSafeAddIndexRepairSQL(sqlText string) bool {
 	normalized := normalizeSQLFragment(sqlText)
-	if strings.HasPrefix(normalized, "create index ") {
-		return true
-	}
-	if strings.HasPrefix(normalized, "create unique index ") {
+	if strings.HasPrefix(normalized, "create index ") ||
+		strings.HasPrefix(normalized, "create unique index ") ||
+		strings.HasPrefix(normalized, "create fulltext index ") ||
+		strings.HasPrefix(normalized, "create vector index ") ||
+		strings.HasPrefix(normalized, "create spatial index ") {
 		return true
 	}
 	if strings.HasPrefix(normalized, "alter table ") {

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -1790,6 +1790,24 @@ func parseInlineIndexDefinition(tableName, def string) (indexName, createSQL str
 	if name, cols, ok := parseConstraintUniqueIndexDefinition(def); ok {
 		return name, fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s%s", name, tableName, cols), true
 	}
+	if strings.HasPrefix(normalized, "fulltext index ") || strings.HasPrefix(normalized, "fulltext key ") {
+		prefix := "FULLTEXT INDEX"
+		if strings.HasPrefix(normalized, "fulltext key ") {
+			prefix = "FULLTEXT KEY"
+		}
+		name, cols := parseIndexNameAndColumns(def, prefix)
+		if name == "" || cols == "" {
+			return "", "", false
+		}
+		return name, fmt.Sprintf("CREATE FULLTEXT INDEX %s ON %s%s", name, tableName, cols), true
+	}
+	if strings.HasPrefix(normalized, "vector index ") {
+		name, cols := parseIndexNameAndColumns(def, "VECTOR INDEX")
+		if name == "" || cols == "" {
+			return "", "", false
+		}
+		return name, fmt.Sprintf("CREATE VECTOR INDEX %s ON %s%s", name, tableName, cols), true
+	}
 	if strings.HasPrefix(normalized, "index ") || strings.HasPrefix(normalized, "key ") {
 		prefix := "INDEX"
 		if strings.HasPrefix(normalized, "key ") {
@@ -2008,6 +2026,12 @@ func parseCreateIndexStatement(stmt string) (tableName, indexName, createSQL str
 	switch {
 	case strings.HasPrefix(normalized, "create unique index "):
 		prefix = "create unique index "
+	case strings.HasPrefix(normalized, "create fulltext index "):
+		prefix = "create fulltext index "
+	case strings.HasPrefix(normalized, "create vector index "):
+		prefix = "create vector index "
+	case strings.HasPrefix(normalized, "create spatial index "):
+		prefix = "create spatial index "
 	case strings.HasPrefix(normalized, "create index "):
 		prefix = "create index "
 	default:
@@ -2071,10 +2095,22 @@ func parseAlterTableAddIndexStatement(stmt string) (tableName, indexName, create
 		if len(nameFields) == 0 {
 			return "", "", "", false
 		}
-		return table, strings.ToLower(nameFields[0]), strings.TrimSpace(stmt), true
+		createSQL := strings.TrimSpace(stmt)
+		if marker == " add fulltext index " || marker == " add vector index " {
+			createSQL = stripColumnarReplicaOnDemand(createSQL)
+		}
+		return table, strings.ToLower(nameFields[0]), createSQL, true
 	}
 
 	return "", "", "", false
+}
+
+func stripColumnarReplicaOnDemand(stmt string) string {
+	idx := strings.LastIndex(strings.ToLower(stmt), "add_columnar_replica_on_demand")
+	if idx < 0 {
+		return stmt
+	}
+	return strings.TrimSpace(stmt[:idx])
 }
 
 func diffTiDBTableMeta(table tidbTableSpec, meta tidbTableMeta, createStmt string) []tidbSchemaDiff {
@@ -2182,6 +2218,18 @@ func parseObservedTiDBIndexes(createStmt string) (map[string]struct{}, bool) {
 			}
 		case strings.HasPrefix(normalized, "unique index "):
 			if name, _ := parseIndexNameAndColumns(def, "UNIQUE INDEX"); name != "" {
+				observed[name] = struct{}{}
+			}
+		case strings.HasPrefix(normalized, "fulltext index "):
+			if name, _ := parseIndexNameAndColumns(def, "FULLTEXT INDEX"); name != "" {
+				observed[name] = struct{}{}
+			}
+		case strings.HasPrefix(normalized, "fulltext key "):
+			if name, _ := parseIndexNameAndColumns(def, "FULLTEXT KEY"); name != "" {
+				observed[name] = struct{}{}
+			}
+		case strings.HasPrefix(normalized, "vector index "):
+			if name, _ := parseIndexNameAndColumns(def, "VECTOR INDEX"); name != "" {
 				observed[name] = struct{}{}
 			}
 		case strings.HasPrefix(normalized, "index "):

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -1034,6 +1034,123 @@ func TestParseAlterTableAddIndexStatementAcceptsUniqueKey(t *testing.T) {
 	}
 }
 
+func TestStripColumnarReplicaOnDemand(t *testing.T) {
+	tests := []struct {
+		name string
+		stmt string
+		want string
+	}{
+		{
+			name: "fulltext index with add_columnar_replica_on_demand",
+			stmt: "ALTER TABLE semantic ADD FULLTEXT INDEX idx_semantic_fts_description(description) WITH PARSER MULTILINGUAL ADD_COLUMNAR_REPLICA_ON_DEMAND",
+			want: "ALTER TABLE semantic ADD FULLTEXT INDEX idx_semantic_fts_description(description) WITH PARSER MULTILINGUAL",
+		},
+		{
+			name: "vector index with add_columnar_replica_on_demand",
+			stmt: "ALTER TABLE semantic ADD VECTOR INDEX idx_semantic_cosine((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND",
+			want: "ALTER TABLE semantic ADD VECTOR INDEX idx_semantic_cosine((VEC_COSINE_DISTANCE(embedding)))",
+		},
+		{
+			name: "no add_columnar_replica_on_demand",
+			stmt: "ALTER TABLE uploads ADD UNIQUE KEY uk_uploads_target (target_path)",
+			want: "ALTER TABLE uploads ADD UNIQUE KEY uk_uploads_target (target_path)",
+		},
+		{
+			name: "regular add index without columnar",
+			stmt: "ALTER TABLE contents ADD INDEX idx_contents_ref (storage_ref_hash)",
+			want: "ALTER TABLE contents ADD INDEX idx_contents_ref (storage_ref_hash)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripColumnarReplicaOnDemand(tt.stmt)
+			if got != tt.want {
+				t.Fatalf("stripColumnarReplicaOnDemand()=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAlterTableAddFulltextIndexStripsColumnarReplicaOnDemand(t *testing.T) {
+	stmt := `ALTER TABLE semantic
+		ADD FULLTEXT INDEX idx_semantic_fts_description(description)
+		WITH PARSER MULTILINGUAL
+		ADD_COLUMNAR_REPLICA_ON_DEMAND`
+
+	tableName, indexName, createSQL, ok := parseAlterTableAddIndexStatement(stmt)
+	if !ok {
+		t.Fatal("expected ALTER TABLE with ADD FULLTEXT INDEX to parse")
+	}
+	if tableName != "semantic" {
+		t.Fatalf("tableName=%q, want semantic", tableName)
+	}
+	if indexName != "idx_semantic_fts_description" {
+		t.Fatalf("indexName=%q, want idx_semantic_fts_description", indexName)
+	}
+	if strings.Contains(strings.ToLower(createSQL), "add_columnar_replica_on_demand") {
+		t.Fatalf("createSQL must not contain ADD_COLUMNAR_REPLICA_ON_DEMAND: %q", createSQL)
+	}
+	if !strings.Contains(createSQL, "ADD FULLTEXT INDEX") {
+		t.Fatalf("createSQL must contain ADD FULLTEXT INDEX: %q", createSQL)
+	}
+}
+
+func TestParseAlterTableAddVectorIndexStripsColumnarReplicaOnDemand(t *testing.T) {
+	stmt := `ALTER TABLE semantic
+		ADD VECTOR INDEX idx_semantic_cosine((VEC_COSINE_DISTANCE(embedding)))
+		ADD_COLUMNAR_REPLICA_ON_DEMAND`
+
+	tableName, indexName, createSQL, ok := parseAlterTableAddIndexStatement(stmt)
+	if !ok {
+		t.Fatal("expected ALTER TABLE with ADD VECTOR INDEX to parse")
+	}
+	if tableName != "semantic" {
+		t.Fatalf("tableName=%q, want semantic", tableName)
+	}
+	if indexName != "idx_semantic_cosine" {
+		t.Fatalf("indexName=%q, want idx_semantic_cosine", indexName)
+	}
+	if strings.Contains(strings.ToLower(createSQL), "add_columnar_replica_on_demand") {
+		t.Fatalf("createSQL must not contain ADD_COLUMNAR_REPLICA_ON_DEMAND: %q", createSQL)
+	}
+	if !strings.Contains(createSQL, "ADD VECTOR INDEX") {
+		t.Fatalf("createSQL must contain ADD VECTOR INDEX: %q", createSQL)
+	}
+}
+
+func TestParseObservedTiDBIndexesRecognizesFulltextAndVector(t *testing.T) {
+	createStmt := `CREATE TABLE semantic (
+		inode_id VARCHAR(64) PRIMARY KEY,
+		content_text LONGTEXT,
+		description LONGTEXT,
+		embedding VECTOR(1024) GENERATED ALWAYS AS (EMBED_TEXT('m', content_text, '{}')) STORED,
+		description_embedding VECTOR(1024) GENERATED ALWAYS AS (EMBED_TEXT('m', description, '{}')) STORED,
+		FULLTEXT INDEX idx_semantic_fts_content (content_text),
+		FULLTEXT KEY idx_semantic_fts_description (description),
+		VECTOR INDEX idx_semantic_cosine ((VEC_COSINE_DISTANCE(embedding))),
+		VECTOR INDEX idx_semantic_desc_cosine ((VEC_COSINE_DISTANCE(description_embedding)))
+	)`
+	observed, ok := parseObservedTiDBIndexes(createStmt)
+	if !ok {
+		t.Fatal("expected observed indexes parse to succeed")
+	}
+	if !hasObservedTiDBIndex(observed, "idx_semantic_fts_content") {
+		t.Fatalf("expected idx_semantic_fts_content FULLTEXT INDEX to be observed, got %#v", observed)
+	}
+	if !hasObservedTiDBIndex(observed, "idx_semantic_fts_description") {
+		t.Fatalf("expected idx_semantic_fts_description FULLTEXT KEY to be observed, got %#v", observed)
+	}
+	if !hasObservedTiDBIndex(observed, "idx_semantic_cosine") {
+		t.Fatalf("expected idx_semantic_cosine VECTOR INDEX to be observed, got %#v", observed)
+	}
+	if !hasObservedTiDBIndex(observed, "idx_semantic_desc_cosine") {
+		t.Fatalf("expected idx_semantic_desc_cosine VECTOR INDEX to be observed, got %#v", observed)
+	}
+	if !hasObservedTiDBIndex(observed, "primary") {
+		t.Fatal("expected primary key to be observed from inline PRIMARY KEY column")
+	}
+}
+
 func testSemanticTableMeta(mode TiDBEmbeddingMode) tidbTableMeta {
 	meta := tidbTableMeta{
 		tableName: "semantic",


### PR DESCRIPTION
## Problem

When a tenant's `semantic` table is missing a FULLTEXT or VECTOR index, the schema repair uses the original ALTER TABLE statement as repair SQL. This statement includes `ADD_COLUMNAR_REPLICA_ON_DEMAND`:

```sql
ALTER TABLE semantic
    ADD FULLTEXT INDEX idx_semantic_fts_description(description)
    WITH PARSER MULTILINGUAL
    ADD_COLUMNAR_REPLICA_ON_DEMAND
```

On TiDB instances without columnar replica support, the entire ALTER TABLE fails. The error is silently swallowed by `isIgnorableOptionalSchemaError` because it matches the `fulltext` / `add_columnar_replica_on_demand` keyword checks. The index is never created, and repeated repair passes all fail identically. After 3 passes, final validation reports:

```
tidb schema contract mismatch for mode "auto-embedding":
semantic schema contract: missing idx_semantic_fts_description index
```

## Root Cause (2 issues)

1. **Repair SQL contains `ADD_COLUMNAR_REPLICA_ON_DEMAND`**: `parseAlterTableAddIndexStatement` returns the full ALTER TABLE statement as the repair SQL. The columnar replica clause is unrelated to index creation but causes the entire statement to fail on unsupported TiDB instances.

2. **Fallback parser misses FULLTEXT/VECTOR indexes**: `parseObservedTiDBIndexes` (fallback when `information_schema.statistics` doesn't return these index types) only handled plain INDEX/KEY/UNIQUE variants, not FULLTEXT INDEX/KEY or VECTOR INDEX definitions from SHOW CREATE TABLE output.

## Fix

- `stripColumnarReplicaOnDemand`: strips `ADD_COLUMNAR_REPLICA_ON_DEMAND` from FULLTEXT/VECTOR index repair SQL
- `parseObservedTiDBIndexes`: recognizes `FULLTEXT INDEX` / `FULLTEXT KEY` / `VECTOR INDEX` definitions
- `parseCreateIndexStatement` / `parseInlineIndexDefinition`: adds `CREATE FULLTEXT/VECTOR/SPATIAL INDEX` handling for robustness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for TiDB index types including FULLTEXT, VECTOR, and SPATIAL indexes in schema parsing and validation.
  * Improved schema normalization for accurate index comparison and repair operations.

* **Tests**
  * Added comprehensive test coverage for index type parsing and schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->