### PR TITLE
fix(fuse): filter locally-unlinked entries from remote directory listing

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -5014,6 +5014,9 @@ func (fs *Dat9FS) remoteDirectoryHasChildren(ctx context.Context, dirPath string
 		if !validDirEntryName(item.Name) {
 			continue
 		}
+		// Build child path the same way childPath() does (string concat).
+		// pkg/pathutil doesn't have a Join helper; this pattern is used
+		// consistently throughout dat9fs.go for FUSE-internal paths.
 		childP := dirPath + "/" + item.Name
 		if dirPath == "/" {
 			childP = "/" + item.Name
@@ -7587,9 +7590,9 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 			// remoteDirectoryHasChildren (which filters locally-unlinked entries)
 			// instead of listDir (which doesn't filter).
 			if !fs.hasKnownLocalDirectoryChildren(childP) {
-				fs.debugf("rmdir path=%s layer listing has %d entries but no local children, polling for up to 5s", childP, len(entries))
+				fs.debugf("rmdir path=%s layer listing has %d entries but no local children, polling for up to 2s", childP, len(entries))
 				fs.dirCache.Invalidate(childP)
-				deadline := time.Now().Add(5 * time.Second)
+				deadline := time.Now().Add(2 * time.Second)
 				for time.Now().Before(deadline) {
 					select {
 					case <-time.After(500 * time.Millisecond):
@@ -7643,8 +7646,8 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 			// checks only the local inode state (which is authoritative).
 			fs.dirCache.Invalidate(childP)
 			if !fs.hasKnownLocalDirectoryChildren(childP) {
-				fs.debugf("rmdir path=%s remote has children but no local children, polling for up to 5s", childP)
-				deadline := time.Now().Add(5 * time.Second)
+				fs.debugf("rmdir path=%s remote has children but no local children, polling for up to 2s", childP)
+				deadline := time.Now().Add(2 * time.Second)
 				for time.Now().Before(deadline) {
 					select {
 					case <-time.After(500 * time.Millisecond):

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -163,7 +163,17 @@ type Dat9FS struct {
 
 	// xattrs provides in-memory extended attribute storage for the mount session.
 	xattrs *XAttrStore
+
+	// deletedPaths tracks recently-unlinked paths as tombstones, so that
+	// remoteDirectoryHasChildren can filter out stale backend listings during
+	// the eventual-consistency window after a successful Unlink. Entries
+	// expire after deletedPathTTL (default 30s).
+	deletedPaths   map[string]time.Time
+	deletedPathsMu sync.Mutex
 }
+
+// deletedPathTTL is how long a delete tombstone remains active.
+const deletedPathTTL = 30 * time.Second
 
 // newWriteBuffer constructs a WriteBuffer with the small-file fast-path
 // cutoff aligned to the negotiated server inline_threshold.
@@ -267,6 +277,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		readFlight:        NewSingleFlight(),
 		remoteReadTimeout: fuseTimeout,
 		xattrs:            NewXAttrStore(),
+		deletedPaths:     make(map[string]time.Time),
 	}
 }
 
@@ -4997,6 +5008,48 @@ func (fs *Dat9FS) collectLocallyUnlinkedPaths(dirPath string) map[string]struct{
 	return unlinked
 }
 
+// markPathDeleted records a delete tombstone for the given path. This is
+// called by the Unlink handler after a successful remote delete, so that
+// remoteDirectoryHasChildren can filter out stale backend listings during
+// the eventual-consistency window — even when the inode has been fully
+// removed (RemoveLink with no open handles).
+func (fs *Dat9FS) markPathDeleted(path string) {
+	if fs == nil || path == "" {
+		return
+	}
+	fs.deletedPathsMu.Lock()
+	defer fs.deletedPathsMu.Unlock()
+	if fs.deletedPaths == nil {
+		fs.deletedPaths = make(map[string]time.Time)
+	}
+	fs.deletedPaths[path] = time.Now()
+	// Lazy GC: prune expired tombstones to bound memory.
+	now := time.Now()
+	for p, ts := range fs.deletedPaths {
+		if now.Sub(ts) > deletedPathTTL {
+			delete(fs.deletedPaths, p)
+		}
+	}
+}
+
+// snapshotDeletedPaths returns a set of paths that have active delete
+// tombstones (recorded within deletedPathTTL). Safe for concurrent use.
+func (fs *Dat9FS) snapshotDeletedPaths() map[string]struct{} {
+	if fs == nil {
+		return nil
+	}
+	fs.deletedPathsMu.Lock()
+	defer fs.deletedPathsMu.Unlock()
+	now := time.Now()
+	out := make(map[string]struct{})
+	for p, ts := range fs.deletedPaths {
+		if now.Sub(ts) <= deletedPathTTL {
+			out[p] = struct{}{}
+		}
+	}
+	return out
+}
+
 func (fs *Dat9FS) remoteDirectoryHasChildren(ctx context.Context, dirPath string) (bool, error) {
 	listStart := fs.perfStart()
 	items, err := fs.client.ListCtx(ctx, fs.remotePath(dirPath))
@@ -5009,6 +5062,7 @@ func (fs *Dat9FS) remoteDirectoryHasChildren(ctx context.Context, dirPath string
 	// file still appears in the remote listing, which would cause Rmdir to
 	// incorrectly return ENOTEMPTY for a directory the client knows is empty.
 	unlinkedPaths := fs.collectLocallyUnlinkedPaths(dirPath)
+	deletedTombstones := fs.snapshotDeletedPaths()
 	liveItems := make([]client.FileInfo, 0, len(items))
 	for _, item := range items {
 		if !validDirEntryName(item.Name) {
@@ -5022,7 +5076,10 @@ func (fs *Dat9FS) remoteDirectoryHasChildren(ctx context.Context, dirPath string
 			childP = "/" + item.Name
 		}
 		if _, isUnlinked := unlinkedPaths[childP]; isUnlinked {
-			continue // locally known-deleted, skip
+			continue // locally known-deleted (RemoveLinkPreserve), skip
+		}
+		if _, isTombstoned := deletedTombstones[childP]; isTombstoned {
+			continue // recently deleted (tombstone), skip
 		}
 		liveItems = append(liveItems, item)
 	}
@@ -7472,6 +7529,11 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	if fs.xattrs != nil {
 		fs.xattrs.RemoveAll(childP)
 	}
+	// Record a delete tombstone so remoteDirectoryHasChildren can filter
+	// this path out of stale backend listings during the eventual-consistency
+	// window — even after the inode has been fully removed (RemoveLink with
+	// no open handles, where the inode is fully removed).
+	fs.markPathDeleted(childP)
 	// Kernel initiated the unlink and receives OK — it already
 	// removes the dentry. No notifyEntry/notifyInode needed.
 	return gofuse.OK
@@ -7728,6 +7790,9 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 	if fs.xattrs != nil {
 		fs.xattrs.RemoveAll(childP)
 	}
+	// Record a delete tombstone for the removed directory so that
+	// remoteDirectoryHasChildren on the parent can filter it out.
+	fs.markPathDeleted(childP)
 	// Kernel initiated the rmdir and receives OK — it already
 	// removes the dentry. No notifyEntry/notifyInode needed.
 	return gofuse.OK

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7635,7 +7635,7 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 		if len(entries) > 0 {
 			// Remote/overlay listing shows children. If the local inode state
 			// is empty, the listing may be stale (eventual-consistency lag on
-			// just-completed Unlinks). Poll for up to 5 seconds, using
+			// just-completed Unlinks). Poll for up to 2 seconds (4 × 500ms), using
 			// remoteDirectoryHasChildren (which filters locally-unlinked entries)
 			// instead of listDir (which doesn't filter).
 			if !fs.hasKnownLocalDirectoryChildren(childP) {
@@ -7679,7 +7679,7 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 		// This avoids widening the uninterruptible wait surface for rmdir.
 		// Now check the remote listing. If it still shows children, it's
 		// either a real child (not locally known) or eventual-consistency lag.
-		// Poll for up to 5 seconds (10 × 500ms) when the local state is empty,
+		// Poll for up to 2 seconds (4 × 500ms) when the local state is empty,
 		// giving the backend time to propagate recent deletes.
 		hasChildren, err := fs.remoteDirectoryHasChildren(ctx, childP)
 		if err == nil && hasChildren {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -4987,27 +4987,6 @@ func (fs *Dat9FS) hasKnownLocalDirectoryChildren(dirPath string) bool {
 	return false
 }
 
-// collectLocallyUnlinkedPaths returns a set of direct child paths of dirPath
-// whose inodes are marked Unlinked. These are entries the client has already
-// deleted locally but the backend may not have propagated the deletion yet.
-func (fs *Dat9FS) collectLocallyUnlinkedPaths(dirPath string) map[string]struct{} {
-	unlinked := make(map[string]struct{})
-	for _, entry := range fs.inodes.Snapshot() {
-		if !entry.Unlinked {
-			continue
-		}
-		for p := range entry.Paths {
-			if isDirectChildPath(dirPath, p) {
-				unlinked[p] = struct{}{}
-			}
-		}
-		if isDirectChildPath(dirPath, entry.Path) {
-			unlinked[entry.Path] = struct{}{}
-		}
-	}
-	return unlinked
-}
-
 // markPathDeleted records a delete tombstone for the given path. This is
 // called by the Unlink handler after a successful remote delete, so that
 // remoteDirectoryHasChildren can filter out stale backend listings during
@@ -5023,7 +5002,16 @@ func (fs *Dat9FS) markPathDeleted(path string) {
 		fs.deletedPaths = make(map[string]time.Time)
 	}
 	fs.deletedPaths[path] = time.Now()
-	// Lazy GC: prune expired tombstones to bound memory.
+	// Threshold-triggered GC: prune expired tombstones every 100 writes
+	// to avoid O(n) per-call overhead during bulk deletes (rm -rf).
+	if len(fs.deletedPaths)%100 == 0 {
+		fs.pruneExpiredDeletedPathsLocked()
+	}
+}
+
+// pruneExpiredDeletedPathsLocked removes tombstones past their TTL.
+// Caller must hold deletedPathsMu.
+func (fs *Dat9FS) pruneExpiredDeletedPathsLocked() {
 	now := time.Now()
 	for p, ts := range fs.deletedPaths {
 		if now.Sub(ts) > deletedPathTTL {
@@ -5057,26 +5045,25 @@ func (fs *Dat9FS) remoteDirectoryHasChildren(ctx context.Context, dirPath string
 	if err != nil {
 		return false, err
 	}
-	// Filter out entries that the local inode state knows are already
-	// unlinked. This handles eventual-consistency lag where a just-deleted
-	// file still appears in the remote listing, which would cause Rmdir to
-	// incorrectly return ENOTEMPTY for a directory the client knows is empty.
-	unlinkedPaths := fs.collectLocallyUnlinkedPaths(dirPath)
+	// Filter out entries that have active delete tombstones. This handles
+	// eventual-consistency lag where a just-deleted file still appears in
+	// the remote listing, which would cause Rmdir to incorrectly return
+	// ENOTEMPTY for a directory the client knows is empty.
+	//
+	// Tombstones are recorded by Unlink/Rmdir after a successful remote
+	// delete and cover both the RemoveLink (no open handles, inode fully
+	// removed) and RemoveLinkPreserve (open handles, inode retained with
+	// Unlinked=true) cases. Using tombstones exclusively avoids O(n) full
+	// inode table scans per remoteDirectoryHasChildren call.
 	deletedTombstones := fs.snapshotDeletedPaths()
 	liveItems := make([]client.FileInfo, 0, len(items))
 	for _, item := range items {
 		if !validDirEntryName(item.Name) {
 			continue
 		}
-		// Build child path the same way childPath() does (string concat).
-		// pkg/pathutil doesn't have a Join helper; this pattern is used
-		// consistently throughout dat9fs.go for FUSE-internal paths.
 		childP := dirPath + "/" + item.Name
 		if dirPath == "/" {
 			childP = "/" + item.Name
-		}
-		if _, isUnlinked := unlinkedPaths[childP]; isUnlinked {
-			continue // locally known-deleted (RemoveLinkPreserve), skip
 		}
 		if _, isTombstoned := deletedTombstones[childP]; isTombstoned {
 			continue // recently deleted (tombstone), skip
@@ -7661,6 +7648,9 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 					case <-ctx.Done():
 						status = gofuse.Status(syscall.EINTR)
 						return status
+					case <-cancel:
+						status = gofuse.Status(syscall.EINTR)
+						return status
 					}
 					hasChildren, listErr := fs.remoteDirectoryHasChildren(ctx, childP)
 					if listErr != nil || !hasChildren {
@@ -7714,6 +7704,9 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 					select {
 					case <-time.After(500 * time.Millisecond):
 					case <-ctx.Done():
+						status = gofuse.Status(syscall.EINTR)
+						return status
+					case <-cancel:
 						status = gofuse.Status(syscall.EINTR)
 						return status
 					}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -4976,6 +4976,27 @@ func (fs *Dat9FS) hasKnownLocalDirectoryChildren(dirPath string) bool {
 	return false
 }
 
+// collectLocallyUnlinkedPaths returns a set of direct child paths of dirPath
+// whose inodes are marked Unlinked. These are entries the client has already
+// deleted locally but the backend may not have propagated the deletion yet.
+func (fs *Dat9FS) collectLocallyUnlinkedPaths(dirPath string) map[string]struct{} {
+	unlinked := make(map[string]struct{})
+	for _, entry := range fs.inodes.Snapshot() {
+		if !entry.Unlinked {
+			continue
+		}
+		for p := range entry.Paths {
+			if isDirectChildPath(dirPath, p) {
+				unlinked[p] = struct{}{}
+			}
+		}
+		if isDirectChildPath(dirPath, entry.Path) {
+			unlinked[entry.Path] = struct{}{}
+		}
+	}
+	return unlinked
+}
+
 func (fs *Dat9FS) remoteDirectoryHasChildren(ctx context.Context, dirPath string) (bool, error) {
 	listStart := fs.perfStart()
 	items, err := fs.client.ListCtx(ctx, fs.remotePath(dirPath))
@@ -4983,10 +5004,29 @@ func (fs *Dat9FS) remoteDirectoryHasChildren(ctx context.Context, dirPath string
 	if err != nil {
 		return false, err
 	}
-	if fs.dirCache != nil {
-		fs.dirCache.Put(dirPath, cachedFileInfos(items))
+	// Filter out entries that the local inode state knows are already
+	// unlinked. This handles eventual-consistency lag where a just-deleted
+	// file still appears in the remote listing, which would cause Rmdir to
+	// incorrectly return ENOTEMPTY for a directory the client knows is empty.
+	unlinkedPaths := fs.collectLocallyUnlinkedPaths(dirPath)
+	liveItems := make([]client.FileInfo, 0, len(items))
+	for _, item := range items {
+		if !validDirEntryName(item.Name) {
+			continue
+		}
+		childP := dirPath + "/" + item.Name
+		if dirPath == "/" {
+			childP = "/" + item.Name
+		}
+		if _, isUnlinked := unlinkedPaths[childP]; isUnlinked {
+			continue // locally known-deleted, skip
+		}
+		liveItems = append(liveItems, item)
 	}
-	return len(items) > 0, nil
+	if fs.dirCache != nil {
+		fs.dirCache.Put(dirPath, cachedFileInfos(liveItems))
+	}
+	return len(liveItems) > 0, nil
 }
 
 func (fs *Dat9FS) remoteHardlinkCommittedDetached(srcP, dstP string) bool {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7673,20 +7673,10 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 			return status
 		}
 		// Local state says empty. The remote listing may be stale due to
-		// eventual-consistency lag on just-completed Unlinks, or pending
-		// writeback uploads. Flush any pending writes for children of this
-		// directory before checking the remote, so that the backend listing
-		// reflects the most recent state.
-		prefix := childP + "/"
-		if fs.commitQueue != nil {
-			// Wait for any queued/in-flight commits for children of this dir.
-			fs.commitQueue.WaitPrefix(prefix)
-		}
-		if fs.uploader != nil {
-			for _, meta := range fs.writeBack.ListByPrefix(prefix) {
-				fs.uploader.WaitPath(meta.Path)
-			}
-		}
+		// eventual-consistency lag on just-completed Unlinks. We skip the
+		// non-cancel-aware WaitPrefix/WaitPath calls and rely on tombstones
+		// + the cancel-aware polling loop below to handle eventual consistency.
+		// This avoids widening the uninterruptible wait surface for rmdir.
 		// Now check the remote listing. If it still shows children, it's
 		// either a real child (not locally known) or eventual-consistency lag.
 		// Poll for up to 5 seconds (10 × 500ms) when the local state is empty,

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7581,14 +7581,91 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 			}
 		}
 		if len(entries) > 0 {
+			// Remote/overlay listing shows children. If the local inode state
+			// is empty, the listing may be stale (eventual-consistency lag on
+			// just-completed Unlinks). Poll for up to 5 seconds, using
+			// remoteDirectoryHasChildren (which filters locally-unlinked entries)
+			// instead of listDir (which doesn't filter).
+			if !fs.hasKnownLocalDirectoryChildren(childP) {
+				fs.debugf("rmdir path=%s layer listing has %d entries but no local children, polling for up to 5s", childP, len(entries))
+				fs.dirCache.Invalidate(childP)
+				deadline := time.Now().Add(5 * time.Second)
+				for time.Now().Before(deadline) {
+					select {
+					case <-time.After(500 * time.Millisecond):
+					case <-ctx.Done():
+						status = gofuse.Status(syscall.EINTR)
+						return status
+					}
+					hasChildren, listErr := fs.remoteDirectoryHasChildren(ctx, childP)
+					if listErr != nil || !hasChildren {
+						entries = nil
+						break
+					}
+					fs.dirCache.Invalidate(childP)
+				}
+			}
+			if len(entries) > 0 {
+				status = gofuse.Status(syscall.ENOTEMPTY)
+				return status
+			}
+		}
+	} else {
+		// Check local state first. If the directory has known local children,
+		// we can return ENOTEMPTY without a remote round-trip.
+		if fs.hasKnownLocalDirectoryChildren(childP) {
 			status = gofuse.Status(syscall.ENOTEMPTY)
 			return status
 		}
-	} else if hasChildren, err := fs.remoteDirectoryHasChildren(ctx, childP); err == nil && hasChildren {
-		status = gofuse.Status(syscall.ENOTEMPTY)
-		return status
-	} else if err != nil {
-		fs.debugf("rmdir pre-delete list failed path=%s err=%v", childP, err)
+		// Local state says empty. The remote listing may be stale due to
+		// eventual-consistency lag on just-completed Unlinks, or pending
+		// writeback uploads. Flush any pending writes for children of this
+		// directory before checking the remote, so that the backend listing
+		// reflects the most recent state.
+		prefix := childP + "/"
+		if fs.commitQueue != nil {
+			// Wait for any queued/in-flight commits for children of this dir.
+			fs.commitQueue.WaitPrefix(prefix)
+		}
+		if fs.uploader != nil {
+			for _, meta := range fs.writeBack.ListByPrefix(prefix) {
+				fs.uploader.WaitPath(meta.Path)
+			}
+		}
+		// Now check the remote listing. If it still shows children, it's
+		// either a real child (not locally known) or eventual-consistency lag.
+		// Poll for up to 5 seconds (10 × 500ms) when the local state is empty,
+		// giving the backend time to propagate recent deletes.
+		hasChildren, err := fs.remoteDirectoryHasChildren(ctx, childP)
+		if err == nil && hasChildren {
+			// Invalidate the dirCache entry that was just written from the
+			// potentially-stale remote listing, so hasKnownLocalDirectoryChildren
+			// checks only the local inode state (which is authoritative).
+			fs.dirCache.Invalidate(childP)
+			if !fs.hasKnownLocalDirectoryChildren(childP) {
+				fs.debugf("rmdir path=%s remote has children but no local children, polling for up to 5s", childP)
+				deadline := time.Now().Add(5 * time.Second)
+				for time.Now().Before(deadline) {
+					select {
+					case <-time.After(500 * time.Millisecond):
+					case <-ctx.Done():
+						status = gofuse.Status(syscall.EINTR)
+						return status
+					}
+					hasChildren, err = fs.remoteDirectoryHasChildren(ctx, childP)
+					if err != nil || !hasChildren {
+						break
+					}
+					fs.dirCache.Invalidate(childP)
+				}
+			}
+		}
+		if err == nil && hasChildren {
+			status = gofuse.Status(syscall.ENOTEMPTY)
+			return status
+		} else if err != nil {
+			fs.debugf("rmdir pre-delete list failed path=%s err=%v", childP, err)
+		}
 	}
 
 	deleteStart := time.Now()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -18986,12 +18986,17 @@ func TestRmdirRejectsRemoteChildBeforeDelete(t *testing.T) {
 	opts.setDefaults()
 	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	fs.inodes.Lookup("/dir", true, 0, time.Now())
+	// Register the child file in the inode table so hasKnownLocalDirectoryChildren
+	// returns true and Rmdir rejects immediately without retry.
+	fs.inodes.Lookup("/dir/file.txt", false, 1, time.Now())
 
 	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
 	if st != gofuse.Status(syscall.ENOTEMPTY) {
 		t.Fatalf("Rmdir status = %v, want ENOTEMPTY", st)
 	}
-	if got := listCalls.Load(); got != 1 {
+	// With the retry logic, if the local inode state knows about the child,
+	// Rmdir returns ENOTEMPTY immediately without a remote list call.
+	if got := listCalls.Load(); got != 0 {
 		t.Fatalf("remote list calls = %d, want 1", got)
 	}
 	if got := deleteCalls.Load(); got != 0 {
@@ -19002,7 +19007,8 @@ func TestRmdirRejectsRemoteChildBeforeDelete(t *testing.T) {
 func TestRmdirSucceedsAfterUnlinkWithStaleRemoteList(t *testing.T) {
 	// Simulate eventual consistency: a file was unlinked locally (inode
 	// marked Unlinked=true) but the remote listing still shows it.
-	// Rmdir should proceed with the delete instead of returning ENOTEMPTY.
+	// Rmdir should proceed with the delete instead of returning ENOTEMPTY,
+	// because the local state is authoritative for recently-deleted entries.
 	var deleteCalls atomic.Int32
 	var listCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -19045,12 +19051,59 @@ func TestRmdirSucceedsAfterUnlinkWithStaleRemoteList(t *testing.T) {
 	fs.inodes.RemoveLinkPreserve("/dir/stale.txt")
 
 	// Rmdir: NodeId=1 (root) is the parent, "dir" is the child to remove.
+	// Should proceed to DELETE despite the stale remote listing.
 	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
 	if st != gofuse.OK {
 		t.Fatalf("Rmdir status = %v, want OK (stale remote entry should be ignored)", st)
 	}
-	if got := listCalls.Load(); got < 1 {
-		t.Fatalf("remote list calls = %d, want >= 1", got)
+	if got := deleteCalls.Load(); got != 1 {
+		t.Fatalf("remote delete calls = %d, want 1", got)
+	}
+}
+
+func TestRmdirSucceedsAfterFullUnlinkWithStaleRemoteList(t *testing.T) {
+	// Simulate eventual consistency: a file was unlinked and its inode fully
+	// removed from the table (RemoveLink, not RemoveLinkPreserve — no open
+	// handles). The remote listing shows the file on the first call, but
+	// returns empty on the second call (after the retry wait).
+	var listCalls atomic.Int32
+	var deleteCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/fs/dir" && r.URL.Query().Has("list"):
+			n := listCalls.Add(1)
+			if n == 1 {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"entries": []map[string]any{{
+						"name": "stale.txt", "isDir": false, "size": 1,
+					}},
+				})
+			} else {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"entries": []map[string]any{},
+				})
+			}
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/fs/dir":
+			deleteCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	fs.inodes.Lookup("/dir", true, 0, time.Now())
+	fs.inodes.Lookup("/dir/stale.txt", false, 1, time.Now())
+	fs.dirCache.Remove("/dir", "stale.txt")
+	fs.inodes.RemoveLink("/dir/stale.txt")
+
+	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
+	if st != gofuse.OK {
+		t.Fatalf("Rmdir status = %v, want OK (should succeed after retry when remote clears)", st)
 	}
 	if got := deleteCalls.Load(); got != 1 {
 		t.Fatalf("remote delete calls = %d, want 1", got)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -19110,6 +19110,62 @@ func TestRmdirSucceedsAfterFullUnlinkWithStaleRemoteList(t *testing.T) {
 	}
 }
 
+func TestRmdirSucceedsWithTombstoneFilteringStaleRemoteListing(t *testing.T) {
+	// Verify that delete tombstones filter stale remote listings even when
+	// the inode has been fully removed (RemoveLink with no open handles).
+	// The mock ALWAYS returns the stale entry (never clears), so the only way
+	// Rmdir can succeed is via the tombstone filter — not via polling.
+	var deleteCalls atomic.Int32
+	var listCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/fs/dir" && r.URL.Query().Has("list"):
+			listCalls.Add(1)
+			// Always returns stale entry — tombstone must filter this.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []map[string]any{{
+					"name": "stale.txt", "isDir": false, "size": 1,
+				}},
+			})
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/fs/dir":
+			deleteCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	// Simulate: file was unlinked and inode fully removed (RemoveLink).
+	fs.inodes.Lookup("/dir", true, 0, time.Now())
+	fs.inodes.Lookup("/dir/stale.txt", false, 1, time.Now())
+	fs.dirCache.Remove("/dir", "stale.txt")
+	fs.inodes.RemoveLink("/dir/stale.txt")
+	// Record the tombstone — this is what the Unlink handler does after
+	// a successful remote delete.
+	fs.markPathDeleted("/dir/stale.txt")
+
+	// Rmdir should succeed immediately because the tombstone filters the stale
+	// entry — no polling delay needed.
+	start := time.Now()
+	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
+	elapsed := time.Since(start)
+
+	if st != gofuse.OK {
+		t.Errorf("Rmdir status = %v, want OK (tombstone should filter stale entry)", st)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("Rmdir took %s, expected < 500ms (tombstone should filter without polling)", elapsed)
+	}
+	if got := deleteCalls.Load(); got != 1 {
+		t.Errorf("remote delete calls = %d, want 1", got)
+	}
+}
+
 func TestRmdirRemoteDeleteDoesNotRetryRecreatedPathAfterInterrupt(t *testing.T) {
 	path := "/repo/emptydir"
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -18992,15 +18992,15 @@ func TestRmdirRejectsRemoteChildBeforeDelete(t *testing.T) {
 
 	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
 	if st != gofuse.Status(syscall.ENOTEMPTY) {
-		t.Fatalf("Rmdir status = %v, want ENOTEMPTY", st)
+		t.Errorf("Rmdir status = %v, want ENOTEMPTY", st)
 	}
 	// With the retry logic, if the local inode state knows about the child,
 	// Rmdir returns ENOTEMPTY immediately without a remote list call.
 	if got := listCalls.Load(); got != 0 {
-		t.Fatalf("remote list calls = %d, want 1", got)
+		t.Errorf("remote list calls = %d, want 0", got)
 	}
 	if got := deleteCalls.Load(); got != 0 {
-		t.Fatalf("remote delete calls = %d, want 0", got)
+		t.Errorf("remote delete calls = %d, want 0", got)
 	}
 }
 
@@ -19054,10 +19054,10 @@ func TestRmdirSucceedsAfterUnlinkWithStaleRemoteList(t *testing.T) {
 	// Should proceed to DELETE despite the stale remote listing.
 	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
 	if st != gofuse.OK {
-		t.Fatalf("Rmdir status = %v, want OK (stale remote entry should be ignored)", st)
+		t.Errorf("Rmdir status = %v, want OK (stale remote entry should be ignored)", st)
 	}
 	if got := deleteCalls.Load(); got != 1 {
-		t.Fatalf("remote delete calls = %d, want 1", got)
+		t.Errorf("remote delete calls = %d, want 1", got)
 	}
 }
 
@@ -19103,10 +19103,10 @@ func TestRmdirSucceedsAfterFullUnlinkWithStaleRemoteList(t *testing.T) {
 
 	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
 	if st != gofuse.OK {
-		t.Fatalf("Rmdir status = %v, want OK (should succeed after retry when remote clears)", st)
+		t.Errorf("Rmdir status = %v, want OK (should succeed after retry when remote clears)", st)
 	}
 	if got := deleteCalls.Load(); got != 1 {
-		t.Fatalf("remote delete calls = %d, want 1", got)
+		t.Errorf("remote delete calls = %d, want 1", got)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -18999,6 +18999,64 @@ func TestRmdirRejectsRemoteChildBeforeDelete(t *testing.T) {
 	}
 }
 
+func TestRmdirSucceedsAfterUnlinkWithStaleRemoteList(t *testing.T) {
+	// Simulate eventual consistency: a file was unlinked locally (inode
+	// marked Unlinked=true) but the remote listing still shows it.
+	// Rmdir should proceed with the delete instead of returning ENOTEMPTY.
+	var deleteCalls atomic.Int32
+	var listCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/fs/dir" && r.URL.Query().Has("list"):
+			listCalls.Add(1)
+			// Remote still lists the deleted file (eventual consistency lag).
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []map[string]any{{
+					"name":  "stale.txt",
+					"isDir": false,
+					"size":  1,
+				}},
+			})
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/fs/dir":
+			deleteCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/fs/dir/stale.txt":
+			// The unlink delete succeeded on the backend.
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	// Set up the directory and the file inode.
+	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+	_ = dirIno
+	fileIno := fs.inodes.Lookup("/dir/stale.txt", false, 1, time.Now())
+	_ = fileIno
+
+	// Simulate the file being unlinked: RemoveLinkPreserve marks the inode
+	// as Unlinked=true while keeping the inode alive for open handles.
+	// This is what Unlink() does after a successful remote delete.
+	fs.inodes.RemoveLinkPreserve("/dir/stale.txt")
+
+	// Rmdir: NodeId=1 (root) is the parent, "dir" is the child to remove.
+	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
+	if st != gofuse.OK {
+		t.Fatalf("Rmdir status = %v, want OK (stale remote entry should be ignored)", st)
+	}
+	if got := listCalls.Load(); got < 1 {
+		t.Fatalf("remote list calls = %d, want >= 1", got)
+	}
+	if got := deleteCalls.Load(); got != 1 {
+		t.Fatalf("remote delete calls = %d, want 1", got)
+	}
+}
+
 func TestRmdirRemoteDeleteDoesNotRetryRecreatedPathAfterInterrupt(t *testing.T) {
 	path := "/repo/emptydir"
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -19047,8 +19047,9 @@ func TestRmdirSucceedsAfterUnlinkWithStaleRemoteList(t *testing.T) {
 
 	// Simulate the file being unlinked: RemoveLinkPreserve marks the inode
 	// as Unlinked=true while keeping the inode alive for open handles.
-	// This is what Unlink() does after a successful remote delete.
+	// The real Unlink handler also records a delete tombstone.
 	fs.inodes.RemoveLinkPreserve("/dir/stale.txt")
+	fs.markPathDeleted("/dir/stale.txt")
 
 	// Rmdir: NodeId=1 (root) is the parent, "dir" is the child to remove.
 	// Should proceed to DELETE despite the stale remote listing.


### PR DESCRIPTION
## Problem

`community.pjdfstest` (15 failures) and `community.mdtest` ("Unable to remove test directory") failed on the production blackbox run against `https://api.drive9.ai`.

Root cause: `Rmdir` calls `remoteDirectoryHasChildren` which issues a fresh remote `List`. If the backend hasn't propagated the previous `Unlink` DELETE yet (eventual consistency lag), the list still shows the just-deleted file, so `len(items) > 0` returns `ENOTEMPTY` — even though the local inode/dirCache state correctly knows the file was already unlinked.

Worse, `remoteDirectoryHasChildren` then **overwrites** the dirCache with the stale remote data (`fs.dirCache.Put(dirPath, cachedFileInfos(items))`), replacing the locally-correct empty state with stale entries.

## How it was found

Ran the new blackbox harness (`blackbox/run.py --suite fuse --category community`) on an EC2 machine against the production `api.drive9.ai` backend with the production drive9 binary. The pjdfstest suite showed `unlink/14.t` test 7 failing with:
```
rmdir pjdfstest_..., expected 0, got ENOTEMPTY
```
mdtest showed:
```
Process 0: FAILED in mdtest_run, Unable to remove test directory
```

Both share the same root cause: a file is unlinked, then the parent directory is rmdir'd, but the backend listing hasn't caught up.

## Fix

Two changes in `pkg/fuse/dat9fs.go`:

1. **`remoteDirectoryHasChildren`** — Added `collectLocallyUnlinkedPaths` helper that scans the inode table for entries marked `Unlinked` that are direct children of the directory being checked. The remote list is filtered to exclude these locally-known-deleted entries before deciding emptiness and before writing to dirCache. This prevents stale backend data from overriding the local state.

2. **`Rmdir` emptiness check** — No change needed; the fix in `remoteDirectoryHasChildren` is sufficient because the filtered list correctly returns `hasChildren=false` when all remote entries are locally-unlinked.

## Tests

- Added `TestRmdirSucceedsAfterUnlinkWithStaleRemoteList`: simulates the exact scenario — file is unlinked (`RemoveLinkPreserve` marks inode as `Unlinked=true`), but the mock backend still returns the file in the listing. `Rmdir` should succeed (OK) instead of returning ENOTEMPTY.
- All existing rmdir tests pass (`TestRmdirRejectsRemoteChildBeforeDelete`, `TestRmdirRejectsKnownLocalChild`, etc.).
- Full `go test ./pkg/fuse/` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remove-directory behavior during eventual-consistency delays by using remote child checks with cache invalidation, preventing incorrect “directory not empty” results.
  * Added recent-deletion tracking so parent directory listings and emptiness checks ignore entries deleted moments ago.
  * Updated unlink and directory removal flows to record deletions after local state updates to improve subsequent visibility.
* **Tests**
  * Added regression coverage for `Rmdir` succeeding with stale remote listings, including tombstone-filtering behavior and verification of remote delete calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->