### PR TITLE
feat: add CLI TiDB Cloud native routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,24 @@ DRIVE9_PRIVATE_KEY="$TIDBCLOUD_PRIVATE_KEY" \
 drive9 create --name dev-native
 ```
 
+For TiDB Cloud native tenants, `drive9 create` stores the local context with
+`mode=TiDBCloud` and records `cloud_provider` / `region` when the server returns
+them. `drive9 ctx list` shows `MODE`, `CLOUD_PROVIDER`, and `REGION` by default;
+older contexts with no mode keep those fields empty.
+
+To add an existing owner API key for a native tenant manually, include the same
+metadata explicitly:
+
+```bash
+drive9 ctx add \
+  --name dev-native \
+  --server https://native-sg.drive9.ai \
+  --api-key "$DRIVE9_API_KEY" \
+  --mode TiDBCloud \
+  --cloud-provider aws \
+  --region us-east-1
+```
+
 `--server` has the highest priority. When it is set, the CLI bypasses the region
 manifest, ignores `--region-code`, and sends the request to that server directly:
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,91 @@ drive9 create --name dev --server https://api.drive9.ai
 drive9 ctx use dev
 ```
 
+### Provision Tenants
+
+List Drive9 provisioning regions:
+
+```bash
+drive9 region list
+```
+
+The text output uses user-facing mode names:
+
+```text
+REGION              MODE       SERVER
+aws-ap-southeast-1  Anonymous  https://api.drive9.ai
+aws-ap-southeast-1  TiDBCloud  https://native-sg.drive9.ai
+```
+
+`Anonymous` maps to the `tidb_cloud_starter` provider mode. `TiDBCloud` maps to
+the `tidbcloud_native` provider mode. If the public region manifest cannot be
+reached, `drive9 region list` falls back to:
+
+```text
+REGION              MODE       SERVER
+aws-ap-southeast-1  Anonymous  https://api.drive9.ai
+```
+
+Create an anonymous Starter tenant by region code:
+
+```bash
+drive9 create --region-code aws-ap-southeast-1 --name dev
+```
+
+Create a TiDB Cloud native tenant in the customer's TiDB Cloud account by
+passing the customer's TiDB Cloud API keys:
+
+```bash
+drive9 create \
+  --region-code aws-ap-southeast-1 \
+  --tidbcloud-public-key "$TIDBCLOUD_PUBLIC_KEY" \
+  --tidbcloud-private-key "$TIDBCLOUD_PRIVATE_KEY" \
+  --name dev-native
+```
+
+The same values can come from environment variables:
+
+```bash
+DRIVE9_REGION_CODE=aws-ap-southeast-1 \
+DRIVE9_PUBLIC_KEY="$TIDBCLOUD_PUBLIC_KEY" \
+DRIVE9_PRIVATE_KEY="$TIDBCLOUD_PRIVATE_KEY" \
+drive9 create --name dev-native
+```
+
+`--server` has the highest priority. When it is set, the CLI bypasses the region
+manifest and sends the request to that server directly:
+
+```bash
+drive9 create \
+  --server https://api.drive9.ai \
+  --tidbcloud-public-key "$TIDBCLOUD_PUBLIC_KEY" \
+  --tidbcloud-private-key "$TIDBCLOUD_PRIVATE_KEY" \
+  --name dev-native
+```
+
+Delete the current tenant with the current owner context:
+
+```bash
+drive9 delete
+```
+
+For `tidbcloud_native`, pass the customer's TiDB Cloud API keys again so the
+server can delete the customer-account Starter cluster:
+
+```bash
+drive9 delete \
+  --tidbcloud-public-key "$TIDBCLOUD_PUBLIC_KEY" \
+  --tidbcloud-private-key "$TIDBCLOUD_PRIVATE_KEY"
+```
+
+`drive9 delete` only uses owner API keys from local context automatically.
+Delegated and `fs_scoped` contexts are rejected for tenant deletion. Use
+`--api-key` to pass an owner key explicitly:
+
+```bash
+drive9 delete --server https://api.drive9.ai --api-key "$DRIVE9_API_KEY"
+```
+
 ### Filesystem Commands
 
 ```bash
@@ -249,7 +334,8 @@ DRIVE9_TENANT_PROVIDER=db9 | tidb_zero | tidb_cloud_starter | tidbcloud_native
 - `tidbcloud_native`: creates TiDB Cloud Serverless Starter clusters in the
   customer's TiDB Cloud account using `public_key` / `private_key` submitted to
   `POST /v1/provision`; server config supplies the API URL, cloud provider,
-  region, and optional default database name.
+  region, and default database name. The CLI does not expose a database-name
+  option for customers.
 - `db9`: supported provider path with its own schema, but not the default
   architecture used in this README.
 
@@ -416,7 +502,8 @@ DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER
                                 cloud provider for tidbcloud_native cluster creation
 DRIVE9_TIDBCLOUD_NATIVE_REGION  region for tidbcloud_native cluster creation
 DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME
-                                optional default database_name for tidbcloud_native
+                                server-side default database name for tidbcloud_native
+                                when unset, the server uses tidbcloud_fs
 DRIVE9_TOKEN_SIGNING_KEY        32-byte hex JWT signing key
 DRIVE9_ENCRYPT_TYPE             local_aes | kms
 DRIVE9_MASTER_KEY               local AES key

--- a/README.md
+++ b/README.md
@@ -102,16 +102,13 @@ REGION              MODE       SERVER
 aws-ap-southeast-1  Anonymous  https://api.drive9.ai
 ```
 
-`drive9 region list --json` returns the same region list as a JSON array. The
-`mode` field uses canonical IDs (`tidb_cloud_starter`, `tidb_cloud_native`), and
-`mode_label` contains the text display label:
+`drive9 region list --json` returns the same region list as a JSON array:
 
 ```json
 [
   {
     "region_code": "aws-ap-southeast-1",
-    "mode": "tidb_cloud_starter",
-    "mode_label": "Anonymous",
+    "mode": "Anonymous",
     "server_url": "https://api.drive9.ai"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ REGION              MODE       SERVER
 aws-ap-southeast-1  Anonymous  https://api.drive9.ai
 ```
 
+`drive9 region list --json` uses canonical mode IDs (`tidb_cloud_starter`,
+`tidb_cloud_native`) instead of the display labels shown in text output.
+
 Create an anonymous Starter tenant by region code:
 
 ```bash
@@ -129,7 +132,7 @@ drive9 create --name dev-native
 ```
 
 `--server` has the highest priority. When it is set, the CLI bypasses the region
-manifest and sends the request to that server directly:
+manifest, ignores `--region-code`, and sends the request to that server directly:
 
 ```bash
 drive9 create \

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ aws-ap-southeast-1  TiDBCloud  https://native-sg.drive9.ai
 ```
 
 `Anonymous` maps to the `tidb_cloud_starter` provider mode. `TiDBCloud` maps to
-the `tidbcloud_native` provider mode. If the public region manifest cannot be
+the `tidb_cloud_native` provider mode. If the public region manifest cannot be
 reached, `drive9 region list` falls back to:
 
 ```text
@@ -145,7 +145,7 @@ Delete the current tenant with the current owner context:
 drive9 delete
 ```
 
-For `tidbcloud_native`, pass the customer's TiDB Cloud API keys again so the
+For `tidb_cloud_native`, pass the customer's TiDB Cloud API keys again so the
 server can delete the customer-account Starter cluster:
 
 ```bash
@@ -326,12 +326,12 @@ func main() {
 Current tenant providers are selected explicitly:
 
 ```text
-DRIVE9_TENANT_PROVIDER=db9 | tidb_zero | tidb_cloud_starter | tidbcloud_native
+DRIVE9_TENANT_PROVIDER=db9 | tidb_zero | tidb_cloud_starter | tidb_cloud_native
 ```
 
 - `tidb_zero`: default development/provisioning path backed by TiDB Zero.
 - `tidb_cloud_starter`: production-oriented TiDB Cloud Starter pool takeover.
-- `tidbcloud_native`: creates TiDB Cloud Serverless Starter clusters in the
+- `tidb_cloud_native`: creates TiDB Cloud Serverless Starter clusters in the
   customer's TiDB Cloud account using `public_key` / `private_key` submitted to
   `POST /v1/provision`; server config supplies the API URL, cloud provider,
   region, and default database name. The CLI does not expose a database-name
@@ -456,7 +456,7 @@ DELETE /v1/tenant                 delete current tenant with owner API key
 Vault endpoints also exist for secret storage, scoped grants, delegated tokens,
 and read-only vault mounts.
 
-`DELETE /v1/tenant` is owner-key only. For `tidbcloud_native`, the request body
+`DELETE /v1/tenant` is owner-key only. For `tidb_cloud_native`, the request body
 must also include the customer's TiDB Cloud `public_key` and `private_key` so
 Drive9 can delete the customer-account Starter cluster. `tidb_zero` tenants are
 not deleted through this endpoint; they expire automatically.
@@ -493,16 +493,16 @@ Important environment variables:
 
 ```text
 DRIVE9_META_DSN                 control-plane MySQL/TiDB DSN
-DRIVE9_TENANT_PROVIDER          db9 | tidb_zero | tidb_cloud_starter | tidbcloud_native
+DRIVE9_TENANT_PROVIDER          db9 | tidb_zero | tidb_cloud_starter | tidb_cloud_native
 DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT
                                 default TiDB Cloud spendingLimit.monthly in USD cents
-                                optional for tidb_cloud_starter; tidbcloud_native defaults to 1000 when unset
+                                optional for tidb_cloud_starter; tidb_cloud_native defaults to 1000 when unset
 DRIVE9_TIDBCLOUD_NATIVE_API_URL TiDB Cloud Serverless API base URL
 DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER
-                                cloud provider for tidbcloud_native cluster creation
-DRIVE9_TIDBCLOUD_NATIVE_REGION  region for tidbcloud_native cluster creation
+                                cloud provider for tidb_cloud_native cluster creation
+DRIVE9_TIDBCLOUD_NATIVE_REGION  region for tidb_cloud_native cluster creation
 DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME
-                                server-side default database name for tidbcloud_native
+                                server-side default database name for tidb_cloud_native
                                 when unset, the server uses tidbcloud_fs
 DRIVE9_TOKEN_SIGNING_KEY        32-byte hex JWT signing key
 DRIVE9_ENCRYPT_TYPE             local_aes | kms

--- a/README.md
+++ b/README.md
@@ -102,8 +102,20 @@ REGION              MODE       SERVER
 aws-ap-southeast-1  Anonymous  https://api.drive9.ai
 ```
 
-`drive9 region list --json` uses canonical mode IDs (`tidb_cloud_starter`,
-`tidb_cloud_native`) instead of the display labels shown in text output.
+`drive9 region list --json` returns the same region list as a JSON array. The
+`mode` field uses canonical IDs (`tidb_cloud_starter`, `tidb_cloud_native`), and
+`mode_label` contains the text display label:
+
+```json
+[
+  {
+    "region_code": "aws-ap-southeast-1",
+    "mode": "tidb_cloud_starter",
+    "mode_label": "Anonymous",
+    "server_url": "https://api.drive9.ai"
+  }
+]
+```
 
 Create an anonymous Starter tenant by region code:
 

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -403,7 +403,7 @@ func usage(out io.Writer, exitCode int) {
 	_, _ = fmt.Fprintf(out, `usage:
   drive9-server [listen-addr]
   drive9-server version
-  drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter|tidbcloud_native>
+  drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter|tidb_cloud_native>
 
 environment:
   DRIVE9_LISTEN_ADDR serve listen address (default: :9009)
@@ -433,12 +433,12 @@ environment:
                                     required by openai, cohere, jina_ai, gemini, huggingface, nvidia_nim, nvidia
   DRIVE9_TIDB_AUTO_EMBEDDING_API_BASE provider base endpoint for models that require it
                                      optional for openai models; set it for Azure OpenAI endpoints
-  DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter|tidbcloud_native (default for provisioning)
+  DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_starter|tidb_cloud_native (default for provisioning)
   DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT default TiDB Cloud spendingLimit.monthly in USD cents; optional for Starter, native defaults to 1000 when unset
-  DRIVE9_TIDBCLOUD_NATIVE_API_URL TiDB Cloud Serverless API base URL for tidbcloud_native
-  DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER cloud provider for tidbcloud_native cluster creation, e.g. aws
-  DRIVE9_TIDBCLOUD_NATIVE_REGION region for tidbcloud_native cluster creation, e.g. us-east-1
-  DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME default tidbcloud_native database name when /v1/provision omits database_name (default: tidbcloud_fs)
+  DRIVE9_TIDBCLOUD_NATIVE_API_URL TiDB Cloud Serverless API base URL for tidb_cloud_native
+  DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER cloud provider for tidb_cloud_native cluster creation, e.g. aws
+  DRIVE9_TIDBCLOUD_NATIVE_REGION region for tidb_cloud_native cluster creation, e.g. us-east-1
+  DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME default tidb_cloud_native database name when /v1/provision omits database_name (default: tidbcloud_fs)
   DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*
   DRIVE9_SLOCK_API_ORIGIN Slock API origin (required when DRIVE9_SLOCK_ORIGIN is set)
   DRIVE9_SLOCK_CLIENT_ID Slock connected-app client id (required when DRIVE9_SLOCK_ORIGIN is set)

--- a/cmd/drive9-server/schema_test.go
+++ b/cmd/drive9-server/schema_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSchemaDumpInitSQLByProvider(t *testing.T) {
-	for _, provider := range []string{"tidb_zero", "tidb_cloud_starter", "tidbcloud_native"} {
+	for _, provider := range []string{"tidb_zero", "tidb_cloud_starter", "tidb_cloud_native"} {
 		t.Run(provider, func(t *testing.T) {
 			out := captureSchemaStdout(t, func() {
 				if err := runSchemaCommand([]string{"dump-init-sql", "--provider", provider}); err != nil {
@@ -36,7 +36,7 @@ func TestSchemaDumpInitSQLByProvider(t *testing.T) {
 }
 
 func TestSchemaDumpInitSQLByProviderIncludesVault(t *testing.T) {
-	for _, provider := range []string{"tidb_zero", "tidb_cloud_starter", "tidbcloud_native"} {
+	for _, provider := range []string{"tidb_zero", "tidb_cloud_starter", "tidb_cloud_native"} {
 		t.Run(provider, func(t *testing.T) {
 			out := captureSchemaStdout(t, func() {
 				if err := runSchemaCommand([]string{"dump-init-sql", "--provider", provider}); err != nil {

--- a/cmd/drive9/cli/config.go
+++ b/cmd/drive9/cli/config.go
@@ -31,7 +31,7 @@ const (
 // Context is a single entry in ~/.drive9/config. Field presence depends on
 // Type per spec §13.1:
 //
-//   - owner:     APIKey, Server
+//   - owner:     APIKey, Server, optional Mode/CloudProvider/Region
 //   - fs_scoped: APIKey, Server, Scope[], ExpiresAt
 //   - delegated: Token, Server (from iss), Agent, Scope[], Perm, ExpiresAt,
 //     GrantID, optional LabelHint
@@ -40,16 +40,19 @@ const (
 // `ctx import` time. This is UX-only — authorization remains server-side
 // (Invariant #7).
 type Context struct {
-	Type      PrincipalType `json:"type"`
-	Server    string        `json:"server,omitempty"`
-	APIKey    string        `json:"api_key,omitempty"`
-	Token     string        `json:"token,omitempty"`
-	Agent     string        `json:"agent,omitempty"`
-	Scope     []string      `json:"scope,omitempty"`
-	Perm      Perm          `json:"perm,omitempty"`
-	ExpiresAt time.Time     `json:"expires_at,omitempty"`
-	GrantID   string        `json:"grant_id,omitempty"`
-	LabelHint string        `json:"label_hint,omitempty"`
+	Type          PrincipalType `json:"type"`
+	Server        string        `json:"server,omitempty"`
+	APIKey        string        `json:"api_key,omitempty"`
+	Token         string        `json:"token,omitempty"`
+	Mode          string        `json:"mode,omitempty"`
+	CloudProvider string        `json:"cloud_provider,omitempty"`
+	Region        string        `json:"region,omitempty"`
+	Agent         string        `json:"agent,omitempty"`
+	Scope         []string      `json:"scope,omitempty"`
+	Perm          Perm          `json:"perm,omitempty"`
+	ExpiresAt     time.Time     `json:"expires_at,omitempty"`
+	GrantID       string        `json:"grant_id,omitempty"`
+	LabelHint     string        `json:"label_hint,omitempty"`
 }
 
 type Config struct {

--- a/cmd/drive9/cli/credentials.go
+++ b/cmd/drive9/cli/credentials.go
@@ -8,13 +8,13 @@ import (
 	"sync"
 )
 
-// Environment variable names recognised by the credential resolver. See spec
+// Environment variable names for credential-bearing CLI inputs. See spec
 // §14.1. The dual-principal separation is locked — there is no single combined
 // variable; DRIVE9_VAULT_TOKEN and DRIVE9_API_KEY remain distinct knobs.
 //
-// This exact set of three names is also the F14 scrub whitelist for
+// This exact set of credential-bearing names is also the F14 scrub whitelist for
 // `drive9 vault with` (spec §9 L209): the child process MUST NOT inherit
-// any of these three from the parent, even when they are unset, absent, or
+// any of these from the parent, even when they are unset, absent, or
 // identical to the current mount's credential. Other DRIVE9_* vars
 // (profiling, log level, etc.) are outside the scrub — they do not grant
 // authority — and flow through untouched. `scrubDrive9CredEnv` in
@@ -22,9 +22,11 @@ import (
 // env var here requires a matching update there (and a new V2c-style
 // review gate). The exactness of this list IS the contract.
 const (
-	EnvVaultToken = "DRIVE9_VAULT_TOKEN"
-	EnvAPIKey     = "DRIVE9_API_KEY"
-	EnvServer     = "DRIVE9_SERVER"
+	EnvVaultToken          = "DRIVE9_VAULT_TOKEN"
+	EnvAPIKey              = "DRIVE9_API_KEY"
+	EnvServer              = "DRIVE9_SERVER"
+	EnvTiDBCloudPublicKey  = "DRIVE9_PUBLIC_KEY"
+	EnvTiDBCloudPrivateKey = "DRIVE9_PRIVATE_KEY"
 )
 
 // CredentialKind classifies which principal the resolved credential

--- a/cmd/drive9/cli/credentials.go
+++ b/cmd/drive9/cli/credentials.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 )
 
@@ -236,7 +237,7 @@ const defaultServerURL = "https://api.drive9.ai"
 //
 // Call this on each credential flag after flag.Parse.
 func rejectEmptyFlag(flagName, value string, provided bool) error {
-	if provided && value == "" {
+	if provided && strings.TrimSpace(value) == "" {
 		return fmt.Errorf("--%s was given an empty value; pass a non-empty credential or omit the flag", flagName)
 	}
 	return nil

--- a/cmd/drive9/cli/credentials.go
+++ b/cmd/drive9/cli/credentials.go
@@ -199,6 +199,14 @@ func consumeEnv(name string) string {
 	return trimmed
 }
 
+func readTrimEnv(name string) string {
+	raw, ok := os.LookupEnv(name)
+	if !ok {
+		return ""
+	}
+	return trimASCIISpace(raw)
+}
+
 func trimASCIISpace(s string) string {
 	start := 0
 	for start < len(s) && isASCIISpace(s[start]) {

--- a/cmd/drive9/cli/credentials_test.go
+++ b/cmd/drive9/cli/credentials_test.go
@@ -340,6 +340,7 @@ func TestRejectEmptyFlag(t *testing.T) {
 		{"unset", false, "", false},
 		{"set-non-empty", true, "v", false},
 		{"explicit-empty", true, "", true},
+		{"explicit-whitespace", true, "   ", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -51,7 +51,7 @@ func Ctx(args []string) error {
 func ctxUsage() string {
 	return `usage: drive9 ctx <show|add|import|fork|ls|use|rm>
   show [--json] [--reveal]                            show current context
-  add --api-key <key> [--name <n>] [--server <url>]   add owner context
+  add --api-key <key> [--name <n>] [--server <url>] [--mode <Anonymous|TiDBCloud>] [--cloud-provider <p>] [--region <r>]
   import --from-file <path>                           add delegated context from file (must be mode 0600)
   import --from-file -                                add delegated context from stdin explicitly
   import                                              add delegated context from stdin (default when stdin is a pipe)
@@ -62,20 +62,23 @@ func ctxUsage() string {
 }
 
 type ctxShowEntry struct {
-	Name      string     `json:"name"`
-	Type      string     `json:"type"`
-	Server    string     `json:"server,omitempty"`
-	TenantID  string     `json:"tenant_id,omitempty"`
-	APIKey    string     `json:"api_key,omitempty"`
-	Token     string     `json:"token,omitempty"`
-	Agent     string     `json:"agent,omitempty"`
-	Scope     []string   `json:"scope,omitempty"`
-	Perm      string     `json:"perm,omitempty"`
-	ExpiresAt *time.Time `json:"expires_at,omitempty"`
-	Status    string     `json:"status,omitempty"`
-	GrantID   string     `json:"grant_id,omitempty"`
-	LabelHint string     `json:"label_hint,omitempty"`
-	Source    string     `json:"source,omitempty"`
+	Name          string     `json:"name"`
+	Type          string     `json:"type"`
+	Server        string     `json:"server,omitempty"`
+	Mode          string     `json:"mode,omitempty"`
+	CloudProvider string     `json:"cloud_provider,omitempty"`
+	Region        string     `json:"region,omitempty"`
+	TenantID      string     `json:"tenant_id,omitempty"`
+	APIKey        string     `json:"api_key,omitempty"`
+	Token         string     `json:"token,omitempty"`
+	Agent         string     `json:"agent,omitempty"`
+	Scope         []string   `json:"scope,omitempty"`
+	Perm          string     `json:"perm,omitempty"`
+	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
+	Status        string     `json:"status,omitempty"`
+	GrantID       string     `json:"grant_id,omitempty"`
+	LabelHint     string     `json:"label_hint,omitempty"`
+	Source        string     `json:"source,omitempty"`
 }
 
 func ctxShowCmd(args []string) error {
@@ -109,11 +112,14 @@ func buildCtxShowEntry(cfg *Config, reveal bool) *ctxShowEntry {
 	}
 
 	entry := &ctxShowEntry{
-		Name:     cfg.CurrentContext,
-		Type:     string(current.Type),
-		Server:   cfg.ResolveServer(),
-		TenantID: tenantIDFromContext(current),
-		Source:   configPath(),
+		Name:          cfg.CurrentContext,
+		Type:          string(current.Type),
+		Server:        cfg.ResolveServer(),
+		Mode:          strings.TrimSpace(current.Mode),
+		CloudProvider: strings.TrimSpace(current.CloudProvider),
+		Region:        strings.TrimSpace(current.Region),
+		TenantID:      tenantIDFromContext(current),
+		Source:        configPath(),
 	}
 
 	switch current.Type {
@@ -165,6 +171,24 @@ func writeCtxShowText(entry *ctxShowEntry) error {
 		{label: "name", value: entry.Name},
 		{label: "type", value: entry.Type},
 		{label: "server", value: entry.Server},
+	}
+	if entry.Mode != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "mode", value: entry.Mode})
+	}
+	if entry.CloudProvider != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "cloud_provider", value: entry.CloudProvider})
+	}
+	if entry.Region != "" {
+		fields = append(fields, struct {
+			label string
+			value string
+		}{label: "region", value: entry.Region})
 	}
 	if entry.TenantID != "" {
 		fields = append(fields, struct {
@@ -300,9 +324,12 @@ func formatSecretForDisplay(secret string, reveal bool) string {
 // preserved.
 func ctxAddCmd(args []string) error {
 	var (
-		apiKey string
-		name   string
-		server string
+		apiKey        string
+		name          string
+		server        string
+		mode          string
+		cloudProvider string
+		region        string
 	)
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -324,12 +351,39 @@ func ctxAddCmd(args []string) error {
 			}
 			i++
 			server = args[i]
+		case "--mode":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--mode requires a value")
+			}
+			i++
+			mode = strings.TrimSpace(args[i])
+		case "--cloud-provider":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--cloud-provider requires a value")
+			}
+			i++
+			cloudProvider = strings.TrimSpace(args[i])
+		case "--region":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--region requires a value")
+			}
+			i++
+			region = strings.TrimSpace(args[i])
 		default:
-			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx add --api-key <key> [--name <n>] [--server <url>]", args[i])
+			return fmt.Errorf("unknown flag %q\nusage: drive9 ctx add --api-key <key> [--name <n>] [--server <url>] [--mode <Anonymous|TiDBCloud>] [--cloud-provider <p>] [--region <r>]", args[i])
 		}
 	}
 	if apiKey == "" {
 		return fmt.Errorf("--api-key is required")
+	}
+	if mode != "" && !isKnownContextMode(mode) {
+		return fmt.Errorf("unknown --mode %q; valid: Anonymous, TiDBCloud", mode)
+	}
+	if (cloudProvider != "" || region != "") && mode == "" {
+		return fmt.Errorf("--cloud-provider and --region require --mode TiDBCloud")
+	}
+	if mode == regionModeLabel(RegionModeTiDBCloudStarter) && (cloudProvider != "" || region != "") {
+		return fmt.Errorf("anonymous contexts do not use --cloud-provider or --region")
 	}
 
 	cfg := loadConfig()
@@ -340,9 +394,12 @@ func ctxAddCmd(args []string) error {
 		name = randomName()
 	}
 	if _, err := ctxAdd(cfg, name, &Context{
-		Type:   PrincipalOwner,
-		Server: server,
-		APIKey: apiKey,
+		Type:          PrincipalOwner,
+		Server:        server,
+		APIKey:        apiKey,
+		Mode:          mode,
+		CloudProvider: cloudProvider,
+		Region:        region,
 	}); err != nil {
 		return err
 	}
@@ -785,18 +842,30 @@ func isKnownPrincipalType(value string) bool {
 	return false
 }
 
+func isKnownContextMode(value string) bool {
+	switch strings.TrimSpace(value) {
+	case regionModeLabel(RegionModeTiDBCloudStarter), regionModeLabel(RegionModeTiDBCloudNative):
+		return true
+	default:
+		return false
+	}
+}
+
 type ctxListEntry struct {
-	Name      string    `json:"name"`
-	Current   bool      `json:"current"`
-	Type      string    `json:"type"`
-	Server    string    `json:"server,omitempty"`
-	TenantID  string    `json:"tenant_id,omitempty"`
-	Scope     []string  `json:"scope,omitempty"`
-	Perm      string    `json:"perm,omitempty"`
-	ExpiresAt time.Time `json:"expires_at,omitempty"`
-	Status    string    `json:"status"`
-	Agent     string    `json:"agent,omitempty"`
-	GrantID   string    `json:"grant_id,omitempty"`
+	Name          string    `json:"name"`
+	Current       bool      `json:"current"`
+	Type          string    `json:"type"`
+	Server        string    `json:"server,omitempty"`
+	Mode          string    `json:"mode,omitempty"`
+	CloudProvider string    `json:"cloud_provider,omitempty"`
+	Region        string    `json:"region,omitempty"`
+	TenantID      string    `json:"tenant_id,omitempty"`
+	Scope         []string  `json:"scope,omitempty"`
+	Perm          string    `json:"perm,omitempty"`
+	ExpiresAt     time.Time `json:"expires_at,omitempty"`
+	Status        string    `json:"status"`
+	Agent         string    `json:"agent,omitempty"`
+	GrantID       string    `json:"grant_id,omitempty"`
 }
 
 func writeCtxListJSON(cfg *Config, typeFilter string) error {
@@ -823,9 +892,9 @@ func writeCtxListTable(cfg *Config, longForm, details bool, typeFilter string) e
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	if details {
-		_, _ = fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tTENANT_ID\tSERVER\tAGENT\tGRANT_ID\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS")
+		_, _ = fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tMODE\tCLOUD_PROVIDER\tREGION\tTENANT_ID\tSERVER\tAGENT\tGRANT_ID\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS")
 	} else {
-		_, _ = fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS")
+		_, _ = fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tMODE\tCLOUD_PROVIDER\tREGION\tSCOPE\tPERM\tEXPIRES_AT\tSTATUS")
 	}
 	for _, e := range entries {
 		cur := " "
@@ -846,10 +915,13 @@ func writeCtxListTable(cfg *Config, longForm, details bool, typeFilter string) e
 			if grantID == "" {
 				grantID = "—"
 			}
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				cur,
 				e.Name,
 				e.Type,
+				e.Mode,
+				e.CloudProvider,
+				e.Region,
 				e.TenantID,
 				e.Server,
 				agent,
@@ -860,10 +932,13 @@ func writeCtxListTable(cfg *Config, longForm, details bool, typeFilter string) e
 				e.Status,
 			)
 		} else {
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				cur,
 				e.Name,
 				e.Type,
+				e.Mode,
+				e.CloudProvider,
+				e.Region,
 				scope,
 				perm,
 				formatExpiresAt(e.ExpiresAt),
@@ -888,17 +963,20 @@ func buildCtxListEntries(cfg *Config) []ctxListEntry {
 			continue
 		}
 		entries = append(entries, ctxListEntry{
-			Name:      n,
-			Current:   n == cfg.CurrentContext,
-			Type:      string(c.Type),
-			Server:    c.Server,
-			TenantID:  tenantIDFromContext(c),
-			Scope:     c.Scope,
-			Perm:      string(c.Perm),
-			ExpiresAt: c.ExpiresAt,
-			Status:    ctxStatus(c, now),
-			Agent:     c.Agent,
-			GrantID:   c.GrantID,
+			Name:          n,
+			Current:       n == cfg.CurrentContext,
+			Type:          string(c.Type),
+			Server:        c.Server,
+			Mode:          strings.TrimSpace(c.Mode),
+			CloudProvider: strings.TrimSpace(c.CloudProvider),
+			Region:        strings.TrimSpace(c.Region),
+			TenantID:      tenantIDFromContext(c),
+			Scope:         c.Scope,
+			Perm:          string(c.Perm),
+			ExpiresAt:     c.ExpiresAt,
+			Status:        ctxStatus(c, now),
+			Agent:         c.Agent,
+			GrantID:       c.GrantID,
 		})
 	}
 	return entries

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -375,6 +375,40 @@ func TestCtxShowOwnerMaskedText(t *testing.T) {
 	}
 }
 
+func TestCtxShowOmitsEmptyModeFields(t *testing.T) {
+	_ = withIsolatedHome(t)
+	cfg := loadConfig()
+	_, err := ctxAdd(cfg, "prod", &Context{
+		Type:   PrincipalOwner,
+		APIKey: "drive9_abcdxxxxxxxxwxyz",
+		Server: "https://api.drive9.ai",
+	})
+	if err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	out, err := captureStdoutE(t, func() error { return Ctx([]string{"show", "--json"}) })
+	if err != nil {
+		t.Fatalf("ctx show --json: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v\nout=%q", err, out)
+	}
+	if _, ok := got["mode"]; ok {
+		t.Fatalf("mode should be omitted when empty: %#v", got)
+	}
+	if _, ok := got["cloud_provider"]; ok {
+		t.Fatalf("cloud_provider should be omitted when empty: %#v", got)
+	}
+	if _, ok := got["region"]; ok {
+		t.Fatalf("region should be omitted when empty: %#v", got)
+	}
+}
+
 func TestCtxShowOwnerRevealJSON(t *testing.T) {
 	home := withIsolatedHome(t)
 	cfg := loadConfig()
@@ -418,6 +452,110 @@ func TestCtxShowOwnerRevealJSON(t *testing.T) {
 	}
 	if got["source"] != filepath.Join(home, ".drive9", "config") {
 		t.Fatalf("source = %v, want config path", got["source"])
+	}
+}
+
+func TestCtxAddNativeMetadataAndListDefaultColumns(t *testing.T) {
+	_ = withIsolatedHome(t)
+
+	out, err := captureStdoutE(t, func() error {
+		return Ctx([]string{
+			"add",
+			"--api-key", "drive9_abcdxxxxxxxxwxyz",
+			"--name", "native",
+			"--server", "https://native.drive9.example",
+			"--mode", "TiDBCloud",
+			"--cloud-provider", "aws",
+			"--region", "us-east-1",
+		})
+	})
+	if err != nil {
+		t.Fatalf("ctx add: %v", err)
+	}
+	if !strings.Contains(out, `added context "native"`) {
+		t.Fatalf("ctx add output = %q", out)
+	}
+
+	cfg := loadConfig()
+	got := cfg.Contexts["native"]
+	if got == nil || got.Mode != "TiDBCloud" || got.CloudProvider != "aws" || got.Region != "us-east-1" {
+		t.Fatalf("saved native context = %#v", got)
+	}
+
+	out, err = captureStdoutE(t, func() error { return Ctx([]string{"list"}) })
+	if err != nil {
+		t.Fatalf("ctx list: %v", err)
+	}
+	for _, want := range []string{"MODE", "CLOUD_PROVIDER", "REGION", "TiDBCloud", "aws", "us-east-1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("ctx list output = %q, want %q", out, want)
+		}
+	}
+
+	out, err = captureStdoutE(t, func() error { return Ctx([]string{"show", "--json", "--reveal"}) })
+	if err != nil {
+		t.Fatalf("ctx show --json --reveal: %v", err)
+	}
+	var shown struct {
+		Mode          string `json:"mode"`
+		CloudProvider string `json:"cloud_provider"`
+		Region        string `json:"region"`
+	}
+	if err := json.Unmarshal([]byte(out), &shown); err != nil {
+		t.Fatalf("json.Unmarshal: %v\nout=%q", err, out)
+	}
+	if shown.Mode != "TiDBCloud" || shown.CloudProvider != "aws" || shown.Region != "us-east-1" {
+		t.Fatalf("ctx show native metadata = %#v", shown)
+	}
+
+	out, err = captureStdoutE(t, func() error { return Ctx([]string{"list", "--json"}) })
+	if err != nil {
+		t.Fatalf("ctx list --json: %v", err)
+	}
+	var listed struct {
+		Contexts []struct {
+			Name          string `json:"name"`
+			Mode          string `json:"mode"`
+			CloudProvider string `json:"cloud_provider"`
+			Region        string `json:"region"`
+		} `json:"contexts"`
+	}
+	if err := json.Unmarshal([]byte(out), &listed); err != nil {
+		t.Fatalf("json.Unmarshal list: %v\nout=%q", err, out)
+	}
+	if len(listed.Contexts) != 1 || listed.Contexts[0].Name != "native" || listed.Contexts[0].Mode != "TiDBCloud" || listed.Contexts[0].CloudProvider != "aws" || listed.Contexts[0].Region != "us-east-1" {
+		t.Fatalf("ctx list json native metadata = %#v", listed.Contexts)
+	}
+}
+
+func TestCtxAddRejectsAmbiguousRegionMetadata(t *testing.T) {
+	_ = withIsolatedHome(t)
+
+	err := Ctx([]string{
+		"add",
+		"--api-key", "drive9_abcdxxxxxxxxwxyz",
+		"--name", "bad",
+		"--cloud-provider", "aws",
+	})
+	if err == nil {
+		t.Fatal("ctx add error = nil, want cloud-provider requires mode error")
+	}
+	if !strings.Contains(err.Error(), "require --mode TiDBCloud") {
+		t.Fatalf("ctx add error = %q", err)
+	}
+
+	err = Ctx([]string{
+		"add",
+		"--api-key", "drive9_abcdxxxxxxxxwxyz",
+		"--name", "bad-anon",
+		"--mode", "Anonymous",
+		"--region", "us-east-1",
+	})
+	if err == nil {
+		t.Fatal("ctx add error = nil, want Anonymous region error")
+	}
+	if !strings.Contains(err.Error(), "anonymous contexts do not use") {
+		t.Fatalf("ctx add error = %q", err)
 	}
 }
 

--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -160,11 +160,17 @@ func Create(args []string) error {
 		return fmt.Errorf("decode response: %w", err)
 	}
 
-	if _, err := ctxAdd(cfg, name, &Context{
+	ctx := &Context{
 		Type:   PrincipalOwner,
 		Server: server,
 		APIKey: result.APIKey,
-	}); err != nil {
+		Mode:   regionModeLabel(mode),
+	}
+	if mode == RegionModeTiDBCloudNative {
+		ctx.CloudProvider = strings.TrimSpace(result.CloudProvider)
+		ctx.Region = strings.TrimSpace(result.Region)
+	}
+	if _, err := ctxAdd(cfg, name, ctx); err != nil {
 		return err
 	}
 	if err := saveConfig(cfg); err != nil {
@@ -173,18 +179,19 @@ func Create(args []string) error {
 
 	if asJSON {
 		out := createOutput{
-			Context:    name,
-			TenantID:   result.TenantID,
-			APIKey:     result.APIKey,
-			Status:     result.Status,
-			Server:     server,
-			RegionCode: regionCode,
-			Mode:       mode,
-			Config:     configPath(),
+			Context:       name,
+			TenantID:      result.TenantID,
+			APIKey:        result.APIKey,
+			Status:        result.Status,
+			Server:        server,
+			RegionCode:    regionCode,
+			Mode:          regionModeLabel(mode),
+			CloudProvider: ctx.CloudProvider,
+			Region:        ctx.Region,
+			Config:        configPath(),
 		}
 		if regionEntry != nil {
 			out.RegionCode = strings.TrimSpace(regionEntry.RegionCode)
-			out.Mode = strings.TrimSpace(regionEntry.Mode)
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -204,20 +211,24 @@ const (
 )
 
 type createResult struct {
-	TenantID string `json:"tenant_id"`
-	APIKey   string `json:"api_key"`
-	Status   string `json:"status"`
+	TenantID      string `json:"tenant_id"`
+	APIKey        string `json:"api_key"`
+	Status        string `json:"status"`
+	CloudProvider string `json:"cloud_provider"`
+	Region        string `json:"region"`
 }
 
 type createOutput struct {
-	Context    string `json:"context"`
-	TenantID   string `json:"tenant_id"`
-	APIKey     string `json:"api_key"`
-	Status     string `json:"status"`
-	Server     string `json:"server"`
-	RegionCode string `json:"region_code,omitempty"`
-	Mode       string `json:"mode,omitempty"`
-	Config     string `json:"config"`
+	Context       string `json:"context"`
+	TenantID      string `json:"tenant_id"`
+	APIKey        string `json:"api_key"`
+	Status        string `json:"status"`
+	Server        string `json:"server"`
+	RegionCode    string `json:"region_code,omitempty"`
+	Mode          string `json:"mode,omitempty"`
+	CloudProvider string `json:"cloud_provider,omitempty"`
+	Region        string `json:"region,omitempty"`
+	Config        string `json:"config"`
 }
 
 func createUsage() string {

--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -1,11 +1,21 @@
 package cli
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+)
+
+const (
+	EnvTiDBCloudPublicKey  = "DRIVE9_PUBLIC_KEY"
+	EnvTiDBCloudPrivateKey = "DRIVE9_PRIVATE_KEY"
 )
 
 // Create provisions a new tenant and registers the returned API key as a
@@ -19,9 +29,19 @@ func Create(args []string) error {
 	name := ""
 	serverFlag := ""
 	serverFlagGiven := false
+	regionCodeFlag := ""
+	regionCodeGiven := false
+	publicKeyFlag := ""
+	publicKeyGiven := false
+	privateKeyFlag := ""
+	privateKeyGiven := false
+	asJSON := false
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
+		case "-h", "-help", "--help", "help":
+			_, _ = fmt.Fprintln(os.Stdout, createUsage())
+			return nil
 		case "--name":
 			if i+1 >= len(args) {
 				return fmt.Errorf("--name requires an argument")
@@ -35,12 +55,44 @@ func Create(args []string) error {
 			i++
 			serverFlag = args[i]
 			serverFlagGiven = true
+		case "--region-code":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--region-code requires an argument")
+			}
+			i++
+			regionCodeFlag = args[i]
+			regionCodeGiven = true
+		case "--tidbcloud-public-key":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--tidbcloud-public-key requires an argument")
+			}
+			i++
+			publicKeyFlag = args[i]
+			publicKeyGiven = true
+		case "--tidbcloud-private-key":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--tidbcloud-private-key requires an argument")
+			}
+			i++
+			privateKeyFlag = args[i]
+			privateKeyGiven = true
+		case "--json":
+			asJSON = true
 		default:
-			return fmt.Errorf("unknown flag %q\nusage: drive9 create [--name NAME] [--server URL]", args[i])
+			return fmt.Errorf("unknown flag %q\n%s", args[i], createUsage())
 		}
 	}
 
 	if err := rejectEmptyFlag("server", serverFlag, serverFlagGiven); err != nil {
+		return err
+	}
+	if err := rejectEmptyFlag("region-code", regionCodeFlag, regionCodeGiven); err != nil {
+		return err
+	}
+	if err := rejectEmptyFlag("tidbcloud-public-key", publicKeyFlag, publicKeyGiven); err != nil {
+		return err
+	}
+	if err := rejectEmptyFlag("tidbcloud-private-key", privateKeyFlag, privateKeyGiven); err != nil {
 		return err
 	}
 
@@ -50,9 +102,33 @@ func Create(args []string) error {
 	// env to keep downstream forks from inheriting it. Credential resolution is
 	// not used here — provisioning is unauthenticated.
 	r := ResolveCredentials()
-	server := serverFlag
-	if server == "" {
-		server = r.Server
+	envPublicKey := consumeEnv(EnvTiDBCloudPublicKey)
+	envPrivateKey := consumeEnv(EnvTiDBCloudPrivateKey)
+	publicKey := publicKeyFlag
+	if publicKey == "" {
+		publicKey = envPublicKey
+	}
+	privateKey := privateKeyFlag
+	if privateKey == "" {
+		privateKey = envPrivateKey
+	}
+	regionCode := ""
+	if strings.TrimSpace(serverFlag) == "" {
+		regionCode = strings.TrimSpace(regionCodeFlag)
+		if regionCode == "" {
+			regionCode = readTrimEnv(EnvRegionCode)
+		}
+	}
+	publicKey = strings.TrimSpace(publicKey)
+	privateKey = strings.TrimSpace(privateKey)
+
+	mode := provisionModeForCredentials(publicKey, privateKey)
+	if mode == RegionModeTiDBCloudNative && (publicKey == "" || privateKey == "") {
+		return fmt.Errorf("tidbcloud_native create requires --tidbcloud-public-key and --tidbcloud-private-key, or %s/%s", EnvTiDBCloudPublicKey, EnvTiDBCloudPrivateKey)
+	}
+	server, regionEntry, err := resolveProvisionServer(serverFlag, regionCode, mode, r.Server)
+	if err != nil {
+		return err
 	}
 
 	cfg := loadConfig()
@@ -65,8 +141,12 @@ func Create(args []string) error {
 		return fmt.Errorf("context %q already exists; use a different name", name)
 	}
 
+	body, err := provisionRequestBody(publicKey, privateKey)
+	if err != nil {
+		return err
+	}
 	c := client.New(server, "")
-	resp, err := c.RawPost("/v1/provision", nil)
+	resp, err := c.RawPost("/v1/provision", body)
 	if err != nil {
 		return fmt.Errorf("provision failed: %w", err)
 	}
@@ -80,11 +160,7 @@ func Create(args []string) error {
 		return fmt.Errorf("provision failed (HTTP %d): %s", resp.StatusCode, errResp.Error)
 	}
 
-	var result struct {
-		TenantID string `json:"tenant_id"`
-		APIKey   string `json:"api_key"`
-		Status   string `json:"status"`
-	}
+	var result createResult
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return fmt.Errorf("decode response: %w", err)
 	}
@@ -100,10 +176,269 @@ func Create(args []string) error {
 		return fmt.Errorf("save config: %w", err)
 	}
 
+	if asJSON {
+		out := createOutput{
+			Context:    name,
+			TenantID:   result.TenantID,
+			APIKey:     result.APIKey,
+			Status:     result.Status,
+			Server:     server,
+			RegionCode: regionCode,
+			Mode:       mode,
+			Config:     configPath(),
+		}
+		if regionEntry != nil {
+			out.RegionCode = regionEntry.RegionCode
+			out.Mode = regionEntry.Mode
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
 	fmt.Printf("created %q (tenant: %s, status: %s)\n", name, result.TenantID, result.Status)
 	if cfg.CurrentContext == name {
 		fmt.Printf("switched to context %q\n", name)
 	}
 	fmt.Printf("config: %s\n", configPath())
 	return nil
+}
+
+const (
+	RegionModeTiDBCloudNative        = "tidbcloud_native"
+	RegionModeTiDBCloudStarter       = "tidbcloud_starter"
+	RegionModeTiDBCloudStarterLegacy = "tidb_cloud_starter"
+)
+
+type createResult struct {
+	TenantID string `json:"tenant_id"`
+	APIKey   string `json:"api_key"`
+	Status   string `json:"status"`
+}
+
+type createOutput struct {
+	Context    string `json:"context"`
+	TenantID   string `json:"tenant_id"`
+	APIKey     string `json:"api_key"`
+	Status     string `json:"status"`
+	Server     string `json:"server"`
+	RegionCode string `json:"region_code,omitempty"`
+	Mode       string `json:"mode,omitempty"`
+	Config     string `json:"config"`
+}
+
+func createUsage() string {
+	return "usage: drive9 create [--name NAME] [--region-code CODE] [--server URL] [--tidbcloud-public-key KEY] [--tidbcloud-private-key KEY] [--json]"
+}
+
+func provisionModeForCredentials(publicKey, privateKey string) string {
+	if strings.TrimSpace(publicKey) != "" || strings.TrimSpace(privateKey) != "" {
+		return RegionModeTiDBCloudNative
+	}
+	return RegionModeTiDBCloudStarter
+}
+
+func provisionRequestBody(publicKey, privateKey string) (io.Reader, error) {
+	if publicKey == "" && privateKey == "" {
+		return nil, nil
+	}
+	if publicKey == "" || privateKey == "" {
+		return nil, fmt.Errorf("tidbcloud_native create requires both public and private keys")
+	}
+	body := map[string]string{
+		"public_key":  publicKey,
+		"private_key": privateKey,
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(raw), nil
+}
+
+func resolveProvisionServer(serverFlag, regionCode, mode, fallbackServer string) (string, *RegionManifestEntry, error) {
+	if strings.TrimSpace(serverFlag) != "" {
+		return strings.TrimSpace(serverFlag), nil, nil
+	}
+	if strings.TrimSpace(regionCode) == "" {
+		return fallbackServer, nil, nil
+	}
+	manifest, err := fetchRegionManifest(context.Background(), regionManifestURL())
+	if err != nil {
+		return "", nil, err
+	}
+	entry, err := selectRegionServer(manifest.Regions, regionCode, mode)
+	if err != nil {
+		return "", nil, err
+	}
+	return entry.ServerURL, entry, nil
+}
+
+func selectRegionServer(entries []RegionManifestEntry, regionCode, mode string) (*RegionManifestEntry, error) {
+	regionCode = strings.TrimSpace(regionCode)
+	mode = normalizeRegionMode(mode)
+	var matches []RegionManifestEntry
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.RegionCode) == regionCode && normalizeRegionMode(entry.Mode) == mode {
+			matches = append(matches, entry)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("region %q does not support mode %q; run `drive9 region list`", regionCode, mode)
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("region %q mode %q matches multiple servers; pass --server explicitly", regionCode, mode)
+	}
+	return &matches[0], nil
+}
+
+func normalizeRegionMode(mode string) string {
+	switch strings.TrimSpace(mode) {
+	case RegionModeTiDBCloudStarterLegacy:
+		return RegionModeTiDBCloudStarter
+	default:
+		return strings.TrimSpace(mode)
+	}
+}
+
+func DeleteTenant(args []string) error {
+	serverFlag := ""
+	serverFlagGiven := false
+	apiKeyFlag := ""
+	apiKeyGiven := false
+	publicKeyFlag := ""
+	publicKeyGiven := false
+	privateKeyFlag := ""
+	privateKeyGiven := false
+	asJSON := false
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-h", "-help", "--help", "help":
+			_, _ = fmt.Fprintln(os.Stdout, deleteUsage())
+			return nil
+		case "--server":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--server requires an argument")
+			}
+			i++
+			serverFlag = args[i]
+			serverFlagGiven = true
+		case "--api-key":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--api-key requires an argument")
+			}
+			i++
+			apiKeyFlag = args[i]
+			apiKeyGiven = true
+		case "--tidbcloud-public-key":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--tidbcloud-public-key requires an argument")
+			}
+			i++
+			publicKeyFlag = args[i]
+			publicKeyGiven = true
+		case "--tidbcloud-private-key":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--tidbcloud-private-key requires an argument")
+			}
+			i++
+			privateKeyFlag = args[i]
+			privateKeyGiven = true
+		case "--json":
+			asJSON = true
+		default:
+			return fmt.Errorf("unknown flag %q\n%s", args[i], deleteUsage())
+		}
+	}
+
+	if err := rejectEmptyFlag("server", serverFlag, serverFlagGiven); err != nil {
+		return err
+	}
+	if err := rejectEmptyFlag("api-key", apiKeyFlag, apiKeyGiven); err != nil {
+		return err
+	}
+	if err := rejectEmptyFlag("tidbcloud-public-key", publicKeyFlag, publicKeyGiven); err != nil {
+		return err
+	}
+	if err := rejectEmptyFlag("tidbcloud-private-key", privateKeyFlag, privateKeyGiven); err != nil {
+		return err
+	}
+
+	r := ResolveCredentials()
+	server := strings.TrimSpace(serverFlag)
+	if server == "" {
+		server = r.Server
+	}
+	apiKey := strings.TrimSpace(apiKeyFlag)
+	if apiKey == "" && r.Kind == CredentialOwner {
+		apiKey = r.APIKey
+	}
+	if apiKey == "" {
+		return fmt.Errorf("delete requires an owner API key; pass --api-key or set %s", EnvAPIKey)
+	}
+	envPublicKey := consumeEnv(EnvTiDBCloudPublicKey)
+	envPrivateKey := consumeEnv(EnvTiDBCloudPrivateKey)
+	publicKey := strings.TrimSpace(publicKeyFlag)
+	if publicKey == "" {
+		publicKey = envPublicKey
+	}
+	privateKey := strings.TrimSpace(privateKeyFlag)
+	if privateKey == "" {
+		privateKey = envPrivateKey
+	}
+	publicKey = strings.TrimSpace(publicKey)
+	privateKey = strings.TrimSpace(privateKey)
+	body, err := deprovisionRequestBody(publicKey, privateKey)
+	if err != nil {
+		return err
+	}
+
+	c := client.New(server, apiKey)
+	resp, err := c.RawDelete("/v1/tenant", body)
+	if err != nil {
+		return fmt.Errorf("delete tenant failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var result struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("delete tenant failed (HTTP %d): %s", resp.StatusCode, result.Error)
+	}
+	if result.Status == "" {
+		result.Status = "deleting"
+	}
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(map[string]string{
+			"status": result.Status,
+			"server": server,
+		})
+	}
+	fmt.Printf("delete accepted (status: %s)\n", result.Status)
+	return nil
+}
+
+func deleteUsage() string {
+	return "usage: drive9 delete [--server URL] [--api-key KEY] [--tidbcloud-public-key KEY] [--tidbcloud-private-key KEY] [--json]"
+}
+
+func deprovisionRequestBody(publicKey, privateKey string) (io.Reader, error) {
+	if publicKey == "" && privateKey == "" {
+		return nil, nil
+	}
+	if publicKey == "" || privateKey == "" {
+		return nil, fmt.Errorf("tidbcloud_native delete requires both public and private keys")
+	}
+	raw, err := json.Marshal(map[string]string{
+		"public_key":  publicKey,
+		"private_key": privateKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(raw), nil
 }

--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -389,13 +389,24 @@ func DeleteTenant(args []string) error {
 		return fmt.Errorf("delete tenant failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	rawResp, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read delete tenant response: %w", err)
+	}
 	var result struct {
 		Status string `json:"status"`
 		Error  string `json:"error"`
 	}
-	_ = json.NewDecoder(resp.Body).Decode(&result)
+	_ = json.Unmarshal(rawResp, &result)
 	if resp.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("delete tenant failed (HTTP %d): %s", resp.StatusCode, result.Error)
+		msg := strings.TrimSpace(result.Error)
+		if msg == "" {
+			msg = strings.TrimSpace(string(rawResp))
+		}
+		if msg == "" {
+			msg = http.StatusText(resp.StatusCode)
+		}
+		return fmt.Errorf("delete tenant failed (HTTP %d): %s", resp.StatusCode, msg)
 	}
 	if result.Status == "" {
 		result.Status = "deleting"

--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -83,16 +83,16 @@ func Create(args []string) error {
 		}
 	}
 
-	if err := rejectEmptyFlag("server", serverFlag, serverFlagGiven); err != nil {
+	if err := rejectEmptyFlag("server", strings.TrimSpace(serverFlag), serverFlagGiven); err != nil {
 		return err
 	}
-	if err := rejectEmptyFlag("region-code", regionCodeFlag, regionCodeGiven); err != nil {
+	if err := rejectEmptyFlag("region-code", strings.TrimSpace(regionCodeFlag), regionCodeGiven); err != nil {
 		return err
 	}
-	if err := rejectEmptyFlag("tidbcloud-public-key", publicKeyFlag, publicKeyGiven); err != nil {
+	if err := rejectEmptyFlag("tidbcloud-public-key", strings.TrimSpace(publicKeyFlag), publicKeyGiven); err != nil {
 		return err
 	}
-	if err := rejectEmptyFlag("tidbcloud-private-key", privateKeyFlag, privateKeyGiven); err != nil {
+	if err := rejectEmptyFlag("tidbcloud-private-key", strings.TrimSpace(privateKeyFlag), privateKeyGiven); err != nil {
 		return err
 	}
 
@@ -188,8 +188,8 @@ func Create(args []string) error {
 			Config:     configPath(),
 		}
 		if regionEntry != nil {
-			out.RegionCode = regionEntry.RegionCode
-			out.Mode = regionEntry.Mode
+			out.RegionCode = strings.TrimSpace(regionEntry.RegionCode)
+			out.Mode = strings.TrimSpace(regionEntry.Mode)
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -269,7 +269,7 @@ func resolveProvisionServer(serverFlag, regionCode, mode, fallbackServer string)
 	if err != nil {
 		return "", nil, err
 	}
-	return entry.ServerURL, entry, nil
+	return strings.TrimSpace(entry.ServerURL), entry, nil
 }
 
 func selectRegionServer(entries []RegionManifestEntry, regionCode, mode string) (*RegionManifestEntry, error) {
@@ -341,16 +341,16 @@ func DeleteTenant(args []string) error {
 		}
 	}
 
-	if err := rejectEmptyFlag("server", serverFlag, serverFlagGiven); err != nil {
+	if err := rejectEmptyFlag("server", strings.TrimSpace(serverFlag), serverFlagGiven); err != nil {
 		return err
 	}
-	if err := rejectEmptyFlag("api-key", apiKeyFlag, apiKeyGiven); err != nil {
+	if err := rejectEmptyFlag("api-key", strings.TrimSpace(apiKeyFlag), apiKeyGiven); err != nil {
 		return err
 	}
-	if err := rejectEmptyFlag("tidbcloud-public-key", publicKeyFlag, publicKeyGiven); err != nil {
+	if err := rejectEmptyFlag("tidbcloud-public-key", strings.TrimSpace(publicKeyFlag), publicKeyGiven); err != nil {
 		return err
 	}
-	if err := rejectEmptyFlag("tidbcloud-private-key", privateKeyFlag, privateKeyGiven); err != nil {
+	if err := rejectEmptyFlag("tidbcloud-private-key", strings.TrimSpace(privateKeyFlag), privateKeyGiven); err != nil {
 		return err
 	}
 

--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -124,7 +124,7 @@ func Create(args []string) error {
 
 	mode := provisionModeForCredentials(publicKey, privateKey)
 	if mode == RegionModeTiDBCloudNative && (publicKey == "" || privateKey == "") {
-		return fmt.Errorf("tidbcloud_native create requires --tidbcloud-public-key and --tidbcloud-private-key, or %s/%s", EnvTiDBCloudPublicKey, EnvTiDBCloudPrivateKey)
+		return fmt.Errorf("tidb_cloud_native create requires --tidbcloud-public-key and --tidbcloud-private-key, or %s/%s", EnvTiDBCloudPublicKey, EnvTiDBCloudPrivateKey)
 	}
 	server, regionEntry, err := resolveProvisionServer(serverFlag, regionCode, mode, r.Server)
 	if err != nil {
@@ -204,9 +204,8 @@ func Create(args []string) error {
 }
 
 const (
-	RegionModeTiDBCloudNative        = "tidbcloud_native"
-	RegionModeTiDBCloudStarter       = "tidbcloud_starter"
-	RegionModeTiDBCloudStarterLegacy = "tidb_cloud_starter"
+	RegionModeTiDBCloudNative  = "tidb_cloud_native"
+	RegionModeTiDBCloudStarter = "tidb_cloud_starter"
 )
 
 type createResult struct {
@@ -242,7 +241,7 @@ func provisionRequestBody(publicKey, privateKey string) (io.Reader, error) {
 		return nil, nil
 	}
 	if publicKey == "" || privateKey == "" {
-		return nil, fmt.Errorf("tidbcloud_native create requires both public and private keys")
+		return nil, fmt.Errorf("tidb_cloud_native create requires both public and private keys")
 	}
 	body := map[string]string{
 		"public_key":  publicKey,
@@ -275,10 +274,10 @@ func resolveProvisionServer(serverFlag, regionCode, mode, fallbackServer string)
 
 func selectRegionServer(entries []RegionManifestEntry, regionCode, mode string) (*RegionManifestEntry, error) {
 	regionCode = strings.TrimSpace(regionCode)
-	mode = normalizeRegionMode(mode)
+	mode = strings.TrimSpace(mode)
 	var matches []RegionManifestEntry
 	for _, entry := range entries {
-		if strings.TrimSpace(entry.RegionCode) == regionCode && normalizeRegionMode(entry.Mode) == mode {
+		if strings.TrimSpace(entry.RegionCode) == regionCode && strings.TrimSpace(entry.Mode) == mode {
 			matches = append(matches, entry)
 		}
 	}
@@ -289,15 +288,6 @@ func selectRegionServer(entries []RegionManifestEntry, regionCode, mode string) 
 		return nil, fmt.Errorf("region %q mode %q matches multiple servers; pass --server explicitly", regionCode, mode)
 	}
 	return &matches[0], nil
-}
-
-func normalizeRegionMode(mode string) string {
-	switch strings.TrimSpace(mode) {
-	case RegionModeTiDBCloudStarterLegacy:
-		return RegionModeTiDBCloudStarter
-	default:
-		return strings.TrimSpace(mode)
-	}
 }
 
 func DeleteTenant(args []string) error {
@@ -431,7 +421,7 @@ func deprovisionRequestBody(publicKey, privateKey string) (io.Reader, error) {
 		return nil, nil
 	}
 	if publicKey == "" || privateKey == "" {
-		return nil, fmt.Errorf("tidbcloud_native delete requires both public and private keys")
+		return nil, fmt.Errorf("tidb_cloud_native delete requires both public and private keys")
 	}
 	raw, err := json.Marshal(map[string]string{
 		"public_key":  publicKey,

--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -13,11 +13,6 @@ import (
 	"github.com/mem9-ai/dat9/pkg/client"
 )
 
-const (
-	EnvTiDBCloudPublicKey  = "DRIVE9_PUBLIC_KEY"
-	EnvTiDBCloudPrivateKey = "DRIVE9_PRIVATE_KEY"
-)
-
 // Create provisions a new tenant and registers the returned API key as a
 // local owner context. Both steps are performed from a single Go code path:
 // Create calls ctxAdd(name, &Context{...}) after provisioning, which is the

--- a/cmd/drive9/cli/db_test.go
+++ b/cmd/drive9/cli/db_test.go
@@ -1,0 +1,514 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func clearProvisionEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		EnvVaultToken,
+		EnvAPIKey,
+		EnvServer,
+		EnvRegionCode,
+		EnvRegionManifestURL,
+		EnvTiDBCloudPublicKey,
+		EnvTiDBCloudPrivateKey,
+	} {
+		t.Setenv(name, "")
+		_ = os.Unsetenv(name)
+	}
+	resetCredentialCacheForTest()
+	t.Cleanup(resetCredentialCacheForTest)
+}
+
+func TestCreateUsesResolvedServerWithoutNativeBody(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	var called bool
+	var requestBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/provision" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("Authorization = %q, want empty for provision", got)
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		requestBody = string(raw)
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"tenant_id": "tenant-1",
+			"api_key":   "owner-key-1",
+			"status":    "active",
+		})
+	}))
+	defer ts.Close()
+
+	t.Setenv(EnvServer, ts.URL)
+	t.Setenv(EnvRegionManifestURL, "http://127.0.0.1:1/not-used")
+	resetCredentialCacheForTest()
+
+	out, err := captureStdoutE(t, func() error {
+		return Create([]string{"--name", "starter"})
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !called {
+		t.Fatal("provision server was not called")
+	}
+	if requestBody != "" {
+		t.Fatalf("request body = %q, want empty starter body", requestBody)
+	}
+	if !strings.Contains(out, `created "starter"`) {
+		t.Fatalf("output = %q, want created message", out)
+	}
+	cfg := loadConfig()
+	if cfg.CurrentContext != "starter" {
+		t.Fatalf("current context = %q, want starter", cfg.CurrentContext)
+	}
+	ctx := cfg.Contexts["starter"]
+	if ctx == nil || ctx.APIKey != "owner-key-1" || ctx.Server != ts.URL || ctx.Type != PrincipalOwner {
+		t.Fatalf("saved context = %#v", ctx)
+	}
+}
+
+func TestCreateServerOverrideSendsNativeBodyAndSkipsManifest(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	var manifestHits int32
+	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&manifestHits, 1)
+		http.Error(w, "manifest should not be fetched", http.StatusInternalServerError)
+	}))
+	defer manifest.Close()
+
+	var gotBody map[string]string
+	provision := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/provision" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"tenant_id": "tenant-native",
+			"api_key":   "owner-native",
+			"status":    "provisioning",
+		})
+	}))
+	defer provision.Close()
+
+	t.Setenv(EnvRegionManifestURL, manifest.URL)
+	t.Setenv(EnvRegionCode, "aws-us-east-1")
+	t.Setenv(EnvTiDBCloudPublicKey, "env-public-should-be-consumed")
+	t.Setenv(EnvTiDBCloudPrivateKey, "env-private-should-be-consumed")
+	resetCredentialCacheForTest()
+
+	out, err := captureStdoutE(t, func() error {
+		return Create([]string{
+			"--name", "native",
+			"--server", provision.URL,
+			"--region-code", "aws-us-east-1",
+			"--tidbcloud-public-key", "public-1",
+			"--tidbcloud-private-key", "private-1",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if atomic.LoadInt32(&manifestHits) != 0 {
+		t.Fatalf("manifest hits = %d, want 0 when --server is set", manifestHits)
+	}
+	if gotBody["public_key"] != "public-1" || gotBody["private_key"] != "private-1" {
+		t.Fatalf("request body = %#v", gotBody)
+	}
+	if _, ok := gotBody["database_name"]; ok {
+		t.Fatalf("request body unexpectedly included database_name: %#v", gotBody)
+	}
+	if _, ok := os.LookupEnv(EnvTiDBCloudPublicKey); ok {
+		t.Fatalf("%s was not consumed", EnvTiDBCloudPublicKey)
+	}
+	if _, ok := os.LookupEnv(EnvTiDBCloudPrivateKey); ok {
+		t.Fatalf("%s was not consumed", EnvTiDBCloudPrivateKey)
+	}
+	var result map[string]string
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode json output: %v\n%s", err, out)
+	}
+	if result["server"] != provision.URL {
+		t.Fatalf("json server = %q, want %q", result["server"], provision.URL)
+	}
+	if _, ok := result["region_code"]; ok {
+		t.Fatalf("json output included ignored region_code: %#v", result)
+	}
+	if result["mode"] != RegionModeTiDBCloudNative {
+		t.Fatalf("json mode = %q, want %q", result["mode"], RegionModeTiDBCloudNative)
+	}
+}
+
+func TestCreateRegionCodeSelectsNativeServer(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	var nativeHits int32
+	var starterHits int32
+	var gotBody map[string]string
+	native := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&nativeHits, 1)
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/provision" {
+			t.Fatalf("unexpected native request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode native body: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"tenant_id": "tenant-native",
+			"api_key":   "owner-native",
+			"status":    "active",
+		})
+	}))
+	defer native.Close()
+	starter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&starterHits, 1)
+		http.Error(w, "starter server should not be used", http.StatusInternalServerError)
+	}))
+	defer starter.Close()
+	manifest := newRegionManifestTestServer(t, []RegionManifestEntry{
+		{
+			RegionCode: "aws-us-east-1",
+			Mode:       RegionModeTiDBCloudStarterLegacy,
+			ServerURL:  starter.URL,
+		},
+		{
+			RegionCode: "aws-us-east-1",
+			Mode:       RegionModeTiDBCloudNative,
+			ServerURL:  native.URL,
+		},
+	})
+	defer manifest.Close()
+
+	t.Setenv(EnvRegionManifestURL, manifest.URL)
+	resetCredentialCacheForTest()
+
+	if _, err := captureStdoutE(t, func() error {
+		return Create([]string{
+			"--name", "native-region",
+			"--region-code", "aws-us-east-1",
+			"--tidbcloud-public-key", "public-1",
+			"--tidbcloud-private-key", "private-1",
+		})
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if atomic.LoadInt32(&nativeHits) != 1 {
+		t.Fatalf("native hits = %d, want 1", nativeHits)
+	}
+	if atomic.LoadInt32(&starterHits) != 0 {
+		t.Fatalf("starter hits = %d, want 0", starterHits)
+	}
+	if gotBody["public_key"] != "public-1" || gotBody["private_key"] != "private-1" {
+		t.Fatalf("native body = %#v", gotBody)
+	}
+	if _, ok := gotBody["database_name"]; ok {
+		t.Fatalf("native body unexpectedly included database_name: %#v", gotBody)
+	}
+	cfg := loadConfig()
+	if got := cfg.Contexts["native-region"].Server; got != native.URL {
+		t.Fatalf("saved server = %q, want native %q", got, native.URL)
+	}
+}
+
+func TestCreateRegionCodeSelectsStarterWithoutBody(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	var starterHits int32
+	var requestBody string
+	starter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&starterHits, 1)
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/provision" {
+			t.Fatalf("unexpected starter request %s %s", r.Method, r.URL.Path)
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read starter body: %v", err)
+		}
+		requestBody = string(raw)
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"tenant_id": "tenant-starter",
+			"api_key":   "owner-starter",
+			"status":    "active",
+		})
+	}))
+	defer starter.Close()
+	native := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "native server should not be used", http.StatusInternalServerError)
+	}))
+	defer native.Close()
+	manifest := newRegionManifestTestServer(t, []RegionManifestEntry{
+		{
+			RegionCode: "aws-us-east-1",
+			Mode:       RegionModeTiDBCloudNative,
+			ServerURL:  native.URL,
+		},
+		{
+			RegionCode: "aws-us-east-1",
+			Mode:       RegionModeTiDBCloudStarterLegacy,
+			ServerURL:  starter.URL,
+		},
+	})
+	defer manifest.Close()
+
+	t.Setenv(EnvRegionManifestURL, manifest.URL)
+	t.Setenv(EnvRegionCode, "aws-us-east-1")
+	resetCredentialCacheForTest()
+
+	if _, err := captureStdoutE(t, func() error {
+		return Create([]string{"--name", "starter-region"})
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if atomic.LoadInt32(&starterHits) != 1 {
+		t.Fatalf("starter hits = %d, want 1", starterHits)
+	}
+	if requestBody != "" {
+		t.Fatalf("starter body = %q, want empty", requestBody)
+	}
+	if got := readTrimEnv(EnvRegionCode); got != "aws-us-east-1" {
+		t.Fatalf("%s = %q, want preserved region code", EnvRegionCode, got)
+	}
+}
+
+func TestCreateRejectsHalfTiDBCloudKeyBeforeManifestFetch(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	var manifestHits int32
+	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&manifestHits, 1)
+		_ = json.NewEncoder(w).Encode(RegionManifest{Service: "drive9", Regions: []RegionManifestEntry{
+			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudNative, ServerURL: "https://native.example"},
+		}})
+	}))
+	defer manifest.Close()
+
+	t.Setenv(EnvRegionManifestURL, manifest.URL)
+	resetCredentialCacheForTest()
+
+	err := Create([]string{
+		"--name", "bad-native",
+		"--region-code", "aws-us-east-1",
+		"--tidbcloud-public-key", "public-1",
+	})
+	if err == nil {
+		t.Fatal("Create error = nil, want missing private key error")
+	}
+	if !strings.Contains(err.Error(), "tidbcloud_native create requires") {
+		t.Fatalf("Create error = %q", err)
+	}
+	if atomic.LoadInt32(&manifestHits) != 0 {
+		t.Fatalf("manifest hits = %d, want 0 before key validation succeeds", manifestHits)
+	}
+}
+
+func TestCreateRejectsDatabaseNameFlag(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	err := Create([]string{
+		"--server", "https://drive9.example",
+		"--tidbcloud-public-key", "public-1",
+		"--tidbcloud-private-key", "private-1",
+		"--database-name", "appdb",
+	})
+	if err == nil {
+		t.Fatal("Create error = nil, want unknown flag error")
+	}
+	if !strings.Contains(err.Error(), `unknown flag "--database-name"`) {
+		t.Fatalf("Create error = %q", err)
+	}
+}
+
+func TestDeleteTenantUsesOwnerContext(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	var called bool
+	var requestBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/tenant" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer owner-key" {
+			t.Fatalf("Authorization = %q, want Bearer owner-key", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "" {
+			t.Fatalf("Content-Type = %q, want empty for nil delete body", got)
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		requestBody = string(raw)
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "delete_queued"})
+	}))
+	defer ts.Close()
+
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "owner", &Context{Type: PrincipalOwner, APIKey: "owner-key", Server: ts.URL}); err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	resetCredentialCacheForTest()
+
+	out, err := captureStdoutE(t, func() error {
+		return DeleteTenant(nil)
+	})
+	if err != nil {
+		t.Fatalf("DeleteTenant: %v", err)
+	}
+	if !called {
+		t.Fatal("delete server was not called")
+	}
+	if requestBody != "" {
+		t.Fatalf("delete body = %q, want empty", requestBody)
+	}
+	if !strings.Contains(out, "delete accepted (status: delete_queued)") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestDeleteTenantServerOverrideSendsNativeBody(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	var gotBody map[string]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/tenant" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer owner-override" {
+			t.Fatalf("Authorization = %q, want Bearer owner-override", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleting"})
+	}))
+	defer ts.Close()
+
+	out, err := captureStdoutE(t, func() error {
+		return DeleteTenant([]string{
+			"--server", ts.URL,
+			"--api-key", "owner-override",
+			"--tidbcloud-public-key", "public-1",
+			"--tidbcloud-private-key", "private-1",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("DeleteTenant: %v", err)
+	}
+	if gotBody["public_key"] != "public-1" || gotBody["private_key"] != "private-1" {
+		t.Fatalf("delete body = %#v", gotBody)
+	}
+	var result map[string]string
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode json output: %v\n%s", err, out)
+	}
+	if result["status"] != "deleting" || result["server"] != ts.URL {
+		t.Fatalf("delete json = %#v", result)
+	}
+}
+
+func TestDeleteTenantRejectsFSScopedContext(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "scoped", &Context{Type: PrincipalFSScoped, APIKey: "scoped-key", Server: "https://drive9.example"}); err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	resetCredentialCacheForTest()
+
+	err := DeleteTenant(nil)
+	if err == nil {
+		t.Fatal("DeleteTenant error = nil, want owner API key error")
+	}
+	if !strings.Contains(err.Error(), "owner API key") {
+		t.Fatalf("DeleteTenant error = %q", err)
+	}
+}
+
+func TestDeleteTenantRejectsHalfTiDBCloudKey(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	cfg := loadConfig()
+	if _, err := ctxAdd(cfg, "owner", &Context{Type: PrincipalOwner, APIKey: "owner-key", Server: "https://drive9.example"}); err != nil {
+		t.Fatalf("ctxAdd: %v", err)
+	}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	resetCredentialCacheForTest()
+
+	err := DeleteTenant([]string{"--tidbcloud-public-key", "public-1"})
+	if err == nil {
+		t.Fatal("DeleteTenant error = nil, want missing private key error")
+	}
+	if !strings.Contains(err.Error(), "requires both public and private keys") {
+		t.Fatalf("DeleteTenant error = %q", err)
+	}
+}
+
+func newRegionManifestTestServer(t *testing.T, entries []RegionManifestEntry) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("manifest method = %s, want GET", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RegionManifest{
+			Service: "drive9",
+			Default: &RegionManifestDefault{
+				RegionCode: "aws-ap-southeast-1",
+				Mode:       RegionModeTiDBCloudStarterLegacy,
+			},
+			Regions: entries,
+		})
+	}))
+}

--- a/cmd/drive9/cli/db_test.go
+++ b/cmd/drive9/cli/db_test.go
@@ -33,10 +33,8 @@ func TestCreateUsesResolvedServerWithoutNativeBody(t *testing.T) {
 	withIsolatedHome(t)
 	clearProvisionEnv(t)
 
-	var called bool
-	var requestBody string
+	requestBodyCh := make(chan string, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/provision" {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
@@ -47,7 +45,7 @@ func TestCreateUsesResolvedServerWithoutNativeBody(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read body: %v", err)
 		}
-		requestBody = string(raw)
+		requestBodyCh <- string(raw)
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"tenant_id": "tenant-1",
@@ -67,11 +65,13 @@ func TestCreateUsesResolvedServerWithoutNativeBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if !called {
+	select {
+	case requestBody := <-requestBodyCh:
+		if requestBody != "" {
+			t.Fatalf("request body = %q, want empty starter body", requestBody)
+		}
+	default:
 		t.Fatal("provision server was not called")
-	}
-	if requestBody != "" {
-		t.Fatalf("request body = %q, want empty starter body", requestBody)
 	}
 	if !strings.Contains(out, `created "starter"`) {
 		t.Fatalf("output = %q, want created message", out)
@@ -97,7 +97,7 @@ func TestCreateServerOverrideSendsNativeBodyAndSkipsManifest(t *testing.T) {
 	}))
 	defer manifest.Close()
 
-	var gotBody map[string]string
+	bodyCh := make(chan map[string]string, 1)
 	provision := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/provision" {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
@@ -105,9 +105,11 @@ func TestCreateServerOverrideSendsNativeBodyAndSkipsManifest(t *testing.T) {
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
 			t.Fatalf("Content-Type = %q, want application/json", got)
 		}
+		var gotBody map[string]string
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Fatalf("decode request body: %v", err)
 		}
+		bodyCh <- gotBody
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"tenant_id": "tenant-native",
@@ -138,6 +140,12 @@ func TestCreateServerOverrideSendsNativeBodyAndSkipsManifest(t *testing.T) {
 	}
 	if atomic.LoadInt32(&manifestHits) != 0 {
 		t.Fatalf("manifest hits = %d, want 0 when --server is set", manifestHits)
+	}
+	var gotBody map[string]string
+	select {
+	case gotBody = <-bodyCh:
+	default:
+		t.Fatal("provision server was not called")
 	}
 	if gotBody["public_key"] != "public-1" || gotBody["private_key"] != "private-1" {
 		t.Fatalf("request body = %#v", gotBody)
@@ -172,15 +180,17 @@ func TestCreateRegionCodeSelectsNativeServer(t *testing.T) {
 
 	var nativeHits int32
 	var starterHits int32
-	var gotBody map[string]string
+	bodyCh := make(chan map[string]string, 1)
 	native := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&nativeHits, 1)
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/provision" {
 			t.Fatalf("unexpected native request %s %s", r.Method, r.URL.Path)
 		}
+		var gotBody map[string]string
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Fatalf("decode native body: %v", err)
 		}
+		bodyCh <- gotBody
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"tenant_id": "tenant-native",
@@ -227,6 +237,12 @@ func TestCreateRegionCodeSelectsNativeServer(t *testing.T) {
 	if atomic.LoadInt32(&starterHits) != 0 {
 		t.Fatalf("starter hits = %d, want 0", starterHits)
 	}
+	var gotBody map[string]string
+	select {
+	case gotBody = <-bodyCh:
+	default:
+		t.Fatal("native server was not called")
+	}
 	if gotBody["public_key"] != "public-1" || gotBody["private_key"] != "private-1" {
 		t.Fatalf("native body = %#v", gotBody)
 	}
@@ -244,7 +260,7 @@ func TestCreateRegionCodeSelectsStarterWithoutBody(t *testing.T) {
 	clearProvisionEnv(t)
 
 	var starterHits int32
-	var requestBody string
+	requestBodyCh := make(chan string, 1)
 	starter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&starterHits, 1)
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/provision" {
@@ -254,7 +270,7 @@ func TestCreateRegionCodeSelectsStarterWithoutBody(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read starter body: %v", err)
 		}
-		requestBody = string(raw)
+		requestBodyCh <- string(raw)
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"tenant_id": "tenant-starter",
@@ -293,8 +309,13 @@ func TestCreateRegionCodeSelectsStarterWithoutBody(t *testing.T) {
 	if atomic.LoadInt32(&starterHits) != 1 {
 		t.Fatalf("starter hits = %d, want 1", starterHits)
 	}
-	if requestBody != "" {
-		t.Fatalf("starter body = %q, want empty", requestBody)
+	select {
+	case requestBody := <-requestBodyCh:
+		if requestBody != "" {
+			t.Fatalf("starter body = %q, want empty", requestBody)
+		}
+	default:
+		t.Fatal("starter server was not called")
 	}
 	if got := readTrimEnv(EnvRegionCode); got != "aws-us-east-1" {
 		t.Fatalf("%s = %q, want preserved region code", EnvRegionCode, got)
@@ -351,14 +372,25 @@ func TestCreateRejectsDatabaseNameFlag(t *testing.T) {
 	}
 }
 
+func TestCreateRejectsWhitespaceServerFlag(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	err := Create([]string{"--server", "   "})
+	if err == nil {
+		t.Fatal("Create error = nil, want whitespace flag error")
+	}
+	if !strings.Contains(err.Error(), "--server was given an empty value") {
+		t.Fatalf("Create error = %q", err)
+	}
+}
+
 func TestDeleteTenantUsesOwnerContext(t *testing.T) {
 	withIsolatedHome(t)
 	clearProvisionEnv(t)
 
-	var called bool
-	var requestBody string
+	requestBodyCh := make(chan string, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
 		if r.Method != http.MethodDelete || r.URL.Path != "/v1/tenant" {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
@@ -372,7 +404,7 @@ func TestDeleteTenantUsesOwnerContext(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read body: %v", err)
 		}
-		requestBody = string(raw)
+		requestBodyCh <- string(raw)
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(map[string]string{"status": "delete_queued"})
 	}))
@@ -393,11 +425,13 @@ func TestDeleteTenantUsesOwnerContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteTenant: %v", err)
 	}
-	if !called {
+	select {
+	case requestBody := <-requestBodyCh:
+		if requestBody != "" {
+			t.Fatalf("delete body = %q, want empty", requestBody)
+		}
+	default:
 		t.Fatal("delete server was not called")
-	}
-	if requestBody != "" {
-		t.Fatalf("delete body = %q, want empty", requestBody)
 	}
 	if !strings.Contains(out, "delete accepted (status: delete_queued)") {
 		t.Fatalf("output = %q", out)
@@ -408,7 +442,7 @@ func TestDeleteTenantServerOverrideSendsNativeBody(t *testing.T) {
 	withIsolatedHome(t)
 	clearProvisionEnv(t)
 
-	var gotBody map[string]string
+	bodyCh := make(chan map[string]string, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete || r.URL.Path != "/v1/tenant" {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
@@ -419,9 +453,11 @@ func TestDeleteTenantServerOverrideSendsNativeBody(t *testing.T) {
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
 			t.Fatalf("Content-Type = %q, want application/json", got)
 		}
+		var gotBody map[string]string
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Fatalf("decode body: %v", err)
 		}
+		bodyCh <- gotBody
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleting"})
 	}))
@@ -439,6 +475,12 @@ func TestDeleteTenantServerOverrideSendsNativeBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteTenant: %v", err)
 	}
+	var gotBody map[string]string
+	select {
+	case gotBody = <-bodyCh:
+	default:
+		t.Fatal("delete server was not called")
+	}
 	if gotBody["public_key"] != "public-1" || gotBody["private_key"] != "private-1" {
 		t.Fatalf("delete body = %#v", gotBody)
 	}
@@ -448,6 +490,38 @@ func TestDeleteTenantServerOverrideSendsNativeBody(t *testing.T) {
 	}
 	if result["status"] != "deleting" || result["server"] != ts.URL {
 		t.Fatalf("delete json = %#v", result)
+	}
+}
+
+func TestDeleteTenantFallsBackToRawErrorBody(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream unavailable"))
+	}))
+	defer ts.Close()
+
+	err := DeleteTenant([]string{"--server", ts.URL, "--api-key", "owner-key"})
+	if err == nil {
+		t.Fatal("DeleteTenant error = nil, want HTTP error")
+	}
+	if !strings.Contains(err.Error(), "upstream unavailable") {
+		t.Fatalf("DeleteTenant error = %q", err)
+	}
+}
+
+func TestDeleteTenantRejectsWhitespaceAPIKeyFlag(t *testing.T) {
+	withIsolatedHome(t)
+	clearProvisionEnv(t)
+
+	err := DeleteTenant([]string{"--api-key", "   "})
+	if err == nil {
+		t.Fatal("DeleteTenant error = nil, want whitespace flag error")
+	}
+	if !strings.Contains(err.Error(), "--api-key was given an empty value") {
+		t.Fatalf("DeleteTenant error = %q", err)
 	}
 }
 
@@ -502,12 +576,16 @@ func newRegionManifestTestServer(t *testing.T, entries []RegionManifestEntry) *h
 			t.Fatalf("manifest method = %s, want GET", r.Method)
 		}
 		w.Header().Set("Content-Type", "application/json")
+		var defaultEntry *RegionManifestDefault
+		if len(entries) > 0 {
+			defaultEntry = &RegionManifestDefault{
+				RegionCode: entries[0].RegionCode,
+				Mode:       entries[0].Mode,
+			}
+		}
 		_ = json.NewEncoder(w).Encode(RegionManifest{
 			Service: "drive9",
-			Default: &RegionManifestDefault{
-				RegionCode: "aws-ap-southeast-1",
-				Mode:       RegionModeTiDBCloudStarter,
-			},
+			Default: defaultEntry,
 			Regions: entries,
 		})
 	}))

--- a/cmd/drive9/cli/db_test.go
+++ b/cmd/drive9/cli/db_test.go
@@ -197,7 +197,7 @@ func TestCreateRegionCodeSelectsNativeServer(t *testing.T) {
 	manifest := newRegionManifestTestServer(t, []RegionManifestEntry{
 		{
 			RegionCode: "aws-us-east-1",
-			Mode:       RegionModeTiDBCloudStarterLegacy,
+			Mode:       RegionModeTiDBCloudStarter,
 			ServerURL:  starter.URL,
 		},
 		{
@@ -275,7 +275,7 @@ func TestCreateRegionCodeSelectsStarterWithoutBody(t *testing.T) {
 		},
 		{
 			RegionCode: "aws-us-east-1",
-			Mode:       RegionModeTiDBCloudStarterLegacy,
+			Mode:       RegionModeTiDBCloudStarter,
 			ServerURL:  starter.URL,
 		},
 	})
@@ -325,7 +325,7 @@ func TestCreateRejectsHalfTiDBCloudKeyBeforeManifestFetch(t *testing.T) {
 	if err == nil {
 		t.Fatal("Create error = nil, want missing private key error")
 	}
-	if !strings.Contains(err.Error(), "tidbcloud_native create requires") {
+	if !strings.Contains(err.Error(), "tidb_cloud_native create requires") {
 		t.Fatalf("Create error = %q", err)
 	}
 	if atomic.LoadInt32(&manifestHits) != 0 {
@@ -506,7 +506,7 @@ func newRegionManifestTestServer(t *testing.T, entries []RegionManifestEntry) *h
 			Service: "drive9",
 			Default: &RegionManifestDefault{
 				RegionCode: "aws-ap-southeast-1",
-				Mode:       RegionModeTiDBCloudStarterLegacy,
+				Mode:       RegionModeTiDBCloudStarter,
 			},
 			Regions: entries,
 		})

--- a/cmd/drive9/cli/db_test.go
+++ b/cmd/drive9/cli/db_test.go
@@ -211,9 +211,9 @@ func TestCreateRegionCodeSelectsNativeServer(t *testing.T) {
 			ServerURL:  starter.URL,
 		},
 		{
-			RegionCode: "aws-us-east-1",
-			Mode:       RegionModeTiDBCloudNative,
-			ServerURL:  native.URL,
+			RegionCode: " aws-us-east-1 ",
+			Mode:       " " + RegionModeTiDBCloudNative + " ",
+			ServerURL:  " " + native.URL + " ",
 		},
 	})
 	defer manifest.Close()
@@ -221,14 +221,16 @@ func TestCreateRegionCodeSelectsNativeServer(t *testing.T) {
 	t.Setenv(EnvRegionManifestURL, manifest.URL)
 	resetCredentialCacheForTest()
 
-	if _, err := captureStdoutE(t, func() error {
+	out, err := captureStdoutE(t, func() error {
 		return Create([]string{
 			"--name", "native-region",
 			"--region-code", "aws-us-east-1",
 			"--tidbcloud-public-key", "public-1",
 			"--tidbcloud-private-key", "private-1",
+			"--json",
 		})
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if atomic.LoadInt32(&nativeHits) != 1 {
@@ -248,6 +250,13 @@ func TestCreateRegionCodeSelectsNativeServer(t *testing.T) {
 	}
 	if _, ok := gotBody["database_name"]; ok {
 		t.Fatalf("native body unexpectedly included database_name: %#v", gotBody)
+	}
+	var result map[string]string
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode json output: %v\n%s", err, out)
+	}
+	if result["region_code"] != "aws-us-east-1" || result["mode"] != RegionModeTiDBCloudNative || result["server"] != native.URL {
+		t.Fatalf("json output = %#v, want trimmed native manifest values", result)
 	}
 	cfg := loadConfig()
 	if got := cfg.Contexts["native-region"].Server; got != native.URL {

--- a/cmd/drive9/cli/db_test.go
+++ b/cmd/drive9/cli/db_test.go
@@ -112,9 +112,11 @@ func TestCreateServerOverrideSendsNativeBodyAndSkipsManifest(t *testing.T) {
 		bodyCh <- gotBody
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(map[string]string{
-			"tenant_id": "tenant-native",
-			"api_key":   "owner-native",
-			"status":    "provisioning",
+			"tenant_id":      "tenant-native",
+			"api_key":        "owner-native",
+			"status":         "provisioning",
+			"cloud_provider": "aws",
+			"region":         "us-east-1",
 		})
 	}))
 	defer provision.Close()
@@ -169,8 +171,16 @@ func TestCreateServerOverrideSendsNativeBodyAndSkipsManifest(t *testing.T) {
 	if _, ok := result["region_code"]; ok {
 		t.Fatalf("json output included ignored region_code: %#v", result)
 	}
-	if result["mode"] != RegionModeTiDBCloudNative {
-		t.Fatalf("json mode = %q, want %q", result["mode"], RegionModeTiDBCloudNative)
+	if result["mode"] != "TiDBCloud" {
+		t.Fatalf("json mode = %q, want TiDBCloud", result["mode"])
+	}
+	if result["cloud_provider"] != "aws" || result["region"] != "us-east-1" {
+		t.Fatalf("json cloud/region = %#v", result)
+	}
+	cfg := loadConfig()
+	gotCtx := cfg.Contexts["native"]
+	if gotCtx == nil || gotCtx.Mode != "TiDBCloud" || gotCtx.CloudProvider != "aws" || gotCtx.Region != "us-east-1" {
+		t.Fatalf("saved native context = %#v", gotCtx)
 	}
 }
 
@@ -193,9 +203,11 @@ func TestCreateRegionCodeSelectsNativeServer(t *testing.T) {
 		bodyCh <- gotBody
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(map[string]string{
-			"tenant_id": "tenant-native",
-			"api_key":   "owner-native",
-			"status":    "active",
+			"tenant_id":      "tenant-native",
+			"api_key":        "owner-native",
+			"status":         "active",
+			"cloud_provider": "aws",
+			"region":         "us-east-1",
 		})
 	}))
 	defer native.Close()
@@ -255,12 +267,19 @@ func TestCreateRegionCodeSelectsNativeServer(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &result); err != nil {
 		t.Fatalf("decode json output: %v\n%s", err, out)
 	}
-	if result["region_code"] != "aws-us-east-1" || result["mode"] != RegionModeTiDBCloudNative || result["server"] != native.URL {
+	if result["region_code"] != "aws-us-east-1" || result["mode"] != "TiDBCloud" || result["server"] != native.URL {
 		t.Fatalf("json output = %#v, want trimmed native manifest values", result)
 	}
+	if result["cloud_provider"] != "aws" || result["region"] != "us-east-1" {
+		t.Fatalf("json cloud/region = %#v", result)
+	}
 	cfg := loadConfig()
-	if got := cfg.Contexts["native-region"].Server; got != native.URL {
+	saved := cfg.Contexts["native-region"]
+	if got := saved.Server; got != native.URL {
 		t.Fatalf("saved server = %q, want native %q", got, native.URL)
+	}
+	if saved.Mode != "TiDBCloud" || saved.CloudProvider != "aws" || saved.Region != "us-east-1" {
+		t.Fatalf("saved native context = %#v", saved)
 	}
 }
 

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -524,7 +524,9 @@ func mountBackgroundEnv(environ []string, req mountBackgroundRequest) []string {
 	for _, kv := range environ {
 		if strings.HasPrefix(kv, EnvServer+"=") ||
 			strings.HasPrefix(kv, EnvAPIKey+"=") ||
-			strings.HasPrefix(kv, EnvVaultToken+"=") {
+			strings.HasPrefix(kv, EnvVaultToken+"=") ||
+			strings.HasPrefix(kv, EnvTiDBCloudPublicKey+"=") ||
+			strings.HasPrefix(kv, EnvTiDBCloudPrivateKey+"=") {
 			continue
 		}
 		out = append(out, kv)

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -1001,6 +1001,8 @@ func TestMountBackgroundEnvSnapshotsCredentials(t *testing.T) {
 		EnvServer + "=https://old.example",
 		EnvAPIKey + "=old-key",
 		EnvVaultToken + "=old-token",
+		EnvTiDBCloudPublicKey + "=tidb-public",
+		EnvTiDBCloudPrivateKey + "=tidb-private",
 	}, mountBackgroundRequest{
 		Server: "https://drive9.example",
 		Token:  "jwt-token",

--- a/cmd/drive9/cli/region.go
+++ b/cmd/drive9/cli/region.go
@@ -26,12 +26,12 @@ var fallbackRegionManifest = RegionManifest{
 	Service: "drive9",
 	Default: &RegionManifestDefault{
 		RegionCode: "aws-ap-southeast-1",
-		Mode:       RegionModeTiDBCloudStarterLegacy,
+		Mode:       RegionModeTiDBCloudStarter,
 	},
 	Regions: []RegionManifestEntry{
 		{
 			RegionCode: "aws-ap-southeast-1",
-			Mode:       RegionModeTiDBCloudStarterLegacy,
+			Mode:       RegionModeTiDBCloudStarter,
 			ServerURL:  defaultServerURL,
 		},
 	},
@@ -177,9 +177,10 @@ func validateRegionManifest(manifest *RegionManifest) error {
 		if strings.TrimSpace(entry.ServerURL) == "" {
 			return fmt.Errorf("region manifest entry %d missing server_url", i)
 		}
-		key := strings.TrimSpace(entry.RegionCode) + "\x00" + normalizeRegionMode(entry.Mode)
+		mode := strings.TrimSpace(entry.Mode)
+		key := strings.TrimSpace(entry.RegionCode) + "\x00" + mode
 		if first, ok := seen[key]; ok {
-			return fmt.Errorf("region manifest entries %d and %d duplicate region_code %q mode %q", first, i, strings.TrimSpace(entry.RegionCode), normalizeRegionMode(entry.Mode))
+			return fmt.Errorf("region manifest entries %d and %d duplicate region_code %q mode %q", first, i, strings.TrimSpace(entry.RegionCode), mode)
 		}
 		seen[key] = i
 	}
@@ -199,7 +200,7 @@ func sortRegionManifestEntries(entries []RegionManifestEntry) {
 }
 
 func regionModeLabel(mode string) string {
-	switch normalizeRegionMode(mode) {
+	switch strings.TrimSpace(mode) {
 	case RegionModeTiDBCloudStarter:
 		return "Anonymous"
 	case RegionModeTiDBCloudNative:

--- a/cmd/drive9/cli/region.go
+++ b/cmd/drive9/cli/region.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+)
+
+var errRegionManifestUnavailable = errors.New("region manifest unavailable")
+
+const (
+	EnvRegionCode        = "DRIVE9_REGION_CODE"
+	EnvRegionManifestURL = "DRIVE9_REGION_MANIFEST_URL"
+
+	defaultRegionManifestURL = "https://drive9.ai/manifest/regions/drive9-regions.json"
+)
+
+var fallbackRegionManifest = RegionManifest{
+	Service: "drive9",
+	Default: &RegionManifestDefault{
+		RegionCode: "aws-ap-southeast-1",
+		Mode:       RegionModeTiDBCloudStarterLegacy,
+	},
+	Regions: []RegionManifestEntry{
+		{
+			RegionCode: "aws-ap-southeast-1",
+			Mode:       RegionModeTiDBCloudStarterLegacy,
+			ServerURL:  defaultServerURL,
+		},
+	},
+}
+
+type RegionManifest struct {
+	Service string                 `json:"service"`
+	Default *RegionManifestDefault `json:"default,omitempty"`
+	Regions []RegionManifestEntry  `json:"regions"`
+}
+
+type RegionManifestDefault struct {
+	RegionCode string `json:"region_code"`
+	Mode       string `json:"mode"`
+}
+
+type RegionManifestEntry struct {
+	RegionCode    string            `json:"region_code"`
+	Mode          string            `json:"mode"`
+	ServerURL     string            `json:"server_url"`
+	CloudProvider string            `json:"cloud_provider,omitempty"`
+	TiDBRegion    string            `json:"tidb_region,omitempty"`
+	Tags          []string          `json:"tags,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+}
+
+func Region(args []string) error {
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		_, _ = fmt.Fprintln(os.Stdout, regionUsage())
+		return nil
+	}
+	switch args[0] {
+	case "ls", "list":
+		return regionListCmd(args[1:])
+	default:
+		return fmt.Errorf("unknown region command %q\n%s", args[0], regionUsage())
+	}
+}
+
+func regionUsage() string {
+	return `usage: drive9 region <list|ls>
+  list [--json] [--manifest-url <url>]   list create regions from the drive9 manifest`
+}
+
+func regionListCmd(args []string) error {
+	asJSON := false
+	manifestURL := regionManifestURL()
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--json":
+			asJSON = true
+		case "--manifest-url":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--manifest-url requires an argument")
+			}
+			i++
+			manifestURL = strings.TrimSpace(args[i])
+		default:
+			return fmt.Errorf("unknown flag %q\nusage: drive9 region list [--json] [--manifest-url URL]", args[i])
+		}
+	}
+	if manifestURL == "" {
+		return fmt.Errorf("region manifest URL is empty")
+	}
+	manifest, err := fetchRegionManifest(context.Background(), manifestURL)
+	if err != nil {
+		if !errors.Is(err, errRegionManifestUnavailable) {
+			return err
+		}
+		manifest = fallbackRegionManifestCopy()
+	}
+	sortRegionManifestEntries(manifest.Regions)
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(manifest)
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "REGION\tMODE\tSERVER")
+	for _, entry := range manifest.Regions {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", entry.RegionCode, regionModeLabel(entry.Mode), entry.ServerURL)
+	}
+	return w.Flush()
+}
+
+func fallbackRegionManifestCopy() *RegionManifest {
+	manifest := fallbackRegionManifest
+	if fallbackRegionManifest.Default != nil {
+		defaultEntry := *fallbackRegionManifest.Default
+		manifest.Default = &defaultEntry
+	}
+	manifest.Regions = append([]RegionManifestEntry(nil), fallbackRegionManifest.Regions...)
+	return &manifest
+}
+
+func regionManifestURL() string {
+	if raw := strings.TrimSpace(os.Getenv(EnvRegionManifestURL)); raw != "" {
+		return raw
+	}
+	return defaultRegionManifestURL
+}
+
+func fetchRegionManifest(ctx context.Context, manifestURL string) (*RegionManifest, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build region manifest request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: fetch region manifest: %v", errRegionManifestUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: fetch region manifest: HTTP %d", errRegionManifestUnavailable, resp.StatusCode)
+	}
+	var manifest RegionManifest
+	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("decode region manifest: %w", err)
+	}
+	if err := validateRegionManifest(&manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+func validateRegionManifest(manifest *RegionManifest) error {
+	if manifest == nil {
+		return fmt.Errorf("region manifest is required")
+	}
+	if len(manifest.Regions) == 0 {
+		return fmt.Errorf("region manifest has no regions")
+	}
+	seen := map[string]int{}
+	for i, entry := range manifest.Regions {
+		if strings.TrimSpace(entry.RegionCode) == "" {
+			return fmt.Errorf("region manifest entry %d missing region_code", i)
+		}
+		if strings.TrimSpace(entry.Mode) == "" {
+			return fmt.Errorf("region manifest entry %d missing mode", i)
+		}
+		if strings.TrimSpace(entry.ServerURL) == "" {
+			return fmt.Errorf("region manifest entry %d missing server_url", i)
+		}
+		key := strings.TrimSpace(entry.RegionCode) + "\x00" + normalizeRegionMode(entry.Mode)
+		if first, ok := seen[key]; ok {
+			return fmt.Errorf("region manifest entries %d and %d duplicate region_code %q mode %q", first, i, strings.TrimSpace(entry.RegionCode), normalizeRegionMode(entry.Mode))
+		}
+		seen[key] = i
+	}
+	return nil
+}
+
+func sortRegionManifestEntries(entries []RegionManifestEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].RegionCode != entries[j].RegionCode {
+			return entries[i].RegionCode < entries[j].RegionCode
+		}
+		if entries[i].Mode != entries[j].Mode {
+			return entries[i].Mode < entries[j].Mode
+		}
+		return entries[i].ServerURL < entries[j].ServerURL
+	})
+}
+
+func regionModeLabel(mode string) string {
+	switch normalizeRegionMode(mode) {
+	case RegionModeTiDBCloudStarter:
+		return "Anonymous"
+	case RegionModeTiDBCloudNative:
+		return "TiDBCloud"
+	default:
+		return strings.TrimSpace(mode)
+	}
+}

--- a/cmd/drive9/cli/region.go
+++ b/cmd/drive9/cli/region.go
@@ -61,7 +61,6 @@ type RegionManifestEntry struct {
 type regionListOutputEntry struct {
 	RegionCode    string            `json:"region_code"`
 	Mode          string            `json:"mode"`
-	ModeLabel     string            `json:"mode_label"`
 	ServerURL     string            `json:"server_url"`
 	CloudProvider string            `json:"cloud_provider,omitempty"`
 	TiDBRegion    string            `json:"tidb_region,omitempty"`
@@ -133,8 +132,7 @@ func regionListOutput(entries []RegionManifestEntry) []regionListOutputEntry {
 	for _, entry := range entries {
 		out = append(out, regionListOutputEntry{
 			RegionCode:    entry.RegionCode,
-			Mode:          entry.Mode,
-			ModeLabel:     regionModeLabel(entry.Mode),
+			Mode:          regionModeLabel(entry.Mode),
 			ServerURL:     entry.ServerURL,
 			CloudProvider: entry.CloudProvider,
 			TiDBRegion:    entry.TiDBRegion,

--- a/cmd/drive9/cli/region.go
+++ b/cmd/drive9/cli/region.go
@@ -73,7 +73,7 @@ func Region(args []string) error {
 
 func regionUsage() string {
 	return `usage: drive9 region <list|ls>
-  list [--json] [--manifest-url <url>]   list create regions from the drive9 manifest`
+  list [--json] [--manifest-url <url>]   list provisioning regions from the drive9 manifest`
 }
 
 func regionListCmd(args []string) error {
@@ -167,22 +167,39 @@ func validateRegionManifest(manifest *RegionManifest) error {
 		return fmt.Errorf("region manifest has no regions")
 	}
 	seen := map[string]int{}
-	for i, entry := range manifest.Regions {
-		if strings.TrimSpace(entry.RegionCode) == "" {
+	for i := range manifest.Regions {
+		entry := &manifest.Regions[i]
+		entry.RegionCode = strings.TrimSpace(entry.RegionCode)
+		entry.Mode = strings.TrimSpace(entry.Mode)
+		entry.ServerURL = strings.TrimSpace(entry.ServerURL)
+		if entry.RegionCode == "" {
 			return fmt.Errorf("region manifest entry %d missing region_code", i)
 		}
-		if strings.TrimSpace(entry.Mode) == "" {
+		if entry.Mode == "" {
 			return fmt.Errorf("region manifest entry %d missing mode", i)
 		}
-		if strings.TrimSpace(entry.ServerURL) == "" {
+		if entry.ServerURL == "" {
 			return fmt.Errorf("region manifest entry %d missing server_url", i)
 		}
-		mode := strings.TrimSpace(entry.Mode)
-		key := strings.TrimSpace(entry.RegionCode) + "\x00" + mode
+		key := entry.RegionCode + "\x00" + entry.Mode
 		if first, ok := seen[key]; ok {
-			return fmt.Errorf("region manifest entries %d and %d duplicate region_code %q mode %q", first, i, strings.TrimSpace(entry.RegionCode), mode)
+			return fmt.Errorf("region manifest entries %d and %d duplicate region_code %q mode %q", first, i, entry.RegionCode, entry.Mode)
 		}
 		seen[key] = i
+	}
+	if manifest.Default != nil {
+		manifest.Default.RegionCode = strings.TrimSpace(manifest.Default.RegionCode)
+		manifest.Default.Mode = strings.TrimSpace(manifest.Default.Mode)
+		if manifest.Default.RegionCode == "" {
+			return fmt.Errorf("region manifest default missing region_code")
+		}
+		if manifest.Default.Mode == "" {
+			return fmt.Errorf("region manifest default missing mode")
+		}
+		defaultKey := manifest.Default.RegionCode + "\x00" + manifest.Default.Mode
+		if _, ok := seen[defaultKey]; !ok {
+			return fmt.Errorf("region manifest default %q/%q not found in regions", manifest.Default.RegionCode, manifest.Default.Mode)
+		}
 	}
 	return nil
 }

--- a/cmd/drive9/cli/region.go
+++ b/cmd/drive9/cli/region.go
@@ -58,6 +58,17 @@ type RegionManifestEntry struct {
 	Metadata      map[string]string `json:"metadata,omitempty"`
 }
 
+type regionListOutputEntry struct {
+	RegionCode    string            `json:"region_code"`
+	Mode          string            `json:"mode"`
+	ModeLabel     string            `json:"mode_label"`
+	ServerURL     string            `json:"server_url"`
+	CloudProvider string            `json:"cloud_provider,omitempty"`
+	TiDBRegion    string            `json:"tidb_region,omitempty"`
+	Tags          []string          `json:"tags,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+}
+
 func Region(args []string) error {
 	if len(args) == 0 || IsHelpArg(args[0]) {
 		_, _ = fmt.Fprintln(os.Stdout, regionUsage())
@@ -107,7 +118,7 @@ func regionListCmd(args []string) error {
 	if asJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(manifest)
+		return enc.Encode(regionListOutput(manifest.Regions))
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "REGION\tMODE\tSERVER")
@@ -115,6 +126,23 @@ func regionListCmd(args []string) error {
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", entry.RegionCode, regionModeLabel(entry.Mode), entry.ServerURL)
 	}
 	return w.Flush()
+}
+
+func regionListOutput(entries []RegionManifestEntry) []regionListOutputEntry {
+	out := make([]regionListOutputEntry, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, regionListOutputEntry{
+			RegionCode:    entry.RegionCode,
+			Mode:          entry.Mode,
+			ModeLabel:     regionModeLabel(entry.Mode),
+			ServerURL:     entry.ServerURL,
+			CloudProvider: entry.CloudProvider,
+			TiDBRegion:    entry.TiDBRegion,
+			Tags:          entry.Tags,
+			Metadata:      entry.Metadata,
+		})
+	}
+	return out
 }
 
 func fallbackRegionManifestCopy() *RegionManifest {

--- a/cmd/drive9/cli/region_test.go
+++ b/cmd/drive9/cli/region_test.go
@@ -19,7 +19,7 @@ func TestRegionListTextAndJSON(t *testing.T) {
 		},
 		{
 			RegionCode:    "aws-us-east-1",
-			Mode:          RegionModeTiDBCloudStarterLegacy,
+			Mode:          RegionModeTiDBCloudStarter,
 			ServerURL:     "https://api.drive9.ai",
 			CloudProvider: "aws",
 			TiDBRegion:    "us-east-1",
@@ -49,7 +49,7 @@ func TestRegionListTextAndJSON(t *testing.T) {
 	if strings.Contains(textOut, "NAME") {
 		t.Fatalf("text output = %q, want no NAME column", textOut)
 	}
-	if strings.Contains(textOut, "tidbcloud_native") || strings.Contains(textOut, "tidb_cloud_starter") {
+	if strings.Contains(textOut, "tidb_cloud_native") || strings.Contains(textOut, "tidb_cloud_starter") {
 		t.Fatalf("text output = %q, want mapped mode labels", textOut)
 	}
 
@@ -80,7 +80,6 @@ func TestRegionModeLabel(t *testing.T) {
 		mode string
 		want string
 	}{
-		{mode: RegionModeTiDBCloudStarterLegacy, want: "Anonymous"},
 		{mode: RegionModeTiDBCloudStarter, want: "Anonymous"},
 		{mode: RegionModeTiDBCloudNative, want: "TiDBCloud"},
 		{mode: "custom", want: "custom"},
@@ -124,14 +123,14 @@ func TestRegionListJSONFallsBackWhenManifestUnavailable(t *testing.T) {
 	if err := json.Unmarshal([]byte(jsonOut), &manifest); err != nil {
 		t.Fatalf("decode json output: %v\n%s", err, jsonOut)
 	}
-	if manifest.Default == nil || manifest.Default.RegionCode != "aws-ap-southeast-1" || manifest.Default.Mode != RegionModeTiDBCloudStarterLegacy {
+	if manifest.Default == nil || manifest.Default.RegionCode != "aws-ap-southeast-1" || manifest.Default.Mode != RegionModeTiDBCloudStarter {
 		t.Fatalf("fallback default = %#v", manifest.Default)
 	}
 	if len(manifest.Regions) != 1 {
 		t.Fatalf("fallback regions len = %d, want 1", len(manifest.Regions))
 	}
 	entry := manifest.Regions[0]
-	if entry.RegionCode != "aws-ap-southeast-1" || entry.Mode != RegionModeTiDBCloudStarterLegacy || entry.ServerURL != defaultServerURL {
+	if entry.RegionCode != "aws-ap-southeast-1" || entry.Mode != RegionModeTiDBCloudStarter || entry.ServerURL != defaultServerURL {
 		t.Fatalf("fallback region = %#v", entry)
 	}
 }
@@ -140,7 +139,7 @@ func TestValidateRegionManifestAllowsSameRegionDifferentModes(t *testing.T) {
 	err := validateRegionManifest(&RegionManifest{
 		Service: "drive9",
 		Regions: []RegionManifestEntry{
-			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarterLegacy, ServerURL: "https://starter.example"},
+			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarter, ServerURL: "https://starter.example"},
 			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudNative, ServerURL: "https://native.example"},
 		},
 	})
@@ -153,7 +152,7 @@ func TestValidateRegionManifestRejectsDuplicateRegionMode(t *testing.T) {
 	err := validateRegionManifest(&RegionManifest{
 		Service: "drive9",
 		Regions: []RegionManifestEntry{
-			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarterLegacy, ServerURL: "https://starter-a.example"},
+			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarter, ServerURL: "https://starter-a.example"},
 			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarter, ServerURL: "https://starter-b.example"},
 		},
 	})
@@ -165,9 +164,9 @@ func TestValidateRegionManifestRejectsDuplicateRegionMode(t *testing.T) {
 	}
 }
 
-func TestSelectRegionServerMatchesRegionAndNormalizedMode(t *testing.T) {
+func TestSelectRegionServerMatchesRegionAndExactMode(t *testing.T) {
 	entry, err := selectRegionServer([]RegionManifestEntry{
-		{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarterLegacy, ServerURL: "https://starter.example"},
+		{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarter, ServerURL: "https://starter.example"},
 		{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudNative, ServerURL: "https://native.example"},
 	}, "aws-us-east-1", RegionModeTiDBCloudStarter)
 	if err != nil {
@@ -178,10 +177,23 @@ func TestSelectRegionServerMatchesRegionAndNormalizedMode(t *testing.T) {
 	}
 }
 
+func TestSelectRegionServerDoesNotAcceptLegacyNativeMode(t *testing.T) {
+	legacyNativeMode := strings.Replace(RegionModeTiDBCloudNative, "tidb_cloud", "tidbcloud", 1)
+	_, err := selectRegionServer([]RegionManifestEntry{
+		{RegionCode: "aws-us-east-1", Mode: legacyNativeMode, ServerURL: "https://legacy-native.example"},
+	}, "aws-us-east-1", RegionModeTiDBCloudNative)
+	if err == nil {
+		t.Fatal("selectRegionServer error = nil, want unsupported mode error")
+	}
+	if !strings.Contains(err.Error(), `does not support mode "tidb_cloud_native"`) {
+		t.Fatalf("selectRegionServer error = %q", err)
+	}
+}
+
 func TestRegionListRejectsInvalidManifest(t *testing.T) {
 	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"service":"drive9","regions":[{"region_code":"aws-us-east-1","mode":"tidbcloud_native"}]}`))
+		_, _ = w.Write([]byte(`{"service":"drive9","regions":[{"region_code":"aws-us-east-1","mode":"tidb_cloud_native"}]}`))
 	}))
 	defer manifest.Close()
 

--- a/cmd/drive9/cli/region_test.go
+++ b/cmd/drive9/cli/region_test.go
@@ -59,19 +59,18 @@ func TestRegionListTextAndJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("region list --json: %v", err)
 	}
-	var raw map[string]any
-	if err := json.Unmarshal([]byte(jsonOut), &raw); err != nil {
+	var regions []regionListOutputEntry
+	if err := json.Unmarshal([]byte(jsonOut), &regions); err != nil {
 		t.Fatalf("decode json output: %v\n%s", err, jsonOut)
 	}
-	if _, ok := raw["schema"]; ok {
-		t.Fatalf("json output unexpectedly contains schema: %#v", raw)
+	if len(regions) != 2 {
+		t.Fatalf("json regions len = %d, want 2\n%s", len(regions), jsonOut)
 	}
-	if raw["service"] != "drive9" {
-		t.Fatalf("service = %#v, want drive9", raw["service"])
+	if regions[0].RegionCode != "ali-ap-southeast-1" || regions[0].Mode != RegionModeTiDBCloudNative || regions[0].ModeLabel != "TiDBCloud" || regions[0].ServerURL != "https://native-sg.example" {
+		t.Fatalf("json region[0] = %#v", regions[0])
 	}
-	regions, ok := raw["regions"].([]any)
-	if !ok || len(regions) != 2 {
-		t.Fatalf("regions = %#v, want 2 entries", raw["regions"])
+	if regions[1].RegionCode != "aws-us-east-1" || regions[1].Mode != RegionModeTiDBCloudStarter || regions[1].ModeLabel != "Anonymous" || regions[1].ServerURL != "https://api.drive9.ai" {
+		t.Fatalf("json region[1] = %#v", regions[1])
 	}
 }
 
@@ -119,18 +118,15 @@ func TestRegionListJSONFallsBackWhenManifestUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("region list --json fallback: %v", err)
 	}
-	var manifest RegionManifest
-	if err := json.Unmarshal([]byte(jsonOut), &manifest); err != nil {
+	var regions []regionListOutputEntry
+	if err := json.Unmarshal([]byte(jsonOut), &regions); err != nil {
 		t.Fatalf("decode json output: %v\n%s", err, jsonOut)
 	}
-	if manifest.Default == nil || manifest.Default.RegionCode != "aws-ap-southeast-1" || manifest.Default.Mode != RegionModeTiDBCloudStarter {
-		t.Fatalf("fallback default = %#v", manifest.Default)
+	if len(regions) != 1 {
+		t.Fatalf("fallback regions len = %d, want 1", len(regions))
 	}
-	if len(manifest.Regions) != 1 {
-		t.Fatalf("fallback regions len = %d, want 1", len(manifest.Regions))
-	}
-	entry := manifest.Regions[0]
-	if entry.RegionCode != "aws-ap-southeast-1" || entry.Mode != RegionModeTiDBCloudStarter || entry.ServerURL != defaultServerURL {
+	entry := regions[0]
+	if entry.RegionCode != "aws-ap-southeast-1" || entry.Mode != RegionModeTiDBCloudStarter || entry.ModeLabel != "Anonymous" || entry.ServerURL != defaultServerURL {
 		t.Fatalf("fallback region = %#v", entry)
 	}
 }

--- a/cmd/drive9/cli/region_test.go
+++ b/cmd/drive9/cli/region_test.go
@@ -66,10 +66,10 @@ func TestRegionListTextAndJSON(t *testing.T) {
 	if len(regions) != 2 {
 		t.Fatalf("json regions len = %d, want 2\n%s", len(regions), jsonOut)
 	}
-	if regions[0].RegionCode != "ali-ap-southeast-1" || regions[0].Mode != RegionModeTiDBCloudNative || regions[0].ModeLabel != "TiDBCloud" || regions[0].ServerURL != "https://native-sg.example" {
+	if regions[0].RegionCode != "ali-ap-southeast-1" || regions[0].Mode != "TiDBCloud" || regions[0].ServerURL != "https://native-sg.example" {
 		t.Fatalf("json region[0] = %#v", regions[0])
 	}
-	if regions[1].RegionCode != "aws-us-east-1" || regions[1].Mode != RegionModeTiDBCloudStarter || regions[1].ModeLabel != "Anonymous" || regions[1].ServerURL != "https://api.drive9.ai" {
+	if regions[1].RegionCode != "aws-us-east-1" || regions[1].Mode != "Anonymous" || regions[1].ServerURL != "https://api.drive9.ai" {
 		t.Fatalf("json region[1] = %#v", regions[1])
 	}
 }
@@ -126,7 +126,7 @@ func TestRegionListJSONFallsBackWhenManifestUnavailable(t *testing.T) {
 		t.Fatalf("fallback regions len = %d, want 1", len(regions))
 	}
 	entry := regions[0]
-	if entry.RegionCode != "aws-ap-southeast-1" || entry.Mode != RegionModeTiDBCloudStarter || entry.ModeLabel != "Anonymous" || entry.ServerURL != defaultServerURL {
+	if entry.RegionCode != "aws-ap-southeast-1" || entry.Mode != "Anonymous" || entry.ServerURL != defaultServerURL {
 		t.Fatalf("fallback region = %#v", entry)
 	}
 }

--- a/cmd/drive9/cli/region_test.go
+++ b/cmd/drive9/cli/region_test.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRegionListTextAndJSON(t *testing.T) {
+	manifest := newRegionManifestTestServer(t, []RegionManifestEntry{
+		{
+			RegionCode:    "ali-ap-southeast-1",
+			Mode:          RegionModeTiDBCloudNative,
+			ServerURL:     "https://native-sg.example",
+			CloudProvider: "alicloud",
+			TiDBRegion:    "ap-southeast-1",
+		},
+		{
+			RegionCode:    "aws-us-east-1",
+			Mode:          RegionModeTiDBCloudStarterLegacy,
+			ServerURL:     "https://api.drive9.ai",
+			CloudProvider: "aws",
+			TiDBRegion:    "us-east-1",
+		},
+	})
+	defer manifest.Close()
+
+	textOut, err := captureStdoutE(t, func() error {
+		return Region([]string{"list", "--manifest-url", manifest.URL})
+	})
+	if err != nil {
+		t.Fatalf("region list: %v", err)
+	}
+	for _, want := range []string{
+		"REGION",
+		"MODE",
+		"SERVER",
+		"ali-ap-southeast-1",
+		"TiDBCloud",
+		"Anonymous",
+		"https://api.drive9.ai",
+	} {
+		if !strings.Contains(textOut, want) {
+			t.Fatalf("text output = %q, want substring %q", textOut, want)
+		}
+	}
+	if strings.Contains(textOut, "NAME") {
+		t.Fatalf("text output = %q, want no NAME column", textOut)
+	}
+	if strings.Contains(textOut, "tidbcloud_native") || strings.Contains(textOut, "tidb_cloud_starter") {
+		t.Fatalf("text output = %q, want mapped mode labels", textOut)
+	}
+
+	jsonOut, err := captureStdoutE(t, func() error {
+		return Region([]string{"list", "--manifest-url", manifest.URL, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("region list --json: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(jsonOut), &raw); err != nil {
+		t.Fatalf("decode json output: %v\n%s", err, jsonOut)
+	}
+	if _, ok := raw["schema"]; ok {
+		t.Fatalf("json output unexpectedly contains schema: %#v", raw)
+	}
+	if raw["service"] != "drive9" {
+		t.Fatalf("service = %#v, want drive9", raw["service"])
+	}
+	regions, ok := raw["regions"].([]any)
+	if !ok || len(regions) != 2 {
+		t.Fatalf("regions = %#v, want 2 entries", raw["regions"])
+	}
+}
+
+func TestRegionModeLabel(t *testing.T) {
+	cases := []struct {
+		mode string
+		want string
+	}{
+		{mode: RegionModeTiDBCloudStarterLegacy, want: "Anonymous"},
+		{mode: RegionModeTiDBCloudStarter, want: "Anonymous"},
+		{mode: RegionModeTiDBCloudNative, want: "TiDBCloud"},
+		{mode: "custom", want: "custom"},
+	}
+	for _, tc := range cases {
+		if got := regionModeLabel(tc.mode); got != tc.want {
+			t.Fatalf("regionModeLabel(%q) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+func TestRegionListFallsBackWhenManifestUnavailable(t *testing.T) {
+	textOut, err := captureStdoutE(t, func() error {
+		return Region([]string{"list", "--manifest-url", "http://127.0.0.1:1/drive9-regions.json"})
+	})
+	if err != nil {
+		t.Fatalf("region list fallback: %v", err)
+	}
+	for _, want := range []string{
+		"REGION",
+		"MODE",
+		"SERVER",
+		"aws-ap-southeast-1",
+		"Anonymous",
+		"https://api.drive9.ai",
+	} {
+		if !strings.Contains(textOut, want) {
+			t.Fatalf("text output = %q, want substring %q", textOut, want)
+		}
+	}
+}
+
+func TestRegionListJSONFallsBackWhenManifestUnavailable(t *testing.T) {
+	jsonOut, err := captureStdoutE(t, func() error {
+		return Region([]string{"list", "--manifest-url", "http://127.0.0.1:1/drive9-regions.json", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("region list --json fallback: %v", err)
+	}
+	var manifest RegionManifest
+	if err := json.Unmarshal([]byte(jsonOut), &manifest); err != nil {
+		t.Fatalf("decode json output: %v\n%s", err, jsonOut)
+	}
+	if manifest.Default == nil || manifest.Default.RegionCode != "aws-ap-southeast-1" || manifest.Default.Mode != RegionModeTiDBCloudStarterLegacy {
+		t.Fatalf("fallback default = %#v", manifest.Default)
+	}
+	if len(manifest.Regions) != 1 {
+		t.Fatalf("fallback regions len = %d, want 1", len(manifest.Regions))
+	}
+	entry := manifest.Regions[0]
+	if entry.RegionCode != "aws-ap-southeast-1" || entry.Mode != RegionModeTiDBCloudStarterLegacy || entry.ServerURL != defaultServerURL {
+		t.Fatalf("fallback region = %#v", entry)
+	}
+}
+
+func TestValidateRegionManifestAllowsSameRegionDifferentModes(t *testing.T) {
+	err := validateRegionManifest(&RegionManifest{
+		Service: "drive9",
+		Regions: []RegionManifestEntry{
+			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarterLegacy, ServerURL: "https://starter.example"},
+			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudNative, ServerURL: "https://native.example"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("validateRegionManifest: %v", err)
+	}
+}
+
+func TestValidateRegionManifestRejectsDuplicateRegionMode(t *testing.T) {
+	err := validateRegionManifest(&RegionManifest{
+		Service: "drive9",
+		Regions: []RegionManifestEntry{
+			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarterLegacy, ServerURL: "https://starter-a.example"},
+			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarter, ServerURL: "https://starter-b.example"},
+		},
+	})
+	if err == nil {
+		t.Fatal("validateRegionManifest error = nil, want duplicate key error")
+	}
+	if !strings.Contains(err.Error(), "duplicate region_code") {
+		t.Fatalf("validateRegionManifest error = %q", err)
+	}
+}
+
+func TestSelectRegionServerMatchesRegionAndNormalizedMode(t *testing.T) {
+	entry, err := selectRegionServer([]RegionManifestEntry{
+		{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarterLegacy, ServerURL: "https://starter.example"},
+		{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudNative, ServerURL: "https://native.example"},
+	}, "aws-us-east-1", RegionModeTiDBCloudStarter)
+	if err != nil {
+		t.Fatalf("selectRegionServer: %v", err)
+	}
+	if entry.ServerURL != "https://starter.example" {
+		t.Fatalf("server = %q, want starter", entry.ServerURL)
+	}
+}
+
+func TestRegionListRejectsInvalidManifest(t *testing.T) {
+	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"service":"drive9","regions":[{"region_code":"aws-us-east-1","mode":"tidbcloud_native"}]}`))
+	}))
+	defer manifest.Close()
+
+	_, err := captureStdoutE(t, func() error {
+		return Region([]string{"list", "--manifest-url", manifest.URL})
+	})
+	if err == nil {
+		t.Fatal("region list error = nil, want invalid manifest error")
+	}
+	if !strings.Contains(err.Error(), "missing server_url") {
+		t.Fatalf("region list error = %q", err)
+	}
+}

--- a/cmd/drive9/cli/region_test.go
+++ b/cmd/drive9/cli/region_test.go
@@ -138,6 +138,10 @@ func TestRegionListJSONFallsBackWhenManifestUnavailable(t *testing.T) {
 func TestValidateRegionManifestAllowsSameRegionDifferentModes(t *testing.T) {
 	err := validateRegionManifest(&RegionManifest{
 		Service: "drive9",
+		Default: &RegionManifestDefault{
+			RegionCode: "aws-us-east-1",
+			Mode:       RegionModeTiDBCloudStarter,
+		},
 		Regions: []RegionManifestEntry{
 			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarter, ServerURL: "https://starter.example"},
 			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudNative, ServerURL: "https://native.example"},
@@ -145,6 +149,25 @@ func TestValidateRegionManifestAllowsSameRegionDifferentModes(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("validateRegionManifest: %v", err)
+	}
+}
+
+func TestValidateRegionManifestRejectsMissingDefaultEntry(t *testing.T) {
+	err := validateRegionManifest(&RegionManifest{
+		Service: "drive9",
+		Default: &RegionManifestDefault{
+			RegionCode: "aws-us-east-1",
+			Mode:       RegionModeTiDBCloudNative,
+		},
+		Regions: []RegionManifestEntry{
+			{RegionCode: "aws-us-east-1", Mode: RegionModeTiDBCloudStarter, ServerURL: "https://starter.example"},
+		},
+	})
+	if err == nil {
+		t.Fatal("validateRegionManifest error = nil, want missing default entry error")
+	}
+	if !strings.Contains(err.Error(), "region manifest default") {
+		t.Fatalf("validateRegionManifest error = %q", err)
 	}
 }
 

--- a/cmd/drive9/cli/secret.go
+++ b/cmd/drive9/cli/secret.go
@@ -330,10 +330,11 @@ func indexOfForbiddenEnvByte(value string) int {
 	return -1
 }
 
-// scrubDrive9CredEnv implements the F14 scrub from spec §9 L209. Exactly
-// three variables are dropped from the child's base env:
+// scrubDrive9CredEnv implements the F14 scrub from spec §9 L209. Credential
+// variables are dropped from the child's base env:
 //
-//	DRIVE9_API_KEY, DRIVE9_VAULT_TOKEN, DRIVE9_SERVER
+//	DRIVE9_API_KEY, DRIVE9_VAULT_TOKEN, DRIVE9_SERVER,
+//	DRIVE9_PUBLIC_KEY, DRIVE9_PRIVATE_KEY
 //
 // Any other DRIVE9_* (e.g. DRIVE9_PROF_CPU_PROFILE, DRIVE9_CLI_LOG_*) is
 // preserved — profiling and logging controls are developer-side knobs that
@@ -349,7 +350,7 @@ func scrubDrive9CredEnv(base []string) []string {
 			continue
 		}
 		switch key {
-		case EnvAPIKey, EnvVaultToken, EnvServer:
+		case EnvAPIKey, EnvVaultToken, EnvServer, EnvTiDBCloudPublicKey, EnvTiDBCloudPrivateKey:
 			continue
 		}
 		out = append(out, entry)

--- a/cmd/drive9/cli/secret_with_test.go
+++ b/cmd/drive9/cli/secret_with_test.go
@@ -102,6 +102,8 @@ func TestScrubDrive9CredEnv(t *testing.T) {
 		"DRIVE9_API_KEY=owner-key",
 		"DRIVE9_VAULT_TOKEN=cap-token",
 		"DRIVE9_SERVER=https://api.example",
+		EnvTiDBCloudPublicKey + "=tidb-public",
+		EnvTiDBCloudPrivateKey + "=tidb-private",
 		"DRIVE9_PROF_CPU_PROFILE=/tmp/cpu.pprof", // preserved (profiling knob)
 		"DRIVE9_CLI_LOG_LEVEL=debug",             // preserved (log knob)
 		"HOME=/home/drive9",
@@ -118,6 +120,8 @@ func TestScrubDrive9CredEnv(t *testing.T) {
 		"DRIVE9_API_KEY=owner-key",
 		"DRIVE9_VAULT_TOKEN=cap-token",
 		"DRIVE9_SERVER=https://api.example",
+		EnvTiDBCloudPublicKey + "=tidb-public",
+		EnvTiDBCloudPrivateKey + "=tidb-private",
 	}
 	for _, want := range mustHave {
 		if !containsEntry(got, want) {

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -7,6 +7,7 @@
 // Commands:
 //
 //	create  provision a new database and owner context
+//	delete  delete the current tenant
 //	ctx     manage contexts (show, add, import, fork, ls, use, rm)
 //	fs      filesystem operations (cp, cat, ls, stat, mv, rm, mkdir, chmod,
 //	        symlink, hardlink, sh, grep, find, layer)
@@ -14,6 +15,7 @@
 //	vault   vault operations (set, get, put, with, ls, rm, grant, revoke, audit)
 //	journal append-only agent/workflow journal operations
 //	git     git-aware drive9 workflows
+//	region list drive9 create regions
 //	profile show mount profile configuration
 //	mount   mount drive9 as a local filesystem, or mount vault secrets
 //	umount  unmount a drive9 local mount
@@ -45,10 +47,12 @@ var exitFunc = os.Exit
 // "handler not reached". Production callers see no change: the default value
 // is the real cli.Secret and nothing else reassigns it outside tests.
 var vaultHandler = cli.Secret
+var deleteHandler = cli.DeleteTenant
 var tokenHandler = cli.Token
 var doctorHandler = cli.Doctor
 var journalHandler = cli.Journal
 var gitHandler = cli.Git
+var regionHandler = cli.Region
 var packHandler = cli.PackCommand
 var unpackHandler = cli.UnpackCommand
 var profileHandler = cli.Profile
@@ -104,6 +108,13 @@ func dispatch(cmd string, args []string) {
 		}
 		if err := cli.Create(args); err != nil {
 			fatal("create", err)
+		}
+	case "delete":
+		if cliLogger != nil {
+			logger.Info(context.Background(), "cli_command", zap.String("command", "delete"))
+		}
+		if err := deleteHandler(args); err != nil {
+			fatal("delete", err)
 		}
 	case "ctx":
 		if cliLogger != nil {
@@ -180,6 +191,21 @@ func dispatch(cmd string, args []string) {
 				sub = " " + args[0]
 			}
 			fatal("git"+sub, err)
+		}
+	case "region":
+		if cliLogger != nil {
+			sub := ""
+			if len(args) > 0 {
+				sub = args[0]
+			}
+			logger.Info(context.Background(), "cli_command", zap.String("command", "region"), zap.String("subcommand", sub))
+		}
+		if err := regionHandler(args); err != nil {
+			sub := ""
+			if len(args) > 0 {
+				sub = " " + args[0]
+			}
+			fatal("region"+sub, err)
 		}
 	case "pack":
 		if cliLogger != nil {
@@ -352,8 +378,12 @@ func usage(code int) {
 	fmt.Fprint(os.Stderr,
 		"usage: drive9 <command> [arguments]\n\n"+
 			"commands:\n"+
-			"  create [--name NAME] [--server URL]\n"+
+			"  create [--name NAME] [--region-code CODE] [--server URL] [--json]\n"+
+			"                         [--tidbcloud-public-key KEY] [--tidbcloud-private-key KEY]\n"+
 			"                         provision a new database and owner context\n"+
+			"  delete [--server URL] [--api-key KEY] [--json]\n"+
+			"                         [--tidbcloud-public-key KEY] [--tidbcloud-private-key KEY]\n"+
+			"                         delete current tenant with owner API key\n"+
 			"  ctx show [--json] [--reveal]\n"+
 			"                         show current context\n"+
 			"  ctx add --api-key <key> [--name NAME] [--server URL]\n"+
@@ -374,6 +404,7 @@ func usage(code int) {
 			"                         append-only agent/workflow journal operations\n"+
 			"  git clone --fast <repo-url> <mounted-path>\n"+
 			"                         git-aware fast clone workflow\n"+
+			"  region list [--json]   list create regions\n"+
 			"  pack [flags] [archive] [path...]\n"+
 			"                         archive coding-agent local overlay paths to drive9/S3\n"+
 			"  unpack [flags] [archive]\n"+

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -15,7 +15,7 @@
 //	vault   vault operations (set, get, put, with, ls, rm, grant, revoke, audit)
 //	journal append-only agent/workflow journal operations
 //	git     git-aware drive9 workflows
-//	region list drive9 create regions
+//	region list provisioning regions
 //	profile show mount profile configuration
 //	mount   mount drive9 as a local filesystem, or mount vault secrets
 //	umount  unmount a drive9 local mount
@@ -404,7 +404,7 @@ func usage(code int) {
 			"                         append-only agent/workflow journal operations\n"+
 			"  git clone --fast <repo-url> <mounted-path>\n"+
 			"                         git-aware fast clone workflow\n"+
-			"  region list [--json]   list create regions\n"+
+			"  region list [--json]   list provisioning regions\n"+
 			"  pack [flags] [archive] [path...]\n"+
 			"                         archive coding-agent local overlay paths to drive9/S3\n"+
 			"  unpack [flags] [archive]\n"+

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -80,10 +80,13 @@ func TestDispatchLongHelpFlagShowsUsage(t *testing.T) {
 	}
 	for _, want := range []string{
 		"usage: drive9 <command> [arguments]",
+		"create [--name NAME] [--region-code CODE] [--server URL] [--json]",
+		"delete [--server URL] [--api-key KEY] [--json]",
 		"ctx show [--json] [--reveal]",
 		"ctx use <name>",
 		"token <issue|revoke>",
 		"journal <new|append|cat|find|verify>",
+		"region list [--json]",
 		"profile show [profile]",
 		"mount [flags] [:/remote] <mountpoint>",
 		"mount vault [flags] <mountpoint>",
@@ -128,6 +131,12 @@ func TestDispatchSubcommandHelpShowsUsageWithoutFatalPrefix(t *testing.T) {
 			cmd:       "vault",
 			args:      []string{"--help"},
 			firstLine: "usage drive9 vault <set|get|put|with|ls|rm|grant|revoke|audit>",
+		},
+		{
+			name:      "region",
+			cmd:       "region",
+			args:      []string{"--help"},
+			firstLine: "usage: drive9 region <list|ls>",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -251,6 +260,72 @@ func TestDispatchTokenVerbReachesHandler(t *testing.T) {
 		t.Fatal("token handler was not invoked for `drive9 token ...`")
 	}
 	want := []string{"issue", "--subject", "vm0"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q", i, gotArgs[i], want[i])
+		}
+	}
+}
+
+func TestDispatchDeleteVerbReachesHandler(t *testing.T) {
+	origHandler := deleteHandler
+	origExit := exitFunc
+	t.Cleanup(func() {
+		deleteHandler = origHandler
+		exitFunc = origExit
+	})
+	exitFunc = func(int) {}
+
+	var gotArgs []string
+	called := false
+	deleteHandler = func(args []string) error {
+		called = true
+		gotArgs = args
+		return nil
+	}
+
+	dispatch("delete", []string{"--json"})
+
+	if !called {
+		t.Fatal("delete handler was not invoked for `drive9 delete ...`")
+	}
+	want := []string{"--json"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q", i, gotArgs[i], want[i])
+		}
+	}
+}
+
+func TestDispatchRegionVerbReachesHandler(t *testing.T) {
+	origHandler := regionHandler
+	origExit := exitFunc
+	t.Cleanup(func() {
+		regionHandler = origHandler
+		exitFunc = origExit
+	})
+	exitFunc = func(int) {}
+
+	var gotArgs []string
+	called := false
+	regionHandler = func(args []string) error {
+		called = true
+		gotArgs = args
+		return nil
+	}
+
+	dispatch("region", []string{"list", "--json"})
+
+	if !called {
+		t.Fatal("region handler was not invoked for `drive9 region ...`")
+	}
+	want := []string{"list", "--json"}
 	if len(gotArgs) != len(want) {
 		t.Fatalf("args = %v, want %v", gotArgs, want)
 	}

--- a/pkg/client/auth_test.go
+++ b/pkg/client/auth_test.go
@@ -61,21 +61,17 @@ func TestRawDeleteSendsBearerAPIKeyAndBody(t *testing.T) {
 
 	var gotAuth string
 	var gotBody string
+	var gotMethod string
+	var gotPath string
+	var gotContentType string
+	var gotBodyErr error
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			t.Fatalf("method = %s, want DELETE", r.Method)
-		}
-		if r.URL.Path != "/v1/tenant" {
-			t.Fatalf("path = %s, want /v1/tenant", r.URL.Path)
-		}
+		gotMethod = r.Method
+		gotPath = r.URL.Path
 		gotAuth = r.Header.Get("Authorization")
-		if got := r.Header.Get("Content-Type"); got != "application/json" {
-			t.Fatalf("Content-Type = %q, want application/json", got)
-		}
+		gotContentType = r.Header.Get("Content-Type")
 		raw, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
+		gotBodyErr = err
 		gotBody = string(raw)
 		w.WriteHeader(http.StatusAccepted)
 	}))
@@ -89,8 +85,20 @@ func TestRawDeleteSendsBearerAPIKeyAndBody(t *testing.T) {
 	if resp.StatusCode != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
 	}
+	if gotMethod != http.MethodDelete {
+		t.Fatalf("method = %s, want DELETE", gotMethod)
+	}
+	if gotPath != "/v1/tenant" {
+		t.Fatalf("path = %s, want /v1/tenant", gotPath)
+	}
+	if gotBodyErr != nil {
+		t.Fatalf("read body: %v", gotBodyErr)
+	}
 	if gotAuth != "Bearer owner-api-key-xyz" {
 		t.Fatalf("Authorization = %q, want bearer API key", gotAuth)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", gotContentType)
 	}
 	if gotBody != `{"public_key":"pub"}` {
 		t.Fatalf("body = %q", gotBody)

--- a/pkg/client/auth_test.go
+++ b/pkg/client/auth_test.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -51,6 +53,47 @@ func TestNewWithTokenSendsBearerJWT(t *testing.T) {
 	}
 	if gotAuth != "Bearer jwt-aaa.bbb.ccc" {
 		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer jwt-aaa.bbb.ccc")
+	}
+}
+
+func TestRawDeleteSendsBearerAPIKeyAndBody(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/v1/tenant" {
+			t.Fatalf("path = %s, want /v1/tenant", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		gotBody = string(raw)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	resp, err := New(srv.URL, "owner-api-key-xyz").RawDelete("/v1/tenant", strings.NewReader(`{"public_key":"pub"}`))
+	if err != nil {
+		t.Fatalf("RawDelete: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if gotAuth != "Bearer owner-api-key-xyz" {
+		t.Fatalf("Authorization = %q, want bearer API key", gotAuth)
+	}
+	if gotBody != `{"public_key":"pub"}` {
+		t.Fatalf("body = %q", gotBody)
 	}
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -287,6 +287,17 @@ func (c *Client) RawPost(endpoint string, body io.Reader) (*http.Response, error
 	return c.do(req)
 }
 
+func (c *Client) RawDelete(endpoint string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodDelete, c.baseURL+endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return c.do(req)
+}
+
 // SetActor sets the X-Dat9-Actor header value for all subsequent requests.
 // Used by FUSE mounts to identify the per-mount actor for SSE self-filtering.
 func (c *Client) SetActor(actor string) {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -25,6 +25,8 @@ import (
 
 type fakeProvisioner struct {
 	provider          string
+	cloudProvider     string
+	region            string
 	cluster           *tenant.ClusterInfo
 	initErr           error
 	provisionErr      error
@@ -37,6 +39,10 @@ type fakeProvisioner struct {
 }
 
 func (f *fakeProvisioner) ProviderType() string { return f.provider }
+
+func (f *fakeProvisioner) ProvisioningCloudProvider() string { return f.cloudProvider }
+
+func (f *fakeProvisioner) ProvisioningRegion() string { return f.region }
 
 func (f *fakeProvisioner) InitSchema(_ context.Context, dsn string) error {
 	if f.initErr != nil {
@@ -355,7 +361,7 @@ func TestProvisionTiDBCloudNativeUsesRequestCredentials(t *testing.T) {
 	if _, err := rand.Read(tokenSecret); err != nil {
 		t.Fatal(err)
 	}
-	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cluster: &tenant.ClusterInfo{
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1", cluster: &tenant.ClusterInfo{
 		ClusterID: "native-cluster-1",
 		Host:      "db.example",
 		Port:      4000,
@@ -405,6 +411,12 @@ func TestProvisionTiDBCloudNativeUsesRequestCredentials(t *testing.T) {
 	}
 	if out["tenant_id"] == "" || out["api_key"] == "" || out["status"] != string(meta.TenantProvisioning) {
 		t.Fatalf("unexpected response: %+v", out)
+	}
+	if out["cloud_provider"] != "aws" || out["region"] != "us-east-1" {
+		t.Fatalf("native cloud/region response = %+v", out)
+	}
+	if _, ok := out["mode"]; ok {
+		t.Fatalf("native provision response unexpectedly included mode: %+v", out)
 	}
 
 	deadline := time.Now().Add(3 * time.Second)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -80,6 +80,11 @@ type credentialProvisionRequestValidator interface {
 	ValidateCredentialProvisionRequest(tenant.CredentialProvisionRequest) error
 }
 
+type provisioningRegionProvider interface {
+	ProvisioningCloudProvider() string
+	ProvisioningRegion() string
+}
+
 type Server struct {
 	fallback            *backend.Dat9Backend
 	meta                *meta.Store
@@ -3409,11 +3414,20 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
-	_ = json.NewEncoder(w).Encode(map[string]string{
+	response := map[string]string{
 		"tenant_id": res.TenantID,
 		"api_key":   res.APIKey,
 		"status":    string(res.Status),
-	})
+	}
+	if res.Provider == tenant.ProviderTiDBCloudNative {
+		if res.CloudProvider != "" {
+			response["cloud_provider"] = res.CloudProvider
+		}
+		if res.Region != "" {
+			response["region"] = res.Region
+		}
+	}
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 func decodeCredentialProvisionRequest(w http.ResponseWriter, r *http.Request) (*tenant.CredentialProvisionRequest, error) {
@@ -3464,12 +3478,14 @@ type provisionTenantOptions struct {
 }
 
 type provisionTenantResult struct {
-	TenantID  string
-	APIKey    string
-	APIKeyID  string
-	Status    meta.TenantStatus
-	Provider  string
-	TenantDSN string
+	TenantID      string
+	APIKey        string
+	APIKeyID      string
+	Status        meta.TenantStatus
+	Provider      string
+	TenantDSN     string
+	CloudProvider string
+	Region        string
 }
 
 type provisionTenantError struct {
@@ -3717,14 +3733,31 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	logger.Info(ctx, "server_event", eventFields(ctx, "provision_accepted", "tenant_id", tenantID, "provider", provider)...)
 	metricEvent(ctx, "tenant_provision", "provider", provider, "result", "accepted")
 
+	cloudProvider, region := "", ""
+	if provider == tenant.ProviderTiDBCloudNative {
+		cloudProvider, region = provisioningCloudRegion(s.provisioner)
+	}
 	return &provisionTenantResult{
-		TenantID:  tenantID,
-		APIKey:    apiToken,
-		APIKeyID:  apiKeyID,
-		Status:    meta.TenantProvisioning,
-		Provider:  provider,
-		TenantDSN: tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true),
+		TenantID:      tenantID,
+		APIKey:        apiToken,
+		APIKeyID:      apiKeyID,
+		Status:        meta.TenantProvisioning,
+		Provider:      provider,
+		TenantDSN:     tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true),
+		CloudProvider: cloudProvider,
+		Region:        region,
 	}, nil
+}
+
+func provisioningCloudRegion(provisioner tenant.Provisioner) (string, string) {
+	if provisioner == nil {
+		return "", ""
+	}
+	regionProvider, ok := provisioner.(provisioningRegionProvider)
+	if !ok {
+		return "", ""
+	}
+	return strings.TrimSpace(regionProvider.ProvisioningCloudProvider()), strings.TrimSpace(regionProvider.ProvisioningRegion())
 }
 
 func (s *Server) persistFailedProvisionClusterInfo(ctx context.Context, tenantID, provider string, cluster *tenant.ClusterInfo) {

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -132,7 +132,7 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Cluster deprovision already succeeded. Keep owner keys active until
 		// cleanup is durably enqueued so the same owner can retry the delete
-		// request. This matters for tidbcloud_native because customer TiDB Cloud
+		// request. This matters for tidb_cloud_native because customer TiDB Cloud
 		// credentials are accepted per request and are not stored server-side.
 		errJSON(w, http.StatusInternalServerError, "failed to enqueue tenant delete cleanup")
 		return

--- a/pkg/tenant/provider.go
+++ b/pkg/tenant/provider.go
@@ -6,7 +6,7 @@ const (
 	ProviderDB9              = "db9"
 	ProviderTiDBZero         = "tidb_zero"
 	ProviderTiDBCloudStarter = "tidb_cloud_starter"
-	ProviderTiDBCloudNative  = "tidbcloud_native"
+	ProviderTiDBCloudNative  = "tidb_cloud_native"
 )
 
 func NormalizeProvider(provider string) (string, error) {

--- a/pkg/tenant/provider_test.go
+++ b/pkg/tenant/provider_test.go
@@ -25,7 +25,7 @@ func TestSmallInDB(t *testing.T) {
 		t.Fatal("tidb_cloud_starter should store small files in db")
 	}
 	if !SmallInDB(ProviderTiDBCloudNative) {
-		t.Fatal("tidbcloud_native should store small files in db")
+		t.Fatal("tidb_cloud_native should store small files in db")
 	}
 	if SmallInDB(ProviderDB9) {
 		t.Fatal("db9 should not store small files in db")

--- a/pkg/tenant/schemadump/schemadump.go
+++ b/pkg/tenant/schemadump/schemadump.go
@@ -9,7 +9,7 @@ import (
 	tenantschema "github.com/mem9-ai/dat9/pkg/tenant/schema"
 )
 
-const usage = "usage: drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter|tidbcloud_native>"
+const usage = "usage: drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_starter|tidb_cloud_native>"
 
 // ResolveProvider normalizes a schema dump provider selection.
 func ResolveProvider(provider string) (string, error) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -86,6 +86,10 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 
 func (p *Provisioner) ProviderType() string { return tenant.ProviderTiDBCloudNative }
 
+func (p *Provisioner) ProvisioningCloudProvider() string { return p.cloudProvider }
+
+func (p *Provisioner) ProvisioningRegion() string { return p.region }
+
 func (p *Provisioner) InitSchema(ctx context.Context, dsn string) error {
 	return schema.EnsureTiDBSchemaForModeDSN(ctx, dsn, schema.TiDBEmbeddingModeAuto)
 }

--- a/site/skill.md
+++ b/site/skill.md
@@ -65,7 +65,7 @@ drive9 create \
   --tidbcloud-private-key <private-key>
 ```
 
-The TiDB Cloud keys can also be supplied through `DRIVE9_PUBLIC_KEY` and `DRIVE9_PRIVATE_KEY`. If `--server` is provided, it has highest priority and bypasses region manifest routing.
+The TiDB Cloud keys can also be supplied through `DRIVE9_PUBLIC_KEY` and `DRIVE9_PRIVATE_KEY`. If `--server` is provided, it has highest priority, bypasses region manifest routing, and ignores `--region-code`.
 
 ### File operations
 

--- a/site/skill.md
+++ b/site/skill.md
@@ -67,6 +67,8 @@ drive9 create \
 
 The TiDB Cloud keys can also be supplied through `DRIVE9_PUBLIC_KEY` and `DRIVE9_PRIVATE_KEY`. If `--server` is provided, it has highest priority, bypasses region manifest routing, and ignores `--region-code`.
 
+Native contexts created by `drive9 create` are stored locally with `mode=TiDBCloud` and any `cloud_provider` / `region` returned by the server. `drive9 ctx list` shows `MODE`, `CLOUD_PROVIDER`, and `REGION` by default; empty mode fields stay empty. When adding an existing native owner key manually, use `drive9 ctx add --api-key <key> --mode TiDBCloud --cloud-provider <provider> --region <region>`.
+
 ### File operations
 
 Remote paths use `:` prefix (e.g. `:/data/file.txt`). Local paths have no prefix. Intermediate remote directories are created automatically — no mkdir needed.

--- a/site/skill.md
+++ b/site/skill.md
@@ -46,10 +46,26 @@ Each workspace is an isolated storage scope. The initial workspace is created du
 
 ```bash
 drive9 create --name <name>     # create an additional workspace
+drive9 region list              # list available provisioning regions and modes
+drive9 create --region-code <code>
 drive9 ctx                      # show current workspace
 drive9 ctx list                 # list all workspaces
 drive9 ctx <name>               # switch workspace
+drive9 delete                   # delete the current workspace/tenant
 ```
+
+Only run `drive9 delete` when the user explicitly asks to delete the current workspace/tenant. This is destructive and requires an owner API key; delegated and `fs_scoped` contexts cannot delete tenants.
+
+`drive9 create` uses the default Drive9 server when no server, region, or TiDB Cloud keys are provided. Use `drive9 region list` to see supported provisioning routes. Modes shown as `Anonymous` use Drive9-managed starter provisioning. Modes shown as `TiDBCloud` create the starter cluster in the user's TiDB Cloud account and require TiDB Cloud API keys:
+
+```bash
+drive9 create \
+  --region-code <code> \
+  --tidbcloud-public-key <public-key> \
+  --tidbcloud-private-key <private-key>
+```
+
+The TiDB Cloud keys can also be supplied through `DRIVE9_PUBLIC_KEY` and `DRIVE9_PRIVATE_KEY`. If `--server` is provided, it has highest priority and bypasses region manifest routing.
 
 ### File operations
 

--- a/site/skill.md
+++ b/site/skill.md
@@ -54,7 +54,7 @@ drive9 ctx <name>               # switch workspace
 drive9 delete                   # delete the current workspace/tenant
 ```
 
-Only run `drive9 delete` when the user explicitly asks to delete the current workspace/tenant. This is destructive and requires an owner API key; delegated and `fs_scoped` contexts cannot delete tenants.
+Only run `drive9 delete` when the user explicitly asks to delete the current workspace/tenant. This is destructive and requires an owner API key. The CLI will use the active context only when it is an owner context; if the active context is delegated or `fs_scoped`, pass an owner key explicitly with `--api-key`.
 
 `drive9 create` uses the default Drive9 server when no server, region, or TiDB Cloud keys are provided. Use `drive9 region list` to see supported provisioning routes. Modes shown as `Anonymous` use Drive9-managed starter provisioning. Modes shown as `TiDBCloud` create the starter cluster in the user's TiDB Cloud account and require TiDB Cloud API keys:
 


### PR DESCRIPTION
Summary:
- Add `drive9 region list` with manifest-backed routing and built-in list fallback.
- Add CLI create/delete support for TiDB Cloud native public/private keys and env fallbacks.
- Keep default anonymous create behavior unchanged and document provisioning/delete usage in README and site skill.

Tests:
- `env GOCACHE=/tmp/drive9-gocache go test ./cmd/drive9/cli ./cmd/drive9 ./pkg/client`
- `make lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `drive9 region list/ls` to view available regions, modes, and servers (supports `--json` and falls back to an embedded manifest when unreachable).
  * Enhanced `drive9 create` and `drive9 delete` for TiDB Cloud native/starter provisioning, with `--server` taking precedence and native JSON request handling.
  * Extended `drive9 ctx` to store and display `mode`, `cloud_provider`, and `region` metadata.
* **Documentation**
  * Updated Quick Start and API/CLI environment variable guidance, including `tidb_cloud_native` naming and native delete request requirements.
* **Tests**
  * Added coverage for region listing and create/delete routing/authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->