### PR TITLE
fix: allow quota outbox owner ack after lease expiry

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -903,18 +903,18 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		quotaOutboxEnqueued = false
 
 		done := backendTimingStep(timingEnabled, &quotaStorageCheckDuration)
-		if err := b.ensureStorageQuota(ctx, tx, path, int64(len(data))); err != nil {
-			done()
+		err := b.ensureStorageQuota(ctx, tx, path, int64(len(data)))
+		done()
+		if err != nil {
 			return err
 		}
-		done()
 
 		done = backendTimingStep(timingEnabled, &quotaFileCountCheckDuration)
-		if err := b.ensureFileCountQuotaServer(ctx, tx, 1); err != nil {
-			done()
+		err = b.ensureFileCountQuotaServer(ctx, tx, 1)
+		done()
+		if err != nil {
 			return err
 		}
-		done()
 
 		fileRev := int64(1)
 		insertFile := &datastore.File{
@@ -931,44 +931,45 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		}
 
 		done = backendTimingStep(timingEnabled, &insertFileDuration)
-		if err := b.store.InsertFileTx(tx, insertFile); err != nil {
-			done()
+		err = b.store.InsertFileTx(tx, insertFile)
+		done()
+		if err != nil {
 			return err
 		}
-		done()
 
 		done = backendTimingStep(timingEnabled, &ensureParentDirsDuration)
-		if err := b.store.EnsureParentDirsTx(tx, path, b.genID); err != nil {
-			done()
+		err = b.store.EnsureParentDirsTx(tx, path, b.genID)
+		done()
+		if err != nil {
 			return err
 		}
-		done()
 
 		done = backendTimingStep(timingEnabled, &insertNodeDuration)
-		if err := b.store.InsertNodeTx(tx, &datastore.FileNode{
+		err = b.store.InsertNodeTx(tx, &datastore.FileNode{
 			NodeID: b.genID(), Path: path, ParentPath: pathutil.ParentPath(path),
 			Name: pathutil.BaseName(path), FileID: fileID, CreatedAt: now,
-		}); err != nil {
-			done()
+		})
+		done()
+		if err != nil {
 			return err
 		}
-		done()
 
 		if tags != nil {
 			done = backendTimingStep(timingEnabled, &tagUpdateDuration)
-			if err := b.store.ReplaceFileTagsTx(tx, fileID, tags); err != nil {
-				done()
+			err = b.store.ReplaceFileTagsTx(tx, fileID, tags)
+			done()
+			if err != nil {
 				return err
 			}
-			done()
 		}
 		currentMediaDelta := quotaMediaDelta(false, isQuotaMediaContentType(contentType))
 		done = backendTimingStep(timingEnabled, &semanticEnqueueDuration)
 		if b.UsesDatabaseAutoEmbedding() {
-			created, err := b.enqueueExtractSemanticTasksTx(ctx, tx, fileID, 1, path, contentType, currentMediaDelta)
+			var created bool
+			created, err = b.enqueueExtractSemanticTasksTx(ctx, tx, fileID, 1, path, contentType, currentMediaDelta)
 			semanticTaskEnqueued = created
+			done()
 			if err != nil {
-				done()
 				return err
 			}
 		} else {
@@ -976,22 +977,19 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 			// of EMBED_TEXT, so register them in the same transaction. The embed task
 			// (if any) is enqueued separately below.
 			extractCreated, extractErr := b.enqueueExtractSemanticTasksTx(ctx, tx, fileID, 1, path, contentType, currentMediaDelta)
-			if extractErr != nil {
-				done()
-				return extractErr
-			}
-			if b.shouldEnqueueEmbedForRevision(path, contentType, contentText, description) {
-				created, err := b.enqueueEmbedTaskTx(tx, fileID, 1)
-				semanticTaskEnqueued = created || extractCreated
-				if err != nil {
-					done()
-					return err
-				}
+			err = extractErr
+			if err == nil && b.shouldEnqueueEmbedForRevision(path, contentType, contentText, description) {
+				var embedCreated bool
+				embedCreated, err = b.enqueueEmbedTaskTx(tx, fileID, 1)
+				semanticTaskEnqueued = embedCreated || extractCreated
 			} else {
 				semanticTaskEnqueued = extractCreated
 			}
+			done()
+			if err != nil {
+				return err
+			}
 		}
-		done()
 		if timingEnabled {
 			// Keep the legacy field populated for existing dashboards; create
 			// uses the semantic enqueue phase as its image enqueue boundary.
@@ -1000,11 +998,10 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 
 		done = backendTimingStep(timingEnabled, &quotaOutboxEnqueueDuration)
 		created, err := b.enqueueQuotaFileCreateOutboxTx(tx, fileID, int64(len(data)), contentType)
+		done()
 		if err != nil {
-			done()
 			return err
 		}
-		done()
 		quotaOutboxEnqueued = created
 		return nil
 	}); err != nil {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -1018,6 +1018,8 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		}
 		if timingEnabled {
 			semanticEnqueueDuration = time.Since(stepStart)
+			// Keep the legacy field populated for existing dashboards; create
+			// uses the semantic enqueue phase as its image enqueue boundary.
 			imageEnqueueDuration = semanticEnqueueDuration
 			stepStart = time.Now()
 		}

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -768,6 +768,16 @@ func backendDurationMs(d time.Duration) float64 {
 	return float64(d.Microseconds()) / 1000.0
 }
 
+func backendTimingStep(enabled bool, dst *time.Duration) func() {
+	if !enabled {
+		return func() {}
+	}
+	start := time.Now()
+	return func() {
+		*dst = time.Since(start)
+	}
+}
+
 func cloneFileTags(tags map[string]string) map[string]string {
 	if tags == nil {
 		return nil
@@ -891,29 +901,21 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
 		semanticTaskEnqueued = false
 		quotaOutboxEnqueued = false
-		stepStart := time.Time{}
-		if timingEnabled {
-			stepStart = time.Now()
-		}
+
+		done := backendTimingStep(timingEnabled, &quotaStorageCheckDuration)
 		if err := b.ensureStorageQuota(ctx, tx, path, int64(len(data))); err != nil {
-			if timingEnabled {
-				quotaStorageCheckDuration = time.Since(stepStart)
-			}
+			done()
 			return err
 		}
-		if timingEnabled {
-			quotaStorageCheckDuration = time.Since(stepStart)
-			stepStart = time.Now()
-		}
+		done()
+
+		done = backendTimingStep(timingEnabled, &quotaFileCountCheckDuration)
 		if err := b.ensureFileCountQuotaServer(ctx, tx, 1); err != nil {
-			if timingEnabled {
-				quotaFileCountCheckDuration = time.Since(stepStart)
-			}
+			done()
 			return err
 		}
-		if timingEnabled {
-			quotaFileCountCheckDuration = time.Since(stepStart)
-		}
+		done()
+
 		fileRev := int64(1)
 		insertFile := &datastore.File{
 			FileID: fileID, StorageType: storageType, StorageRef: storageRef,
@@ -927,67 +929,46 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		if b.UsesDatabaseAutoEmbedding() && description != "" {
 			insertFile.DescriptionEmbeddingRevision = &fileRev
 		}
-		if timingEnabled {
-			stepStart = time.Now()
-		}
+
+		done = backendTimingStep(timingEnabled, &insertFileDuration)
 		if err := b.store.InsertFileTx(tx, insertFile); err != nil {
-			if timingEnabled {
-				insertFileDuration = time.Since(stepStart)
-			}
+			done()
 			return err
 		}
-		if timingEnabled {
-			insertFileDuration = time.Since(stepStart)
-			stepStart = time.Now()
-		}
+		done()
+
+		done = backendTimingStep(timingEnabled, &ensureParentDirsDuration)
 		if err := b.store.EnsureParentDirsTx(tx, path, b.genID); err != nil {
-			if timingEnabled {
-				ensureParentDirsDuration = time.Since(stepStart)
-			}
+			done()
 			return err
 		}
-		if timingEnabled {
-			ensureParentDirsDuration = time.Since(stepStart)
-			stepStart = time.Now()
-		}
+		done()
+
+		done = backendTimingStep(timingEnabled, &insertNodeDuration)
 		if err := b.store.InsertNodeTx(tx, &datastore.FileNode{
 			NodeID: b.genID(), Path: path, ParentPath: pathutil.ParentPath(path),
 			Name: pathutil.BaseName(path), FileID: fileID, CreatedAt: now,
 		}); err != nil {
-			if timingEnabled {
-				insertNodeDuration = time.Since(stepStart)
-			}
+			done()
 			return err
 		}
-		if timingEnabled {
-			insertNodeDuration = time.Since(stepStart)
-		}
+		done()
+
 		if tags != nil {
-			if timingEnabled {
-				stepStart = time.Now()
-			}
+			done = backendTimingStep(timingEnabled, &tagUpdateDuration)
 			if err := b.store.ReplaceFileTagsTx(tx, fileID, tags); err != nil {
-				if timingEnabled {
-					tagUpdateDuration = time.Since(stepStart)
-				}
+				done()
 				return err
 			}
-			if timingEnabled {
-				tagUpdateDuration = time.Since(stepStart)
-			}
+			done()
 		}
 		currentMediaDelta := quotaMediaDelta(false, isQuotaMediaContentType(contentType))
-		if timingEnabled {
-			stepStart = time.Now()
-		}
+		done = backendTimingStep(timingEnabled, &semanticEnqueueDuration)
 		if b.UsesDatabaseAutoEmbedding() {
 			created, err := b.enqueueExtractSemanticTasksTx(ctx, tx, fileID, 1, path, contentType, currentMediaDelta)
 			semanticTaskEnqueued = created
 			if err != nil {
-				if timingEnabled {
-					semanticEnqueueDuration = time.Since(stepStart)
-					imageEnqueueDuration = semanticEnqueueDuration
-				}
+				done()
 				return err
 			}
 		} else {
@@ -996,43 +977,34 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 			// (if any) is enqueued separately below.
 			extractCreated, extractErr := b.enqueueExtractSemanticTasksTx(ctx, tx, fileID, 1, path, contentType, currentMediaDelta)
 			if extractErr != nil {
-				if timingEnabled {
-					semanticEnqueueDuration = time.Since(stepStart)
-					imageEnqueueDuration = semanticEnqueueDuration
-				}
+				done()
 				return extractErr
 			}
 			if b.shouldEnqueueEmbedForRevision(path, contentType, contentText, description) {
 				created, err := b.enqueueEmbedTaskTx(tx, fileID, 1)
 				semanticTaskEnqueued = created || extractCreated
 				if err != nil {
-					if timingEnabled {
-						semanticEnqueueDuration = time.Since(stepStart)
-						imageEnqueueDuration = semanticEnqueueDuration
-					}
+					done()
 					return err
 				}
 			} else {
 				semanticTaskEnqueued = extractCreated
 			}
 		}
+		done()
 		if timingEnabled {
-			semanticEnqueueDuration = time.Since(stepStart)
 			// Keep the legacy field populated for existing dashboards; create
 			// uses the semantic enqueue phase as its image enqueue boundary.
 			imageEnqueueDuration = semanticEnqueueDuration
-			stepStart = time.Now()
 		}
+
+		done = backendTimingStep(timingEnabled, &quotaOutboxEnqueueDuration)
 		created, err := b.enqueueQuotaFileCreateOutboxTx(tx, fileID, int64(len(data)), contentType)
 		if err != nil {
-			if timingEnabled {
-				quotaOutboxEnqueueDuration = time.Since(stepStart)
-			}
+			done()
 			return err
 		}
-		if timingEnabled {
-			quotaOutboxEnqueueDuration = time.Since(stepStart)
-		}
+		done()
 		quotaOutboxEnqueued = created
 		return nil
 	}); err != nil {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -792,6 +792,14 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 	var tenantTxDuration time.Duration
 	var centralQuotaDuration time.Duration
 	var imageEnqueueDuration time.Duration
+	var quotaStorageCheckDuration time.Duration
+	var quotaFileCountCheckDuration time.Duration
+	var insertFileDuration time.Duration
+	var ensureParentDirsDuration time.Duration
+	var insertNodeDuration time.Duration
+	var tagUpdateDuration time.Duration
+	var semanticEnqueueDuration time.Duration
+	var quotaOutboxEnqueueDuration time.Duration
 	defer func() {
 		if !timingEnabled {
 			return
@@ -807,6 +815,14 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 			zap.Float64("s3_put_ms", backendDurationMs(s3PutDuration)),
 			zap.Float64("tenant_tx_ms", backendDurationMs(tenantTxDuration)),
 			zap.Float64("central_quota_ms", backendDurationMs(centralQuotaDuration)),
+			zap.Float64("quota_storage_check_ms", backendDurationMs(quotaStorageCheckDuration)),
+			zap.Float64("quota_file_count_check_ms", backendDurationMs(quotaFileCountCheckDuration)),
+			zap.Float64("insert_file_ms", backendDurationMs(insertFileDuration)),
+			zap.Float64("ensure_parent_dirs_ms", backendDurationMs(ensureParentDirsDuration)),
+			zap.Float64("insert_node_ms", backendDurationMs(insertNodeDuration)),
+			zap.Float64("tag_update_ms", backendDurationMs(tagUpdateDuration)),
+			zap.Float64("semantic_enqueue_ms", backendDurationMs(semanticEnqueueDuration)),
+			zap.Float64("quota_outbox_enqueue_ms", backendDurationMs(quotaOutboxEnqueueDuration)),
 			zap.Float64("image_enqueue_ms", backendDurationMs(imageEnqueueDuration)),
 			zap.Float64("total_ms", backendDurationMs(time.Since(start))),
 		}
@@ -875,11 +891,28 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
 		semanticTaskEnqueued = false
 		quotaOutboxEnqueued = false
+		stepStart := time.Time{}
+		if timingEnabled {
+			stepStart = time.Now()
+		}
 		if err := b.ensureStorageQuota(ctx, tx, path, int64(len(data))); err != nil {
+			if timingEnabled {
+				quotaStorageCheckDuration = time.Since(stepStart)
+			}
 			return err
 		}
+		if timingEnabled {
+			quotaStorageCheckDuration = time.Since(stepStart)
+			stepStart = time.Now()
+		}
 		if err := b.ensureFileCountQuotaServer(ctx, tx, 1); err != nil {
+			if timingEnabled {
+				quotaFileCountCheckDuration = time.Since(stepStart)
+			}
 			return err
+		}
+		if timingEnabled {
+			quotaFileCountCheckDuration = time.Since(stepStart)
 		}
 		fileRev := int64(1)
 		insertFile := &datastore.File{
@@ -894,28 +927,67 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		if b.UsesDatabaseAutoEmbedding() && description != "" {
 			insertFile.DescriptionEmbeddingRevision = &fileRev
 		}
+		if timingEnabled {
+			stepStart = time.Now()
+		}
 		if err := b.store.InsertFileTx(tx, insertFile); err != nil {
+			if timingEnabled {
+				insertFileDuration = time.Since(stepStart)
+			}
 			return err
 		}
+		if timingEnabled {
+			insertFileDuration = time.Since(stepStart)
+			stepStart = time.Now()
+		}
 		if err := b.store.EnsureParentDirsTx(tx, path, b.genID); err != nil {
+			if timingEnabled {
+				ensureParentDirsDuration = time.Since(stepStart)
+			}
 			return err
+		}
+		if timingEnabled {
+			ensureParentDirsDuration = time.Since(stepStart)
+			stepStart = time.Now()
 		}
 		if err := b.store.InsertNodeTx(tx, &datastore.FileNode{
 			NodeID: b.genID(), Path: path, ParentPath: pathutil.ParentPath(path),
 			Name: pathutil.BaseName(path), FileID: fileID, CreatedAt: now,
 		}); err != nil {
+			if timingEnabled {
+				insertNodeDuration = time.Since(stepStart)
+			}
 			return err
 		}
+		if timingEnabled {
+			insertNodeDuration = time.Since(stepStart)
+		}
 		if tags != nil {
+			if timingEnabled {
+				stepStart = time.Now()
+			}
 			if err := b.store.ReplaceFileTagsTx(tx, fileID, tags); err != nil {
+				if timingEnabled {
+					tagUpdateDuration = time.Since(stepStart)
+				}
 				return err
+			}
+			if timingEnabled {
+				tagUpdateDuration = time.Since(stepStart)
 			}
 		}
 		currentMediaDelta := quotaMediaDelta(false, isQuotaMediaContentType(contentType))
+		if timingEnabled {
+			stepStart = time.Now()
+		}
 		if b.UsesDatabaseAutoEmbedding() {
 			created, err := b.enqueueExtractSemanticTasksTx(ctx, tx, fileID, 1, path, contentType, currentMediaDelta)
 			semanticTaskEnqueued = created
 			if err != nil {
+				if timingEnabled {
+					semanticEnqueueDuration = time.Since(stepStart)
+					imageEnqueueDuration = semanticEnqueueDuration
+				}
 				return err
 			}
 		} else {
@@ -924,21 +996,40 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 			// (if any) is enqueued separately below.
 			extractCreated, extractErr := b.enqueueExtractSemanticTasksTx(ctx, tx, fileID, 1, path, contentType, currentMediaDelta)
 			if extractErr != nil {
+				if timingEnabled {
+					semanticEnqueueDuration = time.Since(stepStart)
+					imageEnqueueDuration = semanticEnqueueDuration
+				}
 				return extractErr
 			}
 			if b.shouldEnqueueEmbedForRevision(path, contentType, contentText, description) {
 				created, err := b.enqueueEmbedTaskTx(tx, fileID, 1)
 				semanticTaskEnqueued = created || extractCreated
 				if err != nil {
+					if timingEnabled {
+						semanticEnqueueDuration = time.Since(stepStart)
+						imageEnqueueDuration = semanticEnqueueDuration
+					}
 					return err
 				}
 			} else {
 				semanticTaskEnqueued = extractCreated
 			}
 		}
+		if timingEnabled {
+			semanticEnqueueDuration = time.Since(stepStart)
+			imageEnqueueDuration = semanticEnqueueDuration
+			stepStart = time.Now()
+		}
 		created, err := b.enqueueQuotaFileCreateOutboxTx(tx, fileID, int64(len(data)), contentType)
 		if err != nil {
+			if timingEnabled {
+				quotaOutboxEnqueueDuration = time.Since(stepStart)
+			}
 			return err
+		}
+		if timingEnabled {
+			quotaOutboxEnqueueDuration = time.Since(stepStart)
 		}
 		quotaOutboxEnqueued = created
 		return nil

--- a/pkg/backend/quota_integration_test.go
+++ b/pkg/backend/quota_integration_test.go
@@ -180,6 +180,7 @@ func TestServerQuotaUploadOverwriteDeltaIntegration(t *testing.T) {
 	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
 		t.Fatalf("confirm overwrite upload: %v", err)
 	}
+	b.processQuotaOutboxAvailable(ctx)
 
 	usage, err := fake.GetQuotaUsage(ctx, "tenant-a")
 	if err != nil {

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -433,6 +433,97 @@ func TestUploadOverwriteQueuesCompleteBehindPendingFileMutation(t *testing.T) {
 	if fileMeta.SizeBytes != totalSize {
 		t.Fatalf("central file meta size = %d, want %d", fileMeta.SizeBytes, totalSize)
 	}
+	if got := countPendingQuotaOutboxRowsByFile(t, ctx, b, target.File.FileID); got != 0 {
+		t.Fatalf("pending quota outbox rows after drain = %d, want 0", got)
+	}
+}
+
+func TestUploadCompleteOutboxRetryAfterCentralApplyDoesNotDoubleCharge(t *testing.T) {
+	b, fake := newServerQuotaBackend(t, Options{})
+	b.stopQuotaOutboxWorker()
+	ctx := context.Background()
+
+	const (
+		uploadID = "upload-retry-after-central-apply"
+		fileID   = "file-retry-after-central-apply"
+		size     = int64(128)
+	)
+	if err := fake.AtomicReserveAndInsertUpload(ctx, &UploadReservationView{
+		TenantID:       "tenant-a",
+		UploadID:       uploadID,
+		ReservedBytes:  size,
+		FileCountDelta: 1,
+		TargetPath:     "/retry.bin",
+		Status:         "active",
+		ExpiresAt:      time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("reserve upload: %v", err)
+	}
+	raw := mustQuotaMutationJSON(t, uploadCompleteMutationData{
+		UploadID:      uploadID,
+		FileID:        fileID,
+		ReservedBytes: size,
+		NewSizeBytes:  size,
+	})
+	if _, err := b.store.EnqueueQuotaOutboxTx(b.store.DB(), &datastore.QuotaOutboxEntry{
+		FileID:       fileID,
+		MutationType: quotaMutationTypeUploadComplete,
+		MutationData: raw,
+	}); err != nil {
+		t.Fatalf("enqueue upload complete: %v", err)
+	}
+
+	claimAt := time.Now().UTC()
+	entry, found, err := b.store.ClaimQuotaOutbox(ctx, claimAt, time.Second)
+	if err != nil {
+		t.Fatalf("claim upload complete: %v", err)
+	}
+	if !found {
+		t.Fatal("claim upload complete: not found")
+	}
+	if err := b.applyQuotaOutboxEntry(ctx, entry); err != nil {
+		t.Fatalf("first central apply: %v", err)
+	}
+	usage, err := fake.GetQuotaUsage(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("get usage after first apply: %v", err)
+	}
+	if usage.StorageBytes != size || usage.ReservedBytes != 0 || usage.FileCount != 1 {
+		t.Fatalf("usage after first apply = %+v, want storage=%d reserved=0 files=1", usage, size)
+	}
+
+	recoverAt := claimAt.Add(2 * time.Second)
+	recovered, err := b.store.RecoverExpiredQuotaOutbox(ctx, recoverAt, 10)
+	if err != nil {
+		t.Fatalf("recover expired outbox: %v", err)
+	}
+	if recovered != 1 {
+		t.Fatalf("recovered rows = %d, want 1", recovered)
+	}
+	retryEntry, found, err := b.store.ClaimQuotaOutbox(ctx, recoverAt, quotaOutboxLeaseDuration)
+	if err != nil {
+		t.Fatalf("reclaim upload complete: %v", err)
+	}
+	if !found {
+		t.Fatal("reclaim upload complete: not found")
+	}
+	applied, processed, err := b.processQuotaOutboxEntry(ctx, retryEntry)
+	if err != nil {
+		t.Fatalf("retry process upload complete: %v", err)
+	}
+	if !applied || !processed {
+		t.Fatalf("retry process applied=%t processed=%t, want true/true", applied, processed)
+	}
+	usage, err = fake.GetQuotaUsage(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("get usage after retry: %v", err)
+	}
+	if usage.StorageBytes != size || usage.ReservedBytes != 0 || usage.FileCount != 1 {
+		t.Fatalf("usage after retry = %+v, want storage=%d reserved=0 files=1", usage, size)
+	}
+	if got := countQuotaOutboxRowsByFile(t, ctx, b, fileID, datastore.QuotaOutboxSucceeded); got != 1 {
+		t.Fatalf("succeeded upload-complete rows = %d, want 1", got)
+	}
 }
 
 func TestDrainQuotaOutboxForFileContinuesAfterUnrelatedBatchError(t *testing.T) {
@@ -738,6 +829,17 @@ func countQuotaOutboxRowsByFileAndMutation(t *testing.T, ctx context.Context, b 
 	var count int
 	if err := b.Store().DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM quota_outbox
 		WHERE file_id = ? AND mutation_type = ? AND status = ?`, fileID, mutationType, status).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}
+
+func countPendingQuotaOutboxRowsByFile(t *testing.T, ctx context.Context, b *Dat9Backend, fileID string) int {
+	t.Helper()
+	var count int
+	if err := b.Store().DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM quota_outbox
+		WHERE file_id = ? AND status IN (?, ?)`,
+		fileID, datastore.QuotaOutboxQueued, datastore.QuotaOutboxProcessing).Scan(&count); err != nil {
 		t.Fatal(err)
 	}
 	return count

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -500,7 +500,7 @@ func TestUploadCompleteOutboxRetryAfterCentralApplyDoesNotDoubleCharge(t *testin
 	if recovered != 1 {
 		t.Fatalf("recovered rows = %d, want 1", recovered)
 	}
-	retryEntry, found, err := b.store.ClaimQuotaOutbox(ctx, recoverAt, quotaOutboxLeaseDuration)
+	retryEntry, found, err := b.store.ClaimQuotaOutbox(ctx, recoverAt.Add(time.Second), quotaOutboxLeaseDuration)
 	if err != nil {
 		t.Fatalf("reclaim upload complete: %v", err)
 	}

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 	"github.com/mem9-ai/drive9/pkg/datastore"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/s3client"
 )
 
 func TestServerQuotaSmallWriteUsesTenantOutbox(t *testing.T) {
@@ -349,41 +352,86 @@ func TestDrainQuotaOutboxForFileErrorsWhenPendingRowIsNotClaimable(t *testing.T)
 	}
 }
 
-func TestDrainQuotaOutboxForUploadTargetProcessesClaimableBatch(t *testing.T) {
-	b, fake := newServerQuotaBackend(t, Options{})
+func TestUploadOverwriteQueuesCompleteBehindPendingFileMutation(t *testing.T) {
+	b := newTestBackendWithS3AndOptions(t, Options{QuotaSource: QuotaSourceServer})
+	fake := newFakeMetaQuotaStore()
+	fake.config["tenant-a"] = &QuotaConfigView{
+		TenantID:         "tenant-a",
+		MaxStorageBytes:  1 << 30,
+		MaxFileSizeBytes: meta.DefaultMaxFileSizeBytes(),
+		MaxMediaLLMFiles: 1000,
+		MaxMonthlyCostMC: 1 << 30,
+	}
+	b.SetMetaQuotaStore(context.Background(), "tenant-a", fake)
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()
 
-	if _, err := b.WriteCtx(ctx, "/older.txt", []byte("older"), 0, filesystem.WriteFlagCreate); err != nil {
-		t.Fatalf("write older: %v", err)
-	}
-	older, err := b.Store().Stat(ctx, "/older.txt")
-	if err != nil {
-		t.Fatalf("stat older: %v", err)
-	}
-	if _, err := b.WriteCtx(ctx, "/target.txt", []byte("target"), 0, filesystem.WriteFlagCreate); err != nil {
+	if _, err := b.WriteCtx(ctx, "/target.bin", []byte("old"), 0, filesystem.WriteFlagCreate); err != nil {
 		t.Fatalf("write target: %v", err)
 	}
-	target, err := b.Store().Stat(ctx, "/target.txt")
+	target, err := b.Store().Stat(ctx, "/target.bin")
 	if err != nil {
 		t.Fatalf("stat target: %v", err)
 	}
+	if got := countQuotaOutboxRowsByFile(t, ctx, b, target.File.FileID, datastore.QuotaOutboxQueued); got != 1 {
+		t.Fatalf("queued rows before upload = %d, want 1", got)
+	}
 
-	if err := b.drainQuotaOutboxForUploadTarget(ctx, target, true); err != nil {
-		t.Fatalf("drain target: %v", err)
+	totalSize := int64(2 << 20)
+	plan, err := b.InitiateUpload(ctx, "/target.bin", totalSize)
+	if err != nil {
+		t.Fatalf("initiate overwrite upload: %v", err)
 	}
-	if got := countQuotaOutboxRowsByFile(t, ctx, b, older.File.FileID, datastore.QuotaOutboxSucceeded); got != 1 {
-		t.Fatalf("older succeeded rows = %d, want 1", got)
-	}
-	if got := countQuotaOutboxRowsByFile(t, ctx, b, target.File.FileID, datastore.QuotaOutboxSucceeded); got != 1 {
-		t.Fatalf("target succeeded rows = %d, want 1", got)
+	if got := countQuotaOutboxRowsByFileAndMutation(t, ctx, b, target.File.FileID, quotaMutationTypeFileCreate, datastore.QuotaOutboxQueued); got != 1 {
+		t.Fatalf("queued create rows after initiate = %d, want 1", got)
 	}
 	usage, err := fake.GetQuotaUsage(ctx, "tenant-a")
 	if err != nil {
-		t.Fatalf("get usage: %v", err)
+		t.Fatalf("get usage after initiate: %v", err)
 	}
-	if usage.StorageBytes != int64(len("older")+len("target")) || usage.FileCount != 2 {
-		t.Fatalf("central usage after drain = %+v, want both files applied", usage)
+	if usage.StorageBytes != 0 || usage.ReservedBytes != totalSize || usage.FileCount != 0 {
+		t.Fatalf("usage after initiate = %+v, want storage=0 reserved=%d files=0", usage, totalSize)
+	}
+
+	upload, err := b.GetUpload(ctx, plan.UploadID)
+	if err != nil {
+		t.Fatalf("get upload: %v", err)
+	}
+	partData := bytes.Repeat([]byte{7}, int(totalSize))
+	for _, p := range plan.Parts {
+		start := int64(p.Number-1) * plan.PartSize
+		end := start + p.Size
+		if end > totalSize {
+			end = totalSize
+		}
+		if _, err := b.S3().(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, p.Number, bytes.NewReader(partData[start:end])); err != nil {
+			t.Fatalf("upload part %d: %v", p.Number, err)
+		}
+	}
+	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
+		t.Fatalf("confirm upload: %v", err)
+	}
+	if got := countQuotaOutboxRowsByFileAndMutation(t, ctx, b, target.File.FileID, quotaMutationTypeFileCreate, datastore.QuotaOutboxQueued); got != 1 {
+		t.Fatalf("queued create rows after confirm = %d, want 1", got)
+	}
+	if got := countQuotaOutboxRowsByFileAndMutation(t, ctx, b, target.File.FileID, quotaMutationTypeUploadComplete, datastore.QuotaOutboxQueued); got != 1 {
+		t.Fatalf("queued upload-complete rows after confirm = %d, want 1", got)
+	}
+
+	b.processQuotaOutboxAvailable(ctx)
+	usage, err = fake.GetQuotaUsage(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("get usage after outbox: %v", err)
+	}
+	if usage.StorageBytes != totalSize || usage.ReservedBytes != 0 || usage.FileCount != 1 {
+		t.Fatalf("usage after outbox = %+v, want storage=%d reserved=0 files=1", usage, totalSize)
+	}
+	fileMeta, err := fake.GetFileMeta(ctx, "tenant-a", target.File.FileID)
+	if err != nil {
+		t.Fatalf("get central file meta: %v", err)
+	}
+	if fileMeta.SizeBytes != totalSize {
+		t.Fatalf("central file meta size = %d, want %d", fileMeta.SizeBytes, totalSize)
 	}
 }
 
@@ -680,6 +728,16 @@ func countQuotaOutboxRowsByFile(t *testing.T, ctx context.Context, b *Dat9Backen
 	t.Helper()
 	var count int
 	if err := b.Store().DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM quota_outbox WHERE file_id = ? AND status = ?`, fileID, status).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}
+
+func countQuotaOutboxRowsByFileAndMutation(t *testing.T, ctx context.Context, b *Dat9Backend, fileID string, mutationType string, status datastore.QuotaOutboxStatus) int {
+	t.Helper()
+	var count int
+	if err := b.Store().DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM quota_outbox
+		WHERE file_id = ? AND mutation_type = ? AND status = ?`, fileID, mutationType, status).Scan(&count); err != nil {
 		t.Fatal(err)
 	}
 	return count

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -29,6 +29,7 @@ const (
 	quotaOutboxRetryMaxDelay            = 30 * time.Second
 	quotaMutationTypeFileCreate         = "file_create"
 	quotaMutationTypeOverwrite          = "file_overwrite"
+	quotaMutationTypeUploadComplete     = "upload_complete"
 )
 
 func (b *Dat9Backend) startQuotaOutboxWorker() {
@@ -147,16 +148,6 @@ func (b *Dat9Backend) processQuotaOutboxAvailable(ctx context.Context) {
 		processedTotal += processed
 	}
 	b.notifyQuotaOutbox(true)
-}
-
-func (b *Dat9Backend) drainQuotaOutboxForUploadTarget(ctx context.Context, target *datastore.NodeWithFile, targetExists bool) error {
-	if !targetExists || !b.UseServerQuota() || b.store == nil {
-		return nil
-	}
-	if target == nil || target.File == nil || target.File.FileID == "" {
-		return nil
-	}
-	return b.drainQuotaOutboxForFile(ctx, target.File.FileID, quotaOutboxUploadDrainLimit)
 }
 
 func (b *Dat9Backend) drainQuotaOutboxForFile(ctx context.Context, fileID string, limit int) error {
@@ -450,6 +441,34 @@ func (b *Dat9Backend) enqueueQuotaFileCreateOutboxTx(tx *sql.Tx, fileID string, 
 		StorageDelta: sizeBytes,
 		FileDelta:    1,
 		MediaDelta:   mediaDelta,
+	})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (b *Dat9Backend) enqueueQuotaUploadCompleteOutboxTx(tx *sql.Tx, uploadID string, reservedBytes int64, fileID string, oldSizeBytes int64, oldIsMedia bool, newSizeBytes int64, newIsMedia bool) (bool, error) {
+	if !b.UseServerQuota() {
+		return false, nil
+	}
+	data := uploadCompleteMutationData{
+		UploadID:      uploadID,
+		FileID:        fileID,
+		ReservedBytes: reservedBytes,
+		OldSizeBytes:  oldSizeBytes,
+		OldIsMedia:    oldIsMedia,
+		NewSizeBytes:  newSizeBytes,
+		NewIsMedia:    newIsMedia,
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return false, err
+	}
+	_, err = b.store.EnqueueQuotaOutboxTx(tx, &datastore.QuotaOutboxEntry{
+		FileID:       fileID,
+		MutationType: quotaMutationTypeUploadComplete,
+		MutationData: raw,
 	})
 	if err != nil {
 		return false, err

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -390,6 +390,8 @@ func (b *Dat9Backend) applyQuotaOutboxEntryTx(tx *sql.Tx, entry *datastore.Quota
 	if entry == nil {
 		return fmt.Errorf("quota outbox entry is required")
 	}
+	// Reuse the central mutation dispatcher; upload_complete is handled there
+	// by applyUploadCompleteTx, the same body used by mutation replay.
 	return applyCentralQuotaMutationTx(b.metaStore, tx, b.tenantID, entry.MutationType, entry.MutationData, entry.ID)
 }
 

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -1016,6 +1016,9 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	var semanticEnqueueDurationMs float64
 	var semanticTaskEnqueued bool
 	var quotaOutboxEnqueued bool
+	// upload.TotalSize is immutable from the upload row. The old* fields and
+	// confirmedFileID are refreshed inside each InTx attempt after locking the
+	// target node/file, then consumed by this same transaction's outbox enqueue.
 	enqueueUploadCompleteOutbox := func(tx *sql.Tx) error {
 		created, err := b.enqueueQuotaUploadCompleteOutboxTx(tx,
 			uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia)
@@ -1207,6 +1210,12 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	b.notifyQuotaOutbox(quotaOutboxEnqueued)
 
 	if !quotaOutboxEnqueued {
+		if b.UseServerQuota() {
+			logger.Error(ctx, "upload_complete_quota_accounting_skipped",
+				zap.String("tenant_id", b.tenantID),
+				zap.String("upload_id", uploadID),
+				zap.String("file_id", confirmedFileID))
+		}
 		// Preserve the non-outbox path when central quota is wired without
 		// server-quota mode; server quota uses the tenant-local outbox so
 		// upload completion is ordered with prior mutations for the same file.

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -274,17 +274,13 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
-	target, targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
+	_, targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
 	if err != nil {
 		if errors.Is(err, datastore.ErrRevisionConflict) {
 			metrics.RecordOperation("backend", "initiate_upload", "conflict", time.Since(start))
 		} else {
 			metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		}
-		return nil, err
-	}
-	if err := b.drainQuotaOutboxForUploadTarget(ctx, target, targetExists); err != nil {
-		metrics.RecordOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 
@@ -459,17 +455,13 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
-	target, targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
+	_, targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
 	if err != nil {
 		if errors.Is(err, datastore.ErrRevisionConflict) {
 			metrics.RecordOperation("backend", "initiate_upload_v2", "conflict", time.Since(start))
 		} else {
 			metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		}
-		return nil, err
-	}
-	if err := b.drainQuotaOutboxForUploadTarget(ctx, target, targetExists); err != nil {
-		metrics.RecordOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	validateDurationMs := uploadPhaseMs(validateStart)
@@ -1024,8 +1016,19 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	var insertNodeDurationMs float64
 	var semanticEnqueueDurationMs float64
 	var semanticTaskEnqueued bool
+	var quotaOutboxEnqueued bool
+	enqueueUploadCompleteOutbox := func(tx *sql.Tx) error {
+		created, err := b.enqueueQuotaUploadCompleteOutboxTx(tx,
+			uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia)
+		if err != nil {
+			return err
+		}
+		quotaOutboxEnqueued = created
+		return nil
+	}
 	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
 		semanticTaskEnqueued = false
+		quotaOutboxEnqueued = false
 		stepStart := time.Now()
 		if err := b.store.CompleteUploadTx(tx, uploadID); err != nil {
 			return err
@@ -1118,7 +1121,10 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 					quotaMediaDelta(oldIsMedia, newIsMedia))
 				semanticTaskEnqueued = created
 				semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
-				return err
+				if err != nil {
+					return err
+				}
+				return enqueueUploadCompleteOutbox(tx)
 			}
 			// App-embedding mode: image/audio extract tasks are durable and
 			// independent of EMBED_TEXT, so register them in the same transaction.
@@ -1132,11 +1138,14 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 				created, err := b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
 				semanticTaskEnqueued = created || extractCreated
 				semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
-				return err
+				if err != nil {
+					return err
+				}
+				return enqueueUploadCompleteOutbox(tx)
 			}
 			semanticTaskEnqueued = extractCreated
 			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
-			return nil
+			return enqueueUploadCompleteOutbox(tx)
 		}
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
@@ -1190,7 +1199,10 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 				quotaMediaDelta(false, newIsMedia))
 			semanticTaskEnqueued = created
 			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
-			return err
+			if err != nil {
+				return err
+			}
+			return enqueueUploadCompleteOutbox(tx)
 		}
 		// App-embedding mode: image/audio extract tasks are durable and
 		// independent of EMBED_TEXT, so register them in the same transaction.
@@ -1204,11 +1216,14 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 			created, err := b.enqueueEmbedTaskTx(tx, confirmedFileID, confirmedRevision)
 			semanticTaskEnqueued = created || extractCreated
 			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
-			return err
+			if err != nil {
+				return err
+			}
+			return enqueueUploadCompleteOutbox(tx)
 		}
 		semanticTaskEnqueued = extractCreated
 		semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
-		return nil
+		return enqueueUploadCompleteOutbox(tx)
 	}); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_tx_failed", zap.String("upload_id", uploadID), zap.Error(err))
 		b.cleanupFailedFinalizeUpload(ctx, upload)
@@ -1219,10 +1234,14 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	}
 	txDurationMs := uploadPhaseMs(txStart)
 	b.notifySemanticTaskEnqueued(semanticTaskEnqueued)
+	b.notifyQuotaOutbox(quotaOutboxEnqueued)
 
-	// Transfer server-side reservation, update file shadow state, and mark the
-	// upload-complete mutation applied in one server-DB transaction.
-	b.completeUploadReservation(ctx, uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia)
+	if !quotaOutboxEnqueued {
+		// Preserve the non-outbox path when central quota is wired without
+		// server-quota mode; server quota uses the tenant-local outbox so
+		// upload completion is ordered with prior mutations for the same file.
+		b.completeUploadReservation(ctx, uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia)
+	}
 
 	if isOverwrite {
 		b.deleteBlobIfS3Ctx(ctx, oldStorageType, oldStorageRef, upload.S3Key)

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -1056,6 +1056,15 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
 		semanticTaskEnqueued = false
 		quotaOutboxEnqueued = false
+		oldStorageRef = ""
+		oldStorageType = ""
+		oldContentType = ""
+		isOverwrite = false
+		oldSizeBytes = 0
+		oldIsMedia = false
+		confirmedFileID = ""
+		confirmedRevision = 0
+		branch = "create"
 		stepStart := time.Now()
 		if err := b.store.CompleteUploadTx(tx, uploadID); err != nil {
 			return err

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -1142,56 +1142,56 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 			if err := enqueueUploadSemanticTasks(tx, quotaMediaDelta(oldIsMedia, newIsMedia)); err != nil {
 				return err
 			}
-			return enqueueUploadCompleteOutbox(tx)
-		}
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return err
-		}
-		if expectedRevision > 0 {
-			return datastore.ErrRevisionConflict
-		}
-
-		if b.UsesDatabaseAutoEmbedding() {
-			stepStart = time.Now()
-			if err := b.store.ConfirmPendingFileAutoEmbeddingTx(tx,
-				upload.FileID, datastore.StorageS3, upload.S3Key, contentType, upload.TotalSize, upload.Description,
-			); err != nil {
-				return err
-			}
-			confirmPendingFileDurationMs = uploadPhaseMs(stepStart)
 		} else {
-			stepStart = time.Now()
-			if err := b.store.ConfirmPendingFileTx(tx,
-				upload.FileID, datastore.StorageS3, upload.S3Key, contentType, upload.TotalSize, upload.Description,
-			); err != nil {
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				return err
 			}
-			confirmPendingFileDurationMs = uploadPhaseMs(stepStart)
-		}
-		confirmedFileID = upload.FileID
-		confirmedRevision = 1
-		stepStart = time.Now()
-		if err := b.store.InsertNodeTx(tx, &datastore.FileNode{
-			NodeID:     b.genID(),
-			Path:       upload.TargetPath,
-			ParentPath: pathutil.ParentPath(upload.TargetPath),
-			Name:       pathutil.BaseName(upload.TargetPath),
-			FileID:     upload.FileID,
-			CreatedAt:  time.Now(),
-		}); err != nil {
-			if expectedRevision >= 0 && errors.Is(err, datastore.ErrPathConflict) {
+			if expectedRevision > 0 {
 				return datastore.ErrRevisionConflict
 			}
-			return err
-		}
-		insertNodeDurationMs = uploadPhaseMs(stepStart)
-		if tags != nil {
-			if err := b.store.ReplaceFileTagsTx(tx, upload.FileID, tags); err != nil {
+
+			if b.UsesDatabaseAutoEmbedding() {
+				stepStart = time.Now()
+				if err := b.store.ConfirmPendingFileAutoEmbeddingTx(tx,
+					upload.FileID, datastore.StorageS3, upload.S3Key, contentType, upload.TotalSize, upload.Description,
+				); err != nil {
+					return err
+				}
+				confirmPendingFileDurationMs = uploadPhaseMs(stepStart)
+			} else {
+				stepStart = time.Now()
+				if err := b.store.ConfirmPendingFileTx(tx,
+					upload.FileID, datastore.StorageS3, upload.S3Key, contentType, upload.TotalSize, upload.Description,
+				); err != nil {
+					return err
+				}
+				confirmPendingFileDurationMs = uploadPhaseMs(stepStart)
+			}
+			confirmedFileID = upload.FileID
+			confirmedRevision = 1
+			stepStart = time.Now()
+			if err := b.store.InsertNodeTx(tx, &datastore.FileNode{
+				NodeID:     b.genID(),
+				Path:       upload.TargetPath,
+				ParentPath: pathutil.ParentPath(upload.TargetPath),
+				Name:       pathutil.BaseName(upload.TargetPath),
+				FileID:     upload.FileID,
+				CreatedAt:  time.Now(),
+			}); err != nil {
+				if expectedRevision >= 0 && errors.Is(err, datastore.ErrPathConflict) {
+					return datastore.ErrRevisionConflict
+				}
 				return err
 			}
-		}
-		if err := enqueueUploadSemanticTasks(tx, quotaMediaDelta(false, newIsMedia)); err != nil {
-			return err
+			insertNodeDurationMs = uploadPhaseMs(stepStart)
+			if tags != nil {
+				if err := b.store.ReplaceFileTagsTx(tx, upload.FileID, tags); err != nil {
+					return err
+				}
+			}
+			if err := enqueueUploadSemanticTasks(tx, quotaMediaDelta(false, newIsMedia)); err != nil {
+				return err
+			}
 		}
 		return enqueueUploadCompleteOutbox(tx)
 	}); err != nil {

--- a/pkg/backend/upload_reservation.go
+++ b/pkg/backend/upload_reservation.go
@@ -323,8 +323,7 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 //     claim on reserved_bytes is real, so we transfer reserved → storage.
 //
 //   - settled=false: no active reservation row found. This covers THREE
-//     sub-cases that are indistinguishable from the apply tx's POV and must
-//     all land on the same code path:
+//     sub-cases:
 //     (1) fail-open initiate — reserveUploadOnServer returned (false, nil)
 //     because the server DB was unreachable; no reserved_bytes were
 //     ever claimed and no reservation row was written.
@@ -335,9 +334,12 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 //     but ExpireActiveReservations released it (and backed out the
 //     reserved_bytes) between initiate and this apply tx.
 //
-//     In all three sub-cases reserved_bytes is either untouched (case 1) or
-//     already balanced (cases 2, 3), so we skip the reserved→storage
-//     transfer and charge storage_bytes directly with newSizeBytes.
+//     If file_meta already equals the post-upload state, the row is a
+//     duplicate retry after a previous central apply committed but the
+//     tenant-local ack did not. In that case this helper is a no-op. Otherwise
+//     reserved_bytes is either untouched (case 1) or already balanced
+//     (cases 2, 3), so we skip the reserved→storage transfer and charge
+//     storage_bytes directly with newSizeBytes.
 //
 // This function is package-level (not a *Dat9Backend method) so that the
 // replay worker — which only holds a MetaQuotaStore, no backend — can call
@@ -355,16 +357,21 @@ func applyUploadCompleteTx(store MetaQuotaStore, tx *sql.Tx, tenantID string, da
 		mediaDelta = -1
 	}
 	oldExists := false
+	var oldMeta *FileMetaView
 	if old, err := store.GetFileMetaForUpdateTx(tx, tenantID, data.FileID); err != nil {
 		if !errors.Is(err, meta.ErrNotFound) {
 			return err
 		}
 	} else if old != nil {
 		oldExists = true
+		oldMeta = old
 	}
 	settled, reservedFileCountDelta, err := store.SettleActiveReservationTx(tx, tenantID, data.UploadID, "completed")
 	if err != nil {
 		return err
+	}
+	if !settled && oldMeta != nil && oldMeta.SizeBytes == data.NewSizeBytes && oldMeta.IsMedia == data.NewIsMedia {
+		return nil
 	}
 	if settled {
 		if err := store.TransferReservedToConfirmedTx(tx, tenantID, -data.ReservedBytes, data.ReservedBytes); err != nil {

--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -331,6 +331,8 @@ func (s *Store) retryQuotaOutboxTx(ctx context.Context, tx *sql.Tx, id int64, re
 	if err != nil {
 		return err
 	}
+	// Receipt is the worker ownership token. Recovery clears the receipt before
+	// requeueing, so stale owners fail here even when their old lease expired.
 	if entry.Status != QuotaOutboxProcessing || entry.Receipt != receipt {
 		return ErrQuotaOutboxLeaseMismatch
 	}

--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -451,7 +451,7 @@ func (s *Store) HasPendingQuotaOutboxFileMutation(ctx context.Context, fileID st
 	var count int
 	err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM quota_outbox
 		WHERE file_id = ?
-		  AND mutation_type IN ('file_create', 'file_overwrite')
+		  AND mutation_type IN ('file_create', 'file_overwrite', 'upload_complete')
 		  AND status IN (?, ?)`,
 		fileID, QuotaOutboxQueued, QuotaOutboxProcessing).Scan(&count)
 	if err != nil {

--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -242,10 +242,10 @@ func (s *Store) AckQuotaOutboxBatchTx(ctx context.Context, tx *sql.Tx, entries [
 		}
 		ids = append(ids, entries[i].ID)
 	}
-	args := append([]any{QuotaOutboxSucceeded, now, now, QuotaOutboxProcessing, receipt, now}, ids...)
+	args := append([]any{QuotaOutboxSucceeded, now, now, QuotaOutboxProcessing, receipt}, ids...)
 	res, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE quota_outbox SET status = ?, receipt = NULL,
 		leased_at = NULL, lease_until = NULL, completed_at = ?, updated_at = ?
-		WHERE status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?
+		WHERE status = ? AND receipt = ?
 		  AND id IN (%s)`, sqlPlaceholders(len(entries))), args...)
 	if err != nil {
 		return err
@@ -264,8 +264,8 @@ func (s *Store) ackQuotaOutbox(ctx context.Context, db execer, id int64, receipt
 	now := time.Now().UTC()
 	res, err := db.ExecContext(ctx, `UPDATE quota_outbox SET status = ?, receipt = NULL,
 		leased_at = NULL, lease_until = NULL, completed_at = ?, updated_at = ?
-		WHERE id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`,
-		QuotaOutboxSucceeded, now, now, id, QuotaOutboxProcessing, receipt, now)
+		WHERE id = ? AND status = ? AND receipt = ?`,
+		QuotaOutboxSucceeded, now, now, id, QuotaOutboxProcessing, receipt)
 	if err != nil {
 		return err
 	}
@@ -331,7 +331,7 @@ func (s *Store) retryQuotaOutboxTx(ctx context.Context, tx *sql.Tx, id int64, re
 	if err != nil {
 		return err
 	}
-	if entry.Status != QuotaOutboxProcessing || entry.Receipt != receipt || entry.LeaseUntil == nil || !entry.LeaseUntil.After(now) {
+	if entry.Status != QuotaOutboxProcessing || entry.Receipt != receipt {
 		return ErrQuotaOutboxLeaseMismatch
 	}
 

--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -242,6 +242,8 @@ func (s *Store) AckQuotaOutboxBatchTx(ctx context.Context, tx *sql.Tx, entries [
 		}
 		ids = append(ids, entries[i].ID)
 	}
+	// Receipt is the worker ownership token. Recovery clears receipt before
+	// requeueing, so stale owners cannot match after another worker reclaims.
 	args := append([]any{QuotaOutboxSucceeded, now, now, QuotaOutboxProcessing, receipt}, ids...)
 	res, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE quota_outbox SET status = ?, receipt = NULL,
 		leased_at = NULL, lease_until = NULL, completed_at = ?, updated_at = ?

--- a/pkg/datastore/quota_outbox_test.go
+++ b/pkg/datastore/quota_outbox_test.go
@@ -118,7 +118,7 @@ func TestQuotaOutboxRecoverExpired(t *testing.T) {
 func TestQuotaOutboxAckAllowsExpiredLeaseWhenReceiptStillOwned(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	now := time.Now().UTC().Add(-time.Second).Truncate(time.Microsecond)
 
 	id, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
 		FileID:       "file-1",
@@ -152,7 +152,7 @@ func TestQuotaOutboxAckAllowsExpiredLeaseWhenReceiptStillOwned(t *testing.T) {
 func TestQuotaOutboxBatchAckAllowsExpiredLeaseWhenReceiptStillOwned(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	now := time.Now().UTC().Add(-time.Second).Truncate(time.Microsecond)
 	availableNow := now.Add(-time.Second)
 
 	firstID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
@@ -198,7 +198,7 @@ func TestQuotaOutboxBatchAckAllowsExpiredLeaseWhenReceiptStillOwned(t *testing.T
 func TestQuotaOutboxRetryAllowsExpiredLeaseWhenReceiptStillOwned(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
-	now := time.Now().UTC().Truncate(time.Microsecond)
+	now := time.Now().UTC().Add(-time.Second).Truncate(time.Microsecond)
 
 	id, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
 		FileID:       "file-1",

--- a/pkg/datastore/quota_outbox_test.go
+++ b/pkg/datastore/quota_outbox_test.go
@@ -69,6 +69,49 @@ func TestQuotaOutboxLifecycle(t *testing.T) {
 	}
 }
 
+func TestHasPendingQuotaOutboxFileMutationIncludesUploadComplete(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	payload := json.RawMessage(`{"upload_id":"upload-1","file_id":"file-1"}`)
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		_, err := s.EnqueueQuotaOutboxTx(tx, &QuotaOutboxEntry{
+			FileID:       "file-1",
+			MutationType: "upload_complete",
+			MutationData: payload,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("enqueue upload complete outbox: %v", err)
+	}
+
+	pending, err := s.HasPendingQuotaOutboxFileMutation(ctx, "file-1")
+	if err != nil {
+		t.Fatalf("has pending file mutation: %v", err)
+	}
+	if !pending {
+		t.Fatal("pending file mutation = false, want true")
+	}
+
+	claimed, found, err := s.ClaimQuotaOutbox(ctx, time.Now().UTC(), time.Minute)
+	if err != nil {
+		t.Fatalf("claim quota outbox: %v", err)
+	}
+	if !found {
+		t.Fatal("expected quota outbox row")
+	}
+	if err := s.AckQuotaOutbox(ctx, claimed.ID, claimed.Receipt); err != nil {
+		t.Fatalf("ack quota outbox: %v", err)
+	}
+	pending, err = s.HasPendingQuotaOutboxFileMutation(ctx, "file-1")
+	if err != nil {
+		t.Fatalf("has pending file mutation after ack: %v", err)
+	}
+	if pending {
+		t.Fatal("pending file mutation after ack = true, want false")
+	}
+}
+
 func TestQuotaOutboxRecoverExpired(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/datastore/quota_outbox_test.go
+++ b/pkg/datastore/quota_outbox_test.go
@@ -115,6 +115,76 @@ func TestQuotaOutboxRecoverExpired(t *testing.T) {
 	}
 }
 
+func TestQuotaOutboxBatchAckRejectsRecoveredOldReceipt(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Add(-time.Second).Truncate(time.Microsecond)
+
+	id, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-1",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-1"}`),
+		AvailableAt:  now.Add(-time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed, err := s.ClaimQuotaOutboxBatch(ctx, now, time.Millisecond, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != id {
+		t.Fatalf("claimed = %+v, want id %d", claimed, id)
+	}
+	if recovered, err := s.RecoverExpiredQuotaOutbox(ctx, time.Now().UTC(), 10); err != nil {
+		t.Fatal(err)
+	} else if recovered != 1 {
+		t.Fatalf("recovered rows = %d, want 1", recovered)
+	}
+	if _, err := s.ClaimQuotaOutboxBatch(ctx, time.Now().UTC(), time.Minute, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.AckQuotaOutboxBatchTx(ctx, tx, claimed)
+	}); err != ErrQuotaOutboxLeaseMismatch {
+		t.Fatalf("batch ack recovered row with old receipt error = %v, want lease mismatch", err)
+	}
+}
+
+func TestQuotaOutboxRetryRejectsRecoveredOldReceipt(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Add(-time.Second).Truncate(time.Microsecond)
+
+	id, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-1",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-1"}`),
+		AvailableAt:  now.Add(-time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed, found, err := s.ClaimQuotaOutbox(ctx, now, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || claimed.ID != id {
+		t.Fatalf("claimed = %+v found=%v, want id %d", claimed, found, id)
+	}
+	if recovered, err := s.RecoverExpiredQuotaOutbox(ctx, time.Now().UTC(), 10); err != nil {
+		t.Fatal(err)
+	} else if recovered != 1 {
+		t.Fatalf("recovered rows = %d, want 1", recovered)
+	}
+	if _, _, err := s.ClaimQuotaOutbox(ctx, time.Now().UTC(), time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RetryQuotaOutbox(ctx, claimed.ID, claimed.Receipt, time.Now().UTC(), "temporary"); err != ErrQuotaOutboxLeaseMismatch {
+		t.Fatalf("retry recovered row with old receipt error = %v, want lease mismatch", err)
+	}
+}
+
 func TestQuotaOutboxAckAllowsExpiredLeaseWhenReceiptStillOwned(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/datastore/quota_outbox_test.go
+++ b/pkg/datastore/quota_outbox_test.go
@@ -110,6 +110,124 @@ func TestQuotaOutboxRecoverExpired(t *testing.T) {
 	if !found || reclaimed.ID != claimed.ID {
 		t.Fatalf("reclaimed row = %+v found=%v, want id %d", reclaimed, found, claimed.ID)
 	}
+	if err := s.AckQuotaOutbox(ctx, claimed.ID, claimed.Receipt); err != ErrQuotaOutboxLeaseMismatch {
+		t.Fatalf("ack recovered row with old receipt error = %v, want lease mismatch", err)
+	}
+}
+
+func TestQuotaOutboxAckAllowsExpiredLeaseWhenReceiptStillOwned(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	id, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-1",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-1"}`),
+		AvailableAt:  now.Add(-time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed, found, err := s.ClaimQuotaOutbox(ctx, now, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || claimed.ID != id {
+		t.Fatalf("claimed = %+v found=%v, want id %d", claimed, found, id)
+	}
+
+	if err := s.AckQuotaOutbox(ctx, claimed.ID, claimed.Receipt); err != nil {
+		t.Fatalf("ack expired-but-owned quota outbox: %v", err)
+	}
+	var status QuotaOutboxStatus
+	if err := s.DB().QueryRowContext(ctx, `SELECT status FROM quota_outbox WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != QuotaOutboxSucceeded {
+		t.Fatalf("status = %q, want %q", status, QuotaOutboxSucceeded)
+	}
+}
+
+func TestQuotaOutboxBatchAckAllowsExpiredLeaseWhenReceiptStillOwned(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	availableNow := now.Add(-time.Second)
+
+	firstID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-1",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-1"}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-2",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-2"}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimed, err := s.ClaimQuotaOutboxBatch(ctx, now, time.Millisecond, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 2 || claimed[0].ID != firstID || claimed[1].ID != secondID {
+		t.Fatalf("claimed = %+v, want ids %d,%d", claimed, firstID, secondID)
+	}
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.AckQuotaOutboxBatchTx(ctx, tx, claimed)
+	}); err != nil {
+		t.Fatalf("batch ack expired-but-owned quota outbox: %v", err)
+	}
+	var succeeded int
+	if err := s.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM quota_outbox WHERE status = ?`, QuotaOutboxSucceeded).Scan(&succeeded); err != nil {
+		t.Fatal(err)
+	}
+	if succeeded != 2 {
+		t.Fatalf("succeeded rows = %d, want 2", succeeded)
+	}
+}
+
+func TestQuotaOutboxRetryAllowsExpiredLeaseWhenReceiptStillOwned(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	id, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-1",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-1"}`),
+		AvailableAt:  now.Add(-time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed, found, err := s.ClaimQuotaOutbox(ctx, now, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || claimed.ID != id {
+		t.Fatalf("claimed = %+v found=%v, want id %d", claimed, found, id)
+	}
+
+	retryAt := now.Add(time.Minute)
+	if err := s.RetryQuotaOutbox(ctx, claimed.ID, claimed.Receipt, retryAt, "temporary"); err != nil {
+		t.Fatalf("retry expired-but-owned quota outbox: %v", err)
+	}
+	var status QuotaOutboxStatus
+	if err := s.DB().QueryRowContext(ctx, `SELECT status FROM quota_outbox WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != QuotaOutboxQueued {
+		t.Fatalf("status = %q, want %q", status, QuotaOutboxQueued)
+	}
 }
 
 func TestQuotaOutboxClaimWaitsForDelayedOlderRetry(t *testing.T) {


### PR DESCRIPTION
## Summary
- Allow quota outbox ack/retry when the worker still owns the receipt, even if the lease deadline has passed.
- Keep recovered/reclaimed rows protected because recovery clears the receipt, so stale owners still fail with lease mismatch.
- Add deterministic datastore regressions for single ack, batch ack, retry, and recovered-row old receipt behavior.
- Add fine-grained backend_write_create_timing fields behind DRIVE9_BENCH_TIMING_LOG_ENABLED, with helper-based timing bookkeeping.
- Remove the upload initiate synchronous quota-outbox drain barrier; upload completion now enqueues an upload_complete tenant quota outbox row so same-file quota mutations converge in per-file order.

## Why
Production server-quota logs showed repeated quota outbox lease mismatch during outbox processing. The lease should authorize recovery by other workers, while the receipt remains the owner token for ack/retry.

The later upload-path finding showed that drainQuotaOutboxForUploadTarget had become a request-path serial barrier: each overwrite upload could wait for the target file outbox to clear, and multiple pods could contend on the same processing row. This PR removes that barrier from initiate and orders upload completion through the same tenant-local quota outbox instead. Older same-file create/overwrite rows now apply before upload_complete without making PUT/initiate requests act as outbox workers.

## Tests
- make test TEST_PKGS='./pkg/backend'
- make test TEST_PKGS='./pkg/backend' TEST_RUN='TestUploadOverwriteQueuesCompleteBehindPendingFileMutation'
- make test TEST_PKGS='./pkg/backend' TEST_RUN='TestUploadOverwriteQueuesCompleteBehindPendingFileMutation|TestServerQuotaUploadOverwriteDeltaIntegration|Test.*QuotaOutbox|TestDrainQuotaOutboxForFile|TestExpiredUploadReservationNoLongerCountsTowardQuota'
- make test TEST_PKGS='./pkg/datastore' TEST_RUN='TestQuotaOutbox|TestHasPendingQuotaOutboxFileMutation'
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/datastore -run TestQuotaOutbox -count=1
- git diff --check