### PR TITLE
Add native tenant delete cleanup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Important environment variables:
 DRIVE9_META_DSN                 control-plane MySQL/TiDB DSN
 DRIVE9_TENANT_PROVIDER          db9 | tidb_zero | tidb_cloud_starter | tidbcloud_native
 DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT
-                                default TiDB Cloud Starter spendingLimit.monthly in USD cents
+                                default TiDB Cloud Starter/native spendingLimit.monthly in USD cents
 DRIVE9_TIDBCLOUD_NATIVE_API_URL TiDB Cloud Serverless API base URL
 DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER
                                 cloud provider for tidbcloud_native cluster creation

--- a/README.md
+++ b/README.md
@@ -364,10 +364,16 @@ POST   /v2/uploads/{id}/abort
 
 GET    /v1/events                 SSE change stream
 GET    /v1/status                 server status and upload limits
+DELETE /v1/tenant                 delete current tenant with owner API key
 ```
 
 Vault endpoints also exist for secret storage, scoped grants, delegated tokens,
 and read-only vault mounts.
+
+`DELETE /v1/tenant` is owner-key only. For `tidbcloud_native`, the request body
+must also include the customer's TiDB Cloud `public_key` and `private_key` so
+Drive9 can delete the customer-account Starter cluster. `tidb_zero` tenants are
+not deleted through this endpoint; they expire automatically.
 
 ## Mount Options
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,8 @@ Important environment variables:
 DRIVE9_META_DSN                 control-plane MySQL/TiDB DSN
 DRIVE9_TENANT_PROVIDER          db9 | tidb_zero | tidb_cloud_starter | tidbcloud_native
 DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT
-                                default TiDB Cloud Starter/native spendingLimit.monthly in USD cents
+                                default TiDB Cloud spendingLimit.monthly in USD cents
+                                optional for tidb_cloud_starter; tidbcloud_native defaults to 1000 when unset
 DRIVE9_TIDBCLOUD_NATIVE_API_URL TiDB Cloud Serverless API base URL
 DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER
                                 cloud provider for tidbcloud_native cluster creation

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -434,7 +434,7 @@ environment:
   DRIVE9_TIDB_AUTO_EMBEDDING_API_BASE provider base endpoint for models that require it
                                      optional for openai models; set it for Azure OpenAI endpoints
   DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter|tidbcloud_native (default for provisioning)
-  DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT default Starter spendingLimit.monthly in USD cents; applied after pool takeover
+  DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT default TiDB Cloud spendingLimit.monthly in USD cents; optional for Starter, native defaults to 1000 when unset
   DRIVE9_TIDBCLOUD_NATIVE_API_URL TiDB Cloud Serverless API base URL for tidbcloud_native
   DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER cloud provider for tidbcloud_native cluster creation, e.g. aws
   DRIVE9_TIDBCLOUD_NATIVE_REGION region for tidbcloud_native cluster creation, e.g. us-east-1

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1991,10 +1991,11 @@ func (s *Store) RecoverStaleTenantDeleteJobs(ctx context.Context, before time.Ti
 func (s *Store) MarkTenantDeleteJobRunning(ctx context.Context, tenantID string) (updated bool, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "mark_tenant_delete_job_running", start, &err)
+	now := time.Now().UTC()
 	res, err := s.db.ExecContext(ctx, `UPDATE tenant_delete_jobs
 		SET state = ?, updated_at = ?
-		WHERE tenant_id = ? AND state = ?`,
-		TenantDeleteJobRunning, time.Now().UTC(), tenantID, TenantDeleteJobPending)
+		WHERE tenant_id = ? AND state = ? AND not_before <= ?`,
+		TenantDeleteJobRunning, now, tenantID, TenantDeleteJobPending, now)
 	if err != nil {
 		return false, err
 	}
@@ -2022,6 +2023,55 @@ func (s *Store) MarkTenantDeleteJobDeleted(ctx context.Context, tenantID string,
 		WHERE tenant_id = ?`,
 		TenantDeleteJobDeleted, deletedObjects, abortedMultipartUploads, now, now, tenantID)
 	return err
+}
+
+func (s *Store) FinalizeTenantDelete(ctx context.Context, tenantID, namespaceID string, deletedObjects, abortedMultipartUploads int64) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "finalize_tenant_delete", start, &err)
+	now := time.Now().UTC()
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `UPDATE tenant_delete_jobs
+			SET state = ?, deleted_objects = ?, aborted_multipart_uploads = ?, completed_at = ?,
+				last_error = NULL, updated_at = ?
+			WHERE tenant_id = ? AND state = ?`,
+			TenantDeleteJobDeleted, deletedObjects, abortedMultipartUploads, now, now, tenantID, TenantDeleteJobRunning)
+		if err != nil {
+			return err
+		}
+		if err := requireAffected(res); err != nil {
+			return err
+		}
+		if namespaceID != "" {
+			res, err = tx.ExecContext(ctx, `UPDATE storage_namespaces SET state = ?, updated_at = ? WHERE namespace_id = ?`,
+				StorageNamespaceDeleted, now, namespaceID)
+			if err != nil {
+				return err
+			}
+			if err := requireAffected(res); err != nil {
+				return err
+			}
+		}
+		res, err = tx.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ? WHERE id = ?`,
+			TenantDeleted, now, tenantID)
+		if err != nil {
+			return err
+		}
+		if err := requireAffected(res); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func requireAffected(res sql.Result) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 func getStorageNamespaceTx(ctx context.Context, tx *sql.Tx, id string) (*StorageNamespace, error) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -99,8 +99,9 @@ type TenantAutoEmbeddingProfile struct {
 type StorageNamespaceState string
 
 const (
-	StorageNamespaceActive  StorageNamespaceState = "active"
-	StorageNamespaceDeleted StorageNamespaceState = "deleted"
+	StorageNamespaceActive   StorageNamespaceState = "active"
+	StorageNamespaceDeleting StorageNamespaceState = "deleting"
+	StorageNamespaceDeleted  StorageNamespaceState = "deleted"
 )
 
 type StorageNamespace struct {
@@ -131,6 +132,31 @@ const (
 	ObjectGCReasonFailedWrite ObjectGCCandidateReason = "failed_write"
 	ObjectGCReasonForkDelete  ObjectGCCandidateReason = "fork_delete"
 )
+
+type TenantDeleteJobState string
+
+const (
+	TenantDeleteJobPending TenantDeleteJobState = "pending"
+	TenantDeleteJobRunning TenantDeleteJobState = "running"
+	TenantDeleteJobDeleted TenantDeleteJobState = "deleted"
+)
+
+type TenantDeleteJob struct {
+	TenantID                string
+	NamespaceID             string
+	Backend                 string
+	Bucket                  string
+	Prefix                  string
+	State                   TenantDeleteJobState
+	Attempts                int
+	LastError               string
+	NotBefore               time.Time
+	DeletedObjects          int64
+	AbortedMultipartUploads int64
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
+	CompletedAt             *time.Time
+}
 
 func (t Tenant) S3EncryptionPolicy() S3EncryptionPolicy {
 	return S3EncryptionPolicy{
@@ -415,6 +441,24 @@ func metaInitSchemaStatements() []string {
 			updated_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			INDEX idx_storage_namespace_owner (owner_tenant_id),
 			INDEX idx_storage_namespace_state (state)
+		)`,
+		`CREATE TABLE IF NOT EXISTS tenant_delete_jobs (
+			tenant_id                  VARCHAR(64) PRIMARY KEY,
+			namespace_id               VARCHAR(64) NOT NULL,
+			backend                    VARCHAR(16) NOT NULL,
+			bucket                     VARCHAR(255) NOT NULL DEFAULT '',
+			prefix                     VARCHAR(2048) NOT NULL,
+			state                      VARCHAR(20) NOT NULL DEFAULT 'pending',
+			attempts                   INT NOT NULL DEFAULT 0,
+			last_error                 TEXT NULL,
+			not_before                 DATETIME(3) NOT NULL,
+			deleted_objects            BIGINT NOT NULL DEFAULT 0,
+			aborted_multipart_uploads BIGINT NOT NULL DEFAULT 0,
+			created_at                 DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at                 DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			completed_at               DATETIME(3) NULL,
+			INDEX idx_tenant_delete_jobs_due (state, not_before),
+			INDEX idx_tenant_delete_jobs_namespace (namespace_id, state)
 		)`,
 		`CREATE TABLE IF NOT EXISTS object_gc_candidates (
 			namespace_id     VARCHAR(64) NOT NULL,
@@ -1759,6 +1803,27 @@ func (s *Store) GetStorageNamespace(ctx context.Context, id string) (out *Storag
 	return &ns, nil
 }
 
+func (s *Store) UpdateStorageNamespaceState(ctx context.Context, id string, state StorageNamespaceState) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_storage_namespace_state", start, &err)
+	if id == "" {
+		return fmt.Errorf("namespace id is required")
+	}
+	if state == "" {
+		return fmt.Errorf("namespace state is required")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE storage_namespaces SET state = ?, updated_at = ? WHERE namespace_id = ?`,
+		state, time.Now().UTC(), id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) EnsureTenantStorageNamespace(ctx context.Context, tenantID, backendName, bucket, prefix string) (out *StorageNamespace, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "ensure_tenant_storage_namespace", start, &err)
@@ -1814,6 +1879,149 @@ func (s *Store) EnsureTenantStorageNamespace(ctx context.Context, tenantID, back
 		return nil, err
 	}
 	return ns, nil
+}
+
+func (s *Store) EnqueueTenantDeleteJob(ctx context.Context, job *TenantDeleteJob) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "enqueue_tenant_delete_job", start, &err)
+	if job == nil {
+		return fmt.Errorf("tenant delete job is required")
+	}
+	if job.TenantID == "" {
+		return fmt.Errorf("tenant id is required")
+	}
+	if job.NamespaceID == "" {
+		return fmt.Errorf("namespace id is required")
+	}
+	if job.Backend == "" {
+		return fmt.Errorf("storage backend is required")
+	}
+	if job.Prefix == "" {
+		return fmt.Errorf("storage prefix is required")
+	}
+	notBefore := job.NotBefore.UTC()
+	if notBefore.IsZero() {
+		notBefore = time.Now().UTC()
+	}
+	now := time.Now().UTC()
+	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_delete_jobs
+		(tenant_id, namespace_id, backend, bucket, prefix, state, not_before, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			namespace_id = VALUES(namespace_id),
+			backend = VALUES(backend),
+			bucket = VALUES(bucket),
+			prefix = VALUES(prefix),
+			state = CASE WHEN state = 'deleted' THEN state ELSE 'pending' END,
+			not_before = LEAST(not_before, VALUES(not_before)),
+			updated_at = VALUES(updated_at)`,
+		job.TenantID, job.NamespaceID, job.Backend, job.Bucket, job.Prefix, TenantDeleteJobPending, notBefore, now, now)
+	return err
+}
+
+func (s *Store) TenantDeleteJobExists(ctx context.Context, tenantID string) (out bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "tenant_delete_job_exists", start, &err)
+	if tenantID == "" {
+		return false, fmt.Errorf("tenant id is required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT 1 FROM tenant_delete_jobs WHERE tenant_id = ? LIMIT 1`, tenantID)
+	var one int
+	if err := row.Scan(&one); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *Store) ListDueTenantDeleteJobs(ctx context.Context, now time.Time, limit int) (out []TenantDeleteJob, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_due_tenant_delete_jobs", start, &err)
+	if limit <= 0 {
+		limit = 25
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT tenant_id, namespace_id, backend, bucket, prefix,
+			state, attempts, COALESCE(last_error, ''), not_before, deleted_objects,
+			aborted_multipart_uploads, created_at, updated_at, completed_at
+		FROM tenant_delete_jobs
+		WHERE state = ? AND not_before <= ?
+		ORDER BY not_before ASC, created_at ASC
+		LIMIT ?`, TenantDeleteJobPending, now.UTC(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var job TenantDeleteJob
+		var completedAt sql.NullTime
+		if err := rows.Scan(&job.TenantID, &job.NamespaceID, &job.Backend, &job.Bucket, &job.Prefix,
+			&job.State, &job.Attempts, &job.LastError, &job.NotBefore, &job.DeletedObjects,
+			&job.AbortedMultipartUploads, &job.CreatedAt, &job.UpdatedAt, &completedAt); err != nil {
+			return nil, err
+		}
+		if completedAt.Valid {
+			t := completedAt.Time.UTC()
+			job.CompletedAt = &t
+		}
+		out = append(out, job)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *Store) RecoverStaleTenantDeleteJobs(ctx context.Context, before time.Time) (n int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "recover_stale_tenant_delete_jobs", start, &err)
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_delete_jobs
+		SET state = ?, not_before = ?, last_error = ?, updated_at = ?
+		WHERE state = ? AND updated_at < ?`,
+		TenantDeleteJobPending, time.Now().UTC(), "recovered stale running delete job", time.Now().UTC(),
+		TenantDeleteJobRunning, before.UTC())
+	if err != nil {
+		return 0, err
+	}
+	n, _ = res.RowsAffected()
+	return n, nil
+}
+
+func (s *Store) MarkTenantDeleteJobRunning(ctx context.Context, tenantID string) (updated bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "mark_tenant_delete_job_running", start, &err)
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_delete_jobs
+		SET state = ?, updated_at = ?
+		WHERE tenant_id = ? AND state = ?`,
+		TenantDeleteJobRunning, time.Now().UTC(), tenantID, TenantDeleteJobPending)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+func (s *Store) RetryTenantDeleteJob(ctx context.Context, tenantID string, notBefore time.Time, lastError string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "retry_tenant_delete_job", start, &err)
+	_, err = s.db.ExecContext(ctx, `UPDATE tenant_delete_jobs
+		SET state = ?, not_before = ?, attempts = attempts + 1, last_error = ?, updated_at = ?
+		WHERE tenant_id = ? AND state = ?`,
+		TenantDeleteJobPending, notBefore.UTC(), nullStr(lastError), time.Now().UTC(), tenantID, TenantDeleteJobRunning)
+	return err
+}
+
+func (s *Store) MarkTenantDeleteJobDeleted(ctx context.Context, tenantID string, deletedObjects, abortedMultipartUploads int64) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "mark_tenant_delete_job_deleted", start, &err)
+	now := time.Now().UTC()
+	_, err = s.db.ExecContext(ctx, `UPDATE tenant_delete_jobs
+		SET state = ?, deleted_objects = ?, aborted_multipart_uploads = ?, completed_at = ?,
+			last_error = NULL, updated_at = ?
+		WHERE tenant_id = ?`,
+		TenantDeleteJobDeleted, deletedObjects, abortedMultipartUploads, now, now, tenantID)
+	return err
 }
 
 func getStorageNamespaceTx(ctx context.Context, tx *sql.Tx, id string) (*StorageNamespace, error) {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -822,6 +822,7 @@ func TestMetaSchemaSpecIncludesForkStorageNamespaceColumns(t *testing.T) {
 		t.Fatal("tenants schema missing idx_tenant_parent")
 	}
 	_ = mustMetaTableSpec(t, mustMetaSpec(t), "storage_namespaces")
+	_ = mustMetaTableSpec(t, mustMetaSpec(t), "tenant_delete_jobs")
 	_ = mustMetaTableSpec(t, mustMetaSpec(t), "object_gc_candidates")
 }
 

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -615,6 +615,81 @@ func TestUpdateTenantStatus(t *testing.T) {
 	}
 }
 
+func TestFinalizeTenantDeleteUpdatesJobNamespaceAndTenant(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := s.InsertTenant(ctx, &Tenant{
+		ID:                 "delete-finalize-tenant",
+		Status:             TenantDeleting,
+		StorageNamespaceID: "delete-finalize-ns",
+		DBHost:             "127.0.0.1",
+		DBPort:             4000,
+		DBUser:             "root",
+		DBPasswordCipher:   []byte("cipher"),
+		DBName:             "tenant_delete_finalize",
+		DBTLS:              true,
+		Provider:           "tidb_cloud_starter",
+		SchemaVersion:      1,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertStorageNamespace(ctx, &StorageNamespace{
+		ID:            "delete-finalize-ns",
+		OwnerTenantID: "delete-finalize-tenant",
+		Backend:       "s3",
+		Bucket:        "bucket",
+		Prefix:        "tenant/delete-finalize-tenant",
+		State:         StorageNamespaceDeleting,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.EnqueueTenantDeleteJob(ctx, &TenantDeleteJob{
+		TenantID:    "delete-finalize-tenant",
+		NamespaceID: "delete-finalize-ns",
+		Backend:     "s3",
+		Bucket:      "bucket",
+		Prefix:      "tenant/delete-finalize-tenant",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := s.MarkTenantDeleteJobRunning(ctx, "delete-finalize-tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("MarkTenantDeleteJobRunning updated = false, want true")
+	}
+	if err := s.FinalizeTenantDelete(ctx, "delete-finalize-tenant", "delete-finalize-ns", 11, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	var jobState, nsState, tenantStatus string
+	var deletedObjects, abortedMultipartUploads int64
+	if err := s.DB().QueryRow(`SELECT state, deleted_objects, aborted_multipart_uploads FROM tenant_delete_jobs WHERE tenant_id = ?`, "delete-finalize-tenant").Scan(&jobState, &deletedObjects, &abortedMultipartUploads); err != nil {
+		t.Fatal(err)
+	}
+	if jobState != string(TenantDeleteJobDeleted) || deletedObjects != 11 || abortedMultipartUploads != 2 {
+		t.Fatalf("job = state %s deleted %d aborted %d, want deleted/11/2", jobState, deletedObjects, abortedMultipartUploads)
+	}
+	if err := s.DB().QueryRow(`SELECT state FROM storage_namespaces WHERE namespace_id = ?`, "delete-finalize-ns").Scan(&nsState); err != nil {
+		t.Fatal(err)
+	}
+	if nsState != string(StorageNamespaceDeleted) {
+		t.Fatalf("namespace state = %s, want %s", nsState, StorageNamespaceDeleted)
+	}
+	if err := s.DB().QueryRow(`SELECT status FROM tenants WHERE id = ?`, "delete-finalize-tenant").Scan(&tenantStatus); err != nil {
+		t.Fatal(err)
+	}
+	if tenantStatus != string(TenantDeleted) {
+		t.Fatalf("tenant status = %s, want %s", tenantStatus, TenantDeleted)
+	}
+}
+
 func TestListTenantsByStatus(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC()
@@ -868,6 +943,91 @@ func TestMetaSchemaSpecIncludesTenantStatusCreatedIDIndex(t *testing.T) {
 	plans := plannedMetaSchemaRepairs([]metaSchemaDiff{indexDiff})
 	if len(plans) != 1 || plans[0] != wantCreateSQL {
 		t.Errorf("repair plans = %#v, want [%q]", plans, wantCreateSQL)
+	}
+}
+
+func TestFinalizeTenantDeleteRollsBackWhenTenantStatusUpdateFails(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := s.UpsertStorageNamespace(ctx, &StorageNamespace{
+		ID:            "delete-ns-rollback",
+		OwnerTenantID: "missing-delete-tenant",
+		Backend:       "s3",
+		Bucket:        "bucket",
+		Prefix:        "tenant/missing-delete-tenant",
+		State:         StorageNamespaceDeleting,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.EnqueueTenantDeleteJob(ctx, &TenantDeleteJob{
+		TenantID:    "missing-delete-tenant",
+		NamespaceID: "delete-ns-rollback",
+		Backend:     "s3",
+		Bucket:      "bucket",
+		Prefix:      "tenant/missing-delete-tenant",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := s.MarkTenantDeleteJobRunning(ctx, "missing-delete-tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("MarkTenantDeleteJobRunning updated = false, want true")
+	}
+
+	err = s.FinalizeTenantDelete(ctx, "missing-delete-tenant", "delete-ns-rollback", 7, 3)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("FinalizeTenantDelete error = %v, want ErrNotFound", err)
+	}
+
+	var jobState string
+	var deletedObjects int64
+	if err := s.DB().QueryRow(`SELECT state, deleted_objects FROM tenant_delete_jobs WHERE tenant_id = ?`, "missing-delete-tenant").Scan(&jobState, &deletedObjects); err != nil {
+		t.Fatal(err)
+	}
+	if jobState != string(TenantDeleteJobRunning) || deletedObjects != 0 {
+		t.Fatalf("tenant delete job = state %s deleted_objects %d, want running/0", jobState, deletedObjects)
+	}
+	var nsState string
+	if err := s.DB().QueryRow(`SELECT state FROM storage_namespaces WHERE namespace_id = ?`, "delete-ns-rollback").Scan(&nsState); err != nil {
+		t.Fatal(err)
+	}
+	if nsState != string(StorageNamespaceDeleting) {
+		t.Fatalf("namespace state = %s, want %s", nsState, StorageNamespaceDeleting)
+	}
+}
+
+func TestMarkTenantDeleteJobRunningHonorsNotBefore(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	future := time.Now().UTC().Add(time.Hour)
+	if err := s.EnqueueTenantDeleteJob(ctx, &TenantDeleteJob{
+		TenantID:    "delete-job-future",
+		NamespaceID: "delete-ns-future",
+		Backend:     "s3",
+		Bucket:      "bucket",
+		Prefix:      "tenant/delete-job-future",
+		NotBefore:   future,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := s.MarkTenantDeleteJobRunning(ctx, "delete-job-future")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Fatal("MarkTenantDeleteJobRunning updated future job, want false")
+	}
+	var state string
+	if err := s.DB().QueryRow(`SELECT state FROM tenant_delete_jobs WHERE tenant_id = ?`, "delete-job-future").Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if state != string(TenantDeleteJobPending) {
+		t.Fatalf("job state = %s, want %s", state, TenantDeleteJobPending)
 	}
 }
 

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -573,6 +573,105 @@ func (c *AWSS3Client) DeleteObject(ctx context.Context, key string) error {
 	return nil
 }
 
+func (c *AWSS3Client) DeletePrefix(ctx context.Context, prefix string) (PrefixDeleteResult, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("delete_prefix", result, start) }()
+
+	fullPrefix := c.fullKey(strings.TrimLeft(prefix, "/"))
+	var out PrefixDeleteResult
+	if err := c.abortMultipartUploadsByPrefix(ctx, fullPrefix, &out); err != nil {
+		result = "error"
+		return out, err
+	}
+	if err := c.deleteObjectsByPrefix(ctx, fullPrefix, &out); err != nil {
+		result = "error"
+		return out, err
+	}
+	return out, nil
+}
+
+func (c *AWSS3Client) abortMultipartUploadsByPrefix(ctx context.Context, fullPrefix string, out *PrefixDeleteResult) error {
+	var keyMarker *string
+	var uploadIDMarker *string
+	for {
+		res, err := c.client.ListMultipartUploads(ctx, &s3.ListMultipartUploadsInput{
+			Bucket:         &c.bucket,
+			Prefix:         aws.String(fullPrefix),
+			KeyMarker:      keyMarker,
+			UploadIdMarker: uploadIDMarker,
+		})
+		if err != nil {
+			return fmt.Errorf("list multipart uploads by prefix: %w", err)
+		}
+		for _, upload := range res.Uploads {
+			key := aws.ToString(upload.Key)
+			uploadID := aws.ToString(upload.UploadId)
+			if key == "" || uploadID == "" {
+				continue
+			}
+			if _, err := c.client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
+				Bucket:   &c.bucket,
+				Key:      aws.String(key),
+				UploadId: aws.String(uploadID),
+			}); err != nil {
+				return fmt.Errorf("abort multipart upload %s/%s: %w", key, uploadID, err)
+			}
+			out.AbortedMultipartUploads++
+		}
+		if !aws.ToBool(res.IsTruncated) {
+			return nil
+		}
+		keyMarker = res.NextKeyMarker
+		uploadIDMarker = res.NextUploadIdMarker
+	}
+}
+
+func (c *AWSS3Client) deleteObjectsByPrefix(ctx context.Context, fullPrefix string, out *PrefixDeleteResult) error {
+	var continuation *string
+	for {
+		res, err := c.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            &c.bucket,
+			Prefix:            aws.String(fullPrefix),
+			ContinuationToken: continuation,
+		})
+		if err != nil {
+			return fmt.Errorf("list objects by prefix: %w", err)
+		}
+		if len(res.Contents) > 0 {
+			objects := make([]types.ObjectIdentifier, 0, len(res.Contents))
+			for _, obj := range res.Contents {
+				key := aws.ToString(obj.Key)
+				if key == "" {
+					continue
+				}
+				objects = append(objects, types.ObjectIdentifier{Key: aws.String(key)})
+			}
+			if len(objects) > 0 {
+				del, err := c.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+					Bucket: &c.bucket,
+					Delete: &types.Delete{
+						Objects: objects,
+						Quiet:   aws.Bool(true),
+					},
+				})
+				if err != nil {
+					return fmt.Errorf("delete objects by prefix: %w", err)
+				}
+				if len(del.Errors) > 0 {
+					first := del.Errors[0]
+					return fmt.Errorf("delete object %q: %s %s", aws.ToString(first.Key), aws.ToString(first.Code), aws.ToString(first.Message))
+				}
+				out.DeletedObjects += len(objects)
+			}
+		}
+		if !aws.ToBool(res.IsTruncated) {
+			return nil
+		}
+		continuation = res.NextContinuationToken
+	}
+}
+
 func (c *AWSS3Client) UploadPartCopy(ctx context.Context, destKey, uploadID string, partNumber int, sourceKey string, startByte, endByte int64) (string, error) {
 	start := time.Now()
 	result := "ok"

--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -662,7 +662,7 @@ func (c *AWSS3Client) deleteObjectsByPrefix(ctx context.Context, fullPrefix stri
 					first := del.Errors[0]
 					return fmt.Errorf("delete object %q: %s %s", aws.ToString(first.Key), aws.ToString(first.Code), aws.ToString(first.Message))
 				}
-				out.DeletedObjects += len(objects)
+				out.DeletedObjects += int64(len(objects))
 			}
 		}
 		if !aws.ToBool(res.IsTruncated) {

--- a/pkg/s3client/local.go
+++ b/pkg/s3client/local.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -298,6 +299,73 @@ func (c *LocalS3Client) DeleteObject(ctx context.Context, key string) error {
 		return err
 	}
 	return nil
+}
+
+func (c *LocalS3Client) DeletePrefix(ctx context.Context, prefix string) (PrefixDeleteResult, error) {
+	start := time.Now()
+	result := "ok"
+	defer func() { recordS3Operation("delete_prefix", result, start) }()
+
+	prefix = strings.TrimLeft(prefix, "/")
+	var out PrefixDeleteResult
+	objectsRoot := filepath.Join(c.rootDir, "objects")
+	targetRoot := filepath.Join(objectsRoot, filepath.FromSlash(prefix))
+	if prefix == "" {
+		targetRoot = objectsRoot
+	}
+	cleanObjectsRoot, err := filepath.Abs(objectsRoot)
+	if err != nil {
+		result = "error"
+		return out, err
+	}
+	cleanTargetRoot, err := filepath.Abs(targetRoot)
+	if err != nil {
+		result = "error"
+		return out, err
+	}
+	rel, err := filepath.Rel(cleanObjectsRoot, cleanTargetRoot)
+	if err != nil {
+		result = "error"
+		return out, err
+	}
+	if rel == ".." || strings.HasPrefix(rel, "../") || filepath.IsAbs(rel) {
+		result = "error"
+		return out, fmt.Errorf("prefix escapes local s3 root: %q", prefix)
+	}
+	if err := filepath.WalkDir(targetRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return filepath.SkipDir
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		out.DeletedObjects++
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		result = "error"
+		return out, err
+	}
+
+	c.mu.Lock()
+	uploadIDs := make([]string, 0)
+	for uploadID, upload := range c.uploads {
+		if prefix == "" || strings.HasPrefix(upload.key, prefix) {
+			uploadIDs = append(uploadIDs, uploadID)
+			delete(c.uploads, uploadID)
+		}
+	}
+	c.mu.Unlock()
+	for _, uploadID := range uploadIDs {
+		_ = os.RemoveAll(filepath.Join(c.rootDir, "parts", uploadID))
+		out.AbortedMultipartUploads++
+	}
+	return out, nil
 }
 
 func (c *LocalS3Client) UploadPartCopy(ctx context.Context, destKey, uploadID string, partNumber int, sourceKey string, startByte, endByte int64) (string, error) {

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -76,6 +76,12 @@ type MultipartUpload struct {
 	Key      string
 }
 
+// PrefixDeleteResult summarizes a best-effort prefix cleanup pass.
+type PrefixDeleteResult struct {
+	DeletedObjects          int
+	AbortedMultipartUploads int
+}
+
 // S3Client abstracts S3-compatible object store operations.
 // Implementations: LocalS3Client (testing), AWSS3Client (production).
 type S3Client interface {
@@ -118,6 +124,11 @@ type S3Client interface {
 	// PresignGetObjectRange returns a presigned URL for reading a byte range of
 	// an object. startByte and endByte are inclusive.
 	PresignGetObjectRange(ctx context.Context, key string, startByte, endByte int64, ttl time.Duration) (string, error)
+
+	// DeletePrefix removes all objects under prefix and aborts multipart uploads
+	// under the same prefix. Prefix is relative to the client's configured base
+	// prefix.
+	DeletePrefix(ctx context.Context, prefix string) (PrefixDeleteResult, error)
 }
 
 // Default presigned URL TTLs per design doc §11.2.

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -78,8 +78,8 @@ type MultipartUpload struct {
 
 // PrefixDeleteResult summarizes a best-effort prefix cleanup pass.
 type PrefixDeleteResult struct {
-	DeletedObjects          int
-	AbortedMultipartUploads int
+	DeletedObjects          int64
+	AbortedMultipartUploads int64
 }
 
 // S3Client abstracts S3-compatible object store operations.

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -245,6 +245,11 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			return
 		}
 
+		if isTenantDeleteRequest(r) {
+			handleTenantDeleteAuth(w, r, pool, next, resolved, claims)
+			return
+		}
+
 		switch resolved.Tenant.Status {
 		case meta.TenantActive:
 		case meta.TenantPending:
@@ -353,6 +358,65 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 		setRequestMetricScope(r.Context(), scope, classifyTenantRequest(r))
 		next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))
 	})
+}
+
+func isTenantDeleteRequest(r *http.Request) bool {
+	return r.Method == http.MethodDelete && r.URL.Path == "/v1/tenant"
+}
+
+func handleTenantDeleteAuth(w http.ResponseWriter, r *http.Request, pool *tenant.Pool, next http.Handler, resolved *meta.TenantWithAPIKey, claims *token.Claims) {
+	switch resolved.Tenant.Status {
+	case meta.TenantActive, meta.TenantFailed, meta.TenantDeleting, meta.TenantDeleted:
+	case meta.TenantPending:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_pending", "tenant_id", resolved.Tenant.ID)...)
+		metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantPending))
+		errJSON(w, http.StatusServiceUnavailable, "tenant provisioning is pending")
+		return
+	case meta.TenantProvisioning:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_provisioning", "tenant_id", resolved.Tenant.ID)...)
+		metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantProvisioning))
+		errJSON(w, http.StatusServiceUnavailable, "tenant is provisioning")
+		return
+	case meta.TenantSuspended:
+		pool.Invalidate(resolved.Tenant.ID)
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_blocked", "tenant_id", resolved.Tenant.ID, "status", resolved.Tenant.Status)...)
+		metricEvent(r.Context(), "tenant_status", "status", string(resolved.Tenant.Status))
+		errJSON(w, http.StatusForbidden, "tenant is unavailable")
+		return
+	default:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_unavailable", "tenant_id", resolved.Tenant.ID, "status", resolved.Tenant.Status)...)
+		metricEvent(r.Context(), "tenant_status", "status", string(resolved.Tenant.Status))
+		errJSON(w, http.StatusForbidden, "tenant is unavailable")
+		return
+	}
+
+	scopeKind := resolved.APIKey.ScopeKind
+	if scopeKind == "" {
+		scopeKind = meta.APIKeyScopeKindOwner
+	}
+	isScoped := false
+	switch scopeKind {
+	case meta.APIKeyScopeKindOwner:
+	case meta.APIKeyScopeKindFS:
+		isScoped = true
+	default:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_scope_kind_unsupported", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "scope_kind", scopeKind)...)
+		metricEvent(r.Context(), "auth", "result", "scope_kind_unsupported")
+		errJSON(w, http.StatusForbidden, "unsupported API key scope kind")
+		return
+	}
+
+	scope := &TenantScope{
+		TenantID:           resolved.Tenant.ID,
+		APIKeyID:           resolved.APIKey.ID,
+		TokenVersion:       resolved.APIKey.TokenVersion,
+		Provider:           resolved.Tenant.Provider,
+		JournalPermissions: journalPermissionsFromClaims(claims),
+		ScopeKind:          scopeKind,
+		IsScoped:           isScoped,
+	}
+	setRequestMetricScope(r.Context(), scope, classifyTenantRequest(r))
+	next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))
 }
 
 // capabilityAuthMiddleware returns a handler that resolves the tenant backend

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -298,6 +298,8 @@ func requestRoute(path string) string {
 		return "/v1/provision"
 	case path == "/v1/status":
 		return "/v1/status"
+	case path == "/v1/tenant":
+		return "/v1/tenant"
 	case path == "/v1/tokens" || strings.HasPrefix(path, "/v1/tokens/"):
 		return "/v1/tokens/*"
 	case path == "/v1/sql":
@@ -381,6 +383,8 @@ func classifyTenantRequest(r *http.Request) tenantRequestClass {
 		return tenantRequestClass{surface: "status", action: strings.ToLower(r.Method)}
 	case path == "/v1/provision":
 		return tenantRequestClass{surface: "provision", action: strings.ToLower(r.Method)}
+	case path == "/v1/tenant":
+		return tenantRequestClass{surface: "tenant", action: strings.ToLower(r.Method)}
 	default:
 		return tenantRequestClass{surface: "other", action: strings.ToLower(r.Method)}
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -28,9 +28,12 @@ type fakeProvisioner struct {
 	cluster           *tenant.ClusterInfo
 	initErr           error
 	provisionErr      error
+	deprovisionErr    error
 	provisionCalls    atomic.Int32
 	credentialCalls   atomic.Int32
+	deprovisionCalls  atomic.Int32
 	lastCredentialReq tenant.CredentialProvisionRequest
+	lastDeprovision   *tenant.ClusterInfo
 }
 
 func (f *fakeProvisioner) ProviderType() string { return f.provider }
@@ -75,6 +78,25 @@ func (f *fakeProvisioner) ProvisionWithCredentials(_ context.Context, tenantID s
 	out.TenantID = tenantID
 	out.Provider = f.provider
 	return &out, nil
+}
+
+func (f *fakeProvisioner) Deprovision(_ context.Context, cluster *tenant.ClusterInfo) error {
+	f.deprovisionCalls.Add(1)
+	if cluster != nil {
+		out := *cluster
+		f.lastDeprovision = &out
+	}
+	return f.deprovisionErr
+}
+
+func (f *fakeProvisioner) DeprovisionWithCredentials(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) error {
+	f.deprovisionCalls.Add(1)
+	f.lastCredentialReq = req
+	if cluster != nil {
+		out := *cluster
+		f.lastDeprovision = &out
+	}
+	return f.deprovisionErr
 }
 
 func (f *fakeProvisioner) ProvisionCallCount() int {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3422,10 +3422,20 @@ func decodeCredentialProvisionRequest(w http.ResponseWriter, r *http.Request) (*
 		PrivateKey   string `json:"private_key"`
 		DatabaseName string `json:"database_name"`
 	}
+	return decodeCredentialRequest(w, r, &req, func() tenant.CredentialProvisionRequest {
+		return tenant.CredentialProvisionRequest{
+			PublicKey:    strings.TrimSpace(req.PublicKey),
+			PrivateKey:   strings.TrimSpace(req.PrivateKey),
+			DatabaseName: strings.TrimSpace(req.DatabaseName),
+		}
+	})
+}
+
+func decodeCredentialRequest(w http.ResponseWriter, r *http.Request, raw any, build func() tenant.CredentialProvisionRequest) (*tenant.CredentialProvisionRequest, error) {
 	if r.Body != nil {
 		dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxCredentialProvisionBodyBytes))
 		dec.DisallowUnknownFields()
-		if err := dec.Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		if err := dec.Decode(raw); err != nil && !errors.Is(err, io.EOF) {
 			return nil, fmt.Errorf("invalid JSON body: %w", err)
 		}
 		var extra struct{}
@@ -3433,15 +3443,11 @@ func decodeCredentialProvisionRequest(w http.ResponseWriter, r *http.Request) (*
 			return nil, fmt.Errorf("invalid JSON body: trailing data")
 		}
 	}
-	out := &tenant.CredentialProvisionRequest{
-		PublicKey:    strings.TrimSpace(req.PublicKey),
-		PrivateKey:   strings.TrimSpace(req.PrivateKey),
-		DatabaseName: strings.TrimSpace(req.DatabaseName),
-	}
+	out := build()
 	if out.PublicKey == "" || out.PrivateKey == "" {
 		return nil, fmt.Errorf("public_key and private_key are required")
 	}
-	return out, nil
+	return &out, nil
 }
 
 type apiKeyIssueSource struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -226,6 +226,7 @@ func NewWithConfig(cfg Config) *Server {
 	mux.Handle("/v2/uploads/", business)
 	mux.Handle("/v1/tokens", business)
 	mux.Handle("/v1/tokens/", business)
+	mux.Handle("/v1/tenant", business)
 	mux.Handle("/v1/fork", business)
 	mux.Handle("/v1/sql", business)
 	mux.Handle("/v1/events", business)
@@ -307,6 +308,7 @@ func NewWithConfig(cfg Config) *Server {
 		s.startPendingTenantReconciler()
 		s.resumeProvisioningTenants()
 		s.resumeDeletingForkTenants()
+		s.startTenantDeleteCleanup(backgroundWithTrace(context.Background()))
 	}
 	s.semanticWorker = newSemanticWorkerManager(cfg.Backend, cfg.Meta, cfg.Pool, cfg.SemanticEmbedder, cfg.SemanticWorkers)
 	if s.semanticWorker != nil {
@@ -576,6 +578,8 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 		s.handleV2Uploads(w, r)
 	case r.URL.Path == "/v1/tokens" || strings.HasPrefix(r.URL.Path, "/v1/tokens/"):
 		s.handleTokens(w, r)
+	case r.URL.Path == "/v1/tenant":
+		s.handleTenantDelete(w, r)
 	case r.URL.Path == "/v1/fork":
 		s.handleFork(w, r)
 	case r.URL.Path == "/v1/sql":

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -18,6 +18,7 @@ const (
 	defaultTenantDeletePollInterval = time.Minute
 	defaultTenantDeleteRetryDelay   = time.Hour
 	defaultTenantDeleteRunningTTL   = 30 * time.Minute
+	defaultTenantDeleteJobTimeout   = 25 * time.Minute
 )
 
 func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
@@ -212,6 +213,7 @@ func (s *Server) startTenantDeleteCleanup(ctx context.Context) {
 	s.startForkWorker(ctx, func(workerCtx context.Context) {
 		ticker := time.NewTicker(defaultTenantDeletePollInterval)
 		defer ticker.Stop()
+		s.processTenantDeleteJobs(workerCtx)
 		for {
 			select {
 			case <-workerCtx.Done():
@@ -224,8 +226,9 @@ func (s *Server) startTenantDeleteCleanup(ctx context.Context) {
 }
 
 func (s *Server) processTenantDeleteJobs(ctx context.Context) {
-	_, _ = s.meta.RecoverStaleTenantDeleteJobs(ctx, time.Now().UTC().Add(-defaultTenantDeleteRunningTTL))
-	jobs, err := s.meta.ListDueTenantDeleteJobs(ctx, time.Now().UTC(), 25)
+	now := time.Now().UTC()
+	_, _ = s.meta.RecoverStaleTenantDeleteJobs(ctx, now.Add(-defaultTenantDeleteRunningTTL))
+	jobs, err := s.meta.ListDueTenantDeleteJobs(ctx, now, 25)
 	if err != nil {
 		return
 	}
@@ -256,11 +259,15 @@ func (s *Server) processTenantDeleteJob(ctx context.Context, job meta.TenantDele
 	if err != nil {
 		return err
 	}
-	res, err := s3c.DeletePrefix(ctx, "")
+	jobCtx, cancel := context.WithTimeout(ctx, defaultTenantDeleteJobTimeout)
+	defer cancel()
+	// The S3 client is already scoped to job.Prefix, so an empty relative
+	// prefix deletes the whole storage namespace without opening tenant DB.
+	res, err := s3c.DeletePrefix(jobCtx, "")
 	if err != nil {
 		return err
 	}
-	if err := s.meta.MarkTenantDeleteJobDeleted(ctx, job.TenantID, int64(res.DeletedObjects), int64(res.AbortedMultipartUploads)); err != nil {
+	if err := s.meta.MarkTenantDeleteJobDeleted(ctx, job.TenantID, res.DeletedObjects, res.AbortedMultipartUploads); err != nil {
 		return err
 	}
 	if err := s.meta.UpdateStorageNamespaceState(ctx, job.NamespaceID, meta.StorageNamespaceDeleted); err != nil && !errors.Is(err, meta.ErrNotFound) {

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -10,8 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mem9-ai/dat9/pkg/logger"
 	"github.com/mem9-ai/dat9/pkg/meta"
 	"github.com/mem9-ai/dat9/pkg/tenant"
+	"go.uber.org/zap"
 )
 
 const (
@@ -110,6 +112,13 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if err := s.pool.InvalidateAndWait(r.Context(), t.ID); err != nil {
+		if t.Status != meta.TenantDeleting {
+			_, _ = s.meta.UpdateTenantStatusIf(r.Context(), t.ID, meta.TenantDeleting, t.Status)
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to drain tenant backend")
+		return
+	}
 	if err := s.deprovisionTenantCluster(r.Context(), t, req); err != nil {
 		if t.Status != meta.TenantDeleting {
 			_, _ = s.meta.UpdateTenantStatusIf(r.Context(), t.ID, meta.TenantDeleting, t.Status)
@@ -118,7 +127,6 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.pool.Invalidate(t.ID)
 	_ = s.meta.AbortActiveUploadReservations(r.Context(), t.ID)
 
 	status, err := s.enqueueTenantDeleteJob(r.Context(), t)
@@ -231,9 +239,13 @@ func (s *Server) startTenantDeleteCleanup(ctx context.Context) {
 
 func (s *Server) processTenantDeleteJobs(ctx context.Context) {
 	now := time.Now().UTC()
-	_, _ = s.meta.RecoverStaleTenantDeleteJobs(ctx, now.Add(-defaultTenantDeleteRunningTTL))
+	if _, err := s.meta.RecoverStaleTenantDeleteJobs(ctx, now.Add(-defaultTenantDeleteRunningTTL)); err != nil {
+		logger.Error(ctx, "tenant_delete_recover_stale_failed", zap.Error(err))
+		return
+	}
 	jobs, err := s.meta.ListDueTenantDeleteJobs(ctx, now, 25)
 	if err != nil {
+		logger.Error(ctx, "tenant_delete_list_due_failed", zap.Error(err))
 		return
 	}
 	for _, job := range jobs {
@@ -271,11 +283,5 @@ func (s *Server) processTenantDeleteJob(ctx context.Context, job meta.TenantDele
 	if err != nil {
 		return err
 	}
-	if err := s.meta.MarkTenantDeleteJobDeleted(ctx, job.TenantID, res.DeletedObjects, res.AbortedMultipartUploads); err != nil {
-		return err
-	}
-	if err := s.meta.UpdateStorageNamespaceState(ctx, job.NamespaceID, meta.StorageNamespaceDeleted); err != nil && !errors.Is(err, meta.ErrNotFound) {
-		return err
-	}
-	return s.meta.UpdateTenantStatus(ctx, job.TenantID, meta.TenantDeleted)
+	return s.meta.FinalizeTenantDelete(ctx, job.TenantID, job.NamespaceID, res.DeletedObjects, res.AbortedMultipartUploads)
 }

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -1,0 +1,270 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/tenant"
+)
+
+const (
+	defaultTenantDeletePollInterval = time.Minute
+	defaultTenantDeleteRetryDelay   = time.Hour
+	defaultTenantDeleteRunningTTL   = 30 * time.Minute
+)
+
+func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
+	if s.meta == nil || s.pool == nil || s.provisioner == nil || len(s.tokenSecret) == 0 {
+		errJSON(w, http.StatusNotFound, "tenant delete not enabled")
+		return
+	}
+	if r.Method != http.MethodDelete {
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	scope, ok := ownerScopeFromRequest(w, r, "delete tenant")
+	if !ok {
+		return
+	}
+	if scope == nil || scope.TenantID == "" {
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+
+	t, err := s.meta.GetTenant(r.Context(), scope.TenantID)
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "tenant not found")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "tenant lookup failed")
+		return
+	}
+	if t.Kind != meta.TenantKindLive {
+		errJSON(w, http.StatusConflict, "only live tenants can be deleted")
+		return
+	}
+	if t.Status == meta.TenantDeleted {
+		errJSON(w, http.StatusNotFound, "tenant not found")
+		return
+	}
+	if t.Provider == tenant.ProviderTiDBZero {
+		errJSON(w, http.StatusConflict, "tidb_zero tenants expire automatically and do not support delete")
+		return
+	}
+	if t.Provider != tenant.ProviderTiDBCloudStarter && t.Provider != tenant.ProviderTiDBCloudNative {
+		errJSON(w, http.StatusConflict, "tenant delete is not supported for provider")
+		return
+	}
+	if t.StorageNamespaceID != "" {
+		hasFork, err := s.meta.NamespaceHasNonDeletedFork(r.Context(), t.StorageNamespaceID)
+		if err != nil {
+			errJSON(w, http.StatusInternalServerError, "failed to check tenant forks")
+			return
+		}
+		if hasFork {
+			errJSON(w, http.StatusConflict, "tenant has non-deleted forks")
+			return
+		}
+	}
+
+	var req tenant.CredentialProvisionRequest
+	if t.Status == meta.TenantDeleting {
+		hasJob, err := s.meta.TenantDeleteJobExists(r.Context(), t.ID)
+		if err != nil {
+			errJSON(w, http.StatusInternalServerError, "failed to check tenant delete cleanup")
+			return
+		}
+		if hasJob {
+			_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
+			writeTenantDeleteStatus(w, meta.TenantDeleting)
+			return
+		}
+	}
+
+	if t.Provider == tenant.ProviderTiDBCloudNative {
+		req, err = decodeCredentialDeprovisionRequest(w, r)
+		if err != nil {
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	if t.Status != meta.TenantDeleting {
+		updated, err := s.meta.UpdateTenantStatusIf(r.Context(), t.ID, t.Status, meta.TenantDeleting)
+		if err != nil {
+			errJSON(w, http.StatusInternalServerError, "failed to mark tenant deleting")
+			return
+		}
+		if !updated {
+			writeTenantDeleteStatus(w, meta.TenantDeleting)
+			return
+		}
+	}
+
+	if err := s.deprovisionTenantCluster(r.Context(), t, req); err != nil {
+		if t.Status != meta.TenantDeleting {
+			_, _ = s.meta.UpdateTenantStatusIf(r.Context(), t.ID, meta.TenantDeleting, t.Status)
+		}
+		errJSON(w, http.StatusBadGateway, fmt.Sprintf("delete tenant cluster failed: %v", err))
+		return
+	}
+
+	s.pool.Invalidate(t.ID)
+	_ = s.meta.AbortActiveUploadReservations(r.Context(), t.ID)
+
+	status, err := s.enqueueTenantDeleteJob(r.Context(), t)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to enqueue tenant delete cleanup")
+		return
+	}
+	_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
+	writeTenantDeleteStatus(w, status)
+}
+
+func (s *Server) enqueueTenantDeleteJob(ctx context.Context, t *meta.Tenant) (meta.TenantStatus, error) {
+	if t.StorageNamespaceID == "" {
+		if err := s.meta.UpdateTenantStatus(ctx, t.ID, meta.TenantDeleted); err != nil {
+			return "", err
+		}
+		return meta.TenantDeleted, nil
+	}
+	ns, err := s.meta.GetStorageNamespace(ctx, t.StorageNamespaceID)
+	if err != nil {
+		return "", err
+	}
+	if err := s.meta.UpdateStorageNamespaceState(ctx, ns.ID, meta.StorageNamespaceDeleting); err != nil {
+		return "", err
+	}
+	if err := s.meta.EnqueueTenantDeleteJob(ctx, &meta.TenantDeleteJob{
+		TenantID:    t.ID,
+		NamespaceID: ns.ID,
+		Backend:     ns.Backend,
+		Bucket:      ns.Bucket,
+		Prefix:      ns.Prefix,
+	}); err != nil {
+		return "", err
+	}
+	return meta.TenantDeleting, nil
+}
+
+func writeTenantDeleteStatus(w http.ResponseWriter, status meta.TenantStatus) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": string(status)})
+}
+
+func (s *Server) deprovisionTenantCluster(ctx context.Context, t *meta.Tenant, req tenant.CredentialProvisionRequest) error {
+	cluster := clusterInfoFromTenant(t)
+	switch t.Provider {
+	case tenant.ProviderTiDBCloudNative:
+		deprovisioner, ok := s.provisioner.(tenant.CredentialDeprovisioner)
+		if !ok {
+			return fmt.Errorf("provisioner does not support credential deprovision")
+		}
+		return deprovisioner.DeprovisionWithCredentials(ctx, cluster, req)
+	case tenant.ProviderTiDBCloudStarter:
+		deprovisioner, ok := s.provisioner.(tenant.Deprovisioner)
+		if !ok {
+			return fmt.Errorf("provisioner does not support deprovision")
+		}
+		return deprovisioner.Deprovision(ctx, cluster)
+	default:
+		return fmt.Errorf("delete is not supported for provider %s", t.Provider)
+	}
+}
+
+func decodeCredentialDeprovisionRequest(w http.ResponseWriter, r *http.Request) (tenant.CredentialProvisionRequest, error) {
+	var raw struct {
+		PublicKey  string `json:"public_key"`
+		PrivateKey string `json:"private_key"`
+	}
+	if r.Body == nil {
+		return tenant.CredentialProvisionRequest{}, fmt.Errorf("public_key and private_key are required")
+	}
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxCredentialProvisionBodyBytes))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&raw); err != nil && !errors.Is(err, io.EOF) {
+		return tenant.CredentialProvisionRequest{}, fmt.Errorf("invalid JSON body: %w", err)
+	}
+	var extra struct{}
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		return tenant.CredentialProvisionRequest{}, fmt.Errorf("invalid JSON body: trailing data")
+	}
+	req := tenant.CredentialProvisionRequest{
+		PublicKey:  strings.TrimSpace(raw.PublicKey),
+		PrivateKey: strings.TrimSpace(raw.PrivateKey),
+	}
+	if req.PublicKey == "" || req.PrivateKey == "" {
+		return tenant.CredentialProvisionRequest{}, fmt.Errorf("public_key and private_key are required")
+	}
+	return req, nil
+}
+
+func (s *Server) startTenantDeleteCleanup(ctx context.Context) {
+	s.startForkWorker(ctx, func(workerCtx context.Context) {
+		ticker := time.NewTicker(defaultTenantDeletePollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-workerCtx.Done():
+				return
+			case <-ticker.C:
+				s.processTenantDeleteJobs(workerCtx)
+			}
+		}
+	})
+}
+
+func (s *Server) processTenantDeleteJobs(ctx context.Context) {
+	_, _ = s.meta.RecoverStaleTenantDeleteJobs(ctx, time.Now().UTC().Add(-defaultTenantDeleteRunningTTL))
+	jobs, err := s.meta.ListDueTenantDeleteJobs(ctx, time.Now().UTC(), 25)
+	if err != nil {
+		return
+	}
+	for _, job := range jobs {
+		if err := s.processTenantDeleteJob(ctx, job); err != nil {
+			_ = s.meta.RetryTenantDeleteJob(ctx, job.TenantID, time.Now().UTC().Add(defaultTenantDeleteRetryDelay), err.Error())
+		}
+	}
+}
+
+func (s *Server) processTenantDeleteJob(ctx context.Context, job meta.TenantDeleteJob) error {
+	updated, err := s.meta.MarkTenantDeleteJobRunning(ctx, job.TenantID)
+	if err != nil {
+		return err
+	}
+	if !updated {
+		return nil
+	}
+	ns := &meta.StorageNamespace{
+		ID:            job.NamespaceID,
+		OwnerTenantID: job.TenantID,
+		Backend:       job.Backend,
+		Bucket:        job.Bucket,
+		Prefix:        job.Prefix,
+		State:         meta.StorageNamespaceDeleting,
+	}
+	s3c, err := s.pool.S3ForStorageNamespace(ctx, ns)
+	if err != nil {
+		return err
+	}
+	res, err := s3c.DeletePrefix(ctx, "")
+	if err != nil {
+		return err
+	}
+	if err := s.meta.MarkTenantDeleteJobDeleted(ctx, job.TenantID, int64(res.DeletedObjects), int64(res.AbortedMultipartUploads)); err != nil {
+		return err
+	}
+	if err := s.meta.UpdateStorageNamespaceState(ctx, job.NamespaceID, meta.StorageNamespaceDeleted); err != nil && !errors.Is(err, meta.ErrNotFound) {
+		return err
+	}
+	return s.meta.UpdateTenantStatus(ctx, job.TenantID, meta.TenantDeleted)
+}

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -123,6 +123,10 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 
 	status, err := s.enqueueTenantDeleteJob(r.Context(), t)
 	if err != nil {
+		// Cluster deprovision already succeeded. Keep owner keys active until
+		// cleanup is durably enqueued so the same owner can retry the delete
+		// request. This matters for tidbcloud_native because customer TiDB Cloud
+		// credentials are accepted per request and are not stored server-side.
 		errJSON(w, http.StatusInternalServerError, "failed to enqueue tenant delete cleanup")
 		return
 	}

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -199,26 +198,16 @@ func decodeCredentialDeprovisionRequest(w http.ResponseWriter, r *http.Request) 
 		PublicKey  string `json:"public_key"`
 		PrivateKey string `json:"private_key"`
 	}
-	if r.Body == nil {
-		return tenant.CredentialProvisionRequest{}, fmt.Errorf("public_key and private_key are required")
+	req, err := decodeCredentialRequest(w, r, &raw, func() tenant.CredentialProvisionRequest {
+		return tenant.CredentialProvisionRequest{
+			PublicKey:  strings.TrimSpace(raw.PublicKey),
+			PrivateKey: strings.TrimSpace(raw.PrivateKey),
+		}
+	})
+	if err != nil {
+		return tenant.CredentialProvisionRequest{}, err
 	}
-	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxCredentialProvisionBodyBytes))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&raw); err != nil && !errors.Is(err, io.EOF) {
-		return tenant.CredentialProvisionRequest{}, fmt.Errorf("invalid JSON body: %w", err)
-	}
-	var extra struct{}
-	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
-		return tenant.CredentialProvisionRequest{}, fmt.Errorf("invalid JSON body: trailing data")
-	}
-	req := tenant.CredentialProvisionRequest{
-		PublicKey:  strings.TrimSpace(raw.PublicKey),
-		PrivateKey: strings.TrimSpace(raw.PrivateKey),
-	}
-	if req.PublicKey == "" || req.PrivateKey == "" {
-		return tenant.CredentialProvisionRequest{}, fmt.Errorf("public_key and private_key are required")
-	}
-	return req, nil
+	return *req, nil
 }
 
 func (s *Server) startTenantDeleteCleanup(ctx context.Context) {

--- a/pkg/server/tenant_delete_test.go
+++ b/pkg/server/tenant_delete_test.go
@@ -221,6 +221,23 @@ func TestTenantDeleteRejectsScopedAPIKey(t *testing.T) {
 	}
 }
 
+func TestTenantDeleteNativeRejectsDatabaseNameCredentialField(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNative, meta.APIKeyScopeKindOwner)
+	req := httptest.NewRequest(http.MethodDelete, "/v1/tenant", strings.NewReader(`{"public_key":"public-1","private_key":"private-1","database_name":"ignored"}`))
+	req.Header.Set("Authorization", "Bearer "+rt.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	rt.server.ServeHTTP(rec, req)
+	resp := rec.Result()
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+}
+
 func TestTenantDeleteNativeSucceedsWithCredentials(t *testing.T) {
 	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNative, meta.APIKeyScopeKindOwner)
 	resp := rt.deleteTenant(t, map[string]string{"public_key": "public-1", "private_key": "private-1"})

--- a/pkg/server/tenant_delete_test.go
+++ b/pkg/server/tenant_delete_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -255,6 +256,48 @@ func TestTenantDeleteStarterUsesServerCredentials(t *testing.T) {
 	assertTenantDeletedAndKeysRevoked(t, rt)
 }
 
+func TestTenantDeleteWaitsForBorrowedBackendBeforeClusterDelete(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudStarter, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	tenantMeta, err := rt.meta.GetTenant(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, release, err := rt.pool.Acquire(ctx, tenantMeta)
+	if err != nil {
+		t.Fatalf("acquire tenant backend: %v", err)
+	}
+	defer release()
+
+	respCh := make(chan *http.Response, 1)
+	go func() {
+		respCh <- rt.deleteTenant(t, nil)
+	}()
+	waitTenantDeleteStatus(t, rt, meta.TenantDeleting)
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls before backend release = %d, want 0", got)
+	}
+	select {
+	case resp := <-respCh:
+		defer func() { _ = resp.Body.Close() }()
+		t.Fatalf("delete response returned before backend release: status %d", resp.StatusCode)
+	default:
+	}
+
+	release()
+	resp := receiveTenantDeleteResponse(t, respCh)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls after backend release = %d, want 1", got)
+	}
+	assertTenantDeletingAndKeysRevoked(t, rt)
+	rt.server.processTenantDeleteJobs(ctx)
+	assertTenantDeletedAndKeysRevoked(t, rt)
+}
+
 func TestTenantDeleteRejectsNonDeletedFork(t *testing.T) {
 	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudStarter, meta.APIKeyScopeKindOwner)
 	ctx := context.Background()
@@ -329,7 +372,13 @@ func TestTenantDeleteRemovesS3PrefixAsyncAfterClusterDelete(t *testing.T) {
 		t.Fatalf("write s3 file: %v", err)
 	}
 	storageRef := objectGCFileStorageRef(t, backendFS, "/large.bin")
-	assertObjectGCS3ObjectBytes(t, backendFS, storageRef, payload)
+	tenantMeta, err = rt.meta.GetTenant(ctx, rt.tenantID)
+	if err != nil {
+		release()
+		t.Fatal(err)
+	}
+	namespaceID := tenantMeta.StorageNamespaceID
+	assertTenantDeleteS3ObjectBytes(t, rt, namespaceID, storageRef, payload)
 	release()
 
 	resp := rt.deleteTenant(t, nil)
@@ -341,12 +390,12 @@ func TestTenantDeleteRemovesS3PrefixAsyncAfterClusterDelete(t *testing.T) {
 		t.Fatalf("deprovision calls = %d, want 1", got)
 	}
 	assertTenantDeletingAndKeysRevoked(t, rt)
-	assertObjectGCS3ObjectBytes(t, backendFS, storageRef, payload)
+	assertTenantDeleteS3ObjectBytes(t, rt, namespaceID, storageRef, payload)
 
 	rt.server.processTenantDeleteJobs(ctx)
 	assertTenantDeletedAndKeysRevoked(t, rt)
 
-	assertTenantDeleteS3ObjectMissing(t, rt, tenantMeta.StorageNamespaceID, storageRef)
+	assertTenantDeleteS3ObjectMissing(t, rt, namespaceID, storageRef)
 }
 
 func TestTenantDeleteAsyncCleanupAbortsActiveMultipartUploads(t *testing.T) {
@@ -380,6 +429,12 @@ func TestTenantDeleteAsyncCleanupAbortsActiveMultipartUploads(t *testing.T) {
 		release()
 		t.Fatalf("upload part: %v", err)
 	}
+	tenantMeta, err = rt.meta.GetTenant(ctx, rt.tenantID)
+	if err != nil {
+		release()
+		t.Fatal(err)
+	}
+	namespaceID := tenantMeta.StorageNamespaceID
 	release()
 
 	resp := rt.deleteTenant(t, nil)
@@ -395,7 +450,7 @@ func TestTenantDeleteAsyncCleanupAbortsActiveMultipartUploads(t *testing.T) {
 	rt.server.processTenantDeleteJobs(ctx)
 	assertTenantDeletedAndKeysRevoked(t, rt)
 
-	s3c := tenantDeleteS3ForNamespace(t, rt, tenantMeta.StorageNamespaceID)
+	s3c := tenantDeleteS3ForNamespace(t, rt, namespaceID)
 	parts, err := s3c.ListParts(ctx, uploadBeforeDelete.S3Key, uploadBeforeDelete.S3UploadID)
 	if err == nil {
 		if len(parts) != 0 {
@@ -419,6 +474,22 @@ func tenantDeleteS3ForNamespace(t *testing.T, rt *tenantDeleteRuntime, namespace
 		t.Fatalf("s3 for storage namespace: %v", err)
 	}
 	return s3c
+}
+
+func assertTenantDeleteS3ObjectBytes(t *testing.T, rt *tenantDeleteRuntime, namespaceID, storageRef string, want []byte) {
+	t.Helper()
+	reader, err := tenantDeleteS3ForNamespace(t, rt, namespaceID).GetObject(context.Background(), storageRef)
+	if err != nil {
+		t.Fatalf("get s3 object %q: %v", storageRef, err)
+	}
+	defer func() { _ = reader.Close() }()
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read s3 object %q: %v", storageRef, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("s3 object %q bytes mismatch: got %d bytes want %d bytes", storageRef, len(got), len(want))
+	}
 }
 
 func assertTenantDeleteS3ObjectMissing(t *testing.T, rt *tenantDeleteRuntime, namespaceID, storageRef string) {
@@ -464,6 +535,35 @@ func assertTenantDeletedAndKeysRevoked(t *testing.T, rt *tenantDeleteRuntime) {
 	}
 	if revokedKeys != 1 {
 		t.Fatalf("revoked api keys = %d, want 1", revokedKeys)
+	}
+}
+
+func waitTenantDeleteStatus(t *testing.T, rt *tenantDeleteRuntime, want meta.TenantStatus) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var status string
+		if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status == string(want) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("tenant status did not become %s, last status %s", want, status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func receiveTenantDeleteResponse(t *testing.T, ch <-chan *http.Response) *http.Response {
+	t.Helper()
+	select {
+	case resp := <-ch:
+		return resp
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for delete response")
+		return nil
 	}
 }
 

--- a/pkg/server/tenant_delete_test.go
+++ b/pkg/server/tenant_delete_test.go
@@ -220,7 +220,7 @@ func TestTenantDeleteRejectsScopedAPIKey(t *testing.T) {
 	}
 }
 
-func TestTenantDeleteNativeRequiresBothOwnerAndCustomerCredentials(t *testing.T) {
+func TestTenantDeleteNativeSucceedsWithCredentials(t *testing.T) {
 	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNative, meta.APIKeyScopeKindOwner)
 	resp := rt.deleteTenant(t, map[string]string{"public_key": "public-1", "private_key": "private-1"})
 	defer func() { _ = resp.Body.Close() }()
@@ -349,7 +349,7 @@ func TestTenantDeleteRemovesS3PrefixAsyncAfterClusterDelete(t *testing.T) {
 	assertTenantDeleteS3ObjectMissing(t, rt, tenantMeta.StorageNamespaceID, storageRef)
 }
 
-func TestTenantDeleteAbortsActiveMultipartUploadsBeforeClusterDelete(t *testing.T) {
+func TestTenantDeleteAsyncCleanupAbortsActiveMultipartUploads(t *testing.T) {
 	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudStarter, meta.APIKeyScopeKindOwner)
 	ctx := context.Background()
 	payload := deterministicObjectGCPayload(8*1024*1024, 0x29)

--- a/pkg/server/tenant_delete_test.go
+++ b/pkg/server/tenant_delete_test.go
@@ -1,0 +1,577 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+	"github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/dat9/internal/testmysql"
+	"github.com/mem9-ai/dat9/pkg/encrypt"
+	"github.com/mem9-ai/dat9/pkg/meta"
+	"github.com/mem9-ai/dat9/pkg/s3client"
+	"github.com/mem9-ai/dat9/pkg/tenant"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
+)
+
+type tenantDeleteRuntime struct {
+	meta        *meta.Store
+	pool        *tenant.Pool
+	tokenSecret []byte
+	tenantID    string
+	apiKey      string
+	prov        *fakeProvisioner
+	server      *Server
+}
+
+func newTenantDeleteRuntime(t *testing.T, provider string, scopeKind meta.APIKeyScopeKind) *tenantDeleteRuntime {
+	t.Helper()
+	db := newTenantDeleteDBInfo(t)
+	testmysql.ResetMetaDB(t, db.Meta.DB())
+	testmysql.ResetDB(t, db.Meta.DB())
+	t.Cleanup(func() {
+		testmysql.ResetMetaDB(t, db.Meta.DB())
+		testmysql.ResetDB(t, db.Meta.DB())
+	})
+	tenantID := token.NewID()
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	apiKey, err := token.IssueToken(tokenSecret, tenantID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	apiKeyCipher, err := db.Pool.Encrypt(context.Background(), []byte(apiKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbPassCipher, err := db.Pool.Encrypt(context.Background(), []byte(db.DBPass))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if err := db.Meta.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		Kind:             meta.TenantKindLive,
+		DBHost:           db.DBHost,
+		DBPort:           db.DBPort,
+		DBUser:           db.DBUser,
+		DBPasswordCipher: dbPassCipher,
+		DBName:           db.DBName,
+		DBTLS:            false,
+		Provider:         provider,
+		ClusterID:        "cluster-delete-1",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Meta.InsertAPIKey(context.Background(), &meta.APIKey{
+		ID:            token.NewID(),
+		TenantID:      tenantID,
+		KeyName:       "default",
+		JWTCiphertext: apiKeyCipher,
+		JWTHash:       token.HashToken(apiKey),
+		TokenVersion:  1,
+		Status:        meta.APIKeyActive,
+		ScopeKind:     scopeKind,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: provider, cluster: &tenant.ClusterInfo{}}
+	server := NewWithConfig(Config{Meta: db.Meta, Pool: db.Pool, Provisioner: prov, TokenSecret: tokenSecret})
+	t.Cleanup(server.Close)
+	return &tenantDeleteRuntime{
+		meta:        db.Meta,
+		pool:        db.Pool,
+		tokenSecret: tokenSecret,
+		tenantID:    tenantID,
+		apiKey:      apiKey,
+		prov:        prov,
+		server:      server,
+	}
+}
+
+func newTenantDeleteDBInfo(t *testing.T) *testDBInfo {
+	t.Helper()
+	if testDSN == "" {
+		t.Skip("no test database available")
+	}
+	dropTenantSchemaLLMUsage(t)
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	initServerTenantSchema(t, testDSN)
+
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost", SkipTiDBSchemaCheck: true}, enc)
+	pool.SetMetaStore(metaStore)
+	t.Cleanup(pool.Close)
+	return &testDBInfo{Meta: metaStore, Pool: pool, DBHost: host, DBPort: port, DBUser: parsed.User, DBPass: parsed.Passwd, DBName: parsed.DBName}
+}
+
+func dropTenantSchemaLLMUsage(t *testing.T) {
+	t.Helper()
+	db := testmysql.OpenDB(t, testDSN)
+	var tableCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'llm_usage'`).Scan(&tableCount); err != nil {
+		t.Fatalf("check llm_usage table: %v", err)
+	}
+	if tableCount == 0 {
+		return
+	}
+	var tenantIDColumnCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'llm_usage' AND column_name = 'tenant_id'`).Scan(&tenantIDColumnCount); err != nil {
+		t.Fatalf("check llm_usage tenant_id column: %v", err)
+	}
+	if tenantIDColumnCount > 0 {
+		return
+	}
+	if _, err := db.Exec("DROP TABLE llm_usage"); err != nil {
+		t.Fatalf("drop tenant-schema llm_usage: %v", err)
+	}
+}
+
+func (rt *tenantDeleteRuntime) deleteTenant(t *testing.T, body any) *http.Response {
+	t.Helper()
+	var reader *bytes.Reader
+	if body == nil {
+		reader = bytes.NewReader(nil)
+	} else {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		reader = bytes.NewReader(raw)
+	}
+	req := httptest.NewRequest(http.MethodDelete, "/v1/tenant", reader)
+	req.Header.Set("Authorization", "Bearer "+rt.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	rt.server.ServeHTTP(rec, req)
+	return rec.Result()
+}
+
+func TestTenantDeleteNativeRequiresOwnerAndTiDBCloudCredentials(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNative, meta.APIKeyScopeKindOwner)
+	resp := rt.deleteTenant(t, map[string]string{"public_key": "public-1"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+	var status string
+	if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantActive) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantActive)
+	}
+}
+
+func TestTenantDeleteRejectsScopedAPIKey(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNative, meta.APIKeyScopeKindFS)
+	resp := rt.deleteTenant(t, map[string]string{"public_key": "public-1", "private_key": "private-1"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+}
+
+func TestTenantDeleteNativeRequiresBothOwnerAndCustomerCredentials(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNative, meta.APIKeyScopeKindOwner)
+	resp := rt.deleteTenant(t, map[string]string{"public_key": "public-1", "private_key": "private-1"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	if rt.prov.lastCredentialReq.PublicKey != "public-1" || rt.prov.lastCredentialReq.PrivateKey != "private-1" {
+		t.Fatalf("credential request = %+v", rt.prov.lastCredentialReq)
+	}
+	if rt.prov.lastDeprovision == nil || rt.prov.lastDeprovision.ClusterID != "cluster-delete-1" {
+		t.Fatalf("deprovision cluster = %+v", rt.prov.lastDeprovision)
+	}
+	assertTenantDeletedAndKeysRevoked(t, rt)
+}
+
+func TestTenantDeleteStarterUsesServerCredentials(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudStarter, meta.APIKeyScopeKindOwner)
+	resp := rt.deleteTenant(t, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	if rt.prov.lastCredentialReq.PublicKey != "" || rt.prov.lastCredentialReq.PrivateKey != "" {
+		t.Fatalf("starter delete should not use customer credentials: %+v", rt.prov.lastCredentialReq)
+	}
+	assertTenantDeletedAndKeysRevoked(t, rt)
+}
+
+func TestTenantDeleteRejectsNonDeletedFork(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudStarter, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	tenantMeta, err := rt.meta.GetTenant(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, release, err := rt.pool.Acquire(ctx, tenantMeta); err != nil {
+		t.Fatalf("acquire tenant backend: %v", err)
+	} else {
+		release()
+	}
+	tenantMeta, err = rt.meta.GetTenant(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:                 token.NewID(),
+		Status:             meta.TenantActive,
+		Kind:               meta.TenantKindFork,
+		ParentTenantID:     rt.tenantID,
+		StorageNamespaceID: tenantMeta.StorageNamespaceID,
+		DBHost:             tenantMeta.DBHost,
+		DBPort:             tenantMeta.DBPort,
+		DBUser:             tenantMeta.DBUser,
+		DBPasswordCipher:   tenantMeta.DBPasswordCipher,
+		DBName:             tenantMeta.DBName,
+		DBTLS:              tenantMeta.DBTLS,
+		Provider:           tenantMeta.Provider,
+		ClusterID:          tenantMeta.ClusterID,
+		BranchID:           "branch-a",
+		SchemaVersion:      tenantMeta.SchemaVersion,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := rt.deleteTenant(t, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+	var status string
+	if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantActive) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantActive)
+	}
+}
+
+func TestTenantDeleteRemovesS3PrefixAsyncAfterClusterDelete(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudStarter, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	payload := deterministicObjectGCPayload(8*1024*1024, 0x72)
+
+	tenantMeta, err := rt.meta.GetTenant(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backendFS, release, err := rt.pool.Acquire(ctx, tenantMeta)
+	if err != nil {
+		t.Fatalf("acquire tenant backend: %v", err)
+	}
+	if _, err := backendFS.Write("/large.bin", payload, 0, filesystem.WriteFlagCreate); err != nil {
+		release()
+		t.Fatalf("write s3 file: %v", err)
+	}
+	storageRef := objectGCFileStorageRef(t, backendFS, "/large.bin")
+	assertObjectGCS3ObjectBytes(t, backendFS, storageRef, payload)
+	release()
+
+	resp := rt.deleteTenant(t, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	assertTenantDeletingAndKeysRevoked(t, rt)
+	assertObjectGCS3ObjectBytes(t, backendFS, storageRef, payload)
+
+	rt.server.processTenantDeleteJobs(ctx)
+	assertTenantDeletedAndKeysRevoked(t, rt)
+
+	assertTenantDeleteS3ObjectMissing(t, rt, tenantMeta.StorageNamespaceID, storageRef)
+}
+
+func TestTenantDeleteAbortsActiveMultipartUploadsBeforeClusterDelete(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudStarter, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	payload := deterministicObjectGCPayload(8*1024*1024, 0x29)
+
+	tenantMeta, err := rt.meta.GetTenant(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backendFS, release, err := rt.pool.Acquire(ctx, tenantMeta)
+	if err != nil {
+		t.Fatalf("acquire tenant backend: %v", err)
+	}
+	plan, err := backendFS.InitiateUpload(ctx, "/uploading.bin", int64(len(payload)))
+	if err != nil {
+		release()
+		t.Fatalf("initiate upload: %v", err)
+	}
+	if len(plan.Parts) == 0 {
+		release()
+		t.Fatal("upload plan has no parts")
+	}
+	uploadBeforeDelete, err := backendFS.Store().GetUpload(ctx, plan.UploadID)
+	if err != nil {
+		release()
+		t.Fatalf("get upload before delete: %v", err)
+	}
+	if _, err := backendFS.S3().(*s3client.LocalS3Client).UploadPart(ctx, uploadBeforeDelete.S3UploadID, plan.Parts[0].Number, bytes.NewReader(payload[:plan.Parts[0].Size])); err != nil {
+		release()
+		t.Fatalf("upload part: %v", err)
+	}
+	release()
+
+	resp := rt.deleteTenant(t, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	assertTenantDeletingAndKeysRevoked(t, rt)
+
+	rt.server.processTenantDeleteJobs(ctx)
+	assertTenantDeletedAndKeysRevoked(t, rt)
+
+	s3c := tenantDeleteS3ForNamespace(t, rt, tenantMeta.StorageNamespaceID)
+	parts, err := s3c.ListParts(ctx, uploadBeforeDelete.S3Key, uploadBeforeDelete.S3UploadID)
+	if err == nil {
+		if len(parts) != 0 {
+			t.Fatalf("multipart parts after delete = %d, want 0", len(parts))
+		}
+		t.Fatal("multipart upload still exists after tenant delete")
+	}
+	if !strings.Contains(err.Error(), "upload not found") {
+		t.Fatalf("list parts after delete error = %v, want upload not found", err)
+	}
+}
+
+func tenantDeleteS3ForNamespace(t *testing.T, rt *tenantDeleteRuntime, namespaceID string) s3client.S3Client {
+	t.Helper()
+	ns, err := rt.meta.GetStorageNamespace(context.Background(), namespaceID)
+	if err != nil {
+		t.Fatalf("get storage namespace: %v", err)
+	}
+	s3c, err := rt.pool.S3ForStorageNamespace(context.Background(), ns)
+	if err != nil {
+		t.Fatalf("s3 for storage namespace: %v", err)
+	}
+	return s3c
+}
+
+func assertTenantDeleteS3ObjectMissing(t *testing.T, rt *tenantDeleteRuntime, namespaceID, storageRef string) {
+	t.Helper()
+	reader, err := tenantDeleteS3ForNamespace(t, rt, namespaceID).GetObject(context.Background(), storageRef)
+	if err == nil {
+		_ = reader.Close()
+		t.Fatalf("s3 object %q still exists after tenant delete", storageRef)
+	}
+}
+
+func TestTenantDeleteTiDBZeroUnsupported(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBZero, meta.APIKeyScopeKindOwner)
+	resp := rt.deleteTenant(t, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+}
+
+func assertTenantDeletedAndKeysRevoked(t *testing.T, rt *tenantDeleteRuntime) {
+	t.Helper()
+	var status string
+	if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantDeleted) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantDeleted)
+	}
+	var activeKeys int
+	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND status = ?", rt.tenantID, meta.APIKeyActive).Scan(&activeKeys); err != nil {
+		t.Fatal(err)
+	}
+	if activeKeys != 0 {
+		t.Fatalf("active api keys = %d, want 0", activeKeys)
+	}
+	var revokedKeys int
+	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND status = ?", rt.tenantID, meta.APIKeyRevoked).Scan(&revokedKeys); err != nil {
+		t.Fatal(err)
+	}
+	if revokedKeys != 1 {
+		t.Fatalf("revoked api keys = %d, want 1", revokedKeys)
+	}
+}
+
+func assertTenantDeletingAndKeysRevoked(t *testing.T, rt *tenantDeleteRuntime) {
+	t.Helper()
+	var status string
+	if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantDeleting) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantDeleting)
+	}
+	var activeKeys int
+	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND status = ?", rt.tenantID, meta.APIKeyActive).Scan(&activeKeys); err != nil {
+		t.Fatal(err)
+	}
+	if activeKeys != 0 {
+		t.Fatalf("active api keys = %d, want 0", activeKeys)
+	}
+}
+
+func TestTenantDeleteClusterFailureLeavesTenantActiveForCredentialRetry(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNative, meta.APIKeyScopeKindOwner)
+	rt.prov.deprovisionErr = fmt.Errorf("upstream down")
+	resp := rt.deleteTenant(t, map[string]string{"public_key": "public-1", "private_key": "private-1"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
+	}
+	var status string
+	if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantActive) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantActive)
+	}
+}
+
+func TestTenantDeleteCanRetryDeletingTenant(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNative, meta.APIKeyScopeKindOwner)
+	if err := rt.meta.UpdateTenantStatus(context.Background(), rt.tenantID, meta.TenantDeleting); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := rt.deleteTenant(t, map[string]string{"public_key": "public-1", "private_key": "private-1"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	rt.server.processTenantDeleteJobs(context.Background())
+	assertTenantDeletedAndKeysRevoked(t, rt)
+}
+
+func TestTenantDeleteKeepsOwnerKeyWhenCleanupEnqueueFails(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNative, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE tenants SET storage_namespace_id = ? WHERE id = ?", "missing-namespace", rt.tenantID); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := rt.deleteTenant(t, map[string]string{"public_key": "public-1", "private_key": "private-1"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	var status string
+	if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantDeleting) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantDeleting)
+	}
+	var activeKeys int
+	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND status = ?", rt.tenantID, meta.APIKeyActive).Scan(&activeKeys); err != nil {
+		t.Fatal(err)
+	}
+	if activeKeys != 1 {
+		t.Fatalf("active api keys = %d, want 1", activeKeys)
+	}
+}
+
+func TestTenantDeleteDeletingTenantWithCleanupJobDoesNotRepeatClusterDelete(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNative, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	if err := rt.meta.UpdateTenantStatus(ctx, rt.tenantID, meta.TenantDeleting); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.EnqueueTenantDeleteJob(ctx, &meta.TenantDeleteJob{
+		TenantID:    rt.tenantID,
+		NamespaceID: rt.tenantID,
+		Backend:     "local",
+		Prefix:      rt.tenantID + "/",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := rt.deleteTenant(t, map[string]string{"public_key": "public-1", "private_key": "private-1"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+}

--- a/pkg/server/tokens.go
+++ b/pkg/server/tokens.go
@@ -48,7 +48,7 @@ func (s *Server) handleTokens(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusNotFound, "token management not enabled")
 		return
 	}
-	scope, ok := ownerScopeFromRequest(w, r)
+	scope, ok := ownerScopeFromRequest(w, r, "manage tokens")
 	if !ok {
 		return
 	}
@@ -82,14 +82,17 @@ func (s *Server) handleTokens(w http.ResponseWriter, r *http.Request) {
 	s.handleScopedTokenRevoke(w, r, scope, tokenID)
 }
 
-func ownerScopeFromRequest(w http.ResponseWriter, r *http.Request) (*TenantScope, bool) {
+func ownerScopeFromRequest(w http.ResponseWriter, r *http.Request, action string) (*TenantScope, bool) {
 	scope := ScopeFromContext(r.Context())
 	if scope == nil {
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return nil, false
 	}
 	if scope.IsScoped || scope.ScopeKind == meta.APIKeyScopeKindFS {
-		errJSON(w, http.StatusForbidden, "scoped token cannot manage tokens")
+		if strings.TrimSpace(action) == "" {
+			action = "perform this operation"
+		}
+		errJSON(w, http.StatusForbidden, "scoped token cannot "+action)
 		return nil, false
 	}
 	return scope, true

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -368,6 +368,51 @@ func (p *Pool) InvalidateAndWait(ctx context.Context, tenantID string) error {
 	}
 }
 
+func (p *Pool) S3ForStorageNamespace(ctx context.Context, ns *meta.StorageNamespace) (out s3client.S3Client, err error) {
+	start := time.Now()
+	namespaceID := ""
+	if ns != nil {
+		namespaceID = ns.ID
+	}
+	defer observePool(ctx, "s3_for_storage_namespace", namespaceID, &err, start)
+	if ns == nil {
+		return nil, fmt.Errorf("storage namespace is required")
+	}
+	switch ns.Backend {
+	case "s3":
+		if p.cfg.S3Bucket == "" {
+			return nil, fmt.Errorf("s3 bucket is not configured")
+		}
+		if ns.Bucket != "" && ns.Bucket != p.cfg.S3Bucket {
+			return nil, fmt.Errorf("storage namespace bucket %q does not match configured bucket", ns.Bucket)
+		}
+		return s3client.New(ctx, s3client.AWSConfig{
+			Region:          p.cfg.S3Region,
+			Bucket:          p.cfg.S3Bucket,
+			Prefix:          ns.Prefix,
+			RoleARN:         p.cfg.S3RoleARN,
+			Endpoint:        p.cfg.S3Endpoint,
+			ForcePathStyle:  p.cfg.S3ForcePathStyle,
+			AccessKeyID:     p.cfg.S3AccessKeyID,
+			SecretAccessKey: p.cfg.S3SecretAccessKey,
+			SessionToken:    p.cfg.S3SessionToken,
+		})
+	case "local":
+		if p.cfg.S3Dir == "" {
+			return nil, fmt.Errorf("local s3 dir is not configured")
+		}
+		localPrefix := strings.Trim(ns.Prefix, "/")
+		s3Dir := strings.TrimRight(p.cfg.S3Dir, "/") + "/" + localPrefix
+		baseURL := strings.TrimRight(p.cfg.PublicURL, "/")
+		if baseURL != "" {
+			baseURL += "/s3/" + localPrefix
+		}
+		return s3client.NewLocal(s3Dir, baseURL)
+	default:
+		return nil, fmt.Errorf("unsupported storage backend %q", ns.Backend)
+	}
+}
+
 func withTenantPoolDrainTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
 	if _, ok := ctx.Deadline(); ok {
 		return ctx, func() {}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -401,8 +402,20 @@ func (p *Pool) S3ForStorageNamespace(ctx context.Context, ns *meta.StorageNamesp
 		if p.cfg.S3Dir == "" {
 			return nil, fmt.Errorf("local s3 dir is not configured")
 		}
-		localPrefix := strings.Trim(ns.Prefix, "/")
-		s3Dir := strings.TrimRight(p.cfg.S3Dir, "/") + "/" + localPrefix
+		localPrefix, err := cleanStorageNamespaceLocalPrefix(ns.Prefix)
+		if err != nil {
+			return nil, err
+		}
+		rootDir, err := filepath.Abs(p.cfg.S3Dir)
+		if err != nil {
+			return nil, fmt.Errorf("resolve local s3 dir: %w", err)
+		}
+		s3Dir := filepath.Join(rootDir, localPrefix)
+		if rel, err := filepath.Rel(rootDir, s3Dir); err != nil {
+			return nil, fmt.Errorf("resolve local storage namespace prefix: %w", err)
+		} else if rel == ".." || strings.HasPrefix(rel, "../") {
+			return nil, fmt.Errorf("storage namespace prefix escapes local s3 dir")
+		}
 		baseURL := strings.TrimRight(p.cfg.PublicURL, "/")
 		if baseURL != "" {
 			baseURL += "/s3/" + localPrefix
@@ -411,6 +424,22 @@ func (p *Pool) S3ForStorageNamespace(ctx context.Context, ns *meta.StorageNamesp
 	default:
 		return nil, fmt.Errorf("unsupported storage backend %q", ns.Backend)
 	}
+}
+
+func cleanStorageNamespaceLocalPrefix(prefix string) (string, error) {
+	if filepath.IsAbs(prefix) {
+		return "", fmt.Errorf("storage namespace prefix must be relative")
+	}
+	localPrefix := strings.Trim(prefix, "/")
+	if localPrefix == "" {
+		return "", fmt.Errorf("storage namespace prefix is required")
+	}
+	for _, part := range strings.Split(localPrefix, "/") {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("invalid storage namespace prefix %q", prefix)
+		}
+	}
+	return localPrefix, nil
 }
 
 func withTenantPoolDrainTimeout(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -52,6 +52,40 @@ func TestPoolAcquireInvalidateDefersCloseUntilRelease(t *testing.T) {
 	release2()
 }
 
+func TestCleanStorageNamespaceLocalPrefixRejectsUnsafeSegments(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		want    string
+		wantErr bool
+	}{
+		{name: "normal", prefix: "tenant/abc", want: "tenant/abc"},
+		{name: "trim", prefix: "tenant/abc/", want: "tenant/abc"},
+		{name: "empty", prefix: "", wantErr: true},
+		{name: "absolute", prefix: "/tmp/tenant", wantErr: true},
+		{name: "parent", prefix: "tenant/../other", wantErr: true},
+		{name: "dot", prefix: "tenant/./other", wantErr: true},
+		{name: "empty segment", prefix: "tenant//other", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cleanStorageNamespaceLocalPrefix(tc.prefix)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("cleanStorageNamespaceLocalPrefix(%q) error = nil, want error", tc.prefix)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("cleanStorageNamespaceLocalPrefix(%q): %v", tc.prefix, err)
+			}
+			if got != tc.want {
+				t.Fatalf("cleanStorageNamespaceLocalPrefix(%q) = %q, want %q", tc.prefix, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPoolAcquireEvictionRetiresPinnedEntry(t *testing.T) {
 	pool, tenantA := newTestPoolAndTenant(t, 1, "tenant-a")
 	ctx := context.Background()

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -26,6 +26,11 @@ type Provisioner interface {
 	ProviderType() string
 }
 
+type Deprovisioner interface {
+	Provisioner
+	Deprovision(ctx context.Context, cluster *ClusterInfo) error
+}
+
 type CredentialProvisionRequest struct {
 	PublicKey    string
 	PrivateKey   string
@@ -35,6 +40,11 @@ type CredentialProvisionRequest struct {
 type CredentialProvisioner interface {
 	Provisioner
 	ProvisionWithCredentials(ctx context.Context, tenantID string, req CredentialProvisionRequest) (*ClusterInfo, error)
+}
+
+type CredentialDeprovisioner interface {
+	Provisioner
+	DeprovisionWithCredentials(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) error
 }
 
 type BranchProvisioner interface {

--- a/pkg/tenant/starter/provisioner.go
+++ b/pkg/tenant/starter/provisioner.go
@@ -182,7 +182,7 @@ func (p *Provisioner) Deprovision(ctx context.Context, cluster *tenant.ClusterIn
 	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s", p.apiURL, url.PathEscape(strings.TrimSpace(cluster.ClusterID)))
 	resp, err := p.doDigestAuthRequest(ctx, http.MethodDelete, endpoint, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("delete starter cluster digest request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	raw, _ := io.ReadAll(resp.Body)

--- a/pkg/tenant/starter/provisioner.go
+++ b/pkg/tenant/starter/provisioner.go
@@ -175,6 +175,23 @@ func (p *Provisioner) UpdateSpendingLimit(ctx context.Context, clusterID string,
 	return nil
 }
 
+func (p *Provisioner) Deprovision(ctx context.Context, cluster *tenant.ClusterInfo) error {
+	if cluster == nil || strings.TrimSpace(cluster.ClusterID) == "" {
+		return fmt.Errorf("cluster id is required")
+	}
+	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s", p.apiURL, url.PathEscape(strings.TrimSpace(cluster.ClusterID)))
+	resp, err := p.doDigestAuthRequest(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("starter cluster delete status %d: %s", resp.StatusCode, string(raw))
+	}
+	return nil
+}
+
 func (p *Provisioner) ProvisionBranch(ctx context.Context, forkTenantID string, source *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
 	out, err := p.CreateBranch(ctx, forkTenantID, source)
 	if err != nil {

--- a/pkg/tenant/starter/provisioner_test.go
+++ b/pkg/tenant/starter/provisioner_test.go
@@ -233,6 +233,31 @@ func TestProvisionReturnsSpendingLimitUpdateError(t *testing.T) {
 	}
 }
 
+func TestDeprovisionDeletesCluster(t *testing.T) {
+	var deleteCalled bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1beta1/clusters/c1" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		deleteCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{apiURL: ts.URL, apiKey: "public-1", apiSecret: "private-1", client: ts.Client()}
+	if err := p.Deprovision(context.Background(), &tenant.ClusterInfo{ClusterID: "c1"}); err != nil {
+		t.Fatalf("Deprovision: %v", err)
+	}
+	if !deleteCalled {
+		t.Fatal("delete was not called")
+	}
+}
+
 func TestProvisionBranchCreatesBranchFromSourceBranch(t *testing.T) {
 	var gotParentID string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -33,6 +33,7 @@ const (
 	EnvTiDBCloudDefaultSpendingLimit      = "DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT"
 
 	DefaultDatabaseName = "tidbcloud_fs"
+	DefaultSpendLimit   = int32(1000)
 
 	upstreamErrorBodyLimit = 2048
 )
@@ -237,10 +238,11 @@ func (p *Provisioner) resolveDatabaseName(raw string) (string, error) {
 }
 
 func parseDefaultSpendLimit(raw string) (*int32, error) {
-	if raw == "" {
-		return nil, nil
-	}
 	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		out := DefaultSpendLimit
+		return &out, nil
+	}
 	monthly, err := strconv.ParseInt(trimmed, 10, 32)
 	if err != nil || monthly < 0 {
 		return nil, fmt.Errorf("invalid %s value %q: must be a non-negative integer in USD cents", EnvTiDBCloudDefaultSpendingLimit, raw)

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -177,6 +177,28 @@ func (p *Provisioner) ProvisionWithCredentials(ctx context.Context, tenantID str
 	return out, nil
 }
 
+func (p *Provisioner) DeprovisionWithCredentials(ctx context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) error {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return fmt.Errorf("public_key and private_key are required")
+	}
+	if cluster == nil || strings.TrimSpace(cluster.ClusterID) == "" {
+		return fmt.Errorf("cluster id is required")
+	}
+	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s", p.apiURL, url.PathEscape(strings.TrimSpace(cluster.ClusterID)))
+	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("tidbcloud native cluster delete status %d: %s", resp.StatusCode, sanitizeUpstreamBody(raw))
+	}
+	return nil
+}
+
 func (p *Provisioner) regionName() string {
 	if strings.HasPrefix(p.region, "regions/") {
 		return p.region

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ const (
 	EnvTiDBCloudNativeCloudProvider       = "DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER"
 	EnvTiDBCloudNativeRegion              = "DRIVE9_TIDBCLOUD_NATIVE_REGION"
 	EnvTiDBCloudNativeDefaultDatabaseName = "DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME"
+	EnvTiDBCloudDefaultSpendingLimit      = "DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT"
 
 	DefaultDatabaseName = "tidbcloud_fs"
 
@@ -45,6 +47,7 @@ type Provisioner struct {
 	cloudProvider       string
 	region              string
 	defaultDatabaseName string
+	defaultSpendLimit   *int32
 	client              *http.Client
 }
 
@@ -53,6 +56,10 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 	cloudProvider := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeCloudProvider))
 	region := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeRegion))
 	defaultDB := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeDefaultDatabaseName))
+	defaultSpendLimit, err := parseDefaultSpendLimit(os.Getenv(EnvTiDBCloudDefaultSpendingLimit))
+	if err != nil {
+		return nil, err
+	}
 	if defaultDB == "" {
 		defaultDB = DefaultDatabaseName
 	}
@@ -71,6 +78,7 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 		cloudProvider:       cloudProvider,
 		region:              region,
 		defaultDatabaseName: defaultDB,
+		defaultSpendLimit:   defaultSpendLimit,
 		client:              &http.Client{Timeout: 60 * time.Second},
 	}, nil
 }
@@ -113,13 +121,17 @@ func (p *Provisioner) ProvisionWithCredentials(ctx context.Context, tenantID str
 	if err != nil {
 		return nil, err
 	}
-	body, err := json.Marshal(map[string]any{
+	reqBody := map[string]any{
 		"displayName":  clusterDisplayName(tenantID),
 		"rootPassword": password,
 		"region": map[string]string{
 			"name": p.regionName(),
 		},
-	})
+	}
+	if p.defaultSpendLimit != nil {
+		reqBody["spendingLimit"] = map[string]int32{"monthly": *p.defaultSpendLimit}
+	}
+	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -222,6 +234,19 @@ func (p *Provisioner) resolveDatabaseName(raw string) (string, error) {
 		name = p.defaultDatabaseName
 	}
 	return normalizeDatabaseName(name)
+}
+
+func parseDefaultSpendLimit(raw string) (*int32, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	trimmed := strings.TrimSpace(raw)
+	monthly, err := strconv.ParseInt(trimmed, 10, 32)
+	if err != nil || monthly < 0 {
+		return nil, fmt.Errorf("invalid %s value %q: must be a non-negative integer in USD cents", EnvTiDBCloudDefaultSpendingLimit, raw)
+	}
+	out := int32(monthly)
+	return &out, nil
 }
 
 func normalizeDatabaseName(name string) (string, error) {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -39,6 +39,21 @@ func TestNewProvisionerFromEnvReadsServerSideConfigOnly(t *testing.T) {
 	}
 }
 
+func TestNewProvisionerFromEnvUsesBuiltinDefaultSpendingLimit(t *testing.T) {
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+	t.Setenv(EnvTiDBCloudDefaultSpendingLimit, "")
+
+	p, err := NewProvisionerFromEnv()
+	if err != nil {
+		t.Fatalf("NewProvisionerFromEnv: %v", err)
+	}
+	if p.defaultSpendLimit == nil || *p.defaultSpendLimit != DefaultSpendLimit {
+		t.Fatalf("defaultSpendLimit = %v, want %d", p.defaultSpendLimit, DefaultSpendLimit)
+	}
+}
+
 func TestNewProvisionerFromEnvRequiresCloudProviderAndRegion(t *testing.T) {
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "")

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -17,6 +17,7 @@ func TestNewProvisionerFromEnvReadsServerSideConfigOnly(t *testing.T) {
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
 	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
 	t.Setenv(EnvTiDBCloudNativeDefaultDatabaseName, "drive9_db")
+	t.Setenv(EnvTiDBCloudDefaultSpendingLimit, "5000")
 	t.Setenv("DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY", "must-not-be-read")
 	t.Setenv("DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY", "must-not-be-read")
 
@@ -32,6 +33,9 @@ func TestNewProvisionerFromEnvReadsServerSideConfigOnly(t *testing.T) {
 	}
 	if p.defaultDatabaseName != "drive9_db" {
 		t.Fatalf("default db = %q", p.defaultDatabaseName)
+	}
+	if p.defaultSpendLimit == nil || *p.defaultSpendLimit != 5000 {
+		t.Fatalf("default spend limit = %v, want 5000", p.defaultSpendLimit)
 	}
 }
 
@@ -78,6 +82,21 @@ func TestNewProvisionerFromEnvRejectsInvalidDefaultDatabaseName(t *testing.T) {
 	}
 }
 
+func TestNewProvisionerFromEnvRejectsInvalidDefaultSpendingLimit(t *testing.T) {
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+	t.Setenv(EnvTiDBCloudDefaultSpendingLimit, "-1")
+
+	_, err := NewProvisionerFromEnv()
+	if err == nil {
+		t.Fatal("expected invalid default spending limit error")
+	}
+	if !strings.Contains(err.Error(), EnvTiDBCloudDefaultSpendingLimit) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testing.T) {
 	var ensureDBCalled bool
 	var pollCount int
@@ -98,6 +117,9 @@ func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testin
 		Region       struct {
 			Name string `json:"name"`
 		} `json:"region"`
+		SpendingLimit struct {
+			Monthly int32 `json:"monthly"`
+		} `json:"spendingLimit"`
 	}
 	var requestCount int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -146,6 +168,7 @@ func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testin
 		cloudProvider:       "aws",
 		region:              "us-east-1",
 		defaultDatabaseName: DefaultDatabaseName,
+		defaultSpendLimit:   int32Ptr(5000),
 		client:              ts.Client(),
 	}
 	out, err := p.ProvisionWithCredentials(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
@@ -171,6 +194,9 @@ func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testin
 	if gotBody.RootPassword == "" {
 		t.Fatal("rootPassword was empty")
 	}
+	if gotBody.SpendingLimit.Monthly != 5000 {
+		t.Fatalf("spendingLimit.monthly = %d, want 5000", gotBody.SpendingLimit.Monthly)
+	}
 	if out.ClusterID != "cluster-1" || out.Username != "u1.root" || out.DBName != "customer_db" || out.Provider != tenant.ProviderTiDBCloudNative {
 		t.Fatalf("unexpected cluster info: %#v", out)
 	}
@@ -180,6 +206,10 @@ func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testin
 	if pollCount < 2 {
 		t.Fatalf("poll count = %d, want at least 2", pollCount)
 	}
+}
+
+func int32Ptr(v int32) *int32 {
+	return &v
 }
 
 func TestProvisionWithCredentialsDefaultsDatabaseName(t *testing.T) {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -273,6 +273,45 @@ func TestProvisionWithCredentialsIncludesUpstreamBodyOnError(t *testing.T) {
 	}
 }
 
+func TestDeprovisionWithCredentialsDeletesCluster(t *testing.T) {
+	var gotAuth string
+	var deleteCalled bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1beta1/clusters/cluster-1" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		deleteCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL: ts.URL,
+		client: ts.Client(),
+	}
+	if err := p.DeprovisionWithCredentials(context.Background(), &tenant.ClusterInfo{ClusterID: "cluster-1"}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	}); err != nil {
+		t.Fatalf("DeprovisionWithCredentials: %v", err)
+	}
+	if !deleteCalled {
+		t.Fatal("delete was not called")
+	}
+	if !strings.Contains(gotAuth, `username="public-1"`) {
+		t.Fatalf("Authorization header did not use request public key: %q", gotAuth)
+	}
+	if strings.Contains(gotAuth, "private-1") {
+		t.Fatalf("Authorization header leaked private key: %q", gotAuth)
+	}
+}
+
 func TestRegionNameAcceptsFullRegionResourceName(t *testing.T) {
 	p := &Provisioner{cloudProvider: "alicloud", region: "regions/alicloud-ap-southeast-1"}
 	if got := p.regionName(); got != "regions/alicloud-ap-southeast-1" {


### PR DESCRIPTION
## Summary
- add owner-only `DELETE /v1/tenant` for live tenant deletion
- synchronously delete TiDB Cloud Starter clusters before revoking keys; `tidbcloud_native` uses request-provided customer public/private keys and does not store them
- reject `tidb_zero` deletes and reject live tenant deletes while non-deleted forks share the storage namespace
- add durable `tenant_delete_jobs` and async S3 prefix cleanup with retry/recovery
- add S3 prefix deletion for AWS/local clients and cleanup access by storage namespace

## Testing
- `go test ./pkg/server -run 'TestTenantDelete'`\n- `make test TEST_PKGS='./pkg/server'`\n- `make test TEST_PKGS='./pkg/meta'`\n- `go test ./pkg/s3client`\n- `make test TEST_PKGS='./pkg/tenant'`\n- `make test TEST_PKGS='./pkg/backend'`\n- `make test TEST_PKGS='./pkg/tenant/starter ./pkg/tenant/tidbcloudnative'`\n- `make lint`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added owner-scoped `DELETE /v1/tenant` with idempotent tenant state transitions and asynchronous deletion cleanup.
  * Implemented best-effort storage prefix cleanup for both S3 and local storage, including object deletion and multipart upload aborts.
  * Introduced “deleting” storage namespace lifecycle and persisted delete-job orchestration with retry/recovery.
  * Extended teardown support to include credential-aware deprovisioning.
* **Bug Fixes**
  * Improved request routing/metrics and clearer authorization errors for scoped token actions.
* **Documentation**
  * Updated API docs for tenant deletion credential/provider behavior and clarified spending-limit defaults.
* **Tests**
  * Added integration coverage for deletion authorization, eligibility checks, retries, idempotency, and async cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->