### PR TITLE
fix: propagate VL image extract errors instead of writing placeholder text

### DIFF
--- a/pkg/backend/image_extract_basic.go
+++ b/pkg/backend/image_extract_basic.go
@@ -46,6 +46,10 @@ type fallbackImageTextExtractor struct {
 }
 
 // NewFallbackImageTextExtractor wraps an extractor with a fallback extractor.
+// The fallback only covers primary success with empty text; primary errors
+// propagate to the caller so they surface in semantic_tasks.last_error and
+// retry with backoff, instead of being permanently masked by placeholder
+// metadata text that no log retains.
 func NewFallbackImageTextExtractor(primary, fallback ImageTextExtractor) ImageTextExtractor {
 	if primary == nil {
 		return fallback
@@ -58,20 +62,21 @@ func NewFallbackImageTextExtractor(primary, fallback ImageTextExtractor) ImageTe
 
 func (e *fallbackImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, ImageExtractUsage, error) {
 	text, usage, err := e.primary.ExtractImageText(ctx, req)
-	if err == nil && strings.TrimSpace(text) != "" {
-		return text, usage, nil
-	}
 	if err != nil {
-		logger.Warn(ctx, "backend_image_extract_primary_failed_use_fallback",
+		logger.Warn(ctx, "backend_image_extract_primary_failed",
 			zap.String("file_id", req.FileID),
 			zap.String("path", req.Path),
+			zap.String("content_type", req.ContentType),
 			zap.Error(err))
 		metrics.RecordOperation("image_extract", "fallback", "primary_error", 0)
-	} else {
-		logger.Warn(ctx, "backend_image_extract_primary_empty_use_fallback",
-			zap.String("file_id", req.FileID),
-			zap.String("path", req.Path))
-		metrics.RecordOperation("image_extract", "fallback", "primary_empty", 0)
+		return "", usage, fmt.Errorf("primary image extractor: %w", err)
 	}
+	if strings.TrimSpace(text) != "" {
+		return text, usage, nil
+	}
+	logger.Warn(ctx, "backend_image_extract_primary_empty_use_fallback",
+		zap.String("file_id", req.FileID),
+		zap.String("path", req.Path))
+	metrics.RecordOperation("image_extract", "fallback", "primary_empty", 0)
 	return e.fallback.ExtractImageText(ctx, req)
 }

--- a/pkg/backend/image_extract_basic_test.go
+++ b/pkg/backend/image_extract_basic_test.go
@@ -1,0 +1,67 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type countingImageExtractor struct {
+	text  string
+	err   error
+	calls int
+}
+
+func (e *countingImageExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, ImageExtractUsage, error) {
+	e.calls++
+	return e.text, ImageExtractUsage{}, e.err
+}
+
+func TestFallbackImageTextExtractorPropagatesPrimaryError(t *testing.T) {
+	primaryErr := errors.New("vl api: 400 unsupported image format")
+	primary := &countingImageExtractor{err: primaryErr}
+	fallback := &countingImageExtractor{text: "basic text"}
+	e := NewFallbackImageTextExtractor(primary, fallback)
+
+	_, _, err := e.ExtractImageText(context.Background(), ImageExtractRequest{FileID: "f1", Path: "/img/a.png"})
+	if !errors.Is(err, primaryErr) {
+		t.Fatalf("expected primary error to propagate, got %v", err)
+	}
+	if fallback.calls != 0 {
+		t.Fatalf("fallback must not run when primary errors, got %d calls", fallback.calls)
+	}
+}
+
+func TestFallbackImageTextExtractorUsesPrimaryText(t *testing.T) {
+	primary := &countingImageExtractor{text: "rich caption"}
+	fallback := &countingImageExtractor{text: "basic text"}
+	e := NewFallbackImageTextExtractor(primary, fallback)
+
+	text, _, err := e.ExtractImageText(context.Background(), ImageExtractRequest{FileID: "f1", Path: "/img/a.png"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "rich caption" {
+		t.Fatalf("got %q", text)
+	}
+	if fallback.calls != 0 {
+		t.Fatalf("fallback must not run on primary success, got %d calls", fallback.calls)
+	}
+}
+
+func TestFallbackImageTextExtractorFallsBackOnEmptyPrimaryText(t *testing.T) {
+	primary := &countingImageExtractor{text: "  \n"}
+	fallback := &countingImageExtractor{text: "basic text"}
+	e := NewFallbackImageTextExtractor(primary, fallback)
+
+	text, _, err := e.ExtractImageText(context.Background(), ImageExtractRequest{FileID: "f1", Path: "/img/a.png"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "basic text" {
+		t.Fatalf("got %q", text)
+	}
+	if primary.calls != 1 || fallback.calls != 1 {
+		t.Fatalf("calls primary=%d fallback=%d", primary.calls, fallback.calls)
+	}
+}


### PR DESCRIPTION
## Summary
- `fallbackImageTextExtractor` silently downgraded any VL (vision model) failure to basic metadata text (~74 chars, "image file x.png content type image/png"), leaving the semantic task `succeeded` with `last_error` NULL. With prod pod logs rotating in ~5 minutes, the real error was unrecoverable — this masked both the expired-key incident and today's AVIF-mislabeled-as-PNG uploads from photovault, and permanently destroyed extraction for transient 429/timeout failures.
- Primary errors now propagate: the semantic worker retries with backoff and persists the real error (`vision api status NNN: ...`) into `semantic_tasks.last_error`, dead-lettering after max attempts. Transient VL failures now recover via retry instead of permanently writing junk text; permanent failures stay visible in the DB.
- The basic fallback is kept only for primary success with empty text (nothing to surface there).

## Test plan
- [x] `go test ./pkg/backend/ ./pkg/server/` passes
- [x] New unit tests: primary error propagates without invoking fallback; primary text used on success; basic fallback only on empty primary text
- [ ] After deploy: upload an AVIF-named-.png via photovault, verify task retries then dead-letters with `last_error` showing the vision api error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for image text extraction—failures from the primary extractor now properly surface to the caller instead of silently attempting fallback recovery.
* Enhanced fallback behavior to distinguish between extraction errors and empty results.

## Tests
* Added comprehensive test coverage for image text extraction fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->