### PR TITLE
Suppress datastore context cancellation error logs

### DIFF
--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -2896,10 +2896,16 @@ func observeStoreOp(ctx context.Context, op string, start time.Time, errp *error
 			result = "not_found"
 		case errors.Is(*errp, ErrPathConflict), errors.Is(*errp, ErrUploadConflict), errors.Is(*errp, ErrIdempotencyConflict):
 			result = "conflict"
+		case errors.Is(*errp, context.Canceled):
+			result = "canceled"
+		case errors.Is(*errp, context.DeadlineExceeded):
+			result = "deadline_exceeded"
 		default:
 			result = "error"
 		}
-		logger.Error(ctx, "datastore_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
+		if result != "canceled" && result != "deadline_exceeded" {
+			logger.Error(ctx, "datastore_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
+		}
 	}
 	logger.InfoBenchTiming(ctx, "datastore_op_timing",
 		zap.String("operation", op),


### PR DESCRIPTION
## Summary
- classify datastore context cancellation as canceled/deadline_exceeded instead of error
- avoid emitting datastore_op_failed error logs for expected shutdown cancellation
- keep timing logs and datastore metrics result labels for visibility

## Context
This handles shutdown noise that still appears below the FileGC worker layer, for example recover_expired_file_gc_tasks returning context canceled.

## Tests
- env GOCACHE=/tmp/drive9-go-build go test ./pkg/datastore -count=1
- env GOCACHE=/tmp/drive9-go-build go test ./pkg/backend -count=1
- env GOCACHE=/tmp/drive9-go-build GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-lint make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Datastore operations now distinguish cancellations and timeouts from generic errors, reducing misleading error logs and improving clarity of operation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->