### PR TITLE
Fix TiDBCloud Mode create-time quota handling

### DIFF
--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -290,6 +290,10 @@ func (s *Server) handleAdminTenantQuotaSet(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
+	if err := s.rejectQuotaSetForTenantStatus(t); err != nil {
+		errJSON(w, http.StatusConflict, err.Error())
+		return
+	}
 	cloudCfg, err := s.applyQuotaSet(r.Context(), t, cred, quotaReq)
 	if err != nil {
 		writeQuotaSetError(w, r.Context(), err, "update")

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -203,6 +203,29 @@ func (f *fakeProvisioner) ProvisionCallCount() int {
 	return int(f.provisionCalls.Load())
 }
 
+type credentialOnlyProvisioner struct {
+	provider string
+	cluster  *tenant.ClusterInfo
+}
+
+func (f *credentialOnlyProvisioner) ProviderType() string { return f.provider }
+
+func (f *credentialOnlyProvisioner) InitSchema(_ context.Context, _ string) error { return nil }
+
+func (f *credentialOnlyProvisioner) Provision(_ context.Context, tenantID string) (*tenant.ClusterInfo, error) {
+	out := *f.cluster
+	out.TenantID = tenantID
+	out.Provider = f.provider
+	return &out, nil
+}
+
+func (f *credentialOnlyProvisioner) ProvisionWithCredentials(_ context.Context, tenantID string, _ tenant.CredentialProvisionRequest) (*tenant.ClusterInfo, error) {
+	out := *f.cluster
+	out.TenantID = tenantID
+	out.Provider = f.provider
+	return &out, nil
+}
+
 type profileAwareFakeProvisioner struct {
 	fakeProvisioner
 	mu               sync.Mutex
@@ -755,6 +778,158 @@ func TestProvisionTiDBCloudNativeCreateQuotaSkipsQuotaPatch(t *testing.T) {
 	}
 	if cfg.MaxStorageBytes != maxStorageSize*quotaStorageSizeBytes {
 		t.Fatalf("quota max storage = %d, want %d", cfg.MaxStorageBytes, maxStorageSize*quotaStorageSizeBytes)
+	}
+}
+
+func TestProvisionTiDBCloudNativeCreateTimeQuotaRequiresQuotaProvisioner(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &credentialOnlyProvisioner{
+		provider: tenant.ProviderTiDBCloudNative,
+		cluster: &tenant.ClusterInfo{
+			ClusterID:      "native-cluster-no-quota-provisioner",
+			OrganizationID: "org-1",
+			Host:           "db.example",
+			Port:           4000,
+			Username:       "u1.root",
+			Password:       "db-pass",
+			DBName:         "customer_db",
+		},
+	}
+	srv := NewWithConfig(Config{
+		Meta:                         metaStore,
+		Pool:                         pool,
+		Provisioner:                  prov,
+		TokenSecret:                  tokenSecret,
+		DisableDatabaseAutoEmbedding: true,
+	})
+	defer srv.Close()
+
+	spendingLimit := int64(10000)
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}
+	_, err = srv.provisionTenant(context.Background(), provisionTenantOptions{
+		KeyName:               "default",
+		TokenVersion:          1,
+		CredentialProvisioner: &cred,
+		Quota: &quotaRequest{quotaFields: quotaFields{
+			TiDBCloudSpendingLimit: &spendingLimit,
+		}},
+	})
+	if err == nil {
+		t.Fatal("provisionTenant error = nil, want unsupported create-time quota error")
+	}
+	var provisionErr *provisionTenantError
+	if !errors.As(err, &provisionErr) || provisionErr.status != http.StatusInternalServerError {
+		t.Fatalf("provision error = %#v, want 500 provisionTenantError", err)
+	}
+	var status string
+	if err := metaStore.DB().QueryRow("SELECT status FROM tenants").Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantFailed) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
+	}
+}
+
+func TestProvisionTiDBCloudNativeCreateTimeQuotaLocalPersistenceErrorIsInternal(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	if _, err := metaStore.DB().Exec("RENAME TABLE tenant_quota_config TO tenant_quota_config_unavailable"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = metaStore.DB().Exec("RENAME TABLE tenant_quota_config_unavailable TO tenant_quota_config")
+	})
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{
+		provider:      tenant.ProviderTiDBCloudNative,
+		cloudProvider: "aws",
+		region:        "us-east-1",
+		cluster: &tenant.ClusterInfo{
+			ClusterID:      "native-cluster-quota-local-error",
+			OrganizationID: "org-1",
+			Host:           "db.example",
+			Port:           4000,
+			Username:       "u1.root",
+			Password:       "db-pass",
+			DBName:         "customer_db",
+		},
+	}
+	srv := NewWithConfig(Config{
+		Meta:                         metaStore,
+		Pool:                         pool,
+		Provisioner:                  prov,
+		TokenSecret:                  tokenSecret,
+		DisableDatabaseAutoEmbedding: true,
+	})
+	defer srv.Close()
+
+	maxStorageSize := int64(1000)
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}
+	_, err = srv.provisionTenant(context.Background(), provisionTenantOptions{
+		KeyName:               "default",
+		TokenVersion:          1,
+		CredentialProvisioner: &cred,
+		Quota: &quotaRequest{quotaFields: quotaFields{
+			MaxStorageSize: &maxStorageSize,
+		}},
+	})
+	if err == nil {
+		t.Fatal("provisionTenant error = nil, want quota persistence error")
+	}
+	var provisionErr *provisionTenantError
+	if !errors.As(err, &provisionErr) || provisionErr.status != http.StatusInternalServerError {
+		t.Fatalf("provision error = %#v, want 500 provisionTenantError", err)
+	}
+	if got := prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	var status string
+	if err := metaStore.DB().QueryRow("SELECT status FROM tenants").Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantFailed) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -25,30 +25,32 @@ import (
 )
 
 type fakeProvisioner struct {
-	provider          string
-	cloudProvider     string
-	region            string
-	cluster           *tenant.ClusterInfo
-	initErr           error
-	provisionErr      error
-	systemUserErr     error
-	systemUsername    string
-	systemPassword    string
-	deprovisionErr    error
-	quotaMarkErr      error
-	quotaUpdateErr    error
-	provisionCalls    atomic.Int32
-	credentialCalls   atomic.Int32
-	systemUserCalls   atomic.Int32
-	deprovisionCalls  atomic.Int32
-	quotaMarkCalls    atomic.Int32
-	quotaUpdateCalls  atomic.Int32
-	lastCredentialReq tenant.CredentialProvisionRequest
-	lastDeprovision   *tenant.ClusterInfo
-	lastQuotaCluster  *tenant.ClusterInfo
-	lastQuotaOptions  tenant.QuotaUpdateOptions
-	defaultPublicKey  string
-	defaultPrivateKey string
+	provider               string
+	cloudProvider          string
+	region                 string
+	cluster                *tenant.ClusterInfo
+	initErr                error
+	provisionErr           error
+	systemUserErr          error
+	systemUsername         string
+	systemPassword         string
+	deprovisionErr         error
+	quotaMarkErr           error
+	quotaUpdateErr         error
+	provisionCalls         atomic.Int32
+	credentialCalls        atomic.Int32
+	credentialQuotaCalls   atomic.Int32
+	systemUserCalls        atomic.Int32
+	deprovisionCalls       atomic.Int32
+	quotaMarkCalls         atomic.Int32
+	quotaUpdateCalls       atomic.Int32
+	lastCredentialReq      tenant.CredentialProvisionRequest
+	lastDeprovision        *tenant.ClusterInfo
+	lastQuotaCluster       *tenant.ClusterInfo
+	lastQuotaOptions       tenant.QuotaUpdateOptions
+	lastCreateQuotaOptions tenant.QuotaUpdateOptions
+	defaultPublicKey       string
+	defaultPrivateKey      string
 }
 
 func (f *fakeProvisioner) DefaultCredentials() (tenant.CredentialProvisionRequest, bool) {
@@ -123,6 +125,29 @@ func (f *fakeProvisioner) ProvisionWithCredentials(_ context.Context, tenantID s
 	out.TenantID = tenantID
 	out.Provider = f.provider
 	return &out, nil
+}
+
+func (f *fakeProvisioner) ProvisionWithCredentialsAndQuota(_ context.Context, tenantID string, req tenant.CredentialProvisionRequest, opts tenant.QuotaUpdateOptions) (*tenant.ClusterInfo, *tenant.QuotaCloudConfig, error) {
+	f.credentialQuotaCalls.Add(1)
+	f.lastCredentialReq = req
+	f.lastCreateQuotaOptions = opts
+	if f.provisionErr != nil {
+		if f.cluster == nil {
+			return nil, nil, f.provisionErr
+		}
+		out := *f.cluster
+		out.TenantID = tenantID
+		out.Provider = f.provider
+		return &out, nil, f.provisionErr
+	}
+	out := *f.cluster
+	out.TenantID = tenantID
+	out.Provider = f.provider
+	var cloudCfg *tenant.QuotaCloudConfig
+	if opts.TiDBCloudSpendingLimitMonthly != nil {
+		cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: opts.TiDBCloudSpendingLimitMonthly}
+	}
+	return &out, cloudCfg, nil
 }
 
 func (f *fakeProvisioner) Deprovision(_ context.Context, cluster *tenant.ClusterInfo) error {
@@ -540,10 +565,12 @@ func TestProvisionTiDBCloudNativeUsesRequestCredentials(t *testing.T) {
 	defer ts.Close()
 
 	spendingLimit := int64(10000)
+	maxStorageSize := int64(1000)
 	body, _ := json.Marshal(map[string]any{
 		"public_key":               "public-1",
 		"private_key":              "private-1",
 		"tidbcloud_spending_limit": spendingLimit,
+		"max_storage_size":         maxStorageSize,
 	})
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -558,17 +585,20 @@ func TestProvisionTiDBCloudNativeUsesRequestCredentials(t *testing.T) {
 	if got := prov.ProvisionCallCount(); got != 0 {
 		t.Fatalf("plain provision calls = %d, want 0", got)
 	}
-	if got := prov.credentialCalls.Load(); got != 1 {
-		t.Fatalf("credential provision calls = %d, want 1", got)
+	if got := prov.credentialCalls.Load(); got != 0 {
+		t.Fatalf("credential provision calls = %d, want 0 when create-time quota is set", got)
 	}
-	if got := prov.quotaMarkCalls.Load(); got != 1 {
-		t.Fatalf("quota mark calls = %d, want 1", got)
+	if got := prov.credentialQuotaCalls.Load(); got != 1 {
+		t.Fatalf("credential quota provision calls = %d, want 1", got)
 	}
-	if got := prov.quotaUpdateCalls.Load(); got != 1 {
-		t.Fatalf("quota update calls = %d, want 1", got)
+	if got := prov.quotaMarkCalls.Load(); got != 0 {
+		t.Fatalf("quota mark calls = %d, want 0 for create-time quota", got)
 	}
-	if prov.lastQuotaOptions.TiDBCloudSpendingLimitMonthly == nil || *prov.lastQuotaOptions.TiDBCloudSpendingLimitMonthly != spendingLimit {
-		t.Fatalf("quota spending limit = %#v, want %d", prov.lastQuotaOptions.TiDBCloudSpendingLimitMonthly, spendingLimit)
+	if got := prov.quotaUpdateCalls.Load(); got != 0 {
+		t.Fatalf("quota update calls = %d, want 0 for create-time quota", got)
+	}
+	if prov.lastCreateQuotaOptions.TiDBCloudSpendingLimitMonthly == nil || *prov.lastCreateQuotaOptions.TiDBCloudSpendingLimitMonthly != spendingLimit {
+		t.Fatalf("create quota spending limit = %#v, want %d", prov.lastCreateQuotaOptions.TiDBCloudSpendingLimitMonthly, spendingLimit)
 	}
 	if prov.lastCredentialReq.PublicKey != "public-1" || prov.lastCredentialReq.PrivateKey != "private-1" {
 		t.Fatalf("credential request = %+v", prov.lastCredentialReq)
@@ -613,6 +643,13 @@ func TestProvisionTiDBCloudNativeUsesRequestCredentials(t *testing.T) {
 	if binding.OrganizationID != "org-1" || binding.ClusterID != "native-cluster-1" {
 		t.Fatalf("binding = %#v", binding)
 	}
+	quotaCfg, err := metaStore.GetQuotaConfig(context.Background(), out["tenant_id"])
+	if err != nil {
+		t.Fatalf("get quota config: %v", err)
+	}
+	if quotaCfg.MaxStorageBytes != maxStorageSize*quotaStorageSizeBytes {
+		t.Fatalf("quota max storage = %d, want %d", quotaCfg.MaxStorageBytes, maxStorageSize*quotaStorageSizeBytes)
+	}
 
 	var provider, dbName, dbUser string
 	var passCipher []byte
@@ -634,7 +671,7 @@ func TestProvisionTiDBCloudNativeUsesRequestCredentials(t *testing.T) {
 	}
 }
 
-func TestProvisionTiDBCloudNativeCleansClusterWhenCreateQuotaFails(t *testing.T) {
+func TestProvisionTiDBCloudNativeCreateQuotaSkipsQuotaPatch(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -659,11 +696,10 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenCreateQuotaFails(t *testing.T)
 	}
 	prov := &fakeProvisioner{
 		provider:      tenant.ProviderTiDBCloudNative,
-		quotaMarkErr:  tenant.ErrQuotaPermissionDenied,
 		cloudProvider: "aws",
 		region:        "us-east-1",
 		cluster: &tenant.ClusterInfo{
-			ClusterID:      "native-cluster-quota-fail",
+			ClusterID:      "native-cluster-create-quota",
 			OrganizationID: "org-1",
 			Host:           "db.example",
 			Port:           4000,
@@ -683,46 +719,42 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenCreateQuotaFails(t *testing.T)
 	defer srv.Close()
 
 	maxStorageSize := int64(1000)
+	spendingLimit := int64(10000)
 	cred := tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}
-	_, err = srv.provisionTenant(context.Background(), provisionTenantOptions{
+	res, err := srv.provisionTenant(context.Background(), provisionTenantOptions{
 		KeyName:               "default",
 		TokenVersion:          1,
 		CredentialProvisioner: &cred,
-		Quota:                 &quotaRequest{quotaFields: quotaFields{MaxStorageSize: &maxStorageSize}},
+		Quota: &quotaRequest{quotaFields: quotaFields{
+			MaxStorageSize:         &maxStorageSize,
+			TiDBCloudSpendingLimit: &spendingLimit,
+		}},
 	})
-	if err == nil {
-		t.Fatal("provisionTenant error = nil, want quota error")
+	if err != nil {
+		t.Fatalf("provisionTenant: %v", err)
 	}
-	var provisionErr *provisionTenantError
-	if !errors.As(err, &provisionErr) || provisionErr.status != http.StatusForbidden {
-		t.Fatalf("provision error = %#v, want 403 provisionTenantError", err)
+	if got := prov.credentialQuotaCalls.Load(); got != 1 {
+		t.Fatalf("credential quota provision calls = %d, want 1", got)
 	}
-	if got := prov.quotaMarkCalls.Load(); got != 1 {
-		t.Errorf("quota mark calls = %d, want 1", got)
+	if got := prov.quotaMarkCalls.Load(); got != 0 {
+		t.Fatalf("quota mark calls = %d, want 0 for create-time quota", got)
 	}
-	if got := prov.deprovisionCalls.Load(); got != 1 {
-		t.Errorf("deprovision calls = %d, want 1", got)
+	if got := prov.quotaUpdateCalls.Load(); got != 0 {
+		t.Fatalf("quota update calls = %d, want 0 for create-time quota", got)
 	}
-	if prov.lastDeprovision == nil || prov.lastDeprovision.ClusterID != "native-cluster-quota-fail" {
-		t.Errorf("deprovision cluster = %#v", prov.lastDeprovision)
+	if got := prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
 	}
-	if prov.lastCredentialReq.PublicKey != "public-1" || prov.lastCredentialReq.PrivateKey != "private-1" {
-		t.Errorf("cleanup credentials = %+v", prov.lastCredentialReq)
+	if prov.lastCreateQuotaOptions.TiDBCloudSpendingLimitMonthly == nil || *prov.lastCreateQuotaOptions.TiDBCloudSpendingLimitMonthly != spendingLimit {
+		t.Fatalf("create quota spending limit = %#v, want %d", prov.lastCreateQuotaOptions.TiDBCloudSpendingLimitMonthly, spendingLimit)
 	}
 
-	var tenantID, status string
-	if err := metaStore.DB().QueryRow("SELECT id, status FROM tenants WHERE cluster_id = ?", "native-cluster-quota-fail").Scan(&tenantID, &status); err != nil {
+	cfg, err := metaStore.GetQuotaConfig(context.Background(), res.TenantID)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if status != string(meta.TenantFailed) {
-		t.Errorf("tenant status = %s, want %s", status, meta.TenantFailed)
-	}
-	var apiKeyCount int
-	if err := metaStore.DB().QueryRow("SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ?", tenantID).Scan(&apiKeyCount); err != nil {
-		t.Fatal(err)
-	}
-	if apiKeyCount != 0 {
-		t.Errorf("api key count = %d, want 0", apiKeyCount)
+	if cfg.MaxStorageBytes != maxStorageSize*quotaStorageSizeBytes {
+		t.Fatalf("quota max storage = %d, want %d", cfg.MaxStorageBytes, maxStorageSize*quotaStorageSizeBytes)
 	}
 }
 

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -256,8 +256,6 @@ func (s *Server) rejectQuotaSetForTenantStatus(t *meta.Tenant) error {
 		return fmt.Errorf("tenant is still provisioning")
 	case meta.TenantDeleting:
 		return fmt.Errorf("tenant is deleting")
-	case meta.TenantDeleted:
-		return fmt.Errorf("tenant not found")
 	default:
 		return nil
 	}

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -161,6 +161,10 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusConflict, "quota setting is only supported for tidb_cloud_native tenants")
 		return
 	}
+	if err := s.rejectQuotaSetForTenantStatus(t); err != nil {
+		errJSON(w, http.StatusConflict, err.Error())
+		return
+	}
 	cloudCfg, err := s.applyQuotaSet(r.Context(), t, cred, req)
 	if err != nil {
 		writeQuotaSetError(w, r.Context(), err, "update")
@@ -243,6 +247,22 @@ var (
 	errQuotaLocalUpdateFailed = errors.New("quota local update failed")
 )
 
+func (s *Server) rejectQuotaSetForTenantStatus(t *meta.Tenant) error {
+	if t == nil {
+		return nil
+	}
+	switch t.Status {
+	case meta.TenantProvisioning:
+		return fmt.Errorf("tenant is still provisioning")
+	case meta.TenantDeleting:
+		return fmt.Errorf("tenant is deleting")
+	case meta.TenantDeleted:
+		return fmt.Errorf("tenant not found")
+	default:
+		return nil
+	}
+}
+
 func (s *Server) applyQuotaSet(ctx context.Context, t *meta.Tenant, cred tenant.CredentialProvisionRequest, req quotaRequest) (*tenant.QuotaCloudConfig, error) {
 	if t == nil {
 		return nil, fmt.Errorf("tenant is required")
@@ -284,6 +304,23 @@ func (s *Server) applyQuotaSet(ctx context.Context, t *meta.Tenant, cred tenant.
 		}
 	}
 	return cloudCfg, nil
+}
+
+func (s *Server) applyQuotaLocalConfig(ctx context.Context, tenantID string, req quotaRequest) error {
+	quotaPatch, err := quotaConfigPatchFromRequest(req)
+	if err != nil {
+		return err
+	}
+	if quotaPatch.MaxStorageBytes == nil && quotaPatch.MaxFileSizeBytes == nil && quotaPatch.MaxFileCount == nil {
+		return nil
+	}
+	if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, quotaPatch); err != nil {
+		return fmt.Errorf("%w: quota config update failed: %w", errQuotaLocalUpdateFailed, err)
+	}
+	if err := s.meta.EnsureQuotaUsageRow(ctx, tenantID); err != nil {
+		return fmt.Errorf("%w: quota usage initialization failed: %w", errQuotaLocalUpdateFailed, err)
+	}
+	return nil
 }
 
 func quotaConfigPatchFromRequest(req quotaRequest) (meta.QuotaConfigPatch, error) {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -467,6 +467,33 @@ func TestDeprecatedQuotaSetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
 	}
 }
 
+func TestQuotaSetRejectsProvisioningTenant(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	if err := rt.meta.UpdateTenantStatus(context.Background(), rt.tenantID, meta.TenantProvisioning); err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+
+	resp := postJSON(t, ts.URL+"/v1/quota", map[string]any{
+		"tenant_id":        rt.tenantID,
+		"public_key":       "public-1",
+		"private_key":      "private-1",
+		"max_storage_size": int64(1000),
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, body)
+	}
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("mark calls = %d, want 0", got)
+	}
+	if got := rt.prov.updateCalls.Load(); got != 0 {
+		t.Fatalf("update calls = %d, want 0", got)
+	}
+}
+
 func TestQuotaSetChecksClusterWritePermissionBeforeFileLimitUpdate(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
@@ -1211,6 +1238,51 @@ func TestAdminTenantQuotaSetRequiresPatchLabelAuthorization(t *testing.T) {
 	}
 	if len(rt.prov.calls) < 2 || rt.prov.calls[0] != "list" || rt.prov.calls[1] != "mark" {
 		t.Fatalf("calls = %#v, want list then mark", rt.prov.calls)
+	}
+}
+
+func TestAdminTenantQuotaSetRejectsProvisioningTenant(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	if err := rt.meta.UpdateTenantStatus(ctx, rt.tenantID, meta.TenantProvisioning); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       rt.tenantID,
+		OrganizationID: "org-1",
+		ClusterID:      "cluster-quota-1",
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{
+			ClusterID:      "cluster-quota-1",
+			OrganizationID: "org-1",
+		}},
+	}}
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+
+	resp := postJSON(t, ts.URL+"/v1/admin/tenants/"+rt.tenantID+"/quota", map[string]any{
+		"public_key":       "public-1",
+		"private_key":      "private-1",
+		"max_storage_size": int64(200),
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, body)
+	}
+	if got := rt.prov.listCalls.Load(); got != 1 {
+		t.Fatalf("list calls = %d, want 1", got)
+	}
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("mark calls = %d, want 0", got)
+	}
+	if got := rt.prov.updateCalls.Load(); got != 0 {
+		t.Fatalf("update calls = %d, want 0", got)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4198,8 +4198,27 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	}
 
 	var cluster *tenant.ClusterInfo
+	var provisionCloudCfg *tenant.QuotaCloudConfig
 	if provider == tenant.ProviderTiDBCloudNative {
-		if credentialProvisioner, ok := s.provisioner.(tenant.CredentialProvisioner); ok {
+		if opts.Quota != nil {
+			quotaReq := *opts.Quota
+			quotaReq.TenantID = tenantID
+			if err := s.validateQuotaSetRequest(quotaReq); err != nil {
+				_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+				return nil, newProvisionTenantError(http.StatusBadRequest, err.Error(), err)
+			}
+			if opts.CredentialProvisioner == nil {
+				_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+				return nil, newProvisionTenantError(http.StatusBadRequest, tenant.ErrCredentialsRequired.Error(), tenant.ErrCredentialsRequired)
+			}
+			if quotaProvisioner, ok := s.provisioner.(tenant.CredentialQuotaProvisioner); ok {
+				cluster, provisionCloudCfg, err = quotaProvisioner.ProvisionWithCredentialsAndQuota(ctx, tenantID, *opts.CredentialProvisioner, tenant.QuotaUpdateOptions{
+					TiDBCloudSpendingLimitMonthly: quotaReq.TiDBCloudSpendingLimit,
+				})
+			} else {
+				err = fmt.Errorf("provisioner does not support create-time quota")
+			}
+		} else if credentialProvisioner, ok := s.provisioner.(tenant.CredentialProvisioner); ok {
 			cluster, err = credentialProvisioner.ProvisionWithCredentials(ctx, tenantID, *opts.CredentialProvisioner)
 		} else {
 			err = fmt.Errorf("provisioner does not support request credentials")
@@ -4291,32 +4310,14 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	if opts.Quota != nil {
 		quotaReq := *opts.Quota
 		quotaReq.TenantID = tenantID
-		if err := s.validateQuotaSetRequest(quotaReq); err != nil {
-			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-			return nil, newProvisionTenantError(http.StatusBadRequest, err.Error(), err)
-		}
-		if opts.CredentialProvisioner == nil {
-			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-			return nil, newProvisionTenantError(http.StatusBadRequest, tenant.ErrCredentialsRequired.Error(), tenant.ErrCredentialsRequired)
-		}
-		if _, err := s.applyQuotaSet(ctx, &meta.Tenant{
-			ID:        tenantID,
-			Provider:  provider,
-			ClusterID: cluster.ClusterID,
-		}, *opts.CredentialProvisioner, quotaReq); err != nil {
+		if err := s.applyQuotaLocalConfig(ctx, tenantID, quotaReq); err != nil {
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 			metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
-			if status, msg, ok := quotaSetErrorStatusMessage(err, "update"); ok {
-				return nil, newProvisionTenantError(status, msg, err)
-			}
-			if errors.Is(err, tenant.ErrQuotaPermissionDenied) {
-				return nil, newProvisionTenantError(http.StatusForbidden, "no permission to update quota with TiDB Cloud API key", err)
-			}
-			if errors.Is(err, tenant.ErrQuotaBackendNotFound) {
-				return nil, newProvisionTenantError(http.StatusNotFound, quotaBackendNotFoundMessage, err)
-			}
 			return nil, newProvisionTenantError(http.StatusBadGateway, "failed to set tenant quota", err)
+		}
+		if provisionCloudCfg != nil && provisionCloudCfg.TiDBCloudSpendingLimitMonthly != nil {
+			metricEvent(ctx, "tenant_provision", "provider", provider, "quota", "create_time_spending_limit")
 		}
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4217,6 +4217,12 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 				})
 			} else {
 				err = fmt.Errorf("provisioner does not support create-time quota")
+				logger.Error(ctx, "server_event", eventFields(ctx, "provision_create_time_quota_not_supported", "tenant_id", tenantID, "provider", provider, "error", err)...)
+				metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
+				if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
+					logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
+				}
+				return nil, newProvisionTenantError(http.StatusInternalServerError, "provisioner does not support create-time quota", err)
 			}
 		} else if credentialProvisioner, ok := s.provisioner.(tenant.CredentialProvisioner); ok {
 			cluster, err = credentialProvisioner.ProvisionWithCredentials(ctx, tenantID, *opts.CredentialProvisioner)
@@ -4314,8 +4320,10 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 			metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
-			return nil, newProvisionTenantError(http.StatusBadGateway, "failed to set tenant quota", err)
+			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to set tenant quota", err)
 		}
+		// The TiDB Cloud spending limit is applied in the create-cluster request and
+		// remains cloud-side; list/get quota reads it back from TiDB Cloud.
 		if provisionCloudCfg != nil && provisionCloudCfg.TiDBCloudSpendingLimitMonthly != nil {
 			metricEvent(ctx, "tenant_provision", "provider", provider, "quota", "create_time_spending_limit")
 		}

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -60,6 +60,11 @@ type CredentialProvisioner interface {
 	ProvisionWithCredentials(ctx context.Context, tenantID string, req CredentialProvisionRequest) (*ClusterInfo, error)
 }
 
+type CredentialQuotaProvisioner interface {
+	Provisioner
+	ProvisionWithCredentialsAndQuota(ctx context.Context, tenantID string, req CredentialProvisionRequest, opts QuotaUpdateOptions) (*ClusterInfo, *QuotaCloudConfig, error)
+}
+
 type CredentialDeprovisioner interface {
 	Provisioner
 	DeprovisionWithCredentials(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) error

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -190,18 +190,28 @@ func (p *Provisioner) ValidateCredentialProvisionRequest(req tenant.CredentialPr
 }
 
 func (p *Provisioner) ProvisionWithCredentials(ctx context.Context, tenantID string, req tenant.CredentialProvisionRequest) (*tenant.ClusterInfo, error) {
+	out, _, err := p.ProvisionWithCredentialsAndQuota(ctx, tenantID, req, tenant.QuotaUpdateOptions{})
+	return out, err
+}
+
+func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tenantID string, req tenant.CredentialProvisionRequest, opts tenant.QuotaUpdateOptions) (*tenant.ClusterInfo, *tenant.QuotaCloudConfig, error) {
 	publicKey := strings.TrimSpace(req.PublicKey)
 	privateKey := strings.TrimSpace(req.PrivateKey)
 	if publicKey == "" || privateKey == "" {
-		return nil, fmt.Errorf("public_key and private_key are required")
+		return nil, nil, fmt.Errorf("public_key and private_key are required")
 	}
 	dbName, err := p.resolveDatabaseName("")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+	if opts.TiDBCloudSpendingLimitMonthly != nil {
+		if err := validateTiDBCloudSpendingLimit(*opts.TiDBCloudSpendingLimitMonthly); err != nil {
+			return nil, nil, err
+		}
 	}
 	password, err := generateRandomPassword(24)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	reqBody := map[string]any{
 		"displayName":  clusterDisplayName(tenantID),
@@ -214,36 +224,42 @@ func (p *Provisioner) ProvisionWithCredentials(ctx context.Context, tenantID str
 			Drive9TenantIDLabel: tenantID,
 		},
 	}
-	if p.defaultSpendLimit != nil {
+	var spendingLimit *int64
+	if opts.TiDBCloudSpendingLimitMonthly != nil {
+		spendingLimit = opts.TiDBCloudSpendingLimitMonthly
+		reqBody["spendingLimit"] = map[string]int32{"monthly": int32(*spendingLimit)}
+	} else if p.defaultSpendLimit != nil {
+		defaultLimit := int64(*p.defaultSpendLimit)
+		spendingLimit = &defaultLimit
 		reqBody["spendingLimit"] = map[string]int32{"monthly": *p.defaultSpendLimit}
 	}
 	body, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	endpoint := p.apiURL + "/v1beta1/clusters"
 	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodPost, endpoint, body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 		if readErr != nil {
-			return nil, readErr
+			return nil, nil, readErr
 		}
-		return nil, fmt.Errorf("%s", statusError("provision", resp.StatusCode, sanitizeUpstreamBody(raw)))
+		return nil, nil, fmt.Errorf("%s", statusError("provision", resp.StatusCode, sanitizeUpstreamBody(raw)))
 	}
 	raw, readErr := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
 	if readErr != nil {
-		return nil, readErr
+		return nil, nil, readErr
 	}
 	info, err := parseClusterInfo(raw)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if info.ClusterID == "" {
-		return nil, fmt.Errorf("tidbcloud native response missing cluster id")
+		return nil, nil, fmt.Errorf("tidbcloud native response missing cluster id")
 	}
 	if clusterProvisionMetadataIncomplete(info) {
 		info, err = p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, info.ClusterID)
@@ -254,7 +270,7 @@ func (p *Provisioner) ProvisionWithCredentials(ctx context.Context, tenantID str
 				Password:  password,
 				DBName:    dbName,
 				Provider:  tenant.ProviderTiDBCloudNative,
-			}, err
+			}, nil, err
 		}
 	}
 	out := &tenant.ClusterInfo{
@@ -272,12 +288,21 @@ func (p *Provisioner) ProvisionWithCredentials(ctx context.Context, tenantID str
 		out.Username = info.UserPrefix + ".root"
 	}
 	if out.Host == "" || out.Port == 0 {
-		return out, fmt.Errorf("tidbcloud native response missing endpoint")
+		return out, nil, fmt.Errorf("tidbcloud native response missing endpoint")
 	}
 	if out.Username == "" {
-		return out, fmt.Errorf("tidbcloud native response missing username")
+		return out, nil, fmt.Errorf("tidbcloud native response missing username")
 	}
-	return out, nil
+	cloudCfg := &tenant.QuotaCloudConfig{
+		Labels: map[string]string{
+			Drive9ManagedLabel:  "true",
+			Drive9TenantIDLabel: tenantID,
+		},
+	}
+	if spendingLimit != nil {
+		cloudCfg.TiDBCloudSpendingLimitMonthly = ptrInt64(*spendingLimit)
+	}
+	return out, cloudCfg, nil
 }
 
 func (p *Provisioner) ProvisionBranch(ctx context.Context, forkTenantID string, source *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -212,6 +212,9 @@ func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testin
 	if gotBody.Labels[Drive9ManagedLabel] != "true" || gotBody.Labels[Drive9TenantIDLabel] != "tenant-1" {
 		t.Fatalf("labels = %#v", gotBody.Labels)
 	}
+	if _, ok := gotBody.Labels[Drive9QuotaUpdateAtLabel]; ok {
+		t.Fatalf("create labels unexpectedly included %s: %#v", Drive9QuotaUpdateAtLabel, gotBody.Labels)
+	}
 	if gotBody.SpendingLimit.Monthly != 5000 {
 		t.Fatalf("spendingLimit.monthly = %d, want 5000", gotBody.SpendingLimit.Monthly)
 	}
@@ -220,6 +223,65 @@ func TestProvisionWithCredentialsUsesRequestCredentialsAndServerConfig(t *testin
 	}
 	if pollCount < 2 {
 		t.Fatalf("poll count = %d, want at least 2", pollCount)
+	}
+}
+
+func TestProvisionWithCredentialsAndQuotaSendsCreateTimeSpendingLimit(t *testing.T) {
+	var gotBody struct {
+		Labels        map[string]string `json:"labels"`
+		SpendingLimit struct {
+			Monthly int32 `json:"monthly"`
+		} `json:"spendingLimit"`
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/v1beta1/clusters" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"clusterId":  "cluster-1",
+			"state":      "CREATING",
+			"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1"},
+			"userPrefix": "u1",
+			"endpoints":  map[string]any{"public": map[string]any{"host": "db.example", "port": 4000}},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		cloudProvider:       "aws",
+		region:              "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+		defaultSpendLimit:   int32Ptr(5000),
+		client:              ts.Client(),
+	}
+	monthly := int64(10000)
+	_, cloudCfg, err := p.ProvisionWithCredentialsAndQuota(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	}, tenant.QuotaUpdateOptions{TiDBCloudSpendingLimitMonthly: &monthly})
+	if err != nil {
+		t.Fatalf("ProvisionWithCredentialsAndQuota: %v", err)
+	}
+	if gotBody.SpendingLimit.Monthly != int32(monthly) {
+		t.Fatalf("spendingLimit.monthly = %d, want %d", gotBody.SpendingLimit.Monthly, monthly)
+	}
+	if gotBody.Labels[Drive9ManagedLabel] != "true" || gotBody.Labels[Drive9TenantIDLabel] != "tenant-1" {
+		t.Fatalf("labels = %#v", gotBody.Labels)
+	}
+	if _, ok := gotBody.Labels[Drive9QuotaUpdateAtLabel]; ok {
+		t.Fatalf("create labels unexpectedly included %s: %#v", Drive9QuotaUpdateAtLabel, gotBody.Labels)
+	}
+	if cloudCfg == nil || cloudCfg.TiDBCloudSpendingLimitMonthly == nil || *cloudCfg.TiDBCloudSpendingLimitMonthly != monthly {
+		t.Fatalf("cloud config = %#v, want spending limit %d", cloudCfg, monthly)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix TiDBCloud Mode create-time quota handling.

- Send `tidbcloud_spending_limit` as TiDB Cloud `spendingLimit.monthly` in the initial cluster create request instead of patching it after the cluster is created.
- Keep create labels limited to `drive9.ai/managed` and `drive9.ai/tenant_id`; do not add `drive9.ai/update_quota_at` during create.
- Persist create-time Drive9 quota knobs (`max_storage_size`, `max_file_size`, `max_file_count`) directly into Drive9 DB after the tenant connection is persisted.
- Keep normal set-quota/delete authorization behavior unchanged: later set-quota still uses patch-label authorization.
- Reject set-quota while the tenant is still `provisioning`, before patching TiDB Cloud labels.

## Notes

- I left CLI error parsing unchanged; the observed `parse error: Invalid numeric literal` looks like an e2e/script-side JSON parsing issue rather than a CLI behavior issue.

## Validation

- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant/tidbcloudnative -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -run 'TestProvisionTiDBCloudNative|TestQuotaSet|TestAdminTenantQuotaSet|TestDeprecatedQuotaSet' -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./cmd/drive9/cli -run 'TestCreate|TestAdminTenant|TestQuota' -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/client -run 'TestAdmin|TestQuota' -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -count=1`
- `make lint`
- `git diff --check`
