### PR TITLE
fix(fuse): implement in-memory xattr store replacing no-op stubs

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11849,7 +11849,9 @@ func (fs *Dat9FS) SetXAttr(cancel <-chan struct{}, input *gofuse.SetXAttrIn, att
 	if !ok {
 		return gofuse.ENOENT
 	}
-	fs.xattrs.Set(path, attr, data)
+	if err := fs.xattrs.SetWithFlags(path, attr, data, input.Flags); err != 0 {
+		return gofuse.Status(err)
+	}
 	return gofuse.OK
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7655,6 +7655,10 @@ func (fs *Dat9FS) finishLocalRename(input *gofuse.RenameIn, oldP, newP string) {
 	}
 	fs.inodes.Rename(oldP, newP)
 	fs.renameSpecialNodeSubtree(oldP, newP)
+	// Migrate in-memory xattrs from old path to new path.
+	if fs.xattrs != nil {
+		fs.xattrs.Rename(oldP, newP)
+	}
 	fs.invalidateReadCacheAndTargets(oldP)
 	fs.invalidateReadCacheAndTargets(newP)
 	fs.readCache.InvalidatePrefix(oldP + "/")

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -156,6 +156,9 @@ type Dat9FS struct {
 	// the dat9 client). When 0, defaultSmallFileThreshold is used. Use the
 	// inlineThreshold() accessor; do not read directly.
 	smallFileMax atomic.Int64
+
+	// xattrs provides in-memory extended attribute storage for the mount session.
+	xattrs *XAttrStore
 }
 
 // newWriteBuffer constructs a WriteBuffer with the small-file fast-path
@@ -259,6 +262,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		gitOverlayPending: make(map[string]map[string]pendingGitOverlayEntry),
 		readFlight:        NewSingleFlight(),
 		remoteReadTimeout: fuseTimeout,
+		xattrs:            NewXAttrStore(),
 	}
 }
 
@@ -7282,6 +7286,10 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	fs.dirCache.Remove(parentPath, name)
 	fs.touchDirectoryChangeTime(parentPath, time.Now())
 	fs.cacheNegativePath(childP)
+	// Clean up in-memory xattrs for the unlinked path.
+	if fs.xattrs != nil {
+		fs.xattrs.RemoveAll(childP)
+	}
 	// Kernel initiated the unlink and receives OK — it already
 	// removes the dentry. No notifyEntry/notifyInode needed.
 	return gofuse.OK
@@ -7457,6 +7465,10 @@ func (fs *Dat9FS) Rmdir(cancel <-chan struct{}, header *gofuse.InHeader, name st
 	fs.dirCache.Remove(parentPath, name)
 	fs.touchDirectoryChangeTime(parentPath, time.Now())
 	fs.cacheNegativePath(childP)
+	// Clean up in-memory xattrs for the removed directory and its children.
+	if fs.xattrs != nil {
+		fs.xattrs.RemoveAll(childP)
+	}
 	// Kernel initiated the rmdir and receives OK — it already
 	// removes the dentry. No notifyEntry/notifyInode needed.
 	return gofuse.OK
@@ -11782,22 +11794,70 @@ func (fs *Dat9FS) StatFs(cancel <-chan struct{}, header *gofuse.InHeader, out *g
 	return gofuse.OK
 }
 
-// --- Xattr stubs (macOS Finder/Spotlight compatibility) ----------------------
+// --- Xattr handlers (in-memory, session-scoped) ----------------------------
 
 func (fs *Dat9FS) GetXAttr(cancel <-chan struct{}, header *gofuse.InHeader, attr string, dest []byte) (uint32, gofuse.Status) {
-	return 0, gofuse.ENOATTR
+	path, ok := fs.inodes.GetPath(header.NodeId)
+	if !ok {
+		return 0, gofuse.ENOENT
+	}
+	val, found := fs.xattrs.Get(path, attr)
+	if !found {
+		return 0, gofuse.ENOATTR
+	}
+	if len(dest) == 0 {
+		return uint32(len(val)), gofuse.OK
+	}
+	if len(val) > len(dest) {
+		return uint32(len(val)), gofuse.Status(syscall.ERANGE)
+	}
+	copy(dest, val)
+	return uint32(len(val)), gofuse.OK
 }
 
 func (fs *Dat9FS) ListXAttr(cancel <-chan struct{}, header *gofuse.InHeader, dest []byte) (uint32, gofuse.Status) {
-	return 0, gofuse.OK
+	path, ok := fs.inodes.GetPath(header.NodeId)
+	if !ok {
+		return 0, gofuse.ENOENT
+	}
+	names := fs.xattrs.List(path)
+	var total int
+	for _, name := range names {
+		total += len(name) + 1
+	}
+	if len(dest) == 0 {
+		return uint32(total), gofuse.OK
+	}
+	if total > len(dest) {
+		return uint32(total), gofuse.Status(syscall.ERANGE)
+	}
+	off := 0
+	for _, name := range names {
+		off += copy(dest[off:], name)
+		dest[off] = 0
+		off++
+	}
+	return uint32(off), gofuse.OK
 }
 
 func (fs *Dat9FS) SetXAttr(cancel <-chan struct{}, input *gofuse.SetXAttrIn, attr string, data []byte) gofuse.Status {
+	path, ok := fs.inodes.GetPath(input.NodeId)
+	if !ok {
+		return gofuse.ENOENT
+	}
+	fs.xattrs.Set(path, attr, data)
 	return gofuse.OK
 }
 
 func (fs *Dat9FS) RemoveXAttr(cancel <-chan struct{}, header *gofuse.InHeader, attr string) gofuse.Status {
-	return gofuse.ENOATTR
+	path, ok := fs.inodes.GetPath(header.NodeId)
+	if !ok {
+		return gofuse.ENOENT
+	}
+	if !fs.xattrs.Remove(path, attr) {
+		return gofuse.ENOATTR
+	}
+	return gofuse.OK
 }
 
 // onCommitQueueSuccess is called by the commit queue after a successful upload.

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -11846,6 +11846,49 @@ func TestXAttr_RameNoOpPreservesXattrs(t *testing.T) {
 	}
 }
 
+func TestXAttr_RenameOverExistingClearsDestinationXattrs(t *testing.T) {
+	// POSIX rename replaces the destination object. Stale xattrs from the
+	// old destination must not remain visible on the new object.
+	store := NewXAttrStore()
+	// Destination has xattrs; source does not.
+	store.Set("/dst", "user.old", []byte("stale"))
+	store.Set("/dst/child.txt", "user.child", []byte("stale_child"))
+
+	// Rename /src -> /dst (source has no xattrs).
+	store.Rename("/src", "/dst")
+
+	// /dst should have NO xattrs (source had none, destination's were cleared).
+	if _, ok := store.Get("/dst", "user.old"); ok {
+		t.Errorf("stale xattr on /dst survived rename-over-existing")
+	}
+	// /dst/child.txt should also be gone (destination subtree cleared).
+	if _, ok := store.Get("/dst/child.txt", "user.child"); ok {
+		t.Errorf("stale xattr on /dst/child.txt survived rename-over-existing")
+	}
+}
+
+func TestXAttr_RenameOverExistingReplacesDestinationXattrs(t *testing.T) {
+	// Both source and destination have xattrs — source wins.
+	store := NewXAttrStore()
+	store.Set("/dst", "user.old", []byte("stale"))
+	store.Set("/src", "user.new", []byte("fresh"))
+
+	store.Rename("/src", "/dst")
+
+	// Source's xattr should be on destination.
+	if v, ok := store.Get("/dst", "user.new"); !ok || string(v) != "fresh" {
+		t.Errorf("source xattr not migrated to destination: ok=%v val=%q", ok, v)
+	}
+	// Old destination xattr should be gone.
+	if _, ok := store.Get("/dst", "user.old"); ok {
+		t.Errorf("stale destination xattr survived rename-over-existing")
+	}
+	// Old source path should be empty.
+	if _, ok := store.Get("/src", "user.new"); ok {
+		t.Errorf("xattr still on old source path after rename")
+	}
+}
+
 func TestSetAttr_MtimeUpdate(t *testing.T) {
 	fs, ino, cleanup := newTestDat9FS(t, 42, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(make([]byte, 42))

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -11834,6 +11834,18 @@ func TestXAttr_RenameMigratesSubtree(t *testing.T) {
 	}
 }
 
+func TestXAttr_RameNoOpPreservesXattrs(t *testing.T) {
+	// Rename to the same path should be a no-op — xattrs must survive.
+	store := NewXAttrStore()
+	store.Set("/file.txt", "user.test", []byte("hello"))
+
+	store.Rename("/file.txt", "/file.txt")
+
+	if v, ok := store.Get("/file.txt", "user.test"); !ok || string(v) != "hello" {
+		t.Errorf("xattr lost after no-op Rename: ok=%v val=%q", ok, v)
+	}
+}
+
 func TestSetAttr_MtimeUpdate(t *testing.T) {
 	fs, ino, cleanup := newTestDat9FS(t, 42, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(make([]byte, 42))

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -11575,7 +11575,7 @@ func TestStatFs_ReportsVirtualCapacity(t *testing.T) {
 	}
 }
 
-func TestXAttr_GetReturnsENOATTR(t *testing.T) {
+func TestXAttr_GetMissingReturnsENOATTR(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
 	fs := NewDat9FS(newTestClient("http://localhost"), opts)
@@ -11586,40 +11586,127 @@ func TestXAttr_GetReturnsENOATTR(t *testing.T) {
 	}
 }
 
-func TestXAttr_ListReturnsEmpty(t *testing.T) {
+func TestXAttr_SetGetRoundTrip(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
 	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	fs.inodes.Lookup("/test.txt", false, 0, time.Now())
+	ino, _ := fs.inodes.GetInode("/test.txt")
 
-	n, st := fs.ListXAttr(nil, &gofuse.InHeader{NodeId: 1}, nil)
-	if st != gofuse.OK {
-		t.Fatalf("ListXAttr status = %v, want OK", st)
-	}
-	if n != 0 {
-		t.Fatalf("ListXAttr size = %d, want 0", n)
-	}
-}
-
-func TestXAttr_SetDiscardsSilently(t *testing.T) {
-	opts := &MountOptions{}
-	opts.setDefaults()
-	fs := NewDat9FS(newTestClient("http://localhost"), opts)
-
-	st := fs.SetXAttr(nil, &gofuse.SetXAttrIn{}, "user.test", []byte("val"))
+	st := fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, "user.test", []byte("hello"))
 	if st != gofuse.OK {
 		t.Fatalf("SetXAttr status = %v, want OK", st)
 	}
+
+	n, st := fs.GetXAttr(nil, &gofuse.InHeader{NodeId: ino}, "user.test", nil)
+	if st != gofuse.OK {
+		t.Fatalf("GetXAttr status = %v, want OK", st)
+	}
+	if n != 5 {
+		t.Fatalf("GetXAttr size = %d, want 5", n)
+	}
+
+	dest := make([]byte, 16)
+	n, st = fs.GetXAttr(nil, &gofuse.InHeader{NodeId: ino}, "user.test", dest)
+	if st != gofuse.OK {
+		t.Fatalf("GetXAttr status = %v, want OK", st)
+	}
+	if string(dest[:n]) != "hello" {
+		t.Fatalf("GetXAttr value = %q, want %q", string(dest[:n]), "hello")
+	}
 }
 
-func TestXAttr_RemoveReturnsENOATTR(t *testing.T) {
+func TestXAttr_ListReturnsSetAttrs(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
 	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	fs.inodes.Lookup("/test.txt", false, 0, time.Now())
+	ino, _ := fs.inodes.GetInode("/test.txt")
 
-	st := fs.RemoveXAttr(nil, &gofuse.InHeader{NodeId: 1}, "user.test")
+	_ = fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, "user.foo", []byte("1"))
+	_ = fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, "user.bar", []byte("2"))
+
+	n, st := fs.ListXAttr(nil, &gofuse.InHeader{NodeId: ino}, nil)
+	if st != gofuse.OK {
+		t.Fatalf("ListXAttr status = %v, want OK", st)
+	}
+	// Two names, each null-terminated.
+	expectedSize := len("user.foo") + 1 + len("user.bar") + 1
+	if n != uint32(expectedSize) {
+		t.Fatalf("ListXAttr size = %d, want %d", n, expectedSize)
+	}
+
+	dest := make([]byte, expectedSize)
+	n, st = fs.ListXAttr(nil, &gofuse.InHeader{NodeId: ino}, dest)
+	if st != gofuse.OK {
+		t.Fatalf("ListXAttr status = %v, want OK", st)
+	}
+	// Verify both names appear in the null-separated output.
+	names := strings.Split(strings.TrimRight(string(dest[:n]), "\x00"), "\x00")
+	if !contains(names, "user.foo") || !contains(names, "user.bar") {
+		t.Fatalf("ListXAttr names = %v, want both user.foo and user.bar", names)
+	}
+}
+
+func TestXAttr_RemoveWorks(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	fs.inodes.Lookup("/test.txt", false, 0, time.Now())
+	ino, _ := fs.inodes.GetInode("/test.txt")
+
+	_ = fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, "user.test", []byte("val"))
+
+	st := fs.RemoveXAttr(nil, &gofuse.InHeader{NodeId: ino}, "user.test")
+	if st != gofuse.OK {
+		t.Fatalf("RemoveXAttr status = %v, want OK", st)
+	}
+
+	_, st = fs.GetXAttr(nil, &gofuse.InHeader{NodeId: ino}, "user.test", nil)
+	if st != gofuse.ENOATTR {
+		t.Fatalf("GetXAttr after remove status = %v, want ENOATTR", st)
+	}
+}
+
+func TestXAttr_RemoveMissingReturnsENOATTR(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	fs.inodes.Lookup("/test.txt", false, 0, time.Now())
+	ino, _ := fs.inodes.GetInode("/test.txt")
+
+	st := fs.RemoveXAttr(nil, &gofuse.InHeader{NodeId: ino}, "user.test")
 	if st != gofuse.ENOATTR {
 		t.Fatalf("RemoveXAttr status = %v, want ENOATTR", st)
 	}
+}
+
+func TestXAttr_GetReturnsERANGEWhenDestTooSmall(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	fs.inodes.Lookup("/test.txt", false, 0, time.Now())
+	ino, _ := fs.inodes.GetInode("/test.txt")
+
+	_ = fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, "user.test", []byte("hello world"))
+
+	dest := make([]byte, 3)
+	n, st := fs.GetXAttr(nil, &gofuse.InHeader{NodeId: ino}, "user.test", dest)
+	if st != gofuse.Status(syscall.ERANGE) {
+		t.Fatalf("GetXAttr status = %v, want ERANGE", st)
+	}
+	if n != 11 {
+		t.Fatalf("GetXAttr size = %d, want 11", n)
+	}
+}
+
+func contains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSetAttr_MtimeUpdate(t *testing.T) {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -11709,6 +11709,36 @@ func contains(slice []string, s string) bool {
 	return false
 }
 
+func TestXAttr_RenameMigratesXattrs(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	fs.inodes.Lookup("/old.txt", false, 0, time.Now())
+	oldIno, _ := fs.inodes.GetInode("/old.txt")
+
+	_ = fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: oldIno}}, "user.test", []byte("hello"))
+
+	// Rename the file — xattrs should migrate to the new path.
+	fs.xattrs.Rename("/old.txt", "/new.txt")
+
+	// Old path should have no xattrs.
+	_, st := fs.GetXAttr(nil, &gofuse.InHeader{NodeId: oldIno}, "user.test", nil)
+	if st != gofuse.ENOATTR {
+		t.Errorf("GetXAttr on old path status = %v, want ENOATTR", st)
+	}
+
+	// New path should have the xattr.
+	fs.inodes.Lookup("/new.txt", false, 0, time.Now())
+	newIno, _ := fs.inodes.GetInode("/new.txt")
+	n, st := fs.GetXAttr(nil, &gofuse.InHeader{NodeId: newIno}, "user.test", nil)
+	if st != gofuse.OK {
+		t.Errorf("GetXAttr on new path status = %v, want OK", st)
+	}
+	if n != 5 {
+		t.Errorf("GetXAttr on new path size = %d, want 5", n)
+	}
+}
+
 func TestSetAttr_MtimeUpdate(t *testing.T) {
 	fs, ino, cleanup := newTestDat9FS(t, 42, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(make([]byte, 42))

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -11739,6 +11739,101 @@ func TestXAttr_RenameMigratesXattrs(t *testing.T) {
 	}
 }
 
+func TestXAttr_SetXAttrCreateFlagFailsIfExists(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	fs.inodes.Lookup("/test.txt", false, 0, time.Now())
+	ino, _ := fs.inodes.GetInode("/test.txt")
+
+	// Set initial value.
+	_ = fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, "user.test", []byte("first"))
+
+	// XATTR_CREATE should fail (EEXIST) since attr already exists.
+	st := fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: ino}, Flags: 1}, "user.test", []byte("second"))
+	if st != gofuse.Status(syscall.EEXIST) {
+		t.Errorf("SetXAttr with XATTR_CREATE on existing attr status = %v, want EEXIST", st)
+	}
+
+	// Value should be unchanged.
+	dest := make([]byte, 16)
+	n, _ := fs.GetXAttr(nil, &gofuse.InHeader{NodeId: ino}, "user.test", dest)
+	if string(dest[:n]) != "first" {
+		t.Errorf("value after failed CREATE = %q, want 'first'", string(dest[:n]))
+	}
+}
+
+func TestXAttr_SetXAttrReplaceFlagFailsIfMissing(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	fs.inodes.Lookup("/test.txt", false, 0, time.Now())
+	ino, _ := fs.inodes.GetInode("/test.txt")
+
+	// XATTR_REPLACE should fail (ENODATA) since attr doesn't exist.
+	st := fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: ino}, Flags: 2}, "user.test", []byte("val"))
+	if st != gofuse.Status(syscall.ENODATA) {
+		t.Errorf("SetXAttr with XATTR_REPLACE on missing attr status = %v, want ENODATA", st)
+	}
+
+	// Set then replace — should succeed.
+	_ = fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: ino}}, "user.test", []byte("first"))
+	st = fs.SetXAttr(nil, &gofuse.SetXAttrIn{InHeader: gofuse.InHeader{NodeId: ino}, Flags: 2}, "user.test", []byte("replaced"))
+	if st != gofuse.OK {
+		t.Errorf("SetXAttr with XATTR_REPLACE on existing attr status = %v, want OK", st)
+	}
+	dest := make([]byte, 16)
+	n, _ := fs.GetXAttr(nil, &gofuse.InHeader{NodeId: ino}, "user.test", dest)
+	if string(dest[:n]) != "replaced" {
+		t.Errorf("value after REPLACE = %q, want 'replaced'", string(dest[:n]))
+	}
+}
+
+func TestXAttr_RemoveAllCleansChildren(t *testing.T) {
+	store := NewXAttrStore()
+	store.Set("/dir", "user.dir", []byte("d"))
+	store.Set("/dir/file.txt", "user.file", []byte("f"))
+	store.Set("/dir/sub/inner.txt", "user.inner", []byte("i"))
+
+	// RemoveAll on "/dir" should clear itself and all children.
+	store.RemoveAll("/dir")
+
+	if _, ok := store.Get("/dir", "user.dir"); ok {
+		t.Errorf("xattr on /dir still exists after RemoveAll")
+	}
+	if _, ok := store.Get("/dir/file.txt", "user.file"); ok {
+		t.Errorf("xattr on /dir/file.txt still exists after RemoveAll")
+	}
+	if _, ok := store.Get("/dir/sub/inner.txt", "user.inner"); ok {
+		t.Errorf("xattr on /dir/sub/inner.txt still exists after RemoveAll")
+	}
+}
+
+func TestXAttr_RenameMigratesSubtree(t *testing.T) {
+	store := NewXAttrStore()
+	store.Set("/old", "user.top", []byte("t"))
+	store.Set("/old/child.txt", "user.child", []byte("c"))
+	store.Set("/old/sub/grand.txt", "user.grand", []byte("g"))
+
+	store.Rename("/old", "/new")
+
+	if _, ok := store.Get("/old", "user.top"); ok {
+		t.Errorf("xattr on /old still exists after Rename")
+	}
+	if _, ok := store.Get("/old/child.txt", "user.child"); ok {
+		t.Errorf("xattr on /old/child.txt still exists after Rename")
+	}
+	if v, ok := store.Get("/new", "user.top"); !ok || string(v) != "t" {
+		t.Errorf("xattr not migrated to /new")
+	}
+	if v, ok := store.Get("/new/child.txt", "user.child"); !ok || string(v) != "c" {
+		t.Errorf("xattr not migrated to /new/child.txt")
+	}
+	if v, ok := store.Get("/new/sub/grand.txt", "user.grand"); !ok || string(v) != "g" {
+		t.Errorf("xattr not migrated to /new/sub/grand.txt")
+	}
+}
+
 func TestSetAttr_MtimeUpdate(t *testing.T) {
 	fs, ino, cleanup := newTestDat9FS(t, 42, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(make([]byte, 42))

--- a/pkg/fuse/xattr_store.go
+++ b/pkg/fuse/xattr_store.go
@@ -139,19 +139,37 @@ func (s *XAttrStore) Rename(oldPath, newPath string) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Move the exact path.
+	// POSIX rename replaces the destination object: stale xattrs from the
+	// old destination must not remain visible on the new object. Clear the
+	// destination exact path and its subtree before moving source state.
+	delete(s.data, newPath)
+	newPrefix := newPath + "/"
+	// Collect keys to delete (avoid map mutation during range).
+	var toDelete []string
+	for p := range s.data {
+		if strings.HasPrefix(p, newPrefix) {
+			toDelete = append(toDelete, p)
+		}
+	}
+	for _, p := range toDelete {
+		delete(s.data, p)
+	}
+	// Move the exact path from source to destination.
 	if attrs, ok := s.data[oldPath]; ok {
 		s.data[newPath] = attrs
 		delete(s.data, oldPath)
 	}
 	// Move child paths (directory rename).
 	oldPrefix := oldPath + "/"
-	newPrefix := newPath + "/"
+	var keys []string
 	for p := range s.data {
 		if strings.HasPrefix(p, oldPrefix) {
-			child := newPrefix + strings.TrimPrefix(p, oldPrefix)
-			s.data[child] = s.data[p]
-			delete(s.data, p)
+			keys = append(keys, p)
 		}
+	}
+	for _, p := range keys {
+		child := newPrefix + strings.TrimPrefix(p, oldPrefix)
+		s.data[child] = s.data[p]
+		delete(s.data, p)
 	}
 }

--- a/pkg/fuse/xattr_store.go
+++ b/pkg/fuse/xattr_store.go
@@ -1,7 +1,15 @@
 package fuse
 
 import (
+	"strings"
 	"sync"
+	"syscall"
+)
+
+// XATTR_CREATE and XATTR_REPLACE flag values from Linux's setxattr(2).
+const (
+	xattrCreateFlag  = 1 // XATTR_CREATE
+	xattrReplaceFlag = 2 // XATTR_REPLACE
 )
 
 // XAttrStore provides in-memory extended attribute (xattr) storage for a
@@ -29,14 +37,31 @@ func NewXAttrStore() *XAttrStore {
 	}
 }
 
-// Set stores or replaces the value of attr for the given path.
-func (s *XAttrStore) Set(path, attr string, value []byte) {
+// SetWithFlags stores, creates, or replaces the value of attr for the given
+// path, honoring the XATTR_CREATE and XATTR_REPLACE flags from setxattr(2):
+//   - flags == 0 (neither): set unconditionally (create or replace).
+//   - XATTR_CREATE: fail with EEXIST if the attr already exists.
+//   - XATTR_REPLACE: fail with ENODATA if the attr does not exist.
+func (s *XAttrStore) SetWithFlags(path, attr string, value []byte, flags uint32) syscall.Errno {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.data[path] == nil {
 		s.data[path] = make(map[string][]byte)
 	}
+	_, exists := s.data[path][attr]
+	if flags&xattrCreateFlag != 0 && exists {
+		return syscall.EEXIST
+	}
+	if flags&xattrReplaceFlag != 0 && !exists {
+		return syscall.ENODATA
+	}
 	s.data[path][attr] = append([]byte(nil), value...)
+	return 0
+}
+
+// Set stores or replaces the value of attr for the given path (no flags).
+func (s *XAttrStore) Set(path, attr string, value []byte) {
+	_ = s.SetWithFlags(path, attr, value, 0)
 }
 
 // Get retrieves the value of attr for the given path.
@@ -89,21 +114,41 @@ func (s *XAttrStore) Remove(path, attr string) bool {
 	return true
 }
 
-// RemoveAll deletes all xattrs for the given path.
-// This should be called on Unlink/Rmdir to clean up xattr state.
+// RemoveAll deletes all xattrs for the given path and any paths underneath it
+// (i.e., for a directory path "/foo", also clears "/foo/bar", "/foo/baz/qux", etc.).
+// This should be called on Unlink (file) and Rmdir (directory) to clean up.
 func (s *XAttrStore) RemoveAll(path string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.data, path)
+	// Clean up any child paths (for rmdir of a directory with xattr'd children).
+	prefix := path + "/"
+	for p := range s.data {
+		if strings.HasPrefix(p, prefix) {
+			delete(s.data, p)
+		}
+	}
 }
 
-// Rename moves all xattrs from oldPath to newPath.
+// Rename moves all xattrs from oldPath to newPath, and migrates any child-path
+// xattrs for directory renames (e.g. "/old/" → "/new/" also moves "/old/sub").
 // This should be called on Rename to preserve xattrs across moves.
 func (s *XAttrStore) Rename(oldPath, newPath string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Move the exact path.
 	if attrs, ok := s.data[oldPath]; ok {
 		s.data[newPath] = attrs
 		delete(s.data, oldPath)
+	}
+	// Move child paths (directory rename).
+	oldPrefix := oldPath + "/"
+	newPrefix := newPath + "/"
+	for p := range s.data {
+		if strings.HasPrefix(p, oldPrefix) {
+			child := newPrefix + strings.TrimPrefix(p, oldPrefix)
+			s.data[child] = s.data[p]
+			delete(s.data, p)
+		}
 	}
 }

--- a/pkg/fuse/xattr_store.go
+++ b/pkg/fuse/xattr_store.go
@@ -1,0 +1,92 @@
+package fuse
+
+import (
+	"sync"
+)
+
+// XAttrStore provides in-memory extended attribute (xattr) storage for a
+// FUSE mount session. Xattrs are scoped to file paths and are not persisted
+// to the backend — they exist only for the lifetime of the mount.
+//
+// On Darwin (macOS), the store still works, but callers should filter out
+// system-generated xattr prefixes (com.apple.*, system.*) to avoid
+// polluting results with Finder/Spotlight metadata.
+type XAttrStore struct {
+	mu   sync.RWMutex
+	data map[string]map[string][]byte // path -> attrName -> value
+}
+
+// NewXAttrStore creates a new empty XAttrStore.
+func NewXAttrStore() *XAttrStore {
+	return &XAttrStore{
+		data: make(map[string]map[string][]byte),
+	}
+}
+
+// Set stores or replaces the value of attr for the given path.
+func (s *XAttrStore) Set(path, attr string, value []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.data[path] == nil {
+		s.data[path] = make(map[string][]byte)
+	}
+	s.data[path][attr] = append([]byte(nil), value...)
+}
+
+// Get retrieves the value of attr for the given path.
+// Returns the value and true if the attribute exists, or nil and false otherwise.
+func (s *XAttrStore) Get(path, attr string) ([]byte, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	attrs, ok := s.data[path]
+	if !ok {
+		return nil, false
+	}
+	val, ok := attrs[attr]
+	if !ok {
+		return nil, false
+	}
+	return append([]byte(nil), val...), true
+}
+
+// List returns the names of all xattrs for the given path.
+func (s *XAttrStore) List(path string) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	attrs, ok := s.data[path]
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(attrs))
+	for name := range attrs {
+		names = append(names, name)
+	}
+	return names
+}
+
+// Remove deletes the attr for the given path.
+// Returns true if the attribute existed and was removed.
+func (s *XAttrStore) Remove(path, attr string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	attrs, ok := s.data[path]
+	if !ok {
+		return false
+	}
+	if _, ok := attrs[attr]; !ok {
+		return false
+	}
+	delete(attrs, attr)
+	if len(attrs) == 0 {
+		delete(s.data, path)
+	}
+	return true
+}
+
+// RemoveAll deletes all xattrs for the given path.
+// This should be called on Unlink/Rmdir to clean up xattr state.
+func (s *XAttrStore) RemoveAll(path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, path)
+}

--- a/pkg/fuse/xattr_store.go
+++ b/pkg/fuse/xattr_store.go
@@ -134,6 +134,9 @@ func (s *XAttrStore) RemoveAll(path string) {
 // xattrs for directory renames (e.g. "/old/" → "/new/" also moves "/old/sub").
 // This should be called on Rename to preserve xattrs across moves.
 func (s *XAttrStore) Rename(oldPath, newPath string) {
+	if oldPath == newPath {
+		return // no-op rename; avoid deleting the entry we just assigned
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// Move the exact path.

--- a/pkg/fuse/xattr_store.go
+++ b/pkg/fuse/xattr_store.go
@@ -8,9 +8,15 @@ import (
 // FUSE mount session. Xattrs are scoped to file paths and are not persisted
 // to the backend — they exist only for the lifetime of the mount.
 //
-// On Darwin (macOS), the store still works, but callers should filter out
-// system-generated xattr prefixes (com.apple.*, system.*) to avoid
-// polluting results with Finder/Spotlight metadata.
+// Note: xattrs are keyed by path, not by inode. This means hardlinks (multiple
+// paths to the same inode) get independent xattr sets. This is a deliberate
+// simplification — the primary use case is macOS Finder/Spotlight compatibility
+// and Linux POSIX xattr testing, where per-path semantics are sufficient.
+//
+// On Darwin (macOS), system-generated xattr prefixes (com.apple.*, system.*)
+// are NOT filtered by this store. The FUSE kernel layer handles those before
+// they reach the handler. If explicit filtering becomes needed, it should be
+// added in the GetXAttr/ListXAttr handlers, not in the store.
 type XAttrStore struct {
 	mu   sync.RWMutex
 	data map[string]map[string][]byte // path -> attrName -> value
@@ -89,4 +95,15 @@ func (s *XAttrStore) RemoveAll(path string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.data, path)
+}
+
+// Rename moves all xattrs from oldPath to newPath.
+// This should be called on Rename to preserve xattrs across moves.
+func (s *XAttrStore) Rename(oldPath, newPath string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if attrs, ok := s.data[oldPath]; ok {
+		s.data[newPath] = attrs
+		delete(s.data, oldPath)
+	}
 }


### PR DESCRIPTION
## Problem

`community.pyxattr` failed on the production blackbox run with:
```
os.setxattr(path, name, b'value')  → succeeds
os.getxattr(path, name)           → OSError: [Errno 61] No data available (ENODATA)
```

Root cause: all four xattr FUSE handlers were hardcoded stubs in `pkg/fuse/dat9fs.go`:
- `SetXAttr`: returned `gofuse.OK` but **discarded the value** — no store, no metadata update
- `GetXAttr`: always returned `(0, gofuse.ENOATTR)`
- `ListXAttr`: always returned `(0, gofuse.OK)` (empty)
- `RemoveXAttr`: always returned `gofuse.ENOATTR`

The comment said "macOS Finder/Spotlight compatibility" — they were originally added to suppress macOS system xattr noise, but on Linux they break the real xattr contract. `setxattr` succeeds (stub returns OK) but `getxattr` returns ENOATTR/ENODATA because the value was never stored anywhere.

## How it was found

Ran the blackbox harness (`blackbox/run.py --suite fuse --module community.pyxattr`) on an EC2 machine against `api.drive9.ai`. The module's round-trip test (`setxattr` → `getxattr` → verify) exposed the stub behavior immediately.

## Fix

Implemented session-scoped in-memory xattr storage:

**New file `pkg/fuse/xattr_store.go`**:
- `XAttrStore` struct: `sync.RWMutex` + `map[string]map[string][]byte` (path → attrName → value)
- `Set`, `Get`, `List`, `Remove`, `RemoveAll` methods
- Xattrs exist only for the lifetime of the FUSE mount (not persisted to backend)

**Updated `Dat9FS` in `dat9fs.go`**:
- Added `xattrs *XAttrStore` field, initialized in `NewDat9FS`
- `SetXAttr`: resolves path from `input.NodeId`, stores value, returns OK
- `GetXAttr`: retrieves value; returns ENOATTR if missing, ERANGE if dest buffer too small
- `ListXAttr`: returns null-separated attr names; returns ERANGE if buffer too small
- `RemoveXAttr`: removes attr, returns ENOATTR if not found
- `Unlink` and `Rmdir`: call `xattrs.RemoveAll(childP)` to clean up xattrs for deleted paths

## Tests

Replaced the 4 stub-asserting tests with 6 round-trip tests:
- `TestXAttr_SetGetRoundTrip`: set then get, verify value matches
- `TestXAttr_ListReturnsSetAttrs`: set two attrs, list, verify both names returned
- `TestXAttr_RemoveWorks`: set, remove, get returns ENOATTR
- `TestXAttr_GetMissingReturnsENOATTR`: get on unset attr returns ENOATTR
- `TestXAttr_RemoveMissingReturnsENOATTR`: remove on unset attr returns ENOATTR
- `TestXAttr_GetReturnsERANGEWhenDestTooSmall`: dest buffer too small returns ERANGE + correct size

Full `go test ./pkg/fuse/` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extended attributes in FUSE mounts, including setting, reading, listing, and removing attributes.
  * Extended attributes now persist for the lifetime of a mount and move correctly when files or directories are renamed.

* **Bug Fixes**
  * Improved error handling for missing attributes and small buffers.
  * Removing files or directories now also clears related extended attributes, including nested paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->