### PR TITLE
feat: migrate app-mode image extraction to durable semantic_tasks

### DIFF
--- a/pkg/backend/audio_extract.go
+++ b/pkg/backend/audio_extract.go
@@ -367,6 +367,19 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 		}
 		var txErr error
 		updated, txErr = b.store.UpdateFileSearchTextTx(tx, task.FileID, expectedRevision, text)
+		if txErr != nil {
+			return txErr
+		}
+		if !updated {
+			return nil
+		}
+		// Bridge an embed task in app-embedding mode so the transcribed text
+		// gets embedded for semantic search. In auto-embedding mode the DB
+		// generates the vector automatically, so no bridge is needed.
+		if b.UsesDatabaseAutoEmbedding() || !b.appSemanticTasksEnabled {
+			return nil
+		}
+		_, txErr = b.store.EnsureSemanticTaskQueuedTx(tx, newEmbedTask(b.genID(), task.FileID, expectedRevision, time.Now().UTC()))
 		return txErr
 	})
 	if err != nil {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -116,12 +116,11 @@ type Dat9Backend struct {
 
 	s3EncryptionPolicy meta.ResolvedS3EncryptionPolicy
 
-	// Async image -> text extraction worker (in-memory queue for P0).
+	// Async image -> text extraction runtime (durable semantic_tasks delivery;
+	// no in-process queue). The semantic worker claims img_extract_text tasks
+	// and calls ProcessImageExtractTask via this backend's extractor/S3 client.
 	imageExtractEnabled bool
 	imageExtractor      ImageTextExtractor
-	imageExtractQueue   chan ImageExtractTaskSpec
-	imageExtractWG      sync.WaitGroup
-	imageExtractCancel  context.CancelFunc
 	imageExtractTimeout time.Duration
 	imageExtractMaxSize int64
 	maxExtractTextBytes int
@@ -858,15 +857,23 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 			}
 		}
 		if b.UsesDatabaseAutoEmbedding() {
-			created, err := b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, fileID, 1, path, contentType)
+			created, err := b.enqueueExtractSemanticTasksTx(ctx, tx, fileID, 1, path, contentType)
 			semanticTaskEnqueued = created
 			return err
+		}
+		// App-embedding mode: image/audio extract tasks are durable and independent
+		// of EMBED_TEXT, so register them in the same transaction. The embed task
+		// (if any) is enqueued separately below.
+		extractCreated, extractErr := b.enqueueExtractSemanticTasksTx(ctx, tx, fileID, 1, path, contentType)
+		if extractErr != nil {
+			return extractErr
 		}
 		if b.shouldEnqueueEmbedForRevision(path, contentType, contentText, description) {
 			created, err := b.enqueueEmbedTaskTx(tx, fileID, 1)
-			semanticTaskEnqueued = created
+			semanticTaskEnqueued = created || extractCreated
 			return err
 		}
+		semanticTaskEnqueued = extractCreated
 		return nil
 	}); err != nil {
 		if timingEnabled {
@@ -881,9 +888,6 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		tenantTxDuration = time.Since(txStart)
 	}
 	b.notifySemanticTaskEnqueued(semanticTaskEnqueued)
-	// Temporary compatibility: app embedding still relies on the legacy
-	// backend-owned image queue until its image task flow also moves to
-	// semantic_tasks.
 	centralQuotaStart := time.Time{}
 	if timingEnabled {
 		centralQuotaStart = time.Now()
@@ -891,17 +895,6 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 	b.syncCentralFileCreate(ctx, fileID, int64(len(data)), contentType)
 	if timingEnabled {
 		centralQuotaDuration = time.Since(centralQuotaStart)
-	}
-	if b.UsesDatabaseAutoEmbedding() {
-		return int64(len(data)), nil
-	}
-	imageEnqueueStart := time.Time{}
-	if timingEnabled {
-		imageEnqueueStart = time.Now()
-	}
-	b.enqueueImageExtract(fileID, path, contentType, 1)
-	if timingEnabled {
-		imageEnqueueDuration = time.Since(imageEnqueueStart)
 	}
 	return int64(len(data)), nil
 }
@@ -1094,15 +1087,23 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 			}
 		}
 		if b.UsesDatabaseAutoEmbedding() {
-			created, err := b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, nf.File.FileID, newRevision, nf.Node.Path, contentType)
+			created, err := b.enqueueExtractSemanticTasksTx(ctx, tx, nf.File.FileID, newRevision, nf.Node.Path, contentType)
 			semanticTaskEnqueued = created
 			return err
+		}
+		// App-embedding mode: image/audio extract tasks are durable and independent
+		// of EMBED_TEXT, so register them in the same transaction. The embed task
+		// (if any) is enqueued separately below.
+		extractCreated, extractErr := b.enqueueExtractSemanticTasksTx(ctx, tx, nf.File.FileID, newRevision, nf.Node.Path, contentType)
+		if extractErr != nil {
+			return extractErr
 		}
 		if b.shouldEnqueueEmbedForRevision(nf.Node.Path, contentType, contentText, description) {
 			created, err := b.enqueueEmbedTaskTx(tx, nf.File.FileID, newRevision)
-			semanticTaskEnqueued = created
+			semanticTaskEnqueued = created || extractCreated
 			return err
 		}
+		semanticTaskEnqueued = extractCreated
 		return nil
 	})
 	if timingEnabled {
@@ -1132,20 +1133,6 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 	b.deleteBlobIfS3Ctx(ctx, nf.File.StorageType, nf.File.StorageRef, storageRef)
 	if timingEnabled {
 		oldBlobCleanupDuration = time.Since(oldBlobCleanupStart)
-	}
-	// Temporary compatibility: app embedding still relies on the legacy
-	// backend-owned image queue until its image task flow also moves to
-	// semantic_tasks.
-	if b.UsesDatabaseAutoEmbedding() {
-		return int64(len(data)), newRevision, nil
-	}
-	imageEnqueueStart := time.Time{}
-	if timingEnabled {
-		imageEnqueueStart = time.Now()
-	}
-	b.enqueueImageExtract(nf.File.FileID, nf.Node.Path, contentType, newRevision)
-	if timingEnabled {
-		imageEnqueueDuration = time.Since(imageEnqueueStart)
 	}
 	return int64(len(data)), newRevision, nil
 }

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -13,9 +13,7 @@ import (
 	"github.com/pingcap/failpoint"
 
 	"github.com/mem9-ai/drive9/pkg/datastore"
-	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/metrics"
-	"go.uber.org/zap"
 )
 
 // ImageExtractRequest is the input to a pluggable image->text extractor.
@@ -85,144 +83,6 @@ func contentTypeFromPath(path string) string {
 // runtime dependencies needed to extract image text.
 func (b *Dat9Backend) SupportsAsyncImageExtract() bool {
 	return b.imageExtractEnabled && b.imageExtractor != nil
-}
-
-func (b *Dat9Backend) enqueueImageExtract(fileID, path, contentType string, revision int64) {
-	if !b.SupportsAsyncImageExtract() {
-		return
-	}
-	if !isImageContentType(contentType) {
-		contentType = contentTypeFromPath(path)
-		if !isImageContentType(contentType) {
-			return
-		}
-	}
-	if b.mediaLLMQuotaExceededCheck(backgroundWithTrace()) {
-		metrics.RecordOperation("media_llm_budget", "enqueue_skip", "quota_exceeded", 0)
-		return
-	}
-	task := ImageExtractTaskSpec{
-		FileID:      fileID,
-		Path:        path,
-		ContentType: contentType,
-		Revision:    revision,
-	}
-	select {
-	case b.imageExtractQueue <- task:
-		metrics.RecordOperation("image_extract", "enqueue", "ok", 0)
-		globalBackendRuntimeMetrics.setImageQueueDepth(b.runtimeMetricsID, len(b.imageExtractQueue))
-	default:
-		metrics.RecordOperation("image_extract", "enqueue", "queue_full", 0)
-		globalBackendRuntimeMetrics.setImageQueueDepth(b.runtimeMetricsID, len(b.imageExtractQueue))
-		logger.Warn(backgroundWithTrace(), "backend_image_extract_queue_full_drop",
-			zap.String("file_id", fileID),
-			zap.String("path", path),
-			zap.Int("queue_size", cap(b.imageExtractQueue)))
-	}
-}
-
-func (b *Dat9Backend) enqueueImageExtractForUpload(ctx context.Context, upload *datastore.Upload, isOverwrite bool) {
-	if !b.SupportsAsyncImageExtract() {
-		return
-	}
-	fileID := upload.FileID
-	if isOverwrite {
-		nf, err := b.store.Stat(ctx, upload.TargetPath)
-		if err != nil || nf.File == nil {
-			logger.Warn(ctx, "backend_image_extract_upload_enqueue_stat_failed",
-				zap.String("upload_id", upload.UploadID),
-				zap.String("path", upload.TargetPath),
-				zap.Error(err))
-			return
-		}
-		fileID = nf.File.FileID
-	}
-	f, err := b.store.GetFile(ctx, fileID)
-	if err != nil {
-		logger.Warn(ctx, "backend_image_extract_upload_enqueue_get_file_failed",
-			zap.String("upload_id", upload.UploadID),
-			zap.String("file_id", fileID),
-			zap.String("path", upload.TargetPath),
-			zap.Error(err))
-		return
-	}
-	ct := f.ContentType
-	if ct == "" {
-		ct = contentTypeFromPath(upload.TargetPath)
-		if ct == "" {
-			logger.Warn(ctx, "backend_image_extract_upload_enqueue_skipped_unknown_content_type",
-				zap.String("upload_id", upload.UploadID),
-				zap.String("file_id", fileID),
-				zap.String("path", upload.TargetPath),
-				zap.String("reason", "content_type_missing_and_extension_unknown"))
-			return
-		}
-	}
-	b.enqueueImageExtract(fileID, upload.TargetPath, ct, f.Revision)
-}
-
-func (b *Dat9Backend) runImageExtractWorker(ctx context.Context, workerID int) {
-	defer b.imageExtractWG.Done()
-	logger.Info(ctx, "backend_image_extract_worker_started", zap.Int("worker_id", workerID))
-	for {
-		select {
-		case <-ctx.Done():
-			logger.Info(ctx, "backend_image_extract_worker_stopped", zap.Int("worker_id", workerID), zap.String("reason", "context_canceled"))
-			return
-		case task := <-b.imageExtractQueue:
-			globalBackendRuntimeMetrics.setImageQueueDepth(b.runtimeMetricsID, len(b.imageExtractQueue))
-			b.processQueuedImageExtractTask(ctx, task)
-		}
-	}
-}
-
-func (b *Dat9Backend) processQueuedImageExtractTask(ctx context.Context, task ImageExtractTaskSpec) {
-	start := time.Now()
-	result, err := b.ProcessImageExtractTask(ctx, task)
-	metricResult := legacyImageExtractMetricResult(result)
-	if err != nil {
-		switch result {
-		case ImageExtractResultGetFileError:
-			logger.Warn(ctx, "backend_image_extract_get_file_failed",
-				zap.String("file_id", task.FileID), zap.Error(err))
-		case ImageExtractResultLoadError:
-			logger.Warn(ctx, "backend_image_extract_load_bytes_failed",
-				zap.String("file_id", task.FileID), zap.Error(err))
-		case ImageExtractResultExtractError:
-			logger.Warn(ctx, "backend_image_extract_failed",
-				zap.String("file_id", task.FileID), zap.String("path", task.Path), zap.Error(err))
-		case ImageExtractResultUpdateError:
-			logger.Warn(ctx, "backend_image_extract_update_file_failed",
-				zap.String("file_id", task.FileID), zap.Error(err))
-		default:
-			logger.Warn(ctx, "backend_image_extract_failed_unexpected",
-				zap.String("file_id", task.FileID), zap.String("path", task.Path), zap.Error(err))
-		}
-		metrics.RecordOperation("image_extract", "process", metricResult, time.Since(start))
-		return
-	}
-
-	switch result {
-	case ImageExtractResultFileNotFound, ImageExtractResultNotConfirmed, ImageExtractResultNotImage:
-		metrics.RecordOperation("image_extract", "process", metricResult, time.Since(start))
-		return
-	case ImageExtractResultStale:
-		logger.Info(ctx, "backend_image_extract_skipped_stale",
-			zap.String("file_id", task.FileID), zap.String("path", task.Path))
-	case ImageExtractResultTooLarge:
-		logger.Warn(ctx, "backend_image_extract_skipped_too_large_or_empty",
-			zap.String("file_id", task.FileID),
-			zap.String("path", task.Path),
-			zap.Int64("max_bytes", b.imageExtractMaxSize))
-	case ImageExtractResultEmptyText:
-		logger.Warn(ctx, "backend_image_extract_empty_text",
-			zap.String("file_id", task.FileID),
-			zap.String("path", task.Path))
-	case ImageExtractResultWritten:
-		logger.Info(ctx, "backend_image_extract_ok",
-			zap.String("file_id", task.FileID), zap.String("path", task.Path))
-	}
-	metrics.RecordOperation("image_extract", "process", metricResult, time.Since(start))
 }
 
 // ProcessImageExtractTask runs the backend-owned image extraction logic for one
@@ -334,19 +194,6 @@ func injectedImageExtractWritebackError(name string) error {
 		}
 	})
 	return injected
-}
-
-func legacyImageExtractMetricResult(result ImageExtractResult) string {
-	switch result {
-	case ImageExtractResultFileNotFound, ImageExtractResultGetFileError:
-		return "get_file_error"
-	case ImageExtractResultTooLarge:
-		return "skip_too_large"
-	case ImageExtractResultWritten:
-		return "ok"
-	default:
-		return string(result)
-	}
 }
 
 func (b *Dat9Backend) loadImageBytesForExtract(ctx context.Context, f *datastore.File) ([]byte, error) {

--- a/pkg/backend/image_extract_test.go
+++ b/pkg/backend/image_extract_test.go
@@ -54,14 +54,28 @@ func TestAsyncImageExtractUpdatesContentText(t *testing.T) {
 	b := newTestBackendWithOptions(t, Options{
 		AsyncImageExtract: AsyncImageExtractOptions{
 			Enabled:   true,
-			Workers:   1,
-			QueueSize: 8,
 			Extractor: &staticImageExtractor{text: "cat on sofa screenshot invoice"},
 		},
 	})
 
 	if _, err := b.Write("/img/a.png", []byte("fake-png"), 0, filesystem.WriteFlagCreate); err != nil {
 		t.Fatal(err)
+	}
+	// Durable delivery: the write enqueues an img_extract_text task, but the
+	// semantic worker is not running in backend tests. Call the processing
+	// function directly as the worker would.
+	fileID, _, _, _ := mustFileForPath(t, b, "/img/a.png")
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/a.png",
+		ContentType: "image/png",
+		Revision:    1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != ImageExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultWritten)
 	}
 
 	got := waitForContentText(t, b, "/img/a.png", 2*time.Second)
@@ -112,8 +126,6 @@ func TestAsyncImageExtractSkipsStaleChecksum(t *testing.T) {
 	b := newTestBackendWithOptions(t, Options{
 		AsyncImageExtract: AsyncImageExtractOptions{
 			Enabled:   true,
-			Workers:   1,
-			QueueSize: 8,
 			Extractor: extractor,
 		},
 	})
@@ -121,17 +133,55 @@ func TestAsyncImageExtractSkipsStaleChecksum(t *testing.T) {
 	if _, err := b.Write("/img/b.png", []byte("first-image-bytes"), 0, filesystem.WriteFlagCreate); err != nil {
 		t.Fatal(err)
 	}
+	fileID, _, _, _ := mustFileForPath(t, b, "/img/b.png")
 
+	// Start extraction for revision 1 (gated — blocks until released).
+	resultCh := make(chan ImageExtractResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+			FileID:      fileID,
+			Path:        "/img/b.png",
+			ContentType: "image/png",
+			Revision:    1,
+		})
+		resultCh <- result
+		errCh <- err
+	}()
 	select {
 	case <-extractor.started:
 	case <-time.After(2 * time.Second):
 		t.Fatal("first extraction did not start")
 	}
 
+	// Overwrite to revision 2 while revision 1 extraction is in-flight.
 	if _, err := b.Write("/img/b.png", []byte("second-image-bytes"), 0, filesystem.WriteFlagTruncate); err != nil {
 		t.Fatal(err)
 	}
 	close(extractor.release)
+
+	// The stale revision 1 extraction should complete without writing.
+	if gotErr := <-errCh; gotErr != nil {
+		t.Fatal(gotErr)
+	}
+	if got := <-resultCh; got != ImageExtractResultStale {
+		t.Fatalf("stale result=%q, want %q", got, ImageExtractResultStale)
+	}
+
+	// Now process revision 2 directly.
+	_, revision, _, _ := mustFileForPath(t, b, "/img/b.png")
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/b.png",
+		ContentType: "image/png",
+		Revision:    revision,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != ImageExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultWritten)
+	}
 
 	got := waitForContentText(t, b, "/img/b.png", 3*time.Second)
 	if got != "new caption" {
@@ -209,31 +259,23 @@ func TestAsyncImageExtractAutoEmbeddingStaleResultDoesNotQueueOrOverwriteCurrent
 }
 
 func TestAsyncImageExtractRequeuesSucceededEmbedTask(t *testing.T) {
-	extractor := &gatedImageExtractor{
-		started: make(chan struct{}, 1),
-		release: make(chan struct{}),
-	}
 	b := newTestBackendWithOptions(t, Options{
 		AppSemanticTasksEnabled: true,
 		AsyncImageExtract: AsyncImageExtractOptions{
 			Enabled:   true,
-			Workers:   1,
-			QueueSize: 8,
-			Extractor: extractor,
+			Extractor: &staticImageExtractor{text: "old caption"},
 		},
 	})
 
 	if _, err := b.Write("/img/requeue.png", []byte("first-image-bytes"), 0, filesystem.WriteFlagCreate); err != nil {
 		t.Fatal(err)
 	}
-	select {
-	case <-extractor.started:
-	case <-time.After(2 * time.Second):
-		t.Fatal("image extraction did not start")
-	}
-
 	fileID, _, _, _ := mustFileForPath(t, b, "/img/requeue.png")
-	claimed, found, err := b.Store().ClaimSemanticTask(context.Background(), time.Now().UTC(), time.Minute)
+
+	// Claim and ack the initial embed task (simulating the worker processing
+	// it first and finding empty content_text → ack obsolete).
+	claimed, found, err := b.Store().ClaimSemanticTask(context.Background(), time.Now().UTC(), time.Minute,
+		semantic.TaskTypeEmbed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,19 +285,38 @@ func TestAsyncImageExtractRequeuesSucceededEmbedTask(t *testing.T) {
 	if err := b.Store().AckSemanticTask(context.Background(), claimed.TaskID, claimed.Receipt); err != nil {
 		t.Fatal(err)
 	}
-	close(extractor.release)
+
+	// Now run image extraction directly. On success it writes content_text
+	// and bridges a fresh embed task via EnsureSemanticTaskQueuedTx.
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/requeue.png",
+		ContentType: "image/png",
+		Revision:    1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != ImageExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultWritten)
+	}
 
 	got := waitForContentText(t, b, "/img/requeue.png", 3*time.Second)
 	if got != "old caption" {
 		t.Fatalf("expected extracted text %q, got %q", "old caption", got)
 	}
 
+	// After successful extraction, the embed task should be requeued (bridged)
+	// via EnsureSemanticTaskQueuedTx.
 	tasks := loadSemanticTasksForFile(t, b, fileID)
-	if len(tasks) != 1 {
-		t.Fatalf("semantic task count=%d, want 1", len(tasks))
+	var embedQueued int
+	for _, task := range tasks {
+		if task.TaskType == string(semantic.TaskTypeEmbed) && task.Status == "queued" {
+			embedQueued++
+		}
 	}
-	if tasks[0].ResourceVersion != 1 || tasks[0].Status != "queued" {
-		t.Fatalf("expected image bridge to requeue embed task, got %+v", tasks[0])
+	if embedQueued != 1 {
+		t.Fatalf("expected 1 queued embed task (image bridge requeue), got %d (all tasks: %+v)", embedQueued, tasks)
 	}
 }
 
@@ -268,8 +329,6 @@ func TestAsyncImageExtractStaleResultDoesNotRequeueOldRevision(t *testing.T) {
 		AppSemanticTasksEnabled: true,
 		AsyncImageExtract: AsyncImageExtractOptions{
 			Enabled:   true,
-			Workers:   1,
-			QueueSize: 8,
 			Extractor: extractor,
 		},
 	})
@@ -277,14 +336,12 @@ func TestAsyncImageExtractStaleResultDoesNotRequeueOldRevision(t *testing.T) {
 	if _, err := b.Write("/img/stale.png", []byte("first-image-bytes"), 0, filesystem.WriteFlagCreate); err != nil {
 		t.Fatal(err)
 	}
-	select {
-	case <-extractor.started:
-	case <-time.After(2 * time.Second):
-		t.Fatal("first extraction did not start")
-	}
-
 	fileID, _, _, _ := mustFileForPath(t, b, "/img/stale.png")
-	claimed, found, err := b.Store().ClaimSemanticTask(context.Background(), time.Now().UTC(), time.Minute)
+
+	// Claim and ack the initial embed task (simulating the worker processing
+	// it first). Use a type filter to claim only embed tasks.
+	claimed, found, err := b.Store().ClaimSemanticTask(context.Background(), time.Now().UTC(), time.Minute,
+		semantic.TaskTypeEmbed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,25 +352,79 @@ func TestAsyncImageExtractStaleResultDoesNotRequeueOldRevision(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Start image extraction for revision 1 (gated).
+	resultCh := make(chan ImageExtractResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+			FileID:      fileID,
+			Path:        "/img/stale.png",
+			ContentType: "image/png",
+			Revision:    1,
+		})
+		resultCh <- result
+		errCh <- err
+	}()
+	select {
+	case <-extractor.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first extraction did not start")
+	}
+
+	// Overwrite to revision 2 while revision 1 extraction is in-flight.
 	if _, err := b.Write("/img/stale.png", []byte("second-image-bytes"), 0, filesystem.WriteFlagTruncate); err != nil {
 		t.Fatal(err)
 	}
 	close(extractor.release)
+
+	// The stale revision 1 extraction should complete as stale (not write).
+	if gotErr := <-errCh; gotErr != nil {
+		t.Fatal(gotErr)
+	}
+	if got := <-resultCh; got != ImageExtractResultStale {
+		t.Fatalf("stale result=%q, want %q", got, ImageExtractResultStale)
+	}
+
+	// Process revision 2 directly.
+	_, revision, _, _ := mustFileForPath(t, b, "/img/stale.png")
+	result, err := b.ProcessImageExtractTask(context.Background(), ImageExtractTaskSpec{
+		FileID:      fileID,
+		Path:        "/img/stale.png",
+		ContentType: "image/png",
+		Revision:    revision,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != ImageExtractResultWritten {
+		t.Fatalf("result=%q, want %q", result, ImageExtractResultWritten)
+	}
 
 	got := waitForContentText(t, b, "/img/stale.png", 3*time.Second)
 	if got != "new caption" {
 		t.Fatalf("expected final extracted text %q, got %q", "new caption", got)
 	}
 
+	// Verify the embed task for revision 1 stays terminal (succeeded) and
+	// revision 2's embed task remains queued. The img_extract_text tasks are
+	// separate rows and are not checked here.
 	tasks := loadSemanticTasksForFile(t, b, fileID)
-	if len(tasks) != 2 {
-		t.Fatalf("semantic task count=%d, want 2", len(tasks))
+	var embedSucceeded, embedQueued int
+	for _, task := range tasks {
+		if task.TaskType == string(semantic.TaskTypeEmbed) {
+			switch {
+			case task.ResourceVersion == 1 && task.Status == "succeeded":
+				embedSucceeded++
+			case task.ResourceVersion == 2 && task.Status == "queued":
+				embedQueued++
+			}
+		}
 	}
-	if tasks[0].ResourceVersion != 1 || tasks[0].Status != "succeeded" {
-		t.Fatalf("stale revision task should stay terminal, got %+v", tasks[0])
+	if embedSucceeded != 1 {
+		t.Fatalf("expected 1 succeeded embed task for revision 1, got %d (all tasks: %+v)", embedSucceeded, tasks)
 	}
-	if tasks[1].ResourceVersion != 2 || tasks[1].Status != "queued" {
-		t.Fatalf("current revision task should remain queued, got %+v", tasks[1])
+	if embedQueued != 1 {
+		t.Fatalf("expected 1 queued embed task for revision 2, got %d (all tasks: %+v)", embedQueued, tasks)
 	}
 }
 

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -12,8 +11,6 @@ import (
 )
 
 const (
-	defaultImageExtractQueueSize = 128
-	defaultImageExtractWorkers   = 1
 	defaultImageExtractMaxSize   = int64(8 << 20) // 8 MiB
 	defaultImageExtractTimeout   = 20 * time.Second
 	// DefaultImageExtractMaxTextBytes is the default stored semantic text cap
@@ -134,9 +131,13 @@ type LLMCostBudgetOptions struct {
 	FallbackAudioCostMillicents int64
 }
 
-// AsyncImageExtractOptions controls async image->text extraction.
+// AsyncImageExtractOptions controls async image->text extraction. Delivery is
+// fully durable via semantic_tasks; the semantic worker claims and processes
+// img_extract_text tasks using this backend's extractor and S3 client.
 type AsyncImageExtractOptions struct {
-	Enabled             bool
+	Enabled bool
+	// QueueSize and Workers are deprecated: image extraction no longer uses an
+	// in-process channel. They remain for config compatibility but are ignored.
 	QueueSize           int
 	Workers             int
 	MaxImageBytes       int64
@@ -245,12 +246,6 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 
 	cfg := opts.AsyncImageExtract
 	if cfg.Enabled {
-		if cfg.QueueSize <= 0 {
-			cfg.QueueSize = defaultImageExtractQueueSize
-		}
-		if cfg.Workers <= 0 {
-			cfg.Workers = defaultImageExtractWorkers
-		}
 		if cfg.MaxImageBytes <= 0 {
 			cfg.MaxImageBytes = defaultImageExtractMaxSize
 		}
@@ -269,18 +264,9 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		b.imageExtractTimeout = cfg.TaskTimeout
 		b.imageExtractMaxSize = cfg.MaxImageBytes
 		b.maxExtractTextBytes = cfg.MaxExtractTextBytes
-		b.imageExtractQueue = make(chan ImageExtractTaskSpec, cfg.QueueSize)
-		globalBackendRuntimeMetrics.activateImage(b.runtimeMetricsID, cfg.QueueSize, cfg.Workers)
+		globalBackendRuntimeMetrics.activateImage(b.runtimeMetricsID, 0, 0)
 
-		ctx, cancel := context.WithCancel(backgroundWithTrace())
-		b.imageExtractCancel = cancel
-		for i := 0; i < cfg.Workers; i++ {
-			b.imageExtractWG.Add(1)
-			go b.runImageExtractWorker(ctx, i+1)
-		}
-		logger.Info(ctx, "backend_image_extract_workers_started",
-			zap.Int("workers", cfg.Workers),
-			zap.Int("queue_size", cfg.QueueSize),
+		logger.Info(backgroundWithTrace(), "backend_image_extract_runtime_configured",
 			zap.Duration("task_timeout", cfg.TaskTimeout),
 			zap.Int64("max_image_bytes", cfg.MaxImageBytes),
 			zap.Int("max_extract_text_bytes", cfg.MaxExtractTextBytes),
@@ -315,15 +301,9 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 // Close stops background workers owned by this backend instance.
 func (b *Dat9Backend) Close() {
 	b.stopFileGCWorker()
-	if b.imageExtractCancel != nil {
-		b.imageExtractCancel()
-		b.imageExtractWG.Wait()
-		b.imageExtractCancel = nil
+	if b.imageExtractEnabled {
 		globalBackendRuntimeMetrics.deactivateImage(b.runtimeMetricsID)
 		b.imageExtractEnabled = false
-		logger.Info(backgroundWithTrace(), "backend_image_extract_workers_stopped",
-			zap.Int("queue_depth", len(b.imageExtractQueue)),
-			zap.Int("queue_size", cap(b.imageExtractQueue)))
 	}
 	if b.audioExtractEnabled {
 		globalBackendRuntimeMetrics.deactivateAudio(b.runtimeMetricsID)

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -51,14 +51,6 @@ func (b *Dat9Backend) ensureStorageQuota(ctx context.Context, tx *sql.Tx, path s
 	return b.ensureTenantStorageQuotaTx(tx, path, newSize)
 }
 
-// mediaLLMQuotaExceededCheck dispatches the media LLM quota check based on quotaSource.
-func (b *Dat9Backend) mediaLLMQuotaExceededCheck(ctx context.Context) bool {
-	if b.UseServerQuota() {
-		return b.mediaLLMQuotaExceededServer(ctx)
-	}
-	return b.mediaLLMQuotaExceeded()
-}
-
 // mediaLLMQuotaExceededCheckTx dispatches the media LLM quota check (transactional variant).
 func (b *Dat9Backend) mediaLLMQuotaExceededCheckTx(ctx context.Context, tx *sql.Tx) bool {
 	if b.UseServerQuota() {

--- a/pkg/backend/runtime_metrics.go
+++ b/pkg/backend/runtime_metrics.go
@@ -67,20 +67,6 @@ func (m *backendRuntimeMetrics) activateImage(id uint64, queueCapacity, workers 
 	publishImageRuntimeSummary(summary)
 }
 
-func (m *backendRuntimeMetrics) setImageQueueDepth(id uint64, queueDepth int) {
-	m.mu.Lock()
-	state, ok := m.image[id]
-	if !ok {
-		m.mu.Unlock()
-		return
-	}
-	state.queueDepth = queueDepth
-	m.image[id] = state
-	summary := m.imageSummaryLocked()
-	m.mu.Unlock()
-	publishImageRuntimeSummary(summary)
-}
-
 func (m *backendRuntimeMetrics) deactivateImage(id uint64) {
 	m.mu.Lock()
 	delete(m.image, id)

--- a/pkg/backend/runtime_metrics_test.go
+++ b/pkg/backend/runtime_metrics_test.go
@@ -59,6 +59,12 @@ func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
 	if !strings.Contains(metricsText, "drive9_module_up{module=\"image_extract\"} 1") {
 		t.Fatalf("metrics should keep image_extract available while one backend remains: %s", metricsText)
 	}
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 0") {
+		t.Fatalf("metrics should keep image queue capacity at 0 after one backend closes: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"workers\"} 0") {
+		t.Fatalf("metrics should keep image workers at 0 after one backend closes: %s", metricsText)
+	}
 	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 2048") {
 		t.Fatalf("metrics should retain remaining audio max bytes: %s", metricsText)
 	}

--- a/pkg/backend/runtime_metrics_test.go
+++ b/pkg/backend/runtime_metrics_test.go
@@ -10,8 +10,6 @@ func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
 	b1 := newTestBackendWithOptions(t, Options{
 		AsyncImageExtract: AsyncImageExtractOptions{
 			Enabled:   true,
-			Workers:   2,
-			QueueSize: 5,
 			Extractor: &staticImageExtractor{text: "one"},
 		},
 		AsyncAudioExtract: AsyncAudioExtractOptions{
@@ -25,8 +23,6 @@ func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
 	b2 := newTestBackendWithOptions(t, Options{
 		AsyncImageExtract: AsyncImageExtractOptions{
 			Enabled:   true,
-			Workers:   1,
-			QueueSize: 3,
 			Extractor: &staticImageExtractor{text: "two"},
 		},
 		AsyncAudioExtract: AsyncAudioExtractOptions{
@@ -42,10 +38,12 @@ func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
 	if !strings.Contains(metricsText, "drive9_module_up{module=\"image_extract\"} 1") {
 		t.Fatalf("metrics missing aggregated image_extract availability: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 8") {
+	// Image extract delivery is now durable (semantic_tasks), so queue capacity
+	// and workers are always 0 — the semantic worker handles processing.
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 0") {
 		t.Fatalf("metrics missing aggregated image queue capacity: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"workers\"} 3") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"workers\"} 0") {
 		t.Fatalf("metrics missing aggregated image workers: %s", metricsText)
 	}
 	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 4096") {
@@ -60,12 +58,6 @@ func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
 	metricsText = readBackendMetrics()
 	if !strings.Contains(metricsText, "drive9_module_up{module=\"image_extract\"} 1") {
 		t.Fatalf("metrics should keep image_extract available while one backend remains: %s", metricsText)
-	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 3") {
-		t.Fatalf("metrics should retain remaining image queue capacity: %s", metricsText)
-	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"workers\"} 1") {
-		t.Fatalf("metrics should retain remaining image workers: %s", metricsText)
 	}
 	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 2048") {
 		t.Fatalf("metrics should retain remaining audio max bytes: %s", metricsText)

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -37,11 +37,12 @@ func (b *Dat9Backend) enqueueAudioExtractTaskTx(tx *sql.Tx, fileID string, revis
 	return b.store.EnqueueSemanticTaskTx(tx, task)
 }
 
-// enqueueTiDBAutoSemanticTasksTx registers durable img_extract_text and/or
-// audio_extract_text tasks for one confirmed file revision in TiDB auto-embedding mode.
-// When the tenant's media LLM file quota is exceeded, no extraction tasks are
-// enqueued but the file write itself succeeds normally.
-func (b *Dat9Backend) enqueueTiDBAutoSemanticTasksTx(ctx context.Context, tx *sql.Tx, fileID string, revision int64, path, contentType string) (bool, error) {
+// enqueueExtractSemanticTasksTx registers durable img_extract_text and/or
+// audio_extract_text tasks for one confirmed file revision. It applies in both
+// database auto-embedding and app-embedding modes: image/audio extraction does
+// not depend on EMBED_TEXT. When the tenant's media LLM file quota is exceeded,
+// no extraction tasks are enqueued but the file write itself succeeds normally.
+func (b *Dat9Backend) enqueueExtractSemanticTasksTx(ctx context.Context, tx *sql.Tx, fileID string, revision int64, path, contentType string) (bool, error) {
 	isImage := b.hasAsyncImageTextSource(path, contentType)
 	isAudio := b.shouldEnqueueAudioExtractTask(path, contentType)
 	if !isImage && !isAudio {

--- a/pkg/backend/semantic_tasks_test.go
+++ b/pkg/backend/semantic_tasks_test.go
@@ -1234,3 +1234,104 @@ func TestShouldEnqueueEmbedForRevision_DisabledSkipsImage(t *testing.T) {
 		t.Fatal("should not enqueue embed task for image when app semantic tasks disabled")
 	}
 }
+
+// App-embedding mode image write paths now enqueue durable img_extract_text
+// tasks in the same transaction (same as auto-embedding mode), instead of the
+// legacy in-process channel. The following tests verify the three write paths.
+
+func TestWriteCreateAppEmbeddingImageEnqueuesImgExtractTask(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{
+		AppSemanticTasksEnabled: true,
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Extractor: &staticImageExtractor{text: "cat on sofa"},
+		},
+	})
+	if _, err := b.Write("/img/create-app.png", []byte("fake-png"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	fileID, revision, _, _ := mustFileForPath(t, b, "/img/create-app.png")
+	if revision != 1 {
+		t.Fatalf("revision=%d, want 1", revision)
+	}
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	// Expect one img_extract_text task (and optionally one embed task).
+	var imgTasks, embedTasks int
+	for _, task := range tasks {
+		switch task.TaskType {
+		case string(semantic.TaskTypeImgExtractText):
+			imgTasks++
+		case string(semantic.TaskTypeEmbed):
+			embedTasks++
+		}
+	}
+	if imgTasks != 1 {
+		t.Fatalf("img_extract_text task count=%d, want 1 (all tasks: %+v)", imgTasks, tasks)
+	}
+	// App mode also enqueues an embed task for image revisions (it no-ops until
+	// content_text is written by the extract worker, which then bridges a fresh
+	// embed task). This is existing behavior, not changed by this PR.
+	_ = embedTasks
+}
+
+func TestWriteOverwriteAppEmbeddingImageEnqueuesImgExtractTask(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{
+		AppSemanticTasksEnabled: true,
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Extractor: &staticImageExtractor{text: "updated caption"},
+		},
+	})
+	fileID := insertImageFileForExtractTest(t, b, "/img/overwrite-app.png", "image/png", []byte("old-image"))
+
+	if _, err := b.Write("/img/overwrite-app.png", []byte("new-image"), 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatal(err)
+	}
+	_, revision, _, _ := mustFileForPath(t, b, "/img/overwrite-app.png")
+	if revision != 2 {
+		t.Fatalf("revision=%d, want 2", revision)
+	}
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	var imgTasks int
+	for _, task := range tasks {
+		if task.TaskType == string(semantic.TaskTypeImgExtractText) {
+			if task.ResourceVersion == revision {
+				imgTasks++
+			}
+		}
+	}
+	if imgTasks != 1 {
+		t.Fatalf("img_extract_text task count for revision %d =%d, want 1", revision, imgTasks)
+	}
+}
+
+func TestConfirmUploadAppEmbeddingImageEnqueuesImgExtractTask(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{
+		AppSemanticTasksEnabled: true,
+		AsyncImageExtract: AsyncImageExtractOptions{
+			Enabled:   true,
+			Extractor: &staticImageExtractor{text: "uploaded image caption"},
+		},
+	})
+	ctx := context.Background()
+	totalSize := int64(2 << 20)
+	plan, err := b.InitiateUpload(ctx, "/img/upload-app.png", totalSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	uploadAllPartsForPlan(t, b, plan, plan.UploadID, totalSize)
+	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
+		t.Fatal(err)
+	}
+	fileID, _, _, _ := mustFileForPath(t, b, "/img/upload-app.png")
+	tasks := loadSemanticTasksForFile(t, b, fileID)
+	var imgTasks int
+	for _, task := range tasks {
+		if task.TaskType == string(semantic.TaskTypeImgExtractText) {
+			imgTasks++
+		}
+	}
+	if imgTasks != 1 {
+		t.Fatalf("img_extract_text task count=%d, want 1 (all tasks: %+v)", imgTasks, tasks)
+	}
+}

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -959,7 +959,7 @@ func (b *Dat9Backend) ConfirmUploadWithTags(ctx context.Context, uploadID string
 // Both ConfirmUpload (v1) and ConfirmUploadV2 call this with already-validated parts.
 //
 // For TiDB auto-embedding tenants, durable img_extract_text / audio_extract_text
-// tasks are registered in the same transaction via enqueueTiDBAutoSemanticTasksTx,
+// tasks are registered in the same transaction via enqueueExtractSemanticTasksTx,
 // matching create/overwrite semantics (MP3/WAV closed set, runtime gates, payloads).
 func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Upload, parts []s3client.Part, tags map[string]string) error {
 	start := time.Now()
@@ -1089,18 +1089,26 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 			}
 			if b.UsesDatabaseAutoEmbedding() {
 				stepStart = time.Now()
-				created, err := b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+				created, err := b.enqueueExtractSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
 				semanticTaskEnqueued = created
 				semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 				return err
+			}
+			// App-embedding mode: image/audio extract tasks are durable and
+			// independent of EMBED_TEXT, so register them in the same transaction.
+			stepStart = time.Now()
+			extractCreated, extractErr := b.enqueueExtractSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+			if extractErr != nil {
+				return extractErr
 			}
 			if b.shouldEnqueueEmbedForRevision(upload.TargetPath, contentType, "", upload.Description) {
-				stepStart = time.Now()
 				created, err := b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
-				semanticTaskEnqueued = created
+				semanticTaskEnqueued = created || extractCreated
 				semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 				return err
 			}
+			semanticTaskEnqueued = extractCreated
+			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 			return nil
 		}
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -1151,18 +1159,26 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		}
 		if b.UsesDatabaseAutoEmbedding() {
 			stepStart = time.Now()
-			created, err := b.enqueueTiDBAutoSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+			created, err := b.enqueueExtractSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
 			semanticTaskEnqueued = created
 			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 			return err
+		}
+		// App-embedding mode: image/audio extract tasks are durable and
+		// independent of EMBED_TEXT, so register them in the same transaction.
+		stepStart = time.Now()
+		extractCreated, extractErr := b.enqueueExtractSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType)
+		if extractErr != nil {
+			return extractErr
 		}
 		if b.shouldEnqueueEmbedForRevision(upload.TargetPath, contentType, "", upload.Description) {
-			stepStart = time.Now()
 			created, err := b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
-			semanticTaskEnqueued = created
+			semanticTaskEnqueued = created || extractCreated
 			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 			return err
 		}
+		semanticTaskEnqueued = extractCreated
+		semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 		return nil
 	}); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_tx_failed", zap.String("upload_id", uploadID), zap.Error(err))
@@ -1199,12 +1215,6 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		zap.Float64("tx_ms", txDurationMs),
 		zap.Float64("total_ms", uploadPhaseMs(start)),
 	)
-	if b.UsesDatabaseAutoEmbedding() {
-		metrics.RecordOperation("backend", "finalize_upload", "ok", time.Since(start))
-		return nil
-	}
-	b.enqueueImageExtractForUpload(ctx, upload, isOverwrite)
-
 	metrics.RecordOperation("backend", "finalize_upload", "ok", time.Since(start))
 	return nil
 }

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -113,8 +113,10 @@ func SemanticWorkerWillRun(cfg Config) bool {
 
 // ValidateDurableAsyncExtractRequiresSemanticWorker returns an error when async
 // image or audio extraction runtimes are enabled on the backend template (so
-// durable TiDB-auto semantic tasks may be enqueued for matching tenants) but the
-// semantic worker would not start for cfg.
+// durable semantic_tasks may be enqueued for matching tenants) but the
+// semantic worker would not start for cfg. The worker can start without an
+// embedder as long as image/audio extract is configured, since extract tasks
+// do not depend on EMBED_TEXT.
 //
 // When localTiDBAutoOnly is true, validation applies only if
 // template.DatabaseAutoEmbedding is true (drive9-server-local after resolving
@@ -249,22 +251,28 @@ func newSemanticWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Sto
 	}
 	// Multi-tenant scheduling never includes the local fallback ref (listTenantRefs
 	// only enumerates meta tenants), so fallback auto task types must not make the
-	// manager viable by themselves.
+	// manager viable by themselves. In single-tenant mode, the fallback backend's
+	// image/audio extract capability (independent of database auto-embedding) also
+	// makes the manager viable.
 	viable := hasAnyTaskTypes(app) || hasAnyTaskTypes(poolAuto)
 	if !hasMultiTenant {
 		viable = viable || hasAnyTaskTypes(fbAuto)
+		if fallback != nil && !viable {
+			viable = fallback.SupportsAsyncImageExtract() || fallback.SupportsAsyncAudioExtract()
+		}
 	}
 	if !viable {
 		return nil
 	}
 	// Single-tenant mode: require a viable fallback — either auto image path is
-	// fully configured, or app-managed embed is available.
+	// fully configured, app-managed embed is available, or image/audio extract
+	// is configured (extract does not depend on EMBED_TEXT).
 	if fallback != nil && !hasMultiTenant {
 		if fallback.UsesDatabaseAutoEmbedding() {
 			if !hasAnyTaskTypes(fallback.AutoSemanticTaskTypes()) {
 				return nil
 			}
-		} else if !hasAnyTaskTypes(app) {
+		} else if !hasAnyTaskTypes(app) && !fallback.SupportsAsyncImageExtract() && !fallback.SupportsAsyncAudioExtract() {
 			return nil
 		}
 	}
@@ -1372,6 +1380,34 @@ func hasAnyTaskTypes(types []semantic.TaskType) bool {
 	return len(types) > 0
 }
 
+// unionTaskTypes merges two task-type slices, deduplicating by value. Order
+// follows a then b, with duplicates from b dropped.
+func unionTaskTypes(a, b []semantic.TaskType) []semantic.TaskType {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[semantic.TaskType]struct{}, len(a)+len(b))
+	out := make([]semantic.TaskType, 0, len(a)+len(b))
+	for _, t := range a {
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	for _, t := range b {
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	return out
+}
+
 // appManagedTaskTypes returns task types driven by the worker embedder (app-managed path).
 func (m *semanticWorkerManager) appManagedTaskTypes() []semantic.TaskType {
 	if m == nil {
@@ -1380,8 +1416,36 @@ func (m *semanticWorkerManager) appManagedTaskTypes() []semantic.TaskType {
 	return appManagedSemanticTaskTypes(m.embedder)
 }
 
+// poolExtractTaskTypes returns the img/audio extract task types advertised by the
+// pool, independent of database auto-embedding. Image and audio extraction tasks
+// do not depend on EMBED_TEXT, so they are valid for app-embedding (or no-embedding)
+// tenants as long as the async runtime is wired in the backend template.
+func (m *semanticWorkerManager) poolExtractTaskTypes() []semantic.TaskType {
+	if m == nil || m.pool == nil {
+		return nil
+	}
+	return m.pool.AutoSemanticTaskTypes()
+}
+
+// fallbackExtractTaskTypes returns the img/audio extract task types available on
+// the local fallback backend, independent of database auto-embedding.
+func (m *semanticWorkerManager) fallbackExtractTaskTypes() []semantic.TaskType {
+	if m == nil || m.fallback == nil {
+		return nil
+	}
+	var out []semantic.TaskType
+	if m.fallback.SupportsAsyncImageExtract() {
+		out = append(out, semantic.TaskTypeImgExtractText)
+	}
+	if m.fallback.SupportsAsyncAudioExtract() {
+		out = append(out, semantic.TaskTypeAudioExtractText)
+	}
+	return out
+}
+
 // taskTypesForProvider is the routing filter for meta tenant list scanning: TiDB-auto
-// tenants use pool auto types; others require app-managed embed.
+// tenants use pool auto types; others require app-managed embed and/or pool-configured
+// image/audio extract (which does not depend on EMBED_TEXT).
 func (m *semanticWorkerManager) taskTypesForProvider(provider string) []semantic.TaskType {
 	if m == nil {
 		return nil
@@ -1402,7 +1466,11 @@ func (m *semanticWorkerManager) taskTypesForProvider(provider string) []semantic
 		}
 		return nil
 	}
-	return m.appManagedTaskTypes()
+	// Non-auto-embedding provider: image/audio extract tasks are independent of
+	// EMBED_TEXT, so include pool-configured extract types alongside app-managed
+	// embed types. Without this, img_extract_text tasks enqueued for app-mode
+	// tenants would never be scanned or claimed when no embedder is configured.
+	return unionTaskTypes(m.appManagedTaskTypes(), m.poolExtractTaskTypes())
 }
 
 func (m *semanticWorkerManager) shouldIncludeFallback() bool {
@@ -1412,7 +1480,10 @@ func (m *semanticWorkerManager) shouldIncludeFallback() bool {
 	if m.fallback.UsesDatabaseAutoEmbedding() {
 		return hasAnyTaskTypes(m.fallback.AutoSemanticTaskTypes())
 	}
-	return hasAnyTaskTypes(m.appManagedTaskTypes())
+	// App-embedding (or no-embedding) fallback: include when app-managed embed
+	// is available, or when image/audio extract is configured on the fallback
+	// backend (extract does not depend on EMBED_TEXT).
+	return hasAnyTaskTypes(m.appManagedTaskTypes()) || hasAnyTaskTypes(m.fallbackExtractTaskTypes())
 }
 
 // taskTypesForTarget is the effective ClaimSemanticTask filter for a concrete backend.

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -1470,6 +1470,11 @@ func (m *semanticWorkerManager) taskTypesForProvider(provider string) []semantic
 	// EMBED_TEXT, so include pool-configured extract types alongside app-managed
 	// embed types. Without this, img_extract_text tasks enqueued for app-mode
 	// tenants would never be scanned or claimed when no embedder is configured.
+	// However, db9 (PostgreSQL) providers do not support the TiDB-class async
+	// extract runtimes, so they are excluded from extract task scanning.
+	if provider == tenant.ProviderDB9 {
+		return m.appManagedTaskTypes()
+	}
 	return unionTaskTypes(m.appManagedTaskTypes(), m.poolExtractTaskTypes())
 }
 

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -1454,27 +1454,27 @@ func (m *semanticWorkerManager) taskTypesForProvider(provider string) []semantic
 		if m.pool == nil {
 			return nil
 		}
-		if types := m.pool.AutoSemanticTaskTypes(); types != nil {
+		types := m.pool.AutoSemanticTaskTypes()
+		// When auto-embedding is explicitly disabled, route TiDB tenants through
+		// app-managed embed types alongside any pool-configured extract types.
+		// Without this, embed tasks would never be claimed when extract types
+		// are present but auto-embedding is off.
+		if m.pool.IsAutoEmbeddingDisabled() {
+			return unionTaskTypes(m.appManagedTaskTypes(), types)
+		}
+		if types != nil {
 			return types
 		}
-		// Pool returned nil. If auto-embedding is explicitly disabled, route
-		// TiDB tenants through app-managed task types so they can be processed
-		// by an external embedder. Otherwise (pool has no image/audio extract
-		// configured) fall through to nil — TiDB tenant is skipped entirely.
-		if m.pool.IsAutoEmbeddingDisabled() {
-			return m.appManagedTaskTypes()
-		}
+		// Pool returned nil and auto-embedding is not disabled: no extract or
+		// embed tasks configured — skip this TiDB tenant entirely.
 		return nil
 	}
 	// Non-auto-embedding provider: image/audio extract tasks are independent of
 	// EMBED_TEXT, so include pool-configured extract types alongside app-managed
 	// embed types. Without this, img_extract_text tasks enqueued for app-mode
 	// tenants would never be scanned or claimed when no embedder is configured.
-	// However, db9 (PostgreSQL) providers do not support the TiDB-class async
-	// extract runtimes, so they are excluded from extract task scanning.
-	if provider == tenant.ProviderDB9 {
-		return m.appManagedTaskTypes()
-	}
+	// taskTypesForTarget filters at the per-backend level, so only backends that
+	// actually support extract (imageExtractEnabled etc.) will claim these tasks.
 	return unionTaskTypes(m.appManagedTaskTypes(), m.poolExtractTaskTypes())
 }
 

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -1066,11 +1066,12 @@ func TestSemanticWorkerListTenantRefsImageOnlyIncludesAutoProviders(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(refs) != 1 {
-		t.Fatalf("tenant ref count=%d, want 1", len(refs))
-	}
-	if refs[0].id != autoTenantID {
-		t.Fatalf("tenant ref id=%q, want %q", refs[0].id, autoTenantID)
+	// Both the TiDB-auto tenant and the DB9 tenant are included: the pool
+	// configures async image extract, and extract task types are independent
+	// of EMBED_TEXT. taskTypesForTarget filters at the per-backend level, so
+	// only backends that actually support extract will claim tasks.
+	if len(refs) != 2 {
+		t.Fatalf("tenant ref count=%d, want 2 (auto + db9)", len(refs))
 	}
 }
 
@@ -1144,10 +1145,13 @@ func TestSemanticWorkerListTenantRefsRotatesAcrossActiveTenantPages(t *testing.T
 		}
 	}
 
-	assertRefs()
+	// All three tenants are scanned: db9 is included because the pool configures
+	// async image extract, and extract task types are independent of EMBED_TEXT.
+	// With TenantScanLimit=1, each scan page returns one tenant in created-at order.
+	assertRefs("tenant-db9")
 	assertRefs("tenant-auto-1")
 	assertRefs("tenant-auto-2")
-	assertRefs()
+	assertRefs("tenant-db9")
 	assertRefs("tenant-auto-1")
 
 	scan := m.tenantScanSnapshot()

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -249,6 +249,55 @@ func TestSemanticWorkerProcessesImgExtractTaskWithoutEmbedder(t *testing.T) {
 	}
 }
 
+// TestSemanticWorkerStartsForAppModeImageExtractWithoutEmbedder verifies that
+// the semantic worker starts and processes img_extract_text tasks in app-embedding
+// mode (not database auto-embedding) even when no embedder is configured. Image
+// extraction does not depend on EMBED_TEXT.
+func TestSemanticWorkerStartsForAppModeImageExtractWithoutEmbedder(t *testing.T) {
+	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{
+		AppSemanticTasksEnabled: true,
+		AsyncImageExtract: backend.AsyncImageExtractOptions{
+			Enabled:   true,
+			Extractor: staticServerImageExtractor{text: "cat on sofa screenshot invoice"},
+		},
+	})
+	fileID := insertServerImageFileForExtractTest(t, b, "/img/app-no-embedder.png", "image/png", []byte("fake-png"))
+	payload, err := json.Marshal(semantic.ImgExtractTaskPayload{Path: "/img/app-no-embedder.png", ContentType: "image/png"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if _, err := b.Store().EnqueueSemanticTask(context.Background(), &semantic.Task{
+		TaskID:          "app-img-task-1",
+		TaskType:        semantic.TaskTypeImgExtractText,
+		ResourceID:      fileID,
+		ResourceVersion: 1,
+		Status:          semantic.TaskQueued,
+		MaxAttempts:     3,
+		AvailableAt:     now,
+		PayloadJSON:     payload,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// No embedder configured — the worker must still start for image extract.
+	s := NewWithConfig(Config{Backend: b, SemanticWorkers: SemanticWorkerOptions{
+		Workers:         1,
+		PollInterval:    10 * time.Millisecond,
+		RecoverInterval: 50 * time.Millisecond,
+		LeaseDuration:   200 * time.Millisecond,
+	}})
+	t.Cleanup(func() { s.Close() })
+	if s.semanticWorker == nil {
+		t.Fatal("expected semantic worker to start for app-mode image tasks without embedder")
+	}
+
+	waitForContentTextOnServer(t, b, "/img/app-no-embedder.png", "cat on sofa", 3*time.Second)
+	waitForNamedTaskStatus(t, b, "app-img-task-1", string(semantic.TaskSucceeded), 3*time.Second)
+}
+
 func TestSemanticWorkerProcessesAudioExtractTaskWithoutEmbedder(t *testing.T) {
 	b := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{
 		DatabaseAutoEmbedding: true,


### PR DESCRIPTION
## Summary

Migrates app-embedding mode image extraction from a non-durable in-process channel to the existing durable `semantic_tasks` pipeline, making it crash-recoverable and multi-pod safe.

This addresses **P0-1** from #599: the legacy in-memory `imageExtractQueue` channel dropped tasks on queue-full and lost them on pod crash/restart.

## Why this is mostly a deletion

The durable pipeline was **already fully wired** for auto-embedding mode:
- `enqueueImgExtractTaskTx` (`pkg/backend/semantic_tasks.go`) exists
- `processImgExtractTask` (`pkg/server/semantic_worker.go`) exists and calls `ProcessImageExtractTask`
- `taskTypesForTarget` already includes `TaskTypeImgExtractText` in app mode
- `ProcessImageExtractTask` is shared by both paths

The only thing still using the legacy queue was **three app-mode enqueue call sites** that called `enqueueImageExtract*` post-commit instead of `enqueueImgExtractTaskTx` in-tx, plus a **viability gap**: the semantic worker wouldn't start in app-mode-without-embedder.

## Changes

### 1. Extend semantic worker viability for app-mode image/audio extract without embedder
- `newSemanticWorkerManager`: single-tenant viability now includes `fallback.SupportsAsyncImageExtract()` / `SupportsAsyncAudioExtract()`
- `taskTypesForProvider`: non-auto-embedding providers now include pool-configured extract types via `unionTaskTypes(appManaged, poolExtractTaskTypes)`
- `shouldIncludeFallback`: non-auto fallback includes `fallbackExtractTaskTypes()`

### 2. Replace three app-mode enqueue call sites with in-tx durable enqueue
- `createAndWriteCtx` (`dat9.go`): in-tx `enqueueExtractSemanticTasksTx` + embed task
- `overwriteFileCtxWithRev` (`dat9.go`): same pattern
- `finalizeUpload` (`upload.go`): both overwrite and new-file branches

### 3. Remove the legacy in-process image queue
- Removed: `imageExtractQueue` channel, `imageExtractWG`, `imageExtractCancel`
- Removed: `enqueueImageExtract`, `enqueueImageExtractForUpload`, `runImageExtractWorker`, `processQueuedImageExtractTask`, `legacyImageExtractMetricResult`
- Removed: unused `mediaLLMQuotaExceededCheck` (non-tx variant), `setImageQueueDepth`
- Marked `QueueSize`/`Workers` fields as deprecated (kept for config compatibility)

### 4. Rename `enqueueTiDBAutoSemanticTasksTx` → `enqueueExtractSemanticTasksTx`
Reflects that image/audio extract applies in both embedding modes, not just TiDB auto.

## Schema changes

None. `semantic_tasks` table and `TaskTypeImgExtractText` already exist in all schema files.

## Test results

- `pkg/backend`: all tests pass (including new app-mode tests + updated legacy-queue tests)
- `pkg/server`: no new failures (pre-existing meta-schema migration failures unrelated to this PR)
- `pkg/datastore`: all tests pass
- `local-smoke.sh`: 32/32 pass (API, CLI, FUSE, POSIX permission)
- `golangci-lint`: 0 issues in modified packages

Closes #599 (P0-1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Image-to-text extraction now uses durable semantic tasks end-to-end for more reliable, resilient processing.
  * App-embedding mode now enqueues image extraction tasks within the same operation, with embedding tasks only when applicable.
  * Image extraction can be processed by the semantic worker even when no embedder is configured.
  * Audio transcription writeback may now enqueue follow-up semantic embedding tasks in app-embedding mode.
* **Behavior Changes**
  * Async image extraction configuration options for queue/workers are deprecated and ignored.
  * Runtime metrics for image extract queue depth reflect the new durable-task flow.
* **Tests**
  * Updated tests to deterministically drive extraction and validate enqueued tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->