### PR TITLE
fix: update drain imports to drive9 module path

### DIFF
--- a/cmd/drive9/cli/mount_drain.go
+++ b/cmd/drive9/cli/mount_drain.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mem9-ai/dat9/pkg/mountcontrol"
-	"github.com/mem9-ai/dat9/pkg/mountstate"
+	"github.com/mem9-ai/drive9/pkg/mountcontrol"
+	"github.com/mem9-ai/drive9/pkg/mountstate"
 )
 
 type mountDrainDeps struct {

--- a/cmd/drive9/cli/mount_drain_test.go
+++ b/cmd/drive9/cli/mount_drain_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mem9-ai/dat9/pkg/mountcontrol"
-	"github.com/mem9-ai/dat9/pkg/mountstate"
+	"github.com/mem9-ai/drive9/pkg/mountcontrol"
+	"github.com/mem9-ai/drive9/pkg/mountstate"
 )
 
 func TestRunMountDrainJSON(t *testing.T) {

--- a/pkg/fuse/drain.go
+++ b/pkg/fuse/drain.go
@@ -10,7 +10,7 @@ import (
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
 
-	"github.com/mem9-ai/dat9/pkg/mountcontrol"
+	"github.com/mem9-ai/drive9/pkg/mountcontrol"
 )
 
 type drainError struct {

--- a/pkg/fuse/drain_test.go
+++ b/pkg/fuse/drain_test.go
@@ -7,7 +7,7 @@ import (
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
 
-	"github.com/mem9-ai/dat9/pkg/mountcontrol"
+	"github.com/mem9-ai/drive9/pkg/mountcontrol"
 )
 
 func newTestDrainFS() *Dat9FS {

--- a/pkg/fuse/mount_control_unix.go
+++ b/pkg/fuse/mount_control_unix.go
@@ -15,9 +15,9 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/mem9-ai/dat9/pkg/logger"
-	"github.com/mem9-ai/dat9/pkg/mountcontrol"
-	"github.com/mem9-ai/dat9/pkg/mountstate"
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/mountcontrol"
+	"github.com/mem9-ai/drive9/pkg/mountstate"
 )
 
 type mountControlServer struct {


### PR DESCRIPTION
## Summary
- Replace stale `github.com/mem9-ai/dat9` imports in the new drain/control files with the current `github.com/mem9-ai/drive9` module path.
- Restore `cmd/drive9` / FUSE package buildability on `main` after the module rename.

## Test Plan
- `go test ./cmd/drive9 ./pkg/fuse ./pkg/mountcontrol ./pkg/mountstate -run 'TestRunMountDrain|TestDrain|TestSyncFs|TestMountState|^$' -count=1`
- `make build-cli`

## Context
While validating the newly merged live mount drain / syncfs functionality from `main`, `make build-cli` failed because the drain files still imported the old `github.com/mem9-ai/dat9` module path. This PR only updates those imports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package dependencies across mount control and FUSE modules. No changes to functionality, behavior, or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->