### PR TITLE
fix: reject root self dentry writes

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -199,6 +199,9 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 	if err != nil {
 		return err
 	}
+	if err := rejectRootFileNodePath(path); err != nil {
+		return err
+	}
 
 	fileID := b.genID()
 	now := time.Now()
@@ -267,6 +270,9 @@ func (b *Dat9Backend) CreateSymlinkCtx(ctx context.Context, linkPath, target str
 	if err != nil {
 		return err
 	}
+	if err := rejectRootFileNodePath(linkPath); err != nil {
+		return err
+	}
 
 	if err := b.ensureUploadSizeAllowed(int64(len(data))); err != nil {
 		return err
@@ -322,6 +328,9 @@ func (b *Dat9Backend) MkdirCtx(ctx context.Context, path string, perm uint32) (e
 	dirPath, err := pathutil.CanonicalizeDir(path)
 	if err != nil {
 		return err
+	}
+	if dirPath == "/" {
+		return nil
 	}
 	err = b.store.EnsureParentDirs(ctx, dirPath, b.genID)
 	if err != nil {
@@ -383,6 +392,9 @@ func (b *Dat9Backend) RemoveCtx(ctx context.Context, path string) (err error) {
 	if err != nil {
 		return err
 	}
+	if path == "/" {
+		return datastore.ErrInvalidRootDentry
+	}
 	if node.IsDirectory {
 		return b.store.DeleteEmptyDir(ctx, path)
 	}
@@ -398,6 +410,9 @@ func (b *Dat9Backend) RemoveFileCtx(ctx context.Context, path string) (err error
 	if err != nil {
 		return err
 	}
+	if err := rejectRootFileNodePath(path); err != nil {
+		return err
+	}
 	_, err = b.store.DeleteFileWithRefCheck(ctx, path)
 	return err
 }
@@ -409,6 +424,9 @@ func (b *Dat9Backend) RemoveDirCtx(ctx context.Context, path string) (err error)
 	path, err = pathutil.CanonicalizeDir(path)
 	if err != nil {
 		return err
+	}
+	if path == "/" {
+		return datastore.ErrInvalidRootDentry
 	}
 	return b.store.DeleteEmptyDir(ctx, path)
 }
@@ -424,6 +442,9 @@ func (b *Dat9Backend) RemoveAllCtx(ctx context.Context, path string) (err error)
 	path, node, err := b.resolveNodePath(ctx, path)
 	if err != nil {
 		return err
+	}
+	if path == "/" {
+		return datastore.ErrInvalidRootDentry
 	}
 	if !node.IsDirectory {
 		_, err = b.store.DeleteFileWithRefCheck(ctx, path)
@@ -444,6 +465,9 @@ func (b *Dat9Backend) ReadCtx(ctx context.Context, path string, offset int64, si
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
 		return nil, err
+	}
+	if path == "/" {
+		return nil, datastore.ErrNotFound
 	}
 	nf, err := b.store.Stat(ctx, path)
 	if err != nil {
@@ -514,6 +538,9 @@ func (b *Dat9Backend) WriteCtxIfRevisionWithTagsResult(ctx context.Context, path
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
+		return 0, 0, err
+	}
+	if err := rejectRootFileNodePath(path); err != nil {
 		return 0, 0, err
 	}
 
@@ -1006,6 +1033,9 @@ func (b *Dat9Backend) ReadPlanCtx(ctx context.Context, path string) (plan *ReadP
 	if err != nil {
 		return nil, err
 	}
+	if resolvedPath == "/" {
+		return nil, datastore.ErrNotFound
+	}
 	phase = "stat_for_read"
 	logger.InfoBenchTiming(ctx, "backend_read_plan_start",
 		zap.String("path", path),
@@ -1070,6 +1100,9 @@ func (b *Dat9Backend) ReadInlinePlanCtx(ctx context.Context, path string) (plan 
 	resolvedPath, err := pathutil.Canonicalize(path)
 	if err != nil {
 		return nil, err
+	}
+	if resolvedPath == "/" {
+		return nil, datastore.ErrNotFound
 	}
 	nf, err := b.store.StatForRead(ctx, resolvedPath)
 	if err != nil {
@@ -1144,6 +1177,9 @@ func (b *Dat9Backend) RenameCtx(ctx context.Context, oldPath, newPath string) (e
 		return err
 	}
 	newPath = canonicalizePathForKind(newPath, node.IsDirectory)
+	if oldPath == "/" || newPath == "/" {
+		return datastore.ErrInvalidRootDentry
+	}
 	if oldPath == newPath {
 		return nil
 	}
@@ -1205,8 +1241,14 @@ func (b *Dat9Backend) CopyFileCtx(ctx context.Context, srcPath, dstPath string) 
 	if err != nil {
 		return err
 	}
+	if srcPath == "/" {
+		return datastore.ErrNotFound
+	}
 	dstPath, err = pathutil.Canonicalize(dstPath)
 	if err != nil {
+		return err
+	}
+	if err := rejectRootFileNodePath(dstPath); err != nil {
 		return err
 	}
 	srcNode, err := b.store.GetNode(ctx, srcPath)
@@ -1244,9 +1286,15 @@ func (b *Dat9Backend) HardlinkFileCtx(ctx context.Context, srcPath, dstPath stri
 	if err != nil {
 		return err
 	}
+	if err := rejectRootFileNodePath(dstPath); err != nil {
+		return err
+	}
 	srcPath, srcNode, err := b.resolveNodePath(ctx, srcPath)
 	if err != nil {
 		return err
+	}
+	if srcPath == "/" {
+		return datastore.ErrNotFound
 	}
 	if srcPath == dstPath {
 		return datastore.ErrPathConflict
@@ -1378,6 +1426,13 @@ func (w *writeCloser) Close() error {
 }
 
 // --- helpers ---
+
+func rejectRootFileNodePath(path string) error {
+	if path == "/" {
+		return datastore.ErrInvalidRootDentry
+	}
+	return nil
+}
 
 func normalizePath(path string) string {
 	if pathutil.IsDir(path) {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -373,6 +373,13 @@ func (b *Dat9Backend) ChmodCtx(ctx context.Context, path string, mode uint32) (e
 	start := time.Now()
 	defer func() { observeBackend(ctx, "chmod", err, start) }()
 
+	path, err = pathutil.Canonicalize(path)
+	if err != nil {
+		return err
+	}
+	if path == "/" {
+		return datastore.ErrInvalidRootDentry
+	}
 	resolvedPath, _, err := b.resolveNodePath(ctx, path)
 	if err != nil {
 		return err

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/mem9-ai/dat9/internal/testmysql"
@@ -933,6 +934,44 @@ func TestChmod(t *testing.T) {
 	}
 	if info.Mode != 0o600 {
 		t.Errorf("mode=%o, want 0o600", info.Mode)
+	}
+}
+
+func TestChmodRootHistoricalDentryRejected(t *testing.T) {
+	b := newTestBackend(t)
+	ctx := context.Background()
+	now := time.Now()
+	const inodeID = "root-inode"
+	const originalMode = 0o755
+
+	if err := b.Store().InsertInode(ctx, &datastore.Inode{
+		InodeID:   inodeID,
+		SizeBytes: 0,
+		Revision:  1,
+		Mode:      originalMode,
+		Status:    datastore.StatusConfirmed,
+		CreatedAt: now,
+		Mtime:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Store().DB().ExecContext(ctx, `
+		INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, inode_id, created_at)
+		VALUES (?, ?, ?, ?, 1, ?, ?)`,
+		"root-node", "/", "/", "root-alias", inodeID, now); err != nil {
+		t.Fatal(err)
+	}
+
+	err := b.ChmodCtx(ctx, "/", 0o700)
+	if !errors.Is(err, datastore.ErrInvalidRootDentry) {
+		t.Fatalf("ChmodCtx(/) error = %v, want %v", err, datastore.ErrInvalidRootDentry)
+	}
+	var mode uint32
+	if err := b.Store().DB().QueryRowContext(ctx, `SELECT mode FROM inodes WHERE inode_id = ?`, inodeID).Scan(&mode); err != nil {
+		t.Fatal(err)
+	}
+	if mode != originalMode {
+		t.Fatalf("root inode mode = %o, want unchanged %o", mode, originalMode)
 	}
 }
 

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -752,6 +752,39 @@ func TestEnsureParentDirsNoRootSelfInsert(t *testing.T) {
 	}
 }
 
+func TestMkdirRootIsIdempotentAndDoesNotCreateDentry(t *testing.T) {
+	b := newTestBackend(t)
+	if err := b.MkdirCtx(context.Background(), "/", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.MkdirCtx(context.Background(), "/", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Store().GetNode(context.Background(), "/"); !errors.Is(err, datastore.ErrNotFound) {
+		t.Fatalf("GetNode(/) error = %v, want %v", err, datastore.ErrNotFound)
+	}
+	entries, err := b.ReadDir("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name == "/" {
+			t.Fatalf("root dir should not appear as its own child: %+v", e)
+		}
+	}
+}
+
+func TestWriteRootRejected(t *testing.T) {
+	b := newTestBackend(t)
+	_, err := b.Write("/", []byte("x"), 0, filesystem.WriteFlagCreate)
+	if !errors.Is(err, datastore.ErrInvalidRootDentry) {
+		t.Fatalf("Write(/) error = %v, want %v", err, datastore.ErrInvalidRootDentry)
+	}
+	if _, err := b.Store().GetNode(context.Background(), "/"); !errors.Is(err, datastore.ErrNotFound) {
+		t.Fatalf("GetNode(/) error = %v, want %v", err, datastore.ErrNotFound)
+	}
+}
+
 func TestOffsetWritePreservesTail(t *testing.T) {
 	b := newTestBackend(t)
 	if _, err := b.Write("/f.txt", []byte("ABCDEFGH"), 0, filesystem.WriteFlagCreate); err != nil {

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -73,6 +73,9 @@ func (b *Dat9Backend) InitiateAppendUploadIfRevision(ctx context.Context, path s
 	if err != nil {
 		return nil, fmt.Errorf("canonicalize append path %q: %w", path, err)
 	}
+	if err := rejectRootFileNodePath(path); err != nil {
+		return nil, err
+	}
 	if b.s3 == nil {
 		return nil, ErrS3NotConfigured
 	}
@@ -151,6 +154,10 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
+		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		return nil, err
+	}
+	if err := rejectRootFileNodePath(path); err != nil {
 		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -915,6 +915,10 @@ func (b *Dat9Backend) ConfirmUploadWithTags(ctx context.Context, uploadID string
 func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Upload, parts []s3client.Part, tags map[string]string) error {
 	start := time.Now()
 	uploadID := upload.UploadID
+	if err := rejectRootFileNodePath(upload.TargetPath); err != nil {
+		metrics.RecordOperation("backend", "finalize_upload", "error", time.Since(start))
+		return err
+	}
 	expectedRevision := uploadExpectedRevision(upload)
 
 	completeMultipartStart := time.Now()

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -233,6 +233,10 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
+	if err := rejectRootFileNodePath(path); err != nil {
+		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		return nil, err
+	}
 	if b.s3 == nil {
 		err := ErrS3NotConfigured
 		logger.Error(ctx, "backend_initiate_upload_s3_missing", zap.String("path", path), zap.Error(err))
@@ -388,6 +392,10 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
 		logger.Warn(ctx, "backend_initiate_upload_v2_invalid_path", zap.String("path", path), zap.Error(err))
+		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		return nil, err
+	}
+	if err := rejectRootFileNodePath(path); err != nil {
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
@@ -1293,6 +1301,9 @@ func (b *Dat9Backend) ListUploads(ctx context.Context, path string, status datas
 	if err != nil {
 		return nil, err
 	}
+	if path == "/" {
+		return nil, datastore.ErrNotFound
+	}
 	return b.store.ListUploadsByPath(ctx, path, status)
 }
 
@@ -1303,6 +1314,10 @@ func (b *Dat9Backend) PresignGetObject(ctx context.Context, path string) (string
 	if err != nil {
 		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", err
+	}
+	if path == "/" {
+		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
+		return "", datastore.ErrNotFound
 	}
 	nf, err := b.store.Stat(ctx, path)
 	if err != nil {

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -58,6 +58,16 @@ func newTestBackendWithS3AndOptions(t *testing.T, opts Options) *Dat9Backend {
 	return b
 }
 
+type completeRecordingS3Client struct {
+	s3client.S3Client
+	completeCalls int
+}
+
+func (c *completeRecordingS3Client) CompleteMultipartUpload(ctx context.Context, key, uploadID string, parts []s3client.Part) error {
+	c.completeCalls++
+	return c.S3Client.CompleteMultipartUpload(ctx, key, uploadID, parts)
+}
+
 func newTestBackendNoS3(t *testing.T) *Dat9Backend {
 	t.Helper()
 	initBackendSchema(t, testDSN)
@@ -219,6 +229,30 @@ func TestInitiateAndConfirmUpload(t *testing.T) {
 	}
 	if url == "" {
 		t.Error("expected non-empty presigned URL")
+	}
+}
+
+func TestFinalizeUploadRejectsRootTargetBeforeS3Complete(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	rec := &completeRecordingS3Client{S3Client: b.s3}
+	b.s3 = rec
+
+	err := b.finalizeUpload(context.Background(), &datastore.Upload{
+		UploadID:   "upload-root",
+		FileID:     "pending-root",
+		TargetPath: "/",
+		S3UploadID: "s3-root",
+		S3Key:      "blobs/root",
+		TotalSize:  1,
+		PartSize:   1,
+		PartsTotal: 1,
+		Status:     datastore.UploadUploading,
+	}, []s3client.Part{{Number: 1, Size: 1, ETag: "etag"}}, nil)
+	if !errors.Is(err, datastore.ErrInvalidRootDentry) {
+		t.Fatalf("finalizeUpload root target error = %v, want %v", err, datastore.ErrInvalidRootDentry)
+	}
+	if rec.completeCalls != 0 {
+		t.Fatalf("CompleteMultipartUpload calls = %d, want 0", rec.completeCalls)
 	}
 }
 

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -226,12 +226,12 @@ func (s *Store) columnExists(table, column string) bool {
 
 // --- file_nodes operations ---
 
-func isRootDentryFields(path, parentPath, name string) bool {
-	return path == "/" && parentPath == "/" && name == "/"
+func isRootFileNodePath(path string) bool {
+	return path == "/"
 }
 
-func isRootSelfDentry(n FileNode) bool {
-	return isRootDentryFields(n.Path, n.ParentPath, n.Name)
+func isRootFileNode(n FileNode) bool {
+	return isRootFileNodePath(n.Path)
 }
 
 func (s *Store) InsertNode(ctx context.Context, n *FileNode) error {
@@ -239,7 +239,7 @@ func (s *Store) InsertNode(ctx context.Context, n *FileNode) error {
 	var opErr error
 	defer observeStoreOp(ctx, "insert_node", start, &opErr)
 
-	if isRootSelfDentry(*n) {
+	if isRootFileNode(*n) {
 		opErr = ErrInvalidRootDentry
 		return ErrInvalidRootDentry
 	}
@@ -282,7 +282,7 @@ func (s *Store) ListNodes(ctx context.Context, parentPath string) (out []*FileNo
 		if err != nil {
 			return nil, err
 		}
-		if isRootSelfDentry(*n) {
+		if isRootFileNode(*n) {
 			continue
 		}
 		nodes = append(nodes, n)
@@ -356,7 +356,7 @@ func (s *Store) UpdateNodePath(ctx context.Context, oldPath, newPath, newParentP
 	start := time.Now()
 	defer observeStoreOp(ctx, "update_node_path", start, &err)
 
-	if isRootDentryFields(newPath, newParentPath, newName) {
+	if isRootFileNodePath(oldPath) || isRootFileNodePath(newPath) {
 		return ErrInvalidRootDentry
 	}
 	res, err := s.db.ExecContext(ctx, `UPDATE file_nodes SET path = ?, parent_path = ?, name = ?
@@ -378,7 +378,7 @@ func (s *Store) RenameFileReplacingTarget(ctx context.Context, oldPath, newPath,
 	start := time.Now()
 	defer observeStoreOp(ctx, "rename_file_replacing_target", start, &err)
 
-	if isRootDentryFields(newPath, newParentPath, newName) {
+	if isRootFileNodePath(oldPath) || isRootFileNodePath(newPath) {
 		return nil, ErrInvalidRootDentry
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -618,7 +618,7 @@ func (s *Store) LinkFileNode(ctx context.Context, srcPath, dstPath, dstParentPat
 
 // LinkFileNodeTx creates a hardlink node inside an existing transaction.
 func (s *Store) LinkFileNodeTx(ctx context.Context, db execer, srcPath, dstPath, dstParentPath, dstName, nodeID string, createdAt time.Time) error {
-	if isRootDentryFields(dstPath, dstParentPath, dstName) {
+	if isRootFileNodePath(srcPath) || isRootFileNodePath(dstPath) {
 		return ErrInvalidRootDentry
 	}
 	if dstParentPath != "/" {
@@ -1281,7 +1281,7 @@ func ensureParentDirsWithExecer(ctx context.Context, db execer, path string, gen
 }
 
 func (s *Store) InsertNodeTx(db execer, n *FileNode) error {
-	if isRootSelfDentry(*n) {
+	if isRootFileNode(*n) {
 		return ErrInvalidRootDentry
 	}
 	if !n.IsDirectory && n.FileID != "" {
@@ -1718,7 +1718,7 @@ func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWith
 		n.IsDirectory = isDir != 0
 		n.FileID = nodeFileID.String
 		n.CreatedAt = nodeCreatedAt.UTC()
-		if isRootSelfDentry(n) {
+		if isRootFileNode(n) {
 			continue
 		}
 		nf := &NodeWithFile{Node: n}

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -28,6 +28,7 @@ var (
 	ErrUploadExpired           = errors.New("upload has expired")
 	ErrPathConflict            = errors.New("path already exists")
 	ErrInvalidLinkTarget       = errors.New("invalid link target")
+	ErrInvalidRootDentry       = errors.New("root path is implicit and cannot be stored as a file node")
 	ErrUploadConflict          = errors.New("active upload already exists for this path")
 	ErrIdempotencyConflict     = errors.New("duplicate idempotency key")
 	ErrJournalConflict         = errors.New("journal create conflict")
@@ -225,11 +226,23 @@ func (s *Store) columnExists(table, column string) bool {
 
 // --- file_nodes operations ---
 
+func isRootDentryFields(path, parentPath, name string) bool {
+	return path == "/" && parentPath == "/" && name == "/"
+}
+
+func isRootSelfDentry(n FileNode) bool {
+	return isRootDentryFields(n.Path, n.ParentPath, n.Name)
+}
+
 func (s *Store) InsertNode(ctx context.Context, n *FileNode) error {
 	start := time.Now()
 	var opErr error
 	defer observeStoreOp(ctx, "insert_node", start, &opErr)
 
+	if isRootSelfDentry(*n) {
+		opErr = ErrInvalidRootDentry
+		return ErrInvalidRootDentry
+	}
 	_, err := s.db.ExecContext(ctx, `INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, file_id, inode_id, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		n.NodeID, n.Path, n.ParentPath, n.Name, n.IsDirectory, nullStr(n.FileID), nullStr(n.InodeID), n.CreatedAt.UTC())
@@ -268,6 +281,9 @@ func (s *Store) ListNodes(ctx context.Context, parentPath string) (out []*FileNo
 		n, err := scanNode(rows)
 		if err != nil {
 			return nil, err
+		}
+		if isRootSelfDentry(*n) {
+			continue
 		}
 		nodes = append(nodes, n)
 	}
@@ -340,6 +356,9 @@ func (s *Store) UpdateNodePath(ctx context.Context, oldPath, newPath, newParentP
 	start := time.Now()
 	defer observeStoreOp(ctx, "update_node_path", start, &err)
 
+	if isRootDentryFields(newPath, newParentPath, newName) {
+		return ErrInvalidRootDentry
+	}
 	res, err := s.db.ExecContext(ctx, `UPDATE file_nodes SET path = ?, parent_path = ?, name = ?
 		WHERE path = ?`, newPath, newParentPath, newName, oldPath)
 	if err != nil {
@@ -359,6 +378,9 @@ func (s *Store) RenameFileReplacingTarget(ctx context.Context, oldPath, newPath,
 	start := time.Now()
 	defer observeStoreOp(ctx, "rename_file_replacing_target", start, &err)
 
+	if isRootDentryFields(newPath, newParentPath, newName) {
+		return nil, ErrInvalidRootDentry
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -462,6 +484,9 @@ func (s *Store) RenameDir(ctx context.Context, oldPrefix, newPrefix string) (cou
 	start := time.Now()
 	defer observeStoreOp(ctx, "rename_dir", start, &err)
 
+	if oldPrefix == "/" || newPrefix == "/" {
+		return 0, ErrInvalidRootDentry
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
@@ -593,6 +618,9 @@ func (s *Store) LinkFileNode(ctx context.Context, srcPath, dstPath, dstParentPat
 
 // LinkFileNodeTx creates a hardlink node inside an existing transaction.
 func (s *Store) LinkFileNodeTx(ctx context.Context, db execer, srcPath, dstPath, dstParentPath, dstName, nodeID string, createdAt time.Time) error {
+	if isRootDentryFields(dstPath, dstParentPath, dstName) {
+		return ErrInvalidRootDentry
+	}
 	if dstParentPath != "/" {
 		var parentIsDir bool
 		err := db.QueryRowContext(ctx, `SELECT is_directory FROM file_nodes WHERE path = ? FOR UPDATE`, dstParentPath).
@@ -1253,6 +1281,9 @@ func ensureParentDirsWithExecer(ctx context.Context, db execer, path string, gen
 }
 
 func (s *Store) InsertNodeTx(db execer, n *FileNode) error {
+	if isRootSelfDentry(*n) {
+		return ErrInvalidRootDentry
+	}
 	if !n.IsDirectory && n.FileID != "" {
 		if err := s.lockConfirmedFileForAttachTx(db, n.FileID); err != nil {
 			return err
@@ -1687,6 +1718,9 @@ func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWith
 		n.IsDirectory = isDir != 0
 		n.FileID = nodeFileID.String
 		n.CreatedAt = nodeCreatedAt.UTC()
+		if isRootSelfDentry(n) {
+			continue
+		}
 		nf := &NodeWithFile{Node: n}
 		if fFileID.Valid {
 			nf.File = &File{

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -28,7 +28,7 @@ var (
 	ErrUploadExpired           = errors.New("upload has expired")
 	ErrPathConflict            = errors.New("path already exists")
 	ErrInvalidLinkTarget       = errors.New("invalid link target")
-	ErrInvalidRootDentry       = errors.New("root path is implicit and cannot be stored as a file node")
+	ErrInvalidRootDentry       = errors.New("root path is implicit and cannot be mutated as a file node")
 	ErrUploadConflict          = errors.New("active upload already exists for this path")
 	ErrIdempotencyConflict     = errors.New("duplicate idempotency key")
 	ErrJournalConflict         = errors.New("journal create conflict")
@@ -1163,6 +1163,9 @@ func (s *Store) Chmod(ctx context.Context, path string, mode uint32) (err error)
 	start := time.Now()
 	defer observeStoreOp(ctx, "chmod", start, &err)
 
+	if isRootFileNodePath(path) {
+		return ErrInvalidRootDentry
+	}
 	node, err := s.GetNode(ctx, path)
 	if err != nil {
 		return err

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -299,16 +299,53 @@ func TestListDir(t *testing.T) {
 
 func TestInsertNodeRejectsRootDentry(t *testing.T) {
 	s := newTestStore(t)
-	err := s.InsertNode(context.Background(), &FileNode{
-		NodeID:      "root-self",
+	for _, name := range []string{"/", "root-alias"} {
+		err := s.InsertNode(context.Background(), &FileNode{
+			NodeID:      "root-" + name,
+			Path:        "/",
+			ParentPath:  "/",
+			Name:        name,
+			IsDirectory: true,
+			CreatedAt:   time.Now(),
+		})
+		if !errors.Is(err, ErrInvalidRootDentry) {
+			t.Fatalf("InsertNode root dentry name %q error = %v, want %v", name, err, ErrInvalidRootDentry)
+		}
+	}
+}
+
+func TestStoreRejectsRootPathWrites(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now()
+
+	err := s.InsertNodeTx(s.DB(), &FileNode{
+		NodeID:      "root-tx",
 		Path:        "/",
 		ParentPath:  "/",
-		Name:        "/",
+		Name:        "root-alias",
 		IsDirectory: true,
-		CreatedAt:   time.Now(),
+		CreatedAt:   now,
 	})
 	if !errors.Is(err, ErrInvalidRootDentry) {
-		t.Fatalf("InsertNode root dentry error = %v, want %v", err, ErrInvalidRootDentry)
+		t.Fatalf("InsertNodeTx root path error = %v, want %v", err, ErrInvalidRootDentry)
+	}
+	if err := s.UpdateNodePath(context.Background(), "/src.txt", "/", "/", "root-alias"); !errors.Is(err, ErrInvalidRootDentry) {
+		t.Fatalf("UpdateNodePath root destination error = %v, want %v", err, ErrInvalidRootDentry)
+	}
+	if err := s.UpdateNodePath(context.Background(), "/", "/dst.txt", "/", "dst.txt"); !errors.Is(err, ErrInvalidRootDentry) {
+		t.Fatalf("UpdateNodePath root source error = %v, want %v", err, ErrInvalidRootDentry)
+	}
+	if _, err := s.RenameFileReplacingTarget(context.Background(), "/src.txt", "/", "/", "root-alias"); !errors.Is(err, ErrInvalidRootDentry) {
+		t.Fatalf("RenameFileReplacingTarget root destination error = %v, want %v", err, ErrInvalidRootDentry)
+	}
+	if _, err := s.RenameFileReplacingTarget(context.Background(), "/", "/dst.txt", "/", "dst.txt"); !errors.Is(err, ErrInvalidRootDentry) {
+		t.Fatalf("RenameFileReplacingTarget root source error = %v, want %v", err, ErrInvalidRootDentry)
+	}
+	if err := s.LinkFileNodeTx(context.Background(), s.DB(), "/src.txt", "/", "/", "root-alias", "link-root", now); !errors.Is(err, ErrInvalidRootDentry) {
+		t.Fatalf("LinkFileNodeTx root destination error = %v, want %v", err, ErrInvalidRootDentry)
+	}
+	if err := s.LinkFileNodeTx(context.Background(), s.DB(), "/", "/dst.txt", "/", "dst.txt", "link-dst", now); !errors.Is(err, ErrInvalidRootDentry) {
+		t.Fatalf("LinkFileNodeTx root source error = %v, want %v", err, ErrInvalidRootDentry)
 	}
 }
 
@@ -318,7 +355,7 @@ func TestListDirSkipsHistoricalRootDentry(t *testing.T) {
 	if _, err := s.DB().Exec(`
 		INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, created_at)
 		VALUES (?, ?, ?, ?, 1, ?)`,
-		"root-self", "/", "/", "/", now); err != nil {
+		"root-self", "/", "/", "root-alias", now); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.InsertNode(context.Background(), &FileNode{
@@ -379,7 +416,7 @@ func TestListNodesSkipsHistoricalRootDentry(t *testing.T) {
 	if _, err := s.DB().Exec(`
 		INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, created_at)
 		VALUES (?, ?, ?, ?, 1, ?)`,
-		"root-self", "/", "/", "/", now); err != nil {
+		"root-self", "/", "/", "root-alias", now); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.InsertNode(context.Background(), &FileNode{

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -1368,6 +1368,44 @@ func TestChmod(t *testing.T) {
 	}
 }
 
+func TestChmodRejectsHistoricalRootDentry(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	const inodeID = "root-inode"
+	const originalMode = 0o755
+
+	if err := s.InsertInode(ctx, &Inode{
+		InodeID:   inodeID,
+		SizeBytes: 0,
+		Revision:  1,
+		Mode:      originalMode,
+		Status:    StatusConfirmed,
+		CreatedAt: now,
+		Mtime:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `
+		INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, inode_id, created_at)
+		VALUES (?, ?, ?, ?, 1, ?, ?)`,
+		"root-node", "/", "/", "root-alias", inodeID, now); err != nil {
+		t.Fatal(err)
+	}
+
+	err := s.Chmod(ctx, "/", 0o700)
+	if !errors.Is(err, ErrInvalidRootDentry) {
+		t.Fatalf("Chmod(/) error = %v, want %v", err, ErrInvalidRootDentry)
+	}
+	var mode uint32
+	if err := s.DB().QueryRowContext(ctx, `SELECT mode FROM inodes WHERE inode_id = ?`, inodeID).Scan(&mode); err != nil {
+		t.Fatal(err)
+	}
+	if mode != originalMode {
+		t.Fatalf("root inode mode = %o, want unchanged %o", mode, originalMode)
+	}
+}
+
 func TestChmodPreservesFileTypeBits(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -297,6 +297,50 @@ func TestListDir(t *testing.T) {
 	requireEmbeddingRevision(t, entries[0].File.EmbeddingRevision, 13)
 }
 
+func TestInsertNodeRejectsRootDentry(t *testing.T) {
+	s := newTestStore(t)
+	err := s.InsertNode(context.Background(), &FileNode{
+		NodeID:      "root-self",
+		Path:        "/",
+		ParentPath:  "/",
+		Name:        "/",
+		IsDirectory: true,
+		CreatedAt:   time.Now(),
+	})
+	if !errors.Is(err, ErrInvalidRootDentry) {
+		t.Fatalf("InsertNode root dentry error = %v, want %v", err, ErrInvalidRootDentry)
+	}
+}
+
+func TestListDirSkipsHistoricalRootDentry(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now()
+	if _, err := s.DB().Exec(`
+		INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, created_at)
+		VALUES (?, ?, ?, ?, 1, ?)`,
+		"root-self", "/", "/", "/", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(context.Background(), &FileNode{
+		NodeID:      "d1",
+		Path:        "/data/",
+		ParentPath:  "/",
+		Name:        "data",
+		IsDirectory: true,
+		CreatedAt:   now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := s.ListDir(context.Background(), "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Node.Name != "data" {
+		t.Fatalf("ListDir entries = %+v, want only data", entries)
+	}
+}
+
 func TestListNodes(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
@@ -326,6 +370,35 @@ func TestListNodes(t *testing.T) {
 	}
 	if nodes[0].InodeID != "f1" {
 		t.Errorf("inode_id=%q, want f1", nodes[0].InodeID)
+	}
+}
+
+func TestListNodesSkipsHistoricalRootDentry(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now()
+	if _, err := s.DB().Exec(`
+		INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, created_at)
+		VALUES (?, ?, ?, ?, 1, ?)`,
+		"root-self", "/", "/", "/", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(context.Background(), &FileNode{
+		NodeID:      "d1",
+		Path:        "/data/",
+		ParentPath:  "/",
+		Name:        "data",
+		IsDirectory: true,
+		CreatedAt:   now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := s.ListNodes(context.Background(), "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 || nodes[0].Name != "data" {
+		t.Fatalf("ListNodes entries = %+v, want only data", nodes)
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3337,13 +3337,16 @@ func (fs *Dat9FS) getAttrStatWithRetry(cancel <-chan struct{}, remotePath string
 }
 
 func cachedFileInfos(items []client.FileInfo) []CachedFileInfo {
-	cached := make([]CachedFileInfo, len(items))
-	for i, item := range items {
+	cached := make([]CachedFileInfo, 0, len(items))
+	for _, item := range items {
+		if !validDirEntryName(item.Name) {
+			continue
+		}
 		var mtime time.Time
 		if item.Mtime > 0 {
 			mtime = time.Unix(item.Mtime, 0)
 		}
-		cached[i] = CachedFileInfo{
+		cached = append(cached, CachedFileInfo{
 			Name:       item.Name,
 			Size:       item.Size,
 			IsDir:      item.IsDir,
@@ -3352,7 +3355,7 @@ func cachedFileInfos(items []client.FileInfo) []CachedFileInfo {
 			HasMode:    item.HasMode,
 			ResourceID: item.ResourceID,
 			Nlink:      item.Nlink,
-		}
+		})
 	}
 	return cached
 }
@@ -5757,6 +5760,9 @@ func (fs *Dat9FS) ReadDir(cancel <-chan struct{}, input *gofuse.ReadIn, out *gof
 
 	for i := int(input.Offset); i < len(dh.Entries); i++ {
 		e := dh.Entries[i]
+		if !validDirEntryName(e.Name) {
+			continue
+		}
 		if !out.AddDirEntry(gofuse.DirEntry{
 			Name: e.Name,
 			Ino:  e.Ino,
@@ -5791,6 +5797,9 @@ func (fs *Dat9FS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out 
 
 	for i := int(input.Offset); i < len(dh.Entries); i++ {
 		e := dh.Entries[i]
+		if !validDirEntryName(e.Name) {
+			continue
+		}
 		if _, ok := fs.inodes.GetEntry(e.Ino); !ok {
 			e.Ino = fs.recreateDirEntryInode(dh.Path, e)
 			dh.Entries[i].Ino = e.Ino
@@ -6160,6 +6169,9 @@ func listDirErrToFuseStatus(err error) gofuse.Status {
 func (fs *Dat9FS) cachedToDirEntries(dirPath string, items []CachedFileInfo) []DirEntry {
 	entries := make([]DirEntry, 0, len(items))
 	for _, item := range items {
+		if !validDirEntryName(item.Name) {
+			continue
+		}
 		childP := dirEntryChildPath(dirPath, item.Name)
 
 		mtime := item.Mtime
@@ -6177,6 +6189,14 @@ func (fs *Dat9FS) cachedToDirEntries(dirPath string, items []CachedFileInfo) []D
 		entries = append(entries, dirEntryFromCachedInfo(item, ino))
 	}
 	return entries
+}
+
+func validDirEntryName(name string) bool {
+	return name != "" &&
+		name != "." &&
+		name != ".." &&
+		!strings.ContainsRune(name, '/') &&
+		!strings.ContainsRune(name, 0)
 }
 
 func dirEntryChildPath(dirPath, name string) string {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -4778,6 +4778,33 @@ func TestReadDirPlusStaleSnapshotUsesStoredEntryMetadataAfterDirCacheInvalidated
 	}
 }
 
+func TestRemoteListSkipsInvalidDirEntryNames(t *testing.T) {
+	items := []client.FileInfo{
+		{Name: "/"},
+		{Name: ""},
+		{Name: "."},
+		{Name: ".."},
+		{Name: "bad/name"},
+		{Name: "ok.txt"},
+	}
+	cached := cachedFileInfos(items)
+	if len(cached) != 1 || cached[0].Name != "ok.txt" {
+		t.Fatalf("cachedFileInfos = %+v, want only ok.txt", cached)
+	}
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	entries := fs.cachedToDirEntries("/", []CachedFileInfo{
+		{Name: "/"},
+		{Name: "bad/name"},
+		{Name: "ok.txt"},
+	})
+	if len(entries) != 1 || entries[0].Name != "ok.txt" {
+		t.Fatalf("cachedToDirEntries = %+v, want only ok.txt", entries)
+	}
+}
+
 func TestLookupSSEForeignDeleteInvalidatesPositiveNamespaceHit(t *testing.T) {
 	var headCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2379,6 +2379,13 @@ func (s *Server) handleUploads(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "uploads_list_failed", "path", path, "status", status, "error", err)...)
 		metricEvent(r.Context(), "metadb_query", "api", "uploads_list", "result", "error")
+		if errors.Is(err, datastore.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if errJSONInvalidRootDentry(w, err) {
+			return
+		}
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1536,6 +1536,10 @@ func (s *Server) handlePatch(w http.ResponseWriter, r *http.Request, path string
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
+		if errJSONInvalidRootDentry(w, err) {
+			metricEvent(r.Context(), "fs_patch", "result", "error")
+			return
+		}
 		if errors.Is(err, backend.ErrNotS3Stored) || errors.Is(err, backend.ErrS3NotConfigured) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "patch_unsupported_target", "path", path, "error", err)...)
 			metricEvent(r.Context(), "fs_patch", "result", "error")
@@ -1628,6 +1632,10 @@ func (s *Server) handleAppend(w http.ResponseWriter, r *http.Request, path strin
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "append_not_found", "path", path)...)
 			metricEvent(r.Context(), "fs_append", "result", "error")
 			errJSON(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if errJSONInvalidRootDentry(w, err) {
+			metricEvent(r.Context(), "fs_append", "result", "error")
 			return
 		}
 		if errors.Is(err, backend.ErrNotS3Stored) || errors.Is(err, backend.ErrS3NotConfigured) {
@@ -2242,6 +2250,9 @@ func (s *Server) handleChmod(w http.ResponseWriter, r *http.Request, path string
 	if err := b.ChmodCtx(r.Context(), path, req.Mode); err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "not found")
+			return
+		}
+		if errJSONInvalidRootDentry(w, err) {
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "chmod_failed", "path", path, "error", err)...)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1386,6 +1386,10 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 				errJSON(w, http.StatusConflict, err.Error())
 				return
 			}
+			if errJSONInvalidRootDentry(w, err) {
+				metricEvent(r.Context(), "fs_write", "result", "error")
+				return
+			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "write_upload_initiate_failed", "path", path, "error", err)...)
 			metricEvent(r.Context(), "fs_write", "result", "error")
 			errJSONInternalStorage(w)
@@ -1436,6 +1440,10 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_conflict", "path", path, "error", err)...)
 			metricEvent(r.Context(), "fs_write", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		if errJSONInvalidRootDentry(w, err) {
+			metricEvent(r.Context(), "fs_write", "result", "error")
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "write_failed", "path", path, "error", err)...)
@@ -2032,6 +2040,9 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path strin
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
+		if errJSONInvalidRootDentry(w, err) {
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "delete_failed", "path", path, "recursive", recursive, "kind", kind, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
@@ -2067,6 +2078,9 @@ func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath stri
 		if errors.Is(err, datastore.ErrNotFound) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "copy_not_found", "src_path", srcPath, "dst_path", dstPath)...)
 			errJSON(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if errJSONInvalidRootDentry(w, err) {
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "copy_failed", "src_path", srcPath, "dst_path", dstPath, "error", err)...)
@@ -2110,6 +2124,9 @@ func (s *Server) handleHardlink(w http.ResponseWriter, r *http.Request, dstPath 
 			errJSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
+		if errJSONInvalidRootDentry(w, err) {
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "hardlink_failed", "src_path", srcPath, "dst_path", dstPath, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
@@ -2151,6 +2168,9 @@ func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath st
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
+		if errJSONInvalidRootDentry(w, err) {
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "rename_failed", "old_path", oldPath, "new_path", newPath, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
@@ -2180,6 +2200,9 @@ func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string
 		if errors.Is(err, datastore.ErrPathConflict) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "mkdir_conflict", "path", path, "error", err)...)
 			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		if errJSONInvalidRootDentry(w, err) {
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "mkdir_failed", "path", path, "error", err)...)
@@ -2245,6 +2268,9 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request, path strin
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
+		if errJSONInvalidRootDentry(w, err) {
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "create_failed", "path", path, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
@@ -2302,6 +2328,9 @@ func (s *Server) handleSymlink(w http.ResponseWriter, r *http.Request, path stri
 		if errors.Is(err, datastore.ErrPathConflict) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_conflict", "path", path, "error", err)...)
 			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		if errJSONInvalidRootDentry(w, err) {
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "symlink_failed", "path", path, "error", err)...)
@@ -2477,6 +2506,10 @@ func (s *Server) handleUploadInitiate(w http.ResponseWriter, r *http.Request, b 
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
+		if errJSONInvalidRootDentry(w, err) {
+			metricEvent(r.Context(), "fs_write", "result", "error")
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_failed", "path", req.Path, "error", err)...)
 		metricEvent(r.Context(), "fs_write", "result", "error")
 		errJSONInternalStorage(w)
@@ -2586,6 +2619,10 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_revision_conflict", "upload_id", uploadID, "error", err)...)
 			metricEvent(r.Context(), "upload_complete", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		if errJSONInvalidRootDentry(w, err) {
+			metricEvent(r.Context(), "upload_complete", "result", "error")
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_failed", "upload_id", uploadID, "error", err)...)
@@ -2934,6 +2971,10 @@ func (s *Server) handleV2UploadInitiate(w http.ResponseWriter, r *http.Request) 
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
+		if errJSONInvalidRootDentry(w, err) {
+			metricEvent(r.Context(), "v2_upload_initiate", "result", "error")
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_failed", "path", req.Path, "error", err)...)
 		metricEvent(r.Context(), "v2_upload_initiate", "result", "error")
 		errJSONInternalStorage(w)
@@ -3142,6 +3183,10 @@ func (s *Server) handleV2UploadComplete(w http.ResponseWriter, r *http.Request, 
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_client_protocol_error", "upload_id", uploadID, "error", err)...)
 			metricEvent(r.Context(), "v2_upload_complete", "result", "error")
 			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if errJSONInvalidRootDentry(w, err) {
+			metricEvent(r.Context(), "v2_upload_complete", "result", "error")
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_failed", "upload_id", uploadID, "error", err)...)
@@ -3675,6 +3720,14 @@ func errJSON(w http.ResponseWriter, code int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+func errJSONInvalidRootDentry(w http.ResponseWriter, err error) bool {
+	if !errors.Is(err, datastore.ErrInvalidRootDentry) {
+		return false
+	}
+	errJSON(w, http.StatusBadRequest, err.Error())
+	return true
 }
 
 const internalStorageErrorMessage = "storage backend unavailable; contact support"

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -87,6 +87,30 @@ func insertTestS3File(t *testing.T, s *Server, p string, size int64) {
 	}
 }
 
+func insertHistoricalRootDentry(t *testing.T, s *Server, inodeID string, mode uint32) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	store := s.fallback.Store()
+	if err := store.InsertInode(ctx, &datastore.Inode{
+		InodeID:   inodeID,
+		SizeBytes: 0,
+		Revision:  1,
+		Mode:      mode,
+		Status:    datastore.StatusConfirmed,
+		CreatedAt: now,
+		Mtime:     now,
+	}); err != nil {
+		t.Fatalf("insert root inode: %v", err)
+	}
+	if _, err := store.DB().ExecContext(ctx, `
+		INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, inode_id, created_at)
+		VALUES (?, ?, ?, ?, 1, ?, ?)`,
+		"node-"+inodeID, "/", "/", "root-alias", inodeID, now); err != nil {
+		t.Fatalf("insert historical root dentry: %v", err)
+	}
+}
+
 func newLocalTenantShimServer(t *testing.T, apiKey string) *Server {
 	t.Helper()
 
@@ -1030,6 +1054,75 @@ func TestSymlinkRoundTrip(t *testing.T) {
 	}
 	if string(body) != "../target.txt" {
 		t.Fatalf("read link payload = %q, want ../target.txt", body)
+	}
+}
+
+func TestChmodRootHistoricalDentryReturnsBadRequest(t *testing.T) {
+	s := newTestServer(t)
+	const inodeID = "root-inode"
+	const originalMode = 0o755
+	insertHistoricalRootDentry(t, s, inodeID, originalMode)
+
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/?chmod=1", strings.NewReader(`{"mode":448}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	var mode uint32
+	if err := s.fallback.Store().DB().QueryRowContext(context.Background(), `SELECT mode FROM inodes WHERE inode_id = ?`, inodeID).Scan(&mode); err != nil {
+		t.Fatal(err)
+	}
+	if mode != originalMode {
+		t.Fatalf("root inode mode = %o, want unchanged %o", mode, originalMode)
+	}
+}
+
+func TestPatchAndAppendRootReturnBadRequest(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cases := []struct {
+		name   string
+		method string
+		url    string
+		body   string
+	}{
+		{
+			name:   "patch",
+			method: http.MethodPatch,
+			url:    ts.URL + "/v1/fs/",
+			body:   `{"new_size":1,"dirty_parts":[1]}`,
+		},
+		{
+			name:   "append",
+			method: http.MethodPost,
+			url:    ts.URL + "/v1/fs/?append=1",
+			body:   `{"append_size":1}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.method, tc.url, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+			}
+		})
 	}
 }
 

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -1236,6 +1236,22 @@ func TestListUploadsEndpoint(t *testing.T) {
 	}
 }
 
+func TestListUploadsEndpointRootPathReturnsNotFound(t *testing.T) {
+	s, _ := newTestServerWithS3(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/uploads?path=/&status=UPLOADING")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
 func TestOneUploadPerPath(t *testing.T) {
 	s, _ := newTestServerWithS3(t)
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary
- Reject any attempt to persist or mutate the implicit root path `/` as a `file_nodes` row, regardless of dentry name.
- Skip historical root rows from datastore/FUSE directory listings, including malformed rows whose name is not `/`.
- Reject root targets across backend write/mutation paths, including multipart finalize/complete and chmod before S3 or tenant DB mutation.
- Return explicit client errors for root-path mutations, including write/copy/link/rename/chmod/append/patch and upload listing at `/`.

## Tests
- `make test TEST_PKGS='./pkg/datastore ./pkg/backend ./pkg/fuse ./pkg/server' TEST_RUN='Test(InsertNodeRejectsRootDentry|StoreRejectsRootPathWrites|ListDirSkipsHistoricalRootDentry|ListNodesSkipsHistoricalRootDentry|MkdirRootIsIdempotentAndDoesNotCreateDentry|WriteRootRejected|FinalizeUploadRejectsRootTargetBeforeS3Complete|RemoteListSkipsInvalidDirEntryNames|ListUploadsEndpointRootPathReturnsNotFound|ChmodRejectsHistoricalRootDentry|ChmodRootHistoricalDentryRejected|ChmodRootHistoricalDentryReturnsBadRequest|PatchAndAppendRootReturnBadRequest)$'`

## Notes
- A broader `make test TEST_PKGS='./pkg/datastore ./pkg/backend ./pkg/fuse'` run previously still failed in `pkg/fuse` on `TestDiskReadCacheStartupRecoveryAndTempCleanup` with `recovered cache entry = "", false; want hello hit`, which appears unrelated to this root dentry change.