### PR TITLE
fix: batch quota outbox processing per file

### DIFF
--- a/cmd/drive9-server/schema_test.go
+++ b/cmd/drive9-server/schema_test.go
@@ -28,6 +28,9 @@ func TestSchemaDumpInitSQLByProvider(t *testing.T) {
 			if !strings.Contains(out, "CREATE INDEX idx_task_claim_type ON semantic_tasks") {
 				t.Fatalf("dump missing semantic_tasks index: %q", out)
 			}
+			if !strings.Contains(out, "CREATE INDEX idx_quota_outbox_file_order ON quota_outbox") {
+				t.Fatalf("dump missing quota_outbox file-order index: %q", out)
+			}
 			if !strings.Contains(out, ";\n") {
 				t.Fatalf("dump missing SQL statement terminators: %q", out)
 			}

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -102,6 +103,50 @@ func TestServerQuotaOutboxBatchProcessesDifferentFiles(t *testing.T) {
 	}
 	if usage.StorageBytes != int64(len("aaaa")+len("bb")) || usage.FileCount != 2 || usage.MediaFileCount != 1 {
 		t.Fatalf("central usage after batch = %+v", usage)
+	}
+}
+
+func TestQuotaOutboxWorkerRepollsAfterUnderfilledSameFileBatch(t *testing.T) {
+	b, fake := newServerQuotaBackend(t, Options{})
+	b.stopQuotaOutboxWorker()
+	ctx := context.Background()
+	fileID := "same-file-backlog"
+
+	if _, err := b.store.EnqueueQuotaOutboxTx(b.store.DB(), &datastore.QuotaOutboxEntry{
+		FileID:       fileID,
+		MutationType: quotaMutationTypeFileCreate,
+		MutationData: mustQuotaMutationJSON(t, fileCreateMutationData{
+			FileID:    fileID,
+			SizeBytes: 1,
+		}),
+		StorageDelta: 1,
+		FileDelta:    1,
+	}); err != nil {
+		t.Fatalf("enqueue create: %v", err)
+	}
+	if _, err := b.store.EnqueueQuotaOutboxTx(b.store.DB(), &datastore.QuotaOutboxEntry{
+		FileID:       fileID,
+		MutationType: quotaMutationTypeOverwrite,
+		MutationData: mustQuotaMutationJSON(t, fileOverwriteMutationData{
+			FileID:       fileID,
+			OldSizeBytes: 1,
+			NewSizeBytes: 3,
+		}),
+		StorageDelta: 2,
+	}); err != nil {
+		t.Fatalf("enqueue overwrite: %v", err)
+	}
+
+	b.processQuotaOutboxAvailable(ctx)
+	if got := countQuotaOutboxRowsByFile(t, ctx, b, fileID, datastore.QuotaOutboxSucceeded); got != 2 {
+		t.Fatalf("succeeded same-file rows = %d, want 2", got)
+	}
+	usage, err := fake.GetQuotaUsage(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("get usage: %v", err)
+	}
+	if usage.StorageBytes != 3 || usage.FileCount != 1 {
+		t.Fatalf("usage after same-file backlog drain = %+v, want storage=3 files=1", usage)
 	}
 }
 
@@ -339,6 +384,56 @@ func TestDrainQuotaOutboxForUploadTargetProcessesClaimableBatch(t *testing.T) {
 	}
 	if usage.StorageBytes != int64(len("older")+len("target")) || usage.FileCount != 2 {
 		t.Fatalf("central usage after drain = %+v, want both files applied", usage)
+	}
+}
+
+func TestDrainQuotaOutboxForFileContinuesAfterUnrelatedBatchError(t *testing.T) {
+	b, _ := newServerQuotaBackend(t, Options{})
+	b.stopQuotaOutboxWorker()
+	ctx := context.Background()
+
+	for i := 0; i < quotaOutboxBatchSize; i++ {
+		fileID := "older-file"
+		data := json.RawMessage(`{"file_id":"bad-json","size_bytes":"bad","is_media":false}`)
+		if i > 0 {
+			fileID = fmt.Sprintf("older-file-%03d", i)
+			data = mustQuotaMutationJSON(t, fileCreateMutationData{
+				FileID:    fileID,
+				SizeBytes: 1,
+			})
+		}
+		if _, err := b.store.EnqueueQuotaOutboxTx(b.store.DB(), &datastore.QuotaOutboxEntry{
+			FileID:       fileID,
+			MutationType: quotaMutationTypeFileCreate,
+			MutationData: data,
+			StorageDelta: 1,
+			FileDelta:    1,
+		}); err != nil {
+			t.Fatalf("enqueue older %d: %v", i, err)
+		}
+	}
+	targetFileID := "target-file-after-unrelated-error"
+	if _, err := b.store.EnqueueQuotaOutboxTx(b.store.DB(), &datastore.QuotaOutboxEntry{
+		FileID:       targetFileID,
+		MutationType: quotaMutationTypeFileCreate,
+		MutationData: mustQuotaMutationJSON(t, fileCreateMutationData{
+			FileID:    targetFileID,
+			SizeBytes: 1,
+		}),
+		StorageDelta: 1,
+		FileDelta:    1,
+	}); err != nil {
+		t.Fatalf("enqueue target: %v", err)
+	}
+
+	if err := b.drainQuotaOutboxForFile(ctx, targetFileID, quotaOutboxUploadDrainLimit); err != nil {
+		t.Fatalf("drain target: %v", err)
+	}
+	if got := countQuotaOutboxRowsByFile(t, ctx, b, targetFileID, datastore.QuotaOutboxSucceeded); got != 1 {
+		t.Fatalf("target succeeded rows = %d, want 1", got)
+	}
+	if got := countQuotaOutboxRowsByFile(t, ctx, b, "older-file", datastore.QuotaOutboxQueued); got != 1 {
+		t.Fatalf("bad unrelated queued retry rows = %d, want 1", got)
 	}
 }
 
@@ -599,4 +694,13 @@ func latestQuotaOutboxStorageDeltaByFile(t *testing.T, ctx context.Context, b *D
 		t.Fatal(err)
 	}
 	return delta
+}
+
+func mustQuotaMutationJSON(t *testing.T, payload any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal quota mutation: %v", err)
+	}
+	return raw
 }

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -63,6 +63,48 @@ func TestServerQuotaSmallWriteUsesTenantOutbox(t *testing.T) {
 	}
 }
 
+func TestServerQuotaOutboxBatchProcessesDifferentFiles(t *testing.T) {
+	b, fake := newServerQuotaBackend(t, Options{})
+	b.stopQuotaOutboxWorker()
+	ctx := context.Background()
+
+	if _, err := b.WriteCtx(ctx, "/batch-a.txt", []byte("aaaa"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	a, err := b.Store().Stat(ctx, "/batch-a.txt")
+	if err != nil {
+		t.Fatalf("stat a: %v", err)
+	}
+	if _, err := b.WriteCtx(ctx, "/batch-b.png", []byte("bb"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	bb, err := b.Store().Stat(ctx, "/batch-b.png")
+	if err != nil {
+		t.Fatalf("stat b: %v", err)
+	}
+
+	processed, err := b.ProcessQuotaOutboxBatch(ctx, 100)
+	if err != nil {
+		t.Fatalf("process quota outbox batch: %v", err)
+	}
+	if processed != 2 {
+		t.Fatalf("processed rows = %d, want 2", processed)
+	}
+	if got := countQuotaOutboxRowsByFile(t, ctx, b, a.File.FileID, datastore.QuotaOutboxSucceeded); got != 1 {
+		t.Fatalf("a succeeded rows = %d, want 1", got)
+	}
+	if got := countQuotaOutboxRowsByFile(t, ctx, b, bb.File.FileID, datastore.QuotaOutboxSucceeded); got != 1 {
+		t.Fatalf("b succeeded rows = %d, want 1", got)
+	}
+	usage, err := fake.GetQuotaUsage(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("get usage: %v", err)
+	}
+	if usage.StorageBytes != int64(len("aaaa")+len("bb")) || usage.FileCount != 2 || usage.MediaFileCount != 1 {
+		t.Fatalf("central usage after batch = %+v", usage)
+	}
+}
+
 func TestServerQuotaSmallWriteDoesNotWaitForAdmissionLock(t *testing.T) {
 	b, _ := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
@@ -262,7 +304,7 @@ func TestDrainQuotaOutboxForFileErrorsWhenPendingRowIsNotClaimable(t *testing.T)
 	}
 }
 
-func TestDrainQuotaOutboxForUploadTargetProcessesOlderTenantRows(t *testing.T) {
+func TestDrainQuotaOutboxForUploadTargetProcessesClaimableBatch(t *testing.T) {
 	b, fake := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -127,22 +127,17 @@ func (b *Dat9Backend) processQuotaOutboxAvailable(ctx context.Context) {
 			zap.Error(err))
 		metrics.RecordOperation("quota_outbox", "recover_expired", "error", 0)
 	}
-	for i := 0; i < quotaOutboxBatchSize; i++ {
-		if ctx.Err() != nil {
+	processed, err := b.ProcessQuotaOutboxBatch(ctx, quotaOutboxBatchSize)
+	if err != nil {
+		if isContextDone(err) {
 			return
 		}
-		processed, err := b.ProcessOneQuotaOutbox(ctx)
-		if err != nil {
-			if isContextDone(err) {
-				return
-			}
-			logger.Warn(ctx, "quota_outbox_process_failed",
-				zap.String("tenant_id", b.tenantID),
-				zap.Error(err))
-		}
-		if !processed {
-			return
-		}
+		logger.Warn(ctx, "quota_outbox_process_failed",
+			zap.String("tenant_id", b.tenantID),
+			zap.Error(err))
+	}
+	if processed == quotaOutboxBatchSize {
+		b.notifyQuotaOutbox(true)
 	}
 }
 
@@ -165,7 +160,7 @@ func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string
 	}
 	start := time.Now()
 	processedCount := 0
-	for i := 0; i < limit; i++ {
+	for processedCount < limit {
 		if quotaOutboxUploadDrainMaxWait > 0 && time.Since(start) > quotaOutboxUploadDrainMaxWait {
 			return fmt.Errorf("quota outbox for file %s still pending after %s", fileID, quotaOutboxUploadDrainMaxWait)
 		}
@@ -182,11 +177,19 @@ func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string
 			}
 			return nil
 		}
-		processed, err := b.ProcessOneQuotaOutbox(ctx)
+		batchLimit := quotaOutboxBatchSize
+		if remaining := limit - processedCount; remaining < batchLimit {
+			batchLimit = remaining
+		}
+		processed, err := b.ProcessQuotaOutboxBatch(ctx, batchLimit)
 		if err != nil {
+			pendingAfterErr, pendingErr := b.store.HasPendingQuotaOutboxFileMutation(ctx, fileID)
+			if pendingErr == nil && !pendingAfterErr {
+				return nil
+			}
 			return fmt.Errorf("drain quota outbox for file: %w", err)
 		}
-		if !processed {
+		if processed == 0 {
 			timer := time.NewTimer(quotaOutboxUploadDrainWait)
 			select {
 			case <-ctx.Done():
@@ -198,7 +201,7 @@ func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string
 			}
 			continue
 		}
-		processedCount++
+		processedCount += processed
 	}
 	return fmt.Errorf("quota outbox for file %s still pending after %d entries", fileID, limit)
 }
@@ -206,66 +209,102 @@ func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string
 // ProcessOneQuotaOutbox applies at most one tenant-local quota outbox row. It is
 // exported for deterministic tests and admin drain hooks.
 func (b *Dat9Backend) ProcessOneQuotaOutbox(ctx context.Context) (processed bool, err error) {
+	n, err := b.ProcessQuotaOutboxBatch(ctx, 1)
+	return n > 0, err
+}
+
+// ProcessQuotaOutboxBatch applies up to limit tenant-local quota outbox rows.
+// Rows are claimed with per-file ordering, so unrelated file mutations can
+// converge in one tenant admission-lock window.
+func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (processed int, err error) {
 	start := time.Now()
 	if b.store == nil || b.metaStore == nil || b.tenantID == "" {
-		return false, nil
+		return 0, nil
 	}
-	entry, found, err := b.store.ClaimQuotaOutbox(ctx, time.Now().UTC(), quotaOutboxLeaseDuration)
+	if limit <= 0 {
+		limit = 1
+	}
+	entries, err := b.store.ClaimQuotaOutboxBatch(ctx, time.Now().UTC(), quotaOutboxLeaseDuration, limit)
 	if err != nil {
 		metrics.RecordOperation("quota_outbox", "claim", "error", time.Since(start))
-		return false, err
+		return 0, err
 	}
-	if !found {
+	if len(entries) == 0 {
 		metrics.RecordOperation("quota_outbox", "claim", "empty", time.Since(start))
-		return false, nil
+		return 0, nil
 	}
 
-	var applyErr error
-	var ackErr error
-	var retryErr error
+	var batchErr error
+	appliedEntries := make([]datastore.QuotaOutboxEntry, 0, len(entries))
 	err = b.withQuotaAdmissionLock(ctx, func(tx *sql.Tx) error {
-		applyErr = b.applyQuotaOutboxEntry(ctx, entry)
-		if applyErr == nil {
-			if tx != nil {
-				ackErr = b.store.AckQuotaOutboxTx(ctx, tx, entry.ID, entry.Receipt)
+		if tx != nil && len(entries) > 1 {
+			if applyErr := b.applyQuotaOutboxEntries(ctx, entries); applyErr == nil {
+				if ackErr := b.store.AckQuotaOutboxBatchTx(ctx, tx, entries); ackErr != nil {
+					return ackErr
+				}
+				processed = len(entries)
+				appliedEntries = append(appliedEntries, entries...)
+				return nil
 			} else {
-				ackErr = b.store.AckQuotaOutbox(ctx, entry.ID, entry.Receipt)
+				logger.Warn(ctx, "quota_outbox_batch_apply_failed_falling_back",
+					zap.String("tenant_id", b.tenantID),
+					zap.Int("entries", len(entries)),
+					zap.Error(applyErr))
 			}
-			return ackErr
 		}
-		retryAt := time.Now().UTC().Add(quotaOutboxRetryDelay(entry.AttemptCount, quotaOutboxRetryBaseDelay, quotaOutboxRetryMaxDelay))
-		if tx != nil {
-			retryErr = b.store.RetryQuotaOutboxTx(ctx, tx, entry.ID, entry.Receipt, retryAt, applyErr.Error())
-		} else {
-			retryErr = b.store.RetryQuotaOutbox(ctx, entry.ID, entry.Receipt, retryAt, applyErr.Error())
-		}
-		if retryErr != nil {
-			return fmt.Errorf("process quota outbox %d: %w; update retry: %v", entry.ID, applyErr, retryErr)
+
+		for i := range entries {
+			entry := &entries[i]
+			applyErr := b.applyQuotaOutboxEntry(ctx, entry)
+			if applyErr == nil {
+				var ackErr error
+				if tx != nil {
+					ackErr = b.store.AckQuotaOutboxTx(ctx, tx, entry.ID, entry.Receipt)
+				} else {
+					ackErr = b.store.AckQuotaOutbox(ctx, entry.ID, entry.Receipt)
+				}
+				if ackErr != nil {
+					return ackErr
+				}
+				processed++
+				appliedEntries = append(appliedEntries, *entry)
+				continue
+			}
+
+			retryAt := time.Now().UTC().Add(quotaOutboxRetryDelay(entry.AttemptCount, quotaOutboxRetryBaseDelay, quotaOutboxRetryMaxDelay))
+			var retryErr error
+			if tx != nil {
+				retryErr = b.store.RetryQuotaOutboxTx(ctx, tx, entry.ID, entry.Receipt, retryAt, applyErr.Error())
+			} else {
+				retryErr = b.store.RetryQuotaOutbox(ctx, entry.ID, entry.Receipt, retryAt, applyErr.Error())
+			}
+			if retryErr != nil {
+				return fmt.Errorf("process quota outbox %d: %w; update retry: %v", entry.ID, applyErr, retryErr)
+			}
+			metrics.RecordOperation("quota_outbox", entry.MutationType, "error", time.Since(start))
+			if batchErr == nil {
+				batchErr = applyErr
+			}
 		}
 		return nil
 	})
 	if err == nil {
-		if applyErr != nil {
-			metrics.RecordOperation("quota_outbox", entry.MutationType, "error", time.Since(start))
-			return true, applyErr
+		if len(appliedEntries) > 0 {
+			if b.quotaUsageCache != nil {
+				b.quotaUsageCache.invalidate()
+			}
+			for _, entry := range appliedEntries {
+				b.addLocalQuotaPendingDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
+				metrics.RecordOperation("quota_outbox", entry.MutationType, "ok", time.Since(start))
+			}
 		}
-		if b.quotaUsageCache != nil {
-			b.quotaUsageCache.invalidate()
+		if batchErr != nil {
+			return len(entries), batchErr
 		}
-		b.addLocalQuotaPendingDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
-		metrics.RecordOperation("quota_outbox", entry.MutationType, "ok", time.Since(start))
-		return true, nil
+		return processed, nil
 	}
-	if ackErr != nil {
-		metrics.RecordOperation("quota_outbox", "ack", "error", time.Since(start))
-		return true, ackErr
-	}
-	if retryErr != nil {
-		metrics.RecordOperation("quota_outbox", "retry", "error", time.Since(start))
-		return true, err
-	}
-	metrics.RecordOperation("quota_outbox", entry.MutationType, "error", time.Since(start))
-	return true, err
+	metrics.RecordOperation("quota_outbox", "process", "error", time.Since(start))
+	return processed, err
 }
 
 func (b *Dat9Backend) withQuotaAdmissionLock(ctx context.Context, fn func(tx *sql.Tx) error) error {
@@ -285,8 +324,26 @@ func (b *Dat9Backend) applyQuotaOutboxEntry(ctx context.Context, entry *datastor
 		return fmt.Errorf("quota outbox entry is required")
 	}
 	return b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
-		return applyCentralQuotaMutationTx(b.metaStore, tx, b.tenantID, entry.MutationType, entry.MutationData, entry.ID)
+		return b.applyQuotaOutboxEntryTx(tx, entry)
 	})
+}
+
+func (b *Dat9Backend) applyQuotaOutboxEntries(ctx context.Context, entries []datastore.QuotaOutboxEntry) error {
+	return b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
+		for i := range entries {
+			if err := b.applyQuotaOutboxEntryTx(tx, &entries[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (b *Dat9Backend) applyQuotaOutboxEntryTx(tx *sql.Tx, entry *datastore.QuotaOutboxEntry) error {
+	if entry == nil {
+		return fmt.Errorf("quota outbox entry is required")
+	}
+	return applyCentralQuotaMutationTx(b.metaStore, tx, b.tenantID, entry.MutationType, entry.MutationData, entry.ID)
 }
 
 func quotaOutboxRetryDelay(attempt int, base, max time.Duration) time.Duration {

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -127,18 +127,26 @@ func (b *Dat9Backend) processQuotaOutboxAvailable(ctx context.Context) {
 			zap.Error(err))
 		metrics.RecordOperation("quota_outbox", "recover_expired", "error", 0)
 	}
-	processed, err := b.ProcessQuotaOutboxBatch(ctx, quotaOutboxBatchSize)
-	if err != nil {
-		if isContextDone(err) {
+	processedTotal := 0
+	for processedTotal < quotaOutboxBatchSize {
+		processed, err := b.ProcessQuotaOutboxBatch(ctx, quotaOutboxBatchSize-processedTotal)
+		if err != nil {
+			if isContextDone(err) {
+				return
+			}
+			logger.Warn(ctx, "quota_outbox_process_failed",
+				zap.String("tenant_id", b.tenantID),
+				zap.Error(err))
+			if processed == 0 {
+				return
+			}
+		}
+		if processed == 0 {
 			return
 		}
-		logger.Warn(ctx, "quota_outbox_process_failed",
-			zap.String("tenant_id", b.tenantID),
-			zap.Error(err))
+		processedTotal += processed
 	}
-	if processed == quotaOutboxBatchSize {
-		b.notifyQuotaOutbox(true)
-	}
+	b.notifyQuotaOutbox(true)
 }
 
 func (b *Dat9Backend) drainQuotaOutboxForUploadTarget(ctx context.Context, target *datastore.NodeWithFile, targetExists bool) error {
@@ -187,7 +195,18 @@ func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string
 			if pendingErr == nil && !pendingAfterErr {
 				return nil
 			}
-			return fmt.Errorf("drain quota outbox for file: %w", err)
+			if processed == 0 {
+				timer := time.NewTimer(quotaOutboxUploadDrainWait)
+				select {
+				case <-ctx.Done():
+					if !timer.Stop() {
+						<-timer.C
+					}
+					return fmt.Errorf("quota outbox for file %s still pending but not claimable: %w", fileID, ctx.Err())
+				case <-timer.C:
+				}
+				continue
+			}
 		}
 		if processed == 0 {
 			timer := time.NewTimer(quotaOutboxUploadDrainWait)
@@ -234,11 +253,15 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 		return 0, nil
 	}
 
-	var batchErr error
 	appliedEntries := make([]datastore.QuotaOutboxEntry, 0, len(entries))
+	var batchApplyErr error
 	err = b.withQuotaAdmissionLock(ctx, func(tx *sql.Tx) error {
 		if tx != nil && len(entries) > 1 {
 			if applyErr := b.applyQuotaOutboxEntries(ctx, entries); applyErr == nil {
+				// The central apply commits before this tenant-local ack. If the
+				// lease expires or the ack tx rolls back, recovery may re-apply
+				// the same rows later; file-state mutations are idempotent and
+				// pending deltas remain conservative until those rows are acked.
 				if ackErr := b.store.AckQuotaOutboxBatchTx(ctx, tx, entries); ackErr != nil {
 					return ackErr
 				}
@@ -246,65 +269,98 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 				appliedEntries = append(appliedEntries, entries...)
 				return nil
 			} else {
-				logger.Warn(ctx, "quota_outbox_batch_apply_failed_falling_back",
-					zap.String("tenant_id", b.tenantID),
-					zap.Int("entries", len(entries)),
-					zap.Error(applyErr))
-			}
-		}
-
-		for i := range entries {
-			entry := &entries[i]
-			applyErr := b.applyQuotaOutboxEntry(ctx, entry)
-			if applyErr == nil {
-				var ackErr error
-				if tx != nil {
-					ackErr = b.store.AckQuotaOutboxTx(ctx, tx, entry.ID, entry.Receipt)
-				} else {
-					ackErr = b.store.AckQuotaOutbox(ctx, entry.ID, entry.Receipt)
-				}
-				if ackErr != nil {
-					return ackErr
-				}
-				processed++
-				appliedEntries = append(appliedEntries, *entry)
-				continue
-			}
-
-			retryAt := time.Now().UTC().Add(quotaOutboxRetryDelay(entry.AttemptCount, quotaOutboxRetryBaseDelay, quotaOutboxRetryMaxDelay))
-			var retryErr error
-			if tx != nil {
-				retryErr = b.store.RetryQuotaOutboxTx(ctx, tx, entry.ID, entry.Receipt, retryAt, applyErr.Error())
-			} else {
-				retryErr = b.store.RetryQuotaOutbox(ctx, entry.ID, entry.Receipt, retryAt, applyErr.Error())
-			}
-			if retryErr != nil {
-				return fmt.Errorf("process quota outbox %d: %w; update retry: %v", entry.ID, applyErr, retryErr)
-			}
-			metrics.RecordOperation("quota_outbox", entry.MutationType, "error", time.Since(start))
-			if batchErr == nil {
-				batchErr = applyErr
+				batchApplyErr = applyErr
+				return nil
 			}
 		}
 		return nil
 	})
-	if err == nil {
-		if len(appliedEntries) > 0 {
-			if b.quotaUsageCache != nil {
-				b.quotaUsageCache.invalidate()
-			}
-			for _, entry := range appliedEntries {
-				b.addLocalQuotaPendingDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
-				metrics.RecordOperation("quota_outbox", entry.MutationType, "ok", time.Since(start))
-			}
-		}
-		if batchErr != nil {
-			return len(entries), batchErr
-		}
+	if err != nil {
+		metrics.RecordOperation("quota_outbox", "process", "error", time.Since(start))
+		return processed, err
+	}
+	if batchApplyErr == nil && processed > 0 {
+		b.recordAppliedQuotaOutboxEntries(start, appliedEntries)
 		return processed, nil
 	}
-	metrics.RecordOperation("quota_outbox", "process", "error", time.Since(start))
-	return processed, err
+	if len(entries) > 1 && batchApplyErr != nil {
+		logger.Warn(ctx, "quota_outbox_batch_apply_failed_falling_back",
+			zap.String("tenant_id", b.tenantID),
+			zap.Int("entries", len(entries)),
+			zap.Error(batchApplyErr))
+	}
+
+	var fallbackErr error
+	for i := range entries {
+		applied, entryProcessed, entryErr := b.processQuotaOutboxEntry(ctx, &entries[i])
+		if entryProcessed {
+			processed++
+		}
+		if applied {
+			appliedEntries = append(appliedEntries, entries[i])
+		}
+		if entryErr != nil {
+			metrics.RecordOperation("quota_outbox", entries[i].MutationType, "error", time.Since(start))
+			if !entryProcessed {
+				b.recordAppliedQuotaOutboxEntries(start, appliedEntries)
+				return processed, entryErr
+			}
+			if fallbackErr == nil {
+				fallbackErr = entryErr
+			}
+		}
+	}
+	b.recordAppliedQuotaOutboxEntries(start, appliedEntries)
+	if fallbackErr != nil {
+		return processed, fallbackErr
+	}
+	return processed, nil
+}
+
+func (b *Dat9Backend) processQuotaOutboxEntry(ctx context.Context, entry *datastore.QuotaOutboxEntry) (applied, processed bool, err error) {
+	var applyErr error
+	err = b.withQuotaAdmissionLock(ctx, func(tx *sql.Tx) error {
+		applyErr = b.applyQuotaOutboxEntry(ctx, entry)
+		if applyErr == nil {
+			if tx != nil {
+				return b.store.AckQuotaOutboxTx(ctx, tx, entry.ID, entry.Receipt)
+			}
+			return b.store.AckQuotaOutbox(ctx, entry.ID, entry.Receipt)
+		}
+
+		retryAt := time.Now().UTC().Add(quotaOutboxRetryDelay(entry.AttemptCount, quotaOutboxRetryBaseDelay, quotaOutboxRetryMaxDelay))
+		var retryErr error
+		if tx != nil {
+			retryErr = b.store.RetryQuotaOutboxTx(ctx, tx, entry.ID, entry.Receipt, retryAt, applyErr.Error())
+		} else {
+			retryErr = b.store.RetryQuotaOutbox(ctx, entry.ID, entry.Receipt, retryAt, applyErr.Error())
+		}
+		if retryErr != nil {
+			return fmt.Errorf("process quota outbox %d: %w; update retry: %v", entry.ID, applyErr, retryErr)
+		}
+		processed = true
+		return nil
+	})
+	if err != nil {
+		return false, processed, err
+	}
+	if applyErr != nil {
+		return false, processed, applyErr
+	}
+	return true, true, nil
+}
+
+func (b *Dat9Backend) recordAppliedQuotaOutboxEntries(start time.Time, entries []datastore.QuotaOutboxEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	if b.quotaUsageCache != nil {
+		b.quotaUsageCache.invalidate()
+	}
+	for _, entry := range entries {
+		b.addLocalQuotaPendingDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
+		metrics.RecordOperation("quota_outbox", entry.MutationType, "ok", time.Since(start))
+	}
 }
 
 func (b *Dat9Backend) withQuotaAdmissionLock(ctx context.Context, fn func(tx *sql.Tx) error) error {

--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -131,7 +131,7 @@ func (s *Store) claimQuotaOutboxBatch(ctx context.Context, now time.Time, leaseD
 		    SELECT 1 FROM quota_outbox older
 		     WHERE older.id < q.id
 		       AND older.status IN (?, ?)
-		       AND (older.file_id = q.file_id OR (older.file_id IS NULL AND q.file_id IS NULL))
+		       AND (older.file_id = q.file_id OR older.file_id IS NULL OR q.file_id IS NULL)
 		  )
 		ORDER BY id
 		LIMIT ?
@@ -234,16 +234,19 @@ func (s *Store) AckQuotaOutboxBatchTx(ctx context.Context, tx *sql.Tx, entries [
 		return nil
 	}
 	now := time.Now().UTC()
-	conds := make([]string, 0, len(entries))
-	args := []any{QuotaOutboxSucceeded, now, now, QuotaOutboxProcessing, now}
+	ids := make([]any, 0, len(entries))
+	receipt := entries[0].Receipt
 	for i := range entries {
-		conds = append(conds, `(id = ? AND receipt = ?)`)
-		args = append(args, entries[i].ID, entries[i].Receipt)
+		if entries[i].Receipt != receipt {
+			return ErrQuotaOutboxLeaseMismatch
+		}
+		ids = append(ids, entries[i].ID)
 	}
+	args := append([]any{QuotaOutboxSucceeded, now, now, QuotaOutboxProcessing, receipt, now}, ids...)
 	res, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE quota_outbox SET status = ?, receipt = NULL,
 		leased_at = NULL, lease_until = NULL, completed_at = ?, updated_at = ?
-		WHERE status = ? AND lease_until IS NOT NULL AND lease_until > ?
-		  AND (%s)`, strings.Join(conds, " OR ")), args...)
+		WHERE status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?
+		  AND id IN (%s)`, sqlPlaceholders(len(entries))), args...)
 	if err != nil {
 		return err
 	}

--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -80,14 +80,35 @@ func (s *Store) LockQuotaAdmissionTx(db execer) error {
 	return nil
 }
 
-// ClaimQuotaOutbox claims the oldest queued quota mutation for this tenant
-// store. Only one row is allowed to be processing at a time, preserving
-// per-tenant apply order even when multiple server instances poll the same
-// tenant DB.
+// ClaimQuotaOutbox claims one queued quota mutation for this tenant store.
 func (s *Store) ClaimQuotaOutbox(ctx context.Context, now time.Time, leaseDuration time.Duration) (out *QuotaOutboxEntry, found bool, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "claim_quota_outbox", start, &err)
 
+	entries, err := s.claimQuotaOutboxBatch(ctx, now, leaseDuration, 1)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(entries) == 0 {
+		return nil, false, nil
+	}
+	return &entries[0], true, nil
+}
+
+// ClaimQuotaOutboxBatch claims up to limit queued quota mutations. It preserves
+// ordering per file_id while allowing unrelated files to be processed in the
+// same batch.
+func (s *Store) ClaimQuotaOutboxBatch(ctx context.Context, now time.Time, leaseDuration time.Duration, limit int) (entries []QuotaOutboxEntry, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "claim_quota_outbox_batch", start, &err)
+
+	return s.claimQuotaOutboxBatch(ctx, now, leaseDuration, limit)
+}
+
+func (s *Store) claimQuotaOutboxBatch(ctx context.Context, now time.Time, leaseDuration time.Duration, limit int) ([]QuotaOutboxEntry, error) {
+	if limit <= 0 {
+		limit = 1
+	}
 	if now.IsZero() {
 		now = time.Now().UTC()
 	} else {
@@ -99,64 +120,85 @@ func (s *Store) ClaimQuotaOutbox(ctx context.Context, now time.Time, leaseDurati
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	row := tx.QueryRowContext(ctx, quotaOutboxSelectSQL+`
+	rows, err := tx.QueryContext(ctx, quotaOutboxSelectSQL+`
 		FROM quota_outbox q
 		WHERE q.status = ? AND q.available_at <= ?
 		  AND NOT EXISTS (
 		    SELECT 1 FROM quota_outbox older
-		     WHERE older.id < q.id AND older.status IN (?, ?)
-		  )
-		  AND NOT EXISTS (
-		    SELECT 1 FROM quota_outbox active
-		     WHERE active.status = ? AND active.lease_until IS NOT NULL AND active.lease_until > ?
+		     WHERE older.id < q.id
+		       AND older.status IN (?, ?)
+		       AND (older.file_id = q.file_id OR (older.file_id IS NULL AND q.file_id IS NULL))
 		  )
 		ORDER BY id
-		LIMIT 1
+		LIMIT ?
 		FOR UPDATE SKIP LOCKED`, QuotaOutboxQueued, now,
-		QuotaOutboxQueued, QuotaOutboxProcessing, QuotaOutboxProcessing, now)
-	entry, err := scanQuotaOutbox(row)
+		QuotaOutboxQueued, QuotaOutboxProcessing, limit)
 	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return nil, false, nil
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	entries := make([]QuotaOutboxEntry, 0, limit)
+	for rows.Next() {
+		entry, err := scanQuotaOutbox(rows)
+		if err != nil {
+			return nil, err
 		}
-		return nil, false, err
+		entries = append(entries, *entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		if err := tx.Commit(); err != nil {
+			return nil, err
+		}
+		return nil, nil
 	}
 
 	receipt := uuid.NewString()
 	leasedAt := now
 	leaseUntil := now.Add(leaseDuration)
-	res, err := tx.ExecContext(ctx, `UPDATE quota_outbox SET status = ?,
+	ids := make([]any, 0, len(entries))
+	for i := range entries {
+		ids = append(ids, entries[i].ID)
+	}
+	args := append([]any{
+		QuotaOutboxProcessing, receipt, leasedAt, leaseUntil, now,
+		QuotaOutboxQueued, now,
+	}, ids...)
+	res, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE quota_outbox SET status = ?,
 		attempt_count = attempt_count + 1, receipt = ?, leased_at = ?,
 		lease_until = ?, updated_at = ?
-		WHERE id = ? AND status = ? AND available_at <= ?`,
-		QuotaOutboxProcessing, receipt, leasedAt, leaseUntil, now,
-		entry.ID, QuotaOutboxQueued, now)
+		WHERE status = ? AND available_at <= ? AND id IN (%s)`, sqlPlaceholders(len(entries))), args...)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	rowsAffected, err := res.RowsAffected()
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	if rowsAffected == 0 {
-		return nil, false, nil
+	if rowsAffected != int64(len(entries)) {
+		return nil, ErrQuotaOutboxLeaseMismatch
 	}
 
-	entry.Status = QuotaOutboxProcessing
-	entry.AttemptCount++
-	entry.Receipt = receipt
-	entry.LeasedAt = &leasedAt
-	entry.LeaseUntil = &leaseUntil
-	entry.UpdatedAt = now
+	for i := range entries {
+		entries[i].Status = QuotaOutboxProcessing
+		entries[i].AttemptCount++
+		entries[i].Receipt = receipt
+		entries[i].LeasedAt = &leasedAt
+		entries[i].LeaseUntil = &leaseUntil
+		entries[i].UpdatedAt = now
+	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	return entry, true, nil
+	return entries, nil
 }
 
 // AckQuotaOutbox marks a leased quota outbox row as successfully applied.
@@ -179,6 +221,42 @@ func (s *Store) AckQuotaOutboxTx(ctx context.Context, tx *sql.Tx, id int64, rece
 	return s.ackQuotaOutbox(ctx, tx, id, receipt)
 }
 
+// AckQuotaOutboxBatchTx marks leased quota outbox rows as successfully applied
+// inside a caller-owned transaction.
+func (s *Store) AckQuotaOutboxBatchTx(ctx context.Context, tx *sql.Tx, entries []QuotaOutboxEntry) (err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "ack_quota_outbox_batch_tx", start, &err)
+
+	if tx == nil {
+		return fmt.Errorf("quota outbox ack transaction is required")
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	now := time.Now().UTC()
+	conds := make([]string, 0, len(entries))
+	args := []any{QuotaOutboxSucceeded, now, now, QuotaOutboxProcessing, now}
+	for i := range entries {
+		conds = append(conds, `(id = ? AND receipt = ?)`)
+		args = append(args, entries[i].ID, entries[i].Receipt)
+	}
+	res, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE quota_outbox SET status = ?, receipt = NULL,
+		leased_at = NULL, lease_until = NULL, completed_at = ?, updated_at = ?
+		WHERE status = ? AND lease_until IS NOT NULL AND lease_until > ?
+		  AND (%s)`, strings.Join(conds, " OR ")), args...)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected != int64(len(entries)) {
+		return ErrQuotaOutboxLeaseMismatch
+	}
+	return nil
+}
+
 func (s *Store) ackQuotaOutbox(ctx context.Context, db execer, id int64, receipt string) error {
 	now := time.Now().UTC()
 	res, err := db.ExecContext(ctx, `UPDATE quota_outbox SET status = ?, receipt = NULL,
@@ -196,6 +274,16 @@ func (s *Store) ackQuotaOutbox(ctx context.Context, db execer, id int64, receipt
 		return nil
 	}
 	return s.quotaOutboxLeaseError(ctx, db, id)
+}
+
+func sqlPlaceholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if n == 1 {
+		return "?"
+	}
+	return "?" + strings.Repeat(",?", n-1)
 }
 
 // RetryQuotaOutbox requeues or dead-letters a leased quota outbox row.

--- a/pkg/datastore/quota_outbox_test.go
+++ b/pkg/datastore/quota_outbox_test.go
@@ -220,6 +220,51 @@ func TestQuotaOutboxBatchClaimPreservesPerFileOrder(t *testing.T) {
 	}
 }
 
+func TestQuotaOutboxBatchClaimTreatsNullFileIDAsGlobalBarrier(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	availableNow := now.Add(-time.Second)
+
+	globalID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		MutationType: "global_legacy",
+		MutationData: json.RawMessage(`{}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-1",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-1"}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimed, err := s.ClaimQuotaOutboxBatch(ctx, now, time.Minute, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != globalID {
+		t.Fatalf("claimed behind older NULL file_id = %+v, want only global id %d", claimed, globalID)
+	}
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.AckQuotaOutboxBatchTx(ctx, tx, claimed)
+	}); err != nil {
+		t.Fatalf("ack global row: %v", err)
+	}
+	claimed, err = s.ClaimQuotaOutboxBatch(ctx, now.Add(time.Second), time.Minute, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != fileID {
+		t.Fatalf("claimed after global ack = %+v, want file id %d", claimed, fileID)
+	}
+}
+
 func TestQuotaOutboxDeadLetteredOlderRowUnblocksLaterClaim(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/datastore/quota_outbox_test.go
+++ b/pkg/datastore/quota_outbox_test.go
@@ -161,6 +161,65 @@ func TestQuotaOutboxClaimWaitsForDelayedOlderRetry(t *testing.T) {
 	}
 }
 
+func TestQuotaOutboxBatchClaimPreservesPerFileOrder(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	availableNow := now.Add(-time.Second)
+
+	file1CreateID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-1",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-1"}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	file2CreateID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-2",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-2"}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	file1OverwriteID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-1",
+		MutationType: "file_overwrite",
+		MutationData: json.RawMessage(`{"file_id":"file-1"}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimed, err := s.ClaimQuotaOutboxBatch(ctx, now, time.Minute, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 2 {
+		t.Fatalf("claimed rows = %d, want 2", len(claimed))
+	}
+	if claimed[0].ID != file1CreateID || claimed[1].ID != file2CreateID {
+		t.Fatalf("claimed ids = %d,%d want %d,%d", claimed[0].ID, claimed[1].ID, file1CreateID, file2CreateID)
+	}
+
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.AckQuotaOutboxBatchTx(ctx, tx, claimed)
+	}); err != nil {
+		t.Fatalf("ack claimed batch: %v", err)
+	}
+	claimed, err = s.ClaimQuotaOutboxBatch(ctx, now.Add(time.Second), time.Minute, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != file1OverwriteID {
+		t.Fatalf("claimed after ack = %+v, want file-1 overwrite id %d", claimed, file1OverwriteID)
+	}
+}
+
 func TestQuotaOutboxDeadLetteredOlderRowUnblocksLaterClaim(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/tenant/schema/quota_outbox.go
+++ b/pkg/tenant/schema/quota_outbox.go
@@ -30,6 +30,7 @@ func QuotaOutboxTiDBSchemaStatements() []string {
 		)`,
 		`CREATE INDEX idx_quota_outbox_claim ON quota_outbox(status, available_at, id)`,
 		`CREATE INDEX idx_quota_outbox_processing ON quota_outbox(status, lease_until)`,
+		`CREATE INDEX idx_quota_outbox_file_order ON quota_outbox(file_id, status, id)`,
 		`CREATE INDEX idx_quota_outbox_file_pending ON quota_outbox(file_id, status, mutation_type)`,
 	}
 }
@@ -64,6 +65,7 @@ func QuotaOutboxDB9SchemaStatements() []string {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_quota_outbox_claim ON quota_outbox(status, available_at, id)`,
 		`CREATE INDEX IF NOT EXISTS idx_quota_outbox_processing ON quota_outbox(status, lease_until)`,
+		`CREATE INDEX IF NOT EXISTS idx_quota_outbox_file_order ON quota_outbox(file_id, status, id)`,
 		`CREATE INDEX IF NOT EXISTS idx_quota_outbox_file_pending ON quota_outbox(file_id, status, mutation_type)`,
 	}
 }

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -265,6 +265,37 @@ func TestMissingTableAndIndexDiffsIncludesExternalIndexes(t *testing.T) {
 	}
 }
 
+func TestQuotaOutboxMissingFileOrderIndexIsRepairable(t *testing.T) {
+	spec, err := tidbSchemaSpecForMode(TiDBEmbeddingModeAuto)
+	if err != nil {
+		t.Fatalf("schema spec: %v", err)
+	}
+	table := mustTableSpecFromSchemaSpec(t, spec, "quota_outbox")
+	meta := tidbTableMeta{
+		tableName: table.name,
+		columns:   make(map[string]tidbColumnMeta, len(table.columns)),
+	}
+	for name, col := range table.columns {
+		meta.columns[name] = tidbColumnMeta{columnType: col.columnType}
+	}
+	observedIndexes := make(map[string]struct{}, len(table.indexes))
+	for name := range table.indexes {
+		if name == "idx_quota_outbox_file_order" {
+			continue
+		}
+		observedIndexes[strings.ToLower(name)] = struct{}{}
+	}
+
+	diffs := diffTiDBTableMetaWithObservedIndexes(table, meta, "", observedIndexes, true)
+	if !hasDiffKindAndDetail(diffs, tidbSchemaDiffMissingIndex, "idx_quota_outbox_file_order") {
+		t.Fatalf("expected missing file-order index diff, got %#v", diffs)
+	}
+	repairs := plannedTiDBSchemaRepairs(diffs)
+	if len(repairs) != 1 || repairs[0] != "CREATE INDEX idx_quota_outbox_file_order ON quota_outbox(file_id, status, id)" {
+		t.Fatalf("unexpected repairs for missing quota_outbox file-order index: %#v", repairs)
+	}
+}
+
 func TestPlannedTiDBSchemaRepairsIncludesSafeStatementsOnly(t *testing.T) {
 	diffs := []tidbSchemaDiff{
 		{kind: tidbSchemaDiffMissingTable, tableName: "semantic_tasks", repairSQL: "CREATE TABLE IF NOT EXISTS semantic_tasks (...)"},


### PR DESCRIPTION
## Summary
- change quota outbox claiming from tenant-global FIFO to per-file ordering so unrelated file mutations can drain concurrently
- add batch claim/apply/ack for quota outbox rows to reduce per-row DB round trips under small-file create workloads
- treat NULL file_id outbox rows as tenant-global ordering barriers for legacy/global mutations
- add a dedicated quota_outbox(file_id, status, id) index for the per-file ordering subquery
- keep batch fallback bounded by taking the tenant admission lock per fallback row instead of holding it across the full fallback batch

## Ops note
- Existing TiDB tenants with quota_outbox already created will get idx_quota_outbox_file_order during the next schema ensure/repair pass. TiDB ADD INDEX is online, but large backlog tables may spend time/CPU building this index once.

## Tests
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/datastore -run 'TestQuotaOutbox' -count=1
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/backend -run 'Test.*QuotaOutbox|TestDrainQuotaOutbox|TestServerQuota.*Pending|TestServerQuotaReserve|TestServerQuotaOverwrite|TestServerQuotaMedia' -count=1
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant/schema -run 'TestQuotaOutbox|TestSchema|Test.*Repair|TestPlanned' -count=1
- GOCACHE=/tmp/drive9-go-cache go test ./cmd/drive9-server -run 'TestSchemaDump' -count=1
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/backend ./pkg/datastore ./pkg/tenant/schema ./cmd/drive9-server -count=1
- make lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quota outbox processing now works in batches, improving throughput and reducing repeated single-item work.
  * File-based draining handles multiple pending entries more efficiently and continues past unrelated processing issues when possible.

* **Bug Fixes**
  * Improved ordering and fairness for queued quota actions, including better handling of same-file sequences and global queue items.
  * Added schema support for a new index that helps keep quota outbox processing performant and repairable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->