### PR TITLE
feat: add tenant_id dimension to metrics, logs, and alert rules

### DIFF
--- a/docs/grafana/drive9-async-fuse-dashboard.json
+++ b/docs/grafana/drive9-async-fuse-dashboard.json
@@ -132,7 +132,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "drive9_service_gauge{component=\"semantic_worker\",name=\"queue_lag_seconds\"}",
+          "expr": "sum(drive9_service_gauge{component=\"semantic_worker\",name=\"queue_lag_seconds\",tenant_id=\"\"})",
           "legendFormat": "queue_lag_seconds",
           "refId": "A"
         }
@@ -199,7 +199,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "drive9_service_gauge{component=\"semantic_worker\",name=\"dead_lettered\"}",
+          "expr": "sum(drive9_service_gauge{component=\"semantic_worker\",name=\"dead_lettered\",tenant_id=\"\"})",
           "legendFormat": "dead_lettered",
           "refId": "A"
         }
@@ -409,7 +409,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "drive9_service_gauge{component=\"semantic_worker\",name=~\"inflight|queued|processing|dead_lettered\"}",
+          "expr": "sum by (name) (drive9_service_gauge{component=\"semantic_worker\",name=~\"inflight|queued|processing|dead_lettered\",tenant_id=\"\"})",
           "legendFormat": "semantic_worker {{name}}",
           "refId": "A"
         }
@@ -456,7 +456,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "drive9_service_gauge{component=\"semantic_worker\",name=\"queue_lag_seconds\"}",
+          "expr": "sum(drive9_service_gauge{component=\"semantic_worker\",name=\"queue_lag_seconds\",tenant_id=\"\"})",
           "legendFormat": "semantic_worker queue_lag_seconds",
           "refId": "A"
         },

--- a/pkg/backend/audio_extract.go
+++ b/pkg/backend/audio_extract.go
@@ -18,6 +18,7 @@ import (
 
 // AudioExtractRequest is the input to a pluggable audio->text extractor.
 type AudioExtractRequest struct {
+	TenantID    string
 	FileID      string
 	Path        string
 	ContentType string
@@ -336,6 +337,7 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 
 	taskCtx, cancel := context.WithTimeout(ctx, b.audioExtractTimeout)
 	text, audioUsage, err := b.audioExtractor.ExtractAudioText(taskCtx, AudioExtractRequest{
+		TenantID:    b.tenantID,
 		FileID:      task.FileID,
 		Path:        task.Path,
 		ContentType: extractorContentType,

--- a/pkg/backend/audio_extract.go
+++ b/pkg/backend/audio_extract.go
@@ -284,7 +284,7 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 	start := time.Now()
 	var result AudioExtractResult
 	defer func() {
-		metrics.RecordOperation("audio_extract", "process", legacyAudioExtractMetricResult(result), time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "audio_extract", "process", legacyAudioExtractMetricResult(result), time.Since(start))
 	}()
 
 	if !b.SupportsAsyncAudioExtract() {
@@ -292,7 +292,7 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 		return result, fmt.Errorf("async audio extract runtime not configured")
 	}
 	if b.monthlyLLMCostExceededCheck(ctx) {
-		metrics.RecordOperation("llm_cost_budget", "process_skip", "budget_exhausted", 0)
+		metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "process_skip", "budget_exhausted", 0)
 		result = AudioExtractResultBudgetExhausted
 		return result, nil
 	}

--- a/pkg/backend/audio_extract_test.go
+++ b/pkg/backend/audio_extract_test.go
@@ -99,7 +99,7 @@ func TestAsyncAudioExtractMetricsExposed(t *testing.T) {
 	if !strings.Contains(metricsText, "drive9_module_up{module=\"audio_extract\"} 1") {
 		t.Fatalf("metrics missing audio_extract module availability: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 4096") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\",tenant_id=\"\"} 4096") {
 		t.Fatalf("metrics missing audio_extract runtime gauge: %s", metricsText)
 	}
 	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"audio_extract\",operation=\"process\",result=\"ok\"}") {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -243,7 +243,7 @@ func (b *Dat9Backend) Create(path string) error {
 
 func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "create", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "create", err, start) }()
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
@@ -327,7 +327,7 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 // payload and whose inode mode carries the POSIX symlink file type bits.
 func (b *Dat9Backend) CreateSymlinkCtx(ctx context.Context, linkPath, target string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "create_symlink", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "create_symlink", err, start) }()
 
 	data := []byte(target)
 	if target == "" || strings.ContainsRune(target, 0) || len(data) > MaxSymlinkTargetBytes {
@@ -414,7 +414,7 @@ func (b *Dat9Backend) Mkdir(path string, perm uint32) error {
 
 func (b *Dat9Backend) MkdirCtx(ctx context.Context, path string, perm uint32) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "mkdir", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "mkdir", err, start) }()
 
 	dirPath, err := pathutil.CanonicalizeDir(path)
 	if err != nil {
@@ -462,7 +462,7 @@ func (b *Dat9Backend) Chmod(path string, mode uint32) error {
 
 func (b *Dat9Backend) ChmodCtx(ctx context.Context, path string, mode uint32) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "chmod", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "chmod", err, start) }()
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
@@ -484,7 +484,7 @@ func (b *Dat9Backend) Remove(path string) error {
 
 func (b *Dat9Backend) RemoveCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "remove", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "remove", err, start) }()
 
 	path, node, err := b.resolveNodePath(ctx, path)
 	if err != nil {
@@ -502,7 +502,7 @@ func (b *Dat9Backend) RemoveCtx(ctx context.Context, path string) (err error) {
 
 func (b *Dat9Backend) RemoveFileCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "remove_file", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "remove_file", err, start) }()
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
@@ -517,7 +517,7 @@ func (b *Dat9Backend) RemoveFileCtx(ctx context.Context, path string) (err error
 
 func (b *Dat9Backend) RemoveDirCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "remove_dir", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "remove_dir", err, start) }()
 
 	path, err = pathutil.CanonicalizeDir(path)
 	if err != nil {
@@ -535,7 +535,7 @@ func (b *Dat9Backend) RemoveAll(path string) error {
 
 func (b *Dat9Backend) RemoveAllCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "remove_all", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "remove_all", err, start) }()
 
 	path, node, err := b.resolveNodePath(ctx, path)
 	if err != nil {
@@ -558,7 +558,7 @@ func (b *Dat9Backend) Read(path string, offset int64, size int64) ([]byte, error
 
 func (b *Dat9Backend) ReadCtx(ctx context.Context, path string, offset int64, size int64) (data []byte, err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "read", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "read", err, start) }()
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
@@ -639,7 +639,7 @@ func (b *Dat9Backend) WriteCtxIfRevisionWithTagsResult(ctx context.Context, path
 	var statDuration time.Duration
 	var implementationDuration time.Duration
 	defer func() {
-		observeBackend(ctx, "write", err, start)
+		observeBackend(ctx, b.tenantID, "write", err, start)
 		if !timingEnabled {
 			return
 		}
@@ -1269,7 +1269,7 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 	var canonicalPath string
 	var listDuration time.Duration
 	defer func() {
-		observeBackend(ctx, "read_dir", err, start)
+		observeBackend(ctx, b.tenantID, "read_dir", err, start)
 		fields := []zap.Field{
 			zap.String("path", path),
 			zap.String("canonical_path", canonicalPath),
@@ -1464,7 +1464,7 @@ func (b *Dat9Backend) ReadPlanCtx(ctx context.Context, path string) (plan *ReadP
 	var size int64
 	phase := "canonicalize"
 	defer func() {
-		observeBackend(ctx, "read_plan", err, start)
+		observeBackend(ctx, b.tenantID, "read_plan", err, start)
 		fields := []zap.Field{
 			zap.String("path", path),
 			zap.String("phase", phase),
@@ -1545,7 +1545,7 @@ func (b *Dat9Backend) ReadPlanCtx(ctx context.Context, path string) (plan *ReadP
 // without reading or presigning object storage data.
 func (b *Dat9Backend) ReadInlinePlanCtx(ctx context.Context, path string) (plan *ReadPlan, err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "read_inline_plan", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "read_inline_plan", err, start) }()
 
 	resolvedPath, err := pathutil.Canonicalize(path)
 	if err != nil {
@@ -1620,7 +1620,7 @@ func (b *Dat9Backend) Rename(oldPath, newPath string) error {
 
 func (b *Dat9Backend) RenameCtx(ctx context.Context, oldPath, newPath string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "rename", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "rename", err, start) }()
 
 	oldPath, node, err := b.resolveNodePath(ctx, oldPath)
 	if err != nil {
@@ -1653,7 +1653,7 @@ func (b *Dat9Backend) RenameCtx(ctx context.Context, oldPath, newPath string) (e
 // if the target path already exists.
 func (b *Dat9Backend) RenameFileNoReplaceCtx(ctx context.Context, oldPath, newPath string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "rename_file_no_replace", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "rename_file_no_replace", err, start) }()
 
 	oldPath, node, err := b.resolveNodePath(ctx, oldPath)
 	if err != nil {
@@ -1714,7 +1714,7 @@ func (b *Dat9Backend) CopyFile(srcPath, dstPath string) error {
 
 func (b *Dat9Backend) CopyFileCtx(ctx context.Context, srcPath, dstPath string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "copy_file", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "copy_file", err, start) }()
 
 	srcPath, err = pathutil.Canonicalize(srcPath)
 	if err != nil {
@@ -1759,7 +1759,7 @@ func (b *Dat9Backend) HardlinkFile(srcPath, dstPath string) error {
 
 func (b *Dat9Backend) HardlinkFileCtx(ctx context.Context, srcPath, dstPath string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, "hardlink_file", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "hardlink_file", err, start) }()
 
 	dstPath, err = pathutil.Canonicalize(dstPath)
 	if err != nil {
@@ -2023,7 +2023,7 @@ func extractText(data []byte, contentType string, maxBytes int64) string {
 func (b *Dat9Backend) ExecSQL(ctx context.Context, query string) ([]map[string]interface{}, error) {
 	start := time.Now()
 	rows, err := b.store.ExecSQL(ctx, query)
-	observeBackend(ctx, "exec_sql", err, start)
+	observeBackend(ctx, b.tenantID, "exec_sql", err, start)
 	if err != nil {
 		logger.Error(ctx, "backend_exec_sql_failed", zap.Int("query_len", len(query)), zap.Error(err))
 		return nil, err
@@ -2034,7 +2034,7 @@ func (b *Dat9Backend) ExecSQL(ctx context.Context, query string) ([]map[string]i
 func (b *Dat9Backend) Grep(ctx context.Context, query, pathPrefix string, limit int) ([]datastore.SearchResult, error) {
 	start := time.Now()
 	var err error
-	defer func() { observeBackend(ctx, "grep", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, "grep", err, start) }()
 
 	if strings.TrimSpace(query) == "" {
 		err = fmt.Errorf("empty query")
@@ -2182,7 +2182,7 @@ func mergeVectorResults(a, b []datastore.SearchResult) []datastore.SearchResult 
 func (b *Dat9Backend) Find(ctx context.Context, f *datastore.FindFilter) ([]datastore.SearchResult, error) {
 	start := time.Now()
 	rows, err := b.store.Find(ctx, f)
-	observeBackend(ctx, "find", err, start)
+	observeBackend(ctx, b.tenantID, "find", err, start)
 	if err != nil {
 		logger.Error(ctx, "backend_find_failed", zap.String("path", f.PathPrefix), zap.String("name", f.NameGlob), zap.Error(err))
 		return nil, err
@@ -2190,7 +2190,7 @@ func (b *Dat9Backend) Find(ctx context.Context, f *datastore.FindFilter) ([]data
 	return rows, nil
 }
 
-func observeBackend(ctx context.Context, op string, err error, start time.Time) {
+func observeBackend(ctx context.Context, tenantID, op string, err error, start time.Time) {
 	result := "ok"
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
@@ -2199,5 +2199,5 @@ func observeBackend(ctx context.Context, op string, err error, start time.Time) 
 			result = "error"
 		}
 	}
-	metrics.RecordOperation("backend", op, result, time.Since(start))
+	metrics.RecordTenantOperation(tenantID, "backend", op, result, time.Since(start))
 }

--- a/pkg/backend/file_gc_worker.go
+++ b/pkg/backend/file_gc_worker.go
@@ -59,6 +59,7 @@ func (b *Dat9Backend) StartFileGCWorker(opts FileGCWorkerOptions) *FileGCWorker 
 	b.fileGCWorker = w
 	go w.run(ctx)
 	logger.Info(ctx, "file_gc_worker_started",
+		zap.String("tenant_id", b.tenantID),
 		zap.Duration("poll_interval", opts.PollInterval),
 		zap.Duration("lease_duration", opts.LeaseDuration),
 		zap.Int("batch_size", opts.BatchSize))
@@ -108,7 +109,7 @@ func (w *FileGCWorker) run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			logger.Info(ctx, "file_gc_worker_stopped")
+			logger.Info(ctx, "file_gc_worker_stopped", zap.String("tenant_id", w.backend.tenantID))
 			return
 		case <-ticker.C:
 			w.processAvailable(ctx)
@@ -120,13 +121,14 @@ func (w *FileGCWorker) processAvailable(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
 	}
+	tenantID := w.backend.tenantID
 	now := time.Now().UTC()
 	if _, err := w.backend.store.RecoverExpiredFileGCTasks(ctx, now, w.opts.RecoverLimit); err != nil {
 		if isContextDone(err) {
 			return
 		}
-		logger.Warn(ctx, "file_gc_recover_expired_failed", zap.Error(err))
-		metrics.RecordOperation("file_gc", "recover_expired", "error", 0)
+		logger.Warn(ctx, "file_gc_recover_expired_failed", zap.String("tenant_id", tenantID), zap.Error(err))
+		metrics.RecordTenantOperation(tenantID, "file_gc", "recover_expired", "error", 0)
 	}
 	for i := 0; i < w.opts.BatchSize; i++ {
 		if ctx.Err() != nil {
@@ -137,7 +139,7 @@ func (w *FileGCWorker) processAvailable(ctx context.Context) {
 			if isContextDone(err) {
 				return
 			}
-			logger.Warn(ctx, "file_gc_task_process_failed", zap.Error(err))
+			logger.Warn(ctx, "file_gc_task_process_failed", zap.String("tenant_id", w.backend.tenantID), zap.Error(err))
 		}
 		if !processed {
 			return
@@ -159,32 +161,33 @@ func (b *Dat9Backend) ProcessOneFileGCTask(ctx context.Context) (bool, error) {
 
 func (b *Dat9Backend) processOneFileGCTask(ctx context.Context, opts FileGCWorkerOptions) (processed bool, err error) {
 	start := time.Now()
+	tenantID := b.tenantID
 	task, found, err := b.store.ClaimFileGCTask(ctx, time.Now().UTC(), opts.LeaseDuration)
 	if err != nil {
-		metrics.RecordOperation("file_gc", "claim", "error", time.Since(start))
+		metrics.RecordTenantOperation(tenantID, "file_gc", "claim", "error", time.Since(start))
 		return false, err
 	}
 	if !found {
-		metrics.RecordOperation("file_gc", "claim", "empty", time.Since(start))
+		metrics.RecordTenantOperation(tenantID, "file_gc", "claim", "empty", time.Since(start))
 		return false, nil
 	}
 
 	err = b.processFileGCTask(ctx, task)
 	if err == nil {
 		if ackErr := b.store.AckFileGCTask(ctx, task.TaskID, task.Receipt); ackErr != nil {
-			metrics.RecordOperation("file_gc", "ack", "error", time.Since(start))
+			metrics.RecordTenantOperation(tenantID, "file_gc", "ack", "error", time.Since(start))
 			return true, ackErr
 		}
-		metrics.RecordOperation("file_gc", "process", "ok", time.Since(start))
+		metrics.RecordTenantOperation(tenantID, "file_gc", "process", "ok", time.Since(start))
 		return true, nil
 	}
 
 	retryAt := time.Now().UTC().Add(fileGCRetryDelay(task.AttemptCount, opts.RetryBase, opts.RetryMax))
 	if retryErr := b.store.RetryFileGCTask(ctx, task.TaskID, task.Receipt, retryAt, err.Error()); retryErr != nil {
-		metrics.RecordOperation("file_gc", "retry", "error", time.Since(start))
+		metrics.RecordTenantOperation(tenantID, "file_gc", "retry", "error", time.Since(start))
 		return true, fmt.Errorf("process file gc task %s: %w; update retry: %v", task.TaskID, err, retryErr)
 	}
-	metrics.RecordOperation("file_gc", "process", "error", time.Since(start))
+	metrics.RecordTenantOperation(tenantID, "file_gc", "process", "error", time.Since(start))
 	return true, err
 }
 
@@ -202,6 +205,7 @@ func (b *Dat9Backend) processFileGCTask(ctx context.Context, task *datastore.Fil
 		}
 		if err != nil {
 			logger.Warn(ctx, "file_gc_object_gc_candidate_failed",
+				zap.String("tenant_id", b.tenantID),
 				zap.String("file_id", task.FileID),
 				zap.String("storage_ref", task.StorageRef),
 				zap.Error(err))

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -18,6 +18,7 @@ import (
 
 // ImageExtractRequest is the input to a pluggable image->text extractor.
 type ImageExtractRequest struct {
+	TenantID    string
 	FileID      string
 	Path        string
 	ContentType string
@@ -94,7 +95,7 @@ func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExt
 		return ImageExtractResultRuntimeNotConfigured, fmt.Errorf("async image extract runtime not configured")
 	}
 	if b.monthlyLLMCostExceededCheck(ctx) {
-		metrics.RecordOperation("llm_cost_budget", "process_skip", "budget_exhausted", 0)
+		metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "process_skip", "budget_exhausted", 0)
 		return ImageExtractResultBudgetExhausted, nil
 	}
 
@@ -132,6 +133,7 @@ func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExt
 
 	taskCtx, cancel := context.WithTimeout(ctx, b.imageExtractTimeout)
 	text, imageUsage, err := b.imageExtractor.ExtractImageText(taskCtx, ImageExtractRequest{
+		TenantID:    b.tenantID,
 		FileID:      task.FileID,
 		Path:        task.Path,
 		ContentType: ct,

--- a/pkg/backend/image_extract_basic.go
+++ b/pkg/backend/image_extract_basic.go
@@ -63,20 +63,20 @@ func NewFallbackImageTextExtractor(primary, fallback ImageTextExtractor) ImageTe
 func (e *fallbackImageTextExtractor) ExtractImageText(ctx context.Context, req ImageExtractRequest) (string, ImageExtractUsage, error) {
 	text, usage, err := e.primary.ExtractImageText(ctx, req)
 	if err != nil {
-		logger.Warn(ctx, "backend_image_extract_primary_failed",
+		logger.Warn(ctx, "backend_image_extract_primary_failed", zap.String("tenant_id", req.TenantID),
 			zap.String("file_id", req.FileID),
 			zap.String("path", req.Path),
 			zap.String("content_type", req.ContentType),
 			zap.Error(err))
-		metrics.RecordOperation("image_extract", "fallback", "primary_error", 0)
+		metrics.RecordTenantOperation(req.TenantID, "image_extract", "fallback", "primary_error", 0)
 		return "", usage, fmt.Errorf("primary image extractor: %w", err)
 	}
 	if strings.TrimSpace(text) != "" {
 		return text, usage, nil
 	}
-	logger.Warn(ctx, "backend_image_extract_primary_empty_use_fallback",
+	logger.Warn(ctx, "backend_image_extract_primary_empty_use_fallback", zap.String("tenant_id", req.TenantID),
 		zap.String("file_id", req.FileID),
 		zap.String("path", req.Path))
-	metrics.RecordOperation("image_extract", "fallback", "primary_empty", 0)
+	metrics.RecordTenantOperation(req.TenantID, "image_extract", "fallback", "primary_empty", 0)
 	return e.fallback.ExtractImageText(ctx, req)
 }

--- a/pkg/backend/image_extract_basic_test.go
+++ b/pkg/backend/image_extract_basic_test.go
@@ -23,7 +23,7 @@ func TestFallbackImageTextExtractorPropagatesPrimaryError(t *testing.T) {
 	fallback := &countingImageExtractor{text: "basic text"}
 	e := NewFallbackImageTextExtractor(primary, fallback)
 
-	_, _, err := e.ExtractImageText(context.Background(), ImageExtractRequest{FileID: "f1", Path: "/img/a.png"})
+	_, _, err := e.ExtractImageText(context.Background(), ImageExtractRequest{TenantID: "test-tenant", FileID: "f1", Path: "/img/a.png"})
 	if !errors.Is(err, primaryErr) {
 		t.Fatalf("expected primary error to propagate, got %v", err)
 	}
@@ -37,7 +37,7 @@ func TestFallbackImageTextExtractorUsesPrimaryText(t *testing.T) {
 	fallback := &countingImageExtractor{text: "basic text"}
 	e := NewFallbackImageTextExtractor(primary, fallback)
 
-	text, _, err := e.ExtractImageText(context.Background(), ImageExtractRequest{FileID: "f1", Path: "/img/a.png"})
+	text, _, err := e.ExtractImageText(context.Background(), ImageExtractRequest{TenantID: "test-tenant", FileID: "f1", Path: "/img/a.png"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestFallbackImageTextExtractorFallsBackOnEmptyPrimaryText(t *testing.T) {
 	fallback := &countingImageExtractor{text: "basic text"}
 	e := NewFallbackImageTextExtractor(primary, fallback)
 
-	text, _, err := e.ExtractImageText(context.Background(), ImageExtractRequest{FileID: "f1", Path: "/img/a.png"})
+	text, _, err := e.ExtractImageText(context.Background(), ImageExtractRequest{TenantID: "test-tenant", FileID: "f1", Path: "/img/a.png"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/backend/llm_usage.go
+++ b/pkg/backend/llm_usage.go
@@ -36,10 +36,11 @@ func (b *Dat9Backend) recordImageExtractUsage(taskID string, usage ImageExtractU
 	if !b.UseServerQuota() {
 		if err := b.store.InsertLLMUsage("img_extract_text", taskID, cost, totalTokens, "tokens"); err != nil {
 			logger.Warn(backgroundWithTrace(), "llm_usage_insert_failed",
+				zap.String("tenant_id", b.tenantID),
 				zap.String("task_type", "img_extract_text"),
 				zap.String("task_id", taskID),
 				zap.Error(err))
-			metrics.RecordOperation("llm_cost_budget", "usage_insert", "error", 0)
+			metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "usage_insert", "error", 0)
 		}
 	}
 	b.syncCentralLLMCostRecord(backgroundWithTrace(), "img_extract_text", taskID, cost, totalTokens, "tokens")
@@ -70,10 +71,11 @@ func (b *Dat9Backend) recordAudioExtractUsage(taskID string, usage AudioExtractU
 	if !b.UseServerQuota() {
 		if err := b.store.InsertLLMUsage("audio_extract_text", taskID, cost, rawUnits, rawUnitType); err != nil {
 			logger.Warn(backgroundWithTrace(), "llm_usage_insert_failed",
+				zap.String("tenant_id", b.tenantID),
 				zap.String("task_type", "audio_extract_text"),
 				zap.String("task_id", taskID),
 				zap.Error(err))
-			metrics.RecordOperation("llm_cost_budget", "usage_insert", "error", 0)
+			metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "usage_insert", "error", 0)
 		}
 	}
 	b.syncCentralLLMCostRecord(backgroundWithTrace(), "audio_extract_text", taskID, cost, rawUnits, rawUnitType)
@@ -113,8 +115,8 @@ func (b *Dat9Backend) monthlyLLMCostExceeded() bool {
 	}
 	total, err := b.store.MonthlyLLMCostMillicents()
 	if err != nil {
-		logger.Warn(backgroundWithTrace(), "llm_cost_budget_check_fail_open", zap.Error(err))
-		metrics.RecordOperation("llm_cost_budget", "quota_check", "fail_open", 0)
+		logger.Warn(backgroundWithTrace(), "llm_cost_budget_check_fail_open", zap.String("tenant_id", b.tenantID), zap.Error(err))
+		metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "quota_check", "fail_open", 0)
 		return false
 	}
 	return total > b.maxMonthlyLLMCostMillicents

--- a/pkg/backend/mutation_replay.go
+++ b/pkg/backend/mutation_replay.go
@@ -117,12 +117,15 @@ func (w *MutationReplayWorker) replayBatch(ctx context.Context) (fatal bool) {
 				zap.Error(err))
 			if rErr := w.store.IncrMutationRetry(ctx, entry.ID, replayMaxRetries); rErr != nil {
 				logger.Error(ctx, "mutation_replay_incr_retry_failed",
+					zap.String("tenant_id", entry.TenantID),
 					zap.Int64("log_id", entry.ID),
 					zap.Error(rErr))
 			}
+			metrics.RecordTenantOperation(entry.TenantID, "mutation_replay", entry.MutationType, "error", 0)
 			blockedTenants[entry.TenantID] = struct{}{}
 			failed++
 		} else {
+			metrics.RecordTenantOperation(entry.TenantID, "mutation_replay", entry.MutationType, "ok", 0)
 			applied++
 		}
 	}
@@ -226,6 +229,7 @@ func applyCentralQuotaMutationTx(store MetaQuotaStore, tx *sql.Tx, tenantID, mut
 
 	default:
 		logger.Warn(context.Background(), "mutation_replay_unknown_type",
+			zap.String("tenant_id", tenantID),
 			zap.String("mutation_type", mutationType),
 			zap.Int64("log_id", logID))
 		return nil // skip unknown types gracefully

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -148,44 +148,44 @@ func appendDirtyPartNumbers(baseSize int64, newSize int64, partSize int64) []int
 func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path string, newSize int64, dirtyParts []int, clientPartSize int64, expectedRevision int64) (*PatchPlan, error) {
 	start := time.Now()
 	if err := b.ensureUploadSizeAllowed(newSize); err != nil {
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if err := b.ensureFileSizeQuota(ctx, newSize); err != nil {
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}
 
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if err := rejectRootFileNodePath(path); err != nil {
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if b.s3 == nil {
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, ErrS3NotConfigured
 	}
 
 	// Look up existing file to get its S3 key
 	nf, err := b.store.Stat(ctx, path)
 	if err != nil {
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("stat existing file: %w", err)
 	}
 	if nf.File == nil || nf.File.StorageType != datastore.StorageS3 {
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("%w: %s", ErrNotS3Stored, path)
 	}
 	if expectedRevision == 0 {
-		metrics.RecordOperation("backend", "patch_upload", "conflict", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "conflict", time.Since(start))
 		return nil, datastore.ErrRevisionConflict
 	}
 	if expectedRevision > 0 && nf.File.Revision != expectedRevision {
-		metrics.RecordOperation("backend", "patch_upload", "conflict", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "conflict", time.Since(start))
 		return nil, datastore.ErrRevisionConflict
 	}
 
@@ -200,12 +200,12 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 		partSize = s3client.PartSize
 	}
 	if partSize > s3client.MaxPartSize {
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("part_size %d exceeds S3 per-part limit of %d", partSize, s3client.MaxPartSize)
 	}
 	newParts := s3client.CalcParts(newSize, partSize)
 	if len(newParts) > MaxMultipartParts {
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("part_size %d produces %d parts for size %d, exceeds S3 limit of %d", partSize, len(newParts), newSize, MaxMultipartParts)
 	}
 
@@ -220,8 +220,8 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 	// the presigned URL does not sign it — causing S3 403/400.  See #555.
 	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key, s3client.ChecksumAlgoNone, encOpts)
 	if err != nil {
-		logger.Error(ctx, "backend_patch_upload_create_mpu_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		logger.Error(ctx, "backend_patch_upload_create_mpu_failed", zap.String("tenant_id", b.tenantID), zap.String("path", path), zap.Error(err))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 
@@ -256,8 +256,8 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 			_, err := b.s3.UploadPartCopy(ctx, newS3Key, mpu.UploadID, p.Number, sourceKey, partStart, partEnd)
 			if err != nil {
 				_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
-				logger.Error(ctx, "backend_patch_upload_copy_failed", zap.String("path", path), zap.Int("part", p.Number), zap.Error(err))
-				metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+				logger.Error(ctx, "backend_patch_upload_copy_failed", zap.String("tenant_id", b.tenantID), zap.String("path", path), zap.Int("part", p.Number), zap.Error(err))
+				metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 				return nil, fmt.Errorf("copy part %d: %w", p.Number, err)
 			}
 			plan.CopiedParts = append(plan.CopiedParts, p.Number)
@@ -266,8 +266,8 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 			u, err := b.s3.PresignUploadPart(ctx, newS3Key, mpu.UploadID, p.Number, p.Size, s3client.ChecksumAlgoNone, "", s3client.UploadTTL)
 			if err != nil {
 				_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
-				logger.Error(ctx, "backend_patch_upload_presign_failed", zap.String("path", path), zap.Int("part", p.Number), zap.Error(err))
-				metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+				logger.Error(ctx, "backend_patch_upload_presign_failed", zap.String("tenant_id", b.tenantID), zap.String("path", path), zap.Int("part", p.Number), zap.Error(err))
+				metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 				return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
 			}
 
@@ -289,7 +289,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 				}
 				readURL, err := b.s3.PresignGetObjectRange(ctx, sourceKey, partStart, partEnd, s3client.DownloadTTL)
 				if err != nil {
-					logger.Warn(ctx, "backend_patch_upload_presign_read_failed", zap.String("path", path), zap.Int("part", p.Number), zap.Error(err))
+					logger.Warn(ctx, "backend_patch_upload_presign_read_failed", zap.String("tenant_id", b.tenantID), zap.String("path", path), zap.Int("part", p.Number), zap.Error(err))
 					// Non-fatal: client can still upload the full part without merging
 				} else {
 					pup.ReadURL = readURL
@@ -314,7 +314,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 	reserved, err := b.reserveUploadOnServer(ctx, uploadID, path, newSize, 0)
 	if err != nil {
 		_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
-		metrics.RecordOperation("backend", "patch_upload", "quota_exceeded", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "quota_exceeded", time.Since(start))
 		return nil, err
 	}
 
@@ -328,7 +328,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 			b.abortUploadReservation(ctx, uploadID, newSize)
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("lookup active upload for %s: %w", path, err)
 	}
 	if existing != nil {
@@ -337,7 +337,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 				b.abortUploadReservation(ctx, uploadID, newSize)
 			}
 			_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
-			metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 			return nil, fmt.Errorf("supersede active upload for %s: %w", path, err)
 		}
 	}
@@ -383,15 +383,15 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 			b.abortUploadReservation(ctx, uploadID, newSize)
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
-		logger.Error(ctx, "backend_patch_upload_insert_upload_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "patch_upload", "error", time.Since(start))
+		logger.Error(ctx, "backend_patch_upload_insert_upload_failed", zap.String("tenant_id", b.tenantID), zap.String("path", path), zap.Error(err))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}
 
 	plan.UploadID = uploadID
-	metrics.RecordOperation("backend", "patch_upload", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "ok", time.Since(start))
 
-	logger.Info(ctx, "backend_patch_upload_initiated",
+	logger.Info(ctx, "backend_patch_upload_initiated", zap.String("tenant_id", b.tenantID),
 		zap.String("path", path),
 		zap.Int64("new_size", newSize),
 		zap.Int("total_parts", len(newParts)),

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -123,17 +123,17 @@ func (b *Dat9Backend) ensureFileSizeQuota(ctx context.Context, size int64) error
 	}
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
-		metrics.RecordOperation("server_quota", "file_size_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_size_check", "fail_open", 0)
 		return nil
 	}
 	if cfg.MaxFileSizeBytes <= 0 {
 		return nil
 	}
 	if size > cfg.MaxFileSizeBytes {
-		metrics.RecordOperation("server_quota", "file_size_check", "exceeded", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_size_check", "exceeded", 0)
 		return fmt.Errorf("%w: server limit=%d requested=%d", ErrFileSizeQuotaExceeded, cfg.MaxFileSizeBytes, size)
 	}
-	metrics.RecordOperation("server_quota", "file_size_check", "ok", 0)
+	metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_size_check", "ok", 0)
 	return nil
 }
 
@@ -158,10 +158,10 @@ func (b *Dat9Backend) ensureStorageQuotaServer(ctx context.Context, tx *sql.Tx, 
 		return nil
 	}
 	if result.exceeded() {
-		metrics.RecordOperation("server_quota", "storage_check", "exceeded", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "storage_check", "exceeded", 0)
 		return result.quotaExceededError()
 	}
-	metrics.RecordOperation("server_quota", "storage_check", "ok", 0)
+	metrics.RecordTenantOperation(b.tenantID, "server_quota", "storage_check", "ok", 0)
 	return nil
 }
 
@@ -175,7 +175,7 @@ func (b *Dat9Backend) ensureFileCountQuotaServer(ctx context.Context, tx *sql.Tx
 	}
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
-		metrics.RecordOperation("server_quota", "file_count_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check", "fail_open", 0)
 		return nil
 	}
 	if cfg.MaxFileCount <= 0 {
@@ -183,21 +183,21 @@ func (b *Dat9Backend) ensureFileCountQuotaServer(ctx context.Context, tx *sql.Tx
 	}
 	usage := b.cachedQuotaUsage(ctx)
 	if usage == nil {
-		metrics.RecordOperation("server_quota", "file_count_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check", "fail_open", 0)
 		return nil
 	}
 	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
 	_, pendingFileDelta, _, pendingOK := b.cachedPendingQuotaOutboxDeltasTx(ctx, tx)
 	if !pendingOK {
-		metrics.RecordOperation("server_quota", "file_count_check_pending_delta", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check_pending_delta", "fail_open", 0)
 	}
 	projected := usage.FileCount + pendingFileDelta + currentFileDelta
 	if projected > cfg.MaxFileCount {
-		metrics.RecordOperation("server_quota", "file_count_check", "exceeded", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check", "exceeded", 0)
 		return fmt.Errorf("%w: server limit=%d used=%d pending=%d delta=%d",
 			ErrFileCountQuotaExceeded, cfg.MaxFileCount, usage.FileCount, pendingFileDelta, currentFileDelta)
 	}
-	metrics.RecordOperation("server_quota", "file_count_check", "ok", 0)
+	metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check", "ok", 0)
 	return nil
 }
 
@@ -209,7 +209,7 @@ func (b *Dat9Backend) checkStorageQuotaServerTx(ctx context.Context, tx *sql.Tx,
 
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
-		metrics.RecordOperation("server_quota", "storage_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "storage_check", "fail_open", 0)
 		return result, false // fail-open: config unavailable
 	}
 	if cfg.MaxStorageBytes <= 0 {
@@ -217,13 +217,13 @@ func (b *Dat9Backend) checkStorageQuotaServerTx(ctx context.Context, tx *sql.Tx,
 	}
 	usage := b.cachedQuotaUsage(ctx)
 	if usage == nil {
-		metrics.RecordOperation("server_quota", "storage_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "storage_check", "fail_open", 0)
 		return result, false // fail-open: usage unavailable
 	}
 	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
 	pendingStorageDelta, _, _, pendingOK := b.cachedPendingQuotaOutboxDeltasTx(ctx, tx)
 	if !pendingOK {
-		metrics.RecordOperation("server_quota", "storage_check_pending_delta", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "storage_check_pending_delta", "fail_open", 0)
 	}
 	result.checked = true
 	result.limitBytes = cfg.MaxStorageBytes
@@ -241,10 +241,10 @@ func (b *Dat9Backend) lockQuotaAdmissionTx(ctx context.Context, tx *sql.Tx) erro
 	if err := b.store.LockQuotaAdmissionTx(tx); err != nil {
 		logger.Warn(ctx, "server_quota_admission_lock_failed",
 			zap.String("tenant_id", b.tenantID), zap.Error(err))
-		metrics.RecordOperation("server_quota", "admission_lock", "error", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "admission_lock", "error", 0)
 		return fmt.Errorf("lock quota admission: %w", err)
 	}
-	metrics.RecordOperation("server_quota", "admission_lock", "ok", 0)
+	metrics.RecordTenantOperation(b.tenantID, "server_quota", "admission_lock", "ok", 0)
 	return nil
 }
 
@@ -332,7 +332,7 @@ func (b *Dat9Backend) mediaLLMQuotaExceededServerTx(ctx context.Context, tx *sql
 	}
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
-		metrics.RecordOperation("server_quota", "media_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "media_check", "fail_open", 0)
 		return false
 	}
 	if cfg.MaxMediaLLMFiles <= 0 {
@@ -340,13 +340,13 @@ func (b *Dat9Backend) mediaLLMQuotaExceededServerTx(ctx context.Context, tx *sql
 	}
 	usage := b.cachedQuotaUsage(ctx)
 	if usage == nil {
-		metrics.RecordOperation("server_quota", "media_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "media_check", "fail_open", 0)
 		return false
 	}
 	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
 	_, _, pendingMediaDelta, pendingOK := b.cachedPendingQuotaOutboxDeltasTx(ctx, tx)
 	if !pendingOK {
-		metrics.RecordOperation("server_quota", "media_check_pending_delta", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "media_check_pending_delta", "fail_open", 0)
 	}
 	return usage.MediaFileCount+pendingMediaDelta+currentMediaDelta > cfg.MaxMediaLLMFiles
 }
@@ -411,7 +411,7 @@ func (b *Dat9Backend) mediaLLMQuotaExceededTx(tx *sql.Tx) bool {
 	count, err := b.store.ConfirmedMediaFileCountTx(tx)
 	if err != nil {
 		logger.Warn(backgroundWithTrace(), "media_llm_quota_check_fail_open", zap.Error(err))
-		metrics.RecordOperation("media_llm_budget", "quota_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "media_llm_budget", "quota_check", "fail_open", 0)
 		return false
 	}
 	return count > b.maxMediaLLMFiles

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -93,7 +93,7 @@ func (b *Dat9Backend) monthlyLLMCostExceededServer(ctx context.Context) bool {
 	if err != nil {
 		logger.Warn(ctx, "server_llm_cost_check_fail_open",
 			zap.String("tenant_id", b.tenantID), zap.Error(err))
-		metrics.RecordOperation("server_quota", "llm_cost_check", "fail_open", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "llm_cost_check", "fail_open", time.Since(start))
 		return false // fail-open
 	}
 	// Use per-tenant config if available, otherwise fall back to global default.

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -110,23 +110,23 @@ func (c *quotaConfigCache) load(ctx context.Context) *QuotaConfigView {
 	if err != nil {
 		logger.Warn(ctx, "quota_config_cache_config_failed",
 			zap.String("tenant_id", c.tenantID), zap.Error(err))
-		metrics.RecordOperation("quota_config_cache", "load", "config_error", time.Since(start))
+		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "load", "config_error", time.Since(start))
 		return nil
 	}
 	if cfg == nil {
-		metrics.RecordOperation("quota_config_cache", "load", "config_empty", time.Since(start))
+		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "load", "config_empty", time.Since(start))
 		return nil
 	}
 	c.mu.Lock()
 	if c.snapshot != nil && c.snapshot.config != nil {
 		existing := cloneQuotaConfigView(c.snapshot.config)
 		c.mu.Unlock()
-		metrics.RecordOperation("quota_config_cache", "load", "raced_refresh", time.Since(start))
+		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "load", "raced_refresh", time.Since(start))
 		return existing
 	}
 	c.snapshot = &quotaConfigSnapshot{config: cloneQuotaConfigView(cfg), version: ""}
 	c.mu.Unlock()
-	metrics.RecordOperation("quota_config_cache", "load", "ok", time.Since(start))
+	metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "load", "ok", time.Since(start))
 	return cloneQuotaConfigView(cfg)
 }
 
@@ -155,7 +155,7 @@ func (c *quotaConfigCache) refresh(ctx context.Context) {
 	if err != nil {
 		logger.Warn(ctx, "quota_config_cache_version_failed",
 			zap.String("tenant_id", c.tenantID), zap.Error(err))
-		metrics.RecordOperation("quota_config_cache", "refresh", "version_error", time.Since(start))
+		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "refresh", "version_error", time.Since(start))
 		return
 	}
 
@@ -163,7 +163,7 @@ func (c *quotaConfigCache) refresh(ctx context.Context) {
 	snapshot := c.snapshot
 	if snapshot != nil && snapshot.version == version {
 		c.mu.RUnlock()
-		metrics.RecordOperation("quota_config_cache", "refresh", "unchanged", time.Since(start))
+		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "refresh", "unchanged", time.Since(start))
 		return
 	}
 	c.mu.RUnlock()
@@ -172,13 +172,13 @@ func (c *quotaConfigCache) refresh(ctx context.Context) {
 	if err != nil {
 		logger.Warn(ctx, "quota_config_cache_config_failed",
 			zap.String("tenant_id", c.tenantID), zap.Error(err))
-		metrics.RecordOperation("quota_config_cache", "refresh", "config_error", time.Since(start))
+		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "refresh", "config_error", time.Since(start))
 		return
 	}
 	c.mu.Lock()
 	c.snapshot = &quotaConfigSnapshot{config: cloneQuotaConfigView(cfg), version: version}
 	c.mu.Unlock()
-	metrics.RecordOperation("quota_config_cache", "refresh", "ok", time.Since(start))
+	metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "refresh", "ok", time.Since(start))
 }
 
 type quotaUsageSnapshot struct {
@@ -226,11 +226,11 @@ func (c *quotaUsageCache) get(ctx context.Context) *QuotaUsageView {
 	if err != nil {
 		logger.Warn(ctx, "server_quota_usage_fail_open",
 			zap.String("tenant_id", c.tenantID), zap.Error(err))
-		metrics.RecordOperation("server_quota", "usage_cache", "load_error", time.Since(start))
+		metrics.RecordTenantOperation(c.tenantID, "server_quota", "usage_cache", "load_error", time.Since(start))
 		return nil
 	}
 	if usage == nil {
-		metrics.RecordOperation("server_quota", "usage_cache", "load_empty", time.Since(start))
+		metrics.RecordTenantOperation(c.tenantID, "server_quota", "usage_cache", "load_empty", time.Since(start))
 		return nil
 	}
 	copied := *usage
@@ -240,7 +240,7 @@ func (c *quotaUsageCache) get(ctx context.Context) *QuotaUsageView {
 		expiresAt: time.Now().Add(c.ttl),
 	}
 	c.mu.Unlock()
-	metrics.RecordOperation("server_quota", "usage_cache", "load_ok", time.Since(start))
+	metrics.RecordTenantOperation(c.tenantID, "server_quota", "usage_cache", "load_ok", time.Since(start))
 	return cloneQuotaUsageView(usage)
 }
 
@@ -287,8 +287,9 @@ type quotaPendingDeltasLoader func(context.Context) (storageDelta, fileDelta, me
 // only used by soft admission checks; strict upload reservation still reads the
 // tenant DB directly.
 type quotaPendingDeltasCache struct {
-	load quotaPendingDeltasLoader
-	ttl  time.Duration
+	tenantID string
+	load     quotaPendingDeltasLoader
+	ttl      time.Duration
 
 	mu         sync.RWMutex
 	snapshot   *quotaPendingDeltasSnapshot
@@ -296,11 +297,11 @@ type quotaPendingDeltasCache struct {
 	loadMu     sync.Mutex
 }
 
-func newQuotaPendingDeltasCache(load quotaPendingDeltasLoader, ttl time.Duration) *quotaPendingDeltasCache {
+func newQuotaPendingDeltasCache(tenantID string, load quotaPendingDeltasLoader, ttl time.Duration) *quotaPendingDeltasCache {
 	if ttl <= 0 {
 		ttl = quotaPendingDeltasCacheTTL
 	}
-	return &quotaPendingDeltasCache{load: load, ttl: ttl}
+	return &quotaPendingDeltasCache{tenantID: tenantID, load: load, ttl: ttl}
 }
 
 func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, bool) {
@@ -326,8 +327,8 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 	start := time.Now()
 	storageDelta, fileDelta, mediaDelta, err := c.load(ctx)
 	if err != nil {
-		logger.Warn(ctx, "server_quota_pending_outbox_delta_fail_open", zap.Error(err))
-		metrics.RecordOperation("server_quota", "pending_delta_cache", "load_error", time.Since(start))
+		logger.Warn(ctx, "server_quota_pending_outbox_delta_fail_open", zap.String("tenant_id", c.tenantID), zap.Error(err))
+		metrics.RecordTenantOperation(c.tenantID, "server_quota", "pending_delta_cache", "load_error", time.Since(start))
 		return quotaPendingDeltas{}, false
 	}
 	deltas := quotaPendingDeltas{
@@ -342,7 +343,7 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 		// A local enqueue or ack raced this DB load. Do not merge blindly:
 		// the SELECT may or may not have observed that row. Let the caller
 		// fall back to a live tenant-DB read for this check.
-		metrics.RecordOperation("server_quota", "pending_delta_cache", "raced_local_delta", time.Since(start))
+		metrics.RecordTenantOperation(c.tenantID, "server_quota", "pending_delta_cache", "raced_local_delta", time.Since(start))
 		return quotaPendingDeltas{}, false
 	}
 	c.snapshot = &quotaPendingDeltasSnapshot{
@@ -350,7 +351,7 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 		expiresAt: expiresAt,
 	}
 	c.mu.Unlock()
-	metrics.RecordOperation("server_quota", "pending_delta_cache", "load_ok", time.Since(start))
+	metrics.RecordTenantOperation(c.tenantID, "server_quota", "pending_delta_cache", "load_ok", time.Since(start))
 	return deltas, true
 }
 

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -286,7 +286,7 @@ func TestQuotaPendingDeltasCacheUsesTTLAndLocalAdjustments(t *testing.T) {
 	storage := int64(10)
 	file := int64(1)
 	media := int64(0)
-	c := newQuotaPendingDeltasCache(func(context.Context) (int64, int64, int64, error) {
+	c := newQuotaPendingDeltasCache("test-tenant", func(context.Context) (int64, int64, int64, error) {
 		calls.Add(1)
 		return storage, file, media, nil
 	}, time.Hour)
@@ -320,7 +320,7 @@ func TestQuotaPendingDeltasCacheDoesNotPublishSnapshotWhenLocalDeltaRacesLoad(t 
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var once sync.Once
-	c := newQuotaPendingDeltasCache(func(context.Context) (int64, int64, int64, error) {
+	c := newQuotaPendingDeltasCache("test-tenant", func(context.Context) (int64, int64, int64, error) {
 		calls.Add(1)
 		once.Do(func() { close(started) })
 		<-release

--- a/pkg/backend/quota_mutation.go
+++ b/pkg/backend/quota_mutation.go
@@ -76,7 +76,7 @@ func (b *Dat9Backend) logQuotaMutation(ctx context.Context, mutationType string,
 			zap.String("tenant_id", b.tenantID),
 			zap.String("mutation_type", mutationType),
 			zap.Error(err))
-		metrics.RecordOperation("central_quota", mutationType, "fail_open", time.Duration(0))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "fail_open", time.Duration(0))
 		return 0, false
 	}
 	return logID, true
@@ -97,10 +97,10 @@ func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType strin
 			zap.String("mutation_type", mutationType),
 			zap.Int64("log_id", logID),
 			zap.Error(err))
-		metrics.RecordOperation("central_quota", mutationType, "pending", time.Duration(0))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "pending", time.Duration(0))
 		return
 	}
-	metrics.RecordOperation("central_quota", mutationType, "ok", time.Duration(0))
+	metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "ok", time.Duration(0))
 }
 
 // logAndEnqueueMutation atomically logs a mutation and enqueues its apply

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -125,7 +125,7 @@ func (b *Dat9Backend) processQuotaOutboxAvailable(ctx context.Context) {
 		logger.Warn(ctx, "quota_outbox_recover_expired_failed",
 			zap.String("tenant_id", b.tenantID),
 			zap.Error(err))
-		metrics.RecordOperation("quota_outbox", "recover_expired", "error", 0)
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "recover_expired", "error", 0)
 	}
 	processedTotal := 0
 	for processedTotal < quotaOutboxBatchSize {
@@ -245,11 +245,11 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 	}
 	entries, err := b.store.ClaimQuotaOutboxBatch(ctx, time.Now().UTC(), quotaOutboxLeaseDuration, limit)
 	if err != nil {
-		metrics.RecordOperation("quota_outbox", "claim", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "claim", "error", time.Since(start))
 		return 0, err
 	}
 	if len(entries) == 0 {
-		metrics.RecordOperation("quota_outbox", "claim", "empty", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "claim", "empty", time.Since(start))
 		return 0, nil
 	}
 
@@ -276,7 +276,7 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 		return nil
 	})
 	if err != nil {
-		metrics.RecordOperation("quota_outbox", "process", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "process", "error", time.Since(start))
 		return processed, err
 	}
 	if batchApplyErr == nil && processed > 0 {
@@ -300,7 +300,7 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 			appliedEntries = append(appliedEntries, entries[i])
 		}
 		if entryErr != nil {
-			metrics.RecordOperation("quota_outbox", entries[i].MutationType, "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "quota_outbox", entries[i].MutationType, "error", time.Since(start))
 			if !entryProcessed {
 				b.recordAppliedQuotaOutboxEntries(start, appliedEntries)
 				return processed, entryErr
@@ -359,7 +359,7 @@ func (b *Dat9Backend) recordAppliedQuotaOutboxEntries(start time.Time, entries [
 	}
 	for _, entry := range entries {
 		b.addLocalQuotaPendingDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
-		metrics.RecordOperation("quota_outbox", entry.MutationType, "ok", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", entry.MutationType, "ok", time.Since(start))
 	}
 }
 

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -141,7 +141,7 @@ func (b *Dat9Backend) SetMetaQuotaStore(ctx context.Context, tenantID string, mq
 		b.quotaConfigCache = newQuotaConfigCache(tenantID, mqs)
 		b.quotaUsageCache = newQuotaUsageCache(tenantID, mqs, quotaUsageCacheTTL)
 		if b.store != nil {
-			b.quotaPendingCache = newQuotaPendingDeltasCache(b.store.PendingQuotaOutboxDeltas, quotaPendingDeltasCacheTTL)
+			b.quotaPendingCache = newQuotaPendingDeltasCache(b.tenantID, b.store.PendingQuotaOutboxDeltas, quotaPendingDeltasCacheTTL)
 		}
 		b.startMutationWorker()
 		b.startQuotaOutboxWorker()

--- a/pkg/backend/runtime_metrics_test.go
+++ b/pkg/backend/runtime_metrics_test.go
@@ -40,16 +40,16 @@ func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
 	}
 	// Image extract delivery is now durable (semantic_tasks), so queue capacity
 	// and workers are always 0 — the semantic worker handles processing.
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 0") {
+	if !strings.Contains(metricsText, 	"drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\",tenant_id=\"\"} 0") {
 		t.Fatalf("metrics missing aggregated image queue capacity: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"workers\"} 0") {
+	if !strings.Contains(metricsText, 	"drive9_service_gauge{component=\"image_extract\",name=\"workers\",tenant_id=\"\"} 0") {
 		t.Fatalf("metrics missing aggregated image workers: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 4096") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\",tenant_id=\"\"} 4096") {
 		t.Fatalf("metrics missing aggregated audio max bytes: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\"} 3") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\",tenant_id=\"\"} 3") {
 		t.Fatalf("metrics missing aggregated audio timeout: %s", metricsText)
 	}
 
@@ -59,19 +59,19 @@ func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
 	if !strings.Contains(metricsText, "drive9_module_up{module=\"image_extract\"} 1") {
 		t.Fatalf("metrics should keep image_extract available while one backend remains: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\"} 0") {
+	if !strings.Contains(metricsText, 	"drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\",tenant_id=\"\"} 0") {
 		t.Fatalf("metrics should keep image queue capacity at 0 after one backend closes: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"workers\"} 0") {
+	if !strings.Contains(metricsText, 	"drive9_service_gauge{component=\"image_extract\",name=\"workers\",tenant_id=\"\"} 0") {
 		t.Fatalf("metrics should keep image workers at 0 after one backend closes: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\"} 2048") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\",tenant_id=\"\"} 2048") {
 		t.Fatalf("metrics should retain remaining audio max bytes: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_extract_text_bytes\"} 555") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_extract_text_bytes\",tenant_id=\"\"} 555") {
 		t.Fatalf("metrics should retain remaining audio text limit: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\"} 2") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\",tenant_id=\"\"} 2") {
 		t.Fatalf("metrics should retain remaining audio timeout: %s", metricsText)
 	}
 

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -51,7 +51,7 @@ func (b *Dat9Backend) enqueueExtractSemanticTasksTx(ctx context.Context, tx *sql
 		return false, nil
 	}
 	if b.mediaLLMQuotaExceededCheckTx(ctx, tx, currentMediaDelta) {
-		metrics.RecordOperation("media_llm_budget", "enqueue_skip", "quota_exceeded", 0)
+		metrics.RecordTenantOperation(b.tenantID, "media_llm_budget", "enqueue_skip", "quota_exceeded", 0)
 		return false, nil
 	}
 	enqueued := false

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -246,45 +246,45 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context, path string, totalSize int64, partChecksums []string, expectedRevision int64, description string) (*UploadPlan, error) {
 	start := time.Now()
 	if utf8.RuneCountInString(description) > MaxDescriptionLen {
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("description exceeds %d characters", MaxDescriptionLen)
 	}
 	if err := b.ensureUploadSizeAllowed(totalSize); err != nil {
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if err := b.ensureFileSizeQuota(ctx, totalSize); err != nil {
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
 		logger.Warn(ctx, "backend_initiate_upload_invalid_path", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if err := rejectRootFileNodePath(path); err != nil {
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if b.s3 == nil {
 		err := ErrS3NotConfigured
 		logger.Error(ctx, "backend_initiate_upload_s3_missing", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 	target, targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
 	if err != nil {
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			metrics.RecordOperation("backend", "initiate_upload", "conflict", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "conflict", time.Since(start))
 		} else {
-			metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		}
 		return nil, err
 	}
 	if err := b.drainQuotaOutboxForUploadTarget(ctx, target, targetExists); err != nil {
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 
@@ -296,7 +296,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 	// remote side effects.
 	parts := s3client.CalcParts(totalSize, s3client.PartSize)
 	if len(partChecksums) > 0 && len(partChecksums) != len(parts) {
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("%w: got %d, expected %d", ErrPartChecksumCountMismatch, len(partChecksums), len(parts))
 	}
 
@@ -304,7 +304,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoCRC32C, encOpts)
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_create_multipart_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 
@@ -319,7 +319,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 		if err != nil {
 			_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 			logger.Error(ctx, "backend_initiate_upload_presign_failed", zap.String("path", path), zap.Int("part_number", p.Number), zap.Error(err))
-			metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 			return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
 		}
 		urls[i] = u
@@ -333,7 +333,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 	reserved, err := b.reserveUploadOnServer(ctx, uploadID, path, totalSize, uploadFileCountDelta(targetExists))
 	if err != nil {
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-		metrics.RecordOperation("backend", "initiate_upload", "quota_exceeded", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "quota_exceeded", time.Since(start))
 		return nil, err
 	}
 
@@ -347,7 +347,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 			b.abortUploadReservation(ctx, uploadID, totalSize)
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("lookup active upload for %s: %w", path, err)
 	}
 	if existing != nil {
@@ -356,7 +356,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 				b.abortUploadReservation(ctx, uploadID, totalSize)
 			}
 			_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-			metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 			return nil, fmt.Errorf("supersede active upload for %s: %w", path, err)
 		}
 	}
@@ -407,10 +407,10 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 		logger.Error(ctx, "backend_initiate_upload_insert_upload_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
-	metrics.RecordOperation("backend", "initiate_upload", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "ok", time.Since(start))
 
 	return &UploadPlan{
 		UploadID: uploadID,
@@ -430,46 +430,46 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path string, totalSize int64, expectedRevision int64, description string) (*UploadPlanV2, error) {
 	start := time.Now()
 	if utf8.RuneCountInString(description) > MaxDescriptionLen {
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, fmt.Errorf("description exceeds %d characters", MaxDescriptionLen)
 	}
 	validateStart := time.Now()
 	if err := b.ensureUploadSizeAllowed(totalSize); err != nil {
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	if err := b.ensureFileSizeQuota(ctx, totalSize); err != nil {
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
 		logger.Warn(ctx, "backend_initiate_upload_v2_invalid_path", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	if err := rejectRootFileNodePath(path); err != nil {
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	if b.s3 == nil {
 		err := ErrS3NotConfigured
 		logger.Error(ctx, "backend_initiate_upload_v2_s3_missing", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	target, targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
 	if err != nil {
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			metrics.RecordOperation("backend", "initiate_upload_v2", "conflict", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "conflict", time.Since(start))
 		} else {
-			metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		}
 		return nil, err
 	}
 	if err := b.drainQuotaOutboxForUploadTarget(ctx, target, targetExists); err != nil {
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	validateDurationMs := uploadPhaseMs(validateStart)
@@ -481,7 +481,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 	if len(parts) > MaxMultipartParts {
 		err := fmt.Errorf("file too large: %d parts exceeds S3 limit of %d", len(parts), MaxMultipartParts)
 		logger.Warn(ctx, "backend_initiate_upload_v2_too_many_parts", zap.String("path", path), zap.Int("parts", len(parts)), zap.Int64("total_size", totalSize))
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 
@@ -496,7 +496,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoNone, encOpts)
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_v2_create_multipart_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 	createMultipartDurationMs := uploadPhaseMs(createMultipartStart)
@@ -510,7 +510,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 	reserved, err := b.reserveUploadOnServer(ctx, uploadID, path, totalSize, uploadFileCountDelta(targetExists))
 	if err != nil {
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-		metrics.RecordOperation("backend", "initiate_upload_v2", "quota_exceeded", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "quota_exceeded", time.Since(start))
 		return nil, err
 	}
 
@@ -521,7 +521,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 			b.abortUploadReservation(ctx, uploadID, totalSize)
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, fmt.Errorf("lookup active upload for %s: %w", path, err)
 	}
 	if existing != nil {
@@ -533,7 +533,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 				b.abortUploadReservation(ctx, uploadID, totalSize)
 			}
 			_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-			metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 			return nil, fmt.Errorf("supersede active upload for %s: %w", path, err)
 		}
 	}
@@ -598,7 +598,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 		logger.Error(ctx, "backend_initiate_upload_v2_insert_upload_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	txDurationMs := uploadPhaseMs(txStart)
@@ -616,7 +616,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		zap.Float64("tx_ms", txDurationMs),
 		zap.Float64("total_ms", uploadPhaseMs(start)),
 	)
-	metrics.RecordOperation("backend", "initiate_upload_v2", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "ok", time.Since(start))
 
 	return &UploadPlanV2{
 		UploadID:   uploadID,
@@ -656,24 +656,24 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "error", time.Since(start))
 		return nil, err
 	}
 	upload, err = b.ensureUploadPresignable(ctx, uploadID, upload)
 	if err != nil {
 		switch {
 		case errors.Is(err, datastore.ErrUploadExpired):
-			metrics.RecordOperation("backend", "presign_part", "expired", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "expired", time.Since(start))
 		case errors.Is(err, datastore.ErrUploadNotActive):
-			metrics.RecordOperation("backend", "presign_part", "not_active", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "not_active", time.Since(start))
 		default:
 			logger.Error(ctx, "backend_presign_part_ensure_presignable_failed", zap.String("upload_id", uploadID), zap.Error(err))
-			metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "error", time.Since(start))
 		}
 		return nil, err
 	}
 	if partNumber < 1 || partNumber > upload.PartsTotal {
-		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "error", time.Since(start))
 		return nil, uploadClientProtocolErrorf("invalid part number %d: must be between 1 and %d", partNumber, upload.PartsTotal)
 	}
 
@@ -682,16 +682,16 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 
 	checksumSHA256, err := resolveChecksumSHA256(checksum)
 	if err != nil {
-		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "error", time.Since(start))
 		return nil, err
 	}
 	u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, partNumber, partSize, s3client.ChecksumAlgoSHA256, checksumSHA256, s3client.UploadTTL)
 	if err != nil {
 		logger.Error(ctx, "backend_presign_part_failed", zap.String("upload_id", uploadID), zap.Int("part_number", partNumber), zap.Error(err))
-		metrics.RecordOperation("backend", "presign_part", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "error", time.Since(start))
 		return nil, fmt.Errorf("presign part %d: %w", partNumber, err)
 	}
-	metrics.RecordOperation("backend", "presign_part", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "ok", time.Since(start))
 	return u, nil
 }
 
@@ -703,7 +703,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 	getUploadStart := time.Now()
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
 		return nil, err
 	}
 	getUploadDurationMs := uploadPhaseMs(getUploadStart)
@@ -714,12 +714,12 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 	if err != nil {
 		switch {
 		case errors.Is(err, datastore.ErrUploadExpired):
-			metrics.RecordOperation("backend", "presign_parts", "expired", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "expired", time.Since(start))
 		case errors.Is(err, datastore.ErrUploadNotActive):
-			metrics.RecordOperation("backend", "presign_parts", "not_active", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "not_active", time.Since(start))
 		default:
 			logger.Error(ctx, "backend_presign_parts_ensure_presignable_failed", zap.String("upload_id", uploadID), zap.Error(err))
-			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
 		}
 		return nil, err
 	}
@@ -727,14 +727,14 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		statusTransitionDurationMs = uploadPhaseMs(statusTransitionStart)
 	}
 	if len(entries) > MaxPresignBatch {
-		metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
 		return nil, uploadClientProtocolErrorf("batch too large: %d parts exceeds limit of %d", len(entries), MaxPresignBatch)
 	}
 	// Reject duplicate part numbers in the batch.
 	seen := make(map[int]bool, len(entries))
 	for _, e := range entries {
 		if seen[e.PartNumber] {
-			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
 			return nil, uploadClientProtocolErrorf("duplicate part number %d in batch", e.PartNumber)
 		}
 		seen[e.PartNumber] = true
@@ -752,7 +752,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 	for i, e := range entries {
 		pn := e.PartNumber
 		if pn < 1 || pn > upload.PartsTotal {
-			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
 			return nil, uploadClientProtocolErrorf("invalid part number %d: must be between 1 and %d", pn, upload.PartsTotal)
 		}
 		partSize := parts[pn-1].Size
@@ -761,7 +761,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		resolveChecksumDurationMs := uploadPhaseMs(resolveChecksumStart)
 		resolveChecksumTotalMs += resolveChecksumDurationMs
 		if err != nil {
-			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
 			return nil, err
 		}
 		s3PresignStart := time.Now()
@@ -773,7 +773,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		}
 		if err != nil {
 			logger.Error(ctx, "backend_presign_parts_failed", zap.String("upload_id", uploadID), zap.Int("part_number", pn), zap.Error(err))
-			metrics.RecordOperation("backend", "presign_parts", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
 			return nil, fmt.Errorf("presign part %d: %w", pn, err)
 		}
 		urls[i] = u
@@ -798,7 +798,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		zap.Float64("s3_presign_max_ms", s3PresignMaxMs),
 		zap.Float64("total_ms", uploadPhaseMs(start)),
 	)
-	metrics.RecordOperation("backend", "presign_parts", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "ok", time.Since(start))
 	return urls, nil
 }
 
@@ -825,24 +825,24 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	getUploadStart := time.Now()
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
 		return err
 	}
 	getUploadDurationMs := uploadPhaseMs(getUploadStart)
 	if upload.Status != datastore.UploadUploading {
-		metrics.RecordOperation("backend", "confirm_upload_v2", "not_active", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "not_active", time.Since(start))
 		return datastore.ErrUploadNotActive
 	}
 	if time.Now().After(upload.ExpiresAt) {
 		_ = b.AbortUploadV2(ctx, uploadID)
-		metrics.RecordOperation("backend", "confirm_upload_v2", "expired", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "expired", time.Since(start))
 		return datastore.ErrUploadExpired
 	}
 
 	// Validate client-supplied part count
 	clientValidationStart := time.Now()
 	if len(clientParts) != upload.PartsTotal {
-		metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
 		return uploadClientProtocolErrorf("part count mismatch: client sent %d, expected %d", len(clientParts), upload.PartsTotal)
 	}
 
@@ -850,11 +850,11 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	clientPartMap := make(map[int]string, len(clientParts))
 	for _, cp := range clientParts {
 		if _, dup := clientPartMap[cp.Number]; dup {
-			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
 			return uploadClientProtocolErrorf("duplicate part number %d in complete request", cp.Number)
 		}
 		if cp.Number < 1 || cp.Number > upload.PartsTotal {
-			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
 			return uploadClientProtocolErrorf("invalid part number %d: must be between 1 and %d", cp.Number, upload.PartsTotal)
 		}
 		clientPartMap[cp.Number] = cp.ETag
@@ -866,7 +866,7 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	s3Parts, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
 	if err != nil {
 		logger.Error(ctx, "backend_confirm_upload_v2_list_parts_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
 		return fmt.Errorf("list parts: %w", err)
 	}
 	listPartsDurationMs := uploadPhaseMs(listPartsStart)
@@ -880,11 +880,11 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	for partNum, clientETag := range clientPartMap {
 		s3ETag, ok := s3PartMap[partNum]
 		if !ok {
-			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
 			return uploadClientProtocolErrorf("part %d not found in S3", partNum)
 		}
 		if normalizeETag(clientETag) != normalizeETag(s3ETag) {
-			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
 			return uploadClientProtocolErrorf("part %d ETag mismatch: client=%q, S3=%q", partNum, clientETag, s3ETag)
 		}
 	}
@@ -894,12 +894,12 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	sizeValidationStart := time.Now()
 	expectedParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	if len(s3Parts) != len(expectedParts) {
-		metrics.RecordOperation("backend", "confirm_upload_v2", "incomplete", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "incomplete", time.Since(start))
 		return uploadClientProtocolErrorf("incomplete upload: S3 has %d parts, expected %d", len(s3Parts), len(expectedParts))
 	}
 	for i, p := range s3Parts {
 		if p.Size != expectedParts[i].Size {
-			metrics.RecordOperation("backend", "confirm_upload_v2", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
 			return uploadClientProtocolErrorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
 		}
 	}
@@ -922,7 +922,7 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 		zap.Float64("finalize_upload_ms", finalizeDurationMs),
 		zap.Float64("total_ms", uploadPhaseMs(start)),
 	)
-	metrics.RecordOperation("backend", "confirm_upload_v2", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "ok", time.Since(start))
 	return nil
 }
 
@@ -943,11 +943,11 @@ func (b *Dat9Backend) ConfirmUploadWithTags(ctx context.Context, uploadID string
 
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "error", time.Since(start))
 		return err
 	}
 	if upload.Status != datastore.UploadUploading {
-		metrics.RecordOperation("backend", "confirm_upload", "not_active", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "not_active", time.Since(start))
 		return datastore.ErrUploadNotActive
 	}
 
@@ -955,28 +955,28 @@ func (b *Dat9Backend) ConfirmUploadWithTags(ctx context.Context, uploadID string
 	parts, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
 	if err != nil {
 		logger.Error(ctx, "backend_confirm_upload_list_parts_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "error", time.Since(start))
 		return fmt.Errorf("list parts: %w", err)
 	}
 
 	// Verify all parts are present, correctly sized, and have ETags
 	if len(parts) != upload.PartsTotal {
-		metrics.RecordOperation("backend", "confirm_upload", "incomplete", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "incomplete", time.Since(start))
 		return uploadClientProtocolErrorf("incomplete upload: got %d parts, expected %d", len(parts), upload.PartsTotal)
 	}
 	expectedParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	for i, p := range parts {
 		if p.Size != expectedParts[i].Size {
-			metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "error", time.Since(start))
 			return uploadClientProtocolErrorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
 		}
 		if p.ETag == "" {
-			metrics.RecordOperation("backend", "confirm_upload", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "error", time.Since(start))
 			return uploadClientProtocolErrorf("part %d missing ETag", p.Number)
 		}
 	}
 
-	metrics.RecordOperation("backend", "confirm_upload", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "ok", time.Since(start))
 	return b.finalizeUpload(ctx, upload, parts, tags)
 }
 
@@ -990,7 +990,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	start := time.Now()
 	uploadID := upload.UploadID
 	if err := rejectRootFileNodePath(upload.TargetPath); err != nil {
-		metrics.RecordOperation("backend", "finalize_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
 		return err
 	}
 	expectedRevision := uploadExpectedRevision(upload)
@@ -998,7 +998,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	completeMultipartStart := time.Now()
 	if err := b.s3.CompleteMultipartUpload(ctx, upload.S3Key, upload.S3UploadID, parts); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_complete_multipart_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordOperation("backend", "finalize_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
 		return fmt.Errorf("complete multipart: %w", err)
 	}
 	completeMultipartDurationMs := uploadPhaseMs(completeMultipartStart)
@@ -1214,7 +1214,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		b.cleanupFailedFinalizeUpload(ctx, upload)
 		// Abort the server-side reservation since the tenant DB tx failed.
 		b.abortUploadReservation(ctx, uploadID, upload.TotalSize)
-		metrics.RecordOperation("backend", "finalize_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
 		return err
 	}
 	txDurationMs := uploadPhaseMs(txStart)
@@ -1244,7 +1244,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		zap.Float64("tx_ms", txDurationMs),
 		zap.Float64("total_ms", uploadPhaseMs(start)),
 	)
-	metrics.RecordOperation("backend", "finalize_upload", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "ok", time.Since(start))
 	return nil
 }
 
@@ -1258,11 +1258,11 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordOperation("backend", "resume_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if upload.Status != datastore.UploadUploading {
-		metrics.RecordOperation("backend", "resume_upload", "not_active", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "not_active", time.Since(start))
 		return nil, datastore.ErrUploadNotActive
 	}
 
@@ -1274,7 +1274,7 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 			logger.Warn(ctx, "backend_resume_upload_abort_expired_failed", zap.String("upload_id", uploadID), zap.Error(err))
 		}
 		_ = b.store.AbortUpload(ctx, uploadID)
-		metrics.RecordOperation("backend", "resume_upload", "expired", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "expired", time.Since(start))
 		return nil, datastore.ErrUploadExpired
 	}
 
@@ -1282,7 +1282,7 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 	uploaded, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
 	if err != nil {
 		logger.Error(ctx, "backend_resume_upload_list_parts_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordOperation("backend", "resume_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("list parts: %w", err)
 	}
 
@@ -1294,7 +1294,7 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 	// Calculate all expected parts
 	allParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	if len(partChecksums) > 0 && len(partChecksums) != len(allParts) {
-		metrics.RecordOperation("backend", "resume_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("%w: got %d, expected %d", ErrPartChecksumCountMismatch, len(partChecksums), len(allParts))
 	}
 
@@ -1311,13 +1311,13 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, p.Number, p.Size, s3client.ChecksumAlgoCRC32C, checksum, s3client.UploadTTL)
 		if err != nil {
 			logger.Error(ctx, "backend_resume_upload_presign_failed", zap.String("upload_id", uploadID), zap.Int("part_number", p.Number), zap.Error(err))
-			metrics.RecordOperation("backend", "resume_upload", "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "error", time.Since(start))
 			return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
 		}
 		urls = append(urls, u)
 	}
 
-	metrics.RecordOperation("backend", "resume_upload", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "ok", time.Since(start))
 	return &UploadPlan{
 		UploadID: uploadID,
 		Key:      upload.S3Key,
@@ -1331,23 +1331,23 @@ func (b *Dat9Backend) AbortUpload(ctx context.Context, uploadID string) error {
 	start := time.Now()
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordOperation("backend", "abort_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload", "error", time.Since(start))
 		return err
 	}
 	if upload.Status != datastore.UploadUploading {
-		metrics.RecordOperation("backend", "abort_upload", "not_active", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload", "not_active", time.Since(start))
 		return datastore.ErrUploadNotActive
 	}
 
 	_ = b.s3.AbortMultipartUpload(ctx, upload.S3Key, upload.S3UploadID)
 	if err := b.store.AbortUpload(ctx, uploadID); err != nil {
 		logger.Error(ctx, "backend_abort_upload_store_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordOperation("backend", "abort_upload", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload", "error", time.Since(start))
 		return err
 	}
 	// Release server-side reservation.
 	b.abortUploadReservation(ctx, uploadID, upload.TotalSize)
-	metrics.RecordOperation("backend", "abort_upload", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload", "ok", time.Since(start))
 	return nil
 }
 
@@ -1364,26 +1364,26 @@ func (b *Dat9Backend) abortUploadV2(ctx context.Context, uploadID string) (bool,
 	if err != nil {
 		// Not found → idempotent success
 		if errors.Is(err, datastore.ErrNotFound) {
-			metrics.RecordOperation("backend", "abort_upload_v2", "ok", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "ok", time.Since(start))
 			return false, nil
 		}
-		metrics.RecordOperation("backend", "abort_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "error", time.Since(start))
 		return false, err
 	}
 	// Already terminal → idempotent success
 	if upload.Status == datastore.UploadAborted || upload.Status == datastore.UploadCompleted || upload.Status == datastore.UploadExpired {
-		metrics.RecordOperation("backend", "abort_upload_v2", "ok", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "ok", time.Since(start))
 		return false, nil
 	}
 
 	aborted, err := b.store.AbortUploadV2(ctx, uploadID)
 	if err != nil {
 		logger.Error(ctx, "backend_abort_upload_v2_store_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordOperation("backend", "abort_upload_v2", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "error", time.Since(start))
 		return false, err
 	}
 	if !aborted {
-		metrics.RecordOperation("backend", "abort_upload_v2", "ok", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "ok", time.Since(start))
 		return false, nil
 	}
 	_ = b.s3.AbortMultipartUpload(ctx, upload.S3Key, upload.S3UploadID)
@@ -1395,7 +1395,7 @@ func (b *Dat9Backend) abortUploadV2(ctx context.Context, uploadID string) (bool,
 	}
 	// Release server-side reservation.
 	b.abortUploadReservation(ctx, uploadID, upload.TotalSize)
-	metrics.RecordOperation("backend", "abort_upload_v2", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "ok", time.Since(start))
 	return true, nil
 }
 
@@ -1421,36 +1421,36 @@ func (b *Dat9Backend) PresignGetObject(ctx context.Context, path string) (string
 	start := time.Now()
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
-		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
 		return "", err
 	}
 	if path == "/" {
-		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
 		return "", datastore.ErrNotFound
 	}
 	nf, err := b.store.Stat(ctx, path)
 	if err != nil {
-		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
 		return "", err
 	}
 	if nf.File == nil {
-		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
 		return "", fmt.Errorf("no file entity for path: %s", path)
 	}
 	if nf.File.StorageType != datastore.StorageS3 {
-		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
 		return "", fmt.Errorf("%w: %s", ErrNotS3Stored, path)
 	}
 	if b.s3 == nil {
-		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
 		return "", ErrS3NotConfigured
 	}
 	url, err := b.s3.PresignGetObject(ctx, nf.File.StorageRef, s3client.DownloadTTL)
 	if err != nil {
 		logger.Error(ctx, "backend_presign_get_object_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordOperation("backend", "presign_get_object", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
 		return "", err
 	}
-	metrics.RecordOperation("backend", "presign_get_object", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "ok", time.Since(start))
 	return url, nil
 }

--- a/pkg/backend/upload_reservation.go
+++ b/pkg/backend/upload_reservation.go
@@ -148,6 +148,7 @@ func (b *Dat9Backend) ensureUploadReserveFitsPendingQuotaTx(ctx context.Context,
 	pendingStorageDelta, pendingFileDelta, _, pendingOK := b.livePendingQuotaOutboxDeltasTx(ctx, tx)
 	if !pendingOK {
 		metrics.RecordTenantOperation(b.tenantID, "server_quota", "upload_reserve_pending_check", "fail_open", 0)
+		return nil
 	}
 	projected := usage.StorageBytes + usage.ReservedBytes + pendingStorageDelta + totalSize
 	if cfg.MaxStorageBytes > 0 && projected > cfg.MaxStorageBytes {

--- a/pkg/backend/upload_reservation.go
+++ b/pkg/backend/upload_reservation.go
@@ -44,7 +44,7 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 		logger.Info(ctx, "central_quota_reserve_upload_duplicate",
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID))
-		metrics.RecordOperation("central_quota", "reserve_upload", "duplicate", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "duplicate", time.Since(start))
 		return true, nil
 	} else if err != nil && !errors.Is(err, ErrReservationNotFound) {
 		logger.Warn(ctx, "central_quota_reserve_upload_duplicate_lookup_failed",
@@ -87,7 +87,7 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 		logger.Info(ctx, "central_quota_reserve_upload_duplicate",
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID))
-		metrics.RecordOperation("central_quota", "reserve_upload", "duplicate", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "duplicate", time.Since(start))
 		return true, nil
 	}
 	if err != nil && centralReserved {
@@ -95,18 +95,18 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID),
 			zap.Error(err))
-		metrics.RecordOperation("central_quota", "reserve_upload", "ok_lock_commit_failed", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "ok_lock_commit_failed", time.Since(start))
 		return true, nil
 	}
 	switch {
 	case err == nil:
-		metrics.RecordOperation("central_quota", "reserve_upload", "ok", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "ok", time.Since(start))
 		return true, nil
 	case errors.Is(err, ErrStorageQuotaExceeded):
-		metrics.RecordOperation("central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
 		return false, err
 	case errors.Is(err, ErrFileCountQuotaExceeded):
-		metrics.RecordOperation("central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
 		return false, err
 	case errors.Is(err, ErrReservationAlreadyExists):
 		// Idempotent retry: reservation already exists from an earlier initiate.
@@ -114,7 +114,7 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 		logger.Info(ctx, "central_quota_reserve_upload_duplicate",
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID))
-		metrics.RecordOperation("central_quota", "reserve_upload", "duplicate", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "duplicate", time.Since(start))
 		return true, nil
 	default:
 		logger.Warn(ctx, "central_quota_reserve_upload_failed",
@@ -122,7 +122,7 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 			zap.String("upload_id", uploadID),
 			zap.Int64("size", totalSize),
 			zap.Error(err))
-		metrics.RecordOperation("central_quota", "reserve_upload", "fail_open", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "fail_open", time.Since(start))
 		// Fail-open: allow the upload to proceed when the server DB is down.
 		return false, nil
 	}
@@ -134,7 +134,7 @@ func (b *Dat9Backend) ensureUploadReserveFitsPendingQuotaTx(ctx context.Context,
 	}
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
-		metrics.RecordOperation("server_quota", "upload_reserve_pending_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "upload_reserve_pending_check", "fail_open", 0)
 		return nil
 	}
 	if cfg.MaxStorageBytes <= 0 && (fileCountDelta <= 0 || cfg.MaxFileCount <= 0) {
@@ -142,12 +142,12 @@ func (b *Dat9Backend) ensureUploadReserveFitsPendingQuotaTx(ctx context.Context,
 	}
 	usage := b.loadQuotaUsage(ctx)
 	if usage == nil {
-		metrics.RecordOperation("server_quota", "upload_reserve_pending_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "upload_reserve_pending_check", "fail_open", 0)
 		return nil
 	}
 	pendingStorageDelta, pendingFileDelta, _, pendingOK := b.livePendingQuotaOutboxDeltasTx(ctx, tx)
 	if !pendingOK {
-		metrics.RecordOperation("server_quota", "upload_reserve_pending_check", "fail_open", 0)
+		metrics.RecordTenantOperation(b.tenantID, "server_quota", "upload_reserve_pending_check", "fail_open", 0)
 	}
 	projected := usage.StorageBytes + usage.ReservedBytes + pendingStorageDelta + totalSize
 	if cfg.MaxStorageBytes > 0 && projected > cfg.MaxStorageBytes {
@@ -178,7 +178,7 @@ func (b *Dat9Backend) abortUploadReservation(ctx context.Context, uploadID strin
 	r, err := b.metaStore.GetUploadReservation(ctx, b.tenantID, uploadID)
 	if errors.Is(err, ErrReservationNotFound) {
 		// No reservation row — initiate was a fail-open no-op; nothing to release.
-		metrics.RecordOperation("central_quota", "abort_reservation", "skip_no_reservation", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "skip_no_reservation", time.Since(start))
 		return
 	}
 	if err != nil {
@@ -187,12 +187,12 @@ func (b *Dat9Backend) abortUploadReservation(ctx context.Context, uploadID strin
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID),
 			zap.Error(err))
-		metrics.RecordOperation("central_quota", "abort_reservation", "lookup_error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "lookup_error", time.Since(start))
 		return
 	}
 	if r.Status != "active" {
 		// Already completed or aborted — nothing to release.
-		metrics.RecordOperation("central_quota", "abort_reservation", "skip_no_reservation", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "skip_no_reservation", time.Since(start))
 		return
 	}
 
@@ -212,11 +212,11 @@ func (b *Dat9Backend) abortUploadReservation(ctx context.Context, uploadID strin
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID),
 			zap.Error(err))
-		metrics.RecordOperation("central_quota", "abort_reservation", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "error", time.Since(start))
 		return
 	}
 
-	metrics.RecordOperation("central_quota", "abort_reservation", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "ok", time.Since(start))
 }
 
 // --- Mutation log helpers ---
@@ -278,7 +278,7 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID),
 			zap.Error(err))
-		metrics.RecordOperation("central_quota", "upload_complete", "fail_open", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_complete", "fail_open", time.Since(start))
 		return
 	}
 	if err := b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
@@ -300,12 +300,12 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 			zap.String("upload_id", uploadID),
 			zap.Int64("log_id", logID),
 			zap.Error(err))
-		metrics.RecordOperation("central_quota", "upload_complete", "pending", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_complete", "pending", time.Since(start))
 		// Leave entry in 'pending' — replay worker will retry inside
 		// applyUploadCompleteTx with the same reservation-state decision.
 		return
 	}
-	metrics.RecordOperation("central_quota", "upload_complete", "ok", time.Since(start))
+	metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_complete", "ok", time.Since(start))
 }
 
 // applyUploadCompleteTx is the single tx-scoped apply body shared by both

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2544,14 +2544,18 @@ func observeMeta(ctx context.Context, op string, start time.Time, errp *error) {
 	result := "ok"
 	if errp != nil && *errp != nil {
 		switch {
-		case errors.Is(*errp, ErrNotFound):
+		case errors.Is(*errp, ErrNotFound), errors.Is(*errp, sql.ErrNoRows):
 			result = "not_found"
 		case errors.Is(*errp, ErrDuplicate):
 			result = "duplicate"
 		default:
 			result = "error"
 		}
-		logger.Error(ctx, "meta_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
+		if result == "not_found" || result == "duplicate" {
+			logger.Warn(ctx, "meta_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
+		} else {
+			logger.Error(ctx, "meta_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
+		}
 	}
 	metrics.RecordOperation("meta", op, result, time.Since(start))
 }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -55,24 +55,41 @@ func SetModuleAvailability(module string, up bool) {
 }
 
 func RecordOperation(component, operation, result string, d time.Duration) {
+	RecordTenantOperation("", component, operation, result, d)
+}
+
+func RecordTenantOperation(tenantID, component, operation, result string, d time.Duration) {
 	component = cleanMetricValue(component, "unknown")
 	operation = cleanMetricValue(operation, "unknown")
 	result = cleanMetricValue(result, "unknown")
+	tenantID = cleanMetricValue(tenantID, "unknown")
 	RegisterModule(component)
 	attrs := []Attribute{
 		Attr("component", component),
 		Attr("operation", operation),
 		Attr("result", result),
 	}
+	if tenantID != "unknown" {
+		attrs = append(attrs, Attr("tenant_id", tenantID))
+	}
 	serviceOperationsTotal.Add(1, attrs...)
 	serviceOperationDuration.Observe(d.Seconds(), attrs...)
 }
 
 func RecordGauge(component, name string, value float64) {
+	RecordTenantGauge("", component, name, value)
+}
+
+func RecordTenantGauge(tenantID, component, name string, value float64) {
 	component = cleanMetricValue(component, "unknown")
 	name = cleanMetricValue(name, "unknown")
+	tenantID = cleanMetricValue(tenantID, "unknown")
 	RegisterModule(component)
-	serviceGauge.Set(value, Attr("component", component), Attr("name", name))
+	if tenantID != "unknown" {
+		serviceGauge.Set(value, Attr("component", component), Attr("name", name), Attr("tenant_id", tenantID))
+	} else {
+		serviceGauge.Set(value, Attr("component", component), Attr("name", name))
+	}
 }
 
 func RecordHTTPRequest(method, route string, status int, d time.Duration) {
@@ -99,9 +116,17 @@ func RecordHTTPInFlightRoute(route string, value float64) {
 }
 
 func RecordEvent(event string, labels ...string) {
+	RecordTenantEvent("", event, labels...)
+}
+
+func RecordTenantEvent(tenantID, event string, labels ...string) {
 	RegisterModule("server")
-	attrs := make([]Attribute, 0, len(labels)/2+1)
+	attrs := make([]Attribute, 0, len(labels)/2+2)
 	attrs = append(attrs, Attr("event", cleanMetricValue(event, "unknown")))
+	tenantID = cleanMetricValue(tenantID, "unknown")
+	if tenantID != "unknown" {
+		attrs = append(attrs, Attr("tenant_id", tenantID))
+	}
 	for i := 0; i+1 < len(labels); i += 2 {
 		attrs = append(attrs, Attr(labels[i], labels[i+1]))
 	}

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -85,11 +85,7 @@ func RecordTenantGauge(tenantID, component, name string, value float64) {
 	name = cleanMetricValue(name, "unknown")
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	RegisterModule(component)
-	if tenantID != "unknown" {
-		serviceGauge.Set(value, Attr("component", component), Attr("name", name), Attr("tenant_id", tenantID))
-	} else {
-		serviceGauge.Set(value, Attr("component", component), Attr("name", name))
-	}
+	serviceGauge.Set(value, Attr("component", component), Attr("name", name), Attr("tenant_id", tenantID))
 }
 
 func RecordHTTPRequest(method, route string, status int, d time.Duration) {

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -83,7 +83,7 @@ func RecordGauge(component, name string, value float64) {
 func RecordTenantGauge(tenantID, component, name string, value float64) {
 	component = cleanMetricValue(component, "unknown")
 	name = cleanMetricValue(name, "unknown")
-	tenantID = cleanMetricValue(tenantID, "unknown")
+	tenantID = strings.TrimSpace(tenantID)
 	RegisterModule(component)
 	serviceGauge.Set(value, Attr("component", component), Attr("name", name), Attr("tenant_id", tenantID))
 }

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -36,7 +36,8 @@ const (
 // The store field is an atomic pointer so it can be safely refreshed by
 // eventBuses.get (when the pool recreates a backend) while SSE handlers read it.
 type EventBus struct {
-	store     atomic.Pointer[datastore.Store]
+	tenantID string
+	store    atomic.Pointer[datastore.Store]
 	mu        sync.Mutex
 	listeners map[uint64]chan struct{}
 	nextID    uint64
@@ -50,8 +51,9 @@ type EventBus struct {
 }
 
 // NewEventBus creates a new EventBus backed by the given tenant store.
-func NewEventBus(store *datastore.Store) *EventBus {
+func NewEventBus(tenantID string, store *datastore.Store) *EventBus {
 	eb := &EventBus{
+		tenantID:  tenantID,
 		listeners: make(map[uint64]chan struct{}),
 	}
 	eb.store.Store(store)
@@ -191,6 +193,7 @@ func (eb *EventBus) pollOnce(ctx context.Context) {
 		// Log so operators can detect persistent failures or pool-churn-induced
 		// stale-store hits. Don't send reset — just skip this tick.
 		logger.Warn(ctx, "event_bus_poll_failed",
+			zap.String("tenant_id", eb.tenantID),
 			zap.Uint64("since", since),
 			zap.Error(err))
 		return
@@ -247,9 +250,10 @@ func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []Cha
 		// operators can detect and alert on persistent table-missing or DB
 		// connectivity issues.
 		logger.Warn(ctx, "event_bus_query_failed",
+			zap.String("tenant_id", eb.tenantID),
 			zap.Uint64("since", since),
 			zap.Error(err))
-		metrics.RecordOperation("event_bus", "query", "error", 0)
+		metrics.RecordTenantOperation(eb.tenantID, "event_bus", "query", "error", 0)
 		headSeq = since // keep the client's cursor unchanged
 		return nil, headSeq, true
 	}

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -39,7 +39,7 @@ func newTestStoreForEventBus(t *testing.T) *datastore.Store {
 
 func TestEventBusSubscribeAndNotify(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	subID, notify := bus.Subscribe()
 	defer bus.Unsubscribe(subID)
@@ -70,7 +70,7 @@ func TestEventBusSubscribeAndNotify(t *testing.T) {
 
 func TestEventBusEventsSinceZeroReturnsReset(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	if _, err := store.InsertFSEvent(context.Background(), "/a.txt", "write", "", time.Now().UnixMilli()); err != nil {
 		t.Fatal(err)
@@ -87,7 +87,7 @@ func TestEventBusEventsSinceZeroReturnsReset(t *testing.T) {
 
 func TestEventBusEventsSinceReplays(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	// Insert two events.
 	seq1, err := store.InsertFSEvent(context.Background(), "/a.txt", "write", "actor1", time.Now().UnixMilli())
@@ -117,7 +117,7 @@ func TestEventBusEventsSinceReplays(t *testing.T) {
 
 func TestEventBusSeq(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	// Reset AUTO_INCREMENT so seq starts at 1.
 	if _, err := store.DB().Exec(`ALTER TABLE fs_events AUTO_INCREMENT = 1`); err != nil {
@@ -142,7 +142,7 @@ func TestEventBusSeq(t *testing.T) {
 
 func TestEventBusSubscribeUnsubscribe(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	subID, _ := bus.Subscribe()
 	bus.Unsubscribe(subID)
@@ -164,7 +164,7 @@ func TestEventBusSubscribeUnsubscribe(t *testing.T) {
 
 func TestEventBusMultipleSubscribers(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	var wg sync.WaitGroup
 	const n = 5
@@ -191,7 +191,7 @@ func TestEventBusMultipleSubscribers(t *testing.T) {
 // to catch data races on the store field. Run with -race to detect violations.
 func TestEventBusStoreRefreshNoRace(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	done := make(chan struct{})
 
@@ -218,7 +218,7 @@ func TestEventBusStoreRefreshNoRace(t *testing.T) {
 // failure branch flagged in D1.
 func TestEventBusEventsSinceQueryErrorReturnsCaughtUp(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	// Insert one event so since=1 is valid.
 	if _, err := store.InsertFSEvent(context.Background(), "/a.txt", "write", "", time.Now().UnixMilli()); err != nil {
@@ -248,7 +248,7 @@ func TestEventBusEventsSinceQueryErrorReturnsCaughtUp(t *testing.T) {
 // all other subscribers left.
 func TestEventBusUnsubscribeOneOfManyReturnsImmediately(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	// Two subscribers.
 	id1, _ := bus.Subscribe()
@@ -274,7 +274,7 @@ func TestEventBusUnsubscribeOneOfManyReturnsImmediately(t *testing.T) {
 // stops after the last Unsubscribe and can restart cleanly on a later Subscribe.
 func TestEventBusPollLoopStopsAfterLastUnsubscribe(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	// Subscribe then unsubscribe — poll should stop.
 	id, _ := bus.Subscribe()
@@ -315,7 +315,7 @@ func TestEventBusPollLoopStopsAfterLastUnsubscribe(t *testing.T) {
 // goroutine discovers new fs_events rows and signals subscribers via Publish.
 func TestEventBusPollLoopSignalsCrossPodEvents(t *testing.T) {
 	store := newTestStoreForEventBus(t)
-	bus := NewEventBus(store)
+	bus := NewEventBus("test-tenant", store)
 
 	// Insert an initial event so pollLast initializes to it.
 	if _, err := store.InsertFSEvent(context.Background(), "/init.txt", "write", "", time.Now().UnixMilli()); err != nil {

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -178,7 +178,8 @@ func metricEvent(ctx context.Context, event string, labels ...string) {
 	if m == nil {
 		return
 	}
-	m.recordEvent(event, labels...)
+	tenantID, _, _ := requestMetricScope(ctx)
+	m.recordEvent(tenantID, event, labels...)
 }
 
 type serverMetrics struct {
@@ -203,8 +204,8 @@ func (m *serverMetrics) record(method, route string, status int, d time.Duration
 	metrics.RecordHTTPRequest(method, route, status, d)
 }
 
-func (m *serverMetrics) recordEvent(event string, labels ...string) {
-	metrics.RecordEvent(event, labels...)
+func (m *serverMetrics) recordEvent(tenantID, event string, labels ...string) {
+	metrics.RecordTenantEvent(tenantID, event, labels...)
 }
 
 func (m *serverMetrics) writePrometheus(w http.ResponseWriter) {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -160,6 +160,8 @@ type semanticWorkerManager struct {
 	lastTenantScan            semanticTenantScanSnapshot
 	tenantScanMu              sync.Mutex
 
+	priorObservedTenants map[string]struct{}
+
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 }
@@ -1337,10 +1339,19 @@ func (m *semanticWorkerManager) observeOnce(ctx context.Context, now time.Time) 
 	metrics.RecordGauge("semantic_worker", "processing", float64(snapshot.processing))
 	metrics.RecordGauge("semantic_worker", "dead_lettered", float64(snapshot.deadLettered))
 	metrics.RecordGauge("semantic_worker", "queue_lag_seconds", snapshot.queueLagSeconds)
+	seen := make(map[string]struct{}, len(snapshot.perTenant))
 	for tenantID, tenantObs := range snapshot.perTenant {
 		metrics.RecordTenantGauge(tenantID, "semantic_worker", "dead_lettered", float64(tenantObs.deadLettered))
 		metrics.RecordTenantGauge(tenantID, "semantic_worker", "queue_lag_seconds", tenantObs.queueLagSeconds)
+		seen[tenantID] = struct{}{}
 	}
+	for tenantID := range m.priorObservedTenants {
+		if _, ok := seen[tenantID]; !ok {
+			metrics.RecordTenantGauge(tenantID, "semantic_worker", "dead_lettered", 0)
+			metrics.RecordTenantGauge(tenantID, "semantic_worker", "queue_lag_seconds", 0)
+		}
+	}
+	m.priorObservedTenants = seen
 }
 
 func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time.Time) semanticObservationSnapshot {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -183,6 +183,12 @@ type semanticObservationSnapshot struct {
 	deadLettered    int
 	queueLagSeconds float64
 	inflight        int
+	perTenant       map[string]semanticTenantObservation
+}
+
+type semanticTenantObservation struct {
+	deadLettered    int
+	queueLagSeconds float64
 }
 
 type semanticTenantScanSnapshot struct {
@@ -302,10 +308,10 @@ func (m *semanticWorkerManager) Kick(tenantID string) {
 	m.mu.Unlock()
 	select {
 	case m.kicks <- tenantID:
-		metrics.RecordOperation("semantic_worker", "kick", "queued", 0)
+		metrics.RecordTenantOperation(tenantID, "semantic_worker", "kick", "queued", 0)
 	default:
 		m.clearKickPending(tenantID)
-		metrics.RecordOperation("semantic_worker", "kick", "dropped", 0)
+		metrics.RecordTenantOperation(tenantID, "semantic_worker", "kick", "dropped", 0)
 	}
 }
 
@@ -484,7 +490,7 @@ func (m *semanticWorkerManager) claimAndProcessOne(ctx context.Context, target *
 	claimStart := time.Now()
 	task, found, err := target.store.ClaimSemanticTask(ctx, time.Now().UTC(), m.opts.LeaseDuration, target.allowedTaskTypes...)
 	if err != nil {
-		metrics.RecordOperation("semantic_worker", "claim", "error", time.Since(claimStart))
+		metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "claim", "error", time.Since(claimStart))
 		logger.Warn(ctx, "semantic_worker_claim_failed",
 			append([]zap.Field{
 				zap.String("tenant_id", target.tenantID),
@@ -496,7 +502,7 @@ func (m *semanticWorkerManager) claimAndProcessOne(ctx context.Context, target *
 	if !found {
 		return false
 	}
-	metrics.RecordOperation("semantic_worker", "claim", "ok", time.Since(claimStart))
+	metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "claim", "ok", time.Since(claimStart))
 	logger.Info(ctx, "semantic_worker_claim_ok",
 		append([]zap.Field{
 			zap.String("tenant_id", target.tenantID),
@@ -514,8 +520,9 @@ func (m *semanticWorkerManager) processTask(ctx context.Context, target *semanti
 	}
 	start := time.Now()
 	result := "ok"
+	tenantID := target.tenantID
 	defer func() {
-		metrics.RecordOperation("semantic_worker", string(task.TaskType), result, time.Since(start))
+		metrics.RecordTenantOperation(tenantID, "semantic_worker", string(task.TaskType), result, time.Since(start))
 	}()
 	leaseExec := m.startTaskLeaseExecution(ctx, target, task)
 	var (
@@ -586,7 +593,7 @@ func (m *semanticWorkerManager) retryTask(ctx context.Context, tenantID string, 
 	retryAt := time.Now().UTC().Add(m.retryDelay(task.AttemptCount))
 	willDeadLetter := task.AttemptCount >= task.MaxAttempts
 	if err := store.RetrySemanticTask(ctx, task.TaskID, task.Receipt, retryAt, message); err != nil {
-		metrics.RecordOperation("semantic_worker", "retry", "error", time.Since(start))
+		metrics.RecordTenantOperation(tenantID, "semantic_worker", "retry", "error", time.Since(start))
 		logger.Warn(ctx, "semantic_worker_retry_failed",
 			append([]zap.Field{
 				zap.String("tenant_id", tenantID),
@@ -600,7 +607,7 @@ func (m *semanticWorkerManager) retryTask(ctx context.Context, tenantID string, 
 		result = "dead_lettered"
 		logMessage = "semantic_worker_dead_lettered"
 	}
-	metrics.RecordOperation("semantic_worker", "retry", result, time.Since(start))
+	metrics.RecordTenantOperation(tenantID, "semantic_worker", "retry", result, time.Since(start))
 	fields := append([]zap.Field{
 		zap.String("tenant_id", tenantID),
 		zap.String("result", result),
@@ -615,7 +622,7 @@ func (m *semanticWorkerManager) retryTask(ctx context.Context, tenantID string, 
 func (m *semanticWorkerManager) deadLetterTask(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task, message string) {
 	start := time.Now()
 	if err := store.DeadLetterSemanticTask(ctx, task.TaskID, task.Receipt, message); err != nil {
-		metrics.RecordOperation("semantic_worker", "dead_letter", "error", time.Since(start))
+		metrics.RecordTenantOperation(tenantID, "semantic_worker", "dead_letter", "error", time.Since(start))
 		logger.Warn(ctx, "semantic_worker_dead_letter_failed",
 			append([]zap.Field{
 				zap.String("tenant_id", tenantID),
@@ -623,7 +630,7 @@ func (m *semanticWorkerManager) deadLetterTask(ctx context.Context, tenantID str
 			}, append(semanticTaskLogFields(task), zap.Error(err))...)...)
 		return
 	}
-	metrics.RecordOperation("semantic_worker", "dead_letter", "dead_lettered", time.Since(start))
+	metrics.RecordTenantOperation(tenantID, "semantic_worker", "dead_letter", "dead_lettered", time.Since(start))
 	logger.Warn(ctx, "semantic_worker_dead_lettered",
 		append([]zap.Field{
 			zap.String("tenant_id", tenantID),
@@ -668,7 +675,7 @@ func (m *semanticWorkerManager) recoverExpired(ctx context.Context) {
 			start := time.Now()
 			recovered, err := target.store.RecoverExpiredSemanticTasks(ctx, time.Now().UTC(), 64)
 			if err != nil {
-				metrics.RecordOperation("semantic_worker", "recover", "error", time.Since(start))
+				metrics.RecordTenantOperation(ref.id, "semantic_worker", "recover", "error", time.Since(start))
 				logger.Warn(ctx, "semantic_worker_recover_failed",
 					zap.String("tenant_id", ref.id),
 					zap.Error(err))
@@ -676,7 +683,7 @@ func (m *semanticWorkerManager) recoverExpired(ctx context.Context) {
 				return
 			}
 			if recovered > 0 {
-				metrics.RecordOperation("semantic_worker", "recover", "ok", time.Since(start))
+				metrics.RecordTenantOperation(ref.id, "semantic_worker", "recover", "ok", time.Since(start))
 				logger.Info(ctx, "semantic_worker_recover_ok",
 					zap.String("tenant_id", ref.id),
 					zap.String("result", "ok"),
@@ -1017,12 +1024,12 @@ func (e *semanticTaskLeaseExecution) run(m *semanticWorkerManager, target *seman
 			leaseUntil, err := target.store.RenewSemanticTask(e.ctx, task.TaskID, task.Receipt, m.opts.LeaseDuration)
 			if err != nil {
 				if errors.Is(err, semantic.ErrTaskLeaseMismatch) || errors.Is(err, semantic.ErrTaskNotFound) {
-					metrics.RecordOperation("semantic_worker", "renew", "error", time.Since(renewStart))
+					metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "renew", "error", time.Since(renewStart))
 					// A renew already in flight can still discover lease loss after
 					// processTask begins shutdown, so lease mismatch wins over stop.
 					e.markLeaseLost()
 					failpoint.InjectCall("semanticWorkerOnLeaseLost", target.tenantID, target.store, task, err)
-					metrics.RecordOperation("semantic_worker", "lease_lost", "ok", time.Since(renewStart))
+					metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "lease_lost", "ok", time.Since(renewStart))
 					logger.Warn(e.ctx, "semantic_worker_lease_lost",
 						append([]zap.Field{
 							zap.String("tenant_id", target.tenantID),
@@ -1037,7 +1044,7 @@ func (e *semanticTaskLeaseExecution) run(m *semanticWorkerManager, target *seman
 					e.logStopped(m, target, task)
 					return
 				}
-				metrics.RecordOperation("semantic_worker", "renew", "error", time.Since(renewStart))
+				metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "renew", "error", time.Since(renewStart))
 				logger.Warn(e.ctx, "semantic_worker_lease_renew_failed",
 					append([]zap.Field{
 						zap.String("tenant_id", target.tenantID),
@@ -1047,7 +1054,7 @@ func (e *semanticTaskLeaseExecution) run(m *semanticWorkerManager, target *seman
 			}
 			e.recordRenewedLease(leaseUntil)
 			failpoint.InjectCall("semanticWorkerAfterRenew", target.tenantID, target.store, task, leaseUntil)
-			metrics.RecordOperation("semantic_worker", "renew", "ok", time.Since(renewStart))
+			metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "renew", "ok", time.Since(renewStart))
 		}
 	}
 }
@@ -1224,7 +1231,7 @@ func (m *semanticWorkerManager) semanticTaskStillOwned(ctx context.Context, tena
 	}
 	// Treat ownership loss as a finalized runtime event: the worker must not ack
 	// or retry once another actor could have legitimately reclaimed the task.
-	metrics.RecordOperation("semantic_worker", "lease_lost", "ok", 0)
+	metrics.RecordTenantOperation(tenantID, "semantic_worker", "lease_lost", "ok", 0)
 	logger.Warn(ctx, "semantic_worker_finalize_skipped_lease_lost",
 		append([]zap.Field{
 			zap.String("tenant_id", tenantID),
@@ -1330,6 +1337,10 @@ func (m *semanticWorkerManager) observeOnce(ctx context.Context, now time.Time) 
 	metrics.RecordGauge("semantic_worker", "processing", float64(snapshot.processing))
 	metrics.RecordGauge("semantic_worker", "dead_lettered", float64(snapshot.deadLettered))
 	metrics.RecordGauge("semantic_worker", "queue_lag_seconds", snapshot.queueLagSeconds)
+	for tenantID, tenantObs := range snapshot.perTenant {
+		metrics.RecordTenantGauge(tenantID, "semantic_worker", "dead_lettered", float64(tenantObs.deadLettered))
+		metrics.RecordTenantGauge(tenantID, "semantic_worker", "queue_lag_seconds", tenantObs.queueLagSeconds)
+	}
 }
 
 func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time.Time) semanticObservationSnapshot {
@@ -1338,7 +1349,7 @@ func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time
 	} else {
 		now = now.UTC()
 	}
-	snapshot := semanticObservationSnapshot{inflight: m.snapshotProcessing()}
+	snapshot := semanticObservationSnapshot{inflight: m.snapshotProcessing(), perTenant: make(map[string]semanticTenantObservation)}
 	refs, err := m.listTenantRefs(ctx)
 	if err != nil {
 		logger.Warn(ctx, "semantic_worker_list_tenants_for_observation_failed", zap.Error(err))
@@ -1367,6 +1378,17 @@ func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time
 			snapshot.queued += obs.Queued
 			snapshot.processing += obs.Processing
 			snapshot.deadLettered += obs.DeadLettered
+			tenantLag := float64(0)
+			if obs.OldestClaimableAvailableAt != nil {
+				tenantLag = now.Sub(obs.OldestClaimableAvailableAt.UTC()).Seconds()
+			}
+			if tenantLag < 0 {
+				tenantLag = 0
+			}
+			snapshot.perTenant[ref.id] = semanticTenantObservation{
+				deadLettered:    obs.DeadLettered,
+				queueLagSeconds: tenantLag,
+			}
 			if obs.OldestClaimableAvailableAt != nil && (oldest == nil || obs.OldestClaimableAvailableAt.Before(*oldest)) {
 				t := obs.OldestClaimableAvailableAt.UTC()
 				oldest = &t

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4516,7 +4516,7 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			s.schemaInitErrors.Delete(tenantID)
 			logger.Info(ctx, "server_event", eventFields(ctx, "schema_init_ok", "tenant_id", tenantID, "provider", provider, "attempt", attempt)...)
 			if s.metrics != nil {
-				s.metrics.recordEvent("tenant_schema_init", "provider", provider, "result", "ok")
+				s.metrics.recordEvent(tenantID, "tenant_schema_init", "provider", provider, "result", "ok")
 			}
 			updated, err := s.meta.UpdateTenantStatusIf(ctx, tenantID, meta.TenantProvisioning, meta.TenantActive)
 			if err != nil {
@@ -4532,7 +4532,7 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			s.schemaInitErrors.Store(tenantID, schemaInitStatusErrorMessage(err))
 			logger.Error(ctx, "server_event", eventFields(ctx, "schema_init_failed", "tenant_id", tenantID, "provider", provider, "attempt", attempt, "error", err)...)
 			if s.metrics != nil {
-				s.metrics.recordEvent("tenant_schema_init", "provider", provider, "result", "error")
+				s.metrics.recordEvent(tenantID, "tenant_schema_init", "provider", provider, "result", "error")
 			}
 			remaining := time.Until(deadline)
 			if remaining <= 0 {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2062,13 +2062,13 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `drive9_http_inflight_requests{route="/v1/fs/*"} 0.000000`) {
 		t.Fatalf("expected route-scoped inflight metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_service_operations_total{component="backend",operation="exec_sql",result="ok",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_service_operations_total{component="backend",operation="exec_sql",result="ok"}`) {
 		t.Fatalf("expected backend service metric in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_http_request_duration_seconds_bucket{method="GET",route="/v1/fs/*",le="0.1"}`) {
 		t.Fatalf("expected http duration histogram bucket in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_service_operation_duration_seconds_bucket{component="backend",operation="exec_sql",result="ok",tenant_id="local",le="0.01"}`) {
+	if !strings.Contains(text, `drive9_service_operation_duration_seconds_bucket{component="backend",operation="exec_sql",result="ok",le="0.01"}`) {
 		t.Fatalf("expected service operation histogram bucket in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_db_operations_total{operation="`) || !strings.Contains(text, `role="user"`) {
@@ -2100,10 +2100,10 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="read",direction="read",surface="fs",tenant_id="local"}`) {
 		t.Fatalf("expected tenant file read byte metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="fs_write",result="ok"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="fs_write",result="ok",tenant_id="local"}`) {
 		t.Fatalf("expected fs_write tenant event metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="fs_read",result="ok"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="fs_read",result="ok",tenant_id="local"}`) {
 		t.Fatalf("expected fs_read tenant event metric in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_business_events_total{event="tenant_provision",result="error"}`) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2062,13 +2062,13 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `drive9_http_inflight_requests{route="/v1/fs/*"} 0.000000`) {
 		t.Fatalf("expected route-scoped inflight metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_service_operations_total{component="backend",operation="exec_sql",result="ok"}`) {
+	if !strings.Contains(text, `drive9_service_operations_total{component="backend",operation="exec_sql",result="ok",tenant_id="local"}`) {
 		t.Fatalf("expected backend service metric in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_http_request_duration_seconds_bucket{method="GET",route="/v1/fs/*",le="0.1"}`) {
 		t.Fatalf("expected http duration histogram bucket in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_service_operation_duration_seconds_bucket{component="backend",operation="exec_sql",result="ok",le="0.01"}`) {
+	if !strings.Contains(text, `drive9_service_operation_duration_seconds_bucket{component="backend",operation="exec_sql",result="ok",tenant_id="local",le="0.01"}`) {
 		t.Fatalf("expected service operation histogram bucket in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_db_operations_total{operation="`) || !strings.Contains(text, `role="user"`) {
@@ -2174,13 +2174,13 @@ func TestUploadActionMetrics(t *testing.T) {
 	body, _ := io.ReadAll(metricsResp.Body)
 	text := string(body)
 
-	if !strings.Contains(text, `drive9_business_events_total{event="upload_complete",result="error"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_complete",result="error",tenant_id="local"}`) {
 		t.Fatalf("expected upload_complete metric, got: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="upload_resume",result="error"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_resume",result="error",tenant_id="local"}`) {
 		t.Fatalf("expected upload_resume metric, got: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="upload_abort",result="error"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_abort",result="error",tenant_id="local"}`) {
 		t.Fatalf("expected upload_abort metric, got: %s", text)
 	}
 }

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -137,7 +137,7 @@ func (ebs *eventBuses) get(tenantID string, store *datastore.Store) *EventBus {
 		}
 		return bus
 	}
-	bus := NewEventBus(store)
+	bus := NewEventBus(tenantID, store)
 	ebs.buses[tenantID] = bus
 	return bus
 }
@@ -172,10 +172,11 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 	if store != nil {
 		if _, err := store.InsertFSEvent(r.Context(), path, op, actor, time.Now().UnixMilli()); err != nil {
 			logger.Warn(r.Context(), "sse_publish_fs_event_insert_failed",
+				zap.String("tenant_id", bus.tenantID),
 				zap.String("path", path),
 				zap.String("op", op),
 				zap.Error(err))
-			metrics.RecordOperation("event_bus", "publish", "error", 0)
+			metrics.RecordTenantOperation(bus.tenantID, "event_bus", "publish", "error", 0)
 		}
 	}
 	bus.Publish()

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -726,6 +726,9 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	result := "ok"
 	auditTenantID := "unknown"
+	if scope := ScopeFromContext(r.Context()); scope != nil {
+		auditTenantID = scope.TenantID
+	}
 	defer func() { recordVaultOperation(auditTenantID, "audit_query", start, result) }()
 
 	if r.Method != http.MethodGet {
@@ -745,10 +748,6 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
 	}
-	scope := ScopeFromContext(r.Context())
-	if scope != nil {
-		auditTenantID = scope.TenantID
-	}
 
 	secretName := r.URL.Query().Get("secret")
 	limit := 100
@@ -758,7 +757,7 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	events, err := vs.QueryAuditLog(r.Context(), scope.TenantID, secretName, limit)
+	events, err := vs.QueryAuditLog(r.Context(), auditTenantID, secretName, limit)
 	if err != nil {
 		result = "error"
 		errJSON(w, http.StatusInternalServerError, "failed to query audit log")

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -58,8 +58,8 @@ func (s *Server) handleVault(w http.ResponseWriter, r *http.Request) {
 
 var errVaultUnsupported = errors.New("vault is not supported for this provider")
 
-func recordVaultOperation(op string, start time.Time, result string) {
-	metrics.RecordOperation("vault", op, result, time.Since(start))
+func recordVaultOperation(tenantID, op string, start time.Time, result string) {
+	metrics.RecordTenantOperation(tenantID, "vault", op, result, time.Since(start))
 }
 
 // vaultStore returns the vault store for the current tenant.
@@ -146,7 +146,7 @@ func (s *Server) handleVaultSecrets(w http.ResponseWriter, r *http.Request, sub 
 func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("secret_create", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "secret_create", start, result) }()
 
 	var req struct {
 		Name       string            `json:"name"`
@@ -213,7 +213,7 @@ func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request,
 func (s *Server) handleVaultSecretList(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("secret_list", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "secret_list", start, result) }()
 
 	secrets, err := vs.ListSecrets(r.Context(), tenantID)
 	if err != nil {
@@ -231,7 +231,7 @@ func (s *Server) handleVaultSecretList(w http.ResponseWriter, r *http.Request, v
 func (s *Server) handleVaultSecretGet(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("secret_get", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "secret_get", start, result) }()
 
 	sec, err := vs.GetSecret(r.Context(), tenantID, name)
 	if err != nil {
@@ -253,7 +253,7 @@ func (s *Server) handleVaultSecretGet(w http.ResponseWriter, r *http.Request, vs
 func (s *Server) handleVaultSecretReadValue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, secretName string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("secret_read_value", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "secret_read_value", start, result) }()
 
 	fields, err := vs.ReadSecretFields(r.Context(), tenantID, secretName)
 	if err != nil {
@@ -301,7 +301,7 @@ func (s *Server) handleVaultSecretReadValue(w http.ResponseWriter, r *http.Reque
 func (s *Server) handleVaultSecretReadField(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, secretName, fieldName string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("secret_read_field", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "secret_read_field", start, result) }()
 
 	plaintext, err := vs.ReadSecretField(r.Context(), tenantID, secretName, fieldName)
 	if err != nil {
@@ -332,7 +332,7 @@ func (s *Server) handleVaultSecretReadField(w http.ResponseWriter, r *http.Reque
 func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("secret_update", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "secret_update", start, result) }()
 
 	var req struct {
 		Fields    map[string]string `json:"fields"`
@@ -387,7 +387,7 @@ func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request,
 func (s *Server) handleVaultSecretDelete(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("secret_delete", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "secret_delete", start, result) }()
 
 	err := vs.DeleteSecret(r.Context(), tenantID, name)
 	if err != nil {
@@ -448,7 +448,7 @@ func (s *Server) handleVaultTokens(w http.ResponseWriter, r *http.Request, sub s
 func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("token_issue", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "token_issue", start, result) }()
 
 	var req struct {
 		AgentID string   `json:"agent_id"`
@@ -508,7 +508,7 @@ func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, v
 func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, tokenID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("token_revoke", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "token_revoke", start, result) }()
 
 	var req struct {
 		RevokedBy string `json:"revoked_by"`
@@ -589,7 +589,7 @@ func (s *Server) handleVaultGrants(w http.ResponseWriter, r *http.Request, sub s
 func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("grant_issue", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "grant_issue", start, result) }()
 
 	// Grants require a canonical server URL for the `iss` claim. If the
 	// operator hasn't configured one, we cannot mint non-forgeable tokens:
@@ -678,7 +678,7 @@ func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, v
 func (s *Server) handleVaultGrantRevoke(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, grantID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("grant_revoke", start, result) }()
+	defer func() { recordVaultOperation(tenantID, "grant_revoke", start, result) }()
 
 	var req struct {
 		RevokedBy string `json:"revoked_by"`
@@ -725,7 +725,8 @@ func (s *Server) handleVaultGrantRevoke(w http.ResponseWriter, r *http.Request, 
 func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("audit_query", start, result) }()
+	auditTenantID := "unknown"
+	defer func() { recordVaultOperation(auditTenantID, "audit_query", start, result) }()
 
 	if r.Method != http.MethodGet {
 		result = "invalid_argument"
@@ -745,6 +746,9 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	scope := ScopeFromContext(r.Context())
+	if scope != nil {
+		auditTenantID = scope.TenantID
+	}
 
 	secretName := r.URL.Query().Get("secret")
 	limit := 100
@@ -902,7 +906,7 @@ func (s *Server) verifyGrantReadToken(r *http.Request, vs *vault.Store, tenantID
 func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("read_enumerate", start, result) }()
+	defer func() { recordVaultOperation(p.TenantID, "read_enumerate", start, result) }()
 
 	scopedNames := vault.ScopedSecretNames(p.Scope)
 	// Filter to secrets that actually exist.
@@ -933,7 +937,7 @@ func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request
 func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal, secretName string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("read_secret", start, result) }()
+	defer func() { recordVaultOperation(p.TenantID, "read_secret", start, result) }()
 
 	// Scope check.
 	allFields, allowedFields := vault.AllowedFields(p.Scope, secretName)
@@ -1010,7 +1014,7 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal, secretName, fieldName string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation("read_field", start, result) }()
+	defer func() { recordVaultOperation(p.TenantID, "read_field", start, result) }()
 
 	// Scope check.
 	if !vault.CheckScope(p.Scope, secretName, fieldName) {

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -725,10 +725,13 @@ func (s *Server) handleVaultGrantRevoke(w http.ResponseWriter, r *http.Request, 
 func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	result := "ok"
-	auditTenantID := "unknown"
-	if scope := ScopeFromContext(r.Context()); scope != nil {
-		auditTenantID = scope.TenantID
+	scope := ScopeFromContext(r.Context())
+	if scope == nil {
+		result = "error"
+		errJSON(w, http.StatusForbidden, "missing tenant scope")
+		return
 	}
+	auditTenantID := scope.TenantID
 	defer func() { recordVaultOperation(auditTenantID, "audit_query", start, result) }()
 
 	if r.Method != http.MethodGet {

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -364,10 +364,10 @@ func TestVaultMetricsExposed(t *testing.T) {
 	if !strings.Contains(metricsText, "drive9_module_up{module=\"vault\"} 1") {
 		t.Fatalf("metrics missing vault module availability: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"vault\",operation=\"read_secret\",result=\"ok\",tenant_id=\"") {
 		t.Fatalf("metrics missing vault service operation counter: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
+	if !strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\",tenant_id=\"") {
 		t.Fatalf("metrics missing vault service duration histogram: %s", metricsText)
 	}
 }


### PR DESCRIPTION
## Summary

Add tenant_id dimension to per-tenant metrics, logs, and alert rules to enable tenant-level observability and faster root-cause identification during incidents.

## Changes

### Metrics (25 files, 85+ call sites)
- Add `RecordTenantOperation`, `RecordTenantGauge`, `RecordTenantEvent` to metrics package
- Update `metricEvent` to extract tenant_id from request context automatically
- Convert all per-tenant `RecordOperation` calls to `RecordTenantOperation` across:
  - `backend` (20 call sites: create/write/read/rename/copy/symlink/grep/find/exec_sql)
  - `vault` (15 call sites: secret/token/grant/read/audit)
  - `central_quota` / `server_quota` (22 call sites)
  - `semantic_worker` (11 additional call sites: retry/dead_letter/recover/renew)
  - `file_gc`, `mutation_replay`, `quota_outbox`, `llm_cost_budget`
  - `image_extract`, `audio_extract`, `event_bus`

### Logs (8 files, 24 call sites)
- Add tenant_id to log statements in background workers, SSE, eventbus, patch upload, and LLM usage paths

### Struct changes
- Add `TenantID` field to `ImageExtractRequest`, `quotaPendingDeltasCache`, and `EventBus`

## Motivation

During the Jun 26 production incident, 5 alerts fired (BackgroundWorkerErrorsHigh, SemanticWorkerDeadLettered, SemanticWorkerUnavailable, HighHTTPP99Latency, UserDBUnavailable) but none had tenant_id, making it impossible to identify which tenant's database was degraded. This PR ensures future incidents can be traced to the specific affected tenant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-scoped usage and activity tracking across backend operations, files/GC, uploads, event delivery, and semantic workflows.
  * Tenant-aware metric/event recording is now consistently applied, and dashboards/tests were updated to include `tenant_id`.

* **Bug Fixes**
  * Improved quota and budget skip/fail-open telemetry for more consistent tenant-level reporting.
  * Enhanced vault behavior by improving duplicate-entry detection and requiring tenant scope for vault audit requests (returns `403` when missing).
  * Expanded tenant context in logs and metrics for clearer diagnosis of retries and failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->