### PR TITLE
feat(cli): add update command

### DIFF
--- a/cmd/drive9/cli/update.go
+++ b/cmd/drive9/cli/update.go
@@ -143,7 +143,7 @@ func updateWithDeps(args []string, deps updateDeps) error {
 	}()
 
 	if err := deps.replaceExecutable(tmpPath, target); err != nil {
-		return fmt.Errorf("replace %s: %w\nIf this binary is owned by another user, rerun with sufficient permissions or install drive9 into a user-writable directory.", target, err)
+		return fmt.Errorf("replace %s: %w; rerun with sufficient permissions or install drive9 into a user-writable directory", target, err)
 	}
 	installed = true
 

--- a/cmd/drive9/cli/update.go
+++ b/cmd/drive9/cli/update.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -26,35 +27,21 @@ const (
 )
 
 type updateDeps struct {
-	baseURL           string
-	currentVersion    string
-	goos              string
-	goarch            string
-	executable        func() (string, error)
-	httpClient        *http.Client
-	stdout            io.Writer
-	stderr            io.Writer
-	preflightReplace  func() error
-	replaceExecutable func(string, string) error
+	baseURL              string
+	currentVersion       string
+	goos                 string
+	goarch               string
+	executable           func() (string, error)
+	httpClient           *http.Client
+	stdout               io.Writer
+	stderr               io.Writer
+	allowInsecureBaseURL bool
+	preflightReplace     func() error
+	replaceExecutable    func(string, string) error
 }
 
 func defaultUpdateDeps() updateDeps {
-	baseURL := strings.TrimSpace(os.Getenv("DRIVE9_UPDATE_BASE_URL"))
-	if baseURL == "" {
-		baseURL = defaultUpdateBaseURL
-	}
-	return updateDeps{
-		baseURL:           baseURL,
-		currentVersion:    buildinfo.Version,
-		goos:              runtime.GOOS,
-		goarch:            runtime.GOARCH,
-		executable:        os.Executable,
-		httpClient:        &http.Client{Timeout: updateCommandTimeout},
-		stdout:            os.Stdout,
-		stderr:            os.Stderr,
-		preflightReplace:  preflightReplaceExecutableFile,
-		replaceExecutable: replaceExecutableFile,
-	}
+	return fillUpdateDeps(updateDeps{})
 }
 
 // Update updates the running drive9 CLI binary in place.
@@ -85,6 +72,9 @@ func updateWithDeps(args []string, deps updateDeps) error {
 		return fmt.Errorf("unexpected argument %q\n%s", fs.Arg(0), updateUsage())
 	}
 	deps.baseURL = normalizeUpdateBaseURL(*baseURL)
+	if err := validateUpdateBaseURL(deps.baseURL, deps.allowInsecureBaseURL); err != nil {
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), updateCommandTimeout)
 	defer cancel()
@@ -446,11 +436,28 @@ func parseChecksums(data []byte) (map[string]string, error) {
 		if _, err := hex.DecodeString(sum); err != nil {
 			return nil, fmt.Errorf("invalid checksum for %s: %w", fields[1], err)
 		}
-		name := strings.TrimPrefix(fields[1], "*")
+		name, err := checksumArtifactName(fields[1])
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := checksums[name]; exists {
+			return nil, fmt.Errorf("duplicate checksum for %s", name)
+		}
 		checksums[name] = sum
-		checksums[filepath.Base(name)] = sum
 	}
 	return checksums, nil
+}
+
+func checksumArtifactName(raw string) (string, error) {
+	name := strings.TrimPrefix(raw, "*")
+	if name == "" {
+		return "", errors.New("empty checksum artifact name")
+	}
+	clean := filepath.ToSlash(filepath.Clean(name))
+	if clean == "." || strings.HasPrefix(clean, "/") || strings.HasPrefix(clean, "../") || strings.Contains(clean, "/") {
+		return "", fmt.Errorf("checksum artifact %q must be a release artifact filename", raw)
+	}
+	return clean, nil
 }
 
 func downloadUpdateBinary(ctx context.Context, deps updateDeps, url, targetPath, wantSHA string) (string, error) {
@@ -538,6 +545,17 @@ func updateArtifactName(goos, goarch string) string {
 
 func normalizeUpdateBaseURL(baseURL string) string {
 	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+func validateUpdateBaseURL(baseURL string, allowInsecure bool) error {
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("invalid release base URL %q", baseURL)
+	}
+	if parsed.Scheme == "https" || allowInsecure {
+		return nil
+	}
+	return fmt.Errorf("release base URL %q must use https", baseURL)
 }
 
 func releaseURL(baseURL, name string) string {

--- a/cmd/drive9/cli/update.go
+++ b/cmd/drive9/cli/update.go
@@ -1,0 +1,519 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/buildinfo"
+)
+
+const (
+	defaultUpdateBaseURL = "https://drive9.ai"
+	updateCheckInterval  = 24 * time.Hour
+	autoUpdateTimeout    = 1500 * time.Millisecond
+	updateCommandTimeout = 2 * time.Minute
+	maxUpdateFileBytes   = 200 << 20
+)
+
+type updateDeps struct {
+	baseURL           string
+	currentVersion    string
+	goos              string
+	goarch            string
+	now               func() time.Time
+	executable        func() (string, error)
+	httpClient        *http.Client
+	stdout            io.Writer
+	stderr            io.Writer
+	replaceExecutable func(string, string) error
+}
+
+type updateCache struct {
+	LastCheckedAt time.Time `json:"last_checked_at"`
+	LatestVersion string    `json:"latest_version,omitempty"`
+	LatestURL     string    `json:"latest_url,omitempty"`
+}
+
+func defaultUpdateDeps() updateDeps {
+	baseURL := strings.TrimSpace(os.Getenv("DRIVE9_UPDATE_BASE_URL"))
+	if baseURL == "" {
+		baseURL = defaultUpdateBaseURL
+	}
+	return updateDeps{
+		baseURL:           baseURL,
+		currentVersion:    buildinfo.Version,
+		goos:              runtime.GOOS,
+		goarch:            runtime.GOARCH,
+		now:               time.Now,
+		executable:        os.Executable,
+		httpClient:        &http.Client{Timeout: updateCommandTimeout},
+		stdout:            os.Stdout,
+		stderr:            os.Stderr,
+		replaceExecutable: replaceExecutableFile,
+	}
+}
+
+// Update updates the running drive9 CLI binary in place.
+func Update(args []string) error {
+	return updateWithDeps(args, defaultUpdateDeps())
+}
+
+func updateWithDeps(args []string, deps updateDeps) error {
+	deps = fillUpdateDeps(deps)
+	if len(args) > 0 && IsHelpArg(args[0]) {
+		_, _ = fmt.Fprintln(deps.stdout, updateUsage())
+		return nil
+	}
+
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	checkOnly := fs.Bool("check", false, "check for the latest version without installing it")
+	force := fs.Bool("force", false, "reinstall the latest binary even when versions match")
+	baseURL := fs.String("base-url", deps.baseURL, "release base URL")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("%w\n%s", err, updateUsage())
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected argument %q\n%s", fs.Arg(0), updateUsage())
+	}
+	deps.baseURL = normalizeUpdateBaseURL(*baseURL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateCommandTimeout)
+	defer cancel()
+
+	latestVersion, err := fetchLatestVersion(ctx, deps)
+	if err != nil {
+		return err
+	}
+	artifact := updateArtifactName(deps.goos, deps.goarch)
+	latestURL := releaseURL(deps.baseURL, artifact)
+	_ = writeUpdateCache(updateCache{
+		LastCheckedAt: deps.now().UTC(),
+		LatestVersion: latestVersion,
+		LatestURL:     latestURL,
+	})
+
+	if *checkOnly {
+		if versionsDiffer(deps.currentVersion, latestVersion) {
+			_, _ = fmt.Fprintf(deps.stdout, "drive9 update available: %s -> %s\n", displayVersion(deps.currentVersion), latestVersion)
+		} else {
+			_, _ = fmt.Fprintf(deps.stdout, "drive9 is up to date (%s)\n", displayVersion(deps.currentVersion))
+		}
+		return nil
+	}
+	if !*force && !versionsDiffer(deps.currentVersion, latestVersion) {
+		_, _ = fmt.Fprintf(deps.stdout, "drive9 is already up to date (%s)\n", displayVersion(deps.currentVersion))
+		return nil
+	}
+
+	target, err := currentExecutablePath(deps)
+	if err != nil {
+		return err
+	}
+	checksums, err := fetchReleaseChecksums(ctx, deps)
+	if err != nil {
+		return err
+	}
+	want, ok := checksums[artifact]
+	if !ok {
+		return fmt.Errorf("checksum for %s not found in %s", artifact, releaseURL(deps.baseURL, "checksums.txt"))
+	}
+
+	tmpPath, err := downloadUpdateBinary(ctx, deps, latestURL, target, want)
+	if err != nil {
+		return err
+	}
+	installed := false
+	defer func() {
+		if !installed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := deps.replaceExecutable(tmpPath, target); err != nil {
+		return fmt.Errorf("replace %s: %w\nIf this binary is owned by another user, rerun with sufficient permissions or install drive9 into a user-writable directory.", target, err)
+	}
+	installed = true
+
+	_, _ = fmt.Fprintf(deps.stdout, "drive9 updated: %s -> %s\n", displayVersion(deps.currentVersion), latestVersion)
+	return nil
+}
+
+func updateUsage() string {
+	return `usage: drive9 update [--check] [--force] [--base-url URL]
+  --check          check for a newer release without installing
+  --force          reinstall latest release even when versions match
+  --base-url URL   release base URL (default https://drive9.ai)`
+}
+
+// MaybeNotifyUpdate prints a cached update reminder, then refreshes the cache
+// when the previous check is stale. Refresh results are intentionally silent so
+// a newly discovered version is reported on the next CLI invocation.
+func MaybeNotifyUpdate(currentVersion string) {
+	maybeNotifyUpdateWithDeps(fillUpdateDeps(updateDeps{currentVersion: currentVersion}))
+}
+
+func maybeNotifyUpdateWithDeps(deps updateDeps) {
+	deps = fillUpdateDeps(deps)
+	if updateCheckDisabled() {
+		return
+	}
+	if updateCachePath() == "" {
+		return
+	}
+
+	cache, _ := readUpdateCache()
+	if shouldShowUpdateNotice(deps.currentVersion, cache.LatestVersion) {
+		_, _ = fmt.Fprintf(deps.stderr, "\ndrive9 update available: %s -> %s\nRun `drive9 update` to install the latest binary.\n", displayVersion(deps.currentVersion), cache.LatestVersion)
+	}
+	if !updateCheckDue(cache, deps.now()) {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), autoUpdateTimeout)
+	defer cancel()
+	latestVersion, err := fetchLatestVersion(ctx, deps)
+	if err != nil {
+		cache.LastCheckedAt = deps.now().UTC()
+		_ = writeUpdateCache(cache)
+		return
+	}
+	artifact := updateArtifactName(deps.goos, deps.goarch)
+	_ = writeUpdateCache(updateCache{
+		LastCheckedAt: deps.now().UTC(),
+		LatestVersion: latestVersion,
+		LatestURL:     releaseURL(deps.baseURL, artifact),
+	})
+}
+
+func fillUpdateDeps(deps updateDeps) updateDeps {
+	if deps.baseURL == "" {
+		deps.baseURL = strings.TrimSpace(os.Getenv("DRIVE9_UPDATE_BASE_URL"))
+	}
+	if deps.baseURL == "" {
+		deps.baseURL = defaultUpdateBaseURL
+	}
+	deps.baseURL = normalizeUpdateBaseURL(deps.baseURL)
+	if deps.currentVersion == "" {
+		deps.currentVersion = buildinfo.Version
+	}
+	if deps.goos == "" {
+		deps.goos = runtime.GOOS
+	}
+	if deps.goarch == "" {
+		deps.goarch = runtime.GOARCH
+	}
+	if deps.now == nil {
+		deps.now = time.Now
+	}
+	if deps.executable == nil {
+		deps.executable = os.Executable
+	}
+	if deps.httpClient == nil {
+		deps.httpClient = &http.Client{Timeout: updateCommandTimeout}
+	}
+	if deps.stdout == nil {
+		deps.stdout = os.Stdout
+	}
+	if deps.stderr == nil {
+		deps.stderr = os.Stderr
+	}
+	if deps.replaceExecutable == nil {
+		deps.replaceExecutable = replaceExecutableFile
+	}
+	return deps
+}
+
+func updateCheckDisabled() bool {
+	if isTruthy(os.Getenv("DRIVE9_NO_UPDATE_CHECK")) {
+		return true
+	}
+	if isFalsey(os.Getenv("DRIVE9_UPDATE_CHECK")) {
+		return true
+	}
+	return false
+}
+
+func isTruthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func isFalsey(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "0", "false", "no", "off":
+		return true
+	default:
+		return false
+	}
+}
+
+func updateCheckDue(cache updateCache, now time.Time) bool {
+	if cache.LastCheckedAt.IsZero() {
+		return true
+	}
+	if now.Before(cache.LastCheckedAt) {
+		return true
+	}
+	return now.Sub(cache.LastCheckedAt) >= updateCheckInterval
+}
+
+func shouldShowUpdateNotice(currentVersion, latestVersion string) bool {
+	if isDevVersion(currentVersion) {
+		return false
+	}
+	return versionsDiffer(currentVersion, latestVersion)
+}
+
+func isDevVersion(version string) bool {
+	switch normalizeVersion(version) {
+	case "", "dev", "unknown":
+		return true
+	default:
+		return false
+	}
+}
+
+func versionsDiffer(currentVersion, latestVersion string) bool {
+	current := normalizeVersion(currentVersion)
+	latest := normalizeVersion(latestVersion)
+	if current == "" || latest == "" {
+		return false
+	}
+	return current != latest
+}
+
+func normalizeVersion(version string) string {
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "v")
+	return version
+}
+
+func displayVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "unknown"
+	}
+	return version
+}
+
+func fetchLatestVersion(ctx context.Context, deps updateDeps) (string, error) {
+	body, err := httpGetBytes(ctx, deps.httpClient, releaseURL(deps.baseURL, "version"), 4096)
+	if err != nil {
+		return "", fmt.Errorf("fetch latest drive9 version: %w", err)
+	}
+	version := strings.TrimSpace(string(body))
+	if version == "" {
+		return "", errors.New("fetch latest drive9 version: empty response")
+	}
+	return version, nil
+}
+
+func fetchReleaseChecksums(ctx context.Context, deps updateDeps) (map[string]string, error) {
+	body, err := httpGetBytes(ctx, deps.httpClient, releaseURL(deps.baseURL, "checksums.txt"), 1<<20)
+	if err != nil {
+		return nil, fmt.Errorf("fetch release checksums: %w", err)
+	}
+	checksums, err := parseChecksums(body)
+	if err != nil {
+		return nil, err
+	}
+	if len(checksums) == 0 {
+		return nil, errors.New("fetch release checksums: empty checksum list")
+	}
+	return checksums, nil
+}
+
+func httpGetBytes(ctx context.Context, client *http.Client, url string, limit int64) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("GET %s: response too large", url)
+	}
+	return body, nil
+}
+
+func parseChecksums(data []byte) (map[string]string, error) {
+	checksums := map[string]string{}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("invalid checksum line %q", line)
+		}
+		sum := strings.ToLower(fields[0])
+		if len(sum) != sha256.Size*2 {
+			return nil, fmt.Errorf("invalid checksum for %s", fields[1])
+		}
+		if _, err := hex.DecodeString(sum); err != nil {
+			return nil, fmt.Errorf("invalid checksum for %s: %w", fields[1], err)
+		}
+		name := strings.TrimPrefix(fields[1], "*")
+		checksums[name] = sum
+		checksums[filepath.Base(name)] = sum
+	}
+	return checksums, nil
+}
+
+func downloadUpdateBinary(ctx context.Context, deps updateDeps, url, targetPath, wantSHA string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := deps.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "", fmt.Errorf("download %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	targetInfo, err := os.Stat(targetPath)
+	if err != nil {
+		return "", fmt.Errorf("stat current executable %s: %w", targetPath, err)
+	}
+	mode := targetInfo.Mode().Perm()
+	if mode == 0 {
+		mode = 0o755
+	}
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(targetPath), ".drive9-update-*")
+	if err != nil {
+		return "", fmt.Errorf("create update temp file next to %s: %w", targetPath, err)
+	}
+	tmpPath := tmpFile.Name()
+	keep := false
+	defer func() {
+		_ = tmpFile.Close()
+		if !keep {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	hash := sha256.New()
+	n, err := io.Copy(io.MultiWriter(tmpFile, hash), io.LimitReader(resp.Body, maxUpdateFileBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("write update temp file: %w", err)
+	}
+	if n > maxUpdateFileBytes {
+		return "", fmt.Errorf("download %s: response too large", url)
+	}
+	gotSHA := hex.EncodeToString(hash.Sum(nil))
+	if gotSHA != strings.ToLower(wantSHA) {
+		return "", fmt.Errorf("checksum mismatch for %s: got %s, want %s", updateArtifactName(deps.goos, deps.goarch), gotSHA, wantSHA)
+	}
+	if err := tmpFile.Chmod(mode); err != nil {
+		return "", fmt.Errorf("chmod update temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return "", fmt.Errorf("close update temp file: %w", err)
+	}
+	keep = true
+	return tmpPath, nil
+}
+
+func currentExecutablePath(deps updateDeps) (string, error) {
+	path, err := deps.executable()
+	if err != nil {
+		return "", fmt.Errorf("locate current executable: %w", err)
+	}
+	if path == "" {
+		return "", errors.New("locate current executable: empty path")
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return path, nil
+}
+
+func updateArtifactName(goos, goarch string) string {
+	name := "drive9-" + goos + "-" + goarch
+	if goos == "windows" {
+		name += ".exe"
+	}
+	return name
+}
+
+func normalizeUpdateBaseURL(baseURL string) string {
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+func releaseURL(baseURL, name string) string {
+	return normalizeUpdateBaseURL(baseURL) + "/releases/" + strings.TrimLeft(name, "/")
+}
+
+func updateCachePath() string {
+	dir := configDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "update-check.json")
+}
+
+func readUpdateCache() (updateCache, error) {
+	path := updateCachePath()
+	if path == "" {
+		return updateCache{}, errors.New("cannot determine update cache path")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return updateCache{}, err
+	}
+	var cache updateCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return updateCache{}, err
+	}
+	return cache, nil
+}
+
+func writeUpdateCache(cache updateCache) error {
+	path := updateCachePath()
+	if path == "" {
+		return errors.New("cannot determine update cache path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}

--- a/cmd/drive9/cli/update.go
+++ b/cmd/drive9/cli/update.go
@@ -82,7 +82,11 @@ func updateWithDeps(args []string, deps updateDeps) error {
 	checkOnly := fs.Bool("check", false, "check for the latest version without installing it")
 	force := fs.Bool("force", false, "reinstall the latest binary even when versions match")
 	baseURL := fs.String("base-url", deps.baseURL, "release base URL")
-	if err := fs.Parse(args); err != nil {
+	if err := fs.Parse(normalizeHelpFlags(args, fs)); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			_, _ = fmt.Fprintln(deps.stdout, updateUsage())
+			return nil
+		}
 		return fmt.Errorf("%w\n%s", err, updateUsage())
 	}
 	if fs.NArg() != 0 {
@@ -99,7 +103,7 @@ func updateWithDeps(args []string, deps updateDeps) error {
 	}
 	artifact := updateArtifactName(deps.goos, deps.goarch)
 	latestURL := releaseURL(deps.baseURL, artifact)
-	_ = writeUpdateCache(updateCache{
+	_ = writeUpdateCache(ctx, updateCache{
 		LastCheckedAt: deps.now().UTC(),
 		LatestVersion: latestVersion,
 		LatestURL:     latestURL,
@@ -174,7 +178,10 @@ func maybeNotifyUpdateWithDeps(deps updateDeps) {
 		return
 	}
 
-	cache, _ := readUpdateCache()
+	ctx, cancel := context.WithTimeout(context.Background(), autoUpdateTimeout)
+	defer cancel()
+
+	cache, _ := readUpdateCache(ctx)
 	if shouldShowUpdateNotice(deps.currentVersion, cache.LatestVersion) {
 		_, _ = fmt.Fprintf(deps.stderr, "\ndrive9 update available: %s -> %s\nRun `drive9 update` to install the latest binary.\n", displayVersion(deps.currentVersion), cache.LatestVersion)
 	}
@@ -182,16 +189,14 @@ func maybeNotifyUpdateWithDeps(deps updateDeps) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), autoUpdateTimeout)
-	defer cancel()
 	latestVersion, err := fetchLatestVersion(ctx, deps)
 	if err != nil {
 		cache.LastCheckedAt = deps.now().UTC()
-		_ = writeUpdateCache(cache)
+		_ = writeUpdateCache(ctx, cache)
 		return
 	}
 	artifact := updateArtifactName(deps.goos, deps.goarch)
-	_ = writeUpdateCache(updateCache{
+	_ = writeUpdateCache(ctx, updateCache{
 		LastCheckedAt: deps.now().UTC(),
 		LatestVersion: latestVersion,
 		LatestURL:     releaseURL(deps.baseURL, artifact),
@@ -487,33 +492,42 @@ func updateCachePath() string {
 	return filepath.Join(dir, "update-check.json")
 }
 
-func readUpdateCache() (updateCache, error) {
+func readUpdateCache(ctx context.Context) (updateCache, error) {
+	if err := ctx.Err(); err != nil {
+		return updateCache{}, fmt.Errorf("read update cache: %w", err)
+	}
 	path := updateCachePath()
 	if path == "" {
-		return updateCache{}, errors.New("cannot determine update cache path")
+		return updateCache{}, errors.New("read update cache: cannot determine update cache path")
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return updateCache{}, err
+		return updateCache{}, fmt.Errorf("read update cache %s: %w", path, err)
 	}
 	var cache updateCache
 	if err := json.Unmarshal(data, &cache); err != nil {
-		return updateCache{}, err
+		return updateCache{}, fmt.Errorf("decode update cache %s: %w", path, err)
 	}
 	return cache, nil
 }
 
-func writeUpdateCache(cache updateCache) error {
+func writeUpdateCache(ctx context.Context, cache updateCache) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("write update cache: %w", err)
+	}
 	path := updateCachePath()
 	if path == "" {
-		return errors.New("cannot determine update cache path")
+		return errors.New("write update cache: cannot determine update cache path")
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
+		return fmt.Errorf("create update cache dir %s: %w", filepath.Dir(path), err)
 	}
 	data, err := json.MarshalIndent(cache, "", "  ")
 	if err != nil {
-		return err
+		return fmt.Errorf("encode update cache: %w", err)
 	}
-	return os.WriteFile(path, append(data, '\n'), 0o600)
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write update cache %s: %w", path, err)
+	}
+	return nil
 }

--- a/cmd/drive9/cli/update.go
+++ b/cmd/drive9/cli/update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,8 +21,6 @@ import (
 
 const (
 	defaultUpdateBaseURL = "https://drive9.ai"
-	updateCheckInterval  = 24 * time.Hour
-	autoUpdateTimeout    = 1500 * time.Millisecond
 	updateCommandTimeout = 2 * time.Minute
 	maxUpdateFileBytes   = 200 << 20
 )
@@ -32,18 +30,12 @@ type updateDeps struct {
 	currentVersion    string
 	goos              string
 	goarch            string
-	now               func() time.Time
 	executable        func() (string, error)
 	httpClient        *http.Client
 	stdout            io.Writer
 	stderr            io.Writer
+	preflightReplace  func() error
 	replaceExecutable func(string, string) error
-}
-
-type updateCache struct {
-	LastCheckedAt time.Time `json:"last_checked_at"`
-	LatestVersion string    `json:"latest_version,omitempty"`
-	LatestURL     string    `json:"latest_url,omitempty"`
 }
 
 func defaultUpdateDeps() updateDeps {
@@ -56,11 +48,11 @@ func defaultUpdateDeps() updateDeps {
 		currentVersion:    buildinfo.Version,
 		goos:              runtime.GOOS,
 		goarch:            runtime.GOARCH,
-		now:               time.Now,
 		executable:        os.Executable,
 		httpClient:        &http.Client{Timeout: updateCommandTimeout},
 		stdout:            os.Stdout,
 		stderr:            os.Stderr,
+		preflightReplace:  preflightReplaceExecutableFile,
 		replaceExecutable: replaceExecutableFile,
 	}
 }
@@ -103,23 +95,37 @@ func updateWithDeps(args []string, deps updateDeps) error {
 	}
 	artifact := updateArtifactName(deps.goos, deps.goarch)
 	latestURL := releaseURL(deps.baseURL, artifact)
-	_ = writeUpdateCache(ctx, updateCache{
-		LastCheckedAt: deps.now().UTC(),
-		LatestVersion: latestVersion,
-		LatestURL:     latestURL,
-	})
+	relation := compareReleaseVersions(deps.currentVersion, latestVersion)
 
 	if *checkOnly {
-		if versionsDiffer(deps.currentVersion, latestVersion) {
+		switch relation {
+		case releaseNewer:
 			_, _ = fmt.Fprintf(deps.stdout, "drive9 update available: %s -> %s\n", displayVersion(deps.currentVersion), latestVersion)
-		} else {
+		case releaseSame:
 			_, _ = fmt.Fprintf(deps.stdout, "drive9 is up to date (%s)\n", displayVersion(deps.currentVersion))
+		case releaseOlder:
+			_, _ = fmt.Fprintf(deps.stdout, "drive9 latest release %s is older than current %s\n", latestVersion, displayVersion(deps.currentVersion))
+		default:
+			_, _ = fmt.Fprintf(deps.stdout, "drive9 latest release %s cannot be compared with current %s\n", latestVersion, displayVersion(deps.currentVersion))
 		}
 		return nil
 	}
-	if !*force && !versionsDiffer(deps.currentVersion, latestVersion) {
-		_, _ = fmt.Fprintf(deps.stdout, "drive9 is already up to date (%s)\n", displayVersion(deps.currentVersion))
-		return nil
+	if !*force {
+		switch relation {
+		case releaseNewer:
+		case releaseSame:
+			_, _ = fmt.Fprintf(deps.stdout, "drive9 is already up to date (%s)\n", displayVersion(deps.currentVersion))
+			return nil
+		case releaseOlder:
+			_, _ = fmt.Fprintf(deps.stdout, "drive9 latest release %s is older than current %s; use --force to install it\n", latestVersion, displayVersion(deps.currentVersion))
+			return nil
+		default:
+			_, _ = fmt.Fprintf(deps.stdout, "drive9 latest release %s cannot be compared with current %s; use --force to install it\n", latestVersion, displayVersion(deps.currentVersion))
+			return nil
+		}
+	}
+	if err := deps.preflightReplace(); err != nil {
+		return err
 	}
 
 	target, err := currentExecutablePath(deps)
@@ -159,48 +165,7 @@ func updateUsage() string {
 	return `usage: drive9 update [--check] [--force] [--base-url URL]
   --check          check for a newer release without installing
   --force          reinstall latest release even when versions match
-  --base-url URL   release base URL (default https://drive9.ai)`
-}
-
-// MaybeNotifyUpdate prints a cached update reminder, then refreshes the cache
-// when the previous check is stale. Refresh results are intentionally silent so
-// a newly discovered version is reported on the next CLI invocation.
-func MaybeNotifyUpdate(currentVersion string) {
-	maybeNotifyUpdateWithDeps(fillUpdateDeps(updateDeps{currentVersion: currentVersion}))
-}
-
-func maybeNotifyUpdateWithDeps(deps updateDeps) {
-	deps = fillUpdateDeps(deps)
-	if updateCheckDisabled() {
-		return
-	}
-	if updateCachePath() == "" {
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), autoUpdateTimeout)
-	defer cancel()
-
-	cache, _ := readUpdateCache(ctx)
-	if shouldShowUpdateNotice(deps.currentVersion, cache.LatestVersion) {
-		_, _ = fmt.Fprintf(deps.stderr, "\ndrive9 update available: %s -> %s\nRun `drive9 update` to install the latest binary.\n", displayVersion(deps.currentVersion), cache.LatestVersion)
-	}
-	if !updateCheckDue(cache, deps.now()) {
-		return
-	}
-
-	latestVersion, err := fetchLatestVersion(ctx, deps)
-	if err != nil {
-		cache.LastCheckedAt = deps.now().UTC()
-		_ = writeUpdateCache(ctx, cache)
-		return
-	}
-	artifact := updateArtifactName(deps.goos, deps.goarch)
-	_ = writeUpdateCache(ctx, updateCache{
-		LastCheckedAt: deps.now().UTC(),
-		LatestVersion: latestVersion,
-		LatestURL:     releaseURL(deps.baseURL, artifact),
-	})
+  --base-url URL   release base URL (default https://drive9.ai)` + updatePlatformUsageNote()
 }
 
 func fillUpdateDeps(deps updateDeps) updateDeps {
@@ -220,9 +185,6 @@ func fillUpdateDeps(deps updateDeps) updateDeps {
 	if deps.goarch == "" {
 		deps.goarch = runtime.GOARCH
 	}
-	if deps.now == nil {
-		deps.now = time.Now
-	}
 	if deps.executable == nil {
 		deps.executable = os.Executable
 	}
@@ -235,79 +197,177 @@ func fillUpdateDeps(deps updateDeps) updateDeps {
 	if deps.stderr == nil {
 		deps.stderr = os.Stderr
 	}
+	if deps.preflightReplace == nil {
+		deps.preflightReplace = preflightReplaceExecutableFile
+	}
 	if deps.replaceExecutable == nil {
 		deps.replaceExecutable = replaceExecutableFile
 	}
 	return deps
 }
 
-func updateCheckDisabled() bool {
-	if isTruthy(os.Getenv("DRIVE9_NO_UPDATE_CHECK")) {
-		return true
-	}
-	if isFalsey(os.Getenv("DRIVE9_UPDATE_CHECK")) {
-		return true
-	}
-	return false
-}
-
-func isTruthy(value string) bool {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "1", "true", "yes", "on":
-		return true
-	default:
-		return false
-	}
-}
-
-func isFalsey(value string) bool {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "0", "false", "no", "off":
-		return true
-	default:
-		return false
-	}
-}
-
-func updateCheckDue(cache updateCache, now time.Time) bool {
-	if cache.LastCheckedAt.IsZero() {
-		return true
-	}
-	if now.Before(cache.LastCheckedAt) {
-		return true
-	}
-	return now.Sub(cache.LastCheckedAt) >= updateCheckInterval
-}
-
-func shouldShowUpdateNotice(currentVersion, latestVersion string) bool {
-	if isDevVersion(currentVersion) {
-		return false
-	}
-	return versionsDiffer(currentVersion, latestVersion)
-}
-
-func isDevVersion(version string) bool {
-	switch normalizeVersion(version) {
-	case "", "dev", "unknown":
-		return true
-	default:
-		return false
-	}
-}
-
-func versionsDiffer(currentVersion, latestVersion string) bool {
-	current := normalizeVersion(currentVersion)
-	latest := normalizeVersion(latestVersion)
-	if current == "" || latest == "" {
-		return false
-	}
-	return current != latest
-}
-
 func normalizeVersion(version string) string {
 	version = strings.TrimSpace(version)
 	version = strings.TrimPrefix(version, "v")
 	return version
+}
+
+type releaseRelation int
+
+const (
+	releaseUnknown releaseRelation = iota
+	releaseSame
+	releaseNewer
+	releaseOlder
+)
+
+type semverVersion struct {
+	major int
+	minor int
+	patch int
+	pre   []string
+}
+
+func compareReleaseVersions(currentVersion, latestVersion string) releaseRelation {
+	current := normalizeVersion(currentVersion)
+	latest := normalizeVersion(latestVersion)
+	if current == "" || latest == "" {
+		return releaseUnknown
+	}
+	if current == latest {
+		return releaseSame
+	}
+	currentSemver, currentOK := parseSemver(current)
+	latestSemver, latestOK := parseSemver(latest)
+	if latestOK && !currentOK {
+		return releaseNewer
+	}
+	if !latestOK || !currentOK {
+		return releaseUnknown
+	}
+	switch compareSemver(latestSemver, currentSemver) {
+	case 0:
+		return releaseSame
+	case 1:
+		return releaseNewer
+	default:
+		return releaseOlder
+	}
+}
+
+func parseSemver(version string) (semverVersion, bool) {
+	version, _, _ = strings.Cut(version, "+")
+	mainPart, prePart, hasPre := strings.Cut(version, "-")
+	parts := strings.Split(mainPart, ".")
+	if len(parts) != 3 {
+		return semverVersion{}, false
+	}
+	major, ok := parseSemverNumber(parts[0])
+	if !ok {
+		return semverVersion{}, false
+	}
+	minor, ok := parseSemverNumber(parts[1])
+	if !ok {
+		return semverVersion{}, false
+	}
+	patch, ok := parseSemverNumber(parts[2])
+	if !ok {
+		return semverVersion{}, false
+	}
+	var pre []string
+	if hasPre {
+		if prePart == "" {
+			return semverVersion{}, false
+		}
+		pre = strings.Split(prePart, ".")
+		for _, id := range pre {
+			if id == "" {
+				return semverVersion{}, false
+			}
+		}
+	}
+	return semverVersion{major: major, minor: minor, patch: patch, pre: pre}, true
+}
+
+func parseSemverNumber(value string) (int, bool) {
+	if value == "" {
+		return 0, false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+	n, err := strconv.Atoi(value)
+	return n, err == nil
+}
+
+func compareSemver(a, b semverVersion) int {
+	for _, pair := range [][2]int{{a.major, b.major}, {a.minor, b.minor}, {a.patch, b.patch}} {
+		if pair[0] > pair[1] {
+			return 1
+		}
+		if pair[0] < pair[1] {
+			return -1
+		}
+	}
+	return compareSemverPrerelease(a.pre, b.pre)
+}
+
+func compareSemverPrerelease(a, b []string) int {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	if len(a) == 0 {
+		return 1
+	}
+	if len(b) == 0 {
+		return -1
+	}
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	for i := 0; i < limit; i++ {
+		cmp := compareSemverIdentifier(a[i], b[i])
+		if cmp != 0 {
+			return cmp
+		}
+	}
+	if len(a) > len(b) {
+		return 1
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	return 0
+}
+
+func compareSemverIdentifier(a, b string) int {
+	aNum, aOK := parseSemverNumber(a)
+	bNum, bOK := parseSemverNumber(b)
+	switch {
+	case aOK && bOK:
+		if aNum > bNum {
+			return 1
+		}
+		if aNum < bNum {
+			return -1
+		}
+		return 0
+	case aOK:
+		return -1
+	case bOK:
+		return 1
+	default:
+		if a > b {
+			return 1
+		}
+		if a < b {
+			return -1
+		}
+		return 0
+	}
 }
 
 func displayVersion(version string) string {
@@ -482,52 +542,4 @@ func normalizeUpdateBaseURL(baseURL string) string {
 
 func releaseURL(baseURL, name string) string {
 	return normalizeUpdateBaseURL(baseURL) + "/releases/" + strings.TrimLeft(name, "/")
-}
-
-func updateCachePath() string {
-	dir := configDir()
-	if dir == "" {
-		return ""
-	}
-	return filepath.Join(dir, "update-check.json")
-}
-
-func readUpdateCache(ctx context.Context) (updateCache, error) {
-	if err := ctx.Err(); err != nil {
-		return updateCache{}, fmt.Errorf("read update cache: %w", err)
-	}
-	path := updateCachePath()
-	if path == "" {
-		return updateCache{}, errors.New("read update cache: cannot determine update cache path")
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return updateCache{}, fmt.Errorf("read update cache %s: %w", path, err)
-	}
-	var cache updateCache
-	if err := json.Unmarshal(data, &cache); err != nil {
-		return updateCache{}, fmt.Errorf("decode update cache %s: %w", path, err)
-	}
-	return cache, nil
-}
-
-func writeUpdateCache(ctx context.Context, cache updateCache) error {
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("write update cache: %w", err)
-	}
-	path := updateCachePath()
-	if path == "" {
-		return errors.New("write update cache: cannot determine update cache path")
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return fmt.Errorf("create update cache dir %s: %w", filepath.Dir(path), err)
-	}
-	data, err := json.MarshalIndent(cache, "", "  ")
-	if err != nil {
-		return fmt.Errorf("encode update cache: %w", err)
-	}
-	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
-		return fmt.Errorf("write update cache %s: %w", path, err)
-	}
-	return nil
 }

--- a/cmd/drive9/cli/update_replace_unix.go
+++ b/cmd/drive9/cli/update_replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package cli
+
+import "os"
+
+func replaceExecutableFile(newPath, targetPath string) error {
+	return os.Rename(newPath, targetPath)
+}

--- a/cmd/drive9/cli/update_replace_unix.go
+++ b/cmd/drive9/cli/update_replace_unix.go
@@ -4,6 +4,14 @@ package cli
 
 import "os"
 
+func preflightReplaceExecutableFile() error {
+	return nil
+}
+
 func replaceExecutableFile(newPath, targetPath string) error {
 	return os.Rename(newPath, targetPath)
+}
+
+func updatePlatformUsageNote() string {
+	return ""
 }

--- a/cmd/drive9/cli/update_replace_windows.go
+++ b/cmd/drive9/cli/update_replace_windows.go
@@ -4,6 +4,16 @@ package cli
 
 import "errors"
 
+var ErrWindowsSelfUpdateUnsupported = errors.New("windows self-update cannot replace the running drive9.exe; download the latest release and replace it from a separate process")
+
+func preflightReplaceExecutableFile() error {
+	return ErrWindowsSelfUpdateUnsupported
+}
+
 func replaceExecutableFile(newPath, targetPath string) error {
-	return errors.New("windows self-update cannot replace the running drive9.exe; download the latest release and replace it from a separate process")
+	return ErrWindowsSelfUpdateUnsupported
+}
+
+func updatePlatformUsageNote() string {
+	return "\n  note: Windows self-update is not supported; download the latest release manually."
 }

--- a/cmd/drive9/cli/update_replace_windows.go
+++ b/cmd/drive9/cli/update_replace_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package cli
+
+import "golang.org/x/sys/windows"
+
+func replaceExecutableFile(newPath, targetPath string) error {
+	from, err := windows.UTF16PtrFromString(newPath)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(targetPath)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}

--- a/cmd/drive9/cli/update_replace_windows.go
+++ b/cmd/drive9/cli/update_replace_windows.go
@@ -2,16 +2,8 @@
 
 package cli
 
-import "golang.org/x/sys/windows"
+import "errors"
 
 func replaceExecutableFile(newPath, targetPath string) error {
-	from, err := windows.UTF16PtrFromString(newPath)
-	if err != nil {
-		return err
-	}
-	to, err := windows.UTF16PtrFromString(targetPath)
-	if err != nil {
-		return err
-	}
-	return windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+	return errors.New("windows self-update cannot replace the running drive9.exe; download the latest release and replace it from a separate process")
 }

--- a/cmd/drive9/cli/update_test.go
+++ b/cmd/drive9/cli/update_test.go
@@ -26,12 +26,13 @@ func TestUpdateCheckReportsAvailable(t *testing.T) {
 
 	var stdout bytes.Buffer
 	err := updateWithDeps([]string{"--check"}, updateDeps{
-		baseURL:        srv.URL,
-		currentVersion: "v0.1.0",
-		goos:           "linux",
-		goarch:         "amd64",
-		httpClient:     srv.Client(),
-		stdout:         &stdout,
+		baseURL:              srv.URL,
+		currentVersion:       "v0.1.0",
+		goos:                 "linux",
+		goarch:               "amd64",
+		httpClient:           srv.Client(),
+		stdout:               &stdout,
+		allowInsecureBaseURL: true,
 	})
 	if err != nil {
 		t.Fatalf("update --check: %v", err)
@@ -68,13 +69,14 @@ func TestUpdateDownloadsVerifiesAndReplacesExecutable(t *testing.T) {
 
 	var stdout bytes.Buffer
 	err := updateWithDeps(nil, updateDeps{
-		baseURL:        srv.URL,
-		currentVersion: "v0.1.0",
-		goos:           "linux",
-		goarch:         "amd64",
-		executable:     func() (string, error) { return target, nil },
-		httpClient:     srv.Client(),
-		stdout:         &stdout,
+		baseURL:              srv.URL,
+		currentVersion:       "v0.1.0",
+		goos:                 "linux",
+		goarch:               "amd64",
+		executable:           func() (string, error) { return target, nil },
+		httpClient:           srv.Client(),
+		stdout:               &stdout,
+		allowInsecureBaseURL: true,
 		replaceExecutable: func(newPath, targetPath string) error {
 			if err := os.Remove(targetPath); err != nil {
 				return err
@@ -108,13 +110,14 @@ func TestUpdateRejectsChecksumMismatch(t *testing.T) {
 	defer srv.Close()
 
 	err := updateWithDeps(nil, updateDeps{
-		baseURL:        srv.URL,
-		currentVersion: "v0.1.0",
-		goos:           "linux",
-		goarch:         "amd64",
-		executable:     func() (string, error) { return target, nil },
-		httpClient:     srv.Client(),
-		stdout:         &bytes.Buffer{},
+		baseURL:              srv.URL,
+		currentVersion:       "v0.1.0",
+		goos:                 "linux",
+		goarch:               "amd64",
+		executable:           func() (string, error) { return target, nil },
+		httpClient:           srv.Client(),
+		stdout:               &bytes.Buffer{},
+		allowInsecureBaseURL: true,
 		replaceExecutable: func(string, string) error {
 			t.Fatal("replaceExecutable must not run after checksum mismatch")
 			return nil
@@ -144,12 +147,13 @@ func TestUpdateDoesNotInstallDowngradeWithoutForce(t *testing.T) {
 
 	var stdout bytes.Buffer
 	err := updateWithDeps(nil, updateDeps{
-		baseURL:        srv.URL,
-		currentVersion: "v0.9.0",
-		goos:           "linux",
-		goarch:         "amd64",
-		httpClient:     srv.Client(),
-		stdout:         &stdout,
+		baseURL:              srv.URL,
+		currentVersion:       "v0.9.0",
+		goos:                 "linux",
+		goarch:               "amd64",
+		httpClient:           srv.Client(),
+		stdout:               &stdout,
+		allowInsecureBaseURL: true,
 		replaceExecutable: func(string, string) error {
 			t.Fatal("replaceExecutable must not run for downgrade without --force")
 			return nil
@@ -177,13 +181,14 @@ func TestUpdateForceInstallsDowngrade(t *testing.T) {
 	defer srv.Close()
 
 	err := updateWithDeps([]string{"--force"}, updateDeps{
-		baseURL:        srv.URL,
-		currentVersion: "v0.9.0",
-		goos:           "linux",
-		goarch:         "amd64",
-		executable:     func() (string, error) { return target, nil },
-		httpClient:     srv.Client(),
-		stdout:         &bytes.Buffer{},
+		baseURL:              srv.URL,
+		currentVersion:       "v0.9.0",
+		goos:                 "linux",
+		goarch:               "amd64",
+		executable:           func() (string, error) { return target, nil },
+		httpClient:           srv.Client(),
+		stdout:               &bytes.Buffer{},
+		allowInsecureBaseURL: true,
 		replaceExecutable: func(newPath, targetPath string) error {
 			if err := os.Remove(targetPath); err != nil {
 				return err
@@ -213,13 +218,14 @@ func TestUpdatePreflightReplaceRunsBeforeDownload(t *testing.T) {
 	defer srv.Close()
 
 	err := updateWithDeps(nil, updateDeps{
-		baseURL:          srv.URL,
-		currentVersion:   "v0.1.0",
-		goos:             "linux",
-		goarch:           "amd64",
-		httpClient:       srv.Client(),
-		stdout:           &bytes.Buffer{},
-		preflightReplace: func() error { return errUnsupported },
+		baseURL:              srv.URL,
+		currentVersion:       "v0.1.0",
+		goos:                 "linux",
+		goarch:               "amd64",
+		httpClient:           srv.Client(),
+		stdout:               &bytes.Buffer{},
+		allowInsecureBaseURL: true,
+		preflightReplace:     func() error { return errUnsupported },
 		replaceExecutable: func(string, string) error {
 			t.Fatal("replaceExecutable must not run after preflight failure")
 			return nil
@@ -230,6 +236,30 @@ func TestUpdatePreflightReplaceRunsBeforeDownload(t *testing.T) {
 	}
 	if got, want := strings.Join(requests, ","), "/releases/version"; got != want {
 		t.Errorf("requests = %q, want only %q", got, want)
+	}
+}
+
+func TestUpdateRejectsInsecureBaseURLByDefault(t *testing.T) {
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	err := updateWithDeps([]string{"--check"}, updateDeps{
+		baseURL:        srv.URL,
+		currentVersion: "v0.1.0",
+		goos:           "linux",
+		goarch:         "amd64",
+		httpClient:     srv.Client(),
+		stdout:         &bytes.Buffer{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "must use https") {
+		t.Fatalf("update error = %v, want HTTPS requirement", err)
+	}
+	if len(requests) != 0 {
+		t.Fatalf("requests = %v, want none before HTTPS validation", requests)
 	}
 }
 
@@ -253,6 +283,23 @@ func TestCompareReleaseVersions(t *testing.T) {
 				t.Fatalf("compareReleaseVersions(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseChecksumsRejectsPathQualifiedArtifactNames(t *testing.T) {
+	sum := strings.Repeat("a", sha256.Size*2)
+	_, err := parseChecksums([]byte(fmt.Sprintf("%s  releases/drive9-linux-amd64\n", sum)))
+	if err == nil || !strings.Contains(err.Error(), "must be a release artifact filename") {
+		t.Fatalf("parseChecksums error = %v, want artifact filename error", err)
+	}
+}
+
+func TestParseChecksumsRejectsDuplicateArtifactNames(t *testing.T) {
+	first := strings.Repeat("a", sha256.Size*2)
+	second := strings.Repeat("b", sha256.Size*2)
+	_, err := parseChecksums([]byte(fmt.Sprintf("%s  drive9-linux-amd64\n%s  drive9-linux-amd64\n", first, second)))
+	if err == nil || !strings.Contains(err.Error(), "duplicate checksum") {
+		t.Fatalf("parseChecksums error = %v, want duplicate checksum error", err)
 	}
 }
 

--- a/cmd/drive9/cli/update_test.go
+++ b/cmd/drive9/cli/update_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"net/http"
@@ -38,7 +39,20 @@ func TestUpdateCheckReportsAvailable(t *testing.T) {
 		t.Fatalf("update --check: %v", err)
 	}
 	if !strings.Contains(stdout.String(), "drive9 update available: old123 -> new123") {
-		t.Fatalf("stdout = %q, want update-available line", stdout.String())
+		t.Errorf("stdout = %q, want update-available line", stdout.String())
+	}
+}
+
+func TestUpdateHelpFlagAfterOptionPrintsUsage(t *testing.T) {
+	var stdout bytes.Buffer
+	err := updateWithDeps([]string{"--check", "-h"}, updateDeps{
+		stdout: &stdout,
+	})
+	if err != nil {
+		t.Fatalf("update --check -h: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "usage: drive9 update") {
+		t.Errorf("stdout = %q, want update usage", stdout.String())
 	}
 }
 
@@ -79,10 +93,10 @@ func TestUpdateDownloadsVerifiesAndReplacesExecutable(t *testing.T) {
 		t.Fatalf("read target: %v", err)
 	}
 	if string(got) != string(payload) {
-		t.Fatalf("updated binary = %q, want %q", got, payload)
+		t.Errorf("updated binary = %q, want %q", got, payload)
 	}
 	if !strings.Contains(stdout.String(), "drive9 updated: old123 -> new123") {
-		t.Fatalf("stdout = %q, want update success line", stdout.String())
+		t.Errorf("stdout = %q, want update success line", stdout.String())
 	}
 }
 
@@ -111,14 +125,14 @@ func TestUpdateRejectsChecksumMismatch(t *testing.T) {
 		},
 	})
 	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
-		t.Fatalf("update error = %v, want checksum mismatch", err)
+		t.Errorf("update error = %v, want checksum mismatch", err)
 	}
 	got, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatalf("read target: %v", err)
 	}
 	if string(got) != "old-drive9" {
-		t.Fatalf("target changed after checksum mismatch: %q", got)
+		t.Errorf("target changed after checksum mismatch: %q", got)
 	}
 }
 
@@ -149,25 +163,25 @@ func TestMaybeNotifyUpdateUsesCachedResultOnNextRun(t *testing.T) {
 
 	maybeNotifyUpdateWithDeps(deps)
 	if stderr.String() != "" {
-		t.Fatalf("first run stderr = %q, want no same-run update notice", stderr.String())
+		t.Errorf("first run stderr = %q, want no same-run update notice", stderr.String())
 	}
 	if versionHits != 1 {
-		t.Fatalf("version hits after first run = %d, want 1", versionHits)
+		t.Errorf("version hits after first run = %d, want 1", versionHits)
 	}
 
 	stderr.Reset()
 	maybeNotifyUpdateWithDeps(deps)
 	if !strings.Contains(stderr.String(), "drive9 update available: old123 -> new123") {
-		t.Fatalf("second run stderr = %q, want cached update notice", stderr.String())
+		t.Errorf("second run stderr = %q, want cached update notice", stderr.String())
 	}
 	if versionHits != 1 {
-		t.Fatalf("version hits after second run = %d, want stale check to be skipped", versionHits)
+		t.Errorf("version hits after second run = %d, want stale check to be skipped", versionHits)
 	}
 }
 
 func TestMaybeNotifyUpdateSkipsDevVersionNotice(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if err := writeUpdateCache(updateCache{
+	if err := writeUpdateCache(context.Background(), updateCache{
 		LastCheckedAt: fixedUpdateNow().UTC(),
 		LatestVersion: "new123",
 		LatestURL:     "https://drive9.ai/releases/drive9-linux-amd64",
@@ -182,7 +196,7 @@ func TestMaybeNotifyUpdateSkipsDevVersionNotice(t *testing.T) {
 		now:            fixedUpdateNow,
 	})
 	if stderr.String() != "" {
-		t.Fatalf("stderr = %q, want no notice for dev builds", stderr.String())
+		t.Errorf("stderr = %q, want no notice for dev builds", stderr.String())
 	}
 }
 

--- a/cmd/drive9/cli/update_test.go
+++ b/cmd/drive9/cli/update_test.go
@@ -2,8 +2,8 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestUpdateCheckReportsAvailable(t *testing.T) {
@@ -21,24 +20,23 @@ func TestUpdateCheckReportsAvailable(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		_, _ = fmt.Fprintln(w, "new123")
+		_, _ = fmt.Fprintln(w, "v0.2.0")
 	}))
 	defer srv.Close()
 
 	var stdout bytes.Buffer
 	err := updateWithDeps([]string{"--check"}, updateDeps{
 		baseURL:        srv.URL,
-		currentVersion: "old123",
+		currentVersion: "v0.1.0",
 		goos:           "linux",
 		goarch:         "amd64",
 		httpClient:     srv.Client(),
 		stdout:         &stdout,
-		now:            fixedUpdateNow,
 	})
 	if err != nil {
 		t.Fatalf("update --check: %v", err)
 	}
-	if !strings.Contains(stdout.String(), "drive9 update available: old123 -> new123") {
+	if !strings.Contains(stdout.String(), "drive9 update available: v0.1.0 -> v0.2.0") {
 		t.Errorf("stdout = %q, want update-available line", stdout.String())
 	}
 }
@@ -71,13 +69,12 @@ func TestUpdateDownloadsVerifiesAndReplacesExecutable(t *testing.T) {
 	var stdout bytes.Buffer
 	err := updateWithDeps(nil, updateDeps{
 		baseURL:        srv.URL,
-		currentVersion: "old123",
+		currentVersion: "v0.1.0",
 		goos:           "linux",
 		goarch:         "amd64",
 		executable:     func() (string, error) { return target, nil },
 		httpClient:     srv.Client(),
 		stdout:         &stdout,
-		now:            fixedUpdateNow,
 		replaceExecutable: func(newPath, targetPath string) error {
 			if err := os.Remove(targetPath); err != nil {
 				return err
@@ -95,7 +92,7 @@ func TestUpdateDownloadsVerifiesAndReplacesExecutable(t *testing.T) {
 	if string(got) != string(payload) {
 		t.Errorf("updated binary = %q, want %q", got, payload)
 	}
-	if !strings.Contains(stdout.String(), "drive9 updated: old123 -> new123") {
+	if !strings.Contains(stdout.String(), "drive9 updated: v0.1.0 -> v0.2.0") {
 		t.Errorf("stdout = %q, want update success line", stdout.String())
 	}
 }
@@ -112,13 +109,12 @@ func TestUpdateRejectsChecksumMismatch(t *testing.T) {
 
 	err := updateWithDeps(nil, updateDeps{
 		baseURL:        srv.URL,
-		currentVersion: "old123",
+		currentVersion: "v0.1.0",
 		goos:           "linux",
 		goarch:         "amd64",
 		executable:     func() (string, error) { return target, nil },
 		httpClient:     srv.Client(),
 		stdout:         &bytes.Buffer{},
-		now:            fixedUpdateNow,
 		replaceExecutable: func(string, string) error {
 			t.Fatal("replaceExecutable must not run after checksum mismatch")
 			return nil
@@ -136,76 +132,140 @@ func TestUpdateRejectsChecksumMismatch(t *testing.T) {
 	}
 }
 
-func TestMaybeNotifyUpdateUsesCachedResultOnNextRun(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	var versionHits int
+func TestUpdateDoesNotInstallDowngradeWithoutForce(t *testing.T) {
+	payload := []byte("older-drive9")
+	sum := sha256.Sum256(payload)
+	var requests []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/releases/version" {
-			http.NotFound(w, r)
-			return
-		}
-		versionHits++
-		_, _ = fmt.Fprintln(w, "new123")
+		requests = append(requests, r.URL.Path)
+		updateTestReleaseHandlerWithVersion(t, "v0.8.0", payload, fmt.Sprintf("%x", sum[:]))(w, r)
 	}))
 	defer srv.Close()
 
-	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
-	var stderr bytes.Buffer
-	deps := updateDeps{
+	var stdout bytes.Buffer
+	err := updateWithDeps(nil, updateDeps{
 		baseURL:        srv.URL,
-		currentVersion: "old123",
+		currentVersion: "v0.9.0",
 		goos:           "linux",
 		goarch:         "amd64",
 		httpClient:     srv.Client(),
-		stderr:         &stderr,
-		now:            func() time.Time { return now },
+		stdout:         &stdout,
+		replaceExecutable: func(string, string) error {
+			t.Fatal("replaceExecutable must not run for downgrade without --force")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("update downgrade: %v", err)
 	}
-
-	maybeNotifyUpdateWithDeps(deps)
-	if stderr.String() != "" {
-		t.Errorf("first run stderr = %q, want no same-run update notice", stderr.String())
+	if !strings.Contains(stdout.String(), "v0.8.0 is older than current v0.9.0; use --force") {
+		t.Errorf("stdout = %q, want downgrade message", stdout.String())
 	}
-	if versionHits != 1 {
-		t.Errorf("version hits after first run = %d, want 1", versionHits)
-	}
-
-	stderr.Reset()
-	maybeNotifyUpdateWithDeps(deps)
-	if !strings.Contains(stderr.String(), "drive9 update available: old123 -> new123") {
-		t.Errorf("second run stderr = %q, want cached update notice", stderr.String())
-	}
-	if versionHits != 1 {
-		t.Errorf("version hits after second run = %d, want stale check to be skipped", versionHits)
+	if got, want := strings.Join(requests, ","), "/releases/version"; got != want {
+		t.Errorf("requests = %q, want only %q", got, want)
 	}
 }
 
-func TestMaybeNotifyUpdateSkipsDevVersionNotice(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	if err := writeUpdateCache(context.Background(), updateCache{
-		LastCheckedAt: fixedUpdateNow().UTC(),
-		LatestVersion: "new123",
-		LatestURL:     "https://drive9.ai/releases/drive9-linux-amd64",
-	}); err != nil {
-		t.Fatalf("write cache: %v", err)
+func TestUpdateForceInstallsDowngrade(t *testing.T) {
+	payload := []byte("older-drive9")
+	sum := sha256.Sum256(payload)
+	target := filepath.Join(t.TempDir(), "drive9")
+	if err := os.WriteFile(target, []byte("current-drive9"), 0o755); err != nil {
+		t.Fatalf("write target: %v", err)
 	}
+	srv := httptest.NewServer(updateTestReleaseHandlerWithVersion(t, "v0.8.0", payload, fmt.Sprintf("%x", sum[:])))
+	defer srv.Close()
 
-	var stderr bytes.Buffer
-	maybeNotifyUpdateWithDeps(updateDeps{
-		currentVersion: "dev",
-		stderr:         &stderr,
-		now:            fixedUpdateNow,
+	err := updateWithDeps([]string{"--force"}, updateDeps{
+		baseURL:        srv.URL,
+		currentVersion: "v0.9.0",
+		goos:           "linux",
+		goarch:         "amd64",
+		executable:     func() (string, error) { return target, nil },
+		httpClient:     srv.Client(),
+		stdout:         &bytes.Buffer{},
+		replaceExecutable: func(newPath, targetPath string) error {
+			if err := os.Remove(targetPath); err != nil {
+				return err
+			}
+			return os.Rename(newPath, targetPath)
+		},
 	})
-	if stderr.String() != "" {
-		t.Errorf("stderr = %q, want no notice for dev builds", stderr.String())
+	if err != nil {
+		t.Fatalf("update --force downgrade: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("updated binary = %q, want %q", got, payload)
+	}
+}
+
+func TestUpdatePreflightReplaceRunsBeforeDownload(t *testing.T) {
+	errUnsupported := errors.New("unsupported platform")
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.Path)
+		updateTestReleaseHandler(t, []byte("new-drive9"), strings.Repeat("1", 64))(w, r)
+	}))
+	defer srv.Close()
+
+	err := updateWithDeps(nil, updateDeps{
+		baseURL:          srv.URL,
+		currentVersion:   "v0.1.0",
+		goos:             "linux",
+		goarch:           "amd64",
+		httpClient:       srv.Client(),
+		stdout:           &bytes.Buffer{},
+		preflightReplace: func() error { return errUnsupported },
+		replaceExecutable: func(string, string) error {
+			t.Fatal("replaceExecutable must not run after preflight failure")
+			return nil
+		},
+	})
+	if !errors.Is(err, errUnsupported) {
+		t.Fatalf("update error = %v, want %v", err, errUnsupported)
+	}
+	if got, want := strings.Join(requests, ","), "/releases/version"; got != want {
+		t.Errorf("requests = %q, want only %q", got, want)
+	}
+}
+
+func TestCompareReleaseVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+		want    releaseRelation
+	}{
+		{name: "newer", current: "v0.1.0", latest: "v0.2.0", want: releaseNewer},
+		{name: "same ignores build", current: "v0.2.0+local", latest: "0.2.0", want: releaseSame},
+		{name: "older", current: "v0.9.0", latest: "v0.8.0", want: releaseOlder},
+		{name: "release newer than prerelease", current: "v1.0.0-rc.1", latest: "v1.0.0", want: releaseNewer},
+		{name: "semver latest updates non-semver current", current: "dev", latest: "v0.2.0", want: releaseNewer},
+		{name: "unknown latest", current: "v0.2.0", latest: "new123", want: releaseUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compareReleaseVersions(tt.current, tt.latest); got != tt.want {
+				t.Fatalf("compareReleaseVersions(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
+			}
+		})
 	}
 }
 
 func updateTestReleaseHandler(t *testing.T, payload []byte, checksum string) http.HandlerFunc {
+	return updateTestReleaseHandlerWithVersion(t, "v0.2.0", payload, checksum)
+}
+
+func updateTestReleaseHandlerWithVersion(t *testing.T, version string, payload []byte, checksum string) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/releases/version":
-			_, _ = fmt.Fprintln(w, "new123")
+			_, _ = fmt.Fprintln(w, version)
 		case "/releases/checksums.txt":
 			_, _ = fmt.Fprintf(w, "%s  drive9-linux-amd64\n", checksum)
 		case "/releases/drive9-linux-amd64":
@@ -214,8 +274,4 @@ func updateTestReleaseHandler(t *testing.T, payload []byte, checksum string) htt
 			http.NotFound(w, r)
 		}
 	}
-}
-
-func fixedUpdateNow() time.Time {
-	return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
 }

--- a/cmd/drive9/cli/update_test.go
+++ b/cmd/drive9/cli/update_test.go
@@ -1,0 +1,207 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUpdateCheckReportsAvailable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/releases/version" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprintln(w, "new123")
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := updateWithDeps([]string{"--check"}, updateDeps{
+		baseURL:        srv.URL,
+		currentVersion: "old123",
+		goos:           "linux",
+		goarch:         "amd64",
+		httpClient:     srv.Client(),
+		stdout:         &stdout,
+		now:            fixedUpdateNow,
+	})
+	if err != nil {
+		t.Fatalf("update --check: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "drive9 update available: old123 -> new123") {
+		t.Fatalf("stdout = %q, want update-available line", stdout.String())
+	}
+}
+
+func TestUpdateDownloadsVerifiesAndReplacesExecutable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	payload := []byte("#!/bin/sh\necho new-drive9\n")
+	sum := sha256.Sum256(payload)
+	target := filepath.Join(t.TempDir(), "drive9")
+	if err := os.WriteFile(target, []byte("old-drive9"), 0o755); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	srv := httptest.NewServer(updateTestReleaseHandler(t, payload, fmt.Sprintf("%x", sum[:])))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	err := updateWithDeps(nil, updateDeps{
+		baseURL:        srv.URL,
+		currentVersion: "old123",
+		goos:           "linux",
+		goarch:         "amd64",
+		executable:     func() (string, error) { return target, nil },
+		httpClient:     srv.Client(),
+		stdout:         &stdout,
+		now:            fixedUpdateNow,
+		replaceExecutable: func(newPath, targetPath string) error {
+			if err := os.Remove(targetPath); err != nil {
+				return err
+			}
+			return os.Rename(newPath, targetPath)
+		},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("updated binary = %q, want %q", got, payload)
+	}
+	if !strings.Contains(stdout.String(), "drive9 updated: old123 -> new123") {
+		t.Fatalf("stdout = %q, want update success line", stdout.String())
+	}
+}
+
+func TestUpdateRejectsChecksumMismatch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	target := filepath.Join(t.TempDir(), "drive9")
+	if err := os.WriteFile(target, []byte("old-drive9"), 0o755); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	srv := httptest.NewServer(updateTestReleaseHandler(t, []byte("new-drive9"), strings.Repeat("0", 64)))
+	defer srv.Close()
+
+	err := updateWithDeps(nil, updateDeps{
+		baseURL:        srv.URL,
+		currentVersion: "old123",
+		goos:           "linux",
+		goarch:         "amd64",
+		executable:     func() (string, error) { return target, nil },
+		httpClient:     srv.Client(),
+		stdout:         &bytes.Buffer{},
+		now:            fixedUpdateNow,
+		replaceExecutable: func(string, string) error {
+			t.Fatal("replaceExecutable must not run after checksum mismatch")
+			return nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("update error = %v, want checksum mismatch", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "old-drive9" {
+		t.Fatalf("target changed after checksum mismatch: %q", got)
+	}
+}
+
+func TestMaybeNotifyUpdateUsesCachedResultOnNextRun(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var versionHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/releases/version" {
+			http.NotFound(w, r)
+			return
+		}
+		versionHits++
+		_, _ = fmt.Fprintln(w, "new123")
+	}))
+	defer srv.Close()
+
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	var stderr bytes.Buffer
+	deps := updateDeps{
+		baseURL:        srv.URL,
+		currentVersion: "old123",
+		goos:           "linux",
+		goarch:         "amd64",
+		httpClient:     srv.Client(),
+		stderr:         &stderr,
+		now:            func() time.Time { return now },
+	}
+
+	maybeNotifyUpdateWithDeps(deps)
+	if stderr.String() != "" {
+		t.Fatalf("first run stderr = %q, want no same-run update notice", stderr.String())
+	}
+	if versionHits != 1 {
+		t.Fatalf("version hits after first run = %d, want 1", versionHits)
+	}
+
+	stderr.Reset()
+	maybeNotifyUpdateWithDeps(deps)
+	if !strings.Contains(stderr.String(), "drive9 update available: old123 -> new123") {
+		t.Fatalf("second run stderr = %q, want cached update notice", stderr.String())
+	}
+	if versionHits != 1 {
+		t.Fatalf("version hits after second run = %d, want stale check to be skipped", versionHits)
+	}
+}
+
+func TestMaybeNotifyUpdateSkipsDevVersionNotice(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := writeUpdateCache(updateCache{
+		LastCheckedAt: fixedUpdateNow().UTC(),
+		LatestVersion: "new123",
+		LatestURL:     "https://drive9.ai/releases/drive9-linux-amd64",
+	}); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	maybeNotifyUpdateWithDeps(updateDeps{
+		currentVersion: "dev",
+		stderr:         &stderr,
+		now:            fixedUpdateNow,
+	})
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want no notice for dev builds", stderr.String())
+	}
+}
+
+func updateTestReleaseHandler(t *testing.T, payload []byte, checksum string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/version":
+			_, _ = fmt.Fprintln(w, "new123")
+		case "/releases/checksums.txt":
+			_, _ = fmt.Fprintf(w, "%s  drive9-linux-amd64\n", checksum)
+		case "/releases/drive9-linux-amd64":
+			_, _ = w.Write(payload)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func fixedUpdateNow() time.Time {
+	return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+}

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -18,6 +18,7 @@
 //	mount   mount drive9 as a local filesystem, or mount vault secrets
 //	umount  unmount a drive9 local mount
 //	doctor  diagnose local drive9 runtime prerequisites
+//	update  update the drive9 CLI binary in place
 package main
 
 import (
@@ -25,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/pprof"
+	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -52,6 +54,7 @@ var packHandler = cli.PackCommand
 var unpackHandler = cli.UnpackCommand
 var profileHandler = cli.Profile
 var umountHandler = cli.UmountCmd
+var updateHandler = cli.Update
 
 func main() {
 	if logger.CLIEnabled() {
@@ -77,6 +80,7 @@ func main() {
 	}
 
 	dispatch(os.Args[1], os.Args[2:])
+	maybeNotifyUpdate(os.Args[1])
 }
 
 // dispatch routes a parsed (verb, args) pair to the matching command handler.
@@ -229,6 +233,13 @@ func dispatch(cmd string, args []string) {
 		if err := doctorHandler(args); err != nil {
 			fatal("doctor", err)
 		}
+	case "update":
+		if cliLogger != nil {
+			logger.Info(context.Background(), "cli_command", zap.String("command", "update"))
+		}
+		if err := updateHandler(args); err != nil {
+			fatal("update", err)
+		}
 	default:
 		if cliLogger != nil {
 			logger.Warn(context.Background(), "cli_unknown_command", zap.String("command", cmd))
@@ -332,11 +343,29 @@ func fatal(cmd string, err error) {
 		logger.Error(context.Background(), "cli_command_failed", zap.String("command", cmd), zap.Error(err))
 	}
 	fmt.Fprintf(os.Stderr, "%s: %v\n", cmd, err)
+	maybeNotifyUpdate(primaryCommand(cmd))
 	type exitCoder interface{ ExitCode() int }
 	if ec, ok := err.(exitCoder); ok && ec.ExitCode() > 0 {
 		exitWithCode(ec.ExitCode())
 	}
 	exitWithCode(1)
+}
+
+func primaryCommand(cmd string) string {
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+func maybeNotifyUpdate(cmd string) {
+	switch primaryCommand(cmd) {
+	case "", "update", "version", "--version", "-v", "help", "--help", "-help", "-h":
+		return
+	default:
+		cli.MaybeNotifyUpdate(buildinfo.Version)
+	}
 }
 
 func usage(code int) {
@@ -375,7 +404,8 @@ func usage(code int) {
 			"  mount vault [flags] <mountpoint>\n"+
 			"                         mount vault secrets read-only\n"+
 			"  umount <mountpoint>    unmount a drive9 mount\n"+
-			"  doctor fuse            diagnose local FUSE prerequisites\n\n"+
+			"  doctor fuse            diagnose local FUSE prerequisites\n"+
+			"  update [--check]       update drive9 CLI in place\n\n"+
 			"global:\n"+
 			"  -h, --help, help       show this help\n"+
 			"  -v, --version, version print version information\n",

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"os"
 	"runtime/pprof"
-	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -80,7 +79,6 @@ func main() {
 	}
 
 	dispatch(os.Args[1], os.Args[2:])
-	maybeNotifyUpdate(os.Args[1])
 }
 
 // dispatch routes a parsed (verb, args) pair to the matching command handler.
@@ -343,29 +341,11 @@ func fatal(cmd string, err error) {
 		logger.Error(context.Background(), "cli_command_failed", zap.String("command", cmd), zap.Error(err))
 	}
 	fmt.Fprintf(os.Stderr, "%s: %v\n", cmd, err)
-	maybeNotifyUpdate(primaryCommand(cmd))
 	type exitCoder interface{ ExitCode() int }
 	if ec, ok := err.(exitCoder); ok && ec.ExitCode() > 0 {
 		exitWithCode(ec.ExitCode())
 	}
 	exitWithCode(1)
-}
-
-func primaryCommand(cmd string) string {
-	fields := strings.Fields(cmd)
-	if len(fields) == 0 {
-		return ""
-	}
-	return fields[0]
-}
-
-func maybeNotifyUpdate(cmd string) {
-	switch primaryCommand(cmd) {
-	case "", "update", "version", "--version", "-v", "help", "--help", "-help", "-h":
-		return
-	default:
-		cli.MaybeNotifyUpdate(buildinfo.Version)
-	}
 }
 
 func usage(code int) {

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -89,6 +89,7 @@ func TestDispatchLongHelpFlagShowsUsage(t *testing.T) {
 		"mount vault [flags] <mountpoint>",
 		"umount <mountpoint>",
 		"doctor fuse",
+		"update [--check]",
 		"-h, --help, help",
 	} {
 		if !strings.Contains(stderr, want) {
@@ -283,6 +284,39 @@ func TestDispatchDoctorVerbReachesHandler(t *testing.T) {
 		t.Fatal("doctor handler was not invoked for `drive9 doctor ...`")
 	}
 	want := []string{"fuse", "--mountpoint", "/mnt/drive9"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q", i, gotArgs[i], want[i])
+		}
+	}
+}
+
+func TestDispatchUpdateVerbReachesHandler(t *testing.T) {
+	origHandler := updateHandler
+	origExit := exitFunc
+	t.Cleanup(func() {
+		updateHandler = origHandler
+		exitFunc = origExit
+	})
+	exitFunc = func(int) {}
+
+	var gotArgs []string
+	called := false
+	updateHandler = func(args []string) error {
+		called = true
+		gotArgs = args
+		return nil
+	}
+
+	dispatch("update", []string{"--check"})
+
+	if !called {
+		t.Fatal("update handler was not invoked for `drive9 update ...`")
+	}
+	want := []string{"--check"}
 	if len(gotArgs) != len(want) {
 		t.Fatalf("args = %v, want %v", gotArgs, want)
 	}

--- a/e2e/git_fixture.py
+++ b/e2e/git_fixture.py
@@ -87,7 +87,10 @@ def build_fixture(root: Path, tree_files: int = 0) -> dict[str, str]:
     commit(source, "feature rebase upstream")
 
     run(source, "checkout", "main")
-    run(None, "clone", "--bare", str(source), str(bare))
+    # Avoid Git's local clone object hardlink/copy optimization here. On CI this
+    # path has occasionally failed while copying pack index files, leaving a
+    # broken bare fixture and cascading clone failures through the smoke test.
+    run(None, "clone", "--bare", "--no-local", str(source), str(bare))
     run(bare, "config", "uploadpack.allowFilter", "true")
     run(bare, "config", "uploadpack.allowAnySHA1InWant", "true")
 


### PR DESCRIPTION
## Summary

Adds a first-class `drive9 update` command that can replace the currently running drive9 CLI binary in place with the latest published release artifact.

This PR is intentionally scoped to the explicit update command. Automatic update notifications, prompt throttling, and background update-check state are left to PR #535.

## User-facing behavior

- `drive9 update` downloads the latest platform-specific binary from `https://drive9.ai/releases/drive9-<goos>-<goarch>`.
- `drive9 update --check` reports whether the installed CLI is behind the published release without modifying the binary.
- `drive9 update --force` reinstalls the latest binary and is required for downgrades or versions that cannot be compared as semver.
- `drive9 update --base-url <url>` supports alternate HTTPS release roots for controlled rollout environments.
- Non-HTTPS release roots are rejected by default because the checksum source must be authenticated.
- Windows self-update is explicitly unsupported for now because the running `.exe` cannot be replaced safely in-process.

## Implementation details

- Reuses the existing release artifact convention:
  - `/releases/version`
  - `/releases/checksums.txt`
  - `/releases/drive9-<goos>-<goarch>[.exe]`
- Uses semver-aware comparison so default update behavior only installs newer releases.
- Downloads into a temporary file next to the target executable, validates SHA-256 from `checksums.txt`, preserves the executable mode, then swaps the binary into place on Unix.
- Runs platform replacement preflight before downloading so unsupported platforms fail fast.
- Keeps Unix and Windows replacement logic split behind build tags.

## Safety and failure behavior

- Explicit `drive9 update` fails loudly if version metadata, checksums, download, validation, or replacement fails.
- The current binary is not replaced until the downloaded artifact checksum matches the published checksum.
- If the installed binary is not writable, the command returns a clear permission-oriented error instead of attempting fallback behavior.
- Older published releases are reported as downgrades and are not installed unless `--force` is provided.

## Tests

Targeted validation run:

```bash
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9 ./cmd/drive9/cli
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache GOOS=windows GOARCH=amd64 go test -c ./cmd/drive9/cli -o /tmp/drive9-cli.test.exe
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go vet ./cmd/drive9/cli ./cmd/drive9
env GOCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gocache go test ./cmd/drive9/cli -race -count=1
make lint
git diff --check
```

Covered cases include:

- top-level `update` dispatch
- global help including `update`
- `update --check` reporting an available release
- successful download, checksum verification, and replacement
- checksum mismatch refusing replacement
- semver downgrade blocking unless `--force`
- non-HTTPS release root rejection by default
- replacement preflight running before artifact download
- checksum file validation for duplicate or path-qualified artifact names


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `drive9 update` command to self-update the binary
  * Supports `--check` flag to report available updates
  * Supports `--force` flag to override version constraints
  * Supports `--base-url` flag to customize release source
  * Automatic checksum verification on download (Unix/Linux/macOS supported; Windows requires manual installation)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->