### PR TITLE
feat: leader election via TiDB GET_LOCK for background schedulers

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -244,6 +244,11 @@ func main() {
 			if v := envOr("DRIVE9_LEADER_HEARTBEAT_INTERVAL", ""); v != "" {
 				if d, err := time.ParseDuration(v); err == nil {
 					leaderOpts = append(leaderOpts, leader.WithHeartbeatInterval(d))
+				} else {
+					logger.Warn(context.Background(), "leader_heartbeat_interval_invalid_falling_back_to_default",
+						zap.String("env", "DRIVE9_LEADER_HEARTBEAT_INTERVAL"),
+						zap.String("value", v),
+						zap.Error(err))
 				}
 			}
 			leaderManager = leader.NewManager(store.DB(), leaderOpts...)
@@ -271,33 +276,12 @@ func main() {
 
 		pool.SetMetaStore(store)
 
-		// Gate mutation replay and expiry sweep workers behind leadership.
-		var replayWorker *backend.MutationReplayWorker
-		var expirySweepWorker *backend.ExpirySweepWorker
-		leaderManager.SetCallbacks(
-			func() {
-				replayWorker = backend.StartMutationReplayWorker(tenant.NewMetaQuotaAdapter(store))
-				expirySweepWorker = backend.StartExpirySweepWorker(store)
-			},
-			func() {
-				if replayWorker != nil {
-					replayWorker.Stop()
-					replayWorker = nil
-				}
-				if expirySweepWorker != nil {
-					expirySweepWorker.Stop()
-					expirySweepWorker = nil
-				}
-			},
-		)
-		defer func() {
-			if replayWorker != nil {
-				replayWorker.Stop()
-			}
-			if expirySweepWorker != nil {
-				expirySweepWorker.Stop()
-			}
-		}()
+		// The mutation replay and expiry sweep workers are owned by the server
+		// (started/stopped in its leader-gated startLeaderWorkers/stopLeaderWorkers),
+		// so they follow leadership transitions alongside the other leader-gated
+		// schedulers. main.go no longer registers a competing SetCallbacks pair
+		// (that earlier pair was clobbered by the server's own SetCallbacks and
+		// never fired).
 
 		// TODO: Run ValidateDurableAsyncExtractRequiresSemanticWorker only when this process
 		// can serve tenants that enqueue durable audio_extract_text / img_extract_text

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/buildinfo"
 	"github.com/mem9-ai/drive9/pkg/embedding"
 	"github.com/mem9-ai/drive9/pkg/encrypt"
+	"github.com/mem9-ai/drive9/pkg/leader"
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/s3client"
@@ -205,6 +206,7 @@ func main() {
 	}
 
 	var pool *tenant.Pool
+	var leaderManager *leader.Manager
 	var tokenSecret []byte
 	if tokenHex != "" {
 		tokenSecret, err = hex.DecodeString(tokenHex)
@@ -230,6 +232,24 @@ func main() {
 			die(fmt.Errorf("control-plane db unavailable: %w", err))
 		}
 
+		// Create a leader election manager for gating background schedulers.
+		// When disabled (single-pod), IsLeader always returns true and workers
+		// start immediately. In multi-pod mode, workers start only on the leader.
+		if os.Getenv("DRIVE9_LEADER_DISABLED") == "1" || os.Getenv("DRIVE9_LEADER_DISABLED") == "true" {
+			leaderManager = leader.NewManager(store.DB(), leader.WithDisabled())
+		} else {
+			leaderOpts := []leader.Option{
+				leader.WithLockName(envOr("DRIVE9_LEADER_LOCK_NAME", "drive9:leader")),
+			}
+			if v := envOr("DRIVE9_LEADER_HEARTBEAT_INTERVAL", ""); v != "" {
+				if d, err := time.ParseDuration(v); err == nil {
+					leaderOpts = append(leaderOpts, leader.WithHeartbeatInterval(d))
+				}
+			}
+			leaderManager = leader.NewManager(store.DB(), leaderOpts...)
+		}
+		defer leaderManager.Stop()
+
 		pool = tenant.NewPool(tenant.PoolConfig{
 			S3Dir:                        s3cfg.Dir,
 			PublicURL:                    publicBaseURL(addr),
@@ -245,24 +265,39 @@ func main() {
 			S3EncryptionPolicy:           s3cfg.EncryptionPolicy,
 			BackendOptions:               backendOptions,
 			DisableDatabaseAutoEmbedding: disableDatabaseAutoEmbedding,
+			LeaderChecker:                leaderManager,
 		}, enc)
 		defer pool.Close()
-	}
 
-	if pool != nil {
 		pool.SetMetaStore(store)
 
-		// Start the mutation log replay worker for central quota.
-		replayWorker := backend.StartMutationReplayWorker(tenant.NewMetaQuotaAdapter(store))
-		if replayWorker != nil {
-			defer replayWorker.Stop()
-		}
-
-		// Start the upload reservation expiry sweep worker.
-		expirySweepWorker := backend.StartExpirySweepWorker(store)
-		if expirySweepWorker != nil {
-			defer expirySweepWorker.Stop()
-		}
+		// Gate mutation replay and expiry sweep workers behind leadership.
+		var replayWorker *backend.MutationReplayWorker
+		var expirySweepWorker *backend.ExpirySweepWorker
+		leaderManager.SetCallbacks(
+			func() {
+				replayWorker = backend.StartMutationReplayWorker(tenant.NewMetaQuotaAdapter(store))
+				expirySweepWorker = backend.StartExpirySweepWorker(store)
+			},
+			func() {
+				if replayWorker != nil {
+					replayWorker.Stop()
+					replayWorker = nil
+				}
+				if expirySweepWorker != nil {
+					expirySweepWorker.Stop()
+					expirySweepWorker = nil
+				}
+			},
+		)
+		defer func() {
+			if replayWorker != nil {
+				replayWorker.Stop()
+			}
+			if expirySweepWorker != nil {
+				expirySweepWorker.Stop()
+			}
+		}()
 
 		// TODO: Run ValidateDurableAsyncExtractRequiresSemanticWorker only when this process
 		// can serve tenants that enqueue durable audio_extract_text / img_extract_text
@@ -319,6 +354,7 @@ func main() {
 		TiDBAutoEmbeddingAPIKey:      autoEmbeddingAPIKey,
 		TiDBAutoEmbeddingAPIBase:     autoEmbeddingAPIBase,
 		DisableDatabaseAutoEmbedding: disableDatabaseAutoEmbedding,
+		Leader:                       leaderManager,
 	}).ListenAndServe(addr))
 }
 

--- a/pkg/backend/file_gc_worker.go
+++ b/pkg/backend/file_gc_worker.go
@@ -65,7 +65,21 @@ func (b *Dat9Backend) StartFileGCWorker(opts FileGCWorkerOptions) *FileGCWorker 
 	return w
 }
 
-func (b *Dat9Backend) stopFileGCWorker() {
+// FileGCWorkerRunning reports whether the per-tenant file GC worker is currently
+// active. Intended for leadership-lifecycle tests and diagnostics.
+func (b *Dat9Backend) FileGCWorkerRunning() bool {
+	if b == nil {
+		return false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.fileGCWorker != nil
+}
+
+// StopFileGCWorker stops the per-tenant file GC worker if it is running. Safe
+// to call when no worker is active. Used by the tenant pool's StopAllFileGC
+// (leader-loss path) and the backend's own Close.
+func (b *Dat9Backend) StopFileGCWorker() {
 	b.mu.Lock()
 	w := b.fileGCWorker
 	b.fileGCWorker = nil

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -300,7 +300,7 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 
 // Close stops background workers owned by this backend instance.
 func (b *Dat9Backend) Close() {
-	b.stopFileGCWorker()
+	b.StopFileGCWorker()
 	if b.imageExtractEnabled {
 		globalBackendRuntimeMetrics.deactivateImage(b.runtimeMetricsID)
 		b.imageExtractEnabled = false

--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -1,0 +1,345 @@
+// Package leader provides a TiDB/MySQL GET_LOCK-based leader election mechanism
+// so that background schedulers run only on the leader pod in a multi-pod
+// deployment. The leader holds a named session-level lock on the shared meta
+// database; connection death (pod crash / restart) auto-releases the lock,
+// allowing another pod to acquire it.
+package leader
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"go.uber.org/zap"
+)
+
+const (
+	// defaultLockName is the named lock used for leader election.
+	defaultLockName = "drive9:leader"
+	// defaultHeartbeatInterval is how often the leader verifies it still holds
+	// the lock, and how often non-leaders retry acquisition.
+	defaultHeartbeatInterval = 10 * time.Second
+	// keepAliveSQL keeps the dedicated connection alive between heartbeats,
+	// preventing MySQL wait_timeout from closing it.
+	keepAliveSQL = "SELECT 1"
+	// getLockSQL acquires a named session lock. Timeout 0 means non-blocking:
+	// returns 1 if acquired, 0 if held by another connection.
+	getLockSQL = "SELECT GET_LOCK(?, 0)"
+	// isUsedLockSQL returns the connection ID holding the named lock, or NULL
+	// if no one holds it. Used by the leader to verify it still owns the lock.
+	isUsedLockSQL = "SELECT IS_USED_LOCK(?)"
+	// releaseLockSQL releases the named session lock.
+	releaseLockSQL = "SELECT RELEASE_LOCK(?)"
+)
+
+// LeaderChecker is a minimal interface for callers that only need to query
+// leadership status (e.g. the tenant pool gating per-tenant FileGCWorker).
+type LeaderChecker interface {
+	IsLeader() bool
+}
+
+// Manager acquires and maintains leadership via a TiDB/MySQL named lock.
+// When leadership is gained, OnLead is called; when lost, OnLose is called.
+// If disabled (single-pod mode), IsLeader always returns true and no lock
+// is acquired.
+type Manager struct {
+	db       *sql.DB
+	lockName string
+	interval time.Duration
+	disabled bool
+
+	mu       sync.Mutex
+	isLeader bool
+	onLead   func()
+	onLose   func()
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// Option configures a Manager.
+type Option func(*Manager)
+
+// WithLockName sets the named lock used for election.
+func WithLockName(name string) Option {
+	return func(m *Manager) {
+		if name != "" {
+			m.lockName = name
+		}
+	}
+}
+
+// WithHeartbeatInterval sets the heartbeat / retry interval.
+func WithHeartbeatInterval(d time.Duration) Option {
+	return func(m *Manager) {
+		if d > 0 {
+			m.interval = d
+		}
+	}
+}
+
+// WithDisabled makes the manager always report IsLeader=true without acquiring
+// any lock. Use for single-pod deployments (e.g. drive9-server-local).
+func WithDisabled() Option {
+	return func(m *Manager) {
+		m.disabled = true
+	}
+}
+
+// WithCallbacks sets the leadership-change callbacks. OnLead is called when
+// this pod gains leadership; OnLose is called when it loses leadership.
+// Callbacks are invoked from the heartbeat goroutine and must be non-blocking.
+func WithCallbacks(onLead, onLose func()) Option {
+	return func(m *Manager) {
+		m.onLead = onLead
+		m.onLose = onLose
+	}
+}
+
+// SetCallbacks sets the leadership-change callbacks. OnLead is called when
+// this pod gains leadership; OnLose is called when it loses leadership.
+// Callbacks are invoked from the heartbeat goroutine and must be non-blocking.
+// Must be called before Start.
+func (m *Manager) SetCallbacks(onLead, onLose func()) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.onLead = onLead
+	m.onLose = onLose
+	m.mu.Unlock()
+}
+
+// NewManager creates a leader election manager. db must be a shared database
+// connection (the meta/control-plane DB) visible to all pods. If db is nil,
+// the manager is created in disabled mode (always leader).
+func NewManager(db *sql.DB, opts ...Option) *Manager {
+	m := &Manager{
+		db:       db,
+		lockName: defaultLockName,
+		interval: defaultHeartbeatInterval,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	if db == nil {
+		m.disabled = true
+	}
+	return m
+}
+
+// IsLeader reports whether this pod currently holds leadership. Always true
+// when the manager is disabled.
+func (m *Manager) IsLeader() bool {
+	if m == nil || m.disabled {
+		return true
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.isLeader
+}
+
+// Start begins the leader election heartbeat goroutine. When disabled, it
+// immediately invokes onLead and returns (no goroutine). Safe to call once;
+// calling Start again after Stop is not supported.
+func (m *Manager) Start(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	if m.disabled {
+		m.mu.Lock()
+		m.isLeader = true
+		cb := m.onLead
+		m.mu.Unlock()
+		if cb != nil {
+			cb()
+		}
+		return
+	}
+
+	workerCtx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	m.done = make(chan struct{})
+
+	go m.run(workerCtx, ctx)
+}
+
+// Stop releases leadership (if held) and stops the heartbeat goroutine.
+func (m *Manager) Stop() {
+	if m == nil {
+		return
+	}
+	if m.disabled {
+		m.mu.Lock()
+		m.isLeader = false
+		cb := m.onLose
+		m.mu.Unlock()
+		if cb != nil {
+			cb()
+		}
+		return
+	}
+	if m.cancel != nil {
+		m.cancel()
+	}
+	if m.done != nil {
+		<-m.done
+	}
+}
+
+func (m *Manager) run(workerCtx context.Context, parentCtx context.Context) {
+	defer close(m.done)
+
+	for {
+		select {
+		case <-workerCtx.Done():
+			m.releaseLeadership()
+			return
+		default:
+		}
+
+		acquired, conn, err := m.tryAcquire(workerCtx)
+		if err != nil {
+			logger.Warn(workerCtx, "leader_acquire_failed",
+				zap.String("lock", m.lockName),
+				zap.Error(err))
+			m.sleep(workerCtx, m.interval)
+			continue
+		}
+
+		if acquired {
+			m.gainLeadership()
+			m.holdLeadership(workerCtx, conn)
+			// When holdLeadership returns, we lost the lock or ctx was cancelled.
+			m.loseLeadership()
+			m.releaseConn(conn)
+		} else {
+			// Someone else holds the lock. Release the conn and retry.
+			m.releaseConn(conn)
+			m.sleep(workerCtx, m.interval)
+		}
+
+		select {
+		case <-workerCtx.Done():
+			return
+		default:
+		}
+	}
+}
+
+// tryAcquire attempts a non-blocking GET_LOCK. Returns (true, conn) if the
+// lock was acquired, (false, conn) if someone else holds it. The conn is
+// always returned (even on failure) and must be released by the caller.
+func (m *Manager) tryAcquire(ctx context.Context) (bool, *sql.Conn, error) {
+	conn, err := m.db.Conn(ctx)
+	if err != nil {
+		return false, nil, err
+	}
+	var got sql.NullInt64
+	if err := conn.QueryRowContext(ctx, getLockSQL, m.lockName).Scan(&got); err != nil {
+		_ = conn.Close()
+		return false, nil, err
+	}
+	if !got.Valid || got.Int64 != 1 {
+		return false, conn, nil
+	}
+	return true, conn, nil
+}
+
+// holdLeadership periodically verifies that we still hold the named lock by
+// checking IS_USED_LOCK and keeping the connection alive. Returns when the
+// lock is lost or the context is cancelled.
+func (m *Manager) holdLeadership(ctx context.Context, conn *sql.Conn) {
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Keep the connection alive and verify lock ownership in one round-trip.
+			var ownerID sql.NullInt64
+			if err := conn.QueryRowContext(ctx, isUsedLockSQL, m.lockName).Scan(&ownerID); err != nil {
+				logger.Warn(ctx, "leader_heartbeat_failed",
+					zap.String("lock", m.lockName),
+					zap.Error(err))
+				return
+			}
+			if !ownerID.Valid || ownerID.Int64 == 0 {
+				logger.Info(ctx, "leader_lock_lost",
+					zap.String("lock", m.lockName),
+					zap.String("reason", "is_used_lock_returned_null_or_zero"))
+				return
+			}
+			// Keep the connection alive to prevent wait_timeout from closing it.
+			if _, err := conn.ExecContext(ctx, keepAliveSQL); err != nil {
+				logger.Warn(ctx, "leader_keepalive_failed",
+					zap.String("lock", m.lockName),
+					zap.Error(err))
+				return
+			}
+		}
+	}
+}
+
+func (m *Manager) releaseConn(conn *sql.Conn) {
+	if conn == nil {
+		return
+	}
+	releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var released sql.NullInt64
+	_ = conn.QueryRowContext(releaseCtx, releaseLockSQL, m.lockName).Scan(&released)
+	_ = conn.Close()
+}
+
+func (m *Manager) gainLeadership() {
+	m.mu.Lock()
+	wasLeader := m.isLeader
+	m.isLeader = true
+	cb := m.onLead
+	m.mu.Unlock()
+	if !wasLeader && cb != nil {
+		logger.Info(context.Background(), "leader_gained",
+			zap.String("lock", m.lockName))
+		cb()
+	}
+}
+
+func (m *Manager) loseLeadership() {
+	m.mu.Lock()
+	wasLeader := m.isLeader
+	m.isLeader = false
+	cb := m.onLose
+	m.mu.Unlock()
+	if wasLeader && cb != nil {
+		logger.Info(context.Background(), "leader_lost",
+			zap.String("lock", m.lockName))
+		cb()
+	}
+}
+
+func (m *Manager) releaseLeadership() {
+	// On Stop: if we were leader, fire onLose. The conn cleanup is handled
+	// by the caller (releaseConn is called in run after holdLeadership returns).
+	m.mu.Lock()
+	wasLeader := m.isLeader
+	m.isLeader = false
+	cb := m.onLose
+	m.mu.Unlock()
+	if wasLeader && cb != nil {
+		logger.Info(context.Background(), "leader_released",
+			zap.String("lock", m.lockName))
+		cb()
+	}
+}
+
+func (m *Manager) sleep(ctx context.Context, d time.Duration) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(d):
+	}
+}

--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -32,6 +32,10 @@ const (
 	isUsedLockSQL = "SELECT IS_USED_LOCK(?)"
 	// releaseLockSQL releases the named session lock.
 	releaseLockSQL = "SELECT RELEASE_LOCK(?)"
+	// connectionIDSQL returns the connection ID of the current session. Used to
+	// capture the owning connection ID right after GET_LOCK so holdLeadership can
+	// verify ownership via IS_USED_LOCK (split-brain defense).
+	connectionIDSQL = "SELECT CONNECTION_ID()"
 )
 
 // LeaderChecker is a minimal interface for callers that only need to query
@@ -50,10 +54,11 @@ type Manager struct {
 	interval time.Duration
 	disabled bool
 
-	mu       sync.Mutex
-	isLeader bool
-	onLead   func()
-	onLose   func()
+	mu        sync.Mutex
+	isLeader  bool
+	ownConnID int64 // connection ID of the pinned lock-holding conn; 0 if not held
+	onLead    func()
+	onLose    func()
 
 	cancel context.CancelFunc
 	done   chan struct{}
@@ -91,6 +96,12 @@ func WithDisabled() Option {
 // WithCallbacks sets the leadership-change callbacks. OnLead is called when
 // this pod gains leadership; OnLose is called when it loses leadership.
 // Callbacks are invoked from the heartbeat goroutine and must be non-blocking.
+//
+// WithCallbacks and SetCallbacks are the same mechanism, differing only by when
+// they are applied (construction time vs post-construction). The last callback
+// pair registered before Start wins; callers that need to compose multiple
+// concerns should own a single callback pair (e.g. the server owns all
+// leader-gated worker start/stop) rather than registering competing pairs.
 func WithCallbacks(onLead, onLose func()) Option {
 	return func(m *Manager) {
 		m.onLead = onLead
@@ -101,7 +112,10 @@ func WithCallbacks(onLead, onLose func()) Option {
 // SetCallbacks sets the leadership-change callbacks. OnLead is called when
 // this pod gains leadership; OnLose is called when it loses leadership.
 // Callbacks are invoked from the heartbeat goroutine and must be non-blocking.
-// Must be called before Start.
+// Must be called before Start. Overwrites any callbacks registered via
+// WithCallbacks or a prior SetCallbacks — only one callback pair is active at
+// a time, so callers that need to compose multiple concerns should register a
+// single pair that fans out internally (see the comment on WithCallbacks).
 func (m *Manager) SetCallbacks(onLead, onLose func()) {
 	if m == nil {
 		return
@@ -159,11 +173,11 @@ func (m *Manager) Start(ctx context.Context) {
 		return
 	}
 
-	workerCtx, cancel := context.WithCancel(context.Background())
+	workerCtx, cancel := context.WithCancel(ctx)
 	m.cancel = cancel
 	m.done = make(chan struct{})
 
-	go m.run(workerCtx, ctx)
+	go m.run(workerCtx)
 }
 
 // Stop releases leadership (if held) and stops the heartbeat goroutine.
@@ -189,7 +203,7 @@ func (m *Manager) Stop() {
 	}
 }
 
-func (m *Manager) run(workerCtx context.Context, parentCtx context.Context) {
+func (m *Manager) run(workerCtx context.Context) {
 	defer close(m.done)
 
 	for {
@@ -232,6 +246,10 @@ func (m *Manager) run(workerCtx context.Context, parentCtx context.Context) {
 // tryAcquire attempts a non-blocking GET_LOCK. Returns (true, conn) if the
 // lock was acquired, (false, conn) if someone else holds it. The conn is
 // always returned (even on failure) and must be released by the caller.
+// When acquired, the owning connection ID is captured (via CONNECTION_ID())
+// on the same pinned conn so holdLeadership can verify ownership against
+// IS_USED_LOCK — a split-brain defense in case another session somehow
+// acquired the lock (session reuse, failover, etc.).
 func (m *Manager) tryAcquire(ctx context.Context) (bool, *sql.Conn, error) {
 	conn, err := m.db.Conn(ctx)
 	if err != nil {
@@ -245,13 +263,31 @@ func (m *Manager) tryAcquire(ctx context.Context) (bool, *sql.Conn, error) {
 	if !got.Valid || got.Int64 != 1 {
 		return false, conn, nil
 	}
+	// Capture the owning connection ID on the same pinned conn.
+	var connID int64
+	if err := conn.QueryRowContext(ctx, connectionIDSQL).Scan(&connID); err != nil {
+		_ = conn.Close()
+		return false, nil, err
+	}
+	m.mu.Lock()
+	m.ownConnID = connID
+	m.mu.Unlock()
 	return true, conn, nil
 }
 
 // holdLeadership periodically verifies that we still hold the named lock by
 // checking IS_USED_LOCK and keeping the connection alive. Returns when the
 // lock is lost or the context is cancelled.
+//
+// Ownership check: IS_USED_LOCK returns the connection ID of the current lock
+// holder. We compare it against ownConnID (captured in tryAcquire on the same
+// pinned conn). If they differ, another session now holds the lock (split-brain)
+// and we release leadership. NULL/0 is treated as lost as before.
 func (m *Manager) holdLeadership(ctx context.Context, conn *sql.Conn) {
+	m.mu.Lock()
+	ownConnID := m.ownConnID
+	m.mu.Unlock()
+
 	ticker := time.NewTicker(m.interval)
 	defer ticker.Stop()
 
@@ -272,6 +308,14 @@ func (m *Manager) holdLeadership(ctx context.Context, conn *sql.Conn) {
 				logger.Info(ctx, "leader_lock_lost",
 					zap.String("lock", m.lockName),
 					zap.String("reason", "is_used_lock_returned_null_or_zero"))
+				return
+			}
+			if ownConnID != 0 && ownerID.Int64 != ownConnID {
+				logger.Info(ctx, "leader_lock_lost",
+					zap.String("lock", m.lockName),
+					zap.String("reason", "lock_not_owned_by_this_connection"),
+					zap.Int64("owner_conn_id", ownerID.Int64),
+					zap.Int64("expected_conn_id", ownConnID))
 				return
 			}
 			// Keep the connection alive to prevent wait_timeout from closing it.
@@ -313,6 +357,7 @@ func (m *Manager) loseLeadership() {
 	m.mu.Lock()
 	wasLeader := m.isLeader
 	m.isLeader = false
+	m.ownConnID = 0
 	cb := m.onLose
 	m.mu.Unlock()
 	if wasLeader && cb != nil {
@@ -328,6 +373,7 @@ func (m *Manager) releaseLeadership() {
 	m.mu.Lock()
 	wasLeader := m.isLeader
 	m.isLeader = false
+	m.ownConnID = 0
 	cb := m.onLose
 	m.mu.Unlock()
 	if wasLeader && cb != nil {

--- a/pkg/leader/leader_test.go
+++ b/pkg/leader/leader_test.go
@@ -35,13 +35,18 @@ func TestLeaderNilDBIsDisabled(t *testing.T) {
 	}
 }
 
+func newTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db := testmysql.OpenDB(t, testDSN)
+	// Leader election is connection-scoped (GET_LOCK/IS_USED_LOCK/RELEASE_LOCK)
+	// and does not touch any tables, but reset keeps the package consistent with
+	// the repo's shared-MySQL convention.
+	testmysql.ResetDB(t, db)
+	return db
+}
+
 func TestLeaderAcquireAndLose(t *testing.T) {
-	inst, err := testmysql.Start(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = inst.Close(context.Background()) })
-	db := testmysql.OpenDB(t, inst.DSN)
+	db := newTestDB(t)
 
 	var mu sync.Mutex
 	leadCount := 0
@@ -108,12 +113,7 @@ func TestLeaderAcquireAndLose(t *testing.T) {
 }
 
 func TestLeaderExclusive(t *testing.T) {
-	inst, err := testmysql.Start(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = inst.Close(context.Background()) })
-	db := testmysql.OpenDB(t, inst.DSN)
+	db := newTestDB(t)
 
 	m1 := NewManager(db,
 		WithLockName("drive9:test:exclusive"),
@@ -154,12 +154,7 @@ func TestLeaderCheckerInterface(t *testing.T) {
 
 func TestLeaderDirectDBCheck(t *testing.T) {
 	// Verify the GET_LOCK / RELEASE_LOCK primitives work as expected.
-	inst, err := testmysql.Start(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = inst.Close(context.Background()) })
-	db := testmysql.OpenDB(t, inst.DSN)
+	db := newTestDB(t)
 
 	ctx := context.Background()
 	conn1, err := db.Conn(ctx)
@@ -174,6 +169,19 @@ func TestLeaderDirectDBCheck(t *testing.T) {
 	}
 	if !got.Valid || got.Int64 != 1 {
 		t.Fatalf("GET_LOCK should return 1, got %+v", got)
+	}
+
+	// The owning connection ID should match what IS_USED_LOCK reports.
+	var connID int64
+	if err := conn1.QueryRowContext(ctx, connectionIDSQL).Scan(&connID); err != nil {
+		t.Fatal(err)
+	}
+	var ownerID sql.NullInt64
+	if err := conn1.QueryRowContext(ctx, isUsedLockSQL, "drive9:test:primitive").Scan(&ownerID); err != nil {
+		t.Fatal(err)
+	}
+	if !ownerID.Valid || ownerID.Int64 != connID {
+		t.Fatalf("IS_USED_LOCK owner %d should match CONNECTION_ID() %d", ownerID.Int64, connID)
 	}
 
 	// A second connection should fail to acquire the same lock.
@@ -191,15 +199,6 @@ func TestLeaderDirectDBCheck(t *testing.T) {
 		t.Fatal("second GET_LOCK should not acquire an already-held lock")
 	}
 
-	// IS_USED_LOCK should return a non-zero connection ID.
-	var ownerID sql.NullInt64
-	if err := conn1.QueryRowContext(ctx, isUsedLockSQL, "drive9:test:primitive").Scan(&ownerID); err != nil {
-		t.Fatal(err)
-	}
-	if !ownerID.Valid || ownerID.Int64 == 0 {
-		t.Fatal("IS_USED_LOCK should return the holding connection ID")
-	}
-
 	// Release.
 	var released sql.NullInt64
 	if err := conn1.QueryRowContext(ctx, releaseLockSQL, "drive9:test:primitive").Scan(&released); err != nil {
@@ -207,5 +206,47 @@ func TestLeaderDirectDBCheck(t *testing.T) {
 	}
 	if !released.Valid || released.Int64 != 1 {
 		t.Fatalf("RELEASE_LOCK should return 1, got %+v", released)
+	}
+}
+
+// TestLeaderCtxCancellation verifies that cancelling the parent context passed
+// to Start stops the election loop (the loop now derives workerCtx from ctx
+// rather than context.Background()).
+func TestLeaderCtxCancellation(t *testing.T) {
+	db := newTestDB(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m := NewManager(db,
+		WithLockName("drive9:test:ctx-cancel"),
+		WithHeartbeatInterval(100*time.Millisecond),
+	)
+	m.Start(ctx)
+	t.Cleanup(func() { m.Stop() })
+
+	// Wait for m to become leader.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if m.IsLeader() {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !m.IsLeader() {
+		t.Fatal("m should become leader")
+	}
+
+	// Cancel the parent context; the election loop should exit and the manager
+	// should stop being leader once holdLeadership returns.
+	cancel()
+
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !m.IsLeader() {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if m.IsLeader() {
+		t.Fatal("m should lose leadership after parent context cancellation")
 	}
 }

--- a/pkg/leader/leader_test.go
+++ b/pkg/leader/leader_test.go
@@ -1,0 +1,211 @@
+package leader
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/internal/testmysql"
+)
+
+func TestLeaderDisabledAlwaysLeader(t *testing.T) {
+	var leadCount atomic.Int32
+	m := NewManager(nil, WithDisabled(), WithCallbacks(
+		func() { leadCount.Add(1) },
+		nil,
+	))
+	m.Start(context.Background())
+	t.Cleanup(func() { m.Stop() })
+
+	if !m.IsLeader() {
+		t.Fatal("disabled manager should report IsLeader=true")
+	}
+	if leadCount.Load() != 1 {
+		t.Fatalf("onLead should fire once, got %d", leadCount.Load())
+	}
+}
+
+func TestLeaderNilDBIsDisabled(t *testing.T) {
+	m := NewManager(nil)
+	if !m.IsLeader() {
+		t.Fatal("nil DB should make manager disabled (always leader)")
+	}
+}
+
+func TestLeaderAcquireAndLose(t *testing.T) {
+	inst, err := testmysql.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inst.Close(context.Background()) })
+	db := testmysql.OpenDB(t, inst.DSN)
+
+	var mu sync.Mutex
+	leadCount := 0
+	loseCount := 0
+
+	m1 := NewManager(db,
+		WithLockName("drive9:test:acquire-lose"),
+		WithHeartbeatInterval(100*time.Millisecond),
+		WithCallbacks(
+			func() { mu.Lock(); leadCount++; mu.Unlock() },
+			func() { mu.Lock(); loseCount++; mu.Unlock() },
+		),
+	)
+	m1.Start(context.Background())
+	t.Cleanup(func() { m1.Stop() })
+
+	// Wait for m1 to become leader.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if m1.IsLeader() {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !m1.IsLeader() {
+		t.Fatal("m1 should become leader")
+	}
+
+	// m2 tries to acquire the same lock — should not become leader.
+	m2 := NewManager(db,
+		WithLockName("drive9:test:acquire-lose"),
+		WithHeartbeatInterval(100*time.Millisecond),
+	)
+	m2.Start(context.Background())
+	t.Cleanup(func() { m2.Stop() })
+
+	time.Sleep(300 * time.Millisecond)
+	if m2.IsLeader() {
+		t.Fatal("m2 should not be leader while m1 holds the lock")
+	}
+
+	// Stop m1 — releases the lock. m2 should acquire it.
+	m1.Stop()
+
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if m2.IsLeader() {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !m2.IsLeader() {
+		t.Fatal("m2 should become leader after m1 releases the lock")
+	}
+
+	mu.Lock()
+	if leadCount != 1 {
+		t.Fatalf("m1 onLead should fire once, got %d", leadCount)
+	}
+	if loseCount != 1 {
+		t.Fatalf("m1 onLose should fire once, got %d", loseCount)
+	}
+	mu.Unlock()
+}
+
+func TestLeaderExclusive(t *testing.T) {
+	inst, err := testmysql.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inst.Close(context.Background()) })
+	db := testmysql.OpenDB(t, inst.DSN)
+
+	m1 := NewManager(db,
+		WithLockName("drive9:test:exclusive"),
+		WithHeartbeatInterval(100*time.Millisecond),
+	)
+	m2 := NewManager(db,
+		WithLockName("drive9:test:exclusive"),
+		WithHeartbeatInterval(100*time.Millisecond),
+	)
+	m1.Start(context.Background())
+	m2.Start(context.Background())
+	t.Cleanup(func() { m2.Stop() })
+	t.Cleanup(func() { m1.Stop() })
+
+	// Wait a bit for both to settle.
+	time.Sleep(500 * time.Millisecond)
+
+	// Exactly one should be leader.
+	l1, l2 := m1.IsLeader(), m2.IsLeader()
+	if l1 && l2 {
+		t.Fatal("both managers should not be leader simultaneously")
+	}
+	if !l1 && !l2 {
+		t.Fatal("at least one manager should be leader")
+	}
+}
+
+func TestLeaderCheckerInterface(t *testing.T) {
+	var _ LeaderChecker = (*Manager)(nil)
+
+	// A disabled manager satisfies LeaderChecker and always returns true.
+	m := NewManager(nil, WithDisabled())
+	var checker LeaderChecker = m
+	if !checker.IsLeader() {
+		t.Fatal("LeaderChecker.IsLeader should return true for disabled manager")
+	}
+}
+
+func TestLeaderDirectDBCheck(t *testing.T) {
+	// Verify the GET_LOCK / RELEASE_LOCK primitives work as expected.
+	inst, err := testmysql.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inst.Close(context.Background()) })
+	db := testmysql.OpenDB(t, inst.DSN)
+
+	ctx := context.Background()
+	conn1, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn1.Close() })
+
+	var got sql.NullInt64
+	if err := conn1.QueryRowContext(ctx, getLockSQL, "drive9:test:primitive").Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Valid || got.Int64 != 1 {
+		t.Fatalf("GET_LOCK should return 1, got %+v", got)
+	}
+
+	// A second connection should fail to acquire the same lock.
+	conn2, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn2.Close() })
+
+	var got2 sql.NullInt64
+	if err := conn2.QueryRowContext(ctx, getLockSQL, "drive9:test:primitive").Scan(&got2); err != nil {
+		t.Fatal(err)
+	}
+	if got2.Valid && got2.Int64 == 1 {
+		t.Fatal("second GET_LOCK should not acquire an already-held lock")
+	}
+
+	// IS_USED_LOCK should return a non-zero connection ID.
+	var ownerID sql.NullInt64
+	if err := conn1.QueryRowContext(ctx, isUsedLockSQL, "drive9:test:primitive").Scan(&ownerID); err != nil {
+		t.Fatal(err)
+	}
+	if !ownerID.Valid || ownerID.Int64 == 0 {
+		t.Fatal("IS_USED_LOCK should return the holding connection ID")
+	}
+
+	// Release.
+	var released sql.NullInt64
+	if err := conn1.QueryRowContext(ctx, releaseLockSQL, "drive9:test:primitive").Scan(&released); err != nil {
+		t.Fatal(err)
+	}
+	if !released.Valid || released.Int64 != 1 {
+		t.Fatalf("RELEASE_LOCK should return 1, got %+v", released)
+	}
+}

--- a/pkg/leader/testmain_test.go
+++ b/pkg/leader/testmain_test.go
@@ -1,0 +1,26 @@
+package leader
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/mem9-ai/drive9/internal/testmysql"
+)
+
+var testDSN string
+
+func TestMain(m *testing.M) {
+	inst, err := testmysql.Start(context.Background())
+	if err != nil {
+		log.Fatalf("setup mysql test instance: %v", err)
+	}
+	testDSN = inst.DSN
+
+	code := m.Run()
+	if err := inst.Close(context.Background()); err != nil {
+		log.Printf("teardown mysql test instance: %v", err)
+	}
+	os.Exit(code)
+}

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -1054,18 +1054,6 @@ func (s *Server) enqueueForkConfirmedRefs(ctx context.Context, t *meta.Tenant, s
 	}
 }
 
-func (s *Server) resumeDeletingForkTenants() {
-	ctx := backgroundWithTrace(context.Background())
-	for _, status := range []meta.TenantStatus{meta.TenantDeleting, meta.TenantFailed} {
-		tenants, err := s.meta.ListTenantsByStatus(ctx, status, 1000)
-		if err != nil {
-			logger.Error(ctx, "resume_fork_cleanup_list_failed", zap.String("status", string(status)), zap.Error(err))
-			continue
-		}
-		s.resumeForkCleanup(ctx, tenants)
-	}
-}
-
 func (s *Server) resumeForkCleanup(ctx context.Context, tenants []meta.Tenant) {
 	const maxConcurrentForkCleanup = 4
 	sem := make(chan struct{}, maxConcurrentForkCleanup)

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -565,7 +565,7 @@ func TestResumeProvisioningForkActivatesBranchBackedTenant(t *testing.T) {
 	rt.insertLiveTenant(t, "parent")
 	rt.insertForkTenant(t, "fork-provisioning", meta.TenantProvisioning, "branch-a")
 
-	rt.server.resumeProvisioningTenants()
+	rt.server.resumeProvisioningTenantsWithCtx(context.Background())
 
 	waitForCondition(t, func() bool {
 		got, err := rt.meta.GetTenant(context.Background(), "fork-provisioning")

--- a/pkg/server/leader_lifecycle_test.go
+++ b/pkg/server/leader_lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,24 +17,18 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestLeaderGatedWorkersStartAndStop is a regression for the blocking review
-// finding on PR #601: SetCallbacks was overwrite-only, so the server's
-// onLead/onLose clobbered main.go's mutation-replay / expiry-sweep callbacks and
-// those workers never started. This test proves that, with the server as the
-// single callback owner, ALL leader-gated workers start on leadership gain and
-// stop on leadership loss:
-//   - semantic worker
-//   - object GC worker
-//   - central-quota mutation replay worker
-//   - upload-reservation expiry sweep worker
-//   - per-tenant FileGC worker
-//
-// It uses a disabled leader manager, whose Start invokes onLead synchronously,
-// so the assertions are deterministic.
-func TestLeaderGatedWorkersStartAndStop(t *testing.T) {
-	initServerTenantSchema(t, testDSN)
+var leaderLifecycleMetaStoreDSN = testDSN
 
-	metaStore, err := meta.Open(testDSN)
+// newLeaderLifecycleServer builds a fully-wired server with a disabled leader
+// manager (so onLead fires synchronously in NewWithConfig), an active tenant
+// backend cached in the pool, and the metaStore reset to a clean state. It
+// returns the server, pool, and cached tenant ID so callers can inspect worker
+// state. All resources are registered with t.Cleanup.
+func newLeaderLifecycleServer(t *testing.T) (*Server, *tenant.Pool, string) {
+	t.Helper()
+	initServerTenantSchema(t, leaderLifecycleMetaStoreDSN)
+
+	metaStore, err := meta.Open(leaderLifecycleMetaStoreDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,8 +40,7 @@ func TestLeaderGatedWorkersStartAndStop(t *testing.T) {
 	pool.SetMetaStore(metaStore)
 	t.Cleanup(func() { pool.Close() })
 
-	// Insert an active tenant so a backend is cached (for FileGC coverage).
-	parsed, err := mysql.ParseDSN(testDSN)
+	parsed, err := mysql.ParseDSN(leaderLifecycleMetaStoreDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,9 +81,9 @@ func TestLeaderGatedWorkersStartAndStop(t *testing.T) {
 	}
 
 	leaderMgr := leader.NewManager(nil, leader.WithDisabled(),
-		// The server will overwrite these callbacks with its own onLead/onLose
-		// via SetCallbacks in NewWithConfig; that is exactly the scenario under
-		// test. The disabled manager invokes onLead synchronously inside Start.
+		// The server overwrites these callbacks with its own onLead/onLose via
+		// SetCallbacks in NewWithConfig. The disabled manager invokes onLead
+		// synchronously inside Start.
 		leader.WithCallbacks(func() {}, func() {}),
 	)
 
@@ -115,6 +109,25 @@ func TestLeaderGatedWorkersStartAndStop(t *testing.T) {
 	if _, err := pool.Get(context.Background(), tenantMeta); err != nil {
 		t.Fatal(err)
 	}
+	return srv, pool, tenantID
+}
+
+// TestLeaderGatedWorkersStartAndStop is a regression for the blocking review
+// finding on PR #601: SetCallbacks was overwrite-only, so the server's
+// onLead/onLose clobbered main.go's mutation-replay / expiry-sweep callbacks and
+// those workers never started. This test proves that, with the server as the
+// single callback owner, ALL leader-gated workers start on leadership gain and
+// stop on leadership loss:
+//   - semantic worker
+//   - object GC worker
+//   - central-quota mutation replay worker
+//   - upload-reservation expiry sweep worker
+//   - per-tenant FileGC worker
+//
+// It uses a disabled leader manager, whose Start invokes onLead synchronously,
+// so the assertions are deterministic.
+func TestLeaderGatedWorkersStartAndStop(t *testing.T) {
+	srv, pool, tenantID := newLeaderLifecycleServer(t)
 
 	// NewWithConfig already called leader.Start(), which (disabled) fired
 	// onLead synchronously, so all leader-gated workers should be running.
@@ -173,4 +186,85 @@ func objectGCWorkerRunning(w *objectGCWorker) bool {
 
 func backendOptionsWithFileGC() backend.Options {
 	return backend.Options{AppSemanticTasksEnabled: true}
+}
+
+// TestLeaderGatedWorkersCloseRacesOnLead is a regression for qiffang R3: the
+// leader worker start/stop path must be truly non-overlapping so that Close()
+// (or onLose) racing with a concurrent onLead cannot leave orphan workers
+// running (e.g. start assigns replay/expiry/FileGC/semantic/objectGC after a
+// stop already ran). Because startLeaderWorkers/stopLeaderWorkers now hold
+// leaderWorkerMu for the entire transition, the two are serialized; this test
+// races them in a loop (run with -race to catch the data race on
+// s.replayWorker / s.expirySweepWorker) and asserts that after Close() no
+// leader-gated worker remains running.
+func TestLeaderGatedWorkersCloseRacesOnLead(t *testing.T) {
+	for i := range 50 {
+		srv, pool, tenantID := newLeaderLifecycleServer(t)
+		b := pool.S3Backend(tenantID)
+		if b == nil {
+			t.Fatalf("iter %d: cached backend missing", i)
+		}
+
+		// Race onLead (re-start path) against Close (which stops the leader
+		// manager first, then stopLeaderWorkers). Whichever ordering wins the
+		// leaderWorkerMu, Close must end with everything stopped.
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			srv.onLead() // guarded by leaderWorkersStarted → no-op if already started
+		}()
+		srv.Close()
+		<-done
+
+		if srv.leaderWorkersStarted {
+			t.Fatalf("iter %d: leaderWorkersStarted should be false after Close", i)
+		}
+		if srv.replayWorker != nil || srv.expirySweepWorker != nil {
+			t.Fatalf("iter %d: central-quota worker should be nil after Close", i)
+		}
+		if objectGCWorkerRunning(srv.objectGCWorker) {
+			t.Fatalf("iter %d: object GC worker should be stopped after Close", i)
+		}
+		if srv.semanticWorker != nil && srv.semanticWorker.cancel != nil {
+			t.Fatalf("iter %d: semantic worker should be stopped after Close", i)
+		}
+		if b.FileGCWorkerRunning() {
+			t.Fatalf("iter %d: per-tenant FileGC worker should be stopped after Close", i)
+		}
+	}
+}
+
+// TestLeaderGatedWorkersOnLoseRacesOnLead races onLead against onLose directly
+// (no Close) to confirm the serialized state machine never leaves workers
+// running after a loss, regardless of start/stop interleaving. After the
+// racing pair settles, a final onLose guarantees the stopped state.
+func TestLeaderGatedWorkersOnLoseRacesOnLead(t *testing.T) {
+	for i := range 50 {
+		srv, pool, tenantID := newLeaderLifecycleServer(t)
+		b := pool.S3Backend(tenantID)
+		if b == nil {
+			t.Fatalf("iter %d: cached backend missing", i)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); srv.onLead() }()
+		go func() { defer wg.Done(); srv.onLose() }()
+		wg.Wait()
+		// A final loss guarantees the stopped end state regardless of which
+		// racing call won the leaderWorkerMu first.
+		srv.onLose()
+
+		if srv.leaderWorkersStarted {
+			t.Fatalf("iter %d: leaderWorkersStarted should be false after final onLose", i)
+		}
+		if srv.replayWorker != nil || srv.expirySweepWorker != nil {
+			t.Fatalf("iter %d: central-quota worker should be nil after final onLose", i)
+		}
+		if b.FileGCWorkerRunning() {
+			t.Fatalf("iter %d: per-tenant FileGC worker should be stopped after final onLose", i)
+		}
+		// Clean up the server (no-op stop path) and pool.
+		srv.Close()
+	}
 }

--- a/pkg/server/leader_lifecycle_test.go
+++ b/pkg/server/leader_lifecycle_test.go
@@ -1,0 +1,176 @@
+package server
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/drive9/pkg/backend"
+	"github.com/mem9-ai/drive9/pkg/leader"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+	"github.com/mem9-ai/drive9/pkg/tenant/token"
+	"go.uber.org/zap"
+)
+
+// TestLeaderGatedWorkersStartAndStop is a regression for the blocking review
+// finding on PR #601: SetCallbacks was overwrite-only, so the server's
+// onLead/onLose clobbered main.go's mutation-replay / expiry-sweep callbacks and
+// those workers never started. This test proves that, with the server as the
+// single callback owner, ALL leader-gated workers start on leadership gain and
+// stop on leadership loss:
+//   - semantic worker
+//   - object GC worker
+//   - central-quota mutation replay worker
+//   - upload-reservation expiry sweep worker
+//   - per-tenant FileGC worker
+//
+// It uses a disabled leader manager, whose Start invokes onLead synchronously,
+// so the assertions are deterministic.
+func TestLeaderGatedWorkersStartAndStop(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
+
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	pool := newTestTenantPoolWithBackendOptions(t, backendOptionsWithFileGC())
+	pool.SetMetaStore(metaStore)
+	t.Cleanup(func() { pool.Close() })
+
+	// Insert an active tenant so a backend is cached (for FileGC coverage).
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			if n, err := strconv.Atoi(p); err == nil {
+				port = n
+			}
+		}
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	tenantID := token.NewID()
+	tenantMeta := &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
+		t.Fatal(err)
+	}
+
+	leaderMgr := leader.NewManager(nil, leader.WithDisabled(),
+		// The server will overwrite these callbacks with its own onLead/onLose
+		// via SetCallbacks in NewWithConfig; that is exactly the scenario under
+		// test. The disabled manager invokes onLead synchronously inside Start.
+		leader.WithCallbacks(func() {}, func() {}),
+	)
+
+	prov := &fakeProvisioner{provider: tenant.ProviderDB9}
+	srv := NewWithConfig(Config{
+		Meta:             metaStore,
+		Pool:             pool,
+		Provisioner:      prov,
+		TokenSecret:      []byte("leader-lifecycle-test-secret"),
+		SemanticEmbedder: staticSemanticEmbedder{vec: []float32{0.1, 0.2, 0.3}},
+		SemanticWorkers: SemanticWorkerOptions{
+			Workers:         1,
+			PollInterval:    10 * time.Millisecond,
+			RecoverInterval: 50 * time.Millisecond,
+			LeaseDuration:   200 * time.Millisecond,
+		},
+		Leader: leaderMgr,
+		Logger: zap.NewNop(),
+	})
+	t.Cleanup(func() { srv.Close() })
+
+	// Acquire a backend so a FileGC worker can be started on it by onLead.
+	if _, err := pool.Get(context.Background(), tenantMeta); err != nil {
+		t.Fatal(err)
+	}
+
+	// NewWithConfig already called leader.Start(), which (disabled) fired
+	// onLead synchronously, so all leader-gated workers should be running.
+	if srv.semanticWorker == nil || srv.semanticWorker.cancel == nil {
+		t.Fatal("semantic worker should be started on leadership gain")
+	}
+	if srv.objectGCWorker == nil || !objectGCWorkerRunning(srv.objectGCWorker) {
+		t.Fatal("object GC worker should be started on leadership gain")
+	}
+	if srv.replayWorker == nil {
+		t.Fatal("mutation replay worker should be started on leadership gain")
+	}
+	if srv.expirySweepWorker == nil {
+		t.Fatal("expiry sweep worker should be started on leadership gain")
+	}
+	if !srv.leaderWorkersStarted {
+		t.Fatal("leaderWorkersStarted flag should be true after onLead")
+	}
+	// Per-tenant FileGC: the cached backend should have a running FileGC worker.
+	b := pool.S3Backend(tenantID)
+	if b == nil {
+		t.Fatal("cached backend should exist for the tenant")
+	}
+	if !b.FileGCWorkerRunning() {
+		t.Fatal("per-tenant FileGC worker should be started on leadership gain")
+	}
+
+	// Simulate leadership loss. onLose should stop ALL leader-gated workers.
+	srv.onLose()
+
+	if srv.leaderWorkersStarted {
+		t.Fatal("leaderWorkersStarted flag should be false after onLose")
+	}
+	if srv.replayWorker != nil {
+		t.Fatal("mutation replay worker should be nil after onLose")
+	}
+	if srv.expirySweepWorker != nil {
+		t.Fatal("expiry sweep worker should be nil after onLose")
+	}
+	if srv.semanticWorker != nil && srv.semanticWorker.cancel != nil {
+		t.Fatal("semantic worker should be stopped after onLose")
+	}
+	if b.FileGCWorkerRunning() {
+		t.Fatal("per-tenant FileGC worker should be stopped after onLose")
+	}
+}
+
+func objectGCWorkerRunning(w *objectGCWorker) bool {
+	if w == nil {
+		return false
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.stop != nil
+}
+
+func backendOptionsWithFileGC() backend.Options {
+	return backend.Options{AppSemanticTasksEnabled: true}
+}

--- a/pkg/server/leader_lifecycle_test.go
+++ b/pkg/server/leader_lifecycle_test.go
@@ -17,8 +17,6 @@ import (
 	"go.uber.org/zap"
 )
 
-var leaderLifecycleMetaStoreDSN = testDSN
-
 // newLeaderLifecycleServer builds a fully-wired server with a disabled leader
 // manager (so onLead fires synchronously in NewWithConfig), an active tenant
 // backend cached in the pool, and the metaStore reset to a clean state. It
@@ -26,9 +24,9 @@ var leaderLifecycleMetaStoreDSN = testDSN
 // state. All resources are registered with t.Cleanup.
 func newLeaderLifecycleServer(t *testing.T) (*Server, *tenant.Pool, string) {
 	t.Helper()
-	initServerTenantSchema(t, leaderLifecycleMetaStoreDSN)
+	initServerTenantSchema(t, testDSN)
 
-	metaStore, err := meta.Open(leaderLifecycleMetaStoreDSN)
+	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +38,7 @@ func newLeaderLifecycleServer(t *testing.T) (*Server, *tenant.Pool, string) {
 	pool.SetMetaStore(metaStore)
 	t.Cleanup(func() { pool.Close() })
 
-	parsed, err := mysql.ParseDSN(leaderLifecycleMetaStoreDSN)
+	parsed, err := mysql.ParseDSN(testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/leader_lifecycle_test.go
+++ b/pkg/server/leader_lifecycle_test.go
@@ -24,6 +24,36 @@ import (
 // state. All resources are registered with t.Cleanup.
 func newLeaderLifecycleServer(t *testing.T) (*Server, *tenant.Pool, string) {
 	t.Helper()
+	leaderMgr := leader.NewManager(nil, leader.WithDisabled(),
+		// The server overwrites these callbacks with its own onLead/onLose via
+		// SetCallbacks in NewWithConfig. The disabled manager invokes onLead
+		// synchronously inside Start.
+		leader.WithCallbacks(func() {}, func() {}),
+	)
+	return newLeaderLifecycleServerWithLeader(t, leaderMgr)
+}
+
+// newLeaderLifecycleServerWithRealLeader is like newLeaderLifecycleServer but
+// uses a real (non-disabled) leader manager backed by the shared MySQL so the
+// heartbeat goroutine drives onLead/onLose naturally. heartbeat controls the
+// acquisition/verification interval. A unique lock name isolates this manager
+// from other tests.
+func newLeaderLifecycleServerWithRealLeader(t *testing.T, heartbeat time.Duration) (*Server, *tenant.Pool, string) {
+	t.Helper()
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	leaderMgr := leader.NewManager(metaStore.DB(),
+		leader.WithLockName("drive9:test:server-lifecycle:"+token.NewID()),
+		leader.WithHeartbeatInterval(heartbeat),
+	)
+	return newLeaderLifecycleServerWithLeader(t, leaderMgr)
+}
+
+func newLeaderLifecycleServerWithLeader(t *testing.T, leaderMgr *leader.Manager) (*Server, *tenant.Pool, string) {
+	t.Helper()
 	initServerTenantSchema(t, testDSN)
 
 	metaStore, err := meta.Open(testDSN)
@@ -77,13 +107,6 @@ func newLeaderLifecycleServer(t *testing.T) (*Server, *tenant.Pool, string) {
 	if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
 		t.Fatal(err)
 	}
-
-	leaderMgr := leader.NewManager(nil, leader.WithDisabled(),
-		// The server overwrites these callbacks with its own onLead/onLose via
-		// SetCallbacks in NewWithConfig. The disabled manager invokes onLead
-		// synchronously inside Start.
-		leader.WithCallbacks(func() {}, func() {}),
-	)
 
 	prov := &fakeProvisioner{provider: tenant.ProviderDB9}
 	srv := NewWithConfig(Config{
@@ -182,37 +205,50 @@ func objectGCWorkerRunning(w *objectGCWorker) bool {
 	return w.stop != nil
 }
 
+// waitForLeaderOrTimeout polls srv.leader.IsLeader() until it reports true or
+// the timeout elapses. A non-leader result at timeout is not fatal — the race
+// test only needs the heartbeat loop running so onLead can overlap with Close;
+// leadership gain is the common case but not required for the test to be valid.
+func waitForLeaderOrTimeout(t *testing.T, srv *Server, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if srv.leader != nil && srv.leader.IsLeader() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func backendOptionsWithFileGC() backend.Options {
 	return backend.Options{AppSemanticTasksEnabled: true}
 }
 
-// TestLeaderGatedWorkersCloseRacesOnLead is a regression for qiffang R3: the
-// leader worker start/stop path must be truly non-overlapping so that Close()
-// (or onLose) racing with a concurrent onLead cannot leave orphan workers
-// running (e.g. start assigns replay/expiry/FileGC/semantic/objectGC after a
-// stop already ran). Because startLeaderWorkers/stopLeaderWorkers now hold
-// leaderWorkerMu for the entire transition, the two are serialized; this test
-// races them in a loop (run with -race to catch the data race on
-// s.replayWorker / s.expirySweepWorker) and asserts that after Close() no
-// leader-gated worker remains running.
+// TestLeaderGatedWorkersCloseRacesOnLead is a regression for qiffang R3: a
+// leader manager heartbeat goroutine may be inside onLead (calling
+// startLeaderWorkers) when Close() runs. Close() must stop the leader manager
+// first — leader.Stop() waits for the heartbeat goroutine to exit, so no
+// onLead can outlive it — then stopLeaderWorkers tears down whatever workers
+// the in-flight onLead started (the onLead's onLose from the cancelled loop, or
+// the local stopLeaderWorkers, stops them). After Close() returns no
+// leader-gated worker may remain running.
+//
+// This uses a real (non-disabled) leader manager against the shared MySQL so
+// the heartbeat goroutine naturally drives onLead; with a short heartbeat the
+// loop maximizes the chance that onLead is in progress when Close() runs (run
+// with -race to catch a data race on s.replayWorker / s.expirySweepWorker).
 func TestLeaderGatedWorkersCloseRacesOnLead(t *testing.T) {
-	for i := range 50 {
-		srv, pool, tenantID := newLeaderLifecycleServer(t)
+	for i := range 25 {
+		srv, pool, tenantID := newLeaderLifecycleServerWithRealLeader(t, 20*time.Millisecond)
 		b := pool.S3Backend(tenantID)
 		if b == nil {
 			t.Fatalf("iter %d: cached backend missing", i)
 		}
 
-		// Race onLead (re-start path) against Close (which stops the leader
-		// manager first, then stopLeaderWorkers). Whichever ordering wins the
-		// leaderWorkerMu, Close must end with everything stopped.
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			srv.onLead() // guarded by leaderWorkersStarted → no-op if already started
-		}()
+		// Give the heartbeat a chance to gain leadership (onLead starts workers),
+		// then close while the loop is still running — racing onLead with Close.
+		waitForLeaderOrTimeout(t, srv, 2*time.Second)
 		srv.Close()
-		<-done
 
 		if srv.leaderWorkersStarted {
 			t.Fatalf("iter %d: leaderWorkersStarted should be false after Close", i)

--- a/pkg/server/leader_lifecycle_test.go
+++ b/pkg/server/leader_lifecycle_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -10,6 +11,7 @@ import (
 
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/drive9/pkg/backend"
+	"github.com/mem9-ai/drive9/pkg/encrypt"
 	"github.com/mem9-ai/drive9/pkg/leader"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/tenant"
@@ -64,7 +66,7 @@ func newLeaderLifecycleServerWithLeader(t *testing.T, leaderMgr *leader.Manager)
 	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
 	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
 
-	pool := newTestTenantPoolWithBackendOptions(t, backendOptionsWithFileGC())
+	pool := newTestTenantPoolWithLeaderChecker(t, backendOptionsWithFileGC(), leaderMgr)
 	pool.SetMetaStore(metaStore)
 	t.Cleanup(func() { pool.Close() })
 
@@ -222,6 +224,29 @@ func waitForLeaderOrTimeout(t *testing.T, srv *Server, timeout time.Duration) {
 
 func backendOptionsWithFileGC() backend.Options {
 	return backend.Options{AppSemanticTasksEnabled: true}
+}
+
+// newTestTenantPoolWithLeaderChecker builds a tenant pool whose per-tenant
+// FileGCWorker is gated by checker, so the leader lifecycle tests exercise the
+// real fileGCEnabled path (StartAllFileGC/StopAllFileGC + insertion-time read).
+func newTestTenantPoolWithLeaderChecker(t *testing.T, opts backend.Options, checker tenant.LeaderChecker) *tenant.Pool {
+	t.Helper()
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{
+		S3Dir:          mustTempDir(t),
+		PublicURL:      "http://localhost",
+		BackendOptions: opts,
+		LeaderChecker:  checker,
+	}, enc)
+	t.Cleanup(func() { pool.Close() })
+	return pool
 }
 
 // TestLeaderGatedWorkersCloseRacesOnLead is a regression for qiffang R3: a

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -401,35 +401,42 @@ func (s *Server) Close() {
 	}
 	s.forkWorkerMu.Unlock()
 	s.forkWorkerWG.Wait()
-	if s.semanticWorker != nil {
-		s.semanticWorker.Stop()
-	}
-	if s.objectGCWorker != nil {
-		s.objectGCWorker.Stop()
-	}
-	s.stopLeaderWorkers()
-	s.leaderWorkerMu.Lock()
-	if s.leaderWorkerCancel != nil {
-		s.leaderWorkerCancel()
-	}
-	s.leaderWorkerMu.Unlock()
-	s.leaderWorkerWG.Wait()
+	// Stop the leader manager first so any in-flight onLead/onLose callbacks
+	// finish before we tear down local workers. leader.Stop() waits for the
+	// heartbeat goroutine to exit, so no further callback can fire after it
+	// returns. If this pod currently holds leadership, Stop() invokes onLose,
+	// which runs stopLeaderWorkers and stops the leader-gated workers; the
+	// stopLeaderWorkers call below is then a no-op. If this pod is a standby,
+	// onLose does not fire, and stopLeaderWorkers is a no-op (workers were
+	// never started). This ordering prevents the race where Close() stops
+	// workers while onLead is still starting them (the callbacks and the local
+	// teardown are serialized on leaderWorkerMu, and no callback can outlive
+	// leader.Stop()).
 	if s.leader != nil {
 		s.leader.Stop()
 	}
+	// In single-pod (no-leader) mode, leader-gated workers were started
+	// unconditionally in NewWithConfig; stop them now. In leader mode this is a
+	// no-op (already stopped via onLose above) guarded by leaderWorkersStarted.
+	// stopLeaderWorkers also stops the semantic and object GC workers in both
+	// modes (they are started by startLeaderWorkers), so no separate Stop calls
+	// are needed here.
+	s.stopLeaderWorkers()
 }
 
 // startLeaderWorkers launches the background schedulers that should run only
 // on the leader pod: the fork-worker group (pending tenant reconciler, tenant
 // delete cleanup, one-time resume tasks), the semantic and object GC workers,
-// and the central-quota mutation replay + expiry sweep workers. Safe to call
-// concurrently — the whole start sequence is serialized under leaderWorkerMu
-// and guarded by leaderWorkersStarted, so onLead racing with Close() cannot
-// double-start any worker.
+// and the central-quota mutation replay + expiry sweep workers. The whole start
+// (including the worker assignments and Start calls) is serialized under
+// leaderWorkerMu and guarded by leaderWorkersStarted, so onLead racing with
+// Close()/onLose cannot interleave a start with a stop and leave orphan workers
+// running. The mutex is held for the entire transition so that a concurrent
+// stopLeaderWorkers observes the fully-started worker set (not a partial one).
 func (s *Server) startLeaderWorkers() {
 	s.leaderWorkerMu.Lock()
+	defer s.leaderWorkerMu.Unlock()
 	if s.leaderWorkersStarted {
-		s.leaderWorkerMu.Unlock()
 		return
 	}
 	s.leaderWorkersStarted = true
@@ -439,7 +446,6 @@ func (s *Server) startLeaderWorkers() {
 	leaderCtx, cancel := context.WithCancel(context.Background())
 	s.leaderWorkerCtx = leaderCtx
 	s.leaderWorkerCancel = cancel
-	s.leaderWorkerMu.Unlock()
 
 	if s.meta != nil && s.pool != nil && s.provisioner != nil {
 		// One-time resume tasks (run in leader-gated goroutines).
@@ -505,13 +511,17 @@ func (s *Server) startLeaderWorkers() {
 
 // stopLeaderWorkers stops the background schedulers started by startLeaderWorkers.
 // Called when the pod loses leadership or the server shuts down. The whole stop
-// sequence is serialized under leaderWorkerMu and guarded by leaderWorkersStarted,
-// so onLose (heartbeat goroutine) and Close() (main goroutine) cannot concurrently
-// double-stop a worker or race on the worker managers' own cancel fields.
+// (including the worker Stop/wait calls and clearing the worker fields) is
+// serialized under leaderWorkerMu and guarded by leaderWorkersStarted, so
+// onLose (heartbeat goroutine), Close() (main goroutine), and a concurrent
+// startLeaderWorkers cannot interleave. Holding the mutex for the entire
+// transition guarantees a concurrent startLeaderWorkers observes the
+// fully-stopped state (leaderWorkersStarted == false) and does not leave
+// orphan workers that a stop already ran past.
 func (s *Server) stopLeaderWorkers() {
 	s.leaderWorkerMu.Lock()
+	defer s.leaderWorkerMu.Unlock()
 	if !s.leaderWorkersStarted {
-		s.leaderWorkerMu.Unlock()
 		return
 	}
 	s.leaderWorkersStarted = false
@@ -521,15 +531,11 @@ func (s *Server) stopLeaderWorkers() {
 	s.replayWorker = nil
 	expirySweepWorker := s.expirySweepWorker
 	s.expirySweepWorker = nil
-	s.leaderWorkerMu.Unlock()
 
 	if cancel != nil {
 		cancel()
 	}
 	s.leaderWorkerWG.Wait()
-	// Stop the central-quota workers under the same serialized critical section
-	// (the worker managers' own cancel fields are not mutex-guarded, so we rely on
-	// leaderWorkersStarted to ensure Stop is called exactly once).
 	if replayWorker != nil {
 		replayWorker.Stop()
 	}
@@ -617,6 +623,9 @@ func (s *Server) onLose() {
 
 // logSemanticWorkerStatus logs whether the semantic worker is enabled or disabled.
 // Called in single-pod mode (no leader manager) for backward-compatible logging.
+// Log-only: the workers are started by startLeaderWorkers (called just before
+// this in the no-leader path), so this must NOT call Start again (that would be
+// a redundant double-start and previously silently over-started them).
 func (s *Server) logSemanticWorkerStatus(cfg Config, appManagedTaskTypes, fallbackTaskTypes, poolAutoTaskTypes []string) {
 	ctx := backgroundWithTrace(context.Background())
 	if s.semanticWorker != nil {
@@ -634,7 +643,6 @@ func (s *Server) logSemanticWorkerStatus(cfg Config, appManagedTaskTypes, fallba
 		}
 		fields = append(fields, s.semanticWorker.tenantScanLogFields()...)
 		logger.Info(ctx, "server_semantic_workers_enabled", fields...)
-		s.semanticWorker.Start(ctx)
 	} else {
 		logger.Info(ctx, "server_semantic_workers_disabled",
 			zap.Bool("embedder_configured", cfg.SemanticEmbedder != nil),
@@ -648,7 +656,6 @@ func (s *Server) logSemanticWorkerStatus(cfg Config, appManagedTaskTypes, fallba
 	}
 	if s.objectGCWorker != nil {
 		logger.Info(ctx, "server_object_gc_worker_enabled")
-		s.objectGCWorker.Start(ctx)
 	} else {
 		logger.Info(ctx, "server_object_gc_worker_disabled")
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,9 +69,10 @@ type Config struct {
 	// TiDB EMBED_TEXT, but TiDB tenants still use the normal auto schema.
 	DisableDatabaseAutoEmbedding bool
 	// Leader, when set, gates background schedulers (semantic worker, object GC,
-	// tenant delete cleanup, pending tenant reconciler, and one-time resume tasks)
-	// to run only on the leader pod. When nil or disabled, all workers start
-	// unconditionally (single-pod mode).
+	// tenant delete cleanup, pending tenant reconciler, one-time resume tasks,
+	// central-quota mutation replay, upload-reservation expiry sweep, and
+	// per-tenant FileGC) to run only on the leader pod. When nil or disabled, all
+	// workers start unconditionally (single-pod mode).
 	Leader *leader.Manager
 }
 
@@ -132,10 +133,17 @@ type Server struct {
 	// changes, this context is cancelled and recreated. Workers that use it
 	// (pending tenant reconciler, tenant delete cleanup, one-time resume tasks)
 	// stop automatically on cancellation.
-	leaderWorkerCtx    context.Context
-	leaderWorkerCancel context.CancelFunc
-	leaderWorkerWG     sync.WaitGroup
-	leaderWorkerMu     sync.Mutex
+	leaderWorkerCtx      context.Context
+	leaderWorkerCancel   context.CancelFunc
+	leaderWorkerWG       sync.WaitGroup
+	leaderWorkerMu       sync.Mutex
+	leaderWorkersStarted bool
+	// replayWorker and expirySweepWorker are leader-gated central quota
+	// workers owned by the server (single callback owner). Started in
+	// startLeaderWorkers and stopped in stopLeaderWorkers so they follow
+	// leadership transitions rather than being wired separately in main.go.
+	replayWorker      *backend.MutationReplayWorker
+	expirySweepWorker *backend.ExpirySweepWorker
 }
 
 type tenantAutoEmbeddingDefault struct {
@@ -413,17 +421,21 @@ func (s *Server) Close() {
 
 // startLeaderWorkers launches the background schedulers that should run only
 // on the leader pod: the fork-worker group (pending tenant reconciler, tenant
-// delete cleanup, one-time resume tasks) plus the semantic and object GC
-// workers. Safe to call multiple times — each worker checks its own start guard.
+// delete cleanup, one-time resume tasks), the semantic and object GC workers,
+// and the central-quota mutation replay + expiry sweep workers. Safe to call
+// concurrently — the whole start sequence is serialized under leaderWorkerMu
+// and guarded by leaderWorkersStarted, so onLead racing with Close() cannot
+// double-start any worker.
 func (s *Server) startLeaderWorkers() {
+	s.leaderWorkerMu.Lock()
+	if s.leaderWorkersStarted {
+		s.leaderWorkerMu.Unlock()
+		return
+	}
+	s.leaderWorkersStarted = true
 	// Create a fresh leaderWorkerCtx for the fork-worker group and one-time
 	// resume tasks. These use leaderWorkerCtx (not forkWorkerCtx, which is
 	// reserved for API-triggered fork operations that must run on any pod).
-	s.leaderWorkerMu.Lock()
-	if s.leaderWorkerCancel != nil {
-		s.leaderWorkerMu.Unlock()
-		return // already started
-	}
 	leaderCtx, cancel := context.WithCancel(context.Background())
 	s.leaderWorkerCtx = leaderCtx
 	s.leaderWorkerCancel = cancel
@@ -470,6 +482,19 @@ func (s *Server) startLeaderWorkers() {
 			})
 		}
 	}
+	// Central-quota workers: the server owns these as the single leader-callback
+	// owner so they start/stop with leadership transitions (previously they were
+	// wired in main.go via a second SetCallbacks call that was clobbered by the
+	// server's own SetCallbacks).
+	if s.meta != nil {
+		s.replayWorker = backend.StartMutationReplayWorker(tenant.NewMetaQuotaAdapter(s.meta))
+		s.expirySweepWorker = backend.StartExpirySweepWorker(s.meta)
+	}
+	// Per-tenant FileGC: start on every cached backend so FileGC reacts to a
+	// leadership gain for backends created while this pod was a standby.
+	if s.pool != nil {
+		s.pool.StartAllFileGC()
+	}
 	if s.semanticWorker != nil {
 		s.semanticWorker.Start(backgroundWithTrace(leaderCtx))
 	}
@@ -479,16 +504,43 @@ func (s *Server) startLeaderWorkers() {
 }
 
 // stopLeaderWorkers stops the background schedulers started by startLeaderWorkers.
-// Called when the pod loses leadership or the server shuts down.
+// Called when the pod loses leadership or the server shuts down. The whole stop
+// sequence is serialized under leaderWorkerMu and guarded by leaderWorkersStarted,
+// so onLose (heartbeat goroutine) and Close() (main goroutine) cannot concurrently
+// double-stop a worker or race on the worker managers' own cancel fields.
 func (s *Server) stopLeaderWorkers() {
 	s.leaderWorkerMu.Lock()
+	if !s.leaderWorkersStarted {
+		s.leaderWorkerMu.Unlock()
+		return
+	}
+	s.leaderWorkersStarted = false
 	cancel := s.leaderWorkerCancel
 	s.leaderWorkerCancel = nil
+	replayWorker := s.replayWorker
+	s.replayWorker = nil
+	expirySweepWorker := s.expirySweepWorker
+	s.expirySweepWorker = nil
 	s.leaderWorkerMu.Unlock()
+
 	if cancel != nil {
 		cancel()
 	}
 	s.leaderWorkerWG.Wait()
+	// Stop the central-quota workers under the same serialized critical section
+	// (the worker managers' own cancel fields are not mutex-guarded, so we rely on
+	// leaderWorkersStarted to ensure Stop is called exactly once).
+	if replayWorker != nil {
+		replayWorker.Stop()
+	}
+	if expirySweepWorker != nil {
+		expirySweepWorker.Stop()
+	}
+	// Per-tenant FileGC: stop on every cached backend so FileGC reacts to a
+	// leadership loss for backends created while this pod was the leader.
+	if s.pool != nil {
+		s.pool.StopAllFileGC()
+	}
 	if s.semanticWorker != nil {
 		s.semanticWorker.Stop()
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/backend"
 	"github.com/mem9-ai/drive9/pkg/datastore"
 	"github.com/mem9-ai/drive9/pkg/embedding"
+	"github.com/mem9-ai/drive9/pkg/leader"
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
@@ -67,6 +68,11 @@ type Config struct {
 	// DisableDatabaseAutoEmbedding suppresses runtime writes that would trigger
 	// TiDB EMBED_TEXT, but TiDB tenants still use the normal auto schema.
 	DisableDatabaseAutoEmbedding bool
+	// Leader, when set, gates background schedulers (semantic worker, object GC,
+	// tenant delete cleanup, pending tenant reconciler, and one-time resume tasks)
+	// to run only on the leader pod. When nil or disabled, all workers start
+	// unconditionally (single-pod mode).
+	Leader *leader.Manager
 }
 
 type SlockOAuthClient interface {
@@ -121,6 +127,15 @@ type Server struct {
 	forkWorkerMu        sync.Mutex
 	forkWorkerClosed    bool
 	schemaInitErrors    sync.Map
+	leader              *leader.Manager
+	// leaderWorkerCtx gates leader-only background schedulers. When leadership
+	// changes, this context is cancelled and recreated. Workers that use it
+	// (pending tenant reconciler, tenant delete cleanup, one-time resume tasks)
+	// stop automatically on cancellation.
+	leaderWorkerCtx    context.Context
+	leaderWorkerCancel context.CancelFunc
+	leaderWorkerWG     sync.WaitGroup
+	leaderWorkerMu     sync.Mutex
 }
 
 type tenantAutoEmbeddingDefault struct {
@@ -224,6 +239,7 @@ func NewWithConfig(cfg Config) *Server {
 		journalCursorSecret: newJournalCursorSecret(cfg.TokenSecret),
 		forkWorkerCtx:       forkWorkerCtx,
 		forkWorkerCancel:    forkWorkerCancel,
+		leader:              cfg.Leader,
 	}
 	mux := http.NewServeMux()
 
@@ -318,13 +334,6 @@ func NewWithConfig(cfg Config) *Server {
 	}
 
 	s.mux = mux
-	if s.meta != nil && s.pool != nil && s.provisioner != nil {
-		s.resumePendingTenants()
-		s.startPendingTenantReconciler()
-		s.resumeProvisioningTenants()
-		s.resumeDeletingForkTenants()
-		s.startTenantDeleteCleanup(backgroundWithTrace(context.Background()))
-	}
 	s.semanticWorker = newSemanticWorkerManager(cfg.Backend, cfg.Meta, cfg.Pool, cfg.SemanticEmbedder, cfg.SemanticWorkers)
 	if s.semanticWorker != nil {
 		// Wire upload/write-commit kicks so freshly enqueued semantic tasks are
@@ -339,6 +348,8 @@ func NewWithConfig(cfg Config) *Server {
 			})
 		}
 	}
+	s.objectGCWorker = newObjectGCWorker(cfg.Meta, cfg.Pool)
+
 	appManagedTaskTypes := semanticWorkerLogTaskTypesFromTypes(appManagedSemanticTaskTypes(cfg.SemanticEmbedder))
 	var fallbackTaskTypes, poolAutoTaskTypes []string
 	if cfg.Backend != nil {
@@ -347,39 +358,27 @@ func NewWithConfig(cfg Config) *Server {
 	if cfg.Pool != nil {
 		poolAutoTaskTypes = semanticWorkerLogTaskTypesFromTypes(cfg.Pool.AutoSemanticTaskTypes())
 	}
-	if s.semanticWorker != nil {
-		fields := []zap.Field{
-			zap.Int("workers", s.semanticWorker.opts.Workers),
-			zap.Duration("poll_interval", s.semanticWorker.opts.PollInterval),
-			zap.Duration("lease_duration", s.semanticWorker.opts.LeaseDuration),
-			zap.Duration("recover_interval", s.semanticWorker.opts.RecoverInterval),
-			zap.Bool("embedder_configured", cfg.SemanticEmbedder != nil),
-			zap.Strings("app_managed_task_types", appManagedTaskTypes),
-			zap.Strings("fallback_task_types", fallbackTaskTypes),
-			zap.Strings("pool_auto_task_types", poolAutoTaskTypes),
-			zap.Bool("fallback_image_extract_enabled", cfg.Backend != nil && cfg.Backend.SupportsAsyncImageExtract()),
-			zap.Bool("pool_image_extract_enabled", cfg.Pool != nil && cfg.Pool.SupportsAsyncImageExtract()),
+
+	// Gate background schedulers behind the leader manager when configured. When
+	// the leader is nil or disabled (single-pod mode), workers start immediately.
+	if s.leader != nil {
+		s.leader.SetCallbacks(s.onLead, s.onLose)
+		s.leader.Start(backgroundWithTrace(context.Background()))
+		// In disabled mode, Start calls onLead synchronously, which starts workers.
+		// In active mode, if this pod is already leader, onLead fires from the
+		// heartbeat goroutine. If not yet leader, workers stay stopped until
+		// leadership is gained.
+		if !s.leader.IsLeader() {
+			logger.Info("server_leader_standby",
+				zap.Bool("embedder_configured", cfg.SemanticEmbedder != nil),
+				zap.Strings("app_managed_task_types", appManagedTaskTypes),
+				zap.Strings("fallback_task_types", fallbackTaskTypes),
+				zap.Strings("pool_auto_task_types", poolAutoTaskTypes))
 		}
-		fields = append(fields, s.semanticWorker.tenantScanLogFields()...)
-		logger.Info("server_semantic_workers_enabled", fields...)
-		s.semanticWorker.Start(backgroundWithTrace(context.Background()))
 	} else {
-		logger.Info("server_semantic_workers_disabled",
-			zap.Bool("embedder_configured", cfg.SemanticEmbedder != nil),
-			zap.Strings("app_managed_task_types", appManagedTaskTypes),
-			zap.Strings("fallback_task_types", fallbackTaskTypes),
-			zap.Strings("pool_auto_task_types", poolAutoTaskTypes),
-			zap.Bool("fallback_present", cfg.Backend != nil),
-			zap.Bool("fallback_image_extract_enabled", cfg.Backend != nil && cfg.Backend.SupportsAsyncImageExtract()),
-			zap.Bool("pool_present", cfg.Pool != nil),
-			zap.Bool("pool_image_extract_enabled", cfg.Pool != nil && cfg.Pool.SupportsAsyncImageExtract()))
-	}
-	s.objectGCWorker = newObjectGCWorker(cfg.Meta, cfg.Pool)
-	if s.objectGCWorker != nil {
-		logger.Info("server_object_gc_worker_enabled")
-		s.objectGCWorker.Start(backgroundWithTrace(context.Background()))
-	} else {
-		logger.Info("server_object_gc_worker_disabled")
+		// No leader manager: single-pod mode, start workers immediately.
+		s.startLeaderWorkers()
+		s.logSemanticWorkerStatus(cfg, appManagedTaskTypes, fallbackTaskTypes, poolAutoTaskTypes)
 	}
 	return s
 }
@@ -400,10 +399,130 @@ func (s *Server) Close() {
 	if s.objectGCWorker != nil {
 		s.objectGCWorker.Stop()
 	}
+	s.stopLeaderWorkers()
+	s.leaderWorkerMu.Lock()
+	if s.leaderWorkerCancel != nil {
+		s.leaderWorkerCancel()
+	}
+	s.leaderWorkerMu.Unlock()
+	s.leaderWorkerWG.Wait()
+	if s.leader != nil {
+		s.leader.Stop()
+	}
 }
 
-func (s *Server) resumeProvisioningTenants() {
-	ctx := backgroundWithTrace(context.Background())
+// startLeaderWorkers launches the background schedulers that should run only
+// on the leader pod: the fork-worker group (pending tenant reconciler, tenant
+// delete cleanup, one-time resume tasks) plus the semantic and object GC
+// workers. Safe to call multiple times — each worker checks its own start guard.
+func (s *Server) startLeaderWorkers() {
+	// Create a fresh leaderWorkerCtx for the fork-worker group and one-time
+	// resume tasks. These use leaderWorkerCtx (not forkWorkerCtx, which is
+	// reserved for API-triggered fork operations that must run on any pod).
+	s.leaderWorkerMu.Lock()
+	if s.leaderWorkerCancel != nil {
+		s.leaderWorkerMu.Unlock()
+		return // already started
+	}
+	leaderCtx, cancel := context.WithCancel(context.Background())
+	s.leaderWorkerCtx = leaderCtx
+	s.leaderWorkerCancel = cancel
+	s.leaderWorkerMu.Unlock()
+
+	if s.meta != nil && s.pool != nil && s.provisioner != nil {
+		// One-time resume tasks (run in leader-gated goroutines).
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			s.resumePendingTenantsWithCtx(workerCtx)
+		})
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			s.resumeProvisioningTenantsWithCtx(workerCtx)
+		})
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			s.resumeDeletingForkTenantsWithCtx(workerCtx)
+		})
+		// Periodic tenant delete cleanup.
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			ticker := time.NewTicker(defaultTenantDeletePollInterval)
+			defer ticker.Stop()
+			s.processTenantDeleteJobs(workerCtx)
+			for {
+				select {
+				case <-workerCtx.Done():
+					return
+				case <-ticker.C:
+					s.processTenantDeleteJobs(workerCtx)
+				}
+			}
+		})
+		// Periodic pending tenant reconciler.
+		if pendingTenantSweepEvery > 0 {
+			s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+				ticker := time.NewTicker(pendingTenantSweepEvery)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-workerCtx.Done():
+						return
+					case <-ticker.C:
+						s.resumePendingTenantsWithCtx(workerCtx)
+					}
+				}
+			})
+		}
+	}
+	if s.semanticWorker != nil {
+		s.semanticWorker.Start(backgroundWithTrace(leaderCtx))
+	}
+	if s.objectGCWorker != nil {
+		s.objectGCWorker.Start(backgroundWithTrace(leaderCtx))
+	}
+}
+
+// stopLeaderWorkers stops the background schedulers started by startLeaderWorkers.
+// Called when the pod loses leadership or the server shuts down.
+func (s *Server) stopLeaderWorkers() {
+	s.leaderWorkerMu.Lock()
+	cancel := s.leaderWorkerCancel
+	s.leaderWorkerCancel = nil
+	s.leaderWorkerMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	s.leaderWorkerWG.Wait()
+	if s.semanticWorker != nil {
+		s.semanticWorker.Stop()
+	}
+	if s.objectGCWorker != nil {
+		s.objectGCWorker.Stop()
+	}
+}
+
+// startLeaderGoroutine launches a goroutine that runs fn under the leader
+// worker context. The goroutine is tracked by leaderWorkerWG and stops when
+// leadership is lost (leaderWorkerCtx is cancelled).
+func (s *Server) startLeaderGoroutine(ctx context.Context, fn func(context.Context)) {
+	s.leaderWorkerWG.Add(1)
+	go func() {
+		defer s.leaderWorkerWG.Done()
+		fn(ctx)
+	}()
+}
+
+// resumePendingTenantsWithCtx lists pending tenants and reconciles stale ones.
+func (s *Server) resumePendingTenantsWithCtx(ctx context.Context) {
+	tenants, err := s.meta.ListTenantsByStatus(ctx, meta.TenantPending, 1000)
+	if err != nil {
+		logger.Error(ctx, "resume_pending_list_failed", zap.Error(err))
+		return
+	}
+	for i := range tenants {
+		s.reconcilePendingTenant(ctx, tenants[i])
+	}
+}
+
+// resumeProvisioningTenantsWithCtx resumes provisioning tenants that were
+// interrupted by a previous restart.
+func (s *Server) resumeProvisioningTenantsWithCtx(ctx context.Context) {
 	tenants, err := s.meta.ListTenantsByStatus(ctx, meta.TenantProvisioning, 1000)
 	if err != nil {
 		logger.Error(ctx, "resume_provisioning_list_failed", zap.Error(err))
@@ -422,15 +541,64 @@ func (s *Server) resumeProvisioningTenants() {
 	}
 }
 
-func (s *Server) resumePendingTenants() {
-	ctx := backgroundWithTrace(context.Background())
-	tenants, err := s.meta.ListTenantsByStatus(ctx, meta.TenantPending, 1000)
-	if err != nil {
-		logger.Error(ctx, "resume_pending_list_failed", zap.Error(err))
-		return
+// resumeDeletingForkTenantsWithCtx resumes cleanup for deleting/failed fork tenants.
+func (s *Server) resumeDeletingForkTenantsWithCtx(ctx context.Context) {
+	for _, status := range []meta.TenantStatus{meta.TenantDeleting, meta.TenantFailed} {
+		tenants, err := s.meta.ListTenantsByStatus(ctx, status, 1000)
+		if err != nil {
+			logger.Error(ctx, "resume_fork_cleanup_list_failed", zap.String("status", string(status)), zap.Error(err))
+			continue
+		}
+		s.resumeForkCleanup(ctx, tenants)
 	}
-	for i := range tenants {
-		s.reconcilePendingTenant(ctx, tenants[i])
+}
+
+// onLead is the leader manager callback invoked when this pod gains leadership.
+func (s *Server) onLead() {
+	s.startLeaderWorkers()
+}
+
+// onLose is the leader manager callback invoked when this pod loses leadership.
+func (s *Server) onLose() {
+	s.stopLeaderWorkers()
+}
+
+// logSemanticWorkerStatus logs whether the semantic worker is enabled or disabled.
+// Called in single-pod mode (no leader manager) for backward-compatible logging.
+func (s *Server) logSemanticWorkerStatus(cfg Config, appManagedTaskTypes, fallbackTaskTypes, poolAutoTaskTypes []string) {
+	ctx := backgroundWithTrace(context.Background())
+	if s.semanticWorker != nil {
+		fields := []zap.Field{
+			zap.Int("workers", s.semanticWorker.opts.Workers),
+			zap.Duration("poll_interval", s.semanticWorker.opts.PollInterval),
+			zap.Duration("lease_duration", s.semanticWorker.opts.LeaseDuration),
+			zap.Duration("recover_interval", s.semanticWorker.opts.RecoverInterval),
+			zap.Bool("embedder_configured", cfg.SemanticEmbedder != nil),
+			zap.Strings("app_managed_task_types", appManagedTaskTypes),
+			zap.Strings("fallback_task_types", fallbackTaskTypes),
+			zap.Strings("pool_auto_task_types", poolAutoTaskTypes),
+			zap.Bool("fallback_image_extract_enabled", cfg.Backend != nil && cfg.Backend.SupportsAsyncImageExtract()),
+			zap.Bool("pool_image_extract_enabled", cfg.Pool != nil && cfg.Pool.SupportsAsyncImageExtract()),
+		}
+		fields = append(fields, s.semanticWorker.tenantScanLogFields()...)
+		logger.Info(ctx, "server_semantic_workers_enabled", fields...)
+		s.semanticWorker.Start(ctx)
+	} else {
+		logger.Info(ctx, "server_semantic_workers_disabled",
+			zap.Bool("embedder_configured", cfg.SemanticEmbedder != nil),
+			zap.Strings("app_managed_task_types", appManagedTaskTypes),
+			zap.Strings("fallback_task_types", fallbackTaskTypes),
+			zap.Strings("pool_auto_task_types", poolAutoTaskTypes),
+			zap.Bool("fallback_present", cfg.Backend != nil),
+			zap.Bool("fallback_image_extract_enabled", cfg.Backend != nil && cfg.Backend.SupportsAsyncImageExtract()),
+			zap.Bool("pool_present", cfg.Pool != nil),
+			zap.Bool("pool_image_extract_enabled", cfg.Pool != nil && cfg.Pool.SupportsAsyncImageExtract()))
+	}
+	if s.objectGCWorker != nil {
+		logger.Info(ctx, "server_object_gc_worker_enabled")
+		s.objectGCWorker.Start(ctx)
+	} else {
+		logger.Info(ctx, "server_object_gc_worker_disabled")
 	}
 }
 
@@ -444,26 +612,6 @@ func (s *Server) startTenantSchemaInitResume(ctx context.Context, t meta.Tenant)
 		dsn := tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS)
 		s.initTenantSchemaAsync(workerCtx, t.ID, dsn, t.Provider, s.schemaInitForTenant(t.ID, t.Provider, s.provisioner.InitSchema))
 	})
-}
-
-func (s *Server) startPendingTenantReconciler() {
-	if s.forkWorkerCtx == nil || pendingTenantSweepEvery <= 0 {
-		return
-	}
-	s.forkWorkerWG.Add(1)
-	go func() {
-		defer s.forkWorkerWG.Done()
-		ticker := time.NewTicker(pendingTenantSweepEvery)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-s.forkWorkerCtx.Done():
-				return
-			case <-ticker.C:
-				s.resumePendingTenants()
-			}
-		}
-	}()
 }
 
 func (s *Server) reconcilePendingTenant(ctx context.Context, t meta.Tenant) {

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -218,22 +218,6 @@ func decodeCredentialDeprovisionRequest(w http.ResponseWriter, r *http.Request) 
 	return *req, nil
 }
 
-func (s *Server) startTenantDeleteCleanup(ctx context.Context) {
-	s.startForkWorker(ctx, func(workerCtx context.Context) {
-		ticker := time.NewTicker(defaultTenantDeletePollInterval)
-		defer ticker.Stop()
-		s.processTenantDeleteJobs(workerCtx)
-		for {
-			select {
-			case <-workerCtx.Done():
-				return
-			case <-ticker.C:
-				s.processTenantDeleteJobs(workerCtx)
-			}
-		}
-	})
-}
-
 func (s *Server) processTenantDeleteJobs(ctx context.Context) {
 	now := time.Now().UTC()
 	if _, err := s.meta.RecoverStaleTenantDeleteJobs(ctx, now.Add(-defaultTenantDeleteRunningTTL)); err != nil {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -52,6 +52,22 @@ type PoolConfig struct {
 	// tidb_cloud_starter). Use when the TiDB Cloud cluster does not have a
 	// supported auto-embedding provider configured.
 	DisableDatabaseAutoEmbedding bool
+
+	// LeaderChecker, when set, gates per-tenant FileGCWorker to run only on
+	// the leader pod. When nil, FileGCWorker starts unconditionally (single-pod).
+	LeaderChecker LeaderChecker
+}
+
+// LeaderChecker reports whether the current process is the leader. Used by
+// the tenant pool to gate per-tenant background workers (e.g. FileGCWorker).
+type LeaderChecker interface {
+	IsLeader() bool
+}
+
+// shouldStartFileGC reports whether per-tenant FileGCWorker should start on
+// this pod. When no leader checker is configured, FileGC starts unconditionally.
+func (p *Pool) shouldStartFileGC() bool {
+	return p.cfg.LeaderChecker == nil || p.cfg.LeaderChecker.IsLeader()
 }
 
 type Pool struct {
@@ -684,7 +700,9 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		p.wireQuotaStore(b, t.ID)
 		p.wireSemanticTaskNotifier(b, t.ID)
-		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
+		if p.shouldStartFileGC() {
+			b.StartFileGCWorker(backend.FileGCWorkerOptions{})
+		}
 		return b, store, nil
 	}
 	if p.cfg.S3Dir != "" {
@@ -725,7 +743,9 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		p.wireQuotaStore(b, t.ID)
 		p.wireSemanticTaskNotifier(b, t.ID)
-		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
+		if p.shouldStartFileGC() {
+			b.StartFileGCWorker(backend.FileGCWorkerOptions{})
+		}
 		return b, store, nil
 	}
 	backendCreateStart := time.Now()
@@ -748,7 +768,9 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 	p.wireQuotaStore(b, t.ID)
 	p.wireSemanticTaskNotifier(b, t.ID)
-	b.StartFileGCWorker(backend.FileGCWorkerOptions{})
+	if p.shouldStartFileGC() {
+		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
+	}
 	return b, store, nil
 }
 

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -56,11 +56,13 @@ type PoolConfig struct {
 	// LeaderChecker, when set, gates per-tenant FileGCWorker to run only on
 	// the leader pod. When nil, FileGCWorker starts unconditionally (single-pod).
 	//
-	// FileGC reacts to leadership transitions: the server calls StartAllFileGC
-	// on leadership gain and StopAllFileGC on loss, so cached backends created
-	// while this pod was a standby get FileGC once it becomes leader, and backends
-	// created while leader stop FileGC on loss. The shouldStartFileGC check at
-	// backend creation only handles the case where this pod is already leader.
+	// FileGC reacts to leadership transitions and races safely with concurrent
+	// backend creation: the server calls StartAllFileGC on leadership gain and
+	// StopAllFileGC on loss. These set a pool-owned fileGCEnabled flag under p.mu,
+	// and Get/Acquire start FileGC on a newly inserted backend according to that
+	// flag (read under p.mu), so a backend created concurrently with a transition
+	// resolves to the post-transition state instead of a moment-in-time
+	// IsLeader() snapshot.
 	LeaderChecker LeaderChecker
 }
 
@@ -70,22 +72,17 @@ type LeaderChecker interface {
 	IsLeader() bool
 }
 
-// shouldStartFileGC reports whether per-tenant FileGCWorker should start on
-// this pod. When no leader checker is configured, FileGC starts unconditionally.
-func (p *Pool) shouldStartFileGC() bool {
-	return p.cfg.LeaderChecker == nil || p.cfg.LeaderChecker.IsLeader()
-}
-
-// StartAllFileGC starts the per-tenant FileGCWorker on every cached backend.
-// Called by the server's onLead callback so FileGC reacts to leadership gains
-// for backends created while this pod was a standby (which skipped FileGC at
-// creation time). Backends created after leadership is gained already start
-// FileGC in createBackend, so this only fills the gap for already-cached ones.
+// StartAllFileGC starts the per-tenant FileGCWorker on every cached backend
+// and marks FileGC as enabled so backends created afterwards also start FileGC.
+// Called by the server's onLead callback. All state changes happen under p.mu,
+// so a backend being created concurrently will observe a consistent
+// fileGCEnabled value when it is inserted (see Get/Acquire).
 func (p *Pool) StartAllFileGC() {
 	if p == nil {
 		return
 	}
 	p.mu.Lock()
+	p.fileGCEnabled = true
 	backends := make([]*backend.Dat9Backend, 0, len(p.items))
 	for _, e := range p.items {
 		backends = append(backends, e.backend)
@@ -96,16 +93,17 @@ func (p *Pool) StartAllFileGC() {
 	}
 }
 
-// StopAllFileGC stops the per-tenant FileGCWorker on every cached backend.
-// Called by the server's onLose callback so FileGC reacts to leadership loss
-// for backends created while this pod was the leader (which started FileGC at
-// creation time). Stopping the worker cancels its context; a later leadership
-// regain re-starts it via StartAllFileGC.
+// StopAllFileGC stops the per-tenant FileGCWorker on every cached backend and
+// marks FileGC as disabled so backends created afterwards do not start FileGC.
+// Called by the server's onLose callback. All state changes happen under p.mu,
+// so a backend being created concurrently will observe a consistent
+// fileGCEnabled value when it is inserted (see Get/Acquire).
 func (p *Pool) StopAllFileGC() {
 	if p == nil {
 		return
 	}
 	p.mu.Lock()
+	p.fileGCEnabled = false
 	backends := make([]*backend.Dat9Backend, 0, len(p.items))
 	for _, e := range p.items {
 		backends = append(backends, e.backend)
@@ -126,6 +124,14 @@ type Pool struct {
 	maxSize                   int
 	tidbSchemaValidationOpens atomic.Uint64
 	semanticTaskNotifier      atomic.Pointer[func(tenantID string)]
+	// fileGCEnabled tracks whether per-tenant FileGCWorker should be running on
+	// this pod. It is set under p.mu by StartAllFileGC (leader gain) /
+	// StopAllFileGC (leader loss), and read under p.mu when a newly created
+	// backend is inserted, so backend creation racing with a leadership
+	// transition resolves correctly instead of using a moment-in-time
+	// IsLeader() check taken outside the pool lock. When no LeaderChecker is
+	// configured (single-pod) it is always true.
+	fileGCEnabled bool
 }
 
 type tenantAutoEmbeddingProfile struct {
@@ -160,7 +166,15 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 	if max <= 0 {
 		max = 128
 	}
-	return &Pool{cfg: cfg, enc: enc, items: map[string]*entry{}, order: list.New(), maxSize: max}
+	return &Pool{
+		cfg:           cfg,
+		enc:           enc,
+		items:         map[string]*entry{},
+		order:         list.New(),
+		maxSize:       max,
+		// No LeaderChecker means single-pod mode: FileGC runs unconditionally.
+		fileGCEnabled: cfg.LeaderChecker == nil,
+	}
 }
 
 // SetMetaStore sets the central server DB store for quota operations.
@@ -257,7 +271,14 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 			}
 		}
 	}
+	// Read the pool-owned FileGC leader state under p.mu so a backend created
+	// concurrently with a leadership transition resolves to the post-transition
+	// state rather than a moment-in-time IsLeader() check taken outside the lock.
+	startFileGC := p.fileGCEnabled
 	p.mu.Unlock()
+	if startFileGC {
+		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
+	}
 	for _, retired := range toClose {
 		closeEntry(retired)
 	}
@@ -343,7 +364,14 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 			}
 		}
 	}
+	// Read the pool-owned FileGC leader state under p.mu so a backend created
+	// concurrently with a leadership transition resolves to the post-transition
+	// state rather than a moment-in-time IsLeader() check taken outside the lock.
+	startFileGC := p.fileGCEnabled
 	p.mu.Unlock()
+	if startFileGC {
+		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
+	}
 	for _, retired := range toClose {
 		closeEntry(retired)
 	}
@@ -746,9 +774,6 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		p.wireQuotaStore(b, t.ID)
 		p.wireSemanticTaskNotifier(b, t.ID)
-		if p.shouldStartFileGC() {
-			b.StartFileGCWorker(backend.FileGCWorkerOptions{})
-		}
 		return b, store, nil
 	}
 	if p.cfg.S3Dir != "" {
@@ -789,9 +814,6 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 		p.wireQuotaStore(b, t.ID)
 		p.wireSemanticTaskNotifier(b, t.ID)
-		if p.shouldStartFileGC() {
-			b.StartFileGCWorker(backend.FileGCWorkerOptions{})
-		}
 		return b, store, nil
 	}
 	backendCreateStart := time.Now()
@@ -814,9 +836,6 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 	p.wireQuotaStore(b, t.ID)
 	p.wireSemanticTaskNotifier(b, t.ID)
-	if p.shouldStartFileGC() {
-		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
-	}
 	return b, store, nil
 }
 

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -55,6 +55,12 @@ type PoolConfig struct {
 
 	// LeaderChecker, when set, gates per-tenant FileGCWorker to run only on
 	// the leader pod. When nil, FileGCWorker starts unconditionally (single-pod).
+	//
+	// FileGC reacts to leadership transitions: the server calls StartAllFileGC
+	// on leadership gain and StopAllFileGC on loss, so cached backends created
+	// while this pod was a standby get FileGC once it becomes leader, and backends
+	// created while leader stop FileGC on loss. The shouldStartFileGC check at
+	// backend creation only handles the case where this pod is already leader.
 	LeaderChecker LeaderChecker
 }
 
@@ -68,6 +74,46 @@ type LeaderChecker interface {
 // this pod. When no leader checker is configured, FileGC starts unconditionally.
 func (p *Pool) shouldStartFileGC() bool {
 	return p.cfg.LeaderChecker == nil || p.cfg.LeaderChecker.IsLeader()
+}
+
+// StartAllFileGC starts the per-tenant FileGCWorker on every cached backend.
+// Called by the server's onLead callback so FileGC reacts to leadership gains
+// for backends created while this pod was a standby (which skipped FileGC at
+// creation time). Backends created after leadership is gained already start
+// FileGC in createBackend, so this only fills the gap for already-cached ones.
+func (p *Pool) StartAllFileGC() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	backends := make([]*backend.Dat9Backend, 0, len(p.items))
+	for _, e := range p.items {
+		backends = append(backends, e.backend)
+	}
+	p.mu.Unlock()
+	for _, b := range backends {
+		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
+	}
+}
+
+// StopAllFileGC stops the per-tenant FileGCWorker on every cached backend.
+// Called by the server's onLose callback so FileGC reacts to leadership loss
+// for backends created while this pod was the leader (which started FileGC at
+// creation time). Stopping the worker cancels its context; a later leadership
+// regain re-starts it via StartAllFileGC.
+func (p *Pool) StopAllFileGC() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	backends := make([]*backend.Dat9Backend, 0, len(p.items))
+	for _, e := range p.items {
+		backends = append(backends, e.backend)
+	}
+	p.mu.Unlock()
+	for _, b := range backends {
+		b.StopFileGCWorker()
+	}
 }
 
 type Pool struct {

--- a/pkg/tenant/pool_filegc_leader_test.go
+++ b/pkg/tenant/pool_filegc_leader_test.go
@@ -1,0 +1,119 @@
+package tenant
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeLeaderChecker is a controllable LeaderChecker for FileGC leader-gating tests.
+type fakeLeaderChecker struct {
+	leader atomic.Bool
+}
+
+func (f *fakeLeaderChecker) IsLeader() bool { return f.leader.Load() }
+
+// TestPoolFileGCStartsOnLeaderGainDuringBackendCreation simulates the race
+// where a tenant backend is created while this pod is a standby, and the pod
+// gains leadership before the backend is inserted into the pool. The backend
+// must end up with FileGC running, because fileGCEnabled is set under p.mu by
+// StartAllFileGC and read under p.mu at insertion — so the post-transition
+// (leader) state wins rather than the moment-in-time standby snapshot.
+func TestPoolFileGCStartsOnLeaderGainDuringBackendCreation(t *testing.T) {
+	lc := &fakeLeaderChecker{}
+	// Start as standby: FileGC disabled.
+	lc.leader.Store(false)
+	pool, tnt := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants:    2,
+		LeaderChecker: lc,
+	}, "tenant-leader-gain")
+	ctx := context.Background()
+
+	// Simulate a leadership gain that happens while the backend is being
+	// created (pool empty): StartAllFileGC only flips fileGCEnabled=true here
+	// since no backends are cached yet — the transition "wins" the race.
+	// The fake checker is left as standby to prove the outcome is driven by
+	// fileGCEnabled (pool-owned state), not by a moment-in-time IsLeader().
+	pool.StartAllFileGC()
+
+	// Now create+insert the backend. Insertion reads fileGCEnabled (true) under
+	// p.mu and starts FileGC, even though this pod was a standby at create time.
+	b, err := pool.Get(ctx, tnt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b.FileGCWorkerRunning() {
+		t.Fatal("FileGC worker should be running on a backend inserted after a leadership gain that raced with creation")
+	}
+
+	// Subsequent cached Get must keep FileGC running (no re-evaluation on hits).
+	b2, err := pool.Get(ctx, tnt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b2 != b {
+		t.Fatal("second Get should hit the cache")
+	}
+	if !b2.FileGCWorkerRunning() {
+		t.Fatal("FileGC worker should still be running on a cached hit")
+	}
+}
+
+// TestPoolFileGCSkipsOnLeaderLossDuringBackendCreation simulates the race
+// where a tenant backend is created while this pod is the leader, and the pod
+// loses leadership before the backend is inserted into the pool. The backend
+// must end up WITHOUT FileGC running, because fileGCEnabled is set to false
+// under p.mu by StopAllFileGC and read under p.mu at insertion — so the
+// post-transition (standby) state wins rather than the moment-in-time leader
+// snapshot.
+func TestPoolFileGCSkipsOnLeaderLossDuringBackendCreation(t *testing.T) {
+	lc := &fakeLeaderChecker{}
+	// Start as leader: FileGC enabled.
+	lc.leader.Store(true)
+	pool, tnt := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants:    2,
+		LeaderChecker: lc,
+	}, "tenant-leader-loss")
+	ctx := context.Background()
+
+	// Simulate a leadership loss that happens while the backend is being
+	// created (pool empty): StopAllFileGC only flips fileGCEnabled=false here
+	// since no backends are cached yet — the transition "wins" the race.
+	pool.StopAllFileGC()
+
+	// Now create+insert the backend. Insertion reads fileGCEnabled (false) under
+	// p.mu and does NOT start FileGC, even though this pod was leader at create.
+	b, err := pool.Get(ctx, tnt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.FileGCWorkerRunning() {
+		t.Fatal("FileGC worker should NOT be running on a backend inserted after a leadership loss that raced with creation")
+	}
+
+	// A later leadership gain must start FileGC on the cached backend.
+	pool.StartAllFileGC()
+	if !b.FileGCWorkerRunning() {
+		t.Fatal("StartAllFileGC should start FileGC on the cached backend after a leadership regain")
+	}
+}
+
+// TestPoolFileGCNoLeaderCheckerAlwaysEnabled verifies single-pod mode (nil
+// LeaderChecker): fileGCEnabled defaults to true and every backend starts
+// FileGC regardless of transitions.
+func TestPoolFileGCNoLeaderCheckerAlwaysEnabled(t *testing.T) {
+	pool, tnt := newTestPoolAndTenant(t, 2, "tenant-no-leader")
+	ctx := context.Background()
+
+	b, err := pool.Get(ctx, tnt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b.FileGCWorkerRunning() {
+		t.Fatal("FileGC worker should run in single-pod mode (nil LeaderChecker)")
+	}
+
+	// StartAllFileGC / StopAllFileGC are no-ops in single-pod mode in practice
+	// (the server only calls them when a Leader is configured); verify the
+	// default is enabled.
+}


### PR DESCRIPTION
## Summary

Introduces a TiDB/MySQL `GET_LOCK`-based leader election mechanism so that background schedulers run only on the leader pod in a multi-pod deployment. This prevents duplicate work across pods — especially for Object GC which has **no DB-level claim/lease protection** and would otherwise produce duplicate S3 HEAD/DELETE calls.

This addresses **P0-3** from #599, and is the **foundation for P0-2** (event bus externalization), which will also use the leader manager to coordinate event publishing. The PR numbering (P0-3 before P0-2) is intentional: leader election must exist before event bus externalization can safely coordinate cross-pod event delivery.

## New `pkg/leader` package

- `Manager` acquires a named session lock via `GET_LOCK('drive9:leader', 0)` (non-blocking, timeout=0)
- Connection death (pod crash/restart) auto-releases the lock — MySQL session-level semantics
- Heartbeat goroutine verifies lock ownership via `IS_USED_LOCK` and keeps the connection alive with `SELECT 1`
- `SetCallbacks` for `onLead`/`onLose` leadership transitions
- `WithDisabled` option for single-pod mode (always leader, no lock acquired)
- Config: `DRIVE9_LEADER_LOCK_NAME`, `DRIVE9_LEADER_HEARTBEAT_INTERVAL`, `DRIVE9_LEADER_DISABLED`

## Workers gated behind leader

| Worker | Gate mechanism | Why gated |
|--------|---------------|-----------|
| Semantic worker | Start/Stop on leadership change | Reduces scan amplification (claim already safe via SKIP LOCKED) |
| Object GC worker | Start/Stop on leadership change | **No DB-level claim** — most critical to gate |
| Tenant delete cleanup | Leader-gated goroutine group | Prevents duplicate S3 prefix deletes |
| Pending tenant reconciler | Leader-gated goroutine group | Prevents duplicate scans |
| One-time resume tasks | Leader-gated goroutines | Prevents duplicate TiDB Cloud provisioner calls |
| Mutation replay worker | Start/Stop on leadership change (main.go) | Prevents duplicate quota mutation scans |
| Expiry sweep worker | Start/Stop on leadership change (main.go) | Prevents duplicate reservation sweeps |
| Per-tenant FileGCWorker | Pool `LeaderChecker` interface | Reduces per-tenant scan overhead |

## Backward compatibility

- **nil leader manager** (drive9-server-local, single-pod) = all workers start immediately (existing behavior, unchanged)
- **`DRIVE9_LEADER_DISABLED=true`** = always leader, no lock acquired
- No schema changes required
- `local-smoke.sh`: 32/32 pass (single-pod, leader disabled)

## Test results

- `pkg/leader`: all tests pass (acquire/lose/reacquire, exclusivity, disabled mode, primitives)
- `pkg/server`: no new failures (pre-existing meta-schema migration failures unrelated to this PR)
- `pkg/tenant`: all tests pass
- `cmd/drive9-server` / `cmd/drive9-server-local`: all tests pass
- `golangci-lint`: 0 new issues in modified packages
- `local-smoke.sh`: 32/32 pass

Ref #599 (P0-3).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added MySQL `GET_LOCK`-based leader election with lead/lose callbacks.
  - Background maintenance and processing now run only on the active leader; FileGC is also leader-gated when configured for multi-instance operation.

- **Refactor**
  - Reworked server startup/shutdown so leader transitions control worker lifecycles.
  - Improved fork-tenant cleanup to run concurrently with bounded parallelism.
  - Adjusted tenant delete job scheduling to be handled without a periodic cleanup ticker.

- **Tests**
  - Added leader-election, server leader lifecycle, and FileGC leader-gating race coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->