### PR TITLE
Fix shadow upload tier routing

### DIFF
--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1433,9 +1434,9 @@ func TestCommitQueueRecoverPendingSkipsLegacyOverwriteWithoutBaseRev(t *testing.
 
 // --- ShadowSpill tests ---
 
-// TestCommitQueueShadowSpillUpload verifies that ShadowSpill entries are
-// uploaded via streaming (uploadFromShadow) rather than ReadAll, and that
-// the server receives the correct data and expected revision.
+// TestCommitQueueShadowSpillUpload verifies that ShadowSpill entries at or
+// above the cached inline threshold are uploaded via streaming multipart and
+// that the server receives the correct data and expected revision.
 func TestCommitQueueShadowSpillUpload(t *testing.T) {
 	data := bytes.Repeat([]byte("shadowspill-data-"), 100) // ~1700 bytes
 	var gotExpected int64
@@ -1514,7 +1515,9 @@ func TestCommitQueueShadowSpillUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
 	cq.OnSuccess = func(entry *CommitEntry, committedRev int64) {
 		if entry.Path != "/big.bin" {
 			t.Fatalf("OnSuccess path = %q, want /big.bin", entry.Path)
@@ -1549,6 +1552,92 @@ func TestCommitQueueShadowSpillUpload(t *testing.T) {
 	}
 	if shadow.Has("/big.bin") {
 		t.Fatal("shadow should be removed after successful ShadowSpill commit")
+	}
+}
+
+func TestCommitQueueShadowSpillSmallFileDirectPUTCleansState(t *testing.T) {
+	data := []byte("small shadow spill content")
+	const path = "/small-spill.bin"
+	var gotExpected int64 = -1
+	var gotBody []byte
+	var multipartCalls atomic.Int32
+	var successRev int64
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs/small-spill.bin":
+			var err error
+			gotBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read direct PUT body: %v", err)
+			}
+			gotExpected, err = strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64)
+			if err != nil {
+				t.Fatalf("expected revision header: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"revision": 13})
+		case strings.HasPrefix(r.URL.Path, "/v2/uploads/"):
+			multipartCalls.Add(1)
+			t.Fatalf("small ShadowSpill should not use multipart: %s %s", r.Method, r.URL.String())
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(path, data, 12); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutShadowSpill(path, int64(len(data)), PendingOverwrite, 12); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.OnSuccess = func(entry *CommitEntry, committedRev int64) {
+		if entry.Path != path {
+			t.Fatalf("OnSuccess path = %q, want %q", entry.Path, path)
+		}
+		successRev = committedRev
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:        path,
+		BaseRev:     12,
+		Size:        int64(len(data)),
+		Kind:        PendingOverwrite,
+		ShadowSpill: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if gotExpected != 12 {
+		t.Fatalf("expected revision = %d, want 12", gotExpected)
+	}
+	if !bytes.Equal(gotBody, data) {
+		t.Fatalf("direct PUT body = %q, want %q", gotBody, data)
+	}
+	if multipartCalls.Load() != 0 {
+		t.Fatalf("multipart calls = %d, want 0", multipartCalls.Load())
+	}
+	if successRev != 13 {
+		t.Fatalf("OnSuccess committedRev = %d, want 13", successRev)
+	}
+	if pending.HasPending(path) {
+		t.Fatal("pending entry should be removed after successful direct PUT ShadowSpill commit")
+	}
+	if shadow.Has(path) {
+		t.Fatal("shadow should be removed after successful direct PUT ShadowSpill commit")
 	}
 }
 
@@ -1612,7 +1701,9 @@ func TestCommitQueueMultipartCreateInfersRevisionForOpenHandle(t *testing.T) {
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1)
+	fs := NewDat9FS(c, opts)
 	shadow, err := NewShadowStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -1624,7 +1715,7 @@ func TestCommitQueueMultipartCreateInfersRevisionForOpenHandle(t *testing.T) {
 	}
 	fs.shadowStore = shadow
 	fs.pendingIndex = pending
-	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
 	cq.PathLock = fs.lockRemoteCommitPath
 	cq.OnSuccess = fs.onCommitQueueSuccess
 	cq.OnCleanup = fs.onCommitQueueCleanup
@@ -1721,7 +1812,9 @@ func TestCommitQueueShadowSpillConflictTerminal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
 	if err := cq.Enqueue(&CommitEntry{
 		Path:        "/big-conflict.bin",
 		BaseRev:     5,
@@ -1971,7 +2064,9 @@ func TestCommitQueueShadowSpillConflictNotFoundRetriesAsCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
 	cq.OnSuccess = func(entry *CommitEntry, committedRev int64) {
 		successRev = committedRev
 	}
@@ -2119,7 +2214,9 @@ func TestCommitQueueRecoverPendingShadowSpill(t *testing.T) {
 
 	// RecoverPending should reconstruct CommitEntry with ShadowSpill=true,
 	// causing uploadEntry to use streaming (uploadFromShadow) not ReadAll.
-	cq := NewCommitQueue(newTestClient(ts.URL), shadow2, pending2, nil, 1, 8)
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1)
+	cq := NewCommitQueue(c, shadow2, pending2, nil, 1, 8)
 	cq.OnSuccess = func(entry *CommitEntry, committedRev int64) {
 		if entry.Path != "/recover.bin" {
 			t.Fatalf("OnSuccess path = %q, want /recover.bin", entry.Path)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1851,6 +1851,20 @@ func (fs *Dat9FS) markHandleRemoteCommittedLocked(fh *FileHandle, revision int64
 	fh.ShadowCommitSeq = 0
 }
 
+func (fs *Dat9FS) seedReadCacheFromShadowLocked(path string, size int64, revision int64) {
+	if fs == nil || fs.shadowStore == nil || fs.readCache == nil || revision <= 0 {
+		return
+	}
+	if size > fs.readCache.MaxFileSize() {
+		return
+	}
+	data, err := fs.shadowStore.ReadAll(path)
+	if err != nil {
+		return
+	}
+	fs.readCache.PutOwned(path, data, revision)
+}
+
 func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gofuse.Status {
 	statStart := fs.perfStart()
 	stat, err := fs.client.StatCtx(ctx, fs.remotePath(fh.Path))
@@ -8595,6 +8609,7 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		clearReadTargetForLockedHandle(fh)
 		if committedRev > 0 {
 			fs.clearReadTargetsForPathExcept(fh.Path, fh)
+			fs.seedReadCacheFromShadowLocked(fh.Path, size, committedRev)
 			fs.markHandleRemoteCommittedLocked(fh, committedRev)
 		} else {
 			fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
@@ -8911,6 +8926,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			if committedRev > 0 {
 				clearReadTargetForLockedHandle(fh)
 				fs.clearReadTargetsForPathExcept(fh.Path, fh)
+				fs.seedReadCacheFromShadowLocked(fh.Path, size, committedRev)
 				fs.markHandleRemoteCommittedLocked(fh, committedRev)
 				fs.inodes.UpdateSize(fh.Ino, size)
 				fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
@@ -9168,6 +9184,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		if committedRev > 0 {
 			clearReadTargetForLockedHandle(fh)
 			fs.clearReadTargetsForPathExcept(fh.Path, fh)
+			fs.seedReadCacheFromShadowLocked(fh.Path, size, committedRev)
 			fs.markHandleRemoteCommittedLocked(fh, committedRev)
 			fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
 		} else {

--- a/pkg/fuse/remote_upload.go
+++ b/pkg/fuse/remote_upload.go
@@ -38,6 +38,14 @@ func uploadFromShadowRemoteWithRevision(ctx context.Context, c *client.Client, s
 	if size == 0 {
 		return c.WriteCtxConditionalWithRevision(ctx, remotePath, nil, expectedRevision)
 	}
+	threshold := c.CachedSmallFileThreshold()
+	if threshold > 0 && size < threshold {
+		data, err := shadows.ReadAll(localPath)
+		if err != nil {
+			return 0, err
+		}
+		return c.WriteCtxConditionalWithRevision(ctx, remotePath, data, expectedRevision)
+	}
 	ra := &shadowReaderAt{store: shadows, path: localPath}
 	sr := io.NewSectionReader(ra, 0, size)
 	if err := c.WriteMultipartStreamConditional(ctx, remotePath, sr, size, nil, expectedRevision); err != nil {

--- a/pkg/fuse/remote_upload_test.go
+++ b/pkg/fuse/remote_upload_test.go
@@ -50,7 +50,34 @@ func newMultipartUploadRecorder(t *testing.T, wantPath string, wantSize int64, w
 		switch {
 		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/v1/fs/"):
 			rec.directFilePuts.Add(1)
+			gotPath := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+			if gotPath != rec.wantPath {
+				t.Fatalf("direct PUT path = %q, want %q", gotPath, rec.wantPath)
+			}
+			gotExpected, err := strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64)
+			if err != nil {
+				t.Fatalf("direct PUT expected revision header: %v", err)
+			}
+			if rec.wantExpected == nil {
+				if gotExpected != -1 {
+					t.Fatalf("direct PUT expected revision = %d, want -1", gotExpected)
+				}
+			} else if gotExpected != *rec.wantExpected {
+				t.Fatalf("direct PUT expected revision = %d, want %d", gotExpected, *rec.wantExpected)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read direct PUT body: %v", err)
+			}
+			if int64(len(body)) != rec.wantSize {
+				t.Fatalf("direct PUT body size = %d, want %d", len(body), rec.wantSize)
+			}
+			rec.mu.Lock()
+			rec.gotUploadedBytes = int64(len(body))
+			rec.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"revision": rec.committedRev})
 			return
 
 		case r.Method == http.MethodHead && strings.HasPrefix(r.URL.Path, "/v1/fs/"):
@@ -178,7 +205,7 @@ func (rec *multipartUploadRecorder) client() *client.Client {
 	return newTestClient(rec.server.URL)
 }
 
-func TestUploadFromShadowRemoteWithRevisionStreamsSmallSpill(t *testing.T) {
+func TestUploadFromShadowRemoteWithRevisionDirectPutsSmallSpill(t *testing.T) {
 	const remotePath = "/sqlite/workload.db-journal"
 	data := []byte("small sqlite journal frame")
 	expectedRevision := int64(3)
@@ -186,6 +213,49 @@ func TestUploadFromShadowRemoteWithRevisionStreamsSmallSpill(t *testing.T) {
 
 	c := rec.client()
 	c.SetSmallFileThresholdForTests(50_000)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull(remotePath, data, expectedRevision); err != nil {
+		t.Fatal(err)
+	}
+
+	committedRev, err := uploadFromShadowRemoteWithRevision(context.Background(), c, shadow, remotePath, remotePath, expectedRevision)
+	if err != nil {
+		t.Fatalf("uploadFromShadowRemoteWithRevision: %v", err)
+	}
+	if committedRev != rec.committedRev {
+		t.Fatalf("committed revision = %d, want %d", committedRev, rec.committedRev)
+	}
+	if rec.directFilePuts.Load() != 1 {
+		t.Fatalf("direct PUT count = %d, want 1", rec.directFilePuts.Load())
+	}
+	if rec.initiateCalls.Load() != 0 || rec.presignCalls.Load() != 0 || rec.completeCalls.Load() != 0 || rec.s3PutCalls.Load() != 0 {
+		t.Fatalf("multipart flow calls = initiate:%d presign:%d complete:%d s3put:%d, want 0 each",
+			rec.initiateCalls.Load(), rec.presignCalls.Load(), rec.completeCalls.Load(), rec.s3PutCalls.Load())
+	}
+	if rec.statCalls.Load() != 0 {
+		t.Fatalf("stat calls = %d, want 0", rec.statCalls.Load())
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if rec.gotUploadedBytes != int64(len(data)) {
+		t.Fatalf("uploaded bytes = %d, want %d", rec.gotUploadedBytes, len(data))
+	}
+}
+
+func TestUploadFromShadowRemoteWithRevisionUsesMultipartAtThreshold(t *testing.T) {
+	const remotePath = "/threshold.bin"
+	data := []byte("exact threshold data")
+	expectedRevision := int64(9)
+	rec := newMultipartUploadRecorder(t, remotePath, int64(len(data)), &expectedRevision)
+
+	c := rec.client()
+	c.SetSmallFileThresholdForTests(int64(len(data)))
 
 	shadow, err := NewShadowStore(t.TempDir())
 	if err != nil {
@@ -210,14 +280,38 @@ func TestUploadFromShadowRemoteWithRevisionStreamsSmallSpill(t *testing.T) {
 		t.Fatalf("multipart flow calls = initiate:%d presign:%d complete:%d s3put:%d, want 1 each",
 			rec.initiateCalls.Load(), rec.presignCalls.Load(), rec.completeCalls.Load(), rec.s3PutCalls.Load())
 	}
-	if rec.statCalls.Load() != 0 {
-		t.Fatalf("stat calls = %d, want 0", rec.statCalls.Load())
+}
+
+func TestUploadFromShadowRemoteWithRevisionUsesMultipartWhenThresholdUnknown(t *testing.T) {
+	const remotePath = "/unknown-threshold.bin"
+	data := []byte("small but threshold is unknown")
+	expectedRevision := int64(11)
+	rec := newMultipartUploadRecorder(t, remotePath, int64(len(data)), &expectedRevision)
+
+	c := client.New(rec.server.URL, "")
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull(remotePath, data, expectedRevision); err != nil {
+		t.Fatal(err)
 	}
 
-	rec.mu.Lock()
-	defer rec.mu.Unlock()
-	if rec.gotUploadedBytes != int64(len(data)) {
-		t.Fatalf("uploaded bytes = %d, want %d", rec.gotUploadedBytes, len(data))
+	committedRev, err := uploadFromShadowRemoteWithRevision(context.Background(), c, shadow, remotePath, remotePath, expectedRevision)
+	if err != nil {
+		t.Fatalf("uploadFromShadowRemoteWithRevision: %v", err)
+	}
+	if committedRev != 0 {
+		t.Fatalf("committed revision = %d, want 0 for multipart stream", committedRev)
+	}
+	if rec.directFilePuts.Load() != 0 {
+		t.Fatalf("direct PUT count = %d, want 0", rec.directFilePuts.Load())
+	}
+	if rec.initiateCalls.Load() != 1 || rec.presignCalls.Load() != 1 || rec.completeCalls.Load() != 1 || rec.s3PutCalls.Load() != 1 {
+		t.Fatalf("multipart flow calls = initiate:%d presign:%d complete:%d s3put:%d, want 1 each",
+			rec.initiateCalls.Load(), rec.presignCalls.Load(), rec.completeCalls.Load(), rec.s3PutCalls.Load())
 	}
 }
 

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -2748,6 +2748,59 @@ func TestFsyncQueuedCommitSameOpenHandleWritePreservesCommittedBytes(t *testing.
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
 			return
+		case r.Method == http.MethodPatch && r.URL.Path == "/v1/fs"+filePath:
+			var req struct {
+				NewSize int64 `json:"new_size"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode patch request: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if req.NewSize != int64(len(wantFinal)) {
+				t.Errorf("patch new_size = %d, want %d", req.NewSize, len(wantFinal))
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"upload_id": "patch-1",
+				"part_size": req.NewSize,
+				"upload_parts": []map[string]any{{
+					"number":   1,
+					"url":      ts.URL + "/patch/patch-1/1",
+					"size":     req.NewSize,
+					"read_url": ts.URL + "/patch-read",
+				}},
+			})
+			return
+		case r.Method == http.MethodGet && r.URL.Path == "/patch-read":
+			mu.Lock()
+			data := append([]byte(nil), remote[filePath]...)
+			mu.Unlock()
+			_, _ = w.Write(data)
+			return
+		case r.Method == http.MethodPut && r.URL.Path == "/patch/patch-1/1":
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			uploads["patch-1"] = &uploadState{path: filePath, size: int64(len(body)), body: append([]byte(nil), body...)}
+			mu.Unlock()
+			w.Header().Set("ETag", "etag-patch")
+			w.WriteHeader(http.StatusOK)
+			return
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/uploads/patch-1/complete":
+			mu.Lock()
+			state := uploads["patch-1"]
+			if state == nil || len(state.body) == 0 {
+				mu.Unlock()
+				t.Errorf("patch complete before body")
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			remote[filePath] = append([]byte(nil), state.body...)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
 		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+filePath:
 			body, _ := io.ReadAll(r.Body)
 			mu.Lock()
@@ -2794,6 +2847,7 @@ func TestFsyncQueuedCommitSameOpenHandleWritePreservesCommittedBytes(t *testing.
 	opts := &MountOptions{FlushDebounce: 0, SyncMode: SyncInteractive}
 	opts.setDefaults()
 	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1)
 	fs := NewDat9FS(c, opts)
 	shadow, err := NewShadowStore(t.TempDir())
 	if err != nil {
@@ -3144,6 +3198,9 @@ func TestFsyncShadowSpillCommitRefreshesRevisionAndClearsPending(t *testing.T) {
 	if shadow.Has(filePath) {
 		t.Fatal("shadow should be cleared after remote-durable fsync")
 	}
+	if cached, ok := fs.readCache.Get(filePath, 1); !ok || string(cached) != "first journal frame" {
+		t.Fatalf("read cache after first fsync = %q, ok=%t; want first journal frame", cached, ok)
+	}
 
 	if _, st := fs.Write(nil, &gofuse.WriteIn{
 		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
@@ -3160,6 +3217,9 @@ func TestFsyncShadowSpillCommitRefreshesRevisionAndClearsPending(t *testing.T) {
 	}
 	if fh.BaseRev != 2 {
 		t.Fatalf("BaseRev after second fsync = %d, want 2", fh.BaseRev)
+	}
+	if cached, ok := fs.readCache.Get(filePath, 2); !ok || string(cached) != "second journal frame" {
+		t.Fatalf("read cache after second fsync = %q, ok=%t; want second journal frame", cached, ok)
 	}
 
 	mu.Lock()
@@ -3280,6 +3340,28 @@ func newShadowSpillFallbackRecorder(t *testing.T, wantPath string, chmodStatus i
 				status = http.StatusOK
 			}
 			w.WriteHeader(status)
+			return
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+rec.wantPath:
+			gotExpected, err := strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64)
+			if err != nil {
+				t.Fatalf("expected revision header: %v", err)
+			}
+			if gotExpected != 0 {
+				t.Fatalf("expected_revision = %d, want 0", gotExpected)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read direct PUT body: %v", err)
+			}
+			if len(body) == 0 {
+				t.Fatal("direct PUT body should not be empty")
+			}
+			rec.mu.Lock()
+			rec.uploadCount++
+			rec.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"revision": 1})
 			return
 		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/initiate":
 			var req struct {


### PR DESCRIPTION
## Summary
- route ShadowSpill uploads below the cached server inline threshold through direct PUT so they land in DB/TiDB inline storage
- keep threshold-unknown and size >= threshold shadow uploads on multipart/S3
- seed read cache from shadow data before successful synchronous shadow commits clear local shadow state

## Tests
- /usr/local/go/bin/go test ./pkg/fuse -run 'TestFsyncShadowSpillCommitRefreshesRevisionAndClearsPending|TestUploadFromShadowRemoteWithRevision|TestCommitQueueShadowSpillSmallFileDirectPUTCleansState|TestCommitQueueShadowSpillUpload|TestReleaseShadowSpillFallback' -count=1\n- /usr/local/go/bin/go test ./pkg/fuse -count=1\n- git diff --check\n\n## Notes\n- Backend tier transition focused tests could not run locally because testcontainers panics with: rootless Docker not found. Existing backend tier transition coverage remains unchanged.\n\nFixes #558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Small files are now uploaded more efficiently using optimized direct PUT transfers instead of multipart streaming.
  * Read cache is automatically populated from shadow storage after successful uploads for improved performance.
  * Enhanced state cleanup and recovery mechanisms to ensure data consistency after commits.

* **Tests**
  * Added comprehensive test coverage for direct PUT uploads and small-file handling scenarios.
  * Expanded validation of revision tracking, request bodies, and state management across upload flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->