### PR TITLE
fix: patch upload respects presigned checksum headers

### DIFF
--- a/clients/drive9-js/src/patch.ts
+++ b/clients/drive9-js/src/patch.ts
@@ -63,14 +63,20 @@ async function uploadPatchPart(client: Client, part: PatchPartURL, readPart: Rea
     origData = new Uint8Array(await resp.arrayBuffer());
   }
   const data = readPart(part.number, part.size, origData);
-  const checksum = await sha256Base64(data);
-  const headers: Record<string, string> = { "x-amz-checksum-sha256": checksum };
+  const headers: Record<string, string> = {};
+  let shouldSendChecksum = false;
   if (part.headers) {
     for (const [k, v] of Object.entries(part.headers)) {
       if (typeof v === "string" && k.toLowerCase() !== "host") {
         headers[k] = v;
+        if (k.toLowerCase() === "x-amz-checksum-sha256") {
+          shouldSendChecksum = true;
+        }
       }
     }
+  }
+  if (shouldSendChecksum) {
+    headers["x-amz-checksum-sha256"] = await sha256Base64(data);
   }
   const resp = await fetch(part.url, { method: "PUT", headers, body: bodyInit(data) });
   await checkError(resp);
@@ -85,4 +91,3 @@ async function sha256Base64(data: Uint8Array): Promise<string> {
   const hash = await crypto.subtle.digest("SHA-256", bufferSource(data));
   return bytesToBase64(new Uint8Array(hash));
 }
-

--- a/clients/drive9-js/tests/transfer.test.ts
+++ b/clients/drive9-js/tests/transfer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { Client } from "../src/index.js";
 import { setupServer } from "msw/node";
 import { http, HttpResponse } from "msw";
+import { createHash } from "node:crypto";
 
 const server = setupServer();
 server.listen({ onUnhandledRequest: "error" });
@@ -71,5 +72,49 @@ describe("Transfer", () => {
       offset += c.length;
     }
     expect(new TextDecoder().decode(all)).toBe("world");
+  });
+
+  it("patchFile only sends checksum when it is presigned", async () => {
+    let firstChecksum: string | null = null;
+    let secondChecksum: string | null = null;
+    server.use(
+      http.patch("http://localhost:9009/v1/fs/file.bin", () => {
+        return HttpResponse.json(
+          {
+            upload_id: "patch-js",
+            part_size: 8,
+            upload_parts: [
+              { number: 1, url: "http://localhost:9009/patch/1", size: 8, headers: {} },
+              {
+                number: 2,
+                url: "http://localhost:9009/patch/2",
+                size: 8,
+                headers: { "x-amz-checksum-sha256": "placeholder" },
+              },
+            ],
+            copied_parts: [],
+          },
+          { status: 202 }
+        );
+      }),
+      http.put("http://localhost:9009/patch/1", ({ request }) => {
+        firstChecksum = request.headers.get("x-amz-checksum-sha256");
+        return HttpResponse.text("ok");
+      }),
+      http.put("http://localhost:9009/patch/2", ({ request }) => {
+        secondChecksum = request.headers.get("x-amz-checksum-sha256");
+        return HttpResponse.text("ok");
+      }),
+      http.post("http://localhost:9009/v1/uploads/patch-js/complete", () => {
+        return HttpResponse.text("ok");
+      })
+    );
+
+    const client = new Client("http://localhost:9009", "test-key");
+    await client.patchFile("/file.bin", 16, [1, 2], (part) => new TextEncoder().encode(`part-${part}`), undefined, 8);
+
+    const expectedSecond = createHash("sha256").update("part-2").digest("base64");
+    expect(firstChecksum).toBeNull();
+    expect(secondChecksum).toBe(expectedSecond);
   });
 });

--- a/clients/drive9-kotlin/lib/src/main/kotlin/com/drive9/mobile/Drive9.kt
+++ b/clients/drive9-kotlin/lib/src/main/kotlin/com/drive9/mobile/Drive9.kt
@@ -676,7 +676,9 @@ public class Drive9Client(
 
     private fun uploadPatchPart(part: Drive9PatchPartUrl, data: ByteArray) {
         val headers = part.headers.toMutableMap()
-        headers["x-amz-checksum-sha256"] = sha256Base64(data)
+        if (headers.keys.any { it.equals("x-amz-checksum-sha256", ignoreCase = true) }) {
+            headers["x-amz-checksum-sha256"] = sha256Base64(data)
+        }
         val result = rawPut(part.url, headers, data, retryOnForbidden = false)
         if (result.status !in 200..299) throw errorFrom(result.status, result.body)
     }

--- a/clients/drive9-kotlin/lib/src/test/kotlin/com/drive9/mobile/Drive9Test.kt
+++ b/clients/drive9-kotlin/lib/src/test/kotlin/com/drive9/mobile/Drive9Test.kt
@@ -6,12 +6,14 @@ import com.sun.net.httpserver.HttpServer
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import java.io.ByteArrayOutputStream
+import java.security.MessageDigest
 import java.nio.file.Files
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.exists
 import kotlin.io.path.readBytes
 import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
+import java.util.Base64
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -467,7 +469,7 @@ class Drive9Test {
             ex.close()
         }
         route("PUT", "/patch-part") { ex ->
-            assertTrue(ex.requestHeaders.getFirst("x-amz-checksum-sha256") != null)
+            assertEquals(null, ex.requestHeaders.getFirst("x-amz-checksum-sha256"))
             patched += ex.requestBody.readBytes()
             ex.sendResponseHeaders(200, -1)
             ex.close()
@@ -483,6 +485,41 @@ class Drive9Test {
         try {
             client.patchFileParts(local.toString(), "/r", listOf(1), 6, 4)
             assertContentEquals("abcd".toByteArray(), patched.single())
+        } finally {
+            local.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun patchFilePartsSendsPresignedChecksumHeader() = runBlocking {
+        val patched = mutableListOf<ByteArray>()
+        route("PATCH", "/v1/fs/r") { ex ->
+            ex.requestBody.readBytes()
+            val response = """{"upload_id":"p1","part_size":8,"upload_parts":[{"number":1,"url":"$baseUrl/patch-part-checksum","size":8,"headers":{"x-amz-checksum-sha256":"placeholder"}}],"copied_parts":[]}"""
+                .toByteArray()
+            ex.responseHeaders.add("Content-Type", "application/json")
+            ex.sendResponseHeaders(200, response.size.toLong())
+            ex.responseBody.write(response)
+            ex.close()
+        }
+        route("PUT", "/patch-part-checksum") { ex ->
+            val expected = Base64.getEncoder().encodeToString(MessageDigest.getInstance("SHA-256").digest("testdata".toByteArray()))
+            assertEquals(expected, ex.requestHeaders.getFirst("x-amz-checksum-sha256"))
+            patched += ex.requestBody.readBytes()
+            ex.sendResponseHeaders(200, -1)
+            ex.close()
+        }
+        route("POST", "/v1/uploads/p1/complete") { ex ->
+            ex.sendResponseHeaders(200, -1)
+            ex.close()
+        }
+
+        val local = Files.createTempFile("drive9-kotlin-patch-checksum", ".bin")
+        Files.write(local, "testdata".toByteArray())
+        val client = Drive9Client(baseUrl, "k")
+        try {
+            client.patchFileParts(local.toString(), "/r", listOf(1), 8, 8)
+            assertContentEquals("testdata".toByteArray(), patched.single())
         } finally {
             local.deleteIfExists()
         }

--- a/clients/drive9-py/drive9/patch.py
+++ b/clients/drive9-py/drive9/patch.py
@@ -125,14 +125,20 @@ class PatchMixin:
             orig_data = resp.content
 
         data = read_part(part.number, part.size, orig_data)
-        checksum = base64.b64encode(hashlib.sha256(data).digest()).decode("ascii")
 
-        headers = {"x-amz-checksum-sha256": checksum}
+        headers = {}
+        should_send_checksum = False
         if part.headers:
             for k, v in part.headers.items():
                 if k.lower() == "host":
                     continue
                 headers[k] = v
+                if k.lower() == "x-amz-checksum-sha256":
+                    should_send_checksum = True
+        if should_send_checksum:
+            headers["x-amz-checksum-sha256"] = base64.b64encode(
+                hashlib.sha256(data).digest()
+            ).decode("ascii")
 
         resp = self.session.put(part.url, data=data, headers=headers)
         if resp.status_code >= 300:

--- a/clients/drive9-py/tests/test_client.py
+++ b/clients/drive9-py/tests/test_client.py
@@ -1,5 +1,7 @@
 """Tests for the Drive9 Python SDK."""
 
+import base64
+import hashlib
 import json
 from io import BytesIO
 from unittest import mock
@@ -287,6 +289,47 @@ def test_patch_file(client):
         return b"a" * part_size
 
     client.patch_file("/file.bin", 1024, [1], read_part)
+    assert "x-amz-checksum-sha256" not in responses.calls[1].request.headers
+
+
+@responses.activate
+def test_patch_file_sends_presigned_checksum(client):
+    plan = {
+        "upload_id": "puid",
+        "part_size": 8,
+        "upload_parts": [
+            {
+                "number": 1,
+                "url": "http://s3/patch1",
+                "size": 8,
+                "headers": {"x-amz-checksum-sha256": "placeholder"},
+            }
+        ],
+        "copied_parts": [],
+    }
+    responses.add(
+        responses.PATCH,
+        f"{BASE_URL}/v1/fs/file.bin",
+        json=plan,
+        status=202,
+    )
+    responses.add(
+        responses.PUT,
+        "http://s3/patch1",
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/v1/uploads/puid/complete",
+        status=200,
+    )
+
+    def read_part(part_number, part_size, orig_data):
+        return b"testdata"
+
+    client.patch_file("/file.bin", 8, [1], read_part)
+    expected = base64.b64encode(hashlib.sha256(b"testdata").digest()).decode("ascii")
+    assert responses.calls[1].request.headers["x-amz-checksum-sha256"] == expected
 
 
 

--- a/clients/drive9-rs/src/patch.rs
+++ b/clients/drive9-rs/src/patch.rs
@@ -106,28 +106,33 @@ impl Client {
         };
 
         let data = read_part(part.number, part.size, orig_data.as_deref())?;
-        let checksum = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            Sha256::digest(&data),
-        );
 
         let mut headers = HeaderMap::new();
-        headers.insert(
-            "x-amz-checksum-sha256",
-            reqwest::header::HeaderValue::from_str(&checksum).unwrap(),
-        );
+        let mut should_send_checksum = false;
         if let Some(ref ph) = part.headers {
             for (k, v) in ph {
                 if k.eq_ignore_ascii_case("host") {
                     continue;
                 }
                 if let Ok(hv) = reqwest::header::HeaderValue::from_str(v.as_str().unwrap_or("")) {
-                    let name = HeaderName::from_bytes(k.as_bytes()).map_err(|_| {
-                        Drive9Error::Other(format!("invalid header name: {}", k))
-                    })?;
+                    let name = HeaderName::from_bytes(k.as_bytes())
+                        .map_err(|_| Drive9Error::Other(format!("invalid header name: {}", k)))?;
                     headers.insert(name, hv);
+                    if k.eq_ignore_ascii_case("x-amz-checksum-sha256") {
+                        should_send_checksum = true;
+                    }
                 }
             }
+        }
+        if should_send_checksum {
+            let checksum = base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                Sha256::digest(&data),
+            );
+            headers.insert(
+                "x-amz-checksum-sha256",
+                reqwest::header::HeaderValue::from_str(&checksum).unwrap(),
+            );
         }
         let resp = self
             .http

--- a/clients/drive9-rs/tests/test_client.rs
+++ b/clients/drive9-rs/tests/test_client.rs
@@ -1,4 +1,7 @@
+use base64::Engine;
 use drive9::{Client, Drive9Error};
+use mockito::Matcher;
+use sha2::{Digest, Sha256};
 
 #[tokio::test]
 async fn test_write_and_read() {
@@ -68,7 +71,11 @@ async fn test_conflict_error() {
     let client = Client::new(server.url(), "test-key");
     let err = client.write("/conflict.txt", b"x").await.unwrap_err();
     match err {
-        Drive9Error::Conflict { status_code, server_revision, .. } => {
+        Drive9Error::Conflict {
+            status_code,
+            server_revision,
+            ..
+        } => {
             assert_eq!(status_code, 409);
             assert_eq!(server_revision, None);
         }
@@ -89,7 +96,11 @@ async fn test_conflict_error_with_server_revision() {
     let client = Client::new(server.url(), "test-key");
     let err = client.write("/conflict2.txt", b"x").await.unwrap_err();
     match err {
-        Drive9Error::Conflict { status_code, server_revision, .. } => {
+        Drive9Error::Conflict {
+            status_code,
+            server_revision,
+            ..
+        } => {
             assert_eq!(status_code, 409);
             assert_eq!(server_revision, Some(42));
         }
@@ -147,4 +158,59 @@ fn test_default_client_loads_config() {
         None => std::env::remove_var("HOME"),
     }
     let _ = std::fs::remove_dir_all(&temp_home);
+}
+
+#[tokio::test]
+async fn test_patch_file_respects_presigned_checksum_header() {
+    let mut server = mockito::Server::new_async().await;
+    let expected = base64::engine::general_purpose::STANDARD.encode(Sha256::digest(b"part-2"));
+    let patch_body = format!(
+        r#"{{
+            "upload_id":"patch-rs",
+            "part_size":8,
+            "upload_parts":[
+                {{"number":1,"url":"{}/patch/1","size":8,"headers":{{}}}},
+                {{"number":2,"url":"{}/patch/2","size":8,"headers":{{"x-amz-checksum-sha256":"placeholder"}}}}
+            ],
+            "copied_parts":[]
+        }}"#,
+        server.url(),
+        server.url()
+    );
+    let _plan = server
+        .mock("PATCH", "/v1/fs/file.bin")
+        .with_status(202)
+        .with_body(patch_body)
+        .create_async()
+        .await;
+    let _part1 = server
+        .mock("PUT", "/patch/1")
+        .match_header("x-amz-checksum-sha256", Matcher::Missing)
+        .with_status(200)
+        .create_async()
+        .await;
+    let _part2 = server
+        .mock("PUT", "/patch/2")
+        .match_header("x-amz-checksum-sha256", expected.as_str())
+        .with_status(200)
+        .create_async()
+        .await;
+    let _complete = server
+        .mock("POST", "/v1/uploads/patch-rs/complete")
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "test-key");
+    client
+        .patch_file(
+            "/file.bin",
+            16,
+            &[1, 2],
+            |part, _, _| Ok(format!("part-{}", part).into_bytes()),
+            Some(8),
+            None,
+        )
+        .await
+        .unwrap();
 }

--- a/clients/drive9-swift/Sources/Drive9Mobile/Drive9.swift
+++ b/clients/drive9-swift/Sources/Drive9Mobile/Drive9.swift
@@ -582,7 +582,9 @@ public final class Drive9Client: @unchecked Sendable {
 
     private func uploadPatchPart(_ part: Drive9PatchPartURL, data: Data) async throws {
         var headers = part.headers
-        headers["x-amz-checksum-sha256"] = sha256Base64(data)
+        if headers.keys.contains(where: { $0.caseInsensitiveCompare("x-amz-checksum-sha256") == .orderedSame }) {
+            headers["x-amz-checksum-sha256"] = sha256Base64(data)
+        }
         let response = try await rawPut(url: part.url, headers: headers, data: data)
         guard (200...299).contains(response.status) else { throw errorFrom(data: response.body, status: response.status) }
     }

--- a/clients/drive9-swift/Tests/Drive9MobileTests/Drive9Tests.swift
+++ b/clients/drive9-swift/Tests/Drive9MobileTests/Drive9Tests.swift
@@ -311,7 +311,7 @@ final class Drive9Tests: XCTestCase {
         }
         server.route("PUT", "/patch-part") { req in
             patched.set(req.body)
-            XCTAssertTrue(req.headers["x-amz-checksum-sha256"] != nil)
+            XCTAssertNil(req.headers["x-amz-checksum-sha256"])
             return MockResponse(status: 200, body: Data())
         }
         server.route("POST", "/v1/uploads/p1/complete") { _ in MockResponse(status: 200, body: Data()) }
@@ -328,6 +328,34 @@ final class Drive9Tests: XCTestCase {
             partSize: 4
         )
         XCTAssertEqual(patched.get(), Data("abcd".utf8))
+    }
+
+    func testPatchFilePartsSendsPresignedChecksumHeader() async throws {
+        let client = Drive9Client(baseUrl: server.baseURL, apiKey: "k")
+        let patched = ReceivedBody()
+        server.route("PATCH", "/v1/fs/r") { _ in
+            let body = #"{"upload_id":"p1","part_size":8,"upload_parts":[{"number":1,"url":"\#(self.server.baseURL)/patch-part-checksum","size":8,"headers":{"x-amz-checksum-sha256":"placeholder"}}],"copied_parts":[]}"#
+            return MockResponse(status: 200, body: Data(body.utf8), contentType: "application/json")
+        }
+        server.route("PUT", "/patch-part-checksum") { req in
+            patched.set(req.body)
+            XCTAssertEqual(req.headers["x-amz-checksum-sha256"], "gQ/y+yQqXe5CIPLLDmpRmJH7Z/L4KKbKtO+IlGM7H1A=")
+            return MockResponse(status: 200, body: Data())
+        }
+        server.route("POST", "/v1/uploads/p1/complete") { _ in MockResponse(status: 200, body: Data()) }
+
+        let local = FileManager.default.temporaryDirectory
+            .appendingPathComponent("drive9-swift-patch-checksum-\(UUID().uuidString).bin")
+        try Data("testdata".utf8).write(to: local)
+        defer { try? FileManager.default.removeItem(at: local) }
+        try await client.patchFileParts(
+            localPath: local.path,
+            remotePath: "/r",
+            dirtyParts: [1],
+            newSize: 8,
+            partSize: 8
+        )
+        XCTAssertEqual(patched.get(), Data("testdata".utf8))
     }
 
     private func assertDrive9Code<T>(

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -210,7 +210,11 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 	newS3Key := "blobs/" + fileID
 	encOpts, encMode, encKeyID := b.s3WriteEncryption(newS3Key)
 
-	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key, s3client.ChecksumAlgoSHA256, encOpts)
+	// Use ChecksumAlgoNone: patch parts are assembled client-side after
+	// presigning, so the checksum is not known at presign time.  Declaring
+	// SHA-256 here would force every UploadPart to carry the header, but
+	// the presigned URL does not sign it — causing S3 403/400.  See #555.
+	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key, s3client.ChecksumAlgoNone, encOpts)
 	if err != nil {
 		logger.Error(ctx, "backend_patch_upload_create_mpu_failed", zap.String("path", path), zap.Error(err))
 		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
@@ -255,7 +259,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 			plan.CopiedParts = append(plan.CopiedParts, p.Number)
 		} else {
 			// Dirty part or new part beyond original → client must upload
-			u, err := b.s3.PresignUploadPart(ctx, newS3Key, mpu.UploadID, p.Number, p.Size, s3client.ChecksumAlgoSHA256, "", s3client.UploadTTL)
+			u, err := b.s3.PresignUploadPart(ctx, newS3Key, mpu.UploadID, p.Number, p.Size, s3client.ChecksumAlgoNone, "", s3client.UploadTTL)
 			if err != nil {
 				_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
 				logger.Error(ctx, "backend_patch_upload_presign_failed", zap.String("path", path), zap.Int("part", p.Number), zap.Error(err))

--- a/pkg/backend/patch_test.go
+++ b/pkg/backend/patch_test.go
@@ -1,12 +1,18 @@
 package backend
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+	"github.com/mem9-ai/dat9/internal/testmysql"
+	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/s3client"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPatchAndAppendRejectDBBackedFilesWithSentinel(t *testing.T) {
@@ -30,4 +36,110 @@ func TestPatchAndAppendRejectDBBackedFilesWithSentinel(t *testing.T) {
 			t.Fatalf("InitiatePatchUploadIfRevision error = %v, want ErrNotS3Stored", err)
 		}
 	})
+}
+
+// patchChecksumRecordingS3Client wraps an S3Client and records the
+// ChecksumAlgo argument passed to CreateMultipartUpload and
+// PresignUploadPart.  This is a regression test helper for issue #555:
+// the patch path must use ChecksumAlgoNone so that the presigned URL
+// contract is consistent with the MPU checksum declaration.
+type patchChecksumRecordingS3Client struct {
+	s3client.S3Client
+	createMPUAlgos      []s3client.ChecksumAlgo
+	presignPartAlgos    []s3client.ChecksumAlgo
+	presignPartChecksum []string
+}
+
+func (c *patchChecksumRecordingS3Client) CreateMultipartUpload(ctx context.Context, key string, algo s3client.ChecksumAlgo, encOpts s3client.EncryptionOpts) (*s3client.MultipartUpload, error) {
+	c.createMPUAlgos = append(c.createMPUAlgos, algo)
+	return c.S3Client.CreateMultipartUpload(ctx, key, algo, encOpts)
+}
+
+func (c *patchChecksumRecordingS3Client) PresignUploadPart(ctx context.Context, key, uploadID string, partNumber int, partSize int64, algo s3client.ChecksumAlgo, checksumValue string, ttl time.Duration) (*s3client.UploadPartURL, error) {
+	c.presignPartAlgos = append(c.presignPartAlgos, algo)
+	c.presignPartChecksum = append(c.presignPartChecksum, checksumValue)
+	return c.S3Client.PresignUploadPart(ctx, key, uploadID, partNumber, partSize, algo, checksumValue, ttl)
+}
+
+// TestPatchUploadUsesChecksumAlgoNone verifies that InitiatePatchUploadIfRevision
+// calls CreateMultipartUpload and PresignUploadPart with ChecksumAlgoNone.
+// This is a regression test for issue #555: declaring ChecksumAlgoSHA256 at
+// MPU creation forces S3 to require a checksum header on every UploadPart,
+// but patch parts are assembled client-side after presigning so the checksum
+// cannot be included in the signature — causing S3 403 or 400.
+func TestPatchUploadUsesChecksumAlgoNone(t *testing.T) {
+	// Set up backend with recording S3 client.
+	s3Dir, err := os.MkdirTemp("", "dat9-s3-patch-checksum-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
+
+	initBackendSchema(t, testDSN)
+	store, err := datastore.Open(testDSN)
+	require.NoError(t, err)
+	testmysql.ResetDB(t, store.DB())
+	t.Cleanup(func() { _ = store.Close() })
+
+	localS3, err := s3client.NewLocal(s3Dir, "http://localhost:9091/s3")
+	require.NoError(t, err)
+	rec := &patchChecksumRecordingS3Client{S3Client: localS3}
+
+	b, err := NewWithS3ModeAndOptions(store, rec, true, Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { b.Close() })
+
+	ctx := context.Background()
+
+	// Step 1: Create an S3-backed file via v1 upload + confirm.
+	totalSize := int64(2 * s3client.PartSize) // 2 parts
+	plan, err := b.InitiateUpload(ctx, "/patch-checksum-test.bin", totalSize)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Parts)
+
+	// Get S3 upload ID for direct part upload.
+	upload, err := b.GetUpload(ctx, plan.UploadID)
+	require.NoError(t, err)
+
+	// Upload parts via the underlying local S3 client directly.
+	partData := make([]byte, totalSize)
+	for i := range partData {
+		partData[i] = byte(i % 256)
+	}
+	for _, p := range plan.Parts {
+		start := int64(p.Number-1) * s3client.PartSize
+		end := start + p.Size
+		if end > totalSize {
+			end = totalSize
+		}
+		_, err := localS3.UploadPart(ctx, upload.S3UploadID, p.Number, bytes.NewReader(partData[start:end]))
+		require.NoError(t, err, "upload part %d", p.Number)
+	}
+	require.NoError(t, b.ConfirmUpload(ctx, plan.UploadID))
+
+	// Reset recording — we only care about the patch path calls.
+	rec.createMPUAlgos = nil
+	rec.presignPartAlgos = nil
+	rec.presignPartChecksum = nil
+
+	// Step 2: Initiate a patch upload marking part 1 as dirty.
+	patchPlan, err := b.InitiatePatchUploadIfRevision(ctx, "/patch-checksum-test.bin", totalSize, []int{1}, s3client.PartSize, -1)
+	require.NoError(t, err)
+	require.NotNil(t, patchPlan)
+
+	// Step 3: Assert CreateMultipartUpload used ChecksumAlgoNone.
+	require.Len(t, rec.createMPUAlgos, 1, "expected exactly 1 CreateMultipartUpload call from patch")
+	require.Equal(t, s3client.ChecksumAlgoNone, rec.createMPUAlgos[0],
+		"patch CreateMultipartUpload must use ChecksumAlgoNone; "+
+			"using ChecksumAlgoSHA256 forces S3 to require checksum headers "+
+			"that cannot be included in presigned URLs (issue #555)")
+
+	// Step 4: Assert PresignUploadPart used ChecksumAlgoNone with empty checksum.
+	// Part 1 is dirty → should have a presigned upload URL.
+	// Part 2 is clean → server-side copy, no presign.
+	require.NotEmpty(t, rec.presignPartAlgos, "expected at least 1 PresignUploadPart call for dirty part")
+	for i, algo := range rec.presignPartAlgos {
+		require.Equal(t, s3client.ChecksumAlgoNone, algo,
+			"patch PresignUploadPart[%d] must use ChecksumAlgoNone (issue #555)", i)
+		require.Empty(t, rec.presignPartChecksum[i],
+			"patch PresignUploadPart[%d] checksum value must be empty", i)
+	}
 }

--- a/pkg/backend/patch_test.go
+++ b/pkg/backend/patch_test.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+
 	"github.com/mem9-ai/dat9/internal/testmysql"
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/s3client"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPatchAndAppendRejectDBBackedFilesWithSentinel(t *testing.T) {
@@ -70,21 +70,29 @@ func (c *patchChecksumRecordingS3Client) PresignUploadPart(ctx context.Context, 
 func TestPatchUploadUsesChecksumAlgoNone(t *testing.T) {
 	// Set up backend with recording S3 client.
 	s3Dir, err := os.MkdirTemp("", "dat9-s3-patch-checksum-*")
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
 	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
 
 	initBackendSchema(t, testDSN)
 	store, err := datastore.Open(testDSN)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("Open datastore: %v", err)
+	}
 	testmysql.ResetDB(t, store.DB())
 	t.Cleanup(func() { _ = store.Close() })
 
 	localS3, err := s3client.NewLocal(s3Dir, "http://localhost:9091/s3")
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewLocal S3: %v", err)
+	}
 	rec := &patchChecksumRecordingS3Client{S3Client: localS3}
 
 	b, err := NewWithS3ModeAndOptions(store, rec, true, Options{})
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewWithS3ModeAndOptions: %v", err)
+	}
 	t.Cleanup(func() { b.Close() })
 
 	ctx := context.Background()
@@ -92,12 +100,18 @@ func TestPatchUploadUsesChecksumAlgoNone(t *testing.T) {
 	// Step 1: Create an S3-backed file via v1 upload + confirm.
 	totalSize := int64(2 * s3client.PartSize) // 2 parts
 	plan, err := b.InitiateUpload(ctx, "/patch-checksum-test.bin", totalSize)
-	require.NoError(t, err)
-	require.NotEmpty(t, plan.Parts)
+	if err != nil {
+		t.Fatalf("InitiateUpload: %v", err)
+	}
+	if len(plan.Parts) == 0 {
+		t.Fatal("InitiateUpload returned no parts")
+	}
 
 	// Get S3 upload ID for direct part upload.
 	upload, err := b.GetUpload(ctx, plan.UploadID)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("GetUpload: %v", err)
+	}
 
 	// Upload parts via the underlying local S3 client directly.
 	partData := make([]byte, totalSize)
@@ -111,9 +125,13 @@ func TestPatchUploadUsesChecksumAlgoNone(t *testing.T) {
 			end = totalSize
 		}
 		_, err := localS3.UploadPart(ctx, upload.S3UploadID, p.Number, bytes.NewReader(partData[start:end]))
-		require.NoError(t, err, "upload part %d", p.Number)
+		if err != nil {
+			t.Fatalf("upload part %d: %v", p.Number, err)
+		}
 	}
-	require.NoError(t, b.ConfirmUpload(ctx, plan.UploadID))
+	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
+		t.Fatalf("ConfirmUpload: %v", err)
+	}
 
 	// Reset recording — we only care about the patch path calls.
 	rec.createMPUAlgos = nil
@@ -122,24 +140,33 @@ func TestPatchUploadUsesChecksumAlgoNone(t *testing.T) {
 
 	// Step 2: Initiate a patch upload marking part 1 as dirty.
 	patchPlan, err := b.InitiatePatchUploadIfRevision(ctx, "/patch-checksum-test.bin", totalSize, []int{1}, s3client.PartSize, -1)
-	require.NoError(t, err)
-	require.NotNil(t, patchPlan)
+	if err != nil {
+		t.Fatalf("InitiatePatchUploadIfRevision: %v", err)
+	}
+	if patchPlan == nil {
+		t.Fatal("InitiatePatchUploadIfRevision returned nil plan")
+	}
 
 	// Step 3: Assert CreateMultipartUpload used ChecksumAlgoNone.
-	require.Len(t, rec.createMPUAlgos, 1, "expected exactly 1 CreateMultipartUpload call from patch")
-	require.Equal(t, s3client.ChecksumAlgoNone, rec.createMPUAlgos[0],
-		"patch CreateMultipartUpload must use ChecksumAlgoNone; "+
-			"using ChecksumAlgoSHA256 forces S3 to require checksum headers "+
-			"that cannot be included in presigned URLs (issue #555)")
+	if len(rec.createMPUAlgos) != 1 {
+		t.Fatalf("CreateMultipartUpload calls = %d, want 1", len(rec.createMPUAlgos))
+	}
+	if rec.createMPUAlgos[0] != s3client.ChecksumAlgoNone {
+		t.Errorf("patch CreateMultipartUpload algo = %v, want %v", rec.createMPUAlgos[0], s3client.ChecksumAlgoNone)
+	}
 
 	// Step 4: Assert PresignUploadPart used ChecksumAlgoNone with empty checksum.
 	// Part 1 is dirty → should have a presigned upload URL.
 	// Part 2 is clean → server-side copy, no presign.
-	require.NotEmpty(t, rec.presignPartAlgos, "expected at least 1 PresignUploadPart call for dirty part")
+	if len(rec.presignPartAlgos) == 0 {
+		t.Fatal("expected at least 1 PresignUploadPart call for dirty part")
+	}
 	for i, algo := range rec.presignPartAlgos {
-		require.Equal(t, s3client.ChecksumAlgoNone, algo,
-			"patch PresignUploadPart[%d] must use ChecksumAlgoNone (issue #555)", i)
-		require.Empty(t, rec.presignPartChecksum[i],
-			"patch PresignUploadPart[%d] checksum value must be empty", i)
+		if algo != s3client.ChecksumAlgoNone {
+			t.Errorf("patch PresignUploadPart[%d] algo = %v, want %v", i, algo, s3client.ChecksumAlgoNone)
+		}
+		if rec.presignPartChecksum[i] != "" {
+			t.Errorf("patch PresignUploadPart[%d] checksum = %q, want empty", i, rec.presignPartChecksum[i])
+		}
 	}
 }

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -195,10 +195,9 @@ func (c *Client) uploadPatchPart(ctx context.Context, part *PatchPartURL, readPa
 		return fmt.Errorf("readPart callback: %w", err)
 	}
 
-	// Upload to presigned URL
-	h := sha256.Sum256(data)
-	checksum := base64.StdEncoding.EncodeToString(h[:])
-
+	// Upload to presigned URL.
+	// Only send x-amz-checksum-sha256 if the server included it in the
+	// presigned headers — otherwise S3 rejects the unsigned header with 403.
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, part.URL, bytes.NewReader(data))
 	if err != nil {
 		return err
@@ -210,7 +209,12 @@ func (c *Client) uploadPatchPart(ctx context.Context, part *PatchPartURL, readPa
 		req.Header.Set(k, v)
 	}
 	req.ContentLength = int64(len(data))
-	req.Header.Set("x-amz-checksum-sha256", checksum)
+	if _, ok := part.Headers["x-amz-checksum-sha256"]; ok {
+		// Server presigned this header — recompute and set the actual value.
+		h := sha256.Sum256(data)
+		checksum := base64.StdEncoding.EncodeToString(h[:])
+		req.Header.Set("x-amz-checksum-sha256", checksum)
+	}
 
 	resp, err := c.httpClient.Do(req) // Direct to S3, no auth
 	if err != nil {

--- a/pkg/client/patch_test.go
+++ b/pkg/client/patch_test.go
@@ -3,6 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -377,10 +379,12 @@ func TestPatchUploadRespectsPresignedChecksumHeader(t *testing.T) {
 				t.Fatalf("x-amz-checksum-sha256 present = %v, want %v (header value: %q)",
 					gotChecksumPresent, tt.expectChecksum, gotChecksumHeader)
 			}
-			// When checksum IS sent, verify it's a valid base64-encoded SHA-256
-			// (not the placeholder from presigned headers).
-			if tt.expectChecksum && gotChecksumHeader == "placeholder" {
-				t.Fatal("checksum header should be recomputed, not the presigned placeholder")
+			if tt.expectChecksum {
+				sum := sha256.Sum256([]byte("testdata"))
+				want := base64.StdEncoding.EncodeToString(sum[:])
+				if gotChecksumHeader != want {
+					t.Fatalf("checksum header = %q, want %q", gotChecksumHeader, want)
+				}
 			}
 		})
 	}

--- a/pkg/client/patch_test.go
+++ b/pkg/client/patch_test.go
@@ -67,8 +67,10 @@ func TestPatchFileSendsExplicitPartSize(t *testing.T) {
 				http.Error(w, "missing upload token", http.StatusBadRequest)
 				return
 			}
-			if got := r.Header.Get("x-amz-checksum-sha256"); got == "" {
-				http.Error(w, "missing checksum header", http.StatusBadRequest)
+			// Server did not include x-amz-checksum-sha256 in presigned
+			// headers, so client must NOT send it (would cause S3 403).
+			if got := r.Header.Get("x-amz-checksum-sha256"); got != "" {
+				http.Error(w, "unexpected checksum header: server did not sign it", http.StatusForbidden)
 				return
 			}
 			uploaded, _ = io.ReadAll(r.Body)
@@ -292,5 +294,94 @@ func TestPatchFileSendsExpectedRevision(t *testing.T) {
 	}
 	if !completeCalled {
 		t.Fatal("complete was not called")
+	}
+}
+
+// TestPatchUploadRespectsPresignedChecksumHeader verifies that uploadPatchPart
+// only sends x-amz-checksum-sha256 when the server included it in the
+// presigned headers. This is a regression test for issue #555: when the header
+// is absent from the presigned URL signature, sending it causes S3 to return
+// 403 (HeadersNotSigned: x-amz-checksum-sha256).
+func TestPatchUploadRespectsPresignedChecksumHeader(t *testing.T) {
+	tests := []struct {
+		name           string
+		presignHeaders map[string]string
+		expectChecksum bool
+	}{
+		{
+			name:           "no checksum in presigned headers",
+			presignHeaders: map[string]string{"x-amz-content-sha256": "UNSIGNED-PAYLOAD"},
+			expectChecksum: false,
+		},
+		{
+			name:           "checksum in presigned headers",
+			presignHeaders: map[string]string{"x-amz-checksum-sha256": "placeholder"},
+			expectChecksum: true,
+		},
+		{
+			name:           "empty presigned headers",
+			presignHeaders: nil,
+			expectChecksum: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotChecksumHeader string
+			var gotChecksumPresent bool
+			var completeCalled bool
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPatch && r.URL.Path == "/v1/fs/checksum-test.bin":
+					w.WriteHeader(http.StatusAccepted)
+					_ = json.NewEncoder(w).Encode(PatchPlan{
+						UploadID: "patch-cs",
+						PartSize: 8,
+						UploadParts: []*PatchPartURL{{
+							Number:  1,
+							URL:     fmt.Sprintf("http://%s/upload/1", r.Host),
+							Size:    8,
+							Headers: tt.presignHeaders,
+						}},
+					})
+
+				case r.Method == http.MethodPut && r.URL.Path == "/upload/1":
+					gotChecksumHeader = r.Header.Get("x-amz-checksum-sha256")
+					gotChecksumPresent = gotChecksumHeader != ""
+					w.WriteHeader(http.StatusOK)
+
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/patch-cs/complete":
+					completeCalled = true
+					w.WriteHeader(http.StatusOK)
+
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			c := New(srv.URL, "")
+			err := c.PatchFile(context.Background(), "/checksum-test.bin", 8, []int{1},
+				func(partNumber int, partSize int64, origData []byte) ([]byte, error) {
+					return []byte("testdata"), nil
+				},
+				nil,
+				WithPartSize(8))
+			if err != nil {
+				t.Fatalf("PatchFile: %v", err)
+			}
+			if !completeCalled {
+				t.Fatal("complete was not called")
+			}
+			if gotChecksumPresent != tt.expectChecksum {
+				t.Fatalf("x-amz-checksum-sha256 present = %v, want %v (header value: %q)",
+					gotChecksumPresent, tt.expectChecksum, gotChecksumHeader)
+			}
+			// When checksum IS sent, verify it's a valid base64-encoded SHA-256
+			// (not the placeholder from presigned headers).
+			if tt.expectChecksum && gotChecksumHeader == "placeholder" {
+				t.Fatal("checksum header should be recomputed, not the presigned placeholder")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Fix `uploadPatchPart` sending unsigned `x-amz-checksum-sha256` header that S3 rejects with 403
- Only send the checksum header when the server's presigned headers include it
- Add regression test covering 3 cases: no checksum, with checksum, nil headers

## Root Cause (Issue #555)

`pkg/client/patch.go` unconditionally added `x-amz-checksum-sha256` to the S3 presigned PUT, but the server presigns patch parts with empty checksum (because the final part content isn't known at presign time). S3 correctly rejects the unsigned header.

**Error chain:** S3 403 -> FUSE EACCES -> fdatasync() failure -> SQLite "disk I/O error"

This blocked all large SQLite workloads on Drive9 FUSE mounts (speedtest1 --size 50, app-style 10k+ WAL updates).

## Changes

- `pkg/client/patch.go`: Only set `x-amz-checksum-sha256` when `part.Headers` includes the key
- `pkg/client/patch_test.go`: Updated existing test + added `TestPatchUploadRespectsPresignedChecksumHeader` with 3 subtests

## Test plan

- [ ] CI passes (unit tests for patch upload)
- [ ] After merge: rebuild drive9 CLI on EC2, re-run speedtest1 --size 50 and app-style 10k/50k WAL workloads
- [ ] Verify mount logs show no more S3 403 errors

Closes #555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected multipart PATCH uploads so `x-amz-checksum-sha256` is only sent when the server/plan included it in presigned part headers; otherwise the SDK omits it.
  * Updated patch multipart initialization and presigned part URL behavior to use “no checksum” settings to avoid S3 validation/authorization issues.

* **Tests**
  * Extended and added regression tests across client SDKs to verify correct presence/absence of `x-amz-checksum-sha256` and proper checksum computation/propagation when presigned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->