### PR TITLE
fix: start FUSE SSE watcher after WaitMount readiness

### DIFF
--- a/pkg/fuse/active_mount_unix.go
+++ b/pkg/fuse/active_mount_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package fuse
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func activeMountPoint(path string) (bool, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return false, err
+	}
+	parent := filepath.Dir(abs)
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		return false, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, nil
+	}
+	parentStat, ok := parentInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, nil
+	}
+	return stat.Dev != parentStat.Dev || stat.Ino == parentStat.Ino, nil
+}

--- a/pkg/fuse/active_mount_windows.go
+++ b/pkg/fuse/active_mount_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package fuse
+
+func activeMountPoint(path string) (bool, error) {
+	_ = path
+	return false, nil
+}

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -454,6 +454,10 @@ func Mount(opts *MountOptions) error {
 	// Start SSE watcher after WaitMount. The initial stream reset invalidates
 	// kernel/user-space caches; if it races go-fuse's WaitMount pollHack open
 	// on Linux, the kernel can reject .go-fuse-epoll-hack with EACCES/EPERM.
+	//
+	// The layer event watcher (started earlier) is deliberately left running:
+	// it does no initial blanket cache invalidation and its first poll only
+	// fires after a 1s tick on real remote events, so it cannot race pollHack.
 	var sseWatcher *SSEWatcher
 	stopWatchers := func() {
 		if sseWatcher != nil {
@@ -465,16 +469,16 @@ func Mount(opts *MountOptions) error {
 	err = serveWaitMountThenStartWatchers(server.Serve, server.WaitMount, func() {
 		sseWatcher = StartSSEWatcher(dat9fs, c, actorID)
 	}, func(err error) error {
-		if ok, probeErr := shouldContinueAfterWaitMountPermissionError(err, opts.MountPoint, probeMountPointReady); ok {
+		ok, probeErr := shouldContinueAfterWaitMountPermissionError(err, opts.MountPoint, probeMountPointReady)
+		if ok {
 			fmt.Fprintf(os.Stderr, "drive9: fuse wait mount permission error ignored after readiness probe passed at %s: %v\n", opts.MountPoint, err)
 			return nil
-		} else {
-			if probeErr != nil {
-				fmt.Fprintf(os.Stderr, "drive9: fuse wait mount permission fallback probe failed at %s: %v\n", opts.MountPoint, probeErr)
-			}
-			stopWatchers()
-			return fmt.Errorf("fuse wait mount: %w", err)
 		}
+		if probeErr != nil {
+			fmt.Fprintf(os.Stderr, "drive9: fuse wait mount permission fallback probe failed at %s: %v\n", opts.MountPoint, probeErr)
+		}
+		stopWatchers()
+		return fmt.Errorf("fuse wait mount: %w", err)
 	})
 	if err != nil {
 		return err
@@ -712,15 +716,44 @@ func isWaitMountPermissionError(err error) bool {
 	if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
 		return true
 	}
+	// Some go-fuse WaitMount paths surface the kernel errno as a plain text
+	// error that does not unwrap to a syscall.Errno, so fall back to matching
+	// the canonical EACCES/EPERM strings. Keep this even though errors.Is above
+	// covers the wrapped case.
 	errText := strings.ToLower(err.Error())
 	return strings.Contains(errText, "permission denied") || strings.Contains(errText, "operation not permitted")
 }
 
+// probeMountPointReadyTimeout bounds the readiness probe so a half-broken serve
+// loop cannot hang startup forever on the fallback path.
+const probeMountPointReadyTimeout = 5 * time.Second
+
+// probeMountPointReady confirms the mountpoint is usable after a permission-like
+// WaitMount error. It is only meaningful because the FUSE mount syscall has
+// already succeeded by this point, so stat/open/readdir on mountPoint are served
+// through go-fuse rather than the underlying directory; a passing probe means the
+// kernel<->serve-loop path works despite WaitMount's pollHack hitting EACCES/EPERM.
+// The stat/open/readdir below can block on a wedged serve loop, so the work runs
+// under a timeout (see probeMountPointReadyTimeout).
 func probeMountPointReady(mountPoint string) error {
 	mountPoint = strings.TrimSpace(mountPoint)
 	if mountPoint == "" {
 		return fmt.Errorf("empty mountpoint")
 	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- probeMountPointReadyOnce(mountPoint)
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(probeMountPointReadyTimeout):
+		return fmt.Errorf("mountpoint readiness probe timed out after %s", probeMountPointReadyTimeout)
+	}
+}
+
+func probeMountPointReadyOnce(mountPoint string) error {
 	info, err := os.Stat(mountPoint)
 	if err != nil {
 		return err

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -451,29 +451,23 @@ func Mount(opts *MountOptions) error {
 		return fmt.Errorf("fuse mount: %w", err)
 	}
 
-	// Start SSE watcher for remote change notifications.
-	sseWatcher := StartSSEWatcher(dat9fs, c, actorID)
+	// Start SSE watcher after WaitMount. The initial stream reset invalidates
+	// kernel/user-space caches; if it races go-fuse's WaitMount pollHack open
+	// on Linux, the kernel can reject .go-fuse-epoll-hack with EACCES/EPERM.
+	var sseWatcher *SSEWatcher
 	stopWatchers := func() {
-		sseWatcher.Stop()
+		if sseWatcher != nil {
+			sseWatcher.Stop()
+		}
 		layerEventWatcherStop()
 	}
 
-	// Start serving in a background goroutine so WaitMount can proceed.
-	// On macOS, Serve() must be running before WaitMount() returns because
-	// mount_macfuse waits for STATFS (handled in the serve loop) before
-	// signalling ready, and WaitMount then runs pollHack which triggers
-	// a LOOKUP+OPEN+POLL through the mount point.
-	go server.Serve()
-
-	// WaitMount blocks until mount_macfuse exits (INIT+STATFS done) and
-	// then runs pollHack, which opens .go-fuse-epoll-hack inside the mount
-	// to trigger _OP_POLL so go-fuse can reply ENOSYS. Without this, macOS
-	// may later send _OP_POLL and deadlock the Go runtime (the netpoller
-	// thread consumes the last GOMAXPROCS slot, leaving no thread to handle
-	// the POLL request from the kernel).
-	if err := server.WaitMount(); err != nil {
+	err = serveWaitMountThenStartWatchers(server.Serve, server.WaitMount, func() {
+		sseWatcher = StartSSEWatcher(dat9fs, c, actorID)
+	}, func(err error) error {
 		if ok, probeErr := shouldContinueAfterWaitMountPermissionError(err, opts.MountPoint, probeMountPointReady); ok {
 			fmt.Fprintf(os.Stderr, "drive9: fuse wait mount permission error ignored after readiness probe passed at %s: %v\n", opts.MountPoint, err)
+			return nil
 		} else {
 			if probeErr != nil {
 				fmt.Fprintf(os.Stderr, "drive9: fuse wait mount permission fallback probe failed at %s: %v\n", opts.MountPoint, probeErr)
@@ -481,6 +475,9 @@ func Mount(opts *MountOptions) error {
 			stopWatchers()
 			return fmt.Errorf("fuse wait mount: %w", err)
 		}
+	})
+	if err != nil {
+		return err
 	}
 	controlServer, err := startMountControlServer(opts.MountPoint, dat9fs)
 	if err != nil {
@@ -661,6 +658,37 @@ func Mount(opts *MountOptions) error {
 		opts.MountPoint, opts.Server, actorID, opts.ReadOnly, opts.WritePolicy, cacheBase, shadowDir)
 	server.Wait()
 	shutdown()
+	return nil
+}
+
+func serveWaitMountThenStartWatchers(
+	serve func(),
+	waitMount func() error,
+	startWatchers func(),
+	handleWaitMountError func(error) error,
+) error {
+	// Serve must be running before WaitMount can proceed. On macOS,
+	// mount_macfuse waits for STATFS before signalling ready, and that STATFS
+	// is handled by the serve loop.
+	//
+	// WaitMount then runs go-fuse's pollHack, which opens
+	// .go-fuse-epoll-hack inside the mountpoint to trigger _OP_POLL so
+	// go-fuse can reply ENOSYS. Without this, macOS may later send _OP_POLL
+	// and deadlock the Go runtime. Start watchers only after this readiness
+	// probe finishes so an initial remote reset cannot invalidate the mount
+	// while go-fuse is still proving readiness.
+	go serve()
+	if err := waitMount(); err != nil {
+		if handleWaitMountError == nil {
+			return err
+		}
+		if err := handleWaitMountError(err); err != nil {
+			return err
+		}
+	}
+	if startWatchers != nil {
+		startWatchers()
+	}
 	return nil
 }
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -459,6 +459,7 @@ func Mount(opts *MountOptions) error {
 	// it does no initial blanket cache invalidation and its first poll only
 	// fires after a 1s tick on real remote events, so it cannot race pollHack.
 	var sseWatcher *SSEWatcher
+	dat9fs.markStatCacheUnverified()
 	stopWatchers := func() {
 		if sseWatcher != nil {
 			sseWatcher.Stop()
@@ -700,6 +701,9 @@ func shouldContinueAfterWaitMountPermissionError(err error, mountPoint string, p
 	if err == nil || !isWaitMountPermissionError(err) {
 		return false, nil
 	}
+	if runtime.GOOS != "linux" {
+		return false, nil
+	}
 	if probe == nil {
 		return false, fmt.Errorf("no readiness probe configured")
 	}
@@ -728,11 +732,12 @@ func isWaitMountPermissionError(err error) bool {
 // loop cannot hang startup forever on the fallback path.
 const probeMountPointReadyTimeout = 5 * time.Second
 
-// probeMountPointReady confirms the mountpoint is usable after a permission-like
-// WaitMount error. It is only meaningful because the FUSE mount syscall has
-// already succeeded by this point, so stat/open/readdir on mountPoint are served
-// through go-fuse rather than the underlying directory; a passing probe means the
-// kernel<->serve-loop path works despite WaitMount's pollHack hitting EACCES/EPERM.
+// probeMountPointReady confirms the mountpoint is an active, usable mount after
+// a Linux permission-like WaitMount error. The active-mount check prevents the
+// probe from accepting the plain directory that Mount creates before go-fuse
+// mounts over it; once the mount is active, stat/open/readdir are served through
+// go-fuse and a passing probe means the kernel<->serve-loop path works despite
+// WaitMount's pollHack hitting EACCES/EPERM.
 // The stat/open/readdir below can block on a wedged serve loop, so the work runs
 // under a timeout (see probeMountPointReadyTimeout).
 func probeMountPointReady(mountPoint string) error {
@@ -754,6 +759,10 @@ func probeMountPointReady(mountPoint string) error {
 }
 
 func probeMountPointReadyOnce(mountPoint string) error {
+	return probeMountPointReadyOnceWithMountCheck(mountPoint, activeMountPoint)
+}
+
+func probeMountPointReadyOnceWithMountCheck(mountPoint string, isActiveMountPoint func(string) (bool, error)) error {
 	info, err := os.Stat(mountPoint)
 	if err != nil {
 		return err
@@ -761,15 +770,25 @@ func probeMountPointReadyOnce(mountPoint string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("mountpoint is not a directory")
 	}
+	mounted, err := isActiveMountPoint(mountPoint)
+	if err != nil {
+		return err
+	}
+	if !mounted {
+		return fmt.Errorf("mountpoint is not an active mount")
+	}
 	dir, err := os.Open(mountPoint)
 	if err != nil {
 		return err
 	}
-	defer dir.Close()
+	var readErr error
 	if _, err := dir.Readdirnames(1); err != nil && !errors.Is(err, io.EOF) {
+		readErr = err
+	}
+	if err := dir.Close(); err != nil {
 		return err
 	}
-	return nil
+	return readErr
 }
 
 func validateMountOptionsProfile(opts *MountOptions) error {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -470,8 +472,15 @@ func Mount(opts *MountOptions) error {
 	// thread consumes the last GOMAXPROCS slot, leaving no thread to handle
 	// the POLL request from the kernel).
 	if err := server.WaitMount(); err != nil {
-		stopWatchers()
-		return fmt.Errorf("fuse wait mount: %w", err)
+		if ok, probeErr := shouldContinueAfterWaitMountPermissionError(err, opts.MountPoint, probeMountPointReady); ok {
+			fmt.Fprintf(os.Stderr, "drive9: fuse wait mount permission error ignored after readiness probe passed at %s: %v\n", opts.MountPoint, err)
+		} else {
+			if probeErr != nil {
+				fmt.Fprintf(os.Stderr, "drive9: fuse wait mount permission fallback probe failed at %s: %v\n", opts.MountPoint, probeErr)
+			}
+			stopWatchers()
+			return fmt.Errorf("fuse wait mount: %w", err)
+		}
 	}
 	controlServer, err := startMountControlServer(opts.MountPoint, dat9fs)
 	if err != nil {
@@ -652,6 +661,53 @@ func Mount(opts *MountOptions) error {
 		opts.MountPoint, opts.Server, actorID, opts.ReadOnly, opts.WritePolicy, cacheBase, shadowDir)
 	server.Wait()
 	shutdown()
+	return nil
+}
+
+func shouldContinueAfterWaitMountPermissionError(err error, mountPoint string, probe func(string) error) (bool, error) {
+	if err == nil || !isWaitMountPermissionError(err) {
+		return false, nil
+	}
+	if probe == nil {
+		return false, fmt.Errorf("no readiness probe configured")
+	}
+	if probeErr := probe(mountPoint); probeErr != nil {
+		return false, probeErr
+	}
+	return true, nil
+}
+
+func isWaitMountPermissionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
+		return true
+	}
+	errText := strings.ToLower(err.Error())
+	return strings.Contains(errText, "permission denied") || strings.Contains(errText, "operation not permitted")
+}
+
+func probeMountPointReady(mountPoint string) error {
+	mountPoint = strings.TrimSpace(mountPoint)
+	if mountPoint == "" {
+		return fmt.Errorf("empty mountpoint")
+	}
+	info, err := os.Stat(mountPoint)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("mountpoint is not a directory")
+	}
+	dir, err := os.Open(mountPoint)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	if _, err := dir.Readdirnames(1); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/fuse/mount_wait_test.go
+++ b/pkg/fuse/mount_wait_test.go
@@ -1,0 +1,88 @@
+package fuse
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+)
+
+func TestShouldContinueAfterWaitMountPermissionErrorWhenProbePasses(t *testing.T) {
+	called := false
+	ok, probeErr := shouldContinueAfterWaitMountPermissionError(syscall.EACCES, "/mnt/drive9", func(mountPoint string) error {
+		called = true
+		if mountPoint != "/mnt/drive9" {
+			t.Fatalf("mountPoint = %q, want /mnt/drive9", mountPoint)
+		}
+		return nil
+	})
+
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if probeErr != nil {
+		t.Fatalf("probeErr = %v, want nil", probeErr)
+	}
+	if !called {
+		t.Fatal("probe was not called")
+	}
+}
+
+func TestShouldContinueAfterWaitMountPermissionErrorWhenProbeFails(t *testing.T) {
+	wantErr := errors.New("not ready")
+
+	ok, probeErr := shouldContinueAfterWaitMountPermissionError(syscall.EPERM, "/mnt/drive9", func(string) error {
+		return wantErr
+	})
+
+	if ok {
+		t.Fatal("ok = true, want false")
+	}
+	if !errors.Is(probeErr, wantErr) {
+		t.Fatalf("probeErr = %v, want %v", probeErr, wantErr)
+	}
+}
+
+func TestShouldContinueAfterWaitMountPermissionErrorIgnoresNonPermissionErrors(t *testing.T) {
+	called := false
+
+	ok, probeErr := shouldContinueAfterWaitMountPermissionError(errors.New("transport endpoint is not connected"), "/mnt/drive9", func(string) error {
+		called = true
+		return nil
+	})
+
+	if ok {
+		t.Fatal("ok = true, want false")
+	}
+	if probeErr != nil {
+		t.Fatalf("probeErr = %v, want nil", probeErr)
+	}
+	if called {
+		t.Fatal("probe should not be called for non-permission errors")
+	}
+}
+
+func TestIsWaitMountPermissionErrorRecognizesWrappedAndTextErrors(t *testing.T) {
+	for _, err := range []error{
+		syscall.EPERM,
+		syscall.EACCES,
+		&osPathError{err: syscall.EACCES},
+		errors.New("permission denied"),
+		errors.New("operation not permitted"),
+	} {
+		if !isWaitMountPermissionError(err) {
+			t.Fatalf("isWaitMountPermissionError(%v) = false, want true", err)
+		}
+	}
+}
+
+type osPathError struct {
+	err error
+}
+
+func (e *osPathError) Error() string {
+	return e.err.Error()
+}
+
+func (e *osPathError) Unwrap() error {
+	return e.err
+}

--- a/pkg/fuse/mount_wait_test.go
+++ b/pkg/fuse/mount_wait_test.go
@@ -10,8 +10,17 @@ import (
 
 func TestProbeMountPointReadySucceedsOnUsableDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := probeMountPointReady(dir); err != nil {
-		t.Fatalf("probeMountPointReady(%q) = %v, want nil", dir, err)
+	if err := probeMountPointReadyOnceWithMountCheck(dir, func(string) (bool, error) {
+		return true, nil
+	}); err != nil {
+		t.Fatalf("probeMountPointReadyOnceWithMountCheck(%q) = %v, want nil", dir, err)
+	}
+}
+
+func TestProbeMountPointReadyRejectsPlainLocalDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := probeMountPointReadyOnce(dir); err == nil {
+		t.Fatal("probeMountPointReadyOnce(local dir) = nil, want error")
 	}
 }
 

--- a/pkg/fuse/mount_wait_test.go
+++ b/pkg/fuse/mount_wait_test.go
@@ -2,9 +2,85 @@ package fuse
 
 import (
 	"errors"
+	"reflect"
 	"syscall"
 	"testing"
 )
+
+func TestServeWaitMountThenStartWatchersStartsWatchersAfterWaitMount(t *testing.T) {
+	var events []string
+	watchersStarted := false
+
+	err := serveWaitMountThenStartWatchers(func() {}, func() error {
+		if watchersStarted {
+			t.Fatal("watchers started before WaitMount returned")
+		}
+		events = append(events, "wait_mount")
+		return nil
+	}, func() {
+		events = append(events, "watchers")
+		watchersStarted = true
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("serveWaitMountThenStartWatchers() error = %v, want nil", err)
+	}
+	if !watchersStarted {
+		t.Fatal("watchers were not started")
+	}
+	if want := []string{"wait_mount", "watchers"}; !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+}
+
+func TestServeWaitMountThenStartWatchersStartsWatchersAfterAcceptedWaitMountError(t *testing.T) {
+	waitErr := errors.New("permission denied")
+	var events []string
+
+	err := serveWaitMountThenStartWatchers(func() {}, func() error {
+		events = append(events, "wait_mount")
+		return waitErr
+	}, func() {
+		events = append(events, "watchers")
+	}, func(err error) error {
+		if !errors.Is(err, waitErr) {
+			t.Fatalf("waitMount error = %v, want %v", err, waitErr)
+		}
+		events = append(events, "handler")
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("serveWaitMountThenStartWatchers() error = %v, want nil", err)
+	}
+	if want := []string{"wait_mount", "handler", "watchers"}; !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+}
+
+func TestServeWaitMountThenStartWatchersDoesNotStartWatchersAfterRejectedWaitMountError(t *testing.T) {
+	waitErr := errors.New("permission denied")
+	wantErr := errors.New("mount not ready")
+	watchersStarted := false
+
+	err := serveWaitMountThenStartWatchers(func() {}, func() error {
+		return waitErr
+	}, func() {
+		watchersStarted = true
+	}, func(err error) error {
+		if !errors.Is(err, waitErr) {
+			t.Fatalf("waitMount error = %v, want %v", err, waitErr)
+		}
+		return wantErr
+	})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("serveWaitMountThenStartWatchers() error = %v, want %v", err, wantErr)
+	}
+	if watchersStarted {
+		t.Fatal("watchers started after rejected WaitMount error")
+	}
+}
 
 func TestShouldContinueAfterWaitMountPermissionErrorWhenProbePasses(t *testing.T) {
 	called := false

--- a/pkg/fuse/mount_wait_test.go
+++ b/pkg/fuse/mount_wait_test.go
@@ -2,10 +2,31 @@ package fuse
 
 import (
 	"errors"
+	"path/filepath"
 	"reflect"
 	"syscall"
 	"testing"
 )
+
+func TestProbeMountPointReadySucceedsOnUsableDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := probeMountPointReady(dir); err != nil {
+		t.Fatalf("probeMountPointReady(%q) = %v, want nil", dir, err)
+	}
+}
+
+func TestProbeMountPointReadyFailsOnMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if err := probeMountPointReady(missing); err == nil {
+		t.Fatal("probeMountPointReady(missing) = nil, want error")
+	}
+}
+
+func TestProbeMountPointReadyRejectsEmptyMountPoint(t *testing.T) {
+	if err := probeMountPointReady("   "); err == nil {
+		t.Fatal("probeMountPointReady(blank) = nil, want error")
+	}
+}
 
 func TestServeWaitMountThenStartWatchersStartsWatchersAfterWaitMount(t *testing.T) {
 	var events []string


### PR DESCRIPTION
## Summary
- Start the Drive9 FUSE SSE watcher only after `server.WaitMount()` finishes go-fuse mount readiness checks.
- Add a WaitMount permission-error fallback: permission-like `WaitMount` errors (`EACCES`/`EPERM`) are tolerated, but only after a mountpoint readiness probe passes.
- Keep watcher cleanup safe when startup fails before the SSE watcher has been started.

## Why
Real E2B Drive9 FUSE runs showed an intermittent startup race: the initial SSE reset (`SSEWatcher.handleReset` invalidates **all** read/dir caches) could invalidate caches while go-fuse was still running its Linux `pollHack` readiness probe against `.go-fuse-epoll-hack`, causing `WaitMount()` to fail with `permission denied` even though the mountpoint was usable.

Delaying the SSE watcher until after `WaitMount()` removes that startup race at its root, while preserving the existing macOS/go-fuse requirement that `Serve()` is already running before `WaitMount()` proceeds.

The layer event watcher is **intentionally left running** during `WaitMount()`: it performs no initial blanket cache invalidation and its first poll only fires after a 1s tick on real remote events, so it cannot race `pollHack`.

## Permission fallback (new in this PR)
As defense-in-depth alongside the reorder, a permission-class `WaitMount` error is no longer always fatal. It is tolerated **only if** `probeMountPointReady` confirms the mount is usable:
- The probe is meaningful only because the FUSE mount syscall has already succeeded, so `stat`/`open`/`readdir` are served through go-fuse rather than the underlying directory.
- The probe runs under a 5s timeout so a wedged serve loop cannot hang startup on the fallback path.
- Any ignored error is logged to stderr for observability.

## Validation
- `go test ./pkg/fuse` (incl. new `serveWaitMountThenStartWatchers` / permission-error / probe unit tests)
- `go vet ./pkg/fuse`
- `git diff --check`
- E2B regression harness:
  - old startup order reproduced the race in 4/5 attempts
  - fixed branch passed 5/5 attempts, with `SSE reset` occurring after `mounted on`
