### PR TITLE
fix: release fh.mu during Path 2 flushHandle network calls

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1905,6 +1905,39 @@ func (fs *Dat9FS) adoptCommittedRevisionLocked(fh *FileHandle) {
 	}
 }
 
+// markHandleRevisionOnlyLocked updates the handle's committed revision,
+// IsNew flag, and propagates the revision to other open handles, but does
+// NOT read from fh.Dirty for OrigSize/inode size. This is used when a
+// concurrent write mutated the dirty buffer during the Path 2 unlock
+// window, so the live dirty state reflects uncommitted post-upload data.
+func (fs *Dat9FS) markHandleRevisionOnlyLocked(fh *FileHandle, revision int64) {
+	if fs == nil || fh == nil || revision <= 0 {
+		return
+	}
+	if fh.IsNew {
+		fs.replaceCommittedRevision(fh.Path, revision)
+	} else {
+		fs.recordCommittedRevision(fh.Path, revision)
+	}
+	fh.IsNew = false
+	fh.BaseRev = revision
+	fs.inodes.UpdateRevision(fh.Ino, revision)
+	fs.refreshCommittedRevisionForOpenHandles(fh.Path, revision, fh)
+	if fs.writeBack != nil {
+		fs.writeBack.Remove(fh.Path)
+	}
+	if fs.shadowStore != nil {
+		fs.shadowStore.Remove(fh.Path)
+	}
+	if fs.pendingIndex != nil {
+		fs.pendingIndex.Remove(fh.Path)
+	}
+	fh.ShadowReady = false
+	fh.ShadowSpill = false
+	fh.ShadowCommitReady = false
+	fh.ShadowCommitSeq = 0
+}
+
 func (fs *Dat9FS) markHandleRemoteCommittedLocked(fh *FileHandle, revision int64) {
 	if fs == nil || fh == nil || revision <= 0 {
 		return
@@ -11722,7 +11755,17 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			// the WriteBuffer may have been mutated by concurrent writes
 			// while the lock was released.
 			fs.readCache.Put(handlePath, dataCopy, committedRev)
-			fs.markHandleRemoteCommittedLocked(fh, committedRev)
+			if fh.DirtySeq == handleDirtySeq {
+				// No concurrent writes — safe to finalize from live handle.
+				fs.markHandleRemoteCommittedLocked(fh, committedRev)
+			} else {
+				// B7: concurrent writes mutated fh.Dirty during the unlock
+				// window. markHandleRemoteCommittedLocked reads fh.Dirty.Size()
+				// for OrigSize, which would associate the uploaded snapshot's
+				// revision with the post-write buffer size. Only update the
+				// committed revision and flags without consuming live dirty state.
+				fs.markHandleRevisionOnlyLocked(fh, committedRev)
+			}
 		}
 	} else if sidecarCached {
 		clearReadTargetForLockedHandle(fh)
@@ -11745,7 +11788,13 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		publishSize = fh.Dirty.Size()
 	}
 	fs.inodes.UpdateSize(handleIno, publishSize)
-	fs.cacheFileForPath(handlePath, publishSize, time.Now(), committedRev)
+	// B8: skip dir cache update for retargeted handles. finishLocalRename
+	// has already removed/negatively cached the old path (handlePath), and
+	// re-adding it here with the upload's size/revision would resurrect a
+	// stale entry. The new path (fh.Path) will be cached on its own flush.
+	if !pathRetargeted {
+		fs.cacheFileForPath(handlePath, publishSize, time.Now(), committedRev)
+	}
 	// Local flush — kernel receives the Flush reply with status.
 	// No notifyInode/notifyEntry needed; userspace caches are updated
 	// above and kernel will refresh attrs on next getattr/lookup.

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11558,30 +11558,21 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		}
 	}
 
-	// Lock ordering fix (B3): Release fh.mu FIRST, then acquire the
-	// per-path remote commit lock for the upload. Write() acquires
-	// fh.mu → remoteCommitLock; if we held remoteCommitLock while
-	// waiting to reacquire fh.mu, a concurrent Write() would deadlock.
+	// Lock ordering fix (B3): Release fh.mu but keep remoteCommitLock
+	// held throughout the upload for same-path serialization.
 	//
-	// By releasing fh.mu before acquiring remoteCommitLock:
-	// - Concurrent Read() can proceed (fh.mu not held) — fixes #579
-	// - Concurrent Write() can acquire fh.mu, then block on
-	//   remoteCommitLock until the upload finishes — no deadlock
-	// - Same-path uploads remain serialized via remoteCommitLock
+	// Write() acquires fh.mu → remoteCommitLock. To avoid deadlock,
+	// flush must NOT hold remoteCommitLock while waiting for fh.mu.
+	// We achieve this by:
+	//   1. Releasing fh.mu here (concurrent Read/Write can proceed)
+	//   2. Uploading while holding remoteCommitLock (serialization)
+	//   3. Releasing remoteCommitLock AFTER upload, BEFORE fh.Lock()
 	//
-	// Release the top-level remoteCommitLock first (we'll acquire a
-	// fresh one after fh.Unlock for the upload window only).
-	unlockRemoteCommit()
-	remoteCommitReleased = true
-
+	// Concurrent Write() acquires fh.mu, then blocks on remoteCommitLock
+	// until upload finishes — linear wait, no cycle.
 	uploadStart := time.Now()
 	fs.debugf("flushHandle path2 unlock before upload path=%s size=%d phase_hint=%s expected_rev=%d", handlePath, size, phase, expectedRevision)
 	fh.Unlock()
-
-	// Acquire the remote commit lock for upload serialization AFTER
-	// releasing fh.mu — correct lock order (never hold remoteCommitLock
-	// while waiting for fh.mu).
-	uploadPathLock := fs.lockWritableRemoteCommitPath(handlePath)
 
 	if useDirectPUT {
 		if size == 0 && handleIsNew {
@@ -11649,9 +11640,25 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.debugDurationf(writeStart, 0, "flushHandle write stream done path=%s size=%d err=%v", handlePath, size, err)
 	}
 
-	// Release the upload path lock BEFORE re-acquiring fh.mu to maintain
-	// correct lock ordering (fh.mu → remoteCommitLock, never the reverse).
-	uploadPathLock()
+	// Record the committed revision to global state WHILE still holding
+	// remoteCommitLock, so any subsequent flush that acquires the lock
+	// will see the updated revision via adoptCommittedRevisionLocked.
+	// This must happen before releasing remoteCommitLock to prevent a
+	// same-path flush from snapshotting a stale expectedRevision.
+	if err == nil && committedRev > 0 {
+		if handleIsNew {
+			fs.replaceCommittedRevision(handlePath, committedRev)
+		} else {
+			fs.recordCommittedRevision(handlePath, committedRev)
+		}
+	}
+
+	// Release remoteCommitLock AFTER upload + revision recording but
+	// BEFORE re-acquiring fh.mu. This preserves same-path serialization
+	// (lock held during upload) while avoiding B3 deadlock (never hold
+	// remoteCommitLock while waiting for fh.mu).
+	unlockRemoteCommit()
+	remoteCommitReleased = true
 
 	// Re-acquire fh.mu after network call completes.
 	fh.Lock()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11275,6 +11275,20 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 			return
 		}
 
+		// B13: Re-check the expected revision after acquiring handle.Lock().
+		// A forced flush (Path 2) may have uploaded while this callback was
+		// blocked waiting for handle.Lock(). Path 2 records the committed
+		// revision to global state before releasing remoteCommitLock, and
+		// releases fh.mu before the callback can acquire it. So by the time
+		// we get here, adoptCommittedRevisionLocked will see the updated
+		// revision. If expectedRevision changed, the forced flush already
+		// uploaded — skip to avoid a double PUT with a stale CAS revision.
+		currentExpectedRevision := fs.expectedRevisionForHandleLocked(handle)
+		if currentExpectedRevision != expectedRevision {
+			handle.Unlock()
+			return
+		}
+
 		dCtx, dCf := context.WithTimeout(context.Background(), fuseTimeout)
 		writeStart := fs.perfStart()
 		committedRev, err := fs.client.WriteCtxConditionalWithRevision(dCtx, fs.remotePath(filePath), data, expectedRevision)
@@ -11672,6 +11686,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	// remoteCommitLock serialization. If a debounced upload fires while
 	// fh.mu is released (steps 1-3 below), both uploads race with the same
 	// expectedRevision — whichever conditional PUT loses gets a CAS error.
+	//
+	// Cancel stops pending timers. For already-fired callbacks that are
+	// blocked waiting for handle.Lock(), the callback itself re-checks
+	// expectedRevision after acquiring the lock and skips the upload if
+	// the revision advanced (see flushHandleDebounced callback).
 	if fs.debouncer != nil {
 		fs.debouncer.Cancel(handlePath)
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11506,8 +11506,25 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	}
 
 	// Path 2: No streaming uploader or small file — materialize all data for upload.
+	//
+	// Snapshot the dirty buffer into an immutable copy before releasing fh.mu.
+	// bytesView() may return a mutable slice backed by the WriteBuffer's
+	// internal smallFileData; concurrent Write() calls while the lock is
+	// released would corrupt the upload payload. Path 1a/1b already follow
+	// this pattern (copy + unlock before network).
 	data := fh.Dirty.bytesView()
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+	data = nil // prevent accidental use of mutable view after this point
+
 	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+	remotePath := fs.remotePath(fh.Path)
+	handlePath := fh.Path
+	handleIsNew := fh.IsNew
+	handleIno := fh.Ino
+	handleDirtySeq := fh.DirtySeq
+	handleOrigSize := fh.OrigSize
+	handleDirtyPartSize := fh.Dirty.PartSize()
 	var committedRev int64
 
 	// Use the negotiated server threshold (not the heuristic-only inline
@@ -11519,32 +11536,14 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	// rejects total_size=0.
 	threshold := fs.negotiatedInlineThreshold()
 	useDirectPUT := size == 0 || (threshold > 0 && size < threshold)
-	if useDirectPUT {
-		if size == 0 && fh.IsNew {
-			phase = "empty-create"
-			writeStart := time.Now()
-			fs.debugf("flushHandle empty create start path=%s expected_rev=%d", fh.Path, expectedRevision)
-			committedRev, err = fs.client.CreateFileCtx(ctx, fs.remotePath(fh.Path))
-			if isCreateActionUnsupportedErr(err) {
-				fs.debugf("flushHandle empty create unsupported path=%s fallback=small-write err=%v", fh.Path, err)
-				committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), data, expectedRevision)
-			}
-			fs.perfRecordRemote(perfRemoteWrite, writeStart, err, 0)
-			fs.debugDurationf(writeStart, 0, "flushHandle empty create done path=%s committed_rev=%d err=%v", fh.Path, committedRev, err)
-		} else {
-			// Small file: direct PUT with revision return for freshness seeding.
-			phase = "small-write"
-			writeStart := time.Now()
-			fs.debugf("flushHandle small write start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
-			committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, fs.remotePath(fh.Path), data, expectedRevision)
-			fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
-			fs.debugDurationf(writeStart, 0, "flushHandle small write done path=%s size=%d committed_rev=%d err=%v", fh.Path, size, committedRev, err)
-		}
-	} else if threshold > 0 && fh.OrigSize >= threshold {
-		phase = "patch-file"
-		dirtyParts := fh.Dirty.DirtyPartNumbers()
+
+	// Prepare patch snapshots while we still hold the lock.
+	var dirtyParts []int
+	var partSnapshots map[int][]byte
+	if !useDirectPUT && threshold > 0 && handleOrigSize >= threshold {
+		dirtyParts = fh.Dirty.DirtyPartNumbers()
 		if len(dirtyParts) > 0 {
-			partSnapshots := make(map[int][]byte, len(dirtyParts))
+			partSnapshots = make(map[int][]byte, len(dirtyParts))
 			for _, pn := range dirtyParts {
 				src := fh.Dirty.PartData(pn)
 				if src != nil {
@@ -11553,11 +11552,47 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 					partSnapshots[pn] = cp
 				}
 			}
+		}
+	}
+
+	// Release fh.mu before network calls — same deadlock avoidance as
+	// Path 1a/1b. Without this unlock, concurrent FUSE Read() on the same
+	// handle blocks for the entire HTTP upload duration, causing kernel
+	// read timeouts (especially with FOPEN_DIRECT_IO where every pread is
+	// a FUSE round-trip, e.g. SQLite WAL workloads — see issue #579).
+	uploadStart := time.Now()
+	fs.debugf("flushHandle path2 unlock before upload path=%s size=%d phase_hint=%s expected_rev=%d", handlePath, size, phase, expectedRevision)
+	fh.Unlock()
+
+	if useDirectPUT {
+		if size == 0 && handleIsNew {
+			phase = "empty-create"
+			writeStart := time.Now()
+			fs.debugf("flushHandle empty create start path=%s expected_rev=%d", handlePath, expectedRevision)
+			committedRev, err = fs.client.CreateFileCtx(ctx, remotePath)
+			if isCreateActionUnsupportedErr(err) {
+				fs.debugf("flushHandle empty create unsupported path=%s fallback=small-write err=%v", handlePath, err)
+				committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, remotePath, dataCopy, expectedRevision)
+			}
+			fs.perfRecordRemote(perfRemoteWrite, writeStart, err, 0)
+			fs.debugDurationf(writeStart, 0, "flushHandle empty create done path=%s committed_rev=%d err=%v", handlePath, committedRev, err)
+		} else {
+			// Small file: direct PUT with revision return for freshness seeding.
+			phase = "small-write"
+			writeStart := time.Now()
+			fs.debugf("flushHandle small write start path=%s size=%d expected_rev=%d", handlePath, size, expectedRevision)
+			committedRev, err = fs.client.WriteCtxConditionalWithRevision(ctx, remotePath, dataCopy, expectedRevision)
+			fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(dataCopy)))
+			fs.debugDurationf(writeStart, 0, "flushHandle small write done path=%s size=%d committed_rev=%d err=%v", handlePath, size, committedRev, err)
+		}
+	} else if threshold > 0 && handleOrigSize >= threshold {
+		phase = "patch-file"
+		if len(dirtyParts) > 0 {
 			patchStart := time.Now()
-			fs.debugf("flushHandle patch start path=%s size=%d dirty_parts=%d expected_rev=%d", fh.Path, size, len(dirtyParts), expectedRevision)
+			fs.debugf("flushHandle patch start path=%s size=%d dirty_parts=%d expected_rev=%d", handlePath, size, len(dirtyParts), expectedRevision)
 			err = fs.client.PatchFile(
 				ctx,
-				fs.remotePath(fh.Path),
+				remotePath,
 				size,
 				dirtyParts,
 				func(partNumber int, partSize int64, origData []byte) ([]byte, error) {
@@ -11567,7 +11602,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 					return origData, nil
 				},
 				nil,
-				client.WithPartSize(fh.Dirty.PartSize()),
+				client.WithPartSize(handleDirtyPartSize),
 				client.WithExpectedRevision(expectedRevision),
 			)
 			var patchBytes uint64
@@ -11575,55 +11610,63 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 				patchBytes = uint64(size)
 			}
 			fs.perfRecordRemote(perfRemoteWrite, patchStart, err, patchBytes)
-			fs.debugDurationf(patchStart, 0, "flushHandle patch done path=%s size=%d dirty_parts=%d err=%v", fh.Path, size, len(dirtyParts), err)
+			fs.debugDurationf(patchStart, 0, "flushHandle patch done path=%s size=%d dirty_parts=%d err=%v", handlePath, size, len(dirtyParts), err)
 		}
 		// If no dirty parts, nothing changed — skip upload.
 	} else {
 		// New large file or small-to-large growth: full upload via multipart.
 		phase = "write-stream"
 		writeStart := time.Now()
-		fs.debugf("flushHandle write stream start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
+		fs.debugf("flushHandle write stream start path=%s size=%d expected_rev=%d", handlePath, size, expectedRevision)
 		err = fs.client.WriteStreamConditional(
 			ctx,
-			fs.remotePath(fh.Path),
-			bytes.NewReader(data),
+			remotePath,
+			bytes.NewReader(dataCopy),
 			size,
 			nil,
 			expectedRevision,
 		)
-		fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
-		fs.debugDurationf(writeStart, 0, "flushHandle write stream done path=%s size=%d err=%v", fh.Path, size, err)
+		fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(dataCopy)))
+		fs.debugDurationf(writeStart, 0, "flushHandle write stream done path=%s size=%d err=%v", handlePath, size, err)
 	}
+
+	// Re-acquire fh.mu after network call completes.
+	fh.Lock()
+	fs.debugDurationf(uploadStart, 0, "flushHandle path2 relock after upload path=%s size=%d err=%v", handlePath, size, err)
+
 	if err != nil {
-		log.Printf("flush upload failed for %s: %v", fh.Path, err)
+		log.Printf("flush upload failed for %s: %v", handlePath, err)
 		return httpToFuseStatus(err)
 	}
 	if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
-		log.Printf("flush pending chmod failed for %s: %v", fh.Path, err)
+		log.Printf("flush pending chmod failed for %s: %v", handlePath, err)
 		return httpToFuseStatus(err)
 	}
 
 	sidecarRevision := sqliteCommittedRevision(committedRev, expectedRevision)
 	sidecarCached := fs.cacheCommittedSQLitePersistentJournalLocked(fh, sidecarRevision)
 	fh.Dirty.ClearDirty()
-	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+	fs.clearDirtySize(fh.Ino, handleDirtySeq)
 	fh.DirtySeq = 0
 	if committedRev > 0 {
 		clearReadTargetForLockedHandle(fh)
-		fs.clearReadTargetsForPathExcept(fh.Path, fh)
-		fs.readCache.Put(fh.Path, data, committedRev)
+		fs.clearReadTargetsForPathExcept(handlePath, fh)
+		// Use dataCopy (immutable snapshot) for read cache seeding —
+		// the WriteBuffer may have been mutated by concurrent writes
+		// while the lock was released.
+		fs.readCache.Put(handlePath, dataCopy, committedRev)
 		fs.markHandleRemoteCommittedLocked(fh, committedRev)
 	} else if sidecarCached {
 		clearReadTargetForLockedHandle(fh)
-		fs.clearReadTargetsForPathExcept(fh.Path, fh)
+		fs.clearReadTargetsForPathExcept(handlePath, fh)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 	} else {
 		clearReadTargetForLockedHandle(fh)
-		fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
+		fs.invalidateReadCacheAndTargetsExcept(handlePath, fh)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 	}
-	fs.inodes.UpdateSize(fh.Ino, size)
-	fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
+	fs.inodes.UpdateSize(handleIno, size)
+	fs.cacheFileForPath(handlePath, size, time.Now(), committedRev)
 	// Local flush — kernel receives the Flush reply with status.
 	// No notifyInode/notifyEntry needed; userspace caches are updated
 	// above and kernel will refresh attrs on next getattr/lookup.

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11641,6 +11641,15 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	// (committedRev == 0) does not seed the read cache with full data.
 	var dataCopy []byte
 	if !usePatch {
+		// B12: For the WriteStreamConditional path (grown large file), check
+		// that all parts are loaded before materializing. Lazy-loaded existing
+		// files may have unloaded remote-backed parts; bytesView() would fill
+		// them with zeroes, overwriting remote data. Consistent with write-sync
+		// path's CanMaterializeFull() guard (line ~9971).
+		if !useDirectPUT && !fh.Dirty.CanMaterializeFull() {
+			log.Printf("flushHandle cannot materialize full file for %s (path2 growth)", fh.Path)
+			return gofuse.EIO
+		}
 		dataCopy = make([]byte, fh.Dirty.Size())
 		copy(dataCopy, fh.Dirty.bytesView())
 	}
@@ -11657,6 +11666,16 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	//
 	// Concurrent Write() acquires fh.mu, then blocks on remoteCommitLock
 	// until upload finishes — linear wait, no cycle.
+	// B13: Cancel any pending debounced upload for this path before releasing
+	// fh.mu. The debouncer callback acquires handle.Lock() and calls
+	// WriteCtxConditionalWithRevision directly, without participating in
+	// remoteCommitLock serialization. If a debounced upload fires while
+	// fh.mu is released (steps 1-3 below), both uploads race with the same
+	// expectedRevision — whichever conditional PUT loses gets a CAS error.
+	if fs.debouncer != nil {
+		fs.debouncer.Cancel(handlePath)
+	}
+
 	uploadStart := time.Now()
 	fs.debugf("flushHandle path2 unlock before upload path=%s size=%d phase_hint=%s expected_rev=%d", handlePath, size, phase, expectedRevision)
 	fh.Unlock()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11579,15 +11579,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		return gofuse.OK
 	}
 
-	// Path 2: No streaming uploader or small file — materialize all data for upload.
-	//
-	// Snapshot the dirty buffer into an immutable copy before releasing fh.mu.
-	// bytesView() may return a mutable slice backed by the WriteBuffer's
-	// internal smallFileData; concurrent Write() calls while the lock is
-	// released would corrupt the upload payload. Path 1a/1b already follow
-	// this pattern (copy + unlock before network).
-	dataCopy := make([]byte, fh.Dirty.Size())
-	copy(dataCopy, fh.Dirty.bytesView())
+	// Path 2: No streaming uploader or small file — materialize data for upload.
 
 	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 	remotePath := fs.remotePath(fh.Path)
@@ -11610,10 +11602,15 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	threshold := fs.negotiatedInlineThreshold()
 	useDirectPUT := size == 0 || (threshold > 0 && size < threshold)
 
+	// Determine whether we take the patch path (existing large file with
+	// dirty parts). Patch mode only needs per-part snapshots, NOT a full
+	// buffer copy — avoiding 2x memory for small edits to large files.
+	usePatch := !useDirectPUT && threshold > 0 && handleOrigSize >= threshold
+
 	// Prepare patch snapshots while we still hold the lock.
 	var dirtyParts []int
 	var partSnapshots map[int][]byte
-	if !useDirectPUT && threshold > 0 && handleOrigSize >= threshold {
+	if usePatch {
 		dirtyParts = fh.Dirty.DirtyPartNumbers()
 		if len(dirtyParts) > 0 {
 			partSnapshots = make(map[int][]byte, len(dirtyParts))
@@ -11626,6 +11623,22 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 				}
 			}
 		}
+	}
+
+	// Snapshot the dirty buffer into an immutable copy before releasing fh.mu.
+	// bytesView() may return a mutable slice backed by the WriteBuffer's
+	// internal smallFileData; concurrent Write() calls while the lock is
+	// released would corrupt the upload payload.
+	//
+	// B9: Only build dataCopy for paths that actually need the full buffer
+	// (direct PUT, WriteStreamConditional, sidecar/read cache seeding).
+	// Patch mode uses per-part snapshots above and never reads dataCopy
+	// for the upload itself. Post-upload cache seeding for patch mode
+	// (committedRev == 0) does not seed the read cache with full data.
+	var dataCopy []byte
+	if !usePatch {
+		dataCopy = make([]byte, fh.Dirty.Size())
+		copy(dataCopy, fh.Dirty.bytesView())
 	}
 
 	// Lock ordering fix (B3): Release fh.mu but keep remoteCommitLock
@@ -11665,7 +11678,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(dataCopy)))
 			fs.debugDurationf(writeStart, 0, "flushHandle small write done path=%s size=%d committed_rev=%d err=%v", handlePath, size, committedRev, err)
 		}
-	} else if threshold > 0 && handleOrigSize >= threshold {
+	} else if usePatch {
 		phase = "patch-file"
 		if len(dirtyParts) > 0 {
 			patchStart := time.Now()
@@ -11722,6 +11735,17 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			fs.recordCommittedRevision(handlePath, committedRev)
 		}
 	}
+	// B10: For successful uploads that don't return a server revision
+	// (PatchFile, WriteStreamConditional), derive a synthetic revision
+	// from expectedRevision and record it before releasing the commit
+	// lock. Without this, a same-path flush can acquire the lock in the
+	// gap between unlockRemoteCommit() and fh.Lock(), snapshot a stale
+	// expectedRevision, and issue a conditional upload that conflicts.
+	if err == nil && committedRev == 0 {
+		if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok && syntheticRev > 0 {
+			fs.recordCommittedRevision(handlePath, syntheticRev)
+		}
+	}
 
 	// Release remoteCommitLock AFTER upload + revision recording but
 	// BEFORE re-acquiring fh.mu. This preserves same-path serialization
@@ -11750,7 +11774,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	// contain concurrent Write() data — using them would cache
 	// uncommitted bytes or cache under the wrong path.
 	var sidecarCached bool
-	if fs.readCache != nil && sidecarRevision > 0 && isSQLitePersistentJournalPath(handlePath) &&
+	if fs.readCache != nil && dataCopy != nil && sidecarRevision > 0 && isSQLitePersistentJournalPath(handlePath) &&
 		size <= fs.readCache.MaxFileSize() && handleFullRangeLoaded {
 		fs.readCache.Put(handlePath, dataCopy, sidecarRevision)
 		sidecarCached = true

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11671,8 +11671,15 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.invalidateReadCacheAndTargetsExcept(handlePath, fh)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 	}
-	fs.inodes.UpdateSize(handleIno, size)
-	fs.cacheFileForPath(handlePath, size, time.Now(), committedRev)
+	// When concurrent writes happened (DirtySeq changed), the buffer may
+	// have a different size than the uploaded snapshot. Use the current
+	// dirty buffer size so inode attrs and dir cache reflect reality.
+	publishSize := size
+	if fh.DirtySeq != 0 && fh.Dirty != nil {
+		publishSize = fh.Dirty.Size()
+	}
+	fs.inodes.UpdateSize(handleIno, publishSize)
+	fs.cacheFileForPath(handlePath, publishSize, time.Now(), committedRev)
 	// Local flush — kernel receives the Flush reply with status.
 	// No notifyInode/notifyEntry needed; userspace caches are updated
 	// above and kernel will refresh attrs on next getattr/lookup.

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1586,6 +1586,39 @@ func (fs *Dat9FS) refreshCommittedRevisionForOpenHandles(path string, revision i
 	}
 }
 
+// refreshCommittedRevisionForOpenHandlesWithSize is like
+// refreshCommittedRevisionForOpenHandles but uses an explicit committed
+// size instead of reading from the inode table. This is needed in the
+// Path 2 concurrent-write case where the inode size has already been
+// updated by the concurrent Write() but the committed revision
+// corresponds to the pre-write snapshot.
+func (fs *Dat9FS) refreshCommittedRevisionForOpenHandlesWithSize(path string, revision int64, skip *FileHandle, committedSize int64) {
+	if fs == nil || fs.openHandles == nil || path == "" || revision <= 0 {
+		return
+	}
+
+	for _, fh := range fs.openHandles.SnapshotPath(path) {
+		if fh == nil || fh == skip {
+			continue
+		}
+		if !fh.TryLock() {
+			continue
+		}
+		if fh.Dirty != nil {
+			cleanBuffer := fh.DirtySeq == 0 && !fh.Dirty.HasDirtyParts()
+			fh.IsNew = false
+			fh.BaseRev = revision
+			if fh.Streamer != nil {
+				fh.Streamer.RefreshExpectedRevision(expectedRevisionForHandle(fh))
+			}
+			if cleanBuffer {
+				fs.rebindCleanWriteBufferToRemoteLocked(fh, committedSize)
+			}
+		}
+		fh.Unlock()
+	}
+}
+
 func (fs *Dat9FS) refreshCleanCommittedRevisionForHandleLocked(fh *FileHandle) bool {
 	if fs == nil || fh == nil || fh.Dirty == nil || fh.DirtySeq != 0 || fh.Dirty.HasDirtyParts() {
 		return false
@@ -1925,7 +1958,7 @@ func (fs *Dat9FS) markHandleRevisionOnlyLocked(fh *FileHandle, revision int64, s
 	fh.BaseRev = revision
 	fh.OrigSize = snapshotSize
 	fs.inodes.UpdateRevision(fh.Ino, revision)
-	fs.refreshCommittedRevisionForOpenHandles(fh.Path, revision, fh)
+	fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, revision, fh, snapshotSize)
 	if fs.writeBack != nil {
 		fs.writeBack.Remove(fh.Path)
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11351,7 +11351,12 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	}
 
 	unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
-	defer unlockRemoteCommit()
+	remoteCommitReleased := false
+	defer func() {
+		if !remoteCommitReleased {
+			unlockRemoteCommit()
+		}
+	}()
 
 	var err error
 	// Path 1a: Streaming mode — parts were submitted during Write() and are
@@ -11553,14 +11558,30 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		}
 	}
 
-	// Release fh.mu before network calls — same deadlock avoidance as
-	// Path 1a/1b. Without this unlock, concurrent FUSE Read() on the same
-	// handle blocks for the entire HTTP upload duration, causing kernel
-	// read timeouts (especially with FOPEN_DIRECT_IO where every pread is
-	// a FUSE round-trip, e.g. SQLite WAL workloads — see issue #579).
+	// Lock ordering fix (B3): Release fh.mu FIRST, then acquire the
+	// per-path remote commit lock for the upload. Write() acquires
+	// fh.mu → remoteCommitLock; if we held remoteCommitLock while
+	// waiting to reacquire fh.mu, a concurrent Write() would deadlock.
+	//
+	// By releasing fh.mu before acquiring remoteCommitLock:
+	// - Concurrent Read() can proceed (fh.mu not held) — fixes #579
+	// - Concurrent Write() can acquire fh.mu, then block on
+	//   remoteCommitLock until the upload finishes — no deadlock
+	// - Same-path uploads remain serialized via remoteCommitLock
+	//
+	// Release the top-level remoteCommitLock first (we'll acquire a
+	// fresh one after fh.Unlock for the upload window only).
+	unlockRemoteCommit()
+	remoteCommitReleased = true
+
 	uploadStart := time.Now()
 	fs.debugf("flushHandle path2 unlock before upload path=%s size=%d phase_hint=%s expected_rev=%d", handlePath, size, phase, expectedRevision)
 	fh.Unlock()
+
+	// Acquire the remote commit lock for upload serialization AFTER
+	// releasing fh.mu — correct lock order (never hold remoteCommitLock
+	// while waiting for fh.mu).
+	uploadPathLock := fs.lockWritableRemoteCommitPath(handlePath)
 
 	if useDirectPUT {
 		if size == 0 && handleIsNew {
@@ -11628,6 +11649,10 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.debugDurationf(writeStart, 0, "flushHandle write stream done path=%s size=%d err=%v", handlePath, size, err)
 	}
 
+	// Release the upload path lock BEFORE re-acquiring fh.mu to maintain
+	// correct lock ordering (fh.mu → remoteCommitLock, never the reverse).
+	uploadPathLock()
+
 	// Re-acquire fh.mu after network call completes.
 	fh.Lock()
 	fs.debugDurationf(uploadStart, 0, "flushHandle path2 relock after upload path=%s size=%d err=%v", handlePath, size, err)
@@ -11652,22 +11677,45 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.clearDirtySize(handleIno, handleDirtySeq)
 		fh.DirtySeq = 0
 	}
+	// B4 guard: if fh.Path was changed by retargetOpenHandlesForRename
+	// while the lock was released, the upload went to the old path
+	// (handlePath/remotePath) but fh.Path now points to the new path.
+	// Do NOT record the committed revision on the renamed path — that
+	// would attribute an old-path upload to the new path. Instead, use
+	// handlePath for cache operations and skip markHandleRemoteCommittedLocked
+	// which would pollute the renamed path's revision/shadow/pending state.
+	pathRetargeted := fh.Path != handlePath
+
 	if committedRev > 0 {
 		clearReadTargetForLockedHandle(fh)
-		fs.clearReadTargetsForPathExcept(handlePath, fh)
-		// Use dataCopy (immutable snapshot) for read cache seeding —
-		// the WriteBuffer may have been mutated by concurrent writes
-		// while the lock was released.
-		fs.readCache.Put(handlePath, dataCopy, committedRev)
-		fs.markHandleRemoteCommittedLocked(fh, committedRev)
+		if pathRetargeted {
+			// Upload went to handlePath; fh.Path is now different.
+			// Seed read cache and clear targets for the OLD path only.
+			// The handle's committed state should NOT be updated because
+			// the rename already changed the remote identity.
+			fs.clearReadTargetsForPathExcept(handlePath, nil)
+			fs.readCache.Put(handlePath, dataCopy, committedRev)
+			fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
+		} else {
+			fs.clearReadTargetsForPathExcept(handlePath, fh)
+			// Use dataCopy (immutable snapshot) for read cache seeding —
+			// the WriteBuffer may have been mutated by concurrent writes
+			// while the lock was released.
+			fs.readCache.Put(handlePath, dataCopy, committedRev)
+			fs.markHandleRemoteCommittedLocked(fh, committedRev)
+		}
 	} else if sidecarCached {
 		clearReadTargetForLockedHandle(fh)
 		fs.clearReadTargetsForPathExcept(handlePath, fh)
-		fs.finalizeHandleFlushLocked(fh, expectedRevision)
+		if !pathRetargeted {
+			fs.finalizeHandleFlushLocked(fh, expectedRevision)
+		}
 	} else {
 		clearReadTargetForLockedHandle(fh)
 		fs.invalidateReadCacheAndTargetsExcept(handlePath, fh)
-		fs.finalizeHandleFlushLocked(fh, expectedRevision)
+		if !pathRetargeted {
+			fs.finalizeHandleFlushLocked(fh, expectedRevision)
+		}
 	}
 	// When concurrent writes happened (DirtySeq changed), the buffer may
 	// have a different size than the uploaded snapshot. Use the current

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11807,13 +11807,41 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		clearReadTargetForLockedHandle(fh)
 		fs.clearReadTargetsForPathExcept(handlePath, fh)
 		if !pathRetargeted {
-			fs.finalizeHandleFlushLocked(fh, expectedRevision)
+			if fh.DirtySeq == handleDirtySeq {
+				// No concurrent writes — safe to finalize from live handle.
+				fs.finalizeHandleFlushLocked(fh, expectedRevision)
+			} else {
+				// N1: concurrent writes mutated fh.Dirty during the unlock
+				// window. finalizeHandleFlushLocked would read fh.Dirty.Size()
+				// for OrigSize, associating the uploaded snapshot's synthetic
+				// revision with the post-write buffer size. Use the snapshot
+				// size instead.
+				if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok {
+					fs.markHandleRevisionOnlyLocked(fh, syntheticRev, size)
+				} else {
+					fs.finalizeHandleFlushLocked(fh, expectedRevision)
+				}
+			}
 		}
 	} else {
 		clearReadTargetForLockedHandle(fh)
 		fs.invalidateReadCacheAndTargetsExcept(handlePath, fh)
 		if !pathRetargeted {
-			fs.finalizeHandleFlushLocked(fh, expectedRevision)
+			if fh.DirtySeq == handleDirtySeq {
+				// No concurrent writes — safe to finalize from live handle.
+				fs.finalizeHandleFlushLocked(fh, expectedRevision)
+			} else {
+				// N1: concurrent writes mutated fh.Dirty during the unlock
+				// window. finalizeHandleFlushLocked would read fh.Dirty.Size()
+				// for OrigSize, associating the uploaded snapshot's synthetic
+				// revision with the post-write buffer size. Use the snapshot
+				// size instead.
+				if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok {
+					fs.markHandleRevisionOnlyLocked(fh, syntheticRev, size)
+				} else {
+					fs.finalizeHandleFlushLocked(fh, expectedRevision)
+				}
+			}
 		}
 	}
 	// When concurrent writes happened (DirtySeq changed), the buffer may

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11605,7 +11605,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	// Determine whether we take the patch path (existing large file with
 	// dirty parts). Patch mode only needs per-part snapshots, NOT a full
 	// buffer copy — avoiding 2x memory for small edits to large files.
-	usePatch := !useDirectPUT && threshold > 0 && handleOrigSize >= threshold
+	// B11: must also check size <= handleOrigSize — if the file grew beyond
+	// OrigSize, new parts have no server-side original data and the patch
+	// callback cannot construct correct content. Consistent with write-sync
+	// path's canPatchExisting guard (line ~9912).
+	usePatch := !useDirectPUT && threshold > 0 && handleOrigSize >= threshold && size <= handleOrigSize
 
 	// Prepare patch snapshots while we still hold the lock.
 	var dirtyParts []int

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1906,11 +1906,13 @@ func (fs *Dat9FS) adoptCommittedRevisionLocked(fh *FileHandle) {
 }
 
 // markHandleRevisionOnlyLocked updates the handle's committed revision,
-// IsNew flag, and propagates the revision to other open handles, but does
-// NOT read from fh.Dirty for OrigSize/inode size. This is used when a
-// concurrent write mutated the dirty buffer during the Path 2 unlock
-// window, so the live dirty state reflects uncommitted post-upload data.
-func (fs *Dat9FS) markHandleRevisionOnlyLocked(fh *FileHandle, revision int64) {
+// IsNew flag, OrigSize, and propagates the revision to other open handles,
+// but does NOT read from fh.Dirty for size information. snapshotSize is
+// the size of the data that was actually uploaded (captured before the
+// unlock window). This is used when a concurrent write mutated the dirty
+// buffer during the Path 2 unlock window, so the live dirty state reflects
+// uncommitted post-upload data.
+func (fs *Dat9FS) markHandleRevisionOnlyLocked(fh *FileHandle, revision int64, snapshotSize int64) {
 	if fs == nil || fh == nil || revision <= 0 {
 		return
 	}
@@ -1921,6 +1923,7 @@ func (fs *Dat9FS) markHandleRevisionOnlyLocked(fh *FileHandle, revision int64) {
 	}
 	fh.IsNew = false
 	fh.BaseRev = revision
+	fh.OrigSize = snapshotSize
 	fs.inodes.UpdateRevision(fh.Ino, revision)
 	fs.refreshCommittedRevisionForOpenHandles(fh.Path, revision, fh)
 	if fs.writeBack != nil {
@@ -11764,7 +11767,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 				// for OrigSize, which would associate the uploaded snapshot's
 				// revision with the post-write buffer size. Only update the
 				// committed revision and flags without consuming live dirty state.
-				fs.markHandleRevisionOnlyLocked(fh, committedRev)
+				fs.markHandleRevisionOnlyLocked(fh, committedRev, size)
 			}
 		}
 	} else if sidecarCached {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11528,6 +11528,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	handleDirtySeq := fh.DirtySeq
 	handleOrigSize := fh.OrigSize
 	handleDirtyPartSize := fh.Dirty.PartSize()
+	handleFullRangeLoaded := writeBufferHasLoadedFullRange(fh.Dirty)
 	var committedRev int64
 
 	// Use the negotiated server threshold (not the heuristic-only inline
@@ -11674,7 +11675,17 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	}
 
 	sidecarRevision := sqliteCommittedRevision(committedRev, expectedRevision)
-	sidecarCached := fs.cacheCommittedSQLitePersistentJournalLocked(fh, sidecarRevision)
+	// Use snapshot path (handlePath), immutable data (dataCopy), and
+	// snapshot full-range flag for the SQLite sidecar cache. After the
+	// unlock window, live fh.Path may be retargeted and fh.Dirty may
+	// contain concurrent Write() data — using them would cache
+	// uncommitted bytes or cache under the wrong path.
+	var sidecarCached bool
+	if fs.readCache != nil && sidecarRevision > 0 && isSQLitePersistentJournalPath(handlePath) &&
+		size <= fs.readCache.MaxFileSize() && handleFullRangeLoaded {
+		fs.readCache.Put(handlePath, dataCopy, sidecarRevision)
+		sidecarCached = true
+	}
 
 	// B4 guard: check retarget BEFORE dirty cleanup. If fh.Path was
 	// changed by retargetOpenHandlesForRename while the lock was released,

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11645,9 +11645,15 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 
 	sidecarRevision := sqliteCommittedRevision(committedRev, expectedRevision)
 	sidecarCached := fs.cacheCommittedSQLitePersistentJournalLocked(fh, sidecarRevision)
-	fh.Dirty.ClearDirty()
-	fs.clearDirtySize(fh.Ino, handleDirtySeq)
-	fh.DirtySeq = 0
+	// Only clear dirty state if no concurrent writes happened while the
+	// lock was released. If DirtySeq changed, a new write arrived and the
+	// buffer must stay dirty so the next flush picks it up. This mirrors
+	// the generation guard in flushHandleDebounced (line ~11243).
+	if fh.DirtySeq == handleDirtySeq {
+		fh.Dirty.ClearDirty()
+		fs.clearDirtySize(handleIno, handleDirtySeq)
+		fh.DirtySeq = 0
+	}
 	if committedRev > 0 {
 		clearReadTargetForLockedHandle(fh)
 		fs.clearReadTargetsForPathExcept(handlePath, fh)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11512,10 +11512,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	// internal smallFileData; concurrent Write() calls while the lock is
 	// released would corrupt the upload payload. Path 1a/1b already follow
 	// this pattern (copy + unlock before network).
-	data := fh.Dirty.bytesView()
-	dataCopy := make([]byte, len(data))
-	copy(dataCopy, data)
-	data = nil // prevent accidental use of mutable view after this point
+	dataCopy := make([]byte, fh.Dirty.Size())
+	copy(dataCopy, fh.Dirty.bytesView())
 
 	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 	remotePath := fs.remotePath(fh.Path)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11275,16 +11275,22 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 			return
 		}
 
-		// B13: Re-check the expected revision after acquiring handle.Lock().
-		// A forced flush (Path 2) may have uploaded while this callback was
-		// blocked waiting for handle.Lock(). Path 2 records the committed
-		// revision to global state before releasing remoteCommitLock, and
-		// releases fh.mu before the callback can acquire it. So by the time
-		// we get here, adoptCommittedRevisionLocked will see the updated
-		// revision. If expectedRevision changed, the forced flush already
-		// uploaded — skip to avoid a double PUT with a stale CAS revision.
+		// B13: Acquire remoteCommitLock to serialize with any concurrent
+		// forced flush (Path 2). Lock ordering is handle.Lock() →
+		// remoteCommitLock — same as Write()'s fh.mu → remoteCommitLock,
+		// so no deadlock. Path 2 holds remoteCommitLock and releases fh.mu
+		// before uploading, so the callback blocks here until Path 2
+		// finishes and releases remoteCommitLock.
+		unlockRemoteCommit := fs.lockRemoteCommitPath(filePath)
+
+		// Re-check the expected revision after acquiring both locks.
+		// Path 2 records committed revision while holding remoteCommitLock,
+		// so by the time we acquire it, adoptCommittedRevisionLocked will
+		// see the updated revision. If expectedRevision changed, the
+		// forced flush already uploaded — skip to avoid double PUT.
 		currentExpectedRevision := fs.expectedRevisionForHandleLocked(handle)
 		if currentExpectedRevision != expectedRevision {
+			unlockRemoteCommit()
 			handle.Unlock()
 			return
 		}
@@ -11295,6 +11301,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		dCf()
 		fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
 		if err != nil {
+			unlockRemoteCommit()
 			handle.Unlock()
 			log.Printf("debounced flush failed for %s: %v", filePath, err)
 			return
@@ -11303,12 +11310,13 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		modeErr := fs.applyPendingModeForHandleLocked(modeCtx, handle)
 		modeCancel()
 		if modeErr != nil {
+			unlockRemoteCommit()
 			handle.Unlock()
 			log.Printf("debounced flush pending chmod failed for %s: %v", filePath, modeErr)
 			return
 		}
-		// The handle stays locked across upload + finalize so concurrent writes
-		// cannot advance live state for data outside this committed snapshot.
+		// Record committed revision while holding remoteCommitLock, consistent
+		// with Path 2's approach (lines 11754-11770).
 		if committedRev > 0 {
 			fs.recordCommittedRevision(filePath, committedRev)
 			handle.IsNew = false
@@ -11323,6 +11331,10 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		} else {
 			fs.finalizeHandleFlushLocked(handle, expectedRevision)
 		}
+		// Release remoteCommitLock after recording revision, before
+		// releasing handle lock — same pattern as Path 2.
+		unlockRemoteCommit()
+
 		if handle.Dirty != nil && handle.DirtySeq == snapshotSeq {
 			handle.Dirty.ClearDirty()
 		}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11675,23 +11675,25 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 
 	sidecarRevision := sqliteCommittedRevision(committedRev, expectedRevision)
 	sidecarCached := fs.cacheCommittedSQLitePersistentJournalLocked(fh, sidecarRevision)
+
+	// B4 guard: check retarget BEFORE dirty cleanup. If fh.Path was
+	// changed by retargetOpenHandlesForRename while the lock was released,
+	// the upload went to the old path (handlePath) but fh.Path now points
+	// to the new path. The dirty buffer now belongs to the new path and
+	// must NOT be cleared — the old-path upload success does not satisfy
+	// the new path's flush obligation.
+	pathRetargeted := fh.Path != handlePath
+
 	// Only clear dirty state if no concurrent writes happened while the
-	// lock was released. If DirtySeq changed, a new write arrived and the
-	// buffer must stay dirty so the next flush picks it up. This mirrors
-	// the generation guard in flushHandleDebounced (line ~11243).
-	if fh.DirtySeq == handleDirtySeq {
+	// lock was released AND the handle was not retargeted. If DirtySeq
+	// changed, a new write arrived and the buffer must stay dirty so the
+	// next flush picks it up. If retargeted, the dirty data belongs to
+	// the new path and must be preserved for a subsequent flush.
+	if !pathRetargeted && fh.DirtySeq == handleDirtySeq {
 		fh.Dirty.ClearDirty()
 		fs.clearDirtySize(handleIno, handleDirtySeq)
 		fh.DirtySeq = 0
 	}
-	// B4 guard: if fh.Path was changed by retargetOpenHandlesForRename
-	// while the lock was released, the upload went to the old path
-	// (handlePath/remotePath) but fh.Path now points to the new path.
-	// Do NOT record the committed revision on the renamed path — that
-	// would attribute an old-path upload to the new path. Instead, use
-	// handlePath for cache operations and skip markHandleRemoteCommittedLocked
-	// which would pollute the renamed path's revision/shadow/pending state.
-	pathRetargeted := fh.Path != handlePath
 
 	if committedRev > 0 {
 		clearReadTargetForLockedHandle(fh)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -13921,6 +13921,18 @@ func TestFlushHandle_Path2_SnapshotIsolation(t *testing.T) {
 	if !hasDirty {
 		t.Fatal("Dirty.HasDirtyParts() = false after flush with concurrent write — new write not preserved")
 	}
+
+	// Verify inode size reflects the concurrent write, not the old snapshot.
+	// Without this guard, UpdateSize(ino, size) would roll back to the
+	// uploaded snapshot size, making getattr report a stale file length.
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode entry not found after flush")
+	}
+	if entry.Size != int64(len(mutated)) {
+		t.Fatalf("inode size = %d, want %d (concurrent write size); stale snapshot size would be %d",
+			entry.Size, len(mutated), len(original))
+	}
 }
 
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -13867,14 +13867,18 @@ func TestFlushHandle_Path2_SnapshotIsolation(t *testing.T) {
 	// Wait for the HTTP handler to receive the upload (lock released).
 	<-uploadStarted
 
-	// Mutate the WriteBuffer while upload is in-flight. If the fix is
-	// correct, the upload uses the pre-unlock snapshot and this write
-	// does not affect the committed data.
+	// Mutate the WriteBuffer while upload is in-flight, simulating what
+	// a real fs.Write() would do: write data + advance DirtySeq. If the
+	// fix is correct, the upload uses the pre-unlock snapshot and this
+	// write does not affect the committed data. The generation guard must
+	// also preserve the dirty state so the new data is flushed next time.
 	mutated := []byte("MUTATED-WHILE-UPLOAD-INFLIGHT!")
 	fh.Lock()
 	if _, err := fh.Dirty.Write(0, mutated); err != nil {
 		t.Fatal(err)
 	}
+	// Advance DirtySeq like fs.Write() does via markDirtySize.
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
 	fh.Unlock()
 
 	// Let the upload complete.
@@ -13902,6 +13906,20 @@ func TestFlushHandle_Path2_SnapshotIsolation(t *testing.T) {
 	}
 	if !bytes.Equal(cached, original) {
 		t.Fatalf("readCache content = %q, want %q", cached, original)
+	}
+
+	// Verify the concurrent write kept the handle dirty (generation guard).
+	// If ClearDirty ran unconditionally, DirtySeq would be 0 and the new
+	// data would be silently lost on the next flush.
+	fh.Lock()
+	dirtySeqAfter := fh.DirtySeq
+	hasDirty := fh.Dirty.HasDirtyParts()
+	fh.Unlock()
+	if dirtySeqAfter == 0 {
+		t.Fatal("DirtySeq = 0 after flush with concurrent write — new write data would be lost")
+	}
+	if !hasDirty {
+		t.Fatal("Dirty.HasDirtyParts() = false after flush with concurrent write — new write not preserved")
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -15138,6 +15138,138 @@ func TestFlushHandle_Path2_SyntheticRevRecordedBeforeUnlock(t *testing.T) {
 	}
 }
 
+// TestFlushHandle_Path2_LazyLoadedGrowthReturnsEIO verifies that when a
+// lazy-loaded existing large file grows beyond OrigSize and enters the
+// WriteStreamConditional path, flushHandle returns EIO if the buffer
+// cannot materialize all parts. Without the B12 fix, bytesView() would
+// zero-fill unloaded remote-backed parts, overwriting remote data.
+func TestFlushHandle_Path2_LazyLoadedGrowthReturnsEIO(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("should not reach server — flush should return EIO before upload")
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var threshold int64 = 100
+	fs.smallFileMax.Store(threshold)
+
+	path := "/b12-lazy-growth.dat"
+	ino := fs.inodes.Lookup(path, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	// Create a part-mode WriteBuffer with remoteSize > 0 (simulating
+	// a lazy-loaded existing large file where some parts are NOT loaded).
+	wb := NewWriteBuffer(path, maxPreloadSize, 256)
+	wb.remoteSize = 512 // remote has 512 bytes that are NOT loaded locally
+	wb.totalSize = 512
+
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    wb,
+		BaseRev:  5,
+		OrigSize: 200, // above threshold
+	}
+
+	// Write ONLY at offset 512 (append), growing file to 600.
+	// Parts 0 and 1 (covering bytes 0-511) are NOT loaded.
+	appendData := make([]byte, 88)
+	for i := range appendData {
+		appendData[i] = byte(i + 1)
+	}
+	if _, err := fh.Dirty.Write(512, appendData); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	_ = fs.fileHandles.Allocate(fh)
+
+	// Verify CanMaterializeFull is false (parts 0,1 not loaded).
+	if fh.Dirty.CanMaterializeFull() {
+		t.Fatal("expected CanMaterializeFull() = false for lazy-loaded buffer")
+	}
+
+	fh.Lock()
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+
+	// B12 assertion: must return EIO, not attempt upload with zero-filled data.
+	if st == gofuse.OK {
+		t.Fatal("expected EIO for lazy-loaded growth path — B12: must not materialize unloaded remote parts as zeroes")
+	}
+	if st != gofuse.EIO {
+		t.Fatalf("expected EIO, got %v", st)
+	}
+}
+
+// TestFlushHandle_Path2_DebounceCancelledBeforeUnlock verifies that the
+// debouncer is cancelled for the flush path before releasing fh.mu.
+// Without the B13 fix, a debounced upload could fire while fh.mu is
+// released, racing with the forced flush upload using the same
+// expectedRevision and causing a CAS conflict.
+func TestFlushHandle_Path2_DebounceCancelledBeforeUnlock(t *testing.T) {
+	var uploadCount atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			uploadCount.Add(1)
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 10})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.FlushDebounce = 50 * time.Millisecond
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	path := "/b13-debounce-cancel.txt"
+	ino := fs.inodes.Lookup(path, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    path,
+		Dirty:   NewWriteBuffer(path, maxPreloadSize, 0),
+		BaseRev: 5,
+	}
+	if _, err := fh.Dirty.Write(0, []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	_ = fs.fileHandles.Allocate(fh)
+
+	// Schedule a debounced flush first.
+	fh.Lock()
+	_ = fs.flushHandleDebounced(context.Background(), fh, false)
+	fh.Unlock()
+
+	// Now do a forced flush (flushHandle directly). This should cancel
+	// the pending debounce before releasing fh.mu.
+	fh.Lock()
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+
+	if st != gofuse.OK {
+		t.Fatalf("flushHandle status = %v, want OK", st)
+	}
+
+	// Wait for debounce timer to expire. If the debounce was properly
+	// cancelled, only the forced flush upload should have occurred.
+	time.Sleep(200 * time.Millisecond)
+
+	count := uploadCount.Load()
+	if count != 1 {
+		t.Fatalf("upload count = %d, want 1 — B13: debounced upload should be cancelled before forced flush", count)
+	}
+}
+
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -15270,6 +15270,89 @@ func TestFlushHandle_Path2_DebounceCancelledBeforeUnlock(t *testing.T) {
 	}
 }
 
+// TestFlushHandle_Path2_DebounceAlreadyFiredSkipsUpload verifies that when a
+// debounced callback has already fired and is blocked waiting on handle.Lock(),
+// it re-checks expectedRevision after acquiring the lock and skips the upload
+// if a forced flush (Path 2) already uploaded successfully.
+//
+// Interleaving under test:
+//
+//	1. Schedule debounce (short delay)
+//	2. Hold handle.Lock() — callback fires but blocks on Lock()
+//	3. Forced flush (flushHandle) uploads and records committed revision
+//	4. Release handle.Lock() — callback acquires it
+//	5. Callback sees revised expectedRevision → skip (no double upload)
+func TestFlushHandle_Path2_DebounceAlreadyFiredSkipsUpload(t *testing.T) {
+	var uploadCount atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			uploadCount.Add(1)
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 10})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	// Very short debounce so the timer fires while we hold the lock.
+	opts.FlushDebounce = 5 * time.Millisecond
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	path := "/b13-already-fired.txt"
+	ino := fs.inodes.Lookup(path, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    path,
+		Dirty:   NewWriteBuffer(path, maxPreloadSize, 0),
+		BaseRev: 5,
+	}
+	if _, err := fh.Dirty.Write(0, []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	_ = fs.fileHandles.Allocate(fh)
+
+	// Step 1: Schedule debounce while holding lock.
+	fh.Lock()
+	_ = fs.flushHandleDebounced(context.Background(), fh, false)
+	fh.Unlock()
+
+	// Step 2: Wait for the debounce timer to fire. The callback will try
+	// handle.Lock(). We re-acquire the lock first so the callback blocks.
+	//
+	// Give timer plenty of time to fire and block on Lock().
+	time.Sleep(50 * time.Millisecond)
+	fh.Lock()
+	// At this point the debounced callback has fired (timer expired) and
+	// is blocked on handle.Lock(). Cancel() will NOT stop it because the
+	// callback already removed itself from the pending map.
+
+	// Step 3: Force flush (Path 2) — uploads and records committed revision.
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+	// Step 4: fh.Unlock() lets the debounced callback acquire handle.Lock().
+	// It should see the updated expectedRevision and skip the upload.
+
+	if st != gofuse.OK {
+		t.Fatalf("flushHandle status = %v, want OK", st)
+	}
+
+	// Step 5: Wait for debounced callback to finish.
+	time.Sleep(100 * time.Millisecond)
+
+	count := uploadCount.Load()
+	if count != 1 {
+		t.Fatalf("upload count = %d, want 1 — B13: already-fired debounced callback should skip upload when expectedRevision advanced", count)
+	}
+}
+
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -13945,10 +13945,12 @@ func TestFlushHandle_Path2_SnapshotIsolation(t *testing.T) {
 // upload, remoteCommitLock is released BEFORE re-acquiring fh.mu — so flush
 // never holds remoteCommitLock while waiting for fh.mu. Concurrent Write()
 // acquires fh.mu then blocks on remoteCommitLock until upload finishes —
-// linear wait, no deadlock. This test verifies:
-// 1. fh.mu is released during upload (Read can proceed)
-// 2. After upload completes, Write() succeeds (no circular wait)
-// 3. The write's dirty state is preserved for the next flush
+// linear wait, no deadlock. This test exercises the actual B3 scenario:
+//
+// 1. Flush starts, upload blocks (remoteCommitLock held, fh.mu released)
+// 2. Write() starts DURING upload — acquires fh.mu, blocks on remoteCommitLock
+// 3. Upload resumes → remoteCommitLock released → Write() completes
+// 4. Both flush and Write succeed, dirty state preserved
 func TestFlushHandle_Path2_NoDeadlockWithConcurrentWrite(t *testing.T) {
 	uploadStarted := make(chan struct{})
 	uploadResume := make(chan struct{})
@@ -14001,50 +14003,54 @@ func TestFlushHandle_Path2_NoDeadlockWithConcurrentWrite(t *testing.T) {
 		t.Fatal("upload did not start within timeout — fh.mu not released during Path 2 upload")
 	}
 
-	// Verify fh.mu IS released during upload by acquiring it briefly.
-	// This is the critical check: before the fix, this would block
-	// because flushHandle held fh.mu during the entire upload.
-	fhMuAcquired := make(chan struct{})
+	// Issue Write() DURING upload — this is the B3 deadlock scenario.
+	// Write() acquires fh.mu (released by flush), then blocks on
+	// remoteCommitLock (held by flush for upload serialization).
+	// Before the fix: flush held remoteCommitLock and waited for fh.mu
+	// to relock → circular wait → deadlock.
+	// After the fix: flush releases remoteCommitLock before fh.Lock(),
+	// so Write() completes after upload finishes → no deadlock.
+	writeDone := make(chan gofuse.Status, 1)
 	go func() {
-		fh.Lock()
-		close(fhMuAcquired)
-		fh.Unlock()
+		_, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+			Offset:   0,
+			Size:     uint32(len("WORLD")),
+		}, []byte("WORLD"))
+		writeDone <- st
 	}()
-	select {
-	case <-fhMuAcquired:
-		// Good — fh.mu is released during upload.
-	case <-time.After(2 * time.Second):
-		t.Fatal("fh.mu not released during Path 2 upload — Read() would block")
-	}
 
-	// Let the upload finish, then issue Write() after flush completes.
-	// Write() will succeed because there's no lock inversion.
+	// Give Write() a moment to acquire fh.mu and block on remoteCommitLock.
+	// If this were the old code, both goroutines would be stuck forever.
+	time.Sleep(50 * time.Millisecond)
+
+	// Resume upload — this releases remoteCommitLock, unblocking Write().
 	close(uploadResume)
+
+	// Both flush and Write must complete without deadlock.
 	select {
 	case st := <-flushDone:
 		if st != gofuse.OK {
 			t.Fatalf("flushHandle status = %v, want OK", st)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("flushHandle did not complete after upload resumed")
+		t.Fatal("flushHandle did not complete — deadlock?")
+	}
+	select {
+	case st := <-writeDone:
+		if st != gofuse.OK {
+			t.Fatalf("concurrent Write status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write did not complete after upload released remoteCommitLock — deadlock?")
 	}
 
-	// Write after flush completes — must succeed and mark dirty.
-	_, st := fs.Write(nil, &gofuse.WriteIn{
-		InHeader: gofuse.InHeader{NodeId: ino},
-		Fh:       fhID,
-		Offset:   0,
-		Size:     uint32(len("WORLD")),
-	}, []byte("WORLD"))
-	if st != gofuse.OK {
-		t.Fatalf("Write after flush status = %v, want OK", st)
-	}
-
-	// The write must have kept the handle dirty.
+	// The concurrent write must have kept the handle dirty for next flush.
 	fh.Lock()
 	if fh.DirtySeq == 0 {
 		fh.Unlock()
-		t.Fatal("DirtySeq = 0 after Write — data loss")
+		t.Fatal("DirtySeq = 0 after concurrent Write — data loss")
 	}
 	fh.Unlock()
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -15272,16 +15272,18 @@ func TestFlushHandle_Path2_DebounceCancelledBeforeUnlock(t *testing.T) {
 
 // TestFlushHandle_Path2_DebounceAlreadyFiredSkipsUpload verifies that when a
 // debounced callback has already fired and is blocked waiting on handle.Lock(),
-// it re-checks expectedRevision after acquiring the lock and skips the upload
-// if a forced flush (Path 2) already uploaded successfully.
+// it acquires remoteCommitLock and re-checks expectedRevision, skipping the
+// upload if a forced flush (Path 2) already uploaded successfully.
 //
 // Interleaving under test:
 //
-//	1. Schedule debounce (short delay)
-//	2. Hold handle.Lock() — callback fires but blocks on Lock()
-//	3. Forced flush (flushHandle) uploads and records committed revision
-//	4. Release handle.Lock() — callback acquires it
-//	5. Callback sees revised expectedRevision → skip (no double upload)
+//	1. Hold fh.Lock() → schedule debounce (short delay) → keep lock held
+//	2. Timer fires → callback blocks on handle.Lock() (we hold it)
+//	3. Call flushHandle (Path 2) while holding lock — Path 2 internally
+//	   releases fh.mu, uploads, records committed revision, releases
+//	   remoteCommitLock, reacquires fh.mu, returns
+//	4. fh.Unlock() → callback acquires handle.Lock() → acquires
+//	   remoteCommitLock → re-checks expectedRevision → skip (no double PUT)
 func TestFlushHandle_Path2_DebounceAlreadyFiredSkipsUpload(t *testing.T) {
 	var uploadCount atomic.Int32
 
@@ -15319,37 +15321,39 @@ func TestFlushHandle_Path2_DebounceAlreadyFiredSkipsUpload(t *testing.T) {
 	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
 	_ = fs.fileHandles.Allocate(fh)
 
-	// Step 1: Schedule debounce while holding lock.
+	// Step 1: Hold lock, schedule debounce, keep lock held.
 	fh.Lock()
 	_ = fs.flushHandleDebounced(context.Background(), fh, false)
-	fh.Unlock()
+	// Do NOT unlock — we keep fh.mu held so the callback blocks.
 
-	// Step 2: Wait for the debounce timer to fire. The callback will try
-	// handle.Lock(). We re-acquire the lock first so the callback blocks.
-	//
-	// Give timer plenty of time to fire and block on Lock().
+	// Step 2: Wait for the debounce timer to fire. The callback removes
+	// itself from the pending map and then blocks on handle.Lock().
 	time.Sleep(50 * time.Millisecond)
-	fh.Lock()
-	// At this point the debounced callback has fired (timer expired) and
-	// is blocked on handle.Lock(). Cancel() will NOT stop it because the
-	// callback already removed itself from the pending map.
+	// At this point: callback has fired, removed from pending map,
+	// blocked on handle.Lock(). Cancel() would be a no-op.
 
-	// Step 3: Force flush (Path 2) — uploads and records committed revision.
+	// Step 3: Force flush (Path 2) while holding fh.mu.
+	// flushHandle internally: acquires remoteCommitLock → releases fh.mu →
+	// uploads → records committed revision → releases remoteCommitLock →
+	// reacquires fh.mu → returns.
+	//
+	// During the fh.Unlock() window inside flushHandle, the debounced
+	// callback acquires handle.Lock() but then blocks on remoteCommitLock
+	// (which Path 2 still holds). After Path 2 finishes, callback acquires
+	// remoteCommitLock, re-checks expectedRevision, sees it changed, skips.
 	st := fs.flushHandle(context.Background(), fh)
 	fh.Unlock()
-	// Step 4: fh.Unlock() lets the debounced callback acquire handle.Lock().
-	// It should see the updated expectedRevision and skip the upload.
 
 	if st != gofuse.OK {
 		t.Fatalf("flushHandle status = %v, want OK", st)
 	}
 
-	// Step 5: Wait for debounced callback to finish.
+	// Step 4: Wait for debounced callback to finish (it should skip).
 	time.Sleep(100 * time.Millisecond)
 
 	count := uploadCount.Load()
 	if count != 1 {
-		t.Fatalf("upload count = %d, want 1 — B13: already-fired debounced callback should skip upload when expectedRevision advanced", count)
+		t.Fatalf("upload count = %d, want 1 — B13: already-fired debounced callback should be serialized by remoteCommitLock and skip when expectedRevision advanced", count)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14963,6 +14963,96 @@ func TestFlushHandle_Path2_PatchPathNoFullBufferCopy(t *testing.T) {
 	}
 }
 
+// TestFlushHandle_Path2_GrowthBypassesPatch verifies that when a large
+// existing file grows beyond OrigSize, Path 2 uses WriteStreamConditional
+// (full upload) instead of PatchFile. Without the B11 guard
+// (size <= handleOrigSize), PatchFile would be selected for a grown file,
+// but new parts beyond the original size have no server-side data, and the
+// patch callback cannot construct correct content for them.
+func TestFlushHandle_Path2_GrowthBypassesPatch(t *testing.T) {
+	var patchReceived atomic.Bool
+	var writeStreamReceived atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			patchReceived.Store(true)
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"upload_id":    "test-upload-b11",
+				"upload_parts": []interface{}{},
+				"copied_parts": []interface{}{},
+			})
+			return
+		}
+		if r.Method == http.MethodPost {
+			// Multipart initiate or complete.
+			if strings.Contains(r.URL.Path, "/complete") {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+				return
+			}
+			// Initiate — WriteStreamConditional starts with POST.
+			writeStreamReceived.Store(true)
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+			return
+		}
+		if r.Method == http.MethodPut {
+			_, _ = io.ReadAll(r.Body)
+			writeStreamReceived.Store(true)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var threshold int64 = 100
+	fs.smallFileMax.Store(threshold)
+
+	path := "/b11-growth-no-patch.dat"
+	ino := fs.inodes.Lookup(path, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	// Existing large file (OrigSize=200), but write grows it to 400.
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    NewWriteBuffer(path, maxPreloadSize, 0),
+		BaseRev:  5,
+		OrigSize: 200, // above threshold
+	}
+
+	// Write 400 bytes — grows beyond OrigSize.
+	data := make([]byte, 400)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	if _, err := fh.Dirty.Write(0, data); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	_ = fs.fileHandles.Allocate(fh)
+
+	fh.Lock()
+	_ = fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+
+	// B11 assertion: growth must NOT use PatchFile. It should use
+	// WriteStreamConditional (full upload) because new parts beyond
+	// OrigSize have no server-side original data.
+	if patchReceived.Load() {
+		t.Fatal("received PATCH for grown file — B11: growth beyond OrigSize must bypass patch path and use full upload")
+	}
+}
+
 // TestFlushHandle_Path2_SyntheticRevRecordedBeforeUnlock verifies that when
 // a Path 2 flush succeeds without the server returning a committed revision
 // (e.g. PatchFile / WriteStreamConditional), the synthetic revision

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14170,6 +14170,106 @@ func TestFlushHandle_Path2_RenameRetargetDuringUpload(t *testing.T) {
 	}
 }
 
+// TestFlushHandle_Path2_SidecarCacheUsesSnapshotOnRetarget verifies that the
+// SQLite persistent journal sidecar cache uses snapshot path+data (handlePath,
+// dataCopy) after the unlock window, not live fh.Path/fh.Dirty which may be
+// retargeted or mutated by concurrent writes.
+//
+// Uses a -wal path to trigger the isSQLitePersistentJournalPath branch.
+// During upload: rename retarget changes fh.Path to a new -wal path.
+// After flush: asserts sidecar cache contains old path + snapshot data,
+// NOT the retargeted new path.
+func TestFlushHandle_Path2_SidecarCacheUsesSnapshotOnRetarget(t *testing.T) {
+	uploadStarted := make(chan struct{})
+	uploadResume := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			_, _ = io.ReadAll(r.Body)
+			close(uploadStarted)
+			<-uploadResume
+			w.WriteHeader(http.StatusOK)
+			// Return revision 0 so committedRev == 0, forcing the
+			// sidecar cache branch (sidecarCached) instead of the
+			// committedRev > 0 branch.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 0})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	oldPath := "/workload.db-wal"
+	newPath := "/renamed.db-wal"
+	ino := fs.inodes.Lookup(oldPath, false, 8, time.Now())
+	fs.inodes.UpdateRevision(ino, 3)
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    oldPath,
+		Dirty:   NewWriteBuffer(oldPath, maxPreloadSize, 0),
+		BaseRev: 3,
+	}
+	walData := []byte("wal-snapshot-data")
+	if _, err := fh.Dirty.Write(0, walData); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	fs.openHandles.Add(fh)
+
+	// Start flush in background.
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+
+	// Wait for upload to start.
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload did not start")
+	}
+
+	// Rename retarget during upload — fh.Path changes from old to new.
+	fs.retargetOpenHandlesForRename(oldPath, newPath)
+
+	// Let the upload complete.
+	close(uploadResume)
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("flushHandle status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("flushHandle did not complete")
+	}
+
+	// The sidecar cache MUST have been seeded under the old path
+	// (handlePath snapshot) with the snapshot data (dataCopy), NOT
+	// under the retargeted new path.
+	// expectedRevision for BaseRev=3 is 3 (expectedRevisionForHandle).
+	sidecarRev := int64(4) // sqliteCommittedRevision(0, 3) = 3+1 = 4
+	cached, ok := fs.readCache.Get(oldPath, sidecarRev)
+	if !ok {
+		t.Fatal("readCache miss for old -wal path — sidecar cache did not use snapshot handlePath")
+	}
+	if !bytes.Equal(cached, walData) {
+		t.Fatalf("readCache for old path = %q, want %q — sidecar cache did not use dataCopy", cached, walData)
+	}
+
+	// The new path must NOT have sidecar cache from the old-path upload.
+	if _, ok := fs.readCache.Get(newPath, sidecarRev); ok {
+		t.Fatal("readCache hit for new -wal path — sidecar cache leaked to retargeted path")
+	}
+}
+
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14176,9 +14176,12 @@ func TestFlushHandle_Path2_RenameRetargetDuringUpload(t *testing.T) {
 // retargeted or mutated by concurrent writes.
 //
 // Uses a -wal path to trigger the isSQLitePersistentJournalPath branch.
-// During upload: rename retarget changes fh.Path to a new -wal path.
-// After flush: asserts sidecar cache contains old path + snapshot data,
-// NOT the retargeted new path.
+// During upload:
+//   - rename retarget changes fh.Path to a new -wal path
+//   - concurrent write mutates fh.Dirty with different data
+//
+// After flush: asserts sidecar cache contains old path + original snapshot
+// data, NOT the retargeted new path or the mutated dirty buffer.
 func TestFlushHandle_Path2_SidecarCacheUsesSnapshotOnRetarget(t *testing.T) {
 	uploadStarted := make(chan struct{})
 	uploadResume := make(chan struct{})
@@ -14240,6 +14243,17 @@ func TestFlushHandle_Path2_SidecarCacheUsesSnapshotOnRetarget(t *testing.T) {
 	// Rename retarget during upload — fh.Path changes from old to new.
 	fs.retargetOpenHandlesForRename(oldPath, newPath)
 
+	// Mutate fh.Dirty during upload — simulates concurrent Write() while
+	// fh.mu is released. The sidecar cache must still use dataCopy
+	// (snapshot before upload), not live fh.Dirty.bytesView().
+	fh.Lock()
+	mutatedData := []byte("MUTATED-WAL-DATA!")
+	if _, err := fh.Dirty.Write(0, mutatedData); err != nil {
+		fh.Unlock()
+		t.Fatal(err)
+	}
+	fh.Unlock()
+
 	// Let the upload complete.
 	close(uploadResume)
 	select {
@@ -14262,6 +14276,10 @@ func TestFlushHandle_Path2_SidecarCacheUsesSnapshotOnRetarget(t *testing.T) {
 	}
 	if !bytes.Equal(cached, walData) {
 		t.Fatalf("readCache for old path = %q, want %q — sidecar cache did not use dataCopy", cached, walData)
+	}
+	// Explicitly verify the cached data is NOT the mutated dirty buffer.
+	if bytes.Equal(cached, mutatedData) {
+		t.Fatal("readCache contains mutated dirty bytes — sidecar cache used live fh.Dirty.bytesView() instead of dataCopy")
 	}
 
 	// The new path must NOT have sidecar cache from the old-path upload.

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -13935,6 +13935,210 @@ func TestFlushHandle_Path2_SnapshotIsolation(t *testing.T) {
 	}
 }
 
+// TestFlushHandle_Path2_NoDeadlockWithConcurrentWrite verifies that the lock
+// ordering between fh.mu and remoteCommitLock does not deadlock. Before the
+// fix, flushHandle held remoteCommitLock while waiting to reacquire fh.mu,
+// while Write() held fh.mu waiting for remoteCommitLock → deadlock.
+//
+// After the fix, flush releases fh.mu FIRST (unblocking Read), then acquires
+// remoteCommitLock for the upload. Write() can acquire fh.mu immediately but
+// may wait on remoteCommitLock until the upload finishes — that's correct
+// serialization, not a deadlock. This test verifies:
+// 1. fh.mu is released during upload (Read can proceed)
+// 2. After upload completes, Write() succeeds (no circular wait)
+// 3. The write's dirty state is preserved for the next flush
+func TestFlushHandle_Path2_NoDeadlockWithConcurrentWrite(t *testing.T) {
+	uploadStarted := make(chan struct{})
+	uploadResume := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			_, _ = io.ReadAll(r.Body)
+			close(uploadStarted)
+			<-uploadResume
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 10})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/deadlock-test.txt", false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    "/deadlock-test.txt",
+		Dirty:   NewWriteBuffer("/deadlock-test.txt", maxPreloadSize, 0),
+		BaseRev: 1,
+	}
+	if _, err := fh.Dirty.Write(0, []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	fhID := fs.fileHandles.Allocate(fh)
+
+	// Start flush in background.
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+
+	// Wait for upload to start (fh.mu released by Path 2).
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload did not start within timeout — fh.mu not released during Path 2 upload")
+	}
+
+	// Verify fh.mu IS released during upload by acquiring it briefly.
+	// This is the critical check: before the fix, this would block
+	// because flushHandle held fh.mu during the entire upload.
+	fhMuAcquired := make(chan struct{})
+	go func() {
+		fh.Lock()
+		close(fhMuAcquired)
+		fh.Unlock()
+	}()
+	select {
+	case <-fhMuAcquired:
+		// Good — fh.mu is released during upload.
+	case <-time.After(2 * time.Second):
+		t.Fatal("fh.mu not released during Path 2 upload — Read() would block")
+	}
+
+	// Let the upload finish, then issue Write() after flush completes.
+	// Write() will succeed because there's no lock inversion.
+	close(uploadResume)
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("flushHandle status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("flushHandle did not complete after upload resumed")
+	}
+
+	// Write after flush completes — must succeed and mark dirty.
+	_, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       fhID,
+		Offset:   0,
+		Size:     uint32(len("WORLD")),
+	}, []byte("WORLD"))
+	if st != gofuse.OK {
+		t.Fatalf("Write after flush status = %v, want OK", st)
+	}
+
+	// The write must have kept the handle dirty.
+	fh.Lock()
+	if fh.DirtySeq == 0 {
+		fh.Unlock()
+		t.Fatal("DirtySeq = 0 after Write — data loss")
+	}
+	fh.Unlock()
+
+	_ = fhID // keep allocated for the duration of the test
+}
+
+// TestFlushHandle_Path2_RenameRetargetDuringUpload verifies that when
+// retargetOpenHandlesForRename changes fh.Path while a Path 2 upload is
+// in-flight, the committed revision is NOT misattributed to the new path.
+func TestFlushHandle_Path2_RenameRetargetDuringUpload(t *testing.T) {
+	uploadStarted := make(chan struct{})
+	uploadResume := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			_, _ = io.ReadAll(r.Body)
+			close(uploadStarted)
+			<-uploadResume
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 20})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	oldPath := "/rename-old.txt"
+	newPath := "/rename-new.txt"
+	ino := fs.inodes.Lookup(oldPath, false, 4, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    oldPath,
+		Dirty:   NewWriteBuffer(oldPath, maxPreloadSize, 0),
+		BaseRev: 5,
+	}
+	if _, err := fh.Dirty.Write(0, []byte("data")); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	fs.openHandles.Add(fh)
+
+	// Start flush in background.
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+
+	// Wait for upload to start.
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload did not start")
+	}
+
+	// Simulate rename retarget while upload is in-flight.
+	fs.retargetOpenHandlesForRename(oldPath, newPath)
+
+	// Let the upload complete.
+	close(uploadResume)
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("flushHandle status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("flushHandle did not complete")
+	}
+
+	// The committed revision (20) should NOT be recorded on the new path's
+	// handle state, because the upload went to the old path.
+	fh.Lock()
+	if fh.BaseRev == 20 {
+		fh.Unlock()
+		t.Fatal("markHandleRemoteCommittedLocked ran on retargeted handle — committed old-path upload data to new path")
+	}
+	fh.Unlock()
+
+	// Verify the old path got cached with the upload data.
+	cached, ok := fs.readCache.Get(oldPath, 20)
+	if !ok {
+		t.Fatal("readCache miss for old path after flush")
+	}
+	if !bytes.Equal(cached, []byte("data")) {
+		t.Fatalf("readCache for old path = %q, want %q", cached, "data")
+	}
+}
+
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14290,9 +14290,9 @@ func TestFlushHandle_Path2_SidecarCacheUsesSnapshotOnRetarget(t *testing.T) {
 
 // TestFlushHandle_Path2_ConcurrentWriteDoesNotCorruptOrigSize verifies that
 // when a concurrent Write() grows the file during the Path 2 unlock window,
-// markHandleRemoteCommittedLocked does NOT derive OrigSize from the live
-// dirty buffer. The uploaded snapshot was small, so OrigSize must reflect
-// the snapshot size, not the post-write buffer size. (B7 regression test)
+// OrigSize is set to the uploaded snapshot size, not the live dirty buffer
+// size. This ensures the next flush selects the correct upload path (direct
+// PUT vs patch) based on the actual committed base size. (B7 regression test)
 func TestFlushHandle_Path2_ConcurrentWriteDoesNotCorruptOrigSize(t *testing.T) {
 	uploadStarted := make(chan struct{})
 	uploadResume := make(chan struct{})
@@ -14395,10 +14395,124 @@ func TestFlushHandle_Path2_ConcurrentWriteDoesNotCorruptOrigSize(t *testing.T) {
 	if dirtySeq == 0 {
 		t.Fatal("DirtySeq = 0 after concurrent Write — dirty data lost")
 	}
-	// OrigSize must not equal the large dirty buffer size.
-	if origSize == dirtySize && dirtySize > int64(len(smallData)) {
-		t.Fatalf("OrigSize = %d equals dirty buffer size %d — markHandleRemoteCommittedLocked read live dirty state (B7 bug)",
-			origSize, dirtySize)
+	// OrigSize must equal the uploaded snapshot size (5 bytes), not the
+	// large dirty buffer size from the concurrent write.
+	snapshotSize := int64(len(smallData))
+	if origSize != snapshotSize {
+		t.Fatalf("OrigSize = %d, want %d (uploaded snapshot size); dirty buffer size = %d — B7: revision-only path must set OrigSize from snapshot",
+			origSize, snapshotSize, dirtySize)
+	}
+
+	_ = fhID
+}
+
+// TestFlushHandle_Path2_LargeBaseSmallSnapshotOrigSize verifies the
+// old-large-base → small snapshot → concurrent write scenario. OrigSize
+// must be set to the uploaded snapshot size (small), not the stale large
+// base size. Otherwise the next flush would incorrectly select patch path
+// against a small remote object. (B7 regression test, adversary scenario)
+func TestFlushHandle_Path2_LargeBaseSmallSnapshotOrigSize(t *testing.T) {
+	uploadStarted := make(chan struct{})
+	uploadResume := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			_, _ = io.ReadAll(r.Body)
+			close(uploadStarted)
+			<-uploadResume
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 20})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/large-base-test.txt", false, 100*1024, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	// Start with a large OrigSize (simulating a previously-large file that
+	// was truncated and rewritten to a small size before this flush).
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     "/large-base-test.txt",
+		Dirty:    NewWriteBuffer("/large-base-test.txt", maxPreloadSize, 0),
+		BaseRev:  5,
+		OrigSize: 100 * 1024, // old large base
+	}
+	// Write small data (simulating truncate + small rewrite).
+	smallData := []byte("tiny")
+	if _, err := fh.Dirty.Write(0, smallData); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	fhID := fs.fileHandles.Allocate(fh)
+
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload did not start")
+	}
+
+	// Concurrent Write during upload — grow file to 64KB.
+	largeData := make([]byte, 64*1024)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+	writeDone := make(chan gofuse.Status, 1)
+	go func() {
+		_, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+			Offset:   0,
+			Size:     uint32(len(largeData)),
+		}, largeData)
+		writeDone <- st
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(uploadResume)
+
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("flushHandle status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("flushHandle timed out")
+	}
+	select {
+	case st := <-writeDone:
+		if st != gofuse.OK {
+			t.Fatalf("Write status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write timed out")
+	}
+
+	fh.Lock()
+	origSize := fh.OrigSize
+	dirtySize := fh.Dirty.Size()
+	fh.Unlock()
+
+	// OrigSize must equal the uploaded snapshot size (4 bytes = "tiny"),
+	// NOT the old large base (100KB) and NOT the post-write dirty size (64KB).
+	snapshotSize := int64(len(smallData))
+	if origSize != snapshotSize {
+		t.Fatalf("OrigSize = %d, want %d (uploaded snapshot size); old base = %d, dirty = %d — B7: stale large OrigSize not corrected",
+			origSize, snapshotSize, 100*1024, dirtySize)
 	}
 
 	_ = fhID

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14871,6 +14871,183 @@ func TestFlushHandle_Path2_RetargetSkipsDirCacheForOldPath(t *testing.T) {
 	}
 }
 
+// TestFlushHandle_Path2_PatchPathNoFullBufferCopy verifies that the patch
+// path (existing large file with dirty parts) does NOT build a full-buffer
+// dataCopy. Before the B9 fix, dataCopy was unconditionally allocated for
+// all Path 2 flushes, causing 2x memory use for small edits to large files.
+// This test verifies the patch path works correctly without dataCopy by
+// confirming it uses PATCH (not PUT) and completes successfully.
+func TestFlushHandle_Path2_PatchPathNoFullBufferCopy(t *testing.T) {
+	var patchReceived atomic.Bool
+	var putReceived atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			patchReceived.Store(true)
+			_, _ = io.ReadAll(r.Body)
+			// Return a patch plan with no parts to upload (all clean).
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"upload_id":    "test-upload-b9",
+				"upload_parts": []interface{}{},
+				"copied_parts": []interface{}{},
+			})
+			return
+		}
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/complete") {
+			// Complete upload endpoint.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+			return
+		}
+		if r.Method == http.MethodPut {
+			putReceived.Store(true)
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 10})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	// Set inline threshold low so the file is treated as "large".
+	var threshold int64 = 100
+	fs.smallFileMax.Store(threshold)
+
+	path := "/b9-patch-no-full-copy.dat"
+	ino := fs.inodes.Lookup(path, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	// Create a handle with OrigSize above threshold (existing large file).
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    NewWriteBuffer(path, maxPreloadSize, 0),
+		BaseRev:  5,
+		OrigSize: 200, // above threshold → patch path
+	}
+
+	// Write some data to make it dirty.
+	data := make([]byte, 200)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	if _, err := fh.Dirty.Write(0, data); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	_ = fs.fileHandles.Allocate(fh)
+
+	fh.Lock()
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+
+	if st != gofuse.OK {
+		t.Fatalf("flushHandle status = %v, want OK", st)
+	}
+
+	// B9 assertion: The flush should have used PATCH (not PUT) for this
+	// existing large file, confirming the patch path was taken. The patch
+	// path uses partSnapshots (per-dirty-part copies) instead of a full
+	// dataCopy, avoiding 2x memory for large files with small edits.
+	if !patchReceived.Load() {
+		t.Fatal("expected PATCH request for existing large file above threshold — patch path not taken")
+	}
+	if putReceived.Load() {
+		t.Fatal("received PUT for existing large file — should use patch path, not direct PUT")
+	}
+}
+
+// TestFlushHandle_Path2_SyntheticRevRecordedBeforeUnlock verifies that when
+// a Path 2 flush succeeds without the server returning a committed revision
+// (e.g. PatchFile / WriteStreamConditional), the synthetic revision
+// (expectedRevision + 1) is recorded to committedRev BEFORE releasing
+// the per-path remote commit lock. Without this (B10), a same-path flush
+// could acquire the lock, snapshot a stale expectedRevision, and issue a
+// conditional upload that conflicts with the just-completed one.
+func TestFlushHandle_Path2_SyntheticRevRecordedBeforeUnlock(t *testing.T) {
+	uploadStarted := make(chan struct{})
+	uploadResume := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			_, _ = io.ReadAll(r.Body)
+			close(uploadStarted)
+			<-uploadResume
+			// Return OK WITHOUT a revision — simulates WriteStreamConditional.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	path := "/b10-synthetic-rev.txt"
+	ino := fs.inodes.Lookup(path, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    path,
+		Dirty:   NewWriteBuffer(path, maxPreloadSize, 0),
+		BaseRev: 5,
+	}
+	if _, err := fh.Dirty.Write(0, []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	_ = fs.fileHandles.Allocate(fh)
+
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload did not start")
+	}
+
+	close(uploadResume)
+
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("flushHandle status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("flushHandle timed out")
+	}
+
+	// B10 assertion: The synthetic revision (expectedRevision + 1 = 6)
+	// must be recorded in committedRev. Without the B10 fix, committedRev
+	// was only recorded for server-returned revisions (committedRev > 0),
+	// leaving a window where a same-path flush could snapshot stale state.
+	fs.committedMu.Lock()
+	recordedRev := fs.committedRev[path]
+	fs.committedMu.Unlock()
+
+	expectedSyntheticRev := int64(6) // BaseRev(5) + 1
+	if recordedRev != expectedSyntheticRev {
+		t.Fatalf("committedRev[%q] = %d, want %d — B10: synthetic revision must be recorded before releasing remote commit lock",
+			path, recordedRev, expectedSyntheticRev)
+	}
+}
+
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -13795,6 +13795,116 @@ func TestFlushHandle_SmallFile_SeedsReadCache(t *testing.T) {
 	}
 }
 
+// TestFlushHandle_Path2_SnapshotIsolation verifies that Path 2 of flushHandle
+// creates an immutable snapshot of dirty data before releasing fh.mu, so that
+// concurrent writes to the same handle during the HTTP upload do not pollute
+// the already-committed upload payload.
+//
+// Regression test for issue #579: without the snapshot+unlock fix, bytesView()
+// returned a mutable slice into WriteBuffer.smallFileData and the lock was
+// held for the entire HTTP round-trip, blocking FUSE Read() on the same handle.
+func TestFlushHandle_Path2_SnapshotIsolation(t *testing.T) {
+	original := []byte("ORIGINAL-PAYLOAD-BEFORE-FLUSH")
+
+	// uploadStarted signals the test goroutine that the HTTP handler has
+	// received the upload body — the lock has been released and a concurrent
+	// write can proceed.
+	uploadStarted := make(chan struct{})
+	// uploadResume lets the test control when the HTTP handler returns,
+	// keeping the upload in-flight while the concurrent write happens.
+	uploadResume := make(chan struct{})
+
+	var uploadedBody atomic.Value // stores []byte
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read PUT body: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			uploadedBody.Store(body)
+			close(uploadStarted)
+			<-uploadResume
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 10})
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/snapshot-test.txt", false, int64(len(original)), time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+	fs.inodes.UpdateSize(ino, int64(len(original)))
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    "/snapshot-test.txt",
+		Dirty:   NewWriteBuffer("/snapshot-test.txt", maxPreloadSize, 0),
+		BaseRev: 1,
+	}
+	if _, err := fh.Dirty.Write(0, original); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+
+	// Start flush in a goroutine — it will release fh.mu during upload.
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+
+	// Wait for the HTTP handler to receive the upload (lock released).
+	<-uploadStarted
+
+	// Mutate the WriteBuffer while upload is in-flight. If the fix is
+	// correct, the upload uses the pre-unlock snapshot and this write
+	// does not affect the committed data.
+	mutated := []byte("MUTATED-WHILE-UPLOAD-INFLIGHT!")
+	fh.Lock()
+	if _, err := fh.Dirty.Write(0, mutated); err != nil {
+		t.Fatal(err)
+	}
+	fh.Unlock()
+
+	// Let the upload complete.
+	close(uploadResume)
+
+	st := <-flushDone
+	if st != gofuse.OK {
+		t.Fatalf("flushHandle status = %v, want OK", st)
+	}
+
+	// Verify the uploaded body matches the ORIGINAL snapshot, not the
+	// mutated data written while the upload was in-flight.
+	got, ok := uploadedBody.Load().([]byte)
+	if !ok {
+		t.Fatal("no upload body recorded")
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("uploaded body = %q, want %q (concurrent write leaked into upload)", got, original)
+	}
+
+	// Verify read cache was seeded with the snapshot, not the mutated buffer.
+	cached, ok := fs.readCache.Get("/snapshot-test.txt", 10)
+	if !ok {
+		t.Fatal("readCache miss after flush")
+	}
+	if !bytes.Equal(cached, original) {
+		t.Fatalf("readCache content = %q, want %q", cached, original)
+	}
+}
+
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14518,6 +14518,147 @@ func TestFlushHandle_Path2_LargeBaseSmallSnapshotOrigSize(t *testing.T) {
 	_ = fhID
 }
 
+// TestFlushHandle_Path2_CleanSiblingOrigSizeFromSnapshot verifies that a
+// clean sibling handle refreshed by markHandleRevisionOnlyLocked gets
+// OrigSize from the uploaded snapshot size, not from the post-concurrent-write
+// inode size. Without this fix, committedHandleSizeLocked would read the
+// inode entry (already updated by the concurrent Write) and rebind the
+// sibling with the wrong OrigSize. (B7 sibling regression test)
+func TestFlushHandle_Path2_CleanSiblingOrigSizeFromSnapshot(t *testing.T) {
+	uploadStarted := make(chan struct{})
+	uploadResume := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			_, _ = io.ReadAll(r.Body)
+			close(uploadStarted)
+			<-uploadResume
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 30})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/sibling-test.txt", false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+
+	// Primary handle: small file (5 bytes), dirty.
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    "/sibling-test.txt",
+		Dirty:   NewWriteBuffer("/sibling-test.txt", maxPreloadSize, 0),
+		BaseRev: 1,
+	}
+	smallData := []byte("hello")
+	if _, err := fh.Dirty.Write(0, smallData); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	fhID := fs.fileHandles.Allocate(fh)
+
+	// Clean sibling handle: same path, no dirty parts, DirtySeq == 0.
+	sibling := &FileHandle{
+		Ino:      ino,
+		Path:     "/sibling-test.txt",
+		Dirty:    NewWriteBuffer("/sibling-test.txt", maxPreloadSize, 0),
+		BaseRev:  1,
+		OrigSize: 5,
+	}
+	// Set totalSize/remoteSize to match a clean read buffer.
+	sibling.Dirty.totalSize = 5
+	sibling.Dirty.remoteSize = 5
+	siblingID := fs.fileHandles.Allocate(sibling)
+	// Register both handles so refreshCommittedRevisionForOpenHandlesWithSize finds the sibling.
+	if fs.openHandles == nil {
+		fs.openHandles = NewOpenHandleIndex()
+	}
+	fs.openHandles.Add(fh)
+	fs.openHandles.Add(sibling)
+
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload did not start")
+	}
+
+	// Concurrent Write on the primary handle during upload.
+	largeData := make([]byte, 64*1024)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+	writeDone := make(chan gofuse.Status, 1)
+	go func() {
+		_, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+			Offset:   0,
+			Size:     uint32(len(largeData)),
+		}, largeData)
+		writeDone <- st
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(uploadResume)
+
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("flushHandle status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("flushHandle timed out")
+	}
+	select {
+	case st := <-writeDone:
+		if st != gofuse.OK {
+			t.Fatalf("Write status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write timed out")
+	}
+
+	snapshotSize := int64(len(smallData))
+
+	// Primary handle: OrigSize must equal snapshot size.
+	fh.Lock()
+	primaryOrigSize := fh.OrigSize
+	fh.Unlock()
+	if primaryOrigSize != snapshotSize {
+		t.Fatalf("primary OrigSize = %d, want %d", primaryOrigSize, snapshotSize)
+	}
+
+	// Sibling handle: OrigSize must also equal snapshot size, NOT the
+	// post-concurrent-write dirty size (64KB).
+	sibling.Lock()
+	siblingOrigSize := sibling.OrigSize
+	siblingBaseRev := sibling.BaseRev
+	sibling.Unlock()
+	if siblingBaseRev != 30 {
+		t.Fatalf("sibling BaseRev = %d, want 30", siblingBaseRev)
+	}
+	if siblingOrigSize != snapshotSize {
+		t.Fatalf("sibling OrigSize = %d, want %d (snapshot size) — clean sibling rebound from post-write inode size",
+			siblingOrigSize, snapshotSize)
+	}
+
+	_ = fhID
+	_ = siblingID
+}
+
 // TestFlushHandle_Path2_RetargetSkipsDirCacheForOldPath verifies that when
 // a handle is retargeted by rename during the Path 2 unlock window,
 // cacheFileForPath is NOT called for the old handlePath. Otherwise it

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14406,6 +14406,131 @@ func TestFlushHandle_Path2_ConcurrentWriteDoesNotCorruptOrigSize(t *testing.T) {
 	_ = fhID
 }
 
+// TestFlushHandle_Path2_NoCommittedRevConcurrentWriteOrigSize verifies
+// that when a Path 2 flush succeeds without the server returning a
+// committed revision (e.g. PatchFile / WriteStreamConditional), and a
+// concurrent Write() grows the file during the unlock window, OrigSize
+// is set to the uploaded snapshot size (not the live dirty buffer size).
+// This is the N1 regression test: without the DirtySeq guard in the
+// non-committedRev finalization paths, finalizeHandleFlushLocked would
+// derive a synthetic revision from expectedRevision and read
+// fh.Dirty.Size() for OrigSize, associating the wrong size.
+func TestFlushHandle_Path2_NoCommittedRevConcurrentWriteOrigSize(t *testing.T) {
+	uploadStarted := make(chan struct{})
+	uploadResume := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			_, _ = io.ReadAll(r.Body)
+			close(uploadStarted)
+			<-uploadResume
+			// Server returns OK but WITHOUT a revision field —
+			// simulates PatchFile/WriteStreamConditional behavior.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/n1-origsize-test.txt", false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+
+	// Start with a small file (5 bytes).
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    "/n1-origsize-test.txt",
+		Dirty:   NewWriteBuffer("/n1-origsize-test.txt", maxPreloadSize, 0),
+		BaseRev: 1,
+	}
+	smallData := []byte("hello")
+	if _, err := fh.Dirty.Write(0, smallData); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	fhID := fs.fileHandles.Allocate(fh)
+
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload did not start")
+	}
+
+	// Concurrent Write during upload — grow file significantly.
+	largeData := make([]byte, 64*1024)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+	writeDone := make(chan gofuse.Status, 1)
+	go func() {
+		_, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+			Offset:   0,
+			Size:     uint32(len(largeData)),
+		}, largeData)
+		writeDone <- st
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(uploadResume)
+
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("flushHandle status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("flushHandle timed out")
+	}
+	select {
+	case st := <-writeDone:
+		if st != gofuse.OK {
+			t.Fatalf("Write status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write timed out")
+	}
+
+	// N1 assertion: OrigSize must NOT be the large post-write size.
+	// The uploaded snapshot was 5 bytes; the server did NOT return a
+	// revision, so the finalization uses a synthetic revision. OrigSize
+	// should reflect the snapshot, not the concurrent write.
+	fh.Lock()
+	origSize := fh.OrigSize
+	dirtySize := fh.Dirty.Size()
+	dirtySeq := fh.DirtySeq
+	fh.Unlock()
+
+	// Dirty must still be pending (DirtySeq != 0) because concurrent write
+	// changed it during upload.
+	if dirtySeq == 0 {
+		t.Fatal("DirtySeq = 0 after concurrent Write — dirty data lost")
+	}
+	// OrigSize must equal the uploaded snapshot size (5 bytes), not the
+	// large dirty buffer size from the concurrent write.
+	snapshotSize := int64(len(smallData))
+	if origSize != snapshotSize {
+		t.Fatalf("OrigSize = %d, want %d (uploaded snapshot size); dirty buffer size = %d — N1: non-committedRev path must set OrigSize from snapshot",
+			origSize, snapshotSize, dirtySize)
+	}
+
+	_ = fhID
+}
+
 // TestFlushHandle_Path2_LargeBaseSmallSnapshotOrigSize verifies the
 // old-large-base → small snapshot → concurrent write scenario. OrigSize
 // must be set to the uploaded snapshot size (small), not the stale large

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14288,6 +14288,209 @@ func TestFlushHandle_Path2_SidecarCacheUsesSnapshotOnRetarget(t *testing.T) {
 	}
 }
 
+// TestFlushHandle_Path2_ConcurrentWriteDoesNotCorruptOrigSize verifies that
+// when a concurrent Write() grows the file during the Path 2 unlock window,
+// markHandleRemoteCommittedLocked does NOT derive OrigSize from the live
+// dirty buffer. The uploaded snapshot was small, so OrigSize must reflect
+// the snapshot size, not the post-write buffer size. (B7 regression test)
+func TestFlushHandle_Path2_ConcurrentWriteDoesNotCorruptOrigSize(t *testing.T) {
+	uploadStarted := make(chan struct{})
+	uploadResume := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			_, _ = io.ReadAll(r.Body)
+			close(uploadStarted)
+			<-uploadResume
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 10})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/origsize-test.txt", false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+
+	// Start with a small file (5 bytes).
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    "/origsize-test.txt",
+		Dirty:   NewWriteBuffer("/origsize-test.txt", maxPreloadSize, 0),
+		BaseRev: 1,
+	}
+	smallData := []byte("hello")
+	if _, err := fh.Dirty.Write(0, smallData); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	fhID := fs.fileHandles.Allocate(fh)
+
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload did not start")
+	}
+
+	// Concurrent Write during upload — grow file significantly.
+	largeData := make([]byte, 64*1024)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+	writeDone := make(chan gofuse.Status, 1)
+	go func() {
+		_, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+			Offset:   0,
+			Size:     uint32(len(largeData)),
+		}, largeData)
+		writeDone <- st
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(uploadResume)
+
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("flushHandle status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("flushHandle timed out")
+	}
+	select {
+	case st := <-writeDone:
+		if st != gofuse.OK {
+			t.Fatalf("Write status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write timed out")
+	}
+
+	// B7 assertion: OrigSize must NOT be the large post-write size.
+	// The uploaded snapshot was 5 bytes, so the committed revision's
+	// OrigSize should reflect the snapshot, not the concurrent write.
+	fh.Lock()
+	origSize := fh.OrigSize
+	dirtySize := fh.Dirty.Size()
+	dirtySeq := fh.DirtySeq
+	fh.Unlock()
+
+	// Dirty must still be pending (DirtySeq != 0) because concurrent write
+	// changed it during upload.
+	if dirtySeq == 0 {
+		t.Fatal("DirtySeq = 0 after concurrent Write — dirty data lost")
+	}
+	// OrigSize must not equal the large dirty buffer size.
+	if origSize == dirtySize && dirtySize > int64(len(smallData)) {
+		t.Fatalf("OrigSize = %d equals dirty buffer size %d — markHandleRemoteCommittedLocked read live dirty state (B7 bug)",
+			origSize, dirtySize)
+	}
+
+	_ = fhID
+}
+
+// TestFlushHandle_Path2_RetargetSkipsDirCacheForOldPath verifies that when
+// a handle is retargeted by rename during the Path 2 unlock window,
+// cacheFileForPath is NOT called for the old handlePath. Otherwise it
+// would re-add the pre-rename path to the directory cache after
+// finishLocalRename already removed it. (B8 regression test)
+func TestFlushHandle_Path2_RetargetSkipsDirCacheForOldPath(t *testing.T) {
+	uploadStarted := make(chan struct{})
+	uploadResume := make(chan struct{})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			_, _ = io.ReadAll(r.Body)
+			close(uploadStarted)
+			<-uploadResume
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "revision": 20})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	oldPath := "/rename-dircache-old.txt"
+	newPath := "/rename-dircache-new.txt"
+	ino := fs.inodes.Lookup(oldPath, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 3)
+
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    oldPath,
+		Dirty:   NewWriteBuffer(oldPath, maxPreloadSize, 0),
+		BaseRev: 3,
+	}
+	if _, err := fh.Dirty.Write(0, []byte("data1")); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	_ = fs.fileHandles.Allocate(fh)
+
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload did not start")
+	}
+
+	// Retarget handle during upload (simulates rename).
+	fh.Lock()
+	fh.Path = newPath
+	fh.Unlock()
+
+	// Negative-cache the old path (simulates finishLocalRename).
+	fs.cacheNegativePath(oldPath)
+
+	close(uploadResume)
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("flushHandle status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("flushHandle timed out")
+	}
+
+	// B8 assertion: the old path must NOT have been re-added to dir cache
+	// as a positive entry. After rename, finishLocalRename negatively cached
+	// oldPath. If cacheFileForPath ran for the retargeted handle, it would
+	// resurrect oldPath with a positive entry (size/revision from upload).
+	parentPath, name := cacheParentName(oldPath)
+	result := fs.dirCache.Lookup(parentPath, name)
+	if result.kind == namespaceLookupPositive {
+		t.Fatalf("dir cache has positive entry for old path %q after retarget — B8 bug: cacheFileForPath should be skipped for retargeted handles (size=%d)",
+			oldPath, result.item.Size)
+	}
+}
+
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -13940,10 +13940,12 @@ func TestFlushHandle_Path2_SnapshotIsolation(t *testing.T) {
 // fix, flushHandle held remoteCommitLock while waiting to reacquire fh.mu,
 // while Write() held fh.mu waiting for remoteCommitLock → deadlock.
 //
-// After the fix, flush releases fh.mu FIRST (unblocking Read), then acquires
-// remoteCommitLock for the upload. Write() can acquire fh.mu immediately but
-// may wait on remoteCommitLock until the upload finishes — that's correct
-// serialization, not a deadlock. This test verifies:
+// After the fix, flush releases fh.mu before uploading (unblocking Read)
+// while keeping remoteCommitLock held for same-path serialization. After the
+// upload, remoteCommitLock is released BEFORE re-acquiring fh.mu — so flush
+// never holds remoteCommitLock while waiting for fh.mu. Concurrent Write()
+// acquires fh.mu then blocks on remoteCommitLock until upload finishes —
+// linear wait, no deadlock. This test verifies:
 // 1. fh.mu is released during upload (Read can proceed)
 // 2. After upload completes, Write() succeeds (no circular wait)
 // 3. The write's dirty state is preserved for the next flush
@@ -14127,6 +14129,16 @@ func TestFlushHandle_Path2_RenameRetargetDuringUpload(t *testing.T) {
 		fh.Unlock()
 		t.Fatal("markHandleRemoteCommittedLocked ran on retargeted handle — committed old-path upload data to new path")
 	}
+	// Verify the handle was actually retargeted to the new path.
+	if fh.Path != newPath {
+		fh.Unlock()
+		t.Fatalf("fh.Path = %q after retarget, want %q", fh.Path, newPath)
+	}
+	// B4 dirty-preservation: if the DirtySeq was cleared but the handle
+	// was retargeted, subsequent writes to the new path still need a flush.
+	// Write new data to the handle and verify it becomes dirty — proving
+	// the retarget did not corrupt the write buffer or lose dirty tracking.
+	dirtyBuf := fh.Dirty
 	fh.Unlock()
 
 	// Verify the old path got cached with the upload data.
@@ -14137,6 +14149,24 @@ func TestFlushHandle_Path2_RenameRetargetDuringUpload(t *testing.T) {
 	if !bytes.Equal(cached, []byte("data")) {
 		t.Fatalf("readCache for old path = %q, want %q", cached, "data")
 	}
+
+	// The new path should NOT have cached data from the old-path upload.
+	if _, ok := fs.readCache.Get(newPath, 20); ok {
+		t.Fatal("readCache hit for new path — old-path upload data leaked to new path")
+	}
+
+	// Dirty-preservation gate: the write buffer must still be functional
+	// after retarget. Write new data to prove no corruption.
+	if _, err := dirtyBuf.Write(0, []byte("new-data")); err != nil {
+		t.Fatalf("Write to dirty buffer after retarget failed: %v", err)
+	}
+	fh.Lock()
+	fh.DirtySeq = fs.markDirtySize(ino, dirtyBuf.Size())
+	if fh.DirtySeq == 0 {
+		fh.Unlock()
+		t.Fatal("markDirtySize returned 0 after retarget — dirty tracking broken")
+	}
+	fh.Unlock()
 }
 
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14134,11 +14134,19 @@ func TestFlushHandle_Path2_RenameRetargetDuringUpload(t *testing.T) {
 		fh.Unlock()
 		t.Fatalf("fh.Path = %q after retarget, want %q", fh.Path, newPath)
 	}
-	// B4 dirty-preservation: if the DirtySeq was cleared but the handle
-	// was retargeted, subsequent writes to the new path still need a flush.
-	// Write new data to the handle and verify it becomes dirty — proving
-	// the retarget did not corrupt the write buffer or lose dirty tracking.
-	dirtyBuf := fh.Dirty
+	// B4 dirty-preservation: the upload went to old path, but the handle
+	// is now retargeted to new path. The dirty data in the buffer belongs
+	// to the new path and must NOT have been cleared by the old-path
+	// upload's success. DirtySeq must still be non-zero so the next flush
+	// picks up this data for the new path.
+	if fh.DirtySeq == 0 {
+		fh.Unlock()
+		t.Fatal("DirtySeq cleared after retargeted upload — new path data is no longer scheduled for flush")
+	}
+	if fh.Dirty.Size() == 0 {
+		fh.Unlock()
+		t.Fatal("Dirty buffer cleared after retargeted upload — new path data lost")
+	}
 	fh.Unlock()
 
 	// Verify the old path got cached with the upload data.
@@ -14154,19 +14162,6 @@ func TestFlushHandle_Path2_RenameRetargetDuringUpload(t *testing.T) {
 	if _, ok := fs.readCache.Get(newPath, 20); ok {
 		t.Fatal("readCache hit for new path — old-path upload data leaked to new path")
 	}
-
-	// Dirty-preservation gate: the write buffer must still be functional
-	// after retarget. Write new data to prove no corruption.
-	if _, err := dirtyBuf.Write(0, []byte("new-data")); err != nil {
-		t.Fatalf("Write to dirty buffer after retarget failed: %v", err)
-	}
-	fh.Lock()
-	fh.DirtySeq = fs.markDirtySize(ino, dirtyBuf.Size())
-	if fh.DirtySeq == 0 {
-		fh.Unlock()
-		t.Fatal("markDirtySize returned 0 after retarget — dirty tracking broken")
-	}
-	fh.Unlock()
 }
 
 func TestFinalizeHandleFlushLocked_ResetsStreamerToCommittedRevision(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #579 — FUSE read hang during SQLite WAL workload (speedtest1 --size 20).

**Root cause**: Path 2 of `flushHandle` (small files and non-streaming uploads) held `fh.Lock()` for the entire HTTP upload duration. With `FOPEN_DIRECT_IO` (used for SQLite `.db`/`-wal`/`-journal` files), every `pread()` becomes a FUSE round-trip that needs `fh.Lock()`, so a slow upload blocks all concurrent reads on the same handle — causing kernel read timeouts and hangs.

**Fix**:
- Snapshot dirty buffer into immutable copy before releasing lock (`bytesView()` returns mutable slice into `WriteBuffer.smallFileData`)
- Release `fh.mu` before all 4 network call paths in Path 2 (`CreateFileCtx`, `WriteCtxConditionalWithRevision`, `PatchFile`, `WriteStreamConditional`)
- Re-acquire `fh.mu` after network call completes
- Use snapshot (not live buffer) for read cache seeding post-upload
- Capture handle fields (`Path`, `IsNew`, `Ino`, etc.) before unlock to avoid reading potentially-stale state
- Add debug logging for Path 2 unlock/relock timing

This matches the existing pattern in Path 1a (`FinishStreaming`) and Path 1b (`UploadAll`) which already release `fh.mu` before network calls.

## Scope (agreed with adversaries)
First PR — Path 2 only:
1. Path 2 immutable snapshot before unlock
2. Concurrent write regression test
3. Flush debug logging enhancement

EAGAIN timeout mapping (P2) deferred to a follow-up PR after goroutine/pprof proof.

## Test plan
- [x] `go build ./pkg/fuse/` — compiles clean
- [x] `go vet ./pkg/fuse/` — no warnings
- [x] New `TestFlushHandle_Path2_SnapshotIsolation` — proves concurrent writes during in-flight upload do not pollute the committed snapshot
- [x] All existing flush tests pass (TestFlush*, TestCreateWriteFlush*)
- [ ] CI green
- [ ] Adversary review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent flush/upload to use an immutable data snapshot, preventing in-flight payload corruption.
  * Prevented double-unlocking and deadlocks when multiple operations contend on handle and remote commit coordination.
  * Fixed revision and size bookkeeping for path2, including correct `OrigSize`/inode size from the uploaded snapshot and correct behavior when open handles are retargeted during upload, with cache/sidecar invariants preserved.

* **Tests**
  * Added eight new regression tests covering snapshot isolation, deadlock prevention, rename retargeting, sidecar cache snapshotting, and `OrigSize`/directory-cache correctness in concurrent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->