### PR TITLE
feat(cli): make read cache ttl configurable

### DIFF
--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -34,6 +34,7 @@ type mountFuseOptions struct {
 	CacheDir                string
 	CacheSize               int64
 	ReadCacheMaxFileBytes   int64
+	ReadCacheTTL            time.Duration
 	DiskReadCacheSize       int64
 	DiskReadCacheFreeRatio  float64
 	DirTTL                  time.Duration

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -27,6 +27,7 @@ func mountFuseImpl(opts *mountFuseOptions) error {
 		CacheDir:                opts.CacheDir,
 		CacheSize:               opts.CacheSize,
 		ReadCacheMaxFileBytes:   opts.ReadCacheMaxFileBytes,
+		ReadCacheTTL:            opts.ReadCacheTTL,
 		DiskReadCacheSize:       opts.DiskReadCacheSize,
 		DiskReadCacheFreeRatio:  opts.DiskReadCacheFreeRatio,
 		DirTTL:                  opts.DirTTL,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -112,6 +112,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	cacheDir := fs.String("cache-dir", "", "write-back cache directory (default ~/.cache/drive9)")
 	cacheSize := fs.Int("cache-size", 128, "read cache size in MB")
 	readCacheMaxFile := fs.Int64("read-cache-max-file-mb", 4, "maximum single file size admitted to read cache in MB; files at or below this size are fetched with a single whole-file request")
+	readCacheTTL := fs.Duration("read-cache-ttl", 30*time.Second, "read cache TTL; 0 disables time-based expiry")
 	diskReadCacheSize := fs.Int64("disk-read-cache-size-mb", 1024, "disk-backed read cache size in MB")
 	diskReadCacheFreeRatio := fs.Float64("disk-read-cache-free-ratio", 0.10, "minimum filesystem free-space ratio before disk read cache evicts")
 	dirTTL := fs.Duration("dir-ttl", 10*time.Second, "directory cache TTL")
@@ -192,6 +193,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 
 	lookupRetryCountGiven := flagProvided(fs, "lookup-retry-count")
 	lookupRetryTimeoutGiven := flagProvided(fs, "lookup-retry-timeout")
+	readCacheTTLGiven := flagProvided(fs, "read-cache-ttl")
 	trustProcessLocalEventsGiven := flagProvided(fs, "trust-process-local-events")
 	if err := validateLookupRetryFlags(*lookupRetryCount, *lookupRetryTimeout, lookupRetryCountGiven, lookupRetryTimeoutGiven); err != nil {
 		return err
@@ -237,6 +239,10 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	if *readCacheMaxFile <= 0 {
 		return fmt.Errorf("drive9 mount: --read-cache-max-file-mb must be > 0")
 	}
+	normalizedReadCacheTTL, err := readCacheTTLFlagValue(readCacheTTLGiven, *readCacheTTL)
+	if err != nil {
+		return err
+	}
 	if *diskReadCacheSize <= 0 {
 		return fmt.Errorf("drive9 mount: --disk-read-cache-size-mb must be > 0")
 	}
@@ -266,6 +272,9 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	}
 	if resolved == MountModeWebDAV && trustProcessLocalEventsGiven {
 		return fmt.Errorf("drive9 mount: --trust-process-local-events is only supported with --mode=fuse")
+	}
+	if resolved == MountModeWebDAV && readCacheTTLGiven {
+		return fmt.Errorf("drive9 mount: --read-cache-ttl is only supported with --mode=fuse")
 	}
 	if resolved == MountModeWebDAV && *durability != string(fuseDurabilityAuto) {
 		return fmt.Errorf("--durability is only supported with --mode=fuse; WebDAV mounts always use their native write behavior")
@@ -411,6 +420,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 		CacheDir:                *cacheDir,
 		CacheSize:               int64(*cacheSize) << 20,
 		ReadCacheMaxFileBytes:   *readCacheMaxFile << 20,
+		ReadCacheTTL:            normalizedReadCacheTTL,
 		DiskReadCacheSize:       *diskReadCacheSize << 20,
 		DiskReadCacheFreeRatio:  *diskReadCacheFreeRatio,
 		DirTTL:                  normalizedDirTTL,
@@ -855,6 +865,19 @@ func durationFlagValue(fs *flag.FlagSet, name string, value time.Duration) time.
 		return value
 	}
 	return 0
+}
+
+func readCacheTTLFlagValue(given bool, value time.Duration) (time.Duration, error) {
+	if !given {
+		return 0, nil
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("drive9 mount: --read-cache-ttl must be >= 0")
+	}
+	if value == 0 {
+		return -time.Nanosecond, nil
+	}
+	return value, nil
 }
 
 func lookupRetryCountFlagValue(given bool, count int) int {

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -1238,6 +1238,122 @@ func TestMountCmdPassesReadCacheMaxFileOption(t *testing.T) {
 	}
 }
 
+func TestMountCmdLeavesReadCacheTTLUnsetByDefault(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--foreground",
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if got.ReadCacheTTL != 0 {
+		t.Fatalf("ReadCacheTTL = %v, want unset zero value", got.ReadCacheTTL)
+	}
+}
+
+func TestMountCmdPassesReadCacheTTLOption(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--foreground",
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--read-cache-ttl", "5m",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if got.ReadCacheTTL != 5*time.Minute {
+		t.Fatalf("ReadCacheTTL = %v, want 5m", got.ReadCacheTTL)
+	}
+}
+
+func TestMountCmdReadCacheTTLZeroDisablesTimeExpiry(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--foreground",
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--read-cache-ttl", "0",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	if got.ReadCacheTTL >= 0 {
+		t.Fatalf("ReadCacheTTL = %v, want negative no-expiry sentinel", got.ReadCacheTTL)
+	}
+}
+
+func TestMountCmdRejectsNegativeReadCacheTTL(t *testing.T) {
+	err := MountCmd([]string{
+		"--foreground",
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--read-cache-ttl", "-1s",
+		t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "--read-cache-ttl") {
+		t.Fatalf("MountCmd error = %v, want read-cache-ttl validation error", err)
+	}
+}
+
+func TestMountCmdRejectsReadCacheTTLWithWebDAV(t *testing.T) {
+	err := MountCmd([]string{
+		"--mode", "webdav",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--read-cache-ttl", "5m",
+		t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "--read-cache-ttl") {
+		t.Fatalf("MountCmd error = %v, want read-cache-ttl validation error", err)
+	}
+}
+
 func TestMountCmdRejectsZeroDiskReadCacheFreeRatio(t *testing.T) {
 	err := MountCmd([]string{
 		"--foreground",

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -234,7 +234,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		dirHandles:        NewHandleTable[*DirHandle](),
 		committedRev:      make(map[string]int64),
 		remoteCommitLocks: make(map[string]*sync.Mutex),
-		readCache:         NewReadCacheWithMaxFileSize(opts.CacheSize, 0, opts.ReadCacheMaxFileBytes),
+		readCache:         NewReadCacheWithMaxFileSize(opts.CacheSize, opts.ReadCacheTTL, opts.ReadCacheMaxFileBytes),
 		dirCache:          NewNamespaceCache(opts.DirTTL, opts.NegativeEntryTTL, defaultNamespaceCacheMaxEntries),
 		readSlots:         make(chan struct{}, readConcurrencyOrDefault(opts.ReadConcurrency)),
 		dirtyInodes:       make(map[uint64]dirtyInodeState),

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -6143,6 +6143,30 @@ func TestDefaultTTLIs60Seconds(t *testing.T) {
 	}
 }
 
+func TestMountOptionsReadCacheTTLDefaults(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	if opts.ReadCacheTTL != defaultReadCacheTTL {
+		t.Fatalf("default ReadCacheTTL = %v, want %v", opts.ReadCacheTTL, defaultReadCacheTTL)
+	}
+}
+
+func TestMountOptionsReadCacheTTLKeepsNoExpiry(t *testing.T) {
+	opts := &MountOptions{ReadCacheTTL: readCacheNoExpiryTTL}
+	opts.setDefaults()
+	if opts.ReadCacheTTL != readCacheNoExpiryTTL {
+		t.Fatalf("ReadCacheTTL = %v, want no-expiry sentinel", opts.ReadCacheTTL)
+	}
+}
+
+func TestNewDat9FSUsesReadCacheTTL(t *testing.T) {
+	opts := &MountOptions{ReadCacheTTL: readCacheNoExpiryTTL}
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	if fs.readCache.ttl != readCacheNoExpiryTTL {
+		t.Fatalf("read cache ttl = %v, want no-expiry sentinel", fs.readCache.ttl)
+	}
+}
+
 func TestInteractiveProfileAppliesTTLDefaults(t *testing.T) {
 	opts := &MountOptions{Profile: "interactive"}
 	opts.setDefaults()

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -295,6 +295,27 @@ func TestReadCache_TTLExpiry(t *testing.T) {
 	}
 }
 
+func TestReadCache_NoTTLExpiry(t *testing.T) {
+	rc := NewReadCache(1<<20, readCacheNoExpiryTTL)
+	rc.Put("/f", []byte("x"), 1)
+	time.Sleep(5 * time.Millisecond)
+	got, ok := rc.Get("/f", 1)
+	if !ok {
+		t.Fatal("expected cache hit when time-based expiry is disabled")
+	}
+	if string(got) != "x" {
+		t.Fatalf("got %q, want x", got)
+	}
+}
+
+func TestReadCache_NoTTLExpiryStillChecksRevision(t *testing.T) {
+	rc := NewReadCache(1<<20, readCacheNoExpiryTTL)
+	rc.Put("/f", []byte("x"), 1)
+	if _, ok := rc.Get("/f", 2); ok {
+		t.Fatal("expected cache miss on revision mismatch")
+	}
+}
+
 func TestReadCache_SkipLargeFiles(t *testing.T) {
 	rc := NewReadCache(1<<20, 10*time.Second)
 	bigData := make([]byte, defaultReadCacheMaxFileSize+1)

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -38,6 +38,7 @@ type MountOptions struct {
 	CacheDir                string        // write-back cache directory (default ~/.cache/drive9); empty string uses default
 	CacheSize               int64         // ReadCache max size in bytes (default 128MB)
 	ReadCacheMaxFileBytes   int64         // largest single file admitted to ReadCache and fetched whole-file in one request (default 4MiB)
+	ReadCacheTTL            time.Duration // ReadCache TTL (default 30s; negative disables time-based expiry)
 	DiskReadCacheSize       int64         // disk-backed read cache max size in bytes (default 1GiB)
 	DiskReadCacheFreeRatio  float64       // minimum filesystem free-space ratio before disk read cache evicts (default 0.10)
 	DirTTL                  time.Duration // DirCache TTL (default 10s)
@@ -88,6 +89,9 @@ func (o *MountOptions) setDefaults() {
 	}
 	if o.ReadCacheMaxFileBytes <= 0 {
 		o.ReadCacheMaxFileBytes = defaultReadCacheMaxFileSize
+	}
+	if o.ReadCacheTTL == 0 {
+		o.ReadCacheTTL = defaultReadCacheTTL
 	}
 	if o.DiskReadCacheSize <= 0 {
 		o.DiskReadCacheSize = defaultDiskReadCacheMaxSize

--- a/pkg/fuse/read.go
+++ b/pkg/fuse/read.go
@@ -10,6 +10,7 @@ import (
 const (
 	defaultReadCacheMaxSize = 128 << 20        // 128MB
 	defaultReadCacheTTL     = 30 * time.Second // 30s
+	readCacheNoExpiryTTL    = -1
 	// defaultPositiveKernelCacheTTL keeps positive path metadata hot across
 	// repeated scans while SSE/self-invalidation still handles namespace changes.
 	defaultPositiveKernelCacheTTL = 60 * time.Second
@@ -40,7 +41,7 @@ type cacheEntry struct {
 // ReadCache is a thread-safe LRU + TTL read cache for small and medium files.
 // It only caches files whose size does not exceed the per-cache maxFile limit.
 // Entries are evicted when the total cached size exceeds maxSize or when
-// their TTL expires.
+// their TTL expires. A negative TTL disables time-based expiry.
 type ReadCache struct {
 	mu      sync.Mutex
 	items   map[string]*cacheEntry
@@ -53,7 +54,8 @@ type ReadCache struct {
 
 // NewReadCache creates a ReadCache with the given capacity and TTL.
 // If maxSize <= 0, defaultReadCacheMaxSize (128MB) is used.
-// If ttl <= 0, defaultReadCacheTTL (30s) is used.
+// If ttl == 0, defaultReadCacheTTL (30s) is used.
+// If ttl < 0, entries do not expire by time.
 func NewReadCache(maxSize int64, ttl time.Duration) *ReadCache {
 	return NewReadCacheWithMaxFileSize(maxSize, ttl, 0)
 }
@@ -64,7 +66,7 @@ func NewReadCacheWithMaxFileSize(maxSize int64, ttl time.Duration, maxFileSize i
 	if maxSize <= 0 {
 		maxSize = defaultReadCacheMaxSize
 	}
-	if ttl <= 0 {
+	if ttl == 0 {
 		ttl = defaultReadCacheTTL
 	}
 	if maxFileSize <= 0 {
@@ -101,8 +103,8 @@ func (rc *ReadCache) Get(path string, currentRevision int64) ([]byte, bool) {
 		return nil, false
 	}
 
-	// Check TTL expiration.
-	if time.Now().After(entry.expires) {
+	// Check TTL expiration. A negative TTL means no time-based expiry.
+	if rc.ttl > 0 && time.Now().After(entry.expires) {
 		rc.evict(entry)
 		return nil, false
 	}


### PR DESCRIPTION
## Summary
- add configurable FUSE userspace read cache TTL
- support --read-cache-ttl=0 to disable time-based expiry
- keep capacity/LRU, revision mismatch, mutation invalidation, and SSE invalidation unchanged

## Tests
- env GOCACHE=/private/tmp/drive9-ttl-worktree/.codex-gocache go test ./cmd/drive9/cli
- env GOCACHE=/private/tmp/drive9-ttl-worktree/.codex-gocache go test ./pkg/fuse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--read-cache-ttl` duration flag to mount command for controlling read cache expiration (pass 0 to disable time-based expiry; unsupported with WebDAV mode)

* **Tests**
  * Added comprehensive test coverage for read cache TTL configuration, defaults, and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->