### PR TITLE
fix: cli quota output

### DIFF
--- a/cmd/drive9/cli/quota.go
+++ b/cmd/drive9/cli/quota.go
@@ -382,7 +382,7 @@ func printQuotaCLIResponse(out *client.QuotaResponse, asJSON bool) error {
 		fmt.Printf("%-20s %d\n", "MaxFileCount:", out.Config.MaxFileCount)
 	}
 	if out.Config.TiDBCloudSpendingLimit != nil {
-		fmt.Printf("%-20s %.2f\n", "SpendingLimit:", float64(*out.Config.TiDBCloudSpendingLimit)/100)
+		fmt.Printf("%-20s %d\n", "SpendingLimit:", *out.Config.TiDBCloudSpendingLimit)
 	}
 	fmt.Printf("%-20s %s\n", "StorageUsed:", formatBytes(out.Usage.StorageBytes))
 	fmt.Printf("%-20s %s\n", "Reserved:", formatBytes(out.Usage.ReservedBytes))

--- a/cmd/drive9/cli/quota_test.go
+++ b/cmd/drive9/cli/quota_test.go
@@ -71,7 +71,7 @@ func TestQuotaGetUsesTenantIDAndTiDBCloudHeaders(t *testing.T) {
 	if !strings.Contains(stdout, "MaxFileCount:") || !strings.Contains(stdout, "42") {
 		t.Fatalf("stdout should include max file count: %s", stdout)
 	}
-	if !strings.Contains(stdout, "SpendingLimit:") || !strings.Contains(stdout, "100.00") {
+	if !strings.Contains(stdout, "SpendingLimit:") || !strings.Contains(stdout, "10000") {
 		t.Fatalf("stdout should include spending limit: %s", stdout)
 	}
 	if !strings.Contains(stdout, "StorageUsed:") || !strings.Contains(stdout, "1 B") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the CLI quota output to show the spending limit as a whole number instead of a scaled decimal value.
  * Aligned the quota command output with the returned limit value, while keeping JSON output unchanged.
  * Adjusted related test expectations to match the updated display format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->