### PR TITLE
perf: fetch small files whole in one request on FUSE cold reads

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -111,7 +111,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	foreground := fs.Bool("foreground", false, "run in the foreground and block until unmounted")
 	cacheDir := fs.String("cache-dir", "", "write-back cache directory (default ~/.cache/drive9)")
 	cacheSize := fs.Int("cache-size", 128, "read cache size in MB")
-	readCacheMaxFile := fs.Int64("read-cache-max-file-mb", 1, "maximum single file size admitted to read cache in MB")
+	readCacheMaxFile := fs.Int64("read-cache-max-file-mb", 4, "maximum single file size admitted to read cache in MB; files at or below this size are fetched with a single whole-file request")
 	diskReadCacheSize := fs.Int64("disk-read-cache-size-mb", 1024, "disk-backed read cache size in MB")
 	diskReadCacheFreeRatio := fs.Float64("disk-read-cache-free-ratio", 0.10, "minimum filesystem free-space ratio before disk read cache evicts")
 	dirTTL := fs.Duration("dir-ttl", 10*time.Second, "directory cache TTL")

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -8003,12 +8003,31 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 			// Whole-file disk cache tier: survives ReadCache TTL/eviction
 			// so warm reads of small files are served from local disk
 			// instead of re-fetching from the remote.
+			//
+			// When TrustLocalEvents is false (default), revalidate the
+			// inode revision via HEAD before serving a disk cache hit.
+			// Without this check a stale revision from a prior session
+			// would match a persisted disk entry and serve outdated bytes
+			// after another client updates the file remotely — the same
+			// guard the range disk-cache path applies below.
 			if diskKeyOK {
 				if cached, ok := fs.diskReadCache.Get(diskKey); ok {
+					if !fs.statCacheTrustedAndVerified() && !revalidatedForRead {
+						refreshed, headErr := fs.revalidateReadCacheEntryIfUntrusted(cancel, p, entry)
+						if headErr != nil {
+							return nil, headErr
+						}
+						if refreshed.Revision != entry.Revision {
+							// Revision changed — disk entry is stale; fall
+							// through to fetch fresh data from the remote.
+							goto wholeFileDiskCacheMiss
+						}
+					}
 					fs.readCache.PutOwned(p, cached, cacheRev)
 					return cached, nil
 				}
 			}
+		wholeFileDiskCacheMiss:
 			// Use a detached context for the shared HTTP fetch so that
 			// cancellation of the owner's FUSE request does not fail
 			// piggybacking readers. Apply a fresh bounded timeout so the

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7998,7 +7998,17 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		// the observed revision so that concurrent reads after a revision
 		// change do not share stale in-flight results.
 		sfKey := fmt.Sprintf("%s@%d", p, cacheRev)
+		diskKey, diskKeyOK := fs.diskReadCacheKey(p, entry, 0, entry.Size)
 		data, err, _ := fs.readFlight.Do(ctx, sfKey, func() ([]byte, error) {
+			// Whole-file disk cache tier: survives ReadCache TTL/eviction
+			// so warm reads of small files are served from local disk
+			// instead of re-fetching from the remote.
+			if diskKeyOK {
+				if cached, ok := fs.diskReadCache.Get(diskKey); ok {
+					fs.readCache.PutOwned(p, cached, cacheRev)
+					return cached, nil
+				}
+			}
 			// Use a detached context for the shared HTTP fetch so that
 			// cancellation of the owner's FUSE request does not fail
 			// piggybacking readers. Apply a fresh bounded timeout so the
@@ -8018,6 +8028,11 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 			// is visible before the flight key is released. This closes
 			// the window where a concurrent reader could miss both the
 			// cache and the in-flight dedup.
+			if diskKeyOK {
+				// PutAsync validates len(fetchData) == diskKey.Length, so a
+				// stale stat size cannot persist a truncated entry.
+				fs.diskReadCache.PutAsync(diskKey, fetchData)
+			}
 			fs.readCache.PutOwned(p, fetchData, cacheRev)
 			return fetchData, nil
 		})

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -965,6 +965,127 @@ func TestReadCacheCachesMediumSmallFileAfterFirstRead(t *testing.T) {
 	}
 }
 
+// A 2MiB file sits above the old 1MiB whole-file threshold and below the
+// current default: its cold read must be one whole-file GET (no Range
+// header, no prefetcher) instead of block-split range reads.
+func TestReadTwoMiBFileUsesSingleWholeFileRequest(t *testing.T) {
+	data := bytes.Repeat([]byte("y"), 2<<20)
+	var getCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			getCalls.Add(1)
+			if got := r.Header.Get("Range"); got != "" {
+				http.Error(w, "unexpected range request: "+got, http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+			_, _ = w.Write(data)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(client.New(ts.URL, ""), opts)
+
+	const rev = 11
+	ino := fs.inodes.Lookup("/bench.bin", false, int64(len(data)), time.Now())
+	fs.inodes.UpdateRevision(ino, rev)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	fh, ok := fs.fileHandles.Get(out.Fh)
+	if !ok {
+		t.Fatal("file handle not found")
+	}
+	if fh.Prefetch != nil {
+		t.Fatal("expected no Prefetcher for a file within the whole-file read threshold")
+	}
+
+	got, st, err := readDat9FSTestRange(fs, ino, out.Fh, 0, 128<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st != gofuse.OK || !bytes.Equal(got, data[:128<<10]) {
+		t.Fatalf("first read status = %v, len = %d; want OK with 128KiB prefix", st, len(got))
+	}
+	got, st, err = readDat9FSTestRange(fs, ino, out.Fh, int64(len(data))-(128<<10), 128<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st != gofuse.OK || !bytes.Equal(got, data[len(data)-(128<<10):]) {
+		t.Fatalf("second read status = %v, len = %d; want OK with 128KiB suffix", st, len(got))
+	}
+	if calls := getCalls.Load(); calls != 1 {
+		t.Fatalf("GET calls = %d, want 1 whole-file request", calls)
+	}
+}
+
+// Whole-file reads must persist into the disk read cache so warm reads
+// after ReadCache TTL expiry or eviction are served from local disk
+// instead of re-fetching from the remote.
+func TestReadWholeFilePopulatesDiskReadCacheTier(t *testing.T) {
+	const (
+		path = "/file.bin"
+		rev  = int64(7)
+	)
+	data := bytes.Repeat([]byte("z"), 2<<20)
+	var objectReads atomic.Int32
+
+	fs, ino, cleanup := newTestDat9FSWithRangeObject(t, int64(len(data)), func(w http.ResponseWriter, r *http.Request) {
+		objectReads.Add(1)
+		if got := r.Header.Get("Range"); got != "" {
+			http.Error(w, "unexpected range request: "+got, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+		_, _ = w.Write(data)
+	})
+	defer cleanup()
+	fs.diskReadCache = newTestDiskReadCache(t, 8<<20)
+	fs.inodes.UpdateRevision(ino, rev)
+	fh := openDat9FSTestHandle(t, fs, ino, path)
+	defer fs.fileHandles.Delete(fh)
+	key, ok := fs.diskReadCacheKey(path, mustGetInodeEntry(t, fs, ino), 0, int64(len(data)))
+	if !ok {
+		t.Fatal("disk read cache key unavailable")
+	}
+
+	got, st, err := readDat9FSTestRange(fs, ino, fh, 0, 64<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st != gofuse.OK || !bytes.Equal(got, data[:64<<10]) {
+		t.Fatalf("first read status = %v, len = %d; want OK", st, len(got))
+	}
+	waitForDiskReadCacheEntry(t, fs.diskReadCache, key)
+
+	// Simulate ReadCache TTL expiry/eviction: the next read must be served
+	// from the disk tier without another remote fetch.
+	fs.readCache.InvalidateAll()
+
+	got, st, err = readDat9FSTestRange(fs, ino, fh, int64(len(data))-(64<<10), 64<<10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st != gofuse.OK || !bytes.Equal(got, data[len(data)-(64<<10):]) {
+		t.Fatalf("disk-tier read status = %v, len = %d; want OK", st, len(got))
+	}
+	if calls := objectReads.Load(); calls != 1 {
+		t.Fatalf("object reads = %d, want 1 (second read must come from disk tier)", calls)
+	}
+}
+
 func readDat9FSTestBytes(fs *Dat9FS, ino, fh uint64, size int) ([]byte, gofuse.Status, error) {
 	buf := make([]byte, size)
 	result, st := fs.Read(nil, &gofuse.ReadIn{
@@ -5781,7 +5902,7 @@ func TestIsTransientLookupErr_Treats499AsTransient(t *testing.T) {
 }
 
 func TestOpenReadOnlyLargeFileGetsPrefetcher(t *testing.T) {
-	size := int64(2 * 1024 * 1024) // above default read-cache admission limit
+	size := int64(defaultReadCacheMaxFileSize + 1024) // above default read-cache admission limit
 	data := make([]byte, size)
 	for i := range data {
 		data[i] = byte(i % 256)
@@ -14328,7 +14449,7 @@ func TestDoRangeReadBodyTruncationReturnsError(t *testing.T) {
 // TestReadPrefetchNotTriggeredOnFailure verifies that Prefetch.OnRead is NOT
 // called when the remote read fails after a prefetch cache miss.
 func TestReadPrefetchNotTriggeredOnFailure(t *testing.T) {
-	fileSize := int64(2 << 20) // above default read-cache admission limit
+	fileSize := int64(defaultReadCacheMaxFileSize + 1024) // above default read-cache admission limit
 	var getCalls atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -37,7 +37,7 @@ type MountOptions struct {
 	RemoteRoot              string        // remote subtree root (default "/"); set via "drive9 mount :/path /local"
 	CacheDir                string        // write-back cache directory (default ~/.cache/drive9); empty string uses default
 	CacheSize               int64         // ReadCache max size in bytes (default 128MB)
-	ReadCacheMaxFileBytes   int64         // largest single file admitted to ReadCache (default 1MiB)
+	ReadCacheMaxFileBytes   int64         // largest single file admitted to ReadCache and fetched whole-file in one request (default 4MiB)
 	DiskReadCacheSize       int64         // disk-backed read cache max size in bytes (default 1GiB)
 	DiskReadCacheFreeRatio  float64       // minimum filesystem free-space ratio before disk read cache evicts (default 0.10)
 	DirTTL                  time.Duration // DirCache TTL (default 10s)

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -20,9 +20,12 @@ const (
 	// defaultReadCacheMaxFileSize is deliberately larger than the inline
 	// fallback so medium files do not miss userspace cache solely because
 	// their server inline threshold is lower. The aggregate cache cap still
-	// bounds memory use. Keeping this at 1MiB covers common benchmark and
-	// editor workloads without turning the cache into an unbounded object store.
-	defaultReadCacheMaxFileSize = 1 << 20
+	// bounds memory use. This threshold also gates the whole-file
+	// single-request read path in Read: files at or below it are fetched
+	// with one GET instead of block-split range reads + prefetch, so it is
+	// sized to cover common small-object workloads (e.g. 2MiB media chunks)
+	// without turning the cache into an unbounded object store.
+	defaultReadCacheMaxFileSize = 4 << 20
 )
 
 // cacheEntry holds a single cached file's data and metadata.


### PR DESCRIPTION
## Summary

Cold-read benchmarking on the EC2 fio box (1000 × 2MB files, 4-way concurrency) showed the FUSE read path is 2-3x slower than the bare API for small files, entirely due to request amplification in the daemon — not server/network:

- Per 100 cold 2MB files (perf-counters): **707 remote range reads** @ avg 64ms / 384KB each (~7 requests per file), **278MB fetched for 200MB delivered** (33% over-read from prefetch fragments + block splits), plus 1 remote stat per file.
- fio cold read: **14.8 MB/s, avg 331ms/file, p99 826ms**; the bare API does the same file in one GET (~150ms) and scales linearly to 36 MB/s at 4-way.

The whole-file single-request path already existed but was gated at 1MiB, so 2MB files fell into the block-split + prefetch path.

### Changes

1. **Raise the whole-file read threshold from 1MiB to 4MiB** (`--read-cache-max-file-mb` default, `defaultReadCacheMaxFileSize`). Files ≤ threshold are fetched with one GET via `readSmallFileWithRetry` and served from the ReadCache; the prefetcher gate moves with the same constant, so these files no longer spawn fragment prefetches.
2. **Persist whole-file reads into the disk read cache tier** (`pkg/fuse/dat9fs.go` small-file branch). Previously files ≤ threshold only lived in the in-memory ReadCache (30s TTL, LRU) — without this, raising the threshold would regress warm reads of 1-4MiB files to remote re-fetches. Now: RAM → disk tier → remote, with the same revision-keyed invalidation as block entries. `PutAsync` length-validates against the stat size, so a stale stat cannot persist a truncated entry.

Expected cold-read cost per 2MB file drops from ~70ms stat + ~7 range GETs to ~70ms stat + 1 GET.

### Tests

- `TestReadTwoMiBFileUsesSingleWholeFileRequest`: a 2MiB cold read issues exactly one GET with no Range header and no prefetcher.
- `TestReadWholeFilePopulatesDiskReadCacheTier`: after ReadCache invalidation, the next read is served from the disk tier with no extra remote fetch.
- Two prefetcher tests updated to size files relative to `defaultReadCacheMaxFileSize` instead of a hardcoded 2MiB.

## Test plan

- [x] `go test ./pkg/fuse/ ./cmd/drive9/cli/` full suites green
- [ ] fio cold-read re-run on the EC2 bench box vs the 14.8 MB/s baseline (box SSH currently blocked by SG; binary built and ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a disk-level read cache tier for small files to reduce remote fetches after cache misses.
  * Increased the default per-file read-cache limit from 1 MB to 4 MB.

* **Tests**
  * Added tests validating read-cache behavior around the legacy threshold and that whole-file reads populate the disk read cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->