### PR TITLE
feat: create native tenant system user

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1658,7 +1658,7 @@ func (s *Store) UpdateTenantConnection(ctx context.Context, id string, cluster *
 
 func (s *Store) UpdateTenantDBCredentialIf(ctx context.Context, id, fromDBUser, dbUser string, dbPasswordCipher []byte) (updated bool, err error) {
 	start := time.Now()
-	defer observeMeta(ctx, "update_tenant_db_credential", start, &err)
+	defer observeMeta(ctx, "update_tenant_db_credential_if", start, &err)
 	res, err := s.db.ExecContext(ctx, `UPDATE tenants SET db_user = ?, db_password = ?, updated_at = ? WHERE id = ? AND db_user = ?`,
 		dbUser, dbPasswordCipher, time.Now().UTC(), id, fromDBUser)
 	if err != nil {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1656,19 +1656,16 @@ func (s *Store) UpdateTenantConnection(ctx context.Context, id string, cluster *
 	return nil
 }
 
-func (s *Store) UpdateTenantDBCredential(ctx context.Context, id, dbUser string, dbPasswordCipher []byte) (err error) {
+func (s *Store) UpdateTenantDBCredentialIf(ctx context.Context, id, fromDBUser, dbUser string, dbPasswordCipher []byte) (updated bool, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "update_tenant_db_credential", start, &err)
-	res, err := s.db.ExecContext(ctx, `UPDATE tenants SET db_user = ?, db_password = ?, updated_at = ? WHERE id = ?`,
-		dbUser, dbPasswordCipher, time.Now().UTC(), id)
+	res, err := s.db.ExecContext(ctx, `UPDATE tenants SET db_user = ?, db_password = ?, updated_at = ? WHERE id = ? AND db_user = ?`,
+		dbUser, dbPasswordCipher, time.Now().UTC(), id, fromDBUser)
 	if err != nil {
-		return err
+		return false, err
 	}
 	n, _ := res.RowsAffected()
-	if n == 0 {
-		return ErrNotFound
-	}
-	return nil
+	return n > 0, nil
 }
 
 func (s *Store) UpdateTenantBranch(ctx context.Context, id string, cluster *Tenant) (err error) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1656,6 +1656,21 @@ func (s *Store) UpdateTenantConnection(ctx context.Context, id string, cluster *
 	return nil
 }
 
+func (s *Store) UpdateTenantDBCredential(ctx context.Context, id, dbUser string, dbPasswordCipher []byte) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_tenant_db_credential", start, &err)
+	res, err := s.db.ExecContext(ctx, `UPDATE tenants SET db_user = ?, db_password = ?, updated_at = ? WHERE id = ?`,
+		dbUser, dbPasswordCipher, time.Now().UTC(), id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) UpdateTenantBranch(ctx context.Context, id string, cluster *Tenant) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "update_tenant_branch", start, &err)

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -57,6 +57,57 @@ func TestMetaDBMetrics(t *testing.T) {
 	}
 }
 
+func TestUpdateTenantDBCredentialIfComparesPreviousUser(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertTenant(context.Background(), &Tenant{
+		ID:               "credential-cas-tenant",
+		Status:           TenantProvisioning,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "u1.root",
+		DBPasswordCipher: []byte("root-cipher"),
+		DBName:           "tenant_db",
+		DBTLS:            true,
+		Provider:         "tidb_cloud_native",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := s.UpdateTenantDBCredentialIf(context.Background(), "credential-cas-tenant", "other.root", "u1.tidbcloud_fs_system", []byte("system-cipher"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Fatal("credential update succeeded with mismatched previous user")
+	}
+	var dbUser string
+	var passCipher []byte
+	if err := s.DB().QueryRow("SELECT db_user, db_password FROM tenants WHERE id = ?", "credential-cas-tenant").Scan(&dbUser, &passCipher); err != nil {
+		t.Fatal(err)
+	}
+	if dbUser != "u1.root" || string(passCipher) != "root-cipher" {
+		t.Fatalf("tenant credential changed after failed CAS: user=%q pass=%q", dbUser, passCipher)
+	}
+
+	updated, err = s.UpdateTenantDBCredentialIf(context.Background(), "credential-cas-tenant", "u1.root", "u1.tidbcloud_fs_system", []byte("system-cipher"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("credential update did not match previous user")
+	}
+	if err := s.DB().QueryRow("SELECT db_user, db_password FROM tenants WHERE id = ?", "credential-cas-tenant").Scan(&dbUser, &passCipher); err != nil {
+		t.Fatal(err)
+	}
+	if dbUser != "u1.tidbcloud_fs_system" || string(passCipher) != "system-cipher" {
+		t.Fatalf("tenant credential = %q/%q, want system credential", dbUser, passCipher)
+	}
+}
+
 func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC()

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -30,9 +30,13 @@ type fakeProvisioner struct {
 	cluster           *tenant.ClusterInfo
 	initErr           error
 	provisionErr      error
+	systemUserErr     error
+	systemUsername    string
+	systemPassword    string
 	deprovisionErr    error
 	provisionCalls    atomic.Int32
 	credentialCalls   atomic.Int32
+	systemUserCalls   atomic.Int32
 	deprovisionCalls  atomic.Int32
 	lastCredentialReq tenant.CredentialProvisionRequest
 	lastDeprovision   *tenant.ClusterInfo
@@ -49,6 +53,22 @@ func (f *fakeProvisioner) InitSchema(_ context.Context, dsn string) error {
 		return f.initErr
 	}
 	return nil
+}
+
+func (f *fakeProvisioner) EnsureSystemUser(_ context.Context, _ string, _ string) (string, string, error) {
+	f.systemUserCalls.Add(1)
+	if f.systemUserErr != nil {
+		return "", "", f.systemUserErr
+	}
+	username := f.systemUsername
+	if username == "" {
+		username = "u1.tidbcloud_fs_system"
+	}
+	password := f.systemPassword
+	if password == "" {
+		password = "system-pass"
+	}
+	return username, password, nil
 }
 
 func (f *fakeProvisioner) Provision(_ context.Context, tenantID string) (*tenant.ClusterInfo, error) {
@@ -434,12 +454,27 @@ func TestProvisionTiDBCloudNativeUsesRequestCredentials(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	var provider, dbName string
-	if err := metaStore.DB().QueryRow("SELECT provider, db_name FROM tenants WHERE id = ?", out["tenant_id"]).Scan(&provider, &dbName); err != nil {
+	if got := prov.systemUserCalls.Load(); got == 0 {
+		t.Fatal("native system user setup was not called")
+	}
+
+	var provider, dbName, dbUser string
+	var passCipher []byte
+	if err := metaStore.DB().QueryRow("SELECT provider, db_name, db_user, db_password FROM tenants WHERE id = ?", out["tenant_id"]).Scan(&provider, &dbName, &dbUser, &passCipher); err != nil {
 		t.Fatal(err)
 	}
 	if provider != tenant.ProviderTiDBCloudNative || dbName != "customer_db" {
 		t.Fatalf("tenant provider/db = %s/%s", provider, dbName)
+	}
+	if dbUser != "u1.tidbcloud_fs_system" {
+		t.Fatalf("tenant db_user = %q, want system user", dbUser)
+	}
+	plain, err := pool.Decrypt(context.Background(), passCipher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(plain) != "system-pass" {
+		t.Fatalf("tenant db password = %q, want system password", plain)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -85,6 +85,10 @@ type provisioningRegionProvider interface {
 	ProvisioningRegion() string
 }
 
+type nativeSystemUserProvisioner interface {
+	EnsureSystemUser(ctx context.Context, dsn, tenantID string) (username, password string, err error)
+}
+
 type Server struct {
 	fallback            *backend.Dat9Backend
 	meta                *meta.Store
@@ -3888,7 +3892,11 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			return
 		default:
 		}
-		if err := schemaInit(ctx, tenantDSN); err == nil {
+		err := schemaInit(ctx, tenantDSN)
+		if err == nil {
+			err = s.finalizeTenantSchemaInit(ctx, tenantID, tenantDSN, provider)
+		}
+		if err == nil {
 			s.schemaInitErrors.Delete(tenantID)
 			logger.Info(ctx, "server_event", eventFields(ctx, "schema_init_ok", "tenant_id", tenantID, "provider", provider, "attempt", attempt)...)
 			if s.metrics != nil {
@@ -3956,6 +3964,34 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 		backoff *= 2
 		attempt++
 	}
+}
+
+func (s *Server) finalizeTenantSchemaInit(ctx context.Context, tenantID, tenantDSN, provider string) error {
+	if provider != tenant.ProviderTiDBCloudNative {
+		return nil
+	}
+	if s.provisioner == nil {
+		return fmt.Errorf("native system user provisioner unavailable")
+	}
+	systemUserProvisioner, ok := s.provisioner.(nativeSystemUserProvisioner)
+	if !ok {
+		return fmt.Errorf("native provisioner does not support system user setup")
+	}
+	username, password, err := systemUserProvisioner.EnsureSystemUser(ctx, tenantDSN, tenantID)
+	if err != nil {
+		return fmt.Errorf("ensure native system user: %w", err)
+	}
+	if username == "" || password == "" {
+		return fmt.Errorf("native system user setup returned empty credential")
+	}
+	cipherPass, err := s.pool.Encrypt(ctx, []byte(password))
+	if err != nil {
+		return fmt.Errorf("encrypt native system user password: %w", err)
+	}
+	if err := s.meta.UpdateTenantDBCredential(ctx, tenantID, username, cipherPass); err != nil {
+		return fmt.Errorf("persist native system user credential: %w", err)
+	}
+	return nil
 }
 
 func errJSON(w http.ResponseWriter, code int, msg string) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -87,6 +87,7 @@ type provisioningRegionProvider interface {
 }
 
 type nativeSystemUserProvisioner interface {
+	// tenantID is reserved for audit/log naming; current native setup derives SQL principals from the DSN user.
 	EnsureSystemUser(ctx context.Context, dsn, tenantID string) (username, password string, err error)
 }
 
@@ -3972,7 +3973,7 @@ func (s *Server) finalizeTenantSchemaInit(ctx context.Context, tenantID, tenantD
 		return nil
 	}
 	if s.provisioner == nil {
-		return fmt.Errorf("native system user provisioner unavailable")
+		return fmt.Errorf("server misconfigured: native tenant provider is missing")
 	}
 	systemUserProvisioner, ok := s.provisioner.(nativeSystemUserProvisioner)
 	if !ok {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,6 +18,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/dat9/pkg/backend"
 	"github.com/mem9-ai/dat9/pkg/datastore"
 	"github.com/mem9-ai/dat9/pkg/embedding"
@@ -3977,6 +3978,14 @@ func (s *Server) finalizeTenantSchemaInit(ctx context.Context, tenantID, tenantD
 	if !ok {
 		return fmt.Errorf("native provisioner does not support system user setup")
 	}
+	cfg, err := mysql.ParseDSN(tenantDSN)
+	if err != nil {
+		return fmt.Errorf("parse native tenant DSN for credential finalization: %w", err)
+	}
+	fromDBUser := strings.TrimSpace(cfg.User)
+	if fromDBUser == "" {
+		return fmt.Errorf("native tenant DSN has empty username")
+	}
 	username, password, err := systemUserProvisioner.EnsureSystemUser(ctx, tenantDSN, tenantID)
 	if err != nil {
 		return fmt.Errorf("ensure native system user: %w", err)
@@ -3988,8 +3997,15 @@ func (s *Server) finalizeTenantSchemaInit(ctx context.Context, tenantID, tenantD
 	if err != nil {
 		return fmt.Errorf("encrypt native system user password: %w", err)
 	}
-	if err := s.meta.UpdateTenantDBCredential(ctx, tenantID, username, cipherPass); err != nil {
+	updated, err := s.meta.UpdateTenantDBCredentialIf(ctx, tenantID, fromDBUser, username, cipherPass)
+	if err != nil {
 		return fmt.Errorf("persist native system user credential: %w", err)
+	}
+	if !updated {
+		logger.Info(ctx, "native_system_user_credential_update_skipped",
+			zap.String("tenant_id", tenantID),
+			zap.String("from_db_user", fromDBUser),
+			zap.String("db_user", username))
 	}
 	return nil
 }

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -98,6 +98,37 @@ func (p *Provisioner) InitSchemaForAutoEmbeddingProfile(ctx context.Context, dsn
 	return schema.EnsureTiDBSchemaForAutoEmbeddingProfileDSN(ctx, dsn, profile)
 }
 
+func (p *Provisioner) EnsureSystemUser(ctx context.Context, dsn, _ string) (string, string, error) {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return "", "", err
+	}
+	username, needsSetup, err := systemUsernameForCurrent(cfg.User)
+	if err != nil {
+		return "", "", err
+	}
+	if !needsSetup {
+		return cfg.User, cfg.Passwd, nil
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() { _ = db.Close() }()
+	dbName, err := normalizeDatabaseName(cfg.DBName)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve native system user database: %w", err)
+	}
+	password, err := generateRandomPassword(24)
+	if err != nil {
+		return "", "", err
+	}
+	if err := ensureSystemUser(ctx, db, dbName, username, password); err != nil {
+		return "", "", err
+	}
+	return username, password, nil
+}
+
 func (p *Provisioner) Provision(ctx context.Context, tenantID string) (*tenant.ClusterInfo, error) {
 	return nil, fmt.Errorf("tidbcloud native requires request credentials")
 }
@@ -225,7 +256,7 @@ func (p *Provisioner) regionName() string {
 
 func clusterDisplayName(tenantID string) string {
 	const maxDisplayNameLen = 64
-	name := displayNameCharPattern.ReplaceAllString("drive9-"+tenantID, "-")
+	name := displayNameCharPattern.ReplaceAllString("tidbcloud-fs-"+tenantID, "-")
 	if len(name) <= maxDisplayNameLen {
 		return name
 	}
@@ -239,6 +270,48 @@ func (p *Provisioner) resolveDatabaseName(raw string) (string, error) {
 		name = p.defaultDatabaseName
 	}
 	return normalizeDatabaseName(name)
+}
+
+func ensureSystemUser(ctx context.Context, db *sql.DB, dbName, username, password string) error {
+	for _, stmt := range systemUserStatements(dbName, username, password) {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("execute native system user statement: %w", err)
+		}
+	}
+	return nil
+}
+
+func systemUserStatements(dbName, username, password string) []string {
+	const roleName = "tidbcloud_fs_admin"
+	return []string{
+		fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteIdent(dbName)),
+		fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s", quoteString(roleName)),
+		fmt.Sprintf("GRANT CREATE, ALTER, DROP, INDEX, SELECT, INSERT, UPDATE, DELETE ON %s.* TO %s", quoteIdent(dbName), quoteString(roleName)),
+		fmt.Sprintf("CREATE USER IF NOT EXISTS %s IDENTIFIED BY %s", quoteString(username), quoteString(password)),
+		fmt.Sprintf("ALTER USER %s IDENTIFIED BY %s", quoteString(username), quoteString(password)),
+		fmt.Sprintf("GRANT %s TO %s", quoteString(roleName), quoteString(username)),
+		fmt.Sprintf("SET DEFAULT ROLE %s TO %s", quoteString(roleName), quoteString(username)),
+	}
+}
+
+func systemUsernameForCurrent(currentUsername string) (string, bool, error) {
+	currentUsername = strings.TrimSpace(currentUsername)
+	if currentUsername == "" {
+		return "", false, fmt.Errorf("native database username is empty")
+	}
+	prefix, ok := strings.CutSuffix(currentUsername, ".root")
+	if !ok || prefix == "" {
+		return currentUsername, false, nil
+	}
+	return prefix + ".tidbcloud_fs_system", true, nil
+}
+
+func quoteIdent(value string) string {
+	return "`" + strings.ReplaceAll(value, "`", "``") + "`"
+}
+
+func quoteString(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 func parseDefaultSpendLimit(raw string) (*int32, error) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -101,30 +101,30 @@ func (p *Provisioner) InitSchemaForAutoEmbeddingProfile(ctx context.Context, dsn
 func (p *Provisioner) EnsureSystemUser(ctx context.Context, dsn, _ string) (string, string, error) {
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("parse native tenant DSN: %w", err)
 	}
 	username, needsSetup, err := systemUsernameForCurrent(cfg.User)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("resolve native system username: %w", err)
+	}
+	if cfg.Passwd == "" {
+		return "", "", fmt.Errorf("native tenant DSN password is empty")
 	}
 	if !needsSetup {
 		return cfg.User, cfg.Passwd, nil
 	}
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("open native tenant database: %w", err)
 	}
 	defer func() { _ = db.Close() }()
 	dbName, err := normalizeDatabaseName(cfg.DBName)
 	if err != nil {
 		return "", "", fmt.Errorf("resolve native system user database: %w", err)
 	}
-	password, err := generateRandomPassword(24)
-	if err != nil {
-		return "", "", err
-	}
+	password := cfg.Passwd
 	if err := ensureSystemUser(ctx, db, dbName, username, password); err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("ensure native system user: %w", err)
 	}
 	return username, password, nil
 }
@@ -273,9 +273,9 @@ func (p *Provisioner) resolveDatabaseName(raw string) (string, error) {
 }
 
 func ensureSystemUser(ctx context.Context, db *sql.DB, dbName, username, password string) error {
-	for _, stmt := range systemUserStatements(dbName, username, password) {
+	for i, stmt := range systemUserStatements(dbName, username, password) {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("execute native system user statement: %w", err)
+			return fmt.Errorf("execute native system user statement %d: %w", i+1, err)
 		}
 	}
 	return nil
@@ -300,10 +300,16 @@ func systemUsernameForCurrent(currentUsername string) (string, bool, error) {
 		return "", false, fmt.Errorf("native database username is empty")
 	}
 	prefix, ok := strings.CutSuffix(currentUsername, ".root")
-	if !ok || prefix == "" {
+	if ok {
+		if prefix == "" {
+			return "", false, fmt.Errorf("native root username %q missing user prefix", currentUsername)
+		}
+		return prefix + ".tidbcloud_fs_system", true, nil
+	}
+	if prefix, ok := strings.CutSuffix(currentUsername, ".tidbcloud_fs_system"); ok && prefix != "" {
 		return currentUsername, false, nil
 	}
-	return prefix + ".tidbcloud_fs_system", true, nil
+	return "", false, fmt.Errorf("native database username %q is not a root or tidbcloud_fs_system account", currentUsername)
 }
 
 func quoteIdent(value string) string {
@@ -311,7 +317,9 @@ func quoteIdent(value string) string {
 }
 
 func quoteString(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "'", "''")
+	return "'" + value + "'"
 }
 
 func parseDefaultSpendLimit(raw string) (*int32, error) {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -200,7 +200,7 @@ func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testin
 	if strings.Contains(gotAuth, "private-1") {
 		t.Fatalf("Authorization header leaked private key: %q", gotAuth)
 	}
-	if gotBody.DisplayName != "drive9-tenant-1" {
+	if gotBody.DisplayName != "tidbcloud-fs-tenant-1" {
 		t.Fatalf("displayName = %q", gotBody.DisplayName)
 	}
 	if gotBody.Region.Name != "regions/aws-us-east-1" {
@@ -369,11 +369,64 @@ func TestClusterDisplayNameMatchesSwaggerContract(t *testing.T) {
 	if len(got) < 4 || len(got) > 64 {
 		t.Fatalf("display name length = %d for %q", len(got), got)
 	}
+	if !strings.HasPrefix(got, "tidbcloud-fs-") {
+		t.Fatalf("display name = %q, want tidbcloud-fs prefix", got)
+	}
 	matched, err := regexp.MatchString(`^[A-Za-z0-9][-A-Za-z0-9]{2,62}[A-Za-z0-9]$`, got)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !matched {
 		t.Fatalf("display name %q does not match swagger pattern", got)
+	}
+}
+
+func TestSystemUsernameForCurrent(t *testing.T) {
+	got, needsSetup, err := systemUsernameForCurrent("22ipQWBXXq2wN2S.root")
+	if err != nil {
+		t.Fatalf("systemUsernameForCurrent: %v", err)
+	}
+	if !needsSetup || got != "22ipQWBXXq2wN2S.tidbcloud_fs_system" {
+		t.Fatalf("system username = %q setup=%v", got, needsSetup)
+	}
+	got, needsSetup, err = systemUsernameForCurrent("22ipQWBXXq2wN2S.tidbcloud_fs_system")
+	if err != nil {
+		t.Fatalf("systemUsernameForCurrent existing: %v", err)
+	}
+	if needsSetup || got != "22ipQWBXXq2wN2S.tidbcloud_fs_system" {
+		t.Fatalf("existing system username = %q setup=%v", got, needsSetup)
+	}
+	if _, _, err := systemUsernameForCurrent(""); err == nil {
+		t.Fatal("expected empty username error")
+	}
+}
+
+func TestSystemUserStatements(t *testing.T) {
+	got := systemUserStatements("tidbcloud_fs", "22ipQWBXXq2wN2S.tidbcloud_fs_system", "pass123")
+	want := []string{
+		"CREATE DATABASE IF NOT EXISTS `tidbcloud_fs`",
+		"CREATE ROLE IF NOT EXISTS 'tidbcloud_fs_admin'",
+		"GRANT CREATE, ALTER, DROP, INDEX, SELECT, INSERT, UPDATE, DELETE ON `tidbcloud_fs`.* TO 'tidbcloud_fs_admin'",
+		"CREATE USER IF NOT EXISTS '22ipQWBXXq2wN2S.tidbcloud_fs_system' IDENTIFIED BY 'pass123'",
+		"ALTER USER '22ipQWBXXq2wN2S.tidbcloud_fs_system' IDENTIFIED BY 'pass123'",
+		"GRANT 'tidbcloud_fs_admin' TO '22ipQWBXXq2wN2S.tidbcloud_fs_system'",
+		"SET DEFAULT ROLE 'tidbcloud_fs_admin' TO '22ipQWBXXq2wN2S.tidbcloud_fs_system'",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("statement count = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("statement %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSQLQuoting(t *testing.T) {
+	if got := quoteIdent("db`name"); got != "`db``name`" {
+		t.Fatalf("quoteIdent = %q", got)
+	}
+	if got := quoteString("u'ser"); got != "'u''ser'" {
+		t.Fatalf("quoteString = %q", got)
 	}
 }

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -399,6 +399,11 @@ func TestSystemUsernameForCurrent(t *testing.T) {
 	if _, _, err := systemUsernameForCurrent(""); err == nil {
 		t.Fatal("expected empty username error")
 	}
+	for _, username := range []string{"root", "u1.admin"} {
+		if _, _, err := systemUsernameForCurrent(username); err == nil {
+			t.Fatalf("expected unexpected username %q to be rejected", username)
+		}
+	}
 }
 
 func TestSystemUserStatements(t *testing.T) {
@@ -426,7 +431,7 @@ func TestSQLQuoting(t *testing.T) {
 	if got := quoteIdent("db`name"); got != "`db``name`" {
 		t.Fatalf("quoteIdent = %q", got)
 	}
-	if got := quoteString("u'ser"); got != "'u''ser'" {
+	if got := quoteString(`u'ser\name`); got != `'u''ser\\name'` {
 		t.Fatalf("quoteString = %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- change TiDB Cloud native cluster display name to `tidbcloud-fs-<tenant_id>`
- create the `tidbcloud_fs_admin` role and `<prefix>.tidbcloud_fs_system` user during async schema initialization
- keep metadata on `<prefix>.root` until the async role/user setup succeeds, then switch `db_user`/`db_password` to the restricted system user

## Review notes
- The system user reuses the current root DSN password. This keeps concurrent/retried `ALTER USER` calls deterministic and avoids DB/metadata password skew.
- The role is granted only database-scoped privileges on the tenant DB.
- Resume is idempotent: if metadata still has `<prefix>.root`, setup is retried; if metadata already has `<prefix>.tidbcloud_fs_system`, finalize treats it as complete. Unexpected native usernames are rejected.
- Metadata credential persistence uses a compare-and-swap update on the previous `db_user`.

## Tests
- `env GOCACHE=/tmp/drive9-gocache go test ./cmd/drive9-server ./pkg/tenant/tidbcloudnative ./pkg/server ./pkg/meta`
- `make lint`
- `git diff --check`