### PR TITLE
Fix fast git workspace clone and worktree e2e regressions

### DIFF
--- a/cmd/drive9/cli/git.go
+++ b/cmd/drive9/cli/git.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -135,7 +136,7 @@ func gitClone(args []string) error {
 	if enrichErr != nil {
 		fmt.Fprintf(os.Stderr, "drive9: warning: could not enrich GitHub tree sizes: %v\n", enrichErr)
 		if unknown := unknownGitTreeFileSizeCount(nodes); unknown > 0 {
-			fmt.Fprintf(os.Stderr, "drive9: warning: %d git file sizes remain unknown; git status may need to read those blobs lazily\n", unknown)
+			fmt.Fprintf(os.Stderr, "drive9: warning: %d git file sizes remain unknown; stat metadata will stay unknown until file content is read\n", unknown)
 		}
 	} else {
 		nodes = enriched
@@ -162,6 +163,9 @@ func gitClone(args []string) error {
 	cancel()
 	if err != nil {
 		return fmt.Errorf("register git workspace: %w", err)
+	}
+	if err := clearLocalGitWorkspaceDeleted(cmdCtx, resolved, ws.WorkspaceID); err != nil {
+		return fmt.Errorf("clear stale local git workspace deletion marker: %w", err)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
 	if err := c.ReplaceGitTree(ctx, ws.WorkspaceID, client.GitTreeReplaceRequest{
@@ -331,7 +335,7 @@ func gitWorktreeAdd(args []string) error {
 	if enrichErr != nil {
 		fmt.Fprintf(os.Stderr, "drive9: warning: could not enrich GitHub tree sizes: %v\n", enrichErr)
 		if unknown := unknownGitTreeFileSizeCount(nodes); unknown > 0 {
-			fmt.Fprintf(os.Stderr, "drive9: warning: %d git file sizes remain unknown; git status may need to read those blobs lazily\n", unknown)
+			fmt.Fprintf(os.Stderr, "drive9: warning: %d git file sizes remain unknown; stat metadata will stay unknown until file content is read\n", unknown)
 		}
 	} else {
 		nodes = enriched
@@ -362,6 +366,9 @@ func gitWorktreeAdd(args []string) error {
 	cancel()
 	if err != nil {
 		return fmt.Errorf("register linked git workspace: %w", err)
+	}
+	if err := clearLocalGitWorkspaceDeleted(cmdCtx, worktreeResolved, ws.WorkspaceID); err != nil {
+		return fmt.Errorf("clear stale linked git workspace deletion marker: %w", err)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
 	if err := c.ReplaceGitTree(ctx, ws.WorkspaceID, client.GitTreeReplaceRequest{
@@ -504,16 +511,22 @@ func gitWorktreeRemove(args []string) error {
 		return fmt.Errorf("delete linked git workspace: %w", err)
 	}
 	cancel()
-	if err := markLocalGitWorkspaceDeleted(resolved, ws.WorkspaceID); err != nil {
-		return fmt.Errorf("mark linked git workspace deleted locally: %w", err)
+	var cleanupErrs []error
+	if err := markLocalGitWorkspaceDeleted(cmdCtx, resolved, ws.WorkspaceID); err != nil {
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("mark linked git workspace deleted locally: %w", err))
 	}
 	if overlayRoot, err := localOverlayRootForMountedTarget(resolved); err == nil && overlayRoot != "" {
 		if err := os.RemoveAll(overlayRoot); err != nil {
-			return fmt.Errorf("remove linked local overlay root: %w", err)
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("remove linked local overlay root: %w", err))
 		}
+	} else if err != nil {
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("resolve linked local overlay root: %w", err))
 	}
 	if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
 		fmt.Fprintf(os.Stderr, "drive9: warning: could not remove empty worktree root %s: %v\n", target, err)
+	}
+	if err := errors.Join(cleanupErrs...); err != nil {
+		return err
 	}
 	fmt.Fprintf(os.Stderr, "drive9: removed linked git workspace %s at :%s\n", ws.WorkspaceID, resolved.RemotePath)
 	return nil
@@ -791,7 +804,7 @@ func localOverlayRootForMountedTarget(resolved mountedGitTarget) (string, error)
 	return localPath, nil
 }
 
-func markLocalGitWorkspaceDeleted(resolved mountedGitTarget, workspaceID string) error {
+func markLocalGitWorkspaceDeleted(ctx context.Context, resolved mountedGitTarget, workspaceID string) error {
 	localRoot := strings.TrimSpace(resolved.LocalRoot)
 	if localRoot == "" || strings.TrimSpace(workspaceID) == "" {
 		return nil
@@ -799,7 +812,18 @@ func markLocalGitWorkspaceDeleted(resolved mountedGitTarget, workspaceID string)
 	if !filepath.IsAbs(localRoot) {
 		return fmt.Errorf("drive9 mount metadata local_root must be absolute, got %q", localRoot)
 	}
-	return gitcache.MarkWorkspaceDeleted(localRoot, workspaceID)
+	return gitcache.MarkWorkspaceDeleted(ctx, localRoot, workspaceID)
+}
+
+func clearLocalGitWorkspaceDeleted(ctx context.Context, resolved mountedGitTarget, workspaceID string) error {
+	localRoot := strings.TrimSpace(resolved.LocalRoot)
+	if localRoot == "" || strings.TrimSpace(workspaceID) == "" {
+		return nil
+	}
+	if !filepath.IsAbs(localRoot) {
+		return fmt.Errorf("drive9 mount metadata local_root must be absolute, got %q", localRoot)
+	}
+	return gitcache.ClearWorkspaceDeleted(ctx, localRoot, workspaceID)
 }
 
 func sameDrive9Mount(a, b mountedGitTarget) bool {

--- a/cmd/drive9/cli/git.go
+++ b/cmd/drive9/cli/git.go
@@ -164,9 +164,6 @@ func gitClone(args []string) error {
 	if err != nil {
 		return fmt.Errorf("register git workspace: %w", err)
 	}
-	if err := clearLocalGitWorkspaceDeleted(cmdCtx, resolved, ws.WorkspaceID); err != nil {
-		return fmt.Errorf("clear stale local git workspace deletion marker: %w", err)
-	}
 	ctx, cancel = context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
 	if err := c.ReplaceGitTree(ctx, ws.WorkspaceID, client.GitTreeReplaceRequest{
 		CommitSHA: head,
@@ -202,6 +199,9 @@ func gitClone(args []string) error {
 				fmt.Fprintf(os.Stderr, "drive9: warning: could not start background hydrate: %v\n", err)
 			}
 		}
+	}
+	if err := clearLocalGitWorkspaceDeleted(cmdCtx, resolved, ws.WorkspaceID); err != nil {
+		return fmt.Errorf("clear stale local git workspace deletion marker: %w", err)
 	}
 	return nil
 }
@@ -367,9 +367,6 @@ func gitWorktreeAdd(args []string) error {
 	if err != nil {
 		return fmt.Errorf("register linked git workspace: %w", err)
 	}
-	if err := clearLocalGitWorkspaceDeleted(cmdCtx, worktreeResolved, ws.WorkspaceID); err != nil {
-		return fmt.Errorf("clear stale linked git workspace deletion marker: %w", err)
-	}
 	ctx, cancel = context.WithTimeout(context.Background(), gitWorkspaceAPITimeout)
 	if err := c.ReplaceGitTree(ctx, ws.WorkspaceID, client.GitTreeReplaceRequest{
 		CommitSHA: head,
@@ -408,6 +405,9 @@ func gitWorktreeAdd(args []string) error {
 				fmt.Fprintf(os.Stderr, "drive9: warning: could not start background hydrate: %v\n", err)
 			}
 		}
+	}
+	if err := clearLocalGitWorkspaceDeleted(cmdCtx, worktreeResolved, ws.WorkspaceID); err != nil {
+		return fmt.Errorf("clear stale linked git workspace deletion marker: %w", err)
 	}
 	return nil
 }

--- a/cmd/drive9/cli/git.go
+++ b/cmd/drive9/cli/git.go
@@ -122,7 +122,7 @@ func gitClone(args []string) error {
 	if branchErr != nil {
 		branch = ""
 	}
-	nodes, err := gitListTree(cmdCtx, target, head)
+	nodes, err := gitListTree(cmdCtx, target, head, !*blobless)
 	if err != nil {
 		return err
 	}
@@ -321,7 +321,7 @@ func gitWorktreeAdd(args []string) error {
 	if branchErr != nil {
 		branchName = ""
 	}
-	nodes, err := gitListTree(cmdCtx, worktreePath, head)
+	nodes, err := gitListTree(cmdCtx, worktreePath, head, !linkedBlobless)
 	if err != nil {
 		return err
 	}
@@ -1027,8 +1027,8 @@ func gitRun(ctx context.Context, repoDir string, args ...string) error {
 	return nil
 }
 
-func gitListTree(ctx context.Context, repoDir, commitSHA string) ([]client.GitTreeNode, error) {
-	full := gitListTreeArgs(repoDir, commitSHA)
+func gitListTree(ctx context.Context, repoDir, commitSHA string, includeSizes bool) ([]client.GitTreeNode, error) {
+	full := gitListTreeArgs(repoDir, commitSHA, includeSizes)
 	cmd := exec.CommandContext(ctx, "git", full...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -1047,8 +1047,12 @@ func gitListTree(ctx context.Context, repoDir, commitSHA string) ([]client.GitTr
 	return nodes, nil
 }
 
-func gitListTreeArgs(repoDir, commitSHA string) []string {
-	return []string{"-C", repoDir, "ls-tree", "-r", "-t", "-z", commitSHA}
+func gitListTreeArgs(repoDir, commitSHA string, includeSizes bool) []string {
+	args := []string{"-C", repoDir, "ls-tree", "-r", "-t"}
+	if includeSizes {
+		args = append(args, "-l")
+	}
+	return append(args, "-z", commitSHA)
 }
 
 func parseGitLsTree(out []byte) ([]client.GitTreeNode, error) {

--- a/cmd/drive9/cli/git.go
+++ b/cmd/drive9/cli/git.go
@@ -990,7 +990,7 @@ func gitRun(ctx context.Context, repoDir string, args ...string) error {
 }
 
 func gitListTree(ctx context.Context, repoDir, commitSHA string) ([]client.GitTreeNode, error) {
-	full := []string{"-C", repoDir, "ls-tree", "-r", "-t", "-l", "-z", commitSHA}
+	full := gitListTreeArgs(repoDir, commitSHA)
 	cmd := exec.CommandContext(ctx, "git", full...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -1007,6 +1007,10 @@ func gitListTree(ctx context.Context, repoDir, commitSHA string) ([]client.GitTr
 		return nil, fmt.Errorf("parse git ls-tree: %w", err)
 	}
 	return nodes, nil
+}
+
+func gitListTreeArgs(repoDir, commitSHA string) []string {
+	return []string{"-C", repoDir, "ls-tree", "-r", "-t", "-z", commitSHA}
 }
 
 func parseGitLsTree(out []byte) ([]client.GitTreeNode, error) {

--- a/cmd/drive9/cli/git.go
+++ b/cmd/drive9/cli/git.go
@@ -504,6 +504,9 @@ func gitWorktreeRemove(args []string) error {
 		return fmt.Errorf("delete linked git workspace: %w", err)
 	}
 	cancel()
+	if err := markLocalGitWorkspaceDeleted(resolved, ws.WorkspaceID); err != nil {
+		return fmt.Errorf("mark linked git workspace deleted locally: %w", err)
+	}
 	if overlayRoot, err := localOverlayRootForMountedTarget(resolved); err == nil && overlayRoot != "" {
 		if err := os.RemoveAll(overlayRoot); err != nil {
 			return fmt.Errorf("remove linked local overlay root: %w", err)
@@ -786,6 +789,17 @@ func localOverlayRootForMountedTarget(resolved mountedGitTarget) (string, error)
 		localPath = filepath.Join(localPath, resolved.MountRel)
 	}
 	return localPath, nil
+}
+
+func markLocalGitWorkspaceDeleted(resolved mountedGitTarget, workspaceID string) error {
+	localRoot := strings.TrimSpace(resolved.LocalRoot)
+	if localRoot == "" || strings.TrimSpace(workspaceID) == "" {
+		return nil
+	}
+	if !filepath.IsAbs(localRoot) {
+		return fmt.Errorf("drive9 mount metadata local_root must be absolute, got %q", localRoot)
+	}
+	return gitcache.MarkWorkspaceDeleted(localRoot, workspaceID)
 }
 
 func sameDrive9Mount(a, b mountedGitTarget) bool {

--- a/cmd/drive9/cli/git_test.go
+++ b/cmd/drive9/cli/git_test.go
@@ -75,8 +75,15 @@ func TestParseGitLsTreeWithoutSizes(t *testing.T) {
 	}
 }
 
-func TestGitListTreeArgsAvoidBlobSizeLookup(t *testing.T) {
-	args := gitListTreeArgs("/mnt/repo", "abc123")
+func TestGitListTreeArgsIncludesBlobSizeLookupForFast(t *testing.T) {
+	args := gitListTreeArgs("/mnt/repo", "abc123", true)
+	if got, want := strings.Join(args, " "), "-C /mnt/repo ls-tree -r -t -l -z abc123"; got != want {
+		t.Fatalf("gitListTreeArgs = %q, want %q", got, want)
+	}
+}
+
+func TestGitListTreeArgsAvoidsBlobSizeLookupForBlobless(t *testing.T) {
+	args := gitListTreeArgs("/mnt/repo", "abc123", false)
 	if got, want := strings.Join(args, " "), "-C /mnt/repo ls-tree -r -t -z abc123"; got != want {
 		t.Fatalf("gitListTreeArgs = %q, want %q", got, want)
 	}
@@ -102,7 +109,7 @@ func TestGitListTreeLeavesBlobSizesUnknown(t *testing.T) {
 	runTestGit(t, root, "commit", "-m", "initial")
 	head := gitOutputForTest(t, root, "rev-parse", "HEAD")
 
-	nodes, err := gitListTree(context.Background(), root, head)
+	nodes, err := gitListTree(context.Background(), root, head, false)
 	if err != nil {
 		t.Fatalf("gitListTree: %v", err)
 	}
@@ -114,6 +121,17 @@ func TestGitListTreeLeavesBlobSizesUnknown(t *testing.T) {
 	}
 	if nodes[0].SizeBytes != -1 {
 		t.Fatalf("SizeBytes = %d, want -1", nodes[0].SizeBytes)
+	}
+
+	nodes, err = gitListTree(context.Background(), root, head, true)
+	if err != nil {
+		t.Fatalf("gitListTree with sizes: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("len(nodes with sizes) = %d, want 1", len(nodes))
+	}
+	if nodes[0].SizeBytes != 6 {
+		t.Fatalf("SizeBytes with sizes = %d, want 6", nodes[0].SizeBytes)
 	}
 }
 

--- a/cmd/drive9/cli/git_test.go
+++ b/cmd/drive9/cli/git_test.go
@@ -75,7 +75,19 @@ func TestParseGitLsTreeWithoutSizes(t *testing.T) {
 	}
 }
 
-func TestGitListTreeIncludesBlobSizes(t *testing.T) {
+func TestGitListTreeArgsAvoidBlobSizeLookup(t *testing.T) {
+	args := gitListTreeArgs("/mnt/repo", "abc123")
+	if got, want := strings.Join(args, " "), "-C /mnt/repo ls-tree -r -t -z abc123"; got != want {
+		t.Fatalf("gitListTreeArgs = %q, want %q", got, want)
+	}
+	for _, arg := range args {
+		if arg == "-l" || arg == "--long" {
+			t.Fatalf("gitListTreeArgs includes blob size lookup arg %q: %v", arg, args)
+		}
+	}
+}
+
+func TestGitListTreeLeavesBlobSizesUnknown(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")
 	}
@@ -100,8 +112,8 @@ func TestGitListTreeIncludesBlobSizes(t *testing.T) {
 	if nodes[0].Path != "README.md" {
 		t.Fatalf("node path = %q, want README.md", nodes[0].Path)
 	}
-	if nodes[0].SizeBytes != 6 {
-		t.Fatalf("SizeBytes = %d, want 6", nodes[0].SizeBytes)
+	if nodes[0].SizeBytes != -1 {
+		t.Fatalf("SizeBytes = %d, want -1", nodes[0].SizeBytes)
 	}
 }
 

--- a/e2e/git-workspace-smoke-test.sh
+++ b/e2e/git-workspace-smoke-test.sh
@@ -266,7 +266,7 @@ start_mount() {
     echo "local_root=$local_root"
   } >>"$MOUNT_LOG"
 
-  local args=(mount --mode=fuse --profile=coding-agent --local-root "$local_root" --durability=interactive --perf-counters)
+  local args=(mount --foreground --mode=fuse --profile=coding-agent --local-root "$local_root" --durability=interactive --perf-counters)
   if [ "$GIT_WORKSPACE_ALLOW_OTHER" = "1" ]; then
     args+=(--allow-other)
   fi

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -72,6 +72,10 @@ func (rt *gitWorkspaceRuntime) isLinked() bool {
 	return rt != nil && rt.workspace.WorkspaceKind == "linked"
 }
 
+func gitWorkspaceIsFastBlobless(rt *gitWorkspaceRuntime) bool {
+	return rt != nil && rt.workspace.Mode == gitWorkspaceModeFastBlobless
+}
+
 type gitMaterializeCall struct {
 	done chan struct{}
 	data []byte
@@ -1317,6 +1321,9 @@ func (fs *Dat9FS) resolveGitCleanNodeSize(ctx context.Context, rt *gitWorkspaceR
 			rt.updateCleanNodeSize(rel, nodeCommit, size)
 			return size
 		}
+	}
+	if gitWorkspaceIsFastBlobless(rt) {
+		return n.SizeBytes
 	}
 	if n.ObjectSHA != "" {
 		if size, err := fs.gitCatFileBlobSize(ctx, rt, n.ObjectSHA); err == nil {

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -119,6 +119,9 @@ func (fs *Dat9FS) ensureGitWorkspacesWithRefresh(ctx context.Context, force bool
 	var loadErrs []error
 	for i := range workspaces {
 		ws := workspaces[i]
+		if fs.gitWorkspaceDeletedLocally(ws.WorkspaceID) {
+			continue
+		}
 		localRoot, ok := fs.localPath(strings.TrimSuffix(ws.RootPath, "/"))
 		if !ok {
 			continue
@@ -236,6 +239,9 @@ func (fs *Dat9FS) loadedGitWorkspaceForPath(localPath string) (*gitWorkspaceRunt
 	fs.git.mu.Lock()
 	defer fs.git.mu.Unlock()
 	for _, rt := range fs.git.workspaces {
+		if fs.gitWorkspaceRuntimeDeletedLocally(rt) {
+			continue
+		}
 		root := rt.localRoot
 		if root == "/" {
 			return rt, strings.TrimPrefix(clean, "/"), true
@@ -249,6 +255,20 @@ func (fs *Dat9FS) loadedGitWorkspaceForPath(localPath string) (*gitWorkspaceRunt
 		}
 	}
 	return nil, "", false
+}
+
+func (fs *Dat9FS) gitWorkspaceRuntimeDeletedLocally(rt *gitWorkspaceRuntime) bool {
+	if rt == nil {
+		return false
+	}
+	return fs.gitWorkspaceDeletedLocally(rt.workspace.WorkspaceID)
+}
+
+func (fs *Dat9FS) gitWorkspaceDeletedLocally(workspaceID string) bool {
+	if fs == nil || fs.opts == nil {
+		return false
+	}
+	return gitcache.WorkspaceDeleted(fs.opts.LocalRoot, workspaceID)
 }
 
 func (fs *Dat9FS) loadedGitWorkspaceForGitStatePath(localPath string) (*gitWorkspaceRuntime, string, bool) {
@@ -279,6 +299,9 @@ func (fs *Dat9FS) linkedWorkspaceForCommonGitStatePath(commonRT *gitWorkspaceRun
 	fs.git.mu.Lock()
 	defer fs.git.mu.Unlock()
 	for _, candidate := range fs.git.workspaces {
+		if fs.gitWorkspaceRuntimeDeletedLocally(candidate) {
+			continue
+		}
 		if candidate.workspace.CommonWorkspaceID == commonRT.workspace.WorkspaceID && candidate.workspace.WorktreeName == name {
 			if rest == "" {
 				return candidate, ".git", true
@@ -296,6 +319,9 @@ func (fs *Dat9FS) gitWorkspaceRuntimeByID(workspaceID string) (*gitWorkspaceRunt
 	fs.git.mu.Lock()
 	defer fs.git.mu.Unlock()
 	for _, rt := range fs.git.workspaces {
+		if fs.gitWorkspaceRuntimeDeletedLocally(rt) {
+			continue
+		}
 		if rt.workspace.WorkspaceID == workspaceID {
 			return rt, true
 		}

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -121,7 +121,7 @@ func (fs *Dat9FS) ensureGitWorkspacesWithRefresh(ctx context.Context, force bool
 	var loadErrs []error
 	for i := range workspaces {
 		ws := workspaces[i]
-		if fs.gitWorkspaceDeletedLocally(ws.WorkspaceID) {
+		if fs.gitWorkspaceDeletedLocally(ctx, ws.WorkspaceID) {
 			continue
 		}
 		localRoot, ok := fs.localPath(strings.TrimSuffix(ws.RootPath, "/"))
@@ -239,9 +239,11 @@ func (fs *Dat9FS) loadedGitWorkspaceForPath(localPath string) (*gitWorkspaceRunt
 	}
 	clean := path.Clean(localPath)
 	fs.git.mu.Lock()
-	defer fs.git.mu.Unlock()
-	for _, rt := range fs.git.workspaces {
-		if fs.gitWorkspaceRuntimeDeletedLocally(rt) {
+	workspaces := make([]*gitWorkspaceRuntime, len(fs.git.workspaces))
+	copy(workspaces, fs.git.workspaces)
+	fs.git.mu.Unlock()
+	for _, rt := range workspaces {
+		if fs.gitWorkspaceRuntimeDeletedLocally(context.Background(), rt) {
 			continue
 		}
 		root := rt.localRoot
@@ -259,18 +261,18 @@ func (fs *Dat9FS) loadedGitWorkspaceForPath(localPath string) (*gitWorkspaceRunt
 	return nil, "", false
 }
 
-func (fs *Dat9FS) gitWorkspaceRuntimeDeletedLocally(rt *gitWorkspaceRuntime) bool {
+func (fs *Dat9FS) gitWorkspaceRuntimeDeletedLocally(ctx context.Context, rt *gitWorkspaceRuntime) bool {
 	if rt == nil {
 		return false
 	}
-	return fs.gitWorkspaceDeletedLocally(rt.workspace.WorkspaceID)
+	return fs.gitWorkspaceDeletedLocally(ctx, rt.workspace.WorkspaceID)
 }
 
-func (fs *Dat9FS) gitWorkspaceDeletedLocally(workspaceID string) bool {
+func (fs *Dat9FS) gitWorkspaceDeletedLocally(ctx context.Context, workspaceID string) bool {
 	if fs == nil || fs.opts == nil {
 		return false
 	}
-	return gitcache.WorkspaceDeleted(fs.opts.LocalRoot, workspaceID)
+	return gitcache.WorkspaceDeleted(ctx, fs.opts.LocalRoot, workspaceID)
 }
 
 func (fs *Dat9FS) loadedGitWorkspaceForGitStatePath(localPath string) (*gitWorkspaceRuntime, string, bool) {
@@ -299,9 +301,11 @@ func (fs *Dat9FS) linkedWorkspaceForCommonGitStatePath(commonRT *gitWorkspaceRun
 		return nil, "", false
 	}
 	fs.git.mu.Lock()
-	defer fs.git.mu.Unlock()
-	for _, candidate := range fs.git.workspaces {
-		if fs.gitWorkspaceRuntimeDeletedLocally(candidate) {
+	workspaces := make([]*gitWorkspaceRuntime, len(fs.git.workspaces))
+	copy(workspaces, fs.git.workspaces)
+	fs.git.mu.Unlock()
+	for _, candidate := range workspaces {
+		if fs.gitWorkspaceRuntimeDeletedLocally(context.Background(), candidate) {
 			continue
 		}
 		if candidate.workspace.CommonWorkspaceID == commonRT.workspace.WorkspaceID && candidate.workspace.WorktreeName == name {
@@ -319,9 +323,11 @@ func (fs *Dat9FS) gitWorkspaceRuntimeByID(workspaceID string) (*gitWorkspaceRunt
 		return nil, false
 	}
 	fs.git.mu.Lock()
-	defer fs.git.mu.Unlock()
-	for _, rt := range fs.git.workspaces {
-		if fs.gitWorkspaceRuntimeDeletedLocally(rt) {
+	workspaces := make([]*gitWorkspaceRuntime, len(fs.git.workspaces))
+	copy(workspaces, fs.git.workspaces)
+	fs.git.mu.Unlock()
+	for _, rt := range workspaces {
+		if fs.gitWorkspaceRuntimeDeletedLocally(context.Background(), rt) {
 			continue
 		}
 		if rt.workspace.WorkspaceID == workspaceID {
@@ -884,10 +890,21 @@ func (fs *Dat9FS) gitInodeWithMtime(localPath string, isDir bool, size int64, mo
 }
 
 func gitCleanTreeMtime(rt *gitWorkspaceRuntime) time.Time {
-	if rt != nil && !rt.workspace.CreatedAt.IsZero() {
-		return rt.workspace.CreatedAt
+	base := gitCleanTreeDefaultMtime
+	commit := ""
+	if rt != nil {
+		if !rt.workspace.CreatedAt.IsZero() {
+			base = rt.workspace.CreatedAt
+		}
+		commit = strings.TrimSpace(rt.workspace.HeadCommit)
 	}
-	return gitCleanTreeDefaultMtime
+	if commit == "" {
+		return base
+	}
+	sum := sha256.Sum256([]byte(strings.ToLower(commit)))
+	raw := uint32(sum[0])<<24 | uint32(sum[1])<<16 | uint32(sum[2])<<8 | uint32(sum[3])
+	nsec := int64(raw % uint32(time.Second))
+	return time.Unix(base.Unix(), nsec).UTC()
 }
 
 func gitNodeMode(n client.GitTreeNode) (mode uint32, hasMode bool, isDir bool) {
@@ -1438,6 +1455,7 @@ func (fs *Dat9FS) gitCatFileBlobSize(ctx context.Context, rt *gitWorkspaceRuntim
 		fs.perf.gitCatFileCount.add(1)
 	}
 	cmd := exec.CommandContext(ctx, "git", "--git-dir", gitDir, "cat-file", "-s", objectSHA)
+	setGitNoLazyEnv(cmd)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
@@ -1896,6 +1914,13 @@ func buildRestoredGitHeadOverlay(ctx context.Context, gitDir string, rt *gitWork
 			UpdatedAt:     now,
 		}
 		if headEntry.kind == "file" || headEntry.kind == "symlink" {
+			object, err := gitRestoredHeadBlobInfo(ctx, gitDir, headEntry.oid, rel)
+			if err != nil {
+				return nil, err
+			}
+			if object.size > gitLocalObjectMaxBlobBytes {
+				return nil, fmt.Errorf("git HEAD tree object %s for %s is %d bytes, exceeds local restore limit %d", headEntry.oid, rel, object.size, gitLocalObjectMaxBlobBytes)
+			}
 			content, err := gitCatBlobNoLazy(ctx, gitDir, headEntry.oid)
 			if err != nil {
 				return nil, err
@@ -1929,6 +1954,21 @@ func buildRestoredGitHeadOverlay(ctx context.Context, gitDir string, rt *gitWork
 		return nil, nil
 	}
 	return out, nil
+}
+
+func gitRestoredHeadBlobInfo(ctx context.Context, gitDir, oid, rel string) (gitObjectInfo, error) {
+	info, err := gitObjectInfoBatch(ctx, gitDir, []string{oid})
+	if err != nil {
+		return gitObjectInfo{}, err
+	}
+	object := info[oid]
+	if object.typ == "" || object.typ == "missing" {
+		return gitObjectInfo{}, fmt.Errorf("git HEAD tree object %s for %s is missing", oid, rel)
+	}
+	if object.typ != "blob" {
+		return gitObjectInfo{}, fmt.Errorf("git HEAD tree object %s for %s is %s, want blob", oid, rel, object.typ)
+	}
+	return object, nil
 }
 
 func (rt *gitWorkspaceRuntime) gitHeadOverlayInputs() (map[string]client.GitTreeNode, map[string]struct{}) {

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -38,6 +38,8 @@ const gitWorkspaceModeFastBlobless = "fast-blobless"
 const gitLocalObjectMaxBlobBytes int64 = 5 << 20
 const gitLocalObjectMaxPackBytes int64 = 256 << 20
 
+var gitCleanTreeDefaultMtime = time.Unix(1, 0).UTC()
+
 type gitWorkspaceLayer struct {
 	mu         sync.Mutex
 	checkpoint sync.Mutex
@@ -812,7 +814,7 @@ func (fs *Dat9FS) gitTreeInode(ctx context.Context, rt *gitWorkspaceRuntime, loc
 	} else if size < 0 {
 		size = fs.resolveGitCleanNodeSize(ctx, rt, rel, n)
 	}
-	return fs.gitInode(localPath, isDir, size, mode, hasMode, incrementLookup)
+	return fs.gitInodeWithMtime(localPath, isDir, size, mode, hasMode, gitCleanTreeMtime(rt), incrementLookup)
 }
 
 func (fs *Dat9FS) gitOverlayInode(ctx context.Context, rt *gitWorkspaceRuntime, rel string, e client.GitOverlayEntry, incrementLookup bool) *InodeEntry {
@@ -863,15 +865,29 @@ func (fs *Dat9FS) gitOverlayInode(ctx context.Context, rt *gitWorkspaceRuntime, 
 }
 
 func (fs *Dat9FS) gitInode(localPath string, isDir bool, size int64, mode uint32, hasMode bool, incrementLookup bool) *InodeEntry {
+	return fs.gitInodeWithMtime(localPath, isDir, size, mode, hasMode, time.Now(), incrementLookup)
+}
+
+func (fs *Dat9FS) gitInodeWithMtime(localPath string, isDir bool, size int64, mode uint32, hasMode bool, mtime time.Time, incrementLookup bool) *InodeEntry {
+	if mtime.IsZero() {
+		mtime = time.Now()
+	}
 	var ino uint64
 	if incrementLookup {
-		ino = fs.inodes.Lookup(localPath, isDir, size, time.Now())
+		ino = fs.inodes.Lookup(localPath, isDir, size, mtime)
 	} else {
-		ino = fs.inodes.EnsureInode(localPath, isDir, size, time.Now())
+		ino = fs.inodes.EnsureInode(localPath, isDir, size, mtime)
 	}
 	fs.inodes.SetModeState(ino, mode, hasMode)
 	entry, _ := fs.inodes.GetEntry(ino)
 	return entry
+}
+
+func gitCleanTreeMtime(rt *gitWorkspaceRuntime) time.Time {
+	if rt != nil && !rt.workspace.CreatedAt.IsZero() {
+		return rt.workspace.CreatedAt
+	}
+	return gitCleanTreeDefaultMtime
 }
 
 func gitNodeMode(n client.GitTreeNode) (mode uint32, hasMode bool, isDir bool) {

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -60,16 +60,37 @@ type gitWorkspaceRuntime struct {
 	nodes     map[string]client.GitTreeNode
 	children  map[string][]client.GitTreeNode
 	overlay   map[string]client.GitOverlayEntry
+	loadedAt  time.Time
 	restored  bool
 
 	localTreeCommit   string
 	localNodes        map[string]client.GitTreeNode
 	localChildren     map[string][]client.GitTreeNode
 	localTreeLoadedAt time.Time
+	locallyDeleted    bool
 }
 
 func (rt *gitWorkspaceRuntime) isLinked() bool {
 	return rt != nil && rt.workspace.WorkspaceKind == "linked"
+}
+
+func (rt *gitWorkspaceRuntime) markLocallyDeleted() {
+	if rt == nil {
+		return
+	}
+	rt.mu.Lock()
+	rt.locallyDeleted = true
+	rt.mu.Unlock()
+}
+
+func (rt *gitWorkspaceRuntime) isLocallyDeleted() bool {
+	if rt == nil {
+		return false
+	}
+	rt.mu.RLock()
+	deleted := rt.locallyDeleted
+	rt.mu.RUnlock()
+	return deleted
 }
 
 func gitWorkspaceIsFastBlobless(rt *gitWorkspaceRuntime) bool {
@@ -170,11 +191,15 @@ func (fs *Dat9FS) ensureGitWorkspacesWithRefresh(ctx context.Context, force bool
 	sort.Slice(loaded, func(i, j int) bool {
 		return len(loaded[i].localRoot) > len(loaded[j].localRoot)
 	})
+	loadedAt := time.Now()
+	for _, rt := range loaded {
+		rt.loadedAt = loadedAt
+	}
 
 	fs.git.mu.Lock()
 	fs.git.workspaces = loaded
 	fs.git.loaded = true
-	fs.git.loadedAt = time.Now()
+	fs.git.loadedAt = loadedAt
 	fs.git.mu.Unlock()
 
 	for _, rt := range loaded {
@@ -196,6 +221,13 @@ func (fs *Dat9FS) gitWorkspaceForPath(ctx context.Context, localPath string) (*g
 		log.Printf("git workspace refresh failed for %s: %v", localPath, err)
 	}
 	cancel()
+	if fs.gitWorkspaceCacheInvalidatedLocally(baseCtx) {
+		refreshCtx, refreshCancel := context.WithTimeout(baseCtx, fuseTimeout)
+		if err := fs.forceRefreshGitWorkspaces(refreshCtx); err != nil {
+			log.Printf("git workspace forced refresh failed for invalidated cache %s: %v", localPath, err)
+		}
+		refreshCancel()
+	}
 
 	if rt, rel, ok := fs.loadedGitWorkspaceForPath(localPath); ok {
 		return rt, rel, true
@@ -247,7 +279,7 @@ func (fs *Dat9FS) loadedGitWorkspaceForPath(localPath string) (*gitWorkspaceRunt
 	copy(workspaces, fs.git.workspaces)
 	fs.git.mu.Unlock()
 	for _, rt := range workspaces {
-		if fs.gitWorkspaceRuntimeDeletedLocally(context.Background(), rt) {
+		if fs.gitWorkspaceRuntimeHiddenLocally(context.Background(), rt) {
 			continue
 		}
 		root := rt.localRoot
@@ -265,11 +297,18 @@ func (fs *Dat9FS) loadedGitWorkspaceForPath(localPath string) (*gitWorkspaceRunt
 	return nil, "", false
 }
 
-func (fs *Dat9FS) gitWorkspaceRuntimeDeletedLocally(ctx context.Context, rt *gitWorkspaceRuntime) bool {
+func (fs *Dat9FS) gitWorkspaceRuntimeHiddenLocally(ctx context.Context, rt *gitWorkspaceRuntime) bool {
 	if rt == nil {
 		return false
 	}
-	return fs.gitWorkspaceDeletedLocally(ctx, rt.workspace.WorkspaceID)
+	if rt.isLocallyDeleted() {
+		return true
+	}
+	if fs.gitWorkspaceDeletedLocally(ctx, rt.workspace.WorkspaceID) {
+		rt.markLocallyDeleted()
+		return true
+	}
+	return fs.gitWorkspaceRuntimeRefreshInvalidated(ctx, rt)
 }
 
 func (fs *Dat9FS) gitWorkspaceDeletedLocally(ctx context.Context, workspaceID string) bool {
@@ -277,6 +316,33 @@ func (fs *Dat9FS) gitWorkspaceDeletedLocally(ctx context.Context, workspaceID st
 		return false
 	}
 	return gitcache.WorkspaceDeleted(ctx, fs.opts.LocalRoot, workspaceID)
+}
+
+func (fs *Dat9FS) gitWorkspaceRuntimeRefreshInvalidated(ctx context.Context, rt *gitWorkspaceRuntime) bool {
+	if fs == nil || fs.opts == nil || rt == nil {
+		return false
+	}
+	markerTime, ok := gitcache.WorkspaceRefreshMarkerTime(ctx, fs.opts.LocalRoot, rt.workspace.WorkspaceID)
+	if !ok {
+		return false
+	}
+	return markerTime.After(rt.loadedAt)
+}
+
+func (fs *Dat9FS) gitWorkspaceCacheInvalidatedLocally(ctx context.Context) bool {
+	if fs == nil || fs.git == nil || fs.opts == nil {
+		return false
+	}
+	fs.git.mu.Lock()
+	workspaces := make([]*gitWorkspaceRuntime, len(fs.git.workspaces))
+	copy(workspaces, fs.git.workspaces)
+	fs.git.mu.Unlock()
+	for _, rt := range workspaces {
+		if fs.gitWorkspaceRuntimeRefreshInvalidated(ctx, rt) {
+			return true
+		}
+	}
+	return false
 }
 
 func (fs *Dat9FS) loadedGitWorkspaceForGitStatePath(localPath string) (*gitWorkspaceRuntime, string, bool) {
@@ -309,7 +375,7 @@ func (fs *Dat9FS) linkedWorkspaceForCommonGitStatePath(commonRT *gitWorkspaceRun
 	copy(workspaces, fs.git.workspaces)
 	fs.git.mu.Unlock()
 	for _, candidate := range workspaces {
-		if fs.gitWorkspaceRuntimeDeletedLocally(context.Background(), candidate) {
+		if fs.gitWorkspaceRuntimeHiddenLocally(context.Background(), candidate) {
 			continue
 		}
 		if candidate.workspace.CommonWorkspaceID == commonRT.workspace.WorkspaceID && candidate.workspace.WorktreeName == name {
@@ -331,7 +397,7 @@ func (fs *Dat9FS) gitWorkspaceRuntimeByID(workspaceID string) (*gitWorkspaceRunt
 	copy(workspaces, fs.git.workspaces)
 	fs.git.mu.Unlock()
 	for _, rt := range workspaces {
-		if fs.gitWorkspaceRuntimeDeletedLocally(context.Background(), rt) {
+		if fs.gitWorkspaceRuntimeHiddenLocally(context.Background(), rt) {
 			continue
 		}
 		if rt.workspace.WorkspaceID == workspaceID {

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -1954,7 +1954,6 @@ func gitHeadTreeEntries(ctx context.Context, gitDir string) (map[string]gitHeadT
 		return nil, err
 	}
 	entries := make(map[string]gitHeadTreeEntry)
-	var blobIDs []string
 	for _, rec := range bytes.Split(out, []byte{0}) {
 		if len(rec) == 0 {
 			continue
@@ -1976,31 +1975,7 @@ func gitHeadTreeEntries(ctx context.Context, gitDir string) (map[string]gitHeadT
 		if kind == "" {
 			continue
 		}
-		entries[rel] = gitHeadTreeEntry{path: rel, kind: kind, mode: mode, oid: oid}
-		if kind == "file" || kind == "symlink" {
-			blobIDs = append(blobIDs, oid)
-		}
-	}
-	info, err := gitObjectInfoBatch(ctx, gitDir, blobIDs)
-	if err != nil {
-		return nil, err
-	}
-	for rel, entry := range entries {
-		if entry.kind != "file" && entry.kind != "symlink" {
-			continue
-		}
-		object := info[entry.oid]
-		if object.typ == "" || object.typ == "missing" {
-			return nil, fmt.Errorf("git HEAD tree object %s for %s is missing", entry.oid, rel)
-		}
-		if object.typ != "blob" {
-			return nil, fmt.Errorf("git HEAD tree object %s for %s is %s, want blob", entry.oid, rel, object.typ)
-		}
-		if object.size > gitLocalObjectMaxBlobBytes {
-			return nil, fmt.Errorf("git HEAD tree object %s for %s is %d bytes, exceeds local restore limit %d", entry.oid, rel, object.size, gitLocalObjectMaxBlobBytes)
-		}
-		entry.size = object.size
-		entries[rel] = entry
+		entries[rel] = gitHeadTreeEntry{path: rel, kind: kind, mode: mode, oid: oid, size: -1}
 	}
 	return entries, nil
 }

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1127,6 +1127,45 @@ func TestLinkedGitStatePathMapsToLinkedRuntime(t *testing.T) {
 	}
 }
 
+func TestLinkedGitStatePathSkipsLocallyDeletedRuntime(t *testing.T) {
+	localRoot := t.TempDir()
+	fs := &Dat9FS{
+		opts: &MountOptions{EnableGitWorkspaces: true, LocalRoot: localRoot},
+		git:  newGitWorkspaceLayer(),
+	}
+	common := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{WorkspaceID: "base", WorkspaceKind: "main"},
+		localRoot: "/repo",
+	}
+	linked := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID:       "wt",
+			WorkspaceKind:     "linked",
+			CommonWorkspaceID: "base",
+			WorktreeName:      "wt",
+		},
+		localRoot: "/repo-wt",
+	}
+	fs.git.workspaces = []*gitWorkspaceRuntime{linked, common}
+	if err := gitcache.MarkWorkspaceDeleted(localRoot, "wt"); err != nil {
+		t.Fatalf("MarkWorkspaceDeleted: %v", err)
+	}
+
+	got, rel, ok := fs.loadedGitWorkspaceForGitStatePath("/repo/.git/worktrees/wt/index")
+	if !ok {
+		t.Fatalf("common git state path was not resolved")
+	}
+	if got != common {
+		t.Fatalf("runtime = %s, want common", got.workspace.WorkspaceID)
+	}
+	if rel != ".git/worktrees/wt/index" {
+		t.Fatalf("rel = %q, want common git state rel", rel)
+	}
+	if _, _, ok := fs.loadedGitWorkspaceForPath("/repo-wt/README.md"); ok {
+		t.Fatalf("deleted linked workspace root should not resolve")
+	}
+}
+
 func TestWriteLinkedGitFileUsesRelativeMountPath(t *testing.T) {
 	localRoot := t.TempDir()
 	overlay := NewLocalOverlay(localRoot)

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1147,7 +1147,7 @@ func TestLinkedGitStatePathSkipsLocallyDeletedRuntime(t *testing.T) {
 		localRoot: "/repo-wt",
 	}
 	fs.git.workspaces = []*gitWorkspaceRuntime{linked, common}
-	if err := gitcache.MarkWorkspaceDeleted(localRoot, "wt"); err != nil {
+	if err := gitcache.MarkWorkspaceDeleted(context.Background(), localRoot, "wt"); err != nil {
 		t.Fatalf("MarkWorkspaceDeleted: %v", err)
 	}
 
@@ -1173,6 +1173,7 @@ func TestGitTreeInodeUsesStableMtime(t *testing.T) {
 		workspace: client.GitWorkspace{
 			WorkspaceID: "ws1",
 			CreatedAt:   createdAt,
+			HeadCommit:  "1111111111111111111111111111111111111111",
 		},
 	}
 	node := client.GitTreeNode{
@@ -1189,8 +1190,13 @@ func TestGitTreeInodeUsesStableMtime(t *testing.T) {
 	if first.Ino != second.Ino {
 		t.Fatalf("inode changed: first=%d second=%d", first.Ino, second.Ino)
 	}
-	if !second.Mtime.Equal(createdAt) {
-		t.Fatalf("mtime = %s, want stable workspace mtime %s", second.Mtime, createdAt)
+	if !second.Mtime.Equal(gitCleanTreeMtime(rt)) {
+		t.Fatalf("mtime = %s, want stable workspace mtime %s", second.Mtime, gitCleanTreeMtime(rt))
+	}
+	rt.workspace.HeadCommit = "2222222222222222222222222222222222222222"
+	third := fs.gitTreeInode(context.Background(), rt, "/repo/README.md", "README.md", node, true)
+	if third.Mtime.Equal(second.Mtime) {
+		t.Fatalf("mtime did not change when head commit changed: %s", third.Mtime)
 	}
 }
 
@@ -1230,6 +1236,35 @@ func TestGitHeadTreeEntriesDoesNotRequireBlobObjects(t *testing.T) {
 	}
 	if entry.oid != blob || entry.size != -1 {
 		t.Fatalf("entry = %+v, want oid=%s size=-1", entry, blob)
+	}
+}
+
+func TestBuildRestoredGitHeadOverlayRejectsOversizedBlob(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	repo := t.TempDir()
+	runFuseTestGit(t, "", "init", "-b", "main", repo)
+	runFuseTestGit(t, repo, "config", "user.email", "drive9-test@example.invalid")
+	runFuseTestGit(t, repo, "config", "user.name", "Drive9 Test")
+	large := bytes.Repeat([]byte("x"), int(gitLocalObjectMaxBlobBytes)+1)
+	if err := os.WriteFile(filepath.Join(repo, "large.bin"), large, 0o644); err != nil {
+		t.Fatalf("write large.bin: %v", err)
+	}
+	runFuseTestGit(t, repo, "add", "large.bin")
+	runFuseTestGit(t, repo, "commit", "-m", "large")
+
+	rt := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID: "ws1",
+			HeadCommit:  "0000000000000000000000000000000000000000",
+		},
+		nodes:   map[string]client.GitTreeNode{},
+		overlay: map[string]client.GitOverlayEntry{},
+	}
+	_, err := buildRestoredGitHeadOverlay(context.Background(), filepath.Join(repo, ".git"), rt)
+	if err == nil || !strings.Contains(err.Error(), "exceeds local restore limit") {
+		t.Fatalf("buildRestoredGitHeadOverlay err = %v, want oversized blob error", err)
 	}
 }
 

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1194,6 +1194,45 @@ func TestGitTreeInodeUsesStableMtime(t *testing.T) {
 	}
 }
 
+func TestGitHeadTreeEntriesDoesNotRequireBlobObjects(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	repo := t.TempDir()
+	runFuseTestGit(t, "", "init", "-b", "main", repo)
+	runFuseTestGit(t, repo, "config", "user.email", "drive9-test@example.invalid")
+	runFuseTestGit(t, repo, "config", "user.name", "Drive9 Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runFuseTestGit(t, repo, "add", ".")
+	runFuseTestGit(t, repo, "commit", "-m", "initial")
+	cmd := exec.Command("git", "-C", repo, "rev-parse", "HEAD:README.md")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD:README.md: %v", err)
+	}
+	blob := strings.TrimSpace(string(out))
+	if len(blob) < 4 {
+		t.Fatalf("blob oid %q too short", blob)
+	}
+	if err := os.Remove(filepath.Join(repo, ".git", "objects", blob[:2], blob[2:])); err != nil {
+		t.Fatalf("remove blob object: %v", err)
+	}
+
+	entries, err := gitHeadTreeEntries(context.Background(), filepath.Join(repo, ".git"))
+	if err != nil {
+		t.Fatalf("gitHeadTreeEntries: %v", err)
+	}
+	entry, ok := entries["README.md"]
+	if !ok {
+		t.Fatalf("README.md missing from entries: %#v", entries)
+	}
+	if entry.oid != blob || entry.size != -1 {
+		t.Fatalf("entry = %+v, want oid=%s size=-1", entry, blob)
+	}
+}
+
 func TestWriteLinkedGitFileUsesRelativeMountPath(t *testing.T) {
 	localRoot := t.TempDir()
 	overlay := NewLocalOverlay(localRoot)

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1166,6 +1166,34 @@ func TestLinkedGitStatePathSkipsLocallyDeletedRuntime(t *testing.T) {
 	}
 }
 
+func TestGitTreeInodeUsesStableMtime(t *testing.T) {
+	fs := &Dat9FS{inodes: NewInodeToPath()}
+	createdAt := time.Unix(123, 456).UTC()
+	rt := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID: "ws1",
+			CreatedAt:   createdAt,
+		},
+	}
+	node := client.GitTreeNode{
+		Path:      "README.md",
+		Kind:      "file",
+		Mode:      "100644",
+		SizeBytes: 9,
+	}
+
+	first := fs.gitTreeInode(context.Background(), rt, "/repo/README.md", "README.md", node, true)
+	time.Sleep(time.Millisecond)
+	second := fs.gitTreeInode(context.Background(), rt, "/repo/README.md", "README.md", node, true)
+
+	if first.Ino != second.Ino {
+		t.Fatalf("inode changed: first=%d second=%d", first.Ino, second.Ino)
+	}
+	if !second.Mtime.Equal(createdAt) {
+		t.Fatalf("mtime = %s, want stable workspace mtime %s", second.Mtime, createdAt)
+	}
+}
+
 func TestWriteLinkedGitFileUsesRelativeMountPath(t *testing.T) {
 	localRoot := t.TempDir()
 	overlay := NewLocalOverlay(localRoot)

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -545,6 +545,57 @@ func TestGitWorkspaceForPathForceRefreshesAfterLocalGitAppears(t *testing.T) {
 	}
 }
 
+func TestLoadedGitWorkspaceForPathSkipsRefreshInvalidatedRuntime(t *testing.T) {
+	localRoot := t.TempDir()
+	rt := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{WorkspaceID: "ws1"},
+		localRoot: "/repo",
+		loadedAt:  time.Now().Add(-time.Minute),
+	}
+	fs := &Dat9FS{
+		opts: &MountOptions{EnableGitWorkspaces: true, LocalRoot: localRoot},
+		git:  newGitWorkspaceLayer(),
+	}
+	fs.git.workspaces = []*gitWorkspaceRuntime{rt}
+	if err := gitcache.ClearWorkspaceDeleted(context.Background(), localRoot, "ws1"); err != nil {
+		t.Fatalf("ClearWorkspaceDeleted: %v", err)
+	}
+
+	if _, _, ok := fs.loadedGitWorkspaceForPath("/repo/README.md"); ok {
+		t.Fatalf("refresh-invalidated runtime should not resolve")
+	}
+}
+
+func TestGitWorkspaceForPathForceRefreshesAfterWorkspaceRefreshMarker(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	localRoot := t.TempDir()
+	opts := &MountOptions{LocalRoot: localRoot, EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	fs.git.mu.Lock()
+	if len(fs.git.workspaces) != 1 {
+		t.Fatalf("workspace count = %d, want 1", len(fs.git.workspaces))
+	}
+	oldRT := fs.git.workspaces[0]
+	oldRT.loadedAt = time.Now().Add(-time.Minute)
+	fs.git.loadedAt = time.Now()
+	fs.git.mu.Unlock()
+	if err := gitcache.ClearWorkspaceDeleted(context.Background(), localRoot, "ws1"); err != nil {
+		t.Fatalf("ClearWorkspaceDeleted: %v", err)
+	}
+
+	got, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/README.md")
+	if !ok {
+		t.Fatalf("gitWorkspaceForPath ok = false, want true after refresh")
+	}
+	if got == oldRT {
+		t.Fatalf("gitWorkspaceForPath returned stale runtime after refresh marker")
+	}
+}
+
 func TestGitWorkspaceWriteSyncWritesOverlay(t *testing.T) {
 	fixture := newGitWorkspaceFixture(t)
 	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1860,6 +1860,28 @@ func TestGitWorkspaceUnknownSizeLookupUsesBlobCacheSize(t *testing.T) {
 	}
 }
 
+func TestGitWorkspaceBloblessUnknownSizeLookupSkipsGitSizeProbe(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	fixture.mode = gitWorkspaceModeFastBlobless
+	fixture.readmeSize = -1
+
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true, PerfCounters: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "README.md", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if got := lookupOut.Size; got != 0 {
+		t.Fatalf("Lookup size = %d, want unknown/0", got)
+	}
+	snap := fs.perf.snapshot()
+	if got := snap.Counters["git_cat_file_count"]; got != 0 {
+		t.Fatalf("git_cat_file_count = %d, want 0", got)
+	}
+}
+
 func TestGitWorkspaceOverlayWinsOverCleanCache(t *testing.T) {
 	fixture := newGitWorkspaceFixture(t)
 	fixture.overlay["README.md"] = client.GitOverlayEntry{

--- a/pkg/gitcache/cache.go
+++ b/pkg/gitcache/cache.go
@@ -97,6 +97,13 @@ func WorkspaceDeletedMarkerPath(localRoot, workspaceID string) string {
 	return filepath.Join(localRoot, "git-workspaces", "deleted", safePathSegment(workspaceID))
 }
 
+// WorkspaceRefreshMarkerPath returns the local marker path used to tell a
+// still-running FUSE mount that a workspace with a reused ID must be refreshed
+// before the cached runtime can be trusted again.
+func WorkspaceRefreshMarkerPath(localRoot, workspaceID string) string {
+	return filepath.Join(localRoot, "git-workspaces", "refresh", safePathSegment(workspaceID))
+}
+
 // MarkWorkspaceDeleted records that a workspace was deleted in this local root.
 func MarkWorkspaceDeleted(ctx context.Context, localRoot, workspaceID string) error {
 	if ctx == nil {
@@ -136,11 +143,41 @@ func ClearWorkspaceDeleted(ctx context.Context, localRoot, workspaceID string) e
 	if localRoot == "" || workspaceID == "" {
 		return nil
 	}
+	refreshMarker := WorkspaceRefreshMarkerPath(localRoot, workspaceID)
+	if err := os.MkdirAll(filepath.Dir(refreshMarker), 0o755); err != nil {
+		return fmt.Errorf("create workspace refresh marker dir %q: %w", filepath.Dir(refreshMarker), err)
+	}
+	if err := os.WriteFile(refreshMarker, []byte(time.Now().UTC().Format(time.RFC3339Nano)+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write workspace refresh marker %q: %w", refreshMarker, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	marker := WorkspaceDeletedMarkerPath(localRoot, workspaceID)
 	if err := os.Remove(marker); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove workspace deleted marker %q: %w", marker, err)
 	}
 	return nil
+}
+
+// WorkspaceRefreshMarkerTime returns the mtime for the local refresh marker.
+func WorkspaceRefreshMarkerTime(ctx context.Context, localRoot, workspaceID string) (time.Time, bool) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if ctx.Err() != nil {
+		return time.Time{}, false
+	}
+	localRoot = strings.TrimSpace(localRoot)
+	workspaceID = strings.TrimSpace(workspaceID)
+	if localRoot == "" || workspaceID == "" {
+		return time.Time{}, false
+	}
+	info, err := os.Stat(WorkspaceRefreshMarkerPath(localRoot, workspaceID))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return info.ModTime(), true
 }
 
 // WorkspaceDeleted reports whether a local deletion marker exists.

--- a/pkg/gitcache/cache.go
+++ b/pkg/gitcache/cache.go
@@ -98,7 +98,13 @@ func WorkspaceDeletedMarkerPath(localRoot, workspaceID string) string {
 }
 
 // MarkWorkspaceDeleted records that a workspace was deleted in this local root.
-func MarkWorkspaceDeleted(localRoot, workspaceID string) error {
+func MarkWorkspaceDeleted(ctx context.Context, localRoot, workspaceID string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	localRoot = strings.TrimSpace(localRoot)
 	workspaceID = strings.TrimSpace(workspaceID)
 	if localRoot == "" || workspaceID == "" {
@@ -106,13 +112,45 @@ func MarkWorkspaceDeleted(localRoot, workspaceID string) error {
 	}
 	marker := WorkspaceDeletedMarkerPath(localRoot, workspaceID)
 	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+		return fmt.Errorf("create workspace deleted marker dir %q: %w", filepath.Dir(marker), err)
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
-	return os.WriteFile(marker, []byte("deleted\n"), 0o644)
+	if err := os.WriteFile(marker, []byte("deleted\n"), 0o644); err != nil {
+		return fmt.Errorf("write workspace deleted marker %q: %w", marker, err)
+	}
+	return nil
+}
+
+// ClearWorkspaceDeleted removes a local deletion marker when a workspace ID is reused.
+func ClearWorkspaceDeleted(ctx context.Context, localRoot, workspaceID string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	localRoot = strings.TrimSpace(localRoot)
+	workspaceID = strings.TrimSpace(workspaceID)
+	if localRoot == "" || workspaceID == "" {
+		return nil
+	}
+	marker := WorkspaceDeletedMarkerPath(localRoot, workspaceID)
+	if err := os.Remove(marker); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove workspace deleted marker %q: %w", marker, err)
+	}
+	return nil
 }
 
 // WorkspaceDeleted reports whether a local deletion marker exists.
-func WorkspaceDeleted(localRoot, workspaceID string) bool {
+func WorkspaceDeleted(ctx context.Context, localRoot, workspaceID string) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if ctx.Err() != nil {
+		return false
+	}
 	localRoot = strings.TrimSpace(localRoot)
 	workspaceID = strings.TrimSpace(workspaceID)
 	if localRoot == "" || workspaceID == "" {

--- a/pkg/gitcache/cache.go
+++ b/pkg/gitcache/cache.go
@@ -90,6 +90,38 @@ func HydrateLogPath(localRoot, workspaceID, commit string) string {
 	return filepath.Join(CacheRoot(localRoot, workspaceID, commit), "hydrate.log")
 }
 
+// WorkspaceDeletedMarkerPath returns the local marker path used to hide a
+// deleted workspace from a still-running FUSE mount before the next backend
+// refresh observes the deletion.
+func WorkspaceDeletedMarkerPath(localRoot, workspaceID string) string {
+	return filepath.Join(localRoot, "git-workspaces", "deleted", safePathSegment(workspaceID))
+}
+
+// MarkWorkspaceDeleted records that a workspace was deleted in this local root.
+func MarkWorkspaceDeleted(localRoot, workspaceID string) error {
+	localRoot = strings.TrimSpace(localRoot)
+	workspaceID = strings.TrimSpace(workspaceID)
+	if localRoot == "" || workspaceID == "" {
+		return nil
+	}
+	marker := WorkspaceDeletedMarkerPath(localRoot, workspaceID)
+	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(marker, []byte("deleted\n"), 0o644)
+}
+
+// WorkspaceDeleted reports whether a local deletion marker exists.
+func WorkspaceDeleted(localRoot, workspaceID string) bool {
+	localRoot = strings.TrimSpace(localRoot)
+	workspaceID = strings.TrimSpace(workspaceID)
+	if localRoot == "" || workspaceID == "" {
+		return false
+	}
+	_, err := os.Stat(WorkspaceDeletedMarkerPath(localRoot, workspaceID))
+	return err == nil
+}
+
 // ReadTreeFile reads a materialized clean tree file or symlink. The boolean is
 // false when the materialized path is simply absent.
 func ReadTreeFile(ctx context.Context, localRoot, workspaceID, commit, rel string, offset, size int64) ([]byte, bool, error) {

--- a/pkg/gitcache/cache_test.go
+++ b/pkg/gitcache/cache_test.go
@@ -64,6 +64,38 @@ func TestSanitizeGitConfigCredentials(t *testing.T) {
 	}
 }
 
+func TestWorkspaceDeletedMarkerLifecycle(t *testing.T) {
+	localRoot := t.TempDir()
+	ctx := context.Background()
+
+	if WorkspaceDeleted(ctx, localRoot, "ws1") {
+		t.Fatal("WorkspaceDeleted before mark = true, want false")
+	}
+	if err := MarkWorkspaceDeleted(ctx, localRoot, "ws1"); err != nil {
+		t.Fatalf("MarkWorkspaceDeleted: %v", err)
+	}
+	if !WorkspaceDeleted(ctx, localRoot, "ws1") {
+		t.Fatal("WorkspaceDeleted after mark = false, want true")
+	}
+	if err := ClearWorkspaceDeleted(ctx, localRoot, "ws1"); err != nil {
+		t.Fatalf("ClearWorkspaceDeleted: %v", err)
+	}
+	if WorkspaceDeleted(ctx, localRoot, "ws1") {
+		t.Fatal("WorkspaceDeleted after clear = true, want false")
+	}
+}
+
+func TestWorkspaceDeletedMarkerHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := MarkWorkspaceDeleted(ctx, t.TempDir(), "ws1"); err == nil {
+		t.Fatal("MarkWorkspaceDeleted with canceled context err = nil, want error")
+	}
+	if WorkspaceDeleted(ctx, t.TempDir(), "ws1") {
+		t.Fatal("WorkspaceDeleted with canceled context = true, want false")
+	}
+}
+
 func TestExtractCodeloadTarRejectsTraversal(t *testing.T) {
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)

--- a/pkg/gitcache/cache_test.go
+++ b/pkg/gitcache/cache_test.go
@@ -86,13 +86,14 @@ func TestWorkspaceDeletedMarkerLifecycle(t *testing.T) {
 }
 
 func TestWorkspaceDeletedMarkerHonorsCanceledContext(t *testing.T) {
+	localRoot := t.TempDir()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := MarkWorkspaceDeleted(ctx, t.TempDir(), "ws1"); err == nil {
+	if err := MarkWorkspaceDeleted(ctx, localRoot, "ws1"); err == nil {
 		t.Fatal("MarkWorkspaceDeleted with canceled context err = nil, want error")
 	}
-	if WorkspaceDeleted(ctx, t.TempDir(), "ws1") {
-		t.Fatal("WorkspaceDeleted with canceled context = true, want false")
+	if WorkspaceDeleted(context.Background(), localRoot, "ws1") {
+		t.Fatal("WorkspaceDeleted after canceled mark = true, want false")
 	}
 }
 

--- a/pkg/gitcache/cache_test.go
+++ b/pkg/gitcache/cache_test.go
@@ -83,6 +83,9 @@ func TestWorkspaceDeletedMarkerLifecycle(t *testing.T) {
 	if WorkspaceDeleted(ctx, localRoot, "ws1") {
 		t.Fatal("WorkspaceDeleted after clear = true, want false")
 	}
+	if _, ok := WorkspaceRefreshMarkerTime(ctx, localRoot, "ws1"); !ok {
+		t.Fatal("WorkspaceRefreshMarkerTime after clear ok = false, want true")
+	}
 }
 
 func TestWorkspaceDeletedMarkerHonorsCanceledContext(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes the current Git workspace regressions found while re-running the live Git E2E suite from `main` on the EC2 POSIX test host.

The fixes cover:

- Keep blobless fast clone objectless by removing `git ls-tree -l` from tree manifest generation. The manifest now records unknown blob sizes instead of forcing Git to lazy-fetch blob objects just to compute sizes.
- Hide removed fast linked worktrees immediately in the current FUSE mount by writing a local deletion marker and filtering deleted workspace runtimes before registry lookups.
- Stabilize clean Git tree inode mtimes so Git does not report false dirty files after clone or commit.
- Run the Git workspace smoke mount in foreground mode because the script already backgrounds the process and waits on the process it owns.
- Restore linked blobless worktrees without requiring clean remote blob objects to exist locally. Restore now parses HEAD tree object metadata without batch-checking every clean blob object.

## Root Causes

1. `git ls-tree -r -t -l -z <commit>` requested blob sizes. In a blobless partial clone, that forced Git to lazy-fetch clean blob objects during manifest creation, turning fast clone back into a slow remote object walk.

2. Clean virtual Git workspace entries used a fresh timestamp on each lookup/getattr. Git interpreted the changing stat metadata as file modifications, so `git status --porcelain` could show false `M` entries even when `git diff` was empty.

3. `drive9 git worktree remove --fast` removed backend/local metadata, but the already-mounted FUSE process still had the linked workspace runtime in memory. The same mount could still expose stale linked worktree metadata until remount.

4. The smoke test launched `drive9 mount` in the background while the CLI default mount path already daemonized, so the script sometimes waited on the short-lived parent instead of the foreground FUSE process.

5. Linked blobless worktree restore called a blob object batch-check across the full HEAD tree. Clean blob objects are intentionally allowed to be missing locally in blobless mode, so restore could fail with `lazy fetching disabled` before the working tree became usable.

## Fix Details

- Added explicit tree listing args that do not include `-l`, plus tests proving blob sizes remain unknown and blob lookup is avoided.
- Added Git cache deletion marker helpers and FUSE-side filtering for locally deleted workspaces.
- Added stable clean-tree mtime selection based on workspace creation time, with a deterministic fallback.
- Updated the E2E Git workspace smoke mount command to pass `--foreground`.
- Changed HEAD tree restore metadata collection to use `git ls-tree` output only; file contents are read only for paths that must become dirty overlay entries.

## Validation

Local Go tests:

```bash
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9/cli
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/gitcache
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/fuse
```

Live EC2 targeted validation against the dev endpoint:

- Instance: `i-076768b42d1d64d14`
- SSM command: `0689a879-cb5e-4ec5-b2fa-89b3ec12b34a`
- Commit: `d90bc503bc7c4770bf88439238287dd9dcda572b`
- Endpoint: `http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com`

Results:

- `drive9 fast_worktree`: 35/35 passed, 0 failed, duration 50s.
- `kimi-cli agent_edit_add_commit`: 17/17 passed, 0 failed, duration 30s.
- The targeted smoke covered fast clone, fast worktree add/remove, edit, add, commit, remount/recovery, linked `.git` restore, and post-remount Git status/log checks.

Full default E2E was not rerun to completion because the failure was isolated earlier and the targeted runs cover the corrected paths without waiting for unrelated long-running cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local "workspace deleted" markers added so removed workspaces are hidden until refreshed; markers are set/cleared during clone/worktree operations.
  * Git clean-tree inodes now use stable mtimes instead of current time; git file entries defer size (size = -1) to avoid expensive blob-size lookups.

* **Bug Fixes**
  * Worktree removal now more robustly marks and cleans local state and continues cleanup even when intermediate steps fail.

* **Tests**
  * Added tests for deletion-marker lifecycle, stable inode mtimes, git-tree size behavior, and restored-head blob handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->