### PR TITLE
Add persistent SSE event replay

### DIFF
--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -33,6 +33,7 @@ Tenant usage metrics intentionally allow `tenant_id` as a Prometheus label, but 
 - `drive9-filesystem-path-dashboard.json`: filesystem-path analysis that owns `/v1/fs/*`, correlates HTTP traffic with `fs_*` backend work, and now includes explicit WebDAV behavior.
 - `drive9-upload-path-dashboard.json`: upload-path analysis that owns upload flows and correlates upload HTTP traffic, backend upload operations, and upload-related events.
 - `drive9-upload-s3-path-dashboard.json`: upload plus raw object-store analysis for incidents that have narrowed from upload symptoms into `s3client` throughput, errors, or latency.
+- `drive9-event-stream-dashboard.json`: SSE event-stream analysis for `/v1/events`, durable replay, reset reasons, persistence errors, and retention sweep behavior.
 
 ## 4. Data-store drill-down dashboards
 

--- a/docs/grafana/drive9-event-stream-dashboard.json
+++ b/docs/grafana/drive9-event-stream-dashboard.json
@@ -1,0 +1,347 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "drive9_service_gauge{component=\"sse\",name=\"active_connections\"}",
+          "legendFormat": "active",
+          "refId": "A"
+        }
+      ],
+      "title": "Active SSE Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (operation, result) (rate(drive9_service_operations_total{component=\"sse\"}[$__rate_interval]))",
+          "legendFormat": "{{operation}} {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "SSE Operation Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(drive9_service_operations_total{component=\"sse\",operation=\"reset\"}[$__rate_interval]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "SSE Resets by Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(drive9_service_operation_duration_seconds_bucket{component=\"sse\",operation=~\"persist|replay|retention_sweep\"}[$__rate_interval])) by (le, operation))",
+          "legendFormat": "p95 {{operation}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(drive9_service_operation_duration_seconds_bucket{component=\"sse\",operation=~\"persist|replay|retention_sweep\"}[$__rate_interval])) by (le, operation))",
+          "legendFormat": "p99 {{operation}}",
+          "refId": "B"
+        }
+      ],
+      "title": "SSE Persistence and Replay Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (operation, result) (increase(drive9_service_operations_total{component=\"sse\",operation=~\"persist|replay|retention_sweep\"}[$__range]))",
+          "legendFormat": "{{operation}} {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Durable Event Log Operations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(drive9_service_operations_total{component=\"sse\",operation=\"persist\",result=\"error\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_service_operations_total{component=\"sse\",operation=\"persist\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "persist errors",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(drive9_service_operations_total{component=\"sse\",operation=\"replay\",result=~\"seq_too_old|error\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_service_operations_total{component=\"sse\",operation=\"replay\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "replay miss/error",
+          "refId": "B"
+        }
+      ],
+      "title": "SSE Error Ratios",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "drive9",
+    "event-stream"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Drive9 Event Stream",
+  "uid": "drive9-event-stream",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/specs/cache-invalidation.md
+++ b/docs/specs/cache-invalidation.md
@@ -31,12 +31,11 @@ This spec describes the **target architecture** for P1 cache implementation. The
 
 **API prerequisites** (NOT in scope of this spec, tracked as separate issues):
 
-- **chmod SSE event**: `handleChmod` (server.go:2033-2069) does NOT call `publishEvent`. Remote chmod changes are invisible to other mounts until TTL expiry. Needs server fix.
 - **Directory revision**: `handleStat` only returns `X-Dat9-Revision` when `nf.File != nil` (server.go:1865-1866). Directories have no revision exposed. Until this is fixed, directory cache validity relies on SSE invalidation + TTL only (no revision-based lazy revalidation for directories).
 
 ## 2. Definitions
 
-- **revision**: A monotonically increasing integer assigned by the server to each file mutation. Every write produces a new revision. Note: chmod does NOT currently increment revision or emit SSE (see §1.1 prerequisites).
+- **revision**: A monotonically increasing integer assigned by the server to each file mutation. Every write and chmod produces a new revision.
 - **SSE**: Server-Sent Events stream from `/v1/events`. Delivers `ChangeEvent` (per-path, for write/upload_complete/create/symlink ops), `ResetEvent` (full invalidation, including for structural ops like rename/delete/mkdir/copy), and heartbeat/current markers after replay/reset catch-up.
 - **trusted event stream**: An SSE stream that is safe to use as a freshness guarantee for revision-bound stat-cache hits. The current server event bus is process-local, so the stream is trusted only for single-server/sticky-routing deployments, or for future deployments with a cluster-wide durable event stream. Mounts must fail closed unless the operator explicitly enables this trust boundary.
 - **stale**: Cache entry whose revision is older than the server's current revision for that path.
@@ -122,7 +121,7 @@ Every server mutation maps to exactly one SSE event type. This table is the auth
 | `delete` | ResetEvent | Full (all caches) | Path + parent dir + potential subtree |
 | `mkdir` | ResetEvent | Full (all caches) | Parent dir structure changed |
 | `copy` | ResetEvent | Full (all caches) | Source metadata + dest path + dest parent |
-| `chmod` | *(none)* | *(not invalidated)* | **Known gap**: `handleChmod` does not call `publishEvent` or increment revision. See §1.1 prerequisites. Remote chmod is invisible until TTL expiry. |
+| `chmod` | ChangeEvent | Targeted (path P) | Mode metadata changed |
 
 **Why structural ops use ResetEvent**: Targeted single-path invalidation cannot reliably cover all affected caches. For example, `rename(A, B)` affects: read cache for A, stat cache for A, stat cache for B, dir cache for `parent(A)`, dir cache for `parent(B)`, negative cache for `(parent(B), basename(B))`, and any subtree under A if A is a directory. Full reset is the safe default; future optimization MAY use the `path`/`op` payload fields for targeted invalidation.
 

--- a/internal/testmysql/testmysql.go
+++ b/internal/testmysql/testmysql.go
@@ -78,6 +78,7 @@ func ResetDB(t *testing.T, db *sql.DB) {
 	t.Helper()
 	queries := []string{
 		"DELETE FROM file_gc_tasks",
+		"DELETE FROM fs_events",
 		"DELETE FROM semantic_tasks",
 		"DELETE FROM file_nodes",
 		"DELETE FROM file_tags",
@@ -122,6 +123,7 @@ func ResetDBWithoutFiles(t *testing.T, db *sql.DB) {
 	t.Helper()
 	queries := []string{
 		"DELETE FROM file_gc_tasks",
+		"DELETE FROM fs_events",
 		"DELETE FROM semantic_tasks",
 		"DELETE FROM file_nodes",
 		"DELETE FROM file_tags",

--- a/pkg/backend/schema_test_helper.go
+++ b/pkg/backend/schema_test_helper.go
@@ -47,6 +47,8 @@ func initBackendSchema(t *testing.T, dsn string) {
 		`CREATE INDEX idx_file_gc_claim ON file_gc_tasks(status, available_at, lease_until, created_at)`,
 		`CREATE TABLE IF NOT EXISTS llm_usage (id BIGINT AUTO_INCREMENT PRIMARY KEY, task_type VARCHAR(32) NOT NULL, task_id VARCHAR(64) NOT NULL, cost_millicents BIGINT NOT NULL DEFAULT 0, raw_units BIGINT NOT NULL DEFAULT 0, raw_unit_type VARCHAR(16) NOT NULL, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
 		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
+		`CREATE TABLE IF NOT EXISTS fs_events (seq BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, path VARCHAR(512) NOT NULL, op VARCHAR(64) NOT NULL, actor VARCHAR(255), ts BIGINT NOT NULL, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
+		`CREATE INDEX idx_fs_events_created ON fs_events(created_at)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -132,6 +132,7 @@ func (c *Client) streamEvents(ctx context.Context, since uint64, actor string, h
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 4<<20)
 	var eventType string
 	var dataLines []string
 

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -133,25 +133,30 @@ func (c *Client) streamEvents(ctx context.Context, since uint64, actor string, h
 
 	scanner := bufio.NewScanner(resp.Body)
 	var eventType string
-	var dataLine string
+	var dataLines []string
 
 	for scanner.Scan() {
 		line := scanner.Text()
 
 		if line == "" {
 			// End of event.
-			if dataLine != "" {
-				parseAndDispatch(eventType, dataLine, handler, onCurrent)
+			if len(dataLines) > 0 {
+				parseAndDispatch(eventType, strings.Join(dataLines, "\n"), handler, onCurrent)
 			}
 			eventType = ""
-			dataLine = ""
+			dataLines = nil
 			continue
 		}
 
-		if strings.HasPrefix(line, "event: ") {
-			eventType = strings.TrimPrefix(line, "event: ")
-		} else if strings.HasPrefix(line, "data: ") {
-			dataLine = strings.TrimPrefix(line, "data: ")
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if strings.HasPrefix(line, "event:") {
+			eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		} else if strings.HasPrefix(line, "data:") {
+			data := strings.TrimPrefix(line, "data:")
+			data = strings.TrimPrefix(data, " ")
+			dataLines = append(dataLines, data)
 		}
 	}
 	return scanner.Err()

--- a/pkg/client/events_test.go
+++ b/pkg/client/events_test.go
@@ -1,6 +1,11 @@
 package client
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestParseAndDispatchResetIncludesStructuralFields(t *testing.T) {
 	data := `{"seq":7,"reason":"structural_change","path":"/old","op":"rename","actor":"actor1"}`
@@ -48,5 +53,35 @@ func TestParseAndDispatchHeartbeatMarksStreamCurrent(t *testing.T) {
 	}
 	if gotSeq != 42 {
 		t.Fatalf("current seq = %d, want 42", gotSeq)
+	}
+}
+
+func TestStreamEventsParsesMultilineDataAndComments(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(": comment\n"))
+		_, _ = w.Write([]byte("event: file_changed\n"))
+		_, _ = w.Write([]byte(`data: {"seq":9,` + "\n"))
+		_, _ = w.Write([]byte(`data: "path":"/multi.txt","op":"write","ts":1}` + "\n\n"))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	var got *ChangeEvent
+	err := c.streamEvents(context.Background(), 0, "", func(change *ChangeEvent, reset *ResetEvent) {
+		if reset != nil {
+			t.Fatalf("reset=%+v, want nil", reset)
+		}
+		got = change
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("change event was not dispatched")
+	}
+	if got.Seq != 9 || got.Path != "/multi.txt" || got.Op != "write" {
+		t.Fatalf("change=%+v, want multiline write event", got)
 	}
 }

--- a/pkg/datastore/fs_events.go
+++ b/pkg/datastore/fs_events.go
@@ -1,0 +1,121 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// FSEvent is a durable filesystem mutation event used by the SSE stream.
+type FSEvent struct {
+	Seq   uint64
+	Path  string
+	Op    string
+	Actor string
+	Ts    int64
+}
+
+const defaultFSEventReplayLimit = 10000
+
+// InsertFSEvent appends a durable filesystem event and returns the assigned
+// tenant-local sequence number.
+func (s *Store) InsertFSEvent(ctx context.Context, path, op, actor string) (ev FSEvent, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "insert_fs_event", start, &err)
+
+	ts := time.Now().UnixMilli()
+	res, err := s.db.ExecContext(ctx,
+		`INSERT INTO fs_events (path, op, actor, ts) VALUES (?, ?, ?, ?)`,
+		path, op, nullStr(actor), ts)
+	if err != nil {
+		return FSEvent{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return FSEvent{}, err
+	}
+	return FSEvent{
+		Seq:   uint64(id),
+		Path:  path,
+		Op:    op,
+		Actor: actor,
+		Ts:    ts,
+	}, nil
+}
+
+// FSEventBounds returns the oldest retained sequence, current head sequence,
+// and retained event count.
+func (s *Store) FSEventBounds(ctx context.Context) (oldestSeq, headSeq uint64, count int64, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "fs_event_bounds", start, &err)
+
+	var oldest, head sql.NullInt64
+	err = s.db.QueryRowContext(ctx, `SELECT MIN(seq), MAX(seq), COUNT(*) FROM fs_events`).Scan(&oldest, &head, &count)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if oldest.Valid && oldest.Int64 > 0 {
+		oldestSeq = uint64(oldest.Int64)
+	}
+	if head.Valid && head.Int64 > 0 {
+		headSeq = uint64(head.Int64)
+	}
+	return oldestSeq, headSeq, count, nil
+}
+
+// ListFSEventsSince returns durable events with seq > since, ordered by seq.
+func (s *Store) ListFSEventsSince(ctx context.Context, since uint64, limit int) (events []FSEvent, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "list_fs_events_since", start, &err)
+
+	if limit <= 0 {
+		limit = defaultFSEventReplayLimit
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT seq, path, op, actor, ts
+		 FROM fs_events
+		 WHERE seq > ?
+		 ORDER BY seq ASC
+		 LIMIT ?`, since, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]FSEvent, 0, 64)
+	for rows.Next() {
+		var ev FSEvent
+		var actor sql.NullString
+		if err := rows.Scan(&ev.Seq, &ev.Path, &ev.Op, &actor, &ev.Ts); err != nil {
+			return nil, err
+		}
+		if actor.Valid {
+			ev.Actor = actor.String
+		}
+		out = append(out, ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// PruneFSEventsBefore deletes retained events older than keepFromSeq.
+func (s *Store) PruneFSEventsBefore(ctx context.Context, keepFromSeq uint64) (deleted int64, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "prune_fs_events", start, &err)
+
+	if keepFromSeq == 0 {
+		return 0, nil
+	}
+	res, err := s.db.ExecContext(ctx, `DELETE FROM fs_events WHERE seq < ?`, keepFromSeq)
+	if err != nil {
+		return 0, err
+	}
+	deleted, err = res.RowsAffected()
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	return deleted, err
+}

--- a/pkg/datastore/fs_events.go
+++ b/pkg/datastore/fs_events.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"time"
 )
 
@@ -113,9 +112,5 @@ func (s *Store) PruneFSEventsBefore(ctx context.Context, keepFromSeq uint64) (de
 	if err != nil {
 		return 0, err
 	}
-	deleted, err = res.RowsAffected()
-	if errors.Is(err, sql.ErrNoRows) {
-		return 0, nil
-	}
-	return deleted, err
+	return res.RowsAffected()
 }

--- a/pkg/datastore/fs_events_test.go
+++ b/pkg/datastore/fs_events_test.go
@@ -1,0 +1,87 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFSEventLogInsertBoundsAndReplay(t *testing.T) {
+	s := newTestStore(t)
+	clearFSEventsForTest(t, s)
+	ctx := context.Background()
+
+	ev1, err := s.InsertFSEvent(ctx, "/a.txt", "write", "actor-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev2, err := s.InsertFSEvent(ctx, "/b.txt", "chmod", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev1.Seq == 0 || ev2.Seq != ev1.Seq+1 {
+		t.Fatalf("seqs = %d, %d; want consecutive positive seqs", ev1.Seq, ev2.Seq)
+	}
+
+	oldest, head, count, err := s.FSEventBounds(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldest != ev1.Seq || head != ev2.Seq || count != 2 {
+		t.Fatalf("bounds oldest=%d head=%d count=%d; want %d %d 2", oldest, head, count, ev1.Seq, ev2.Seq)
+	}
+
+	events, err := s.ListFSEventsSince(ctx, ev1.Seq, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(events))
+	}
+	if got := events[0]; got.Seq != ev2.Seq || got.Path != "/b.txt" || got.Op != "chmod" || got.Actor != "" {
+		t.Fatalf("event = %+v, want second chmod event", got)
+	}
+}
+
+func TestFSEventLogPrune(t *testing.T) {
+	s := newTestStore(t)
+	clearFSEventsForTest(t, s)
+	ctx := context.Background()
+
+	ev1, err := s.InsertFSEvent(ctx, "/a.txt", "write", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev2, err := s.InsertFSEvent(ctx, "/b.txt", "write", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deleted, err := s.PruneFSEventsBefore(ctx, ev2.Seq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	oldest, head, count, err := s.FSEventBounds(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldest != ev2.Seq || head != ev2.Seq || count != 1 {
+		t.Fatalf("bounds after prune oldest=%d head=%d count=%d; want %d %d 1", oldest, head, count, ev2.Seq, ev2.Seq)
+	}
+	events, err := s.ListFSEventsSince(ctx, ev1.Seq-1, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Seq != ev2.Seq {
+		t.Fatalf("events after prune = %+v, want only second event", events)
+	}
+}
+
+func clearFSEventsForTest(t *testing.T, s *Store) {
+	t.Helper()
+	if _, err := s.DB().Exec(`DELETE FROM fs_events`); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/datastore/schema_test_helper_test.go
+++ b/pkg/datastore/schema_test_helper_test.go
@@ -49,6 +49,8 @@ func initDatastoreSchema(t *testing.T, dsn string) {
 		`CREATE INDEX idx_file_gc_claim ON file_gc_tasks(status, available_at, lease_until, created_at)`,
 		`CREATE TABLE IF NOT EXISTS llm_usage (id BIGINT AUTO_INCREMENT PRIMARY KEY, task_type VARCHAR(32) NOT NULL, task_id VARCHAR(64) NOT NULL, cost_millicents BIGINT NOT NULL DEFAULT 0, raw_units BIGINT NOT NULL DEFAULT 0, raw_unit_type VARCHAR(16) NOT NULL, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
 		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
+		`CREATE TABLE IF NOT EXISTS fs_events (seq BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, path VARCHAR(512) NOT NULL, op VARCHAR(64) NOT NULL, actor VARCHAR(255), ts BIGINT NOT NULL, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
+		`CREATE INDEX idx_fs_events_created ON fs_events(created_at)`,
 	}
 	stmts = append(stmts, schema.JournalTiDBSchemaStatements()...)
 	for _, stmt := range stmts {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1179,7 +1179,8 @@ func (s *Store) Chmod(ctx context.Context, path string, mode uint32) (err error)
 	}
 
 	var currentMode uint32
-	if err := s.db.QueryRowContext(ctx, `SELECT mode FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED'`, inodeID).Scan(&currentMode); err != nil {
+	var currentMtime, currentConfirmedAt time.Time
+	if err := s.db.QueryRowContext(ctx, `SELECT mode, mtime, confirmed_at FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED'`, inodeID).Scan(&currentMode, &currentMtime, &currentConfirmedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
 		}
@@ -1187,6 +1188,12 @@ func (s *Store) Chmod(ctx context.Context, path string, mode uint32) (err error)
 	}
 	mode = (mode & 0o777) | (currentMode & fileTypeModeMask)
 	now := time.Now().UTC()
+	if !now.After(currentMtime) {
+		now = currentMtime.Add(time.Millisecond)
+	}
+	if !now.After(currentConfirmedAt) {
+		now = currentConfirmedAt.Add(time.Millisecond)
+	}
 	res, err := s.db.ExecContext(ctx, `UPDATE inodes SET mode = ?, revision = revision + 1, mtime = ?, confirmed_at = ? WHERE inode_id = ? AND status = 'CONFIRMED'`, mode, now, now, inodeID)
 	if err != nil {
 		return err

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1186,7 +1186,7 @@ func (s *Store) Chmod(ctx context.Context, path string, mode uint32) (err error)
 		return err
 	}
 	mode = (mode & 0o777) | (currentMode & fileTypeModeMask)
-	res, err := s.db.ExecContext(ctx, `UPDATE inodes SET mode = ? WHERE inode_id = ? AND status = 'CONFIRMED'`, mode, inodeID)
+	res, err := s.db.ExecContext(ctx, `UPDATE inodes SET mode = ?, revision = revision + 1, mtime = CURRENT_TIMESTAMP(3) WHERE inode_id = ? AND status = 'CONFIRMED'`, mode, inodeID)
 	if err != nil {
 		return err
 	}

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1186,7 +1186,8 @@ func (s *Store) Chmod(ctx context.Context, path string, mode uint32) (err error)
 		return err
 	}
 	mode = (mode & 0o777) | (currentMode & fileTypeModeMask)
-	res, err := s.db.ExecContext(ctx, `UPDATE inodes SET mode = ?, revision = revision + 1, mtime = CURRENT_TIMESTAMP(3) WHERE inode_id = ? AND status = 'CONFIRMED'`, mode, inodeID)
+	now := time.Now().UTC()
+	res, err := s.db.ExecContext(ctx, `UPDATE inodes SET mode = ?, revision = revision + 1, mtime = ?, confirmed_at = ? WHERE inode_id = ? AND status = 'CONFIRMED'`, mode, now, now, inodeID)
 	if err != nil {
 		return err
 	}

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -1366,6 +1366,9 @@ func TestChmod(t *testing.T) {
 	if got.Mode != 0o600 {
 		t.Errorf("mode=%o, want 0o600", got.Mode)
 	}
+	if got.Revision != 2 {
+		t.Errorf("revision=%d, want 2", got.Revision)
+	}
 }
 
 func TestChmodRejectsHistoricalRootDentry(t *testing.T) {

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -1354,6 +1354,10 @@ func TestChmod(t *testing.T) {
 	if err := s.InsertNode(ctx, &FileNode{NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
+	var beforeMtime time.Time
+	if err := s.DB().QueryRowContext(ctx, `SELECT mtime FROM inodes WHERE inode_id = ?`, "f1").Scan(&beforeMtime); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.Chmod(ctx, "/a.txt", 0o600); err != nil {
 		t.Fatal(err)
@@ -1368,6 +1372,13 @@ func TestChmod(t *testing.T) {
 	}
 	if got.Revision != 2 {
 		t.Errorf("revision=%d, want 2", got.Revision)
+	}
+	var afterMtime time.Time
+	if err := s.DB().QueryRowContext(ctx, `SELECT mtime FROM inodes WHERE inode_id = ?`, "f1").Scan(&afterMtime); err != nil {
+		t.Fatal(err)
+	}
+	if !afterMtime.After(beforeMtime) {
+		t.Errorf("mtime=%s, want after %s", afterMtime, beforeMtime)
 	}
 }
 

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -1354,6 +1354,10 @@ func TestChmod(t *testing.T) {
 	if err := s.InsertNode(ctx, &FileNode{NodeID: "n1", Path: "/a.txt", ParentPath: "/", Name: "a.txt", FileID: "f1", CreatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
+	fixedTime := time.Now().UTC().Add(time.Hour).Truncate(time.Millisecond)
+	if _, err := s.DB().ExecContext(ctx, `UPDATE inodes SET mtime = ?, confirmed_at = ? WHERE inode_id = ?`, fixedTime, fixedTime, "f1"); err != nil {
+		t.Fatal(err)
+	}
 	var beforeMtime time.Time
 	var beforeConfirmedAt time.Time
 	if err := s.DB().QueryRowContext(ctx, `SELECT mtime, confirmed_at FROM inodes WHERE inode_id = ?`, "f1").Scan(&beforeMtime, &beforeConfirmedAt); err != nil {

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -1355,7 +1355,8 @@ func TestChmod(t *testing.T) {
 		t.Fatal(err)
 	}
 	var beforeMtime time.Time
-	if err := s.DB().QueryRowContext(ctx, `SELECT mtime FROM inodes WHERE inode_id = ?`, "f1").Scan(&beforeMtime); err != nil {
+	var beforeConfirmedAt time.Time
+	if err := s.DB().QueryRowContext(ctx, `SELECT mtime, confirmed_at FROM inodes WHERE inode_id = ?`, "f1").Scan(&beforeMtime, &beforeConfirmedAt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1374,11 +1375,15 @@ func TestChmod(t *testing.T) {
 		t.Errorf("revision=%d, want 2", got.Revision)
 	}
 	var afterMtime time.Time
-	if err := s.DB().QueryRowContext(ctx, `SELECT mtime FROM inodes WHERE inode_id = ?`, "f1").Scan(&afterMtime); err != nil {
+	var afterConfirmedAt time.Time
+	if err := s.DB().QueryRowContext(ctx, `SELECT mtime, confirmed_at FROM inodes WHERE inode_id = ?`, "f1").Scan(&afterMtime, &afterConfirmedAt); err != nil {
 		t.Fatal(err)
 	}
 	if !afterMtime.After(beforeMtime) {
 		t.Errorf("mtime=%s, want after %s", afterMtime, beforeMtime)
+	}
+	if !afterConfirmedAt.After(beforeConfirmedAt) {
+		t.Errorf("confirmed_at=%s, want after %s", afterConfirmedAt, beforeConfirmedAt)
 	}
 }
 

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -9,7 +9,7 @@ import (
 type ChangeEvent struct {
 	Seq   uint64 `json:"seq"`             // monotonic per-bus sequence number
 	Path  string `json:"path"`            // affected path
-	Op    string `json:"op"`              // "write" | "delete" | "rename" | "mkdir" | "copy" | "upload_complete"
+	Op    string `json:"op"`              // filesystem mutation op, for example "write", "delete", "rename", "mkdir", "copy", "upload_complete", or "chmod"
 	Actor string `json:"actor,omitempty"` // X-Dat9-Actor header value (per-mount ID)
 	Ts    int64  `json:"ts"`              // unix milliseconds
 }
@@ -22,6 +22,8 @@ const (
 // EventBus is a per-tenant in-memory event hub backed by a fixed-size ring buffer.
 // Single-instance only — does not survive restarts or replicate across processes.
 type EventBus struct {
+	durableMu sync.Mutex
+
 	mu        sync.Mutex
 	seq       uint64 // monotonic counter, protected by mu
 	ring      [eventBusRingSize]ChangeEvent
@@ -61,6 +63,9 @@ func (eb *EventBus) PublishEvent(ev ChangeEvent) {
 	if ev.Seq == 0 {
 		eb.seq++
 		ev.Seq = eb.seq
+	} else if ev.Seq <= eb.seq {
+		eb.mu.Unlock()
+		return
 	} else if ev.Seq > eb.seq {
 		eb.seq = ev.Seq
 	}

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -22,8 +22,6 @@ const (
 // EventBus is a per-tenant in-memory event hub backed by a fixed-size ring buffer.
 // Single-instance only — does not survive restarts or replicate across processes.
 type EventBus struct {
-	durableMu sync.Mutex
-
 	mu        sync.Mutex
 	seq       uint64 // monotonic counter, protected by mu
 	ring      [eventBusRingSize]ChangeEvent
@@ -124,6 +122,14 @@ func (eb *EventBus) Seq() uint64 {
 	return eb.seq
 }
 
+func (eb *EventBus) AdvanceSeq(seq uint64) {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	if seq > eb.seq {
+		eb.seq = seq
+	}
+}
+
 // EventsSince returns all events with seq > since and the current head seq.
 // If since is too old (ring wrapped), from the future, or zero, ok is false
 // and the caller should send a reset using the returned headSeq.
@@ -150,6 +156,9 @@ func (eb *EventBus) EventsSince(since uint64) (events []ChangeEvent, headSeq uin
 	oldestSeq := eb.ring[oldestIdx].Seq
 	newestSeq := eb.ring[(eb.head-1+eventBusRingSize)%eventBusRingSize].Seq
 
+	if since == maxUint64 {
+		return nil, headSeq, false
+	}
 	if since+1 < oldestSeq {
 		// Ring has wrapped past the client's position.
 		// since+1 is the first seq the client needs; if it's older than

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -55,15 +55,15 @@ func (eb *EventBus) Publish(path, op, actor string) {
 
 // PublishEvent appends an event whose sequence was assigned by a durable event
 // log. It is used by the SSE endpoint so reconnect replay and live delivery use
-// the same cursor space.
+// the same cursor space when possible. If the in-memory cursor is already ahead
+// because of a volatile fallback or out-of-order publish, the event is remapped
+// to the next in-memory sequence so live subscribers still receive the
+// invalidation; reconnecting clients ahead of the durable head will reset.
 func (eb *EventBus) PublishEvent(ev ChangeEvent) {
 	eb.mu.Lock()
-	if ev.Seq == 0 {
+	if ev.Seq == 0 || ev.Seq <= eb.seq {
 		eb.seq++
 		ev.Seq = eb.seq
-	} else if ev.Seq <= eb.seq {
-		eb.mu.Unlock()
-		return
 	} else if ev.Seq > eb.seq {
 		eb.seq = ev.Seq
 	}
@@ -176,11 +176,16 @@ func (eb *EventBus) EventsSince(since uint64) (events []ChangeEvent, headSeq uin
 
 	// Walk the ring from oldest to newest, collecting events with seq > since.
 	result := make([]ChangeEvent, 0, 64)
+	expectedSeq := since + 1
 	for i := 0; i < eb.count; i++ {
 		idx := (oldestIdx + i) % eventBusRingSize
 		ev := eb.ring[idx]
 		if ev.Seq > since {
+			if ev.Seq != expectedSeq {
+				return nil, headSeq, false
+			}
 			result = append(result, ev)
+			expectedSeq++
 		}
 	}
 	return result, headSeq, true

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -7,11 +7,11 @@ import (
 
 // ChangeEvent represents a single filesystem mutation event.
 type ChangeEvent struct {
-	Seq   uint64 `json:"seq"`              // monotonic per-bus sequence number
-	Path  string `json:"path"`             // affected path
-	Op    string `json:"op"`               // "write" | "delete" | "rename" | "mkdir" | "copy" | "upload_complete"
-	Actor string `json:"actor,omitempty"`  // X-Dat9-Actor header value (per-mount ID)
-	Ts    int64  `json:"ts"`               // unix milliseconds
+	Seq   uint64 `json:"seq"`             // monotonic per-bus sequence number
+	Path  string `json:"path"`            // affected path
+	Op    string `json:"op"`              // "write" | "delete" | "rename" | "mkdir" | "copy" | "upload_complete"
+	Actor string `json:"actor,omitempty"` // X-Dat9-Actor header value (per-mount ID)
+	Ts    int64  `json:"ts"`              // unix milliseconds
 }
 
 const (
@@ -49,6 +49,29 @@ func (eb *EventBus) Publish(path, op, actor string) {
 		Actor: actor,
 		Ts:    time.Now().UnixMilli(),
 	}
+	eb.publishLocked(ev)
+	eb.mu.Unlock()
+}
+
+// PublishEvent appends an event whose sequence was assigned by a durable event
+// log. It is used by the SSE endpoint so reconnect replay and live delivery use
+// the same cursor space.
+func (eb *EventBus) PublishEvent(ev ChangeEvent) {
+	eb.mu.Lock()
+	if ev.Seq == 0 {
+		eb.seq++
+		ev.Seq = eb.seq
+	} else if ev.Seq > eb.seq {
+		eb.seq = ev.Seq
+	}
+	if ev.Ts == 0 {
+		ev.Ts = time.Now().UnixMilli()
+	}
+	eb.publishLocked(ev)
+	eb.mu.Unlock()
+}
+
+func (eb *EventBus) publishLocked(ev ChangeEvent) {
 	eb.ring[eb.head] = ev
 	eb.head = (eb.head + 1) % eventBusRingSize
 	if eb.count < eventBusRingSize {
@@ -62,7 +85,6 @@ func (eb *EventBus) Publish(path, op, actor string) {
 		default:
 		}
 	}
-	eb.mu.Unlock()
 }
 
 // Subscribe registers a new listener. Returns a unique ID and a signal channel.

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -17,6 +17,7 @@ type ChangeEvent struct {
 const (
 	eventBusRingSize         = 10000
 	eventBusListenerChanSize = 1 // signal-only channel
+	eventBusForceResetOp     = "__sse_force_reset__"
 )
 
 // EventBus is a per-tenant in-memory event hub backed by a fixed-size ring buffer.
@@ -55,15 +56,18 @@ func (eb *EventBus) Publish(path, op, actor string) {
 
 // PublishEvent appends an event whose sequence was assigned by a durable event
 // log. It is used by the SSE endpoint so reconnect replay and live delivery use
-// the same cursor space when possible. If the in-memory cursor is already ahead
-// because of a volatile fallback or out-of-order publish, the event is remapped
-// to the next in-memory sequence so live subscribers still receive the
-// invalidation; reconnecting clients ahead of the durable head will reset.
+// the same cursor space when possible. If the durable event arrives out of order
+// or behind a volatile fallback cursor, publish a reset signal instead of
+// renumbering the durable event into a different live ordering.
 func (eb *EventBus) PublishEvent(ev ChangeEvent) {
 	eb.mu.Lock()
-	if ev.Seq == 0 || ev.Seq <= eb.seq {
+	if ev.Seq == 0 {
 		eb.seq++
 		ev.Seq = eb.seq
+	} else if eb.seq > 0 && ev.Seq != eb.seq+1 {
+		eb.publishResetLocked()
+		eb.mu.Unlock()
+		return
 	} else if ev.Seq > eb.seq {
 		eb.seq = ev.Seq
 	}
@@ -72,6 +76,15 @@ func (eb *EventBus) PublishEvent(ev ChangeEvent) {
 	}
 	eb.publishLocked(ev)
 	eb.mu.Unlock()
+}
+
+func (eb *EventBus) publishResetLocked() {
+	eb.seq++
+	eb.publishLocked(ChangeEvent{
+		Seq: eb.seq,
+		Op:  eventBusForceResetOp,
+		Ts:  time.Now().UnixMilli(),
+	})
 }
 
 func (eb *EventBus) publishLocked(ev ChangeEvent) {

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -59,6 +59,23 @@ func TestEventBusReplay(t *testing.T) {
 	}
 }
 
+func TestEventBusPublishEventIgnoresOlderSeq(t *testing.T) {
+	bus := NewEventBus()
+	bus.PublishEvent(ChangeEvent{Seq: 2, Path: "/b.txt", Op: "write", Ts: 1})
+	bus.PublishEvent(ChangeEvent{Seq: 1, Path: "/a.txt", Op: "write", Ts: 1})
+
+	if got := bus.Seq(); got != 2 {
+		t.Fatalf("seq=%d, want 2", got)
+	}
+	events, _, ok := bus.EventsSince(1)
+	if !ok {
+		t.Fatal("EventsSince(1) returned not ok")
+	}
+	if len(events) != 1 || events[0].Seq != 2 || events[0].Path != "/b.txt" {
+		t.Fatalf("events=%+v, want only seq 2", events)
+	}
+}
+
 func TestEventBusCaughtUp(t *testing.T) {
 	bus := NewEventBus()
 	bus.Publish("/a.txt", "write", "")

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -59,20 +59,59 @@ func TestEventBusReplay(t *testing.T) {
 	}
 }
 
-func TestEventBusPublishEventIgnoresOlderSeq(t *testing.T) {
+func TestEventBusPublishEventRemapsOlderSeq(t *testing.T) {
 	bus := NewEventBus()
 	bus.PublishEvent(ChangeEvent{Seq: 2, Path: "/b.txt", Op: "write", Ts: 1})
 	bus.PublishEvent(ChangeEvent{Seq: 1, Path: "/a.txt", Op: "write", Ts: 1})
 
-	if got := bus.Seq(); got != 2 {
-		t.Fatalf("seq=%d, want 2", got)
+	if got := bus.Seq(); got != 3 {
+		t.Fatalf("seq=%d, want 3", got)
 	}
 	events, _, ok := bus.EventsSince(1)
 	if !ok {
 		t.Fatal("EventsSince(1) returned not ok")
 	}
-	if len(events) != 1 || events[0].Seq != 2 || events[0].Path != "/b.txt" {
-		t.Fatalf("events=%+v, want only seq 2", events)
+	if len(events) != 2 || events[0].Seq != 2 || events[1].Seq != 3 || events[1].Path != "/a.txt" {
+		t.Fatalf("events=%+v, want seq 2 then remapped seq 3", events)
+	}
+}
+
+func TestEventBusEventsSinceRejectsSeqGaps(t *testing.T) {
+	bus := NewEventBus()
+	bus.PublishEvent(ChangeEvent{Seq: 1, Path: "/a.txt", Op: "write", Ts: 1})
+	bus.AdvanceSeq(2)
+	bus.PublishEvent(ChangeEvent{Seq: 3, Path: "/c.txt", Op: "write", Ts: 1})
+
+	events, headSeq, ok := bus.EventsSince(1)
+	if ok {
+		t.Fatalf("EventsSince(1) ok=true events=%+v, want reset for missing seq 2", events)
+	}
+	if headSeq != 3 {
+		t.Fatalf("headSeq=%d, want 3", headSeq)
+	}
+}
+
+func TestEventBusPublishEventRemapsAfterVolatileFallbackCollision(t *testing.T) {
+	bus := NewEventBus()
+	bus.AdvanceSeq(5)
+	bus.Publish("/volatile.txt", "write", "")
+	bus.PublishEvent(ChangeEvent{Seq: 6, Path: "/durable.txt", Op: "chmod", Ts: 1})
+
+	events, headSeq, ok := bus.EventsSince(5)
+	if !ok {
+		t.Fatal("EventsSince(5) returned not ok")
+	}
+	if headSeq != 7 {
+		t.Fatalf("headSeq=%d, want 7", headSeq)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events len=%d, want 2: %+v", len(events), events)
+	}
+	if events[0].Seq != 6 || events[0].Path != "/volatile.txt" {
+		t.Fatalf("first event=%+v, want volatile seq 6", events[0])
+	}
+	if events[1].Seq != 7 || events[1].Path != "/durable.txt" {
+		t.Fatalf("second event=%+v, want durable remapped to seq 7", events[1])
 	}
 }
 

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -59,7 +59,7 @@ func TestEventBusReplay(t *testing.T) {
 	}
 }
 
-func TestEventBusPublishEventRemapsOlderSeq(t *testing.T) {
+func TestEventBusPublishEventForcesResetForOlderSeq(t *testing.T) {
 	bus := NewEventBus()
 	bus.PublishEvent(ChangeEvent{Seq: 2, Path: "/b.txt", Op: "write", Ts: 1})
 	bus.PublishEvent(ChangeEvent{Seq: 1, Path: "/a.txt", Op: "write", Ts: 1})
@@ -71,8 +71,8 @@ func TestEventBusPublishEventRemapsOlderSeq(t *testing.T) {
 	if !ok {
 		t.Fatal("EventsSince(1) returned not ok")
 	}
-	if len(events) != 2 || events[0].Seq != 2 || events[1].Seq != 3 || events[1].Path != "/a.txt" {
-		t.Fatalf("events=%+v, want seq 2 then remapped seq 3", events)
+	if len(events) != 2 || events[0].Seq != 2 || events[1].Seq != 3 || events[1].Op != eventBusForceResetOp {
+		t.Fatalf("events=%+v, want seq 2 then force-reset seq 3", events)
 	}
 }
 
@@ -91,7 +91,7 @@ func TestEventBusEventsSinceRejectsSeqGaps(t *testing.T) {
 	}
 }
 
-func TestEventBusPublishEventRemapsAfterVolatileFallbackCollision(t *testing.T) {
+func TestEventBusPublishEventForcesResetAfterVolatileFallbackCollision(t *testing.T) {
 	bus := NewEventBus()
 	bus.AdvanceSeq(5)
 	bus.Publish("/volatile.txt", "write", "")
@@ -110,8 +110,8 @@ func TestEventBusPublishEventRemapsAfterVolatileFallbackCollision(t *testing.T) 
 	if events[0].Seq != 6 || events[0].Path != "/volatile.txt" {
 		t.Fatalf("first event=%+v, want volatile seq 6", events[0])
 	}
-	if events[1].Seq != 7 || events[1].Path != "/durable.txt" {
-		t.Fatalf("second event=%+v, want durable remapped to seq 7", events[1])
+	if events[1].Seq != 7 || events[1].Op != eventBusForceResetOp {
+		t.Fatalf("second event=%+v, want force-reset seq 7", events[1])
 	}
 }
 

--- a/pkg/server/schema_test_helper.go
+++ b/pkg/server/schema_test_helper.go
@@ -50,6 +50,8 @@ func initServerTenantSchema(t *testing.T, dsn string) {
 		`CREATE TABLE IF NOT EXISTS llm_usage (id BIGINT AUTO_INCREMENT PRIMARY KEY, tenant_id VARCHAR(64) NOT NULL, task_type VARCHAR(64) NOT NULL, task_id VARCHAR(255) NOT NULL, cost_millicents BIGINT NOT NULL DEFAULT 0, raw_units BIGINT NOT NULL DEFAULT 0, raw_unit_type VARCHAR(32) NOT NULL DEFAULT '', created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
 		`CREATE INDEX idx_llm_usage_tenant_created ON llm_usage(tenant_id, created_at)`,
 		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
+		`CREATE TABLE IF NOT EXISTS fs_events (seq BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, path VARCHAR(512) NOT NULL, op VARCHAR(64) NOT NULL, actor VARCHAR(255), ts BIGINT NOT NULL, created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))`,
+		`CREATE INDEX idx_fs_events_created ON fs_events(created_at)`,
 	}
 	stmts = append(stmts, schema.JournalTiDBSchemaStatements()...)
 	for _, stmt := range stmts {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2278,6 +2278,7 @@ func (s *Server) handleChmod(w http.ResponseWriter, r *http.Request, path string
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "chmod_ok", "path", path)...)
+	s.publishEvent(r, path, "chmod")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -91,6 +91,7 @@ type Server struct {
 	logger              *zap.Logger
 	mux                 *http.ServeMux
 	events              *eventBuses
+	sseRetention        *sseRetentionSweeper
 	semanticWorker      *semanticWorkerManager
 	journalCursorSecret []byte
 	objectGCWorker      *objectGCWorker
@@ -193,6 +194,7 @@ func NewWithConfig(cfg Config) *Server {
 		metrics:           newServerMetrics(),
 		logger:            logger,
 		events:            newEventBuses(),
+		sseRetention:      newSSERetentionSweeper(),
 		slockOAuth:        cfg.SlockOAuth,
 		tidbAutoEmbedding: tenantAutoEmbeddingDefault{
 			config:  defaultTiDBAutoEmbeddingConfig(cfg.TiDBAutoEmbeddingConfig),

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
+	maxUint64                = ^uint64(0)
 	sseHeartbeatInterval     = 30 * time.Second
 	sseFlushBatchSize        = 10
 	sseFlushMaxDelay         = 1 * time.Millisecond
-	ssePersistTimeout        = 5 * time.Second
+	ssePersistTimeout        = 500 * time.Millisecond
 	ssePersistentReplayLimit = eventBusRingSize
 	ssePersistentRetention   = eventBusRingSize * 10
 )
@@ -36,6 +37,7 @@ const (
 	sseResultInitialSync     sseOperationResult = "initial_sync"
 	sseResultSeqTooOld       sseOperationResult = "seq_too_old"
 	sseResultServerRestart   sseOperationResult = "server_restart"
+	sseResultNoHistory       sseOperationResult = "no_history"
 	sseResultStructural      sseOperationResult = "structural_change"
 	sseResultClientCancelled sseOperationResult = "client_cancelled"
 	sseResultServerClosed    sseOperationResult = "server_closed"
@@ -173,9 +175,6 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 	actor := r.Header.Get("X-Dat9-Actor")
 	bus := s.tenantEventBus(r)
 	if b := backendFromRequest(r); b != nil && b.Store() != nil {
-		bus.durableMu.Lock()
-		defer bus.durableMu.Unlock()
-
 		persistCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), ssePersistTimeout)
 		defer cancel()
 
@@ -204,7 +203,6 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "sse_persist_failed", "path", path, "op", op, "error", err)...)
 		recordSSEOperation("persist", sseResultError, persistStart)
-		return
 	}
 	start := time.Now()
 	bus.Publish(path, op, actor)
@@ -254,6 +252,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// in-memory ring remains the live fan-out path and fallback for tests /
 	// single-tenant setups without a scoped backend.
 	events, headSeq, ok, replayReason := s.eventsSince(r.Context(), bStoreFromRequest(r), bus, since)
+	bus.AdvanceSeq(headSeq)
 	lastSeen := since
 
 	bw := newSSEBufferedWriter(w, flusher)
@@ -411,10 +410,14 @@ func persistentEventsSince(ctx context.Context, store *datastore.Store, since ui
 		return nil, headSeq, false, sseResultInitialSync, nil
 	}
 	if count == 0 {
+		recordSSEOperation("replay", sseResultNoHistory, start)
+		return nil, headSeq, false, sseResultNoHistory, nil
+	}
+	if since > headSeq {
 		recordSSEOperation("replay", sseResultServerRestart, start)
 		return nil, headSeq, false, sseResultServerRestart, nil
 	}
-	if since > headSeq {
+	if since == maxUint64 {
 		recordSSEOperation("replay", sseResultServerRestart, start)
 		return nil, headSeq, false, sseResultServerRestart, nil
 	}

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -8,16 +8,23 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/logger"
+	"github.com/mem9-ai/dat9/pkg/metrics"
 )
 
 const (
-	sseHeartbeatInterval = 30 * time.Second
-	sseFlushBatchSize    = 10
-	sseFlushMaxDelay     = 1 * time.Millisecond
+	sseHeartbeatInterval     = 30 * time.Second
+	sseFlushBatchSize        = 10
+	sseFlushMaxDelay         = 1 * time.Millisecond
+	ssePersistentReplayLimit = eventBusRingSize
+	ssePersistentRetention   = eventBusRingSize * 10
 )
+
+var sseActiveConnections atomic.Int64
 
 // stopTimer drains a timer's channel after stopping it to prevent spurious
 // ticks. Returns true if the timer was stopped before it fired.
@@ -150,7 +157,33 @@ func (s *Server) tenantEventBus(r *http.Request) *EventBus {
 func (s *Server) publishEvent(r *http.Request, path, op string) {
 	actor := r.Header.Get("X-Dat9-Actor")
 	bus := s.tenantEventBus(r)
+	start := time.Now()
+	if b := backendFromRequest(r); b != nil && b.Store() != nil {
+		ev, err := b.Store().InsertFSEvent(r.Context(), path, op, actor)
+		if err == nil {
+			recordSSEOperation("persist", "ok", start)
+			if ev.Seq > ssePersistentRetention {
+				if _, pruneErr := b.Store().PruneFSEventsBefore(r.Context(), ev.Seq-ssePersistentRetention+1); pruneErr != nil {
+					recordSSEOperation("retention_sweep", "error", start)
+				} else {
+					recordSSEOperation("retention_sweep", "ok", start)
+				}
+			}
+			bus.PublishEvent(ChangeEvent{
+				Seq:   ev.Seq,
+				Path:  ev.Path,
+				Op:    ev.Op,
+				Actor: ev.Actor,
+				Ts:    ev.Ts,
+			})
+			recordSSEOperation("publish", "ok", start)
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "sse_persist_failed", "path", path, "op", op, "error", err)...)
+		recordSSEOperation("persist", "error", start)
+	}
 	bus.Publish(path, op, actor)
+	recordSSEOperation("publish", "volatile", start)
 }
 
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
@@ -186,26 +219,23 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
+	metrics.RecordGauge("sse", "active_connections", float64(sseActiveConnections.Add(1)))
+	defer metrics.RecordGauge("sse", "active_connections", float64(sseActiveConnections.Add(-1)))
 
 	ctx := r.Context()
 
 	// Phase 1: Replay or Reset.
-	// EventsSince returns headSeq from the same lock acquisition as the
-	// ring scan, so reset cursor and ring state are a consistent snapshot.
-	events, headSeq, ok := bus.EventsSince(since)
+	// Prefer the durable event log when tenant storage is available. The
+	// in-memory ring remains the live fan-out path and fallback for tests /
+	// single-tenant setups without a scoped backend.
+	events, headSeq, ok, replayReason := s.eventsSince(r.Context(), bStoreFromRequest(r), bus, since)
 	lastSeen := since
 
 	bw := newSSEBufferedWriter(w, flusher)
 
 	if !ok {
-		reason := "initial_sync"
-		if since > 0 {
-			reason = "seq_too_old"
-			if since > headSeq {
-				reason = "server_restart"
-			}
-		}
-		sendSSEReset(bw, headSeq, reason)
+		sendSSEReset(bw, headSeq, replayReason)
+		recordSSEOperation("reset", replayReason, time.Time{})
 		lastSeen = headSeq
 	} else {
 		for _, ev := range events {
@@ -244,6 +274,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case <-ctx.Done():
+			recordSSEOperation("disconnect", "client_cancelled", time.Time{})
 			return
 		case <-heartbeat.C:
 			sendSSEHeartbeat(bw, lastSeen)
@@ -263,6 +294,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			flushC = nil
 		case _, open := <-notify:
 			if !open {
+				recordSSEOperation("disconnect", "server_closed", time.Time{})
 				return
 			}
 			liveEvents, liveHead, liveOK := bus.EventsSince(lastSeen)
@@ -309,6 +341,96 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+}
+
+func bStoreFromRequest(r *http.Request) *datastore.Store {
+	b := backendFromRequest(r)
+	if b == nil {
+		return nil
+	}
+	return b.Store()
+}
+
+func (s *Server) eventsSince(ctx context.Context, store *datastore.Store, bus *EventBus, since uint64) ([]ChangeEvent, uint64, bool, string) {
+	if store != nil {
+		events, headSeq, ok, reason, err := persistentEventsSince(ctx, store, since)
+		if err == nil {
+			return events, headSeq, ok, reason
+		}
+		logger.Error(ctx, "server_event", eventFields(ctx, "sse_replay_persistent_failed", "error", err)...)
+	}
+	events, headSeq, ok := bus.EventsSince(since)
+	if !ok {
+		reason := "initial_sync"
+		if since > 0 {
+			reason = "seq_too_old"
+			if since > headSeq {
+				reason = "server_restart"
+			}
+		}
+		return nil, headSeq, false, reason
+	}
+	return events, headSeq, true, ""
+}
+
+func persistentEventsSince(ctx context.Context, store *datastore.Store, since uint64) ([]ChangeEvent, uint64, bool, string, error) {
+	start := time.Now()
+	oldestSeq, headSeq, count, err := store.FSEventBounds(ctx)
+	if err != nil {
+		recordSSEOperation("replay", "error", start)
+		return nil, 0, false, "", err
+	}
+
+	if since == 0 {
+		recordSSEOperation("replay", "initial_sync", start)
+		return nil, headSeq, false, "initial_sync", nil
+	}
+	if count == 0 {
+		recordSSEOperation("replay", "server_restart", start)
+		return nil, headSeq, false, "server_restart", nil
+	}
+	if since > headSeq {
+		recordSSEOperation("replay", "server_restart", start)
+		return nil, headSeq, false, "server_restart", nil
+	}
+	if oldestSeq > 0 && since+1 < oldestSeq {
+		recordSSEOperation("replay", "seq_too_old", start)
+		return nil, headSeq, false, "seq_too_old", nil
+	}
+	if since == headSeq {
+		recordSSEOperation("replay", "ok", start)
+		return nil, headSeq, true, "", nil
+	}
+
+	events, err := store.ListFSEventsSince(ctx, since, ssePersistentReplayLimit+1)
+	if err != nil {
+		recordSSEOperation("replay", "error", start)
+		return nil, 0, false, "", err
+	}
+	if len(events) > ssePersistentReplayLimit {
+		recordSSEOperation("replay", "seq_too_old", start)
+		return nil, headSeq, false, "seq_too_old", nil
+	}
+	out := make([]ChangeEvent, 0, len(events))
+	for _, ev := range events {
+		out = append(out, ChangeEvent{
+			Seq:   ev.Seq,
+			Path:  ev.Path,
+			Op:    ev.Op,
+			Actor: ev.Actor,
+			Ts:    ev.Ts,
+		})
+	}
+	recordSSEOperation("replay", "ok", start)
+	return out, headSeq, true, "", nil
+}
+
+func recordSSEOperation(operation, result string, start time.Time) {
+	var d time.Duration
+	if !start.IsZero() {
+		d = time.Since(start)
+	}
+	metrics.RecordOperation("sse", operation, result, d)
 }
 
 // isStructuralOp returns true for operations that change namespace structure

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -20,11 +20,26 @@ const (
 	sseHeartbeatInterval     = 30 * time.Second
 	sseFlushBatchSize        = 10
 	sseFlushMaxDelay         = 1 * time.Millisecond
+	ssePersistTimeout        = 5 * time.Second
 	ssePersistentReplayLimit = eventBusRingSize
 	ssePersistentRetention   = eventBusRingSize * 10
 )
 
 var sseActiveConnections atomic.Int64
+
+type sseOperationResult string
+
+const (
+	sseResultOK              sseOperationResult = "ok"
+	sseResultError           sseOperationResult = "error"
+	sseResultVolatile        sseOperationResult = "volatile"
+	sseResultInitialSync     sseOperationResult = "initial_sync"
+	sseResultSeqTooOld       sseOperationResult = "seq_too_old"
+	sseResultServerRestart   sseOperationResult = "server_restart"
+	sseResultStructural      sseOperationResult = "structural_change"
+	sseResultClientCancelled sseOperationResult = "client_cancelled"
+	sseResultServerClosed    sseOperationResult = "server_closed"
+)
 
 // stopTimer drains a timer's channel after stopping it to prevent spurious
 // ticks. Returns true if the timer was stopped before it fired.
@@ -157,18 +172,26 @@ func (s *Server) tenantEventBus(r *http.Request) *EventBus {
 func (s *Server) publishEvent(r *http.Request, path, op string) {
 	actor := r.Header.Get("X-Dat9-Actor")
 	bus := s.tenantEventBus(r)
-	start := time.Now()
 	if b := backendFromRequest(r); b != nil && b.Store() != nil {
-		ev, err := b.Store().InsertFSEvent(r.Context(), path, op, actor)
+		bus.durableMu.Lock()
+		defer bus.durableMu.Unlock()
+
+		persistCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), ssePersistTimeout)
+		defer cancel()
+
+		persistStart := time.Now()
+		ev, err := b.Store().InsertFSEvent(persistCtx, path, op, actor)
 		if err == nil {
-			recordSSEOperation("persist", "ok", start)
+			recordSSEOperation("persist", sseResultOK, persistStart)
 			if ev.Seq > ssePersistentRetention {
-				if _, pruneErr := b.Store().PruneFSEventsBefore(r.Context(), ev.Seq-ssePersistentRetention+1); pruneErr != nil {
-					recordSSEOperation("retention_sweep", "error", start)
+				pruneStart := time.Now()
+				if _, pruneErr := b.Store().PruneFSEventsBefore(persistCtx, ev.Seq-ssePersistentRetention+1); pruneErr != nil {
+					recordSSEOperation("retention_sweep", sseResultError, pruneStart)
 				} else {
-					recordSSEOperation("retention_sweep", "ok", start)
+					recordSSEOperation("retention_sweep", sseResultOK, pruneStart)
 				}
 			}
+			publishStart := time.Now()
 			bus.PublishEvent(ChangeEvent{
 				Seq:   ev.Seq,
 				Path:  ev.Path,
@@ -176,14 +199,16 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 				Actor: ev.Actor,
 				Ts:    ev.Ts,
 			})
-			recordSSEOperation("publish", "ok", start)
+			recordSSEOperation("publish", sseResultOK, publishStart)
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "sse_persist_failed", "path", path, "op", op, "error", err)...)
-		recordSSEOperation("persist", "error", start)
+		recordSSEOperation("persist", sseResultError, persistStart)
+		return
 	}
+	start := time.Now()
 	bus.Publish(path, op, actor)
-	recordSSEOperation("publish", "volatile", start)
+	recordSSEOperation("publish", sseResultVolatile, start)
 }
 
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
@@ -274,7 +299,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case <-ctx.Done():
-			recordSSEOperation("disconnect", "client_cancelled", time.Time{})
+			recordSSEOperation("disconnect", sseResultClientCancelled, time.Time{})
 			return
 		case <-heartbeat.C:
 			sendSSEHeartbeat(bw, lastSeen)
@@ -294,14 +319,14 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			flushC = nil
 		case _, open := <-notify:
 			if !open {
-				recordSSEOperation("disconnect", "server_closed", time.Time{})
+				recordSSEOperation("disconnect", sseResultServerClosed, time.Time{})
 				return
 			}
 			liveEvents, liveHead, liveOK := bus.EventsSince(lastSeen)
 			if !liveOK {
 				// Reset must be sent immediately; buffering it would stall
 				// the client until the next heartbeat or unrelated event.
-				sendSSEReset(bw, liveHead, "seq_too_old")
+				sendSSEReset(bw, liveHead, sseResultSeqTooOld)
 				lastSeen = liveHead
 				if err := bw.Flush(); err != nil {
 					return
@@ -351,7 +376,7 @@ func bStoreFromRequest(r *http.Request) *datastore.Store {
 	return b.Store()
 }
 
-func (s *Server) eventsSince(ctx context.Context, store *datastore.Store, bus *EventBus, since uint64) ([]ChangeEvent, uint64, bool, string) {
+func (s *Server) eventsSince(ctx context.Context, store *datastore.Store, bus *EventBus, since uint64) ([]ChangeEvent, uint64, bool, sseOperationResult) {
 	if store != nil {
 		events, headSeq, ok, reason, err := persistentEventsSince(ctx, store, since)
 		if err == nil {
@@ -361,11 +386,11 @@ func (s *Server) eventsSince(ctx context.Context, store *datastore.Store, bus *E
 	}
 	events, headSeq, ok := bus.EventsSince(since)
 	if !ok {
-		reason := "initial_sync"
+		reason := sseResultInitialSync
 		if since > 0 {
-			reason = "seq_too_old"
+			reason = sseResultSeqTooOld
 			if since > headSeq {
-				reason = "server_restart"
+				reason = sseResultServerRestart
 			}
 		}
 		return nil, headSeq, false, reason
@@ -373,46 +398,55 @@ func (s *Server) eventsSince(ctx context.Context, store *datastore.Store, bus *E
 	return events, headSeq, true, ""
 }
 
-func persistentEventsSince(ctx context.Context, store *datastore.Store, since uint64) ([]ChangeEvent, uint64, bool, string, error) {
+func persistentEventsSince(ctx context.Context, store *datastore.Store, since uint64) ([]ChangeEvent, uint64, bool, sseOperationResult, error) {
 	start := time.Now()
 	oldestSeq, headSeq, count, err := store.FSEventBounds(ctx)
 	if err != nil {
-		recordSSEOperation("replay", "error", start)
+		recordSSEOperation("replay", sseResultError, start)
 		return nil, 0, false, "", err
 	}
 
 	if since == 0 {
-		recordSSEOperation("replay", "initial_sync", start)
-		return nil, headSeq, false, "initial_sync", nil
+		recordSSEOperation("replay", sseResultInitialSync, start)
+		return nil, headSeq, false, sseResultInitialSync, nil
 	}
 	if count == 0 {
-		recordSSEOperation("replay", "server_restart", start)
-		return nil, headSeq, false, "server_restart", nil
+		recordSSEOperation("replay", sseResultServerRestart, start)
+		return nil, headSeq, false, sseResultServerRestart, nil
 	}
 	if since > headSeq {
-		recordSSEOperation("replay", "server_restart", start)
-		return nil, headSeq, false, "server_restart", nil
+		recordSSEOperation("replay", sseResultServerRestart, start)
+		return nil, headSeq, false, sseResultServerRestart, nil
 	}
 	if oldestSeq > 0 && since+1 < oldestSeq {
-		recordSSEOperation("replay", "seq_too_old", start)
-		return nil, headSeq, false, "seq_too_old", nil
+		recordSSEOperation("replay", sseResultSeqTooOld, start)
+		return nil, headSeq, false, sseResultSeqTooOld, nil
 	}
 	if since == headSeq {
-		recordSSEOperation("replay", "ok", start)
+		recordSSEOperation("replay", sseResultOK, start)
 		return nil, headSeq, true, "", nil
 	}
 
 	events, err := store.ListFSEventsSince(ctx, since, ssePersistentReplayLimit+1)
 	if err != nil {
-		recordSSEOperation("replay", "error", start)
+		recordSSEOperation("replay", sseResultError, start)
 		return nil, 0, false, "", err
 	}
 	if len(events) > ssePersistentReplayLimit {
-		recordSSEOperation("replay", "seq_too_old", start)
-		return nil, headSeq, false, "seq_too_old", nil
+		recordSSEOperation("replay", sseResultSeqTooOld, start)
+		return nil, headSeq, false, sseResultSeqTooOld, nil
+	}
+	if len(events) == 0 {
+		recordSSEOperation("replay", sseResultSeqTooOld, start)
+		return nil, headSeq, false, sseResultSeqTooOld, nil
 	}
 	out := make([]ChangeEvent, 0, len(events))
+	expectedSeq := since + 1
 	for _, ev := range events {
+		if ev.Seq != expectedSeq {
+			recordSSEOperation("replay", sseResultSeqTooOld, start)
+			return nil, headSeq, false, sseResultSeqTooOld, nil
+		}
 		out = append(out, ChangeEvent{
 			Seq:   ev.Seq,
 			Path:  ev.Path,
@@ -420,17 +454,18 @@ func persistentEventsSince(ctx context.Context, store *datastore.Store, since ui
 			Actor: ev.Actor,
 			Ts:    ev.Ts,
 		})
+		expectedSeq++
 	}
-	recordSSEOperation("replay", "ok", start)
+	recordSSEOperation("replay", sseResultOK, start)
 	return out, headSeq, true, "", nil
 }
 
-func recordSSEOperation(operation, result string, start time.Time) {
+func recordSSEOperation(operation string, result sseOperationResult, start time.Time) {
 	var d time.Duration
 	if !start.IsZero() {
 		d = time.Since(start)
 	}
-	metrics.RecordOperation("sse", operation, result, d)
+	metrics.RecordOperation("sse", operation, string(result), d)
 }
 
 // isStructuralOp returns true for operations that change namespace structure
@@ -472,7 +507,7 @@ type sseResetPayload struct {
 func sendSSEStructuralReset(w *sseBufferedWriter, ev ChangeEvent) {
 	data, _ := json.Marshal(sseResetPayload{
 		Seq:    ev.Seq,
-		Reason: "structural_change",
+		Reason: string(sseResultStructural),
 		Path:   ev.Path,
 		Op:     ev.Op,
 		Actor:  ev.Actor,
@@ -482,10 +517,10 @@ func sendSSEStructuralReset(w *sseBufferedWriter, ev ChangeEvent) {
 	}
 }
 
-func sendSSEReset(w *sseBufferedWriter, seq uint64, reason string) {
+func sendSSEReset(w *sseBufferedWriter, seq uint64, reason sseOperationResult) {
 	data, _ := json.Marshal(sseResetPayload{
 		Seq:    seq,
-		Reason: reason,
+		Reason: string(reason),
 	})
 	if _, err := fmt.Fprintf(w, "event: reset\ndata: %s\n\n", data); err == nil {
 		w.recordWrite()

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/metrics"
+	"go.uber.org/zap"
 )
 
 const (
@@ -22,6 +23,8 @@ const (
 	sseFlushBatchSize        = 10
 	sseFlushMaxDelay         = 1 * time.Millisecond
 	ssePersistTimeout        = 500 * time.Millisecond
+	sseRetentionSweepTimeout = 5 * time.Second
+	sseRetentionSweepEvery   = time.Minute
 	ssePersistentReplayLimit = eventBusRingSize
 	ssePersistentRetention   = eventBusRingSize * 10
 )
@@ -182,14 +185,6 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 		ev, err := b.Store().InsertFSEvent(persistCtx, path, op, actor)
 		if err == nil {
 			recordSSEOperation("persist", sseResultOK, persistStart)
-			if ev.Seq > ssePersistentRetention {
-				pruneStart := time.Now()
-				if _, pruneErr := b.Store().PruneFSEventsBefore(persistCtx, ev.Seq-ssePersistentRetention+1); pruneErr != nil {
-					recordSSEOperation("retention_sweep", sseResultError, pruneStart)
-				} else {
-					recordSSEOperation("retention_sweep", sseResultOK, pruneStart)
-				}
-			}
 			publishStart := time.Now()
 			bus.PublishEvent(ChangeEvent{
 				Seq:   ev.Seq,
@@ -199,6 +194,9 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 				Ts:    ev.Ts,
 			})
 			recordSSEOperation("publish", sseResultOK, publishStart)
+			if s.sseRetention != nil {
+				s.sseRetention.MaybeSweep(r.Context(), sseRetentionTenantKey(r), b.Store(), ev.Seq)
+			}
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "sse_persist_failed", "path", path, "op", op, "error", err)...)
@@ -207,6 +205,85 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 	start := time.Now()
 	bus.Publish(path, op, actor)
 	recordSSEOperation("publish", sseResultVolatile, start)
+}
+
+type sseRetentionSweeper struct {
+	mu          sync.Mutex
+	last        map[string]time.Time
+	running     map[string]bool
+	retention   uint64
+	minInterval time.Duration
+	timeout     time.Duration
+	now         func() time.Time
+}
+
+func newSSERetentionSweeper() *sseRetentionSweeper {
+	return &sseRetentionSweeper{
+		last:        make(map[string]time.Time),
+		running:     make(map[string]bool),
+		retention:   ssePersistentRetention,
+		minInterval: sseRetentionSweepEvery,
+		timeout:     sseRetentionSweepTimeout,
+		now:         time.Now,
+	}
+}
+
+func sseRetentionTenantKey(r *http.Request) string {
+	if scope := ScopeFromContext(r.Context()); scope != nil {
+		return scope.TenantID
+	}
+	return ""
+}
+
+func (w *sseRetentionSweeper) MaybeSweep(ctx context.Context, tenantKey string, store *datastore.Store, headSeq uint64) {
+	if w == nil || store == nil || w.retention == 0 || headSeq <= w.retention {
+		return
+	}
+	now := w.now()
+
+	w.mu.Lock()
+	if w.running[tenantKey] {
+		w.mu.Unlock()
+		return
+	}
+	if last := w.last[tenantKey]; !last.IsZero() && now.Sub(last) < w.minInterval {
+		w.mu.Unlock()
+		return
+	}
+	w.running[tenantKey] = true
+	w.last[tenantKey] = now
+	w.mu.Unlock()
+
+	go func() {
+		defer func() {
+			w.mu.Lock()
+			w.running[tenantKey] = false
+			w.mu.Unlock()
+		}()
+		sweepCtx, cancel := context.WithTimeout(backgroundWithTrace(ctx), w.timeout)
+		defer cancel()
+		w.sweepHead(sweepCtx, store, headSeq)
+	}()
+}
+
+func (w *sseRetentionSweeper) sweepHead(ctx context.Context, store *datastore.Store, headSeq uint64) {
+	if w == nil || w.retention == 0 || headSeq <= w.retention {
+		return
+	}
+	w.sweepStore(ctx, store, headSeq-w.retention+1)
+}
+
+func (w *sseRetentionSweeper) sweepStore(ctx context.Context, store *datastore.Store, keepFromSeq uint64) {
+	if store == nil || keepFromSeq == 0 {
+		return
+	}
+	start := time.Now()
+	if _, err := store.PruneFSEventsBefore(ctx, keepFromSeq); err != nil {
+		recordSSEOperation("retention_sweep", sseResultError, start)
+		logger.Warn(ctx, "sse_retention_sweep_failed", zap.Uint64("keep_from_seq", keepFromSeq), zap.Error(err))
+		return
+	}
+	recordSSEOperation("retention_sweep", sseResultOK, start)
 }
 
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -561,6 +561,10 @@ func isStructuralOp(op string) bool {
 }
 
 func sendSSEEvent(w *sseBufferedWriter, ev ChangeEvent) {
+	if ev.Op == eventBusForceResetOp {
+		sendSSEReset(w, ev.Seq, sseResultSeqTooOld)
+		return
+	}
 	if isStructuralOp(ev.Op) {
 		// Structural ops are sent as reset events per the accepted design.
 		sendSSEStructuralReset(w, ev)

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -147,6 +148,88 @@ func TestSSEEndpointReplay(t *testing.T) {
 	}
 	if data2.Path != "/c.txt" || data2.Op != "write" {
 		t.Errorf("event2 data: %+v", data2)
+	}
+}
+
+func TestSSEEndpointPersistentReplayAfterMemoryBusReset(t *testing.T) {
+	srv := newTestServer(t)
+	store := srv.fallback.Store()
+	ctx := context.Background()
+	ev1, err := store.InsertFSEvent(ctx, "/persist-a.txt", "write", "actor1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev2, err := store.InsertFSEvent(ctx, "/persist-b.txt", "chmod", "actor2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a server restart: persistent events remain, memory bus is empty.
+	srv.events = newEventBuses()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scope := &TenantScope{TenantID: "", Backend: srv.fallback}
+		srv.handleEvents(w, r.WithContext(withScope(r.Context(), scope)))
+	}))
+	defer ts.Close()
+
+	reqCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(reqCtx, "GET", fmt.Sprintf("%s?since=%d", ts.URL, ev1.Seq), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	scanner := bufio.NewScanner(resp.Body)
+	got, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected replayed persistent event")
+	}
+	if got.Event != "file_changed" {
+		t.Fatalf("event=%q, want file_changed", got.Event)
+	}
+	var data ChangeEvent
+	if err := json.Unmarshal([]byte(got.Data), &data); err != nil {
+		t.Fatal(err)
+	}
+	if data.Seq != ev2.Seq || data.Path != "/persist-b.txt" || data.Op != "chmod" || data.Actor != "actor2" {
+		t.Fatalf("persistent replay event = %+v, want chmod seq %d", data, ev2.Seq)
+	}
+}
+
+func TestHandleChmodPublishesPersistentSSEEvent(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := context.Background()
+	if err := srv.fallback.CreateCtx(ctx, "/chmod.txt"); err != nil {
+		t.Fatal(err)
+	}
+
+	body := bytes.NewBufferString(`{"mode":384}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/fs/chmod.txt?chmod=1", body)
+	req = req.WithContext(withScope(req.Context(), &TenantScope{TenantID: "", Backend: srv.fallback}))
+	rr := httptest.NewRecorder()
+	srv.handleChmod(rr, req, "/chmod.txt")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	events, err := srv.fallback.Store().ListFSEventsSince(ctx, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events len=%d, want 1: %+v", len(events), events)
+	}
+	if got := events[0]; got.Path != "/chmod.txt" || got.Op != "chmod" {
+		t.Fatalf("event=%+v, want chmod event for /chmod.txt", got)
+	}
+	nf, err := srv.fallback.Store().Stat(ctx, "/chmod.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nf.File == nil || nf.File.Revision != 2 {
+		t.Fatalf("revision=%v, want 2 after chmod", nf.File)
 	}
 }
 

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -489,6 +489,57 @@ func TestSSEStructuralOpLiveEmitsReset(t *testing.T) {
 	}
 }
 
+func TestSSEForceResetSignalLiveEmitsReset(t *testing.T) {
+	srv := &Server{events: newEventBuses()}
+	bus := srv.events.get("")
+	bus.PublishEvent(ChangeEvent{Seq: 5, Path: "/seed.txt", Op: "write", Ts: 1})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), tenantScopeKey, &TenantScope{TenantID: ""})
+		srv.handleEvents(w, r.WithContext(ctx))
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"?since=5", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	scanner := bufio.NewScanner(resp.Body)
+	current, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected initial stream-current heartbeat")
+	}
+	if current.Event != "heartbeat" {
+		t.Fatalf("initial event=%q, want heartbeat", current.Event)
+	}
+
+	bus.PublishEvent(ChangeEvent{Seq: 7, Path: "/gap.txt", Op: "write", Ts: 1})
+
+	ev, ok := readSSEEvent(scanner)
+	if !ok {
+		t.Fatal("expected live reset event")
+	}
+	if ev.Event != "reset" {
+		t.Fatalf("event=%q, want reset", ev.Event)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(ev.Data), &data); err != nil {
+		t.Fatalf("unmarshal force reset: %v", err)
+	}
+	if data["reason"] != "seq_too_old" {
+		t.Fatalf("reason=%v, want seq_too_old", data["reason"])
+	}
+	if data["seq"] != float64(6) {
+		t.Fatalf("seq=%v, want 6", data["seq"])
+	}
+}
+
 func TestSSEEndpointMethodNotAllowed(t *testing.T) {
 	srv := &Server{events: newEventBuses()}
 	w := httptest.NewRecorder()

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -198,6 +198,45 @@ func TestSSEEndpointPersistentReplayAfterMemoryBusReset(t *testing.T) {
 	}
 }
 
+func TestSSERetentionSweeperPrunesOutsideWindow(t *testing.T) {
+	srv := newTestServer(t)
+	store := srv.fallback.Store()
+	ctx := context.Background()
+
+	ev1, err := store.InsertFSEvent(ctx, "/old.txt", "write", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev2, err := store.InsertFSEvent(ctx, "/keep-a.txt", "write", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev3, err := store.InsertFSEvent(ctx, "/keep-b.txt", "chmod", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sweeper := newSSERetentionSweeper()
+	sweeper.retention = 2
+	sweeper.sweepHead(ctx, store, ev3.Seq)
+
+	events, err := store.ListFSEventsSince(ctx, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events len=%d, want 2: %+v", len(events), events)
+	}
+	if events[0].Seq != ev2.Seq || events[1].Seq != ev3.Seq {
+		t.Fatalf("kept seqs = [%d %d], want [%d %d]", events[0].Seq, events[1].Seq, ev2.Seq, ev3.Seq)
+	}
+	for _, ev := range events {
+		if ev.Seq == ev1.Seq {
+			t.Fatalf("old event was not pruned: %+v", ev)
+		}
+	}
+}
+
 func TestHandleChmodPublishesPersistentSSEEvent(t *testing.T) {
 	srv := newTestServer(t)
 	ctx := context.Background()

--- a/pkg/tenant/db9/schema.go
+++ b/pkg/tenant/db9/schema.go
@@ -166,6 +166,15 @@ func InitSchemaStatements() []string {
 			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_llm_usage_created ON llm_usage(created_at)`,
+		`CREATE TABLE IF NOT EXISTS fs_events (
+			seq        BIGSERIAL PRIMARY KEY,
+			path       VARCHAR(512) NOT NULL,
+			op         VARCHAR(64) NOT NULL,
+			actor      VARCHAR(255),
+			ts         BIGINT NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_fs_events_created ON fs_events(created_at)`,
 	}
 	core = append(core, schema.GitWorkspaceDB9SchemaStatements()...)
 	core = append(core, schema.JournalDB9SchemaStatements()...)

--- a/pkg/tenant/schema/tidb_app.go
+++ b/pkg/tenant/schema/tidb_app.go
@@ -161,6 +161,15 @@ func tidbAppEmbeddingBaseSchemaStatements() []string {
 			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
 		)`,
 		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
+		`CREATE TABLE IF NOT EXISTS fs_events (
+			seq        BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			path       VARCHAR(512) NOT NULL,
+			op         VARCHAR(64) NOT NULL,
+			actor      VARCHAR(255),
+			ts         BIGINT NOT NULL,
+			created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+		)`,
+		`CREATE INDEX idx_fs_events_created ON fs_events(created_at)`,
 	}
 	stmts = append(stmts, GitWorkspaceTiDBSchemaStatements()...)
 	stmts = append(stmts, JournalTiDBSchemaStatements()...)

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -880,6 +880,15 @@ func tidbAutoEmbeddingSchemaStatementsForConfig(cfg tidbAutoEmbeddingRenderConfi
 			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
 		)`,
 		`CREATE INDEX idx_llm_usage_created ON llm_usage(created_at)`,
+		`CREATE TABLE IF NOT EXISTS fs_events (
+			seq        BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			path       VARCHAR(512) NOT NULL,
+			op         VARCHAR(64) NOT NULL,
+			actor      VARCHAR(255),
+			ts         BIGINT NOT NULL,
+			created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+		)`,
+		`CREATE INDEX idx_fs_events_created ON fs_events(created_at)`,
 	}
 	stmts = append(stmts, GitWorkspaceTiDBSchemaStatements()...)
 	stmts = append(stmts, JournalTiDBSchemaStatements()...)


### PR DESCRIPTION
## Summary
- add tenant-local fs_events persistence and replay for SSE reconnects, with in-memory fanout as fallback
- publish chmod as an SSE mutation and bump file revision/mtime on chmod
- add SSE metrics using existing drive9_service_operations_total/duration and active connection gauge
- add Grafana dashboard coverage and update cache invalidation docs
- improve client SSE parsing for comments and multi-line data frames

## Schema
- added fs_events to TiDB auto/app and db9 tenant init schemas
- verified dump-init-sql for tidb_zero, tidb_cloud_starter, and db9 includes fs_events

## Tests
- make test
- make lint
- env GOCACHE=/tmp/drive9-go-build go test ./pkg/datastore ./pkg/client ./pkg/server ./pkg/backend ./pkg/tenant/schema
- env GOCACHE=/tmp/drive9-go-build go test ./pkg/server -run 'TestSSE|TestEventBus|TestHandleChmodPublishesPersistentSSEEvent'
- jq empty docs/grafana/drive9-event-stream-dashboard.json
- git diff --check

Note: alert rules are committed separately in the runbooks repo as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable filesystem event log with persistent replay, pruning, and retention sweeper
  * chmod now emits change events and increments file revision
  * SSE publishes prefer durable persistence when available; active-connection and operation metrics added

* **Enhancements**
  * SSE client parsing accepts multiline data and ignores comment/metadata lines
  * Replay/reset behavior and structured reset reasons standardized
  * Durable replay continuity and stricter sequence validation

* **Documentation**
  * New Grafana dashboard for event-stream monitoring
  * Cache invalidation spec updated to include chmod

* **Tests**
  * Added tests for persistent replay, retention pruning, chmod publishing, event-log bounds/pruning, and SSE behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->