### PR TITLE
Fix fs_events path schema auto-repair

### DIFF
--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -22,7 +22,7 @@ func newTestStoreForEventBus(t *testing.T) *datastore.Store {
 	// Ensure fs_events table exists.
 	if _, err := store.DB().Exec(`CREATE TABLE IF NOT EXISTS fs_events (
 		seq        BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-		path       VARCHAR(512) NOT NULL,
+		path       TEXT NOT NULL,
 		op         VARCHAR(64) NOT NULL,
 		actor      VARCHAR(255),
 		ts         BIGINT NOT NULL,

--- a/pkg/server/sse_test.go
+++ b/pkg/server/sse_test.go
@@ -50,7 +50,7 @@ func newTestStoreForSSE(t *testing.T) *datastore.Store {
 	testmysql.ResetDB(t, store.DB())
 	if _, err := store.DB().Exec(`CREATE TABLE IF NOT EXISTS fs_events (
 		seq        BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-		path       VARCHAR(512) NOT NULL,
+		path       TEXT NOT NULL,
 		op         VARCHAR(64) NOT NULL,
 		actor      VARCHAR(255),
 		ts         BIGINT NOT NULL,

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -2699,6 +2699,8 @@ func isSafeModifyColumnRepairSQL(diff tidbSchemaDiff) bool {
 		return n == "alter table file_nodes modify column parent_path text not null"
 	case "uploads.target_path":
 		return n == "alter table uploads modify column target_path text not null"
+	case "fs_events.path":
+		return n == "alter table fs_events modify column path text not null"
 	default:
 		return false
 	}

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -352,10 +352,16 @@ func TestPlannedTiDBSchemaRepairsAllowsPathColumnWidening(t *testing.T) {
 			columnName: "target_path",
 			repairSQL:  "ALTER TABLE uploads MODIFY COLUMN target_path TEXT NOT NULL",
 		},
+		{
+			kind:       tidbSchemaDiffColumnType,
+			tableName:  "fs_events",
+			columnName: "path",
+			repairSQL:  "ALTER TABLE fs_events MODIFY COLUMN path TEXT NOT NULL",
+		},
 	}
 
 	got := plannedTiDBSchemaRepairs(diffs)
-	if len(got) != 2 {
+	if len(got) != 3 {
 		t.Fatalf("expected path widening repairs, got %#v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- allow TiDB schema ensure to auto-repair fs_events.path from VARCHAR(512) to TEXT
- cover the repair planner path with a regression test
- align event bus and SSE test fixtures with the current fs_events schema

## Tests
- make test TEST_PKGS='./pkg/tenant/schema' TEST_RUN='TestPlannedTiDBSchemaRepairsAllowsPathColumnWidening'
- make test TEST_PKGS='./pkg/server' TEST_RUN='TestEventBus|TestSSE'