### PR TITLE
Fix git workspace refresh storms during native clones

### DIFF
--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -47,9 +47,10 @@ type gitWorkspaceLayer struct {
 	loadedAt   time.Time
 	workspaces []*gitWorkspaceRuntime
 
-	materialize    map[string]*gitMaterializeCall
-	hydrateStarted map[string]struct{}
-	ignoreCache    map[string]bool
+	materialize     map[string]*gitMaterializeCall
+	hydrateStarted  map[string]struct{}
+	ignoreCache     map[string]bool
+	gitStateRefresh map[string]time.Time
 }
 
 type gitWorkspaceRuntime struct {
@@ -110,9 +111,10 @@ type pendingGitOverlayEntry struct {
 
 func newGitWorkspaceLayer() *gitWorkspaceLayer {
 	return &gitWorkspaceLayer{
-		materialize:    make(map[string]*gitMaterializeCall),
-		hydrateStarted: make(map[string]struct{}),
-		ignoreCache:    make(map[string]bool),
+		materialize:     make(map[string]*gitMaterializeCall),
+		hydrateStarted:  make(map[string]struct{}),
+		ignoreCache:     make(map[string]bool),
+		gitStateRefresh: make(map[string]time.Time),
 	}
 }
 
@@ -232,10 +234,10 @@ func (fs *Dat9FS) gitWorkspaceForPath(ctx context.Context, localPath string) (*g
 	if rt, rel, ok := fs.loadedGitWorkspaceForPath(localPath); ok {
 		return rt, rel, true
 	}
-	if fs.hasLocalGitStateHint(localPath) {
+	if fs.shouldForceRefreshGitWorkspacesForGitStatePath(localPath) {
 		refreshCtx, refreshCancel := context.WithTimeout(baseCtx, fuseTimeout)
 		if err := fs.forceRefreshGitWorkspaces(refreshCtx); err != nil {
-			log.Printf("git workspace forced refresh failed for %s: %v", localPath, err)
+			log.Printf("git workspace forced refresh failed for git state path %s: %v", localPath, err)
 		}
 		refreshCancel()
 		if rt, rel, ok := fs.loadedGitWorkspaceForPath(localPath); ok {
@@ -245,28 +247,42 @@ func (fs *Dat9FS) gitWorkspaceForPath(ctx context.Context, localPath string) (*g
 	return nil, "", false
 }
 
-func (fs *Dat9FS) hasLocalGitStateHint(localPath string) bool {
-	if fs == nil || fs.localOverlay == nil {
+func (fs *Dat9FS) shouldForceRefreshGitWorkspacesForGitStatePath(localPath string) bool {
+	if fs == nil || fs.git == nil {
 		return false
 	}
+	root, ok := gitStatePathRefreshRoot(localPath)
+	if !ok {
+		return false
+	}
+	now := time.Now()
+	fs.git.mu.Lock()
+	defer fs.git.mu.Unlock()
+	if fs.git.gitStateRefresh == nil {
+		fs.git.gitStateRefresh = make(map[string]time.Time)
+	}
+	if last := fs.git.gitStateRefresh[root]; !last.IsZero() && now.Sub(last) < gitWorkspaceRefreshInterval {
+		return false
+	}
+	fs.git.gitStateRefresh[root] = now
+	return true
+}
+
+func gitStatePathRefreshRoot(localPath string) (string, bool) {
 	clean := path.Clean(localPath)
 	if clean == "." {
-		return false
+		return "", false
 	}
-	for _, part := range strings.Split(strings.Trim(clean, "/"), "/") {
+	parts := strings.Split(strings.Trim(clean, "/"), "/")
+	for i, part := range parts {
 		if part == ".git" {
-			return false
+			if clean == "/" || len(parts) == 0 {
+				return "/.git", true
+			}
+			return "/" + strings.Join(parts[:i+1], "/"), true
 		}
 	}
-	for cur := clean; cur != "."; cur = path.Dir(cur) {
-		if _, err := fs.localOverlay.Lstat(path.Join(cur, ".git")); err == nil {
-			return true
-		}
-		if cur == "/" {
-			break
-		}
-	}
-	return false
+	return "", false
 }
 
 func (fs *Dat9FS) loadedGitWorkspaceForPath(localPath string) (*gitWorkspaceRuntime, string, bool) {

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -40,6 +40,7 @@ type gitWorkspaceFixture struct {
 	mode            string
 	headCommit      string
 	deleted         bool
+	listRequests    int
 	server          *httptest.Server
 	repoURL         string
 	treeNodes       []client.GitTreeNode
@@ -207,6 +208,7 @@ func (f *gitWorkspaceFixture) handle(w http.ResponseWriter, r *http.Request) {
 	case r.Method == http.MethodGet && r.URL.Path == "/v1/git-workspaces":
 		f.mu.Lock()
 		deleted := f.deleted
+		f.listRequests++
 		f.mu.Unlock()
 		if deleted {
 			_ = json.NewEncoder(w).Encode(map[string]any{"workspaces": []client.GitWorkspace{}})
@@ -503,7 +505,7 @@ func TestEnsureGitWorkspacesKeepsPreviousSnapshotOnLoadFailure(t *testing.T) {
 	}
 }
 
-func TestGitWorkspaceForPathForceRefreshesAfterLocalGitAppears(t *testing.T) {
+func TestGitWorkspaceForPathDoesNotForceRefreshAfterNativeLocalGitAppears(t *testing.T) {
 	fixture := newGitWorkspaceFixture(t)
 	fixture.deleted = true
 	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
@@ -522,6 +524,9 @@ func TestGitWorkspaceForPathForceRefreshesAfterLocalGitAppears(t *testing.T) {
 	if initialCount != 0 {
 		t.Fatalf("initial workspace count = %d, want 0", initialCount)
 	}
+	fixture.mu.Lock()
+	initialRequests := fixture.listRequests
+	fixture.mu.Unlock()
 	if err := fs.localOverlay.Mkdir("/repo/.git", 0o755); err != nil {
 		t.Fatalf("create local .git hint: %v", err)
 	}
@@ -530,18 +535,74 @@ func TestGitWorkspaceForPathForceRefreshesAfterLocalGitAppears(t *testing.T) {
 	fixture.mu.Unlock()
 
 	entry, handled := fs.gitEntry(context.Background(), "/repo/README.md", false)
-	if !handled || entry == nil {
-		t.Fatalf("gitEntry handled=%t entry=%v, want forced refresh to load README", handled, entry)
+	if handled || entry != nil {
+		t.Fatalf("gitEntry handled=%t entry=%v, want native working tree path to stay on generic FUSE path", handled, entry)
 	}
 	fs.git.mu.Lock()
 	loadedAt := fs.git.loadedAt
 	count := len(fs.git.workspaces)
 	fs.git.mu.Unlock()
-	if count != 1 {
-		t.Fatalf("workspace count after forced refresh = %d, want 1", count)
+	if count != 0 {
+		t.Fatalf("workspace count after native working tree lookup = %d, want 0", count)
 	}
-	if !loadedAt.After(initialLoadedAt) {
-		t.Fatalf("loadedAt did not advance after forced refresh")
+	if !loadedAt.Equal(initialLoadedAt) {
+		t.Fatalf("loadedAt advanced after native working tree lookup: got %s want %s", loadedAt, initialLoadedAt)
+	}
+	fixture.mu.Lock()
+	requests := fixture.listRequests
+	fixture.mu.Unlock()
+	if requests != initialRequests {
+		t.Fatalf("workspace list requests = %d, want unchanged %d", requests, initialRequests)
+	}
+}
+
+func TestGitWorkspaceForPathForceRefreshesAfterGitStatePathAccess(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	fixture.deleted = true
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.localOverlay.EnsureRoot(); err != nil {
+		t.Fatalf("EnsureRoot: %v", err)
+	}
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("initial ensureGitWorkspaces: %v", err)
+	}
+	if err := fs.localOverlay.Mkdir("/repo/.git", 0o755); err != nil {
+		t.Fatalf("create local .git hint: %v", err)
+	}
+	fixture.mu.Lock()
+	initialRequests := fixture.listRequests
+	fixture.deleted = false
+	fixture.mu.Unlock()
+
+	rt, rel, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/.git/config")
+	if !ok || rt == nil {
+		t.Fatalf("gitWorkspaceForPath ok=%t rt=%v, want forced refresh from git state path", ok, rt)
+	}
+	if rel != ".git/config" {
+		t.Fatalf("rel = %q, want .git/config", rel)
+	}
+	fixture.mu.Lock()
+	requestsAfterRefresh := fixture.listRequests
+	fixture.mu.Unlock()
+	if requestsAfterRefresh != initialRequests+1 {
+		t.Fatalf("workspace list requests after git state refresh = %d, want %d", requestsAfterRefresh, initialRequests+1)
+	}
+
+	fs.git.mu.Lock()
+	fs.git.workspaces = nil
+	fs.git.loaded = true
+	fs.git.loadedAt = time.Now()
+	fs.git.mu.Unlock()
+	if _, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/.git/HEAD"); ok {
+		t.Fatal("second git state lookup should be throttled after recent forced refresh")
+	}
+	fixture.mu.Lock()
+	requestsAfterThrottle := fixture.listRequests
+	fixture.mu.Unlock()
+	if requestsAfterThrottle != requestsAfterRefresh {
+		t.Fatalf("workspace list requests after throttled git state lookup = %d, want %d", requestsAfterThrottle, requestsAfterRefresh)
 	}
 }
 
@@ -1129,20 +1190,21 @@ func TestGitWorkspaceRestoresLocalGitStateOnLookup(t *testing.T) {
 	}
 }
 
-func TestGitWorkspaceLocalStateHintChecksMountRootGitDir(t *testing.T) {
-	localRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(localRoot, "overlay", ".git"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	opts := &MountOptions{LocalRoot: localRoot, EnableGitWorkspaces: true}
-	opts.setDefaults()
-	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
-
-	if !fs.hasLocalGitStateHint("/README.md") {
-		t.Fatal("hasLocalGitStateHint missed mount-root .git")
-	}
-	if fs.hasLocalGitStateHint("/.git/config") {
-		t.Fatal("hasLocalGitStateHint should ignore paths inside .git")
+func TestGitStatePathRefreshRoot(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		root string
+		ok   bool
+	}{
+		{path: "/repo/.git", root: "/repo/.git", ok: true},
+		{path: "/repo/.git/config", root: "/repo/.git", ok: true},
+		{path: "/.git/HEAD", root: "/.git", ok: true},
+		{path: "/repo/src/main.go", ok: false},
+	} {
+		root, ok := gitStatePathRefreshRoot(tc.path)
+		if ok != tc.ok || root != tc.root {
+			t.Fatalf("gitStatePathRefreshRoot(%q) = %q, %t; want %q, %t", tc.path, root, ok, tc.root, tc.ok)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a regression where ordinary native `git clone` inside a Drive9 FUSE mount could repeatedly force-refresh Git workspace metadata even when the checkout was not a Drive9 fast Git workspace.

The issue came from the Git workspace discovery path: once a native clone created a local-overlay `.git` directory, regular working-tree paths under that repository were treated as a local Git state hint. Each source-file lookup could then force `GET /v1/git-workspaces`, bypassing the normal workspace refresh TTL. For a normal clone with no registered Git workspace, those refreshes were useless but landed directly on the FUSE hot path.

## Changes

- Stop using ancestor `.git` presence as a forced-refresh hint for ordinary working-tree paths.
- Keep forced refresh available for actual `.git` / Git state paths, with per-Git-root throttling.
- Preserve explicit workspace refresh marker behavior for Drive9 fast clone/worktree flows.
- Add tests covering:
  - native working-tree paths do not force refresh just because local `.git` exists;
  - `.git` state-path access can still force a refresh;
  - repeated `.git` refreshes are throttled.

This is a CLI/FUSE-only change. It does not require backend or schema changes.

## Validation

Local tests:

```bash
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./pkg/fuse
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9/cli
```

Live EC2/prod native clone retest on `drive9-posix-e2e-20260603`, using a CLI built from this branch against `https://api.drive9.ai`:

- Native `git clone https://github.com/mem9-ai/drive9.git` inside Drive9 FUSE: `28.053s`.
- `make build` immediately after clone: `103.393s`, succeeded.
- Clone + build: `131.446s`.
- `forced_refresh_count=0`.
- FUSE perf hot-path latencies dropped back to expected levels:
  - `lookup avg=2.251ms`
  - `create avg=78us`
  - `open avg=494us`
  - `release avg=427us`

Previous prod baseline observed before this fix, using the current prod binary on the same EC2/prod setup:

- Native clone: `215.343s`.
- Build failed after `30.230s` with `readdirent .../pkg/server: resource temporarily unavailable`.
- Mount logs showed repeated `git workspace forced refresh failed ... /v1/git-workspaces` entries.

Fast Git workspace regression check on the same branch CLI and prod backend:

- `drive9 git clone --fast https://github.com/mem9-ai/drive9.git`: clone `11.799s`, `git status` clean, `make build` `53.790s`, succeeded.
- `drive9 git clone --fast --blobless https://github.com/mem9-ai/drive9.git`: clone `11.819s`, `git status` clean, README read succeeded, `make build` `46.805s`, succeeded.
- `forced_refresh_count=0`, `forced_git_state_refresh_count=0`.

This confirms the refresh gating fix restores native clone behavior without regressing Drive9 fast clone or blobless fast clone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Git workspace refresh mechanism with debouncing to reduce unnecessary refresh operations.
  * Updated Git state detection to use a computed refresh root approach instead of local directory scanning.

* **Tests**
  * Updated test suite to verify debouncing behavior and new git state detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
