### PR TITLE
Add TiDB Cloud native provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,15 @@ func main() {
 Current tenant providers are selected explicitly:
 
 ```text
-DRIVE9_TENANT_PROVIDER=db9 | tidb_zero | tidb_cloud_starter
+DRIVE9_TENANT_PROVIDER=db9 | tidb_zero | tidb_cloud_starter | tidbcloud_native
 ```
 
 - `tidb_zero`: default development/provisioning path backed by TiDB Zero.
 - `tidb_cloud_starter`: production-oriented TiDB Cloud Starter pool takeover.
+- `tidbcloud_native`: creates TiDB Cloud Serverless Starter clusters in the
+  customer's TiDB Cloud account using `public_key` / `private_key` submitted to
+  `POST /v1/provision`; server config supplies the API URL, cloud provider,
+  region, and optional default database name.
 - `db9`: supported provider path with its own schema, but not the default
   architecture used in this README.
 
@@ -397,9 +401,15 @@ Important environment variables:
 
 ```text
 DRIVE9_META_DSN                 control-plane MySQL/TiDB DSN
-DRIVE9_TENANT_PROVIDER          db9 | tidb_zero | tidb_cloud_starter
+DRIVE9_TENANT_PROVIDER          db9 | tidb_zero | tidb_cloud_starter | tidbcloud_native
 DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT
                                 default TiDB Cloud Starter spendingLimit.monthly in USD cents
+DRIVE9_TIDBCLOUD_NATIVE_API_URL TiDB Cloud Serverless API base URL
+DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER
+                                cloud provider for tidbcloud_native cluster creation
+DRIVE9_TIDBCLOUD_NATIVE_REGION  region for tidbcloud_native cluster creation
+DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME
+                                optional default database_name for tidbcloud_native
 DRIVE9_TOKEN_SIGNING_KEY        32-byte hex JWT signing key
 DRIVE9_ENCRYPT_TYPE             local_aes | kms
 DRIVE9_MASTER_KEY               local AES key

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mem9-ai/dat9/pkg/tenant/db9"
 	"github.com/mem9-ai/dat9/pkg/tenant/schema"
 	"github.com/mem9-ai/dat9/pkg/tenant/starter"
+	"github.com/mem9-ai/dat9/pkg/tenant/tidbcloudnative"
 	"github.com/mem9-ai/dat9/pkg/tenant/tidbzero"
 )
 
@@ -178,6 +179,8 @@ func main() {
 		provisioner, provisionerErr = tidbzero.NewProvisionerFromEnv()
 	case tenant.ProviderTiDBCloudStarter:
 		provisioner, provisionerErr = starter.NewProvisionerFromEnv()
+	case tenant.ProviderTiDBCloudNative:
+		provisioner, provisionerErr = tidbcloudnative.NewProvisionerFromEnv()
 	case tenant.ProviderDB9:
 		provisioner, provisionerErr = db9.NewProvisionerFromEnv()
 	}
@@ -400,7 +403,7 @@ func usage(out io.Writer, exitCode int) {
 	_, _ = fmt.Fprintf(out, `usage:
   drive9-server [listen-addr]
   drive9-server version
-  drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter>
+  drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter|tidbcloud_native>
 
 environment:
   DRIVE9_LISTEN_ADDR serve listen address (default: :9009)
@@ -430,8 +433,12 @@ environment:
                                     required by openai, cohere, jina_ai, gemini, huggingface, nvidia_nim, nvidia
   DRIVE9_TIDB_AUTO_EMBEDDING_API_BASE provider base endpoint for models that require it
                                      optional for openai models; set it for Azure OpenAI endpoints
-  DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter (default for provisioning)
+  DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter|tidbcloud_native (default for provisioning)
   DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT default Starter spendingLimit.monthly in USD cents; applied after pool takeover
+  DRIVE9_TIDBCLOUD_NATIVE_API_URL TiDB Cloud Serverless API base URL for tidbcloud_native
+  DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER cloud provider for tidbcloud_native cluster creation, e.g. aws
+  DRIVE9_TIDBCLOUD_NATIVE_REGION region for tidbcloud_native cluster creation, e.g. us-east-1
+  DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME default tidbcloud_native database name when /v1/provision omits database_name (default: tidbcloud_fs)
   DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*
   DRIVE9_SLOCK_API_ORIGIN Slock API origin (required when DRIVE9_SLOCK_ORIGIN is set)
   DRIVE9_SLOCK_CLIENT_ID Slock connected-app client id (required when DRIVE9_SLOCK_ORIGIN is set)

--- a/cmd/drive9-server/schema_test.go
+++ b/cmd/drive9-server/schema_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSchemaDumpInitSQLByProvider(t *testing.T) {
-	for _, provider := range []string{"tidb_zero", "tidb_cloud_starter"} {
+	for _, provider := range []string{"tidb_zero", "tidb_cloud_starter", "tidbcloud_native"} {
 		t.Run(provider, func(t *testing.T) {
 			out := captureSchemaStdout(t, func() {
 				if err := runSchemaCommand([]string{"dump-init-sql", "--provider", provider}); err != nil {
@@ -36,7 +36,7 @@ func TestSchemaDumpInitSQLByProvider(t *testing.T) {
 }
 
 func TestSchemaDumpInitSQLByProviderIncludesVault(t *testing.T) {
-	for _, provider := range []string{"tidb_zero", "tidb_cloud_starter"} {
+	for _, provider := range []string{"tidb_zero", "tidb_cloud_starter", "tidbcloud_native"} {
 		t.Run(provider, func(t *testing.T) {
 			out := captureSchemaStdout(t, func() {
 				if err := runSchemaCommand([]string{"dump-init-sql", "--provider", provider}); err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -449,6 +449,54 @@ func TestProvisionTiDBCloudNativeRequiresRequestCredentials(t *testing.T) {
 	}
 }
 
+func TestProvisionTenantRejectsMissingNativeCredentialsBeforeInsert(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}
+	srv := NewWithConfig(Config{
+		Meta:        metaStore,
+		Pool:        pool,
+		Provisioner: prov,
+		TokenSecret: tokenSecret,
+	})
+	defer srv.Close()
+
+	_, err = srv.provisionTenant(context.Background(), provisionTenantOptions{KeyName: "default"})
+	if err == nil {
+		t.Fatal("expected missing native credentials error")
+	}
+	if got := prov.ProvisionCallCount(); got != 0 {
+		t.Fatalf("plain provision calls = %d, want 0", got)
+	}
+	var tenantCount int
+	if err := metaStore.DB().QueryRow("SELECT COUNT(*) FROM tenants").Scan(&tenantCount); err != nil {
+		t.Fatal(err)
+	}
+	if tenantCount != 0 {
+		t.Fatalf("tenant count = %d, want 0", tenantCount)
+	}
+}
+
 func TestProvisionPersistsEncryptedAutoEmbeddingProfile(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -23,11 +23,13 @@ import (
 )
 
 type fakeProvisioner struct {
-	provider       string
-	cluster        *tenant.ClusterInfo
-	initErr        error
-	provisionErr   error
-	provisionCalls atomic.Int32
+	provider          string
+	cluster           *tenant.ClusterInfo
+	initErr           error
+	provisionErr      error
+	provisionCalls    atomic.Int32
+	credentialCalls   atomic.Int32
+	lastCredentialReq tenant.CredentialProvisionRequest
 }
 
 func (f *fakeProvisioner) ProviderType() string { return f.provider }
@@ -41,6 +43,24 @@ func (f *fakeProvisioner) InitSchema(_ context.Context, dsn string) error {
 
 func (f *fakeProvisioner) Provision(_ context.Context, tenantID string) (*tenant.ClusterInfo, error) {
 	f.provisionCalls.Add(1)
+	if f.provisionErr != nil {
+		if f.cluster == nil {
+			return nil, f.provisionErr
+		}
+		out := *f.cluster
+		out.TenantID = tenantID
+		out.Provider = f.provider
+		return &out, f.provisionErr
+	}
+	out := *f.cluster
+	out.TenantID = tenantID
+	out.Provider = f.provider
+	return &out, nil
+}
+
+func (f *fakeProvisioner) ProvisionWithCredentials(_ context.Context, tenantID string, req tenant.CredentialProvisionRequest) (*tenant.ClusterInfo, error) {
+	f.credentialCalls.Add(1)
+	f.lastCredentialReq = req
 	if f.provisionErr != nil {
 		if f.cluster == nil {
 			return nil, f.provisionErr
@@ -286,6 +306,146 @@ func TestProvisionUsesConfiguredProvisioner(t *testing.T) {
 	}
 	if provider != tenant.ProviderTiDBZero || clusterID != "cluster-1" {
 		t.Fatalf("unexpected tenant row: status=%s provider=%s cluster_id=%s", status, provider, clusterID)
+	}
+}
+
+func TestProvisionTiDBCloudNativeUsesRequestCredentials(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cluster: &tenant.ClusterInfo{
+		ClusterID: "native-cluster-1",
+		Host:      "db.example",
+		Port:      4000,
+		Username:  "u1.root",
+		Password:  "db-pass",
+		DBName:    "customer_db",
+	}}
+
+	srv := NewWithConfig(Config{
+		Meta:        metaStore,
+		Pool:        pool,
+		Provisioner: prov,
+		TokenSecret: tokenSecret,
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"public_key":    "public-1",
+		"private_key":   "private-1",
+		"database_name": "customer_db",
+	})
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if got := prov.ProvisionCallCount(); got != 0 {
+		t.Fatalf("plain provision calls = %d, want 0", got)
+	}
+	if got := prov.credentialCalls.Load(); got != 1 {
+		t.Fatalf("credential provision calls = %d, want 1", got)
+	}
+	if prov.lastCredentialReq.PublicKey != "public-1" || prov.lastCredentialReq.PrivateKey != "private-1" || prov.lastCredentialReq.DatabaseName != "customer_db" {
+		t.Fatalf("credential request = %+v", prov.lastCredentialReq)
+	}
+
+	var out map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out["tenant_id"] == "" || out["api_key"] == "" || out["status"] != string(meta.TenantProvisioning) {
+		t.Fatalf("unexpected response: %+v", out)
+	}
+
+	var provider, dbName string
+	if err := metaStore.DB().QueryRow("SELECT provider, db_name FROM tenants WHERE id = ?", out["tenant_id"]).Scan(&provider, &dbName); err != nil {
+		t.Fatal(err)
+	}
+	if provider != tenant.ProviderTiDBCloudNative || dbName != "customer_db" {
+		t.Fatalf("tenant provider/db = %s/%s", provider, dbName)
+	}
+}
+
+func TestProvisionTiDBCloudNativeRequiresRequestCredentials(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cluster: &tenant.ClusterInfo{}}
+	srv := NewWithConfig(Config{
+		Meta:        metaStore,
+		Pool:        pool,
+		Provisioner: prov,
+		TokenSecret: tokenSecret,
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", strings.NewReader(`{"public_key":"public-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if got := prov.credentialCalls.Load(); got != 0 {
+		t.Fatalf("credential provision calls = %d, want 0", got)
+	}
+	var tenantCount int
+	if err := metaStore.DB().QueryRow("SELECT COUNT(*) FROM tenants").Scan(&tenantCount); err != nil {
+		t.Fatal(err)
+	}
+	if tenantCount != 0 {
+		t.Fatalf("tenant count = %d, want 0", tenantCount)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -384,6 +385,21 @@ func TestProvisionTiDBCloudNativeUsesRequestCredentials(t *testing.T) {
 		t.Fatalf("unexpected response: %+v", out)
 	}
 
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		var status string
+		if err := metaStore.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", out["tenant_id"]).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status == string(meta.TenantActive) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("tenant did not become active in time: status=%s", status)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
 	var provider, dbName string
 	if err := metaStore.DB().QueryRow("SELECT provider, db_name FROM tenants WHERE id = ?", out["tenant_id"]).Scan(&provider, &dbName); err != nil {
 		t.Fatal(err)
@@ -446,6 +462,31 @@ func TestProvisionTiDBCloudNativeRequiresRequestCredentials(t *testing.T) {
 	}
 	if tenantCount != 0 {
 		t.Fatalf("tenant count = %d, want 0", tenantCount)
+	}
+}
+
+func TestDecodeCredentialProvisionRequestRejectsTrailingJSON(t *testing.T) {
+	body := strings.NewReader(`{"public_key":"public-1","private_key":"private-1"} {}`)
+	req, _ := http.NewRequest(http.MethodPost, "/v1/provision", body)
+	_, err := decodeCredentialProvisionRequest(httptest.NewRecorder(), req)
+	if err == nil {
+		t.Fatal("expected trailing JSON error")
+	}
+	if !strings.Contains(err.Error(), "trailing data") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDecodeCredentialProvisionRequestRejectsOversizedBody(t *testing.T) {
+	body := strings.NewReader(`{"public_key":"` + strings.Repeat("x", int(maxCredentialProvisionBodyBytes)+1) + `","private_key":"private-1"}`)
+	req, _ := http.NewRequest(http.MethodPost, "/v1/provision", body)
+	_, err := decodeCredentialProvisionRequest(httptest.NewRecorder(), req)
+	if err == nil {
+		t.Fatal("expected oversized body error")
+	}
+	var maxErr *http.MaxBytesError
+	if !errors.As(err, &maxErr) {
+		t.Fatalf("error = %v, want MaxBytesError", err)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -145,10 +145,11 @@ type TenantStatusResponse struct {
 }
 
 const (
-	maxBatchStatPaths       = 256
-	maxBatchReadSmallPaths  = 128
-	maxBatchReadSmallBytes  = 50_000
-	defaultBatchReadMaxBody = 1 << 20
+	maxBatchStatPaths                     = 256
+	maxBatchReadSmallPaths                = 128
+	maxBatchReadSmallBytes                = 50_000
+	defaultBatchReadMaxBody               = 1 << 20
+	maxCredentialProvisionBodyBytes int64 = 1 << 20
 )
 
 func New(b *backend.Dat9Backend) *Server {
@@ -3368,7 +3369,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	}
 	var credentialReq *tenant.CredentialProvisionRequest
 	if provider == tenant.ProviderTiDBCloudNative {
-		req, err := decodeCredentialProvisionRequest(r)
+		req, err := decodeCredentialProvisionRequest(w, r)
 		if err != nil {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_invalid_request", "provider", provider, "error", err)...)
 			metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
@@ -3411,17 +3412,21 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func decodeCredentialProvisionRequest(r *http.Request) (*tenant.CredentialProvisionRequest, error) {
+func decodeCredentialProvisionRequest(w http.ResponseWriter, r *http.Request) (*tenant.CredentialProvisionRequest, error) {
 	var req struct {
 		PublicKey    string `json:"public_key"`
 		PrivateKey   string `json:"private_key"`
 		DatabaseName string `json:"database_name"`
 	}
 	if r.Body != nil {
-		dec := json.NewDecoder(r.Body)
+		dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxCredentialProvisionBodyBytes))
 		dec.DisallowUnknownFields()
 		if err := dec.Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			return nil, fmt.Errorf("invalid JSON body: %w", err)
+		}
+		var extra struct{}
+		if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("invalid JSON body: trailing data")
 		}
 	}
 	out := &tenant.CredentialProvisionRequest{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -76,6 +76,10 @@ type autoEmbeddingSchemaProvisioner interface {
 	InitSchemaForAutoEmbeddingProfile(context.Context, string, tenantschema.TiDBAutoEmbeddingProfile) error
 }
 
+type credentialProvisionRequestValidator interface {
+	ValidateCredentialProvisionRequest(tenant.CredentialProvisionRequest) error
+}
+
 type Server struct {
 	fallback            *backend.Dat9Backend
 	meta                *meta.Store
@@ -3362,9 +3366,29 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	var credentialReq *tenant.CredentialProvisionRequest
+	if provider == tenant.ProviderTiDBCloudNative {
+		req, err := decodeCredentialProvisionRequest(r)
+		if err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_invalid_request", "provider", provider, "error", err)...)
+			metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if validator, ok := s.provisioner.(credentialProvisionRequestValidator); ok {
+			if err := validator.ValidateCredentialProvisionRequest(*req); err != nil {
+				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_invalid_request", "provider", provider, "error", err)...)
+				metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
+				errJSON(w, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
+		credentialReq = req
+	}
 	res, err := s.provisionTenant(r.Context(), provisionTenantOptions{
-		KeyName:      "default",
-		TokenVersion: 1,
+		KeyName:               "default",
+		TokenVersion:          1,
+		CredentialProvisioner: credentialReq,
 	})
 	if err != nil {
 		var pe *provisionTenantError
@@ -3387,6 +3411,30 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func decodeCredentialProvisionRequest(r *http.Request) (*tenant.CredentialProvisionRequest, error) {
+	var req struct {
+		PublicKey    string `json:"public_key"`
+		PrivateKey   string `json:"private_key"`
+		DatabaseName string `json:"database_name"`
+	}
+	if r.Body != nil {
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("invalid JSON body: %w", err)
+		}
+	}
+	out := &tenant.CredentialProvisionRequest{
+		PublicKey:    strings.TrimSpace(req.PublicKey),
+		PrivateKey:   strings.TrimSpace(req.PrivateKey),
+		DatabaseName: strings.TrimSpace(req.DatabaseName),
+	}
+	if out.PublicKey == "" || out.PrivateKey == "" {
+		return nil, fmt.Errorf("public_key and private_key are required")
+	}
+	return out, nil
+}
+
 type apiKeyIssueSource struct {
 	Provider     string
 	SubjectKey   string
@@ -3394,9 +3442,10 @@ type apiKeyIssueSource struct {
 }
 
 type provisionTenantOptions struct {
-	KeyName      string
-	TokenVersion int
-	APIKeySource apiKeyIssueSource
+	KeyName               string
+	TokenVersion          int
+	APIKeySource          apiKeyIssueSource
+	CredentialProvisioner *tenant.CredentialProvisionRequest
 }
 
 type provisionTenantResult struct {
@@ -3578,7 +3627,18 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		}
 	}
 
-	cluster, err := s.provisioner.Provision(ctx, tenantID)
+	var cluster *tenant.ClusterInfo
+	if provider == tenant.ProviderTiDBCloudNative {
+		if opts.CredentialProvisioner == nil {
+			err = fmt.Errorf("public_key and private_key are required")
+		} else if credentialProvisioner, ok := s.provisioner.(tenant.CredentialProvisioner); ok {
+			cluster, err = credentialProvisioner.ProvisionWithCredentials(ctx, tenantID, *opts.CredentialProvisioner)
+		} else {
+			err = fmt.Errorf("provisioner does not support request credentials")
+		}
+	} else {
+		cluster, err = s.provisioner.Provision(ctx, tenantID)
+	}
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "cluster_error")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3580,6 +3580,9 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		metricEvent(ctx, "tenant_provision", "provider", rawProvider, "result", "error")
 		return nil, newProvisionTenantError(http.StatusBadRequest, err.Error(), err)
 	}
+	if provider == tenant.ProviderTiDBCloudNative && opts.CredentialProvisioner == nil {
+		return nil, newProvisionTenantError(http.StatusBadRequest, "public_key and private_key are required", fmt.Errorf("public_key and private_key are required"))
+	}
 	tenantID := token.NewID()
 	logger.Info(ctx, "server_event", eventFields(ctx, "provision_requested", "tenant_id", tenantID, "provider", provider)...)
 	setRequestMetricTenant(ctx, tenantID, "", provider, tenantRequestClass{surface: "provision", action: "post"})

--- a/pkg/tenant/provider.go
+++ b/pkg/tenant/provider.go
@@ -6,11 +6,12 @@ const (
 	ProviderDB9              = "db9"
 	ProviderTiDBZero         = "tidb_zero"
 	ProviderTiDBCloudStarter = "tidb_cloud_starter"
+	ProviderTiDBCloudNative  = "tidbcloud_native"
 )
 
 func NormalizeProvider(provider string) (string, error) {
 	switch provider {
-	case ProviderDB9, ProviderTiDBZero, ProviderTiDBCloudStarter:
+	case ProviderDB9, ProviderTiDBZero, ProviderTiDBCloudStarter, ProviderTiDBCloudNative:
 		return provider, nil
 	default:
 		return "", fmt.Errorf("unsupported provider: %s", provider)
@@ -18,14 +19,14 @@ func NormalizeProvider(provider string) (string, error) {
 }
 
 func SmallInDB(provider string) bool {
-	return provider == ProviderTiDBZero || provider == ProviderTiDBCloudStarter
+	return provider == ProviderTiDBZero || provider == ProviderTiDBCloudStarter || provider == ProviderTiDBCloudNative
 }
 
 // UsesTiDBAutoEmbedding reports whether the provider should run the TiDB
 // database-managed auto-embedding mode.
 func UsesTiDBAutoEmbedding(provider string) bool {
 	switch provider {
-	case ProviderTiDBZero, ProviderTiDBCloudStarter:
+	case ProviderTiDBZero, ProviderTiDBCloudStarter, ProviderTiDBCloudNative:
 		return true
 	default:
 		return false

--- a/pkg/tenant/provider_test.go
+++ b/pkg/tenant/provider_test.go
@@ -3,7 +3,7 @@ package tenant
 import "testing"
 
 func TestNormalizeProvider(t *testing.T) {
-	for _, p := range []string{ProviderDB9, ProviderTiDBZero, ProviderTiDBCloudStarter} {
+	for _, p := range []string{ProviderDB9, ProviderTiDBZero, ProviderTiDBCloudStarter, ProviderTiDBCloudNative} {
 		got, err := NormalizeProvider(p)
 		if err != nil {
 			t.Fatalf("provider %s should be accepted: %v", p, err)
@@ -24,13 +24,16 @@ func TestSmallInDB(t *testing.T) {
 	if !SmallInDB(ProviderTiDBCloudStarter) {
 		t.Fatal("tidb_cloud_starter should store small files in db")
 	}
+	if !SmallInDB(ProviderTiDBCloudNative) {
+		t.Fatal("tidbcloud_native should store small files in db")
+	}
 	if SmallInDB(ProviderDB9) {
 		t.Fatal("db9 should not store small files in db")
 	}
 }
 
 func TestUsesTiDBAutoEmbedding(t *testing.T) {
-	for _, provider := range []string{ProviderTiDBZero, ProviderTiDBCloudStarter} {
+	for _, provider := range []string{ProviderTiDBZero, ProviderTiDBCloudStarter, ProviderTiDBCloudNative} {
 		if !UsesTiDBAutoEmbedding(provider) {
 			t.Fatalf("provider %s should use TiDB auto-embedding mode", provider)
 		}

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -26,6 +26,17 @@ type Provisioner interface {
 	ProviderType() string
 }
 
+type CredentialProvisionRequest struct {
+	PublicKey    string
+	PrivateKey   string
+	DatabaseName string
+}
+
+type CredentialProvisioner interface {
+	Provisioner
+	ProvisionWithCredentials(ctx context.Context, tenantID string, req CredentialProvisionRequest) (*ClusterInfo, error)
+}
+
 type BranchProvisioner interface {
 	Provisioner
 	ProvisionBranch(ctx context.Context, forkTenantID string, source *ClusterInfo) (*ClusterInfo, error)

--- a/pkg/tenant/schemadump/schemadump.go
+++ b/pkg/tenant/schemadump/schemadump.go
@@ -9,7 +9,7 @@ import (
 	tenantschema "github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
 
-const usage = "usage: drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter>"
+const usage = "usage: drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter|tidbcloud_native>"
 
 // ResolveProvider normalizes a schema dump provider selection.
 func ResolveProvider(provider string) (string, error) {
@@ -28,7 +28,7 @@ func Statements(provider string) ([]string, error) {
 	switch provider {
 	case tenant.ProviderDB9:
 		return tenantschema.CloneStatements(tenantdb9.InitSchemaStatements()), nil
-	case tenant.ProviderTiDBZero, tenant.ProviderTiDBCloudStarter:
+	case tenant.ProviderTiDBZero, tenant.ProviderTiDBCloudStarter, tenant.ProviderTiDBCloudNative:
 		return tenantschema.InitTiDBTenantSchemaStatementsForMode(tenantschema.TiDBEmbeddingModeAuto)
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", provider)

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -31,6 +31,8 @@ const (
 	EnvTiDBCloudNativeDefaultDatabaseName = "DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME"
 
 	DefaultDatabaseName = "tidbcloud_fs"
+
+	upstreamErrorBodyLimit = 2048
 )
 
 var databaseNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)
@@ -125,7 +127,7 @@ func (p *Provisioner) ProvisionWithCredentials(ctx context.Context, tenantID str
 	defer func() { _ = resp.Body.Close() }()
 	raw, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("tidbcloud native provision status %d", resp.StatusCode)
+		return nil, fmt.Errorf("tidbcloud native provision status %d: %s", resp.StatusCode, sanitizeUpstreamBody(raw))
 	}
 	info, err := parseClusterInfo(raw)
 	if err != nil {
@@ -134,7 +136,7 @@ func (p *Provisioner) ProvisionWithCredentials(ctx context.Context, tenantID str
 	if info.ClusterID == "" {
 		return nil, fmt.Errorf("tidbcloud native response missing cluster id")
 	}
-	if info.State != "" && info.State != "ACTIVE" && (info.Endpoints.Public.Host == "" || info.UserPrefix == "") {
+	if info.State != "ACTIVE" || clusterConnectionIncomplete(info) {
 		info, err = p.waitForClusterActive(ctx, publicKey, privateKey, info.ClusterID)
 		if err != nil {
 			return &tenant.ClusterInfo{
@@ -209,6 +211,18 @@ func normalizeDatabaseName(name string) (string, error) {
 	}
 }
 
+func sanitizeUpstreamBody(raw []byte) string {
+	s := strings.TrimSpace(string(raw))
+	if s == "" {
+		return ""
+	}
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) > upstreamErrorBodyLimit {
+		s = s[:upstreamErrorBodyLimit] + "...(truncated)"
+	}
+	return s
+}
+
 func ensureDatabase(ctx context.Context, user, password, host string, port int, dbName string) error {
 	cfg := mysql.NewConfig()
 	cfg.User = user
@@ -249,6 +263,13 @@ func parseClusterInfo(raw []byte) (*clusterInfo, error) {
 	return &out, nil
 }
 
+func clusterConnectionIncomplete(info *clusterInfo) bool {
+	if info == nil {
+		return true
+	}
+	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || (info.UserPrefix == "" && info.Username == "")
+}
+
 func (p *Provisioner) waitForClusterActive(ctx context.Context, publicKey, privateKey, clusterID string) (*clusterInfo, error) {
 	deadline := time.Now().Add(10 * time.Minute)
 	for {
@@ -260,13 +281,13 @@ func (p *Provisioner) waitForClusterActive(ctx context.Context, publicKey, priva
 		raw, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("tidbcloud native cluster get status %d", resp.StatusCode)
+			return nil, fmt.Errorf("tidbcloud native cluster get status %d: %s", resp.StatusCode, sanitizeUpstreamBody(raw))
 		}
 		info, err := parseClusterInfo(raw)
 		if err != nil {
 			return nil, err
 		}
-		if info.State == "ACTIVE" {
+		if info.State == "ACTIVE" && !clusterConnectionIncomplete(info) {
 			return info, nil
 		}
 		if time.Now().After(deadline) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1,0 +1,377 @@
+// Package tidbcloudnative implements customer-account TiDB Cloud Serverless
+// tenant provisioning.
+package tidbcloudnative
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"crypto/rand"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/schema"
+)
+
+const (
+	EnvTiDBCloudNativeAPIURL              = "DRIVE9_TIDBCLOUD_NATIVE_API_URL"
+	EnvTiDBCloudNativeCloudProvider       = "DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER"
+	EnvTiDBCloudNativeRegion              = "DRIVE9_TIDBCLOUD_NATIVE_REGION"
+	EnvTiDBCloudNativeDefaultDatabaseName = "DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME"
+
+	DefaultDatabaseName = "tidbcloud_fs"
+)
+
+var databaseNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)
+var displayNameCharPattern = regexp.MustCompile(`[^A-Za-z0-9-]`)
+
+var ensureDatabaseFunc = ensureDatabase
+
+type Provisioner struct {
+	apiURL              string
+	cloudProvider       string
+	region              string
+	defaultDatabaseName string
+	client              *http.Client
+}
+
+func NewProvisionerFromEnv() (*Provisioner, error) {
+	apiURL := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeAPIURL))
+	cloudProvider := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeCloudProvider))
+	region := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeRegion))
+	defaultDB := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeDefaultDatabaseName))
+	if defaultDB == "" {
+		defaultDB = DefaultDatabaseName
+	}
+	if apiURL == "" || cloudProvider == "" || region == "" {
+		return nil, fmt.Errorf("%s, %s and %s are required", EnvTiDBCloudNativeAPIURL, EnvTiDBCloudNativeCloudProvider, EnvTiDBCloudNativeRegion)
+	}
+	if _, err := normalizeDatabaseName(defaultDB); err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", EnvTiDBCloudNativeDefaultDatabaseName, err)
+	}
+	return &Provisioner{
+		apiURL:              strings.TrimRight(apiURL, "/"),
+		cloudProvider:       cloudProvider,
+		region:              region,
+		defaultDatabaseName: defaultDB,
+		client:              &http.Client{Timeout: 60 * time.Second},
+	}, nil
+}
+
+func (p *Provisioner) ProviderType() string { return tenant.ProviderTiDBCloudNative }
+
+func (p *Provisioner) InitSchema(ctx context.Context, dsn string) error {
+	return schema.EnsureTiDBSchemaForModeDSN(ctx, dsn, schema.TiDBEmbeddingModeAuto)
+}
+
+func (p *Provisioner) InitSchemaForAutoEmbeddingProfile(ctx context.Context, dsn string, profile schema.TiDBAutoEmbeddingProfile) error {
+	return schema.EnsureTiDBSchemaForAutoEmbeddingProfileDSN(ctx, dsn, profile)
+}
+
+func (p *Provisioner) Provision(ctx context.Context, tenantID string) (*tenant.ClusterInfo, error) {
+	return nil, fmt.Errorf("tidbcloud native requires request credentials")
+}
+
+func (p *Provisioner) ValidateCredentialProvisionRequest(req tenant.CredentialProvisionRequest) error {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return fmt.Errorf("public_key and private_key are required")
+	}
+	_, err := p.resolveDatabaseName(req.DatabaseName)
+	return err
+}
+
+func (p *Provisioner) ProvisionWithCredentials(ctx context.Context, tenantID string, req tenant.CredentialProvisionRequest) (*tenant.ClusterInfo, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, fmt.Errorf("public_key and private_key are required")
+	}
+	dbName, err := p.resolveDatabaseName(req.DatabaseName)
+	if err != nil {
+		return nil, err
+	}
+	password, err := generateRandomPassword(24)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(map[string]any{
+		"displayName":  clusterDisplayName(tenantID),
+		"rootPassword": password,
+		"region": map[string]string{
+			"name": p.regionName(),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	endpoint := p.apiURL + "/v1beta1/clusters"
+	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodPost, endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("tidbcloud native provision status %d", resp.StatusCode)
+	}
+	info, err := parseClusterInfo(raw)
+	if err != nil {
+		return nil, err
+	}
+	if info.ClusterID == "" {
+		return nil, fmt.Errorf("tidbcloud native response missing cluster id")
+	}
+	if info.State != "" && info.State != "ACTIVE" && (info.Endpoints.Public.Host == "" || info.UserPrefix == "") {
+		info, err = p.waitForClusterActive(ctx, publicKey, privateKey, info.ClusterID)
+		if err != nil {
+			return &tenant.ClusterInfo{
+				TenantID:  tenantID,
+				ClusterID: info.ClusterID,
+				Password:  password,
+				DBName:    dbName,
+				Provider:  tenant.ProviderTiDBCloudNative,
+			}, err
+		}
+	}
+	out := &tenant.ClusterInfo{
+		TenantID:  tenantID,
+		ClusterID: info.ClusterID,
+		Host:      info.Endpoints.Public.Host,
+		Port:      info.Endpoints.Public.Port,
+		Username:  info.Username,
+		Password:  password,
+		DBName:    dbName,
+		Provider:  tenant.ProviderTiDBCloudNative,
+	}
+	if out.Username == "" && info.UserPrefix != "" {
+		out.Username = info.UserPrefix + ".root"
+	}
+	if out.Host == "" || out.Port == 0 {
+		return out, fmt.Errorf("tidbcloud native response missing endpoint")
+	}
+	if out.Username == "" {
+		return out, fmt.Errorf("tidbcloud native response missing username")
+	}
+	if err := ensureDatabaseFunc(ctx, out.Username, out.Password, out.Host, out.Port, dbName); err != nil {
+		return out, fmt.Errorf("ensure tidbcloud native database: %w", err)
+	}
+	return out, nil
+}
+
+func (p *Provisioner) regionName() string {
+	if strings.HasPrefix(p.region, "regions/") {
+		return p.region
+	}
+	return "regions/" + p.cloudProvider + "-" + p.region
+}
+
+func clusterDisplayName(tenantID string) string {
+	const maxDisplayNameLen = 64
+	name := displayNameCharPattern.ReplaceAllString("drive9-"+tenantID, "-")
+	if len(name) <= maxDisplayNameLen {
+		return name
+	}
+	name = name[:maxDisplayNameLen]
+	return strings.TrimRight(name, "-")
+}
+
+func (p *Provisioner) resolveDatabaseName(raw string) (string, error) {
+	name := strings.TrimSpace(raw)
+	if name == "" {
+		name = p.defaultDatabaseName
+	}
+	return normalizeDatabaseName(name)
+}
+
+func normalizeDatabaseName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if !databaseNamePattern.MatchString(name) {
+		return "", fmt.Errorf("database_name must match %s", databaseNamePattern.String())
+	}
+	switch strings.ToLower(name) {
+	case "test", "mysql", "information_schema", "performance_schema", "sys":
+		return "", fmt.Errorf("database_name %q is reserved", name)
+	default:
+		return name, nil
+	}
+}
+
+func ensureDatabase(ctx context.Context, user, password, host string, port int, dbName string) error {
+	cfg := mysql.NewConfig()
+	cfg.User = user
+	cfg.Passwd = password
+	cfg.Net = "tcp"
+	cfg.Addr = fmt.Sprintf("%s:%d", host, port)
+	cfg.ParseTime = true
+	cfg.TLSConfig = "true"
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		return err
+	}
+	return nil
+}
+
+type clusterInfo struct {
+	ClusterID string `json:"clusterId"`
+	State     string `json:"state"`
+	Endpoints struct {
+		Public struct {
+			Host string `json:"host"`
+			Port int    `json:"port"`
+		} `json:"public"`
+	} `json:"endpoints"`
+	UserPrefix string `json:"userPrefix"`
+	Username   string `json:"username"`
+}
+
+func parseClusterInfo(raw []byte) (*clusterInfo, error) {
+	var out clusterInfo
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (p *Provisioner) waitForClusterActive(ctx context.Context, publicKey, privateKey, clusterID string) (*clusterInfo, error) {
+	deadline := time.Now().Add(10 * time.Minute)
+	for {
+		endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s?view=BASIC", p.apiURL, clusterID)
+		resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+		raw, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("tidbcloud native cluster get status %d", resp.StatusCode)
+		}
+		info, err := parseClusterInfo(raw)
+		if err != nil {
+			return nil, err
+		}
+		if info.State == "ACTIVE" {
+			return info, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("tidbcloud native cluster %s not active before timeout: %s", clusterID, info.State)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+	}
+}
+
+func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privateKey, method, uri string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, uri, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	_ = resp.Body.Close()
+
+	wwwAuth := resp.Header.Get("WWW-Authenticate")
+	nonce, realm, qop := parseDigestChallenge(wwwAuth)
+	if nonce == "" {
+		return nil, fmt.Errorf("invalid digest challenge")
+	}
+	auth, err := buildDigestAuth(publicKey, privateKey, method, uri, nonce, realm, qop)
+	if err != nil {
+		return nil, err
+	}
+	req2, err := http.NewRequestWithContext(ctx, method, uri, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("Authorization", auth)
+	return p.client.Do(req2)
+}
+
+func parseDigestChallenge(header string) (nonce, realm, qop string) {
+	header = strings.TrimPrefix(header, "Digest ")
+	parts := strings.Split(header, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "nonce=") {
+			nonce = strings.Trim(strings.TrimPrefix(part, "nonce="), `"`)
+		}
+		if strings.HasPrefix(part, "realm=") {
+			realm = strings.Trim(strings.TrimPrefix(part, "realm="), `"`)
+		}
+		if strings.HasPrefix(part, "qop=") {
+			qop = strings.Trim(strings.TrimPrefix(part, "qop="), `"`)
+		}
+	}
+	return
+}
+
+func buildDigestAuth(username, password, method, uri, nonce, realm, qop string) (string, error) {
+	nc := "00000001"
+	cnonce, err := generateNonce()
+	if err != nil {
+		return "", err
+	}
+	ha1 := md5Hash(fmt.Sprintf("%s:%s:%s", username, realm, password))
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+	path := parsed.Path
+	if parsed.RawQuery != "" {
+		path += "?" + parsed.RawQuery
+	}
+	ha2 := md5Hash(fmt.Sprintf("%s:%s", method, path))
+	resp := md5Hash(fmt.Sprintf("%s:%s:%s:%s:%s:%s", ha1, nonce, nc, cnonce, qop, ha2))
+	return fmt.Sprintf(`Digest username="%s", realm="%s", nonce="%s", uri="%s", qop=%s, nc=%s, cnonce="%s", response="%s"`, username, realm, nonce, path, qop, nc, cnonce, resp), nil
+}
+
+func md5Hash(s string) string { return fmt.Sprintf("%x", md5.Sum([]byte(s))) }
+
+func generateNonce() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
+}
+
+func generateRandomPassword(length int) (string, error) {
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	max := big.NewInt(int64(len(chars)))
+	for i := range b {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		b[i] = chars[n.Int64()]
+	}
+	return string(b), nil
+}

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -59,6 +59,10 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 	if apiURL == "" || cloudProvider == "" || region == "" {
 		return nil, fmt.Errorf("%s, %s and %s are required", EnvTiDBCloudNativeAPIURL, EnvTiDBCloudNativeCloudProvider, EnvTiDBCloudNativeRegion)
 	}
+	parsedAPIURL, err := url.Parse(apiURL)
+	if err != nil || parsedAPIURL.Scheme != "https" || parsedAPIURL.Host == "" {
+		return nil, fmt.Errorf("%s must be a valid https URL", EnvTiDBCloudNativeAPIURL)
+	}
 	if _, err := normalizeDatabaseName(defaultDB); err != nil {
 		return nil, fmt.Errorf("invalid %s: %w", EnvTiDBCloudNativeDefaultDatabaseName, err)
 	}

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1,0 +1,225 @@
+package tidbcloudnative
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/dat9/pkg/tenant"
+)
+
+func TestNewProvisionerFromEnvReadsServerSideConfigOnly(t *testing.T) {
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+	t.Setenv(EnvTiDBCloudNativeDefaultDatabaseName, "drive9_db")
+	t.Setenv("DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY", "must-not-be-read")
+	t.Setenv("DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY", "must-not-be-read")
+
+	p, err := NewProvisionerFromEnv()
+	if err != nil {
+		t.Fatalf("NewProvisionerFromEnv: %v", err)
+	}
+	if p.apiURL != "https://serverless.tidbapi.com" {
+		t.Fatalf("apiURL = %q", p.apiURL)
+	}
+	if p.cloudProvider != "aws" || p.region != "us-east-1" {
+		t.Fatalf("cloud/region = %s/%s", p.cloudProvider, p.region)
+	}
+	if p.defaultDatabaseName != "drive9_db" {
+		t.Fatalf("default db = %q", p.defaultDatabaseName)
+	}
+}
+
+func TestNewProvisionerFromEnvRequiresCloudProviderAndRegion(t *testing.T) {
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+
+	_, err := NewProvisionerFromEnv()
+	if err == nil {
+		t.Fatal("expected missing cloud provider error")
+	}
+	if !strings.Contains(err.Error(), EnvTiDBCloudNativeCloudProvider) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewProvisionerFromEnvRejectsInvalidDefaultDatabaseName(t *testing.T) {
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+	t.Setenv(EnvTiDBCloudNativeDefaultDatabaseName, "test")
+
+	_, err := NewProvisionerFromEnv()
+	if err == nil {
+		t.Fatal("expected invalid database name error")
+	}
+	if !strings.Contains(err.Error(), EnvTiDBCloudNativeDefaultDatabaseName) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testing.T) {
+	var ensureDBCalled bool
+	origEnsureDatabase := ensureDatabaseFunc
+	ensureDatabaseFunc = func(_ context.Context, user, password, host string, port int, dbName string) error {
+		ensureDBCalled = true
+		if user != "u1.root" || password == "" || host != "db.example" || port != 4000 || dbName != "customer_db" {
+			t.Fatalf("ensure database args = %s/%s %s:%d %s", user, password, host, port, dbName)
+		}
+		return nil
+	}
+	t.Cleanup(func() { ensureDatabaseFunc = origEnsureDatabase })
+
+	var gotAuth string
+	var gotBody struct {
+		DisplayName  string `json:"displayName"`
+		RootPassword string `json:"rootPassword"`
+		Region       struct {
+			Name string `json:"name"`
+		} `json:"region"`
+	}
+	var requestCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1beta1/clusters" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"clusterId":  "cluster-1",
+			"state":      "ACTIVE",
+			"userPrefix": "u1",
+			"endpoints":  map[string]any{"public": map[string]any{"host": "db.example", "port": 4000}},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		cloudProvider:       "aws",
+		region:              "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+		client:              ts.Client(),
+	}
+	out, err := p.ProvisionWithCredentials(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
+		PublicKey:    "public-1",
+		PrivateKey:   "private-1",
+		DatabaseName: "customer_db",
+	})
+	if err != nil {
+		t.Fatalf("ProvisionWithCredentials: %v", err)
+	}
+	if !strings.Contains(gotAuth, `username="public-1"`) {
+		t.Fatalf("Authorization header did not use request public key: %q", gotAuth)
+	}
+	if strings.Contains(gotAuth, "private-1") {
+		t.Fatalf("Authorization header leaked private key: %q", gotAuth)
+	}
+	if gotBody.DisplayName != "drive9-tenant-1" {
+		t.Fatalf("displayName = %q", gotBody.DisplayName)
+	}
+	if gotBody.Region.Name != "regions/aws-us-east-1" {
+		t.Fatalf("region.name = %q", gotBody.Region.Name)
+	}
+	if gotBody.RootPassword == "" {
+		t.Fatal("rootPassword was empty")
+	}
+	if out.ClusterID != "cluster-1" || out.Username != "u1.root" || out.DBName != "customer_db" || out.Provider != tenant.ProviderTiDBCloudNative {
+		t.Fatalf("unexpected cluster info: %#v", out)
+	}
+	if !ensureDBCalled {
+		t.Fatal("ensure database was not called")
+	}
+}
+
+func TestProvisionWithCredentialsDefaultsDatabaseName(t *testing.T) {
+	var ensuredDB string
+	origEnsureDatabase := ensureDatabaseFunc
+	ensureDatabaseFunc = func(_ context.Context, _ string, _ string, _ string, _ int, dbName string) error {
+		ensuredDB = dbName
+		return nil
+	}
+	t.Cleanup(func() { ensureDatabaseFunc = origEnsureDatabase })
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"clusterId":  "cluster-1",
+			"state":      "ACTIVE",
+			"userPrefix": "u1",
+			"endpoints":  map[string]any{"public": map[string]any{"host": "db.example", "port": 4000}},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		cloudProvider:       "aws",
+		region:              "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+		client:              ts.Client(),
+	}
+	if _, err := p.ProvisionWithCredentials(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	}); err != nil {
+		t.Fatalf("ProvisionWithCredentials: %v", err)
+	}
+	if ensuredDB != DefaultDatabaseName {
+		t.Fatalf("ensured database = %q, want %q", ensuredDB, DefaultDatabaseName)
+	}
+}
+
+func TestProvisionWithCredentialsRejectsReservedDatabaseName(t *testing.T) {
+	p := &Provisioner{defaultDatabaseName: DefaultDatabaseName}
+	_, err := p.ProvisionWithCredentials(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
+		PublicKey:    "public-1",
+		PrivateKey:   "private-1",
+		DatabaseName: "test",
+	})
+	if err == nil {
+		t.Fatal("expected reserved database_name error")
+	}
+	if !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRegionNameAcceptsFullRegionResourceName(t *testing.T) {
+	p := &Provisioner{cloudProvider: "alicloud", region: "regions/alicloud-ap-southeast-1"}
+	if got := p.regionName(); got != "regions/alicloud-ap-southeast-1" {
+		t.Fatalf("regionName = %q", got)
+	}
+}
+
+func TestClusterDisplayNameMatchesSwaggerContract(t *testing.T) {
+	got := clusterDisplayName("tenant_with_invalid_chars_and_a_very_long_suffix_that_exceeds_the_swagger_limit_1234567890")
+	if len(got) < 4 || len(got) > 64 {
+		t.Fatalf("display name length = %d for %q", len(got), got)
+	}
+	matched, err := regexp.MatchString(`^[A-Za-z0-9][-A-Za-z0-9]{2,62}[A-Za-z0-9]$`, got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !matched {
+		t.Fatalf("display name %q does not match swagger pattern", got)
+	}
+}

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -49,6 +49,20 @@ func TestNewProvisionerFromEnvRequiresCloudProviderAndRegion(t *testing.T) {
 	}
 }
 
+func TestNewProvisionerFromEnvRejectsNonHTTPSAPIURL(t *testing.T) {
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "http://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+
+	_, err := NewProvisionerFromEnv()
+	if err == nil {
+		t.Fatal("expected invalid api URL error")
+	}
+	if !strings.Contains(err.Error(), "valid https URL") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestNewProvisionerFromEnvRejectsInvalidDefaultDatabaseName(t *testing.T) {
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -66,6 +66,7 @@ func TestNewProvisionerFromEnvRejectsInvalidDefaultDatabaseName(t *testing.T) {
 
 func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testing.T) {
 	var ensureDBCalled bool
+	var pollCount int
 	origEnsureDatabase := ensureDatabaseFunc
 	ensureDatabaseFunc = func(_ context.Context, user, password, host string, port int, dbName string) error {
 		ensureDBCalled = true
@@ -86,18 +87,36 @@ func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testin
 	}
 	var requestCount int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1beta1/clusters" {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
 		requestCount++
 		if requestCount == 1 {
 			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
+		if r.URL.Path == "/v1beta1/clusters/cluster-1" {
+			pollCount++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusterId":  "cluster-1",
+				"state":      "ACTIVE",
+				"userPrefix": "u1",
+				"endpoints":  map[string]any{"public": map[string]any{"host": "db.example", "port": 4000}},
+			})
+			return
+		}
+		if r.URL.Path != "/v1beta1/clusters" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
 		gotAuth = r.Header.Get("Authorization")
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Fatalf("decode request body: %v", err)
+		}
+		pollCount++
+		if pollCount == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusterId": "cluster-1",
+				"state":     "CREATING",
+			})
+			return
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"clusterId":  "cluster-1",
@@ -143,6 +162,9 @@ func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testin
 	}
 	if !ensureDBCalled {
 		t.Fatal("ensure database was not called")
+	}
+	if pollCount < 2 {
+		t.Fatalf("poll count = %d, want at least 2", pollCount)
 	}
 }
 
@@ -200,6 +222,40 @@ func TestProvisionWithCredentialsRejectsReservedDatabaseName(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "reserved") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProvisionWithCredentialsIncludesUpstreamBodyOnError(t *testing.T) {
+	longBody := strings.Repeat("x", upstreamErrorBodyLimit+100)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		http.Error(w, longBody, http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		cloudProvider:       "aws",
+		region:              "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+		client:              ts.Client(),
+	}
+	_, err := p.ProvisionWithCredentials(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	if err == nil {
+		t.Fatal("expected upstream error")
+	}
+	if !strings.Contains(err.Error(), "tidbcloud native provision status 400") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "(truncated)") {
+		t.Fatalf("expected truncated upstream body, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `tidbcloud_native` as a server-selected tenant provider
- create TiDB Cloud Starter clusters with request-level customer public/private keys
- create the requested tenant database after cluster creation and initialize it with the existing TiDB auto schema
- wire schema dump, server usage, README, and focused tests

## Testing
- `go test ./pkg/tenant/tidbcloudnative ./cmd/drive9-server`
- `go test ./pkg/server -run 'TestProvisionTiDBCloudNative|TestProvisionUsesConfiguredProvisioner'`\n- `go test ./pkg/tenant -run 'TestNormalizeProvider|TestSmallInDB|TestUsesTiDBAutoEmbedding'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TiDB Cloud Native as a tenant provider with credential-based provisioning (public/private keys) supported via the `POST /v1/provision` request, including required credential validation and provider/db_name persistence.
  * Enabled `tidbcloud_native` in schema-dump init SQL and tenant init-schema generation for auto-embedding mode.

* **Documentation**
  * Extended configuration docs to include `tidbcloud_native` and new `DRIVE9_TIDBCLOUD_NATIVE_*` environment variables, plus the credential/provision request details.

* **Tests**
  * Added/expanded coverage for the native credential provisioning flow, validation failures, and schema-dump behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->