### PR TITLE
fix: use tls=skip-verify for native private endpoint connections

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -213,6 +213,14 @@ func main() {
 		provisioner, provisionerErr = db9.NewProvisionerFromEnv()
 	}
 	if provisionerErr != nil {
+		isWanted := false
+		if providerType == tenant.ProviderTiDBCloudNative && os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_API_URL") != "" {
+			isWanted = true
+		}
+		if isWanted {
+			logger.Error(context.Background(), "provisioner_failed", zap.String("provider", providerType), zap.Error(provisionerErr))
+			os.Exit(1)
+		}
 		logger.Warn(context.Background(), "provisioner_not_configured", zap.String("provider", providerType), zap.Error(provisionerErr))
 	} else {
 		logger.Info(context.Background(), "provisioner_configured", zap.String("provider", providerType))

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -656,7 +656,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 			return "", err
 		}
 		if forkTenant.DBHost != "" && forkTenant.DBPort != 0 && forkTenant.DBUser != "" {
-			return tenantDSN(forkTenant.DBUser, string(plain), forkTenant.DBHost, forkTenant.DBPort, forkTenant.DBName, forkTenant.DBTLS), nil
+			return tenantDSN(forkTenant.DBUser, string(plain), forkTenant.DBHost, forkTenant.DBPort, forkTenant.DBName, forkTenant.DBTLS, forkTenant.Provider), nil
 		}
 		if branchProv, ok := s.provisioner.(tenant.CredentialBranchProvisioner); ok && credentialReq != nil {
 			username, err := branchProv.WaitForBranchUserWithCredentials(ctx, forkTenant.ClusterID, forkTenant.BranchID, *credentialReq)
@@ -687,7 +687,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 			}); err != nil {
 				return "", err
 			}
-			return tenantDSN(username, string(plain), host, port, forkTenant.DBName, true), nil
+			return tenantDSN(username, string(plain), host, port, forkTenant.DBName, true, forkTenant.Provider), nil
 		}
 		cluster, err := s.waitForForkBranchActive(ctx, &tenant.ClusterInfo{
 			TenantID:  forkTenant.ID,
@@ -715,7 +715,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		}); err != nil {
 			return "", err
 		}
-		return tenantDSN(cluster.Username, string(plain), cluster.Host, cluster.Port, cluster.DBName, true), nil
+		return tenantDSN(cluster.Username, string(plain), cluster.Host, cluster.Port, cluster.DBName, true, cluster.Provider), nil
 	}
 
 	branchPassword, err := s.pool.Decrypt(ctx, forkTenant.DBPasswordCipher)
@@ -754,7 +754,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 	if cluster.Host == "" || cluster.Port == 0 || cluster.Username == "" {
 		return "", forkErr(http.StatusServiceUnavailable, "database branch is not active yet")
 	}
-	return tenantDSN(cluster.Username, string(branchPassword), cluster.Host, cluster.Port, cluster.DBName, true), nil
+	return tenantDSN(cluster.Username, string(branchPassword), cluster.Host, cluster.Port, cluster.DBName, true, cluster.Provider), nil
 }
 
 func generateForkDBPassword(length int) (string, error) {
@@ -1029,7 +1029,7 @@ func (s *Server) openTenantStore(ctx context.Context, t *meta.Tenant) (*datastor
 	if err != nil {
 		return nil, err
 	}
-	return datastore.Open(tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS))
+	return datastore.Open(tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS, t.Provider))
 }
 
 func (s *Server) enqueueForkFileGCTaskRefs(ctx context.Context, t *meta.Tenant, store *datastore.Store) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -745,7 +745,7 @@ func (s *Server) startTenantSchemaInitResume(ctx context.Context, t meta.Tenant)
 			logger.Warn(workerCtx, "resume_schema_init_skipped", zap.String("tenant_id", t.ID), zap.Error(err))
 			return
 		}
-		dsn := tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS)
+		dsn := tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS, t.Provider)
 		s.initTenantSchemaAsync(workerCtx, t.ID, dsn, t.Provider, s.schemaInitForTenant(t.ID, t.Provider, s.provisioner.InitSchema))
 	})
 }
@@ -824,10 +824,12 @@ func contextWithTrace(parent, traceSource context.Context) context.Context {
 	return traceid.With(parent, traceID)
 }
 
-func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled bool) string {
+func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled bool, provider string) string {
 	query := "parseTime=true"
 	if tlsEnabled {
 		query += "&tls=true"
+	} else if provider == tenant.ProviderTiDBCloudNative {
+		query += "&tls=skip-verify"
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", user, password, host, port, dbName, query)
 }
@@ -4359,7 +4361,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		APIKeyID:       apiKeyID,
 		Status:         meta.TenantProvisioning,
 		Provider:       provider,
-		TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, dbtls),
+		TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, dbtls, provider),
 		CloudProvider:  cloudProvider,
 		Region:         region,
 		OrganizationID: strings.TrimSpace(cluster.OrganizationID),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -827,18 +827,11 @@ func contextWithTrace(parent, traceSource context.Context) context.Context {
 func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled bool) string {
 	query := "parseTime=true"
 	if tlsEnabled {
-		tlsMode := "true"
-		if isPrivateEndpointEnabled() {
-			tlsMode = "skip-verify"
-		}
-		query += "&tls=" + tlsMode
+		query += "&tls=true"
+	} else {
+		query += "&tls=skip-verify"
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", user, password, host, port, dbName, query)
-}
-
-func isPrivateEndpointEnabled() bool {
-	v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
-	return v == "1" || v == "true" || v == "yes"
 }
 
 func injectFallbackBackend(b *backend.Dat9Backend, next http.Handler) http.Handler {
@@ -4295,13 +4288,20 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		}
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encrypt db password", err)
 	}
+	dbtls := true
+	if provider == tenant.ProviderTiDBCloudNative {
+		v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
+		if v == "1" || v == "true" || v == "yes" {
+			dbtls = false
+		}
+	}
 	if err := s.meta.UpdateTenantConnection(ctx, tenantID, &meta.Tenant{
 		DBHost:           cluster.Host,
 		DBPort:           cluster.Port,
 		DBUser:           cluster.Username,
 		DBPasswordCipher: cipherPass,
 		DBName:           cluster.DBName,
-		DBTLS:            true,
+		DBTLS:            dbtls,
 		Provider:         provider,
 		ClusterID:        cluster.ClusterID,
 		ClaimURL:         cluster.ClaimURL,
@@ -4361,7 +4361,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		APIKeyID:       apiKeyID,
 		Status:         meta.TenantProvisioning,
 		Provider:       provider,
-		TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true),
+		TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, dbtls),
 		CloudProvider:  cloudProvider,
 		Region:         region,
 		OrganizationID: strings.TrimSpace(cluster.OrganizationID),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -827,18 +827,9 @@ func contextWithTrace(parent, traceSource context.Context) context.Context {
 func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled bool) string {
 	query := "parseTime=true"
 	if tlsEnabled {
-		tlsMode := "true"
-		if isPrivateEndpointEnabled() {
-			tlsMode = "skip-verify"
-		}
-		query += "&tls=" + tlsMode
+		query += "&tls=true"
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", user, password, host, port, dbName, query)
-}
-
-func isPrivateEndpointEnabled() bool {
-	v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
-	return v == "1" || v == "true" || v == "yes"
 }
 
 func injectFallbackBackend(b *backend.Dat9Backend, next http.Handler) http.Handler {
@@ -4295,13 +4286,20 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		}
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encrypt db password", err)
 	}
+	dbtls := true
+	if provider == tenant.ProviderTiDBCloudNative {
+		v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
+		if v == "1" || v == "true" || v == "yes" {
+			dbtls = false
+		}
+	}
 	if err := s.meta.UpdateTenantConnection(ctx, tenantID, &meta.Tenant{
 		DBHost:           cluster.Host,
 		DBPort:           cluster.Port,
 		DBUser:           cluster.Username,
 		DBPasswordCipher: cipherPass,
 		DBName:           cluster.DBName,
-		DBTLS:            true,
+		DBTLS:            dbtls,
 		Provider:         provider,
 		ClusterID:        cluster.ClusterID,
 		ClaimURL:         cluster.ClaimURL,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4359,7 +4359,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		APIKeyID:       apiKeyID,
 		Status:         meta.TenantProvisioning,
 		Provider:       provider,
-		TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true),
+		TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, dbtls),
 		CloudProvider:  cloudProvider,
 		Region:         region,
 		OrganizationID: strings.TrimSpace(cluster.OrganizationID),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -828,8 +828,6 @@ func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled 
 	query := "parseTime=true"
 	if tlsEnabled {
 		query += "&tls=true"
-	} else {
-		query += "&tls=skip-verify"
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", user, password, host, port, dbName, query)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -827,9 +827,18 @@ func contextWithTrace(parent, traceSource context.Context) context.Context {
 func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled bool) string {
 	query := "parseTime=true"
 	if tlsEnabled {
-		query += "&tls=true"
+		tlsMode := "true"
+		if isPrivateEndpointEnabled() {
+			tlsMode = "skip-verify"
+		}
+		query += "&tls=" + tlsMode
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", user, password, host, port, dbName, query)
+}
+
+func isPrivateEndpointEnabled() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
+	return v == "1" || v == "true" || v == "yes"
 }
 
 func injectFallbackBackend(b *backend.Dat9Backend, next http.Handler) http.Handler {
@@ -4286,20 +4295,13 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		}
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encrypt db password", err)
 	}
-	dbtls := true
-	if provider == tenant.ProviderTiDBCloudNative {
-		v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
-		if v == "1" || v == "true" || v == "yes" {
-			dbtls = false
-		}
-	}
 	if err := s.meta.UpdateTenantConnection(ctx, tenantID, &meta.Tenant{
 		DBHost:           cluster.Host,
 		DBPort:           cluster.Port,
 		DBUser:           cluster.Username,
 		DBPasswordCipher: cipherPass,
 		DBName:           cluster.DBName,
-		DBTLS:            dbtls,
+		DBTLS:            true,
 		Provider:         provider,
 		ClusterID:        cluster.ClusterID,
 		ClaimURL:         cluster.ClaimURL,
@@ -4359,7 +4361,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		APIKeyID:       apiKeyID,
 		Status:         meta.TenantProvisioning,
 		Provider:       provider,
-		TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, dbtls),
+		TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true),
 		CloudProvider:  cloudProvider,
 		Region:         region,
 		OrganizationID: strings.TrimSpace(cluster.OrganizationID),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	pathpkg "path"
 	"strconv"
 	"strings"
@@ -826,7 +827,11 @@ func contextWithTrace(parent, traceSource context.Context) context.Context {
 func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled bool) string {
 	query := "parseTime=true"
 	if tlsEnabled {
-		query += "&tls=true"
+		tlsMode := "true"
+		if v := strings.TrimSpace(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")); v != "" {
+			tlsMode = "skip-verify"
+		}
+		query += "&tls=" + tlsMode
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", user, password, host, port, dbName, query)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -828,12 +828,17 @@ func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled 
 	query := "parseTime=true"
 	if tlsEnabled {
 		tlsMode := "true"
-		if v := strings.TrimSpace(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")); v != "" {
+		if isPrivateEndpointEnabled() {
 			tlsMode = "skip-verify"
 		}
 		query += "&tls=" + tlsMode
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", user, password, host, port, dbName, query)
+}
+
+func isPrivateEndpointEnabled() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
+	return v == "1" || v == "true" || v == "yes"
 }
 
 func injectFallbackBackend(b *backend.Dat9Backend, next http.Handler) http.Handler {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -666,7 +666,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	query := "parseTime=true"
 	if t.DBTLS {
 		query += "&tls=true"
-	} else if t.Provider == ProviderTiDBCloudNative {
+	} else {
 		query += "&tls=skip-verify"
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -667,8 +667,11 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	query := "parseTime=true"
 	if t.DBTLS {
 		tlsMode := "true"
-		if t.Provider == ProviderTiDBCloudNative && strings.TrimSpace(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")) != "" {
-			tlsMode = "skip-verify"
+		if t.Provider == ProviderTiDBCloudNative {
+			v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
+			if v == "1" || v == "true" || v == "yes" {
+				tlsMode = "skip-verify"
+			}
 		}
 		query += "&tls=" + tlsMode
 	}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -666,14 +665,9 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	query := "parseTime=true"
 	if t.DBTLS {
-		tlsMode := "true"
-		if t.Provider == ProviderTiDBCloudNative {
-			v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
-			if v == "1" || v == "true" || v == "yes" {
-				tlsMode = "skip-verify"
-			}
-		}
-		query += "&tls=" + tlsMode
+		query += "&tls=true"
+	} else if t.Provider == ProviderTiDBCloudNative {
+		query += "&tls=skip-verify"
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
 	openStoreStart := time.Now()

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -666,7 +666,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	query := "parseTime=true"
 	if t.DBTLS {
 		query += "&tls=true"
-	} else {
+	} else if t.Provider == ProviderTiDBCloudNative {
 		query += "&tls=skip-verify"
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -665,7 +666,11 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	query := "parseTime=true"
 	if t.DBTLS {
-		query += "&tls=true"
+		tlsMode := "true"
+		if t.Provider == ProviderTiDBCloudNative && strings.TrimSpace(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")) != "" {
+			tlsMode = "skip-verify"
+		}
+		query += "&tls=" + tlsMode
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
 	openStoreStart := time.Now()

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -666,14 +665,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	query := "parseTime=true"
 	if t.DBTLS {
-		tlsMode := "true"
-		if t.Provider == ProviderTiDBCloudNative {
-			v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
-			if v == "1" || v == "true" || v == "yes" {
-				tlsMode = "skip-verify"
-			}
-		}
-		query += "&tls=" + tlsMode
+		query += "&tls=true"
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
 	openStoreStart := time.Now()

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -665,7 +666,14 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	query := "parseTime=true"
 	if t.DBTLS {
-		query += "&tls=true"
+		tlsMode := "true"
+		if t.Provider == ProviderTiDBCloudNative {
+			v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
+			if v == "1" || v == "true" || v == "yes" {
+				tlsMode = "skip-verify"
+			}
+		}
+		query += "&tls=" + tlsMode
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
 	openStoreStart := time.Now()

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -928,7 +928,7 @@ func ensureDatabase(ctx context.Context, user, password, host string, port int, 
 	cfg.ParseTime = true
 	cfg.TLSConfig = "true"
 	if usePrivate, _ := parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint); usePrivate {
-		cfg.TLSConfig = "false"
+		cfg.TLSConfig = "skip-verify"
 	}
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -927,6 +927,9 @@ func ensureDatabase(ctx context.Context, user, password, host string, port int, 
 	cfg.Addr = fmt.Sprintf("%s:%d", host, port)
 	cfg.ParseTime = true
 	cfg.TLSConfig = "true"
+	if usePrivate, _ := parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint); usePrivate {
+		cfg.TLSConfig = "skip-verify"
+	}
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return err

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -927,6 +927,9 @@ func ensureDatabase(ctx context.Context, user, password, host string, port int, 
 	cfg.Addr = fmt.Sprintf("%s:%d", host, port)
 	cfg.ParseTime = true
 	cfg.TLSConfig = "true"
+	if usePrivate, _ := parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint); usePrivate {
+		cfg.TLSConfig = "false"
+	}
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return err

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -927,9 +927,6 @@ func ensureDatabase(ctx context.Context, user, password, host string, port int, 
 	cfg.Addr = fmt.Sprintf("%s:%d", host, port)
 	cfg.ParseTime = true
 	cfg.TLSConfig = "true"
-	if usePrivate, _ := parseBoolEnv(EnvTiDBCloudNativeUsePrivateEndpoint); usePrivate {
-		cfg.TLSConfig = "skip-verify"
-	}
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return err


### PR DESCRIPTION
## Problem

When using private endpoint, TLS fails with x509 error because the cert is for the public hostname.

## Fix

Use tls=skip-verify in ensureDatabase and tenantDSN when DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS connection handling for database access in private endpoint setups.
  * Updated connection behavior so secure connections work more reliably across standard and private network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->