### PR TITLE
fix: harden fuse write path against daemon crash corner cases

### DIFF
--- a/e2e/fuse-crash-recovery-test.sh
+++ b/e2e/fuse-crash-recovery-test.sh
@@ -1,0 +1,545 @@
+#!/usr/bin/env bash
+# drive9 FUSE crash-recovery e2e gate.
+#
+# Simulates a daemon crash (kill -9) in the middle of the interactive write
+# path and verifies that fsync'd data survives the crash:
+#   - fsync'd small files (shadow + pending + WAL) upload after remount
+#   - a large ShadowSpill file killed mid-upload streams again after remount
+#   - a file unlinked before the crash does NOT resurrect from the WAL
+#   - the journal WAL compacts across clean remounts (no unbounded growth)
+#
+# Interactive durability contract under test: fsync() returning means the data
+# is locally durable and MUST eventually commit remotely, even if the daemon
+# dies immediately afterwards.
+
+set -euo pipefail
+
+BASE="${DRIVE9_BASE:-http://127.0.0.1:9009}"
+DRIVE9_API_KEY="${DRIVE9_API_KEY:-}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-120}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+MOUNT_READY_TIMEOUT_S="${MOUNT_READY_TIMEOUT_S:-20}"
+MOUNT_READY_INTERVAL_S="${MOUNT_READY_INTERVAL_S:-1}"
+FUSE_MOUNT_ROOT="${FUSE_MOUNT_ROOT:-/tmp}"
+FUSE_STRICT_PREREQS="${FUSE_STRICT_PREREQS:-0}"
+FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-60s}"
+CRASH_SMALL_FILES="${CRASH_SMALL_FILES:-10}"
+CRASH_SMALL_KB="${CRASH_SMALL_KB:-16}"
+CRASH_LARGE_MB="${CRASH_LARGE_MB:-96}"
+CRASH_RECOVERY_TIMEOUT_S="${CRASH_RECOVERY_TIMEOUT_S:-240}"
+CRASH_RECOVERY_INTERVAL_S="${CRASH_RECOVERY_INTERVAL_S:-2}"
+CRASH_KEEP_ARTIFACTS="${CRASH_KEEP_ARTIFACTS:-0}"
+REQUEST_MAX_RETRIES="${REQUEST_MAX_RETRIES:-8}"
+REQUEST_RETRY_SLEEP_S="${REQUEST_RETRY_SLEEP_S:-2}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+check_eq() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL + 1))
+  if [ "$got" = "$want" ]; then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    echo "  want: $want"
+    echo "  got:  $got"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@"; then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+require_cmd() {
+  local name="$1"
+  TOTAL=$((TOTAL + 1))
+  if command -v "$name" >/dev/null 2>&1; then
+    echo "PASS $name is available"
+    PASS=$((PASS + 1))
+    return 0
+  fi
+  echo "FAIL $name is available" >&2
+  FAIL=$((FAIL + 1))
+  exit 1
+}
+
+skip() {
+  echo "SKIP $*"
+  exit 0
+}
+
+skip_or_fail() {
+  if [ "$FUSE_STRICT_PREREQS" = "1" ]; then
+    echo "FAIL $*" >&2
+    exit 1
+  fi
+  skip "$@"
+}
+
+is_mounted() {
+  local mount_point="$1"
+  local physical_mount_point
+  physical_mount_point="$(cd "$(dirname "$mount_point")" 2>/dev/null && pwd -P)/$(basename "$mount_point")"
+  if command -v mountpoint >/dev/null 2>&1; then
+    mountpoint -q "$mount_point"
+    return
+  fi
+  mount | awk -v mp="$mount_point" -v pmp="$physical_mount_point" '{for(i=1;i<=NF;i++) if($i=="on" && ($(i+1)==mp || $(i+1)==pmp)) found=1} END{exit !found}'
+}
+
+wait_mount_state() {
+  local expect="$1"
+  local deadline=$(( $(date +%s) + MOUNT_READY_TIMEOUT_S ))
+  while :; do
+    if [ "$expect" = "mounted" ] && is_mounted "$MOUNT_POINT"; then
+      return 0
+    fi
+    if [ "$expect" = "unmounted" ] && ! is_mounted "$MOUNT_POINT"; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep "$MOUNT_READY_INTERVAL_S"
+  done
+}
+
+start_mount() {
+  {
+    echo "=== drive9 crash-recovery mount start time=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
+    echo "cache_dir=$CACHE_DIR"
+  } >>"$MOUNT_LOG"
+  # --foreground keeps the daemon as our child: plain `drive9 mount`
+  # daemonizes (re-execs a --foreground child and the parent exits), which
+  # would make $! useless for kill -9.
+  drive9 mount --foreground --cache-dir "$CACHE_DIR" --durability interactive "$MOUNT_POINT" >>"$MOUNT_LOG" 2>&1 &
+  MOUNT_PID="$!"
+  if wait_mount_state mounted; then
+    DAEMON_PID="$(pgrep -f "$CLI_BIN mount" 2>/dev/null | head -1)"
+    DAEMON_PID="${DAEMON_PID:-$MOUNT_PID}"
+    return 0
+  fi
+  cat "$MOUNT_LOG" >&2 || true
+  return 1
+}
+
+# crash_mount kills the daemon with SIGKILL — no flush, no cleanup — then
+# clears the stale FUSE mount point so the next mount can attach.
+crash_mount() {
+  if [ -z "${DAEMON_PID:-}" ]; then
+    return 1
+  fi
+  kill -9 "$DAEMON_PID" 2>/dev/null || return 1
+  set +e
+  if [ -n "${MOUNT_PID:-}" ]; then
+    kill -9 "$MOUNT_PID" 2>/dev/null
+    wait "$MOUNT_PID" 2>/dev/null
+  fi
+  set -e
+  MOUNT_PID=""
+  DAEMON_PID=""
+  force_unmount_stale
+  return 0
+}
+
+force_unmount_stale() {
+  set +e
+  if [ "$(uname -s)" = "Linux" ]; then
+    fusermount3 -uz "$MOUNT_POINT" 2>/dev/null \
+      || fusermount -uz "$MOUNT_POINT" 2>/dev/null \
+      || umount -l "$MOUNT_POINT" 2>/dev/null
+  else
+    umount -f "$MOUNT_POINT" 2>/dev/null \
+      || diskutil unmount force "$MOUNT_POINT" >/dev/null 2>&1
+  fi
+  wait_mount_state unmounted >/dev/null 2>&1
+  set -e
+}
+
+stop_mount() {
+  set +e
+  if [ -n "${MOUNT_POINT:-}" ] && is_mounted "$MOUNT_POINT"; then
+    drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT" >/dev/null 2>&1 || true
+    wait_mount_state unmounted >/dev/null 2>&1 || true
+  fi
+  if [ -n "${MOUNT_PID:-}" ] && kill -0 "$MOUNT_PID" >/dev/null 2>&1; then
+    kill "$MOUNT_PID" >/dev/null 2>&1 || true
+    wait "$MOUNT_PID" >/dev/null 2>&1 || true
+  fi
+  MOUNT_PID=""
+  set -e
+}
+
+unmount_mount() {
+  if is_mounted "$MOUNT_POINT"; then
+    drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT"
+  fi
+  wait_mount_state unmounted
+  if [ -n "${MOUNT_PID:-}" ]; then
+    set +e
+    wait "$MOUNT_PID" >/dev/null 2>&1
+    MOUNT_PID=""
+    set -e
+  fi
+}
+
+curl_body_code() {
+  local method="$1"
+  local url="$2"
+  local auth="${3:-}"
+  local attempt=1
+  while :; do
+    local body_file code rc
+    body_file="$(mktemp)"
+    set +e
+    if [ -n "$auth" ]; then
+      code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $auth" "$url")
+      rc=$?
+    else
+      code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" "$url")
+      rc=$?
+    fi
+    set -e
+    if [ "$rc" -ne 0 ]; then
+      code="000"
+    fi
+    if { [ "$rc" -eq 0 ] && [ "$code" != "429" ] && [ "$code" != "403" ]; } || [ "$attempt" -ge "$REQUEST_MAX_RETRIES" ]; then
+      cat "$body_file"
+      echo
+      echo "__HTTP__${code}"
+      rm -f "$body_file"
+      return "$rc"
+    fi
+    rm -f "$body_file"
+    attempt=$((attempt + 1))
+    sleep "$REQUEST_RETRY_SLEEP_S"
+  done
+}
+
+http_code() { printf '%s' "$1" | awk -F'__HTTP__' 'NF>1{print $2}' | tr -d '\n'; }
+json_body() { printf '%s' "$1" | sed '/__HTTP__/d'; }
+
+prepare_cli_binary() {
+  CLI_BIN="$(mktemp)"
+  make build-cli CLI_BIN="$CLI_BIN"
+}
+
+# write_crash_workload writes the pre-crash workload through the mount and
+# records the expected sha256 manifest. Everything is fsync'd, so the
+# interactive durability contract applies to every file. Order matters: the
+# large ShadowSpill file goes last so its async upload is most likely still
+# in flight when the daemon is killed.
+write_crash_workload() {
+  python3 - "$WORK_MOUNT" "$EXPECTED_MANIFEST" "$CRASH_SMALL_FILES" "$CRASH_SMALL_KB" "$CRASH_LARGE_MB" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+root, manifest_path = sys.argv[1], sys.argv[2]
+small_files, small_kb, large_mb = int(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5])
+
+os.makedirs(root, exist_ok=True)
+manifest = {}
+
+def write_fsync(rel, data):
+    path = os.path.join(root, rel)
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o644)
+    try:
+        off = 0
+        while off < len(data):
+            off += os.write(fd, data[off:off + (1 << 20)])
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    manifest[rel] = {"size": len(data), "sha256": hashlib.sha256(data).hexdigest()}
+
+def payload(name, size):
+    seed = hashlib.sha256(name.encode()).digest()
+    out = bytearray()
+    counter = 0
+    while len(out) < size:
+        out.extend(hashlib.sha256(seed + counter.to_bytes(8, "big")).digest())
+        counter += 1
+    return bytes(out[:size])
+
+for i in range(small_files):
+    rel = f"small-{i:02d}.bin"
+    write_fsync(rel, payload(rel, small_kb * 1024))
+
+# Unlinked-before-crash file: fsync'd then removed. Must NOT resurrect.
+write_fsync("doomed.txt", b"doomed-by-unlink\n")
+os.unlink(os.path.join(root, "doomed.txt"))
+del manifest["doomed.txt"]
+
+# Large ShadowSpill file last: its async commit is the crash victim.
+write_fsync("large-spill.bin", payload("large-spill.bin", large_mb << 20))
+
+with open(manifest_path, "w", encoding="utf-8") as f:
+    json.dump(manifest, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+# wait_remote_recovered polls until every manifest entry is readable remotely
+# with the exact expected sha256 (via drive9 fs cat), then confirms the
+# unlinked file did not resurrect.
+wait_remote_recovered() {
+  local deadline=$(( $(date +%s) + CRASH_RECOVERY_TIMEOUT_S ))
+  while :; do
+    if DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$API_KEY" HOME="$CTX_HOME" \
+      python3 - "$CLI_BIN" "$WORK_REMOTE" "$EXPECTED_MANIFEST" <<'PY'
+import hashlib
+import json
+import subprocess
+import sys
+
+cli, remote_root, manifest_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(manifest_path, encoding="utf-8") as f:
+    manifest = json.load(f)
+
+for rel, want in sorted(manifest.items()):
+    proc = subprocess.run([cli, "fs", "cat", f"{remote_root}/{rel}"], capture_output=True)
+    if proc.returncode != 0:
+        print(f"waiting: {rel}: {proc.stderr.decode(errors='replace').strip()}", file=sys.stderr)
+        raise SystemExit(1)
+    got = hashlib.sha256(proc.stdout).hexdigest()
+    if got != want["sha256"] or len(proc.stdout) != want["size"]:
+        print(f"waiting: {rel}: size={len(proc.stdout)} sha256={got} want size={want['size']} sha256={want['sha256']}", file=sys.stderr)
+        raise SystemExit(1)
+raise SystemExit(0)
+PY
+    then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep "$CRASH_RECOVERY_INTERVAL_S"
+  done
+}
+
+check_doomed_absent() {
+  local out
+  set +e
+  out=$(drive9 fs cat "$WORK_REMOTE/doomed.txt" 2>&1)
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "  doomed.txt resurrected with content: $out" >&2
+    return 1
+  fi
+  return 0
+}
+
+verify_mount_manifest() {
+  python3 - "$WORK_MOUNT" "$EXPECTED_MANIFEST" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+root, manifest_path = sys.argv[1], sys.argv[2]
+with open(manifest_path, encoding="utf-8") as f:
+    manifest = json.load(f)
+ok = True
+for rel, want in sorted(manifest.items()):
+    path = os.path.join(root, rel)
+    try:
+        with open(path, "rb") as f:
+            data = f.read()
+    except OSError as e:
+        print(f"mount read {rel}: {e}", file=sys.stderr)
+        ok = False
+        continue
+    got = hashlib.sha256(data).hexdigest()
+    if got != want["sha256"]:
+        print(f"mount sha mismatch {rel}: got {got} want {want['sha256']}", file=sys.stderr)
+        ok = False
+if os.path.exists(os.path.join(root, "doomed.txt")):
+    print("doomed.txt visible through mount after recovery", file=sys.stderr)
+    ok = False
+raise SystemExit(0 if ok else 1)
+PY
+}
+
+wal_path() {
+  # cache layout: <cache-dir>/<mountHash>/journal.wal — single mount per dir.
+  find "$CACHE_DIR" -name journal.wal 2>/dev/null | head -1
+}
+
+echo "=== drive9 FUSE crash-recovery test ==="
+echo "BASE=$BASE"
+echo "CRASH_SMALL_FILES=$CRASH_SMALL_FILES CRASH_SMALL_KB=$CRASH_SMALL_KB CRASH_LARGE_MB=$CRASH_LARGE_MB"
+echo "CRASH_RECOVERY_TIMEOUT_S=$CRASH_RECOVERY_TIMEOUT_S"
+
+require_cmd curl
+require_cmd jq
+require_cmd python3
+require_cmd go
+
+if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
+  skip_or_fail "unsupported OS for this workload"
+fi
+if [ "$(uname -s)" = "Linux" ]; then
+  if ! command -v fusermount >/dev/null 2>&1 && ! command -v fusermount3 >/dev/null 2>&1; then
+    skip_or_fail "fusermount/fusermount3 is required for Linux FUSE unmount"
+  fi
+  if [ ! -e /dev/fuse ]; then
+    skip_or_fail "/dev/fuse not available"
+  fi
+fi
+
+echo "[1] provision tenant"
+if [ -n "$DRIVE9_API_KEY" ]; then
+  API_KEY="$DRIVE9_API_KEY"
+  check_eq "use provided DRIVE9_API_KEY" "true" "true"
+else
+  resp=$(curl_body_code POST "$BASE/v1/provision")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  check_eq "POST /v1/provision returns 202" "$code" "202"
+  API_KEY=$(printf '%s' "$body" | jq -r '.api_key // empty')
+  check_cmd "provision returns api_key" test -n "$API_KEY"
+fi
+
+echo "[2] wait tenant active"
+deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+state=""
+while :; do
+  sresp=$(curl_body_code GET "$BASE/v1/status" "$API_KEY")
+  scode=$(http_code "$sresp")
+  sbody=$(json_body "$sresp")
+  state=$(printf '%s' "$sbody" | jq -r '.status // empty')
+  echo "status=${scode}:${state}"
+  if [ "$scode" = "200" ] && [ "$state" = "active" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    break
+  fi
+  sleep "$POLL_INTERVAL_S"
+done
+check_eq "tenant becomes active" "$state" "active"
+
+echo "[3] prepare drive9 cli"
+prepare_cli_binary
+check_cmd "drive9 binary ready" test -x "$CLI_BIN"
+
+# HOME is overridden so a pre-existing ~/.drive9 context cannot shadow
+# DRIVE9_SERVER (context server takes precedence over the env var).
+drive9() {
+  HOME="$CTX_HOME" DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$API_KEY" "$CLI_BIN" "$@"
+}
+
+TS="$(date +%s)"
+RUN_ROOT="$(mktemp -d "$FUSE_MOUNT_ROOT/drive9-fuse-crash-${TS}.XXXXXX")"
+RUN_ID="$(basename "$RUN_ROOT")"
+MOUNT_POINT="$RUN_ROOT/mount"
+MOUNT_LOG="$RUN_ROOT/mount.log"
+CACHE_DIR="$RUN_ROOT/cache"
+CTX_HOME="$RUN_ROOT/ctx-home"
+EXPECTED_MANIFEST="$RUN_ROOT/expected-manifest.json"
+ROOT_REL="$RUN_ID"
+ROOT_REMOTE="/$ROOT_REL"
+WORK_MOUNT="$MOUNT_POINT/$ROOT_REL/work"
+WORK_REMOTE="$ROOT_REMOTE/work"
+MOUNT_PID=""
+DAEMON_PID=""
+
+mkdir -p "$MOUNT_POINT" "$CACHE_DIR" "$CTX_HOME"
+: > "$MOUNT_LOG"
+
+cleanup() {
+  local rc=$?
+  stop_mount
+  force_unmount_stale 2>/dev/null || true
+  if [ -n "${CLI_BIN:-}" ]; then
+    rm -f "$CLI_BIN"
+  fi
+  if [ "$rc" -eq 0 ] && [ "$FAIL" -eq 0 ] && [ "$CRASH_KEEP_ARTIFACTS" != "1" ]; then
+    rm -rf "$RUN_ROOT"
+  else
+    echo "Artifacts preserved at $RUN_ROOT"
+    echo "Mount log: $MOUNT_LOG"
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+echo "[4] create remote root"
+drive9 fs mkdir "$ROOT_REMOTE" >/dev/null
+drive9 fs mkdir "$WORK_REMOTE" >/dev/null
+check_eq "remote crash-recovery root" "$ROOT_REMOTE" "$ROOT_REMOTE"
+
+echo "[5] mount (interactive durability, dedicated cache dir)"
+if start_mount; then
+  check_eq "initial mount is mounted" "true" "true"
+else
+  check_eq "initial mount is mounted" "false" "true"
+  exit 1
+fi
+
+echo "[6] write fsync'd workload (small files + unlink victim + large ShadowSpill)"
+check_cmd "pre-crash workload written and fsync'd" write_crash_workload
+
+echo "[7] kill -9 the mount daemon (no flush, no unmount)"
+check_cmd "daemon killed with SIGKILL" crash_mount
+
+WAL_FILE="$(wal_path)"
+if [ -n "$WAL_FILE" ] && [ -s "$WAL_FILE" ]; then
+  echo "INFO crash state: journal.wal present ($(wc -c <"$WAL_FILE" | tr -d ' ') bytes)"
+fi
+check_cmd "crash left durable local state (journal.wal exists)" test -n "$WAL_FILE"
+
+echo "[8] remount with the same cache dir (crash recovery)"
+if start_mount; then
+  check_eq "recovery mount is mounted" "true" "true"
+else
+  check_eq "recovery mount is mounted" "false" "true"
+  exit 1
+fi
+
+echo "[9] wait for recovered commits to reach the server"
+check_cmd "all fsync'd files recovered remotely with exact content" wait_remote_recovered
+check_cmd "unlinked file did not resurrect remotely" check_doomed_absent
+
+echo "[10] verify read-through-mount content after recovery"
+check_cmd "mount view matches expected manifest" verify_mount_manifest
+
+echo "[11] clean unmount, then remount to verify WAL compaction"
+check_cmd "clean unmount after recovery" unmount_mount
+if start_mount; then
+  check_eq "compaction mount is mounted" "true" "true"
+  WAL_FILE="$(wal_path)"
+  WAL_SIZE=0
+  if [ -n "$WAL_FILE" ]; then
+    WAL_SIZE="$(wc -c <"$WAL_FILE" | tr -d ' ')"
+  fi
+  echo "INFO post-compaction journal.wal size: $WAL_SIZE bytes"
+  # All recovered paths were committed in the previous session, so mount-time
+  # compaction must drop their frames. Allow slack for unrelated mount noise.
+  check_cmd "journal WAL compacted after clean remount (size <= 4096)" test "$WAL_SIZE" -le 4096
+  check_cmd "unmount compaction mount" unmount_mount
+else
+  check_eq "compaction mount is mounted" "false" "true"
+fi
+
+echo "[12] cleanup remote fixture"
+drive9 fs rm -r "$ROOT_REMOTE" >/dev/null 2>&1 || true
+
+echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"
+exit "$FAIL"

--- a/e2e/fuse-crash-recovery-test.sh
+++ b/e2e/fuse-crash-recovery-test.sh
@@ -390,6 +390,7 @@ require_cmd curl
 require_cmd jq
 require_cmd python3
 require_cmd go
+require_cmd make
 
 if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
   skip_or_fail "unsupported OS for this workload"

--- a/e2e/fuse-write-perf-budget-test.sh
+++ b/e2e/fuse-write-perf-budget-test.sh
@@ -462,6 +462,7 @@ require_cmd curl
 require_cmd jq
 require_cmd python3
 require_cmd go
+require_cmd make
 
 if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
   skip_or_fail "unsupported OS for this workload"

--- a/e2e/fuse-write-perf-budget-test.sh
+++ b/e2e/fuse-write-perf-budget-test.sh
@@ -1,0 +1,586 @@
+#!/usr/bin/env bash
+# drive9 FUSE write-path performance-regression gate.
+#
+# Runs a deterministic fsync-heavy write workload (creates + overwrites +
+# renames + one medium file) through an interactive-durability mount with
+# --perf-counters, waits for remote convergence, then asserts remote-op
+# budgets from the perf summary printed at clean unmount:
+#   - remote write ops scale with committed files, not with write()/fsync()
+#     syscalls (catches upload amplification)
+#   - remote stat/list ops stay bounded (catches per-write metadata storms)
+#   - remote mutation ops scale with renames (catches rename storms)
+#   - commit queue reports no enqueue errors / failures and few retries
+#   - fsync stays local-fast (catches fsync blocking on remote round trips)
+#
+# Budgets are op-count based on purpose: wall-clock thresholds flake on shared
+# infrastructure, while op counts are deterministic for a fixed workload and
+# blow past any sane budget by an order of magnitude when a storm regresses.
+
+set -euo pipefail
+
+BASE="${DRIVE9_BASE:-http://127.0.0.1:9009}"
+DRIVE9_API_KEY="${DRIVE9_API_KEY:-}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-120}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+MOUNT_READY_TIMEOUT_S="${MOUNT_READY_TIMEOUT_S:-20}"
+MOUNT_READY_INTERVAL_S="${MOUNT_READY_INTERVAL_S:-1}"
+FUSE_MOUNT_ROOT="${FUSE_MOUNT_ROOT:-/tmp}"
+FUSE_STRICT_PREREQS="${FUSE_STRICT_PREREQS:-0}"
+FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-60s}"
+REQUEST_MAX_RETRIES="${REQUEST_MAX_RETRIES:-8}"
+REQUEST_RETRY_SLEEP_S="${REQUEST_RETRY_SLEEP_S:-2}"
+
+WRITE_PERF_FILES="${WRITE_PERF_FILES:-64}"
+WRITE_PERF_FILE_KB="${WRITE_PERF_FILE_KB:-64}"
+WRITE_PERF_OVERWRITES="${WRITE_PERF_OVERWRITES:-32}"
+WRITE_PERF_RENAMES="${WRITE_PERF_RENAMES:-16}"
+WRITE_PERF_MEDIUM_MB="${WRITE_PERF_MEDIUM_MB:-8}"
+WRITE_PERF_CONVERGE_TIMEOUT_S="${WRITE_PERF_CONVERGE_TIMEOUT_S:-240}"
+WRITE_PERF_CONVERGE_INTERVAL_S="${WRITE_PERF_CONVERGE_INTERVAL_S:-2}"
+WRITE_PERF_KEEP_ARTIFACTS="${WRITE_PERF_KEEP_ARTIFACTS:-0}"
+
+# Budgets. Write ops scale with committed payloads (multipart uploads count
+# several ops per file, hence the generous per-commit factor). Stat/list also
+# get a time-scaled term because background invalidation (SSE, TTL refresh)
+# legitimately scales with uptime, like the git-workspace refresh budget.
+WRITE_PERF_WRITE_BUDGET_BASE="${WRITE_PERF_WRITE_BUDGET_BASE:-20}"
+WRITE_PERF_WRITE_BUDGET_PER_COMMIT="${WRITE_PERF_WRITE_BUDGET_PER_COMMIT:-4}"
+WRITE_PERF_STAT_BUDGET_BASE="${WRITE_PERF_STAT_BUDGET_BASE:-50}"
+WRITE_PERF_STAT_BUDGET_PER_FILE="${WRITE_PERF_STAT_BUDGET_PER_FILE:-8}"
+WRITE_PERF_STAT_BUDGET_PER_SEC="${WRITE_PERF_STAT_BUDGET_PER_SEC:-5}"
+WRITE_PERF_LIST_BUDGET_BASE="${WRITE_PERF_LIST_BUDGET_BASE:-30}"
+WRITE_PERF_LIST_BUDGET_PER_SEC="${WRITE_PERF_LIST_BUDGET_PER_SEC:-3}"
+WRITE_PERF_MUTATION_BUDGET_BASE="${WRITE_PERF_MUTATION_BUDGET_BASE:-20}"
+WRITE_PERF_MUTATION_BUDGET_PER_RENAME="${WRITE_PERF_MUTATION_BUDGET_PER_RENAME:-4}"
+WRITE_PERF_COMMIT_RETRY_BUDGET="${WRITE_PERF_COMMIT_RETRY_BUDGET:-5}"
+WRITE_PERF_FSYNC_AVG_BUDGET_MS="${WRITE_PERF_FSYNC_AVG_BUDGET_MS:-150}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+check_eq() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL + 1))
+  if [ "$got" = "$want" ]; then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    echo "  want: $want"
+    echo "  got:  $got"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@"; then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+require_cmd() {
+  local name="$1"
+  TOTAL=$((TOTAL + 1))
+  if command -v "$name" >/dev/null 2>&1; then
+    echo "PASS $name is available"
+    PASS=$((PASS + 1))
+    return 0
+  fi
+  echo "FAIL $name is available" >&2
+  FAIL=$((FAIL + 1))
+  exit 1
+}
+
+skip() {
+  echo "SKIP $*"
+  exit 0
+}
+
+skip_or_fail() {
+  if [ "$FUSE_STRICT_PREREQS" = "1" ]; then
+    echo "FAIL $*" >&2
+    exit 1
+  fi
+  skip "$@"
+}
+
+is_mounted() {
+  local mount_point="$1"
+  local physical_mount_point
+  physical_mount_point="$(cd "$(dirname "$mount_point")" 2>/dev/null && pwd -P)/$(basename "$mount_point")"
+  if command -v mountpoint >/dev/null 2>&1; then
+    mountpoint -q "$mount_point"
+    return
+  fi
+  mount | awk -v mp="$mount_point" -v pmp="$physical_mount_point" '{for(i=1;i<=NF;i++) if($i=="on" && ($(i+1)==mp || $(i+1)==pmp)) found=1} END{exit !found}'
+}
+
+wait_mount_state() {
+  local expect="$1"
+  local deadline=$(( $(date +%s) + MOUNT_READY_TIMEOUT_S ))
+  while :; do
+    if [ "$expect" = "mounted" ] && is_mounted "$MOUNT_POINT"; then
+      return 0
+    fi
+    if [ "$expect" = "unmounted" ] && ! is_mounted "$MOUNT_POINT"; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep "$MOUNT_READY_INTERVAL_S"
+  done
+}
+
+start_mount() {
+  {
+    echo "=== drive9 write-perf mount start time=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
+    echo "cache_dir=$CACHE_DIR"
+  } >>"$MOUNT_LOG"
+  # --foreground keeps the daemon as our child so its stderr (the perf
+  # summary) lands in MOUNT_LOG; plain `drive9 mount` daemonizes.
+  drive9 mount --foreground --cache-dir "$CACHE_DIR" --durability interactive --perf-counters "$MOUNT_POINT" >>"$MOUNT_LOG" 2>&1 &
+  MOUNT_PID="$!"
+  if wait_mount_state mounted; then
+    return 0
+  fi
+  cat "$MOUNT_LOG" >&2 || true
+  return 1
+}
+
+force_unmount_stale() {
+  set +e
+  if [ "$(uname -s)" = "Linux" ]; then
+    fusermount3 -uz "$MOUNT_POINT" 2>/dev/null \
+      || fusermount -uz "$MOUNT_POINT" 2>/dev/null \
+      || umount -l "$MOUNT_POINT" 2>/dev/null
+  else
+    umount -f "$MOUNT_POINT" 2>/dev/null \
+      || diskutil unmount force "$MOUNT_POINT" >/dev/null 2>&1
+  fi
+  wait_mount_state unmounted >/dev/null 2>&1
+  set -e
+}
+
+stop_mount() {
+  set +e
+  if [ -n "${MOUNT_POINT:-}" ] && is_mounted "$MOUNT_POINT"; then
+    drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT" >/dev/null 2>&1 || true
+    wait_mount_state unmounted >/dev/null 2>&1 || true
+  fi
+  if [ -n "${MOUNT_PID:-}" ] && kill -0 "$MOUNT_PID" >/dev/null 2>&1; then
+    kill "$MOUNT_PID" >/dev/null 2>&1 || true
+    wait "$MOUNT_PID" >/dev/null 2>&1 || true
+  fi
+  MOUNT_PID=""
+  set -e
+}
+
+unmount_mount() {
+  if is_mounted "$MOUNT_POINT"; then
+    drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT"
+  fi
+  wait_mount_state unmounted
+  if [ -n "${MOUNT_PID:-}" ]; then
+    set +e
+    wait "$MOUNT_PID" >/dev/null 2>&1
+    MOUNT_PID=""
+    set -e
+  fi
+}
+
+curl_body_code() {
+  local method="$1"
+  local url="$2"
+  local auth="${3:-}"
+  local attempt=1
+  while :; do
+    local body_file code rc
+    body_file="$(mktemp)"
+    set +e
+    if [ -n "$auth" ]; then
+      code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $auth" "$url")
+      rc=$?
+    else
+      code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" "$url")
+      rc=$?
+    fi
+    set -e
+    if [ "$rc" -ne 0 ]; then
+      code="000"
+    fi
+    if { [ "$rc" -eq 0 ] && [ "$code" != "429" ] && [ "$code" != "403" ]; } || [ "$attempt" -ge "$REQUEST_MAX_RETRIES" ]; then
+      cat "$body_file"
+      echo
+      echo "__HTTP__${code}"
+      rm -f "$body_file"
+      return "$rc"
+    fi
+    rm -f "$body_file"
+    attempt=$((attempt + 1))
+    sleep "$REQUEST_RETRY_SLEEP_S"
+  done
+}
+
+http_code() { printf '%s' "$1" | awk -F'__HTTP__' 'NF>1{print $2}' | tr -d '\n'; }
+json_body() { printf '%s' "$1" | sed '/__HTTP__/d'; }
+
+prepare_cli_binary() {
+  CLI_BIN="$(mktemp)"
+  make build-cli CLI_BIN="$CLI_BIN"
+}
+
+# write_perf_workload performs the deterministic write workload through the
+# mount and records the expected final-state sha256 manifest:
+#   - WRITE_PERF_FILES files of WRITE_PERF_FILE_KB KiB, write+fsync each
+#   - first WRITE_PERF_OVERWRITES files overwritten with new content + fsync
+#   - next WRITE_PERF_RENAMES files renamed (exercises pending rename)
+#   - one WRITE_PERF_MEDIUM_MB MiB file
+write_perf_workload() {
+  python3 - "$WORK_MOUNT" "$EXPECTED_MANIFEST" \
+    "$WRITE_PERF_FILES" "$WRITE_PERF_FILE_KB" \
+    "$WRITE_PERF_OVERWRITES" "$WRITE_PERF_RENAMES" "$WRITE_PERF_MEDIUM_MB" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+root, manifest_path = sys.argv[1], sys.argv[2]
+n_files, file_kb = int(sys.argv[3]), int(sys.argv[4])
+n_overwrites, n_renames, medium_mb = int(sys.argv[5]), int(sys.argv[6]), int(sys.argv[7])
+if n_overwrites + n_renames > n_files:
+    raise SystemExit("overwrites + renames must fit in file count")
+
+os.makedirs(root, exist_ok=True)
+manifest = {}
+
+def payload(name, size):
+    seed = hashlib.sha256(name.encode()).digest()
+    out = bytearray()
+    counter = 0
+    while len(out) < size:
+        out.extend(hashlib.sha256(seed + counter.to_bytes(8, "big")).digest())
+        counter += 1
+    return bytes(out[:size])
+
+def write_fsync(rel, data):
+    path = os.path.join(root, rel)
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o644)
+    try:
+        off = 0
+        while off < len(data):
+            off += os.write(fd, data[off:off + (1 << 20)])
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    manifest[rel] = {"size": len(data), "sha256": hashlib.sha256(data).hexdigest()}
+
+size = file_kb * 1024
+for i in range(n_files):
+    rel = f"small-{i:03d}.bin"
+    write_fsync(rel, payload(rel, size))
+
+for i in range(n_overwrites):
+    rel = f"small-{i:03d}.bin"
+    write_fsync(rel, payload(rel + "-v2", size))
+
+for i in range(n_overwrites, n_overwrites + n_renames):
+    old = f"small-{i:03d}.bin"
+    new = f"renamed-{i:03d}.bin"
+    os.rename(os.path.join(root, old), os.path.join(root, new))
+    manifest[new] = manifest.pop(old)
+
+write_fsync("medium.bin", payload("medium.bin", medium_mb << 20))
+
+with open(manifest_path, "w", encoding="utf-8") as f:
+    json.dump(manifest, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+# wait_remote_converged polls until every manifest entry is readable remotely
+# with the exact expected sha256 (via drive9 fs cat).
+wait_remote_converged() {
+  local deadline=$(( $(date +%s) + WRITE_PERF_CONVERGE_TIMEOUT_S ))
+  while :; do
+    if DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$API_KEY" HOME="$CTX_HOME" \
+      python3 - "$CLI_BIN" "$WORK_REMOTE" "$EXPECTED_MANIFEST" <<'PY'
+import hashlib
+import json
+import subprocess
+import sys
+
+cli, remote_root, manifest_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(manifest_path, encoding="utf-8") as f:
+    manifest = json.load(f)
+
+for rel, want in sorted(manifest.items()):
+    proc = subprocess.run([cli, "fs", "cat", f"{remote_root}/{rel}"], capture_output=True)
+    if proc.returncode != 0:
+        print(f"waiting: {rel}: {proc.stderr.decode(errors='replace').strip()}", file=sys.stderr)
+        raise SystemExit(1)
+    got = hashlib.sha256(proc.stdout).hexdigest()
+    if got != want["sha256"] or len(proc.stdout) != want["size"]:
+        print(f"waiting: {rel}: size={len(proc.stdout)} sha256={got} want size={want['size']} sha256={want['sha256']}", file=sys.stderr)
+        raise SystemExit(1)
+raise SystemExit(0)
+PY
+    then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep "$WRITE_PERF_CONVERGE_INTERVAL_S"
+  done
+}
+
+# check_write_perf_budgets parses the perf summary that --perf-counters prints
+# at clean unmount and enforces op-count budgets. Ops absent from the summary
+# have count 0 (printSummary skips zero-count ops).
+check_write_perf_budgets() {
+  local log_file="$1"
+  local out rc
+  set +e
+  out=$(python3 - "$log_file" \
+    "$WRITE_PERF_FILES" "$WRITE_PERF_OVERWRITES" "$WRITE_PERF_RENAMES" \
+    "$WRITE_PERF_WRITE_BUDGET_BASE" "$WRITE_PERF_WRITE_BUDGET_PER_COMMIT" \
+    "$WRITE_PERF_STAT_BUDGET_BASE" "$WRITE_PERF_STAT_BUDGET_PER_FILE" "$WRITE_PERF_STAT_BUDGET_PER_SEC" \
+    "$WRITE_PERF_LIST_BUDGET_BASE" "$WRITE_PERF_LIST_BUDGET_PER_SEC" \
+    "$WRITE_PERF_MUTATION_BUDGET_BASE" "$WRITE_PERF_MUTATION_BUDGET_PER_RENAME" \
+    "$WRITE_PERF_COMMIT_RETRY_BUDGET" "$WRITE_PERF_FSYNC_AVG_BUDGET_MS" <<'PY'
+import re
+import sys
+
+(log_path,
+ n_files, n_overwrites, n_renames,
+ write_base, write_per_commit,
+ stat_base, stat_per_file, stat_per_sec,
+ list_base, list_per_sec,
+ mut_base, mut_per_rename,
+ retry_budget, fsync_avg_budget_ms) = sys.argv[1], *map(int, sys.argv[2:])
+
+UNIT_SECONDS = {"h": 3600.0, "m": 60.0, "s": 1.0, "ms": 1e-3, "µs": 1e-6, "us": 1e-6, "ns": 1e-9}
+
+def parse_duration(text):
+    total = 0.0
+    for m in re.finditer(r"([0-9.]+)(h|ms|m|s|µs|us|ns)", text):
+        total += float(m.group(1)) * UNIT_SECONDS[m.group(2)]
+    return total
+
+uptime = None
+remote = {}
+fuse = {}
+commit = None
+with open(log_path, "r", errors="replace") as handle:
+    for line in handle:
+        m = re.search(r"drive9: FUSE perf summary uptime=(\S+)", line)
+        if m:
+            uptime = parse_duration(m.group(1))
+            remote.clear()
+            fuse.clear()
+            commit = None
+            continue
+        m = re.search(r"drive9: perf (remote|fuse) (\S+) count=(\d+) errors=(\d+) bytes=(\d+) avg=(\S+)", line)
+        if m:
+            group, name = m.group(1), m.group(2)
+            stats = {"count": int(m.group(3)), "errors": int(m.group(4)),
+                     "avg_s": parse_duration(m.group(6))}
+            (remote if group == "remote" else fuse)[name] = stats
+            continue
+        m = re.search(r"drive9: perf commit enqueue=(\d+) enqueue_errors=(\d+) retries=(\d+) success=(\d+) failure=(\d+)", line)
+        if m:
+            commit = {"enqueue": int(m.group(1)), "enqueue_errors": int(m.group(2)),
+                      "retries": int(m.group(3)), "success": int(m.group(4)),
+                      "failure": int(m.group(5))}
+
+if uptime is None or commit is None:
+    print(f"perf summary not found in {log_path} (uptime={uptime} commit={commit})")
+    raise SystemExit(2)
+
+def count(table, name):
+    return table.get(name, {"count": 0})["count"]
+
+seconds = int(uptime) + 1
+expected_commits = n_files + n_overwrites + 1  # +1 medium file
+write_budget = write_base + write_per_commit * expected_commits
+stat_budget = stat_base + stat_per_file * (n_files + 1) + stat_per_sec * seconds
+list_budget = list_base + list_per_sec * seconds
+mut_budget = mut_base + mut_per_rename * n_renames
+
+failures = []
+
+def budget(name, got, limit):
+    line = f"{name}={got}/{limit}"
+    if got > limit:
+        failures.append(line)
+    return line
+
+report = [
+    f"uptime={uptime:.1f}s",
+    budget("remote_write", count(remote, "write"), write_budget),
+    budget("remote_stat", count(remote, "stat"), stat_budget),
+    budget("remote_list", count(remote, "list"), list_budget),
+    budget("remote_mutation", count(remote, "mutation"), mut_budget),
+    budget("commit_retries", commit["retries"], retry_budget),
+    budget("commit_enqueue_errors", commit["enqueue_errors"], 0),
+    budget("commit_failures", commit["failure"], 0),
+]
+
+fsync_avg_ms = fuse.get("fsync", {"avg_s": 0.0})["avg_s"] * 1000.0
+report.append(budget("fsync_avg_ms", int(fsync_avg_ms), fsync_avg_budget_ms))
+
+print(" ".join(report))
+raise SystemExit(1 if failures else 0)
+PY
+  )
+  rc=$?
+  set -e
+  TOTAL=$((TOTAL + 1))
+  if [ "$rc" -eq 0 ]; then
+    echo "PASS write-path perf budgets ($out)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL write-path perf budgets ($out)" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== drive9 FUSE write-path perf budget test ==="
+echo "BASE=$BASE"
+echo "WRITE_PERF_FILES=$WRITE_PERF_FILES WRITE_PERF_FILE_KB=$WRITE_PERF_FILE_KB WRITE_PERF_OVERWRITES=$WRITE_PERF_OVERWRITES WRITE_PERF_RENAMES=$WRITE_PERF_RENAMES WRITE_PERF_MEDIUM_MB=$WRITE_PERF_MEDIUM_MB"
+
+require_cmd curl
+require_cmd jq
+require_cmd python3
+require_cmd go
+
+if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
+  skip_or_fail "unsupported OS for this workload"
+fi
+if [ "$(uname -s)" = "Linux" ]; then
+  if ! command -v fusermount >/dev/null 2>&1 && ! command -v fusermount3 >/dev/null 2>&1; then
+    skip_or_fail "fusermount/fusermount3 is required for Linux FUSE unmount"
+  fi
+  if [ ! -e /dev/fuse ]; then
+    skip_or_fail "/dev/fuse not available"
+  fi
+fi
+
+echo "[1] provision tenant"
+if [ -n "$DRIVE9_API_KEY" ]; then
+  API_KEY="$DRIVE9_API_KEY"
+  check_eq "use provided DRIVE9_API_KEY" "true" "true"
+else
+  resp=$(curl_body_code POST "$BASE/v1/provision")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  check_eq "POST /v1/provision returns 202" "$code" "202"
+  API_KEY=$(printf '%s' "$body" | jq -r '.api_key // empty')
+  check_cmd "provision returns api_key" test -n "$API_KEY"
+fi
+
+echo "[2] wait tenant active"
+deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+state=""
+while :; do
+  sresp=$(curl_body_code GET "$BASE/v1/status" "$API_KEY")
+  scode=$(http_code "$sresp")
+  sbody=$(json_body "$sresp")
+  state=$(printf '%s' "$sbody" | jq -r '.status // empty')
+  echo "status=${scode}:${state}"
+  if [ "$scode" = "200" ] && [ "$state" = "active" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    break
+  fi
+  sleep "$POLL_INTERVAL_S"
+done
+check_eq "tenant becomes active" "$state" "active"
+
+echo "[3] prepare drive9 cli"
+prepare_cli_binary
+check_cmd "drive9 binary ready" test -x "$CLI_BIN"
+
+# HOME is overridden so a pre-existing ~/.drive9 context cannot shadow
+# DRIVE9_SERVER (context server takes precedence over the env var).
+drive9() {
+  HOME="$CTX_HOME" DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$API_KEY" "$CLI_BIN" "$@"
+}
+
+TS="$(date +%s)"
+RUN_ROOT="$(mktemp -d "$FUSE_MOUNT_ROOT/drive9-fuse-write-perf-${TS}.XXXXXX")"
+RUN_ID="$(basename "$RUN_ROOT")"
+MOUNT_POINT="$RUN_ROOT/mount"
+MOUNT_LOG="$RUN_ROOT/mount.log"
+CACHE_DIR="$RUN_ROOT/cache"
+CTX_HOME="$RUN_ROOT/ctx-home"
+EXPECTED_MANIFEST="$RUN_ROOT/expected-manifest.json"
+ROOT_REL="$RUN_ID"
+ROOT_REMOTE="/$ROOT_REL"
+WORK_MOUNT="$MOUNT_POINT/$ROOT_REL/work"
+WORK_REMOTE="$ROOT_REMOTE/work"
+MOUNT_PID=""
+
+mkdir -p "$MOUNT_POINT" "$CACHE_DIR" "$CTX_HOME"
+: > "$MOUNT_LOG"
+
+cleanup() {
+  local rc=$?
+  stop_mount
+  force_unmount_stale 2>/dev/null || true
+  if [ -n "${CLI_BIN:-}" ]; then
+    rm -f "$CLI_BIN"
+  fi
+  if [ "$rc" -eq 0 ] && [ "$FAIL" -eq 0 ] && [ "$WRITE_PERF_KEEP_ARTIFACTS" != "1" ]; then
+    rm -rf "$RUN_ROOT"
+  else
+    echo "Artifacts preserved at $RUN_ROOT"
+    echo "Mount log: $MOUNT_LOG"
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+echo "[4] create remote root"
+drive9 fs mkdir "$ROOT_REMOTE" >/dev/null
+drive9 fs mkdir "$WORK_REMOTE" >/dev/null
+check_eq "remote write-perf root" "$ROOT_REMOTE" "$ROOT_REMOTE"
+
+echo "[5] mount (interactive durability, perf counters)"
+if start_mount; then
+  check_eq "mount is mounted" "true" "true"
+else
+  check_eq "mount is mounted" "false" "true"
+  exit 1
+fi
+
+echo "[6] run fsync-heavy write workload"
+WORKLOAD_START="$(date +%s)"
+check_cmd "write workload completes" write_perf_workload
+WORKLOAD_SECONDS=$(( $(date +%s) - WORKLOAD_START ))
+echo "INFO workload wall time: ${WORKLOAD_SECONDS}s"
+
+echo "[7] wait for remote convergence"
+check_cmd "all files converged remotely with exact content" wait_remote_converged
+
+echo "[8] clean unmount (flushes perf summary)"
+check_cmd "clean unmount" unmount_mount
+
+echo "[9] enforce write-path perf budgets"
+check_write_perf_budgets "$MOUNT_LOG"
+
+echo "[10] cleanup remote fixture"
+drive9 fs rm -r "$ROOT_REMOTE" >/dev/null 2>&1 || true
+
+echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"
+exit "$FAIL"

--- a/e2e/git-ops-smoke-test.sh
+++ b/e2e/git-ops-smoke-test.sh
@@ -34,6 +34,7 @@ GIT_OPS_REFRESH_BUDGET_BASE="${GIT_OPS_REFRESH_BUDGET_BASE:-20}"
 GIT_OPS_REFRESH_BUDGET_PER_SEC="${GIT_OPS_REFRESH_BUDGET_PER_SEC:-6}"
 GIT_OPS_FORCED_REFRESH_BUDGET_BASE="${GIT_OPS_FORCED_REFRESH_BUDGET_BASE:-10}"
 GIT_OPS_FORCED_REFRESH_BUDGET_PER_SEC="${GIT_OPS_FORCED_REFRESH_BUDGET_PER_SEC:-3}"
+GIT_OPS_STATUS_SETTLE_TIMEOUT_S="${GIT_OPS_STATUS_SETTLE_TIMEOUT_S:-60}"
 
 export GIT_ALLOW_PROTOCOL="${GIT_ALLOW_PROTOCOL:-file:https:http:ssh}"
 
@@ -562,6 +563,36 @@ capture_git_state() {
   cat "$repo/untracked.txt" > "$out_dir/untracked-content.txt"
 }
 
+# Blobless workspaces register tree entries with unknown blob sizes and only
+# learn them as the async hydrator fills the local git cache. Until then,
+# getattr reports a placeholder size, and `git status` flags those entries as
+# phantom-modified purely from the stat-size mismatch (it never re-reads
+# content when sizes differ). The restored state is eventually consistent, so
+# poll until status converges before asserting strict equality below.
+wait_restored_status_settled() {
+  local repo="$1"
+  local expected="$2"
+  local start
+  start=$(date +%s)
+  local deadline=$(( start + GIT_OPS_STATUS_SETTLE_TIMEOUT_S ))
+  local out waited=0
+  while :; do
+    out="$(git_cmd -C "$repo" status --porcelain=v1 --untracked-files=all 2>/dev/null || true)"
+    if [ "$out" = "$(cat "$expected" 2>/dev/null)" ]; then
+      if [ "$waited" = "1" ]; then
+        echo "INFO restored status settled after $(( $(date +%s) - start ))s"
+      fi
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "INFO restored status did not settle within ${GIT_OPS_STATUS_SETTLE_TIMEOUT_S}s" >&2
+      return 0 # let the strict check below report the diff
+    fi
+    waited=1
+    sleep 1
+  done
+}
+
 verify_restored_git_state() {
   local repo="$1"
   local state_dir="$2"
@@ -570,6 +601,7 @@ verify_restored_git_state() {
   mkdir -p "$actual_dir"
 
   check_cmd "restored repo ready" assert_repo_ready "$repo"
+  wait_restored_status_settled "$repo" "$state_dir/status.txt"
   if ! capture_git_state "$repo" "$actual_dir"; then
     check_cmd "restored git state capture" false
     return 0

--- a/e2e/git-ops-smoke-test.sh
+++ b/e2e/git-ops-smoke-test.sh
@@ -24,6 +24,16 @@ GIT_OPS_HYDRATE="${GIT_OPS_HYDRATE:-off}"
 GIT_OPS_KEEP_ARTIFACTS="${GIT_OPS_KEEP_ARTIFACTS:-0}"
 GIT_OPS_TRACE_GIT="${GIT_OPS_TRACE_GIT:-0}"
 GIT_OPS_LOG_AUDIT_PATTERN="${GIT_OPS_LOG_AUDIT_PATTERN:-panic|fatal error|short read|input/output error}"
+GIT_OPS_FIXTURE_TREE_FILES="${GIT_OPS_FIXTURE_TREE_FILES:-128}"
+# Regression guard for git-workspace refresh storms (one remote refresh per
+# FUSE op instead of per TTL window). Healthy refresh traffic is time-bounded
+# (~1/s TTL + ~1/s throttled force), so the budget scales with mount uptime;
+# a storm scales with op count and blows past it by an order of magnitude.
+GIT_OPS_REFRESH_GUARD="${GIT_OPS_REFRESH_GUARD:-1}"
+GIT_OPS_REFRESH_BUDGET_BASE="${GIT_OPS_REFRESH_BUDGET_BASE:-20}"
+GIT_OPS_REFRESH_BUDGET_PER_SEC="${GIT_OPS_REFRESH_BUDGET_PER_SEC:-6}"
+GIT_OPS_FORCED_REFRESH_BUDGET_BASE="${GIT_OPS_FORCED_REFRESH_BUDGET_BASE:-10}"
+GIT_OPS_FORCED_REFRESH_BUDGET_PER_SEC="${GIT_OPS_FORCED_REFRESH_BUDGET_PER_SEC:-3}"
 
 export GIT_ALLOW_PROTOCOL="${GIT_ALLOW_PROTOCOL:-file:https:http:ssh}"
 
@@ -419,9 +429,70 @@ EOF
 prepare_fixture() {
   FIXTURE_ROOT="$RUN_ROOT/fixture"
   local json
-  json="$(python3 "$SCRIPT_DIR/git_fixture.py" "$FIXTURE_ROOT" --force)"
+  json="$(python3 "$SCRIPT_DIR/git_fixture.py" "$FIXTURE_ROOT" --force --tree-files "$GIT_OPS_FIXTURE_TREE_FILES")"
   FIXTURE_URL="$(jq -r '.file_url' <<<"$json")"
   test -n "$FIXTURE_URL"
+}
+
+check_workspace_refresh_budget() {
+  local desc="$1"
+  local log_file="$2"
+  if [ "$GIT_OPS_REFRESH_GUARD" != "1" ]; then
+    return 0
+  fi
+  TOTAL=$((TOTAL + 1))
+  local out rc
+  set +e
+  out=$(python3 - "$log_file" \
+    "$GIT_OPS_REFRESH_BUDGET_BASE" "$GIT_OPS_REFRESH_BUDGET_PER_SEC" \
+    "$GIT_OPS_FORCED_REFRESH_BUDGET_BASE" "$GIT_OPS_FORCED_REFRESH_BUDGET_PER_SEC" <<'PY'
+import re
+import sys
+
+log_path = sys.argv[1]
+refresh_base, refresh_per_sec = int(sys.argv[2]), int(sys.argv[3])
+forced_base, forced_per_sec = int(sys.argv[4]), int(sys.argv[5])
+
+UNIT_SECONDS = {"h": 3600.0, "m": 60.0, "s": 1.0, "ms": 1e-3, "µs": 1e-6, "us": 1e-6, "ns": 1e-9}
+
+def parse_duration(text):
+    total = 0.0
+    for m in re.finditer(r"([0-9.]+)(h|ms|m|s|µs|us|ns)", text):
+        total += float(m.group(1)) * UNIT_SECONDS[m.group(2)]
+    return total
+
+uptime = refresh = forced = None
+with open(log_path, "r", errors="replace") as handle:
+    for line in handle:
+        m = re.search(r"drive9: FUSE perf summary uptime=(\S+)", line)
+        if m:
+            uptime = parse_duration(m.group(1))
+        m = re.search(r"drive9: perf git_workspace refresh=(\d+) forced_refresh=(\d+)", line)
+        if m:
+            refresh, forced = int(m.group(1)), int(m.group(2))
+
+if uptime is None or refresh is None or forced is None:
+    print(f"perf summary not found in {log_path} (uptime={uptime} refresh={refresh} forced={forced})")
+    raise SystemExit(2)
+
+seconds = int(uptime) + 1
+refresh_budget = refresh_base + refresh_per_sec * seconds
+forced_budget = forced_base + forced_per_sec * seconds
+print(
+    f"uptime={uptime:.1f}s refresh={refresh}/{refresh_budget} forced={forced}/{forced_budget}"
+)
+raise SystemExit(0 if refresh <= refresh_budget and forced <= forced_budget else 1)
+PY
+  )
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "PASS $desc ($out)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc ($out)" >&2
+    FAIL=$((FAIL + 1))
+  fi
 }
 
 configure_git_identity() {
@@ -592,9 +663,11 @@ run_case() {
 
   if [ "$use_native_pack" = "1" ]; then
     stop_mount 1 "$native_pack_archive" "repo/.git"
+    check_workspace_refresh_budget "$slug first mount workspace refresh within budget" "$log_a"
     check_cmd "$slug second mount starts" start_mount "$profile" "$mount_b" "$local_root_b" "$log_b" "$remote_root" 1 "$native_pack_archive"
   else
     stop_mount 1
+    check_workspace_refresh_budget "$slug first mount workspace refresh within budget" "$log_a"
     check_cmd "$slug second mount starts" start_mount "$profile" "$mount_b" "$local_root_b" "$log_b" "$remote_root" 1
   fi
 
@@ -602,6 +675,7 @@ run_case() {
   check_cmd "$slug post-restore commit" commit_after_restore "$repo_b" "$marker"
   check_cmd "$slug second mount log audit" audit_mount_log "$log_b"
   stop_mount 1
+  check_workspace_refresh_budget "$slug second mount workspace refresh within budget" "$log_b"
 }
 
 precheck_fuse() {

--- a/e2e/git_fixture.py
+++ b/e2e/git_fixture.py
@@ -51,7 +51,7 @@ def init_repo(repo: Path) -> None:
     run(repo, "config", "core.filemode", "true")
 
 
-def build_fixture(root: Path) -> dict[str, str]:
+def build_fixture(root: Path, tree_files: int = 0) -> dict[str, str]:
     source = root / "source"
     bare = root / "remote.git"
     if source.exists() or bare.exists():
@@ -67,6 +67,8 @@ def build_fixture(root: Path) -> dict[str, str]:
     write(source / "binary.bin", bytes(range(32)), "wb")
     write(source / ".gitignore", "ignored-build/\n*.tmp\nagent-bench/local-only/\n")
     os.symlink("README.md", source / "link-to-readme")
+    for idx in range(tree_files):
+        write(source / "tree" / f"dir{idx // 16:02d}" / f"file{idx:04d}.txt", f"fixture tree file {idx}\n")
     commit(source, "initial fixture tree")
     run(source, "tag", "v0.1.0")
 
@@ -95,6 +97,7 @@ def build_fixture(root: Path) -> dict[str, str]:
         "file_url": bare.resolve().as_uri(),
         "main_branch": "main",
         "tag": "v0.1.0",
+        "tree_files": str(tree_files),
     }
 
 
@@ -144,6 +147,12 @@ def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("root", help="empty directory where fixture repositories will be created")
     parser.add_argument("--force", action="store_true", help="remove the root before creating the fixture")
+    parser.add_argument(
+        "--tree-files",
+        type=int,
+        default=0,
+        help="number of extra committed files under tree/ (scales checkout-heavy workloads)",
+    )
     args = parser.parse_args(argv)
 
     root = Path(args.root).resolve()
@@ -154,7 +163,7 @@ def main(argv: list[str]) -> int:
             print(f"refusing to remove fixture root: {exc}", file=sys.stderr)
             return 2
         shutil.rmtree(root)
-    info = build_fixture(root)
+    info = build_fixture(root, tree_files=max(0, args.tree_files))
     print(json.dumps(info, sort_keys=True))
     return 0
 

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -299,10 +299,20 @@ func (cq *CommitQueue) RecoverPending() {
 			log.Printf("commit queue: skip legacy pending overwrite without base revision for %s", path)
 			continue
 		}
+		// The shadow file is the data actually uploaded; its size is
+		// authoritative. Meta size can be stale (memory-only updates, or a
+		// WAL-resurrected entry from an older fsync) and would mis-route the
+		// direct-PUT vs multipart decision in uploadEntry.
+		size := meta.Size
+		if cq.shadows != nil {
+			if shadowSize := cq.shadows.Size(path); shadowSize >= 0 {
+				size = shadowSize
+			}
+		}
 		entry := &CommitEntry{
 			Path:        path,
 			BaseRev:     meta.BaseRev,
-			Size:        meta.Size,
+			Size:        size,
 			Kind:        meta.Kind,
 			ShadowSpill: meta.ShadowSpill,
 			Mode:        meta.Mode,
@@ -444,11 +454,23 @@ func (cq *CommitQueue) cancelPath(path string, preserveLocal bool) {
 	if preserveLocal {
 		return
 	}
-	if cq.shadows != nil {
+	hadLocal := false
+	if cq.shadows != nil && cq.shadows.Has(path) {
+		hadLocal = true
 		cq.shadows.Remove(path)
 	}
-	if cq.index != nil {
+	if cq.index != nil && cq.index.HasPending(path) {
+		hadLocal = true
 		cq.index.Remove(path)
+	}
+	// Journal a "done" marker so crash recovery does not resurrect the
+	// unlinked path from earlier fsync frames, and so those frames compact.
+	// Only when local pending state existed, to avoid a WAL frame per unlink.
+	if hadLocal && cq.journal != nil {
+		_ = cq.journal.Append(JournalEntry{
+			Op:   JournalCommit,
+			Path: path,
+		})
 	}
 }
 
@@ -506,6 +528,12 @@ func (cq *CommitQueue) CancelPrefix(prefix string) {
 		}
 		if cq.index != nil {
 			cq.index.Remove(p)
+		}
+		if cq.journal != nil {
+			_ = cq.journal.Append(JournalEntry{
+				Op:   JournalCommit,
+				Path: p,
+			})
 		}
 	}
 }
@@ -1014,11 +1042,12 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 		return
 	}
 
-	// ShadowSpill large files: auto-resolve requires full-memory ReadAll +
-	// bytes.Equal which would OOM for multi-GiB files. Terminal failure instead.
+	// ShadowSpill large files: full-memory ReadAll + bytes.Equal would OOM
+	// for multi-GiB files, so no LWW. But the idempotent case (crash after
+	// upload completed, before the local cleanup — the common large-file
+	// crash window) is resolvable with a bounded-memory chunked compare.
 	if entry.ShadowSpill {
-		log.Printf("commit queue: auto-resolve skipped for ShadowSpill %s (would OOM), terminal failure", entry.Path)
-		cq.onCommitTerminalFailure(entry)
+		cq.tryResolveShadowSpillIdempotent(entry)
 		return
 	}
 
@@ -1104,6 +1133,95 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 
 	log.Printf("commit queue: auto-resolved conflict for %s via LWW (overwrote rev %d → new upload based on rev %d)", entry.Path, entry.BaseRev, serverRev)
 	if err := cq.onCommitSuccess(entry, serverRev, 0); err != nil {
+		cq.onCommitPostUploadFailure(entry, err)
+	}
+}
+
+// shadowSpillCompareChunk bounds memory during the streaming idempotency
+// comparison of large ShadowSpill files in conflict auto-resolve.
+const shadowSpillCompareChunk = 8 << 20
+
+// tryResolveShadowSpillIdempotent resolves a 409 for a ShadowSpill entry only
+// in the idempotent direction: if the server content already equals the local
+// shadow byte-for-byte (crash after a completed upload, before local cleanup),
+// the commit is marked successful. Any divergence is a terminal conflict —
+// LWW re-upload is intentionally not attempted for large files.
+func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entry *CommitEntry) {
+	if cq.shadows == nil || cq.client == nil {
+		cq.onCommitTerminalFailure(entry)
+		return
+	}
+	apiPath := cq.remotePath(entry.Path)
+
+	statCtx, statCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	statStart := time.Now()
+	stat, err := cq.client.StatCtx(statCtx, apiPath)
+	statCancel()
+	if cq.perf != nil {
+		cq.perf.recordRemoteOp(perfRemoteStat, err, time.Since(statStart), 0)
+	}
+	if err != nil {
+		log.Printf("commit queue: ShadowSpill auto-resolve failed for %s: stat: %v", entry.Path, err)
+		cq.onCommitTerminalFailure(entry)
+		return
+	}
+
+	localSize := cq.shadows.Size(entry.Path)
+	if localSize < 0 {
+		// Shadow gone — likely canceled by a concurrent Unlink/Rmdir.
+		if cq.isEntryCanceled(entry) {
+			cq.removeFromQueue(entry)
+			log.Printf("commit queue: ShadowSpill auto-resolve skipped for %s (canceled)", entry.Path)
+			return
+		}
+		log.Printf("commit queue: ShadowSpill auto-resolve failed for %s: shadow missing", entry.Path)
+		cq.onCommitTerminalFailure(entry)
+		return
+	}
+	if stat.Size != localSize {
+		log.Printf("commit queue: ShadowSpill conflict for %s is genuine (local %d bytes vs server %d bytes), terminal failure", entry.Path, localSize, stat.Size)
+		cq.onCommitTerminalFailure(entry)
+		return
+	}
+
+	buf := make([]byte, shadowSpillCompareChunk)
+	for off := int64(0); off < localSize; off += shadowSpillCompareChunk {
+		n := int64(shadowSpillCompareChunk)
+		if off+n > localSize {
+			n = localSize - off
+		}
+		readCtx, readCancel := context.WithTimeout(context.Background(), uploadTimeout)
+		readStart := time.Now()
+		serverChunk, err := cq.client.ReadAtCtx(readCtx, apiPath, off, n)
+		readCancel()
+		if cq.perf != nil {
+			cq.perf.recordRemoteOp(perfRemoteRead, err, time.Since(readStart), uint64(len(serverChunk)))
+		}
+		if err != nil {
+			log.Printf("commit queue: ShadowSpill auto-resolve failed for %s: read server @%d: %v", entry.Path, off, err)
+			cq.onCommitTerminalFailure(entry)
+			return
+		}
+		ln, err := cq.shadows.ReadAt(entry.Path, off, buf[:n])
+		if err != nil || int64(ln) != n {
+			if cq.isEntryCanceled(entry) {
+				cq.removeFromQueue(entry)
+				log.Printf("commit queue: ShadowSpill auto-resolve skipped for %s (canceled mid-read)", entry.Path)
+				return
+			}
+			log.Printf("commit queue: ShadowSpill auto-resolve failed for %s: read shadow @%d: n=%d err=%v", entry.Path, off, ln, err)
+			cq.onCommitTerminalFailure(entry)
+			return
+		}
+		if int64(len(serverChunk)) != n || !bytes.Equal(serverChunk, buf[:n]) {
+			log.Printf("commit queue: ShadowSpill conflict for %s is genuine (content differs @%d), terminal failure", entry.Path, off)
+			cq.onCommitTerminalFailure(entry)
+			return
+		}
+	}
+
+	log.Printf("commit queue: auto-resolved ShadowSpill conflict for %s (idempotent, %d bytes match server rev %d)", entry.Path, localSize, stat.Revision)
+	if err := cq.onCommitSuccess(entry, stat.Revision, stat.Revision); err != nil {
 		cq.onCommitPostUploadFailure(entry, err)
 	}
 }

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -467,10 +467,15 @@ func (cq *CommitQueue) cancelPath(path string, preserveLocal bool) {
 	// unlinked path from earlier fsync frames, and so those frames compact.
 	// Only when local pending state existed, to avoid a WAL frame per unlink.
 	if hadLocal && cq.journal != nil {
-		_ = cq.journal.Append(JournalEntry{
+		// Best effort: a lost marker only means recovery re-checks a path
+		// whose shadow/.meta are already gone, which the pending-index
+		// prune discards. Log so persistent WAL write failures surface.
+		if err := cq.journal.Append(JournalEntry{
 			Op:   JournalCommit,
 			Path: path,
-		})
+		}); err != nil {
+			log.Printf("commit queue: journal cancel marker failed for %s: %v", path, err)
+		}
 	}
 }
 
@@ -530,10 +535,12 @@ func (cq *CommitQueue) CancelPrefix(prefix string) {
 			cq.index.Remove(p)
 		}
 		if cq.journal != nil {
-			_ = cq.journal.Append(JournalEntry{
+			if err := cq.journal.Append(JournalEntry{
 				Op:   JournalCommit,
 				Path: p,
-			})
+			}); err != nil {
+				log.Printf("commit queue: journal cancel marker failed for %s: %v", p, err)
+			}
 		}
 	}
 }
@@ -1042,6 +1049,15 @@ func (cq *CommitQueue) tryAutoResolveConflict(entry *CommitEntry) {
 		return
 	}
 
+	// Layer mounts upload through layer endpoints; Stat/Read here would
+	// compare against the base FS namespace, so neither the idempotent
+	// check nor LWW can be trusted. Keep layer conflicts terminal.
+	if cq.layerRefSnapshot() != "" {
+		log.Printf("commit queue: auto-resolve unsupported for layer mount, terminal failure for %s", entry.Path)
+		cq.onCommitTerminalFailure(entry)
+		return
+	}
+
 	// ShadowSpill large files: full-memory ReadAll + bytes.Equal would OOM
 	// for multi-GiB files, so no LWW. But the idempotent case (crash after
 	// upload completed, before the local cleanup — the common large-file
@@ -1186,6 +1202,13 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entry *CommitEntry) {
 
 	buf := make([]byte, shadowSpillCompareChunk)
 	for off := int64(0); off < localSize; off += shadowSpillCompareChunk {
+		// Chunk-boundary cancel check bounds wasted work on multi-GiB
+		// compares when the file is unlinked mid-resolve.
+		if cq.isEntryCanceled(entry) {
+			cq.removeFromQueue(entry)
+			log.Printf("commit queue: ShadowSpill auto-resolve skipped for %s (canceled mid-compare)", entry.Path)
+			return
+		}
 		n := int64(shadowSpillCompareChunk)
 		if off+n > localSize {
 			n = localSize - off
@@ -1257,10 +1280,12 @@ func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry) {
 		}
 	}
 	if cq.journal != nil {
-		_ = cq.journal.Append(JournalEntry{
+		if err := cq.journal.Append(JournalEntry{
 			Op:   JournalCommit, // treated as "done" so recovery won't re-enqueue
 			Path: entry.Path,
-		})
+		}); err != nil {
+			log.Printf("commit queue: journal done marker failed for %s: %v", entry.Path, err)
+		}
 	}
 
 	// Remove from queue AFTER all cleanup so WaitPath sees the entry

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1679,13 +1680,27 @@ func TestCommitQueueMultipartCreateInfersRevisionForOpenHandle(t *testing.T) {
 	}
 }
 
-// TestCommitQueueShadowSpillConflictTerminal verifies that ShadowSpill entries
-// skip auto-resolve (which would OOM) and go straight to terminal failure.
+// TestCommitQueueShadowSpillConflictTerminal verifies that for ShadowSpill
+// entries a genuine conflict (server size differs from local shadow) goes to
+// terminal failure after a single HEAD probe — no content download, no LWW
+// re-upload, no full-memory ReadAll.
 func TestCommitQueueShadowSpillConflictTerminal(t *testing.T) {
-	var calls int
+	var putCalls, headCalls, getCalls int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+		switch r.Method {
+		case http.MethodHead:
+			headCalls++
+			// Server size differs from local 4 bytes → genuine conflict.
+			w.Header().Set("X-Dat9-Revision", "9")
+			w.Header().Set("Content-Length", "999")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getCalls++
+			http.Error(w, `{"error":"unexpected read"}`, http.StatusInternalServerError)
+		default:
+			putCalls++
+			http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+		}
 	}))
 	defer ts.Close()
 
@@ -1718,10 +1733,11 @@ func TestCommitQueueShadowSpillConflictTerminal(t *testing.T) {
 	}
 	cq.DrainAll()
 
-	// ShadowSpill: 409 → skip auto-resolve → terminal failure immediately.
-	// Only 1 call: the initial upload (no Stat/Read for auto-resolve).
-	if calls != 1 {
-		t.Fatalf("expected 1 call (upload only, no auto-resolve), got %d", calls)
+	if headCalls != 1 {
+		t.Fatalf("expected 1 HEAD probe for size check, got %d", headCalls)
+	}
+	if getCalls != 0 {
+		t.Fatalf("expected no content reads when sizes differ, got %d", getCalls)
 	}
 	if !pending.HasPending("/big-conflict.bin") {
 		t.Fatal("pending entry should be preserved after ShadowSpill terminal conflict")
@@ -1732,6 +1748,68 @@ func TestCommitQueueShadowSpillConflictTerminal(t *testing.T) {
 	}
 	if !shadow.Has("/big-conflict.bin") {
 		t.Fatal("shadow should be preserved after ShadowSpill terminal conflict")
+	}
+}
+
+// TestCommitQueueShadowSpillConflictIdempotent verifies that when the server
+// content already equals the local shadow (crash after a completed upload,
+// before local cleanup), a ShadowSpill 409 resolves as idempotent success via
+// chunked compare instead of a phantom terminal conflict.
+func TestCommitQueueShadowSpillConflictIdempotent(t *testing.T) {
+	data := bytes.Repeat([]byte("spill-ok"), 512) // 4096 bytes
+	var putCalls int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("X-Dat9-Revision", "7")
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			http.ServeContent(w, r, "big.bin", time.Time{}, bytes.NewReader(data))
+		default:
+			putCalls++
+			http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := shadow.WriteFull("/big.bin", data, 5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutShadowSpill("/big.bin", int64(len(data)), PendingOverwrite, 5); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:        "/big.bin",
+		BaseRev:     5,
+		Size:        int64(len(data)),
+		Kind:        PendingOverwrite,
+		ShadowSpill: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if putCalls != 1 {
+		t.Fatalf("expected exactly 1 upload attempt (no LWW re-upload), got %d", putCalls)
+	}
+	if pending.HasPending("/big.bin") {
+		t.Fatal("pending entry should be removed after idempotent resolve")
+	}
+	if shadow.Has("/big.bin") {
+		t.Fatal("shadow should be removed after idempotent resolve")
 	}
 }
 
@@ -1870,5 +1948,114 @@ func TestCommitQueueRecoverPendingShadowSpill(t *testing.T) {
 	}
 	if shadow2.Has("/recover.bin") {
 		t.Fatal("shadow should be removed after successful recovery upload")
+	}
+}
+
+// TestCommitQueueRecoverPendingUsesShadowSize verifies that recovery routes
+// the upload by the actual shadow file size, not stale pending metadata. A
+// WAL-resurrected meta can carry an old size; routing on it would direct-PUT
+// a file the server requires to be multipart (or vice versa).
+func TestCommitQueueRecoverPendingUsesShadowSize(t *testing.T) {
+	data := []byte("0123456789abcdef") // 16 bytes, well under the 50KB threshold
+	var putBody []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			putBody, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/uploads/"):
+			t.Errorf("multipart initiate used for a %d-byte file — stale meta size routed the upload", len(data))
+			http.Error(w, `{"error":"unexpected multipart"}`, http.StatusBadRequest)
+		default:
+			http.Error(w, `{"error":"unexpected"}`, http.StatusBadRequest)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := shadow.WriteFull("/stale.bin", data, 5); err != nil {
+		t.Fatal(err)
+	}
+	// Stale meta: claims 60000 bytes (> 50KB threshold → would multipart).
+	if _, err := pending.PutWithBaseRev("/stale.bin", 60000, PendingOverwrite, 5); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.RecoverPending()
+	cq.DrainAll()
+
+	if !bytes.Equal(putBody, data) {
+		t.Fatalf("direct PUT body = %d bytes, want %d", len(putBody), len(data))
+	}
+	if pending.HasPending("/stale.bin") {
+		t.Error("pending entry not cleaned up after recovered commit")
+	}
+}
+
+// TestCommitQueueCancelPathJournalsCommitMarker verifies that unlinking a
+// path with pending local state writes a WAL "done" marker, so a later crash
+// recovery does not resurrect the deleted file from older fsync frames.
+func TestCommitQueueCancelPathJournalsCommitMarker(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"unexpected"}`, http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	journal, err := NewJournal(dir + "/journal.wal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = journal.Close() }()
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the Fsync flow: shadow + meta + WAL fsync frame.
+	if err := shadow.WriteFull("/gone.txt", []byte("data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/gone.txt", 4, PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := journal.Append(JournalEntry{Op: JournalFsync, Path: "/gone.txt", Length: 4}); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, journal, 1, 8)
+	cq.CancelPath("/gone.txt") // Unlink flow
+	cq.DrainAll()
+
+	if shadow.Has("/gone.txt") || pending.HasPending("/gone.txt") {
+		t.Fatal("cancel did not clean local state")
+	}
+
+	// Crash recovery must not resurrect the unlinked path.
+	recovered, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := replayJournalIntoPending(journal, recovered); err != nil {
+		t.Fatal(err)
+	}
+	if recovered.HasPending("/gone.txt") {
+		t.Error("unlinked path resurrected from WAL — cancel marker missing")
 	}
 }

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -6249,20 +6249,23 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 	}
 	defer unlockRemoteCommit()
 
+	if fs.layerEnabled() && fs.shadowStore != nil && !fs.shadowStore.Has(oldP) {
+		return pendingRenameRemoteFallback, nil
+	}
+	// Crash-safe order: persist the new-path meta BEFORE moving the shadow.
+	// If we crash between the two steps, both .meta files exist and recovery
+	// keeps whichever side still has the shadow — the data is never orphaned.
+	preparedMeta, ok := fs.pendingIndex.PrepareRename(oldP, newP)
+	if !ok {
+		return pendingRenameHandled, fmt.Errorf("prepare pending index rename %s -> %s failed", oldP, newP)
+	}
 	if fs.shadowStore != nil {
-		if fs.layerEnabled() && !fs.shadowStore.Has(oldP) {
-			return pendingRenameRemoteFallback, nil
-		}
 		if !fs.shadowStore.Rename(oldP, newP) {
+			fs.pendingIndex.AbortRename(newP)
 			return pendingRenameHandled, fmt.Errorf("move pending shadow %s -> %s failed", oldP, newP)
 		}
 	}
-	if !fs.pendingIndex.RenamePending(oldP, newP) {
-		if fs.shadowStore != nil {
-			_ = fs.shadowStore.Rename(newP, oldP)
-		}
-		return pendingRenameHandled, fmt.Errorf("move pending index %s -> %s failed", oldP, newP)
-	}
+	fs.pendingIndex.CommitRename(oldP, preparedMeta)
 
 	fs.finishLocalRename(input, oldP, newP)
 
@@ -6543,13 +6546,20 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 		}
 	}
 	// Also migrate pendingIndex and shadowStore entries for descendants.
+	// Meta-first order so a crash mid-migration cannot orphan a child's data.
 	if fs.pendingIndex != nil {
 		for _, meta := range fs.pendingIndex.ListByPrefix(prefix) {
 			newChild := newP + meta.Path[len(oldP):]
-			if fs.shadowStore != nil {
-				fs.shadowStore.Rename(meta.Path, newChild)
+			preparedMeta, ok := fs.pendingIndex.PrepareRename(meta.Path, newChild)
+			if !ok {
+				continue
 			}
-			fs.pendingIndex.RenamePending(meta.Path, newChild)
+			if fs.shadowStore != nil && !fs.shadowStore.Rename(meta.Path, newChild) {
+				fs.pendingIndex.AbortRename(newChild)
+				log.Printf("rename: migrate pending child shadow %s -> %s failed", meta.Path, newChild)
+				continue
+			}
+			fs.pendingIndex.CommitRename(meta.Path, preparedMeta)
 		}
 	}
 
@@ -9009,9 +9019,11 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 				}
 				if fs.journal != nil {
 					entry := JournalEntry{
-						Op:      JournalFsync,
-						Path:    fh.Path,
-						BaseRev: fh.BaseRev,
+						Op:          JournalFsync,
+						Path:        fh.Path,
+						Length:      fh.Dirty.Size(),
+						BaseRev:     fh.BaseRev,
+						ShadowSpill: true,
 					}
 					_ = fs.journal.Append(entry)
 					_ = fs.journal.Fsync()
@@ -9043,6 +9055,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 					entry := JournalEntry{
 						Op:      JournalFsync,
 						Path:    fh.Path,
+						Length:  fh.Dirty.Size(),
 						BaseRev: fh.BaseRev,
 					}
 					_ = fs.journal.Append(entry)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -6255,9 +6255,12 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 	// Crash-safe order: persist the new-path meta BEFORE moving the shadow.
 	// If we crash between the two steps, both .meta files exist and recovery
 	// keeps whichever side still has the shadow — the data is never orphaned.
-	preparedMeta, ok := fs.pendingIndex.PrepareRename(oldP, newP)
-	if !ok {
-		return pendingRenameHandled, fmt.Errorf("prepare pending index rename %s -> %s failed", oldP, newP)
+	preparedMeta, err := fs.pendingIndex.PrepareRename(oldP, newP)
+	if err != nil {
+		return pendingRenameHandled, fmt.Errorf("prepare pending index rename %s -> %s: %w", oldP, newP, err)
+	}
+	if preparedMeta == nil {
+		return pendingRenameHandled, fmt.Errorf("prepare pending index rename %s -> %s: pending entry vanished", oldP, newP)
 	}
 	if fs.shadowStore != nil {
 		if !fs.shadowStore.Rename(oldP, newP) {
@@ -6550,8 +6553,22 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 	if fs.pendingIndex != nil {
 		for _, meta := range fs.pendingIndex.ListByPrefix(prefix) {
 			newChild := newP + meta.Path[len(oldP):]
-			preparedMeta, ok := fs.pendingIndex.PrepareRename(meta.Path, newChild)
-			if !ok {
+			preparedMeta, err := fs.pendingIndex.PrepareRename(meta.Path, newChild)
+			if err != nil {
+				// Leave the entry at the stale path rather than losing it;
+				// the upload will fail visibly instead of silently dropping.
+				log.Printf("rename: prepare pending child meta %s -> %s failed: %v", meta.Path, newChild, err)
+				continue
+			}
+			if preparedMeta == nil {
+				// Entry committed or removed since ListByPrefix.
+				continue
+			}
+			// Layer mounts track metadata-only pending entries without a
+			// shadow; migrate the meta directly instead of aborting on the
+			// missing shadow (parity with renamePendingNewCommit).
+			if fs.layerEnabled() && fs.shadowStore != nil && !fs.shadowStore.Has(meta.Path) {
+				fs.pendingIndex.CommitRename(meta.Path, preparedMeta)
 				continue
 			}
 			if fs.shadowStore != nil && !fs.shadowStore.Rename(meta.Path, newChild) {
@@ -9006,17 +9023,9 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			err := fs.stageShadowForQueuedCommitLocked(fh, true)
 			fs.debugDurationf(stageStart, 0, "fsync shadowspill stage done path=%s err=%v", fh.Path, err)
 			if err == nil {
-				if fs.commitQueue != nil {
-					phase = "interactive-shadowspill-enqueue"
-					if err := fs.enqueueStagedShadowCommitLocked(fh); err != nil {
-						log.Printf("fsync: enqueue staged ShadowSpill commit failed for %s: %v; deferring to Release", fh.Path, err)
-						fh.ShadowCommitReady = true
-						fh.ShadowCommitSeq = fh.DirtySeq
-					}
-				} else {
-					fh.ShadowCommitReady = true
-					fh.ShadowCommitSeq = fh.DirtySeq
-				}
+				// Journal before enqueue: the async commit appends a
+				// JournalCommit marker, which must get a higher Seq than
+				// this fsync frame or replay resurrects a committed path.
 				if fs.journal != nil {
 					entry := JournalEntry{
 						Op:          JournalFsync,
@@ -9028,6 +9037,17 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 					_ = fs.journal.Append(entry)
 					_ = fs.journal.Fsync()
 				}
+				if fs.commitQueue != nil {
+					phase = "interactive-shadowspill-enqueue"
+					if err := fs.enqueueStagedShadowCommitLocked(fh); err != nil {
+						log.Printf("fsync: enqueue staged ShadowSpill commit failed for %s: %v; deferring to Release", fh.Path, err)
+						fh.ShadowCommitReady = true
+						fh.ShadowCommitSeq = fh.DirtySeq
+					}
+				} else {
+					fh.ShadowCommitReady = true
+					fh.ShadowCommitSeq = fh.DirtySeq
+				}
 				return gofuse.OK
 			}
 		} else {
@@ -9036,6 +9056,19 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			err := fs.stageShadowForQueuedCommitLocked(fh, true)
 			fs.debugDurationf(stageStart, 0, "fsync stage done path=%s err=%v", fh.Path, err)
 			if err == nil {
+				// Journal before enqueue: the async commit appends a
+				// JournalCommit marker, which must get a higher Seq than
+				// this fsync frame or replay resurrects a committed path.
+				if fs.journal != nil {
+					entry := JournalEntry{
+						Op:      JournalFsync,
+						Path:    fh.Path,
+						Length:  fh.Dirty.Size(),
+						BaseRev: fh.BaseRev,
+					}
+					_ = fs.journal.Append(entry)
+					_ = fs.journal.Fsync()
+				}
 				if fs.commitQueue != nil && fs.shadowStore != nil && fs.shadowStore.Has(fh.Path) {
 					phase = "interactive-enqueue"
 					if err := fs.enqueueStagedShadowCommitLocked(fh); err != nil {
@@ -9049,17 +9082,6 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 						log.Printf("fsync writeback snapshot failed for %s: %v", fh.Path, err)
 					}
 					fh.WriteBackSeq = fh.DirtySeq
-				}
-				// Journal fsync for local durability (when journal is available).
-				if fs.journal != nil {
-					entry := JournalEntry{
-						Op:      JournalFsync,
-						Path:    fh.Path,
-						Length:  fh.Dirty.Size(),
-						BaseRev: fh.BaseRev,
-					}
-					_ = fs.journal.Append(entry)
-					_ = fs.journal.Fsync()
 				}
 				return gofuse.OK
 			}

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2936,7 +2936,10 @@ func TestDiskReadCacheClosePreventsFutureAsyncPuts(t *testing.T) {
 
 func TestDiskReadCacheStartupRecoveryAndTempCleanup(t *testing.T) {
 	dir := t.TempDir()
-	cache, err := NewDiskReadCache(DiskReadCacheOptions{Dir: dir, MaxSize: 1 << 20, FreeRatio: 0})
+	// FreeRatio -1 disables the free-disk eviction: 0 maps to the 10% default,
+	// which evicts the recovered entry at startup on hosts with a nearly full
+	// disk and makes this test environment-dependent.
+	cache, err := NewDiskReadCache(DiskReadCacheOptions{Dir: dir, MaxSize: 1 << 20, FreeRatio: -1})
 	if err != nil {
 		t.Fatalf("NewDiskReadCache: %v", err)
 	}
@@ -2946,7 +2949,7 @@ func TestDiskReadCacheStartupRecoveryAndTempCleanup(t *testing.T) {
 		t.Fatalf("write temp entry: %v", err)
 	}
 
-	recovered, err := NewDiskReadCache(DiskReadCacheOptions{Dir: dir, MaxSize: 1 << 20, FreeRatio: 0})
+	recovered, err := NewDiskReadCache(DiskReadCacheOptions{Dir: dir, MaxSize: 1 << 20, FreeRatio: -1})
 	if err != nil {
 		t.Fatalf("recover DiskReadCache: %v", err)
 	}

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -145,11 +145,13 @@ func (fs *Dat9FS) ensureGitWorkspacesWithRefresh(ctx context.Context, force bool
 	}
 	listStart := fs.perfStart()
 	workspaces, err := fs.client.ListGitWorkspaces(ctx)
+	if client.IsNotFound(err) {
+		// Expected on servers without git workspaces — not a remote error.
+		fs.perfRecordRemote(perfRemoteList, listStart, nil, 0)
+		return nil
+	}
 	fs.perfRecordRemote(perfRemoteList, listStart, err, 0)
 	if err != nil {
-		if client.IsNotFound(err) {
-			err = nil
-		}
 		return err
 	}
 	loaded := make([]*gitWorkspaceRuntime, 0, len(workspaces))
@@ -175,8 +177,12 @@ func (fs *Dat9FS) ensureGitWorkspacesWithRefresh(ctx context.Context, force bool
 		}
 		overlayStart := fs.perfStart()
 		overlays, err := fs.client.ListGitOverlayEntries(ctx, ws.WorkspaceID)
+		if client.IsNotFound(err) {
+			// Expected when a workspace has no overlay entries yet.
+			err = nil
+		}
 		fs.perfRecordRemote(perfRemoteList, overlayStart, err, 0)
-		if err != nil && !client.IsNotFound(err) {
+		if err != nil {
 			loadErrs = append(loadErrs, fmt.Errorf("load git overlay workspace=%s root=%s: %w", ws.WorkspaceID, ws.RootPath, err))
 			continue
 		}

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -137,7 +137,15 @@ func (fs *Dat9FS) ensureGitWorkspacesWithRefresh(ctx context.Context, force bool
 	}
 	fs.git.mu.Unlock()
 
+	if fs.perfEnabled() {
+		fs.perf.gitWorkspaceRefresh.add(1)
+		if force {
+			fs.perf.gitWorkspaceForcedRefresh.add(1)
+		}
+	}
+	listStart := fs.perfStart()
 	workspaces, err := fs.client.ListGitWorkspaces(ctx)
+	fs.perfRecordRemote(perfRemoteList, listStart, err, 0)
 	if err != nil {
 		if client.IsNotFound(err) {
 			err = nil
@@ -158,12 +166,16 @@ func (fs *Dat9FS) ensureGitWorkspacesWithRefresh(ctx context.Context, force bool
 		if localRoot != "/" {
 			localRoot = strings.TrimSuffix(localRoot, "/")
 		}
+		treeStart := fs.perfStart()
 		nodes, err := fs.client.ListGitTree(ctx, ws.WorkspaceID, ws.HeadCommit)
+		fs.perfRecordRemote(perfRemoteList, treeStart, err, 0)
 		if err != nil {
 			loadErrs = append(loadErrs, fmt.Errorf("load git tree workspace=%s root=%s: %w", ws.WorkspaceID, ws.RootPath, err))
 			continue
 		}
+		overlayStart := fs.perfStart()
 		overlays, err := fs.client.ListGitOverlayEntries(ctx, ws.WorkspaceID)
+		fs.perfRecordRemote(perfRemoteList, overlayStart, err, 0)
 		if err != nil && !client.IsNotFound(err) {
 			loadErrs = append(loadErrs, fmt.Errorf("load git overlay workspace=%s root=%s: %w", ws.WorkspaceID, ws.RootPath, err))
 			continue

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -3938,3 +3938,45 @@ func fuseGitOutputForTest(t *testing.T, dir string, args ...string) string {
 	}
 	return string(bytes.TrimSpace(out))
 }
+
+func TestEnsureGitWorkspacesRecordsRefreshPerfCounters(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true, PerfCounters: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensure git workspaces: %v", err)
+	}
+	snap := fs.perf.snapshot()
+	if got := snap.Counters["git_workspace_refresh"]; got != 1 {
+		t.Fatalf("git_workspace_refresh = %d, want 1", got)
+	}
+	if got := snap.Counters["git_workspace_forced_refresh"]; got != 0 {
+		t.Fatalf("git_workspace_forced_refresh = %d, want 0", got)
+	}
+	if got := snap.RemoteOps["list"].count; got == 0 {
+		t.Fatal("remote list ops = 0, want > 0")
+	}
+
+	// A non-forced ensure inside the freshness window must not refresh again.
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensure git workspaces (cached): %v", err)
+	}
+	snap = fs.perf.snapshot()
+	if got := snap.Counters["git_workspace_refresh"]; got != 1 {
+		t.Fatalf("git_workspace_refresh after cached ensure = %d, want 1", got)
+	}
+
+	if err := fs.forceRefreshGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("force refresh git workspaces: %v", err)
+	}
+	snap = fs.perf.snapshot()
+	if got := snap.Counters["git_workspace_refresh"]; got != 2 {
+		t.Fatalf("git_workspace_refresh after force = %d, want 2", got)
+	}
+	if got := snap.Counters["git_workspace_forced_refresh"]; got != 1 {
+		t.Fatalf("git_workspace_forced_refresh after force = %d, want 1", got)
+	}
+}

--- a/pkg/fuse/journal.go
+++ b/pkg/fuse/journal.go
@@ -35,6 +35,10 @@ type JournalEntry struct {
 	Length    int64     `json:"length,omitempty"`    // for Write
 	BaseRev   int64     `json:"base_rev,omitempty"`
 	Timestamp int64     `json:"timestamp,omitempty"`
+	// ShadowSpill records that the fsync'd data lives in a streaming shadow
+	// file, so crash recovery must rebuild the pending entry in spill mode
+	// (streamed upload) instead of full-memory ReadAll.
+	ShadowSpill bool `json:"shadow_spill,omitempty"`
 }
 
 // Journal is an append-only WAL for crash recovery. Each entry is
@@ -252,4 +256,59 @@ func (j *Journal) Close() error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	return j.fd.Close()
+}
+
+// replayJournalIntoPending rebuilds pending-index entries from the WAL for
+// crash recovery. A path is resurrected only when its latest data entry
+// (fsync) is NOT superseded by a later JournalCommit/JournalUnlink marker;
+// otherwise every historically committed path would re-upload on each mount,
+// and a stale WAL entry could pair with a newer session's shadow file and
+// upload torn content under old metadata.
+//
+// Entries whose .meta survived (already present in the pending index) are
+// left untouched: the .meta file carries strictly more metadata than the WAL.
+func replayJournalIntoPending(j *Journal, idx *PendingIndex) error {
+	if j == nil || idx == nil {
+		return nil
+	}
+
+	latestData := make(map[string]JournalEntry) // path → latest fsync-like entry
+	latestDone := make(map[string]uint64)       // path → latest commit/unlink seq
+	if err := j.Replay(func(e JournalEntry) {
+		switch e.Op {
+		case JournalCommit, JournalUnlink:
+			if e.Seq > latestDone[e.Path] {
+				latestDone[e.Path] = e.Seq
+			}
+		default:
+			if prev, ok := latestData[e.Path]; !ok || e.Seq > prev.Seq {
+				latestData[e.Path] = e
+			}
+		}
+	}); err != nil {
+		return err
+	}
+
+	for path, e := range latestData {
+		if doneSeq, ok := latestDone[path]; ok && doneSeq > e.Seq {
+			continue // committed or unlinked after the last local fsync
+		}
+		if idx.HasPending(path) {
+			continue
+		}
+		kind := PendingOverwrite
+		if e.BaseRev == 0 {
+			kind = PendingNew
+		}
+		var err error
+		if e.ShadowSpill {
+			_, err = idx.PutShadowSpill(path, e.Length, kind, e.BaseRev)
+		} else {
+			_, err = idx.PutWithBaseRev(path, e.Length, kind, e.BaseRev)
+		}
+		if err != nil {
+			return fmt.Errorf("journal replay resurrect %s: %w", path, err)
+		}
+	}
+	return nil
 }

--- a/pkg/fuse/journal.go
+++ b/pkg/fuse/journal.go
@@ -32,7 +32,7 @@ type JournalEntry struct {
 	Path      string    `json:"path"`
 	NewPath   string    `json:"new_path,omitempty"` // for Rename
 	Offset    int64     `json:"offset,omitempty"`   // for Write
-	Length    int64     `json:"length,omitempty"`    // for Write
+	Length    int64     `json:"length,omitempty"`   // for Write
 	BaseRev   int64     `json:"base_rev,omitempty"`
 	Timestamp int64     `json:"timestamp,omitempty"`
 	// ShadowSpill records that the fsync'd data lives in a streaming shadow
@@ -50,13 +50,15 @@ type JournalEntry struct {
 //	[N bytes: JSON payload]
 //	[4 bytes: CRC32 of payload (little-endian uint32)]
 type Journal struct {
-	mu     sync.Mutex
-	fd     *os.File
-	seq    atomic.Uint64
-	path   string
+	mu   sync.Mutex
+	fd   *os.File
+	seq  atomic.Uint64
+	path string
 }
 
-// NewJournal opens or creates a journal WAL file at the given path.
+// NewJournal opens or creates a journal WAL file at the given path. The
+// sequence counter resumes from the highest Seq already on disk so that
+// appends before any Replay never reuse sequence numbers.
 func NewJournal(path string) (*Journal, error) {
 	fd, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o644)
 	if err != nil {
@@ -66,12 +68,54 @@ func NewJournal(path string) (*Journal, error) {
 		fd:   fd,
 		path: path,
 	}
+	if data, err := os.ReadFile(path); err == nil {
+		var maxSeq uint64
+		scanJournalFrames(data, func(entry JournalEntry, _ []byte) {
+			if entry.Seq > maxSeq {
+				maxSeq = entry.Seq
+			}
+		})
+		j.seq.Store(maxSeq)
+	}
 	return j, nil
+}
+
+// scanJournalFrames walks the wire format, skipping corrupt or truncated
+// frames, and calls fn with each decoded entry and its raw frame bytes.
+func scanJournalFrames(data []byte, fn func(entry JournalEntry, frame []byte)) {
+	pos := 0
+	for pos+8 <= len(data) { // need at least 4 (len) + 4 (crc)
+		payloadLen := binary.LittleEndian.Uint32(data[pos : pos+4])
+		frameEnd := pos + 4 + int(payloadLen) + 4
+		if frameEnd > len(data) {
+			break // truncated entry
+		}
+		payload := data[pos+4 : pos+4+int(payloadLen)]
+		storedCRC := binary.LittleEndian.Uint32(data[pos+4+int(payloadLen):])
+		if storedCRC != crc32.ChecksumIEEE(payload) {
+			// Corrupt entry — skip to next possible entry boundary.
+			pos++
+			continue
+		}
+		var entry JournalEntry
+		if err := json.Unmarshal(payload, &entry); err != nil {
+			pos = frameEnd
+			continue
+		}
+		fn(entry, data[pos:frameEnd])
+		pos = frameEnd
+	}
 }
 
 // Append writes a journal entry to the WAL. The entry is length-prefixed
 // and CRC32-checksummed for integrity.
 func (j *Journal) Append(entry JournalEntry) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	// Seq must be assigned under the same lock that orders the writes:
+	// recovery and compaction treat higher Seq as "later on disk", so a
+	// frame must never be written before another frame with a lower Seq.
 	entry.Seq = j.seq.Add(1)
 
 	payload, err := json.Marshal(entry)
@@ -85,9 +129,6 @@ func (j *Journal) Append(entry JournalEntry) error {
 	copy(frame[4:4+len(payload)], payload)
 	checksum := crc32.ChecksumIEEE(payload)
 	binary.LittleEndian.PutUint32(frame[4+len(payload):], checksum)
-
-	j.mu.Lock()
-	defer j.mu.Unlock()
 
 	_, err = j.fd.Write(frame)
 	if err != nil {
@@ -110,47 +151,18 @@ func (j *Journal) Replay(fn func(JournalEntry)) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	if _, err := j.fd.Seek(0, 0); err != nil {
-		return err
-	}
-
 	data, err := os.ReadFile(j.path)
 	if err != nil {
 		return err
 	}
 
-	var maxSeq uint64
-	pos := 0
-	for pos+8 <= len(data) { // need at least 4 (len) + 4 (crc)
-		payloadLen := binary.LittleEndian.Uint32(data[pos : pos+4])
-		frameEnd := pos + 4 + int(payloadLen) + 4
-		if frameEnd > len(data) {
-			break // truncated entry
-		}
-
-		payload := data[pos+4 : pos+4+int(payloadLen)]
-		storedCRC := binary.LittleEndian.Uint32(data[pos+4+int(payloadLen):])
-		computedCRC := crc32.ChecksumIEEE(payload)
-
-		if storedCRC != computedCRC {
-			// Corrupt entry — skip to next possible entry.
-			pos++
-			continue
-		}
-
-		var entry JournalEntry
-		if err := json.Unmarshal(payload, &entry); err != nil {
-			pos = frameEnd
-			continue
-		}
-
+	maxSeq := j.seq.Load()
+	scanJournalFrames(data, func(entry JournalEntry, _ []byte) {
 		fn(entry)
 		if entry.Seq > maxSeq {
 			maxSeq = entry.Seq
 		}
-		pos = frameEnd
-	}
-
+	})
 	j.seq.Store(maxSeq)
 	return nil
 }
@@ -161,10 +173,6 @@ func (j *Journal) Compact() error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	if _, err := j.fd.Seek(0, 0); err != nil {
-		return err
-	}
-
 	data, err := os.ReadFile(j.path)
 	if err != nil {
 		return err
@@ -174,31 +182,11 @@ func (j *Journal) Compact() error {
 	// Only entries with Seq <= committedUpTo[path] are safe to discard.
 	// Entries written after the commit must be preserved for recovery.
 	committedUpTo := make(map[string]uint64) // path → max committed seq
-	pos := 0
-	for pos+8 <= len(data) {
-		payloadLen := binary.LittleEndian.Uint32(data[pos : pos+4])
-		frameEnd := pos + 4 + int(payloadLen) + 4
-		if frameEnd > len(data) {
-			break
+	scanJournalFrames(data, func(entry JournalEntry, _ []byte) {
+		if entry.Op == JournalCommit && entry.Seq > committedUpTo[entry.Path] {
+			committedUpTo[entry.Path] = entry.Seq
 		}
-		payload := data[pos+4 : pos+4+int(payloadLen)]
-		storedCRC := binary.LittleEndian.Uint32(data[pos+4+int(payloadLen):])
-		if storedCRC != crc32.ChecksumIEEE(payload) {
-			pos++
-			continue
-		}
-		var entry JournalEntry
-		if err := json.Unmarshal(payload, &entry); err != nil {
-			pos = frameEnd
-			continue
-		}
-		if entry.Op == JournalCommit {
-			if entry.Seq > committedUpTo[entry.Path] {
-				committedUpTo[entry.Path] = entry.Seq
-			}
-		}
-		pos = frameEnd
-	}
+	})
 
 	if len(committedUpTo) == 0 {
 		return nil // nothing to compact
@@ -207,30 +195,12 @@ func (j *Journal) Compact() error {
 	// Second pass: keep frames that are newer than the commit boundary
 	// for their path, and all frames for paths without a commit marker.
 	var kept []byte
-	pos = 0
-	for pos+8 <= len(data) {
-		payloadLen := binary.LittleEndian.Uint32(data[pos : pos+4])
-		frameEnd := pos + 4 + int(payloadLen) + 4
-		if frameEnd > len(data) {
-			break
-		}
-		payload := data[pos+4 : pos+4+int(payloadLen)]
-		storedCRC := binary.LittleEndian.Uint32(data[pos+4+int(payloadLen):])
-		if storedCRC != crc32.ChecksumIEEE(payload) {
-			pos++
-			continue
-		}
-		var entry JournalEntry
-		if err := json.Unmarshal(payload, &entry); err != nil {
-			pos = frameEnd
-			continue
-		}
+	scanJournalFrames(data, func(entry JournalEntry, frame []byte) {
 		boundary, hasCommit := committedUpTo[entry.Path]
 		if !hasCommit || entry.Seq > boundary {
-			kept = append(kept, data[pos:frameEnd]...)
+			kept = append(kept, frame...)
 		}
-		pos = frameEnd
-	}
+	})
 
 	// Rewrite journal file.
 	tmpPath := j.path + ".compact"
@@ -272,7 +242,7 @@ func replayJournalIntoPending(j *Journal, idx *PendingIndex) error {
 		return nil
 	}
 
-	latestData := make(map[string]JournalEntry) // path → latest fsync-like entry
+	latestData := make(map[string]JournalEntry) // path → latest fsync entry
 	latestDone := make(map[string]uint64)       // path → latest commit/unlink seq
 	if err := j.Replay(func(e JournalEntry) {
 		switch e.Op {
@@ -280,7 +250,9 @@ func replayJournalIntoPending(j *Journal, idx *PendingIndex) error {
 			if e.Seq > latestDone[e.Path] {
 				latestDone[e.Path] = e.Seq
 			}
-		default:
+		case JournalFsync:
+			// Only fsync frames assert "shadow data is durable"; other ops
+			// (write/rename/mkdir/...) must not resurrect pending uploads.
 			if prev, ok := latestData[e.Path]; !ok || e.Seq > prev.Seq {
 				latestData[e.Path] = e
 			}

--- a/pkg/fuse/journal_test.go
+++ b/pkg/fuse/journal_test.go
@@ -5,6 +5,20 @@ import (
 	"testing"
 )
 
+func mustAppend(t *testing.T, j *Journal, e JournalEntry) {
+	t.Helper()
+	if err := j.Append(e); err != nil {
+		t.Fatalf("append %+v: %v", e, err)
+	}
+}
+
+func mustFsync(t *testing.T, j *Journal) {
+	t.Helper()
+	if err := j.Fsync(); err != nil {
+		t.Fatalf("journal fsync: %v", err)
+	}
+}
+
 func TestJournalAppendReplay(t *testing.T) {
 	dir := t.TempDir()
 	jPath := filepath.Join(dir, "test.wal")
@@ -75,10 +89,10 @@ func TestJournalCompact(t *testing.T) {
 	}
 
 	// Write, commit for /a.txt; write (no commit) for /b.txt.
-	_ = j.Append(JournalEntry{Op: JournalWrite, Path: "/a.txt"})
-	_ = j.Append(JournalEntry{Op: JournalWrite, Path: "/b.txt"})
-	_ = j.Append(JournalEntry{Op: JournalCommit, Path: "/a.txt"})
-	_ = j.Fsync()
+	mustAppend(t, j, JournalEntry{Op: JournalWrite, Path: "/a.txt"})
+	mustAppend(t, j, JournalEntry{Op: JournalWrite, Path: "/b.txt"})
+	mustAppend(t, j, JournalEntry{Op: JournalCommit, Path: "/a.txt"})
+	mustFsync(t, j)
 
 	// Compact.
 	if err := j.Compact(); err != nil {
@@ -118,20 +132,20 @@ func TestReplayJournalIntoPendingHonorsCommitMarkers(t *testing.T) {
 	defer func() { _ = j.Close() }()
 
 	// /committed.txt: fsync then commit — must NOT resurrect.
-	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/committed.txt", Length: 10, BaseRev: 5})
-	_ = j.Append(JournalEntry{Op: JournalCommit, Path: "/committed.txt"})
+	mustAppend(t, j, JournalEntry{Op: JournalFsync, Path: "/committed.txt", Length: 10, BaseRev: 5})
+	mustAppend(t, j, JournalEntry{Op: JournalCommit, Path: "/committed.txt"})
 	// /pending.txt: fsync, commit, then fsync again — MUST resurrect with
 	// the latest entry's metadata.
-	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/pending.txt", Length: 10, BaseRev: 3})
-	_ = j.Append(JournalEntry{Op: JournalCommit, Path: "/pending.txt"})
-	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/pending.txt", Length: 30, BaseRev: 4})
+	mustAppend(t, j, JournalEntry{Op: JournalFsync, Path: "/pending.txt", Length: 10, BaseRev: 3})
+	mustAppend(t, j, JournalEntry{Op: JournalCommit, Path: "/pending.txt"})
+	mustAppend(t, j, JournalEntry{Op: JournalFsync, Path: "/pending.txt", Length: 30, BaseRev: 4})
 	// /new-spill.bin: ShadowSpill fsync, never committed — must resurrect
 	// in spill mode so recovery streams instead of ReadAll.
-	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/new-spill.bin", Length: 1 << 30, BaseRev: 0, ShadowSpill: true})
+	mustAppend(t, j, JournalEntry{Op: JournalFsync, Path: "/new-spill.bin", Length: 1 << 30, BaseRev: 0, ShadowSpill: true})
 	// /unlinked.txt: fsync then unlink marker — must NOT resurrect.
-	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/unlinked.txt", Length: 7, BaseRev: 2})
-	_ = j.Append(JournalEntry{Op: JournalUnlink, Path: "/unlinked.txt"})
-	_ = j.Fsync()
+	mustAppend(t, j, JournalEntry{Op: JournalFsync, Path: "/unlinked.txt", Length: 7, BaseRev: 2})
+	mustAppend(t, j, JournalEntry{Op: JournalUnlink, Path: "/unlinked.txt"})
+	mustFsync(t, j)
 
 	idx, err := NewPendingIndex(t.TempDir())
 	if err != nil {
@@ -184,8 +198,8 @@ func TestReplayJournalIntoPendingPrefersSurvivingMeta(t *testing.T) {
 	}
 	defer func() { _ = j.Close() }()
 
-	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/a.txt", Length: 10, BaseRev: 1})
-	_ = j.Fsync()
+	mustAppend(t, j, JournalEntry{Op: JournalFsync, Path: "/a.txt", Length: 10, BaseRev: 1})
+	mustFsync(t, j)
 
 	idx, err := NewPendingIndex(t.TempDir())
 	if err != nil {
@@ -218,11 +232,13 @@ func TestJournalCompactAfterReplayKeepsSeqMonotonic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/done.txt", Length: 4, BaseRev: 1})
-	_ = j.Append(JournalEntry{Op: JournalCommit, Path: "/done.txt"})
-	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/live.txt", Length: 8, BaseRev: 2})
-	_ = j.Fsync()
-	_ = j.Close()
+	mustAppend(t, j, JournalEntry{Op: JournalFsync, Path: "/done.txt", Length: 4, BaseRev: 1})
+	mustAppend(t, j, JournalEntry{Op: JournalCommit, Path: "/done.txt"})
+	mustAppend(t, j, JournalEntry{Op: JournalFsync, Path: "/live.txt", Length: 8, BaseRev: 2})
+	mustFsync(t, j)
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	// "Remount": replay then compact, as mount.go does.
 	j2, err := NewJournal(jPath)
@@ -249,7 +265,7 @@ func TestJournalCompactAfterReplayKeepsSeqMonotonic(t *testing.T) {
 
 	// Frames for the committed path must be gone; new appends must replay
 	// with strictly increasing seq.
-	_ = j2.Append(JournalEntry{Op: JournalFsync, Path: "/after.txt", Length: 2, BaseRev: 3})
+	mustAppend(t, j2, JournalEntry{Op: JournalFsync, Path: "/after.txt", Length: 2, BaseRev: 3})
 	var replayed []JournalEntry
 	if err := j2.Replay(func(e JournalEntry) { replayed = append(replayed, e) }); err != nil {
 		t.Fatal(err)

--- a/pkg/fuse/journal_test.go
+++ b/pkg/fuse/journal_test.go
@@ -105,6 +105,166 @@ func TestJournalCompact(t *testing.T) {
 	}
 }
 
+// TestReplayJournalIntoPendingHonorsCommitMarkers verifies that crash
+// recovery does not resurrect paths whose latest fsync was followed by a
+// commit marker (the path was uploaded or unlinked before the crash), while
+// still resurrecting paths fsync'd again after their last commit.
+func TestReplayJournalIntoPendingHonorsCommitMarkers(t *testing.T) {
+	dir := t.TempDir()
+	j, err := NewJournal(filepath.Join(dir, "replay.wal"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = j.Close() }()
+
+	// /committed.txt: fsync then commit — must NOT resurrect.
+	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/committed.txt", Length: 10, BaseRev: 5})
+	_ = j.Append(JournalEntry{Op: JournalCommit, Path: "/committed.txt"})
+	// /pending.txt: fsync, commit, then fsync again — MUST resurrect with
+	// the latest entry's metadata.
+	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/pending.txt", Length: 10, BaseRev: 3})
+	_ = j.Append(JournalEntry{Op: JournalCommit, Path: "/pending.txt"})
+	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/pending.txt", Length: 30, BaseRev: 4})
+	// /new-spill.bin: ShadowSpill fsync, never committed — must resurrect
+	// in spill mode so recovery streams instead of ReadAll.
+	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/new-spill.bin", Length: 1 << 30, BaseRev: 0, ShadowSpill: true})
+	// /unlinked.txt: fsync then unlink marker — must NOT resurrect.
+	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/unlinked.txt", Length: 7, BaseRev: 2})
+	_ = j.Append(JournalEntry{Op: JournalUnlink, Path: "/unlinked.txt"})
+	_ = j.Fsync()
+
+	idx, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := replayJournalIntoPending(j, idx); err != nil {
+		t.Fatal(err)
+	}
+
+	if idx.HasPending("/committed.txt") {
+		t.Error("committed path was resurrected")
+	}
+	if idx.HasPending("/unlinked.txt") {
+		t.Error("unlinked path was resurrected")
+	}
+
+	meta, ok := idx.GetMeta("/pending.txt")
+	if !ok {
+		t.Fatal("re-fsync'd path was not resurrected")
+	}
+	if meta.Size != 30 || meta.BaseRev != 4 {
+		t.Errorf("resurrected meta = size %d baseRev %d, want 30/4 (latest fsync)", meta.Size, meta.BaseRev)
+	}
+	if meta.Kind != PendingOverwrite {
+		t.Errorf("resurrected kind = %v, want PendingOverwrite", meta.Kind)
+	}
+
+	spill, ok := idx.GetMeta("/new-spill.bin")
+	if !ok {
+		t.Fatal("ShadowSpill path was not resurrected")
+	}
+	if !spill.ShadowSpill {
+		t.Error("resurrected entry lost ShadowSpill flag — recovery would ReadAll a huge file")
+	}
+	if spill.Kind != PendingNew {
+		t.Errorf("resurrected kind = %v, want PendingNew (BaseRev 0)", spill.Kind)
+	}
+	if spill.Size != 1<<30 {
+		t.Errorf("resurrected size = %d, want %d", spill.Size, int64(1<<30))
+	}
+}
+
+// TestReplayJournalIntoPendingPrefersSurvivingMeta verifies that a .meta file
+// that survived the crash stays authoritative over older WAL frames.
+func TestReplayJournalIntoPendingPrefersSurvivingMeta(t *testing.T) {
+	dir := t.TempDir()
+	j, err := NewJournal(filepath.Join(dir, "replay.wal"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = j.Close() }()
+
+	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/a.txt", Length: 10, BaseRev: 1})
+	_ = j.Fsync()
+
+	idx, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.PutWithBaseRev("/a.txt", 99, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+	if err := replayJournalIntoPending(j, idx); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, ok := idx.GetMeta("/a.txt")
+	if !ok {
+		t.Fatal("pending entry missing")
+	}
+	if meta.Size != 99 || meta.BaseRev != 7 {
+		t.Errorf("surviving meta was overwritten by WAL frame: size %d baseRev %d, want 99/7", meta.Size, meta.BaseRev)
+	}
+}
+
+// TestJournalCompactAfterReplayKeepsSeqMonotonic simulates the mount-time
+// replay+compact cycle and verifies appends after Compact stay monotonic and
+// replayable.
+func TestJournalCompactAfterReplayKeepsSeqMonotonic(t *testing.T) {
+	dir := t.TempDir()
+	jPath := filepath.Join(dir, "cycle.wal")
+
+	j, err := NewJournal(jPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/done.txt", Length: 4, BaseRev: 1})
+	_ = j.Append(JournalEntry{Op: JournalCommit, Path: "/done.txt"})
+	_ = j.Append(JournalEntry{Op: JournalFsync, Path: "/live.txt", Length: 8, BaseRev: 2})
+	_ = j.Fsync()
+	_ = j.Close()
+
+	// "Remount": replay then compact, as mount.go does.
+	j2, err := NewJournal(jPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = j2.Close() }()
+	idx, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := replayJournalIntoPending(j2, idx); err != nil {
+		t.Fatal(err)
+	}
+	if err := j2.Compact(); err != nil {
+		t.Fatal(err)
+	}
+	if idx.HasPending("/done.txt") {
+		t.Error("committed path resurrected")
+	}
+	if !idx.HasPending("/live.txt") {
+		t.Error("uncommitted path not resurrected")
+	}
+
+	// Frames for the committed path must be gone; new appends must replay
+	// with strictly increasing seq.
+	_ = j2.Append(JournalEntry{Op: JournalFsync, Path: "/after.txt", Length: 2, BaseRev: 3})
+	var replayed []JournalEntry
+	if err := j2.Replay(func(e JournalEntry) { replayed = append(replayed, e) }); err != nil {
+		t.Fatal(err)
+	}
+	if len(replayed) != 2 {
+		t.Fatalf("after compact+append: replayed %d entries, want 2", len(replayed))
+	}
+	if replayed[0].Path != "/live.txt" || replayed[1].Path != "/after.txt" {
+		t.Errorf("unexpected frames: %q, %q", replayed[0].Path, replayed[1].Path)
+	}
+	if replayed[1].Seq <= replayed[0].Seq {
+		t.Errorf("seq not monotonic after compact: %d then %d", replayed[0].Seq, replayed[1].Seq)
+	}
+}
+
 func TestJournalEmptyReplay(t *testing.T) {
 	dir := t.TempDir()
 	jPath := filepath.Join(dir, "empty.wal")

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -324,17 +324,15 @@ func Mount(opts *MountOptions) error {
 				dat9fs.journal = journal
 				// Replay journal for crash recovery. Preserve the original kind
 				// and base revision so CommitQueue.RecoverPending can re-enqueue.
-				_ = journal.Replay(func(e JournalEntry) {
-					if pendingIdx != nil && e.Op != JournalCommit && e.Op != JournalUnlink {
-						if !pendingIdx.HasPending(e.Path) {
-							kind := PendingOverwrite
-							if e.BaseRev == 0 {
-								kind = PendingNew
-							}
-							_, _ = pendingIdx.PutWithBaseRev(e.Path, e.Length, kind, e.BaseRev)
-						}
-					}
-				})
+				if err := replayJournalIntoPending(journal, pendingIdx); err != nil {
+					fmt.Fprintf(os.Stderr, "drive9: journal replay: %v\n", err)
+				}
+				// Drop frames already covered by commit markers so the WAL does
+				// not grow unboundedly across mounts. Safe here: mount init is
+				// single-threaded, no concurrent Append yet.
+				if err := journal.Compact(); err != nil {
+					fmt.Fprintf(os.Stderr, "drive9: journal compact: %v\n", err)
+				}
 			}
 
 			// Initialize WriteBackCache before CommitQueue so that legacy

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -223,14 +223,15 @@ func (idx *PendingIndex) RenamePending(oldPath, newPath string) bool {
 // entry under newPath on disk while oldPath stays authoritative in memory and
 // on disk. With both .meta files durable, a crash leaves the data reachable
 // no matter whether the shadow file has moved yet — recovery prunes whichever
-// side has no shadow. Returns the prepared meta for CommitRename, or ok=false
-// when there is no pending entry for oldPath.
-func (idx *PendingIndex) PrepareRename(oldPath, newPath string) (*WriteBackMeta, bool) {
+// side has no shadow. Returns the prepared meta for CommitRename, nil meta
+// (with nil error) when there is no pending entry for oldPath, and a non-nil
+// error when persisting the prepared meta fails.
+func (idx *PendingIndex) PrepareRename(oldPath, newPath string) (*WriteBackMeta, error) {
 	idx.mu.RLock()
 	meta, ok := idx.items[oldPath]
 	if !ok {
 		idx.mu.RUnlock()
-		return nil, false
+		return nil, nil
 	}
 	gen := idx.nextGen.Add(1)
 	newMeta := &WriteBackMeta{
@@ -249,12 +250,12 @@ func (idx *PendingIndex) PrepareRename(oldPath, newPath string) (*WriteBackMeta,
 
 	metaBytes, err := json.Marshal(newMeta)
 	if err != nil {
-		return nil, false
+		return nil, fmt.Errorf("marshal prepared meta for %s: %w", newPath, err)
 	}
 	if err := atomicWrite(filepath.Join(idx.dir, hashPath(newPath)+".meta"), metaBytes); err != nil {
-		return nil, false
+		return nil, fmt.Errorf("persist prepared meta for %s: %w", newPath, err)
 	}
-	return newMeta, true
+	return newMeta, nil
 }
 
 // CommitRename completes a rename prepared by PrepareRename after the shadow

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -219,6 +219,69 @@ func (idx *PendingIndex) RenamePending(oldPath, newPath string) bool {
 	return true
 }
 
+// PrepareRename is phase one of a crash-safe rename: it persists the pending
+// entry under newPath on disk while oldPath stays authoritative in memory and
+// on disk. With both .meta files durable, a crash leaves the data reachable
+// no matter whether the shadow file has moved yet — recovery prunes whichever
+// side has no shadow. Returns the prepared meta for CommitRename, or ok=false
+// when there is no pending entry for oldPath.
+func (idx *PendingIndex) PrepareRename(oldPath, newPath string) (*WriteBackMeta, bool) {
+	idx.mu.RLock()
+	meta, ok := idx.items[oldPath]
+	if !ok {
+		idx.mu.RUnlock()
+		return nil, false
+	}
+	gen := idx.nextGen.Add(1)
+	newMeta := &WriteBackMeta{
+		Path:        newPath,
+		Size:        meta.Size,
+		Mtime:       meta.Mtime,
+		CreatedAt:   meta.CreatedAt,
+		Generation:  gen,
+		Kind:        meta.Kind,
+		BaseRev:     meta.BaseRev,
+		ShadowSpill: meta.ShadowSpill,
+		Mode:        meta.Mode,
+		HasMode:     meta.HasMode,
+	}
+	idx.mu.RUnlock()
+
+	metaBytes, err := json.Marshal(newMeta)
+	if err != nil {
+		return nil, false
+	}
+	if err := atomicWrite(filepath.Join(idx.dir, hashPath(newPath)+".meta"), metaBytes); err != nil {
+		return nil, false
+	}
+	return newMeta, true
+}
+
+// CommitRename completes a rename prepared by PrepareRename after the shadow
+// file has moved: newPath becomes authoritative in memory, oldPath is removed
+// from memory and disk.
+func (idx *PendingIndex) CommitRename(oldPath string, newMeta *WriteBackMeta) {
+	idx.mu.Lock()
+	delete(idx.items, oldPath)
+	idx.items[newMeta.Path] = newMeta
+	idx.mu.Unlock()
+
+	_ = os.Remove(filepath.Join(idx.dir, hashPath(oldPath)+".meta"))
+}
+
+// AbortRename rolls back PrepareRename by deleting the prepared on-disk meta
+// for newPath. It refuses to touch disk when newPath is live in memory, so an
+// unrelated pending entry at the target path cannot be destroyed.
+func (idx *PendingIndex) AbortRename(newPath string) {
+	idx.mu.RLock()
+	_, live := idx.items[newPath]
+	idx.mu.RUnlock()
+	if live {
+		return
+	}
+	_ = os.Remove(filepath.Join(idx.dir, hashPath(newPath)+".meta"))
+}
+
 // ListPendingPaths returns the set of remote paths that have pending entries.
 func (idx *PendingIndex) ListPendingPaths() map[string]struct{} {
 	idx.mu.RLock()

--- a/pkg/fuse/pending_index_test.go
+++ b/pkg/fuse/pending_index_test.go
@@ -232,3 +232,115 @@ func TestPendingIndexRenameNonexistent(t *testing.T) {
 		t.Error("expected rename of nonexistent path to return false")
 	}
 }
+
+// TestPendingIndexPrepareCommitRename verifies the crash-safe three-phase
+// rename: after Prepare both .meta files are durable on disk (so a crash at
+// any point between shadow rename and CommitRename leaves the data
+// reachable), and Commit makes newPath authoritative.
+func TestPendingIndexPrepareCommitRename(t *testing.T) {
+	dir := t.TempDir()
+	idx, err := NewPendingIndex(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.PutShadowSpillWithMode("/old.txt", 42, PendingNew, 0, 0o640, true); err != nil {
+		t.Fatal(err)
+	}
+
+	newMeta, ok := idx.PrepareRename("/old.txt", "/new.txt")
+	if !ok {
+		t.Fatal("PrepareRename failed")
+	}
+
+	// Phase 1 (prepared): memory unchanged, BOTH metas durable on disk.
+	if !idx.HasPending("/old.txt") {
+		t.Error("old path must stay authoritative in memory until Commit")
+	}
+	if idx.HasPending("/new.txt") {
+		t.Error("new path must not be live in memory before Commit")
+	}
+	crash, err := NewPendingIndex(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := crash.RecoverFromDisk(); err != nil {
+		t.Fatal(err)
+	}
+	if !crash.HasPending("/old.txt") || !crash.HasPending("/new.txt") {
+		t.Fatal("crash between Prepare and Commit must recover both metas (recovery prunes the one without a shadow)")
+	}
+	recovered, _ := crash.GetMeta("/new.txt")
+	if recovered.Size != 42 || recovered.Kind != PendingNew || !recovered.ShadowSpill || !recovered.HasMode || recovered.Mode != 0o640 {
+		t.Errorf("prepared meta lost fields: %+v", recovered)
+	}
+
+	// Phase 3 (commit): newPath authoritative, oldPath gone in memory + disk.
+	idx.CommitRename("/old.txt", newMeta)
+	if idx.HasPending("/old.txt") {
+		t.Error("old path still pending after Commit")
+	}
+	if !idx.HasPending("/new.txt") {
+		t.Error("new path not pending after Commit")
+	}
+	after, err := NewPendingIndex(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := after.RecoverFromDisk(); err != nil {
+		t.Fatal(err)
+	}
+	if after.HasPending("/old.txt") {
+		t.Error("old .meta not removed from disk after Commit")
+	}
+	if !after.HasPending("/new.txt") {
+		t.Error("new .meta missing from disk after Commit")
+	}
+}
+
+// TestPendingIndexAbortRename verifies that Abort removes only the prepared
+// on-disk meta, and refuses to delete a meta that is live in memory.
+func TestPendingIndexAbortRename(t *testing.T) {
+	dir := t.TempDir()
+	idx, err := NewPendingIndex(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.PutWithBaseRev("/old.txt", 10, PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := idx.PrepareRename("/old.txt", "/new.txt"); !ok {
+		t.Fatal("PrepareRename failed")
+	}
+	idx.AbortRename("/new.txt")
+
+	recovered, err := NewPendingIndex(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := recovered.RecoverFromDisk(); err != nil {
+		t.Fatal(err)
+	}
+	if recovered.HasPending("/new.txt") {
+		t.Error("aborted .meta still on disk")
+	}
+	if !recovered.HasPending("/old.txt") {
+		t.Error("old .meta lost by abort")
+	}
+
+	// Abort must not delete a live entry's meta.
+	if _, err := idx.PutWithBaseRev("/live.txt", 5, PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+	idx.AbortRename("/live.txt")
+	recovered2, err := NewPendingIndex(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := recovered2.RecoverFromDisk(); err != nil {
+		t.Fatal(err)
+	}
+	if !recovered2.HasPending("/live.txt") {
+		t.Error("AbortRename deleted a live entry's meta")
+	}
+}

--- a/pkg/fuse/pending_index_test.go
+++ b/pkg/fuse/pending_index_test.go
@@ -247,9 +247,12 @@ func TestPendingIndexPrepareCommitRename(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newMeta, ok := idx.PrepareRename("/old.txt", "/new.txt")
-	if !ok {
-		t.Fatal("PrepareRename failed")
+	newMeta, err := idx.PrepareRename("/old.txt", "/new.txt")
+	if err != nil {
+		t.Fatalf("PrepareRename: %v", err)
+	}
+	if newMeta == nil {
+		t.Fatal("PrepareRename found no pending entry")
 	}
 
 	// Phase 1 (prepared): memory unchanged, BOTH metas durable on disk.
@@ -309,8 +312,8 @@ func TestPendingIndexAbortRename(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, ok := idx.PrepareRename("/old.txt", "/new.txt"); !ok {
-		t.Fatal("PrepareRename failed")
+	if prepared, err := idx.PrepareRename("/old.txt", "/new.txt"); err != nil || prepared == nil {
+		t.Fatalf("PrepareRename: meta=%v err=%v", prepared, err)
 	}
 	idx.AbortRename("/new.txt")
 

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -165,6 +165,9 @@ type fusePerfCounters struct {
 	gitOverlayFailure         atomicUint64
 	gitOverlayDrainCount      atomicUint64
 	gitOverlayDrainTotalNS    atomicUint64
+
+	gitWorkspaceRefresh       atomicUint64
+	gitWorkspaceForcedRefresh atomicUint64
 }
 
 // atomicUint64 is a small wrapper around sync/atomic.Uint64. Keeping it local
@@ -334,6 +337,8 @@ func (p *fusePerfCounters) snapshot() fusePerfSnapshot {
 	snap.Counters["git_overlay_failure"] = p.gitOverlayFailure.load()
 	snap.Counters["git_overlay_drain_count"] = p.gitOverlayDrainCount.load()
 	snap.Counters["git_overlay_drain_total_ns"] = p.gitOverlayDrainTotalNS.load()
+	snap.Counters["git_workspace_refresh"] = p.gitWorkspaceRefresh.load()
+	snap.Counters["git_workspace_forced_refresh"] = p.gitWorkspaceForcedRefresh.load()
 	return snap
 }
 
@@ -396,6 +401,9 @@ func (p *fusePerfCounters) printSummary(w io.Writer) {
 		snap.Counters["git_overlay_failure"],
 		snap.Counters["git_overlay_drain_count"],
 		time.Duration(snap.Counters["git_overlay_drain_total_ns"]).Truncate(time.Millisecond))
+	writePerfLine(w, "drive9: perf git_workspace refresh=%d forced_refresh=%d\n",
+		snap.Counters["git_workspace_refresh"],
+		snap.Counters["git_workspace_forced_refresh"])
 }
 
 func writePerfOps(w io.Writer, group string, names []string, stats map[string]perfOpStats) {

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -74,6 +74,16 @@ func NewShadowStore(dir string) (*ShadowStore, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("shadow store dir: %w", err)
 	}
+	// Sweep retired shadows leaked by a previous process that died while
+	// pinned readers still held them — pins cannot survive a restart, and
+	// nothing else ever deletes these files.
+	if entries, err := os.ReadDir(dir); err == nil {
+		for _, e := range entries {
+			if strings.Contains(e.Name(), ".shadow.retired.") {
+				_ = os.Remove(filepath.Join(dir, e.Name()))
+			}
+		}
+	}
 	ss := &ShadowStore{
 		dir:     dir,
 		files:   make(map[string]*ShadowFile),

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -3,6 +3,7 @@ package fuse
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -644,5 +645,56 @@ func TestShadowStoreCheckDiskSpaceThrottled(t *testing.T) {
 	// Verify initial diskOK state matches the real check.
 	if r1 != ss.CheckDiskSpace() {
 		t.Fatal("throttled result does not match real check")
+	}
+}
+
+// TestNewShadowStoreSweepsRetiredFiles verifies that retired shadows leaked
+// by a crashed process (pinned readers never unpinned) are removed at store
+// construction, while live .shadow files are preserved.
+func TestNewShadowStoreSweepsRetiredFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	ss, err := NewShadowStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ss.WriteFull("/keep.txt", []byte("keep"), 1); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a crash while a pinned reader held a retired shadow.
+	gen := ss.Pin("/keep.txt")
+	if gen == 0 {
+		t.Fatal("pin failed")
+	}
+	ss.Remove("/keep.txt") // pinned → retired on disk
+	if err := ss.WriteFull("/live.txt", []byte("live"), 1); err != nil {
+		t.Fatal(err)
+	}
+	ss.Close() // crash: Unpin never runs
+
+	leftover, err := filepath.Glob(filepath.Join(dir, "*.retired.*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftover) != 1 {
+		t.Fatalf("test setup: expected 1 leaked retired file, got %d", len(leftover))
+	}
+
+	// "Remount": construction sweeps the leak, keeps live shadows.
+	ss2, err := NewShadowStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss2.Close()
+
+	leftover, err = filepath.Glob(filepath.Join(dir, "*.retired.*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftover) != 0 {
+		t.Errorf("retired files not swept: %v", leftover)
+	}
+	if !ss2.Has("/live.txt") {
+		t.Error("live shadow was swept")
 	}
 }

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -2494,6 +2494,145 @@ func TestFsyncInteractiveStageEnqueuesBeforeReleasingPath(t *testing.T) {
 	}
 }
 
+// TestFsyncInteractiveWALFrameDurableBeforeEnqueue pins the crash-recovery
+// ordering invariant: the JournalFsync frame must be durable BEFORE the staged
+// commit becomes visible to the commit queue. If the order is reversed, a fast
+// worker can upload and append its JournalCommit marker first, the fsync frame
+// then gets a higher Seq, and replay resurrects a path whose upload already
+// completed.
+//
+// The test simulates a slow WAL device by holding the journal mutex: while the
+// append cannot complete, the entry must not appear in the queue. Both
+// interactive branches (ShadowSpill and regular staged) are covered.
+func TestFsyncInteractiveWALFrameDurableBeforeEnqueue(t *testing.T) {
+	t.Run("shadowspill", func(t *testing.T) { testFsyncWALFrameDurableBeforeEnqueue(t, true) })
+	t.Run("regular", func(t *testing.T) { testFsyncWALFrameDurableBeforeEnqueue(t, false) })
+}
+
+func testFsyncWALFrameDurableBeforeEnqueue(t *testing.T, spill bool) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no remote traffic expected", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0, SyncMode: SyncInteractive}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal, err := NewJournal(filepath.Join(t.TempDir(), "order.wal"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = journal.Close() }()
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.journal = journal
+	fs.commitQueue = &CommitQueue{
+		maxPending:   4,
+		shadows:      shadow,
+		index:        pending,
+		journal:      journal,
+		inFlight:     make(map[string]*CommitEntry),
+		queuedByPath: make(map[string]map[*CommitEntry]struct{}),
+		workCh:       make(chan *CommitEntry, 8),
+	}
+
+	const remotePath = "/wal-order.bin"
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+	}, "wal-order.bin", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}, []byte("ordering invariant bytes")); st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+	if !spill {
+		// Freshly created handles default to ShadowSpill; force the
+		// regular staged branch (small dirty buffer materialized to the
+		// shadow at fsync time).
+		fh, ok := fs.fileHandles.Get(createOut.Fh)
+		if !ok {
+			t.Fatal("created handle missing")
+		}
+		fh.Lock()
+		fh.ShadowSpill = false
+		fh.Unlock()
+	}
+
+	// Block the WAL append; Fsync must not hand the commit to the queue
+	// until the frame is on disk.
+	journal.mu.Lock()
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	start := time.Now()
+	for time.Since(start) < 300*time.Millisecond {
+		if fs.commitQueue.HasPath(remotePath) {
+			journal.mu.Unlock()
+			t.Fatal("staged commit visible to the queue before its JournalFsync frame was durable")
+		}
+		select {
+		case st := <-fsyncDone:
+			journal.mu.Unlock()
+			t.Fatalf("Fsync returned %v while the WAL append was blocked", st)
+		default:
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	journal.mu.Unlock()
+
+	if st := <-fsyncDone; st != gofuse.OK {
+		t.Fatalf("Fsync: %v", st)
+	}
+	if !fs.commitQueue.HasPath(remotePath) {
+		t.Fatal("staged commit not enqueued after the WAL append completed")
+	}
+	var fsyncSeq uint64
+	if err := journal.Replay(func(e JournalEntry) {
+		if e.Op == JournalFsync && e.Path == remotePath {
+			fsyncSeq = e.Seq
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if fsyncSeq == 0 {
+		t.Fatal("JournalFsync frame missing after Fsync returned")
+	}
+
+	// The async commit marker (what onCommitSuccess appends) now necessarily
+	// gets a higher Seq, so replay must NOT resurrect the committed path.
+	mustAppend(t, journal, JournalEntry{Op: JournalCommit, Path: remotePath})
+	mustFsync(t, journal)
+	idx, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := replayJournalIntoPending(journal, idx); err != nil {
+		t.Fatal(err)
+	}
+	if idx.HasPending(remotePath) {
+		t.Fatal("replay resurrected a committed path: commit marker did not supersede the fsync frame")
+	}
+}
+
 func TestFsyncQueuedCommitSameOpenHandleWritePreservesCommittedBytes(t *testing.T) {
 	const filePath = "/fsync-rewrite.bin"
 	first := []byte("first")


### PR DESCRIPTION
## Summary
- Fixes five crash corner cases in the FUSE interactive write path (shadow / pending / WAL / commit queue) exposed by `kill -9` between fsync and async commit:
  1. WAL replay resurrected already-committed/unlinked paths and could pair stale frames with a newer session's shadow → replay now honors commit/unlink markers; fsync frames carry `Length`/`ShadowSpill`; journal compacts at mount; cancel paths write commit markers
  2. ShadowSpill 409 was unconditionally terminal, stranding crash-replayed uploads that had already landed → bounded chunked idempotent compare (8MB chunks, no LWW)
  3. pending-new rename moved the shadow before the index, silently orphaning data on crash → meta-first three-phase rename (Prepare/Commit/Abort); recovery prunes whichever side lacks a shadow
  4. `.shadow.retired.*` files leaked by pinned removal → swept at `NewShadowStore`
  5. `RecoverPending` routed uploads by stale `meta.Size` → routes by actual shadow size
- Adds two e2e gates plus unit tests:
  - `e2e/fuse-crash-recovery-test.sh` — kill -9 mid-write, remount, verify exact remote sha256, no unlink resurrection, WAL compaction
  - `e2e/fuse-write-perf-budget-test.sh` — op-count perf budgets (remote write/stat/list/mutation, commit retries/failures, fsync latency) from `--perf-counters`; plus `git_workspace` refresh counters and a refresh budget in `git-ops-smoke-test.sh` guarding the #542 storm class
- Fixes an environment-dependent disk read cache test (`FreeRatio: 0` means the 10% default, not disabled — recovered entry was evicted at startup on nearly-full disks)

## Test plan
- [x] `go test ./pkg/fuse/ -count=1` green on macOS and Linux (go 1.26)
- [x] `e2e/fuse-crash-recovery-test.sh` 21/21 on EC2 against hosted server (journal.wal survives kill -9; all fsync'd files incl. 96MB ShadowSpill recover with exact sha256; doomed unlinked file does not resurrect; WAL compacts to 0 bytes after clean remount)
- [x] `e2e/fuse-write-perf-budget-test.sh` 14/14 on EC2 (remote_write=129/408 ≈ 1.3 ops/commit, stat=44/685, 16 renames → exactly 16 mutations, commit retries/failures 0, fsync avg sub-ms i.e. purely local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end tests covering FUSE crash recovery and write-path perf budgets.
  * Added perf counters and monitoring for Git workspace refreshes.

* **Bug Fixes**
  * Improved crash recovery to avoid resurrecting deleted files and to honor commit/unlink markers.
  * Made rename and commit/cancellation flows more crash-safe and idempotent.
  * Prevented accumulation of retired shadow files on startup.

* **Performance**
  * Journal replay + compaction on startup to bound WAL growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->