### PR TITLE
fix: skip pool.Acquire for fork delete to avoid deadlock

### DIFF
--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -246,7 +246,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 		}
 
 		if isTenantDeleteRequest(r) || isForkDeleteRequest(r) {
-			handleTenantDeleteAuth(w, r, pool, next, resolved, claims)
+			handleDeleteNoAcquireAuth(w, r, pool, next, resolved, claims)
 			return
 		}
 
@@ -368,7 +368,7 @@ func isForkDeleteRequest(r *http.Request) bool {
 	return r.Method == http.MethodDelete && r.URL.Path == "/v1/fork"
 }
 
-func handleTenantDeleteAuth(w http.ResponseWriter, r *http.Request, pool *tenant.Pool, next http.Handler, resolved *meta.TenantWithAPIKey, claims *token.Claims) {
+func handleDeleteNoAcquireAuth(w http.ResponseWriter, r *http.Request, pool *tenant.Pool, next http.Handler, resolved *meta.TenantWithAPIKey, claims *token.Claims) {
 	switch resolved.Tenant.Status {
 	case meta.TenantActive, meta.TenantFailed, meta.TenantDeleting, meta.TenantDeleted:
 	case meta.TenantPending:

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -245,7 +245,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			return
 		}
 
-		if isTenantDeleteRequest(r) {
+		if isTenantDeleteRequest(r) || isForkDeleteRequest(r) {
 			handleTenantDeleteAuth(w, r, pool, next, resolved, claims)
 			return
 		}
@@ -362,6 +362,10 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 
 func isTenantDeleteRequest(r *http.Request) bool {
 	return r.Method == http.MethodDelete && r.URL.Path == "/v1/tenant"
+}
+
+func isForkDeleteRequest(r *http.Request) bool {
+	return r.Method == http.MethodDelete && r.URL.Path == "/v1/fork"
 }
 
 func handleTenantDeleteAuth(w http.ResponseWriter, r *http.Request, pool *tenant.Pool, next http.Handler, resolved *meta.TenantWithAPIKey, claims *token.Claims) {

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -731,3 +731,33 @@ func TestSanitizeClientError_Fallback(t *testing.T) {
 		}
 	}
 }
+
+func TestAuthForkDeleteSkipsPoolAcquire(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+
+	h := tenantAuthMiddleware(rt.meta, rt.pool, rt.tokenSecret, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scope := ScopeFromContext(r.Context())
+		if scope == nil {
+			t.Fatal("expected tenant scope")
+		}
+		if scope.Backend != nil {
+			t.Fatal("fork delete should not acquire backend")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/v1/fork", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+}

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -919,6 +919,11 @@ func (s *Server) cleanupNativeFork(w http.ResponseWriter, r *http.Request, t *me
 	}
 	if err := s.cleanupForkTenantOnce(r.Context(), t.ID, credentialReq); err != nil {
 		logger.Error(r.Context(), "native_fork_cleanup_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+		if t.Status != meta.TenantDeleting {
+			if _, revertErr := s.meta.UpdateTenantStatusIf(r.Context(), t.ID, meta.TenantDeleting, t.Status); revertErr != nil {
+				logger.Error(r.Context(), "native_fork_cleanup_revert_failed", zap.String("tenant_id", t.ID), zap.Error(revertErr))
+			}
+		}
 		errJSON(w, http.StatusBadGateway, "fork delete cleanup failed")
 		return
 	}

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -919,11 +919,6 @@ func (s *Server) cleanupNativeFork(w http.ResponseWriter, r *http.Request, t *me
 	}
 	if err := s.cleanupForkTenantOnce(r.Context(), t.ID, credentialReq); err != nil {
 		logger.Error(r.Context(), "native_fork_cleanup_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-		if t.Status != meta.TenantDeleting {
-			if _, revertErr := s.meta.UpdateTenantStatusIf(r.Context(), t.ID, meta.TenantDeleting, t.Status); revertErr != nil {
-				logger.Error(r.Context(), "native_fork_cleanup_revert_failed", zap.String("tenant_id", t.ID), zap.Error(revertErr))
-			}
-		}
 		errJSON(w, http.StatusBadGateway, "fork delete cleanup failed")
 		return
 	}


### PR DESCRIPTION
DELETE /v1/fork deadlocks: tenantAuthMiddleware pool.Acquire holds refs:1, then cleanupForkTenantOnce calls InvalidateAndWait which waits for refs==0 — but the ref is held by the middleware itself.\n\nDELETE /v1/tenant has isTenantDeleteRequest special-casing that routes through handleTenantDeleteAuth (no pool.Acquire). Add the same for fork delete.