### PR TITLE
fix: make e2e built CLI executable

### DIFF
--- a/e2e/_feature-matrix-runner.sh
+++ b/e2e/_feature-matrix-runner.sh
@@ -242,6 +242,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make -C "$REPO_ROOT" build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -105,6 +105,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/fuse-concurrency-stress.sh
+++ b/e2e/fuse-concurrency-stress.sh
@@ -138,6 +138,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/fuse-correctness-workload.sh
+++ b/e2e/fuse-correctness-workload.sh
@@ -133,6 +133,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/fuse-crash-recovery-test.sh
+++ b/e2e/fuse-crash-recovery-test.sh
@@ -235,6 +235,7 @@ json_body() { printf '%s' "$1" | sed '/__HTTP__/d'; }
 prepare_cli_binary() {
   CLI_BIN="$(mktemp)"
   make build-cli CLI_BIN="$CLI_BIN"
+  chmod +x "$CLI_BIN"
 }
 
 # write_crash_workload writes the pre-crash workload through the mount and

--- a/e2e/fuse-performance-baseline.sh
+++ b/e2e/fuse-performance-baseline.sh
@@ -163,6 +163,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/fuse-posix-fsx-gate.sh
+++ b/e2e/fuse-posix-fsx-gate.sh
@@ -129,7 +129,10 @@ download_official_cli() {
 prepare_cli_binary() {
   CLI_BIN="$(mktemp)"
   case "$CLI_SOURCE" in
-    build) make build-cli CLI_BIN="$CLI_BIN" ;;
+    build)
+      make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
+      ;;
     official) download_official_cli ;;
     *) echo "invalid CLI_SOURCE: $CLI_SOURCE (expected build|official)" >&2; return 1 ;;
   esac

--- a/e2e/fuse-smoke-test.sh
+++ b/e2e/fuse-smoke-test.sh
@@ -117,6 +117,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/fuse-sqlite-correctness.sh
+++ b/e2e/fuse-sqlite-correctness.sh
@@ -160,6 +160,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/fuse-write-perf-budget-test.sh
+++ b/e2e/fuse-write-perf-budget-test.sh
@@ -246,6 +246,7 @@ json_body() { printf '%s' "$1" | sed '/__HTTP__/d'; }
 prepare_cli_binary() {
   CLI_BIN="$(mktemp)"
   make build-cli CLI_BIN="$CLI_BIN"
+  chmod +x "$CLI_BIN"
 }
 
 # write_perf_workload performs the deterministic write workload through the

--- a/e2e/git-ops-smoke-test.sh
+++ b/e2e/git-ops-smoke-test.sh
@@ -146,6 +146,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/git-workspace-smoke-test.sh
+++ b/e2e/git-workspace-smoke-test.sh
@@ -114,6 +114,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/layer-fs-smoke-test.sh
+++ b/e2e/layer-fs-smoke-test.sh
@@ -328,6 +328,7 @@ prepare_cli_binary() {
       script_dir="$(cd "$(dirname "$0")" && pwd)"
       repo_root="$(git -C "$script_dir/.." rev-parse --show-toplevel 2>/dev/null || (cd "$script_dir/.." && pwd))"
       make -C "$repo_root" build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -58,7 +58,10 @@ download_official_cli() {
 prepare_cli_binary() {
   CLI_BIN="$(mktemp)"
   case "$CLI_SOURCE" in
-    build) make build-cli CLI_BIN="$CLI_BIN" ;;
+    build)
+      make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
+      ;;
     official) download_official_cli ;;
     *) echo "invalid CLI_SOURCE: $CLI_SOURCE (expected build|official)" >&2; return 1 ;;
   esac

--- a/e2e/portable-pack-unpack-e2e.sh
+++ b/e2e/portable-pack-unpack-e2e.sh
@@ -89,6 +89,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/e2e/posix-permission-smoke-test.sh
+++ b/e2e/posix-permission-smoke-test.sh
@@ -110,6 +110,7 @@ prepare_cli_binary() {
   case "$CLI_SOURCE" in
     build)
       make build-cli CLI_BIN="$CLI_BIN"
+      chmod +x "$CLI_BIN"
       ;;
     official)
       download_official_cli

--- a/scripts/verify_e2e_cli_bin_chmod.py
+++ b/scripts/verify_e2e_cli_bin_chmod.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Verify E2E scripts chmod CLI_BIN after building into a mktemp path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    failures: list[str] = []
+
+    for script in sorted((repo_root / "e2e").glob("*.sh")):
+        lines = script.read_text().splitlines()
+        for index, line in enumerate(lines):
+            if "make " not in line or "build-cli" not in line or 'CLI_BIN="$CLI_BIN"' not in line:
+                continue
+            followup = "\n".join(lines[index + 1:index + 4])
+            if 'chmod +x "$CLI_BIN"' not in followup:
+                failures.append(f"{script.relative_to(repo_root)}:{index + 1}")
+
+    if failures:
+        print("missing chmod +x after build-cli CLI_BIN output:")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+
+    print("all e2e build-cli CLI_BIN outputs restore execute permission")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- chmod the temporary CLI binary after `make build-cli CLI_BIN="$CLI_BIN"` in E2E scripts
- apply the fix across E2E helpers that build into `mktemp` paths
- add `scripts/verify_e2e_cli_bin_chmod.py` to catch future regressions

## Root cause
`mktemp` creates files with mode `0600`. When `go build -o "$CLI_BIN"` writes to that existing temp path, the output can remain non-executable. Later helpers call the CLI via `env DRIVE9_SERVER=... "$CLI_BIN" ...`, so `env` reports `Permission denied` on `/tmp/tmp.*` because it is trying to execute the non-executable CLI binary.

## Validation
- `python3 scripts/verify_e2e_cli_bin_chmod.py`
- `python3 -m py_compile scripts/verify_e2e_cli_bin_chmod.py`
- `tmp=$(mktemp); make build-cli CLI_BIN="$tmp"; test -x "$tmp"` reproduces non-executable before chmod; `chmod +x "$tmp"` makes it executable
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of end-to-end checks by ensuring locally built CLI binaries are executable before they’re used.
  * Reduced the chance of smoke tests and stress tests failing due to permission issues on temporary binaries.

* **Tests**
  * Added automated validation to catch missing executable permissions in end-to-end test scripts, helping prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->