### PR TITLE
perf: escalate negative-lookup storms to a single directory listing

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3562,6 +3562,37 @@ func (fs *Dat9FS) cacheNegativePath(p string) {
 	fs.dirCache.MarkNegative(parentPath, name)
 }
 
+// maybeListOnNegativeLookupStorm converts a burst of remote ENOENT lookups
+// under one directory into a single ListDir. Workloads that probe many
+// missing names (fio layout passes, build systems, archive extraction)
+// otherwise pay one remote stat per name; one listing lets the namespace
+// cache answer the rest of the burst locally under the same negative-TTL
+// staleness contract.
+//
+// Lock files are excluded because lookupFromDirCache deliberately bypasses
+// the namespace cache for them, so a listing could never absorb their misses
+// and each lock probe would re-trigger escalation.
+func (fs *Dat9FS) maybeListOnNegativeLookupStorm(cancel <-chan struct{}, parentPath, childP string) {
+	if fs.dirCache == nil || isLockFilePath(childP) || fs.opts.LegacyDirStatFallback {
+		return
+	}
+	if !fs.dirCache.RecordRemoteNegative(parentPath) {
+		return
+	}
+	if fs.perf != nil {
+		fs.perf.lookupStormList.add(1)
+	}
+	items, err := fs.lookupListWithRetry(cancel, parentPath)
+	if err != nil || !fs.dirCache.CanAnswerMisses(parentPath) {
+		// Listing failed or was too large to mark complete; cool down so a
+		// sustained probe storm cannot hammer the server with listings.
+		fs.dirCache.DeferEscalation(parentPath)
+		fs.debugf("lookup storm list deferred dir=%s items=%d err=%v", parentPath, len(items), err)
+		return
+	}
+	fs.debugf("lookup storm list dir=%s items=%d", parentPath, len(items))
+}
+
 func (fs *Dat9FS) negativeEntryTTL(p string) time.Duration {
 	if isLockFilePath(p) {
 		return 0
@@ -4127,6 +4158,7 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// Cache negative lookup: tell kernel this entry doesn't exist
 		// for NegativeEntryTTL so it doesn't re-ask immediately.
 		fs.cacheNegativePath(childP)
+		fs.maybeListOnNegativeLookupStorm(cancel, parentPath, childP)
 		out.NodeId = 0
 		out.SetEntryTimeout(fs.negativeEntryTTL(childP))
 		return gofuse.ENOENT

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3569,6 +3569,12 @@ func (fs *Dat9FS) cacheNegativePath(p string) {
 // cache answer the rest of the burst locally under the same negative-TTL
 // staleness contract.
 //
+// The listing runs synchronously in the triggering Lookup: one request per
+// storm (rate-limited to one per escalateMissWindow) pays a List RTT instead
+// of a stat RTT. Running it async would return this ENOENT marginally sooner
+// but lengthen the window in which concurrent misses still pay individual
+// stats, and add goroutine lifecycle/cancel complexity for no measured win.
+//
 // Lock files are excluded because lookupFromDirCache deliberately bypasses
 // the namespace cache for them, so a listing could never absorb their misses
 // and each lock probe would re-trigger escalation.
@@ -3587,6 +3593,9 @@ func (fs *Dat9FS) maybeListOnNegativeLookupStorm(cancel <-chan struct{}, parentP
 		// Listing failed or was too large to mark complete; cool down so a
 		// sustained probe storm cannot hammer the server with listings.
 		fs.dirCache.DeferEscalation(parentPath)
+		if fs.perf != nil {
+			fs.perf.lookupStormDeferred.add(1)
+		}
 		fs.debugf("lookup storm list deferred dir=%s items=%d err=%v", parentPath, len(items), err)
 		return
 	}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -4634,6 +4634,10 @@ func TestLookupNegativeStormEscalatesToSingleList(t *testing.T) {
 		}
 	}
 
+	// Misses 1-3 each pay a HEAD; the third triggers the listing, which runs
+	// synchronously inside that Lookup (the in-process test server makes this
+	// deterministic), so misses 4-10 are answered locally from the complete
+	// listing: exactly threshold HEADs and one LIST.
 	if got := headCalls.Load(); got != int32(escalateMissThreshold) {
 		t.Fatalf("HEAD calls = %d, want %d (storm should escalate to a listing)", got, escalateMissThreshold)
 	}
@@ -4690,6 +4694,9 @@ func TestLookupNegativeStormOversizedListingCoolsDown(t *testing.T) {
 
 	// Oversized listings cannot answer misses; every probe stays remote, but
 	// the cooldown must prevent more than the single listing attempt.
+	// Misses 1-3 pay HEADs and trigger the listing; it exceeds the cache
+	// limit, so DeferEscalation kicks in and misses 4-10 fall back to one
+	// HEAD each: all 10 probes stay remote but only one LIST is ever sent.
 	if got := listCalls.Load(); got != 1 {
 		t.Fatalf("LIST calls = %d, want 1 (cooldown should stop repeat listings)", got)
 	}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -4603,6 +4603,101 @@ func TestLookupSSEForeignCreateInvalidatesSessionCreatedMiss(t *testing.T) {
 	}
 }
 
+func TestLookupNegativeStormEscalatesToSingleList(t *testing.T) {
+	var headCalls, listCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			headCalls.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			listCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"entries":[{"name":"existing.txt","size":4}]}`))
+		default:
+			t.Errorf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	dirIno := fs.inodes.Lookup("/bench", true, 0, time.Now())
+
+	for i := 0; i < 10; i++ {
+		var out gofuse.EntryOut
+		st := fs.Lookup(nil, &gofuse.InHeader{NodeId: dirIno}, fmt.Sprintf("file.%d", i), &out)
+		if st != gofuse.ENOENT {
+			t.Fatalf("Lookup file.%d status = %v, want ENOENT", i, st)
+		}
+	}
+
+	if got := headCalls.Load(); got != int32(escalateMissThreshold) {
+		t.Fatalf("HEAD calls = %d, want %d (storm should escalate to a listing)", got, escalateMissThreshold)
+	}
+	if got := listCalls.Load(); got != 1 {
+		t.Fatalf("LIST calls = %d, want 1", got)
+	}
+
+	// The listing also serves positive lookups without another remote stat.
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: dirIno}, "existing.txt", &out)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup existing.txt status = %v, want OK", st)
+	}
+	if got := headCalls.Load(); got != int32(escalateMissThreshold) {
+		t.Fatalf("HEAD calls after positive lookup = %d, want %d", got, escalateMissThreshold)
+	}
+}
+
+func TestLookupNegativeStormOversizedListingCoolsDown(t *testing.T) {
+	var headCalls, listCalls atomic.Int32
+	entries := make([]string, 0, defaultNamespaceCacheMaxEntries+1)
+	for i := 0; i <= defaultNamespaceCacheMaxEntries; i++ {
+		entries = append(entries, fmt.Sprintf(`{"name":"e%d","size":1}`, i))
+	}
+	listBody := `{"entries":[` + strings.Join(entries, ",") + `]}`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			headCalls.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			listCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(listBody))
+		default:
+			t.Errorf("unexpected request %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	dirIno := fs.inodes.Lookup("/huge", true, 0, time.Now())
+
+	for i := 0; i < 10; i++ {
+		var out gofuse.EntryOut
+		st := fs.Lookup(nil, &gofuse.InHeader{NodeId: dirIno}, fmt.Sprintf("file.%d", i), &out)
+		if st != gofuse.ENOENT {
+			t.Fatalf("Lookup file.%d status = %v, want ENOENT", i, st)
+		}
+	}
+
+	// Oversized listings cannot answer misses; every probe stays remote, but
+	// the cooldown must prevent more than the single listing attempt.
+	if got := listCalls.Load(); got != 1 {
+		t.Fatalf("LIST calls = %d, want 1 (cooldown should stop repeat listings)", got)
+	}
+	if got := headCalls.Load(); got != 10 {
+		t.Fatalf("HEAD calls = %d, want 10", got)
+	}
+}
+
 func TestReadDirPlusRecreatesStaleSnapshotInode(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dir.go
+++ b/pkg/fuse/dir.go
@@ -264,14 +264,19 @@ func (dc *DirCache) RecordRemoteNegative(dirPath string) bool {
 	entry.remoteMisses = 0
 	entry.missWindowStart = time.Time{}
 	// Suppress duplicate escalations from concurrent lookups while the
-	// caller's listing is in flight.
+	// caller's listing is in flight. Concurrent misses arriving during that
+	// RTT still fall through to individual remote stats; that tail cost is
+	// accepted to keep this path free of cross-request coordination.
 	entry.escalateNotBefore = now.Add(escalateMissWindow)
 	return true
 }
 
 // DeferEscalation applies an escalation cooldown of one full cache TTL. Used
 // after a listing failed or was too large to answer misses locally, so a
-// sustained probe storm cannot turn into repeated listings.
+// sustained probe storm cannot turn into repeated listings. This deliberately
+// overwrites the short post-escalation cooldown set by RecordRemoteNegative:
+// that one only bridges the in-flight listing, while this one says "listing
+// this directory does not pay off, stop trying for a while".
 func (dc *DirCache) DeferEscalation(dirPath string) {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()

--- a/pkg/fuse/dir.go
+++ b/pkg/fuse/dir.go
@@ -10,6 +10,13 @@ import (
 const (
 	defaultDirCacheTTL              = 10 * time.Second
 	defaultNamespaceCacheMaxEntries = 2000
+
+	// escalateMissThreshold/escalateMissWindow detect negative-lookup storms:
+	// once this many remote ENOENT stats hit the same directory within the
+	// window, the caller should issue one listing so the remaining misses are
+	// answered locally instead of one remote stat per name.
+	escalateMissThreshold = 3
+	escalateMissWindow    = time.Second
 )
 
 // CachedFileInfo matches the client.FileInfo shape but avoids importing client.
@@ -49,6 +56,11 @@ type dirCacheEntry struct {
 	completeExpires time.Time // safe ENOENT-on-miss TTL for a complete listing
 	sessionExpires  time.Time // safe ENOENT-on-miss TTL for a session-created dir
 	negatives       map[string]time.Time
+
+	// Negative-lookup storm tracking; see RecordRemoteNegative.
+	remoteMisses      int
+	missWindowStart   time.Time
+	escalateNotBefore time.Time
 }
 
 // DirCache is a thread-safe, TTL-based namespace cache.
@@ -211,7 +223,9 @@ func (dc *DirCache) MarkNegative(parentPath, name string) {
 }
 
 // MarkSessionCreatedDir records a directory created by this mount as having a
-// locally managed empty namespace for a short TTL.
+// locally managed empty namespace for the directory TTL. Local mutations flow
+// through Upsert/Remove and foreign writes invalidate via SSE, so the marker
+// can safely outlive the negative TTL used for single-name ENOENT markers.
 func (dc *DirCache) MarkSessionCreatedDir(dirPath string) {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
@@ -220,9 +234,66 @@ func (dc *DirCache) MarkSessionCreatedDir(dirPath string) {
 	entry := dc.ensureEntryLocked(dirPath)
 	entry.expires = now.Add(dc.ttl)
 	entry.complete = true
-	entry.completeExpires = now.Add(dc.negativeTTL)
-	entry.sessionExpires = now.Add(dc.negativeTTL)
+	entry.completeExpires = now.Add(dc.ttl)
+	entry.sessionExpires = now.Add(dc.ttl)
 	entry.negatives = make(map[string]time.Time)
+}
+
+// RecordRemoteNegative notes that a remote stat for a child of dirPath
+// returned ENOENT. It reports true when the caller should escalate to a
+// single directory listing: escalateMissThreshold misses accumulated within
+// escalateMissWindow and no escalation cooldown is active.
+func (dc *DirCache) RecordRemoteNegative(dirPath string) bool {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	now := time.Now()
+	entry := dc.ensureEntryLocked(dirPath)
+	if !entry.escalateNotBefore.IsZero() && now.Before(entry.escalateNotBefore) {
+		return false
+	}
+	if entry.missWindowStart.IsZero() || now.Sub(entry.missWindowStart) > escalateMissWindow {
+		entry.missWindowStart = now
+		entry.remoteMisses = 1
+		return false
+	}
+	entry.remoteMisses++
+	if entry.remoteMisses < escalateMissThreshold {
+		return false
+	}
+	entry.remoteMisses = 0
+	entry.missWindowStart = time.Time{}
+	// Suppress duplicate escalations from concurrent lookups while the
+	// caller's listing is in flight.
+	entry.escalateNotBefore = now.Add(escalateMissWindow)
+	return true
+}
+
+// DeferEscalation applies an escalation cooldown of one full cache TTL. Used
+// after a listing failed or was too large to answer misses locally, so a
+// sustained probe storm cannot turn into repeated listings.
+func (dc *DirCache) DeferEscalation(dirPath string) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	entry := dc.ensureEntryLocked(dirPath)
+	entry.escalateNotBefore = time.Now().Add(dc.ttl)
+	entry.remoteMisses = 0
+	entry.missWindowStart = time.Time{}
+}
+
+// CanAnswerMisses reports whether dirPath currently has namespace state that
+// answers child misses locally (a valid complete listing or session marker).
+func (dc *DirCache) CanAnswerMisses(dirPath string) bool {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	now := time.Now()
+	entry, ok := dc.getEntryLocked(dirPath, now)
+	if !ok {
+		return false
+	}
+	return entry.sessionValid(now) || entry.completeValid(now)
 }
 
 // InvalidatePrefix removes cached namespace state for dirPath and descendants.
@@ -343,6 +414,13 @@ func (e *dirCacheEntry) prune(now time.Time) {
 	if !e.sessionExpires.IsZero() && now.After(e.sessionExpires) {
 		e.sessionExpires = time.Time{}
 	}
+	if !e.missWindowStart.IsZero() && now.Sub(e.missWindowStart) > escalateMissWindow {
+		e.missWindowStart = time.Time{}
+		e.remoteMisses = 0
+	}
+	if !e.escalateNotBefore.IsZero() && now.After(e.escalateNotBefore) {
+		e.escalateNotBefore = time.Time{}
+	}
 	for name, expires := range e.negatives {
 		if now.After(expires) {
 			delete(e.negatives, name)
@@ -372,7 +450,9 @@ func (e *dirCacheEntry) negativeValid(name string, now time.Time) bool {
 }
 
 func (e *dirCacheEntry) hasState() bool {
-	return len(e.items) > 0 || len(e.negatives) > 0 || e.complete || !e.completeExpires.IsZero() || !e.sessionExpires.IsZero()
+	return len(e.items) > 0 || len(e.negatives) > 0 || e.complete ||
+		!e.completeExpires.IsZero() || !e.sessionExpires.IsZero() ||
+		!e.missWindowStart.IsZero() || !e.escalateNotBefore.IsZero()
 }
 
 func cacheParentName(p string) (string, string) {

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -821,6 +821,110 @@ func TestNamespaceCache_SessionCreatedMissIsSafeNegative(t *testing.T) {
 	}
 }
 
+func TestNamespaceCache_SessionCreatedDirOutlivesNegativeTTL(t *testing.T) {
+	dc := NewNamespaceCache(300*time.Millisecond, 10*time.Millisecond, 10)
+	dc.MarkSessionCreatedDir("/dir")
+
+	time.Sleep(50 * time.Millisecond)
+	if got := dc.Lookup("/dir", "missing"); got.kind != namespaceLookupSessionMiss {
+		t.Fatalf("lookup kind after negative TTL = %v, want session miss", got.kind)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	if got := dc.Lookup("/dir", "missing"); got.kind != namespaceLookupNone {
+		t.Fatalf("lookup kind after dir TTL = %v, want none", got.kind)
+	}
+}
+
+func TestNamespaceCache_RecordRemoteNegativeEscalatesAtThreshold(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, time.Second, 10)
+
+	for i := 1; i < escalateMissThreshold; i++ {
+		if dc.RecordRemoteNegative("/dir") {
+			t.Fatalf("miss %d escalated, want escalation only at %d", i, escalateMissThreshold)
+		}
+	}
+	if !dc.RecordRemoteNegative("/dir") {
+		t.Fatalf("miss %d did not escalate", escalateMissThreshold)
+	}
+
+	// Cooldown right after an escalation suppresses duplicates.
+	for i := 0; i < escalateMissThreshold; i++ {
+		if dc.RecordRemoteNegative("/dir") {
+			t.Fatal("escalated again during post-escalation cooldown")
+		}
+	}
+}
+
+func TestNamespaceCache_RecordRemoteNegativeWindowExpiryResets(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, time.Second, 10)
+
+	dc.RecordRemoteNegative("/dir")
+	dc.RecordRemoteNegative("/dir")
+
+	// Backdate the window: the partial count must not carry over.
+	dc.mu.Lock()
+	dc.entries["/dir"].missWindowStart = time.Now().Add(-2 * escalateMissWindow)
+	dc.mu.Unlock()
+
+	for i := 1; i < escalateMissThreshold; i++ {
+		if dc.RecordRemoteNegative("/dir") {
+			t.Fatalf("miss %d of new window escalated early", i)
+		}
+	}
+	if !dc.RecordRemoteNegative("/dir") {
+		t.Fatal("fresh window did not escalate at threshold")
+	}
+}
+
+func TestNamespaceCache_DeferEscalationCoolsDown(t *testing.T) {
+	dc := NewNamespaceCache(50*time.Millisecond, 10*time.Millisecond, 10)
+	dc.DeferEscalation("/dir")
+
+	for i := 0; i < escalateMissThreshold; i++ {
+		if dc.RecordRemoteNegative("/dir") {
+			t.Fatal("escalated during cooldown")
+		}
+	}
+
+	time.Sleep(70 * time.Millisecond)
+	for i := 1; i < escalateMissThreshold; i++ {
+		if dc.RecordRemoteNegative("/dir") {
+			t.Fatalf("miss %d after cooldown escalated early", i)
+		}
+	}
+	if !dc.RecordRemoteNegative("/dir") {
+		t.Fatal("did not escalate after cooldown expired")
+	}
+}
+
+func TestNamespaceCache_CanAnswerMisses(t *testing.T) {
+	dc := NewNamespaceCache(10*time.Second, 30*time.Millisecond, 2)
+
+	if dc.CanAnswerMisses("/dir") {
+		t.Fatal("empty cache should not answer misses")
+	}
+
+	dc.Put("/dir", []CachedFileInfo{{Name: "a.txt"}})
+	if !dc.CanAnswerMisses("/dir") {
+		t.Fatal("complete listing should answer misses")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if dc.CanAnswerMisses("/dir") {
+		t.Fatal("expired complete marker should not answer misses")
+	}
+
+	dc.Put("/big", []CachedFileInfo{{Name: "a"}, {Name: "b"}, {Name: "c"}})
+	if dc.CanAnswerMisses("/big") {
+		t.Fatal("oversized listing should not answer misses")
+	}
+
+	dc.MarkSessionCreatedDir("/session")
+	if !dc.CanAnswerMisses("/session") {
+		t.Fatal("session-created dir should answer misses")
+	}
+}
+
 func TestNamespaceCache_NegativeExpires(t *testing.T) {
 	dc := NewNamespaceCache(10*time.Second, time.Millisecond, 10)
 	dc.MarkNegative("/repo", "missing.txt")

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -105,6 +105,7 @@ type fusePerfCounters struct {
 	namespaceCompleteMiss atomicUint64
 	namespaceSessionMiss  atomicUint64
 	namespacePartialMiss  atomicUint64
+	lookupStormList       atomicUint64
 
 	lookupRetryTotal     atomicUint64
 	lookupRetrySuccess   atomicUint64
@@ -280,6 +281,7 @@ func (p *fusePerfCounters) snapshot() fusePerfSnapshot {
 	snap.Counters["namespace_complete_miss"] = p.namespaceCompleteMiss.load()
 	snap.Counters["namespace_session_miss"] = p.namespaceSessionMiss.load()
 	snap.Counters["namespace_partial_miss"] = p.namespacePartialMiss.load()
+	snap.Counters["lookup_storm_list"] = p.lookupStormList.load()
 	snap.Counters["lookup_retry_total"] = p.lookupRetryTotal.load()
 	snap.Counters["lookup_retry_success"] = p.lookupRetrySuccess.load()
 	snap.Counters["lookup_retry_exhausted"] = p.lookupRetryExhausted.load()

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -106,6 +106,7 @@ type fusePerfCounters struct {
 	namespaceSessionMiss  atomicUint64
 	namespacePartialMiss  atomicUint64
 	lookupStormList       atomicUint64
+	lookupStormDeferred   atomicUint64
 
 	lookupRetryTotal     atomicUint64
 	lookupRetrySuccess   atomicUint64
@@ -282,6 +283,7 @@ func (p *fusePerfCounters) snapshot() fusePerfSnapshot {
 	snap.Counters["namespace_session_miss"] = p.namespaceSessionMiss.load()
 	snap.Counters["namespace_partial_miss"] = p.namespacePartialMiss.load()
 	snap.Counters["lookup_storm_list"] = p.lookupStormList.load()
+	snap.Counters["lookup_storm_list_deferred"] = p.lookupStormDeferred.load()
 	snap.Counters["lookup_retry_total"] = p.lookupRetryTotal.load()
 	snap.Counters["lookup_retry_success"] = p.lookupRetrySuccess.load()
 	snap.Counters["lookup_retry_exhausted"] = p.lookupRetryExhausted.load()


### PR DESCRIPTION
## Summary
- A 10k-file fio prepare on a FUSE mount spent **13min22s (94% of wall time)** in the layout phase, paying one synchronous remote stat per missing name at ~50 lookups/s (fio probes every target file 3×before writing).
- Lookup now detects negative-lookup storms: once 3 remote ENOENT stats hit the same directory within 1s, it issues a **single listing** and the namespace cache answers the remaining misses locally, under the same negative-TTL staleness contract. Expected cost for the fio case: ~3 stats + 1 list per directory instead of 30,000 stats.
- Guards: listings that fail or exceed the 2000-entry cache limit set a one-dirTTL cooldown so sustained storms cannot turn into repeated listings; lock files are excluded because they deliberately bypass the namespace cache; `LegacyDirStatFallback` mode is excluded because it already lists per miss.
- Also fixes `MarkSessionCreatedDir` to keep its complete/session markers for the directory TTL (10s) instead of the negative TTL (1s) — the marker expired 1s after Mkdir, making it useless for the create-heavy workloads it was meant to absorb. Local mutations flow through Upsert/Remove and foreign writes invalidate via SSE, so the longer window is safe (covered by existing `TestLookupSSEForeignCreateInvalidatesSessionCreatedMiss`).
- Adds a `lookup_storm_list` perf counter to observe escalations in production.

## Test plan
- [x] New unit tests: session marker outlives negative TTL, storm threshold/window/cooldown semantics, `CanAnswerMisses`
- [x] New integration tests: 10 missing-name lookups → exactly 3 HEAD + 1 LIST, later misses and positive hits answered locally; oversized listing → exactly 1 LIST then cooldown
- [x] `go test ./pkg/fuse/` — only pre-existing failure `TestDiskReadCacheStartupRecoveryAndTempCleanup` (fails identically on clean `main`)
- [x] `go build ./...` and `go vet ./pkg/fuse/` clean
- [ ] Re-run the 10k×2MB fio prepare on the EC2 test host and compare layout-phase duration and `lookup_storm_list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced redundant remote checks for repeated lookups of missing files in the same directory by warming the directory namespace, improving responsiveness and lowering remote operations.
  * Handles oversized listings by applying a cooldown to avoid repeated expensive attempts.

* **Tests**
  * Added tests validating negative-lookup escalation, cooldowns, and namespace-cache behaviors to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->