### PR TITLE
fix: reduce quota hot-path overhead

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -252,7 +252,7 @@ func main() {
 		defer func() { _ = metaStore.Close() }()
 
 		adapter := tenant.NewMetaQuotaAdapter(metaStore)
-		b.SetMetaQuotaStore("local-tenant", adapter)
+		b.SetMetaQuotaStore(context.Background(), "local-tenant", adapter)
 
 		if err := metaStore.EnsureQuotaUsageRow(context.Background(), "local-tenant"); err != nil {
 			logger.Warn(startupCtx, "ensure_quota_usage_row_failed",

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -153,7 +153,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	fs.Var(&remoteOnlyPatterns, "remote-only", "remote-persistent override path pattern for overlay routing (repeatable)")
 	fs.Var(&unpackArchives, "unpack", "restore a drive9 pack archive into --local-root before mounting (repeatable)")
 	uploadConcurrency := fs.Int("upload-concurrency", 16, "maximum concurrent background uploads issued by FUSE")
-	dirCacheMaxEntries := fs.Int("dir-cache-max-entries", 100000, "maximum entries per directory in namespace cache before complete marking is disabled")
+	dirCacheMaxEntries := fs.Int("dir-cache-max-entries", 200000, "maximum entries per directory in namespace cache before complete marking is disabled")
 	commitQueueMaxPending := fs.Int("commit-queue-max-pending", 100, "maximum pending entries in CommitQueue before backpressure")
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
 	readOnly := fs.Bool("read-only", false, "mount as read-only")

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -100,6 +100,7 @@ type Dat9Backend struct {
 	metaStore          MetaQuotaStore // nil when central quota is not wired (tests, fallback)
 	quotaSource        QuotaSource    // "tenant" (default) or "server"
 	quotaConfigCache   *quotaConfigCache
+	quotaUsageCache    *quotaUsageCache
 
 	// mutationQueue decouples central quota mutations (syncCentralFileCreate,
 	// syncCentralFileOverwrite) from the fsync critical path. Mutations are

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -101,6 +101,7 @@ type Dat9Backend struct {
 	quotaSource        QuotaSource    // "tenant" (default) or "server"
 	quotaConfigCache   *quotaConfigCache
 	quotaUsageCache    *quotaUsageCache
+	quotaPendingCache  *quotaPendingDeltasCache
 
 	// mutationQueue decouples central quota mutations (syncCentralFileCreate,
 	// syncCentralFileOverwrite) from the fsync critical path. Mutations are
@@ -314,6 +315,7 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 		return err
 	}
 	if quotaOutboxEnqueued {
+		b.addLocalQuotaPendingDeltas(0, 1, 0)
 		b.notifyQuotaOutbox(true)
 	} else {
 		b.syncCentralFileCreate(ctx, fileID, 0, "")
@@ -394,6 +396,11 @@ func (b *Dat9Backend) CreateSymlinkCtx(ctx context.Context, linkPath, target str
 		return err
 	}
 	if quotaOutboxEnqueued {
+		mediaDelta := int64(0)
+		if isQuotaMediaContentType(symlinkContentType) {
+			mediaDelta = 1
+		}
+		b.addLocalQuotaPendingDeltas(int64(len(data)), 1, mediaDelta)
 		b.notifyQuotaOutbox(true)
 	} else {
 		b.syncCentralFileCreate(ctx, fileID, int64(len(data)), symlinkContentType)
@@ -953,6 +960,11 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		centralQuotaStart = time.Now()
 	}
 	if quotaOutboxEnqueued {
+		mediaDelta := int64(0)
+		if isQuotaMediaContentType(contentType) {
+			mediaDelta = 1
+		}
+		b.addLocalQuotaPendingDeltas(int64(len(data)), 1, mediaDelta)
 		b.notifyQuotaOutbox(true)
 	} else {
 		b.syncCentralFileCreate(ctx, fileID, int64(len(data)), contentType)
@@ -1223,6 +1235,11 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 		centralQuotaStart = time.Now()
 	}
 	if quotaOutboxEnqueued {
+		b.addLocalQuotaPendingDeltas(
+			int64(len(finalData))-nf.File.SizeBytes,
+			0,
+			quotaMediaDelta(isQuotaMediaContentType(nf.File.ContentType), isQuotaMediaContentType(contentType)),
+		)
 		b.notifyQuotaOutbox(true)
 	} else {
 		b.syncCentralFileOverwrite(ctx, nf.File.FileID, nf.File.SizeBytes, nf.File.ContentType, int64(len(finalData)), contentType)

--- a/pkg/backend/file_gc_worker_test.go
+++ b/pkg/backend/file_gc_worker_test.go
@@ -38,7 +38,7 @@ func TestFileGCTaskEnqueuesOriginalStorageRefAfterPathRecreate(t *testing.T) {
 	rec := &deleteRecordingS3Client{S3Client: b.s3}
 	b.s3 = rec
 	fake := newFakeMetaQuotaStore()
-	b.SetMetaQuotaStore("tenant-a", fake)
+	b.SetMetaQuotaStore(context.Background(), "tenant-a", fake)
 	b.storageNamespaceID = "ns-a"
 
 	ctx := context.Background()
@@ -132,7 +132,7 @@ func TestFileGCTaskEnqueuesObjectCandidateWhenNamespaceWired(t *testing.T) {
 	rec := &deleteRecordingS3Client{S3Client: b.s3}
 	b.s3 = rec
 	fake := newFakeMetaQuotaStore()
-	b.SetMetaQuotaStore("tenant-a", fake)
+	b.SetMetaQuotaStore(context.Background(), "tenant-a", fake)
 	b.storageNamespaceID = "ns-a"
 
 	ctx := context.Background()
@@ -312,7 +312,7 @@ func TestFileGCTaskRetriesWhenObjectCandidateEnqueueFails(t *testing.T) {
 	fake := newFakeMetaQuotaStore()
 	enqueueErr := errors.New("meta unavailable")
 	fake.objectGCCandidateErr = enqueueErr
-	b.SetMetaQuotaStore("tenant-a", fake)
+	b.SetMetaQuotaStore(context.Background(), "tenant-a", fake)
 	b.storageNamespaceID = "ns-a"
 
 	ctx := context.Background()

--- a/pkg/backend/fs_layer_content.go
+++ b/pkg/backend/fs_layer_content.go
@@ -177,6 +177,11 @@ func (b *Dat9Backend) WriteStoredObjectCtxIfRevision(ctx context.Context, path s
 			return 0, err
 		}
 		if quotaOutboxEnqueued {
+			mediaDelta := int64(0)
+			if isQuotaMediaContentType(contentType) {
+				mediaDelta = 1
+			}
+			b.addLocalQuotaPendingDeltas(entry.SizeBytes, 1, mediaDelta)
 			b.notifyQuotaOutbox(true)
 		} else {
 			b.syncCentralFileCreate(ctx, fileID, entry.SizeBytes, contentType)
@@ -251,6 +256,11 @@ func (b *Dat9Backend) WriteStoredObjectCtxIfRevision(ctx context.Context, path s
 		return 0, err
 	}
 	if quotaOutboxEnqueued {
+		b.addLocalQuotaPendingDeltas(
+			entry.SizeBytes-oldSize,
+			0,
+			quotaMediaDelta(isQuotaMediaContentType(oldContentType), isQuotaMediaContentType(contentType)),
+		)
 		b.notifyQuotaOutbox(true)
 	} else {
 		b.syncCentralFileOverwrite(ctx, nf.File.FileID, oldSize, oldContentType, entry.SizeBytes, contentType)

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -351,6 +351,12 @@ func (b *Dat9Backend) pendingQuotaOutboxDeltasTx(ctx context.Context, tx *sql.Tx
 	if b.store == nil || tx == nil {
 		return 0, 0, 0, true
 	}
+	if b.quotaPendingCache != nil {
+		deltas, ok := b.quotaPendingCache.get(ctx)
+		if ok {
+			return deltas.storageDelta, deltas.fileDelta, deltas.mediaDelta, true
+		}
+	}
 	storageDelta, fileDelta, mediaDelta, err := b.store.PendingQuotaOutboxDeltasTx(tx)
 	if err != nil {
 		logger.Warn(ctx, "server_quota_pending_outbox_delta_fail_open",
@@ -358,6 +364,12 @@ func (b *Dat9Backend) pendingQuotaOutboxDeltasTx(ctx context.Context, tx *sql.Tx
 		return 0, 0, 0, false
 	}
 	return storageDelta, fileDelta, mediaDelta, true
+}
+
+func (b *Dat9Backend) addLocalQuotaPendingDeltas(storageDelta, fileDelta, mediaDelta int64) {
+	if b.quotaPendingCache != nil {
+		b.quotaPendingCache.add(storageDelta, fileDelta, mediaDelta)
+	}
 }
 
 func (r storageQuotaCheckResult) exceeded() bool {

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -165,6 +165,10 @@ func (b *Dat9Backend) ensureStorageQuotaServer(ctx context.Context, tx *sql.Tx, 
 	return nil
 }
 
+// ensureFileCountQuotaServer is a soft optimistic file-count check for small
+// create-like writes. Like storage soft admission, concurrent servers may
+// briefly over-admit within the quota usage/pending-delta cache TTL; strict
+// upload reservations keep using live counters under the admission lock.
 func (b *Dat9Backend) ensureFileCountQuotaServer(ctx context.Context, tx *sql.Tx, currentFileDelta int64) error {
 	if !b.UseServerQuota() || currentFileDelta <= 0 {
 		return nil

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -177,7 +177,7 @@ func (b *Dat9Backend) ensureFileCountQuotaServer(ctx context.Context, tx *sql.Tx
 	if cfg.MaxFileCount <= 0 {
 		return nil
 	}
-	usage := b.loadQuotaUsage(ctx)
+	usage := b.cachedQuotaUsage(ctx)
 	if usage == nil {
 		metrics.RecordOperation("server_quota", "file_count_check", "fail_open", 0)
 		return nil
@@ -211,7 +211,7 @@ func (b *Dat9Backend) checkStorageQuotaServerTx(ctx context.Context, tx *sql.Tx,
 	if cfg.MaxStorageBytes <= 0 {
 		return result, false // quota not configured
 	}
-	usage := b.loadQuotaUsage(ctx)
+	usage := b.cachedQuotaUsage(ctx)
 	if usage == nil {
 		metrics.RecordOperation("server_quota", "storage_check", "fail_open", 0)
 		return result, false // fail-open: usage unavailable
@@ -251,6 +251,10 @@ func (b *Dat9Backend) cachedQuotaConfig(ctx context.Context) *QuotaConfigView {
 		if cfg := b.quotaConfigCache.get(); cfg != nil {
 			return cfg
 		}
+		return b.quotaConfigCache.load(ctx)
+	}
+	if b.metaStore == nil {
+		return nil
 	}
 	cfg, err := b.metaStore.GetQuotaConfig(ctx, b.tenantID)
 	if err != nil {
@@ -261,9 +265,9 @@ func (b *Dat9Backend) cachedQuotaConfig(ctx context.Context) *QuotaConfigView {
 	return cfg
 }
 
-// loadQuotaUsage reads high-churn quota counters directly from the central DB.
-// Usage is not served from a per-process cache because multi-server deployments
-// would otherwise widen the stale window for quota checks.
+// loadQuotaUsage reads quota counters directly from the central DB. Use this
+// for strict quota paths such as upload reservations; small-write soft checks
+// use cachedQuotaUsage to avoid a central read on every write.
 func (b *Dat9Backend) loadQuotaUsage(ctx context.Context) *QuotaUsageView {
 	usage, err := b.metaStore.GetQuotaUsage(ctx, b.tenantID)
 	if err != nil {
@@ -272,6 +276,16 @@ func (b *Dat9Backend) loadQuotaUsage(ctx context.Context) *QuotaUsageView {
 		return nil
 	}
 	return usage
+}
+
+// cachedQuotaUsage reads central usage through a short TTL cache. It is only
+// used by soft small-write checks; strict upload reservation paths call
+// loadQuotaUsage directly.
+func (b *Dat9Backend) cachedQuotaUsage(ctx context.Context) *QuotaUsageView {
+	if b.quotaUsageCache != nil {
+		return b.quotaUsageCache.get(ctx)
+	}
+	return b.loadQuotaUsage(ctx)
 }
 
 // --- Server-side media file count (Rev 4 migration) ---
@@ -320,7 +334,7 @@ func (b *Dat9Backend) mediaLLMQuotaExceededServerTx(ctx context.Context, tx *sql
 	if cfg.MaxMediaLLMFiles <= 0 {
 		return false
 	}
-	usage := b.loadQuotaUsage(ctx)
+	usage := b.cachedQuotaUsage(ctx)
 	if usage == nil {
 		metrics.RecordOperation("server_quota", "media_check", "fail_open", 0)
 		return false

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -183,7 +183,7 @@ func (b *Dat9Backend) ensureFileCountQuotaServer(ctx context.Context, tx *sql.Tx
 		return nil
 	}
 	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
-	_, pendingFileDelta, _, pendingOK := b.pendingQuotaOutboxDeltasTx(ctx, tx)
+	_, pendingFileDelta, _, pendingOK := b.cachedPendingQuotaOutboxDeltasTx(ctx, tx)
 	if !pendingOK {
 		metrics.RecordOperation("server_quota", "file_count_check_pending_delta", "fail_open", 0)
 	}
@@ -217,7 +217,7 @@ func (b *Dat9Backend) checkStorageQuotaServerTx(ctx context.Context, tx *sql.Tx,
 		return result, false // fail-open: usage unavailable
 	}
 	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
-	pendingStorageDelta, _, _, pendingOK := b.pendingQuotaOutboxDeltasTx(ctx, tx)
+	pendingStorageDelta, _, _, pendingOK := b.cachedPendingQuotaOutboxDeltasTx(ctx, tx)
 	if !pendingOK {
 		metrics.RecordOperation("server_quota", "storage_check_pending_delta", "fail_open", 0)
 	}
@@ -340,14 +340,18 @@ func (b *Dat9Backend) mediaLLMQuotaExceededServerTx(ctx context.Context, tx *sql
 		return false
 	}
 	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
-	_, _, pendingMediaDelta, pendingOK := b.pendingQuotaOutboxDeltasTx(ctx, tx)
+	_, _, pendingMediaDelta, pendingOK := b.cachedPendingQuotaOutboxDeltasTx(ctx, tx)
 	if !pendingOK {
 		metrics.RecordOperation("server_quota", "media_check_pending_delta", "fail_open", 0)
 	}
 	return usage.MediaFileCount+pendingMediaDelta+currentMediaDelta > cfg.MaxMediaLLMFiles
 }
 
-func (b *Dat9Backend) pendingQuotaOutboxDeltasTx(ctx context.Context, tx *sql.Tx) (storageDelta, fileDelta, mediaDelta int64, ok bool) {
+// cachedPendingQuotaOutboxDeltasTx returns tenant-local pending quota deltas
+// for soft small-write checks. The short TTL cache avoids a SUM over
+// quota_outbox on every tiny write; strict upload reservations must call
+// livePendingQuotaOutboxDeltasTx under the admission lock instead.
+func (b *Dat9Backend) cachedPendingQuotaOutboxDeltasTx(ctx context.Context, tx *sql.Tx) (storageDelta, fileDelta, mediaDelta int64, ok bool) {
 	if b.store == nil || tx == nil {
 		return 0, 0, 0, true
 	}
@@ -356,6 +360,13 @@ func (b *Dat9Backend) pendingQuotaOutboxDeltasTx(ctx context.Context, tx *sql.Tx
 		if ok {
 			return deltas.storageDelta, deltas.fileDelta, deltas.mediaDelta, true
 		}
+	}
+	return b.livePendingQuotaOutboxDeltasTx(ctx, tx)
+}
+
+func (b *Dat9Backend) livePendingQuotaOutboxDeltasTx(ctx context.Context, tx *sql.Tx) (storageDelta, fileDelta, mediaDelta int64, ok bool) {
+	if b.store == nil || tx == nil {
+		return 0, 0, 0, true
 	}
 	storageDelta, fileDelta, mediaDelta, err := b.store.PendingQuotaOutboxDeltasTx(tx)
 	if err != nil {

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -31,6 +31,14 @@ type quotaConfigSnapshot struct {
 	version string
 }
 
+func cloneQuotaConfigView(cfg *QuotaConfigView) *QuotaConfigView {
+	if cfg == nil {
+		return nil
+	}
+	cp := *cfg
+	return &cp
+}
+
 // quotaConfigCache is a per-tenant cache for low-frequency quota config. It
 // only removes repeated config reads and uses version polling so config changes
 // converge without a cross-server invalidation channel.
@@ -70,8 +78,7 @@ func (c *quotaConfigCache) get() *QuotaConfigView {
 	if c.snapshot == nil || c.snapshot.config == nil {
 		return nil
 	}
-	cfg := *c.snapshot.config
-	return &cfg
+	return cloneQuotaConfigView(c.snapshot.config)
 }
 
 func (c *quotaConfigCache) load(ctx context.Context) *QuotaConfigView {
@@ -98,15 +105,15 @@ func (c *quotaConfigCache) load(ctx context.Context) *QuotaConfigView {
 	}
 	c.mu.Lock()
 	if c.snapshot != nil && c.snapshot.config != nil {
-		existing := *c.snapshot.config
+		existing := cloneQuotaConfigView(c.snapshot.config)
 		c.mu.Unlock()
 		metrics.RecordOperation("quota_config_cache", "load", "raced_refresh", time.Since(start))
-		return &existing
+		return existing
 	}
-	c.snapshot = &quotaConfigSnapshot{config: cfg, version: ""}
+	c.snapshot = &quotaConfigSnapshot{config: cloneQuotaConfigView(cfg), version: ""}
 	c.mu.Unlock()
 	metrics.RecordOperation("quota_config_cache", "load", "ok", time.Since(start))
-	return cfg
+	return cloneQuotaConfigView(cfg)
 }
 
 func (c *quotaConfigCache) stop() {
@@ -155,7 +162,7 @@ func (c *quotaConfigCache) refresh(ctx context.Context) {
 		return
 	}
 	c.mu.Lock()
-	c.snapshot = &quotaConfigSnapshot{config: cfg, version: version}
+	c.snapshot = &quotaConfigSnapshot{config: cloneQuotaConfigView(cfg), version: version}
 	c.mu.Unlock()
 	metrics.RecordOperation("quota_config_cache", "refresh", "ok", time.Since(start))
 }

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -173,14 +173,18 @@ type quotaUsageSnapshot struct {
 }
 
 // quotaUsageCache is used only by soft small-write admission checks. It avoids
-// one central DB read per 1KB write while keeping the stale window short.
+// one central DB read per tiny write while keeping the stale window short.
+// In multi-server deployments, each backend can briefly admit writes against a
+// usage snapshot that is stale by at most ttl; strict upload reservations must
+// continue to call loadQuotaUsage directly.
 type quotaUsageCache struct {
 	tenantID string
 	store    MetaQuotaStore
 	ttl      time.Duration
 
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	snapshot *quotaUsageSnapshot
+	loadMu   sync.Mutex
 }
 
 func newQuotaUsageCache(tenantID string, store MetaQuotaStore, ttl time.Duration) *quotaUsageCache {
@@ -192,11 +196,15 @@ func newQuotaUsageCache(tenantID string, store MetaQuotaStore, ttl time.Duration
 
 func (c *quotaUsageCache) get(ctx context.Context) *QuotaUsageView {
 	now := time.Now()
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.snapshot != nil && c.snapshot.usage != nil && now.Before(c.snapshot.expiresAt) {
-		usage := *c.snapshot.usage
-		return &usage
+	if usage := c.cached(now); usage != nil {
+		return usage
+	}
+
+	c.loadMu.Lock()
+	defer c.loadMu.Unlock()
+	now = time.Now()
+	if usage := c.cached(now); usage != nil {
+		return usage
 	}
 
 	start := time.Now()
@@ -211,12 +219,31 @@ func (c *quotaUsageCache) get(ctx context.Context) *QuotaUsageView {
 		metrics.RecordOperation("server_quota", "usage_cache", "load_empty", time.Since(start))
 		return nil
 	}
+	copied := *usage
+	c.mu.Lock()
 	c.snapshot = &quotaUsageSnapshot{
-		usage:     usage,
-		expiresAt: now.Add(c.ttl),
+		usage:     &copied,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+	metrics.RecordOperation("server_quota", "usage_cache", "load_ok", time.Since(start))
+	return cloneQuotaUsageView(usage)
+}
+
+func (c *quotaUsageCache) cached(now time.Time) *QuotaUsageView {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.snapshot != nil && c.snapshot.usage != nil && now.Before(c.snapshot.expiresAt) {
+		return cloneQuotaUsageView(c.snapshot.usage)
+	}
+	return nil
+}
+
+func cloneQuotaUsageView(usage *QuotaUsageView) *QuotaUsageView {
+	if usage == nil {
+		return nil
 	}
 	copied := *usage
-	metrics.RecordOperation("server_quota", "usage_cache", "load_ok", time.Since(start))
 	return &copied
 }
 
@@ -288,6 +315,9 @@ func (c *quotaPendingDeltasCache) add(storageDelta, fileDelta, mediaDelta int64)
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// If the snapshot is missing or expired, leave it cold. The next soft
+	// admission check reloads from quota_outbox and sees this backend's queued
+	// row along with rows from other servers.
 	if c.snapshot == nil || time.Now().After(c.snapshot.expiresAt) {
 		return
 	}

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -239,6 +239,15 @@ func (c *quotaUsageCache) cached(now time.Time) *QuotaUsageView {
 	return nil
 }
 
+func (c *quotaUsageCache) invalidate() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.snapshot = nil
+	c.mu.Unlock()
+}
+
 func cloneQuotaUsageView(usage *QuotaUsageView) *QuotaUsageView {
 	if usage == nil {
 		return nil
@@ -267,8 +276,10 @@ type quotaPendingDeltasCache struct {
 	load quotaPendingDeltasLoader
 	ttl  time.Duration
 
-	mu       sync.Mutex
-	snapshot *quotaPendingDeltasSnapshot
+	mu         sync.RWMutex
+	snapshot   *quotaPendingDeltasSnapshot
+	generation uint64
+	loadMu     sync.Mutex
 }
 
 func newQuotaPendingDeltasCache(load quotaPendingDeltasLoader, ttl time.Duration) *quotaPendingDeltasCache {
@@ -283,11 +294,20 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 		return quotaPendingDeltas{}, false
 	}
 	now := time.Now()
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.snapshot != nil && now.Before(c.snapshot.expiresAt) {
-		return c.snapshot.deltas, true
+	if deltas, ok := c.cached(now); ok {
+		return deltas, true
 	}
+
+	c.loadMu.Lock()
+	defer c.loadMu.Unlock()
+	now = time.Now()
+	if deltas, ok := c.cached(now); ok {
+		return deltas, true
+	}
+
+	c.mu.RLock()
+	generation := c.generation
+	c.mu.RUnlock()
 
 	start := time.Now()
 	storageDelta, fileDelta, mediaDelta, err := c.load(ctx)
@@ -301,12 +321,32 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 		fileDelta:    fileDelta,
 		mediaDelta:   mediaDelta,
 	}
+	expiresAt := time.Now().Add(c.ttl)
+	c.mu.Lock()
+	if c.generation != generation {
+		c.mu.Unlock()
+		// A local enqueue or ack raced this DB load. Do not merge blindly:
+		// the SELECT may or may not have observed that row. Let the caller
+		// fall back to a live tenant-DB read for this check.
+		metrics.RecordOperation("server_quota", "pending_delta_cache", "raced_local_delta", time.Since(start))
+		return quotaPendingDeltas{}, false
+	}
 	c.snapshot = &quotaPendingDeltasSnapshot{
 		deltas:    deltas,
-		expiresAt: now.Add(c.ttl),
+		expiresAt: expiresAt,
 	}
+	c.mu.Unlock()
 	metrics.RecordOperation("server_quota", "pending_delta_cache", "load_ok", time.Since(start))
 	return deltas, true
+}
+
+func (c *quotaPendingDeltasCache) cached(now time.Time) (quotaPendingDeltas, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.snapshot != nil && now.Before(c.snapshot.expiresAt) {
+		return c.snapshot.deltas, true
+	}
+	return quotaPendingDeltas{}, false
 }
 
 func (c *quotaPendingDeltasCache) add(storageDelta, fileDelta, mediaDelta int64) {
@@ -315,9 +355,11 @@ func (c *quotaPendingDeltasCache) add(storageDelta, fileDelta, mediaDelta int64)
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	// If the snapshot is missing or expired, leave it cold. The next soft
-	// admission check reloads from quota_outbox and sees this backend's queued
-	// row along with rows from other servers.
+	c.generation++
+	// If the snapshot is missing or expired, leave it cold. The generation bump
+	// prevents any concurrent loader from publishing a pre-delta snapshot; the
+	// next soft admission check reloads from quota_outbox and sees this
+	// backend's queued row along with rows from other servers.
 	if c.snapshot == nil || time.Now().After(c.snapshot.expiresAt) {
 		return
 	}

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -15,6 +15,10 @@ const (
 	// quotaConfigCacheRefreshInterval is how often the background goroutine
 	// polls the tenant quota config version from the central DB.
 	quotaConfigCacheRefreshInterval = 30 * time.Second
+	// quotaUsageCacheTTL bounds how long soft small-write quota checks may
+	// reuse central usage counters. Strict upload reservations still read
+	// central usage directly.
+	quotaUsageCacheTTL = 100 * time.Millisecond
 )
 
 type quotaConfigSnapshot struct {
@@ -35,14 +39,16 @@ type quotaConfigCache struct {
 
 	mu       sync.RWMutex
 	snapshot *quotaConfigSnapshot
+	loadMu   sync.Mutex
 
 	cancel context.CancelFunc
 	done   chan struct{}
 }
 
 // newQuotaConfigCache creates and starts a background-refreshing config cache.
-// Performs one best-effort synchronous initial load so the first quota check
-// usually has config available. If the initial load fails, callers fail open.
+// Backend construction must stay cheap for read-only operations such as ls, so
+// the initial load is lazy: the first quota check loads config on demand and
+// the background refresher keeps it current after that.
 func newQuotaConfigCache(tenantID string, store MetaQuotaStore) *quotaConfigCache {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &quotaConfigCache{
@@ -51,7 +57,6 @@ func newQuotaConfigCache(tenantID string, store MetaQuotaStore) *quotaConfigCach
 		cancel:   cancel,
 		done:     make(chan struct{}),
 	}
-	c.refresh(ctx)
 	go c.run(ctx)
 	return c
 }
@@ -66,6 +71,39 @@ func (c *quotaConfigCache) get() *QuotaConfigView {
 	}
 	cfg := *c.snapshot.config
 	return &cfg
+}
+
+func (c *quotaConfigCache) load(ctx context.Context) *QuotaConfigView {
+	if cfg := c.get(); cfg != nil {
+		return cfg
+	}
+	c.loadMu.Lock()
+	defer c.loadMu.Unlock()
+	if cfg := c.get(); cfg != nil {
+		return cfg
+	}
+
+	start := time.Now()
+	cfg, err := c.store.GetQuotaConfig(ctx, c.tenantID)
+	if err != nil {
+		logger.Warn(ctx, "quota_config_cache_config_failed",
+			zap.String("tenant_id", c.tenantID), zap.Error(err))
+		metrics.RecordOperation("quota_config_cache", "load", "config_error", time.Since(start))
+		return nil
+	}
+	if cfg == nil {
+		metrics.RecordOperation("quota_config_cache", "load", "config_empty", time.Since(start))
+		return nil
+	}
+	c.mu.Lock()
+	version := ""
+	if c.snapshot != nil {
+		version = c.snapshot.version
+	}
+	c.snapshot = &quotaConfigSnapshot{config: cfg, version: version}
+	c.mu.Unlock()
+	metrics.RecordOperation("quota_config_cache", "load", "ok", time.Since(start))
+	return cfg
 }
 
 func (c *quotaConfigCache) stop() {
@@ -117,4 +155,57 @@ func (c *quotaConfigCache) refresh(ctx context.Context) {
 	c.snapshot = &quotaConfigSnapshot{config: cfg, version: version}
 	c.mu.Unlock()
 	metrics.RecordOperation("quota_config_cache", "refresh", "ok", time.Since(start))
+}
+
+type quotaUsageSnapshot struct {
+	usage     *QuotaUsageView
+	expiresAt time.Time
+}
+
+// quotaUsageCache is used only by soft small-write admission checks. It avoids
+// one central DB read per 1KB write while keeping the stale window short.
+type quotaUsageCache struct {
+	tenantID string
+	store    MetaQuotaStore
+	ttl      time.Duration
+
+	mu       sync.Mutex
+	snapshot *quotaUsageSnapshot
+}
+
+func newQuotaUsageCache(tenantID string, store MetaQuotaStore, ttl time.Duration) *quotaUsageCache {
+	if ttl <= 0 {
+		ttl = quotaUsageCacheTTL
+	}
+	return &quotaUsageCache{tenantID: tenantID, store: store, ttl: ttl}
+}
+
+func (c *quotaUsageCache) get(ctx context.Context) *QuotaUsageView {
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.snapshot != nil && c.snapshot.usage != nil && now.Before(c.snapshot.expiresAt) {
+		usage := *c.snapshot.usage
+		return &usage
+	}
+
+	start := time.Now()
+	usage, err := c.store.GetQuotaUsage(ctx, c.tenantID)
+	if err != nil {
+		logger.Warn(ctx, "server_quota_usage_fail_open",
+			zap.String("tenant_id", c.tenantID), zap.Error(err))
+		metrics.RecordOperation("server_quota", "usage_cache", "load_error", time.Since(start))
+		return nil
+	}
+	if usage == nil {
+		metrics.RecordOperation("server_quota", "usage_cache", "load_empty", time.Since(start))
+		return nil
+	}
+	c.snapshot = &quotaUsageSnapshot{
+		usage:     usage,
+		expiresAt: now.Add(c.ttl),
+	}
+	copied := *usage
+	metrics.RecordOperation("server_quota", "usage_cache", "load_ok", time.Since(start))
+	return &copied
 }

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -19,6 +19,11 @@ const (
 	// reuse central usage counters. Strict upload reservations still read
 	// central usage directly.
 	quotaUsageCacheTTL = 100 * time.Millisecond
+	// quotaPendingDeltasCacheTTL bounds tenant-local pending outbox aggregate
+	// reuse for soft small-write checks. The cache is adjusted for mutations
+	// enqueued/acked by this backend instance and periodically reloads to see
+	// other servers.
+	quotaPendingDeltasCacheTTL = 100 * time.Millisecond
 )
 
 type quotaConfigSnapshot struct {
@@ -26,13 +31,9 @@ type quotaConfigSnapshot struct {
 	version string
 }
 
-// quotaConfigCache is a per-tenant cache for low-frequency quota config.
-//
-// It intentionally does not cache usage counters. In multi-server deployments,
-// storage_bytes/reserved_bytes/file_count/media_file_count are high-churn shared
-// state, so quota checks read those counters from the central DB directly. This
-// cache only removes repeated config reads and uses version polling so config
-// changes converge without a cross-server invalidation channel.
+// quotaConfigCache is a per-tenant cache for low-frequency quota config. It
+// only removes repeated config reads and uses version polling so config changes
+// converge without a cross-server invalidation channel.
 type quotaConfigCache struct {
 	tenantID string
 	store    MetaQuotaStore
@@ -208,4 +209,80 @@ func (c *quotaUsageCache) get(ctx context.Context) *QuotaUsageView {
 	copied := *usage
 	metrics.RecordOperation("server_quota", "usage_cache", "load_ok", time.Since(start))
 	return &copied
+}
+
+type quotaPendingDeltas struct {
+	storageDelta int64
+	fileDelta    int64
+	mediaDelta   int64
+}
+
+type quotaPendingDeltasSnapshot struct {
+	deltas    quotaPendingDeltas
+	expiresAt time.Time
+}
+
+type quotaPendingDeltasLoader func(context.Context) (storageDelta, fileDelta, mediaDelta int64, err error)
+
+// quotaPendingDeltasCache avoids SUM(quota_outbox) on every small write. It is
+// only used by soft admission checks; strict upload reservation still reads the
+// tenant DB directly.
+type quotaPendingDeltasCache struct {
+	load quotaPendingDeltasLoader
+	ttl  time.Duration
+
+	mu       sync.Mutex
+	snapshot *quotaPendingDeltasSnapshot
+}
+
+func newQuotaPendingDeltasCache(load quotaPendingDeltasLoader, ttl time.Duration) *quotaPendingDeltasCache {
+	if ttl <= 0 {
+		ttl = quotaPendingDeltasCacheTTL
+	}
+	return &quotaPendingDeltasCache{load: load, ttl: ttl}
+}
+
+func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, bool) {
+	if c == nil || c.load == nil {
+		return quotaPendingDeltas{}, false
+	}
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.snapshot != nil && now.Before(c.snapshot.expiresAt) {
+		return c.snapshot.deltas, true
+	}
+
+	start := time.Now()
+	storageDelta, fileDelta, mediaDelta, err := c.load(ctx)
+	if err != nil {
+		logger.Warn(ctx, "server_quota_pending_outbox_delta_fail_open", zap.Error(err))
+		metrics.RecordOperation("server_quota", "pending_delta_cache", "load_error", time.Since(start))
+		return quotaPendingDeltas{}, false
+	}
+	deltas := quotaPendingDeltas{
+		storageDelta: storageDelta,
+		fileDelta:    fileDelta,
+		mediaDelta:   mediaDelta,
+	}
+	c.snapshot = &quotaPendingDeltasSnapshot{
+		deltas:    deltas,
+		expiresAt: now.Add(c.ttl),
+	}
+	metrics.RecordOperation("server_quota", "pending_delta_cache", "load_ok", time.Since(start))
+	return deltas, true
+}
+
+func (c *quotaPendingDeltasCache) add(storageDelta, fileDelta, mediaDelta int64) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.snapshot == nil || time.Now().After(c.snapshot.expiresAt) {
+		return
+	}
+	c.snapshot.deltas.storageDelta += storageDelta
+	c.snapshot.deltas.fileDelta += fileDelta
+	c.snapshot.deltas.mediaDelta += mediaDelta
 }

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -97,11 +97,13 @@ func (c *quotaConfigCache) load(ctx context.Context) *QuotaConfigView {
 		return nil
 	}
 	c.mu.Lock()
-	version := ""
-	if c.snapshot != nil {
-		version = c.snapshot.version
+	if c.snapshot != nil && c.snapshot.config != nil {
+		existing := *c.snapshot.config
+		c.mu.Unlock()
+		metrics.RecordOperation("quota_config_cache", "load", "raced_refresh", time.Since(start))
+		return &existing
 	}
-	c.snapshot = &quotaConfigSnapshot{config: cfg, version: version}
+	c.snapshot = &quotaConfigSnapshot{config: cfg, version: ""}
 	c.mu.Unlock()
 	metrics.RecordOperation("quota_config_cache", "load", "ok", time.Since(start))
 	return cfg

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ type cacheTestStore struct {
 	versionErr   error
 	configErr    error
 	configHook   func()
+	usageHook    func()
 }
 
 func newCacheTestStore() *cacheTestStore {
@@ -24,6 +26,9 @@ func newCacheTestStore() *cacheTestStore {
 
 func (m *cacheTestStore) GetQuotaUsage(ctx context.Context, tenantID string) (*QuotaUsageView, error) {
 	m.usageCalls.Add(1)
+	if m.usageHook != nil {
+		m.usageHook()
+	}
 	return m.fakeMetaQuotaStore.GetQuotaUsage(ctx, tenantID)
 }
 
@@ -211,6 +216,39 @@ func TestQuotaUsageCacheUsesTTL(t *testing.T) {
 	second := c.get(context.Background())
 	if second == nil || second.StorageBytes != 10 {
 		t.Fatalf("second usage = %+v, want cached storage 10", second)
+	}
+	if got := store.usageCalls.Load(); got != 1 {
+		t.Fatalf("usageCalls = %d, want 1", got)
+	}
+}
+
+func TestQuotaUsageCacheCoalescesConcurrentMisses(t *testing.T) {
+	store := newCacheTestStore()
+	store.usage["t1"] = &QuotaUsageView{TenantID: "t1", StorageBytes: 10}
+	c := newQuotaUsageCache("t1", store, time.Hour)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	store.usageHook = func() {
+		once.Do(func() { close(started) })
+		<-release
+	}
+
+	const workers = 5
+	results := make(chan *QuotaUsageView, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			results <- c.get(context.Background())
+		}()
+	}
+
+	<-started
+	close(release)
+	for i := 0; i < workers; i++ {
+		usage := <-results
+		if usage == nil || usage.StorageBytes != 10 {
+			t.Fatalf("usage = %+v, want storage 10", usage)
+		}
 	}
 	if got := store.usageCalls.Load(); got != 1 {
 		t.Fatalf("usageCalls = %d, want 1", got)

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // cacheTestStore wraps fakeMetaQuotaStore with error injection for cache tests.
@@ -41,21 +42,32 @@ func (m *cacheTestStore) GetQuotaConfigVersion(ctx context.Context, tenantID str
 	return m.fakeMetaQuotaStore.GetQuotaConfigVersion(ctx, tenantID)
 }
 
-func TestQuotaConfigCacheInitialLoad(t *testing.T) {
+func TestQuotaConfigCacheLazyLoad(t *testing.T) {
 	store := newCacheTestStore()
 	store.config["t1"] = &QuotaConfigView{MaxStorageBytes: 1000}
 	c := newQuotaConfigCache("t1", store)
 	defer c.stop()
 
 	cfg := c.get()
+	if cfg != nil {
+		t.Fatalf("config = %+v, want nil before lazy load", cfg)
+	}
+	if got := store.versionCalls.Load(); got != 0 {
+		t.Fatalf("versionCalls = %d, want 0", got)
+	}
+	if got := store.configCalls.Load(); got != 0 {
+		t.Fatalf("configCalls = %d, want 0", got)
+	}
+
+	cfg = c.load(context.Background())
 	if cfg == nil {
-		t.Fatal("config is nil")
+		t.Fatal("config is nil after lazy load")
 	}
 	if cfg.MaxStorageBytes != 1000 {
 		t.Fatalf("MaxStorageBytes = %d, want 1000", cfg.MaxStorageBytes)
 	}
-	if got := store.versionCalls.Load(); got != 1 {
-		t.Fatalf("versionCalls = %d, want 1", got)
+	if got := store.versionCalls.Load(); got != 0 {
+		t.Fatalf("versionCalls = %d, want 0", got)
 	}
 	if got := store.configCalls.Load(); got != 1 {
 		t.Fatalf("configCalls = %d, want 1", got)
@@ -65,12 +77,13 @@ func TestQuotaConfigCacheInitialLoad(t *testing.T) {
 	}
 }
 
-func TestQuotaConfigCacheFailOpenOnVersionError(t *testing.T) {
+func TestQuotaConfigCacheRefreshFailOpenOnVersionError(t *testing.T) {
 	store := newCacheTestStore()
 	store.versionErr = context.DeadlineExceeded
 	c := newQuotaConfigCache("t1", store)
 	defer c.stop()
 
+	c.refresh(context.Background())
 	if cfg := c.get(); cfg != nil {
 		t.Fatalf("config = %+v, want nil", cfg)
 	}
@@ -90,6 +103,14 @@ func TestQuotaConfigCacheRefreshOnlyLoadsConfigWhenVersionChanges(t *testing.T) 
 	store.config["t1"] = &QuotaConfigView{MaxStorageBytes: 1000}
 	c := newQuotaConfigCache("t1", store)
 	defer c.stop()
+
+	c.refresh(context.Background())
+	if got := store.versionCalls.Load(); got != 1 {
+		t.Fatalf("versionCalls = %d, want 1", got)
+	}
+	if got := store.configCalls.Load(); got != 1 {
+		t.Fatalf("configCalls = %d, want 1", got)
+	}
 
 	c.refresh(context.Background())
 	if got := store.versionCalls.Load(); got != 2 {
@@ -119,6 +140,27 @@ func TestQuotaConfigCacheRefreshOnlyLoadsConfigWhenVersionChanges(t *testing.T) 
 	}
 	if got := store.usageCalls.Load(); got != 0 {
 		t.Fatalf("usageCalls = %d, want 0", got)
+	}
+}
+
+func TestQuotaUsageCacheUsesTTL(t *testing.T) {
+	store := newCacheTestStore()
+	store.usage["t1"] = &QuotaUsageView{TenantID: "t1", StorageBytes: 10}
+	c := newQuotaUsageCache("t1", store, time.Hour)
+
+	first := c.get(context.Background())
+	if first == nil || first.StorageBytes != 10 {
+		t.Fatalf("first usage = %+v, want storage 10", first)
+	}
+	store.mu.Lock()
+	store.usage["t1"].StorageBytes = 20
+	store.mu.Unlock()
+	second := c.get(context.Background())
+	if second == nil || second.StorageBytes != 10 {
+		t.Fatalf("second usage = %+v, want cached storage 10", second)
+	}
+	if got := store.usageCalls.Load(); got != 1 {
+		t.Fatalf("usageCalls = %d, want 1", got)
 	}
 }
 

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -255,6 +255,32 @@ func TestQuotaUsageCacheCoalescesConcurrentMisses(t *testing.T) {
 	}
 }
 
+func TestQuotaUsageCacheInvalidateForcesReload(t *testing.T) {
+	store := newCacheTestStore()
+	store.usage["t1"] = &QuotaUsageView{TenantID: "t1", StorageBytes: 10}
+	c := newQuotaUsageCache("t1", store, time.Hour)
+
+	first := c.get(context.Background())
+	if first == nil || first.StorageBytes != 10 {
+		t.Fatalf("first usage = %+v, want storage 10", first)
+	}
+	store.mu.Lock()
+	store.usage["t1"].StorageBytes = 20
+	store.mu.Unlock()
+	if cached := c.get(context.Background()); cached == nil || cached.StorageBytes != 10 {
+		t.Fatalf("cached usage = %+v, want storage 10", cached)
+	}
+
+	c.invalidate()
+	reloaded := c.get(context.Background())
+	if reloaded == nil || reloaded.StorageBytes != 20 {
+		t.Fatalf("reloaded usage = %+v, want storage 20", reloaded)
+	}
+	if got := store.usageCalls.Load(); got != 2 {
+		t.Fatalf("usageCalls = %d, want 2", got)
+	}
+}
+
 func TestQuotaPendingDeltasCacheUsesTTLAndLocalAdjustments(t *testing.T) {
 	var calls atomic.Int64
 	storage := int64(10)
@@ -285,6 +311,50 @@ func TestQuotaPendingDeltasCacheUsesTTLAndLocalAdjustments(t *testing.T) {
 	}
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("loader calls = %d, want 1", got)
+	}
+}
+
+func TestQuotaPendingDeltasCacheDoesNotPublishSnapshotWhenLocalDeltaRacesLoad(t *testing.T) {
+	var calls atomic.Int64
+	storage := int64(10)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	c := newQuotaPendingDeltasCache(func(context.Context) (int64, int64, int64, error) {
+		calls.Add(1)
+		once.Do(func() { close(started) })
+		<-release
+		return storage, 1, 0, nil
+	}, time.Hour)
+
+	type result struct {
+		deltas quotaPendingDeltas
+		ok     bool
+	}
+	done := make(chan result, 1)
+	go func() {
+		deltas, ok := c.get(context.Background())
+		done <- result{deltas: deltas, ok: ok}
+	}()
+
+	<-started
+	c.add(5, 1, 0)
+	storage = 15
+	close(release)
+
+	got := <-done
+	if got.ok {
+		t.Fatalf("racing get ok=true deltas=%+v, want fallback", got.deltas)
+	}
+	next, ok := c.get(context.Background())
+	if !ok {
+		t.Fatal("second get failed")
+	}
+	if next.storageDelta != 15 || next.fileDelta != 1 || next.mediaDelta != 0 {
+		t.Fatalf("second deltas = %+v, want 15/1/0", next)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("loader calls = %d, want 2", got)
 	}
 }
 

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -175,6 +175,27 @@ func TestQuotaConfigCacheLazyLoadDoesNotOverwriteRefreshedSnapshot(t *testing.T)
 	}
 }
 
+func TestQuotaConfigCacheLazyLoadReturnsDefensiveCopy(t *testing.T) {
+	store := newCacheTestStore()
+	store.config["t1"] = &QuotaConfigView{MaxStorageBytes: 1000}
+	c := newQuotaConfigCache("t1", store)
+	defer c.stop()
+
+	cfg := c.load(context.Background())
+	if cfg == nil {
+		t.Fatal("config is nil")
+	}
+	cfg.MaxStorageBytes = 2000
+
+	cached := c.get()
+	if cached == nil {
+		t.Fatal("cached config is nil")
+	}
+	if cached.MaxStorageBytes != 1000 {
+		t.Fatalf("cached MaxStorageBytes = %d, want 1000", cached.MaxStorageBytes)
+	}
+}
+
 func TestQuotaUsageCacheUsesTTL(t *testing.T) {
 	store := newCacheTestStore()
 	store.usage["t1"] = &QuotaUsageView{TenantID: "t1", StorageBytes: 10}

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -164,6 +164,39 @@ func TestQuotaUsageCacheUsesTTL(t *testing.T) {
 	}
 }
 
+func TestQuotaPendingDeltasCacheUsesTTLAndLocalAdjustments(t *testing.T) {
+	var calls atomic.Int64
+	storage := int64(10)
+	file := int64(1)
+	media := int64(0)
+	c := newQuotaPendingDeltasCache(func(context.Context) (int64, int64, int64, error) {
+		calls.Add(1)
+		return storage, file, media, nil
+	}, time.Hour)
+
+	first, ok := c.get(context.Background())
+	if !ok {
+		t.Fatal("first get failed")
+	}
+	if first.storageDelta != 10 || first.fileDelta != 1 || first.mediaDelta != 0 {
+		t.Fatalf("first deltas = %+v, want 10/1/0", first)
+	}
+
+	storage = 99
+	file = 9
+	c.add(5, 2, 1)
+	second, ok := c.get(context.Background())
+	if !ok {
+		t.Fatal("second get failed")
+	}
+	if second.storageDelta != 15 || second.fileDelta != 3 || second.mediaDelta != 1 {
+		t.Fatalf("second deltas = %+v, want 15/3/1", second)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("loader calls = %d, want 1", got)
+	}
+}
+
 func TestQuotaConfigCacheStop(t *testing.T) {
 	store := newCacheTestStore()
 	c := newQuotaConfigCache("t1", store)

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -15,6 +15,7 @@ type cacheTestStore struct {
 	usageCalls   atomic.Int64
 	versionErr   error
 	configErr    error
+	configHook   func()
 }
 
 func newCacheTestStore() *cacheTestStore {
@@ -30,6 +31,9 @@ func (m *cacheTestStore) GetQuotaConfig(ctx context.Context, tenantID string) (*
 	m.configCalls.Add(1)
 	if m.configErr != nil {
 		return nil, m.configErr
+	}
+	if m.configHook != nil {
+		m.configHook()
 	}
 	return m.fakeMetaQuotaStore.GetQuotaConfig(ctx, tenantID)
 }
@@ -140,6 +144,34 @@ func TestQuotaConfigCacheRefreshOnlyLoadsConfigWhenVersionChanges(t *testing.T) 
 	}
 	if got := store.usageCalls.Load(); got != 0 {
 		t.Fatalf("usageCalls = %d, want 0", got)
+	}
+}
+
+func TestQuotaConfigCacheLazyLoadDoesNotOverwriteRefreshedSnapshot(t *testing.T) {
+	store := newCacheTestStore()
+	store.config["t1"] = &QuotaConfigView{MaxStorageBytes: 1000}
+	c := newQuotaConfigCache("t1", store)
+	defer c.stop()
+
+	store.configHook = func() {
+		c.mu.Lock()
+		c.snapshot = &quotaConfigSnapshot{
+			config:  &QuotaConfigView{MaxStorageBytes: 2000},
+			version: "new-version",
+		}
+		c.mu.Unlock()
+	}
+
+	cfg := c.load(context.Background())
+	if cfg == nil {
+		t.Fatal("config is nil")
+	}
+	if cfg.MaxStorageBytes != 2000 {
+		t.Fatalf("lazy load config = %d, want refreshed 2000", cfg.MaxStorageBytes)
+	}
+	cached := c.get()
+	if cached == nil || cached.MaxStorageBytes != 2000 {
+		t.Fatalf("cached config = %+v, want refreshed 2000", cached)
 	}
 }
 

--- a/pkg/backend/quota_integration_test.go
+++ b/pkg/backend/quota_integration_test.go
@@ -25,7 +25,7 @@ func newServerQuotaBackend(t *testing.T, opts Options) (*Dat9Backend, *fakeMetaQ
 		MaxMediaLLMFiles: 1000,
 		MaxMonthlyCostMC: 1 << 30,
 	}
-	b.SetMetaQuotaStore("tenant-a", fake)
+	b.SetMetaQuotaStore(context.Background(), "tenant-a", fake)
 	return b, fake
 }
 
@@ -66,7 +66,7 @@ func TestServerQuotaFeatureFlagRejectsOverLimitWrite(t *testing.T) {
 		TenantID:     "tenant-a",
 		StorageBytes: 8,
 	}
-	b.SetMetaQuotaStore("tenant-a", fake)
+	b.SetMetaQuotaStore(context.Background(), "tenant-a", fake)
 
 	if _, err := b.Write("/beta.txt", []byte("xyz"), 0, filesystem.WriteFlagCreate); !errors.Is(err, ErrStorageQuotaExceeded) {
 		t.Fatalf("expected ErrStorageQuotaExceeded from server quota path, got %v", err)

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -510,7 +510,7 @@ func newCentralQuotaBackend(t *testing.T) (*Dat9Backend, *fakeMetaQuotaStore) {
 		MaxMediaLLMFiles: 1000,
 		MaxMonthlyCostMC: 1 << 30,
 	}
-	b.SetMetaQuotaStore("tenant-a", fake)
+	b.SetMetaQuotaStore(context.Background(), "tenant-a", fake)
 	return b, fake
 }
 

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -353,6 +353,53 @@ func TestServerQuotaPendingOutboxDeltaRejectsUploadReserve(t *testing.T) {
 	}
 }
 
+func TestServerQuotaUploadReserveUsesLivePendingOutboxDeltas(t *testing.T) {
+	b, fake := newServerQuotaBackend(t, Options{})
+	b.stopQuotaOutboxWorker()
+	ctx := context.Background()
+
+	fake.mu.Lock()
+	fake.config["tenant-a"].MaxStorageBytes = 10
+	fake.mu.Unlock()
+	b.quotaConfigCache.refresh(ctx)
+
+	if b.quotaPendingCache == nil {
+		t.Fatal("quota pending cache is nil")
+	}
+	cached, ok := b.quotaPendingCache.get(ctx)
+	if !ok {
+		t.Fatal("warm quota pending cache failed")
+	}
+	if cached.storageDelta != 0 || cached.fileDelta != 0 || cached.mediaDelta != 0 {
+		t.Fatalf("initial cached pending deltas = %+v, want zero", cached)
+	}
+
+	if _, err := b.store.EnqueueQuotaOutboxTx(b.store.DB(), &datastore.QuotaOutboxEntry{
+		FileID:       "other-server-file",
+		MutationType: quotaMutationTypeFileCreate,
+		MutationData: json.RawMessage(`{}`),
+		StorageDelta: 8,
+		FileDelta:    1,
+	}); err != nil {
+		t.Fatalf("enqueue quota outbox: %v", err)
+	}
+
+	reserved, err := b.reserveUploadOnServer(ctx, "upload-live-pending", "/upload.bin", 3, 0)
+	if !errors.Is(err, ErrStorageQuotaExceeded) {
+		t.Fatalf("reserve error = %v, want ErrStorageQuotaExceeded", err)
+	}
+	if reserved {
+		t.Fatal("reserve should be false when live pending outbox pushes tenant over limit")
+	}
+	usage, err := fake.GetQuotaUsage(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("get usage after rejected reserve: %v", err)
+	}
+	if usage.ReservedBytes != 0 {
+		t.Fatalf("reserved bytes after rejected reserve = %d, want 0", usage.ReservedBytes)
+	}
+}
+
 func TestServerQuotaReserveUploadRetrySkipsPendingPrecheck(t *testing.T) {
 	b, fake := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -184,6 +184,104 @@ func TestQuotaOutboxWorkerCommitsRetryAfterApplyError(t *testing.T) {
 	}
 }
 
+func TestQuotaOutboxNotifyQuietHasMaxWait(t *testing.T) {
+	b := &Dat9Backend{quotaOutboxNotify: make(chan struct{}, quotaOutboxNotifySize)}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				select {
+				case b.quotaOutboxNotify <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+
+	start := time.Now()
+	if !b.waitQuotaOutboxNotifyQuiet(ctx) {
+		t.Fatal("waitQuotaOutboxNotifyQuiet returned false")
+	}
+	if dur := time.Since(start); dur > 500*time.Millisecond {
+		t.Fatalf("waitQuotaOutboxNotifyQuiet duration = %s, want bounded by max delay", dur)
+	}
+}
+
+func TestDrainQuotaOutboxForFileErrorsWhenPendingRowIsNotClaimable(t *testing.T) {
+	b, _ := newServerQuotaBackend(t, Options{})
+	b.stopQuotaOutboxWorker()
+	ctx := context.Background()
+
+	if _, err := b.WriteCtx(ctx, "/leased.txt", []byte("payload"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	nf, err := b.Store().Stat(ctx, "/leased.txt")
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	claimed, found, err := b.store.ClaimQuotaOutbox(ctx, time.Now().UTC(), time.Minute)
+	if err != nil {
+		t.Fatalf("claim quota outbox: %v", err)
+	}
+	if !found || claimed.FileID != nf.File.FileID {
+		t.Fatalf("claimed = %+v found=%t, want leased row for target", claimed, found)
+	}
+
+	drainCtx, cancel := context.WithTimeout(ctx, 75*time.Millisecond)
+	defer cancel()
+	err = b.drainQuotaOutboxForFile(drainCtx, nf.File.FileID, quotaOutboxUploadDrainLimit)
+	if err == nil {
+		t.Fatal("drain error = nil, want pending-not-claimable error")
+	}
+}
+
+func TestDrainQuotaOutboxForUploadTargetProcessesOlderTenantRows(t *testing.T) {
+	b, fake := newServerQuotaBackend(t, Options{})
+	b.stopQuotaOutboxWorker()
+	ctx := context.Background()
+
+	if _, err := b.WriteCtx(ctx, "/older.txt", []byte("older"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatalf("write older: %v", err)
+	}
+	older, err := b.Store().Stat(ctx, "/older.txt")
+	if err != nil {
+		t.Fatalf("stat older: %v", err)
+	}
+	if _, err := b.WriteCtx(ctx, "/target.txt", []byte("target"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	target, err := b.Store().Stat(ctx, "/target.txt")
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+
+	if err := b.drainQuotaOutboxForUploadTarget(ctx, target, true); err != nil {
+		t.Fatalf("drain target: %v", err)
+	}
+	if got := countQuotaOutboxRowsByFile(t, ctx, b, older.File.FileID, datastore.QuotaOutboxSucceeded); got != 1 {
+		t.Fatalf("older succeeded rows = %d, want 1", got)
+	}
+	if got := countQuotaOutboxRowsByFile(t, ctx, b, target.File.FileID, datastore.QuotaOutboxSucceeded); got != 1 {
+		t.Fatalf("target succeeded rows = %d, want 1", got)
+	}
+	usage, err := fake.GetQuotaUsage(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("get usage: %v", err)
+	}
+	if usage.StorageBytes != int64(len("older")+len("target")) || usage.FileCount != 2 {
+		t.Fatalf("central usage after drain = %+v, want both files applied", usage)
+	}
+}
+
 func TestServerQuotaPendingOutboxDeltaRejectsOverLimitWrite(t *testing.T) {
 	b, fake := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -216,6 +216,24 @@ func TestQuotaOutboxNotifyQuietHasMaxWait(t *testing.T) {
 	}
 }
 
+func TestQuotaOutboxNotifyQuietReturnsAfterQuietPeriod(t *testing.T) {
+	b := &Dat9Backend{quotaOutboxNotify: make(chan struct{}, quotaOutboxNotifySize)}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	start := time.Now()
+	if !b.waitQuotaOutboxNotifyQuiet(ctx) {
+		t.Fatal("waitQuotaOutboxNotifyQuiet returned false")
+	}
+	dur := time.Since(start)
+	if dur < quotaOutboxNotifyDelay/2 {
+		t.Fatalf("waitQuotaOutboxNotifyQuiet duration = %s, want quiet-period wait", dur)
+	}
+	if dur > quotaOutboxNotifyMaxDelay+100*time.Millisecond {
+		t.Fatalf("waitQuotaOutboxNotifyQuiet duration = %s, want before max delay", dur)
+	}
+}
+
 func TestDrainQuotaOutboxForFileErrorsWhenPendingRowIsNotClaimable(t *testing.T) {
 	b, _ := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -14,17 +14,20 @@ import (
 )
 
 const (
-	quotaOutboxNotifySize       = 1
-	quotaOutboxNotifyDelay      = 50 * time.Millisecond
-	quotaOutboxPollInterval     = 1 * time.Second
-	quotaOutboxLeaseDuration    = 5 * time.Minute
-	quotaOutboxBatchSize        = 100
-	quotaOutboxRecoverLimit     = 100
-	quotaOutboxUploadDrainLimit = 1000
-	quotaOutboxRetryBaseDelay   = 200 * time.Millisecond
-	quotaOutboxRetryMaxDelay    = 30 * time.Second
-	quotaMutationTypeFileCreate = "file_create"
-	quotaMutationTypeOverwrite  = "file_overwrite"
+	quotaOutboxNotifySize               = 1
+	quotaOutboxNotifyDelay              = 50 * time.Millisecond
+	quotaOutboxNotifyMaxDelay           = 200 * time.Millisecond
+	quotaOutboxPollInterval             = 1 * time.Second
+	quotaOutboxLeaseDuration            = 5 * time.Minute
+	quotaOutboxBatchSize                = 100
+	quotaOutboxRecoverLimit             = 100
+	quotaOutboxUploadDrainLimit         = 1000
+	quotaOutboxUploadDrainWait          = 25 * time.Millisecond
+	quotaOutboxUploadDrainWarnThreshold = 10
+	quotaOutboxRetryBaseDelay           = 200 * time.Millisecond
+	quotaOutboxRetryMaxDelay            = 30 * time.Second
+	quotaMutationTypeFileCreate         = "file_create"
+	quotaMutationTypeOverwrite          = "file_overwrite"
 )
 
 func (b *Dat9Backend) startQuotaOutboxWorker() {
@@ -85,11 +88,15 @@ func (b *Dat9Backend) waitQuotaOutboxNotifyQuiet(ctx context.Context) bool {
 	}
 	timer := time.NewTimer(quotaOutboxNotifyDelay)
 	defer timer.Stop()
+	maxTimer := time.NewTimer(quotaOutboxNotifyMaxDelay)
+	defer maxTimer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return false
 		case <-timer.C:
+			return true
+		case <-maxTimer.C:
 			return true
 		case <-b.quotaOutboxNotify:
 			if !timer.Stop() {
@@ -136,18 +143,14 @@ func (b *Dat9Backend) processQuotaOutboxAvailable(ctx context.Context) {
 	}
 }
 
-func (b *Dat9Backend) drainQuotaOutboxForUploadTarget(ctx context.Context, path string, targetExists bool) error {
+func (b *Dat9Backend) drainQuotaOutboxForUploadTarget(ctx context.Context, target *datastore.NodeWithFile, targetExists bool) error {
 	if !targetExists || !b.UseServerQuota() || b.store == nil {
 		return nil
 	}
-	nf, err := b.store.Stat(ctx, path)
-	if err != nil {
-		return err
-	}
-	if nf.File == nil || nf.File.FileID == "" {
+	if target == nil || target.File == nil || target.File.FileID == "" {
 		return nil
 	}
-	return b.drainQuotaOutboxForFile(ctx, nf.File.FileID, quotaOutboxUploadDrainLimit)
+	return b.drainQuotaOutboxForFile(ctx, target.File.FileID, quotaOutboxUploadDrainLimit)
 }
 
 func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string, limit int) error {
@@ -157,12 +160,19 @@ func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string
 	if limit <= 0 {
 		limit = quotaOutboxUploadDrainLimit
 	}
+	processedCount := 0
 	for i := 0; i < limit; i++ {
 		pending, err := b.store.HasPendingQuotaOutboxFileMutation(ctx, fileID)
 		if err != nil {
 			return fmt.Errorf("check pending quota outbox for file: %w", err)
 		}
 		if !pending {
+			if processedCount > quotaOutboxUploadDrainWarnThreshold {
+				logger.Warn(ctx, "quota_outbox_upload_target_deep_drain",
+					zap.String("tenant_id", b.tenantID),
+					zap.String("file_id", fileID),
+					zap.Int("processed", processedCount))
+			}
 			return nil
 		}
 		processed, err := b.ProcessOneQuotaOutbox(ctx)
@@ -170,8 +180,18 @@ func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string
 			return fmt.Errorf("drain quota outbox for file: %w", err)
 		}
 		if !processed {
-			return nil
+			timer := time.NewTimer(quotaOutboxUploadDrainWait)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return fmt.Errorf("quota outbox for file %s still pending but not claimable: %w", fileID, ctx.Err())
+			case <-timer.C:
+			}
+			continue
 		}
+		processedCount++
 	}
 	return fmt.Errorf("quota outbox for file %s still pending after %d entries", fileID, limit)
 }

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -222,6 +222,7 @@ func (b *Dat9Backend) ProcessOneQuotaOutbox(ctx context.Context) (processed bool
 			metrics.RecordOperation("quota_outbox", entry.MutationType, "error", time.Since(start))
 			return true, applyErr
 		}
+		b.addLocalQuotaPendingDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
 		metrics.RecordOperation("quota_outbox", entry.MutationType, "ok", time.Since(start))
 		return true, nil
 	}

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -249,6 +249,9 @@ func (b *Dat9Backend) ProcessOneQuotaOutbox(ctx context.Context) (processed bool
 			metrics.RecordOperation("quota_outbox", entry.MutationType, "error", time.Since(start))
 			return true, applyErr
 		}
+		if b.quotaUsageCache != nil {
+			b.quotaUsageCache.invalidate()
+		}
 		b.addLocalQuotaPendingDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
 		metrics.RecordOperation("quota_outbox", entry.MutationType, "ok", time.Since(start))
 		return true, nil

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -15,10 +15,12 @@ import (
 
 const (
 	quotaOutboxNotifySize       = 1
+	quotaOutboxNotifyDelay      = 50 * time.Millisecond
 	quotaOutboxPollInterval     = 1 * time.Second
 	quotaOutboxLeaseDuration    = 5 * time.Minute
 	quotaOutboxBatchSize        = 100
 	quotaOutboxRecoverLimit     = 100
+	quotaOutboxUploadDrainLimit = 1000
 	quotaOutboxRetryBaseDelay   = 200 * time.Millisecond
 	quotaOutboxRetryMaxDelay    = 30 * time.Second
 	quotaMutationTypeFileCreate = "file_create"
@@ -67,9 +69,36 @@ func (b *Dat9Backend) runQuotaOutboxWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-b.quotaOutboxNotify:
+			if !b.waitQuotaOutboxNotifyQuiet(ctx) {
+				return
+			}
 			b.processQuotaOutboxAvailable(ctx)
 		case <-ticker.C:
 			b.processQuotaOutboxAvailable(ctx)
+		}
+	}
+}
+
+func (b *Dat9Backend) waitQuotaOutboxNotifyQuiet(ctx context.Context) bool {
+	if quotaOutboxNotifyDelay <= 0 {
+		return true
+	}
+	timer := time.NewTimer(quotaOutboxNotifyDelay)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-timer.C:
+			return true
+		case <-b.quotaOutboxNotify:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(quotaOutboxNotifyDelay)
 		}
 	}
 }
@@ -105,6 +134,46 @@ func (b *Dat9Backend) processQuotaOutboxAvailable(ctx context.Context) {
 			return
 		}
 	}
+}
+
+func (b *Dat9Backend) drainQuotaOutboxForUploadTarget(ctx context.Context, path string, targetExists bool) error {
+	if !targetExists || !b.UseServerQuota() || b.store == nil {
+		return nil
+	}
+	nf, err := b.store.Stat(ctx, path)
+	if err != nil {
+		return err
+	}
+	if nf.File == nil || nf.File.FileID == "" {
+		return nil
+	}
+	return b.drainQuotaOutboxForFile(ctx, nf.File.FileID, quotaOutboxUploadDrainLimit)
+}
+
+func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string, limit int) error {
+	if fileID == "" || b.store == nil {
+		return nil
+	}
+	if limit <= 0 {
+		limit = quotaOutboxUploadDrainLimit
+	}
+	for i := 0; i < limit; i++ {
+		pending, err := b.store.HasPendingQuotaOutboxFileMutation(ctx, fileID)
+		if err != nil {
+			return fmt.Errorf("check pending quota outbox for file: %w", err)
+		}
+		if !pending {
+			return nil
+		}
+		processed, err := b.ProcessOneQuotaOutbox(ctx)
+		if err != nil {
+			return fmt.Errorf("drain quota outbox for file: %w", err)
+		}
+		if !processed {
+			return nil
+		}
+	}
+	return fmt.Errorf("quota outbox for file %s still pending after %d entries", fileID, limit)
 }
 
 // ProcessOneQuotaOutbox applies at most one tenant-local quota outbox row. It is

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -22,6 +22,7 @@ const (
 	quotaOutboxBatchSize                = 100
 	quotaOutboxRecoverLimit             = 100
 	quotaOutboxUploadDrainLimit         = 1000
+	quotaOutboxUploadDrainMaxWait       = 5 * time.Second
 	quotaOutboxUploadDrainWait          = 25 * time.Millisecond
 	quotaOutboxUploadDrainWarnThreshold = 10
 	quotaOutboxRetryBaseDelay           = 200 * time.Millisecond
@@ -86,6 +87,8 @@ func (b *Dat9Backend) waitQuotaOutboxNotifyQuiet(ctx context.Context) bool {
 	if quotaOutboxNotifyDelay <= 0 {
 		return true
 	}
+	// Coalesce bursts until the channel is quiet for quotaOutboxNotifyDelay.
+	// quotaOutboxNotifyMaxDelay bounds the wait under a steady write stream.
 	timer := time.NewTimer(quotaOutboxNotifyDelay)
 	defer timer.Stop()
 	maxTimer := time.NewTimer(quotaOutboxNotifyMaxDelay)
@@ -160,8 +163,12 @@ func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string
 	if limit <= 0 {
 		limit = quotaOutboxUploadDrainLimit
 	}
+	start := time.Now()
 	processedCount := 0
 	for i := 0; i < limit; i++ {
+		if quotaOutboxUploadDrainMaxWait > 0 && time.Since(start) > quotaOutboxUploadDrainMaxWait {
+			return fmt.Errorf("quota outbox for file %s still pending after %s", fileID, quotaOutboxUploadDrainMaxWait)
+		}
 		pending, err := b.store.HasPendingQuotaOutboxFileMutation(ctx, fileID)
 		if err != nil {
 			return fmt.Errorf("check pending quota outbox for file: %w", err)

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -127,12 +127,12 @@ type MutationLogView struct {
 
 // SetMetaQuotaStore sets the central quota store on the backend.
 // Called by tenant.Pool after backend creation.
-func (b *Dat9Backend) SetMetaQuotaStore(tenantID string, mqs MetaQuotaStore) {
+func (b *Dat9Backend) SetMetaQuotaStore(ctx context.Context, tenantID string, mqs MetaQuotaStore) {
 	b.tenantID = tenantID
 	b.metaStore = mqs
 	if mqs != nil {
-		if err := mqs.EnsureQuotaUsageRow(context.Background(), tenantID); err != nil {
-			logger.Warn(context.Background(), "ensure_quota_usage_row_failed",
+		if err := mqs.EnsureQuotaUsageRow(ctx, tenantID); err != nil {
+			logger.Warn(ctx, "ensure_quota_usage_row_failed",
 				zap.String("tenant_id", tenantID),
 				zap.Error(err))
 		}

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -130,12 +130,14 @@ type MutationLogView struct {
 func (b *Dat9Backend) SetMetaQuotaStore(tenantID string, mqs MetaQuotaStore) {
 	b.tenantID = tenantID
 	b.metaStore = mqs
-	if mqs != nil && b.quotaSource == QuotaSourceServer {
+	if mqs != nil {
 		if err := mqs.EnsureQuotaUsageRow(context.Background(), tenantID); err != nil {
 			logger.Warn(context.Background(), "ensure_quota_usage_row_failed",
 				zap.String("tenant_id", tenantID),
 				zap.Error(err))
 		}
+	}
+	if mqs != nil && b.quotaSource == QuotaSourceServer {
 		b.quotaConfigCache = newQuotaConfigCache(tenantID, mqs)
 		b.quotaUsageCache = newQuotaUsageCache(tenantID, mqs, quotaUsageCacheTTL)
 		if b.store != nil {

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -137,6 +137,7 @@ func (b *Dat9Backend) SetMetaQuotaStore(tenantID string, mqs MetaQuotaStore) {
 				zap.Error(err))
 		}
 		b.quotaConfigCache = newQuotaConfigCache(tenantID, mqs)
+		b.quotaUsageCache = newQuotaUsageCache(tenantID, mqs, quotaUsageCacheTTL)
 		b.startMutationWorker()
 		b.startQuotaOutboxWorker()
 	}

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -138,6 +138,9 @@ func (b *Dat9Backend) SetMetaQuotaStore(tenantID string, mqs MetaQuotaStore) {
 		}
 		b.quotaConfigCache = newQuotaConfigCache(tenantID, mqs)
 		b.quotaUsageCache = newQuotaUsageCache(tenantID, mqs, quotaUsageCacheTTL)
+		if b.store != nil {
+			b.quotaPendingCache = newQuotaPendingDeltasCache(b.store.PendingQuotaOutboxDeltas, quotaPendingDeltasCacheTTL)
+		}
 		b.startMutationWorker()
 		b.startQuotaOutboxWorker()
 	}

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -283,6 +283,10 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 		}
 		return nil, err
 	}
+	if err := b.drainQuotaOutboxForUploadTarget(ctx, path, targetExists); err != nil {
+		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		return nil, err
+	}
 
 	fileID := b.genID()
 	s3Key := "blobs/" + fileID
@@ -462,6 +466,10 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		} else {
 			metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		}
+		return nil, err
+	}
+	if err := b.drainQuotaOutboxForUploadTarget(ctx, path, targetExists); err != nil {
+		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	validateDurationMs := uploadPhaseMs(validateStart)

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -177,27 +177,27 @@ func (b *Dat9Backend) supersedeActiveUpload(ctx context.Context, op string, exis
 	return err
 }
 
-func (b *Dat9Backend) validateUploadTargetRevision(ctx context.Context, path string, expectedRevision int64) (bool, error) {
+func (b *Dat9Backend) validateUploadTargetRevision(ctx context.Context, path string, expectedRevision int64) (*datastore.NodeWithFile, bool, error) {
 	nf, err := b.store.Stat(ctx, path)
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			if expectedRevision > 0 {
-				return false, datastore.ErrRevisionConflict
+				return nil, false, datastore.ErrRevisionConflict
 			}
-			return false, nil
+			return nil, false, nil
 		}
-		return false, err
+		return nil, false, err
 	}
 	if nf.Node.IsDirectory {
-		return false, fmt.Errorf("is a directory: %s", path)
+		return nil, false, fmt.Errorf("is a directory: %s", path)
 	}
 	if expectedRevision == 0 {
-		return true, datastore.ErrRevisionConflict
+		return nf, true, datastore.ErrRevisionConflict
 	}
 	if expectedRevision > 0 && (nf.File == nil || nf.File.Status != datastore.StatusConfirmed || nf.File.Revision != expectedRevision) {
-		return true, datastore.ErrRevisionConflict
+		return nf, true, datastore.ErrRevisionConflict
 	}
-	return true, nil
+	return nf, true, nil
 }
 
 func uploadFileCountDelta(targetExists bool) int64 {
@@ -274,7 +274,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
-	targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
+	target, targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
 	if err != nil {
 		if errors.Is(err, datastore.ErrRevisionConflict) {
 			metrics.RecordOperation("backend", "initiate_upload", "conflict", time.Since(start))
@@ -283,7 +283,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 		}
 		return nil, err
 	}
-	if err := b.drainQuotaOutboxForUploadTarget(ctx, path, targetExists); err != nil {
+	if err := b.drainQuotaOutboxForUploadTarget(ctx, target, targetExists); err != nil {
 		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
@@ -459,7 +459,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
-	targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
+	target, targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
 	if err != nil {
 		if errors.Is(err, datastore.ErrRevisionConflict) {
 			metrics.RecordOperation("backend", "initiate_upload_v2", "conflict", time.Since(start))
@@ -468,7 +468,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		}
 		return nil, err
 	}
-	if err := b.drainQuotaOutboxForUploadTarget(ctx, path, targetExists); err != nil {
+	if err := b.drainQuotaOutboxForUploadTarget(ctx, target, targetExists); err != nil {
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}

--- a/pkg/backend/upload_reservation.go
+++ b/pkg/backend/upload_reservation.go
@@ -145,7 +145,7 @@ func (b *Dat9Backend) ensureUploadReserveFitsPendingQuotaTx(ctx context.Context,
 		metrics.RecordOperation("server_quota", "upload_reserve_pending_check", "fail_open", 0)
 		return nil
 	}
-	pendingStorageDelta, pendingFileDelta, _, pendingOK := b.pendingQuotaOutboxDeltasTx(ctx, tx)
+	pendingStorageDelta, pendingFileDelta, _, pendingOK := b.livePendingQuotaOutboxDeltasTx(ctx, tx)
 	if !pendingOK {
 		metrics.RecordOperation("server_quota", "upload_reserve_pending_check", "fail_open", 0)
 	}

--- a/pkg/fuse/dir.go
+++ b/pkg/fuse/dir.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	defaultDirCacheTTL              = 10 * time.Second
-	defaultNamespaceCacheMaxEntries = 100000
+	defaultNamespaceCacheMaxEntries = 200000
 
 	// escalateMissThreshold/escalateMissWindow detect negative-lookup storms:
 	// once this many remote ENOENT stats hit the same directory within the

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -1086,7 +1086,7 @@ func TestNamespaceCache_InvalidatePrefix(t *testing.T) {
 func TestNamespaceCache_LargeDirCachesCompleteWithHighMaxEntries(t *testing.T) {
 	// With a high maxEntries (like the default), a 10k-entry
 	// directory should be cached as complete and returned by Get().
-	dc := NewNamespaceCache(10*time.Second, 10*time.Second, 100000)
+	dc := NewNamespaceCache(10*time.Second, 10*time.Second, defaultNamespaceCacheMaxEntries)
 	items := make([]CachedFileInfo, 10000)
 	for i := range items {
 		items[i] = CachedFileInfo{

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -1084,7 +1084,7 @@ func TestNamespaceCache_InvalidatePrefix(t *testing.T) {
 }
 
 func TestNamespaceCache_LargeDirCachesCompleteWithHighMaxEntries(t *testing.T) {
-	// With a high maxEntries (like the new default 100000), a 10k-entry
+	// With a high maxEntries (like the default), a 10k-entry
 	// directory should be cached as complete and returned by Get().
 	dc := NewNamespaceCache(10*time.Second, 10*time.Second, 100000)
 	items := make([]CachedFileInfo, 10000)
@@ -1099,7 +1099,7 @@ func TestNamespaceCache_LargeDirCachesCompleteWithHighMaxEntries(t *testing.T) {
 
 	got, ok := dc.Get("/bigdir")
 	if !ok {
-		t.Fatal("10k-entry dir should be cached as complete with maxEntries=100000")
+		t.Fatal("10k-entry dir should be cached as complete with high maxEntries")
 	}
 	if len(got) != 10000 {
 		t.Fatalf("got %d cached entries, want 10000", len(got))

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -69,7 +69,7 @@ type MountOptions struct {
 	PrefetchMaxFileBytes    int64         // maximum individual file size prefetched (default 50KB)
 	PrefetchMaxBytes        int64         // maximum aggregate bytes prefetched per directory read (default 1MB)
 	PrefetchTimeout         time.Duration // timeout for one readdir prefetch batch (default 1s)
-	DirCacheMaxEntries      int           // maximum entries per directory in DirCache (default 100000); directories exceeding this limit are not cached as complete
+	DirCacheMaxEntries      int           // maximum entries per directory in DirCache (default 200000); directories exceeding this limit are not cached as complete
 	TrustLocalEvents        bool          // allow revision-bound GetAttr hits from DirCache using process-local SSE freshness; safe only for single-server/sticky or cluster-wide event streams
 	AllowOther              bool          // allow other users to access mount
 	ReadOnly                bool          // mount as read-only

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -774,7 +774,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			zap.Float64("create_s3_client_ms", s3ClientDurationMs),
 			zap.Float64("create_backend_ms", backendCreateDurationMs),
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
-		p.wireQuotaStore(b, t.ID)
+		p.wireQuotaStore(ctx, b, t.ID)
 		p.wireSemanticTaskNotifier(b, t.ID)
 		return b, store, nil
 	}
@@ -814,7 +814,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			zap.Float64("create_s3_client_ms", s3ClientDurationMs),
 			zap.Float64("create_backend_ms", backendCreateDurationMs),
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
-		p.wireQuotaStore(b, t.ID)
+		p.wireQuotaStore(ctx, b, t.ID)
 		p.wireSemanticTaskNotifier(b, t.ID)
 		return b, store, nil
 	}
@@ -836,7 +836,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		zap.Float64("create_s3_client_ms", 0),
 		zap.Float64("create_backend_ms", backendCreateDurationMs),
 		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
-	p.wireQuotaStore(b, t.ID)
+	p.wireQuotaStore(ctx, b, t.ID)
 	p.wireSemanticTaskNotifier(b, t.ID)
 	return b, store, nil
 }
@@ -952,12 +952,12 @@ func (p *Pool) defaultStorageNamespacePrefix(tenantID, backendName string) strin
 
 // wireQuotaStore sets the central quota store on a newly created backend.
 // No-op when the pool's metaStore is nil (tests, non-multi-tenant mode).
-func (p *Pool) wireQuotaStore(b *backend.Dat9Backend, tenantID string) {
+func (p *Pool) wireQuotaStore(ctx context.Context, b *backend.Dat9Backend, tenantID string) {
 	if p.metaStore == nil {
 		return
 	}
 	adapter := NewMetaQuotaAdapter(p.metaStore)
-	b.SetMetaQuotaStore(tenantID, adapter)
+	b.SetMetaQuotaStore(ctx, tenantID, adapter)
 }
 
 func (p *Pool) removeLocked(elem *list.Element) *entry {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -167,11 +167,11 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 		max = 128
 	}
 	return &Pool{
-		cfg:           cfg,
-		enc:           enc,
-		items:         map[string]*entry{},
-		order:         list.New(),
-		maxSize:       max,
+		cfg:     cfg,
+		enc:     enc,
+		items:   map[string]*entry{},
+		order:   list.New(),
+		maxSize: max,
 		// No LeaderChecker means single-pod mode: FileGC runs unconditionally.
 		fileGCEnabled: cfg.LeaderChecker == nil,
 	}
@@ -952,20 +952,12 @@ func (p *Pool) defaultStorageNamespacePrefix(tenantID, backendName string) strin
 
 // wireQuotaStore sets the central quota store on a newly created backend.
 // No-op when the pool's metaStore is nil (tests, non-multi-tenant mode).
-// Also ensures a tenant_quota_usage row exists so that counter UPDATEs
-// do not fail for newly provisioned tenants.
 func (p *Pool) wireQuotaStore(b *backend.Dat9Backend, tenantID string) {
 	if p.metaStore == nil {
 		return
 	}
 	adapter := NewMetaQuotaAdapter(p.metaStore)
 	b.SetMetaQuotaStore(tenantID, adapter)
-	// Bootstrap quota usage row (INSERT IGNORE — idempotent, cheap).
-	if err := p.metaStore.EnsureQuotaUsageRow(context.Background(), tenantID); err != nil {
-		logger.Warn(context.Background(), "wire_quota_store_ensure_usage_row_failed",
-			zap.String("tenant_id", tenantID),
-			zap.Error(err))
-	}
 }
 
 func (p *Pool) removeLocked(elem *list.Element) *entry {


### PR DESCRIPTION
## Summary
- avoid duplicate quota usage-row bootstrap when wiring tenant backends
- make quota config cache lazy so read-only backend opens do not synchronously query quota config
- add a short TTL central usage cache for soft small-write quota checks while keeping upload reservations on direct central reads
- coalesce quota outbox worker wakeups and drain target file quota outbox before overwrite uploads that need up-to-date central file metadata

## Tests
- make test TEST_PKGS='./pkg/backend ./pkg/tenant' TEST_RUN='TestQuota|TestServerQuota|TestQuotaConfig|TestQuotaUsage|TestPool'
- make test TEST_PKGS='./pkg/backend' TEST_RUN='TestQuotaConfig|TestQuotaUsage|TestServerQuotaUploadOverwriteDeltaIntegration'
- make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased directory cache entry limit from 100,000 to 200,000 for improved handling of large directories.

* **Improvements**
  * Enhanced quota enforcement with improved caching mechanisms for better reliability.
  * Upload operations now properly process pending quota transactions before initiating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->