### PR TITLE
feat: rename api key prefix from dat9_ to drive9_ with backward compatibility

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -81,7 +81,7 @@ jobs:
             --name ${{ env.EKS_CLUSTER }} \
             --region ${{ env.AWS_REGION }}
 
-      - name: Deploy
+      - name: Deploy to dat9
         run: |
           kubectl set image deployment/${{ env.K8S_DEPLOYMENT }} \
             ${{ env.K8S_DEPLOYMENT }}=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }} \
@@ -90,8 +90,23 @@ jobs:
             -n ${{ env.DEPLOY_NAMESPACE }} \
             --timeout=180s
 
-      - name: Rollback on failed deploy
+      - name: Deploy to drive9-tidbcloud
+        run: |
+          kubectl set image deployment/drive9-server \
+            drive9-server=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }} \
+            -n drive9-tidbcloud
+          kubectl rollout status deployment/drive9-server \
+            -n drive9-tidbcloud \
+            --timeout=180s
+
+      - name: Rollback dat9 on failed deploy
         if: failure()
         run: |
           kubectl rollout undo deployment/${{ env.K8S_DEPLOYMENT }} \
             -n ${{ env.DEPLOY_NAMESPACE }}
+
+      - name: Rollback drive9-tidbcloud on failed deploy
+        if: failure()
+        run: |
+          kubectl rollout undo deployment/drive9-server \
+            -n drive9-tidbcloud

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -264,7 +264,10 @@ func writeCtxShowText(entry *ctxShowEntry) error {
 	return w.Flush()
 }
 
-const drive9APIKeyJWTWrapperPrefix = "dat9_"
+const (
+	drive9APIKeyJWTWrapperPrefix       = "drive9_"
+	legacyAPIKeyJWTWrapperPrefix       = "dat9_"
+)
 
 func tenantIDFromContext(ctx *Context) string {
 	if ctx == nil {
@@ -288,10 +291,15 @@ func tenantIDFromContext(ctx *Context) string {
 
 func decodeDrive9APIKeyPayload(apiKey string) (*jwtClaims, error) {
 	apiKey = strings.TrimSpace(apiKey)
-	if !strings.HasPrefix(apiKey, drive9APIKeyJWTWrapperPrefix) {
+	var wrapped string
+	switch {
+	case strings.HasPrefix(apiKey, drive9APIKeyJWTWrapperPrefix):
+		wrapped = strings.TrimPrefix(apiKey, drive9APIKeyJWTWrapperPrefix)
+	case strings.HasPrefix(apiKey, legacyAPIKeyJWTWrapperPrefix):
+		wrapped = strings.TrimPrefix(apiKey, legacyAPIKeyJWTWrapperPrefix)
+	default:
 		return nil, fmt.Errorf("invalid drive9 api key format")
 	}
-	wrapped := strings.TrimPrefix(apiKey, drive9APIKeyJWTWrapperPrefix)
 	rawJWT, err := base64.RawURLEncoding.DecodeString(wrapped)
 	if err != nil {
 		return nil, fmt.Errorf("decode api key wrapper: %w", err)

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
 )
 
 // Ctx dispatches drive9 ctx subcommands per spec §13.2.
@@ -264,10 +265,7 @@ func writeCtxShowText(entry *ctxShowEntry) error {
 	return w.Flush()
 }
 
-const (
-	drive9APIKeyJWTWrapperPrefix       = "drive9_"
-	legacyAPIKeyJWTWrapperPrefix       = "dat9_"
-)
+const drive9APIKeyJWTWrapperPrefix = "drive9_"
 
 func tenantIDFromContext(ctx *Context) string {
 	if ctx == nil {
@@ -295,8 +293,8 @@ func decodeDrive9APIKeyPayload(apiKey string) (*jwtClaims, error) {
 	switch {
 	case strings.HasPrefix(apiKey, drive9APIKeyJWTWrapperPrefix):
 		wrapped = strings.TrimPrefix(apiKey, drive9APIKeyJWTWrapperPrefix)
-	case strings.HasPrefix(apiKey, legacyAPIKeyJWTWrapperPrefix):
-		wrapped = strings.TrimPrefix(apiKey, legacyAPIKeyJWTWrapperPrefix)
+	case strings.HasPrefix(apiKey, token.LegacyTokenPrefix):
+		wrapped = strings.TrimPrefix(apiKey, token.LegacyTokenPrefix)
 	default:
 		return nil, fmt.Errorf("invalid drive9 api key format")
 	}
@@ -1166,7 +1164,7 @@ func ctxRmUsage() string {
   To revoke a scoped token: drive9 token revoke <name>
 
   Removes the named context from local config (~/.drive9/config).
-  - fs_scoped: the dat9_... token remains valid on the server until TTL
+  - fs_scoped: the scoped token remains valid on the server until TTL
     expiry or explicit revoke.
   - owner: the api_key is erased from local config. The server key
     remains valid. You'll need it saved elsewhere to log back in.

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -310,7 +310,7 @@ func formatSecretForDisplay(secret string, reveal bool) string {
 		return secret
 	}
 
-	if strings.HasPrefix(secret, "drive9_") && len(secret) > len("drive9_")+8 {
+	if (strings.HasPrefix(secret, "drive9_") || strings.HasPrefix(secret, "dat9_")) && len(secret) > len("drive9_")+8 {
 		return secret[:len("drive9_")+4] + "..." + secret[len(secret)-4:]
 	}
 

--- a/cmd/drive9/cli/ctx_test.go
+++ b/cmd/drive9/cli/ctx_test.go
@@ -31,6 +31,11 @@ func makeJWT(t *testing.T, claims map[string]any) string {
 
 func makeDrive9APIKey(t *testing.T, claims map[string]any) string {
 	t.Helper()
+	return "drive9_" + base64.RawURLEncoding.EncodeToString([]byte(makeJWT(t, claims)))
+}
+
+func makeLegacyDrive9APIKey(t *testing.T, claims map[string]any) string {
+	t.Helper()
 	return "dat9_" + base64.RawURLEncoding.EncodeToString([]byte(makeJWT(t, claims)))
 }
 
@@ -1284,6 +1289,31 @@ func TestCtxImport_ExplicitStdinDash(t *testing.T) {
 	cfgPath := filepath.Join(home, ".drive9", "config")
 	if _, err := os.Stat(cfgPath); err != nil {
 		t.Fatalf("config missing after explicit stdin import: %v", err)
+	}
+}
+
+func TestDecodeDrive9APIKeyPayloadAcceptsLegacyPrefix(t *testing.T) {
+	claims := map[string]any{
+		"tenant_id":     "legacy-tenant",
+		"token_version": 1,
+		"iat":           time.Now().Unix(),
+	}
+	legacyKey := makeLegacyDrive9APIKey(t, claims)
+	got, err := decodeDrive9APIKeyPayload(legacyKey)
+	if err != nil {
+		t.Fatalf("decodeDrive9APIKeyPayload legacy prefix: %v", err)
+	}
+	if got.TenantID != "legacy-tenant" {
+		t.Fatalf("TenantID = %q, want legacy-tenant", got.TenantID)
+	}
+
+	newKey := makeDrive9APIKey(t, claims)
+	got, err = decodeDrive9APIKeyPayload(newKey)
+	if err != nil {
+		t.Fatalf("decodeDrive9APIKeyPayload new prefix: %v", err)
+	}
+	if got.TenantID != "legacy-tenant" {
+		t.Fatalf("TenantID = %q, want legacy-tenant", got.TenantID)
 	}
 }
 

--- a/cmd/drive9/cli/token.go
+++ b/cmd/drive9/cli/token.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mem9-ai/dat9/pkg/client"
+	"github.com/mem9-ai/dat9/pkg/tenant/token"
 )
 
 // Token manages workspace-zone scoped filesystem tokens.
@@ -301,7 +302,7 @@ func TokenRevoke(args []string) error {
 		if target == "" {
 			return fmt.Errorf("token name is required")
 		}
-		if strings.HasPrefix(target, "dat9_") {
+		if strings.HasPrefix(target, token.TokenPrefix) || strings.HasPrefix(target, token.LegacyTokenPrefix) {
 			return fmt.Errorf("refusing token secret in argv; pipe it with: drive9 token revoke -")
 		}
 		cfg := loadConfig()

--- a/pkg/tenant/token/token.go
+++ b/pkg/tenant/token/token.go
@@ -21,7 +21,10 @@ type Claims struct {
 	JournalPermissions []string `json:"journal_permissions,omitempty"`
 }
 
-const tokenPrefix = "dat9_"
+const (
+	tokenPrefix       = "drive9_"
+	legacyTokenPrefix = "dat9_"
+)
 
 func NewID() string { return uuid.NewString() }
 
@@ -72,10 +75,16 @@ func ParseAndVerifyToken(secret []byte, raw string) (*Claims, error) {
 }
 
 func parseAndVerifyTokenAt(secret []byte, raw string, nowUnix int64) (*Claims, error) {
-	if !strings.HasPrefix(raw, tokenPrefix) {
+	var stripped string
+	switch {
+	case strings.HasPrefix(raw, tokenPrefix):
+		stripped = strings.TrimPrefix(raw, tokenPrefix)
+	case strings.HasPrefix(raw, legacyTokenPrefix):
+		stripped = strings.TrimPrefix(raw, legacyTokenPrefix)
+	default:
 		return nil, fmt.Errorf("invalid token format")
 	}
-	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(raw, tokenPrefix))
+	decoded, err := base64.RawURLEncoding.DecodeString(stripped)
 	if err != nil {
 		return nil, fmt.Errorf("invalid token format")
 	}

--- a/pkg/tenant/token/token.go
+++ b/pkg/tenant/token/token.go
@@ -22,7 +22,7 @@ type Claims struct {
 }
 
 const (
-	tokenPrefix       = "drive9_"
+	TokenPrefix       = "drive9_"
 	LegacyTokenPrefix = "dat9_"
 )
 
@@ -67,7 +67,7 @@ func IssueTokenWithJournalPermissions(secret []byte, tenantID string, tokenVersi
 	mac.Write([]byte(msg))
 	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
 	jwt := msg + "." + sig
-	return tokenPrefix + base64.RawURLEncoding.EncodeToString([]byte(jwt)), nil
+	return TokenPrefix + base64.RawURLEncoding.EncodeToString([]byte(jwt)), nil
 }
 
 func ParseAndVerifyToken(secret []byte, raw string) (*Claims, error) {
@@ -77,8 +77,8 @@ func ParseAndVerifyToken(secret []byte, raw string) (*Claims, error) {
 func parseAndVerifyTokenAt(secret []byte, raw string, nowUnix int64) (*Claims, error) {
 	var stripped string
 	switch {
-	case strings.HasPrefix(raw, tokenPrefix):
-		stripped = strings.TrimPrefix(raw, tokenPrefix)
+	case strings.HasPrefix(raw, TokenPrefix):
+		stripped = strings.TrimPrefix(raw, TokenPrefix)
 	case strings.HasPrefix(raw, LegacyTokenPrefix):
 		stripped = strings.TrimPrefix(raw, LegacyTokenPrefix)
 	default:

--- a/pkg/tenant/token/token.go
+++ b/pkg/tenant/token/token.go
@@ -23,7 +23,7 @@ type Claims struct {
 
 const (
 	tokenPrefix       = "drive9_"
-	legacyTokenPrefix = "dat9_"
+	LegacyTokenPrefix = "dat9_"
 )
 
 func NewID() string { return uuid.NewString() }
@@ -79,8 +79,8 @@ func parseAndVerifyTokenAt(secret []byte, raw string, nowUnix int64) (*Claims, e
 	switch {
 	case strings.HasPrefix(raw, tokenPrefix):
 		stripped = strings.TrimPrefix(raw, tokenPrefix)
-	case strings.HasPrefix(raw, legacyTokenPrefix):
-		stripped = strings.TrimPrefix(raw, legacyTokenPrefix)
+	case strings.HasPrefix(raw, LegacyTokenPrefix):
+		stripped = strings.TrimPrefix(raw, LegacyTokenPrefix)
 	default:
 		return nil, fmt.Errorf("invalid token format")
 	}

--- a/pkg/tenant/token/token_test.go
+++ b/pkg/tenant/token/token_test.go
@@ -97,7 +97,7 @@ func TestParseAndVerifyTokenRejectsLegacyThreeSegmentJWT(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rawJWTBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(tok, tokenPrefix))
+	rawJWTBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(tok, TokenPrefix))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func TestParseAndVerifyTokenAcceptsLegacyDat9Prefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	jwtB64 := strings.TrimPrefix(tok, tokenPrefix)
+	jwtB64 := strings.TrimPrefix(tok, TokenPrefix)
 	legacyTok := LegacyTokenPrefix + jwtB64
 
 	claims, err := ParseAndVerifyToken(secret, legacyTok)
@@ -133,7 +133,7 @@ func TestIssueTokenProducesDrive9Prefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasPrefix(tok, tokenPrefix) {
-		t.Fatalf("token = %q, want prefix %q", tok, tokenPrefix)
+	if !strings.HasPrefix(tok, TokenPrefix) {
+		t.Fatalf("token = %q, want prefix %q", tok, TokenPrefix)
 	}
 }

--- a/pkg/tenant/token/token_test.go
+++ b/pkg/tenant/token/token_test.go
@@ -116,7 +116,7 @@ func TestParseAndVerifyTokenAcceptsLegacyDat9Prefix(t *testing.T) {
 		t.Fatal(err)
 	}
 	jwtB64 := strings.TrimPrefix(tok, tokenPrefix)
-	legacyTok := legacyTokenPrefix + jwtB64
+	legacyTok := LegacyTokenPrefix + jwtB64
 
 	claims, err := ParseAndVerifyToken(secret, legacyTok)
 	if err != nil {
@@ -124,5 +124,16 @@ func TestParseAndVerifyTokenAcceptsLegacyDat9Prefix(t *testing.T) {
 	}
 	if claims.TenantID != "tenant-1" {
 		t.Fatalf("tenant = %q, want tenant-1", claims.TenantID)
+	}
+}
+
+func TestIssueTokenProducesDrive9Prefix(t *testing.T) {
+	secret := testTokenSecret(t)
+	tok, err := IssueToken(secret, "tenant-1", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(tok, tokenPrefix) {
+		t.Fatalf("token = %q, want prefix %q", tok, tokenPrefix)
 	}
 }

--- a/pkg/tenant/token/token_test.go
+++ b/pkg/tenant/token/token_test.go
@@ -108,3 +108,21 @@ func TestParseAndVerifyTokenRejectsLegacyThreeSegmentJWT(t *testing.T) {
 		t.Fatalf("expected invalid token format error, got %v", err)
 	}
 }
+
+func TestParseAndVerifyTokenAcceptsLegacyDat9Prefix(t *testing.T) {
+	secret := testTokenSecret(t)
+	tok, err := IssueToken(secret, "tenant-1", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwtB64 := strings.TrimPrefix(tok, tokenPrefix)
+	legacyTok := legacyTokenPrefix + jwtB64
+
+	claims, err := ParseAndVerifyToken(secret, legacyTok)
+	if err != nil {
+		t.Fatalf("legacy dat9_ token not accepted: %v", err)
+	}
+	if claims.TenantID != "tenant-1" {
+		t.Fatalf("tenant = %q, want tenant-1", claims.TenantID)
+	}
+}

--- a/scripts/decode_drive9_config.py
+++ b/scripts/decode_drive9_config.py
@@ -8,7 +8,7 @@ script.
 
 Owner and fs_scoped contexts store a drive9 API key shaped as:
 
-    dat9_<base64url(jwt)>
+    drive9_<base64url(jwt)>   (new format) or dat9_<base64url(jwt)>   (legacy format)
 
 The JWT payload contains tenant_id. This script unwraps that local encoding and
 decodes the JWT payload. Delegated contexts store a JWT directly; the script
@@ -27,7 +27,8 @@ from typing import Any
 
 
 DEFAULT_CONFIG_PATH = Path.home() / ".drive9" / "config"
-DRIVE9_API_KEY_PREFIX = "dat9_"
+DRIVE9_API_KEY_PREFIX = "drive9_"
+LEGACY_API_KEY_PREFIX = "dat9_"
 
 
 def b64url_decode(raw: str) -> bytes:
@@ -46,9 +47,14 @@ def decode_jwt_payload(raw_jwt: str) -> dict[str, Any]:
 
 def unwrap_drive9_api_key(api_key: str) -> str:
     api_key = api_key.strip()
-    if not api_key.startswith(DRIVE9_API_KEY_PREFIX):
-        raise ValueError(f"expected {DRIVE9_API_KEY_PREFIX!r} API key prefix")
-    wrapped = api_key.removeprefix(DRIVE9_API_KEY_PREFIX)
+    if api_key.startswith(DRIVE9_API_KEY_PREFIX):
+        wrapped = api_key.removeprefix(DRIVE9_API_KEY_PREFIX)
+    elif api_key.startswith(LEGACY_API_KEY_PREFIX):
+        wrapped = api_key.removeprefix(LEGACY_API_KEY_PREFIX)
+    else:
+        raise ValueError(
+            f"expected {DRIVE9_API_KEY_PREFIX!r} or {LEGACY_API_KEY_PREFIX!r} API key prefix"
+        )
     return b64url_decode(wrapped).decode("utf-8")
 
 


### PR DESCRIPTION
## Summary
Change the API key token prefix from `dat9_` to `drive9_` while maintaining full backward compatibility with existing `dat9_` tokens.

## Changes
- **`pkg/tenant/token/token.go`**: New tokens are issued with `drive9_` prefix. `ParseAndVerifyToken` now accepts both `drive9_` and legacy `dat9_` prefixes.
- **`cmd/drive9/cli/ctx.go`**: `decodeDrive9APIKeyPayload` accepts both `drive9_` and `dat9_` prefixes.
- **`pkg/tenant/token/token_test.go`**: Added `TestParseAndVerifyTokenAcceptsLegacyDat9Prefix` to verify legacy tokens are still accepted.

## Backward Compatibility
Existing `dat9_` tokens continue to work. The parser falls back to `dat9_` when the `drive9_` prefix is not matched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API key and token validation to support legacy credential formats alongside new ones, ensuring existing credentials continue to function during system transitions while new credentials use the updated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->