### PR TITLE
fix: revert native fork status on cleanup failure

### DIFF
--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -452,8 +452,7 @@ func ctxForkCmd(args []string) error {
 	if len(args) == 1 && IsHelpArg(args[0]) {
 		_, _ = fmt.Fprintln(os.Stdout, `usage: drive9 ctx fork [<new>] [--from <ctx>] [--json] [--tidbcloud-public-key KEY] [--tidbcloud-private-key KEY]
 
-  create a copy-on-write fork context from a TiDB Cloud tenant.
-  The fork shares the parent's storage namespace and uses a lightweight
+  create a copy-on-write fork context. The fork shares the parent's storage namespace and uses a lightweight
   TiDB Cloud branch for its database.
 
   --from <ctx>                    source context name (default: current context)

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -450,6 +450,24 @@ func ctxAdd(cfg *Config, name string, ctx *Context) (*Context, error) {
 }
 
 func ctxForkCmd(args []string) error {
+	if len(args) == 1 && IsHelpArg(args[0]) {
+		_, _ = fmt.Fprintln(os.Stdout, `usage: drive9 ctx fork [<new>] [--from <ctx>] [--json] [--tidbcloud-public-key KEY] [--tidbcloud-private-key KEY]
+
+  create a copy-on-write fork context from a TiDB Cloud Native tenant.
+  The fork shares the parent's storage namespace and uses a lightweight
+  TiDB Cloud branch for its database.
+
+  --from <ctx>                    source context name (default: current context)
+  --json                          output fork result as JSON
+  --tidbcloud-public-key KEY      TiDB Cloud public key
+  --tidbcloud-private-key KEY     TiDB Cloud private key
+
+  Prefer DRIVE9_PUBLIC_KEY / DRIVE9_PRIVATE_KEY over private-key flags in
+  shared shells.
+
+  The fork tenant provisions asynchronously. Use "drive9 fs ls /" to poll.`)
+		return nil
+	}
 	newName := ""
 	fromName := ""
 	publicKeyFlag := ""

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -453,7 +453,7 @@ func ctxForkCmd(args []string) error {
 	if len(args) == 1 && IsHelpArg(args[0]) {
 		_, _ = fmt.Fprintln(os.Stdout, `usage: drive9 ctx fork [<new>] [--from <ctx>] [--json] [--tidbcloud-public-key KEY] [--tidbcloud-private-key KEY]
 
-  create a copy-on-write fork context from a TiDB Cloud Native tenant.
+  create a copy-on-write fork context from a TiDB Cloud tenant.
   The fork shares the parent's storage namespace and uses a lightweight
   TiDB Cloud branch for its database.
 

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -59,7 +59,7 @@ func ctxUsage() string {
   import                                              add delegated context from stdin (default when stdin is a pipe)
   fork [<new>] [--from <ctx>] [--json] [--tidbcloud-public-key KEY] [--tidbcloud-private-key KEY]
                                                         create a copy-on-write fork context
-                                                        prefer DRIVE9_PUBLIC_KEY/DRIVE9_PRIVATE_KEY over private-key flags in shared shells
+                                                        flags take precedence; use env vars to avoid shell history
   ls [-l|--json] [--type <kind>|--scoped]             list contexts (filter by type: owner|delegated|fs_scoped)
   use <name>                                          activate a context
   rm <name>                                           remove a local context name (does NOT revoke server-side credential)`
@@ -462,8 +462,8 @@ func ctxForkCmd(args []string) error {
   --tidbcloud-public-key KEY      TiDB Cloud public key
   --tidbcloud-private-key KEY     TiDB Cloud private key
 
-  Prefer DRIVE9_PUBLIC_KEY / DRIVE9_PRIVATE_KEY over private-key flags in
-  shared shells.
+  Flags take precedence; use DRIVE9_PUBLIC_KEY / DRIVE9_PRIVATE_KEY env
+  vars to avoid exposing keys in shell history.
 
   The fork tenant provisions asynchronously. Use "drive9 fs ls /" to poll.`)
 		return nil

--- a/cmd/drive9/cli/ctx.go
+++ b/cmd/drive9/cli/ctx.go
@@ -59,7 +59,6 @@ func ctxUsage() string {
   import                                              add delegated context from stdin (default when stdin is a pipe)
   fork [<new>] [--from <ctx>] [--json] [--tidbcloud-public-key KEY] [--tidbcloud-private-key KEY]
                                                         create a copy-on-write fork context
-                                                        flags take precedence; use env vars to avoid shell history
   ls [-l|--json] [--type <kind>|--scoped]             list contexts (filter by type: owner|delegated|fs_scoped)
   use <name>                                          activate a context
   rm <name>                                           remove a local context name (does NOT revoke server-side credential)`
@@ -461,9 +460,6 @@ func ctxForkCmd(args []string) error {
   --json                          output fork result as JSON
   --tidbcloud-public-key KEY      TiDB Cloud public key
   --tidbcloud-private-key KEY     TiDB Cloud private key
-
-  Flags take precedence; use DRIVE9_PUBLIC_KEY / DRIVE9_PRIVATE_KEY env
-  vars to avoid exposing keys in shell history.
 
   The fork tenant provisions asynchronously. Use "drive9 fs ls /" to poll.`)
 		return nil

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -505,7 +505,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 				{Name: "--reveal", Desc: "show sensitive fields on ctx show"},
 				{Name: "--type <kind>|--scoped", Desc: "filter ctx ls results"},
 				{Name: "--tidbcloud-public-key KEY", Desc: "TiDB Cloud public key for ctx fork"},
-				{Name: "--tidbcloud-private-key KEY", Desc: "flags take precedence; use DRIVE9_PRIVATE_KEY env var to avoid shell history"},
+				{Name: "--tidbcloud-private-key KEY", Desc: "TiDB Cloud private key for ctx fork; use env vars to avoid shell history"},
 			},
 			Examples: []visualHelpExample{
 				{Command: "drive9 ctx show", Desc: "show active context"},

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -504,8 +504,8 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 				{Name: "--json", Desc: "available on show, fork, and ls"},
 				{Name: "--reveal", Desc: "show sensitive fields on ctx show"},
 				{Name: "--type <kind>|--scoped", Desc: "filter ctx ls results"},
-				{Name: "--tidbcloud-public-key KEY", Desc: "TiDB Cloud public key for ctx fork"},
-				{Name: "--tidbcloud-private-key KEY", Desc: "TiDB Cloud private key for ctx fork"},
+				{Name: "--tidbcloud-public-key KEY", Desc: "TiDB Cloud public key for ctx fork in TiDBCloud mode"},
+				{Name: "--tidbcloud-private-key KEY", Desc: "TiDB Cloud private key for ctx fork in TiDBCloud mode"},
 			},
 			Examples: []visualHelpExample{
 				{Command: "drive9 ctx show", Desc: "show active context"},

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -498,7 +498,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 			Details: []string{
 				"show -> inspect active context; ls -> scan saved contexts",
 				"add/import -> save owner or delegated keys",
-				"fork -> create a copy-on-write context from a TiDB Cloud tenant; rm -> remove local credentials",
+				"fork -> create a copy-on-write context; rm -> remove local credentials",
 			},
 			Flags: []visualHelpFlag{
 				{Name: "--json", Desc: "available on show, fork, and ls"},

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -505,7 +505,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 				{Name: "--reveal", Desc: "show sensitive fields on ctx show"},
 				{Name: "--type <kind>|--scoped", Desc: "filter ctx ls results"},
 				{Name: "--tidbcloud-public-key KEY", Desc: "TiDB Cloud public key for ctx fork"},
-				{Name: "--tidbcloud-private-key KEY", Desc: "TiDB Cloud private key for ctx fork; use env vars to avoid shell history"},
+				{Name: "--tidbcloud-private-key KEY", Desc: "TiDB Cloud private key for ctx fork"},
 			},
 			Examples: []visualHelpExample{
 				{Command: "drive9 ctx show", Desc: "show active context"},

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -498,14 +498,14 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 			Details: []string{
 				"show -> inspect active context; ls -> scan saved contexts",
 				"add/import -> save owner or delegated keys",
-				"fork -> create a copy-on-write context; rm -> remove local credentials",
+				"fork -> create a copy-on-write context from a TiDB Cloud tenant; rm -> remove local credentials",
 			},
 			Flags: []visualHelpFlag{
 				{Name: "--json", Desc: "available on show, fork, and ls"},
 				{Name: "--reveal", Desc: "show sensitive fields on ctx show"},
 				{Name: "--type <kind>|--scoped", Desc: "filter ctx ls results"},
-				{Name: "--tidbcloud-public-key KEY", Desc: "TiDB Cloud public key for ctx fork in TiDBCloud mode"},
-				{Name: "--tidbcloud-private-key KEY", Desc: "TiDB Cloud private key; prefer DRIVE9_PRIVATE_KEY in shared shells"},
+				{Name: "--tidbcloud-public-key KEY", Desc: "TiDB Cloud public key for ctx fork"},
+				{Name: "--tidbcloud-private-key KEY", Desc: "flags take precedence; use DRIVE9_PRIVATE_KEY env var to avoid shell history"},
 			},
 			Examples: []visualHelpExample{
 				{Command: "drive9 ctx show", Desc: "show active context"},

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -220,10 +220,7 @@ func (s *Server) resolveForkCredentialRequest(provider string, req *tenant.Crede
 		return nil, nil
 	}
 	if req == nil {
-		req = resolveDefaultCredentials(s.provisioner)
-		if req == nil {
-			return nil, tenant.ErrCredentialsRequired
-		}
+		return nil, tenant.ErrCredentialsRequired
 	}
 	if validator, ok := s.provisioner.(credentialProvisionRequestValidator); ok {
 		if err := validator.ValidateCredentialProvisionRequest(*req); err != nil {
@@ -448,24 +445,6 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster)
 		s.markForkFailedAndCleanup(ctx, forkID)
 		return nil, makeProvisionFailedErr(err)
-	}
-
-	// When the branch endpoint is not yet available (branch still CREATING)
-	// and we have per-request credentials, defer to async provisioning instead
-	// of failing. The async provisioner will wait for the branch to become active.
-	if source.Provider == tenant.ProviderTiDBCloudNative && cluster.Username == "" && credentialReq == nil && resolveDefaultCredentials(s.provisioner) == nil {
-		logger.Error(ctx, "fork_missing_endpoint_no_credentials",
-			zap.String("source_tenant_id", source.ID),
-			zap.String("fork_id", forkID))
-		if s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster) {
-			if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantDeleted); err != nil {
-				logger.Error(ctx, "fork_credential_gate_mark_deleted_failed",
-					zap.String("tenant_id", forkID), zap.Error(err))
-			}
-		} else {
-			s.markForkFailedAndCleanup(ctx, forkID)
-		}
-		return nil, makeProvisionFailedErr(forkErr(http.StatusBadRequest, "branch response missing endpoint; server default TiDB Cloud credential is required to provision this fork"))
 	}
 
 	if source.Provider == tenant.ProviderTiDBCloudNative {
@@ -992,8 +971,11 @@ func (s *Server) cleanupForkTenantOnce(ctx context.Context, tenantID string, cre
 		}
 		return nil
 	}
-	if t.Provider == tenant.ProviderTiDBCloudNative && credentialReq == nil && resolveDefaultCredentials(s.provisioner) == nil {
-		return tenant.ErrCredentialsRequired
+	if t.Provider == tenant.ProviderTiDBCloudNative && credentialReq == nil {
+		if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantDeleted); err != nil {
+			return fmt.Errorf("mark fork deleted: %w", err)
+		}
+		return nil
 	}
 	if t.Status != meta.TenantDeleting {
 		return s.cleanupFailedForkBranch(ctx, t, credentialReq)

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -910,10 +910,6 @@ func (s *Server) handleForkDelete(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{"status": string(meta.TenantDeleting)})
 		return
 	}
-	if t.Provider == tenant.ProviderTiDBCloudNative && t.Status == meta.TenantFailed {
-		s.cleanupNativeFork(w, r, t, credentialReq)
-		return
-	}
 	if t.Provider == tenant.ProviderTiDBCloudNative {
 		s.cleanupNativeFork(w, r, t, credentialReq)
 		return

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -972,14 +972,7 @@ func (s *Server) cleanupForkTenantOnce(ctx context.Context, tenantID string, cre
 		return nil
 	}
 	if t.Provider == tenant.ProviderTiDBCloudNative && credentialReq == nil {
-		logger.Warn(ctx, "fork_cleanup_no_credentials_branch_orphaned",
-			zap.String("tenant_id", tenantID),
-			zap.String("cluster_id", t.ClusterID),
-			zap.String("branch_id", t.BranchID))
-		if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantDeleted); err != nil {
-			return fmt.Errorf("mark fork deleted: %w", err)
-		}
-		return nil
+		return tenant.ErrCredentialsRequired
 	}
 	if t.Status != meta.TenantDeleting {
 		return s.cleanupFailedForkBranch(ctx, t, credentialReq)

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -661,6 +661,34 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		if forkTenant.DBHost != "" && forkTenant.DBPort != 0 && forkTenant.DBUser != "" {
 			return tenantDSN(forkTenant.DBUser, string(plain), forkTenant.DBHost, forkTenant.DBPort, forkTenant.DBName, forkTenant.DBTLS), nil
 		}
+		if branchProv, ok := s.provisioner.(tenant.CredentialBranchProvisioner); ok {
+			username, err := branchProv.WaitForBranchUserWithCredentials(ctx, forkTenant.ClusterID, forkTenant.BranchID, *credentialReq)
+			if err != nil {
+				return "", err
+			}
+			host := forkTenant.DBHost
+			port := forkTenant.DBPort
+			if host == "" {
+				host = source.DBHost
+			}
+			if port == 0 {
+				port = source.DBPort
+			}
+			if err := s.meta.UpdateTenantConnection(ctx, forkTenant.ID, &meta.Tenant{
+				DBHost:           host,
+				DBPort:           port,
+				DBUser:           username,
+				DBPasswordCipher: forkTenant.DBPasswordCipher,
+				DBName:           forkTenant.DBName,
+				DBTLS:            true,
+				Provider:         forkTenant.Provider,
+				ClusterID:        forkTenant.ClusterID,
+				BranchID:         forkTenant.BranchID,
+			}); err != nil {
+				return "", err
+			}
+			return tenantDSN(username, string(plain), host, port, forkTenant.DBName, true), nil
+		}
 		cluster, err := s.waitForForkBranchActive(ctx, &tenant.ClusterInfo{
 			TenantID:  forkTenant.ID,
 			ClusterID: forkTenant.ClusterID,

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -422,9 +422,15 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 	}
 	forkRoot.ClusterID = cluster.ClusterID
 	forkRoot.BranchID = cluster.BranchID
+	dbHost := cluster.Host
+	dbPort := cluster.Port
+	if source.Provider == tenant.ProviderTiDBCloudNative {
+		dbHost = source.DBHost
+		dbPort = source.DBPort
+	}
 	if err := s.meta.UpdateTenantConnection(ctx, forkID, &meta.Tenant{
-		DBHost:           source.DBHost,
-		DBPort:           source.DBPort,
+		DBHost:           dbHost,
+		DBPort:           dbPort,
 		DBUser:           cluster.Username,
 		DBPasswordCipher: forkRoot.DBPasswordCipher,
 		DBName:           cluster.DBName,
@@ -684,6 +690,8 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 				Provider:         forkTenant.Provider,
 				ClusterID:        forkTenant.ClusterID,
 				BranchID:         forkTenant.BranchID,
+				ClaimURL:         forkTenant.ClaimURL,
+				ClaimExpiresAt:   forkTenant.ClaimExpiresAt,
 			}); err != nil {
 				return "", err
 			}

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -972,6 +972,10 @@ func (s *Server) cleanupForkTenantOnce(ctx context.Context, tenantID string, cre
 		return nil
 	}
 	if t.Provider == tenant.ProviderTiDBCloudNative && credentialReq == nil {
+		logger.Warn(ctx, "fork_cleanup_no_credentials_branch_orphaned",
+			zap.String("tenant_id", tenantID),
+			zap.String("cluster_id", t.ClusterID),
+			zap.String("branch_id", t.BranchID))
 		if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantDeleted); err != nil {
 			return fmt.Errorf("mark fork deleted: %w", err)
 		}

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -347,18 +347,27 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		return nil, err
 	}
 	if err := s.copyAutoEmbeddingProfileForFork(ctx, source.ID, forkID, source.Provider, now); err != nil {
-		s.markForkFailed(ctx, forkID)
+		s.deleteForkBranchOrPersist(ctx, forkID, credentialReq, nil)
+		if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantDeleted); err != nil {
+			logger.Error(ctx, "fork_pre_api_key_mark_deleted_failed", zap.String("tenant_id", forkID), zap.Error(err))
+		}
 		return nil, err
 	}
 
 	apiToken, err := token.IssueToken(s.tokenSecret, forkID, 1)
 	if err != nil {
-		s.markForkFailed(ctx, forkID)
+		s.deleteForkBranchOrPersist(ctx, forkID, credentialReq, nil)
+		if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantDeleted); err != nil {
+			logger.Error(ctx, "fork_pre_api_key_mark_deleted_failed", zap.String("tenant_id", forkID), zap.Error(err))
+		}
 		return nil, err
 	}
 	cipherToken, err := s.pool.Encrypt(ctx, []byte(apiToken))
 	if err != nil {
-		s.markForkFailed(ctx, forkID)
+		s.deleteForkBranchOrPersist(ctx, forkID, credentialReq, nil)
+		if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantDeleted); err != nil {
+			logger.Error(ctx, "fork_pre_api_key_mark_deleted_failed", zap.String("tenant_id", forkID), zap.Error(err))
+		}
 		return nil, err
 	}
 	if err := s.meta.InsertAPIKey(ctx, &meta.APIKey{
@@ -373,7 +382,10 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		CreatedAt:     time.Now().UTC(),
 		UpdatedAt:     time.Now().UTC(),
 	}); err != nil {
-		s.markForkFailed(ctx, forkID)
+		s.deleteForkBranchOrPersist(ctx, forkID, credentialReq, nil)
+		if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantDeleted); err != nil {
+			logger.Error(ctx, "fork_pre_api_key_mark_deleted_failed", zap.String("tenant_id", forkID), zap.Error(err))
+		}
 		return nil, err
 	}
 

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -347,18 +347,18 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		return nil, err
 	}
 	if err := s.copyAutoEmbeddingProfileForFork(ctx, source.ID, forkID, source.Provider, now); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
+		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
 
 	apiToken, err := token.IssueToken(s.tokenSecret, forkID, 1)
 	if err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
+		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
 	cipherToken, err := s.pool.Encrypt(ctx, []byte(apiToken))
 	if err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
+		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
 	if err := s.meta.InsertAPIKey(ctx, &meta.APIKey{
@@ -373,7 +373,7 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		CreatedAt:     time.Now().UTC(),
 		UpdatedAt:     time.Now().UTC(),
 	}); err != nil {
-		s.markForkFailedAndCleanup(ctx, forkID)
+		s.markForkFailed(ctx, forkID)
 		return nil, err
 	}
 
@@ -399,7 +399,7 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 			zap.String("cluster_id", sourceCluster.ClusterID),
 			zap.Error(err))
 		s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster)
-		s.markForkFailedAndCleanup(ctx, forkID)
+		s.markForkFailed(ctx, forkID)
 		return nil, makeProvisionFailedErr(err)
 	}
 	if cluster == nil || cluster.ClusterID == "" || cluster.BranchID == "" {
@@ -414,7 +414,7 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 			zap.String("fork_id", forkID),
 			zap.String("response_cluster_id", cid),
 			zap.String("response_branch_id", bid))
-		s.markForkFailedAndCleanup(ctx, forkID)
+		s.markForkFailed(ctx, forkID)
 		return nil, makeProvisionFailedErr(forkErr(http.StatusBadGateway, "branch response missing required metadata"))
 	}
 	forkRoot.ClusterID = cluster.ClusterID
@@ -443,7 +443,7 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 			zap.String("fork_id", forkID),
 			zap.Error(err))
 		s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster)
-		s.markForkFailedAndCleanup(ctx, forkID)
+		s.markForkFailed(ctx, forkID)
 		return nil, makeProvisionFailedErr(err)
 	}
 
@@ -518,7 +518,7 @@ func (s *Server) provisionForkTenantAsyncWithProvision(ctx context.Context, fork
 					zap.String("tenant_id", forkID),
 					zap.Int("attempt", attempt),
 					zap.Error(err))
-				s.markForkFailedAndCleanup(ctx, forkID)
+				s.markForkFailed(ctx, forkID)
 				return
 			}
 			logger.Warn(ctx, "fork_provision_retry",
@@ -786,11 +786,6 @@ func (s *Server) markForkFailed(ctx context.Context, forkID string) {
 	if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantFailed); err != nil {
 		logger.Error(ctx, "fork_mark_failed_failed", zap.String("tenant_id", forkID), zap.Error(err))
 	}
-}
-
-func (s *Server) markForkFailedAndCleanup(ctx context.Context, forkID string) {
-	s.markForkFailed(ctx, forkID)
-	s.startForkCleanup(ctx, forkID)
 }
 
 func clusterInfoFromTenant(t *meta.Tenant) *tenant.ClusterInfo {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -914,6 +914,10 @@ func (s *Server) handleForkDelete(w http.ResponseWriter, r *http.Request) {
 		s.cleanupNativeFork(w, r, t, credentialReq)
 		return
 	}
+	if t.Provider == tenant.ProviderTiDBCloudNative {
+		s.cleanupNativeFork(w, r, t, credentialReq)
+		return
+	}
 	updated, err := s.meta.UpdateTenantStatusIf(r.Context(), t.ID, t.Status, meta.TenantDeleting)
 	if err != nil {
 		errJSON(w, http.StatusInternalServerError, "failed to mark tenant deleting")
@@ -945,11 +949,6 @@ func (s *Server) cleanupNativeFork(w http.ResponseWriter, r *http.Request, t *me
 	}
 	if err := s.cleanupForkTenantOnce(r.Context(), t.ID, credentialReq); err != nil {
 		logger.Error(r.Context(), "native_fork_cleanup_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-		if t.Status != meta.TenantDeleting {
-			if revertErr := s.meta.UpdateTenantStatus(r.Context(), t.ID, t.Status); revertErr != nil {
-				logger.Error(r.Context(), "native_fork_cleanup_revert_failed", zap.String("tenant_id", t.ID), zap.Error(revertErr))
-			}
-		}
 		errJSON(w, http.StatusBadGateway, "fork delete cleanup failed")
 		return
 	}

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -667,7 +667,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		if forkTenant.DBHost != "" && forkTenant.DBPort != 0 && forkTenant.DBUser != "" {
 			return tenantDSN(forkTenant.DBUser, string(plain), forkTenant.DBHost, forkTenant.DBPort, forkTenant.DBName, forkTenant.DBTLS), nil
 		}
-		if branchProv, ok := s.provisioner.(tenant.CredentialBranchProvisioner); ok {
+		if branchProv, ok := s.provisioner.(tenant.CredentialBranchProvisioner); ok && credentialReq != nil {
 			username, err := branchProv.WaitForBranchUserWithCredentials(ctx, forkTenant.ClusterID, forkTenant.BranchID, *credentialReq)
 			if err != nil {
 				return "", err

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -945,6 +945,11 @@ func (s *Server) cleanupNativeFork(w http.ResponseWriter, r *http.Request, t *me
 	}
 	if err := s.cleanupForkTenantOnce(r.Context(), t.ID, credentialReq); err != nil {
 		logger.Error(r.Context(), "native_fork_cleanup_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+		if t.Status != meta.TenantDeleting {
+			if revertErr := s.meta.UpdateTenantStatus(r.Context(), t.ID, t.Status); revertErr != nil {
+				logger.Error(r.Context(), "native_fork_cleanup_revert_failed", zap.String("tenant_id", t.ID), zap.Error(revertErr))
+			}
+		}
 		errJSON(w, http.StatusBadGateway, "fork delete cleanup failed")
 		return
 	}

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -444,66 +444,22 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		return nil, makeProvisionFailedErr(err)
 	}
 
-	// For TiDB Cloud Native, when the branch was created but the connection
-	// username (user prefix) is not yet available (branch still CREATING),
-	// synchronously wait for it if per-request credentials were provided.
-	// Host and port are inherited from the source cluster.
-	// Starter mode branches return the full endpoint immediately so this path
-	// is cloud-native only.
-	if source.Provider == tenant.ProviderTiDBCloudNative && cluster.Username == "" {
-		if credentialReq != nil {
-			logger.Info(ctx, "fork_waiting_branch_user",
-				zap.String("fork_id", forkID),
-				zap.String("cluster_id", cluster.ClusterID),
-				zap.String("branch_id", cluster.BranchID))
-			branchProv, ok := s.provisioner.(tenant.CredentialBranchProvisioner)
-			if !ok {
-				s.markForkFailedAndCleanup(ctx, forkID)
-				return nil, makeProvisionFailedErr(fmt.Errorf("fork requires credential branch-capable provisioner"))
+	// When the branch endpoint is not yet available (branch still CREATING)
+	// and we have per-request credentials, defer to async provisioning instead
+	// of failing. The async provisioner will wait for the branch to become active.
+	if source.Provider == tenant.ProviderTiDBCloudNative && cluster.Username == "" && credentialReq == nil && resolveDefaultCredentials(s.provisioner) == nil {
+		logger.Error(ctx, "fork_missing_endpoint_no_credentials",
+			zap.String("source_tenant_id", source.ID),
+			zap.String("fork_id", forkID))
+		if s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster) {
+			if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantDeleted); err != nil {
+				logger.Error(ctx, "fork_credential_gate_mark_deleted_failed",
+					zap.String("tenant_id", forkID), zap.Error(err))
 			}
-			username, err := branchProv.WaitForBranchUserWithCredentials(ctx, cluster.ClusterID, cluster.BranchID, *credentialReq)
-			if err != nil {
-				logger.Error(ctx, "fork_wait_branch_user_failed",
-					zap.String("source_tenant_id", source.ID),
-					zap.String("fork_id", forkID),
-					zap.Error(err))
-				s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster)
-				s.markForkFailedAndCleanup(ctx, forkID)
-				return nil, makeProvisionFailedErr(err)
-			}
-			if err := s.meta.UpdateTenantConnection(ctx, forkID, &meta.Tenant{
-				DBHost:           source.DBHost,
-				DBPort:           source.DBPort,
-				DBUser:           username,
-				DBPasswordCipher: forkRoot.DBPasswordCipher,
-				DBName:           cluster.DBName,
-				DBTLS:            true,
-				Provider:         cluster.Provider,
-				ClusterID:        cluster.ClusterID,
-				BranchID:         cluster.BranchID,
-			}); err != nil {
-				logger.Error(ctx, "fork_update_user_failed",
-					zap.String("source_tenant_id", source.ID),
-					zap.String("fork_id", forkID),
-					zap.Error(err))
-				s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster)
-				s.markForkFailedAndCleanup(ctx, forkID)
-				return nil, makeProvisionFailedErr(err)
-			}
-		} else if resolveDefaultCredentials(s.provisioner) == nil {
-			logger.Error(ctx, "fork_missing_endpoint_no_credentials",
-				zap.String("source_tenant_id", source.ID),
-				zap.String("fork_id", forkID))
-			if s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster) {
-				if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantDeleted); err != nil {
-					logger.Error(ctx, "fork_credential_gate_mark_deleted_failed",
-						zap.String("tenant_id", forkID), zap.Error(err))
-				}
-			} else {
-				s.markForkFailedAndCleanup(ctx, forkID)
-			}
-			return nil, makeProvisionFailedErr(forkErr(http.StatusBadRequest, "branch response missing endpoint; server default TiDB Cloud credential is required to provision this fork"))
+		} else {
+			s.markForkFailedAndCleanup(ctx, forkID)
 		}
+		return nil, makeProvisionFailedErr(forkErr(http.StatusBadRequest, "branch response missing endpoint; server default TiDB Cloud credential is required to provision this fork"))
 	}
 
 	if source.Provider == tenant.ProviderTiDBCloudNative {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -651,6 +651,9 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 			if err != nil {
 				return "", err
 			}
+			if username == "" {
+				return "", fmt.Errorf("branch user prefix not yet available")
+			}
 			host := forkTenant.DBHost
 			port := forkTenant.DBPort
 			if host == "" {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -423,8 +423,8 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 	forkRoot.ClusterID = cluster.ClusterID
 	forkRoot.BranchID = cluster.BranchID
 	if err := s.meta.UpdateTenantConnection(ctx, forkID, &meta.Tenant{
-		DBHost:           cluster.Host,
-		DBPort:           cluster.Port,
+		DBHost:           source.DBHost,
+		DBPort:           source.DBPort,
 		DBUser:           cluster.Username,
 		DBPasswordCipher: forkRoot.DBPasswordCipher,
 		DBName:           cluster.DBName,
@@ -444,19 +444,66 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		return nil, makeProvisionFailedErr(err)
 	}
 
-	// Defensive: native branch created without endpoint and server has no default
-	// TiDB Cloud credential. Normally POST create-branch returns endpoint immediately,
-	// so this path should not trigger. Fail fast and clean up or return api_key for recovery.
-	if source.Provider == tenant.ProviderTiDBCloudNative && (cluster.Host == "" || cluster.Port == 0 || cluster.Username == "") && resolveDefaultCredentials(s.provisioner) == nil {
-		if s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster) {
-			if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantDeleted); err != nil {
-				logger.Error(ctx, "fork_credential_gate_mark_deleted_failed",
-					zap.String("tenant_id", forkID), zap.Error(err))
+	// For TiDB Cloud Native, when the branch was created but the connection
+	// username (user prefix) is not yet available (branch still CREATING),
+	// synchronously wait for it if per-request credentials were provided.
+	// Host and port are inherited from the source cluster.
+	// Starter mode branches return the full endpoint immediately so this path
+	// is cloud-native only.
+	if source.Provider == tenant.ProviderTiDBCloudNative && cluster.Username == "" {
+		if credentialReq != nil {
+			logger.Info(ctx, "fork_waiting_branch_user",
+				zap.String("fork_id", forkID),
+				zap.String("cluster_id", cluster.ClusterID),
+				zap.String("branch_id", cluster.BranchID))
+			branchProv, ok := s.provisioner.(tenant.CredentialBranchProvisioner)
+			if !ok {
+				s.markForkFailedAndCleanup(ctx, forkID)
+				return nil, makeProvisionFailedErr(fmt.Errorf("fork requires credential branch-capable provisioner"))
 			}
-		} else {
-			s.markForkFailedAndCleanup(ctx, forkID)
+			username, err := branchProv.WaitForBranchUserWithCredentials(ctx, cluster.ClusterID, cluster.BranchID, *credentialReq)
+			if err != nil {
+				logger.Error(ctx, "fork_wait_branch_user_failed",
+					zap.String("source_tenant_id", source.ID),
+					zap.String("fork_id", forkID),
+					zap.Error(err))
+				s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster)
+				s.markForkFailedAndCleanup(ctx, forkID)
+				return nil, makeProvisionFailedErr(err)
+			}
+			if err := s.meta.UpdateTenantConnection(ctx, forkID, &meta.Tenant{
+				DBHost:           source.DBHost,
+				DBPort:           source.DBPort,
+				DBUser:           username,
+				DBPasswordCipher: forkRoot.DBPasswordCipher,
+				DBName:           cluster.DBName,
+				DBTLS:            true,
+				Provider:         cluster.Provider,
+				ClusterID:        cluster.ClusterID,
+				BranchID:         cluster.BranchID,
+			}); err != nil {
+				logger.Error(ctx, "fork_update_user_failed",
+					zap.String("source_tenant_id", source.ID),
+					zap.String("fork_id", forkID),
+					zap.Error(err))
+				s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster)
+				s.markForkFailedAndCleanup(ctx, forkID)
+				return nil, makeProvisionFailedErr(err)
+			}
+		} else if resolveDefaultCredentials(s.provisioner) == nil {
+			logger.Error(ctx, "fork_missing_endpoint_no_credentials",
+				zap.String("source_tenant_id", source.ID),
+				zap.String("fork_id", forkID))
+			if s.deleteForkBranchOrPersist(backgroundWithTrace(ctx), forkID, credentialReq, cluster) {
+				if err := s.meta.UpdateTenantStatus(ctx, forkID, meta.TenantDeleted); err != nil {
+					logger.Error(ctx, "fork_credential_gate_mark_deleted_failed",
+						zap.String("tenant_id", forkID), zap.Error(err))
+				}
+			} else {
+				s.markForkFailedAndCleanup(ctx, forkID)
+			}
+			return nil, makeProvisionFailedErr(forkErr(http.StatusBadRequest, "branch response missing endpoint; server default TiDB Cloud credential is required to provision this fork"))
 		}
-		return nil, makeProvisionFailedErr(forkErr(http.StatusBadRequest, "branch response missing endpoint; server default TiDB Cloud credential is required to provision this fork"))
 	}
 
 	if source.Provider == tenant.ProviderTiDBCloudNative {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -690,8 +690,6 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 				Provider:         forkTenant.Provider,
 				ClusterID:        forkTenant.ClusterID,
 				BranchID:         forkTenant.BranchID,
-				ClaimURL:         forkTenant.ClaimURL,
-				ClaimExpiresAt:   forkTenant.ClaimExpiresAt,
 			}); err != nil {
 				return "", err
 			}

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -363,9 +363,6 @@ func TestCreateForkPartialBranchProvisionErrorPersistsBranchAndKeepsRoot(t *test
 		t.Fatalf("message = %q", resp.Message)
 	}
 	waitForCondition(t, func() bool {
-		return len(rt.prov.deletedBranches()) >= 1
-	})
-	waitForCondition(t, func() bool {
 		failed, err := rt.meta.ListTenantsByStatus(context.Background(), meta.TenantFailed, 10)
 		return err == nil && len(failed) == 1
 	})
@@ -379,9 +376,6 @@ func TestCreateForkPartialBranchProvisionErrorPersistsBranchAndKeepsRoot(t *test
 	}
 	if failed[0].BranchID != "branch-created" || failed[0].ClusterID != "cluster-a" {
 		t.Fatalf("failed fork branch metadata = cluster:%q branch:%q", failed[0].ClusterID, failed[0].BranchID)
-	}
-	if deleted := rt.prov.deletedBranches(); len(deleted) == 0 || deleted[0] != "cluster-a/branch-created" {
-		t.Fatalf("deleted branches = %#v", deleted)
 	}
 }
 
@@ -794,7 +788,7 @@ func (d *defaultCredentialsProvisioner) DefaultCredentials() (tenant.CredentialP
 	return d.creds, true
 }
 
-func TestHandleForkDeleteNativeUsesDefaultCredentialsWhenRequestLacksKey(t *testing.T) {
+func TestHandleForkDeleteNativeRejectedWhenRequestLacksKey(t *testing.T) {
 	rt := newForkCleanupTestRuntime(t)
 	rt.prov.provider = tenant.ProviderTiDBCloudNative
 	rt.insertTenantWithProvider(t, "fork-native-def", meta.TenantFailed, meta.TenantKindFork, "parent", "ns-parent", "branch-a", tenant.ProviderTiDBCloudNative)
@@ -803,34 +797,17 @@ func TestHandleForkDeleteNativeUsesDefaultCredentialsWhenRequestLacksKey(t *test
 		t.Fatal(err)
 	}
 
-	defaultCreds := tenant.CredentialProvisionRequest{PublicKey: "default-pk", PrivateKey: "default-sk"}
-	rt.server.provisioner = &defaultCredentialsProvisioner{fakeBranchProvisioner: rt.prov, creds: defaultCreds}
-
 	req := httptest.NewRequest(http.MethodDelete, "/v1/fork", strings.NewReader(`{}`))
 	req = req.WithContext(withScope(req.Context(), &TenantScope{TenantID: "fork-native-def"}))
 	rr := httptest.NewRecorder()
 	rt.server.handleForkDelete(rr, req)
 
-	if rr.Code != http.StatusAccepted {
+	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
 	}
-	got, err := rt.meta.GetTenant(context.Background(), "fork-native-def")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Status != meta.TenantDeleted {
-		t.Fatalf("status = %s, want %s", got.Status, meta.TenantDeleted)
-	}
-	if deleted := rt.prov.deletedBranches(); len(deleted) != 1 || deleted[0] != "cluster-a/branch-a" {
-		t.Fatalf("deleted branches = %#v", deleted)
-	}
-	creds := rt.prov.credentialRequests()
-	if len(creds) == 0 {
-		t.Fatal("DeleteBranchWithCredentials was not called")
-	}
-	last := creds[len(creds)-1]
-	if last.PublicKey != "default-pk" || last.PrivateKey != "default-sk" {
-		t.Fatalf("credential request = %+v", last)
+	body := rr.Body.String()
+	if !strings.Contains(body, "invalid or missing TiDB Cloud credentials") {
+		t.Fatalf("body missing expected error: %s", body)
 	}
 }
 

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -379,6 +379,38 @@ func TestCreateForkPartialBranchProvisionErrorPersistsBranchAndKeepsRoot(t *test
 	}
 }
 
+func TestCreateForkTenantPreAPIKeyFailureMarksDeleted(t *testing.T) {
+	rt := newForkCleanupTestRuntime(t)
+	rt.prov.provider = tenant.ProviderTiDBCloudNative
+	rt.insertLiveTenantWithProvider(t, "source", tenant.ProviderTiDBCloudNative)
+	rt.prov.cluster = &tenant.ClusterInfo{
+		ClusterID: "cluster-a",
+		BranchID:  "branch-created",
+		Provider:  tenant.ProviderTiDBCloudNative,
+	}
+	rt.prov.initErr = errors.New("init failed")
+	rt.prov.systemUsername = "u1.root"
+
+	_, err := rt.server.createForkTenant(context.Background(), "source", "fork", &tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	if err == nil {
+		t.Fatal("createForkTenant error = nil, want error")
+	}
+
+	// Before this PR, pre-API-key failures left tenant as "failed".
+	// Now they should be marked "deleted" since caller has no API key.
+	failed, _ := rt.meta.ListTenantsByStatus(context.Background(), meta.TenantFailed, 10)
+	if len(failed) != 0 {
+		t.Fatalf("failed tenants = %d, want 0 (pre-API-key failure should mark deleted)", len(failed))
+	}
+	deleted, _ := rt.meta.ListTenantsByStatus(context.Background(), meta.TenantDeleted, 10)
+	if len(deleted) == 0 {
+		t.Fatal("deleted tenants = 0, want at least 1 (pre-API-key failure should mark deleted)")
+	}
+}
+
 func TestCreateForkTenantPersistsGeneratedBranchPassword(t *testing.T) {
 	rt := newForkCleanupTestRuntime(t)
 	rt.insertLiveTenant(t, "source")

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -379,35 +379,53 @@ func TestCreateForkPartialBranchProvisionErrorPersistsBranchAndKeepsRoot(t *test
 	}
 }
 
-func TestCreateForkTenantPreAPIKeyFailureMarksDeleted(t *testing.T) {
+func TestCreateForkTenantPostAPIKeyFailureMarksFailed(t *testing.T) {
+	origWindow, origInitialBackoff, origMaxBackoff := forkProvisionRetryWindow, forkProvisionInitialBackoff, forkProvisionMaxBackoff
+	forkProvisionRetryWindow = 500 * time.Millisecond
+	forkProvisionInitialBackoff = 5 * time.Millisecond
+	forkProvisionMaxBackoff = 5 * time.Millisecond
+	t.Cleanup(func() {
+		forkProvisionRetryWindow = origWindow
+		forkProvisionInitialBackoff = origInitialBackoff
+		forkProvisionMaxBackoff = origMaxBackoff
+	})
+
 	rt := newForkCleanupTestRuntime(t)
 	rt.prov.provider = tenant.ProviderTiDBCloudNative
 	rt.insertLiveTenantWithProvider(t, "source", tenant.ProviderTiDBCloudNative)
 	rt.prov.cluster = &tenant.ClusterInfo{
 		ClusterID: "cluster-a",
 		BranchID:  "branch-created",
+		Host:      rt.dbHost,
+		Port:      rt.dbPort,
+		Username:  rt.dbUser,
+		DBName:    rt.dbName,
 		Provider:  tenant.ProviderTiDBCloudNative,
 	}
 	rt.prov.initErr = errors.New("init failed")
-	rt.prov.systemUsername = "u1.root"
 
-	_, err := rt.server.createForkTenant(context.Background(), "source", "fork", &tenant.CredentialProvisionRequest{
+	resp, err := rt.server.createForkTenant(context.Background(), "source", "fork", &tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	})
-	if err == nil {
-		t.Fatal("createForkTenant error = nil, want error")
+	if err != nil {
+		t.Fatalf("createForkTenant error = %v, want nil (provision is async)", err)
+	}
+	if resp.Status != string(meta.TenantProvisioning) || resp.APIKey == "" {
+		t.Fatalf("unexpected fork response: %+v", resp)
 	}
 
-	// Before this PR, pre-API-key failures left tenant as "failed".
-	// Now they should be marked "deleted" since caller has no API key.
-	failed, _ := rt.meta.ListTenantsByStatus(context.Background(), meta.TenantFailed, 10)
-	if len(failed) != 0 {
-		t.Fatalf("failed tenants = %d, want 0 (pre-API-key failure should mark deleted)", len(failed))
+	waitForCondition(t, func() bool {
+		failed, err := rt.meta.ListTenantsByStatus(context.Background(), meta.TenantFailed, 10)
+		return err == nil && len(failed) == 1
+	})
+
+	failed, err := rt.meta.ListTenantsByStatus(context.Background(), meta.TenantFailed, 10)
+	if err != nil {
+		t.Fatal(err)
 	}
-	deleted, _ := rt.meta.ListTenantsByStatus(context.Background(), meta.TenantDeleted, 10)
-	if len(deleted) == 0 {
-		t.Fatal("deleted tenants = 0, want at least 1 (pre-API-key failure should mark deleted)")
+	if len(failed) != 1 {
+		t.Fatalf("failed tenants = %d, want 1 (post-API-key failure should mark failed, not deleted)", len(failed))
 	}
 }
 

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -779,15 +779,6 @@ func TestHandleForkDeleteNativeFailedBranchIDEmptyNoCredentialsDeletesLocally(t 
 	}
 }
 
-type defaultCredentialsProvisioner struct {
-	*fakeBranchProvisioner
-	creds tenant.CredentialProvisionRequest
-}
-
-func (d *defaultCredentialsProvisioner) DefaultCredentials() (tenant.CredentialProvisionRequest, bool) {
-	return d.creds, true
-}
-
 func TestHandleForkDeleteNativeRejectedWhenRequestLacksKey(t *testing.T) {
 	rt := newForkCleanupTestRuntime(t)
 	rt.prov.provider = tenant.ProviderTiDBCloudNative

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -860,9 +860,10 @@ func TestHandleForkDeleteNativeRejectsWhenNoCredentialsAvailable(t *testing.T) {
 	}
 }
 
-func TestCreateForkTenantNativeNoEndpointNoDefaultCredentialFailsWithAPIKey(t *testing.T) {
+func TestCreateForkTenantNativeProvisionsWhenCredentialsPresent(t *testing.T) {
 	rt := newForkCleanupTestRuntime(t)
 	rt.prov.provider = tenant.ProviderTiDBCloudNative
+	rt.prov.systemUsername = "u1.root"
 	rt.insertLiveTenantWithProvider(t, "source", tenant.ProviderTiDBCloudNative)
 	rt.prov.cluster = &tenant.ClusterInfo{
 		ClusterID: "cluster-a",
@@ -874,25 +875,21 @@ func TestCreateForkTenantNativeNoEndpointNoDefaultCredentialFailsWithAPIKey(t *t
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	})
-	if err == nil {
-		t.Fatal("createForkTenant error = nil, want forkProvisionFailedError")
+	if err != nil {
+		t.Fatalf("createForkTenant error = %v, want nil", err)
 	}
-	var provisionErr *forkProvisionFailedError
-	if !errors.As(err, &provisionErr) {
-		t.Fatalf("createForkTenant error type = %T, want forkProvisionFailedError", err)
+	if resp == nil {
+		t.Fatal("createForkTenant response is nil")
 	}
-	if provisionErr.APIKey == "" {
-		t.Fatal("forkProvisionFailedError.APIKey is empty")
+	if resp.Status != string(meta.TenantProvisioning) {
+		t.Fatalf("createForkTenant status = %s, want %s", resp.Status, meta.TenantProvisioning)
 	}
-	if provisionErr.TenantID == "" {
-		t.Fatal("forkProvisionFailedError.TenantID is empty")
-	}
-	if resp != nil {
-		t.Fatalf("createForkTenant response = %+v, want nil on error", resp)
+	if resp.APIKey == "" {
+		t.Fatal("createForkTenant response missing api_key")
 	}
 }
 
-func TestHandleForkCreateNativeNoEndpointNoDefaultCredentialReturnsFailedWithAPIKey(t *testing.T) {
+func TestCreateForkTenantNativeNoDefaultCredentialReturnsError(t *testing.T) {
 	rt := newForkCleanupTestRuntime(t)
 	rt.prov.provider = tenant.ProviderTiDBCloudNative
 	rt.insertLiveTenantWithProvider(t, "source", tenant.ProviderTiDBCloudNative)
@@ -901,7 +898,26 @@ func TestHandleForkCreateNativeNoEndpointNoDefaultCredentialReturnsFailedWithAPI
 		BranchID:  "branch-created",
 		Provider:  tenant.ProviderTiDBCloudNative,
 	}
-	rt.prov.deleteErr = fmt.Errorf("delete branch failed")
+
+	_, err := rt.server.createForkTenant(context.Background(), "source", "fork", nil)
+	if err == nil {
+		t.Fatal("createForkTenant error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), tenant.ErrCredentialsRequired.Error()) {
+		t.Fatalf("createForkTenant error = %v, want ErrCredentialsRequired", err)
+	}
+}
+
+func TestHandleForkCreateNativeReturnsProvisioningWhenCredentialsPresent(t *testing.T) {
+	rt := newForkCleanupTestRuntime(t)
+	rt.prov.provider = tenant.ProviderTiDBCloudNative
+	rt.prov.systemUsername = "u1.root"
+	rt.insertLiveTenantWithProvider(t, "source", tenant.ProviderTiDBCloudNative)
+	rt.prov.cluster = &tenant.ClusterInfo{
+		ClusterID: "cluster-a",
+		BranchID:  "branch-created",
+		Provider:  tenant.ProviderTiDBCloudNative,
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/fork", strings.NewReader(`{"name":"test-fork","public_key":"public-1","private_key":"private-1"}`))
 	req = req.WithContext(withScope(req.Context(), &TenantScope{TenantID: "source"}))
@@ -912,17 +928,14 @@ func TestHandleForkCreateNativeNoEndpointNoDefaultCredentialReturnsFailedWithAPI
 		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
 	}
 	body := rr.Body.String()
-	if !strings.Contains(body, `"status":"failed"`) {
-		t.Fatalf("body missing status failed: %s", body)
+	if !strings.Contains(body, `"status":"provisioning"`) {
+		t.Fatalf("body missing status provisioning: %s", body)
 	}
 	if !strings.Contains(body, `"api_key"`) {
 		t.Fatalf("body missing api_key: %s", body)
 	}
-	if !strings.Contains(body, `"tenant_id"`) {
-		t.Fatalf("body missing tenant_id: %s", body)
-	}
-	if strings.Contains(body, `"status":"provisioning"`) {
-		t.Fatalf("body should not contain provisioning status: %s", body)
+	if strings.Contains(body, `"status":"failed"`) {
+		t.Fatalf("body should not contain failed status: %s", body)
 	}
 }
 

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -139,6 +139,13 @@ func (f *fakeBranchProvisioner) WaitForBranchActiveWithCredentials(ctx context.C
 	return f.WaitForBranchActive(ctx, branch)
 }
 
+func (f *fakeBranchProvisioner) WaitForBranchUserWithCredentials(_ context.Context, clusterID, branchID string, req tenant.CredentialProvisionRequest) (string, error) {
+	f.mu.Lock()
+	f.credentialReqs = append(f.credentialReqs, req)
+	f.mu.Unlock()
+	return f.systemUsername, nil
+}
+
 func (f *fakeBranchProvisioner) DeleteBranch(_ context.Context, clusterID, branchID string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -593,7 +593,7 @@ func (s *Server) resumeProvisioningTenantsWithCtx(ctx context.Context) {
 			logger.Info(ctx, "resume_provisioning_fork",
 				zap.String("tenant_id", t.ID),
 				zap.String("parent_tenant_id", t.ParentTenantID))
-			if t.Provider == tenant.ProviderTiDBCloudNative && t.DBUser == "" && resolveDefaultCredentials(s.provisioner) == nil {
+			if t.Provider == tenant.ProviderTiDBCloudNative && t.DBUser == "" {
 				logger.Error(ctx, "resume_provisioning_fork_no_credentials",
 					zap.String("tenant_id", t.ID),
 					zap.String("provider", t.Provider))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -593,6 +593,13 @@ func (s *Server) resumeProvisioningTenantsWithCtx(ctx context.Context) {
 			logger.Info(ctx, "resume_provisioning_fork",
 				zap.String("tenant_id", t.ID),
 				zap.String("parent_tenant_id", t.ParentTenantID))
+			if t.Provider == tenant.ProviderTiDBCloudNative && t.DBUser == "" && resolveDefaultCredentials(s.provisioner) == nil {
+				logger.Error(ctx, "resume_provisioning_fork_no_credentials",
+					zap.String("tenant_id", t.ID),
+					zap.String("provider", t.Provider))
+				s.markForkFailedAndCleanup(ctx, t.ID)
+				continue
+			}
 			s.startForkProvision(ctx, t.ID)
 			continue
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -596,7 +596,9 @@ func (s *Server) resumeProvisioningTenantsWithCtx(ctx context.Context) {
 			if t.Provider == tenant.ProviderTiDBCloudNative && t.DBUser == "" {
 				logger.Error(ctx, "resume_provisioning_fork_no_credentials",
 					zap.String("tenant_id", t.ID),
-					zap.String("provider", t.Provider))
+					zap.String("provider", t.Provider),
+					zap.String("cluster_id", t.ClusterID),
+					zap.String("branch_id", t.BranchID))
 				s.markForkFailedAndCleanup(ctx, t.ID)
 				continue
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -599,7 +599,7 @@ func (s *Server) resumeProvisioningTenantsWithCtx(ctx context.Context) {
 					zap.String("provider", t.Provider),
 					zap.String("cluster_id", t.ClusterID),
 					zap.String("branch_id", t.BranchID))
-				s.markForkFailedAndCleanup(ctx, t.ID)
+				s.markForkFailed(ctx, t.ID)
 				continue
 			}
 			s.startForkProvision(ctx, t.ID)

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -88,6 +88,7 @@ type CredentialBranchProvisioner interface {
 	Provisioner
 	CreateBranchWithCredentials(ctx context.Context, forkTenantID string, source *ClusterInfo, req CredentialProvisionRequest) (*ClusterInfo, error)
 	WaitForBranchActiveWithCredentials(ctx context.Context, branch *ClusterInfo, req CredentialProvisionRequest) (*ClusterInfo, error)
+	WaitForBranchUserWithCredentials(ctx context.Context, clusterID, branchID string, req CredentialProvisionRequest) (string, error)
 	DeleteBranchWithCredentials(ctx context.Context, clusterID, branchID string, req CredentialProvisionRequest) error
 }
 

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -88,7 +88,6 @@ type CredentialBranchProvisioner interface {
 	Provisioner
 	CreateBranchWithCredentials(ctx context.Context, forkTenantID string, source *ClusterInfo, req CredentialProvisionRequest) (*ClusterInfo, error)
 	WaitForBranchActiveWithCredentials(ctx context.Context, branch *ClusterInfo, req CredentialProvisionRequest) (*ClusterInfo, error)
-	WaitForBranchUserWithCredentials(ctx context.Context, clusterID, branchID string, req CredentialProvisionRequest) (string, error)
 	DeleteBranchWithCredentials(ctx context.Context, clusterID, branchID string, req CredentialProvisionRequest) error
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -963,6 +963,49 @@ func (p *Provisioner) waitForBranchActive(ctx context.Context, publicKey, privat
 	}
 }
 
+func (p *Provisioner) WaitForBranchUserWithCredentials(ctx context.Context, clusterID, branchID string, req tenant.CredentialProvisionRequest) (string, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return "", tenant.ErrCredentialsRequired
+	}
+	deadline := time.Now().Add(10 * time.Minute)
+	for {
+		endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s/branches/%s?view=BASIC", p.apiURL, url.PathEscape(clusterID), url.PathEscape(branchID))
+		resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return "", err
+		}
+		limit := int64(upstreamClusterBodyLimit)
+		if resp.StatusCode != http.StatusOK {
+			limit = upstreamErrorBodyLimit + 1
+		}
+		raw, readErr := readUpstreamBody(resp.Body, limit)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return "", readErr
+		}
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("%s", statusError("branch get", resp.StatusCode, sanitizeUpstreamBody(raw)))
+		}
+		info, err := parseBranchInfo(raw)
+		if err != nil {
+			return "", err
+		}
+		if info.UserPrefix != "" {
+			return info.UserPrefix + ".root", nil
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("tidbcloud native branch %s user prefix not available before timeout", branchID)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(tidbCloudNativePollInterval):
+		}
+	}
+}
+
 func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privateKey, method, uri string, body []byte) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, uri, bytes.NewReader(body))
 	if err != nil {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -925,40 +925,27 @@ func (p *Provisioner) waitForClusterActive(ctx context.Context, publicKey, priva
 	}
 }
 
-func (p *Provisioner) WaitForBranchUserWithCredentials(ctx context.Context, clusterID, branchID string, req tenant.CredentialProvisionRequest) (string, error) {
-	publicKey := strings.TrimSpace(req.PublicKey)
-	privateKey := strings.TrimSpace(req.PrivateKey)
-	if publicKey == "" || privateKey == "" {
-		return "", tenant.ErrCredentialsRequired
-	}
-	return p.waitForBranchUserPrefix(ctx, publicKey, privateKey, clusterID, branchID)
-}
-
-func (p *Provisioner) waitForBranchUserPrefix(ctx context.Context, publicKey, privateKey, clusterID, branchID string) (string, error) {
-	deadline := time.Now().Add(10 * time.Minute)
-	for {
-		info, err := p.getBranchInfo(ctx, publicKey, privateKey, clusterID, branchID)
-		if err != nil {
-			return "", err
-		}
-		if info.UserPrefix != "" {
-			return info.UserPrefix + ".root", nil
-		}
-		if time.Now().After(deadline) {
-			return "", fmt.Errorf("tidbcloud native branch %s user prefix not available before timeout", branchID)
-		}
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case <-time.After(tidbCloudNativePollInterval):
-		}
-	}
-}
-
 func (p *Provisioner) waitForBranchActive(ctx context.Context, publicKey, privateKey, clusterID, branchID string) (*branchInfo, error) {
 	deadline := time.Now().Add(10 * time.Minute)
 	for {
-		info, err := p.getBranchInfo(ctx, publicKey, privateKey, clusterID, branchID)
+		endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s/branches/%s?view=BASIC", p.apiURL, url.PathEscape(clusterID), url.PathEscape(branchID))
+		resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+		limit := int64(upstreamClusterBodyLimit)
+		if resp.StatusCode != http.StatusOK {
+			limit = upstreamErrorBodyLimit + 1
+		}
+		raw, readErr := readUpstreamBody(resp.Body, limit)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("%s", statusError("branch get", resp.StatusCode, sanitizeUpstreamBody(raw)))
+		}
+		info, err := parseBranchInfo(raw)
 		if err != nil {
 			return nil, err
 		}
@@ -974,31 +961,6 @@ func (p *Provisioner) waitForBranchActive(ctx context.Context, publicKey, privat
 		case <-time.After(tidbCloudNativePollInterval):
 		}
 	}
-}
-
-func (p *Provisioner) getBranchInfo(ctx context.Context, publicKey, privateKey, clusterID, branchID string) (*branchInfo, error) {
-	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s/branches/%s?view=BASIC", p.apiURL, url.PathEscape(clusterID), url.PathEscape(branchID))
-	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-	limit := int64(upstreamClusterBodyLimit)
-	if resp.StatusCode != http.StatusOK {
-		limit = upstreamErrorBodyLimit + 1
-	}
-	raw, readErr := readUpstreamBody(resp.Body, limit)
-	_ = resp.Body.Close()
-	if readErr != nil {
-		return nil, readErr
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", statusError("branch get", resp.StatusCode, sanitizeUpstreamBody(raw)))
-	}
-	info, err := parseBranchInfo(raw)
-	if err != nil {
-		return nil, err
-	}
-	return info, nil
 }
 
 func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privateKey, method, uri string, body []byte) (*http.Response, error) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -992,6 +992,9 @@ func (p *Provisioner) WaitForBranchUserWithCredentials(ctx context.Context, clus
 		if err != nil {
 			return "", err
 		}
+		if info.Username != "" {
+			return info.Username, nil
+		}
 		if info.UserPrefix != "" {
 			return info.UserPrefix + ".root", nil
 		}

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -925,27 +925,40 @@ func (p *Provisioner) waitForClusterActive(ctx context.Context, publicKey, priva
 	}
 }
 
+func (p *Provisioner) WaitForBranchUserWithCredentials(ctx context.Context, clusterID, branchID string, req tenant.CredentialProvisionRequest) (string, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return "", tenant.ErrCredentialsRequired
+	}
+	return p.waitForBranchUserPrefix(ctx, publicKey, privateKey, clusterID, branchID)
+}
+
+func (p *Provisioner) waitForBranchUserPrefix(ctx context.Context, publicKey, privateKey, clusterID, branchID string) (string, error) {
+	deadline := time.Now().Add(10 * time.Minute)
+	for {
+		info, err := p.getBranchInfo(ctx, publicKey, privateKey, clusterID, branchID)
+		if err != nil {
+			return "", err
+		}
+		if info.UserPrefix != "" {
+			return info.UserPrefix + ".root", nil
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("tidbcloud native branch %s user prefix not available before timeout", branchID)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(tidbCloudNativePollInterval):
+		}
+	}
+}
+
 func (p *Provisioner) waitForBranchActive(ctx context.Context, publicKey, privateKey, clusterID, branchID string) (*branchInfo, error) {
 	deadline := time.Now().Add(10 * time.Minute)
 	for {
-		endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s/branches/%s?view=BASIC", p.apiURL, url.PathEscape(clusterID), url.PathEscape(branchID))
-		resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
-		if err != nil {
-			return nil, err
-		}
-		limit := int64(upstreamClusterBodyLimit)
-		if resp.StatusCode != http.StatusOK {
-			limit = upstreamErrorBodyLimit + 1
-		}
-		raw, readErr := readUpstreamBody(resp.Body, limit)
-		_ = resp.Body.Close()
-		if readErr != nil {
-			return nil, readErr
-		}
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("%s", statusError("branch get", resp.StatusCode, sanitizeUpstreamBody(raw)))
-		}
-		info, err := parseBranchInfo(raw)
+		info, err := p.getBranchInfo(ctx, publicKey, privateKey, clusterID, branchID)
 		if err != nil {
 			return nil, err
 		}
@@ -961,6 +974,31 @@ func (p *Provisioner) waitForBranchActive(ctx context.Context, publicKey, privat
 		case <-time.After(tidbCloudNativePollInterval):
 		}
 	}
+}
+
+func (p *Provisioner) getBranchInfo(ctx context.Context, publicKey, privateKey, clusterID, branchID string) (*branchInfo, error) {
+	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s/branches/%s?view=BASIC", p.apiURL, url.PathEscape(clusterID), url.PathEscape(branchID))
+	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	limit := int64(upstreamClusterBodyLimit)
+	if resp.StatusCode != http.StatusOK {
+		limit = upstreamErrorBodyLimit + 1
+	}
+	raw, readErr := readUpstreamBody(resp.Body, limit)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s", statusError("branch get", resp.StatusCode, sanitizeUpstreamBody(raw)))
+	}
+	info, err := parseBranchInfo(raw)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
 }
 
 func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privateKey, method, uri string, body []byte) (*http.Response, error) {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1025,3 +1025,77 @@ func TestSQLQuoting(t *testing.T) {
 		t.Fatalf("quoteString = %q", got)
 	}
 }
+
+func TestWaitForBranchUserWithCredentialsPollsUserPrefix(t *testing.T) {
+	polls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		polls++
+		if polls < 3 {
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"branchId": "branch-1",
+				"state":    "CREATING",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"branchId":   "branch-1",
+			"state":      "ACTIVE",
+			"userPrefix": "u3",
+			"endpoints":  map[string]any{"public": map[string]any{"host": "branch.example", "port": 4000}},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		defaultDatabaseName: DefaultDatabaseName,
+		client:              ts.Client(),
+	}
+	username, err := p.WaitForBranchUserWithCredentials(context.Background(), "cluster-1", "branch-1", tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"})
+	if err != nil {
+		t.Fatalf("WaitForBranchUserWithCredentials: %v", err)
+	}
+	if username != "u3.root" {
+		t.Fatalf("username = %q, want u3.root", username)
+	}
+	if polls != 3 {
+		t.Fatalf("polls = %d, want 3", polls)
+	}
+}
+
+func TestWaitForBranchUserWithCredentialsPrefersUsername(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"branchId": "branch-1",
+			"state":    "ACTIVE",
+			"username": "direct-user",
+			"endpoints": map[string]any{
+				"public": map[string]any{"host": "branch.example", "port": 4000},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		defaultDatabaseName: DefaultDatabaseName,
+		client:              ts.Client(),
+	}
+	username, err := p.WaitForBranchUserWithCredentials(context.Background(), "cluster-1", "branch-1", tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"})
+	if err != nil {
+		t.Fatalf("WaitForBranchUserWithCredentials: %v", err)
+	}
+	if username != "direct-user" {
+		t.Fatalf("username = %q, want direct-user", username)
+	}
+}


### PR DESCRIPTION
When cleanupNativeFork fails (e.g. InvalidateAndWait timeout), the status was already set to 'deleting' by handleForkDelete. Revert the status back so the caller can retry.