### PR TITLE
fix: capture tccli stderr for TCR token diagnosis

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -192,16 +192,12 @@ jobs:
           TCR_IMAGE="drive9.tencentcloudcr.com/drive9/dat9-server:$TAG"
           docker tag "$IMAGE" "$TCR_IMAGE"
            TCR_LOG=/tmp/tcr-token.log
-           TCR_ERR=/tmp/tcr-token.err
            tccli configure set secretId "$TENCENTCLOUD_SECRET_ID" secretKey "$TENCENTCLOUD_SECRET_KEY" region "$TENCENTCLOUD_REGION" token "$TENCENTCLOUD_SECURITY_TOKEN" 2>/dev/null || true
-           tccli tcr CreateInstanceToken --region ap-beijing --RegistryId tcr-jkzfg64e --TokenType longterm >"$TCR_LOG" 2>"$TCR_ERR"
-           TCR_USER=$(python3 -c "import sys,json; d=json.load(sys.stdin); r=d.get('Response',d); print(r.get('Username','100049824031'))" < "$TCR_LOG" 2>/dev/null) || true
-           TCR_TOKEN=$(python3 -c "import sys,json; d=json.load(sys.stdin); r=d.get('Response',d); print(r['Token'])" < "$TCR_LOG" 2>/dev/null) || true
+           tccli tcr CreateInstanceToken --region ap-beijing --RegistryId tcr-jkzfg64e --TokenType longterm >"$TCR_LOG"
+           TCR_USER=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('Username','100049824031'))" < "$TCR_LOG" 2>/dev/null) || true
+           TCR_TOKEN=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Token'])" < "$TCR_LOG" 2>/dev/null) || true
            if [ -z "$TCR_TOKEN" ]; then
-             echo "create TCR token failed; stderr:" >&2
-             cat "$TCR_ERR" >&2
-             echo "stdout:" >&2
-             cat "$TCR_LOG" >&2
+             echo "create TCR token failed" >&2
              exit 1
            fi
           echo "::add-mask::$TCR_TOKEN"
@@ -214,7 +210,7 @@ jobs:
         if: inputs.region == 'all' || inputs.region == 'tencentcloud-ap-beijing'
         run: |
           mkdir -p ~/.kube
-          tccli tke DescribeClusterKubeconfig --ClusterId cls-6dpiw235 --IsExtranet true --region ap-beijing | python3 -c "import sys,json; d=json.load(sys.stdin); r=d.get('Response',d); print(r['Kubeconfig'])" > ~/.kube/tencent-config
+          tccli tke DescribeClusterKubeconfig --ClusterId cls-6dpiw235 --IsExtranet true --region ap-beijing | python3 -c "import sys,json; print(json.load(sys.stdin)['Kubeconfig'])" > ~/.kube/tencent-config
           kubectl --kubeconfig ~/.kube/tencent-config -n drive9-tidbcloud \
             set image deployment/drive9-server \
             drive9-server=$TCR_IMAGE

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -195,8 +195,8 @@ jobs:
            TCR_ERR=/tmp/tcr-token.err
            tccli configure set secretId "$TENCENTCLOUD_SECRET_ID" secretKey "$TENCENTCLOUD_SECRET_KEY" region "$TENCENTCLOUD_REGION" token "$TENCENTCLOUD_SECURITY_TOKEN" 2>/dev/null || true
            tccli tcr CreateInstanceToken --region ap-beijing --RegistryId tcr-jkzfg64e --TokenType longterm >"$TCR_LOG" 2>"$TCR_ERR"
-           TCR_USER=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Response'].get('Username','100049824031'))" < "$TCR_LOG" 2>/dev/null) || true
-           TCR_TOKEN=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Response']['Token'])" < "$TCR_LOG" 2>/dev/null) || true
+           TCR_USER=$(python3 -c "import sys,json; d=json.load(sys.stdin); r=d.get('Response',d); print(r.get('Username','100049824031'))" < "$TCR_LOG" 2>/dev/null) || true
+           TCR_TOKEN=$(python3 -c "import sys,json; d=json.load(sys.stdin); r=d.get('Response',d); print(r['Token'])" < "$TCR_LOG" 2>/dev/null) || true
            if [ -z "$TCR_TOKEN" ]; then
              echo "create TCR token failed; stderr:" >&2
              cat "$TCR_ERR" >&2
@@ -214,7 +214,7 @@ jobs:
         if: inputs.region == 'all' || inputs.region == 'tencentcloud-ap-beijing'
         run: |
           mkdir -p ~/.kube
-          tccli tke DescribeClusterKubeconfig --ClusterId cls-6dpiw235 --IsExtranet true --region ap-beijing | python3 -c "import sys,json; print(json.load(sys.stdin)['Response']['Kubeconfig'])" > ~/.kube/tencent-config
+          tccli tke DescribeClusterKubeconfig --ClusterId cls-6dpiw235 --IsExtranet true --region ap-beijing | python3 -c "import sys,json; d=json.load(sys.stdin); r=d.get('Response',d); print(r['Kubeconfig'])" > ~/.kube/tencent-config
           kubectl --kubeconfig ~/.kube/tencent-config -n drive9-tidbcloud \
             set image deployment/drive9-server \
             drive9-server=$TCR_IMAGE

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -193,6 +193,7 @@ jobs:
           docker tag "$IMAGE" "$TCR_IMAGE"
            TCR_LOG=/tmp/tcr-token.log
            TCR_ERR=/tmp/tcr-token.err
+           tccli configure set secretId "$TENCENTCLOUD_SECRET_ID" secretKey "$TENCENTCLOUD_SECRET_KEY" region "$TENCENTCLOUD_REGION" token "$TENCENTCLOUD_SECURITY_TOKEN" 2>/dev/null || true
            tccli tcr CreateInstanceToken --region ap-beijing --RegistryId tcr-jkzfg64e --TokenType longterm >"$TCR_LOG" 2>"$TCR_ERR"
            TCR_USER=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Response'].get('Username','100049824031'))" < "$TCR_LOG" 2>/dev/null) || true
            TCR_TOKEN=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Response']['Token'])" < "$TCR_LOG" 2>/dev/null) || true

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -192,7 +192,7 @@ jobs:
           TCR_IMAGE="drive9.tencentcloudcr.com/drive9/dat9-server:$TAG"
           docker tag "$IMAGE" "$TCR_IMAGE"
            TCR_LOG=/tmp/tcr-token.log
-           tccli configure set secretId "$TENCENTCLOUD_SECRET_ID" secretKey "$TENCENTCLOUD_SECRET_KEY" region "$TENCENTCLOUD_REGION" token "$TENCENTCLOUD_SECURITY_TOKEN" 2>/dev/null || true
+           tccli configure set secretId "$TENCENTCLOUD_SECRET_ID" secretKey "$TENCENTCLOUD_SECRET_KEY" region "$TENCENTCLOUD_REGION" 2>/dev/null || true
            tccli tcr CreateInstanceToken --region ap-beijing --RegistryId tcr-jkzfg64e --TokenType longterm >"$TCR_LOG"
            TCR_USER=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('Username','100049824031'))" < "$TCR_LOG" 2>/dev/null) || true
            TCR_TOKEN=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Token'])" < "$TCR_LOG" 2>/dev/null) || true
@@ -200,7 +200,8 @@ jobs:
              echo "create TCR token failed" >&2
              exit 1
            fi
-          echo "::add-mask::$TCR_TOKEN"
+           rm -f "$TCR_LOG"
+           echo "::add-mask::$TCR_TOKEN"
           echo "$TCR_TOKEN" | docker login drive9.tencentcloudcr.com --username "$TCR_USER" --password-stdin
           docker push "$TCR_IMAGE"
           echo "TCR_IMAGE=$TCR_IMAGE" >> "$GITHUB_ENV"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -191,15 +191,18 @@ jobs:
           TAG=$(echo "$IMAGE" | awk -F: '{print $NF}')
           TCR_IMAGE="drive9.tencentcloudcr.com/drive9/dat9-server:$TAG"
           docker tag "$IMAGE" "$TCR_IMAGE"
-          TCR_LOG=/tmp/tcr-token.log
-          tccli tcr CreateInstanceToken --region ap-beijing --RegistryId tcr-jkzfg64e --TokenType longterm >"$TCR_LOG"
-          TCR_USER=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Response'].get('Username','100049824031'))" < "$TCR_LOG" 2>/dev/null) || true
-          TCR_TOKEN=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Response']['Token'])" < "$TCR_LOG" 2>/dev/null) || true
-          if [ -z "$TCR_TOKEN" ]; then
-            echo "create TCR token failed" >&2
-            python3 -c "import sys,json; d=json.load(sys.stdin); print('RequestId:', d.get('Response',{}).get('RequestId','N/A'))" < "$TCR_LOG" 2>/dev/null >&2 || true
-            exit 1
-          fi
+           TCR_LOG=/tmp/tcr-token.log
+           TCR_ERR=/tmp/tcr-token.err
+           tccli tcr CreateInstanceToken --region ap-beijing --RegistryId tcr-jkzfg64e --TokenType longterm >"$TCR_LOG" 2>"$TCR_ERR"
+           TCR_USER=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Response'].get('Username','100049824031'))" < "$TCR_LOG" 2>/dev/null) || true
+           TCR_TOKEN=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Response']['Token'])" < "$TCR_LOG" 2>/dev/null) || true
+           if [ -z "$TCR_TOKEN" ]; then
+             echo "create TCR token failed; stderr:" >&2
+             cat "$TCR_ERR" >&2
+             echo "stdout:" >&2
+             cat "$TCR_LOG" >&2
+             exit 1
+           fi
           echo "::add-mask::$TCR_TOKEN"
           echo "$TCR_TOKEN" | docker login drive9.tencentcloudcr.com --username "$TCR_USER" --password-stdin
           docker push "$TCR_IMAGE"


### PR DESCRIPTION
The TCR token creation step in the Tencent Cloud CD pipeline is failing silently. This PR captures tccli stderr separately so the actual error message is visible in CI logs.