### PR TITLE
Add tenant usage metrics dashboards

### DIFF
--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -1,32 +1,49 @@
 # Drive9 Grafana Dashboards
 
-This directory uses a three-bucket layout instead of a single mega dashboard.
+This directory uses a usage-first layout plus focused incident drill-downs.
 
-## 1. Overview dashboards
+## 1. Usage dashboard
+
+- `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, HTTP transport bytes, storage/media quota state, latency, and non-OK rates by tenant/surface/action. Use this to answer `who is using Drive9, how much, and through which workflows?`
+
+Tenant usage metrics intentionally allow `tenant_id` as a Prometheus label, but keep high-cardinality values out of labels: no path, file ID, upload ID, API key ID, raw URL, user agent, or trace ID.
+
+## Tenant metric contract
+
+- `drive9_tenant_requests_total`: request count by `tenant_id`, `surface`, `action`, `result`, `status`, and `status_class`.
+- `drive9_tenant_request_duration_seconds`: request latency histogram with the same labels as `drive9_tenant_requests_total`.
+- `drive9_tenant_inflight_requests`: current in-flight request gauge by `tenant_id`, `surface`, and `action`.
+- `drive9_tenant_http_bytes_total`: HTTP transport bytes by `tenant_id`, `surface`, `action`, and `direction=request|response`.
+- `drive9_tenant_file_bytes_total`: logical file bytes by `tenant_id`, `surface`, `action`, and `direction=read|write`.
+- `drive9_tenant_storage_bytes`: opportunistically published quota storage gauge by `tenant_id` and `state=confirmed|reserved|limit`.
+- `drive9_tenant_media_files`: opportunistically published quota media-file gauge by `tenant_id` and `state=confirmed|limit`.
+
+## 2. Service overview dashboards
 
 - `drive9-service-health-dashboard.json`: first-stop dashboard for service incidents, module availability, HTTP health, service error ratio, and coarse DB pressure.
 - `drive9-async-fuse-dashboard.json`: first-stop dashboard for delayed background work and mount-path incidents, especially semantic worker backlog, image/audio extraction runtime, audio extract failures, and FUSE remote behavior.
 
-## 2. Request-path drill-down dashboards
+## 3. Request-path drill-down dashboards
 
 - `drive9-api-surface-dashboard.json`: non-FS and non-upload API request-path analysis for control, vault, SQL, events, and auxiliary HTTP surfaces.
 - `drive9-filesystem-path-dashboard.json`: filesystem-path analysis that owns `/v1/fs/*`, correlates HTTP traffic with `fs_*` backend work, and now includes explicit WebDAV behavior.
 - `drive9-upload-path-dashboard.json`: upload-path analysis that owns upload flows and correlates upload HTTP traffic, backend upload operations, and upload-related events.
 - `drive9-upload-s3-path-dashboard.json`: upload plus raw object-store analysis for incidents that have narrowed from upload symptoms into `s3client` throughput, errors, or latency.
 
-## 3. Data-store drill-down dashboards
+## 4. Data-store drill-down dashboards
 
 - `drive9-metadata-db-dashboard.json`: metadata/control-plane DB analysis that owns `role="meta"`.
 - `drive9-tenant-data-db-dashboard.json`: tenant data-path DB analysis that owns `role="user"`.
 
 ## Operating rule
 
-Start from an overview dashboard. Only move into drill-down dashboards after the incident shape is clear.
+Start from `Drive9 Tenant Usage` for product/user questions and from `Drive9 Service Health` for incidents. Only move into request-path or DB drill-down dashboards after the shape is clear.
 
 Dashboard links are embedded in the overview and drill-down dashboards so the normal workflow is clickable inside Grafana rather than document-only.
 
-We intentionally do not keep a single all-in-one observability dashboard anymore. The split is:
+We intentionally do not keep a single all-in-one observability dashboard. The split is:
 
-- Overview dashboards answer `is the system healthy and where is the blast radius?`
+- Tenant usage answers `which tenants are active, what operations are they doing, and how much are they reading/writing?`
+- Service overview dashboards answer `is the system healthy and where is the blast radius?`
 - Request-path dashboards answer `which API or business path is slow or failing?`
 - Data-store dashboards answer `is the database the limiting factor?`

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -2,6 +2,10 @@
 
 This directory uses a usage-first layout plus focused incident drill-downs.
 
+## Breaking metric migration
+
+This dashboard set expects the `drive9_*` Prometheus namespace. The previous `dat9_*` metric names are intentionally not dual-emitted by Drive9 after this metrics contract rewrite. Existing external dashboards, alerts, and recording rules must be migrated from `dat9_*` to `drive9_*` at the same time as this server rollout.
+
 ## 1. Usage dashboard
 
 - `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, HTTP transport bytes, storage/media quota state, latency, and non-OK rates by tenant/surface/action. Use this to answer `who is using Drive9, how much, and through which workflows?`

--- a/docs/grafana/drive9-api-surface-dashboard.json
+++ b/docs/grafana/drive9-api-surface-dashboard.json
@@ -121,7 +121,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$route\"}[$__rate_interval]))",
           "legendFormat": "http_rps",
           "refId": "A"
         }
@@ -188,7 +188,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval])))",
           "legendFormat": "http_p95",
           "refId": "A"
         }
@@ -255,7 +255,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval])))",
           "legendFormat": "http_p99",
           "refId": "A"
         }
@@ -322,7 +322,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_http_inflight_requests{route=~\"$route\"})",
+          "expr": "sum(drive9_http_inflight_requests{route=~\"$route\"})",
           "legendFormat": "inflight",
           "refId": "A"
         }
@@ -389,7 +389,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval])), 0.000001)",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_http_requests_total{route=~\"$route\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "http_5xx_ratio",
           "refId": "A"
         }
@@ -456,7 +456,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$route\",status=~\"4..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval])), 0.000001)",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$route\",status=~\"4..\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_http_requests_total{route=~\"$route\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "http_4xx_ratio",
           "refId": "A"
         }
@@ -503,7 +503,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, sum by (route) (rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval])))",
+          "expr": "topk(12, sum by (route) (rate(drive9_http_requests_total{route=~\"$route\"}[$__rate_interval])))",
           "legendFormat": "{{route}}",
           "refId": "A"
         }
@@ -550,7 +550,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval]))))",
           "legendFormat": "{{route}} p95",
           "refId": "A"
         },
@@ -559,7 +559,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval]))))",
           "legendFormat": "{{route}} p99",
           "refId": "B"
         }
@@ -606,7 +606,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (status) (rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval]))",
+          "expr": "sum by (status) (rate(drive9_http_requests_total{route=~\"$route\"}[$__rate_interval]))",
           "legendFormat": "status={{status}}",
           "refId": "A"
         }
@@ -653,7 +653,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, sum by (route, status) (rate(dat9_http_requests_total{route=~\"$route\",status!~\"2..|3..\"}[$__rate_interval])))",
+          "expr": "topk(12, sum by (route, status) (rate(drive9_http_requests_total{route=~\"$route\",status!~\"2..|3..\"}[$__rate_interval])))",
           "legendFormat": "{{route}} / {{status}}",
           "refId": "A"
         },
@@ -662,7 +662,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_http_inflight_requests{route=~\"$route\"})",
+          "expr": "sum(drive9_http_inflight_requests{route=~\"$route\"})",
           "legendFormat": "inflight",
           "refId": "B"
         }
@@ -709,7 +709,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"tenant_provision|tenant_schema_init\"}[$__rate_interval]))",
+          "expr": "sum by (event, result) (rate(drive9_business_events_total{event=~\"tenant_provision|tenant_schema_init\"}[$__rate_interval]))",
           "legendFormat": "{{event}} {{result}}",
           "refId": "A"
         }
@@ -756,7 +756,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"tenant_provision|tenant_schema_init\",result!~\"ok|accepted\"}[$__rate_interval]))",
+          "expr": "sum by (event, result) (rate(drive9_business_events_total{event=~\"tenant_provision|tenant_schema_init\",result!~\"ok|accepted\"}[$__rate_interval]))",
           "legendFormat": "{{event}} {{result}}",
           "refId": "A"
         }
@@ -805,14 +805,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
+        "definition": "label_values(drive9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
         "hide": 0,
         "includeAll": true,
         "label": "API Route",
         "multi": true,
         "name": "route",
         "options": [],
-        "query": "label_values(dat9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
+        "query": "label_values(drive9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/docs/grafana/drive9-async-fuse-dashboard.json
+++ b/docs/grafana/drive9-async-fuse-dashboard.json
@@ -132,7 +132,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_service_gauge{component=\"semantic_worker\",name=\"queue_lag_seconds\"}",
+          "expr": "drive9_service_gauge{component=\"semantic_worker\",name=\"queue_lag_seconds\"}",
           "legendFormat": "queue_lag_seconds",
           "refId": "A"
         }
@@ -199,7 +199,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_service_gauge{component=\"semantic_worker\",name=\"dead_lettered\"}",
+          "expr": "drive9_service_gauge{component=\"semantic_worker\",name=\"dead_lettered\"}",
           "legendFormat": "dead_lettered",
           "refId": "A"
         }
@@ -266,7 +266,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_fuse_remote_operations_total{result=\"error\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_fuse_remote_operations_total[$__rate_interval])), 0.000001)",
+          "expr": "sum(rate(drive9_fuse_remote_operations_total{result=\"error\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_fuse_remote_operations_total[$__rate_interval])), 0.000001)",
           "legendFormat": "fuse_remote_error_ratio",
           "refId": "A"
         }
@@ -333,7 +333,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_fuse_remote_operation_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_fuse_remote_operation_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "fuse_remote_p95",
           "refId": "A"
         }
@@ -409,7 +409,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_service_gauge{component=\"semantic_worker\",name=~\"inflight|queued|processing|dead_lettered\"}",
+          "expr": "drive9_service_gauge{component=\"semantic_worker\",name=~\"inflight|queued|processing|dead_lettered\"}",
           "legendFormat": "semantic_worker {{name}}",
           "refId": "A"
         }
@@ -456,7 +456,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_service_gauge{component=\"semantic_worker\",name=\"queue_lag_seconds\"}",
+          "expr": "drive9_service_gauge{component=\"semantic_worker\",name=\"queue_lag_seconds\"}",
           "legendFormat": "semantic_worker queue_lag_seconds",
           "refId": "A"
         },
@@ -465,7 +465,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_service_gauge{component=\"image_extract\",name=~\"workers|queue_capacity|queue_depth\"}",
+          "expr": "drive9_service_gauge{component=\"image_extract\",name=~\"workers|queue_capacity|queue_depth\"}",
           "legendFormat": "image_extract {{name}}",
           "refId": "B"
         },
@@ -474,7 +474,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_service_gauge{component=\"audio_extract\",name=~\"task_timeout_seconds|max_audio_bytes|max_extract_text_bytes\"}",
+          "expr": "drive9_service_gauge{component=\"audio_extract\",name=~\"task_timeout_seconds|max_audio_bytes|max_extract_text_bytes\"}",
           "legendFormat": "audio_extract {{name}}",
           "refId": "C"
         }
@@ -521,7 +521,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_fuse_remote_operations_total[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(drive9_fuse_remote_operations_total[$__rate_interval]))",
           "legendFormat": "{{operation}} {{result}}",
           "refId": "A"
         }
@@ -568,7 +568,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(dat9_fuse_remote_operation_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(drive9_fuse_remote_operation_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "{{operation}} remote_p95",
           "refId": "A"
         }
@@ -615,7 +615,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (result) (rate(dat9_service_operations_total{component=\"audio_extract\",operation=\"process\"}[$__rate_interval]))",
+          "expr": "sum by (result) (rate(drive9_service_operations_total{component=\"audio_extract\",operation=\"process\"}[$__rate_interval]))",
           "legendFormat": "audio_extract {{result}}",
           "refId": "A"
         }
@@ -662,7 +662,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{component=\"audio_extract\",operation=\"process\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_service_operation_duration_seconds_bucket{component=\"audio_extract\",operation=\"process\"}[$__rate_interval])))",
           "legendFormat": "audio_extract p95",
           "refId": "A"
         },
@@ -671,7 +671,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{component=\"audio_extract\",operation=\"process\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_service_operation_duration_seconds_bucket{component=\"audio_extract\",operation=\"process\"}[$__rate_interval])))",
           "legendFormat": "audio_extract p99",
           "refId": "B"
         }
@@ -718,7 +718,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (result) (rate(dat9_service_operations_total{component=\"image_extract\",operation=\"process\"}[$__rate_interval]))",
+          "expr": "sum by (result) (rate(drive9_service_operations_total{component=\"image_extract\",operation=\"process\"}[$__rate_interval]))",
           "legendFormat": "image_extract {{result}}",
           "refId": "A"
         }
@@ -765,7 +765,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_service_gauge{component=\"image_extract\",name=\"queue_depth\"} / clamp_min(dat9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"}, 1)",
+          "expr": "drive9_service_gauge{component=\"image_extract\",name=\"queue_depth\"} / clamp_min(drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"}, 1)",
           "legendFormat": "image_extract queue_saturation",
           "refId": "A"
         }

--- a/docs/grafana/drive9-fs-operations-dashboard.json
+++ b/docs/grafana/drive9-fs-operations-dashboard.json
@@ -121,7 +121,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
           "legendFormat": "fs_rps",
           "refId": "A"
         }
@@ -188,7 +188,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
           "legendFormat": "http_p95",
           "refId": "A"
         }
@@ -255,7 +255,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval])))",
           "legendFormat": "svc_p95",
           "refId": "A"
         }
@@ -322,7 +322,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 1)",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 1)",
           "legendFormat": "fs_5xx_ratio",
           "refId": "A"
         }
@@ -389,7 +389,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_http_inflight_requests{route=~\"$http_route\"})",
+          "expr": "sum(drive9_http_inflight_requests{route=~\"$http_route\"})",
           "legendFormat": "fs_inflight",
           "refId": "A"
         }
@@ -436,7 +436,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (route, method) (rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "expr": "sum by (route, method) (rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
           "legendFormat": "{{method}} {{route}}",
           "refId": "A"
         }
@@ -483,7 +483,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route, method) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route, method) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
           "legendFormat": "{{method}} {{route}} p95",
           "refId": "A"
         },
@@ -492,7 +492,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route, method) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route, method) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
           "legendFormat": "{{method}} {{route}} p99",
           "refId": "B"
         }
@@ -539,7 +539,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_service_operations_total{operation=~\"$service_operation\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(drive9_service_operations_total{operation=~\"$service_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -586,7 +586,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -595,7 +595,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -642,7 +642,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (status) (rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "expr": "sum by (status) (rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         },
@@ -651,7 +651,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_http_inflight_requests{route=~\"$http_route\"})",
+          "expr": "sum(drive9_http_inflight_requests{route=~\"$http_route\"})",
           "legendFormat": "inflight",
           "refId": "B"
         }
@@ -698,7 +698,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"fs_read|fs_write|fs_patch|fs_append\"}[$__rate_interval]))",
+          "expr": "sum by (event, result) (rate(drive9_business_events_total{event=~\"fs_read|fs_write|fs_patch|fs_append\"}[$__rate_interval]))",
           "legendFormat": "{{event}} / {{result}}",
           "refId": "A"
         }
@@ -745,7 +745,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"fs_read|fs_write|fs_patch|fs_append\",result!~\"ok|accepted\"}[$__rate_interval]))",
+          "expr": "sum by (event, result) (rate(drive9_business_events_total{event=~\"fs_read|fs_write|fs_patch|fs_append\",result!~\"ok|accepted\"}[$__rate_interval]))",
           "legendFormat": "{{event}} / {{result}}",
           "refId": "A"
         }
@@ -792,7 +792,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_service_operations_total{component=\"webdav\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(drive9_service_operations_total{component=\"webdav\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -839,7 +839,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{component=\"webdav\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_service_operation_duration_seconds_bucket{component=\"webdav\"}[$__rate_interval])))",
           "legendFormat": "webdav p95",
           "refId": "A"
         },
@@ -848,7 +848,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{component=\"webdav\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_service_operation_duration_seconds_bucket{component=\"webdav\"}[$__rate_interval])))",
           "legendFormat": "webdav p99",
           "refId": "B"
         }
@@ -897,14 +897,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_http_requests_total{route=~\"/v1/fs.*\"}, route)",
+        "definition": "label_values(drive9_http_requests_total{route=~\"/v1/fs.*\"}, route)",
         "hide": 0,
         "includeAll": true,
         "label": "HTTP Route",
         "multi": true,
         "name": "http_route",
         "options": [],
-        "query": "label_values(dat9_http_requests_total{route=~\"/v1/fs.*\"}, route)",
+        "query": "label_values(drive9_http_requests_total{route=~\"/v1/fs.*\"}, route)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -921,14 +921,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_service_operations_total{operation=~\"fs_.*\"}, operation)",
+        "definition": "label_values(drive9_service_operations_total{operation=~\"fs_.*\"}, operation)",
         "hide": 0,
         "includeAll": true,
         "label": "Service Operation",
         "multi": true,
         "name": "service_operation",
         "options": [],
-        "query": "label_values(dat9_service_operations_total{operation=~\"fs_.*\"}, operation)",
+        "query": "label_values(drive9_service_operations_total{operation=~\"fs_.*\"}, operation)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/docs/grafana/drive9-http-performance-dashboard.json
+++ b/docs/grafana/drive9-http-performance-dashboard.json
@@ -121,7 +121,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$route\"}[$__rate_interval]))",
           "legendFormat": "http_rps",
           "refId": "A"
         }
@@ -188,7 +188,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval])))",
           "legendFormat": "http_p95",
           "refId": "A"
         }
@@ -255,7 +255,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval])))",
           "legendFormat": "http_p99",
           "refId": "A"
         }
@@ -322,7 +322,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_http_inflight_requests{route=~\"$route\"})",
+          "expr": "sum(drive9_http_inflight_requests{route=~\"$route\"})",
           "legendFormat": "inflight",
           "refId": "A"
         }
@@ -389,7 +389,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval])), 0.000001)",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_http_requests_total{route=~\"$route\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "http_5xx_ratio",
           "refId": "A"
         }
@@ -456,7 +456,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$route\",status=~\"4..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval])), 0.000001)",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$route\",status=~\"4..\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_http_requests_total{route=~\"$route\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "http_4xx_ratio",
           "refId": "A"
         }
@@ -503,7 +503,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, sum by (route) (rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval])))",
+          "expr": "topk(12, sum by (route) (rate(drive9_http_requests_total{route=~\"$route\"}[$__rate_interval])))",
           "legendFormat": "{{route}}",
           "refId": "A"
         }
@@ -550,7 +550,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval]))))",
           "legendFormat": "{{route}} p95",
           "refId": "A"
         },
@@ -559,7 +559,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$route\"}[$__rate_interval]))))",
           "legendFormat": "{{route}} p99",
           "refId": "B"
         }
@@ -606,7 +606,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (status) (rate(dat9_http_requests_total{route=~\"$route\"}[$__rate_interval]))",
+          "expr": "sum by (status) (rate(drive9_http_requests_total{route=~\"$route\"}[$__rate_interval]))",
           "legendFormat": "status={{status}}",
           "refId": "A"
         }
@@ -653,7 +653,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, sum by (route, status) (rate(dat9_http_requests_total{route=~\"$route\",status!~\"2..|3..\"}[$__rate_interval])))",
+          "expr": "topk(12, sum by (route, status) (rate(drive9_http_requests_total{route=~\"$route\",status!~\"2..|3..\"}[$__rate_interval])))",
           "legendFormat": "{{route}} / {{status}}",
           "refId": "A"
         },
@@ -662,7 +662,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_http_inflight_requests{route=~\"$route\"})",
+          "expr": "sum(drive9_http_inflight_requests{route=~\"$route\"})",
           "legendFormat": "inflight",
           "refId": "B"
         }
@@ -711,14 +711,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
+        "definition": "label_values(drive9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
         "hide": 0,
         "includeAll": true,
         "label": "API Route",
         "multi": true,
         "name": "route",
         "options": [],
-        "query": "label_values(dat9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
+        "query": "label_values(drive9_http_requests_total{route=~\"/v1/provision|/v1/status|/v1/sql|/v1/events|/v1/vault/.*|/s3/.*\"}, route)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/docs/grafana/drive9-meta-db-performance-dashboard.json
+++ b/docs/grafana/drive9-meta-db-performance-dashboard.json
@@ -110,7 +110,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "meta_p95",
           "refId": "A"
         }
@@ -177,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "meta_p99",
           "refId": "A"
         }
@@ -244,7 +244,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"meta\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_db_pool_wait_count_total{role=\"meta\"}[$__rate_interval]))",
           "legendFormat": "meta_waits",
           "refId": "A"
         }
@@ -311,7 +311,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"meta\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"meta\",state=\"max_open\"}), 1)",
+          "expr": "sum(drive9_db_pool_connections{role=\"meta\",state=\"in_use\"}) / clamp_min(sum(drive9_db_pool_connections{role=\"meta\",state=\"max_open\"}), 1)",
           "legendFormat": "meta_utilization",
           "refId": "A"
         }
@@ -378,7 +378,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"meta\",state=\"open\"})",
+          "expr": "sum(drive9_db_pool_connections{role=\"meta\",state=\"open\"})",
           "legendFormat": "meta_open",
           "refId": "A"
         }
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(drive9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -481,7 +481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -528,7 +528,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (state) (dat9_db_pool_connections{role=\"meta\"})",
+          "expr": "sum by (state) (drive9_db_pool_connections{role=\"meta\"})",
           "legendFormat": "{{state}}",
           "refId": "A"
         }
@@ -600,7 +600,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"meta\"}[$__rate_interval])",
+          "expr": "rate(drive9_db_pool_wait_duration_seconds_total{role=\"meta\"}[$__rate_interval])",
           "legendFormat": "wait_seconds_rate",
           "refId": "A"
         },
@@ -609,7 +609,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_count_total{role=\"meta\"}[$__rate_interval])",
+          "expr": "rate(drive9_db_pool_wait_count_total{role=\"meta\"}[$__rate_interval])",
           "legendFormat": "wait_count_rate",
           "refId": "B"
         }
@@ -656,7 +656,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"meta\"}[$__rate_interval]))",
+          "expr": "sum by (reason) (rate(drive9_db_pool_closes_total{role=\"meta\"}[$__rate_interval]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
@@ -703,7 +703,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (operation) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "topk(10, sum by (operation) (rate(drive9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "{{operation}} qps",
           "refId": "A"
         }
@@ -750,7 +750,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         }
@@ -799,20 +799,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"meta\"}, operation)",
+        "definition": "label_values(drive9_db_operations_total{role=\"meta\"}, operation)",
         "hide": 0,
         "includeAll": true,
         "label": "DB Operation",
         "multi": true,
         "name": "db_operation",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"meta\"}, operation)",
+        "query": "label_values(drive9_db_operations_total{role=\"meta\"}, operation)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
         "type": "query"
-      },
-
+      }
     ]
   },
   "time": {

--- a/docs/grafana/drive9-metadata-db-dashboard.json
+++ b/docs/grafana/drive9-metadata-db-dashboard.json
@@ -110,7 +110,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "meta_p95",
           "refId": "A"
         }
@@ -177,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "meta_p99",
           "refId": "A"
         }
@@ -244,7 +244,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"meta\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_db_pool_wait_count_total{role=\"meta\"}[$__rate_interval]))",
           "legendFormat": "meta_waits",
           "refId": "A"
         }
@@ -311,7 +311,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"meta\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"meta\",state=\"max_open\"}), 1)",
+          "expr": "sum(drive9_db_pool_connections{role=\"meta\",state=\"in_use\"}) / clamp_min(sum(drive9_db_pool_connections{role=\"meta\",state=\"max_open\"}), 1)",
           "legendFormat": "meta_utilization",
           "refId": "A"
         }
@@ -378,7 +378,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"meta\",state=\"open\"})",
+          "expr": "sum(drive9_db_pool_connections{role=\"meta\",state=\"open\"})",
           "legendFormat": "meta_open",
           "refId": "A"
         }
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(drive9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -481,7 +481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -528,7 +528,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (state) (dat9_db_pool_connections{role=\"meta\"})",
+          "expr": "sum by (state) (drive9_db_pool_connections{role=\"meta\"})",
           "legendFormat": "{{state}}",
           "refId": "A"
         }
@@ -600,7 +600,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"meta\"}[$__rate_interval])",
+          "expr": "rate(drive9_db_pool_wait_duration_seconds_total{role=\"meta\"}[$__rate_interval])",
           "legendFormat": "wait_seconds_rate",
           "refId": "A"
         },
@@ -609,7 +609,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_count_total{role=\"meta\"}[$__rate_interval])",
+          "expr": "rate(drive9_db_pool_wait_count_total{role=\"meta\"}[$__rate_interval])",
           "legendFormat": "wait_count_rate",
           "refId": "B"
         }
@@ -656,7 +656,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"meta\"}[$__rate_interval]))",
+          "expr": "sum by (reason) (rate(drive9_db_pool_closes_total{role=\"meta\"}[$__rate_interval]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
@@ -703,7 +703,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (operation) (rate(dat9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "topk(10, sum by (operation) (rate(drive9_db_operations_total{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "{{operation}} qps",
           "refId": "A"
         }
@@ -750,7 +750,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"meta\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         }
@@ -799,20 +799,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"meta\"}, operation)",
+        "definition": "label_values(drive9_db_operations_total{role=\"meta\"}, operation)",
         "hide": 0,
         "includeAll": true,
         "label": "DB Operation",
         "multi": true,
         "name": "db_operation",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"meta\"}, operation)",
+        "query": "label_values(drive9_db_operations_total{role=\"meta\"}, operation)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
         "type": "query"
-      },
-
+      }
     ]
   },
   "time": {

--- a/docs/grafana/drive9-service-health-dashboard.json
+++ b/docs/grafana/drive9-service-health-dashboard.json
@@ -28,6 +28,17 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
+      "title": "Tenant Usage",
+      "type": "link",
+      "url": "/d/drive9-tenant-usage"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
       "title": "API Surface Drill-Down",
       "type": "link",
       "url": "/d/drive9-api-surface"
@@ -165,7 +176,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=~\"$db_role\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_db_pool_wait_count_total{role=~\"$db_role\"}[$__rate_interval]))",
           "legendFormat": "db_waits_per_second",
           "refId": "A"
         }
@@ -232,7 +243,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(1 - dat9_module_up{module=~\"$module\"})",
+          "expr": "sum(1 - drive9_module_up{module=~\"$module\"})",
           "legendFormat": "down_modules",
           "refId": "A"
         }
@@ -299,7 +310,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route!~\"/healthz|/metrics|other\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_http_requests_total{route!~\"/healthz|/metrics|other\"}[$__rate_interval]))",
           "legendFormat": "http_rps",
           "refId": "A"
         }
@@ -366,7 +377,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route!~\"/healthz|/metrics|other\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route!~\"/healthz|/metrics|other\"}[$__rate_interval])), 0.000001)",
+          "expr": "sum(rate(drive9_http_requests_total{route!~\"/healthz|/metrics|other\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_http_requests_total{route!~\"/healthz|/metrics|other\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "http_5xx_ratio",
           "refId": "A"
         }
@@ -433,7 +444,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route!~\"/healthz|/metrics|other\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route!~\"/healthz|/metrics|other\"}[$__rate_interval])))",
           "legendFormat": "http_p99",
           "refId": "A"
         }
@@ -500,7 +511,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_http_inflight_requests",
+          "expr": "drive9_http_inflight_requests",
           "legendFormat": "http_inflight",
           "refId": "A"
         }
@@ -547,7 +558,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_module_up{module=~\"$module\"}",
+          "expr": "drive9_module_up{module=~\"$module\"}",
           "legendFormat": "{{module}} up",
           "refId": "A"
         }
@@ -594,7 +605,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(8, histogram_quantile(0.95, sum by (le, route) (rate(dat9_http_request_duration_seconds_bucket{route!~\"/healthz|/metrics|other\"}[$__rate_interval]))))",
+          "expr": "topk(8, histogram_quantile(0.95, sum by (le, route) (rate(drive9_http_request_duration_seconds_bucket{route!~\"/healthz|/metrics|other\"}[$__rate_interval]))))",
           "legendFormat": "{{route}} p95",
           "refId": "A"
         }
@@ -641,7 +652,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, sum by (route, status) (rate(dat9_http_requests_total{route!~\"/healthz|/metrics|other\",status!~\"2..|3..\"}[$__rate_interval])))",
+          "expr": "topk(12, sum by (route, status) (rate(drive9_http_requests_total{route!~\"/healthz|/metrics|other\",status!~\"2..|3..\"}[$__rate_interval])))",
           "legendFormat": "{{route}} {{status}}",
           "refId": "A"
         }
@@ -688,7 +699,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (component) (rate(dat9_service_operations_total{component=~\"$component\",result=~\"error|deadline_exceeded|canceled|bad_conn\"}[$__rate_interval])) / clamp_min(sum by (component) (rate(dat9_service_operations_total{component=~\"$component\"}[$__rate_interval])), 0.000001)",
+          "expr": "sum by (component) (rate(drive9_service_operations_total{component=~\"$component\",result=~\"error|deadline_exceeded|canceled|bad_conn\"}[$__rate_interval])) / clamp_min(sum by (component) (rate(drive9_service_operations_total{component=~\"$component\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "{{component}} error_ratio",
           "refId": "A"
         }
@@ -735,7 +746,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (role, state) (dat9_db_pool_connections{role=~\"$db_role\"})",
+          "expr": "sum by (role, state) (drive9_db_pool_connections{role=~\"$db_role\"})",
           "legendFormat": "{{role}} {{state}}",
           "refId": "A"
         }
@@ -782,7 +793,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, role) (rate(dat9_db_operation_duration_seconds_bucket{role=~\"$db_role\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, role) (rate(drive9_db_operation_duration_seconds_bucket{role=~\"$db_role\"}[$__rate_interval])))",
           "legendFormat": "{{role}} db_p95",
           "refId": "A"
         }
@@ -829,7 +840,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "dat9_module_uptime_seconds{module=~\"$module\"}",
+          "expr": "drive9_module_uptime_seconds{module=~\"$module\"}",
           "legendFormat": "{{module}} uptime",
           "refId": "A"
         }
@@ -877,14 +888,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_module_up, module)",
+        "definition": "label_values(drive9_module_up, module)",
         "hide": 0,
         "includeAll": true,
         "label": "Module",
         "multi": true,
         "name": "module",
         "options": [],
-        "query": "label_values(dat9_module_up, module)",
+        "query": "label_values(drive9_module_up, module)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -901,14 +912,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_service_operations_total, component)",
+        "definition": "label_values(drive9_service_operations_total, component)",
         "hide": 0,
         "includeAll": true,
         "label": "Component",
         "multi": true,
         "name": "component",
         "options": [],
-        "query": "label_values(dat9_service_operations_total, component)",
+        "query": "label_values(drive9_service_operations_total, component)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -925,14 +936,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_pool_registered, role)",
+        "definition": "label_values(drive9_db_pool_registered, role)",
         "hide": 0,
         "includeAll": true,
         "label": "DB Role",
         "multi": true,
         "name": "db_role",
         "options": [],
-        "query": "label_values(dat9_db_pool_registered, role)",
+        "query": "label_values(drive9_db_pool_registered, role)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/docs/grafana/drive9-tenant-data-db-dashboard.json
+++ b/docs/grafana/drive9-tenant-data-db-dashboard.json
@@ -110,7 +110,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "user_p95",
           "refId": "A"
         }
@@ -177,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "user_p99",
           "refId": "A"
         }
@@ -244,7 +244,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval]))",
           "legendFormat": "user_waits",
           "refId": "A"
         }
@@ -311,7 +311,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"user\",state=\"max_open\"}), 1)",
+          "expr": "sum(drive9_db_pool_connections{role=\"user\",state=\"in_use\"}) / clamp_min(sum(drive9_db_pool_connections{role=\"user\",state=\"max_open\"}), 1)",
           "legendFormat": "user_utilization",
           "refId": "A"
         }
@@ -378,7 +378,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"open\"})",
+          "expr": "sum(drive9_db_pool_connections{role=\"user\",state=\"open\"})",
           "legendFormat": "user_open",
           "refId": "A"
         }
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(drive9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -481,7 +481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -528,7 +528,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (state) (dat9_db_pool_connections{role=\"user\"})",
+          "expr": "sum by (state) (drive9_db_pool_connections{role=\"user\"})",
           "legendFormat": "{{state}}",
           "refId": "A"
         }
@@ -600,7 +600,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"user\"}[$__rate_interval])",
+          "expr": "rate(drive9_db_pool_wait_duration_seconds_total{role=\"user\"}[$__rate_interval])",
           "legendFormat": "wait_seconds_rate",
           "refId": "A"
         },
@@ -609,7 +609,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval])",
+          "expr": "rate(drive9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval])",
           "legendFormat": "wait_count_rate",
           "refId": "B"
         }
@@ -656,7 +656,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"user\"}[$__rate_interval]))",
+          "expr": "sum by (reason) (rate(drive9_db_pool_closes_total{role=\"user\"}[$__rate_interval]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
@@ -703,7 +703,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (operation) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "topk(10, sum by (operation) (rate(drive9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "{{operation}} qps",
           "refId": "A"
         }
@@ -750,7 +750,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         }
@@ -799,20 +799,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "definition": "label_values(drive9_db_operations_total{role=\"user\"}, operation)",
         "hide": 0,
         "includeAll": true,
         "label": "DB Operation",
         "multi": true,
         "name": "db_operation",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "query": "label_values(drive9_db_operations_total{role=\"user\"}, operation)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
         "type": "query"
-      },
-
+      }
     ]
   },
   "time": {

--- a/docs/grafana/drive9-tenant-usage-dashboard.json
+++ b/docs/grafana/drive9-tenant-usage-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Request-path drill-down dashboard for the Drive9 filesystem path, correlating /v1/fs HTTP requests with backend fs_* work.",
+  "description": "Tenant usage dashboard: request frequency, logical file IO, transport bytes, latency, and errors by tenant/surface/action.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -28,7 +28,7 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "Service Health Overview",
+      "title": "Service Health",
       "type": "link",
       "url": "/d/drive9-service-health"
     },
@@ -39,29 +39,23 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "Async And FUSE Overview",
+      "title": "Filesystem Drill-Down",
       "type": "link",
-      "url": "/d/drive9-async-fuse"
+      "url": "/d/drive9-filesystem-path"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Upload Drill-Down",
+      "type": "link",
+      "url": "/d/drive9-upload-path"
     }
   ],
-  "liveNow": false,
   "panels": [
-    {
-      "gridPos": {
-        "h": 4,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 100,
-      "options": {
-        "content": "# Filesystem Path Performance\n\nCategory: request-path drill-down.\n\nUse this when the incident is clearly on the filesystem path. This dashboard owns the `/v1/fs/*` path and should be preferred over the generic API surface dashboard for filesystem symptoms. It combines HTTP `/v1/fs/*` traffic with backend `fs_*` service operations so you can separate front-door symptoms from internal work.",
-        "mode": "markdown"
-      },
-      "title": "Guide",
-      "transparent": true,
-      "type": "text"
-    },
     {
       "datasource": {
         "type": "prometheus",
@@ -69,36 +63,15 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 20
-              },
-              {
-                "color": "red",
-                "value": 100
-              }
-            ]
-          },
-          "unit": "reqps"
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
+        "w": 6,
         "x": 0,
-        "y": 4
+        "y": 0
       },
       "id": 1,
       "options": {
@@ -121,12 +94,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
-          "legendFormat": "fs_rps",
+          "expr": "count(count by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]) > 0))",
+          "legendFormat": "active tenants",
           "refId": "A"
         }
       ],
-      "title": "FS HTTP RPS",
+      "title": "Active Tenants",
       "type": "stat"
     },
     {
@@ -136,36 +109,15 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0.2
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "s"
+          "unit": "reqps"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 4,
-        "y": 4
+        "w": 6,
+        "x": 6,
+        "y": 0
       },
       "id": 2,
       "options": {
@@ -188,12 +140,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
-          "legendFormat": "http_p95",
+          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "requests/s",
           "refId": "A"
         }
       ],
-      "title": "FS HTTP P95",
+      "title": "Tenant Requests/s",
       "type": "stat"
     },
     {
@@ -203,36 +155,15 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0.1
-              },
-              {
-                "color": "red",
-                "value": 0.5
-              }
-            ]
-          },
-          "unit": "s"
+          "unit": "Bps"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 8,
-        "y": 4
+        "w": 6,
+        "x": 12,
+        "y": 0
       },
       "id": 3,
       "options": {
@@ -255,12 +186,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval])))",
-          "legendFormat": "svc_p95",
+          "expr": "sum(rate(drive9_tenant_file_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "file bytes/s",
           "refId": "A"
         }
       ],
-      "title": "FS Service P95",
+      "title": "Logical File IO",
       "type": "stat"
     },
     {
@@ -270,36 +201,15 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0.01
-              },
-              {
-                "color": "red",
-                "value": 0.05
-              }
-            ]
-          },
           "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 12,
-        "y": 4
+        "w": 6,
+        "x": 18,
+        "y": 0
       },
       "id": 4,
       "options": {
@@ -322,12 +232,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(drive9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 0.000001)",
-          "legendFormat": "fs_5xx_ratio",
+          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\",result!=\"ok\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "non-ok ratio",
           "refId": "A"
         }
       ],
-      "title": "FS 5xx Ratio",
+      "title": "Non-OK Ratio",
       "type": "stat"
     },
     {
@@ -337,93 +247,310 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 20
-              },
-              {
-                "color": "red",
-                "value": 100
-              }
-            ]
+          "expr": "topk(15, sum by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
+          "legendFormat": "{{tenant_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Tenants by Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
+          "expr": "topk(15, sum by (tenant_id, direction) (rate(drive9_tenant_file_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
+          "legendFormat": "{{tenant_id}} {{direction}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Tenants by Logical File IO",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (surface, action) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "{{surface}}/{{action}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Usage by Surface and Action",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, surface, action) (rate(drive9_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
+          "legendFormat": "{{surface}}/{{action}} p95",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, surface, action) (rate(drive9_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
+          "legendFormat": "{{surface}}/{{action}} p99",
+          "refId": "B"
+        }
+      ],
+      "title": "Tenant Request Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(15, sum by (tenant_id, result) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\",result!=\"ok\"}[$__rate_interval])))",
+          "legendFormat": "{{tenant_id}} {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Tenant Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (surface, action, direction) (rate(drive9_tenant_http_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "{{surface}}/{{action}} {{direction}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Transport Bytes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
           "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 4
-      },
-      "id": 5,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum(drive9_http_inflight_requests{route=~\"$http_route\"})",
-          "legendFormat": "fs_inflight",
-          "refId": "A"
-        }
-      ],
-      "title": "FS HTTP Inflight",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 7,
+        "w": 8,
         "x": 0,
-        "y": 8
+        "y": 28
       },
       "id": 11,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -436,12 +563,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (route, method) (rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
-          "legendFormat": "{{method}} {{route}}",
+          "expr": "sum by (tenant_id, surface, action) (drive9_tenant_inflight_requests{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"})",
+          "legendFormat": "{{tenant_id}} {{surface}}/{{action}}",
           "refId": "A"
         }
       ],
-      "title": "FS Route Throughput",
+      "title": "Tenant In-Flight Requests",
       "type": "timeseries"
     },
     {
@@ -451,26 +578,25 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "s"
+          "unit": "bytes"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 28
       },
       "id": 12,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -483,21 +609,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route, method) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
-          "legendFormat": "{{method}} {{route}} p95",
+          "expr": "topk(15, drive9_tenant_storage_bytes{tenant_id=~\"$tenant\",state=~\"confirmed|reserved\"})",
+          "legendFormat": "{{tenant_id}} {{state}}",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route, method) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
-          "legendFormat": "{{method}} {{route}} p99",
-          "refId": "B"
         }
       ],
-      "title": "FS Route Tail Latency",
+      "title": "Tenant Storage Bytes",
       "type": "timeseries"
     },
     {
@@ -507,26 +624,25 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "ops"
+          "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 28
       },
       "id": 13,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -539,55 +655,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(drive9_service_operations_total{operation=~\"$service_operation\"}[$__rate_interval]))",
-          "legendFormat": "{{operation}} / {{result}}",
-          "refId": "A"
-        }
-      ],
-      "title": "FS Service Throughput",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p95",
+          "expr": "topk(15, ((sum by (tenant_id) (drive9_tenant_storage_bytes{tenant_id=~\"$tenant\",state=~\"confirmed|reserved\"}) / sum by (tenant_id) (drive9_tenant_storage_bytes{tenant_id=~\"$tenant\",state=\"limit\"})) and on (tenant_id) (sum by (tenant_id) (drive9_tenant_storage_bytes{tenant_id=~\"$tenant\",state=\"limit\"}) > 0)))",
+          "legendFormat": "{{tenant_id}} storage",
           "refId": "A"
         },
         {
@@ -595,174 +664,21 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
-          "legendFormat": "{{operation}} p99",
+          "expr": "topk(15, ((drive9_tenant_media_files{tenant_id=~\"$tenant\",state=\"confirmed\"} / on (tenant_id) drive9_tenant_media_files{tenant_id=~\"$tenant\",state=\"limit\"}) and on (tenant_id) (drive9_tenant_media_files{tenant_id=~\"$tenant\",state=\"limit\"} > 0)))",
+          "legendFormat": "{{tenant_id}} media files",
           "refId": "B"
         }
       ],
-      "title": "FS Service Tail Latency",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum by (status) (rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
-          "legendFormat": "{{status}}",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum(drive9_http_inflight_requests{route=~\"$http_route\"})",
-          "legendFormat": "inflight",
-          "refId": "B"
-        }
-      ],
-      "title": "FS HTTP Status Mix And Inflight",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 32
-      },
-      "id": 16,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum by (event, result) (rate(drive9_business_events_total{event=~\"fs_read|fs_write|fs_patch|fs_append\"}[$__rate_interval]))",
-          "legendFormat": "{{event}} / {{result}}",
-          "refId": "A"
-        }
-      ],
-      "title": "FS Outcome Events",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 32
-      },
-      "id": 17,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum by (event, result) (rate(drive9_business_events_total{event=~\"fs_read|fs_write|fs_patch|fs_append\",result!~\"ok|accepted\"}[$__rate_interval]))",
-          "legendFormat": "{{event}} / {{result}}",
-          "refId": "A"
-        }
-      ],
-      "title": "FS Conflict And Error Events",
+      "title": "Tenant Quota Usage Ratio",
       "type": "timeseries"
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 41,
+  "schemaVersion": 39,
   "tags": [
     "drive9",
-    "filesystem",
-    "request-path",
-    "performance",
-    "grafana",
-    "prometheus"
+    "tenant",
+    "usage"
   ],
   "templating": {
     "list": [
@@ -770,21 +686,22 @@
         "current": {
           "selected": false,
           "text": "Prometheus",
-          "value": "Prometheus"
+          "value": "prometheus"
         },
         "hide": 0,
         "includeAll": false,
-        "label": "Datasource",
+        "label": "Data source",
         "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
-        "allValue": "/v1/fs/.*",
+        "allValue": ".*",
         "current": {
           "selected": true,
           "text": "All",
@@ -794,21 +711,22 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(drive9_http_requests_total{route=~\"/v1/fs.*\"}, route)",
+        "definition": "label_values(drive9_tenant_requests_total, tenant_id)",
         "hide": 0,
         "includeAll": true,
-        "label": "HTTP Route",
+        "label": "Tenant",
         "multi": true,
-        "name": "http_route",
+        "name": "tenant",
         "options": [],
-        "query": "label_values(drive9_http_requests_total{route=~\"/v1/fs.*\"}, route)",
-        "refresh": 2,
+        "query": "label_values(drive9_tenant_requests_total, tenant_id)",
+        "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       },
       {
-        "allValue": "fs_.*",
+        "allValue": ".*",
         "current": {
           "selected": true,
           "text": "All",
@@ -818,16 +736,42 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(drive9_service_operations_total{operation=~\"fs_.*\"}, operation)",
+        "definition": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\"}, surface)",
         "hide": 0,
         "includeAll": true,
-        "label": "Service Operation",
+        "label": "Surface",
         "multi": true,
-        "name": "service_operation",
+        "name": "surface",
         "options": [],
-        "query": "label_values(drive9_service_operations_total{operation=~\"fs_.*\"}, operation)",
-        "refresh": 2,
+        "query": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\"}, surface)",
+        "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Action",
+        "multi": true,
+        "name": "action",
+        "options": [],
+        "query": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       }
@@ -839,8 +783,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Drive9 Filesystem Path Performance",
-  "uid": "drive9-filesystem-path",
+  "title": "Drive9 Tenant Usage",
+  "uid": "drive9-tenant-usage",
   "version": 1,
   "weekStart": ""
 }

--- a/docs/grafana/drive9-tenant-usage-dashboard.json
+++ b/docs/grafana/drive9-tenant-usage-dashboard.json
@@ -416,8 +416,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, surface, action) (rate(drive9_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
-          "legendFormat": "{{surface}}/{{action}} p95",
+          "expr": "histogram_quantile(0.95, sum by (le, tenant_id, surface, action) (rate(drive9_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
+          "legendFormat": "{{tenant_id}} {{surface}}/{{action}} p95",
           "refId": "A"
         },
         {
@@ -425,8 +425,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le, surface, action) (rate(drive9_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
-          "legendFormat": "{{surface}}/{{action}} p99",
+          "expr": "histogram_quantile(0.99, sum by (le, tenant_id, surface, action) (rate(drive9_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
+          "legendFormat": "{{tenant_id}} {{surface}}/{{action}} p99",
           "refId": "B"
         }
       ],

--- a/docs/grafana/drive9-upload-path-dashboard.json
+++ b/docs/grafana/drive9-upload-path-dashboard.json
@@ -121,7 +121,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
           "legendFormat": "upload_rps",
           "refId": "A"
         }
@@ -188,7 +188,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
           "legendFormat": "upload_http_p95",
           "refId": "A"
         }
@@ -255,7 +255,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
           "legendFormat": "upload_http_p99",
           "refId": "A"
         }
@@ -322,7 +322,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval])))",
           "legendFormat": "upload_service_p95",
           "refId": "A"
         }
@@ -389,7 +389,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 1)",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 1)",
           "legendFormat": "upload_5xx_ratio",
           "refId": "A"
         }
@@ -456,7 +456,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_http_inflight_requests{route=~\"$http_route\"})",
+          "expr": "sum(drive9_http_inflight_requests{route=~\"$http_route\"})",
           "legendFormat": "upload_inflight",
           "refId": "A"
         }
@@ -503,7 +503,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (route, method) (rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "expr": "sum by (route, method) (rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
           "legendFormat": "{{method}} {{route}}",
           "refId": "A"
         }
@@ -550,7 +550,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route, method) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route, method) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
           "legendFormat": "{{method}} {{route}} p95",
           "refId": "A"
         },
@@ -559,7 +559,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route, method) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route, method) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
           "legendFormat": "{{method}} {{route}} p99",
           "refId": "B"
         }
@@ -606,7 +606,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (status) (rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "expr": "sum by (status) (rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
@@ -653,7 +653,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_service_operations_total{operation=~\"$service_operation\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(drive9_service_operations_total{operation=~\"$service_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -700,7 +700,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -709,7 +709,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -756,7 +756,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"$event\"}[$__rate_interval]))",
+          "expr": "sum by (event, result) (rate(drive9_business_events_total{event=~\"$event\"}[$__rate_interval]))",
           "legendFormat": "{{event}} / {{result}}",
           "refId": "A"
         }
@@ -805,14 +805,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_http_requests_total{route=~\"/v1/uploads.*|/v2/uploads.*\"}, route)",
+        "definition": "label_values(drive9_http_requests_total{route=~\"/v1/uploads.*|/v2/uploads.*\"}, route)",
         "hide": 0,
         "includeAll": true,
         "label": "HTTP Route",
         "multi": true,
         "name": "http_route",
         "options": [],
-        "query": "label_values(dat9_http_requests_total{route=~\"/v1/uploads.*|/v2/uploads.*\"}, route)",
+        "query": "label_values(drive9_http_requests_total{route=~\"/v1/uploads.*|/v2/uploads.*\"}, route)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -829,14 +829,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_service_operations_total{operation=~\"upload_.*|v2_upload_.*|v2_presign_.*|complete_upload|resume_upload|abort_upload\"}, operation)",
+        "definition": "label_values(drive9_service_operations_total{operation=~\"upload_.*|v2_upload_.*|v2_presign_.*|complete_upload|resume_upload|abort_upload\"}, operation)",
         "hide": 0,
         "includeAll": true,
         "label": "Service Operation",
         "multi": true,
         "name": "service_operation",
         "options": [],
-        "query": "label_values(dat9_service_operations_total{operation=~\"upload_.*|v2_upload_.*|v2_presign_.*|complete_upload|resume_upload|abort_upload\"}, operation)",
+        "query": "label_values(drive9_service_operations_total{operation=~\"upload_.*|v2_upload_.*|v2_presign_.*|complete_upload|resume_upload|abort_upload\"}, operation)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -853,14 +853,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_tenant_events_total{event=~\"upload_.*|v2_upload_.*|v2_presign_.*\"}, event)",
+        "definition": "label_values(drive9_business_events_total{event=~\"upload_.*|v2_upload_.*|v2_presign_.*\"}, event)",
         "hide": 0,
         "includeAll": true,
         "label": "Tenant Event",
         "multi": true,
         "name": "event",
         "options": [],
-        "query": "label_values(dat9_tenant_events_total{event=~\"upload_.*|v2_upload_.*|v2_presign_.*\"}, event)",
+        "query": "label_values(drive9_business_events_total{event=~\"upload_.*|v2_upload_.*|v2_presign_.*\"}, event)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/docs/grafana/drive9-upload-s3-path-dashboard.json
+++ b/docs/grafana/drive9-upload-s3-path-dashboard.json
@@ -121,7 +121,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
           "legendFormat": "upload_rps",
           "refId": "A"
         }
@@ -188,7 +188,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
           "legendFormat": "upload_http_p95",
           "refId": "A"
         }
@@ -255,7 +255,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval])))",
           "legendFormat": "upload_http_p99",
           "refId": "A"
         }
@@ -322,7 +322,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval])))",
           "legendFormat": "upload_service_p95",
           "refId": "A"
         }
@@ -389,7 +389,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 1)",
+          "expr": "sum(rate(drive9_http_requests_total{route=~\"$http_route\",status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval])), 1)",
           "legendFormat": "upload_5xx_ratio",
           "refId": "A"
         }
@@ -456,7 +456,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_http_inflight_requests{route=~\"$http_route\"})",
+          "expr": "sum(drive9_http_inflight_requests{route=~\"$http_route\"})",
           "legendFormat": "upload_inflight",
           "refId": "A"
         }
@@ -503,7 +503,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (route, method) (rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "expr": "sum by (route, method) (rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
           "legendFormat": "{{method}} {{route}}",
           "refId": "A"
         }
@@ -550,7 +550,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route, method) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, route, method) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
           "legendFormat": "{{method}} {{route}} p95",
           "refId": "A"
         },
@@ -559,7 +559,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route, method) (rate(dat9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, route, method) (rate(drive9_http_request_duration_seconds_bucket{route=~\"$http_route\"}[$__rate_interval]))))",
           "legendFormat": "{{method}} {{route}} p99",
           "refId": "B"
         }
@@ -606,7 +606,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (status) (rate(dat9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
+          "expr": "sum by (status) (rate(drive9_http_requests_total{route=~\"$http_route\"}[$__rate_interval]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
@@ -653,7 +653,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_service_operations_total{operation=~\"$service_operation\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(drive9_service_operations_total{operation=~\"$service_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -700,7 +700,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -709,7 +709,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(drive9_service_operation_duration_seconds_bucket{operation=~\"$service_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -756,7 +756,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (event, result) (rate(dat9_tenant_events_total{event=~\"$event\"}[$__rate_interval]))",
+          "expr": "sum by (event, result) (rate(drive9_business_events_total{event=~\"$event\"}[$__rate_interval]))",
           "legendFormat": "{{event}} / {{result}}",
           "refId": "A"
         }
@@ -803,7 +803,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_service_operations_total{component=\"s3client\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(drive9_service_operations_total{component=\"s3client\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -850,7 +850,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{component=\"s3client\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_service_operation_duration_seconds_bucket{component=\"s3client\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -859,7 +859,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_service_operation_duration_seconds_bucket{component=\"s3client\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(drive9_service_operation_duration_seconds_bucket{component=\"s3client\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -908,14 +908,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_http_requests_total{route=~\"/v1/uploads.*|/v2/uploads.*\"}, route)",
+        "definition": "label_values(drive9_http_requests_total{route=~\"/v1/uploads.*|/v2/uploads.*\"}, route)",
         "hide": 0,
         "includeAll": true,
         "label": "HTTP Route",
         "multi": true,
         "name": "http_route",
         "options": [],
-        "query": "label_values(dat9_http_requests_total{route=~\"/v1/uploads.*|/v2/uploads.*\"}, route)",
+        "query": "label_values(drive9_http_requests_total{route=~\"/v1/uploads.*|/v2/uploads.*\"}, route)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -932,14 +932,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_service_operations_total{operation=~\"upload_.*|v2_upload_.*|v2_presign_.*|complete_upload|resume_upload|abort_upload\"}, operation)",
+        "definition": "label_values(drive9_service_operations_total{operation=~\"upload_.*|v2_upload_.*|v2_presign_.*|complete_upload|resume_upload|abort_upload\"}, operation)",
         "hide": 0,
         "includeAll": true,
         "label": "Service Operation",
         "multi": true,
         "name": "service_operation",
         "options": [],
-        "query": "label_values(dat9_service_operations_total{operation=~\"upload_.*|v2_upload_.*|v2_presign_.*|complete_upload|resume_upload|abort_upload\"}, operation)",
+        "query": "label_values(drive9_service_operations_total{operation=~\"upload_.*|v2_upload_.*|v2_presign_.*|complete_upload|resume_upload|abort_upload\"}, operation)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -956,14 +956,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_tenant_events_total{event=~\"upload_.*|v2_upload_.*|v2_presign_.*\"}, event)",
+        "definition": "label_values(drive9_business_events_total{event=~\"upload_.*|v2_upload_.*|v2_presign_.*\"}, event)",
         "hide": 0,
         "includeAll": true,
         "label": "Tenant Event",
         "multi": true,
         "name": "event",
         "options": [],
-        "query": "label_values(dat9_tenant_events_total{event=~\"upload_.*|v2_upload_.*|v2_presign_.*\"}, event)",
+        "query": "label_values(drive9_business_events_total{event=~\"upload_.*|v2_upload_.*|v2_presign_.*\"}, event)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/docs/grafana/drive9-user-db-performance-dashboard.json
+++ b/docs/grafana/drive9-user-db-performance-dashboard.json
@@ -110,7 +110,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(drive9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "user_p95",
           "refId": "A"
         }
@@ -177,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(drive9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "user_p99",
           "refId": "A"
         }
@@ -244,7 +244,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval]))",
           "legendFormat": "user_waits",
           "refId": "A"
         }
@@ -311,7 +311,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"in_use\"}) / clamp_min(sum(dat9_db_pool_connections{role=\"user\",state=\"max_open\"}), 1)",
+          "expr": "sum(drive9_db_pool_connections{role=\"user\",state=\"in_use\"}) / clamp_min(sum(drive9_db_pool_connections{role=\"user\",state=\"max_open\"}), 1)",
           "legendFormat": "user_utilization",
           "refId": "A"
         }
@@ -378,7 +378,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(dat9_db_pool_connections{role=\"user\",state=\"open\"})",
+          "expr": "sum(drive9_db_pool_connections{role=\"user\",state=\"open\"})",
           "legendFormat": "user_open",
           "refId": "A"
         }
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation, result) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))",
+          "expr": "sum by (operation, result) (rate(drive9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} / {{result}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         },
@@ -481,7 +481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(12, histogram_quantile(0.99, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p99",
           "refId": "B"
         }
@@ -528,7 +528,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (state) (dat9_db_pool_connections{role=\"user\"})",
+          "expr": "sum by (state) (drive9_db_pool_connections{role=\"user\"})",
           "legendFormat": "{{state}}",
           "refId": "A"
         }
@@ -600,7 +600,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_duration_seconds_total{role=\"user\"}[$__rate_interval])",
+          "expr": "rate(drive9_db_pool_wait_duration_seconds_total{role=\"user\"}[$__rate_interval])",
           "legendFormat": "wait_seconds_rate",
           "refId": "A"
         },
@@ -609,7 +609,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(dat9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval])",
+          "expr": "rate(drive9_db_pool_wait_count_total{role=\"user\"}[$__rate_interval])",
           "legendFormat": "wait_count_rate",
           "refId": "B"
         }
@@ -656,7 +656,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (reason) (rate(dat9_db_pool_closes_total{role=\"user\"}[$__rate_interval]))",
+          "expr": "sum by (reason) (rate(drive9_db_pool_closes_total{role=\"user\"}[$__rate_interval]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
@@ -703,7 +703,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (operation) (rate(dat9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
+          "expr": "topk(10, sum by (operation) (rate(drive9_db_operations_total{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval])))",
           "legendFormat": "{{operation}} qps",
           "refId": "A"
         }
@@ -750,7 +750,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(dat9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, operation) (rate(drive9_db_operation_duration_seconds_bucket{role=\"user\",operation=~\"$db_operation\"}[$__rate_interval]))))",
           "legendFormat": "{{operation}} p95",
           "refId": "A"
         }
@@ -799,20 +799,19 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "definition": "label_values(drive9_db_operations_total{role=\"user\"}, operation)",
         "hide": 0,
         "includeAll": true,
         "label": "DB Operation",
         "multi": true,
         "name": "db_operation",
         "options": [],
-        "query": "label_values(dat9_db_operations_total{role=\"user\"}, operation)",
+        "query": "label_values(drive9_db_operations_total{role=\"user\"}, operation)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
         "type": "query"
-      },
-
+      }
     ]
   },
   "time": {

--- a/pkg/backend/audio_extract_test.go
+++ b/pkg/backend/audio_extract_test.go
@@ -96,16 +96,16 @@ func TestAsyncAudioExtractMetricsExposed(t *testing.T) {
 	}
 
 	metricsText := readBackendMetrics()
-	if !strings.Contains(metricsText, "dat9_module_up{module=\"audio_extract\"} 1") {
+	if !strings.Contains(metricsText, "drive9_module_up{module=\"audio_extract\"} 1") {
 		t.Fatalf("metrics missing audio_extract module availability: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 4096") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 4096") {
 		t.Fatalf("metrics missing audio_extract runtime gauge: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_operations_total{component=\"audio_extract\",operation=\"process\",result=\"ok\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"audio_extract\",operation=\"process\",result=\"ok\"}") {
 		t.Fatalf("metrics missing audio_extract process counter: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_operation_duration_seconds_count{component=\"audio_extract\",operation=\"process\",result=\"ok\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"audio_extract\",operation=\"process\",result=\"ok\"}") {
 		t.Fatalf("metrics missing audio_extract duration histogram: %s", metricsText)
 	}
 }

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -199,8 +199,12 @@ func recordTenantQuotaSnapshot(tenantID string, usage *QuotaUsageView, cfg *Quot
 	if cfg == nil {
 		return
 	}
-	metrics.RecordTenantStorageBytes(tenantID, "limit", cfg.MaxStorageBytes)
-	metrics.RecordTenantMediaFiles(tenantID, "limit", cfg.MaxMediaLLMFiles)
+	if cfg.MaxStorageBytes > 0 {
+		metrics.RecordTenantStorageBytes(tenantID, "limit", cfg.MaxStorageBytes)
+	}
+	if cfg.MaxMediaLLMFiles > 0 {
+		metrics.RecordTenantMediaFiles(tenantID, "limit", cfg.MaxMediaLLMFiles)
+	}
 }
 
 // mediaLLMQuotaExceededServerTx checks the server DB counter for media file

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -146,6 +146,7 @@ func (b *Dat9Backend) ensureStorageQuotaServer(ctx context.Context, deltaBytes i
 		metrics.RecordOperation("server_quota", "storage_check", "fail_open", 0)
 		return nil // fail-open
 	}
+	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
 	if cfg.MaxStorageBytes <= 0 {
 		return nil // quota not configured
 	}
@@ -181,10 +182,25 @@ func (b *Dat9Backend) mediaLLMQuotaExceededServer(ctx context.Context) bool {
 		metrics.RecordOperation("server_quota", "media_check", "fail_open", 0)
 		return false // fail-open
 	}
+	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
 	if cfg.MaxMediaLLMFiles <= 0 {
 		return false
 	}
 	return usage.MediaFileCount > cfg.MaxMediaLLMFiles
+}
+
+func recordTenantQuotaSnapshot(tenantID string, usage *QuotaUsageView, cfg *QuotaConfigView) {
+	if tenantID == "" || usage == nil {
+		return
+	}
+	metrics.RecordTenantStorageBytes(tenantID, "confirmed", usage.StorageBytes)
+	metrics.RecordTenantStorageBytes(tenantID, "reserved", usage.ReservedBytes)
+	metrics.RecordTenantMediaFiles(tenantID, "confirmed", usage.MediaFileCount)
+	if cfg == nil {
+		return
+	}
+	metrics.RecordTenantStorageBytes(tenantID, "limit", cfg.MaxStorageBytes)
+	metrics.RecordTenantMediaFiles(tenantID, "limit", cfg.MaxMediaLLMFiles)
 }
 
 // mediaLLMQuotaExceededServerTx checks the server DB counter for media file

--- a/pkg/backend/runtime_metrics_test.go
+++ b/pkg/backend/runtime_metrics_test.go
@@ -39,51 +39,51 @@ func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
 	})
 
 	metricsText := readBackendMetrics()
-	if !strings.Contains(metricsText, "dat9_module_up{module=\"image_extract\"} 1") {
+	if !strings.Contains(metricsText, "drive9_module_up{module=\"image_extract\"} 1") {
 		t.Fatalf("metrics missing aggregated image_extract availability: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 8") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 8") {
 		t.Fatalf("metrics missing aggregated image queue capacity: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"image_extract\",name=\"workers\"} 3") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"workers\"} 3") {
 		t.Fatalf("metrics missing aggregated image workers: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 4096") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 4096") {
 		t.Fatalf("metrics missing aggregated audio max bytes: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\"} 3") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\"} 3") {
 		t.Fatalf("metrics missing aggregated audio timeout: %s", metricsText)
 	}
 
 	b1.Close()
 
 	metricsText = readBackendMetrics()
-	if !strings.Contains(metricsText, "dat9_module_up{module=\"image_extract\"} 1") {
+	if !strings.Contains(metricsText, "drive9_module_up{module=\"image_extract\"} 1") {
 		t.Fatalf("metrics should keep image_extract available while one backend remains: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 3") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 3") {
 		t.Fatalf("metrics should retain remaining image queue capacity: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"image_extract\",name=\"workers\"} 1") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"workers\"} 1") {
 		t.Fatalf("metrics should retain remaining image workers: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 2048") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 2048") {
 		t.Fatalf("metrics should retain remaining audio max bytes: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"max_extract_text_bytes\"} 555") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_extract_text_bytes\"} 555") {
 		t.Fatalf("metrics should retain remaining audio text limit: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\"} 2") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\"} 2") {
 		t.Fatalf("metrics should retain remaining audio timeout: %s", metricsText)
 	}
 
 	b2.Close()
 
 	metricsText = readBackendMetrics()
-	if !strings.Contains(metricsText, "dat9_module_up{module=\"image_extract\"} 0") {
+	if !strings.Contains(metricsText, "drive9_module_up{module=\"image_extract\"} 0") {
 		t.Fatalf("metrics should mark image_extract unavailable once all backends close: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_module_up{module=\"audio_extract\"} 0") {
+	if !strings.Contains(metricsText, "drive9_module_up{module=\"audio_extract\"} 0") {
 		t.Fatalf("metrics should mark audio_extract unavailable once all backends close: %s", metricsText)
 	}
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -49,10 +49,10 @@ func TestMetaDBMetrics(t *testing.T) {
 	rec := httptest.NewRecorder()
 	metrics.WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `dat9_db_operations_total{operation="`) || !strings.Contains(text, `role="meta"`) {
+	if !strings.Contains(text, `drive9_db_operations_total{operation="`) || !strings.Contains(text, `role="meta"`) {
 		t.Fatalf("expected meta db operation metric in response: %s", text)
 	}
-	if !strings.Contains(text, `dat9_db_pool_registered{role="meta"}`) {
+	if !strings.Contains(text, `drive9_db_pool_registered{role="meta"}`) {
 		t.Fatalf("expected meta db pool metric in response: %s", text)
 	}
 }

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -33,8 +33,8 @@ var globalDB = &dbMetrics{
 }
 
 var dbMeter = globalMeterProvider.Meter("db")
-var dbOperationsTotal = dbMeter.Int64Counter("dat9_db_operations_total", "Database operations by role/operation/result")
-var dbOperationDuration = dbMeter.Float64Histogram("dat9_db_operation_duration_seconds", "Database operation duration histogram", dbOperationDurationBounds)
+var dbOperationsTotal = dbMeter.Int64Counter("drive9_db_operations_total", "Database operations by role/operation/result")
+var dbOperationDuration = dbMeter.Float64Histogram("drive9_db_operation_duration_seconds", "Database operation duration histogram", dbOperationDurationBounds)
 
 func RecordDBOperation(role, operation, result string, d time.Duration) {
 	RegisterModule("db")
@@ -92,42 +92,42 @@ func writeDBPrometheus(w http.ResponseWriter) {
 	}
 	roles := SortedKeys(poolTotals)
 
-	_, _ = fmt.Fprintln(w, "# HELP dat9_db_pool_registered Database pools currently registered for metrics by role")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_pool_registered gauge")
+	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_registered Database pools currently registered for metrics by role")
+	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_registered gauge")
 	for _, role := range roles {
-		_, _ = fmt.Fprintf(w, "dat9_db_pool_registered{role=\"%s\"} %d\n", EscapePromLabel(role), poolTotals[role].registered)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_registered{role=\"%s\"} %d\n", EscapePromLabel(role), poolTotals[role].registered)
 	}
 
-	_, _ = fmt.Fprintln(w, "# HELP dat9_db_pool_connections Aggregated database pool connections by role/state")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_pool_connections gauge")
+	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_connections Aggregated database pool connections by role/state")
+	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_connections gauge")
 	for _, role := range roles {
 		totals := poolTotals[role]
 		escapedRole := EscapePromLabel(role)
-		_, _ = fmt.Fprintf(w, "dat9_db_pool_connections{role=\"%s\",state=\"open\"} %d\n", escapedRole, totals.openConnections)
-		_, _ = fmt.Fprintf(w, "dat9_db_pool_connections{role=\"%s\",state=\"in_use\"} %d\n", escapedRole, totals.inUseConnections)
-		_, _ = fmt.Fprintf(w, "dat9_db_pool_connections{role=\"%s\",state=\"idle\"} %d\n", escapedRole, totals.idleConnections)
-		_, _ = fmt.Fprintf(w, "dat9_db_pool_connections{role=\"%s\",state=\"max_open\"} %d\n", escapedRole, totals.maxOpenConnections)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{role=\"%s\",state=\"open\"} %d\n", escapedRole, totals.openConnections)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{role=\"%s\",state=\"in_use\"} %d\n", escapedRole, totals.inUseConnections)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{role=\"%s\",state=\"idle\"} %d\n", escapedRole, totals.idleConnections)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{role=\"%s\",state=\"max_open\"} %d\n", escapedRole, totals.maxOpenConnections)
 	}
 
-	_, _ = fmt.Fprintln(w, "# HELP dat9_db_pool_wait_count_total Aggregated database pool wait count by role")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_pool_wait_count_total counter")
+	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_wait_count_total Aggregated database pool wait count by role")
+	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_wait_count_total counter")
 	for _, role := range roles {
-		_, _ = fmt.Fprintf(w, "dat9_db_pool_wait_count_total{role=\"%s\"} %d\n", EscapePromLabel(role), poolTotals[role].waitCount)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_wait_count_total{role=\"%s\"} %d\n", EscapePromLabel(role), poolTotals[role].waitCount)
 	}
 
-	_, _ = fmt.Fprintln(w, "# HELP dat9_db_pool_wait_duration_seconds_total Aggregated database pool wait duration by role")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_pool_wait_duration_seconds_total counter")
+	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_wait_duration_seconds_total Aggregated database pool wait duration by role")
+	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_wait_duration_seconds_total counter")
 	for _, role := range roles {
-		_, _ = fmt.Fprintf(w, "dat9_db_pool_wait_duration_seconds_total{role=\"%s\"} %.6f\n", EscapePromLabel(role), poolTotals[role].waitDuration)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_wait_duration_seconds_total{role=\"%s\"} %.6f\n", EscapePromLabel(role), poolTotals[role].waitDuration)
 	}
 
-	_, _ = fmt.Fprintln(w, "# HELP dat9_db_pool_closes_total Aggregated database pool closes by role/reason")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_db_pool_closes_total counter")
+	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_closes_total Aggregated database pool closes by role/reason")
+	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_closes_total counter")
 	for _, role := range roles {
 		totals := poolTotals[role]
 		escapedRole := EscapePromLabel(role)
-		_, _ = fmt.Fprintf(w, "dat9_db_pool_closes_total{role=\"%s\",reason=\"max_idle\"} %d\n", escapedRole, totals.maxIdleClosed)
-		_, _ = fmt.Fprintf(w, "dat9_db_pool_closes_total{role=\"%s\",reason=\"max_idle_time\"} %d\n", escapedRole, totals.maxIdleTimeClosed)
-		_, _ = fmt.Fprintf(w, "dat9_db_pool_closes_total{role=\"%s\",reason=\"max_lifetime\"} %d\n", escapedRole, totals.maxLifetimeClosed)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_closes_total{role=\"%s\",reason=\"max_idle\"} %d\n", escapedRole, totals.maxIdleClosed)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_closes_total{role=\"%s\",reason=\"max_idle_time\"} %d\n", escapedRole, totals.maxIdleTimeClosed)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_closes_total{role=\"%s\",reason=\"max_lifetime\"} %d\n", escapedRole, totals.maxLifetimeClosed)
 	}
 }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -10,7 +10,7 @@ import (
 )
 
 var operationDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
-var httpDurationBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+var httpDurationBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
 
 var globalRegistry = NewRegistry()
 var globalMeterProvider = NewMeterProvider(globalRegistry)
@@ -19,23 +19,32 @@ var serviceMeter = globalMeterProvider.Meter("service")
 var httpMeter = globalMeterProvider.Meter("http")
 var eventMeter = globalMeterProvider.Meter("event")
 var fuseMeter = globalMeterProvider.Meter("fuse")
+var tenantMeter = globalMeterProvider.Meter("tenant")
 
-var serviceOperationsTotal = serviceMeter.Int64Counter("dat9_service_operations_total", "Service operations by component/operation/result")
-var serviceOperationDuration = serviceMeter.Float64Histogram("dat9_service_operation_duration_seconds", "Service operation duration histogram", operationDurationBounds)
-var serviceGauge = serviceMeter.Float64Gauge("dat9_service_gauge", "Service gauges by component/name")
+var serviceOperationsTotal = serviceMeter.Int64Counter("drive9_service_operations_total", "Service operations by component/operation/result")
+var serviceOperationDuration = serviceMeter.Float64Histogram("drive9_service_operation_duration_seconds", "Service operation duration histogram", operationDurationBounds)
+var serviceGauge = serviceMeter.Float64Gauge("drive9_service_gauge", "Service gauges by component/name")
 
-var httpRequestsTotal = httpMeter.Int64Counter("dat9_http_requests_total", "Total HTTP requests by method/route/status")
-var httpRequestDuration = httpMeter.Float64Histogram("dat9_http_request_duration_seconds", "HTTP request duration histogram by method/route", httpDurationBounds)
-var httpInflight = httpMeter.Float64Gauge("dat9_http_inflight_requests", "Current in-flight HTTP requests")
+var httpRequestsTotal = httpMeter.Int64Counter("drive9_http_requests_total", "Total HTTP requests by method/route/status")
+var httpRequestDuration = httpMeter.Float64Histogram("drive9_http_request_duration_seconds", "HTTP request duration histogram by method/route", httpDurationBounds)
+var httpInflight = httpMeter.Float64Gauge("drive9_http_inflight_requests", "Current in-flight HTTP requests")
 
-var tenantEventsTotal = eventMeter.Int64Counter("dat9_tenant_events_total", "Tenant/business lifecycle events")
+var businessEventsTotal = eventMeter.Int64Counter("drive9_business_events_total", "Business lifecycle events")
 
-var fuseOperationsTotal = fuseMeter.Int64Counter("dat9_fuse_operations_total", "FUSE operations by operation/result")
-var fuseOperationDuration = fuseMeter.Float64Histogram("dat9_fuse_operation_duration_seconds", "FUSE operation duration histogram", operationDurationBounds)
-var fuseOperationBytes = fuseMeter.Int64Counter("dat9_fuse_operation_bytes_total", "Bytes processed by FUSE operation/result")
-var fuseRemoteOperationsTotal = fuseMeter.Int64Counter("dat9_fuse_remote_operations_total", "Remote FUSE operations by operation/result")
-var fuseRemoteOperationDuration = fuseMeter.Float64Histogram("dat9_fuse_remote_operation_duration_seconds", "Remote FUSE operation duration histogram", operationDurationBounds)
-var fuseRemoteOperationBytes = fuseMeter.Int64Counter("dat9_fuse_remote_operation_bytes_total", "Bytes processed by remote FUSE operation/result")
+var fuseOperationsTotal = fuseMeter.Int64Counter("drive9_fuse_operations_total", "FUSE operations by operation/result")
+var fuseOperationDuration = fuseMeter.Float64Histogram("drive9_fuse_operation_duration_seconds", "FUSE operation duration histogram", operationDurationBounds)
+var fuseOperationBytes = fuseMeter.Int64Counter("drive9_fuse_operation_bytes_total", "Bytes processed by FUSE operation/result")
+var fuseRemoteOperationsTotal = fuseMeter.Int64Counter("drive9_fuse_remote_operations_total", "Remote FUSE operations by operation/result")
+var fuseRemoteOperationDuration = fuseMeter.Float64Histogram("drive9_fuse_remote_operation_duration_seconds", "Remote FUSE operation duration histogram", operationDurationBounds)
+var fuseRemoteOperationBytes = fuseMeter.Int64Counter("drive9_fuse_remote_operation_bytes_total", "Bytes processed by remote FUSE operation/result")
+
+var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/surface/action/result/status/status_class")
+var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_duration_seconds", "Tenant-scoped request duration histogram", httpDurationBounds)
+var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/surface/action")
+var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/surface/action/direction")
+var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/surface/action/direction")
+var tenantStorageBytes = tenantMeter.Float64Gauge("drive9_tenant_storage_bytes", "Tenant storage bytes by state")
+var tenantMediaFiles = tenantMeter.Float64Gauge("drive9_tenant_media_files", "Tenant media file count by state")
 
 func RegisterModule(module string) {
 	globalRegistry.RegisterModule(module)
@@ -96,7 +105,83 @@ func RecordEvent(event string, labels ...string) {
 	for i := 0; i+1 < len(labels); i += 2 {
 		attrs = append(attrs, Attr(labels[i], labels[i+1]))
 	}
-	tenantEventsTotal.Add(1, attrs...)
+	businessEventsTotal.Add(1, attrs...)
+}
+
+func RecordTenantRequest(tenantID, surface, action, result string, status int, d time.Duration) {
+	tenantID = cleanMetricValue(tenantID, "unknown")
+	surface = cleanMetricValue(surface, "other")
+	action = cleanMetricValue(action, "other")
+	result = cleanMetricValue(result, "unknown")
+	statusValue := "unknown"
+	statusClass := "unknown"
+	if status > 0 {
+		statusValue = strconv.Itoa(status)
+		statusClass = strconv.Itoa(status/100) + "xx"
+	}
+	RegisterModule("tenant_usage")
+	attrs := []Attribute{
+		Attr("tenant_id", tenantID),
+		Attr("surface", surface),
+		Attr("action", action),
+		Attr("result", result),
+		Attr("status", statusValue),
+		Attr("status_class", statusClass),
+	}
+	tenantRequestsTotal.Add(1, attrs...)
+	tenantRequestDuration.Observe(d.Seconds(), attrs...)
+}
+
+func RecordTenantHTTPBytes(tenantID, surface, action, direction string, bytes int64) {
+	recordTenantBytes(tenantHTTPBytes, tenantID, surface, action, direction, bytes)
+}
+
+func RecordTenantFileBytes(tenantID, surface, action, direction string, bytes int64) {
+	recordTenantBytes(tenantFileBytes, tenantID, surface, action, direction, bytes)
+}
+
+func RecordTenantInFlight(tenantID, surface, action string, value float64) {
+	RegisterModule("tenant_usage")
+	tenantInflight.Set(value,
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("surface", cleanMetricValue(surface, "other")),
+		Attr("action", cleanMetricValue(action, "other")),
+	)
+}
+
+func RecordTenantStorageBytes(tenantID, state string, bytes int64) {
+	if bytes < 0 {
+		return
+	}
+	RegisterModule("tenant_usage")
+	tenantStorageBytes.Set(float64(bytes),
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("state", cleanMetricValue(state, "unknown")),
+	)
+}
+
+func RecordTenantMediaFiles(tenantID, state string, count int64) {
+	if count < 0 {
+		return
+	}
+	RegisterModule("tenant_usage")
+	tenantMediaFiles.Set(float64(count),
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("state", cleanMetricValue(state, "unknown")),
+	)
+}
+
+func recordTenantBytes(counter *Int64Counter, tenantID, surface, action, direction string, bytes int64) {
+	if bytes <= 0 {
+		return
+	}
+	RegisterModule("tenant_usage")
+	counter.Add(bytes,
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("surface", cleanMetricValue(surface, "other")),
+		Attr("action", cleanMetricValue(action, "other")),
+		Attr("direction", cleanMetricValue(direction, "unknown")),
+	)
 }
 
 func RecordFuseOperation(operation, result string, d time.Duration, bytes uint64) {

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -322,21 +322,21 @@ func (r *Registry) writeModules(w io.Writer) {
 	}
 	sort.Strings(names)
 
-	_, _ = fmt.Fprintln(w, "# HELP dat9_module_up Module availability state")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_module_up gauge")
+	_, _ = fmt.Fprintln(w, "# HELP drive9_module_up Module availability state")
+	_, _ = fmt.Fprintln(w, "# TYPE drive9_module_up gauge")
 	for _, module := range names {
-		writeMetricLine(w, "dat9_module_up", labelsKey([]Attribute{Attr("module", module)}), formatFloat(modules[module].up))
+		writeMetricLine(w, "drive9_module_up", labelsKey([]Attribute{Attr("module", module)}), formatFloat(modules[module].up))
 	}
 
-	_, _ = fmt.Fprintln(w, "# HELP dat9_module_uptime_seconds Module uptime in seconds since first registration")
-	_, _ = fmt.Fprintln(w, "# TYPE dat9_module_uptime_seconds gauge")
+	_, _ = fmt.Fprintln(w, "# HELP drive9_module_uptime_seconds Module uptime in seconds since first registration")
+	_, _ = fmt.Fprintln(w, "# TYPE drive9_module_uptime_seconds gauge")
 	for _, module := range names {
 		state := modules[module]
 		uptime := 0.0
 		if !state.registeredAt.IsZero() {
 			uptime = now.Sub(state.registeredAt).Seconds()
 		}
-		writeMetricLine(w, "dat9_module_uptime_seconds", labelsKey([]Attribute{Attr("module", module)}), formatFloat(uptime))
+		writeMetricLine(w, "drive9_module_uptime_seconds", labelsKey([]Attribute{Attr("module", module)}), formatFloat(uptime))
 	}
 }
 

--- a/pkg/s3client/s3client_test.go
+++ b/pkg/s3client/s3client_test.go
@@ -118,16 +118,16 @@ func TestS3MetricsExposed(t *testing.T) {
 	}
 
 	metricsText := readS3Metrics()
-	if !strings.Contains(metricsText, "dat9_module_up{module=\"s3client\"} 1") {
+	if !strings.Contains(metricsText, "drive9_module_up{module=\"s3client\"} 1") {
 		t.Fatalf("metrics missing s3client module availability: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_operations_total{component=\"s3client\",operation=\"put_object\",result=\"ok\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"s3client\",operation=\"put_object\",result=\"ok\"}") {
 		t.Fatalf("metrics missing s3client put_object counter: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_operations_total{component=\"s3client\",operation=\"get_object\",result=\"ok\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"s3client\",operation=\"get_object\",result=\"ok\"}") {
 		t.Fatalf("metrics missing s3client get_object counter: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_operation_duration_seconds_count{component=\"s3client\",operation=\"get_object\",result=\"ok\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"s3client\",operation=\"get_object\",result=\"ok\"}") {
 		t.Fatalf("metrics missing s3client duration histogram: %s", metricsText)
 	}
 }

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -332,6 +332,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			IsScoped:           isScoped,
 			FSScopes:           fsScopes,
 		}
+		setRequestMetricScope(r.Context(), scope, classifyTenantRequest(r))
 		next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))
 	})
 }
@@ -375,6 +376,7 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 		defer release()
 
 		scope := &TenantScope{TenantID: tenantID, Provider: tenant.Provider, Backend: b}
+		setRequestMetricScope(r.Context(), scope, classifyTenantRequest(r))
 		sub := strings.TrimPrefix(r.URL.Path, "/v1/vault/read")
 		s.handleVaultRead(w, r.WithContext(withScope(r.Context(), scope)), sub)
 	})

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -182,6 +182,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
+		setRequestMetricTenant(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID, resolved.Tenant.Provider, classifyTenantRequest(r))
 
 		if resolved.APIKey.Status != meta.APIKeyActive {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_key_inactive", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "status", resolved.APIKey.Status)...)

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -17,7 +17,10 @@ import (
 
 type metricsKeyType int
 
-const metricsKey metricsKeyType = iota
+const (
+	metricsKey metricsKeyType = iota
+	requestMetricsKey
+)
 
 func eventFields(ctx context.Context, event string, kv ...any) []zap.Field {
 	fields := make([]zap.Field, 0, len(kv)/2+3)
@@ -40,13 +43,121 @@ func eventFields(ctx context.Context, event string, kv ...any) []zap.Field {
 	return fields
 }
 
+type requestMetricState struct {
+	mu             sync.Mutex
+	tenantID       string
+	apiKeyID       string
+	provider       string
+	surface        string
+	action         string
+	tenantInFlight bool
+}
+
 func withMetrics(ctx context.Context, m *serverMetrics) context.Context {
 	return context.WithValue(ctx, metricsKey, m)
+}
+
+func withRequestMetricState(ctx context.Context, state *requestMetricState) context.Context {
+	return context.WithValue(ctx, requestMetricsKey, state)
 }
 
 func metricsFromContext(ctx context.Context) *serverMetrics {
 	v, _ := ctx.Value(metricsKey).(*serverMetrics)
 	return v
+}
+
+func requestMetricStateFromContext(ctx context.Context) *requestMetricState {
+	v, _ := ctx.Value(requestMetricsKey).(*requestMetricState)
+	return v
+}
+
+func setRequestMetricScope(ctx context.Context, scope *TenantScope, class tenantRequestClass) {
+	if scope == nil {
+		return
+	}
+	setRequestMetricTenant(ctx, scope.TenantID, scope.APIKeyID, scope.Provider, class)
+}
+
+func setRequestMetricTenant(ctx context.Context, tenantID, apiKeyID, provider string, class tenantRequestClass) {
+	state := requestMetricStateFromContext(ctx)
+	if state == nil || tenantID == "" {
+		return
+	}
+	surface := strings.TrimSpace(class.surface)
+	if surface == "" {
+		surface = "other"
+	}
+	action := strings.TrimSpace(class.action)
+	if action == "" {
+		action = "other"
+	}
+
+	var oldTenantID, oldSurface, oldAction string
+	var shouldMove bool
+	state.mu.Lock()
+	if state.tenantInFlight {
+		shouldMove = state.tenantID != tenantID || state.surface != surface || state.action != action
+		if shouldMove {
+			oldTenantID = state.tenantID
+			oldSurface = state.surface
+			oldAction = state.action
+			state.surface = surface
+			state.action = action
+		}
+		state.tenantID = tenantID
+		state.apiKeyID = apiKeyID
+		state.provider = provider
+		state.mu.Unlock()
+		if shouldMove {
+			if m := metricsFromContext(ctx); m != nil {
+				m.adjustTenantInFlight(oldTenantID, oldSurface, oldAction, -1)
+				m.adjustTenantInFlight(tenantID, surface, action, 1)
+			}
+		}
+		return
+	}
+	state.tenantID = tenantID
+	state.apiKeyID = apiKeyID
+	state.provider = provider
+	state.surface = surface
+	state.action = action
+	state.tenantInFlight = true
+	state.mu.Unlock()
+
+	if m := metricsFromContext(ctx); m != nil {
+		m.adjustTenantInFlight(tenantID, surface, action, 1)
+	}
+}
+
+func requestMetricScope(ctx context.Context) (tenantID, apiKeyID, provider string) {
+	state := requestMetricStateFromContext(ctx)
+	if state == nil {
+		return "", "", ""
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.tenantID, state.apiKeyID, state.provider
+}
+
+func finishRequestMetricTenant(ctx context.Context) {
+	state := requestMetricStateFromContext(ctx)
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	if !state.tenantInFlight {
+		state.mu.Unlock()
+		return
+	}
+	tenantID := state.tenantID
+	surface := state.surface
+	action := state.action
+	state.tenantInFlight = false
+	state.mu.Unlock()
+
+	if m := metricsFromContext(ctx); m != nil {
+		m.adjustTenantInFlight(tenantID, surface, action, -1)
+	}
 }
 
 func metricEvent(ctx context.Context, event string, labels ...string) {
@@ -61,12 +172,18 @@ type serverMetrics struct {
 	inFlight atomic.Int64
 	routeMu  sync.Mutex
 	routes   map[string]int64
+
+	tenantMu       sync.Mutex
+	tenantInFlight map[string]int64
 }
 
 func newServerMetrics() *serverMetrics {
 	metrics.SetModuleAvailability("server", true)
 	metrics.RecordHTTPInFlight(0)
-	return &serverMetrics{routes: map[string]int64{}}
+	return &serverMetrics{
+		routes:         map[string]int64{},
+		tenantInFlight: map[string]int64{},
+	}
 }
 
 func (m *serverMetrics) record(method, route string, status int, d time.Duration) {
@@ -95,6 +212,38 @@ func (m *serverMetrics) adjustRouteInFlight(route string, delta int64) int64 {
 	}
 	m.routes[route] = next
 	return next
+}
+
+func (m *serverMetrics) adjustTenantInFlight(tenantID, surface, action string, delta int64) int64 {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return 0
+	}
+	surface = strings.TrimSpace(surface)
+	if surface == "" {
+		surface = "other"
+	}
+	action = strings.TrimSpace(action)
+	if action == "" {
+		action = "other"
+	}
+	key := tenantInFlightKey(tenantID, surface, action)
+
+	m.tenantMu.Lock()
+	defer m.tenantMu.Unlock()
+	next := m.tenantInFlight[key] + delta
+	if next <= 0 {
+		delete(m.tenantInFlight, key)
+		metrics.RecordTenantInFlight(tenantID, surface, action, 0)
+		return 0
+	}
+	m.tenantInFlight[key] = next
+	metrics.RecordTenantInFlight(tenantID, surface, action, float64(next))
+	return next
+}
+
+func tenantInFlightKey(tenantID, surface, action string) string {
+	return tenantID + "\x00" + surface + "\x00" + action
 }
 
 type observedResponseWriter struct {
@@ -144,6 +293,10 @@ func requestRoute(path string) string {
 		return "/v1/events"
 	case path == "/v1/fork":
 		return "/v1/fork"
+	case path == "/v1/fs:batch-stat":
+		return "/v1/fs:batch-stat"
+	case path == "/v1/fs:batch-read-small":
+		return "/v1/fs:batch-read-small"
 	case strings.HasPrefix(path, "/v1/fs/"):
 		return "/v1/fs/*"
 	case path == "/v1/uploads":
@@ -169,6 +322,256 @@ func requestRoute(path string) string {
 	}
 }
 
+type tenantRequestClass struct {
+	surface string
+	action  string
+}
+
+func classifyTenantRequest(r *http.Request) tenantRequestClass {
+	if r == nil || r.URL == nil {
+		return tenantRequestClass{surface: "other", action: "other"}
+	}
+	path := r.URL.Path
+	switch {
+	case path == "/v1/fs:batch-stat":
+		return tenantRequestClass{surface: "fs", action: "batch_stat"}
+	case path == "/v1/fs:batch-read-small":
+		return tenantRequestClass{surface: "fs", action: "batch_read_small"}
+	case strings.HasPrefix(path, "/v1/fs/"):
+		return tenantRequestClass{surface: "fs", action: classifyFSAction(r)}
+	case path == "/v1/uploads":
+		if r.Method == http.MethodPost {
+			return tenantRequestClass{surface: "upload", action: "initiate"}
+		}
+		return tenantRequestClass{surface: "upload", action: "list"}
+	case path == "/v1/uploads/initiate":
+		return tenantRequestClass{surface: "upload", action: "initiate"}
+	case strings.HasPrefix(path, "/v1/uploads/"):
+		return tenantRequestClass{surface: "upload", action: classifyV1UploadAction(r)}
+	case strings.HasPrefix(path, "/v2/uploads/"):
+		return tenantRequestClass{surface: "upload", action: classifyV2UploadAction(r)}
+	case path == "/v1/sql":
+		return tenantRequestClass{surface: "sql", action: strings.ToLower(r.Method)}
+	case path == "/v1/events":
+		return tenantRequestClass{surface: "events", action: strings.ToLower(r.Method)}
+	case path == "/v1/tokens" || strings.HasPrefix(path, "/v1/tokens/"):
+		return tenantRequestClass{surface: "tokens", action: classifyTokenAction(r)}
+	case path == "/v1/journals" || strings.HasPrefix(path, "/v1/journals/") || path == "/v1/journal-entries":
+		return tenantRequestClass{surface: "journal", action: strings.ToLower(r.Method)}
+	case path == "/v1/git-workspaces" || strings.HasPrefix(path, "/v1/git-workspaces/"):
+		return tenantRequestClass{surface: "git_workspace", action: strings.ToLower(r.Method)}
+	case strings.HasPrefix(path, "/v1/vault/"):
+		return tenantRequestClass{surface: "vault", action: classifyVaultAction(r)}
+	case strings.HasPrefix(path, "/s3/"):
+		return tenantRequestClass{surface: "object_store", action: classifyS3Action(r)}
+	case path == "/v1/status":
+		return tenantRequestClass{surface: "status", action: strings.ToLower(r.Method)}
+	case path == "/v1/provision":
+		return tenantRequestClass{surface: "provision", action: strings.ToLower(r.Method)}
+	default:
+		return tenantRequestClass{surface: "other", action: strings.ToLower(r.Method)}
+	}
+}
+
+func classifyFSAction(r *http.Request) string {
+	switch r.Method {
+	case http.MethodGet:
+		q := r.URL.Query()
+		switch {
+		case q.Has("stat"):
+			return "stat"
+		case q.Has("grep"):
+			return "grep"
+		case q.Has("find"):
+			return "find"
+		case q.Has("list"):
+			return "list"
+		default:
+			return "read"
+		}
+	case http.MethodHead:
+		return "stat"
+	case http.MethodPut:
+		return "write"
+	case http.MethodPatch:
+		return "patch"
+	case http.MethodDelete:
+		return "delete"
+	case http.MethodPost:
+		q := r.URL.Query()
+		for _, key := range []string{"append", "copy", "rename", "mkdir", "chmod", "create", "symlink", "hardlink"} {
+			if q.Has(key) {
+				return key
+			}
+		}
+		return "post"
+	default:
+		return strings.ToLower(r.Method)
+	}
+}
+
+func classifyV1UploadAction(r *http.Request) string {
+	rest := strings.TrimPrefix(r.URL.Path, "/v1/uploads/")
+	if rest == "" {
+		return strings.ToLower(r.Method)
+	}
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) == 1 {
+		if r.Method == http.MethodDelete {
+			return "abort"
+		}
+		return "other"
+	}
+	action := strings.Trim(parts[1], "/")
+	if action == "" && r.Method == http.MethodDelete {
+		return "abort"
+	}
+	switch {
+	case strings.HasPrefix(action, "complete"):
+		return "complete"
+	case strings.HasPrefix(action, "resume"):
+		return "resume"
+	default:
+		return "other"
+	}
+}
+
+func classifyV2UploadAction(r *http.Request) string {
+	rest := strings.TrimPrefix(r.URL.Path, "/v2/uploads/")
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return strings.ToLower(r.Method)
+	}
+	if parts[0] == "initiate" {
+		return "initiate"
+	}
+	if len(parts) == 1 {
+		return "other"
+	}
+	switch strings.Trim(parts[1], "/") {
+	case "presign":
+		return "presign"
+	case "presign-batch":
+		return "presign_batch"
+	case "complete":
+		return "complete"
+	case "abort":
+		return "abort"
+	default:
+		return "other"
+	}
+}
+
+func classifyVaultAction(r *http.Request) string {
+	path := r.URL.Path
+	switch {
+	case strings.HasPrefix(path, "/v1/vault/secrets"):
+		return "secrets_" + strings.ToLower(r.Method)
+	case strings.HasPrefix(path, "/v1/vault/tokens"):
+		return "tokens_" + strings.ToLower(r.Method)
+	case strings.HasPrefix(path, "/v1/vault/grants"):
+		return "grants_" + strings.ToLower(r.Method)
+	case strings.HasPrefix(path, "/v1/vault/read"):
+		return "read"
+	case path == "/v1/vault/audit":
+		return "audit"
+	default:
+		return strings.ToLower(r.Method)
+	}
+}
+
+func classifyTokenAction(r *http.Request) string {
+	switch {
+	case r.URL.Path == "/v1/tokens" && r.Method == http.MethodPost:
+		return "issue"
+	case r.URL.Path == "/v1/tokens/revoke" && r.Method == http.MethodPost:
+		return "revoke_by_key"
+	case strings.HasPrefix(r.URL.Path, "/v1/tokens/") && r.Method == http.MethodDelete:
+		return "revoke"
+	default:
+		return strings.ToLower(r.Method)
+	}
+}
+
+func classifyS3Action(r *http.Request) string {
+	if strings.Contains(r.URL.Path, "/upload/") && r.Method == http.MethodPut {
+		return "upload_part"
+	}
+	if strings.Contains(r.URL.Path, "/objects/") && r.Method == http.MethodGet {
+		return "get_object"
+	}
+	return strings.ToLower(r.Method)
+}
+
+func tenantRequestResult(status int) string {
+	switch {
+	case status >= 200 && status < 400:
+		return "ok"
+	case status == http.StatusUnauthorized:
+		return "unauthorized"
+	case status == http.StatusForbidden:
+		return "denied"
+	case status == http.StatusNotFound:
+		return "not_found"
+	case status == http.StatusConflict:
+		return "conflict"
+	case status == http.StatusInsufficientStorage || status == http.StatusTooManyRequests:
+		return "quota_or_rate_limited"
+	case status >= 400 && status < 500:
+		return "client_error"
+	case status >= 500:
+		return "server_error"
+	default:
+		return "unknown"
+	}
+}
+
+func requestTenantID(r *http.Request) string {
+	tenantID, _, _ := requestMetricScope(r.Context())
+	if tenantID != "" {
+		return tenantID
+	}
+	if r.URL != nil && strings.HasPrefix(r.URL.Path, "/s3/") {
+		rest := strings.TrimPrefix(r.URL.Path, "/s3/")
+		if tenant, _, ok := strings.Cut(rest, "/"); ok && tenant != "" {
+			if tenant == "upload" || tenant == "objects" {
+				return "local"
+			}
+			return tenant
+		}
+	}
+	return ""
+}
+
+func recordTenantHTTPRequest(r *http.Request, status int, d time.Duration, responseBytes int) {
+	tenantID := requestTenantID(r)
+	if tenantID == "" {
+		return
+	}
+	class := classifyTenantRequest(r)
+	metrics.RecordTenantRequest(tenantID, class.surface, class.action, tenantRequestResult(status), status, d)
+	if r.ContentLength > 0 {
+		metrics.RecordTenantHTTPBytes(tenantID, class.surface, class.action, "request", r.ContentLength)
+		if class.surface == "object_store" && class.action == "upload_part" && status >= 200 && status < 300 {
+			metrics.RecordTenantFileBytes(tenantID, class.surface, class.action, "write", r.ContentLength)
+		}
+	}
+	if responseBytes > 0 {
+		metrics.RecordTenantHTTPBytes(tenantID, class.surface, class.action, "response", int64(responseBytes))
+		if class.surface == "object_store" && class.action == "get_object" && status >= 200 && status < 300 {
+			metrics.RecordTenantFileBytes(tenantID, class.surface, class.action, "read", int64(responseBytes))
+		}
+	}
+}
+
+func recordTenantFileBytes(ctx context.Context, surface, action, direction string, bytes int64) {
+	tenantID, _, _ := requestMetricScope(ctx)
+	if tenantID == "" || bytes <= 0 {
+		return
+	}
+	metrics.RecordTenantFileBytes(tenantID, surface, action, direction, bytes)
+}
+
 func generateTraceID() string { return traceid.Generate() }
 
 func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Request) {
@@ -180,6 +583,7 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	r = r.WithContext(traceid.With(r.Context(), traceID))
 	r = r.WithContext(logger.WithContext(r.Context(), s.logger.With(zap.String("trace_id", traceID))))
 	r = r.WithContext(withMetrics(r.Context(), s.metrics))
+	r = r.WithContext(withRequestMetricState(r.Context(), &requestMetricState{}))
 	w.Header().Set("X-Trace-ID", traceID)
 
 	start := time.Now()
@@ -194,7 +598,12 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	defer func() {
 		metrics.RecordHTTPInFlight(float64(s.metrics.inFlight.Add(-1)))
 		metrics.RecordHTTPInFlightRoute(route, float64(s.metrics.adjustRouteInFlight(route, -1)))
+		finishRequestMetricTenant(r.Context())
 	}()
+
+	if strings.HasPrefix(r.URL.Path, "/s3/") {
+		setRequestMetricTenant(r.Context(), requestTenantID(r), "", "", classifyTenantRequest(r))
+	}
 
 	next.ServeHTTP(rw, r)
 	if ow.status == 0 {
@@ -203,13 +612,9 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 
 	dur := time.Since(start)
 	s.metrics.record(r.Method, route, ow.status, dur)
+	recordTenantHTTPRequest(r, ow.status, dur, ow.size)
 
-	tenantID := ""
-	apiKeyID := ""
-	if scope := ScopeFromContext(r.Context()); scope != nil {
-		tenantID = scope.TenantID
-		apiKeyID = scope.APIKeyID
-	}
+	tenantID, apiKeyID, _ := requestMetricScope(r.Context())
 
 	fields := []zap.Field{
 		zap.String("method", r.Method),

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -139,6 +139,19 @@ func requestMetricScope(ctx context.Context) (tenantID, apiKeyID, provider strin
 	return state.tenantID, state.apiKeyID, state.provider
 }
 
+func requestMetricClass(ctx context.Context) (tenantRequestClass, bool) {
+	state := requestMetricStateFromContext(ctx)
+	if state == nil {
+		return tenantRequestClass{}, false
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.tenantID == "" || state.surface == "" || state.action == "" {
+		return tenantRequestClass{}, false
+	}
+	return tenantRequestClass{surface: state.surface, action: state.action}, true
+}
+
 func finishRequestMetricTenant(ctx context.Context) {
 	state := requestMetricStateFromContext(ctx)
 	if state == nil {
@@ -534,10 +547,9 @@ func requestTenantID(r *http.Request) string {
 	if r.URL != nil && strings.HasPrefix(r.URL.Path, "/s3/") {
 		rest := strings.TrimPrefix(r.URL.Path, "/s3/")
 		if tenant, _, ok := strings.Cut(rest, "/"); ok && tenant != "" {
-			if tenant == "upload" || tenant == "objects" {
+			if tenant == "local" || tenant == "upload" || tenant == "objects" {
 				return "local"
 			}
-			return tenant
 		}
 	}
 	return ""
@@ -549,18 +561,15 @@ func recordTenantHTTPRequest(r *http.Request, status int, d time.Duration, respo
 		return
 	}
 	class := classifyTenantRequest(r)
+	if scopedClass, ok := requestMetricClass(r.Context()); ok {
+		class = scopedClass
+	}
 	metrics.RecordTenantRequest(tenantID, class.surface, class.action, tenantRequestResult(status), status, d)
 	if r.ContentLength > 0 {
 		metrics.RecordTenantHTTPBytes(tenantID, class.surface, class.action, "request", r.ContentLength)
-		if class.surface == "object_store" && class.action == "upload_part" && status >= 200 && status < 300 {
-			metrics.RecordTenantFileBytes(tenantID, class.surface, class.action, "write", r.ContentLength)
-		}
 	}
 	if responseBytes > 0 {
 		metrics.RecordTenantHTTPBytes(tenantID, class.surface, class.action, "response", int64(responseBytes))
-		if class.surface == "object_store" && class.action == "get_object" && status >= 200 && status < 300 {
-			metrics.RecordTenantFileBytes(tenantID, class.surface, class.action, "read", int64(responseBytes))
-		}
 	}
 }
 

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -97,8 +97,8 @@ func TestRequestTenantID(t *testing.T) {
 		{path: "/s3/local/upload/u1/1", want: "local"},
 		{path: "/s3/upload/u1/1", want: "local"},
 		{path: "/s3/objects/blob", want: "local"},
-		{path: "/s3/tenant-a/upload/u1/1", want: "tenant-a"},
-		{path: "/s3/tenant-a/objects/blob", want: "tenant-a"},
+		{path: "/s3/tenant-a/upload/u1/1", want: ""},
+		{path: "/s3/tenant-a/objects/blob", want: ""},
 		{path: "/v1/fs/doc.txt", want: ""},
 	}
 
@@ -110,6 +110,17 @@ func TestRequestTenantID(t *testing.T) {
 		if got := requestTenantID(req); got != tc.want {
 			t.Fatalf("requestTenantID(%q) = %q, want %q", tc.path, got, tc.want)
 		}
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.test/s3/tenant-a/objects/blob", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := withRequestMetricState(req.Context(), &requestMetricState{})
+	req = req.WithContext(ctx)
+	setRequestMetricTenant(req.Context(), "tenant-a", "", "", tenantRequestClass{surface: "object_store", action: "get_object"})
+	if got := requestTenantID(req); got != "tenant-a" {
+		t.Fatalf("requestTenantID with verified scope = %q, want tenant-a", got)
 	}
 }
 

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -21,6 +22,8 @@ func TestRequestRoute(t *testing.T) {
 		{path: "/v1/sql", want: "/v1/sql"},
 		{path: "/v1/events", want: "/v1/events"},
 		{path: "/v1/fs/doc.txt", want: "/v1/fs/*"},
+		{path: "/v1/fs:batch-stat", want: "/v1/fs:batch-stat"},
+		{path: "/v1/fs:batch-read-small", want: "/v1/fs:batch-read-small"},
 		{path: "/v1/uploads", want: "/v1/uploads"},
 		{path: "/v1/uploads/u1/complete", want: "/v1/uploads/*"},
 		{path: "/v2/uploads/u1/parts", want: "/v2/uploads/*"},
@@ -39,6 +42,100 @@ func TestRequestRoute(t *testing.T) {
 		if got := requestRoute(tc.path); got != tc.want {
 			t.Fatalf("requestRoute(%q) = %q, want %q", tc.path, got, tc.want)
 		}
+	}
+}
+
+func TestClassifyTenantRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		method string
+		path   string
+		want   tenantRequestClass
+	}{
+		{method: http.MethodGet, path: "/v1/fs/doc.txt", want: tenantRequestClass{surface: "fs", action: "read"}},
+		{method: http.MethodGet, path: "/v1/fs/dir/?list=1", want: tenantRequestClass{surface: "fs", action: "list"}},
+		{method: http.MethodGet, path: "/v1/fs:batch-stat", want: tenantRequestClass{surface: "fs", action: "batch_stat"}},
+		{method: http.MethodPost, path: "/v1/fs:batch-read-small", want: tenantRequestClass{surface: "fs", action: "batch_read_small"}},
+		{method: http.MethodPost, path: "/v1/fs/large.bin?append=1", want: tenantRequestClass{surface: "fs", action: "append"}},
+		{method: http.MethodPost, path: "/v1/uploads", want: tenantRequestClass{surface: "upload", action: "initiate"}},
+		{method: http.MethodGet, path: "/v1/uploads", want: tenantRequestClass{surface: "upload", action: "list"}},
+		{method: http.MethodPost, path: "/v1/uploads/u1/complete", want: tenantRequestClass{surface: "upload", action: "complete"}},
+		{method: http.MethodDelete, path: "/v1/uploads/u1", want: tenantRequestClass{surface: "upload", action: "abort"}},
+		{method: http.MethodPost, path: "/v1/uploads/u1/random-user-input", want: tenantRequestClass{surface: "upload", action: "other"}},
+		{method: http.MethodPost, path: "/v2/uploads/initiate", want: tenantRequestClass{surface: "upload", action: "initiate"}},
+		{method: http.MethodPost, path: "/v2/uploads/u1/presign-batch", want: tenantRequestClass{surface: "upload", action: "presign_batch"}},
+		{method: http.MethodPost, path: "/v2/uploads/u1/random-user-input", want: tenantRequestClass{surface: "upload", action: "other"}},
+		{method: http.MethodPost, path: "/v1/tokens", want: tenantRequestClass{surface: "tokens", action: "issue"}},
+		{method: http.MethodPost, path: "/v1/tokens/revoke", want: tenantRequestClass{surface: "tokens", action: "revoke_by_key"}},
+		{method: http.MethodDelete, path: "/v1/tokens/tok_123", want: tenantRequestClass{surface: "tokens", action: "revoke"}},
+		{method: http.MethodGet, path: "/v1/vault/read/db/password", want: tenantRequestClass{surface: "vault", action: "read"}},
+		{method: http.MethodPut, path: "/s3/local/upload/u1/1", want: tenantRequestClass{surface: "object_store", action: "upload_part"}},
+		{method: http.MethodGet, path: "/s3/local/objects/blob", want: tenantRequestClass{surface: "object_store", action: "get_object"}},
+		{method: http.MethodPost, path: "/v1/sql", want: tenantRequestClass{surface: "sql", action: "post"}},
+	}
+
+	for _, tc := range tests {
+		req, err := http.NewRequest(tc.method, "http://example.test"+tc.path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := classifyTenantRequest(req)
+		if got != tc.want {
+			t.Fatalf("classifyTenantRequest(%s %s) = %#v, want %#v", tc.method, tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestRequestTenantID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "/s3/local/upload/u1/1", want: "local"},
+		{path: "/s3/upload/u1/1", want: "local"},
+		{path: "/s3/objects/blob", want: "local"},
+		{path: "/s3/tenant-a/upload/u1/1", want: "tenant-a"},
+		{path: "/s3/tenant-a/objects/blob", want: "tenant-a"},
+		{path: "/v1/fs/doc.txt", want: ""},
+	}
+
+	for _, tc := range tests {
+		req, err := http.NewRequest(http.MethodGet, "http://example.test"+tc.path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := requestTenantID(req); got != tc.want {
+			t.Fatalf("requestTenantID(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestSetRequestMetricTenantMovesInFlightLabel(t *testing.T) {
+	m := newServerMetrics()
+	state := &requestMetricState{}
+	ctx := withMetrics(context.Background(), m)
+	ctx = withRequestMetricState(ctx, state)
+	class := tenantRequestClass{surface: "object_store", action: "upload_part"}
+
+	setRequestMetricTenant(ctx, "local", "", "", class)
+	if got := m.tenantInFlight[tenantInFlightKey("local", "object_store", "upload_part")]; got != 1 {
+		t.Fatalf("local in-flight = %d, want 1", got)
+	}
+
+	setRequestMetricTenant(ctx, "tenant-a", "", "", class)
+	if got := m.tenantInFlight[tenantInFlightKey("local", "object_store", "upload_part")]; got != 0 {
+		t.Fatalf("local in-flight after move = %d, want 0", got)
+	}
+	if got := m.tenantInFlight[tenantInFlightKey("tenant-a", "object_store", "upload_part")]; got != 1 {
+		t.Fatalf("tenant-a in-flight = %d, want 1", got)
+	}
+
+	finishRequestMetricTenant(ctx)
+	if got := len(m.tenantInFlight); got != 0 {
+		t.Fatalf("tenant in-flight map size after finish = %d, want 0", got)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -282,8 +282,12 @@ func NewWithConfig(cfg Config) *Server {
 				http.Error(w, "not found", http.StatusNotFound)
 				return
 			}
-			r.URL.Path = "/" + sub
-			localS3.Handler().ServeHTTP(w, r)
+			subReq := r.Clone(r.Context())
+			subURL := *r.URL
+			subURL.Path = "/" + sub
+			subURL.RawPath = ""
+			subReq.URL = &subURL
+			localS3.Handler().ServeHTTP(w, subReq)
 		}))
 	}
 
@@ -1078,6 +1082,7 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "read_presigned_redirect", "path", path)...)
 		metricEvent(r.Context(), "fs_read", "result", "ok")
+		recordTenantFileBytes(r.Context(), "fs", "read", "read", plan.Size)
 		http.Redirect(w, r, plan.PresignURL, http.StatusFound)
 		return
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -282,6 +282,7 @@ func NewWithConfig(cfg Config) *Server {
 				http.Error(w, "not found", http.StatusNotFound)
 				return
 			}
+			setRequestMetricTenant(r.Context(), tenantID, "", "", classifyTenantRequest(r))
 			subReq := r.Clone(r.Context())
 			subURL := *r.URL
 			subURL.Path = "/" + sub
@@ -894,6 +895,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
+	setRequestMetricTenant(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID, resolved.Tenant.Provider, classifyTenantRequest(r))
 	if resolved.APIKey.Status != meta.APIKeyActive {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_key_inactive", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "status", resolved.APIKey.Status)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
@@ -968,6 +970,7 @@ func (s *Server) handleLocalTenantStatus(w http.ResponseWriter, r *http.Request)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
+	setRequestMetricTenant(r.Context(), "local", "local", "local", classifyTenantRequest(r))
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_ok", "tenant_id", "local", "status", "active")...)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(TenantStatusResponse{
@@ -3303,6 +3306,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusInternalServerError, "failed to provision tenant")
 		return
 	}
+	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
 	s.startProvisionedTenantSchemaInit(r.Context(), res)
 
 	w.Header().Set("Content-Type", "application/json")
@@ -3460,6 +3464,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	}
 	tenantID := token.NewID()
 	logger.Info(ctx, "server_event", eventFields(ctx, "provision_requested", "tenant_id", tenantID, "provider", provider)...)
+	setRequestMetricTenant(ctx, tenantID, "", provider, tenantRequestClass{surface: "provision", action: "post"})
 
 	keyName := strings.TrimSpace(opts.KeyName)
 	if keyName == "" {
@@ -3656,6 +3661,7 @@ func (s *Server) issueOwnerAPIKey(ctx context.Context, tenantID, keyName string,
 // compatibility path so e2e scripts can obtain one stable API key without
 // enabling the multi-tenant provision flow.
 func (s *Server) handleLocalTenantProvision(w http.ResponseWriter, r *http.Request) {
+	setRequestMetricTenant(r.Context(), "local", "local", "local", classifyTenantRequest(r))
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_requested", "tenant_id", "local", "provider", "local")...)
 	metricEvent(r.Context(), "tenant_provision", "provider", "local", "result", "ok")
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -513,6 +513,7 @@ func injectFallbackBackend(b *backend.Dat9Backend, next http.Handler) http.Handl
 			Backend:            b,
 			JournalPermissions: ownerJournalPermissions(),
 		}
+		setRequestMetricScope(r.Context(), scope, classifyTenantRequest(r))
 		next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))
 	})
 }
@@ -1090,6 +1091,7 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "read_ok", "path", path, "bytes", len(plan.InlineData))...)
 	metricEvent(r.Context(), "fs_read", "result", "ok")
+	recordTenantFileBytes(r.Context(), "fs", "read", "read", int64(len(plan.InlineData)))
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", strconv.Itoa(len(plan.InlineData)))
 	_, _ = w.Write(plan.InlineData)
@@ -1453,6 +1455,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "write_ok", "path", path, "bytes", len(data))...)
 	metricEvent(r.Context(), "fs_write", "result", "ok")
+	recordTenantFileBytes(r.Context(), "fs", "write", "write", int64(len(data)))
 	s.publishEvent(r, path, "write")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": committedRevision})
 }
@@ -1781,6 +1784,13 @@ func (s *Server) handleBatchReadSmall(w http.ResponseWriter, r *http.Request) {
 		}
 		results[i] = s.batchReadSmallOne(r.Context(), b, path, maxBytes)
 	}
+	var readBytes int64
+	for _, result := range results {
+		if result.Status == http.StatusOK {
+			readBytes += int64(len(result.Data))
+		}
+	}
+	recordTenantFileBytes(r.Context(), "fs", "batch_read_small", "read", readBytes)
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "batch_read_small_ok", "count", len(results), "max_bytes", maxBytes)...)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(batchReadSmallResponse{Results: results})
@@ -2650,6 +2660,7 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_ok", "upload_id", uploadID)...)
 	metricEvent(r.Context(), "upload_complete", "result", "ok")
+	recordTenantFileBytes(r.Context(), "upload", "complete", "write", upload.TotalSize)
 	s.publishEvent(r, upload.TargetPath, "upload_complete")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
@@ -3214,6 +3225,7 @@ func (s *Server) handleV2UploadComplete(w http.ResponseWriter, r *http.Request, 
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_ok", "upload_id", uploadID)...)
 	metricEvent(r.Context(), "v2_upload_complete", "result", "ok")
+	recordTenantFileBytes(r.Context(), "upload", "complete", "write", upload.TotalSize)
 	s.publishEvent(r, upload.TargetPath, "upload_complete")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "completed"})
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1996,43 +1996,63 @@ func TestMetricsEndpoint(t *testing.T) {
 	}
 	body, _ := io.ReadAll(resp.Body)
 	text := string(body)
-	if !strings.Contains(text, "dat9_http_requests_total") {
+	if !strings.Contains(text, "drive9_http_requests_total") {
 		t.Fatalf("expected requests metric in response: %s", text)
 	}
 	if !strings.Contains(text, `route="/v1/fs/*"`) {
 		t.Fatalf("expected fs route metric label in response: %s", text)
 	}
-	if !strings.Contains(text, "dat9_http_inflight_requests") {
+	if !strings.Contains(text, "drive9_http_inflight_requests") {
 		t.Fatalf("expected inflight metric in response: %s", text)
 	}
-	if !strings.Contains(text, `dat9_http_inflight_requests{route="/v1/fs/*"} 0.000000`) {
+	if !strings.Contains(text, `drive9_http_inflight_requests{route="/v1/fs/*"} 0.000000`) {
 		t.Fatalf("expected route-scoped inflight metric in response: %s", text)
 	}
-	if !strings.Contains(text, `dat9_service_operations_total{component="backend",operation="exec_sql",result="ok"}`) {
+	if !strings.Contains(text, `drive9_service_operations_total{component="backend",operation="exec_sql",result="ok"}`) {
 		t.Fatalf("expected backend service metric in response: %s", text)
 	}
-	if !strings.Contains(text, `dat9_http_request_duration_seconds_bucket{method="GET",route="/v1/fs/*",le="0.1"}`) {
+	if !strings.Contains(text, `drive9_http_request_duration_seconds_bucket{method="GET",route="/v1/fs/*",le="0.1"}`) {
 		t.Fatalf("expected http duration histogram bucket in response: %s", text)
 	}
-	if !strings.Contains(text, `dat9_service_operation_duration_seconds_bucket{component="backend",operation="exec_sql",result="ok",le="0.01"}`) {
+	if !strings.Contains(text, `drive9_service_operation_duration_seconds_bucket{component="backend",operation="exec_sql",result="ok",le="0.01"}`) {
 		t.Fatalf("expected service operation histogram bucket in response: %s", text)
 	}
-	if !strings.Contains(text, `dat9_db_operations_total{operation="`) || !strings.Contains(text, `role="user"`) {
+	if !strings.Contains(text, `drive9_db_operations_total{operation="`) || !strings.Contains(text, `role="user"`) {
 		t.Fatalf("expected user db operation metric in response: %s", text)
 	}
-	if strings.Contains(text, `tenant_id="`) {
-		t.Fatalf("expected db operation metrics to avoid tenant_id labels: %s", text)
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "drive9_db_") && strings.Contains(line, `tenant_id="`) {
+			t.Fatalf("expected db operation metrics to avoid tenant_id labels: %s", line)
+		}
 	}
-	if !strings.Contains(text, `dat9_db_pool_registered{role="user"}`) {
+	if !strings.Contains(text, `drive9_db_pool_registered{role="user"}`) {
 		t.Fatalf("expected user db pool metric in response: %s", text)
 	}
-	if !strings.Contains(text, `dat9_tenant_events_total{event="fs_write",result="ok"}`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="write",result="ok",status="200",status_class="2xx",surface="fs",tenant_id="local"}`) {
+		t.Fatalf("expected tenant request usage metric in response: %s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_bucket{action="read",result="ok",status="200",status_class="2xx",surface="fs",tenant_id="local",le="0.1"}`) {
+		t.Fatalf("expected tenant request duration usage metric in response: %s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_inflight_requests{action="read",surface="fs",tenant_id="local"} 0.000000`) {
+		t.Fatalf("expected tenant in-flight usage metric in response: %s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_http_bytes_total{action="write",direction="request",surface="fs",tenant_id="local"}`) {
+		t.Fatalf("expected tenant HTTP byte metric in response: %s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="write",direction="write",surface="fs",tenant_id="local"}`) {
+		t.Fatalf("expected tenant file write byte metric in response: %s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="read",direction="read",surface="fs",tenant_id="local"}`) {
+		t.Fatalf("expected tenant file read byte metric in response: %s", text)
+	}
+	if !strings.Contains(text, `drive9_business_events_total{event="fs_write",result="ok"}`) {
 		t.Fatalf("expected fs_write tenant event metric in response: %s", text)
 	}
-	if !strings.Contains(text, `dat9_tenant_events_total{event="fs_read",result="ok"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="fs_read",result="ok"}`) {
 		t.Fatalf("expected fs_read tenant event metric in response: %s", text)
 	}
-	if !strings.Contains(text, `dat9_tenant_events_total{event="tenant_provision",result="error"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="tenant_provision",result="error"}`) {
 		t.Fatalf("expected tenant_provision error metric in response: %s", text)
 	}
 }
@@ -2100,13 +2120,13 @@ func TestUploadActionMetrics(t *testing.T) {
 	body, _ := io.ReadAll(metricsResp.Body)
 	text := string(body)
 
-	if !strings.Contains(text, `dat9_tenant_events_total{event="upload_complete",result="error"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_complete",result="error"}`) {
 		t.Fatalf("expected upload_complete metric, got: %s", text)
 	}
-	if !strings.Contains(text, `dat9_tenant_events_total{event="upload_resume",result="error"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_resume",result="error"}`) {
 		t.Fatalf("expected upload_resume metric, got: %s", text)
 	}
-	if !strings.Contains(text, `dat9_tenant_events_total{event="upload_abort",result="error"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_abort",result="error"}`) {
 		t.Fatalf("expected upload_abort metric, got: %s", text)
 	}
 }

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -361,13 +361,13 @@ func TestVaultMetricsExposed(t *testing.T) {
 	}
 
 	metricsText := readServerMetrics(t, rt.server)
-	if !strings.Contains(metricsText, "dat9_module_up{module=\"vault\"} 1") {
+	if !strings.Contains(metricsText, "drive9_module_up{module=\"vault\"} 1") {
 		t.Fatalf("metrics missing vault module availability: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_operations_total{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
 		t.Fatalf("metrics missing vault service operation counter: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
 		t.Fatalf("metrics missing vault service duration histogram: %s", metricsText)
 	}
 }

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -430,7 +430,7 @@ func TestRecordTenantSchemaVersionUpdateFailureRecordsMetric(t *testing.T) {
 
 func operationMetricValue(t *testing.T, output, labels string) uint64 {
 	t.Helper()
-	prefix := `dat9_service_operations_total{` + labels + `} `
+	prefix := `drive9_service_operations_total{` + labels + `} `
 	for _, line := range strings.Split(output, "\n") {
 		if !strings.HasPrefix(line, prefix) {
 			continue

--- a/pkg/webdav/fs_test.go
+++ b/pkg/webdav/fs_test.go
@@ -231,13 +231,13 @@ func TestHandlerMetricsExposed(t *testing.T) {
 	}
 
 	metricsText := readWebDAVMetrics()
-	if !strings.Contains(metricsText, "dat9_module_up{module=\"webdav\"} 1") {
+	if !strings.Contains(metricsText, "drive9_module_up{module=\"webdav\"} 1") {
 		t.Fatalf("metrics missing webdav module availability: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_operations_total{component=\"webdav\",operation=\"put\",result=\"conflict\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"webdav\",operation=\"put\",result=\"conflict\"}") {
 		t.Fatalf("metrics missing webdav service counter: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "dat9_service_operation_duration_seconds_count{component=\"webdav\",operation=\"put\",result=\"conflict\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"webdav\",operation=\"put\",result=\"conflict\"}") {
 		t.Fatalf("metrics missing webdav duration histogram: %s", metricsText)
 	}
 }


### PR DESCRIPTION
## Summary
- replace the legacy dat9_* metrics namespace with drive9_* metrics
- add tenant-scoped usage metrics for requests, latency, in-flight requests, transport bytes, logical file IO, and quota snapshots
- add a Drive9 Tenant Usage Grafana dashboard and update existing dashboards to the new metric names
- tighten tenant metric label cardinality for token/upload/S3 paths

## Tests
- env GOCACHE=/tmp/drive9-go-build go test ./...
- find docs/grafana -name '*.json' -exec python3 -m json.tool {} /tmp/drive9-json-check.out \;
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tenant Usage dashboard for per-tenant request activity, IO, storage and quota ratios.
  * Expanded tenant-scoped metrics and recording (requests, durations, in-flight, HTTP/file bytes, storage/media gauges).

* **Documentation**
  * Reorganized Grafana docs to a usage-first workflow and added dashboard-embedded navigation links.
  * Updated many dashboards to reflect the new tenant-focused organization.

* **Breaking Changes**
  * Dashboards now expect metrics under the new drive9_* namespace — external dashboards/alerts require coordinated migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->