### PR TITLE
Fix FUSE mount startup cleanup and diagnostics

### DIFF
--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -470,14 +470,26 @@ func Mount(opts *MountOptions) error {
 	// thread consumes the last GOMAXPROCS slot, leaving no thread to handle
 	// the POLL request from the kernel).
 	if err := server.WaitMount(); err != nil {
-		stopWatchers()
+		cleanupMountStartFailure(mountStartCleanup{
+			reason:       "fuse wait mount failure",
+			mountPoint:   opts.MountPoint,
+			stopWatchers: stopWatchers,
+			flushAll:     dat9fs.FlushAll,
+			unmount:      server.Unmount,
+			forceUnmount: forceUnmount,
+		})
 		return fmt.Errorf("fuse wait mount: %w", err)
 	}
 	controlServer, err := startMountControlServer(opts.MountPoint, dat9fs)
 	if err != nil {
-		stopWatchers()
-		dat9fs.FlushAll()
-		_ = server.Unmount()
+		cleanupMountStartFailure(mountStartCleanup{
+			reason:       "mount control socket failure",
+			mountPoint:   opts.MountPoint,
+			stopWatchers: stopWatchers,
+			flushAll:     dat9fs.FlushAll,
+			unmount:      server.Unmount,
+			forceUnmount: forceUnmount,
+		})
 		return fmt.Errorf("start mount control socket: %w", err)
 	}
 	if controlServer != nil {
@@ -519,9 +531,17 @@ func Mount(opts *MountOptions) error {
 		ControlSocket:       controlServer.SocketPath(),
 	})
 	if err != nil {
-		stopWatchers()
-		dat9fs.FlushAll()
-		_ = server.Unmount()
+		if controlServer != nil {
+			controlServer.Close()
+		}
+		cleanupMountStartFailure(mountStartCleanup{
+			reason:       "mount process state failure",
+			mountPoint:   opts.MountPoint,
+			stopWatchers: stopWatchers,
+			flushAll:     dat9fs.FlushAll,
+			unmount:      server.Unmount,
+			forceUnmount: forceUnmount,
+		})
 		return fmt.Errorf("write mount pid file: %w", err)
 	}
 	defer func() {
@@ -653,6 +673,37 @@ func Mount(opts *MountOptions) error {
 	server.Wait()
 	shutdown()
 	return nil
+}
+
+type mountStartCleanup struct {
+	reason       string
+	mountPoint   string
+	stopWatchers func()
+	flushAll     func()
+	unmount      func() error
+	forceUnmount func(string)
+}
+
+func cleanupMountStartFailure(cleanup mountStartCleanup) {
+	if cleanup.stopWatchers != nil {
+		cleanup.stopWatchers()
+	}
+	if cleanup.flushAll != nil {
+		cleanup.flushAll()
+	}
+	if cleanup.unmount == nil {
+		return
+	}
+	if err := cleanup.unmount(); err != nil {
+		reason := strings.TrimSpace(cleanup.reason)
+		if reason == "" {
+			reason = "mount start failure"
+		}
+		fmt.Fprintf(os.Stderr, "drive9: cleanup after %s: unmount failed: %v\n", reason, err)
+		if cleanup.forceUnmount != nil && strings.TrimSpace(cleanup.mountPoint) != "" {
+			cleanup.forceUnmount(cleanup.mountPoint)
+		}
+	}
 }
 
 func validateMountOptionsProfile(opts *MountOptions) error {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -446,6 +446,19 @@ func Mount(opts *MountOptions) error {
 	server, err := gofuse.NewServer(dat9fs, opts.MountPoint, fuseOpts)
 	if err != nil {
 		layerEventWatcherStop()
+		cleanupMountStartFailure(mountStartCleanup{
+			reason:     "fuse server initialization failure",
+			mountPoint: opts.MountPoint,
+			cause:      err,
+		})
+		if shouldForceUnmountAfterNewServerError(err) {
+			mountPoint := strings.TrimSpace(opts.MountPoint)
+			if mountPoint == "" {
+				mountPoint = "<unknown>"
+			}
+			fmt.Fprintf(os.Stderr, "drive9: cleanup after fuse server initialization failure: forcing unmount of %s after partial init failure\n", mountPoint)
+			forceUnmount(opts.MountPoint)
+		}
 		return fmt.Errorf("fuse mount: %w", err)
 	}
 
@@ -473,6 +486,7 @@ func Mount(opts *MountOptions) error {
 		cleanupMountStartFailure(mountStartCleanup{
 			reason:       "fuse wait mount failure",
 			mountPoint:   opts.MountPoint,
+			cause:        err,
 			stopWatchers: stopWatchers,
 			flushAll:     dat9fs.FlushAll,
 			unmount:      server.Unmount,
@@ -485,6 +499,7 @@ func Mount(opts *MountOptions) error {
 		cleanupMountStartFailure(mountStartCleanup{
 			reason:       "mount control socket failure",
 			mountPoint:   opts.MountPoint,
+			cause:        err,
 			stopWatchers: stopWatchers,
 			flushAll:     dat9fs.FlushAll,
 			unmount:      server.Unmount,
@@ -537,6 +552,7 @@ func Mount(opts *MountOptions) error {
 		cleanupMountStartFailure(mountStartCleanup{
 			reason:       "mount process state failure",
 			mountPoint:   opts.MountPoint,
+			cause:        err,
 			stopWatchers: stopWatchers,
 			flushAll:     dat9fs.FlushAll,
 			unmount:      server.Unmount,
@@ -678,13 +694,35 @@ func Mount(opts *MountOptions) error {
 type mountStartCleanup struct {
 	reason       string
 	mountPoint   string
+	cause        error
 	stopWatchers func()
 	flushAll     func()
 	unmount      func() error
 	forceUnmount func(string)
+	logf         func(string, ...any)
 }
 
 func cleanupMountStartFailure(cleanup mountStartCleanup) {
+	reason := strings.TrimSpace(cleanup.reason)
+	if reason == "" {
+		reason = "mount start failure"
+	}
+	mountPoint := strings.TrimSpace(cleanup.mountPoint)
+	mountPointLabel := mountPoint
+	if mountPointLabel == "" {
+		mountPointLabel = "<unknown>"
+	}
+	logf := cleanup.logf
+	if logf == nil {
+		logf = func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, format, args...)
+		}
+	}
+	if cleanup.cause != nil {
+		logf("drive9: mount startup failed during %s at %s: %v\n", reason, mountPointLabel, cleanup.cause)
+	} else {
+		logf("drive9: mount startup failed during %s at %s\n", reason, mountPointLabel)
+	}
 	if cleanup.stopWatchers != nil {
 		cleanup.stopWatchers()
 	}
@@ -695,15 +733,21 @@ func cleanupMountStartFailure(cleanup mountStartCleanup) {
 		return
 	}
 	if err := cleanup.unmount(); err != nil {
-		reason := strings.TrimSpace(cleanup.reason)
-		if reason == "" {
-			reason = "mount start failure"
+		logf("drive9: cleanup after %s: unmount failed: %v\n", reason, err)
+		if cleanup.forceUnmount != nil && mountPoint != "" {
+			cleanup.forceUnmount(mountPoint)
 		}
-		fmt.Fprintf(os.Stderr, "drive9: cleanup after %s: unmount failed: %v\n", reason, err)
-		if cleanup.forceUnmount != nil && strings.TrimSpace(cleanup.mountPoint) != "" {
-			cleanup.forceUnmount(cleanup.mountPoint)
-		}
+		return
 	}
+	if mountPoint != "" {
+		logf("drive9: cleanup after %s: unmounted %s\n", reason, mountPoint)
+	} else {
+		logf("drive9: cleanup after %s: unmounted mountpoint\n", reason)
+	}
+}
+
+func shouldForceUnmountAfterNewServerError(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "init:")
 }
 
 func validateMountOptionsProfile(opts *MountOptions) error {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -445,20 +445,7 @@ func Mount(opts *MountOptions) error {
 	// Create FUSE server
 	server, err := gofuse.NewServer(dat9fs, opts.MountPoint, fuseOpts)
 	if err != nil {
-		layerEventWatcherStop()
-		cleanupMountStartFailure(mountStartCleanup{
-			reason:     "fuse server initialization failure",
-			mountPoint: opts.MountPoint,
-			cause:      err,
-		})
-		if shouldForceUnmountAfterNewServerError(err) {
-			mountPoint := strings.TrimSpace(opts.MountPoint)
-			if mountPoint == "" {
-				mountPoint = "<unknown>"
-			}
-			fmt.Fprintf(os.Stderr, "drive9: cleanup after fuse server initialization failure: forcing unmount of %s after partial init failure\n", mountPoint)
-			forceUnmount(opts.MountPoint)
-		}
+		cleanupNewServerFailure(opts.MountPoint, err, layerEventWatcherStop, dat9fs.FlushAll, forceUnmount, nil)
 		return fmt.Errorf("fuse mount: %w", err)
 	}
 
@@ -483,6 +470,8 @@ func Mount(opts *MountOptions) error {
 	// thread consumes the last GOMAXPROCS slot, leaving no thread to handle
 	// the POLL request from the kernel).
 	if err := server.WaitMount(); err != nil {
+		// NewServer succeeded and Serve is running, so cleanup can drain Drive9-side
+		// workers before asking go-fuse to detach any partially mounted kernel state.
 		cleanupMountStartFailure(mountStartCleanup{
 			reason:       "fuse wait mount failure",
 			mountPoint:   opts.MountPoint,
@@ -699,7 +688,10 @@ type mountStartCleanup struct {
 	flushAll     func()
 	unmount      func() error
 	forceUnmount func(string)
-	logf         func(string, ...any)
+	// forceUnmountWithoutServer is for the go-fuse NewServer post-mount/pre-server
+	// INIT failure path, where no Server exists to call Unmount on.
+	forceUnmountWithoutServer bool
+	logf                      func(string, ...any)
 }
 
 func cleanupMountStartFailure(cleanup mountStartCleanup) {
@@ -730,6 +722,10 @@ func cleanupMountStartFailure(cleanup mountStartCleanup) {
 		cleanup.flushAll()
 	}
 	if cleanup.unmount == nil {
+		if cleanup.forceUnmountWithoutServer && cleanup.forceUnmount != nil && mountPoint != "" {
+			logf("drive9: cleanup after %s: forcing unmount of %s after partial init failure\n", reason, mountPoint)
+			cleanup.forceUnmount(mountPoint)
+		}
 		return
 	}
 	if err := cleanup.unmount(); err != nil {
@@ -746,6 +742,32 @@ func cleanupMountStartFailure(cleanup mountStartCleanup) {
 	}
 }
 
+func cleanupNewServerFailure(
+	mountPoint string,
+	cause error,
+	stopWatchers func(),
+	flushAll func(),
+	forceUnmount func(string),
+	logf func(string, ...any),
+) {
+	cleanupMountStartFailure(mountStartCleanup{
+		reason:                    "fuse server initialization failure",
+		mountPoint:                mountPoint,
+		cause:                     cause,
+		stopWatchers:              stopWatchers,
+		flushAll:                  flushAll,
+		forceUnmount:              forceUnmount,
+		forceUnmountWithoutServer: shouldForceUnmountAfterNewServerError(cause),
+		logf:                      logf,
+	})
+}
+
+// shouldForceUnmountAfterNewServerError targets go-fuse's post-mount INIT
+// failure. In github.com/mornyx/go-fuse/v2, NewServer calls mount(), then
+// handleInit(), and returns fmt.Errorf("init: %s", code) if INIT fails after
+// closing the mount fd. That path has no Server handle for Unmount, so Drive9
+// must detach the mountpoint itself. Re-check this predicate when go-fuse is
+// upgraded or replaced.
 func shouldForceUnmountAfterNewServerError(err error) bool {
 	return err != nil && strings.HasPrefix(err.Error(), "init:")
 }

--- a/pkg/fuse/mount_shutdown_test.go
+++ b/pkg/fuse/mount_shutdown_test.go
@@ -110,6 +110,92 @@ func TestCleanupMountStartFailureForceUnmountsWhenServerUnmountFails(t *testing.
 	}
 }
 
+func TestCleanupNewServerFailureStopsFlushesAndForceUnmountsInitFailure(t *testing.T) {
+	var calls []string
+	var logs strings.Builder
+
+	cleanupNewServerFailure(
+		"/mnt/drive9",
+		errors.New("init: ENODEV"),
+		func() {
+			calls = append(calls, "stop")
+		},
+		func() {
+			calls = append(calls, "flush")
+		},
+		func(mountPoint string) {
+			calls = append(calls, "force:"+mountPoint)
+		},
+		func(format string, args ...any) {
+			logs.WriteString(fmt.Sprintf(format, args...))
+		},
+	)
+
+	want := []string{"stop", "flush", "force:/mnt/drive9"}
+	if len(calls) != len(want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("calls = %v, want %v", calls, want)
+		}
+	}
+	gotLogs := logs.String()
+	for _, wantLog := range []string{
+		"drive9: mount startup failed during fuse server initialization failure at /mnt/drive9: init: ENODEV",
+		"drive9: cleanup after fuse server initialization failure: forcing unmount of /mnt/drive9 after partial init failure",
+	} {
+		if !strings.Contains(gotLogs, wantLog) {
+			t.Fatalf("logs = %q, want substring %q", gotLogs, wantLog)
+		}
+	}
+}
+
+func TestCleanupNewServerFailureDoesNotForceUnmountNonInitFailure(t *testing.T) {
+	var calls []string
+
+	cleanupNewServerFailure(
+		"/mnt/drive9",
+		errors.New("fusermount: mountpoint is busy"),
+		func() {
+			calls = append(calls, "stop")
+		},
+		func() {
+			calls = append(calls, "flush")
+		},
+		func(mountPoint string) {
+			calls = append(calls, "force:"+mountPoint)
+		},
+		func(string, ...any) {},
+	)
+
+	want := []string{"stop", "flush"}
+	if len(calls) != len(want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("calls = %v, want %v", calls, want)
+		}
+	}
+}
+
+func TestCleanupMountStartFailureSkipsForceUnmountForEmptyMountPoint(t *testing.T) {
+	forced := false
+
+	cleanupMountStartFailure(mountStartCleanup{
+		reason:                    "test",
+		cause:                     errors.New("init: ENODEV"),
+		forceUnmount:              func(string) { forced = true },
+		forceUnmountWithoutServer: true,
+		logf:                      func(string, ...any) {},
+	})
+
+	if forced {
+		t.Fatal("forceUnmount should not be called for an empty mountpoint")
+	}
+}
+
 func TestShouldForceUnmountAfterNewServerErrorOnlyForInitFailure(t *testing.T) {
 	if !shouldForceUnmountAfterNewServerError(errors.New("init: ENODEV")) {
 		t.Fatal("init failure should force cleanup")

--- a/pkg/fuse/mount_shutdown_test.go
+++ b/pkg/fuse/mount_shutdown_test.go
@@ -1,6 +1,7 @@
 package fuse
 
 import (
+	"errors"
 	"sync"
 	"testing"
 )
@@ -39,5 +40,56 @@ func TestMountShutdownRunsOnce(t *testing.T) {
 	}
 	if flushCount != 1 {
 		t.Fatalf("flushCount = %d, want 1", flushCount)
+	}
+}
+
+func TestCleanupMountStartFailureUnmountsAfterStoppingWatchersAndFlushing(t *testing.T) {
+	var calls []string
+
+	cleanupMountStartFailure(mountStartCleanup{
+		reason:     "test",
+		mountPoint: "/mnt/drive9",
+		stopWatchers: func() {
+			calls = append(calls, "stop")
+		},
+		flushAll: func() {
+			calls = append(calls, "flush")
+		},
+		unmount: func() error {
+			calls = append(calls, "unmount")
+			return nil
+		},
+		forceUnmount: func(string) {
+			calls = append(calls, "force")
+		},
+	})
+
+	want := []string{"stop", "flush", "unmount"}
+	if len(calls) != len(want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("calls = %v, want %v", calls, want)
+		}
+	}
+}
+
+func TestCleanupMountStartFailureForceUnmountsWhenServerUnmountFails(t *testing.T) {
+	var forced []string
+
+	cleanupMountStartFailure(mountStartCleanup{
+		reason:     "test",
+		mountPoint: "/mnt/drive9",
+		unmount: func() error {
+			return errors.New("transport endpoint is not connected")
+		},
+		forceUnmount: func(mountPoint string) {
+			forced = append(forced, mountPoint)
+		},
+	})
+
+	if len(forced) != 1 || forced[0] != "/mnt/drive9" {
+		t.Fatalf("forced = %v, want [/mnt/drive9]", forced)
 	}
 }

--- a/pkg/fuse/mount_shutdown_test.go
+++ b/pkg/fuse/mount_shutdown_test.go
@@ -2,6 +2,8 @@ package fuse
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -45,10 +47,12 @@ func TestMountShutdownRunsOnce(t *testing.T) {
 
 func TestCleanupMountStartFailureUnmountsAfterStoppingWatchersAndFlushing(t *testing.T) {
 	var calls []string
+	var logs strings.Builder
 
 	cleanupMountStartFailure(mountStartCleanup{
 		reason:     "test",
 		mountPoint: "/mnt/drive9",
+		cause:      errors.New("fuse init failed"),
 		stopWatchers: func() {
 			calls = append(calls, "stop")
 		},
@@ -62,6 +66,9 @@ func TestCleanupMountStartFailureUnmountsAfterStoppingWatchersAndFlushing(t *tes
 		forceUnmount: func(string) {
 			calls = append(calls, "force")
 		},
+		logf: func(format string, args ...any) {
+			logs.WriteString(fmt.Sprintf(format, args...))
+		},
 	})
 
 	want := []string{"stop", "flush", "unmount"}
@@ -71,6 +78,15 @@ func TestCleanupMountStartFailureUnmountsAfterStoppingWatchersAndFlushing(t *tes
 	for i := range want {
 		if calls[i] != want[i] {
 			t.Fatalf("calls = %v, want %v", calls, want)
+		}
+	}
+	gotLogs := logs.String()
+	for _, wantLog := range []string{
+		"drive9: mount startup failed during test at /mnt/drive9: fuse init failed",
+		"drive9: cleanup after test: unmounted /mnt/drive9",
+	} {
+		if !strings.Contains(gotLogs, wantLog) {
+			t.Fatalf("logs = %q, want substring %q", gotLogs, wantLog)
 		}
 	}
 }
@@ -91,5 +107,17 @@ func TestCleanupMountStartFailureForceUnmountsWhenServerUnmountFails(t *testing.
 
 	if len(forced) != 1 || forced[0] != "/mnt/drive9" {
 		t.Fatalf("forced = %v, want [/mnt/drive9]", forced)
+	}
+}
+
+func TestShouldForceUnmountAfterNewServerErrorOnlyForInitFailure(t *testing.T) {
+	if !shouldForceUnmountAfterNewServerError(errors.New("init: ENODEV")) {
+		t.Fatal("init failure should force cleanup")
+	}
+	if shouldForceUnmountAfterNewServerError(errors.New("fusermount: mountpoint is busy")) {
+		t.Fatal("pre-mount failure should not force cleanup")
+	}
+	if shouldForceUnmountAfterNewServerError(nil) {
+		t.Fatal("nil error should not force cleanup")
 	}
 }


### PR DESCRIPTION
## Summary

- clean up partially-started FUSE mounts when Drive9 mount startup fails
- force-unmount the mountpoint after go-fuse returns an INIT-stage `init: ...` error without a server handle
- add safe startup diagnostics that report the failed phase, mountpoint, and underlying error without printing server, remote, token, or API key values

## Details

Drive9 could leave a stale FUSE mount when mount startup failed after the kernel/FUSE INIT path had already begun. It showed up as a later `transport endpoint is not connected` mountpoint with no live `drive9` process, making retries in the same sandbox fail.

This change covers both startup failure shapes:

1. `gofuse.NewServer()` can mount and handle INIT synchronously, then return an `init: ...` error before Drive9 has a server handle. In that case, Drive9 now logs a safe diagnostic and calls the existing force-unmount fallback for the mountpoint.
2. After a server exists, failures from `WaitMount()`, mount control socket setup, or process-state writing now stop watchers, flush pending state, try `server.Unmount()`, and fall back to force-unmount if normal unmount fails.

The added diagnostics make foreground failures actionable. For example:

```text
drive9: mount startup failed during fuse wait mount failure at /home/user/workspace: permission denied
drive9: cleanup after fuse wait mount failure: unmounted /home/user/workspace
mount: fuse wait mount: permission denied
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mount startup failure handling with a consistent best-effort cleanup sequence: stop watchers, flush pending data, and unmount (with forced unmount fallback when appropriate).
  * Added targeted behavior for partial initialization failures to force unmount only when needed.
  * Ensured the control server is closed as part of the unified cleanup flow.
* **Tests**
  * Added/expanded tests covering cleanup ordering, forced unmount behavior (including “transport endpoint is not connected”), and correct detection of init-failure cases (including skipping force unmount for empty mount points).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->