### PR TITLE
fix: randomize semantic worker tenant pick to stop claim starvation

### DIFF
--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -565,10 +565,10 @@ func (m *semanticWorkerManager) nextTarget(ctx context.Context) (*semanticTarget
 		return nil, nil
 	}
 
-	for i := 0; i < len(refs); i++ {
-		ref, ok := m.claimTenantSlot(refs)
-		if !ok {
-			return nil, nil
+	for _, idx := range pageWalkOrder(len(refs)) {
+		ref := refs[idx]
+		if !m.tryClaimTenantSlot(ref.id) {
+			continue
 		}
 		target, err := m.targetForRef(ctx, ref)
 		if err != nil {
@@ -588,29 +588,32 @@ func (m *semanticWorkerManager) nextTarget(ctx context.Context) (*semanticTarget
 	return nil, nil
 }
 
-// claimTenantSlot picks one tenant from refs for a claim attempt. The start
-// index must be random: refs is a rotating keyset page whose length differs
-// between calls, so a persistent round-robin cursor taken modulo the current
-// page length gets clamped by the shortest page and permanently starves
-// tenants at higher in-page indices. A uniform random start visits every
-// tenant with equal probability regardless of page geometry.
-func (m *semanticWorkerManager) claimTenantSlot(refs []semanticTenantRef) (semanticTenantRef, bool) {
+// pageWalkOrder returns the visit order for one keyset page of tenants: a
+// single wrap-around walk of all indices from a uniformly random start. The
+// random start keeps scheduling fair across pages of different lengths — any
+// cursor persisted across calls and taken modulo the current page length gets
+// clamped by the shortest page and permanently starves tenants at higher
+// in-page indices. The deterministic walk after the start guarantees each
+// tenant in the page is attempted at most once per pass, so a tenant whose
+// backend consistently fails to open cannot consume retries that should move
+// on to healthy tenants.
+func pageWalkOrder(n int) []int {
+	order := make([]int, n)
+	start := rand.Intn(n)
+	for i := range order {
+		order[i] = (start + i) % n
+	}
+	return order
+}
+
+func (m *semanticWorkerManager) tryClaimTenantSlot(tenantID string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(refs) == 0 {
-		return semanticTenantRef{}, false
+	if m.inflight[tenantID] >= m.opts.PerTenantConcurrency {
+		return false
 	}
-	start := rand.Intn(len(refs))
-	for i := 0; i < len(refs); i++ {
-		idx := (start + i) % len(refs)
-		ref := refs[idx]
-		if m.inflight[ref.id] >= m.opts.PerTenantConcurrency {
-			continue
-		}
-		m.inflight[ref.id]++
-		return ref, true
-	}
-	return semanticTenantRef{}, false
+	m.inflight[tenantID]++
+	return true
 }
 
 func (m *semanticWorkerManager) releaseTenantSlot(tenantID string) {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -137,7 +138,6 @@ type semanticWorkerManager struct {
 	mu         sync.Mutex
 	inflight   map[string]int
 	processing int
-	rr         int
 
 	tenantScanCursorSet       bool
 	tenantScanCursorCreatedAt time.Time
@@ -588,13 +588,19 @@ func (m *semanticWorkerManager) nextTarget(ctx context.Context) (*semanticTarget
 	return nil, nil
 }
 
+// claimTenantSlot picks one tenant from refs for a claim attempt. The start
+// index must be random: refs is a rotating keyset page whose length differs
+// between calls, so a persistent round-robin cursor taken modulo the current
+// page length gets clamped by the shortest page and permanently starves
+// tenants at higher in-page indices. A uniform random start visits every
+// tenant with equal probability regardless of page geometry.
 func (m *semanticWorkerManager) claimTenantSlot(refs []semanticTenantRef) (semanticTenantRef, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if len(refs) == 0 {
 		return semanticTenantRef{}, false
 	}
-	start := m.rr % len(refs)
+	start := rand.Intn(len(refs))
 	for i := 0; i < len(refs); i++ {
 		idx := (start + i) % len(refs)
 		ref := refs[idx]
@@ -602,7 +608,6 @@ func (m *semanticWorkerManager) claimTenantSlot(refs []semanticTenantRef) (seman
 			continue
 		}
 		m.inflight[ref.id]++
-		m.rr = (idx + 1) % len(refs)
 		return ref, true
 	}
 	return semanticTenantRef{}, false

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -1875,3 +1875,47 @@ func TestSemanticWorkerTaskTypesForTargetDisabledAutoEmbedWithImageExtract(t *te
 		t.Fatalf("taskTypesForTarget() = %v, want to include TaskTypeImgExtractText when SupportsAsyncImageExtract=true and !UsesDatabaseAutoEmbedding", types)
 	}
 }
+
+func TestClaimTenantSlotCoversAllTenantsAcrossUnevenRotatingPages(t *testing.T) {
+	m := &semanticWorkerManager{inflight: make(map[string]int)}
+	m.opts.normalize()
+
+	// Mirror TenantScanLimit keyset pagination over 310 active tenants:
+	// rotating pages of 128, 128, and 54. A persistent round-robin cursor
+	// taken modulo the current page length gets clamped by the short page and
+	// permanently starves tenants at higher in-page indices.
+	const total = 310
+	pageBounds := [][2]int{{0, 128}, {128, 256}, {256, total}}
+	pages := make([][]semanticTenantRef, 0, len(pageBounds))
+	for _, bounds := range pageBounds {
+		page := make([]semanticTenantRef, 0, bounds[1]-bounds[0])
+		for i := bounds[0]; i < bounds[1]; i++ {
+			page = append(page, semanticTenantRef{id: fmt.Sprintf("tenant-%03d", i)})
+		}
+		pages = append(pages, page)
+	}
+
+	picked := make(map[string]bool, total)
+	// 200k ticks gives each tenant >500 expected picks, so the probability of
+	// any tenant being missed by uniform random starts is negligible.
+	for tick := 0; tick < 200000; tick++ {
+		refs := pages[tick%len(pages)]
+		ref, ok := m.claimTenantSlot(refs)
+		if !ok {
+			t.Fatalf("claimTenantSlot returned no slot at tick %d", tick)
+		}
+		picked[ref.id] = true
+		m.releaseTenantSlot(ref.id)
+	}
+
+	var starved []string
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("tenant-%03d", i)
+		if !picked[id] {
+			starved = append(starved, id)
+		}
+	}
+	if len(starved) > 0 {
+		t.Fatalf("%d of %d tenants never picked: %v", len(starved), total, starved)
+	}
+}

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -1876,46 +1876,134 @@ func TestSemanticWorkerTaskTypesForTargetDisabledAutoEmbedWithImageExtract(t *te
 	}
 }
 
-func TestClaimTenantSlotCoversAllTenantsAcrossUnevenRotatingPages(t *testing.T) {
-	m := &semanticWorkerManager{inflight: make(map[string]int)}
-	m.opts.normalize()
-
+func TestPageWalkOrderCoversAllTenantsAcrossUnevenRotatingPages(t *testing.T) {
 	// Mirror TenantScanLimit keyset pagination over 310 active tenants:
 	// rotating pages of 128, 128, and 54. A persistent round-robin cursor
 	// taken modulo the current page length gets clamped by the short page and
 	// permanently starves tenants at higher in-page indices.
 	const total = 310
 	pageBounds := [][2]int{{0, 128}, {128, 256}, {256, total}}
-	pages := make([][]semanticTenantRef, 0, len(pageBounds))
-	for _, bounds := range pageBounds {
-		page := make([]semanticTenantRef, 0, bounds[1]-bounds[0])
-		for i := bounds[0]; i < bounds[1]; i++ {
-			page = append(page, semanticTenantRef{id: fmt.Sprintf("tenant-%03d", i)})
-		}
-		pages = append(pages, page)
-	}
 
-	picked := make(map[string]bool, total)
+	picked := make(map[int]bool, total)
 	// 200k ticks gives each tenant >500 expected picks, so the probability of
 	// any tenant being missed by uniform random starts is negligible.
-	for tick := 0; tick < 200000; tick++ {
-		refs := pages[tick%len(pages)]
-		ref, ok := m.claimTenantSlot(refs)
-		if !ok {
-			t.Fatalf("claimTenantSlot returned no slot at tick %d", tick)
+	for tick := range 200000 {
+		bounds := pageBounds[tick%len(pageBounds)]
+		n := bounds[1] - bounds[0]
+		order := pageWalkOrder(n)
+		if len(order) != n {
+			t.Fatalf("pageWalkOrder(%d) returned %d indices", n, len(order))
 		}
-		picked[ref.id] = true
-		m.releaseTenantSlot(ref.id)
+		// The walk must be a complete wrap-around permutation so that within
+		// one nextTarget pass every tenant in the page is attempted at most
+		// once and failing tenants cannot absorb retries meant for others.
+		for i := 1; i < n; i++ {
+			if order[i] != (order[i-1]+1)%n {
+				t.Fatalf("pageWalkOrder(%d) is not a wrap-around walk at position %d: %v", n, i, order)
+			}
+		}
+		// When every tenant is healthy, nextTarget picks the first index.
+		picked[bounds[0]+order[0]] = true
 	}
 
-	var starved []string
-	for i := 0; i < total; i++ {
-		id := fmt.Sprintf("tenant-%03d", i)
-		if !picked[id] {
-			starved = append(starved, id)
+	var starved []int
+	for i := range total {
+		if !picked[i] {
+			starved = append(starved, i)
 		}
 	}
 	if len(starved) > 0 {
-		t.Fatalf("%d of %d tenants never picked: %v", len(starved), total, starved)
+		t.Fatalf("%d of %d tenants never picked first: %v", len(starved), total, starved)
+	}
+}
+
+func TestSemanticWorkerNextTargetSkipsFailingTenantWithinPage(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	pool := newTestTenantPool(t)
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	// The failing tenant sorts first in the keyset page (older created_at):
+	// its backend can never be acquired because port 1 refuses connections.
+	failingTenantID := token.NewID()
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               failingTenantID,
+		Status:           meta.TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           1,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now.Add(-time.Hour),
+		UpdatedAt:        now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	healthyTenantID := token.NewID()
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               healthyTenantID,
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
+
+	// Every pass over the page must reach the healthy tenant: the wrap-around
+	// walk attempts each tenant at most once, so the failing tenant cannot
+	// absorb retries meant for its neighbors. Under a per-claim random picker
+	// each pass had a 25% chance of claiming the failing tenant twice and
+	// returning nil, so 30 iterations expose that regression with probability
+	// 1 - 0.75^30 ≈ 99.98%.
+	for i := range 30 {
+		target, err := m.nextTarget(context.Background())
+		if err != nil {
+			t.Fatalf("nextTarget error at iteration %d: %v", i, err)
+		}
+		if target == nil {
+			t.Fatalf("nextTarget returned nil at iteration %d; failing tenant absorbed the page walk", i)
+		}
+		tenantID := target.tenantID
+		target.release()
+		if tenantID != healthyTenantID {
+			t.Fatalf("nextTarget picked tenant %q at iteration %d, want healthy tenant %q", tenantID, i, healthyTenantID)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- `claimTenantSlot` kept a persistent round-robin cursor taken modulo the *current* tenant page length. Keyset pages rotate with different lengths (128/128/54 at 310 active tenants in prod), so each pick on the short last page clamped the cursor back into `[0..53]`, locking the picker into a small orbit synchronized with page rotation. Simulation shows only ~54 of 310 tenants ever receive `ClaimSemanticTask` attempts in steady state; the rest are starved indefinitely (restart does not help — the orbit is deterministic from `rr=0`).
- Confirmed in prod (2026-06-11): a tenant's `img_extract_text` task sat `queued` with `attempt_count=0` for 15+ minutes while pod logs showed ~5 claims/sec against other tenants and the tenant's TiDB `statements_summary` showed the claim query had never executed there. Also explains historical multi-hour extraction delays (2026-05-23).
- Fix: pick a uniform random start index per call, which visits every tenant with equal probability regardless of page geometry. Removed the now-unused `rr` cursor.

## Test plan
- [x] New regression test `TestClaimTenantSlotCoversAllTenantsAcrossUnevenRotatingPages` simulates 128/128/54 rotating pages and asserts all 310 tenants get picked (deterministically fails on the old cursor logic)
- [x] `go test ./pkg/server/` passes
- [ ] After deploy: verify the stuck prod task `01KTTCB36QHK86YGCN765MQBQY` (tenant `2c89e856-...`) gets claimed and the image's `content_text` is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant scheduling to prevent starvation by walking tenants in a randomized-start wrap-around order and enforcing per-tenant concurrency checks, ensuring fair access across uneven tenant pages.

* **Tests**
  * Added tests validating full tenant coverage across uneven page rotations and that the scheduler skips failing tenants while continuing to select healthy ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->