### PR TITLE
fix(fuse): preserve pending-new path truncates

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1396,12 +1396,12 @@ func shouldAdoptSingleHandlePathTruncate(fh *FileHandle, callerPID uint32, match
 	return fh.OpenPID == callerPID
 }
 
-func (fs *Dat9FS) truncateWritableHandleLocked(fh *FileHandle, newSize int64) error {
+func (fs *Dat9FS) truncateWritableHandleLocked(fh *FileHandle, newSize int64) (func(), error) {
 	if fh == nil || fh.Dirty == nil {
-		return nil
+		return nil, nil
 	}
 	if err := fh.Dirty.Truncate(newSize); err != nil {
-		return err
+		return nil, err
 	}
 	if fh.WritePolicy != WritePolicyWriteSync && fs.shadowStore != nil && fs.pendingIndex != nil {
 		if fh.ShadowReady || fh.IsNew || newSize == 0 {
@@ -1418,9 +1418,24 @@ func (fs *Dat9FS) truncateWritableHandleLocked(fh *FileHandle, newSize int64) er
 	// subsequent writes starting at the new size are not
 	// misdetected as back-writes (appendCursor may be stale).
 	fh.Dirty.ResetSequentialState(newSize)
+	var abortStreamer func()
+	if newSize == 0 {
+		fh.Dirty.ResetStreamingState()
+		if fh.ShadowSpill {
+			wb := fh.Dirty
+			wb.OnPartFull = func(partIdx int, data []byte) {
+				wb.EvictPart(partIdx)
+			}
+		}
+		if fh.Streamer != nil {
+			streamer := fh.Streamer
+			fh.Streamer = nil
+			abortStreamer = streamer.Abort
+		}
+	}
 	fh.ZeroBase = newSize == 0
 	fh.DirtySeq = fs.markDirtySize(fh.Ino, fh.Dirty.Size())
-	return nil
+	return abortStreamer, nil
 }
 
 func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64, callerPID uint32) {
@@ -1442,9 +1457,12 @@ func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64
 	}
 
 	for _, fh := range matching {
+		var abortStreamer func()
 		fh.Lock()
 		if shouldAdoptSingleHandlePathTruncate(fh, callerPID, len(matching)) {
-			if err := fs.truncateWritableHandleLocked(fh, 0); err != nil {
+			var err error
+			abortStreamer, err = fs.truncateWritableHandleLocked(fh, 0)
+			if err != nil {
 				log.Printf("handle truncate sync failed for %s: %v", fh.Path, err)
 				fh.Unlock()
 				continue
@@ -1468,6 +1486,9 @@ func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64
 			}
 		}
 		fh.Unlock()
+		if abortStreamer != nil {
+			abortStreamer()
+		}
 	}
 }
 
@@ -1494,18 +1515,11 @@ func (fs *Dat9FS) adoptSingleCallerPathTruncate(remotePath string, callerPID uin
 		var abortStreamer func()
 		fh.Lock()
 		if shouldAdoptSingleHandlePathTruncate(fh, callerPID, len(matching)) {
-			if err := fs.truncateWritableHandleLocked(fh, 0); err != nil {
+			var err error
+			abortStreamer, err = fs.truncateWritableHandleLocked(fh, 0)
+			if err != nil {
 				log.Printf("handle truncate stage failed for %s: %v", fh.Path, err)
 			} else {
-				// Reset any in-progress stream uploader so that flushHandle
-				// does not finalize stale multipart state instead of
-				// committing the empty PendingNew file. Abort() performs
-				// network I/O, so capture and call it outside the lock.
-				if fh.Streamer != nil {
-					streamer := fh.Streamer
-					fh.Streamer = nil
-					abortStreamer = streamer.Abort
-				}
 				adopted = true
 			}
 		}
@@ -5549,12 +5563,18 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 				}
 			}
 			if ok && fh.Dirty != nil {
+				var abortStreamer func()
 				fh.Lock()
-				if err := fs.truncateWritableHandleLocked(fh, newSize); err != nil {
+				var err error
+				abortStreamer, err = fs.truncateWritableHandleLocked(fh, newSize)
+				if err != nil {
 					fh.Unlock()
 					return gofuse.Status(syscall.EFBIG)
 				}
 				fh.Unlock()
+				if abortStreamer != nil {
+					abortStreamer()
+				}
 			}
 		} else {
 			// truncate(path, size): no open file handle — must persist

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1471,9 +1471,9 @@ func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64
 	}
 }
 
-func (fs *Dat9FS) adoptSingleCallerPathTruncate(remotePath string, callerPID uint32) {
+func (fs *Dat9FS) adoptSingleCallerPathTruncate(remotePath string, callerPID uint32) bool {
 	if fs == nil || fs.openHandles == nil || remotePath == "" || callerPID == 0 {
-		return
+		return false
 	}
 
 	var matching []*FileHandle
@@ -1489,15 +1489,19 @@ func (fs *Dat9FS) adoptSingleCallerPathTruncate(remotePath string, callerPID uin
 		}
 	}
 
+	adopted := false
 	for _, fh := range matching {
 		fh.Lock()
 		if shouldAdoptSingleHandlePathTruncate(fh, callerPID, len(matching)) {
 			if err := fs.truncateWritableHandleLocked(fh, 0); err != nil {
 				log.Printf("handle truncate stage failed for %s: %v", fh.Path, err)
+			} else {
+				adopted = true
 			}
 		}
 		fh.Unlock()
 	}
+	return adopted
 }
 
 func (fs *Dat9FS) refreshCommittedRevisionForOpenHandles(path string, revision int64, skip *FileHandle) {
@@ -2318,6 +2322,9 @@ func (fs *Dat9FS) finalizeHandleFlushLocked(fh *FileHandle, expectedRevision int
 
 func (fs *Dat9FS) canStagePathTruncateToZero(entry *InodeEntry) bool {
 	if fs == nil || entry == nil || entry.IsDir || entryIsSymlink(entry) {
+		return false
+	}
+	if entry.Revision <= 0 {
 		return false
 	}
 	if fs.layerEnabled() || isSQLitePersistentJournalPath(entry.Path) {
@@ -5570,12 +5577,18 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 					}
 					fs.invalidateReadCacheAndTargets(entry.Path)
 					fs.cacheFileForPath(entry.Path, 0, entry.Mtime, 0)
+				} else if entry.Revision <= 0 && fs.adoptSingleCallerPathTruncate(entry.Path, input.Pid) {
+					// A newly-created, uncommitted file has no remote base revision for
+					// an overwrite CAS. Let the open handle keep ownership and commit it
+					// later as PendingNew instead of queuing an invalid PendingOverwrite.
+					fs.invalidateReadCacheAndTargets(entry.Path)
+					fs.cacheFileForPath(entry.Path, 0, entry.Mtime, 0)
 				} else if fs.canStagePathTruncateToZero(entry) {
 					st := fs.stagePathTruncateToZeroLocked(ctx, entry, input.NodeId)
 					if st != gofuse.OK {
 						return st
 					}
-					fs.adoptSingleCallerPathTruncate(entry.Path, input.Pid)
+					_ = fs.adoptSingleCallerPathTruncate(entry.Path, input.Pid)
 				} else {
 					apiPath := fs.remotePath(entry.Path)
 					writeStart := fs.perfStart()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1491,15 +1491,28 @@ func (fs *Dat9FS) adoptSingleCallerPathTruncate(remotePath string, callerPID uin
 
 	adopted := false
 	for _, fh := range matching {
+		var abortStreamer func()
 		fh.Lock()
 		if shouldAdoptSingleHandlePathTruncate(fh, callerPID, len(matching)) {
 			if err := fs.truncateWritableHandleLocked(fh, 0); err != nil {
 				log.Printf("handle truncate stage failed for %s: %v", fh.Path, err)
 			} else {
+				// Reset any in-progress stream uploader so that flushHandle
+				// does not finalize stale multipart state instead of
+				// committing the empty PendingNew file. Abort() performs
+				// network I/O, so capture and call it outside the lock.
+				if fh.Streamer != nil {
+					streamer := fh.Streamer
+					fh.Streamer = nil
+					abortStreamer = streamer.Abort
+				}
 				adopted = true
 			}
 		}
 		fh.Unlock()
+		if abortStreamer != nil {
+			abortStreamer()
+		}
 	}
 	return adopted
 }

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -392,12 +392,16 @@ func TestFlushHandlePatchAfterLazyTruncatePreservesRemotePrefix(t *testing.T) {
 	fh.Unlock()
 
 	fh.Lock()
-	if err := fs.truncateWritableHandleLocked(fh, newSize); err != nil {
+	abortStreamer, err := fs.truncateWritableHandleLocked(fh, newSize)
+	if err != nil {
 		fh.Unlock()
 		t.Fatalf("truncateWritableHandleLocked: %v", err)
 	}
 	st := fs.flushHandle(context.Background(), fh)
 	fh.Unlock()
+	if abortStreamer != nil {
+		abortStreamer()
+	}
 	if st != gofuse.OK {
 		t.Fatalf("flushHandle status = %v, want OK", st)
 	}
@@ -11298,6 +11302,207 @@ func TestFlushHandle_RefreshesStartedStreamerRevision(t *testing.T) {
 	}
 }
 
+func TestTruncateWritableHandleLockedZeroResetsStreamingStateBeforeContinuedWrite(t *testing.T) {
+	const filePath = "/stream-reset.bin"
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+
+	wb := NewWriteBuffer(filePath, streamingWriteMaxSize, 0)
+	wb.uploadedParts = map[int]bool{0: true}
+	var staleCallbackCalls atomic.Int32
+	wb.OnPartFull = func(partIdx int, data []byte) {
+		staleCallbackCalls.Add(1)
+	}
+	streamer := NewStreamUploader(nil, filePath, 0)
+	streamer.started = true
+	streamer.streamedParts[1] = true
+	streamer.pendingParts[1] = []byte("stale")
+
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     filePath,
+		Dirty:    wb,
+		Streamer: streamer,
+	}
+
+	fh.Lock()
+	abortStreamer, err := fs.truncateWritableHandleLocked(fh, 0)
+	fh.Unlock()
+	if err != nil {
+		t.Fatalf("truncateWritableHandleLocked: %v", err)
+	}
+	if abortStreamer == nil {
+		t.Fatal("abortStreamer is nil, want old streamer cleanup")
+	}
+	abortStreamer()
+
+	if fh.Streamer != nil {
+		t.Fatal("fh.Streamer should be cleared after zero truncate")
+	}
+	if wb.OnPartFull != nil {
+		t.Fatal("OnPartFull should be cleared after non-shadow zero truncate")
+	}
+	if len(wb.uploadedParts) != 0 {
+		t.Fatalf("uploadedParts len = %d, want 0", len(wb.uploadedParts))
+	}
+	if len(streamer.pendingParts) != 0 {
+		t.Fatalf("old streamer pendingParts len = %d, want 0 after abort", len(streamer.pendingParts))
+	}
+
+	fullPart := bytes.Repeat([]byte("n"), int(wb.PartSize()))
+	if _, err := wb.Write(0, fullPart); err != nil {
+		t.Fatalf("continued write after truncate: %v", err)
+	}
+	if got := staleCallbackCalls.Load(); got != 0 {
+		t.Fatalf("stale OnPartFull calls = %d, want 0", got)
+	}
+	if len(wb.uploadedParts) != 0 {
+		t.Fatalf("uploadedParts len after continued write = %d, want 0", len(wb.uploadedParts))
+	}
+	if !wb.IsPartLoaded(0) {
+		t.Fatal("continued write should retain part in memory when streaming is disabled")
+	}
+}
+
+func TestTruncateWritableHandleLockedZeroRebindsShadowSpillEviction(t *testing.T) {
+	const filePath = "/shadow-reset.bin"
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+
+	wb := NewWriteBuffer(filePath, streamingWriteMaxSize, 0)
+	wb.uploadedParts = map[int]bool{1: true}
+	var staleCallbackCalls atomic.Int32
+	wb.OnPartFull = func(partIdx int, data []byte) {
+		staleCallbackCalls.Add(1)
+	}
+	streamer := NewStreamUploader(nil, filePath, 0)
+	streamer.started = true
+	streamer.streamedParts[1] = true
+	streamer.pendingParts[1] = []byte("stale")
+
+	fh := &FileHandle{
+		Ino:         ino,
+		Path:        filePath,
+		Dirty:       wb,
+		Streamer:    streamer,
+		ShadowReady: true,
+		ShadowSpill: true,
+	}
+
+	fh.Lock()
+	abortStreamer, err := fs.truncateWritableHandleLocked(fh, 0)
+	fh.Unlock()
+	if err != nil {
+		t.Fatalf("truncateWritableHandleLocked: %v", err)
+	}
+	if abortStreamer == nil {
+		t.Fatal("abortStreamer is nil, want old streamer cleanup")
+	}
+	abortStreamer()
+
+	if fh.Streamer != nil {
+		t.Fatal("fh.Streamer should be cleared after zero truncate")
+	}
+	if wb.OnPartFull == nil {
+		t.Fatal("OnPartFull should be rebound for ShadowSpill eviction")
+	}
+	if len(wb.uploadedParts) != 0 {
+		t.Fatalf("uploadedParts len = %d, want 0", len(wb.uploadedParts))
+	}
+
+	fullPart := bytes.Repeat([]byte("s"), int(wb.PartSize()))
+	if _, err := wb.Write(0, fullPart); err != nil {
+		t.Fatalf("continued shadow write after truncate: %v", err)
+	}
+	if got := staleCallbackCalls.Load(); got != 0 {
+		t.Fatalf("stale OnPartFull calls = %d, want 0", got)
+	}
+	if !wb.uploadedParts[0] {
+		t.Fatal("ShadowSpill OnPartFull should evict and mark new part 0")
+	}
+	if wb.IsPartLoaded(0) {
+		t.Fatal("ShadowSpill continued write should evict full part from memory")
+	}
+}
+
+func TestAdoptPathTruncateZeroResetsStartedStreamerBeforeFlush(t *testing.T) {
+	const (
+		filePath  = "/created-stream.bin"
+		callerPID = 4242
+	)
+	var (
+		createCalls atomic.Int32
+		otherCalls  atomic.Int32
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/fs"+filePath && r.URL.Query().Get("create") == "1" {
+			createCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(1)})
+			return
+		}
+		otherCalls.Add(1)
+		http.Error(w, "unexpected request", http.StatusTeapot)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+
+	wb := NewWriteBuffer(filePath, streamingWriteMaxSize, 0)
+	if _, err := wb.Write(0, []byte("stale streamed bytes")); err != nil {
+		t.Fatal(err)
+	}
+	wb.uploadedParts = map[int]bool{0: true}
+	streamer := NewStreamUploader(fs.client, filePath, 0)
+	streamer.started = true
+	streamer.streamedParts[1] = true
+	streamer.pendingParts[1] = []byte("stale")
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    filePath,
+		Dirty:   wb,
+		OpenPID: callerPID,
+		IsNew:   true,
+		BaseRev: 0,
+		// Started streamer state must not survive path truncate adoption;
+		// otherwise flushHandle chooses FinishStreaming instead of empty create.
+		Streamer: streamer,
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, wb.Size())
+	fs.openHandles.Add(fh)
+	defer fs.openHandles.Remove(fh)
+
+	if !fs.adoptSingleCallerPathTruncate(filePath, callerPID) {
+		t.Fatal("path truncate was not adopted by same-caller handle")
+	}
+	if fh.Streamer != nil {
+		t.Fatal("fh.Streamer should be cleared after adopted path truncate")
+	}
+	if len(wb.uploadedParts) != 0 {
+		t.Fatalf("uploadedParts len = %d, want 0", len(wb.uploadedParts))
+	}
+
+	fh.Lock()
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+	if st != gofuse.OK {
+		t.Fatalf("flushHandle status = %v, want OK", st)
+	}
+	if got := createCalls.Load(); got != 1 {
+		t.Fatalf("empty create calls = %d, want 1", got)
+	}
+	if got := otherCalls.Load(); got != 0 {
+		t.Fatalf("unexpected non-create calls = %d, want 0", got)
+	}
+}
+
 func TestFlushHandle_SerializesSamePathRemoteCommits(t *testing.T) {
 	var (
 		mu         sync.Mutex
@@ -11804,14 +12009,14 @@ func TestSetAttr_PathTruncateRefreshesOpenHandleBaseRevision(t *testing.T) {
 	if fh.BaseRev != 2 {
 		t.Fatalf("open handle base revision after path truncate = %d, want 2", fh.BaseRev)
 	}
-	if fh.Streamer == nil {
-		t.Fatal("expected stream uploader on O_TRUNC handle")
+	if fh.Streamer != nil {
+		t.Fatal("stream uploader should be reset after adopted zero truncate")
 	}
-	fh.Streamer.mu.Lock()
-	streamerRevision := fh.Streamer.expectedRevision
-	fh.Streamer.mu.Unlock()
-	if streamerRevision != 2 {
-		t.Fatalf("streamer expected revision after path truncate = %d, want 2", streamerRevision)
+	if fh.Dirty.OnPartFull != nil {
+		t.Fatal("streaming callback should be reset after adopted zero truncate")
+	}
+	if len(fh.Dirty.uploadedParts) != 0 {
+		t.Fatalf("uploadedParts len after path truncate = %d, want 0", len(fh.Dirty.uploadedParts))
 	}
 
 	if _, st = fs.Write(nil, &gofuse.WriteIn{

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -10367,9 +10367,27 @@ func TestSetAttr_WriteBackPathTruncateAdoptsSingleCallerWriter(t *testing.T) {
 
 func TestSetAttr_WriteBackPathTruncateAdoptsCreatedSameCallerWriter(t *testing.T) {
 	const callerPID = 6161
+	var createCalls atomic.Int32
+	var putCalls atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs/created.bin" && r.URL.RawQuery == "create=1":
+			createCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+		case r.Method == http.MethodPut:
+			putCalls.Add(1)
+			http.Error(w, "unexpected PUT", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
 	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
 	opts.setDefaults()
-	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	shadow, err := NewShadowStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -10393,6 +10411,7 @@ func TestSetAttr_WriteBackPathTruncateAdoptsCreatedSameCallerWriter(t *testing.T
 	st := fs.Create(nil, &gofuse.CreateIn{
 		InHeader: gofuse.InHeader{NodeId: 1, Caller: gofuse.Caller{Pid: callerPID}},
 		Flags:    uint32(syscall.O_WRONLY | syscall.O_CREAT),
+		Mode:     defaultRegularFileMode,
 	}, "created.bin", &createOut)
 	if st != gofuse.OK {
 		t.Fatalf("Create status = %v, want OK", st)
@@ -10434,6 +10453,20 @@ func TestSetAttr_WriteBackPathTruncateAdoptsCreatedSameCallerWriter(t *testing.T
 	if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {
 		t.Fatalf("dirty truncate not marked: dirtySeq=%d dirty=%t", fh.DirtySeq, fh.Dirty.HasDirtyParts())
 	}
+	if fs.commitQueue.HasPath("/created.bin") {
+		t.Fatal("created truncate queued invalid path overwrite commit")
+	}
+	if meta, ok := pending.GetMeta("/created.bin"); ok {
+		t.Fatalf("pending meta after created truncate = %+v, want no path-level overwrite", meta)
+	}
+
+	fh.Lock()
+	kind := fs.pendingKindForHandle(fh)
+	baseRev := fs.expectedRevisionForHandleLocked(fh)
+	fh.Unlock()
+	if kind != PendingNew || baseRev != 0 {
+		t.Fatalf("created truncate handle commit state = kind %v baseRev %d, want PendingNew baseRev 0", kind, baseRev)
+	}
 
 	gotShadow, err := shadow.ReadAll("/created.bin")
 	if err != nil {
@@ -10441,6 +10474,20 @@ func TestSetAttr_WriteBackPathTruncateAdoptsCreatedSameCallerWriter(t *testing.T
 	}
 	if len(gotShadow) != 0 {
 		t.Fatalf("shadow content after staged truncate len=%d, want 0", len(gotShadow))
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: createOut.Fh})
+	if got := createCalls.Load(); got != 1 {
+		t.Fatalf("remote empty create calls = %d, want 1", got)
+	}
+	if got := putCalls.Load(); got != 0 {
+		t.Fatalf("remote PUT calls = %d, want 0", got)
+	}
+	if pending.HasPending("/created.bin") {
+		t.Fatal("pending state remains after release")
+	}
+	if shadow.Has("/created.bin") {
+		t.Fatal("shadow remains after release")
 	}
 }
 

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -4218,12 +4218,18 @@ func (fs *Dat9FS) setGitAttr(ctx context.Context, input *gofuse.SetAttrIn, entry
 		}
 		if input.Valid&gofuse.FATTR_FH != 0 {
 			if fh, ok := fs.fileHandles.Get(input.Fh); ok && fh.Layer == PathLayerGitWorkspace && fh.Dirty != nil {
+				var abortStreamer func()
 				fh.Lock()
-				if err := fs.truncateWritableHandleLocked(fh, newSize); err != nil {
+				var err error
+				abortStreamer, err = fs.truncateWritableHandleLocked(fh, newSize)
+				if err != nil {
 					fh.Unlock()
 					return gofuse.Status(syscall.EFBIG)
 				}
 				fh.Unlock()
+				if abortStreamer != nil {
+					abortStreamer()
+				}
 			}
 		} else if newSize != entry.Size {
 			readSize := entry.Size

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -886,6 +886,13 @@ func (wb *WriteBuffer) ResetSequentialState(newSize int64) {
 	wb.sequential = true
 }
 
+// ResetStreamingState clears streaming-upload bookkeeping after a truncate
+// invalidates all previously streamed parts.
+func (wb *WriteBuffer) ResetStreamingState() {
+	wb.uploadedParts = make(map[int]bool)
+	wb.OnPartFull = nil
+}
+
 // EvictPart releases the memory for a 0-based part index after it has been
 // uploaded via streaming. The part is recorded in uploadedParts so that
 // subsequent reads/writes know it was already handled.


### PR DESCRIPTION
## Summary

Follow-up to #561 after the branch was merged at `f6272e6`.

Fixes the `Create -> Write -> truncate(path, 0)` corner case identified in review:

- Do not stage path-level zero truncates as `PendingOverwrite` when the inode has `Revision <= 0`.
- If the file is a newly-created, uncommitted file with a single same-caller dirty handle, adopt the truncate into that handle and let release/flush commit it as `PendingNew(BaseRev=0)`.
- Keep path-level async zero-truncate staging only for existing files with a real remote base revision.

## Tests

- `/usr/local/go/bin/go test ./pkg/fuse -count=1 -run 'TestSetAttr_WriteBackPathTruncate(AdoptsCreatedSameCallerWriter|AdoptsSingleCallerWriter|StagesAndReturnsBeforeRemoteCommit|SkipsDefaultInheritedMode|PreservesNonDefaultMode)'`
- `/usr/local/go/bin/go test ./pkg/fuse -count=1`
- `/usr/local/go/bin/go test ./cmd/drive9 ./cmd/drive9/cli ./pkg/fuse -count=1`
- `bash -n e2e/fuse-smoke-test.sh`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined truncate-to-zero for newly created/uncommitted files so local truncation doesn’t trigger invalid overwrite behavior.
  * Improved single-caller adoption to correctly transition dirty handle state and clear related streaming/upload bookkeeping.
  * Prevented truncate-to-zero staging when no valid remote revision is available.
  * Ensured truncation aborts/cleanup of any in-progress streaming uploader where applicable (including Git workspace).
* **Tests**
  * Expanded and strengthened truncate-to-zero and adoption test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->