### PR TITLE
feat: native e2e smoke test + reject credentials on non-native providers

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -31,6 +31,9 @@ Current shared dev deployment:
 # Dev
 export DRIVE9_BASE="http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com"
 
+# Dev (tidbcloud-native)
+export DRIVE9_BASE="http://k8s-drive9ti-drive9se-b6bbe5ba6e-cee81207452d1185.elb.ap-southeast-1.amazonaws.com"
+
 # Prod
 export DRIVE9_BASE="https://api.drive9.ai"
 ```
@@ -91,6 +94,14 @@ RUN_GIT_OPS_SMOKE=1 RUN_GIT_WORKSPACE_SMOKE=1 bash e2e/smoke-all.sh
 
 # Include portable profile pack/unpack coverage in smoke-all when desired.
 RUN_PORTABLE_PACK_E2E=1 bash e2e/smoke-all.sh
+
+# TiDB Cloud Native (tidbcloud-native) tenant lifecycle smoke
+# Requires credentials, not wired into CI. Set DRIVE9_BASE from Deployment
+# endpoints above, or export manually. Credentials are stored in repo secrets
+# (DRIVE9_TIDBCLOUD_PUBLIC_KEY, DRIVE9_TIDBCLOUD_PRIVATE_KEY).
+DRIVE9_TIDBCLOUD_PUBLIC_KEY="$DRIVE9_TIDBCLOUD_PUBLIC_KEY" \
+DRIVE9_TIDBCLOUD_PRIVATE_KEY="$DRIVE9_TIDBCLOUD_PRIVATE_KEY" \
+bash e2e/native-smoke-test.sh
 ```
 
 ### Local via `drive9-server-local`
@@ -494,6 +505,16 @@ enabled.
 5. Runs `portable-pack-unpack-e2e.sh` when `RUN_PORTABLE_PACK_E2E=1`
 6. Aggregates pass/fail at script level for quick regression checks
 
+### `native-smoke-test.sh`
+
+Manual-only: requires TiDB Cloud API credentials. Not wired into CI.
+
+1. Provision tenant via `drive9 create` with `--tidbcloud-public-key` / `--tidbcloud-private-key`
+2. Poll `GET /v1/status` until active
+3. Basic CLI fs operations (`mkdir`, `cp`, `cat`, `ls`, `rm`)
+4. Delete tenant via `drive9 delete` and verify removal (401/403/404 on `GET /v1/status`)
+5. Trap-based cleanup: attempts `drive9 delete` on script failure unless `SKIP_CLEANUP=1`
+
 ## Environment variables
 
 | Variable | Default | Used by |
@@ -596,6 +617,9 @@ enabled.
 | `PJDFSTEST_MOUNT_ALLOW_OTHER` | `auto` | on-demand `pjdfstest-suite.sh` / `posix-feature-matrix.sh`; Linux auto-adds `--allow-other`, Darwin does not |
 | `GIT_MATRIX_TIMEOUT_S` | `240` | on-demand `git-feature-matrix.sh` |
 | `GIT_MATRIX_RUN_OVERSIZED` | `1` | on-demand `git-feature-matrix.sh` |
+| `DRIVE9_TIDBCLOUD_PUBLIC_KEY` | *(required)* | `native-smoke-test.sh` |
+| `DRIVE9_TIDBCLOUD_PRIVATE_KEY` | *(required)* | `native-smoke-test.sh` |
+| `SKIP_CLEANUP` | `0` | `native-smoke-test.sh` |
 
 ## Conventions
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -31,6 +31,7 @@ including local single-tenant validation via `drive9-server-local`.
 | `fuse-write-perf-budget-test.sh` | FUSE write-path perf budgets: fsync-heavy workload with deterministic op-count budgets (remote writes/stats/lists/mutations, commit retries/failures) plus an fsync latency ceiling, asserted from mount perf counters |
 | `git-workspace-smoke-test.sh` | Git workspace fast-blobless clone with coding-agent local overlay, batched tracked-file edits, ignored local-only paths, `git add`/`commit`, `git apply`, and remount restore |
 | `posix-permission-smoke-test.sh` | POSIX permission coverage: API mkdir/chmod mode propagation, CLI `fs chmod`, FUSE `chmod`/`mkdir -m` with remote and local stat parity |
+| `native-smoke-test.sh` | TiDB Cloud Native tenant lifecycle: CLI provision with credentials, status poll, basic fs ops (mkdir/cp/cat/ls/rm), delete + verification, trap cleanup on failure |
 | `pjdfstest-suite.sh` | On-demand Linux/macOS pjdfstest POSIX compatibility suite over a real Drive9 FUSE mount; `pjdfstests.sh` and `posix-feature-matrix.sh` are aliases |
 | `smoke-all.sh` | Runs API + CLI + journal + layer FS + FUSE + POSIX permission smoke scripts in sequence with aggregated pass/fail; set `RUN_FUSE_SMOKE=0` to skip FUSE symlink/hardlink coverage, `RUN_GIT_OPS_SMOKE=1` to include lightweight Git coverage, `RUN_GIT_WORKSPACE_SMOKE=1` to include heavier Git workspace coverage, and `RUN_PORTABLE_PACK_E2E=1` to include portable pack/unpack coverage |
 | `local-smoke.sh` | Starts `drive9-server-local` with a disposable local DB by default, then runs `smoke-all.sh` with semantic checks disabled and FUSE smoke skipped unless `RUN_FUSE_SMOKE=1` |
@@ -47,7 +48,7 @@ without adding it to `.github/workflows/local-e2e.yml`.
 | Post-merge | `push` to `main` (local-e2e, coalesced via concurrency group) | PR gate + concurrency stress, POSIX/fsx, sqlite WAL/churn/concurrency, full `smoke-all.sh` (journal, posix-permission, git-workspace), git feature matrix |
 | Nightly | cron 20:17 UTC (local-e2e) | Post-merge set + FUSE performance baseline/archive/compare (compare is report-only; hosted-runner noise) |
 | Manual all | `e2e-all` workflow (`Run workflow` button) | Everything above + pjdfstest POSIX suite (best-effort) via `run_all_e2e=1` |
-| Manual only | not wired, run by hand | `layer-fs-smoke-test-realdev.sh` (shared dev endpoint), `verify-description-e2e.sh` (Docker + Ollama), `verify-description-tidb-zero-e2e.sh` (TiDB Cloud Zero), `local-smoke.sh` (`make e2e-local` wrapper) |
+| Manual only | not wired, run by hand | `layer-fs-smoke-test-realdev.sh` (shared dev endpoint), `verify-description-e2e.sh` (Docker + Ollama), `verify-description-tidb-zero-e2e.sh` (TiDB Cloud Zero), `native-smoke-test.sh` (TiDB Cloud Native — requires credentials), `local-smoke.sh` (`make e2e-local` wrapper) |
 
 Scheduled and post-merge failures auto-file/append to a `ci-e2e-failure`
 GitHub issue, since GitHub only notifies the workflow author otherwise.
@@ -64,6 +65,9 @@ Use a hosted deployment by default. For local development on this machine, use
 ```bash
 # Dev
 export DRIVE9_BASE="http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com"
+
+# Dev (tidbcloud-native)
+export DRIVE9_BASE="http://k8s-drive9ti-drive9se-b6bbe5ba6e-cee81207452d1185.elb.ap-southeast-1.amazonaws.com"
 
 # Prod
 export DRIVE9_BASE="https://api.drive9.ai"
@@ -155,6 +159,9 @@ CLI_SOURCE=official bash e2e/fuse-release-gate.sh
 CLI_SOURCE=official bash e2e/posix-permission-smoke-test.sh
 
 bash e2e/posix-permission-smoke-test.sh
+
+# TiDB Cloud Native tenant lifecycle smoke (requires credentials, manual-only).
+DRIVE9_TIDBCLOUD_PUBLIC_KEY=xxx DRIVE9_TIDBCLOUD_PRIVATE_KEY=xxx bash e2e/native-smoke-test.sh
 
 bash e2e/smoke-all.sh
 

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -131,12 +131,14 @@ echo "hello native smoke test $TS" > "$TMP_FILE"
 # ── [1] provision tenant ────────────────────────────────────────────────────
 
 echo "[1] provision tenant"
+set +e
 create_out="$(drive9_ctx create \
   --server "$BASE" \
   --tidbcloud-public-key "$PUBLIC_KEY" \
   --tidbcloud-private-key "$PRIVATE_KEY" \
   --json 2>&1)"
 create_code=$?
+set -e
 check_eq "drive9 create exit code" "$create_code" "0"
 
 API_KEY="$(printf '%s' "$create_out" | jq -r '.api_key // empty')"
@@ -241,6 +243,7 @@ drive9_retry fs rm "$BATCH_DIR" >/dev/null
 rm -f "$LARGE_LOCAL" "$LARGE_DOWNLOADED"
 
 echo "[6] delete tenant"
+set +e
 delete_out="$(drive9_ctx delete \
   --server "$BASE" \
   --api-key "$API_KEY" \
@@ -248,6 +251,7 @@ delete_out="$(drive9_ctx delete \
   --tidbcloud-private-key "$PRIVATE_KEY" \
   --json 2>&1)"
 delete_code=$?
+set -e
 check_eq "drive9 delete exit code" "$delete_code" "0"
 
 DELETE_STATUS="$(printf '%s' "$delete_out" | jq -r '.status // empty')"

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -101,7 +101,7 @@ drive9_retry() {
     if out="$(drive9 "$@" 2>&1)"; then
       printf '%s' "$out"; return 0
     fi
-    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"not found"* ]]; then
+    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"HTTP 502"* || "$out" == *"not found"* || "$out" == *"unexpected EOF"* || "$out" == *"connection reset"* ]]; then
       echo "retry $attempt/$CLI_MAX_RETRIES for drive9 $* " >&2
       sleep "$CLI_RETRY_SLEEP_S"; attempt=$((attempt+1)); continue
     fi

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -112,13 +112,20 @@ drive9_retry() {
 
 cleanup() {
   if [ "$CREATED" -eq 1 ] && [ "$SKIP_CLEANUP" != "1" ] && [ -n "${TENANT_ID:-}" ]; then
-    echo "[cleanup] deleting tenant $TENANT_ID"
-    drive9_ctx delete \
-      --server "$BASE" \
-      --api-key "${API_KEY:-}" \
-      --tidbcloud-public-key "$PUBLIC_KEY" \
-      --tidbcloud-private-key "$PRIVATE_KEY" \
-      >/dev/null 2>&1 || true
+    echo "[cleanup] deleting tenant $TENANT_ID" >&2
+    for i in $(seq 1 3); do
+      if drive9_ctx delete \
+        --server "$BASE" \
+        --api-key "${API_KEY:-}" \
+        --tidbcloud-public-key "$PUBLIC_KEY" \
+        --tidbcloud-private-key "$PRIVATE_KEY" \
+        >/tmp/native-cleanup.log 2>&1; then
+        echo "[cleanup] tenant $TENANT_ID deleted" >&2
+        break
+      fi
+      echo "[cleanup] retry $i/3 deleting tenant $TENANT_ID (see /tmp/native-cleanup.log)" >&2
+      sleep 30
+    done
   fi
   rm -f "$CLI_BIN" "$TMP_FILE"
   rm -rf "$CLI_HOME"
@@ -217,7 +224,7 @@ check_cmd "rm -r batch dir" true
 
 echo "[5] large file upload/download"
 
-LARGE_MB="${CLI_LARGE_FILE_MB:-100}"
+LARGE_MB="${CLI_LARGE_FILE_MB:-50}"
 LARGE_LOCAL="$(mktemp)"
 LARGE_REMOTE="$BATCH_DIR/large-${TS}.bin"
 LARGE_DOWNLOADED="$(mktemp)"

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -111,7 +111,7 @@ drive9_retry() {
 }
 
 cleanup() {
-  if [ "$CREATED" -eq 1 ] && [ "$SKIP_CLEANUP" != "1" ]; then
+  if [ "$CREATED" -eq 1 ] && [ "$SKIP_CLEANUP" != "1" ] && [ -n "${TENANT_ID:-}" ]; then
     echo "[cleanup] deleting tenant $TENANT_ID"
     drive9_ctx delete \
       --server "$BASE" \
@@ -166,15 +166,12 @@ check_eq "tenant becomes active" "$LAST_STATUS" "active"
 
 # ── [3] basic fs operations ─────────────────────────────────────────────────
 
-echo "[3] basic fs operations"
+echo "[3] small file ops"
 
 DIR="/$TEST_DIR"
 
 drive9_retry fs mkdir "$DIR" >/dev/null
-check_cmd "mkdir $DIR" true
-
 drive9_retry fs cp "$TMP_FILE" ":$DIR/hello.txt" >/dev/null
-check_cmd "cp file to $DIR/hello.txt" true
 
 ls_out="$(drive9_retry fs ls "$DIR")"
 check_cmd "ls $DIR lists file" bash -c "echo \"\$1\" | grep -q hello.txt" _ "$ls_out"
@@ -182,22 +179,68 @@ check_cmd "ls $DIR lists file" bash -c "echo \"\$1\" | grep -q hello.txt" _ "$ls
 cat_out="$(drive9_retry fs cat "$DIR/hello.txt")"
 check_cmd "cat $DIR/hello.txt returns content" bash -c "echo \"\$1\" | grep -q 'hello native smoke test'" _ "$cat_out"
 
-drive9_retry fs rm "$DIR/hello.txt" >/dev/null
-check_cmd "rm $DIR/hello.txt" true
+mv_dst="$DIR/world.txt"
+drive9_retry fs mv "$DIR/hello.txt" "$mv_dst" >/dev/null
 
-ls_after="$(drive9_retry fs ls "$DIR" 2>&1 || true)"
-if printf '%s' "$ls_after" | grep -q "hello.txt"; then
-  check_eq "rm $DIR/hello.txt removes file" "fail" "pass"
-else
-  check_cmd "rm $DIR/hello.txt removes file" true
-fi
+mv_ls="$(drive9_retry fs ls "$DIR")"
+check_cmd "ls after mv shows world.txt" bash -c "echo \"\$1\" | grep -q world.txt" _ "$mv_ls"
 
+drive9_retry fs rm "$mv_dst" >/dev/null
 drive9_retry fs rm "$DIR" >/dev/null
-check_cmd "rmdir $DIR" true
 
-# ── [4] delete tenant ───────────────────────────────────────────────────────
+echo "[4] batch small file ops"
 
-echo "[4] delete tenant"
+BATCH_DIR="/native-batch-${TS}"
+BATCH_COUNT=5
+drive9_retry fs mkdir "$BATCH_DIR" >/dev/null
+for i in $(seq 1 "$BATCH_COUNT"); do
+  lp="$(mktemp)"
+  printf "native-batch-%s-%s" "$TS" "$i" > "$lp"
+  drive9_retry fs cp "$lp" ":$BATCH_DIR/file-${i}.txt" >/dev/null
+  rm -f "$lp"
+done
+
+batch_ls="$(drive9_retry fs ls "$BATCH_DIR")"
+batch_count=$(printf '%s' "$batch_ls" | grep -c 'file-' || true)
+check_eq "batch dir has $BATCH_COUNT files" "$batch_count" "$BATCH_COUNT"
+
+for i in 1 "$BATCH_COUNT"; do
+  got="$(drive9_retry fs cat "$BATCH_DIR/file-${i}.txt")"
+  want="native-batch-$TS-$i"
+  check_eq "$BATCH_DIR/file-${i}.txt content" "$got" "$want"
+done
+
+drive9_retry fs rm -r "$BATCH_DIR" >/dev/null
+check_cmd "rm -r batch dir" true
+
+echo "[5] large file upload/download"
+
+LARGE_MB="${CLI_LARGE_FILE_MB:-10}"
+LARGE_LOCAL="$(mktemp)"
+LARGE_REMOTE="$BATCH_DIR/large-${TS}.bin"
+LARGE_DOWNLOADED="$(mktemp)"
+
+dd if=/dev/zero of="$LARGE_LOCAL" bs=1M count="$LARGE_MB" status=none
+LARGE_BYTES=$((LARGE_MB * 1048576))
+
+drive9_retry fs mkdir "$BATCH_DIR" >/dev/null
+drive9_retry fs cp "$LARGE_LOCAL" ":$LARGE_REMOTE" >/dev/null
+
+stat_out="$(drive9_retry fs stat "$LARGE_REMOTE")"
+remote_size=$(printf '%s' "$stat_out" | python3 -c "import sys; [print(l.split(':',1)[1].strip()) for l in sys.stdin.read().splitlines() if l.strip().startswith('size:')]" 2>/dev/null || echo "0")
+check_eq "large remote size matches" "$remote_size" "$LARGE_BYTES"
+
+drive9_retry fs cp ":$LARGE_REMOTE" "$LARGE_DOWNLOADED" >/dev/null
+
+sum_src=$(sha256sum "$LARGE_LOCAL" | cut -d' ' -f1)
+sum_dst=$(sha256sum "$LARGE_DOWNLOADED" | cut -d' ' -f1)
+check_eq "downloaded sha256 matches" "$sum_dst" "$sum_src"
+
+drive9_retry fs rm "$LARGE_REMOTE" >/dev/null
+drive9_retry fs rm "$BATCH_DIR" >/dev/null
+rm -f "$LARGE_LOCAL" "$LARGE_DOWNLOADED"
+
+echo "[6] delete tenant"
 delete_out="$(drive9_ctx delete \
   --server "$BASE" \
   --api-key "$API_KEY" \
@@ -213,7 +256,7 @@ CREATED=0
 
 # ── [5] verify tenant gone ──────────────────────────────────────────────────
 
-echo "[5] verify tenant removed"
+echo "[7] verify tenant removed"
 vfile="$(mktemp)"
 vcode=$(curl -sS -o "$vfile" -w "%{http_code}" -H "Authorization: Bearer $API_KEY" "$BASE/v1/status")
 rm -f "$vfile"

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -101,8 +101,8 @@ drive9_retry() {
     if out="$(drive9 "$@" 2>&1)"; then
       printf '%s' "$out"; return 0
     fi
-    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* ]]; then
-      echo "retry $attempt/$CLI_MAX_RETRIES for drive9 $* (throttled)" >&2
+    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"not found"* ]]; then
+      echo "retry $attempt/$CLI_MAX_RETRIES for drive9 $* " >&2
       sleep "$CLI_RETRY_SLEEP_S"; attempt=$((attempt+1)); continue
     fi
     printf '%s' "$out" >&2; return 1
@@ -177,16 +177,16 @@ drive9_retry fs cp "$TMP_FILE" ":$DIR/hello.txt" >/dev/null
 check_cmd "cp file to $DIR/hello.txt" true
 
 ls_out="$(drive9_retry fs ls "$DIR")"
-check_cmd "ls $DIR lists file" echo "$ls_out" | grep -q "hello.txt"
+check_cmd "ls $DIR lists file" bash -c "echo \"\$1\" | grep -q hello.txt" _ "$ls_out"
 
 cat_out="$(drive9_retry fs cat "$DIR/hello.txt")"
-check_cmd "cat $DIR/hello.txt returns content" echo "$cat_out" | grep -q "hello native smoke test"
+check_cmd "cat $DIR/hello.txt returns content" bash -c "echo \"\$1\" | grep -q 'hello native smoke test'" _ "$cat_out"
 
 drive9_retry fs rm "$DIR/hello.txt" >/dev/null
 check_cmd "rm $DIR/hello.txt" true
 
 ls_after="$(drive9_retry fs ls "$DIR" 2>&1 || true)"
-if echo "$ls_after" | grep -q "hello.txt"; then
+if printf '%s' "$ls_after" | grep -q "hello.txt"; then
   check_eq "rm $DIR/hello.txt removes file" "fail" "pass"
 else
   check_cmd "rm $DIR/hello.txt removes file" true
@@ -208,7 +208,7 @@ delete_code=$?
 check_eq "drive9 delete exit code" "$delete_code" "0"
 
 DELETE_STATUS="$(printf '%s' "$delete_out" | jq -r '.status // empty')"
-check_cmd "delete status is deleted or deleting" echo "$DELETE_STATUS" | grep -qE 'deleted|deleting'
+check_cmd "delete status is deleted or deleting" bash -c "echo \"\$1\" | grep -qE 'deleted|deleting'" _ "$DELETE_STATUS"
 CREATED=0
 
 # ── [5] verify tenant gone ──────────────────────────────────────────────────

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# native-smoke-test.sh — TiDB Cloud Native tenant lifecycle smoke test.
+# Manual-only: requires TiDB Cloud API credentials (public/private key).
+
+BASE="${DRIVE9_BASE:?DRIVE9_BASE is required}"
+PUBLIC_KEY="${DRIVE9_TIDBCLOUD_PUBLIC_KEY:?DRIVE9_TIDBCLOUD_PUBLIC_KEY is required}"
+PRIVATE_KEY="${DRIVE9_TIDBCLOUD_PRIVATE_KEY:?DRIVE9_TIDBCLOUD_PRIVATE_KEY is required}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-600}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-10}"
+CLI_SOURCE="${CLI_SOURCE:-build}"
+CLI_MAX_RETRIES="${CLI_MAX_RETRIES:-8}"
+CLI_RETRY_SLEEP_S="${CLI_RETRY_SLEEP_S:-2}"
+SKIP_CLEANUP="${SKIP_CLEANUP:-0}"
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+PASS=0 FAIL=0 SKIP=0 TOTAL=0
+
+check_eq() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL+1))
+  if [ "$got" = "$want" ]; then
+    echo -e "${GREEN}PASS${NC} $desc (got=$got)"
+    PASS=$((PASS+1))
+  else
+    echo -e "${RED}FAIL${NC} $desc (want=$want got=$got)"
+    FAIL=$((FAIL+1))
+  fi
+}
+check_cmd() {
+  local desc="$1"; shift
+  TOTAL=$((TOTAL+1))
+  if "$@" >/dev/null 2>&1; then
+    echo -e "${GREEN}PASS${NC} $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "${RED}FAIL${NC} $desc"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# ── prepare CLI ─────────────────────────────────────────────────────────────
+
+download_official_cli() {
+  local os arch
+  case "$(uname -s)" in Linux) os="linux" ;; Darwin) os="darwin" ;; *) echo "unsupported OS" >&2; return 1 ;; esac
+  case "$(uname -m)" in x86_64|amd64) arch="amd64" ;; aarch64|arm64) arch="arm64" ;; *) echo "unsupported arch" >&2; return 1 ;; esac
+  curl -fsSL "${CLI_RELEASE_BASE_URL:-https://drive9.ai/releases}/drive9-${os}-${arch}" -o "$CLI_BIN"
+  chmod +x "$CLI_BIN"
+}
+
+prepare_cli_binary() {
+  CLI_BIN="$(mktemp)"
+  case "$CLI_SOURCE" in
+    build) make build-cli CLI_BIN="$CLI_BIN" ;;
+    official) download_official_cli ;;
+    *) echo "invalid CLI_SOURCE: $CLI_SOURCE (expected build|official)" >&2; return 1 ;;
+  esac
+}
+
+echo "=== drive9 native smoke test ==="
+echo "BASE=$BASE"
+echo "CLI_SOURCE=$CLI_SOURCE"
+
+check_cmd "jq is available" bash -c 'command -v jq >/dev/null'
+if [ "$CLI_SOURCE" = "build" ]; then
+  check_cmd "go is available" bash -c 'command -v go >/dev/null'
+else
+  check_cmd "curl is available" bash -c 'command -v curl >/dev/null'
+fi
+
+prepare_cli_binary
+check_cmd "drive9 binary ready" test -x "$CLI_BIN"
+
+CLI_HOME="$(mktemp -d)"
+TS="$(date +%s)"
+TEST_DIR="native-smoke-${TS}"
+TENANT_ID=""
+API_KEY=""
+CREATED=0
+TMP_FILE="$(mktemp)"
+
+drive9() {
+  env DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$API_KEY" HOME="$CLI_HOME" "$CLI_BIN" "$@"
+}
+
+drive9_ctx() {
+  env -u DRIVE9_SERVER -u DRIVE9_API_KEY HOME="$CLI_HOME" "$CLI_BIN" "$@"
+}
+
+drive9_retry() {
+  local attempt=1
+  while [ "$attempt" -le "$CLI_MAX_RETRIES" ]; do
+    local out
+    if out="$(drive9 "$@" 2>&1)"; then
+      printf '%s' "$out"; return 0
+    fi
+    if [ "$attempt" -lt "$CLI_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* ]]; then
+      echo "retry $attempt/$CLI_MAX_RETRIES for drive9 $* (throttled)" >&2
+      sleep "$CLI_RETRY_SLEEP_S"; attempt=$((attempt+1)); continue
+    fi
+    printf '%s' "$out" >&2; return 1
+  done
+  return 1
+}
+
+cleanup() {
+  if [ "$CREATED" -eq 1 ] && [ "$SKIP_CLEANUP" != "1" ]; then
+    echo "[cleanup] deleting tenant $TENANT_ID"
+    drive9_ctx delete \
+      --server "$BASE" \
+      --api-key "${API_KEY:-}" \
+      --tidbcloud-public-key "$PUBLIC_KEY" \
+      --tidbcloud-private-key "$PRIVATE_KEY" \
+      >/dev/null 2>&1 || true
+  fi
+  rm -f "$CLI_BIN" "$TMP_FILE"
+  rm -rf "$CLI_HOME"
+  exit "$FAIL"
+}
+trap cleanup EXIT
+
+echo "hello native smoke test $TS" > "$TMP_FILE"
+
+# ── [1] provision tenant ────────────────────────────────────────────────────
+
+echo "[1] provision tenant"
+create_out="$(drive9_ctx create \
+  --server "$BASE" \
+  --tidbcloud-public-key "$PUBLIC_KEY" \
+  --tidbcloud-private-key "$PRIVATE_KEY" \
+  --json 2>&1)"
+create_code=$?
+check_eq "drive9 create exit code" "$create_code" "0"
+
+API_KEY="$(printf '%s' "$create_out" | jq -r '.api_key // empty')"
+TENANT_ID="$(printf '%s' "$create_out" | jq -r '.tenant_id // empty')"
+CREATE_STATUS="$(printf '%s' "$create_out" | jq -r '.status // empty')"
+
+check_cmd "response contains tenant_id" test -n "$TENANT_ID"
+check_cmd "response contains api_key" test -n "$API_KEY"
+check_eq "provision status is provisioning" "$CREATE_STATUS" "provisioning"
+CREATED=1
+
+# ── [2] wait tenant active ──────────────────────────────────────────────────
+
+echo "[2] wait tenant active (timeout=${POLL_TIMEOUT_S}s)"
+deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+LAST_STATUS=""
+while :; do
+  sfile="$(mktemp)"
+  scode=$(curl -sS -o "$sfile" -w "%{http_code}" -H "Authorization: Bearer $API_KEY" "$BASE/v1/status")
+  LAST_STATUS=$(jq -r '.status // empty' "$sfile")
+  rm -f "$sfile"
+  if [ "$scode" = "200" ] && [ "$LAST_STATUS" = "active" ]; then break; fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then break; fi
+  sleep "$POLL_INTERVAL_S"
+done
+check_eq "tenant becomes active" "$LAST_STATUS" "active"
+
+# ── [3] basic fs operations ─────────────────────────────────────────────────
+
+echo "[3] basic fs operations"
+
+DIR="/$TEST_DIR"
+
+drive9_retry fs mkdir "$DIR" >/dev/null
+check_cmd "mkdir $DIR" true
+
+drive9_retry fs cp "$TMP_FILE" ":$DIR/hello.txt" >/dev/null
+check_cmd "cp file to $DIR/hello.txt" true
+
+ls_out="$(drive9_retry fs ls "$DIR")"
+check_cmd "ls $DIR lists file" echo "$ls_out" | grep -q "hello.txt"
+
+cat_out="$(drive9_retry fs cat "$DIR/hello.txt")"
+check_cmd "cat $DIR/hello.txt returns content" echo "$cat_out" | grep -q "hello native smoke test"
+
+drive9_retry fs rm "$DIR/hello.txt" >/dev/null
+check_cmd "rm $DIR/hello.txt" true
+
+ls_after="$(drive9_retry fs ls "$DIR" 2>&1 || true)"
+if echo "$ls_after" | grep -q "hello.txt"; then
+  check_eq "rm $DIR/hello.txt removes file" "fail" "pass"
+else
+  check_cmd "rm $DIR/hello.txt removes file" true
+fi
+
+drive9_retry fs rm "$DIR" >/dev/null
+check_cmd "rmdir $DIR" true
+
+# ── [4] delete tenant ───────────────────────────────────────────────────────
+
+echo "[4] delete tenant"
+delete_out="$(drive9_ctx delete \
+  --server "$BASE" \
+  --api-key "$API_KEY" \
+  --tidbcloud-public-key "$PUBLIC_KEY" \
+  --tidbcloud-private-key "$PRIVATE_KEY" \
+  --json 2>&1)"
+delete_code=$?
+check_eq "drive9 delete exit code" "$delete_code" "0"
+
+DELETE_STATUS="$(printf '%s' "$delete_out" | jq -r '.status // empty')"
+check_cmd "delete status is deleted or deleting" echo "$DELETE_STATUS" | grep -qE 'deleted|deleting'
+CREATED=0
+
+# ── [5] verify tenant gone ──────────────────────────────────────────────────
+
+echo "[5] verify tenant removed"
+vfile="$(mktemp)"
+vcode=$(curl -sS -o "$vfile" -w "%{http_code}" -H "Authorization: Bearer $API_KEY" "$BASE/v1/status")
+rm -f "$vfile"
+if [ "$vcode" = "401" ] || [ "$vcode" = "403" ] || [ "$vcode" = "404" ]; then
+  check_eq "GET /v1/status returns auth error or not-found after delete" "ok" "ok"
+else
+  check_eq "GET /v1/status returns auth error or not-found after delete (got $vcode)" "$vcode" "401/403/404"
+fi
+
+# ── summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== native smoke test: $PASS passed, $FAIL failed, $SKIP skipped (total $TOTAL) ==="

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -215,7 +215,7 @@ check_cmd "rm -r batch dir" true
 
 echo "[5] large file upload/download"
 
-LARGE_MB="${CLI_LARGE_FILE_MB:-10}"
+LARGE_MB="${CLI_LARGE_FILE_MB:-100}"
 LARGE_LOCAL="$(mktemp)"
 LARGE_REMOTE="$BATCH_DIR/large-${TS}.bin"
 LARGE_DOWNLOADED="$(mktemp)"

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -607,6 +607,56 @@ func TestProvisionTenantRejectsMissingNativeCredentialsBeforeInsert(t *testing.T
 	}
 }
 
+func TestProvisionRejectsCredentialsForNonNativeProvider(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, provider := range []string{tenant.ProviderTiDBZero, tenant.ProviderTiDBCloudStarter, tenant.ProviderDB9} {
+		prov := &fakeProvisioner{provider: provider}
+		srv := NewWithConfig(Config{
+			Meta:        metaStore,
+			Pool:        pool,
+			Provisioner: prov,
+			TokenSecret: tokenSecret,
+		})
+
+		ts := httptest.NewServer(srv)
+		body, _ := json.Marshal(map[string]string{"public_key": "test", "private_key": "test"})
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			ts.Close()
+			t.Fatalf("%s: request failed: %v", provider, err)
+		}
+		_ = resp.Body.Close()
+		ts.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("%s: status=%d, want 400", provider, resp.StatusCode)
+		}
+	}
+}
+
 func TestProvisionPersistsEncryptedAutoEmbeddingProfile(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3422,7 +3422,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		credentialReq = req
 	} else {
 		if err := rejectCredentialProvisionBody(r); err != nil {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_credential_rejected", "provider", provider)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_credential_rejected", "provider", provider, "error", err)...)
 			metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
 			errJSON(w, http.StatusBadRequest, err.Error())
 			return
@@ -3509,12 +3509,15 @@ func rejectCredentialProvisionBody(r *http.Request) error {
 	if len(body) == 0 {
 		return nil
 	}
+	if int64(len(body)) >= maxCredentialProvisionBodyBytes {
+		return fmt.Errorf("request body too large")
+	}
 	var raw struct {
 		PublicKey  string `json:"public_key"`
 		PrivateKey string `json:"private_key"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil
+		return fmt.Errorf("invalid JSON body: %w", err)
 	}
 	if strings.TrimSpace(raw.PublicKey) != "" {
 		return fmt.Errorf("tidbcloud public key is not supported for this provider (only tidb_cloud_native)")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3422,7 +3422,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		credentialReq = req
 	} else {
 		if err := rejectCredentialProvisionBody(r); err != nil {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_credential_rejected", "provider", provider, "error", err)...)
+			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_credential_rejected", "provider", provider, "error", err)...)
 			metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
 			errJSON(w, http.StatusBadRequest, err.Error())
 			return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3501,7 +3501,7 @@ func rejectCredentialProvisionBody(r *http.Request) error {
 	if r.Body == nil {
 		return nil
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxCredentialProvisionBodyBytes+1))
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxCredentialProvisionBodyBytes))
 	if err != nil {
 		return nil
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/subtle"
 	"encoding/base64"
@@ -3419,6 +3420,13 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		credentialReq = req
+	} else {
+		if err := rejectCredentialProvisionBody(r); err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_credential_rejected", "provider", provider)...)
+			metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
 	}
 	res, err := s.provisionTenant(r.Context(), provisionTenantOptions{
 		KeyName:               "default",
@@ -3487,6 +3495,34 @@ func decodeCredentialRequest(w http.ResponseWriter, r *http.Request, raw any, bu
 		return nil, fmt.Errorf("public_key and private_key are required")
 	}
 	return &out, nil
+}
+
+func rejectCredentialProvisionBody(r *http.Request) error {
+	if r.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxCredentialProvisionBodyBytes+1))
+	if err != nil {
+		return nil
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	if len(body) == 0 {
+		return nil
+	}
+	var raw struct {
+		PublicKey  string `json:"public_key"`
+		PrivateKey string `json:"private_key"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil
+	}
+	if strings.TrimSpace(raw.PublicKey) != "" {
+		return fmt.Errorf("tidbcloud public key is not supported for this provider (only tidb_cloud_native)")
+	}
+	if strings.TrimSpace(raw.PrivateKey) != "" {
+		return fmt.Errorf("tidbcloud private key is not supported for this provider (only tidb_cloud_native)")
+	}
+	return nil
 }
 
 type apiKeyIssueSource struct {


### PR DESCRIPTION
## Summary

- **native-smoke-test.sh**: TiDB Cloud Native tenant lifecycle e2e smoke test  
  (manual-only, requires `DRIVE9_TIDBCLOUD_PUBLIC_KEY` / `DRIVE9_TIDBCLOUD_PRIVATE_KEY`)
- **pkg/server/server.go**: Reject `public_key`/`private_key` in provision body for non-native providers (zero, starter) with 400 Bad Request
- **e2e/AGENTS.md** + **e2e/README.md**: Document native dev endpoint, run command, coverage, and env vars

## Test coverage

1. Provision tenant via `drive9 create` with TiDB Cloud credentials
2. Poll `GET /v1/status` until active
3. Basic CLI fs ops (mkdir, cp, cat, ls, rm)
4. Delete tenant via `drive9 delete` and verify removal
5. Trap-based cleanup on failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TiDB Cloud Native tenant lifecycle testing with automated provisioning, status polling, filesystem operations, and cleanup.
  * Implemented credential validation to reject native provider credentials for non-native providers.

* **Documentation**
  * Updated test documentation with new TiDB Cloud Native endpoint and required credential environment variables.

* **Tests**
  * Added test to verify native credentials are properly rejected for non-native providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->