### PR TITLE
fix: keep quota usage cache warm after outbox ack

### DIFF
--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -387,6 +387,12 @@ func (b *Dat9Backend) addLocalQuotaPendingDeltas(storageDelta, fileDelta, mediaD
 	}
 }
 
+func (b *Dat9Backend) addLocalQuotaUsageDeltas(storageDelta, fileDelta, mediaDelta int64) {
+	if b.quotaUsageCache != nil {
+		b.quotaUsageCache.add(storageDelta, fileDelta, mediaDelta)
+	}
+}
+
 func (r storageQuotaCheckResult) exceeded() bool {
 	return r.checked && r.projected > r.limitBytes
 }

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -239,13 +239,22 @@ func (c *quotaUsageCache) cached(now time.Time) *QuotaUsageView {
 	return nil
 }
 
-func (c *quotaUsageCache) invalidate() {
+func (c *quotaUsageCache) add(storageDelta, fileDelta, mediaDelta int64) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
-	c.snapshot = nil
-	c.mu.Unlock()
+	defer c.mu.Unlock()
+	// If the snapshot is missing or expired, leave it cold. The next soft
+	// admission check reloads the central usage row. When the snapshot is
+	// fresh, a successfully applied quota outbox row can be reflected locally
+	// without forcing the next small write to hit the central DB again.
+	if c.snapshot == nil || c.snapshot.usage == nil || time.Now().After(c.snapshot.expiresAt) {
+		return
+	}
+	c.snapshot.usage.StorageBytes += storageDelta
+	c.snapshot.usage.FileCount += fileDelta
+	c.snapshot.usage.MediaFileCount += mediaDelta
 }
 
 func cloneQuotaUsageView(usage *QuotaUsageView) *QuotaUsageView {

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -255,29 +255,26 @@ func TestQuotaUsageCacheCoalescesConcurrentMisses(t *testing.T) {
 	}
 }
 
-func TestQuotaUsageCacheInvalidateForcesReload(t *testing.T) {
+func TestQuotaUsageCacheAddUpdatesFreshSnapshot(t *testing.T) {
 	store := newCacheTestStore()
-	store.usage["t1"] = &QuotaUsageView{TenantID: "t1", StorageBytes: 10}
+	store.usage["t1"] = &QuotaUsageView{TenantID: "t1", StorageBytes: 10, FileCount: 1}
 	c := newQuotaUsageCache("t1", store, time.Hour)
 
 	first := c.get(context.Background())
-	if first == nil || first.StorageBytes != 10 {
-		t.Fatalf("first usage = %+v, want storage 10", first)
+	if first == nil || first.StorageBytes != 10 || first.FileCount != 1 {
+		t.Fatalf("first usage = %+v, want storage 10 file_count 1", first)
 	}
 	store.mu.Lock()
-	store.usage["t1"].StorageBytes = 20
+	store.usage["t1"].StorageBytes = 99
+	store.usage["t1"].FileCount = 99
 	store.mu.Unlock()
-	if cached := c.get(context.Background()); cached == nil || cached.StorageBytes != 10 {
-		t.Fatalf("cached usage = %+v, want storage 10", cached)
+	c.add(5, 2, 1)
+	updated := c.get(context.Background())
+	if updated == nil || updated.StorageBytes != 15 || updated.FileCount != 3 || updated.MediaFileCount != 1 {
+		t.Fatalf("updated usage = %+v, want storage 15 file_count 3 media_count 1", updated)
 	}
-
-	c.invalidate()
-	reloaded := c.get(context.Background())
-	if reloaded == nil || reloaded.StorageBytes != 20 {
-		t.Fatalf("reloaded usage = %+v, want storage 20", reloaded)
-	}
-	if got := store.usageCalls.Load(); got != 2 {
-		t.Fatalf("usageCalls = %d, want 2", got)
+	if got := store.usageCalls.Load(); got != 1 {
+		t.Fatalf("usageCalls = %d, want 1", got)
 	}
 }
 

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -249,9 +249,7 @@ func (b *Dat9Backend) ProcessOneQuotaOutbox(ctx context.Context) (processed bool
 			metrics.RecordOperation("quota_outbox", entry.MutationType, "error", time.Since(start))
 			return true, applyErr
 		}
-		if b.quotaUsageCache != nil {
-			b.quotaUsageCache.invalidate()
-		}
+		b.addLocalQuotaUsageDeltas(entry.StorageDelta, entry.FileDelta, entry.MediaDelta)
 		b.addLocalQuotaPendingDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
 		metrics.RecordOperation("quota_outbox", entry.MutationType, "ok", time.Since(start))
 		return true, nil


### PR DESCRIPTION
## Summary

Follow-up to the quota hot-path work for the 1k small-file upload case.

The previous outbox ACK path invalidated quotaUsageCache after every successfully applied quota outbox row. That closes the stale-usage undercount window, but under a busy upload it also forces the next soft small-write quota check to re-read central tenant_quota_usage after each ACK, reintroducing central quota reads while the outbox worker is active.

This PR keeps the cache warm instead:

- add quotaUsageCache.add(storageDelta, fileDelta, mediaDelta)
- after a quota outbox row is applied and ACKed, forward the fresh usage snapshot by the applied deltas
- keep the old cold behavior when the snapshot is missing or expired; the next soft check reloads central usage normally
- continue subtracting the same deltas from quotaPendingDeltasCache, so usage + pending remains stable across ACK

Strict upload reservations are unchanged; they still read live central usage and live tenant pending deltas under the admission lock.

## Validation

- make test TEST_PKGS=./pkg/backend TEST_RUN=TestQuotaUsageCache|TestQuotaPendingDeltasCache|TestQuotaOutbox|TestServerQuota|TestServerModeBudget|TestConcurrentServerQuota|TestInitiateUpload
- make lint
- git diff --check

## Notes

This is intentionally narrow. The remaining 1k upload bottleneck may still involve pending-delta cache misses falling back to live SUM(quota_outbox) under heavy concurrent create load, but that needs a more careful design because caching those sums too aggressively can undercount cross-server pending rows. This PR only removes the avoidable central usage reload caused by our own outbox ACK path.