### PR TITLE
perf: move central quota mutation off write hot path

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -102,15 +102,12 @@ type Dat9Backend struct {
 	qCache             *quotaCache    // nil when central quota is not wired
 
 	// mutationQueue decouples central quota mutations (syncCentralFileCreate,
-	// syncCentralFileOverwrite) from the fsync critical path. Mutations are
-	// enqueued here and drained by a background worker. The mutation log
-	// provides crash recovery via the existing MutationReplayWorker.
-	//
-	// mutationMu serializes logQuotaMutation + enqueueMutation so that
-	// durable log_id order and channel enqueue order cannot diverge under
-	// concurrent same-tenant writes.
-	mutationMu    sync.Mutex
-	mutationQueue chan func()
+	// syncCentralFileOverwrite) from the fsync critical path. The write hot
+	// path performs a non-blocking channel send of a mutationEntry struct;
+	// the background worker does both the durable log INSERT and the
+	// quota-state apply. If the channel is full the entry is dropped —
+	// backfill-quota reconciles from the source-of-truth tenant DB.
+	mutationQueue chan mutationEntry
 	mutationWG    sync.WaitGroup
 	mutationStop  context.CancelFunc
 

--- a/pkg/backend/quota_async.go
+++ b/pkg/backend/quota_async.go
@@ -6,26 +6,22 @@ import (
 
 const (
 	// mutationQueueSize is the buffer size for the async mutation channel.
-	// Sized to absorb short bursts without blocking the write path. A single
-	// worker drains the channel to preserve per-tenant FIFO ordering
-	// (UpsertFileMetaTx is not commutative across create/overwrite).
+	// Sized to absorb short bursts. The channel accepts mutationEntry structs
+	// (not closures) so the write hot path does zero DB work — the background
+	// worker performs both the durable log INSERT and the quota-state apply.
 	mutationQueueSize = 256
 )
 
 // startMutationWorker initializes the async mutation queue and a single
-// sequencing worker. A single worker guarantees that within this backend
-// instance, per-tenant mutation apply order matches the log insertion order
-// (which is serialized by the caller's mutationMu + logQuotaMutation).
-// Cross-instance ordering is not guaranteed; see logAndEnqueueMutation.
-//
-// Called once from SetMetaQuotaStore when server quota is active.
+// sequencing worker. Called once from SetMetaQuotaStore when server quota is
+// active.
 func (b *Dat9Backend) startMutationWorker() {
 	if b.mutationQueue != nil {
 		return // already started
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	b.mutationStop = cancel
-	b.mutationQueue = make(chan func(), mutationQueueSize)
+	b.mutationQueue = make(chan mutationEntry, mutationQueueSize)
 	b.mutationWG.Add(1)
 	go b.drainMutations(ctx)
 }
@@ -38,33 +34,16 @@ func (b *Dat9Backend) drainMutations(ctx context.Context) {
 			// Drain remaining items before exiting.
 			for {
 				select {
-				case fn := <-b.mutationQueue:
-					fn()
+				case entry := <-b.mutationQueue:
+					b.processOneMutation(context.Background(), entry)
 				default:
 					return
 				}
 			}
-		case fn := <-b.mutationQueue:
-			fn()
+		case entry := <-b.mutationQueue:
+			b.processOneMutation(context.Background(), entry)
 		}
 	}
-}
-
-// enqueueMutation submits a mutation apply function to the async queue.
-// The mutation log entry has already been durably written by the caller
-// (logQuotaMutation), so if this enqueue blocks or the process crashes
-// before the worker runs, MutationReplayWorker recovers the pending entry.
-//
-// If the queue is not wired (tests), the function runs inline.
-// The channel send blocks if the buffer is full, preserving FIFO ordering;
-// the 256-slot buffer makes blocking extremely unlikely in practice.
-func (b *Dat9Backend) enqueueMutation(fn func()) {
-	if b.mutationQueue == nil {
-		// No async queue — run inline (test/fallback path).
-		fn()
-		return
-	}
-	b.mutationQueue <- fn
 }
 
 // stopMutationWorker shuts down the async mutation queue and waits for

--- a/pkg/backend/quota_async_test.go
+++ b/pkg/backend/quota_async_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"database/sql"
 	"sync/atomic"
 	"testing"
@@ -96,4 +97,105 @@ func TestStopMutationWorker_Idempotent(t *testing.T) {
 	b.startMutationWorker()
 	b.stopMutationWorker()
 	b.stopMutationWorker() // Should not panic.
+}
+
+// TestProcessOneMutation_LogApplyMark verifies that processOneMutation
+// calls InsertMutationLog, the apply function, and MarkMutationAppliedTx
+// using a fakeMetaQuotaStore (defined in quota_migration_test.go).
+func TestProcessOneMutation_LogApplyMark(t *testing.T) {
+	fake := newFakeMetaQuotaStore()
+	b := &Dat9Backend{
+		tenantID:  "tenant-test",
+		metaStore: fake,
+	}
+
+	var applyCalled atomic.Bool
+	entry := mutationEntry{
+		mutationType: "file_create",
+		payload: fileCreateMutationData{
+			FileID:    "file-1",
+			SizeBytes: 1024,
+			IsMedia:   false,
+		},
+		apply: func(tx *sql.Tx) error {
+			applyCalled.Store(true)
+			return b.metaStore.IncrStorageBytesTx(tx, b.tenantID, 1024)
+		},
+	}
+
+	b.processOneMutation(context.Background(), entry)
+
+	require.True(t, applyCalled.Load(), "apply function should be called")
+
+	// Verify mutation log was inserted and marked applied.
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	require.Len(t, fake.mutations, 1, "one mutation log entry expected")
+	require.Equal(t, "file_create", fake.mutations[0].typ)
+	require.Equal(t, "applied", fake.mutationStatus(fake.mutations[0].id))
+
+	// Verify storage bytes were incremented.
+	usage := fake.usage["tenant-test"]
+	require.NotNil(t, usage)
+	require.Equal(t, int64(1024), usage.StorageBytes)
+}
+
+// TestProcessOneMutation_WorkerDrain verifies that the background worker
+// calls processOneMutation with a real metaStore for each enqueued entry.
+func TestProcessOneMutation_WorkerDrain(t *testing.T) {
+	fake := newFakeMetaQuotaStore()
+	b := &Dat9Backend{
+		tenantID:  "tenant-test",
+		metaStore: fake,
+	}
+	b.startMutationWorker()
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		b.enqueueMutationEntry(context.Background(), mutationEntry{
+			mutationType: "file_create",
+			payload: fileCreateMutationData{
+				FileID:    "file-1",
+				SizeBytes: 100,
+			},
+			apply: func(tx *sql.Tx) error {
+				return b.metaStore.IncrStorageBytesTx(tx, b.tenantID, 100)
+			},
+		})
+	}
+
+	b.stopMutationWorker()
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	require.Len(t, fake.mutations, n, "all mutations should be logged")
+	for _, entry := range fake.mutations {
+		require.Equal(t, "applied", fake.mutationStatus(entry.id))
+	}
+	require.Equal(t, int64(n*100), fake.usage["tenant-test"].StorageBytes)
+}
+
+// TestSyncCentralLLMCostRecord_Synchronous verifies that LLM cost records
+// are processed synchronously (not enqueued to the async channel).
+func TestSyncCentralLLMCostRecord_Synchronous(t *testing.T) {
+	fake := newFakeMetaQuotaStore()
+	b := &Dat9Backend{
+		tenantID:  "tenant-test",
+		metaStore: fake,
+	}
+	// Start worker with tiny queue — if LLM cost went through queue,
+	// it would be enqueued there.
+	b.mutationQueue = make(chan mutationEntry, 1)
+
+	b.syncCentralLLMCostRecord(context.Background(), "img_extract_text", "task-1", 500, 100, "tokens")
+
+	// Queue should be empty — LLM cost bypasses the queue.
+	require.Equal(t, 0, len(b.mutationQueue), "LLM cost should not use async queue")
+
+	// Verify it was logged and applied.
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	require.Len(t, fake.mutations, 1)
+	require.Equal(t, "llm_cost_record", fake.mutations[0].typ)
+	require.Equal(t, "applied", fake.mutationStatus(fake.mutations[0].id))
 }

--- a/pkg/backend/quota_async_test.go
+++ b/pkg/backend/quota_async_test.go
@@ -193,11 +193,11 @@ func TestProcessOneMutation_WorkerDrain(t *testing.T) {
 func TestSyncCentralFileCreate_AsyncPath(t *testing.T) {
 	fake := newFakeMetaQuotaStore()
 	b := &Dat9Backend{
-		tenantID:    "tenant-test",
-		metaStore:   fake,
 		quotaSource: QuotaSourceServer,
 	}
-	b.startMutationWorker()
+	// Use the production wiring path to start the worker.
+	b.SetMetaQuotaStore("tenant-test", fake)
+	require.NotNil(t, b.mutationQueue, "SetMetaQuotaStore should start mutation worker")
 
 	b.syncCentralFileCreate(context.Background(), "file-abc", 2048, "image/png")
 

--- a/pkg/backend/quota_async_test.go
+++ b/pkg/backend/quota_async_test.go
@@ -1,7 +1,7 @@
 package backend
 
 import (
-	"sync"
+	"database/sql"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -9,138 +9,86 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnqueueMutation_Async(t *testing.T) {
+// noopMutationEntry returns a mutationEntry whose apply is a counter bump.
+func noopMutationEntry(counter *atomic.Int64) mutationEntry {
+	return mutationEntry{
+		mutationType: "test",
+		payload:      fileCreateMutationData{FileID: "f1"},
+		apply: func(tx *sql.Tx) error {
+			counter.Add(1)
+			return nil
+		},
+	}
+}
+
+func TestEnqueueMutationEntry_Async(t *testing.T) {
 	b := &Dat9Backend{}
 	b.startMutationWorker()
 	defer b.stopMutationWorker()
 
-	var executed atomic.Int64
+	// Without metaStore, processOneMutation short-circuits (no-op).
+	// Verify the entry is dequeued and processed (even if it's a no-op).
+	var enqueued atomic.Int64
 	for i := 0; i < 10; i++ {
-		b.enqueueMutation(func() {
-			executed.Add(1)
-		})
+		entry := mutationEntry{
+			mutationType: "test",
+			payload:      fileCreateMutationData{FileID: "f1"},
+			apply: func(tx *sql.Tx) error {
+				enqueued.Add(1)
+				return nil
+			},
+		}
+		b.mutationQueue <- entry
 	}
 
 	require.Eventually(t, func() bool {
-		return executed.Load() == 10
-	}, 2*time.Second, 10*time.Millisecond)
+		return len(b.mutationQueue) == 0
+	}, 2*time.Second, 10*time.Millisecond, "queue should drain")
 }
 
-func TestEnqueueMutation_InlineFallback(t *testing.T) {
-	// No mutation worker started — should run inline.
+func TestEnqueueMutationEntry_NonBlocking_DropOnFull(t *testing.T) {
 	b := &Dat9Backend{}
-	var executed atomic.Int64
-	b.enqueueMutation(func() {
-		executed.Add(1)
-	})
-	require.Equal(t, int64(1), executed.Load())
+	// Create a tiny queue to easily fill it.
+	b.mutationQueue = make(chan mutationEntry, 2)
+	// Don't start worker — entries stay in queue.
+
+	var counter atomic.Int64
+	// Fill the queue.
+	b.mutationQueue <- noopMutationEntry(&counter)
+	b.mutationQueue <- noopMutationEntry(&counter)
+
+	// Third entry should be dropped (non-blocking).
+	b.enqueueMutationEntry(t.Context(), noopMutationEntry(&counter))
+
+	// Queue should still have exactly 2 entries.
+	require.Equal(t, 2, len(b.mutationQueue))
 }
 
-func TestEnqueueMutation_FIFO_SingleWorker(t *testing.T) {
+func TestEnqueueMutationEntry_InlineFallback(t *testing.T) {
+	// No mutation worker started, no metaStore — should run inline
+	// (processOneMutation short-circuits because metaStore is nil).
 	b := &Dat9Backend{}
-	b.startMutationWorker()
-	defer b.stopMutationWorker()
-
-	// Verify FIFO: record execution order.
-	var order []int
-	done := make(chan struct{})
-	const n = 20
-	for i := 0; i < n; i++ {
-		i := i
-		b.enqueueMutation(func() {
-			order = append(order, i)
-			if len(order) == n {
-				close(done)
-			}
-		})
-	}
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timeout waiting for mutations")
-	}
-
-	for i := 0; i < n; i++ {
-		require.Equal(t, i, order[i], "mutation %d executed out of order", i)
-	}
-}
-
-// TestMutationMu_ConcurrentOrdering verifies that mutationMu serializes
-// concurrent log+enqueue operations so the worker applies mutations in
-// log_id order even when goroutines interleave. Without the mutex,
-// goroutine A could log log_id=1, stall, goroutine B logs log_id=2 and
-// enqueues first, causing the worker to apply log_id=2 before log_id=1.
-func TestMutationMu_ConcurrentOrdering(t *testing.T) {
-	b := &Dat9Backend{}
-	b.startMutationWorker()
-	defer b.stopMutationWorker()
-
-	const n = 100
-	var (
-		resultMu sync.Mutex
-		applied  []int // log_ids in worker apply order
-		nextID   int   // simulates auto-increment log_id
-	)
-	done := make(chan struct{})
-
-	// Simulate concurrent writers: each goroutine acquires mutationMu,
-	// assigns a log_id (simulating InsertMutationLog's auto-increment),
-	// and enqueues — exactly what logAndEnqueueMutation does.
-	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			b.mutationMu.Lock()
-			// Under mutationMu: assign log_id + enqueue are atomic.
-			// This models InsertMutationLog returning sequential IDs.
-			logID := nextID
-			nextID++
-			b.enqueueMutation(func() {
-				resultMu.Lock()
-				applied = append(applied, logID)
-				if len(applied) == n {
-					close(done)
-				}
-				resultMu.Unlock()
-			})
-			b.mutationMu.Unlock()
-		}()
-	}
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timeout waiting for mutations")
-	}
-	wg.Wait()
-
-	// Verify: worker applied mutations in strict log_id order.
-	// Because log_id is assigned inside mutationMu and enqueue happens
-	// before unlock, channel order = log_id order. Single worker
-	// preserves FIFO, so applied[i] must equal i.
-	require.Len(t, applied, n)
-	for i := 0; i < n; i++ {
-		require.Equal(t, i, applied[i],
-			"apply order[%d]=%d, want %d (log_id FIFO violated)",
-			i, applied[i], i)
-	}
+	entry := noopMutationEntry(new(atomic.Int64))
+	// Should not panic.
+	b.enqueueMutationEntry(t.Context(), entry)
 }
 
 func TestStopMutationWorker_DrainsPending(t *testing.T) {
 	b := &Dat9Backend{}
 	b.startMutationWorker()
 
-	var executed atomic.Int64
+	// Push entries directly to channel — they will be processed on drain.
 	for i := 0; i < 50; i++ {
-		b.enqueueMutation(func() {
-			executed.Add(1)
-		})
+		b.mutationQueue <- mutationEntry{
+			mutationType: "test",
+			payload:      fileCreateMutationData{FileID: "f1"},
+			apply:        func(tx *sql.Tx) error { return nil },
+		}
 	}
 
 	b.stopMutationWorker()
-	require.Equal(t, int64(50), executed.Load())
+	// After stop, queue should be nil (drained + cleaned up).
+	require.Nil(t, b.mutationQueue)
 }
 
 func TestStopMutationWorker_Idempotent(t *testing.T) {

--- a/pkg/backend/quota_async_test.go
+++ b/pkg/backend/quota_async_test.go
@@ -28,18 +28,13 @@ func TestEnqueueMutationEntry_Async(t *testing.T) {
 	defer b.stopMutationWorker()
 
 	// Without metaStore, processOneMutation short-circuits (no-op).
-	// Verify the entry is dequeued and processed (even if it's a no-op).
-	var enqueued atomic.Int64
+	// Verify the entry is dequeued (queue drains).
 	for i := 0; i < 10; i++ {
-		entry := mutationEntry{
+		b.mutationQueue <- mutationEntry{
 			mutationType: "test",
 			payload:      fileCreateMutationData{FileID: "f1"},
-			apply: func(tx *sql.Tx) error {
-				enqueued.Add(1)
-				return nil
-			},
+			apply:        func(tx *sql.Tx) error { return nil },
 		}
-		b.mutationQueue <- entry
 	}
 
 	require.Eventually(t, func() bool {
@@ -48,10 +43,13 @@ func TestEnqueueMutationEntry_Async(t *testing.T) {
 }
 
 func TestEnqueueMutationEntry_NonBlocking_DropOnFull(t *testing.T) {
-	b := &Dat9Backend{}
-	// Create a tiny queue to easily fill it.
+	fake := newFakeMetaQuotaStore()
+	b := &Dat9Backend{
+		tenantID:  "tenant-drop",
+		metaStore: fake,
+	}
+	// Create a tiny queue and don't start worker — entries stay in queue.
 	b.mutationQueue = make(chan mutationEntry, 2)
-	// Don't start worker — entries stay in queue.
 
 	var counter atomic.Int64
 	// Fill the queue.
@@ -59,10 +57,24 @@ func TestEnqueueMutationEntry_NonBlocking_DropOnFull(t *testing.T) {
 	b.mutationQueue <- noopMutationEntry(&counter)
 
 	// Third entry should be dropped (non-blocking).
-	b.enqueueMutationEntry(t.Context(), noopMutationEntry(&counter))
+	droppedEntry := mutationEntry{
+		mutationType: "file_create",
+		payload:      fileCreateMutationData{FileID: "dropped-file", SizeBytes: 999},
+		apply: func(tx *sql.Tx) error {
+			return b.metaStore.IncrStorageBytesTx(tx, b.tenantID, 999)
+		},
+	}
+	b.enqueueMutationEntry(t.Context(), droppedEntry)
 
 	// Queue should still have exactly 2 entries.
 	require.Equal(t, 2, len(b.mutationQueue))
+
+	// Verify the dropped entry was NOT logged or applied.
+	require.Len(t, fake.mutations, 0, "dropped entry must not be logged")
+	usage := fake.usage["tenant-drop"]
+	if usage != nil {
+		require.Equal(t, int64(0), usage.StorageBytes, "dropped entry must not be applied")
+	}
 }
 
 func TestEnqueueMutationEntry_InlineFallback(t *testing.T) {
@@ -78,7 +90,6 @@ func TestStopMutationWorker_DrainsPending(t *testing.T) {
 	b := &Dat9Backend{}
 	b.startMutationWorker()
 
-	// Push entries directly to channel — they will be processed on drain.
 	for i := 0; i < 50; i++ {
 		b.mutationQueue <- mutationEntry{
 			mutationType: "test",
@@ -88,7 +99,6 @@ func TestStopMutationWorker_DrainsPending(t *testing.T) {
 	}
 
 	b.stopMutationWorker()
-	// After stop, queue should be nil (drained + cleaned up).
 	require.Nil(t, b.mutationQueue)
 }
 
@@ -128,14 +138,16 @@ func TestProcessOneMutation_LogApplyMark(t *testing.T) {
 	require.True(t, applyCalled.Load(), "apply function should be called")
 
 	// Verify mutation log was inserted and marked applied.
-	fake.mu.Lock()
-	defer fake.mu.Unlock()
+	// Note: mutationStatus locks fake.mu internally, so we must NOT hold
+	// fake.mu when calling it.
 	require.Len(t, fake.mutations, 1, "one mutation log entry expected")
 	require.Equal(t, "file_create", fake.mutations[0].typ)
 	require.Equal(t, "applied", fake.mutationStatus(fake.mutations[0].id))
 
 	// Verify storage bytes were incremented.
+	fake.mu.Lock()
 	usage := fake.usage["tenant-test"]
+	fake.mu.Unlock()
 	require.NotNil(t, usage)
 	require.Equal(t, int64(1024), usage.StorageBytes)
 }
@@ -166,13 +178,46 @@ func TestProcessOneMutation_WorkerDrain(t *testing.T) {
 
 	b.stopMutationWorker()
 
-	fake.mu.Lock()
-	defer fake.mu.Unlock()
 	require.Len(t, fake.mutations, n, "all mutations should be logged")
 	for _, entry := range fake.mutations {
 		require.Equal(t, "applied", fake.mutationStatus(entry.id))
 	}
+	fake.mu.Lock()
 	require.Equal(t, int64(n*100), fake.usage["tenant-test"].StorageBytes)
+	fake.mu.Unlock()
+}
+
+// TestSyncCentralFileCreate_AsyncPath verifies the full production path:
+// syncCentralFileCreate enqueues to the async channel, and the background
+// worker processes it through InsertMutationLog → apply → MarkMutationApplied.
+func TestSyncCentralFileCreate_AsyncPath(t *testing.T) {
+	fake := newFakeMetaQuotaStore()
+	b := &Dat9Backend{
+		tenantID:    "tenant-test",
+		metaStore:   fake,
+		quotaSource: QuotaSourceServer,
+	}
+	b.startMutationWorker()
+
+	b.syncCentralFileCreate(context.Background(), "file-abc", 2048, "image/png")
+
+	b.stopMutationWorker()
+
+	require.Len(t, fake.mutations, 1)
+	require.Equal(t, "file_create", fake.mutations[0].typ)
+	require.Equal(t, "applied", fake.mutationStatus(fake.mutations[0].id))
+
+	fake.mu.Lock()
+	usage := fake.usage["tenant-test"]
+	fm := fake.fileMeta[metaKey("tenant-test", "file-abc")]
+	fake.mu.Unlock()
+
+	require.NotNil(t, usage)
+	require.Equal(t, int64(2048), usage.StorageBytes)
+	require.Equal(t, int64(1), usage.MediaFileCount)
+	require.NotNil(t, fm)
+	require.Equal(t, int64(2048), fm.SizeBytes)
+	require.True(t, fm.IsMedia)
 }
 
 // TestSyncCentralLLMCostRecord_Synchronous verifies that LLM cost records
@@ -193,8 +238,6 @@ func TestSyncCentralLLMCostRecord_Synchronous(t *testing.T) {
 	require.Equal(t, 0, len(b.mutationQueue), "LLM cost should not use async queue")
 
 	// Verify it was logged and applied.
-	fake.mu.Lock()
-	defer fake.mu.Unlock()
 	require.Len(t, fake.mutations, 1)
 	require.Equal(t, "llm_cost_record", fake.mutations[0].typ)
 	require.Equal(t, "applied", fake.mutationStatus(fake.mutations[0].id))

--- a/pkg/backend/quota_mutation.go
+++ b/pkg/backend/quota_mutation.go
@@ -13,9 +13,9 @@ import (
 )
 
 // mutationEntry is the unit of work enqueued to the async mutation channel.
-// It carries enough information for the background worker to perform both the
-// durable log INSERT and the quota-state apply in a single transaction,
-// entirely off the write hot path.
+// Used for storage quota mutations (file create/overwrite) that can tolerate
+// eventual consistency. LLM cost records use processOneMutation directly
+// (synchronous) because they are billable and must not be dropped.
 type mutationEntry struct {
 	mutationType string
 	payload      any            // JSON-serializable mutation data
@@ -71,10 +71,12 @@ func (b *Dat9Backend) enqueueMutationEntry(ctx context.Context, entry mutationEn
 	case b.mutationQueue <- entry:
 		// Enqueued successfully.
 	default:
-		// Queue full — drop. MutationReplayWorker will NOT recover this
-		// entry because it was never logged, but backfill-quota reconciles
-		// from the source-of-truth tenant DB file table. This is acceptable
-		// per @qiffang: "quota没必要非常精准，还是要保证性能最重要".
+		// Queue full — drop. The entry was never logged, so neither
+		// MutationReplayWorker nor automatic reconciliation will recover it.
+		// Quota counters will remain inaccurate until a manual run of the
+		// backfill-quota CLI, which reconciles from the source-of-truth
+		// tenant DB file table. Acceptable for storage quota per product
+		// decision (performance > precision).
 		logger.Warn(ctx, "central_quota_mutation_dropped",
 			zap.String("tenant_id", b.tenantID),
 			zap.String("mutation_type", entry.mutationType))
@@ -83,8 +85,15 @@ func (b *Dat9Backend) enqueueMutationEntry(ctx context.Context, entry mutationEn
 }
 
 // processOneMutation durably logs a mutation and applies its quota-state
-// changes in a single transaction. Called by the background worker (or
-// inline when no worker is wired).
+// changes. Called by the background worker (or inline when no worker is
+// wired).
+//
+// Two-phase approach:
+//  1. INSERT into quota_mutation_log (auto-commit, separate connection).
+//  2. InTx: apply quota state + MarkMutationAppliedTx.
+//
+// If phase 2 fails or crashes, the log entry stays pending and
+// MutationReplayWorker picks it up on its next poll (30s interval).
 func (b *Dat9Backend) processOneMutation(ctx context.Context, entry mutationEntry) {
 	if b.metaStore == nil || b.tenantID == "" {
 		return
@@ -100,42 +109,37 @@ func (b *Dat9Backend) processOneMutation(ctx context.Context, entry mutationEntr
 		return
 	}
 
-	// Single transaction: INSERT log + apply quota state + mark applied.
+	// Phase 1: durable log INSERT (auto-commit, own connection).
+	logID, err := b.metaStore.InsertMutationLog(ctx, &MutationLogView{
+		TenantID:     b.tenantID,
+		MutationType: entry.mutationType,
+		MutationData: data,
+	})
+	if err != nil {
+		logger.Warn(ctx, "central_quota_mutation_log_insert_failed",
+			zap.String("tenant_id", b.tenantID),
+			zap.String("mutation_type", entry.mutationType),
+			zap.Error(err))
+		metrics.RecordOperation("central_quota", entry.mutationType, "log_failed", time.Since(start))
+		return
+	}
+
+	// Phase 2: apply quota state + mark applied in one transaction.
 	if err := b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
-		logID, insErr := insertMutationLogTx(tx, b.metaStore, b.tenantID, entry.mutationType, data)
-		if insErr != nil {
-			return insErr
-		}
 		if err := entry.apply(tx); err != nil {
 			return err
 		}
 		return b.metaStore.MarkMutationAppliedTx(tx, logID)
 	}); err != nil {
-		logger.Warn(ctx, "central_quota_mutation_process_failed",
+		logger.Warn(ctx, "central_quota_mutation_apply_failed",
 			zap.String("tenant_id", b.tenantID),
 			zap.String("mutation_type", entry.mutationType),
+			zap.Int64("log_id", logID),
 			zap.Error(err))
-		metrics.RecordOperation("central_quota", entry.mutationType, "error", time.Since(start))
+		metrics.RecordOperation("central_quota", entry.mutationType, "pending", time.Since(start))
 		return
 	}
 	metrics.RecordOperation("central_quota", entry.mutationType, "ok", time.Since(start))
-}
-
-// insertMutationLogTx inserts a mutation log entry within an existing
-// transaction. This is used by processOneMutation to combine log + apply +
-// mark-applied in a single tx round-trip.
-func insertMutationLogTx(tx *sql.Tx, store MetaQuotaStore, tenantID, mutationType string, data json.RawMessage) (int64, error) {
-	// InsertMutationLog uses its own connection; we need a Tx variant.
-	// For now, call the non-Tx version — it auto-commits the INSERT which
-	// is safe because MarkMutationAppliedTx in the same outer tx will mark
-	// it applied. If the outer tx rolls back, the log entry stays pending
-	// and MutationReplayWorker picks it up — this is the correct recovery
-	// behavior.
-	return store.InsertMutationLog(context.Background(), &MutationLogView{
-		TenantID:     tenantID,
-		MutationType: mutationType,
-		MutationData: data,
-	})
 }
 
 func (b *Dat9Backend) syncCentralFileCreate(ctx context.Context, fileID string, sizeBytes int64, contentType string) {
@@ -215,8 +219,13 @@ func (b *Dat9Backend) syncCentralFileOverwrite(ctx context.Context, fileID strin
 	})
 }
 
+// syncCentralLLMCostRecord logs and applies an LLM cost mutation
+// synchronously. Unlike file create/overwrite, LLM cost records are
+// billable and must not be silently dropped. This is not in the file
+// write hot path (called from image/audio extract workers), so the
+// synchronous overhead is acceptable.
 func (b *Dat9Backend) syncCentralLLMCostRecord(ctx context.Context, taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) {
-	b.enqueueMutationEntry(ctx, mutationEntry{
+	b.processOneMutation(ctx, mutationEntry{
 		mutationType: "llm_cost_record",
 		payload: llmCostMutationData{
 			TaskType:       taskType,

--- a/pkg/backend/quota_mutation.go
+++ b/pkg/backend/quota_mutation.go
@@ -58,7 +58,8 @@ func isQuotaMediaContentType(contentType string) bool {
 
 // enqueueMutationEntry performs a non-blocking send of a mutation entry to the
 // async queue. If the queue is full the entry is dropped and a metric is
-// emitted — the MutationReplayWorker + backfill-quota CLI handle convergence.
+// emitted. Dropped entries are never logged, so MutationReplayWorker cannot
+// recover them — only a manual backfill-quota CLI run reconciles counters.
 // If the queue is not wired (tests without StartMutationWorker), the mutation
 // is executed inline (log + apply).
 func (b *Dat9Backend) enqueueMutationEntry(ctx context.Context, entry mutationEntry) {

--- a/pkg/backend/quota_mutation.go
+++ b/pkg/backend/quota_mutation.go
@@ -12,6 +12,16 @@ import (
 	"go.uber.org/zap"
 )
 
+// mutationEntry is the unit of work enqueued to the async mutation channel.
+// It carries enough information for the background worker to perform both the
+// durable log INSERT and the quota-state apply in a single transaction,
+// entirely off the write hot path.
+type mutationEntry struct {
+	mutationType string
+	payload      any            // JSON-serializable mutation data
+	apply        func(tx *sql.Tx) error // applies quota state changes within a tx
+}
+
 type fileCreateMutationData struct {
 	FileID    string `json:"file_id"`
 	SizeBytes int64  `json:"size_bytes"`
@@ -46,123 +56,118 @@ func isQuotaMediaContentType(contentType string) bool {
 	return strings.HasPrefix(contentType, "image/") || strings.HasPrefix(contentType, "audio/")
 }
 
-// logQuotaMutation durably records a mutation in the central quota_mutation_log.
-// Returns the log ID and true on success, or (0, false) if the mutation could
-// not be logged (caller should treat as fail-open). This is the synchronous
-// half of the split mutation path — it MUST complete before the write/fsync
-// returns success so that MutationReplayWorker can recover the mutation after
-// a crash.
-func (b *Dat9Backend) logQuotaMutation(ctx context.Context, mutationType string, payload any) (int64, bool) {
-	if b.metaStore == nil || b.tenantID == "" {
-		return 0, false
+// enqueueMutationEntry performs a non-blocking send of a mutation entry to the
+// async queue. If the queue is full the entry is dropped and a metric is
+// emitted — the MutationReplayWorker + backfill-quota CLI handle convergence.
+// If the queue is not wired (tests without StartMutationWorker), the mutation
+// is executed inline (log + apply).
+func (b *Dat9Backend) enqueueMutationEntry(ctx context.Context, entry mutationEntry) {
+	if b.mutationQueue == nil {
+		// No async queue — run inline (test/fallback path).
+		b.processOneMutation(ctx, entry)
+		return
 	}
-	data, err := json.Marshal(payload)
+	select {
+	case b.mutationQueue <- entry:
+		// Enqueued successfully.
+	default:
+		// Queue full — drop. MutationReplayWorker will NOT recover this
+		// entry because it was never logged, but backfill-quota reconciles
+		// from the source-of-truth tenant DB file table. This is acceptable
+		// per @qiffang: "quota没必要非常精准，还是要保证性能最重要".
+		logger.Warn(ctx, "central_quota_mutation_dropped",
+			zap.String("tenant_id", b.tenantID),
+			zap.String("mutation_type", entry.mutationType))
+		metrics.RecordOperation("central_quota", entry.mutationType, "dropped", 0)
+	}
+}
+
+// processOneMutation durably logs a mutation and applies its quota-state
+// changes in a single transaction. Called by the background worker (or
+// inline when no worker is wired).
+func (b *Dat9Backend) processOneMutation(ctx context.Context, entry mutationEntry) {
+	if b.metaStore == nil || b.tenantID == "" {
+		return
+	}
+	start := time.Now()
+
+	data, err := json.Marshal(entry.payload)
 	if err != nil {
 		logger.Warn(ctx, "central_quota_mutation_marshal_failed",
 			zap.String("tenant_id", b.tenantID),
-			zap.String("mutation_type", mutationType),
+			zap.String("mutation_type", entry.mutationType),
 			zap.Error(err))
-		return 0, false
+		return
 	}
-	logID, err := b.metaStore.InsertMutationLog(ctx, &MutationLogView{
-		TenantID:     b.tenantID,
-		MutationType: mutationType,
-		MutationData: data,
-	})
-	if err != nil {
-		logger.Warn(ctx, "central_quota_mutation_log_insert_failed",
-			zap.String("tenant_id", b.tenantID),
-			zap.String("mutation_type", mutationType),
-			zap.Error(err))
-		metrics.RecordOperation("central_quota", mutationType, "fail_open", time.Duration(0))
-		return 0, false
-	}
-	return logID, true
-}
 
-// applyQuotaMutation applies a previously-logged mutation and marks it as
-// applied. This is the async-safe half of the split mutation path — if it
-// fails or never runs, MutationReplayWorker picks up the pending log entry.
-func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType string, logID int64, apply func(tx *sql.Tx) error) {
+	// Single transaction: INSERT log + apply quota state + mark applied.
 	if err := b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
-		if err := apply(tx); err != nil {
+		logID, insErr := insertMutationLogTx(tx, b.metaStore, b.tenantID, entry.mutationType, data)
+		if insErr != nil {
+			return insErr
+		}
+		if err := entry.apply(tx); err != nil {
 			return err
 		}
 		return b.metaStore.MarkMutationAppliedTx(tx, logID)
 	}); err != nil {
-		logger.Warn(ctx, "central_quota_mutation_apply_failed",
+		logger.Warn(ctx, "central_quota_mutation_process_failed",
 			zap.String("tenant_id", b.tenantID),
-			zap.String("mutation_type", mutationType),
-			zap.Int64("log_id", logID),
+			zap.String("mutation_type", entry.mutationType),
 			zap.Error(err))
-		metrics.RecordOperation("central_quota", mutationType, "pending", time.Duration(0))
+		metrics.RecordOperation("central_quota", entry.mutationType, "error", time.Since(start))
 		return
 	}
-	metrics.RecordOperation("central_quota", mutationType, "ok", time.Duration(0))
+	metrics.RecordOperation("central_quota", entry.mutationType, "ok", time.Since(start))
 }
 
-// logAndEnqueueMutation atomically logs a mutation and enqueues its apply
-// function under mutationMu. This ensures that within a single backend
-// instance, durable log_id order and channel enqueue order are identical,
-// preventing reordering between concurrent same-tenant writes on this
-// process. The mutex scope is kept minimal: just the log insert (~1ms) +
-// channel send (non-blocking into 256-slot buffer).
-//
-// Cross-instance ordering: in a multi-pod deployment, each pod has its own
-// mutationMu and worker queue. Two pods can apply mutations for the same
-// tenant in different log_id order. This is a pre-existing condition — the
-// the old synchronous log+apply path also had no cross-pod ordering.
-// UpsertFileMetaTx is last-writer-wins; MutationReplayWorker replays
-// pending (unapplied) entries in (tenant_id, id) order, which handles
-// crash recovery. For cross-pod last-writer divergence on file_meta,
-// the backfill-quota tool can be run manually to reconcile.
-func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType string, payload any, apply func(tx *sql.Tx) error) {
-	start := time.Now()
-
-	b.mutationMu.Lock()
-	logID, ok := b.logQuotaMutation(ctx, mutationType, payload)
-	if !ok {
-		b.mutationMu.Unlock()
-		return
-	}
-	b.enqueueMutation(func() {
-		b.applyQuotaMutation(context.Background(), mutationType, logID, apply)
+// insertMutationLogTx inserts a mutation log entry within an existing
+// transaction. This is used by processOneMutation to combine log + apply +
+// mark-applied in a single tx round-trip.
+func insertMutationLogTx(tx *sql.Tx, store MetaQuotaStore, tenantID, mutationType string, data json.RawMessage) (int64, error) {
+	// InsertMutationLog uses its own connection; we need a Tx variant.
+	// For now, call the non-Tx version — it auto-commits the INSERT which
+	// is safe because MarkMutationAppliedTx in the same outer tx will mark
+	// it applied. If the outer tx rolls back, the log entry stays pending
+	// and MutationReplayWorker picks it up — this is the correct recovery
+	// behavior.
+	return store.InsertMutationLog(context.Background(), &MutationLogView{
+		TenantID:     tenantID,
+		MutationType: mutationType,
+		MutationData: data,
 	})
-	b.mutationMu.Unlock()
-
-	logger.InfoBenchTiming(ctx, "central_quota_mutation_sync_timing",
-		zap.String("tenant_id", b.tenantID),
-		zap.String("mutation_type", mutationType),
-		zap.Int64("log_id", logID),
-		zap.Float64("total_ms", backendDurationMs(time.Since(start))))
 }
 
 func (b *Dat9Backend) syncCentralFileCreate(ctx context.Context, fileID string, sizeBytes int64, contentType string) {
 	isMedia := isQuotaMediaContentType(contentType)
-	b.logAndEnqueueMutation(ctx, "file_create", fileCreateMutationData{
-		FileID:    fileID,
-		SizeBytes: sizeBytes,
-		IsMedia:   isMedia,
-	}, func(tx *sql.Tx) error {
-		if err := b.metaStore.UpsertFileMetaTx(tx, &FileMetaView{
-			TenantID:  b.tenantID,
+	b.enqueueMutationEntry(ctx, mutationEntry{
+		mutationType: "file_create",
+		payload: fileCreateMutationData{
 			FileID:    fileID,
 			SizeBytes: sizeBytes,
 			IsMedia:   isMedia,
-		}); err != nil {
-			return err
-		}
-		if sizeBytes != 0 {
-			if err := b.metaStore.IncrStorageBytesTx(tx, b.tenantID, sizeBytes); err != nil {
+		},
+		apply: func(tx *sql.Tx) error {
+			if err := b.metaStore.UpsertFileMetaTx(tx, &FileMetaView{
+				TenantID:  b.tenantID,
+				FileID:    fileID,
+				SizeBytes: sizeBytes,
+				IsMedia:   isMedia,
+			}); err != nil {
 				return err
 			}
-		}
-		if isMedia {
-			if err := b.metaStore.IncrMediaFileCountTx(tx, b.tenantID, 1); err != nil {
-				return err
+			if sizeBytes != 0 {
+				if err := b.metaStore.IncrStorageBytesTx(tx, b.tenantID, sizeBytes); err != nil {
+					return err
+				}
 			}
-		}
-		return nil
+			if isMedia {
+				if err := b.metaStore.IncrMediaFileCountTx(tx, b.tenantID, 1); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 	})
 }
 
@@ -177,53 +182,61 @@ func (b *Dat9Backend) syncCentralFileOverwrite(ctx context.Context, fileID strin
 	case oldIsMedia && !newIsMedia:
 		mediaDelta = -1
 	}
-	b.logAndEnqueueMutation(ctx, "file_overwrite", fileOverwriteMutationData{
-		FileID:       fileID,
-		OldSizeBytes: oldSize,
-		OldIsMedia:   oldIsMedia,
-		NewSizeBytes: newSize,
-		NewIsMedia:   newIsMedia,
-	}, func(tx *sql.Tx) error {
-		if err := b.metaStore.UpsertFileMetaTx(tx, &FileMetaView{
-			TenantID:  b.tenantID,
-			FileID:    fileID,
-			SizeBytes: newSize,
-			IsMedia:   newIsMedia,
-		}); err != nil {
-			return err
-		}
-		if storageDelta != 0 {
-			if err := b.metaStore.IncrStorageBytesTx(tx, b.tenantID, storageDelta); err != nil {
+	b.enqueueMutationEntry(ctx, mutationEntry{
+		mutationType: "file_overwrite",
+		payload: fileOverwriteMutationData{
+			FileID:       fileID,
+			OldSizeBytes: oldSize,
+			OldIsMedia:   oldIsMedia,
+			NewSizeBytes: newSize,
+			NewIsMedia:   newIsMedia,
+		},
+		apply: func(tx *sql.Tx) error {
+			if err := b.metaStore.UpsertFileMetaTx(tx, &FileMetaView{
+				TenantID:  b.tenantID,
+				FileID:    fileID,
+				SizeBytes: newSize,
+				IsMedia:   newIsMedia,
+			}); err != nil {
 				return err
 			}
-		}
-		if mediaDelta != 0 {
-			if err := b.metaStore.IncrMediaFileCountTx(tx, b.tenantID, mediaDelta); err != nil {
-				return err
+			if storageDelta != 0 {
+				if err := b.metaStore.IncrStorageBytesTx(tx, b.tenantID, storageDelta); err != nil {
+					return err
+				}
 			}
-		}
-		return nil
+			if mediaDelta != 0 {
+				if err := b.metaStore.IncrMediaFileCountTx(tx, b.tenantID, mediaDelta); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 	})
 }
 
 func (b *Dat9Backend) syncCentralLLMCostRecord(ctx context.Context, taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) {
-	b.logAndEnqueueMutation(ctx, "llm_cost_record", llmCostMutationData{
-		TaskType:       taskType,
-		TaskID:         taskID,
-		CostMillicents: costMillicents,
-		RawUnits:       rawUnits,
-		RawUnitType:    rawUnitType,
-	}, func(tx *sql.Tx) error {
-		if err := b.metaStore.InsertCentralLLMUsageTx(tx, &LLMUsageView{
-			TenantID:       b.tenantID,
+	b.enqueueMutationEntry(ctx, mutationEntry{
+		mutationType: "llm_cost_record",
+		payload: llmCostMutationData{
 			TaskType:       taskType,
 			TaskID:         taskID,
 			CostMillicents: costMillicents,
 			RawUnits:       rawUnits,
 			RawUnitType:    rawUnitType,
-		}); err != nil {
-			return err
-		}
-		return b.metaStore.IncrMonthlyLLMCostTx(tx, b.tenantID, costMillicents)
+		},
+		apply: func(tx *sql.Tx) error {
+			if err := b.metaStore.InsertCentralLLMUsageTx(tx, &LLMUsageView{
+				TenantID:       b.tenantID,
+				TaskType:       taskType,
+				TaskID:         taskID,
+				CostMillicents: costMillicents,
+				RawUnits:       rawUnits,
+				RawUnitType:    rawUnitType,
+			}); err != nil {
+				return err
+			}
+			return b.metaStore.IncrMonthlyLLMCostTx(tx, b.tenantID, costMillicents)
+		},
 	})
 }


### PR DESCRIPTION
## Summary

Part of #597 (step 1: decouple hot path from central DB)

The write hot path (`syncCentralFileCreate`, `syncCentralFileOverwrite`) previously held `mutationMu` and performed a **synchronous INSERT** into `quota_mutation_log` (~700ms under row lock contention on `tenant_quota_usage`), blocking every file write. This was the root cause of the 263 QPS ceiling in benchmarks (77% of server write latency).

**Changes:**
- **`quota_mutation.go`**: File create/overwrite hot path now does a non-blocking channel send of a `mutationEntry` struct (zero DB operations). New `processOneMutation` performs log INSERT + apply in the background worker (two-phase: log auto-commit, then apply+mark in tx).
- **`quota_async.go`**: Channel type changed from `chan func()` to `chan mutationEntry`. Worker calls `processOneMutation` for each entry.
- **`dat9.go`**: Removed `mutationMu` (no longer needed). Updated channel type.
- **LLM cost records stay synchronous** — `syncCentralLLMCostRecord` calls `processOneMutation` directly (not the async queue). LLM costs are billable and must not be dropped. Not in the file write hot path.
- If the 256-slot channel is full, storage quota entries are **dropped** with a metric. Quota counters remain inaccurate until a manual `backfill-quota` CLI run. Acceptable per product decision (performance > precision for storage quota).

**Follow-up needed (separate PR):**
- Per-tenant delta batching to reduce row lock contention in background worker
- Automated periodic reconciliation (currently manual `backfill-quota` only)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./pkg/backend/...` passes
- [x] Tests verify full log+apply+mark pipeline with fakeMetaQuotaStore
- [x] Test verifies LLM cost bypasses async queue (synchronous)
- [x] Test verifies non-blocking drop when queue is full
- [ ] CI tests pass
- [ ] Deploy to test server and re-run benchmark to verify QPS improvement
- [ ] Monitor `central_quota_mutation_dropped` metric under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)