### PR TITLE
fix: quota label update strips immutable labels and improves CLI output

### DIFF
--- a/cmd/drive9/cli/quota.go
+++ b/cmd/drive9/cli/quota.go
@@ -382,7 +382,7 @@ func printQuotaCLIResponse(out *client.QuotaResponse, asJSON bool) error {
 		fmt.Printf("%-20s %d\n", "MaxFileCount:", out.Config.MaxFileCount)
 	}
 	if out.Config.TiDBCloudSpendingLimit != nil {
-		fmt.Printf("%-20s %.2f\n", "SpendingLimit:", float64(*out.Config.TiDBCloudSpendingLimit)/100)
+		fmt.Printf("%-20s $%.2f\n", "SpendingLimit:", float64(*out.Config.TiDBCloudSpendingLimit)/100)
 	}
 	fmt.Printf("%-20s %s\n", "StorageUsed:", formatBytes(out.Usage.StorageBytes))
 	fmt.Printf("%-20s %s\n", "Reserved:", formatBytes(out.Usage.ReservedBytes))
@@ -402,12 +402,13 @@ func formatBytes(n int64) string {
 	if n < unit {
 		return fmt.Sprintf("%d B", n)
 	}
+	units := []string{"KiB", "MiB", "GiB", "TiB", "PiB"}
 	div, exp := int64(unit), 0
-	for m := n / unit; m >= unit && exp < len([]string{"KiB", "MiB", "GiB", "TiB", "PiB"})-1; m /= unit {
+	for m := n / unit; m >= unit && exp < len(units)-1; m /= unit {
 		div *= unit
 		exp++
 	}
-	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), []string{"KiB", "MiB", "GiB", "TiB", "PiB"}[exp])
+	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), units[exp])
 }
 
 func quotaUsage() string {

--- a/cmd/drive9/cli/quota.go
+++ b/cmd/drive9/cli/quota.go
@@ -382,7 +382,7 @@ func printQuotaCLIResponse(out *client.QuotaResponse, asJSON bool) error {
 		fmt.Printf("%-20s %d\n", "MaxFileCount:", out.Config.MaxFileCount)
 	}
 	if out.Config.TiDBCloudSpendingLimit != nil {
-		fmt.Printf("%-20s $%.2f\n", "SpendingLimit:", float64(*out.Config.TiDBCloudSpendingLimit)/100)
+		fmt.Printf("%-20s %.2f\n", "SpendingLimit:", float64(*out.Config.TiDBCloudSpendingLimit)/100)
 	}
 	fmt.Printf("%-20s %s\n", "StorageUsed:", formatBytes(out.Usage.StorageBytes))
 	fmt.Printf("%-20s %s\n", "Reserved:", formatBytes(out.Usage.ReservedBytes))

--- a/cmd/drive9/cli/quota.go
+++ b/cmd/drive9/cli/quota.go
@@ -373,21 +373,41 @@ func printQuotaCLIResponse(out *client.QuotaResponse, asJSON bool) error {
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
 	}
-	fmt.Printf("tenant: %s\n", out.TenantID)
-	fmt.Printf("provider: %s\n", out.Provider)
-	fmt.Printf("status: %s\n", out.Status)
-	fmt.Printf("supports_update: %t\n", out.SupportsUpdate)
-	configParts := []string{
-		fmt.Sprintf("max_storage_size=%dMi", out.Config.MaxStorageSize),
-		fmt.Sprintf("max_file_size=%dMi", out.Config.MaxFileSize),
-		fmt.Sprintf("max_file_count=%d", out.Config.MaxFileCount),
+	fmt.Printf("%-20s %s\n", "TenantID:", out.TenantID)
+	fmt.Printf("%-20s %d Mi\n", "MaxStorage:", out.Config.MaxStorageSize)
+	fmt.Printf("%-20s %d Mi\n", "MaxFileSize:", out.Config.MaxFileSize)
+	if out.Config.MaxFileCount == 0 {
+		fmt.Printf("%-20s %s\n", "MaxFileCount:", "unlimited")
+	} else {
+		fmt.Printf("%-20s %d\n", "MaxFileCount:", out.Config.MaxFileCount)
 	}
 	if out.Config.TiDBCloudSpendingLimit != nil {
-		configParts = append(configParts, fmt.Sprintf("tidbcloud_spending_limit=%d", *out.Config.TiDBCloudSpendingLimit))
+		fmt.Printf("%-20s %.2f\n", "SpendingLimit:", float64(*out.Config.TiDBCloudSpendingLimit)/100)
 	}
-	fmt.Printf("config: %s\n", strings.Join(configParts, " "))
-	fmt.Printf("usage: storage_bytes=%d reserved_bytes=%d file_count=%d\n", out.Usage.StorageBytes, out.Usage.ReservedBytes, out.Usage.FileCount)
+	fmt.Printf("%-20s %s\n", "StorageUsed:", formatBytes(out.Usage.StorageBytes))
+	fmt.Printf("%-20s %s\n", "Reserved:", formatBytes(out.Usage.ReservedBytes))
+	if out.Usage.FileCount == 0 {
+		fmt.Printf("%-20s %s\n", "FileCount:", "0")
+	} else {
+		fmt.Printf("%-20s %d\n", "FileCount:", out.Usage.FileCount)
+	}
 	return nil
+}
+
+func formatBytes(n int64) string {
+	if n < 0 {
+		return "0 B"
+	}
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for m := n / unit; m >= unit && exp < len([]string{"KiB", "MiB", "GiB", "TiB", "PiB"})-1; m /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), []string{"KiB", "MiB", "GiB", "TiB", "PiB"}[exp])
 }
 
 func quotaUsage() string {

--- a/cmd/drive9/cli/quota_test.go
+++ b/cmd/drive9/cli/quota_test.go
@@ -71,7 +71,7 @@ func TestQuotaGetUsesTenantIDAndTiDBCloudHeaders(t *testing.T) {
 	if !strings.Contains(stdout, "MaxFileCount:") || !strings.Contains(stdout, "42") {
 		t.Fatalf("stdout should include max file count: %s", stdout)
 	}
-	if !strings.Contains(stdout, "SpendingLimit:") || !strings.Contains(stdout, "$100.00") {
+	if !strings.Contains(stdout, "SpendingLimit:") || !strings.Contains(stdout, "100.00") {
 		t.Fatalf("stdout should include spending limit: %s", stdout)
 	}
 	if !strings.Contains(stdout, "StorageUsed:") || !strings.Contains(stdout, "1 B") {

--- a/cmd/drive9/cli/quota_test.go
+++ b/cmd/drive9/cli/quota_test.go
@@ -59,11 +59,29 @@ func TestQuotaGetUsesTenantIDAndTiDBCloudHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Quota get: %v", err)
 	}
-	if !strings.Contains(stdout, "StorageUsed:") || !strings.Contains(stdout, "Reserved:") {
-		t.Fatalf("stdout should include storage usage counters: %s", stdout)
+	if !strings.Contains(stdout, "TenantID:") || !strings.Contains(stdout, "tenant-1") {
+		t.Fatalf("stdout should include tenant ID: %s", stdout)
 	}
-	if !strings.Contains(stdout, "MaxFileSize:") || !strings.Contains(stdout, "64 Mi") || !strings.Contains(stdout, "MaxFileCount:") {
-		t.Fatalf("stdout should include file limits: %s", stdout)
+	if !strings.Contains(stdout, "MaxStorage:") || !strings.Contains(stdout, "1000 Mi") {
+		t.Fatalf("stdout should include max storage: %s", stdout)
+	}
+	if !strings.Contains(stdout, "MaxFileSize:") || !strings.Contains(stdout, "64 Mi") {
+		t.Fatalf("stdout should include max file size: %s", stdout)
+	}
+	if !strings.Contains(stdout, "MaxFileCount:") || !strings.Contains(stdout, "42") {
+		t.Fatalf("stdout should include max file count: %s", stdout)
+	}
+	if !strings.Contains(stdout, "SpendingLimit:") || !strings.Contains(stdout, "$100.00") {
+		t.Fatalf("stdout should include spending limit: %s", stdout)
+	}
+	if !strings.Contains(stdout, "StorageUsed:") || !strings.Contains(stdout, "1 B") {
+		t.Fatalf("stdout should include storage used: %s", stdout)
+	}
+	if !strings.Contains(stdout, "Reserved:") || !strings.Contains(stdout, "2 B") {
+		t.Fatalf("stdout should include reserved: %s", stdout)
+	}
+	if !strings.Contains(stdout, "FileCount:") || !strings.Contains(stdout, "3") {
+		t.Fatalf("stdout should include file count: %s", stdout)
 	}
 	if strings.Contains(stdout, "media_file_count") || strings.Contains(stdout, "monthly_cost_mc") {
 		t.Fatalf("stdout should not include media or cost counters: %s", stdout)

--- a/cmd/drive9/cli/quota_test.go
+++ b/cmd/drive9/cli/quota_test.go
@@ -59,10 +59,10 @@ func TestQuotaGetUsesTenantIDAndTiDBCloudHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Quota get: %v", err)
 	}
-	if !strings.Contains(stdout, "usage: storage_bytes=1 reserved_bytes=2 file_count=3") {
+	if !strings.Contains(stdout, "StorageUsed:") || !strings.Contains(stdout, "Reserved:") {
 		t.Fatalf("stdout should include storage usage counters: %s", stdout)
 	}
-	if !strings.Contains(stdout, "max_file_size=64Mi") || !strings.Contains(stdout, "max_file_count=42") {
+	if !strings.Contains(stdout, "MaxFileSize:") || !strings.Contains(stdout, "64 Mi") || !strings.Contains(stdout, "MaxFileCount:") {
 		t.Fatalf("stdout should include file limits: %s", stdout)
 	}
 	if strings.Contains(stdout, "media_file_count") || strings.Contains(stdout, "monthly_cost_mc") {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -46,6 +46,13 @@ const (
 	upstreamClusterBodyLimit = 1 << 20
 )
 
+var (
+	immutableLabelKeys = []string{
+		"tidb.cloud/project",
+		"tidb.cloud/organization",
+	}
+)
+
 var databaseNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)
 var displayNameCharPattern = regexp.MustCompile(`[^A-Za-z0-9-]`)
 
@@ -500,7 +507,10 @@ func (p *Provisioner) MarkQuotaUpdateStarted(ctx context.Context, cluster *tenan
 	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
 		labels[Drive9TenantIDLabel] = tenantID
 	}
-	labels[Drive9QuotaUpdateAtLabel] = time.Now().UTC().Format(time.RFC3339Nano)
+	labels[Drive9QuotaUpdateAtLabel] = strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	for _, k := range immutableLabelKeys {
+		delete(labels, k)
+	}
 	if err := p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels); err != nil {
 		return nil, fmt.Errorf("update cluster quota labels: %w", err)
 	}

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -600,10 +600,12 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"clusterId": "cluster-1",
 				"labels": map[string]string{
-					"environment":         "prod",
-					Drive9ManagedLabel:    "old",
-					Drive9TenantIDLabel:   "old-tenant",
-					"drive9.ai/unrelated": "keep",
+					"environment":             "prod",
+					Drive9ManagedLabel:        "old",
+					Drive9TenantIDLabel:       "old-tenant",
+					"drive9.ai/unrelated":     "keep",
+					"tidb.cloud/project":      "123",
+					"tidb.cloud/organization": "456",
 				},
 				"spendingLimit": map[string]int32{
 					"monthly": 15000,
@@ -652,6 +654,12 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 	labels := gotPatch.Cluster.Labels
 	if labels["environment"] != "prod" || labels["drive9.ai/unrelated"] != "keep" {
 		t.Fatalf("existing labels were not preserved: %#v", labels)
+	}
+	if _, ok := labels["tidb.cloud/project"]; ok {
+		t.Fatalf("immutable label tidb.cloud/project was not stripped: %#v", labels)
+	}
+	if _, ok := labels["tidb.cloud/organization"]; ok {
+		t.Fatalf("immutable label tidb.cloud/organization was not stripped: %#v", labels)
 	}
 	if labels[Drive9ManagedLabel] != "true" || labels[Drive9TenantIDLabel] != "tenant-1" {
 		t.Fatalf("drive9 labels = %#v", labels)


### PR DESCRIPTION
## Summary

Two fixes + one UX improvement:

### 1. Fix 400 "Invalid labels" on quota update

`MarkQuotaUpdateStarted` reads cluster labels via GET, which includes system labels `tidb.cloud/project` and `tidb.cloud/organization`. When sending the PATCH, all labels were included. The TiDB Cloud API rejects PATCH payloads containing these immutable system labels.

**Fix:** Strip `tidb.cloud/project` and `tidb.cloud/organization` from labels before PATCH.

### 2. Fix label value format

`Drive9QuotaUpdateAtLabel` was set to `time.RFC3339Nano` which produces characters invalid for Kubernetes-style label values (e.g. `:`, `T`, `Z`).

**Fix:** Changed to Unix timestamp string.

### 3. Redesigned CLI quota output

Before:
```
tenant: xxx
provider: tidb_cloud_native
status: active
supports_update: true
config: max_storage_size=102400Mi max_file_size=10240Mi max_file_count=0 tidbcloud_spending_limit=50000
usage: storage_bytes=0 reserved_bytes=0 file_count=0
```

After:
```
TenantID:             xxx
MaxStorage:           102400 Mi
MaxFileSize:          10240 Mi
MaxFileCount:         unlimited
SpendingLimit:        500.00
StorageUsed:          0 B
Reserved:             0 B
FileCount:            0
```

- One field per line with aligned values
- Bytes formatted as human-readable (B/KiB/MiB/GiB)
- Spending limit shown in dollars
- Zero max file count displays as "unlimited"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quota CLI output is now easier to read, with clear labels for tenant ID, storage and file limits, spending limit, storage usage, reserved space, and file count.
  * Storage values are shown in human-friendly units, and unlimited limits are displayed explicitly.

* **Bug Fixes**
  * Quota updates now avoid overwriting existing project/organization labels.
  * Update timestamps are now recorded in a simpler UTC epoch format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->