### PR TITLE
perf: kick semantic worker on upload commit to claim new tasks immediately

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -117,6 +118,11 @@ type Dat9Backend struct {
 	fileGCWorker     *FileGCWorker
 	runtimeMetricsID uint64
 
+	// semanticTaskNotifier, when set, runs after a write or upload commit that
+	// enqueued at least one durable semantic task, so the semantic worker can
+	// claim it immediately instead of waiting for the tenant scan.
+	semanticTaskNotifier atomic.Pointer[func()]
+
 	// Monthly LLM cost budget (P1).
 	maxMonthlyLLMCostMillicents     int64
 	visionCostPerKTokenMillicents   int64
@@ -135,6 +141,27 @@ func newBaseBackend(store *datastore.Store) *Dat9Backend {
 		inlineThreshold:     DefaultInlineThreshold,
 		textExtractMaxBytes: DefaultTextExtractMaxBytes,
 		runtimeMetricsID:    globalBackendRuntimeMetrics.allocateID(),
+	}
+}
+
+// SetSemanticTaskEnqueuedNotifier registers fn to run after a write or upload
+// commit that enqueued at least one durable semantic task. fn must be cheap
+// and non-blocking: it is invoked inline on the write path. A dropped or
+// missing notification is safe — tasks are durable and the semantic worker's
+// periodic tenant scan claims them eventually.
+func (b *Dat9Backend) SetSemanticTaskEnqueuedNotifier(fn func()) {
+	if b == nil {
+		return
+	}
+	b.semanticTaskNotifier.Store(&fn)
+}
+
+func (b *Dat9Backend) notifySemanticTaskEnqueued(enqueued bool) {
+	if !enqueued {
+		return
+	}
+	if fn := b.semanticTaskNotifier.Load(); fn != nil && *fn != nil {
+		(*fn)()
 	}
 }
 
@@ -634,7 +661,9 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		}
 	}
 
+	var semanticTaskEnqueued bool
 	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
+		semanticTaskEnqueued = false
 		if err := b.ensureStorageQuota(ctx, tx, path, int64(len(data))); err != nil {
 			return err
 		}
@@ -669,10 +698,14 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 			}
 		}
 		if b.UsesDatabaseAutoEmbedding() {
-			return b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, fileID, 1, path, contentType)
+			created, err := b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, fileID, 1, path, contentType)
+			semanticTaskEnqueued = created
+			return err
 		}
 		if b.shouldEnqueueEmbedForRevision(path, contentType, contentText, description) {
-			return b.enqueueEmbedTaskTx(tx, fileID, 1)
+			created, err := b.enqueueEmbedTaskTx(tx, fileID, 1)
+			semanticTaskEnqueued = created
+			return err
 		}
 		return nil
 	}); err != nil {
@@ -681,6 +714,7 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		}
 		return 0, err
 	}
+	b.notifySemanticTaskEnqueued(semanticTaskEnqueued)
 	// Temporary compatibility: app embedding still relies on the legacy
 	// backend-owned image queue until its image task flow also moves to
 	// semantic_tasks.
@@ -751,7 +785,9 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 	}
 
 	var newRev int64
+	var semanticTaskEnqueued bool
 	err := b.store.InTx(ctx, func(tx *sql.Tx) error {
+		semanticTaskEnqueued = false
 		if err := b.ensureStorageQuota(ctx, tx, nf.Node.Path, int64(len(finalData))); err != nil {
 			return err
 		}
@@ -793,10 +829,14 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 			}
 		}
 		if b.UsesDatabaseAutoEmbedding() {
-			return b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, nf.File.FileID, newRev, nf.Node.Path, contentType)
+			created, err := b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, nf.File.FileID, newRev, nf.Node.Path, contentType)
+			semanticTaskEnqueued = created
+			return err
 		}
 		if b.shouldEnqueueEmbedForRevision(nf.Node.Path, contentType, contentText, description) {
-			return b.enqueueEmbedTaskTx(tx, nf.File.FileID, newRev)
+			created, err := b.enqueueEmbedTaskTx(tx, nf.File.FileID, newRev)
+			semanticTaskEnqueued = created
+			return err
 		}
 		return nil
 	})
@@ -806,6 +846,7 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 		}
 		return 0, 0, err
 	}
+	b.notifySemanticTaskEnqueued(semanticTaskEnqueued)
 	b.syncCentralFileOverwrite(ctx, nf.File.FileID, nf.File.SizeBytes, nf.File.ContentType, int64(len(finalData)), contentType)
 	// Overwrite cleanup is object-level: file_gc_tasks track deleted file
 	// identities, not old blob refs for a still-live file_id.

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -11,57 +11,62 @@ import (
 	"github.com/mem9-ai/dat9/pkg/semantic"
 )
 
-func (b *Dat9Backend) enqueueEmbedTaskTx(tx *sql.Tx, fileID string, revision int64) error {
+// The enqueue helpers report whether a task row was actually created (the
+// store dedupes identical queued tasks), so callers can fire the post-commit
+// semantic task notifier only when there is new work to claim.
+func (b *Dat9Backend) enqueueEmbedTaskTx(tx *sql.Tx, fileID string, revision int64) (bool, error) {
 	now := time.Now().UTC()
-	_, err := b.store.EnqueueSemanticTaskTx(tx, newEmbedTask(b.genID(), fileID, revision, now))
-	return err
+	return b.store.EnqueueSemanticTaskTx(tx, newEmbedTask(b.genID(), fileID, revision, now))
 }
 
-func (b *Dat9Backend) enqueueImgExtractTaskTx(tx *sql.Tx, fileID string, revision int64, path, contentType string) error {
+func (b *Dat9Backend) enqueueImgExtractTaskTx(tx *sql.Tx, fileID string, revision int64, path, contentType string) (bool, error) {
 	now := time.Now().UTC()
 	task, err := newImgExtractTask(b.genID(), fileID, revision, path, contentType, now)
 	if err != nil {
-		return err
+		return false, err
 	}
-	_, err = b.store.EnqueueSemanticTaskTx(tx, task)
-	return err
+	return b.store.EnqueueSemanticTaskTx(tx, task)
 }
 
-func (b *Dat9Backend) enqueueAudioExtractTaskTx(tx *sql.Tx, fileID string, revision int64, path, contentType string) error {
+func (b *Dat9Backend) enqueueAudioExtractTaskTx(tx *sql.Tx, fileID string, revision int64, path, contentType string) (bool, error) {
 	now := time.Now().UTC()
 	task, err := newAudioExtractTask(b.genID(), fileID, revision, path, contentType, now)
 	if err != nil {
-		return err
+		return false, err
 	}
-	_, err = b.store.EnqueueSemanticTaskTx(tx, task)
-	return err
+	return b.store.EnqueueSemanticTaskTx(tx, task)
 }
 
 // enqueueTiDBAutoSemanticTasksTx registers durable img_extract_text and/or
 // audio_extract_text tasks for one confirmed file revision in TiDB auto-embedding mode.
 // When the tenant's media LLM file quota is exceeded, no extraction tasks are
 // enqueued but the file write itself succeeds normally.
-func (b *Dat9Backend) enqueueTiDBAutoSemanticTasksTx(ctx context.Context, tx *sql.Tx, fileID string, revision int64, path, contentType string) error {
+func (b *Dat9Backend) enqueueTiDBAutoSemanticTasksTx(ctx context.Context, tx *sql.Tx, fileID string, revision int64, path, contentType string) (bool, error) {
 	isImage := b.hasAsyncImageTextSource(path, contentType)
 	isAudio := b.shouldEnqueueAudioExtractTask(path, contentType)
 	if !isImage && !isAudio {
-		return nil
+		return false, nil
 	}
 	if b.mediaLLMQuotaExceededCheckTx(ctx, tx) {
 		metrics.RecordOperation("media_llm_budget", "enqueue_skip", "quota_exceeded", 0)
-		return nil
+		return false, nil
 	}
+	enqueued := false
 	if isImage {
-		if err := b.enqueueImgExtractTaskTx(tx, fileID, revision, path, contentType); err != nil {
-			return err
+		created, err := b.enqueueImgExtractTaskTx(tx, fileID, revision, path, contentType)
+		if err != nil {
+			return enqueued, err
 		}
+		enqueued = enqueued || created
 	}
 	if isAudio {
-		if err := b.enqueueAudioExtractTaskTx(tx, fileID, revision, path, contentType); err != nil {
-			return err
+		created, err := b.enqueueAudioExtractTaskTx(tx, fileID, revision, path, contentType)
+		if err != nil {
+			return enqueued, err
 		}
+		enqueued = enqueued || created
 	}
-	return nil
+	return enqueued, nil
 }
 
 func (b *Dat9Backend) shouldEnqueueAudioExtractTask(path, contentType string) bool {

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -949,7 +949,9 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	var confirmPendingFileDurationMs float64
 	var insertNodeDurationMs float64
 	var semanticEnqueueDurationMs float64
+	var semanticTaskEnqueued bool
 	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
+		semanticTaskEnqueued = false
 		stepStart := time.Now()
 		if err := b.store.CompleteUploadTx(tx, uploadID); err != nil {
 			return err
@@ -1038,13 +1040,15 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 			}
 			if b.UsesDatabaseAutoEmbedding() {
 				stepStart = time.Now()
-				err := b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+				created, err := b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+				semanticTaskEnqueued = created
 				semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 				return err
 			}
 			if b.shouldEnqueueEmbedForRevision(upload.TargetPath, contentType, "", upload.Description) {
 				stepStart = time.Now()
-				err := b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
+				created, err := b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
+				semanticTaskEnqueued = created
 				semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 				return err
 			}
@@ -1098,13 +1102,15 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		}
 		if b.UsesDatabaseAutoEmbedding() {
 			stepStart = time.Now()
-			err := b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+			created, err := b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+			semanticTaskEnqueued = created
 			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 			return err
 		}
 		if b.shouldEnqueueEmbedForRevision(upload.TargetPath, contentType, "", upload.Description) {
 			stepStart = time.Now()
-			err := b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
+			created, err := b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
+			semanticTaskEnqueued = created
 			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 			return err
 		}
@@ -1118,6 +1124,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		return err
 	}
 	txDurationMs := uploadPhaseMs(txStart)
+	b.notifySemanticTaskEnqueued(semanticTaskEnqueued)
 
 	// Transfer server-side reservation, update file shadow state, and mark the
 	// upload-complete mutation applied in one server-DB transaction.

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -33,6 +33,14 @@ const (
 	defaultSemanticTenantScanLimit      = 128
 	defaultSemanticPerTenantConcurrency = 1
 	semanticLocalTenantID               = "local"
+	// semanticKickQueueCapacity bounds buffered upload-commit kicks; overflow
+	// kicks are dropped because the periodic tenant scan remains the durable
+	// fallback for claiming queued tasks.
+	semanticKickQueueCapacity = 256
+	// semanticKickDrainLimit caps tasks drained per kick so one busy tenant
+	// cannot monopolize a worker; the tenant is re-kicked to continue after
+	// other pending kicks get their turn.
+	semanticKickDrainLimit = 8
 )
 
 var semanticWorkerUsesTiDBAutoEmbedding = tenant.UsesTiDBAutoEmbedding
@@ -135,9 +143,12 @@ type semanticWorkerManager struct {
 	embedder embedding.Client
 	opts     SemanticWorkerOptions
 
-	mu         sync.Mutex
-	inflight   map[string]int
-	processing int
+	mu          sync.Mutex
+	inflight    map[string]int
+	processing  int
+	kickPending map[string]struct{}
+
+	kicks chan string
 
 	tenantScanCursorSet       bool
 	tenantScanCursorCreatedAt time.Time
@@ -260,7 +271,40 @@ func newSemanticWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Sto
 	opts.normalize()
 	m.opts = opts
 	m.inflight = make(map[string]int)
+	m.kickPending = make(map[string]struct{})
+	m.kicks = make(chan string, semanticKickQueueCapacity)
 	return m
+}
+
+// Kick prompts a worker to attempt claiming tasks for tenantID as soon as one
+// is idle, instead of waiting for the round-robin tenant scan to reach the
+// tenant. Kicks are best-effort: duplicates collapse while one is pending, and
+// the kick is dropped when the buffer is full — the periodic scan remains the
+// durable path that eventually claims every queued task.
+func (m *semanticWorkerManager) Kick(tenantID string) {
+	if m == nil || tenantID == "" {
+		return
+	}
+	m.mu.Lock()
+	if _, pending := m.kickPending[tenantID]; pending {
+		m.mu.Unlock()
+		return
+	}
+	m.kickPending[tenantID] = struct{}{}
+	m.mu.Unlock()
+	select {
+	case m.kicks <- tenantID:
+		metrics.RecordOperation("semantic_worker", "kick", "queued", 0)
+	default:
+		m.clearKickPending(tenantID)
+		metrics.RecordOperation("semantic_worker", "kick", "dropped", 0)
+	}
+}
+
+func (m *semanticWorkerManager) clearKickPending(tenantID string) {
+	m.mu.Lock()
+	delete(m.kickPending, tenantID)
+	m.mu.Unlock()
 }
 
 func (m *semanticWorkerManager) Start(ctx context.Context) {
@@ -320,6 +364,8 @@ func (m *semanticWorkerManager) workerLoop(ctx context.Context, workerID int) {
 		case <-ctx.Done():
 			logger.Info(ctx, "semantic_worker_stopped", zap.Int("worker_id", workerID))
 			return
+		case tenantID := <-m.kicks:
+			m.processKicked(ctx, tenantID)
 		case <-ticker.C:
 		}
 	}
@@ -350,7 +396,83 @@ func (m *semanticWorkerManager) processNext(ctx context.Context) bool {
 		return false
 	}
 	defer target.release()
+	return m.claimAndProcessOne(ctx, target)
+}
 
+// processKicked attempts to claim tasks for one kicked tenant immediately. It
+// is best-effort by design: every early return leaves the committed task to
+// the periodic tenant scan, which stays the durable claiming path.
+func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID string) {
+	// Clear the pending mark before claiming: a task committed after this
+	// point triggers a fresh kick, and a task committed before it is already
+	// visible to the claim below, so no enqueue can slip through unnoticed.
+	m.clearKickPending(tenantID)
+	ref, ok := m.kickRef(ctx, tenantID)
+	if !ok {
+		return
+	}
+	if !m.tryClaimTenantSlot(ref.id) {
+		// Another worker already holds this tenant's slot and its claim will
+		// observe any task committed before the kick was sent.
+		return
+	}
+	target, err := m.targetForRef(ctx, ref)
+	if err != nil {
+		logger.Warn(ctx, "semantic_worker_kick_open_store_failed",
+			zap.String("tenant_id", ref.id),
+			zap.Error(err))
+		m.releaseTenantSlot(ref.id)
+		return
+	}
+	target.release = chainReleases(target.release, func() { m.releaseTenantSlot(ref.id) })
+	defer target.release()
+	if len(target.allowedTaskTypes) == 0 {
+		return
+	}
+	for range semanticKickDrainLimit {
+		if ctx.Err() != nil {
+			return
+		}
+		if !m.claimAndProcessOne(ctx, target) {
+			return
+		}
+	}
+	m.Kick(tenantID)
+}
+
+// kickRef resolves a kicked tenant ID to a schedulable ref, applying the same
+// status and provider/task-type filters as the scan path (listTenantRefs).
+func (m *semanticWorkerManager) kickRef(ctx context.Context, tenantID string) (semanticTenantRef, bool) {
+	if tenantID == semanticLocalTenantID {
+		// Match scan behavior: the local fallback is only schedulable outside
+		// multi-tenant mode (listTenantRefs never enumerates it otherwise).
+		if m.meta == nil || m.pool == nil {
+			if m.shouldIncludeFallback() {
+				return semanticTenantRef{id: semanticLocalTenantID}, true
+			}
+		}
+		return semanticTenantRef{}, false
+	}
+	if m.meta == nil || m.pool == nil {
+		return semanticTenantRef{}, false
+	}
+	t, err := m.meta.GetTenant(ctx, tenantID)
+	if err != nil {
+		logger.Warn(ctx, "semantic_worker_kick_tenant_lookup_failed",
+			zap.String("tenant_id", tenantID),
+			zap.Error(err))
+		return semanticTenantRef{}, false
+	}
+	if t.Status != meta.TenantActive {
+		return semanticTenantRef{}, false
+	}
+	if !hasAnyTaskTypes(m.taskTypesForProvider(t.Provider)) {
+		return semanticTenantRef{}, false
+	}
+	return semanticTenantRef{id: t.ID, tenant: t}, true
+}
+
+func (m *semanticWorkerManager) claimAndProcessOne(ctx context.Context, target *semanticTarget) bool {
 	claimStart := time.Now()
 	task, found, err := target.store.ClaimSemanticTask(ctx, time.Now().UTC(), m.opts.LeaseDuration, target.allowedTaskTypes...)
 	if err != nil {

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -2007,3 +2007,199 @@ func TestSemanticWorkerNextTargetSkipsFailingTenantWithinPage(t *testing.T) {
 		}
 	}
 }
+
+func TestSemanticWorkerKickDedupAndOverflow(t *testing.T) {
+	m := newSemanticWorkerManager(newTestBackendForSemanticWorker(t), nil, nil, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+
+	var nilManager *semanticWorkerManager
+	nilManager.Kick("tenant") // must be a safe no-op
+
+	m.Kick("")
+	if len(m.kicks) != 0 {
+		t.Fatalf("kicks=%d after empty tenant id, want 0", len(m.kicks))
+	}
+
+	m.Kick("tenant-a")
+	m.Kick("tenant-a")
+	if len(m.kicks) != 1 {
+		t.Fatalf("kicks=%d after duplicate kick, want 1", len(m.kicks))
+	}
+
+	for i := range semanticKickQueueCapacity {
+		m.Kick(fmt.Sprintf("tenant-fill-%d", i))
+	}
+	if len(m.kicks) != semanticKickQueueCapacity {
+		t.Fatalf("kicks=%d after overflow, want %d", len(m.kicks), semanticKickQueueCapacity)
+	}
+	// A dropped kick must not stay marked pending, or later kicks for that
+	// tenant would be deduped away forever.
+	droppedID := fmt.Sprintf("tenant-fill-%d", semanticKickQueueCapacity-1)
+	m.mu.Lock()
+	_, pending := m.kickPending[droppedID]
+	m.mu.Unlock()
+	if pending {
+		t.Fatalf("tenant %s still pending after dropped kick", droppedID)
+	}
+
+	got := <-m.kicks
+	if got != "tenant-a" {
+		t.Fatalf("first queued kick=%q, want tenant-a", got)
+	}
+	m.clearKickPending(got)
+	m.Kick("tenant-a")
+	if len(m.kicks) != semanticKickQueueCapacity {
+		t.Fatalf("kicks=%d after re-kick, want %d", len(m.kicks), semanticKickQueueCapacity)
+	}
+}
+
+func TestSemanticWorkerKickClaimsFallbackTaskWithoutScan(t *testing.T) {
+	// PollInterval and RecoverInterval of one hour park the scan and recovery
+	// loops, so only the write-commit kick can drive the claim below.
+	_, b := newTestServerWithSemanticWorker(t, staticSemanticEmbedder{vec: []float32{0.1, 0.2, 0.3}}, SemanticWorkerOptions{
+		Workers:         1,
+		PollInterval:    time.Hour,
+		RecoverInterval: time.Hour,
+		LeaseDuration:   time.Minute,
+	})
+	// Let the worker finish its initial processNext pass and block in select,
+	// so a successful claim can only come from the kick.
+	time.Sleep(300 * time.Millisecond)
+	if _, err := b.Write("/docs/kick.txt", []byte("kick claims this without scan"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	nf := mustServerFile(t, b, "/docs/kick.txt")
+	waitForEmbeddingRevision(t, b, "/docs/kick.txt", 1, 5*time.Second)
+	waitForTaskStatus(t, b, nf.FileID, 1, string(semantic.TaskSucceeded), 5*time.Second)
+}
+
+func TestSemanticWorkerKickClaimsPoolTenantTaskWithoutScan(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	pool := newTestTenantPool(t)
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+
+	initServerTenantSchema(t, testDSN)
+	appStore, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetDB(t, appStore.DB())
+	if err := appStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	parsedTenant, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsedTenant.Addr != "" {
+		h, p, _ := strings.Cut(parsedTenant.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsedTenant.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	tenantMeta := &meta.Tenant{
+		ID:               token.NewID(),
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsedTenant.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsedTenant.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
+		t.Fatal(err)
+	}
+	tok, err := token.IssueToken(tokenSecret, tenantMeta.ID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokCipher, err := pool.Encrypt(context.Background(), []byte(tok))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.InsertAPIKey(context.Background(), &meta.APIKey{
+		ID:            token.NewID(),
+		TenantID:      tenantMeta.ID,
+		KeyName:       "kick-test",
+		JWTCiphertext: tokCipher,
+		JWTHash:       token.HashToken(tok),
+		TokenVersion:  1,
+		Status:        meta.APIKeyActive,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// PollInterval and RecoverInterval of one hour park the scan and recovery
+	// loops, so only the upload-commit kick can drive the claim below.
+	s := NewWithConfig(Config{Meta: metaStore, Pool: pool, TokenSecret: tokenSecret,
+		SemanticEmbedder: staticSemanticEmbedder{vec: []float32{0.1, 0.2}},
+		SemanticWorkers: SemanticWorkerOptions{
+			Workers:         1,
+			PollInterval:    time.Hour,
+			RecoverInterval: time.Hour,
+			LeaseDuration:   time.Minute,
+		}})
+	t.Cleanup(func() { s.Close() })
+	if s.semanticWorker == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Let the worker finish its initial processNext pass and block in select,
+	// so a successful claim can only come from the kick.
+	time.Sleep(300 * time.Millisecond)
+
+	body := []byte("kick claims pool tenant task without scan")
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/docs/kick.txt", strings.NewReader(string(body)))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.ContentLength = int64(len(body))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PUT status=%d body=%s", resp.StatusCode, payload)
+	}
+
+	tenantBackend, release, err := pool.Acquire(context.Background(), tenantMeta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	nf := mustServerFile(t, tenantBackend, "/docs/kick.txt")
+	waitForTaskStatus(t, tenantBackend, nf.FileID, 1, string(semantic.TaskSucceeded), 5*time.Second)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -300,6 +300,19 @@ func NewWithConfig(cfg Config) *Server {
 		s.resumeDeletingForkTenants()
 	}
 	s.semanticWorker = newSemanticWorkerManager(cfg.Backend, cfg.Meta, cfg.Pool, cfg.SemanticEmbedder, cfg.SemanticWorkers)
+	if s.semanticWorker != nil {
+		// Wire upload/write-commit kicks so freshly enqueued semantic tasks are
+		// claimed immediately instead of waiting for the tenant scan to come
+		// around (which can take many minutes with hundreds of active tenants).
+		if cfg.Pool != nil {
+			cfg.Pool.SetSemanticTaskNotifier(s.semanticWorker.Kick)
+		}
+		if cfg.Backend != nil {
+			cfg.Backend.SetSemanticTaskEnqueuedNotifier(func() {
+				s.semanticWorker.Kick(semanticLocalTenantID)
+			})
+		}
+	}
 	appManagedTaskTypes := semanticWorkerLogTaskTypesFromTypes(appManagedSemanticTaskTypes(cfg.SemanticEmbedder))
 	var fallbackTaskTypes, poolAutoTaskTypes []string
 	if cfg.Backend != nil {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -62,6 +62,7 @@ type Pool struct {
 	order                     *list.List
 	maxSize                   int
 	tidbSchemaValidationOpens atomic.Uint64
+	semanticTaskNotifier      atomic.Pointer[func(tenantID string)]
 }
 
 type tenantAutoEmbeddingProfile struct {
@@ -105,6 +106,28 @@ func (p *Pool) SetMetaStore(ms *meta.Store) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.metaStore = ms
+}
+
+// SetSemanticTaskNotifier registers a callback invoked with the tenant ID
+// whenever one of this pool's backends commits a durable semantic task, so the
+// semantic worker can claim the new work immediately instead of waiting for
+// the periodic tenant scan.
+func (p *Pool) SetSemanticTaskNotifier(fn func(tenantID string)) {
+	if p == nil {
+		return
+	}
+	p.semanticTaskNotifier.Store(&fn)
+}
+
+func (p *Pool) wireSemanticTaskNotifier(b *backend.Dat9Backend, tenantID string) {
+	// Resolve the notifier at call time, not wire time, so backends created
+	// before SetSemanticTaskNotifier (e.g. during tenant resume on startup)
+	// still notify once the semantic worker registers.
+	b.SetSemanticTaskEnqueuedNotifier(func() {
+		if fn := p.semanticTaskNotifier.Load(); fn != nil && *fn != nil {
+			(*fn)(tenantID)
+		}
+	})
 }
 
 func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backend, err error) {
@@ -586,6 +609,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			zap.Float64("create_backend_ms", backendCreateDurationMs),
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		p.wireQuotaStore(b, t.ID)
+		p.wireSemanticTaskNotifier(b, t.ID)
 		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
 		return b, store, nil
 	}
@@ -626,6 +650,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			zap.Float64("create_backend_ms", backendCreateDurationMs),
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		p.wireQuotaStore(b, t.ID)
+		p.wireSemanticTaskNotifier(b, t.ID)
 		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
 		return b, store, nil
 	}
@@ -648,6 +673,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		zap.Float64("create_backend_ms", backendCreateDurationMs),
 		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 	p.wireQuotaStore(b, t.ID)
+	p.wireSemanticTaskNotifier(b, t.ID)
 	b.StartFileGCWorker(backend.FileGCWorkerOptions{})
 	return b, store, nil
 }


### PR DESCRIPTION
## Summary
- Follow-up to #540: the scan is now fair but still slow — one random tenant per 200ms poll, and each uncached tenant visit costs a fresh cross-region TiDB connect (~2-4s), so with ~310 active tenants a freshly enqueued task waits ~20-25 min on average before its tenant is even visited (observed: prod task `01KTTG6RR43FKZEEQZXSXRVWAN` still `queued` with `attempt_count=0` 70+ minutes after upload).
- Backend enqueue helpers now return whether a semantic task row was actually created (store dedupes queued tasks) and fire a post-commit notifier only when there is new work, on all three enqueue paths (`createAndWriteCtx`, `overwriteFileCtxWithRev`, `finalizeUpload`).
- The tenant pool maps the backend notifier to the tenant ID (resolved at call time, so backends created during startup tenant-resume are still wired), and the semantic worker manager exposes `Kick(tenantID)`: deduped while pending, buffered (cap 256), dropped on overflow — the periodic scan stays the durable fallback, so a lost kick only means the old latency, never a lost task.
- An idle worker handles a kick by resolving the tenant through the same status/provider filters as the scan path (`kickRef`), claiming the per-tenant concurrency slot (dropping the kick if another worker already drains that tenant), and draining at most 8 tasks before re-kicking itself so one busy tenant cannot monopolize a worker.

## Test plan
- [x] `TestSemanticWorkerKickDedupAndOverflow` — dedup while pending, drop on full buffer without leaking the pending mark, re-kick after drain
- [x] `TestSemanticWorkerKickClaimsFallbackTaskWithoutScan` — single-tenant path: PollInterval/RecoverInterval = 1h park the scan; the write-commit kick alone gets the embed task claimed and succeeded
- [x] `TestSemanticWorkerKickClaimsPoolTenantTaskWithoutScan` — multi-tenant path: HTTP PUT through the pool tenant; kick alone gets the task succeeded
- [x] `go test ./pkg/server/ ./pkg/backend/ ./pkg/tenant/ -count=1` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Semantic tasks are now claimed and processed immediately upon enqueuement during uploads and writes, eliminating wait time for periodic scans.
  * Added per-tenant kick scheduling mechanism for faster semantic task distribution in multi-tenant environments.

* **Tests**
  * Comprehensive test coverage for semantic worker kick scheduling, including deduplication and multi-tenant task claiming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->