### PR TITLE
Fix Git workspace local HEAD size resolution

### DIFF
--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -880,6 +880,11 @@ func TestCtxListDisplaysTenantID(t *testing.T) {
 // pins it.
 func TestF13_NoDaemonStateBetweenCalls(t *testing.T) {
 	home := withIsolatedHome(t)
+	tmpRoot := filepath.Join(home, "tmp")
+	if err := os.MkdirAll(tmpRoot, 0o700); err != nil {
+		t.Fatalf("mkdir temp root: %v", err)
+	}
+	t.Setenv("TMPDIR", tmpRoot)
 	// Snapshot pre-state of common leak sinks.
 	preEntries := func() []string {
 		var out []string

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -776,6 +776,9 @@ func (fs *Dat9FS) ensureGitLocalHeadTree(ctx context.Context, rt *gitWorkspaceRu
 		return false, err
 	}
 	nodes, children := parseLocalGitTree(rt.workspace.WorkspaceID, head, treeOut)
+	if err := fs.fillLocalGitTreeSizes(ctx, rt, gitDir, nodes, children); err != nil {
+		log.Printf("git workspace local HEAD size fill failed workspace=%s head=%s: %v", rt.workspace.WorkspaceID, head, err)
+	}
 	rt.mu.Lock()
 	rt.localTreeCommit = head
 	rt.localNodes = nodes
@@ -850,6 +853,109 @@ func parseLocalGitTree(workspaceID, commit string, raw []byte) (map[string]clien
 		sort.Slice(children[parent], func(i, j int) bool { return children[parent][i].Name < children[parent][j].Name })
 	}
 	return nodes, children
+}
+
+func (fs *Dat9FS) fillLocalGitTreeSizes(ctx context.Context, rt *gitWorkspaceRuntime, gitDir string, nodes map[string]client.GitTreeNode, children map[string][]client.GitTreeNode) error {
+	if fs == nil || rt == nil || len(nodes) == 0 {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	sizeByObject, baseCommit, workspaceID := rt.knownBaseGitObjectSizes()
+	localRoot := ""
+	if fs.opts != nil {
+		localRoot = strings.TrimSpace(fs.opts.LocalRoot)
+	}
+	missing := make(map[string]struct{})
+	for rel, n := range nodes {
+		if !gitNodeHasBlobSize(n) {
+			continue
+		}
+		oid := strings.ToLower(strings.TrimSpace(n.ObjectSHA))
+		if oid == "" {
+			continue
+		}
+		if size, ok := sizeByObject[oid]; ok {
+			setGitTreeNodeSize(nodes, children, rel, size)
+			continue
+		}
+		if localRoot != "" && workspaceID != "" && baseCommit != "" {
+			if size, hit, err := gitcache.StatBlob(ctx, localRoot, workspaceID, baseCommit, oid); err != nil {
+				return err
+			} else if hit {
+				sizeByObject[oid] = size
+				setGitTreeNodeSize(nodes, children, rel, size)
+				continue
+			}
+		}
+		missing[oid] = struct{}{}
+	}
+	if len(missing) == 0 || strings.TrimSpace(gitDir) == "" {
+		return nil
+	}
+	ids := mapKeys(missing)
+	sort.Strings(ids)
+	infos, err := gitObjectInfoBatch(ctx, gitDir, ids)
+	if err != nil {
+		return err
+	}
+	for rel, n := range nodes {
+		if !gitNodeHasBlobSize(n) || n.SizeBytes >= 0 {
+			continue
+		}
+		oid := strings.ToLower(strings.TrimSpace(n.ObjectSHA))
+		info := infos[oid]
+		if info.typ != "blob" || info.size < 0 {
+			continue
+		}
+		setGitTreeNodeSize(nodes, children, rel, info.size)
+	}
+	return nil
+}
+
+func (rt *gitWorkspaceRuntime) knownBaseGitObjectSizes() (map[string]int64, string, string) {
+	sizeByObject := make(map[string]int64)
+	if rt == nil {
+		return sizeByObject, "", ""
+	}
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+	for _, n := range rt.nodes {
+		if !gitNodeHasBlobSize(n) || n.SizeBytes < 0 {
+			continue
+		}
+		oid := strings.ToLower(strings.TrimSpace(n.ObjectSHA))
+		if oid == "" {
+			continue
+		}
+		sizeByObject[oid] = n.SizeBytes
+	}
+	return sizeByObject, rt.workspace.HeadCommit, rt.workspace.WorkspaceID
+}
+
+func gitNodeHasBlobSize(n client.GitTreeNode) bool {
+	return n.Kind == "file" || n.Kind == "symlink"
+}
+
+func setGitTreeNodeSize(nodes map[string]client.GitTreeNode, children map[string][]client.GitTreeNode, rel string, size int64) {
+	if size < 0 {
+		return
+	}
+	n, ok := nodes[rel]
+	if !ok {
+		return
+	}
+	n.SizeBytes = size
+	nodes[rel] = n
+	childNodes := children[n.ParentPath]
+	for i := range childNodes {
+		if childNodes[i].Path == rel {
+			childNodes[i].SizeBytes = size
+			children[n.ParentPath] = childNodes
+			return
+		}
+	}
 }
 
 func (rt *gitWorkspaceRuntime) hasImpliedDir(rel string) bool {
@@ -1345,6 +1451,22 @@ func (fs *Dat9FS) readGitCleanFile(ctx context.Context, rt *gitWorkspaceRuntime,
 			}
 			return data, nil
 		}
+		baseCommit := strings.TrimSpace(rt.workspace.HeadCommit)
+		if baseCommit != "" && !strings.EqualFold(baseCommit, nodeCommit) {
+			data, hit, err = gitcache.ReadBlob(ctx, localRoot, rt.workspace.WorkspaceID, baseCommit, n.ObjectSHA, offset, size)
+			if err != nil {
+				return nil, err
+			}
+			if hit {
+				if fs.perfEnabled() {
+					fs.perf.gitCleanBlobCacheHit.add(1)
+				}
+				if offset == 0 && size < 0 {
+					fs.updateGitKnownSize(rt, localPath, rel, n, int64(len(data)))
+				}
+				return data, nil
+			}
+		}
 	}
 	if fs.perfEnabled() {
 		fs.perf.gitCleanCacheMiss.add(1)
@@ -1386,6 +1508,13 @@ func (fs *Dat9FS) resolveGitCleanNodeSize(ctx context.Context, rt *gitWorkspaceR
 		if size, hit, err := gitcache.StatBlob(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, n.ObjectSHA); err == nil && hit {
 			rt.updateCleanNodeSize(rel, nodeCommit, size)
 			return size
+		}
+		baseCommit := strings.TrimSpace(rt.workspace.HeadCommit)
+		if baseCommit != "" && !strings.EqualFold(baseCommit, nodeCommit) {
+			if size, hit, err := gitcache.StatBlob(ctx, localRoot, rt.workspace.WorkspaceID, baseCommit, n.ObjectSHA); err == nil && hit {
+				rt.updateCleanNodeSize(rel, nodeCommit, size)
+				return size
+			}
 		}
 	}
 	if gitWorkspaceIsFastBlobless(rt) {

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1911,6 +1911,152 @@ func TestGitWorkspaceUnknownSizeLookupUsesBlobCacheSize(t *testing.T) {
 	}
 }
 
+func TestGitLocalHeadTreeSizeFillInheritsBaseManifestSize(t *testing.T) {
+	objectSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	localCommit := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	raw := []byte("100644 blob " + objectSHA + "\tREADME.md\x00")
+	nodes, children := parseLocalGitTree("ws1", localCommit, raw)
+	rt := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID: "ws1",
+			HeadCommit:  fixtureHeadCommit,
+		},
+		nodes: map[string]client.GitTreeNode{
+			"README.md": {
+				Path:      "README.md",
+				Kind:      "file",
+				Mode:      "100644",
+				ObjectSHA: objectSHA,
+				SizeBytes: 123,
+			},
+		},
+	}
+	fs := &Dat9FS{opts: &MountOptions{}}
+	if err := fs.fillLocalGitTreeSizes(context.Background(), rt, "", nodes, children); err != nil {
+		t.Fatalf("fillLocalGitTreeSizes: %v", err)
+	}
+	if got := nodes["README.md"].SizeBytes; got != 123 {
+		t.Fatalf("local node size = %d, want inherited base size", got)
+	}
+	if got := children[""][0].SizeBytes; got != 123 {
+		t.Fatalf("local child size = %d, want inherited base size", got)
+	}
+}
+
+func TestGitLocalHeadTreeSizeFillUsesBaseBlobCache(t *testing.T) {
+	objectSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	localCommit := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	content := []byte("cached base object\n")
+	localRoot := t.TempDir()
+	if err := gitcache.WriteBlob(context.Background(), localRoot, "ws1", fixtureHeadCommit, objectSHA, content); err != nil {
+		t.Fatal(err)
+	}
+	raw := []byte("100644 blob " + objectSHA + "\tREADME.md\x00")
+	nodes, children := parseLocalGitTree("ws1", localCommit, raw)
+	rt := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID: "ws1",
+			HeadCommit:  fixtureHeadCommit,
+		},
+		nodes: map[string]client.GitTreeNode{
+			"README.md": {
+				Path:      "README.md",
+				Kind:      "file",
+				Mode:      "100644",
+				ObjectSHA: objectSHA,
+				SizeBytes: -1,
+			},
+		},
+	}
+	fs := &Dat9FS{opts: &MountOptions{LocalRoot: localRoot}}
+	if err := fs.fillLocalGitTreeSizes(context.Background(), rt, "", nodes, children); err != nil {
+		t.Fatalf("fillLocalGitTreeSizes: %v", err)
+	}
+	if got := nodes["README.md"].SizeBytes; got != int64(len(content)) {
+		t.Fatalf("local node size = %d, want base blob cache size %d", got, len(content))
+	}
+}
+
+func TestGitLocalHeadTreeSizeFillBatchChecksLocalBlob(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	baseContent := []byte("hello base\n")
+	localContent := []byte("hello local commit\n")
+	repo := createGitRepoWithReadme(t, baseContent)
+	baseCommit := fuseGitOutputForTest(t, repo, "rev-parse", "HEAD")
+	baseSHA := fuseGitOutputForTest(t, repo, "hash-object", "README.md")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), localContent, 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runFuseTestGit(t, repo, "add", "README.md")
+	runFuseTestGit(t, repo, "commit", "-m", "local")
+	localCommit := fuseGitOutputForTest(t, repo, "rev-parse", "HEAD")
+	localSHA := fuseGitOutputForTest(t, repo, "hash-object", "README.md")
+	treeOut, err := gitCommandOutputNoLazy(context.Background(), "--git-dir", filepath.Join(repo, ".git"), "ls-tree", "-r", "-t", "-z", localCommit)
+	if err != nil {
+		t.Fatalf("git ls-tree: %v", err)
+	}
+	nodes, children := parseLocalGitTree("ws1", localCommit, treeOut)
+	rt := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID: "ws1",
+			HeadCommit:  baseCommit,
+		},
+		nodes: map[string]client.GitTreeNode{
+			"README.md": {
+				Path:      "README.md",
+				Kind:      "file",
+				Mode:      "100644",
+				ObjectSHA: baseSHA,
+				SizeBytes: int64(len(baseContent)),
+			},
+		},
+	}
+	fs := &Dat9FS{opts: &MountOptions{}}
+	if err := fs.fillLocalGitTreeSizes(context.Background(), rt, filepath.Join(repo, ".git"), nodes, children); err != nil {
+		t.Fatalf("fillLocalGitTreeSizes: %v", err)
+	}
+	if got := nodes["README.md"].ObjectSHA; got != localSHA {
+		t.Fatalf("local object = %s, want %s", got, localSHA)
+	}
+	if got := nodes["README.md"].SizeBytes; got != int64(len(localContent)) {
+		t.Fatalf("local node size = %d, want local blob size %d", got, len(localContent))
+	}
+}
+
+func TestGitWorkspaceLocalHeadReadUsesBaseBlobCache(t *testing.T) {
+	objectSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	baseCommit := fixtureHeadCommit
+	localCommit := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	content := []byte("cached base object\n")
+	localRoot := t.TempDir()
+	if err := gitcache.WriteBlob(context.Background(), localRoot, "ws1", baseCommit, objectSHA, content); err != nil {
+		t.Fatal(err)
+	}
+	rt := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID: "ws1",
+			HeadCommit:  baseCommit,
+		},
+	}
+	fs := &Dat9FS{opts: &MountOptions{LocalRoot: localRoot}, git: newGitWorkspaceLayer(), inodes: NewInodeToPath()}
+	got, err := fs.readGitCleanFile(context.Background(), rt, "/repo/README.md", "README.md", client.GitTreeNode{
+		CommitSHA: localCommit,
+		Path:      "README.md",
+		Kind:      "file",
+		Mode:      "100644",
+		ObjectSHA: objectSHA,
+		SizeBytes: int64(len(content)),
+	}, 0, -1)
+	if err != nil {
+		t.Fatalf("readGitCleanFile: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("readGitCleanFile = %q, want %q", got, content)
+	}
+}
+
 func TestGitWorkspaceBloblessUnknownSizeLookupSkipsGitSizeProbe(t *testing.T) {
 	fixture := newGitWorkspaceFixture(t)
 	fixture.mode = gitWorkspaceModeFastBlobless


### PR DESCRIPTION
## Summary

This PR fixes a Git workspace correctness issue where files could be reported as modified after a local commit even though their contents had not changed.

The root cause was the local HEAD tree path used after local Git commits. Drive9 intentionally lists local Git trees without `git ls-tree -l` to avoid triggering GitHub partial-clone lazy fetches. That keeps fast clone fast, but it also means blob sizes are unknown for the local HEAD manifest. In some paths those unknown sizes surfaced as zero-sized clean files, so Git compared the working tree against the index and reported false `modified` entries after commit/status operations.

## Fix

The fix keeps the no-`-l` behavior and fills local HEAD tree sizes without remote blob fetches:

- Reuse known clean blob sizes from the base workspace manifest by object SHA.
- Fall back to the base commit local clean blob cache when the local HEAD manifest references unchanged base blobs.
- Batch-check only remaining local-only objects with `git cat-file --batch-check` using the existing no-lazy-fetch path.
- Add base-commit blob-cache fallback for clean file reads and clean node size resolution when the active clean node belongs to a local commit.

This preserves the fast-clone design goal: no clean remote blob contents are uploaded to Drive9, and size repair does not reintroduce per-file GitHub lazy fetches.

## Tests

Local:

- `go test ./pkg/fuse -run "TestGit(LocalHead|Workspace)"`
- `go test ./pkg/fuse`
- `go test ./cmd/drive9/cli`
- `git diff --check`

EC2 live E2E against Aliyun Drive9 endpoint:

- Instance: `drive9-posix-e2e-20260603`
- Endpoint: `http://alb-b6w55jkdwh9a82dkrk.ap-southeast-1.alb.aliyuncsslbintl.com`
- Script: `e2e/git-workspace-smoke-test.sh`
- Repos: `drive9`, `kimi-cli`, `kimi-code`
- Scenarios: `agent_edit_add_commit`, `agent_patch_apply`, `sandbox_restore`, `fast_worktree`
- Result: `182/182 passed, 0 failed`
- Runtime: about 9m30s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and symlink size resolution for locally restored Git workspace data with multi-level fallbacks so restoration proceeds even when size metadata is missing
  * Enhanced handling of repository HEAD drift with additional fallback lookups to reduce failed reads and materializations
  * Increased resilience so size-resolution errors are logged without aborting local tree restoration

* **Tests**
  * Added tests validating size-filling behavior and cached-base read semantics; tightened a CLI test to isolate its temp directory
<!-- end of auto-generated comment: release notes by coderabbit.ai -->