### PR TITLE
fix(fuse): stage writeback path truncates locally

### DIFF
--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -380,6 +380,15 @@ with open(path, "wb") as handle:
 PY
 }
 
+path_truncate_zero() {
+  local file_path="$1"
+  python3 - "$file_path" <<'PY'
+import os
+import sys
+os.truncate(sys.argv[1], 0)
+PY
+}
+
 wait_mount_state() {
   local expect="$1"
   local deadline=$(( $(date +%s) + MOUNT_READY_TIMEOUT_S ))
@@ -731,12 +740,25 @@ RW_HARDLINK_MOUNT="$MOUNT_POINT/$RW_HARDLINK_REL"
 RW_TEXT_RENAMED_REL="${RW_ALPHA_REL}/text-renamed.txt"
 RW_TEXT_RENAMED_REMOTE="/${RW_TEXT_RENAMED_REL}"
 RW_TEXT_RENAMED_MOUNT="$MOUNT_POINT/$RW_TEXT_RENAMED_REL"
+RW_PATH_TRUNC_REL="${RW_ALPHA_REL}/path-truncate.txt"
+RW_PATH_TRUNC_REMOTE="/${RW_PATH_TRUNC_REL}"
+RW_PATH_TRUNC_MOUNT="$MOUNT_POINT/$RW_PATH_TRUNC_REL"
+RW_PATH_TRUNC_RENAME_SRC_REL="${RW_ALPHA_REL}/path-truncate-rename-src.txt"
+RW_PATH_TRUNC_RENAME_SRC_REMOTE="/${RW_PATH_TRUNC_RENAME_SRC_REL}"
+RW_PATH_TRUNC_RENAME_SRC_MOUNT="$MOUNT_POINT/$RW_PATH_TRUNC_RENAME_SRC_REL"
+RW_PATH_TRUNC_RENAME_DST_REL="${RW_ALPHA_REL}/path-truncate-rename-dst.txt"
+RW_PATH_TRUNC_RENAME_DST_REMOTE="/${RW_PATH_TRUNC_RENAME_DST_REL}"
+RW_PATH_TRUNC_RENAME_DST_MOUNT="$MOUNT_POINT/$RW_PATH_TRUNC_RENAME_DST_REL"
+RW_PATH_TRUNC_UNLINK_REL="${RW_ALPHA_REL}/path-truncate-unlink.txt"
+RW_PATH_TRUNC_UNLINK_REMOTE="/${RW_PATH_TRUNC_UNLINK_REL}"
+RW_PATH_TRUNC_UNLINK_MOUNT="$MOUNT_POINT/$RW_PATH_TRUNC_UNLINK_REL"
 RW_ATTR_REL="${RW_ALPHA_REL}/attr.txt"
 RW_ATTR_REMOTE="/${RW_ATTR_REL}"
 RW_ATTR_MOUNT="$MOUNT_POINT/$RW_ATTR_REL"
 RW_ALPHA_RENAMED_REL="${ROOT_REL}/alpha-renamed"
 RW_ALPHA_RENAMED_REMOTE="/${RW_ALPHA_RENAMED_REL}"
 RW_ALPHA_RENAMED_MOUNT="$MOUNT_POINT/$RW_ALPHA_RENAMED_REL"
+RW_PATH_TRUNC_AFTER_RENAME_MOUNT="$MOUNT_POINT/${RW_ALPHA_RENAMED_REL}/path-truncate.txt"
 CLI_TO_MOUNT_REL="${RW_ALPHA_RENAMED_REL}/from-cli.txt"
 CLI_TO_MOUNT_REMOTE="/${CLI_TO_MOUNT_REL}"
 CLI_TO_MOUNT_MOUNT="$MOUNT_POINT/$CLI_TO_MOUNT_REL"
@@ -884,6 +906,47 @@ if is_mounted "$MOUNT_POINT"; then
     check_eq "truncate sets size to 0" "$truncated_size" "0"
   else
     check_eq "truncate via mount succeeds" "false" "true"
+  fi
+
+  printf "path-truncate-%s" "$TS" > "$RW_PATH_TRUNC_MOUNT"
+  path_truncate_seed=$(wait_remote_cat_eq "$RW_PATH_TRUNC_REMOTE" "path-truncate-${TS}")
+  check_eq "explicit path truncate seed visible via remote cat" "$path_truncate_seed" "path-truncate-${TS}"
+  if path_truncate_zero "$RW_PATH_TRUNC_MOUNT"; then
+    check_eq "explicit path truncate succeeds" "true" "true"
+    path_truncate_local=$(cat "$RW_PATH_TRUNC_MOUNT")
+    path_truncate_remote_size=$(wait_remote_stat_field_eq "$RW_PATH_TRUNC_REMOTE" "size" "0")
+    path_truncate_remote=$(wait_remote_cat_eq "$RW_PATH_TRUNC_REMOTE" "")
+    check_eq "explicit path truncate immediate mounted read is empty" "$path_truncate_local" ""
+    check_eq "explicit path truncate remote size is 0" "$path_truncate_remote_size" "0"
+    check_eq "explicit path truncate remote content is empty" "$path_truncate_remote" ""
+  else
+    check_eq "explicit path truncate succeeds" "false" "true"
+  fi
+
+  printf "path-truncate-rename-%s" "$TS" > "$RW_PATH_TRUNC_RENAME_SRC_MOUNT"
+  path_truncate_rename_seed=$(wait_remote_cat_eq "$RW_PATH_TRUNC_RENAME_SRC_REMOTE" "path-truncate-rename-${TS}")
+  check_eq "explicit path truncate rename seed visible via remote cat" "$path_truncate_rename_seed" "path-truncate-rename-${TS}"
+  if path_truncate_zero "$RW_PATH_TRUNC_RENAME_SRC_MOUNT" && mv "$RW_PATH_TRUNC_RENAME_SRC_MOUNT" "$RW_PATH_TRUNC_RENAME_DST_MOUNT"; then
+    check_eq "explicit path truncate then rename succeeds" "true" "true"
+    check_cmd_fail "explicit path truncate rename source missing locally" test -e "$RW_PATH_TRUNC_RENAME_SRC_MOUNT"
+    path_truncate_rename_size=$(wait_remote_stat_field_eq "$RW_PATH_TRUNC_RENAME_DST_REMOTE" "size" "0")
+    path_truncate_rename_remote=$(wait_remote_cat_eq "$RW_PATH_TRUNC_RENAME_DST_REMOTE" "")
+    check_cmd "explicit path truncate rename source missing remotely" wait_remote_ls_missing_name "$RW_ALPHA_REMOTE" "path-truncate-rename-src.txt"
+    check_eq "explicit path truncate rename destination remote size is 0" "$path_truncate_rename_size" "0"
+    check_eq "explicit path truncate rename destination remote content is empty" "$path_truncate_rename_remote" ""
+  else
+    check_eq "explicit path truncate then rename succeeds" "false" "true"
+  fi
+
+  printf "path-truncate-unlink-%s" "$TS" > "$RW_PATH_TRUNC_UNLINK_MOUNT"
+  path_truncate_unlink_seed=$(wait_remote_cat_eq "$RW_PATH_TRUNC_UNLINK_REMOTE" "path-truncate-unlink-${TS}")
+  check_eq "explicit path truncate unlink seed visible via remote cat" "$path_truncate_unlink_seed" "path-truncate-unlink-${TS}"
+  if path_truncate_zero "$RW_PATH_TRUNC_UNLINK_MOUNT" && rm -f "$RW_PATH_TRUNC_UNLINK_MOUNT"; then
+    check_eq "explicit path truncate then unlink succeeds" "true" "true"
+    check_cmd_fail "explicit path truncate unlink target missing locally" test -e "$RW_PATH_TRUNC_UNLINK_MOUNT"
+    check_cmd "explicit path truncate unlink target missing remotely" wait_remote_ls_missing_name "$RW_ALPHA_REMOTE" "path-truncate-unlink.txt"
+  else
+    check_eq "explicit path truncate then unlink succeeds" "false" "true"
   fi
 
   echo "[6] attribute semantics"
@@ -1119,6 +1182,13 @@ PY
         tier_remount_hash=""
       fi
       check_eq "tier transition final checksum survives remount" "$tier_remount_hash" "$tier_small_final_hash"
+      check_cmd "explicit path truncate file visible after remount" wait_path_exists "$RW_PATH_TRUNC_AFTER_RENAME_MOUNT"
+      if [ -f "$RW_PATH_TRUNC_AFTER_RENAME_MOUNT" ]; then
+        path_truncate_remount=$(cat "$RW_PATH_TRUNC_AFTER_RENAME_MOUNT")
+      else
+        path_truncate_remount="missing"
+      fi
+      check_eq "explicit path truncate content survives remount" "$path_truncate_remount" ""
     else
       echo "SKIP tier transition remount content checks because rw mount is unavailable"
       rw_mount_available=false

--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -486,6 +486,57 @@ PY
   done
 }
 
+assert_remote_ls_missing_stable() {
+  local parent="$1"
+  local name="$2"
+  local stable_s="${3:-3}"
+  local interval_s="${4:-0.25}"
+  local deadline
+  local out rc
+
+  wait_remote_ls_missing_name "$parent" "$name" || return 1
+  deadline=$(python3 - "$stable_s" <<'PY'
+import sys
+import time
+print(time.time() + float(sys.argv[1]))
+PY
+)
+
+  while :; do
+    set +e
+    out=$(drive9 fs ls "$parent" 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+      if python3 - "$out" "$name" <<'PY'
+import sys
+lines=[ln.strip() for ln in sys.argv[1].splitlines() if ln.strip()]
+name=sys.argv[2]
+raise SystemExit(0 if all(line != name and line != name + "/" for line in lines) else 1)
+PY
+      then
+        :
+      else
+        printf 'assert_remote_ls_missing_stable: %s reappeared under %s\n' "$name" "$parent" >&2
+        return 1
+      fi
+    elif [[ "$out" != *"not found"* && "$out" != *"Too Many Requests"* && "$out" != *"HTTP 429"* && "$out" != *"HTTP 403"* && "$out" != *"403 Forbidden"* ]]; then
+      printf '%s\n' "$out" >&2
+      return 1
+    fi
+
+    if python3 - "$deadline" <<'PY'
+import sys
+import time
+raise SystemExit(0 if time.time() >= float(sys.argv[1]) else 1)
+PY
+    then
+      return 0
+    fi
+    sleep "$interval_s"
+  done
+}
+
 wait_remote_cat_eq() {
   local path="$1"
   local want="$2"
@@ -931,7 +982,7 @@ if is_mounted "$MOUNT_POINT"; then
     check_cmd_fail "explicit path truncate rename source missing locally" test -e "$RW_PATH_TRUNC_RENAME_SRC_MOUNT"
     path_truncate_rename_size=$(wait_remote_stat_field_eq "$RW_PATH_TRUNC_RENAME_DST_REMOTE" "size" "0")
     path_truncate_rename_remote=$(wait_remote_cat_eq "$RW_PATH_TRUNC_RENAME_DST_REMOTE" "")
-    check_cmd "explicit path truncate rename source missing remotely" wait_remote_ls_missing_name "$RW_ALPHA_REMOTE" "path-truncate-rename-src.txt"
+    check_cmd "explicit path truncate rename source stays missing remotely" assert_remote_ls_missing_stable "$RW_ALPHA_REMOTE" "path-truncate-rename-src.txt"
     check_eq "explicit path truncate rename destination remote size is 0" "$path_truncate_rename_size" "0"
     check_eq "explicit path truncate rename destination remote content is empty" "$path_truncate_rename_remote" ""
   else
@@ -944,7 +995,7 @@ if is_mounted "$MOUNT_POINT"; then
   if path_truncate_zero "$RW_PATH_TRUNC_UNLINK_MOUNT" && rm -f "$RW_PATH_TRUNC_UNLINK_MOUNT"; then
     check_eq "explicit path truncate then unlink succeeds" "true" "true"
     check_cmd_fail "explicit path truncate unlink target missing locally" test -e "$RW_PATH_TRUNC_UNLINK_MOUNT"
-    check_cmd "explicit path truncate unlink target missing remotely" wait_remote_ls_missing_name "$RW_ALPHA_REMOTE" "path-truncate-unlink.txt"
+    check_cmd "explicit path truncate unlink target stays missing remotely" assert_remote_ls_missing_stable "$RW_ALPHA_REMOTE" "path-truncate-unlink.txt"
   else
     check_eq "explicit path truncate then unlink succeeds" "false" "true"
   fi

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -397,6 +397,39 @@ func (cq *CommitQueue) CancelPathPreserveLocal(path string) {
 	cq.cancelPath(path, true)
 }
 
+// CancelQueuedZeroTruncatePreserveLocal cancels queued, not in-flight,
+// zero-byte overwrite entries for path without removing shadow/pending state.
+// It returns true only when no in-flight or other queued same-path entry remains.
+func (cq *CommitQueue) CancelQueuedZeroTruncatePreserveLocal(path string) bool {
+	if cq == nil || path == "" {
+		return true
+	}
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	if cq.inFlight[path] != nil {
+		return false
+	}
+	otherQueued := false
+	remaining := cq.queue[:0]
+	for _, entry := range cq.queue {
+		if entry == nil || entry.Path != path {
+			remaining = append(remaining, entry)
+			continue
+		}
+		if isQueuedZeroTruncateEntry(entry) {
+			entry.canceled = true
+			continue
+		}
+		otherQueued = true
+		remaining = append(remaining, entry)
+	}
+	cq.queue = remaining
+	if cq.queuedByPath != nil {
+		cq.rebuildQueuedIndexLocked()
+	}
+	return !otherQueued
+}
+
 func (cq *CommitQueue) cancelPath(path string, preserveLocal bool) {
 	var cancels []context.CancelFunc
 	seen := make(map[*CommitEntry]struct{})
@@ -581,6 +614,10 @@ func (cq *CommitQueue) worker() {
 		// Clear in-flight after all cleanup is done.
 		cq.endInFlight(entry)
 	}
+}
+
+func isQueuedZeroTruncateEntry(entry *CommitEntry) bool {
+	return entry != nil && entry.Kind == PendingOverwrite && entry.Size == 0
 }
 
 func (cq *CommitQueue) beginInFlight(entry *CommitEntry) bool {

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -2352,3 +2352,67 @@ func TestCommitQueueCancelPathJournalsCommitMarker(t *testing.T) {
 		t.Error("unlinked path resurrected from WAL — cancel marker missing")
 	}
 }
+
+func TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight(t *testing.T) {
+	zero := &CommitEntry{Path: "/file.txt", Size: 0, Kind: PendingOverwrite}
+	nonzero := &CommitEntry{Path: "/other.txt", Size: 4, Kind: PendingOverwrite}
+	cq := &CommitQueue{
+		queue:        []*CommitEntry{zero, nonzero},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{},
+	}
+	cq.rebuildQueuedIndexLocked()
+
+	if !cq.CancelQueuedZeroTruncatePreserveLocal("/file.txt") {
+		t.Fatal("cancel queued zero truncate returned false")
+	}
+	if !zero.canceled {
+		t.Fatal("zero truncate entry was not marked canceled")
+	}
+	if cq.HasPath("/file.txt") {
+		t.Fatal("zero truncate path still queued")
+	}
+	if !cq.HasPath("/other.txt") {
+		t.Fatal("non-zero queued entry was affected")
+	}
+
+	zero = &CommitEntry{Path: "/same.txt", Size: 0, Kind: PendingOverwrite}
+	samePathNonzero := &CommitEntry{Path: "/same.txt", Size: 4, Kind: PendingOverwrite}
+	cq = &CommitQueue{
+		queue:        []*CommitEntry{zero, samePathNonzero},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{},
+	}
+	cq.rebuildQueuedIndexLocked()
+
+	if cq.CancelQueuedZeroTruncatePreserveLocal("/same.txt") {
+		t.Fatal("cancel returned true while non-zero same-path entry remained queued")
+	}
+	if !zero.canceled {
+		t.Fatal("zero truncate entry was not marked canceled with same-path non-zero entry")
+	}
+	if samePathNonzero.canceled {
+		t.Fatal("non-zero same-path entry was canceled")
+	}
+	if !cq.HasPath("/same.txt") {
+		t.Fatal("same-path non-zero entry disappeared")
+	}
+
+	inFlight := &CommitEntry{Path: "/busy.txt", Size: 0, Kind: PendingOverwrite}
+	cq = &CommitQueue{
+		queue:        []*CommitEntry{inFlight},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{"/busy.txt": inFlight},
+	}
+	cq.rebuildQueuedIndexLocked()
+
+	if cq.CancelQueuedZeroTruncatePreserveLocal("/busy.txt") {
+		t.Fatal("cancel returned true for in-flight zero truncate")
+	}
+	if inFlight.canceled {
+		t.Fatal("in-flight zero truncate was canceled")
+	}
+	if !cq.HasPath("/busy.txt") {
+		t.Fatal("in-flight path disappeared")
+	}
+}

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -579,6 +579,73 @@ func TestCommitQueueSkipsDefaultModeForPendingNew(t *testing.T) {
 	}
 }
 
+func TestCommitQueueSkipsDefaultModeForPendingOverwrite(t *testing.T) {
+	var putCalls atomic.Int32
+	var chmodCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			putCalls.Add(1)
+			if got := r.Header.Get("X-Dat9-Expected-Revision"); got != "7" {
+				t.Errorf("X-Dat9-Expected-Revision = %q, want 7", got)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
+			chmodCalls.Add(1)
+			http.Error(w, "unexpected chmod", http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull("/plain.txt", []byte("data"), 7); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRevAndMode("/plain.txt", 4, PendingOverwrite, 7, defaultRegularFileMode, true); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:    "/plain.txt",
+		BaseRev: 7,
+		Size:    4,
+		Kind:    PendingOverwrite,
+		Mode:    defaultRegularFileMode,
+		HasMode: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want 1", got)
+	}
+	if got := chmodCalls.Load(); got != 0 {
+		t.Fatalf("chmod calls = %d, want 0", got)
+	}
+	if pending.HasPending("/plain.txt") {
+		t.Fatal("pending entry should be removed after successful default-mode overwrite")
+	}
+	if shadow.Has("/plain.txt") {
+		t.Fatal("shadow should be removed after successful default-mode overwrite")
+	}
+}
+
 func TestCommitQueueRetriesPostUploadChmodNotFound(t *testing.T) {
 	var putCalls atomic.Int32
 	var chmodCalls atomic.Int32

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -579,70 +579,9 @@ func TestCommitQueueSkipsDefaultModeForPendingNew(t *testing.T) {
 	}
 }
 
-func TestCommitQueueSkipsDefaultModeForPendingOverwrite(t *testing.T) {
-	var putCalls atomic.Int32
-	var chmodCalls atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPut:
-			putCalls.Add(1)
-			if got := r.Header.Get("X-Dat9-Expected-Revision"); got != "7" {
-				t.Errorf("X-Dat9-Expected-Revision = %q, want 7", got)
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
-		case r.Method == http.MethodPost && r.URL.RawQuery == "chmod":
-			chmodCalls.Add(1)
-			http.Error(w, "unexpected chmod", http.StatusInternalServerError)
-		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-	}))
-	defer ts.Close()
-
-	shadow, err := NewShadowStore(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer shadow.Close()
-	pending, err := NewPendingIndex(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := shadow.WriteFull("/plain.txt", []byte("data"), 7); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := pending.PutWithBaseRevAndMode("/plain.txt", 4, PendingOverwrite, 7, defaultRegularFileMode, true); err != nil {
-		t.Fatal(err)
-	}
-
-	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
-	if err := cq.Enqueue(&CommitEntry{
-		Path:    "/plain.txt",
-		BaseRev: 7,
-		Size:    4,
-		Kind:    PendingOverwrite,
-		Mode:    defaultRegularFileMode,
-		HasMode: true,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	cq.DrainAll()
-
-	if got := putCalls.Load(); got != 1 {
-		t.Fatalf("PUT calls = %d, want 1", got)
-	}
-	if got := chmodCalls.Load(); got != 0 {
-		t.Fatalf("chmod calls = %d, want 0", got)
-	}
-	if pending.HasPending("/plain.txt") {
-		t.Fatal("pending entry should be removed after successful default-mode overwrite")
-	}
-	if shadow.Has("/plain.txt") {
-		t.Fatal("shadow should be removed after successful default-mode overwrite")
+func TestShouldApplyRemoteModePreservesExplicitDefaultOverwrite(t *testing.T) {
+	if !shouldApplyRemoteMode(PendingOverwrite, true, defaultRegularFileMode) {
+		t.Fatal("PendingOverwrite with explicit 0644 mode must still apply remote chmod")
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1308,6 +1308,13 @@ func (fs *Dat9FS) writePolicyForOpen(flags uint32) WritePolicy {
 	return policy
 }
 
+func (fs *Dat9FS) mountWritePolicy() WritePolicy {
+	if fs == nil || fs.opts == nil || fs.opts.WritePolicy == "" {
+		return WritePolicyWriteBack
+	}
+	return fs.opts.WritePolicy
+}
+
 func isGitLooseObjectFinalPath(p string) bool {
 	const marker = "/.git/objects/"
 
@@ -2280,6 +2287,68 @@ func (fs *Dat9FS) finalizeHandleFlushLocked(fh *FileHandle, expectedRevision int
 	}
 }
 
+func (fs *Dat9FS) canStagePathTruncateToZero(entry *InodeEntry) bool {
+	if fs == nil || entry == nil || entry.IsDir || entryIsSymlink(entry) {
+		return false
+	}
+	if fs.layerEnabled() || isSQLitePersistentJournalPath(entry.Path) {
+		return false
+	}
+	if fs.mountWritePolicy() != WritePolicyWriteBack {
+		return false
+	}
+	return fs.shadowStore != nil && fs.pendingIndex != nil && fs.commitQueue != nil
+}
+
+func (fs *Dat9FS) stagePathTruncateToZeroLocked(ctx context.Context, entry *InodeEntry, ino uint64) gofuse.Status {
+	if !fs.canStagePathTruncateToZero(entry) {
+		return gofuse.Status(syscall.ENOTSUP)
+	}
+	expectedRevision := entry.Revision
+	mode := uint32(0)
+	hasMode := false
+	if entry.HasMode {
+		mode = entry.Mode & 0o777
+		hasMode = true
+	}
+	if err := fs.shadowStore.WriteFull(entry.Path, nil, expectedRevision); err != nil {
+		log.Printf("path truncate shadow stage failed for %s: %v", entry.Path, err)
+		return gofuse.EIO
+	}
+	if err := fs.shadowStore.Sync(entry.Path); err != nil {
+		fs.shadowStore.Remove(entry.Path)
+		log.Printf("path truncate shadow sync failed for %s: %v", entry.Path, err)
+		return gofuse.EIO
+	}
+	if _, err := fs.pendingIndex.PutWithBaseRevAndMode(entry.Path, 0, PendingOverwrite, expectedRevision, mode, hasMode); err != nil {
+		fs.shadowStore.Remove(entry.Path)
+		log.Printf("path truncate pending index update failed for %s: %v", entry.Path, err)
+		return gofuse.EIO
+	}
+
+	commit := &CommitEntry{
+		Path:    entry.Path,
+		Inode:   ino,
+		BaseRev: expectedRevision,
+		Size:    0,
+		Kind:    PendingOverwrite,
+		Mode:    mode,
+		HasMode: hasMode,
+	}
+	if err := fs.commitQueue.Enqueue(commit); err != nil {
+		log.Printf("path truncate async enqueue failed for %s: %v, falling back to sync commit", entry.Path, err)
+		if commitErr := fs.commitQueue.commitNowPathLocked(ctx, commit); commitErr != nil {
+			fs.pendingIndex.Remove(entry.Path)
+			fs.shadowStore.Remove(entry.Path)
+			log.Printf("path truncate sync fallback failed for %s: %v", entry.Path, commitErr)
+			return httpToFuseStatus(commitErr)
+		}
+	}
+	fs.invalidateReadCacheAndTargets(entry.Path)
+	fs.cacheFileForPath(entry.Path, 0, entry.Mtime, 0)
+	return gofuse.OK
+}
+
 func (fs *Dat9FS) canStageShadowFastLocked(fh *FileHandle) bool {
 	if fs.shadowStore == nil || fs.pendingIndex == nil || fh == nil || fh.Dirty == nil {
 		return false
@@ -2409,6 +2478,7 @@ func (fs *Dat9FS) loadWritableHandleFromShadowLocked(fh *FileHandle, meta *Write
 	if err != nil {
 		return err
 	}
+	zeroOverwrite := meta.Kind == PendingOverwrite && meta.Size == 0 && len(data) == 0
 
 	wb := fs.newWriteBuffer(fh.Path, maxPreloadSize, 0)
 	if len(data) > 0 {
@@ -2416,6 +2486,10 @@ func (fs *Dat9FS) loadWritableHandleFromShadowLocked(fh *FileHandle, meta *Write
 			return err
 		}
 		wb.ClearDirty()
+	} else if zeroOverwrite {
+		if err := wb.Truncate(0); err != nil {
+			return err
+		}
 	} else {
 		wb.totalSize = meta.Size
 	}
@@ -2423,11 +2497,15 @@ func (fs *Dat9FS) loadWritableHandleFromShadowLocked(fh *FileHandle, meta *Write
 	fh.Dirty = wb
 	fh.ShadowReady = true
 	fh.IsNew = meta.Kind == PendingNew
+	fh.ZeroBase = zeroOverwrite
 	fh.OrigSize = meta.Size
 	if meta.BaseRev > 0 {
 		fh.BaseRev = meta.BaseRev
 	} else if rev := fs.shadowStore.BaseRev(fh.Path); rev > 0 {
 		fh.BaseRev = rev
+	}
+	if zeroOverwrite {
+		fh.DirtySeq = fs.markDirtySize(fh.Ino, 0)
 	}
 	if meta.HasMode {
 		mode := meta.Mode & 0o777
@@ -4953,6 +5031,35 @@ func (fs *Dat9FS) waitQueuedRemoteCommitBeforeWrite(p string) func() {
 	return fs.lockWritableRemoteCommitPath(p)
 }
 
+func (fs *Dat9FS) lockWritableRemoteCommitPathForWritableOpen(p string) func() {
+	if fs == nil || p == "" {
+		return func() {}
+	}
+	if !fs.canSupersedeQueuedPathTruncate(p) {
+		return fs.lockWritableRemoteCommitPath(p)
+	}
+	unlockRemoteCommit := fs.lockRemoteCommitPath(p)
+	if fs.commitQueue != nil && fs.commitQueue.HasPath(p) {
+		unlockRemoteCommit()
+		return fs.lockWritableRemoteCommitPath(p)
+	}
+	return unlockRemoteCommit
+}
+
+func (fs *Dat9FS) canSupersedeQueuedPathTruncate(p string) bool {
+	if fs == nil || p == "" || fs.mountWritePolicy() != WritePolicyWriteBack {
+		return false
+	}
+	if fs.commitQueue == nil || fs.shadowStore == nil || fs.pendingIndex == nil {
+		return false
+	}
+	meta, ok := fs.pendingIndex.GetMeta(p)
+	if !ok || meta.Kind != PendingOverwrite || meta.Size != 0 || !fs.shadowStore.Has(p) {
+		return false
+	}
+	return fs.commitQueue.CancelQueuedZeroTruncatePreserveLocal(p)
+}
+
 func (fs *Dat9FS) lockWritableRemoteCommitPath(p string) func() {
 	if fs == nil || p == "" {
 		return func() {}
@@ -5429,6 +5536,11 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 					}
 					fs.invalidateReadCacheAndTargets(entry.Path)
 					fs.cacheFileForPath(entry.Path, 0, entry.Mtime, 0)
+				} else if fs.canStagePathTruncateToZero(entry) {
+					st := fs.stagePathTruncateToZeroLocked(ctx, entry, input.NodeId)
+					if st != gofuse.OK {
+						return st
+					}
 				} else {
 					apiPath := fs.remotePath(entry.Path)
 					writeStart := fs.perfStart()
@@ -7416,7 +7528,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		if fs.opts.ReadOnly {
 			return gofuse.EROFS
 		}
-		unlockRemoteCommit := fs.waitQueuedRemoteCommitBeforeWrite(p)
+		unlockRemoteCommit := fs.lockWritableRemoteCommitPathForWritableOpen(p)
 		defer func() {
 			if unlockRemoteCommit != nil {
 				unlockRemoteCommit()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7437,6 +7437,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		Ino:         ino,
 		Path:        childP,
 		Flags:       input.Flags,
+		OpenPID:     input.Pid,
 		Dirty:       wb,
 		IsNew:       true,
 		ShadowReady: false,

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2338,7 +2338,7 @@ func (fs *Dat9FS) stagePathTruncateToZeroLocked(ctx context.Context, entry *Inod
 	hasMode := false
 	if entry.HasMode {
 		mode = entry.Mode & 0o777
-		hasMode = true
+		hasMode = mode != defaultRegularFileMode
 	}
 	if err := fs.shadowStore.WriteFull(entry.Path, nil, expectedRevision); err != nil {
 		log.Printf("path truncate shadow stage failed for %s: %v", entry.Path, err)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7534,6 +7534,11 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 				unlockRemoteCommit()
 			}
 		}()
+		if refreshedEntry, ok := fs.inodes.GetEntry(input.NodeId); ok {
+			fh.OrigSize = refreshedEntry.Size
+			fh.BaseRev = refreshedEntry.Revision
+			entry = refreshedEntry
+		}
 
 		fh.Dirty = fs.newWriteBuffer(p, maxPreloadSize, 0)
 
@@ -7593,8 +7598,8 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			fh.DirtySeq = fs.markDirtySize(fh.Ino, 0)
 			fs.inodes.UpdateSize(fh.Ino, 0)
 			if fh.WritePolicy != WritePolicyWriteSync && fs.shadowStore != nil && fs.pendingIndex != nil {
-				if err := fs.shadowStore.Ensure(p, 0, fh.BaseRev); err != nil {
-					log.Printf("shadow ensure failed for truncate-open %s: %v", p, err)
+				if err := fs.shadowStore.WriteFull(p, nil, fh.BaseRev); err != nil {
+					log.Printf("shadow reset failed for truncate-open %s: %v", p, err)
 				} else {
 					fh.ShadowReady = true
 					fh.ShadowSpill = true

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1471,6 +1471,35 @@ func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64
 	}
 }
 
+func (fs *Dat9FS) adoptSingleCallerPathTruncate(remotePath string, callerPID uint32) {
+	if fs == nil || fs.openHandles == nil || remotePath == "" || callerPID == 0 {
+		return
+	}
+
+	var matching []*FileHandle
+	for _, fh := range fs.openHandles.SnapshotPath(remotePath) {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		dirty := fh.Dirty != nil
+		fh.Unlock()
+		if dirty {
+			matching = append(matching, fh)
+		}
+	}
+
+	for _, fh := range matching {
+		fh.Lock()
+		if shouldAdoptSingleHandlePathTruncate(fh, callerPID, len(matching)) {
+			if err := fs.truncateWritableHandleLocked(fh, 0); err != nil {
+				log.Printf("handle truncate stage failed for %s: %v", fh.Path, err)
+			}
+		}
+		fh.Unlock()
+	}
+}
+
 func (fs *Dat9FS) refreshCommittedRevisionForOpenHandles(path string, revision int64, skip *FileHandle) {
 	if fs == nil || fs.openHandles == nil || path == "" || revision <= 0 {
 		return
@@ -2577,6 +2606,11 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 
 		src.Lock()
 		if src.Dirty == nil {
+			src.Unlock()
+			continue
+		}
+		pendingLocal := src.IsNew || src.ZeroBase || src.DirtySeq != 0 || src.WriteBackSeq != 0 || src.ShadowCommitReady || src.Dirty.HasDirtyParts()
+		if !pendingLocal {
 			src.Unlock()
 			continue
 		}
@@ -5541,6 +5575,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 					if st != gofuse.OK {
 						return st
 					}
+					fs.adoptSingleCallerPathTruncate(entry.Path, input.Pid)
 				} else {
 					apiPath := fs.remotePath(entry.Path)
 					writeStart := fs.perfStart()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2366,7 +2366,7 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 	fs.adoptCommittedRevisionLocked(fh)
 
 	size := fh.Dirty.Size()
-	if fh.ShadowReady {
+	if fh.ShadowReady && fh.ShadowSpill {
 		if err := fs.shadowStore.Truncate(fh.Path, size, fh.BaseRev); err != nil {
 			return err
 		}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7602,7 +7602,6 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 					log.Printf("shadow reset failed for truncate-open %s: %v", p, err)
 				} else {
 					fh.ShadowReady = true
-					fh.ShadowSpill = true
 					// Pin shadow so commit queue cleanup doesn't delete it while
 					// this handle is reading.
 					fh.ShadowGen = fs.shadowStore.Pin(p)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -10526,6 +10526,93 @@ func TestOpenWritableCancelsQueuedPathTruncateWithoutOTruncFlag(t *testing.T) {
 	}
 }
 
+func TestOpenWritableRefreshesInodeAfterWaitingForInFlightZeroTruncate(t *testing.T) {
+	path := "/tier-transition.bin"
+	staleData := bytes.Repeat([]byte("s"), 8*1024*1024)
+	statCh := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		statCh <- struct{}{}
+		w.Header().Set("Content-Length", "0")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", "8")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.readCache.Put(path, staleData, 7)
+	inFlight := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7}
+	fs.commitQueue = &CommitQueue{
+		queue:        nil,
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{path: inFlight},
+	}
+
+	ino := fs.inodes.Lookup(path, false, int64(len(staleData)), time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+
+	openDone := make(chan gofuse.OpenOut, 1)
+	statusDone := make(chan gofuse.Status, 1)
+	go func() {
+		var out gofuse.OpenOut
+		statusDone <- fs.Open(nil, &gofuse.OpenIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Flags:    uint32(syscall.O_WRONLY),
+		}, &out)
+		openDone <- out
+	}()
+
+	select {
+	case st := <-statusDone:
+		t.Fatalf("Open returned before in-flight zero truncate completed: %v", st)
+	case <-time.After(75 * time.Millisecond):
+	}
+	fs.inodes.UpdateSize(ino, 0)
+	fs.inodes.UpdateRevision(ino, 8)
+	fs.commitQueue.endInFlight(inFlight)
+
+	var st gofuse.Status
+	select {
+	case st = <-statusDone:
+	case <-time.After(time.Second):
+		t.Fatal("Open did not return after in-flight zero truncate completed")
+	}
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	var out gofuse.OpenOut
+	select {
+	case out = <-openDone:
+	case <-time.After(time.Second):
+		t.Fatal("OpenOut missing")
+	}
+	select {
+	case <-statCh:
+	case <-time.After(time.Second):
+		t.Fatal("Open did not stat zero-sized remote file after wait")
+	}
+
+	fh, ok := fs.fileHandles.Get(out.Fh)
+	if !ok {
+		t.Fatal("opened handle missing")
+	}
+	if fh.OrigSize != 0 || fh.BaseRev != 8 {
+		t.Fatalf("handle orig/base = %d/%d, want 0/8", fh.OrigSize, fh.BaseRev)
+	}
+	if fh.Dirty == nil {
+		t.Fatal("dirty buffer missing")
+	}
+	if got := fh.Dirty.Size(); got != 0 {
+		t.Fatalf("dirty buffer size = %d, want 0; stale read cache was preloaded", got)
+	}
+}
+
 func TestStageShadowReadyNonSpillRewritesShadowWithDirtyBuffer(t *testing.T) {
 	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -10526,6 +10526,64 @@ func TestOpenWritableCancelsQueuedPathTruncateWithoutOTruncFlag(t *testing.T) {
 	}
 }
 
+func TestStageShadowReadyNonSpillRewritesShadowWithDirtyBuffer(t *testing.T) {
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	const baseRev int64 = 7
+	path := "/tier-transition.bin"
+	if err := shadow.WriteFull(path, nil, baseRev); err != nil {
+		t.Fatal(err)
+	}
+
+	finalData := bytes.Repeat([]byte("x"), 10*1024)
+	dirty := fs.newWriteBuffer(path, maxPreloadSize, 0)
+	if _, err := dirty.Write(0, finalData); err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Ino:         42,
+		Path:        path,
+		Dirty:       dirty,
+		BaseRev:     baseRev,
+		ShadowReady: true,
+		ShadowSpill: false,
+		WritePolicy: WritePolicyWriteBack,
+	}
+
+	if err := fs.stageShadowForQueuedCommitLocked(fh, true); err != nil {
+		t.Fatal(err)
+	}
+	defer fs.releaseHandleRemoteCommitPathLocked(fh)
+
+	got, err := shadow.ReadAll(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, finalData) {
+		t.Fatalf("shadow content mismatch after staged rewrite: got len=%d want len=%d", len(got), len(finalData))
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending metadata missing after staged rewrite")
+	}
+	if meta.Size != int64(len(finalData)) || meta.Kind != PendingOverwrite || meta.BaseRev != baseRev {
+		t.Fatalf("pending meta = %+v, want size=%d kind=%v baseRev=%d", meta, len(finalData), PendingOverwrite, baseRev)
+	}
+}
+
 func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
 	var (
 		mu         sync.Mutex

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -10117,6 +10117,415 @@ func TestSetAttr_TruncateWithoutHandleRefreshesRevision(t *testing.T) {
 	}
 }
 
+func TestSetAttr_WriteBackInteractivePathTruncateStagesAndReturnsBeforeRemoteCommit(t *testing.T) {
+	putStarted := make(chan struct{})
+	releasePut := make(chan struct{})
+	var putOnce sync.Once
+	var putBody []byte
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			putBody = append([]byte(nil), body...)
+			putOnce.Do(func() { close(putStarted) })
+			<-releasePut
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 2})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+	fs.syncMode = SyncInteractive
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.PathLock = fs.lockRemoteCommitPath
+	cq.OnSuccess = fs.onCommitQueueSuccess
+	cq.OnCleanup = fs.onCommitQueueCleanup
+	fs.commitQueue = cq
+	defer cq.DrainAll()
+
+	ino := fs.inodes.Lookup("/file.bin", false, 42, time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		var out gofuse.AttrOut
+		done <- fs.SetAttr(nil, &gofuse.SetAttrIn{
+			SetAttrInCommon: gofuse.SetAttrInCommon{
+				InHeader: gofuse.InHeader{NodeId: ino},
+				Valid:    gofuse.FATTR_SIZE,
+				Size:     0,
+			},
+		}, &out)
+	}()
+
+	select {
+	case st := <-done:
+		if st != gofuse.OK {
+			t.Fatalf("SetAttr status = %v, want OK", st)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("SetAttr blocked on remote zero-byte commit")
+	}
+
+	meta, ok := pending.GetMeta("/file.bin")
+	if !ok {
+		t.Fatal("pending truncate metadata missing")
+	}
+	if meta.Size != 0 || meta.Kind != PendingOverwrite || meta.BaseRev != 1 {
+		t.Fatalf("pending meta = %+v, want zero-byte overwrite at base rev 1", meta)
+	}
+	if !shadow.Has("/file.bin") {
+		t.Fatal("shadow missing for staged truncate")
+	}
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode entry missing")
+	}
+	if entry.Size != 0 {
+		t.Fatalf("inode size = %d, want 0", entry.Size)
+	}
+
+	select {
+	case <-putStarted:
+	case <-time.After(time.Second):
+		t.Fatal("async zero-byte commit did not start")
+	}
+	close(releasePut)
+	cq.DrainAll()
+	if len(putBody) != 0 {
+		t.Fatalf("remote truncate body = %q, want empty", string(putBody))
+	}
+	if pending.HasPending("/file.bin") {
+		t.Fatal("pending truncate still present after commit")
+	}
+	if shadow.Has("/file.bin") {
+		t.Fatal("shadow still present after commit")
+	}
+}
+
+func TestSetAttr_CloseSyncPathTruncateKeepsSynchronousRemoteCommit(t *testing.T) {
+	putStarted := make(chan struct{})
+	releasePut := make(chan struct{})
+	var putOnce sync.Once
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putOnce.Do(func() { close(putStarted) })
+			<-releasePut
+			w.WriteHeader(http.StatusOK)
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "0")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "2")
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	defer fs.commitQueue.DrainAll()
+
+	ino := fs.inodes.Lookup("/file.bin", false, 42, time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		var out gofuse.AttrOut
+		done <- fs.SetAttr(nil, &gofuse.SetAttrIn{
+			SetAttrInCommon: gofuse.SetAttrInCommon{
+				InHeader: gofuse.InHeader{NodeId: ino},
+				Valid:    gofuse.FATTR_SIZE,
+				Size:     0,
+			},
+		}, &out)
+	}()
+
+	select {
+	case <-putStarted:
+	case <-time.After(time.Second):
+		t.Fatal("close-sync SetAttr did not start remote truncate")
+	}
+	select {
+	case st := <-done:
+		t.Fatalf("close-sync SetAttr returned before remote truncate completed: %v", st)
+	default:
+	}
+	close(releasePut)
+	select {
+	case st := <-done:
+		if st != gofuse.OK {
+			t.Fatalf("SetAttr status = %v, want OK", st)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("close-sync SetAttr did not return after remote truncate completed")
+	}
+}
+
+func TestSetAttr_WriteBackStrictPathTruncateStagesAndReturnsBeforeRemoteCommit(t *testing.T) {
+	putStarted := make(chan struct{})
+	releasePut := make(chan struct{})
+	var putOnce sync.Once
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putOnce.Do(func() { close(putStarted) })
+			<-releasePut
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 2})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{SyncMode: SyncStrict, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.PathLock = fs.lockRemoteCommitPath
+	cq.OnSuccess = fs.onCommitQueueSuccess
+	cq.OnCleanup = fs.onCommitQueueCleanup
+	fs.commitQueue = cq
+	defer cq.DrainAll()
+
+	ino := fs.inodes.Lookup("/file.bin", false, 42, time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		var out gofuse.AttrOut
+		done <- fs.SetAttr(nil, &gofuse.SetAttrIn{
+			SetAttrInCommon: gofuse.SetAttrInCommon{
+				InHeader: gofuse.InHeader{NodeId: ino},
+				Valid:    gofuse.FATTR_SIZE,
+				Size:     0,
+			},
+		}, &out)
+	}()
+
+	select {
+	case st := <-done:
+		if st != gofuse.OK {
+			t.Fatalf("SetAttr status = %v, want OK", st)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("writeback strict SetAttr blocked on remote zero-byte commit")
+	}
+	if !pending.HasPending("/file.bin") {
+		t.Fatal("pending truncate metadata missing")
+	}
+	select {
+	case <-putStarted:
+	case <-time.After(time.Second):
+		t.Fatal("async zero-byte commit did not start")
+	}
+	close(releasePut)
+	cq.DrainAll()
+}
+
+func TestOpenTruncateCancelsQueuedPathTruncateWithoutCancelingInFlight(t *testing.T) {
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	fs.syncMode = SyncInteractive
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := "/file.bin"
+	if err := shadow.WriteFull(path, nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(path, 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	queued := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7}
+	fs.commitQueue = &CommitQueue{
+		queue:        []*CommitEntry{queued},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{},
+	}
+	fs.commitQueue.rebuildQueuedIndexLocked()
+
+	ino := fs.inodes.Lookup(path, false, 42, time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	if !queued.canceled {
+		t.Fatal("queued zero truncate was not canceled")
+	}
+	if fs.commitQueue.HasPath(path) {
+		t.Fatal("queued zero truncate still blocks path")
+	}
+	if !pending.HasPending(path) {
+		t.Fatal("pending local truncate metadata was removed")
+	}
+	if !shadow.Has(path) {
+		t.Fatal("pending local truncate shadow was removed")
+	}
+	fh, ok := fs.fileHandles.Get(out.Fh)
+	if !ok {
+		t.Fatal("opened handle missing")
+	}
+	if fh.BaseRev != 7 {
+		t.Fatalf("handle base revision = %d, want 7", fh.BaseRev)
+	}
+	if !fh.ZeroBase || fh.Dirty == nil || fh.Dirty.Size() != 0 {
+		t.Fatalf("handle did not adopt zero-base dirty buffer: zero=%t dirty=%v", fh.ZeroBase, fh.Dirty)
+	}
+
+	inFlight := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7}
+	fs.commitQueue = &CommitQueue{
+		queue:        []*CommitEntry{inFlight},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{path: inFlight},
+	}
+	fs.commitQueue.rebuildQueuedIndexLocked()
+	if fs.canSupersedeQueuedPathTruncate(path) {
+		t.Fatal("in-flight zero truncate was incorrectly superseded")
+	}
+	if inFlight.canceled {
+		t.Fatal("in-flight zero truncate was canceled")
+	}
+}
+
+func TestOpenWritableCancelsQueuedPathTruncateWithoutOTruncFlag(t *testing.T) {
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	fs.syncMode = SyncInteractive
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := "/file.bin"
+	if err := shadow.WriteFull(path, nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(path, 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	queued := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7}
+	fs.commitQueue = &CommitQueue{
+		queue:        []*CommitEntry{queued},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{},
+	}
+	fs.commitQueue.rebuildQueuedIndexLocked()
+
+	ino := fs.inodes.Lookup(path, false, 0, time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_WRONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	if !queued.canceled {
+		t.Fatal("queued zero truncate was not canceled")
+	}
+	if fs.commitQueue.HasPath(path) {
+		t.Fatal("queued zero truncate still blocks path")
+	}
+	fh, ok := fs.fileHandles.Get(out.Fh)
+	if !ok {
+		t.Fatal("opened handle missing")
+	}
+	if fh.BaseRev != 7 {
+		t.Fatalf("handle base revision = %d, want 7", fh.BaseRev)
+	}
+	if !fh.ZeroBase {
+		t.Fatal("handle did not preserve zero-base truncate state")
+	}
+	if fh.Dirty == nil {
+		t.Fatal("handle dirty buffer missing")
+	}
+	if !fh.Dirty.HasDirtyParts() || fh.Dirty.Size() != 0 {
+		t.Fatalf("handle dirty state = dirty:%v size:%d", fh.Dirty.HasDirtyParts(), fh.Dirty.Size())
+	}
+	if fh.DirtySeq == 0 {
+		t.Fatal("handle dirty sequence was not marked")
+	}
+}
+
 func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
 	var (
 		mu         sync.Mutex

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -10671,6 +10671,79 @@ func TestStageShadowReadyNonSpillRewritesShadowWithDirtyBuffer(t *testing.T) {
 	}
 }
 
+func TestOpenTruncateResetShadowStagesDirtyBuffer(t *testing.T) {
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	const baseRev int64 = 7
+	path := "/tier-transition.bin"
+	if err := shadow.WriteFull(path, bytes.Repeat([]byte{0x5a}, 64*1024), baseRev); err != nil {
+		t.Fatal(err)
+	}
+	ino := fs.inodes.Lookup(path, false, 8*1024*1024, time.Now())
+	fs.inodes.UpdateRevision(ino, baseRev)
+	fs.inodes.UpdateSize(ino, 8*1024*1024)
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	fh, ok := fs.fileHandles.Get(out.Fh)
+	if !ok {
+		t.Fatal("opened handle missing")
+	}
+	if !fh.ShadowReady {
+		t.Fatal("truncate-open did not reset shadow")
+	}
+	if fh.ShadowSpill {
+		t.Fatal("truncate-open shadow must stay dirty-buffer backed, not ShadowSpill")
+	}
+
+	finalData := bytes.Repeat([]byte("x"), 10*1024)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       out.Fh,
+		Offset:   0,
+	}, finalData); st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+	if err := fs.stageShadowForQueuedCommitLocked(fh, true); err != nil {
+		t.Fatal(err)
+	}
+	defer fs.releaseHandleRemoteCommitPathLocked(fh)
+
+	got, err := shadow.ReadAll(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, finalData) {
+		t.Fatalf("shadow content mismatch after truncate-open staged write: got len=%d want len=%d", len(got), len(finalData))
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending metadata missing after truncate-open staged write")
+	}
+	if meta.Size != int64(len(finalData)) || meta.Kind != PendingOverwrite || meta.BaseRev != baseRev || meta.ShadowSpill {
+		t.Fatalf("pending meta = %+v, want size=%d kind=%v baseRev=%d shadowSpill=false", meta, len(finalData), PendingOverwrite, baseRev)
+	}
+}
+
 func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
 	var (
 		mu         sync.Mutex

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -10365,6 +10365,85 @@ func TestSetAttr_WriteBackPathTruncateAdoptsSingleCallerWriter(t *testing.T) {
 	}
 }
 
+func TestSetAttr_WriteBackPathTruncateAdoptsCreatedSameCallerWriter(t *testing.T) {
+	const callerPID = 6161
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = &CommitQueue{
+		maxPending:   8,
+		queue:        []*CommitEntry{},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{},
+		workCh:       make(chan *CommitEntry, 16),
+	}
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1, Caller: gofuse.Caller{Pid: callerPID}},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_CREAT),
+	}, "created.bin", &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("created file handle missing")
+	}
+	if fh.OpenPID != callerPID {
+		t.Fatalf("created file handle OpenPID = %d, want %d", fh.OpenPID, callerPID)
+	}
+
+	oldData := bytes.Repeat([]byte{0x41}, 64*1024)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Offset:   0,
+	}, oldData); st != gofuse.OK {
+		t.Fatalf("Write old data status = %v, want OK", st)
+	}
+
+	var attrOut gofuse.AttrOut
+	st = fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId, Caller: gofuse.Caller{Pid: callerPID}},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &attrOut)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+	if !fh.ZeroBase {
+		t.Fatal("created same-caller writer did not adopt zero base")
+	}
+	if got := fh.Dirty.Size(); got != 0 {
+		t.Fatalf("dirty size after staged truncate = %d, want 0", got)
+	}
+	if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {
+		t.Fatalf("dirty truncate not marked: dirtySeq=%d dirty=%t", fh.DirtySeq, fh.Dirty.HasDirtyParts())
+	}
+
+	gotShadow, err := shadow.ReadAll("/created.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gotShadow) != 0 {
+		t.Fatalf("shadow content after staged truncate len=%d, want 0", len(gotShadow))
+	}
+}
+
 func TestSetAttr_WriteBackPathTruncateSkipsDefaultInheritedMode(t *testing.T) {
 	fs, shadow, pending := newWriteBackPathTruncateModeTestFS(t)
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -7686,6 +7686,57 @@ func TestOpenWritablePreloadSkipsCleanSiblingReboundToNewRevision(t *testing.T) 
 	}
 }
 
+func TestOpenWritablePreloadSkipsCleanOldRevisionShadowHandle(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	fs.shadowStore = shadow
+
+	const filePath = "/tier-transition.bin"
+	stale := bytes.Repeat([]byte{0x5a}, 64*1024)
+	ino := fs.inodes.Lookup(filePath, false, int64(len(stale)), time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+	fs.inodes.UpdateSize(ino, 0)
+	fs.inodes.UpdateRevision(ino, 8)
+	if err := shadow.WriteFull(filePath, stale, 7); err != nil {
+		t.Fatal(err)
+	}
+
+	sibling := &FileHandle{
+		Ino:         ino,
+		Path:        filePath,
+		Dirty:       fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+		OrigSize:    int64(len(stale)),
+		BaseRev:     7,
+		ShadowReady: true,
+		ShadowSpill: true,
+	}
+	if _, err := sibling.Dirty.Write(0, stale); err != nil {
+		t.Fatal(err)
+	}
+	sibling.Dirty.ClearDirty()
+	fs.openHandles.Add(sibling)
+
+	target := &FileHandle{
+		Ino:      ino,
+		Path:     filePath,
+		Dirty:    fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+		OrigSize: 0,
+		BaseRev:  8,
+	}
+	if fs.loadWritableHandleFromOpenHandleLocked(target) {
+		t.Fatal("clean old-revision sibling shadow must not be used as preload data")
+	}
+	if got := target.Dirty.Size(); got != 0 {
+		t.Fatalf("target dirty size = %d, want 0", got)
+	}
+}
+
 func TestReadCleanWritableHandleRefreshesSkippedCommittedRevision(t *testing.T) {
 	stale := []byte("sqlite db before checkpoint")
 	fresh := []byte("sqlite db after checkpoint with event rows")
@@ -10223,6 +10274,94 @@ func TestSetAttr_WriteBackInteractivePathTruncateStagesAndReturnsBeforeRemoteCom
 	}
 	if shadow.Has("/file.bin") {
 		t.Fatal("shadow still present after commit")
+	}
+}
+
+func TestSetAttr_WriteBackPathTruncateAdoptsSingleCallerWriter(t *testing.T) {
+	const callerPID = 5151
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = &CommitQueue{
+		maxPending:   8,
+		queue:        []*CommitEntry{},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{},
+		workCh:       make(chan *CommitEntry, 16),
+	}
+
+	const path = "/tier-transition.bin"
+	const baseRev int64 = 7
+	ino := fs.inodes.Lookup(path, false, 8*1024*1024, time.Now())
+	fs.inodes.UpdateRevision(ino, baseRev)
+	fs.inodes.UpdateSize(ino, 8*1024*1024)
+
+	fh := &FileHandle{
+		Ino:         ino,
+		Path:        path,
+		Flags:       uint32(syscall.O_WRONLY),
+		OpenPID:     callerPID,
+		Dirty:       fs.newWriteBuffer(path, maxPreloadSize, 0),
+		OrigSize:    8 * 1024 * 1024,
+		BaseRev:     baseRev,
+		WritePolicy: WritePolicyWriteBack,
+	}
+	if err := fh.Dirty.Truncate(8 * 1024 * 1024); err != nil {
+		t.Fatal(err)
+	}
+	fh.Dirty.ClearDirty()
+	fhID := fs.allocateFileHandle(fh)
+	defer fs.deleteFileHandle(fhID, fh)
+
+	var attrOut gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino, Caller: gofuse.Caller{Pid: callerPID}},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &attrOut)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+	if !fh.ZeroBase {
+		t.Fatal("same-caller writer did not adopt zero base")
+	}
+	if got := fh.Dirty.Size(); got != 0 {
+		t.Fatalf("dirty size after staged truncate = %d, want 0", got)
+	}
+	if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {
+		t.Fatalf("dirty truncate not marked: dirtySeq=%d dirty=%t", fh.DirtySeq, fh.Dirty.HasDirtyParts())
+	}
+
+	finalData := bytes.Repeat([]byte{0x59}, 10*1024)
+	if _, err := fh.Dirty.Write(0, finalData); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	if got := fh.Dirty.Size(); got != int64(len(finalData)) {
+		t.Fatalf("dirty size after write = %d, want %d", got, len(finalData))
+	}
+	if err := fs.stageShadowLocked(fh, true); err != nil {
+		t.Fatal(err)
+	}
+	got, err := shadow.ReadAll(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, finalData) {
+		t.Fatalf("shadow content mismatch after staged truncate writer adoption: got len=%d want len=%d", len(got), len(finalData))
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -10365,6 +10365,122 @@ func TestSetAttr_WriteBackPathTruncateAdoptsSingleCallerWriter(t *testing.T) {
 	}
 }
 
+func TestSetAttr_WriteBackPathTruncateSkipsDefaultInheritedMode(t *testing.T) {
+	fs, shadow, pending := newWriteBackPathTruncateModeTestFS(t)
+
+	const path = "/file.bin"
+	ino := fs.inodes.Lookup(path, false, 4096, time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+	fs.inodes.UpdateMode(ino, defaultRegularFileMode)
+
+	var out gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+	if out.Size != 0 {
+		t.Fatalf("out.Size = %d, want 0", out.Size)
+	}
+	if !shadow.Has(path) {
+		t.Fatal("shadow missing for staged truncate")
+	}
+
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending truncate metadata missing")
+	}
+	if meta.HasMode {
+		t.Fatalf("pending mode = has:%t mode:%o, want has:false for inherited default mode", meta.HasMode, meta.Mode)
+	}
+
+	commit := singleQueuedCommitForPath(t, fs.commitQueue, path)
+	if commit.HasMode {
+		t.Fatalf("queued commit mode = has:%t mode:%o, want has:false for inherited default mode", commit.HasMode, commit.Mode)
+	}
+}
+
+func TestSetAttr_WriteBackPathTruncatePreservesNonDefaultInheritedMode(t *testing.T) {
+	fs, _, pending := newWriteBackPathTruncateModeTestFS(t)
+
+	const path = "/private.bin"
+	ino := fs.inodes.Lookup(path, false, 4096, time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+	fs.inodes.UpdateMode(ino, 0o600)
+
+	var out gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending truncate metadata missing")
+	}
+	if !meta.HasMode || meta.Mode&0o777 != 0o600 {
+		t.Fatalf("pending mode = has:%t mode:%o, want has:true mode:0600", meta.HasMode, meta.Mode&0o777)
+	}
+
+	commit := singleQueuedCommitForPath(t, fs.commitQueue, path)
+	if !commit.HasMode || commit.Mode&0o777 != 0o600 {
+		t.Fatalf("queued commit mode = has:%t mode:%o, want has:true mode:0600", commit.HasMode, commit.Mode&0o777)
+	}
+}
+
+func newWriteBackPathTruncateModeTestFS(t *testing.T) (*Dat9FS, *ShadowStore, *PendingIndex) {
+	t.Helper()
+
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { shadow.Close() })
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = &CommitQueue{
+		maxPending:   8,
+		queue:        []*CommitEntry{},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{},
+		workCh:       make(chan *CommitEntry, 16),
+	}
+	return fs, shadow, pending
+}
+
+func singleQueuedCommitForPath(t *testing.T, cq *CommitQueue, path string) *CommitEntry {
+	t.Helper()
+
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	if len(cq.queue) != 1 {
+		t.Fatalf("queued commits = %d, want 1", len(cq.queue))
+	}
+	commit := cq.queue[0]
+	if commit.Path != path {
+		t.Fatalf("queued commit path = %q, want %q", commit.Path, path)
+	}
+	return commit
+}
+
 func TestSetAttr_CloseSyncPathTruncateKeepsSynchronousRemoteCommit(t *testing.T) {
 	putStarted := make(chan struct{})
 	releasePut := make(chan struct{})

--- a/pkg/fuse/mode.go
+++ b/pkg/fuse/mode.go
@@ -17,7 +17,7 @@ func shouldApplyRemoteMode(kind PendingKind, hasMode bool, mode uint32) bool {
 	if !hasMode {
 		return false
 	}
-	if (kind == PendingNew || kind == PendingOverwrite) && mode&0o777 == defaultRegularFileMode {
+	if kind == PendingNew && mode&0o777 == defaultRegularFileMode {
 		return false
 	}
 	return true

--- a/pkg/fuse/mode.go
+++ b/pkg/fuse/mode.go
@@ -17,7 +17,7 @@ func shouldApplyRemoteMode(kind PendingKind, hasMode bool, mode uint32) bool {
 	if !hasMode {
 		return false
 	}
-	if kind == PendingNew && mode&0o777 == defaultRegularFileMode {
+	if (kind == PendingNew || kind == PendingOverwrite) && mode&0o777 == defaultRegularFileMode {
 		return false
 	}
 	return true


### PR DESCRIPTION
## Summary
- stage writeback path `SETATTR size=0` locally in shadow + pending index and enqueue the zero-byte commit asynchronously
- keep close-sync/write-sync/non-writeback paths on the existing synchronous remote truncate path
- allow a later writable open to cancel only queued, not in-flight, zero-byte truncate commits while preserving local shadow/pending state

## Scope / safety
- no fixed coalesce timer
- no in-flight commit cancellation or supersession
- no close-sync/write-sync semantic changes
- excludes layer paths, SQLite persistent journal sidecars, dirs, and symlinks

## Tests
- go test ./pkg/fuse -run 'TestSetAttr_WriteBackInteractivePathTruncateStagesAndReturnsBeforeRemoteCommit|TestSetAttr_CloseSyncPathTruncateKeepsSynchronousRemoteCommit|TestSetAttr_WriteBackStrictPathTruncateStagesAndReturnsBeforeRemoteCommit|TestOpenTruncateCancelsQueuedPathTruncateWithoutCancelingInFlight|TestOpenWritableCancelsQueuedPathTruncateWithoutOTruncFlag|TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight|TestSetAttr_TruncateWithoutHandleRefreshesRevision' -count=1\n- go test ./pkg/fuse -count=1\n- go test ./cmd/drive9 ./cmd/drive9/cli ./pkg/fuse -count=1\n- go test -race ./pkg/fuse -run 'TestOpenWritableCancelsQueuedPathTruncateWithoutOTruncFlag|TestOpenTruncateCancelsQueuedPathTruncateWithoutCancelingInFlight|TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight' -count=1\n- go vet ./pkg/fuse ./cmd/drive9 ./cmd/drive9/cli\n- git diff --check\n\nFixes #560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for local zero-byte truncation staging on write-back mounts.

* **Bug Fixes**
  * Improved truncation handling and file mode preservation across multiple scenarios.

* **Tests**
  * Added comprehensive test coverage for zero-byte truncation workflows, including write-back mode interactions, mode preservation, and cancellation semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->