### PR TITLE
feat: support private endpoint for tidb_cloud_native tenants

### DIFF
--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -978,6 +978,7 @@ type clusterInfo struct {
 	} `json:"endpoints"`
 	UserPrefix string `json:"userPrefix"`
 }
+
 type branchInfo struct {
 	BranchID  string `json:"branchId"`
 	State     string `json:"state"`
@@ -992,7 +993,6 @@ type branchInfo struct {
 		} `json:"private"`
 	} `json:"endpoints"`
 	UserPrefix string `json:"userPrefix"`
-	Username   string `json:"username"`
 }
 
 type clusterListResponse struct {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -264,7 +264,7 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 	if info.ClusterID == "" {
 		return nil, nil, fmt.Errorf("tidbcloud native response missing cluster id")
 	}
-	if clusterProvisionMetadataIncomplete(info) {
+	if clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint) {
 		info, err = p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, info.ClusterID)
 		if err != nil {
 			return &tenant.ClusterInfo{
@@ -279,10 +279,8 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 	host := info.Endpoints.Public.Host
 	port := info.Endpoints.Public.Port
 	if p.usePrivateEndpoint {
-		if info.Endpoints.Private.Host != "" {
-			host = info.Endpoints.Private.Host
-			port = info.Endpoints.Private.Port
-		}
+		host = info.Endpoints.Private.Host
+		port = info.Endpoints.Private.Port
 	}
 	out := &tenant.ClusterInfo{
 		TenantID:       tenantID,
@@ -407,8 +405,8 @@ func (p *Provisioner) CreateBranchWithCredentials(ctx context.Context, forkTenan
 		DBName:    dbName,
 		Provider:  tenant.ProviderTiDBCloudNative,
 	}
-	if !branchConnectionIncomplete(branch) {
-		if err := fillBranchEndpoint(out, branch); err != nil {
+	if !branchConnectionIncomplete(branch, p.usePrivateEndpoint) {
+		if err := p.fillBranchEndpoint(out, branch); err != nil {
 			return out, err
 		}
 		return out, nil
@@ -444,7 +442,7 @@ func (p *Provisioner) WaitForBranchActiveWithCredentials(ctx context.Context, br
 	if err != nil {
 		return &out, fmt.Errorf("wait for branch active: %w", err)
 	}
-	if err := fillBranchEndpoint(&out, info); err != nil {
+	if err := p.fillBranchEndpoint(&out, info); err != nil {
 		return &out, err
 	}
 	return &out, nil
@@ -994,6 +992,10 @@ type branchInfo struct {
 			Host string `json:"host"`
 			Port int    `json:"port"`
 		} `json:"public"`
+		Private struct {
+			Host string `json:"host"`
+			Port int    `json:"port"`
+		} `json:"private"`
 	} `json:"endpoints"`
 	UserPrefix string `json:"userPrefix"`
 	Username   string `json:"username"`
@@ -1044,32 +1046,41 @@ func parseBranchInfo(raw []byte) (*branchInfo, error) {
 	return &out, nil
 }
 
-func clusterConnectionIncomplete(info *clusterInfo) bool {
+func clusterConnectionIncomplete(info *clusterInfo, usePrivate bool) bool {
 	if info == nil {
 		return true
 	}
-	if parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint) {
+	if usePrivate {
 		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || (info.UserPrefix == "" && info.Username == "")
 	}
 	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || (info.UserPrefix == "" && info.Username == "")
 }
 
-func clusterProvisionMetadataIncomplete(info *clusterInfo) bool {
-	if clusterConnectionIncomplete(info) {
+func clusterProvisionMetadataIncomplete(info *clusterInfo, usePrivate bool) bool {
+	if clusterConnectionIncomplete(info, usePrivate) {
 		return true
 	}
 	return strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]) == ""
 }
 
-func branchConnectionIncomplete(info *branchInfo) bool {
+func branchConnectionIncomplete(info *branchInfo, usePrivate bool) bool {
 	if info == nil {
 		return true
+	}
+	if usePrivate {
+		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || (info.UserPrefix == "" && info.Username == "")
 	}
 	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || (info.UserPrefix == "" && info.Username == "")
 }
 
-func fillBranchEndpoint(out *tenant.ClusterInfo, branch *branchInfo) error {
-	if branch.Endpoints.Public.Host == "" || branch.Endpoints.Public.Port == 0 {
+func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branchInfo) error {
+	host := branch.Endpoints.Public.Host
+	port := branch.Endpoints.Public.Port
+	if p.usePrivateEndpoint {
+		host = branch.Endpoints.Private.Host
+		port = branch.Endpoints.Private.Port
+	}
+	if host == "" || port == 0 {
 		return fmt.Errorf("tidbcloud native branch response missing endpoint")
 	}
 	if branch.Username != "" {
@@ -1080,8 +1091,8 @@ func fillBranchEndpoint(out *tenant.ClusterInfo, branch *branchInfo) error {
 	if out.Username == "" {
 		return fmt.Errorf("tidbcloud native branch response missing username")
 	}
-	out.Host = branch.Endpoints.Public.Host
-	out.Port = branch.Endpoints.Public.Port
+	out.Host = host
+	out.Port = port
 	return nil
 }
 
@@ -1109,7 +1120,7 @@ func (p *Provisioner) waitForClusterProvisionMetadata(ctx context.Context, publi
 		if err != nil {
 			return nil, err
 		}
-		if !clusterProvisionMetadataIncomplete(info) {
+		if !clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint) {
 			return info, nil
 		}
 		if time.Now().After(deadline) {
@@ -1147,7 +1158,7 @@ func (p *Provisioner) waitForBranchActive(ctx context.Context, publicKey, privat
 		if err != nil {
 			return nil, err
 		}
-		if info.State == stateActive && !branchConnectionIncomplete(info) {
+		if info.State == stateActive && !branchConnectionIncomplete(info, p.usePrivateEndpoint) {
 			return info, nil
 		}
 		if time.Now().After(deadline) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -300,7 +300,11 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 		out.Username = info.UserPrefix + ".root"
 	}
 	if out.Host == "" || out.Port == 0 {
-		return out, nil, fmt.Errorf("tidbcloud native response missing endpoint")
+		epKind := "public"
+		if p.usePrivateEndpoint {
+			epKind = "private"
+		}
+		return out, nil, fmt.Errorf("tidbcloud native response missing %s endpoint", epKind)
 	}
 	if out.Username == "" {
 		return out, nil, fmt.Errorf("tidbcloud native response missing username")
@@ -1087,7 +1091,11 @@ func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branch
 		port = branch.Endpoints.Public.Port
 	}
 	if host == "" || port == 0 {
-		return fmt.Errorf("tidbcloud native branch response missing endpoint")
+		epKind := "public"
+		if p.usePrivateEndpoint {
+			epKind = "private"
+		}
+		return fmt.Errorf("tidbcloud native branch response missing %s endpoint", epKind)
 	}
 	if branch.Username != "" {
 		out.Username = branch.Username

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -276,11 +276,14 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 			}, nil, err
 		}
 	}
-	host := info.Endpoints.Public.Host
-	port := info.Endpoints.Public.Port
+	var host string
+	var port int
 	if p.usePrivateEndpoint {
 		host = info.Endpoints.Private.Host
 		port = info.Endpoints.Private.Port
+	} else {
+		host = info.Endpoints.Public.Host
+		port = info.Endpoints.Public.Port
 	}
 	out := &tenant.ClusterInfo{
 		TenantID:       tenantID,
@@ -1074,11 +1077,14 @@ func branchConnectionIncomplete(info *branchInfo, usePrivate bool) bool {
 }
 
 func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branchInfo) error {
-	host := branch.Endpoints.Public.Host
-	port := branch.Endpoints.Public.Port
+	var host string
+	var port int
 	if p.usePrivateEndpoint {
 		host = branch.Endpoints.Private.Host
 		port = branch.Endpoints.Private.Port
+	} else {
+		host = branch.Endpoints.Public.Host
+		port = branch.Endpoints.Public.Port
 	}
 	if host == "" || port == 0 {
 		return fmt.Errorf("tidbcloud native branch response missing endpoint")

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -100,6 +100,12 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 	if _, err := normalizeDatabaseName(defaultDB); err != nil {
 		return nil, fmt.Errorf("invalid %s: %w", EnvTiDBCloudNativeDefaultDatabaseName, err)
 	}
+	usePrivate := parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint)
+	privateHost := strings.TrimSpace(os.Getenv(EnvTiDBCloudTencentPrivateEndpointHost))
+	if usePrivate && strings.EqualFold(cloudProvider, "tencentcloud") && privateHost == "" {
+		return nil, fmt.Errorf("%s is required when %s=true and cloud provider is tencentcloud",
+			EnvTiDBCloudTencentPrivateEndpointHost, EnvTiDBCloudNativeUsePrivateEndpoint)
+	}
 	return &Provisioner{
 		apiURL:              strings.TrimRight(apiURL, "/"),
 		cloudProvider:       cloudProvider,
@@ -108,8 +114,8 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 		defaultSpendLimit:   defaultSpendLimit,
 		defaultPublicKey:    strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePublicKey)),
 		defaultPrivateKey:   strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePrivateKey)),
-		usePrivateEndpoint:  parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint),
-		tencentPrivateEndpointHost: strings.TrimSpace(os.Getenv(EnvTiDBCloudTencentPrivateEndpointHost)),
+		usePrivateEndpoint:         usePrivate,
+		tencentPrivateEndpointHost: privateHost,
 		client:              &http.Client{Timeout: 60 * time.Second},
 	}, nil
 }

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -34,6 +34,7 @@ const (
 	EnvTiDBCloudDefaultSpendingLimit      = "DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT"
 	EnvTiDBCloudNativePublicKey           = "DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY"
 	EnvTiDBCloudNativePrivateKey          = "DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY"
+	EnvTiDBCloudNativeUsePrivateEndpoint  = "DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT"
 
 	DefaultDatabaseName = "tidbcloud_fs"
 	DefaultSpendLimit   = int32(1000)
@@ -71,6 +72,7 @@ type Provisioner struct {
 	defaultSpendLimit   *int32
 	defaultPublicKey    string
 	defaultPrivateKey   string
+	usePrivateEndpoint  bool
 	client              *http.Client
 }
 
@@ -104,6 +106,7 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 		defaultSpendLimit:   defaultSpendLimit,
 		defaultPublicKey:    strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePublicKey)),
 		defaultPrivateKey:   strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePrivateKey)),
+		usePrivateEndpoint:  parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint),
 		client:              &http.Client{Timeout: 60 * time.Second},
 	}, nil
 }
@@ -273,12 +276,20 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 			}, nil, err
 		}
 	}
+	host := info.Endpoints.Public.Host
+	port := info.Endpoints.Public.Port
+	if p.usePrivateEndpoint {
+		if info.Endpoints.Private.Host != "" {
+			host = info.Endpoints.Private.Host
+			port = info.Endpoints.Private.Port
+		}
+	}
 	out := &tenant.ClusterInfo{
 		TenantID:       tenantID,
 		ClusterID:      info.ClusterID,
 		OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
-		Host:           info.Endpoints.Public.Host,
-		Port:           info.Endpoints.Public.Port,
+		Host:           host,
+		Port:           port,
 		Username:       info.Username,
 		Password:       password,
 		DBName:         dbName,
@@ -814,6 +825,11 @@ func parseDefaultSpendLimit(raw string) (*int32, error) {
 	return &out, nil
 }
 
+func parseBoolEnv(name string) bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv(name)))
+	return v == "1" || v == "true" || v == "yes"
+}
+
 func normalizeDatabaseName(name string) (string, error) {
 	name = strings.TrimSpace(name)
 	if !databaseNamePattern.MatchString(name) {
@@ -961,6 +977,10 @@ type clusterInfo struct {
 			Host string `json:"host"`
 			Port int    `json:"port"`
 		} `json:"public"`
+		Private struct {
+			Host string `json:"host"`
+			Port int    `json:"port"`
+		} `json:"private"`
 	} `json:"endpoints"`
 	UserPrefix string `json:"userPrefix"`
 	Username   string `json:"username"`
@@ -1027,6 +1047,9 @@ func parseBranchInfo(raw []byte) (*branchInfo, error) {
 func clusterConnectionIncomplete(info *clusterInfo) bool {
 	if info == nil {
 		return true
+	}
+	if parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint) {
+		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || (info.UserPrefix == "" && info.Username == "")
 	}
 	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || (info.UserPrefix == "" && info.Username == "")
 }

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -299,13 +299,6 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 	if out.Username == "" && info.UserPrefix != "" {
 		out.Username = info.UserPrefix + ".root"
 	}
-	if out.Host == "" || out.Port == 0 {
-		epKind := "public"
-		if p.usePrivateEndpoint {
-			epKind = "private"
-		}
-		return out, nil, fmt.Errorf("tidbcloud native response missing %s endpoint", epKind)
-	}
 	if out.Username == "" {
 		return out, nil, fmt.Errorf("tidbcloud native response missing username")
 	}
@@ -1089,13 +1082,6 @@ func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branch
 	} else {
 		host = branch.Endpoints.Public.Host
 		port = branch.Endpoints.Public.Port
-	}
-	if host == "" || port == 0 {
-		epKind := "public"
-		if p.usePrivateEndpoint {
-			epKind = "private"
-		}
-		return fmt.Errorf("tidbcloud native branch response missing %s endpoint", epKind)
 	}
 	if branch.Username != "" {
 		out.Username = branch.Username

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -34,7 +34,8 @@ const (
 	EnvTiDBCloudDefaultSpendingLimit      = "DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT"
 	EnvTiDBCloudNativePublicKey           = "DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY"
 	EnvTiDBCloudNativePrivateKey          = "DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY"
-	EnvTiDBCloudNativeUsePrivateEndpoint  = "DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT"
+	EnvTiDBCloudNativeUsePrivateEndpoint          = "DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT"
+	EnvTiDBCloudTencentPrivateEndpointHost        = "DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST"
 
 	DefaultDatabaseName = "tidbcloud_fs"
 	DefaultSpendLimit   = int32(1000)
@@ -73,6 +74,7 @@ type Provisioner struct {
 	defaultPublicKey    string
 	defaultPrivateKey   string
 	usePrivateEndpoint  bool
+	tencentPrivateEndpointHost string
 	client              *http.Client
 }
 
@@ -107,6 +109,7 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 		defaultPublicKey:    strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePublicKey)),
 		defaultPrivateKey:   strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePrivateKey)),
 		usePrivateEndpoint:  parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint),
+		tencentPrivateEndpointHost: strings.TrimSpace(os.Getenv(EnvTiDBCloudTencentPrivateEndpointHost)),
 		client:              &http.Client{Timeout: 60 * time.Second},
 	}, nil
 }
@@ -264,7 +267,7 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 	if info.ClusterID == "" {
 		return nil, nil, fmt.Errorf("tidbcloud native response missing cluster id")
 	}
-	if clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint) {
+	if clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
 		info, err = p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, info.ClusterID)
 		if err != nil {
 			return &tenant.ClusterInfo{
@@ -281,6 +284,9 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 	if p.usePrivateEndpoint {
 		host = info.Endpoints.Private.Host
 		port = info.Endpoints.Private.Port
+		if host == "" && p.tencentPrivateEndpointHost != "" {
+			host = p.tencentPrivateEndpointHost
+		}
 	} else {
 		host = info.Endpoints.Public.Host
 		port = info.Endpoints.Public.Port
@@ -401,7 +407,7 @@ func (p *Provisioner) CreateBranchWithCredentials(ctx context.Context, forkTenan
 		DBName:    dbName,
 		Provider:  tenant.ProviderTiDBCloudNative,
 	}
-	if !branchConnectionIncomplete(branch, p.usePrivateEndpoint) {
+	if !branchConnectionIncomplete(branch, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
 		if err := p.fillBranchEndpoint(out, branch); err != nil {
 			return out, err
 		}
@@ -1040,28 +1046,34 @@ func parseBranchInfo(raw []byte) (*branchInfo, error) {
 	return &out, nil
 }
 
-func clusterConnectionIncomplete(info *clusterInfo, usePrivate bool) bool {
+func clusterConnectionIncomplete(info *clusterInfo, usePrivate bool, overridePrivateHost string) bool {
 	if info == nil {
 		return true
 	}
 	if usePrivate {
+		if overridePrivateHost != "" {
+			return info.Endpoints.Private.Port == 0 || info.UserPrefix == ""
+		}
 		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || info.UserPrefix == ""
 	}
 	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
 }
 
-func clusterProvisionMetadataIncomplete(info *clusterInfo, usePrivate bool) bool {
-	if clusterConnectionIncomplete(info, usePrivate) {
+func clusterProvisionMetadataIncomplete(info *clusterInfo, usePrivate bool, overridePrivateHost string) bool {
+	if clusterConnectionIncomplete(info, usePrivate, overridePrivateHost) {
 		return true
 	}
 	return strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]) == ""
 }
 
-func branchConnectionIncomplete(info *branchInfo, usePrivate bool) bool {
+func branchConnectionIncomplete(info *branchInfo, usePrivate bool, overridePrivateHost string) bool {
 	if info == nil {
 		return true
 	}
 	if usePrivate {
+		if overridePrivateHost != "" {
+			return info.Endpoints.Private.Port == 0 || info.UserPrefix == ""
+		}
 		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || info.UserPrefix == ""
 	}
 	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
@@ -1073,6 +1085,9 @@ func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branch
 	if p.usePrivateEndpoint {
 		host = branch.Endpoints.Private.Host
 		port = branch.Endpoints.Private.Port
+		if host == "" && p.tencentPrivateEndpointHost != "" {
+			host = p.tencentPrivateEndpointHost
+		}
 	} else {
 		host = branch.Endpoints.Public.Host
 		port = branch.Endpoints.Public.Port
@@ -1109,7 +1124,7 @@ func (p *Provisioner) waitForClusterProvisionMetadata(ctx context.Context, publi
 		if err != nil {
 			return nil, err
 		}
-		if !clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint) {
+		if !clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
 			return info, nil
 		}
 		if time.Now().After(deadline) {
@@ -1147,7 +1162,7 @@ func (p *Provisioner) waitForBranchActive(ctx context.Context, publicKey, privat
 		if err != nil {
 			return nil, err
 		}
-		if info.State == stateActive && !branchConnectionIncomplete(info, p.usePrivateEndpoint) {
+		if info.State == stateActive && !branchConnectionIncomplete(info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
 			return info, nil
 		}
 		if time.Now().After(deadline) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -100,7 +100,10 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 	if _, err := normalizeDatabaseName(defaultDB); err != nil {
 		return nil, fmt.Errorf("invalid %s: %w", EnvTiDBCloudNativeDefaultDatabaseName, err)
 	}
-	usePrivate := parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint)
+	usePrivate, err := parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint)
+	if err != nil {
+		return nil, err
+	}
 	privateHost := strings.TrimSpace(os.Getenv(EnvTiDBCloudTencentPrivateEndpointHost))
 	if usePrivate && strings.EqualFold(cloudProvider, "tencentcloud") && privateHost == "" {
 		return nil, fmt.Errorf("%s is required when %s=true and cloud provider is tencentcloud",
@@ -274,11 +277,12 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 		return nil, nil, fmt.Errorf("tidbcloud native response missing cluster id")
 	}
 	if clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
-		info, err = p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, info.ClusterID)
+		clusterID := info.ClusterID
+		info, err = p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, clusterID)
 		if err != nil {
 			return &tenant.ClusterInfo{
 				TenantID:  tenantID,
-				ClusterID: info.ClusterID,
+				ClusterID: clusterID,
 				Password:  password,
 				DBName:    dbName,
 				Provider:  tenant.ProviderTiDBCloudNative,
@@ -831,9 +835,18 @@ func parseDefaultSpendLimit(raw string) (*int32, error) {
 	return &out, nil
 }
 
-func parseBoolEnv(name string) bool {
+func parseBoolEnv(name string) (bool, error) {
 	v := strings.TrimSpace(strings.ToLower(os.Getenv(name)))
-	return v == "1" || v == "true" || v == "yes"
+	if v == "" {
+		return false, nil
+	}
+	switch v {
+	case "1", "true", "yes":
+		return true, nil
+	case "0", "false", "no":
+		return false, nil
+	}
+	return false, fmt.Errorf("%s must be 1/true/yes or 0/false/no, got %q", name, os.Getenv(name))
 }
 
 func normalizeDatabaseName(name string) (string, error) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -291,16 +291,12 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 		OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
 		Host:           host,
 		Port:           port,
-		Username:       info.Username,
 		Password:       password,
 		DBName:         dbName,
 		Provider:       tenant.ProviderTiDBCloudNative,
 	}
-	if out.Username == "" && info.UserPrefix != "" {
+	if info.UserPrefix != "" {
 		out.Username = info.UserPrefix + ".root"
-	}
-	if out.Username == "" {
-		return out, nil, fmt.Errorf("tidbcloud native response missing username")
 	}
 	cloudCfg := &tenant.QuotaCloudConfig{
 		Labels: map[string]string{
@@ -981,9 +977,7 @@ type clusterInfo struct {
 		} `json:"private"`
 	} `json:"endpoints"`
 	UserPrefix string `json:"userPrefix"`
-	Username   string `json:"username"`
 }
-
 type branchInfo struct {
 	BranchID  string `json:"branchId"`
 	State     string `json:"state"`
@@ -1051,9 +1045,9 @@ func clusterConnectionIncomplete(info *clusterInfo, usePrivate bool) bool {
 		return true
 	}
 	if usePrivate {
-		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || (info.UserPrefix == "" && info.Username == "")
+		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || info.UserPrefix == ""
 	}
-	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || (info.UserPrefix == "" && info.Username == "")
+	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
 }
 
 func clusterProvisionMetadataIncomplete(info *clusterInfo, usePrivate bool) bool {
@@ -1068,9 +1062,9 @@ func branchConnectionIncomplete(info *branchInfo, usePrivate bool) bool {
 		return true
 	}
 	if usePrivate {
-		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || (info.UserPrefix == "" && info.Username == "")
+		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || info.UserPrefix == ""
 	}
-	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || (info.UserPrefix == "" && info.Username == "")
+	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
 }
 
 func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branchInfo) error {
@@ -1083,13 +1077,8 @@ func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branch
 		host = branch.Endpoints.Public.Host
 		port = branch.Endpoints.Public.Port
 	}
-	if branch.Username != "" {
-		out.Username = branch.Username
-	} else if branch.UserPrefix != "" {
+	if branch.UserPrefix != "" {
 		out.Username = branch.UserPrefix + ".root"
-	}
-	if out.Username == "" {
-		return fmt.Errorf("tidbcloud native branch response missing username")
 	}
 	out.Host = host
 	out.Port = port
@@ -1200,9 +1189,6 @@ func (p *Provisioner) WaitForBranchUserWithCredentials(ctx context.Context, clus
 		info, err := parseBranchInfo(raw)
 		if err != nil {
 			return "", err
-		}
-		if info.Username != "" {
-			return info.Username, nil
 		}
 		if info.UserPrefix != "" {
 			return info.UserPrefix + ".root", nil

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -27,15 +27,15 @@ import (
 )
 
 const (
-	EnvTiDBCloudNativeAPIURL              = "DRIVE9_TIDBCLOUD_NATIVE_API_URL"
-	EnvTiDBCloudNativeCloudProvider       = "DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER"
-	EnvTiDBCloudNativeRegion              = "DRIVE9_TIDBCLOUD_NATIVE_REGION"
-	EnvTiDBCloudNativeDefaultDatabaseName = "DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME"
-	EnvTiDBCloudDefaultSpendingLimit      = "DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT"
-	EnvTiDBCloudNativePublicKey           = "DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY"
-	EnvTiDBCloudNativePrivateKey          = "DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY"
-	EnvTiDBCloudNativeUsePrivateEndpoint          = "DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT"
-	EnvTiDBCloudTencentPrivateEndpointHost        = "DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST"
+	EnvTiDBCloudNativeAPIURL               = "DRIVE9_TIDBCLOUD_NATIVE_API_URL"
+	EnvTiDBCloudNativeCloudProvider        = "DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER"
+	EnvTiDBCloudNativeRegion               = "DRIVE9_TIDBCLOUD_NATIVE_REGION"
+	EnvTiDBCloudNativeDefaultDatabaseName  = "DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME"
+	EnvTiDBCloudDefaultSpendingLimit       = "DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT"
+	EnvTiDBCloudNativePublicKey            = "DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY"
+	EnvTiDBCloudNativePrivateKey           = "DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY"
+	EnvTiDBCloudNativeUsePrivateEndpoint   = "DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT"
+	EnvTiDBCloudTencentPrivateEndpointHost = "DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST"
 
 	DefaultDatabaseName = "tidbcloud_fs"
 	DefaultSpendLimit   = int32(1000)
@@ -66,16 +66,16 @@ var (
 )
 
 type Provisioner struct {
-	apiURL              string
-	cloudProvider       string
-	region              string
-	defaultDatabaseName string
-	defaultSpendLimit   *int32
-	defaultPublicKey    string
-	defaultPrivateKey   string
-	usePrivateEndpoint  bool
+	apiURL                     string
+	cloudProvider              string
+	region                     string
+	defaultDatabaseName        string
+	defaultSpendLimit          *int32
+	defaultPublicKey           string
+	defaultPrivateKey          string
+	usePrivateEndpoint         bool
 	tencentPrivateEndpointHost string
-	client              *http.Client
+	client                     *http.Client
 }
 
 func NewProvisionerFromEnv() (*Provisioner, error) {
@@ -110,16 +110,16 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 			EnvTiDBCloudTencentPrivateEndpointHost, EnvTiDBCloudNativeUsePrivateEndpoint)
 	}
 	return &Provisioner{
-		apiURL:              strings.TrimRight(apiURL, "/"),
-		cloudProvider:       cloudProvider,
-		region:              region,
-		defaultDatabaseName: defaultDB,
-		defaultSpendLimit:   defaultSpendLimit,
-		defaultPublicKey:    strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePublicKey)),
-		defaultPrivateKey:   strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePrivateKey)),
+		apiURL:                     strings.TrimRight(apiURL, "/"),
+		cloudProvider:              cloudProvider,
+		region:                     region,
+		defaultDatabaseName:        defaultDB,
+		defaultSpendLimit:          defaultSpendLimit,
+		defaultPublicKey:           strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePublicKey)),
+		defaultPrivateKey:          strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePrivateKey)),
 		usePrivateEndpoint:         usePrivate,
 		tencentPrivateEndpointHost: privateHost,
-		client:              &http.Client{Timeout: 60 * time.Second},
+		client:                     &http.Client{Timeout: 60 * time.Second},
 	}, nil
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1276,6 +1276,20 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointFlag(t *testing.T) {
 	}
 }
 
+func TestNewProvisionerFromEnvRejectsMalformedPrivateEndpointFlag(t *testing.T) {
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+
+	for _, v := range []string{"on", "Y", "ture", "enabled", "2", "enable"} {
+		t.Setenv(EnvTiDBCloudNativeUsePrivateEndpoint, v)
+		_, err := NewProvisionerFromEnv()
+		if err == nil {
+			t.Fatalf("expected error for %q, got nil", v)
+		}
+	}
+}
+
 func TestClusterConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	info := &clusterInfo{
 		ClusterID:  "cluster-1",

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1202,7 +1202,7 @@ func TestWaitForBranchUserWithCredentialsPollsUserPrefix(t *testing.T) {
 	}
 }
 
-func TestWaitForBranchUserWithCredentialsPrefersUsername(t *testing.T) {
+func TestWaitForBranchUserWithCredentialsUsesUserPrefix(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {
 			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
@@ -1210,9 +1210,9 @@ func TestWaitForBranchUserWithCredentialsPrefersUsername(t *testing.T) {
 			return
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"branchId": "branch-1",
-			"state":    "ACTIVE",
-			"username": "direct-user",
+			"branchId":   "branch-1",
+			"state":      "ACTIVE",
+			"userPrefix": "u2",
 			"endpoints": map[string]any{
 				"public": map[string]any{"host": "branch.example", "port": 4000},
 			},
@@ -1229,8 +1229,8 @@ func TestWaitForBranchUserWithCredentialsPrefersUsername(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WaitForBranchUserWithCredentials: %v", err)
 	}
-	if username != "direct-user" {
-		t.Fatalf("username = %q, want direct-user", username)
+	if username != "u2.root" {
+		t.Fatalf("username = %q, want u2.root", username)
 	}
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1323,7 +1323,7 @@ func TestProvisionWithCredentialsUsesPrivateEndpoint(t *testing.T) {
 			"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1"},
 			"endpoints": map[string]any{
 				"public":  map[string]any{"host": "public.example", "port": 4000},
-				"private": map[string]any{"host": "private.internal", "port": 4000},
+				"private": map[string]any{"host": "private.internal", "port": 4001},
 			},
 		})
 	}))
@@ -1344,8 +1344,8 @@ func TestProvisionWithCredentialsUsesPrivateEndpoint(t *testing.T) {
 	if res.Host != "private.internal" {
 		t.Fatalf("Host = %q, want private.internal", res.Host)
 	}
-	if res.Port != 4000 {
-		t.Fatalf("Port = %d, want 4000", res.Port)
+	if res.Port != 4001 {
+		t.Fatalf("Port = %d, want 4001", res.Port)
 	}
 }
 
@@ -1364,5 +1364,31 @@ func TestBranchConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	}
 	if !branchConnectionIncomplete(branch, true) {
 		t.Fatalf("private mode should report incomplete when private host is empty")
+	}
+}
+
+func TestFillBranchEndpointUsesPrivateEndpoint(t *testing.T) {
+	branch := &branchInfo{
+		BranchID:   "branch-1",
+		UserPrefix: "u1",
+	}
+	branch.Endpoints.Public.Host = "public.example"
+	branch.Endpoints.Public.Port = 4000
+	branch.Endpoints.Private.Host = "private.internal"
+	branch.Endpoints.Private.Port = 4001
+
+	p := &Provisioner{usePrivateEndpoint: true}
+	out := &tenant.ClusterInfo{}
+	if err := p.fillBranchEndpoint(out, branch); err != nil {
+		t.Fatalf("fillBranchEndpoint: %v", err)
+	}
+	if out.Host != "private.internal" {
+		t.Fatalf("Host = %q, want private.internal", out.Host)
+	}
+	if out.Port != 4001 {
+		t.Fatalf("Port = %d, want 4001", out.Port)
+	}
+	if out.Username != "u1.root" {
+		t.Fatalf("Username = %q, want u1.root", out.Username)
 	}
 }

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1233,3 +1233,136 @@ func TestWaitForBranchUserWithCredentialsPrefersUsername(t *testing.T) {
 		t.Fatalf("username = %q, want direct-user", username)
 	}
 }
+
+func TestNewProvisionerFromEnvReadsPrivateEndpointFlag(t *testing.T) {
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+
+	defaultUse := false
+	p, err := NewProvisionerFromEnv()
+	if err != nil {
+		t.Fatalf("NewProvisionerFromEnv: %v", err)
+	}
+	if p.usePrivateEndpoint != defaultUse {
+		t.Fatalf("usePrivateEndpoint = %v, want %v (default)", p.usePrivateEndpoint, defaultUse)
+	}
+
+	t.Setenv(EnvTiDBCloudNativeUsePrivateEndpoint, "true")
+	p, err = NewProvisionerFromEnv()
+	if err != nil {
+		t.Fatalf("NewProvisionerFromEnv with true: %v", err)
+	}
+	if !p.usePrivateEndpoint {
+		t.Fatalf("usePrivateEndpoint = %v, want true", p.usePrivateEndpoint)
+	}
+
+	t.Setenv(EnvTiDBCloudNativeUsePrivateEndpoint, "1")
+	p, err = NewProvisionerFromEnv()
+	if err != nil {
+		t.Fatalf("NewProvisionerFromEnv with 1: %v", err)
+	}
+	if !p.usePrivateEndpoint {
+		t.Fatalf("usePrivateEndpoint = %v, want true", p.usePrivateEndpoint)
+	}
+
+	t.Setenv(EnvTiDBCloudNativeUsePrivateEndpoint, "no")
+	p, err = NewProvisionerFromEnv()
+	if err != nil {
+		t.Fatalf("NewProvisionerFromEnv with no: %v", err)
+	}
+	if p.usePrivateEndpoint {
+		t.Fatalf("usePrivateEndpoint = %v, want false", p.usePrivateEndpoint)
+	}
+}
+
+func TestClusterConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
+	info := &clusterInfo{
+		ClusterID:  "cluster-1",
+		UserPrefix: "u1",
+	}
+	info.Endpoints.Public.Host = "public.example"
+	info.Endpoints.Public.Port = 4000
+	info.Endpoints.Private.Host = ""
+	info.Endpoints.Private.Port = 4000
+
+	if clusterConnectionIncomplete(info, false) {
+		t.Fatalf("public mode should report complete")
+	}
+	if !clusterConnectionIncomplete(info, true) {
+		t.Fatalf("private mode should report incomplete when private host is empty")
+	}
+}
+
+func TestProvisionWithCredentialsUsesPrivateEndpoint(t *testing.T) {
+	var pollCount int
+	origEnsureDatabase := ensureDatabaseFunc
+	ensureDatabaseFunc = func(context.Context, string, string, string, int, string) error {
+		return nil
+	}
+	t.Cleanup(func() { ensureDatabaseFunc = origEnsureDatabase })
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		pollCount++
+		if r.URL.Path != "/v1beta1/clusters" && pollCount == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusterId": "cluster-1",
+				"state":     "CREATING",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"clusterId":  "cluster-1",
+			"state":      "ACTIVE",
+			"userPrefix": "u1",
+			"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1"},
+			"endpoints": map[string]any{
+				"public":  map[string]any{"host": "public.example", "port": 4000},
+				"private": map[string]any{"host": "private.internal", "port": 4000},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		defaultDatabaseName: DefaultDatabaseName,
+		usePrivateEndpoint:  true,
+		client:              ts.Client(),
+	}
+	res, _, err := p.ProvisionWithCredentialsAndQuota(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
+		PublicKey: "public-1", PrivateKey: "private-1",
+	}, tenant.QuotaUpdateOptions{})
+	if err != nil {
+		t.Fatalf("ProvisionWithCredentialsAndQuota: %v", err)
+	}
+	if res.Host != "private.internal" {
+		t.Fatalf("Host = %q, want private.internal", res.Host)
+	}
+	if res.Port != 4000 {
+		t.Fatalf("Port = %d, want 4000", res.Port)
+	}
+}
+
+func TestBranchConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
+	branch := &branchInfo{
+		BranchID:   "branch-1",
+		UserPrefix: "u1",
+	}
+	branch.Endpoints.Public.Host = "public.example"
+	branch.Endpoints.Public.Port = 4000
+	branch.Endpoints.Private.Host = ""
+	branch.Endpoints.Private.Port = 4000
+
+	if branchConnectionIncomplete(branch, false) {
+		t.Fatalf("public mode should report complete")
+	}
+	if !branchConnectionIncomplete(branch, true) {
+		t.Fatalf("private mode should report incomplete when private host is empty")
+	}
+}

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1286,11 +1286,15 @@ func TestClusterConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	info.Endpoints.Private.Host = ""
 	info.Endpoints.Private.Port = 4000
 
-	if clusterConnectionIncomplete(info, false) {
+	if clusterConnectionIncomplete(info, false, "") {
 		t.Fatalf("public mode should report complete")
 	}
-	if !clusterConnectionIncomplete(info, true) {
+	if !clusterConnectionIncomplete(info, true, "") {
 		t.Fatalf("private mode should report incomplete when private host is empty")
+	}
+	// With tencent override host set, API private host empty is OK
+	if clusterConnectionIncomplete(info, true, "tencent.internal") {
+		t.Fatalf("private mode with override host should report complete even if API private host is empty")
 	}
 }
 
@@ -1359,10 +1363,10 @@ func TestBranchConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	branch.Endpoints.Private.Host = ""
 	branch.Endpoints.Private.Port = 4000
 
-	if branchConnectionIncomplete(branch, false) {
+	if branchConnectionIncomplete(branch, false, "") {
 		t.Fatalf("public mode should report complete")
 	}
-	if !branchConnectionIncomplete(branch, true) {
+	if !branchConnectionIncomplete(branch, true, "") {
 		t.Fatalf("private mode should report incomplete when private host is empty")
 	}
 }


### PR DESCRIPTION
## Summary

Add support for using TiDB Cloud private endpoints instead of public endpoints when provisioning native tenants.

## Usage

Set `DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT=true` to use private endpoints.

## Changes

- Parse `endpoints.private.host` and `endpoints.private.port` from TiDB Cloud API response
- `Provisioner.usePrivateEndpoint` field driven by env var
- `clusterConnectionIncomplete` checks only the relevant endpoint type
- Existing tenants unaffected — endpoint is stored in tenant record at create time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for provisioning TiDB Cloud tenants and branches using either public or private connectivity, controlled by an environment flag for private endpoint mode.
  * Endpoint selection and readiness gating now follow the chosen connectivity type.

* **Bug Fixes**
  * Connection details (host/port) are now filled from the correct public vs. private endpoint.
  * Tenant/branch username resolution now consistently derives from the prefix-based naming.

* **Tests**
  * Added coverage for the private endpoint flag parsing and private-vs-public completeness and endpoint filling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->