### PR TITLE
fix(fuse): prevent writeback deadlock and post-upload chmod stall under concurrent same-file writes

### DIFF
--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1264,7 +1264,20 @@ func (cq *CommitQueue) onCommitSuccess(entry *CommitEntry, expectedRevision, com
 		})
 		cancel()
 		if err != nil {
-			return fmt.Errorf("%w: chmod %s to %o: %w", errCommitPostUpload, entry.Path, mode, err)
+			// Chmod is a best-effort metadata operation. The file data has
+			// already been uploaded successfully. Under concurrent writes to
+			// the same file, the server may have already moved to a newer
+			// revision (or the file may have been replaced), causing the chmod
+			// to fail with "not found". Treating this as a terminal failure
+			// blocks the commit queue path indefinitely and stalls all
+			// subsequent FUSE operations on that path. Instead, log the warning
+			// and proceed — the mode will be applied by the next successful
+			// commit for this path.
+			if client.IsNotFound(err) {
+				log.Printf("commit queue: post-upload chmod not found for %s (concurrent write likely replaced it); proceeding without mode update", entry.Path)
+			} else {
+				return fmt.Errorf("%w: chmod %s to %o: %w", errCommitPostUpload, entry.Path, mode, err)
+			}
 		}
 	}
 

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -967,6 +967,18 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 		cancel()
 
 		if err == nil {
+			// Check if the entry was canceled while the upload was in flight.
+			// If canceled, skip onCommitSuccess entirely — its path-scoped
+			// cleanup (shadowStore.Remove + pendingIndex.Remove) would delete
+			// a newer writer's staged data. The upload already succeeded on the
+			// backend, so we just clean up the queue entry without touching
+			// local shadow/pending state.
+			if cq.isEntryCanceled(entry) {
+				unlockPath()
+				cq.removeFromQueue(entry)
+				log.Printf("commit queue: entry for %s was canceled after upload succeeded, skipping cleanup to preserve newer staged data", entry.Path)
+				return
+			}
 			if err := cq.onCommitSuccess(entry, entry.BaseRev, committedRev); err == nil {
 				unlockPath()
 				return

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -546,6 +546,22 @@ func (cq *CommitQueue) WaitPath(path string) {
 	}
 }
 
+// WaitPathTimeout is like WaitPath but returns false if the path is still
+// busy after pollInterval. Returns true immediately if the path is idle.
+// Callers should use this in a loop with their own deadline to bound wait time.
+func (cq *CommitQueue) WaitPathTimeout(path string, pollInterval time.Duration) bool {
+	cq.mu.Lock()
+	cq.forceDelayedPathLocked(path)
+	_, inflight := cq.inFlight[path]
+	queued := cq.hasQueuedPathLocked(path)
+	cq.mu.Unlock()
+	if !inflight && !queued {
+		return true
+	}
+	time.Sleep(pollInterval)
+	return false
+}
+
 // HasPath reports whether a path is queued or currently in flight.
 func (cq *CommitQueue) HasPath(path string) bool {
 	if cq == nil {

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -2960,7 +2960,9 @@ func TestCommitQueueCanceledInFlightDoesNotRemoveNewerStagedData(t *testing.T) {
 		Mode:    0o644,
 		HasMode: true,
 	}
-	cq.Enqueue(oldEntry)
+	if err := cq.Enqueue(oldEntry); err != nil {
+		t.Fatalf("Enqueue failed: %v", err)
+	}
 
 	// Wait for the upload to start, then cancel the in-flight entry.
 	// This simulates the timeout path in lockWritableRemoteCommitPath calling CancelPath.

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -2899,3 +2899,115 @@ func TestCommitQueueCancelPathStopsDelayedZeroTruncateAndCleansLocal(t *testing.
 		t.Fatal("CancelPath should clean local shadow/pending")
 	}
 }
+
+// TestCommitQueueCanceledInFlightDoesNotRemoveNewerStagedData verifies that
+// when an in-flight commit is canceled after its upload succeeds, its cleanup
+// path (onCommitSuccess) does NOT remove shadowStore/pendingIndex data that a
+// newer writer may have staged for the same path.
+//
+// This is the regression test for the data-loss bug identified in PR #617 review:
+// without the canceled check before onCommitSuccess, the old commit's
+// shadowStore.Remove(path) + pendingIndex.Remove(path) would delete the newer
+// writer's staged data.
+func TestCommitQueueCanceledInFlightDoesNotRemoveNewerStagedData(t *testing.T) {
+	path := "/repo/concurrent.bin"
+
+	// Track whether the upload context was canceled.
+	var uploadCanceled atomic.Bool
+	var uploadStarted atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploadStarted.Store(true)
+		// Simulate a slow upload that will be canceled mid-flight.
+		// The server responds after a short delay so the upload can succeed
+		// before the cancel is processed, exercising the post-upload cancel path.
+		time.Sleep(50 * time.Millisecond)
+		// Check if the request context was canceled.
+		if r.Context().Err() != nil {
+			uploadCanceled.Store(true)
+			http.Error(w, "canceled", http.StatusRequestTimeout)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":1}`))
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Stage old data for the path.
+	if err := shadow.WriteFull(path, []byte("old data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRevAndMode(path, 4, PendingNew, 0, 0o644, true); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	// Enqueue the old commit entry.
+	oldEntry := &CommitEntry{
+		Path:    path,
+		Size:    4,
+		Kind:    PendingNew,
+		Mode:    0o644,
+		HasMode: true,
+	}
+	cq.Enqueue(oldEntry)
+
+	// Wait for the upload to start, then cancel the in-flight entry.
+	// This simulates the timeout path in lockWritableRemoteCommitPath calling CancelPath.
+	deadline := time.Now().Add(2 * time.Second)
+	for !uploadStarted.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !uploadStarted.Load() {
+		t.Fatal("upload did not start within 2s")
+	}
+
+	// Cancel the in-flight commit for this path.
+	cq.CancelPath(path)
+
+	// Now stage newer data (simulating the newer writer proceeding after timeout).
+	// The newer writer writes new content to the same shadow path.
+	newData := []byte("newer data from second writer")
+	if err := shadow.WriteFull(path, newData, 1); err != nil {
+		t.Fatalf("newer writer shadow stage failed: %v", err)
+	}
+	if _, err := pending.PutWithBaseRevAndMode(path, int64(len(newData)), PendingOverwrite, 1, 0o644, true); err != nil {
+		t.Fatalf("newer writer pending stage failed: %v", err)
+	}
+
+	// Wait for the old commit to finish (it may have succeeded or been canceled).
+	cq.DrainAll()
+
+	// Verify the newer staged data survived — the old commit's cleanup
+	// must NOT have removed it.
+	if !shadow.Has(path) {
+		t.Fatal("newer writer's shadow data was removed by old commit cleanup — data loss!")
+	}
+	data, err := shadow.ReadAll(path)
+	if err != nil {
+		t.Fatalf("read shadow after old commit: %v", err)
+	}
+	if string(data) != string(newData) {
+		t.Fatalf("shadow data = %q, want %q (newer writer's data)", string(data), string(newData))
+	}
+	if !pending.HasPending(path) {
+		t.Fatal("newer writer's pending entry was removed by old commit cleanup — data loss!")
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending meta not found after old commit")
+	}
+	if meta.Size != int64(len(newData)) {
+		t.Fatalf("pending size = %d, want %d (newer writer's size)", meta.Size, len(newData))
+	}
+}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -5755,10 +5755,16 @@ func (fs *Dat9FS) lockWritableRemoteCommitPath(p string) func() {
 			// and the timeout is long enough (default 5s) that genuine commits
 			// should normally drain before it fires.
 			//
-			// Use TryLock instead of Lock: if the in-flight worker still holds
-			// the per-path mutex, we proceed without it (no-op unlock) rather
-			// than blocking — blocking here would re-introduce the deadlock.
-			fs.debugf("lockWritableRemoteCommitPath: timeout (%s) waiting for %s, proceeding anyway", timeout, p)
+			// CRITICAL: before proceeding, cancel any in-flight commit for this
+			// path and clean up its shadow/pending state. Without this, the old
+			// commit's onCommitSuccess cleanup (shadowStore.Remove + pendingIndex.Remove)
+			// would delete the newer writer's staged data after it stages — a
+			// silent data-loss bug. Canceling the old entry first ensures its
+			// cleanup runs (or has already run) before the new writer stages.
+			fs.debugf("lockWritableRemoteCommitPath: timeout (%s) waiting for %s, canceling in-flight and proceeding", timeout, p)
+			if fs.commitQueue != nil {
+				fs.commitQueue.CancelPath(p)
+			}
 			unlock, ok := fs.tryLockRemoteCommitPath(p)
 			if ok {
 				return unlock

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -5716,15 +5716,28 @@ func (fs *Dat9FS) lockWritableRemoteCommitPath(p string) func() {
 	if fs == nil || p == "" {
 		return func() {}
 	}
+	var timeout time.Duration
+	if fs.opts != nil {
+		timeout = fs.opts.RemoteCommitWaitTimeout
+	}
+	deadline := time.Now().Add(timeout)
 	for {
+		if timeout > 0 && time.Now().After(deadline) {
+			fs.debugf("lockWritableRemoteCommitPath: timeout (%s) waiting for %s, proceeding anyway", timeout, p)
+			return fs.lockRemoteCommitPath(p)
+		}
 		if fs.commitQueue != nil && fs.commitQueue.HasPath(p) {
-			fs.commitQueue.WaitPath(p)
+			if !fs.commitQueue.WaitPathTimeout(p, 50*time.Millisecond) {
+				continue // timed out this poll, recheck deadline on next loop
+			}
 			continue
 		}
 		unlockRemoteCommit := fs.lockRemoteCommitPath(p)
 		if fs.commitQueue != nil && fs.commitQueue.HasPath(p) {
 			unlockRemoteCommit()
-			fs.commitQueue.WaitPath(p)
+			if !fs.commitQueue.WaitPathTimeout(p, 50*time.Millisecond) {
+				continue
+			}
 			continue
 		}
 		return unlockRemoteCommit

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1885,6 +1885,30 @@ func (fs *Dat9FS) lockRemoteCommitPath(path string) func() {
 	return lock.Unlock
 }
 
+// tryLockRemoteCommitPath attempts to acquire the per-path remote commit
+// lock without blocking. Returns (unlock, true) on success, (nil, false) if
+// the lock is already held.
+func (fs *Dat9FS) tryLockRemoteCommitPath(path string) (func(), bool) {
+	if fs == nil || path == "" {
+		return func() {}, true
+	}
+	fs.remoteCommitMu.Lock()
+	if fs.remoteCommitLocks == nil {
+		fs.remoteCommitLocks = make(map[string]*sync.Mutex)
+	}
+	lock := fs.remoteCommitLocks[path]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		fs.remoteCommitLocks[path] = lock
+	}
+	fs.remoteCommitMu.Unlock()
+
+	if lock.TryLock() {
+		return lock.Unlock, true
+	}
+	return nil, false
+}
+
 func (fs *Dat9FS) adoptCommittedRevisionLocked(fh *FileHandle) {
 	if fs == nil || fh == nil {
 		return
@@ -5723,8 +5747,24 @@ func (fs *Dat9FS) lockWritableRemoteCommitPath(p string) func() {
 	deadline := time.Now().Add(timeout)
 	for {
 		if timeout > 0 && time.Now().After(deadline) {
+			// Proceeding after timeout trades per-path commit ordering for
+			// forward progress. The in-flight background commit may land on
+			// the backend after this newer write, causing a last-writer-wins
+			// inversion (stale overwrite). This is an accepted tradeoff: a
+			// hung FUSE daemon is strictly worse than a potential lost update,
+			// and the timeout is long enough (default 5s) that genuine commits
+			// should normally drain before it fires.
+			//
+			// Use TryLock instead of Lock: if the in-flight worker still holds
+			// the per-path mutex, we proceed without it (no-op unlock) rather
+			// than blocking — blocking here would re-introduce the deadlock.
 			fs.debugf("lockWritableRemoteCommitPath: timeout (%s) waiting for %s, proceeding anyway", timeout, p)
-			return fs.lockRemoteCommitPath(p)
+			unlock, ok := fs.tryLockRemoteCommitPath(p)
+			if ok {
+				return unlock
+			}
+			fs.debugf("lockWritableRemoteCommitPath: per-path lock still held for %s, proceeding without lock", p)
+			return func() {}
 		}
 		if fs.commitQueue != nil && fs.commitQueue.HasPath(p) {
 			if !fs.commitQueue.WaitPathTimeout(p, 50*time.Millisecond) {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -5764,6 +5764,13 @@ func (fs *Dat9FS) lockWritableRemoteCommitPath(p string) func() {
 			fs.debugf("lockWritableRemoteCommitPath: timeout (%s) waiting for %s, canceling in-flight and proceeding", timeout, p)
 			if fs.commitQueue != nil {
 				fs.commitQueue.CancelPath(p)
+				// Wait briefly for the worker to acknowledge cancellation and
+				// exit in-flight state. The worker checks isEntryCanceled before
+				// onCommitSuccess cleanup (skipping cleanup if canceled), so a
+				// short wait here ensures the old entry's cleanup (which could
+				// remove shadow/pending data) has either run or been skipped
+				// before we proceed to stage new data.
+				fs.commitQueue.WaitPathTimeout(p, 100*time.Millisecond)
 			}
 			unlock, ok := fs.tryLockRemoteCommitPath(p)
 			if ok {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -7973,6 +7973,39 @@ func TestWaitQueuedRemoteCommitBeforeWriteBlocksUntilQueuedCommitDone(t *testing
 	}
 }
 
+func TestLockWritableRemoteCommitPathTimeoutProceedsAfterDeadline(t *testing.T) {
+	// Verify that lockWritableRemoteCommitPath returns within a bounded
+	// timeout even when the commit queue never releases the path.
+	path := "/repo/stuck.bin"
+	entry := &CommitEntry{Path: path}
+	cq := &CommitQueue{
+		queue:        []*CommitEntry{entry},
+		queuedByPath: make(map[string]map[*CommitEntry]struct{}),
+		inFlight:     make(map[string]*CommitEntry),
+	}
+	cq.rebuildQueuedIndexLocked()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	// Use a short timeout for the test so we don't wait 30s.
+	opts.RemoteCommitWaitTimeout = 200 * time.Millisecond
+	fs := &Dat9FS{commitQueue: cq, opts: opts}
+	fs.remoteCommitLocks = make(map[string]*sync.Mutex)
+
+	start := time.Now()
+	unlock := fs.lockWritableRemoteCommitPath(path)
+	elapsed := time.Since(start)
+	unlock()
+
+	// Should have waited at least ~200ms (the timeout) but not more than ~2s.
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("lockWritableRemoteCommitPath returned in %s, expected >= 150ms (timeout)", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("lockWritableRemoteCommitPath returned in %s, expected < 2s (timeout bounded)", elapsed)
+	}
+}
+
 func TestCodingAgentLocalOverlayFlushSkipsSyncForGeneratedPath(t *testing.T) {
 	var syncCalls atomic.Int32
 	previousSync := syncOpenLocalFile

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -7975,7 +7975,9 @@ func TestWaitQueuedRemoteCommitBeforeWriteBlocksUntilQueuedCommitDone(t *testing
 
 func TestLockWritableRemoteCommitPathTimeoutProceedsAfterDeadline(t *testing.T) {
 	// Verify that lockWritableRemoteCommitPath returns within a bounded
-	// timeout even when the commit queue never releases the path.
+	// timeout even when the commit queue never releases the path. This covers
+	// BOTH the queued case and the in-flight case (worker holds the per-path
+	// remote commit lock, simulating a slow upload that never completes).
 	path := "/repo/stuck.bin"
 	entry := &CommitEntry{Path: path}
 	cq := &CommitQueue{
@@ -7987,10 +7989,16 @@ func TestLockWritableRemoteCommitPathTimeoutProceedsAfterDeadline(t *testing.T) 
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	// Use a short timeout for the test so we don't wait 30s.
+	// Use a short timeout for the test so we don't wait 5s.
 	opts.RemoteCommitWaitTimeout = 200 * time.Millisecond
 	fs := &Dat9FS{commitQueue: cq, opts: opts}
 	fs.remoteCommitLocks = make(map[string]*sync.Mutex)
+
+	// Pre-lock the per-path remote commit mutex to simulate an in-flight
+	// worker holding the lock during a slow upload. This reproduces the
+	// actual deadlock scenario: the FUSE handler busy-waits holding fh.mu
+	// while the worker holds remoteCommitLocks[path] across a long upload.
+	fs.lockRemoteCommitPath(path)
 
 	start := time.Now()
 	unlock := fs.lockWritableRemoteCommitPath(path)

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -80,7 +80,7 @@ type MountOptions struct {
 	// RemoteCommitWaitTimeout bounds how long a FUSE write/flush handler waits
 	// for a background commit to finish before proceeding anyway. This prevents
 	// the FUSE daemon from hanging indefinitely when a backend upload is slow.
-	// Default 30s; 0 uses default; negative disables the timeout (legacy behavior).
+	// Default 5s; 0 uses default; negative disables the timeout (legacy behavior).
 	RemoteCommitWaitTimeout time.Duration
 }
 
@@ -179,7 +179,7 @@ func (o *MountOptions) setDefaults() {
 		o.Profiling.PerfMaxProfileFiles = defaultPerfMaxProfileFiles
 	}
 	if o.RemoteCommitWaitTimeout == 0 {
-		o.RemoteCommitWaitTimeout = 30 * time.Second
+		o.RemoteCommitWaitTimeout = 5 * time.Second
 	}
 }
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -77,6 +77,11 @@ type MountOptions struct {
 	PerfCounters            bool          // print low-overhead FUSE perf counter summary on shutdown
 	EnableGitWorkspaces     bool          // enable fast-clone git workspace overlay discovery
 	Profiling               ProfilingOptions
+	// RemoteCommitWaitTimeout bounds how long a FUSE write/flush handler waits
+	// for a background commit to finish before proceeding anyway. This prevents
+	// the FUSE daemon from hanging indefinitely when a backend upload is slow.
+	// Default 30s; 0 uses default; negative disables the timeout (legacy behavior).
+	RemoteCommitWaitTimeout time.Duration
 }
 
 const defaultUploadConcurrency = 16
@@ -172,6 +177,9 @@ func (o *MountOptions) setDefaults() {
 	}
 	if o.Profiling.ProfileDir != "" && o.Profiling.PerfMaxProfileFiles <= 0 {
 		o.Profiling.PerfMaxProfileFiles = defaultPerfMaxProfileFiles
+	}
+	if o.RemoteCommitWaitTimeout == 0 {
+		o.RemoteCommitWaitTimeout = 30 * time.Second
 	}
 }
 


### PR DESCRIPTION
## Problem

Two related issues cause the FUSE daemon to stall under concurrent writes to the same file in writeback mode:

1. **`lockWritableRemoteCommitPath` deadlock** (`dat9fs.go:5695`): busy-waits (50ms polls) for the commit queue to release a path **while `fh.mu` is held**. When the commit queue worker holds `remoteCommitLocks[path]` across a slow HTTP upload, the Write/Flush handler busy-waits indefinitely, blocking all FUSE operations on that handle. Under concurrent writes from multiple processes, multiple handles pile up in D state, hanging the FUSE daemon.

2. **Post-upload chmod "not found" stall** (`commit_queue.go`): after successfully uploading a new revision, the commit queue applies a chmod step. Under concurrent same-file writes, a newer revision has already replaced the file on the server, causing the chmod to return "not found". Previously this was treated as a terminal post-upload failure — the commit queue preserved local pending state and retained the path, blocking all subsequent FUSE operations (including reads) on that path indefinitely.

## How it was found

- LTP `ftest01` (multi-process fork test) caused FUSE mount to stop responding in writeback mode.
- Manus customer blackbox `drive9.customer.manus_shared_mount` with `concurrent_same_file=1`: 2 agents concurrently appending to the same file caused the FUSE daemon to hang for 15+ minutes. Minimal repro confirmed: without pre-workload, 3.9s; with pre-workload (130 files written first), write stalls 9-10s per op and read blocks indefinitely.

## Fix (3 commits)

1. **`lockWritableRemoteCommitPath` timeout + TryLock** (`dat9fs.go`, `commit_queue.go`, `mount.go`): Added a deadline (default 5s, configurable via `MountOptions.RemoteCommitWaitTimeout`). When the deadline is reached, use `tryLockRemoteCommitPath` (non-blocking) instead of `lockRemoteCommitPath` (blocking) — if the per-path mutex is still held, proceed without the lock rather than re-deadlocking. Added `WaitPathTimeout` to `CommitQueue` as a non-blocking variant of `WaitPath`.

2. **Post-upload chmod not-found as non-fatal** (`commit_queue.go`): When chmod returns "not found" after a successful upload, log a warning and proceed with the commit (the file data is already uploaded; the mode will be applied by the next successful commit). Other chmod errors (HTTP 500, timeout) remain fatal to preserve existing behavior.

## Verification

- **LTP ftest01**: No longer hangs (was 600s timeout → now passes).
- **Minimal repro** (2 threads × 5 append+read ops, no pre-workload): ALL DONE in 3.9s with v6 binary (was indefinite hang with production binary).
- **Minimal repro with pre-workload** (130 files written first): read completes in 0.3-348ms (was indefinite block); write takes 9-10s per op due to commit queue serialization of pre-workload uploads (expected behavior, not a deadlock).
- **Blackbox concurrent_same_file**: 1KB combo passes (write completes, read completes); subsequent combos slow due to commit queue serialization (~5min each). Not suitable as a fast regression test, but the core deadlock/read-block is resolved.

## Tests

- `TestLockWritableRemoteCommitPathTimeoutProceedsAfterDeadline`: verifies the timeout fires within a bounded window.
- `TestCommitQueueChmodFailureKeepsPendingState`: verifies that non-not-found chmod errors (HTTP 500) still retain pending state (existing behavior preserved).
- Full `go test ./pkg/fuse/` passes.

## Known limitation

After the fixes, concurrent append+read to the same file no longer deadlocks or permanently blocks reads. However, writes are slow (~5-10s per op) when there is a large backlog of pending uploads in the commit queue, because `lockWritableRemoteCommitPath` serializes same-file writes. This is expected behavior — concurrent writes to the same file must serialize through the commit queue. The recommendation is to avoid concurrent writes to the same file at the application level; use last-writer-wins semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `RemoteCommitWaitTimeout` to bound how long file writes/flushes wait for background remote commits.
* **Bug Fixes**
  * Prevented canceled in-flight commits from deleting newer staged data.
  * Improved behavior when post-upload permission updates report “not found,” allowing uploads to complete successfully.
  * Made remote commit waiting and per-path locking more deadline-aware to avoid indefinite blocking.
* **Tests**
  * Added coverage for timeout/unblocking behavior and cancellation safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->