### PR TITLE
fix(fuse): coalesce queued zero truncates

### DIFF
--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -54,6 +54,7 @@ type CommitEntry struct {
 	Mode                 uint32
 	HasMode              bool
 	CoalesceZeroTruncate bool
+	dispatched           bool
 	canceled             bool
 	cancelCommit         context.CancelFunc
 	cancelUpload         context.CancelFunc
@@ -207,6 +208,7 @@ func (cq *CommitQueue) Enqueue(entry *CommitEntry) error {
 		cq.delayZeroTruncateLocked(entry)
 		return nil
 	}
+	entry.dispatched = true
 
 	// Send to workers while holding the lock. The channel buffer is always
 	// > maxPending, so this will not block as long as the backpressure
@@ -221,6 +223,13 @@ func (cq *CommitQueue) shouldDelayZeroTruncateLocked(entry *CommitEntry) bool {
 		return false
 	}
 	return cq.zeroTruncateDelay > 0
+}
+
+func (cq *CommitQueue) isDelayedLocked(entry *CommitEntry) bool {
+	if cq == nil || entry == nil || cq.delayed == nil {
+		return false
+	}
+	return cq.delayed[entry] != nil
 }
 
 func (cq *CommitQueue) delayZeroTruncateLocked(entry *CommitEntry) {
@@ -246,6 +255,7 @@ func (cq *CommitQueue) dispatchDelayed(entry *CommitEntry) {
 	if cq.stopped || entry.canceled {
 		return
 	}
+	entry.dispatched = true
 	cq.workCh <- entry
 }
 
@@ -270,6 +280,7 @@ func (cq *CommitQueue) forceDelayedPathLocked(path string) {
 		timer.Stop()
 		delete(cq.delayed, entry)
 		if !cq.stopped && !entry.canceled {
+			entry.dispatched = true
 			cq.workCh <- entry
 		}
 	}
@@ -286,6 +297,7 @@ func (cq *CommitQueue) forceDelayedPrefixLocked(prefix string) {
 		timer.Stop()
 		delete(cq.delayed, entry)
 		if !cq.stopped && !entry.canceled {
+			entry.dispatched = true
 			cq.workCh <- entry
 		}
 	}
@@ -299,6 +311,7 @@ func (cq *CommitQueue) forceAllDelayedLocked() {
 		timer.Stop()
 		delete(cq.delayed, entry)
 		if !cq.stopped && entry != nil && !entry.canceled {
+			entry.dispatched = true
 			cq.workCh <- entry
 		}
 	}
@@ -521,7 +534,7 @@ func (cq *CommitQueue) CancelQueuedZeroTruncatePreserveLocal(path string) bool {
 			remaining = append(remaining, entry)
 			continue
 		}
-		if isQueuedZeroTruncateEntry(entry) {
+		if isQueuedZeroTruncateEntry(entry) && cq.isDelayedLocked(entry) && !entry.dispatched {
 			entry.canceled = true
 			cq.stopDelayedLocked(entry)
 			continue

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -17,7 +17,10 @@ import (
 
 var errCommitPostUpload = errors.New("commit post-upload step failed")
 
-const maxInlineLayerEntryBytes = 96 << 20
+const (
+	maxInlineLayerEntryBytes     = 96 << 20
+	zeroTruncateCommitQueueDelay = 50 * time.Millisecond
+)
 
 // directPutThreshold returns the size limit below which commit queue workers
 // use direct PUT (WriteCtxConditionalWithRevision) instead of multipart
@@ -42,17 +45,18 @@ func (cq *CommitQueue) directPutThreshold() int64 {
 
 // CommitEntry represents a pending remote commit.
 type CommitEntry struct {
-	Path         string
-	Inode        uint64
-	BaseRev      int64 // revision when we started editing
-	Size         int64
-	Kind         PendingKind
-	ShadowSpill  bool // true when data is only in shadow file (auto-resolve would OOM)
-	Mode         uint32
-	HasMode      bool
-	canceled     bool
-	cancelCommit context.CancelFunc
-	cancelUpload context.CancelFunc
+	Path                 string
+	Inode                uint64
+	BaseRev              int64 // revision when we started editing
+	Size                 int64
+	Kind                 PendingKind
+	ShadowSpill          bool // true when data is only in shadow file (auto-resolve would OOM)
+	Mode                 uint32
+	HasMode              bool
+	CoalesceZeroTruncate bool
+	canceled             bool
+	cancelCommit         context.CancelFunc
+	cancelUpload         context.CancelFunc
 }
 
 // CommitSuccessFunc is called after a commit queue entry is successfully
@@ -71,6 +75,7 @@ type CommitQueue struct {
 	queue        []*CommitEntry
 	queuedByPath map[string]map[*CommitEntry]struct{}
 	inFlight     map[string]*CommitEntry // paths currently being processed by workers
+	delayed      map[*CommitEntry]*time.Timer
 	maxPending   int
 	client       *client.Client
 	remoteRoot   string
@@ -96,6 +101,8 @@ type CommitQueue struct {
 	// larger than maxPending so Enqueue never blocks.
 	workCh chan *CommitEntry
 
+	zeroTruncateDelay time.Duration
+
 	perf *fusePerfCounters
 }
 
@@ -117,15 +124,17 @@ func NewCommitQueue(c *client.Client, shadows *ShadowStore, index *PendingIndex,
 		bufSize = 256
 	}
 	cq := &CommitQueue{
-		maxPending:   maxPending,
-		client:       c,
-		remoteRoot:   root,
-		shadows:      shadows,
-		index:        index,
-		journal:      journal,
-		inFlight:     make(map[string]*CommitEntry),
-		queuedByPath: make(map[string]map[*CommitEntry]struct{}),
-		workCh:       make(chan *CommitEntry, bufSize),
+		maxPending:        maxPending,
+		client:            c,
+		remoteRoot:        root,
+		shadows:           shadows,
+		index:             index,
+		journal:           journal,
+		inFlight:          make(map[string]*CommitEntry),
+		queuedByPath:      make(map[string]map[*CommitEntry]struct{}),
+		delayed:           make(map[*CommitEntry]*time.Timer),
+		workCh:            make(chan *CommitEntry, bufSize),
+		zeroTruncateDelay: zeroTruncateCommitQueueDelay,
 	}
 	for i := 0; i < numWorkers; i++ {
 		cq.wg.Add(1)
@@ -194,12 +203,105 @@ func (cq *CommitQueue) Enqueue(entry *CommitEntry) error {
 		cq.perf.commitEnqueue.add(1)
 	}
 
+	if cq.shouldDelayZeroTruncateLocked(entry) {
+		cq.delayZeroTruncateLocked(entry)
+		return nil
+	}
+
 	// Send to workers while holding the lock. The channel buffer is always
 	// > maxPending, so this will not block as long as the backpressure
 	// check above holds. Holding the lock prevents DrainAll from closing
 	// workCh between our check and the send.
 	cq.workCh <- entry
 	return nil
+}
+
+func (cq *CommitQueue) shouldDelayZeroTruncateLocked(entry *CommitEntry) bool {
+	if cq == nil || entry == nil || entry.canceled || !entry.CoalesceZeroTruncate || !isQueuedZeroTruncateEntry(entry) {
+		return false
+	}
+	return cq.zeroTruncateDelay > 0
+}
+
+func (cq *CommitQueue) delayZeroTruncateLocked(entry *CommitEntry) {
+	if cq.delayed == nil {
+		cq.delayed = make(map[*CommitEntry]*time.Timer)
+	}
+	delay := cq.zeroTruncateDelay
+	cq.delayed[entry] = time.AfterFunc(delay, func() {
+		cq.dispatchDelayed(entry)
+	})
+}
+
+func (cq *CommitQueue) dispatchDelayed(entry *CommitEntry) {
+	if cq == nil || entry == nil {
+		return
+	}
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	if cq.delayed == nil || cq.delayed[entry] == nil {
+		return
+	}
+	delete(cq.delayed, entry)
+	if cq.stopped || entry.canceled {
+		return
+	}
+	cq.workCh <- entry
+}
+
+func (cq *CommitQueue) stopDelayedLocked(entry *CommitEntry) {
+	if cq == nil || entry == nil || cq.delayed == nil {
+		return
+	}
+	if timer := cq.delayed[entry]; timer != nil {
+		timer.Stop()
+		delete(cq.delayed, entry)
+	}
+}
+
+func (cq *CommitQueue) forceDelayedPathLocked(path string) {
+	if cq == nil || path == "" || len(cq.delayed) == 0 {
+		return
+	}
+	for entry, timer := range cq.delayed {
+		if entry == nil || entry.Path != path {
+			continue
+		}
+		timer.Stop()
+		delete(cq.delayed, entry)
+		if !cq.stopped && !entry.canceled {
+			cq.workCh <- entry
+		}
+	}
+}
+
+func (cq *CommitQueue) forceDelayedPrefixLocked(prefix string) {
+	if cq == nil || prefix == "" || len(cq.delayed) == 0 {
+		return
+	}
+	for entry, timer := range cq.delayed {
+		if entry == nil || !strings.HasPrefix(entry.Path, prefix) {
+			continue
+		}
+		timer.Stop()
+		delete(cq.delayed, entry)
+		if !cq.stopped && !entry.canceled {
+			cq.workCh <- entry
+		}
+	}
+}
+
+func (cq *CommitQueue) forceAllDelayedLocked() {
+	if cq == nil || len(cq.delayed) == 0 {
+		return
+	}
+	for entry, timer := range cq.delayed {
+		timer.Stop()
+		delete(cq.delayed, entry)
+		if !cq.stopped && entry != nil && !entry.canceled {
+			cq.workCh <- entry
+		}
+	}
 }
 
 // Pending returns the number of pending commits.
@@ -267,6 +369,7 @@ func (cq *CommitQueue) DrainAll() {
 		cq.wg.Wait()
 		return
 	}
+	cq.forceAllDelayedLocked()
 	cq.stopped = true
 	// Close workCh under the lock so no concurrent Enqueue can send after close.
 	close(cq.workCh)
@@ -330,6 +433,7 @@ func (cq *CommitQueue) RecoverPending() {
 func (cq *CommitQueue) WaitPath(path string) {
 	for {
 		cq.mu.Lock()
+		cq.forceDelayedPathLocked(path)
 		_, inflight := cq.inFlight[path]
 		queued := cq.hasQueuedPathLocked(path)
 		cq.mu.Unlock()
@@ -358,6 +462,7 @@ func (cq *CommitQueue) HasPath(path string) bool {
 func (cq *CommitQueue) WaitPrefix(prefix string) {
 	for {
 		cq.mu.Lock()
+		cq.forceDelayedPrefixLocked(prefix)
 		found := false
 		for p := range cq.inFlight {
 			if strings.HasPrefix(p, prefix) {
@@ -418,6 +523,7 @@ func (cq *CommitQueue) CancelQueuedZeroTruncatePreserveLocal(path string) bool {
 		}
 		if isQueuedZeroTruncateEntry(entry) {
 			entry.canceled = true
+			cq.stopDelayedLocked(entry)
 			continue
 		}
 		otherQueued = true
@@ -438,6 +544,7 @@ func (cq *CommitQueue) cancelPath(path string, preserveLocal bool) {
 			return
 		}
 		e.canceled = true
+		cq.stopDelayedLocked(e)
 		if _, ok := seen[e]; ok {
 			return
 		}
@@ -526,6 +633,7 @@ func (cq *CommitQueue) CancelPrefix(prefix string) {
 			return
 		}
 		e.canceled = true
+		cq.stopDelayedLocked(e)
 		if _, ok := seen[e]; ok {
 			return
 		}
@@ -959,6 +1067,7 @@ func (cq *CommitQueue) uploadLayerEntry(ctx context.Context, layerRef string, en
 func (cq *CommitQueue) removeFromQueue(entry *CommitEntry) {
 	cq.mu.Lock()
 	defer cq.mu.Unlock()
+	cq.stopDelayedLocked(entry)
 	for i, e := range cq.queue {
 		if e == entry {
 			cq.queue = append(cq.queue[:i], cq.queue[i+1:]...)

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -2425,6 +2425,35 @@ func TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight(t 
 	}
 }
 
+func TestCommitQueueCancelQueuedZeroTruncateDoesNotCancelDispatchedBeforeInFlight(t *testing.T) {
+	entry := &CommitEntry{
+		Path:                 "/dispatched.txt",
+		Size:                 0,
+		Kind:                 PendingOverwrite,
+		CoalesceZeroTruncate: true,
+		dispatched:           true,
+	}
+	cq := &CommitQueue{
+		queue:        []*CommitEntry{entry},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{},
+	}
+	cq.rebuildQueuedIndexLocked()
+
+	if cq.CancelQueuedZeroTruncatePreserveLocal("/dispatched.txt") {
+		t.Fatal("cancel returned true for dispatched zero truncate")
+	}
+	if entry.canceled {
+		t.Fatal("dispatched zero truncate was canceled before in-flight")
+	}
+	if !cq.HasPath("/dispatched.txt") {
+		t.Fatal("dispatched zero truncate disappeared from queue")
+	}
+	if pending := cq.Pending(); pending != 1 {
+		t.Fatalf("pending after dispatched cancel attempt = %d, want 1", pending)
+	}
+}
+
 func markCommitEntryDelayedForTest(t *testing.T, cq *CommitQueue, entry *CommitEntry) {
 	t.Helper()
 	if cq.delayed == nil {

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -2475,6 +2475,81 @@ func TestCommitQueueDelayedZeroTruncateCancelNeverUploads(t *testing.T) {
 	}
 }
 
+func TestCommitQueueCancelDelayedZeroTruncateDoesNotLeaveBackpressureZombie(t *testing.T) {
+	var uploads atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	cq := NewCommitQueue(newTestClient(ts.URL), nil, nil, nil, 1, 2)
+	cq.zeroTruncateDelay = time.Hour
+	for i := 0; i < 10; i++ {
+		entry := &CommitEntry{
+			Path:                 "/loop.txt",
+			Size:                 0,
+			Kind:                 PendingOverwrite,
+			BaseRev:              7,
+			CoalesceZeroTruncate: true,
+		}
+		if err := cq.Enqueue(entry); err != nil {
+			t.Fatalf("enqueue iteration %d: %v", i, err)
+		}
+		if !cq.CancelQueuedZeroTruncatePreserveLocal("/loop.txt") {
+			t.Fatalf("cancel iteration %d returned false", i)
+		}
+		if pending := cq.Pending(); pending != 0 {
+			t.Fatalf("pending after cancel iteration %d = %d, want 0", i, pending)
+		}
+		if cq.HasPath("/loop.txt") {
+			t.Fatalf("path remains queued after cancel iteration %d", i)
+		}
+	}
+	cq.DrainAll()
+	if got := uploads.Load(); got != 0 {
+		t.Fatalf("uploads after repeated cancel = %d, want 0", got)
+	}
+}
+
+func TestCommitQueueCancelQueuedZeroTruncateCancelsAllDelayedSamePath(t *testing.T) {
+	var uploads atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	cq := NewCommitQueue(newTestClient(ts.URL), nil, nil, nil, 1, 8)
+	cq.zeroTruncateDelay = time.Hour
+	first := &CommitEntry{Path: "/same.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
+	second := &CommitEntry{Path: "/same.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
+	if err := cq.Enqueue(first); err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(second); err != nil {
+		t.Fatal(err)
+	}
+	if !cq.CancelQueuedZeroTruncatePreserveLocal("/same.txt") {
+		t.Fatal("cancel delayed same-path zero truncates returned false")
+	}
+	if !first.canceled || !second.canceled {
+		t.Fatalf("same-path delayed entries canceled = %t/%t, want true/true", first.canceled, second.canceled)
+	}
+	if pending := cq.Pending(); pending != 0 {
+		t.Fatalf("pending after same-path delayed cancel = %d, want 0", pending)
+	}
+	if cq.HasPath("/same.txt") {
+		t.Fatal("same-path delayed entries still visible after cancel")
+	}
+	cq.DrainAll()
+	if got := uploads.Load(); got != 0 {
+		t.Fatalf("uploads after same-path delayed cancel = %d, want 0", got)
+	}
+}
+
 func TestCommitQueueDelayedZeroTruncateTimerDispatches(t *testing.T) {
 	uploadDone := make(chan struct{}, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -2360,7 +2360,7 @@ func TestCommitQueueCancelPathJournalsCommitMarker(t *testing.T) {
 }
 
 func TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight(t *testing.T) {
-	zero := &CommitEntry{Path: "/file.txt", Size: 0, Kind: PendingOverwrite}
+	zero := &CommitEntry{Path: "/file.txt", Size: 0, Kind: PendingOverwrite, CoalesceZeroTruncate: true}
 	nonzero := &CommitEntry{Path: "/other.txt", Size: 4, Kind: PendingOverwrite}
 	cq := &CommitQueue{
 		queue:        []*CommitEntry{zero, nonzero},
@@ -2368,6 +2368,7 @@ func TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight(t 
 		inFlight:     map[string]*CommitEntry{},
 	}
 	cq.rebuildQueuedIndexLocked()
+	markCommitEntryDelayedForTest(t, cq, zero)
 
 	if !cq.CancelQueuedZeroTruncatePreserveLocal("/file.txt") {
 		t.Fatal("cancel queued zero truncate returned false")
@@ -2382,7 +2383,7 @@ func TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight(t 
 		t.Fatal("non-zero queued entry was affected")
 	}
 
-	zero = &CommitEntry{Path: "/same.txt", Size: 0, Kind: PendingOverwrite}
+	zero = &CommitEntry{Path: "/same.txt", Size: 0, Kind: PendingOverwrite, CoalesceZeroTruncate: true}
 	samePathNonzero := &CommitEntry{Path: "/same.txt", Size: 4, Kind: PendingOverwrite}
 	cq = &CommitQueue{
 		queue:        []*CommitEntry{zero, samePathNonzero},
@@ -2390,6 +2391,7 @@ func TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight(t 
 		inFlight:     map[string]*CommitEntry{},
 	}
 	cq.rebuildQueuedIndexLocked()
+	markCommitEntryDelayedForTest(t, cq, zero)
 
 	if cq.CancelQueuedZeroTruncatePreserveLocal("/same.txt") {
 		t.Fatal("cancel returned true while non-zero same-path entry remained queued")
@@ -2421,6 +2423,18 @@ func TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight(t 
 	if !cq.HasPath("/busy.txt") {
 		t.Fatal("in-flight path disappeared")
 	}
+}
+
+func markCommitEntryDelayedForTest(t *testing.T, cq *CommitQueue, entry *CommitEntry) {
+	t.Helper()
+	if cq.delayed == nil {
+		cq.delayed = make(map[*CommitEntry]*time.Timer)
+	}
+	timer := time.NewTimer(time.Hour)
+	cq.delayed[entry] = timer
+	t.Cleanup(func() {
+		timer.Stop()
+	})
 }
 
 func TestCommitQueueDelayedZeroTruncateCancelNeverUploads(t *testing.T) {
@@ -2646,6 +2660,80 @@ func TestCommitQueueWaitPathForcesDelayedZeroTruncate(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("WaitPath did not return after forced delayed zero truncate")
+	}
+}
+
+func TestCommitQueueForcedDelayedZeroTruncateCannotBeCanceledBeforeInFlight(t *testing.T) {
+	uploadDone := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case uploadDone <- struct{}{}:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull("/force-cancel.txt", nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/force-cancel.txt", 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.zeroTruncateDelay = time.Hour
+	lockAcquired := make(chan struct{})
+	releaseLock := make(chan struct{})
+	cq.PathLock = func(path string) func() {
+		if path == "/force-cancel.txt" {
+			close(lockAcquired)
+			<-releaseLock
+		}
+		return func() {}
+	}
+	defer cq.DrainAll()
+	entry := &CommitEntry{Path: "/force-cancel.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
+	if err := cq.Enqueue(entry); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		cq.WaitPath("/force-cancel.txt")
+		close(done)
+	}()
+	select {
+	case <-lockAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("forced delayed zero truncate did not reach worker path lock")
+	}
+	if cq.CancelQueuedZeroTruncatePreserveLocal("/force-cancel.txt") {
+		t.Fatal("force-dispatched zero truncate was canceled before in-flight")
+	}
+	if entry.canceled {
+		t.Fatal("force-dispatched zero truncate was marked canceled")
+	}
+	close(releaseLock)
+	select {
+	case <-uploadDone:
+	case <-time.After(time.Second):
+		t.Fatal("force-dispatched zero truncate was not uploaded")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("WaitPath did not return after forced zero truncate upload")
 	}
 }
 

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -2422,3 +2422,288 @@ func TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight(t 
 		t.Fatal("in-flight path disappeared")
 	}
 }
+
+func TestCommitQueueDelayedZeroTruncateCancelNeverUploads(t *testing.T) {
+	var uploads atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull("/file.txt", nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/file.txt", 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.zeroTruncateDelay = time.Hour
+	entry := &CommitEntry{Path: "/file.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
+	if err := cq.Enqueue(entry); err != nil {
+		t.Fatal(err)
+	}
+	if !cq.HasPath("/file.txt") {
+		t.Fatal("delayed zero truncate should remain visible as queued")
+	}
+	if !cq.CancelQueuedZeroTruncatePreserveLocal("/file.txt") {
+		t.Fatal("cancel delayed zero truncate returned false")
+	}
+	if !entry.canceled {
+		t.Fatal("delayed zero truncate was not marked canceled")
+	}
+	if cq.HasPath("/file.txt") {
+		t.Fatal("delayed zero truncate still blocks path after cancel")
+	}
+	cq.DrainAll()
+	if got := uploads.Load(); got != 0 {
+		t.Fatalf("uploads after cancel = %d, want 0", got)
+	}
+	if !shadow.Has("/file.txt") || !pending.HasPending("/file.txt") {
+		t.Fatal("cancel queued zero truncate should preserve local shadow/pending")
+	}
+}
+
+func TestCommitQueueDelayedZeroTruncateTimerDispatches(t *testing.T) {
+	uploadDone := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Dat9-Expected-Revision") != "7" {
+			t.Errorf("X-Dat9-Expected-Revision = %q, want 7", r.Header.Get("X-Dat9-Expected-Revision"))
+		}
+		select {
+		case uploadDone <- struct{}{}:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull("/standalone.txt", nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/standalone.txt", 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.zeroTruncateDelay = 20 * time.Millisecond
+	defer cq.DrainAll()
+	if err := cq.Enqueue(&CommitEntry{Path: "/standalone.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-uploadDone:
+	case <-time.After(time.Second):
+		t.Fatal("delayed zero truncate was not dispatched after delay")
+	}
+	cq.WaitPath("/standalone.txt")
+	if shadow.Has("/standalone.txt") || pending.HasPending("/standalone.txt") {
+		t.Fatal("successful delayed zero truncate should clean local shadow/pending")
+	}
+}
+
+func TestCommitQueueWaitPathForcesDelayedZeroTruncate(t *testing.T) {
+	uploadDone := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case uploadDone <- struct{}{}:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull("/force.txt", nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/force.txt", 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.zeroTruncateDelay = time.Hour
+	defer cq.DrainAll()
+	if err := cq.Enqueue(&CommitEntry{Path: "/force.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		cq.WaitPath("/force.txt")
+		close(done)
+	}()
+	select {
+	case <-uploadDone:
+	case <-time.After(150 * time.Millisecond):
+		t.Fatal("WaitPath did not force delayed zero truncate dispatch")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("WaitPath did not return after forced delayed zero truncate")
+	}
+}
+
+func TestCommitQueueWaitPrefixForcesDelayedZeroTruncate(t *testing.T) {
+	uploadDone := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case uploadDone <- struct{}{}:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull("/dir/file.txt", nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/dir/file.txt", 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.zeroTruncateDelay = time.Hour
+	defer cq.DrainAll()
+	if err := cq.Enqueue(&CommitEntry{Path: "/dir/file.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		cq.WaitPrefix("/dir/")
+		close(done)
+	}()
+	select {
+	case <-uploadDone:
+	case <-time.After(150 * time.Millisecond):
+		t.Fatal("WaitPrefix did not force delayed zero truncate dispatch")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("WaitPrefix did not return after forced delayed zero truncate")
+	}
+}
+
+func TestCommitQueueDrainAllForcesDelayedZeroTruncate(t *testing.T) {
+	var uploads atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull("/drain.txt", nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/drain.txt", 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.zeroTruncateDelay = time.Hour
+	if err := cq.Enqueue(&CommitEntry{Path: "/drain.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+	if got := uploads.Load(); got != 1 {
+		t.Fatalf("uploads after DrainAll = %d, want 1", got)
+	}
+	if shadow.Has("/drain.txt") || pending.HasPending("/drain.txt") {
+		t.Fatal("DrainAll forced delayed zero truncate should clean local shadow/pending")
+	}
+}
+
+func TestCommitQueueCancelPathStopsDelayedZeroTruncateAndCleansLocal(t *testing.T) {
+	var uploads atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull("/unlink.txt", nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/unlink.txt", 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.zeroTruncateDelay = time.Hour
+	entry := &CommitEntry{Path: "/unlink.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
+	if err := cq.Enqueue(entry); err != nil {
+		t.Fatal(err)
+	}
+	cq.CancelPath("/unlink.txt")
+	cq.DrainAll()
+	if !entry.canceled {
+		t.Fatal("CancelPath did not mark delayed zero truncate canceled")
+	}
+	if got := uploads.Load(); got != 0 {
+		t.Fatalf("uploads after CancelPath = %d, want 0", got)
+	}
+	if shadow.Has("/unlink.txt") || pending.HasPending("/unlink.txt") {
+		t.Fatal("CancelPath should clean local shadow/pending")
+	}
+}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2390,13 +2390,14 @@ func (fs *Dat9FS) stagePathTruncateToZeroLocked(ctx context.Context, entry *Inod
 	}
 
 	commit := &CommitEntry{
-		Path:    entry.Path,
-		Inode:   ino,
-		BaseRev: expectedRevision,
-		Size:    0,
-		Kind:    PendingOverwrite,
-		Mode:    mode,
-		HasMode: hasMode,
+		Path:                 entry.Path,
+		Inode:                ino,
+		BaseRev:              expectedRevision,
+		Size:                 0,
+		Kind:                 PendingOverwrite,
+		Mode:                 mode,
+		HasMode:              hasMode,
+		CoalesceZeroTruncate: true,
 	}
 	if err := fs.commitQueue.Enqueue(commit); err != nil {
 		log.Printf("path truncate async enqueue failed for %s: %v, falling back to sync commit", entry.Path, err)
@@ -5154,6 +5155,7 @@ func (fs *Dat9FS) lockHandleRemoteCommitPathLocked(fh *FileHandle) func() {
 	if fh.RemoteCommitUnlock != nil {
 		return func() {}
 	}
+	_ = fs.canSupersedeQueuedPathTruncate(fh.Path)
 	fh.RemoteCommitUnlock = fs.lockWritableRemoteCommitPath(fh.Path)
 	return func() {
 		fs.releaseHandleRemoteCommitPathLocked(fh)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -5155,7 +5155,9 @@ func (fs *Dat9FS) lockHandleRemoteCommitPathLocked(fh *FileHandle) func() {
 	if fh.RemoteCommitUnlock != nil {
 		return func() {}
 	}
-	_ = fs.canSupersedeQueuedPathTruncate(fh.Path)
+	if fh.ZeroBase && fh.Dirty != nil && fh.Dirty.Size() == 0 {
+		_ = fs.canSupersedeQueuedPathTruncate(fh.Path)
+	}
 	fh.RemoteCommitUnlock = fs.lockWritableRemoteCommitPath(fh.Path)
 	return func() {
 		fs.releaseHandleRemoteCommitPathLocked(fh)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -10960,6 +10960,8 @@ func TestWriteCancelsDelayedQueuedPathTruncateBeforeRemoteWait(t *testing.T) {
 		Ino:         ino,
 		Path:        path,
 		BaseRev:     7,
+		Dirty:       fs.newWriteBuffer(path, 0, 0),
+		ZeroBase:    true,
 		WritePolicy: WritePolicyWriteBack,
 	}
 	fhID := fs.allocateFileHandle(fh)
@@ -10985,6 +10987,96 @@ func TestWriteCancelsDelayedQueuedPathTruncateBeforeRemoteWait(t *testing.T) {
 	}
 	if !pending.HasPending(path) || !shadow.Has(path) {
 		t.Fatal("Write supersede should preserve local pending/shadow state")
+	}
+}
+
+func TestWriteDoesNotCancelDelayedPathTruncateForOldHandle(t *testing.T) {
+	var uploads atomic.Int32
+	allowUpload := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads.Add(1)
+		<-allowUpload
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.syncMode = SyncInteractive
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := "/file.bin"
+	if err := shadow.WriteFull(path, nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(path, 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.zeroTruncateDelay = time.Hour
+	fs.commitQueue = cq
+	defer cq.DrainAll()
+	queued := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
+	if err := cq.Enqueue(queued); err != nil {
+		t.Fatal(err)
+	}
+
+	ino := fs.inodes.Lookup(path, false, 8, time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+	fh := &FileHandle{
+		Ino:         ino,
+		Path:        path,
+		BaseRev:     7,
+		Dirty:       fs.newWriteBuffer(path, 8, 0),
+		WritePolicy: WritePolicyWriteBack,
+	}
+	if _, err := fh.Dirty.Write(0, []byte("old-tail")); err != nil {
+		t.Fatal(err)
+	}
+	fhID := fs.allocateFileHandle(fh)
+	writeDone := make(chan gofuse.Status, 1)
+	go func() {
+		_, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+			Offset:   0,
+		}, []byte("x"))
+		writeDone <- st
+	}()
+
+	select {
+	case st := <-writeDone:
+		t.Fatalf("Write returned after canceling zero truncate for old handle: %v", st)
+	case <-time.After(75 * time.Millisecond):
+	}
+	if queued.canceled {
+		t.Fatal("old handle write canceled delayed zero truncate")
+	}
+	if !cq.HasPath(path) {
+		t.Fatal("delayed zero truncate disappeared before force")
+	}
+	close(allowUpload)
+	select {
+	case st := <-writeDone:
+		if st != gofuse.OK {
+			t.Fatalf("Write status = %v, want OK", st)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Write did not return after delayed zero truncate was forced")
+	}
+	if got := uploads.Load(); got != 1 {
+		t.Fatalf("zero truncate uploads = %d, want 1", got)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -10792,6 +10792,7 @@ func TestOpenTruncateCancelsQueuedPathTruncateWithoutCancelingInFlight(t *testin
 		inFlight:     map[string]*CommitEntry{},
 	}
 	fs.commitQueue.rebuildQueuedIndexLocked()
+	markCommitEntryDelayedForTest(t, fs.commitQueue, queued)
 
 	ino := fs.inodes.Lookup(path, false, 42, time.Now())
 	fs.inodes.UpdateRevision(ino, 7)
@@ -10872,6 +10873,7 @@ func TestOpenWritableCancelsQueuedPathTruncateWithoutOTruncFlag(t *testing.T) {
 		inFlight:     map[string]*CommitEntry{},
 	}
 	fs.commitQueue.rebuildQueuedIndexLocked()
+	markCommitEntryDelayedForTest(t, fs.commitQueue, queued)
 
 	ino := fs.inodes.Lookup(path, false, 0, time.Now())
 	fs.inodes.UpdateRevision(ino, 7)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -10785,7 +10785,7 @@ func TestOpenTruncateCancelsQueuedPathTruncateWithoutCancelingInFlight(t *testin
 	}
 	fs.shadowStore = shadow
 	fs.pendingIndex = pending
-	queued := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7}
+	queued := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
 	fs.commitQueue = &CommitQueue{
 		queue:        []*CommitEntry{queued},
 		queuedByPath: map[string]map[*CommitEntry]struct{}{},
@@ -10827,7 +10827,7 @@ func TestOpenTruncateCancelsQueuedPathTruncateWithoutCancelingInFlight(t *testin
 		t.Fatalf("handle did not adopt zero-base dirty buffer: zero=%t dirty=%v", fh.ZeroBase, fh.Dirty)
 	}
 
-	inFlight := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7}
+	inFlight := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
 	fs.commitQueue = &CommitQueue{
 		queue:        []*CommitEntry{inFlight},
 		queuedByPath: map[string]map[*CommitEntry]struct{}{},
@@ -10865,7 +10865,7 @@ func TestOpenWritableCancelsQueuedPathTruncateWithoutOTruncFlag(t *testing.T) {
 	}
 	fs.shadowStore = shadow
 	fs.pendingIndex = pending
-	queued := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7}
+	queued := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
 	fs.commitQueue = &CommitQueue{
 		queue:        []*CommitEntry{queued},
 		queuedByPath: map[string]map[*CommitEntry]struct{}{},
@@ -10911,6 +10911,150 @@ func TestOpenWritableCancelsQueuedPathTruncateWithoutOTruncFlag(t *testing.T) {
 	}
 }
 
+func TestWriteCancelsDelayedQueuedPathTruncateBeforeRemoteWait(t *testing.T) {
+	var uploads atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploads.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":8}`))
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.syncMode = SyncInteractive
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := "/file.bin"
+	if err := shadow.WriteFull(path, nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(path, 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.zeroTruncateDelay = time.Hour
+	fs.commitQueue = cq
+	defer cq.DrainAll()
+	queued := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
+	if err := cq.Enqueue(queued); err != nil {
+		t.Fatal(err)
+	}
+	if !cq.HasPath(path) {
+		t.Fatal("delayed zero truncate should be visible before Write")
+	}
+
+	ino := fs.inodes.Lookup(path, false, 0, time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+	fh := &FileHandle{
+		Ino:         ino,
+		Path:        path,
+		BaseRev:     7,
+		WritePolicy: WritePolicyWriteBack,
+	}
+	fhID := fs.allocateFileHandle(fh)
+	written, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       fhID,
+		Offset:   0,
+	}, []byte("new"))
+	if st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+	if written != 3 {
+		t.Fatalf("Write bytes = %d, want 3", written)
+	}
+	if !queued.canceled {
+		t.Fatal("Write did not cancel delayed zero truncate")
+	}
+	if cq.HasPath(path) {
+		t.Fatal("delayed zero truncate still blocks path after Write")
+	}
+	if got := uploads.Load(); got != 0 {
+		t.Fatalf("uploads before drain = %d, want 0", got)
+	}
+	if !pending.HasPending(path) || !shadow.Has(path) {
+		t.Fatal("Write supersede should preserve local pending/shadow state")
+	}
+}
+
+func TestWriteWaitsForInFlightPathTruncate(t *testing.T) {
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	fs.syncMode = SyncInteractive
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := "/file.bin"
+	if err := shadow.WriteFull(path, nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(path, 0, PendingOverwrite, 7); err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	inFlight := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
+	fs.commitQueue = &CommitQueue{
+		queuedByPath: map[string]map[*CommitEntry]struct{}{},
+		inFlight:     map[string]*CommitEntry{path: inFlight},
+	}
+
+	ino := fs.inodes.Lookup(path, false, 0, time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+	fh := &FileHandle{
+		Ino:         ino,
+		Path:        path,
+		BaseRev:     7,
+		WritePolicy: WritePolicyWriteBack,
+	}
+	fhID := fs.allocateFileHandle(fh)
+	writeDone := make(chan gofuse.Status, 1)
+	go func() {
+		_, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+			Offset:   0,
+		}, []byte("new"))
+		writeDone <- st
+	}()
+
+	select {
+	case st := <-writeDone:
+		t.Fatalf("Write returned while zero truncate was in-flight: %v", st)
+	case <-time.After(75 * time.Millisecond):
+	}
+	if inFlight.canceled {
+		t.Fatal("in-flight zero truncate was canceled")
+	}
+	fs.commitQueue.endInFlight(inFlight)
+	select {
+	case st := <-writeDone:
+		if st != gofuse.OK {
+			t.Fatalf("Write status = %v, want OK", st)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Write did not return after in-flight zero truncate completed")
+	}
+}
+
 func TestOpenWritableRefreshesInodeAfterWaitingForInFlightZeroTruncate(t *testing.T) {
 	path := "/tier-transition.bin"
 	staleData := bytes.Repeat([]byte("s"), 8*1024*1024)
@@ -10932,7 +11076,7 @@ func TestOpenWritableRefreshesInodeAfterWaitingForInFlightZeroTruncate(t *testin
 	opts.setDefaults()
 	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	fs.readCache.Put(path, staleData, 7)
-	inFlight := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7}
+	inFlight := &CommitEntry{Path: path, Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}
 	fs.commitQueue = &CommitQueue{
 		queue:        nil,
 		queuedByPath: map[string]map[*CommitEntry]struct{}{},


### PR DESCRIPTION
## Summary
- add a queued-only coalescing window for path-level zero-truncate commits
- keep delayed zero-truncate entries visible to `HasPath`/`WaitPath`, but prevent workers from picking them up until the window expires
- let write/open supersede queued zero-truncate entries; cancellation must happen before the write path proceeds
- force delayed entries due for `WaitPath`, `WaitPrefix`, and `DrainAll` so durability and namespace operations are not weakened

## Correctness boundaries
- does not skip same-path remote commit wait
- does not cancel in-flight commits
- cancellation and timer dispatch are serialized by the commit queue lock
- delayed entries are only enabled for explicitly flagged path-truncate zero commits (`CoalesceZeroTruncate`)
- cancel success means the zero-truncate entry is removed and cannot upload; cancel failure falls back to existing wait semantics

## Tests
- `/usr/local/go/bin/go test ./pkg/fuse -run 'TestCommitQueueDelayedZeroTruncate|TestCommitQueueWaitPathForcesDelayedZeroTruncate|TestCommitQueueWaitPrefixForcesDelayedZeroTruncate|TestCommitQueueDrainAllForcesDelayedZeroTruncate|TestCommitQueueCancelPathStopsDelayedZeroTruncateAndCleansLocal|TestCommitQueueCancelQueuedZeroTruncatePreservesLocalOnlyWhenNotInFlight|TestWriteCancelsDelayedQueuedPathTruncateBeforeRemoteWait|TestWriteWaitsForInFlightPathTruncate|TestOpenWritableCancelsQueuedPathTruncate' -count=1`
- `/usr/local/go/bin/go test ./pkg/fuse -count=1`
- `/usr/local/go/bin/go test ./cmd/drive9 ./cmd/drive9/cli ./pkg/fuse -count=1`
- `/usr/local/go/bin/go vet ./pkg/fuse ./cmd/drive9 ./cmd/drive9/cli`
- `/usr/local/go/bin/go test -race ./pkg/fuse -run 'TestCommitQueueDelayedZeroTruncateCancelNeverUploads|TestCommitQueueWaitPathForcesDelayedZeroTruncate|TestCommitQueueWaitPrefixForcesDelayedZeroTruncate|TestCommitQueueDrainAllForcesDelayedZeroTruncate|TestCommitQueueCancelPathStopsDelayedZeroTruncateAndCleansLocal|TestWriteCancelsDelayedQueuedPathTruncateBeforeRemoteWait|TestWriteWaitsForInFlightPathTruncate' -count=1`
- `git diff --check`

Fixes #564.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of queued truncation operations with configurable delays to prevent unwanted uploads.
  * Enhanced cleanup of pending operations during shutdown and path synchronization.
  * Fixed cancellation behavior for delayed operations to ensure consistent state management.

* **Tests**
  * Added comprehensive test coverage for delayed truncation behavior and cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->