### PR TITLE
fix: retry deadlocked split-tables migration writes

### DIFF
--- a/pkg/migrate/lock_conflict_test.go
+++ b/pkg/migrate/lock_conflict_test.go
@@ -1,0 +1,110 @@
+package migrate
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mem9-ai/dat9/internal/testmysql"
+	"github.com/mem9-ai/dat9/pkg/datastore"
+)
+
+func TestIsLockConflictError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"mysql deadlock", errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction"), true},
+		{"deadlock message only", errors.New("Deadlock found when trying to get lock"), true},
+		{"sqlstate 40001 only", errors.New("SQLSTATE 40001 serialization failure"), true},
+		{"wrapped", errors.New("backfill file_nodes: Error 1213 (40001): Deadlock found when trying to get lock"), true},
+		{"unrelated error", errors.New("Error 1062 (23000): Duplicate entry"), false},
+		{"connection error", errors.New("driver: bad connection"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isLockConflictError(tc.err); got != tc.want {
+				t.Fatalf("isLockConflictError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// Regression for the CI flake where concurrent backend opens of the same
+// tenant DB each ran the idempotent migration and the full-table backfill
+// UPDATEs deadlocked (Error 1213). All concurrent runs must now succeed.
+func TestSplitTablesMigratorConcurrentRuns(t *testing.T) {
+	s, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+	testmysql.ResetDB(t, s.DB())
+
+	const fileCount = 300
+	var fileVals, nodeVals strings.Builder
+	for i := range fileCount {
+		if i > 0 {
+			fileVals.WriteString(",")
+			nodeVals.WriteString(",")
+		}
+		fmt.Fprintf(&fileVals, "('f%04d', 'db9', 'ref%04d', %d, 1, 'CONFIRMED')", i, i, i)
+		fmt.Fprintf(&nodeVals, "('n%04d', '/dir/f%04d.txt', '/dir', 'f%04d.txt', 0, 'f%04d', NULL)", i, i, i, i)
+	}
+	db := s.DB()
+	if _, err := db.Exec("INSERT INTO files (file_id, storage_type, storage_ref, size_bytes, revision, status) VALUES " + fileVals.String()); err != nil {
+		t.Fatalf("seed files: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, file_id, inode_id) VALUES " + nodeVals.String()); err != nil {
+		t.Fatalf("seed file_nodes: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO file_nodes (node_id, path, parent_path, name, is_directory, file_id, inode_id) VALUES ('d0001', '/dir', '/', 'dir', 1, NULL, NULL)"); err != nil {
+		t.Fatalf("seed dir node: %v", err)
+	}
+
+	const runners = 4
+	var wg sync.WaitGroup
+	errs := make([]error, runners)
+	for i := range runners {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			conn, err := sql.Open("mysql", testDSN)
+			if err != nil {
+				errs[idx] = fmt.Errorf("open conn: %w", err)
+				return
+			}
+			defer func() { _ = conn.Close() }()
+			if _, err := NewSplitTablesMigrator(conn).Run(ctx); err != nil {
+				errs[idx] = err
+			}
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("concurrent run %d failed: %v", i, err)
+		}
+	}
+
+	var inodeCount, orphanNodes int64
+	if err := db.QueryRow("SELECT COUNT(*) FROM inodes").Scan(&inodeCount); err != nil {
+		t.Fatalf("count inodes: %v", err)
+	}
+	if err := db.QueryRow("SELECT COUNT(*) FROM file_nodes WHERE inode_id IS NULL").Scan(&orphanNodes); err != nil {
+		t.Fatalf("count orphan nodes: %v", err)
+	}
+	if inodeCount != fileCount+1 {
+		t.Errorf("inodes = %d, want %d", inodeCount, fileCount+1)
+	}
+	if orphanNodes != 0 {
+		t.Errorf("file_nodes without inode_id = %d, want 0", orphanNodes)
+	}
+}

--- a/pkg/migrate/split_tables.go
+++ b/pkg/migrate/split_tables.go
@@ -240,6 +240,42 @@ func (m *SplitTablesMigrator) insertIgnore(table string, columns string, selectS
 	}
 }
 
+// execRetryingDeadlock executes a write statement, retrying transient lock
+// conflicts (MySQL Error 1213 "Deadlock found" / SQLSTATE 40001). Run is
+// idempotent and is invoked on every backend open, so concurrent opens of the
+// same tenant DB can race the full-table backfills into a deadlock; the
+// deadlock victim must retry instead of failing the backend open.
+func (m *SplitTablesMigrator) execRetryingDeadlock(ctx context.Context, query string) (sql.Result, error) {
+	const maxAttempts = 5
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		res, err := m.db.ExecContext(ctx, query)
+		if err == nil || !isLockConflictError(err) {
+			return res, err
+		}
+		lastErr = err
+		logger.Warn(ctx, "migrate_split_tables_lock_conflict_retry",
+			zap.Int("attempt", attempt),
+			zap.Error(err))
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(time.Duration(attempt) * 50 * time.Millisecond):
+		}
+	}
+	return nil, lastErr
+}
+
+func isLockConflictError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Deadlock found") ||
+		strings.Contains(msg, "Error 1213") ||
+		strings.Contains(msg, "40001")
+}
+
 func (m *SplitTablesMigrator) migrateInodes(ctx context.Context) (int64, error) {
 	sql := m.insertIgnore("inodes",
 		"inode_id, size_bytes, revision, mode, status, created_at, mtime, confirmed_at, expires_at",
@@ -248,7 +284,7 @@ func (m *SplitTablesMigrator) migrateInodes(ctx context.Context) (int64, error) 
 			COALESCE(confirmed_at, created_at), confirmed_at, expires_at
 		FROM files
 		WHERE status != 'DELETED'`, 0o644))
-	res, err := m.db.ExecContext(ctx, sql)
+	res, err := m.execRetryingDeadlock(ctx, sql)
 	if err != nil {
 		return 0, err
 	}
@@ -267,7 +303,7 @@ func (m *SplitTablesMigrator) migrateContents(ctx context.Context) (int64, error
 			content_blob, content_type, checksum_sha256, source_id
 		FROM files
 		WHERE status != 'DELETED'`, storageRefHashExpr))
-	res, err := m.db.ExecContext(ctx, sql)
+	res, err := m.execRetryingDeadlock(ctx, sql)
 	if err != nil {
 		return 0, err
 	}
@@ -298,7 +334,7 @@ func (m *SplitTablesMigrator) migrateSemantic(ctx context.Context) (int64, error
 
 	sql := m.insertIgnore("semantic", columns,
 		fmt.Sprintf(`SELECT %s FROM files WHERE status != 'DELETED'`, selectCols))
-	res, err := m.db.ExecContext(ctx, sql)
+	res, err := m.execRetryingDeadlock(ctx, sql)
 	if err != nil {
 		return 0, err
 	}
@@ -345,12 +381,12 @@ func (m *SplitTablesMigrator) createDirInodes(ctx context.Context) (int64, error
 			node_id, 0, 1, %d, 'CONFIRMED', created_at, created_at, created_at
 		FROM file_nodes
 		WHERE is_directory = 1`, 0o755))
-	res, err := m.db.ExecContext(ctx, sql)
+	res, err := m.execRetryingDeadlock(ctx, sql)
 	if err != nil {
 		return 0, err
 	}
 	// Link migrated directory inodes back to file_nodes.
-	if _, err := m.db.ExecContext(ctx, `
+	if _, err := m.execRetryingDeadlock(ctx, `
 		UPDATE file_nodes SET inode_id = node_id WHERE is_directory = 1 AND inode_id IS NULL
 	`); err != nil {
 		return 0, fmt.Errorf("backfill directory inode_id: %w", err)
@@ -371,7 +407,7 @@ func (m *SplitTablesMigrator) backfillSharedInodeID(ctx context.Context) (int64,
 
 	var total int64
 	for _, tbl := range tables {
-		res, err := m.db.ExecContext(ctx, fmt.Sprintf(`
+		res, err := m.execRetryingDeadlock(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET inode_id = %s
 			WHERE inode_id IS NULL AND %s IS NOT NULL


### PR DESCRIPTION
## Summary
- `SplitTablesMigrator.Run` is idempotent and runs on **every pool backend open** (pkg/tenant/pool.go:563). Concurrent opens of the same tenant DB race the full-table backfill `INSERT…SELECT`/`UPDATE` statements into MySQL **Error 1213 (40001) deadlocks**; the deadlock victim fails the whole backend open.
- This surfaced as a CI flake on #543: `TestSemanticWorkerKickClaimsPoolTenantTaskWithoutScan` failed in setup with `migrate split tables: backfill shared inode_id: backfill file_nodes: Error 1213 (40001): Deadlock found`.
- Fix: wrap the 6 migration write statements in `execRetryingDeadlock` — up to 5 attempts with linear backoff, retrying only deadlock/serialization (1213/40001) errors. No behavior change for any other error.

## Test plan
- [x] `TestIsLockConflictError` — table-driven classification test (deadlock / 40001 / unrelated errors)
- [x] `TestSplitTablesMigratorConcurrentRuns` — regression test: 4 migrators on separate connections run concurrently against 300 seeded legacy rows; all must succeed and converge (mirrors the concurrent-backend-open flake)
- [x] `go build ./... && go test ./pkg/migrate/ -count=1` green locally (real MySQL harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests to verify migration data integrity under concurrent operations and validate lock-conflict error handling.

* **Improvements**
  * Enhanced migration process with improved resilience during concurrent database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->