### PR TITLE
docs: add weekly release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The current storage path is **TiDB + S3-compatible object storage**. db9 remains
 a provider/inspiration path in the codebase, but it is not the default storage
 backend described by the current production architecture.
 
+Recent project updates are summarized in the [weekly release notes](docs/release-notes/2026-05-18-to-2026-06-14.md).
+
 ## What It Does
 
 **One path namespace.** Files live at paths such as `:/src/main.go` or

--- a/docs/release-notes/2026-05-18-to-2026-06-14.md
+++ b/docs/release-notes/2026-05-18-to-2026-06-14.md
@@ -1,0 +1,106 @@
+# Drive9 Weekly Release Notes
+
+Coverage: merged PRs from 2026-05-18 through 2026-06-14. This is a curated summary of community-facing changes, not a full changelog.
+
+
+## Four-week highlights
+
+Over the last four weeks, Drive9 moved significantly closer to a production-grade agent workspace filesystem:
+
+- **More complete POSIX workspace semantics**: symlinks, hardlinks, safer local write visibility, preserved create modes, FUSE durability profiles, and crash-recovery hardening make Drive9 mounts behave more like a real working directory.
+- **Git-native agent workflows**: fast clone, fast worktree, Git workspace restore fixes, blob-cache fallbacks, local HEAD size resolution, and Git smoke/feature-matrix tests make Drive9 more practical for coding agents working inside repositories.
+- **Faster and safer FUSE reads**: revision-bound disk caching, block-level parallel reads, singleflight read deduplication, directory/stat cache improvements, negative-lookup storm reduction, and whole-file small-read fetches reduce request amplification while preserving cache correctness.
+- **Portable and layered workspaces**: pack/unpack archives, the portable profile, and layered filesystem overlays introduce the primitives needed for moving, branching, checkpointing, and isolating agent workspace state.
+- **Stronger operating model**: scoped Workspace Zone tokens, Alibaba KMS/OSS/ACK support, tenant metrics, semantic-worker scheduling improvements, and tiered e2e/performance regression gates improve production readiness.
+
+## Week of 2026-05-18 — Durability controls, scoped workspace access, and stronger CLI primitives
+
+This week focused on making Drive9 mounts safer to operate and easier to automate.
+
+### Behavior changes
+- Scoped Workspace Zone tokens are intentionally denied from endpoints outside their declared filesystem scopes. Owner tokens continue to behave as before.
+
+### Highlights
+- **FUSE durability profiles**: `drive9 mount` now exposes `--durability=auto|interactive|fsync|close-sync|write-sync`, giving users explicit control over write durability without exposing internal sync/write-policy plumbing. ([#429](https://github.com/mem9-ai/drive9/pull/429), [#431](https://github.com/mem9-ai/drive9/pull/431))
+- **Workspace Zone scoped tokens**: Drive9 added prefix/op-scoped filesystem tokens and enforced them across reads, writes, copy/rename, and upload continuation paths. Owners can issue and revoke scoped tokens from the CLI/API. ([#438](https://github.com/mem9-ai/drive9/pull/438), [#439](https://github.com/mem9-ai/drive9/pull/439), [#440](https://github.com/mem9-ai/drive9/pull/440), [#441](https://github.com/mem9-ai/drive9/pull/441), [#442](https://github.com/mem9-ai/drive9/pull/442))
+- **Recursive filesystem copy**: `drive9 fs cp -r` now supports recursive local↔remote and remote↔remote copy workflows. ([#434](https://github.com/mem9-ai/drive9/pull/434))
+- **Byte-range reads**: `drive9 fs cat --offset --length` and SDK `ReadAt` support make it possible to inspect parts of large files without downloading the entire object. ([#436](https://github.com/mem9-ai/drive9/pull/436))
+
+### Reliability and operations
+- Added FUSE knobs for backend read concurrency and synchronous kernel read dispatch, plus upload-concurrency tuning and lower allocation overhead for large writes. ([#435](https://github.com/mem9-ai/drive9/pull/435), [#437](https://github.com/mem9-ai/drive9/pull/437), [#449](https://github.com/mem9-ai/drive9/pull/449), [#448](https://github.com/mem9-ai/drive9/pull/448))
+- New tenants now skip the legacy `files` table and write directly to the split schema, reducing new-deployment overhead. ([#423](https://github.com/mem9-ai/drive9/pull/423))
+- Simplified context/token UX by consolidating token inventory under `ctx list --type` and local removal under `ctx rm`. ([#445](https://github.com/mem9-ai/drive9/pull/445))
+
+## Week of 2026-05-25 — POSIX compatibility, SDK expansion, and fast Git clone
+
+This week moved Drive9 closer to a real agent working directory: more POSIX behavior, better local-write visibility, and the first fast Git workspace path.
+
+### Highlights
+- **Symlink support**: Drive9 now supports symbolic links across backend, server, client, CLI, and FUSE, including `Symlink`/`Readlink` behavior on mounts. ([#458](https://github.com/mem9-ai/drive9/pull/458))
+- **Safer local writes**: FUSE now keeps local writes visible across reopen paths, preserves pending create modes, and avoids stale directory snapshot `EIO` failures. ([#461](https://github.com/mem9-ai/drive9/pull/461), [#460](https://github.com/mem9-ai/drive9/pull/460))
+- **Coding-agent mount profile groundwork**: Added an observe-only `coding-agent` policy scaffold for local/remote path classification and future sandbox-aware overlay behavior. ([#464](https://github.com/mem9-ai/drive9/pull/464))
+- **Fast Git clone workspaces**: `drive9 git clone --fast` creates Git-aware Drive9 workspaces, including blobless modes. It avoids pushing clean checkout traffic through ordinary FUSE writes, making clones into Drive9 mounts faster while preserving agent work across sandbox/container replacement. ([#471](https://github.com/mem9-ai/drive9/pull/471))
+
+### SDKs and integrations
+- Added native Kotlin and Swift SDKs covering filesystem operations, streaming transfer, patch/resume, and vault APIs, with SDK CI coverage. ([#455](https://github.com/mem9-ai/drive9/pull/455))
+- Added Slock OAuth/callback tenant provisioning and dev login support, including reusable tenant creation and richer callback responses. ([#467](https://github.com/mem9-ai/drive9/pull/467), [#470](https://github.com/mem9-ai/drive9/pull/470), [#472](https://github.com/mem9-ai/drive9/pull/472))
+- Added a latest archive index for published Drive9 artifacts. ([#462](https://github.com/mem9-ai/drive9/pull/462))
+- Rotated semantic tenant scans to reduce starvation risk in multi-tenant background processing. ([#453](https://github.com/mem9-ai/drive9/pull/453))
+
+## Week of 2026-06-01 — Git worktrees, hardlinks, read-cache architecture, and real FUSE quality gates
+
+This week was a major performance/correctness push for Drive9 as a mounted workspace.
+
+### Highlights
+- **Fast Git worktrees**: `drive9 git worktree add --fast` and `drive9 git worktree remove --fast` extend fast Git workflows to branch/worktree-based agent development. ([#480](https://github.com/mem9-ai/drive9/pull/480))
+- **Hardlink support**: Drive9 added hardlinks across datastore, backend, HTTP API, Go client, CLI, and FUSE, including stable file identity and link counts. ([#479](https://github.com/mem9-ai/drive9/pull/479))
+- **Revision-bound disk read cache**: Large FUSE reads can now use a disk-backed cache keyed by file identity, revision, offset, and length, with invalidation on local mutations, renames, and server-side change/reset events. ([#495](https://github.com/mem9-ai/drive9/pull/495))
+- **Block-level parallel reads**: Large reads are split into cacheable blocks fetched with bounded concurrency, improving cold and repeated read performance. ([#496](https://github.com/mem9-ai/drive9/pull/496))
+
+### Performance and cache correctness
+- Added singleflight deduplication so concurrent reads of the same uncached file share one remote fetch instead of stampeding the backend. ([#493](https://github.com/mem9-ai/drive9/pull/493))
+- Added revision-bound directory/stat cache hits for `GetAttr`. ([#494](https://github.com/mem9-ai/drive9/pull/494))
+- Published the FUSE cache invalidation spec covering read cache, disk cache, directory/stat cache, negative cache, SSE invalidation, local mutations, and lazy revalidation. ([#491](https://github.com/mem9-ai/drive9/pull/491))
+- Added a reproducible FUSE benchmark harness with stable JSON/Markdown output. ([#492](https://github.com/mem9-ai/drive9/pull/492))
+
+### Testing
+- Added live POSIX and Git feature matrices, FUSE read correctness, concurrency stress, SQLite correctness, SQLite churn/concurrency, and performance baseline workloads. ([#497](https://github.com/mem9-ai/drive9/pull/497), [#501](https://github.com/mem9-ai/drive9/pull/501), [#502](https://github.com/mem9-ai/drive9/pull/502), [#505](https://github.com/mem9-ai/drive9/pull/505), [#506](https://github.com/mem9-ai/drive9/pull/506), [#508](https://github.com/mem9-ai/drive9/pull/508))
+- Added tier-transition regression coverage verifying data integrity across repeated inline↔S3 storage switches. ([#503](https://github.com/mem9-ai/drive9/pull/503), [#504](https://github.com/mem9-ai/drive9/pull/504))
+
+### Cloud support
+- Added Alibaba Cloud KMS as an encryption provider. ([#500](https://github.com/mem9-ai/drive9/pull/500))
+
+## Week of 2026-06-08 — Portable workspaces, layered overlays, crash recovery, and performance regression gates
+
+This week introduced larger workspace primitives and turned more correctness/performance checks into release gates.
+
+### Behavior changes
+- **`drive9 mount` now backgrounds by default** and returns once the mount worker is ready. Use `--foreground` for the previous blocking behavior. ([#520](https://github.com/mem9-ai/drive9/pull/520))
+- **Layer/checkpoint mismatch now fails fast** when `--layer` and `--checkpoint` refer to different layers. ([#547](https://github.com/mem9-ai/drive9/pull/547))
+
+### Highlights
+- **Layered filesystem overlays**: Drive9 introduced writable copy-on-write layers that let agents modify files without changing the base workspace. Overlay changes can be preserved across sandboxes and later checkpointed or committed, which is useful for sandboxed experiments, branching workspace state, and staging changes before merge. ([#507](https://github.com/mem9-ai/drive9/pull/507))
+- **Pack/unpack for portable agent state**: `drive9 pack` / `drive9 unpack` store local overlay resources as ordinary Drive9 archives, enabling workspace handoff across machines or sandboxes without bypassing Drive9 storage policy. ([#509](https://github.com/mem9-ai/drive9/pull/509))
+- **Portable mount profile**: Added a built-in `portable` profile with pack/unpack e2e coverage for files that need to move with a sandbox or machine. ([#530](https://github.com/mem9-ai/drive9/pull/530))
+- **Small-file cold-read improvement**: FUSE can fetch small files in one whole-file request and populate the disk read-cache tier, reducing request amplification for common source/config-file reads. ([#549](https://github.com/mem9-ai/drive9/pull/549))
+
+### Git workspace reliability
+- Fixed fast Git workspace restore/worktree regressions found by live Git feature-matrix tests, including unknown clean-tree sizes, local HEAD reads, blob-cache fallbacks, objectless/blobless behavior, deleted-marker handling, refresh storms during native clones, and local HEAD size resolution. ([#523](https://github.com/mem9-ai/drive9/pull/523), [#527](https://github.com/mem9-ai/drive9/pull/527), [#529](https://github.com/mem9-ai/drive9/pull/529), [#536](https://github.com/mem9-ai/drive9/pull/536), [#542](https://github.com/mem9-ai/drive9/pull/542))
+- Added lightweight Git ops smoke tests for local server runs and profile coverage. ([#533](https://github.com/mem9-ai/drive9/pull/533))
+
+### FUSE correctness and release gates
+- FUSE performance comparisons now hard-fail metric regressions by default while preserving JSON/Markdown diagnostics. ([#510](https://github.com/mem9-ai/drive9/pull/510), [#519](https://github.com/mem9-ai/drive9/pull/519))
+- Heavy FUSE e2e coverage now includes SQLite WAL baselines, all-workload flags, daily/manual gates, and explicit PR/post-merge/nightly/manual tiers. ([#513](https://github.com/mem9-ai/drive9/pull/513), [#516](https://github.com/mem9-ai/drive9/pull/516), [#548](https://github.com/mem9-ai/drive9/pull/548))
+- Hardened the FUSE write path against daemon-crash corner cases between `fsync` and async commit, covering WAL replay, pending metadata, shadow spill, commit queue, and crash-recovery e2e behavior. ([#545](https://github.com/mem9-ai/drive9/pull/545))
+- Reduced negative-lookup storms by escalating repeated missing-name lookups in one directory to a single directory listing. ([#537](https://github.com/mem9-ai/drive9/pull/537))
+- Inferred revisions after async commits when stream/multipart completions do not return a revision. ([#521](https://github.com/mem9-ai/drive9/pull/521))
+- Rejected invalid root self-dentry writes to avoid root metadata corruption. ([#528](https://github.com/mem9-ai/drive9/pull/528))
+
+### Cloud and operations
+- Improved Alibaba OSS/KMS production support with custom KMS endpoints, VPC/TLS/RRSA handling, S3 client refactoring, and schema generated-column guards. ([#512](https://github.com/mem9-ai/drive9/pull/512), [#514](https://github.com/mem9-ai/drive9/pull/514))
+- Added Alibaba Cloud ACK deployment support to production CD using OIDC and dynamic kubeconfig retrieval. ([#551](https://github.com/mem9-ai/drive9/pull/551))
+- Added tenant usage dashboards and improved semantic worker scheduling so new upload-commit tasks can be claimed sooner and tenant selection avoids starvation. ([#532](https://github.com/mem9-ai/drive9/pull/532), [#540](https://github.com/mem9-ai/drive9/pull/540), [#541](https://github.com/mem9-ai/drive9/pull/541))
+- Retried deadlocked split-table migration writes and propagated visual-language image extraction errors instead of writing placeholder text. ([#544](https://github.com/mem9-ai/drive9/pull/544), [#543](https://github.com/mem9-ai/drive9/pull/543))
+
+### Internal note
+- Persistent SSE event replay was added and then reverted during the week, keeping the release conservative while event replay semantics continue to be refined. ([#534](https://github.com/mem9-ai/drive9/pull/534), [#538](https://github.com/mem9-ai/drive9/pull/538))


### PR DESCRIPTION
## Summary

Adds curated weekly release notes for the last four weeks of Drive9 development:

- 2026-05-18 week: FUSE durability, scoped workspace tokens, CLI primitives
- 2026-05-25 week: POSIX compatibility, SDK expansion, fast Git clone
- 2026-06-01 week: Git worktrees, hardlinks, read-cache architecture, FUSE quality gates
- 2026-06-08 week: portable/layered workspaces, crash recovery, performance gates

The notes intentionally summarize community-facing changes rather than listing every merged PR.

## Validation

- `git diff --check`

## Notes

Prepared from merged PRs between 2026-05-18 and 2026-06-14, with linked PR references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added weekly release notes covering May 18–June 14, highlighting improvements to FUSE semantics, Git-native workspace workflows, expanded SDKs and integrations, new workspace primitives (including portable workspaces and layered overlays), and ongoing reliability/performance work.
  * Updated the README with a “Recent project updates” pointer to the new release notes document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->