### PR TITLE
perf: reduce writeback flush latency

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2738,11 +2738,23 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 	}
 	mode, hasMode := fs.modeForPendingHandle(fh)
 	if fh.ShadowSpill {
-		if _, err := fs.pendingIndex.PutShadowSpillWithMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode); err != nil {
+		var err error
+		if durable {
+			_, err = fs.pendingIndex.PutShadowSpillWithMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode)
+		} else {
+			_, err = fs.pendingIndex.PutVolatileShadowSpillWithMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode)
+		}
+		if err != nil {
 			log.Printf("pending index put failed for %s: %v", fh.Path, err)
 		}
 	} else {
-		if _, err := fs.pendingIndex.PutWithBaseRevAndMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode); err != nil {
+		var err error
+		if durable {
+			_, err = fs.pendingIndex.PutWithBaseRevAndMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode)
+		} else {
+			_, err = fs.pendingIndex.PutVolatileWithBaseRevAndMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode)
+		}
+		if err != nil {
 			log.Printf("pending index put failed for %s: %v", fh.Path, err)
 		}
 	}
@@ -10219,9 +10231,12 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 
 	requiresRemoteSync := isSQLitePersistentJournalPath(fh.Path)
 
-	// Write-back path: small dirty files are persisted to local disk
-	// and return immediately. The actual HTTP upload happens in Release
-	// (async). This reduces Flush latency from ~100-300ms to ~1-5ms.
+	// Write-back path: dirty data is staged locally and returned to the
+	// caller before the remote upload completes. When the CommitQueue is
+	// available, this intentionally keeps pending metadata in memory and skips
+	// local fsync/writeback-cache durability. Same-mount namespace consistency
+	// is still preserved; crash recovery before the queued commit reaches the
+	// remote is a close-sync/write-sync concern.
 	//
 	// IMPORTANT: We do NOT ClearDirty here. The buffer stays dirty as a
 	// safety net — if the user writes more data between Flush and Release,
@@ -10244,6 +10259,19 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			// current file contents. Otherwise a background full-file PUT would
 			// silently zero untouched remote-backed ranges.
 			if fs.canStageShadowFastLocked(fh) || fh.Dirty.CanMaterializeFull() {
+				if fs.commitQueue != nil && fs.shadowStore != nil {
+					phase = "small-stage-shadow-nondurable"
+					stageStart := time.Now()
+					fs.debugf("flush stage nondurable shadow start path=%s size=%d", fh.Path, size)
+					err := fs.stageShadowForQueuedCommitLocked(fh, false)
+					fs.debugDurationf(stageStart, 0, "flush stage nondurable shadow done path=%s size=%d err=%v", fh.Path, size, err)
+					if err != nil {
+						log.Printf("nondurable shadow stage failed for %s: %v, falling through", fh.Path, err)
+					} else {
+						fh.WriteBackSeq = fh.DirtySeq
+						return gofuse.OK
+					}
+				}
 				if fs.shadowStore != nil && fs.pendingIndex != nil {
 					phase = "small-stage-shadow"
 					stageStart := time.Now()
@@ -10386,6 +10414,23 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			if fs.canStageShadowFastLocked(fh) || fh.Dirty.CanMaterializeFull() {
 				phase = "large-stage-shadow"
 				size := fh.Dirty.Size()
+				if fs.commitQueue != nil {
+					phase = "large-stage-shadow-nondurable"
+					stageStart := time.Now()
+					fs.debugf("flush stage nondurable shadow start path=%s size=%d", fh.Path, size)
+					err := fs.stageShadowForQueuedCommitLocked(fh, false)
+					fs.debugDurationf(stageStart, 0, "flush stage nondurable shadow done path=%s size=%d err=%v", fh.Path, size, err)
+					if err != nil {
+						log.Printf("flush: nondurable shadow stage failed for %s (size=%d): %v, falling through", fh.Path, fh.Dirty.Size(), err)
+					} else {
+						fh.WriteBackSeq = fh.DirtySeq
+						if fh.Streamer != nil && fh.Streamer.Started() {
+							fh.Streamer.Abort()
+							fh.Streamer = nil
+						}
+						return gofuse.OK
+					}
+				}
 				stageStart := time.Now()
 				fs.debugf("flush stage shadow start path=%s size=%d durable=true", fh.Path, size)
 				err := fs.stageShadowForQueuedCommitLocked(fh, true)

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -85,7 +85,15 @@ func (idx *PendingIndex) PutWithBaseRev(remotePath string, size int64, kind Pend
 // PutWithBaseRevAndMode stores metadata for the given path together with the
 // file mode that must be applied after the pending data commits remotely.
 func (idx *PendingIndex) PutWithBaseRevAndMode(remotePath string, size int64, kind PendingKind, baseRev int64, mode uint32, hasMode bool) (uint64, error) {
-	return idx.putInternal(remotePath, size, kind, baseRev, false, mode, hasMode)
+	return idx.putInternal(remotePath, size, kind, baseRev, false, mode, hasMode, true)
+}
+
+// PutVolatileWithBaseRevAndMode stores pending metadata in memory only.
+// It preserves same-mount namespace visibility without paying the local
+// metadata fsync cost. Crash recovery before the queued commit reaches the
+// remote is intentionally not guaranteed for this path.
+func (idx *PendingIndex) PutVolatileWithBaseRevAndMode(remotePath string, size int64, kind PendingKind, baseRev int64, mode uint32, hasMode bool) (uint64, error) {
+	return idx.putInternal(remotePath, size, kind, baseRev, false, mode, hasMode, false)
 }
 
 // PutShadowSpill is like PutWithBaseRev but marks the entry as ShadowSpill
@@ -98,10 +106,16 @@ func (idx *PendingIndex) PutShadowSpill(remotePath string, size int64, kind Pend
 // PutShadowSpillWithMode is like PutShadowSpill, but also persists file mode
 // metadata for the eventual remote chmod.
 func (idx *PendingIndex) PutShadowSpillWithMode(remotePath string, size int64, kind PendingKind, baseRev int64, mode uint32, hasMode bool) (uint64, error) {
-	return idx.putInternal(remotePath, size, kind, baseRev, true, mode, hasMode)
+	return idx.putInternal(remotePath, size, kind, baseRev, true, mode, hasMode, true)
 }
 
-func (idx *PendingIndex) putInternal(remotePath string, size int64, kind PendingKind, baseRev int64, shadowSpill bool, mode uint32, hasMode bool) (uint64, error) {
+// PutVolatileShadowSpillWithMode is the in-memory-only variant of
+// PutShadowSpillWithMode.
+func (idx *PendingIndex) PutVolatileShadowSpillWithMode(remotePath string, size int64, kind PendingKind, baseRev int64, mode uint32, hasMode bool) (uint64, error) {
+	return idx.putInternal(remotePath, size, kind, baseRev, true, mode, hasMode, false)
+}
+
+func (idx *PendingIndex) putInternal(remotePath string, size int64, kind PendingKind, baseRev int64, shadowSpill bool, mode uint32, hasMode bool, durable bool) (uint64, error) {
 	gen := idx.nextGen.Add(1)
 	meta := &WriteBackMeta{
 		Path:        remotePath,
@@ -116,14 +130,16 @@ func (idx *PendingIndex) putInternal(remotePath string, size int64, kind Pending
 		HasMode:     hasMode,
 	}
 
-	// Write to disk first for durability.
-	metaBytes, err := json.Marshal(meta)
-	if err != nil {
-		return 0, fmt.Errorf("pending index marshal: %w", err)
-	}
-	metaPath := filepath.Join(idx.dir, hashPath(remotePath)+".meta")
-	if err := atomicWrite(metaPath, metaBytes); err != nil {
-		return 0, fmt.Errorf("pending index put meta: %w", err)
+	if durable {
+		// Write to disk first for durability.
+		metaBytes, err := json.Marshal(meta)
+		if err != nil {
+			return 0, fmt.Errorf("pending index marshal: %w", err)
+		}
+		metaPath := filepath.Join(idx.dir, hashPath(remotePath)+".meta")
+		if err := atomicWrite(metaPath, metaBytes); err != nil {
+			return 0, fmt.Errorf("pending index put meta: %w", err)
+		}
 	}
 
 	idx.mu.Lock()


### PR DESCRIPTION
## Summary

This PR reduces writeback-mode `Flush` latency for dirty files mounted through Drive9 FUSE.

The previous writeback path staged dirty file contents into the local shadow store and persisted pending-index metadata to disk before returning from `Flush`. That made writeback behave closer to a durable local flush path, even though remote upload still happens asynchronously through the commit queue. For small-file-heavy agent workloads, this added avoidable local durability cost on the hot path.

This change adds an explicitly volatile pending-index path for writeback flushes when the commit queue is available:

- stage dirty file contents into the shadow store without forcing the durable pending-index metadata path
- keep pending metadata in memory so same-mount namespace visibility still works
- keep remote upload ownership in the existing close/release commit-queue path
- preserve the durable pending-index path as the fallback when the non-durable staging path cannot be used

## Implementation

### `pkg/fuse/dat9fs.go`

- Updates the writeback `Flush` path to prefer non-durable shadow staging when both the commit queue and shadow store are available.
- Sets `fh.WriteBackSeq` after successful non-durable staging so repeated flushes for the same dirty sequence can return quickly.
- Keeps existing durable staging behavior as the fallback path if non-durable staging fails or is not applicable.
- Applies the same strategy to both small dirty files and larger dirty files that can be staged into the shadow store.
- Leaves `fh.Dirty` uncleared during `Flush`, matching the existing safety model for additional writes before `Release`.

### `pkg/fuse/pending_index.go`

- Adds volatile pending-index APIs:
  - `PutVolatileWithBaseRevAndMode`
  - `PutVolatileShadowSpillWithMode`
- Extends `putInternal` with a `durable` flag.
- Keeps the existing durable APIs writing metadata through `atomicWrite`.
- Lets volatile entries update in-memory pending metadata without writing `.meta` files to disk.

## Semantics

This is intentionally a writeback-mode optimization. It does not make writeback equivalent to close-sync or write-sync.

Expected behavior after this change:

- Same-mount visibility remains available through in-memory pending metadata.
- Remote visibility is still provided by the existing commit-queue flow after close/release.
- Crash recovery before the queued commit reaches the remote is not guaranteed for volatile pending metadata.
- Callers that need stronger remote/durable guarantees should continue using close-sync or write-sync behavior.

## Validation

Unit tests:

```bash
env GOCACHE=/private/tmp/drive9-fix-writeback/.codex-gocache \
  GOMODCACHE=/Users/mornyx/Desktop/repos/github.com/mem9-ai/drive9/.codex-gomodcache \
  go test -count=1 ./pkg/fuse
```

Result:

```text
ok   github.com/mem9-ai/drive9/pkg/fuse  24.992s
```

Manual blackbox / e2e validation was also run against a production Drive9 endpoint with an optimized CLI build. The results showed strong improvements for writeback flush-heavy small-file workloads, and the main FUSE release gate passed. However, this PR is intentionally opened as a draft because there are still known follow-up issues listed below.

## Known follow-ups

This PR should not be treated as merge-ready without reviewer sign-off on the semantics and follow-up fixes:

- Native git clone remount-restore still showed status drift in the git-ops e2e path for `native` clone mode.
- Close/release cross-mount visibility needs more focused A/B validation because remote commit still begins at close/release.
- FUSE unmount can still take around 60 seconds in some blackbox workloads; logs show this issue existed before this PR, but it remains a product/test-experience problem.
- The current behavior intentionally trades local pending-index crash recovery on writeback `Flush` for lower latency; this should be documented clearly before marking the PR ready.

## Risk

Medium to high.

The code path is narrow, but it sits on the FUSE writeback hot path. The main risk is semantic confusion around what `Flush` means in writeback mode versus close-sync/write-sync modes. The implementation preserves fallbacks and same-mount visibility, but reviewers should pay special attention to cross-mount visibility, crash recovery expectations, and commit-queue drain behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of data staging during flush operations with optimized metadata management paths for better control over durability guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->