### PR TITLE
Fix git workspace blob cache fallbacks

### DIFF
--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -882,7 +882,7 @@ func (fs *Dat9FS) fillLocalGitTreeSizes(ctx context.Context, rt *gitWorkspaceRun
 		}
 		if localRoot != "" && workspaceID != "" && baseCommit != "" {
 			if size, hit, err := gitcache.StatBlob(ctx, localRoot, workspaceID, baseCommit, oid); err != nil {
-				return err
+				log.Printf("git workspace base blob cache stat failed workspace=%s commit=%s oid=%s: %v", workspaceID, baseCommit, oid, err)
 			} else if hit {
 				sizeByObject[oid] = size
 				setGitTreeNodeSize(nodes, children, rel, size)
@@ -898,7 +898,7 @@ func (fs *Dat9FS) fillLocalGitTreeSizes(ctx context.Context, rt *gitWorkspaceRun
 	sort.Strings(ids)
 	infos, err := gitObjectInfoBatch(ctx, gitDir, ids)
 	if err != nil {
-		return err
+		return fmt.Errorf("batch check local git objects gitDir=%s ids=%v: %w", gitDir, ids, err)
 	}
 	for rel, n := range nodes {
 		if !gitNodeHasBlobSize(n) || n.SizeBytes >= 0 {
@@ -936,6 +936,10 @@ func (rt *gitWorkspaceRuntime) knownBaseGitObjectSizes() (map[string]int64, stri
 
 func gitNodeHasBlobSize(n client.GitTreeNode) bool {
 	return n.Kind == "file" || n.Kind == "symlink"
+}
+
+func gitObjectCacheKey(objectSHA string) string {
+	return strings.ToLower(strings.TrimSpace(objectSHA))
 }
 
 func setGitTreeNodeSize(nodes map[string]client.GitTreeNode, children map[string][]client.GitTreeNode, rel string, size int64) {
@@ -1424,6 +1428,7 @@ func (fs *Dat9FS) readGitCleanFile(ctx context.Context, rt *gitWorkspaceRuntime,
 		fs.perf.gitCleanReadCount.add(1)
 	}
 	nodeCommit := gitNodeCommit(rt, n)
+	objectSHA := gitObjectCacheKey(n.ObjectSHA)
 	if localRoot := strings.TrimSpace(fs.opts.LocalRoot); localRoot != "" {
 		data, hit, err := gitcache.ReadTreeFile(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, rel, offset, size)
 		if err != nil {
@@ -1438,7 +1443,7 @@ func (fs *Dat9FS) readGitCleanFile(ctx context.Context, rt *gitWorkspaceRuntime,
 			}
 			return data, nil
 		}
-		data, hit, err = gitcache.ReadBlob(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, n.ObjectSHA, offset, size)
+		data, hit, err = gitcache.ReadBlob(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, objectSHA, offset, size)
 		if err != nil {
 			return nil, err
 		}
@@ -1453,7 +1458,7 @@ func (fs *Dat9FS) readGitCleanFile(ctx context.Context, rt *gitWorkspaceRuntime,
 		}
 		baseCommit := strings.TrimSpace(rt.workspace.HeadCommit)
 		if baseCommit != "" && !strings.EqualFold(baseCommit, nodeCommit) {
-			data, hit, err = gitcache.ReadBlob(ctx, localRoot, rt.workspace.WorkspaceID, baseCommit, n.ObjectSHA, offset, size)
+			data, hit, err = gitcache.ReadBlob(ctx, localRoot, rt.workspace.WorkspaceID, baseCommit, objectSHA, offset, size)
 			if err != nil {
 				return nil, err
 			}
@@ -1471,7 +1476,7 @@ func (fs *Dat9FS) readGitCleanFile(ctx context.Context, rt *gitWorkspaceRuntime,
 	if fs.perfEnabled() {
 		fs.perf.gitCleanCacheMiss.add(1)
 	}
-	data, err := fs.materializeGitBlob(ctx, rt, nodeCommit, n.ObjectSHA)
+	data, err := fs.materializeGitBlob(ctx, rt, nodeCommit, objectSHA)
 	if err != nil {
 		return nil, err
 	}
@@ -1500,18 +1505,19 @@ func (fs *Dat9FS) resolveGitCleanNodeSize(ctx context.Context, rt *gitWorkspaceR
 		ctx = context.Background()
 	}
 	nodeCommit := gitNodeCommit(rt, n)
+	objectSHA := gitObjectCacheKey(n.ObjectSHA)
 	if localRoot := strings.TrimSpace(fs.opts.LocalRoot); localRoot != "" {
 		if size, hit, err := gitcache.StatTreeFile(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, rel); err == nil && hit {
 			rt.updateCleanNodeSize(rel, nodeCommit, size)
 			return size
 		}
-		if size, hit, err := gitcache.StatBlob(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, n.ObjectSHA); err == nil && hit {
+		if size, hit, err := gitcache.StatBlob(ctx, localRoot, rt.workspace.WorkspaceID, nodeCommit, objectSHA); err == nil && hit {
 			rt.updateCleanNodeSize(rel, nodeCommit, size)
 			return size
 		}
 		baseCommit := strings.TrimSpace(rt.workspace.HeadCommit)
 		if baseCommit != "" && !strings.EqualFold(baseCommit, nodeCommit) {
-			if size, hit, err := gitcache.StatBlob(ctx, localRoot, rt.workspace.WorkspaceID, baseCommit, n.ObjectSHA); err == nil && hit {
+			if size, hit, err := gitcache.StatBlob(ctx, localRoot, rt.workspace.WorkspaceID, baseCommit, objectSHA); err == nil && hit {
 				rt.updateCleanNodeSize(rel, nodeCommit, size)
 				return size
 			}
@@ -1520,8 +1526,8 @@ func (fs *Dat9FS) resolveGitCleanNodeSize(ctx context.Context, rt *gitWorkspaceR
 	if gitWorkspaceIsFastBlobless(rt) {
 		return n.SizeBytes
 	}
-	if n.ObjectSHA != "" {
-		if size, err := fs.gitCatFileBlobSize(ctx, rt, n.ObjectSHA); err == nil {
+	if objectSHA != "" {
+		if size, err := fs.gitCatFileBlobSize(ctx, rt, objectSHA); err == nil {
 			rt.updateCleanNodeSize(rel, nodeCommit, size)
 			return size
 		}

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -1977,6 +1977,72 @@ func TestGitLocalHeadTreeSizeFillUsesBaseBlobCache(t *testing.T) {
 	}
 }
 
+func TestGitLocalHeadTreeSizeFillIgnoresBaseBlobCacheStatError(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	content := []byte("hello local commit\n")
+	repo := createGitRepoWithReadme(t, content)
+	localCommit := fuseGitOutputForTest(t, repo, "rev-parse", "HEAD")
+	localSHA := fuseGitOutputForTest(t, repo, "hash-object", "README.md")
+	badSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	localRoot := t.TempDir()
+	badPath, err := gitcache.BlobPath(localRoot, "ws1", fixtureHeadCommit, badSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(filepath.Dir(badPath)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Dir(badPath), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes := map[string]client.GitTreeNode{
+		"README.md": {
+			WorkspaceID: "ws1",
+			CommitSHA:   localCommit,
+			Path:        "README.md",
+			ParentPath:  "",
+			Name:        "README.md",
+			Kind:        "file",
+			Mode:        "100644",
+			ObjectSHA:   localSHA,
+			SizeBytes:   -1,
+		},
+		"broken.txt": {
+			WorkspaceID: "ws1",
+			CommitSHA:   localCommit,
+			Path:        "broken.txt",
+			ParentPath:  "",
+			Name:        "broken.txt",
+			Kind:        "file",
+			Mode:        "100644",
+			ObjectSHA:   badSHA,
+			SizeBytes:   -1,
+		},
+	}
+	children := map[string][]client.GitTreeNode{
+		"": {nodes["README.md"], nodes["broken.txt"]},
+	}
+	rt := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID: "ws1",
+			HeadCommit:  fixtureHeadCommit,
+		},
+	}
+	fs := &Dat9FS{opts: &MountOptions{LocalRoot: localRoot}}
+	if err := fs.fillLocalGitTreeSizes(context.Background(), rt, filepath.Join(repo, ".git"), nodes, children); err != nil {
+		t.Fatalf("fillLocalGitTreeSizes: %v", err)
+	}
+	if got := nodes["README.md"].SizeBytes; got != int64(len(content)) {
+		t.Fatalf("local node size = %d, want local blob size %d", got, len(content))
+	}
+	if got := nodes["broken.txt"].SizeBytes; got != int64(-1) {
+		t.Fatalf("broken node size = %d, want unchanged unknown size", got)
+	}
+}
+
 func TestGitLocalHeadTreeSizeFillBatchChecksLocalBlob(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")
@@ -2046,7 +2112,7 @@ func TestGitWorkspaceLocalHeadReadUsesBaseBlobCache(t *testing.T) {
 		Path:      "README.md",
 		Kind:      "file",
 		Mode:      "100644",
-		ObjectSHA: objectSHA,
+		ObjectSHA: strings.ToUpper(objectSHA),
 		SizeBytes: int64(len(content)),
 	}, 0, -1)
 	if err != nil {
@@ -2054,6 +2120,35 @@ func TestGitWorkspaceLocalHeadReadUsesBaseBlobCache(t *testing.T) {
 	}
 	if !bytes.Equal(got, content) {
 		t.Fatalf("readGitCleanFile = %q, want %q", got, content)
+	}
+}
+
+func TestGitWorkspaceLocalHeadSizeUsesBaseBlobCacheWithUppercaseObjectSHA(t *testing.T) {
+	objectSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	baseCommit := fixtureHeadCommit
+	localCommit := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	content := []byte("cached base object\n")
+	localRoot := t.TempDir()
+	if err := gitcache.WriteBlob(context.Background(), localRoot, "ws1", baseCommit, objectSHA, content); err != nil {
+		t.Fatal(err)
+	}
+	rt := &gitWorkspaceRuntime{
+		workspace: client.GitWorkspace{
+			WorkspaceID: "ws1",
+			HeadCommit:  baseCommit,
+		},
+	}
+	fs := &Dat9FS{opts: &MountOptions{LocalRoot: localRoot}}
+	got := fs.resolveGitCleanNodeSize(context.Background(), rt, "README.md", client.GitTreeNode{
+		CommitSHA: localCommit,
+		Path:      "README.md",
+		Kind:      "file",
+		Mode:      "100644",
+		ObjectSHA: strings.ToUpper(objectSHA),
+		SizeBytes: -1,
+	})
+	if got != int64(len(content)) {
+		t.Fatalf("resolveGitCleanNodeSize = %d, want %d", got, len(content))
 	}
 }
 


### PR DESCRIPTION
Follow-up to #529 addressing qiffang's post-merge review blockers.

## Changes

- Treat local HEAD blob-cache `StatBlob` errors as best-effort cache misses before batch git metadata fallback.
- Normalize blob cache object keys to lowercase for local HEAD read and size fallbacks.
- Add regression tests for cache stat errors and uppercase `ObjectSHA` cache hits.

## Validation

- `env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/fuse -run 'TestGitLocalHeadTreeSizeFill|TestGitWorkspaceLocalHead(Read|Size)UsesBaseBlobCache'`
- `env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/fuse -run 'TestGit(LocalHead|Workspace)'`
- `env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/fuse`
- `git diff --check`
