### PR TITLE
feat(observability): harden metrics/logs across dependencies, runtime, and process

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/leader"
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/s3client"
 	"github.com/mem9-ai/drive9/pkg/server"
 	"github.com/mem9-ai/drive9/pkg/slockoauth"
@@ -135,6 +136,21 @@ func main() {
 		}
 	}
 	defer func() { _ = store.Close() }()
+
+	// Continuously probe registered databases so that a metadata ("meta") or tenant
+	// ("user") store that becomes unreachable *after* startup is visible via the
+	// drive9_db_up gauge and the access log, not just indirectly through failing
+	// traffic. The probe covers the meta store immediately and tenant pools as they
+	// register. The startup ping above only proves reachability at boot.
+	probeInterval := time.Duration(envInt("DRIVE9_DB_HEALTH_PROBE_INTERVAL_SECONDS", 15)) * time.Second
+	probeTimeout := time.Duration(envInt("DRIVE9_DB_HEALTH_PROBE_TIMEOUT_SECONDS", 3)) * time.Second
+	metrics.StartDBHealthProbe(context.Background(), probeInterval, probeTimeout, func(role string, up bool, err error) {
+		if up {
+			logger.Info(context.Background(), "db_recovered", zap.String("role", role))
+			return
+		}
+		logger.Error(context.Background(), "db_unavailable", zap.String("role", role), zap.Error(err))
+	})
 
 	if s3cfg.Bucket == "" {
 		if err := os.MkdirAll(s3cfg.Dir, 0o755); err != nil {

--- a/pkg/embedding/openai.go
+++ b/pkg/embedding/openai.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 // OpenAIClientConfig configures an OpenAI-compatible embeddings endpoint.
@@ -63,8 +66,32 @@ func NewOpenAIClient(cfg OpenAIClientConfig) (*OpenAIClient, error) {
 	}, nil
 }
 
-// EmbedText implements Client.
+// EmbedText implements Client. It records drive9_service_operations_total and
+// drive9_service_operation_duration_seconds under component="embedding" so the
+// outbound LLM embedding provider's latency and error rate are observable (these
+// calls were previously silent — failures only surfaced indirectly as semantic
+// task retries / extract errors).
 func (c *OpenAIClient) EmbedText(ctx context.Context, text string) ([]float32, error) {
+	start := time.Now()
+	emb, err := c.embedText(ctx, text)
+	metrics.RecordOperation("embedding", "embed_text", embeddingResult(err), time.Since(start))
+	return emb, err
+}
+
+func embeddingResult(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	default:
+		return "error"
+	}
+}
+
+func (c *OpenAIClient) embedText(ctx context.Context, text string) ([]float32, error) {
 	payload := map[string]any{
 		"model": c.model,
 		"input": text,

--- a/pkg/encrypt/factory.go
+++ b/pkg/encrypt/factory.go
@@ -31,6 +31,14 @@ type Config struct {
 }
 
 func New(ctx context.Context, cfg Config) (Encryptor, error) {
+	enc, err := newEncryptor(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return newInstrumentedEncryptor(enc), nil
+}
+
+func newEncryptor(ctx context.Context, cfg Config) (Encryptor, error) {
 	switch strings.ToLower(string(cfg.Type)) {
 	case string(TypeLocalAES), "":
 		if cfg.Key == "" {

--- a/pkg/encrypt/instrumented.go
+++ b/pkg/encrypt/instrumented.go
@@ -1,0 +1,52 @@
+package encrypt
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/metrics"
+)
+
+// instrumentedEncryptor wraps an Encryptor to record drive9_service_operations_total
+// and drive9_service_operation_duration_seconds under component="encrypt". The
+// KMS-backed encryptors (AWS/Aliyun/Tencent) make network calls whose failures
+// (KMS unreachable, throttling, key disabled/rotated) would otherwise be invisible
+// until a tenant's DB password fails to decrypt and the tenant becomes unusable.
+type instrumentedEncryptor struct {
+	inner Encryptor
+}
+
+func newInstrumentedEncryptor(inner Encryptor) Encryptor {
+	if inner == nil {
+		return nil
+	}
+	return &instrumentedEncryptor{inner: inner}
+}
+
+func (e *instrumentedEncryptor) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	start := time.Now()
+	out, err := e.inner.Encrypt(ctx, plaintext)
+	metrics.RecordOperation("encrypt", "encrypt", encryptResult(err), time.Since(start))
+	return out, err
+}
+
+func (e *instrumentedEncryptor) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
+	start := time.Now()
+	out, err := e.inner.Decrypt(ctx, ciphertext)
+	metrics.RecordOperation("encrypt", "decrypt", encryptResult(err), time.Since(start))
+	return out, err
+}
+
+func encryptResult(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	default:
+		return "error"
+	}
+}

--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -208,6 +208,7 @@ func (m *Manager) Stop() {
 		m.isLeader = false
 		cb := m.onLose
 		m.mu.Unlock()
+		recordLeaderState(false)
 		if cb != nil {
 			cb()
 		}
@@ -232,9 +233,10 @@ func (m *Manager) run(workerCtx context.Context) {
 		default:
 		}
 
+		acquireStart := time.Now()
 		acquired, conn, err := m.tryAcquire(workerCtx)
 		if err != nil {
-			metrics.RecordOperation(metricsComponent, "acquire", "error", 0)
+			metrics.RecordOperation(metricsComponent, "acquire", "error", time.Since(acquireStart))
 			recordLeaderState(false)
 			logger.Warn(workerCtx, "leader_acquire_failed",
 				zap.String("lock", m.lockName),
@@ -244,6 +246,7 @@ func (m *Manager) run(workerCtx context.Context) {
 		}
 
 		if acquired {
+			metrics.RecordOperation(metricsComponent, "acquire", "ok", time.Since(acquireStart))
 			m.gainLeadership()
 			m.holdLeadership(workerCtx, conn)
 			// When holdLeadership returns, we lost the lock or ctx was cancelled.
@@ -318,9 +321,10 @@ func (m *Manager) holdLeadership(ctx context.Context, conn *sql.Conn) {
 			return
 		case <-ticker.C:
 			// Keep the connection alive and verify lock ownership in one round-trip.
+			heartbeatStart := time.Now()
 			var ownerID sql.NullInt64
 			if err := conn.QueryRowContext(ctx, isUsedLockSQL, m.lockName).Scan(&ownerID); err != nil {
-				metrics.RecordOperation(metricsComponent, "heartbeat", "error", 0)
+				metrics.RecordOperation(metricsComponent, "heartbeat", "error", time.Since(heartbeatStart))
 				logger.Warn(ctx, "leader_heartbeat_failed",
 					zap.String("lock", m.lockName),
 					zap.Error(err))
@@ -341,8 +345,9 @@ func (m *Manager) holdLeadership(ctx context.Context, conn *sql.Conn) {
 				return
 			}
 			// Keep the connection alive to prevent wait_timeout from closing it.
+			keepaliveStart := time.Now()
 			if _, err := conn.ExecContext(ctx, keepAliveSQL); err != nil {
-				metrics.RecordOperation(metricsComponent, "keepalive", "error", 0)
+				metrics.RecordOperation(metricsComponent, "keepalive", "error", time.Since(keepaliveStart))
 				logger.Warn(ctx, "leader_keepalive_failed",
 					zap.String("lock", m.lockName),
 					zap.Error(err))
@@ -370,7 +375,6 @@ func (m *Manager) gainLeadership() {
 	cb := m.onLead
 	m.mu.Unlock()
 	recordLeaderState(true)
-	metrics.RecordOperation(metricsComponent, "acquire", "ok", 0)
 	if !wasLeader && cb != nil {
 		logger.Info(context.Background(), "leader_gained",
 			zap.String("lock", m.lockName))

--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -12,8 +12,23 @@ import (
 	"time"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"go.uber.org/zap"
 )
+
+// metricsComponent is the metrics component name for leader election. It exposes
+// drive9_service_gauge{component="leader",name="is_leader"} (1 on the pod that
+// currently holds the lock, 0 on followers), so the fleet can be alerted when no
+// pod is leader and all leader-gated background workers have stalled.
+const metricsComponent = "leader"
+
+func recordLeaderState(isLeader bool) {
+	if isLeader {
+		metrics.RecordGauge(metricsComponent, "is_leader", 1)
+		return
+	}
+	metrics.RecordGauge(metricsComponent, "is_leader", 0)
+}
 
 const (
 	// defaultLockName is the named lock used for leader election.
@@ -167,6 +182,9 @@ func (m *Manager) Start(ctx context.Context) {
 		m.isLeader = true
 		cb := m.onLead
 		m.mu.Unlock()
+		// Single-pod mode is always the leader; publish it so the no-leader
+		// alert never false-fires against a healthy single-pod deployment.
+		recordLeaderState(true)
 		if cb != nil {
 			cb()
 		}
@@ -216,6 +234,8 @@ func (m *Manager) run(workerCtx context.Context) {
 
 		acquired, conn, err := m.tryAcquire(workerCtx)
 		if err != nil {
+			metrics.RecordOperation(metricsComponent, "acquire", "error", 0)
+			recordLeaderState(false)
 			logger.Warn(workerCtx, "leader_acquire_failed",
 				zap.String("lock", m.lockName),
 				zap.Error(err))
@@ -230,7 +250,8 @@ func (m *Manager) run(workerCtx context.Context) {
 			m.loseLeadership()
 			m.releaseConn(conn)
 		} else {
-			// Someone else holds the lock. Release the conn and retry.
+			// Someone else holds the lock. Publish follower state and retry.
+			recordLeaderState(false)
 			m.releaseConn(conn)
 			m.sleep(workerCtx, m.interval)
 		}
@@ -299,6 +320,7 @@ func (m *Manager) holdLeadership(ctx context.Context, conn *sql.Conn) {
 			// Keep the connection alive and verify lock ownership in one round-trip.
 			var ownerID sql.NullInt64
 			if err := conn.QueryRowContext(ctx, isUsedLockSQL, m.lockName).Scan(&ownerID); err != nil {
+				metrics.RecordOperation(metricsComponent, "heartbeat", "error", 0)
 				logger.Warn(ctx, "leader_heartbeat_failed",
 					zap.String("lock", m.lockName),
 					zap.Error(err))
@@ -320,6 +342,7 @@ func (m *Manager) holdLeadership(ctx context.Context, conn *sql.Conn) {
 			}
 			// Keep the connection alive to prevent wait_timeout from closing it.
 			if _, err := conn.ExecContext(ctx, keepAliveSQL); err != nil {
+				metrics.RecordOperation(metricsComponent, "keepalive", "error", 0)
 				logger.Warn(ctx, "leader_keepalive_failed",
 					zap.String("lock", m.lockName),
 					zap.Error(err))
@@ -346,6 +369,8 @@ func (m *Manager) gainLeadership() {
 	m.isLeader = true
 	cb := m.onLead
 	m.mu.Unlock()
+	recordLeaderState(true)
+	metrics.RecordOperation(metricsComponent, "acquire", "ok", 0)
 	if !wasLeader && cb != nil {
 		logger.Info(context.Background(), "leader_gained",
 			zap.String("lock", m.lockName))
@@ -360,6 +385,7 @@ func (m *Manager) loseLeadership() {
 	m.ownConnID = 0
 	cb := m.onLose
 	m.mu.Unlock()
+	recordLeaderState(false)
 	if wasLeader && cb != nil {
 		logger.Info(context.Background(), "leader_lost",
 			zap.String("lock", m.lockName))

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net/http"
@@ -8,9 +9,20 @@ import (
 	"time"
 )
 
+// dbProbeState is the cached result of the most recent health probe for a role.
+type dbProbeState struct {
+	up               bool
+	unreachablePools int
+	totalPools       int
+	lastProbe        time.Time
+	known            bool
+}
+
 type dbMetrics struct {
-	mu  sync.RWMutex
-	dbs map[*sql.DB]string
+	mu      sync.RWMutex
+	dbs     map[*sql.DB]string
+	probe   map[string]dbProbeState
+	started bool
 }
 
 type dbPoolTotals struct {
@@ -27,14 +39,24 @@ type dbPoolTotals struct {
 }
 
 var dbOperationDurationBounds = []float64{0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
+var dbProbeDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
 
 var globalDB = &dbMetrics{
-	dbs: map[*sql.DB]string{},
+	dbs:   map[*sql.DB]string{},
+	probe: map[string]dbProbeState{},
 }
 
 var dbMeter = globalMeterProvider.Meter("db")
 var dbOperationsTotal = dbMeter.Int64Counter("drive9_db_operations_total", "Database operations by role/operation/result")
 var dbOperationDuration = dbMeter.Float64Histogram("drive9_db_operation_duration_seconds", "Database operation duration histogram", dbOperationDurationBounds)
+var dbProbeDuration = dbMeter.Float64Histogram("drive9_db_probe_duration_seconds", "Database health probe ping duration histogram by role/result", dbProbeDurationBounds)
+
+// DefaultDBHealthProbeInterval and DefaultDBHealthProbeTimeout are the fallbacks
+// used by StartDBHealthProbe when callers pass non-positive values.
+const (
+	DefaultDBHealthProbeInterval = 15 * time.Second
+	DefaultDBHealthProbeTimeout  = 3 * time.Second
+)
 
 func RecordDBOperation(role, operation, result string, d time.Duration) {
 	RegisterModule("db")
@@ -66,6 +88,128 @@ func UnregisterDB(db *sql.DB) {
 	globalDB.mu.Unlock()
 }
 
+// StartDBHealthProbe launches a background goroutine that periodically pings every
+// registered *sql.DB and publishes a per-role availability signal as the
+// drive9_db_up gauge. It is the active dependency-health probe for the metadata
+// store ("meta") and tenant data stores ("user"): pool/operation metrics only move
+// while there is live traffic, so an idle-but-unreachable database is otherwise
+// invisible.
+//
+// The probe never blocks the /metrics scrape path — scrapes read the cached probe
+// state. onChange (optional) is invoked outside the lock on a role's first observed
+// failure and on every subsequent up<->down transition, so callers can emit a log
+// without coupling this package to a logger. The goroutine stops when ctx is done;
+// repeat calls after the first are no-ops.
+//
+// Example alert (critical — control-plane DB unreachable):
+//
+//	max(drive9_db_up{role="meta"}) == 0
+func StartDBHealthProbe(ctx context.Context, interval, timeout time.Duration, onChange func(role string, up bool, err error)) {
+	if interval <= 0 {
+		interval = DefaultDBHealthProbeInterval
+	}
+	if timeout <= 0 {
+		timeout = DefaultDBHealthProbeTimeout
+	}
+
+	globalDB.mu.Lock()
+	if globalDB.started {
+		globalDB.mu.Unlock()
+		return
+	}
+	globalDB.started = true
+	globalDB.mu.Unlock()
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		globalDB.probeOnce(ctx, timeout, onChange)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				globalDB.probeOnce(ctx, timeout, onChange)
+			}
+		}
+	}()
+}
+
+// probeOnce runs a single probe cycle across all registered pools and updates the
+// cached per-role state. Exported indirectly for tests via probeOnce.
+func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChange func(role string, up bool, err error)) {
+	m.mu.RLock()
+	dbByRole := make(map[*sql.DB]string, len(m.dbs))
+	for db, role := range m.dbs {
+		dbByRole[db] = role
+	}
+	m.mu.RUnlock()
+
+	type roleAgg struct {
+		total       int
+		unreachable int
+		firstErr    error
+	}
+	results := map[string]*roleAgg{}
+	for db, role := range dbByRole {
+		agg := results[role]
+		if agg == nil {
+			agg = &roleAgg{}
+			results[role] = agg
+		}
+		agg.total++
+
+		pingCtx, cancel := context.WithTimeout(ctx, timeout)
+		start := time.Now()
+		err := db.PingContext(pingCtx)
+		cancel()
+
+		result := "ok"
+		if err != nil {
+			result = "error"
+			agg.unreachable++
+			if agg.firstErr == nil {
+				agg.firstErr = err
+			}
+		}
+		dbProbeDuration.Observe(time.Since(start).Seconds(), Attr("role", role), Attr("result", result))
+	}
+
+	type transition struct {
+		role string
+		up   bool
+		err  error
+	}
+	var transitions []transition
+	now := time.Now()
+
+	m.mu.Lock()
+	if m.probe == nil {
+		m.probe = map[string]dbProbeState{}
+	}
+	for role, agg := range results {
+		up := agg.unreachable == 0
+		prev, existed := m.probe[role]
+		m.probe[role] = dbProbeState{
+			up:               up,
+			unreachablePools: agg.unreachable,
+			totalPools:       agg.total,
+			lastProbe:        now,
+			known:            true,
+		}
+		// Fire on the first observed failure, and on every up<->down change
+		// thereafter. A first observation that is healthy is not a transition.
+		if onChange != nil && ((!existed && !up) || (existed && prev.up != up)) {
+			transitions = append(transitions, transition{role: role, up: up, err: agg.firstErr})
+		}
+	}
+	m.mu.Unlock()
+
+	for _, t := range transitions {
+		onChange(t.role, t.up, t.err)
+	}
+}
+
 func writeDBPrometheus(w http.ResponseWriter) {
 	globalDB.mu.RLock()
 	dbByRole := make(map[*sql.DB]string, len(globalDB.dbs))
@@ -91,6 +235,37 @@ func writeDBPrometheus(w http.ResponseWriter) {
 		poolTotals[role] = totals
 	}
 	roles := SortedKeys(poolTotals)
+
+	globalDB.mu.RLock()
+	probeByRole := make(map[string]dbProbeState, len(globalDB.probe))
+	for role, state := range globalDB.probe {
+		probeByRole[role] = state
+	}
+	globalDB.mu.RUnlock()
+
+	// drive9_db_up is the active availability signal: 1 when every registered pool
+	// for the role answered its last health ping, 0 when any pool is unreachable.
+	// Roles not yet probed default to 1 (the startup ping already succeeded), so the
+	// `== 0` alert never fires on a cold series.
+	_, _ = fmt.Fprintln(w, "# HELP drive9_db_up Database availability by role (1 = all registered pools reachable on last probe)")
+	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_up gauge")
+	for _, role := range roles {
+		up := 1.0
+		if state, ok := probeByRole[role]; ok && state.known && !state.up {
+			up = 0.0
+		}
+		_, _ = fmt.Fprintf(w, "drive9_db_up{role=\"%s\"} %s\n", EscapePromLabel(role), formatFloat(up))
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP drive9_db_unreachable_pools Registered pools that failed their last health probe by role")
+	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_unreachable_pools gauge")
+	for _, role := range roles {
+		unreachable := 0
+		if state, ok := probeByRole[role]; ok && state.known {
+			unreachable = state.unreachablePools
+		}
+		_, _ = fmt.Fprintf(w, "drive9_db_unreachable_pools{role=\"%s\"} %d\n", EscapePromLabel(role), unreachable)
+	}
 
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_registered Database pools currently registered for metrics by role")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_registered gauge")

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -173,6 +173,18 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 			defer wg.Done()
 			defer func() { <-sem }()
 
+			// PingContext borrows a connection from the pool (reusing an idle one,
+			// else opening a new one when under MaxOpenConns) and returns it
+			// immediately, so each cycle adds a transient +1 connection per pinged
+			// pool — at most probeConcurrency in flight cluster-wide. Any opened
+			// conn is later reaped by ConnMaxIdleTime.
+			//
+			// Caveat: on a pool with an explicit MaxOpenConns that is fully checked
+			// out, PingContext blocks for a free slot and may hit `timeout`,
+			// recording the pool as unreachable when it is merely saturated. This is
+			// rarely hit because ApplyPoolDefaults leaves MaxOpenConns unlimited
+			// unless DRIVE9_DB_MAX_OPEN_CONNS is set; the pool-saturation alert
+			// covers that condition directly.
 			pingCtx, cancel := context.WithTimeout(ctx, timeout)
 			start := time.Now()
 			err := db.PingContext(pingCtx)

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -151,29 +151,48 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 		firstErr    error
 	}
 	results := map[string]*roleAgg{}
-	for db, role := range dbByRole {
-		agg := results[role]
-		if agg == nil {
-			agg = &roleAgg{}
-			results[role] = agg
+	for _, role := range dbByRole {
+		if results[role] == nil {
+			results[role] = &roleAgg{}
 		}
-		agg.total++
-
-		pingCtx, cancel := context.WithTimeout(ctx, timeout)
-		start := time.Now()
-		err := db.PingContext(pingCtx)
-		cancel()
-
-		result := "ok"
-		if err != nil {
-			result = "error"
-			agg.unreachable++
-			if agg.firstErr == nil {
-				agg.firstErr = err
-			}
-		}
-		dbProbeDuration.Observe(time.Since(start).Seconds(), Attr("role", role), Attr("result", result))
+		results[role].total++
 	}
+
+	// Ping pools concurrently with a fixed bound so one slow/unreachable pool
+	// cannot serialize the whole cycle: with many unreachable tenant ("user")
+	// pools a serial loop would burn timeout*N and leave drive9_db_up stale.
+	const probeConcurrency = 8
+	sem := make(chan struct{}, probeConcurrency)
+	var wg sync.WaitGroup
+	var aggMu sync.Mutex
+	for db, role := range dbByRole {
+		db, role := db, role
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			pingCtx, cancel := context.WithTimeout(ctx, timeout)
+			start := time.Now()
+			err := db.PingContext(pingCtx)
+			cancel()
+
+			result := "ok"
+			if err != nil {
+				result = "error"
+				aggMu.Lock()
+				agg := results[role]
+				agg.unreachable++
+				if agg.firstErr == nil {
+					agg.firstErr = err
+				}
+				aggMu.Unlock()
+			}
+			dbProbeDuration.Observe(time.Since(start).Seconds(), Attr("role", cleanMetricValue(role, "unknown")), Attr("result", result))
+		}()
+	}
+	wg.Wait()
 
 	type transition struct {
 		role string

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -1,0 +1,125 @@
+package metrics
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeConnector is a minimal database/sql driver whose reachability can be
+// toggled at runtime so the health probe can be exercised without a real MySQL.
+type fakeConnector struct {
+	healthy *atomic.Bool
+}
+
+func (c fakeConnector) Connect(context.Context) (driver.Conn, error) {
+	if !c.healthy.Load() {
+		return nil, errors.New("fake db unreachable")
+	}
+	return fakeConn{healthy: c.healthy}, nil
+}
+
+func (c fakeConnector) Driver() driver.Driver { return fakeDriver{} }
+
+type fakeDriver struct{}
+
+func (fakeDriver) Open(string) (driver.Conn, error) { return nil, errors.New("not supported") }
+
+type fakeConn struct {
+	healthy *atomic.Bool
+}
+
+func (fakeConn) Prepare(string) (driver.Stmt, error) { return nil, errors.New("not supported") }
+func (fakeConn) Close() error                        { return nil }
+func (fakeConn) Begin() (driver.Tx, error)           { return nil, errors.New("not supported") }
+
+func (c fakeConn) Ping(context.Context) error {
+	if !c.healthy.Load() {
+		return driver.ErrBadConn
+	}
+	return nil
+}
+
+func renderDB(t *testing.T) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	writeDBPrometheus(rec)
+	return rec.Body.String()
+}
+
+func TestDBHealthProbeFlipsDriveDBUp(t *testing.T) {
+	const role = "probe_test_role"
+
+	healthy := &atomic.Bool{}
+	healthy.Store(true)
+	db := sql.OpenDB(fakeConnector{healthy: healthy})
+	// Force a fresh connection per ping so toggling health takes effect immediately.
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() { UnregisterDB(db); _ = db.Close() })
+
+	RegisterDB(role, db)
+
+	var mu sync.Mutex
+	type change struct {
+		up  bool
+		err error
+	}
+	var changes []change
+	onChange := func(r string, up bool, err error) {
+		if r != role {
+			return
+		}
+		mu.Lock()
+		changes = append(changes, change{up: up, err: err})
+		mu.Unlock()
+	}
+
+	// 1) First probe while healthy: up=1, no transition logged.
+	globalDB.probeOnce(context.Background(), time.Second, onChange)
+	if out := renderDB(t); !strings.Contains(out, `drive9_db_up{role="`+role+`"} 1`) {
+		t.Fatalf("expected drive9_db_up=1 after healthy probe, got:\n%s", out)
+	}
+	mu.Lock()
+	if len(changes) != 0 {
+		mu.Unlock()
+		t.Fatalf("expected no transition on first healthy probe, got %+v", changes)
+	}
+	mu.Unlock()
+
+	// 2) Database goes down: up=0, one down transition.
+	healthy.Store(false)
+	globalDB.probeOnce(context.Background(), time.Second, onChange)
+	out := renderDB(t)
+	if !strings.Contains(out, `drive9_db_up{role="`+role+`"} 0`) {
+		t.Fatalf("expected drive9_db_up=0 after failed probe, got:\n%s", out)
+	}
+	if !strings.Contains(out, `drive9_db_unreachable_pools{role="`+role+`"} 1`) {
+		t.Fatalf("expected drive9_db_unreachable_pools=1, got:\n%s", out)
+	}
+
+	// 3) Database recovers: up=1, one up transition.
+	healthy.Store(true)
+	globalDB.probeOnce(context.Background(), time.Second, onChange)
+	if out := renderDB(t); !strings.Contains(out, `drive9_db_up{role="`+role+`"} 1`) {
+		t.Fatalf("expected drive9_db_up=1 after recovery, got:\n%s", out)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(changes) != 2 {
+		t.Fatalf("expected exactly 2 transitions (down, up), got %+v", changes)
+	}
+	if changes[0].up || changes[0].err == nil {
+		t.Fatalf("expected first transition to be down with an error, got %+v", changes[0])
+	}
+	if !changes[1].up {
+		t.Fatalf("expected second transition to be up, got %+v", changes[1])
+	}
+}

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -23,7 +23,7 @@ func (c fakeConnector) Connect(context.Context) (driver.Conn, error) {
 	if !c.healthy.Load() {
 		return nil, errors.New("fake db unreachable")
 	}
-	return fakeConn{healthy: c.healthy}, nil
+	return fakeConn(c), nil
 }
 
 func (c fakeConnector) Driver() driver.Driver { return fakeDriver{} }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -217,6 +217,8 @@ func WritePrometheus(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
 	globalRegistry.WritePrometheus(w)
 	writeDBPrometheus(w)
+	writeRuntimeMetrics(w)
+	writeProcessMetrics(w)
 }
 
 func cleanMetricValue(value, fallback string) string {

--- a/pkg/metrics/process.go
+++ b/pkg/metrics/process.go
@@ -1,0 +1,110 @@
+package metrics
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// userHZ is the Linux clock-tick frequency assumed for converting /proc CPU
+// counters to seconds. It is 100 on effectively all Linux kernels drive9 runs on
+// (the value sysconf(_SC_CLK_TCK) returns); reading it precisely needs cgo, which
+// this pure-Go collector avoids.
+const userHZ = 100.0
+
+// writeProcessMetrics exports OS process performance/saturation signals using the
+// conventional process_* metric names (CPU, resident/virtual memory, and file
+// descriptors), matching client_golang's process collector so standard dashboards
+// and the FD-exhaustion / CPU-saturation alerts work. Without this the process
+// exported no CPU or file-descriptor metrics at all.
+//
+// Linux-only: it reads /proc/self. On other platforms (local dev on macOS) /proc
+// is absent and the function emits nothing rather than failing.
+func writeProcessMetrics(w io.Writer) {
+	if w == nil {
+		return
+	}
+	stat, err := os.ReadFile("/proc/self/stat")
+	if err != nil {
+		return // not Linux / no procfs: skip process metrics
+	}
+	ps, ok := parseProcStat(string(stat))
+	if !ok {
+		return
+	}
+
+	writeRuntimeCounter(w, "process_cpu_seconds_total", "Total user and system CPU time spent in seconds", ps.cpuSeconds)
+	writeRuntimeGauge(w, "process_resident_memory_bytes", "Resident memory size in bytes", ps.residentBytes)
+	writeRuntimeGauge(w, "process_virtual_memory_bytes", "Virtual memory size in bytes", ps.virtualBytes)
+
+	if openFDs, ok := openFileDescriptors(); ok {
+		writeRuntimeGauge(w, "process_open_fds", "Number of open file descriptors", float64(openFDs))
+	}
+	if maxFDs, ok := maxFileDescriptors(); ok {
+		writeRuntimeGauge(w, "process_max_fds", "Maximum number of open file descriptors", float64(maxFDs))
+	}
+}
+
+type procStat struct {
+	cpuSeconds    float64
+	residentBytes float64
+	virtualBytes  float64
+}
+
+// parseProcStat extracts CPU and memory fields from a /proc/<pid>/stat line.
+// The 2nd field (comm) may contain spaces and parentheses, so fields are taken
+// from after the final ')'. Field numbers are 1-based per proc(5):
+// utime=14, stime=15, vsize=23, rss=24 (in pages).
+func parseProcStat(data string) (procStat, bool) {
+	rparen := strings.LastIndex(data, ")")
+	if rparen < 0 || rparen+2 >= len(data) {
+		return procStat{}, false
+	}
+	fields := strings.Fields(data[rparen+2:])
+	// After comm, index 0 == field 3 (state); field N -> index N-3.
+	const (
+		idxUtime = 14 - 3
+		idxStime = 15 - 3
+		idxVsize = 23 - 3
+		idxRss   = 24 - 3
+	)
+	if len(fields) <= idxRss {
+		return procStat{}, false
+	}
+	utime, err1 := strconv.ParseFloat(fields[idxUtime], 64)
+	stime, err2 := strconv.ParseFloat(fields[idxStime], 64)
+	vsize, err3 := strconv.ParseFloat(fields[idxVsize], 64)
+	rssPages, err4 := strconv.ParseFloat(fields[idxRss], 64)
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		return procStat{}, false
+	}
+	return procStat{
+		cpuSeconds:    (utime + stime) / userHZ,
+		residentBytes: rssPages * float64(os.Getpagesize()),
+		virtualBytes:  vsize,
+	}, true
+}
+
+func openFileDescriptors() (int, bool) {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return 0, false
+	}
+	// Subtract 1 for the fd opened by ReadDir itself (best-effort, matches
+	// client_golang's behaviour closely enough for saturation alerting).
+	n := len(entries)
+	if n > 0 {
+		n--
+	}
+	return n, true
+}
+
+func maxFileDescriptors() (uint64, bool) {
+	var rl syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl); err != nil {
+		return 0, false
+	}
+	return uint64(rl.Cur), true
+}

--- a/pkg/metrics/process.go
+++ b/pkg/metrics/process.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 // userHZ is the Linux clock-tick frequency assumed for converting /proc CPU
@@ -101,10 +100,5 @@ func openFileDescriptors() (int, bool) {
 	return n, true
 }
 
-func maxFileDescriptors() (uint64, bool) {
-	var rl syscall.Rlimit
-	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl); err != nil {
-		return 0, false
-	}
-	return uint64(rl.Cur), true
-}
+// maxFileDescriptors is implemented per-platform (process_unix.go / process_other.go)
+// because the RLIMIT_NOFILE syscall constants do not exist on Windows.

--- a/pkg/metrics/process_other.go
+++ b/pkg/metrics/process_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package metrics
+
+// maxFileDescriptors is unsupported off-Unix; process metrics are Linux-only in
+// practice (they read /proc), so the fd-limit gauge is simply omitted there.
+func maxFileDescriptors() (uint64, bool) {
+	return 0, false
+}

--- a/pkg/metrics/process_test.go
+++ b/pkg/metrics/process_test.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseProcStat(t *testing.T) {
+	// Synthetic /proc/self/stat line. comm "(dr ive9)" deliberately contains a
+	// space and parens to exercise the after-last-')' parsing. utime=200,
+	// stime=100 (-> (200+100)/100 = 3.0s), vsize=1048576, rss=10 pages.
+	line := "1234 (dr ive9) R 1 1234 1234 0 -1 0 0 0 0 0 200 100 0 0 20 0 1 0 5000 1048576 10 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n"
+	ps, ok := parseProcStat(line)
+	if !ok {
+		t.Fatalf("parseProcStat returned ok=false for valid line")
+	}
+	if ps.cpuSeconds != 3.0 {
+		t.Fatalf("cpuSeconds = %v, want 3.0", ps.cpuSeconds)
+	}
+	if ps.virtualBytes != 1048576 {
+		t.Fatalf("virtualBytes = %v, want 1048576", ps.virtualBytes)
+	}
+	wantRSS := 10.0 * float64(os.Getpagesize())
+	if ps.residentBytes != wantRSS {
+		t.Fatalf("residentBytes = %v, want %v", ps.residentBytes, wantRSS)
+	}
+}
+
+func TestParseProcStatMalformed(t *testing.T) {
+	if _, ok := parseProcStat("garbage-without-paren"); ok {
+		t.Fatalf("expected ok=false for line without ')'")
+	}
+	if _, ok := parseProcStat("1 (x) R 1 2 3"); ok {
+		t.Fatalf("expected ok=false for truncated line")
+	}
+}

--- a/pkg/metrics/process_unix.go
+++ b/pkg/metrics/process_unix.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package metrics
+
+import "syscall"
+
+// maxFileDescriptors returns the soft RLIMIT_NOFILE on Unix platforms.
+func maxFileDescriptors() (uint64, bool) {
+	var rl syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl); err != nil {
+		return 0, false
+	}
+	return uint64(rl.Cur), true
+}

--- a/pkg/metrics/runtime.go
+++ b/pkg/metrics/runtime.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"runtime/pprof"
+)
+
+// writeRuntimeMetrics exports Go runtime saturation/health signals using the
+// conventional go_* metric names, so the standard Go runtime dashboards
+// (Grafana 6671 / 10826) and the goroutine-leak / GC-pressure alerts work out of
+// the box. The custom drive9 registry does not pull in client_golang's default
+// collectors, so without this the process exports no go_goroutines, heap, thread,
+// or GC metrics at all — the "Saturation" golden signal had no runtime coverage.
+//
+// Read on the scrape path (like client_golang). ReadMemStats briefly stops the
+// world; at a 15-30s scrape interval the cost is negligible.
+func writeRuntimeMetrics(w io.Writer) {
+	if w == nil {
+		return
+	}
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	writeRuntimeGauge(w, "go_goroutines", "Number of goroutines that currently exist", float64(runtime.NumGoroutine()))
+	writeRuntimeGauge(w, "go_threads", "Number of OS threads created", float64(pprof.Lookup("threadcreate").Count()))
+	writeRuntimeGauge(w, "go_memstats_alloc_bytes", "Number of bytes allocated and still in use", float64(ms.Alloc))
+	writeRuntimeGauge(w, "go_memstats_heap_inuse_bytes", "Number of heap bytes that are in use", float64(ms.HeapInuse))
+	writeRuntimeGauge(w, "go_memstats_heap_sys_bytes", "Number of heap bytes obtained from system", float64(ms.HeapSys))
+	writeRuntimeGauge(w, "go_memstats_sys_bytes", "Number of bytes obtained from system", float64(ms.Sys))
+	writeRuntimeGauge(w, "go_memstats_next_gc_bytes", "Number of heap bytes when next GC will take place", float64(ms.NextGC))
+
+	writeRuntimeCounter(w, "go_gc_runs_total", "Total number of completed GC cycles", float64(ms.NumGC))
+	writeRuntimeCounter(w, "go_gc_pause_seconds_total", "Cumulative stop-the-world GC pause time in seconds", float64(ms.PauseTotalNs)/1e9)
+}
+
+func writeRuntimeGauge(w io.Writer, name, help string, value float64) {
+	_, _ = fmt.Fprintf(w, "# HELP %s %s\n", name, help)
+	_, _ = fmt.Fprintf(w, "# TYPE %s gauge\n", name)
+	_, _ = fmt.Fprintf(w, "%s %s\n", name, formatFloat(value))
+}
+
+func writeRuntimeCounter(w io.Writer, name, help string, value float64) {
+	_, _ = fmt.Fprintf(w, "# HELP %s %s\n", name, help)
+	_, _ = fmt.Fprintf(w, "# TYPE %s counter\n", name)
+	_, _ = fmt.Fprintf(w, "%s %s\n", name, formatFloat(value))
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1250,6 +1250,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	tok := bearerToken(r)
 	if tok == "" {
+		metricEvent(r.Context(), "auth", "result", "missing_token")
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_missing_token")...)
 		errJSON(w, http.StatusUnauthorized, "missing or malformed Authorization header")
 		return
@@ -1258,43 +1259,51 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 	resolved, err := s.meta.ResolveByAPIKeyHash(r.Context(), token.HashToken(tok))
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
+			metricEvent(r.Context(), "auth", "result", "key_not_found")
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_key_not_found")...)
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
+		metricEvent(r.Context(), "auth", "result", "meta_unavailable")
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_meta_unavailable", "error", err)...)
 		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
 		return
 	}
 	if subtle.ConstantTimeCompare([]byte(token.HashToken(tok)), []byte(resolved.APIKey.JWTHash)) != 1 {
+		metricEvent(r.Context(), "auth", "result", "hash_mismatch")
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_hash_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
 	setRequestMetricTenant(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID, resolved.Tenant.Provider, classifyTenantRequest(r))
 	if resolved.APIKey.Status != meta.APIKeyActive {
+		metricEvent(r.Context(), "auth", "result", "key_inactive")
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_key_inactive", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "status", resolved.APIKey.Status)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
 	plain, err := poolDecryptToken(r.Context(), s.pool, resolved.APIKey.JWTCiphertext)
 	if err != nil {
+		metricEvent(r.Context(), "auth", "result", "decrypt_failed")
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_decrypt_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
 		return
 	}
 	if subtle.ConstantTimeCompare([]byte(tok), plain) != 1 {
+		metricEvent(r.Context(), "auth", "result", "token_mismatch")
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_token_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
 	claims, err := token.ParseAndVerifyToken(s.tokenSecret, tok)
 	if err != nil {
+		metricEvent(r.Context(), "auth", "result", "token_invalid")
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_token_invalid", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
 	if claims.TenantID != resolved.Tenant.ID || claims.TokenVersion != resolved.APIKey.TokenVersion {
+		metricEvent(r.Context(), "auth", "result", "claims_mismatch")
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_claims_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "claim_tenant", claims.TenantID, "claim_version", claims.TokenVersion)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1264,7 +1264,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
-		metricEvent(r.Context(), "auth", "result", "meta_unavailable")
+		metricEvent(r.Context(), "auth", "result", "meta_backend_error")
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_meta_unavailable", "error", err)...)
 		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
 		return
@@ -1290,7 +1290,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if subtle.ConstantTimeCompare([]byte(tok), plain) != 1 {
-		metricEvent(r.Context(), "auth", "result", "token_mismatch")
+		metricEvent(r.Context(), "auth", "result", "cipher_mismatch")
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_token_mismatch", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -230,7 +230,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 			p.mu.Unlock()
 			return b, nil
 		}
-		if removed := p.removeLocked(e.elem); removed != nil {
+		if removed := p.removeLocked(e.elem, "replace"); removed != nil {
 			toClose = append(toClose, removed)
 		}
 		p.mu.Unlock()
@@ -256,7 +256,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 			p.mu.Unlock()
 			return e.backend, nil
 		}
-		if removed := p.removeLocked(e.elem); removed != nil {
+		if removed := p.removeLocked(e.elem, "replace"); removed != nil {
 			toClose = append(toClose, removed)
 		}
 	}
@@ -266,7 +266,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 	for p.order.Len() > p.maxSize {
 		oldest := p.order.Back()
 		if oldest != nil {
-			if removed := p.removeLocked(oldest); removed != nil {
+			if removed := p.removeLocked(oldest, "evict"); removed != nil {
 				toClose = append(toClose, removed)
 			}
 		}
@@ -316,7 +316,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 				zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 			return e.backend, p.makeRelease(e), nil
 		}
-		if removed := p.removeLocked(e.elem); removed != nil {
+		if removed := p.removeLocked(e.elem, "replace"); removed != nil {
 			toClose = append(toClose, removed)
 		}
 		p.mu.Unlock()
@@ -351,7 +351,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 				zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 			return e.backend, p.makeRelease(e), nil
 		}
-		if removed := p.removeLocked(e.elem); removed != nil {
+		if removed := p.removeLocked(e.elem, "replace"); removed != nil {
 			toClose = append(toClose, removed)
 		}
 	}
@@ -361,7 +361,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	for p.order.Len() > p.maxSize {
 		oldest := p.order.Back()
 		if oldest != nil {
-			if removed := p.removeLocked(oldest); removed != nil {
+			if removed := p.removeLocked(oldest, "evict"); removed != nil {
 				toClose = append(toClose, removed)
 			}
 		}
@@ -392,7 +392,7 @@ func (p *Pool) Invalidate(tenantID string) {
 	var toClose *entry
 	p.mu.Lock()
 	if e, ok := p.items[tenantID]; ok {
-		toClose = p.removeLocked(e.elem)
+		toClose = p.removeLocked(e.elem, "invalidate")
 	}
 	p.mu.Unlock()
 	closeEntry(toClose)
@@ -435,7 +435,7 @@ func (p *Pool) InvalidateAndWait(ctx context.Context, tenantID string) error {
 	p.mu.Lock()
 	if e, ok := p.items[tenantID]; ok {
 		retired = e
-		toClose = p.removeLocked(e.elem)
+		toClose = p.removeLocked(e.elem, "invalidate")
 	}
 	p.mu.Unlock()
 	closeEntry(toClose)
@@ -548,7 +548,7 @@ func (p *Pool) Close() {
 	toClose := make([]*entry, 0, p.order.Len())
 	p.mu.Lock()
 	for p.order.Len() > 0 {
-		if removed := p.removeLocked(p.order.Back()); removed != nil {
+		if removed := p.removeLocked(p.order.Back(), "shutdown"); removed != nil {
 			toClose = append(toClose, removed)
 		}
 	}
@@ -965,13 +965,17 @@ func (p *Pool) wireQuotaStore(ctx context.Context, b *backend.Dat9Backend, tenan
 	b.SetMetaQuotaStore(ctx, tenantID, adapter)
 }
 
-func (p *Pool) removeLocked(elem *list.Element) *entry {
+// removeLocked drops elem from the pool. reason distinguishes capacity eviction
+// ("evict") from entry replacement ("replace"), explicit invalidation
+// ("invalidate"), and pool shutdown ("shutdown") so the tenant_pool/remove metric
+// doesn't conflate them — only result="evict" reflects real cache pressure.
+func (p *Pool) removeLocked(elem *list.Element, reason string) *entry {
 	e := elem.Value.(*entry)
 	p.order.Remove(elem)
 	e.elem = nil
 	delete(p.items, e.tenantID)
 	e.retired = true
-	metrics.RecordOperation("tenant_pool", "evict", "ok", 0)
+	metrics.RecordOperation("tenant_pool", "remove", reason, 0)
 	if e.refs == 0 {
 		return e
 	}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -370,8 +370,9 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	// concurrently with a leadership transition resolves to the post-transition
 	// state rather than a moment-in-time IsLeader() check taken outside the lock.
 	startFileGC := p.fileGCEnabled
-	metrics.RecordGauge("tenant_pool", "cached_backends", float64(len(p.items)))
+	cachedCount := len(p.items)
 	p.mu.Unlock()
+	metrics.RecordGauge("tenant_pool", "cached_backends", float64(cachedCount))
 	if startFileGC {
 		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
 	}
@@ -971,7 +972,6 @@ func (p *Pool) removeLocked(elem *list.Element) *entry {
 	delete(p.items, e.tenantID)
 	e.retired = true
 	metrics.RecordOperation("tenant_pool", "evict", "ok", 0)
-	metrics.RecordGauge("tenant_pool", "cached_backends", float64(len(p.items)))
 	if e.refs == 0 {
 		return e
 	}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -309,6 +309,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 			e.refs++
 			p.order.MoveToFront(e.elem)
 			p.mu.Unlock()
+			metrics.RecordOperation("tenant_pool", "cache_lookup", "hit", 0)
 			logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
 				zap.String("tenant_id", t.ID),
 				zap.Bool("cache_hit", true),
@@ -342,6 +343,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 			p.mu.Unlock()
 			b.Close()
 			_ = st.Close()
+			metrics.RecordOperation("tenant_pool", "cache_lookup", "hit", 0)
 			logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
 				zap.String("tenant_id", t.ID),
 				zap.Bool("cache_hit", true),
@@ -368,6 +370,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	// concurrently with a leadership transition resolves to the post-transition
 	// state rather than a moment-in-time IsLeader() check taken outside the lock.
 	startFileGC := p.fileGCEnabled
+	metrics.RecordGauge("tenant_pool", "cached_backends", float64(len(p.items)))
 	p.mu.Unlock()
 	if startFileGC {
 		b.StartFileGCWorker(backend.FileGCWorkerOptions{})
@@ -375,6 +378,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	for _, retired := range toClose {
 		closeEntry(retired)
 	}
+	metrics.RecordOperation("tenant_pool", "cache_lookup", "miss", 0)
 	logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
 		zap.String("tenant_id", t.ID),
 		zap.Bool("cache_hit", false),
@@ -966,6 +970,8 @@ func (p *Pool) removeLocked(elem *list.Element) *entry {
 	e.elem = nil
 	delete(p.items, e.tenantID)
 	e.retired = true
+	metrics.RecordOperation("tenant_pool", "evict", "ok", 0)
+	metrics.RecordGauge("tenant_pool", "cached_backends", float64(len(p.items)))
 	if e.refs == 0 {
 		return e
 	}


### PR DESCRIPTION
## Why

drive9 exported a rich `drive9_*` application surface but was missing the **dependency-health**, **runtime**, and **OS-process performance** signals the standardized observability requirements expect (e.g. a metadb that died after startup was invisible — pinged once at boot, the module gauge never flipped). This PR closes those gaps. All changes are additive instrumentation; request paths are unchanged.

## What

**Dependency health**
- DB health prober + `drive9_db_up{role}` / `drive9_db_unreachable_pools{role}` / `drive9_db_probe_duration_seconds` — meta/user stores are probed continuously, with `db_unavailable`/`db_recovered` transition logging.
- Leader election: `drive9_service_gauge{component="leader",name="is_leader"}` + acquire/heartbeat/keepalive error ops (previously fully silent; gates all background workers).
- Embedding/LLM provider: outbound call latency + error/timeout results.
- Encryption/KMS: encrypt/decrypt latency + errors via one decorator covering all backends.

**Runtime / process performance**
- Go runtime: `go_goroutines`, `go_threads`, `go_memstats_*`, GC counters.
- OS process (Linux `/proc`, no-ops off-Linux): `process_cpu_seconds_total`, RSS/VSZ, `process_open_fds`/`process_max_fds`.

**Other**
- Tenant pool cache hit/miss, eviction, and cached-backend size gauge.
- `handleTenantStatus` auth-failure events (aligned with the auth-middleware vocabulary).

## Tests
- New unit tests: DB probe flip/transition (`db_test.go`) and `/proc/self/stat` parser (`process_test.go`).
- `go build ./...`, `go vet`, and `go test ./pkg/metrics/... ./pkg/leader/... ./pkg/embedding/... ./pkg/encrypt/... ./pkg/tenant/...` pass. (pkg/server integration tests require a MySQL container not available locally; failures observed are all DB-dial, unrelated to this change.)

Alert rules consuming these metrics are in a companion runbooks PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added continuous database health probing with availability and probe-duration metrics.
  * Added leader-election observability via a leader-state gauge and acquisition/heartbeat/keepalive metrics.
  * Added runtime and process metrics (CPU/memory, file descriptor limits, open FDs).
  * Added encryption and embedding operation metrics (including ok/canceled/timeout/error outcomes).
* **Bug Fixes**
  * Improved auth telemetry for additional authentication/authorization failure paths without changing responses.
  * Database availability metrics now reflect recovery/unavailability transitions automatically.
* **Tests**
  * Added database probe tests and Linux `/proc` stat parsing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->