### PR TITLE
feat: sanitize client errors and add ctx ls --details flag

### DIFF
--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -753,7 +753,7 @@ func ctxListCmd(args []string) error {
 				typeFilter = strings.TrimPrefix(args[i], "--type=")
 				continue
 			}
-			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx ls [-l|--json|--details] [--type <kind>|--scoped]", args[i])
+			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx ls [-l|--long] [-D|--details] [--json] [--type <kind>|--scoped]", args[i])
 		}
 	}
 	if longForm && asJSON {

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -727,6 +727,7 @@ func scopeRootSegment(scope string) string {
 func ctxListCmd(args []string) error {
 	longForm := false
 	asJSON := false
+	details := false
 	typeFilter := ""
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -734,6 +735,8 @@ func ctxListCmd(args []string) error {
 			longForm = true
 		case "--json":
 			asJSON = true
+		case "-D", "--details":
+			details = true
 		case "--scoped":
 			// Shorthand for --type fs_scoped. The user mental model
 			// is "show me the scoped tokens" — accept the shortcut
@@ -750,11 +753,14 @@ func ctxListCmd(args []string) error {
 				typeFilter = strings.TrimPrefix(args[i], "--type=")
 				continue
 			}
-			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx ls [-l|--json] [--type <kind>|--scoped]", args[i])
+			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx ls [-l|--json|--details] [--type <kind>|--scoped]", args[i])
 		}
 	}
 	if longForm && asJSON {
 		return fmt.Errorf("-l/--long and --json are mutually exclusive")
+	}
+	if details && asJSON {
+		return fmt.Errorf("-D/--details and --json are mutually exclusive")
 	}
 	if typeFilter != "" {
 		if !isKnownPrincipalType(typeFilter) {
@@ -765,7 +771,7 @@ func ctxListCmd(args []string) error {
 	if asJSON {
 		return writeCtxListJSON(cfg, typeFilter)
 	}
-	return writeCtxListTable(cfg, longForm, typeFilter)
+	return writeCtxListTable(cfg, longForm, details, typeFilter)
 }
 
 // isKnownPrincipalType validates a --type filter value against the set
@@ -803,7 +809,7 @@ func writeCtxListJSON(cfg *Config, typeFilter string) error {
 	})
 }
 
-func writeCtxListTable(cfg *Config, longForm bool, typeFilter string) error {
+func writeCtxListTable(cfg *Config, longForm, details bool, typeFilter string) error {
 	entries := filterCtxListEntries(buildCtxListEntries(cfg), typeFilter)
 	if len(entries) == 0 {
 		if typeFilter != "" {
@@ -816,8 +822,11 @@ func writeCtxListTable(cfg *Config, longForm bool, typeFilter string) error {
 		return nil
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	// tabwriter.Writer buffers internally; errors surface at Flush().
-	_, _ = fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tTENANT_ID\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS")
+	if details {
+		_, _ = fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tTENANT_ID\tSERVER\tAGENT\tGRANT_ID\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS")
+	} else {
+		_, _ = fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS")
+	}
 	for _, e := range entries {
 		cur := " "
 		if e.Current {
@@ -828,16 +837,39 @@ func writeCtxListTable(cfg *Config, longForm bool, typeFilter string) error {
 		if e.Type == string(PrincipalOwner) {
 			perm = "rw"
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			cur,
-			e.Name,
-			e.Type,
-			e.TenantID,
-			scope,
-			perm,
-			formatExpiresAt(e.ExpiresAt),
-			e.Status,
-		)
+		if details {
+			agent := e.Agent
+			if agent == "" {
+				agent = "—"
+			}
+			grantID := e.GrantID
+			if grantID == "" {
+				grantID = "—"
+			}
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				cur,
+				e.Name,
+				e.Type,
+				e.TenantID,
+				e.Server,
+				agent,
+				grantID,
+				scope,
+				perm,
+				formatExpiresAt(e.ExpiresAt),
+				e.Status,
+			)
+		} else {
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				cur,
+				e.Name,
+				e.Type,
+				scope,
+				perm,
+				formatExpiresAt(e.ExpiresAt),
+				e.Status,
+			)
+		}
 	}
 	return w.Flush()
 }

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -842,9 +842,17 @@ func TestCtxListDisplaysTenantID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ctx ls: %v", err)
 	}
+	if strings.Contains(out, "TENANT_ID") {
+		t.Fatalf("ctx ls default output should not contain TENANT_ID, got %q", out)
+	}
+
+	out, err = captureStdoutE(t, func() error { return Ctx([]string{"ls", "--details"}) })
+	if err != nil {
+		t.Fatalf("ctx ls --details: %v", err)
+	}
 	for _, want := range []string{"TENANT_ID", "tenant-owner-1", "tenant-delegated-1"} {
 		if !strings.Contains(out, want) {
-			t.Fatalf("ctx ls output = %q, want substring %q", out, want)
+			t.Fatalf("ctx ls --details output = %q, want substring %q", out, want)
 		}
 	}
 

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -353,7 +353,8 @@ func usage(code int) {
 			"                         add delegated context\n"+
 			"  ctx fork [<new>] [--from <ctx>] [--json]\n"+
 			"                         create a copy-on-write fork context\n"+
-			"  ctx ls [-l|--json]     list contexts\n"+
+			"  ctx ls [-l|--long] [-D|--details] [--json] [--type <kind>|--scoped]\n"+
+			"                         list contexts\n"+
 			"  ctx use <name>         activate context\n"+
 			"  ctx rm <name>          delete context\n"+
 			"  fs <command>           filesystem operations\n"+

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -388,7 +388,8 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 
 		b, release, err := pool.Acquire(r.Context(), tenant)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "capability_backend_load_failed", "tenant_id", tenantID, "error", err)...)
+			errJSON(w, http.StatusInternalServerError, "backend unavailable")
 			return
 		}
 		defer release()

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -54,8 +54,8 @@ func sanitizeClientError(err error) string {
 	if err == nil {
 		return "backend unavailable"
 	}
-	msg := err.Error()
-	if strings.Contains(msg, "Error 1105") && strings.Contains(msg, "quota") {
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "error 1105") && strings.Contains(msg, "quota") {
 		return "tenant usage quota exceeded"
 	}
 	if strings.Contains(msg, "ensure tidb auto-embedding schema") ||

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -51,6 +51,9 @@ const (
 const statusClientClosedRequest = 499
 
 func sanitizeClientError(err error) string {
+	if err == nil {
+		return "backend unavailable"
+	}
 	msg := err.Error()
 	if strings.Contains(msg, "Error 1105") && strings.Contains(msg, "quota") {
 		return "tenant usage quota exceeded"

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -50,6 +50,20 @@ const (
 
 const statusClientClosedRequest = 499
 
+func sanitizeClientError(err error) string {
+	msg := err.Error()
+	if strings.Contains(msg, "Error 1105") && strings.Contains(msg, "quota") {
+		return "tenant usage quota exceeded"
+	}
+	if strings.Contains(msg, "ensure tidb auto-embedding schema") ||
+		strings.Contains(msg, "validate tidb auto-embedding schema") ||
+		strings.Contains(msg, "migrate split tables") ||
+		strings.Contains(msg, "detect legacy files table") {
+		return "tenant metadata error"
+	}
+	return "backend unavailable"
+}
+
 func ScopeFromContext(ctx context.Context) *TenantScope {
 	s, _ := ctx.Value(tenantScopeKey).(*TenantScope)
 	return s
@@ -305,7 +319,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "backend_load_failed", "tenant_id", resolved.Tenant.ID, "error", err)...)
 			metricEvent(r.Context(), "tenant_backend", "result", "load_failed")
-			errJSON(w, http.StatusInternalServerError, "backend unavailable")
+			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 			return
 		}
 		defer release()
@@ -371,7 +385,7 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 
 		b, release, err := pool.Acquire(r.Context(), tenant)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "backend unavailable")
+			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 			return
 		}
 		defer release()

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -670,3 +670,64 @@ func TestTenantStatusForkProvisioningBranchShowsMigrationMessage(t *testing.T) {
 		t.Fatalf("message = %q", out.Message)
 	}
 }
+
+func TestSanitizeClientError_NilError(t *testing.T) {
+	if got := sanitizeClientError(nil); got != "backend unavailable" {
+		t.Fatalf("nil error: got %q, want %q", got, "backend unavailable")
+	}
+}
+
+func TestSanitizeClientError_QuotaExhausted(t *testing.T) {
+	err := fmt.Errorf("open db: Error 1105 (HY000): Due to the usage quota being exhausted")
+	got := sanitizeClientError(err)
+	if got != "tenant usage quota exceeded" {
+		t.Fatalf("got %q, want %q", got, "tenant usage quota exceeded")
+	}
+}
+
+func TestSanitizeClientError_QuotaExhaustedLowerCase(t *testing.T) {
+	err := fmt.Errorf("open db: error 1105 (hy000): due to the usage quota being exhausted")
+	got := sanitizeClientError(err)
+	if got != "tenant usage quota exceeded" {
+		t.Fatalf("case-insensitive: got %q, want %q", got, "tenant usage quota exceeded")
+	}
+}
+
+func TestSanitizeClientError_QuotaExhaustedWrapped(t *testing.T) {
+	err := fmt.Errorf("open datastore: open db: Error 1105 (HY000): Due to the usage quota being exhausted, access to the cluster has been restricted. Try increasing spending limits to gain full access.")
+	got := sanitizeClientError(err)
+	if got != "tenant usage quota exceeded" {
+		t.Fatalf("wrapped: got %q, want %q", got, "tenant usage quota exceeded")
+	}
+}
+
+func TestSanitizeClientError_MetadataError(t *testing.T) {
+	tests := []string{
+		"ensure tidb auto-embedding schema: Error 1060: Duplicate column name 'foo'",
+		"validate tidb auto-embedding schema: column mismatch",
+		"migrate split tables: Error 1146: Table doesn't exist",
+		"detect legacy files table: Error 1045: Access denied",
+	}
+	for _, tc := range tests {
+		err := fmt.Errorf("%s", tc)
+		got := sanitizeClientError(err)
+		if got != "tenant metadata error" {
+			t.Fatalf("input=%q: got %q, want %q", tc, got, "tenant metadata error")
+		}
+	}
+}
+
+func TestSanitizeClientError_Fallback(t *testing.T) {
+	tests := []string{
+		"dial tcp: connection refused",
+		"open db: Error 1045: Access denied for user",
+		"some random error",
+	}
+	for _, tc := range tests {
+		err := fmt.Errorf("%s", tc)
+		got := sanitizeClientError(err)
+		if got != "backend unavailable" {
+			t.Fatalf("input=%q: got %q, want %q", tc, got, "backend unavailable")
+		}
+	}
+}

--- a/pkg/server/fs_layer.go
+++ b/pkg/server/fs_layer.go
@@ -18,6 +18,7 @@ import (
 	backendpkg "github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/journal"
+	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/pathutil"
 )
 
@@ -171,12 +172,12 @@ func (s *Server) handleFSLayerCheckpointObject(w http.ResponseWriter, r *http.Re
 	}
 	checkpoint, err := store.GetFSLayerCheckpoint(r.Context(), checkpointID)
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	layer, err := store.GetFSLayer(r.Context(), checkpoint.LayerID)
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	if !authorizeFS(w, r, FSOpRead, layer.BaseRootPath) {
@@ -218,12 +219,12 @@ func (s *Server) handleFSLayerCreate(w http.ResponseWriter, r *http.Request, sto
 		ActorID:        actorID,
 	}
 	if err := store.CreateFSLayer(r.Context(), &layer); err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	created, err := store.GetFSLayer(r.Context(), layerID)
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -233,7 +234,7 @@ func (s *Server) handleFSLayerCreate(w http.ResponseWriter, r *http.Request, sto
 func (s *Server) handleFSLayerList(w http.ResponseWriter, r *http.Request, store *datastore.Store) {
 	layers, err := store.ListFSLayers(r.Context())
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	out := make([]fsLayerResponse, 0, len(layers))
@@ -295,7 +296,7 @@ func (s *Server) handleFSLayerObject(w http.ResponseWriter, r *http.Request, b *
 	}
 	layer, err := store.ResolveFSLayerRef(r.Context(), layerRef)
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	layerID := layer.LayerID
@@ -335,7 +336,7 @@ func (s *Server) handleFSLayerObject(w http.ResponseWriter, r *http.Request, b *
 			entries, err = store.ListFSLayerEntries(r.Context(), layerID)
 		}
 		if err != nil {
-			writeFSLayerStoreError(w, err)
+			writeFSLayerStoreError(w, r, err)
 			return
 		}
 		out := make([]fsLayerEntryResponse, 0, len(entries))
@@ -396,7 +397,7 @@ func (s *Server) handleFSLayerObject(w http.ResponseWriter, r *http.Request, b *
 			return
 		}
 		if err := store.RollbackFSLayer(r.Context(), layerID); err != nil {
-			writeFSLayerStoreError(w, err)
+			writeFSLayerStoreError(w, r, err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -443,7 +444,7 @@ func (s *Server) handleFSLayerObjectRead(w http.ResponseWriter, r *http.Request,
 		entry, err = store.GetFSLayerEntry(r.Context(), layer.LayerID, path)
 	}
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	if entry.Op != datastore.FSLayerEntryOpUpsert || entry.Kind != datastore.FSLayerEntryKindFile {
@@ -452,6 +453,7 @@ func (s *Server) handleFSLayerObjectRead(w http.ResponseWriter, r *http.Request,
 	}
 	rc, err := b.OpenFSLayerEntryData(r.Context(), entry)
 	if err != nil {
+		logger.Error(r.Context(), "fs_layer_object_read_failed", eventFields(r.Context(), "fs_layer_object_read_failed", "path", entry.Path, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
@@ -517,6 +519,7 @@ func (s *Server) handleFSLayerObjectUpload(w http.ResponseWriter, r *http.Reques
 	body := http.MaxBytesReader(w, r.Body, s.maxUploadBytes)
 	entry, err := b.PutFSLayerObject(r.Context(), layer.LayerID, prepared.Path, body, size)
 	if err != nil {
+		logger.Error(r.Context(), "fs_layer_object_upload_failed", eventFields(r.Context(), "fs_layer_object_upload_failed", "path", prepared.Path, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
@@ -528,12 +531,12 @@ func (s *Server) handleFSLayerObjectUpload(w http.ResponseWriter, r *http.Reques
 	entry.BaseRevision = prepared.BaseRevision
 	entry.BaseInodeID = prepared.BaseInodeID
 	if err := store.UpsertFSLayerEntry(r.Context(), entry); err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	stored, err := store.GetFSLayerEntry(r.Context(), layer.LayerID, entry.Path)
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -544,7 +547,7 @@ func (s *Server) handleFSLayerEvents(w http.ResponseWriter, r *http.Request, sto
 	since := parseFSLayerInt64Query(r, "since")
 	events, err := store.ListFSLayerEvents(r.Context(), layer.LayerID, since, 1000)
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -602,12 +605,12 @@ func (s *Server) handleFSLayerEntryUpsert(w http.ResponseWriter, r *http.Request
 	}
 	fillFSLayerBaseSnapshot(r.Context(), b, &entry)
 	if err := store.UpsertFSLayerEntry(r.Context(), &entry); err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	stored, err := store.GetFSLayerEntry(r.Context(), layer.LayerID, entry.Path)
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -671,7 +674,7 @@ func (s *Server) handleFSLayerEntryGet(w http.ResponseWriter, r *http.Request, s
 		entry, err = store.GetFSLayerEntry(r.Context(), layer.LayerID, path)
 	}
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -692,13 +695,13 @@ func (s *Server) handleFSLayerCommit(w http.ResponseWriter, r *http.Request, b *
 		return
 	}
 	if err := store.BeginFSLayerCommit(r.Context(), layer.LayerID); err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	entries, err := store.ListFSLayerEntryLog(r.Context(), layer.LayerID)
 	if err != nil {
 		_ = store.SetFSLayerStateIf(r.Context(), layer.LayerID, []datastore.FSLayerState{datastore.FSLayerStateCommitting}, datastore.FSLayerStateConflicted)
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	if conflicts := validateFSLayerCommitScope(layer, entries); len(conflicts) > 0 {
@@ -727,6 +730,7 @@ func (s *Server) handleFSLayerCommit(w http.ResponseWriter, r *http.Request, b *
 	snapshots := snapshotFSLayerCommit(r.Context(), b, entries)
 	if err := validateFSLayerCommitSnapshots(snapshots); err != nil {
 		_ = store.SetFSLayerStateIf(r.Context(), layer.LayerID, []datastore.FSLayerState{datastore.FSLayerStateCommitting}, datastore.FSLayerStateConflicted)
+		logger.Error(r.Context(), "fs_layer_commit_validate_failed", eventFields(r.Context(), "fs_layer_commit_validate_failed", "layer_id", layer.LayerID, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
@@ -782,12 +786,12 @@ func (s *Server) handleFSLayerCheckpoint(w http.ResponseWriter, r *http.Request,
 		Label:        strings.TrimSpace(req.Label),
 	}
 	if err := store.CreateFSLayerCheckpoint(r.Context(), &checkpoint); err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	stored, err := store.GetFSLayerCheckpoint(r.Context(), checkpointID)
 	if err != nil {
-		writeFSLayerStoreError(w, err)
+		writeFSLayerStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -1661,7 +1665,7 @@ func applyFSLayerEntryMode(ctx context.Context, b *backendpkg.Dat9Backend, path 
 	return nil
 }
 
-func writeFSLayerStoreError(w http.ResponseWriter, err error) {
+func writeFSLayerStoreError(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.Is(err, datastore.ErrNotFound) {
 		errJSON(w, http.StatusNotFound, "not found")
 		return
@@ -1674,6 +1678,7 @@ func writeFSLayerStoreError(w http.ResponseWriter, err error) {
 		errJSON(w, http.StatusConflict, err.Error())
 		return
 	}
+	logger.Error(r.Context(), "fs_layer_store_error", eventFields(r.Context(), "fs_layer_store_error", "error", err)...)
 	errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 }
 

--- a/pkg/server/fs_layer.go
+++ b/pkg/server/fs_layer.go
@@ -743,10 +743,12 @@ func (s *Server) handleFSLayerCommit(w http.ResponseWriter, r *http.Request, b *
 			rollbackErr := rollbackFSLayerCommit(rollbackCtx, b, filterFSLayerSnapshotsForEntries(snapshots, entries[:i]))
 			_ = store.SetFSLayerStateIf(rollbackCtx, layer.LayerID, []datastore.FSLayerState{datastore.FSLayerStateCommitting}, datastore.FSLayerStateConflicted)
 			if rollbackErr != nil {
-				errJSON(w, http.StatusInternalServerError, fmt.Sprintf("apply fs layer entry %s: %v; rollback failed: %v", entries[i].Path, err, rollbackErr))
+				logger.Error(r.Context(), "fs_layer_commit_apply_failed", eventFields(r.Context(), "fs_layer_commit_apply_failed", "path", entries[i].Path, "error", err, "rollback_error", rollbackErr)...)
+				errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 				return
 			}
-			errJSON(w, http.StatusInternalServerError, fmt.Sprintf("apply fs layer entry %s: %v", entries[i].Path, err))
+			logger.Error(r.Context(), "fs_layer_commit_apply_failed", eventFields(r.Context(), "fs_layer_commit_apply_failed", "path", entries[i].Path, "error", err)...)
+			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 			return
 		}
 		markFSLayerEntryTouched(touchedPaths, &entries[i])
@@ -755,10 +757,12 @@ func (s *Server) handleFSLayerCommit(w http.ResponseWriter, r *http.Request, b *
 		rollbackErr := rollbackFSLayerCommit(rollbackCtx, b, snapshots)
 		_ = store.SetFSLayerStateIf(rollbackCtx, layer.LayerID, []datastore.FSLayerState{datastore.FSLayerStateCommitting}, datastore.FSLayerStateConflicted)
 		if rollbackErr != nil {
-			errJSON(w, http.StatusInternalServerError, fmt.Sprintf("finalize fs layer commit %s: %v; rollback failed: %v", layer.LayerID, err, rollbackErr))
+			logger.Error(r.Context(), "fs_layer_commit_finalize_failed", eventFields(r.Context(), "fs_layer_commit_finalize_failed", "layer_id", layer.LayerID, "error", err, "rollback_error", rollbackErr)...)
+			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, fmt.Sprintf("finalize fs layer commit %s: %v", layer.LayerID, err))
+		logger.Error(r.Context(), "fs_layer_commit_finalize_failed", eventFields(r.Context(), "fs_layer_commit_finalize_failed", "layer_id", layer.LayerID, "error", err)...)
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/fs_layer.go
+++ b/pkg/server/fs_layer.go
@@ -452,7 +452,7 @@ func (s *Server) handleFSLayerObjectRead(w http.ResponseWriter, r *http.Request,
 	}
 	rc, err := b.OpenFSLayerEntryData(r.Context(), entry)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	defer func() { _ = rc.Close() }()
@@ -517,7 +517,7 @@ func (s *Server) handleFSLayerObjectUpload(w http.ResponseWriter, r *http.Reques
 	body := http.MaxBytesReader(w, r.Body, s.maxUploadBytes)
 	entry, err := b.PutFSLayerObject(r.Context(), layer.LayerID, prepared.Path, body, size)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	entry.LayerID = layer.LayerID
@@ -727,7 +727,7 @@ func (s *Server) handleFSLayerCommit(w http.ResponseWriter, r *http.Request, b *
 	snapshots := snapshotFSLayerCommit(r.Context(), b, entries)
 	if err := validateFSLayerCommitSnapshots(snapshots); err != nil {
 		_ = store.SetFSLayerStateIf(r.Context(), layer.LayerID, []datastore.FSLayerState{datastore.FSLayerStateCommitting}, datastore.FSLayerStateConflicted)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	rollbackCtx, rollbackCancel := context.WithTimeout(context.WithoutCancel(r.Context()), fsLayerRollbackTimeout)
@@ -1674,7 +1674,7 @@ func writeFSLayerStoreError(w http.ResponseWriter, err error) {
 		errJSON(w, http.StatusConflict, err.Error())
 		return
 	}
-	errJSON(w, http.StatusInternalServerError, err.Error())
+	errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 }
 
 func toFSLayerResponse(layer *datastore.FSLayer) fsLayerResponse {

--- a/pkg/server/git_workspace.go
+++ b/pkg/server/git_workspace.go
@@ -832,7 +832,7 @@ func writeGitWorkspaceStoreError(w http.ResponseWriter, err error) {
 		errJSON(w, http.StatusNotFound, "not found")
 		return
 	}
-	errJSON(w, http.StatusInternalServerError, err.Error())
+	errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 }
 
 func toGitWorkspaceResponse(ws *datastore.GitWorkspace) gitWorkspaceResponse {

--- a/pkg/server/git_workspace.go
+++ b/pkg/server/git_workspace.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/gitcache"
+	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/pathutil"
 	"github.com/mem9-ai/dat9/pkg/tenant/token"
 )
@@ -240,7 +241,7 @@ func (s *Server) handleGitWorkspaceUpsert(w http.ResponseWriter, r *http.Request
 				errJSON(w, http.StatusBadRequest, "common_workspace_id does not reference an active workspace")
 				return
 			}
-			writeGitWorkspaceStoreError(w, err)
+			writeGitWorkspaceStoreError(w, r, err)
 			return
 		}
 		if common.Status != datastore.GitWorkspaceStatusLive || common.Kind == datastore.GitWorkspaceKindLinked {
@@ -262,7 +263,7 @@ func (s *Server) handleGitWorkspaceUpsert(w http.ResponseWriter, r *http.Request
 		}
 		workspaceID = existing.WorkspaceID
 	} else if !errors.Is(err, datastore.ErrNotFound) {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	ws := datastore.GitWorkspace{
@@ -287,12 +288,12 @@ func (s *Server) handleGitWorkspaceUpsert(w http.ResponseWriter, r *http.Request
 		ws.Mode = datastore.GitWorkspaceModeFast
 	}
 	if err := store.UpsertGitWorkspace(r.Context(), ws); err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	out, err := store.GetGitWorkspaceByRoot(r.Context(), root)
 	if err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -312,7 +313,7 @@ func (s *Server) handleGitWorkspaceGetByRoot(w http.ResponseWriter, r *http.Requ
 	}
 	ws, err := store.GetGitWorkspaceByRoot(r.Context(), root)
 	if err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -322,7 +323,7 @@ func (s *Server) handleGitWorkspaceGetByRoot(w http.ResponseWriter, r *http.Requ
 func (s *Server) handleGitWorkspaceList(w http.ResponseWriter, r *http.Request, store *datastore.Store) {
 	workspaces, err := store.ListGitWorkspaces(r.Context())
 	if err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	out := make([]gitWorkspaceResponse, 0, len(workspaces))
@@ -335,7 +336,7 @@ func (s *Server) handleGitWorkspaceList(w http.ResponseWriter, r *http.Request, 
 
 func (s *Server) handleGitWorkspaceDelete(w http.ResponseWriter, r *http.Request, store *datastore.Store, workspaceID string) {
 	if err := store.DeleteGitWorkspace(r.Context(), workspaceID); err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -366,7 +367,7 @@ func (s *Server) handleGitWorkspaceObject(w http.ResponseWriter, r *http.Request
 		}
 		ws, err := store.GetGitWorkspace(r.Context(), workspaceID)
 		if err != nil {
-			writeGitWorkspaceStoreError(w, err)
+			writeGitWorkspaceStoreError(w, r, err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -394,7 +395,7 @@ func (s *Server) handleGitWorkspaceObject(w http.ResponseWriter, r *http.Request
 		case http.MethodGet:
 			packs, err := store.ListGitObjectPacks(r.Context(), workspaceID)
 			if err != nil {
-				writeGitWorkspaceStoreError(w, err)
+				writeGitWorkspaceStoreError(w, r, err)
 				return
 			}
 			out := make([]gitObjectPackResponse, 0, len(packs))
@@ -428,7 +429,7 @@ func (s *Server) handleGitWorkspaceObject(w http.ResponseWriter, r *http.Request
 			}
 			entries, err := store.ListGitOverlayEntries(r.Context(), workspaceID)
 			if err != nil {
-				writeGitWorkspaceStoreError(w, err)
+				writeGitWorkspaceStoreError(w, r, err)
 				return
 			}
 			out := make([]gitOverlayEntryResponse, 0, len(entries))
@@ -472,12 +473,12 @@ func (s *Server) handleGitObjectPackUpsert(w http.ResponseWriter, r *http.Reques
 		ContentBlob:    req.Content,
 	}
 	if err := store.UpsertGitObjectPack(r.Context(), pack); err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	stored, err := store.GetGitObjectPack(r.Context(), workspaceID, packID)
 	if err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -498,7 +499,7 @@ func (s *Server) handleGitObjectPackGet(w http.ResponseWriter, r *http.Request, 
 	}
 	pack, err := store.GetGitObjectPack(r.Context(), workspaceID, strings.ToLower(packID))
 	if err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -522,7 +523,7 @@ func (s *Server) handleGitTreeReplace(w http.ResponseWriter, r *http.Request, st
 		return
 	}
 	if err := store.ReplaceGitTreeNodes(r.Context(), workspaceID, req.CommitSHA, nodes); err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -537,7 +538,7 @@ func (s *Server) handleGitTreeList(w http.ResponseWriter, r *http.Request, store
 	}
 	nodes, err := store.ListGitTreeNodes(r.Context(), workspaceID, commitSHA)
 	if err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	out := make([]gitTreeNodeResponse, 0, len(nodes))
@@ -573,12 +574,12 @@ func (s *Server) handleGitStateUpsert(w http.ResponseWriter, r *http.Request, st
 		SizeBytes:        req.SizeBytes,
 		ContentBlob:      req.Content,
 	}); err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	state, err := store.GetGitState(r.Context(), workspaceID)
 	if err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -635,12 +636,12 @@ func (s *Server) handleGitOverlayUpsert(w http.ResponseWriter, r *http.Request, 
 		entry.SizeBytes = int64(len(entry.ContentBlob))
 	}
 	if err := store.UpsertGitOverlayEntry(r.Context(), entry); err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	stored, err := store.GetGitOverlayEntry(r.Context(), workspaceID, relPath)
 	if err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -655,7 +656,7 @@ func (s *Server) handleGitOverlayGet(w http.ResponseWriter, r *http.Request, sto
 	}
 	entry, err := store.GetGitOverlayEntry(r.Context(), workspaceID, relPath)
 	if err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -665,7 +666,7 @@ func (s *Server) handleGitOverlayGet(w http.ResponseWriter, r *http.Request, sto
 func (s *Server) handleGitStateGet(w http.ResponseWriter, r *http.Request, store *datastore.Store, workspaceID string) {
 	state, err := store.GetGitState(r.Context(), workspaceID)
 	if err != nil {
-		writeGitWorkspaceStoreError(w, err)
+		writeGitWorkspaceStoreError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -827,11 +828,12 @@ func validateGitMetadataRelativePath(raw string) error {
 	return nil
 }
 
-func writeGitWorkspaceStoreError(w http.ResponseWriter, err error) {
+func writeGitWorkspaceStoreError(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.Is(err, datastore.ErrNotFound) {
 		errJSON(w, http.StatusNotFound, "not found")
 		return
 	}
+	logger.Error(r.Context(), "git_workspace_store_error", eventFields(r.Context(), "git_workspace_store_error", "error", err)...)
 	errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1141,7 +1141,7 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "read_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "fs_read", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 
@@ -1202,7 +1202,7 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "list_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "userdb_query", "api", "list", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	metricEvent(r.Context(), "userdb_query", "api", "list", "result", "ok")
@@ -1293,7 +1293,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "stat_metadata_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 
@@ -1307,7 +1307,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 	nlink, err := nodeLinkCount(r.Context(), b, nf)
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "stat_metadata_refcount_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	if nf.File != nil {
@@ -1327,7 +1327,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 		tags, err = b.Store().GetFileTags(r.Context(), nf.File.FileID)
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "stat_metadata_load_tags_failed", "path", path, "error", err)...)
-			errJSON(w, http.StatusInternalServerError, err.Error())
+			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 			return
 		}
 	} else {
@@ -2139,7 +2139,7 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path strin
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "delete_failed", "path", path, "recursive", recursive, "kind", kind, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "delete_ok", "path", path, "recursive", recursive, "kind", kind)...)
@@ -2179,7 +2179,7 @@ func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath stri
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "copy_failed", "src_path", srcPath, "dst_path", dstPath, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "copy_ok", "src_path", srcPath, "dst_path", dstPath)...)
@@ -2223,7 +2223,7 @@ func (s *Server) handleHardlink(w http.ResponseWriter, r *http.Request, dstPath 
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "hardlink_failed", "src_path", srcPath, "dst_path", dstPath, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "hardlink_ok", "src_path", srcPath, "dst_path", dstPath)...)
@@ -2267,7 +2267,7 @@ func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath st
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "rename_failed", "old_path", oldPath, "new_path", newPath, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "rename_ok", "old_path", oldPath, "new_path", newPath)...)
@@ -2301,7 +2301,7 @@ func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "mkdir_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "mkdir_ok", "path", path)...)
@@ -2343,7 +2343,7 @@ func (s *Server) handleChmod(w http.ResponseWriter, r *http.Request, path string
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "chmod_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "chmod_ok", "path", path)...)
@@ -2370,7 +2370,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request, path strin
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "create_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "create_ok", "path", path)...)
@@ -2432,7 +2432,7 @@ func (s *Server) handleSymlink(w http.ResponseWriter, r *http.Request, path stri
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "symlink_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "symlink_ok", "path", path)...)
@@ -2484,7 +2484,7 @@ func (s *Server) handleUploads(w http.ResponseWriter, r *http.Request) {
 		if errJSONInvalidRootDentry(w, err) {
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	metricEvent(r.Context(), "metadb_query", "api", "uploads_list", "result", "ok")
@@ -3918,14 +3918,14 @@ func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string)
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "grep_failed", "path", path, "query_len", len(query), "limit", limit, "error", err)...)
 		metricEvent(r.Context(), "userdb_query", "api", "grep", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	if layerRef := strings.TrimSpace(r.URL.Query().Get("layer")); layerRef != "" {
 		results, err = overlayFSLayerGrep(r.Context(), b, layerRef, query, path, limit, results)
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "grep_layer_failed", "path", path, "query_len", len(query), "limit", limit, "layer", layerRef, "error", err)...)
-			errJSON(w, http.StatusInternalServerError, err.Error())
+			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 			return
 		}
 	}
@@ -4002,14 +4002,14 @@ func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string)
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "find_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "userdb_query", "api", "find", "result", "error")
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	if layerRef := strings.TrimSpace(q.Get("layer")); layerRef != "" {
 		results, err = overlayFSLayerFind(r.Context(), b, layerRef, f, results)
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "find_layer_failed", "path", path, "layer", layerRef, "error", err)...)
-			errJSON(w, http.StatusInternalServerError, err.Error())
+			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 			return
 		}
 	}

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -87,6 +87,7 @@ func (s *Server) handleVaultSecrets(w http.ResponseWriter, r *http.Request, sub 
 			errJSON(w, http.StatusNotImplemented, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "vault_secrets_store_failed", eventFields(r.Context(), "vault_secrets_store_failed", "error", err)...)
 		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
@@ -419,6 +420,7 @@ func (s *Server) handleVaultTokens(w http.ResponseWriter, r *http.Request, sub s
 			errJSON(w, http.StatusNotImplemented, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "vault_tokens_store_failed", eventFields(r.Context(), "vault_tokens_store_failed", "error", err)...)
 		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
@@ -560,6 +562,7 @@ func (s *Server) handleVaultGrants(w http.ResponseWriter, r *http.Request, sub s
 			errJSON(w, http.StatusNotImplemented, err.Error())
 			return
 		}
+		logger.Error(r.Context(), "vault_grants_store_failed", eventFields(r.Context(), "vault_grants_store_failed", "error", err)...)
 		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
@@ -737,6 +740,7 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		result = "error"
+		logger.Error(r.Context(), "vault_audit_store_failed", eventFields(r.Context(), "vault_audit_store_failed", "error", err)...)
 		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -87,7 +87,7 @@ func (s *Server) handleVaultSecrets(w http.ResponseWriter, r *http.Request, sub 
 			errJSON(w, http.StatusNotImplemented, err.Error())
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	scope := ScopeFromContext(r.Context())
@@ -419,7 +419,7 @@ func (s *Server) handleVaultTokens(w http.ResponseWriter, r *http.Request, sub s
 			errJSON(w, http.StatusNotImplemented, err.Error())
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	scope := ScopeFromContext(r.Context())
@@ -560,7 +560,7 @@ func (s *Server) handleVaultGrants(w http.ResponseWriter, r *http.Request, sub s
 			errJSON(w, http.StatusNotImplemented, err.Error())
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	scope := ScopeFromContext(r.Context())
@@ -737,7 +737,7 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
 	scope := ScopeFromContext(r.Context())


### PR DESCRIPTION
## Summary

### Client error sanitization
Previously, backend errors (TiDB/MySQL error codes, internal prefixes like `open datastore: open db:`) leaked directly to CLI users. This PR introduces `sanitizeClientError` to map errors to product-level messages:

| Condition | Client sees |
|---|---|
| TiDB usage quota exhausted | `tenant usage quota exceeded` |
| Metadata schema mismatch / migration failure | `tenant metadata error` |
| All other backend errors | `backend unavailable` |

Applied to all HTTP 500 error paths across `auth.go`, `server.go`, `fs_layer.go`, `vault.go`, `git_workspace.go` (29 call sites). Full errors remain in server logs.

### `ctx ls --details` flag
Added `-D`/`--details` flag to `drive9 ctx ls`:

- **Default view** keeps existing concise columns
- **`--details`** adds SERVER, AGENT, GRANT_ID, TENANT_ID for full context info
- TENANT_ID moved from default to `--details` view only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--details` to `drive9 ctx ls` to show an expanded table with extra metadata columns (tenant id, server, agent, grant id) and improved per-row placeholders.
* **Improvements**
  * Internal server error responses are now sanitized into more user-friendly messages across filesystem, auth, git workspace, and vault endpoints.
  * Added structured server-side error logging for failed filesystem/vault operations.
  * Updated `ctx ls` help text; `--details` is mutually exclusive with `--json`.
* **Tests**
  * Updated context list tests and added coverage for error message sanitization mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->