### PR TITLE
perf: eliminate readdir BatchStat N+1 and raise dir cache limit

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -1216,6 +1216,9 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 			info.Size = e.File.SizeBytes
 			info.ModTime = fileMtime(e.File)
 			meta["resource_id"] = e.File.FileID
+			if e.File.Revision > 0 {
+				meta["revision"] = strconv.FormatInt(e.File.Revision, 10)
+			}
 			count := refCounts[e.File.FileID]
 			if count <= 0 {
 				count = 1

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -188,7 +188,8 @@ type FileInfo struct {
 	Name       string `json:"name"`
 	Size       int64  `json:"size"`
 	IsDir      bool   `json:"isDir"`
-	Mtime      int64  `json:"mtime,omitempty"` // Unix seconds, 0 means unknown
+	Mtime      int64  `json:"mtime,omitempty"`      // Unix seconds, 0 means unknown
+	Revision   int64  `json:"revision,omitempty"`    // file revision from server; 0 means unknown (old server)
 	Mode       uint32 `json:"mode,omitempty"`
 	HasMode    bool   `json:"hasMode"`
 	ResourceID string `json:"resource_id,omitempty"`

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -100,6 +100,12 @@ func TestListDir(t *testing.T) {
 	if len(entries) != 2 {
 		t.Fatalf("expected 2, got %d", len(entries))
 	}
+	// Server now returns revision in list response; verify it is populated.
+	for _, e := range entries {
+		if e.Revision <= 0 {
+			t.Fatalf("list entry %q: revision = %d, want > 0", e.Name, e.Revision)
+		}
+	}
 }
 
 func TestBatchStatCtxPreservesPerPathErrors(t *testing.T) {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -242,7 +242,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		committedRev:      make(map[string]int64),
 		remoteCommitLocks: make(map[string]*sync.Mutex),
 		readCache:         NewReadCacheWithMaxFileSize(opts.CacheSize, opts.ReadCacheTTL, opts.ReadCacheMaxFileBytes),
-		dirCache:          NewNamespaceCache(opts.DirTTL, opts.NegativeEntryTTL, defaultNamespaceCacheMaxEntries),
+		dirCache:          NewNamespaceCache(opts.DirTTL, opts.NegativeEntryTTL, dirCacheMaxEntriesOrDefault(opts.DirCacheMaxEntries)),
 		readSlots:         make(chan struct{}, readConcurrencyOrDefault(opts.ReadConcurrency)),
 		dirtyInodes:       make(map[uint64]dirtyInodeState),
 		specialByPath:     make(map[string]uint64),
@@ -332,6 +332,13 @@ const (
 func readConcurrencyOrDefault(n int) int {
 	if n <= 0 {
 		return defaultRemoteReadConcurrency
+	}
+	return n
+}
+
+func dirCacheMaxEntriesOrDefault(n int) int {
+	if n <= 0 {
+		return defaultNamespaceCacheMaxEntries
 	}
 	return n
 }
@@ -4455,6 +4462,7 @@ func cachedFileInfos(items []client.FileInfo) []CachedFileInfo {
 			Size:       item.Size,
 			IsDir:      item.IsDir,
 			Mtime:      mtime,
+			Revision:   item.Revision,
 			Mode:       item.Mode,
 			HasMode:    item.HasMode,
 			ResourceID: item.ResourceID,
@@ -8168,25 +8176,42 @@ func (fs *Dat9FS) applyBatchStats(ctx context.Context, dirPath string, items []C
 	if len(items) == 0 {
 		return
 	}
-	for start := 0; start < len(items); start += client.MaxBatchStatPaths {
-		end := start + client.MaxBatchStatPaths
-		if end > len(items) {
-			end = len(items)
+
+	// Collect indices of items that need a BatchStat (revision unknown).
+	// When the server list response includes revision (revision > 0), the
+	// item already has full metadata and no per-file stat is needed.
+	// This is backward-compatible: old servers that omit revision leave it
+	// at 0, so those entries still go through BatchStat.
+	var needStat []int
+	for i := range items {
+		if items[i].Revision <= 0 && !items[i].IsDir {
+			needStat = append(needStat, i)
 		}
-		paths := make([]string, end-start)
-		for i := start; i < end; i++ {
-			paths[i-start] = fs.remotePath(dirEntryChildPath(dirPath, items[i].Name))
+	}
+	if len(needStat) == 0 {
+		return
+	}
+
+	for batchStart := 0; batchStart < len(needStat); batchStart += client.MaxBatchStatPaths {
+		batchEnd := batchStart + client.MaxBatchStatPaths
+		if batchEnd > len(needStat) {
+			batchEnd = len(needStat)
+		}
+		batch := needStat[batchStart:batchEnd]
+		paths := make([]string, len(batch))
+		for j, idx := range batch {
+			paths[j] = fs.remotePath(dirEntryChildPath(dirPath, items[idx].Name))
 		}
 		results, err := fs.client.BatchStatCtx(ctx, paths)
 		if err != nil {
-			log.Printf("batch stat failed for %s entries %d-%d: %v", dirPath, start, end, err)
+			log.Printf("batch stat failed for %s entries %d-%d: %v", dirPath, batchStart, batchEnd, err)
 			return
 		}
-		for i, result := range results {
+		for j, result := range results {
 			if !result.OK() {
 				continue
 			}
-			item := &items[start+i]
+			item := &items[batch[j]]
 			item.Size = result.Size
 			item.IsDir = result.IsDir
 			if result.Mtime > 0 {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -8182,9 +8182,17 @@ func (fs *Dat9FS) applyBatchStats(ctx context.Context, dirPath string, items []C
 	// item already has full metadata and no per-file stat is needed.
 	// This is backward-compatible: old servers that omit revision leave it
 	// at 0, so those entries still go through BatchStat.
+	//
+	// Directories are always skipped: they have no file revision, and the
+	// list API already returns their full metadata (name, isDir, mtime,
+	// mode, resourceID, nlink). BatchStat added no new information for
+	// directories.
 	var needStat []int
 	for i := range items {
-		if items[i].Revision <= 0 && !items[i].IsDir {
+		if items[i].IsDir {
+			continue
+		}
+		if items[i].Revision <= 0 {
 			needStat = append(needStat, i)
 		}
 	}
@@ -8204,7 +8212,7 @@ func (fs *Dat9FS) applyBatchStats(ctx context.Context, dirPath string, items []C
 		}
 		results, err := fs.client.BatchStatCtx(ctx, paths)
 		if err != nil {
-			log.Printf("batch stat failed for %s entries %d-%d: %v", dirPath, batchStart, batchEnd, err)
+			log.Printf("batch stat failed for %s (needStat batch %d-%d of %d): %v", dirPath, batchStart, batchEnd, len(needStat), err)
 			return
 		}
 		for j, result := range results {

--- a/pkg/fuse/dir.go
+++ b/pkg/fuse/dir.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	defaultDirCacheTTL              = 10 * time.Second
-	defaultNamespaceCacheMaxEntries = 2000
+	defaultNamespaceCacheMaxEntries = 100000
 
 	// escalateMissThreshold/escalateMissWindow detect negative-lookup storms:
 	// once this many remote ENOENT stats hit the same directory within the

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -1053,6 +1053,48 @@ func TestNamespaceCache_InvalidatePrefix(t *testing.T) {
 	}
 }
 
+func TestNamespaceCache_LargeDirCachesCompleteWithHighMaxEntries(t *testing.T) {
+	// With a high maxEntries (like the new default 100000), a 10k-entry
+	// directory should be cached as complete and returned by Get().
+	dc := NewNamespaceCache(10*time.Second, 10*time.Second, 100000)
+	items := make([]CachedFileInfo, 10000)
+	for i := range items {
+		items[i] = CachedFileInfo{
+			Name:     fmt.Sprintf("file_%05d.txt", i),
+			Size:     1024,
+			Revision: int64(i + 1),
+		}
+	}
+	dc.Put("/bigdir", items)
+
+	got, ok := dc.Get("/bigdir")
+	if !ok {
+		t.Fatal("10k-entry dir should be cached as complete with maxEntries=100000")
+	}
+	if len(got) != 10000 {
+		t.Fatalf("got %d cached entries, want 10000", len(got))
+	}
+	// Verify revision is preserved
+	if got[0].Revision <= 0 {
+		t.Fatal("revision should be preserved in cached entries")
+	}
+}
+
+func TestNamespaceCache_OldDefault2000DoesNotCacheLargeDir(t *testing.T) {
+	// Demonstrates the old behavior: maxEntries=2000 prevents 10k dirs
+	// from being cached as complete.
+	dc := NewNamespaceCache(10*time.Second, 10*time.Second, 2000)
+	items := make([]CachedFileInfo, 10000)
+	for i := range items {
+		items[i] = CachedFileInfo{Name: fmt.Sprintf("file_%05d.txt", i)}
+	}
+	dc.Put("/bigdir", items)
+
+	if _, ok := dc.Get("/bigdir"); ok {
+		t.Fatal("10k-entry dir should NOT be cached as complete with maxEntries=2000")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Sparse WriteBuffer with LoadPart (lazy loading) tests
 // ---------------------------------------------------------------------------

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -68,6 +68,7 @@ type MountOptions struct {
 	PrefetchMaxFileBytes    int64         // maximum individual file size prefetched (default 50KB)
 	PrefetchMaxBytes        int64         // maximum aggregate bytes prefetched per directory read (default 1MB)
 	PrefetchTimeout         time.Duration // timeout for one readdir prefetch batch (default 1s)
+	DirCacheMaxEntries      int           // maximum entries per directory in DirCache (default 100000); directories exceeding this limit are not cached as complete
 	TrustLocalEvents        bool          // allow revision-bound GetAttr hits from DirCache using process-local SSE freshness; safe only for single-server/sticky or cluster-wide event streams
 	AllowOther              bool          // allow other users to access mount
 	ReadOnly                bool          // mount as read-only

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1258,6 +1258,7 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 		Size       int64  `json:"size"`
 		IsDir      bool   `json:"isDir"`
 		Mtime      int64  `json:"mtime,omitempty"`
+		Revision   int64  `json:"revision,omitempty"`
 		Mode       uint32 `json:"mode,omitempty"`
 		HasMode    bool   `json:"hasMode"`
 		ResourceID string `json:"resource_id,omitempty"`
@@ -1276,11 +1277,18 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 				nlink = uint32(parsed)
 			}
 		}
+		var revision int64
+		if raw := e.Meta.Content["revision"]; raw != "" {
+			if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil {
+				revision = parsed
+			}
+		}
 		out = append(out, entry{
 			Name:       e.Name,
 			Size:       e.Size,
 			IsDir:      e.IsDir,
 			Mtime:      mtime,
+			Revision:   revision,
 			Mode:       e.Mode,
 			HasMode:    hasMode,
 			ResourceID: e.Meta.Content["resource_id"],

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -419,6 +419,7 @@ func TestListDir(t *testing.T) {
 		Entries []struct {
 			Name       string `json:"name"`
 			IsDir      bool   `json:"isDir"`
+			Revision   int64  `json:"revision"`
 			ResourceID string `json:"resource_id"`
 			Nlink      uint32 `json:"nlink"`
 		} `json:"entries"`
@@ -434,6 +435,9 @@ func TestListDir(t *testing.T) {
 	}
 	if result.Entries[0].Nlink != 1 {
 		t.Fatalf("list entry nlink = %d, want 1", result.Entries[0].Nlink)
+	}
+	if result.Entries[0].Revision <= 0 {
+		t.Fatalf("list entry revision = %d, want > 0", result.Entries[0].Revision)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the root cause of slow directory listing performance discovered in customer benchmark testing:
- **10k files flat directory**: `ls`/`find` took ~30s even on warm repeated calls
- **1k files cold `ls`**: took ~19s

### Root Causes Found

1. **Missing revision in list API → BatchStat N+1**: Server list response did not include file `revision`. Client called `BatchStatCtx` (256 per batch) on every file just to get revision. For 10k files = 40 sequential HTTP round-trips ≈ 8-16s additional latency.

2. **DirCache maxEntries=2000 → large dirs never cached**: `defaultNamespaceCacheMaxEntries` was 2000. Directories with >2000 files could never be marked as `complete`, so every `ls` re-fetched everything from server.

### Changes

- **Server**: Add `revision` field to list response entry (backward-compatible via `omitempty`)
- **Backend**: Populate revision in `ReadDirCtx` meta map from `File.Revision`
- **Client**: Add `Revision` to `FileInfo` struct (zero value = old server, triggers BatchStat fallback)
- **FUSE `applyBatchStats`**: Skip entries that already have `Revision > 0`; fallback to BatchStat for missing revision (old server compatibility)
- **DirCache**: Raise `defaultNamespaceCacheMaxEntries` from 2000 to 100000
- **MountOptions**: Add `DirCacheMaxEntries` for configurability

### Memory Impact

Each `CachedFileInfo` ≈ 200 bytes. 100k entries ≈ 20MB per cached directory. Acceptable for FUSE mount process memory budget.

### Expected Improvement

| Scenario | Before | After (expected) |
|----------|--------|-----------------|
| Cold 10k `ls` | ~30s | <5s |
| Warm 10k `ls` | ~30s | <100ms |
| Cold 1k `ls` | ~19s | <2s |

### Backward Compatibility

- Old client + new server: client ignores `revision` field (JSON omitempty), no behavior change
- New client + old server: `revision` is 0 (JSON zero value), falls back to existing BatchStat path

## Test plan

- [x] All existing `fuse` tests pass (21.875s, 0 failures)
- [x] New tests: `TestNamespaceCache_LargeDirCachesCompleteWithHighMaxEntries`, `TestNamespaceCache_OldDefault2000DoesNotCacheLargeDir`
- [x] Server test: `TestListDir` updated to assert `revision > 0`
- [x] Client test: `TestListDir` updated to assert `revision > 0`
- [ ] CI green
- [ ] Benchmark re-run on test server: 1k cold, 10k cold/warm, fsync c16 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directory listings now include file revision metadata for improved version tracking of cached files.

* **Improvements**
  * Default directory cache capacity increased from 2,000 to 100,000 entries for better performance with larger directories.
  * Directory cache maximum entry count is now configurable to support various operational needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->