### PR TITLE
ci: add Alibaba Cloud ACK deployment to prod-cd

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -138,7 +138,7 @@ jobs:
         if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         run: |
           mkdir -p ~/.kube
-          aliyun --profile github-actions cs GET "/k8s/c4dad0ecde1e94472a36fec0498e181ed/user_config" --region ap-southeast-1 | jq -r '.config' | base64 -d > ~/.kube/alicloud-config
+          aliyun --profile github-actions cs GET "/k8s/c4dad0ecde1e94472a36fec0498e181ed/user_config" --region ap-southeast-1 | jq -r '.config' > ~/.kube/alicloud-config
           kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
             set image "deployment/${{ env.K8S_DEPLOYMENT }}" \
             "${{ env.K8S_DEPLOYMENT }}=$ACR_IMAGE"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -118,7 +118,7 @@ jobs:
           kubectl --context us -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
 
-      - name: Configure Alibaba Cloud credentials
+      - name: Configure Alibaba Cloud credentials (ap-southeast-1)
         if: inputs.region == 'all' || inputs.region == 'aws-ap-southeast-1' || inputs.region == 'alicloud-ap-southeast-1'
         uses: aliyun/configure-aliyun-credentials-action@v1
         with:

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -117,7 +117,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.ALIYUN_ASSUME_ROLE_ARN }}
           oidc-provider-arn: ${{ secrets.ALIYUN_OIDC_PROVIDER_ARN }}
-          region: ap-southeast-1
 
       - name: Push image to alicloud-ap-southeast-1 ACR
         if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -111,7 +111,7 @@ jobs:
           kubectl --context us -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
 
-      - name: Configure Alibaba Cloud credentials (ap-southeast-1)
+      - name: Configure Alibaba Cloud credentials
         if: inputs.region == 'all' || inputs.region == 'aws-ap-southeast-1' || inputs.region == 'alicloud-ap-southeast-1'
         uses: aliyun/configure-aliyun-credentials-action@v1
         with:

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
 
     steps:
-      - name: Configure AWS credentials (ap-southeast-1)
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ARN_PROD }}
@@ -88,13 +88,6 @@ jobs:
         run: |
           kubectl --context prod -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
-
-      - name: Configure AWS credentials (us-east-1)
-        if: inputs.region == 'all' || inputs.region == 'aws-us-east-1'
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ARN_US }}
-          aws-region: us-east-1
 
       - name: Deploy to us-east-1
         id: deploy-us

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -112,7 +112,7 @@ jobs:
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
 
       - name: Configure Alibaba Cloud credentials
-        if: inputs.region == 'all' || inputs.region == 'aws-ap-southeast-1' || inputs.region == 'alicloud-ap-southeast-1'
+        if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         uses: aliyun/configure-aliyun-credentials-action@v1
         with:
           role-to-assume: ${{ secrets.ALIYUN_ASSUME_ROLE_ARN }}
@@ -120,7 +120,7 @@ jobs:
           region: ap-southeast-1
 
       - name: Push image to Alibaba Cloud ACR
-        if: inputs.region == 'all' || inputs.region == 'aws-ap-southeast-1' || inputs.region == 'alicloud-ap-southeast-1'
+        if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         run: |
           # Install aliyun CLI
           curl -fsSL https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz | tar xz -C /usr/local/bin
@@ -135,19 +135,19 @@ jobs:
 
       - name: Deploy to Alibaba Cloud ACK
         id: deploy-alicloud
-        if: inputs.region == 'all' || inputs.region == 'aws-ap-southeast-1' || inputs.region == 'alicloud-ap-southeast-1'
+        if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         run: |
-          # Fetch kubeconfig dynamically from ACK
-          aliyun cs GET "/k8s/${{ secrets.ALIYUN_ACK_CLUSTER_ID }}/user_config" --region ap-southeast-1 | jq -r '.config' | base64 -d > ~/.kube/config
-          kubectl -n "${{ env.DEPLOY_NAMESPACE }}" \
+          mkdir -p ~/.kube
+          aliyun cs GET "/k8s/${{ secrets.ALIYUN_ACK_CLUSTER_ID }}/user_config" --region ap-southeast-1 | jq -r '.config' | base64 -d > ~/.kube/alicloud-config
+          kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
             set image "deployment/${{ env.K8S_DEPLOYMENT }}" \
             "${{ env.K8S_DEPLOYMENT }}=$ACR_IMAGE"
-          kubectl -n "${{ env.DEPLOY_NAMESPACE }}" \
+          kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
             --timeout=180s
 
       - name: Rollback Alibaba Cloud on failure
         if: failure() && steps.deploy-alicloud.outcome == 'failure'
         run: |
-          kubectl -n "${{ env.DEPLOY_NAMESPACE }}" \
+          kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -122,8 +122,8 @@ jobs:
       - name: Push image to Alibaba Cloud ACR
         if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         run: |
-          # Install aliyun CLI
           curl -fsSL https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz | tar xz -C /usr/local/bin
+          aws ecr get-login-password --region ap-southeast-1 | docker login --username AWS --password-stdin "${{ env.ECR_REGISTRY }}"
           docker pull "$IMAGE"
           TAG=$(echo "$IMAGE" | awk -F: '{print $NF}')
           ACR_IMAGE="${{ secrets.ALIYUN_ACR_REGISTRY }}/${{ secrets.ALIYUN_ACR_NAMESPACE }}/${{ env.ECR_REPOSITORY }}:$TAG"
@@ -149,5 +149,7 @@ jobs:
       - name: Rollback Alibaba Cloud on failure
         if: failure() && steps.deploy-alicloud.outcome == 'failure'
         run: |
-          kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
-            rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
+          if [ -f ~/.kube/alicloud-config ]; then
+            kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
+              rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
+          fi

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -67,7 +67,7 @@ jobs:
           echo "Promoting image: $IMAGE"
           printf '%s=%s\n' "IMAGE" "$IMAGE" >> "$GITHUB_ENV"
 
-      - name: Deploy to ap-southeast-1
+      - name: Deploy to aws-ap-southeast-1
         id: deploy-sg
         if: inputs.region == 'all' || inputs.region == 'aws-ap-southeast-1'
         run: |
@@ -83,13 +83,13 @@ jobs:
             rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
             --timeout=180s
 
-      - name: Rollback ap-southeast-1 on failure
+      - name: Rollback aws-ap-southeast-1 on failure
         if: failure() && steps.deploy-sg.outcome == 'failure'
         run: |
           kubectl --context prod -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
 
-      - name: Deploy to us-east-1
+      - name: Deploy to aws-us-east-1
         id: deploy-us
         if: inputs.region == 'all' || inputs.region == 'aws-us-east-1'
         run: |
@@ -105,7 +105,7 @@ jobs:
             rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
             --timeout=180s
 
-      - name: Rollback us-east-1 on failure
+      - name: Rollback aws-us-east-1 on failure
         if: failure() && steps.deploy-us.outcome == 'failure'
         run: |
           kubectl --context us -n "${{ env.DEPLOY_NAMESPACE }}" \
@@ -119,7 +119,7 @@ jobs:
           oidc-provider-arn: ${{ secrets.ALIYUN_OIDC_PROVIDER_ARN }}
           region: ap-southeast-1
 
-      - name: Push image to Alibaba Cloud ACR
+      - name: Push image to alicloud-ap-southeast-1 ACR
         if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         run: |
           curl -fsSL https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz | tar xz -C /usr/local/bin
@@ -133,7 +133,7 @@ jobs:
           docker push "$ACR_IMAGE"
           echo "ACR_IMAGE=$ACR_IMAGE" >> "$GITHUB_ENV"
 
-      - name: Deploy to Alibaba Cloud ACK
+      - name: Deploy to alicloud-ap-southeast-1
         id: deploy-alicloud
         if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         run: |
@@ -146,7 +146,7 @@ jobs:
             rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
             --timeout=180s
 
-      - name: Rollback Alibaba Cloud on failure
+      - name: Rollback alicloud-ap-southeast-1 on failure
         if: failure() && steps.deploy-alicloud.outcome == 'failure'
         run: |
           if [ -f ~/.kube/alicloud-config ]; then

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -8,8 +8,9 @@ on:
         type: choice
         options:
           - all
-          - ap-southeast-1
-          - us-east-1
+          - aws-ap-southeast-1
+          - aws-us-east-1
+          - alicloud-ap-southeast-1
       image_tag:
         description: "Image tag override (default: resolve from dev deployment)"
         required: false
@@ -68,7 +69,7 @@ jobs:
 
       - name: Deploy to ap-southeast-1
         id: deploy-sg
-        if: inputs.region == 'all' || inputs.region == 'ap-southeast-1'
+        if: inputs.region == 'all' || inputs.region == 'aws-ap-southeast-1'
         run: |
           echo "sg-deploy=1" >> "$GITHUB_ENV"
           aws eks update-kubeconfig \
@@ -89,7 +90,7 @@ jobs:
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
 
       - name: Configure AWS credentials (us-east-1)
-        if: inputs.region == 'all' || inputs.region == 'us-east-1'
+        if: inputs.region == 'all' || inputs.region == 'aws-us-east-1'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ARN_US }}
@@ -97,7 +98,7 @@ jobs:
 
       - name: Deploy to us-east-1
         id: deploy-us
-        if: inputs.region == 'all' || inputs.region == 'us-east-1'
+        if: inputs.region == 'all' || inputs.region == 'aws-us-east-1'
         run: |
           echo "us-deploy=1" >> "$GITHUB_ENV"
           aws eks update-kubeconfig \
@@ -115,4 +116,45 @@ jobs:
         if: failure() && steps.deploy-us.outcome == 'failure'
         run: |
           kubectl --context us -n "${{ env.DEPLOY_NAMESPACE }}" \
+            rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
+
+      - name: Configure Alibaba Cloud credentials
+        if: inputs.region == 'all' || inputs.region == 'aws-ap-southeast-1' || inputs.region == 'alicloud-ap-southeast-1'
+        uses: aliyun/configure-aliyun-credentials-action@v1
+        with:
+          role-to-assume: ${{ secrets.ALIYUN_ASSUME_ROLE_ARN }}
+          oidc-provider-arn: ${{ secrets.ALIYUN_OIDC_PROVIDER_ARN }}
+          region: ap-southeast-1
+
+      - name: Push image to Alibaba Cloud ACR
+        if: inputs.region == 'all' || inputs.region == 'aws-ap-southeast-1' || inputs.region == 'alicloud-ap-southeast-1'
+        run: |
+          # Install aliyun CLI
+          curl -fsSL https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz | tar xz -C /usr/local/bin
+          docker pull "$IMAGE"
+          TAG=$(echo "$IMAGE" | awk -F: '{print $NF}')
+          ACR_IMAGE="${{ secrets.ALIYUN_ACR_REGISTRY }}/${{ secrets.ALIYUN_ACR_NAMESPACE }}/${{ env.ECR_REPOSITORY }}:$TAG"
+          docker tag "$IMAGE" "$ACR_IMAGE"
+          AUTH=$(aliyun cr GetAuthorizationToken --InstanceId "${{ secrets.ALIYUN_ACR_INSTANCE_ID }}" --RegionId ap-southeast-1 | jq -r '.AuthorizationToken')
+          echo "$AUTH" | docker login --username=cr_temp_user --password-stdin "${{ secrets.ALIYUN_ACR_REGISTRY }}"
+          docker push "$ACR_IMAGE"
+          echo "ACR_IMAGE=$ACR_IMAGE" >> "$GITHUB_ENV"
+
+      - name: Deploy to Alibaba Cloud ACK
+        id: deploy-alicloud
+        if: inputs.region == 'all' || inputs.region == 'aws-ap-southeast-1' || inputs.region == 'alicloud-ap-southeast-1'
+        run: |
+          # Fetch kubeconfig dynamically from ACK
+          aliyun cs GET "/k8s/${{ secrets.ALIYUN_ACK_CLUSTER_ID }}/user_config" --region ap-southeast-1 | jq -r '.config' | base64 -d > ~/.kube/config
+          kubectl -n "${{ env.DEPLOY_NAMESPACE }}" \
+            set image "deployment/${{ env.K8S_DEPLOYMENT }}" \
+            "${{ env.K8S_DEPLOYMENT }}=$ACR_IMAGE"
+          kubectl -n "${{ env.DEPLOY_NAMESPACE }}" \
+            rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
+            --timeout=180s
+
+      - name: Rollback Alibaba Cloud on failure
+        if: failure() && steps.deploy-alicloud.outcome == 'failure'
+        run: |
+          kubectl -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -122,12 +122,13 @@ jobs:
         if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         run: |
           curl -fsSL https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz | tar xz -C /usr/local/bin
+          aliyun configure set --region ap-southeast-1 --access-key-id "$ALIBABA_CLOUD_ACCESS_KEY_ID" --access-key-secret "$ALIBABA_CLOUD_ACCESS_KEY_SECRET" --sts-token "$ALIBABA_CLOUD_SECURITY_TOKEN" --mode StsToken --profile github-actions
           aws ecr get-login-password --region ap-southeast-1 | docker login --username AWS --password-stdin "${{ env.ECR_REGISTRY }}"
           docker pull "$IMAGE"
           TAG=$(echo "$IMAGE" | awk -F: '{print $NF}')
           ACR_IMAGE="${{ secrets.ALIYUN_ACR_REGISTRY }}/${{ secrets.ALIYUN_ACR_NAMESPACE }}/${{ env.ECR_REPOSITORY }}:$TAG"
           docker tag "$IMAGE" "$ACR_IMAGE"
-          AUTH=$(aliyun cr GetAuthorizationToken --InstanceId "${{ secrets.ALIYUN_ACR_INSTANCE_ID }}" --RegionId ap-southeast-1 | jq -r '.AuthorizationToken')
+          AUTH=$(aliyun --profile github-actions cr GetAuthorizationToken --InstanceId "${{ secrets.ALIYUN_ACR_INSTANCE_ID }}" --RegionId ap-southeast-1 | jq -r '.AuthorizationToken')
           echo "$AUTH" | docker login --username=cr_temp_user --password-stdin "${{ secrets.ALIYUN_ACR_REGISTRY }}"
           docker push "$ACR_IMAGE"
           echo "ACR_IMAGE=$ACR_IMAGE" >> "$GITHUB_ENV"
@@ -137,7 +138,7 @@ jobs:
         if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         run: |
           mkdir -p ~/.kube
-          aliyun cs GET "/k8s/c4dad0ecde1e94472a36fec0498e181ed/user_config" --region ap-southeast-1 | jq -r '.config' | base64 -d > ~/.kube/alicloud-config
+          aliyun --profile github-actions cs GET "/k8s/c4dad0ecde1e94472a36fec0498e181ed/user_config" --region ap-southeast-1 | jq -r '.config' | base64 -d > ~/.kube/alicloud-config
           kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
             set image "deployment/${{ env.K8S_DEPLOYMENT }}" \
             "${{ env.K8S_DEPLOYMENT }}=$ACR_IMAGE"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -138,7 +138,7 @@ jobs:
         if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         run: |
           mkdir -p ~/.kube
-          aliyun cs GET "/k8s/${{ secrets.ALIYUN_ACK_CLUSTER_ID }}/user_config" --region ap-southeast-1 | jq -r '.config' | base64 -d > ~/.kube/alicloud-config
+          aliyun cs GET "/k8s/c4dad0ecde1e94472a36fec0498e181ed/user_config" --region ap-southeast-1 | jq -r '.config' | base64 -d > ~/.kube/alicloud-config
           kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
             set image "deployment/${{ env.K8S_DEPLOYMENT }}" \
             "${{ env.K8S_DEPLOYMENT }}=$ACR_IMAGE"


### PR DESCRIPTION
## Summary
Add Alibaba Cloud ACK deployment support to the prod-cd workflow.

## Changes
- Add `alicloud-ap-southeast-1` region option
- Use Alibaba Cloud OIDC (`aliyun/configure-aliyun-credentials-action`) for auth — no long-lived secrets
- Dynamically fetch kubeconfig via `aliyun cs GET /k8s/<cluster>/user_config` — no kubeconfig secret needed
- Pull image from ECR, retag and push to ACR, then deploy to ACK
- Rollback on deploy failure
- Prefix AWS regions with `aws-` for clarity

## Required GitHub Secrets (already configured)
- `ALIYUN_ACR_REGISTRY`, `ALIYUN_ACR_NAMESPACE`, `ALIYUN_ACR_INSTANCE_ID`
- `ALIYUN_ACK_CLUSTER_ID`
- `ALIYUN_OIDC_PROVIDER_ARN`, `ALIYUN_ASSUME_ROLE_ARN`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit regional identifiers for AWS deployments (aws-ap-southeast-1, aws-us-east-1) as separate deployment options.
  * Introduced Alibaba Cloud deployment for ap-southeast-1 via ACR/ACK with automated image push and dynamic kubeconfig retrieval.
  * Updated deployment workflow to run provider-specific steps per selected region and perform automatic rollback on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->