### PR TITLE
fix: retry metadb startup initialization

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -120,7 +120,7 @@ func main() {
 	}
 	backendOptions.AppSemanticTasksEnabled = semanticEmbedder != nil
 
-	store, err := meta.Open(metaDSN)
+	store, err := openControlPlaneStoreWithRetry(context.Background(), metaDSN, defaultStartupRetryOptions())
 	if err != nil {
 		die(fmt.Errorf("open control-plane store: %w", err))
 	}
@@ -226,7 +226,7 @@ func main() {
 			die(fmt.Errorf("create encryptor: %w", err))
 		}
 
-		if err := store.DB().Ping(); err != nil {
+		if err := pingControlPlaneDBWithRetry(context.Background(), store, defaultStartupRetryOptions()); err != nil {
 			die(fmt.Errorf("control-plane db unavailable: %w", err))
 		}
 

--- a/cmd/drive9-server/startup_retry.go
+++ b/cmd/drive9-server/startup_retry.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
+)
+
+const (
+	startupMetaRetryTotalTimeout   = 2 * time.Minute
+	startupMetaRetryAttemptTimeout = 10 * time.Second
+	startupMetaRetryInitialBackoff = time.Second
+	startupMetaRetryMaxBackoff     = 15 * time.Second
+)
+
+type startupRetryOptions struct {
+	TotalTimeout   time.Duration
+	AttemptTimeout time.Duration
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+	Sleep          func(context.Context, time.Duration) error
+}
+
+func defaultStartupRetryOptions() startupRetryOptions {
+	return startupRetryOptions{
+		TotalTimeout:   startupMetaRetryTotalTimeout,
+		AttemptTimeout: startupMetaRetryAttemptTimeout,
+		InitialBackoff: startupMetaRetryInitialBackoff,
+		MaxBackoff:     startupMetaRetryMaxBackoff,
+		Sleep:          sleepContext,
+	}
+}
+
+func (o startupRetryOptions) withDefaults() startupRetryOptions {
+	if o.TotalTimeout <= 0 {
+		o.TotalTimeout = startupMetaRetryTotalTimeout
+	}
+	if o.AttemptTimeout <= 0 {
+		o.AttemptTimeout = startupMetaRetryAttemptTimeout
+	}
+	if o.InitialBackoff <= 0 {
+		o.InitialBackoff = startupMetaRetryInitialBackoff
+	}
+	if o.MaxBackoff <= 0 {
+		o.MaxBackoff = startupMetaRetryMaxBackoff
+	}
+	if o.MaxBackoff < o.InitialBackoff {
+		o.MaxBackoff = o.InitialBackoff
+	}
+	if o.Sleep == nil {
+		o.Sleep = sleepContext
+	}
+	return o
+}
+
+func openControlPlaneStoreWithRetry(ctx context.Context, dsn string, opts startupRetryOptions) (*meta.Store, error) {
+	var store *meta.Store
+	err := retryStartupOperation(ctx, "open_control_plane_store", opts, func(attemptCtx context.Context) error {
+		opened, err := meta.OpenContext(attemptCtx, dsn)
+		if err != nil {
+			return err
+		}
+		store = opened
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func pingControlPlaneDBWithRetry(ctx context.Context, store *meta.Store, opts startupRetryOptions) error {
+	return retryStartupOperation(ctx, "ping_control_plane_db", opts, func(attemptCtx context.Context) error {
+		return store.DB().PingContext(attemptCtx)
+	})
+}
+
+func retryStartupOperation(ctx context.Context, name string, opts startupRetryOptions, op func(context.Context) error) error {
+	opts = opts.withDefaults()
+	deadlineCtx, cancel := context.WithTimeout(ctx, opts.TotalTimeout)
+	defer cancel()
+
+	backoff := opts.InitialBackoff
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		attemptCtx, attemptCancel := context.WithTimeout(deadlineCtx, opts.AttemptTimeout)
+		err := op(attemptCtx)
+		attemptCancel()
+		if err == nil {
+			if attempt > 1 {
+				logger.Info(context.Background(), "startup_dependency_available",
+					zap.String("dependency", name),
+					zap.Int("attempt", attempt))
+			}
+			return nil
+		}
+		lastErr = err
+		if deadlineCtx.Err() != nil {
+			return fmt.Errorf("%s failed after %s: %w", name, opts.TotalTimeout, lastErr)
+		}
+
+		wait := backoff
+		if deadline, ok := deadlineCtx.Deadline(); ok {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return fmt.Errorf("%s failed after %s: %w", name, opts.TotalTimeout, lastErr)
+			}
+			if wait > remaining {
+				wait = remaining
+			}
+		}
+		logger.Warn(context.Background(), "startup_dependency_unavailable",
+			zap.String("dependency", name),
+			zap.Int("attempt", attempt),
+			zap.Duration("retry_in", wait),
+			zap.Duration("attempt_timeout", opts.AttemptTimeout),
+			zap.Duration("total_timeout", opts.TotalTimeout),
+			zap.Error(err))
+		if err := opts.Sleep(deadlineCtx, wait); err != nil {
+			return fmt.Errorf("%s failed after %s: %w", name, opts.TotalTimeout, lastErr)
+		}
+		if backoff < opts.MaxBackoff {
+			backoff *= 2
+			if backoff > opts.MaxBackoff {
+				backoff = opts.MaxBackoff
+			}
+		}
+	}
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/cmd/drive9-server/startup_retry_test.go
+++ b/cmd/drive9-server/startup_retry_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetryStartupOperationSucceedsAfterFailures(t *testing.T) {
+	temporaryErr := errors.New("temporary metadb failure")
+	var waits []time.Duration
+	attempts := 0
+	err := retryStartupOperation(context.Background(), "metadb", startupRetryOptions{
+		TotalTimeout:   time.Second,
+		AttemptTimeout: 50 * time.Millisecond,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+		Sleep: func(_ context.Context, d time.Duration) error {
+			waits = append(waits, d)
+			return nil
+		},
+	}, func(ctx context.Context) error {
+		attempts++
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("expected per-attempt context deadline")
+		}
+		if attempts < 3 {
+			return temporaryErr
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retryStartupOperation: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	if len(waits) != 2 || waits[0] != time.Millisecond || waits[1] != 2*time.Millisecond {
+		t.Fatalf("waits = %v, want [1ms 2ms]", waits)
+	}
+}
+
+func TestRetryStartupOperationStopsAfterTotalTimeout(t *testing.T) {
+	temporaryErr := errors.New("metadb down")
+	attempts := 0
+	err := retryStartupOperation(context.Background(), "metadb", startupRetryOptions{
+		TotalTimeout:   10 * time.Millisecond,
+		AttemptTimeout: time.Millisecond,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+	}, func(context.Context) error {
+		attempts++
+		return temporaryErr
+	})
+	if !errors.Is(err, temporaryErr) {
+		t.Fatalf("err = %v, want wrapped temporary error", err)
+	}
+	if attempts == 0 {
+		t.Fatal("expected at least one attempt")
+	}
+}
+
+func TestRetryStartupOperationHonorsParentCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	attempts := 0
+	err := retryStartupOperation(ctx, "metadb", startupRetryOptions{
+		TotalTimeout:   time.Second,
+		AttemptTimeout: time.Second,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+		Sleep: func(context.Context, time.Duration) error {
+			t.Fatal("sleep should not run after canceled parent context")
+			return nil
+		},
+	}, func(ctx context.Context) error {
+		attempts++
+		return ctx.Err()
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRetryStartupOperationPassesAttemptTimeout(t *testing.T) {
+	const attemptTimeout = 25 * time.Millisecond
+	err := retryStartupOperation(context.Background(), "metadb", startupRetryOptions{
+		TotalTimeout:   time.Second,
+		AttemptTimeout: attemptTimeout,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+	}, func(ctx context.Context) error {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("expected per-attempt deadline")
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > attemptTimeout {
+			t.Fatalf("remaining attempt timeout = %s, want within (0, %s]", remaining, attemptTimeout)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retryStartupOperation: %v", err)
+	}
+}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -220,10 +220,14 @@ type Store struct {
 }
 
 func Open(dsn string) (*Store, error) {
+	return OpenContext(context.Background(), dsn)
+}
+
+func OpenContext(ctx context.Context, dsn string) (*Store, error) {
 	if strings.Contains(dsn, "multiStatements=true") {
 		return nil, fmt.Errorf("multiStatements=true is not allowed in production DSN")
 	}
-	db, err := mysqlutil.OpenInstrumented(context.Background(), dsn, mysqlutil.RoleMeta)
+	db, err := mysqlutil.OpenInstrumented(ctx, dsn, mysqlutil.RoleMeta)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}


### PR DESCRIPTION
## Summary
- add bounded startup retry/backoff for control-plane metadb initialization
- add per-attempt context timeout via meta.OpenContext and DB PingContext
- keep failure bounded: after retry budget is exhausted, drive9-server still exits and lets Kubernetes restart it
- add focused retry helper tests for success-after-failure, bounded failure, parent cancel, and per-attempt deadline propagation

## Validation
- /usr/local/go/bin/go test ./cmd/drive9-server -run 'TestRetryStartupOperation|TestVersionText' -count=1
- /usr/local/go/bin/go test ./cmd/drive9-server -count=1
- /usr/local/go/bin/go test -c ./pkg/... ./cmd/...
- /usr/local/go/bin/go build ./cmd/drive9-server ./cmd/drive9
- /usr/local/go/bin/go vet ./cmd/drive9-server ./pkg/meta ./pkg/mysqlutil
- git diff --check

Note: runtime pkg/meta tests are still locally blocked by missing rootless Docker/testcontainers, so this PR uses compile validation for DB-backed packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved server startup resilience by adding automatic retry logic for database connectivity checks. The server now retries opening database connections with exponential backoff instead of failing immediately if the database is temporarily unavailable during startup.

* **Tests**
  * Added comprehensive test coverage for the retry mechanism to validate behavior under various failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->